### PR TITLE
ci: ignore stale CI Gate during active PR checks

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -300,6 +300,19 @@ jobs:
                 // for this startup race.
                 const ciGateStartupRaceAction =
                   action === "auto_merge_enabled" || action === "synchronize";
+                const ciWorkflowActiveCheckNames = new Set([
+                  "PR Sync Check",
+                  "Detect Changed Surfaces",
+                  "Keeper Cwd Leak Gate",
+                  "Meta Guards",
+                  "Health",
+                  "Build and Test",
+                  "Lint",
+                  "Dashboard",
+                  "OCaml Structure Ratchet",
+                  "TLA+ Model Checking",
+                  "CI Gate"
+                ]);
                 let activeHeadChecks = [];
                 if (
                   ciGateStartupRaceAction &&
@@ -314,7 +327,7 @@ jobs:
                   });
                   activeHeadChecks = (refChecks.data.check_runs || [])
                     .filter((run) => run.status !== "completed")
-                    .filter((run) => run.name !== "Draft Auto-Merge Guard")
+                    .filter((run) => ciWorkflowActiveCheckNames.has(run.name))
                     .map((run) => `${run.name}:${run.status}`);
                 }
                 const staleFailedCiGateDuringActiveRun =

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -300,13 +300,40 @@ jobs:
                 // for this startup race.
                 const ciGateStartupRaceAction =
                   action === "auto_merge_enabled" || action === "synchronize";
+                let activeHeadChecks = [];
+                if (
+                  ciGateStartupRaceAction &&
+                  latestCiGate?.status === "completed" &&
+                  latestCiGate?.conclusion === "failure"
+                ) {
+                  const refChecks = await github.rest.checks.listForRef({
+                    owner,
+                    repo,
+                    ref: pr.head.sha,
+                    per_page: 100
+                  });
+                  activeHeadChecks = (refChecks.data.check_runs || [])
+                    .filter((run) => run.status !== "completed")
+                    .filter((run) => run.name !== "Draft Auto-Merge Guard")
+                    .map((run) => `${run.name}:${run.status}`);
+                }
+                const staleFailedCiGateDuringActiveRun =
+                  ciGateStartupRaceAction &&
+                  latestCiGate?.status === "completed" &&
+                  latestCiGate?.conclusion === "failure" &&
+                  activeHeadChecks.length > 0;
                 const ciGateStartupRace =
                   ciGateStartupRaceAction &&
                   (!latestCiGate ||
                     latestCiGate.status !== "completed" ||
-                    latestCiGate.conclusion === "cancelled");
+                    latestCiGate.conclusion === "cancelled" ||
+                    staleFailedCiGateDuringActiveRun);
                 if (ciGateStartupRace) {
-                  core.info(`CI Gate is ${ciGateStatus} for head ${pr.head.sha}; skipping block on ${action} event.`);
+                  const activeSuffix =
+                    activeHeadChecks.length > 0
+                      ? `; active head checks: ${activeHeadChecks.join(", ")}`
+                      : "";
+                  core.info(`CI Gate is ${ciGateStatus} for head ${pr.head.sha}${activeSuffix}; skipping block on ${action} event.`);
                 } else {
                   policyFailures.push(`CI Gate is not completed successfully for head ${pr.head.sha}: ${ciGateStatus}`);
                   shouldDisableAutoMerge = true;


### PR DESCRIPTION
## Summary
- keep Draft Auto-Merge Guard, but stop treating a stale CI Gate failure as current while the same head still has active checks
- preserve the hard block when CI Gate is failed and no replacement checks are running
- add log context for active head checks when the startup race is skipped

## Why
While processing #12568, enabling auto-merge on the ready PR hit an old draft-run CI Gate failure for the same head and Draft Auto-Merge Guard disabled auto-merge even though the replacement CI run was active. This is the confusing failure mode behind the 'Draft Auto-Merge Guard failing after 4s' signal.

## Verification
- git diff --check origin/main...HEAD