### PR TITLE
docs: audit P2 follow-up — experimental markers, provider voice adapters, eval pipeline

### DIFF
--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -376,3 +376,46 @@ LLAMA_SWARM_MODEL=<exact-model-id> \
 
 - [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md)
 - [SUPERVISOR-MODE.md](./SUPERVISOR-MODE.md)
+
+## Eval Pipeline (Quality Scoring)
+
+Keeper의 tool call 품질을 정량 평가하는 파이프라인. 세 가지 평가 경로가 `Reward_advice_artifact.reward_advice_artifact`로 수렴한다.
+
+### 구조
+
+```
+Post_verifier     →  of_post_verifier_verdict  →  reward_advice_artifact
+  (turn 출력 검사)       (content quality)
+
+Benchmark         →  of_benchmark_case_score    →  reward_advice_artifact
+  (tool call 정밀도)     (composite_score → multiplier band)
+
+Task verifier     →  (future)                   →  reward_advice_artifact
+```
+
+### Verdict → Multiplier 매핑
+
+| Verdict | Multiplier | 설명 |
+|---------|-----------|------|
+| `Pass` | 1.0 (post_verifier), 1.1 (benchmark) | 정상 동작 |
+| `Warn` | 0.8 (post_verifier), 0.9 (benchmark) | 품질 저하 |
+| `Fail` | 0.4 (post_verifier), 0.5 (benchmark) | 심각한 문제 |
+
+### 코드 위치
+
+| 모듈 | 역할 |
+|------|------|
+| `reward_advice_artifact.ml` | 평가 결과 record, JSON serialization, verdict→multiplier |
+| `post_verifier.ml` | keeper turn 출력 품질 검사 (공백/의미없는 응답 탐지) |
+| `tool_call_quality_benchmark.ml` | tool call 정밀도 벤치마크 (case_score → reward_advice) |
+| `tool_call_quality_benchmark_types.ml` | case_score, benchmark_case 등 타입 정의 |
+| `tool_call_quality_benchmark_scoring.ml` | composite_score 산출 |
+| `tool_call_quality_benchmark_loader.ml` | 벤치마크 case/evidence 파일 로딩 |
+| `tool_call_quality_benchmark_render.ml` | 벤치마크 결과 렌더링 |
+
+### 테스트
+
+```bash
+dune runtest test/test_reward_advice_artifact.ml
+dune runtest test/test_post_verifier.ml
+```

--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -418,4 +418,5 @@ Task verifier     →  (future)                   →  reward_advice_artifact
 ```bash
 dune runtest test/test_reward_advice_artifact.ml
 dune runtest test/test_post_verifier.ml
+dune runtest test/test_tool_call_quality_benchmark.ml
 ```

--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -379,7 +379,7 @@ LLAMA_SWARM_MODEL=<exact-model-id> \
 
 ## Eval Pipeline (Quality Scoring)
 
-Keeper의 tool call 품질을 정량 평가하는 파이프라인. 세 가지 평가 경로가 `Reward_advice_artifact.reward_advice_artifact`로 수렴한다.
+Keeper의 tool call 품질을 정량 평가하는 파이프라인. 현재는 두 가지 평가 경로가 `Reward_advice_artifact.reward_advice_artifact`로 수렴하며, `Task verifier` 경로는 future로 계획되어 있다.
 
 ### 구조
 

--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -1,8 +1,7 @@
 ---
 status: reference
-last_verified: 2026-04-23
+last_verified: 2026-05-01
 code_refs:
-  - lib/oas.ml
   - lib/oas_worker.ml
   - lib/verifier_oas.ml
   - lib/memory_oas_bridge.ml

--- a/docs/PROVIDER-ADAPTER-RUNBOOK.md
+++ b/docs/PROVIDER-ADAPTER-RUNBOOK.md
@@ -1,6 +1,6 @@
 ---
 status: runbook
-last_verified: 2026-04-23
+last_verified: 2026-05-01
 code_refs:
   - lib/provider_adapter.ml
   - lib/provider_adapter.mli
@@ -36,6 +36,18 @@ code_refs:
 | `codex` | `cli_agent` | `cli_cached_login` | Codex CLI runtime |
 | `gemini` | `cli_agent` | `cli_cached_login` | Gemini CLI runtime |
 | `kimi` | `cli_agent` | `cli_cached_login` | Kimi CLI runtime |
+
+## Voice Adapters
+
+| Canonical name | Runtime | Auth | Aliases | Notes |
+|---|---|---|---|---|
+| `voice-openai-compat` | `direct_api` | `api_key` (provider-specific) | `openai_compat`, `openai`, `railway-elevenlabs-proxy` | OpenAI-compatible TTS endpoint |
+| `elevenlabs-direct` | `direct_api` | `api_key` (`ELEVENLABS_API_KEY`) | `elevenlabs`, `tts-elevenlabs` | ElevenLabs direct TTS |
+| `voice-mcp` | `local` | `none` | `voice_mcp`, `mcp`, `local-voice-mcp` | Local voice MCP bridge |
+
+## Custom Endpoint
+
+`custom:model@url` 형식으로 임의의 OpenAI-compatible 엔드포인트를 지정할 수 있다. `direct_adapters`에 등록되지 않으며, `runtime_kind = Local`인 adapter가 하나라도 존재하면 resolve된다.
 
 ## Direct API Policy
 

--- a/docs/PROVIDER-ADAPTER-RUNBOOK.md
+++ b/docs/PROVIDER-ADAPTER-RUNBOOK.md
@@ -41,13 +41,13 @@ code_refs:
 
 | Canonical name | Runtime | Auth | Aliases | Notes |
 |---|---|---|---|---|
-| `voice-openai-compat` | `direct_api` | `api_key` (provider-specific) | `openai_compat`, `openai`, `railway-elevenlabs-proxy` | OpenAI-compatible TTS endpoint |
+| `voice-openai-compat` | `direct_api` | `none` | `openai_compat`, `openai`, `railway-elevenlabs-proxy` | OpenAI-compatible TTS endpoint; endpoint-specific `api_key_env` can override auth when required |
 | `elevenlabs-direct` | `direct_api` | `api_key` (`ELEVENLABS_API_KEY`) | `elevenlabs`, `tts-elevenlabs` | ElevenLabs direct TTS |
 | `voice-mcp` | `local` | `none` | `voice_mcp`, `mcp`, `local-voice-mcp` | Local voice MCP bridge |
 
 ## Custom Endpoint
 
-`custom:model@url` 형식으로 임의의 OpenAI-compatible 엔드포인트를 지정할 수 있다. `direct_adapters`에 등록되지 않으며, `runtime_kind = Local`인 adapter가 하나라도 존재하면 resolve된다.
+`custom:model@url` 형식으로 임의의 OpenAI-compatible 엔드포인트를 지정할 수 있다. `direct_adapters`에 등록되지는 않지만, `custom` prefix는 별도 direct adapter 등록 없이도 항상 resolve되며 `local`/self-hosted runtime으로 취급된다.
 
 ## Direct API Policy
 

--- a/docs/TRANSPORT-PRACTICAL-PLAYBOOK.md
+++ b/docs/TRANSPORT-PRACTICAL-PLAYBOOK.md
@@ -8,8 +8,8 @@
 | --- | --- | --- | --- |
 | 현황판, wallboard, read-mostly viewer | `observer SSE` (`GET /mcp?sse_kind=observer`) | 브라우저 친화적이고 단방향 freshness에 충분함 | `SSE observer`, `queue max`, `broadcast avg` |
 | agent heartbeat, subscribe, fast fanout | `gRPC` (`:8936`) | 양방향 스트림, backlog replay, typed contract | `gRPC subscribers`, `active streams` |
-| browser/operator duplex bridge | `WebSocket` (`/ws`, standalone port `8937`) | request/response를 한 socket에서 처리하기 좋음 | `WebSocket sessions` |
-| peer-to-peer fast lane, edge a2a | `WebRTC` (`/webrtc/offer`, `/webrtc/answer`) | signaling 후 DataChannel로 직접 통신 | `connected channels`, `active peers` |
+| browser/operator duplex bridge | `WebSocket` (`/ws`, standalone port `8937`) **Experimental** | request/response를 한 socket에서 처리하기 좋음 | `WebSocket sessions` |
+| peer-to-peer fast lane, edge a2a | `WebRTC` (`/webrtc/offer`, `/webrtc/answer`) **Experimental** | signaling 후 DataChannel로 직접 통신 | `connected channels`, `active peers` |
 | stateless scripting, queue trigger, worker bootstrap | `Streamable HTTP` (`POST /mcp`) | curl/harness에서 가장 단순하고 canonical | `primary path`, `recent messages`, `active ops` |
 | 브라우저 다중 탭 / 다중 stream | `HTTP/2 h2c` (`MASC_USE_H2=1` 또는 `auto`) | SSE multiplexing으로 브라우저 connection limit 회피 | `HTTP listener_mode`, `multiplex_ready` |
 

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -106,7 +106,7 @@ graph TB
 | WebRTC | ocaml-webrtc | `server_webrtc_transport` | 8935 `/webrtc/*` | 기본값, `MASC_WEBRTC_ENABLED=0`으로 비활성화 | **Experimental** (local interop only; live env-gated) |
 | stdio | Eio stdin/stdout | `main_stdio_eio` + `mcp_server_eio.run_stdio` | N/A | `masc-mcp-stdio` 실행 | Available |
 
-**Experimental** 상태의 의미: 해당 transport는 코드가 존재하고 로컬 테스트에서 동작하지만, 프로덕션 interop 검증이 미완료. API/프로토콜 호환성이 breaking change 없이 변경될 수 있음. 기본값으로 활성화되어 있으나, 주의해서 사용.
+**Experimental** 상태의 의미: 해당 transport는 코드가 존재하고 로컬 테스트에서 동작하지만, 프로덕션 interop 검증이 미완료. API/프로토콜은 향후 breaking change가 발생할 수 있음. 기본값으로 활성화되어 있으나, 주의해서 사용.
 
 ### 3.1 Transport 선택 로직 (에이전트 측)
 

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -101,10 +101,12 @@ graph TB
 |-----------|---------------|--------|------|------------|--------|
 | HTTP/1.1 | httpun-eio | `server_mcp_transport_http` | 8935 | 기본값 | Canonical |
 | HTTP/2 (h2c) | h2-eio | `server_h2_gateway` | 8935 | `MASC_USE_H2=auto` (기본) 또는 `1` | Available |
-| WebSocket | httpun-ws-eio | `server_ws_standalone` + `server_mcp_transport_ws` | 8937 standalone, discovery via 8935 `/ws` | 기본값, `MASC_WS_ENABLED=0`으로 비활성화 | Available |
+| WebSocket | httpun-ws-eio | `server_ws_standalone` + `server_mcp_transport_ws` | 8937 standalone, discovery via 8935 `/ws` | 기본값, `MASC_WS_ENABLED=0`으로 비활성화 | **Experimental** |
 | gRPC | grpc-direct (h2c) | `masc_grpc_server` | 8936 | 기본값, `MASC_GRPC_ENABLED=0`으로 비활성화 | Available |
-| WebRTC | ocaml-webrtc | `server_webrtc_transport` | 8935 `/webrtc/*` | 기본값, `MASC_WEBRTC_ENABLED=0`으로 비활성화 | Available (local); live interop env-gated |
+| WebRTC | ocaml-webrtc | `server_webrtc_transport` | 8935 `/webrtc/*` | 기본값, `MASC_WEBRTC_ENABLED=0`으로 비활성화 | **Experimental** (local interop only; live env-gated) |
 | stdio | Eio stdin/stdout | `main_stdio_eio` + `mcp_server_eio.run_stdio` | N/A | `masc-mcp-stdio` 실행 | Available |
+
+**Experimental** 상태의 의미: 해당 transport는 코드가 존재하고 로컬 테스트에서 동작하지만, 프로덕션 interop 검증이 미완료. API/프로토콜 호환성이 breaking change 없이 변경될 수 있음. 기본값으로 활성화되어 있으나, 주의해서 사용.
 
 ### 3.1 Transport 선택 로직 (에이전트 측)
 


### PR DESCRIPTION
## Summary

- **Experimental markers**: WebSocket and WebRTC transports marked as **Experimental** in transport spec and practical playbook. Added definition of what "Experimental" means (code exists, local tests pass, but production interop not verified; API may change without notice).
- **Provider voice adapters**: Documented 3 voice adapters (`voice-openai-compat`, `elevenlabs-direct`, `voice-mcp`) and `custom:model@url` endpoint support that were missing from the runbook.
- **Eval pipeline**: Added "Eval Pipeline (Quality Scoring)" section to BENCHMARK-RUNBOOK covering `Reward_advice_artifact`, `Post_verifier`, and `tool_call_quality_benchmark` verdict-to-multiplier mapping with code locations and test commands.

Follow-up to P0 PR #12615 (Oas re-export removal).

## Test plan

- [x] Documentation-only change, no code impact
- [x] `last_verified` date updated in provider runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)