### PR TITLE
fix(coord): set verification timeout deadlines

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -371,6 +371,11 @@ module Verification = struct
   let fsm_enabled () =
     Feature_flag_registry.get_bool "MASC_VERIFICATION_FSM_ENABLED"
 
+  (** Maximum time a task may remain AwaitingVerification before surfacing an
+      operator-visible timeout. Default: 24h. *)
+  let timeout_deadline_seconds () =
+    get_float ~default:(24.0 *. 60.0 *. 60.0) "MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC"
+
   (** Interval for verification timeout check fiber (seconds). Default: 60.
       Issue #7549. *)
   let timeout_check_interval_seconds =

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -185,6 +185,7 @@ end
 
 module Verification : sig
   val fsm_enabled : unit -> bool
+  val timeout_deadline_seconds : unit -> float
   val timeout_check_interval_seconds : float
 end
 

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -97,6 +97,8 @@ let transition_task_r
           match
             Coord_task_lifecycle.decide
               ~verification_enabled:(Env_config_runtime.Verification.fsm_enabled ())
+              ~verification_timeout_seconds:
+                (Env_config_runtime.Verification.timeout_deadline_seconds ())
               ~new_verification_id:(fun () -> Random_id.prefixed ~prefix:"vrf-" ~bytes:16)
               ~agent_name
               ~task_id

--- a/lib/coord/coord_task_lifecycle.ml
+++ b/lib/coord/coord_task_lifecycle.ml
@@ -27,8 +27,14 @@ let cancelled_status ~agent_name ~now ~reason =
     { cancelled_by = agent_name; cancelled_at = now; reason = option_of_non_empty reason }
 ;;
 
+let verification_deadline ~now ~timeout_seconds =
+  let submitted_at = Types.parse_iso8601 ~default_time:(Time_compat.now ()) now in
+  Some (Types.iso8601_of_unix_seconds (submitted_at +. timeout_seconds))
+;;
+
 let decide
       ~verification_enabled
+      ~verification_timeout_seconds
       ~new_verification_id
       ~agent_name
       ~task_id
@@ -106,7 +112,10 @@ let decide
               { assignee
               ; submitted_at = now
               ; verification_id = new_verification_id ()
-              ; deadline = None
+              ; deadline =
+                  verification_deadline
+                    ~now
+                    ~timeout_seconds:verification_timeout_seconds
               })
     else Error Invalid_transition
   | Types.Submit_for_verification,

--- a/lib/coord/coord_task_lifecycle.mli
+++ b/lib/coord/coord_task_lifecycle.mli
@@ -20,6 +20,7 @@ type decision =
 
 val decide
   :  verification_enabled:bool
+  -> verification_timeout_seconds:float
   -> new_verification_id:(unit -> string)
   -> agent_name:string
   -> task_id:string

--- a/lib/verification_protocol.mli
+++ b/lib/verification_protocol.mli
@@ -111,7 +111,7 @@ val notify_reject_verification :
 
 val check_timeouts : config:Coord.config -> unit
 (** [check_timeouts ~config] scans pending verifications and
-    auto-rejects any past their TTL.  No-op when
+    emits operator-visible timeout events for any past their TTL. No-op when
     [Env_config_runtime.Verification.fsm_enabled ()] is [false]
     — pinned at the contract seam so disabling the FSM does not
     silently drop the timeout sweep entirely; it just does nothing. *)

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -11,6 +11,14 @@ open Masc_mcp
 
 let rng_initialized = ref false
 
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect f ~finally:(fun () ->
+      match previous with
+      | Some raw -> Unix.putenv key raw
+      | None -> Unix.putenv key "")
+
 let with_temp_config ~fsm_enabled f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -158,6 +166,29 @@ let test_submit_for_verification_moves_to_awaiting () =
     | Ok _ ->
       Alcotest.(check string) "status" "awaiting_verification"
         (status_string config task_id))
+
+let test_submit_for_verification_sets_timeout_deadline () =
+  with_env "MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC" "86400" @@ fun () ->
+  with_temp_config ~fsm_enabled:true @@ fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    match Coord.transition_task_r config ~agent_name:"worker"
+            ~task_id ~action:Types.Submit_for_verification () with
+    | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e)
+    | Ok _ ->
+      match get_task config task_id with
+      | Some { task_status =
+                 Types.AwaitingVerification { submitted_at; deadline = Some deadline; _ };
+               _ } ->
+        let submitted_ts = Types.parse_iso8601 submitted_at in
+        let deadline_ts = Types.parse_iso8601 deadline in
+        Alcotest.(check (float 0.0)) "deadline offset"
+          86400.0
+          (deadline_ts -. submitted_ts)
+      | Some { task_status = Types.AwaitingVerification { deadline = None; _ }; _ } ->
+        Alcotest.fail "awaiting verification deadline missing"
+      | Some _ -> Alcotest.fail "task is not awaiting verification"
+      | None -> Alcotest.fail "task not found"
 
 let test_submit_for_verification_from_claimed_moves_to_awaiting () =
   with_temp_config ~fsm_enabled:true (fun config ->
@@ -596,6 +627,8 @@ let () =
     ("transitions_enabled", [
       Alcotest.test_case "submit moves to awaiting_verification" `Quick
         test_submit_for_verification_moves_to_awaiting;
+      Alcotest.test_case "submit sets timeout deadline" `Quick
+        test_submit_for_verification_sets_timeout_deadline;
       Alcotest.test_case "submit from claimed moves to awaiting_verification"
         `Quick test_submit_for_verification_from_claimed_moves_to_awaiting;
       Alcotest.test_case "submit prepare failure keeps task in_progress"


### PR DESCRIPTION
## Summary
- Set AwaitingVerification.deadline when a task enters verification.
- Use MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC with a 24h default so the existing timeout sweeper has real deadlines to inspect.
- Cover the submit_for_verification deadline offset with a regression test.

## Validation
- ./scripts/dune-local.sh exec test/test_verification_fsm.exe
- git diff --check