### PR TITLE
style(dashboard): polish cockpit route links

### DIFF
--- a/dashboard/src/components/common/route-link.test.ts
+++ b/dashboard/src/components/common/route-link.test.ts
@@ -49,6 +49,22 @@ describe('RouteLink', () => {
     expect(a?.getAttribute('aria-current')).toBe('page')
   })
 
+  it('passes accessible names through for icon-only nav links', () => {
+    const container = document.createElement('div')
+    render(h(RouteLink, { tab: 'home' as any, 'aria-label': 'Home surface' }, 'Home'), container)
+    const a = container.querySelector('a')
+    expect(a?.getAttribute('aria-label')).toBe('Home surface')
+    expect(a?.getAttribute('role')).toBeNull()
+  })
+
+  it('uses the dashboard accent focus ring instead of the old blue ring', () => {
+    const container = document.createElement('div')
+    render(h(RouteLink, { tab: 'home' as any }, 'Home'), container)
+    const className = container.querySelector('a')?.getAttribute('class') ?? ''
+    expect(className).toContain('focus-visible:ring-[var(--accent-45)]')
+    expect(className).not.toContain('71,184,255')
+  })
+
   it('calls navigate on left click', async () => {
     const container = document.createElement('div')
     render(h(RouteLink, { tab: 'home' as any }, 'Home'), container)

--- a/dashboard/src/components/common/route-link.ts
+++ b/dashboard/src/components/common/route-link.ts
@@ -2,12 +2,14 @@ import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { hashForRoute, navigate } from '../../router'
 import type { TabId } from '../../types'
+import { ringFocusClasses } from './ring'
 
 interface RouteLinkProps {
   tab: TabId
   params?: Record<string, string>
   class?: string
   title?: string
+  'aria-label'?: string
   ariaCurrent?: 'page' | 'location' | undefined
   children: ComponentChildren
 }
@@ -17,13 +19,14 @@ export function RouteLink({
   params,
   class: className,
   title,
+  'aria-label': ariaLabel,
   ariaCurrent,
   children,
 }: RouteLinkProps) {
   const href = hashForRoute(tab, params)
   const classNameWithFocus = [
     className,
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.35)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]',
+    ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' }),
   ].filter(Boolean).join(' ')
 
   return html`
@@ -31,6 +34,7 @@ export function RouteLink({
       href=${href}
       class=${classNameWithFocus}
       title=${title}
+      aria-label=${ariaLabel}
       aria-current=${ariaCurrent}
       onClick=${(event: MouseEvent) => {
         if (

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -469,15 +469,16 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
-                        <${RouteLink}
-                          role="listitem"
-                          tab=${surface.id}
-                          params=${item.params}
-                          class="w-full rounded-sm border px-2 py-0.5 text-left font-mono text-[10px] uppercase leading-5 tracking-[0.06em] cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSectionActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--white-8)] hover:bg-[var(--white-4)] hover:!text-[var(--color-fg-primary)]'}"
-                          ariaCurrent=${isSectionActive ? 'page' : undefined}
-                        >
-                          <div class="truncate">${item.label}</div>
-                        <//>
+                        <div role="listitem">
+                          <${RouteLink}
+                            tab=${surface.id}
+                            params=${item.params}
+                            class="block w-full rounded-sm border px-2 py-0.5 text-left font-mono text-[10px] uppercase leading-5 tracking-[0.06em] cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSectionActive ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--white-8)] hover:bg-[var(--white-4)] hover:!text-[var(--color-fg-primary)]'}"
+                            ariaCurrent=${isSectionActive ? 'page' : undefined}
+                          >
+                            <div class="truncate">${item.label}</div>
+                          <//>
+                        </div>
                       `
                     })}
                   </div>

--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -10,8 +10,17 @@ const routeSignal = signal<{ tab: string; params: Record<string, string>; postId
   postId: null,
 })
 
+function replaceRoute(tab: string, params?: Record<string, string>) {
+  routeSignal.value = { tab, params: params ?? {}, postId: null }
+  const query = new URLSearchParams(params ?? {}).toString()
+  const hash = query ? `#${tab}?${query}` : `#${tab}`
+  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
+
 vi.mock('../router', () => ({
   get route() { return routeSignal },
+  replaceRoute,
 }))
 
 // Mock child panels to avoid real fetch calls. Each renders a data-testid marker.

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -5,7 +5,7 @@
 
 import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
-import { route } from '../router'
+import { replaceRoute, route } from '../router'
 import { FilterChips } from './common/filter-chips'
 import { TelemetryUnified } from './telemetry-unified'
 import { FleetTelemetryPanel } from './fleet-telemetry-panel'
@@ -39,11 +39,12 @@ const VIEW_CHIPS: Array<{ key: FleetHealthView; label: string }> = [
 ]
 
 function updateViewParam(view: FleetHealthView) {
-  const hash = view === 'default'
-    ? '#monitoring?section=fleet-health'
-    : `#monitoring?section=fleet-health&view=${view}`
-  history.replaceState(null, '', hash)
-  window.dispatchEvent(new HashChangeEvent('hashchange'))
+  replaceRoute(
+    'monitoring',
+    view === 'default'
+      ? { section: 'fleet-health' }
+      : { section: 'fleet-health', view },
+  )
 }
 
 function DefaultDualPanel() {

--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -13,7 +13,7 @@ async function flushUi(): Promise<void> {
 
 async function loadPanel() {
   vi.resetModules()
-  vi.doMock('../router', () => ({ route }))
+  vi.doMock('../router', () => ({ route, replaceRoute: vi.fn() }))
   vi.doMock('./ops', () => ({
     Ops: () => html`<div data-testid="ops">Ops</div>`,
   }))

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -9,7 +9,7 @@ import { Ops } from './ops'
 import { Governance } from './governance'
 import { LabInspector } from './lab-inspector'
 import { SafeAutonomyPanel } from './safe-autonomy'
-import { route } from '../router'
+import { replaceRoute, route } from '../router'
 
 type OpsView = 'default' | 'ops' | 'governance' | 'safety' | 'inspector'
 
@@ -30,18 +30,18 @@ function currentView(): OpsView {
 }
 
 function updateViewParam(next: OpsView): void {
-  const base = '#command?section=operations'
-  const hash = next === 'default' ? base : `${base}&view=${next}`
-  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
-  window.dispatchEvent(new HashChangeEvent('hashchange'))
+  replaceRoute(
+    'command',
+    next === 'default'
+      ? { section: 'operations' }
+      : { section: 'operations', view: next },
+  )
 }
 
 // Legacy URL migration (Phase 7):
 // #command?section=operations&view=connectors → #connectors?section=connector-status
 function redirectLegacyConnectorsView(): void {
-  const hash = '#connectors?section=connector-status'
-  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
-  window.dispatchEvent(new HashChangeEvent('hashchange'))
+  replaceRoute('connectors', { section: 'connector-status' })
 }
 
 export function OperationsPanel() {

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -11,6 +11,9 @@ const routeSignal = signal<{ tab: string; params: Record<string, string>; postId
 
 vi.mock('../router', () => ({
   get route() { return routeSignal },
+  replaceRoute: vi.fn((tab: string, params?: Record<string, string>) => {
+    routeSignal.value = { tab, params: params ?? {}, postId: null }
+  }),
 }))
 
 const coordinationSignal = signal<unknown>(null)

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -5,7 +5,7 @@
 
 import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
-import { route } from '../router'
+import { replaceRoute, route } from '../router'
 import { coordinationFsmSnapshot } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals'
@@ -36,11 +36,12 @@ const VIEW_CHIPS: Array<{ key: PlanningView; label: string }> = [
 ]
 
 function updateViewParam(view: PlanningView): void {
-  const hash = view === 'goal-tree'
-    ? '#workspace?section=planning'
-    : `#workspace?section=planning&view=${view}`
-  history.replaceState(null, '', hash)
-  window.dispatchEvent(new HashChangeEvent('hashchange'))
+  replaceRoute(
+    'workspace',
+    view === 'goal-tree'
+      ? { section: 'planning' }
+      : { section: 'planning', view },
+  )
 }
 
 function coordinationCount(

--- a/dashboard/src/components/repository-management.ts
+++ b/dashboard/src/components/repository-management.ts
@@ -7,7 +7,7 @@ import { AddRepoDialog } from './add-repo-dialog'
 import { CredentialSettings } from './credential-settings'
 import { KeeperRepoMapping } from './keeper-repo-mapping'
 import { GitBranch, GitFork, KeyRound, ShieldCheck } from 'lucide-preact'
-import { route } from '../router'
+import { replaceRoute, route } from '../router'
 import { GitGraphPanel } from './git-graph-panel'
 
 type RepositoryView = 'repos' | 'graph' | 'credentials' | 'mappings'
@@ -20,11 +20,12 @@ function currentView(): RepositoryView {
 }
 
 function updateViewParam(view: RepositoryView): void {
-  const hash = view === 'repos'
-    ? '#workspace?section=repositories'
-    : `#workspace?section=repositories&view=${view}`
-  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
-  window.dispatchEvent(new HashChangeEvent('hashchange'))
+  replaceRoute(
+    'workspace',
+    view === 'repos'
+      ? { section: 'repositories' }
+      : { section: 'repositories', view },
+  )
 }
 
 function viewButton(view: RepositoryView, label: string, icon: unknown) {

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -11,7 +11,7 @@ async function flushUi(): Promise<void> {
 
 async function loadRuntimePanel() {
   vi.resetModules()
-  vi.doMock('../router', () => ({ route }))
+  vi.doMock('../router', () => ({ route, replaceRoute: vi.fn() }))
   vi.doMock('./oas-health-chip', () => ({
     OasHealthChip: () => html`<div data-testid="oas-health">OasHealthChip</div>`,
   }))

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -20,7 +20,7 @@
 
 import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
-import { route } from '../router'
+import { replaceRoute, route } from '../router'
 import { FilterChips } from './common/filter-chips'
 import { CollapsibleSection } from './common/collapsible'
 import { OasHealthChip } from './oas-health-chip'
@@ -55,11 +55,12 @@ const VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
 ]
 
 function updateViewParam(view: RuntimeView): void {
-  const hash = view === 'default'
-    ? '#monitoring?section=runtime'
-    : `#monitoring?section=runtime&view=${view}`
-  history.replaceState(null, '', hash)
-  window.dispatchEvent(new HashChangeEvent('hashchange'))
+  replaceRoute(
+    'monitoring',
+    view === 'default'
+      ? { section: 'runtime' }
+      : { section: 'runtime', view },
+  )
 }
 
 export function RuntimePanel() {

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { navigate, route } from './router'
+import { describe, it, expect, vi } from 'vitest'
+import { navigate, replaceRoute, route } from './router'
 
 describe('navigate', () => {
   it('navigates to monitoring tab with agent param', () => {
@@ -56,7 +56,6 @@ describe('navigate', () => {
     expect(route.value.params.section).toBe('operations')
     expect(route.value.params.view).toBe('safety')
   })
-
   it('maps cockpit Cognition design deep links into the production keeper surface', () => {
     window.location.hash = '#repo=viewer&branch=wt%2Fsangsu-smoke&mode=Cognition'
     window.dispatchEvent(new HashChangeEvent('hashchange'))
@@ -125,5 +124,27 @@ describe('navigate', () => {
     expect(route.value.params.section).toBe('operations')
     expect(route.value.params.view).toBe('safety')
     expect(route.value.params.repo).toBe('viewer')
+  })
+
+  it('replaceRoute writes a canonical hash while preserving the current search params', () => {
+    window.history.replaceState(null, '', '/dashboard?theme=paper#overview')
+    replaceRoute('workspace', { section: 'planning', view: 'default' })
+
+    expect(route.value.tab).toBe('workspace')
+    expect(route.value.params.section).toBe('planning')
+    expect(route.value.params.view).toBe('default')
+    expect(window.location.search).toBe('?theme=paper')
+    expect(window.location.hash).toBe('#workspace?section=planning&view=default')
+  })
+
+  it('replaceRoute dispatches hashchange for existing listeners', () => {
+    const onHashChange = vi.fn()
+    window.addEventListener('hashchange', onHashChange)
+    try {
+      replaceRoute('monitoring', { section: 'fleet-health', view: 'tool-quality' })
+      expect(onHashChange).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('hashchange', onHashChange)
+    }
   })
 })

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -253,6 +253,18 @@ export function navigate(tab: TabId, params?: Record<string, string>): void {
   }
 }
 
+export function replaceRoute(tab: TabId, params?: Record<string, string>): void {
+  const next = canonicalRoute(tab, params ?? {})
+  const nextHash = toHash(next)
+  route.value = next
+  window.history.replaceState(
+    null,
+    '',
+    `${window.location.pathname}${window.location.search}${nextHash}`,
+  )
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
+
 export function navigateToPost(postId: string): void {
   window.location.hash = `#workspace?section=board&post=${encodeURIComponent(postId)}`
 }


### PR DESCRIPTION
## What

- Add `replaceRoute()` so dashboard view toggles update canonical cockpit hashes without hand-editing `window.location.hash`.
- Route Fleet, Runtime, Repository, Planning, and Operations view chips through the shared router helper.
- Let `RouteLink` forward `aria-label`, keep anchors as anchors, and move focus styling from the old blue ring to the brass design-system ring.
- Keep cockpit side-section links full-width and list-semantic so active rows render like the rest of the brass cockpit chrome.

## Why

The cockpit chrome is moving toward the new brass/gold design system, but several dashboard entrypoints still behaved like ad hoc buttons or blue-era links. This keeps links shareable, accessible, and visually consistent while preserving normal anchor semantics.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/overview/overview.test.ts src/router.test.ts src/components/common/route-link.test.ts src/components/dashboard-shell.test.ts src/components/fleet-health-panel.test.ts src/components/runtime-panel.test.ts src/components/planning-panel.test.ts src/components/operations-panel.test.ts`
- `pnpm build`
  - Passed with existing Vite warnings about mixed static/dynamic `dashboard.ts` imports and large chunks.
- `git diff --check`
- Browser verification with `agent-browser` at `http://127.0.0.1:5188/dashboard/`:
  - Top nav Workspace -> `#workspace?section=board`
  - Side nav Plans & Goals -> `#workspace?section=planning`
  - Planning Backlog tab -> `#workspace?section=planning&view=default`
  - Screenshot: `/tmp/masc-dashboard-cockpit-link-polish-pr.png`
