### PR TITLE
[codex] Tolerate legacy cascade timeout_sec

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -26,6 +26,15 @@
   "big_three_temperature": 0.2,
   "big_three_max_tokens": 16384,
   "big_three_keeper_assignable": true,
+  "big_three_fallback_cascade": "keeper_diverse",
+  "_comment_keeper_diverse": "Fallback cascade for contract violation retry. Different model composition from big_three to break correlated failure.",
+  "keeper_diverse_models": [
+    "claude_code:claude-sonnet-4-6", "gemini_cli:gemini-2.5-flash",
+    "codex_cli:gpt-5.3-codex-spark"
+  ],
+  "keeper_diverse_temperature": 0.3,
+  "keeper_diverse_max_tokens": 16384,
+  "keeper_diverse_keeper_assignable": true,
   "_comment_tool_rerank": "System-only short-output profile for rerank/scoring calls.",
   "tool_rerank_models": [
     "codex_cli:gpt-5.3-codex-spark", "gemini_cli:auto",

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -286,6 +286,13 @@ let profile_field_json ~profile_name ~field_name field_value =
       match int_value ~path:profile_path field_value with
       | Ok value -> Ok [ (profile_name ^ "_" ^ field_name, `Int value) ]
       | Error _ as err -> err)
+  | "timeout_sec" -> (
+      (* Legacy cascade.toml field from pre-route runtime configs. Timeout
+         behavior is controlled by runtime/env timeout knobs now; accept the
+         old field so one stale profile cannot block the whole catalog. *)
+      match float_value ~path:profile_path field_value with
+      | Ok _ -> Ok []
+      | Error _ as err -> err)
   | "strategy" -> (
       match trimmed_nonempty_string ~path:profile_path field_value with
       | Ok value -> Ok [ (profile_name ^ "_strategy", `String value) ]
@@ -325,7 +332,7 @@ let profile_field_json ~profile_name ~field_name field_value =
       | Error _ as err -> err)
   | other ->
       errorf
-        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, keeper_assignable, fallback_cascade, api_key_env, keep_alive, num_ctx"
+        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, keeper_assignable, fallback_cascade, api_key_env, keep_alive, num_ctx, timeout_sec"
         other profile_name
 
 let profile_table_json_fields ~profile_name value =

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -383,6 +383,23 @@ unknown_field = 1
       check bool "error mentions unknown field" true
         (contains_substring msg "unknown field")
 
+let test_legacy_timeout_sec_field_is_ignored () =
+  match
+    Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+      {|
+[big_three]
+models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
+timeout_sec = 60
+|}
+  with
+  | Error msg -> failf "legacy timeout_sec should be accepted: %s" msg
+  | Ok rendered ->
+      let json = Yojson.Safe.from_string rendered in
+      check bool "profile still renders models" true
+        (json |> member "big_three_models" <> `Null);
+      check bool "legacy timeout_sec is not materialized" true
+        (json |> member "big_three_timeout_sec" = `Null)
+
 let test_runtime_materializes_missing_json_on_load () =
   with_temp_dir "cascade-toml-materialize" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
@@ -581,6 +598,8 @@ let () =
         [
           test_case "unknown profile field is rejected" `Quick
             test_unknown_profile_field_is_rejected;
+          test_case "legacy timeout_sec field is ignored" `Quick
+            test_legacy_timeout_sec_field_is_ignored;
           test_case "fallback_cascade field is parsed" `Quick
             test_fallback_cascade_field_is_parsed;
           test_case "fallback_cascade absent is backward compatible" `Quick


### PR DESCRIPTION
## Summary

- Accept and ignore legacy `timeout_sec` fields in cascade TOML profiles.
- Keep strict rejection for unknown profile fields that are not explicitly supported.
- Sync committed `config/cascade.json` with the current `config/cascade.toml` fallback profile.

## Root Cause

The live runtime had a stale `timeout_sec` field in `/Users/dancer/me/.masc/config/cascade.toml`. The materializer treated that legacy key as fatal, so one old profile field blocked the whole cascade catalog. Keeper preflight then failed for valid `big_three` and `glm_coding_plan_only` profiles because the active catalog could not be loaded.

## Operator Impact

This makes cascade config loading tolerant of that historical field while preserving strict validation for real schema drift. A stale `timeout_sec` no longer prevents keepers from booting or routing through their configured cascades.

## Validation

- `scripts/dune-local.sh build test/test_cascade_toml_materialization.exe`
- `env MASC_CASCADE_TOML_PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cascade-toml-legacy-timeout-0501/config/cascade.toml MASC_CASCADE_JSON_PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cascade-toml-legacy-timeout-0501/config/cascade.json _build/default/test/test_cascade_toml_materialization.exe`
- Live runtime after config repair: `/health` reports `startup.last_error:null`; `/api/v1/cascade/config` reports `validation_status:"validated"` and `invalid_profiles:[]`.
