### PR TITLE
docs: align coord join fail-closed metric wording

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -825,11 +825,11 @@ let metric_auth_strict_would_reject =
 let metric_empty_tool_universe_observed =
   "masc_empty_tool_universe_observed_total"
 
-(** Counter for Coord.join preflight outcomes (RFC P3-a, logging-only mode).
+(** Counter for Coord.join identity-normalization outcomes (RFC P3-a).
    Labels: outcome (ok | empty_input | persona_not_found | credential_missing
-   | name_ambiguous | ephemeral_suffix_rejected). Cross-reference with
-   [metric_silent_auth_token_resolve_error] to attribute 119-burst pattern
-   to a normalize_all_names branch before promoting P3-a to hard-error. *)
+   | name_ambiguous | ephemeral_suffix_rejected). Non-ok outcomes reject the
+   join at the fail-closed gate. Cross-reference with
+   [metric_silent_auth_token_resolve_error] for auth/name drift diagnosis. *)
 let metric_coord_join_normalize_outcome =
   "masc_coord_join_normalize_outcome_total"
 
@@ -1316,13 +1316,12 @@ let init () =
      fallback_used (true | false)."
     Counter;
   add metric_coord_join_normalize_outcome
-    "Total Coord.join calls preflighted by Keeper_identity.normalize_all_names \
+    "Total Coord.join identity normalizations by Keeper_identity.normalize_all_names \
      (RFC P3-a). Labels: outcome (ok | empty_input | persona_not_found | \
      credential_missing | name_ambiguous | ephemeral_suffix_rejected). \
-     Logging-only mode: non-ok outcomes still proceed with the original \
-     agent_name; counter classifies bootstrap-window silent-fallback patterns \
-     (paired with masc_silent_auth_token_resolve_error_total) before the \
-     mode is promoted to hard-error in a follow-up PR."
+     Non-ok outcomes reject masc_join at the fail-closed identity gate; pair \
+     with masc_silent_auth_token_resolve_error_total for auth/name drift \
+     diagnosis."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -511,14 +511,13 @@ val metric_empty_tool_universe_observed : string
     [fallback_used] = "true" | "false". *)
 
 val metric_coord_join_normalize_outcome : string
-(** RFC P3-a (2026-04-26): Coord.join preflighted by
-    [Keeper_identity.normalize_all_names] in logging-only mode.
+(** RFC P3-a (2026-04-26): Coord.join identity normalization by
+    [Keeper_identity.normalize_all_names].
     Labels: [outcome] = "ok" | "empty_input" | "persona_not_found"
     | "credential_missing" | "name_ambiguous" | "ephemeral_suffix_rejected".
-    Non-ok outcomes still proceed with the original agent_name; the
-    counter classifies bootstrap-window silent-fallback patterns
-    (cross-reference [metric_silent_auth_token_resolve_error]) before
-    the mode is promoted to hard-error in a follow-up PR. *)
+    Non-ok outcomes reject [masc_join] at the fail-closed identity gate.
+    Cross-reference [metric_silent_auth_token_resolve_error] for auth/name
+    drift diagnosis. *)
 
 
 (** {1 Transport metrics} *)

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -229,13 +229,15 @@ let handle_join (ctx : context) : tool_result option =
       Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
         ~labels:[ ("outcome", outcome) ] ();
       Log.Misc.warn
-        "[sid=%s] [fail-closed:coord_join_normalize] agent=%s outcome=%s detail=%s          - join rejected"
+        "[sid=%s] [fail-closed:coord_join_normalize] agent=%s outcome=%s \
+         detail=%s - join rejected"
         sid agent_name outcome
         (Keeper_identity.show_validation_error err);
       Some
         ( false,
           Printf.sprintf
-            "masc_join rejected: identity validation failed for '%s' — %s.              Ensure the persona and credential files exist for this agent."
+            "masc_join rejected: identity validation failed for '%s' — %s. \
+             Ensure the persona and credential files exist for this agent."
             agent_name (Keeper_identity.show_validation_error err) )
 
 (** masc_leave — leave a MASC room *)


### PR DESCRIPTION
## Summary

Follow-up to #12586 after it merged before review cleanup landed.

- updates `metric_coord_join_normalize_outcome` comments/help text from logging-only/fail-open wording to the new fail-closed `masc_join` behavior
- cleans the `masc_join` rejection log and user-facing message formatting so wrapped OCaml string literals do not leave large spacing in operator output

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] `scripts/dune-local.sh build ./lib/masc_mcp.cmxa ./test/test_coord_join_fail_closed.exe`
- [x] `env MASC_BASE_PATH=/tmp/masc-pr-coord-metric-docs MASC_TEST_ALLOW_HOME_BASE_PATH=1 ./_build/default/test/test_coord_join_fail_closed.exe`

Note: direct test execution materializes `config/cascade.json` locally; that side effect was restored and is not part of this PR.
