### PR TITLE
style(dashboard): tighten cockpit density tokens

### DIFF
--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -52,7 +52,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 48px 16px;
+  padding: 28px 12px;
   text-align: center;
 }
 
@@ -61,7 +61,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 48px 16px;
+  padding: 28px 12px;
   font-size: var(--fs-sm);
   color: var(--color-fg-muted);
 }
@@ -72,9 +72,9 @@
 }
 /* ── Agent card hover ── */
 .agent-card:hover {
-  box-shadow: 0 2px 8px var(--black-20);
-  transform: translateY(-2px);
-  border-color: var(--accent);
+  box-shadow: inset 2px 0 0 var(--accent);
+  transform: none;
+  border-color: var(--accent-30);
 }
 
 @utility logs-refresh-btn { &:hover { border-color: var(--accent); } }
@@ -87,8 +87,8 @@
   border-color: var(--color-border-default);
   content-visibility: auto;
   contain-intrinsic-size: auto 120px;
-  transition: border-color 0.2s, transform 0.2s, background 0.2s;
-  &:hover { border-color: var(--accent-30); background: var(--white-6); transform: translateY(-1px); }
+  transition: border-color 0.15s, background 0.15s;
+  &:hover { border-color: var(--accent-30); background: var(--white-6); transform: none; }
 }
 
 /* Vote column */
@@ -198,11 +198,11 @@
 .swimlane-vis-container .vis-tooltip {
   background-color: rgba(15, 23, 42, 0.95);
   border: 1px solid rgba(100, 116, 139, 0.3);
-  border-radius: 6px;
+  border-radius: var(--r-1);
   color: var(--frost-100);
   font-size: 11px;
-  padding: 8px 10px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  padding: 6px 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.24);
   white-space: pre-wrap;
 }
 
@@ -220,8 +220,8 @@
 }
 
 .card:hover {
-  border-color: var(--color-border-strong);
-  background: var(--color-bg-elevated);
+  border-color: var(--border-strong);
+  background: var(--bg-panel-hover);
 }
 
 /* ── Custom Webkit Scrollbar ── */
@@ -242,7 +242,7 @@
   
   .custom-scrollbar::-webkit-scrollbar-thumb {
     background: var(--white-10);
-    border-radius: 10px;
+    border-radius: var(--r-1);
   }
   
   .custom-scrollbar::-webkit-scrollbar-thumb:hover {

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -49,63 +49,63 @@
 
 @utility card {
   background: var(--card);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-2);
-  padding: 16px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--r-1);
+  padding: var(--spacing-card);
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.03);
+    inset 0 1px 0 rgb(255 255 255 / 0.02);
   transition: border-color 0.15s, background 0.15s;
-  &:hover { border-color: var(--color-border-strong); background: var(--color-bg-elevated); }
+  &:hover { border-color: var(--border-strong); background: var(--bg-panel-hover); }
 }
 
 @utility monitor-headline {
-  font-size: 17px;
-  font-weight: 700;
+  font: var(--type-title);
+  font-weight: 650;
   color: var(--text-strong);
-  letter-spacing: 0;
+  letter-spacing: var(--track-normal);
   line-height: 1.25;
-  padding-bottom: 6px;
-  border-bottom: 1px solid var(--border-slate-12);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--card-border);
 }
 
 @utility monitor-subheadline {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   color: var(--color-fg-muted);
-  line-height: 1.5;
-  margin-top: 6px;
+  line-height: 1.35;
+  margin-top: 4px;
 }
 
 @utility monitor-surface-card {
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-2);
+  border: 1px solid var(--card-border);
+  border-radius: var(--r-1);
   background: var(--card);
 }
 
 @utility monitor-surface-card-strong {
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.03);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.02);
 }
 
 @utility monitor-surface-card-medium {
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.03);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.02);
 }
 
 @utility monitor-muted-panel {
-  border: 1px solid var(--border-slate-12);
-  border-radius: var(--r-2);
-  background: var(--white-3);
+  border: 1px solid var(--card-border);
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--color-bg-2) 72%, transparent);
 }
 
 /* ── Section header (reusable pattern) ─────────────────────── */
 
 @utility section-header {
-  font-size: 14px;
-  font-weight: 600;
+  font: var(--type-label);
+  font-weight: 650;
   color: var(--text-strong);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding-bottom: 6px;
-  border-bottom: 1px solid var(--border-slate-12);
-  margin-bottom: 10px;
+  letter-spacing: var(--track-caps);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--card-border);
+  margin-bottom: 8px;
 }
 
 /* ── Status Badge base ───────────────────────────────────────
@@ -116,13 +116,15 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 12px;
-  border-radius: 9999px;
+  padding: 2px 7px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--r-1);
   font-size: var(--fs-xs);
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  line-height: 1.6;
+  font-weight: 650;
+  letter-spacing: var(--track-wide);
+  line-height: 1.35;
   white-space: nowrap;
+  text-transform: uppercase;
   background: var(--white-6);
   color: var(--color-fg-muted);
   &.active { background: var(--ok-22); color: var(--ok); }
@@ -140,17 +142,17 @@
 }
 
 @utility control-textarea {
-  padding: 8px 12px;
-  border: 1px solid var(--border-slate-16);
-  border-radius: 8px;
-  background: var(--white-3);
+  padding: 6px 8px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--color-bg-2) 72%, transparent);
   color: var(--text-body);
-  font-size: var(--fs-base);
-  line-height: 1.5;
+  font-size: var(--fs-sm);
+  line-height: 1.4;
   transition: border-color 0.15s;
   resize: vertical;
   min-height: 64px;
-  &:focus { outline: none; border-color: rgba(71, 184, 255, 0.55); }
+  &:focus { outline: none; border-color: var(--border-strong); }
 }
 
 
@@ -164,19 +166,19 @@ table {
 
 thead th {
   text-align: left;
-  padding: 8px 12px;
+  padding: 6px 8px;
   font-size: var(--fs-xs);
-  font-weight: 600;
+  font-weight: 650;
   color: var(--color-fg-muted);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border-bottom: 1px solid var(--border-slate-16);
-  background: var(--white-3);
+  letter-spacing: var(--track-caps);
+  border-bottom: 1px solid var(--card-border);
+  background: color-mix(in srgb, var(--color-bg-2) 76%, transparent);
 }
 
 tbody td {
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border-slate-8);
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
   color: var(--text-body);
   vertical-align: top;
 }
@@ -187,6 +189,28 @@ tbody tr:nth-child(even) {
 
 tbody tr:hover {
   background: var(--white-5);
+}
+
+#app > div > header {
+  border-color: var(--card-border);
+  padding-block: 6px;
+  box-shadow: inset 0 -1px 0 rgb(var(--brass-glow) / 0.08);
+}
+
+#app > div > div.flex-1 {
+  gap: 6px;
+  padding: 6px;
+}
+
+#dashboard-side-rail,
+#main-content {
+  border-color: var(--card-border);
+  border-radius: var(--r-1);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.015);
+}
+
+#main-content > div {
+  padding: var(--spacing-card);
 }
 
 /* Tone border utilities — applied via toneClass() helper */

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -9,11 +9,11 @@
   /* Base & Backgrounds — bridge the live dashboard shell to the generated
      Cockpit / muted-brass token canon. */
   --bg-root: var(--color-bg-0);
-  --bg-panel: color-mix(in srgb, var(--color-bg-1) 94%, transparent);
-  --bg-panel-hover: color-mix(in srgb, var(--color-bg-4) 96%, transparent);
-  --shell-header-bg: color-mix(in srgb, var(--color-bg-1) 72%, transparent);
-  --shell-rail-bg: color-mix(in srgb, var(--color-bg-2) 76%, transparent);
-  --shell-main-bg: color-mix(in srgb, var(--color-bg-1) 84%, transparent);
+  --bg-panel: color-mix(in srgb, var(--color-bg-1) 96%, black);
+  --bg-panel-hover: color-mix(in srgb, var(--color-bg-3) 92%, black);
+  --shell-header-bg: color-mix(in srgb, var(--color-bg-1) 94%, black);
+  --shell-rail-bg: color-mix(in srgb, var(--color-bg-2) 92%, black);
+  --shell-main-bg: color-mix(in srgb, var(--color-bg-1) 88%, var(--color-bg-0));
 
   /* Text & Typography */
   --text-strong: var(--color-fg-1);
@@ -22,9 +22,9 @@
   --text-dim: var(--color-fg-4);
 
   /* Borders */
-  --border-subtle: color-mix(in srgb, var(--color-line-1) 70%, transparent);
-  --border-base: var(--color-line-1);
-  --border-strong: var(--color-line-2);
+  --border-subtle: color-mix(in srgb, var(--color-brass-3) 18%, var(--color-line-1));
+  --border-base: color-mix(in srgb, var(--color-brass-3) 24%, var(--color-line-1));
+  --border-strong: color-mix(in srgb, var(--color-brass-2) 24%, var(--color-line-2));
 
   /* Semantic Colors (Core) */
   --accent: var(--color-brass-1);
@@ -308,7 +308,7 @@
   --k-11-glow: var(--color-k-11-glow);
   --k-12-glow: var(--color-k-12-glow);
   --card: var(--bg-panel);
-  --card-border: var(--border-base);
+  --card-border: color-mix(in srgb, var(--color-brass-3) 26%, var(--border-base));
   --white-2: var(--white-3);
   --white-4: var(--white-5);
   --white-6: var(--white-5);
@@ -325,11 +325,11 @@
   --border-highlight: var(--line-2);
 
   /* Layout & Sizing */
-  --radius-xl: 24px;
-  --radius-lg: 12px;
-  --radius-md: 8px;
-  --radius-sm: 6px;
-  --header-h: 94px;
+  --radius-xl: 8px;
+  --radius-lg: 6px;
+  --radius-md: 4px;
+  --radius-sm: 3px;
+  --header-h: 72px;
 
   /* Font-size scale — aliases to the canonical Tailwind v4 @theme tokens
      in tokens.css. Single SSOT: change values there, both Tailwind utilities
@@ -342,6 +342,12 @@
   --fs-base: var(--font-size-base);
   --fs-md: var(--font-size-md);
   --fs-lg: var(--font-size-lg);
+
+  /* Cockpit density overrides: keep the generated token ladder intact,
+     but make legacy spacing aliases resolve to the compact shell scale. */
+  --spacing-element: 6px;
+  --spacing-group: 8px;
+  --spacing-card: 12px;
 
   /* Extended palette */
   /* --cyan, --purple base hex lifted to source.ts (Iter 2c-4); alpha companions retained */


### PR DESCRIPTION
## Summary

This is one small CSS-only slice of the MASC dashboard cockpit alignment wave.

Visual target: move the existing dashboard shell/cards closer to the dark dense operator cockpit reference with flatter surfaces, sharper low-radius rectangles, thin brass-tinted borders, compact padding, smaller uppercase/mono label treatment, muted brass active accents, and less hover lift.

## Changed Files

- `dashboard/src/styles/variables.css`
- `dashboard/src/styles/global.css`
- `dashboard/src/styles/dashboard.css`

## Validation

- `pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/styles/cockpit-token-cascade.test.ts` passed.
- `pnpm build` passed.

## Notes

- No `app.ts` or dashboard component TS files changed.
- This does not attempt full visual parity with the cockpit reference. Remaining visual alignment should continue in separate disjoint CSS/component slices.
