### PR TITLE
fix: restore dashboard overview type contracts

### DIFF
--- a/dashboard/src/components/common/card.test.ts
+++ b/dashboard/src/components/common/card.test.ts
@@ -66,6 +66,22 @@ describe('SectionCard', () => {
     render(h(SectionCard, { label: 'T', variant: 'compact' }, 'Body'), container)
     expect(container.innerHTML).toContain('p-3.5')
   })
+
+  it('accepts legacy title, right slot, and test id props', () => {
+    const container = document.createElement('div')
+    render(
+      h(
+        SectionCard,
+        { title: 'Section B', right: h('span', null, 'Tail'), testId: 'section-b' },
+        h('p', null, 'Body'),
+      ),
+      container,
+    )
+    expect(container.querySelector('[data-testid="section-b"]')).not.toBeNull()
+    expect(container.textContent).toContain('Section B')
+    expect(container.textContent).toContain('Tail')
+    expect(container.textContent).toContain('Body')
+  })
 })
 
 describe('Card', () => {

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -41,16 +41,26 @@ export function SurfaceCard({
 
 // ── Section card with label header ──
 interface SectionCardProps {
-  label: string
+  label?: ComponentChildren
+  title?: ComponentChildren
+  right?: ComponentChildren
   class?: string
+  tone?: string
   variant?: CardVariant
+  testId?: string
+  'data-testid'?: string
   children: ComponentChildren
 }
 
 export function SectionCard({
   label,
+  title,
+  right,
   class: cx,
+  tone,
   variant = 'light',
+  testId,
+  'data-testid': dataTestId,
   children,
 }: SectionCardProps) {
   // SPEC `.section-head` upgrade — SectionHead atom replaces the
@@ -63,9 +73,15 @@ export function SectionCard({
   // above transparent body. Variant `compact` had p-3.5 in the legacy
   // path; the new wrapper uses p-3.5 to preserve that visual.
   const bodyPadding = variant === 'compact' ? 'p-3.5' : 'p-4'
+  const sectionLabel = label ?? title ?? ''
   return html`
-    <${SurfaceCard} variant=${variant} class="flex flex-col !p-0 overflow-hidden ${cx ?? ''}">
-      <${SectionHead}>${label}<//>
+    <${SurfaceCard}
+      variant=${variant}
+      tone=${tone}
+      testId=${testId ?? dataTestId}
+      class="flex flex-col !p-0 overflow-hidden ${cx ?? ''}"
+    >
+      <${SectionHead} tail=${right}>${sectionLabel}<//>
       <div class="${bodyPadding} flex flex-col gap-4">${children}</div>
     <//>
   `

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -32,8 +32,10 @@ function Highlight({ attention }: { attention: OperatorAttentionItem | null }) {
       <div class="flex items-center gap-3">
         <span class="flex-shrink-0 flex h-2 w-2 rounded-full bg-[var(--color-status-err)] animate-pulse" />
         <div class="flex-1 min-w-0">
-          <p class="text-xs font-medium truncate ${severityToneClass(attention.severity)}">${attention.title}</p>
-          <p class="text-2xs text-[var(--color-fg-secondary)] truncate">${attention.message}</p>
+          <p class="text-xs font-medium truncate ${severityToneClass(attention.severity)}">${attention.summary}</p>
+          <p class="text-2xs text-[var(--color-fg-secondary)] truncate">
+            ${attention.actor ?? attention.target_id ?? attention.target_type}
+          </p>
         </div>
       </div>
     <//>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -22,6 +22,7 @@ import { missionSnapshot } from '../../mission-store'
 import { agents, tasks, keepers } from '../../store'
 import type { Agent, Task, Keeper } from '../../types/core'
 import type {
+  DashboardMissionResponse,
   DashboardMissionSessionCard,
 } from '../../types/dashboard-mission'
 import { openAgentDetail } from '../agent-detail-state'
@@ -47,35 +48,35 @@ export interface TaskAlert {
 }
 
 /** Derive a list of failing / offline agent alerts from the live agent list. */
-export function deriveAgentAlerts(agentList: Agent[]): AgentAlert[] {
+export function deriveAgentAlerts(agentList: readonly Agent[]): AgentAlert[] {
   return agentList
     .filter(a => a.status === 'offline' || a.status === 'inactive')
     .map(a => ({
       name: a.name,
-      display: a.display_name || a.name,
+      display: a.koreanName && a.koreanName !== '' ? a.koreanName : a.name,
       reason: a.status === 'offline' ? 'Offline' : 'Inactive',
       severity: 'critical',
     }))
 }
 
 /** Derive a list of stalled tasks or tasks needing attention. */
-export function deriveTaskAlerts(taskList: Task[], nowMs: number): TaskAlert[] {
-  // Simple heuristic: tasks in 'awaiting_verification' for too long
-  const STALL_THRESHOLD_MS = 1000 * 60 * 10 // 10 mins
-  return taskList
-    .filter(t => t.status === 'awaiting_verification')
-    .filter(t => {
-      const updated = new Date(t.updated_at).getTime()
-      return nowMs - updated > STALL_THRESHOLD_MS
-    })
-    .map(t => ({
+export function deriveTaskAlerts(taskList: readonly Task[], nowMs: number): TaskAlert[] {
+  const STALL_THRESHOLD_MS = 10 * 60 * 1000
+  const alerts: TaskAlert[] = []
+  for (const t of taskList) {
+    if (t.status !== 'awaiting_verification') continue
+    const updated = parseIsoMs(t.updated_at)
+    if (updated !== null && nowMs - updated <= STALL_THRESHOLD_MS) continue
+    alerts.push({
       id: t.id,
       title: t.title,
-      status: t.status,
-      assignee: t.assignee,
+      status: 'awaiting_verification',
+      assignee: t.assignee ?? null,
       severity: 'warn',
       task: t,
-    }))
+    })
+  }
+  return alerts
 }
 
 export function severityToneClass(severity?: string | null): string {
@@ -87,7 +88,7 @@ export function severityToneClass(severity?: string | null): string {
     case 'medium':
       return 'text-[var(--color-status-warn)]'
     default:
-      return 'text-[var(--color-fg-secondary)]'
+      return 'text-[var(--color-fg-muted)]'
   }
 }
 
@@ -99,17 +100,17 @@ function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; ta
   const warnCount = allAlerts.filter(a => a.severity === 'warn').length
 
   return html`
-    <${SectionCard} 
-      title="Alerts" 
+    <${SectionCard}
+      title="Alerts"
       tone=${hasCritical ? 'danger' : 'warn'}
-      right=${html`<${StatusDot} tone=${hasCritical ? 'danger' : 'warn'} />`}
+      right=${html`<${StatusDot} class=${hasCritical ? 'bg-[var(--color-status-err)]' : 'bg-[var(--color-status-warn)]'} />`}
       data-testid="overview-alerts"
     >
       <div class="mb-4">
         <${KpiStripIsland}
           cols=${2}
           cells=${[
-            { label: 'Critical', value: String(criticalCount), kind: 'danger' },
+            { label: 'Critical', value: String(criticalCount), kind: 'err' },
             { label: 'Warning', value: String(warnCount), kind: 'warn' },
           ]}
         />
@@ -117,7 +118,7 @@ function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; ta
       <ul class="space-y-2 border-t border-[var(--color-border-default)] pt-4">
         ${allAlerts.map(
           a => html`
-            <li 
+            <li
               class="flex items-start justify-between gap-4 cursor-pointer hover:bg-[var(--color-bg-secondary)]/50 p-1 -m-1 rounded transition-colors"
               onClick=${() => {
                 if ('name' in a) openAgentDetail(a.name)
@@ -149,25 +150,53 @@ export interface FunnelCounts {
   target: number | null
 }
 
-export function computeFunnelCounts(taskList: Task[], active: DashboardMissionSessionCard | null): FunnelCounts {
-  const todayMs = startOfTodayMs()
-  const created = taskList.filter(t => parseIsoMs(t.created_at) >= todayMs).length
-  const inProgress = taskList.filter(t => t.status === 'claimed' || t.status === 'in_progress').length
-  const awaiting = taskList.filter(t => t.status === 'awaiting_verification').length
-  const completed = taskList.filter(t => t.status === 'done' && parseIsoMs(t.updated_at) >= todayMs).length
-  const target = active?.target_value ? parseInt(active.target_value, 10) : null
-
+export function computeFunnelCounts(
+  taskList: readonly Task[],
+  active: DashboardMissionSessionCard | null,
+  nowMs: number = Date.now(),
+): FunnelCounts {
+  const todayMs = startOfTodayMs(nowMs)
+  let created = 0
+  let inProgress = 0
+  let awaiting = 0
+  let completed = 0
+  for (const t of taskList) {
+    const createdMs = parseIsoMs(t.created_at)
+    if (createdMs !== null && createdMs >= todayMs) created += 1
+    switch (t.status) {
+      case 'claimed':
+      case 'in_progress':
+        inProgress += 1
+        break
+      case 'awaiting_verification':
+        awaiting += 1
+        break
+      case 'done': {
+        const completedMs = parseIsoMs(t.completed_at)
+        if (completedMs !== null && completedMs >= todayMs) completed += 1
+        break
+      }
+      default:
+        break
+    }
+  }
+  const target =
+    typeof active?.required_count === 'number' && active.required_count > 0
+      ? active.required_count
+      : null
   return { created, inProgress, awaiting, completed, target }
 }
 
-function startOfTodayMs(): number {
-  const d = new Date()
+function startOfTodayMs(nowMs: number): number {
+  const d = new Date(nowMs)
   d.setHours(0, 0, 0, 0)
   return d.getTime()
 }
 
-function parseIsoMs(iso: string): number {
-  return new Date(iso).getTime()
+function parseIsoMs(iso: string | null | undefined): number | null {
+  if (iso === null || iso === undefined || iso === '') return null
+  const ms = Date.parse(iso)
+  return Number.isFinite(ms) ? ms : null
 }
 
 export function formatTargetRatio(counts: FunnelCounts): string {
@@ -197,9 +226,10 @@ function FunnelCard({ counts }: { counts: FunnelCounts }) {
 
 // ─── Mission Party ────────────────────────────────────────────────────────────
 
-function progressPct(session: DashboardMissionSessionCard): number {
+export function progressPct(session: DashboardMissionSessionCard | null): number | null {
+  if (session === null) return null
   const req = session.required_count ?? 0
-  if (req <= 0) return 0
+  if (req <= 0) return null
   const cur = session.seen_count ?? session.active_count ?? 0
   return Math.min(100, Math.round((cur / req) * 100))
 }
@@ -213,23 +243,25 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
     `
   }
 
-  const progress = progressPct(active)
+  const progress = progressPct(active) ?? 0
+  const status = active.status ?? 'unknown'
+  const members = active.member_names
 
   return html`
     <${SectionCard} title="Active Mission" data-testid="overview-party">
       <div class="space-y-4">
         <div class="flex items-center justify-between">
            <p class="text-xs font-semibold text-[var(--color-fg-default)] truncate flex-1 mr-4">
-             ${active.goal_id}
+             ${active.goal}
            </p>
            <div class="flex -space-x-1.5">
-             ${active.members.map(m => html`<${AgentAvatar} key=${m} name=${m} size="xs" class="ring-1 ring-[var(--color-bg-default)]" />`)}
+             ${members.map(m => html`<${AgentAvatar} key=${m} name=${m} size="xs" class="ring-1 ring-[var(--color-bg-default)]" />`)}
            </div>
         </div>
-        
+
         <div class="grid grid-cols-2 gap-3">
           <${StatTile} label="Progress" value="${progress}%" variant="${progress > 80 ? 'accent' : 'default'}" />
-          <${StatTile} label="Status" value="${active.status.toUpperCase()}" variant="${active.status === 'running' || active.status === 'active' ? 'accent' : 'default'}" />
+          <${StatTile} label="Status" value="${status.toUpperCase()}" variant="${status === 'running' || status === 'active' ? 'accent' : 'default'}" />
         </div>
       </div>
     <//>
@@ -254,17 +286,19 @@ function keeperStatusToneClass(status?: string | null): string {
   }
 }
 
-function pickActiveKeepers(keeperList: Keeper[], max = 3): Keeper[] {
+export function pickActiveKeepers(keeperList: readonly Keeper[], max = 3): Keeper[] {
   return [...keeperList]
     .sort((a, b) => {
-      const tsA = new Date(a.last_seen_at || 0).getTime()
-      const tsB = new Date(b.last_seen_at || 0).getTime()
-      return tsB - tsA
+      const tsA = parseIsoMs(a.last_heartbeat) ?? 0
+      const tsB = parseIsoMs(b.last_heartbeat) ?? 0
+      const pausedA = a.paused === true ? -1e15 : 0
+      const pausedB = b.paused === true ? -1e15 : 0
+      return tsB + pausedB - (tsA + pausedA)
     })
     .slice(0, max)
 }
 
-function KeeperStrip({ keeperList }: { keeperList: Keeper[] }) {
+function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
   const activeKeepers = pickActiveKeepers(keeperList)
 
   if (activeKeepers.length === 0) {
@@ -280,9 +314,8 @@ function KeeperStrip({ keeperList }: { keeperList: Keeper[] }) {
       <div class="space-y-4">
         ${activeKeepers.slice(0, 1).map(
           k => html`
-            <${LifelineBar} 
-              label=${k.display_name_ko || k.name} 
-              bpm=${72} 
+            <${LifelineBar}
+              label=${k.koreanName && k.koreanName !== '' ? k.koreanName : k.name}
             />
           `,
         )}
@@ -290,10 +323,12 @@ function KeeperStrip({ keeperList }: { keeperList: Keeper[] }) {
           ${activeKeepers.slice(1).map(
             k => html`
               <li key=${k.name} class="flex items-center gap-2">
-                <${StatusDot} tone=${keeperStatusToneClass(k.status)} />
+                <${StatusDot} class=${keeperStatusToneClass(k.status)} />
                 <div class="min-w-0">
-                  <p class="text-xs font-medium truncate">${k.display_name_ko || k.name}</p>
-                  <${TimeAgo} timestamp=${k.last_seen_at} class="text-3xs text-[var(--color-fg-muted)]" />
+                  <p class="text-xs font-medium truncate">${k.koreanName && k.koreanName !== '' ? k.koreanName : k.name}</p>
+                  ${k.last_heartbeat !== undefined
+                    ? html`<${TimeAgo} timestamp=${k.last_heartbeat} class="text-3xs text-[var(--color-fg-muted)]" />`
+                    : null}
                 </div>
               </li>
             `,
@@ -304,10 +339,10 @@ function KeeperStrip({ keeperList }: { keeperList: Keeper[] }) {
   `
 }
 
-export function pickActiveSession(snap: any): DashboardMissionSessionCard | null {
-  if (!snap) return null
-  const running = snap.sessions.find((s: any) => s.status === 'running' || s.status === 'active')
-  return running || snap.sessions[0] || null
+export function pickActiveSession(snap: DashboardMissionResponse | null): DashboardMissionSessionCard | null {
+  if (snap === null) return null
+  const running = snap.sessions.find(s => s.status === 'running' || s.status === 'active' || s.status === 'busy')
+  return running ?? snap.sessions[0] ?? null
 }
 
 // ─── Root ────────────────────────────────────────────────────────────────────
@@ -320,7 +355,7 @@ export function Overview() {
   const agentList = agents.value
   const nowMs = nowSecondsSignal.value * 1000
   const active = useMemo(() => pickActiveSession(snap), [snap])
-  const counts = useMemo(() => computeFunnelCounts(taskList, active), [taskList, active])
+  const counts = useMemo(() => computeFunnelCounts(taskList, active, nowMs), [taskList, active, nowMs])
   const agentAlerts = useMemo(() => deriveAgentAlerts(agentList), [agentList])
   const taskAlerts = useMemo(() => deriveTaskAlerts(taskList, nowMs), [taskList, nowMs])
   return html`


### PR DESCRIPTION
## Summary
- restore Overview helper contracts to match current dashboard entity types after #12601
- switch Lab legacy highlight to OperatorAttentionItem.summary/current target fields
- make SectionCard accept existing title/right/testId call sites and cover that compatibility in tests
- remove fake keeper lifeline BPM and use real keeper heartbeat/display fields

## Verification
- git diff --check
- cd dashboard && pnpm run typecheck
- cd dashboard && pnpm vitest run --config vitest.config.ts src/components/overview/overview.test.ts src/components/common/card.test.ts --no-file-parallelism --maxWorkers=1

## Context
Main CI run 25212045684 failed in Dashboard TypeScript typecheck after #12601. This PR targets that deterministic failure class.