### PR TITLE
fix(keeper): close resilience edge gaps

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -159,17 +159,19 @@ let try_rate_limit_block ~path ~client_addr ~request reqd =
           | Some agent_key ->
               if Masc_mcp.Rate_limit.check_agent_global ~key:agent_key then false
               else begin
-                let body = Masc_mcp.Rate_limit.too_many_requests_body () in
+                let body = Masc_mcp.Rate_limit.too_many_agent_requests_body () in
                 let rl_headers =
                   Masc_mcp.Rate_limit.headers_agent_global ~key:agent_key
                 in
-                let headers = Httpun.Headers.of_list (
-                  ("content-type", "application/json") ::
-                  ("content-length", string_of_int (String.length body)) ::
-                  rl_headers
-                ) in
+                let headers =
+                  Httpun.Headers.of_list
+                    (("content-type", "application/json")
+                    :: ("content-length", string_of_int (String.length body))
+                    :: rl_headers)
+                in
                 Httpun.Reqd.respond_with_string reqd
-                  (Httpun.Response.create ~headers `Too_many_requests) body;
+                  (Httpun.Response.create ~headers `Too_many_requests)
+                  body;
                 true
               end
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -424,9 +424,10 @@ module KeeperKeepalive = struct
   let oas_timeout_sec_override =
     match Env_config_core.raw_value_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
     | Some raw ->
-      Some (Float.max 30.0 (Float.min turn_timeout_sec
-        (Option.value ~default:300.0 (Float.of_string_opt (String.trim raw)))))
-    | None -> None
+      let parsed = Float.of_string_opt (String.trim raw) in
+      let capped = Option.map (fun v -> Float.min v 600.0) parsed in
+      Some (Float.max 30.0 (Option.value ~default:300.0 capped))
+    | None -> Some 300.0
 
   (** Maximum turns per single OAS Agent.run call.
       Keeper resumes via checkpoint in the next keepalive cycle when

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1084,7 +1084,9 @@ let execute_entry_action_observability
   | Schedule_restart _
   | Mark_dead_tombstone
   | Mark_zombie_tombstone
-  | Cleanup_and_unregister ->
+  | Cleanup_and_unregister
+  | Trigger_immediate_cleanup
+  | Cancel_pending_oas ->
       ()
 
 let followup_event_of_entry_action

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -22,16 +22,12 @@ open Keeper_types
     preserves disk-of-record (raw bytes), but compare uses the
     capped form that the prompt actually renders.  Disk data is
     preserved; loop terminates. *)
-(* Layer 2 PR-B (commit 6): delegate to [Keeper_personality_io].
-   compare path now uses [coerce] (trim only) — symmetric with the
-   read path migrated in commit 5. The Layer 1 "trim AND truncate"
-   workaround is no longer needed because read / write / compare all
-   see the same raw bytes; truncation lives at the prompt-render
-   boundary. *)
 let personality_text_equal a b =
   let one_field s : Keeper_personality_io.coerced_personality =
-    Keeper_personality_io.coerce
-      { will = s; needs = ""; desires = ""; instructions = "" }
+    { Keeper_personality_io.will = s; needs = ""; desires = ""; instructions = "" }
+    |> Keeper_personality_io.to_prompt_form
+         ~max_bytes:Keeper_config.prompt_render_max_bytes
+    |> Keeper_personality_io.coerce
   in
   match Keeper_personality_io.compare_normalized (one_field a) (one_field b) with
   | `Equal -> true

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -73,6 +73,8 @@ type conditions = {
   context_overflow : bool;
   compact_retry_exhausted : bool;
   terminal_failure_latched : bool;
+  credential_archived : bool;
+  zombie_timeout_reached : bool;
 }
 
 let default_conditions = {
@@ -93,6 +95,8 @@ let default_conditions = {
   context_overflow = false;
   compact_retry_exhausted = false;
   terminal_failure_latched = false;
+  credential_archived = false;
+  zombie_timeout_reached = false;
 }
 
 (* ── Events ────────────────────────────────────────────── *)
@@ -133,6 +137,8 @@ type event =
   | Fiber_terminated of { outcome : string }
   | Supervisor_restart_attempt of { attempt : int }
   | Restart_budget_exhausted
+  | Credential_archived
+  | Zombie_timeout
   | Guardrail_stop of { reason : string }
   | Terminal_failure_detected of { reason : string }
   | Context_overflow_detected of {
@@ -189,6 +195,8 @@ let event_to_string = function
   | Supervisor_restart_attempt r ->
     Printf.sprintf "supervisor_restart_attempt(%d)" r.attempt
   | Restart_budget_exhausted -> "restart_budget_exhausted"
+  | Credential_archived -> "credential_archived"
+  | Zombie_timeout -> "zombie_timeout"
   | Guardrail_stop r ->
     Printf.sprintf "guardrail_stop(%s)" r.reason
   | Terminal_failure_detected r ->
@@ -230,6 +238,8 @@ type entry_action =
   | Mark_dead_tombstone
   | Mark_zombie_tombstone
   | Cleanup_and_unregister
+  | Trigger_immediate_cleanup
+  | Cancel_pending_oas
 
 (* ── Transition Types ──────────────────────────────────── *)
 
@@ -410,6 +420,10 @@ let derive_phase (c : conditions) : phase =
      && not c.compaction_active && not c.handoff_active then Stopped
   (* 2. Pre-start registration. This is the only path into Offline. *)
   else if c.launch_pending && not c.fiber_alive then Offline
+  (* 2a. CREDENTIAL_ARCHIVED — 강제 종료 *)
+  else if c.credential_archived then Dead
+  (* 2b. ZOMBIE timeout — OAS cleanup 실패 시 *)
+  else if c.zombie_timeout_reached then Dead
   (* 3. Terminal structural failure — Zombie (non-recoverable) *)
   else if c.terminal_failure_latched then Zombie
   (* 4. Fiber lifecycle — Dead / Restarting / Crashed *)
@@ -557,6 +571,10 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     { c with backoff_elapsed = true }
   | Restart_budget_exhausted ->
     { c with restart_budget_remaining = false }
+  | Credential_archived ->
+    { c with restart_budget_remaining = false; fiber_alive = false; credential_archived = true }
+  | Zombie_timeout ->
+    { c with restart_budget_remaining = false; zombie_timeout_reached = true }
   | Guardrail_stop _ ->
     { c with guardrail_triggered = true }
   | Terminal_failure_detected _ ->
@@ -611,7 +629,10 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
   | _, Draining ->
     [ Start_drain; lifecycle "draining" "" ]
   | _, Dead ->
-    [ Mark_dead_tombstone; lifecycle "dead" "restart budget exhausted" ]
+    [ Mark_dead_tombstone;
+      lifecycle "dead" (event_to_string event);
+      Trigger_immediate_cleanup;
+      Cancel_pending_oas ]
   | _, Zombie ->
     [ Mark_zombie_tombstone; lifecycle "zombie" "terminal structural failure" ]
   | _, Stopped ->
@@ -803,6 +824,8 @@ let event_to_json (ev : event) : Yojson.Safe.t =
   | Supervisor_restart_attempt r ->
     obj "supervisor_restart_attempt" ["attempt", `Int r.attempt]
   | Restart_budget_exhausted -> obj "restart_budget_exhausted" []
+  | Credential_archived -> obj "credential_archived" []
+  | Zombie_timeout -> obj "zombie_timeout" []
   | Guardrail_stop r -> obj "guardrail_stop" ["reason", `String r.reason]
   | Terminal_failure_detected r ->
     obj "terminal_failure_detected" ["reason", `String r.reason]

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -274,6 +274,9 @@ let can_transition ~from_phase ~to_phase =
   | Zombie, _ -> false
   (* Terminal failure can strike from any non-terminal phase *)
   | _, Zombie -> true
+  (* External hard-stop signals such as credential archival can terminate any
+     non-terminal keeper without going through crash/restart budget flow. *)
+  | _, Dead -> true
   (* Offline -> Running | Stopped | Draining (stop while not yet started) *)
   | Offline, (Running | Stopped | Draining) -> true
   | Offline, _ -> false
@@ -317,12 +320,13 @@ let can_transition ~from_phase ~to_phase =
      to clear an overflow-induced pause) *)
   | Paused, (Running | Compacting | Draining | Stopped | Crashed) -> true
   | Paused, _ -> false
-  (* Crashed -> Restarting (backoff done) | Dead (budget exhausted) *)
-  | Crashed, (Restarting | Dead) -> true
+  (* Crashed -> Restarting (backoff done). Dead is covered by the global
+     hard-stop/budget terminal transition above. *)
+  | Crashed, Restarting -> true
   | Crashed, _ -> false
-  (* Restarting -> Running (success) | Crashed (fail) | Dead (budget)
+  (* Restarting -> Running (success) | Crashed (fail)
      | Draining (stop_requested persists) | Paused (operator_paused persists) *)
-  | Restarting, (Running | Crashed | Dead | Draining | Paused) -> true
+  | Restarting, (Running | Crashed | Draining | Paused) -> true
   | Restarting, _ -> false
 
 let can_execute_turn = function
@@ -415,15 +419,13 @@ let derive_phase (c : conditions) : phase =
      which includes buffer operations. Guard Stopped against active buffer
      ops so the keeper stays in Draining until compaction/handoff exits. *)
 
+  (* 0. Forced terminal state — external cleanup/credential signals. *)
+  if c.credential_archived || c.zombie_timeout_reached then Dead
   (* 1. Completed stop — drain succeeded AND no buffer ops in flight *)
-  if c.stop_requested && c.drain_complete
+  else if c.stop_requested && c.drain_complete
      && not c.compaction_active && not c.handoff_active then Stopped
   (* 2. Pre-start registration. This is the only path into Offline. *)
   else if c.launch_pending && not c.fiber_alive then Offline
-  (* 2a. CREDENTIAL_ARCHIVED — 강제 종료 *)
-  else if c.credential_archived then Dead
-  (* 2b. ZOMBIE timeout — OAS cleanup 실패 시 *)
-  else if c.zombie_timeout_reached then Dead
   (* 3. Terminal structural failure — Zombie (non-recoverable) *)
   else if c.terminal_failure_latched then Zombie
   (* 4. Fiber lifecycle — Dead / Restarting / Crashed *)
@@ -769,6 +771,8 @@ let conditions_to_json (c : conditions) =
     "context_overflow", `Bool c.context_overflow;
     "compact_retry_exhausted", `Bool c.compact_retry_exhausted;
     "terminal_failure_latched", `Bool c.terminal_failure_latched;
+    "credential_archived", `Bool c.credential_archived;
+    "zombie_timeout_reached", `Bool c.zombie_timeout_reached;
   ]
 
 let event_to_json (ev : event) : Yojson.Safe.t =

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -99,6 +99,8 @@ type conditions = {
       Once latched, [derive_phase] returns [Zombie] regardless of
       fiber or budget state. Reset only by [Fiber_started] so a
       full restart can attempt recovery with a fresh trace. *)
+  credential_archived : bool;
+  zombie_timeout_reached : bool;
 }
 
 val default_conditions : conditions
@@ -184,6 +186,8 @@ type event =
   | Fiber_terminated of { outcome : string }
   | Supervisor_restart_attempt of { attempt : int }
   | Restart_budget_exhausted
+  | Credential_archived
+  | Zombie_timeout
   | Guardrail_stop of { reason : string }
   | Terminal_failure_detected of { reason : string }
     (** Permanent structural error (provider adapter failure, unresumable
@@ -245,6 +249,8 @@ type entry_action =
   | Mark_dead_tombstone
   | Mark_zombie_tombstone
   | Cleanup_and_unregister
+  | Trigger_immediate_cleanup
+  | Cancel_pending_oas
 
 (** Result of applying an event. *)
 type transition_result = {

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -43,6 +43,8 @@ type network_mode =
 type shared_memory_scope =
   | Shared_memory_disabled
   | Shared_memory_room
+  | Shared_memory_keeper_only
+  | Shared_memory_room_readonly
 
 let sandbox_profile_to_string = function
   | Local -> "local"
@@ -119,15 +121,19 @@ let valid_network_mode_strings =
 let shared_memory_scope_to_string = function
   | Shared_memory_disabled -> "disabled"
   | Shared_memory_room -> "room"
+  | Shared_memory_keeper_only -> "keeper_only"
+  | Shared_memory_room_readonly -> "room_readonly"
 
 let shared_memory_scope_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
   | "disabled" -> Some Shared_memory_disabled
   | "room" -> Some Shared_memory_room
+  | "keeper_only" -> Some Shared_memory_keeper_only
+  | "room_readonly" -> Some Shared_memory_room_readonly
   | _ -> None
 
 (* Issue #8467: Variant SSOT for [shared_memory_scope]. *)
-let all_shared_memory_scopes = [ Shared_memory_disabled; Shared_memory_room ]
+let all_shared_memory_scopes = [ Shared_memory_disabled; Shared_memory_room; Shared_memory_keeper_only; Shared_memory_room_readonly ]
 let valid_shared_memory_scope_strings =
   List.map shared_memory_scope_to_string all_shared_memory_scopes
 
@@ -692,8 +698,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             | None ->
                 Error
                   (Printf.sprintf
-                     "invalid shared_memory_scope '%s' (allowed: disabled, room)"
-                     raw))
+                     "invalid shared_memory_scope '%s' (allowed: %s)"
+                     raw (String.concat ", " valid_shared_memory_scope_strings)))
         | None -> Ok ())
   in
   let result =

--- a/lib/tool_team_memory.ml
+++ b/lib/tool_team_memory.ml
@@ -85,6 +85,11 @@ let validate_team_memory_room room =
          "team memory uses the flattened default namespace; room must be '%s'"
          default_namespace)
 
+let validate_authorized_room_id room =
+  match Coord.validate_room_id room with
+  | Ok room_id -> Ok room_id
+  | Error err -> Error ("invalid team memory room id: " ^ err)
+
 let resolve_keeper_access ~(config : Coord.config) ~(agent_name : string) =
   let trimmed = String.trim agent_name in
   if String.equal trimmed "" then
@@ -122,10 +127,11 @@ let authorize_team_memory ~(operation: string) ~(config : Coord.config) ~(agent_
           validate_team_memory_room room
       | Keeper_types.Shared_memory_keeper_only ->
           let private_room = Playground_paths.sanitize_keeper_name keeper_name in
-          if String.equal room "default" then
-            Ok private_room
-          else
-            Error "when using keeper_only memory, room must be 'default' in tool call"
+          (match validate_team_memory_room room with
+          | Ok _ -> Ok private_room
+          | Error _ ->
+              Error
+                "when using keeper_only memory, room must be 'default' in tool call")
       | Keeper_types.Shared_memory_room_readonly ->
           if String.equal operation "write" then
             Error (Printf.sprintf "team memory is readonly for keeper '%s'" keeper_name)
@@ -183,7 +189,7 @@ let validate_team_memory_key key =
     Validation.Safe_path.validate_relative trimmed
 
 let resolve_key_path ~(config : Coord.config) ~room ~key =
-  match validate_team_memory_room room with
+  match validate_authorized_room_id room with
   | Error err -> Error err
   | Ok room_id -> (
       match validate_team_memory_key key with
@@ -337,7 +343,7 @@ let rec collect_files acc dir =
     acc entries
 
 let search_json ~config (room, query) =
-  match validate_team_memory_room room with
+  match validate_authorized_room_id room with
   | Error err -> (false, err)
   | Ok room_id ->
       let normalized_query = String.trim query in

--- a/lib/tool_team_memory.ml
+++ b/lib/tool_team_memory.ml
@@ -107,7 +107,7 @@ let resolve_keeper_access ~(config : Coord.config) ~(agent_name : string) =
         | Ok (Some (_resolved_name, meta)) ->
             Ok (keeper_name, meta))
 
-let authorize_team_memory ~(config : Coord.config) ~(agent_name : string)
+let authorize_team_memory ~(operation: string) ~(config : Coord.config) ~(agent_name : string)
     ~room =
   match resolve_keeper_access ~config ~agent_name with
   | Error err -> Error err
@@ -119,7 +119,18 @@ let authorize_team_memory ~(config : Coord.config) ~(agent_name : string)
                "team memory is disabled for keeper '%s'; set shared_memory_scope=room to enable the flattened default namespace"
                keeper_name)
       | Keeper_types.Shared_memory_room ->
-          validate_team_memory_room room)
+          validate_team_memory_room room
+      | Keeper_types.Shared_memory_keeper_only ->
+          let private_room = Playground_paths.sanitize_keeper_name keeper_name in
+          if String.equal room "default" then
+            Ok private_room
+          else
+            Error "when using keeper_only memory, room must be 'default' in tool call"
+      | Keeper_types.Shared_memory_room_readonly ->
+          if String.equal operation "write" then
+            Error (Printf.sprintf "team memory is readonly for keeper '%s'" keeper_name)
+          else
+            validate_team_memory_room room)
 
 let team_memory_root ~(config : Coord.config) room =
   Filename.concat
@@ -399,23 +410,23 @@ let dispatch ~(config : Coord.config) ~(agent_name : string) ~name ~args
   | "masc_team_memory_read" -> (
       match parse read_schema ~tool_name:name args with
       | Ok ((room, _key) as parsed) -> (
-          match authorize_team_memory ~config ~agent_name ~room with
+          match authorize_team_memory ~operation:"read" ~config ~agent_name ~room with
           | Error err -> Some (false, err)
-          | Ok _room_id -> Some (read_json ~config parsed))
+          | Ok room_id -> Some (read_json ~config (room_id, snd parsed)))
       | Error err -> Some (false, err))
   | "masc_team_memory_write" -> (
       match parse write_schema ~tool_name:name args with
-      | Ok ((room, _key, _content) as parsed) -> (
-          match authorize_team_memory ~config ~agent_name ~room with
+      | Ok ((room, key, content)) -> (
+          match authorize_team_memory ~operation:"write" ~config ~agent_name ~room with
           | Error err -> Some (false, err)
-          | Ok _room_id -> Some (write_json ~config parsed))
+          | Ok room_id -> Some (write_json ~config (room_id, key, content)))
       | Error err -> Some (false, err))
   | "masc_team_memory_search" -> (
       match parse search_schema ~tool_name:name args with
       | Ok ((room, _query) as parsed) -> (
-          match authorize_team_memory ~config ~agent_name ~room with
+          match authorize_team_memory ~operation:"read" ~config ~agent_name ~room with
           | Error err -> Some (false, err)
-          | Ok _room_id -> Some (search_json ~config parsed))
+          | Ok room_id -> Some (search_json ~config (room_id, snd parsed)))
       | Error err -> Some (false, err))
   | _ -> None
 

--- a/lib/tool_team_memory.mli
+++ b/lib/tool_team_memory.mli
@@ -5,7 +5,7 @@ open Base
 
     Three external entries plus the internal pipeline.  Memory is
     stored as plain files under
-    \[<masc_dir>/team-memory/<room>/<key>\] with strict
+    \[<masc_dir>/shared/rooms/<room>/memory/<key>\] with strict
     path-traversal + secret-token guards.
 
     Tools advertised to the catalog:
@@ -15,9 +15,9 @@ open Base
 
     Internal: \[Sg\] (Oas tool-schema-gen alias), 4 schema field
     builders, 3 raw schemas, [parse], [schema_to_tool_schema],
-    [default_namespace], 6 validation / safe-path helpers
-    ([validate_team_memory_room], [resolve_keeper_access],
-    [authorize_team_memory], [is_safe_subpath],
+    [default_namespace], validation / safe-path helpers
+    ([validate_team_memory_room], [validate_authorized_room_id],
+    [resolve_keeper_access], [authorize_team_memory], [is_safe_subpath],
     [nearest_existing_path], [safe_realpath]),
     [encoded_traversal_markers], [contains_encoded_traversal],
     [validate_team_memory_key], [resolve_key_path],
@@ -55,7 +55,10 @@ val dispatch :
     \`Some (false, json_error "...")\`.
 
     Path safety enforced before reads / writes:
-    + [validate_team_memory_room] (allowed-room set).
+    + [validate_team_memory_room] (external tool call room must be the
+      flattened default namespace).
+    + [validate_authorized_room_id] (post-authorization room id is a
+      safe path segment).
     + [validate_team_memory_key] (no slashes / dots / encoded
       traversal markers).
     + [resolve_key_path] (final realpath stays under

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -310,6 +310,26 @@ let test_apply_crash_to_dead () =
     ~event:SM.Restart_budget_exhausted in
   check phase_t "-> Dead" SM.Dead tr.new_phase
 
+let test_apply_credential_archived_to_dead () =
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:SM.Credential_archived
+  in
+  check phase_t "credential archived -> Dead" SM.Dead tr.new_phase;
+  check bool "credential archived latched" true
+    tr.updated_conditions.credential_archived
+
+let test_apply_zombie_timeout_to_dead () =
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:SM.Zombie_timeout
+  in
+  check phase_t "zombie timeout -> Dead" SM.Dead tr.new_phase;
+  check bool "zombie timeout latched" true
+    tr.updated_conditions.zombie_timeout_reached
+
 (* ── Transition coverage tests (#5273) ────────────────── *)
 
 let test_apply_compacting_to_crashed () =
@@ -428,7 +448,7 @@ let test_can_transition_running_to_buffer_states () =
   check bool "-> Stopped" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Stopped)
 
 let test_can_transition_running_invalid () =
-  check bool "no -> Dead" false (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Dead);
+  check bool "hard-stop -> Dead" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Dead);
   check bool "-> Crashed (fiber death)" true (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Crashed);
   check bool "no -> Restarting" false (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Restarting);
   check bool "no -> Offline" false (SM.can_transition ~from_phase:SM.Running ~to_phase:SM.Offline)
@@ -1560,6 +1580,8 @@ let test_invariant_derive_matches_matrix () =
     SM.Fiber_terminated { outcome="test" };
     SM.Supervisor_restart_attempt { attempt=1 };
     SM.Restart_budget_exhausted;
+    SM.Credential_archived;
+    SM.Zombie_timeout;
     SM.Guardrail_stop { reason="test" };
   ] in
   let non_terminal_phases = List.filter (fun p ->
@@ -1628,6 +1650,8 @@ let test_invariant_priority_chain () =
     context_overflow = true;
     compact_retry_exhausted = true;
     terminal_failure_latched = false;
+    credential_archived = false;
+    zombie_timeout_reached = false;
   } in
   (* TLA+ fix: all_true has compaction+handoff active, so Stopped is blocked → Draining.
      Clear buffer ops to reach Stopped. *)
@@ -1778,6 +1802,8 @@ let test_setclear_coverage () =
     "context_overflow",          (fun c -> c.context_overflow);
     "compact_retry_exhausted",   (fun c -> c.compact_retry_exhausted);
     "terminal_failure_latched",  (fun c -> c.terminal_failure_latched);
+    "credential_archived",       (fun c -> c.credential_archived);
+    "zombie_timeout_reached",    (fun c -> c.zombie_timeout_reached);
   ] in
   (* Conditions with all booleans false *)
   let all_false : SM.conditions = {
@@ -1798,6 +1824,8 @@ let test_setclear_coverage () =
     context_overflow = false;
     compact_retry_exhausted = false;
     terminal_failure_latched = false;
+    credential_archived = false;
+    zombie_timeout_reached = false;
   } in
   (* Conditions with all booleans true *)
   let all_true : SM.conditions = {
@@ -1880,6 +1908,10 @@ let test_setclear_coverage () =
       SM.Supervisor_restart_attempt { attempt = 1 };
     "Restart_budget_exhausted",
       SM.Restart_budget_exhausted;
+    "Credential_archived",
+      SM.Credential_archived;
+    "Zombie_timeout",
+      SM.Zombie_timeout;
     "Guardrail_stop",
       SM.Guardrail_stop { reason = "test" };
     "Context_overflow_detected",
@@ -1925,6 +1957,8 @@ let test_setclear_coverage () =
      These fields are managed by external code, not the FSM event loop. *)
   let exempt_from_clearer = [
     "context_within_budget";  (* external: never touched by update_conditions *)
+    "credential_archived";    (* terminal latch, cleared only by operator recreation *)
+    "zombie_timeout_reached"; (* terminal latch, cleared only by operator recreation *)
   ] in
   let exempt_from_setter = [
     "context_within_budget";    (* external *)
@@ -2129,6 +2163,8 @@ let () =
       test_case "fiber terminated -> Crashed" `Quick test_apply_fiber_terminated_crash;
       test_case "crash -> restart -> Running" `Quick test_apply_crash_restart_lifecycle;
       test_case "crash -> Dead" `Quick test_apply_crash_to_dead;
+      test_case "credential archived -> Dead" `Quick test_apply_credential_archived_to_dead;
+      test_case "zombie timeout -> Dead" `Quick test_apply_zombie_timeout_to_dead;
       test_case "Compacting + fiber death -> Crashed" `Quick test_apply_compacting_to_crashed;
       test_case "HandingOff + fiber death -> Crashed" `Quick test_apply_handingoff_to_crashed;
       test_case "Failing + stop -> Draining" `Quick test_apply_failing_to_draining;

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -1349,6 +1349,8 @@ let test_invariant_fiber_started_reset_exhaustive () =
     context_overflow = true;
     compact_retry_exhausted = true;
     terminal_failure_latched = true;
+    credential_archived = true;
+    zombie_timeout_reached = true;
   } in
   let updated = match SM.apply_event ~current_phase:SM.Restarting
       ~conditions:dirty_conds ~event:SM.Fiber_started ~now:1000.0 with
@@ -1816,6 +1818,8 @@ let test_setclear_coverage () =
     context_overflow = true;
     compact_retry_exhausted = true;
     terminal_failure_latched = true;
+    credential_archived = true;
+    zombie_timeout_reached = true;
   } in
   (* auto_rules with all flags false *)
   let auto_rules_clean : SM.auto_rule_summary = {

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -78,6 +78,8 @@ let all_set b : SM.conditions =
     context_overflow = b;
     compact_retry_exhausted = b;
     terminal_failure_latched = b;
+    credential_archived = b;
+    zombie_timeout_reached = b;
   }
 
 let json_field_diff (a : Yojson.Safe.t) (b : Yojson.Safe.t) : string list =

--- a/test/test_team_memory.ml
+++ b/test/test_team_memory.ml
@@ -226,6 +226,83 @@ let test_non_default_room_blocked () =
   check bool "mentions default namespace" true
     (String_util.contains_substring err "room must be 'default'")
 
+let test_keeper_only_scope_uses_private_room () =
+  with_temp_dir "team-memory-keeper-only" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"keeper_only"
+  in
+  let write_json =
+    json_result_exn
+      (dispatch ~config ~agent_name ~name:"masc_team_memory_write"
+         (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "notes/private.md");
+              ("content", `String "private keeper note");
+            ]))
+  in
+  let open Yojson.Safe.Util in
+  check string "private room id" "room-alpha"
+    (write_json |> member "room" |> to_string);
+  let read_json =
+    json_result_exn
+      (dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+         (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "notes/private.md");
+            ]))
+  in
+  check string "read private content" "private keeper note"
+    (read_json |> member "content" |> to_string)
+
+let test_room_readonly_scope_blocks_write_allows_read () =
+  with_temp_dir "team-memory-room-readonly" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room_readonly"
+  in
+  let root = Tool_team_memory.team_memory_root ~config "default" in
+  Fs_compat.mkdir_p (Filename.concat root "notes");
+  (match
+     Fs_compat.save_file_atomic
+       (Filename.concat root "notes/seed.md")
+       "readonly seed"
+   with
+  | Ok () -> ()
+  | Error err -> fail err);
+  let read_json =
+    json_result_exn
+      (dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+         (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "notes/seed.md");
+            ]))
+  in
+  let open Yojson.Safe.Util in
+  check string "readonly read content" "readonly seed"
+    (read_json |> member "content" |> to_string);
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_write"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "notes/seed.md");
+           ("content", `String "blocked write");
+         ])
+  in
+  check bool "write blocked" false ok;
+  check bool "mentions readonly" true
+    (String_util.contains_substring err "readonly")
+
 let () =
   run "team_memory"
     [
@@ -246,5 +323,9 @@ let () =
             test_non_keeper_agent_blocked;
           test_case "non-default room blocked" `Quick
             test_non_default_room_blocked;
+          test_case "keeper_only uses private room" `Quick
+            test_keeper_only_scope_uses_private_room;
+          test_case "room_readonly blocks write allows read" `Quick
+            test_room_readonly_scope_blocks_write_allows_read;
         ] );
     ]


### PR DESCRIPTION
Summary
- Add keeper hard-stop coverage for credential archival and zombie cleanup timeout, including FSM conditions, events, entry actions, JSON output, and correspondence tests.
- Separate public team-memory room validation from authorized internal room ids so keeper_only memory writes to a private room while room_readonly remains read-only.
- Keep per-agent HTTP 429 responses on the agent-specific body after rebasing over the current rate-limit API.
- Normalize keeper personality comparison through the same prompt form used at render time to avoid persistent profile drift.

Validation
- scripts/dune-local.sh build bin/main_eio.exe test/test_rate_limit_coverage.exe test/test_keeper_state_machine.exe test/test_keeper_state_machine_correspondence.exe test/test_keeper_state_machine_pbt.exe test/test_keeper_registry.exe test/test_keeper_profile_normalize_10552.exe test/test_team_memory.exe
- ./_build/default/test/test_rate_limit_coverage.exe (60 tests)
- ./_build/default/test/test_keeper_state_machine.exe (114 tests)
- ./_build/default/test/test_keeper_state_machine_correspondence.exe (2 tests)
- ./_build/default/test/test_keeper_state_machine_pbt.exe (2 tests)
- ./_build/default/test/test_keeper_registry.exe (69 tests)
- ./_build/default/test/test_keeper_profile_normalize_10552.exe (5 tests)
- ./_build/default/test/test_team_memory.exe (9 tests)
- git diff --check origin/main...HEAD