### PR TITLE
[codex] Harden dashboard GitHub credential provisioning

### DIFF
--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -20,17 +20,63 @@ open Repo_manager_types
 let now_unix_ms () =
   Int64.of_float (Unix.gettimeofday () *. 1000.0)
 
-(** Run [gh auth status] against the supplied [GH_CONFIG_DIR] and
-    return whether it succeeded.  The implementation runs synchronously
-    via [Unix.system] for now; PR-C will move it to [Process_eio.run_argv]
-    once the lifecycle hooks land in the keeper-side path. *)
-let gh_auth_status_ok ~gh_config_dir =
-  let cmd =
-    Printf.sprintf
-      "GH_CONFIG_DIR=%s gh auth status >/dev/null 2>&1"
-      (Filename.quote gh_config_dir)
+let close_fd_noerr fd =
+  try Unix.close fd with Unix.Unix_error _ -> ()
+
+let env_key kv =
+  match String.index_opt kv '=' with
+  | None -> kv
+  | Some i -> String.sub kv 0 i
+
+let scrubbed_gh_env_key = function
+  | "GH_CONFIG_DIR"
+  | "GH_TOKEN"
+  | "GITHUB_TOKEN"
+  | "GH_ENTERPRISE_TOKEN"
+  | "GITHUB_ENTERPRISE_TOKEN"
+  | "GH_PROMPT_DISABLED"
+  | "GIT_TERMINAL_PROMPT" ->
+      true
+  | _ -> false
+
+let gh_bundle_env ~gh_config_dir =
+  let inherited =
+    Unix.environment ()
+    |> Array.to_list
+    |> List.filter (fun kv -> not (scrubbed_gh_env_key (env_key kv)))
   in
-  match Unix.system cmd with Unix.WEXITED 0 -> true | _ -> false
+  Array.of_list
+    (inherited
+     @ [
+         "GH_CONFIG_DIR=" ^ gh_config_dir;
+         "GIT_TERMINAL_PROMPT=0";
+         "GH_PROMPT_DISABLED=1";
+       ])
+
+(** Run [gh auth status] against the supplied [GH_CONFIG_DIR] and
+    return whether it succeeded.  The child process receives a
+    bundle-scoped environment only, so ambient GH_TOKEN/GITHUB_TOKEN
+    values cannot make a stale bundle look materialized. *)
+let gh_auth_status_ok ~gh_config_dir =
+  let devnull_in = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+  let devnull_out = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644 in
+  let pid =
+    try
+      Some
+        (Unix.create_process_env "gh"
+           [| "gh"; "auth"; "status" |]
+           (gh_bundle_env ~gh_config_dir)
+           devnull_in devnull_out devnull_out)
+    with Unix.Unix_error _ -> None
+  in
+  close_fd_noerr devnull_in;
+  close_fd_noerr devnull_out;
+  match pid with
+  | None -> false
+  | Some pid -> (
+      match snd (Unix.waitpid [] pid) with
+      | Unix.WEXITED 0 -> true
+      | _ -> false)
 
 (** Compute the new state for [gh_config_dir] without writing anywhere.
     Pure with respect to credential records; reads filesystem + invokes
@@ -308,6 +354,10 @@ let rec mkdir_p path mode =
       [/dev/null] so partial-failure messages from [gh] cannot
       accidentally surface a user-supplied token.
     - [gh_config_dir] is rejected if it contains a [".."] segment.
+    - [gh] receives only bundle-scoped GitHub auth env and is forced to
+      [--insecure-storage], so the token is written into
+      [GH_CONFIG_DIR/hosts.yml] instead of an operator keyring that a
+      keeper container cannot mount.
     - The resulting bundle is verified by [verify_state] before the
       function returns; the caller can rely on the returned [state]
       reflecting the actual on-disk outcome.
@@ -343,17 +393,12 @@ let provision_via_with_token ?credential_id ?identity_label
           let devnull_out =
             Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644
           in
-          let env =
-            Array.append (Unix.environment ())
-              [|
-                "GH_CONFIG_DIR=" ^ gh_config_dir;
-                "GIT_TERMINAL_PROMPT=0";
-              |]
-          in
+          let env = gh_bundle_env ~gh_config_dir in
           let argv =
             [|
               "gh"; "auth"; "login";
               "--with-token";
+              "--insecure-storage";
               "--hostname"; "github.com";
               "--git-protocol"; "https";
             |]

--- a/lib/repo_manager/credential_materializer.mli
+++ b/lib/repo_manager/credential_materializer.mli
@@ -75,6 +75,10 @@ val provision_via_with_token :
     - [stdout]/[stderr] of the subprocess are redirected to [/dev/null]
       so [gh] cannot leak a malformed-token diagnostic.
     - [gh_config_dir] is rejected if it contains a [..] segment.
+    - [gh] receives a bundle-local environment that scrubs ambient
+      GH_TOKEN/GITHUB_TOKEN values and forces [--insecure-storage], so
+      the resulting [hosts.yml] is mounted with the keeper bundle
+      instead of being hidden in the operator's host keyring.
     - On success the function: (1) calls {!relabel_hosts_yml} when
       [identity_label] is supplied (RFC-0008 F-2 close), (2) calls
       {!f1_gate_check} when [credential_id] is supplied (RFC-0019 PR-C

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -123,6 +123,28 @@ let apply_base_path_defaults ~base_path
       }
   | _ -> credential
 
+let credential_create_preflight ~base_path
+    (credential : Repo_manager_types.credential) =
+  if String.equal credential.id Credential_store.default_credential.id then
+    Error
+      (`Already_exists
+        (Printf.sprintf "Credential already exists: %s" credential.id))
+  else
+    match Credential_store.load_all ~base_path with
+    | Error msg -> Error (`Load_failed msg)
+    | Ok credentials ->
+        if
+          List.exists
+            (fun (c : Repo_manager_types.credential) ->
+              String.equal c.id credential.id)
+            credentials
+        then
+          Error
+            (`Already_exists
+              (Printf.sprintf "Credential already exists: %s"
+                 credential.id))
+        else Ok ()
+
 let add_routes router =
   router
   |> Http.Router.get "/api/v1/credentials" (fun request reqd ->
@@ -241,82 +263,109 @@ let add_routes router =
                        let credential =
                          apply_base_path_defaults ~base_path credential
                        in
-                       match oauth_method with
-                       | "web" -> (
-                           match Credential_store.add ~base_path credential with
-                           | Error msg -> response `Bad_request msg
-                           | Ok cred ->
-                               Http.Response.json ~request:req
-                                 (Yojson.Safe.to_string (credential_json cred))
-                                 reqd)
-                       | "with_token" -> (
-                           match token_opt with
-                           | None ->
-                               response `Bad_request
-                                 "with_token oauth_method requires a \
-                                  \"token\" field"
-                           | Some token -> (
-                               match credential.gh_config_dir with
-                               | None ->
-                                   response `Bad_request
-                                     "with_token oauth_method requires \
-                                      gh_config_dir or a server-derived \
-                                      default"
-                               | Some dir -> (
-                                   match
-                                     Credential_materializer
-                                     .provision_via_with_token
-                                       ~credential_id:credential.id
-                                       ~identity_label:credential.username
-                                       ~gh_config_dir:dir ~token ()
-                                   with
-                                   | Error msg -> response `Bad_request msg
-                                   | Ok _state -> (
-                                       (* RFC-0019 PR-C F-1 gate
-                                          (permissive): emit the
-                                          gate_warned counter when the
-                                          freshly-provisioned bundle's
-                                          token fingerprint matches the
-                                          operator ambient `gh auth
-                                          token`.  Operator can trace
-                                          credentials that share their
-                                          PAT via Prometheus before
-                                          PR-D ramps the gate to strict.
-                                          Never blocks materialisation. *)
-                                       (match
+                       (match
+                          credential_create_preflight ~base_path
+                            credential
+                        with
+                        | Error (`Load_failed msg) ->
+                            response `Internal_server_error msg
+                        | Error (`Already_exists msg) ->
+                            response `Bad_request msg
+                        | Ok () -> (
+                            match oauth_method with
+                            | "web" -> (
+                                match
+                                  Credential_store.add ~base_path
+                                    credential
+                                with
+                                | Error msg -> response `Bad_request msg
+                                | Ok cred ->
+                                    Http.Response.json ~request:req
+                                      (Yojson.Safe.to_string
+                                         (credential_json cred))
+                                      reqd)
+                            | "with_token" -> (
+                                match token_opt with
+                                | None ->
+                                    response `Bad_request
+                                      "with_token oauth_method requires a \
+                                       \"token\" field"
+                                | Some token -> (
+                                    match credential.gh_config_dir with
+                                    | None ->
+                                        response `Bad_request
+                                          "with_token oauth_method \
+                                           requires gh_config_dir or a \
+                                           server-derived default"
+                                    | Some dir -> (
+                                        match
                                           Credential_materializer
-                                          .f1_gate_check
-                                            ~credential_id:credential.id
-                                            ~gh_config_dir:dir
+                                          .provision_via_with_token
+                                            ~credential_id:
+                                              credential.id
+                                            ~identity_label:
+                                              credential.username
+                                            ~gh_config_dir:dir ~token
+                                            ()
                                         with
-                                        | Credential_materializer
-                                          .F1_shared_with_operator ->
-                                            Prometheus.inc_counter
-                                              "keeper_credential_provider_gate_warned_total"
-                                              ~labels:
-                                                [ ("credential_id",
-                                                   credential.id);
-                                                  ("scope",
-                                                   "shared_with_operator") ]
-                                              ()
-                                        | F1_distinct | F1_skipped _ ->
-                                            ());
-                                       match
-                                         Credential_store.add
-                                           ~base_path credential
-                                       with
-                                       | Error msg -> response `Bad_request msg
-                                       | Ok cred ->
-                                           Http.Response.json ~request:req
-                                             (Yojson.Safe.to_string
-                                                (credential_json cred))
-                                             reqd))))
-                       | other ->
-                           response `Bad_request
-                             (Printf.sprintf
-                                "unknown oauth_method: %S; expected \
-                                 \"web\" or \"with_token\""
-                                other))))
+                                        | Error msg ->
+                                            response `Bad_request msg
+                                        | Ok _state -> (
+                                            (* RFC-0019 PR-C F-1 gate
+                                               (permissive): emit the
+                                               gate_warned counter when
+                                               the freshly-provisioned
+                                               bundle's token fingerprint
+                                               matches the operator
+                                               ambient `gh auth token`.
+                                               Operator can trace
+                                               credentials that share
+                                               their PAT via Prometheus
+                                               before PR-D ramps the gate
+                                               to strict. Never blocks
+                                               materialisation. *)
+                                            (match
+                                               Credential_materializer
+                                               .f1_gate_check
+                                                 ~credential_id:
+                                                   credential.id
+                                                 ~gh_config_dir:dir
+                                             with
+                                             | Credential_materializer
+                                               .F1_shared_with_operator ->
+                                                 Prometheus.inc_counter
+                                                   "keeper_credential_provider_gate_warned_total"
+                                                   ~labels:
+                                                     [
+                                                       ( "credential_id",
+                                                         credential.id );
+                                                       ( "scope",
+                                                         "shared_with_operator"
+                                                       );
+                                                     ]
+                                                   ()
+                                             | F1_distinct
+                                             | F1_skipped _ ->
+                                                 ());
+                                            match
+                                              Credential_store.add
+                                                ~base_path credential
+                                            with
+                                            | Error msg ->
+                                                response `Bad_request msg
+                                            | Ok cred ->
+                                                Http.Response.json
+                                                  ~request:req
+                                                  (Yojson.Safe.to_string
+                                                     (credential_json
+                                                        cred))
+                                                  reqd))))
+                            | other ->
+                                response `Bad_request
+                                  (Printf.sprintf
+                                     "unknown oauth_method: %S; expected \
+                                      \"web\" or \"with_token\""
+                                     other))))))
          request reqd)
   |> Http.Router.add ~path:("PREFIX:/api/v1/credentials/")
        ~methods:[`DELETE]

--- a/test/test_credential_materializer.ml
+++ b/test/test_credential_materializer.ml
@@ -182,6 +182,46 @@ let test_path_safe_accepts_ordinary_paths () =
 let canary_token =
   "canary_token_RFC0019_PRB_a1b2c3d4e5f6_should_NEVER_appear_in_logs"
 
+let contains_substring s needle =
+  try
+    ignore (Str.search_forward (Str.regexp_string needle) s 0);
+    true
+  with Not_found -> false
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let read_file path =
+  let ic = open_in path in
+  let buf = Buffer.create 256 in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      try
+        while true do
+          Buffer.add_string buf (input_line ic);
+          Buffer.add_char buf '\n'
+        done;
+        Buffer.contents buf
+      with End_of_file -> Buffer.contents buf)
+
+let with_env_vars vars f =
+  let saved =
+    List.map (fun (k, _) -> (k, Sys.getenv_opt k)) vars
+  in
+  List.iter (fun (k, v) -> Unix.putenv k v) vars;
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (function
+          | k, Some v -> Unix.putenv k v
+          | k, None -> Unix.putenv k "")
+        saved)
+    f
+
 let test_provision_rejects_empty_token () =
   match
     Credential_materializer.provision_via_with_token
@@ -215,6 +255,126 @@ let test_provision_rejects_path_traversal () =
            true
          with Not_found -> false)
   | Ok _ -> Alcotest.fail "expected Error for path with .. segment"
+
+let test_provision_uses_bundle_env_and_insecure_storage () =
+  with_temp_base_path (fun base ->
+      let bin_dir = Filename.concat base "bin" in
+      Unix.mkdir bin_dir 0o755;
+      let gh_path = Filename.concat bin_dir "gh" in
+      write_file gh_path
+        {|#!/bin/sh
+set -eu
+cmd1="${1:-}"
+cmd2="${2:-}"
+mkdir -p "$GH_CONFIG_DIR"
+if [ "$cmd1" = "auth" ] && [ "$cmd2" = "login" ]; then
+  env | sort > "$GH_CONFIG_DIR/login.env"
+  printf '%s\n' "$@" > "$GH_CONFIG_DIR/login.argv"
+  IFS= read -r token || token=""
+  {
+    printf 'github.com:\n'
+    printf '    user: real-login\n'
+    printf '    oauth_token: %s\n' "$token"
+    printf '    git_protocol: https\n'
+  } > "$GH_CONFIG_DIR/hosts.yml"
+  exit 0
+fi
+if [ "$cmd1" = "auth" ] && [ "$cmd2" = "status" ]; then
+  env | sort > "$GH_CONFIG_DIR/status.env"
+  printf '%s\n' "$@" > "$GH_CONFIG_DIR/status.argv"
+  if [ -s "$GH_CONFIG_DIR/hosts.yml" ]; then
+    exit 0
+  fi
+  exit 1
+fi
+exit 2
+|};
+      Unix.chmod gh_path 0o755;
+      let gh_config_dir = Filename.concat base "bundle-gh" in
+      let ambient_gh_config_dir = Filename.concat base "ambient-gh" in
+      let path =
+        match Sys.getenv_opt "PATH" with
+        | None | Some "" -> bin_dir
+        | Some current -> bin_dir ^ ":" ^ current
+      in
+      with_env_vars
+        [
+          ("PATH", path);
+          ("GH_CONFIG_DIR", ambient_gh_config_dir);
+          ("GH_TOKEN", "ambient-gh-token");
+          ("GITHUB_TOKEN", "ambient-github-token");
+          ("GH_ENTERPRISE_TOKEN", "ambient-enterprise-token");
+          ("GITHUB_ENTERPRISE_TOKEN", "ambient-github-enterprise-token");
+          ("GH_PROMPT_DISABLED", "0");
+          ("GIT_TERMINAL_PROMPT", "1");
+        ]
+        (fun () ->
+          match
+            Credential_materializer.provision_via_with_token
+              ~credential_id:"keeper-A" ~identity_label:"keeper-A"
+              ~gh_config_dir ~token:canary_token ()
+          with
+          | Error msg ->
+              Alcotest.failf
+                "expected fake gh provisioning to succeed: %s" msg
+          | Ok (Materialized _) -> ()
+          | Ok other ->
+              Alcotest.failf "expected Materialized, got %s"
+                (show_credential_state other));
+      let login_argv =
+        read_file (Filename.concat gh_config_dir "login.argv")
+      in
+      Alcotest.(check bool) "login uses --insecure-storage" true
+        (contains_substring login_argv "--insecure-storage");
+      Alcotest.(check bool) "login argv does not expose token" false
+        (contains_substring login_argv canary_token);
+      let assert_clean_env label content =
+        Alcotest.(check bool)
+          (label ^ " uses target GH_CONFIG_DIR")
+          true
+          (contains_substring content ("GH_CONFIG_DIR=" ^ gh_config_dir));
+        Alcotest.(check bool)
+          (label ^ " disables gh prompts")
+          true
+          (contains_substring content "GH_PROMPT_DISABLED=1");
+        Alcotest.(check bool)
+          (label ^ " disables git terminal prompts")
+          true
+          (contains_substring content "GIT_TERMINAL_PROMPT=0");
+        List.iter
+          (fun poisoned ->
+            Alcotest.(check bool)
+              (label ^ " scrubs " ^ poisoned)
+              false
+              (contains_substring content poisoned))
+          [
+            "GH_CONFIG_DIR=" ^ ambient_gh_config_dir;
+            "GH_TOKEN=ambient-gh-token";
+            "GITHUB_TOKEN=ambient-github-token";
+            "GH_ENTERPRISE_TOKEN=ambient-enterprise-token";
+            "GITHUB_ENTERPRISE_TOKEN=ambient-github-enterprise-token";
+          ]
+      in
+      assert_clean_env "login env"
+        (read_file (Filename.concat gh_config_dir "login.env"));
+      assert_clean_env "status env"
+        (read_file (Filename.concat gh_config_dir "status.env"));
+      let hosts_yml =
+        read_file (Filename.concat gh_config_dir "hosts.yml")
+      in
+      Alcotest.(check bool) "hosts.yml user relabeled" true
+        (contains_substring hosts_yml "user: keeper-A");
+      Alcotest.(check bool) "real gh login user hidden" false
+        (contains_substring hosts_yml "user: real-login");
+      match
+        Credential_materializer.compute_token_sha256_prefix
+          ~gh_config_dir
+      with
+      | None -> Alcotest.fail "expected token fingerprint"
+      | Some prefix ->
+          Alcotest.(check string) "fingerprint is canary hash"
+            (Credential_materializer.sha256_prefix canary_token)
+            prefix)
 
 (* --- 6. SHA-256 fingerprint + F-1 gate (PR-C) --- *)
 
@@ -414,6 +574,9 @@ let () =
           Alcotest.test_case
             "provision rejects path traversal without echoing token"
             `Quick test_provision_rejects_path_traversal;
+          Alcotest.test_case
+            "provision writes bundle-local gh auth without ambient env"
+            `Quick test_provision_uses_bundle_env_and_insecure_storage;
         ] );
       ( "F-1 gate fingerprint",
         [


### PR DESCRIPTION
## Summary

- Force dashboard `with_token` GitHub materialization to write plain-text `hosts.yml` into the selected `GH_CONFIG_DIR` bundle via `gh auth login --with-token --insecure-storage`.
- Scrub ambient `GH_TOKEN`/`GITHUB_TOKEN`/enterprise token env when running bundle-local `gh auth login` and `gh auth status`, so host credentials cannot make a keeper bundle look valid.
- Preflight credential ID duplicates before running `with_token` provisioning, preventing duplicate POSTs from mutating an existing bundle before `Credential_store.add` rejects them.
- Add a fake-`gh` regression test proving bundle-local env, `--insecure-storage`, relabeling, and token fingerprint behavior.

## Root Cause / Operator Impact

PR #12583 made the dashboard POST path show `Materialized`, but `gh auth login --with-token` defaulted to the host credential store on this machine. Keeper Docker only mounts the configured `GH_CONFIG_DIR` bundle, not the operator keyring, so the dashboard could report success while the keeper container had no usable token. The same route also provisioned before checking duplicate IDs, so a duplicate request could mutate the on-disk bundle and then fail persistence.

## Checks

- `scripts/dune-local.sh build test/test_credential_materializer.exe test/test_credential_store.exe test/test_credential_provider.exe`
- `./_build/default/test/test_credential_materializer.exe` (20 tests)
- `./_build/default/test/test_credential_store.exe` (12 tests)
- `./_build/default/test/test_credential_provider.exe` (17 tests)
- `git diff --check HEAD~1..HEAD`