### PR TITLE
fix(dashboard): render card status affordances

### DIFF
--- a/dashboard/src/components/common/card.test.ts
+++ b/dashboard/src/components/common/card.test.ts
@@ -82,6 +82,21 @@ describe('SectionCard', () => {
     expect(container.textContent).toContain('Tail')
     expect(container.textContent).toContain('Body')
   })
+
+  it('renders status and eyebrow when no right slot is provided', () => {
+    const container = document.createElement('div')
+    render(
+      h(
+        SectionCard,
+        { title: 'Transport', status: 'warn', eyebrow: 'degraded' },
+        h('p', null, 'Body'),
+      ),
+      container,
+    )
+    expect(container.textContent).toContain('Transport')
+    expect(container.textContent).toContain('degraded')
+    expect(container.innerHTML).toContain('bg-[var(--color-status-warn)]')
+  })
 })
 
 describe('Card', () => {

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -44,20 +44,44 @@ interface SectionCardProps {
   label?: ComponentChildren
   title?: ComponentChildren
   right?: ComponentChildren
-  class?: string
+  eyebrow?: ComponentChildren
+  status?: string
   tone?: string
+  class?: string
   variant?: CardVariant
   testId?: string
   'data-testid'?: string
   children: ComponentChildren
 }
 
+function statusDotClass(status?: string): string {
+  switch ((status ?? '').toLowerCase()) {
+    case 'ok':
+    case 'healthy':
+    case 'active':
+    case 'live':
+      return 'bg-[var(--color-status-ok)]'
+    case 'warn':
+    case 'watch':
+      return 'bg-[var(--color-status-warn)]'
+    case 'bad':
+    case 'danger':
+    case 'error':
+    case 'offline':
+      return 'bg-[var(--color-status-err)]'
+    default:
+      return 'bg-[var(--color-fg-muted)]'
+  }
+}
+
 export function SectionCard({
   label,
   title,
   right,
-  class: cx,
+  eyebrow,
+  status,
   tone,
+  class: cx,
   variant = 'light',
   testId,
   'data-testid': dataTestId,
@@ -74,6 +98,16 @@ export function SectionCard({
   // path; the new wrapper uses p-3.5 to preserve that visual.
   const bodyPadding = variant === 'compact' ? 'p-3.5' : 'p-4'
   const sectionLabel = label ?? title ?? ''
+  const tail = right ?? (
+    eyebrow != null || status != null
+      ? html`
+          <span class="inline-flex items-center gap-1.5 text-2xs text-[var(--color-fg-muted)]">
+            ${status != null ? html`<span class="h-1.5 w-1.5 rounded-full ${statusDotClass(status)}" />` : null}
+            ${eyebrow != null ? html`<span>${eyebrow}</span>` : null}
+          </span>
+        `
+      : null
+  )
   return html`
     <${SurfaceCard}
       variant=${variant}
@@ -81,7 +115,7 @@ export function SectionCard({
       testId=${testId ?? dataTestId}
       class="flex flex-col !p-0 overflow-hidden ${cx ?? ''}"
     >
-      <${SectionHead} tail=${right}>${sectionLabel}<//>
+      <${SectionHead} tail=${tail}>${sectionLabel}<//>
       <div class="${bodyPadding} flex flex-col gap-4">${children}</div>
     <//>
   `

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -102,7 +102,7 @@ function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; ta
   return html`
     <${SectionCard}
       title="Alerts"
-      tone=${hasCritical ? 'danger' : 'warn'}
+      tone=${hasCritical ? 'border-[var(--color-status-err)]/45' : 'border-[var(--color-status-warn)]/45'}
       right=${html`<${StatusDot} class=${hasCritical ? 'bg-[var(--color-status-err)]' : 'bg-[var(--color-status-warn)]'} />`}
       data-testid="overview-alerts"
     >
@@ -243,7 +243,7 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
     `
   }
 
-  const progress = progressPct(active) ?? 0
+  const progress = progressPct(active)
   const status = active.status ?? 'unknown'
   const members = active.member_names
 
@@ -260,8 +260,8 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
         </div>
 
         <div class="grid grid-cols-2 gap-3">
-          <${StatTile} label="Progress" value="${progress}%" variant="${progress > 80 ? 'accent' : 'default'}" />
-          <${StatTile} label="Status" value="${status.toUpperCase()}" variant="${status === 'running' || status === 'active' ? 'accent' : 'default'}" />
+          <${StatTile} label="Progress" value=${progress === null ? 'n/a' : `${progress}%`} variant=${progress !== null && progress > 80 ? 'accent' : 'default'} />
+          <${StatTile} label="Status" value=${status.toUpperCase()} variant=${status === 'running' || status === 'active' ? 'accent' : 'default'} />
         </div>
       </div>
     <//>
@@ -274,15 +274,15 @@ function keeperStatusToneClass(status?: string | null): string {
   switch ((status ?? '').toLowerCase()) {
     case 'active':
     case 'live':
-      return 'tone-good'
+      return 'bg-[var(--color-status-ok)]'
     case 'busy':
     case 'executing':
-      return 'tone-info'
+      return 'bg-[var(--color-accent-fg)]'
     case 'offline':
     case 'dead':
-      return 'tone-danger'
+      return 'bg-[var(--color-status-err)]'
     default:
-      return 'tone-muted'
+      return 'bg-[var(--color-fg-muted)]'
   }
 }
 


### PR DESCRIPTION
## Summary
- render SectionCard status/eyebrow tail content when no explicit right slot is provided
- use real dashboard token classes for Overview status dots and alert card border tone
- avoid showing 0% progress when a mission has no required count

## Verification
- ./node_modules/.bin/tsc --noEmit --pretty
- ./node_modules/.bin/eslint src/components/common/card.ts src/components/common/card.test.ts src/components/overview/overview.ts src/components/overview/overview.test.ts
- ./node_modules/.bin/vitest run --config vitest.config.ts src/components/common/card.test.ts src/components/common/card.a11y.test.ts src/components/overview/overview.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check