### PR TITLE
[codex] Expose keeper GitHub credentials

### DIFF
--- a/dashboard/src/components/credential-settings.test.ts
+++ b/dashboard/src/components/credential-settings.test.ts
@@ -1,6 +1,17 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest"
-import { coerceCredentialType, isRecord, credentialTypeLabel, credentialTypeBadgeClass } from "./credential-settings"
+import {
+  buildCredentialCreateRequest,
+  coerceCredentialType,
+  credentialStateBadgeClass,
+  credentialStateLabel,
+  credentialTypeBadgeClass,
+  credentialTypeLabel,
+  githubLoginCommand,
+  isRecord,
+  parseCredentialState,
+  sanitizeOptionalString,
+} from "./credential-settings"
 
 describe("coerceCredentialType", () => {
   it("returns github for unknown", () => {
@@ -45,5 +56,69 @@ describe("credentialTypeBadgeClass", () => {
     expect(credentialTypeBadgeClass("github").length).toBeGreaterThan(0)
     expect(credentialTypeBadgeClass("gitlab").length).toBeGreaterThan(0)
     expect(credentialTypeBadgeClass("local").length).toBeGreaterThan(0)
+  })
+})
+
+describe("credential state helpers", () => {
+  it("parses known state objects", () => {
+    expect(parseCredentialState({ kind: "Materialized", last_verified_at_unix_ms: "42" })).toEqual({
+      kind: "Materialized",
+      last_verified_at_unix_ms: "42",
+      reason: null,
+    })
+    expect(parseCredentialState(null)).toBeNull()
+    expect(parseCredentialState({ reason: "missing kind" })).toBeNull()
+  })
+
+  it("labels states and returns badge classes", () => {
+    expect(credentialStateLabel({ kind: "Materialized" })).toBe("Materialized")
+    expect(credentialStateLabel({ kind: "Stale" })).toBe("Stale")
+    expect(credentialStateLabel({ kind: "Unmaterialized" })).toBe("Unmaterialized")
+    expect(credentialStateLabel(null)).toBe("Unknown")
+    expect(credentialStateBadgeClass({ kind: "Materialized" }).length).toBeGreaterThan(0)
+  })
+})
+
+describe("credential create request", () => {
+  it("trims optional paths and omits web token", () => {
+    expect(sanitizeOptionalString("  ")).toBeNull()
+    expect(sanitizeOptionalString(" /tmp/key ")).toBe("/tmp/key")
+    expect(buildCredentialCreateRequest({
+      id: " gh-main ",
+      name: "",
+      type: "github",
+      username: " sangsu ",
+      gh_config_dir: " ",
+      ssh_key_path: " /tmp/id_ed25519 ",
+      oauth_method: "web",
+      token: "secret",
+    })).toEqual({
+      id: "gh-main",
+      cred_type: "github",
+      username: "sangsu",
+      gh_config_dir: null,
+      ssh_key_path: "/tmp/id_ed25519",
+      gpg_key_id: null,
+      oauth_method: "web",
+      token: null,
+    })
+  })
+
+  it("keeps with-token payload and command quoting explicit", () => {
+    expect(buildCredentialCreateRequest({
+      id: "keepers",
+      name: "",
+      type: "github",
+      username: "keeper-user",
+      gh_config_dir: "/Users/dancer/me/.masc/github-identities/keepers/gh",
+      oauth_method: "with_token",
+      token: "ghp_x",
+    })).toMatchObject({
+      oauth_method: "with_token",
+      token: "ghp_x",
+    })
+    expect(githubLoginCommand("/tmp/keeper's-gh")).toBe(
+      "GH_CONFIG_DIR='/tmp/keeper'\\''s-gh' gh auth login --hostname github.com --git-protocol https --web",
+    )
   })
 })

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -11,6 +11,13 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 // ── Types ────────────────────────────────────────────────
 
 export type CredentialType = 'github' | 'gitlab' | 'local'
+export type CredentialOauthMethod = 'web' | 'with_token'
+
+export interface CredentialState {
+  kind: 'Unmaterialized' | 'Materialized' | 'Stale' | string
+  last_verified_at_unix_ms?: string | number | null
+  reason?: string | null
+}
 
 export interface Credential {
   id: string
@@ -20,6 +27,8 @@ export interface Credential {
   gh_config_dir?: string | null
   ssh_key_path?: string | null
   gpg_key_id?: string | null
+  state?: CredentialState | null
+  token_sha256_prefix?: string | null
   description?: string
   config?: Record<string, unknown>
   created_at?: string
@@ -33,6 +42,8 @@ export interface CredentialCreatePayload {
   gh_config_dir?: string | null
   ssh_key_path?: string | null
   gpg_key_id?: string | null
+  oauth_method?: CredentialOauthMethod
+  token?: string | null
   description?: string
   config?: Record<string, unknown>
 }
@@ -52,6 +63,7 @@ const addDraft = signal<CredentialCreatePayload>({
   name: '',
   username: '',
   type: 'github',
+  oauth_method: 'web',
   description: '',
 })
 
@@ -76,6 +88,8 @@ async function fetchCredentials(): Promise<Credential[]> {
         gh_config_dir: typeof r.gh_config_dir === 'string' ? r.gh_config_dir : null,
         ssh_key_path: typeof r.ssh_key_path === 'string' ? r.ssh_key_path : null,
         gpg_key_id: typeof r.gpg_key_id === 'string' ? r.gpg_key_id : null,
+        state: parseCredentialState(r.state),
+        token_sha256_prefix: typeof r.token_sha256_prefix === 'string' ? r.token_sha256_prefix : null,
         description: r.description ? String(r.description) : undefined,
         config: isRecord(r.config) ? r.config : undefined,
         created_at: r.created_at ? String(r.created_at) : undefined,
@@ -86,14 +100,7 @@ async function fetchCredentials(): Promise<Credential[]> {
 }
 
 async function createCredential(payload: CredentialCreatePayload): Promise<void> {
-  await post('/api/v1/credentials', {
-    id: payload.id,
-    cred_type: payload.type,
-    username: payload.username || payload.name,
-    gh_config_dir: payload.gh_config_dir ?? null,
-    ssh_key_path: payload.ssh_key_path ?? null,
-    gpg_key_id: payload.gpg_key_id ?? null,
-  })
+  await post('/api/v1/credentials', buildCredentialCreateRequest(payload))
 }
 
 async function deleteCredential(id: string): Promise<void> {
@@ -119,6 +126,20 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+export function parseCredentialState(raw: unknown): CredentialState | null {
+  if (!isRecord(raw)) return null
+  const kind = typeof raw.kind === 'string' ? raw.kind : null
+  if (!kind) return null
+  return {
+    kind,
+    last_verified_at_unix_ms:
+      typeof raw.last_verified_at_unix_ms === 'string' || typeof raw.last_verified_at_unix_ms === 'number'
+        ? raw.last_verified_at_unix_ms
+        : null,
+    reason: typeof raw.reason === 'string' ? raw.reason : null,
+  }
+}
+
 export function credentialTypeLabel(type: CredentialType): string {
   switch (type) {
     case 'github': return 'GitHub'
@@ -138,8 +159,69 @@ export function credentialTypeBadgeClass(type: CredentialType): string {
   }
 }
 
+export function credentialStateLabel(state: CredentialState | null | undefined): string {
+  switch (state?.kind) {
+    case 'Materialized':
+      return 'Materialized'
+    case 'Stale':
+      return 'Stale'
+    case 'Unmaterialized':
+      return 'Unmaterialized'
+    default:
+      return 'Unknown'
+  }
+}
+
+export function credentialStateBadgeClass(state: CredentialState | null | undefined): string {
+  switch (state?.kind) {
+    case 'Materialized':
+      return 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
+    case 'Stale':
+      return 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]'
+    case 'Unmaterialized':
+      return 'bg-[var(--white-5)] text-text-dim border-[var(--white-10)]'
+    default:
+      return 'bg-[var(--white-5)] text-text-muted border-[var(--white-10)]'
+  }
+}
+
+export function sanitizeOptionalString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? ''
+  return trimmed === '' ? null : trimmed
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.split("'").join("'\\''")}'`
+}
+
+export function githubLoginCommand(ghConfigDir: string | null | undefined): string | null {
+  const dir = sanitizeOptionalString(ghConfigDir)
+  if (!dir) return null
+  return `GH_CONFIG_DIR=${shellQuote(dir)} gh auth login --hostname github.com --git-protocol https --web`
+}
+
+export function buildCredentialCreateRequest(payload: CredentialCreatePayload): Record<string, unknown> {
+  const ghConfigDir = sanitizeOptionalString(payload.gh_config_dir)
+  const sshKeyPath = sanitizeOptionalString(payload.ssh_key_path)
+  const gpgKeyId = sanitizeOptionalString(payload.gpg_key_id)
+  const oauthMethod =
+    payload.type === 'github'
+      ? payload.oauth_method === 'with_token' ? 'with_token' : 'web'
+      : 'web'
+  return {
+    id: payload.id.trim(),
+    cred_type: payload.type,
+    username: (payload.username || payload.name).trim(),
+    gh_config_dir: ghConfigDir,
+    ssh_key_path: sshKeyPath,
+    gpg_key_id: gpgKeyId,
+    oauth_method: oauthMethod,
+    token: oauthMethod === 'with_token' ? sanitizeOptionalString(payload.token) : null,
+  }
+}
+
 function resetAddDraft() {
-  addDraft.value = { id: '', name: '', username: '', type: 'github', description: '' }
+  addDraft.value = { id: '', name: '', username: '', type: 'github', oauth_method: 'web', description: '' }
   saveError.value = null
 }
 
@@ -179,6 +261,14 @@ function CredentialTypeBadge({ type }: { type: CredentialType }) {
   `
 }
 
+function CredentialStateBadge({ state }: { state?: CredentialState | null }) {
+  return html`
+    <span class="text-2xs font-bold px-2 py-0.5 rounded border ${credentialStateBadgeClass(state)} shadow-sm">
+      ${credentialStateLabel(state)}
+    </span>
+  `
+}
+
 // ── Main component ───────────────────────────────────────
 
 export function CredentialSettings() {
@@ -213,8 +303,12 @@ export function CredentialSettings() {
   const draft = addDraft.value
 
   async function handleSave() {
-    if (!draft.id.trim() || !draft.name.trim() || !draft.username.trim()) {
-      saveError.value = 'ID, 이름, 사용자명은 필수입니다.'
+    if (!draft.id.trim() || !draft.username.trim()) {
+      saveError.value = 'ID와 사용자명은 필수입니다.'
+      return
+    }
+    if (draft.type === 'github' && draft.oauth_method === 'with_token' && !sanitizeOptionalString(draft.token)) {
+      saveError.value = 'with-token 방식은 token 값이 필요합니다.'
       return
     }
     saving.value = true
@@ -225,6 +319,11 @@ export function CredentialSettings() {
         name: draft.name.trim(),
         username: draft.username.trim(),
         type: draft.type,
+        gh_config_dir: sanitizeOptionalString(draft.gh_config_dir),
+        ssh_key_path: sanitizeOptionalString(draft.ssh_key_path),
+        gpg_key_id: sanitizeOptionalString(draft.gpg_key_id),
+        oauth_method: draft.oauth_method ?? 'web',
+        token: sanitizeOptionalString(draft.token),
         description: draft.description?.trim() || undefined,
       })
       showToast('크리덴셜 추가 완료', 'success')
@@ -257,6 +356,7 @@ export function CredentialSettings() {
 
   const btnBase = 'py-1.5 px-4 rounded text-xs font-semibold cursor-pointer border-none'
   const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-[var(--t-med)] shadow-inner'
+  const helperStyle = 'mt-1 text-3xs leading-relaxed text-text-dim'
 
   return html`
     <div class="flex flex-col gap-4">
@@ -293,7 +393,7 @@ export function CredentialSettings() {
               <input
                 type="text"
                 class="${fieldStyle}"
-                placeholder="표시 이름"
+                placeholder="선택 사항"
                 value=${draft.name}
                 onInput=${(e: Event) => { addDraft.value = { ...draft, name: (e.target as HTMLInputElement).value } }}
               />
@@ -313,12 +413,82 @@ export function CredentialSettings() {
               <select
                 class="${fieldStyle}"
                 value=${draft.type}
-                onChange=${(e: Event) => { addDraft.value = { ...draft, type: coerceCredentialType((e.target as HTMLSelectElement).value) } }}
+                onChange=${(e: Event) => {
+                  const nextType = coerceCredentialType((e.target as HTMLSelectElement).value)
+                  addDraft.value = {
+                    ...draft,
+                    type: nextType,
+                    oauth_method: nextType === 'github' ? draft.oauth_method ?? 'web' : 'web',
+                    token: nextType === 'github' ? draft.token ?? '' : '',
+                  }
+                }}
               >
                 <option value="github">GitHub</option>
                 <option value="gitlab">GitLab</option>
                 <option value="local">Local</option>
               </select>
+            </div>
+            ${draft.type === 'github' ? html`
+              <div>
+                <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">gh login</label>
+                <select
+                  class="${fieldStyle}"
+                  value=${draft.oauth_method ?? 'web'}
+                  onChange=${(e: Event) => {
+                    addDraft.value = {
+                      ...draft,
+                      oauth_method: (e.target as HTMLSelectElement).value === 'with_token' ? 'with_token' : 'web',
+                    }
+                  }}
+                >
+                  <option value="web">gh auth login --web</option>
+                  <option value="with_token">gh auth login --with-token</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">GH_CONFIG_DIR</label>
+                <input
+                  type="text"
+                  class="${fieldStyle}"
+                  placeholder="base_path/.masc/github-identities/<credential-id>/gh"
+                  value=${draft.gh_config_dir ?? ''}
+                  onInput=${(e: Event) => { addDraft.value = { ...draft, gh_config_dir: (e.target as HTMLInputElement).value } }}
+                />
+                <div class="${helperStyle}">비우면 서버 base_path 아래 identity bundle을 사용합니다.</div>
+              </div>
+              ${draft.oauth_method === 'with_token' ? html`
+                <div>
+                  <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">Token</label>
+                  <textarea
+                    class="${fieldStyle} min-h-20 resize-y"
+                    placeholder="gh auth login --with-token 입력값"
+                    value=${draft.token ?? ''}
+                    onInput=${(e: Event) => { addDraft.value = { ...draft, token: (e.target as HTMLTextAreaElement).value } }}
+                  />
+                </div>
+              ` : null}
+            ` : null}
+            ${(draft.type === 'github' || draft.type === 'local') ? html`
+              <div>
+                <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">SSH key path</label>
+                <input
+                  type="text"
+                  class="${fieldStyle}"
+                  placeholder="base_path/.masc/github-identities/<credential-id>/ssh/id_ed25519"
+                  value=${draft.ssh_key_path ?? ''}
+                  onInput=${(e: Event) => { addDraft.value = { ...draft, ssh_key_path: (e.target as HTMLInputElement).value } }}
+                />
+              </div>
+            ` : null}
+            <div>
+              <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">GPG key id</label>
+              <input
+                type="text"
+                class="${fieldStyle}"
+                placeholder="선택 사항"
+                value=${draft.gpg_key_id ?? ''}
+                onInput=${(e: Event) => { addDraft.value = { ...draft, gpg_key_id: (e.target as HTMLInputElement).value } }}
+              />
             </div>
             <div>
               <label class="block text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">설명</label>
@@ -362,9 +532,10 @@ export function CredentialSettings() {
             <thead>
               <tr class="border-b border-card-border/30 bg-card/40">
                 <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">ID</th>
-                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">이름</th>
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">계정</th>
                 <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">타입</th>
-                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">설명</th>
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">상태</th>
+                <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted">경로</th>
                 <th class="py-2 px-3 text-2xs font-semibold uppercase tracking-wider text-text-muted text-right">동작</th>
               </tr>
             </thead>
@@ -376,8 +547,29 @@ export function CredentialSettings() {
                   <td class="py-2 px-3">
                     <${CredentialTypeBadge} type=${cred.type} />
                   </td>
-                  <td class="py-2 px-3 text-xs text-text-muted truncate max-w-[16rem]">
-                    ${cred.description || '--'}
+                  <td class="py-2 px-3">
+                    <div class="flex flex-col gap-1">
+                      <${CredentialStateBadge} state=${cred.state} />
+                      ${cred.token_sha256_prefix ? html`
+                        <span class="text-3xs font-mono text-text-dim">token ${cred.token_sha256_prefix}</span>
+                      ` : null}
+                      ${cred.state?.kind === 'Stale' && cred.state.reason ? html`
+                        <span class="text-3xs text-[var(--color-status-warn)] max-w-[12rem] break-words">${cred.state.reason}</span>
+                      ` : null}
+                    </div>
+                  </td>
+                  <td class="py-2 px-3 text-xs text-text-muted max-w-[28rem]">
+                    <div class="flex flex-col gap-1">
+                      ${cred.gh_config_dir ? html`
+                        <code class="font-mono text-3xs text-text-body break-all">${cred.gh_config_dir}</code>
+                      ` : html`<span class="text-3xs text-text-dim">GH_CONFIG_DIR --</span>`}
+                      ${githubLoginCommand(cred.gh_config_dir) && cred.state?.kind !== 'Materialized' ? html`
+                        <code class="font-mono text-3xs text-accent break-all">${githubLoginCommand(cred.gh_config_dir)}</code>
+                      ` : null}
+                      ${cred.ssh_key_path ? html`
+                        <code class="font-mono text-3xs text-text-dim break-all">ssh ${cred.ssh_key_path}</code>
+                      ` : null}
+                    </div>
                   </td>
                   <td class="py-2 px-3 text-right">
                     <button

--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -1,6 +1,8 @@
 (** See {!Host_config_provider} interface. *)
 
 let cred_root = "/tmp/keeper-creds"
+let explicit_ssh_key_container_path =
+  Filename.concat (Filename.concat cred_root ".ssh") "id_credential"
 
 let mount_if_present ~host ~container : Credential_provider.ro_mount list =
   if host = "" then []
@@ -90,7 +92,18 @@ let warn_mount_skips_if_any ~keeper_name (attempts : mount_attempt list) =
    credential dispatch container.  Ambient operator credential env is
    scrubbed before callers reach this provider; this block exposes only
    container-local GH/Git paths plus non-interactive git guards. *)
-let compose_env ~git_author_name ~git_author_email =
+let compose_env ?ssh_key_container ~git_author_name ~git_author_email () =
+  let ssh_env =
+    match ssh_key_container with
+    | None -> []
+    | Some key ->
+        [
+          ( "GIT_SSH_COMMAND",
+            Printf.sprintf
+              "ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+              (Filename.quote key) );
+        ]
+  in
   [
     "HOME", cred_root;
     "GH_CONFIG_DIR", Filename.concat cred_root ".config/gh";
@@ -103,6 +116,7 @@ let compose_env ~git_author_name ~git_author_email =
     "GIT_COMMITTER_NAME", git_author_name;
     "GIT_COMMITTER_EMAIL", git_author_email;
   ]
+  @ ssh_env
   @ Env_git_noninteractive.env
 
 let compose_ro_mounts ?keeper_name (kb : Keeper_gh_env.keeper_binding) =
@@ -172,13 +186,28 @@ let count_resolve_outcome ~keeper_name ~source ~reason =
       [ ("keeper", keeper_name); ("source", source); ("reason", reason) ]
     ()
 
-let bind_from_keeper_binding ~keeper_name (kb : Keeper_gh_env.keeper_binding)
-    ~extra_metadata =
+let bind_from_keeper_binding ?ssh_key_path ~keeper_name
+    (kb : Keeper_gh_env.keeper_binding) ~extra_metadata =
   let git_author_name, git_author_email =
     resolve_git_identity kb ~keeper_name
   in
-  let env = compose_env ~git_author_name ~git_author_email in
-  let ro_mounts = compose_ro_mounts ~keeper_name kb in
+  let ssh_key_container =
+    Option.map (fun _ -> explicit_ssh_key_container_path) ssh_key_path
+  in
+  let env =
+    compose_env ?ssh_key_container ~git_author_name ~git_author_email ()
+  in
+  let ro_mounts =
+    compose_ro_mounts ~keeper_name kb
+    @
+    match ssh_key_path with
+    | None -> []
+    | Some host ->
+        [
+          Credential_provider.
+            { host; container = explicit_ssh_key_container_path };
+        ]
+  in
   (* β7 fail-closed: resolve is called only when git_creds_enabled
      (caller at keeper_shell_docker.ml:398-400).  If ALL credential
      host paths are empty or missing, ro_mounts will be [].  Returning
@@ -259,10 +288,40 @@ let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
         (Credential_provider.Missing_bundle
            { identity = keeper_name; path = reason })
   | Ok kb ->
-      bind_from_keeper_binding ~keeper_name kb
-        ~extra_metadata:
-          [ ("credential_source", "credential_store");
-            ("credential_id", cred.id) ]
+      let ssh_key_path =
+        match cred.ssh_key_path with
+        | Some path when String.trim path <> "" -> Some (String.trim path)
+        | _ -> None
+      in
+      (match ssh_key_path with
+      | Some path when not (Sys.file_exists path) ->
+          Error
+            (Credential_provider.Missing_bundle
+               { identity = keeper_name
+               ; path =
+                   Printf.sprintf
+                     "credential %s ssh_key_path %S does not exist"
+                     cred.id path
+               })
+      | Some path when Sys.is_directory path ->
+          Error
+            (Credential_provider.Missing_bundle
+               { identity = keeper_name
+               ; path =
+                   Printf.sprintf
+                     "credential %s ssh_key_path %S is a directory; \
+                      expected a private key file"
+                     cred.id path
+               })
+      | _ ->
+          bind_from_keeper_binding ?ssh_key_path ~keeper_name kb
+            ~extra_metadata:
+              ([ ("credential_source", "credential_store");
+                 ("credential_id", cred.id) ]
+              @
+              match ssh_key_path with
+              | None -> []
+              | Some path -> [ ("ssh_key_path", path) ]))
 
 let resolve ~config ~identity:keeper_name =
   match
@@ -318,6 +377,8 @@ let tear_down (_b : Credential_provider.binding) ~container_id:_ =
   ()
 
 module For_testing = struct
-  let compose_env = compose_env
+  let compose_env ?ssh_key_container ~git_author_name ~git_author_email () =
+    compose_env ?ssh_key_container ~git_author_name ~git_author_email ()
+
   let mount_if_present = mount_if_present
 end

--- a/lib/keeper/host_config_provider.mli
+++ b/lib/keeper/host_config_provider.mli
@@ -24,8 +24,9 @@ val cred_root : string
     API; do not call from production code. *)
 module For_testing : sig
   val compose_env :
+    ?ssh_key_container:string ->
     git_author_name:string -> git_author_email:string ->
-    (string * string) list
+    unit -> (string * string) list
 
   val mount_if_present :
     host:string -> container:string -> Credential_provider.ro_mount list

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -106,6 +106,23 @@ let credential_of_json (json : Yojson.Safe.t) :
         }
   | _ -> Error "expected JSON object body"
 
+let default_github_gh_config_dir ~base_path ~credential_id =
+  Filename.concat
+    (Filename.concat base_path ".masc/github-identities")
+    (Filename.concat credential_id "gh")
+
+let apply_base_path_defaults ~base_path
+    (credential : Repo_manager_types.credential) =
+  match credential.cred_type, credential.gh_config_dir with
+  | Repo_manager_types.Github, None ->
+      { credential with
+        gh_config_dir =
+          Some
+            (default_github_gh_config_dir ~base_path
+               ~credential_id:credential.id)
+      }
+  | _ -> credential
+
 let add_routes router =
   router
   |> Http.Router.get "/api/v1/credentials" (fun request reqd ->
@@ -216,22 +233,13 @@ let add_routes router =
                          "credential id must be a non-empty filename \
                           fragment without slashes or directory traversal"
                      else
-                       (* When provisioning via with_token, derive a
-                          default gh_config_dir under the MASC-owned
-                          identity bundle layout so operators do not
-                          have to think about filesystem paths.  The
-                          path is path_safe by construction. *)
+                       (* GitHub credentials are rooted under the active
+                          server base_path when the operator leaves
+                          GH_CONFIG_DIR blank.  This keeps both web and
+                          with-token login flows on the same
+                          MASC-owned bundle layout. *)
                        let credential =
-                         if String.equal oauth_method "with_token"
-                            && credential.gh_config_dir = None then
-                           let derived =
-                             Filename.concat
-                               (Filename.concat base_path
-                                  ".masc/github-identities")
-                               (Filename.concat credential.id "gh")
-                           in
-                           { credential with gh_config_dir = Some derived }
-                         else credential
+                         apply_base_path_defaults ~base_path credential
                        in
                        match oauth_method with
                        | "web" -> (

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -27,6 +27,88 @@ open Alcotest
 
 module CP = Masc_mcp.Credential_provider
 module HCP = Masc_mcp.Host_config_provider
+open Repo_manager_types
+
+let mkdir_p path =
+  let rec loop dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else begin
+      loop (Filename.dirname dir);
+      Unix.mkdir dir 0o755
+    end
+  in
+  loop path
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "credential_provider" "" in
+  Sys.remove dir;
+  mkdir_p (Filename.concat dir ".masc/config");
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Sys.readdir path
+            |> Array.iter (fun n -> rm_rf (Filename.concat path n));
+            Unix.rmdir path
+          end
+          else Sys.remove path
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
+let write_mapping base_path keeper_id repo_ids =
+  let path =
+    Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
+  in
+  let entries =
+    String.concat ", " (List.map (fun s -> "\"" ^ s ^ "\"") repo_ids)
+  in
+  let content =
+    Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n" keeper_id entries
+  in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let seed_credential ~base_path cred =
+  match Credential_store.add ~base_path cred with
+  | Ok _ -> ()
+  | Error msg -> failf "seed credential %s: %s" cred.id msg
+
+let seed_repo ~base_path repo =
+  match Repo_store.add ~base_path repo with
+  | Ok _ -> ()
+  | Error msg -> failf "seed repo %s: %s" repo.id msg
+
+let make_credential ?ssh_key_path ~id ~username ~gh_config_dir () =
+  {
+    id;
+    cred_type = Github;
+    username;
+    gh_config_dir = Some gh_config_dir;
+    ssh_key_path;
+    gpg_key_id = None;
+    state = Unmaterialized;
+    token_sha256_prefix = None;
+  }
+
+let make_repo ~id ~credential_id : repository =
+  {
+    id;
+    name = "repo-" ^ id;
+    url = "git@github.com:test/" ^ id ^ ".git";
+    local_path = "repos/" ^ id;
+    default_branch = "main";
+    credential_id;
+    keepers = [];
+    status = Active;
+    auto_sync = false;
+    sync_interval = 0;
+    created_at = Int64.zero;
+    updated_at = Int64.zero;
+  }
 
 (* --- 1. pp_error covers every variant --- *)
 
@@ -134,7 +216,7 @@ let test_compose_env_key_set () =
   let env =
     HCP.For_testing.compose_env
       ~git_author_name:"keeper-A"
-      ~git_author_email:"keeper-A@example.invalid"
+      ~git_author_email:"keeper-A@example.invalid" ()
   in
   let actual_keys = List.sort compare (List.map fst env) in
   let expected_keys = List.sort compare expected_env_keys in
@@ -145,7 +227,7 @@ let test_compose_env_key_set () =
 let test_compose_env_path_values_anchored_to_cred_root () =
   let env =
     HCP.For_testing.compose_env
-      ~git_author_name:"k" ~git_author_email:"k@e"
+      ~git_author_name:"k" ~git_author_email:"k@e" ()
   in
   let lookup k = List.assoc k env in
   check string "HOME" HCP.cred_root (lookup "HOME");
@@ -160,13 +242,77 @@ let test_compose_env_git_identity_threaded () =
   let env =
     HCP.For_testing.compose_env
       ~git_author_name:"NAME-X"
-      ~git_author_email:"EMAIL-X"
+      ~git_author_email:"EMAIL-X" ()
   in
   let lookup k = List.assoc k env in
   check string "GIT_AUTHOR_NAME" "NAME-X" (lookup "GIT_AUTHOR_NAME");
   check string "GIT_AUTHOR_EMAIL" "EMAIL-X" (lookup "GIT_AUTHOR_EMAIL");
   check string "GIT_COMMITTER_NAME" "NAME-X" (lookup "GIT_COMMITTER_NAME");
   check string "GIT_COMMITTER_EMAIL" "EMAIL-X" (lookup "GIT_COMMITTER_EMAIL")
+
+let test_compose_env_explicit_ssh_key () =
+  let env =
+    HCP.For_testing.compose_env
+      ~ssh_key_container:"/tmp/keeper-creds/.ssh/id_credential"
+      ~git_author_name:"k" ~git_author_email:"k@e" ()
+  in
+  let cmd = List.assoc "GIT_SSH_COMMAND" env in
+  check bool "ssh command points at mounted key" true
+    (try
+       ignore
+         (Str.search_forward
+            (Str.regexp_string
+               "/tmp/keeper-creds/.ssh/id_credential")
+            cmd 0);
+       true
+     with Not_found -> false);
+  check bool "ssh command pins identity selection" true
+    (try
+       ignore
+         (Str.search_forward
+            (Str.regexp_string "-o IdentitiesOnly=yes") cmd 0);
+       true
+     with Not_found -> false)
+
+let test_resolve_credential_store_mounts_explicit_ssh_key () =
+  with_temp_base_path (fun base_path ->
+      let config = Masc_mcp.Coord.default_config base_path in
+      let gh_config_dir =
+        Filename.concat base_path ".masc/github-identities/cred-A/gh"
+      in
+      let ssh_key_path =
+        Filename.concat base_path ".masc/github-identities/cred-A/ssh/id_ed25519"
+      in
+      mkdir_p gh_config_dir;
+      mkdir_p (Filename.dirname ssh_key_path);
+      let oc = open_out ssh_key_path in
+      close_out oc;
+      seed_credential ~base_path
+        (make_credential ~id:"cred-A" ~username:"user-A"
+           ~gh_config_dir ~ssh_key_path ());
+      seed_repo ~base_path (make_repo ~id:"repo-1" ~credential_id:"cred-A");
+      write_mapping base_path "keeper-1" [ "repo-1" ];
+      match HCP.resolve ~config ~identity:"keeper-1" with
+      | Error err ->
+          failf "resolve failed: %s" (CP.pp_error err)
+      | Ok binding ->
+          let ssh_cmd = List.assoc "GIT_SSH_COMMAND" binding.CP.env in
+          check bool "ssh command points at projected key" true
+            (try
+               ignore
+                 (Str.search_forward
+                    (Str.regexp_string
+                       "/tmp/keeper-creds/.ssh/id_credential")
+                    ssh_cmd 0);
+               true
+             with Not_found -> false);
+          check bool "explicit ssh key mounted" true
+            (List.exists
+               (fun (m : CP.ro_mount) ->
+                 String.equal m.host ssh_key_path
+                 && String.equal m.container
+                      "/tmp/keeper-creds/.ssh/id_credential")
+               binding.ro_mounts))
 
 (* --- 4. finalize / tear_down noop semantics --- *)
 
@@ -214,6 +360,13 @@ let () =
             test_compose_env_path_values_anchored_to_cred_root;
           test_case "identity threaded" `Quick
             test_compose_env_git_identity_threaded;
+          test_case "explicit ssh key" `Quick
+            test_compose_env_explicit_ssh_key;
+        ] );
+      ( "credential_store_bridge",
+        [
+          test_case "explicit ssh key is mounted" `Quick
+            test_resolve_credential_store_mounts_explicit_ssh_key;
         ] );
       ( "lifecycle (PR-1 noop)",
         [


### PR DESCRIPTION
## Summary

Expose keeper GitHub credentials in the dashboard and make the server/runtime path match the active MASC base path.

- Add GitHub credential form controls for `gh auth login --web`, `gh auth login --with-token`, `GH_CONFIG_DIR`, SSH key path, and GPG key id.
- Default blank GitHub `GH_CONFIG_DIR` to `<base_path>/.masc/github-identities/<credential-id>/gh` for both web and with-token flows.
- Project credential-store `ssh_key_path` into Docker keeper credential dispatch and select it via `GIT_SSH_COMMAND`.
- Render credential materialization state, token prefix, and the exact `GH_CONFIG_DIR=... gh auth login ...` command in the dashboard.

## Product impact

Operators can keep the default local credential while adding a distinct GitHub account for keeper/repo work from the dashboard. The path convention now follows the live `base_path`, so a server running with `--base-path=/Users/dancer/me` stores GitHub identity bundles under `/Users/dancer/me/.masc/github-identities/...`.

This also closes the previous gray zone where `ssh_key_path` was visible in credential data but not consumed by Docker keeper execution.

## Evidence

- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/credential-settings.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec eslint src/components/credential-settings.ts src/components/credential-settings.test.ts`
- `scripts/dune-local.sh build test/test_credential_provider.exe`
- `./_build/default/test/test_credential_provider.exe`
- `git diff --check`

## Review evidence

Focus review on:

- `server_routes_http_routes_credentials.ml`: base-path-derived GitHub bundle default.
- `credential-settings.ts`: dashboard create payload and visible login/status paths.
- `host_config_provider.ml`: explicit SSH key projection into Docker credential dispatch.

The dashboard eslint command reports the existing ignored-test-file warning for `credential-settings.test.ts`; the changed source file passes eslint.

## Linked issue

None.
