### PR TITLE
ci: keep PR state flips from canceling builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-    # State-only PR readiness events are handled by PR Automation. Keeping CI
-    # on code-changing events avoids canceling a still-useful build for the
-    # same PR concurrency group.
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}
 
 permissions:
@@ -18,10 +15,14 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Code-changing PR events supersede older CI for the same PR. State-only
+  # readiness events must not cancel an already-running code CI; they may queue
+  # behind it to run the ready/full-matrix path.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) }}
 
-# Draft/ready policy lives in PR Automation. CI stays tied to code-changing
-# PR events so state flips do not cancel build jobs for the same PR group.
+# Draft/ready policy lives in PR Automation. CI still listens for readiness
+# events so draft PRs can run the full matrix when promoted, without letting
+# state flips cancel build jobs for the same PR group.
 jobs:
   pr-sync-check:
     name: PR Sync Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Draft PRs are collaboration scratch space. Keep only the lightweight
-# PR-sync/CI-Gate path there, then run the full matrix on ready_for_review.
+# Draft/ready policy lives in PR Automation. CI stays tied to code-changing
+# PR events so state flips do not cancel build jobs for the same PR group.
 jobs:
   pr-sync-check:
     name: PR Sync Check
@@ -619,7 +619,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Dependency installation plus @install warn-error build regularly exceeds
+    # 20 minutes on cold runners; keep this above the install-only worst case.
+    timeout-minutes: 40
     needs: [pr-sync-check, changes]
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.lint == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ concurrency:
   # behind it to run the ready/full-matrix path.
   cancel-in-progress: ${{ github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) }}
 
-# Draft/ready policy lives in PR Automation. CI still listens for readiness
-# events so draft PRs can run the full matrix when promoted, without letting
-# state flips cancel build jobs for the same PR group.
 jobs:
   pr-sync-check:
     name: PR Sync Check

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -88,9 +88,12 @@ let test_ci_sync_and_asset_contracts () =
     (file_contains_pattern ".github/workflows/ci.yml" "Verify PR sync");
   check bool "ci workflow passes pr number to sync check" true
     (file_contains_pattern ".github/workflows/ci.yml" "--pr-number \"$PR_NUMBER\"");
-  check bool "ci workflow ignores PR readiness state events" true
-    (file_not_contains_pattern ".github/workflows/ci.yml" "ready_for_review");
-  check bool "pr automation owns PR readiness state events" true
+  check bool "ci workflow still listens for PR readiness state events" true
+    (file_contains_pattern ".github/workflows/ci.yml" "ready_for_review");
+  check bool "ci workflow does not cancel builds on readiness state events" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       {|contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action)|});
+  check bool "pr automation owns PR readiness policy" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "ready_for_review");
   check bool "ci gate enforces agent draft policy" true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -272,6 +272,21 @@ let test_health_and_ci_runner_diagnostics () =
     (file_not_contains_pattern "scripts/ci-run-tests.sh" "> >(tee");
   check bool "ci runner tracks active build dir for diagnostics" true
     (file_contains_pattern "scripts/ci-run-tests.sh" "ACTIVE_TEST_BUILD_DIR");
+  let lint_job =
+    file_pattern_position ".github/workflows/ci.yml" "\n  lint:\n    name: Lint"
+  in
+  let lint_timeout =
+    file_pattern_position ".github/workflows/ci.yml"
+      "    timeout-minutes: 40"
+  in
+  let dashboard_job =
+    file_pattern_position ".github/workflows/ci.yml" "\n  dashboard:\n    name: Dashboard"
+  in
+  check bool "lint job has cold dependency install headroom" true
+    (match lint_job, lint_timeout, dashboard_job with
+     | Some lint_pos, Some timeout_pos, Some dashboard_pos ->
+       lint_pos < timeout_pos && timeout_pos < dashboard_pos
+     | _ -> false);
   check bool "quick suite excludes operator control from monolithic dune test" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "MASC_INCLUDE_OPERATOR_CONTROL: \"false\"");


### PR DESCRIPTION
Follow-up to #12423.

Summary:
- keep the CI ready-for-review trigger so draft PRs can still run the full matrix when promoted
- scope CI cancel-in-progress to code-changing PR events only: opened, synchronize, reopened
- raise Lint timeout from 20m to 40m after live run 25204749143 canceled during OCaml dependency install
- add source guards for the ready-event concurrency contract and lint timeout headroom

Validation:
- git diff --check
- bash scripts/check-spec-truth.sh --verbose
- make check-ssot
- scripts/dune-local.sh build test/test_ci_hardening_source.exe
- _build/default/test/test_ci_hardening_source.exe

Current draft-check state:
- PR Sync Check, Draft Auto-Merge Guard, and label-and-review pass
- full matrix is skipped while draft
- CI Gate is expected red until a human adds human-approved-ready