### PR TITLE
fix(keeper): add fallback cascade to break correlated contract violation

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -30,6 +30,18 @@ models = [
 temperature = 0.2
 max_tokens = 16384
 keeper_assignable = true
+fallback_cascade = "keeper_diverse"
+
+[keeper_diverse]
+comment = "Fallback cascade for contract violation retry. Different model composition from big_three to break correlated failure."
+models = [
+  "claude_code:claude-sonnet-4-6",
+  "gemini_cli:gemini-2.5-flash",
+  "codex_cli:gpt-5.3-codex-spark",
+]
+temperature = 0.3
+max_tokens = 16384
+keeper_assignable = true
 
 [tool_rerank]
 comment = "System-only short-output profile for rerank/scoring calls."

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1011,7 +1011,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 end else if
                   (* Fast-fail on second consecutive contract violation: if
                      we already rotated once because the LLM only used
-                     passive/read-only tools, rotating to a weaker cascade
+                     passive/read-only tools, rotating to the same cascade
                      is unlikely to change the LLM's choice on the same
                      prompt.  Each rotation eats ~600s of turn budget, and
                      in production we observe 4–5 rotations all hitting
@@ -1021,9 +1021,25 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      keeper_unified → kimi_cli_keeper → … →
                      oas_timeout_budget at 1064s/1200s).  Cap rotation
                      at 1 for this error class so the keeper releases
-                     its turn budget for actionable work. *)
+                     its turn budget for actionable work.
+
+                     Exception: if the current cascade declares a
+                     fallback_cascade that has not been attempted yet,
+                     allow one more rotation to try it — the fallback
+                     has a different model composition and may not
+                     exhibit the same passive-tool behavior. *)
+                  let fallback_not_yet_tried =
+                    match
+                      KCP.fallback_cascade_for execution_cascade_name
+                    with
+                    | Some fb ->
+                        not (List.exists (String.equal fb) attempted_cascades)
+                        && not (String.equal fb execution_cascade_name)
+                    | None -> false
+                  in
                   EC.is_required_tool_contract_violation err
                   && List.length attempted_cascades >= 1
+                  && not fallback_not_yet_tried
                 then begin
                   Log.Keeper.warn
                     "%s: required_tool_contract_violation on second cascade \


### PR DESCRIPTION
## Summary

- Add `keeper_diverse` cascade profile with different model composition (claude-sonnet-4-6, gemini-2.5-flash, gpt-5.3-codex-spark) and higher temperature (0.3) as fallback for contract violation retry
- Wire `fallback_cascade = "keeper_diverse"` on `big_three` profile in `cascade.toml`
- Add `fallback_not_yet_tried` guard to rotation cap in `keeper_unified_turn.ml` — allows one more rotation to try the fallback cascade before capping

## Root Cause

Keeper fleet batch termination chain:

```
Model fails require_tool_use contract (0 tool calls despite has_unclaimed_tasks)
  → cascade_exhausted → heartbeat stops → 300s idle → watchdog Idle_turn kill → FLEET BATCH TERMINATION alert
```

Single `keeper_assignable=true` cascade (`big_three`) = SPOF. One model's non-compliance causes correlated failure across entire fleet.

## Production Evidence (2026-05-01)

- 22 `cascade_exhausted`, 23 `required_tool_contract_violation`, 55 stale watchdog kills, 13 fleet batch alerts
- 07:04-07:05: 6 keepers simultaneous contract violation (all cascade=big_three)

## How This Fixes It

1. **Breaks correlation**: `keeper_diverse` uses different model variants
2. **Activates existing infra**: `fallback_cascade_for`, `degraded_rotation_candidates`, `fallback_hint` priority — all built but never wired up
3. **Minimal change**: 30 lines added (12 config + 18 code)
4. **Safe degradation**: If fallback also fails, existing cap behavior is unchanged

## Files Changed

| File | Change |
|------|--------|
| `config/cascade.toml` | `keeper_diverse` profile + `fallback_cascade` on big_three |
| `lib/keeper/keeper_unified_turn.ml` | `fallback_not_yet_tried` guard at rotation cap |

## Test Plan

- [x] `dune build lib/keeper/keeper_unified_turn.ml` — compiles clean
- [ ] Deploy → observe fallback metric > 0
- [ ] `cascade_exhausted` count reduction vs baseline (22/day)
- [ ] FLEET BATCH TERMINATION alert reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
