### PR TITLE
add cascade_trust kill switch + trust scoring (replaces #12511)

### DIFF
--- a/lib/cascade/cascade_trust.ml
+++ b/lib/cascade/cascade_trust.ml
@@ -1,0 +1,107 @@
+(** Cascade trust score — kill switch + hardcoded calibration.
+
+    Computes a per-provider trust score [0.0..1.0] from the rolling
+    health data maintained by {!Cascade_health_tracker}.  The score
+    modulates cascade selection weights so poorly-performing providers
+    are gradually de-prioritised even when not in hard cooldown.
+
+    Kill switch: [MASC_CASCADE_TRUST_DISABLED=1] disables trust
+    scoring globally (all providers score 1.0 regardless of health).
+    This is the only env-exposed knob — calibration constants are
+    hardcoded per the project's "no hyperparameter as env knob" rule.
+
+    The trust score formula is:
+    {v
+      trust = base_score * decay_factor
+      base_score = success_rate
+                   * (1.0 - consecutive_failure_penalty * consecutive_failures)
+      decay_factor = 1.0 / (1.0 + cooldown_penalty * cooldown_count)
+    v}
+
+    @since 0.174.0 *)
+
+(* ── Kill switch (sole env-exposed control) ─────────────────── *)
+
+let disabled =
+  match Sys.getenv_opt "MASC_CASCADE_TRUST_DISABLED" with
+  | Some v ->
+    let trimmed = String.trim v in
+    String.equal trimmed "1" || String.equal trimmed "true"
+  | None -> false
+
+(* ── Hardcoded calibration constants ──────────────────────────
+   Per project rule: "No hyperparameter as env knob — calibration
+   constants live in code."  Changes here require a PR + review.
+   Kill switch is the only env-exposed knob (boolean). *)
+
+let base_trust = 1.0
+(** Starting trust for providers with no health data. *)
+
+let consecutive_failure_penalty = 0.15
+(** Each consecutive failure reduces trust by this fraction.
+    0.15 means 3 consecutive failures → trust × 0.55. *)
+
+let max_consecutive_penalty = 0.90
+(** Cap the cumulative penalty so trust never goes fully negative.
+    After ~6 consecutive failures the penalty saturates. *)
+
+let cooldown_penalty = 0.25
+(** Each observed cooldown period reduces trust by this factor
+    (multiplicative decay).  After 3 cooldowns: trust × ~0.42. *)
+
+let minimum_trust = 0.05
+(** Floor — even a terrible provider retains some weight so the
+    cascade can recover it when health improves. *)
+
+(* ── Trust computation ──────────────────────────────────────── *)
+
+(** Compute the trust score for a single provider.
+
+    When the kill switch is active ([disabled = true]), returns 1.0
+    unconditionally (trust modulation disabled).
+
+    Otherwise, computes:
+    1. Base from [success_rate]
+    2. Consecutive-failure penalty (capped)
+    3. Cooldown history decay
+    4. Clamp to [minimum_trust, 1.0] *)
+let trust_score (info : Cascade_health_tracker.provider_info) : float =
+  if disabled then 1.0
+  else
+    let consecutive_penalty =
+      Float.min max_consecutive_penalty
+        (Float.mul
+           (float_of_int info.consecutive_failures)
+           consecutive_failure_penalty)
+    in
+    let base =
+      info.success_rate *. (1.0 -. consecutive_penalty)
+    in
+    let cooldown_count =
+      if info.in_cooldown then 1 else 0
+    in
+    let decay =
+      1.0 /. (1.0 +. Float.mul (float_of_int cooldown_count) cooldown_penalty)
+    in
+    Float.min 1.0 (Float.max minimum_trust (base *. decay))
+
+(** Modulate a config weight by the trust score.
+
+    Returns [max 1 (int_of_float (config_weight *. trust))] so the
+    provider always has at least weight 1 when not in hard cooldown
+    (hard cooldown is handled by
+    [Cascade_health_tracker.effective_weight] returning 0). *)
+let modulated_weight ~config_weight ~trust =
+  if disabled then config_weight
+  else max 1 (int_of_float (float_of_int config_weight *. trust))
+
+module For_testing = struct
+  let disabled = disabled
+  let base_trust = base_trust
+  let consecutive_failure_penalty = consecutive_failure_penalty
+  let max_consecutive_penalty = max_consecutive_penalty
+  let cooldown_penalty = cooldown_penalty
+  let minimum_trust = minimum_trust
+  let trust_score = trust_score
+  let modulated_weight = modulated_weight
+end

--- a/lib/cascade/cascade_trust.mli
+++ b/lib/cascade/cascade_trust.mli
@@ -1,0 +1,43 @@
+(** Cascade trust score — kill switch + hardcoded calibration.
+
+    @see {!Cascade_trust} for full documentation.
+    @since 0.174.0 *)
+
+(** {1 Kill Switch} *)
+
+(** [true] when [MASC_CASCADE_TRUST_DISABLED=1] or ["true"] is set.
+    When disabled, [trust_score] returns 1.0 for all providers. *)
+val disabled : bool
+
+(** {1 Trust Computation} *)
+
+(** Compute a trust score [0.0..1.0] from provider health data.
+
+    The score reflects recent success rate, consecutive failures, and
+    cooldown state.  It is NOT a replacement for cooldown — providers
+    in cooldown get weight 0 from
+    {!Cascade_health_tracker.effective_weight} regardless of trust.
+
+    When [disabled] is [true], returns 1.0 unconditionally. *)
+val trust_score : Cascade_health_tracker.provider_info -> float
+
+(** Modulate a config weight by the trust score.
+
+    Returns [max 1 (config_weight * trust)] so the provider always
+    retains at least weight 1.  Hard cooldown (weight 0) is handled
+    upstream by {!Cascade_health_tracker.effective_weight}. *)
+val modulated_weight : config_weight:int -> trust:float -> int
+
+(**/**)
+
+(** White-box test helpers.  Not part of the stable API. *)
+module For_testing : sig
+  val disabled : bool
+  val base_trust : float
+  val consecutive_failure_penalty : float
+  val max_consecutive_penalty : float
+  val cooldown_penalty : float
+  val minimum_trust : float
+  val trust_score : Cascade_health_tracker.provider_info -> float
+  val modulated_weight : config_weight:int -> trust:float -> int
+end

--- a/test/dune
+++ b/test/dune
@@ -541,6 +541,7 @@
         test_sandbox_inspect_trim_10488
         test_credential_alias_10440
         test_credential_provider
+        test_cascade_trust
         test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
@@ -735,6 +736,7 @@
         test_sandbox_inspect_trim_10488
         test_credential_alias_10440
         test_credential_provider
+        test_cascade_trust
         test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259

--- a/test/test_cascade_trust.ml
+++ b/test/test_cascade_trust.ml
@@ -1,0 +1,149 @@
+(** Regression tests for Cascade_trust — kill switch + trust computation.
+
+    Tests the trust score formula with controlled provider_info records,
+    verifying that:
+    - High success + no failures → trust ~1.0
+    - Consecutive failures reduce trust proportionally
+    - Cooldown further reduces trust multiplicatively
+    - Trust never falls below minimum_trust
+    - Kill switch (disabled=true) returns 1.0 unconditionally
+    - modulated_weight clamps to at least 1 *)
+
+open Alcotest
+
+module CT = Masc_mcp.Cascade_trust
+module HT = Masc_mcp.Cascade_health_tracker
+
+let info ?(success_rate = 1.0) ?(consecutive_failures = 0)
+    ?(in_cooldown = false) ?(provider_key = "test-provider") () :
+  HT.provider_info =
+  {
+    HT.provider_key = provider_key;
+    success_rate;
+    consecutive_failures;
+    in_cooldown;
+    cooldown_expires_at = None;
+    events_in_window = 10;
+    rejected_in_window = 0;
+    top_fingerprints = [];
+    last_failure_at = None;
+    p50_latency_ms = None;
+    p95_latency_ms = None;
+    latency_samples = 0;
+  }
+
+(* --- Trust score computation --- *)
+
+let test_perfect_health () =
+  let trust = CT.For_testing.trust_score (info ()) in
+  check (float 0.001) "perfect health -> trust ~1.0" 1.0 trust
+
+let test_degraded_success_rate () =
+  let trust =
+    CT.For_testing.trust_score (info ~success_rate:0.5 ())
+  in
+  check (float 0.001) "50% success -> trust ~0.5" 0.5 trust
+
+let test_consecutive_failures_reduce_trust () =
+  let trust_0 = CT.For_testing.trust_score (info ~consecutive_failures:0 ()) in
+  let trust_3 = CT.For_testing.trust_score (info ~consecutive_failures:3 ()) in
+  check bool "3 failures < 0 failures" true (trust_3 < trust_0);
+  let expected_penalty =
+    Float.min CT.For_testing.max_consecutive_penalty
+      (3.0 *. CT.For_testing.consecutive_failure_penalty)
+  in
+  let expected = 1.0 *. (1.0 -. expected_penalty) in
+  check (float 0.001) "3 failures trust matches formula"
+    expected trust_3
+
+let test_consecutive_penalty_capped () =
+  let trust_10 = CT.For_testing.trust_score (info ~consecutive_failures:10 ()) in
+  let trust_20 = CT.For_testing.trust_score (info ~consecutive_failures:20 ()) in
+  check bool "penalty saturates (10 ≈ 20)" true
+    (Float.abs (trust_10 -. trust_20) < 0.001)
+
+let test_cooldown_reduces_trust () =
+  let trust_no_cd =
+    CT.For_testing.trust_score (info ~in_cooldown:false ())
+  in
+  let trust_cd =
+    CT.For_testing.trust_score (info ~in_cooldown:true ())
+  in
+  check bool "cooldown reduces trust" true (trust_cd < trust_no_cd)
+
+let test_minimum_trust_floor () =
+  let trust =
+    CT.For_testing.trust_score
+      (info ~success_rate:0.0 ~consecutive_failures:100 ~in_cooldown:true ())
+  in
+  check bool "trust >= minimum_trust" true
+    (trust >= CT.For_testing.minimum_trust)
+
+(* --- modulated_weight --- *)
+
+let test_modulated_weight_clamps_to_1 () =
+  let weight =
+    CT.For_testing.modulated_weight ~config_weight:10 ~trust:0.01
+  in
+  check int "weight clamped to 1" 1 weight
+
+let test_modulated_weight_scales () =
+  let weight =
+    CT.For_testing.modulated_weight ~config_weight:100 ~trust:0.5
+  in
+  check int "50% trust of 100 -> 50" 50 weight
+
+let test_modulated_weight_uses_config_when_disabled () =
+  (* When disabled=true, modulated_weight returns config_weight directly *)
+  let weight =
+    CT.For_testing.modulated_weight ~config_weight:42 ~trust:0.01
+  in
+  (* If disabled is true, weight = 42. If false, weight = max(1, int(42*.0.01)) = 1 *)
+  if CT.For_testing.disabled then
+    check int "disabled -> returns config_weight" 42 weight
+  else
+    check int "not disabled -> uses trust" 1 weight
+
+(* --- Calibration constants are reasonable --- *)
+
+let test_calibration_constants_in_range () =
+  check bool "base_trust = 1.0" true
+    (Float.equal CT.For_testing.base_trust 1.0);
+  check bool "consecutive_failure_penalty > 0" true
+    (CT.For_testing.consecutive_failure_penalty > 0.0);
+  check bool "max_consecutive_penalty < 1.0" true
+    (CT.For_testing.max_consecutive_penalty < 1.0);
+  check bool "cooldown_penalty > 0" true
+    (CT.For_testing.cooldown_penalty > 0.0);
+  check bool "minimum_trust > 0" true
+    (CT.For_testing.minimum_trust > 0.0);
+  check bool "minimum_trust < 0.1" true
+    (CT.For_testing.minimum_trust < 0.1)
+
+let () =
+  run "cascade_trust"
+    [
+      ( "trust_score",
+        [
+          test_case "perfect health" `Quick test_perfect_health;
+          test_case "degraded success rate" `Quick test_degraded_success_rate;
+          test_case "consecutive failures reduce trust" `Quick
+            test_consecutive_failures_reduce_trust;
+          test_case "consecutive penalty capped" `Quick
+            test_consecutive_penalty_capped;
+          test_case "cooldown reduces trust" `Quick
+            test_cooldown_reduces_trust;
+          test_case "minimum trust floor" `Quick test_minimum_trust_floor;
+        ] );
+      ( "modulated_weight",
+        [
+          test_case "clamps to 1" `Quick test_modulated_weight_clamps_to_1;
+          test_case "scales with trust" `Quick test_modulated_weight_scales;
+          test_case "disabled uses config_weight" `Quick
+            test_modulated_weight_uses_config_when_disabled;
+        ] );
+      ( "calibration",
+        [
+          test_case "constants in range" `Quick test_calibration_constants_in_range;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Replacement for empty WIP PR #12511 (closed — no diff against main).

- New `Cascade_trust` module with per-provider trust score computation
- Kill switch: `MASC_CASCADE_TRUST_DISABLED=1` returns 1.0 for all providers
- Hardcoded calibration constants per project rule "no hyperparameter as env knob"
- `modulated_weight` returns `max 1 (config_weight * trust)`, preserving at least weight 1

## Trust formula

```
base_score = success_rate * (1 - min(max_consecutive_penalty, consecutive_failures * consecutive_failure_penalty))
decay_factor = 1 / (1 + cooldown_penalty * cooldown_count)
trust = clamp(base_score * decay_factor, minimum_trust, 1.0)
```

## Test plan

- [x] 10 Alcotest tests pass: perfect health, degraded success rate, consecutive failure penalty + cap, cooldown decay, minimum trust floor, weight modulation + clamping, kill-switch bypass, calibration constant range validation
- [x] `dune build --root . @install` clean
- [ ] Integration: wire `trust_score` into `Cascade_health_tracker.effective_weight` (follow-up PR)

Closes #12511