### PR TITLE
fix: remove chronicle ingest List.hd usage

### DIFF
--- a/lib/chronicle_ingest.ml
+++ b/lib/chronicle_ingest.ml
@@ -234,7 +234,12 @@ let make_candidate commits =
   match commits with
   | [] -> assert false
   | first :: _ ->
-    let last = List.hd (List.rev commits) in
+    let rec last_event = function
+      | [] -> None
+      | [ ev ] -> Some ev
+      | _ :: rest -> last_event rest
+    in
+    let last = Option.value ~default:first (last_event commits) in
     let all_goals =
       commits
       |> List.map extract_goal_ids
@@ -299,16 +304,16 @@ let group_events ?(time_window_days = 7) events =
   let goal_groups = group_by_goal_id events in
   let ungrouped =
     goal_groups
-    |> List.filter (fun g ->
-      List.length g = 1
-      && extract_goal_ids (List.hd g) = [])
-    |> List.map List.hd
+    |> List.filter_map (function
+      | [ ev ] when extract_goal_ids ev = [] -> Some ev
+      | _ -> None)
   in
   let grouped =
     goal_groups
-    |> List.filter (fun g ->
-      List.length g > 1
-      || extract_goal_ids (List.hd g) <> [])
+    |> List.filter (function
+      | [] -> false
+      | [ ev ] -> extract_goal_ids ev <> []
+      | _ -> true)
   in
   let time_groups = group_by_time_window ungrouped ~days:time_window_days in
   let all_groups = grouped @ time_groups in


### PR DESCRIPTION
## Summary

- Remove the remaining `List.hd` usage from `lib/chronicle_ingest.ml`.
- Preserve chronicle grouping behavior with explicit pattern matching and a safe last-event helper.

## Product impact

- Promise affected: `none/internal`
- User-visible change: restores CI Health ratchet compatibility for the latest `main`; no user-facing runtime change intended.

## Evidence

- `scripts/dune-local.sh exec test/test_chronicle_ingest.exe`
- `bash scripts/health_snapshot.sh --json-out /private/tmp/health-chronicle-list-hd-origin-main.json --baseline-ref origin/main --fail-on-lib-regression`
- `git diff --check`

## Review evidence

- The failing Health job reported `Ratchet: fail (lib_list_hd 0->4)`.
- `rg "List\\.hd" -n lib` returns no matches after this change.
- `test_chronicle_ingest` passed 18/18 tests.

## Linked issue

- Closes #
- Relates #12566

## Variant addition checklist

- [ ] **OCaml** - not applicable; no variant added or removed.
- [ ] **TypeScript** - not applicable; no dashboard type change.
- [ ] **TLA+ spec** - not applicable; no TLA domain change.
- [ ] **Event / JSON schema** - not applicable; no event or schema enum change.
- [ ] **`make check-variants` passes** - not applicable; this PR does not touch variant/schema surfaces.
