### PR TITLE
ci: compare health ratchets against baseline ref

### DIFF
--- a/.ci/health-baseline.json
+++ b/.ci/health-baseline.json
@@ -2,14 +2,20 @@
   "version": 1,
   "counts": {
     "lib_failwith": 0,
-    "lib_list_hd": 0,
+    "lib_list_hd": 4,
     "lib_list_tl": 0,
-    "lib_option_get": 3,
-    "lib_obj_magic": 3,
-    "test_failwith": 227,
-    "test_list_hd": 174,
+    "lib_option_get": 2,
+    "lib_obj_magic": 0,
+    "test_failwith": 415,
+    "test_list_hd": 322,
     "test_list_tl": 0,
-    "test_option_get": 49,
-    "test_obj_magic": 1
+    "test_option_get": 57,
+    "test_obj_magic": 0,
+    "manual_ml_over_500": 267,
+    "excepted_ml_over_500": 1,
+    "lib_ml_over_500": 171,
+    "bin_ml_over_500": 2,
+    "test_ml_over_500": 95,
+    "examples_ml_over_500": 0
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,26 +337,49 @@ jobs:
         with:
           install-flags: --with-test
 
-      - name: Fetch base branch for health ratchet
-        if: github.event_name == 'pull_request' && needs.changes.outputs.health_snapshot == 'true'
-        run: bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --depth=1
+      - name: Fetch baseline for health ratchet
+        if: needs.changes.outputs.health_snapshot == 'true'
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          zero_sha="0000000000000000000000000000000000000000"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            bash scripts/ci/git-fetch-retry.sh origin "${GITHUB_BASE_REF}" --depth=1
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ -n "${GITHUB_BEFORE}" ] && [ "${GITHUB_BEFORE}" != "${zero_sha}" ]; then
+            bash scripts/ci/git-fetch-retry.sh origin "${GITHUB_BEFORE}" --depth=1
+          else
+            echo "No health baseline ref for ${GITHUB_EVENT_NAME}; snapshot will run without ratchet gating"
+          fi
 
       - name: Run health snapshot
         if: needs.changes.outputs.health_snapshot == 'true'
         env:
-          HEALTH_BASELINE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BEFORE: ${{ github.event.before }}
         run: |
+          set -euo pipefail
           chmod +x scripts/health_snapshot.sh scripts/anti-fake-audit.sh
-          if [ -n "${HEALTH_BASELINE_REF}" ]; then
+          zero_sha="0000000000000000000000000000000000000000"
+          baseline_ref=""
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            baseline_ref="origin/${GITHUB_BASE_REF}"
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ -n "${GITHUB_BEFORE}" ] && [ "${GITHUB_BEFORE}" != "${zero_sha}" ]; then
+            baseline_ref="${GITHUB_BEFORE}"
+          fi
+
+          if [ -n "${baseline_ref}" ]; then
             opam exec -- bash scripts/health_snapshot.sh \
               --json-out .health/health-snapshot.json \
-              --baseline-ref "${HEALTH_BASELINE_REF}" \
+              --baseline-ref "${baseline_ref}" \
               --fail-on-lib-regression
           else
             opam exec -- bash scripts/health_snapshot.sh \
               --json-out .health/health-snapshot.json \
-              --baseline-file .ci/health-baseline.json \
-              --fail-on-lib-regression
+              --baseline-file .ci/health-baseline.json
           fi
 
       - name: Upload health snapshot

--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -83,6 +83,14 @@ baseline_source="none"
 baseline_ref_used=""
 baseline_file_used="$BASELINE_FILE"
 BASELINE_CONTENT=""
+BASELINE_TMP=""
+
+cleanup() {
+  if [ -n "$BASELINE_TMP" ]; then
+    rm -rf "$BASELINE_TMP"
+  fi
+}
+trap cleanup EXIT
 
 count_pattern() {
   local dir="$1"
@@ -129,6 +137,22 @@ load_baseline_content() {
   else
     BASELINE_CONTENT=""
   fi
+}
+
+load_baseline_ref_counts() {
+  BASELINE_TMP="$(mktemp -d)"
+  if ! git archive "$BASELINE_REF" -- lib | tar -x -C "$BASELINE_TMP"; then
+    echo "ERROR: unable to read baseline ref: $BASELINE_REF" >&2
+    exit 2
+  fi
+
+  baseline_source="git_ref_scan"
+  baseline_ref_used="$BASELINE_REF"
+  baseline_lib_failwith="$(count_pattern "$BASELINE_TMP/lib" 'failwith')"
+  baseline_lib_list_hd="$(count_pattern "$BASELINE_TMP/lib" 'List\.hd')"
+  baseline_lib_list_tl="$(count_pattern "$BASELINE_TMP/lib" 'List\.tl')"
+  baseline_lib_option_get="$(count_pattern "$BASELINE_TMP/lib" 'Option\.get')"
+  baseline_lib_obj_magic="$(count_pattern_pcre "$BASELINE_TMP/lib" '^(?:[^"\n]*"[^"\n]*")*[^"\n]*\bObj\.magic\b')"
 }
 
 extract_json_int() {
@@ -247,18 +271,22 @@ baseline_lib_list_tl=0
 baseline_lib_option_get=0
 baseline_lib_obj_magic=0
 if [ "$FAIL_ON_LIB_REGRESSION" -eq 1 ]; then
-  load_baseline_content
-  baseline_content="$BASELINE_CONTENT"
-  if [ -z "$baseline_content" ]; then
-    echo "ERROR: baseline file not found: $BASELINE_FILE" >&2
-    exit 2
-  fi
+  if [ -n "$BASELINE_REF" ]; then
+    load_baseline_ref_counts
+  else
+    load_baseline_content
+    baseline_content="$BASELINE_CONTENT"
+    if [ -z "$baseline_content" ]; then
+      echo "ERROR: baseline file not found: $BASELINE_FILE" >&2
+      exit 2
+    fi
 
-  baseline_lib_failwith="$(extract_baseline_value "$baseline_content" "lib_failwith")"
-  baseline_lib_list_hd="$(extract_baseline_value "$baseline_content" "lib_list_hd")"
-  baseline_lib_list_tl="$(extract_baseline_value "$baseline_content" "lib_list_tl")"
-  baseline_lib_option_get="$(extract_baseline_value "$baseline_content" "lib_option_get")"
-  baseline_lib_obj_magic="$(extract_baseline_value "$baseline_content" "lib_obj_magic")"
+    baseline_lib_failwith="$(extract_baseline_value "$baseline_content" "lib_failwith")"
+    baseline_lib_list_hd="$(extract_baseline_value "$baseline_content" "lib_list_hd")"
+    baseline_lib_list_tl="$(extract_baseline_value "$baseline_content" "lib_list_tl")"
+    baseline_lib_option_get="$(extract_baseline_value "$baseline_content" "lib_option_get")"
+    baseline_lib_obj_magic="$(extract_baseline_value "$baseline_content" "lib_obj_magic")"
+  fi
 
   [ "$lib_failwith" -gt "$baseline_lib_failwith" ] && regressions+=("lib_failwith ${baseline_lib_failwith}->${lib_failwith}")
   [ "$lib_list_hd" -gt "$baseline_lib_list_hd" ] && regressions+=("lib_list_hd ${baseline_lib_list_hd}->${lib_list_hd}")
@@ -277,7 +305,9 @@ if [ "$FAIL_ON_LIB_REGRESSION" -eq 1 ]; then
 fi
 
 baseline_label="disabled"
-if [ "$baseline_source" = "git_ref" ]; then
+if [ "$baseline_source" = "git_ref_scan" ]; then
+  baseline_label="ref-scan:${baseline_ref_used}:lib"
+elif [ "$baseline_source" = "git_ref" ]; then
   baseline_label="ref:${baseline_ref_used}:${baseline_file_used}"
 elif [ "$baseline_source" = "file" ]; then
   baseline_label="file:${baseline_file_used}"


### PR DESCRIPTION
## Summary
- compare Health unsafe-pattern ratchets against the actual baseline ref tree instead of stale fallback JSON
- fetch PR base or push-before SHA for Health ratchet baselines
- refresh fallback health-baseline counts to current main for manual and no-baseline runs

## Why
Main CI run 25207078935 failed Health because push CI had no baseline ref and compared current main against stale .ci/health-baseline.json values such as lib_list_hd 0, while current main already has 4 pre-existing occurrences. That makes Health consume queue and fail after merge without pointing at a real new regression.

## Validation
- bash -n scripts/health_snapshot.sh scripts/ml_line_cap_audit.sh
- YAML parse for .github/workflows/ci.yml
- python3 -m json.tool .ci/health-baseline.json
- bash scripts/health_snapshot.sh --skip-build --json-out /tmp/masc-health-baseline-ref.json --baseline-ref HEAD^ --fail-on-lib-regression
- bash scripts/health_snapshot.sh --skip-build --json-out /tmp/masc-health-baseline-file.json --baseline-file .ci/health-baseline.json --fail-on-lib-regression
- git diff --check