### PR TITLE
Fix board write stalls without timeout knob

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -35,6 +35,7 @@ let create_store () = {
   post_count = ref 0;
   last_sweep = Time_compat.now ();
   mutex = Eio.Mutex.create ();
+  persist_mutex = Eio.Mutex.create ();
   karma_cache = None;
   sorted_posts_cache = None;
   comments_by_post = Hashtbl.create 1024;
@@ -78,6 +79,10 @@ let mark_dirty_comment store comment_id =
 (** Execute f with mutex held, using Eio.Mutex for proper concurrency *)
 let with_lock store f =
   Eio.Mutex.use_rw ~protect:true store.mutex (fun () -> f ())
+
+(** Serialize JSONL writes without holding the state mutex. *)
+let with_persist_lock store f =
+  Eio.Mutex.use_rw ~protect:true store.persist_mutex (fun () -> f ())
 
 (** {1 Sweeper - Aggressive Cleanup} *)
 
@@ -379,7 +384,6 @@ let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
         Hashtbl.add store.posts (Post_id.to_string post.id) post;
         Stdlib.incr store.post_count;
         invalidate_post_caches store;
-        append_post post;
         Ok post
       end)
   in
@@ -392,6 +396,7 @@ let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
      post itself is already in the store and on disk. *)
   (match board_result with
    | Ok post ->
+       with_persist_lock store (fun () -> append_post post);
        (match Agent_economy.earn
           ~base_path:(board_base_path ()) ~agent_name:author
           ~kind:Earn_board_post ~reason:"board post" () with
@@ -629,55 +634,60 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
     Error (Validation_error "Content cannot be empty")
   else
 
-  with_lock store (fun () ->
-    (* Verify post exists *)
-    match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
-    | None -> Error (Post_not_found post_id)
-    | Some post ->
-        (* Check comment count using index *)
-        let post_key = Post_id.to_string pid in
-        let post_comment_count =
-          Hashtbl.find_opt store.comments_by_post post_key
-          |> Option.value ~default:[] |> List.length
-        in
-        if post_comment_count >= Limits.max_comments_per_post then
-          Error (Capacity_exceeded { current = post_comment_count; max = Limits.max_comments_per_post })
-        else begin
-          let now = Time_compat.now () in
-          let ttl =
-            match post.post_kind with
-            | Automation_post | System_post ->
-                let forced = Limits.automation_ttl_hours in
-                if ttl_hours = 0 then forced
-                else min ttl_hours forced
-            | Human_post ->
-                if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours
-          in
-          let comment = {
-            id = Comment_id.generate ();
-            post_id = pid;
-            parent_id = parent_cid;
-            author = author_id;
-            content;
-            created_at = now;
-            expires_at = if ttl = 0 then 0.0 else now +. (Stdlib.Float.of_int ttl *. 3600.0);
-            votes_up = 0;
-            votes_down = 0;
-          } in
-          Hashtbl.add store.comments (Comment_id.to_string comment.id) comment;
-          (* Update comments_by_post index *)
+  let board_result =
+    with_lock store (fun () ->
+      (* Verify post exists *)
+      match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
+      | None -> Error (Post_not_found post_id)
+      | Some post ->
+          (* Check comment count using index *)
           let post_key = Post_id.to_string pid in
-          let existing = Hashtbl.find_opt store.comments_by_post post_key |> Option.value ~default:[] in
-          Hashtbl.replace store.comments_by_post post_key (Comment_id.to_string comment.id :: existing);
-          (* Update post reply count and updated_at *)
-          Hashtbl.replace store.posts post_key
-            { post with reply_count = post.reply_count + 1; updated_at = now };
-          invalidate_post_caches store;
-          invalidate_comment_caches store;
-          append_comment comment;
-          Ok comment
-        end
-  )
+          let post_comment_count =
+            Hashtbl.find_opt store.comments_by_post post_key
+            |> Option.value ~default:[] |> List.length
+          in
+          if post_comment_count >= Limits.max_comments_per_post then
+            Error (Capacity_exceeded { current = post_comment_count; max = Limits.max_comments_per_post })
+          else begin
+            let now = Time_compat.now () in
+            let ttl =
+              match post.post_kind with
+              | Automation_post | System_post ->
+                  let forced = Limits.automation_ttl_hours in
+                  if ttl_hours = 0 then forced
+                  else min ttl_hours forced
+              | Human_post ->
+                  if ttl_hours = 0 then 0 else min ttl_hours Limits.max_ttl_hours
+            in
+            let comment = {
+              id = Comment_id.generate ();
+              post_id = pid;
+              parent_id = parent_cid;
+              author = author_id;
+              content;
+              created_at = now;
+              expires_at = if ttl = 0 then 0.0 else now +. (Stdlib.Float.of_int ttl *. 3600.0);
+              votes_up = 0;
+              votes_down = 0;
+            } in
+            Hashtbl.add store.comments (Comment_id.to_string comment.id) comment;
+            (* Update comments_by_post index *)
+            let post_key = Post_id.to_string pid in
+            let existing = Hashtbl.find_opt store.comments_by_post post_key |> Option.value ~default:[] in
+            Hashtbl.replace store.comments_by_post post_key (Comment_id.to_string comment.id :: existing);
+            (* Update post reply count and updated_at *)
+            Hashtbl.replace store.posts post_key
+              { post with reply_count = post.reply_count + 1; updated_at = now };
+            invalidate_post_caches store;
+            invalidate_comment_caches store;
+            Ok comment
+          end)
+  in
+  match board_result with
+  | Ok comment ->
+      with_persist_lock store (fun () -> append_comment comment);
+      Ok comment
+  | Error _ as e -> e
 
 let get_comments store ~post_id : (comment list, board_error) Result.t =
   maybe_sweep store;

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -79,6 +79,10 @@ val with_lock : store -> (unit -> 'a) -> 'a
     {b outside} the lock so the ledger write does not block
     every other reader / writer. *)
 
+val with_persist_lock : store -> (unit -> 'a) -> 'a
+(** [with_persist_lock store f] serializes JSONL writes that must run
+    after the state mutation lock has been released. *)
+
 val invalidate_post_caches : store -> unit
 (** Clears [karma_cache] and [sorted_posts_cache].  Called
     after every post mutation. *)
@@ -180,9 +184,9 @@ val create_post :
     posts are forced to {!Limits.automation_ttl_hours}).
     Errors on validation failure, capacity exhaustion
     ([Capacity_exceeded]), or content length overflow.  The
-    [Agent_economy.earn] credit is intentionally awarded
-    {b outside} the lock to avoid blocking concurrent
-    readers on the ledger write. *)
+    JSONL append and the [Agent_economy.earn] credit are intentionally
+    performed {b outside} the state lock to avoid blocking concurrent
+    readers on filesystem writes. *)
 
 val get_post :
   store -> post_id:string -> (post, board_error) Result.t

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -194,6 +194,7 @@ type store = {
   post_count: int ref;
   mutable last_sweep: float;
   mutex: Eio.Mutex.t;
+  persist_mutex: Eio.Mutex.t;
   (* Phase 2 caches *)
   mutable karma_cache: (string * int) list option;       (** None = stale *)
   mutable sorted_posts_cache: post list option;           (** None = stale *)

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -140,6 +140,7 @@ type store = {
   post_count : int ref;
   mutable last_sweep : float;
   mutex : Eio.Mutex.t;
+  persist_mutex : Eio.Mutex.t;
   mutable karma_cache : (string * int) list option;
   (** [None] = stale. *)
   mutable sorted_posts_cache : post list option;

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -65,39 +65,45 @@ let append_vote_log ~target ~voter ~direction ~ts =
     rotate_if_needed path
   with Sys_error msg -> Log.BoardLog.error "persist error (append_vote_log): %s" msg
 
-let rewrite_vote_log store =
+let vote_log_jsonl store =
+  let buf = Buffer.create 4096 in
+  Hashtbl.iter
+    (fun target (direction, ts) ->
+      let voter =
+        match String.rindex_opt target ':' with
+        | Some idx when idx + 1 < String.length target ->
+            String.sub target (idx + 1) (String.length target - idx - 1)
+        | _ -> ""
+      in
+      let json =
+        `Assoc
+          [
+            ("target", `String target);
+            ("voter", `String voter);
+            ("direction", `String (vote_direction_to_string direction));
+            (* #10086: persist the cast ts stored alongside the
+               direction, NOT [Time_compat.now ()].  The previous
+               behaviour rewrote every row's timestamp on each
+               flush cycle, destroying audit and feeding wrong
+               values to hot-ranking / recency scoring. *)
+            ("ts", `Float ts);
+          ]
+      in
+      Buffer.add_string buf (Yojson.Safe.to_string json ^ "\n"))
+    store.vote_log;
+  Buffer.contents buf
+
+let save_vote_log_jsonl content =
   try
     ensure_masc_dir ();
     let path = vote_log_path () in
-    let buf = Buffer.create 4096 in
-    Hashtbl.iter
-      (fun target (direction, ts) ->
-        let voter =
-          match String.rindex_opt target ':' with
-          | Some idx when idx + 1 < String.length target ->
-              String.sub target (idx + 1) (String.length target - idx - 1)
-          | _ -> ""
-        in
-        let json =
-          `Assoc
-            [
-              ("target", `String target);
-              ("voter", `String voter);
-              ("direction", `String (vote_direction_to_string direction));
-              (* #10086: persist the cast ts stored alongside the
-                 direction, NOT [Time_compat.now ()].  The previous
-                 behaviour rewrote every row's timestamp on each
-                 flush cycle, destroying audit and feeding wrong
-                 values to hot-ranking / recency scoring. *)
-              ("ts", `Float ts);
-            ]
-        in
-        Buffer.add_string buf (Yojson.Safe.to_string json ^ "\n"))
-      store.vote_log;
-    (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
+    (match Fs_compat.save_file_atomic path content with
      | Ok () -> ()
      | Error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg)
   with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg
+
+let rewrite_vote_log store =
+  save_vote_log_jsonl (vote_log_jsonl store)
 
 (* [vote_outcome] carries the information needed to run the post-lock
    [Agent_economy.earn] call.  [earn_upvote_for] is [Some author] only
@@ -107,7 +113,26 @@ let rewrite_vote_log store =
 type vote_outcome = {
   delta : int;
   earn_upvote_for : string option;
+  vote_target : string;
+  vote_voter : string;
+  vote_direction : vote_direction;
+  vote_ts : float;
+  vote_author_name : string;
 }
+
+let record_vote_side_effect store outcome =
+  with_persist_lock store (fun () ->
+      append_vote_log
+        ~target:outcome.vote_target
+        ~voter:outcome.vote_voter
+        ~direction:outcome.vote_direction
+        ~ts:outcome.vote_ts);
+  let vote_dir =
+    match outcome.vote_direction with Up -> `Up | Down -> `Down
+  in
+  Thompson_sampling.record_vote
+    ~agent_name:outcome.vote_author_name
+    ~direction:vote_dir
 
 let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
   match Agent_id.of_string voter with
@@ -140,14 +165,15 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
                   Hashtbl.replace store.vote_log vote_key (direction, now);
                   mark_dirty_post store (Post_id.to_string pid);
                   invalidate_post_caches store;
-                  append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
-                  (* Record vote for Thompson Sampling feedback *)
                   let author_name = Agent_id.to_string post.author in
-                  let vote_dir = match direction with Up -> `Up | Down -> `Down in
-                  Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
                   (* No economy earn on flip: prevents down/up alternation abuse *)
                   Ok { delta = flipped.votes_up - flipped.votes_down;
-                       earn_upvote_for = None }
+                       earn_upvote_for = None;
+                       vote_target = vote_key;
+                       vote_voter = voter;
+                       vote_direction = direction;
+                       vote_ts = now;
+                       vote_author_name = author_name }
               | None ->
                   let updated = match direction with
                     | Up -> { post with votes_up = post.votes_up + 1; updated_at = now }
@@ -157,16 +183,17 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
                   Hashtbl.replace store.vote_log vote_key (direction, now);
                   mark_dirty_post store (Post_id.to_string pid);
                   invalidate_post_caches store;
-                  append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
-                  (* Record vote for Thompson Sampling feedback *)
                   let author_name = Agent_id.to_string post.author in
-                  let vote_dir = match direction with Up -> `Up | Down -> `Down in
-                  Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
                   let earn =
                     if Poly.equal direction Up then Some author_name else None
                   in
                   Ok { delta = updated.votes_up - updated.votes_down;
-                       earn_upvote_for = earn })
+                       earn_upvote_for = earn;
+                       vote_target = vote_key;
+                       vote_voter = voter;
+                       vote_direction = direction;
+                       vote_ts = now;
+                       vote_author_name = author_name })
       in
       (* Agent Economy: earn credits for an upvote received.  Moved
          OUTSIDE the store lock — [Agent_economy.earn] writes its own
@@ -174,7 +201,8 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
          so holding [store.mutex] across its disk I/O was gratuitous
          contention with every other reader/writer. *)
       (match board_result with
-       | Ok { delta; earn_upvote_for = Some author_name } ->
+       | Ok ({ delta; earn_upvote_for = Some author_name } as outcome) ->
+           record_vote_side_effect store outcome;
            (match Agent_economy.earn
               ~base_path:(board_base_path ()) ~agent_name:author_name
               ~kind:Earn_upvote ~reason:"upvote on post" () with
@@ -182,7 +210,9 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
             | Error e ->
                 Log.BoardLog.warn "board_votes: economy earn failed for %s: %s" author_name e);
            Ok delta
-       | Ok { delta; earn_upvote_for = None } -> Ok delta
+       | Ok ({ delta; earn_upvote_for = None } as outcome) ->
+           record_vote_side_effect store outcome;
+           Ok delta
        | Error _ as e -> e)
 
 (** Vote on a comment *)
@@ -214,12 +244,16 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result
                 Hashtbl.replace store.vote_log vote_key (direction, now);
                 mark_dirty_comment store (Comment_id.to_string cid);
                 invalidate_comment_caches store;
-                append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
-                (* Record vote for Thompson Sampling feedback *)
                 let author_name = Agent_id.to_string cmt.author in
-                let vote_dir = match direction with Up -> `Up | Down -> `Down in
-                Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
-                Ok (flipped.votes_up - flipped.votes_down)
+                Ok {
+                  delta = flipped.votes_up - flipped.votes_down;
+                  earn_upvote_for = None;
+                  vote_target = vote_key;
+                  vote_voter = voter;
+                  vote_direction = direction;
+                  vote_ts = now;
+                  vote_author_name = author_name;
+                }
             | None ->
                 let updated = match direction with
                   | Up -> { cmt with votes_up = cmt.votes_up + 1 }
@@ -229,13 +263,20 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result
                 Hashtbl.replace store.vote_log vote_key (direction, now);
                 mark_dirty_comment store (Comment_id.to_string cid);
                 invalidate_comment_caches store;
-                append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
-                (* Record vote for Thompson Sampling feedback *)
                 let author_name = Agent_id.to_string cmt.author in
-                let vote_dir = match direction with Up -> `Up | Down -> `Down in
-                Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
-                Ok (updated.votes_up - updated.votes_down)
+                Ok {
+                  delta = updated.votes_up - updated.votes_down;
+                  earn_upvote_for = None;
+                  vote_target = vote_key;
+                  vote_voter = voter;
+                  vote_direction = direction;
+                  vote_ts = now;
+                  vote_author_name = author_name;
+                }
       )
+      |> Result.map (fun outcome ->
+             record_vote_side_effect store outcome;
+             outcome.delta)
 
 (** {1 Stats} *)
 
@@ -643,8 +684,9 @@ let reset_global_for_test () =
 
 (** Flush any dirty state to disk. Call on shutdown to prevent data loss. *)
 let flush_dirty store =
-  let posts, comments =
+  let posts, comments, vote_log =
     with_lock store (fun () ->
+      let had_dirty = store.dirty_posts || store.dirty_comments in
       let posts =
         if store.dirty_posts then
           Hashtbl.fold
@@ -672,10 +714,15 @@ let flush_dirty store =
       store.dirty_posts <- false;
       store.dirty_comments <- false;
       store.last_flush <- Time_compat.now ();
-      (posts, comments))
+      let vote_log =
+        if had_dirty then Some (vote_log_jsonl store) else None
+      in
+      (posts, comments, vote_log))
   in
-  List.iter append_post posts;
-  List.iter append_comment comments
+  with_persist_lock store (fun () ->
+      List.iter append_post posts;
+      List.iter append_comment comments;
+      Option.iter save_vote_log_jsonl vote_log)
 
 
 (** {1 Karma & Flair - Reddit-style} *)

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -22,9 +22,8 @@
     - {b Vote log persistence}: [append_vote_log],
       [rewrite_vote_log].
     - {b Internal vote outcome}: the [vote_outcome] record
-      ({delta; earn_upvote_for}) is consumed only inside the
-      vote / vote_comment paths to gate the
-      [Agent_economy.earn] credit on the fresh-upvote path.
+      carries the score delta, optional fresh-upvote economy
+      credit, and post-lock vote log / feedback side effects.
     - {b Persistence loaders}: [load_persisted_posts],
       [load_persisted_comments], [load_persisted_votes],
       [recalculate_reply_counts].
@@ -91,8 +90,8 @@ val vote :
     author a credit via [Agent_economy.earn] {b outside}
     the lock so the ledger write does not block other
     readers.  Every vote is broadcast to
-    {!Thompson_sampling.record_vote} for posterior
-    feedback. *)
+    {!Thompson_sampling.record_vote} outside the state lock
+    for posterior feedback. *)
 
 val vote_comment :
   store ->
@@ -171,8 +170,9 @@ val reset_global_for_test : unit -> unit
 val flush_dirty : store -> unit
 (** Flushes dirty post/comment snapshots to the JSONL files
     with a short in-memory snapshot lock and append-only disk
-    writes.  Vote changes are already appended on the vote
-    path.  Stamps [last_flush] with the wall clock. *)
+    writes.  When dirty vote targets exist, compacts the vote
+    log from the same timestamp-preserving in-memory snapshot.
+    Stamps [last_flush] with the wall clock. *)
 
 (** {1 Karma} *)
 


### PR DESCRIPTION
Supersedes closed #12517. The closed PR raised board write timeouts via MASC_TOOL_TIMEOUT_BOARD_SEC; this keeps the fix in the board runtime instead of adding another env knob.\n\nChanges:\n- Adds a separate board persistence mutex so JSONL writes are serialized without holding the in-memory store mutex.\n- Moves post/comment creation persistence and vote log/Thompson side effects out of the state lock.\n- Makes dirty flush snapshot under the state lock, then append/compact JSONL under the persistence lock.\n- Preserves vote timestamp rewrite semantics while avoiding state-lock filesystem writes.\n\nVerification:\n- git diff --check\n- scripts/dune-local.sh build ./test/test_mcp_server_eio_call_tool.exe ./test/test_board_ttl.exe ./test/test_vote_ts_preservation_10086.exe ./lib/masc_mcp.cmxa\n- ./_build/default/test/test_mcp_server_eio_call_tool.exe\n- env MASC_BASE_PATH=/private/tmp/masc-board-ttl-12517 ./_build/default/test/test_board_ttl.exe\n- ./_build/default/test/test_vote_ts_preservation_10086.exe