### PR TITLE
refactor(dashboard): simplify Overview tab and move Highlight to Lab

### DIFF
--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -1,25 +1,50 @@
 import { html } from 'htm/preact'
 import { route } from '../router'
-import { Card } from './common/card'
+import { Card, SectionCard } from './common/card'
 import { Tools } from './tools'
 import { Autoresearch } from './autoresearch'
 import { HarnessHealth } from './harness-health'
+import { severityToneClass } from './overview/overview'
+import type { OperatorAttentionItem } from '../types/dashboard-mission'
 
-type LabSection = 'tools' | 'autoresearch' | 'harness'
+type LabSection = 'tools' | 'autoresearch' | 'harness' | 'legacy'
 
 function currentSection(): LabSection {
   const section = route.value.params.section
-  if (section === 'autoresearch' || section === 'harness') {
+  if (section === 'autoresearch' || section === 'harness' || section === 'legacy') {
     return section
   }
   return 'tools'
+}
+
+function Highlight({ attention }: { attention: OperatorAttentionItem | null }) {
+  if (!attention) {
+    return html`
+      <${SectionCard} title="Legacy Highlight" data-testid="overview-highlight-empty">
+        <p class="text-2xs text-[var(--color-fg-muted)] italic">No critical attention items (Preview Mode)</p>
+      <//>
+    `
+  }
+  return html`
+    <${SectionCard} title="Legacy Highlight" data-testid="overview-highlight">
+      <div class="flex items-center gap-3">
+        <span class="flex-shrink-0 flex h-2 w-2 rounded-full bg-[var(--color-status-err)] animate-pulse" />
+        <div class="flex-1 min-w-0">
+          <p class="text-xs font-medium truncate ${severityToneClass(attention.severity)}">${attention.summary}</p>
+          <p class="text-2xs text-[var(--color-fg-secondary)] truncate">
+            ${attention.actor ?? attention.target_id ?? attention.target_type}
+          </p>
+        </div>
+      </div>
+    <//>
+  `
 }
 
 export function Lab() {
   const section = currentSection()
 
   return html`
-    <div>
+    <div class="space-y-6">
       ${section === 'tools' ? html`
         <${Tools} />
       ` : null}
@@ -32,6 +57,18 @@ export function Lab() {
 
       ${section === 'harness' ? html`
         <${HarnessHealth} />
+      ` : null}
+
+      ${section === 'legacy' ? html`
+        <div class="space-y-4">
+          <header class="flex items-center justify-between">
+            <h2 class="text-sm font-bold uppercase tracking-wider text-[var(--color-fg-muted)]">Legacy / Hidden Widgets</h2>
+          </header>
+          <${Highlight} attention=${null} />
+          <p class="text-2xs text-[var(--color-fg-muted)] italic">
+            This widget was removed from the main Overview tab to reduce clutter.
+          </p>
+        </div>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -3,7 +3,7 @@
 // "What's the party doing today?" in one glance, no scroll.
 // 5 sections, top-to-bottom (V2):
 //   0. Alert Panel     — failing agents and stalled tasks, actionable alerts first
-//   1. Highlight       — mission.summary.top_attention, one-line focus
+//   1. (Removed: Highlight moved to Lab)
 //   2. Funnel          — 5 task-count cells (new/active/verify/done/target)
 //   3. Mission party   — one active session (goal, members, progress bar, blocker)
 //   4. Keeper strip    — top three keepers by recent heartbeat
@@ -23,7 +23,6 @@ import type { Agent, Task, Keeper } from '../../types/core'
 import type {
   DashboardMissionResponse,
   DashboardMissionSessionCard,
-  OperatorAttentionItem,
 } from '../../types/dashboard-mission'
 import { openAgentDetail } from '../agent-detail-state'
 import { nowSecondsSignal, useNowSecondsTicker } from '../../lib/now-signal'
@@ -264,7 +263,7 @@ function FunnelCard({ counts }: { counts: FunnelCounts }) {
   `
 }
 
-// ─── Highlight ───────────────────────────────────────────────────────────────
+// ─── Shared Tone ─────────────────────────────────────────────────────────────
 
 export function severityToneClass(severity?: string | null): string {
   switch ((severity ?? '').toLowerCase()) {
@@ -277,39 +276,6 @@ export function severityToneClass(severity?: string | null): string {
     default:
       return 'text-[var(--color-fg-muted)]'
   }
-}
-
-function Highlight({ attention }: { attention: OperatorAttentionItem | null }) {
-  if (attention === null) {
-    return html`
-      <section class=${CARD} aria-label="Highlight" data-testid="overview-highlight-empty">
-        <header class=${HEADER_ROW}>
-          <span class="flex min-w-0 items-center gap-2">
-            <span aria-hidden="true" class=${BRASS_RULE}></span>
-            <span>Top Signal</span>
-          </span>
-        </header>
-        <p class="text-xs text-[var(--color-fg-muted)]">No notable signal</p>
-      </section>
-    `
-  }
-  const severity = attention.severity === '' ? 'info' : attention.severity
-  return html`
-    <section class=${CARD} aria-label="Highlight" data-testid="overview-highlight">
-      <header class=${HEADER_ROW}>
-        <span class="flex min-w-0 items-center gap-2">
-          <span aria-hidden="true" class=${BRASS_RULE}></span>
-          <span>Top Signal</span>
-        </span>
-        <span class=${`shrink-0 ${severityToneClass(severity)}`}>
-          ${severity.toUpperCase()}
-        </span>
-      </header>
-      <div class="${COCKPIT_CELL} min-w-0">
-        <span class="block truncate text-xs text-[var(--color-fg-secondary)]">${attention.summary}</span>
-      </div>
-    </section>
-  `
 }
 
 // ─── Mission Party ───────────────────────────────────────────────────────────
@@ -494,13 +460,11 @@ export function Overview() {
   const nowMs = nowSecondsSignal.value * 1000
   const active = useMemo(() => pickActiveSession(snap), [snap])
   const counts = useMemo(() => computeFunnelCounts(taskList, active), [taskList, active])
-  const attention = snap?.summary?.top_attention ?? null
   const agentAlerts = useMemo(() => deriveAgentAlerts(agentList), [agentList])
   const taskAlerts = useMemo(() => deriveTaskAlerts(taskList, nowMs), [taskList, nowMs])
   return html`
     <div class="flex flex-col gap-2.5">
       <${AlertPanel} agentAlerts=${agentAlerts} taskAlerts=${taskAlerts} />
-      <${Highlight} attention=${attention} />
       <${FunnelCard} counts=${counts} />
       <${MissionPartyCard} active=${active} />
       <${KeeperStrip} keeperList=${keeperList} />


### PR DESCRIPTION
## 작업 내용
- Overview 탭에서 정보 밀도를 낮추기 위해 Highlight (2번 항목) 제거
- 제거된 Highlight 컴포넌트를 Lab > Legacy 섹션으로 이동하여 추후 참고 가능하게 보존
- Overview 내의 구형 CARD 스타일을 디자인 시스템의 SectionCard 컴포넌트로 교체