### PR TITLE
refactor: rename misleading *_from_env accessors

### DIFF
--- a/lib/backend/backend_types.ml
+++ b/lib/backend/backend_types.ml
@@ -49,7 +49,7 @@ type config = {
   pubsub_max_messages: int;
 }
 
-let pubsub_max_messages_from_env () = 1000
+let pubsub_max_messages = 1000
 
 let generate_node_id () =
   let hostname = try Unix.gethostname () with Unix.Unix_error _ -> "unknown" in
@@ -62,7 +62,7 @@ let default_config = {
   base_path = Common.masc_dirname;
   node_id = generate_node_id ();
   cluster_name = "default";
-  pubsub_max_messages = pubsub_max_messages_from_env ();
+  pubsub_max_messages = pubsub_max_messages;
 }
 
 (* ============================================ *)

--- a/lib/backend/backend_types.mli
+++ b/lib/backend/backend_types.mli
@@ -41,9 +41,8 @@ type config = {
   pubsub_max_messages : int;
 }
 
-(** Currently returns a fixed literal (1000). Kept as a function to
-    allow future env-var override without API change. *)
-val pubsub_max_messages_from_env : unit -> int
+(** Fixed upper bound for in-memory pub/sub message delivery. *)
+val pubsub_max_messages : int
 
 (** Generate a node identifier of the form
     ["<hostname>-<pid>-<rand4hex>"], suitable for
@@ -51,7 +50,7 @@ val pubsub_max_messages_from_env : unit -> int
 val generate_node_id : unit -> string
 
 (** Default config: [FileSystem] backend rooted at [".masc"], cluster
-    ["default"], and [pubsub_max_messages = pubsub_max_messages_from_env ()]. *)
+    ["default"], and [pubsub_max_messages]. *)
 val default_config : config
 
 (** {1 Status reporting} *)

--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -79,7 +79,7 @@ let create_config ~fs ?clock base_path =
     base_path = Common.masc_dir_from_base_path ~base_path;
     node_id = Printf.sprintf "node_%d" (Unix.getpid ());
     cluster_name = "default";
-    pubsub_max_messages = Backend.pubsub_max_messages_from_env ();
+    pubsub_max_messages = Backend.pubsub_max_messages;
   } in
   let backend = Backend.FileSystem.create ~fs ?clock backend_config in
   {

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -296,7 +296,7 @@ let backend_config_for base_path =
     Backend_types.base_path = backend_base_path;
     Backend_types.cluster_name;
     Backend_types.node_id = Backend_types.generate_node_id ();
-    Backend_types.pubsub_max_messages = Backend_types.pubsub_max_messages_from_env ();
+    Backend_types.pubsub_max_messages = Backend_types.pubsub_max_messages;
   }
 
 let create_backend cfg =

--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -69,7 +69,7 @@ let create
     cooldown_sec = cooldown;
   }
 
-let create_from_env () = create ()
+let create_default () = create ()
 
 (** {1 Internal Helpers} *)
 
@@ -314,7 +314,7 @@ let wrap_result t ~agent_id (f : unit -> 'a) : ('a, string) result =
     [cancel:`Protect] ensures init finishes even if the forcing fiber
     is cancelled. *)
 
-let global = Eio.Lazy.from_fun ~cancel:`Protect create_from_env
+let global = Eio.Lazy.from_fun ~cancel:`Protect create_default
 
 let check_global ~agent_id = check (Eio.Lazy.force global) ~agent_id
 let record_failure_global ~agent_id ~reason = record_failure (Eio.Lazy.force global) ~agent_id ~reason

--- a/lib/core/circuit_breaker.mli
+++ b/lib/core/circuit_breaker.mli
@@ -85,10 +85,10 @@ val create :
     a fresh instance with an empty breaker map.  Defaults match
     the [default_*] constants above. *)
 
-val create_from_env : unit -> t
-(** [create_from_env ()] currently delegates to {!create} with all
-    defaults.  Pinned at the contract seam — future env-driven
-    overrides reuse this entry without breaking callers. *)
+val create_default : unit -> t
+(** [create_default ()] creates an instance with all defaults.
+    Pinned at the contract seam — future config-driven overrides
+    reuse this entry without breaking callers. *)
 
 (** {1 Lifecycle} *)
 

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -325,7 +325,7 @@ let deterministic_baseline_action (obs : world_observation) : deliberation_actio
 
 (* ---------- Budget check ---------- *)
 
-(** Daily budget from cached config (set via env at startup). *)
+(** Current daily budget from keeper runtime config. *)
 let daily_budget_usd () : float =
   Env_config.KeeperRuntime.deliberation_daily_budget_usd ()
 

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -325,8 +325,8 @@ let deterministic_baseline_action (obs : world_observation) : deliberation_actio
 
 (* ---------- Budget check ---------- *)
 
-(** Read the daily budget from env, returning the default if absent or invalid. *)
-let daily_budget_usd_from_env () : float =
+(** Daily budget from cached config (set via env at startup). *)
+let daily_budget_usd () : float =
   Env_config.KeeperRuntime.deliberation_daily_budget_usd ()
 
 (** Check whether the keeper has remaining budget for another deliberation call.

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -138,9 +138,9 @@ val deterministic_baseline_action : world_observation -> deliberation_action
 
 (** {1 Phase 2: Deliberation Evaluation} *)
 
-(** Read the daily budget from [MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD]
-    env var (default: 0.10). *)
-val daily_budget_usd_from_env : unit -> float
+(** Daily budget from cached [MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD]
+    config (default: 0.10). *)
+val daily_budget_usd : unit -> float
 
 (** Check whether the keeper has remaining budget for deliberation.
     Returns [true] when [cost_today_usd < daily_budget_usd]. *)

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -138,8 +138,8 @@ val deterministic_baseline_action : world_observation -> deliberation_action
 
 (** {1 Phase 2: Deliberation Evaluation} *)
 
-(** Daily budget from cached [MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD]
-    config (default: 0.10). *)
+(** Current daily budget from keeper runtime config
+    ([MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD], default: 0.10). *)
 val daily_budget_usd : unit -> float
 
 (** Check whether the keeper has remaining budget for deliberation.

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -212,13 +212,13 @@ let default_burst = 150
 let default_agent_rate = 20.0
 let default_agent_burst = 50
 
-let rate_from_env () = Env_config.Rate_bucket.rate
+let rate_of_config () = Env_config.Rate_bucket.rate
 
-let burst_from_env () = Env_config.Rate_bucket.burst
+let burst_of_config () = Env_config.Rate_bucket.burst
 
-let agent_rate_from_env () = Env_config.Rate_bucket.agent_rate
+let agent_rate_of_config () = Env_config.Rate_bucket.agent_rate
 
-let agent_burst_from_env () = Env_config.Rate_bucket.agent_burst
+let agent_burst_of_config () = Env_config.Rate_bucket.agent_burst
 
 (** {1 Limiter Creation} *)
 
@@ -233,11 +233,11 @@ let create ?(rate=default_rate) ?(burst=default_burst) () =
 let rate t = t.rate
 let burst t = t.burst
 
-let create_from_env () =
-  create ~rate:(rate_from_env ()) ~burst:(burst_from_env ()) ()
+let create_of_config () =
+  create ~rate:(rate_of_config ()) ~burst:(burst_of_config ()) ()
 
-let create_agent_from_env () =
-  create ~rate:(agent_rate_from_env ()) ~burst:(agent_burst_from_env ()) ()
+let create_agent_of_config () =
+  create ~rate:(agent_rate_of_config ()) ~burst:(agent_burst_of_config ()) ()
 
 (** {1 Rate Checking} *)
 
@@ -292,7 +292,7 @@ let cleanup limiter ~older_than_seconds =
     Uses [Eio.Lazy] for fiber-safe initialization.
     [cancel:`Protect] ensures init completes even if forcing fiber is cancelled. *)
 
-let global = Eio.Lazy.from_fun ~cancel:`Protect create_from_env
+let global = Eio.Lazy.from_fun ~cancel:`Protect create_of_config
 
 let check_global ~key =
   check (Eio.Lazy.force global) ~key
@@ -307,7 +307,7 @@ let remaining_global ~key =
     single agent cannot starve others even if they share the same egress IP. *)
 
 let agent_global =
-  Eio.Lazy.from_fun ~cancel:`Protect create_agent_from_env
+  Eio.Lazy.from_fun ~cancel:`Protect create_agent_of_config
 
 let check_agent_global ~key =
   check (Eio.Lazy.force agent_global) ~key

--- a/lib/rate_limit.mli
+++ b/lib/rate_limit.mli
@@ -51,18 +51,18 @@ val default_agent_rate : float
 (** Default per-agent requests per second: [20.0]. *)
 val default_agent_burst : int
 (** Default per-agent burst capacity: [50]. *)
-val rate_from_env : unit -> float
-val burst_from_env : unit -> int
-val agent_rate_from_env : unit -> float
-(** Per-agent rate from [MASC_AGENT_RATE_LIMIT] env var (default [20.0]). *)
-val agent_burst_from_env : unit -> int
-(** Per-agent burst from [MASC_AGENT_RATE_BURST] env var (default [50]). *)
+val rate_of_config : unit -> float
+val burst_of_config : unit -> int
+val agent_rate_of_config : unit -> float
+(** Per-agent rate from cached [MASC_AGENT_RATE_LIMIT] config (default [20.0]). *)
+val agent_burst_of_config : unit -> int
+(** Per-agent burst from cached [MASC_AGENT_RATE_BURST] config (default [50]). *)
 val rate : t -> float
 val burst : t -> int
 val create : ?rate:float -> ?burst:int -> unit -> t
-val create_from_env : unit -> t
-val create_agent_from_env : unit -> t
-(** Like [create_from_env] but uses the per-agent rate/burst env vars. *)
+val create_of_config : unit -> t
+val create_agent_of_config : unit -> t
+(** Like [create_of_config] but uses the per-agent rate/burst config. *)
 
 (** {1 Agent Quota Tier Contract} *)
 

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -74,7 +74,7 @@ let test_get_status_all_backends () =
 
 let test_pubsub_max_messages_env () =
   (* Test the default value - cannot easily test env override in unit test *)
-  let result = Backend_types.pubsub_max_messages_from_env () in
+  let result = Backend_types.pubsub_max_messages in
   check bool "pubsub default >= 100" true (result >= 100)
 
 (* ============================================================ *)

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -72,8 +72,8 @@ let test_get_status_all_backends () =
   let s2 = Backend_types.get_status cfg_fs in
   check string "fs status" "filesystem" (s2 |> member "backend_type" |> to_string)
 
-let test_pubsub_max_messages_env () =
-  (* Test the default value - cannot easily test env override in unit test *)
+let test_pubsub_max_messages_constant () =
+  (* Test the fixed default value. *)
   let result = Backend_types.pubsub_max_messages in
   check bool "pubsub default >= 100" true (result >= 100)
 
@@ -478,7 +478,7 @@ let () =
     ];
     "config_status", [
       test_case "get_status all backends" `Quick test_get_status_all_backends;
-      test_case "pubsub_max_messages" `Quick test_pubsub_max_messages_env;
+      test_case "pubsub_max_messages" `Quick test_pubsub_max_messages_constant;
     ];
     "eio_compression", [
       test_case "small data" `Quick test_compression_small_data;

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -630,7 +630,7 @@ let test_default_daily_budget () =
   (* default is 0.10 in env_config_keeper.ml KeeperRuntime *)
   check (float 0.001) "default budget" 0.10 (D.daily_budget_usd ())
 
-let test_daily_budget_from_env_default () =
+let test_daily_budget_empty_env_default () =
   (* Unset the env var to get default *)
   let saved = Sys.getenv_opt "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" in
   (match saved with
@@ -646,7 +646,7 @@ let test_daily_budget_from_env_default () =
   (* Empty string causes Failure in float_of_string, so default applies *)
   check (float 0.001) "env default budget" 0.10 budget
 
-let test_daily_budget_from_env_custom () =
+let test_daily_budget_live_env_custom () =
   let saved = Sys.getenv_opt "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" in
   Unix.putenv "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" "0.50";
   let budget = D.daily_budget_usd () in
@@ -1206,10 +1206,10 @@ let () =
             test_budget_check_zero_cost;
           test_case "default daily budget value" `Quick
             test_default_daily_budget;
-          test_case "daily budget from env default" `Quick
-            test_daily_budget_from_env_default;
-          test_case "daily budget from env custom" `Quick
-            test_daily_budget_from_env_custom;
+          test_case "daily budget empty env default" `Quick
+            test_daily_budget_empty_env_default;
+          test_case "daily budget live env custom" `Quick
+            test_daily_budget_live_env_custom;
         ] );
       ( "keeper_field_cleanup",
         [

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -628,7 +628,7 @@ let test_budget_check_zero_cost () =
 
 let test_default_daily_budget () =
   (* default is 0.10 in env_config_keeper.ml KeeperRuntime *)
-  check (float 0.001) "default budget" 0.10 (D.daily_budget_usd_from_env ())
+  check (float 0.001) "default budget" 0.10 (D.daily_budget_usd ())
 
 let test_daily_budget_from_env_default () =
   (* Unset the env var to get default *)
@@ -638,7 +638,7 @@ let test_daily_budget_from_env_default () =
    | None -> ());
   (* The function reads at call time, but with empty string it should
      fall back to default due to float_of_string failure *)
-  let budget = D.daily_budget_usd_from_env () in
+  let budget = D.daily_budget_usd () in
   (* Restore *)
   (match saved with
    | Some v -> Unix.putenv "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" v
@@ -649,7 +649,7 @@ let test_daily_budget_from_env_default () =
 let test_daily_budget_from_env_custom () =
   let saved = Sys.getenv_opt "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" in
   Unix.putenv "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" "0.50";
-  let budget = D.daily_budget_usd_from_env () in
+  let budget = D.daily_budget_usd () in
   (match saved with
    | Some v -> Unix.putenv "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" v
    | None ->

--- a/test/test_rate_limit_coverage.ml
+++ b/test/test_rate_limit_coverage.ml
@@ -237,18 +237,18 @@ let test_cleanup_keeps_recent () =
   check int "keeps recent" 0 removed
 
 (* ============================================================
-   Env Functions Tests
+   Config Accessor Tests
    ============================================================ *)
 
-let test_rate_from_env_returns_float () =
+let test_rate_of_config_returns_float () =
   let rate = Rate_limit.rate_of_config () in
   check bool "rate is positive" true (rate > 0.0)
 
-let test_burst_from_env_returns_int () =
+let test_burst_of_config_returns_int () =
   let burst = Rate_limit.burst_of_config () in
   check bool "burst is positive" true (burst > 0)
 
-let test_create_from_env () =
+let test_create_of_config () =
   let limiter = Rate_limit.create_of_config () in
   check bool "rate positive" true ((Rate_limit.rate limiter) > 0.0);
   check bool "burst positive" true ((Rate_limit.burst limiter) > 0)
@@ -362,15 +362,15 @@ let test_default_agent_rate () =
 let test_default_agent_burst () =
   check int "default agent burst" 50 Rate_limit.default_agent_burst
 
-let test_agent_rate_from_env_returns_float () =
+let test_agent_rate_of_config_returns_float () =
   let rate = Rate_limit.agent_rate_of_config () in
   check bool "agent rate is positive" true (rate > 0.0)
 
-let test_agent_burst_from_env_returns_int () =
+let test_agent_burst_of_config_returns_int () =
   let burst = Rate_limit.agent_burst_of_config () in
   check bool "agent burst is positive" true (burst > 0)
 
-let test_create_agent_from_env () =
+let test_create_agent_of_config () =
   let limiter = Rate_limit.create_agent_of_config () in
   check bool "agent rate positive" true ((Rate_limit.rate limiter) > 0.0);
   check bool "agent burst positive" true ((Rate_limit.burst limiter) > 0)
@@ -553,10 +553,10 @@ let () =
       test_case "removes old" `Quick test_cleanup_removes_old;
       test_case "keeps recent" `Quick test_cleanup_keeps_recent;
     ];
-    "env", [
-      test_case "rate_from_env" `Quick test_rate_from_env_returns_float;
-      test_case "burst_from_env" `Quick test_burst_from_env_returns_int;
-      test_case "create_from_env" `Quick test_create_from_env;
+    "config", [
+      test_case "rate_of_config" `Quick test_rate_of_config_returns_float;
+      test_case "burst_of_config" `Quick test_burst_of_config_returns_int;
+      test_case "create_of_config" `Quick test_create_of_config;
     ];
     "global", [
       test_case "check_global" `Quick test_check_global;
@@ -584,9 +584,9 @@ let () =
     "per_agent_config", [
       test_case "default_agent_rate" `Quick test_default_agent_rate;
       test_case "default_agent_burst" `Quick test_default_agent_burst;
-      test_case "agent_rate_from_env" `Quick test_agent_rate_from_env_returns_float;
-      test_case "agent_burst_from_env" `Quick test_agent_burst_from_env_returns_int;
-      test_case "create_agent_from_env" `Quick test_create_agent_from_env;
+      test_case "agent_rate_of_config" `Quick test_agent_rate_of_config_returns_float;
+      test_case "agent_burst_of_config" `Quick test_agent_burst_of_config_returns_int;
+      test_case "create_agent_of_config" `Quick test_create_agent_of_config;
     ];
     "per_agent_global", [
       test_case "check_agent_global" `Quick test_check_agent_global;

--- a/test/test_rate_limit_coverage.ml
+++ b/test/test_rate_limit_coverage.ml
@@ -241,15 +241,15 @@ let test_cleanup_keeps_recent () =
    ============================================================ *)
 
 let test_rate_from_env_returns_float () =
-  let rate = Rate_limit.rate_from_env () in
+  let rate = Rate_limit.rate_of_config () in
   check bool "rate is positive" true (rate > 0.0)
 
 let test_burst_from_env_returns_int () =
-  let burst = Rate_limit.burst_from_env () in
+  let burst = Rate_limit.burst_of_config () in
   check bool "burst is positive" true (burst > 0)
 
 let test_create_from_env () =
-  let limiter = Rate_limit.create_from_env () in
+  let limiter = Rate_limit.create_of_config () in
   check bool "rate positive" true ((Rate_limit.rate limiter) > 0.0);
   check bool "burst positive" true ((Rate_limit.burst limiter) > 0)
 
@@ -363,15 +363,15 @@ let test_default_agent_burst () =
   check int "default agent burst" 50 Rate_limit.default_agent_burst
 
 let test_agent_rate_from_env_returns_float () =
-  let rate = Rate_limit.agent_rate_from_env () in
+  let rate = Rate_limit.agent_rate_of_config () in
   check bool "agent rate is positive" true (rate > 0.0)
 
 let test_agent_burst_from_env_returns_int () =
-  let burst = Rate_limit.agent_burst_from_env () in
+  let burst = Rate_limit.agent_burst_of_config () in
   check bool "agent burst is positive" true (burst > 0)
 
 let test_create_agent_from_env () =
-  let limiter = Rate_limit.create_agent_from_env () in
+  let limiter = Rate_limit.create_agent_of_config () in
   check bool "agent rate positive" true ((Rate_limit.rate limiter) > 0.0);
   check bool "agent burst positive" true ((Rate_limit.burst limiter) > 0)
 


### PR DESCRIPTION
## Summary

Replaces closed Copilot PR #12522 with reviewer feedback addressed.

Renames `_from_env` functions that no longer read environment variables directly, fixing the semantic mismatch between name and behavior:

| Module | Before | After | Why |
|--------|--------|-------|-----|
| Backend_types | `pubsub_max_messages_from_env ()` | `pubsub_max_messages` | Hardcoded `1000`, never read env |
| Circuit_breaker | `create_from_env ()` | `create_default ()` | Delegates to `create()` with no env params |
| Rate_limit | `{rate,burst}_from_env ()` | `*_of_config ()` | Read from cached `Env_config` values |
| Rate_limit | `create_from_env` / `create_agent_from_env` | `*_of_config` | Same cached config delegation |
| keeper_deliberation | `daily_budget_usd_from_env ()` | `daily_budget_usd ()` | Delegates to `Env_config.KeeperRuntime` |

**Not renamed** (correctly reads env): `Masc_grpc_client.create_from_env`, `keep_recent_from_env`, `reducer_from_env`, `keeper_compaction_policy_from_env`.

## Test plan
- [x] `dune build --root . @install` passes (type-checked)
- [ ] CI Gate: full build + test suite
- [ ] `rg '_from_env' lib/ --type ml` confirms remaining `_from_env` functions actually read env

🤖 Generated with [Claude Code](https://claude.com/claude-code)