### PR TITLE
add reward_advice_artifact with typed verdict (replaces #12505)

### DIFF
--- a/lib/post_verifier.ml
+++ b/lib/post_verifier.ml
@@ -263,3 +263,31 @@ let to_dimension_results result =
     { dimension = Quality; verdict = result.quality };
     { dimension = Safety; verdict = result.safety };
   ]
+
+let to_reward_advice ~agent_name ?task_id result =
+  let verdict =
+    match result.overall with
+    | Pass -> Reward_advice_artifact.Pass
+    | Warn _ -> Reward_advice_artifact.Warn
+    | Fail _ -> Reward_advice_artifact.Fail
+  in
+  let advisory_message =
+    match result.overall with
+    | Pass ->
+      "Content passes all 3 post-verifier dimensions (relevance, quality, safety). \
+       No reward adjustment recommended."
+    | Warn reason ->
+      Printf.sprintf
+        "Post-verifier advisory: %s. \
+         Content is acceptable but a small reward reduction is suggested \
+         to reflect the warning signal. Evaluate in context before applying."
+        reason
+    | Fail reason ->
+      Printf.sprintf
+        "Post-verifier failed: %s. \
+         A significant reward reduction is suggested. \
+         This is an advisory; the reward system should confirm before applying."
+        reason
+  in
+  Reward_advice_artifact.of_post_verifier_verdict
+    ~agent_name ?task_id ~verdict ~advisory_message ()

--- a/lib/post_verifier.mli
+++ b/lib/post_verifier.mli
@@ -65,3 +65,11 @@ val result_to_json : verification_result -> Yojson.Safe.t
 (** Flatten a {!verification_result} into a list of three
     {!dimension_result} entries (Relevance, Quality, Safety). *)
 val to_dimension_results : verification_result -> dimension_result list
+
+val to_reward_advice :
+  agent_name:string ->
+  ?task_id:string ->
+  verification_result ->
+  Reward_advice_artifact.reward_advice_artifact
+(** Build a {!Reward_advice_artifact.reward_advice_artifact} from a verification result.
+    Convenience wrapper around {!Reward_advice_artifact.of_post_verifier_verdict}. *)

--- a/lib/reward_advice_artifact.ml
+++ b/lib/reward_advice_artifact.ml
@@ -1,0 +1,215 @@
+(** Reward_advice_artifact — Structured advisory artifacts from verifiers and benchmarks.
+
+    Bridges verification verdicts and benchmark scores to the reward system
+    with evidence-backed advisory hints.  The advisory pattern means callers
+    decide whether to apply the recommended [reward_multiplier]; the artifact
+    itself is a proposal, not a command.
+
+    @since Task-044 — Advisory Reward Advice Artifacts *)
+
+(** {1 Types} *)
+
+(** Source module that produced this artifact. *)
+type advice_source =
+  | Post_verifier   (** Heuristic 3-dimension content check. *)
+  | Benchmark       (** Tool-call quality benchmark scoring. *)
+  | Task_verifier   (** OAS/LLM task action verifier. *)
+
+(** Typed verdict classification.  Downstream consumers receive only valid
+    verdicts; [of_yojson] rejects unknown strings instead of mapping them
+    to a silent neutral default. *)
+type verdict =
+  | Pass
+  | Warn
+  | Fail
+
+(** A structured advisory hint from a verifier or benchmark to the reward system. *)
+type reward_advice_artifact = {
+  source : advice_source;
+  agent_name : string;
+  task_id : string option;
+  verdict : verdict;
+  reward_multiplier : float;   (** Suggested multiplier [0.0, 2.0]; 1.0 = neutral. *)
+  advisory_message : string;
+  evidence_refs : string list;
+  confidence : float;          (** Confidence in the advice [0.0, 1.0]. *)
+  timestamp : float;           (** Unix timestamp of artifact creation. *)
+}
+
+(** {1 Source helpers} *)
+
+let advice_source_to_string = function
+  | Post_verifier -> "post_verifier"
+  | Benchmark -> "benchmark"
+  | Task_verifier -> "task_verifier"
+
+let advice_source_of_string = function
+  | "post_verifier" -> Some Post_verifier
+  | "benchmark" -> Some Benchmark
+  | "task_verifier" -> Some Task_verifier
+  | _ -> None
+
+(** {1 Verdict helpers} *)
+
+let verdict_to_string = function
+  | Pass -> "pass"
+  | Warn -> "warn"
+  | Fail -> "fail"
+
+let verdict_of_string = function
+  | "pass" -> Some Pass
+  | "warn" -> Some Warn
+  | "fail" -> Some Fail
+  | _ -> None
+
+(** Derive a suggested reward multiplier from a typed verdict.
+    Pattern-match is exhaustive — no wildcard fallback. *)
+let multiplier_of_verdict = function
+  | Pass -> 1.0
+  | Warn -> 0.8
+  | Fail -> 0.4
+
+(** {1 Serialization} *)
+
+let clamp ~lo ~hi v = Float.max lo (Float.min hi v)
+
+let to_yojson (a : reward_advice_artifact) : Yojson.Safe.t =
+  `Assoc [
+    ("source", `String (advice_source_to_string a.source));
+    ("agent_name", `String a.agent_name);
+    ("task_id", Option.fold ~none:`Null ~some:(fun s -> `String s) a.task_id);
+    ("verdict", `String (verdict_to_string a.verdict));
+    ("reward_multiplier", `Float a.reward_multiplier);
+    ("advisory_message", `String a.advisory_message);
+    ("evidence_refs", `List (List.map (fun s -> `String s) a.evidence_refs));
+    ("confidence", `Float a.confidence);
+    ("timestamp", `Float a.timestamp);
+  ]
+
+let string_field ~default key (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String s) -> s
+     | _ -> default)
+  | _ -> default
+
+let float_field ~default key (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Float f) -> f
+     | Some (`Int i) -> float_of_int i
+     | _ -> default)
+  | _ -> default
+
+let string_list_field key (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`List items) ->
+       List.filter_map (function `String s -> Some s | _ -> None) items
+     | _ -> [])
+  | _ -> []
+
+let of_yojson (json : Yojson.Safe.t) : (reward_advice_artifact, string) result =
+  let source_str = string_field ~default:"" "source" json in
+  match advice_source_of_string source_str with
+  | None -> Error (Printf.sprintf "reward_advice_artifact: unknown source %S" source_str)
+  | Some source ->
+    let agent_name = string_field ~default:"" "agent_name" json in
+    if agent_name = "" then Error "reward_advice_artifact: agent_name missing"
+    else
+      let verdict_str = string_field ~default:"" "verdict" json in
+      match verdict_of_string verdict_str with
+      | None ->
+        Error (Printf.sprintf
+          "reward_advice_artifact: unknown verdict %S (expected pass/warn/fail)"
+          verdict_str)
+      | Some verdict ->
+        let task_id =
+          match json with
+          | `Assoc fields ->
+            (match List.assoc_opt "task_id" fields with
+             | Some (`String s) when s <> "" -> Some s
+             | _ -> None)
+          | _ -> None
+        in
+        Ok {
+          source;
+          agent_name;
+          task_id;
+          verdict;
+          reward_multiplier =
+            float_field ~default:1.0 "reward_multiplier" json
+            |> clamp ~lo:0.0 ~hi:2.0;
+          advisory_message = string_field ~default:"" "advisory_message" json;
+          evidence_refs = string_list_field "evidence_refs" json;
+          confidence = float_field ~default:1.0 "confidence" json |> clamp ~lo:0.0 ~hi:1.0;
+          timestamp = float_field ~default:0.0 "timestamp" json;
+        }
+
+(** {1 Factory: Post_verifier} *)
+
+(** Build a reward advice artifact from post-verifier verdict components.
+    Called by [Post_verifier.to_reward_advice] to avoid a circular dependency.
+
+    - Pass → multiplier 1.0, confidence 1.0
+    - Warn → multiplier 0.8, confidence 0.9
+    - Fail → multiplier 0.4, confidence 1.0 *)
+let of_post_verifier_verdict ~agent_name ?task_id ~verdict ~advisory_message () =
+  let confidence = match verdict with Warn -> 0.9 | _ -> 1.0 in
+  {
+    source = Post_verifier;
+    agent_name;
+    task_id;
+    verdict;
+    reward_multiplier = multiplier_of_verdict verdict;
+    advisory_message;
+    evidence_refs = [];
+    confidence;
+    timestamp = Time_compat.now ();
+  }
+
+(** {1 Factory: Benchmark} *)
+
+(** Build a reward advice artifact from a {!Tool_call_quality_benchmark_types.case_score}.
+
+    Maps [composite_score] → [reward_multiplier] with:
+    - score >= 0.8 → Pass (multiplier 1.1 bonus)
+    - score >= 0.5 → Warn (multiplier 0.9)
+    - score <  0.5 → Fail (multiplier 0.5) *)
+let of_benchmark_case_score ~agent_name ?task_id
+    (score : Tool_call_quality_benchmark_types.case_score) : reward_advice_artifact =
+  let cs = score.composite_score in
+  let verdict, reward_multiplier =
+    if cs >= 0.8 then (Pass, 1.1)
+    else if cs >= 0.5 then (Warn, 0.9)
+    else (Fail, 0.5)
+  in
+  let advisory_message =
+    Printf.sprintf
+      "Benchmark case %s: composite_score=%.3f (task_pass=%.2f, \
+       tool_selection=%.2f, arg_validity=%.2f, efficiency=%.2f). \
+       Suggested reward multiplier: %.2f. \
+       This is an advisory; apply only when benchmark evidence is trusted."
+      score.case_id cs
+      score.task_pass score.tool_selection score.arg_validity score.efficiency
+      reward_multiplier
+  in
+  let evidence_refs =
+    match score.prompt_fingerprint with
+    | Some fp -> [ "benchmark:" ^ score.case_id; "fingerprint:" ^ fp ]
+    | None -> [ "benchmark:" ^ score.case_id ]
+  in
+  {
+    source = Benchmark;
+    agent_name;
+    task_id;
+    verdict;
+    reward_multiplier;
+    advisory_message;
+    evidence_refs;
+    confidence = clamp ~lo:0.0 ~hi:1.0 cs;
+    timestamp = Time_compat.now ();
+  }

--- a/lib/reward_advice_artifact.mli
+++ b/lib/reward_advice_artifact.mli
@@ -1,0 +1,92 @@
+(** Reward_advice_artifact — Structured advisory artifacts from verifiers and benchmarks.
+
+    Bridges verification verdicts and benchmark scores to the reward system
+    with evidence-backed advisory hints.
+
+    The advisory pattern means callers decide whether to apply the recommended
+    [reward_multiplier]; the artifact itself is a proposal, not a command.
+
+    @since Task-044 — Advisory Reward Advice Artifacts *)
+
+(** {1 Types} *)
+
+(** Source module that produced this artifact. *)
+type advice_source =
+  | Post_verifier   (** Heuristic 3-dimension content check. *)
+  | Benchmark       (** Tool-call quality benchmark scoring. *)
+  | Task_verifier   (** OAS/LLM task action verifier. *)
+
+(** Typed verdict classification.  [of_yojson] rejects unknown strings. *)
+type verdict =
+  | Pass
+  | Warn
+  | Fail
+
+(** A structured advisory hint from a verifier or benchmark to the reward system. *)
+type reward_advice_artifact = {
+  source : advice_source;
+  agent_name : string;
+  task_id : string option;
+  verdict : verdict;
+  reward_multiplier : float;   (** Suggested multiplier [0.0, 2.0]; 1.0 = neutral. *)
+  advisory_message : string;
+  evidence_refs : string list;
+  confidence : float;          (** Confidence in the advice [0.0, 1.0]. *)
+  timestamp : float;           (** Unix timestamp of artifact creation. *)
+}
+
+(** {1 Source helpers} *)
+
+val advice_source_to_string : advice_source -> string
+(** Render a source as a lowercase string. *)
+
+val advice_source_of_string : string -> advice_source option
+(** Parse a source from string.  Returns [None] for unknown values. *)
+
+(** {1 Verdict helpers} *)
+
+val verdict_to_string : verdict -> string
+(** Render a verdict as ["pass"], ["warn"], or ["fail"]. *)
+
+val verdict_of_string : string -> verdict option
+(** Parse a verdict from string.  Returns [None] for unknown values. *)
+
+val multiplier_of_verdict : verdict -> float
+(** Derive a suggested reward multiplier from a typed verdict.
+    Pass → 1.0, Warn → 0.8, Fail → 0.4. *)
+
+(** {1 Serialization} *)
+
+val to_yojson : reward_advice_artifact -> Yojson.Safe.t
+(** Serialize to JSON. *)
+
+val of_yojson : Yojson.Safe.t -> (reward_advice_artifact, string) result
+(** Deserialize from JSON.  Returns [Error] when required fields are missing,
+    the source string is unrecognized, or the verdict string is not one of
+    pass/warn/fail. *)
+
+(** {1 Factory functions} *)
+
+val of_post_verifier_verdict :
+  agent_name:string ->
+  ?task_id:string ->
+  verdict:verdict ->
+  advisory_message:string ->
+  unit ->
+  reward_advice_artifact
+(** Build an artifact from post-verifier verdict components.
+    Called by {!Post_verifier.to_reward_advice}; avoids a circular dependency
+    between [Post_verifier] and [Reward_advice_artifact].
+    - Pass → multiplier 1.0, confidence 1.0
+    - Warn → multiplier 0.8, confidence 0.9
+    - Fail → multiplier 0.4, confidence 1.0 *)
+
+val of_benchmark_case_score :
+  agent_name:string ->
+  ?task_id:string ->
+  Tool_call_quality_benchmark_types.case_score ->
+  reward_advice_artifact
+(** Build an artifact from a {!Tool_call_quality_benchmark_types.case_score}.
+    Composite score >= 0.8 → Pass (multiplier 1.1 bonus);
+    >= 0.5 → Warn (multiplier 0.9);
+    <  0.5 → Fail (multiplier 0.5). *)

--- a/lib/tool_call_quality_benchmark.ml
+++ b/lib/tool_call_quality_benchmark.ml
@@ -23,6 +23,7 @@ let default_evidence_path = Tool_call_quality_benchmark_loader.default_evidence_
 let load_cases_from_file = Tool_call_quality_benchmark_loader.load_cases_from_file
 let load_runs_from_file = Tool_call_quality_benchmark_loader.load_runs_from_file
 let score_run = Tool_call_quality_benchmark_scoring.score_run
+let to_reward_advice = Tool_call_quality_benchmark_scoring.to_reward_advice
 let summarize = Tool_call_quality_benchmark_summary.summarize
 let json_check_to_yojson = Tool_call_quality_benchmark_render.json_check_to_yojson
 let case_score_to_yojson = Tool_call_quality_benchmark_render.case_score_to_yojson

--- a/lib/tool_call_quality_benchmark.mli
+++ b/lib/tool_call_quality_benchmark.mli
@@ -11,6 +11,12 @@ val load_runs_from_file : string -> (evidence_run list, string) Result.t
 val score_run :
   cases:benchmark_case list -> evidence_run -> case_score option
 
+val to_reward_advice :
+  agent_name:string ->
+  ?task_id:string ->
+  case_score ->
+  Reward_advice_artifact.reward_advice_artifact
+
 val summarize :
      cases:benchmark_case list
   -> runs:evidence_run list

--- a/lib/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark_scoring.ml
@@ -264,3 +264,6 @@ let score_run ~cases (run : evidence_run) =
               prompt_fingerprint = run.prompt_fingerprint;
               tool_sequence = tool_sequence run;
             }
+
+let to_reward_advice ~agent_name ?task_id score =
+  Reward_advice_artifact.of_benchmark_case_score ~agent_name ?task_id score

--- a/lib/tool_call_quality_benchmark_scoring.mli
+++ b/lib/tool_call_quality_benchmark_scoring.mli
@@ -64,3 +64,11 @@ val score_run :
     [(forbidden_count + over_limit) / call_count], capped at
     [1.0].  Zero calls -> [0.0].  [Tool_forbidden] case -> [1.0]
     when any call exists. *)
+
+val to_reward_advice :
+  agent_name:string ->
+  ?task_id:string ->
+  Tool_call_quality_benchmark_types.case_score ->
+  Reward_advice_artifact.reward_advice_artifact
+(** Build a {!Reward_advice_artifact.reward_advice_artifact} from a case score.
+    Maps [composite_score] to a reward multiplier and generates an advisory message. *)

--- a/test/dune
+++ b/test/dune
@@ -50,6 +50,7 @@
         test_multi_room test_worktree_detection test_bounded test_mention
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
         test_post_verifier
+        test_reward_advice_artifact
         test_keeper_cascade_profile
         test_keeper_hooks_oas_provider
         test_keeper_hooks_oas_pricing
@@ -246,6 +247,7 @@
           test_multi_room test_worktree_detection test_bounded test_mention
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
           test_post_verifier
+        test_reward_advice_artifact
           test_keeper_cascade_profile
           test_keeper_hooks_oas_provider
           test_keeper_hooks_oas_pricing

--- a/test/test_reward_advice_artifact.ml
+++ b/test/test_reward_advice_artifact.ml
@@ -1,0 +1,294 @@
+(** test_reward_advice_artifact.ml — Unit tests for Reward_advice_artifact.
+
+    Covers:
+    - advice_source round-trip serialization
+    - typed verdict: Pass/Warn/Fail round-trip, unknown → None
+    - multiplier_of_verdict exhaustive contract
+    - of_post_verifier_verdict: pass/warn/fail mapping
+    - of_benchmark_case_score: composite_score → multiplier bands
+    - to_yojson / of_yojson round-trip
+    - of_yojson rejects unknown verdict strings (fail-closed)
+    - Post_verifier.to_reward_advice convenience wrapper *)
+
+module RAA = Masc_mcp.Reward_advice_artifact
+module Pv  = Masc_mcp.Post_verifier
+
+let float_eps = 0.001
+
+let make_case_score ?(case_id = "case-001") ?(provider = "test") ?(model = "m1")
+    ?(keeper_profile = "default") composite_score : Masc_mcp.Tool_call_quality_benchmark_types.case_score =
+  let cs = composite_score in
+  {
+    case_id;
+    provider;
+    model;
+    keeper_profile;
+    passed = cs = 1.0;
+    task_pass = cs;
+    tool_selection = cs;
+    arg_validity = cs;
+    recovery = 1.0;
+    efficiency = cs;
+    unnecessary_tool_rate = 0.0;
+    composite_score = cs;
+    tool_call_count = 3;
+    latency_ms = Some 100;
+    input_tokens = None;
+    output_tokens = None;
+    cost_usd = None;
+    prompt_fingerprint = None;
+    tool_sequence = [];
+  }
+
+(* --- 1. Source round-trip --- *)
+
+let test_source_round_trip () =
+  let sources = [RAA.Post_verifier; RAA.Benchmark; RAA.Task_verifier] in
+  List.iter (fun src ->
+    let s = RAA.advice_source_to_string src in
+    match RAA.advice_source_of_string s with
+    | Some reparsed ->
+      Alcotest.(check string)
+        ("round-trip " ^ s)
+        (RAA.advice_source_to_string src)
+        (RAA.advice_source_to_string reparsed)
+    | None ->
+      Alcotest.fail (Printf.sprintf "advice_source_of_string %S returned None" s)
+  ) sources
+
+let test_source_unknown () =
+  Alcotest.(check (option string))
+    "unknown source -> None"
+    None
+    (Option.map RAA.advice_source_to_string (RAA.advice_source_of_string "no_such_source"))
+
+(* --- 2. Verdict round-trip --- *)
+
+let test_verdict_round_trip () =
+  let verdicts = [RAA.Pass; RAA.Warn; RAA.Fail] in
+  List.iter (fun v ->
+    let s = RAA.verdict_to_string v in
+    match RAA.verdict_of_string s with
+    | Some v' -> Alcotest.(check bool) s true (v = v')
+    | None -> Alcotest.fail (Printf.sprintf "verdict_of_string %S returned None" s)
+  ) verdicts
+
+let test_verdict_unknown () =
+  Alcotest.(check (option string))
+    "unknown verdict -> None"
+    None
+    (Option.map RAA.verdict_to_string (RAA.verdict_of_string "maybe"))
+
+(* --- 3. multiplier_of_verdict exhaustive --- *)
+
+let test_multiplier_pass () =
+  Alcotest.(check (float float_eps))
+    "pass -> 1.0" 1.0 (RAA.multiplier_of_verdict RAA.Pass)
+
+let test_multiplier_warn () =
+  Alcotest.(check (float float_eps))
+    "warn -> 0.8" 0.8 (RAA.multiplier_of_verdict RAA.Warn)
+
+let test_multiplier_fail () =
+  Alcotest.(check (float float_eps))
+    "fail -> 0.4" 0.4 (RAA.multiplier_of_verdict RAA.Fail)
+
+(* --- 4. of_post_verifier_verdict --- *)
+
+let test_post_verifier_pass () =
+  let result = Pv.verify ~content:"A clear and substantive message." in
+  let artifact = Pv.to_reward_advice ~agent_name:"agent-test" result in
+  Alcotest.(check string) "source" "post_verifier"
+    (RAA.advice_source_to_string artifact.source);
+  Alcotest.(check string) "agent_name" "agent-test" artifact.agent_name;
+  Alcotest.(check bool) "verdict is Pass" true (artifact.verdict = RAA.Pass);
+  Alcotest.(check (float float_eps)) "multiplier 1.0" 1.0 artifact.reward_multiplier;
+  Alcotest.(check (float float_eps)) "confidence 1.0" 1.0 artifact.confidence
+
+let test_post_verifier_warn () =
+  let result = Pv.verify ~content:"hello world" in
+  Alcotest.(check bool) "result is warn" true
+    (match result.overall with Pv.Warn _ -> true | _ -> false);
+  let artifact = Pv.to_reward_advice ~agent_name:"agent-warn" ~task_id:"task-42" result in
+  Alcotest.(check bool) "verdict is Warn" true (artifact.verdict = RAA.Warn);
+  Alcotest.(check (float float_eps)) "multiplier 0.8" 0.8 artifact.reward_multiplier;
+  Alcotest.(check (float float_eps)) "confidence 0.9" 0.9 artifact.confidence;
+  Alcotest.(check (option string)) "task_id present" (Some "task-42") artifact.task_id
+
+let test_post_verifier_fail () =
+  let result = Pv.verify ~content:"   \n\t  " in
+  Alcotest.(check bool) "result is fail" true
+    (match result.overall with Pv.Fail _ -> true | _ -> false);
+  let artifact = Pv.to_reward_advice ~agent_name:"agent-fail" result in
+  Alcotest.(check bool) "verdict is Fail" true (artifact.verdict = RAA.Fail);
+  Alcotest.(check (float float_eps)) "multiplier 0.4" 0.4 artifact.reward_multiplier;
+  Alcotest.(check (float float_eps)) "confidence 1.0" 1.0 artifact.confidence
+
+let test_post_verifier_to_reward_advice_pass () =
+  let result = Pv.verify ~content:"Solid engineering work done." in
+  let artifact = Pv.to_reward_advice ~agent_name:"keeper-1" result in
+  Alcotest.(check bool) "verdict is Pass" true (artifact.verdict = RAA.Pass);
+  Alcotest.(check string) "source" "post_verifier"
+    (RAA.advice_source_to_string artifact.source)
+
+(* --- 5. of_benchmark_case_score --- *)
+
+let test_benchmark_high_score () =
+  let score = make_case_score 0.9 in
+  let artifact = RAA.of_benchmark_case_score ~agent_name:"bench-agent" score in
+  Alcotest.(check string) "source" "benchmark"
+    (RAA.advice_source_to_string artifact.source);
+  Alcotest.(check bool) "verdict is Pass" true (artifact.verdict = RAA.Pass);
+  Alcotest.(check (float float_eps)) "multiplier 1.1" 1.1 artifact.reward_multiplier;
+  Alcotest.(check bool) "evidence_refs non-empty" true
+    (artifact.evidence_refs <> [])
+
+let test_benchmark_mid_score () =
+  let score = make_case_score 0.65 in
+  let artifact = RAA.of_benchmark_case_score ~agent_name:"bench-agent" score in
+  Alcotest.(check bool) "verdict is Warn" true (artifact.verdict = RAA.Warn);
+  Alcotest.(check (float float_eps)) "multiplier 0.9" 0.9 artifact.reward_multiplier
+
+let test_benchmark_low_score () =
+  let score = make_case_score 0.3 in
+  let artifact = RAA.of_benchmark_case_score
+    ~agent_name:"bench-agent" ~task_id:"task-low" score in
+  Alcotest.(check bool) "verdict is Fail" true (artifact.verdict = RAA.Fail);
+  Alcotest.(check (float float_eps)) "multiplier 0.5" 0.5 artifact.reward_multiplier;
+  Alcotest.(check (option string)) "task_id" (Some "task-low") artifact.task_id
+
+let test_benchmark_boundary_08 () =
+  let score = make_case_score 0.8 in
+  let artifact = RAA.of_benchmark_case_score ~agent_name:"agent" score in
+  Alcotest.(check bool) "verdict is Pass at 0.8" true (artifact.verdict = RAA.Pass)
+
+let test_benchmark_boundary_05 () =
+  let score = make_case_score 0.5 in
+  let artifact = RAA.of_benchmark_case_score ~agent_name:"agent" score in
+  Alcotest.(check bool) "verdict is Warn at 0.5" true (artifact.verdict = RAA.Warn)
+
+let test_benchmark_with_fingerprint () =
+  let score = { (make_case_score 0.9) with
+    prompt_fingerprint = Some "fp-abc123" } in
+  let artifact = RAA.of_benchmark_case_score ~agent_name:"agent" score in
+  Alcotest.(check bool) "fingerprint ref present" true
+    (List.exists (fun r -> String_util.contains_substring r "fp-abc123")
+       artifact.evidence_refs)
+
+(* --- 6. to_yojson / of_yojson --- *)
+
+let test_json_round_trip_pass () =
+  let result = Pv.verify ~content:"Normal content that passes all checks." in
+  let orig = Pv.to_reward_advice ~agent_name:"rt-agent" ~task_id:"rt-task" result in
+  let json = RAA.to_yojson orig in
+  match RAA.of_yojson json with
+  | Error e -> Alcotest.fail ("of_yojson error: " ^ e)
+  | Ok reparsed ->
+    Alcotest.(check string) "agent_name" orig.agent_name reparsed.agent_name;
+    Alcotest.(check (option string)) "task_id" orig.task_id reparsed.task_id;
+    Alcotest.(check bool) "verdict" true (orig.verdict = reparsed.verdict);
+    Alcotest.(check (float float_eps))
+      "reward_multiplier" orig.reward_multiplier reparsed.reward_multiplier;
+    Alcotest.(check string) "advisory_message" orig.advisory_message reparsed.advisory_message;
+    Alcotest.(check (float float_eps)) "confidence" orig.confidence reparsed.confidence
+
+let test_json_round_trip_benchmark () =
+  let score = make_case_score ~case_id:"rt-case" 0.72 in
+  let orig = RAA.of_benchmark_case_score ~agent_name:"rt-bench" score in
+  let json = RAA.to_yojson orig in
+  match RAA.of_yojson json with
+  | Error e -> Alcotest.fail ("of_yojson error: " ^ e)
+  | Ok reparsed ->
+    Alcotest.(check string) "case_id in evidence" "benchmark:rt-case"
+      (List.hd reparsed.evidence_refs);
+    Alcotest.(check (float float_eps))
+      "multiplier preserved" orig.reward_multiplier reparsed.reward_multiplier
+
+let test_json_missing_agent_name () =
+  let json = `Assoc [ ("source", `String "post_verifier"); ("agent_name", `String "") ] in
+  match RAA.of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for empty agent_name"
+
+let test_json_unknown_source () =
+  let json = `Assoc [ ("source", `String "unknown_src"); ("agent_name", `String "a") ] in
+  match RAA.of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for unknown source"
+
+let test_json_unknown_verdict_rejected () =
+  let json = `Assoc [
+    ("source", `String "benchmark");
+    ("agent_name", `String "agent");
+    ("verdict", `String "maybe");
+    ("reward_multiplier", `Float 1.0);
+    ("confidence", `Float 1.0);
+    ("timestamp", `Float 0.0);
+  ] in
+  match RAA.of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected error for unknown verdict string"
+
+let test_json_multiplier_clamped () =
+  let json = `Assoc [
+    ("source", `String "benchmark");
+    ("agent_name", `String "agent");
+    ("verdict", `String "pass");
+    ("reward_multiplier", `Float 99.0);
+    ("confidence", `Float 1.0);
+    ("timestamp", `Float 0.0);
+  ] in
+  match RAA.of_yojson json with
+  | Error e -> Alcotest.fail ("unexpected error: " ^ e)
+  | Ok a ->
+    Alcotest.(check (float float_eps)) "clamped to 2.0" 2.0 a.reward_multiplier
+
+let () =
+  Alcotest.run "Reward_advice_artifact"
+    [
+      ( "source",
+        [
+          Alcotest.test_case "round-trip" `Quick test_source_round_trip;
+          Alcotest.test_case "unknown -> None" `Quick test_source_unknown;
+        ] );
+      ( "verdict",
+        [
+          Alcotest.test_case "round-trip" `Quick test_verdict_round_trip;
+          Alcotest.test_case "unknown -> None" `Quick test_verdict_unknown;
+        ] );
+      ( "multiplier_of_verdict",
+        [
+          Alcotest.test_case "pass -> 1.0" `Quick test_multiplier_pass;
+          Alcotest.test_case "warn -> 0.8" `Quick test_multiplier_warn;
+          Alcotest.test_case "fail -> 0.4" `Quick test_multiplier_fail;
+        ] );
+      ( "post_verifier_to_reward_advice",
+        [
+          Alcotest.test_case "pass content" `Quick test_post_verifier_pass;
+          Alcotest.test_case "warn content" `Quick test_post_verifier_warn;
+          Alcotest.test_case "fail content" `Quick test_post_verifier_fail;
+          Alcotest.test_case "advisory for pass" `Quick
+            test_post_verifier_to_reward_advice_pass;
+        ] );
+      ( "of_benchmark_case_score",
+        [
+          Alcotest.test_case "high score -> pass 1.1" `Quick test_benchmark_high_score;
+          Alcotest.test_case "mid score -> warn 0.9" `Quick test_benchmark_mid_score;
+          Alcotest.test_case "low score -> fail 0.5" `Quick test_benchmark_low_score;
+          Alcotest.test_case "boundary 0.8 -> pass" `Quick test_benchmark_boundary_08;
+          Alcotest.test_case "boundary 0.5 -> warn" `Quick test_benchmark_boundary_05;
+          Alcotest.test_case "fingerprint in evidence_refs" `Quick
+            test_benchmark_with_fingerprint;
+        ] );
+      ( "json_serialization",
+        [
+          Alcotest.test_case "post_verifier round-trip" `Quick test_json_round_trip_pass;
+          Alcotest.test_case "benchmark round-trip" `Quick test_json_round_trip_benchmark;
+          Alcotest.test_case "missing agent_name -> error" `Quick
+            test_json_missing_agent_name;
+          Alcotest.test_case "unknown source -> error" `Quick test_json_unknown_source;
+          Alcotest.test_case "unknown verdict -> error" `Quick
+            test_json_unknown_verdict_rejected;
+          Alcotest.test_case "multiplier clamped" `Quick test_json_multiplier_clamped;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Add `reward_advice_artifact` module: structured advisory artifacts from verifiers and benchmarks to the reward system
- **Typed verdict** (`Pass | Warn | Fail`) instead of raw string — `of_yojson` rejects unknown verdict strings (fail-closed)
- `Post_verifier.to_reward_advice` convenience wrapper + `tool_call_quality_benchmark_scoring.to_reward_advice` pipeline
- Fixes `Post_verifier.mli` doc comment to correctly reference `of_post_verifier_verdict` (not `of_post_verifier_result`)

## Reviewer feedback from #12505 addressed
1. **Typed verdict**: `verdict : string` → `type verdict = Pass | Warn | Fail` — exhaustive pattern match, no wildcard fallback
2. **Fail-closed deserialization**: `of_yojson` returns `Error` for unknown verdict strings instead of silently defaulting to neutral multiplier
3. **Doc comment fix**: `Post_verifier.mli` now correctly says `of_post_verifier_verdict`
4. **Clean history**: single focused commit, no placeholder

## Test plan
- [x] 23 Alcotest tests across 6 groups pass
- [x] `dune build @install` clean
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)