### PR TITLE
[codex] Map GitHub credentials per keeper

### DIFF
--- a/dashboard/src/api/credentials.ts
+++ b/dashboard/src/api/credentials.ts
@@ -1,0 +1,90 @@
+export type CredentialType = 'github' | 'gitlab' | 'local'
+export type CredentialOauthMethod = 'web' | 'with_token'
+
+export interface CredentialState {
+  kind: 'Unmaterialized' | 'Materialized' | 'Stale' | string
+  last_verified_at_unix_ms?: string | number | null
+  reason?: string | null
+}
+
+export interface Credential {
+  id: string
+  name: string
+  type: CredentialType
+  username: string
+  gh_config_dir?: string | null
+  ssh_key_path?: string | null
+  gpg_key_id?: string | null
+  state?: CredentialState | null
+  token_sha256_prefix?: string | null
+  description?: string
+  config?: Record<string, unknown>
+  created_at?: string
+}
+
+export interface CredentialCreatePayload {
+  id: string
+  name: string
+  type: CredentialType
+  username: string
+  gh_config_dir?: string | null
+  ssh_key_path?: string | null
+  gpg_key_id?: string | null
+  oauth_method?: CredentialOauthMethod
+  token?: string | null
+  description?: string
+  config?: Record<string, unknown>
+}
+
+export function coerceCredentialType(raw: unknown): CredentialType {
+  if (raw === 'gitlab') return 'gitlab'
+  if (raw === 'local') return 'local'
+  return 'github'
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function parseCredentialState(raw: unknown): CredentialState | null {
+  if (!isRecord(raw)) return null
+  const kind = typeof raw.kind === 'string' ? raw.kind : null
+  if (!kind) return null
+  return {
+    kind,
+    last_verified_at_unix_ms:
+      typeof raw.last_verified_at_unix_ms === 'string' || typeof raw.last_verified_at_unix_ms === 'number'
+        ? raw.last_verified_at_unix_ms
+        : null,
+    reason: typeof raw.reason === 'string' ? raw.reason : null,
+  }
+}
+
+export function normalizeCredentialsResponse(data: unknown): Credential[] {
+  const rows = Array.isArray(data)
+    ? data
+    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).credentials)
+      ? (data as Record<string, unknown>).credentials as unknown[]
+      : []
+  if (Array.isArray(rows)) {
+    return rows.map((row: unknown): Credential => {
+      const r = row as Record<string, unknown>
+      const username = String(r.username ?? r.name ?? '')
+      return {
+        id: String(r.id ?? ''),
+        name: String(r.name ?? username ?? r.id ?? ''),
+        type: coerceCredentialType(r.type ?? r.cred_type),
+        username,
+        gh_config_dir: typeof r.gh_config_dir === 'string' ? r.gh_config_dir : null,
+        ssh_key_path: typeof r.ssh_key_path === 'string' ? r.ssh_key_path : null,
+        gpg_key_id: typeof r.gpg_key_id === 'string' ? r.gpg_key_id : null,
+        state: parseCredentialState(r.state),
+        token_sha256_prefix: typeof r.token_sha256_prefix === 'string' ? r.token_sha256_prefix : null,
+        description: r.description ? String(r.description) : undefined,
+        config: isRecord(r.config) ? r.config : undefined,
+        created_at: r.created_at ? String(r.created_at) : undefined,
+      }
+    })
+  }
+  return []
+}

--- a/dashboard/src/components/credential-settings.test.ts
+++ b/dashboard/src/components/credential-settings.test.ts
@@ -118,7 +118,7 @@ describe("credential create request", () => {
       token: "ghp_x",
     })
     expect(githubLoginCommand("/tmp/keeper's-gh")).toBe(
-      "GH_CONFIG_DIR='/tmp/keeper'\\''s-gh' gh auth login --hostname github.com --git-protocol https --web",
+      "GH_CONFIG_DIR='/tmp/keeper'\\''s-gh' gh auth login --hostname github.com --git-protocol https --web --clipboard",
     )
   })
 })

--- a/dashboard/src/components/credential-settings.test.ts
+++ b/dashboard/src/components/credential-settings.test.ts
@@ -9,6 +9,7 @@ import {
   credentialTypeLabel,
   githubLoginCommand,
   isRecord,
+  normalizeCredentialsResponse,
   parseCredentialState,
   sanitizeOptionalString,
 } from "./credential-settings"
@@ -76,6 +77,37 @@ describe("credential state helpers", () => {
     expect(credentialStateLabel({ kind: "Unmaterialized" })).toBe("Unmaterialized")
     expect(credentialStateLabel(null)).toBe("Unknown")
     expect(credentialStateBadgeClass({ kind: "Materialized" }).length).toBeGreaterThan(0)
+  })
+})
+
+describe("normalizeCredentialsResponse", () => {
+  it("normalizes wrapped credential rows", () => {
+    expect(normalizeCredentialsResponse({
+      credentials: [
+        {
+          id: "gh-main",
+          name: "Main",
+          cred_type: "github",
+          username: "sangsu",
+          gh_config_dir: "/tmp/gh",
+          state: { kind: "Materialized" },
+        },
+      ],
+    })).toEqual([
+      expect.objectContaining({
+        id: "gh-main",
+        name: "Main",
+        type: "github",
+        username: "sangsu",
+        gh_config_dir: "/tmp/gh",
+        state: expect.objectContaining({ kind: "Materialized" }),
+      }),
+    ])
+  })
+
+  it("returns an empty list for unexpected payloads", () => {
+    expect(normalizeCredentialsResponse({ credentials: null })).toEqual([])
+    expect(normalizeCredentialsResponse(null)).toEqual([])
   })
 })
 

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -4,49 +4,31 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { authHeaders, get, post } from '../api/core'
+import {
+  coerceCredentialType,
+  normalizeCredentialsResponse,
+  type Credential,
+  type CredentialCreatePayload,
+  type CredentialState,
+  type CredentialType,
+} from '../api/credentials'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 
-// ── Types ────────────────────────────────────────────────
-
-export type CredentialType = 'github' | 'gitlab' | 'local'
-export type CredentialOauthMethod = 'web' | 'with_token'
-
-export interface CredentialState {
-  kind: 'Unmaterialized' | 'Materialized' | 'Stale' | string
-  last_verified_at_unix_ms?: string | number | null
-  reason?: string | null
-}
-
-export interface Credential {
-  id: string
-  name: string
-  type: CredentialType
-  username: string
-  gh_config_dir?: string | null
-  ssh_key_path?: string | null
-  gpg_key_id?: string | null
-  state?: CredentialState | null
-  token_sha256_prefix?: string | null
-  description?: string
-  config?: Record<string, unknown>
-  created_at?: string
-}
-
-export interface CredentialCreatePayload {
-  id: string
-  name: string
-  type: CredentialType
-  username: string
-  gh_config_dir?: string | null
-  ssh_key_path?: string | null
-  gpg_key_id?: string | null
-  oauth_method?: CredentialOauthMethod
-  token?: string | null
-  description?: string
-  config?: Record<string, unknown>
-}
+export {
+  coerceCredentialType,
+  isRecord,
+  normalizeCredentialsResponse,
+  parseCredentialState,
+} from '../api/credentials'
+export type {
+  Credential,
+  CredentialCreatePayload,
+  CredentialOauthMethod,
+  CredentialState,
+  CredentialType,
+} from '../api/credentials'
 
 // ── State ────────────────────────────────────────────────
 
@@ -71,32 +53,7 @@ const addDraft = signal<CredentialCreatePayload>({
 
 async function fetchCredentials(): Promise<Credential[]> {
   const data = await get<unknown>('/api/v1/credentials')
-  const rows = Array.isArray(data)
-    ? data
-    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).credentials)
-      ? (data as Record<string, unknown>).credentials as unknown[]
-      : []
-  if (Array.isArray(rows)) {
-    return rows.map((row: unknown): Credential => {
-      const r = row as Record<string, unknown>
-      const username = String(r.username ?? r.name ?? '')
-      return {
-        id: String(r.id ?? ''),
-        name: String(r.name ?? username ?? r.id ?? ''),
-        type: coerceCredentialType(r.type ?? r.cred_type),
-        username,
-        gh_config_dir: typeof r.gh_config_dir === 'string' ? r.gh_config_dir : null,
-        ssh_key_path: typeof r.ssh_key_path === 'string' ? r.ssh_key_path : null,
-        gpg_key_id: typeof r.gpg_key_id === 'string' ? r.gpg_key_id : null,
-        state: parseCredentialState(r.state),
-        token_sha256_prefix: typeof r.token_sha256_prefix === 'string' ? r.token_sha256_prefix : null,
-        description: r.description ? String(r.description) : undefined,
-        config: isRecord(r.config) ? r.config : undefined,
-        created_at: r.created_at ? String(r.created_at) : undefined,
-      }
-    })
-  }
-  return []
+  return normalizeCredentialsResponse(data)
 }
 
 async function createCredential(payload: CredentialCreatePayload): Promise<void> {
@@ -115,30 +72,6 @@ async function deleteCredential(id: string): Promise<void> {
 }
 
 // ── Helpers ──────────────────────────────────────────────
-
-export function coerceCredentialType(raw: unknown): CredentialType {
-  if (raw === 'gitlab') return 'gitlab'
-  if (raw === 'local') return 'local'
-  return 'github'
-}
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-export function parseCredentialState(raw: unknown): CredentialState | null {
-  if (!isRecord(raw)) return null
-  const kind = typeof raw.kind === 'string' ? raw.kind : null
-  if (!kind) return null
-  return {
-    kind,
-    last_verified_at_unix_ms:
-      typeof raw.last_verified_at_unix_ms === 'string' || typeof raw.last_verified_at_unix_ms === 'number'
-        ? raw.last_verified_at_unix_ms
-        : null,
-    reason: typeof raw.reason === 'string' ? raw.reason : null,
-  }
-}
 
 export function credentialTypeLabel(type: CredentialType): string {
   switch (type) {

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -197,7 +197,7 @@ export function shellQuote(value: string): string {
 export function githubLoginCommand(ghConfigDir: string | null | undefined): string | null {
   const dir = sanitizeOptionalString(ghConfigDir)
   if (!dir) return null
-  return `GH_CONFIG_DIR=${shellQuote(dir)} gh auth login --hostname github.com --git-protocol https --web`
+  return `GH_CONFIG_DIR=${shellQuote(dir)} gh auth login --hostname github.com --git-protocol https --web --clipboard`
 }
 
 export function buildCredentialCreateRequest(payload: CredentialCreatePayload): Record<string, unknown> {

--- a/dashboard/src/components/keeper-repo-mapping.test.ts
+++ b/dashboard/src/components/keeper-repo-mapping.test.ts
@@ -5,7 +5,10 @@ import {
   isAllowAll,
   toggleAllowAll,
   hasChanges,
+  hasCredentialChange,
+  normalizeCredentialId,
   buildRepoSetFromMapping,
+  buildCredentialIdFromMapping,
 } from "./keeper-repo-mapping"
 import type { KeeperRepoMapping } from "./keeper-repo-mapping"
 
@@ -97,6 +100,7 @@ describe("buildRepoSetFromMapping", () => {
       keeper_name: "Keeper 1",
       allowed_repos: ["repo-a"],
       allow_all: true,
+      credential_id: "cred-a",
     }
     expect(buildRepoSetFromMapping(mapping)).toBe("*")
   })
@@ -107,6 +111,7 @@ describe("buildRepoSetFromMapping", () => {
       keeper_name: "Keeper 1",
       allowed_repos: ["repo-a", "repo-b"],
       allow_all: false,
+      credential_id: null,
     }
     const result = buildRepoSetFromMapping(mapping)
     expect(result).toBeInstanceOf(Set)
@@ -121,9 +126,37 @@ describe("buildRepoSetFromMapping", () => {
       keeper_name: "Keeper 1",
       allowed_repos: [],
       allow_all: false,
+      credential_id: undefined,
     }
     const result = buildRepoSetFromMapping(mapping)
     expect(result).toBeInstanceOf(Set)
     expect((result as Set<string>).size).toBe(0)
+  })
+})
+
+describe("credential mapping helpers", () => {
+  it("normalizes credential ids", () => {
+    expect(normalizeCredentialId(" cred-a ")).toBe("cred-a")
+    expect(normalizeCredentialId("")).toBeNull()
+    expect(normalizeCredentialId(null)).toBeNull()
+    expect(normalizeCredentialId(undefined)).toBeNull()
+  })
+
+  it("detects credential id changes after normalization", () => {
+    expect(hasCredentialChange("k1", " cred-a ", "cred-a")).toBe(false)
+    expect(hasCredentialChange("k1", null, "")).toBe(false)
+    expect(hasCredentialChange("k1", null, "cred-a")).toBe(true)
+    expect(hasCredentialChange("k1", "cred-a", "cred-b")).toBe(true)
+  })
+
+  it("builds credential id from mapping", () => {
+    const mapping: KeeperRepoMapping = {
+      keeper_id: "k1",
+      keeper_name: "Keeper 1",
+      allowed_repos: ["*"],
+      allow_all: true,
+      credential_id: " cred-selected ",
+    }
+    expect(buildCredentialIdFromMapping(mapping)).toBe("cred-selected")
   })
 })

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -5,17 +5,18 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { get, post } from '../api/core'
+import {
+  normalizeCredentialsResponse,
+  type CredentialState,
+  type CredentialType,
+} from '../api/credentials'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import {
-  coerceCredentialType,
   credentialStateBadgeClass,
   credentialStateLabel,
   githubLoginCommand,
-  parseCredentialState,
-  type CredentialState,
-  type CredentialType,
 } from './credential-settings'
 import type { Keeper } from '../types'
 
@@ -99,23 +100,7 @@ async function fetchRepositories(): Promise<RepositoryOption[]> {
 
 async function fetchCredentials(): Promise<KeeperCredentialOption[]> {
   const data = await get<unknown>('/api/v1/credentials')
-  const rows = Array.isArray(data)
-    ? data
-    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).credentials)
-      ? (data as Record<string, unknown>).credentials as unknown[]
-      : []
-  return rows.map((row: unknown): KeeperCredentialOption => {
-    const r = row as Record<string, unknown>
-    const username = String(r.username ?? r.name ?? '')
-    return {
-      id: String(r.id ?? ''),
-      name: String(r.name ?? username ?? r.id ?? ''),
-      type: coerceCredentialType(r.type ?? r.cred_type),
-      username,
-      gh_config_dir: typeof r.gh_config_dir === 'string' ? r.gh_config_dir : null,
-      state: parseCredentialState(r.state),
-    }
-  }).filter(cred => cred.id !== '')
+  return normalizeCredentialsResponse(data).filter(cred => cred.id !== '')
 }
 
 async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -8,6 +8,15 @@ import { get, post } from '../api/core'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import {
+  coerceCredentialType,
+  credentialStateBadgeClass,
+  credentialStateLabel,
+  githubLoginCommand,
+  parseCredentialState,
+  type CredentialState,
+  type CredentialType,
+} from './credential-settings'
 import type { Keeper } from '../types'
 
 // ── Types ────────────────────────────────────────────────
@@ -23,6 +32,16 @@ export interface KeeperRepoMapping {
   keeper_name: string
   allowed_repos: string[]
   allow_all: boolean
+  credential_id?: string | null
+}
+
+export interface KeeperCredentialOption {
+  id: string
+  name: string
+  type: CredentialType
+  username: string
+  gh_config_dir?: string | null
+  state?: CredentialState | null
 }
 
 // ── State ────────────────────────────────────────────────
@@ -33,6 +52,9 @@ const keepersState = keepersResource.state
 const reposResource = createAsyncResource<RepositoryOption[]>()
 const reposState = reposResource.state
 
+const credentialsResource = createAsyncResource<KeeperCredentialOption[]>()
+const credentialsState = credentialsResource.state
+
 const mappingsResource = createAsyncResource<KeeperRepoMapping[]>()
 const mappingsState = mappingsResource.state
 
@@ -41,6 +63,7 @@ const saveError = signal<string | null>(null)
 
 // Local draft: keeper_id -> Set of repo ids or '*' for all
 const draftMappings = signal<Map<string, Set<string> | '*'>>(new Map())
+const draftCredentials = signal<Map<string, string | null>>(new Map())
 
 // ── API ──────────────────────────────────────────────────
 
@@ -74,6 +97,27 @@ async function fetchRepositories(): Promise<RepositoryOption[]> {
   return []
 }
 
+async function fetchCredentials(): Promise<KeeperCredentialOption[]> {
+  const data = await get<unknown>('/api/v1/credentials')
+  const rows = Array.isArray(data)
+    ? data
+    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).credentials)
+      ? (data as Record<string, unknown>).credentials as unknown[]
+      : []
+  return rows.map((row: unknown): KeeperCredentialOption => {
+    const r = row as Record<string, unknown>
+    const username = String(r.username ?? r.name ?? '')
+    return {
+      id: String(r.id ?? ''),
+      name: String(r.name ?? username ?? r.id ?? ''),
+      type: coerceCredentialType(r.type ?? r.cred_type),
+      username,
+      gh_config_dir: typeof r.gh_config_dir === 'string' ? r.gh_config_dir : null,
+      state: parseCredentialState(r.state),
+    }
+  }).filter(cred => cred.id !== '')
+}
+
 async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {
   const data = await get<unknown>('/api/v1/keeper-repos')
   const rows = Array.isArray(data)
@@ -93,14 +137,22 @@ async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {
             ? r.repositories.filter((v): v is string => typeof v === 'string')
           : [],
         allow_all: r.allow_all === true,
+        credential_id: normalizeCredentialId(typeof r.credential_id === 'string' ? r.credential_id : null),
       }
     })
   }
   return []
 }
 
-async function saveKeeperRepos(keeperId: string, repos: string[]): Promise<void> {
-  await post(`/api/v1/keeper-repos/${encodeURIComponent(keeperId)}`, { repositories: repos })
+async function saveKeeperRepos(
+  keeperId: string,
+  repos: string[],
+  credentialId: string | null,
+): Promise<void> {
+  await post(`/api/v1/keeper-repos/${encodeURIComponent(keeperId)}`, {
+    repositories: repos,
+    credential_id: normalizeCredentialId(credentialId),
+  })
 }
 
 // ── Helpers ──────────────────────────────────────────────
@@ -108,6 +160,16 @@ async function saveKeeperRepos(keeperId: string, repos: string[]): Promise<void>
 function getDraftForKeeper(keeperId: string, fallback: Set<string> | '*'): Set<string> | '*' {
   const draft = draftMappings.value.get(keeperId)
   return draft !== undefined ? draft : fallback
+}
+
+function getDraftCredentialForKeeper(keeperId: string, fallback: string | null): string | null {
+  const draft = draftCredentials.value.get(keeperId)
+  return draft !== undefined ? draft : fallback
+}
+
+export function normalizeCredentialId(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? ''
+  return trimmed === '' ? null : trimmed
 }
 
 export function isRepoSelected(_keeperId: string, repoId: string, current: Set<string> | '*'): boolean {
@@ -152,9 +214,21 @@ export function hasChanges(_keeperId: string, original: Set<string> | '*', draft
   return false
 }
 
+export function hasCredentialChange(
+  _keeperId: string,
+  original: string | null | undefined,
+  draft: string | null | undefined,
+): boolean {
+  return normalizeCredentialId(original) !== normalizeCredentialId(draft)
+}
+
 export function buildRepoSetFromMapping(mapping: KeeperRepoMapping): Set<string> | '*' {
   if (mapping.allow_all) return '*'
   return new Set(mapping.allowed_repos)
+}
+
+export function buildCredentialIdFromMapping(mapping: KeeperRepoMapping): string | null {
+  return normalizeCredentialId(mapping.credential_id)
 }
 
 // ── Load / Refresh ───────────────────────────────────────
@@ -174,38 +248,50 @@ export async function loadKeeperRepoMappings(options?: { force?: boolean }): Pro
     await reposResource.load(() => fetchRepositories())
   }
 
+  const loadCredentials = async () => {
+    if (!force && credentialsState.value.status === 'loaded') return
+    if (force) credentialsResource.reset()
+    await credentialsResource.load(() => fetchCredentials())
+  }
+
   const loadMappings = async () => {
     if (!force && mappingsState.value.status === 'loaded') return
     if (force) mappingsResource.reset()
     await mappingsResource.load(() => fetchKeeperRepoMappings())
   }
 
-  await Promise.all([loadKeepers(), loadRepos(), loadMappings()])
+  await Promise.all([loadKeepers(), loadRepos(), loadCredentials(), loadMappings()])
 
   // Initialize drafts from loaded mappings
-  if (mappingsState.value.status === 'loaded' && draftMappings.value.size === 0) {
-    const next = new Map<string, Set<string> | '*'>()
+  if (mappingsState.value.status === 'loaded' && (force || draftMappings.value.size === 0)) {
+    const nextMappings = new Map<string, Set<string> | '*'>()
+    const nextCredentials = new Map<string, string | null>()
     for (const m of mappingsState.value.data) {
-      next.set(m.keeper_id, buildRepoSetFromMapping(m))
+      nextMappings.set(m.keeper_id, buildRepoSetFromMapping(m))
+      nextCredentials.set(m.keeper_id, buildCredentialIdFromMapping(m))
     }
     // Also initialize empty drafts for keepers without mappings
     if (keepersState.value.status === 'loaded') {
       for (const k of keepersState.value.data) {
         const id = k.keeper_id ?? k.name
-        if (!next.has(id)) {
-          next.set(id, '*')
+        if (!nextMappings.has(id)) {
+          nextMappings.set(id, '*')
+          nextCredentials.set(id, null)
         }
       }
     }
-    draftMappings.value = next
+    draftMappings.value = nextMappings
+    draftCredentials.value = nextCredentials
   }
 }
 
 export function resetKeeperRepoMappings(): void {
   keepersResource.reset()
   reposResource.reset()
+  credentialsResource.reset()
   mappingsResource.reset()
   draftMappings.value = new Map()
+  draftCredentials.value = new Map()
   savingKeeperId.value = null
   saveError.value = null
 }
@@ -225,6 +311,7 @@ function RepoBadge({ name }: { name: string }) {
 export function KeeperRepoMapping() {
   const kState = keepersState.value
   const rState = reposState.value
+  const cState = credentialsState.value
   const mState = mappingsState.value
 
   // Trigger load on first render
@@ -232,7 +319,7 @@ export function KeeperRepoMapping() {
     void loadKeeperRepoMappings()
   }
 
-  if (kState.status === 'loading' || rState.status === 'loading' || mState.status === 'loading') {
+  if (kState.status === 'loading' || rState.status === 'loading' || cState.status === 'loading' || mState.status === 'loading') {
     return html`<${LoadingState}>키퍼와 저장소 정보 불러오는 중...<//>`
   }
 
@@ -242,16 +329,20 @@ export function KeeperRepoMapping() {
   if (rState.status === 'error') {
     return html`<${ErrorState} message=${rState.message} />`
   }
+  if (cState.status === 'error') {
+    return html`<${ErrorState} message=${cState.message} />`
+  }
   if (mState.status === 'error') {
     return html`<${ErrorState} message=${mState.message} />`
   }
 
-  if (kState.status !== 'loaded' || rState.status !== 'loaded') {
+  if (kState.status !== 'loaded' || rState.status !== 'loaded' || cState.status !== 'loaded') {
     return null
   }
 
   const keepers = kState.data
   const repos = rState.data
+  const credentials = cState.data.filter(credential => credential.type === 'github')
   const mappings = mState.status === 'loaded' ? mState.data : []
   const mappingByKeeper = new Map(mappings.map(m => [m.keeper_id, m]))
 
@@ -262,10 +353,11 @@ export function KeeperRepoMapping() {
     if (draft === undefined) return
 
     const payload = draft === '*' ? ['*'] : Array.from(draft)
+    const credentialId = getDraftCredentialForKeeper(keeperId, null)
     savingKeeperId.value = keeperId
     saveError.value = null
     try {
-      await saveKeeperRepos(keeperId, payload)
+      await saveKeeperRepos(keeperId, payload, credentialId)
       showToast('저장소 매핑 저장 완료', 'success')
       // Update the "original" mapping state so hasChanges resets
       await loadKeeperRepoMappings({ force: true })
@@ -296,6 +388,12 @@ export function KeeperRepoMapping() {
     const nextMap = new Map(draftMappings.value)
     nextMap.set(keeperId, next)
     draftMappings.value = nextMap
+  }
+
+  function handleCredentialChange(keeperId: string, value: string) {
+    const nextMap = new Map(draftCredentials.value)
+    nextMap.set(keeperId, normalizeCredentialId(value))
+    draftCredentials.value = nextMap
   }
 
   return html`
@@ -329,8 +427,32 @@ export function KeeperRepoMapping() {
             const mapping = mappingByKeeper.get(keeperId)
             const original = mapping ? buildRepoSetFromMapping(mapping) : '*'
             const draft = getDraftForKeeper(keeperId, original)
+            const originalCredentialId = mapping ? buildCredentialIdFromMapping(mapping) : null
+            const draftCredentialId = getDraftCredentialForKeeper(keeperId, originalCredentialId)
+            const credentialOptions =
+              draftCredentialId && !credentials.some(credential => credential.id === draftCredentialId)
+                ? [
+                    {
+                      id: draftCredentialId,
+                      name: `Missing: ${draftCredentialId}`,
+                      type: 'github' as const,
+                      username: draftCredentialId,
+                      gh_config_dir: null,
+                      state: null,
+                    },
+                    ...credentials,
+                  ]
+                : credentials
+            const selectedCredential = draftCredentialId
+              ? credentialOptions.find(credential => credential.id === draftCredentialId)
+              : null
+            const selectedLoginCommand = selectedCredential
+              ? githubLoginCommand(selectedCredential.gh_config_dir)
+              : null
             const allowAll = isAllowAll(keeperId, draft)
-            const changed = hasChanges(keeperId, original, draft)
+            const repoChanged = hasChanges(keeperId, original, draft)
+            const credentialChanged = hasCredentialChange(keeperId, originalCredentialId, draftCredentialId)
+            const changed = repoChanged || credentialChanged
             const isSaving = savingKeeperId.value === keeperId
 
             return html`
@@ -361,6 +483,47 @@ export function KeeperRepoMapping() {
                 </div>
 
                 <div class="p-3">
+                  <div class="mb-3 rounded border border-card-border/40 bg-[var(--white-3)] px-2.5 py-2">
+                    <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                      <label class="flex flex-col gap-1 min-w-0 md:min-w-[18rem]">
+                        <span class="text-2xs font-bold uppercase tracking-wide text-text-muted">GitHub credential</span>
+                        <select
+                          class="rounded border border-card-border/60 bg-card px-2 py-1.5 text-xs text-text-body outline-none focus:border-accent"
+                          value=${draftCredentialId ?? ''}
+                          onChange=${(event: Event) => {
+                            const target = event.currentTarget as HTMLSelectElement
+                            handleCredentialChange(keeperId, target.value)
+                          }}
+                        >
+                          <option value="">기본값: repo credential / local root</option>
+                          ${credentialOptions.map(credential => html`
+                            <option key=${credential.id} value=${credential.id}>
+                              ${credential.name || credential.id} (${credential.username || credential.id})
+                            </option>
+                          `)}
+                        </select>
+                      </label>
+
+                      <div class="flex flex-col gap-1 min-w-0 text-2xs text-text-muted md:items-end">
+                        ${selectedCredential ? html`
+                          <div class="flex items-center gap-1.5 min-w-0">
+                            <span class="px-2 py-0.5 rounded border ${credentialStateBadgeClass(selectedCredential.state)}">
+                              ${credentialStateLabel(selectedCredential.state)}
+                            </span>
+                            <span class="font-mono truncate">${selectedCredential.gh_config_dir ?? 'gh_config_dir 없음'}</span>
+                          </div>
+                          ${selectedLoginCommand ? html`
+                            <code class="block max-w-full overflow-x-auto rounded bg-[var(--black-30)] px-2 py-1 font-mono text-3xs text-text-body">
+                              ${selectedLoginCommand}
+                            </code>
+                          ` : null}
+                        ` : html`
+                          <span>직접 지정 없음</span>
+                        `}
+                      </div>
+                    </div>
+                  </div>
+
                   <label class="flex items-center gap-2 mb-3 cursor-pointer select-none">
                     <input
                       type="checkbox"

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -23,12 +23,16 @@ let mapping_of_toml toml keeper_id =
   let* repository_ids =
     Otoml.Helpers.find_strings_result toml (path "repositories")
   in
-  let github_credential_id =
-    match Otoml.find_result toml Otoml.get_string (path "credential_id") with
-    | Ok id ->
+  let* github_credential_id =
+    match Otoml.find_result toml Fun.id (path "credential_id") with
+    | Error _ -> Ok None
+    | Ok (Otoml.TomlString id) ->
         let id = String.trim id in
-        if id = "" then None else Some id
-    | Error _ -> None
+        Ok (if id = "" then None else Some id)
+    | Ok _ ->
+        Error
+          (Printf.sprintf
+             "mapping.%s.credential_id must be a string when present" keeper_id)
   in
   Ok { keeper_id; repository_ids; github_credential_id }
 

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -30,6 +30,11 @@ let mapping_of_toml toml keeper_id =
   in
   Ok { keeper_id; repository_ids; github_credential_id }
 
+let credential_type_label = function
+  | Github -> "GitHub"
+  | Gitlab -> "GitLab"
+  | Local -> "Local"
+
 let toml_of_mapping mapping =
   let fields =
     [
@@ -124,7 +129,14 @@ let credentials_for_keeper ~base_path ~keeper_id =
       (match mapping.github_credential_id with
       | Some id when String.trim id <> "" ->
           let* credential = resolve_credential id in
-          Ok [credential]
+          if credential.cred_type <> Github then
+            Error
+              (Printf.sprintf
+                 "credential %s referenced by github_credential_id for keeper %s \
+                  must be of type GitHub, got %s"
+                 id keeper_id (credential_type_label credential.cred_type))
+          else
+            Ok [credential]
       | Some _ | None ->
       let* repos = Repo_store.load_all ~base_path in
       let mapped_repos =

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -25,8 +25,10 @@ let mapping_of_toml toml keeper_id =
   in
   let github_credential_id =
     match Otoml.find_result toml Otoml.get_string (path "credential_id") with
-    | Ok id when String.trim id <> "" -> Some id
-    | Ok _ | Error _ -> None
+    | Ok id ->
+        let id = String.trim id in
+        if id = "" then None else Some id
+    | Error _ -> None
   in
   Ok { keeper_id; repository_ids; github_credential_id }
 
@@ -45,9 +47,11 @@ let toml_of_mapping mapping =
   in
   let fields =
     match mapping.github_credential_id with
-    | Some id when String.trim id <> "" ->
-        ("credential_id", Otoml.TomlString id) :: fields
-    | Some _ | None -> fields
+    | Some id ->
+        let id = String.trim id in
+        if id = "" then fields
+        else ("credential_id", Otoml.TomlString id) :: fields
+    | None -> fields
   in
   Otoml.TomlTable fields
 
@@ -128,6 +132,7 @@ let credentials_for_keeper ~base_path ~keeper_id =
       in
       (match mapping.github_credential_id with
       | Some id when String.trim id <> "" ->
+          let id = String.trim id in
           let* credential = resolve_credential id in
           if credential.cred_type <> Github then
             Error

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -23,15 +23,28 @@ let mapping_of_toml toml keeper_id =
   let* repository_ids =
     Otoml.Helpers.find_strings_result toml (path "repositories")
   in
-  Ok { keeper_id; repository_ids }
+  let github_credential_id =
+    match Otoml.find_result toml Otoml.get_string (path "credential_id") with
+    | Ok id when String.trim id <> "" -> Some id
+    | Ok _ | Error _ -> None
+  in
+  Ok { keeper_id; repository_ids; github_credential_id }
 
 let toml_of_mapping mapping =
-  Otoml.TomlTable
+  let fields =
     [
       ( "repositories",
         Otoml.TomlArray
           (List.map (fun s -> Otoml.TomlString s) mapping.repository_ids) );
     ]
+  in
+  let fields =
+    match mapping.github_credential_id with
+    | Some id when String.trim id <> "" ->
+        ("credential_id", Otoml.TomlString id) :: fields
+    | Some _ | None -> fields
+  in
+  Otoml.TomlTable fields
 
 let load_all ~base_path =
   let path = mappings_toml_path base_path in
@@ -98,6 +111,21 @@ let credentials_for_keeper ~base_path ~keeper_id =
           keeper_id msg;
       Ok []
   | Ok mapping ->
+      let resolve_credential id =
+        match Credential_store.find ~base_path id with
+        | Ok c -> Ok c
+        | Error msg ->
+            Error
+              (Printf.sprintf
+                 "credential %s referenced by mapping for keeper %s not found \
+                  in credential store: %s"
+                 id keeper_id msg)
+      in
+      (match mapping.github_credential_id with
+      | Some id when String.trim id <> "" ->
+          let* credential = resolve_credential id in
+          Ok [credential]
+      | Some _ | None ->
       let* repos = Repo_store.load_all ~base_path in
       let mapped_repos =
         if List.exists (String.equal "*") mapping.repository_ids then
@@ -123,16 +151,11 @@ let credentials_for_keeper ~base_path ~keeper_id =
       let rec resolve_creds acc = function
         | [] -> Ok (List.rev acc)
         | id :: rest -> (
-            match Credential_store.find ~base_path id with
+            match resolve_credential id with
             | Ok c -> resolve_creds (c :: acc) rest
-            | Error msg ->
-                Error
-                  (Printf.sprintf
-                     "credential %s referenced by mapping for keeper %s \
-                      not found in credential store: %s"
-                     id keeper_id msg))
+            | Error msg -> Error msg)
       in
-      resolve_creds [] cred_ids
+      resolve_creds [] cred_ids)
 
 let is_allowed ~keeper_id ~repository_id ~base_path =
   match find_mapping ~base_path keeper_id with

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -13,10 +13,11 @@ val credentials_for_keeper :
   base_path:string -> keeper_id:string -> (credential list, string) result
 (** [credentials_for_keeper ~base_path ~keeper_id] resolves the
     credential currently mapped to [keeper_id].  A direct
-    [credential_id] on the keeper mapping wins; otherwise this resolves
-    the unique credentials by walking every repository the keeper is
-    allowed to access and looking up each repository's [credential_id] in
-    the credential store.
+    [github_credential_id] / [credential_id] TOML or JSON field on the
+    keeper mapping wins and must reference a GitHub credential; otherwise
+    this resolves the unique credentials by walking every repository the
+    keeper is allowed to access and looking up each repository's
+    [credential_id] in the credential store.
 
     Returns [Ok []] when the keeper has no mapping (backward-compatibility
     signal consumed by the RFC-0019 PR-A credential provider bridge).

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -11,10 +11,12 @@ val allowed_repositories :
 
 val credentials_for_keeper :
   base_path:string -> keeper_id:string -> (credential list, string) result
-(** [credentials_for_keeper ~base_path ~keeper_id] resolves the unique
-    credentials currently mapped to [keeper_id] by walking every
-    repository the keeper is allowed to access and looking up each
-    repository's [credential_id] in the credential store.
+(** [credentials_for_keeper ~base_path ~keeper_id] resolves the
+    credential currently mapped to [keeper_id].  A direct
+    [credential_id] on the keeper mapping wins; otherwise this resolves
+    the unique credentials by walking every repository the keeper is
+    allowed to access and looking up each repository's [credential_id] in
+    the credential store.
 
     Returns [Ok []] when the keeper has no mapping (backward-compatibility
     signal consumed by the RFC-0019 PR-A credential provider bridge).

--- a/lib/repo_manager/repo_manager_types.ml
+++ b/lib/repo_manager/repo_manager_types.ml
@@ -70,5 +70,6 @@ type credential = {
 type keeper_repo_mapping = {
   keeper_id : string;
   repository_ids : string list;
+  github_credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]

--- a/lib/repo_manager/repo_manager_types.mli
+++ b/lib/repo_manager/repo_manager_types.mli
@@ -51,5 +51,6 @@ type credential = {
 type keeper_repo_mapping = {
   keeper_id : string;
   repository_ids : string list;
+  github_credential_id : string option [@default None];
 }
 [@@deriving yojson, show, eq]

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -29,6 +29,10 @@ let mapping_json (m : Repo_manager_types.keeper_repo_mapping) : Yojson.Safe.t =
       ("repositories", `List (List.map (fun s -> `String s) m.repository_ids));
       ("allowed_repos", `List (List.map (fun s -> `String s) m.repository_ids));
       ("allow_all", `Bool allow_all);
+      ( "credential_id",
+        match m.github_credential_id with
+        | Some id -> `String id
+        | None -> `Null );
     ]
 
 let mapping_of_json keeper_id (json : Yojson.Safe.t) :
@@ -45,6 +49,14 @@ let mapping_of_json keeper_id (json : Yojson.Safe.t) :
     | Some _ -> Error (Printf.sprintf "field %s must be an array of strings" key)
     | None -> Error (Printf.sprintf "missing field %s" key)
   in
+  let optional_string_field fields key =
+    match List.assoc_opt key fields with
+    | None | Some `Null -> Ok None
+    | Some (`String s) ->
+        let s = String.trim s in
+        Ok (if s = "" then None else Some s)
+    | Some _ -> Error (Printf.sprintf "field %s must be a string or null" key)
+  in
   match json with
   | `Assoc fields -> (
       let repository_ids =
@@ -52,9 +64,15 @@ let mapping_of_json keeper_id (json : Yojson.Safe.t) :
         | Some _ -> list_field fields "repositories"
         | None -> list_field fields "repos"
       in
-      match repository_ids with
-      | Ok repository_ids -> Ok { Repo_manager_types.keeper_id; repository_ids }
-      | Error msg -> Error msg)
+      match (repository_ids, optional_string_field fields "credential_id") with
+      | Ok repository_ids, Ok credential_id ->
+          Ok
+            {
+              Repo_manager_types.keeper_id;
+              repository_ids;
+              github_credential_id = credential_id;
+            }
+      | Error msg, _ | _, Error msg -> Error msg)
   | _ -> Error "expected JSON object body"
 
 let handle_list_mappings state req reqd =
@@ -77,20 +95,54 @@ let handle_list_mappings state req reqd =
 
 let handle_get_mapping state keeper_id req reqd =
   let base_path = state.Mcp_server.room_config.base_path in
-  match Keeper_repo_mapping.allowed_repositories ~keeper_id ~base_path with
-  | Ok repo_ids ->
+  let mapping =
+    match Keeper_repo_mapping.load_all ~base_path with
+    | Ok mappings ->
+        List.find_opt
+          (fun (m : Repo_manager_types.keeper_repo_mapping) ->
+            String.equal m.keeper_id keeper_id)
+          mappings
+    | Error _ -> None
+  in
+  match mapping with
+  | Some mapping ->
       Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string
-           (mapping_json { Repo_manager_types.keeper_id; repository_ids = repo_ids }))
+        (Yojson.Safe.to_string (mapping_json mapping))
         reqd
-  | Error _ ->
+  | None ->
       (* No mapping is intentionally treated as wildcard access for backward
          compatibility with pre-repository keepers. *)
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string
            (mapping_json
-              { Repo_manager_types.keeper_id; repository_ids = ["*"] }))
+              {
+                Repo_manager_types.keeper_id;
+                repository_ids = ["*"];
+                github_credential_id = None;
+              }))
         reqd
+
+let validate_mapping_credential ~base_path
+    (mapping : Repo_manager_types.keeper_repo_mapping) =
+  match mapping.github_credential_id with
+  | None -> Ok ()
+  | Some credential_id -> (
+      match Credential_store.find ~base_path credential_id with
+      | Error msg ->
+          Error
+            (Printf.sprintf "credential_id %s not found: %s" credential_id msg)
+      | Ok credential ->
+          if credential.cred_type = Repo_manager_types.Github then Ok ()
+          else
+            Error
+              (Printf.sprintf
+                 "credential_id %s is %s; keeper GitHub credential must be \
+                  Github"
+                 credential_id
+                 (match credential.cred_type with
+                 | Repo_manager_types.Github -> "Github"
+                 | Repo_manager_types.Gitlab -> "Gitlab"
+                 | Repo_manager_types.Local -> "Local")))
 
 let handle_save_mapping state keeper_id req reqd =
   let base_path = state.Mcp_server.room_config.base_path in
@@ -107,12 +159,15 @@ let handle_save_mapping state keeper_id req reqd =
           match mapping_of_json keeper_id json with
           | Error msg -> response `Bad_request msg
           | Ok mapping -> (
-              match Keeper_repo_mapping.save_mapping ~base_path mapping with
+              match validate_mapping_credential ~base_path mapping with
               | Error msg -> response `Bad_request msg
-              | Ok () ->
-                  Http.Response.json ~request:req
-                    (Yojson.Safe.to_string (mapping_json mapping))
-                    reqd)))
+              | Ok () -> (
+                  match Keeper_repo_mapping.save_mapping ~base_path mapping with
+                  | Error msg -> response `Bad_request msg
+                  | Ok () ->
+                      Http.Response.json ~request:req
+                        (Yojson.Safe.to_string (mapping_json mapping))
+                        reqd))))
 
 let add_routes router =
   router

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -122,6 +122,11 @@ let handle_get_mapping state keeper_id req reqd =
               }))
         reqd
 
+let credential_type_label = function
+  | Repo_manager_types.Github -> "GitHub"
+  | Repo_manager_types.Gitlab -> "GitLab"
+  | Repo_manager_types.Local -> "Local"
+
 let validate_mapping_credential ~base_path
     (mapping : Repo_manager_types.keeper_repo_mapping) =
   match mapping.github_credential_id with
@@ -136,13 +141,9 @@ let validate_mapping_credential ~base_path
           else
             Error
               (Printf.sprintf
-                 "credential_id %s is %s; keeper GitHub credential must be \
-                  Github"
-                 credential_id
-                 (match credential.cred_type with
-                 | Repo_manager_types.Github -> "Github"
-                 | Repo_manager_types.Gitlab -> "Gitlab"
-                 | Repo_manager_types.Local -> "Local")))
+                 "credential_id %s is %s; keeper credential must be of type \
+                  GitHub"
+                 credential_id (credential_type_label credential.cred_type)))
 
 let handle_save_mapping state keeper_id req reqd =
   let base_path = state.Mcp_server.room_config.base_path in

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -31,7 +31,8 @@ let mapping_json (m : Repo_manager_types.keeper_repo_mapping) : Yojson.Safe.t =
       ("allow_all", `Bool allow_all);
       ( "credential_id",
         match m.github_credential_id with
-        | Some id -> `String id
+        | Some id when String.trim id <> "" -> `String (String.trim id)
+        | Some _ -> `Null
         | None -> `Null );
     ]
 
@@ -95,32 +96,35 @@ let handle_list_mappings state req reqd =
 
 let handle_get_mapping state keeper_id req reqd =
   let base_path = state.Mcp_server.room_config.base_path in
-  let mapping =
-    match Keeper_repo_mapping.load_all ~base_path with
-    | Ok mappings ->
+  match Keeper_repo_mapping.load_all ~base_path with
+  | Error msg ->
+      Http.Response.json ~status:`Internal_server_error ~request:req
+        (Yojson.Safe.to_string
+           (`Assoc [("ok", `Bool false); ("error", `String msg)]))
+        reqd
+  | Ok mappings -> (
+      match
         List.find_opt
           (fun (m : Repo_manager_types.keeper_repo_mapping) ->
             String.equal m.keeper_id keeper_id)
           mappings
-    | Error _ -> None
-  in
-  match mapping with
-  | Some mapping ->
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string (mapping_json mapping))
-        reqd
-  | None ->
-      (* No mapping is intentionally treated as wildcard access for backward
-         compatibility with pre-repository keepers. *)
-      Http.Response.json ~compress:true ~request:req
-        (Yojson.Safe.to_string
-           (mapping_json
-              {
-                Repo_manager_types.keeper_id;
-                repository_ids = ["*"];
-                github_credential_id = None;
-              }))
-        reqd
+      with
+      | Some mapping ->
+          Http.Response.json ~compress:true ~request:req
+            (Yojson.Safe.to_string (mapping_json mapping))
+            reqd
+      | None ->
+          (* No mapping is intentionally treated as wildcard access for backward
+             compatibility with pre-repository keepers. *)
+          Http.Response.json ~compress:true ~request:req
+            (Yojson.Safe.to_string
+               (mapping_json
+                  {
+                    Repo_manager_types.keeper_id;
+                    repository_ids = ["*"];
+                    github_credential_id = None;
+                  }))
+            reqd)
 
 let credential_type_label = function
   | Repo_manager_types.Github -> "GitHub"

--- a/test/stanzas/test_keeper_usage_trust_anthropic_cache_9959.inc
+++ b/test/stanzas/test_keeper_usage_trust_anthropic_cache_9959.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_usage_trust_anthropic_cache_9959)
  (modules test_keeper_usage_trust_anthropic_cache_9959)
- (libraries masc_mcp alcotest))
+ (libraries masc_test_deps))

--- a/test/test_approval_callback_wired.ml
+++ b/test/test_approval_callback_wired.ml
@@ -28,8 +28,9 @@
     gate and are not acceptable. *)
 
 module AC = Masc_mcp.Approval_callbacks
+module Hooks = Agent_sdk.Hooks
 
-let check_reject name (result : Masc_mcp.Agent_sdk.Hooks.approval_decision) =
+let check_reject name (result : Hooks.approval_decision) =
   match result with
   | Reject reason ->
       Alcotest.(check bool)
@@ -43,7 +44,7 @@ let check_reject name (result : Masc_mcp.Agent_sdk.Hooks.approval_decision) =
       Alcotest.fail
         (Printf.sprintf "%s: expected Reject, got Edit" name)
 
-let check_approve name (result : Masc_mcp.Agent_sdk.Hooks.approval_decision) =
+let check_approve name (result : Hooks.approval_decision) =
   match result with
   | Approve -> ()
   | Reject reason ->
@@ -69,7 +70,7 @@ let test_reject_by_default_rejects_any_tool () =
     tools
 
 let test_reject_by_default_reason_mentions_tool () =
-  let decision : Masc_mcp.Agent_sdk.Hooks.approval_decision =
+  let decision : Hooks.approval_decision =
     AC.reject_by_default ~tool_name:"masc_worktree_create"
       ~input:(`Assoc [])
   in

--- a/test/test_cost_ledger_pricing_model_10318.ml
+++ b/test/test_cost_ledger_pricing_model_10318.ml
@@ -23,7 +23,6 @@
 open Alcotest
 
 module H  = Masc_mcp.Keeper_hooks_oas
-module Oas = Masc_mcp.Oas
 
 (* ------------------------------------------------------------------ *)
 (* Helpers                                                             *)

--- a/test/test_credential_provider_bridge.ml
+++ b/test/test_credential_provider_bridge.ml
@@ -24,6 +24,8 @@
        this rather than silently fall back.
     6. Wildcard ["*"] mapping → returns credentials for every
        registered repository (deduplicated by credential id).
+    7. Direct keeper credential mapping → returns that credential even
+       when repo-derived credentials are ambiguous or missing.
 
     Integration of [Host_config_provider.resolve] itself with
     [Coord.config] + filesystem bundles is exercised by
@@ -50,6 +52,11 @@ let with_temp_base_path f =
   Unix.mkdir masc_dir 0o755;
   let cfg_dir = Filename.concat masc_dir "config" in
   Unix.mkdir cfg_dir 0o755;
+  let repos_path = Filename.concat cfg_dir "repositories.toml" in
+  let oc = open_out repos_path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc "[repository]\n");
   Fun.protect
     ~finally:(fun () ->
       let rec rm_rf path =
@@ -64,15 +71,21 @@ let with_temp_base_path f =
       rm_rf dir)
     (fun () -> f dir)
 
-let write_mapping base_path keeper_id repo_ids =
+let write_mapping ?credential_id base_path keeper_id repo_ids =
   let path =
     Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
   in
   let entries =
     String.concat ", " (List.map (fun s -> "\"" ^ s ^ "\"") repo_ids)
   in
+  let credential_line =
+    match credential_id with
+    | Some id -> Printf.sprintf "credential_id = \"%s\"\n" id
+    | None -> ""
+  in
   let content =
-    Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n" keeper_id entries
+    Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n%s" keeper_id
+      entries credential_line
   in
   let oc = open_out path in
   Fun.protect
@@ -255,6 +268,29 @@ let test_wildcard_mapping_returns_all_credentials () =
           Alcotest.(check bool) "has cred-B" true (List.mem "cred-B" ids)
       | Error msg -> Alcotest.failf "unexpected error: %s" msg)
 
+(* --- 7. Direct keeper credential mapping wins over repo derivation --- *)
+
+let test_direct_mapping_returns_selected_credential () =
+  with_temp_base_path (fun base_path ->
+      seed_credential ~base_path
+        (make_credential ~id:"cred-selected" ~username:"keeper-user"
+           ~gh_config_dir:"/tmp/selected/gh");
+      seed_repo ~base_path
+        (make_repo ~id:"repo-1" ~credential_id:"cred-missing-repo");
+      write_mapping ~credential_id:"cred-selected" base_path "keeper-1"
+        [ "repo-1" ];
+      match
+        Keeper_repo_mapping.credentials_for_keeper
+          ~base_path ~keeper_id:"keeper-1"
+      with
+      | Ok [ c ] ->
+          Alcotest.(check string) "credential id" "cred-selected" c.id;
+          Alcotest.(check string) "credential username" "keeper-user" c.username
+      | Ok creds ->
+          Alcotest.failf "expected exactly one direct credential, got %d"
+            (List.length creds)
+      | Error msg -> Alcotest.failf "unexpected error: %s" msg)
+
 let () =
   Alcotest.run "credential_provider_bridge"
     [
@@ -272,5 +308,7 @@ let () =
             test_missing_credential_yields_error;
           Alcotest.test_case "wildcard mapping resolves all" `Quick
             test_wildcard_mapping_returns_all_credentials;
+          Alcotest.test_case "direct keeper credential mapping wins" `Quick
+            test_direct_mapping_returns_selected_credential;
         ] );
     ]

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -5,7 +5,6 @@
     the nearest-rank percentile in {!Dashboard_oas_bridge.summary}. *)
 
 module DOB = Masc_mcp.Dashboard_oas_bridge
-module Oas = Masc_mcp.Oas
 module Json = Yojson.Safe.Util
 
 let make_sample

--- a/test/test_keeper_hooks_oas_pricing.ml
+++ b/test/test_keeper_hooks_oas_pricing.ml
@@ -10,7 +10,6 @@
    non-zero cost for non-zero tokens). *)
 
 module Hooks = Masc_mcp.Keeper_hooks_oas
-module Oas = Masc_mcp.Oas
 module Pricing = Llm_provider.Pricing
 module Prom = Masc_mcp.Prometheus
 

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -50,12 +50,20 @@ let with_empty_temp_base_path f =
       rm_rf dir)
     (fun () -> f dir)
 
-let write_mapping base_path keeper_id repo_ids =
+let write_mapping ?credential_id base_path keeper_id repo_ids =
   let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
   let entries =
     String.concat ", " (List.map (fun s -> "\"" ^ s ^ "\"") repo_ids)
   in
-  let content = Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n" keeper_id entries in
+  let credential_line =
+    match credential_id with
+    | Some id -> Printf.sprintf "credential_id = \"%s\"\n" id
+    | None -> ""
+  in
+  let content =
+    Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n%s" keeper_id entries
+      credential_line
+  in
   let oc = open_out path in
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
 
@@ -243,7 +251,11 @@ let test_allowed_repositories_no_mapping () =
 let test_save_mapping_creates_config_dir () =
   with_empty_temp_base_path (fun base_path ->
       let mapping =
-        { keeper_id = "keeper-new"; repository_ids = [ "repo-a"; "repo-b" ] }
+        {
+          keeper_id = "keeper-new";
+          repository_ids = [ "repo-a"; "repo-b" ];
+          github_credential_id = None;
+        }
       in
       match Keeper_repo_mapping.save_mapping ~base_path mapping with
       | Error e -> Alcotest.fail ("save_mapping failed: " ^ e)
@@ -253,6 +265,28 @@ let test_save_mapping_creates_config_dir () =
           | Ok ids ->
               Alcotest.(check int) "saved count" 2 (List.length ids);
               Alcotest.(check bool) "has repo-a" true (List.mem "repo-a" ids)))
+
+let test_save_mapping_preserves_credential_id () =
+  with_empty_temp_base_path (fun base_path ->
+      let mapping =
+        {
+          keeper_id = "keeper-new";
+          repository_ids = ["*"];
+          github_credential_id = Some "cred-selected";
+        }
+      in
+      match Keeper_repo_mapping.save_mapping ~base_path mapping with
+      | Error e -> Alcotest.fail ("save_mapping failed: " ^ e)
+      | Ok () -> (
+          match Keeper_repo_mapping.load_all ~base_path with
+          | Error e -> Alcotest.fail ("load_all failed: " ^ e)
+          | Ok [loaded] ->
+              Alcotest.(check (option string))
+                "credential id"
+                (Some "cred-selected")
+                loaded.github_credential_id
+          | Ok rows ->
+              Alcotest.failf "expected one mapping, got %d" (List.length rows)))
 
 let sample_credential id cred_type =
   {
@@ -316,6 +350,39 @@ let test_credentials_for_keeper_wildcard () =
                    Alcotest.(check bool) "has cred-1" true (List.mem "cred-1" ids);
                    Alcotest.(check bool) "has cred-2" true (List.mem "cred-2" ids)))))
 
+let test_credentials_for_keeper_direct_credential_overrides_repo () =
+  with_temp_base_path (fun base_path ->
+      let selected = sample_credential "cred-selected" Github in
+      let repo_a =
+        {
+          (sample_repo "repo-a") with
+          local_path = repo_under_base base_path "repo-a";
+          credential_id = "cred-missing-repo";
+        }
+      in
+      write_repositories base_path [repo_a];
+      (match Credential_store.add ~base_path selected with
+       | Error e -> Alcotest.fail ("add selected failed: " ^ e)
+       | Ok _ -> (
+           write_mapping ~credential_id:"cred-selected" base_path "keeper-1" [ "repo-a" ];
+           match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"keeper-1" with
+           | Error e -> Alcotest.fail ("credentials_for_keeper failed: " ^ e)
+           | Ok creds ->
+               Alcotest.(check int) "count" 1 (List.length creds);
+               Alcotest.(check string) "cred id" "cred-selected" (List.hd creds).id)))
+
+let test_credentials_for_keeper_direct_missing_credential () =
+  with_temp_base_path (fun base_path ->
+      write_mapping ~credential_id:"cred-missing" base_path "keeper-1" [ "*" ];
+      match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"keeper-1" with
+      | Ok creds ->
+          Alcotest.failf "expected Error for missing direct credential, got %d creds"
+            (List.length creds)
+      | Error msg ->
+          Alcotest.(check bool)
+            "mentions missing credential"
+            true (contains_substring msg "cred-missing"))
+
 let test_credentials_for_keeper_no_mapping () =
   with_temp_base_path (fun base_path ->
       match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"unknown" with
@@ -356,11 +423,14 @@ let () =
       ( "save_mapping",
         [
           Alcotest.test_case "creates config dir" `Quick test_save_mapping_creates_config_dir;
+          Alcotest.test_case "preserves credential id" `Quick test_save_mapping_preserves_credential_id;
         ] );
       ( "credentials_for_keeper",
         [
           Alcotest.test_case "explicit mapping" `Quick test_credentials_for_keeper_explicit;
           Alcotest.test_case "wildcard mapping" `Quick test_credentials_for_keeper_wildcard;
+          Alcotest.test_case "direct credential overrides repo" `Quick test_credentials_for_keeper_direct_credential_overrides_repo;
+          Alcotest.test_case "direct credential missing" `Quick test_credentials_for_keeper_direct_missing_credential;
           Alcotest.test_case "no mapping" `Quick test_credentials_for_keeper_no_mapping;
         ] );
     ]

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -383,6 +383,32 @@ let test_credentials_for_keeper_direct_missing_credential () =
             "mentions missing credential"
             true (contains_substring msg "cred-missing"))
 
+let test_credentials_for_keeper_direct_wrong_type () =
+  with_temp_base_path (fun base_path ->
+      let local_cred = sample_credential "cred-local" Local in
+      (match Credential_store.add ~base_path local_cred with
+       | Error e -> Alcotest.fail ("add local credential failed: " ^ e)
+       | Ok _ ->
+           write_mapping ~credential_id:"cred-local" base_path "keeper-1" [ "*" ];
+           match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"keeper-1" with
+           | Ok creds ->
+               Alcotest.failf
+                 "expected Error for non-GitHub direct credential, got %d creds"
+                 (List.length creds)
+           | Error msg ->
+               Alcotest.(check bool)
+                 "mentions credential id"
+                 true
+                 (contains_substring msg "cred-local");
+               Alcotest.(check bool)
+                 "mentions GitHub type"
+                 true
+                 (contains_substring msg "must be of type GitHub");
+               Alcotest.(check bool)
+                 "mentions actual type"
+                 true
+                 (contains_substring msg "Local")))
+
 let test_credentials_for_keeper_no_mapping () =
   with_temp_base_path (fun base_path ->
       match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"unknown" with
@@ -431,6 +457,7 @@ let () =
           Alcotest.test_case "wildcard mapping" `Quick test_credentials_for_keeper_wildcard;
           Alcotest.test_case "direct credential overrides repo" `Quick test_credentials_for_keeper_direct_credential_overrides_repo;
           Alcotest.test_case "direct credential missing" `Quick test_credentials_for_keeper_direct_missing_credential;
+          Alcotest.test_case "direct credential wrong type" `Quick test_credentials_for_keeper_direct_wrong_type;
           Alcotest.test_case "no mapping" `Quick test_credentials_for_keeper_no_mapping;
         ] );
     ]

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -288,6 +288,18 @@ let test_save_mapping_preserves_credential_id () =
           | Ok rows ->
               Alcotest.failf "expected one mapping, got %d" (List.length rows)))
 
+let test_load_all_trims_credential_id () =
+  with_temp_base_path (fun base_path ->
+      write_mapping ~credential_id:" cred-selected " base_path "keeper-1" [ "*" ];
+      match Keeper_repo_mapping.load_all ~base_path with
+      | Error e -> Alcotest.fail ("load_all failed: " ^ e)
+      | Ok [loaded] ->
+          Alcotest.(check (option string))
+            "trimmed credential id"
+            (Some "cred-selected")
+            loaded.github_credential_id
+      | Ok rows -> Alcotest.failf "expected one mapping, got %d" (List.length rows))
+
 let sample_credential id cred_type =
   {
     id;
@@ -450,6 +462,7 @@ let () =
         [
           Alcotest.test_case "creates config dir" `Quick test_save_mapping_creates_config_dir;
           Alcotest.test_case "preserves credential id" `Quick test_save_mapping_preserves_credential_id;
+          Alcotest.test_case "loads trimmed credential id" `Quick test_load_all_trims_credential_id;
         ] );
       ( "credentials_for_keeper",
         [

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -300,6 +300,23 @@ let test_load_all_trims_credential_id () =
             loaded.github_credential_id
       | Ok rows -> Alcotest.failf "expected one mapping, got %d" (List.length rows))
 
+let test_load_all_rejects_non_string_credential_id () =
+  with_temp_base_path (fun base_path ->
+      let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
+      let oc = open_out path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () ->
+          output_string oc
+            "[mapping.keeper-1]\nrepositories = [\"*\"]\ncredential_id = 42\n");
+      match Keeper_repo_mapping.load_all ~base_path with
+      | Ok _ -> Alcotest.fail "expected non-string credential_id to fail"
+      | Error msg ->
+          Alcotest.(check bool)
+            "mentions credential_id"
+            true
+            (contains_substring msg "credential_id"))
+
 let sample_credential id cred_type =
   {
     id;
@@ -463,6 +480,8 @@ let () =
           Alcotest.test_case "creates config dir" `Quick test_save_mapping_creates_config_dir;
           Alcotest.test_case "preserves credential id" `Quick test_save_mapping_preserves_credential_id;
           Alcotest.test_case "loads trimmed credential id" `Quick test_load_all_trims_credential_id;
+          Alcotest.test_case "rejects non-string credential id" `Quick
+            test_load_all_rejects_non_string_credential_id;
         ] );
       ( "credentials_for_keeper",
         [

--- a/test/test_keeper_usage_trust_anthropic_cache_9959.ml
+++ b/test/test_keeper_usage_trust_anthropic_cache_9959.ml
@@ -27,7 +27,6 @@
 *)
 
 module T = Masc_mcp.Keeper_usage_trust
-module Oas = Masc_mcp.Oas
 
 let mk_usage
     ?(cache_creation = 0) ?(cache_read = 0) ?(cost_usd = None)


### PR DESCRIPTION
## Summary

- Add a direct per-keeper GitHub credential override to keeper repo mappings while preserving the existing repo-derived fallback.
- Surface the credential selector in Repository Management -> Keeper access so operators can change each keeper's GitHub identity from the dashboard.
- Show the isolated `GH_CONFIG_DIR=... gh auth login --web --clipboard` command for device-code/browser provisioning, matching the installed GitHub CLI help.
- Validate server-side that direct keeper credentials exist and are GitHub credentials before saving the mapping.

## Operator Impact

Default behavior remains unchanged: a keeper with no direct credential override still resolves credentials from its allowed repositories, and an unmapped keeper still falls back to the legacy/root credential path. When a credential is selected per keeper, the existing credential-provider bridge receives that single credential, so Docker-backed keeper sandboxes continue to mount the selected credential bundle through the existing Docker credential dispatch path.

Security-wise, the dashboard stores only the credential id on the keeper mapping. Tokens are not rendered by the keeper mapping UI, and the server rejects non-GitHub credential ids for this GitHub-specific override.

## Validation

- `scripts/dune-local.sh build test/test_keeper_repo_mapping.exe test/test_credential_provider_bridge.exe`
- `./_build/default/test/test_keeper_repo_mapping.exe`
- `./_build/default/test/test_credential_provider_bridge.exe`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-repo-mapping.test.ts src/components/credential-settings.test.ts`
- `pnpm run typecheck`
- `pnpm run lint` (passes with existing unrelated warnings)
- `pnpm run build` (passes with existing Vite chunk warnings)
- `gh auth login --help` confirms `--web --clipboard` device-code support