### PR TITLE
feat(dashboard): surface keeper decisions stream

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -39,7 +39,7 @@ describe('cockpit entrypoint registry', () => {
     }
   })
 
-  it('resolves blocked and partial prototype subtabs to explicit live route homes', () => {
+  it('resolves prototype subtabs to explicit live route homes', () => {
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-str' })).toEqual({
       tab: 'monitoring',
       params: { section: 'cognition', view: 'decisions' },

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -80,7 +80,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper' } }, coverage: 'partial' },
   { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'partial' },
   { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'token-stats' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'decisions' } }, coverage: 'backend-blocked' },
+  { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'decisions' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'memory' } }, coverage: 'partial' },
   { mode: 'cognition', aliases: ['ep-card', 'episodes-cards'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ep-lrn', 'episodes-learnings'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },

--- a/dashboard/src/components/cognition-plane.test.ts
+++ b/dashboard/src/components/cognition-plane.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+void vi
+
+const route = { value: { tab: 'monitoring' as string, params: {} as Record<string, string> } }
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function loadPlane() {
+  vi.resetModules()
+  vi.doMock('../router', () => ({ route, navigate: vi.fn() }))
+  vi.doMock('./agents-unified', () => ({
+    AgentsUnified: () => html`<div data-testid="agents-unified">AgentsUnified</div>`,
+  }))
+  vi.doMock('./autoresearch', () => ({
+    Autoresearch: () => html`<div data-testid="autoresearch">Autoresearch</div>`,
+  }))
+  vi.doMock('./keeper-decisions-stream', () => ({
+    KeeperDecisionsStream: () => html`<div data-testid="keeper-decisions-stream">KeeperDecisionsStream</div>`,
+  }))
+  vi.doMock('./keeper-token-stats', () => ({
+    KeeperTokenStats: () => html`<div data-testid="keeper-token-stats">KeeperTokenStats</div>`,
+  }))
+  vi.doMock('./memory-subsystems', () => ({
+    MemorySubsystems: () => html`<div data-testid="memory-subsystems">MemorySubsystems</div>`,
+  }))
+  return import('./cognition-plane')
+}
+
+describe('CognitionPlane', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    route.value = { tab: 'monitoring', params: { section: 'cognition' } }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../router')
+    vi.doUnmock('./agents-unified')
+    vi.doUnmock('./autoresearch')
+    vi.doUnmock('./keeper-decisions-stream')
+    vi.doUnmock('./keeper-token-stats')
+    vi.doUnmock('./memory-subsystems')
+  })
+
+  it('renders the live decisions stream for the decisions view', async () => {
+    route.value.params = { section: 'cognition', view: 'decisions' }
+    const { CognitionPlane } = await loadPlane()
+
+    render(html`<${CognitionPlane} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="keeper-decisions-stream"]')).not.toBeNull()
+    expect(container.textContent).not.toContain('backend-blocked')
+  })
+})

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -3,6 +3,7 @@ import { navigate, route } from '../router'
 import { AgentsUnified } from './agents-unified'
 import { Autoresearch } from './autoresearch'
 import { FilterChips } from './common/filter-chips'
+import { KeeperDecisionsStream } from './keeper-decisions-stream'
 import { KeeperTokenStats } from './keeper-token-stats'
 import { MemorySubsystems } from './memory-subsystems'
 
@@ -45,22 +46,6 @@ function updateViewParam(view: CognitionView): void {
   navigate('monitoring', next)
 }
 
-function BlockedCognitionSurface() {
-  return html`
-    <section class="rounded border border-[var(--warn-20)] border-l-[3px] border-l-[var(--color-status-warn)] bg-[var(--warn-soft)] px-4 py-3" role="status">
-      <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--warn-bright)]">
-        K2 decisions stream · backend-blocked
-      </div>
-      <div class="mt-1 text-sm text-[var(--color-fg-primary)]">
-        No cross-keeper decisions stream endpoint is registered yet.
-      </div>
-      <div class="mt-1 text-2xs text-[var(--color-fg-muted)]">
-        The route stays live and explicit; no synthetic decisions feed is rendered.
-      </div>
-    </section>
-  `
-}
-
 export function CognitionPlane() {
   const view = currentView()
 
@@ -79,7 +64,7 @@ export function CognitionPlane() {
       ` : view === 'token-stats' ? html`
         <${KeeperTokenStats} />
       ` : view === 'decisions' ? html`
-        <${BlockedCognitionSurface} />
+        <${KeeperDecisionsStream} />
       ` : view === 'memory' || view === 'episodes' ? html`
         <${MemorySubsystems} />
       ` : view === 'autoresearch' ? html`

--- a/dashboard/src/components/keeper-decisions-stream.test.ts
+++ b/dashboard/src/components/keeper-decisions-stream.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+import { h, render } from 'preact'
+import { describe, expect, it } from 'vitest'
+import type { KeeperDecision } from '../api/dashboard'
+import {
+  decisionOutcomeTone,
+  formatDecisionTime,
+  KeeperDecisionsTable,
+  summarizeDecisionEvents,
+} from './keeper-decisions-stream'
+
+function makeDecision(overrides: Partial<KeeperDecision> = {}): KeeperDecision {
+  return {
+    ts_unix: 1_714_000_000,
+    keeper_name: 'sangsu',
+    event_type: 'turn',
+    outcome: 'success',
+    model_used: 'gpt-test',
+    latency_ms: 1234,
+    cost_usd: 0.0123,
+    input_tokens: 100,
+    output_tokens: 50,
+    stop_reason: null,
+    error_category: null,
+    tool: null,
+    duration_ms: null,
+    match_count: null,
+    ...overrides,
+  }
+}
+
+describe('keeper decision helpers', () => {
+  it('classifies outcome tones', () => {
+    expect(decisionOutcomeTone('success')).toContain('ok')
+    expect(decisionOutcomeTone('error')).toContain('err')
+    expect(decisionOutcomeTone(null)).toContain('muted')
+  })
+
+  it('summarizes success, error, and tool-linked rows', () => {
+    expect(summarizeDecisionEvents([
+      makeDecision(),
+      makeDecision({ outcome: 'error', tool: 'keeper_shell' }),
+      makeDecision({ outcome: null }),
+    ])).toEqual({
+      total: 3,
+      success: 1,
+      error: 1,
+      tool: 1,
+    })
+  })
+
+  it('formats missing timestamps as a table placeholder', () => {
+    expect(formatDecisionTime(null)).toBe('-')
+  })
+})
+
+describe('KeeperDecisionsTable', () => {
+  it('renders decision rows and aggregate metrics', () => {
+    const container = document.createElement('div')
+    render(h(KeeperDecisionsTable, {
+      events: [
+        makeDecision(),
+        makeDecision({
+          keeper_name: 'janitor',
+          event_type: 'tool_call',
+          outcome: 'error',
+          model_used: null,
+          latency_ms: null,
+          cost_usd: null,
+          tool: 'keeper_shell',
+        }),
+      ],
+      limit: 200,
+    }), container)
+
+    expect(container.textContent).toContain('keeper decisions')
+    expect(container.textContent).toContain('2 events')
+    expect(container.textContent).toContain('sangsu')
+    expect(container.textContent).toContain('janitor')
+    expect(container.textContent).toContain('tool_call')
+    expect(container.textContent).toContain('keeper_shell')
+    render(null, container)
+  })
+
+  it('renders the empty state without a table', () => {
+    const container = document.createElement('div')
+    render(h(KeeperDecisionsTable, { events: [], limit: 200 }), container)
+
+    expect(container.textContent).toContain('No keeper decision events')
+    expect(container.querySelector('table')).toBeNull()
+    render(null, container)
+  })
+})

--- a/dashboard/src/components/keeper-decisions-stream.ts
+++ b/dashboard/src/components/keeper-decisions-stream.ts
@@ -1,0 +1,160 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { createAsyncResource, type AsyncResource } from '../lib/async-state'
+import { fetchKeeperDecisions, type KeeperDecision, type KeeperDecisionsResponse } from '../api/dashboard'
+import { formatTimeHms } from '../lib/format-time'
+import { AsyncContainer } from './common/async-container'
+import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
+import { KeeperBadge } from './keeper-badge'
+
+interface DecisionStats {
+  total: number
+  success: number
+  error: number
+  tool: number
+}
+
+const decisions: AsyncResource<KeeperDecisionsResponse> = createAsyncResource()
+
+export function decisionOutcomeTone(outcome?: string | null): string {
+  switch ((outcome ?? '').trim().toLowerCase()) {
+    case 'success':
+    case 'ok':
+      return 'text-[var(--color-status-ok)]'
+    case 'error':
+    case 'failed':
+    case 'failure':
+      return 'text-[var(--color-status-err)]'
+    default:
+      return 'text-[var(--color-fg-muted)]'
+  }
+}
+
+export function formatDecisionTime(tsUnix: number | null): string {
+  return tsUnix == null ? '-' : formatTimeHms(tsUnix)
+}
+
+export function summarizeDecisionEvents(events: readonly KeeperDecision[]): DecisionStats {
+  return events.reduce<DecisionStats>(
+    (acc, event) => {
+      acc.total += 1
+      const outcome = (event.outcome ?? '').trim().toLowerCase()
+      if (outcome === 'success' || outcome === 'ok') acc.success += 1
+      if (outcome === 'error' || outcome === 'failed' || outcome === 'failure') acc.error += 1
+      if (event.tool) acc.tool += 1
+      return acc
+    },
+    { total: 0, success: 0, error: 0, tool: 0 },
+  )
+}
+
+function MetricCell({ label, value }: { label: string; value: string | number }) {
+  return html`
+    <div class="rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2">
+      <div class="font-mono text-3xs uppercase tracking-[0.08em] text-[var(--color-fg-muted)]">${label}</div>
+      <div class="mt-1 font-mono text-lg font-semibold leading-none text-[var(--color-fg-primary)]">${value}</div>
+    </div>
+  `
+}
+
+export function KeeperDecisionsTable({
+  events,
+  limit,
+}: {
+  events: KeeperDecision[]
+  limit: number
+}) {
+  if (events.length === 0) {
+    return html`<${EmptyState} message="No keeper decision events are available yet." compact />`
+  }
+
+  const stats = summarizeDecisionEvents(events)
+
+  return html`
+    <div class="flex flex-col gap-3">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-2">
+        <${MetricCell} label="events" value=${stats.total} />
+        <${MetricCell} label="success" value=${stats.success} />
+        <${MetricCell} label="errors" value=${stats.error} />
+        <${MetricCell} label="tool-linked" value=${stats.tool} />
+      </div>
+
+      <div class="flex items-center justify-between rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2">
+        <span class="font-mono text-3xs uppercase tracking-[0.08em] text-[var(--color-fg-muted)]">
+          keeper decisions · ${events.length} events · limit ${limit}
+        </span>
+      </div>
+
+      <div class="overflow-x-auto rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-page)]">
+        <table class="w-full min-w-[760px]" aria-label="Keeper decision events">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-3xs uppercase tracking-[0.08em] text-[var(--color-fg-muted)]">
+              <th scope="col" class="px-2 py-1.5 text-left">time</th>
+              <th scope="col" class="px-2 py-1.5 text-left">keeper</th>
+              <th scope="col" class="px-2 py-1.5 text-left">event</th>
+              <th scope="col" class="px-2 py-1.5 text-left">outcome</th>
+              <th scope="col" class="px-2 py-1.5 text-left">model</th>
+              <th scope="col" class="px-2 py-1.5 text-right">latency</th>
+              <th scope="col" class="px-2 py-1.5 text-right">cost</th>
+              <th scope="col" class="px-2 py-1.5 text-left">tool</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${events.map((event, index) => html`
+              <tr key=${`${event.ts_unix ?? 'na'}:${event.keeper_name}:${index}`} class="border-b border-[var(--color-border-default)]/50 text-2xs">
+                <td class="px-2 py-1.5 text-left font-mono text-[var(--color-fg-muted)]">${formatDecisionTime(event.ts_unix)}</td>
+                <td class="px-2 py-1.5 text-left">
+                  <${KeeperBadge} id=${event.keeper_name} variant="full" size="sm" />
+                </td>
+                <td class="px-2 py-1.5 text-left font-mono text-[var(--color-fg-primary)]">${event.event_type}</td>
+                <td class="px-2 py-1.5 text-left font-mono ${decisionOutcomeTone(event.outcome)}">${event.outcome ?? '-'}</td>
+                <td class="px-2 py-1.5 text-left font-mono text-[var(--color-fg-muted)]">${event.model_used ?? '-'}</td>
+                <td class="px-2 py-1.5 text-right font-mono text-[var(--color-fg-muted)]">
+                  ${event.latency_ms == null ? '-' : `${Math.round(event.latency_ms)}ms`}
+                </td>
+                <td class="px-2 py-1.5 text-right font-mono text-[var(--color-fg-muted)]">
+                  ${event.cost_usd == null ? '-' : `$${event.cost_usd.toFixed(4)}`}
+                </td>
+                <td class="px-2 py-1.5 text-left font-mono text-[var(--color-fg-muted)]">${event.tool ?? '-'}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  `
+}
+
+function loadDecisions(limit: number): Promise<void> {
+  return decisions.load(() => fetchKeeperDecisions(limit))
+}
+
+export function KeeperDecisionsStream({ limit = 200 }: { limit?: number }) {
+  useEffect(() => {
+    void loadDecisions(limit)
+  }, [limit])
+
+  return html`
+    <${Card} title="Keeper Decisions" class="section">
+      <div class="mb-3 flex justify-end">
+        <button
+          type="button"
+          class="rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2.5 py-1.5 font-mono text-3xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
+          onClick=${() => { void loadDecisions(limit) }}
+        >
+          refresh
+        </button>
+      </div>
+      <${AsyncContainer}
+        state=${decisions.state}
+        loadingMessage="Loading keeper decisions..."
+        emptyWhen=${(data: KeeperDecisionsResponse) => data.events.length === 0}
+        emptyMessage="No keeper decision events are available yet."
+        render=${(data: KeeperDecisionsResponse) => html`
+          <${KeeperDecisionsTable} events=${data.events} limit=${data.limit || limit} />
+        `}
+      />
+    <//>
+  `
+}


### PR DESCRIPTION
## Summary
- add a KeeperDecisionsStream component backed by /api/v1/dashboard/keeper-decisions
- render the live decisions stream in Monitoring > Cognition > Decisions instead of the backend-blocked placeholder
- mark the cockpit decisions-stream entry as covered and add focused tests

## Validation
- ./node_modules/.bin/vitest run --config vitest.config.ts src/components/keeper-decisions-stream.test.ts src/components/cognition-plane.test.ts src/cockpit-entrypoints.test.ts --no-file-parallelism --maxWorkers=1
- ./node_modules/.bin/tsc --noEmit --pretty
- ./node_modules/.bin/eslint --config eslint.config.mjs src/components/keeper-decisions-stream.ts src/components/keeper-decisions-stream.test.ts src/components/cognition-plane.ts src/components/cognition-plane.test.ts src/cockpit-entrypoints.ts (0 errors; repo config ignored 3 out-of-scope files)
- git diff --check