### PR TITLE
fix(coord): promote RFC P3-a fail-closed identity gate in handle_join

### DIFF
--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -145,97 +145,98 @@ let handle_join (ctx : context) : tool_result option =
   let mcp_session_id = ctx.mcp_session_id in
   let sid = Option.value ~default:"-" mcp_session_id in
   let caps = arg_get_string_list ctx "capabilities" in
-  (* RFC P3-a — preflight Keeper_identity.normalize_all_names (logging-only).
-     Reasons: (1) classify bootstrap-window silent_auth_token_resolve_error
-     bursts by normalize branch; (2) when promoted to hard-error in a
-     follow-up PR, transient-nickname joins will already use the canonical
-     keeper_name. In logging-only mode every error path emits a warn +
-     Prometheus inc and falls through with the original [agent_name]. *)
-  let resolved_agent_name =
-    match
-      Keeper_identity.normalize_all_names
-        ~input_agent_name:agent_name
-        ~base_path:config.base_path
-        ~check_persona:true ~check_credential:true ()
-    with
-    | Ok bundle ->
-        Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
-          ~labels:[ ("outcome", "ok") ] ();
-        bundle.keeper_name
-    | Error err ->
-        let outcome = Keeper_identity.validation_error_outcome_label err in
-        Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
-          ~labels:[ ("outcome", outcome) ] ();
-        Log.Misc.warn
-          "[sid=%s] [silent:coord_join_normalize] agent=%s outcome=%s detail=%s \
-           - logging-only mode, proceeding with original agent_name"
-          sid agent_name outcome
-          (Keeper_identity.show_validation_error err);
-        agent_name
+  let proceed_with_join resolved_name =
+    let result =
+      Coord.join config ~agent_name:resolved_name ~capabilities:caps ()
+    in
+    (* GC: reap zombie agents on join. Best-effort. *)
+    (try let _ = Coord.cleanup_zombies config in ()
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+       Log.Gc.warn "[sid=%s] join GC failed: %s" sid (Stdlib.Printexc.to_string exn));
+    (* Extract nickname from join result (format: "  Nickname: xxx\n...") *)
+    let nickname =
+      try
+        let prefix = "  Nickname: " in
+        let start_idx =
+          let idx = ref 0 in
+          while !idx < String.length result - String.length prefix &&
+                not (String.equal (Stdlib.String.sub result !idx (String.length prefix)) prefix) do
+            Stdlib.incr idx
+          done;
+          !idx + String.length prefix
+        in
+        let end_idx = match String.index_from_opt result start_idx '\n' with
+          | Some idx -> idx
+          | None -> String.length result
+        in
+        String.sub result start_idx (end_idx - start_idx)
+      with Invalid_argument _ -> agent_name
+    in
+    let _ = Session.register registry ~agent_name:nickname in
+    ctx.write_mcp_session_agent nickname;
+    Log.Misc.debug "[sid=%s] masc_join: saved nickname=%s to MCP session (original=%s)" sid nickname agent_name;
+    if Option.is_none mcp_session_id then begin
+      Log.Misc.warn "[sid=%s] [deprecated] writing agent name to /tmp file for TERM session — migrate to Agent_identity" sid;
+      let term_session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
+      let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
+      (try
+        Fs_compat.save_file agent_file nickname
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e ->
+        Log.Misc.error "[sid=%s] Failed to write agent file %s: %s" sid agent_file (Stdlib.Printexc.to_string e))
+    end;
+    let institution_welcome = match state.Mcp_server.fs with
+      | Some fs ->
+          (try Institution_eio.load_and_format_for_welcome ~fs config
+           with
+           | Eio.Io _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | exn ->
+               Log.Institution.warn "[sid=%s] Unexpected institution error: %s" sid (Stdlib.Printexc.to_string exn); "")
+      | None -> ""
+    in
+    let final_result = if String.equal institution_welcome "" then result
+      else result ^ institution_welcome in
+    let join_event = `Assoc [
+      ("type", `String "masc/agent_joined");
+      ("agent_name", `String nickname);
+      ("timestamp", `Float (Time_compat.now ()));
+    ] in
+    let _pushed = Session.push_notification_to_active_agents registry ~event:join_event in
+    Mcp_server.sse_broadcast state join_event;
+    Some (true, final_result)
   in
-  let result =
-    Coord.join config ~agent_name:resolved_agent_name ~capabilities:caps ()
-  in
-  (* GC: reap zombie agents on join. Best-effort. *)
-  (try let _ = Coord.cleanup_zombies config in ()
-   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     Log.Gc.warn "[sid=%s] join GC failed: %s" sid (Stdlib.Printexc.to_string exn));
-  (* Extract nickname from join result (format: "  Nickname: xxx\n...") *)
-  let nickname =
-    try
-      let prefix = "  Nickname: " in
-      let start_idx =
-        let idx = ref 0 in
-        while !idx < String.length result - String.length prefix &&
-              not (String.equal (Stdlib.String.sub result !idx (String.length prefix)) prefix) do
-          Stdlib.incr idx
-        done;
-        !idx + String.length prefix
-      in
-      let end_idx = match String.index_from_opt result start_idx '\n' with
-        | Some idx -> idx
-        | None -> String.length result
-      in
-      String.sub result start_idx (end_idx - start_idx)
-    with Invalid_argument _ -> agent_name
-  in
-  let _ = Session.register registry ~agent_name:nickname in
-  ctx.write_mcp_session_agent nickname;
-  Log.Misc.debug "[sid=%s] masc_join: saved nickname=%s to MCP session (original=%s)" sid nickname agent_name;
-  (* Deprecated: /tmp file agent identity. Agent_identity system is primary.
-     Remove when deprecation log shows zero hits over a release cycle. *)
-  if Option.is_none mcp_session_id then begin
-    Log.Misc.warn "[sid=%s] [deprecated] writing agent name to /tmp file for TERM session — migrate to Agent_identity" sid;
-    let term_session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
-    let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
-    (try
-      Fs_compat.save_file agent_file nickname
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | e ->
-      Log.Misc.error "[sid=%s] Failed to write agent file %s: %s" sid agent_file (Stdlib.Printexc.to_string e))
-  end;
-  (* Cultural Inheritance: append institution welcome to join response *)
-  let institution_welcome = match state.Mcp_server.fs with
-    | Some fs ->
-        (try Institution_eio.load_and_format_for_welcome ~fs config
-         with
-         | Eio.Io _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | exn ->
-             Log.Institution.warn "[sid=%s] Unexpected institution error: %s" sid (Stdlib.Printexc.to_string exn); "")
-    | None -> ""
-  in
-  let final_result = if String.equal institution_welcome "" then result
-    else result ^ institution_welcome in
-  let join_event = `Assoc [
-    ("type", `String "masc/agent_joined");
-    ("agent_name", `String nickname);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
-  let _pushed = Session.push_notification_to_active_agents registry ~event:join_event in
-  Mcp_server.sse_broadcast state join_event;
-  Some (true, final_result)
+  (* RFC P3-a — fail-closed identity gate.
+     Keeper_identity.normalize_all_names validates the agent identity
+     against persona + credential filesystem checks.  When validation
+     fails, the join is rejected rather than silently accepted.
+     Previously, normalize errors were logged and the join proceeded
+     with the original agent_name (fail-open), causing persona drift
+     and downstream credential resolution failures. *)
+  match
+    Keeper_identity.normalize_all_names
+      ~input_agent_name:agent_name
+      ~base_path:config.base_path
+      ~check_persona:true ~check_credential:true ()
+  with
+  | Ok bundle ->
+      Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
+        ~labels:[ ("outcome", "ok") ] ();
+      proceed_with_join bundle.keeper_name
+  | Error err ->
+      let outcome = Keeper_identity.validation_error_outcome_label err in
+      Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
+        ~labels:[ ("outcome", outcome) ] ();
+      Log.Misc.warn
+        "[sid=%s] [fail-closed:coord_join_normalize] agent=%s outcome=%s detail=%s          - join rejected"
+        sid agent_name outcome
+        (Keeper_identity.show_validation_error err);
+      Some
+        ( false,
+          Printf.sprintf
+            "masc_join rejected: identity validation failed for '%s' — %s.              Ensure the persona and credential files exist for this agent."
+            agent_name (Keeper_identity.show_validation_error err) )
 
 (** masc_leave — leave a MASC room *)
 let handle_leave (ctx : context) : tool_result option =

--- a/test/dune
+++ b/test/dune
@@ -489,6 +489,7 @@
         test_board_vote_quarantine
         test_keeper_identity_parse
         test_keeper_identity_normalize
+        test_coord_join_fail_closed
         test_keeper_personality_io_parse
         test_keeper_personality_io_coerce
         test_keeper_personality_io_validate
@@ -683,6 +684,7 @@
         test_board_vote_quarantine
         test_keeper_identity_parse
         test_keeper_identity_normalize
+        test_coord_join_fail_closed
         test_keeper_personality_io_parse
         test_keeper_personality_io_coerce
         test_keeper_personality_io_validate

--- a/test/test_coord_join_fail_closed.ml
+++ b/test/test_coord_join_fail_closed.ml
@@ -1,0 +1,195 @@
+(** Regression test for masc_join fail-closed identity gate (RFC P3-a).
+
+    Prior to RFC P3-a promotion, [handle_join] logged normalize errors and
+    proceeded with the original [agent_name] (fail-open).  The fail-closed
+    gate rejects join when [Keeper_identity.normalize_all_names] returns [Error].
+
+    This test verifies the gate function at the unit level.  It does NOT call
+    [handle_join] directly (which requires a full
+    [Tool_inline_dispatch_types.context] with Eio fiber infrastructure).
+
+    Note on persona path resolution: [normalize_all_names] uses
+    [Config_dir_resolver.personas_dir_opt()] first, which returns the global
+    config dir and ignores [base_path].  Credential checks DO use [base_path]
+    directly via [Common.agents_dir_from_base_path].  Therefore:
+    - Identity-level rejection tests (empty/whitespace/invalid chars) need no
+      filesystem setup — they fail before filesystem checks.
+    - Credential-only tests use [~check_persona:false] with temp dirs, since
+      credential resolution respects [base_path].
+    - Full-gate tests would require a known persona in the global config dir,
+      which is machine-dependent and excluded from CI. *)
+
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let validation_error =
+  testable Keeper_identity.pp_validation_error ( = )
+
+let normalize ~input ?base_path ?(check_persona = true) ?(check_credential = true) () =
+  Keeper_identity.normalize_all_names
+    ~input_agent_name:input
+    ?base_path
+    ~check_persona
+    ~check_credential
+    ()
+
+(* Same flags as handle_join uses *)
+let join_normalize ~input ?base_path () =
+  normalize ~input ?base_path ~check_persona:true ~check_credential:true ()
+
+let credential_only_normalize ~input ?base_path () =
+  normalize ~input ?base_path ~check_persona:false ~check_credential:true ()
+
+(* --------------------------------------------------------------------- *)
+(* Identity-level rejections (canonical_keeper_name returns None)         *)
+(* --------------------------------------------------------------------- *)
+
+let test_empty_rejected () =
+  match join_normalize ~input:"" () with
+  | Ok _ -> fail "empty input should be rejected by join gate"
+  | Error e ->
+      check validation_error "empty -> Empty_input"
+        Keeper_identity.Empty_input e
+
+let test_whitespace_rejected () =
+  match join_normalize ~input:"   " () with
+  | Ok _ -> fail "whitespace input should be rejected by join gate"
+  | Error e ->
+      check validation_error "whitespace -> Empty_input"
+        Keeper_identity.Empty_input e
+
+let test_invalid_chars_rejected () =
+  match join_normalize ~input:"bad@name!#%" () with
+  | Ok _ -> fail "invalid chars should be rejected by join gate"
+  | Error (Keeper_identity.Persona_not_found _) -> ()
+  | Error other ->
+      fail
+        (Printf.sprintf "invalid chars expected Persona_not_found, got %s"
+           (Keeper_identity.show_validation_error other))
+
+(* --------------------------------------------------------------------- *)
+(* Helpers for temp-dir based credential tests                            *)
+(* --------------------------------------------------------------------- *)
+
+let mkdir_p path =
+  let rec ensure p =
+    if p = "" || p = "/" || Sys.file_exists p then ()
+    else (
+      ensure (Filename.dirname p);
+      try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  ensure path
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter
+        (fun entry -> rm_rf (Filename.concat path entry))
+        (Sys.readdir path);
+      try Unix.rmdir path with Unix.Unix_error _ -> ())
+    else try Sys.remove path with Sys_error _ -> ()
+
+let with_tmp_base f =
+  let tmp_dir = Filename.temp_file "masc_join_gate" "" in
+  Sys.remove tmp_dir;
+  Unix.mkdir tmp_dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf tmp_dir)
+    (fun () -> f tmp_dir)
+
+let credential_path base name =
+  Filename.concat
+    (Filename.concat
+       (Filename.concat base ".masc")
+       (Filename.concat "auth" "agents"))
+    (name ^ ".json")
+
+let write_json path =
+  mkdir_p (Filename.dirname path);
+  let ch = open_out path in
+  output_string ch "{}";
+  close_out ch
+
+(* --------------------------------------------------------------------- *)
+(* Credential gate (check_persona:false — uses base_path directly)        *)
+(* --------------------------------------------------------------------- *)
+
+let test_credential_missing_rejected () =
+  with_tmp_base (fun base ->
+      match credential_only_normalize ~input:"testagent" ~base_path:base () with
+      | Ok _ -> fail "missing credential should be rejected"
+      | Error (Keeper_identity.Credential_missing _) -> ()
+      | Error other ->
+          fail
+            (Printf.sprintf
+               "missing credential expected Credential_missing, got %s"
+               (Keeper_identity.show_validation_error other)))
+
+let test_credential_present_accepted () =
+  with_tmp_base (fun base ->
+      write_json (credential_path base "testagent");
+      match credential_only_normalize ~input:"testagent" ~base_path:base () with
+      | Ok bundle ->
+          check string "keeper_name" "testagent" bundle.keeper_name;
+          check string "credential_stem" "testagent" bundle.credential_stem
+      | Error e ->
+          fail
+            (Printf.sprintf
+               "valid agent with credential should pass, got %s"
+               (Keeper_identity.show_validation_error e)))
+
+let test_wrapper_form_resolves_credential () =
+  with_tmp_base (fun base ->
+      write_json (credential_path base "alice");
+      match credential_only_normalize ~input:"keeper-alice-agent" ~base_path:base () with
+      | Ok bundle ->
+          check string "resolved keeper_name" "alice" bundle.keeper_name;
+          check string "credential_stem" "alice" bundle.credential_stem
+      | Error e ->
+          fail
+            (Printf.sprintf
+               "wrapper form should resolve, got %s"
+               (Keeper_identity.show_validation_error e)))
+
+(* --------------------------------------------------------------------- *)
+(* Join gate flags verification — documents the handle_join contract       *)
+(* --------------------------------------------------------------------- *)
+
+let test_join_gate_uses_both_checks () =
+  (* This is a documentation test: handle_join calls normalize with
+     ~check_persona:true ~check_credential:true.  The join_normalize
+     wrapper mirrors this exactly.  Empty input must fail. *)
+  match join_normalize ~input:"" () with
+  | Error _ -> ()
+  | Ok _ -> fail "join gate must reject empty input with both checks enabled"
+
+(* --------------------------------------------------------------------- *)
+(* Test runner                                                            *)
+(* --------------------------------------------------------------------- *)
+
+let () =
+  run "coord_join_fail_closed"
+    [
+      ( "identity_rejection",
+        [
+          test_case "empty input rejected" `Quick test_empty_rejected;
+          test_case "whitespace input rejected" `Quick test_whitespace_rejected;
+          test_case "invalid chars rejected" `Quick test_invalid_chars_rejected;
+        ] );
+      ( "credential_gate",
+        [
+          test_case "missing credential rejected" `Quick
+            test_credential_missing_rejected;
+          test_case "credential present accepted" `Quick
+            test_credential_present_accepted;
+          test_case "wrapper form resolves" `Quick
+            test_wrapper_form_resolves_credential;
+        ] );
+      ( "join_gate_contract",
+        [
+          test_case "join gate uses both checks" `Quick
+            test_join_gate_uses_both_checks;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Replaces #12523 (closed Copilot WIP).

- **Fail-closed gate**: `handle_join` now rejects joins when `Keeper_identity.normalize_all_names` returns `Error`, instead of logging and proceeding (fail-open)
- **Regression tests**: 7 tests covering identity rejection (empty/whitespace/invalid chars) and credential gate (missing credential, credential present, wrapper form resolution)
- **Prometheus metrics**: `metric_coord_join_normalize_outcome` counter with `ok`/`error` labels for observability

### What changed
- `lib/tool_inline_dispatch_coord.ml`: Extracted join continuation into `proceed_with_join` nested function; top-level match on normalize result returns `tool_result option` directly
- `test/test_coord_join_fail_closed.ml`: New regression test
- `test/dune`: Test registration

### Reviewer notes
The test uses `~check_persona:false` for credential-only tests because `Config_dir_resolver.personas_dir_opt()` returns the global config path and ignores `base_path`. Credential resolution does use `base_path` directly, making temp-dir based credential testing viable.

## Test plan
- [x] `dune build --root . @install` passes
- [x] `dune runtest --root . test/test_coord_join_fail_closed.exe` — 7/7 tests pass
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)