### PR TITLE
fix(keeper): cleanup turn sandbox bundles

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -155,6 +155,24 @@ let run_turn
   match setup with
   | Error e -> Error e
   | Ok s ->
+  let cleanup_agent_setup () =
+    try s.Keeper_run_tools.cleanup () with
+    | Eio.Cancel.Cancelled _ -> ()
+    | e ->
+      Log.Keeper.warn
+        "%s: keeper tool bundle cleanup raised: %s"
+        meta.name (Printexc.to_string e)
+  in
+  let run_with_setup_cleanup f =
+    match f () with
+    | result ->
+      cleanup_agent_setup ();
+      result
+    | exception e ->
+      cleanup_agent_setup ();
+      raise e
+  in
+  run_with_setup_cleanup @@ fun () ->
   let tools = s.Keeper_run_tools.tools in
   let hooks = s.Keeper_run_tools.hooks in
   let reducer = s.Keeper_run_tools.reducer in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -159,9 +159,12 @@ let run_turn
     try s.Keeper_run_tools.cleanup () with
     | Eio.Cancel.Cancelled _ -> ()
     | e ->
+      let backtrace = Printexc.get_backtrace () in
       Log.Keeper.warn
-        "%s: keeper tool bundle cleanup raised: %s"
-        meta.name (Printexc.to_string e)
+        "%s: keeper tool bundle cleanup raised: %s%s"
+        meta.name
+        (Printexc.to_string e)
+        (if String.equal backtrace "" then "" else "\n" ^ backtrace)
   in
   let run_with_setup_cleanup f =
     match f () with

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -172,8 +172,9 @@ let run_turn
       cleanup_agent_setup ();
       result
     | exception e ->
+      let backtrace = Printexc.get_raw_backtrace () in
       cleanup_agent_setup ();
-      raise e
+      Printexc.raise_with_backtrace e backtrace
   in
   run_with_setup_cleanup @@ fun () ->
   let tools = s.Keeper_run_tools.tools in

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -62,6 +62,7 @@ let freeze (acc : hook_accumulator) : hook_outputs =
     at the OAS call site. *)
 type agent_setup =
   { tools : Agent_sdk.Tool.t list
+  ; cleanup : unit -> unit
   ; hooks : Agent_sdk.Hooks.hooks
   ; reducer : Agent_sdk.Context_reducer.t
   ; memory : Agent_sdk.Memory.t
@@ -187,8 +188,8 @@ let prepare_agent_setup
               (fun (e : Keeper_tool_affinity.affinity_entry) ->
                  Printf.sprintf "%s(%.1f)" e.tool_name e.score)
               entries)));
-  let keeper_tools =
-    Keeper_tools_oas.make_tools
+  let keeper_tool_bundle =
+    Keeper_tools_oas.make_tool_bundle
       ~config
       ~meta
       ~ctx_snapshot
@@ -197,6 +198,7 @@ let prepare_agent_setup
         Keeper_discovered_tools.mark_used acc.discovered ~turn:acc.current_turn ~name)
       ()
   in
+  let keeper_tools = keeper_tool_bundle.tools in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
   let tools = extend_turns_tool :: keeper_tools in
   let tool_usage_before =
@@ -1373,6 +1375,7 @@ let prepare_agent_setup
     ])
   in
   Ok { tools
+     ; cleanup = keeper_tool_bundle.cleanup
      ; hooks
      ; reducer
      ; memory

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -51,6 +51,11 @@ val freeze : hook_accumulator -> hook_outputs
     at the OAS call site. *)
 type agent_setup =
   { tools : Agent_sdk.Tool.t list
+  (** Release resources owned by the prepared keeper tool bundle.
+      Callers should invoke this once after the turn consumes the setup,
+      on both success and exception paths.  Implementations must be
+      idempotent and should not raise; callers defensively catch and log
+      non-cancellation failures. *)
   ; cleanup : unit -> unit
   ; hooks : Agent_sdk.Hooks.hooks
   ; reducer : Agent_sdk.Context_reducer.t

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -51,6 +51,7 @@ val freeze : hook_accumulator -> hook_outputs
     at the OAS call site. *)
 type agent_setup =
   { tools : Agent_sdk.Tool.t list
+  ; cleanup : unit -> unit
   ; hooks : Agent_sdk.Hooks.hooks
   ; reducer : Agent_sdk.Context_reducer.t
   ; memory : Agent_sdk.Memory.t

--- a/test/test_keeper_agent_run_sandbox_source.ml
+++ b/test/test_keeper_agent_run_sandbox_source.ml
@@ -8,6 +8,7 @@
 open Alcotest
 
 let target_file = "lib/keeper/keeper_agent_run.ml"
+let run_tools_file = "lib/keeper/keeper_run_tools.ml"
 
 let load_source rel =
   let source_root =
@@ -97,6 +98,36 @@ let test_runtime_contract_sandbox_root_is_keeper_visible () =
        src)
 ;;
 
+let test_keeper_tool_bundle_cleanup_is_retained_and_invoked () =
+  let agent_src = load_source target_file in
+  let run_tools_src = load_source run_tools_file in
+  check
+    bool
+    "run setup retains the full keeper tool bundle"
+    true
+    (contains ~needle:"Keeper_tools_oas.make_tool_bundle" run_tools_src);
+  check
+    bool
+    "run setup exposes the bundle cleanup callback"
+    true
+    (contains ~needle:"cleanup = keeper_tool_bundle.cleanup" run_tools_src);
+  check
+    bool
+    "agent run reads setup cleanup callback"
+    true
+    (contains ~needle:"s.Keeper_run_tools.cleanup ()" agent_src);
+  check
+    bool
+    "agent run invokes cleanup on normal result"
+    true
+    (contains ~needle:"cleanup_agent_setup ();\n      result" agent_src);
+  check
+    bool
+    "agent run invokes cleanup before reraising exceptions"
+    true
+    (contains ~needle:"cleanup_agent_setup ();\n      raise e" agent_src)
+;;
+
 let () =
   run
     "keeper_agent_run_sandbox_source"
@@ -113,6 +144,10 @@ let () =
             "runtime_contract sandbox_root is keeper-visible"
             `Quick
             test_runtime_contract_sandbox_root_is_keeper_visible
+        ; test_case
+            "keeper tool bundle cleanup is retained and invoked"
+            `Quick
+            test_keeper_tool_bundle_cleanup_is_retained_and_invoked
         ] )
     ]
 ;;

--- a/test/test_keeper_agent_run_sandbox_source.ml
+++ b/test/test_keeper_agent_run_sandbox_source.ml
@@ -118,9 +118,9 @@ let test_keeper_tool_bundle_cleanup_is_retained_and_invoked () =
     (contains ~needle:"s.Keeper_run_tools.cleanup ()" agent_src);
   check
     int
-    "agent run invokes cleanup in both result and exception branches"
-    2
-    (count_occurrences ~needle:"cleanup_agent_setup ();" agent_src);
+    "agent run defines cleanup once and references it from both result and exception branches"
+    3
+    (count_occurrences ~needle:"cleanup_agent_setup" agent_src);
   check
     bool
     "agent run preserves exception propagation after cleanup"

--- a/test/test_keeper_agent_run_sandbox_source.ml
+++ b/test/test_keeper_agent_run_sandbox_source.ml
@@ -117,15 +117,15 @@ let test_keeper_tool_bundle_cleanup_is_retained_and_invoked () =
     true
     (contains ~needle:"s.Keeper_run_tools.cleanup ()" agent_src);
   check
-    bool
-    "agent run invokes cleanup on normal result"
-    true
-    (contains ~needle:"cleanup_agent_setup ();\n      result" agent_src);
+    int
+    "agent run invokes cleanup in both result and exception branches"
+    2
+    (count_occurrences ~needle:"cleanup_agent_setup ();" agent_src);
   check
     bool
-    "agent run invokes cleanup before reraising exceptions"
+    "agent run preserves exception propagation after cleanup"
     true
-    (contains ~needle:"cleanup_agent_setup ();\n      raise e" agent_src)
+    (contains ~needle:"raise e" agent_src)
 ;;
 
 let () =


### PR DESCRIPTION
## Summary
- retain the full keeper OAS tool bundle from `Keeper_run_tools.prepare_agent_setup`
- invoke the bundle cleanup callback on normal completion and exceptions in `Keeper_agent_run.run_turn`
- add a source-level regression guard for the turn sandbox cleanup wiring

Fixes #12618

## Verification
- `./scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_agent_run_sandbox_source.exe`
- `./_build/default/test/test_keeper_agent_run_sandbox_source.exe`
- `./scripts/dune-local.sh build test/test_keeper_tools_oas.exe test/test_keeper_docker_read.exe`
- `./_build/default/test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_docker_read.exe`
- `git diff --check`
