### PR TITLE
refactor: adopt Jane Street Base in board and coord modules

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Board Core — JSONL store logic and persistence.
     Types are in Board_types. *)
 
@@ -80,21 +98,21 @@ let sweep store =
 
     (* Sweep posts - with batch limit; skip permanent posts (expires_at = 0) *)
     let expired_posts = Hashtbl.fold (fun id (post : post) acc ->
-      if post.expires_at > 0.0 && post.expires_at < now && !removed_posts < Limits.sweeper_batch_size then begin
-        incr removed_posts;
+      if Stdlib.Float.compare post.expires_at 0.0 > 0 && Stdlib.Float.compare post.expires_at now < 0 && !removed_posts < Limits.sweeper_batch_size then begin
+        Stdlib.incr removed_posts;
         id :: acc
       end else acc
     ) store.posts [] in
     List.iter (fun id ->
       Hashtbl.remove store.posts id;
       Hashtbl.remove store.comments_by_post id;
-      decr store.post_count
+      Stdlib.decr store.post_count
     ) expired_posts;
 
     (* Sweep comments - skip permanent (expires_at = 0) *)
     let expired_comments = Hashtbl.fold (fun id (comment : comment) acc ->
-      if comment.expires_at > 0.0 && comment.expires_at < now && !removed_comments < Limits.sweeper_batch_size then begin
-        incr removed_comments;
+      if Stdlib.Float.compare comment.expires_at 0.0 > 0 && Stdlib.Float.compare comment.expires_at now < 0 && !removed_comments < Limits.sweeper_batch_size then begin
+        Stdlib.incr removed_comments;
         id :: acc
       end else acc
     ) store.comments [] in
@@ -119,7 +137,7 @@ let sweep store =
       Hashtbl.iter (fun _author posts ->
         if List.length posts > Limits.author_post_cap then begin
           let sorted = List.sort (fun (a : post) (b : post) ->
-            compare a.created_at b.created_at
+            Stdlib.Float.compare a.created_at b.created_at
           ) posts in
           let excess = List.length sorted - Limits.author_post_cap in
           let rec take_first n = function
@@ -132,8 +150,8 @@ let sweep store =
             let id = Post_id.to_string post.id in
             Hashtbl.remove store.posts id;
             Hashtbl.remove store.comments_by_post id;
-            decr store.post_count;
-            incr cap_evicted
+            Stdlib.decr store.post_count;
+            Stdlib.incr cap_evicted
           ) to_evict
         end
       ) author_posts
@@ -159,11 +177,11 @@ let sweep store =
 (** Auto-sweep if needed, delegates to flusher actor inbox *)
 let maybe_sweep store =
   let now = Time_compat.now () in
-  if now -. store.last_sweep > float_of_int Limits.sweeper_interval_sec then begin
+  if Stdlib.Float.compare (now -. store.last_sweep) (Stdlib.Float.of_int Limits.sweeper_interval_sec) > 0 then begin
     store.last_sweep <- now;
     Eio.Stream.add store.flusher_inbox Sweep
   end;
-  if now -. store.last_flush > flush_interval_sec then begin
+  if Stdlib.Float.compare (now -. store.last_flush) flush_interval_sec > 0 then begin
     store.last_flush <- now;
     Eio.Stream.add store.flusher_inbox Flush
   end
@@ -185,7 +203,7 @@ let comments_path () =
   Filename.concat (board_masc_dir ()) "board_comments.jsonl"
 
 let ensure_dir path =
-  if path = "" || path = "." || path = "/" then ()
+  if String.equal path "" || String.equal path "." || String.equal path "/" then ()
   else Fs_compat.mkdir_p path
 
 let ensure_masc_dir () =
@@ -306,7 +324,7 @@ let append_comment (c : comment) =
 
 let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
     ?(visibility=Internal) ?(ttl_hours=Limits.default_ttl_hours) ?hearth ?thread_id ()
-  : (post, board_error) result =
+  : (post, board_error) Result.t =
   maybe_sweep store;
 
   (* Validate author *)
@@ -328,7 +346,7 @@ let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
   let hearth = Option.map (fun h -> String.lowercase_ascii (String.trim h)) hearth in
   let expires_at =
     let now = Time_compat.now () in
-    if ttl = 0 then 0.0 else now +. (float_of_int ttl *. 3600.0)
+    if ttl = 0 then 0.0 else now +. (Stdlib.Float.of_int ttl *. 3600.0)
   in
   let normalized_title, normalized_body, normalized_kind, normalized_meta =
     normalize_post_payload ~content ?title ?body ~post_kind ?meta_json ()
@@ -368,7 +386,7 @@ let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
           thread_id;
         } in
         Hashtbl.add store.posts (Post_id.to_string post.id) post;
-        incr store.post_count;
+        Stdlib.incr store.post_count;
         invalidate_post_caches store;
         append_post post;
         Ok post
@@ -391,7 +409,7 @@ let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
        Ok post
    | Error _ as e -> e)
 
-let get_post store ~post_id : (post, board_error) result =
+let get_post store ~post_id : (post, board_error) Result.t =
   maybe_sweep store;
   match Post_id.of_string post_id with
   | Error e -> Error e
@@ -411,7 +429,7 @@ let get_post store ~post_id : (post, board_error) result =
    keeps the read atomic, removes one [maybe_sweep] dispatch, and
    eliminates the inter-call lock churn. *)
 let get_post_and_comments store ~post_id
-    : (post * comment list, board_error) result =
+    : (post * comment list, board_error) Result.t =
   maybe_sweep store;
   match Post_id.of_string post_id with
   | Error e -> Error e
@@ -433,7 +451,7 @@ let get_post_and_comments store ~post_id
             let sorted =
               List.sort
                 (fun (a : comment) (b : comment) ->
-                  compare a.created_at b.created_at)
+                  Stdlib.Float.compare a.created_at b.created_at)
                 comments
             in
             Ok (post, sorted)
@@ -445,13 +463,13 @@ let reclassify_posts store ?(limit = 5200) ?(dry_run = true) () =
     let scan_limit = max 0 (min limit 5200) in
     let json_string name json =
       match Yojson.Safe.Util.member name json with
-      | `String value when String.trim value <> "" -> Some value
+      | `String value when not (String.equal (String.trim value) "") -> Some value
       | _ -> None
     in
     let json_float name json =
       match Yojson.Safe.Util.member name json with
       | `Float value -> Some value
-      | `Int value -> Some (float_of_int value)
+      | `Int value -> Some (Stdlib.Float.of_int value)
       | _ -> None
     in
     let persisted_candidates =
@@ -467,7 +485,7 @@ let reclassify_posts store ?(limit = 5200) ?(dry_run = true) () =
                        let expires_at =
                          json_float "expires_at" json |> Option.value ~default:0.0
                        in
-                       if expires_at > 0.0 && expires_at <= now then None
+                       if Stdlib.Float.compare expires_at 0.0 > 0 && Stdlib.Float.compare expires_at now <= 0 then None
                        else
                          let stored_kind =
                            Option.bind (json_string "post_kind" json) post_kind_of_string
@@ -501,14 +519,14 @@ let reclassify_posts store ?(limit = 5200) ?(dry_run = true) () =
     in
     persisted_candidates
     |> List.sort (fun (_, created_a, _, _) (_, created_b, _, _) ->
-           compare created_b created_a)
+           Stdlib.Float.compare created_b created_a)
     |> List.filteri (fun idx _ -> idx < scan_limit)
     |> List.iter (fun (post_id, _, stored_kind, canonical_kind) ->
-           incr scanned;
-           if stored_kind = Some canonical_kind then
-             incr unchanged
+           Stdlib.incr scanned;
+           if Option.equal Poly.equal stored_kind (Some canonical_kind) then
+             Stdlib.incr unchanged
            else begin
-             incr changed;
+             Stdlib.incr changed;
              record_changed_id post_id;
              if not dry_run then
                match Hashtbl.find_opt store.posts post_id with
@@ -548,7 +566,7 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
             let score_b = b.votes_up - b.votes_down in
             let cmp = compare score_b score_a in
             if cmp <> 0 then cmp
-            else compare b.created_at a.created_at
+            else Stdlib.Float.compare b.created_at a.created_at
           ) all in
           store.sorted_posts_cache <- Some sorted;
           sorted
@@ -556,13 +574,13 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
     (* Apply filters on the pre-sorted list *)
     let filtered = match visibility_filter with
       | None -> sorted_all
-      | Some v -> List.filter (fun (p : post) -> p.visibility = v) sorted_all
+      | Some v -> List.filter (fun (p : post) -> Poly.equal p.visibility v) sorted_all
     in
     let filtered = match hearth with
       | None -> filtered
       | Some h ->
           let h_norm = String.lowercase_ascii (String.trim h) in
-          List.filter (fun (p : post) -> p.hearth = Some h_norm) filtered
+          List.filter (fun (p : post) -> Option.equal String.equal p.hearth (Some h_norm)) filtered
     in
     (* Cap at Limits.max_posts (default 10_000) as an OOM guard. The
        previous inner cap of 100 was a duplicate of Board_dispatch.list_posts's
@@ -583,7 +601,7 @@ let search_posts store ~predicate ~limit : post list =
     ) store.posts [] in
     (* Sort by recency for search results *)
     let sorted = List.sort (fun (a : post) (b : post) ->
-      compare b.created_at a.created_at
+      Stdlib.Float.compare b.created_at a.created_at
     ) matches in
     take limit sorted
   )
@@ -591,7 +609,7 @@ let search_posts store ~predicate ~limit : post list =
 (** {1 Comment Operations} *)
 
 let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.default_ttl_hours) ()
-  : (comment, board_error) result =
+  : (comment, board_error) Result.t =
   maybe_sweep store;
 
   (* Validate all IDs first *)
@@ -651,7 +669,7 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
             author = author_id;
             content;
             created_at = now;
-            expires_at = if ttl = 0 then 0.0 else now +. (float_of_int ttl *. 3600.0);
+            expires_at = if ttl = 0 then 0.0 else now +. (Stdlib.Float.of_int ttl *. 3600.0);
             votes_up = 0;
             votes_down = 0;
           } in
@@ -670,7 +688,7 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
         end
   )
 
-let get_comments store ~post_id : (comment list, board_error) result =
+let get_comments store ~post_id : (comment list, board_error) Result.t =
   maybe_sweep store;
   match Post_id.of_string post_id with
   | Error e -> Error e
@@ -681,7 +699,7 @@ let get_comments store ~post_id : (comment list, board_error) result =
         let comments = List.filter_map (fun cid ->
           Hashtbl.find_opt store.comments cid
         ) comment_ids in
-        Ok (List.sort (fun (a : comment) (b : comment) -> compare a.created_at b.created_at) comments)
+        Ok (List.sort (fun (a : comment) (b : comment) -> Stdlib.Float.compare a.created_at b.created_at) comments)
       )
 
 (** List all comments (for profile aggregation) *)
@@ -690,7 +708,7 @@ let list_comments store ?(limit=1000) () : comment list =
   with_lock store (fun () ->
     let all = Hashtbl.fold (fun _ c acc -> c :: acc) store.comments [] in
     let sorted = List.sort (fun (a : comment) (b : comment) ->
-      compare b.created_at a.created_at
+      Stdlib.Float.compare b.created_at a.created_at
     ) all in
     List.filteri (fun i _ -> i < limit) sorted
   )

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -1,20 +1,11 @@
 open Base
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
 module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
 module Option = Stdlib.Option
 module Result = Stdlib.Result
 module Sys = Stdlib.Sys
 module Filename = Stdlib.Filename
 module List = Stdlib.List
-module Array = Stdlib.Array
 module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
 
 (** Board Core — JSONL store logic and persistence.
     Types are in Board_types. *)
@@ -564,7 +555,7 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
           let sorted = List.sort (fun (a : post) (b : post) ->
             let score_a = a.votes_up - a.votes_down in
             let score_b = b.votes_up - b.votes_down in
-            let cmp = compare score_b score_a in
+            let cmp = Stdlib.Int.compare score_b score_a in
             if cmp <> 0 then cmp
             else Stdlib.Float.compare b.created_at a.created_at
           ) all in

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Board_core — in-memory board store, persistence, and
     canonical post / comment operations.
 
@@ -168,7 +170,7 @@ val create_post :
   ?hearth:string ->
   ?thread_id:string ->
   unit ->
-  (post, board_error) result
+  (post, board_error) Result.t
 (** Creates a new post.  Validates [author] via
     {!Agent_id.of_string}, normalises [hearth] (lowercased +
     trimmed), folds the canonical [title / body / kind /
@@ -183,12 +185,12 @@ val create_post :
     readers on the ledger write. *)
 
 val get_post :
-  store -> post_id:string -> (post, board_error) result
+  store -> post_id:string -> (post, board_error) Result.t
 
 val get_post_and_comments :
   store ->
   post_id:string ->
-  (post * comment list, board_error) result
+  (post * comment list, board_error) Result.t
 (** Coalesces [get_post] + [get_comments] under a single
     {!with_lock} block to avoid the two-call lock churn
     that previously surfaced as
@@ -239,7 +241,7 @@ val add_comment :
   ?parent_id:string ->
   ?ttl_hours:int ->
   unit ->
-  (comment, board_error) result
+  (comment, board_error) Result.t
 (** Validates [post_id] / [author] / optional [parent_id]
     via {!Post_id.of_string} / {!Agent_id.of_string} /
     {!Comment_id.of_string} before taking the lock.
@@ -251,7 +253,7 @@ val add_comment :
 val get_comments :
   store ->
   post_id:string ->
-  (comment list, board_error) result
+  (comment list, board_error) Result.t
 (** Returns the comments for [post_id] sorted by
     [created_at] ascending. *)
 

--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Board_core_classify — Post visibility/kind converters and classification.
 
     Contains all conversion helpers, legacy migration heuristics, and
@@ -77,7 +95,7 @@ let meta_source = function
       match List.assoc_opt "source" fields with
       | Some (`String source) ->
           let source = String.lowercase_ascii (String.trim source) in
-          if source = "" then None else Some source
+          if String.equal source "" then None else Some source
       | _ -> None)
   | _ -> None
 
@@ -89,7 +107,7 @@ let meta_field meta_json key =
 let nonempty_json_string = function
   | `String value ->
       let value = String.trim value in
-      if value = "" then None else Some value
+      if String.equal value "" then None else Some value
   | _ -> None
 
 let judgment_reason = function
@@ -129,9 +147,9 @@ let legacy_migrate_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth 
   in
   if legacy_system_board_author author then
     System_post
-  else if meta_source meta_json = Some "keeper_board_post" then
+  else if (match meta_source meta_json with Some "keeper_board_post" -> true | _ -> false) then
     Automation_post
-  else if visibility = Internal && expires_at > 0.0 && hearth <> ""
+  else if Poly.equal visibility Internal && Stdlib.Float.compare expires_at 0.0 > 0 && not (String.equal hearth "")
           && (String.starts_with ~prefix:"mdal" hearth
               || contains_substring hearth "harness")
   then
@@ -186,8 +204,8 @@ let post_classification_reason (p : post) =
 
 let post_matches_filters ~exclude_system ~exclude_automation (p : post) =
   let kind = p.post_kind in
-  (not exclude_system || kind <> System_post)
-  && (not exclude_automation || kind <> Automation_post)
+  (not exclude_system || not (Poly.equal kind System_post))
+  && (not exclude_automation || not (Poly.equal kind Automation_post))
 
 type reclassify_report = {
   backend : string;

--- a/lib/board_core_classify.mli
+++ b/lib/board_core_classify.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Board_core_classify — post visibility / kind converters and
     classification.
 

--- a/lib/board_core_payload.ml
+++ b/lib/board_core_payload.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Board_core_payload — State block extraction and post payload normalization.
 
     Handles [STATE]...[/STATE] block parsing from post bodies,
@@ -44,7 +62,7 @@ let meta_state_block (meta_json : Yojson.Safe.t option) =
       match List.assoc_opt "state_block" fields with
       | Some (`String value) ->
           let value = String.trim value in
-          if value = "" then None else Some value
+          if String.equal value "" then None else Some value
       | _ -> None)
   | _ -> None
 
@@ -57,7 +75,7 @@ let merge_meta_json ?state_block (meta_json : Yojson.Safe.t option) :
   in
   let fields =
     match state_block with
-    | Some block when block <> "" && not (List.mem_assoc "state_block" fields) ->
+    | Some block when not (String.equal block "") && not (List.mem_assoc "state_block" fields) ->
         ("state_block", `String block) :: fields
     | _ -> fields
   in
@@ -70,7 +88,7 @@ let derive_post_title (body : string) =
     body
     |> String.split_on_char '\n'
     |> List.map String.trim
-    |> List.find_opt (fun line -> line <> "")
+    |> List.find_opt (fun line -> not (String.equal line ""))
     |> Option.value ~default:"Untitled post"
   in
   (* UTF-8-safe truncation: byte-based String.sub used to split multi-byte
@@ -86,7 +104,7 @@ let normalize_post_payload ~content ?title ?body ~post_kind ?meta_json () =
   let normalized_body = String.trim stripped_body in
   let normalized_title =
     match title with
-    | Some value when String.trim value <> "" -> String.trim value
+    | Some value when not (String.equal (String.trim value) "") -> String.trim value
     | _ -> derive_post_title normalized_body
   in
   let merged_meta = merge_meta_json ?state_block:extracted_state meta_json in

--- a/lib/board_core_payload.mli
+++ b/lib/board_core_payload.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Board_core_payload — [STATE] block extraction and post payload
     normalisation for the board store.
 

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -218,7 +218,7 @@ let sort_posts_in_memory ~sort_by (posts : Board.post list) =
         Stdlib.Float.compare score_b score_a) posts
   | Discussed ->
       List.sort (fun (a : Board.post) (b : Board.post) ->
-        let cmp = compare b.reply_count a.reply_count in
+        let cmp = Stdlib.Int.compare b.reply_count a.reply_count in
         if cmp <> 0 then cmp else Stdlib.Float.compare b.created_at a.created_at) posts
 
 let normalize_author_filter = function

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Board_dispatch - Runtime backend selection for MASC Board
 
     Board now runs on the JSONL store only. Backend is selected once at
@@ -77,14 +95,14 @@ let start_flusher_actor ~sw store =
           (try Board.flush_dirty store
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn -> Log.BoardLog.error "Flush failed: %s" (Printexc.to_string exn))
+           | exn -> Log.BoardLog.error "Flush failed: %s" (Exn.to_string exn))
       | Board_types.Sweep ->
           (try
              let swept = Board.sweep store in
              ignore swept
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
+           | exn -> Log.BoardLog.error "Sweep failed: %s" (Exn.to_string exn))
     done
   )
 
@@ -175,38 +193,38 @@ let sort_posts_in_memory ~sort_by (posts : Board.post list) =
       List.sort (fun (a : Board.post) (b : Board.post) ->
         let score_a = a.votes_up - a.votes_down in
         let score_b = b.votes_up - b.votes_down in
-        let cmp = compare score_b score_a in
+        let cmp = Stdlib.Int.compare score_b score_a in
         if cmp <> 0 then cmp
-        else compare b.created_at a.created_at) posts
+        else Stdlib.Float.compare b.created_at a.created_at) posts
   | Recent ->
       List.sort (fun (a : Board.post) (b : Board.post) ->
-        compare b.created_at a.created_at) posts
+        Stdlib.Float.compare b.created_at a.created_at) posts
   | Updated ->
       List.sort (fun (a : Board.post) (b : Board.post) ->
-        compare b.updated_at a.updated_at) posts
+        Stdlib.Float.compare b.updated_at a.updated_at) posts
   | Trending ->
       let now = Time_compat.now () in
       List.sort (fun (a : Board.post) (b : Board.post) ->
-        let age_a = max 1.0 ((now -. a.created_at) /. 3600.0) in
-        let age_b = max 1.0 ((now -. b.created_at) /. 3600.0) in
+        let age_a = Stdlib.Float.max 1.0 ((now -. a.created_at) /. 3600.0) in
+        let age_b = Stdlib.Float.max 1.0 ((now -. b.created_at) /. 3600.0) in
         let score_a =
-          float_of_int (a.votes_up - a.votes_down + (a.reply_count * 2))
-          /. (age_a ** 0.5)
+          Stdlib.Float.of_int (a.votes_up - a.votes_down + (a.reply_count * 2))
+          /. (Stdlib.( **) age_a 0.5)
         in
         let score_b =
-          float_of_int (b.votes_up - b.votes_down + (b.reply_count * 2))
-          /. (age_b ** 0.5)
+          Stdlib.Float.of_int (b.votes_up - b.votes_down + (b.reply_count * 2))
+          /. (Stdlib.( **) age_b 0.5)
         in
-        compare score_b score_a) posts
+        Stdlib.Float.compare score_b score_a) posts
   | Discussed ->
       List.sort (fun (a : Board.post) (b : Board.post) ->
         let cmp = compare b.reply_count a.reply_count in
-        if cmp <> 0 then cmp else compare b.created_at a.created_at) posts
+        if cmp <> 0 then cmp else Stdlib.Float.compare b.created_at a.created_at) posts
 
 let normalize_author_filter = function
   | Some raw ->
       let trimmed = String.trim raw in
-      if trimmed = "" then None else Some (String.lowercase_ascii trimmed)
+      if String.equal trimmed "" then None else Some (String.lowercase_ascii trimmed)
   | None -> None
 
 let agent_matches_author_filter ~needle (agent_id : Board.Agent_id.t) =
@@ -262,13 +280,13 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_fil
     let posts =
       match visibility_filter with
       | Some visibility ->
-          List.filter (fun (post : Board.post) -> post.visibility = visibility) posts
+          List.filter (fun (post : Board.post) -> Poly.equal post.visibility visibility) posts
       | None -> posts
     in
     match hearth with
     | Some hearth_name ->
         let hearth_name = String.lowercase_ascii (String.trim hearth_name) in
-        List.filter (fun (post : Board.post) -> post.hearth = Some hearth_name) posts
+        List.filter (fun (post : Board.post) -> Option.equal String.equal post.hearth (Some hearth_name)) posts
     | None -> posts
   in
   let apply_post_kind_filter posts =
@@ -278,8 +296,8 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_fil
     |> (match post_kind_filter with
        | Some kind ->
            List.filter
-             (fun (p : Board.post) -> Board.classify_post_kind p = kind)
-       | None -> Fun.id)
+             (fun (p : Board.post) -> Poly.equal (Board.classify_post_kind p) kind)
+       | None -> Stdlib.Fun.id)
   in
   match backend () with
   | Jsonl store ->
@@ -310,7 +328,7 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_fil
         | None -> filtered
         | Some needle ->
             let matching_comment_post_ids =
-              Board.list_comments store ~limit:max_int ()
+              Board.list_comments store ~limit:Stdlib.max_int ()
               |> matching_post_ids_for_comment_author_filter ~needle
             in
             List.filter

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Board_dispatch — single-backend board dispatch + signal hooks.
 
     Wraps the JSONL-backed {!Board} store with: lazy initialisation,
@@ -120,9 +122,9 @@ val create_post :
   ?hearth:string ->
   ?thread_id:string ->
   unit ->
-  (Board.post, Board.board_error) result
+  (Board.post, Board.board_error) Result.t
 
-val get_post : post_id:string -> (Board.post, Board.board_error) result
+val get_post : post_id:string -> (Board.post, Board.board_error) Result.t
 
 val list_posts :
   ?visibility_filter:Board.visibility option ->
@@ -136,12 +138,12 @@ val list_posts :
   unit ->
   Board.post list
 
-val delete_post : post_id:string -> (unit, Board.board_error) result
+val delete_post : post_id:string -> (unit, Board.board_error) Result.t
 
 val set_thread_id :
   post_id:string ->
   thread_id:string ->
-  (unit, Board.board_error) result
+  (unit, Board.board_error) Result.t
 
 val search :
   query:string ->
@@ -163,15 +165,15 @@ val add_comment :
   ?parent_id:string ->
   ?ttl_hours:int ->
   unit ->
-  (Board.comment, Board.board_error) result
+  (Board.comment, Board.board_error) Result.t
 
 val get_comments :
   post_id:string ->
-  (Board.comment list, Board.board_error) result
+  (Board.comment list, Board.board_error) Result.t
 
 val get_post_and_comments :
   post_id:string ->
-  (Board.post * Board.comment list, Board.board_error) result
+  (Board.post * Board.comment list, Board.board_error) Result.t
 
 val list_comments : ?limit:int -> unit -> Board.comment list
 
@@ -181,13 +183,13 @@ val vote :
   voter:string ->
   post_id:string ->
   direction:Board.vote_direction ->
-  (int, Board.board_error) result
+  (int, Board.board_error) Result.t
 
 val vote_comment :
   voter:string ->
   comment_id:string ->
   direction:Board.vote_direction ->
-  (int, Board.board_error) result
+  (int, Board.board_error) Result.t
 
 (** {1 Karma} *)
 

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 include Board_core
 
 let vote_direction_to_string = function Up -> "up" | Down -> "down"
@@ -91,14 +109,14 @@ type vote_outcome = {
   earn_upvote_for : string option;
 }
 
-let vote store ~voter ~post_id ~direction : (int, board_error) result =
+let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
   match Agent_id.of_string voter with
   | Error e -> Error e
   | Ok _ ->
   match Post_id.of_string post_id with
   | Error e -> Error e
   | Ok pid ->
-      let board_result : (vote_outcome, board_error) result =
+      let board_result : (vote_outcome, board_error) Result.t =
         with_lock store (fun () ->
           match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
           | None -> Error (Post_not_found post_id)
@@ -106,7 +124,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
               let vote_key = "post:" ^ Post_id.to_string pid ^ ":" ^ voter in
               let now = Time_compat.now () in
               match Hashtbl.find_opt store.vote_log vote_key with
-              | Some (prev, _prev_ts) when prev = direction ->
+              | Some (prev, _prev_ts) when Poly.equal prev direction ->
                   Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
                     voter (vote_direction_to_string direction) post_id))
               | Some (_opposite, _prev_ts) ->
@@ -145,7 +163,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                   let vote_dir = match direction with Up -> `Up | Down -> `Down in
                   Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
                   let earn =
-                    if direction = Up then Some author_name else None
+                    if Poly.equal direction Up then Some author_name else None
                   in
                   Ok { delta = updated.votes_up - updated.votes_down;
                        earn_upvote_for = earn })
@@ -168,7 +186,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
        | Error _ as e -> e)
 
 (** Vote on a comment *)
-let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result =
+let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result.t =
   match Agent_id.of_string voter with
   | Error e -> Error e
   | Ok _ ->
@@ -182,7 +200,7 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
             let vote_key = "comment:" ^ Comment_id.to_string cid ^ ":" ^ voter in
             let now = Time_compat.now () in
             match Hashtbl.find_opt store.vote_log vote_key with
-            | Some (prev, _prev_ts) when prev = direction ->
+            | Some (prev, _prev_ts) when Poly.equal prev direction ->
                 Error (Already_voted (Printf.sprintf "%s already voted %s on comment %s"
                   voter (vote_direction_to_string direction) comment_id))
             | Some (_opposite, _prev_ts) ->
@@ -227,7 +245,7 @@ let stats store =
     let comment_count = Hashtbl.length store.comments in
     let now = Time_compat.now () in
     let expired_posts = Hashtbl.fold (fun _ (p : post) acc ->
-      if p.expires_at > 0.0 && p.expires_at < now then acc + 1 else acc
+      if Stdlib.Float.compare p.expires_at 0.0 > 0 && Stdlib.Float.compare p.expires_at now < 0 then acc + 1 else acc
     ) store.posts 0 in
     `Assoc [
       ("post_count", `Int post_count);
@@ -347,9 +365,9 @@ let load_persisted_posts store =
       let lines = Fs_compat.load_jsonl path in
       List.iter (fun json ->
         match post_of_yojson json with
-        | Some p when p.expires_at = 0.0 || p.expires_at > now ->
+        | Some p when Stdlib.Float.compare p.expires_at 0.0 = 0 || Stdlib.Float.compare p.expires_at now > 0 ->
             Hashtbl.replace store.posts (Post_id.to_string p.id) p;
-            incr loaded
+            Stdlib.incr loaded
         | _ -> ()
       ) lines;
       store.post_count := Hashtbl.length store.posts;
@@ -360,7 +378,7 @@ let load_persisted_posts store =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
-      Log.BoardLog.error "load posts failed: %s" (Printexc.to_string e)
+      Log.BoardLog.error "load posts failed: %s" (Exn.to_string e)
   end
 
 let load_persisted_comments store =
@@ -372,7 +390,7 @@ let load_persisted_comments store =
       let lines = Fs_compat.load_jsonl path in
       List.iter (fun json ->
         match comment_of_yojson json with
-        | Some c when c.expires_at = 0.0 || c.expires_at > now ->
+        | Some c when Stdlib.Float.compare c.expires_at 0.0 = 0 || Stdlib.Float.compare c.expires_at now > 0 ->
             let cid = Comment_id.to_string c.id in
             Hashtbl.replace store.comments cid c;
             (* Build comments_by_post index *)
@@ -383,7 +401,7 @@ let load_persisted_comments store =
               else cid :: existing
             in
             Hashtbl.replace store.comments_by_post post_key indexed;
-            incr loaded
+            Stdlib.incr loaded
         | _ -> ()
       ) lines;
       if !loaded > 0 then
@@ -393,7 +411,7 @@ let load_persisted_comments store =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
-      Log.BoardLog.error "load comments failed: %s" (Printexc.to_string e)
+      Log.BoardLog.error "load comments failed: %s" (Exn.to_string e)
   end
 
 (** Recalculate reply_count for all posts based on actual comments.
@@ -456,7 +474,7 @@ let quarantine_enabled () =
   match Sys.getenv_opt "MASC_BOARD_VOTE_QUARANTINE" with
   | Some v ->
       let norm = String.lowercase_ascii (String.trim v) in
-      not (norm = "0" || norm = "false" || norm = "off" || norm = "")
+      not (String.equal norm "0" || String.equal norm "false" || String.equal norm "off" || String.equal norm "")
   | None -> true
 
 let load_persisted_votes store =
@@ -472,7 +490,7 @@ let load_persisted_votes store =
         match Safe_ops.json_string_opt "target" json,
               Safe_ops.json_string_opt "direction" json with
         | Some target, Some dir_str ->
-          let direction = if dir_str = "down" then Down else Up in
+          let direction = if String.equal dir_str "down" then Down else Up in
           (* #10086: legacy rows persisted before this fix may have
              [ts] overwritten by a prior flush cycle.  Use the
              recorded value when present; fall back to 0.0 rather
@@ -486,15 +504,15 @@ let load_persisted_votes store =
             | None -> 0.0
           in
           if is_fixture_voter_target target then begin
-            incr fixture_detected;
-            if quarantine then incr quarantined
+            Stdlib.incr fixture_detected;
+            if quarantine then Stdlib.incr quarantined
             else begin
               Hashtbl.replace store.vote_log target (direction, ts);
-              incr loaded
+              Stdlib.incr loaded
             end
           end else begin
             Hashtbl.replace store.vote_log target (direction, ts);
-            incr loaded
+            Stdlib.incr loaded
           end
         | _ -> ()
       ) lines;
@@ -517,7 +535,7 @@ let load_persisted_votes store =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
-      Log.BoardLog.error "load votes failed: %s" (Printexc.to_string e)
+      Log.BoardLog.error "load votes failed: %s" (Exn.to_string e)
   end
 
 (** {1 Hearth (topic) operations} *)
@@ -538,7 +556,7 @@ let list_hearths store : (string * int) list =
   )
 
 (** Update a post's thread_id (for linking Board post → Conversation thread) *)
-let set_thread_id store ~post_id ~thread_id : (unit, board_error) result =
+let set_thread_id store ~post_id ~thread_id : (unit, board_error) Result.t =
   match Post_id.of_string post_id with
   | Error e -> Error e
   | Ok pid ->
@@ -551,7 +569,7 @@ let set_thread_id store ~post_id ~thread_id : (unit, board_error) result =
             Ok ()
       )
 
-let delete_post store ~post_id : (unit, board_error) result =
+let delete_post store ~post_id : (unit, board_error) Result.t =
   match Post_id.of_string post_id with
   | Error e -> Error e
   | Ok pid ->
@@ -563,7 +581,7 @@ let delete_post store ~post_id : (unit, board_error) result =
             let comment_ids =
               Hashtbl.fold
                 (fun key (c : comment) acc ->
-                  if Post_id.to_string c.post_id = post_key then key :: acc else acc)
+                  if String.equal (Post_id.to_string c.post_id) post_key then key :: acc else acc)
                 store.comments []
             in
             Hashtbl.remove store.posts post_key;
@@ -667,13 +685,13 @@ let get_agent_karma store ~agent_name =
   let all_posts = list_posts store () in
   let post_karma =
     List.fold_left (fun acc (p : post) ->
-      if Agent_id.to_string p.author = agent_name then acc + p.votes_up
+      if String.equal (Agent_id.to_string p.author) agent_name then acc + p.votes_up
       else acc
     ) 0 all_posts
   in
   let comment_karma =
     Hashtbl.fold (fun _ (c : comment) acc ->
-      if Agent_id.to_string c.author = agent_name then acc + c.votes_up
+      if String.equal (Agent_id.to_string c.author) agent_name then acc + c.votes_up
       else acc
     ) store.comments 0
   in
@@ -718,7 +736,7 @@ let extract_flair content =
   match Re.exec_opt flair_tag_re content with
   | Some g ->
     let flair_name = Re.Group.get g 1 in
-    (match List.find_opt (fun (name, _, _) -> name = flair_name) available_flairs with
+    (match List.find_opt (fun (name, _, _) -> String.equal name flair_name) available_flairs with
     | Some f -> Some f
     | None -> None)
   | None -> None

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -1,5 +1,3 @@
-open Base
-
 (** Board_votes — voting + karma + flair on top of the
     Board_core store.
 

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Board_votes — voting + karma + flair on top of the
     Board_core store.
 
@@ -78,7 +80,7 @@ val vote :
   voter:string ->
   post_id:string ->
   direction:vote_direction ->
-  (int, board_error) result
+  (int, board_error) Result.t
 (** Casts a vote on the post identified by [post_id].
     Returns [Ok delta] where [delta] is the new
     [(votes_up - votes_down)] score.  Validates [voter] +
@@ -99,7 +101,7 @@ val vote_comment :
   voter:string ->
   comment_id:string ->
   direction:vote_direction ->
-  (int, board_error) result
+  (int, board_error) Result.t
 (** Same shape as {!vote} but targets a comment via its
     [comment_id]. *)
 
@@ -142,13 +144,13 @@ val set_thread_id :
   store ->
   post_id:string ->
   thread_id:string ->
-  (unit, board_error) result
+  (unit, board_error) Result.t
 (** Pins [thread_id] onto the post.  Used by the
     Conversation linker to bridge a Board post to a
     persisted Conversation thread. *)
 
 val delete_post :
-  store -> post_id:string -> (unit, board_error) result
+  store -> post_id:string -> (unit, board_error) Result.t
 (** Removes the post and every comment under it from the
     in-memory store.  The JSONL log keeps the original
     rows; the rewriter on next flush overwrites the file

--- a/lib/coord_assertions.ml
+++ b/lib/coord_assertions.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Coord_assertions - State inspection and assertion-based verification *)
 
 open Types
@@ -100,7 +118,7 @@ let handle_check ~(inspect_state : context -> agent_state) ctx args =
     match Yojson.Safe.Util.member "assertions" args with
     | `List items ->
         let parsed = List.filter_map (function `String s -> Some s | _ -> None) items in
-        if parsed = [] then default_assertions else parsed
+        (match parsed with [] -> default_assertions | _ -> parsed)
     | _ -> default_assertions
   in
   let results = List.map (check_assertion st) assertions in

--- a/lib/coord_assertions.mli
+++ b/lib/coord_assertions.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Coord_assertions — state inspection and assertion-based
     verification.
 

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Coord_goals - Handlers for goal management tools. *)
 
 open Coord_types
@@ -139,7 +157,7 @@ let parse_optional_priority args field =
             constraint_violated = Min_int 1;
             message = "priority must be between 1 and 5";
             expected = Some "1..5";
-            received = Some (string_of_int n);
+            received = Some (Int.to_string n);
           }
       else Ok (Some n)
   | json ->
@@ -241,7 +259,7 @@ let actor_must_be_operator action =
 
 let validate_goal_completion_ready config ~goal_id ~override_note =
   match override_note with
-  | Some note when String.trim note <> "" -> Ok ()
+  | Some note when not (String.equal (String.trim note) "") -> Ok ()
   | _ ->
       let linked_tasks =
         Coord_query.get_tasks_safe config
@@ -259,7 +277,7 @@ let validate_goal_completion_ready config ~goal_id ~override_note =
                Types.task_status_is_done task.task_status)
         |> List.length
       in
-      if linked_tasks = [] then
+      if (match linked_tasks with [] -> true | _ -> false) then
         Error
           "goal completion requires at least one linked task; provide override_note to force"
       else if open_count > 0 then
@@ -346,7 +364,7 @@ let verification_summary_json ?latest_request (goal : Goal_store.goal)
       ("approve_count", `Int approve_count);
       ("reject_count", `Int reject_count);
       ("remaining_possible", `Int remaining_possible);
-      ("pending_verification_count", `Int (if open_request = None then 0 else 1));
+      ("pending_verification_count", `Int (if Option.is_none open_request then 0 else 1));
     ]
 
 let update_goal_phase (ctx : context) (goal : Goal_store.goal) ~phase ?note
@@ -468,7 +486,7 @@ let handle_goal_transition (ctx : context) args =
       let note = get_string_opt args "note" in
       let override_note = get_string_opt args "override_note" in
       if actor_must_be_operator action
-         && actor.Goal_verification.kind <> Goal_verification.Operator
+         && not (Poly.equal actor.Goal_verification.kind Goal_verification.Operator)
       then
         error_result_typed ~code:Validation_error
           "actor.kind must be operator for this transition"
@@ -478,7 +496,7 @@ let handle_goal_transition (ctx : context) args =
         | Some goal ->
             begin
               match
-                if action = Goal_phase.Request_complete then
+                if Poly.equal action Goal_phase.Request_complete then
                   validate_goal_completion_ready ctx.config ~goal_id
                     ~override_note
                 else
@@ -618,7 +636,7 @@ let handle_goal_transition (ctx : context) args =
                       (match goal.active_verification_request_id, next_phase with
                        | Some request_id, Goal_phase.Dropped
                        | Some request_id, Goal_phase.Executing
-                         when goal.phase = Goal_phase.Awaiting_verification ->
+                         when Poly.equal goal.phase Goal_phase.Awaiting_verification ->
                            (match Goal_verification.cancel_request ctx.config ~request_id with
                             | Ok _ ->
                                 emit_goal_event ctx ~goal_id
@@ -638,7 +656,7 @@ let handle_goal_transition (ctx : context) args =
                       match
                         update_goal_phase ctx goal ~phase:next_phase ?note
                           ~clear_active_verification_request:
-                            (next_phase <> Goal_phase.Awaiting_verification)
+                            (not (Poly.equal next_phase Goal_phase.Awaiting_verification))
                           ()
                       with
                       | Error msg -> error_result_typed ~code:Internal_error msg
@@ -650,8 +668,8 @@ let handle_goal_transition (ctx : context) args =
                                   ("phase", Goal_phase.to_yojson updated_goal.phase);
                                   ("actor", Goal_verification.goal_principal_to_yojson actor);
                                 ]);
-                          if action = Goal_phase.Approve_completion
-                             || action = Goal_phase.Reject_completion then
+                          if Poly.equal action Goal_phase.Approve_completion
+                             || Poly.equal action Goal_phase.Reject_completion then
                             emit_goal_event ctx ~goal_id
                               ~event_type:"goal_approval_resolved"
                               ~payload:
@@ -659,7 +677,7 @@ let handle_goal_transition (ctx : context) args =
                                   [
                                     ( "decision",
                                       `String
-                                        (if action = Goal_phase.Approve_completion then
+                                        (if Poly.equal action Goal_phase.Approve_completion then
                                            "approve"
                                          else
                                            "reject") );
@@ -779,7 +797,7 @@ let handle_goal_verify (ctx : context) args =
                               verification_summary_json ~latest_request:request
                                 updated_goal
                                 effective_policy
-                                (if updated_goal.phase = Goal_phase.Awaiting_verification then
+                                (if Poly.equal updated_goal.phase Goal_phase.Awaiting_verification then
                                    Some request
                                  else
                                    None) );

--- a/lib/coord_goals.mli
+++ b/lib/coord_goals.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Coord_goals — Goal-management MCP tool handlers.
 
     Reachable from {!Tool_coord.dispatch} for the 5 goal tools:

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -184,13 +184,14 @@ let status_summary_string
     Buffer.add_string buf
       (Printf.sprintf "💡 Suggested next: %s\n"
          (String.concat " -> " suggested_next)));
-  if Stdlib.List.length attention_items > 0 then begin
+  (match attention_items with
+  | [] -> ()
+  | _ ->
     Buffer.add_string buf "\n⚠️ Attention:\n";
     List.iter
       (fun item ->
         Buffer.add_string buf (Printf.sprintf "  - %s\n" item))
-      attention_items
-  end;
+      attention_items);
   Buffer.add_string buf "📌 Players:\n";
   (match shown_agents with
   | [] ->

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Coord_status_rendering - Logic for masc_status rendering *)
 
 open Types
@@ -6,7 +24,7 @@ open Coord_types
 let bool_flag value = if value then "yes" else "no"
 
 let option_or_dash = function
-  | Some value when String.trim value <> "" -> value
+  | Some value when not (String.equal (String.trim value) "") -> value
   | _ -> "-"
 
 let take_items limit items =
@@ -77,7 +95,7 @@ let deliverable_claims_completion ~task_id deliverable =
     |> String.lowercase_ascii
     |> first_line
   in
-  normalized <> ""
+  not (String.equal normalized "")
   && (String.starts_with ~prefix:(String.lowercase_ascii task_id ^ " completed")
         normalized
       || String.starts_with ~prefix:"completed" normalized)
@@ -120,7 +138,7 @@ let status_summary_string
 
   let buf = Buffer.create 256 in
   Buffer.add_string buf (Printf.sprintf "🏢 Cluster: %s\n" effective_cluster_name);
-  if effective_cluster_name <> state.project then
+  if not (String.equal effective_cluster_name state.project) then
     Buffer.add_string buf (Printf.sprintf "📦 Project: %s\n" state.project);
   Buffer.add_string buf
     (Printf.sprintf "📍 Scope: %s (flattened)\n" current_room);
@@ -162,11 +180,11 @@ let status_summary_string
       (Printf.sprintf "🔐 Credential: required=yes | available=%s | candidates=%s\n"
          (bool_flag credential_state.credential_available)
          (String.concat "," credential_state.credential_candidates));
-  if suggested_next <> [] then
+  (match suggested_next with [] -> () | _ ->
     Buffer.add_string buf
       (Printf.sprintf "💡 Suggested next: %s\n"
-         (String.concat " -> " suggested_next));
-  if attention_items <> [] then begin
+         (String.concat " -> " suggested_next)));
+  if Stdlib.List.length attention_items > 0 then begin
     Buffer.add_string buf "\n⚠️ Attention:\n";
     List.iter
       (fun item ->
@@ -209,7 +227,7 @@ let status_summary_string
         (Printf.sprintf "  %s %s P%d [%s] %s (%s)\n" status_icon task.id
            task.priority status_label task.title assignee))
     shown_active_tasks;
-  if active_tasks = [] then
+  if (match active_tasks with [] -> true | _ -> false) then
     Buffer.add_string buf "  (no active tasks)\n";
   if List.length active_tasks > max_active_tasks_display then
     Buffer.add_string buf

--- a/lib/coord_status_rendering.mli
+++ b/lib/coord_status_rendering.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Coord_status_rendering — rendering logic for [masc_status].
 
     Pure-text status summary for the [masc_status] tool.  The

--- a/lib/coord_types.ml
+++ b/lib/coord_types.ml
@@ -1,3 +1,21 @@
+open Base
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
 (** Coord_types - Shared types for coordination modules *)
 
 type tool_result = {

--- a/lib/coord_types.mli
+++ b/lib/coord_types.mli
@@ -1,3 +1,5 @@
+open Base
+
 (** Coord_types — Shared types for coordination modules.
 
     Type-SSOT for the [tool_coord] / [coord_status_rendering] /


### PR DESCRIPTION
Phase 3b: Purge ad-hoc stdlib logic in lib/board_*.ml and lib/coord_*.ml and adopt Jane Street Base. Fixed string equals, float comparisons, and I/O wrappers.