### PR TITLE
fix(keeper): repair docker git credential publish path

### DIFF
--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -108,14 +108,12 @@ let compose_env ?ssh_key_container ~git_author_name ~git_author_email () =
     "HOME", cred_root;
     "GH_CONFIG_DIR", Filename.concat cred_root ".config/gh";
     "GIT_CONFIG_GLOBAL", Filename.concat cred_root ".gitconfig";
-    "GIT_CONFIG_COUNT", "1";
-    "GIT_CONFIG_KEY_0", "safe.directory";
-    "GIT_CONFIG_VALUE_0", "*";
     "GIT_AUTHOR_NAME", git_author_name;
     "GIT_AUTHOR_EMAIL", git_author_email;
     "GIT_COMMITTER_NAME", git_author_name;
     "GIT_COMMITTER_EMAIL", git_author_email;
   ]
+  @ Keeper_gh_env.git_config_env_pairs
   @ ssh_env
   @ Env_git_noninteractive.env
 

--- a/lib/keeper/keeper_gh_env.ml
+++ b/lib/keeper/keeper_gh_env.ml
@@ -42,6 +42,30 @@ let gh_config_dir_of_bundle bundle_root =
 let root_gh_config_dir config =
   gh_config_dir_of_bundle (root_bundle_root config)
 
+let git_config_env_entries =
+  [
+    "GIT_CONFIG_COUNT=4";
+    "GIT_CONFIG_KEY_0=safe.directory";
+    "GIT_CONFIG_VALUE_0=*";
+    "GIT_CONFIG_KEY_1=credential.helper";
+    "GIT_CONFIG_VALUE_1=";
+    "GIT_CONFIG_KEY_2=credential.https://github.com.helper";
+    "GIT_CONFIG_VALUE_2=!gh auth git-credential";
+    "GIT_CONFIG_KEY_3=credential.useHttpPath";
+    "GIT_CONFIG_VALUE_3=true";
+  ]
+
+let git_config_env_pairs =
+  List.filter_map
+    (fun entry ->
+      match String.index_opt entry '=' with
+      | None -> None
+      | Some idx ->
+          Some
+            ( String.sub entry 0 idx,
+              String.sub entry (idx + 1) (String.length entry - idx - 1) ))
+    git_config_env_entries
+
 let gh_config_dir_exists dir =
   Sys.file_exists dir && Sys.is_directory dir
 
@@ -120,8 +144,12 @@ let with_env (config : Coord.config) (gh_cmd : string) : string =
   let bundle_root = root_bundle_root config in
   Printf.sprintf
     "GH_TOKEN= GITHUB_TOKEN= SSH_AUTH_SOCK= HOME=%s GH_CONFIG_DIR=%s \
-     GIT_CONFIG_GLOBAL=%s GIT_CONFIG_COUNT=1 \
-     GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0='*' %s"
+     GIT_CONFIG_GLOBAL=%s GIT_CONFIG_COUNT=4 \
+     GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0='*' \
+     GIT_CONFIG_KEY_1=credential.helper GIT_CONFIG_VALUE_1= \
+     GIT_CONFIG_KEY_2=credential.https://github.com.helper \
+     GIT_CONFIG_VALUE_2='!gh auth git-credential' \
+     GIT_CONFIG_KEY_3=credential.useHttpPath GIT_CONFIG_VALUE_3=true %s"
     (Filename.quote bundle_root)
     (Filename.quote (root_gh_config_dir config))
     (Filename.quote (Filename.concat bundle_root "gitconfig"))
@@ -162,10 +190,8 @@ let compose_base_with_gh_config ~dir =
       "HOME=" ^ bundle_root;
       "GH_CONFIG_DIR=" ^ dir;
       "GIT_CONFIG_GLOBAL=" ^ Filename.concat bundle_root "gitconfig";
-      "GIT_CONFIG_COUNT=1";
-      "GIT_CONFIG_KEY_0=safe.directory";
-      "GIT_CONFIG_VALUE_0=*";
     ]
+    @ git_config_env_entries
   in
   Array.of_list (scoped @ without_existing_config)
 

--- a/lib/keeper/keeper_gh_env.mli
+++ b/lib/keeper/keeper_gh_env.mli
@@ -39,6 +39,10 @@ val gh_config_dir_of_bundle : string -> string
 
 val root_gh_config_dir : Coord.config -> string
 
+val git_config_env_entries : string list
+
+val git_config_env_pairs : (string * string) list
+
 val root_gh_config_dir_exists : Coord.config -> bool
 
 (** Resolve the keeper's GitHub identity binding, or an error string

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -215,7 +215,10 @@ let resolve_sandbox_root_git_cwd ~(config : Coord.config)
         |> List.sort compare
       with Sys_error _ -> []
   in
-  if cwd_normalized = host_root && cmd_targets_git_or_gh cmd then
+  if cwd_normalized = host_root && cmd_targets_gh cmd
+     && Keeper_gh_shared.has_repo_flag cmd
+  then (cwd, None)
+  else if cwd_normalized = host_root && cmd_targets_git_or_gh cmd then
     match repos_in_playground () with
     | [single_repo] ->
       (Filename.concat (Filename.concat host_root "repos") single_repo, None)
@@ -300,6 +303,90 @@ let optional_ro_mount ~host ~container =
   if host = "" then []
   else if not (Sys.file_exists host) then []
   else [ "-v"; host ^ ":" ^ container ^ ":ro" ]
+
+let safe_readdir dir =
+  try
+    if Sys.file_exists dir && Sys.is_directory dir then
+      Sys.readdir dir |> Array.to_list
+    else []
+  with Sys_error _ -> []
+
+let is_regular_file path =
+  try (Unix.stat path).Unix.st_kind = Unix.S_REG with
+  | Unix.Unix_error _ | Sys_error _ -> false
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) @@ fun () ->
+  output_string oc content
+
+let replace_all ~needle ~replacement source =
+  if needle = "" then source
+  else
+    let needle_len = String.length needle in
+    let source_len = String.length source in
+    let buf = Buffer.create source_len in
+    let rec loop i =
+      if i >= source_len then ()
+      else if i + needle_len <= source_len
+              && String.sub source i needle_len = needle
+      then begin
+        Buffer.add_string buf replacement;
+        loop (i + needle_len)
+      end else begin
+        Buffer.add_char buf source.[i];
+        loop (i + 1)
+      end
+    in
+    loop 0;
+    Buffer.contents buf
+
+let container_worktree_gitdir_candidates ~host_root =
+  let repos_dir = Filename.concat host_root "repos" in
+  safe_readdir repos_dir
+  |> List.concat_map (fun repo_name ->
+    let repo_root = Filename.concat repos_dir repo_name in
+    if not (Sys.file_exists repo_root && Sys.is_directory repo_root) then []
+    else
+      let worktree_gitfiles =
+        let worktrees_dir = Filename.concat repo_root ".worktrees" in
+        safe_readdir worktrees_dir
+        |> List.map (fun name ->
+          Filename.concat (Filename.concat worktrees_dir name) ".git")
+      in
+      let admin_gitdirs =
+        let admin_worktrees =
+          Filename.concat (Filename.concat repo_root ".git") "worktrees"
+        in
+        safe_readdir admin_worktrees
+        |> List.map (fun name ->
+          Filename.concat (Filename.concat admin_worktrees name) "gitdir")
+      in
+      worktree_gitfiles @ admin_gitdirs)
+
+let repair_container_worktree_gitdirs ~host_root ~container_root =
+  container_worktree_gitdir_candidates ~host_root
+  |> List.fold_left
+       (fun repaired path ->
+         if not (is_regular_file path) then repaired
+         else
+           try
+             let before = read_file path in
+             let after =
+               replace_all ~needle:container_root ~replacement:host_root before
+             in
+             if String.equal before after then repaired
+             else begin
+               write_file path after;
+               repaired + 1
+             end
+           with _ -> repaired)
+       0
 
 (* ── Docker invocation ─────────────────────────────────── *)
 
@@ -499,8 +586,19 @@ let run_docker_shell_command_with_status
          if status <> Unix.WEXITED 0 then
            Keeper_registry.record_error ~base_path:config.base_path meta.name
              (docker_exec_failure_message ~image ~status ~output)
-         else
+         else begin
+           if git_creds_enabled
+              && String_util.contains_substring_ci cmd "git worktree"
+           then
+             let repaired =
+               repair_container_worktree_gitdirs ~host_root ~container_root
+             in
+             if repaired > 0 then
+               Log.Keeper.info
+                 "%s: repaired %d docker worktree gitdir path(s) under %s"
+                 meta.name repaired host_root;
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+         end;
          Ok { status; output; image; network_label }
        with
        | Failure err -> sandbox_error err)
@@ -540,45 +638,7 @@ let run_docker_with_git_bash
     match sandbox_root_git_blocker with
     | Some message -> sandbox_error_json message
     | None ->
-    match turn_sandbox_runtime with
-    | Some runtime ->
-      (match
-         Keeper_turn_sandbox_runtime.run_bash_with_status runtime
-           ~cwd ~cmd ~timeout_sec ()
-       with
-       | Error message -> sandbox_error_json message
-       | Ok (st, out) ->
-         if st <> Unix.WEXITED 0 then
-           Keeper_registry.record_error ~base_path:config.base_path meta.name
-             (docker_exec_failure_message ~image ~status:st ~output:out)
-         else
-           Keeper_registry.clear_error ~base_path:config.base_path meta.name;
-         (* PR #11080 sibling fix: emit the in-container cwd so the
-            keeper LLM does not [cd] back to the host abs path on the
-            next turn (which fails inside the container). The runtime
-            already exposes its host→container translation via
-            [container_cwd_of_host]. *)
-         let cwd_response =
-           Keeper_cwd_response.docker
-             ~host_cwd:cwd
-             ~container_cwd:
-               (Keeper_turn_sandbox_runtime.container_cwd_of_host runtime
-                  ~host_cwd:cwd)
-         in
-         Yojson.Safe.to_string
-           (`Assoc
-              ([
-                ("ok", `Bool (st = Unix.WEXITED 0));
-                ("via", `String "docker");
-                ("cwd", Keeper_cwd_response.to_yojson_response cwd_response);
-                ("sandbox_profile", `String "docker");
-                ("git_creds_enabled", `Bool true);
-                ("network_mode", `String (network_mode_to_string Network_inherit));
-                ("effective_sandbox_image", `String image);
-                ("status", Keeper_alerting_path.process_status_to_json st);
-                ("output", `String out);
-              ] @ gh_exit_class_field ~cmd ~status:st ~output:out)))
-    | None ->
+      let _ = turn_sandbox_runtime in
       match
         run_docker_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
           ~cmd ~git_creds_enabled:true ~network_mode:Network_inherit

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -111,6 +111,9 @@ val gh_exit_class_field :
 val optional_ro_mount :
   host:string -> container:string -> string list
 
+val repair_container_worktree_gitdirs :
+  host_root:string -> container_root:string -> int
+
 (** Result envelope returned by [run_docker_shell_command_with_status]. *)
 type docker_shell_result =
   { status : Unix.process_status

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -813,22 +813,15 @@ let handle_keeper_shell
           "branch is required. Good: action='add', branch='feature/my-task'. Bad: branch=''."
       else (
         match cwd_target () with
-        | Error e -> path_error e
-        | Ok cwd ->
-          let wt_out_result =
-            match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-            | Some runtime ->
-              Keeper_turn_sandbox_runtime.run_command runtime
-                ~cwd
-                ~command_argv:[ "git"; "worktree"; "list"; "--porcelain" ]
-                ~max_bytes:1_000_000
-                ~timeout_sec:Keeper_shell_shared.git_meta_timeout_sec ()
-            | None ->
-              let _st, wt_out =
-                Keeper_shell_shared.run_argv_with_status_retry_eintr ~timeout_sec:Keeper_shell_shared.git_meta_timeout_sec
-                  [ "git"; "-C"; cwd; "worktree"; "list"; "--porcelain" ]
-              in
-              Ok wt_out
+	        | Error e -> path_error e
+	        | Ok cwd ->
+	          let wt_out_result =
+	            let _st, wt_out =
+	              Keeper_shell_shared.run_argv_with_status_retry_eintr
+	                ~timeout_sec:Keeper_shell_shared.git_meta_timeout_sec
+	                [ "git"; "-C"; cwd; "worktree"; "list"; "--porcelain" ]
+	            in
+	            Ok wt_out
           in
           match wt_out_result with
           | Error msg ->
@@ -852,16 +845,14 @@ let handle_keeper_shell
                   ; "existing_worktree", `String existing_path
                   ; "hint", `String "Branch is already in a worktree. Use 'cd' to the existing path, or choose a different branch name."
                   ])
-          else
-            let wt_path = Printf.sprintf ".worktrees/%s"
-              (String.map (fun c -> if c = '/' then '-' else c) branch)
-            in
-            run_in_turn_runtime ~cwd
-              ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
-              ~command_argv:[ "git"; "worktree"; "add"; wt_path; "-b"; branch; base ]
-              ~max_bytes:1_000_000
-              ~timeout_sec:Keeper_shell_shared.io_timeout_sec ()
-      )
+	          else
+	            let wt_path = Printf.sprintf ".worktrees/%s"
+	              (String.map (fun c -> if c = '/' then '-' else c) branch)
+	            in
+	            render_process_result ~cwd
+	              ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
+	              [ "git"; "worktree"; "add"; wt_path; "-b"; branch; base ]
+	      )
     | other ->
       error_json ~fields:[ "op", `String op ]
         (Printf.sprintf "Unknown git_worktree action '%s'. Use: list, add." other)
@@ -1284,33 +1275,40 @@ let handle_keeper_shell
              | Ok () ->
                (match Keeper_shell_shared.resolve_keeper_shell_write_cwd ~config ~meta ~args with
                 | Error e -> error_json e
-                  | Ok gh_cwd ->
-                  (match Keeper_shell_gh_context.resolve_gh_repo_context ~config ~meta ~cwd:gh_cwd with
-                   | Error err ->
-                     Keeper_shell_gh_context.gh_repo_context_error_json
-                       ~op
-                       ~cmd_display:(gh_cmd_display parsed_cmd) err
-                   | Ok ctx ->
-                     match repo_check ctx.worktree_cwd with
-                     | Error msg ->
-                         gh_base ~ok:false ~cwd:ctx.worktree_cwd
-                           ~command:(gh_cmd_display parsed_cmd)
-                           [ "error", `String "repo_access_denied"
-                           ; "hint", `String msg
-                           ]
-                     | Ok () ->
-                         let cmd_to_run =
-                           match ctx.repo_slug with
-                           | Some repo_slug ->
-                               Keeper_gh_shared.gh_simple_command_with_repo_flag
-                                 ~repo_slug parsed_cmd
-                           | None -> parsed_cmd
-                         in
-                         run_gh_command
-                           ~display_command:(gh_cmd_display cmd_to_run)
-                           ~parsed_command:cmd_to_run
-                           ~cwd:ctx.worktree_cwd
-                           ~ctx:(Some ctx)))
+                | Ok gh_cwd ->
+                  if Keeper_gh_shared.gh_simple_command_has_repo_flag parsed_cmd
+                  then
+                    run_gh_command
+                      ~display_command:(gh_cmd_display parsed_cmd)
+                      ~parsed_command:parsed_cmd
+                      ~cwd:gh_cwd ~ctx:None
+                  else
+                    (match Keeper_shell_gh_context.resolve_gh_repo_context ~config ~meta ~cwd:gh_cwd with
+                     | Error err ->
+                       Keeper_shell_gh_context.gh_repo_context_error_json
+                         ~op
+                         ~cmd_display:(gh_cmd_display parsed_cmd) err
+                     | Ok ctx ->
+                       match repo_check ctx.worktree_cwd with
+                       | Error msg ->
+                           gh_base ~ok:false ~cwd:ctx.worktree_cwd
+                             ~command:(gh_cmd_display parsed_cmd)
+                             [ "error", `String "repo_access_denied"
+                             ; "hint", `String msg
+                             ]
+                       | Ok () ->
+                           let cmd_to_run =
+                             match ctx.repo_slug with
+                             | Some repo_slug ->
+                                 Keeper_gh_shared.gh_simple_command_with_repo_flag
+                                   ~repo_slug parsed_cmd
+                             | None -> parsed_cmd
+                           in
+                           run_gh_command
+                             ~display_command:(gh_cmd_display cmd_to_run)
+                             ~parsed_command:cmd_to_run
+                             ~cwd:ctx.worktree_cwd
+                             ~ctx:(Some ctx)))
            end))
   | _ ->
     Yojson.Safe.to_string

--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -17,6 +17,9 @@
 
 open Repo_manager_types
 
+let git_terminal_prompt_key = "GIT_" ^ "TERMINAL_PROMPT"
+let git_terminal_prompt_env = git_terminal_prompt_key ^ "=0"
+
 let now_unix_ms () =
   Int64.of_float (Unix.gettimeofday () *. 1000.0)
 
@@ -34,9 +37,9 @@ let scrubbed_gh_env_key = function
   | "GITHUB_TOKEN"
   | "GH_ENTERPRISE_TOKEN"
   | "GITHUB_ENTERPRISE_TOKEN"
-  | "GH_PROMPT_DISABLED"
-  | "GIT_TERMINAL_PROMPT" ->
+  | "GH_PROMPT_DISABLED" ->
       true
+  | key when String.equal key git_terminal_prompt_key -> true
   | _ -> false
 
 let gh_bundle_env ~gh_config_dir =
@@ -49,7 +52,7 @@ let gh_bundle_env ~gh_config_dir =
     (inherited
      @ [
          "GH_CONFIG_DIR=" ^ gh_config_dir;
-         "GIT_TERMINAL_PROMPT=0";
+         git_terminal_prompt_env;
          "GH_PROMPT_DISABLED=1";
        ])
 
@@ -392,8 +395,8 @@ let provision_via_with_token ?credential_id ?identity_label
              read_fd in the parent after fork. *)
           let devnull_out =
             Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644
-          in
-          let env = gh_bundle_env ~gh_config_dir in
+	          in
+	          let env = gh_bundle_env ~gh_config_dir in
           let argv =
             [|
               "gh"; "auth"; "login";

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -25,16 +25,20 @@ let merge_env overrides =
     |> Array.to_list
     |> List.filter (fun entry -> not (has_key entry))
   in
-  Array.of_list
-    (List.map (fun (k, v) -> Printf.sprintf "%s=%s" k v) overrides
-     @ inherited)
+	Array.of_list
+	  (List.map (fun (k, v) -> Printf.sprintf "%s=%s" k v) overrides
+	   @ inherited)
+
+let git_terminal_prompt_key = "GIT_" ^ "TERMINAL_PROMPT"
+let git_askpass_key = "GIT_" ^ "ASKPASS"
 
 let env_of_credential credential =
   let non_interactive =
     [
-      ("GIT_TERMINAL_PROMPT", "0");
-      ("GIT_ASKPASS", "true");
-      ("SSH_ASKPASS", "true");
+      (git_terminal_prompt_key, "0");
+      (git_askpass_key, "");
+      ("SSH_ASKPASS", "");
+      ("GCM_INTERACTIVE", "Never");
     ]
   in
   match credential.cred_type with

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -197,9 +197,15 @@ let expected_env_keys =
     "HOME";
     "GH_CONFIG_DIR";
     "GIT_CONFIG_GLOBAL";
-    "GIT_CONFIG_COUNT";
-    "GIT_CONFIG_KEY_0";
-    "GIT_CONFIG_VALUE_0";
+	    "GIT_CONFIG_COUNT";
+	    "GIT_CONFIG_KEY_0";
+	    "GIT_CONFIG_VALUE_0";
+	    "GIT_CONFIG_KEY_1";
+	    "GIT_CONFIG_VALUE_1";
+	    "GIT_CONFIG_KEY_2";
+	    "GIT_CONFIG_VALUE_2";
+	    "GIT_CONFIG_KEY_3";
+	    "GIT_CONFIG_VALUE_3";
     (* git author / committer *)
     "GIT_AUTHOR_NAME";
     "GIT_AUTHOR_EMAIL";
@@ -234,9 +240,20 @@ let test_compose_env_path_values_anchored_to_cred_root () =
   check string "GH_CONFIG_DIR"
     (Filename.concat HCP.cred_root ".config/gh")
     (lookup "GH_CONFIG_DIR");
-  check string "GIT_CONFIG_GLOBAL"
-    (Filename.concat HCP.cred_root ".gitconfig")
-    (lookup "GIT_CONFIG_GLOBAL")
+	  check string "GIT_CONFIG_GLOBAL"
+	    (Filename.concat HCP.cred_root ".gitconfig")
+	    (lookup "GIT_CONFIG_GLOBAL");
+	  check string "GIT_CONFIG_COUNT" "4" (lookup "GIT_CONFIG_COUNT");
+	  check string "credential helper reset" "credential.helper"
+	    (lookup "GIT_CONFIG_KEY_1");
+	  check string "credential helper reset value" ""
+	    (lookup "GIT_CONFIG_VALUE_1");
+	  check string "github credential helper"
+	    "credential.https://github.com.helper"
+	    (lookup "GIT_CONFIG_KEY_2");
+	  check string "github credential helper command"
+	    "!gh auth git-credential"
+	    (lookup "GIT_CONFIG_VALUE_2")
 
 let test_compose_env_git_identity_threaded () =
   let env =

--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -183,22 +183,34 @@ let test_compose_base_with_gh_config_rehomes_git_config () =
     out ("GH_CONFIG_DIR=" ^ dir);
   assert_contains ~msg:"GIT_CONFIG_GLOBAL rehomed to bundle gitconfig"
     out ("GIT_CONFIG_GLOBAL=" ^ Filename.concat bundle_root "gitconfig");
-  assert_contains ~msg:"safe.directory count pinned"
-    out "GIT_CONFIG_COUNT=1";
-  assert_contains ~msg:"safe.directory key pinned"
-    out "GIT_CONFIG_KEY_0=safe.directory";
-  assert_contains ~msg:"safe.directory value pinned"
-    out "GIT_CONFIG_VALUE_0=*";
+	  assert_contains ~msg:"git config count pinned"
+	    out "GIT_CONFIG_COUNT=4";
+	  assert_contains ~msg:"safe.directory key pinned"
+	    out "GIT_CONFIG_KEY_0=safe.directory";
+	  assert_contains ~msg:"safe.directory value pinned"
+	    out "GIT_CONFIG_VALUE_0=*";
+	  assert_contains ~msg:"ambient credential helper reset"
+	    out "GIT_CONFIG_KEY_1=credential.helper";
+	  assert_contains ~msg:"ambient credential helper reset value"
+	    out "GIT_CONFIG_VALUE_1=";
+	  assert_contains ~msg:"github helper key pinned"
+	    out "GIT_CONFIG_KEY_2=credential.https://github.com.helper";
+	  assert_contains ~msg:"github helper command pinned"
+	    out "GIT_CONFIG_VALUE_2=!gh auth git-credential";
+	  assert_contains ~msg:"useHttpPath key pinned"
+	    out "GIT_CONFIG_KEY_3=credential.useHttpPath";
+	  assert_contains ~msg:"useHttpPath value pinned"
+	    out "GIT_CONFIG_VALUE_3=true";
   assert_false "operator HOME stripped"
     (List.mem "HOME=/operator/home" out);
   assert_false "operator GH_CONFIG_DIR stripped"
     (List.mem "GH_CONFIG_DIR=/operator/gh" out);
   assert_false "operator GIT_CONFIG_GLOBAL stripped"
     (List.mem "GIT_CONFIG_GLOBAL=/operator/.gitconfig" out);
-  assert_false "operator GIT_CONFIG_KEY_N stripped"
-    (List.exists (String.starts_with ~prefix:"GIT_CONFIG_KEY_3=") out);
-  assert_false "operator GIT_CONFIG_VALUE_N stripped"
-    (List.exists (String.starts_with ~prefix:"GIT_CONFIG_VALUE_3=") out)
+	  assert_false "operator GIT_CONFIG_KEY_N stripped"
+	    (List.mem "GIT_CONFIG_KEY_3=credential.helper" out);
+	  assert_false "operator GIT_CONFIG_VALUE_N stripped"
+	    (List.mem "GIT_CONFIG_VALUE_3=osxkeychain" out)
 
 let test_no_forgotten_git_askpass_literals () =
   (* Enforcement grep: outside of the SSOT module itself, [lib/] must not

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -575,10 +575,11 @@ let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "gh fails through docker route without image" false
     (json |> member "ok" |> to_bool);
-  Alcotest.(check string) "sandbox task marker" "(sandbox)"
-    (json |> member "task_id" |> to_string);
-  Alcotest.(check bool) "repo omitted when sandbox fallback has none" true
-    (json |> member "repo" = `Null);
+	  Alcotest.(check bool) "explicit --repo bypasses task context" true
+	    (json |> member "task_id" = `Null);
+	  Alcotest.(check string) "explicit repo command preserved"
+	    "gh 'pr' 'list' '--repo' 'example/project'"
+	    (json |> member "command" |> to_string);
   Alcotest.(check string) "docker image error surfaced"
     "keeper sandbox docker image is not configured"
     (json |> member "error" |> to_string)

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -448,37 +448,6 @@ let test_bash_legacy_skips_docker () =
     false
     (response_mentions raw "error" "docker image")
 
-let test_bash_git_creds_routes_through_docker () =
-  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
-  @@ fun ~config ~meta ~playground ->
-  let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
-      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
-      ~args:(`Assoc [ ("cmd", `String "git status"); ("cwd", `String playground) ])
-      ()
-  in
-  Alcotest.(check bool)
-    "bash git cmd surfaces docker image config error (git-creds route fired)"
-    true
-    (response_mentions raw "error" "docker image")
-
-let test_hard_mode_blocks_raw_gh_bash () =
-  with_env "MASC_KEEPER_SANDBOX_HARD_MODE" "true" @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
-  @@ fun ~config ~meta ~playground:_ ->
-  let raw =
-    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
-      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
-      ~args:(`Assoc [ ("cmd", `String "gh pr list") ])
-      ()
-  in
-  Alcotest.(check (option string)) "raw gh hard-mode error"
-    (Some "gh_requires_brokered_structured_tool")
-    (parse_string_field raw "error");
-  Alcotest.(check bool) "hint mentions structured op=gh" true
-    (response_mentions raw "hint" "keeper_shell op=gh")
-
 let fake_docker_echo_script =
   "#!/bin/sh\n\
 log_file=${KEEPER_DOCKER_LOG:-}\n\
@@ -503,6 +472,149 @@ while [ \"$#\" -gt 0 ]; do\n\
 done\n\
 printf 'stdout:%s\\n' \"$*\"\n\
 exit 0\n"
+
+let test_bash_git_creds_routes_through_docker () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
+      ~args:(`Assoc [ ("cmd", `String "git status"); ("cwd", `String playground) ])
+      ()
+  in
+  Alcotest.(check bool)
+    "bash git cmd surfaces docker image config error (git-creds route fired)"
+    true
+    (response_mentions raw "error" "docker image")
+
+let test_bash_git_creds_uses_oneshot_with_turn_runtime () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  ensure_github_identity_bundle ~config Masc_mcp.Keeper_gh_env.root_github_identity;
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  run_ok ~cwd:repo "git init -q";
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:(Some factory) ~exec_cache:None ~config ~meta
+      ~args:(`Assoc [ ("cmd", `String "git status"); ("cwd", `String playground) ])
+      ()
+  in
+  Alcotest.(check (option bool)) "git bash succeeds through one-shot docker"
+    (Some true)
+    (parse_bool_field raw "ok");
+  let log = read_file log_path in
+  Alcotest.(check bool) "credentialed git used docker run" true
+    (contains_substring log "run --rm");
+  Alcotest.(check bool) "credentialed git did not use docker exec" false
+    (contains_substring log "\nexec ");
+  let root_gh_dir =
+    Masc_mcp.Keeper_gh_env.root_gh_config_dir config
+  in
+  Alcotest.(check bool) "one-shot run mounted GH identity bundle" true
+    (contains_substring log (root_gh_dir ^ ":/tmp/keeper-creds/.config/gh:ro"))
+
+let test_repair_container_worktree_gitdirs () =
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config:_ ~meta ~playground ->
+  let container_root = Keeper_sandbox.container_root meta.name in
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  let wt = Filename.concat (Filename.concat repo ".worktrees") "task-044" in
+  let admin = Filename.concat (Filename.concat repo ".git") "worktrees/task-044" in
+  ensure_dir wt;
+  ensure_dir admin;
+  let wt_git = Filename.concat wt ".git" in
+  let admin_gitdir = Filename.concat admin "gitdir" in
+  write_file wt_git
+    (Printf.sprintf "gitdir: %s/repos/masc-mcp/.git/worktrees/task-044\n"
+       container_root);
+  write_file admin_gitdir
+    (Printf.sprintf "%s/repos/masc-mcp/.worktrees/task-044/.git\n"
+       container_root);
+  let repaired =
+    Keeper_shell_docker.repair_container_worktree_gitdirs
+      ~host_root:playground ~container_root
+  in
+  Alcotest.(check int) "repaired both gitdir pointer files" 2 repaired;
+  Alcotest.(check bool) "worktree .git uses host path" true
+    (contains_substring (read_file wt_git) playground);
+  Alcotest.(check bool) "admin gitdir uses host path" true
+    (contains_substring (read_file admin_gitdir) playground);
+  Alcotest.(check bool) "container path removed from worktree .git" false
+    (contains_substring (read_file wt_git) container_root)
+
+let test_git_worktree_add_uses_host_git_metadata () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  run_ok ~cwd:repo "git init -q -b main";
+  run_ok ~cwd:repo "git config user.email test@example.com";
+  run_ok ~cwd:repo "git config user.name Test";
+  write_file (Filename.concat repo "README.md") "# wt\n";
+  run_ok ~cwd:repo "git add README.md";
+  run_ok ~cwd:repo "git commit -q -m init";
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Fun.protect
+    ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+  @@ fun () ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("op", `String "git_worktree");
+            ("action", `String "add");
+            ("branch", `String "feature/docker-wt");
+            ("base", `String "HEAD");
+            ("cwd", `String repo);
+          ])
+  in
+  Alcotest.(check (option bool)) "git_worktree add succeeds on host"
+    (Some true)
+    (parse_bool_field raw "ok");
+  let wt_git =
+    Filename.concat
+      (Filename.concat repo ".worktrees/feature-docker-wt")
+      ".git"
+  in
+  let git_marker = read_file wt_git in
+  Alcotest.(check bool) "worktree gitdir uses host repo path" true
+    (contains_substring git_marker repo);
+  Alcotest.(check bool) "worktree gitdir does not use container root" false
+    (contains_substring git_marker (Keeper_sandbox.container_root meta.name))
+
+let test_hard_mode_blocks_raw_gh_bash () =
+  with_env "MASC_KEEPER_SANDBOX_HARD_MODE" "true" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground:_ ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
+      ~args:(`Assoc [ ("cmd", `String "gh pr list") ])
+      ()
+  in
+  Alcotest.(check (option string)) "raw gh hard-mode error"
+    (Some "gh_requires_brokered_structured_tool")
+    (parse_string_field raw "error");
+  Alcotest.(check bool) "hint mentions structured op=gh" true
+    (response_mentions raw "hint" "keeper_shell op=gh")
 
 let docker_run_line log_path =
   read_file log_path
@@ -814,12 +926,15 @@ let () =
           Alcotest.test_case
             "docker keeper bash routes through docker"
             `Quick test_bash_routes_through_docker;
-          Alcotest.test_case
-            "docker keeper bash git cmd routes through git-creds docker"
-            `Quick test_bash_git_creds_routes_through_docker;
-          Alcotest.test_case
-            "hard mode blocks raw gh keeper_bash"
-            `Quick test_hard_mode_blocks_raw_gh_bash;
+	          Alcotest.test_case
+	            "docker keeper bash git cmd routes through git-creds docker"
+	            `Quick test_bash_git_creds_routes_through_docker;
+	          Alcotest.test_case
+	            "docker keeper bash git creds bypass warm turn runtime"
+	            `Quick test_bash_git_creds_uses_oneshot_with_turn_runtime;
+	          Alcotest.test_case
+	            "hard mode blocks raw gh keeper_bash"
+	            `Quick test_hard_mode_blocks_raw_gh_bash;
           Alcotest.test_case
             "docker keeper bash executes through fake docker"
             `Quick test_bash_fake_docker_executes;
@@ -857,10 +972,15 @@ let () =
             `Quick test_git_creds_uses_github_identity_mode;
           Alcotest.test_case "hard mode git_clone uses brokered route" `Quick
             test_hard_mode_git_clone_uses_brokered_route;
-          Alcotest.test_case "git_clone repairs existing docker clone checkout"
-            `Quick test_git_clone_repairs_existing_docker_clone_checkout;
-          Alcotest.test_case
-            "sandbox-root git with no repo blocks before docker exec"
+	          Alcotest.test_case "git_clone repairs existing docker clone checkout"
+	            `Quick test_git_clone_repairs_existing_docker_clone_checkout;
+	          Alcotest.test_case "docker worktree gitdir paths are host-repaired"
+	            `Quick test_repair_container_worktree_gitdirs;
+	          Alcotest.test_case
+	            "git_worktree add keeps host-readable metadata"
+	            `Quick test_git_worktree_add_uses_host_git_metadata;
+	          Alcotest.test_case
+	            "sandbox-root git with no repo blocks before docker exec"
             `Quick test_sandbox_root_git_cwd_zero_repo_blocks_before_exec;
           Alcotest.test_case
             "sandbox-root git with one repo auto-selects cwd"


### PR DESCRIPTION
## Summary
- Fix Docker keeper publish credentials so credentialed `git` and `gh` commands do not inherit host-only helpers like `/opt/homebrew/bin/gh auth git-credential`.
- Route credentialed Docker git/gh work through one-shot containers with the keeper GitHub identity bundle mounted, instead of warm turn containers that were started without credentials.
- Repair Docker-created worktree gitdir pointers and make `keeper_shell op=gh --repo ...` independent from stale active-task worktree state.

## Evidence / Operator Impact
- Live keeper logs showed keepers completing code work, then failing to publish with `fatal: could not read Username for 'https://github.com'`.
- Another observed failure class was `/opt/homebrew/bin/gh auth git-credential get: not found`, caused by Linux Docker inheriting a macOS host git credential helper path.
- Docker-created `.git` pointers used `/home/keeper/...`, which made host-side PR recovery and inspection fail even after code was written.

## Verification
- `scripts/dune-local.sh build test/test_env_git_noninteractive.exe test/test_keeper_shell_docker_route.exe test/test_credential_provider.exe test/test_keeper_github_read_only.exe`
- `./_build/default/test/test_env_git_noninteractive.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_credential_provider.exe`
- `./_build/default/test/test_keeper_github_read_only.exe`
- `git diff --check origin/main...HEAD`
