### PR TITLE
feat(repo): add register_discovered migration helper and tests

### DIFF
--- a/docs/repo-migration-guide.md
+++ b/docs/repo-migration-guide.md
@@ -1,0 +1,100 @@
+# Repository Migration Guide
+
+This guide helps existing masc-mcp users migrate from the legacy single-repository
+model to the new multi-repository system introduced in Week 8.
+
+## What Changed
+
+| Before | After |
+|--------|-------|
+| Single implicit repository at `base_path` | Multiple explicit repositories in `.masc/config/repositories.toml` |
+| All keepers see all branches | Keeper-repo mapping controls access |
+| No URL tracking | Each repository has a remote URL and local checkout path |
+
+## Migration Steps
+
+### Phase 1: Discover Existing Repositories
+
+The runtime can automatically detect git repositories under your `base_path`:
+
+**Via OCaml API:**
+```ocaml
+(* Returns candidate repositories inferred from origin remotes *)
+let* candidates = Repo_store.discover_repositories ~base_path in
+```
+
+**Via HTTP API:**
+```bash
+curl -X POST http://localhost:8935/api/v1/repositories/discover \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Via automatic registration (Week 8 helper):**
+```ocaml
+(* Discovers and registers all found repositories, skipping duplicates *)
+let* registered = Repo_store.register_discovered ~base_path in
+```
+
+Directories scanned:
+- All paths containing `.git/` up to depth 3 under `base_path`
+- Excludes `.masc/` internals
+- Excludes already-registered repositories
+
+### Phase 2: Verify and Adjust
+
+After discovery, review `.masc/config/repositories.toml`:
+
+```toml
+[repository.project-a]
+name = "project-a"
+url = "https://github.com/myuser/project-a"
+local_path = ".masc/repos/project-a"
+default_branch = "main"
+credential_id = "default"
+keepers = []
+status = "Active"
+auto_sync = false
+sync_interval = 300
+```
+
+Fields to review:
+- `credential_id`: Assign the correct credential for this remote
+- `keepers`: List keeper IDs that should access this repository
+- `local_path`: Change if you want to keep the existing worktree location
+
+### Phase 3: Backward Compatibility
+
+If no `repositories.toml` exists, the system still returns a default repository
+pointing at `base_path`. This means:
+
+- Existing deployments continue to work without any file changes
+- The default repository has `id = "default"`
+- Once you add any explicit repository, the default is no longer injected
+
+### Phase 4: Keeper-Repository Mapping
+
+After registration, restrict keeper access:
+
+```ocaml
+(* Check if a keeper may use a repository *)
+let allowed = Keeper_repo_mapping.is_allowed
+  ~keeper_id:"keeper-a"
+  ~repository_id:"project-a"
+  ~base_path
+```
+
+An empty mapping means "allow all" (open fallback). As soon as you assign at
+least one keeper to a repository, only listed keepers may access it.
+
+## Rollback
+
+To revert to the legacy behavior, delete `.masc/config/repositories.toml`. The
+system will immediately fall back to the single default repository.
+
+## Verification Checklist
+
+- [ ] `discover_repositories` finds your expected repositories
+- [ ] `register_discovered` (or manual `add`) populates TOML
+- [ ] `load_all` returns the registered repositories
+- [ ] Keeper operations still work for allowed repositories
+- [ ] Dashboard shows the repository list correctly

--- a/docs/repo-migration-guide.md
+++ b/docs/repo-migration-guide.md
@@ -83,8 +83,10 @@ let allowed = Keeper_repo_mapping.is_allowed
   ~base_path
 ```
 
-An empty mapping means "allow all" (open fallback). As soon as you assign at
-least one keeper to a repository, only listed keepers may access it.
+If no mapping exists for a keeper, access falls back to "allow all" for backward
+compatibility. Once keeper-repository mappings are configured, access is
+restricted to the repositories explicitly listed for that keeper; an explicit
+empty mapping grants access to no repositories.
 
 ## Rollback
 

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -5,6 +5,9 @@ let ( let* ) = Result.bind
 let repos_toml_path base_path =
   Filename.concat base_path ".masc/config/repositories.toml"
 
+let repositories_toml_exists base_path =
+  Sys.file_exists (repos_toml_path base_path)
+
 let default_local_path id = Filename.concat ".masc/repos" id
 
 let now_unix_seconds () = Int64.of_float (Unix.time ())
@@ -301,10 +304,17 @@ let run_read_line cmd =
   with Sys_error msg -> Error msg
 
 let discover_repositories ~base_path =
+  let toml_exists = repositories_toml_exists base_path in
   let existing_paths =
     match load_all ~base_path with
     | Ok repos ->
-        List.map (fun (r : repository) -> local_path ~base_path r) repos
+        repos
+        |> List.filter (fun (r : repository) ->
+            not
+              ((not toml_exists)
+               && String.equal r.id "default"
+               && String.equal (local_path ~base_path r) base_path))
+        |> List.map (fun (r : repository) -> local_path ~base_path r)
     | Error _ -> []
   in
   let git_dirs =
@@ -371,11 +381,24 @@ let discover_repositories ~base_path =
 
 let register_discovered ~base_path =
   let* candidates = discover_repositories ~base_path in
-  let rec loop acc = function
-    | [] -> Ok (List.rev acc)
-    | candidate :: rest -> (
-        match add ~base_path candidate with
-        | Ok registered -> loop (registered :: acc) rest
-        | Error _ -> loop acc rest)
+  let* existing =
+    if repositories_toml_exists base_path then load_all ~base_path else Ok []
   in
-  loop [] candidates
+  let existing_ids = List.map (fun (r : repository) -> r.id) existing in
+  let timestamp = now_unix_seconds () in
+  let rec collect seen_ids acc = function
+    | [] -> List.rev acc
+    | (candidate : repository) :: rest ->
+        if List.exists (String.equal candidate.id) seen_ids then
+          collect seen_ids acc rest
+        else
+          let registered =
+            { candidate with created_at = timestamp; updated_at = timestamp }
+          in
+          collect (candidate.id :: seen_ids) (registered :: acc) rest
+  in
+  match collect existing_ids [] candidates with
+  | [] -> Ok []
+  | registered ->
+      let* () = save_all ~base_path (existing @ registered) in
+      Ok registered

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -368,3 +368,14 @@ let discover_repositories ~base_path =
       git_dirs
   in
   Ok candidates
+
+let register_discovered ~base_path =
+  let* candidates = discover_repositories ~base_path in
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | candidate :: rest -> (
+        match add ~base_path candidate with
+        | Ok registered -> loop (registered :: acc) rest
+        | Error _ -> loop acc rest)
+  in
+  loop [] candidates

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -51,3 +51,13 @@ val discover_repositories : base_path:string -> (repository list, string) result
     [repositories.toml] are excluded. This function is read-only and is
     intended for Phase 1 onboarding where the operator confirms discovered
     repositories before adding them to the store. *)
+
+val register_discovered : base_path:string -> (repository list, string) result
+(** [register_discovered ~base_path] scans [base_path] for git repositories
+    using {!discover_repositories} and automatically adds each candidate via
+    {!add}. Repositories that already exist (same [id]) are skipped rather
+    than failing. Returns the list of newly registered repositories.
+
+    This is the Week 8 migration helper: existing users with git
+    repositories under their base path can call this once to populate
+    [repositories.toml] without manual registration. *)

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -54,9 +54,10 @@ val discover_repositories : base_path:string -> (repository list, string) result
 
 val register_discovered : base_path:string -> (repository list, string) result
 (** [register_discovered ~base_path] scans [base_path] for git repositories
-    using {!discover_repositories} and automatically adds each candidate via
-    {!add}. Repositories that already exist (same [id]) are skipped rather
-    than failing. Returns the list of newly registered repositories.
+    using {!discover_repositories} and automatically persists each candidate.
+    Repositories that already exist (same [id]) may be skipped; store failures
+    are returned to the caller as [Error _]. On success, returns the list of
+    newly registered repositories.
 
     This is the Week 8 migration helper: existing users with git
     repositories under their base path can call this once to populate

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -333,6 +333,46 @@ let test_discover_skips_registered () =
             | Ok repos ->
                 Alcotest.(check int) "skips already registered" 0
                   (List.length repos)))
+
+let test_register_discovered_auto_adds () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let repo_a = Filename.concat base_path "project-a" in
+        let repo_b = Filename.concat base_path "project-b" in
+        Unix.mkdir repo_a 0o755;
+        Unix.mkdir repo_b 0o755;
+        init_git_repo repo_a "https://github.com/test/project-a";
+        init_git_repo repo_b "https://github.com/test/project-b";
+        match Repo_store.register_discovered ~base_path with
+        | Error e -> Alcotest.fail ("register_discovered failed: " ^ e)
+        | Ok registered ->
+            Alcotest.(check int) "registered 2 repos" 2 (List.length registered);
+            let ids = List.map (fun (r : repository) -> r.id) registered in
+            Alcotest.(check bool) "has project-a" true (List.mem "project-a" ids);
+            Alcotest.(check bool) "has project-b" true (List.mem "project-b" ids);
+            (* Verify TOML now exists and contains both *)
+            match Repo_store.load_all ~base_path with
+            | Error e -> Alcotest.fail ("load after register failed: " ^ e)
+            | Ok loaded ->
+                Alcotest.(check int) "persisted 2 repos" 2 (List.length loaded))
+
+let test_register_discovered_skips_existing () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let repo_a = Filename.concat base_path "project-a" in
+        Unix.mkdir repo_a 0o755;
+        init_git_repo repo_a "https://github.com/test/project-a";
+        (* First call registers *)
+        (match Repo_store.register_discovered ~base_path with
+         | Error e -> Alcotest.fail ("first register failed: " ^ e)
+         | Ok first -> Alcotest.(check int) "first count" 1 (List.length first));
+        (* Second call should skip and return empty *)
+        match Repo_store.register_discovered ~base_path with
+        | Error e -> Alcotest.fail ("second register failed: " ^ e)
+        | Ok second ->
+            Alcotest.(check int) "second count empty" 0 (List.length second))
 let () =
   Alcotest.run "Repo_store"
     [
@@ -392,5 +432,9 @@ let () =
             test_migration_backward_compat_to_explicit;
           Alcotest.test_case "preserves existing toml" `Quick
             test_migration_preserves_existing_toml;
+          Alcotest.test_case "register_discovered auto-adds" `Quick
+            test_register_discovered_auto_adds;
+          Alcotest.test_case "register_discovered skips existing" `Quick
+            test_register_discovered_skips_existing;
         ] );
     ]

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -357,6 +357,38 @@ let test_register_discovered_auto_adds () =
             | Ok loaded ->
                 Alcotest.(check int) "persisted 2 repos" 2 (List.length loaded))
 
+let test_register_discovered_includes_legacy_root_repo () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let repo_b = Filename.concat base_path "project-b" in
+        Unix.mkdir repo_b 0o755;
+        init_git_repo base_path "https://github.com/test/root-repo";
+        init_git_repo repo_b "https://github.com/test/project-b";
+        match Repo_store.register_discovered ~base_path with
+        | Error e -> Alcotest.fail ("register_discovered failed: " ^ e)
+        | Ok registered ->
+            Alcotest.(check int) "registered 2 repos" 2 (List.length registered);
+            let ids = List.map (fun (r : repository) -> r.id) registered in
+            let has_root =
+              List.exists
+                (fun (r : repository) -> String.equal r.local_path base_path)
+                registered
+            in
+            Alcotest.(check bool) "has root repo at base_path" true has_root;
+            Alcotest.(check bool) "has project-b" true (List.mem "project-b" ids);
+            match Repo_store.load_all ~base_path with
+            | Error e -> Alcotest.fail ("load after register failed: " ^ e)
+            | Ok loaded ->
+                let persisted_root =
+                  List.exists
+                    (fun (r : repository) -> String.equal r.local_path base_path)
+                    loaded
+                in
+                Alcotest.(check int) "persisted 2 repos" 2 (List.length loaded);
+                Alcotest.(check bool) "persisted root repo at base_path" true
+                  persisted_root)
+
 let test_register_discovered_skips_existing () =
   if not (git_available ()) then Alcotest.skip ()
   else
@@ -434,6 +466,8 @@ let () =
             test_migration_preserves_existing_toml;
           Alcotest.test_case "register_discovered auto-adds" `Quick
             test_register_discovered_auto_adds;
+          Alcotest.test_case "register_discovered includes legacy root repo" `Quick
+            test_register_discovered_includes_legacy_root_repo;
           Alcotest.test_case "register_discovered skips existing" `Quick
             test_register_discovered_skips_existing;
         ] );


### PR DESCRIPTION
## Summary
- Adds `Repo_store.register_discovered` Week 8 migration helper that discovers git repositories under `base_path` and auto-registers them, skipping duplicates.
- Adds tests: `test_register_discovered_auto_adds`, `test_register_discovered_skips_existing`.
- Adds `docs/repo-migration-guide.md` documenting the 4-phase migration flow.

## Test plan
- [x] `dune build` compiles
- [x] `test_repo_store` tests cover the new helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)