### PR TITLE
ci: trim redundant workflow queue usage

### DIFF
--- a/.github/workflows/approve-agent-pr.yml
+++ b/.github/workflows/approve-agent-pr.yml
@@ -45,6 +45,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: approve-agent-pr-${{ github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   await-human-approval:
     name: Await Human Approval (Environment Gate)

--- a/.github/workflows/dashboard-ws-load.yml
+++ b/.github/workflows/dashboard-ws-load.yml
@@ -25,7 +25,7 @@ name: PR-0.2.G — Dashboard WS Load (k6)
 #
 # References:
 #   - dashboard/test/load/ws-100vu.js
-#   - .github/workflows/perf-baseline.yml          (mirror schedule pattern)
+#   - .github/workflows/perf-baseline.yml          (manual live-run pattern)
 #   - knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-QUEUE.md Q-P1-7
 #
 # Manual-only: this expects an operator-provided live dashboard endpoint, so

--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -1,16 +1,14 @@
-name: Perf Baseline (Daily)
+name: Perf Baseline (Manual)
 
-# Runs scripts/perf-baseline.sh on a daily schedule and records the
-# raw output as an artifact. The script targets a live masc-mcp server
-# at :8935; in CI no server is running, so the run is expected to exit
-# with code 3 ("server unreachable"). The captured artifact is still
-# useful as an audit trail of attempted runs and dependency presence
-# (curl, awk, date, mkdir, tee) on the runner.
+# Validates scripts/perf-baseline.sh on demand and records the dry-run
+# output as an artifact. The script targets a live masc-mcp server at
+# :8935; in GitHub-hosted CI no server is running, so scheduled runs only
+# produced fake green artifacts for the expected "server unreachable" path.
 #
 # Real 14-day baseline collection happens on the Railway production
 # host per docs/design/perf-baseline-protocol.md section 3.3. This
-# workflow documents the schedule and leaves a paper trail; the daily
-# production cron is the source of truth for actual numbers.
+# workflow is manual-only; the production cron is the source of truth for
+# actual numbers.
 #
 # References:
 #   - scripts/perf-baseline.sh        (#11984)
@@ -18,9 +16,11 @@ name: Perf Baseline (Daily)
 #   - knowledge/research/2026-04-masc-ide-strategy/IMPLEMENTATION-PLAN.md PR-0.2.F
 
 on:
-  schedule:
-    - cron: '0 8 * * *'  # daily 08:00 UTC
   workflow_dispatch:
+
+concurrency:
+  group: perf-baseline-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   baseline:
@@ -30,14 +30,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run perf baseline
+      - name: Validate perf baseline script
         run: |
           chmod +x scripts/perf-baseline.sh
-          ./scripts/perf-baseline.sh > baseline-output.txt 2>&1 || echo "exit=$?" >> baseline-output.txt
+          ./scripts/perf-baseline.sh --dry-run > baseline-output.txt 2>&1
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: perf-baseline-${{ github.run_id }}
           path: baseline-output.txt
-          retention-days: 90
+          retention-days: 14

--- a/.github/workflows/tla-index.yml
+++ b/.github/workflows/tla-index.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: tla-spec-index-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   drift-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/webrtc-live-interop.yml
+++ b/.github/workflows/webrtc-live-interop.yml
@@ -6,6 +6,10 @@ on:
     # Run weekly on Sundays at 3:15 AM UTC (reduced from daily to save CI costs)
     - cron: '15 3 * * 0'
 
+concurrency:
+  group: webrtc-live-interop-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   live-interop:
     name: WebRTC Live Interop

--- a/docs/design/dashboard-perf-protocol.md
+++ b/docs/design/dashboard-perf-protocol.md
@@ -89,7 +89,7 @@ Each step is a separate PR. This document is the contract; the workflow is the r
 ## 7. References
 
 - `dashboard/package.json` — `vite build`, `@preact/preset-vite`, `tailwindcss@^4.2.2`
-- `.github/workflows/perf-baseline.yml` — sibling: server-side perf cron
+- `.github/workflows/perf-baseline.yml` — sibling: manual server-side perf script validation
 - `.github/workflows/dashboard-ws-load.yml` — sibling: k6 WS load
 - `knowledge/research/2026-04-masc-ide-strategy/ch4_dashboard.md` §4 lines 230-378 — anti-RUM rationale
 - `knowledge/research/2026-04-masc-ide-strategy/track-c-coordination-perf.md` §3 line 148 — original lighthouse-vitals-pipeline scope


### PR DESCRIPTION
## Summary
- make Perf Baseline manual-only and switch the CI path to `scripts/perf-baseline.sh --dry-run` instead of scheduled fake-green unreachable-server artifacts
- add same-ref / same-PR concurrency cancellation to TLA index, WebRTC live interop, and human approval dispatch workflows
- update dashboard perf references so the docs no longer describe Perf Baseline as a GitHub scheduled cron

## Why
- `Perf Baseline (Daily)` cannot collect real numbers on GitHub-hosted runners because no masc-mcp server is running there; the production cron remains the source of truth
- recent `tla-spec-index` history showed repeated PR runs for superseded heads, so stale runs should cancel instead of occupying queue capacity

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/perf-baseline.yml .github/workflows/tla-index.yml .github/workflows/webrtc-live-interop.yml .github/workflows/approve-agent-pr.yml .github/workflows/dashboard-ws-load.yml`
- `bash scripts/perf-baseline.sh --dry-run`
- `git diff --check`