### PR TITLE
fix(keeper): guard sandbox root git cwd

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -188,6 +188,63 @@ let cmd_targets_gh cmd =
     let tokens = String.split_on_char ' ' trimmed in
     List.exists (fun tok -> tok = "gh") tokens
 
+let resolve_sandbox_root_git_cwd ~(config : Coord.config)
+    ~(meta : keeper_meta) ~cwd ~cmd =
+  let host_root =
+    keeper_playground_root ~config ~meta
+    |> Keeper_alerting_path.normalize_path_for_check
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let cwd_normalized =
+    Keeper_alerting_path.normalize_path_for_check cwd
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let repos_in_playground () =
+    let repos_dir = Filename.concat host_root "repos" in
+    if not (Sys.file_exists repos_dir && Sys.is_directory repos_dir) then []
+    else
+      try
+        Sys.readdir repos_dir
+        |> Array.to_list
+        |> List.filter (fun name ->
+          let p = Filename.concat repos_dir name in
+          try
+            Sys.is_directory p
+            && Sys.file_exists (Filename.concat p ".git")
+          with Sys_error _ -> false)
+        |> List.sort compare
+      with Sys_error _ -> []
+  in
+  if cwd_normalized = host_root && cmd_targets_git_or_gh cmd then
+    match repos_in_playground () with
+    | [single_repo] ->
+      (Filename.concat (Filename.concat host_root "repos") single_repo, None)
+    | [] ->
+      ( cwd,
+        Some
+          (Printf.sprintf
+             "sandbox root cannot run git/gh: mount point %s is not a git repository and no sandbox git clones exist under repos/. First clone a repo with keeper_shell op=git_clone path=\"repos/<repo>\", then retry with cwd=\"repos/<repo>\" or cwd=\"repos/<repo>/.worktrees/<task>\"."
+             host_root) )
+    | example_repo :: _ as many ->
+      (* #10680: keeper-executor-agent saw 17 events / 5min in a single
+         session (mcp_VHsjtow_92C_2a0o, 2026-04-26 08:00→08:06) where
+         the LLM read this descriptive error and still re-issued the
+         same bare git/gh in the next turn. Make the message
+         self-correcting: include the original cmd and the exact
+         next-call shape so the LLM can copy-paste rather than
+         re-derive the cwd convention from prose. *)
+      let cmd_preview =
+        let s = String.trim cmd in
+        if String.length s > 120 then String.sub s 0 117 ^ "..." else s
+      in
+      ( cwd,
+        Some
+          (Printf.sprintf
+             "sandbox root cannot run git/gh: mount point %s is not a git repository and multiple sandbox repos exist. Set cwd explicitly before retrying. Example next call: keeper_bash { \"cmd\": %S, \"cwd\": \"repos/%s\" }. Available repos: %s. Do not retry the same cmd from sandbox root."
+             host_root cmd_preview example_repo (String.concat ", " many)) )
+  else
+    (cwd, None)
+
 (* #10855: keeper LLM (issue_king, masc-improver) hallucinated gh syntax
    `gh --repo X api Y` (108 events / 24h, 2026-04-25→04-26). gh CLI
    semantics: `--repo` is a subcommand flag (gh issue/pr/release/...),
@@ -318,56 +375,9 @@ let run_docker_shell_command_with_status
          (repos/ enumeration)로 결정론적 분기:
          - single-repo → 자동 chdir (silent)
          - multi-repo → explicit error로 LLM이 정확한 경로 학습
-         - 0 repo → preserve (system misconfig은 별도 fail) *)
-      let cwd_normalized =
-        Keeper_alerting_path.normalize_path_for_check cwd
-        |> Keeper_alerting_path.strip_trailing_slashes
-      in
-      let repos_in_playground () =
-        let repos_dir = Filename.concat host_root "repos" in
-        if not (Sys.file_exists repos_dir && Sys.is_directory repos_dir) then []
-        else
-          try
-            Sys.readdir repos_dir
-            |> Array.to_list
-            |> List.filter (fun name ->
-              let p = Filename.concat repos_dir name in
-              try Sys.is_directory p with Sys_error _ -> false)
-            |> List.sort compare
-          with Sys_error _ -> []
-      in
+         - 0 repo → explicit error로 clone/cwd 복구 액션 학습 *)
       let cwd, multi_repo_blocker =
-        if cwd_normalized = host_root && cmd_targets_git_or_gh cmd then
-          match repos_in_playground () with
-          | [single_repo] ->
-            (Filename.concat (Filename.concat host_root "repos") single_repo, None)
-          | [] -> (cwd, None)
-          | example_repo :: _ as many ->
-            (* #10680: keeper-executor-agent saw 17 events / 5min in a single
-               session (mcp_VHsjtow_92C_2a0o, 2026-04-26 08:00→08:06) where
-               the LLM read this descriptive error and still re-issued the
-               same bare git/gh in the next turn.  Make the message
-               self-correcting: include the original cmd and the exact
-               next-call shape so the LLM can copy-paste rather than
-               re-derive the cwd convention from prose. *)
-            let cmd_preview =
-              let s = String.trim cmd in
-              if String.length s > 120 then String.sub s 0 117 ^ "..." else s
-            in
-            ( cwd
-            , Some
-                (Printf.sprintf
-                   "sandbox root에서 git/gh 직접 호출 불가 \
-                    (mount point %s는 git repo 아님). \
-                    필수: 다음 호출에서 cwd를 명시. 예: \
-                    keeper_bash { cmd: \"cd repos/%s && %s\" } \
-                    (가능한 repo: %s). \
-                    같은 cmd를 다음 turn에서 cwd 변경 없이 다시 호출하지 마세요."
-                   host_root
-                   example_repo
-                   cmd_preview
-                   (String.concat ", " many)) )
-        else (cwd, None)
+        resolve_sandbox_root_git_cwd ~config ~meta ~cwd ~cmd
       in
       match multi_repo_blocker with
       | Some msg -> sandbox_error msg
@@ -524,6 +534,12 @@ let run_docker_with_git_bash
     (match check_egress ~config ~meta ~cmd with
      | Some blocked_json -> blocked_json
      | None ->
+    let cwd, sandbox_root_git_blocker =
+      resolve_sandbox_root_git_cwd ~config ~meta ~cwd ~cmd
+    in
+    match sandbox_root_git_blocker with
+    | Some message -> sandbox_error_json message
+    | None ->
     match turn_sandbox_runtime with
     | Some runtime ->
       (match
@@ -612,6 +628,12 @@ let run_docker_hardened_bash
     sandbox_error_json
       "sandbox_profile=docker blocks nested container runtimes and host socket references"
   else
+    let cwd, sandbox_root_git_blocker =
+      resolve_sandbox_root_git_cwd ~config ~meta ~cwd ~cmd
+    in
+    match sandbox_root_git_blocker with
+    | Some message -> sandbox_error_json message
+    | None ->
     match turn_sandbox_runtime, network_mode with
     | Some runtime, Network_none ->
       (match

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -78,6 +78,17 @@ val ensure_keeper_sandbox_runtime :
 val cmd_targets_git_or_gh : string -> bool
 val cmd_targets_gh : string -> bool
 
+(** Resolve raw [keeper_bash] git/gh commands launched from the sandbox
+    mount root. The mount root is not a git repository: a single cloned
+    repo is auto-selected, zero repos or multiple repos return a
+    self-correcting error that tells the keeper to set [cwd] explicitly. *)
+val resolve_sandbox_root_git_cwd :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  cmd:string ->
+  string * string option
+
 (** [#10855] LLM hallucinated [gh --repo X api Y] (108 events / 24h).
     Returns [Some (repo_arg, endpoint)] when the misuse pattern is
     detected, [None] otherwise — caller emits a self-correcting

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -514,6 +514,10 @@ let docker_run_line log_path =
 
 let run_git_creds_docker_shell ~config ~meta ~playground ~log_path =
   ensure_github_identity_bundle ~config Masc_mcp.Keeper_gh_env.root_github_identity;
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  if not (Sys.file_exists (Filename.concat repo ".git")) then
+    run_ok ~cwd:repo "git init -q";
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
@@ -545,6 +549,66 @@ let run_git_creds_docker_shell ~config ~meta ~playground ~log_path =
           (fst observed) (snd observed) (read_file log_path)
           result.Keeper_shell_docker.output;
       docker_run_line log_path
+
+let test_sandbox_root_git_cwd_zero_repo_blocks_before_exec () =
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let cwd, error =
+    Keeper_shell_docker.resolve_sandbox_root_git_cwd ~config ~meta
+      ~cwd:playground ~cmd:"git status"
+  in
+  Alcotest.(check string) "cwd remains sandbox root" playground cwd;
+  match error with
+  | None -> Alcotest.fail "expected missing repo guidance"
+  | Some msg ->
+    Alcotest.(check bool) "mentions no sandbox clones" true
+      (contains_substring msg "no sandbox git clones");
+    Alcotest.(check bool) "mentions git_clone recovery" true
+      (contains_substring msg "keeper_shell op=git_clone");
+    Alcotest.(check bool) "mentions cwd recovery" true
+      (contains_substring msg "cwd=\"repos/<repo>\"")
+
+let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  run_ok ~cwd:repo "git init -q";
+  let cwd, error =
+    Keeper_shell_docker.resolve_sandbox_root_git_cwd ~config ~meta
+      ~cwd:playground ~cmd:"git status"
+  in
+  let repo =
+    Keeper_alerting_path.normalize_path_for_check repo
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  Alcotest.(check (option string)) "no error" None error;
+  Alcotest.(check string) "auto cwd selects the only repo" repo cwd
+
+let test_sandbox_root_git_cwd_multi_repo_blocks_before_exec () =
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repos = Filename.concat playground "repos" in
+  let repo_a = Filename.concat repos "alpha" in
+  let repo_b = Filename.concat repos "beta" in
+  ensure_dir repo_a;
+  ensure_dir repo_b;
+  run_ok ~cwd:repo_a "git init -q";
+  run_ok ~cwd:repo_b "git init -q";
+  let cwd, error =
+    Keeper_shell_docker.resolve_sandbox_root_git_cwd ~config ~meta
+      ~cwd:playground ~cmd:"gh pr list"
+  in
+  Alcotest.(check string) "cwd remains sandbox root" playground cwd;
+  match error with
+  | None -> Alcotest.fail "expected multi repo cwd guidance"
+  | Some msg ->
+    Alcotest.(check bool) "mentions multiple repos" true
+      (contains_substring msg "multiple sandbox repos");
+    Alcotest.(check bool) "mentions concrete cwd" true
+      (contains_substring msg "\"cwd\": \"repos/alpha\"");
+    Alcotest.(check bool) "lists beta too" true
+      (contains_substring msg "alpha, beta")
 
 let test_git_creds_skips_missing_ssh_auth_sock () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -795,5 +859,14 @@ let () =
             test_hard_mode_git_clone_uses_brokered_route;
           Alcotest.test_case "git_clone repairs existing docker clone checkout"
             `Quick test_git_clone_repairs_existing_docker_clone_checkout;
+          Alcotest.test_case
+            "sandbox-root git with no repo blocks before docker exec"
+            `Quick test_sandbox_root_git_cwd_zero_repo_blocks_before_exec;
+          Alcotest.test_case
+            "sandbox-root git with one repo auto-selects cwd"
+            `Quick test_sandbox_root_git_cwd_single_repo_auto_chdir;
+          Alcotest.test_case
+            "sandbox-root git with multiple repos gives cwd correction"
+            `Quick test_sandbox_root_git_cwd_multi_repo_blocks_before_exec;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Share sandbox-root git/gh cwd resolution across one-shot Docker, git-creds Docker, and managed turn-runtime Docker paths.
- Auto-select the only cloned sandbox repo, and fail before exec with concrete recovery guidance for zero or multiple repos.
- Add route tests for zero-repo, single-repo, and multi-repo sandbox root git cwd handling.

## Validation
- git diff --check
- ocamlc -stop-after parsing on touched .ml/.mli files
- scripts/dune-local.sh build test/test_keeper_shell_docker_route.exe
- ./_build/default/test/test_keeper_shell_docker_route.exe