### PR TITLE
fix: apply provider-aware OAS timeout budgets

### DIFF
--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -11,8 +11,8 @@ is effectively advisory.
 | Layer | Role | Typical cap | Source of truth |
 |-------|------|-------------|-----------------|
 | `Tool` | per-tool HTTP / shell invocation | 10–60 s | `Env_config_runtime.*`, `lib/tool_local_runtime_http.ml` |
-| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 60–300 s (adaptive) | `Env_config_keeper.oas_timeout_sec*` |
-| `Keeper_turn` | one keeper turn (may issue many OAS calls) | 3600 s | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
+| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 300 s default; provider attempt caps may be lower | `Env_config_keeper.oas_timeout_sec*`, `Oas_worker_named.effective_provider_attempt_timeout_s` |
+| `Keeper_turn` | one keeper turn (may issue many OAS calls) | 600 s default/hard ceiling | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
 | `Keeper_cycle` | full keeper lifecycle | N×turn | cycle supervisor |
 | `Shutdown` | graceful shutdown board flush | 2 s | `bin/main_eio.ml` |
 
@@ -86,7 +86,7 @@ logs. Candidates:
 
 | Site | Current cap | Owning issue |
 |------|-------------|--------------|
-| `keeper_llm_bridge` | 60–573 s (adaptive) | #9639, #9662 (this PR) |
+| `keeper_llm_bridge` | 300 s default inside 600 s keeper turn | #9639, #9662 |
 | Governance `compute_judgments` | 60 s | #9629 |
 | `Process_eio` `git status --porcelain` | 15 s | #9632 |
 | `Process_eio` `git rev-parse` | 5 s | #9765, #9775 |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -373,18 +373,17 @@ module KeeperKeepalive = struct
   (** Wall-clock timeout in seconds for a single unified turn (including all
       retries and cascade fallbacks). Prevents indefinite blocking when an
       upstream LLM hangs at the TCP level.
-      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 3600. Range: [60, 7200].
-      Raised from 1200 to 3600 (issue #9637): production fleet observed
-      "turn wall-clock timeout after 1200s" with sangsu/qa-king keepers
-      stalling on multi-turn research cycles using GLM-5.1 + local 27B
-      cascade. The new floor matches the budgeted ceiling and gives
-      operators headroom; range upper bumped to 7200 for the same reason.
+      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 600. Range: [60, 600].
 
-      Additionally capped at [timeout_hard_ceiling_sec] (600s) so the turn
-      timeout can never exceed the global hard ceiling. *)
+      The default is deliberately the global hard ceiling. Individual OAS
+      provider attempts are capped by [oas_timeout_default_sec] and
+      provider-specific bounds below, so the full turn budget remains a
+      container for fallback/retry work rather than one provider's spend. *)
   let turn_timeout_sec =
     Float.max 60.0 (Float.min timeout_hard_ceiling_sec
-      (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+      (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+
+  let oas_timeout_default_sec = 300.0
 
   (** Maximum time a proactive keeper will wait in the MASC admission queue
       before abandoning the current OAS attempt.
@@ -412,12 +411,10 @@ module KeeperKeepalive = struct
   (** Per-call timeout in seconds for a single OAS Agent.run execution.
       Guards against indefinite LLM response waits within a turn.
 
-      When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly.
-      Otherwise, {!oas_timeout_for_estimated_input_tokens} returns the
-      keeper wall-clock cap directly.  The previous adaptive formula used
-      token count and per-turn multipliers, but those estimates were far
-      below observed fleet turn latency and could timeout before a real
-      multi-turn call completed.
+      When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly
+      up to the keeper turn cap. Otherwise, the default is 300s. This keeps
+      OAS calls shorter than the 600s keeper turn envelope, so a stalled
+      provider cannot consume the whole turn before cascade fallback can run.
 
       Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: adaptive.
       Range: [30, turn_timeout_sec].
@@ -470,34 +467,13 @@ module KeeperKeepalive = struct
     match oas_timeout_sec_override with
     | Some v -> v
     | None ->
-      (* #10008 fm2: the prior formula scaled the budget linearly with
-         [max_turns * per_turn (=30s)].  #9933 recent-hour measurement
-         shows fleet p50 turn latency ~16 min (960s) — the 30s-per-turn
-         assumption was 32x below reality.  velvet-hammer at max_turns=10
-         computed only 423.8s of OAS budget against a 1200s wall-clock
-         cap; multi-turn research calls regularly hit
-         [oas_timeout_budget] before a single real turn finished.
-
-         Root-cause fix: drop the [per_turn * turns] term entirely.
-         [turn_timeout_sec] is already the authoritative wall-clock
-         cap the formula was trying to approach.  Keep the tiny
-         [base + input_time] estimate as a lower bound so tests and
-         callers that set explicit overrides still see a sensible
-         value, then floor at the wall-clock cap.  [max_turns] stops
-         being an input to this computation — the count controls the
-         OAS agent's retry budget elsewhere, not MASC's wall-clock
-         expectation. *)
+      (* #10008 fm2 removed token-count scaling because it timed out real
+         research turns before useful work could finish. The replacement must
+         still leave headroom for cascade fallback: default OAS calls get a
+         300s cap inside the 600s keeper turn envelope. [max_turns] controls
+         the OAS agent's loop budget elsewhere; it is not a wall-clock input. *)
       let _ = estimated_input_tokens in
-      (* Use wall-clock cap directly.  Short calls exit early via
-         tool-response detection; they do not need a smaller budget
-         reserved up front.  [estimated_input_tokens] and the old
-         [base + input_time] estimate are no longer load-bearing
-         inputs — they scaled at 1.5s/1k tokens, which was
-         negligible compared to the real p50 turn latency the
-         multiplier was trying to reserve for.  Kept in the
-         signature because callers still pass the value; ignored
-         for budget computation. *)
-      turn_timeout_sec
+      Float.min turn_timeout_sec oas_timeout_default_sec
 
   let oas_timeout_for_estimated_input_tokens
       ~(estimated_input_tokens : int) : float =
@@ -509,7 +485,7 @@ module KeeperKeepalive = struct
       Prefer {!oas_timeout_for_estimated_input_tokens} when a live prompt
       estimate is available. *)
   let oas_timeout_sec =
-    Option.value ~default:300.0 oas_timeout_sec_override
+    Option.value ~default:oas_timeout_default_sec oas_timeout_sec_override
 
   (** Idle-gap timeout for streaming OAS provider responses.
       This bounds time between streamed lines, not total turn duration.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -230,6 +230,11 @@ let run_turn
           Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens
             ~estimated_input_tokens
     in
+    let per_provider_timeout_s =
+      match meta.per_provider_timeout_s with
+      | Some _ as configured -> configured
+      | None -> Some timeout_s
+    in
     (* OAS [stream_idle_timeout_s] bounds inter-line idle on HTTP streams
        (Anthropic/OpenAI/Gemini/GLM/Ollama). The deadline resets after each
        successful line, so this is gap detection, not total run cap.
@@ -407,7 +412,7 @@ let run_turn
               natural completion (max_turns or model end_turn). *)
            ?oas_checkpoint:resume_oas_checkpoint
            ?event_bus
-           ?per_provider_timeout_s:meta.per_provider_timeout_s
+           ?per_provider_timeout_s
            ())
      with
      | Error e -> Error e

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -72,12 +72,13 @@ let autonomous_max_idle_turns_live () =
 
 let turn_timeout_sec_live () =
   (* SSOT: must match Env_config_keeper.KeeperKeepalive.turn_timeout_sec
-     (range [60, timeout_hard_ceiling_sec], default 3600 clamped to
-     600 post-bulkhead hard ceiling). Drift here was the mathematical
-     root of #10388 (1200 - 30 oas_guard = 1170s budget). *)
+     (range [60, timeout_hard_ceiling_sec], default 600). Drift here was
+     the mathematical root of #10388 (1200 - 30 oas_guard = 1170s budget). *)
   Float.max 60.0
     (Float.min 600.0
-       (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+       (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+
+let oas_timeout_default_sec = 300.0
 
 let admission_wait_timeout_sec_live () =
   Float.max 5.0
@@ -265,11 +266,9 @@ let oas_timeout_for_estimated_input_tokens_with_turn_budget
          The old formula scaled linearly with [max_turns * per_turn(=30s)]
          but production p50 turn latency was ~16 min (#9933), making
          the multiplier 32x below reality.  Drop the turn-count and
-         input-token scaling; return [turn_timeout_sec] directly as
-         the wall-clock cap.  Short calls exit early via tool-response
-         detection, they do not need a smaller budget reserved up
-         front. *)
-      runtime.turn_timeout_sec.value
+         input-token scaling. Keep the default OAS call cap at 300s so
+         the 600s keeper turn envelope has room for cascade fallback. *)
+      Float.min runtime.turn_timeout_sec.value oas_timeout_default_sec
 
 let oas_timeout_for_estimated_input_tokens ~(estimated_input_tokens : int) :
     float =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -16,24 +16,59 @@ include Oas_worker_named_cascade
 include Oas_worker_named_error
 include Oas_worker_named_fsm
 
-let provider_attempt_timeout_hint_s
-    (provider_cfg : Llm_provider.Provider_config.t) : float option =
+type provider_attempt_timeout_constraints = {
+  min_timeout_s : float option;
+  max_timeout_s : float option;
+}
+
+let provider_attempt_timeout_constraints
+    (provider_cfg : Llm_provider.Provider_config.t) =
   match provider_cfg.kind with
-  | Llm_provider.Provider_config.Ollama -> Some 300.0
-  | Claude_code -> Some 120.0
-  | Gemini | Gemini_cli -> Some 180.0
-  | Kimi_cli -> Some 60.0
-  | Anthropic | Kimi | OpenAI_compat | Glm | DashScope | Codex_cli -> None
+  | Llm_provider.Provider_config.Ollama ->
+      { min_timeout_s = Some 300.0; max_timeout_s = None }
+  | Claude_code ->
+      { min_timeout_s = None; max_timeout_s = Some 120.0 }
+  | Gemini | Gemini_cli ->
+      { min_timeout_s = None; max_timeout_s = Some 180.0 }
+  | Kimi_cli ->
+      { min_timeout_s = None; max_timeout_s = Some 60.0 }
+  | Anthropic | Kimi | OpenAI_compat | Glm | DashScope | Codex_cli ->
+      { min_timeout_s = None; max_timeout_s = None }
+
+let apply_provider_attempt_timeout_constraints constraints timeout_s =
+  let timeout_s =
+    match constraints.min_timeout_s with
+    | Some min_s -> Float.max timeout_s min_s
+    | None -> timeout_s
+  in
+  match constraints.max_timeout_s with
+  | Some max_s -> Float.min timeout_s max_s
+  | None -> timeout_s
+
+let provider_default_attempt_timeout_s constraints =
+  match constraints.min_timeout_s, constraints.max_timeout_s with
+  | Some min_s, Some max_s -> Some (Float.min max_s min_s)
+  | Some min_s, None -> Some min_s
+  | None, Some max_s -> Some max_s
+  | None, None -> None
 
 let effective_provider_attempt_timeout_s
     ~(is_last : bool)
     ~(configured_timeout_s : float option)
     (provider_cfg : Llm_provider.Provider_config.t) : float option =
-  match configured_timeout_s, provider_attempt_timeout_hint_s provider_cfg with
-  | Some configured, Some hinted -> Some (Float.max configured hinted)
-  | Some configured, None -> if is_last then None else Some configured
-  | None, Some hinted -> Some hinted
-  | None, None -> None
+  let constraints = provider_attempt_timeout_constraints provider_cfg in
+  match configured_timeout_s with
+  | Some configured ->
+      let bounded =
+        apply_provider_attempt_timeout_constraints constraints configured
+      in
+      if is_last
+         && Option.is_none constraints.min_timeout_s
+         && Option.is_none constraints.max_timeout_s
+      then None
+      else Some bounded
+  | None ->
+      provider_default_attempt_timeout_s constraints
 
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -15,6 +15,21 @@ include module type of Oas_worker_named_cascade
 include module type of Oas_worker_named_error
 include module type of Oas_worker_named_fsm
 
+(** [effective_provider_attempt_timeout_s] applies provider-specific
+    timeout constraints to a configured cascade attempt budget.
+
+    - Ollama has a 300s floor for local model cold-load.
+    - Claude Code, Gemini, and Kimi CLI have shorter attempt caps so one
+      provider cannot spend the whole keeper turn budget before fallback.
+    - Providers without a known constraint keep the configured timeout unless
+      they are the last attempt, where the enclosing keeper/OAS timeout is
+      sufficient. *)
+val effective_provider_attempt_timeout_s :
+  is_last:bool ->
+  configured_timeout_s:float option ->
+  Llm_provider.Provider_config.t ->
+  float option
+
 (** {1 Named cascade execution} *)
 
 val run_named :

--- a/test/test_keeper_turn_timeout_default_10456.ml
+++ b/test/test_keeper_turn_timeout_default_10456.ml
@@ -1,5 +1,5 @@
 (** #10456/#10716 — pin {!Env_config_keeper.KeeperKeepalive.turn_timeout_sec}
-    SSOT default (1800) and the source literal in
+    SSOT default (600) and the source literal in
     {!Keeper_runtime_resolved.turn_timeout_sec_live}.
 
     Original pre-fix drift was:
@@ -9,8 +9,8 @@
     Math: 1200 - 30 (oas_timeout_guard_sec) = 1170s — exact match for
     #10388 cascade ollama timeout walls.
 
-    #10716 later lowered the SSOT default from 3600 to 1800; this test pins
-    the new default while preserving the 1200 drift guard.
+    The audit hard-ceiling pass later lowered the SSOT default to 600 so the
+    keeper turn envelope cannot hide long OAS provider stalls.
 
     This test pins the SSOT and source-level literal so silent
     re-divergence shows up as a test failure. *)
@@ -21,10 +21,10 @@ module E = Env_config_keeper.KeeperKeepalive
 
 let approx = float 0.001
 
-let test_ssot_default_1800 () =
+let test_ssot_default_600 () =
   check approx
-    "env_config_keeper.KeeperKeepalive.turn_timeout_sec SSOT must stay at 1800 (#10716)"
-    1800.0 E.turn_timeout_sec
+    "env_config_keeper.KeeperKeepalive.turn_timeout_sec SSOT must stay at 600"
+    600.0 E.turn_timeout_sec
 
 let resolver_source_path =
   let candidates =
@@ -49,7 +49,7 @@ let test_resolver_default_matches_ssot () =
   | None -> skip ()
   | Some p ->
       let body = read_file p in
-      (* The fix replaces default:1200.0 with default:1800.0 in
+      (* The fix replaces stale long defaults with default:600.0 in
          turn_timeout_sec_live. Guard: must NOT contain the stale literal
          on the same line as MASC_KEEPER_TURN_TIMEOUT_SEC. *)
       let stale_pattern = "~default:1200.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\"" in
@@ -57,7 +57,7 @@ let test_resolver_default_matches_ssot () =
         "~default:3600.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
       in
       let canonical_pattern =
-        "~default:1800.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
+        "~default:600.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
       in
       let contains s sub =
         let n = String.length s and m = String.length sub in
@@ -73,17 +73,16 @@ let test_resolver_default_matches_ssot () =
       let has_canonical = contains body canonical_pattern in
       check bool "no stale 1200 default in resolver" false has_stale;
       check bool "no stale 3600 default in resolver" false has_stale_3600;
-      check bool "canonical 1800 default in resolver" true has_canonical
+      check bool "canonical 600 default in resolver" true has_canonical
 
 let test_resolver_upper_matches_ssot () =
   match resolver_source_path with
   | None -> skip ()
   | Some p ->
       let body = read_file p in
-      (* The fix raises Float.min upper bound from 3600.0 to 7200.0 in
-         turn_timeout_sec_live block. Both 3600.0 and 7200.0 may appear
-         elsewhere; we just guard that 7200.0 is present after the fix. *)
-      let canonical_upper = "Float.min 7200.0" in
+      (* The resolver must keep the same 600s hard ceiling as
+         Env_config_keeper.KeeperKeepalive.turn_timeout_sec. *)
+      let canonical_upper = "Float.min 600.0" in
       let contains s sub =
         let n = String.length s and m = String.length sub in
         let rec loop i =
@@ -93,7 +92,7 @@ let test_resolver_upper_matches_ssot () =
         in
         loop 0
       in
-      check bool "canonical 7200 upper bound in resolver" true
+      check bool "canonical 600 upper bound in resolver" true
         (contains body canonical_upper)
 
 let () =
@@ -101,14 +100,14 @@ let () =
     [
       ( "ssot-pin",
         [
-          test_case "env_config_keeper SSOT default is 1800 (post-#10716)"
-            `Quick test_ssot_default_1800;
+          test_case "env_config_keeper SSOT default is 600"
+            `Quick test_ssot_default_600;
         ] );
       ( "resolver-drift-gate",
         [
           test_case "resolver default literal matches SSOT (no 1200 drift)"
             `Quick test_resolver_default_matches_ssot;
-          test_case "resolver upper bound literal matches SSOT (7200)" `Quick
+          test_case "resolver upper bound literal matches SSOT (600)" `Quick
             test_resolver_upper_matches_ssot;
         ] );
     ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1609,6 +1609,16 @@ let make_claude_code_provider_cfg ?(model_id = "auto") () =
     ~kind:Llm_provider.Provider_config.Claude_code
     ~model_id ~base_url:"" ()
 
+let make_gemini_cli_provider_cfg ?(model_id = "gemini-2.5-pro") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Gemini_cli
+    ~model_id ~base_url:"" ()
+
+let make_ollama_provider_cfg ?(model_id = "qwen3:27b") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Ollama
+    ~model_id ~base_url:"http://127.0.0.1:11434" ()
+
 let make_openai_compat_provider_cfg ?(model_id = "gpt-4.1") () =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.OpenAI_compat
@@ -1673,6 +1683,56 @@ let test_provider_effective_max_turns_keeps_ollama_budget () =
     (Oas_worker_exec.provider_effective_max_turns
        Llm_provider.Provider_config.Ollama
        39)
+
+let check_timeout_opt label expected actual =
+  Alcotest.(check (option (float 0.001))) label expected actual
+
+let provider_timeout ?(is_last = false) ?configured provider_cfg =
+  Oas_worker_named.effective_provider_attempt_timeout_s
+    ~is_last
+    ~configured_timeout_s:configured
+    provider_cfg
+
+let test_provider_attempt_timeout_caps_claude_code () =
+  check_timeout_opt
+    "claude_code caps configured attempt timeout"
+    (Some 120.0)
+    (provider_timeout
+       ~configured:300.0
+       (make_claude_code_provider_cfg ()))
+
+let test_provider_attempt_timeout_caps_kimi_cli () =
+  check_timeout_opt
+    "kimi_cli caps configured attempt timeout"
+    (Some 60.0)
+    (provider_timeout
+       ~configured:300.0
+       (make_kimi_cli_provider_cfg ()))
+
+let test_provider_attempt_timeout_caps_gemini_cli () =
+  check_timeout_opt
+    "gemini_cli caps configured attempt timeout"
+    (Some 180.0)
+    (provider_timeout
+       ~configured:300.0
+       (make_gemini_cli_provider_cfg ()))
+
+let test_provider_attempt_timeout_floors_ollama () =
+  check_timeout_opt
+    "ollama floors too-short configured attempt timeout"
+    (Some 300.0)
+    (provider_timeout
+       ~configured:60.0
+       (make_ollama_provider_cfg ()))
+
+let test_provider_attempt_timeout_leaves_unconstrained_last_to_outer_budget () =
+  check_timeout_opt
+    "unconstrained final provider relies on enclosing keeper/OAS timeout"
+    None
+    (provider_timeout
+       ~is_last:true
+       ~configured:300.0
+       (make_openai_compat_provider_cfg ()))
 
 let test_cascade_provider_labels_preserve_registered_openai_compat_family () =
   let provider_name = Masc_mcp.Oas_worker_cascade.provider_name_of_config
@@ -3916,6 +3976,16 @@ let () =
         test_provider_effective_max_turns_clamps_claude_code;
       Alcotest.test_case "provider max_turns leaves ollama uncapped" `Quick
         test_provider_effective_max_turns_keeps_ollama_budget;
+      Alcotest.test_case "provider timeout caps claude_code" `Quick
+        test_provider_attempt_timeout_caps_claude_code;
+      Alcotest.test_case "provider timeout caps kimi_cli" `Quick
+        test_provider_attempt_timeout_caps_kimi_cli;
+      Alcotest.test_case "provider timeout caps gemini_cli" `Quick
+        test_provider_attempt_timeout_caps_gemini_cli;
+      Alcotest.test_case "provider timeout floors ollama" `Quick
+        test_provider_attempt_timeout_floors_ollama;
+      Alcotest.test_case "provider timeout leaves unconstrained final provider to outer budget" `Quick
+        test_provider_attempt_timeout_leaves_unconstrained_last_to_outer_budget;
       Alcotest.test_case "cascade provider labels preserve registered openai_compat family" `Quick
         test_cascade_provider_labels_preserve_registered_openai_compat_family;
       Alcotest.test_case "cascade provider labels detect kimi from endpoint metadata" `Quick

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -72,70 +72,64 @@ let test_keepalive_jitter_range () =
 let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens
 
 (* #10008 fm2: the budget formula no longer scales with
-   [max_turns * per_turn(=30s)].  Production p50 turn latency is
-   ~16 min (#9933) — the 30s/turn assumption was 32x off, and
-   velvet-hammer at max_turns=10 computed only 423.8s against a
-   1200s wall-clock cap, starving multi-turn research calls.
-   Budget now equals [turn_timeout_sec] directly.  These tests
-   pin that invariant: input-token size and max_turns no longer
-   affect the computed budget, only the env override and the
-   wall-clock cap do. *)
+   [max_turns * per_turn(=30s)].  Production p50 turn latency showed that
+   token-count estimates were too small for real research turns.
+
+   The current invariant is a fixed 300s OAS call cap inside the 600s keeper
+   turn envelope. Input-token size and max_turns no longer affect the computed
+   budget; explicit env override remains the only way to change it. *)
 
 let turn_cap = Cfg.KeeperKeepalive.turn_timeout_sec
+let oas_cap = Cfg.KeeperKeepalive.oas_timeout_sec
 
-let test_oas_timeout_32k_uses_wall_clock () =
+let test_oas_timeout_32k_uses_oas_cap () =
   let v = adaptive ~estimated_input_tokens:32_000 in
   check (float 1.0)
-    "32K input → wall-clock cap (turn_timeout_sec)" turn_cap v
+    "32K input -> OAS cap" oas_cap v
 
-let test_oas_timeout_128k_uses_wall_clock () =
+let test_oas_timeout_128k_uses_oas_cap () =
   let v = adaptive ~estimated_input_tokens:128_000 in
   check (float 1.0)
-    "128K input → wall-clock cap (turn_timeout_sec)" turn_cap v
+    "128K input -> OAS cap" oas_cap v
 
-let test_oas_timeout_262k_uses_wall_clock () =
+let test_oas_timeout_262k_uses_oas_cap () =
   let v = adaptive ~estimated_input_tokens:262_144 in
   check (float 1.0)
-    "262K input → wall-clock cap (turn_timeout_sec)" turn_cap v
+    "262K input -> OAS cap" oas_cap v
 
-let test_oas_timeout_scheduled_autonomous_uses_wall_clock () =
+let test_oas_timeout_scheduled_autonomous_uses_oas_cap () =
   (* #10008 fm2 regression guard: max_turns must not pull the
-     budget below the wall-clock cap anymore. velvet-hammer's
-     423.8s symptom is gone; this call returns [turn_timeout_sec]
-     regardless of max_turns. *)
+     budget below the provider-attempt envelope anymore. *)
   let v =
     Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget
       ~estimated_input_tokens:262_144
       ~max_turns:Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
   in
   check (float 1.0)
-    "scheduled_autonomous → wall-clock cap (turn_timeout_sec)"
-    turn_cap v
+    "scheduled_autonomous -> OAS cap"
+    oas_cap v
 
-let test_oas_timeout_zero_uses_wall_clock () =
+let test_oas_timeout_zero_uses_oas_cap () =
   let v = adaptive ~estimated_input_tokens:0 in
-  check (float 1.0)
-    "0 context → wall-clock cap (turn_timeout_sec)" turn_cap v
+  check (float 1.0) "0 context -> OAS cap" oas_cap v
 
 (* #10008 fm2: the formula no longer varies with token count,
-   so the old "monotonic increase with input size" invariant is
-   replaced by a "constant equal to wall-clock cap" invariant. *)
+   so the old "monotonic increase with input size" invariant is replaced by a
+   "constant equal to OAS cap" invariant. *)
 let test_oas_timeout_is_token_independent () =
   let v1 = adaptive ~estimated_input_tokens:32_000 in
   let v2 = adaptive ~estimated_input_tokens:128_000 in
   let v3 = adaptive ~estimated_input_tokens:262_144 in
-  check (float 0.1) "32K == 128K (both at wall-clock cap)" v1 v2;
-  check (float 0.1) "128K == 262K (both at wall-clock cap)" v2 v3;
-  check (float 0.1) "all equal to turn_timeout_sec" turn_cap v1
+  check (float 0.1) "32K == 128K (both at OAS cap)" v1 v2;
+  check (float 0.1) "128K == 262K (both at OAS cap)" v2 v3;
+  check (float 0.1) "all equal to oas_timeout_sec" oas_cap v1
 
 let test_oas_timeout_cap () =
   let v = adaptive ~estimated_input_tokens:1_000_000 in
-  check (float 0.1)
-    "1M estimated input tokens → capped at turn_timeout_sec"
-    turn_cap v
+  check (float 0.1) "1M estimated input tokens -> capped at OAS cap" oas_cap v
 
 let test_turn_timeout_default () =
-  check (float 0.1) "default turn timeout 1800s" 1800.0
+  check (float 0.1) "default turn timeout 600s" 600.0
     Cfg.KeeperKeepalive.turn_timeout_sec
 
 let test_max_turns_default () =
@@ -373,20 +367,20 @@ let () =
       test_case "jitter range" `Quick test_keepalive_jitter_range;
     ];
     "oas_timeout_adaptive", [
-      test_case "32K context uses wall-clock cap (#10008 fm2)" `Quick
-        test_oas_timeout_32k_uses_wall_clock;
-      test_case "128K context uses wall-clock cap (#10008 fm2)" `Quick
-        test_oas_timeout_128k_uses_wall_clock;
-      test_case "262K context uses wall-clock cap (#10008 fm2)" `Quick
-        test_oas_timeout_262k_uses_wall_clock;
-      test_case "scheduled autonomous uses wall-clock cap (#10008 fm2)" `Quick
-        test_oas_timeout_scheduled_autonomous_uses_wall_clock;
-      test_case "0 context uses wall-clock cap (#10008 fm2)" `Quick
-        test_oas_timeout_zero_uses_wall_clock;
+      test_case "32K context uses OAS cap (#10008 fm2)" `Quick
+        test_oas_timeout_32k_uses_oas_cap;
+      test_case "128K context uses OAS cap (#10008 fm2)" `Quick
+        test_oas_timeout_128k_uses_oas_cap;
+      test_case "262K context uses OAS cap (#10008 fm2)" `Quick
+        test_oas_timeout_262k_uses_oas_cap;
+      test_case "scheduled autonomous uses OAS cap (#10008 fm2)" `Quick
+        test_oas_timeout_scheduled_autonomous_uses_oas_cap;
+      test_case "0 context uses OAS cap (#10008 fm2)" `Quick
+        test_oas_timeout_zero_uses_oas_cap;
       test_case "budget is token-count independent (#10008 fm2)" `Quick
         test_oas_timeout_is_token_independent;
-      test_case "turn timeout default is 1800" `Quick test_turn_timeout_default;
-      test_case "adaptive capped at turn timeout" `Quick test_oas_timeout_cap;
+      test_case "turn timeout default is 600" `Quick test_turn_timeout_default;
+      test_case "adaptive capped at OAS timeout" `Quick test_oas_timeout_cap;
       test_case "max_turns default is 30" `Quick test_max_turns_default;
       test_case "scheduled autonomous max_turns default is 10" `Quick
         test_scheduled_autonomous_max_turns_default;


### PR DESCRIPTION
## Summary
- cap default keeper OAS calls at 300s inside the 600s keeper turn envelope
- pass the resolved OAS budget into named-cascade provider attempts by default
- enforce provider-specific attempt constraints: Claude Code 120s cap, Gemini 180s cap, Kimi CLI 60s cap, Ollama 300s floor
- update timeout SSOT docs and regression tests

## Verification
- scripts/dune-local.sh build test/test_work_as_heartbeat.exe test/test_keeper_turn_timeout_default_10456.exe test/test_oas_worker.exe
- ./_build/default/test/test_work_as_heartbeat.exe
- ./_build/default/test/test_keeper_turn_timeout_default_10456.exe
- MASC_BASE_PATH=/private/tmp/masc-test-oas-worker-$$ ./_build/default/test/test_oas_worker.exe
- git diff --check