### PR TITLE
add K2 decisions/memory log telemetry endpoints (replaces #12528)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1818,6 +1818,8 @@ let keeper_cost_aggregates_json
     ("generated_at", `Float now_ts);
   ]
 
+let k2_feed_limit limit = max 1 (min 200 limit)
+
 (** Read per-keeper [.decisions.jsonl] files and return a unified,
     time-sorted stream of recent events (turn telemetry, tool_exec,
     memory_search, etc.).  Each event is normalized to a flat record so
@@ -1829,6 +1831,7 @@ let keeper_decisions_json
     ?(limit = 200)
     ()
   : Yojson.Safe.t =
+  let limit = k2_feed_limit limit in
   let per_keeper_limit = limit * 2 in
   let all_events =
     List.concat_map (fun (m : Keeper_types.keeper_meta) ->
@@ -1911,6 +1914,181 @@ let keeper_decisions_json
   in
   `Assoc [
     ("events", `List items);
+    ("limit", `Int limit);
+    ("generated_at", `Float (Unix.gettimeofday ()));
+  ]
+
+let k2_iso8601_of_unix ts_unix =
+  if ts_unix <= 0.0 then ""
+  else
+    let t = Unix.gmtime ts_unix in
+    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+      (t.Unix.tm_year + 1900) (t.Unix.tm_mon + 1) t.Unix.tm_mday
+      t.Unix.tm_hour t.Unix.tm_min t.Unix.tm_sec
+
+let k2_stable_id ~prefix ~keeper_name ~ts_unix ~raw =
+  let ms = Int64.of_float (ts_unix *. 1000.0) in
+  let hash = Digest.to_hex (Digest.string raw) in
+  Printf.sprintf "%s-%s-%016Lx-%s"
+    prefix keeper_name ms (String.sub hash 0 8)
+
+let memory_kind_for_log (kind : string) : string =
+  match String.lowercase_ascii (String.trim kind) with
+  | "progress" -> "episode"
+  | "goal" | "next" | "decision" -> "plan"
+  | _ -> "fact"
+
+let keeper_decisions_log_json
+    ~(config : Coord.config)
+    ~(keepers : Keeper_types.keeper_meta list)
+    ?(limit = 200)
+    ()
+  : Yojson.Safe.t =
+  let limit = k2_feed_limit limit in
+  let per_keeper_limit = limit * 2 in
+  let all_events =
+    List.concat_map (fun (m : Keeper_types.keeper_meta) ->
+      let path = Keeper_types.keeper_decision_log_path config m.name in
+      if not (Fs_compat.file_exists path) then []
+      else
+        let lines =
+          Keeper_memory.read_file_tail_lines path
+            ~max_bytes:500_000 ~max_lines:per_keeper_limit
+        in
+        List.filter_map (fun line ->
+          try
+            let json = Yojson.Safe.from_string line in
+            let str key =
+              match Yojson.Safe.Util.member key json with
+              | `String s -> s
+              | _ -> ""
+            in
+            let ts_unix =
+              match Yojson.Safe.Util.member "ts_unix" json with
+              | `Float f -> f
+              | `Int i -> float_of_int i
+              | _ -> 0.0
+            in
+            let keeper_name =
+              let raw = str "keeper_name" in
+              if raw = "" then m.name else raw
+            in
+            let id =
+              let raw = str "id" in
+              if raw <> "" then raw
+              else k2_stable_id ~prefix:"dec" ~keeper_name ~ts_unix ~raw:line
+            in
+            let ts =
+              let raw = str "ts" in
+              if raw <> "" then raw else k2_iso8601_of_unix ts_unix
+            in
+            let decision_type =
+              let sa = str "speech_act" in
+              if sa <> "" then sa
+              else
+                let outcome = str "outcome" in
+                if outcome <> "" then outcome else "turn"
+            in
+            let belief_summary = str "belief_summary" in
+            let current_intention = str "current_intention" in
+            let blocker = str "blocker" in
+            let channel = str "channel" in
+            let summary_parts =
+              List.filter (fun s -> s <> "")
+                [ decision_type
+                ; (if channel <> "" then "via " ^ channel else "")
+                ; (if current_intention <> "" then "\xe2\x86\x92 " ^ current_intention else "")
+                ; (if blocker <> "" then "blocked: " ^ blocker else "")
+                ; (if belief_summary <> "" then belief_summary else "")
+                ]
+            in
+            let summary = String.concat " \xc2\xb7 " summary_parts in
+            let evidence_refs =
+              let refs = json_string_list_member "evidence_refs" json in
+              let refs =
+                if refs <> [] then refs
+                else json_string_list_member "raw_evidence_refs" json
+              in
+              List.map (fun value -> `String value) refs
+            in
+            Some (ts_unix, `Assoc [
+              ("id", `String id);
+              ("ts", `String ts);
+              ("ts_unix", `Float ts_unix);
+              ("keeper", `String keeper_name);
+              ("decision_type", `String decision_type);
+              ("summary", `String summary);
+              ("evidence_refs", `List evidence_refs);
+            ])
+          with
+          | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+        ) lines
+    ) keepers
+  in
+  let sorted =
+    List.sort (fun (ta, _) (tb, _) -> compare tb ta) all_events
+  in
+  let rec take n = function
+    | [] -> []
+    | _ when n <= 0 -> []
+    | x :: xs -> x :: take (n - 1) xs
+  in
+  let items = List.map snd (take limit sorted) in
+  `Assoc [
+    ("events", `List items);
+    ("limit", `Int limit);
+    ("generated_at", `Float (Unix.gettimeofday ()));
+  ]
+
+let keeper_memory_log_json
+    ~(config : Coord.config)
+    ~(keepers : Keeper_types.keeper_meta list)
+    ?(limit = 200)
+    ()
+  : Yojson.Safe.t =
+  let limit = k2_feed_limit limit in
+  let per_keeper_limit = limit * 2 in
+  let all_entries =
+    List.concat_map (fun (m : Keeper_types.keeper_meta) ->
+      let path = Keeper_types.keeper_memory_bank_path config m.name in
+      if not (Fs_compat.file_exists path) then []
+      else
+        let lines =
+          Keeper_memory.read_file_tail_lines path
+            ~max_bytes:500_000 ~max_lines:per_keeper_limit
+        in
+        List.filter_map (fun line ->
+          match Keeper_memory.parse_memory_bank_row line with
+          | None -> None
+          | Some (row : Keeper_memory.keeper_memory_row_raw) ->
+              let kind = memory_kind_for_log row.kind in
+              let ts = k2_iso8601_of_unix row.ts_unix in
+              let id =
+                k2_stable_id ~prefix:"mem" ~keeper_name:m.name
+                  ~ts_unix:row.ts_unix ~raw:line
+              in
+              Some (row.ts_unix, `Assoc [
+                ("id", `String id);
+                ("ts", `String ts);
+                ("ts_unix", `Float row.ts_unix);
+                ("keeper", `String m.name);
+                ("kind", `String kind);
+                ("summary", `String row.text);
+              ])
+        ) lines
+    ) keepers
+  in
+  let sorted =
+    List.sort (fun (ta, _) (tb, _) -> compare tb ta) all_entries
+  in
+  let rec take n = function
+    | [] -> []
+    | _ when n <= 0 -> []
+    | x :: xs -> x :: take (n - 1) xs
+  in
+  let items = List.map snd (take limit sorted) in
+  `Assoc [
+    ("entries", `List items);
     ("limit", `Int limit);
     ("generated_at", `Float (Unix.gettimeofday ()));
   ]

--- a/lib/dashboard/dashboard_http_keeper.mli
+++ b/lib/dashboard/dashboard_http_keeper.mli
@@ -90,6 +90,22 @@ val keeper_decisions_json :
   Yojson.Safe.t
 (** Renders a recent unified keeper decision/event stream. *)
 
+val keeper_decisions_log_json :
+  config:Coord.config ->
+  keepers:Keeper_types.keeper_meta list ->
+  ?limit:int ->
+  unit ->
+  Yojson.Safe.t
+(** Renders the K2 cross-keeper decision log feed. *)
+
+val keeper_memory_log_json :
+  config:Coord.config ->
+  keepers:Keeper_types.keeper_meta list ->
+  ?limit:int ->
+  unit ->
+  Yojson.Safe.t
+(** Renders the K2 cross-keeper memory-bank feed. *)
+
 (** {1 Per-keeper config snapshot} *)
 
 val keeper_config_json :

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -4,6 +4,9 @@ open Server_auth
 
 module Http = Http_server_eio
 
+let dashboard_feed_limit req =
+  int_query_param req "limit" ~default:200 |> clamp ~min_v:1 ~max_v:200
+
 let add_routes ~sw router =
   router
   |> Http.Router.get "/api/v1/providers" (fun request reqd ->
@@ -118,7 +121,7 @@ let add_routes ~sw router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let limit = int_query_param req "limit" ~default:200 in
+         let limit = dashboard_feed_limit req in
          let config = state.Mcp_server.room_config in
          let keeper_names = Keeper_types.keeper_names config in
          let keepers =
@@ -130,6 +133,44 @@ let add_routes ~sw router =
          in
          let json =
            Dashboard_http_keeper.keeper_decisions_json
+             ~config ~keepers ~limit ()
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/keeper-decisions-log" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let limit = dashboard_feed_limit req in
+         let config = state.Mcp_server.room_config in
+         let keeper_names = Keeper_types.keeper_names config in
+         let keepers =
+           List.filter_map (fun name ->
+             match Keeper_types.read_meta config name with
+             | Ok (Some m) -> Some m
+             | _ -> None
+           ) keeper_names
+         in
+         let json =
+           Dashboard_http_keeper.keeper_decisions_log_json
+             ~config ~keepers ~limit ()
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/keeper-memory-log" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let limit = dashboard_feed_limit req in
+         let config = state.Mcp_server.room_config in
+         let keeper_names = Keeper_types.keeper_names config in
+         let keepers =
+           List.filter_map (fun name ->
+             match Keeper_types.read_meta config name with
+             | Ok (Some m) -> Some m
+             | _ -> None
+           ) keeper_names
+         in
+         let json =
+           Dashboard_http_keeper.keeper_memory_log_json
              ~config ~keepers ~limit ()
          in
          Http.Response.json ~compress:true ~request:req

--- a/test/dune
+++ b/test/dune
@@ -543,6 +543,7 @@
         test_credential_alias_10440
         test_credential_provider
         test_cascade_trust
+        test_dashboard_k2_feeds
         test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
@@ -739,6 +740,7 @@
         test_credential_alias_10440
         test_credential_provider
         test_cascade_trust
+        test_dashboard_k2_feeds
         test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259

--- a/test/test_dashboard_k2_feeds.ml
+++ b/test/test_dashboard_k2_feeds.ml
@@ -1,0 +1,281 @@
+(** Tests for K2 decisions and memory log telemetry feeds.
+
+    Covers:
+    - evidence_refs populated from real reference lists only (not prose)
+    - Limit clamping at both producer and route boundary
+    - Memory log IDs are collision-resistant for same-timestamp rows
+    - JSON shape matches spec:
+      {id, ts, ts_unix, keeper, decision_type, summary, evidence_refs[]}
+      {id, ts, ts_unix, keeper, kind, summary} *)
+
+open Alcotest
+module Coord = Masc_mcp.Coord
+module Dash = Masc_mcp.Dashboard_http_keeper
+module Keeper_config = Masc_mcp.Keeper_config
+module Keeper_types = Masc_mcp.Keeper_types
+module Json = Yojson.Safe.Util
+
+let test_counter = ref 0
+
+let tmpdir prefix =
+  incr test_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "%s_%d_%d_%d"
+         prefix
+         (Unix.getpid ())
+         !test_counter
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+;;
+
+let with_config f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = tmpdir "dashboard_k2_feeds" in
+  let config = Coord.default_config base_dir in
+  f config
+;;
+
+let keeper_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String name
+          ; "trace_id", `String ("trace-" ^ name)
+          ; "cascade_name", `String Keeper_config.default_cascade_name
+          ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+;;
+
+let append_jsonl path json =
+  Keeper_types.mkdir_p (Filename.dirname path);
+  Masc_mcp.Keeper_types_support.append_jsonl_line path json
+;;
+
+let strings json = json |> Json.to_list |> List.map Json.to_string
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if idx + needle_len > haystack_len
+    then false
+    else if String.equal (String.sub haystack idx needle_len) needle
+    then true
+    else loop (idx + 1)
+  in
+  String.equal needle "" || loop 0
+;;
+
+(* --- Decision log tests --- *)
+
+let test_decisions_log_evidence_refs_are_real_refs () =
+  with_config
+  @@ fun config ->
+  let meta = keeper_meta "k2-decisions" in
+  let path = Keeper_types.keeper_decision_log_path config meta.name in
+  append_jsonl
+    path
+    (`Assoc
+        [ "ts_unix", `Float 1_000.0
+        ; "keeper_name", `String meta.name
+        ; "speech_act", `String "inform"
+        ; "belief_summary", `String "prose belief is not an evidence ref"
+        ]);
+  append_jsonl
+    path
+    (`Assoc
+        [ "ts_unix", `Float 1_001.0
+        ; "keeper_name", `String meta.name
+        ; "speech_act", `String "request_help"
+        ; "belief_summary", `String "new prose summary"
+        ; ( "evidence_refs"
+          , `List [ `String "trace:k2"; `String ""; `String " artifact:k2 " ] )
+        ]);
+  let json = Dash.keeper_decisions_log_json ~config ~keepers:[ meta ] ~limit:10 () in
+  let events = Json.(json |> member "events" |> to_list) in
+  check int "events" 2 (List.length events);
+  match events with
+  | newest :: older :: _ ->
+    check
+      (list string)
+      "real evidence refs"
+      [ "trace:k2"; "artifact:k2" ]
+      Json.(newest |> member "evidence_refs" |> strings);
+    check
+      (list string)
+      "prose summary not used as evidence"
+      []
+      Json.(older |> member "evidence_refs" |> strings)
+  | _ -> fail "expected newest and older events"
+;;
+
+let test_decisions_log_clamps_low_limit () =
+  with_config
+  @@ fun config ->
+  let meta = keeper_meta "k2-decision-limit" in
+  let path = Keeper_types.keeper_decision_log_path config meta.name in
+  append_jsonl
+    path
+    (`Assoc
+        [ "ts_unix", `Float 1_000.0
+        ; "keeper_name", `String meta.name
+        ; "speech_act", `String "inform"
+        ]);
+  let json = Dash.keeper_decisions_log_json ~config ~keepers:[ meta ] ~limit:0 () in
+  check int "clamped limit" 1 Json.(json |> member "limit" |> to_int);
+  check int "one event" 1 Json.(json |> member "events" |> to_list |> List.length)
+;;
+
+let test_decisions_log_clamps_high_limit () =
+  with_config
+  @@ fun config ->
+  let meta = keeper_meta "k2-decision-hilimit" in
+  let json = Dash.keeper_decisions_log_json ~config ~keepers:[ meta ] ~limit:999 () in
+  check int "clamped high limit" 200 Json.(json |> member "limit" |> to_int)
+;;
+
+let test_decisions_log_json_shape () =
+  with_config
+  @@ fun config ->
+  let meta = keeper_meta "k2-decisions-shape" in
+  let path = Keeper_types.keeper_decision_log_path config meta.name in
+  append_jsonl
+    path
+    (`Assoc
+        [ "ts_unix", `Float 1_234.0
+        ; "keeper_name", `String meta.name
+        ; "speech_act", `String "assert"
+        ; "blocker", `String "missing config"
+        ; "current_intention", `String "deploy"
+        ]);
+  let json = Dash.keeper_decisions_log_json ~config ~keepers:[ meta ] ~limit:10 () in
+  let events = Json.(json |> member "events" |> to_list) in
+  check int "one event" 1 (List.length events);
+  let event = List.hd events in
+  check bool "has id" true (Json.(event |> member "id" |> to_string) <> "");
+  check string "has ts" "1970-01-01T00:20:34Z" Json.(event |> member "ts" |> to_string);
+  check (float 0.001) "ts_unix" 1234.0 Json.(event |> member "ts_unix" |> to_float);
+  check string "keeper" meta.name Json.(event |> member "keeper" |> to_string);
+  check
+    string
+    "decision_type"
+    "assert"
+    Json.(event |> member "decision_type" |> to_string);
+  check
+    bool
+    "summary contains blocker"
+    true
+    (let s = Json.(event |> member "summary" |> to_string) in
+     contains_substring ~needle:"blocked" s);
+  check
+    bool
+    "summary contains intention"
+    true
+    (let s = Json.(event |> member "summary" |> to_string) in
+     contains_substring ~needle:"deploy" s)
+;;
+
+(* --- Memory log tests --- *)
+
+let memory_row ~ts text =
+  `Assoc
+    [ "schema_version", `Int 2
+    ; "kind", `String "goal"
+    ; "text", `String text
+    ; "priority", `Int 10
+    ; "ts_unix", `Float ts
+    ]
+;;
+
+let test_memory_log_ids_distinguish_same_timestamp_rows () =
+  with_config
+  @@ fun config ->
+  let meta = keeper_meta "k2-memory" in
+  let path = Keeper_types.keeper_memory_bank_path config meta.name in
+  append_jsonl path (memory_row ~ts:2_000.0 "Ship K2 memory feed row alpha");
+  append_jsonl path (memory_row ~ts:2_000.0 "Ship K2 memory feed row beta");
+  let json = Dash.keeper_memory_log_json ~config ~keepers:[ meta ] ~limit:999 () in
+  check int "clamped high limit" 200 Json.(json |> member "limit" |> to_int);
+  let entries = Json.(json |> member "entries" |> to_list) in
+  check int "entries" 2 (List.length entries);
+  let ids = entries |> List.map (fun row -> Json.(row |> member "id" |> to_string)) in
+  match ids with
+  | [ first; second ] -> check bool "ids differ" true (not (String.equal first second))
+  | _ -> fail "expected two memory ids"
+;;
+
+let test_memory_log_kind_mapping () =
+  with_config
+  @@ fun config ->
+  let meta = keeper_meta "k2-memory-kind" in
+  let path = Keeper_types.keeper_memory_bank_path config meta.name in
+  (* progress -> episode *)
+  append_jsonl
+    path
+    (`Assoc
+        [ "schema_version", `Int 2
+        ; "kind", `String "progress"
+        ; "text", `String "p1"
+        ; "priority", `Int 10
+        ; "ts_unix", `Float 3_000.0
+        ]);
+  (* goal -> plan *)
+  append_jsonl
+    path
+    (`Assoc
+        [ "schema_version", `Int 2
+        ; "kind", `String "goal"
+        ; "text", `String "g1"
+        ; "priority", `Int 10
+        ; "ts_unix", `Float 3_001.0
+        ]);
+  (* belief -> fact *)
+  append_jsonl
+    path
+    (`Assoc
+        [ "schema_version", `Int 2
+        ; "kind", `String "belief"
+        ; "text", `String "b1"
+        ; "priority", `Int 10
+        ; "ts_unix", `Float 3_002.0
+        ]);
+  let json = Dash.keeper_memory_log_json ~config ~keepers:[ meta ] ~limit:10 () in
+  let entries = Json.(json |> member "entries" |> to_list) in
+  check int "entries" 3 (List.length entries);
+  let kinds = List.map (fun e -> Json.(e |> member "kind" |> to_string)) entries in
+  (* sorted newest-first: belief(3_002), goal(3_001), progress(3_000) *)
+  check (list string) "kind mapping" [ "fact"; "plan"; "episode" ] kinds
+;;
+
+let () =
+  run
+    "dashboard_k2_feeds"
+    [ ( "decision log"
+      , [ test_case
+            "keeps prose out of evidence refs"
+            `Quick
+            test_decisions_log_evidence_refs_are_real_refs
+        ; test_case "clamps low limit" `Quick test_decisions_log_clamps_low_limit
+        ; test_case "clamps high limit" `Quick test_decisions_log_clamps_high_limit
+        ; test_case "json shape matches spec" `Quick test_decisions_log_json_shape
+        ] )
+    ; ( "memory log"
+      , [ test_case
+            "ids distinguish same timestamp rows"
+            `Quick
+            test_memory_log_ids_distinguish_same_timestamp_rows
+        ; test_case "kind mapping (episode/fact/plan)" `Quick test_memory_log_kind_mapping
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Replacement for closed PR #12528. Ports the reviewed-and-approved OCaml backend changes with all review feedback addressed.

### New endpoints
- `GET /api/v1/dashboard/keeper-decisions-log` — cross-keeper decision feed
- `GET /api/v1/dashboard/keeper-memory-log` — cross-keeper memory bank feed

### Backend changes (`dashboard_http_keeper.ml`)
- `keeper_decisions_log_json`: spec shape `{id, ts, ts_unix, keeper, decision_type, summary, evidence_refs[]}`
- `keeper_memory_log_json`: spec shape `{id, ts, ts_unix, keeper, kind, summary}`
- `k2_feed_limit`: clamp to [1..200] at both producer and route boundary
- `k2_stable_id`: collision-resistant IDs (keeper + timestamp + raw-row hash)
- `memory_kind_for_log`: normalize kinds to `episode|fact|plan`
- `evidence_refs` populated from real reference lists only (not prose summaries)

### Route changes (`server_routes_http_routes_provider_runs.ml`)
- `dashboard_feed_limit` helper for consistent clamping across all K2 routes
- Existing `keeper-decisions` route also benefits from limit clamping

## Review feedback addressed (from #12528)
1. `evidence_refs` now uses only real `evidence_refs`/`raw_evidence_refs` lists — no prose
2. Memory IDs collision-resistant via `k2_stable_id` with raw-row hashing
3. Limit clamped at both route and JSON producer level
4. Focused tests covering all four issues

## Test plan
- [x] 6 Alcotest tests: evidence ref purity, limit clamping (low+high), JSON shape, memory ID collision, kind mapping
- [x] `dune build --root . @install` clean
- [ ] Frontend components (follow-up PR)

Closes #12528