### PR TITLE
chore: bump oas agent sdk pin to latest main (84a3d3fb)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.187.6"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="5063db8ce4ff85cc8a583e53639a1e070465d656"
+readonly OAS_AGENT_SDK_SHA="84a3d3fb7fcb8dff2cb242fc11f6fc88d431084a"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.187.6"


### PR DESCRIPTION
## Summary
- Bump OAS agent SDK SHA from `5063db8c` → `84a3d3fb`
- Base version remains `0.187.6`

## Context
Latest upstream commit: `ci: trigger checks on draft conversion (#1309)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)