### PR TITLE
Route cockpit design entrypoints into dashboard

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  COCKPIT_ENTRYPOINTS,
+  COCKPIT_MODE_TARGETS,
+  cockpitTargetForParams,
+  normalizeCockpitEntrypoint,
+} from './cockpit-entrypoints'
+import { sectionItemsForTab } from './config/navigation'
+
+describe('cockpit entrypoint registry', () => {
+  it('keeps every prototype plane mode mapped to a production route', () => {
+    expect(Object.keys(COCKPIT_MODE_TARGETS)).toEqual([
+      'dashboard',
+      'cockpit',
+      'work',
+      'comms',
+      'observe',
+      'cognition',
+      'ide',
+      'code',
+      'split',
+      'terminal',
+    ])
+  })
+
+  it('normalizes human tab labels and prototype ids to stable aliases', () => {
+    expect(normalizeCockpitEntrypoint('Goal · Horizon')).toBe('goal-horizon')
+    expect(normalizeCockpitEntrypoint('SPLIT DIFF')).toBe('split-diff')
+    expect(normalizeCockpitEntrypoint('Keeper / Tool Access')).toBe('keeper-tool-access')
+  })
+
+  it('targets registered dashboard sections for every cockpit sub-entrypoint', () => {
+    for (const entrypoint of COCKPIT_ENTRYPOINTS) {
+      const section = entrypoint.target.params?.section
+      if (!section) continue
+      const knownSections = sectionItemsForTab(entrypoint.target.tab).map(item => item.params.section)
+      expect(knownSections, `${entrypoint.mode}:${entrypoint.aliases[0]}`).toContain(section)
+    }
+  })
+
+  it('resolves blocked and partial prototype subtabs to explicit live route homes', () => {
+    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-str' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'decisions' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'sa-dash' })).toEqual({
+      tab: 'command',
+      params: { section: 'operations', view: 'safety' },
+    })
+    expect(cockpitTargetForParams({ mode: 'CODE', tab: 'graph' })).toEqual({
+      tab: 'workspace',
+      params: { section: 'repositories', view: 'graph' },
+    })
+  })
+})

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -1,0 +1,144 @@
+import type { TabId } from './types'
+
+export type CockpitMode =
+  | 'dashboard'
+  | 'cockpit'
+  | 'work'
+  | 'comms'
+  | 'observe'
+  | 'cognition'
+  | 'ide'
+  | 'code'
+  | 'split'
+  | 'terminal'
+
+export interface CockpitRouteTarget {
+  tab: TabId
+  params?: Record<string, string>
+}
+
+export interface CockpitEntrypoint {
+  mode: CockpitMode
+  aliases: string[]
+  target: CockpitRouteTarget
+  coverage: 'covered' | 'partial' | 'backend-blocked'
+}
+
+export const COCKPIT_MODE_TARGETS: Record<CockpitMode, CockpitRouteTarget> = {
+  dashboard: { tab: 'overview' },
+  cockpit: { tab: 'overview' },
+  work: { tab: 'workspace', params: { section: 'planning' } },
+  comms: { tab: 'workspace', params: { section: 'board' } },
+  observe: { tab: 'monitoring', params: { section: 'runtime' } },
+  cognition: { tab: 'monitoring', params: { section: 'cognition' } },
+  ide: { tab: 'code', params: { section: 'ide-shell', view: 'source' } },
+  code: { tab: 'code', params: { section: 'ide-shell', view: 'source' } },
+  split: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } },
+  terminal: { tab: 'code', params: { section: 'ide-shell', view: 'source', terminal: 'open' } },
+}
+
+export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
+  // Work Plane: Goal / Task / Accountability.
+  { mode: 'work', aliases: ['goal-h', 'goal-horizon'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
+  { mode: 'work', aliases: ['goal-t', 'goal-tree'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
+  { mode: 'work', aliases: ['goal-d', 'goal-snapshot', 'goal-snapshot-diff'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree', focus: 'snapshot' } }, coverage: 'backend-blocked' },
+  { mode: 'work', aliases: ['task-bl', 'task-backlog'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
+  { mode: 'work', aliases: ['task-st', 'task-stale'], target: { tab: 'workspace', params: { section: 'planning', view: 'default', focus: 'stale' } }, coverage: 'partial' },
+  { mode: 'work', aliases: ['task-w', 'task-wall'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
+  { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'partial' },
+  { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'partial' },
+
+  // Comms Plane: board has production coverage; room/composer zones remain partial.
+  { mode: 'comms', aliases: ['bd-feed', 'board-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'workspace', params: { section: 'board', focus: 'thread' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'workspace', params: { section: 'board', focus: 'automation' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['ms-rm', 'messages-room'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-room' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'workspace', params: { section: 'board', focus: 'mention-inbox' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'workspace', params: { section: 'board', focus: 'state-block' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'partial' },
+
+  // Observe Plane: split prototype tabs across the consolidated production surfaces.
+  { mode: 'observe', aliases: ['cs-list', 'cascade-list'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cascade' } }, coverage: 'covered' },
+  { mode: 'observe', aliases: ['cs-deep', 'cascade-deep-dive'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'inspector' } }, coverage: 'partial' },
+  { mode: 'observe', aliases: ['cs-cmp', 'cascade-compare'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'providers' } }, coverage: 'partial' },
+  { mode: 'observe', aliases: ['au-led', 'audit-ledger'], target: { tab: 'monitoring', params: { section: 'fleet-health', view: 'event-log', focus: 'audit' } }, coverage: 'backend-blocked' },
+  { mode: 'observe', aliases: ['au-act', 'audit-by-actor'], target: { tab: 'monitoring', params: { section: 'fleet-health', view: 'attribution' } }, coverage: 'partial' },
+  { mode: 'observe', aliases: ['au-sum', 'audit-summary'], target: { tab: 'monitoring', params: { section: 'fleet-health', view: 'governance' } }, coverage: 'partial' },
+  { mode: 'observe', aliases: ['sa-dash', 'safe-auto-dashboard'], target: { tab: 'command', params: { section: 'operations', view: 'safety' } }, coverage: 'covered' },
+  { mode: 'observe', aliases: ['sa-kpr', 'safe-auto-by-keeper'], target: { tab: 'command', params: { section: 'operations', view: 'safety', focus: 'keeper' } }, coverage: 'covered' },
+  { mode: 'observe', aliases: ['sa-trd', 'safe-auto-trend'], target: { tab: 'command', params: { section: 'operations', view: 'safety', focus: 'trend' } }, coverage: 'backend-blocked' },
+  { mode: 'observe', aliases: ['ct-agt', 'cost-per-agent'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost' } }, coverage: 'partial' },
+  { mode: 'observe', aliases: ['ct-mtx', 'cost-matrix'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost', focus: 'matrix' } }, coverage: 'partial' },
+  { mode: 'observe', aliases: ['ct-lat', 'cost-latency'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost', focus: 'latency' } }, coverage: 'partial' },
+  { mode: 'observe', aliases: ['hr-log', 'heuristic-log'], target: { tab: 'monitoring', params: { section: 'fleet-health', view: 'tool-quality', focus: 'heuristic-log' } }, coverage: 'backend-blocked' },
+  { mode: 'observe', aliases: ['hr-st', 'stress-board'], target: { tab: 'monitoring', params: { section: 'fleet-health', view: 'tool-quality', focus: 'stress' } }, coverage: 'backend-blocked' },
+  { mode: 'observe', aliases: ['hr-mod', 'heuristic-by-module'], target: { tab: 'monitoring', params: { section: 'fleet-health', view: 'tool-quality', focus: 'module' } }, coverage: 'backend-blocked' },
+
+  // Cognition Plane: production view tabs show available data and blocked backend gaps.
+  { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper' } }, coverage: 'partial' },
+  { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'partial' },
+  { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'token-stats' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'decisions' } }, coverage: 'backend-blocked' },
+  { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'memory' } }, coverage: 'partial' },
+  { mode: 'cognition', aliases: ['ep-card', 'episodes-cards'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ep-lrn', 'episodes-learnings'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ar-lst', 'ar-loops'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ar-fnd', 'ar-finding-card'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'finding' } }, coverage: 'partial' },
+  { mode: 'cognition', aliases: ['ar-flw', 'ar-flow'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'flow' } }, coverage: 'partial' },
+
+  // IDE Plane.
+  { mode: 'ide', aliases: ['edit', 'source'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['review', 'pr-thread'], target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['merge', 'split', 'split-diff'], target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['graph', 'git-graph'], target: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['search', 'find'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source', focus: 'search' } }, coverage: 'partial' },
+]
+
+const ENTRYPOINT_TARGETS = new Map<string, CockpitRouteTarget>()
+
+for (const entrypoint of COCKPIT_ENTRYPOINTS) {
+  for (const alias of entrypoint.aliases) {
+    ENTRYPOINT_TARGETS.set(`${entrypoint.mode}:${normalizeCockpitEntrypoint(alias)}`, entrypoint.target)
+  }
+}
+
+export function normalizeCockpitMode(input: string | null | undefined): CockpitMode | null {
+  const normalized = input?.trim().toLowerCase()
+  if (!normalized) return null
+  return Object.prototype.hasOwnProperty.call(COCKPIT_MODE_TARGETS, normalized)
+    ? normalized as CockpitMode
+    : null
+}
+
+export function normalizeCockpitEntrypoint(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[·/]+/g, ' ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function cockpitEntryParam(params: Record<string, string>): string | null {
+  return params.entry
+    ?? params.panel
+    ?? params.subtab
+    ?? params.cockpit_tab
+    ?? params.cockpitTab
+    ?? params.tab
+    ?? null
+}
+
+export function cockpitTargetForParams(params: Record<string, string>): CockpitRouteTarget | null {
+  const mode = normalizeCockpitMode(params.mode ?? params.plane)
+  if (!mode) return null
+  const entry = cockpitEntryParam(params)
+  if (entry) {
+    const entryMode = mode === 'code' || mode === 'split' || mode === 'terminal' ? 'ide' : mode
+    const entryTarget = ENTRYPOINT_TARGETS.get(`${entryMode}:${normalizeCockpitEntrypoint(entry)}`)
+    if (entryTarget) return entryTarget
+  }
+  return COCKPIT_MODE_TARGETS[mode]
+}

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -1,0 +1,97 @@
+import { html } from 'htm/preact'
+import { navigate, route } from '../router'
+import { AgentsUnified } from './agents-unified'
+import { Autoresearch } from './autoresearch'
+import { FilterChips } from './common/filter-chips'
+import { KeeperTokenStats } from './keeper-token-stats'
+import { MemorySubsystems } from './memory-subsystems'
+
+type CognitionView = 'overview' | 'keeper' | 'token-stats' | 'decisions' | 'memory' | 'episodes' | 'autoresearch'
+
+const COGNITION_VIEWS: CognitionView[] = [
+  'overview',
+  'keeper',
+  'token-stats',
+  'decisions',
+  'memory',
+  'episodes',
+  'autoresearch',
+]
+
+const VIEW_CHIPS: Array<{ key: CognitionView; label: string; title?: string }> = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'keeper', label: 'Keeper' },
+  { key: 'token-stats', label: 'Token Stats' },
+  { key: 'decisions', label: 'Decisions' },
+  { key: 'memory', label: 'Memory' },
+  { key: 'episodes', label: 'Episodes' },
+  { key: 'autoresearch', label: 'Autoresearch' },
+]
+
+function currentView(): CognitionView {
+  const raw = route.value.params.view
+  return raw && (COGNITION_VIEWS as string[]).includes(raw)
+    ? raw as CognitionView
+    : 'overview'
+}
+
+function updateViewParam(view: CognitionView): void {
+  const next: Record<string, string> = { ...route.value.params, section: 'cognition' }
+  if (view === 'overview') {
+    delete next.view
+  } else {
+    next.view = view
+  }
+  navigate('monitoring', next)
+}
+
+function BlockedCognitionSurface() {
+  return html`
+    <section class="rounded border border-[var(--warn-20)] border-l-[3px] border-l-[var(--color-status-warn)] bg-[var(--warn-soft)] px-4 py-3" role="status">
+      <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--warn-bright)]">
+        K2 decisions stream · backend-blocked
+      </div>
+      <div class="mt-1 text-sm text-[var(--color-fg-primary)]">
+        No cross-keeper decisions stream endpoint is registered yet.
+      </div>
+      <div class="mt-1 text-2xs text-[var(--color-fg-muted)]">
+        The route stays live and explicit; no synthetic decisions feed is rendered.
+      </div>
+    </section>
+  `
+}
+
+export function CognitionPlane() {
+  const view = currentView()
+
+  return html`
+    <div class="flex flex-col gap-5">
+      <${FilterChips}
+        chips=${VIEW_CHIPS}
+        value=${view}
+        onChange=${updateViewParam}
+        size="sm"
+        tone="accent"
+      />
+
+      ${view === 'keeper' ? html`
+        <${AgentsUnified} />
+      ` : view === 'token-stats' ? html`
+        <${KeeperTokenStats} />
+      ` : view === 'decisions' ? html`
+        <${BlockedCognitionSurface} />
+      ` : view === 'memory' || view === 'episodes' ? html`
+        <${MemorySubsystems} />
+      ` : view === 'autoresearch' ? html`
+        <${Autoresearch} />
+      ` : html`
+        <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <${KeeperTokenStats} />
+          <${Autoresearch} />
+        </div>
+        <${AgentsUnified} />
+        <${MemorySubsystems} />
+      `}
+    </div>
+  `
+}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,11 +1,12 @@
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditorMock } from './ide-editor-mock'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 import { IdeActivityMock } from './ide-activity-mock'
 import { IdeInterjectMock } from './ide-interject-mock'
 import { IdeToolbar } from './ide-toolbar'
+import { navigate, route } from '../../router'
 
 // PR-3: 4-pane CODE mode shell with editor toolbar (view tabs + LAYERS
 // toggle, RFC 0020 controller). Layout matches the cockpit IdePlane
@@ -25,8 +26,29 @@ import { IdeToolbar } from './ide-toolbar'
 
 type ViewTab = 'source' | 'split-diff' | 'unified' | 'blame'
 
+function viewFromRoute(raw: string | null | undefined): ViewTab {
+  const normalized = raw
+    ?.trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-')
+  if (normalized === 'split' || normalized === 'split-diff' || normalized === 'merge') return 'split-diff'
+  if (normalized === 'unified') return 'unified'
+  if (normalized === 'blame') return 'blame'
+  return 'source'
+}
+
 export function IdeShell() {
-  const [activeView, setActiveView] = useState<ViewTab>('source')
+  const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
+
+  useEffect(() => {
+    const next = viewFromRoute(route.value.params.view)
+    setActiveView(current => current === next ? current : next)
+  }, [route.value.params.view])
+
+  const handleViewChange = (next: ViewTab) => {
+    setActiveView(next)
+    navigate('code', { ...route.value.params, section: 'ide-shell', view: next })
+  }
 
   return html`
     <section
@@ -58,27 +80,24 @@ export function IdeShell() {
         <span>* runtime / main / nick0cave@dkr-a1 / improver@wt-run-47</span>
         <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok, var(--ok))' }}>● mcp · connected</span>
       </header>
-      <${IdeToolbar} activeView=${activeView} onViewChange=${setActiveView} />
+      <${IdeToolbar} activeView=${activeView} onViewChange=${handleViewChange} />
       <div
         class="ide-plane-grid"
         role="presentation"
         style=${{
-          display: 'grid',
-          gridTemplateColumns: 'minmax(180px, 220px) minmax(0, 1fr) minmax(280px, 320px)',
-          gridTemplateRows: '1fr auto',
           minHeight: 0,
         }}
       >
-        <div style=${{ gridColumn: 1, gridRow: '1 / span 2' }}>
+        <div class="ide-plane-tree">
           <${IdeExplorer} />
         </div>
-        <div style=${{ gridColumn: 2, gridRow: '1 / span 2', minHeight: 0 }}>
+        <div class="ide-plane-editor" style=${{ minHeight: 0 }}>
           <${IdeEditorMock} />
         </div>
-        <div style=${{ gridColumn: 3, gridRow: 1, minHeight: 0 }}>
+        <div class="ide-plane-conversation" style=${{ minHeight: 0 }}>
           <${IdeConversationRailMock} />
         </div>
-        <div style=${{ gridColumn: 3, gridRow: 2, minHeight: 0 }}>
+        <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
           <${IdeActivityMock} />
         </div>
       </div>

--- a/dashboard/src/components/status.test.ts
+++ b/dashboard/src/components/status.test.ts
@@ -9,6 +9,7 @@ describe("sectionLabel", () => {
     ["runtime", "Runtime"],
     ["fleet-health", "Fleet Health"],
     ["memory-subsystems", "Memory Subsystems"],
+    ["cognition", "Cognition"],
     ["agents", "Agents"],
   ] as [StatusSection, string][])("maps %s to %s", (section, expected) => {
     expect(sectionLabel(section)).toBe(expected)

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,7 +9,7 @@ import { LoadingState } from './common/feedback-state'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'fleet-health'
-  | 'memory-subsystems'
+  | 'memory-subsystems' | 'cognition'
 
 const LazyAgentsUnified = lazy(async () => ({
   default: (await import('./agents-unified')).AgentsUnified,
@@ -29,6 +29,9 @@ const LazyObservatory = lazy(async () => ({
 const LazyJourneyPanel = lazy(async () => ({
   default: (await import('./journey-panel')).JourneyPanel,
 }))
+const LazyCognitionPlane = lazy(async () => ({
+  default: (await import('./cognition-plane')).CognitionPlane,
+}))
 
 function sectionFallback(label: string) {
   return html`<${LoadingState}>Loading ${label}...<//>`
@@ -46,6 +49,8 @@ export function sectionLabel(section: StatusSection): string {
       return 'Fleet Health'
     case 'memory-subsystems':
       return 'Memory Subsystems'
+    case 'cognition':
+      return 'Cognition'
     case 'agents':
       return 'Agents'
   }
@@ -63,6 +68,8 @@ function renderSection(section: StatusSection) {
       return html`<${LazyFleetHealthPanel} />`
     case 'memory-subsystems':
       return html`<${LazyMemorySubsystems} />`
+    case 'cognition':
+      return html`<${LazyCognitionPlane} />`
     case 'agents':
       return html`<${LazyAgentsUnified} />`
   }
@@ -76,6 +83,7 @@ function currentSection(): StatusSection {
     || section === 'runtime'
     || section === 'fleet-health'
     || section === 'memory-subsystems'
+    || section === 'cognition'
     || section === 'agents'
   ) return section
   return 'journey'

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  DASHBOARD_SURFACES,
   SECTION_REDIRECTS,
   defaultParamsForTab,
   normalizeRouteParams,
@@ -9,13 +10,14 @@ import {
 } from './navigation'
 
 describe('code (IDE plane) navigation', () => {
-  it('keeps the ide-shell route hidden until the IDE plane is real', () => {
+  it('exposes the production IDE plane in the sidebar', () => {
     expect(defaultParamsForTab('code')).toEqual({ section: 'ide-shell' })
+    expect(DASHBOARD_SURFACES.find(surface => surface.id === 'code')?.hidden).not.toBe(true)
 
     const visibleCodeSections = visibleSectionItemsForTab('code')
     const allCodeSections = sectionItemsForTab('code')
 
-    expect(visibleCodeSections).toEqual([])
+    expect(visibleCodeSections.map(item => item.id)).toEqual(['ide-shell'])
     expect(allCodeSections.map(item => item.id)).toEqual(['ide-shell'])
     expect(allCodeSections.map(item => item.label)).toEqual(['Code IDE'])
   })
@@ -98,6 +100,7 @@ describe('monitoring navigation labels', () => {
     // whose labels collide on the same word.
     expect(labelFor('runtime')).toBe('Cascade')
     expect(labelFor('agents')).toBe('Agent Directory')
+    expect(labelFor('cognition')).toBe('Cognition')
   })
 
   it('does not expose sessions section (removed in Phase 0 of RFC-MASC-006)', () => {
@@ -111,8 +114,9 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const ids = sections.map(item => item.id)
 
-    expect(ids).toEqual(['journey', 'agents', 'runtime', 'fleet-health'])
+    expect(ids).toEqual(['journey', 'agents', 'cognition', 'runtime', 'fleet-health'])
     expect(ids).toContain('journey')
+    expect(ids).toContain('cognition')
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('agents')
@@ -136,8 +140,9 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     expect(sections[0]?.id).toBe('journey')
     expect(sections[1]?.id).toBe('agents')
-    expect(sections[2]?.id).toBe('runtime')
-    expect(sections[3]?.id).toBe('fleet-health')
+    expect(sections[2]?.id).toBe('cognition')
+    expect(sections[3]?.id).toBe('runtime')
+    expect(sections[4]?.id).toBe('fleet-health')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -16,6 +16,7 @@ type SurfaceSectionId =
   | 'observatory'
   | 'journey'
   | 'agents'
+  | 'cognition'
   | 'runtime'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'memory-subsystems'
@@ -130,7 +131,6 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     defaultTab: 'code',
     defaultParams: { section: 'ide-shell' },
     tabs: ['code'],
-    hidden: true,
   },
   {
     id: 'logs',
@@ -170,6 +170,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Agent Directory',
       description: 'Live runtime-backed roster and process state.',
       params: { section: 'agents' },
+    },
+    {
+      id: 'cognition',
+      label: 'Cognition',
+      description: 'Keeper BDI, token load, memory, decisions, and autoresearch loops.',
+      params: { section: 'cognition' },
     },
     {
       id: 'runtime',
@@ -266,7 +272,6 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Code IDE',
       description: 'Keeper collaboration code-review IDE shell.',
       params: { section: 'ide-shell' },
-      hidden: true,
     },
   ],
 }

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -149,6 +149,8 @@ describe('dashboardSlicesForRoute', () => {
       .toContain('execution')
     expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'observatory' } }))
       .toContain('execution')
+    expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'cognition' } }))
+      .toContain('execution')
     expect(dashboardSlicesForRoute({
       tab: 'monitoring',
       params: { section: 'fleet-health', view: 'comparison' },
@@ -161,6 +163,8 @@ describe('dashboardSlicesForRoute', () => {
     expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'planning' } }))
       .toContain('goals')
     expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'agents' } }))
+      .toContain('composite')
+    expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'cognition' } }))
       .toContain('composite')
   })
 

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -167,10 +167,10 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
   }
   if (routeState.tab === 'monitoring') {
     const section = routeState.params.section
-    if (section === 'observatory' || section === 'journey' || section === 'agents') {
+    if (section === 'observatory' || section === 'journey' || section === 'agents' || section === 'cognition') {
       slices.add('execution')
     }
-    if (section === 'agents') {
+    if (section === 'agents' || section === 'cognition') {
       slices.add('composite')
     }
     if (section === 'fleet-health' && routeState.params.view === 'comparison') {

--- a/dashboard/src/refresh-scope.test.ts
+++ b/dashboard/src/refresh-scope.test.ts
@@ -18,6 +18,7 @@ describe('routeWantsRefreshTarget', () => {
 
   it('matches execution-backed routes without broadening fleet-health defaults', () => {
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'agents' }), 'execution')).toBe(true)
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'cognition' }), 'execution')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'journey' }), 'execution')).toBe(true)
     expect(routeWantsRefreshTarget(route('workspace', { section: 'planning' }), 'execution')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'fleet-health' }), 'execution')).toBe(false)

--- a/dashboard/src/refresh-scope.ts
+++ b/dashboard/src/refresh-scope.ts
@@ -26,7 +26,7 @@ function routeWantsExecution(routeState: Pick<RouteState, 'tab' | 'params'>): bo
   if (routeState.tab !== 'monitoring') return false
 
   const section = routeState.params.section
-  if (section === 'observatory' || section === 'journey' || section === 'agents') {
+  if (section === 'observatory' || section === 'journey' || section === 'agents' || section === 'cognition') {
     return true
   }
 

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -56,4 +56,74 @@ describe('navigate', () => {
     expect(route.value.params.section).toBe('operations')
     expect(route.value.params.view).toBe('safety')
   })
+
+  it('maps cockpit Cognition design deep links into the production keeper surface', () => {
+    window.location.hash = '#repo=viewer&branch=wt%2Fsangsu-smoke&mode=Cognition'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('cognition')
+    expect(route.value.params.repo).toBe('viewer')
+    expect(route.value.params.branch).toBe('wt/sangsu-smoke')
+    expect(route.value.params.mode).toBe('Cognition')
+    expect(window.location.hash).toContain('#monitoring?')
+  })
+
+  it('treats slash-bearing raw cockpit query hashes as queries', () => {
+    window.location.hash = '#repo=viewer&branch=wt/sangsu-smoke&mode=Cognition'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('cognition')
+    expect(route.value.params.branch).toBe('wt/sangsu-smoke')
+  })
+
+  it('maps cockpit IDE split mode links into the Code IDE view state', () => {
+    window.location.hash = '#mode=Split&branch=main'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('code')
+    expect(route.value.params.section).toBe('ide-shell')
+    expect(route.value.params.view).toBe('split-diff')
+    expect(route.value.params.branch).toBe('main')
+  })
+
+  it('maps path-qualified cockpit mode links when no explicit section is present', () => {
+    window.location.hash = '#code?mode=Split&branch=main'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('code')
+    expect(route.value.params.section).toBe('ide-shell')
+    expect(route.value.params.view).toBe('split-diff')
+    expect(route.value.params.branch).toBe('main')
+  })
+
+  it('keeps explicit production sections stronger than cockpit mode aliases', () => {
+    window.location.hash = '#monitoring?section=runtime&mode=Cognition'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('runtime')
+    expect(route.value.params.mode).toBe('Cognition')
+  })
+
+  it('maps cockpit cognition subtabs to explicit cognition views', () => {
+    window.location.hash = '#mode=Cognition&tab=dc-str'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('cognition')
+    expect(route.value.params.view).toBe('decisions')
+    expect(window.location.hash).toContain('view=decisions')
+  })
+
+  it('maps observe safe-auto subtabs across surfaces without dropping context', () => {
+    window.location.hash = '#repo=viewer&mode=Observe&tab=sa-dash'
+    window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+    expect(route.value.tab).toBe('command')
+    expect(route.value.params.section).toBe('operations')
+    expect(route.value.params.view).toBe('safety')
+    expect(route.value.params.repo).toBe('viewer')
+  })
 })

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -5,6 +5,7 @@ import { signal } from '@preact/signals'
 import type { RouteState, TabId } from './types'
 import { VALID_TABS } from './types'
 import { normalizeRouteParams, sectionItemsForTab } from './config/navigation'
+import { cockpitTargetForParams, normalizeCockpitMode } from './cockpit-entrypoints'
 
 const DEFAULT_ROUTE: RouteState = { tab: 'overview', params: {}, postId: null }
 const VALID_COMMAND_SECTIONS = new Set(
@@ -56,6 +57,21 @@ function parseParams(raw: string | undefined): Record<string, string> {
   return params
 }
 
+function routeForCockpitMode(params: Record<string, string>): RouteState | null {
+  const redirect = cockpitTargetForParams(params)
+  if (!redirect) return null
+
+  const nextParams = { ...params, ...(redirect.params ?? {}) }
+  return canonicalRoute(redirect.tab, nextParams)
+}
+
+function shouldApplyCockpitModeRoute(segments: string[], params: Record<string, string>): boolean {
+  if (!normalizeCockpitMode(params.mode ?? params.plane)) return false
+  if (segments.length === 0) return true
+  if (segments.length === 1 && isTabId(segments[0]) && !params.section) return true
+  return false
+}
+
 function applyCrossSurfaceRedirect(
   tab: TabId,
   params: Record<string, string>,
@@ -105,6 +121,11 @@ function parseSegments(
   segments: string[],
   params: Record<string, string>,
 ): RouteState {
+  if (shouldApplyCockpitModeRoute(segments, params)) {
+    const cockpitModeRoute = routeForCockpitMode(params)
+    if (cockpitModeRoute) return cockpitModeRoute
+  }
+
   if (segments[0] === 'command' && segments[1]) {
     const nextParams = { ...params }
     const second = decodeSafe(segments[1])
@@ -155,14 +176,21 @@ function parseHash(hash: string): RouteState {
     }
   }
 
-  if (!queryPart && pathPart.includes('=') && !pathPart.includes('/')) {
-    queryPart = pathPart
+  if (!queryPart && hashLooksLikeQuery(raw)) {
+    queryPart = raw
     pathPart = ''
   }
 
   const params = parseParams(queryPart)
   const segments = normalizeSegments(pathPart)
   return parseSegments(segments, params)
+}
+
+function hashLooksLikeQuery(rawHashBody: string): boolean {
+  const eqIndex = rawHashBody.indexOf('=')
+  if (eqIndex < 0) return false
+  const slashIndex = rawHashBody.indexOf('/')
+  return slashIndex < 0 || eqIndex < slashIndex
 }
 
 function parsePathname(pathname: string, search: string): RouteState | null {

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -249,3 +249,66 @@
     background: var(--white-20);
   }
 }
+
+/* ── IDE Plane Shell ── */
+.ide-plane-grid {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr) minmax(280px, 320px);
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-width: 0;
+}
+
+.ide-plane-tree {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  min-width: 0;
+}
+
+.ide-plane-editor {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  min-width: 0;
+}
+
+.ide-plane-conversation {
+  grid-column: 3;
+  grid-row: 1;
+  min-width: 0;
+}
+
+.ide-plane-activity {
+  grid-column: 3;
+  grid-row: 2;
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .ide-plane-shell {
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .ide-plane-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto auto auto auto;
+  }
+
+  .ide-plane-tree,
+  .ide-plane-editor,
+  .ide-plane-conversation,
+  .ide-plane-activity {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .ide-plane-tree,
+  .ide-plane-conversation,
+  .ide-plane-activity {
+    max-height: 22rem;
+    overflow: auto;
+  }
+
+  .ide-plane-editor {
+    overflow-x: auto;
+  }
+}

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -77,6 +77,11 @@ describe('refreshPlanForRoute', () => {
 
     expect(refreshPlanForRoute({
       tab: 'monitoring',
+      params: { section: 'cognition' },
+    })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot', 'autoresearch'])
+
+    expect(refreshPlanForRoute({
+      tab: 'monitoring',
       params: { section: 'observatory' },
     })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot', 'observatory', 'activityGraph'])
   })

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -86,6 +86,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       if (routeState.params.section === 'agents') {
         return ['namespaceTruth', 'execution', 'missionSnapshot']
       }
+      if (routeState.params.section === 'cognition') {
+        return ['namespaceTruth', 'execution', 'missionSnapshot', 'autoresearch']
+      }
       if (routeState.params.section === 'runtime' && routeState.params.view === 'inspector') {
         return ['cascadeInspector']
       }


### PR DESCRIPTION
## Summary
- add a cockpit entrypoint registry that maps prototype modes and subtabs into production dashboard routes
- expose the Code surface and Cognition monitor surface, including explicit backend-blocked state for the decisions stream
- wire route-scoped refresh/ws subscriptions for Cognition and keep Code IDE view state deep-linkable

## Why it matters
Design links like `#repo=viewer&branch=wt%2Fsangsu-smoke&mode=Cognition` and mockup tabs like Observe/Safe Auto or CODE/graph should not land on the wrong default screen. Operators now get a stable route home for each known cockpit entrypoint, and backend-missing zones stay visible as missing instead of being silently faked.

## Review focus
- `dashboard/src/cockpit-entrypoints.ts`: prototype mode/subtab to production route mapping
- `dashboard/src/router.ts`: hash/query normalization and mode alias application rules
- `dashboard/src/components/cognition-plane.ts`: Cognition subtabs and backend-blocked decisions state
- `dashboard/src/components/ide/ide-shell.ts`: route-driven IDE view tabs

## Validation
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/cockpit-entrypoints.test.ts src/router.test.ts src/config/navigation.test.ts src/components/status.test.ts src/refresh-scope.test.ts src/dashboard-ws.test.ts src/tab-refresh.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` (passes with 3 existing unused eslint-disable warnings)
- `git diff --check`
- Browser smoke on Vite: Cognition decisions, CODE split, Observe safe-auto, CODE graph entrypoints