### PR TITLE
style(dashboard): compact workspace goal deck

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -48,7 +48,10 @@ import {
 
 type GoalDetailTab = 'summary' | 'tasks' | 'evidence'
 
-const CARD_BOX = 'rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4'
+const CARD_BOX = 'rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3'
+const DECK_LABEL = 'font-mono text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--color-fg-muted)]'
+const DECK_META = 'font-mono text-3xs text-[var(--color-fg-disabled)]'
+const DECK_CHIP = 'rounded-sm border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
 
 /**
  * Pure hierarchy filter for goal tree nodes.
@@ -375,26 +378,26 @@ function GoalVerificationEvidencePanel({
   const statusClass = verificationStatusClass(request, isOpen)
   const votes = request?.votes ?? []
   const panelClass = compact
-    ? 'ml-6 rounded border border-amber-400/20 bg-amber-400/8 p-2 text-xs text-amber-100'
+    ? 'ml-6 rounded-sm border border-amber-400/20 bg-amber-400/8 p-2 text-xs text-amber-100'
     : CARD_BOX
 
   return html`
     <div class=${panelClass}>
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted">AI 확인</div>
-        <span class="rounded border px-2 py-0.5 text-3xs font-semibold ${statusClass}">
+        <div class="${DECK_LABEL}">AI 확인</div>
+        <span class="rounded-sm border px-1.5 py-0.5 font-mono text-3xs font-semibold ${statusClass}">
           ${verificationStatusLabel(request, isOpen)}
         </span>
       </div>
-      <div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-text-body">
-        <span class="rounded border border-amber-400/20 bg-amber-400/8 px-2 py-1 text-amber-100">
+      <div class="mt-2 flex flex-wrap items-center gap-1.5 font-mono text-3xs text-[var(--color-fg-secondary)]">
+        <span class="rounded-sm border border-amber-400/20 bg-amber-400/8 px-1.5 py-0.5 text-amber-100">
           quorum ${summary.approve_count}/${requiredVerdicts}
         </span>
         <span>reject ${summary.reject_count}</span>
         <span>remaining ${summary.remaining_possible}</span>
       </div>
       ${request ? html`
-        <div class="mt-2 flex flex-wrap gap-2 text-3xs text-text-muted">
+        <div class="mt-2 flex flex-wrap gap-2 font-mono text-3xs text-[var(--color-fg-muted)]">
           <span>request ${request.id}</span>
           <span>target ${request.target_phase}</span>
           <span>opened <${TimeAgo} timestamp=${request.created_at} /></span>
@@ -406,7 +409,7 @@ function GoalVerificationEvidencePanel({
       ${policy && policy.eligible_principals.length > 0 ? html`
         <div class="mt-3 flex flex-wrap gap-1.5">
           ${policy.eligible_principals.map(principal => html`
-            <span key=${`${principal.kind}:${principal.id}`} class="rounded border border-card-border/60 bg-[var(--white-4)] px-2 py-0.5 text-3xs font-medium text-text-body">
+            <span key=${`${principal.kind}:${principal.id}`} class="${DECK_CHIP} font-medium text-[var(--color-fg-secondary)]">
               ${verificationPrincipalLabel(principal)}
             </span>
           `)}
@@ -417,19 +420,19 @@ function GoalVerificationEvidencePanel({
           ${votes.map(vote => {
             const evidenceRefs = vote.evidence_refs ?? []
             return html`
-              <div key=${`${vote.principal.kind}:${vote.principal.id}:${vote.submitted_at}`} class="rounded border border-card-border/50 bg-[var(--white-3)] p-2 text-xs text-text-body">
+              <div key=${`${vote.principal.kind}:${vote.principal.id}:${vote.submitted_at}`} class="rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)] p-2 text-xs text-[var(--color-fg-secondary)]">
                 <div class="flex flex-wrap items-center gap-2">
-                  <span class="font-semibold text-text-strong">${verificationPrincipalLabel(vote.principal)}</span>
-                  <span class="rounded border border-card-border/60 bg-[var(--white-4)] px-1.5 py-0.5 text-3xs uppercase tracking-wider text-text-muted">${vote.decision}</span>
-                  <span class="text-3xs text-text-dim"><${TimeAgo} timestamp=${vote.submitted_at} /></span>
+                  <span class="font-semibold text-[var(--color-fg-primary)]">${verificationPrincipalLabel(vote.principal)}</span>
+                  <span class="${DECK_CHIP} uppercase tracking-[0.08em] text-[var(--color-fg-muted)]">${vote.decision}</span>
+                  <span class="${DECK_META}"><${TimeAgo} timestamp=${vote.submitted_at} /></span>
                 </div>
                 ${vote.note ? html`
-                  <div class="mt-1 leading-relaxed text-text-muted">${vote.note}</div>
+                  <div class="mt-1 leading-relaxed text-[var(--color-fg-muted)]">${vote.note}</div>
                 ` : null}
                 ${evidenceRefs.length > 0 ? html`
                   <div class="mt-2 flex flex-wrap gap-1">
                     ${evidenceRefs.map(ref => html`
-                      <code key=${ref} class="rounded border border-card-border/60 bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-text-secondary">${ref}</code>
+                      <code key=${ref} class="${DECK_CHIP} text-[var(--color-fg-secondary)]">${ref}</code>
                     `)}
                   </div>
                 ` : null}
@@ -513,10 +516,10 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
   const h = size === 'sm' ? 'h-1.5' : 'h-2.5'
   return html`
     <div class="flex items-center gap-2">
-      <div class="flex-1 ${h} rounded-sm bg-[var(--white-10)] overflow-hidden">
+      <div class="flex-1 ${h} rounded-sm bg-[var(--color-bg-elevated)] overflow-hidden">
         <div class="${h} rounded-sm transition-all duration-500" style="width:${clamped}%;background:${barColor}"></div>
       </div>
-      <span class="text-2xs font-semibold tabular-nums text-text-muted w-9 text-right">${clamped}%</span>
+      <span class="${DECK_META} w-9 text-right font-semibold tabular-nums">${clamped}%</span>
     </div>
   `
 }
@@ -531,41 +534,41 @@ function TreeSummary({
   goalVerificationCount: number
 }) {
   return html`
-    <div class="grid grid-cols-[repeat(auto-fit,minmax(128px,1fr))] gap-3">
-      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
-        <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_goals}</div>
-        <div class="mt-1 text-3xs font-semibold uppercase tracking-widest text-text-muted">전체 목표</div>
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(112px,1fr))] gap-2">
+      <div class="${CARD_BOX} text-center">
+        <div class="font-mono text-xl font-semibold text-[var(--color-fg-primary)] tabular-nums">${summary.total_goals}</div>
+        <div class="mt-1 ${DECK_LABEL}">전체 목표</div>
       </div>
-      <div class="rounded border border-ok/25 bg-ok/10 p-3 text-center">
-        <div class="text-2xl font-bold text-ok tabular-nums">${summary.active_goals}</div>
-        <div class="mt-1 text-3xs font-semibold uppercase tracking-widest text-ok/80">정상</div>
+      <div class="rounded-sm border border-ok/25 bg-ok/10 p-3 text-center">
+        <div class="font-mono text-xl font-semibold text-ok tabular-nums">${summary.active_goals}</div>
+        <div class="mt-1 font-mono text-3xs font-semibold uppercase tracking-[0.08em] text-ok/80">정상</div>
       </div>
-      <div class="rounded border border-warn/25 bg-warn/10 p-3 text-center">
-        <div class="text-2xl font-bold text-warn tabular-nums">${summary.at_risk_goals}</div>
-        <div class="mt-1 text-3xs font-semibold uppercase tracking-widest text-warn/80">위험</div>
+      <div class="rounded-sm border border-warn/25 bg-warn/10 p-3 text-center">
+        <div class="font-mono text-xl font-semibold text-warn tabular-nums">${summary.at_risk_goals}</div>
+        <div class="mt-1 font-mono text-3xs font-semibold uppercase tracking-[0.08em] text-warn/80">위험</div>
       </div>
-      <div class="rounded border border-bad/25 bg-bad/10 p-3 text-center">
-        <div class="text-2xl font-bold text-bad tabular-nums">${summary.blocked_goals}</div>
-        <div class="mt-1 text-3xs font-semibold uppercase tracking-widest text-bad/80">차단</div>
+      <div class="rounded-sm border border-bad/25 bg-bad/10 p-3 text-center">
+        <div class="font-mono text-xl font-semibold text-bad tabular-nums">${summary.blocked_goals}</div>
+        <div class="mt-1 font-mono text-3xs font-semibold uppercase tracking-[0.08em] text-bad/80">차단</div>
       </div>
-      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
-        <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.pending_approvals}</div>
-        <div class="mt-1 text-3xs font-semibold uppercase tracking-widest text-text-muted">승인 대기</div>
+      <div class="${CARD_BOX} text-center">
+        <div class="font-mono text-xl font-semibold text-[var(--color-fg-primary)] tabular-nums">${summary.pending_approvals}</div>
+        <div class="mt-1 ${DECK_LABEL}">승인 대기</div>
       </div>
       ${goalVerificationCount > 0 ? html`
-        <div class="rounded border border-amber-400/30 bg-amber-400/10 p-3 text-center">
-          <div class="text-2xl font-bold text-amber-200 tabular-nums">${goalVerificationCount}</div>
-          <div class="mt-1 text-3xs font-semibold uppercase tracking-widest text-amber-100/80">Goal 검증 대기</div>
+        <div class="rounded-sm border border-amber-400/30 bg-amber-400/10 p-3 text-center">
+          <div class="font-mono text-xl font-semibold text-amber-200 tabular-nums">${goalVerificationCount}</div>
+          <div class="mt-1 font-mono text-3xs font-semibold uppercase tracking-[0.08em] text-amber-100/80">Goal 검증 대기</div>
         </div>
       ` : null}
       ${awaitingVerificationCount > 0 ? html`
-        <div class="rounded border border-accent/30 bg-[var(--accent-10)] p-3 text-center">
-          <div class="text-2xl font-bold text-accent tabular-nums">${awaitingVerificationCount}</div>
-          <div class="mt-1 text-3xs font-semibold uppercase tracking-widest text-accent/80">Task 검증 대기</div>
+        <div class="rounded-sm border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] p-3 text-center">
+          <div class="font-mono text-xl font-semibold text-[var(--color-accent-fg)] tabular-nums">${awaitingVerificationCount}</div>
+          <div class="mt-1 font-mono text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--color-accent-fg)]/80">Task 검증 대기</div>
         </div>
       ` : null}
-      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3">
-        <div class="mb-2 text-3xs font-semibold uppercase tracking-widest text-text-muted">전체 수렴도</div>
+      <div class="${CARD_BOX}">
+        <div class="mb-2 ${DECK_LABEL}">전체 수렴도</div>
         <${ConvergenceBar} pct=${summary.overall_convergence_pct} />
       </div>
     </div>
@@ -574,7 +577,7 @@ function TreeSummary({
 
 function HealthBadge({ health }: { health: GoalTreeNode['health'] }) {
   return html`
-    <span class="inline-flex items-center rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-wider ${healthClass(health)}">
+    <span class="inline-flex items-center rounded-sm border px-1.5 py-0.5 font-mono text-3xs font-semibold uppercase tracking-[0.08em] ${healthClass(health)}">
       ${healthLabel(health)}
     </span>
   `
@@ -583,11 +586,11 @@ function HealthBadge({ health }: { health: GoalTreeNode['health'] }) {
 function GoalBadges({ badges }: { badges: string[] }) {
   if (badges.length === 0) return null
   return html`
-    <div class="flex flex-wrap gap-1.5">
+    <div class="flex flex-wrap gap-1">
       ${badges.map(badge => html`
         <span
           key=${badge}
-          class="inline-flex items-center rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-wider ${badgeClass(badge)}"
+          class="inline-flex items-center rounded-sm border px-1.5 py-0.5 font-mono text-3xs font-semibold uppercase tracking-[0.08em] ${badgeClass(badge)}"
         >
           ${badgeLabel(badge)}
         </span>

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -33,6 +33,10 @@ const doneVisibleCount = signal(20)
 const searchDoneVisibleCount = signal(20)
 const DONE_PAGE_SIZE = 20
 const REPO_ISSUES_BASE = 'https://github.com/jeong-sik/masc-mcp/issues'
+const DECK_PANEL = 'overflow-hidden rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)]'
+const DECK_HEAD = 'border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2'
+const DECK_CHIP = 'rounded-sm border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
+const META_CHIP = 'rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
 
 export function resetTaskBacklogState() {
   doneVisibleCount.value = DONE_PAGE_SIZE
@@ -41,10 +45,10 @@ export function resetTaskBacklogState() {
 
 function priorityToneClass(priority: number): string {
   switch (priority) {
-    case 1: return 'border-l-[var(--rose-light)] bg-[var(--color-status-err)]/10 text-[var(--rose-fg)]'
-    case 2: return 'border-l-[var(--color-status-warn)] bg-[var(--color-status-warn)]/10 text-[var(--yellow-100)]'
-    case 3: return 'border-l-[var(--blue-400)] bg-[var(--blue-400)]/10 text-[#bfdbfe]'
-    default: return 'border-l-[rgba(148,163,184,0.45)] bg-[var(--white-5)] text-text-muted'
+    case 1: return 'border-[var(--color-err-border)] bg-[var(--color-err-soft)] text-[var(--color-err-fg)]'
+    case 2: return 'border-[var(--color-warn-border)] bg-[var(--color-warn-soft)] text-[var(--color-warn-fg)]'
+    case 3: return 'border-[var(--color-info-border)] bg-[var(--color-info-soft)] text-[var(--color-info-fg)]'
+    default: return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
   }
 }
 
@@ -102,11 +106,11 @@ function KanbanCard({ task }: { task: Task }) {
   }
 
   return html`
-    <article class="flex flex-col gap-3 rounded border border-card-border/60 border-l-4 bg-[rgba(7,12,20,0.92)] p-4 ${priorityToneClass(p)}">
+    <article class="flex flex-col gap-2 rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-panel-alt)]">
       <div class="flex items-start justify-between gap-3">
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="rounded border border-current/20 px-2 py-0.5 text-2xs font-semibold">${priorityLabel(p)}</span>
-          ${scope ? html`<span class="rounded border border-card-border/70 bg-[var(--white-5)] px-2 py-0.5 text-2xs font-medium text-text-body">${scope}</span>` : null}
+        <div class="flex flex-wrap items-center gap-1.5">
+          <span class="${DECK_CHIP} ${priorityToneClass(p)} font-semibold">${priorityLabel(p)}</span>
+          ${scope ? html`<span class="${META_CHIP} font-medium text-[var(--color-fg-secondary)]">${scope}</span>` : null}
         </div>
         <${ActionButton}
           variant="danger"
@@ -122,19 +126,19 @@ function KanbanCard({ task }: { task: Task }) {
 
       <button
         type="button"
-        class="text-left text-base font-semibold leading-snug text-text-strong whitespace-pre-wrap break-words cursor-pointer bg-transparent border-none p-0 font-[inherit] transition-colors hover:text-accent"
+        class="cursor-pointer border-none bg-transparent p-0 text-left font-[inherit] text-sm font-semibold leading-snug text-[var(--color-fg-primary)] whitespace-pre-wrap break-words transition-colors hover:text-[var(--color-accent-fg)]"
         onClick=${() => openTaskDetail(task)}
       >${task.title}</button>
 
       ${hasDescription ? html`
         <div class="flex flex-col gap-2">
-          <div class=${`overflow-hidden text-sm leading-relaxed text-text-body ${isExpanded || !canExpand ? '' : 'max-h-[9rem]'}`}>
+          <div class=${`overflow-hidden text-xs leading-relaxed text-[var(--color-fg-secondary)] ${isExpanded || !canExpand ? '' : 'max-h-[8rem]'}`}>
             <${RichContent} text=${description} previewLimit=${1} />
           </div>
           ${canExpand ? html`
             <button
               type="button"
-              class="w-fit rounded border border-card-border/70 bg-[var(--white-4)] px-2 py-1 text-2xs text-text-muted transition-colors hover:text-text-strong"
+              class="w-fit rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-3xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
               onClick=${() => toggleTaskExpand(task.id)}
               aria-expanded=${isExpanded}
             >
@@ -143,25 +147,25 @@ function KanbanCard({ task }: { task: Task }) {
           ` : null}
         </div>
       ` : html`
-        <div class="text-xs text-text-dim">설명 없음</div>
+        <div class="font-mono text-3xs text-[var(--color-fg-disabled)]">설명 없음</div>
       `}
 
-      <div class="flex flex-wrap items-center gap-2 text-2xs text-text-muted">
+      <div class="flex flex-wrap items-center gap-1.5 font-mono text-3xs text-[var(--color-fg-muted)]">
         ${task.status === 'awaiting_verification'
-          ? html`<span class="rounded border border-accent/30 bg-[var(--accent-10)] px-2 py-1 text-accent" title="verifier keeper의 독립 실측을 기다리는 중">검증 대기${task.updated_at ? html` <${TimeAgo} timestamp=${task.updated_at} />` : null}</span>`
+          ? html`<span class="rounded-sm border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-1.5 py-0.5 text-[var(--color-accent-fg)]" title="verifier keeper의 독립 실측을 기다리는 중">검증 대기${task.updated_at ? html` <${TimeAgo} timestamp=${task.updated_at} />` : null}</span>`
           : task.completed_at && task.status === 'done'
-            ? html`<span class="rounded border border-ok/25 bg-ok/10 px-2 py-1 text-ok">완�� <${TimeAgo} timestamp=${task.completed_at} /></span>`
+            ? html`<span class="rounded-sm border border-ok/25 bg-ok/10 px-1.5 py-0.5 text-ok">완료 <${TimeAgo} timestamp=${task.completed_at} /></span>`
             : task.completed_at && task.status === 'cancelled'
-              ? html`<span class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-[var(--bad-light)]">취소 <${TimeAgo} timestamp=${task.completed_at} /></span>`
+              ? html`<span class="rounded-sm border border-[var(--bad-30)] bg-[var(--bad-10)] px-1.5 py-0.5 text-[var(--bad-light)]">취소 <${TimeAgo} timestamp=${task.completed_at} /></span>`
               : task.created_at
-                ? html`<span class="rounded border border-card-border/70 bg-[var(--white-4)] px-2 py-1"><${TimeAgo} timestamp=${task.created_at} /></span>`
+                ? html`<span class="${META_CHIP}"><${TimeAgo} timestamp=${task.created_at} /></span>`
                 : null}
-        ${task.assignee ? html`<span class="rounded border border-accent/20 bg-[var(--accent-10)] px-2 py-1 text-accent">@${task.assignee}</span>` : null}
+        ${task.assignee ? html`<span class="rounded-sm border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-1.5 py-0.5 text-[var(--color-accent-fg)]">@${task.assignee}</span>` : null}
         <a
           href=${link.href}
           target="_blank"
           rel="noreferrer"
-          class="inline-flex items-center gap-1 rounded border border-card-border/70 bg-[var(--white-4)] px-2 py-1 text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
+          class="inline-flex items-center gap-1 rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-[var(--color-fg-secondary)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
         >
           ${link.label}
           <span aria-hidden="true">\u2197</span>
@@ -193,15 +197,15 @@ function TaskColumn({
   }, [listRef])
 
   return html`
-    <section class="flex min-h-60 flex-col gap-4 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4" aria-label=${title}>
-      <div class="flex items-start justify-between gap-3 border-b border-card-border/50 pb-3">
+    <section class="flex min-h-60 flex-col ${DECK_PANEL}" aria-label=${title}>
+      <div class="${DECK_HEAD} flex items-start justify-between gap-3">
         <div>
-          <h3 class="text-md font-semibold text-text-strong">${title}</h3>
-          <p class="mt-1 text-xs leading-relaxed text-text-muted">${description}</p>
+          <h3 class="font-mono text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--color-fg-primary)]">${title}</h3>
+          <p class="mt-1 text-3xs leading-relaxed text-[var(--color-fg-muted)]">${description}</p>
         </div>
-        <span class="rounded px-2.5 py-1 text-xs font-semibold ${badgeClass}">${count}</span>
+        <span class="rounded-sm px-1.5 py-0.5 font-mono text-3xs font-semibold ${badgeClass}">${count}</span>
       </div>
-      <div ref=${listRef} class="flex max-h-170 flex-col gap-3 overflow-y-auto pr-1 custom-scrollbar">
+      <div ref=${listRef} class="flex max-h-170 flex-col gap-2 overflow-y-auto p-2.5 pr-1.5 custom-scrollbar">
         ${children}
       </div>
     </section>
@@ -256,12 +260,12 @@ export function TaskBacklog() {
   const hasData = executionLoaded.value
 
   if (isLoading) {
-    return html`<${Card} title="태스크 백로그" class="section"><${LoadingState}>백로그 불러오는 중...<//><//>`
+    return html`<${Card} title="태스크 백로그" class="section" variant="compact"><${LoadingState}>백로그 불러오는 중...<//><//>`
   }
 
   if (hasError && !hasData) {
     return html`
-      <${Card} title="태스크 백로그" class="section">
+      <${Card} title="태스크 백로그" class="section" variant="compact">
         <div class="flex flex-col items-center gap-3 py-6">
           <${ErrorState} message="데이터를 불러오지 못했습니다." />
           <${ActionButton} variant="ghost" size="sm" onClick=${() => refreshExecution({ force: true })}>재시도<//>
@@ -271,15 +275,15 @@ export function TaskBacklog() {
   }
 
   if (hasData && totalTasks === 0) {
-    return html`<${Card} title="태스크 백로그" class="section"><${EmptyState} message="등록된 태스크가 없습니다" /><//>`
+    return html`<${Card} title="태스크 백로그" class="section" variant="compact"><${EmptyState} message="등록된 태스크가 없습니다" /><//>`
   }
 
   return html`
-    <${Card} title="태스크 백로그" class="section">
+    <${Card} title="태스크 백로그" class="section" variant="compact">
       ${hasError && hasData ? html`
-        <div class="mb-3 rounded border border-warn/25 bg-warn/10 px-3 py-2 text-xs text-warn">마지막 갱신에 실패했습니다. 표시된 데이터가 오래되었을 수 있습니다.</div>
+        <div class="mb-2 rounded-sm border border-warn/25 bg-warn/10 px-2.5 py-1.5 text-2xs text-warn">마지막 갱신에 실패했습니다. 표시된 데이터가 오래되었을 수 있습니다.</div>
       ` : null}
-      <div class="mb-4 flex flex-wrap items-center gap-2">
+      <div class="mb-3 flex flex-wrap items-center gap-2">
         <div class="min-w-55 flex-1">
           <${TextInput}
             value=${query}
@@ -291,16 +295,16 @@ export function TaskBacklog() {
         ${hasSearch ? html`
           <button
             type="button"
-            class="rounded border border-card-border/70 bg-[var(--white-4)] px-3 py-2 text-xs text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
+            class="rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2.5 py-2 font-mono text-3xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
             onClick=${() => {
               resetTaskSearch()
               searchDoneVisibleCount.value = DONE_PAGE_SIZE
             }}
           >검색 초기화</button>
-          <span class="text-xs text-text-muted">${filteredTotal}/${totalTasks}</span>
+          <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${filteredTotal}/${totalTasks}</span>
         ` : null}
       </div>
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-4 items-start">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-3 items-start">
         <${TaskColumn}
           title="할 일"
           count=${sortedTodo.length}
@@ -343,7 +347,7 @@ export function TaskBacklog() {
           ${hasMoreDone ? html`
             <button
               type="button"
-              class="w-full rounded border border-card-border/60 bg-[var(--white-3)] px-3 py-2 text-xs font-medium text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
+              class="w-full rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1.5 font-mono text-3xs font-medium text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
               onClick=${() => {
                 if (hasSearch) searchDoneVisibleCount.value += DONE_PAGE_SIZE
                 else doneVisibleCount.value += DONE_PAGE_SIZE

--- a/dashboard/src/components/goals/planning.test.ts
+++ b/dashboard/src/components/goals/planning.test.ts
@@ -32,7 +32,7 @@ describe('PlanningStat', () => {
       container,
     )
 
-    const valueDiv = container.querySelector('.text-3xl')
+    const valueDiv = container.querySelector('.text-2xl')
     expect(valueDiv?.classList.contains('text-text-strong')).toBe(true)
   })
 
@@ -42,7 +42,7 @@ describe('PlanningStat', () => {
       container,
     )
 
-    const valueDiv = container.querySelector('.text-3xl')
+    const valueDiv = container.querySelector('.text-2xl')
     expect(valueDiv?.classList.contains('text-bad')).toBe(true)
   })
 
@@ -52,7 +52,7 @@ describe('PlanningStat', () => {
       container,
     )
 
-    const valueDiv = container.querySelector('.text-3xl')
+    const valueDiv = container.querySelector('.text-2xl')
     expect(valueDiv?.classList.contains('text-warn')).toBe(true)
   })
 
@@ -62,7 +62,7 @@ describe('PlanningStat', () => {
       container,
     )
 
-    const valueDiv = container.querySelector('.text-3xl')
+    const valueDiv = container.querySelector('.text-2xl')
     expect(valueDiv?.classList.contains('text-ok')).toBe(true)
   })
 

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -29,6 +29,13 @@ import { TaskWall } from './task-wall'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 
 const QUICK_START_DOC_URL = 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/QUICK-START.md'
+const DECK_PANEL = 'overflow-hidden rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)]'
+const DECK_HEAD = 'flex flex-wrap items-start justify-between gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 shadow-[inset_0_2px_0_var(--color-accent-fg)]'
+const DECK_CARD = 'rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3'
+const DECK_LABEL = 'font-mono text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--color-fg-muted)]'
+const DECK_META = 'font-mono text-3xs text-[var(--color-fg-disabled)]'
+const DECK_CHIP = 'rounded-sm border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
+const BRASS_CHIP = 'rounded-sm border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-1.5 py-0.5 font-mono text-3xs text-[var(--color-accent-fg)]'
 
 export function PlanningStat({
   label,
@@ -49,9 +56,9 @@ export function PlanningStat({
           : 'text-text-strong'
 
   return html`
-    <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
-      <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">${label}</div>
-      <div class="mt-2 text-3xl font-bold leading-none tabular-nums ${toneClass}">${value}</div>
+    <div class="${DECK_CARD}">
+      <div class="${DECK_LABEL}">${label}</div>
+      <div class="mt-1 font-mono text-2xl font-semibold leading-none tabular-nums ${toneClass}">${value}</div>
     </div>
   `
 }
@@ -62,7 +69,7 @@ function ExternalDocLink({ href, label }: { href: string; label: string }) {
       href=${href}
       target="_blank"
       rel="noreferrer"
-      class="inline-flex items-center gap-1 rounded border border-card-border/70 bg-[var(--white-3)] px-2.5 py-1.5 text-2xs font-medium text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
+      class="inline-flex items-center gap-1 rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-3xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
     >
       ${label}
       <span aria-hidden="true">\u2197</span>
@@ -90,20 +97,20 @@ function GuideCard({
   children?: ComponentChildren
 }) {
   return html`
-    <section class="flex flex-col gap-3 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4" aria-label=${title}>
+    <section class="flex flex-col gap-2 ${DECK_CARD}" aria-label=${title}>
       <div class="flex items-start justify-between gap-3">
         <div>
-          <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">${eyebrow}</div>
-          <h3 class="mt-1 text-md font-semibold text-text-strong">${title}</h3>
+          <div class="${DECK_LABEL}">${eyebrow}</div>
+          <h3 class="mt-1 text-sm font-semibold text-[var(--color-fg-primary)]">${title}</h3>
         </div>
-        <span class="rounded border border-card-border/70 bg-[var(--white-4)] px-2.5 py-1 text-2xs font-semibold text-text-body">
+        <span class="${DECK_CHIP} text-[var(--color-fg-secondary)]">
           ${count}
         </span>
       </div>
-      <p class="text-sm leading-relaxed text-text-muted whitespace-pre-wrap">${summary}</p>
+      <p class="text-xs leading-relaxed text-[var(--color-fg-muted)] whitespace-pre-wrap">${summary}</p>
       ${command ? html`
-        <div class="rounded border border-card-border/60 bg-[var(--white-3)] px-3 py-2 text-xs leading-relaxed text-text-body">
-          <code class="text-2xs text-text-strong">${command}</code>
+        <div class="rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-2 text-xs leading-relaxed text-[var(--color-fg-secondary)]">
+          <code class="font-mono text-3xs text-[var(--color-fg-primary)]">${command}</code>
         </div>
       ` : null}
       ${children}
@@ -147,32 +154,32 @@ function KeeperToolActivity() {
   }, [keeperList])
 
   return html`
-    <details class="overview-section-collapsible group overflow-hidden rounded border border-card-border/60 bg-[var(--backdrop-deep)]" open=${true}>
-      <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-base font-bold text-text-strong transition-colors hover:bg-[var(--white-3)]">
+    <details class="overview-section-collapsible group ${DECK_PANEL}" open=${true}>
+      <summary class="flex cursor-pointer items-center gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 text-sm font-semibold text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-panel-alt)]">
         <div class="min-w-0">
           <div>도구 활동 요약</div>
-          <div class="mt-1 text-xs font-normal text-text-muted">
+          <div class="mt-1 text-2xs font-normal text-[var(--color-fg-muted)]">
             keeper가 최근 사용한 도구와 활동 현황. 상세는 keeper 클릭.
           </div>
         </div>
-        <span class="ml-auto inline-flex items-center rounded border border-card-border/70 bg-[var(--white-4)] px-2.5 py-1 text-3xs uppercase tracking-wider text-text-body font-semibold">
+        <span class="ml-auto inline-flex items-center ${DECK_CHIP} font-semibold uppercase tracking-[0.08em] text-[var(--color-fg-secondary)]">
           ${totalToolTurns} calls
         </span>
       </summary>
-      <div class="p-5">
+      <div class="p-3">
         ${activeKeepers.length > 0 ? html`
-          <div class="mb-4">
-            <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted mb-2">활성 keeper</div>
-            <div class="flex flex-wrap gap-2">
+          <div class="mb-3">
+            <div class="${DECK_LABEL} mb-2">활성 keeper</div>
+            <div class="flex flex-wrap gap-1.5">
               ${activeKeepers.map(k => html`
                 <button
                   key=${k.name}
                   type="button"
-                  class="inline-flex items-center gap-1.5 rounded border border-card-border/60 bg-[var(--white-4)] px-3 py-1.5 text-xs text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
+                  class="inline-flex items-center gap-1.5 rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-3xs text-[var(--color-fg-secondary)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
                   onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
                 >
                   ${k.emoji ?? ''} ${k.koreanName ?? k.name}
-                  <span class="text-3xs font-mono text-text-dim">${k.turn_count ?? 0}t</span>
+                  <span class="text-[var(--color-fg-disabled)]">${k.turn_count ?? 0}t</span>
                 </button>
               `)}
             </div>
@@ -181,12 +188,12 @@ function KeeperToolActivity() {
 
         ${topTools.length > 0 ? html`
           <div>
-            <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted mb-2">최근 자주 사용된 도구</div>
-            <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-1.5">
+            <div class="${DECK_LABEL} mb-2">최근 자주 사용된 도구</div>
+            <div class="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-1">
               ${topTools.map(([name, count]) => html`
-                <div key=${name} class="flex items-center justify-between rounded bg-[var(--white-3)] px-3 py-1.5 text-xs">
-                  <span class="font-mono text-text-body truncate">${normalizeToolName(name)}</span>
-                  <span class="ml-2 flex-shrink-0 font-mono text-text-dim">${count}</span>
+                <div key=${name} class="flex items-center justify-between rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 text-3xs">
+                  <span class="truncate font-mono text-[var(--color-fg-secondary)]">${normalizeToolName(name)}</span>
+                  <span class="ml-2 flex-shrink-0 font-mono text-[var(--color-fg-disabled)]">${count}</span>
                 </div>
               `)}
             </div>
@@ -220,13 +227,13 @@ export function Planning() {
       : '아직 등록된 항목이 없습니다.'
 
   return html`
-    <div class="flex flex-col gap-6">
-      <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5" aria-label="계획 상태 요약">
-        <div class="flex flex-wrap items-start justify-between gap-4">
+    <div class="flex flex-col gap-4">
+      <section class="${DECK_PANEL}" aria-label="계획 상태 요약">
+        <div class="${DECK_HEAD}">
           <div class="max-w-190">
-            <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">계획 상태</div>
-            <h3 class="mt-2 text-[22px] font-semibold tracking-[-0.02em] text-text-strong">${planStatusHeadline}</h3>
-            <p class="mt-2 text-sm leading-relaxed text-text-muted whitespace-pre-wrap">${planStatusBody}</p>
+            <div class="${DECK_LABEL}">계획 상태</div>
+            <h3 class="mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">${planStatusHeadline}</h3>
+            <p class="mt-1 text-xs leading-relaxed text-[var(--color-fg-muted)] whitespace-pre-wrap">${planStatusBody}</p>
           </div>
           <${ActionButton}
             variant="ghost"
@@ -238,36 +245,38 @@ export function Planning() {
           <//>
         </div>
 
-        <div class="mt-5 grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3">
-          <${PlanningStat} label="전체 태스크" value=${totalTasks} />
-          <${PlanningStat} label="할 일" value=${todo.length} />
-          <${PlanningStat} label="진행 중" value=${inProgress.length} tone="warn" />
-          <${PlanningStat} label="완료" value=${done.length} tone="ok" />
-          <${PlanningStat} label="높은 우선순위" value=${highPriority} tone=${highPriority > 0 ? 'bad' : 'default'} />
-        </div>
+        <div class="p-3">
+          <div class="grid grid-cols-[repeat(auto-fit,minmax(128px,1fr))] gap-2">
+            <${PlanningStat} label="전체 태스크" value=${totalTasks} />
+            <${PlanningStat} label="할 일" value=${todo.length} />
+            <${PlanningStat} label="진행 중" value=${inProgress.length} tone="warn" />
+            <${PlanningStat} label="완료" value=${done.length} tone="ok" />
+            <${PlanningStat} label="높은 우선순위" value=${highPriority} tone=${highPriority > 0 ? 'bad' : 'default'} />
+          </div>
 
-        <div class="mt-5 grid gap-4 xl:grid-cols-2">
-          <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4" aria-label="태스크 추가">
-            <div class="mb-3">
-              <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">백로그 항목</div>
-              <h3 class="mt-1 text-md font-semibold text-text-strong">태스크 추가</h3>
-            </div>
-            <${TaskCreateForm} />
-            <div class="mt-3 flex items-center gap-2">
-              <${ExternalDocLink} href=${QUICK_START_DOC_URL} label="빠른 시작" />
-            </div>
-          </section>
+          <div class="mt-3 grid gap-3 xl:grid-cols-2">
+            <section class="${DECK_CARD}" aria-label="태스크 추가">
+              <div class="mb-2">
+                <div class="${DECK_LABEL}">백로그 항목</div>
+                <h3 class="mt-1 text-sm font-semibold text-[var(--color-fg-primary)]">태스크 추가</h3>
+              </div>
+              <${TaskCreateForm} />
+              <div class="mt-2 flex items-center gap-2">
+                <${ExternalDocLink} href=${QUICK_START_DOC_URL} label="빠른 시작" />
+              </div>
+            </section>
 
-          <${GuideCard}
-            eyebrow="목표 파이프라인"
-            title="장기 목표 파이프라인"
-            count=${goals.value.length}
-            summary=${hasGoals
-              ? '등록된 목표를 단기/중기/장기로 나눠 추적합니다.'
-              : '등록된 목표가 없습니다. 목표를 등록하면 여기에 표시됩니다.'}
-            docHref=${QUICK_START_DOC_URL}
-            docLabel="빠른 시작"
-          />
+            <${GuideCard}
+              eyebrow="목표 파이프라인"
+              title="장기 목표 파이프라인"
+              count=${goals.value.length}
+              summary=${hasGoals
+                ? '등록된 목표를 단기/중기/장기로 나눠 추적합니다.'
+                : '등록된 목표가 없습니다. 목표를 등록하면 여기에 표시됩니다.'}
+              docHref=${QUICK_START_DOC_URL}
+              docLabel="빠른 시작"
+            />
+          </div>
         </div>
       </section>
 
@@ -279,38 +288,40 @@ export function Planning() {
 
       <${KeeperToolActivity} />
 
-      <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4" aria-label="목표 파이프라인">
-        <div class="flex items-center justify-between gap-3">
-          <div>
-            <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">목표 파이프라인</div>
-            <h3 class="mt-1 text-md font-semibold text-text-strong">
-              장기 목표 ${hasGoals ? `(${goals.value.length})` : ''}
-            </h3>
+      <section class="${DECK_PANEL}" aria-label="목표 파이프라인">
+        <div class="${DECK_HEAD}">
+          <div class="flex w-full items-center justify-between gap-3">
+            <div>
+              <div class="${DECK_LABEL}">목표 파이프라인</div>
+              <h3 class="mt-1 text-sm font-semibold text-[var(--color-fg-primary)]">
+                장기 목표 ${hasGoals ? `(${goals.value.length})` : ''}
+              </h3>
+            </div>
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 rounded-sm border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-2.5 py-1.5 font-mono text-3xs font-medium text-[var(--color-accent-fg)] transition-colors hover:border-[var(--color-accent-fg)]"
+              onClick=${() => navigate('workspace', { section: 'planning', view: 'goal-tree' })}
+            >
+              목표 트리에서 보기
+              <span aria-hidden="true">\u2192</span>
+            </button>
           </div>
-          <button
-            type="button"
-            class="inline-flex items-center gap-1.5 rounded border border-accent/25 bg-[var(--accent-12)] px-3 py-1.5 text-xs font-medium text-accent transition-colors hover:border-accent/40 hover:bg-[var(--accent-15)]"
-            onClick=${() => navigate('workspace', { section: 'planning', view: 'goal-tree' })}
-          >
-            목표 트리에서 보기
-            <span aria-hidden="true">\u2192</span>
-          </button>
         </div>
         ${hasGoals ? html`
-          <div class="mt-3 flex flex-col gap-2">
-            <div class="flex flex-wrap gap-2">
+          <div class="flex flex-col gap-2 p-3">
+            <div class="flex flex-wrap gap-1.5">
               ${(grouped.short ?? []).length > 0 ? html`
-                <span class="rounded border border-ok/25 bg-ok/10 px-2 py-0.5 text-2xs text-ok">
+                <span class="rounded-sm border border-ok/25 bg-ok/10 px-1.5 py-0.5 font-mono text-3xs text-ok">
                   단기 ${(grouped.short ?? []).length}${hp.short.total > 0 ? ` · ${hp.short.done}/${hp.short.total} (${formatProgressPct(hp.short)})` : ''}
                 </span>
               ` : null}
               ${(grouped.mid ?? []).length > 0 ? html`
-                <span class="rounded border border-warn/25 bg-warn/10 px-2 py-0.5 text-2xs text-warn">
+                <span class="rounded-sm border border-warn/25 bg-warn/10 px-1.5 py-0.5 font-mono text-3xs text-warn">
                   중기 ${(grouped.mid ?? []).length}${hp.mid.total > 0 ? ` · ${hp.mid.done}/${hp.mid.total} (${formatProgressPct(hp.mid)})` : ''}
                 </span>
               ` : null}
               ${(grouped.long ?? []).length > 0 ? html`
-                <span class="rounded border border-accent/25 bg-[var(--accent-10)] px-2 py-0.5 text-2xs text-accent">
+                <span class="${BRASS_CHIP}">
                   장기 ${(grouped.long ?? []).length}${hp.long.total > 0 ? ` · ${hp.long.done}/${hp.long.total} (${formatProgressPct(hp.long)})` : ''}
                 </span>
               ` : null}
@@ -318,10 +329,10 @@ export function Planning() {
             ${(hp.short.total + hp.mid.total + hp.long.total) > 0 ? html`
               <div class="flex flex-col gap-1">
                 ${hp.short.total > 0 ? html`
-                  <div class="flex items-center gap-2 text-2xs">
-                    <span class="w-8 shrink-0 text-text-muted">단기</span>
+                  <div class="flex items-center gap-2 text-3xs">
+                    <span class="${DECK_META} w-8 shrink-0">단기</span>
                     <div
-                      class="relative h-1.5 grow overflow-hidden rounded-sm bg-[var(--color-bg-surface)]"
+                      class="relative h-1 grow overflow-hidden rounded-sm bg-[var(--color-bg-elevated)]"
                       role="progressbar"
                       aria-valuenow=${Math.round(hp.short.ratio * 100)}
                       aria-valuemin="0"
@@ -336,10 +347,10 @@ export function Planning() {
                   </div>
                 ` : null}
                 ${hp.mid.total > 0 ? html`
-                  <div class="flex items-center gap-2 text-2xs">
-                    <span class="w-8 shrink-0 text-text-muted">중기</span>
+                  <div class="flex items-center gap-2 text-3xs">
+                    <span class="${DECK_META} w-8 shrink-0">중기</span>
                     <div
-                      class="relative h-1.5 grow overflow-hidden rounded-sm bg-[var(--color-bg-surface)]"
+                      class="relative h-1 grow overflow-hidden rounded-sm bg-[var(--color-bg-elevated)]"
                       role="progressbar"
                       aria-valuenow=${Math.round(hp.mid.ratio * 100)}
                       aria-valuemin="0"
@@ -354,10 +365,10 @@ export function Planning() {
                   </div>
                 ` : null}
                 ${hp.long.total > 0 ? html`
-                  <div class="flex items-center gap-2 text-2xs">
-                    <span class="w-8 shrink-0 text-text-muted">장기</span>
+                  <div class="flex items-center gap-2 text-3xs">
+                    <span class="${DECK_META} w-8 shrink-0">장기</span>
                     <div
-                      class="relative h-1.5 grow overflow-hidden rounded-sm bg-[var(--color-bg-surface)]"
+                      class="relative h-1 grow overflow-hidden rounded-sm bg-[var(--color-bg-elevated)]"
                       role="progressbar"
                       aria-valuenow=${Math.round(hp.long.ratio * 100)}
                       aria-valuemin="0"
@@ -365,7 +376,7 @@ export function Planning() {
                       aria-label=${`장기 목표 진행 ${hp.long.done}/${hp.long.total}`}
                     >
                       <div
-                        class="absolute inset-y-0 left-0 bg-accent"
+                        class="absolute inset-y-0 left-0 bg-[var(--color-accent-fg)]"
                         style=${`width: ${(hp.long.ratio * 100).toFixed(1)}%`}
                       ></div>
                     </div>
@@ -373,24 +384,24 @@ export function Planning() {
                 ` : null}
               </div>
             ` : null}
-            <div class="mt-4 flex flex-col gap-3">
+            <div class="mt-3 flex flex-col gap-2">
               ${(['short', 'mid', 'long'] as const).map(h => {
                 const list = grouped[h] ?? []
                 if (list.length === 0) return null
                 return html`
                   <div key=${h}>
-                    <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted mb-2">
+                    <div class="${DECK_LABEL} mb-1.5">
                       ${horizonLabel(h)} 목표
                     </div>
-                    <div class="flex flex-col gap-2">
+                    <div class="flex flex-col gap-1.5">
                       ${list.map(g => {
                         const p = goalProgressFor(g.id)
                         return html`
-                          <div key=${g.id} class="flex items-center gap-3 rounded border border-card-border/60 bg-[var(--white-3)] px-3 py-2">
+                          <div key=${g.id} class="flex items-center gap-2 rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5">
                             <div class="min-w-0 flex-1">
                               <div class="flex items-center gap-2">
-                                <span class="text-xs font-medium text-text-strong truncate">${g.title}</span>
-                                <span class="shrink-0 rounded border border-card-border/70 bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-text-muted">${goalPhaseLabel(g.phase)}</span>
+                                <span class="truncate text-xs font-medium text-[var(--color-fg-primary)]">${g.title}</span>
+                                <span class="${DECK_CHIP} shrink-0 text-[var(--color-fg-muted)]">${goalPhaseLabel(g.phase)}</span>
                               </div>
                             </div>
                             <div class="w-28">
@@ -406,7 +417,7 @@ export function Planning() {
             </div>
           </div>
         ` : html`
-          <p class="mt-2 text-sm text-text-muted">등록된 목표가 없습니다. 목표 트리에서 추가할 수 있습니다.</p>
+          <p class="p-3 text-xs text-[var(--color-fg-muted)]">등록된 목표가 없습니다. 목표 트리에서 추가할 수 있습니다.</p>
         `}
       </section>
     </div>

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -29,8 +29,8 @@ export function Work() {
     : 'board'
 
   return html`
-    <div class="flex flex-col gap-5">
-      <div class="transition-opacity duration-300">
+    <div class="flex min-w-0 flex-col gap-3">
+      <div class="min-w-0 transition-opacity duration-300">
         <${ErrorBoundary} label=${current}>
           ${current === 'board' ? html`<${Memory} />`
             : current === 'planning' ? html`<${PlanningPanel} />`


### PR DESCRIPTION
## Summary
- Tighten Workspace planning and goal deck panels toward the dark MASC Cockpit visual target.
- Compact stat cards, goal/task rows, metadata chips, and progress surfaces using existing cockpit tokens.
- This is one small slice of the broader cockpit alignment wave.

## Validation
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/goals/planning.test.ts src/components/goals/goal-tree.test.ts src/components/goals/kanban-components.test.ts
- pnpm typecheck
- git diff --check

## Merge control
- Opened as draft and labeled do-not-merge so this visual slice can be reviewed with the rest of the wave.