### PR TITLE
fix(operator): surface keeper runtime trust in summaries

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -549,6 +549,27 @@ let _keeper_snapshot_max_concurrency =
 
 let _keeper_sem = Eio.Semaphore.make _keeper_snapshot_max_concurrency
 
+let compact_keeper_runtime_trust_json ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta) =
+  let runtime_trust =
+    Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+  in
+  let member key = Yojson.Safe.Util.member key runtime_trust in
+  `Assoc
+    [
+      ("disposition", member "disposition");
+      ("disposition_reason", member "disposition_reason");
+      ("operator_disposition", member "operator_disposition");
+      ("operator_disposition_reason", member "operator_disposition_reason");
+      ("needs_attention", member "needs_attention");
+      ("attention_reason", member "attention_reason");
+      ("next_human_action", member "next_human_action");
+      ("execution_summary", member "execution");
+      ("latest_terminal_reason", member "latest_terminal_reason");
+      ("latest_next_action", member "latest_next_action");
+      ("latest_causal_event", member "latest_causal_event");
+    ]
+
 let keepers_json ?keeper_names ?(include_recent_activity = false)
     ?(lightweight = false) config =
   let names = match keeper_names with
@@ -622,6 +643,16 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                      | None -> `String "paused"
                    in
                    dt_phase := Time_compat.now () -. t_ph;
+                   let runtime_trust =
+                     try compact_keeper_runtime_trust_json ~config ~meta
+                     with
+                     | Eio.Cancel.Cancelled _ as e -> raise e
+                     | exn ->
+                         Log.Dashboard.warn
+                           "operator snapshot trust compact failed for paused keeper %s: %s"
+                           meta.name (Printexc.to_string exn);
+                         `Null
+                   in
                    emit_timing_log (Time_compat.now () -. t_work_start);
                    Some
                      (`Assoc
@@ -639,7 +670,10 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                          ("updated_at", `String meta.updated_at);
                          ("created_at", `String meta.created_at);
                        ]
-                       @ keeper_runtime_identity_fields meta))
+                       @ keeper_runtime_identity_fields meta
+                       @ Keeper_status_bridge.runtime_blocker_fields_json config meta
+                       @ Keeper_status_bridge.attention_fields_json config meta
+                       @ [ ("runtime_trust", runtime_trust) ]))
                  ) else begin
                  let t_agent = Time_compat.now () in
                  let agent_json =
@@ -771,6 +805,16 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                  let context_snapshot =
                    if lightweight then fallback_keeper_context_snapshot meta
                    else keeper_context_snapshot_of_meta config meta
+                 in
+                 let runtime_trust =
+                   try compact_keeper_runtime_trust_json ~config ~meta
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                       Log.Dashboard.warn
+                         "operator snapshot trust compact failed for keeper %s: %s"
+                         meta.name (Printexc.to_string exn);
+                       `Null
                  in
                  emit_timing_log (Time_compat.now () -. t_work_start);
                  Some
@@ -961,7 +1005,9 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                           result));
                      ]
                      @ keeper_context_snapshot_fields context_snapshot
-                     @ Keeper_status_bridge.runtime_blocker_fields_json config meta))
+                     @ Keeper_status_bridge.runtime_blocker_fields_json config meta
+                     @ Keeper_status_bridge.attention_fields_json config meta
+                     @ [ ("runtime_trust", runtime_trust) ]))
                  end
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Dashboard.error "keepers_json fiber error (%s): %s"

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -33,6 +33,10 @@ let () =
             `Quick
             Test_operator_control_snapshot
             .test_snapshot_prefers_metrics_context_truth_over_usage_counters;
+          Alcotest.test_case
+            "snapshot summary surfaces paused keeper runtime trust" `Quick
+            Test_operator_control_snapshot
+            .test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust;
           Alcotest.test_case "snapshot sections" `Quick
             Test_operator_control_snapshot.test_snapshot_has_expected_sections;
           Alcotest.test_case "snapshot pending confirm summary tracks actor scope"

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -247,6 +247,140 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       Alcotest.(check bool) "nested context payload omitted" true
         (Yojson.Safe.Util.member "context" keeper = `Null))
 
+let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "paused-runtime-trust" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Expose paused keeper failure in summary");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let meta =
+        match Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "expected keeper meta"
+        | Error err -> Alcotest.fail err
+      in
+      let meta =
+        {
+          meta with
+          paused = true;
+          runtime =
+            {
+              meta.runtime with
+              last_blocker =
+                "Completion contract [require_tool_use] violated: actionable keeper signal was present, but the model called no keeper tools";
+              last_blocker_class =
+                Some Keeper_types.Completion_contract_violation;
+            };
+        }
+      in
+      (match Keeper_types.write_meta config meta with
+      | Ok () -> ()
+      | Error err -> Alcotest.fail err);
+      Dated_jsonl.append
+        (Keeper_types_support.keeper_execution_receipt_store config keeper_name)
+        (`Assoc
+          [
+            ("schema", `String "keeper.execution_receipt.v1");
+            ("keeper_name", `String keeper_name);
+            ("agent_name", `String meta.agent_name);
+            ("trace_id", `String "trace-paused-runtime-trust");
+            ("turn_count", `Int 12);
+            ("outcome", `String "error");
+            ( "terminal_reason_code",
+              `String "completion_contract_violation:require_tool_use" );
+            ("operator_disposition", `String "pause_human");
+            ( "operator_disposition_reason",
+              `String "tool_required_unsatisfied" );
+            ( "tool_contract_result",
+              `String "missing_required_tool_use" );
+            ("tools_used", `List []);
+            ( "tool_surface",
+              `Assoc
+                [
+                  ("tool_requirement", `String "required");
+                  ("required_tools", `List [ `String "keeper_bash" ]);
+                  ("missing_required_tools", `List [ `String "keeper_bash" ]);
+                  ("visible_tool_count", `Int 8);
+                ] );
+            ( "sandbox",
+              `Assoc
+                [
+                  ("kind", `String "docker");
+                  ("sandbox_root", `String base_dir);
+                  ("network_mode", `String "inherit");
+                ] );
+            ( "cascade",
+              `Assoc
+                [
+                  ("name", `String "big_three");
+                  ("selected_model", `String "kimi-for-coding");
+                  ("outcome", `String "completed");
+                ] );
+            ("error", `Assoc [ ("kind", `String "contract") ]);
+            ("ended_at", `String (Types.now_iso ()));
+          ]);
+      Operator_control.invalidate_snapshot_cache ();
+      let snapshot =
+        Operator_control.snapshot_json ~view:"summary" ~include_messages:false
+          ~include_keepers:true ~include_summary_fields:false
+          ~lightweight_summary:true
+          (operator_ctx env sw config "operator")
+      in
+      let open Yojson.Safe.Util in
+      let keeper =
+        snapshot |> member "keepers" |> member "items" |> to_list
+        |> List.find_opt (fun row -> row |> member "name" |> to_string = keeper_name)
+        |> Option.value ~default:`Null
+      in
+      Alcotest.(check bool) "keeper present" true (keeper <> `Null);
+      Alcotest.(check string) "runtime blocker class surfaced"
+        "completion_contract_violation"
+        (keeper |> member "runtime_blocker_class" |> to_string);
+      Alcotest.(check bool) "attention surfaced" true
+        (keeper |> member "needs_attention" |> to_bool);
+      let trust = keeper |> member "runtime_trust" in
+      Alcotest.(check string) "trust disposition pauses" "Pause"
+        (trust |> member "disposition" |> to_string);
+      Alcotest.(check string) "operator reason preserved"
+        "tool_required_unsatisfied"
+        (trust |> member "operator_disposition_reason" |> to_string);
+      Alcotest.(check string) "terminal code preserved"
+        "required_tool_use_unsatisfied"
+        (trust |> member "latest_terminal_reason" |> member "code"
+       |> to_string))
+
 let test_snapshot_has_expected_sections () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary
- include compact keeper runtime_trust in operator-control keeper rows
- keep paused/lightweight keeper rows from dropping runtime blocker fields such as runtime_blocker_class, runtime_blocker_summary, continue gate, and attention fields
- add regression coverage for paused tool_required_unsatisfied receipts

## Why
Paused keepers on the lightweight operator-summary path were emitted as minimal rows, so receipt-derived provider/tool-contract failures could disappear from dashboard/operator summaries even though logs showed the failure.

## Operator impact
The dashboard/operator snapshot can now surface terminal keeper failures like tool_required_unsatisfied or provider/runtime blockers as actionable attention instead of making them look idle or silent.

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_operator_control.exe
- ./_build/default/test/test_operator_control.exe test operator 7 --show-errors

## Runtime note
The local GLM plan-only keeper/profile smoke was applied under /Users/dancer/me/.masc/config and is intentionally not part of this repo diff.