### PR TITLE
fix(keeper): fallback from empty auto goal claim scope

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -51,15 +51,29 @@ let parse_task_contract_arg args =
 ;;
 
 let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
-    ?excluded_count () =
+    ?excluded_count ?effective_mode ?effective_goal_ids ?fallback_reason () =
   let scoped = meta.active_goal_ids <> [] in
+  let mode =
+    match effective_mode with
+    | Some mode -> mode
+    | None -> if scoped then "active_goal_ids" else "all_tasks"
+  in
+  let effective_goal_ids =
+    match effective_goal_ids with
+    | Some goal_ids -> goal_ids
+    | None -> meta.active_goal_ids
+  in
   let fields =
     [
-      ("mode", `String (if scoped then "active_goal_ids" else "all_tasks"));
+      ("mode", `String mode);
       ("scoped", `Bool scoped);
       ( "active_goal_ids",
         `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids)
       );
+      ( "effective_goal_ids",
+        `List (List.map (fun goal_id -> `String goal_id) effective_goal_ids)
+      );
+      ("fallback_reason", Json_util.string_opt_to_json fallback_reason);
       ("matched_goal_id", Json_util.string_opt_to_json matched_goal_id);
     ]
   in
@@ -69,6 +83,65 @@ let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
     | None -> fields
   in
   `Assoc fields
+;;
+
+type claim_goal_scope = {
+  task_filter : Types.task -> bool;
+  mode : string;
+  effective_goal_ids : string list;
+  fallback_reason : string option;
+}
+
+let goal_title_matches_keeper_purpose ~(meta : keeper_meta) goal =
+  String.equal goal.Goal_store.title
+    (Keeper_goal_repair.goal_title_of_purpose meta.goal)
+;;
+
+let active_goal_ids_are_auto_keeper_goals config ~(meta : keeper_meta) goal_ids =
+  goal_ids <> []
+  && List.for_all
+       (fun goal_id ->
+         match Goal_store.get_goal config ~goal_id with
+         | Some goal -> goal_title_matches_keeper_purpose ~meta goal
+         | None -> false)
+       goal_ids
+;;
+
+let active_goal_ids_have_claim_pool_task config goal_ids =
+  Coord.get_tasks_safe config
+  |> List.exists (fun task ->
+       Coord.task_is_claim_pool_candidate task
+       && Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task)
+;;
+
+let resolve_claim_goal_scope ~(config : Coord.config) ~(meta : keeper_meta) =
+  match meta.active_goal_ids with
+  | [] ->
+    { task_filter = (fun (_task : Types.task) -> true);
+      mode = "all_tasks";
+      effective_goal_ids = [];
+      fallback_reason = None;
+    }
+  | goal_ids ->
+    let scoped_filter task =
+      Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task
+    in
+    if active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
+       && not (active_goal_ids_have_claim_pool_task config goal_ids)
+    then
+      { task_filter = (fun (_task : Types.task) -> true);
+        mode = "auto_goal_fallback_all_tasks";
+        effective_goal_ids = [];
+        fallback_reason =
+          Some
+            "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks";
+      }
+    else
+      { task_filter = scoped_filter;
+        mode = "active_goal_ids";
+        effective_goal_ids = goal_ids;
+        fallback_reason = None;
+      }
 ;;
 
 let find_task_goal_id config task_id =
@@ -223,16 +296,11 @@ let handle_keeper_task_tool
                     "goal_id", Json_util.string_opt_to_json goal_id;
                   ])))
   | "keeper_task_claim" ->
-    let task_filter =
-      match meta.active_goal_ids with
-      | [] -> fun (_task : Types.task) -> true
-      | goal_ids ->
-        fun task -> Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task
-    in
+    let claim_goal_scope = resolve_claim_goal_scope ~config ~meta in
     let agent_tool_names = Keeper_tool_policy.keeper_allowed_tool_names meta in
     let result =
       Coord.claim_next_r config ~agent_name:meta.agent_name ~agent_tool_names
-        ~task_filter ()
+        ~task_filter:claim_goal_scope.task_filter ()
     in
     let auto_started_ok = ref false in
     (match result with
@@ -282,7 +350,10 @@ let handle_keeper_task_tool
       match result with
       | Coord.Claim_next_claimed { task_id; title; priority; released_task_id; _ } ->
           let matched_goal_id = find_task_goal_id config task_id in
-          ( active_goal_scope_json ~meta ?matched_goal_id ()
+          ( active_goal_scope_json ~meta ?matched_goal_id
+              ~effective_mode:claim_goal_scope.mode
+              ~effective_goal_ids:claim_goal_scope.effective_goal_ids
+              ?fallback_reason:claim_goal_scope.fallback_reason ()
           , [
               ( "claim_observation",
                 Tool_task.build_claim_observation_payload
@@ -301,9 +372,16 @@ let handle_keeper_task_tool
                   ] );
             ] )
       | Coord.Claim_next_no_eligible { excluded_count } ->
-          (active_goal_scope_json ~meta ~excluded_count (), [])
+          ( active_goal_scope_json ~meta ~excluded_count
+              ~effective_mode:claim_goal_scope.mode
+              ~effective_goal_ids:claim_goal_scope.effective_goal_ids
+              ?fallback_reason:claim_goal_scope.fallback_reason ()
+          , [] )
       | Coord.Claim_next_no_unclaimed | Coord.Claim_next_error _ ->
-          (active_goal_scope_json ~meta (), [])
+          ( active_goal_scope_json ~meta ~effective_mode:claim_goal_scope.mode
+              ~effective_goal_ids:claim_goal_scope.effective_goal_ids
+              ?fallback_reason:claim_goal_scope.fallback_reason ()
+          , [] )
     in
     Yojson.Safe.to_string
       (`Assoc

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -330,6 +330,52 @@ let test_claim_respects_active_goal_ids () =
           json |> member "claimed_task" |> member "goal_id" |> to_string)
     | None -> fail "expected a claimed task")
 
+let test_claim_falls_back_from_empty_auto_goal_scope () =
+  with_room (fun config ->
+    let meta = make_test_meta ~name:"executor" () in
+    let auto_goal, _ =
+      match
+        Goal_store.upsert_goal config
+          ~title:(Keeper_goal_repair.goal_title_of_purpose meta.goal)
+          ()
+      with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let product_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Product goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta = { meta with active_goal_ids = [ auto_goal.id ] } in
+    let _ =
+      Coord_task.add_task ~goal_id:product_goal.id config
+        ~title:"Product task" ~priority:1 ~description:"desc"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    let claimed_task =
+      Coord.get_tasks_raw config
+      |> List.find_opt (fun (task : Types.task) ->
+           Types.task_assignee_of_status task.task_status = Some meta.agent_name)
+    in
+    match claimed_task with
+    | Some task ->
+      check string "claimed product task" "Product task" task.title;
+      let scope = Yojson.Safe.Util.member "claim_scope" json in
+      check string "claim scope mode" "auto_goal_fallback_all_tasks"
+        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
+      check int "effective goal ids cleared" 0
+        Yojson.Safe.Util.(
+          scope |> member "effective_goal_ids" |> to_list |> List.length);
+      check string "claim scope matched product goal" product_goal.id
+        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string);
+      check bool "fallback reason present" true
+        Yojson.Safe.Util.(
+          scope |> member "fallback_reason" |> to_string |> fun s ->
+          String.length s > 0)
+    | None -> fail "expected fallback to claim a product task")
+
 let test_claim_skips_required_tools_without_access () =
   with_room (fun config ->
     let meta = make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ] in
@@ -791,6 +837,8 @@ let () =
       test_case "claim empty room" `Quick test_claim_empty_room;
       test_case "claim respects active_goal_ids" `Quick
         test_claim_respects_active_goal_ids;
+      test_case "claim falls back from empty auto goal scope" `Quick
+        test_claim_falls_back_from_empty_auto_goal_scope;
       test_case "claim skips tasks requiring missing tools" `Quick
         test_claim_skips_required_tools_without_access;
       test_case "claim allows tasks requiring available tools" `Quick


### PR DESCRIPTION
## Summary
- Add a claim-scope resolver for keeper_task_claim.
- Preserve explicit active_goal_ids, but fail open to all claimable tasks when the only active scope is an auto-generated keeper purpose goal with no claimable linked tasks.
- Include effective_goal_ids and fallback_reason in claim_scope JSON so operators can see why the claim was broadened.
- Add regression coverage for an executor-style auto goal claiming a product-goal task.

## Why this matters
Live keepers had code/work tools, but no work evidence: executor and issue_king were stuck on personal auto goals such as goal-executor / goal-issue-king while the backlog was tagged with product goals like goal-keeper-clarity and goal-masc-product. keeper_task_claim returned eligible=0 / excluded=N, so keepers could report blockage instead of producing worktrees or PRs.

This keeps intentional operator scoping strict, while preventing auto-generated identity goals from deadlocking delivery keepers.

## Verification
- scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (27 tests pass)
- git diff --check