### PR TITLE
Sync dashboard design-system cockpit kit

### DIFF
--- a/dashboard/design-system/source_styles/center.css
+++ b/dashboard/design-system/source_styles/center.css
@@ -2,20 +2,20 @@
 .wf { position: relative; padding: var(--sp-3); min-height: 100%; }
 .wf-scale {
   display: flex; justify-content: space-between;
-  font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted);
-  padding: 0 2px 4px; border-bottom: 1px solid var(--color-border-default); margin-bottom: 6px;
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-3);
+  padding: 0 2px 4px; border-bottom: 1px solid var(--line-1); margin-bottom: 6px;
 }
 .wf-track {
   display: grid; grid-template-columns: 100px minmax(0, 1fr); gap: var(--sp-2);
   padding: 3px 0; align-items: center; min-height: 20px;
 }
-.wf-track:hover { background: var(--color-bg-panel-alt); }
+.wf-track:hover { background: var(--bg-2); }
 .wf-track .track-label {
-  font-size: var(--fs-11); color: var(--color-fg-secondary); font-family: var(--font-mono);
+  font-size: var(--fs-11); color: var(--fg-2); font-family: var(--font-mono);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .wf-track .track-bars {
-  position: relative; height: 14px; background: var(--color-bg-panel-alt); border-radius: 2px;
+  position: relative; height: 14px; background: var(--bg-2); border-radius: 2px;
   min-width: 0;
 }
 .wf-bar {
@@ -26,16 +26,16 @@
 .wf-bar.s-tool { background: var(--brass-2); }
 .wf-bar.s-text { background: var(--info); opacity: .6; }
 .wf-bar.s-noop { background: var(--idle); opacity: .4; }
-.wf-bar:hover { outline: 1px solid var(--color-fg-primary); z-index: 2; }
+.wf-bar:hover { outline: 1px solid var(--fg-1); z-index: 2; }
 
 .wf-scale-ctrl { display: flex; gap: 2px; margin-left: auto; }
 .wf-scale-ctrl button {
-  background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-default);
-  color: var(--color-fg-muted); font: 10px/1 var(--font-mono);
+  background: var(--bg-2); border: 1px solid var(--line-1);
+  color: var(--fg-3); font: 10px/1 var(--font-mono);
   padding: 3px 7px; cursor: pointer; border-radius: 2px; letter-spacing: .03em;
 }
-.wf-scale-ctrl button:hover { color: var(--color-fg-primary); }
-.wf-scale-ctrl button.is-active { background: var(--color-bg-elevated); border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
+.wf-scale-ctrl button:hover { color: var(--fg-1); }
+.wf-scale-ctrl button.is-active { background: var(--bg-3); border-color: var(--brass-3); color: var(--brass-1); }
 .wf-scale-ctrl + .pane-meta { margin-left: var(--sp-3); }
 
 .feed-row {
@@ -46,18 +46,18 @@
   align-items: baseline; border-bottom: 1px solid transparent; min-width: 0;
   cursor: pointer;
 }
-.feed-row:hover { background: var(--color-bg-panel-alt); }
-.feed-row.is-active { background: var(--color-bg-elevated); border-bottom-color: var(--color-border-strong); }
-.feed-ts { color: var(--color-fg-muted); }
-.feed-kind { font-size: 10px; color: var(--color-fg-secondary); text-transform: uppercase; letter-spacing: .04em; }
-.feed-kind.k-tool { color: var(--color-accent-fg); }
+.feed-row:hover { background: var(--bg-2); }
+.feed-row.is-active { background: var(--bg-3); border-bottom-color: var(--line-2); }
+.feed-ts { color: var(--fg-3); }
+.feed-kind { font-size: 10px; color: var(--fg-2); text-transform: uppercase; letter-spacing: .04em; }
+.feed-kind.k-tool { color: var(--brass-1); }
 .feed-kind.k-error { color: var(--err); }
 .feed-kind.k-noop { color: var(--idle); }
 .feed-kind.k-text { color: var(--info); }
 .feed-kind.k-claim { color: var(--ok); }
-.feed-actor { color: var(--color-fg-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.feed-actor { color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .feed-body {
-  color: var(--color-fg-primary);
+  color: var(--fg-1);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font-family: var(--font-sans); font-size: var(--fs-12);
 }

--- a/dashboard/design-system/source_styles/code.css
+++ b/dashboard/design-system/source_styles/code.css
@@ -4,7 +4,7 @@
 /* —— mode switcher in topbar —— */
 .mode-switch {
   display: inline-flex; align-items: center; gap: 0;
-  border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
+  border: 1px solid var(--line-2); border-radius: var(--r-1);
   overflow: hidden; margin-left: var(--sp-3);
 }
 .mode-switch button {
@@ -12,12 +12,12 @@
   padding: 3px 10px; height: 22px;
   font-size: var(--fs-11); font-weight: 600;
   letter-spacing: .08em; text-transform: uppercase;
-  color: var(--color-fg-muted); cursor: pointer;
-  border-right: 1px solid var(--color-border-strong);
+  color: var(--fg-3); cursor: pointer;
+  border-right: 1px solid var(--line-2);
 }
 .mode-switch button:last-child { border-right: none; }
-.mode-switch button:hover { color: var(--color-fg-primary); background: var(--color-bg-panel-alt); }
-.mode-switch button.is-active { color: var(--color-accent-fg); background: var(--color-bg-elevated); }
+.mode-switch button:hover { color: var(--fg-1); background: var(--bg-2); }
+.mode-switch button.is-active { color: var(--brass-1); background: var(--bg-3); }
 
 /* —— mode visibility —— */
 body[data-mode="cockpit"] .zone-code { display: none; }
@@ -54,7 +54,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 
 .zone-code {
   grid-area: code;
-  background: var(--color-bg-page);
+  background: var(--bg-0);
   display: grid;
   grid-template-columns: 220px minmax(0, 1fr) 320px 260px;
   grid-template-rows: 32px minmax(0, 1fr);
@@ -69,70 +69,70 @@ body[data-mode="split"] .zone-deck { display: none; }
   grid-area: toolbar;
   display: flex; align-items: center; gap: var(--sp-3);
   padding: 0 var(--sp-3);
-  background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-default);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
   font-size: var(--fs-11);
   min-width: 0; overflow: hidden;
 }
 .code-repo-select, .code-wc-select {
   display: flex; align-items: center; gap: 4px;
-  padding: 3px 8px; border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
-  background: var(--color-bg-panel-alt); color: var(--color-fg-primary);
+  padding: 3px 8px; border: 1px solid var(--line-2); border-radius: var(--r-1);
+  background: var(--bg-2); color: var(--fg-1);
   font-family: var(--font-mono); font-size: 11px; cursor: pointer;
 }
-.code-repo-select:hover, .code-wc-select:hover { background: var(--color-bg-elevated); }
-.code-repo-select .arrow, .code-wc-select .arrow { color: var(--color-fg-disabled); font-size: 9px; margin-left: 2px; }
+.code-repo-select:hover, .code-wc-select:hover { background: var(--bg-3); }
+.code-repo-select .arrow, .code-wc-select .arrow { color: var(--fg-4); font-size: 9px; margin-left: 2px; }
 
 .wc-chips { display: flex; gap: 4px; flex-wrap: nowrap; overflow: hidden; }
 .wc-chip {
   display: inline-flex; align-items: center; gap: 5px;
   height: 22px; padding: 0 8px;
-  border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
-  background: var(--color-bg-panel-alt); color: var(--color-fg-secondary);
+  border: 1px solid var(--line-2); border-radius: var(--r-1);
+  background: var(--bg-2); color: var(--fg-2);
   font-family: var(--font-mono); font-size: 10px;
   cursor: pointer; flex-shrink: 0;
 }
-.wc-chip:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
-.wc-chip.is-active { background: var(--color-bg-hover); color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.wc-chip:hover { background: var(--bg-3); color: var(--fg-1); }
+.wc-chip.is-active { background: var(--bg-4); color: var(--brass-1); border-color: var(--brass-3); }
 .wc-chip .wc-close {
-  color: var(--color-fg-disabled); font-size: 9px; margin-left: 1px;
+  color: var(--fg-4); font-size: 9px; margin-left: 1px;
   width: 12px; text-align: center; border-radius: 2px;
 }
-.wc-chip .wc-close:hover { color: var(--err); background: var(--color-bg-surface); }
+.wc-chip .wc-close:hover { color: var(--err); background: var(--bg-1); }
 .wc-chip .dot { width: 5px; height: 5px; }
 
 .code-toolbar .code-search {
   flex: 1; min-width: 120px; max-width: 320px;
   height: 22px; padding: 0 8px;
-  background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
-  color: var(--color-fg-primary); font-size: 11px; font-family: var(--font-mono);
+  background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1);
+  color: var(--fg-1); font-size: 11px; font-family: var(--font-mono);
 }
-.code-toolbar .code-search::placeholder { color: var(--color-fg-disabled); }
+.code-toolbar .code-search::placeholder { color: var(--fg-4); }
 .code-toolbar .spacer { flex: 1; }
 
-.code-view-tabs { display: flex; gap: 0; border: 1px solid var(--color-border-strong); border-radius: var(--r-1); overflow: hidden; }
+.code-view-tabs { display: flex; gap: 0; border: 1px solid var(--line-2); border-radius: var(--r-1); overflow: hidden; }
 .code-view-tabs button {
-  background: transparent; border: none; border-right: 1px solid var(--color-border-strong);
+  background: transparent; border: none; border-right: 1px solid var(--line-2);
   padding: 0 10px; height: 22px; border-radius: 0;
   font-size: 10px; letter-spacing: .08em; text-transform: uppercase;
-  color: var(--color-fg-muted); cursor: pointer; font-weight: 600;
+  color: var(--fg-3); cursor: pointer; font-weight: 600;
 }
 .code-view-tabs button:last-child { border-right: none; }
-.code-view-tabs button:hover { background: var(--color-bg-panel-alt); color: var(--color-fg-primary); }
-.code-view-tabs button.is-active { background: var(--color-bg-elevated); color: var(--color-accent-fg); }
+.code-view-tabs button:hover { background: var(--bg-2); color: var(--fg-1); }
+.code-view-tabs button.is-active { background: var(--bg-3); color: var(--brass-1); }
 
 /* —— tree —— */
 .code-tree {
   grid-area: tree;
-  background: var(--color-bg-surface); border-right: 1px solid var(--color-border-default);
+  background: var(--bg-1); border-right: 1px solid var(--line-1);
   display: flex; flex-direction: column; min-height: 0; overflow: hidden;
 }
 .tree-head {
   padding: 6px 10px; display: flex; align-items: center; gap: 6px;
-  border-bottom: 1px solid var(--color-border-default); font-size: 10px;
+  border-bottom: 1px solid var(--line-1); font-size: 10px;
   text-transform: uppercase; letter-spacing: .08em;
-  color: var(--color-fg-muted); font-weight: 600;
+  color: var(--fg-3); font-weight: 600;
 }
-.tree-head .count { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); }
+.tree-head .count { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); }
 .tree-body {
   flex: 1; overflow-y: auto; padding: 4px 0;
   font-family: var(--font-mono); font-size: 11px;
@@ -140,39 +140,39 @@ body[data-mode="split"] .zone-deck { display: none; }
 .tree-item {
   display: flex; align-items: center; gap: 4px;
   padding: 2px 8px 2px 4px;
-  cursor: pointer; color: var(--color-fg-secondary);
+  cursor: pointer; color: var(--fg-2);
   position: relative;
 }
-.tree-item:hover { background: var(--color-bg-panel-alt); }
-.tree-item.is-active { background: var(--color-bg-elevated); color: var(--color-accent-fg); }
+.tree-item:hover { background: var(--bg-2); }
+.tree-item.is-active { background: var(--bg-3); color: var(--brass-1); }
 .tree-item.is-active::before {
   content: ""; position: absolute; left: 0; top: 0; bottom: 0;
-  width: 2px; background: var(--color-accent-fg);
+  width: 2px; background: var(--brass-1);
 }
 .tree-item .tw-indent { display: inline-block; width: 10px; flex-shrink: 0; }
-.tree-item .tw-chev { color: var(--color-fg-disabled); width: 10px; font-size: 9px; flex-shrink: 0; }
-.tree-item .tw-icon { color: var(--color-fg-disabled); width: 12px; text-align: center; flex-shrink: 0; }
+.tree-item .tw-chev { color: var(--fg-4); width: 10px; font-size: 9px; flex-shrink: 0; }
+.tree-item .tw-icon { color: var(--fg-4); width: 12px; text-align: center; flex-shrink: 0; }
 .tree-item .tw-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tree-item .tw-badges { display: flex; gap: 2px; flex-shrink: 0; }
 .tree-item .tw-keeper-dot {
   width: 6px; height: 6px; border-radius: 50%;
-  background: var(--color-accent-fg);
-  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
+  background: var(--brass-1);
+  box-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
 }
 .tree-item .tw-keeper-dot.is-multi { background: var(--stalled); }
 .tree-item .tw-count {
-  font-size: 9px; color: var(--color-fg-disabled); font-family: var(--font-mono);
-  padding: 0 4px; background: var(--color-bg-elevated); border-radius: 2px;
+  font-size: 9px; color: var(--fg-4); font-family: var(--font-mono);
+  padding: 0 4px; background: var(--bg-3); border-radius: 2px;
 }
 .tree-item .tw-diff-plus { color: var(--ok); font-size: 9px; }
 .tree-item .tw-diff-minus { color: var(--err); font-size: 9px; }
-.tree-dir { color: var(--color-fg-primary); font-weight: 500; }
+.tree-dir { color: var(--fg-1); font-weight: 500; }
 .tree-dir .tw-icon { color: var(--brass-2); }
 
 /* —— editor —— */
 .code-editor {
   grid-area: editor;
-  background: var(--color-bg-page);
+  background: var(--bg-0);
   display: flex; flex-direction: column;
   min-height: 0; min-width: 0; overflow: hidden;
   position: relative;
@@ -180,28 +180,28 @@ body[data-mode="split"] .zone-deck { display: none; }
 .editor-tabs {
   display: flex; align-items: stretch;
   height: 30px; flex-shrink: 0;
-  background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-default);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
   overflow-x: auto;
 }
 .editor-tab {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 0 12px; height: 30px;
   font-family: var(--font-mono); font-size: 11px;
-  color: var(--color-fg-muted); background: var(--color-bg-surface);
-  border-right: 1px solid var(--color-border-default);
+  color: var(--fg-3); background: var(--bg-1);
+  border-right: 1px solid var(--line-1);
   cursor: pointer; white-space: nowrap;
 }
-.editor-tab:hover { color: var(--color-fg-primary); background: var(--color-bg-panel-alt); }
+.editor-tab:hover { color: var(--fg-1); background: var(--bg-2); }
 .editor-tab.is-active {
-  color: var(--color-fg-primary); background: var(--color-bg-page);
-  box-shadow: inset 0 2px 0 var(--color-accent-fg);
+  color: var(--fg-1); background: var(--bg-0);
+  box-shadow: inset 0 2px 0 var(--brass-1);
 }
 .editor-tab .t-close {
-  color: var(--color-fg-disabled); font-size: 10px;
+  color: var(--fg-4); font-size: 10px;
   width: 14px; height: 14px; border-radius: 2px;
   display: flex; align-items: center; justify-content: center;
 }
-.editor-tab .t-close:hover { color: var(--err); background: var(--color-bg-elevated); }
+.editor-tab .t-close:hover { color: var(--err); background: var(--bg-3); }
 .editor-tab .t-dirty {
   width: 6px; height: 6px; border-radius: 50%; background: var(--warn);
 }
@@ -209,14 +209,14 @@ body[data-mode="split"] .zone-deck { display: none; }
   height: 22px; flex-shrink: 0;
   display: flex; align-items: center; gap: 4px;
   padding: 0 12px;
-  background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-default);
-  font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-3);
   overflow-x: auto; white-space: nowrap;
 }
 .bc-seg { cursor: pointer; }
-.bc-seg:hover { color: var(--color-accent-fg); }
-.bc-sep { color: var(--color-fg-disabled); }
-.bc-seg:last-child { color: var(--color-fg-primary); }
+.bc-seg:hover { color: var(--brass-1); }
+.bc-sep { color: var(--fg-4); }
+.bc-seg:last-child { color: var(--fg-1); }
 
 .editor-body {
   flex: 1; min-height: 0; min-width: 0;
@@ -228,9 +228,9 @@ body[data-mode="split"] .zone-deck { display: none; }
   overflow: auto; min-height: 0; min-width: 0;
   font-family: var(--font-mono); font-size: 12px; line-height: 18px;
   position: relative;
-  background: var(--color-bg-page);
+  background: var(--bg-0);
 }
-.editor-scroll.is-split { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--color-border-default); }
+.editor-scroll.is-split { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--line-1); }
 
 /* —— code line rows —— */
 .code-line {
@@ -241,19 +241,19 @@ body[data-mode="split"] .zone-deck { display: none; }
   position: relative;
 }
 .code-line:hover { background: rgb(255 255 255 / .015); }
-.code-line.is-selected { background: rgb(var(--color-accent-glow) / .06); }
-.code-line.is-anchor-hover { background: rgb(var(--color-accent-glow) / .05); }
-.code-line.is-heatmap-1 { background: rgb(var(--color-accent-glow) / .02); }
-.code-line.is-heatmap-2 { background: rgb(var(--color-accent-glow) / .05); }
-.code-line.is-heatmap-3 { background: rgb(var(--color-accent-glow) / .10); }
+.code-line.is-selected { background: rgb(var(--brass-glow) / .06); }
+.code-line.is-anchor-hover { background: rgb(var(--brass-glow) / .05); }
+.code-line.is-heatmap-1 { background: rgb(var(--brass-glow) / .02); }
+.code-line.is-heatmap-2 { background: rgb(var(--brass-glow) / .05); }
+.code-line.is-heatmap-3 { background: rgb(var(--brass-glow) / .10); }
 .code-line.is-diff-add { background: rgb(107 158 107 / .08); }
 .code-line.is-diff-del { background: rgb(196 106 90 / .08); }
 
 .cl-gutter {
   grid-area: gutter;
   display: flex; align-items: center; justify-content: center;
-  border-right: 1px solid var(--color-border-default);
-  color: var(--color-fg-disabled); font-size: 10px;
+  border-right: 1px solid var(--line-1);
+  color: var(--fg-4); font-size: 10px;
   position: relative;
 }
 .cl-gutter-icon {
@@ -261,16 +261,16 @@ body[data-mode="split"] .zone-deck { display: none; }
   display: inline-flex; align-items: center; justify-content: center;
   border-radius: 2px; cursor: pointer; font-size: 10px;
 }
-.cl-gutter-icon:hover { background: var(--color-bg-elevated); color: var(--color-accent-fg); }
+.cl-gutter-icon:hover { background: var(--bg-3); color: var(--brass-1); }
 .cl-gutter-icon.k-question { color: var(--info); }
 .cl-gutter-icon.k-flag     { color: var(--err); }
-.cl-gutter-icon.k-note     { color: var(--color-fg-secondary); }
+.cl-gutter-icon.k-note     { color: var(--fg-2); }
 .cl-gutter-icon.k-approve  { color: var(--ok); }
-.cl-gutter-icon.k-suggest  { color: var(--color-accent-fg); }
+.cl-gutter-icon.k-suggest  { color: var(--brass-1); }
 .cl-add-btn {
   opacity: 0; transition: opacity var(--t-fast);
   width: 14px; height: 14px; border-radius: 50%;
-  background: var(--brass-2); color: var(--color-bg-page);
+  background: var(--brass-2); color: var(--bg-0);
   display: inline-flex; align-items: center; justify-content: center;
   font-size: 10px; font-weight: bold; cursor: pointer; line-height: 1;
 }
@@ -289,7 +289,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .cl-cursor-dot {
   width: 5px; height: 5px; border-radius: 50%;
-  background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--color-accent-glow) / .7);
+  background: var(--brass-1); box-shadow: 0 0 5px rgb(var(--brass-glow) / .7);
 }
 .cl-cursor-dot.is-green { background: var(--ok); box-shadow: 0 0 5px rgb(107 158 107 / .7); }
 .cl-cursor-dot.is-blue  { background: var(--info); box-shadow: 0 0 5px rgb(106 142 176 / .7); }
@@ -305,21 +305,21 @@ body[data-mode="split"] .zone-deck { display: none; }
 .cl-lineno {
   grid-area: lineno;
   text-align: right; padding-right: 10px;
-  color: var(--color-fg-disabled); font-size: 11px;
-  border-right: 1px solid var(--color-border-default);
+  color: var(--fg-4); font-size: 11px;
+  border-right: 1px solid var(--line-1);
   user-select: none;
 }
-.code-line.is-anchor-hover .cl-lineno { color: var(--color-accent-fg); }
+.code-line.is-anchor-hover .cl-lineno { color: var(--brass-1); }
 
 .cl-blame {
   grid-area: blame;
   padding: 0 6px;
-  color: var(--color-fg-disabled); font-size: 10px;
-  border-right: 1px solid var(--color-border-default);
+  color: var(--fg-4); font-size: 10px;
+  border-right: 1px solid var(--line-1);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  background: var(--color-bg-surface);
+  background: var(--bg-1);
 }
-.cl-blame.is-keeper-nick { color: var(--color-accent-fg); }
+.cl-blame.is-keeper-nick { color: var(--brass-1); }
 .cl-blame.is-keeper-masc { color: var(--ok); }
 .cl-blame.is-keeper-sangsu { color: var(--info); }
 .cl-blame.is-keeper-qa { color: var(--err); }
@@ -329,7 +329,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   grid-area: code;
   padding: 0 12px;
   white-space: pre; overflow-x: auto;
-  color: var(--color-fg-primary);
+  color: var(--fg-1);
 }
 .cl-code::-webkit-scrollbar { height: 0; }
 
@@ -337,21 +337,21 @@ body[data-mode="split"] .zone-deck { display: none; }
 .anchor-bracket {
   position: absolute;
   left: 4px; width: 2px;
-  background: var(--color-accent-fg-dim);
+  background: var(--brass-3);
   border-radius: 1px;
   pointer-events: none;
   opacity: 0.35;
   transition: opacity var(--t-fast), top var(--t-med), height var(--t-med);
 }
-.anchor-bracket.is-active { opacity: 1; background: var(--color-accent-fg); width: 3px; }
+.anchor-bracket.is-active { opacity: 1; background: var(--brass-1); width: 3px; }
 .anchor-bracket.k-flag { background: var(--err); opacity: 0.6; }
 .anchor-bracket.k-approve { background: var(--ok); opacity: 0.5; }
 .anchor-bracket.is-drift {
   animation: drift-pulse 1.2s ease-out;
 }
 @keyframes drift-pulse {
-  0% { box-shadow: 0 0 0 0 rgb(var(--color-accent-glow) / .6); }
-  100% { box-shadow: 0 0 0 8px rgb(var(--color-accent-glow) / 0); }
+  0% { box-shadow: 0 0 0 0 rgb(var(--brass-glow) / .6); }
+  100% { box-shadow: 0 0 0 8px rgb(var(--brass-glow) / 0); }
 }
 .anchor-orphan-banner {
   position: sticky; top: 0; z-index: 2;
@@ -371,19 +371,19 @@ body[data-mode="split"] .zone-deck { display: none; }
 .tok-key    { color: #c195e8; }
 .tok-str    { color: #a8c97a; }
 .tok-num    { color: #d4a14a; }
-.tok-com    { color: var(--color-fg-disabled); font-style: italic; }
+.tok-com    { color: var(--fg-4); font-style: italic; }
 .tok-fn     { color: #e8c976; }
-.tok-var    { color: var(--color-fg-primary); }
+.tok-var    { color: var(--fg-1); }
 .tok-type   { color: #88b5d8; }
 .tok-prop   { color: #b8ad9a; }
-.tok-op     { color: var(--color-fg-muted); }
-.tok-punct  { color: var(--color-fg-muted); }
+.tok-op     { color: var(--fg-3); }
+.tok-punct  { color: var(--fg-3); }
 
 /* —— minimap —— */
 .editor-minimap {
   grid-column: 2;
-  background: var(--color-bg-surface);
-  border-left: 1px solid var(--color-border-default);
+  background: var(--bg-1);
+  border-left: 1px solid var(--line-1);
   overflow: hidden;
   position: relative;
   cursor: pointer;
@@ -394,54 +394,54 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .minimap-viewport {
   position: absolute; left: 0; right: 0;
-  background: rgb(var(--color-accent-glow) / .08);
-  border: 1px solid rgb(var(--color-accent-glow) / .3);
+  background: rgb(var(--brass-glow) / .08);
+  border: 1px solid rgb(var(--brass-glow) / .3);
   pointer-events: none;
 }
 
 /* —— review rail —— */
 .code-review {
   grid-area: review;
-  background: var(--color-bg-surface);
-  border-left: 1px solid var(--color-border-default);
+  background: var(--bg-1);
+  border-left: 1px solid var(--line-1);
   display: flex; flex-direction: column;
   min-height: 0; min-width: 0; overflow: hidden;
 }
 .review-head {
   padding: 6px 10px;
   display: flex; align-items: center; gap: 6px;
-  border-bottom: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--line-1);
   font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
-  color: var(--color-fg-muted); font-weight: 600;
+  color: var(--fg-3); font-weight: 600;
 }
-.review-head .count { margin-left: auto; color: var(--color-fg-disabled); font-family: var(--font-mono); }
+.review-head .count { margin-left: auto; color: var(--fg-4); font-family: var(--font-mono); }
 .review-filter {
   display: flex; gap: 0;
   padding: 4px 8px 6px;
-  border-bottom: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--line-1);
 }
 .review-filter button {
   flex: 1; padding: 2px 6px; font-size: 10px;
-  background: transparent; border: 1px solid var(--color-border-default);
+  background: transparent; border: 1px solid var(--line-1);
   border-right: none; border-radius: 0;
-  color: var(--color-fg-muted); text-transform: uppercase; letter-spacing: .06em;
+  color: var(--fg-3); text-transform: uppercase; letter-spacing: .06em;
 }
 .review-filter button:first-child { border-radius: 2px 0 0 2px; }
-.review-filter button:last-child  { border-right: 1px solid var(--color-border-default); border-radius: 0 2px 2px 0; }
-.review-filter button.is-active { color: var(--color-accent-fg); background: var(--color-bg-elevated); border-color: var(--color-accent-fg-dim); }
+.review-filter button:last-child  { border-right: 1px solid var(--line-1); border-radius: 0 2px 2px 0; }
+.review-filter button.is-active { color: var(--brass-1); background: var(--bg-3); border-color: var(--brass-3); }
 .review-list {
   flex: 1; overflow-y: auto;
 }
 .thread {
   padding: 8px 10px;
-  border-bottom: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--line-1);
   cursor: pointer;
   display: flex; flex-direction: column; gap: 4px;
 }
-.thread:hover { background: var(--color-bg-panel-alt); }
+.thread:hover { background: var(--bg-2); }
 .thread.is-active {
-  background: var(--color-bg-elevated);
-  box-shadow: inset 2px 0 0 var(--color-accent-fg);
+  background: var(--bg-3);
+  box-shadow: inset 2px 0 0 var(--brass-1);
 }
 .thread.is-resolved { opacity: 0.55; }
 .thread-head {
@@ -455,51 +455,51 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .thread-kind.k-question { background: rgb(106 142 176 / .15); color: var(--info); }
 .thread-kind.k-flag     { background: rgb(196 106 90 / .15); color: var(--err); }
-.thread-kind.k-note     { background: var(--color-bg-elevated); color: var(--color-fg-secondary); }
+.thread-kind.k-note     { background: var(--bg-3); color: var(--fg-2); }
 .thread-kind.k-approve  { background: rgb(107 158 107 / .15); color: var(--ok); }
-.thread-kind.k-suggest  { background: rgb(var(--color-accent-glow) / .12); color: var(--color-accent-fg); }
+.thread-kind.k-suggest  { background: rgb(var(--brass-glow) / .12); color: var(--brass-1); }
 .thread-anchor {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
 }
 .thread-author {
-  color: var(--color-fg-primary); font-size: 11px; font-weight: 500;
+  color: var(--fg-1); font-size: 11px; font-weight: 500;
 }
-.thread-ts { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
+.thread-ts { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
 .thread-body {
-  font-size: 12px; color: var(--color-fg-secondary); line-height: 1.4;
+  font-size: 12px; color: var(--fg-2); line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
 }
 .thread-meta {
-  display: flex; gap: 8px; font-size: 10px; color: var(--color-fg-disabled);
+  display: flex; gap: 8px; font-size: 10px; color: var(--fg-4);
   font-family: var(--font-mono);
 }
 .thread-reply-count::before { content: "↩ "; }
 .thread-drift-badge {
-  font-size: 9px; padding: 0 4px; background: var(--color-bg-elevated);
+  font-size: 9px; padding: 0 4px; background: var(--bg-3);
   color: var(--warn); border-radius: 2px; letter-spacing: .04em;
 }
 
 /* —— activity rail —— */
 .code-activity {
   grid-area: activity;
-  background: var(--color-bg-surface);
-  border-left: 1px solid var(--color-border-default);
+  background: var(--bg-1);
+  border-left: 1px solid var(--line-1);
   display: flex; flex-direction: column;
   min-height: 0; overflow: hidden;
 }
 .activity-head {
   padding: 6px 10px;
   display: flex; align-items: center; gap: 6px;
-  border-bottom: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--line-1);
   font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
-  color: var(--color-fg-muted); font-weight: 600;
+  color: var(--fg-3); font-weight: 600;
 }
 .activity-head .scope-pill {
   margin-left: auto;
   font-size: 9px; padding: 1px 5px;
-  background: rgb(var(--color-accent-glow) / .1);
-  color: var(--color-accent-fg); border-radius: 2px;
+  background: rgb(var(--brass-glow) / .1);
+  color: var(--brass-1); border-radius: 2px;
   letter-spacing: .06em;
 }
 .activity-list {
@@ -509,7 +509,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .activity-list::before {
   content: ""; position: absolute;
   left: 22px; top: 6px; bottom: 6px;
-  width: 1px; background: var(--color-border-default);
+  width: 1px; background: var(--line-1);
 }
 .act-row {
   display: grid;
@@ -519,32 +519,32 @@ body[data-mode="split"] .zone-deck { display: none; }
   font-size: 11px; cursor: pointer;
   position: relative;
 }
-.act-row:hover { background: var(--color-bg-panel-alt); }
-.act-row.is-now { background: rgb(var(--color-accent-glow) / .04); }
-.act-ts { color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: 10px; text-align: right; padding-top: 1px; }
+.act-row:hover { background: var(--bg-2); }
+.act-row.is-now { background: rgb(var(--brass-glow) / .04); }
+.act-ts { color: var(--fg-4); font-family: var(--font-mono); font-size: 10px; text-align: right; padding-top: 1px; }
 .act-dot {
   width: 8px; height: 8px; border-radius: 50%;
-  background: var(--color-fg-muted);
-  margin-top: 4px; border: 2px solid var(--color-bg-surface); z-index: 1;
+  background: var(--fg-3);
+  margin-top: 4px; border: 2px solid var(--bg-1); z-index: 1;
 }
-.act-dot.k-edit { background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.5); }
+.act-dot.k-edit { background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--brass-glow)/.5); }
 .act-dot.k-comment { background: var(--info); }
 .act-dot.k-flag { background: var(--err); }
 .act-dot.k-approve { background: var(--ok); }
 .act-dot.k-commit { background: var(--stalled); }
 .act-dot.k-refactor { background: var(--warn); }
 .act-body { min-width: 0; }
-.act-body .who { color: var(--color-fg-primary); font-weight: 500; }
-.act-body .what { color: var(--color-fg-secondary); }
-.act-body .where { font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); }
-.act-body .detail { font-size: 10px; color: var(--color-fg-disabled); margin-top: 2px; }
+.act-body .who { color: var(--fg-1); font-weight: 500; }
+.act-body .what { color: var(--fg-2); }
+.act-body .where { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); }
+.act-body .detail { font-size: 10px; color: var(--fg-4); margin-top: 2px; }
 
 /* —— floating add-comment popover —— */
 .comment-composer {
   position: absolute; z-index: 40;
   width: 320px;
-  background: var(--color-bg-panel-alt);
-  border: 1px solid var(--color-border-divider); border-radius: var(--r-2);
+  background: var(--bg-2);
+  border: 1px solid var(--line-3); border-radius: var(--r-2);
   box-shadow: var(--shadow-2);
   padding: 10px; font-size: 11px;
   display: none;
@@ -552,9 +552,9 @@ body[data-mode="split"] .zone-deck { display: none; }
 .comment-composer.is-open { display: block; }
 .comment-composer .cc-anchor {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--color-fg-muted); margin-bottom: 6px;
+  color: var(--fg-3); margin-bottom: 6px;
 }
-.comment-composer .cc-anchor .cc-anchor-sig { color: var(--color-accent-fg); }
+.comment-composer .cc-anchor .cc-anchor-sig { color: var(--brass-1); }
 .comment-composer .cc-kinds {
   display: flex; gap: 2px; margin-bottom: 6px;
 }
@@ -564,26 +564,26 @@ body[data-mode="split"] .zone-deck { display: none; }
   border-radius: 0; border-right: none;
 }
 .comment-composer .cc-kinds button:first-child { border-radius: 2px 0 0 2px; }
-.comment-composer .cc-kinds button:last-child { border-radius: 0 2px 2px 0; border-right: 1px solid var(--color-border-strong); }
+.comment-composer .cc-kinds button:last-child { border-radius: 0 2px 2px 0; border-right: 1px solid var(--line-2); }
 .comment-composer .cc-kinds button.is-active {
-  background: var(--color-bg-elevated); color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim);
+  background: var(--bg-3); color: var(--brass-1); border-color: var(--brass-3);
 }
 .comment-composer textarea {
   width: 100%; min-height: 72px;
-  background: var(--color-bg-page); border: 1px solid var(--color-border-default);
+  background: var(--bg-0); border: 1px solid var(--line-1);
   border-radius: var(--r-1); padding: 6px 8px;
-  color: var(--color-fg-primary); font-family: var(--font-sans); font-size: 12px;
+  color: var(--fg-1); font-family: var(--font-sans); font-size: 12px;
   resize: vertical; outline: none;
 }
-.comment-composer textarea:focus { border-color: var(--color-accent-fg-dim); }
+.comment-composer textarea:focus { border-color: var(--brass-3); }
 .comment-composer .cc-actions {
   display: flex; gap: 6px; margin-top: 8px; align-items: center;
 }
 .comment-composer .cc-actions .ping {
-  font-size: 10px; color: var(--color-fg-muted); margin-left: auto;
+  font-size: 10px; color: var(--fg-3); margin-left: auto;
   font-family: var(--font-mono);
 }
-.comment-composer .cc-actions .ping.is-ping { color: var(--color-accent-fg); }
+.comment-composer .cc-actions .ping.is-ping { color: var(--brass-1); }
 
 /* —— cross-keeper conflict badge (later) —— */
 .conflict-warn {
@@ -602,3 +602,241 @@ body[data-mode="split"] .zone-sidebar,
 body[data-mode="split"] .zone-rail {
   overflow: hidden;
 }
+
+/* ───────── command palette ───────── */
+.cmd-scrim {
+  position: fixed; inset: 0; z-index: 80;
+  background: rgb(8 7 5 / .55);
+  backdrop-filter: blur(2px);
+  display: none;
+  align-items: flex-start; justify-content: center;
+  padding-top: 14vh;
+}
+.cmd-scrim.is-open { display: flex; }
+.cmd-palette {
+  width: min(720px, 92vw);
+  background: var(--bg-1);
+  border: 1px solid var(--line-3);
+  border-radius: var(--r-2);
+  box-shadow: 0 12px 40px rgb(0 0 0 / .6);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  max-height: 64vh;
+}
+.cmd-input-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-1);
+  background: var(--bg-2);
+}
+.cmd-mode-pill {
+  font-family: var(--font-mono); font-size: 10px;
+  padding: 2px 6px; border-radius: 2px;
+  background: rgb(var(--brass-glow) / .12);
+  color: var(--brass-1);
+  letter-spacing: .08em; text-transform: uppercase;
+}
+.cmd-input {
+  flex: 1; background: transparent; border: none; outline: none;
+  color: var(--fg-1); font-family: var(--font-mono); font-size: 14px;
+  padding: 4px 0;
+}
+.cmd-input::placeholder { color: var(--fg-4); }
+.cmd-hint-keys {
+  display: flex; gap: 4px; align-items: center;
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
+}
+.cmd-hint-keys kbd {
+  display: inline-block; padding: 1px 5px;
+  border: 1px solid var(--line-2); border-radius: 2px;
+  background: var(--bg-3); color: var(--fg-2);
+  font-family: var(--font-mono); font-size: 9px;
+}
+.cmd-results {
+  flex: 1; overflow-y: auto;
+  padding: 4px 0;
+}
+.cmd-section-head {
+  font-size: 9px; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--fg-4); padding: 8px 14px 4px;
+  font-weight: 600;
+}
+.cmd-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 14px;
+  cursor: pointer; font-size: 12px;
+}
+.cmd-row:hover, .cmd-row.is-sel { background: var(--bg-3); }
+.cmd-row.is-sel { box-shadow: inset 2px 0 0 var(--brass-1); }
+.cmd-row .cmd-glyph {
+  width: 16px; height: 16px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--bg-3); border-radius: 2px;
+  color: var(--brass-1); font-size: 10px; flex-shrink: 0;
+}
+.cmd-row .cmd-label { flex: 1; color: var(--fg-1); font-family: var(--font-mono); }
+.cmd-row .cmd-meta {
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
+}
+.cmd-row .cmd-kind-tag {
+  font-size: 9px; padding: 1px 5px; border-radius: 2px;
+  letter-spacing: .06em; text-transform: uppercase;
+  background: var(--bg-2); color: var(--fg-3); font-family: var(--font-mono);
+}
+.cmd-row .cmd-kind-tag.k-file { background: rgb(var(--brass-glow) / .12); color: var(--brass-1); }
+.cmd-row .cmd-kind-tag.k-cmd  { background: rgb(106 142 176 / .12); color: var(--info); }
+.cmd-row .cmd-kind-tag.k-sym  { background: rgb(138 106 160 / .12); color: var(--stalled); }
+.cmd-row .cmd-kind-tag.k-thr  { background: rgb(196 106 90 / .12); color: var(--err); }
+.cmd-empty {
+  padding: 24px 14px; text-align: center;
+  color: var(--fg-4); font-size: 11px;
+}
+.cmd-empty kbd {
+  display: inline-block; padding: 1px 5px;
+  border: 1px solid var(--line-2); border-radius: 2px;
+  background: var(--bg-3); color: var(--fg-2);
+  font-family: var(--font-mono); font-size: 9px;
+  margin: 0 2px;
+}
+
+/* ───────── terminal panel ───────── */
+.zone-code {
+  /* upgrade grid to host an optional terminal row */
+  grid-template-rows: 32px minmax(0, 1fr) 0px;
+  grid-template-areas:
+    "toolbar toolbar toolbar toolbar"
+    "tree    editor  review  activity"
+    "term    term    term    term";
+  transition: grid-template-rows var(--t-med);
+}
+body.term-open .zone-code {
+  grid-template-rows: 32px minmax(0, 1fr) 200px;
+}
+.code-term {
+  grid-area: term;
+  background: var(--bg-0);
+  border-top: 1px solid var(--line-2);
+  display: flex; flex-direction: column;
+  min-height: 0; overflow: hidden;
+}
+body:not(.term-open) .code-term { display: none; }
+.term-tabs {
+  display: flex; align-items: stretch;
+  height: 26px; flex-shrink: 0;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-1);
+  padding-left: 4px;
+  position: relative;
+}
+.term-tab {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 0 12px; height: 26px;
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--fg-3); background: transparent;
+  border: none; border-right: 1px solid var(--line-1);
+  cursor: pointer; white-space: nowrap;
+  letter-spacing: .04em;
+}
+.term-tab:hover { color: var(--fg-1); background: var(--bg-2); }
+.term-tab.is-active {
+  color: var(--brass-1); background: var(--bg-0);
+  box-shadow: inset 0 2px 0 var(--brass-1);
+}
+.term-tab .t-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--ok);
+  box-shadow: 0 0 4px rgb(107 158 107 / .6);
+}
+.term-tab .t-dot.is-running { background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--brass-glow) / .7); animation: term-pulse 1.6s infinite; }
+.term-tab .t-dot.is-error   { background: var(--err); }
+.term-tab .t-dot.is-idle    { background: var(--fg-4); box-shadow: none; }
+@keyframes term-pulse {
+  0%,100% { opacity: 1; } 50% { opacity: 0.4; }
+}
+.term-tab .t-keeper {
+  font-size: 9px; color: var(--fg-4);
+  padding: 0 4px; border-left: 1px solid var(--line-2);
+  margin-left: 2px;
+}
+.term-tabs-spacer { flex: 1; }
+.term-actions {
+  display: flex; align-items: center; gap: 4px;
+  padding: 0 6px;
+}
+.term-action {
+  background: transparent; border: 1px solid var(--line-2); border-radius: 2px;
+  height: 18px; padding: 0 6px;
+  font-size: 9px; color: var(--fg-3);
+  letter-spacing: .06em; text-transform: uppercase; cursor: pointer;
+  font-family: var(--font-mono);
+}
+.term-action:hover { background: var(--bg-3); color: var(--fg-1); }
+.term-body {
+  flex: 1; overflow: auto; padding: 6px 10px;
+  font-family: var(--font-mono); font-size: 11px;
+  line-height: 1.55; color: var(--fg-2);
+  background: var(--bg-0);
+}
+.term-line { white-space: pre-wrap; }
+.term-line.is-prompt { color: var(--brass-1); }
+.term-line.is-cmd    { color: var(--fg-1); }
+.term-line.is-out    { color: var(--fg-2); }
+.term-line.is-err    { color: var(--err); }
+.term-line.is-warn   { color: var(--warn); }
+.term-line.is-ok     { color: var(--ok); }
+.term-line.is-meta   { color: var(--fg-4); font-style: italic; }
+.term-cursor {
+  display: inline-block; width: 7px; height: 12px;
+  background: var(--brass-1); vertical-align: -2px;
+  animation: term-cursor-blink 1s steps(1) infinite;
+}
+@keyframes term-cursor-blink { 50% { opacity: 0; } }
+
+.term-input-row {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 10px; flex-shrink: 0;
+  background: var(--bg-1);
+  border-top: 1px solid var(--line-1);
+  font-family: var(--font-mono); font-size: 11px;
+}
+.term-prompt-prefix {
+  color: var(--brass-1); flex-shrink: 0;
+}
+.term-input-prefix-keeper {
+  color: var(--fg-4); font-size: 10px;
+}
+.term-input {
+  flex: 1; background: transparent; border: none; outline: none;
+  color: var(--fg-1); font-family: var(--font-mono); font-size: 11px;
+  padding: 2px 0;
+}
+.term-watch-pill {
+  font-size: 9px; padding: 1px 5px; border-radius: 2px;
+  background: rgb(var(--brass-glow) / .1);
+  color: var(--brass-1);
+  letter-spacing: .06em; text-transform: uppercase;
+  font-family: var(--font-mono); flex-shrink: 0;
+}
+
+/* topbar terminal toggle button */
+.term-toggle {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 0 8px; height: 22px;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  border-radius: var(--r-1); margin-left: 4px;
+  color: var(--fg-3); font-family: var(--font-mono); font-size: 10px;
+  letter-spacing: .06em; text-transform: uppercase;
+  cursor: pointer;
+}
+.term-toggle:hover { background: var(--bg-3); color: var(--fg-1); }
+.term-toggle.is-active { color: var(--brass-1); border-color: var(--brass-3); background: var(--bg-3); }
+.term-toggle .t-glyph {
+  display: inline-block; width: 8px; height: 8px;
+  border: 1px solid currentColor; border-radius: 1px;
+  position: relative;
+}
+.term-toggle .t-glyph::before {
+  content: ">"; position: absolute; left: 1px; top: -3px;
+  font-size: 8px; line-height: 1;
+}
+body[data-mode="cockpit"] .term-toggle { display: none; }

--- a/dashboard/design-system/source_styles/deck.css
+++ b/dashboard/design-system/source_styles/deck.css
@@ -5,48 +5,48 @@
   height: 30px; flex-shrink: 0;
   display: flex; align-items: center; gap: var(--sp-3);
   padding: 0 var(--sp-3);
-  background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-default);
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-1);
 }
 .deck-tabs { display: flex; gap: 0; }
 .deck-tabs button {
   background: transparent; border: none;
-  border-right: 1px solid var(--color-border-default);
-  color: var(--color-fg-muted); font-size: var(--fs-11); font-weight: 600;
+  border-right: 1px solid var(--line-1);
+  color: var(--fg-3); font-size: var(--fs-11); font-weight: 600;
   letter-spacing: .08em; text-transform: uppercase;
   padding: 0 12px; height: 30px; cursor: pointer;
   display: flex; align-items: center; gap: 6px;
   border-radius: 0;
 }
-.deck-tabs button:hover { color: var(--color-fg-primary); background: var(--color-bg-panel-alt); }
+.deck-tabs button:hover { color: var(--fg-1); background: var(--bg-2); }
 .deck-tabs button.is-active {
-  color: var(--color-accent-fg);
-  background: var(--color-bg-page);
-  box-shadow: inset 0 2px 0 var(--color-accent-fg);
+  color: var(--brass-1);
+  background: var(--bg-0);
+  box-shadow: inset 0 2px 0 var(--brass-1);
 }
 .deck-tabs .deck-tab-count {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--color-fg-disabled); font-weight: 500;
-  padding: 1px 5px; background: var(--color-bg-elevated);
+  color: var(--fg-4); font-weight: 500;
+  padding: 1px 5px; background: var(--bg-3);
   border-radius: 2px; min-width: 18px; text-align: center;
 }
-.deck-tabs button.is-active .deck-tab-count { color: var(--color-fg-secondary); background: var(--color-bg-elevated); }
+.deck-tabs button.is-active .deck-tab-count { color: var(--fg-2); background: var(--bg-3); }
 .deck-head .deck-meta {
   margin-left: auto;
-  font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted);
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-3);
 }
 .deck-head .deck-collapse {
   width: 22px; height: 22px;
   display: flex; align-items: center; justify-content: center;
-  background: transparent; border: 1px solid var(--color-border-strong);
-  border-radius: var(--r-1); color: var(--color-fg-muted); font-size: 10px;
+  background: transparent; border: 1px solid var(--line-2);
+  border-radius: var(--r-1); color: var(--fg-3); font-size: 10px;
   cursor: pointer; padding: 0;
 }
-.deck-head .deck-collapse:hover { color: var(--color-fg-primary); background: var(--color-bg-elevated); }
+.deck-head .deck-collapse:hover { color: var(--fg-1); background: var(--bg-3); }
 
 .deck-body {
   flex: 1; min-height: 0; overflow: hidden;
-  position: relative; background: var(--color-bg-page);
+  position: relative; background: var(--bg-0);
 }
 .deck-view {
   position: absolute; inset: 0;
@@ -59,50 +59,50 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 1px; padding: 1px;
-  background: var(--color-border-default);
+  background: var(--line-1);
   min-height: 100%;
 }
 .board-col {
-  background: var(--color-bg-page);
+  background: var(--bg-0);
   display: flex; flex-direction: column;
   min-height: 180px;
 }
 .board-col-head {
   padding: 6px 10px;
   display: flex; align-items: center; gap: 6px;
-  background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-default);
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-1);
   font-size: 10px; text-transform: uppercase; letter-spacing: .1em;
-  color: var(--color-fg-muted); font-weight: 600;
+  color: var(--fg-3); font-weight: 600;
 }
-.board-col-head .count { margin-left: auto; color: var(--color-fg-disabled); font-family: var(--font-mono); }
+.board-col-head .count { margin-left: auto; color: var(--fg-4); font-family: var(--font-mono); }
 .board-thread {
-  padding: 8px 10px; border-bottom: 1px solid var(--color-border-default);
+  padding: 8px 10px; border-bottom: 1px solid var(--line-1);
   display: flex; flex-direction: column; gap: 4px;
   cursor: pointer;
 }
-.board-thread:hover { background: var(--color-bg-panel-alt); }
-.board-thread.is-active { background: var(--color-bg-elevated); box-shadow: inset 2px 0 0 var(--color-accent-fg); }
+.board-thread:hover { background: var(--bg-2); }
+.board-thread.is-active { background: var(--bg-3); box-shadow: inset 2px 0 0 var(--brass-1); }
 .board-thread .bt-head {
   display: flex; align-items: center; gap: 6px;
   font-size: 11px;
 }
-.board-thread .bt-from { color: var(--color-fg-primary); font-weight: 500; }
-.board-thread .bt-arrow { color: var(--color-fg-disabled); font-family: var(--font-mono); }
-.board-thread .bt-to { color: var(--color-fg-secondary); }
+.board-thread .bt-from { color: var(--fg-1); font-weight: 500; }
+.board-thread .bt-arrow { color: var(--fg-4); font-family: var(--font-mono); }
+.board-thread .bt-to { color: var(--fg-2); }
 .board-thread .bt-ts {
-  margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled);
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
 }
 .board-thread .bt-body {
-  font-size: 12px; color: var(--color-fg-secondary); line-height: 1.4;
+  font-size: 12px; color: var(--fg-2); line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
 }
 .board-thread .bt-meta {
-  display: flex; gap: 8px; font-size: 10px; color: var(--color-fg-disabled); font-family: var(--font-mono);
+  display: flex; gap: 8px; font-size: 10px; color: var(--fg-4); font-family: var(--font-mono);
 }
 .board-thread .bt-meta .tag {
-  padding: 0 4px; background: var(--color-bg-elevated);
-  border-radius: 2px; color: var(--color-fg-muted);
+  padding: 0 4px; background: var(--bg-3);
+  border-radius: 2px; color: var(--fg-3);
 }
 
 /* ——— shared table ——— */
@@ -112,30 +112,30 @@
 }
 .deck-table thead th {
   position: sticky; top: 0;
-  background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-strong);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-2);
   font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
-  color: var(--color-fg-muted); font-weight: 600;
+  color: var(--fg-3); font-weight: 600;
   text-align: left; padding: 6px 10px;
   z-index: 1;
 }
 .deck-table tbody td {
   padding: 6px 10px;
-  border-bottom: 1px solid var(--color-border-default);
-  color: var(--color-fg-secondary); vertical-align: middle;
+  border-bottom: 1px solid var(--line-1);
+  color: var(--fg-2); vertical-align: middle;
 }
 .deck-table tbody tr { cursor: pointer; }
-.deck-table tbody tr:hover { background: var(--color-bg-panel-alt); }
-.deck-table tbody tr.is-active { background: var(--color-bg-elevated); box-shadow: inset 2px 0 0 var(--color-accent-fg); }
-.deck-table .col-id { font-family: var(--font-mono); color: var(--color-fg-muted); font-size: 10px; width: 56px; }
-.deck-table .col-num { text-align: right; font-family: var(--font-mono); color: var(--color-fg-secondary); }
+.deck-table tbody tr:hover { background: var(--bg-2); }
+.deck-table tbody tr.is-active { background: var(--bg-3); box-shadow: inset 2px 0 0 var(--brass-1); }
+.deck-table .col-id { font-family: var(--font-mono); color: var(--fg-3); font-size: 10px; width: 56px; }
+.deck-table .col-num { text-align: right; font-family: var(--font-mono); color: var(--fg-2); }
 .deck-table .col-tag { width: 72px; }
 .deck-table .pill {
   display: inline-block; font-size: 10px;
-  padding: 1px 6px; border: 1px solid var(--color-border-strong);
-  border-radius: 2px; color: var(--color-fg-muted);
+  padding: 1px 6px; border: 1px solid var(--line-2);
+  border-radius: 2px; color: var(--fg-3);
   font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .06em;
 }
-.pill.active, .pill.running { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.pill.active, .pill.running { color: var(--brass-1); border-color: var(--brass-3); }
 .pill.blocked, .pill.err, .pill.error { color: var(--err); border-color: rgb(196 106 90 / .4); }
 .pill.done, .pill.ok, .pill.verified { color: var(--ok); border-color: rgb(107 158 107 / .4); }
 .pill.stalled { color: var(--stalled); border-color: rgb(138 106 160 / .4); }
@@ -144,7 +144,7 @@
 
 .deck-bar {
   display: inline-block; width: 80px; height: 4px;
-  background: var(--color-bg-elevated); border-radius: 2px; position: relative;
+  background: var(--bg-3); border-radius: 2px; position: relative;
   vertical-align: middle;
 }
 .deck-bar .fill {
@@ -160,7 +160,7 @@
   font-family: var(--font-mono); font-size: 11px;
   color: var(--info); text-decoration: none;
 }
-.pr-link:hover, .sb-link:hover { color: var(--color-accent-fg); }
+.pr-link:hover, .sb-link:hover { color: var(--brass-1); }
 .pr-state {
   display: inline-block; width: 8px; height: 8px; border-radius: 50%;
   margin-right: 5px; vertical-align: middle;
@@ -181,84 +181,84 @@
   grid-template-columns: 70px 1fr 120px 120px 160px;
   gap: 10px; align-items: center;
   padding: 6px 8px;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--line-1);
   border-radius: var(--r-1);
-  background: var(--color-bg-surface);
+  background: var(--bg-1);
   font-size: 12px;
 }
-.goal-node.depth-1 { margin-left: 24px; background: var(--color-bg-page); }
-.goal-node.depth-2 { margin-left: 48px; background: var(--color-bg-page); border-style: dashed; }
-.goal-node .g-id { font-family: var(--font-mono); color: var(--color-fg-muted); font-size: 11px; }
-.goal-node .g-title { color: var(--color-fg-primary); }
-.goal-node .g-meta { color: var(--color-fg-muted); font-family: var(--font-mono); font-size: 10px; }
+.goal-node.depth-1 { margin-left: 24px; background: var(--bg-0); }
+.goal-node.depth-2 { margin-left: 48px; background: var(--bg-0); border-style: dashed; }
+.goal-node .g-id { font-family: var(--font-mono); color: var(--fg-3); font-size: 11px; }
+.goal-node .g-title { color: var(--fg-1); }
+.goal-node .g-meta { color: var(--fg-3); font-family: var(--font-mono); font-size: 10px; }
 
 /* ——— VERIFIED list ——— */
 .verif-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 1px;
-  background: var(--color-border-default);
+  background: var(--line-1);
   padding: 1px;
 }
 .verif-card {
-  background: var(--color-bg-page);
+  background: var(--bg-0);
   padding: 10px 12px;
   display: flex; flex-direction: column; gap: 6px;
 }
 .verif-card.is-failing { box-shadow: inset 2px 0 0 var(--err); }
 .verif-card.is-passing { box-shadow: inset 2px 0 0 var(--ok); }
 .verif-head { display: flex; align-items: center; gap: 8px; }
-.verif-head .v-id { font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); }
-.verif-head .v-title { color: var(--color-fg-primary); font-size: 12px; font-weight: 500; flex: 1; }
+.verif-head .v-id { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); }
+.verif-head .v-title { color: var(--fg-1); font-size: 12px; font-weight: 500; flex: 1; }
 .verif-checks { display: flex; flex-direction: column; gap: 3px; font-size: 11px; }
-.verif-check { display: flex; gap: 8px; align-items: center; color: var(--color-fg-secondary); }
+.verif-check { display: flex; gap: 8px; align-items: center; color: var(--fg-2); }
 .verif-check .vc-mark {
   width: 12px; text-align: center; font-family: var(--font-mono);
   color: var(--ok);
 }
 .verif-check.is-fail .vc-mark { color: var(--err); }
 .verif-check.is-fail .vc-label { color: var(--err); }
-.verif-check.is-skip .vc-mark, .verif-check.is-skip .vc-label { color: var(--color-fg-disabled); }
+.verif-check.is-skip .vc-mark, .verif-check.is-skip .vc-label { color: var(--fg-4); }
 .verif-foot {
-  display: flex; gap: 10px; font-size: 10px; color: var(--color-fg-disabled);
+  display: flex; gap: 10px; font-size: 10px; color: var(--fg-4);
   font-family: var(--font-mono); margin-top: auto;
 }
 
 /* ——— PROVIDERS matrix ——— */
 .prov-wrap { padding: 0; }
 .prov-table td.col-tps {
-  color: var(--color-accent-fg); font-family: var(--font-mono);
+  color: var(--brass-1); font-family: var(--font-mono);
 }
 
 /* ——— SANDBOX grid ——— */
 .sandbox-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 1px; background: var(--color-border-default); padding: 1px;
+  gap: 1px; background: var(--line-1); padding: 1px;
 }
 .sandbox-card {
-  background: var(--color-bg-page);
+  background: var(--bg-0);
   padding: 10px 12px;
   display: flex; flex-direction: column; gap: 6px;
   font-size: 11px;
 }
-.sandbox-card.is-running { box-shadow: inset 2px 0 0 var(--color-accent-fg); }
+.sandbox-card.is-running { box-shadow: inset 2px 0 0 var(--brass-1); }
 .sandbox-card.is-stopped { box-shadow: inset 2px 0 0 var(--idle); }
 .sandbox-card.is-errored { box-shadow: inset 2px 0 0 var(--err); }
 .sandbox-card .sb-head {
   display: flex; align-items: center; gap: 6px;
 }
-.sandbox-card .sb-name { font-family: var(--font-mono); color: var(--color-fg-primary); font-size: 12px; }
+.sandbox-card .sb-name { font-family: var(--font-mono); color: var(--fg-1); font-size: 12px; }
 .sandbox-card .sb-type {
   margin-left: auto; font-family: var(--font-mono); font-size: 10px;
-  padding: 1px 5px; background: var(--color-bg-elevated); border-radius: 2px;
-  color: var(--color-fg-muted);
+  padding: 1px 5px; background: var(--bg-3); border-radius: 2px;
+  color: var(--fg-3);
 }
 .sandbox-card .sb-meta {
   display: grid; grid-template-columns: 60px 1fr; gap: 2px 10px;
-  color: var(--color-fg-muted); font-family: var(--font-mono); font-size: 10px;
+  color: var(--fg-3); font-family: var(--font-mono); font-size: 10px;
 }
-.sandbox-card .sb-meta b { color: var(--color-fg-secondary); font-weight: 400; }
+.sandbox-card .sb-meta b { color: var(--fg-2); font-weight: 400; }
 
 /* ——— CASCADE chain viz ——— */
 .cascade-wrap {
@@ -267,51 +267,51 @@
 }
 .cascade-chain {
   display: flex; align-items: stretch; gap: 0;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--line-1);
   border-radius: var(--r-1);
-  background: var(--color-bg-surface);
+  background: var(--bg-1);
   overflow: hidden;
 }
 .cascade-step {
   flex: 1; padding: 10px 12px;
   display: flex; flex-direction: column; gap: 4px;
-  border-right: 1px solid var(--color-border-default);
+  border-right: 1px solid var(--line-1);
   position: relative;
   min-width: 0;
 }
 .cascade-step:last-child { border-right: none; }
 .cascade-step.is-skipped { opacity: 0.4; }
 .cascade-step.is-failed { background: rgb(196 106 90 / .06); }
-.cascade-step.is-hit { box-shadow: inset 0 -2px 0 var(--color-accent-fg); }
+.cascade-step.is-hit { box-shadow: inset 0 -2px 0 var(--brass-1); }
 .cascade-step .cs-num {
-  font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled);
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
 }
 .cascade-step .cs-model {
-  font-size: 12px; color: var(--color-fg-primary); font-weight: 500;
+  font-size: 12px; color: var(--fg-1); font-weight: 500;
 }
 .cascade-step .cs-prov {
-  font-size: 10px; color: var(--color-fg-muted); font-family: var(--font-mono);
+  font-size: 10px; color: var(--fg-3); font-family: var(--font-mono);
 }
 .cascade-step .cs-state {
   display: flex; align-items: center; gap: 5px; font-size: 10px; margin-top: 2px;
 }
 .cascade-step .cs-arrow {
   position: absolute; right: -7px; top: 50%; transform: translateY(-50%);
-  color: var(--color-border-divider); font-size: 10px; z-index: 1;
-  background: var(--color-bg-page); padding: 0 1px;
+  color: var(--line-3); font-size: 10px; z-index: 1;
+  background: var(--bg-0); padding: 0 1px;
 }
 .cascade-step:last-child .cs-arrow { display: none; }
 .cascade-row-head {
   display: flex; align-items: center; gap: 10px;
-  font-size: 11px; color: var(--color-fg-muted);
+  font-size: 11px; color: var(--fg-3);
 }
-.cascade-row-head .ck-name { color: var(--color-fg-primary); font-weight: 500; }
-.cascade-row-head .ck-stat { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); }
+.cascade-row-head .ck-name { color: var(--fg-1); font-weight: 500; }
+.cascade-row-head .ck-stat { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); }
 
 /* density helpers */
 .kv-row {
   display: grid; grid-template-columns: 80px 1fr; gap: 8px;
   font-size: 11px; padding: 2px 0;
 }
-.kv-row .k { color: var(--color-fg-muted); }
-.kv-row .v { color: var(--color-fg-primary); font-family: var(--font-mono); }
+.kv-row .k { color: var(--fg-3); }
+.kv-row .v { color: var(--fg-1); font-family: var(--font-mono); }

--- a/dashboard/design-system/source_styles/drawer.css
+++ b/dashboard/design-system/source_styles/drawer.css
@@ -5,8 +5,8 @@
   right: 0;
   bottom: var(--h-composer);
   width: 520px; max-width: 90vw;
-  background: var(--color-bg-surface);
-  border-left: 1px solid var(--color-border-strong);
+  background: var(--bg-1);
+  border-left: 1px solid var(--line-2);
   box-shadow: -8px 0 24px rgb(0 0 0 / .4);
   transform: translateX(100%);
   transition: transform var(--t-fast) var(--ease);
@@ -17,36 +17,36 @@
   height: 40px; flex-shrink: 0;
   padding: 0 var(--sp-4);
   display: flex; align-items: center; justify-content: space-between;
-  background: var(--color-bg-panel-alt); border-bottom: 1px solid var(--color-border-strong);
+  background: var(--bg-2); border-bottom: 1px solid var(--line-2);
 }
 .drawer-close {
   background: transparent;
-  border: 1px solid var(--color-border-strong);
-  color: var(--color-fg-secondary);
+  border: 1px solid var(--line-2);
+  color: var(--fg-2);
   width: 24px; height: 24px;
   border-radius: var(--r-1); cursor: pointer;
   font-size: 12px; line-height: 1;
 }
-.drawer-close:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
+.drawer-close:hover { background: var(--bg-3); color: var(--fg-1); }
 .drawer-tabs {
   display: flex; gap: 0;
-  background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-strong);
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-2);
   padding: 0 var(--sp-3); flex-shrink: 0;
 }
 .drawer-tab {
   background: transparent; border: none;
   border-bottom: 2px solid transparent;
-  padding: 8px 12px; color: var(--color-fg-muted);
+  padding: 8px 12px; color: var(--fg-3);
   font-size: var(--fs-11); font-weight: 600;
   letter-spacing: .06em; text-transform: uppercase;
   cursor: pointer; border-radius: 0; position: relative;
 }
-.drawer-tab:hover { color: var(--color-fg-primary); background: transparent; }
-.drawer-tab.is-active { color: var(--color-accent-fg); border-bottom-color: var(--color-accent-fg); background: transparent; }
+.drawer-tab:hover { color: var(--fg-1); background: transparent; }
+.drawer-tab.is-active { color: var(--brass-1); border-bottom-color: var(--brass-1); background: transparent; }
 .drawer-tab.has-data::after {
   content: ""; position: absolute; top: 6px; right: 4px;
-  width: 4px; height: 4px; background: var(--color-accent-fg); border-radius: 50%;
+  width: 4px; height: 4px; background: var(--brass-1); border-radius: 50%;
 }
 .drawer-body {
   flex: 1; min-height: 0; overflow: auto;
@@ -56,54 +56,54 @@
 .chip-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 4px 0; }
 .chip {
   font-family: var(--font-mono); font-size: 10px;
-  padding: 2px 6px; background: var(--color-bg-panel-alt);
-  border: 1px solid var(--color-border-default); border-radius: var(--r-1);
-  color: var(--color-fg-secondary); letter-spacing: .02em;
+  padding: 2px 6px; background: var(--bg-2);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
+  color: var(--fg-2); letter-spacing: .02em;
 }
 .chip-err { background: rgb(196 106 90 / .1); border-color: rgb(196 106 90 / .3); color: var(--err); }
-.chip.k-tool { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.chip.k-tool { color: var(--brass-1); border-color: var(--brass-3); }
 .chip.k-claim { color: var(--ok); border-color: rgb(107 158 107 / .4); }
 .chip.k-text { color: var(--info); border-color: rgb(106 142 176 / .4); }
-.chip.k-noop { color: var(--color-fg-muted); }
+.chip.k-noop { color: var(--fg-3); }
 .chip.k-error { color: var(--err); border-color: rgb(196 106 90 / .4); }
 
 .pre {
   font-family: var(--font-mono); font-size: 10.5px; line-height: 1.45;
-  color: var(--color-fg-primary); background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default); border-radius: var(--r-1);
+  color: var(--fg-1); background: var(--bg-0);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
   padding: 8px 10px; overflow: auto; max-height: 280px;
   white-space: pre-wrap; word-break: break-word; margin: 4px 0 8px;
 }
 .pre.is-raw { max-height: 360px; }
 
 .tool-block {
-  border: 1px solid var(--color-border-default);
+  border: 1px solid var(--line-1);
   border-radius: var(--r-1);
   margin-bottom: 10px;
-  background: var(--color-bg-panel-alt); overflow: hidden;
+  background: var(--bg-2); overflow: hidden;
 }
 .tool-name {
   display: flex; align-items: center; gap: 8px;
-  padding: 6px 10px; background: var(--color-bg-elevated);
-  border-bottom: 1px solid var(--color-border-default); font-size: var(--fs-12);
+  padding: 6px 10px; background: var(--bg-3);
+  border-bottom: 1px solid var(--line-1); font-size: var(--fs-12);
 }
-.json-section { border-bottom: 1px solid var(--color-border-default); }
+.json-section { border-bottom: 1px solid var(--line-1); }
 .json-section:last-child { border-bottom: none; }
 .json-head {
   display: flex; align-items: center; gap: 6px;
   padding: 5px 10px; cursor: pointer; user-select: none;
   font-size: var(--fs-11);
 }
-.json-head:hover { background: var(--color-bg-elevated); }
-.json-head .chev { color: var(--color-fg-muted); font-size: 9px; transition: transform var(--t-fast); }
+.json-head:hover { background: var(--bg-3); }
+.json-head .chev { color: var(--fg-3); font-size: 9px; transition: transform var(--t-fast); }
 .json-section.is-collapsed .chev { transform: rotate(-90deg); }
 .json-section.is-collapsed .pre { display: none; }
 .json-section .pre { margin: 0 10px 8px; max-height: 240px; }
 
 .fsm-lifeline {
   display: flex; flex-wrap: wrap; gap: 2px;
-  padding: 6px; background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default); border-radius: var(--r-1);
+  padding: 6px; background: var(--bg-0);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
   margin-top: 4px; max-height: 120px; overflow-y: auto;
 }
 .fsm-lifeline .ll-cell { width: 8px; height: 14px; }
@@ -112,15 +112,15 @@
   display: flex; align-items: center; gap: 6px;
   padding: 4px 6px; border-radius: var(--r-1); font-size: var(--fs-11);
 }
-.fsm-trans:hover { background: var(--color-bg-panel-alt); }
-.fsm-trans.is-active { background: var(--color-bg-elevated); outline: 1px solid var(--color-accent-fg-dim); }
+.fsm-trans:hover { background: var(--bg-2); }
+.fsm-trans.is-active { background: var(--bg-3); outline: 1px solid var(--brass-3); }
 
 .bar {
   display: inline-block; flex: 1; height: 6px;
-  background: var(--color-bg-panel-alt); border-radius: 3px; overflow: hidden;
+  background: var(--bg-2); border-radius: 3px; overflow: hidden;
   vertical-align: middle; position: relative; min-width: 40px;
 }
-.bar-fill { display: block; height: 100%; background: var(--color-fg-muted); }
+.bar-fill { display: block; height: 100%; background: var(--fg-3); }
 .bar-fill.k-tool { background: var(--brass-2); }
 .bar-fill.k-claim { background: var(--ok); }
 .bar-fill.k-text { background: var(--info); }
@@ -131,30 +131,30 @@
 .dd-tag-row { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 10px; }
 .dd-section { margin-bottom: 14px; }
 .dd-section .label {
-  font-size: 10px; color: var(--color-fg-muted);
+  font-size: 10px; color: var(--fg-3);
   text-transform: uppercase; letter-spacing: .06em;
   margin-bottom: 4px; font-family: var(--font-mono);
 }
 .dd-text {
-  font-size: var(--fs-12); color: var(--color-fg-primary); line-height: 1.5;
+  font-size: var(--fs-12); color: var(--fg-1); line-height: 1.5;
   white-space: pre-wrap; word-break: break-word;
 }
-.dd-text.muted { color: var(--color-fg-secondary); }
+.dd-text.muted { color: var(--fg-2); }
 .dd-goal-stack { display: flex; flex-direction: column; gap: 4px; }
 .dd-goal-row {
   display: grid; grid-template-columns: 48px 1fr;
   gap: 8px; align-items: start;
   padding: 6px 8px; border-radius: var(--r-1);
-  background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-default);
+  background: var(--bg-2); border: 1px solid var(--line-1);
   font-size: var(--fs-12);
 }
-.dd-goal-row.is-active { border-color: var(--color-accent-fg-dim); background: var(--color-bg-elevated); }
+.dd-goal-row.is-active { border-color: var(--brass-3); background: var(--bg-3); }
 .dd-goal-tag {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--color-fg-muted); text-transform: uppercase;
+  color: var(--fg-3); text-transform: uppercase;
   letter-spacing: .05em;
 }
-.dd-goal-row.is-active .dd-goal-tag { color: var(--color-accent-fg); }
+.dd-goal-row.is-active .dd-goal-tag { color: var(--brass-1); }
 
 .chip.k-active   { color: var(--ok); border-color: rgb(107 158 107 / .4); }
 .chip.k-blocked  { color: var(--warn); border-color: rgb(194 157 94 / .4); }

--- a/dashboard/design-system/source_styles/kpi.css
+++ b/dashboard/design-system/source_styles/kpi.css
@@ -20,7 +20,7 @@
 .kpi-cell {
   position: relative;
   padding: calc(var(--sp-inline) + 2px) var(--sp-gutter);
-  border-right: 1px solid var(--color-border-default);
+  border-right: 1px solid var(--line-1);
   display: flex; flex-direction: column; justify-content: space-between;
   gap: var(--sp-inline);
   min-width: 0; overflow: hidden;
@@ -47,7 +47,7 @@
   font: var(--type-label);
   letter-spacing: var(--track-caps);
   text-transform: uppercase;
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   min-width: 0;
 }
@@ -62,7 +62,7 @@
   font: var(--type-kpi-l);
   font-weight: var(--fw-med);
   font-variant-numeric: tabular-nums;
-  color: var(--color-fg-primary);
+  color: var(--fg-1);
   letter-spacing: var(--track-tight);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
   transition: color var(--motion-swap);
@@ -70,7 +70,7 @@
 
 .kpi-unit {
   font: var(--type-caption);
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   text-transform: uppercase;
   letter-spacing: var(--track-wide);
 }
@@ -78,11 +78,11 @@
 .kpi-delta {
   font: var(--type-caption);
   font-variant-numeric: tabular-nums;
-  color: var(--color-fg-disabled);
+  color: var(--fg-4);
 }
 .kpi-delta.up   { color: var(--ok-fg); }
 .kpi-delta.down { color: var(--err-fg); }
-.kpi-delta.flat { color: var(--color-fg-disabled); }
+.kpi-delta.flat { color: var(--fg-4); }
 
 /* ── Spark (bottom-right corner) ── */
 .kpi-spark {
@@ -98,7 +98,7 @@
 /* SVG sparks (polyline/path) */
 .spark path, .spark polyline {
   fill: none;
-  stroke: var(--color-accent-fg);
+  stroke: var(--brass-1);
   stroke-width: 1;
   opacity: .7;
 }
@@ -130,7 +130,7 @@
 .kpi-cell.is-brass .kpi-value { color: var(--brass-fg); }
 .kpi-cell.is-brass {
   background: linear-gradient(0deg, var(--brass-soft), transparent 70%);
-  box-shadow: inset 2px 0 0 var(--color-accent-fg);
+  box-shadow: inset 2px 0 0 var(--brass-1);
 }
 
 /* ── "Now" pulse — active / live-updating cell ── */
@@ -142,7 +142,7 @@
 .kpi-cell.is-loading .kpi-value {
   color: transparent;
   background: linear-gradient(90deg,
-    var(--color-bg-panel-alt) 0%, var(--color-bg-elevated) 25%, var(--color-bg-panel-alt) 50%, var(--color-bg-elevated) 75%, var(--color-bg-panel-alt) 100%);
+    var(--bg-2) 0%, var(--bg-3) 25%, var(--bg-2) 50%, var(--bg-3) 75%, var(--bg-2) 100%);
   background-size: 200% 100%;
   animation: anim-shimmer 2s linear infinite;
   border-radius: var(--r-1);

--- a/dashboard/design-system/source_styles/layers.css
+++ b/dashboard/design-system/source_styles/layers.css
@@ -7,14 +7,14 @@
   display: flex; align-items: center; gap: var(--sp-2);
   padding: 0 var(--sp-3);
   height: 28px;
-  background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-default);
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-1);
   font-size: var(--fs-10);
   flex-shrink: 0;
   overflow-x: auto;
 }
 .layer-bar-label {
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   letter-spacing: .08em;
   text-transform: uppercase;
   font-weight: 600;
@@ -25,10 +25,10 @@
   display: inline-flex; align-items: center; gap: 5px;
   padding: 2px 8px;
   height: 20px;
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--line-2);
   border-radius: var(--r-1);
-  background: var(--color-bg-panel-alt);
-  color: var(--color-fg-muted);
+  background: var(--bg-2);
+  color: var(--fg-3);
   font-size: var(--fs-10);
   cursor: pointer;
   font-family: var(--font-mono);
@@ -36,10 +36,10 @@
   flex-shrink: 0;
   transition: all var(--t-fast) var(--ease);
 }
-.layer-toggle:hover { color: var(--color-fg-primary); background: var(--color-bg-elevated); }
+.layer-toggle:hover { color: var(--fg-1); background: var(--bg-3); }
 .layer-toggle .glyph {
   width: 10px; height: 10px; border-radius: 50%;
-  background: var(--color-fg-disabled);
+  background: var(--fg-4);
   transition: all var(--t-fast) var(--ease);
 }
 .layer-toggle.is-on .glyph { transform: scale(1.2); }
@@ -47,8 +47,8 @@
 .layer-toggle.is-on[data-layer="time"]     .glyph { background: var(--warn); box-shadow: 0 0 5px rgb(var(--warn-glow) / .6); }
 .layer-toggle.is-on[data-layer="parallel"] { color: var(--info);   border-color: rgb(var(--info-glow) / .4); background: rgb(var(--info-glow) / .06); }
 .layer-toggle.is-on[data-layer="parallel"] .glyph { background: var(--info); box-shadow: 0 0 5px rgb(var(--info-glow) / .6); }
-.layer-toggle.is-on[data-layer="tools"]    { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: rgb(var(--color-accent-glow) / .08); }
-.layer-toggle.is-on[data-layer="tools"]    .glyph { background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--color-accent-glow) / .6); }
+.layer-toggle.is-on[data-layer="tools"]    { color: var(--brass-1); border-color: var(--brass-3); background: rgb(var(--brass-glow) / .08); }
+.layer-toggle.is-on[data-layer="tools"]    .glyph { background: var(--brass-1); box-shadow: 0 0 5px rgb(var(--brass-glow) / .6); }
 .layer-toggle.is-on[data-layer="approve"]  { color: var(--ok);     border-color: rgb(var(--ok-glow) / .4); background: rgb(var(--ok-glow) / .06); }
 .layer-toggle.is-on[data-layer="approve"]  .glyph { background: var(--ok); box-shadow: 0 0 5px rgb(var(--ok-glow) / .6); }
 .layer-toggle.is-on[data-layer="notes"]    { color: var(--stalled); border-color: rgb(var(--stalled-glow) / .4); background: rgb(var(--stalled-glow) / .06); }
@@ -63,30 +63,30 @@
 .layer-opacity.is-show { display: inline-flex; }
 .layer-opacity label {
   font-size: var(--fs-9);
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   text-transform: uppercase;
   letter-spacing: .08em;
 }
 .layer-opacity input[type="range"] {
   width: 80px; height: 4px;
   -webkit-appearance: none; appearance: none;
-  background: var(--color-bg-elevated);
+  background: var(--bg-3);
   border-radius: 2px; outline: none;
 }
 .layer-opacity input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none; appearance: none;
   width: 10px; height: 10px; border-radius: 50%;
-  background: var(--color-accent-fg); cursor: pointer;
-  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
+  background: var(--brass-1); cursor: pointer;
+  box-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
 }
 
 .layer-explode {
   display: inline-flex; align-items: center; gap: 4px;
   height: 20px; padding: 0 8px;
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--line-2);
   border-radius: var(--r-1);
-  background: var(--color-bg-panel-alt);
-  color: var(--color-fg-secondary);
+  background: var(--bg-2);
+  color: var(--fg-2);
   font-size: var(--fs-10);
   letter-spacing: .08em;
   text-transform: uppercase;
@@ -94,11 +94,11 @@
   font-weight: 600;
   flex-shrink: 0;
 }
-.layer-explode:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
+.layer-explode:hover { background: var(--bg-3); color: var(--fg-1); }
 .layer-explode.is-on {
-  background: rgb(var(--color-accent-glow) / .12);
-  color: var(--color-accent-fg);
-  border-color: var(--color-accent-fg-dim);
+  background: rgb(var(--brass-glow) / .12);
+  color: var(--brass-1);
+  border-color: var(--brass-3);
 }
 
 /* ════════ DOT-MATRIX BACKGROUND ════════ */
@@ -106,10 +106,10 @@
   --dot-op: 0.12;
   --dot-size: 14px;
   background-image:
-    radial-gradient(circle at center, rgb(var(--color-accent-glow) / var(--dot-op)) 0.7px, transparent 1.2px);
+    radial-gradient(circle at center, rgb(var(--brass-glow) / var(--dot-op)) 0.7px, transparent 1.2px);
   background-size: var(--dot-size) var(--dot-size);
   background-position: 0 0;
-  background-color: var(--color-bg-page);
+  background-color: var(--bg-0);
 }
 
 /* ════════ LAYER STACK — z-axis arrangement ════════ */
@@ -147,7 +147,7 @@ body[data-explode="1"] .lyr-notes    { transform: translateZ(200px); }
 body[data-explode="1"] .lyr::before {
   content: "";
   position: absolute; inset: -4px;
-  border: 1px dashed rgb(var(--color-accent-glow) / .15);
+  border: 1px dashed rgb(var(--brass-glow) / .15);
   border-radius: 2px;
   pointer-events: none;
 }
@@ -168,14 +168,14 @@ body[data-explode="1"] .lyr::before {
 }
 .time-stripe.age-recent   { opacity: 1;   background: var(--warn);   box-shadow: 0 0 8px rgb(var(--warn-glow) / .6); }
 .time-stripe.age-near     { opacity: .7;  background: var(--warn); }
-.time-stripe.age-mid      { opacity: .4;  background: var(--color-fg-muted); }
-.time-stripe.age-far      { opacity: .2;  background: var(--color-fg-disabled); }
+.time-stripe.age-mid      { opacity: .4;  background: var(--fg-3); }
+.time-stripe.age-far      { opacity: .2;  background: var(--fg-4); }
 .time-stripe .time-label {
   position: absolute; left: 6px; top: 0;
   font-family: var(--font-mono); font-size: var(--fs-9);
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   white-space: nowrap; padding: 1px 4px;
-  background: var(--color-bg-surface); border-radius: 2px;
+  background: var(--bg-1); border-radius: 2px;
   opacity: 0; transition: opacity var(--t-fast);
 }
 .time-stripe:hover .time-label { opacity: 1; }
@@ -197,20 +197,20 @@ body[data-explode="1"] .lyr::before {
   0%, 100% { opacity: 0.35; }
   50%      { opacity: 0.75; }
 }
-.parallel-streak.k-nick    { stroke: var(--color-keeper-1); color: var(--color-keeper-1); }
-.parallel-streak.k-masc    { stroke: var(--color-keeper-2); color: var(--color-keeper-2); }
-.parallel-streak.k-sangsu  { stroke: var(--color-keeper-3); color: var(--color-keeper-3); }
-.parallel-streak.k-qa      { stroke: var(--color-keeper-4); color: var(--color-keeper-4); }
-.parallel-streak.k-rama    { stroke: var(--color-keeper-5); color: var(--color-keeper-5); }
+.parallel-streak.k-nick    { stroke: var(--k-nick); color: var(--k-nick); }
+.parallel-streak.k-masc    { stroke: var(--k-masc); color: var(--k-masc); }
+.parallel-streak.k-sangsu  { stroke: var(--k-sangsu); color: var(--k-sangsu); }
+.parallel-streak.k-qa      { stroke: var(--k-qa); color: var(--k-qa); }
+.parallel-streak.k-rama    { stroke: var(--k-rama); color: var(--k-rama); }
 .parallel-cursor-dot {
   r: 3;
   filter: drop-shadow(0 0 4px currentColor);
 }
-.parallel-cursor-dot.k-nick    { fill: var(--color-keeper-1); color: var(--color-keeper-1); }
-.parallel-cursor-dot.k-masc    { fill: var(--color-keeper-2); color: var(--color-keeper-2); }
-.parallel-cursor-dot.k-sangsu  { fill: var(--color-keeper-3); color: var(--color-keeper-3); }
-.parallel-cursor-dot.k-qa      { fill: var(--color-keeper-4); color: var(--color-keeper-4); }
-.parallel-cursor-dot.k-rama    { fill: var(--color-keeper-5); color: var(--color-keeper-5); }
+.parallel-cursor-dot.k-nick    { fill: var(--k-nick); color: var(--k-nick); }
+.parallel-cursor-dot.k-masc    { fill: var(--k-masc); color: var(--k-masc); }
+.parallel-cursor-dot.k-sangsu  { fill: var(--k-sangsu); color: var(--k-sangsu); }
+.parallel-cursor-dot.k-qa      { fill: var(--k-qa); color: var(--k-qa); }
+.parallel-cursor-dot.k-rama    { fill: var(--k-rama); color: var(--k-rama); }
 
 /* ════════ LYR: TOOLS ════════
    Per-block left margin icons with use-frequency bars. */
@@ -226,19 +226,19 @@ body[data-explode="1"] .lyr::before {
 }
 .tool-mark .tool-icon {
   font-size: 10px;
-  color: var(--color-accent-fg);
-  text-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
+  color: var(--brass-1);
+  text-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
   line-height: 1;
 }
 .tool-mark .tool-bar {
   width: 16px; height: 2px;
-  background: linear-gradient(90deg, var(--color-accent-fg), transparent);
+  background: linear-gradient(90deg, var(--brass-1), transparent);
   border-radius: 1px;
-  box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .4);
+  box-shadow: 0 0 3px rgb(var(--brass-glow) / .4);
 }
 .tool-mark .tool-count {
   font-size: var(--fs-9);
-  color: var(--color-fg-disabled);
+  color: var(--fg-4);
   font-family: var(--font-mono);
 }
 
@@ -300,7 +300,7 @@ body[data-explode="1"] .lyr::before {
   padding: 6px 8px 8px;
   box-shadow: 0 4px 16px rgb(0 0 0 / .5), 0 0 0 1px rgb(var(--stalled-glow) / .15), inset 0 1px 0 rgb(255 255 255 / .04);
   font-size: var(--fs-10);
-  color: var(--color-fg-secondary);
+  color: var(--fg-2);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   transition: top var(--t-slow) var(--ease-out), transform var(--t-fast) var(--ease);
@@ -327,18 +327,18 @@ body[data-explode="1"] .lyr::before {
   color: var(--stalled);
   letter-spacing: .06em; text-transform: uppercase;
 }
-.note-pin .np-head .np-author { color: var(--color-fg-muted); text-transform: none; letter-spacing: 0; }
-.note-pin .np-head .np-ts { margin-left: auto; color: var(--color-fg-disabled); }
-.note-pin .np-body { line-height: 1.4; color: var(--color-fg-primary); font-size: var(--fs-11); }
+.note-pin .np-head .np-author { color: var(--fg-3); text-transform: none; letter-spacing: 0; }
+.note-pin .np-head .np-ts { margin-left: auto; color: var(--fg-4); }
+.note-pin .np-body { line-height: 1.4; color: var(--fg-1); font-size: var(--fs-11); }
 .note-pin .np-actions {
   display: flex; gap: 4px; margin-top: 6px;
   font-size: var(--fs-9);
-  color: var(--color-fg-disabled);
+  color: var(--fg-4);
   font-family: var(--font-mono);
 }
 .note-pin .np-actions button {
   background: transparent; border: none; padding: 0;
-  color: var(--color-fg-muted); cursor: pointer; font-size: var(--fs-9);
+  color: var(--fg-3); cursor: pointer; font-size: var(--fs-9);
   letter-spacing: .06em; text-transform: uppercase;
 }
 .note-pin .np-actions button:hover { color: var(--stalled); }
@@ -366,7 +366,7 @@ body[data-explode="1"] .lyr::before {
 .note-append-btn:hover {
   background: rgb(var(--stalled-glow) / .12);
   border-style: solid;
-  color: var(--color-fg-primary);
+  color: var(--fg-1);
 }
 
 /* ════════ Depth-of-field when hovering a specific block ════════ */
@@ -376,7 +376,7 @@ body[data-explode="1"] .lyr::before {
 }
 .code-line.is-focused {
   filter: none;
-  background: rgb(var(--color-accent-glow) / .04);
+  background: rgb(var(--brass-glow) / .04);
 }
 
 /* ════════ Block recency aura (active when time layer on) ════════ */

--- a/dashboard/design-system/source_styles/layout.css
+++ b/dashboard/design-system/source_styles/layout.css
@@ -12,7 +12,7 @@
     "sidebar  center   rail"
     "deck     deck     deck"
     "composer composer composer";
-  background: var(--color-bg-page);
+  background: var(--bg-0);
   overflow: hidden;
 }
 
@@ -20,34 +20,34 @@
   grid-area: topbar;
   display: flex; align-items: center; gap: var(--sp-4);
   padding: 0 var(--sp-4);
-  background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-default);
-  font-size: var(--fs-12); color: var(--color-fg-secondary);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
+  font-size: var(--fs-12); color: var(--fg-2);
   min-width: 0; overflow: hidden;
 }
-.topbar-brand { font-weight: 600; color: var(--color-fg-primary); letter-spacing: .02em; flex-shrink: 0; }
+.topbar-brand { font-weight: 600; color: var(--fg-1); letter-spacing: .02em; flex-shrink: 0; }
 .topbar-brand .brand-dot {
   display: inline-block; width: 7px; height: 7px;
-  background: var(--color-accent-fg); border-radius: 50%; margin-right: 8px;
-  box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .5);
+  background: var(--brass-1); border-radius: 50%; margin-right: 8px;
+  box-shadow: 0 0 6px rgb(var(--brass-glow) / .5);
 }
-.topbar-sep { width: 1px; height: 14px; background: var(--color-border-strong); flex-shrink: 0; }
-.topbar-crumbs { display: flex; gap: var(--sp-2); color: var(--color-fg-muted); min-width: 0; overflow: hidden; }
-.topbar-crumbs b { color: var(--color-fg-primary); font-weight: 500; }
+.topbar-sep { width: 1px; height: 14px; background: var(--line-2); flex-shrink: 0; }
+.topbar-crumbs { display: flex; gap: var(--sp-2); color: var(--fg-3); min-width: 0; overflow: hidden; }
+.topbar-crumbs b { color: var(--fg-1); font-weight: 500; }
 .topbar-spacer { flex: 1; }
 .topbar-pills { display: flex; gap: var(--sp-2); flex-shrink: 0; }
 .topbar-pill {
   font-size: var(--fs-11); padding: 2px 8px;
-  border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
-  color: var(--color-fg-secondary); font-variant-numeric: tabular-nums;
+  border: 1px solid var(--line-2); border-radius: var(--r-1);
+  color: var(--fg-2); font-variant-numeric: tabular-nums;
 }
 .topbar-clock {
   font-family: var(--font-mono); font-size: var(--fs-12);
-  color: var(--color-fg-secondary); font-variant-numeric: tabular-nums; flex-shrink: 0;
+  color: var(--fg-2); font-variant-numeric: tabular-nums; flex-shrink: 0;
 }
 
 .zone-sidebar {
   grid-area: sidebar;
-  background: var(--color-bg-surface); border-right: 1px solid var(--color-border-default);
+  background: var(--bg-1); border-right: 1px solid var(--line-1);
   overflow: hidden; display: flex; flex-direction: column;
   min-width: 0; min-height: 0;
 }
@@ -62,52 +62,52 @@
 
 .zone-rail {
   grid-area: rail;
-  background: var(--color-bg-surface); border-left: 1px solid var(--color-border-default);
+  background: var(--bg-1); border-left: 1px solid var(--line-1);
   overflow-y: auto; display: flex; flex-direction: column;
   min-width: 0; min-height: 0;
 }
 
 .zone-composer {
   grid-area: composer;
-  background: var(--color-bg-surface); border-top: 1px solid var(--color-border-strong);
+  background: var(--bg-1); border-top: 1px solid var(--line-2);
   display: flex; align-items: center; gap: var(--sp-3);
   padding: 0 var(--sp-4);
 }
 .composer-input {
-  flex: 1; background: var(--color-bg-panel-alt);
-  border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
-  color: var(--color-fg-primary); font: var(--fs-13)/1 var(--font-sans);
+  flex: 1; background: var(--bg-2);
+  border: 1px solid var(--line-2); border-radius: var(--r-1);
+  color: var(--fg-1); font: var(--fs-13)/1 var(--font-sans);
   padding: 8px 12px; height: 32px; min-width: 0;
 }
-.composer-input::placeholder { color: var(--color-fg-disabled); }
-.composer-input:focus { border-color: var(--color-accent-fg-dim); outline: none; }
+.composer-input::placeholder { color: var(--fg-4); }
+.composer-input:focus { border-color: var(--brass-3); outline: none; }
 
-.pane { display: flex; flex-direction: column; min-height: 0; min-width: 0; border-bottom: 1px solid var(--color-border-default); }
+.pane { display: flex; flex-direction: column; min-height: 0; min-width: 0; border-bottom: 1px solid var(--line-1); }
 .pane:last-child { border-bottom: none; }
 .pane-head {
   height: 28px; flex-shrink: 0;
   padding: 0 var(--sp-3);
   display: flex; align-items: center; gap: var(--sp-3);
-  background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-default);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
   font-size: var(--fs-11);
 }
-.pane-head .label { color: var(--color-fg-secondary); }
+.pane-head .label { color: var(--fg-2); }
 .pane-head .pane-meta {
-  margin-left: auto; color: var(--color-fg-muted);
+  margin-left: auto; color: var(--fg-3);
   font-family: var(--font-mono); font-size: 10px;
 }
-.pane-body { flex: 1; min-height: 0; overflow: auto; background: var(--color-bg-page); }
+.pane-body { flex: 1; min-height: 0; overflow: auto; background: var(--bg-0); }
 
 .top-tabs { display: flex; gap: 2px; }
 .top-tabs button {
   background: transparent; border: none;
   border-bottom: 2px solid transparent;
-  color: var(--color-fg-muted); font-size: var(--fs-11); font-weight: 600;
+  color: var(--fg-3); font-size: var(--fs-11); font-weight: 600;
   letter-spacing: .06em; text-transform: uppercase;
   padding: 4px 10px; cursor: pointer; border-radius: 0;
 }
-.top-tabs button:hover { color: var(--color-fg-primary); background: transparent; }
-.top-tabs button.is-active { color: var(--color-accent-fg); border-bottom-color: var(--color-accent-fg); }
+.top-tabs button:hover { color: var(--fg-1); background: transparent; }
+.top-tabs button.is-active { color: var(--brass-1); border-bottom-color: var(--brass-1); }
 
 .pane-split {
   display: grid;
@@ -117,13 +117,13 @@
 .pane-col {
   display: flex; flex-direction: column;
   min-height: 0; min-width: 0;
-  border-right: 1px solid var(--color-border-default);
+  border-right: 1px solid var(--line-1);
 }
 .pane-col:last-child { border-right: none; }
 
 .empty, .loading {
   display: flex; align-items: center; justify-content: center;
-  height: 100%; color: var(--color-fg-muted); font-size: var(--fs-12); gap: var(--sp-2);
+  height: 100%; color: var(--fg-3); font-size: var(--fs-12); gap: var(--sp-2);
 }
 
 /* narrow viewports — drop the right rail so center gets real estate */
@@ -158,8 +158,8 @@
 
 .zone-deck {
   grid-area: deck;
-  background: var(--color-bg-surface);
-  border-top: 1px solid var(--color-border-divider);
+  background: var(--bg-1);
+  border-top: 1px solid var(--line-3);
   display: flex; flex-direction: column;
   min-height: 0; min-width: 0;
   overflow: hidden;

--- a/dashboard/design-system/source_styles/lifeline.css
+++ b/dashboard/design-system/source_styles/lifeline.css
@@ -4,7 +4,7 @@
 
 .zone-lifeline {
   grid-area: lifeline;
-  background: var(--color-bg-surface);
+  background: var(--bg-1);
   border-bottom: 1px solid var(--divider);
   display: grid;
   grid-template-columns: var(--w-sidebar) minmax(0, 1fr) auto;
@@ -25,10 +25,10 @@
   font-weight: 600;
   letter-spacing: .08em;
   text-transform: uppercase;
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
 }
 .ll-label .active-name {
-  color: var(--color-accent-fg);
+  color: var(--brass-1);
   font-family: var(--font-mono);
   font-size: var(--fs-12);
   letter-spacing: 0;
@@ -38,8 +38,8 @@
 .ll-label .ll-hb {
   width: 6px; height: 6px;
   border-radius: 50%;
-  background: var(--color-accent-fg);
-  box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .7);
+  background: var(--brass-1);
+  box-shadow: 0 0 6px rgb(var(--brass-glow) / .7);
   animation: anim-heartbeat 1.4s var(--ease-inout) infinite;
   margin-left: auto;
   flex-shrink: 0;
@@ -57,10 +57,10 @@
 .ll-turns {
   height: 10px;
   position: relative;
-  border-bottom: 1px dotted var(--color-border-default);
+  border-bottom: 1px dotted var(--line-1);
   font-family: var(--font-mono);
   font-size: var(--fs-9);
-  color: var(--color-fg-disabled);
+  color: var(--fg-4);
   letter-spacing: 0;
   overflow: hidden;
   flex-shrink: 0;
@@ -72,14 +72,14 @@
   line-height: 10px;
   white-space: nowrap;
   padding: 0 2px;
-  background: var(--color-bg-surface);
+  background: var(--bg-1);
 }
 .ll-turn-mark::before {
   content: "";
   position: absolute;
   left: 50%; top: 10px;
   width: 1px; height: 4px;
-  background: var(--color-border-strong);
+  background: var(--line-2);
 }
 
 /* cells row — the actual density bars */
@@ -104,16 +104,16 @@
   height: 100%;
   min-width: 2px;
   border-radius: 1px;
-  background: var(--color-bg-elevated);
+  background: var(--bg-3);
   cursor: pointer;
   position: relative;
   transition: transform var(--t-fast) var(--ease), filter var(--t-fast), outline-color var(--t-fast);
   outline: 1px solid transparent;
 }
-.ll-cell:hover { transform: scaleY(1.12); filter: brightness(1.3); outline-color: var(--color-fg-secondary); z-index: 2; }
+.ll-cell:hover { transform: scaleY(1.12); filter: brightness(1.3); outline-color: var(--fg-2); z-index: 2; }
 .ll-cell.is-active {
-  outline-color: var(--color-accent-fg);
-  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / .5);
+  outline-color: var(--brass-1);
+  box-shadow: 0 0 8px rgb(var(--brass-glow) / .5);
   z-index: 3;
 }
 .ll-cell.k-tool  { background: var(--brass-2); }
@@ -126,7 +126,7 @@
 .ll-turnsep {
   flex: 0 0 auto;
   width: 0;
-  border-left: 1px dashed var(--color-border-strong);
+  border-left: 1px dashed var(--line-2);
   opacity: .5;
   height: 100%;
   margin: 0 2px;
@@ -162,7 +162,7 @@
   border-radius: var(--r-1);
   padding: 4px 8px;
   font: var(--type-caption);
-  color: var(--color-fg-primary);
+  color: var(--fg-1);
   white-space: nowrap;
   opacity: 0;
   pointer-events: none;
@@ -170,9 +170,9 @@
   z-index: 10;
 }
 .ll-tip.is-open { opacity: 1; }
-.ll-tip-head { color: var(--color-accent-fg); font-weight: 600; }
-.ll-tip-row { color: var(--color-fg-muted); }
-.ll-tip-row b { color: var(--color-fg-secondary); font-weight: 400; }
+.ll-tip-head { color: var(--brass-1); font-weight: 600; }
+.ll-tip-row { color: var(--fg-3); }
+.ll-tip-row b { color: var(--fg-2); font-weight: 400; }
 
 /* heartbeat dot at the far right of cells */
 .ll-hb-tail {
@@ -181,8 +181,8 @@
   flex: 0 0 auto;
   width: 6px; height: 6px;
   border-radius: 50%;
-  background: var(--color-accent-fg);
-  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / .8);
+  background: var(--brass-1);
+  box-shadow: 0 0 8px rgb(var(--brass-glow) / .8);
   animation: anim-heartbeat 1.4s var(--ease-inout) infinite;
   align-self: center;
   margin-left: 4px;
@@ -199,27 +199,27 @@
   flex-shrink: 0;
   font-family: var(--font-mono);
   font-size: var(--fs-10);
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
 }
 .ll-tail-meta {
   display: flex; align-items: center; gap: 6px;
 }
 .ll-tail-meta b {
-  color: var(--color-fg-primary);
+  color: var(--fg-1);
   font-weight: 500;
 }
 .ll-zoom {
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--line-2);
   border-radius: var(--r-1);
-  background: var(--color-bg-panel-alt);
+  background: var(--bg-2);
   overflow: hidden;
 }
 .ll-zoom button {
   background: transparent;
   border: 0;
-  color: var(--color-fg-secondary);
+  color: var(--fg-2);
   padding: 2px 6px;
   font-family: var(--font-mono);
   font-size: var(--fs-10);
@@ -227,21 +227,21 @@
   min-width: 18px;
   border-radius: 0;
 }
-.ll-zoom button + button { border-left: 1px solid var(--color-border-default); }
-.ll-zoom button:hover { background: var(--state-hover-bg); color: var(--color-fg-primary); }
+.ll-zoom button + button { border-left: 1px solid var(--line-1); }
+.ll-zoom button:hover { background: var(--state-hover-bg); color: var(--fg-1); }
 .ll-zoom .ll-zoom-lvl {
   padding: 2px 8px;
-  color: var(--color-fg-secondary);
+  color: var(--fg-2);
   font-variant-numeric: tabular-nums;
-  border-left: 1px solid var(--color-border-default);
-  border-right: 1px solid var(--color-border-default);
-  background: var(--color-bg-surface);
+  border-left: 1px solid var(--line-1);
+  border-right: 1px solid var(--line-1);
+  background: var(--bg-1);
 }
 
 .ll-legend {
   display: flex; gap: var(--sp-3);
   font-size: var(--fs-10);
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   font-family: var(--font-mono);
 }
 .ll-legend .lg { display: flex; align-items: center; gap: 4px; }

--- a/dashboard/design-system/source_styles/primitives.css
+++ b/dashboard/design-system/source_styles/primitives.css
@@ -12,19 +12,19 @@
   font-family: var(--font-mono);
   font-size: var(--fs-10);
   line-height: 1;
-  color: var(--color-fg-secondary);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-default);
+  color: var(--fg-2);
+  background: var(--bg-3);
+  border: 1px solid var(--line-1);
   border-radius: var(--r-1);
   white-space: nowrap;
 }
-.chip.is-brass { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: rgb(var(--color-accent-glow) / .08); }
+.chip.is-brass { color: var(--brass-1); border-color: var(--brass-3); background: rgb(var(--brass-glow) / .08); }
 .chip.is-ok    { color: var(--ok);    border-color: rgb(var(--ok-glow) / .35); background: rgb(var(--ok-glow) / .08); }
 .chip.is-warn  { color: var(--warn);  border-color: rgb(var(--warn-glow) / .35); background: rgb(var(--warn-glow) / .08); }
 .chip.is-err   { color: var(--err);   border-color: rgb(var(--err-glow) / .35); background: rgb(var(--err-glow) / .08); }
 .chip.is-info  { color: var(--info);  border-color: rgb(var(--info-glow) / .35); background: rgb(var(--info-glow) / .08); }
 .chip.is-stalled { color: var(--stalled); border-color: rgb(var(--stalled-glow) / .35); background: rgb(var(--stalled-glow) / .08); }
-.chip.is-ghost { background: transparent; border-color: var(--color-border-strong); }
+.chip.is-ghost { background: transparent; border-color: var(--line-2); }
 
 /* chip size variants */
 .chip.sm { height: 14px; padding: 0 5px; font-size: var(--fs-9); }
@@ -41,13 +41,13 @@
   font-size: var(--fs-10);
   font-weight: 500;
   letter-spacing: .04em;
-  color: var(--color-fg-secondary);
-  background: var(--color-bg-elevated);
+  color: var(--fg-2);
+  background: var(--bg-3);
   border-radius: 999px;
   white-space: nowrap;
 }
-.pill.is-running { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow) / .12); }
-.pill.is-paused  { color: var(--color-fg-muted);    background: var(--color-bg-elevated); }
+.pill.is-running { color: var(--brass-1); background: rgb(var(--brass-glow) / .12); }
+.pill.is-paused  { color: var(--fg-3);    background: var(--bg-3); }
 .pill.is-ok      { color: var(--ok);      background: rgb(var(--ok-glow) / .12); }
 .pill.is-err     { color: var(--err);     background: rgb(var(--err-glow) / .12); }
 .pill.is-warn    { color: var(--warn);    background: rgb(var(--warn-glow) / .12); }
@@ -59,7 +59,7 @@
 .bar {
   display: inline-block;
   height: 4px; width: 100%;
-  background: var(--color-bg-elevated);
+  background: var(--bg-3);
   border-radius: 2px;
   overflow: hidden;
   vertical-align: middle;
@@ -76,7 +76,7 @@
 /* bar with segments (a/b/c split — e.g. passing/failing/skipped) */
 .bar-seg {
   display: flex; height: 4px; width: 100%;
-  background: var(--color-bg-elevated); border-radius: 2px; overflow: hidden;
+  background: var(--bg-3); border-radius: 2px; overflow: hidden;
 }
 .bar-seg > span { display: block; height: 100%; }
 .bar-seg .seg-ok { background: var(--ok); }
@@ -94,7 +94,7 @@
 .spark > i {
   display: block;
   width: 2px; min-height: 1px;
-  background: var(--color-fg-muted);
+  background: var(--fg-3);
   border-radius: 1px;
 }
 .spark.is-brass > i { background: var(--brass-2); }
@@ -102,23 +102,23 @@
 .spark.is-err > i { background: var(--err); }
 .spark.is-warn > i { background: var(--warn); }
 /* last bar brightens to signal "now" */
-.spark > i:last-child { background: var(--color-accent-fg); box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .5); }
+.spark > i:last-child { background: var(--brass-1); box-shadow: 0 0 3px rgb(var(--brass-glow) / .5); }
 
 /* ════════ SECTION HEAD ════════
    Panel header strip — small-caps label + optional right chip. */
 .section-head {
   display: flex; align-items: center; gap: var(--sp-2);
   min-height: 28px; padding: 0 var(--sp-3);
-  border-bottom: 1px solid var(--color-border-default);
-  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--line-1);
+  background: var(--bg-1);
   font-size: var(--fs-11);
   font-weight: 600;
   letter-spacing: .08em;
   text-transform: uppercase;
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   flex-shrink: 0;
 }
-.section-head > .count { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-weight: 500; }
+.section-head > .count { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); font-weight: 500; }
 .section-head > .tail  { margin-left: auto; display: flex; gap: 4px; align-items: center; }
 
 /* ════════ KV ROW ════════
@@ -132,12 +132,12 @@
   align-items: baseline;
 }
 .kv-row > .k {
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   font-size: var(--fs-10);
   text-transform: uppercase;
   letter-spacing: .06em;
 }
-.kv-row > .v { color: var(--color-fg-primary); font-family: var(--font-mono); font-size: var(--fs-11); }
+.kv-row > .v { color: var(--fg-1); font-family: var(--font-mono); font-size: var(--fs-11); }
 
 .kv-row.is-wide { grid-template-columns: 120px 1fr; }
 
@@ -145,11 +145,11 @@
    Base button lives in tokens.css. These are semantic variants. */
 .btn.primary {
   background: var(--brass-2);
-  color: var(--color-bg-page);
-  border-color: var(--color-accent-fg-dim);
+  color: var(--bg-0);
+  border-color: var(--brass-3);
   font-weight: 600;
 }
-.btn.primary:hover { background: var(--color-accent-fg); color: var(--color-bg-page); }
+.btn.primary:hover { background: var(--brass-1); color: var(--bg-0); }
 
 .btn.danger {
   border-color: rgb(var(--err-glow) / .4);
@@ -157,12 +157,11 @@
 }
 .btn.danger:hover { background: rgb(var(--err-glow) / .1); color: var(--err); }
 
-.btn.ghost { border-color: transparent; color: var(--color-fg-muted); }
-.btn.ghost:hover { background: var(--color-bg-panel-alt); color: var(--color-fg-primary); }
+.btn.ghost { border-color: transparent; color: var(--fg-3); }
+.btn.ghost:hover { background: var(--bg-2); color: var(--fg-1); }
 
 .btn.sm { height: 20px; padding: 0 8px; font-size: var(--fs-10); }
 .btn.xs { height: 18px; padding: 0 6px; font-size: var(--fs-9); letter-spacing: .06em; }
-.btn.lg { height: 28px; padding: 0 14px; font-size: var(--fs-12); }
 
 /* icon-only button — square */
 .btn.icon {
@@ -176,9 +175,9 @@
   display: inline-flex; align-items: center; justify-content: center;
   min-width: 16px; height: 16px; padding: 0 4px;
   font-family: var(--font-mono); font-size: var(--fs-10);
-  color: var(--color-fg-muted);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-strong);
+  color: var(--fg-3);
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
   border-bottom-width: 2px;
   border-radius: 3px;
 }
@@ -187,18 +186,18 @@
    Thin strip at top of cards indicating overall state. */
 .band {
   height: 2px; width: 100%;
-  background: var(--color-border-strong);
+  background: var(--line-2);
   border-radius: 1px 1px 0 0;
 }
-.band.is-running { background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .5); }
+.band.is-running { background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow) / .5); }
 .band.is-ok      { background: var(--ok); }
 .band.is-warn    { background: var(--warn); }
 .band.is-err     { background: var(--err); }
 .band.is-stalled { background: var(--stalled); }
 
 /* ════════ SEP ════════ */
-.sep-v { width: 1px; height: 16px; background: var(--color-border-strong); margin: 0 var(--sp-2); }
-.sep-h { height: 1px; background: var(--color-border-default); margin: var(--sp-2) 0; }
+.sep-v { width: 1px; height: 16px; background: var(--line-2); margin: 0 var(--sp-2); }
+.sep-h { height: 1px; background: var(--line-1); margin: var(--sp-2) 0; }
 
 /* ════════ TOKEN-CODE (inline mono highlight) ════════ */
 .tk {
@@ -206,10 +205,10 @@
   font-size: .92em;
   padding: 0 4px;
   border-radius: 2px;
-  background: var(--color-bg-elevated);
-  color: var(--color-fg-primary);
+  background: var(--bg-3);
+  color: var(--fg-1);
 }
-.tk.is-brass { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow) / .08); }
+.tk.is-brass { color: var(--brass-1); background: rgb(var(--brass-glow) / .08); }
 .tk.is-err   { color: var(--err);     background: rgb(var(--err-glow) / .08); }
 
 /* ════════ SCROLL PANEL ════════
@@ -220,22 +219,22 @@
 /* ════════ TYPE ROLE CLASSES ════════
    Prefer these over raw --fs-* sizes in new styles. Role names
    match tokens.css. Each applies font shorthand + sensible color. */
-.t-micro   { font: var(--type-micro);   color: var(--color-fg-disabled); letter-spacing: var(--track-caps); text-transform: uppercase; }
-.t-caption { font: var(--type-caption); color: var(--color-fg-muted); letter-spacing: var(--track-wide); }
-.t-label   { font: var(--type-label);   color: var(--color-fg-muted); letter-spacing: var(--track-caps); text-transform: uppercase; font-weight: var(--fw-semi); }
-.t-meta    { font: var(--type-meta);    color: var(--color-fg-muted); }
-.t-body    { font: var(--type-body);    color: var(--color-fg-primary); }
-.t-code    { font: var(--type-code);    color: var(--color-fg-primary); }
-.t-title   { font: var(--type-title);   color: var(--color-fg-primary); font-weight: var(--fw-semi); letter-spacing: var(--track-tight); }
-.t-kpi-m   { font: var(--type-kpi-m);   color: var(--color-fg-primary); font-variant-numeric: tabular-nums; font-weight: var(--fw-med); }
-.t-kpi-l   { font: var(--type-kpi-l);   color: var(--color-fg-primary); font-variant-numeric: tabular-nums; font-weight: var(--fw-med); letter-spacing: var(--track-tight); }
-.t-hero    { font: var(--type-hero);    color: var(--color-fg-primary); font-variant-numeric: tabular-nums; font-weight: var(--fw-med); letter-spacing: var(--track-tight); }
-.t-display { font: var(--type-display); color: var(--color-fg-primary); font-variant-numeric: tabular-nums; font-weight: var(--fw-bold); letter-spacing: var(--track-tight); }
+.t-micro   { font: var(--type-micro);   color: var(--fg-4); letter-spacing: var(--track-caps); text-transform: uppercase; }
+.t-caption { font: var(--type-caption); color: var(--fg-3); letter-spacing: var(--track-wide); }
+.t-label   { font: var(--type-label);   color: var(--fg-3); letter-spacing: var(--track-caps); text-transform: uppercase; font-weight: var(--fw-semi); }
+.t-meta    { font: var(--type-meta);    color: var(--fg-3); }
+.t-body    { font: var(--type-body);    color: var(--fg-1); }
+.t-code    { font: var(--type-code);    color: var(--fg-1); }
+.t-title   { font: var(--type-title);   color: var(--fg-1); font-weight: var(--fw-semi); letter-spacing: var(--track-tight); }
+.t-kpi-m   { font: var(--type-kpi-m);   color: var(--fg-1); font-variant-numeric: tabular-nums; font-weight: var(--fw-med); }
+.t-kpi-l   { font: var(--type-kpi-l);   color: var(--fg-1); font-variant-numeric: tabular-nums; font-weight: var(--fw-med); letter-spacing: var(--track-tight); }
+.t-hero    { font: var(--type-hero);    color: var(--fg-1); font-variant-numeric: tabular-nums; font-weight: var(--fw-med); letter-spacing: var(--track-tight); }
+.t-display { font: var(--type-display); color: var(--fg-1); font-variant-numeric: tabular-nums; font-weight: var(--fw-bold); letter-spacing: var(--track-tight); }
 
 /* colour-modifier classes that pair with type roles */
-.t-dim { color: var(--color-fg-muted); }
-.t-mute { color: var(--color-fg-disabled); }
-.t-brass { color: var(--color-accent-fg); }
+.t-dim { color: var(--fg-3); }
+.t-mute { color: var(--fg-4); }
+.t-brass { color: var(--brass-1); }
 .t-ok { color: var(--ok-fg); }
 .t-warn { color: var(--warn-fg); }
 .t-err { color: var(--err-fg); }
@@ -305,8 +304,8 @@ body[data-grid="1"]::before {
   pointer-events: none;
   z-index: var(--z-toast);
   background-image:
-    linear-gradient(to right,  rgb(var(--color-accent-glow) / .06) 1px, transparent 1px),
-    linear-gradient(to bottom, rgb(var(--color-accent-glow) / .06) 1px, transparent 1px);
+    linear-gradient(to right,  rgb(var(--brass-glow) / .06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(var(--brass-glow) / .06) 1px, transparent 1px);
   background-size: var(--grid-unit) var(--grid-unit);
 }
 
@@ -320,7 +319,7 @@ body[data-grid="1"]::before {
 @keyframes anim-slide-right { from { opacity: 0; transform: translateX(-8px); } to { opacity: 1; transform: none; } }
 @keyframes anim-pop         { from { opacity: 0; transform: scale(.92); } to { opacity: 1; transform: none; } }
 @keyframes anim-pulse       { 0%,100% { opacity: 1; } 50% { opacity: .55; } }
-@keyframes anim-pulse-glow  { 0%,100% { box-shadow: 0 0 0 rgb(var(--color-accent-glow) / 0); } 50% { box-shadow: 0 0 10px rgb(var(--color-accent-glow) / .5); } }
+@keyframes anim-pulse-glow  { 0%,100% { box-shadow: 0 0 0 rgb(var(--brass-glow) / 0); } 50% { box-shadow: 0 0 10px rgb(var(--brass-glow) / .5); } }
 @keyframes anim-pulse-err   { 0%,100% { box-shadow: 0 0 0 rgb(var(--err-glow)   / 0); } 50% { box-shadow: 0 0 10px rgb(var(--err-glow)   / .55); } }
 @keyframes anim-pulse-warn  { 0%,100% { box-shadow: 0 0 0 rgb(var(--warn-glow)  / 0); } 50% { box-shadow: 0 0 10px rgb(var(--warn-glow)  / .5); } }
 @keyframes anim-pulse-ok    { 0%,100% { box-shadow: 0 0 0 rgb(var(--ok-glow)    / 0); } 50% { box-shadow: 0 0 10px rgb(var(--ok-glow)    / .5); } }
@@ -351,7 +350,7 @@ body[data-grid="1"]::before {
 /* shimmer — skeleton / loading state background */
 .anim-shimmer {
   background: linear-gradient(90deg,
-    var(--color-bg-panel-alt) 0%, var(--color-bg-elevated) 25%, var(--color-bg-panel-alt) 50%, var(--color-bg-elevated) 75%, var(--color-bg-panel-alt) 100%);
+    var(--bg-2) 0%, var(--bg-3) 25%, var(--bg-2) 50%, var(--bg-3) 75%, var(--bg-2) 100%);
   background-size: 200% 100%;
   animation: anim-shimmer 2s linear infinite;
 }
@@ -361,7 +360,7 @@ body[data-grid="1"]::before {
   content: "▌";
   display: inline-block;
   margin-left: 2px;
-  color: var(--color-accent-fg);
+  color: var(--brass-1);
   animation: anim-blink 1s steps(1) infinite;
 }
 
@@ -371,7 +370,7 @@ body[data-grid="1"]::before {
   cursor: pointer;
   transition: background var(--motion-swap), color var(--motion-swap), border-color var(--motion-swap), box-shadow var(--motion-swap);
 }
-.interactive:hover:not([aria-disabled="true"]) { background: var(--hover-overlay); color: var(--color-fg-primary); }
+.interactive:hover:not([aria-disabled="true"]) { background: var(--hover-overlay); color: var(--fg-1); }
 .interactive:active:not([aria-disabled="true"]) { background: var(--active-overlay); }
 .interactive[aria-disabled="true"] { opacity: .4; cursor: not-allowed; }
 
@@ -383,7 +382,7 @@ body[data-grid="1"]::before {
 .is-loading::after {
   content: "";
   position: absolute; inset: 0;
-  background: linear-gradient(90deg, transparent, rgb(var(--color-accent-glow) / .08), transparent);
+  background: linear-gradient(90deg, transparent, rgb(var(--brass-glow) / .08), transparent);
   background-size: 200% 100%;
   animation: anim-shimmer 1.4s linear infinite;
 }

--- a/dashboard/design-system/source_styles/primitives.css
+++ b/dashboard/design-system/source_styles/primitives.css
@@ -162,6 +162,7 @@
 
 .btn.sm { height: 20px; padding: 0 8px; font-size: var(--fs-10); }
 .btn.xs { height: 18px; padding: 0 6px; font-size: var(--fs-9); letter-spacing: .06em; }
+.btn.lg { height: 24px; padding: 0 10px; font-size: var(--fs-11); }
 
 /* icon-only button — square */
 .btn.icon {

--- a/dashboard/design-system/source_styles/rail.css
+++ b/dashboard/design-system/source_styles/rail.css
@@ -1,17 +1,17 @@
 /* rail.css — ops card stack */
-.ops-card { border-bottom: 1px solid var(--color-border-default); }
+.ops-card { border-bottom: 1px solid var(--line-1); }
 .ops-card:last-child { border-bottom: none; }
 .ops-head {
   height: 28px; padding: 0 var(--sp-3);
   display: flex; align-items: center; gap: var(--sp-2);
   cursor: pointer; user-select: none; font-size: var(--fs-11);
 }
-.ops-head:hover { background: var(--color-bg-panel-alt); }
-.ops-head .label { flex: 1; color: var(--color-fg-secondary); }
-.ops-head .chev { color: var(--color-fg-muted); font-size: 10px; transition: transform var(--t-fast) var(--ease); }
+.ops-head:hover { background: var(--bg-2); }
+.ops-head .label { flex: 1; color: var(--fg-2); }
+.ops-head .chev { color: var(--fg-3); font-size: 10px; transition: transform var(--t-fast) var(--ease); }
 .ops-card.is-collapsed .chev { transform: rotate(-90deg); }
 .ops-card.is-collapsed .ops-body { display: none; }
-.ops-body { padding: var(--sp-3) var(--sp-3) var(--sp-4); font-size: var(--fs-12); line-height: 1.4; color: var(--color-fg-secondary); }
+.ops-body { padding: var(--sp-3) var(--sp-3) var(--sp-4); font-size: var(--fs-12); line-height: 1.4; color: var(--fg-2); }
 
 .stat-row {
   display: grid; grid-template-columns: 80px minmax(0, 1fr);
@@ -19,24 +19,24 @@
   font-size: var(--fs-12); min-width: 0;
 }
 .stat-row .k {
-  color: var(--color-fg-muted); font-size: var(--fs-11);
+  color: var(--fg-3); font-size: var(--fs-11);
   font-weight: 500; letter-spacing: .04em; text-transform: uppercase; padding-top: 1px;
 }
 .stat-row .v {
-  color: var(--color-fg-primary); font-variant-numeric: tabular-nums;
+  color: var(--fg-1); font-variant-numeric: tabular-nums;
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .stat-row .v.wrap { white-space: normal; overflow: visible; text-overflow: clip; }
 
 .goal-text {
-  font-size: var(--fs-12); color: var(--color-fg-primary); line-height: 1.5;
-  background: var(--color-bg-panel-alt); border-left: 2px solid var(--color-accent-fg-dim);
+  font-size: var(--fs-12); color: var(--fg-1); line-height: 1.5;
+  background: var(--bg-2); border-left: 2px solid var(--brass-3);
   padding: var(--sp-2) var(--sp-3);
   border-radius: 0 var(--r-1) var(--r-1) 0; margin: 4px 0 8px;
 }
-.goal-text.is-short { border-left-color: var(--color-accent-fg); }
+.goal-text.is-short { border-left-color: var(--brass-1); }
 .goal-text.is-mid { border-left-color: var(--brass-2); }
-.goal-text.is-long { border-left-color: var(--color-accent-fg-dim); }
+.goal-text.is-long { border-left-color: var(--brass-3); }
 
 .blocker-banner {
   background: rgb(196 106 90 / .08);
@@ -44,7 +44,7 @@
   border-left: 3px solid var(--err);
   padding: var(--sp-2) var(--sp-3);
   border-radius: var(--r-1);
-  font-size: var(--fs-12); color: var(--color-fg-primary); line-height: 1.4;
+  font-size: var(--fs-12); color: var(--fg-1); line-height: 1.4;
   margin-bottom: 6px;
 }
 .blocker-banner .blocker-class {
@@ -55,7 +55,7 @@
 .cascade-models { display: flex; flex-direction: column; gap: 2px; padding: 2px 0; }
 .cascade-model {
   display: flex; align-items: center; gap: 6px;
-  padding: 3px 6px; background: var(--color-bg-panel-alt);
+  padding: 3px 6px; background: var(--bg-2);
   border-radius: var(--r-1); font-size: var(--fs-11);
 }
 
@@ -67,27 +67,27 @@
 .tool-chip {
   display: inline-flex; align-items: center; gap: 4px;
   padding: 2px 7px;
-  background: var(--color-bg-panel-alt);
-  border: 1px solid var(--color-border-strong);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
   border-radius: 10px;
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--color-fg-secondary);
+  color: var(--fg-2);
   line-height: 1.4;
 }
 .tool-chip.is-last {
-  border-color: var(--color-accent-fg);
-  color: var(--color-accent-fg);
-  background: rgb(var(--color-accent-glow) / 0.08);
+  border-color: var(--brass-1);
+  color: var(--brass-1);
+  background: rgb(var(--brass-glow) / 0.08);
 }
 .tool-count {
-  font-size: 9px; color: var(--color-fg-muted);
-  padding: 0 3px; background: var(--color-bg-elevated);
+  font-size: 9px; color: var(--fg-3);
+  padding: 0 3px; background: var(--bg-3);
   border-radius: 6px; margin-left: 2px;
 }
 .tool-chip.is-last .tool-count {
-  color: var(--color-accent-fg);
-  background: rgb(var(--color-accent-glow) / 0.15);
+  color: var(--brass-1);
+  background: rgb(var(--brass-glow) / 0.15);
 }
 
 /* Tool Timeline (inspector tab) */
@@ -95,24 +95,24 @@
 .tl-track {
   position: relative;
   height: 60px;
-  background: var(--color-bg-panel-alt);
-  border: 1px solid var(--color-border-strong);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
   border-radius: var(--r-1);
   margin: 6px 0 4px;
   overflow: hidden;
 }
 .tl-axis {
   position: absolute; left: 0; right: 0; bottom: 0;
-  height: 18px; border-top: 1px dashed var(--color-border-strong);
+  height: 18px; border-top: 1px dashed var(--line-2);
 }
 .tl-tick {
   position: absolute; top: 0; bottom: 0;
-  border-left: 1px dashed var(--color-border-strong);
+  border-left: 1px dashed var(--line-2);
 }
 .tl-tick span {
   position: absolute; top: 2px; left: 4px;
   font-family: var(--font-mono); font-size: 9px;
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
 }
 .tl-dots {
   position: absolute; left: 0; right: 0;
@@ -139,7 +139,7 @@
   display: flex; align-items: center; gap: 6px;
   padding: 3px 2px;
   font-size: 11px;
-  border-bottom: 1px dotted var(--color-border-strong);
+  border-bottom: 1px dotted var(--line-2);
 }
 .tl-legend-row:last-child { border-bottom: none; }
 .tl-swatch {

--- a/dashboard/design-system/source_styles/sidebar.css
+++ b/dashboard/design-system/source_styles/sidebar.css
@@ -3,22 +3,22 @@
 /* ── Domain rail tabs (top of sidebar) ── */
 .sb-railtabs {
   display: grid; grid-template-columns: repeat(5, 1fr);
-  background: var(--color-bg-page);
-  border-bottom: 1px solid var(--color-border-strong);
+  background: var(--bg-0);
+  border-bottom: 1px solid var(--line-2);
   flex-shrink: 0;
 }
 .sb-railtab {
-  background: transparent; border: none; border-right: 1px solid var(--color-border-default);
+  background: transparent; border: none; border-right: 1px solid var(--line-1);
   border-bottom: 2px solid transparent;
   padding: 8px 4px 6px; cursor: pointer;
   display: flex; flex-direction: column; align-items: center; gap: 2px;
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
 }
 .sb-railtab:last-child { border-right: none; }
-.sb-railtab:hover { background: var(--color-bg-panel-alt); color: var(--color-fg-primary); }
+.sb-railtab:hover { background: var(--bg-2); color: var(--fg-1); }
 .sb-railtab.is-active {
-  background: var(--color-bg-surface); color: var(--color-accent-fg);
-  border-bottom-color: var(--color-accent-fg);
+  background: var(--bg-1); color: var(--brass-1);
+  border-bottom-color: var(--brass-1);
 }
 .sb-railtab-glyph {
   font-size: 14px; line-height: 1;
@@ -43,26 +43,26 @@
   padding: 6px 10px;
   cursor: pointer;
   border-left: 2px solid transparent;
-  border-bottom: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--line-1);
   align-items: start;
 }
-.sb-item:hover { background: var(--color-bg-panel-alt); }
-.sb-item.is-active { background: var(--color-bg-elevated); border-left-color: var(--color-accent-fg); }
+.sb-item:hover { background: var(--bg-2); }
+.sb-item.is-active { background: var(--bg-3); border-left-color: var(--brass-1); }
 .sb-item-main { min-width: 0; }
 .sb-item-title {
-  font-size: var(--fs-12); color: var(--color-fg-primary);
+  font-size: var(--fs-12); color: var(--fg-1);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   line-height: 1.35;
 }
 .sb-item-sub {
-  font-size: 10px; color: var(--color-fg-muted);
+  font-size: 10px; color: var(--fg-3);
   margin-top: 2px; font-variant-numeric: tabular-nums;
 }
 .sb-item-tag {
   font-family: var(--font-mono); font-size: 9px;
   padding: 2px 5px; border-radius: var(--r-1);
-  background: var(--color-bg-elevated); color: var(--color-fg-muted);
-  border: 1px solid var(--color-border-default);
+  background: var(--bg-3); color: var(--fg-3);
+  border: 1px solid var(--line-1);
   letter-spacing: .04em; text-transform: uppercase;
   line-height: 1.2; align-self: start;
   margin-top: 1px;
@@ -72,19 +72,19 @@
 .sb-tag-stalled  { color: var(--idle);  }
 .sb-tag-done     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
 .sb-tag-short    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
-.sb-tag-mid      { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.sb-tag-mid      { color: var(--brass-1); border-color: var(--brass-3); }
 .sb-tag-long     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
-.sb-tag-tool     { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.sb-tag-tool     { color: var(--brass-1); border-color: var(--brass-3); }
 .sb-tag-claim    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
 .sb-tag-text     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
 .sb-tag-error    { color: var(--err);   border-color: rgb(196 106 90 / .4); }
-.sb-tag-noop     { color: var(--color-fg-disabled); }
-.sb-tag-cont     { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.sb-tag-noop     { color: var(--fg-4); }
+.sb-tag-cont     { color: var(--brass-1); border-color: var(--brass-3); }
 .sb-tag-spk      { color: var(--info); }
-.sb-tag-note     { color: var(--color-fg-muted); }
+.sb-tag-note     { color: var(--fg-3); }
 
 .sb-empty {
-  padding: 20px 12px; color: var(--color-fg-muted);
+  padding: 20px 12px; color: var(--fg-3);
   font-size: var(--fs-11); text-align: center;
 }
 
@@ -96,33 +96,33 @@
   flex-shrink: 0;
 }
 .sidebar-head .count {
-  font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-muted);
+  font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-3);
 }
 .sb-filter {
   display: grid; grid-template-columns: repeat(5, 1fr); gap: 2px;
-  padding: 0 8px 6px; border-bottom: 1px solid var(--color-border-default); flex-shrink: 0;
+  padding: 0 8px 6px; border-bottom: 1px solid var(--line-1); flex-shrink: 0;
 }
 .sb-tab {
-  background: var(--color-bg-panel-alt);
-  border: 1px solid var(--color-border-default);
+  background: var(--bg-2);
+  border: 1px solid var(--line-1);
   border-radius: var(--r-1);
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
   font-size: 10px; font-family: var(--font-mono);
   letter-spacing: .04em; padding: 4px 2px; cursor: pointer;
   display: flex; flex-direction: column; align-items: center; gap: 1px; line-height: 1;
 }
-.sb-tab:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
-.sb-tab.is-active { background: var(--color-bg-elevated); border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
-.sb-tab-count { font-size: 10px; color: var(--color-fg-disabled); font-variant-numeric: tabular-nums; }
-.sb-tab.is-active .sb-tab-count { color: var(--color-accent-fg); }
-.sb-search { padding: 6px 8px; border-bottom: 1px solid var(--color-border-default); flex-shrink: 0; }
+.sb-tab:hover { background: var(--bg-3); color: var(--fg-1); }
+.sb-tab.is-active { background: var(--bg-3); border-color: var(--brass-3); color: var(--brass-1); }
+.sb-tab-count { font-size: 10px; color: var(--fg-4); font-variant-numeric: tabular-nums; }
+.sb-tab.is-active .sb-tab-count { color: var(--brass-1); }
+.sb-search { padding: 6px 8px; border-bottom: 1px solid var(--line-1); flex-shrink: 0; }
 .sb-search input {
-  width: 100%; background: var(--color-bg-panel-alt);
-  border: 1px solid var(--color-border-default); border-radius: var(--r-1);
-  color: var(--color-fg-primary); font: 11px/1 var(--font-mono);
+  width: 100%; background: var(--bg-2);
+  border: 1px solid var(--line-1); border-radius: var(--r-1);
+  color: var(--fg-1); font: 11px/1 var(--font-mono);
   padding: 5px 8px; height: 24px;
 }
-.sb-search input:focus { border-color: var(--color-accent-fg-dim); outline: none; }
+.sb-search input:focus { border-color: var(--brass-3); outline: none; }
 .sidebar-list { flex: 1; min-height: 0; padding: 0 0 8px; overflow-y: auto; }
 .keeper-row {
   display: grid; grid-template-columns: 8px minmax(0, 1fr) auto;
@@ -131,8 +131,8 @@
   border-left: 2px solid transparent;
   font-size: var(--fs-12); min-width: 0;
 }
-.keeper-row:hover { background: var(--color-bg-panel-alt); }
-.keeper-row.is-active { background: var(--color-bg-elevated); border-left-color: var(--color-accent-fg); }
-.keeper-row .name { color: var(--color-fg-primary); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.keeper-row.is-active .name { color: var(--color-accent-fg); }
-.keeper-row .meta { font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); font-variant-numeric: tabular-nums; }
+.keeper-row:hover { background: var(--bg-2); }
+.keeper-row.is-active { background: var(--bg-3); border-left-color: var(--brass-1); }
+.keeper-row .name { color: var(--fg-1); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.keeper-row.is-active .name { color: var(--brass-1); }
+.keeper-row .meta { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }

--- a/dashboard/design-system/source_styles/swimlanes.css
+++ b/dashboard/design-system/source_styles/swimlanes.css
@@ -17,8 +17,8 @@
 .sl-toolbar {
   display: flex; align-items: center; gap: 6px;
   padding: 0 var(--sp-3); height: 28px;
-  background: linear-gradient(to bottom, var(--color-bg-surface), var(--color-bg-surface) 80%, var(--color-bg-page));
-  border-bottom: 1px solid var(--color-border-strong);
+  background: linear-gradient(to bottom, var(--bg-1), var(--bg-1) 80%, var(--bg-0));
+  border-bottom: 1px solid var(--line-2);
   font-size: var(--fs-11); flex-shrink: 0;
   white-space: nowrap;
   overflow-x: auto;
@@ -26,50 +26,50 @@
   scrollbar-width: thin;
 }
 .sl-toolbar .label {
-  color: var(--color-fg-muted); letter-spacing: .08em; font-weight: 600;
+  color: var(--fg-3); letter-spacing: .08em; font-weight: 600;
   font-size: 10px;
 }
 .sl-tb-brand { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .sl-tb-sep {
   width: 1px; height: 14px;
-  background: var(--color-border-strong);
+  background: var(--line-2);
   flex-shrink: 0;
   margin: 0 2px;
 }
 .sl-tb-toggles { display: inline-flex; gap: 8px; flex-shrink: 0; }
 .sl-toolbar .pane-meta {
-  color: var(--color-fg-secondary);
+  color: var(--fg-2);
   font-family: var(--font-mono); font-size: 10px;
   font-variant-numeric: tabular-nums;
 }
 .sl-range {
   margin-left: auto;
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--color-fg-disabled);
+  color: var(--fg-4);
   flex-shrink: 0;
   padding-left: var(--sp-3);
 }
-.sl-range b { color: var(--color-fg-secondary); font-weight: 500; }
+.sl-range b { color: var(--fg-2); font-weight: 500; }
 
 .sl-toggle {
   display: inline-flex; align-items: center; gap: 4px;
-  font: 10px/1 var(--font-mono); color: var(--color-fg-muted);
+  font: 10px/1 var(--font-mono); color: var(--fg-3);
   cursor: pointer; user-select: none;
   letter-spacing: .04em;
 }
 .sl-toggle input {
   appearance: none;
   width: 9px; height: 9px; margin: 0;
-  border: 1px solid var(--color-border-strong); border-radius: 2px;
-  background: var(--color-bg-panel-alt); cursor: pointer;
+  border: 1px solid var(--line-2); border-radius: 2px;
+  background: var(--bg-2); cursor: pointer;
   position: relative; flex-shrink: 0;
 }
 .sl-toggle input:checked {
-  background: var(--color-accent-fg-dim); border-color: var(--brass-2);
+  background: var(--brass-3); border-color: var(--brass-2);
 }
 .sl-toggle input:checked::after {
   content: ""; position: absolute; inset: 1px;
-  background: var(--color-accent-fg); border-radius: 1px;
+  background: var(--brass-1); border-radius: 1px;
 }
 
 .wf-scale-ctrl {
@@ -92,32 +92,32 @@
   display: grid;
   grid-template-columns: var(--sl-label-w) minmax(0, 1fr);
   height: 24px; flex-shrink: 0;
-  background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-default);
+  background: var(--bg-1); border-bottom: 1px solid var(--line-1);
   position: relative;
 }
 .sl-axis-label {
   display: flex; align-items: center; padding: 0 var(--sp-3);
-  border-right: 1px solid var(--color-border-default);
-  color: var(--color-fg-muted); font-size: 9px; letter-spacing: .1em;
+  border-right: 1px solid var(--line-1);
+  color: var(--fg-3); font-size: 9px; letter-spacing: .1em;
 }
 .sl-axis-track { position: relative; }
 .sl-tick {
   position: absolute; top: 6px;
   transform: translateX(-50%);
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--color-fg-disabled); white-space: nowrap;
+  color: var(--fg-4); white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
-.sl-tick.is-major { color: var(--color-fg-secondary); }
+.sl-tick.is-major { color: var(--fg-2); }
 
 .sl-now-mark {
   position: absolute; top: 4px;
   transform: translateX(-50%);
-  font: 9px/1 var(--font-mono); color: var(--color-accent-fg);
+  font: 9px/1 var(--font-mono); color: var(--brass-1);
   letter-spacing: .12em;
   padding: 2px 4px;
-  background: var(--color-bg-page);
-  border: 1px solid var(--color-accent-fg-dim);
+  background: var(--bg-0);
+  border: 1px solid var(--brass-3);
   border-radius: 2px;
   z-index: 3;
 }
@@ -126,7 +126,7 @@
 .sl-grid-wrap {
   position: relative;
   padding: 2px 0 6px;
-  background: var(--color-bg-page);
+  background: var(--bg-0);
   overflow: auto;
   min-height: 0;
   flex: 1;
@@ -140,11 +140,11 @@
   position: absolute; top: 0; bottom: 0;
   width: 1px;
   background: linear-gradient(to bottom,
-    rgb(var(--color-accent-glow) / .0),
-    rgb(var(--color-accent-glow) / .7) 6%,
-    rgb(var(--color-accent-glow) / .7) 94%,
-    rgb(var(--color-accent-glow) / .0));
-  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .5);
+    rgb(var(--brass-glow) / .0),
+    rgb(var(--brass-glow) / .7) 6%,
+    rgb(var(--brass-glow) / .7) 94%,
+    rgb(var(--brass-glow) / .0));
+  box-shadow: 0 0 4px rgb(var(--brass-glow) / .5);
   pointer-events: none;
   z-index: 4;
 }
@@ -162,21 +162,21 @@
   grid-template-columns: var(--sl-label-w) minmax(0, 1fr);
   height: var(--sl-row-current-h, var(--sl-row-h));
   align-items: center;
-  border-bottom: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--line-1);
   cursor: pointer;
   transition: background var(--t-fast);
 }
 .sl-row:hover { background: rgb(255 255 255 / .02); }
-.sl-row.is-active { background: var(--color-bg-panel-alt); }
-.sl-row.is-active .sl-name { color: var(--color-accent-fg); }
-.sl-row.is-active .sl-status.dot-running { box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .8); }
+.sl-row.is-active { background: var(--bg-2); }
+.sl-row.is-active .sl-name { color: var(--brass-1); }
+.sl-row.is-active .sl-status.dot-running { box-shadow: 0 0 6px rgb(var(--brass-glow) / .8); }
 
 /* status tinted backgrounds — very subtle */
 .sl-row.st-error     { background: rgb(196 106 90 / .04); }
 .sl-row.st-error.is-active { background: rgb(196 106 90 / .10); }
 .sl-row.st-blocker   { background: rgb(201 162 74 / .04); }
 .sl-row.st-blocker.is-active { background: rgb(201 162 74 / .09); }
-.sl-row.st-running   { background: rgb(var(--color-accent-glow) / .02); }
+.sl-row.st-running   { background: rgb(var(--brass-glow) / .02); }
 
 /* collapsed empty lane — smaller, muted */
 .sl-row-collapsed {
@@ -191,7 +191,7 @@
 .sl-empty-note {
   position: absolute; left: 50%; top: 50%;
   transform: translate(-50%, -50%);
-  font: 9px/1 var(--font-mono); color: var(--color-fg-disabled);
+  font: 9px/1 var(--font-mono); color: var(--fg-4);
   letter-spacing: .08em;
 }
 
@@ -200,7 +200,7 @@
   display: flex; align-items: center; gap: 6px;
   padding: 0 var(--sp-3);
   height: 100%;
-  border-right: 1px solid var(--color-border-default);
+  border-right: 1px solid var(--line-1);
   min-width: 0; overflow: hidden;
   font-size: var(--fs-11);
   position: relative;
@@ -218,7 +218,7 @@
 .sl-status.dot-idle { background: var(--idle); }
 
 .sl-name {
-  color: var(--color-fg-primary); font-weight: 500;
+  color: var(--fg-1); font-weight: 500;
   flex: 1; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font-family: var(--font-mono);
@@ -226,10 +226,10 @@
 }
 .sl-meta {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--color-fg-muted); flex-shrink: 0;
+  color: var(--fg-3); flex-shrink: 0;
   display: flex; gap: 3px;
 }
-.sl-meta b { color: var(--color-fg-primary); font-weight: 500; }
+.sl-meta b { color: var(--fg-1); font-weight: 500; }
 .sl-meta .err { color: var(--err); }
 
 /* mini-sparkline in label */
@@ -243,7 +243,7 @@
 .sl-row.is-active .sl-spark { opacity: 1; }
 .sl-spark-bar {
   flex: 1; min-width: 1px;
-  background: var(--color-fg-muted);
+  background: var(--fg-3);
   border-radius: 1px 1px 0 0;
 }
 .sl-spark-bar.is-err { background: var(--err); }
@@ -272,22 +272,22 @@
 .sl-grid {
   position: absolute; top: 0; bottom: 0;
   width: 1px;
-  background: var(--color-border-default);
+  background: var(--line-1);
   opacity: .4;
   pointer-events: none;
 }
 .sl-grid.is-major {
-  background: var(--color-border-strong);
+  background: var(--line-2);
   opacity: .7;
 }
 
 .sl-crosshair {
   position: absolute; top: 0; bottom: 0;
   width: 1px;
-  background: var(--color-accent-fg);
+  background: var(--brass-1);
   opacity: .8;
   pointer-events: none;
-  box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .7);
+  box-shadow: 0 0 3px rgb(var(--brass-glow) / .7);
   z-index: 2;
 }
 
@@ -304,7 +304,7 @@
 .sl-glyph-mark {
   display: block; width: 100%; height: 100%;
   min-width: 3px;
-  background: var(--color-fg-muted);
+  background: var(--fg-3);
   border-radius: 1px;
   transition: transform var(--t-fast) var(--ease), box-shadow var(--t-fast);
 }
@@ -339,7 +339,7 @@
   height: 30% !important;
 }
 .sl-glyph.k-noop .sl-glyph-mark {
-  background: var(--color-fg-disabled);
+  background: var(--fg-4);
   min-width: 2px;
   opacity: .6;
 }
@@ -375,7 +375,7 @@
   z-index: 4;
 }
 .sl-glyph.is-active .sl-glyph-mark {
-  box-shadow: 0 0 0 2px var(--color-bg-page), 0 0 0 3px var(--color-accent-fg), 0 0 6px rgb(var(--color-accent-glow) / .7);
+  box-shadow: 0 0 0 2px var(--bg-0), 0 0 0 3px var(--brass-1), 0 0 6px rgb(var(--brass-glow) / .7);
   transform: scale(1.3);
   filter: brightness(1.2);
 }
@@ -402,7 +402,7 @@
 }
 .sl-ho-line {
   fill: none;
-  stroke: var(--color-accent-fg-dim);
+  stroke: var(--brass-3);
   stroke-width: 1;
   opacity: .35;
   stroke-linecap: round;
@@ -415,26 +415,26 @@
   transition: r var(--t-fast), fill var(--t-fast), opacity var(--t-fast);
 }
 .sl-ho-tail {
-  fill: var(--color-accent-fg-dim);
+  fill: var(--brass-3);
   opacity: .45;
 }
-.sl-ho.is-involved .sl-ho-line { stroke: var(--color-accent-fg); opacity: .65; stroke-dasharray: none; }
-.sl-ho.is-involved .sl-ho-head { fill: var(--color-accent-fg); opacity: .9; }
+.sl-ho.is-involved .sl-ho-line { stroke: var(--brass-1); opacity: .65; stroke-dasharray: none; }
+.sl-ho.is-involved .sl-ho-head { fill: var(--brass-1); opacity: .9; }
 .sl-ho:hover .sl-ho-line {
-  stroke: var(--color-accent-fg);
+  stroke: var(--brass-1);
   stroke-width: 1.6;
   opacity: 1;
   stroke-dasharray: none;
-  filter: drop-shadow(0 0 3px rgb(var(--color-accent-glow) / .7));
+  filter: drop-shadow(0 0 3px rgb(var(--brass-glow) / .7));
 }
-.sl-ho:hover .sl-ho-head { fill: var(--color-accent-fg); opacity: 1; }
+.sl-ho:hover .sl-ho-head { fill: var(--brass-1); opacity: 1; }
 .sl-ho.is-active .sl-ho-line {
-  stroke: var(--color-accent-fg);
+  stroke: var(--brass-1);
   stroke-width: 1.8;
   opacity: 1;
   stroke-dasharray: none;
 }
-.sl-ho.is-active .sl-ho-head { fill: var(--color-accent-fg); opacity: 1; }
+.sl-ho.is-active .sl-ho-head { fill: var(--brass-1); opacity: 1; }
 
 /* cluster pill */
 .sl-cluster {
@@ -447,23 +447,23 @@
   text-align: center;
   cursor: pointer;
   z-index: 3;
-  background: var(--color-bg-elevated);
-  color: var(--color-fg-primary);
-  border: 1px solid var(--color-border-divider);
+  background: var(--bg-3);
+  color: var(--fg-1);
+  border: 1px solid var(--line-3);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0;
   transition: transform var(--t-fast) var(--ease), box-shadow var(--t-fast);
 }
-.sl-cluster.k-tool { border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
+.sl-cluster.k-tool { border-color: var(--brass-3); color: var(--brass-1); }
 .sl-cluster.k-claim { border-color: var(--ok); color: var(--ok); }
 .sl-cluster.k-error,
 .sl-cluster.is-err {
   background: var(--err);
   border-color: var(--err);
-  color: var(--color-bg-page);
+  color: var(--bg-0);
 }
 .sl-cluster:hover {
   transform: translate(-50%, -50%) scale(1.2);
-  box-shadow: 0 0 0 2px var(--color-bg-page), 0 0 0 3px var(--color-accent-fg);
+  box-shadow: 0 0 0 2px var(--bg-0), 0 0 0 3px var(--brass-1);
   z-index: 5;
 }

--- a/dashboard/design-system/source_styles/ticker.css
+++ b/dashboard/design-system/source_styles/ticker.css
@@ -2,8 +2,8 @@
 
 .zone-ticker {
   grid-area: ticker;
-  background: linear-gradient(to bottom, var(--color-bg-surface), var(--color-bg-page));
-  border-bottom: 1px solid var(--color-border-strong);
+  background: linear-gradient(to bottom, var(--bg-1), var(--bg-0));
+  border-bottom: 1px solid var(--line-2);
   overflow: hidden;
   position: relative;
 }
@@ -12,8 +12,8 @@
   content: ""; position: absolute; top: 0; bottom: 0; width: 40px; z-index: 2;
   pointer-events: none;
 }
-.zone-ticker::before { left: 0; background: linear-gradient(to right, var(--color-bg-surface), transparent); }
-.zone-ticker::after  { right: 0; background: linear-gradient(to left,  var(--color-bg-surface), transparent); }
+.zone-ticker::before { left: 0; background: linear-gradient(to right, var(--bg-1), transparent); }
+.zone-ticker::after  { right: 0; background: linear-gradient(to left,  var(--bg-1), transparent); }
 
 .tk-rail {
   display: flex;
@@ -33,7 +33,7 @@
   padding: 6px 14px;
   background: transparent;
   border: none;
-  border-right: 1px solid var(--color-border-default);
+  border-right: 1px solid var(--line-1);
   border-radius: 0;
   cursor: pointer;
   transition: background .12s ease;
@@ -41,12 +41,12 @@
   position: relative;
 }
 .tk-item:last-child { border-right: none; }
-.tk-item:hover { background: var(--color-bg-panel-alt); color: var(--color-fg-primary); }
+.tk-item:hover { background: var(--bg-2); color: var(--fg-1); }
 .tk-item.is-active {
-  background: var(--color-bg-elevated);
-  box-shadow: inset 0 -2px 0 var(--color-accent-fg);
+  background: var(--bg-3);
+  box-shadow: inset 0 -2px 0 var(--brass-1);
 }
-.tk-item.is-active .tk-sym { color: var(--color-accent-fg); }
+.tk-item.is-active .tk-sym { color: var(--brass-1); }
 
 .tk-dot { display: inline-flex; }
 
@@ -54,12 +54,12 @@
   font-size: 11px;
   font-weight: 600;
   letter-spacing: .06em;
-  color: var(--color-fg-primary);
+  color: var(--fg-1);
   min-width: 36px;
 }
 .tk-price {
   font-size: 11px;
-  color: var(--color-fg-secondary);
+  color: var(--fg-2);
   min-width: 34px;
   text-align: right;
 }
@@ -74,10 +74,10 @@
   letter-spacing: .02em;
   min-width: 42px;
   text-align: right;
-  color: var(--color-fg-muted);
+  color: var(--fg-3);
 }
 .tk-arrow { display: inline-block; margin-right: 2px; font-size: 8px; }
 
 .tk-item.tk-up   .tk-delta { color: var(--ok); }
 .tk-item.tk-down .tk-delta { color: var(--err); }
-.tk-item.tk-flat .tk-delta { color: var(--color-fg-muted); }
+.tk-item.tk-flat .tk-delta { color: var(--fg-3); }

--- a/dashboard/design-system/ui_kits/cockpit/App.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/App.jsx
@@ -2,12 +2,15 @@
           MASC_DATA, WorkPlane, CommsPlane, ObservePlane, CognitionPlane, IdePlane,
           ViewportBanner, useCockpitState, useLayoutProfile, Drawer */
 const { useState, useCallback, useEffect } = React;
+const useCockpitLayoutProfile = window.useLayoutProfile || function useCockpitLayoutProfileNoop() {
+  return undefined;
+};
 
 function App() {
   // sync mode/branch with the cockpit-state singleton (URL+localStorage)
   const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{}, () => {}]);
-  // run layout profile — always call (no-ops when not installed) to satisfy Rules of Hooks
-  (window.useLayoutProfile || (() => {}))();
+  // Always call the same hook-shaped function so hook order stays stable.
+  useCockpitLayoutProfile();
   const [mode, setModeRaw] = useState(cs.mode || "Dashboard");
   const [density, setDensity] = useState("normal");
   const [selKeeper, setSelKeeper] = useState("nick0cave");

--- a/dashboard/design-system/ui_kits/cockpit/App.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/App.jsx
@@ -1,14 +1,28 @@
 /* global React, Topbar, Ticker, KpiStrip, Lifeline, Sidebar, Swimlanes, Deck, Rail, Composer, StatusBar,
-          MASC_DATA, WorkPlane, CommsPlane, ObservePlane, CognitionPlane, IdePlane */
-const { useState, useCallback } = React;
+          MASC_DATA, WorkPlane, CommsPlane, ObservePlane, CognitionPlane, IdePlane,
+          ViewportBanner, useCockpitState, useLayoutProfile, Drawer */
+const { useState, useCallback, useEffect } = React;
 
 function App() {
-  const [mode, setMode] = useState("Dashboard");
+  // sync mode/branch with the cockpit-state singleton (URL+localStorage)
+  const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{}, () => {}]);
+  // run layout profile — auto-collapses chrome per mode
+  if (window.useLayoutProfile) window.useLayoutProfile();
+  const [mode, setModeRaw] = useState(cs.mode || "Dashboard");
   const [density, setDensity] = useState("normal");
   const [selKeeper, setSelKeeper] = useState("nick0cave");
   const [selGoal, setSelGoal] = useState("goal-merge-blockers");
-  const [branch, setBranch] = useState("main");
+  const [branch, setBranchRaw] = useState(cs.branch || "main");
   const [selectedKeepers, setSelectedKeepers] = useState(new Set(["nick0cave","sangsu"]));
+
+  // cs is the source of truth for mode/branch — mirror to local state for child props
+  useEffect(() => {
+    if (cs.mode && cs.mode !== mode) setModeRaw(cs.mode);
+    if (cs.branch && cs.branch !== branch) setBranchRaw(cs.branch);
+  }, [cs.mode, cs.branch]);
+
+  const setMode = useCallback((m) => { setModeRaw(m); setCs({ mode: m }); }, [setCs]);
+  const setBranch = useCallback((b) => { setBranchRaw(b); setCs({ branch: b }); }, [setCs]);
 
   const D = window.MASC_DATA;
   const activeGoal = D.goals.find(g => g.id === selGoal) || D.goals[0];
@@ -41,6 +55,7 @@ function App() {
 
   return (
     <div className="app" data-screen-label="MASC Cockpit" data-density={density}>
+      {window.ViewportBanner ? <window.ViewportBanner/> : null}
       <Topbar goal={activeGoal} goals={D.goals} mode={mode} setMode={setMode}
               density={density} setDensity={setDensity}
               branch={branch} setBranch={setBranch} />
@@ -53,11 +68,21 @@ function App() {
                selectedKeepers={selectedKeepers} toggleKeeper={toggleKeeper} />
       {renderCenter()}
       <Rail events={D.events} cascade={D.cascade} />
+      {window.Drawer ? <window.Drawer/> : null}
       <Composer selKeeper={selKeeper} />
       <StatusBar providers={D.providers} />
+      {window.FocusToggle ? <window.FocusToggle/> : null}
+      {window.StatusTray ? <window.StatusTray/> : null}
     </div>
   );
 }
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(<App />);
+
+// pop-out: if URL has ?widget=<id>, render that widget solo
+const __soloId = new URL(window.location.href).searchParams.get("widget");
+if (__soloId && window.WidgetSolo) {
+  root.render(<window.WidgetSolo id={__soloId} />);
+} else {
+  root.render(<App />);
+}

--- a/dashboard/design-system/ui_kits/cockpit/App.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/App.jsx
@@ -6,8 +6,8 @@ const { useState, useCallback, useEffect } = React;
 function App() {
   // sync mode/branch with the cockpit-state singleton (URL+localStorage)
   const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{}, () => {}]);
-  // run layout profile — auto-collapses chrome per mode
-  if (window.useLayoutProfile) window.useLayoutProfile();
+  // run layout profile — always call (no-ops when not installed) to satisfy Rules of Hooks
+  (window.useLayoutProfile || (() => {}))();
   const [mode, setModeRaw] = useState(cs.mode || "Dashboard");
   const [density, setDensity] = useState("normal");
   const [selKeeper, setSelKeeper] = useState("nick0cave");

--- a/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
@@ -184,6 +184,10 @@ function Lifeline() {
   const [col, toggleLife] = (window.useCollapsed ? window.useCollapsed("lifeline") : [false, () => {}]);
   // Build a heartbeat trace from real keeper events instead of pure sin wave.
   // Each event becomes a peak; baseline runs flat.
+  // Map seed event kinds to lifeline peak levels:
+  //   err → fail (y=2)  |  flag → cascade (y=4)
+  //   note/tool → nudge (y=6)  |  verify → claim (y=8)
+  const _kindMap = { err:"fail", flag:"cascade", note:"nudge", tool:"nudge", verify:"claim" };
   const D = window.MASC_DATA || {};
   const events = (D.events || []).slice(0, 24);
   const N = 120;
@@ -191,7 +195,7 @@ function Lifeline() {
   // Map events to x positions (most recent on right).
   const eventX = events.map((e, i) => Math.floor(N - 1 - (i * (N-2) / Math.max(events.length-1,1))));
   const eventKind = {};
-  events.forEach((e, i) => { eventKind[eventX[i]] = e.kind; });
+  events.forEach((e, i) => { eventKind[eventX[i]] = _kindMap[e.kind] || "nudge"; });
   for (let i = 0; i < N; i++) {
     const x = (i / (N-1)) * 600;
     const base = 12;
@@ -200,14 +204,14 @@ function Lifeline() {
     if (k === "fail")     y = 2;
     else if (k === "cascade") y = 4;
     else if (k === "nudge")   y = 6;
-    else if (k === "claim" || k === "verify") y = 8;
+    else if (k === "claim")   y = 8;
     pts.push(`${x.toFixed(1)},${y.toFixed(1)}`);
   }
   const d = "M" + pts.join(" L");
   // Render event markers as small dots.
   const markers = events.slice(0, 8).map((e, i) => ({
     x: (eventX[i] / (N-1)) * 600,
-    kind: e.kind,
+    kind: _kindMap[e.kind] || "nudge",
     keeper: e.keeper,
   }));
   return (
@@ -219,7 +223,8 @@ function Lifeline() {
         <svg viewBox="0 0 600 20" preserveAspectRatio="none">
           <path d={d} stroke="var(--color-accent-fg)" strokeWidth="1" fill="none" />
           {markers.map((m, i) => (
-            <circle key={i} cx={m.x} cy={m.kind === "fail" ? 2 : m.kind === "cascade" ? 4 : 6} r="1.6"
+            <circle key={i} cx={m.x}
+              cy={m.kind === "fail" ? 2 : m.kind === "cascade" ? 4 : m.kind === "claim" ? 8 : 6} r="1.6"
               fill={m.kind === "fail" ? "var(--err-fg)" : m.kind === "cascade" ? "var(--info-fg)" : m.kind === "nudge" ? "var(--brass-1)" : "var(--ok-fg)"} />
           ))}
         </svg>

--- a/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
@@ -119,7 +119,24 @@ function KpiStrip() {
   }
   return (
     <div className={"kpi" + (col ? " wx-collapsed" : "")}>
-      <div className="kpi-collapse-tab" onClick={toggle} title={col ? "expand KPI" : "collapse KPI"}>
+      <div
+        className="kpi-collapse-tab"
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (
+            e.target !== e.currentTarget &&
+            e.target.closest &&
+            e.target.closest("a,button,input,textarea,select")
+          ) return;
+          if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        title={col ? "expand KPI" : "collapse KPI"}
+        role="button"
+        tabIndex={0}
+        aria-expanded={!col}>
         {col ? "▸ KPI · " + (spot.urgent ? "⚠ " + spot.label : "8 metrics") : "▾"}
         {!col && (
           <a className="wx-popout"

--- a/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
@@ -26,6 +26,8 @@ function Topbar({ goal, goals, mode, setMode, density, setDensity, branch, setBr
         <span className="tb-name">MASC</span>
       </div>
       <span className="tb-sep"></span>
+      {window.RepoSelector ? <window.RepoSelector/> : null}
+      <span className="tb-sep"></span>
       <div className="tb-branch" onClick={() => setBrOpen(o => !o)} title={`HEAD ${cur.head}`}>
         <span className="nm">{cur.name}</span>
         <span className="ahbh">
@@ -98,8 +100,41 @@ function Ticker({ events }) {
 
 // ============== KPI Strip ==============
 function KpiStrip() {
+  const [col, toggle] = (window.useCollapsed ? window.useCollapsed("kpi") : [false, () => {}]);
+  // "Spotlight" — surface the most urgent KPI as the first, larger cell.
+  // Priority: cascade@step ≥ 2 > stalled keepers > failed tests > token velocity
+  const D = window.MASC_DATA || {};
+  const stalled = (D.keepers || []).filter(k => k.status === "stalled");
+  const cascadeHits = 2; // mock seeded
+  const fails = 3;
+  let spot;
+  if (cascadeHits >= 2) {
+    spot = { label: "Cascade @step\u22652", value: cascadeHits, unit: "@step", tone: "info", note: "anthropic → moonshot", urgent: true };
+  } else if (stalled.length > 0) {
+    spot = { label: "Stalled", value: stalled.length, unit: "", tone: "stalled", note: stalled[0].id + " · 22m", urgent: true };
+  } else if (fails > 0) {
+    spot = { label: "Fails", value: fails, unit: "/47", tone: "err", note: "merge-blockers", urgent: true };
+  } else {
+    spot = { label: "Tokens/sec", value: "1.24", unit: "tps", tone: "brass", note: "▲ +0.10 · 5m", urgent: false };
+  }
   return (
-    <div className="kpi">
+    <div className={"kpi" + (col ? " wx-collapsed" : "")}>
+      <div className="kpi-collapse-tab" onClick={toggle} title={col ? "expand KPI" : "collapse KPI"}>
+        {col ? "▸ KPI · " + (spot.urgent ? "⚠ " + spot.label : "8 metrics") : "▾"}
+        {!col && (
+          <a className="wx-popout"
+             href="?widget=kpi"
+             target="_blank" rel="noopener"
+             onClick={(e)=>e.stopPropagation()}
+             title="open KPI strip in new tab"
+             style={{marginLeft:"auto"}}>↗</a>
+        )}
+      </div>
+      <div className={"kpi-cell spotlight " + (spot.urgent ? "urgent" : "")}>
+        <span className="kpi-l">◆ SPOTLIGHT · {spot.label}</span>
+        <span className={"kpi-v " + spot.tone}>{spot.value}{spot.unit && <span className="u">{spot.unit}</span>}</span>
+        <span className="kpi-d">{spot.note}</span>
+      </div>
       <div className="kpi-cell live">
         <span className="kpi-l">Tokens/sec</span>
         <span className="kpi-v brass">1.24<span className="u">tps</span></span>
@@ -146,30 +181,58 @@ function KpiStrip() {
 
 // ============== Lifeline ==============
 function Lifeline() {
-  // Build a nice heartbeat trace (deterministic)
-  const pts = [];
+  const [col, toggleLife] = (window.useCollapsed ? window.useCollapsed("lifeline") : [false, () => {}]);
+  // Build a heartbeat trace from real keeper events instead of pure sin wave.
+  // Each event becomes a peak; baseline runs flat.
+  const D = window.MASC_DATA || {};
+  const events = (D.events || []).slice(0, 24);
   const N = 120;
-  for (let i=0;i<N;i++) {
-    const x = (i/(N-1))*600;
-    const base = 10;
-    let y = base;
-    if (i%14 === 2) y = 2;
-    else if (i%14 === 3) y = 18;
-    else if (i%14 === 4) y = 6;
-    else if (i%14 === 10) y = 14;
-    else y = base + (Math.sin(i*0.4)*1.5);
+  const pts = [];
+  // Map events to x positions (most recent on right).
+  const eventX = events.map((e, i) => Math.floor(N - 1 - (i * (N-2) / Math.max(events.length-1,1))));
+  const eventKind = {};
+  events.forEach((e, i) => { eventKind[eventX[i]] = e.kind; });
+  for (let i = 0; i < N; i++) {
+    const x = (i / (N-1)) * 600;
+    const base = 12;
+    let y = base + Math.sin(i * 0.18) * 0.5;
+    const k = eventKind[i];
+    if (k === "fail")     y = 2;
+    else if (k === "cascade") y = 4;
+    else if (k === "nudge")   y = 6;
+    else if (k === "claim" || k === "verify") y = 8;
     pts.push(`${x.toFixed(1)},${y.toFixed(1)}`);
   }
-  const d = "M"+pts.join(" L");
+  const d = "M" + pts.join(" L");
+  // Render event markers as small dots.
+  const markers = events.slice(0, 8).map((e, i) => ({
+    x: (eventX[i] / (N-1)) * 600,
+    kind: e.kind,
+    keeper: e.keeper,
+  }));
   return (
-    <div className="life">
-      <span className="life-label">Lifeline · 60s</span>
+    <div className={"life" + (col ? " wx-collapsed" : "")}>
+      <span className="life-label" onClick={toggleLife} title={col ? "expand lifeline" : "collapse lifeline"} style={{cursor:"pointer"}}>
+        {col ? "▸" : "▾"} Lifeline · 60s
+      </span>
       <div className="life-trace">
         <svg viewBox="0 0 600 20" preserveAspectRatio="none">
           <path d={d} stroke="var(--color-accent-fg)" strokeWidth="1" fill="none" />
+          {markers.map((m, i) => (
+            <circle key={i} cx={m.x} cy={m.kind === "fail" ? 2 : m.kind === "cascade" ? 4 : 6} r="1.6"
+              fill={m.kind === "fail" ? "var(--err-fg)" : m.kind === "cascade" ? "var(--info-fg)" : m.kind === "nudge" ? "var(--brass-1)" : "var(--ok-fg)"} />
+          ))}
         </svg>
       </div>
-      <span className="life-now"><span className="life-dot"></span> 1.24 TPS · NOW</span>
+      <span className="life-now">
+        <span className="life-dot"></span> {events.length} events · NOW
+        <a className="wx-popout"
+           href="?widget=lifeline"
+           target="_blank" rel="noopener"
+           onClick={(e)=>e.stopPropagation()}
+           title="open lifeline in new tab"
+           style={{marginLeft:"8px"}}>↗</a>
+      </span>
     </div>
   );
 }

--- a/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
@@ -1,0 +1,405 @@
+/* global React, MASC_DATA, useCockpitState */
+/* Drawer.jsx — VSCode-style bottom drawer with Terminal / Output / Cascade / Audit / Cost
+   - draggable grip on top edge (resize)
+   - double-click grip = snap between 30vh and 60vh
+   - tab click on closed drawer opens it
+   - X closes
+   - state synced via useCockpitState  → drawer: { open, height, tab }
+*/
+const { useState: dUseState, useEffect: dUseEffect, useRef: dUseRef, useCallback: dUseCallback, useMemo: dUseMemo } = React;
+
+const DRAWER_TABS = [
+  { id: "terminal", label: "Terminal", glyph: ">_", count: null },
+  { id: "output",   label: "Output",   glyph: "⎯",  count: null },
+  { id: "cascade",  label: "Cascade",  glyph: "⇢",  count: 5  },
+  { id: "audit",    label: "Audit",    glyph: "§",  count: 12 },
+  { id: "cost",     label: "Cost",     glyph: "¤",  count: null },
+];
+
+const DRAWER_DEFAULTS = { open: false, height: 280, tab: "terminal" };
+
+// ─── Drawer state hook (lives on cockpit-state singleton) ───────
+function useDrawerState() {
+  const [s, set] = window.useCockpitState();
+  const drawer = { ...DRAWER_DEFAULTS, ...(s.drawer || {}) };
+  const setDrawer = dUseCallback((patch) => {
+    const next = { ...drawer, ...patch };
+    set({ drawer: next });
+  }, [drawer]);
+  return [drawer, setDrawer];
+}
+
+// ─── individual tab panels ──────────────────────────────────────
+function TerminalPanel() {
+  // mock terminal showing recent claim-loop activity
+  const lines = [
+    { t: "01:42:18", k: "tx", txt: "$ git fetch --all" },
+    { t: "01:42:18", k: "ok", txt: "fetching origin (5 refs)" },
+    { t: "01:42:19", k: "ok", txt: "From github.com:masc/runtime" },
+    { t: "01:42:19", k: "info", txt: "  da11b063..a8c2e91d  main  →  origin/main" },
+    { t: "01:42:20", k: "tx", txt: "$ python -m masc.eval --suite cascade-router --branches feat/keeper-clarity" },
+    { t: "01:42:21", k: "info", txt: "→ loading 47 cases · seed=42" },
+    { t: "01:42:24", k: "ok", txt: "  ✓ cascade.fanout.basic              (124ms)" },
+    { t: "01:42:25", k: "ok", txt: "  ✓ cascade.fanout.with_fallback      (88ms)" },
+    { t: "01:42:25", k: "err", txt: "  ✗ cascade.fanout.cycle_detection    (timeout)" },
+    { t: "01:42:25", k: "err", txt: "        expected len=3, got len=4 (recursive include)" },
+    { t: "01:42:26", k: "ok", txt: "  ✓ cascade.router.priority           (51ms)" },
+    { t: "01:42:27", k: "warn", txt: "  ⚠ cascade.router.weighted          (slow: 412ms)" },
+    { t: "01:42:28", k: "info", txt: "" },
+    { t: "01:42:28", k: "info", txt: "─── 44 passed · 1 failed · 2 slow · 18.4s ────────" },
+    { t: "01:42:29", k: "tx", txt: "$ █" },
+  ];
+  return (
+    <div className="dr-term">
+      {lines.map((l, i) => (
+        <div key={i} className={"dr-term-l k-" + l.k}>
+          <span className="t">{l.t}</span>
+          <span className="x">{l.txt}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function OutputPanel() {
+  // pretend log channels — switchable
+  const channels = ["claim-loop", "cascade-router", "keeper-shell", "tokens-build", "deploy"];
+  const [ch, setCh] = dUseState("claim-loop");
+  const lines = {
+    "claim-loop": [
+      { t: "01:38:00", lv: "info",  txt: "claim-loop tick #4128 · 9 keepers active" },
+      { t: "01:38:00", lv: "info",  txt: "  → nick0cave   claim cb-group/i (held 2m12s)" },
+      { t: "01:38:00", lv: "info",  txt: "  → sangsu      claim plane-cognition (held 5m04s)" },
+      { t: "01:38:00", lv: "warn",  txt: "  ⚠ kraftwerk   stalled 22m04s on cascade.router.weighted" },
+      { t: "01:38:01", lv: "info",  txt: "  → coltrane    idle (last seen 3m)" },
+      { t: "01:38:02", lv: "info",  txt: "tick complete · 8.1ms" },
+      { t: "01:38:30", lv: "info",  txt: "claim-loop tick #4129 · 9 keepers active" },
+      { t: "01:38:30", lv: "warn",  txt: "  ⚠ kraftwerk   stalled 22m34s — escalation soon" },
+      { t: "01:38:31", lv: "ok",    txt: "  ✓ nick0cave   released cb-group/i (changes pushed)" },
+      { t: "01:38:32", lv: "info",  txt: "tick complete · 7.4ms" },
+    ],
+    "cascade-router": [
+      { t: "01:39:14", lv: "info", txt: "router.dispatch  prompt-id=p_8821a1  primary=anthropic/claude-3.5" },
+      { t: "01:39:14", lv: "info", txt: "  step 1  anthropic         200ms · 0.012$" },
+      { t: "01:39:14", lv: "warn", txt: "  step 1  anthropic         RATE_LIMIT (60s)" },
+      { t: "01:39:14", lv: "info", txt: "  step 2  moonshot          318ms · 0.004$" },
+      { t: "01:39:15", lv: "ok",   txt: "  → resolved at step=2 (cascade hit, 5/47 today)" },
+    ],
+    "keeper-shell": [
+      { t: "01:40:00", lv: "info", txt: "[nick0cave] shell open · branch=feat/keeper-clarity" },
+      { t: "01:40:01", lv: "info", txt: "[nick0cave] $ make test" },
+      { t: "01:40:18", lv: "ok",   txt: "[nick0cave] tests passed (44/47)" },
+    ],
+    "tokens-build": [
+      { t: "01:30:01", lv: "info", txt: "tokens:build  target=cockpit/tokens.generated.css" },
+      { t: "01:30:02", lv: "ok",   txt: "  3 themes × 142 tokens emitted" },
+      { t: "01:30:02", lv: "ok",   txt: "  ✓ build complete · 1.1s" },
+    ],
+    "deploy": [
+      { t: "00:42:00", lv: "info", txt: "deploy.runtime  stage=staging  rev=da11b063" },
+      { t: "00:42:34", lv: "ok",   txt: "  ✓ image built · 312MB" },
+      { t: "00:43:04", lv: "ok",   txt: "  ✓ rolled out · 0 errors" },
+    ],
+  }[ch] || [];
+  return (
+    <div className="dr-output">
+      <div className="dr-output-bar">
+        <span className="lbl">channel</span>
+        <select className="chsel" value={ch} onChange={(e) => setCh(e.target.value)}>
+          {channels.map(c => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <span className="meta">{lines.length} lines · live</span>
+      </div>
+      <div className="dr-output-body">
+        {lines.map((l, i) => (
+          <div key={i} className={"dr-out-l lv-" + l.lv}>
+            <span className="t">{l.t}</span>
+            <span className="lv">{l.lv}</span>
+            <span className="x">{l.txt}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CascadePanel() {
+  const D = window.MASC_DATA || {};
+  const cascades = (D.cascade && Array.isArray(D.cascade) ? D.cascade : []).slice(0, 6);
+  return (
+    <div className="dr-cascade">
+      <div className="dr-cascade-bar">
+        <span className="lbl">recent cascades</span>
+        <span className="meta">{cascades.length} shown · 5/47 hit step≥2 today</span>
+      </div>
+      <div className="dr-cascade-body">
+        {cascades.length === 0 && <div className="dr-empty">no cascades yet</div>}
+        {cascades.map((c, i) => (
+          <div key={i} className="dr-csc">
+            <div className="dr-csc-h">
+              <span className="id">{c.id || ("csc-" + i)}</span>
+              <span className="prompt">{c.prompt || "(no prompt)"}</span>
+              <span className={"out " + (c.outcome === "ok" ? "ok" : "fail")}>{c.outcome || "—"}</span>
+            </div>
+            <div className="dr-csc-hops">
+              {(c.hops || []).map((h, hi) => (
+                <span key={hi} className={"hop " + (h.status || "")}>
+                  <span className="ix">{hi + 1}</span>
+                  <span className="prov">{h.provider || h.name}</span>
+                  <span className="ms">{h.latency_ms || h.ms || "—"}ms</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AuditPanel() {
+  // mock audit ledger
+  const rows = [
+    { t: "01:42:19", who: "nick0cave",   verdict: "merge", target: "PR #9712 · runtime", note: "ok-with-warnings" },
+    { t: "01:38:04", who: "automation",  verdict: "block", target: "PR #9710 · runtime", note: "merge-blockers fail" },
+    { t: "01:35:11", who: "sangsu",      verdict: "ack",   target: "ticket-3411",       note: "claim · plane-cognition" },
+    { t: "01:30:00", who: "automation",  verdict: "log",   target: "tokens.generated",  note: "drift detected · auto-build" },
+    { t: "01:22:48", who: "kraftwerk",   verdict: "release", target: "cb-group/i",      note: "stalled · auto-released" },
+    { t: "01:18:02", who: "coltrane",    verdict: "ack",   target: "goal-merge-blockers", note: "claim" },
+    { t: "01:12:00", who: "automation",  verdict: "block", target: "PR #9708 · dashboard", note: "type errors" },
+    { t: "01:05:30", who: "nick0cave",   verdict: "merge", target: "PR #9706 · runtime", note: "ok" },
+    { t: "00:58:14", who: "automation",  verdict: "log",   target: "deploy.runtime",    note: "rev=da11b063 → staging" },
+    { t: "00:42:00", who: "automation",  verdict: "log",   target: "rotation.weekly",   note: "9 keepers eligible" },
+  ];
+  return (
+    <div className="dr-audit">
+      <div className="dr-audit-bar">
+        <span className="lbl">audit · last 60m</span>
+        <span className="meta">{rows.length} entries · signed</span>
+      </div>
+      <div className="dr-audit-body">
+        <div className="dr-aud-row dr-aud-h">
+          <span className="t">time</span>
+          <span className="who">actor</span>
+          <span className="vd">verdict</span>
+          <span className="tg">target</span>
+          <span className="nt">note</span>
+        </div>
+        {rows.map((r, i) => (
+          <div key={i} className="dr-aud-row">
+            <span className="t">{r.t}</span>
+            <span className="who">{r.who}</span>
+            <span className={"vd v-" + r.verdict}>{r.verdict}</span>
+            <span className="tg">{r.target}</span>
+            <span className="nt">{r.note}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CostPanel() {
+  // mock cost breakdown
+  const providers = [
+    { name: "anthropic",  used: 0.812, share: 0.42, calls: 1428, lat: 198 },
+    { name: "moonshot",   used: 0.341, share: 0.18, calls: 612,  lat: 312 },
+    { name: "openai",     used: 0.602, share: 0.31, calls: 891,  lat: 224 },
+    { name: "openrouter", used: 0.171, share: 0.09, calls: 244,  lat: 401 },
+  ];
+  const total = providers.reduce((a, p) => a + p.used, 0);
+  return (
+    <div className="dr-cost">
+      <div className="dr-cost-bar">
+        <span className="lbl">spend · today</span>
+        <span className="big">${total.toFixed(2)}</span>
+        <span className="meta">budget $20 · 9.6% used · projection $4.84/24h</span>
+      </div>
+      <div className="dr-cost-body">
+        <div className="dr-cost-bars">
+          {providers.map(p => (
+            <div key={p.name} className="dr-cost-row">
+              <span className="nm">{p.name}</span>
+              <span className="bar"><span className="fill" style={{ width: (p.share * 100).toFixed(1) + "%" }}></span></span>
+              <span className="used">${p.used.toFixed(3)}</span>
+              <span className="cl">{p.calls} calls</span>
+              <span className="lat">{p.lat}ms p50</span>
+            </div>
+          ))}
+        </div>
+        <div className="dr-cost-foot">
+          <span className="tip">Tip: anthropic at 42% share — cascade fallback to moonshot saved ~$0.18/h vs primary-only.</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── main Drawer component ──────────────────────────────────────
+function Drawer() {
+  const [drawer, setDrawer] = useDrawerState();
+  const dragRef = dUseRef(null);
+
+  // expose programmatic toggles for keyboard / IDE hint
+  dUseEffect(() => {
+    window.__drawerToggle = () => setDrawer({ open: !drawer.open });
+    window.__drawerSet = (patch) => setDrawer(patch);
+    return () => { window.__drawerToggle = null; window.__drawerSet = null; };
+  }, [drawer.open, setDrawer]);
+
+  // apply CSS var --h-drawer to document root so the grid can read it
+  dUseEffect(() => {
+    const h = drawer.open ? Math.max(120, Math.min(window.innerHeight * 0.8, drawer.height)) : 0;
+    document.documentElement.style.setProperty("--h-drawer", h + "px");
+    document.body.classList.toggle("drawer-open", drawer.open);
+  }, [drawer.open, drawer.height]);
+
+  // drag handling on the grip — vertical resize
+  const onDragStart = (e) => {
+    e.preventDefault();
+    const startY = e.clientY;
+    const startH = drawer.height;
+    const move = (ev) => {
+      const dy = startY - ev.clientY;
+      const next = Math.max(120, Math.min(window.innerHeight * 0.8, startH + dy));
+      document.documentElement.style.setProperty("--h-drawer", next + "px");
+    };
+    const up = (ev) => {
+      const dy = startY - ev.clientY;
+      const next = Math.max(120, Math.min(window.innerHeight * 0.8, startH + dy));
+      setDrawer({ height: next, open: true });
+      document.removeEventListener("mousemove", move);
+      document.removeEventListener("mouseup", up);
+    };
+    document.addEventListener("mousemove", move);
+    document.addEventListener("mouseup", up);
+  };
+
+  // double-click grip = snap toggle 30vh ↔ 60vh
+  const onDblClick = () => {
+    const vh = window.innerHeight;
+    const cur = drawer.height;
+    const target = Math.abs(cur - vh * 0.30) < Math.abs(cur - vh * 0.60)
+      ? Math.round(vh * 0.60)
+      : Math.round(vh * 0.30);
+    setDrawer({ height: target, open: true });
+  };
+
+  // click tab — open if closed, switch if same
+  const clickTab = (id) => {
+    if (!drawer.open) setDrawer({ open: true, tab: id });
+    else if (drawer.tab !== id) setDrawer({ tab: id });
+    else setDrawer({ open: false });   // click active tab again → close
+  };
+
+  const close = () => setDrawer({ open: false });
+
+  const Panel = dUseMemo(() => {
+    if (drawer.tab === "terminal") return TerminalPanel;
+    if (drawer.tab === "output")   return OutputPanel;
+    if (drawer.tab === "cascade")  return CascadePanel;
+    if (drawer.tab === "audit")    return AuditPanel;
+    if (drawer.tab === "cost")     return CostPanel;
+    return TerminalPanel;
+  }, [drawer.tab]);
+
+  return (
+    <div className={"drawer " + (drawer.open ? "open" : "closed")}
+         data-screen-label="Bottom Drawer">
+      <div className="dr-grip" ref={dragRef}
+           onMouseDown={drawer.open ? onDragStart : undefined}
+           onDoubleClick={drawer.open ? onDblClick : undefined}
+           title={drawer.open ? "drag to resize · double-click to snap" : ""}>
+        <span className="dr-grip-bar"></span>
+      </div>
+      <div className="dr-bar">
+        <div className="dr-tabs">
+          {DRAWER_TABS.map(t => (
+            <button key={t.id}
+                    className={"dr-tab" + (drawer.tab === t.id && drawer.open ? " on" : "")}
+                    onClick={() => clickTab(t.id)}
+                    title={t.label}>
+              <span className="g">{t.glyph}</span>
+              <span className="l">{t.label}</span>
+              {t.count != null && <span className="ct">{t.count}</span>}
+            </button>
+          ))}
+        </div>
+        <div className="dr-actions">
+          {drawer.open && (
+            <>
+              <button className="dr-act"
+                      onClick={() => {
+                        const vh = window.innerHeight;
+                        setDrawer({ height: Math.round(vh * 0.30) });
+                      }}
+                      title="snap 30%">▭</button>
+              <button className="dr-act"
+                      onClick={() => {
+                        const vh = window.innerHeight;
+                        setDrawer({ height: Math.round(vh * 0.60) });
+                      }}
+                      title="snap 60%">▣</button>
+              <button className="dr-act"
+                      onClick={() => {
+                        const url = new URL(window.location.href);
+                        url.searchParams.set("widget", "drawer-" + drawer.tab);
+                        window.open(url.toString(), "_blank", "noopener");
+                      }}
+                      title="pop out to new tab">↗</button>
+              <button className="dr-act dr-close" onClick={close} title="close">✕</button>
+            </>
+          )}
+          {!drawer.open && (
+            <span className="dr-hint">click a tab to open · ⌃` toggles</span>
+          )}
+        </div>
+      </div>
+      {drawer.open && (
+        <div className="dr-body">
+          <Panel />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── keyboard shortcut: Ctrl+` toggles ──────────────────────────
+(function installDrawerHotkey() {
+  if (window.__drawerHotkey) return;
+  window.__drawerHotkey = true;
+
+  // ctrl/cmd + ` toggles open/closed
+  document.addEventListener("keydown", (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === "`") {
+      e.preventDefault();
+      window.dispatchEvent(new CustomEvent("masc-drawer-toggle"));
+    }
+  });
+
+  // listen for programmatic events (from IDE's drawer hint button etc.)
+  window.addEventListener("masc-drawer-toggle", () => {
+    if (!window.useCockpitState) return;
+    // bypass hook: read singleton directly via the module-internal __state
+    const ev = window.__cockpit_state || null;
+    // simpler: push a custom postMessage that any mounted Drawer hook will receive via state singleton
+    // we trigger by directly invoking the persist with a flipped open flag
+    const cur = (window.MASC_EXT && window.MASC_EXT.initialState) ? null : null;
+    // Use a global helper installed below
+    if (window.__drawerToggle) window.__drawerToggle();
+  });
+  window.addEventListener("masc-drawer-set", (e) => {
+    if (window.__drawerSet) window.__drawerSet(e.detail || {});
+  });
+})();
+
+window.Drawer = Drawer;
+// expose individual panels for pop-out viewing
+window.__DrawerPanel = function ({ kind }) {
+  if (kind === "terminal") return <TerminalPanel/>;
+  if (kind === "output")   return <OutputPanel/>;
+  if (kind === "cascade")  return <CascadePanel/>;
+  if (kind === "audit")    return <AuditPanel/>;
+  if (kind === "cost")     return <CostPanel/>;
+  return <div style={{padding:20}}>unknown drawer panel: {kind}</div>;
+};

--- a/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
@@ -124,8 +124,9 @@ function OutputPanel() {
 }
 
 function CascadePanel() {
-  const D = window.MASC_DATA || {};
-  const cascades = (D.cascade && Array.isArray(D.cascade) ? D.cascade : []).slice(0, 6);
+  // Use MASC_P2.cascadeAudit (array of cascade runs with hops) rather than
+  // MASC_DATA.cascade which is a single object without the required array shape.
+  const cascades = ((window.MASC_P2 && window.MASC_P2.cascadeAudit) || []).slice(0, 6);
   return (
     <div className="dr-cascade">
       <div className="dr-cascade-bar">
@@ -138,15 +139,15 @@ function CascadePanel() {
           <div key={i} className="dr-csc">
             <div className="dr-csc-h">
               <span className="id">{c.id || ("csc-" + i)}</span>
-              <span className="prompt">{c.prompt || "(no prompt)"}</span>
+              <span className="prompt">{[c.cascade || "(unknown)", c.trigger].filter(Boolean).join(" · ")}</span>
               <span className={"out " + (c.outcome === "ok" ? "ok" : "fail")}>{c.outcome || "—"}</span>
             </div>
             <div className="dr-csc-hops">
               {(c.hops || []).map((h, hi) => (
                 <span key={hi} className={"hop " + (h.status || "")}>
                   <span className="ix">{hi + 1}</span>
-                  <span className="prov">{h.provider || h.name}</span>
-                  <span className="ms">{h.latency_ms || h.ms || "—"}ms</span>
+                  <span className="prov">{h.model || h.provider || h.name}</span>
+                  <span className="ms">{h.ms || h.latency_ms || "—"}ms</span>
                 </span>
               ))}
             </div>
@@ -249,7 +250,9 @@ function Drawer() {
 
   // apply CSS var --h-drawer to document root so the grid can read it
   dUseEffect(() => {
-    const h = drawer.open ? Math.max(120, Math.min(window.innerHeight * 0.8, drawer.height)) : 0;
+    // Keep the bar (26px) visible when closed so users can click tabs to open.
+    const CLOSED_H = 26; // matches .drawer.closed min-height in drawer.css
+    const h = drawer.open ? Math.max(120, Math.min(window.innerHeight * 0.8, drawer.height)) : CLOSED_H;
     document.documentElement.style.setProperty("--h-drawer", h + "px");
     document.body.classList.toggle("drawer-open", drawer.open);
   }, [drawer.open, drawer.height]);

--- a/dashboard/design-system/ui_kits/cockpit/FocusMode.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/FocusMode.jsx
@@ -1,0 +1,97 @@
+/* global React */
+/* FocusMode — bottom-right control cluster.
+
+   Click → small popover with:
+     - toggle focus mode (also F11 / Cmd+\)
+     - show/hide status tray
+     - any future global toggles
+
+   Focus mode hides all top chrome (topbar/ticker/kpi/lifeline) and the
+   bottom status bar so the central plane goes full-bleed. State persists
+   in localStorage via useCockpitState. */
+
+const { useEffect: _fmUseEffect, useCallback: _fmUseCb, useState: _fmUseState, useRef: _fmUseRef } = React;
+
+function FocusToggle() {
+  const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{focus:false, trayHidden:false}, ()=>{}]);
+  const focus = !!cs.focus;
+  const trayHidden = !!cs.trayHidden;
+  const [open, setOpen] = _fmUseState(false);
+  const ref = _fmUseRef(null);
+
+  const toggleFocus = _fmUseCb(() => {
+    setCs({ focus: !focus });
+  }, [focus, setCs]);
+
+  // apply body class
+  _fmUseEffect(() => {
+    document.body.classList.toggle("focus-mode", focus);
+    return () => document.body.classList.remove("focus-mode");
+  }, [focus]);
+
+  // keyboard shortcut for focus mode
+  _fmUseEffect(() => {
+    const onKey = (e) => {
+      const isFocusKey =
+        e.key === "F11" ||
+        ((e.ctrlKey || e.metaKey) && e.key === "\\");
+      if (isFocusKey && !e.shiftKey && !e.altKey) {
+        const t = e.target;
+        const tag = t && t.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || (t && t.isContentEditable)) return;
+        e.preventDefault();
+        toggleFocus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [toggleFocus]);
+
+  // outside click closes menu
+  _fmUseEffect(() => {
+    if (!open) return;
+    const onDoc = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    };
+    const onKey = (e) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="focus-cluster" ref={ref}>
+      {open && (
+        <div className="focus-menu">
+          <div className="focus-menu-h">view</div>
+          <button className={"focus-menu-row" + (focus ? " on" : "")}
+                  onClick={() => { toggleFocus(); }}>
+            <span className="focus-menu-k">{focus ? "✓" : " "}</span>
+            <span className="focus-menu-l">focus mode</span>
+            <span className="focus-menu-sub">F11</span>
+          </button>
+          <button className={"focus-menu-row" + (!trayHidden ? " on" : "")}
+                  onClick={() => setCs({ trayHidden: !trayHidden })}>
+            <span className="focus-menu-k">{!trayHidden ? "✓" : " "}</span>
+            <span className="focus-menu-l">status tray</span>
+            <span className="focus-menu-sub">{trayHidden ? "hidden" : "shown"}</span>
+          </button>
+        </div>
+      )}
+      <button
+        className={"focus-toggle " + (focus ? "on" : "") + (open ? " menu-open" : "")}
+        onClick={() => setOpen(!open)}
+        title="view options"
+        aria-pressed={focus}
+        aria-expanded={open}>
+        <span className="focus-icon">⛶</span>
+        <span className="focus-label">{focus ? "exit focus" : "focus"}</span>
+      </button>
+    </div>
+  );
+}
+
+window.FocusToggle = FocusToggle;

--- a/dashboard/design-system/ui_kits/cockpit/FocusMode.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/FocusMode.jsx
@@ -85,7 +85,7 @@ function FocusToggle() {
         className={"focus-toggle " + (focus ? "on" : "") + (open ? " menu-open" : "")}
         onClick={() => setOpen(!open)}
         title="view options"
-        aria-pressed={focus}
+        aria-haspopup="menu"
         aria-expanded={open}>
         <span className="focus-icon">⛶</span>
         <span className="focus-label">{focus ? "exit focus" : "focus"}</span>

--- a/dashboard/design-system/ui_kits/cockpit/Panels.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Panels.jsx
@@ -2,6 +2,11 @@
 const { useState } = React;
 const _Wx = (props) => (window.WxHead ? React.createElement(window.WxHead, props) : null);
 const _useCol = (id) => (window.useCollapsed ? window.useCollapsed(id) : [false, () => {}]);
+const _isToggleKey = (e) => e.key === "Enter" || e.key === " " || e.key === "Spacebar";
+const _fromNestedControl = (e) =>
+  e.target !== e.currentTarget &&
+  e.target.closest &&
+  e.target.closest("a,button,input,textarea,select");
 
 const keeperTone = { "nick0cave":"brass", "masc-improver":"ok", "sangsu":"info", "qa-king":"err", "rama":"stalled", "scholar":"idle", "taskmaster":"idle", "velvet-hammer":"idle" };
 const statusColor = s => ({ running:"running", ok:"ok", pending:"info", fail:"err", stalled:"stalled", idle:"idle", queued:"queued", done:"done", active:"active" }[s] || "idle");
@@ -10,8 +15,15 @@ const statusColor = s => ({ running:"running", ok:"ok", pending:"info", fail:"er
 // Section header — collapsible per-section, no outer wx-head wrapper
 function SideSectHead({ id, label, count, right, onCollapseAll, popoutId }) {
   const [col, toggle] = _useCol(id);
+  const onKeyDown = (e) => {
+    if (_fromNestedControl(e)) return;
+    if (_isToggleKey(e)) {
+      e.preventDefault();
+      toggle();
+    }
+  };
   return (
-    <div className="side-sect-h sx" onClick={toggle} role="button" aria-expanded={!col}>
+    <div className="side-sect-h sx" onClick={toggle} onKeyDown={onKeyDown} role="button" tabIndex={0} aria-expanded={!col}>
       <span className="sx-chev">{col ? "▸" : "▾"}</span>
       <span className="sx-lbl">{label}</span>
       {count != null && <span className="count">{count}</span>}
@@ -315,8 +327,15 @@ function Deck({ tasks, goals, providers, cascade }) {
 // ============== Rail ==============
 function RailSectHead({ id, label, count, right, onCollapseAll, popoutId }) {
   const [col, toggle] = _useCol(id);
+  const onKeyDown = (e) => {
+    if (_fromNestedControl(e)) return;
+    if (_isToggleKey(e)) {
+      e.preventDefault();
+      toggle();
+    }
+  };
   return (
-    <div className="rail-sect-h sx" onClick={toggle} role="button" aria-expanded={!col}>
+    <div className="rail-sect-h sx" onClick={toggle} onKeyDown={onKeyDown} role="button" tabIndex={0} aria-expanded={!col}>
       <span className="sx-chev">{col ? "▸" : "▾"}</span>
       <span className="sx-lbl">{label}</span>
       {count != null && <span className="count">{count}</span>}

--- a/dashboard/design-system/ui_kits/cockpit/Panels.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Panels.jsx
@@ -1,17 +1,58 @@
-/* global React, MASC_DATA */
+/* global React, MASC_DATA, WxHead, useCollapsed */
 const { useState } = React;
+const _Wx = (props) => (window.WxHead ? React.createElement(window.WxHead, props) : null);
+const _useCol = (id) => (window.useCollapsed ? window.useCollapsed(id) : [false, () => {}]);
 
 const keeperTone = { "nick0cave":"brass", "masc-improver":"ok", "sangsu":"info", "qa-king":"err", "rama":"stalled", "scholar":"idle", "taskmaster":"idle", "velvet-hammer":"idle" };
 const statusColor = s => ({ running:"running", ok:"ok", pending:"info", fail:"err", stalled:"stalled", idle:"idle", queued:"queued", done:"done", active:"active" }[s] || "idle");
 
 // ============== Sidebar ==============
+// Section header — collapsible per-section, no outer wx-head wrapper
+function SideSectHead({ id, label, count, right, onCollapseAll, popoutId }) {
+  const [col, toggle] = _useCol(id);
+  return (
+    <div className="side-sect-h sx" onClick={toggle} role="button" aria-expanded={!col}>
+      <span className="sx-chev">{col ? "▸" : "▾"}</span>
+      <span className="sx-lbl">{label}</span>
+      {count != null && <span className="count">{count}</span>}
+      {right}
+      {popoutId && (
+        <a className="wx-popout"
+           href={"?widget=" + popoutId}
+           target="_blank" rel="noopener"
+           onClick={(e)=>e.stopPropagation()}
+           title="open in new tab">↗</a>
+      )}
+      {onCollapseAll && (
+        <span className="sx-rail" onClick={(e)=>{ e.stopPropagation(); onCollapseAll(); }} title="collapse rail">«</span>
+      )}
+    </div>
+  );
+}
+function SideSectBody({ id, children, style }) {
+  const [col] = _useCol(id);
+  if (col) return null;
+  return <div className="side-sect-body" style={style}>{children}</div>;
+}
+
 function Sidebar({ keepers, goals, selKeeper, setSelKeeper, selGoal, setSelGoal, selectedKeepers, toggleKeeper }) {
   const sk = selectedKeepers || new Set();
+  const [colSide, toggleSide] = _useCol("sidebar");
+  if (colSide) {
+    return (
+      <aside className="side wx-collapsed" onClick={toggleSide} title="expand sidebar">
+        <div className="wx-rail-vlabel">FLEET · GOALS</div>
+      </aside>
+    );
+  }
   return (
     <aside className="side">
       <div className="side-sect">
-        <div className="side-sect-h"><span>Fleet</span><span className="count">{keepers.filter(k=>k.status!=="idle").length}/{keepers.length}</span></div>
-        <div className="side-sect-body">
+        <SideSectHead id="sidebar.fleet" label="Fleet"
+          count={`${keepers.filter(k=>k.status!=="idle").length}/${keepers.length}`}
+          popoutId="sidebar"
+          onCollapseAll={toggleSide} />
+        <SideSectBody id="sidebar.fleet">
           {keepers.map(k => (
             <div key={k.id}
                  className={"keeper-row " + (k.status==="idle"?"idle ":"") + (selKeeper===k.id?"selected":"")}
@@ -21,16 +62,11 @@ function Sidebar({ keepers, goals, selKeeper, setSelKeeper, selGoal, setSelGoal,
               <span className="meta">{k.task}</span>
             </div>
           ))}
-        </div>
+        </SideSectBody>
       </div>
       <div className="side-sect">
-        <div className="side-sect-h side-keepers">
-          <div className="h" style={{display:"flex",alignItems:"center",gap:6,width:"100%"}}>
-            <span>Filter</span>
-            <span className="cnt">{sk.size}/{keepers.length}</span>
-          </div>
-        </div>
-        <div className="side-sect-body" style={{paddingTop:0}}>
+        <SideSectHead id="sidebar.filter" label="Filter" count={`${sk.size}/${keepers.length}`} />
+        <SideSectBody id="sidebar.filter" style={{paddingTop:0}}>
           <div className="side-keepers">
             <div className="chips">
               {keepers.map(k => {
@@ -46,11 +82,11 @@ function Sidebar({ keepers, goals, selKeeper, setSelKeeper, selGoal, setSelGoal,
               })}
             </div>
           </div>
-        </div>
+        </SideSectBody>
       </div>
-      <div className="side-sect" style={{flex:1, minHeight:0}}>
-        <div className="side-sect-h"><span>Goals</span><span className="count">{goals.length}</span></div>
-        <div className="side-sect-body">
+      <div className="side-sect side-sect-goals">
+        <SideSectHead id="sidebar.goals" label="Goals" count={goals.length} />
+        <SideSectBody id="sidebar.goals">
           {goals.map(g => (
             <div key={g.id}
                  className={"goal-row " + (g.status==="done"?"done ":"") + (selGoal===g.id?"selected":"")}
@@ -66,7 +102,7 @@ function Sidebar({ keepers, goals, selKeeper, setSelKeeper, selGoal, setSelGoal,
               </div>
             </div>
           ))}
-        </div>
+        </SideSectBody>
       </div>
     </aside>
   );
@@ -101,6 +137,7 @@ function Swimlanes({ keepers, laneEvents }) {
 // ============== Deck ==============
 function Deck({ tasks, goals, providers, cascade }) {
   const [tab, setTab] = useState("board");
+  const [colDeck] = _useCol("deck");
   const tabs = [
     { id:"board",     label:"Board",     ct: tasks.filter(t=>t.status!=="queued").length },
     { id:"tasks",     label:"Tasks",     ct: tasks.length },
@@ -118,7 +155,8 @@ function Deck({ tasks, goals, providers, cascade }) {
   ];
 
   return (
-    <div className="deck">
+    <div className={"deck" + (colDeck ? " wx-collapsed" : "")}>
+      {_Wx({ id:"deck", title:"Deck", meta: `${tab} · ${tasks.length} tasks`, popoutId: "deck" })}
       <div className="deck-tabs">
         {tabs.map(t => (
           <button key={t.id} className={"deck-tab " + (tab===t.id?"active":"")} onClick={()=>setTab(t.id)}>
@@ -275,13 +313,48 @@ function Deck({ tasks, goals, providers, cascade }) {
 }
 
 // ============== Rail ==============
+function RailSectHead({ id, label, count, right, onCollapseAll, popoutId }) {
+  const [col, toggle] = _useCol(id);
+  return (
+    <div className="rail-sect-h sx" onClick={toggle} role="button" aria-expanded={!col}>
+      <span className="sx-chev">{col ? "▸" : "▾"}</span>
+      <span className="sx-lbl">{label}</span>
+      {count != null && <span className="count">{count}</span>}
+      {right}
+      {popoutId && (
+        <a className="wx-popout"
+           href={"?widget=" + popoutId}
+           target="_blank" rel="noopener"
+           onClick={(e)=>e.stopPropagation()}
+           title="open in new tab">↗</a>
+      )}
+      {onCollapseAll && (
+        <span className="sx-rail" onClick={(e)=>{ e.stopPropagation(); onCollapseAll(); }} title="collapse rail">»</span>
+      )}
+    </div>
+  );
+}
+function RailSectBody({ id, children, style, className }) {
+  const [col] = _useCol(id);
+  if (col) return null;
+  return <div className={"rail-sect-body " + (className||"")} style={style}>{children}</div>;
+}
+
 function Rail({ events, cascade }) {
   const nudges = (window.MASC_P2 && window.MASC_P2.nudges) || [];
+  const [colRail, toggleRail] = _useCol("rail");
+  if (colRail) {
+    return (
+      <aside className="rail wx-collapsed" onClick={toggleRail} title="expand activity rail">
+        <div className="wx-rail-vlabel">ACTIVITY · NUDGES</div>
+      </aside>
+    );
+  }
   return (
     <aside className="rail">
       <div className="rail-sect flex">
-        <div className="rail-sect-h"><span>Activity Feed</span><span className="count">{events.length}</span></div>
-        <div className="rail-sect-body">
+        <RailSectHead id="rail.activity" label="Activity Feed" count={events.length} popoutId="rail" onCollapseAll={toggleRail} />
+        <RailSectBody id="rail.activity">
           {events.map((ev,i) => (
             <div key={i} className="activity">
               <span className="t">{ev.t.slice(0,8)}</span>
@@ -292,14 +365,11 @@ function Rail({ events, cascade }) {
               </span>
             </div>
           ))}
-        </div>
+        </RailSectBody>
       </div>
       <div className="rail-sect">
-        <div className="rail-sect-h">
-          <span>Operator Nudges</span>
-          <span className="count">{nudges.filter(n => !n.ack).length}/{nudges.length}</span>
-        </div>
-        <div className="rail-nudges">
+        <RailSectHead id="rail.nudges" label="Operator Nudges" count={`${nudges.filter(n => !n.ack).length}/${nudges.length}`} />
+        <RailSectBody id="rail.nudges" className="rail-nudges">
           {nudges.slice(0, 5).map(n => (
             <div key={n.id} className="rail-nudge">
               <span className={"ch "+n.channel}>{n.channel}</span>
@@ -311,11 +381,11 @@ function Rail({ events, cascade }) {
               <span className={"ack "+(n.ack ? "y" : "n")}>{n.ack ? "✓" : "…"}</span>
             </div>
           ))}
-        </div>
+        </RailSectBody>
       </div>
       <div className="rail-sect">
-        <div className="rail-sect-h"><span>Last Cascade</span><span className="count">{cascade.total_ms}ms</span></div>
-        <div className="rail-sect-body" style={{padding:"0 var(--sp-3) var(--sp-3)"}}>
+        <RailSectHead id="rail.cascade" label="Last Cascade" count={`${cascade.total_ms}ms`} />
+        <RailSectBody id="rail.cascade" style={{padding:"0 var(--sp-3) var(--sp-3)"}}>
           {cascade.steps.map((s,i)=>(
             <div key={i} style={{
               display:"grid", gridTemplateColumns:"80px auto 1fr auto",
@@ -331,7 +401,7 @@ function Rail({ events, cascade }) {
               <span style={{color:"var(--color-fg-secondary)",fontVariantNumeric:"tabular-nums"}}>{s.ms}ms</span>
             </div>
           ))}
-        </div>
+        </RailSectBody>
       </div>
     </aside>
   );
@@ -339,12 +409,39 @@ function Rail({ events, cascade }) {
 
 // ============== Composer ==============
 function Composer({ selKeeper }) {
+  const [val, setVal] = useState("");
+  const [hist, setHist] = useState([
+    { ts:"16:31", kp:"nick0cave", cmd:"keeper.claim(t-9f2a)",  ok:true  },
+    { ts:"16:24", kp:"sangsu",    cmd:"keeper.trace(cascade-3f19)", ok:true },
+    { ts:"16:18", kp:"qa-king",   cmd:"verify(suite-merge-blockers)", ok:false },
+  ]);
+  const ctxLabel = (window.MASC_P2 && window.MASC_P2.repos)
+    ? `${selKeeper} → ${(window.MASC_EXT?.initialState?.().repo) || "runtime"} / ${(window.MASC_EXT?.initialState?.().branch) || "main"}`
+    : selKeeper;
+  const submit = () => {
+    if (!val.trim()) return;
+    setHist(h => [{ ts:"now", kp:selKeeper, cmd: val.trim(), ok:true }, ...h.slice(0,4)]);
+    setVal("");
+  };
   return (
     <div className="compose">
-      <span className="compose-prompt">▸ {selKeeper}:</span>
-      <input className="compose-input" placeholder="keeper.claim(task) · keeper.trace(cascade_id) · /goal goal-keeper-clarity …" />
+      <span className="compose-prompt" title={ctxLabel}>▸ {selKeeper}:</span>
+      <input className="compose-input"
+             value={val}
+             onChange={(e)=>setVal(e.target.value)}
+             onKeyDown={(e)=>{ if (e.key === "Enter") submit(); }}
+             placeholder="keeper.claim(task) · keeper.trace(cascade_id) · /goal goal-keeper-clarity …" />
+      <div className="compose-hist" title="recent commands">
+        {hist.slice(0,3).map((h,i) => (
+          <span key={i} className={"hb " + (h.ok?"ok":"err")}>
+            <span className="ht">{h.ts}</span>
+            <span className="hk">{h.kp}</span>
+            <span className="hc">{h.cmd}</span>
+          </span>
+        ))}
+      </div>
       <span className="compose-hint">⏎ run · ⌘K palette · ? help</span>
-      <button className="compose-btn">Run</button>
+      <button className="compose-btn" onClick={submit}>Run</button>
     </div>
   );
 }

--- a/dashboard/design-system/ui_kits/cockpit/Planes.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Planes.jsx
@@ -6,9 +6,8 @@
 const { useState: usePlaneState } = React;
 
 // ─── shared header ───────────────────────────────────────────
-function PlaneHeader({ title, subtitle, branch, keepers }) {
+function PlaneHeader({ title, subtitle, branch, keepers, popoutId }) {
   const sk = keepers || new Set();
-  const planeId = "plane-" + (title || "").toLowerCase().trim();
   return (
     <div className="plane-hdr">
       <span className="ti">{title}</span>
@@ -17,23 +16,25 @@ function PlaneHeader({ title, subtitle, branch, keepers }) {
         <span>⎇ <span className="br">{branch || "main"}</span></span>
         <span>·</span>
         <span><span className="kp">{sk.size}</span> keepers selected</span>
-        <a className="wx-popout"
-           href={"?widget=" + planeId}
-           target="_blank" rel="noopener"
-           title="open plane in new tab"
-           style={{marginLeft:"8px"}}>↗</a>
+        {popoutId && (
+          <a className="wx-popout"
+             href={"?widget=" + popoutId}
+             target="_blank" rel="noopener"
+             title="open plane in new tab"
+             style={{marginLeft:"8px"}}>↗</a>
+        )}
       </span>
     </div>
   );
 }
 
 // ─── shared tabbed shell ─────────────────────────────────────
-function PlaneShell({ title, subtitle, branch, keepers, tabs, defaultTab }) {
+function PlaneShell({ title, subtitle, branch, keepers, tabs, defaultTab, popoutId }) {
   const [tab, setTab] = usePlaneState(defaultTab || tabs[0].id);
   const cur = tabs.find(t => t.id === tab) || tabs[0];
   return (
     <div className="plane">
-      <PlaneHeader title={title} subtitle={subtitle} branch={branch} keepers={keepers} />
+      <PlaneHeader title={title} subtitle={subtitle} branch={branch} keepers={keepers} popoutId={popoutId} />
       <div className="plane-tabs">
         {tabs.map(t => (
           <button key={t.id} className={tab === t.id ? "active" : ""} onClick={() => setTab(t.id)}>{t.label}</button>
@@ -53,6 +54,7 @@ function WorkPlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Work Plane" subtitle="Goals · Tasks · Accountability"
+      popoutId="plane-work"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"goal-h",   label:"Goal · Horizon",     render: () => <window.GoalHorizonTrack/> },
@@ -75,6 +77,7 @@ function CommsPlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Comms Plane" subtitle="Board · Messages · Composer v2"
+      popoutId="plane-comms"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"bd-feed", label:"Board · Feed",      render: () => <window.BoardFeed/> },
@@ -98,6 +101,7 @@ function ObservePlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Observability" subtitle="Cascade · Audit · Safe Autonomy · Cost · Heuristic"
+      popoutId="plane-observe"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"cs-list", label:"Cascade · List",       render: () => <window.CascadeList/> },
@@ -127,6 +131,7 @@ function CognitionPlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Cognition" subtitle="Keeper Inspector · Decisions · Memory · Episodes · Autoresearch"
+      popoutId="plane-cognition"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"ki-bdi",  label:"Keeper · BDI",         render: () => <window.KeeperBDIPanel/> },
@@ -186,7 +191,7 @@ function IdePlane({ branch, keepers }) {
   const centerPanelId = `ide-v2-center-${mode}`;
   return (
     <div className="plane ide-v2 ide-v3" role="region" aria-label="IDE Plane">
-      <PlaneHeader title="IDE" subtitle="tree · editor · PR · graph · search" branch={branch} keepers={keepers} />
+      <PlaneHeader title="IDE" subtitle="tree · editor · PR · graph · search" branch={branch} keepers={keepers} popoutId="plane-ide" />
       <div className="ide-v2-modebar ide-v3-modebar">
         <div className="ide-v2-branch">
           <span className="lbl">branch</span>

--- a/dashboard/design-system/ui_kits/cockpit/Planes.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Planes.jsx
@@ -180,12 +180,7 @@ function IdePlane({ branch, keepers }) {
 
   // open shared drawer with terminal tab as a hint
   const openTerminal = () => {
-    const cur = (window.MASC_EXT && window.useCockpitState) ? null : null;
-    if (window.useCockpitState) {
-      // push a state change via the singleton helper
-      const ev = new CustomEvent("masc-drawer-set", { detail: { open: true, tab: "terminal" }});
-      window.dispatchEvent(ev);
-    }
+    window.dispatchEvent(new CustomEvent("masc-drawer-set", { detail: { open: true, tab: "terminal" } }));
   };
 
   const centerPanelId = `ide-v2-center-${mode}`;

--- a/dashboard/design-system/ui_kits/cockpit/Planes.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Planes.jsx
@@ -8,6 +8,7 @@ const { useState: usePlaneState } = React;
 // ─── shared header ───────────────────────────────────────────
 function PlaneHeader({ title, subtitle, branch, keepers }) {
   const sk = keepers || new Set();
+  const planeId = "plane-" + (title || "").toLowerCase().trim();
   return (
     <div className="plane-hdr">
       <span className="ti">{title}</span>
@@ -16,6 +17,11 @@ function PlaneHeader({ title, subtitle, branch, keepers }) {
         <span>⎇ <span className="br">{branch || "main"}</span></span>
         <span>·</span>
         <span><span className="kp">{sk.size}</span> keepers selected</span>
+        <a className="wx-popout"
+           href={"?widget=" + planeId}
+           target="_blank" rel="noopener"
+           title="open plane in new tab"
+           style={{marginLeft:"8px"}}>↗</a>
       </span>
     </div>
   );
@@ -139,13 +145,15 @@ function CognitionPlane({ branch, keepers }) {
 }
 
 // ═════════════════════════════════════════════════════════════
-// IDE PLANE — Phase 3 Code IDE v2
+// IDE PLANE — Phase 3 Code IDE v2 (re-designed in Phase B-C)
+// - bottom terminal removed (use shared Drawer instead)
+// - keeper chips removed (sidebar already shows fleet)
+// - modebar: branch + mode tabs only (no terminal toggle)
+// - wide modes (review/merge/graph/search) use full center; edit shows inspector right rail
 // ═════════════════════════════════════════════════════════════
 function IdePlane({ branch, keepers }) {
   const [mode, setMode] = usePlaneState("edit");
-  const [terminalOpen, setTerminalOpen] = usePlaneState(true);
   const ctx = { branch, keepers };
-  const keeperCount = keepers ? keepers.size : 0;
 
   const center =
     mode === "review" ? <window.IxEditReview {...ctx}/> :
@@ -154,44 +162,60 @@ function IdePlane({ branch, keepers }) {
     mode === "search" ? <window.IxSearch {...ctx}/> :
     <window.IxEditAttrib {...ctx}/>;
 
+  // edit mode shows inspector rail on right;
+  // review/merge/graph/search use center wide
   const right =
-    mode === "review" ? <window.IxPrThread {...ctx}/> :
-    mode === "merge" || mode === "graph" || mode === "search" ? null :
-    <div className="ide-v2-right-stack">
-      <window.IxPrHeader {...ctx}/>
-      <window.IxPrChecks {...ctx}/>
-    </div>;
+    mode === "edit" ?
+      <div className="ide-v2-right-stack">
+        <window.IxPrHeader {...ctx}/>
+        <window.IxPrChecks {...ctx}/>
+      </div>
+    : mode === "review" ? <window.IxPrThread {...ctx}/>
+    : null;
+
+  // open shared drawer with terminal tab as a hint
+  const openTerminal = () => {
+    const cur = (window.MASC_EXT && window.useCockpitState) ? null : null;
+    if (window.useCockpitState) {
+      // push a state change via the singleton helper
+      const ev = new CustomEvent("masc-drawer-set", { detail: { open: true, tab: "terminal" }});
+      window.dispatchEvent(ev);
+    }
+  };
 
   const centerPanelId = `ide-v2-center-${mode}`;
   return (
-    <div className="plane ide-v2" role="region" aria-label="IDE Plane">
-      <PlaneHeader title="IDE Plane" subtitle="Tree · editor · PR · graph · terminal/search." branch={branch} keepers={keepers} />
-      <div className="ide-v2-modebar">
-        <div className="ide-v2-branch" aria-label={`Active branch ${branch || "main"}, ${keeperCount} keepers, worktree active`}>
+    <div className="plane ide-v2 ide-v3" role="region" aria-label="IDE Plane">
+      <PlaneHeader title="IDE" subtitle="tree · editor · PR · graph · search" branch={branch} keepers={keepers} />
+      <div className="ide-v2-modebar ide-v3-modebar">
+        <div className="ide-v2-branch">
           <span className="lbl">branch</span>
           <span className="name">{branch || "main"}</span>
-          <span className="meta">{keeperCount} keepers · worktree active</span>
+          <span className="meta">worktree active · 14 changed · 3 staged</span>
         </div>
         <div className="ide-v2-modes" role="tablist" aria-label="IDE mode">
           {["edit","review","merge","graph","search"].map(m => (
-            <button key={m} type="button" role="tab" id={`ide-v2-mode-${m}`} aria-selected={mode === m} aria-controls={`ide-v2-center-${m}`} tabIndex={mode === m ? 0 : -1} className={mode === m ? "active" : ""} onClick={() => setMode(m)}>{m}</button>
+            <button key={m} type="button" role="tab"
+                    id={`ide-v2-mode-${m}`} aria-selected={mode === m}
+                    aria-controls={`ide-v2-center-${m}`}
+                    tabIndex={mode === m ? 0 : -1}
+                    className={mode === m ? "active" : ""}
+                    onClick={() => setMode(m)}>{m}</button>
           ))}
         </div>
-        <button type="button" aria-pressed={terminalOpen} aria-controls="ide-v2-terminal" className={`ide-v2-terminal-toggle ${terminalOpen ? "active" : ""}`} onClick={() => setTerminalOpen(v => !v)}>
-          terminal
+        <button type="button"
+                className="ide-v3-drawer-hint"
+                onClick={openTerminal}
+                title="open shared bottom drawer (Terminal/Output/Cascade/Audit/Cost)">
+          ⌃` drawer
         </button>
       </div>
-      <div className={`ide-v2-body ${right ? "" : "wide"} ${terminalOpen ? "term-open" : ""}`}>
+      <div className={`ide-v2-body ide-v3-body ${right ? "" : "wide"}`}>
         <div className="ide-v2-tree" role="region" aria-label="File tree">
           <window.IxTreeDiff {...ctx}/>
         </div>
         <div className="ide-v2-center" role="tabpanel" id={centerPanelId} aria-labelledby={`ide-v2-mode-${mode}`}>{center}</div>
-        {right && <div className="ide-v2-right" role="region" aria-label="PR context rail">{right}</div>}
-        {terminalOpen && (
-          <div className="ide-v2-terminal" id="ide-v2-terminal" role="region" aria-label="Cascade-aware terminal">
-            <window.IxTerm {...ctx}/>
-          </div>
-        )}
+        {right && <div className="ide-v2-right" role="region" aria-label="Inspector rail">{right}</div>}
       </div>
     </div>
   );

--- a/dashboard/design-system/ui_kits/cockpit/StatusTray.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/StatusTray.jsx
@@ -1,0 +1,125 @@
+/* global React, MASC_DATA */
+/* StatusTray — Slack-style bottom-left status dock.
+   Always-visible row of compact dot indicators that summarize the chrome
+   we hide in focus mode (kpi spotlight, lifeline pulse, latest ticker
+   event, active keepers count, drawer state).
+
+   Each dot is clickable → opens a small popover with the full widget
+   inline. This way focus mode loses no information — just compresses it.
+
+   Lives in bottom-left so it doesn't fight the FocusToggle (bottom-right)
+   or the Composer (which is hidden in focus mode anyway). */
+
+const { useState: _stUseState, useEffect: _stUseEffect, useRef: _stUseRef } = React;
+
+function _useTrayPop() {
+  const [open, setOpen] = _stUseState(null); // 'kpi' | 'life' | 'ticker' | 'keepers' | null
+  const ref = _stUseRef(null);
+  _stUseEffect(() => {
+    if (!open) return;
+    const onDoc = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(null);
+    };
+    const onKey = (e) => { if (e.key === "Escape") setOpen(null); };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+  return [open, setOpen, ref];
+}
+
+function _kpiSpotlight(D) {
+  const evs = (D && D.events) || [];
+  const fails = evs.filter(e => e.kind === "fail").length;
+  const cascades = evs.filter(e => e.kind === "cascade").length;
+  if (fails >= 3) return { l: "Fails", v: fails, t: "err",  u: "/47", urgent: true };
+  if (cascades >= 2) return { l: "Cascade", v: cascades, t: "info", u: "@step" };
+  return { l: "tps", v: "1.24", t: "brass", u: "tps" };
+}
+
+function StatusTray() {
+  const D = window.MASC_DATA || {};
+  const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{trayHidden:false}, ()=>{}]);
+  const hidden = !!cs.trayHidden;
+  const [open, setOpen, ref] = _useTrayPop();
+  const spot = _kpiSpotlight(D);
+  const events = (D.events || []).slice(-1)[0];
+  const evCount = (D.events || []).length;
+  const keepers = (D.keepers || []);
+  const activeK = keepers.filter(k => k.status !== "idle").length;
+  const stalled = keepers.filter(k => k.status === "stalled").length;
+
+  if (hidden) return null;
+
+  const item = (id, dotClass, label, sub) => (
+    <button className={"st-item" + (open === id ? " open" : "")}
+            onClick={() => setOpen(open === id ? null : id)}
+            title={label + (sub ? " · " + sub : "")}>
+      <span className={"st-dot " + dotClass}></span>
+      <span className="st-l">{label}</span>
+      {sub != null && <span className="st-sub">{sub}</span>}
+    </button>
+  );
+
+  return (
+    <div className="status-tray" ref={ref}>
+      {item("kpi",
+            "k-" + spot.t + (spot.urgent ? " urgent" : ""),
+            spot.l,
+            spot.v + (spot.u || ""))}
+      {item("life",
+            "k-" + (spot.urgent ? "err" : "ok"),
+            "lifeline",
+            evCount + " ev")}
+      {item("ticker",
+            "k-info",
+            "ticker",
+            events ? (events.kind || "ev") : "—")}
+      {item("keepers",
+            stalled > 0 ? "k-warn" : "k-ok",
+            "keepers",
+            activeK + "/" + keepers.length)}
+      <button className="st-close"
+              onClick={() => setCs({ trayHidden: true })}
+              title="hide status tray (re-enable from focus button menu)">×</button>
+
+      {open && (
+        <div className="st-pop" data-pop={open}>
+          {open === "kpi" && window.KpiStrip && <window.KpiStrip />}
+          {open === "life" && window.Lifeline && <window.Lifeline />}
+          {open === "ticker" && (
+            <div className="st-list">
+              <div className="st-list-h">recent activity</div>
+              {(D.events || []).slice(-12).reverse().map((e, i) => (
+                <div className="st-list-row" key={i}>
+                  <span className={"st-dot k-" + (e.kind === "fail" ? "err" : e.kind === "cascade" ? "info" : "ok")}></span>
+                  <span className="st-list-keeper">{e.keeper || "system"}</span>
+                  <span className="st-list-kind">{e.kind}</span>
+                  <span className="st-list-msg">{e.summary || e.msg || ""}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {open === "keepers" && (
+            <div className="st-list">
+              <div className="st-list-h">fleet · {activeK}/{keepers.length} active</div>
+              {keepers.map(k => (
+                <div className="st-list-row" key={k.id}>
+                  <span className={"st-dot k-" + (k.status === "stalled" ? "warn" : k.status === "idle" ? "ok" : "info")}></span>
+                  <span className="st-list-keeper">{k.id}</span>
+                  <span className="st-list-kind">{k.status}</span>
+                  <span className="st-list-msg">{k.last_action || ""}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+window.StatusTray = StatusTray;

--- a/dashboard/design-system/ui_kits/cockpit/WidgetSolo.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/WidgetSolo.jsx
@@ -1,0 +1,161 @@
+/* global React, ReactDOM, MASC_DATA,
+          Topbar, Ticker, KpiStrip, Lifeline, Sidebar, Rail,
+          Swimlanes, Deck, Composer, StatusBar,
+          WorkPlane, CommsPlane, ObservePlane, CognitionPlane, IdePlane,
+          Drawer */
+/* WidgetSolo — full-viewport single-widget viewer, activated by ?widget=<id>.
+
+   Lets users pop any cockpit widget into its own browser tab/window for
+   focused work without the surrounding chrome. The widget is rendered with
+   sensible defaults (sample data, sane selection state) so it stands alone.
+
+   Supported ids:
+     sidebar              the full Sidebar (Fleet/Filter/Goals)
+     rail                 the full Rail (Activity/Nudges/Cascade)
+     kpi                  KPI strip
+     lifeline             Lifeline 60s trace
+     deck                 Deck (board/cascade/providers/goals)
+     swimlanes            Keeper swimlanes
+     plane-work           Work plane
+     plane-comms          Comms plane
+     plane-observe        Observe plane
+     plane-cognition      Cognition plane
+     plane-ide            IDE plane
+     plane-dashboard      Dashboard (swimlanes + deck)
+     drawer-<id>          drawer panel (rendered standalone)
+*/
+
+const { useState: _wsUseState, useEffect: _wsUseEffect } = React;
+
+const _WS_DEFS = {
+  sidebar:    { name: "Sidebar",        kind: "sidebar"    },
+  rail:       { name: "Rail",           kind: "rail"       },
+  kpi:        { name: "KPI Strip",      kind: "kpi"        },
+  lifeline:   { name: "Lifeline",       kind: "lifeline"   },
+  deck:       { name: "Deck",           kind: "deck"       },
+  swimlanes:  { name: "Swimlanes",      kind: "swimlanes"  },
+  "plane-dashboard": { name: "Dashboard plane",  kind: "plane-dashboard"  },
+  "plane-work":      { name: "Work plane",       kind: "plane-work"       },
+  "plane-comms":     { name: "Comms plane",      kind: "plane-comms"      },
+  "plane-observe":   { name: "Observe plane",    kind: "plane-observe"    },
+  "plane-cognition": { name: "Cognition plane",  kind: "plane-cognition"  },
+  "plane-ide":       { name: "IDE plane",        kind: "plane-ide"        },
+};
+
+function WidgetSolo({ id }) {
+  // pull state hook to clear collapsed widgets for this solo view
+  const [_cs, _setCs] = (window.useCockpitState ? window.useCockpitState() : [{collapsed:new Set()}, () => {}]);
+
+  // mark body + title; clear collapsed set so widgets render expanded
+  _wsUseEffect(() => {
+    document.body.classList.add("widget-solo-mode");
+    document.title = `MASC · ${id}`;
+    if (_cs.collapsed && _cs.collapsed.size > 0) _setCs({ collapsed: new Set() });
+    return () => { document.body.classList.remove("widget-solo-mode"); };
+  }, [id]);
+
+  const D = window.MASC_DATA || {};
+  const def = _WS_DEFS[id];
+
+  // unknown widget — show a friendly index
+  if (!def) {
+    return (
+      <div className="ws-shell ws-empty ws-kind-empty">
+        <div className="ws-bar">
+          <span className="ws-dot"></span>
+          <span className="ws-name">unknown widget</span>
+          <span className="ws-id">id: {id || "(none)"}</span>
+          <span className="ws-spc"></span>
+          <a className="ws-act" href={window.location.pathname}>← cockpit</a>
+        </div>
+        <div className="ws-body">
+          <div className="ws-empty-msg">
+            <div>No widget registered for <code>?widget={id || "—"}</code>.</div>
+            <ul>
+              {Object.keys(_WS_DEFS).map(k => (
+                <li key={k}>
+                  <a href={"?widget=" + k}>?widget={k}</a>
+                  <span className="dim"> — {_WS_DEFS[k].name}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // shared selection defaults so widgets render usefully alone
+  const dummyKeepers = new Set(["nick0cave", "sangsu"]);
+  const ctx = { branch: "main", keepers: dummyKeepers };
+
+  // render the body for the requested widget
+  let body = null;
+  switch (def.kind) {
+    case "sidebar":
+      body = (
+        <window.Sidebar
+          keepers={D.keepers || []}
+          goals={D.goals || []}
+          selKeeper="nick0cave"
+          setSelKeeper={()=>{}}
+          selGoal={(D.goals && D.goals[0] && D.goals[0].id) || ""}
+          setSelGoal={()=>{}}
+          selectedKeepers={dummyKeepers}
+          toggleKeeper={()=>{}} />
+      );
+      break;
+    case "rail":
+      body = <window.Rail events={D.events || []} cascade={D.cascade || {steps:[],total_ms:0}} />;
+      break;
+    case "kpi":
+      body = <window.KpiStrip />;
+      break;
+    case "lifeline":
+      body = <window.Lifeline />;
+      break;
+    case "deck":
+      body = (
+        <window.Deck
+          tasks={D.tasks || []}
+          goals={D.goals || []}
+          providers={D.providers || []}
+          cascade={D.cascade || {steps:[],total_ms:0}} />
+      );
+      break;
+    case "swimlanes":
+      body = <window.Swimlanes keepers={D.keepers || []} laneEvents={D.laneEvents || {}} />;
+      break;
+    case "plane-dashboard":
+      body = (
+        <div className="center" style={{display:"flex",flexDirection:"column",height:"100%"}}>
+          <window.Swimlanes keepers={D.keepers || []} laneEvents={D.laneEvents || {}} />
+          <window.Deck tasks={D.tasks || []} goals={D.goals || []}
+                       providers={D.providers || []} cascade={D.cascade || {steps:[],total_ms:0}} />
+        </div>
+      );
+      break;
+    case "plane-work":      body = <div className="center"><window.WorkPlane {...ctx}/></div>; break;
+    case "plane-comms":     body = <div className="center"><window.CommsPlane {...ctx}/></div>; break;
+    case "plane-observe":   body = <div className="center"><window.ObservePlane {...ctx}/></div>; break;
+    case "plane-cognition": body = <div className="center"><window.CognitionPlane {...ctx}/></div>; break;
+    case "plane-ide":       body = <div className="center"><window.IdePlane {...ctx}/></div>; break;
+    default:
+      body = <div className="ws-empty-msg">renderer not wired</div>;
+  }
+
+  return (
+    <div className={"ws-shell ws-kind-" + def.kind}>
+      <div className="ws-bar">
+        <span className="ws-dot"></span>
+        <span className="ws-name">{def.name}</span>
+        <span className="ws-id">{id}</span>
+        <span className="ws-spc"></span>
+        <a className="ws-act" href={window.location.pathname} title="back to full cockpit">← cockpit</a>
+      </div>
+      <div className="ws-body">{body}</div>
+    </div>
+  );
+}
+
+window.WidgetSolo = WidgetSolo;

--- a/dashboard/design-system/ui_kits/cockpit/WidgetSolo.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/WidgetSolo.jsx
@@ -22,7 +22,11 @@
      plane-cognition      Cognition plane
      plane-ide            IDE plane
      plane-dashboard      Dashboard (swimlanes + deck)
-     drawer-<id>          drawer panel (rendered standalone)
+     drawer-terminal      Drawer Terminal panel (standalone)
+     drawer-output        Drawer Output panel (standalone)
+     drawer-cascade       Drawer Cascade panel (standalone)
+     drawer-audit         Drawer Audit panel (standalone)
+     drawer-cost          Drawer Cost panel (standalone)
 */
 
 const { useState: _wsUseState, useEffect: _wsUseEffect } = React;
@@ -40,6 +44,11 @@ const _WS_DEFS = {
   "plane-observe":   { name: "Observe plane",    kind: "plane-observe"    },
   "plane-cognition": { name: "Cognition plane",  kind: "plane-cognition"  },
   "plane-ide":       { name: "IDE plane",        kind: "plane-ide"        },
+  "drawer-terminal": { name: "Drawer · Terminal", kind: "drawer-terminal" },
+  "drawer-output":   { name: "Drawer · Output",   kind: "drawer-output"   },
+  "drawer-cascade":  { name: "Drawer · Cascade",  kind: "drawer-cascade"  },
+  "drawer-audit":    { name: "Drawer · Audit",    kind: "drawer-audit"    },
+  "drawer-cost":     { name: "Drawer · Cost",     kind: "drawer-cost"     },
 };
 
 function WidgetSolo({ id }) {
@@ -140,6 +149,17 @@ function WidgetSolo({ id }) {
     case "plane-observe":   body = <div className="center"><window.ObservePlane {...ctx}/></div>; break;
     case "plane-cognition": body = <div className="center"><window.CognitionPlane {...ctx}/></div>; break;
     case "plane-ide":       body = <div className="center"><window.IdePlane {...ctx}/></div>; break;
+    case "drawer-terminal":
+    case "drawer-output":
+    case "drawer-cascade":
+    case "drawer-audit":
+    case "drawer-cost": {
+      const panelKind = def.kind.replace("drawer-", "");
+      body = window.__DrawerPanel
+        ? <window.__DrawerPanel kind={panelKind} />
+        : <div className="ws-empty-msg">drawer panels not loaded</div>;
+      break;
+    }
     default:
       body = <div className="ws-empty-msg">renderer not wired</div>;
   }

--- a/dashboard/design-system/ui_kits/cockpit/cockpit-ext.css
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit-ext.css
@@ -1,0 +1,501 @@
+/* cockpit-ext.css — Phase 1: viewport banner, repo selector, collapsible widgets
+   Loaded AFTER cockpit.css, so these rules win on specificity ties. */
+
+/* ═══════════ VIEWPORT BANNER ═══════════ */
+.vp-banner {
+  position: fixed; top: 0; left: 0; right: 0;
+  z-index: 9999;
+  background: linear-gradient(180deg, rgba(180,140,60,.18), rgba(180,140,60,.08));
+  border-bottom: 1px solid var(--brass-3, #6b5022);
+  color: var(--color-fg-primary);
+  font: 11px/1.4 var(--font-mono);
+  padding: 7px 14px 7px 16px;
+  display: flex; align-items: center; gap: 14px;
+  backdrop-filter: blur(6px);
+}
+.vp-banner .vp-icon {
+  width: 14px; height: 14px; flex: none;
+  border: 1px solid var(--brass-2, #c9a04a);
+  background: rgba(180,140,60,.15);
+  display: grid; place-items: center;
+  color: var(--brass-1, #f0c674);
+  font-size: 9px;
+}
+.vp-banner .vp-msg { flex: 1; }
+.vp-banner .vp-msg b { color: var(--brass-1, #f0c674); }
+.vp-banner .vp-msg .vp-cur {
+  margin-left: 10px;
+  color: var(--color-fg-muted);
+  font-size: 10px;
+}
+.vp-banner button {
+  font: inherit;
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-primary);
+  padding: 3px 10px;
+  cursor: pointer;
+  letter-spacing: .03em;
+}
+.vp-banner button:hover { border-color: var(--brass-2, #c9a04a); color: var(--brass-1, #f0c674); }
+.vp-banner button.vp-fs { background: rgba(180,140,60,.12); border-color: var(--brass-3, #6b5022); }
+.vp-banner button.vp-close { padding: 3px 8px; }
+body.has-vp-banner { padding-top: 32px; }
+
+/* ═══════════ REPO SELECTOR (Topbar) ═══════════ */
+.tb-repo {
+  display: inline-flex; align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  height: 22px;
+  border: 1px solid var(--color-border-default);
+  background: rgba(40,28,12,.35);
+  cursor: pointer;
+  font: 11px/1 var(--font-mono);
+  color: var(--color-fg-primary);
+  position: relative;
+  user-select: none;
+}
+.tb-repo:hover { border-color: var(--brass-2, #c9a04a); }
+.tb-repo .tb-repo-glyph {
+  display: inline-block; width: 9px; height: 9px;
+  border: 1px solid var(--brass-2, #c9a04a);
+  background: var(--brass-3, #6b5022);
+  transform: rotate(45deg);
+  flex: none;
+}
+.tb-repo .tb-repo-name { color: var(--brass-1, #f0c674); font-weight: 600; }
+.tb-repo .tb-repo-meta {
+  color: var(--color-fg-muted);
+  font-size: 10px;
+  letter-spacing: .02em;
+}
+.tb-repo .chev { color: var(--color-fg-muted); font-size: 9px; }
+
+/* repo pin strip (left of selector for multi-repo quick-toggle) */
+.tb-repo-pins {
+  display: inline-flex; align-items: center;
+  gap: 3px;
+  margin-right: 4px;
+}
+.tb-repo-pin {
+  width: 22px; height: 22px;
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-muted);
+  font: 10px/1 var(--font-mono);
+  display: grid; place-items: center;
+  cursor: pointer;
+  letter-spacing: 0;
+  position: relative;
+}
+.tb-repo-pin:hover {
+  border-color: var(--brass-3, #6b5022);
+  color: var(--color-fg-primary);
+}
+.tb-repo-pin.active {
+  border-color: var(--brass-2, #c9a04a);
+  background: rgba(180,140,60,.18);
+  color: var(--brass-1, #f0c674);
+}
+.tb-repo-pin .pin-badge {
+  position: absolute;
+  top: -3px; right: -3px;
+  min-width: 12px; height: 11px;
+  padding: 0 3px;
+  background: var(--err-fg, #d04848);
+  color: #fff;
+  font-size: 8px; line-height: 11px;
+  border-radius: 6px;
+  text-align: center;
+  font-weight: 600;
+}
+
+/* repo selector popover */
+.tb-repo-pop {
+  position: absolute;
+  top: 26px; left: 0;
+  width: 360px;
+  max-height: 420px;
+  overflow: auto;
+  background: var(--color-canvas-default, #161616);
+  border: 1px solid var(--color-border-default);
+  box-shadow: 0 12px 28px rgba(0,0,0,.6);
+  z-index: 200;
+  padding: 8px;
+  font: 11px/1.4 var(--font-mono);
+}
+.tb-repo-pop .h {
+  color: var(--color-fg-muted);
+  font-size: 9px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  padding: 4px 6px 8px;
+  border-bottom: 1px solid var(--color-border-default);
+  margin-bottom: 6px;
+}
+.tb-repo-pop .repo-row {
+  display: grid;
+  grid-template-columns: 14px 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 7px 8px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.tb-repo-pop .repo-row:hover { border-color: var(--color-border-default); background: rgba(180,140,60,.06); }
+.tb-repo-pop .repo-row.on { background: rgba(180,140,60,.14); border-color: var(--brass-3, #6b5022); }
+.tb-repo-pop .repo-row .glyph { color: var(--brass-2, #c9a04a); }
+.tb-repo-pop .repo-row .nm { color: var(--color-fg-primary); font-weight: 600; }
+.tb-repo-pop .repo-row .nm .ow { color: var(--color-fg-muted); font-weight: 400; }
+.tb-repo-pop .repo-row .desc {
+  grid-column: 2 / 3;
+  color: var(--color-fg-muted);
+  font-size: 10px;
+  margin-top: 2px;
+}
+.tb-repo-pop .repo-row .meta {
+  display: flex; gap: 6px;
+  font-size: 10px;
+  color: var(--color-fg-muted);
+}
+.tb-repo-pop .repo-row .meta .pr { color: var(--ok-fg, #6abf6a); }
+.tb-repo-pop .repo-row .meta .dirty { color: var(--err-fg, #d04848); }
+.tb-repo-pop .repo-row .pinbtn {
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-fg-muted);
+  width: 20px; height: 20px;
+  display: grid; place-items: center;
+  cursor: pointer;
+  font-size: 11px;
+}
+.tb-repo-pop .repo-row .pinbtn.on { color: var(--brass-1, #f0c674); border-color: var(--brass-2, #c9a04a); }
+
+/* ═══════════ COLLAPSIBLE WIDGETS ═══════════ */
+/* Standardize collapse affordance — chevron rotates, body hides. */
+.wx-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 5px 10px;
+  font: 9px/1 var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: .14em;
+  color: var(--color-fg-muted);
+  border-bottom: 1px solid var(--color-border-default);
+  cursor: pointer;
+  background: rgba(255,255,255,.012);
+  user-select: none;
+  height: 22px;
+  flex: none;
+}
+.wx-head:hover { color: var(--color-fg-primary); background: rgba(180,140,60,.05); }
+.wx-head .wx-chev {
+  display: inline-block;
+  width: 10px;
+  text-align: center;
+  font-size: 9px;
+  color: var(--color-fg-muted);
+  transition: transform .15s ease;
+}
+.wx-head[aria-expanded="false"] .wx-chev { transform: rotate(-90deg); }
+.wx-head .wx-title { flex: 1; }
+.wx-head .wx-meta {
+  font-size: 10px;
+  color: var(--color-fg-muted);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.wx-head .wx-act {
+  display: inline-flex; gap: 4px;
+}
+.wx-head .wx-act button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-fg-muted);
+  font: 9px/1 var(--font-mono);
+  padding: 2px 5px;
+  cursor: pointer;
+  text-transform: lowercase;
+  letter-spacing: 0;
+}
+.wx-head .wx-act button:hover { border-color: var(--color-border-default); color: var(--color-fg-primary); }
+
+.wx-body { flex: 1 1 auto; min-height: 0; overflow: hidden; }
+.wx-collapsed > .wx-body { display: none; }
+
+/* When sidebar/rail are collapsed, shrink to a thin rail */
+.app .side.wx-collapsed { width: 36px; min-width: 36px; }
+.app .rail.wx-collapsed { width: 36px; min-width: 36px; }
+.app .side.wx-collapsed .wx-head,
+.app .rail.wx-collapsed .wx-head {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  height: 100%;
+  border-bottom: none;
+  border-right: 1px solid var(--color-border-default);
+  padding: 10px 4px;
+  letter-spacing: .2em;
+}
+.app .side.wx-collapsed .wx-head .wx-meta,
+.app .side.wx-collapsed .wx-head .wx-act,
+.app .rail.wx-collapsed .wx-head .wx-meta,
+.app .rail.wx-collapsed .wx-head .wx-act { display: none; }
+
+/* When the central deck is collapsed, only header strip remains */
+.deck.wx-collapsed .deck-tabs,
+.deck.wx-collapsed .deck-body { display: none; }
+
+/* When KPI strip is collapsed, just keep a thin trace bar */
+.kpi.wx-collapsed { height: 22px; min-height: 22px; }
+.kpi.wx-collapsed .kpi-cell { display: none; }
+.kpi.wx-collapsed .kpi-collapse-tab { display: flex; flex: 1; padding: 0 12px; }
+
+/* KPI collapse tab — small chevron at the very left of the strip */
+.kpi-collapse-tab {
+  flex: 0 0 auto;
+  align-self: stretch;
+  display: flex; align-items: center; justify-content: center;
+  width: 22px;
+  border-right: 1px solid var(--color-border-default);
+  background: rgba(255,255,255,.012);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font: 9px/1 var(--font-mono);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  user-select: none;
+}
+.kpi-collapse-tab:hover { color: var(--brass-1, #f0c674); background: rgba(180,140,60,.06); }
+
+/* When lifeline is collapsed, just keep label */
+.life.wx-collapsed .life-trace { display: none; }
+.life.wx-collapsed { height: 22px; }
+
+/* Generic "open in new tab" floating button (fullscreen escape hatch) */
+.cockpit-fs-fab {
+  position: fixed;
+  right: 14px; bottom: 14px;
+  z-index: 200;
+  background: rgba(15,15,15,.85);
+  border: 1px solid var(--brass-3, #6b5022);
+  color: var(--brass-1, #f0c674);
+  padding: 8px 12px;
+  font: 10px/1 var(--font-mono);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  display: none;
+  backdrop-filter: blur(6px);
+}
+.cockpit-fs-fab:hover { background: rgba(180,140,60,.18); }
+body.has-vp-banner.compact-vp .cockpit-fs-fab { display: inline-block; }
+
+/* ═══════════ SECTION HEADER (sx) — collapsible per-section ═══════════ */
+/* fix sidebar/rail flex stacking — .app uses CSS grid so .side is a grid cell.
+   Make .side/.rail flex columns so children (sect-h + body) stack and Goals
+   gets remaining space via flex:1. */
+.app .side,
+.app .rail {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+.app .side > .side-sect,
+.app .rail > .rail-sect {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+/* Fleet section gets a sane cap so it can't push Goals off-screen on narrow viewports */
+.app .side > .side-sect:first-child > .side-sect-body {
+  max-height: clamp(140px, 28vh, 320px);
+  overflow-y: auto;
+}
+/* Filter sect (chips) is naturally short — leave it auto */
+.app .side > .side-sect-goals,
+.app .rail > .rail-sect.flex {
+  flex: 1 1 auto;
+  min-height: 120px;
+}
+.app .side > .side-sect-goals > .side-sect-body { flex: 1 1 auto; overflow-y: auto; }
+.app .rail > .rail-sect.flex > .rail-sect-body { flex: 1 1 auto; overflow-y: auto; }
+
+.side-sect-h.sx,
+.rail-sect-h.sx {
+  cursor: pointer;
+  display: flex; align-items: center; gap: 6px;
+  padding: 9px var(--sp-3) 6px;
+  user-select: none;
+  font: 600 9px/1 var(--font-mono);
+  letter-spacing: var(--track-caps, .14em);
+  text-transform: uppercase;
+  color: var(--color-fg-muted);
+  background: rgba(255,255,255,.012);
+}
+.side-sect-h.sx:hover,
+.rail-sect-h.sx:hover {
+  color: var(--color-fg-primary);
+  background: rgba(180,140,60,.05);
+}
+.side-sect-h.sx .sx-chev,
+.rail-sect-h.sx .sx-chev {
+  display: inline-block; width: 10px;
+  text-align: center; font-size: 9px;
+  color: var(--color-fg-muted);
+  flex: none;
+}
+.side-sect-h.sx:hover .sx-chev,
+.rail-sect-h.sx:hover .sx-chev { color: var(--brass-1, #f0c674); }
+.side-sect-h.sx .sx-lbl,
+.rail-sect-h.sx .sx-lbl { flex: 1; }
+.side-sect-h.sx .count,
+.rail-sect-h.sx .count {
+  color: var(--color-fg-disabled);
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  font-size: 10px;
+}
+.side-sect-h.sx .sx-rail,
+.rail-sect-h.sx .sx-rail {
+  margin-left: 6px;
+  width: 18px; height: 18px;
+  display: grid; place-items: center;
+  border: 1px solid transparent;
+  color: var(--color-fg-muted);
+  font-size: 12px;
+}
+.side-sect-h.sx .sx-rail:hover,
+.rail-sect-h.sx .sx-rail:hover {
+  border-color: var(--brass-3, #6b5022);
+  color: var(--brass-1, #f0c674);
+  background: rgba(180,140,60,.1);
+}
+
+/* Goals section gets remaining flex height with internal scroll */
+.side-sect-goals { flex: 1; min-height: 0; }
+.side-sect-goals .side-sect-body { flex: 1; overflow-y: auto; }
+
+/* Vertical label for collapsed sidebar/rail */
+.wx-rail-vlabel {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  height: 100%;
+  width: 100%;
+  display: flex; align-items: center; justify-content: center;
+  padding: 16px 0;
+  font: 600 9px/1 var(--font-mono);
+  letter-spacing: .25em;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  text-transform: uppercase;
+}
+.wx-rail-vlabel:hover { color: var(--brass-1, #f0c674); }
+.app .side.wx-collapsed,
+.app .rail.wx-collapsed { width: 36px; min-width: 36px; cursor: pointer; }
+.app .side.wx-collapsed { border-right: 1px solid var(--color-border-strong); }
+.app .rail.wx-collapsed { border-left: 1px solid var(--color-border-strong); }
+
+/* App grid must collapse its track widths to match the actual collapsed
+   width of side/rail (36px), otherwise a phantom gap appears between the
+   thin rail and the central plane. */
+.app:has(> .side.wx-collapsed):not(:has(> .rail.wx-collapsed)) {
+  grid-template-columns: 36px 1fr var(--w-rail);
+}
+.app:has(> .rail.wx-collapsed):not(:has(> .side.wx-collapsed)) {
+  grid-template-columns: var(--w-side) 1fr 36px;
+}
+.app:has(> .side.wx-collapsed):has(> .rail.wx-collapsed) {
+  grid-template-columns: 36px 1fr 36px;
+}
+
+/* ═══════════ KPI SPOTLIGHT ═══════════ */
+.kpi-cell.spotlight {
+  border-right: 1px solid var(--brass-3, #6b5022);
+  background: linear-gradient(180deg, rgba(180,140,60,.10), rgba(180,140,60,.02));
+  position: relative;
+  padding-left: 14px;
+}
+.kpi-cell.spotlight::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 8px; bottom: 8px;
+  width: 3px;
+  background: var(--brass-1, #f0c674);
+}
+.kpi-cell.spotlight.urgent::before { background: var(--err-fg, #d04848); animation: kpi-pulse 1.6s ease-in-out infinite; }
+.kpi-cell.spotlight .kpi-l {
+  color: var(--brass-1, #f0c674);
+  font-weight: 700;
+  letter-spacing: .12em;
+}
+.kpi-cell.spotlight.urgent .kpi-l { color: var(--err-fg, #d04848); }
+@keyframes kpi-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: .35; }
+}
+
+/* ═══════════ COMPOSER HISTORY ═══════════ */
+.compose-hist {
+  display: flex; align-items: center;
+  gap: 8px;
+  margin: 0 8px 0 4px;
+  max-width: 380px;
+  overflow: hidden;
+  flex: 0 1 auto;
+}
+.compose-hist .hb {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 2px 6px;
+  border: 1px solid var(--color-border-default);
+  background: rgba(255,255,255,.02);
+  font: 9px/1.4 var(--font-mono);
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+  max-width: 130px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.compose-hist .hb.err { border-color: rgba(208,72,72,.4); color: var(--err-fg, #d04848); }
+.compose-hist .hb.ok:hover  { border-color: var(--brass-3, #6b5022); color: var(--color-fg-primary); }
+.compose-hist .hb .ht { color: var(--color-fg-disabled); }
+.compose-hist .hb .hk { color: var(--brass-1, #f0c674); font-weight: 600; }
+.compose-hist .hb .hc { overflow: hidden; text-overflow: ellipsis; }
+
+
+/* ═══════════════ IDE v3 (Phase B-C) ═══════════════ */
+/* IDE Plane re-design: drawer hint button + tightened modebar +
+   body without bottom terminal grid row (drawer handles it). */
+.ide-v3-body {
+  /* override v2's two-row grid (which had a terminal row) */
+  grid-template-rows: minmax(0, 1fr) !important;
+}
+.ide-v3-body.wide { grid-template-rows: minmax(0, 1fr) !important; }
+
+.ide-v3-modebar .ide-v2-branch .meta {
+  color: var(--color-fg-muted);
+  font-size: 10px;
+  letter-spacing: .04em;
+}
+
+.ide-v3-drawer-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  background: var(--color-bg-panel-alt);
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-muted);
+  font: 10px/1.4 var(--font-mono);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 0;
+}
+.ide-v3-drawer-hint:hover {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--brass-3, #6b5022);
+  background: rgba(180,140,60,.08);
+}

--- a/dashboard/design-system/ui_kits/cockpit/cockpit-ext.js
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit-ext.js
@@ -1,0 +1,120 @@
+/* cockpit-ext.js — Phase 1 enhancements (loaded BEFORE React/Babel scripts)
+   - Augments window.MASC_P2 with multi-repo metadata
+   - Provides window.MASC_EXT helpers (state, repo lookup)
+   No React here — plain JS so it can run before babel transform. */
+(function () {
+  // ── 1. multi-repo seed ─────────────────────────────────────────
+  // Repos referenced in data.js / data-p2.js (tasks[].pr.repo).
+  const REPOS = [
+    { slug: "runtime",   owner: "masc",   pinned: true,  active_prs: 3, openIssues: 12, dirty: 1, head: "da11b063", desc: "claim-loop, cascade router, keeper shell" },
+    { slug: "dashboard", owner: "masc",   pinned: true,  active_prs: 2, openIssues: 4,  dirty: 2, head: "51f062b9", desc: "cockpit UI, tokens, swimlanes" },
+    { slug: "viewer",    owner: "masc",   pinned: false, active_prs: 0, openIssues: 1,  dirty: 0, head: "c0e814e2", desc: "scene viewer, 3D fleet map" },
+    { slug: "mood",      owner: "masc",   pinned: false, active_prs: 1, openIssues: 2,  dirty: 0, head: "918fd2c0", desc: "mood seed, ambient signals" },
+    { slug: "eval",      owner: "masc",   pinned: false, active_prs: 1, openIssues: 0,  dirty: 0, head: "44a1b903", desc: "eval harness, regression suite" },
+  ];
+
+  // Map each known branch to a primary repo (best-effort, derived from data).
+  const BRANCH_TO_REPO = {
+    "main":                "runtime",
+    "release-0.42":        "runtime",
+    "feat/keeper-clarity": "runtime",
+    "fix/dashboard-9712":  "dashboard",
+    "wt/sangsu-smoke":     "viewer",
+    "ar-93ff2489":         "runtime",
+    "ar-aadab70d":         "mood",
+  };
+
+  // Inject repo metadata into MASC_P2 once it exists.
+  function applyRepoMeta() {
+    if (!window.MASC_P2) return false;
+    if (window.MASC_P2.__repoMetaApplied) return true;
+    window.MASC_P2.repos = REPOS;
+    if (Array.isArray(window.MASC_P2.branches)) {
+      window.MASC_P2.branches = window.MASC_P2.branches.map(b => ({
+        ...b,
+        repo: b.repo || BRANCH_TO_REPO[b.name] || "runtime",
+      }));
+    }
+    window.MASC_P2.__repoMetaApplied = true;
+    return true;
+  }
+  // Try now; if MASC_P2 not ready yet, retry on DOMContentLoaded.
+  if (!applyRepoMeta()) {
+    document.addEventListener("DOMContentLoaded", applyRepoMeta, { once: true });
+  }
+
+  // ── 2. cockpit state helpers (URL hash + localStorage) ─────────
+  const STORAGE_KEY = "masc.cockpit.state.v1";
+  function readHash() {
+    const h = (window.location.hash || "").replace(/^#/, "");
+    if (!h) return {};
+    const out = {};
+    h.split("&").forEach(kv => {
+      if (!kv) return;
+      const [k, v] = kv.split("=");
+      if (k) out[decodeURIComponent(k)] = v == null ? true : decodeURIComponent(v);
+    });
+    return out;
+  }
+  function readStorage() {
+    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}"); }
+    catch (e) { return {}; }
+  }
+  function writeHash(state) {
+    // Only write a small allow-list to URL — collapse map + active repo + mode.
+    const allow = ["repo", "branch", "mode", "collapsed"];
+    const parts = [];
+    allow.forEach(k => {
+      if (state[k] == null) return;
+      if (k === "collapsed") {
+        // serialize Set/array of collapsed widget ids
+        const arr = state[k] instanceof Set ? [...state[k]] : state[k];
+        if (!arr || !arr.length) return;
+        parts.push("collapsed=" + encodeURIComponent(arr.join(",")));
+      } else {
+        parts.push(k + "=" + encodeURIComponent(state[k]));
+      }
+    });
+    const h = parts.join("&");
+    const newUrl = window.location.pathname + window.location.search + (h ? "#" + h : "");
+    history.replaceState(null, "", newUrl);
+  }
+  function writeStorage(state) {
+    try {
+      const out = { ...state };
+      if (out.collapsed instanceof Set) out.collapsed = [...out.collapsed];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(out));
+    } catch (e) {}
+  }
+
+  // initial state — URL > localStorage > defaults
+  function initialState() {
+    const url = readHash();
+    const ls = readStorage();
+    const collapsedRaw = url.collapsed != null ? url.collapsed : ls.collapsed;
+    let collapsed = [];
+    if (Array.isArray(collapsedRaw)) collapsed = collapsedRaw;
+    else if (typeof collapsedRaw === "string" && collapsedRaw) collapsed = collapsedRaw.split(",");
+    return {
+      repo: url.repo || ls.repo || "runtime",
+      branch: url.branch || ls.branch || "main",
+      mode: url.mode || ls.mode || "Dashboard",
+      collapsed: new Set(collapsed),
+      bannerDismissed: !!ls.bannerDismissed,
+    };
+  }
+
+  window.MASC_EXT = {
+    REPOS,
+    BRANCH_TO_REPO,
+    initialState,
+    writeHash,
+    writeStorage,
+    persist(state) { writeHash(state); writeStorage(state); },
+    setBannerDismissed() {
+      const ls = readStorage();
+      ls.bannerDismissed = true;
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(ls)); } catch (e) {}
+    },
+  };
+})();

--- a/dashboard/design-system/ui_kits/cockpit/cockpit-ext.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit-ext.jsx
@@ -1,0 +1,263 @@
+/* global React, MASC_EXT, MASC_P2 */
+/* cockpit-ext.jsx — Phase 1 React extensions
+   Loaded AFTER Chrome.jsx, exposes:
+     - useCockpitState()        URL+localStorage hook
+     - useCollapsed(id)         per-widget collapse state
+     - <RepoSelector>           topbar repo picker w/ pin strip
+     - <ViewportBanner>         1440/1920 hint + fullscreen
+     - <WxHead>                 standard collapsible header
+*/
+const { useState: useStateExt, useEffect: useEffectExt, useRef: useRefExt, useCallback: useCallbackExt } = React;
+
+// ── 1. global cockpit-state context (singleton) ────────────────
+const _initial = (window.MASC_EXT && window.MASC_EXT.initialState()) || {
+  repo: "runtime", branch: "main", mode: "Dashboard",
+  collapsed: new Set(), bannerDismissed: false,
+};
+let _stateListeners = new Set();
+let _state = _initial;
+function _setState(patch) {
+  _state = { ..._state, ...patch };
+  if (window.MASC_EXT) window.MASC_EXT.persist(_state);
+  _stateListeners.forEach(fn => fn(_state));
+}
+function useCockpitState() {
+  const [, setTick] = useStateExt(0);
+  useEffectExt(() => {
+    const fn = () => setTick(t => t + 1);
+    _stateListeners.add(fn);
+    return () => _stateListeners.delete(fn);
+  }, []);
+  return [_state, _setState];
+}
+
+function useCollapsed(id) {
+  const [s, set] = useCockpitState();
+  const collapsed = s.collapsed.has(id);
+  const toggle = useCallbackExt(() => {
+    const next = new Set(s.collapsed);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    set({ collapsed: next });
+  }, [s.collapsed, id]);
+  return [collapsed, toggle];
+}
+
+// ── 1c. Layout Profile per mode ───────────────────────────────
+// Each mode has a recommended chrome state (which widgets collapse).
+// On mode change, missing user-pinned overrides get the profile applied.
+const LAYOUT_PROFILES = {
+  Dashboard: { collapse: ["kpi","lifeline"], drawer: null },
+  Work:      { collapse: ["kpi","lifeline"], drawer: null },
+  Comms:     { collapse: ["kpi","lifeline"], drawer: null },
+  Observe:   { collapse: ["lifeline","sidebar","rail"], drawer: null },
+  Cognition: { collapse: ["kpi","lifeline"], drawer: null },
+  IDE:       { collapse: ["kpi","lifeline","sidebar","rail"], drawer: { open: false, tab: "terminal" } },
+};
+
+// remember whether the user has manually overridden a widget's state
+// per mode-session, so mode-switch profile doesn't fight them.
+let _userOverrides = {};   // {mode: Set<widgetId>}
+
+function useLayoutProfile() {
+  const [s, set] = useCockpitState();
+  const mode = s.mode || "Dashboard";
+
+  // apply on mode change
+  useEffectExt(() => {
+    const prof = LAYOUT_PROFILES[mode];
+    if (!prof) return;
+    const overrides = _userOverrides[mode] || new Set();
+    const next = new Set(s.collapsed);
+    // first, clear any collapses that were set by a prior profile but not overridden by user
+    Object.entries(LAYOUT_PROFILES).forEach(([m, p]) => {
+      if (m === mode) return;
+      p.collapse.forEach(id => {
+        // only un-collapse if not in this mode's profile and not user-overridden
+        if (!prof.collapse.includes(id) && !overrides.has(id)) {
+          next.delete(id);
+        }
+      });
+    });
+    // then apply this profile's collapses (unless user explicitly un-collapsed)
+    prof.collapse.forEach(id => {
+      if (!overrides.has(id)) next.add(id);
+    });
+    // patch only if changed
+    let changed = next.size !== s.collapsed.size;
+    if (!changed) for (const id of next) if (!s.collapsed.has(id)) { changed = true; break; }
+    if (changed) set({ collapsed: next });
+
+    // drawer state — only auto-set on mode entry, don't override user
+    if (prof.drawer && (!s.drawer || s.drawer.__autoMode !== mode)) {
+      set({ drawer: { ...(s.drawer || {}), ...prof.drawer, __autoMode: mode } });
+    }
+  }, [mode]);
+
+  return mode;
+}
+
+// expose for Sidebar/etc to mark user-driven collapse toggles
+function markUserOverride(mode, widgetId) {
+  if (!_userOverrides[mode]) _userOverrides[mode] = new Set();
+  _userOverrides[mode].add(widgetId);
+}
+
+
+// ── 2. WxHead — standard collapsible header ───────────────────
+function WxHead({ id, title, meta, actions, popoutId, children }) {
+  const [collapsed, toggle] = useCollapsed(id);
+  const popout = popoutId ? (
+    <a className="wx-popout"
+       href={"?widget=" + popoutId}
+       target="_blank" rel="noopener"
+       title="open this widget in a new tab"
+       onClick={(e) => e.stopPropagation()}>↗</a>
+  ) : null;
+  return (
+    <div className="wx-head" role="button" tabIndex={0}
+         aria-expanded={!collapsed}
+         onClick={(e) => {
+           // ignore clicks inside action buttons
+           if (e.target.closest(".wx-act") || e.target.closest(".wx-popout")) return;
+           toggle();
+         }}
+         onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}>
+      <span className="wx-chev">▾</span>
+      <span className="wx-title">{title}</span>
+      {meta != null && <span className="wx-meta">{meta}</span>}
+      {(actions || popout) && <span className="wx-act">{actions}{popout}</span>}
+      {children}
+    </div>
+  );
+}
+
+// ── 3. RepoSelector ───────────────────────────────────────────
+function RepoSelector() {
+  const [s, set] = useCockpitState();
+  const [open, setOpen] = useStateExt(false);
+  const popRef = useRefExt(null);
+  const repos = (window.MASC_P2 && window.MASC_P2.repos) || [];
+  const cur = repos.find(r => r.slug === s.repo) || repos[0];
+  const pinned = repos.filter(r => r.pinned);
+
+  useEffectExt(() => {
+    if (!open) return;
+    const close = (e) => { if (popRef.current && !popRef.current.contains(e.target)) setOpen(false); };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open]);
+
+  if (!cur) return null;
+
+  const switchRepo = (slug) => {
+    // when repo changes, reset branch to that repo's first known branch (or "main")
+    const branches = (window.MASC_P2 && window.MASC_P2.branches) || [];
+    const repoBranches = branches.filter(b => b.repo === slug);
+    const newBranch = repoBranches.find(b => b.name === "main") ? "main"
+                    : (repoBranches[0] && repoBranches[0].name) || "main";
+    set({ repo: slug, branch: newBranch });
+    setOpen(false);
+  };
+
+  const togglePin = (e, slug) => {
+    e.stopPropagation();
+    repos.forEach(r => { if (r.slug === slug) r.pinned = !r.pinned; });
+    // force re-render via state ping
+    set({});
+  };
+
+  return (
+    <div className="tb-repo-pins-wrap" style={{ display: "inline-flex", alignItems: "center", gap: 6, position: "relative" }}>
+      {pinned.length > 1 && (
+        <div className="tb-repo-pins" aria-label="pinned repos">
+          {pinned.map(r => (
+            <button key={r.slug}
+                    className={"tb-repo-pin" + (r.slug === s.repo ? " active" : "")}
+                    title={`${r.owner}/${r.slug} · ${r.active_prs} PRs · ${r.dirty} dirty`}
+                    onClick={() => switchRepo(r.slug)}>
+              {r.slug.slice(0,2)}
+              {r.active_prs > 0 && <span className="pin-badge">{r.active_prs}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="tb-repo" onClick={() => setOpen(o => !o)}
+           title={`${cur.owner}/${cur.slug} · HEAD ${cur.head}`}>
+        <span className="tb-repo-glyph"></span>
+        <span className="tb-repo-name">{cur.slug}</span>
+        <span className="tb-repo-meta">
+          {cur.active_prs}pr · {cur.dirty}d
+        </span>
+        <span className="chev">▾</span>
+      </div>
+      {open && (
+        <div className="tb-repo-pop" ref={popRef}>
+          <div className="h">workspace · {repos.length} repos</div>
+          {repos.map(r => (
+            <div key={r.slug}
+                 className={"repo-row" + (r.slug === s.repo ? " on" : "")}
+                 onClick={() => switchRepo(r.slug)}>
+              <span className="glyph">⟢</span>
+              <span className="nm"><span className="ow">{r.owner}/</span>{r.slug}</span>
+              <span className="meta">
+                <span className="pr">{r.active_prs}pr</span>
+                <span>{r.openIssues}is</span>
+                {r.dirty > 0 && <span className="dirty">{r.dirty}d</span>}
+              </span>
+              <button className={"pinbtn" + (r.pinned ? " on" : "")}
+                      title={r.pinned ? "unpin" : "pin"}
+                      onClick={(e) => togglePin(e, r.slug)}>
+                {r.pinned ? "★" : "☆"}
+              </button>
+              <span className="desc">{r.desc} · {r.head}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── 4. Viewport banner ────────────────────────────────────────
+function ViewportBanner() {
+  const [w, setW] = useStateExt(window.innerWidth);
+  const [dismissed, setDismissed] = useStateExt(_state.bannerDismissed);
+  useEffectExt(() => {
+    const fn = () => setW(window.innerWidth);
+    window.addEventListener("resize", fn);
+    return () => window.removeEventListener("resize", fn);
+  }, []);
+  // Show only when viewport is meaningfully narrow.
+  const show = !dismissed && w < 1400;
+  useEffectExt(() => {
+    document.body.classList.toggle("has-vp-banner", show);
+    document.body.classList.toggle("compact-vp", w < 1400);
+  }, [show, w]);
+
+  if (!show) return null;
+
+  const target = w < 1280 ? "1920px" : "1440px";
+  const dismiss = () => {
+    if (window.MASC_EXT) window.MASC_EXT.setBannerDismissed();
+    _state.bannerDismissed = true;
+    setDismissed(true);
+  };
+  const openFullscreen = () => {
+    // Open this same page in a new tab — caller can resize freely.
+    window.open(window.location.href, "_blank", "noopener");
+  };
+  return (
+    <div className="vp-banner" role="status">
+      <span className="vp-icon">⤢</span>
+      <span className="vp-msg">
+        Cockpit is built for <b>1440px+</b> (best at <b>1920px</b>).
+        <span className="vp-cur">current: {w}px</span>
+      </span>
+      <button className="vp-fs" onClick={openFullscreen}>Open in new tab →</button>
+      <button className="vp-close" onClick={dismiss} title="dismiss">✕</button>
+    </div>
+  );
+}
+
+// publish
+Object.assign(window, { useCockpitState, useCollapsed, useLayoutProfile, markUserOverride, WxHead, RepoSelector, ViewportBanner });

--- a/dashboard/design-system/ui_kits/cockpit/cockpit.css
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit.css
@@ -16,6 +16,7 @@
   --h-ticker: 32px;
   --h-kpi:    60px;
   --h-life:   32px;
+  --h-drawer: 0px;     /* set dynamically by Drawer.jsx */
   --h-compose:48px;
   --h-status: 20px;
 
@@ -46,6 +47,7 @@ button { font: inherit; }
     var(--h-kpi)
     var(--h-life)
     1fr
+    var(--h-drawer)
     var(--h-compose)
     var(--h-status);
   grid-template-areas:
@@ -54,6 +56,7 @@ button { font: inherit; }
     "kpi    kpi    kpi"
     "life   life   life"
     "side   center rail"
+    "drawer drawer drawer"
     "compose compose compose"
     "status status status";
   gap: 0;
@@ -65,6 +68,7 @@ button { font: inherit; }
 .app > .side    { grid-area: side; overflow: hidden; }
 .app > .center  { grid-area: center; overflow: hidden; min-width: 0; }
 .app > .rail    { grid-area: rail; overflow: hidden; }
+.app > .drawer { grid-area: drawer; overflow: hidden; }
 .app > .compose { grid-area: compose; }
 .app > .status  { grid-area: status; }
 
@@ -275,6 +279,14 @@ button { font: inherit; }
   background: var(--color-bg-page);
   display: grid;
   grid-template-rows: 180px 1fr;
+}
+
+/* When .center holds a plane (Work / Comms / Observe / Cognition / IDE),
+   the dashboard's [180px swimlanes / 1fr deck] grid would squash the plane
+   into the 180px row. Switch to a single-cell flex layout in that case. */
+.center:has(> .plane) {
+  display: flex;
+  flex-direction: column;
 }
 
 /* Swimlanes */

--- a/dashboard/design-system/ui_kits/cockpit/drawer.css
+++ b/dashboard/design-system/ui_kits/cockpit/drawer.css
@@ -1,0 +1,470 @@
+/* drawer.css — Phase B-A: VSCode-style bottom drawer
+   Lives in the .drawer grid area. --h-drawer drives row height (set by Drawer.jsx). */
+
+/* ─── shell ─────────────────────────────────────────────────── */
+.drawer {
+  background: var(--color-bg-page);
+  border-top: 1px solid var(--color-border-strong);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 0;
+  font-family: var(--font-mono);
+  color: var(--color-fg-primary);
+}
+.drawer.closed { /* still mounted; bar is always visible at bottom */
+  /* the bar takes ~26px; height 0 from grid means bar overlaps compose? no — when closed, --h-drawer=0 so we display only the bar via absolute positioning above compose */
+}
+/* When drawer is closed, the bar still needs to be visible.
+   We render the bar in a fixed-position strip above .compose using a negative offset trick: */
+.drawer.closed { height: 26px; min-height: 26px; }
+.drawer.closed .dr-bar { height: 26px; }
+.drawer.closed .dr-grip { display: none; }
+
+/* ─── grip ──────────────────────────────────────────────────── */
+.dr-grip {
+  height: 6px;
+  flex: 0 0 auto;
+  cursor: ns-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-default);
+  user-select: none;
+}
+.dr-grip:hover { background: rgba(180,140,60,.08); }
+.dr-grip-bar {
+  width: 36px; height: 2px;
+  background: var(--color-fg-disabled);
+  border-radius: 2px;
+}
+.dr-grip:hover .dr-grip-bar { background: var(--brass-1, #f0c674); }
+
+/* ─── bar (tabs + actions) ─────────────────────────────────── */
+.dr-bar {
+  flex: 0 0 auto;
+  height: 28px;
+  display: flex;
+  align-items: stretch;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-default);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+}
+.dr-tabs {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: stretch;
+}
+.dr-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--color-border-default);
+  color: var(--color-fg-muted);
+  font: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  letter-spacing: .04em;
+}
+.dr-tab:hover {
+  background: var(--color-bg-panel-alt);
+  color: var(--color-fg-primary);
+}
+.dr-tab.on {
+  background: var(--color-bg-page);
+  color: var(--brass-1, #f0c674);
+  box-shadow: inset 0 -2px 0 var(--brass-2, #c9a04a);
+}
+.dr-tab .g {
+  font-family: var(--font-mono);
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-10);
+  width: 10px;
+  text-align: center;
+}
+.dr-tab.on .g { color: var(--brass-2, #c9a04a); }
+.dr-tab .l {
+  font-size: var(--fs-11);
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  font-weight: 500;
+}
+.dr-tab .ct {
+  font-size: var(--fs-9);
+  color: var(--color-fg-disabled);
+  background: var(--color-bg-panel-alt);
+  border: 1px solid var(--color-border-default);
+  padding: 0 5px;
+  border-radius: 8px;
+  font-variant-numeric: tabular-nums;
+  margin-left: 2px;
+}
+.dr-tab.on .ct {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--brass-3, #6b5022);
+}
+
+.dr-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px;
+  flex: 0 0 auto;
+}
+.dr-act {
+  width: 22px; height: 22px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-fg-muted);
+  font: 11px var(--font-mono);
+  cursor: pointer;
+  border-radius: 2px;
+}
+.dr-act:hover {
+  background: var(--color-bg-panel-alt);
+  border-color: var(--color-border-default);
+  color: var(--brass-1, #f0c674);
+}
+.dr-act.dr-close:hover {
+  color: var(--err-fg);
+  border-color: var(--err-border);
+}
+.dr-hint {
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-10);
+  letter-spacing: .04em;
+  padding: 0 6px;
+}
+
+/* ─── body (active panel) ─────────────────────────────────── */
+.dr-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-page);
+}
+
+/* ─── TERMINAL ─────────────────────────────────────────────── */
+.dr-term {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  line-height: 1.55;
+  background: #0a0908;
+}
+.dr-term-l {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  gap: 10px;
+  align-items: baseline;
+}
+.dr-term-l .t {
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-9);
+  letter-spacing: .04em;
+}
+.dr-term-l .x { white-space: pre; }
+.dr-term-l.k-tx   .x { color: var(--color-fg-primary); }
+.dr-term-l.k-ok   .x { color: var(--ok-fg, #7ec27e); }
+.dr-term-l.k-err  .x { color: var(--err-fg, #e57373); }
+.dr-term-l.k-warn .x { color: var(--warn-fg, #d8a948); }
+.dr-term-l.k-info .x { color: var(--color-fg-muted); }
+
+/* ─── OUTPUT ──────────────────────────────────────────────── */
+.dr-output {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.dr-output-bar,
+.dr-cascade-bar,
+.dr-audit-bar,
+.dr-cost-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-default);
+  font-size: var(--fs-10);
+  flex: 0 0 auto;
+}
+.dr-output-bar .lbl,
+.dr-cascade-bar .lbl,
+.dr-audit-bar .lbl,
+.dr-cost-bar .lbl {
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  font-size: var(--fs-9);
+}
+.dr-output-bar .meta,
+.dr-cascade-bar .meta,
+.dr-audit-bar .meta,
+.dr-cost-bar .meta {
+  margin-left: auto;
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-10);
+}
+.dr-output-bar .chsel {
+  background: var(--color-bg-panel-alt);
+  border: 1px solid var(--color-border-default);
+  color: var(--brass-1, #f0c674);
+  font: var(--fs-11) var(--font-mono);
+  padding: 2px 6px;
+  border-radius: 0;
+}
+.dr-output-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 14px;
+  font-size: var(--fs-11);
+  line-height: 1.5;
+}
+.dr-out-l {
+  display: grid;
+  grid-template-columns: 56px 50px 1fr;
+  gap: 8px;
+  align-items: baseline;
+}
+.dr-out-l .t  { color: var(--color-fg-disabled); font-size: var(--fs-9); }
+.dr-out-l .lv {
+  font-size: var(--fs-9);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--color-fg-muted);
+}
+.dr-out-l.lv-ok   .lv, .dr-out-l.lv-ok   .x { color: var(--ok-fg, #7ec27e); }
+.dr-out-l.lv-err  .lv, .dr-out-l.lv-err  .x { color: var(--err-fg, #e57373); }
+.dr-out-l.lv-warn .lv, .dr-out-l.lv-warn .x { color: var(--warn-fg, #d8a948); }
+.dr-out-l.lv-info .lv { color: var(--color-fg-disabled); }
+.dr-out-l.lv-info .x  { color: var(--color-fg-secondary); }
+
+/* ─── CASCADE ─────────────────────────────────────────────── */
+.dr-cascade {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.dr-cascade-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.dr-empty {
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-11);
+  text-align: center;
+  padding: 24px;
+}
+.dr-csc {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-left: 2px solid var(--brass-2, #c9a04a);
+  padding: 6px 10px;
+}
+.dr-csc-h {
+  display: grid;
+  grid-template-columns: 100px 1fr 60px;
+  gap: 10px;
+  align-items: center;
+  font-size: var(--fs-11);
+  margin-bottom: 4px;
+}
+.dr-csc-h .id { color: var(--color-fg-disabled); font-size: var(--fs-9); letter-spacing: .04em; }
+.dr-csc-h .prompt {
+  color: var(--color-fg-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dr-csc-h .out {
+  text-align: center;
+  font-size: var(--fs-9);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  border: 1px solid var(--color-border-strong);
+  padding: 1px 4px;
+}
+.dr-csc-h .out.ok { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); }
+.dr-csc-h .out.fail { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
+.dr-csc-hops {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: var(--fs-10);
+}
+.dr-csc-hops .hop {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  background: var(--color-bg-panel-alt);
+  border: 1px solid var(--color-border-default);
+}
+.dr-csc-hops .hop .ix {
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-9);
+}
+.dr-csc-hops .hop .prov {
+  color: var(--color-fg-secondary);
+}
+.dr-csc-hops .hop .ms {
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-9);
+}
+.dr-csc-hops .hop.fail {
+  border-color: var(--err-border);
+  background: var(--err-soft);
+}
+.dr-csc-hops .hop.ok {
+  border-color: var(--ok);
+}
+
+/* ─── AUDIT ───────────────────────────────────────────────── */
+.dr-audit {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.dr-audit-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 14px;
+}
+.dr-aud-row {
+  display: grid;
+  grid-template-columns: 70px 110px 70px 1fr 200px;
+  gap: 10px;
+  align-items: baseline;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--color-border-default);
+  font-size: var(--fs-11);
+}
+.dr-aud-row.dr-aud-h {
+  position: sticky;
+  top: 0;
+  background: var(--color-bg-page);
+  color: var(--color-fg-muted);
+  font-size: var(--fs-9);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--color-border-strong);
+  padding: 6px 0;
+}
+.dr-aud-row .t { color: var(--color-fg-disabled); font-size: var(--fs-10); }
+.dr-aud-row .who { color: var(--color-fg-primary); }
+.dr-aud-row .vd {
+  font-size: var(--fs-9);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  text-align: center;
+  border: 1px solid var(--color-border-strong);
+  padding: 1px 4px;
+}
+.dr-aud-row .vd.v-merge   { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); }
+.dr-aud-row .vd.v-block   { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
+.dr-aud-row .vd.v-ack     { color: var(--brass-1, #f0c674); border-color: var(--brass-3, #6b5022); }
+.dr-aud-row .vd.v-log     { color: var(--color-fg-muted); }
+.dr-aud-row .vd.v-release { color: var(--info, #6da6c7); border-color: var(--info-border, #4d7a96); }
+.dr-aud-row .tg {
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dr-aud-row .nt {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-10);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── COST ────────────────────────────────────────────────── */
+.dr-cost {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.dr-cost-bar .big {
+  font-size: 22px;
+  color: var(--brass-1, #f0c674);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: .02em;
+}
+.dr-cost-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.dr-cost-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.dr-cost-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 70px 80px 90px;
+  gap: 12px;
+  align-items: center;
+  font-size: var(--fs-11);
+}
+.dr-cost-row .nm { color: var(--color-fg-primary); }
+.dr-cost-row .bar {
+  height: 8px;
+  background: var(--color-bg-panel-alt);
+  border: 1px solid var(--color-border-default);
+  position: relative;
+  overflow: hidden;
+}
+.dr-cost-row .bar .fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: linear-gradient(90deg, var(--brass-3, #6b5022), var(--brass-2, #c9a04a));
+}
+.dr-cost-row .used {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--brass-1, #f0c674);
+}
+.dr-cost-row .cl,
+.dr-cost-row .lat {
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-10);
+  font-variant-numeric: tabular-nums;
+}
+.dr-cost-foot {
+  padding: 8px 10px;
+  background: var(--color-bg-surface);
+  border: 1px dashed var(--color-border-strong);
+  font-size: var(--fs-10);
+  color: var(--color-fg-muted);
+}
+.dr-cost-foot .tip::before {
+  content: "→ ";
+  color: var(--brass-2, #c9a04a);
+}

--- a/dashboard/design-system/ui_kits/cockpit/focus-mode.css
+++ b/dashboard/design-system/ui_kits/cockpit/focus-mode.css
@@ -1,0 +1,153 @@
+/* focus-mode.css — Phase B-C.1
+   When body has .focus-mode, hide all the top chrome (topbar/ticker/kpi/
+   lifeline) + bottom status bar + composer, and let the central plane
+   (or sidebar/center/rail row) take over the full viewport. */
+
+body.focus-mode .app {
+  /* collapse the chrome rows to 0 — keep the row tracks but with 0px
+     so grid-area assignments still work and elements simply become
+     invisible (display:none on grid items can break grid in some browsers). */
+  grid-template-rows:
+    0    /* topbar  */
+    0    /* ticker  */
+    0    /* kpi     */
+    0    /* life    */
+    1fr  /* center row (side / center / rail) */
+    auto /* drawer  */
+    0    /* compose */
+    0;   /* status  */
+}
+body.focus-mode .app > .topbar,
+body.focus-mode .app > .ticker,
+body.focus-mode .app > .kpi,
+body.focus-mode .app > .life,
+body.focus-mode .app > .compose,
+body.focus-mode .app > .status {
+  display: none !important;
+}
+body.focus-mode .vp-banner { display: none !important; }
+
+/* Focus toggle button — always visible, bottom-right */
+.focus-toggle {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  z-index: 1100;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--color-bg-surface, #1a1814);
+  color: var(--color-fg-muted, #8a857c);
+  border: 1px solid var(--color-border-default, #3a352c);
+  font: var(--fs-11) var(--font-mono);
+  letter-spacing: .04em;
+  cursor: pointer;
+  border-radius: 0;
+  user-select: none;
+  transition: color .12s ease, border-color .12s ease, background .12s ease;
+  box-shadow: 0 2px 12px rgba(0,0,0,.5);
+}
+.focus-toggle:hover {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--brass-3, #6b5022);
+  background: rgba(180,140,60,.08);
+}
+.focus-toggle.on {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--brass-3, #6b5022);
+  background: rgba(180,140,60,.12);
+}
+.focus-toggle .focus-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+.focus-toggle .focus-label {
+  font-size: 10px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+/* When in focus mode, give status tray (added separately) clear space */
+body.focus-mode .focus-toggle {
+  background: rgba(20,18,14,.85);
+  backdrop-filter: blur(4px);
+}
+
+/* Hide focus toggle in widget-solo mode (already chromeless) */
+body.widget-solo-mode .focus-toggle { display: none; }
+body.widget-solo-mode .focus-cluster { display: none; }
+
+/* Focus cluster wrapper — holds toggle button + popover menu */
+.focus-cluster {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  z-index: 51;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+.focus-cluster .focus-toggle {
+  position: static; /* override the fixed positioning above */
+}
+
+/* Menu popover — sits above the toggle button */
+.focus-menu {
+  background: rgba(20,18,14,.96);
+  border: 1px solid var(--color-border-default, #2c2823);
+  box-shadow: 0 4px 20px rgba(0,0,0,.6);
+  padding: 4px 0;
+  min-width: 200px;
+  font: 11px/1 var(--font-mono);
+}
+.focus-menu-h {
+  padding: 6px 10px 4px;
+  font-size: 9px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--color-fg-muted, #6b6258);
+  border-bottom: 1px solid var(--color-border-subtle, #1f1c18);
+}
+.focus-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  background: transparent;
+  border: 0;
+  color: var(--color-fg-default, #c9c2b6);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.focus-menu-row:hover {
+  background: rgba(180,140,60,.08);
+  color: var(--brass-1, #f0c674);
+}
+.focus-menu-row.on .focus-menu-k {
+  color: var(--brass-1, #f0c674);
+}
+.focus-menu-k {
+  width: 10px;
+  color: var(--color-fg-muted, #6b6258);
+  font-weight: 600;
+}
+.focus-menu-l {
+  flex: 1;
+  letter-spacing: .04em;
+}
+.focus-menu-sub {
+  color: var(--color-fg-muted, #6b6258);
+  font-size: 9px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.focus-toggle.menu-open {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--brass-3, #6b5022);
+  background: rgba(180,140,60,.12);
+}

--- a/dashboard/design-system/ui_kits/cockpit/focus-mode.css
+++ b/dashboard/design-system/ui_kits/cockpit/focus-mode.css
@@ -13,7 +13,7 @@ body.focus-mode .app {
     0    /* kpi     */
     0    /* life    */
     1fr  /* center row (side / center / rail) */
-    auto /* drawer  */
+    var(--h-drawer) /* drawer  */
     0    /* compose */
     0;   /* status  */
 }

--- a/dashboard/design-system/ui_kits/cockpit/focus-mode.css
+++ b/dashboard/design-system/ui_kits/cockpit/focus-mode.css
@@ -83,14 +83,14 @@ body.widget-solo-mode .focus-cluster { display: none; }
   position: fixed;
   right: 12px;
   bottom: 12px;
-  z-index: 51;
+  z-index: 1100;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 6px;
 }
 .focus-cluster .focus-toggle {
-  position: static; /* override the fixed positioning above */
+  position: relative; /* keep in stacking context; cancel fixed from standalone rule */
 }
 
 /* Menu popover — sits above the toggle button */

--- a/dashboard/design-system/ui_kits/cockpit/index.html
+++ b/dashboard/design-system/ui_kits/cockpit/index.html
@@ -4,6 +4,11 @@
 <meta charset="utf-8">
 <title>MASC Cockpit</title>
 <link rel="stylesheet" href="cockpit.css">
+<link rel="stylesheet" href="cockpit-ext.css">
+<link rel="stylesheet" href="drawer.css">
+<link rel="stylesheet" href="widget-solo.css">
+<link rel="stylesheet" href="focus-mode.css">
+<link rel="stylesheet" href="status-tray.css">
 <link rel="stylesheet" href="../../source_styles/tokens.generated.css" />
 <link rel="stylesheet" href="../../source_styles/primitives.css">
 <link rel="stylesheet" href="../../preview/components.css">
@@ -12,6 +17,7 @@
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 <script src="data.js"></script>
 <script src="data-p2.js"></script>
+<script src="cockpit-ext.js"></script>
 </head>
 <body class="masc-ds">
 <div id="root"></div>
@@ -23,9 +29,14 @@
 <script type="text/babel" src="../../preview/cb-group-i.jsx"></script>
 <script type="text/babel" src="../../preview/cb-group-j.jsx"></script>
 <script type="text/babel" src="../../preview/cb-group-k.jsx"></script>
+<script type="text/babel" src="cockpit-ext.jsx"></script>
 <script type="text/babel" src="Chrome.jsx"></script>
 <script type="text/babel" src="Panels.jsx"></script>
 <script type="text/babel" src="Planes.jsx"></script>
+<script type="text/babel" src="Drawer.jsx"></script>
+<script type="text/babel" src="FocusMode.jsx"></script>
+<script type="text/babel" src="StatusTray.jsx"></script>
+<script type="text/babel" src="WidgetSolo.jsx"></script>
 <script type="text/babel" src="App.jsx"></script>
 </body>
 </html>

--- a/dashboard/design-system/ui_kits/cockpit/status-tray.css
+++ b/dashboard/design-system/ui_kits/cockpit/status-tray.css
@@ -1,0 +1,161 @@
+/* status-tray.css — Phase B-C.2
+   Slack-style bottom-left status indicator row.
+   Always visible (esp. useful in focus mode) — clickable dots open popovers
+   with the full widget content inline. */
+
+.status-tray {
+  position: fixed;
+  left: 12px;
+  bottom: 12px;
+  z-index: 1100;
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--color-bg-surface, #1a1814);
+  border: 1px solid var(--color-border-default, #3a352c);
+  font: var(--fs-11) var(--font-mono);
+  user-select: none;
+  box-shadow: 0 2px 12px rgba(0,0,0,.5);
+}
+
+.st-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-fg-muted, #8a857c);
+  font: inherit;
+  cursor: pointer;
+  letter-spacing: .04em;
+  border-radius: 0;
+}
+.st-item:hover {
+  color: var(--color-fg-primary, #e8e4d8);
+  background: rgba(180,140,60,.06);
+}
+.st-item.open {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--brass-3, #6b5022);
+  background: rgba(180,140,60,.12);
+}
+
+.st-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--color-fg-disabled, #6b6258);
+}
+.st-dot.k-ok    { background: var(--ok-fg, #6fb96f); }
+.st-dot.k-info  { background: var(--info-fg, #6f9fb9); }
+.st-dot.k-warn  { background: var(--brass-1, #f0c674); }
+.st-dot.k-err   { background: var(--err-fg, #c87474); box-shadow: 0 0 6px rgb(200 116 116 / .6); }
+.st-dot.k-brass { background: var(--brass-1, #f0c674); }
+.st-dot.urgent  { animation: st-pulse 1.4s ease-in-out infinite; }
+
+@keyframes st-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: .55; transform: scale(1.25); }
+}
+
+.st-item .st-l {
+  font-size: 10px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.st-item .st-sub {
+  font-size: 10px;
+  color: var(--color-fg-disabled, #6b6258);
+  font-variant-numeric: tabular-nums;
+}
+.st-item.open .st-sub { color: var(--brass-2, #c9a060); }
+
+/* Close ‘×’ button — hides the tray entirely (re-enable from FocusToggle menu) */
+.st-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px; height: 18px;
+  margin-left: 2px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-fg-disabled, #6b6258);
+  font: 13px/1 var(--font-mono);
+  cursor: pointer;
+  border-radius: 0;
+}
+.st-close:hover {
+  color: var(--err-fg, #c87474);
+  border-color: var(--color-border-default);
+  background: rgba(200,116,116,.06);
+}
+
+/* ── Popover ───────────────────────────────────────────── */
+.st-pop {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 6px);
+  min-width: 380px;
+  max-width: 640px;
+  max-height: 60vh;
+  overflow: auto;
+  background: var(--color-bg-surface, #1a1814);
+  border: 1px solid var(--color-border-strong, #4a4338);
+  box-shadow: 0 4px 24px rgba(0,0,0,.6);
+  padding: 0;
+}
+/* widget-specific embeds need to disable absolute positioning since
+   they normally live in grid-area cells */
+.st-pop > .kpi,
+.st-pop > .life {
+  position: relative !important;
+  width: 100%;
+  height: auto;
+  border: none;
+}
+.st-pop > .kpi {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1px;
+  background: var(--color-border-default);
+}
+
+.st-list {
+  display: flex;
+  flex-direction: column;
+  font: 11px/1.4 var(--font-mono);
+}
+.st-list-h {
+  padding: 8px 12px 6px;
+  font-size: 9px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--color-fg-disabled);
+  border-bottom: 1px solid var(--color-border-default);
+}
+.st-list-row {
+  display: grid;
+  grid-template-columns: 12px 100px 70px 1fr;
+  gap: 8px;
+  align-items: center;
+  padding: 5px 12px;
+  border-bottom: 1px solid var(--color-border-divider, #2a261f);
+}
+.st-list-row:last-child { border-bottom: none; }
+.st-list-keeper { color: var(--color-fg-primary); }
+.st-list-kind {
+  color: var(--color-fg-muted);
+  font-size: 10px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.st-list-msg {
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* In widget-solo mode hide the tray (chromeless surfaces don't need it) */
+body.widget-solo-mode .status-tray { display: none; }

--- a/dashboard/design-system/ui_kits/cockpit/widget-solo.css
+++ b/dashboard/design-system/ui_kits/cockpit/widget-solo.css
@@ -1,0 +1,182 @@
+/* widget-solo.css — Phase B-B: single-widget pop-out viewer
+   Shown when ?widget=<id> is in URL. Single-widget full-viewport surface. */
+
+body.widget-solo-mode {
+  background: var(--color-bg-page);
+  overflow: hidden;
+}
+body.widget-solo-mode #root { height: 100vh; }
+
+.ws-shell {
+  display: grid;
+  grid-template-rows: 32px 1fr;
+  height: 100vh;
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
+  font-family: var(--font-mono);
+}
+
+.ws-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 14px;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-strong);
+  font-size: var(--fs-11);
+}
+.ws-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--brass-1, #f0c674);
+  box-shadow: 0 0 8px rgb(180 140 60 / .5);
+  flex: none;
+}
+.ws-name {
+  color: var(--color-fg-primary);
+  font-weight: 600;
+  letter-spacing: .04em;
+}
+.ws-id {
+  color: var(--color-fg-disabled);
+  font-size: var(--fs-9);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+}
+.ws-spc { flex: 1; }
+.ws-act {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  background: transparent;
+  border: 1px solid var(--color-border-default);
+  color: var(--color-fg-muted);
+  font: var(--fs-11) var(--font-mono);
+  text-decoration: none;
+  cursor: pointer;
+  letter-spacing: .04em;
+}
+.ws-act:hover {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--brass-3, #6b5022);
+  background: rgba(180,140,60,.08);
+}
+
+.ws-body {
+  overflow: auto;
+  padding: 0;
+  position: relative;
+  min-height: 0;
+}
+
+/* Per-widget body padding/styling adjustments so they look at home solo */
+.ws-kind-kpi .ws-body,
+.ws-kind-lifeline .ws-body {
+  display: flex;
+  align-items: center;
+  padding: 14px;
+}
+.ws-kind-kpi .ws-body .kpi,
+.ws-kind-lifeline .ws-body .life {
+  width: 100%;
+  height: auto;
+  min-height: 80px;
+  border: 1px solid var(--color-border-default);
+}
+
+.ws-kind-sidebar .ws-body,
+.ws-kind-rail .ws-body {
+  display: flex;
+  padding: 0;
+}
+.ws-kind-sidebar .ws-body > .side,
+.ws-kind-rail .ws-body > .rail {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  height: 100%;
+  border-left: 1px solid var(--color-border-default);
+  border-right: 1px solid var(--color-border-default);
+}
+
+.ws-kind-swimlanes .ws-body,
+.ws-kind-deck .ws-body {
+  padding: 12px;
+}
+
+/* Plane solo views — full-bleed, height fixed (no grid-area inheritance) */
+.ws-shell[class*="ws-kind-plane-"] .ws-body {
+  display: flex;
+  min-height: 0;
+}
+.ws-shell[class*="ws-kind-plane-"] .ws-body > .center {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+}
+.ws-shell[class*="ws-kind-plane-"] .ws-body > .center > .plane,
+.ws-shell[class*="ws-kind-plane-"] .ws-body > .plane {
+  flex: 1;
+  min-height: 0;
+}
+
+/* Drawer panels solo */
+.ws-shell[class*="ws-kind-drawer-"] .ws-body {
+  background: var(--color-bg-page);
+}
+.ws-shell[class*="ws-kind-drawer-"] .ws-body > * {
+  height: 100%;
+}
+
+/* empty / not-found state */
+.ws-empty .ws-body {
+  display: grid;
+  place-items: center;
+  padding: 40px;
+}
+.ws-empty-msg {
+  font-size: var(--fs-11);
+  line-height: 1.6;
+  color: var(--color-fg-muted);
+  max-width: 560px;
+}
+.ws-empty-msg ul {
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+.ws-empty-msg li a {
+  color: var(--brass-1, #f0c674);
+  text-decoration: none;
+}
+.ws-empty-msg li a:hover { text-decoration: underline; }
+.ws-empty-msg li .dim { color: var(--color-fg-disabled); }
+
+/* ─── pop-out button on widget headers (used inside the main cockpit) ─ */
+.wx-popout {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px; height: 18px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-fg-disabled);
+  font: 10px/1 var(--font-mono);
+  cursor: pointer;
+  border-radius: 2px;
+  margin-left: 4px;
+  text-decoration: none;
+}
+.wx-popout:hover {
+  color: var(--brass-1, #f0c674);
+  border-color: var(--color-border-default);
+  background: var(--color-bg-panel-alt);
+}


### PR DESCRIPTION
## Summary
- sync design-system source styles with the newer dashboard cockpit styles snapshot
- update the design-system cockpit kit modules to the newer cockpit surfaces
- load cockpit extensions, drawer, focus/status tray, and solo-widget entrypoints from the design-system kit index
- keep shared component-library assets on canonical design-system paths while the cockpit kit consumes the newer extension modules

## Verification
- node HTML local-reference check for dashboard/design-system/ui_kits/cockpit/index.html
- pnpm tokens:check
- git diff --cached --check