### PR TITLE
refactor(keeper): name approval queue stale timeout

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -117,6 +117,7 @@ let validate_name name =
 let default_proactive_enabled = true
 let default_proactive_idle_sec = 120
 let default_proactive_cooldown_sec = 300
+let approval_queue_stale_max_wait_sec = 600.0
 let default_room_signal_prompt_enabled = false
 let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -55,6 +55,7 @@ val tool_first_sentence_max_chars : int
 val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
+val approval_queue_stale_max_wait_sec : float
 val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1060,9 +1060,11 @@ let run_heartbeat_loop
         let t_presence_end = Time_compat.now () in
         let now_ts = t_presence_end in
         (* IR-4 fix: expire stale approval-queue entries every heartbeat cycle.
-           max_wait_s = 600 (10 min) — Critical entries are excluded by
+           Uses [Keeper_config.approval_queue_stale_max_wait_sec] so the timeout
+           is explicit and discoverable. Critical entries are excluded by
            expire_stale itself, so only Low/Medium/High are swept. *)
-        Keeper_approval_queue.expire_stale ~max_wait_s:600.0;
+        Keeper_approval_queue.expire_stale
+          ~max_wait_s:Keeper_config.approval_queue_stale_max_wait_sec;
         let t_snapshot_start = now_ts in
         maybe_write_heartbeat_snapshot
           ~ctx


### PR DESCRIPTION
Summary
- Move the heartbeat approval-queue stale timeout from a local numeric literal to Keeper_config.approval_queue_stale_max_wait_sec.
- Keep behavior unchanged at 600 seconds while making the timeout discoverable and reusable.

Validation
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_hitl_approval.exe test/test_keeper_semaphore_wait_counter.exe was attempted but did not start because the shared /tmp/me-dune-local.lock queue was occupied by other long-running Dune jobs; no compiler/test failure observed.