### PR TITLE
ci: cancel superseded branch runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name || github.run_id }}
-  # Code-changing PR events supersede older CI for the same PR. State-only
-  # readiness events must not cancel an already-running code CI; they may queue
-  # behind it to run the ready/full-matrix path.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) }}
+  # Code-changing PR events supersede older CI for the same PR. Pushes to the
+  # same branch also supersede older post-merge CI; only the latest branch head
+  # needs the full verification matrix. State-only readiness events must not
+  # cancel an already-running code CI; they may queue behind it to run the
+  # ready/full-matrix path.
+  cancel-in-progress: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action)) }}
 
 jobs:
   pr-sync-check:


### PR DESCRIPTION
## Summary
- cancel superseded push CI for the same branch, so only the latest main/develop head runs the full matrix
- preserve PR ready/state-event behavior by keeping cancel-on-PR limited to code-changing actions

## Verification
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml
- git diff --check

## Review focus
- This is queue hygiene only: push CI for older branch heads is redundant once a newer branch head exists; PR ready/full-matrix semantics are unchanged.