### PR TITLE
refactor: retire legacy collaboration entrypoints

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -101,7 +101,7 @@ tools = ["masc_status", "masc_web_search"]
 tools = [
   "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task",
   "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
-  "masc_agent_card", "masc_tool_help",
+  "masc_tool_help",
   "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
   "masc_messages", "masc_broadcast",
 ]
@@ -111,7 +111,7 @@ tools = [
 tools = [
   "masc_status", "masc_tasks", "masc_claim_next", "masc_transition",
   "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
-  "masc_agent_card", "masc_tool_help", "masc_web_search",
+  "masc_tool_help", "masc_web_search",
   "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
   "masc_messages", "masc_broadcast",
 ]
@@ -122,7 +122,6 @@ tools = [
   "masc_add_task",
   "masc_agents",
   "masc_dashboard",
-  "masc_agent_card",
   "masc_tool_help",
   "masc_keeper_msg",
   "masc_keeper_msg_result",

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -15,7 +15,11 @@ let dedupe_schemas (schemas : Types.tool_schema list) =
 
 let retired_front_door_schema_names =
   [
+    "masc_agent_card";
     "masc_collaboration_graph";
+    "masc_team_memory_read";
+    "masc_team_memory_write";
+    "masc_team_memory_search";
   ]
 
 let filter_retired_front_door_schemas (schemas : Types.tool_schema list) =
@@ -29,9 +33,7 @@ let raw_all_tool_schemas : Types.tool_schema list =
     (dedupe_schemas
        (Tools.raw_schemas
        @ Tool_schemas_control.schemas
-       @ Tool_schemas_a2a.schemas
        @ Tool_schemas_misc.schemas
-       @ Tool_team_memory.schemas
        @ Tool_board.tools
        @ Keeper_types.schemas
        @ Tool_local_runtime.schemas

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -290,7 +290,6 @@ let tool_search_alias_entries =
   ; "masc_plan_init", "계획 플랜 초기화 생성"
   ; "masc_plan_set_task", "계획 태스크 설정 할당"
   ; "masc_plan_get_task", "계획 태스크 조회"
-  ; "masc_agent_card", "에이전트 카드 프로필 정보"
   ; "masc_agents", "에이전트 목록 현황 누구"
   ; "masc_agent_update", "에이전트 업데이트 상태변경"
   ; "masc_keeper_list", "키퍼 목록 현황"

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -25,7 +25,7 @@ let sandbox_profile_enum_strings =
 let network_mode_enum_strings =
   [ "none"; "inherit" ]
 let shared_memory_scope_enum_strings =
-  [ "disabled"; "room" ]
+  [ "disabled"; "room"; "keeper_only"; "room_readonly" ]
 
 (** Issue #8486: hand-mirrored from
     [Keeper_status_detail.valid_tail_order_strings].  Same cycle
@@ -405,7 +405,7 @@ let keeper_schemas : tool_schema list = [
         ("shared_memory_scope", `Assoc [
           ("type", `String "string");
           ("enum", `List (List.map (fun s -> `String s) shared_memory_scope_enum_strings));
-          ("description", `String "Typed shared-memory lane policy. 'room' enables keeper-authorized masc_team_memory_* access on the flattened default namespace.");
+          ("description", `String "Typed shared-memory lane policy retained for metadata compatibility. Legacy masc_team_memory_* MCP tools are retired.");
         ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -84,8 +84,8 @@ let dispatch
   | Mod_agent ->
       (* Review #4579: Mod_agent includes masc_agent_update, masc_register_capabilities etc.
          Tool_agent.dispatch already validates per-tool; keeper agent_name is passed so
-         self-mutation is gated by the module's own checks. Observation-only tools
-         (masc_get_metrics, masc_collaboration_graph) are safe. *)
+         self-mutation is gated by the module's own checks. Observation-only
+         tools such as masc_get_metrics are safe. *)
       Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args
   | Mod_room ->
       Tool_coord.dispatch { Tool_coord.config; agent_name } ~name ~args

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -86,7 +86,6 @@ let send_resource_updated_notification ~session_id ~uri =
        ~params:(`Assoc [ ("uri", `String uri) ]))
 
 let broadcast_tools_list_changed () =
-  Agent_card.invalidate_cache ();
   Sse.broadcast (jsonrpc_notification "notifications/tools/list_changed")
 
 let dedup_strings items =
@@ -129,10 +128,7 @@ let affected_resource_ids_for_tool = function
   | "masc_heartbeat"
   | "masc_suspend" ->
       agent_resource_ids
-  | "masc_broadcast"
-  | "masc_portal_open"
-  | "masc_portal_send"
-  | "masc_portal_close" ->
+  | "masc_broadcast" ->
       message_resource_ids
   | "masc_worktree_create"
   | "masc_worktree_remove" ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -33,7 +33,6 @@ let managed_agent_passthrough_tool_names =
                 "masc_status";
                 "masc_tasks";
                 "masc_transition";
-                "masc_a2a_delegate";
               ]))
 
 module StringSet = Set.Make (String)
@@ -210,8 +209,6 @@ let custom_tool_titles : (string * string) list = [
   (* Communication *)
   ("masc_broadcast", "Broadcast Message");
   ("masc_messages", "Read Messages");
-  ("masc_a2a_delegate", "Agent-to-Agent Delegate");
-  ("masc_a2a_subscribe", "Subscribe to Agent Events");
   (* Planning *)
   ("masc_plan_init", "Initialize Plan");
   ("masc_plan_get", "Get Plan");

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -834,29 +834,3 @@ and with_token_permission_auth ~permission handler request reqd =
           | Ok () -> handler state agent_name request reqd
           | Error () -> ())
       | Error err -> respond_auth_error request reqd err)
-
-let serve_agent_card ~host ~port request reqd =
-  with_read_auth
-    (fun _state req reqd ->
-      let host_header = Httpun.Headers.get req.Httpun.Request.headers "host" in
-      let resolved_host, resolved_port =
-        match host_header with
-        | None -> (host, port)
-        | Some host_value -> (
-            match String.split_on_char ':' host_value with
-            | [ host_name ] -> (host_name, port)
-            | host_name :: port_str :: _ ->
-                let resolved_port =
-                  Option.value ~default:port (int_of_string_opt port_str)
-                in
-                (host_name, resolved_port)
-            | _ -> (host, port))
-      in
-      let (_card, json) =
-        Agent_card.get_cached ~host:resolved_host
-          ~port:resolved_port ~schemas:Config.raw_all_tool_schemas ()
-      in
-      let a2a_version = A2a_tools.default_a2a_version in
-      Http_server_eio.Response.json ~extra_headers:[ ("A2A-Version", a2a_version) ] json
-        reqd)
-    request reqd

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -313,10 +313,3 @@ val with_token_permission_auth :
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** Like [with_permission_auth] but threads the token id into the
     handler so the handler can audit the call. *)
-
-(** {1 Agent card surface} *)
-
-val serve_agent_card :
-  host:string -> port:int -> Httpun.Request.t -> Httpun.Reqd.t -> unit
-(** Serve the public [.well-known/agent-card.json] using the canonical
-    [(host, port)] for absolute URLs. *)

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -90,8 +90,6 @@ let add_routes ~port ~host router =
          let body = Prometheus.to_prometheus_text () in
          Http.Response.bytes ~content_type:"text/plain; version=0.0.4; charset=utf-8" body reqd
        ) request reqd)
-  |> Http.Router.get "/.well-known/agent.json" (serve_agent_card ~host ~port)
-  |> Http.Router.get "/.well-known/agent-card.json" (serve_agent_card ~host ~port)
   |> Http.Router.get "/ag-ui/events" handle_ag_ui_events
   |> Http.Router.get "/events/presence" handle_presence_events
   (* Dashboard sub-routes: must come before the SPA catchall *)

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -30,54 +30,6 @@ let result_to_response = function
   | Ok msg -> (true, msg)
   | Error e -> (false, Types.masc_error_to_string e)
 
-(* Issue #8501: Variant SSOT for masc_agent_card.action.  Adding a
-   new constructor forces compilation in [agent_card_action_to_string]
-   AND extends [valid_agent_card_action_strings]; the schema in
-   [tool_schemas_agent.ml] mirrors the SSOT (cycle-aware, sync test).
-   The previous code used a string match with a wildcard `_ -> Get`
-   branch which silently routed any unknown action to Get. *)
-type agent_card_action =
-  | Get
-  | Refresh
-
-let agent_card_action_to_string = function
-  | Get -> "get"
-  | Refresh -> "refresh"
-
-let agent_card_action_of_string_opt raw =
-  match String.trim (String.lowercase_ascii raw) with
-  | "get" | "" -> Some Get
-  | "refresh" -> Some Refresh
-  | _ -> None
-
-let all_agent_card_actions = [ Get; Refresh ]
-
-let valid_agent_card_action_strings =
-  List.map agent_card_action_to_string all_agent_card_actions
-
-(* Issue #8501: Variant SSOT for masc_collaboration_graph.format.  Same
-   pattern as agent_card_action above. The previous code used
-   [if String.equal format "json" then ... else (text)] which silently routed
-   any unknown format to text. *)
-type collaboration_format =
-  | Text
-  | Json
-
-let collaboration_format_to_string = function
-  | Text -> "text"
-  | Json -> "json"
-
-let collaboration_format_of_string_opt raw =
-  match String.trim (String.lowercase_ascii raw) with
-  | "text" | "" -> Some Text
-  | "json" -> Some Json
-  | _ -> None
-
-let all_collaboration_formats = [ Text; Json ]
-
-let valid_collaboration_format_strings =
-  List.map collaboration_format_to_string all_collaboration_formats
-
 (** Handle masc_agents *)
 let handle_agents ctx args =
   let limit = get_int args "limit" 20 |> max 1 |> min 50 in
@@ -269,68 +221,6 @@ let handle_agent_fitness ctx args =
     ] in
     (true, Yojson.Safe.to_string json)
 
-(** Handle masc_collaboration_graph *)
-let handle_collaboration_graph ctx args =
-  (* Issue #8501: explicit Variant fallback to Text — back-compat with
-     prior `else` branch but unknown formats are visibly mapped, not
-     silently absorbed. *)
-  let format =
-    collaboration_format_of_string_opt (get_string args "format" "text")
-    |> Option.value ~default:Text
-  in
-  let limit = get_int args "limit" 20 |> max 1 |> min 100 in
-  let (synapses, agents) = Hebbian_eio.get_graph_data ctx.config in
-  match format with
-  | Json ->
-    let synapses = List.filteri (fun i _ -> i < limit) synapses in
-    let json = `Assoc [
-      ("agents", `List (List.map (fun a -> `String a) agents));
-      ("synapses", `List (List.map Hebbian_eio.synapse_to_json synapses));
-    ] in
-    (true, Yojson.Safe.to_string json)
-  | Text ->
-    let lines =
-      synapses
-      |> List.sort (fun a b -> Stdlib.Float.compare b.Hebbian_eio.weight a.Hebbian_eio.weight)
-      |> List.filteri (fun i _ -> i < limit)
-      |> List.map (fun s ->
-          Printf.sprintf "%s → %s (%.2f, success:%d, failure:%d)"
-            s.Hebbian_eio.from_agent s.Hebbian_eio.to_agent
-            s.Hebbian_eio.weight s.Hebbian_eio.success_count s.Hebbian_eio.failure_count)
-    in
-    if Stdlib.List.length lines = 0 then
-      (true, "No collaboration data yet.")
-    else
-      (true, String.concat "\n" lines)
-
-(** Handle masc_agent_card *)
-let handle_agent_card _ctx args =
-  (* Issue #8501: explicit Variant fallback to Get — back-compat with
-     prior wildcard `_ -> get` but unknown actions are now mapped via
-     [Option.value], making the fallback visible at the call site. *)
-  let action =
-    agent_card_action_of_string_opt (get_string args "action" "get")
-    |> Option.value ~default:Get
-  in
-  let card = Agent_card.generate_default ~schemas:Config.raw_all_tool_schemas () in
-  let json = Agent_card.to_json card in
-  let response = match action with
-    | Refresh ->
-        `Assoc [
-          ("status", `String "refreshed");
-          ("card", json);
-          ("endpoint", `String "/.well-known/agent.json");
-          ("legacy_endpoint", `String "/.well-known/agent-card.json");
-        ]
-    | Get ->
-        `Assoc [
-          ("card", json);
-          ("endpoint", `String "/.well-known/agent.json");
-          ("legacy_endpoint", `String "/.well-known/agent-card.json");
-        ]
-  in
-  (true, Yojson.Safe.to_string response)
-
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 let dispatch ctx ~name ~args =
   match name with
@@ -339,8 +229,6 @@ let dispatch ctx ~name ~args =
   | "masc_agent_update" -> Some (handle_agent_update ctx args)
   | "masc_get_metrics" -> Some (handle_get_metrics ctx args)
   | "masc_agent_fitness" -> Some (handle_agent_fitness ctx args)
-  | "masc_collaboration_graph" -> Some (handle_collaboration_graph ctx args)
-  | "masc_agent_card" -> Some (handle_agent_card ctx args)
   | _ -> None
 
 let schemas = Tool_schemas_agent.schemas
@@ -350,13 +238,11 @@ let schemas = Tool_schemas_agent.schemas
 (* ================================================================ *)
 
 let _tool_spec_read_only =
-  [ "masc_agents"; "masc_agent_card" ]
+  [ "masc_agents" ]
 let _tool_spec_requires_join = [ "masc_register_capabilities" ]
 
 let tool_required_permission = function
-  | "masc_agents" | "masc_agent_card" | "masc_agent_fitness"
-  | "masc_collaboration_graph"
-  | "masc_get_metrics" ->
+  | "masc_agents" | "masc_agent_fitness" | "masc_get_metrics" ->
       Some Types.CanReadState
   | "masc_register_capabilities" | "masc_agent_update" ->
       Some Types.CanBroadcast

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -7,23 +7,6 @@ type context = {
   agent_name: string;
 }
 
-(** Issue #8501: Variant SSOT for masc_agent_card.action.  Mirror in
-    [Tool_schemas_agent.agent_card_action_enum_strings] (cycle-aware,
-    sync regression test catches drift). *)
-type agent_card_action = Get | Refresh
-val agent_card_action_to_string : agent_card_action -> string
-val agent_card_action_of_string_opt : string -> agent_card_action option
-val all_agent_card_actions : agent_card_action list
-val valid_agent_card_action_strings : string list
-
-(** Issue #8501: Variant SSOT for masc_collaboration_graph.format.
-    Mirror in [Tool_schemas_agent.collaboration_format_enum_strings]. *)
-type collaboration_format = Text | Json
-val collaboration_format_to_string : collaboration_format -> string
-val collaboration_format_of_string_opt : string -> collaboration_format option
-val all_collaboration_formats : collaboration_format list
-val valid_collaboration_format_strings : string list
-
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
 
@@ -43,9 +26,3 @@ val handle_get_metrics : context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_agent_fitness *)
 val handle_agent_fitness : context -> Yojson.Safe.t -> bool * string
-
-(** Handle masc_collaboration_graph *)
-val handle_collaboration_graph : context -> Yojson.Safe.t -> bool * string
-
-(** Handle masc_agent_card *)
-val handle_agent_card : context -> Yojson.Safe.t -> bool * string

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -208,7 +208,6 @@ let explicit_metadata : (string * metadata) list =
     ("masc_who", readonly_tool);
     ("masc_agents", readonly_tool);
     ("masc_dashboard", readonly_tool);
-    ("masc_agent_card", readonly_tool);
     ("masc_board_list", readonly_tool);
     ("masc_board_get", readonly_tool);
     ("masc_tool_help", readonly_tool);
@@ -232,12 +231,6 @@ let explicit_metadata : (string * metadata) list =
       { readonly_tool with required_permission = Some Types.CanReadState } );
     ( "channel_gate",
       { masc_coordination_tool with required_permission = Some Types.CanBroadcast } );
-    ( "masc_portal_open",
-      { masc_coordination_tool with required_permission = Some Types.CanOpenPortal } );
-    ( "masc_portal_close",
-      { masc_coordination_tool with required_permission = Some Types.CanOpenPortal } );
-    ( "masc_portal_send",
-      { masc_coordination_tool with required_permission = Some Types.CanSendPortal } );
     ( "masc_room_status",
       hidden_active ~canonical_name:"masc_status" ~replacement:"masc_status"
         "Managed-agent compatibility alias. Prefer masc_status for canonical namespace state reads." );
@@ -465,7 +458,6 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Keeper TK.Voice_session_start
   | TN.Keeper TK.Voice_speak ->
       Some Masc_coordination
-  | TN.Masc TM.A2a_delegate
   | TN.Masc TM.Autoresearch_inject
   | TN.Masc TM.Autoresearch_start
   | TN.Masc TM.Autoresearch_stop
@@ -475,7 +467,6 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Spawn
   | TN.Masc TM.Start ->
       Some Main_worktree_write
-  | TN.Masc TM.Agent_card
   | TN.Masc TM.Agent_fitness
   | TN.Masc TM.Agents
   | TN.Masc TM.Autoresearch_search_findings
@@ -490,7 +481,6 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Code_read
   | TN.Masc TM.Code_search
   | TN.Masc TM.Code_symbols
-  | TN.Masc TM.Collaboration_graph
   | TN.Masc TM.Config
   | TN.Masc TM.Coordination_fsm_snapshot
   | TN.Masc TM.Dashboard
@@ -689,11 +679,10 @@ let tool_group_of_typed_tool_name = function
       | TM.Autoresearch_status
       | TM.Autoresearch_stop ) ->
       Some Masc_autoresearch
-  | TN.Masc (TM.Agent_card | TM.Agent_fitness | TM.Agent_update | TM.Agents) ->
+  | TN.Masc (TM.Agent_fitness | TM.Agent_update | TM.Agents) ->
       Some Masc_agent
   | TN.Masc
-      ( TM.A2a_delegate
-      | TM.Add_task
+      ( TM.Add_task
       | TM.Approval_get
       | TM.Batch_add_tasks
       | TM.Broadcast
@@ -702,7 +691,6 @@ let tool_group_of_typed_tool_name = function
       | TM.Claim_next
       | TM.Claim_task
       | TM.Cleanup_zombies
-      | TM.Collaboration_graph
       | TM.Complete_task
       | TM.Config
       | TM.Coordination_fsm_snapshot

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -159,13 +159,11 @@ let public_mcp_surface_tools =
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote";
     (* Agent discovery *)
-    "masc_agents"; "masc_dashboard"; "masc_agent_card";
+    "masc_agents"; "masc_dashboard";
     (* Utility *)
     "masc_tool_help"; "masc_web_search"; "masc_check";
     (* HITL approval queue *)
     "masc_approval_get";
-    (* Shared memory lane — keeper-context-gated at dispatch time. *)
-    "masc_team_memory_read"; "masc_team_memory_write"; "masc_team_memory_search";
     (* Board extended *)
     "masc_board_comment_vote";
     (* Agent discovery *)

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -227,7 +227,6 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
   | Tool_name.Masc m ->
     let open Tool_name.Masc in
     match m with
-    | A2a_delegate
     | Cancel_task
     | Complete_task
     | Dispatch_plan
@@ -246,11 +245,9 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Tasks
     | Transition
     | Update_priority -> Some Mod_task
-    | Agent_card
     | Agent_fitness
     | Agent_update
     | Agents
-    | Collaboration_graph
     | Get_metrics
     | Register_capabilities -> Some Mod_agent
     | Autoresearch_cycle

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -132,10 +132,6 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
   | "masc_web_search" -> Some (handle_web_search ctx args)
-  | "masc_team_memory_read" | "masc_team_memory_write"
-  | "masc_team_memory_search" ->
-      Tool_team_memory.dispatch ~config:ctx.config ~agent_name:ctx.agent_name
-        ~name ~args
   | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot admin_ctx args)
   | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update admin_ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -199,9 +199,7 @@ end
 
 module Masc = struct
   type t =
-    | A2a_delegate
     | Add_task
-    | Agent_card
     | Agent_fitness
     | Agent_update
     | Agents
@@ -290,7 +288,6 @@ module Masc = struct
     | Worktree_list
     | Worktree_remove
     | Approval_get
-    | Collaboration_graph
     | Config
     | Gc
     | Get_metrics
@@ -306,9 +303,7 @@ module Masc = struct
     | Webrtc_offer
 
   let to_string = function
-    | A2a_delegate -> "masc_a2a_delegate"
     | Add_task -> "masc_add_task"
-    | Agent_card -> "masc_agent_card"
     | Agent_fitness -> "masc_agent_fitness"
     | Agent_update -> "masc_agent_update"
     | Agents -> "masc_agents"
@@ -397,7 +392,6 @@ module Masc = struct
     | Worktree_list -> "masc_worktree_list"
     | Worktree_remove -> "masc_worktree_remove"
     | Approval_get -> "masc_approval_get"
-    | Collaboration_graph -> "masc_collaboration_graph"
     | Config -> "masc_config"
     | Gc -> "masc_gc"
     | Get_metrics -> "masc_get_metrics"
@@ -413,9 +407,7 @@ module Masc = struct
     | Webrtc_offer -> "masc_webrtc_offer"
 
   let of_string = function
-    | "masc_a2a_delegate" -> Some A2a_delegate
     | "masc_add_task" -> Some Add_task
-    | "masc_agent_card" -> Some Agent_card
     | "masc_agent_fitness" -> Some Agent_fitness
     | "masc_agent_update" -> Some Agent_update
     | "masc_agents" -> Some Agents
@@ -504,7 +496,6 @@ module Masc = struct
     | "masc_worktree_list" -> Some Worktree_list
     | "masc_worktree_remove" -> Some Worktree_remove
     | "masc_approval_get" -> Some Approval_get
-    | "masc_collaboration_graph" -> Some Collaboration_graph
     | "masc_config" -> Some Config
     | "masc_gc" -> Some Gc
     | "masc_get_metrics" -> Some Get_metrics

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -67,9 +67,7 @@ end
 
 module Masc : sig
   type t =
-    | A2a_delegate
     | Add_task
-    | Agent_card
     | Agent_fitness
     | Agent_update
     | Agents
@@ -158,7 +156,6 @@ module Masc : sig
     | Worktree_list
     | Worktree_remove
     | Approval_get
-    | Collaboration_graph
     | Config
     | Gc
     | Get_metrics

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -51,14 +51,12 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_observe_operations", CanReadState);
     ("masc_observe_capacity", CanReadState);
     ("masc_observe_traces", CanReadState);
-    ("masc_agent_card", CanReadState);
     ("masc_agent_fitness", CanReadState);
     ("masc_dashboard", CanReadState);
     ("masc_check", CanReadState);
     ("masc_coordination_fsm_snapshot", CanReadState);
     ("masc_approval_pending", CanReadState);
     ("masc_approval_get", CanAdmin);
-    ("masc_collaboration_graph", CanReadState);
     ("masc_get_metrics", CanReadState);
     ("masc_plan_get_task", CanReadState);
     ("masc_plan_get", CanReadState);
@@ -125,9 +123,6 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_tool_revoke", CanAdmin);
     ("masc_tool_admin_snapshot", CanAdmin);
     ("masc_tool_admin_update", CanAdmin);
-    ("masc_portal_open", CanOpenPortal);
-    ("masc_portal_close", CanOpenPortal);
-    ("masc_portal_send", CanSendPortal);
     ("masc_worktree_create", CanCreateWorktree);
     ("masc_worktree_remove", CanRemoveWorktree);
   ]

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -209,8 +209,6 @@ let synonyms : (string * string list) list =
     ("masc_worktree_remove",
      [ "remove worktree"; "delete worktree"; "cleanup worktree" ]);
     (* masc_agent_* — agent management *)
-    ("masc_agent_card",
-     [ "agent card"; "agent profile"; "agent info"; "who is agent" ]);
     ("masc_agent_update",
      [ "update agent"; "change agent"; "agent modify"; "agent settings" ]);
     ("masc_agent_fitness",

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -1,15 +1,5 @@
 open Types
 
-(** Issue #8501: hand-mirrored from
-    [Tool_agent.valid_agent_card_action_strings] and
-    [Tool_agent.valid_collaboration_format_strings]. masc_tool_schemas
-    only depends on masc_types so it cannot derive directly. The sync
-    regression test [test_types.ml :: agent_tool_variants_ssot] catches
-    drift. Same shape as #8467/#8480/#8484/#8490/#8493 mirror+sync
-    pattern. *)
-let agent_card_action_enum_strings = [ "get"; "refresh" ]
-let collaboration_format_enum_strings = [ "text"; "json" ]
-
 let schemas : tool_schema list = [
   {
     name = "masc_agents";
@@ -51,22 +41,6 @@ let schemas : tool_schema list = [
     ];
   };
   {
-    name = "masc_agent_card";
-    description = "Get or regenerate the A2A-compatible Agent Card for this MASC instance.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("action", `Assoc [
-          ("type", `String "string");
-          (* Issue #8501: derive from local mirror that tracks
-             [Tool_agent.valid_agent_card_action_strings]. *)
-          ("enum", `List (List.map (fun s -> `String s) agent_card_action_enum_strings));
-          ("description", `String "Action: 'get' returns current card, 'refresh' regenerates it");
-        ]);
-      ]);
-    ];
-  };
-  {
     name = "masc_agent_fitness";
     description = "Get fitness scores for agents based on completion rate, reliability, and speed metrics.";
     input_schema = `Assoc [
@@ -103,32 +77,6 @@ let schemas : tool_schema list = [
       ("required", `List [`String "agent_name"; `String "capabilities"]);
     ];
   };
-
-  {
-    name = "masc_collaboration_graph";
-    description = "View the Hebbian collaboration graph showing learned agent-to-agent relationship strengths.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("format", `Assoc [
-          ("type", `String "string");
-          (* Issue #8501: derive from local mirror that tracks
-             [Tool_agent.valid_collaboration_format_strings]. *)
-          ("enum", `List (List.map (fun s -> `String s) collaboration_format_enum_strings));
-          ("description", `String "Output format (default: text)");
-          ("default", `String "text");
-        ]);
-        ("limit", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Max edges to return (default: 20)");
-          ("minimum", `Int 1);
-          ("maximum", `Int 100);
-          ("default", `Int 20);
-        ]);
-      ]);
-    ];
-  };
-
   {
     name = "masc_get_metrics";
     description = "Fetch raw performance metrics for an agent: task completion, timing, error rates, collaboration history.";

--- a/lib/tool_schemas/tool_schemas_agent.mli
+++ b/lib/tool_schemas/tool_schemas_agent.mli
@@ -1,24 +1,8 @@
 (** Tool_schemas_agent — MCP tool schemas for [masc_agent*] family.
 
-    [masc_tool_schemas] only depends on [masc_types], so enum strings
-    that must stay in sync with {!Tool_agent} (which lives higher up
-    the dep tree) are hand-mirrored here. The
-    [test_types.ml :: agent_tool_variants_ssot] regression test catches
-    drift between the two sides.
+    Legacy A2A agent-card and collaboration-graph front doors are retired
+    and intentionally absent from this schema list. *)
 
-    Issues: #8501 (mirror pattern), #8372 (agent_status enum derivation),
-    #8467/#8480/#8484/#8490/#8493 (related mirror+sync pattern). *)
-
-(** Allowed values for [masc_agent_card] [action]: ["get" | "refresh"].
-    Mirror of [Tool_agent.valid_agent_card_action_strings]. *)
-val agent_card_action_enum_strings : string list
-
-(** Allowed values for [masc_collaboration_graph] [format]:
-    ["text" | "json"]. Mirror of
-    [Tool_agent.valid_collaboration_format_strings]. *)
-val collaboration_format_enum_strings : string list
-
-(** Tool schemas: [masc_agents], [masc_agent_update], [masc_agent_card],
-    [masc_agent_fitness], [masc_register_capabilities],
-    [masc_collaboration_graph], [masc_get_metrics]. *)
+(** Tool schemas: [masc_agents], [masc_agent_update],
+    [masc_agent_fitness], [masc_register_capabilities], [masc_get_metrics]. *)
 val schemas : Types.tool_schema list

--- a/lib/tool_team_memory.ml
+++ b/lib/tool_team_memory.ml
@@ -45,31 +45,7 @@ let parse schema ~tool_name json =
       Error
         (Agent_sdk.Tool_input_validation.format_errors ~tool_name errs)
 
-let schema_to_tool_schema ~name ~description schema : Types.tool_schema =
-  {
-    Types.name = name;
-    description;
-    input_schema = Sg.to_json_schema schema;
-  }
-
-let schemas =
-  [
-    schema_to_tool_schema
-      ~name:"masc_team_memory_read"
-      ~description:
-        "Read shared team memory by key from the flattened default namespace. Uses a typed lane instead of exposing a shared writable shell directory."
-      read_schema;
-    schema_to_tool_schema
-      ~name:"masc_team_memory_write"
-      ~description:
-        "Write shared team memory by key in the flattened default namespace. Traversal, symlink escape, and secret-like payloads are blocked."
-      write_schema;
-    schema_to_tool_schema
-      ~name:"masc_team_memory_search"
-      ~description:
-        "Search shared team memory in the flattened default namespace by filename or content substring."
-      search_schema;
-  ]
+let schemas : Types.tool_schema list = []
 
 let default_namespace = "default"
 
@@ -436,29 +412,4 @@ let dispatch ~(config : Coord.config) ~(agent_name : string) ~name ~args
       | Error err -> Some (false, err))
   | _ -> None
 
-let read_only_tools = [ "masc_team_memory_read"; "masc_team_memory_search" ]
-
-let tool_required_permission = function
-  | "masc_team_memory_read" | "masc_team_memory_search" ->
-      Some Types.CanReadState
-  | "masc_team_memory_write" ->
-      Some Types.CanBroadcast
-  | _ -> None
-
-let () =
-  List.iter
-    (fun (s : Types.tool_schema) ->
-      let is_ro = List.mem s.name read_only_tools in
-      Tool_spec.register
-        (Tool_spec.create
-           ~name:s.name
-           ~description:s.description
-           ~module_tag:Tool_dispatch.Mod_misc
-           ~input_schema:s.input_schema
-           ~handler_binding:Tag_dispatch
-           ~is_read_only:is_ro
-           ~is_idempotent:is_ro
-           ~requires_join:true
-           ?required_permission:(tool_required_permission s.name)
-           ()))
-    schemas
+let () = ()

--- a/lib/tool_team_memory.mli
+++ b/lib/tool_team_memory.mli
@@ -3,18 +3,14 @@ open Base
 (** Tool_team_memory — per-room key/value memory with safe-path
     + secret-token enforcement.
 
-    Three external entries plus the internal pipeline.  Memory is
+    The external MCP front door is retired; this module retains the
+    internal/test-visible safe-path pipeline. Memory is
     stored as plain files under
     \[<masc_dir>/shared/rooms/<room>/memory/<key>\] with strict
     path-traversal + secret-token guards.
 
-    Tools advertised to the catalog:
-    - [masc_team_memory_read]: 2 args (room, key) -> content.
-    - [masc_team_memory_write]: 3 args (room, key, content) -> ack.
-    - [masc_team_memory_search]: 2 args (room, query) -> hits.
-
     Internal: \[Sg\] (Oas tool-schema-gen alias), 4 schema field
-    builders, 3 raw schemas, [parse], [schema_to_tool_schema],
+    builders, [parse],
     [default_namespace], validation / safe-path helpers
     ([validate_team_memory_room], [validate_authorized_room_id],
     [resolve_keeper_access], [authorize_team_memory], [is_safe_subpath],
@@ -27,8 +23,7 @@ open Base
 (** {1 Catalog} *)
 
 val schemas : Types.tool_schema list
-(** Three tool schemas in declaration order: read, write, search.
-    Consumed by {!Config} and {!Tools} during catalog assembly. *)
+(** Empty: legacy team-memory MCP tools are retired. *)
 
 (** {1 Path resolution (test-visible)} *)
 

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2,13 +2,17 @@
 
     All schemas are now owned by individual modules.
     This file assembles cycle-free schemas; config.ml adds
-    modules that depend on Config (Tool_control, Tool_a2a, Tool_misc). *)
+    modules that depend on Config (Tool_control, Tool_misc). *)
 
 open Types
 
 let retired_front_door_schema_names =
   [
+    "masc_agent_card";
     "masc_collaboration_graph";
+    "masc_team_memory_read";
+    "masc_team_memory_write";
+    "masc_team_memory_search";
   ]
 
 let filter_retired_front_door_schemas (schemas : tool_schema list) =
@@ -40,9 +44,7 @@ let all_schemas_extended =
   filter_retired_front_door_schemas
     (all_schemas
     @ Tool_schemas_control.schemas
-    @ Tool_schemas_a2a.schemas
     @ Tool_schemas_misc.schemas
-    @ Tool_team_memory.schemas
     @ Keeper_types.schemas
     @ Tool_local_runtime.schemas @ Tool_shard.schemas
     @ Tool_autoresearch.schemas)

--- a/lib/tools.mli
+++ b/lib/tools.mli
@@ -1,7 +1,7 @@
 (** Tools — MCP tool schema assembly for MASC.
 
     Collects schemas from individual modules into a unified list.
-    Config.ml adds modules that depend on Config (Tool_control, Tool_a2a, Tool_misc).
+    Config.ml adds modules that depend on Config (Tool_control, Tool_misc).
 
     @since 0.1.0 *)
 

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -199,8 +199,7 @@ module Rest = struct
     | "masc_who"
     | "masc_messages"
     | "masc_operator_snapshot"
-    | "masc_operator_digest"
-    | "masc_agent_card" -> Some Conditional_bearer
+    | "masc_operator_digest" -> Some Conditional_bearer
     | _ -> None
 
   (** Back-compat wrapper: callers (OpenAPI doc generation) still receive a
@@ -230,7 +229,6 @@ module Rest = struct
       ("masc_webrtc_offer", [ (POST, "/webrtc/offer") ]);
       ("masc_webrtc_answer", [ (POST, "/webrtc/answer") ]);
       ("masc_broadcast", [ (POST, "/api/v1/broadcast") ]);
-      ("masc_agent_card", [ (GET, "/.well-known/agent.json") ]);
     ]
 
   let actual_rest_bindings_for_operation name =
@@ -255,7 +253,6 @@ module Rest = struct
     [
       ("GET", "/", "masc_status");
       ("POST", "/broadcast", "masc_broadcast");
-      ("GET", "/.well-known/agent-card.json", "masc_agent_card");
     ]
 
   let operation_of_legacy_rest_route ~http_method ~path =

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -795,7 +795,7 @@ let test_masc_coordination_aliases_bypass_boundary () =
       "masc_batch_add_tasks"; "masc_plan_init"; "masc_plan_set_task";
       "masc_plan_update"; "masc_plan_get"; "masc_transition";
       "masc_broadcast"; "masc_messages"; "masc_status";
-      "masc_dashboard"; "masc_agents"; "masc_agent_card";
+      "masc_dashboard"; "masc_agents";
       "masc_board_post"; "masc_board_comment"; "masc_board_vote";
       "masc_board_comment_vote"; "masc_board_delete";
       "masc_board_list"; "masc_board_get"; "masc_board_stats";

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -47,7 +47,6 @@ let all_known_tool_names =
 let strict_success_names =
   [
     "masc_add_task";
-    "masc_agent_card";
     "masc_agents";
     "masc_batch_add_tasks";
     "masc_board_comment";

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -1,7 +1,5 @@
 open Alcotest
 
-module U = Yojson.Safe.Util
-
 type http_result = {
   status : int option;
   body : string;
@@ -483,41 +481,6 @@ let test_mcp_requires_auth_when_bound_non_loopback () =
     (contains_substr "requires room auth enabled with require_token=true"
        result.body)
 
-let test_agent_json_route_served_on_canonical_path () =
-  with_server ~enable_auth:false
-  @@ fun ~port ~supervisor_token:_ ~planner_token:_ ~implementer_a_token:_
-            ~implementer_b_token:_ ~supervisor_nickname:_ ~planner_nickname:_
-            ~implementer_a_nickname:_ ~implementer_b_nickname:_ ->
-  (* Retry up to 3 times to allow server_state initialization after /health readiness *)
-  let rec fetch_agent_card retries =
-    let result = run_curl_get ~port ~path:"/.well-known/agent.json" () in
-    match result.status with
-    | Some 200 ->
-        let json =
-          try Yojson.Safe.from_string result.body
-          with Yojson.Json_error err ->
-            fail
-              (Printf.sprintf "agent.json invalid JSON: %s\nbody=%s" err result.body)
-        in
-        (match json |> U.member "name" |> U.to_string_option with
-        | Some name -> (json, name)
-        | None when retries > 0 ->
-            Unix.sleepf 0.5;
-            fetch_agent_card (retries - 1)
-        | None ->
-            fail
-              (Printf.sprintf "agent.json name is null after retries\nbody=%s"
-                 result.body))
-    | _ when retries > 0 ->
-        Unix.sleepf 0.5;
-        fetch_agent_card (retries - 1)
-    | _ ->
-        require_http_ok "agent.json" result;
-        fail "unreachable"
-  in
-  let (_json, name) = fetch_agent_card 3 in
-  check string "agent card name present" "MASC-MCP" name
-
 let () =
   run "operator_mcp_e2e"
     [
@@ -525,7 +488,5 @@ let () =
         [
           test_case "full mcp requires auth on non-loopback bind" `Slow
             test_mcp_requires_auth_when_bound_non_loopback;
-          test_case "canonical agent discovery route" `Quick
-            test_agent_json_route_served_on_canonical_path;
         ] );
     ]

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -121,13 +121,12 @@ let test_channel_gate_requires_worker () =
   check bool "Worker allows channel_gate" true
     (Tool_access_policy.allows_name worker_policy "channel_gate")
 
-let test_portal_tools_require_worker () =
-  let worker_policy = Tool_access_role.policy_for_role Worker in
+let test_retired_portal_tools_are_not_worker_tools () =
   List.iter (fun tool_name ->
-    check bool
-      (Printf.sprintf "Worker allows %s" tool_name)
-      true
-      (Tool_access_policy.allows_name worker_policy tool_name))
+    check (option testable_permission)
+      (Printf.sprintf "%s has no permission-map entry" tool_name)
+      None
+      (Tool_permission_map.permission_for_tool tool_name))
     [ "masc_portal_open"; "masc_portal_close"; "masc_portal_send" ]
 
 let test_permissions_promoted_to_metadata_ssot () =
@@ -145,12 +144,8 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_autoresearch_record_finding", Types.CanAdmin);
       ("masc_autoresearch_search_findings", Types.CanReadState);
       ("masc_autoresearch_status", Types.CanReadState);
-      ("masc_agent_card", Types.CanReadState);
       ("masc_heartbeat", Types.CanBroadcast);
       ("masc_config", Types.CanReadState);
-      ("masc_team_memory_read", Types.CanReadState);
-      ("masc_team_memory_search", Types.CanReadState);
-      ("masc_team_memory_write", Types.CanBroadcast);
       ("masc_tool_list", Types.CanReadState);
       ("masc_tool_admin_snapshot", Types.CanAdmin);
       ("masc_runtime_verify", Types.CanReadState);
@@ -161,7 +156,6 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_keeper_reset", Types.CanBroadcast);
       ("masc_join", Types.CanJoin);
       ("masc_broadcast", Types.CanBroadcast);
-      ("masc_portal_send", Types.CanSendPortal);
       ("channel_gate", Types.CanBroadcast);
     ]
   in
@@ -248,8 +242,8 @@ let () =
             test_worker_allows_worker_only_tools;
           test_case "channel_gate requires worker" `Quick
             test_channel_gate_requires_worker;
-          test_case "portal tools require worker" `Quick
-            test_portal_tools_require_worker;
+          test_case "retired portal tools omitted" `Quick
+            test_retired_portal_tools_are_not_worker_tools;
           test_case "permissions promoted to metadata ssot" `Quick
             test_permissions_promoted_to_metadata_ssot;
         ] );

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -2,8 +2,7 @@
 
     Tests dispatch routing, handler execution, helper functions for:
     masc_agents, masc_register_capabilities, masc_agent_update,
-    masc_get_metrics, masc_agent_fitness, masc_collaboration_graph,
-    masc_agent_card
+    masc_get_metrics, masc_agent_fitness
 *)
 module Tool_args = Masc_mcp.Tool_args
 module Meta_cognition = Masc_mcp.Meta_cognition
@@ -229,46 +228,6 @@ let test_agent_fitness_specific () =
   )
 
 (* ============================================================
-   Handler tests — collaboration_graph
-   ============================================================ *)
-
-let test_collaboration_graph_text () =
-  with_ctx (fun ctx ->
-  let args = `Assoc [("format", `String "text")] in
-  let (ok, msg) = Tool_agent.handle_collaboration_graph ctx args in
-  Alcotest.(check bool) "text format succeeds" true ok;
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
-  )
-
-let test_collaboration_graph_json () =
-  with_ctx (fun ctx ->
-  let args = `Assoc [("format", `String "json")] in
-  let (ok, msg) = Tool_agent.handle_collaboration_graph ctx args in
-  Alcotest.(check bool) "json format succeeds" true ok;
-  Alcotest.(check bool) "returns JSON" true (String.contains msg '{');
-  )
-
-(* ============================================================
-   Handler tests — agent_card
-   ============================================================ *)
-
-let test_agent_card_get () =
-  with_ctx (fun ctx ->
-  let args = `Assoc [("action", `String "get")] in
-  let (ok, msg) = Tool_agent.handle_agent_card ctx args in
-  Alcotest.(check bool) "get succeeds" true ok;
-  Alcotest.(check bool) "returns JSON" true (String.contains msg '{');
-  )
-
-let test_agent_card_refresh () =
-  with_ctx (fun ctx ->
-  let args = `Assoc [("action", `String "refresh")] in
-  let (ok, msg) = Tool_agent.handle_agent_card ctx args in
-  Alcotest.(check bool) "refresh succeeds" true ok;
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
-  )
-
-(* ============================================================
    Handler tests — meta_cognition_snapshot
    ============================================================ *)
 
@@ -444,14 +403,6 @@ let () =
     ("agent_fitness", [
       Alcotest.test_case "no agents" `Quick test_agent_fitness_no_agents;
       Alcotest.test_case "specific agent" `Quick test_agent_fitness_specific;
-    ]);
-    ("collaboration_graph", [
-      Alcotest.test_case "text format" `Quick test_collaboration_graph_text;
-      Alcotest.test_case "json format" `Quick test_collaboration_graph_json;
-    ]);
-    ("agent_card", [
-      Alcotest.test_case "get action" `Quick test_agent_card_get;
-      Alcotest.test_case "refresh action" `Quick test_agent_card_refresh;
     ]);
     ("meta_cognition_snapshot", [
       Alcotest.test_case "detects beliefs tensions desires and edges" `Quick

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -70,27 +70,6 @@ let make_test_ctx () =
   let _ = Coord.init config ~agent_name:(Some "test-agent") in
   { Tool_misc.config; agent_name = "test-agent" }
 
-let write_team_memory_keeper_meta ~config ~name ~shared_memory_scope =
-  let agent_name = Printf.sprintf "keeper-%s-agent" name in
-  let meta_json =
-    `Assoc
-      [
-        ("name", `String name);
-        ("agent_name", `String agent_name);
-        ("trace_id", `String ("trace-" ^ name));
-        ("goal", `String "team memory fixture");
-        ("shared_memory_scope", `String shared_memory_scope);
-      ]
-  in
-  let meta =
-    match Masc_test_deps.meta_of_json_fixture meta_json with
-    | Ok meta -> meta
-    | Error err -> failwith ("meta_of_json failed: " ^ err)
-  in
-  match Keeper_types.write_meta ~force:true config meta with
-  | Ok () -> agent_name
-  | Error err -> failwith ("write_meta failed: " ^ err)
-
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -148,51 +127,17 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
 )
 
-let () = test "dispatch_team_memory_write_and_read" (fun () ->
+let () = test "dispatch_team_memory_retired_from_misc" (fun () ->
   let ctx = make_test_ctx () in
-  let agent_name =
-    write_team_memory_keeper_meta ~config:ctx.config ~name:"room-alpha"
-      ~shared_memory_scope:"room"
-  in
   let keeper_ctx : Tool_misc.context =
-    { config = ctx.config; agent_name }
+    { config = ctx.config; agent_name = "room-alpha" }
   in
-  let write_body =
-    match
-      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_write"
-        ~args:
-          (`Assoc
-            [
-              ("room", `String "default");
-              ("key", `String "handoff/summary.md");
-              ("content", `String "shared summary");
-            ])
-    with
-    | Some (true, body) -> body
-    | Some (false, err) -> failwith err
-    | None -> failwith "dispatch returned None"
+  let result =
+    Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_write"
+      ~args:(`Assoc [])
   in
-  let write_json = parse_json write_body in
-  let open Yojson.Safe.Util in
-  Alcotest.(check string) "write key" "handoff/summary.md"
-    (write_json |> member "key" |> to_string);
-  let read_body =
-    match
-      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_read"
-        ~args:
-          (`Assoc
-            [
-              ("room", `String "default");
-              ("key", `String "handoff/summary.md");
-            ])
-    with
-    | Some (true, body) -> body
-    | Some (false, err) -> failwith err
-    | None -> failwith "dispatch returned None"
-  in
-  let read_json = parse_json read_body in
-  Alcotest.(check string) "read content" "shared summary"
-    (read_json |> member "content" |> to_string)
+  Alcotest.(check bool) "retired team-memory dispatch omitted" true
+    (Option.is_none result)
 )
 
 let () = test "dispatch_dashboard_invalid_scope" (fun () ->

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -16,7 +16,7 @@ let all_keeper : Tool_name.Keeper.t list =
   ; Voice_sessions; Voice_speak; Write ]
 
 let all_masc : Tool_name.Masc.t list =
-  [ A2a_delegate; Add_task; Agent_card; Agent_fitness; Agent_update; Agents
+  [ Add_task; Agent_fitness; Agent_update; Agents
   ; Autoresearch_cycle; Autoresearch_inject; Autoresearch_start
   ; Autoresearch_record_finding; Autoresearch_search_findings
   ; Autoresearch_status; Autoresearch_stop
@@ -36,7 +36,7 @@ let all_masc : Tool_name.Masc.t list =
   ; Set_current_task; Status; Task_history; Tasks; Tool_grant; Tool_help
   ; Tool_list; Tool_revoke; Transition; Update_priority; Web_search; Who
   ; Workflow_guide; Worktree_create; Worktree_list; Worktree_remove
-  ; Approval_get; Collaboration_graph; Config; Gc; Get_metrics; Mcp_session
+  ; Approval_get; Config; Gc; Get_metrics; Mcp_session
   ; Pause; Resume; Spawn; Start; Tool_admin_snapshot; Tool_admin_update
   ; Tool_stats; Webrtc_answer; Webrtc_offer ]
 

--- a/test/test_tool_prefilter.ml
+++ b/test/test_tool_prefilter.ml
@@ -64,8 +64,6 @@ let extended_tools =
       "Create a new git worktree for an isolated branch.";
     make_schema "masc_worktree_list"
       "List all active git worktrees.";
-    make_schema "masc_agent_card"
-      "Retrieve the agent card and profile information.";
     make_schema "masc_auth_status"
       "Check authentication and token credential status.";
     make_schema "masc_web_search"

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -698,44 +698,6 @@ let test_masc_tool_admin_update_schema () =
           Alcotest.(check bool) "has policy" true (List.mem_assoc "policy" props)
       | None -> Alcotest.fail "masc_tool_admin_update missing properties"
 
-let test_masc_team_memory_read_schema () =
-  match find_tool "masc_team_memory_read" with
-  | None -> Alcotest.fail "masc_team_memory_read not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has room" true
-            (List.mem_assoc "room" props);
-          Alcotest.(check bool) "has key" true
-            (List.mem_assoc "key" props)
-      | None -> Alcotest.fail "masc_team_memory_read missing properties"
-
-let test_masc_team_memory_write_schema () =
-  match find_tool "masc_team_memory_write" with
-  | None -> Alcotest.fail "masc_team_memory_write not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has room" true
-            (List.mem_assoc "room" props);
-          Alcotest.(check bool) "has key" true
-            (List.mem_assoc "key" props);
-          Alcotest.(check bool) "has content" true
-            (List.mem_assoc "content" props)
-      | None -> Alcotest.fail "masc_team_memory_write missing properties"
-
-let test_masc_team_memory_search_schema () =
-  match find_tool "masc_team_memory_search" with
-  | None -> Alcotest.fail "masc_team_memory_search not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has room" true
-            (List.mem_assoc "room" props);
-          Alcotest.(check bool) "has query" true
-            (List.mem_assoc "query" props)
-      | None -> Alcotest.fail "masc_team_memory_search missing properties"
-
 (* ============================================================ *)
 (* 14. Handover Tool Tests                                       *)
 (* ============================================================ *)
@@ -749,6 +711,15 @@ let test_masc_team_memory_search_schema () =
 let test_legacy_swarm_tools_removed () =
   let removed_tools =
     [
+      "masc_agent_card";
+      "masc_collaboration_graph";
+      "masc_team_memory_read";
+      "masc_team_memory_write";
+      "masc_team_memory_search";
+      "masc_a2a_delegate";
+      "masc_portal_open";
+      "masc_portal_close";
+      "masc_portal_send";
       "masc_swarm_init";
       "masc_swarm_join";
       "masc_swarm_leave";
@@ -967,14 +938,6 @@ let () =
         test_masc_tool_admin_snapshot_schema;
       Alcotest.test_case "tool-admin-update" `Quick
         test_masc_tool_admin_update_schema;
-    ];
-    "team_memory_tools", [
-      Alcotest.test_case "team-memory-read" `Quick
-        test_masc_team_memory_read_schema;
-      Alcotest.test_case "team-memory-write" `Quick
-        test_masc_team_memory_write_schema;
-      Alcotest.test_case "team-memory-search" `Quick
-        test_masc_team_memory_search_schema;
     ];
     (* runtime_verify_tools removed: masc_runtime_verify pruned *)
     "legacy_swarm_removed", [

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -491,10 +491,10 @@ let test_rest_tool_to_endpoint_operator_confirm () =
   check string "method" "POST" (Transport.Rest.method_to_string m);
   check string "path" "/api/v1/operator/confirm" path
 
-let test_rest_tool_to_endpoint_agent_card () =
+let test_rest_tool_to_endpoint_retired_agent_card () =
   let (m, path) = Transport.Rest.tool_to_endpoint "masc_agent_card" in
-  check string "method" "GET" (Transport.Rest.method_to_string m);
-  check string "path" "/.well-known/agent.json" path
+  check string "method" "POST" (Transport.Rest.method_to_string m);
+  check string "path" "/mcp" path
 
 let test_rest_tool_to_endpoint_websocket_discovery () =
   let (m, path) = Transport.Rest.tool_to_endpoint "masc_websocket_discovery" in
@@ -559,16 +559,16 @@ let test_rest_parse_request_operator_confirm () =
   in
   check string "method_name" "masc_operator_confirm" req.method_name
 
-let test_rest_parse_request_agent_card () =
+let test_rest_parse_request_agent_card_retired_legacy () =
   let req = Transport.Rest.parse_request ~http_method:"GET" ~path:"/.well-known/agent-card.json" ~query_params:[] ~body:"" in
-  check string "method_name" "masc_agent_card" req.method_name
+  check string "method_name" "unknown" req.method_name
 
-let test_rest_parse_request_agent_card_canonical () =
+let test_rest_parse_request_agent_card_retired_canonical () =
   let req =
     Transport.Rest.parse_request ~http_method:"GET"
       ~path:"/.well-known/agent.json" ~query_params:[] ~body:""
   in
-  check string "method_name" "masc_agent_card" req.method_name
+  check string "method_name" "unknown" req.method_name
 
 let test_rest_parse_request_websocket_discovery () =
   let req =
@@ -630,7 +630,6 @@ let test_rest_parse_request_roundtrips_direct_bindings () =
       "masc_webrtc_offer";
       "masc_webrtc_answer";
       "masc_broadcast";
-      "masc_agent_card";
     ]
   in
   List.iter
@@ -963,7 +962,8 @@ let () =
         test_rest_tool_to_endpoint_operator_action;
       test_case "operator confirm" `Quick
         test_rest_tool_to_endpoint_operator_confirm;
-      test_case "agent_card" `Quick test_rest_tool_to_endpoint_agent_card;
+      test_case "retired agent_card" `Quick
+        test_rest_tool_to_endpoint_retired_agent_card;
       test_case "websocket_discovery" `Quick test_rest_tool_to_endpoint_websocket_discovery;
       test_case "webrtc_offer" `Quick test_rest_tool_to_endpoint_webrtc_offer;
       test_case "webrtc_answer" `Quick test_rest_tool_to_endpoint_webrtc_answer;
@@ -981,9 +981,10 @@ let () =
         test_rest_parse_request_operator_action;
       test_case "operator confirm" `Quick
         test_rest_parse_request_operator_confirm;
-      test_case "agent_card" `Quick test_rest_parse_request_agent_card;
-      test_case "agent_card canonical" `Quick
-        test_rest_parse_request_agent_card_canonical;
+      test_case "retired agent_card legacy" `Quick
+        test_rest_parse_request_agent_card_retired_legacy;
+      test_case "retired agent_card canonical" `Quick
+        test_rest_parse_request_agent_card_retired_canonical;
       test_case "websocket discovery" `Quick
         test_rest_parse_request_websocket_discovery;
       test_case "webrtc offer" `Quick test_rest_parse_request_webrtc_offer;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -14,7 +14,9 @@ let test_agent_status_roundtrip () =
 let test_agent_status_of_string_r () =
   match agent_status_of_string_r "unknown_status" with
   | Ok _ -> Alcotest.fail "expected error for unknown status"
-  | Error msg -> Alcotest.(check string) "error message" "Unknown agent status: unknown_status" msg
+  | Error msg ->
+      Alcotest.(check string) "error message"
+        "unknown agent_status: \"unknown_status\"" msg
 
 let test_task_status_todo () =
   let status = Todo in
@@ -480,15 +482,19 @@ let () =
         in
         witness Network_none; witness Network_inherit;
         Alcotest.(check int) "count" 2 (List.length valid_network_mode_strings));
-      Alcotest.test_case "shared_memory_scope witness covers both variants" `Quick (fun () ->
+      Alcotest.test_case "shared_memory_scope witness covers all variants" `Quick (fun () ->
         let open Masc_mcp.Keeper_types_profile in
         let witness s =
           let actual = shared_memory_scope_to_string s in
           if not (List.mem actual valid_shared_memory_scope_strings) then
             Alcotest.failf "shared_memory_scope_to_string %S not in valid_shared_memory_scope_strings" actual
         in
-        witness Shared_memory_disabled; witness Shared_memory_room;
-        Alcotest.(check int) "count" 2 (List.length valid_shared_memory_scope_strings));
+        witness Shared_memory_disabled;
+        witness Shared_memory_room;
+        witness Shared_memory_keeper_only;
+        witness Shared_memory_room_readonly;
+        Alcotest.(check int) "count" 4
+          (List.length valid_shared_memory_scope_strings));
       Alcotest.test_case "schema mirrors stay in sync" `Quick (fun () ->
         (* Cycle-avoidance: Keeper_schema cannot depend on
            Keeper_types_profile directly, so it hand-mirrors the SSOT.
@@ -729,53 +735,6 @@ let () =
         Alcotest.(check (list string)) "tool_shard mirror == SSOT"
           Masc_mcp.Board_votes.valid_vote_direction_strings
           Masc_mcp.Tool_shard.vote_direction_enum_strings);
-    ];
-    "agent_tool_variants_ssot", [
-      (* Issue #8501: introduces [agent_card_action] and
-         [collaboration_format] Variants where 4 sites previously
-         hand-validated raw strings. Same shape as #8480/#8484/#8490
-         mirror+sync pattern. *)
-      Alcotest.test_case "agent_card_action witness covers both variants" `Quick (fun () ->
-        let module T = Masc_mcp.Tool_agent in
-        let witness a =
-          let actual = T.agent_card_action_to_string a in
-          if not (List.mem actual T.valid_agent_card_action_strings) then
-            Alcotest.failf "agent_card_action_to_string %S not in valid_agent_card_action_strings" actual
-        in
-        witness T.Get; witness T.Refresh;
-        Alcotest.(check int) "count" 2 (List.length T.valid_agent_card_action_strings));
-      Alcotest.test_case "collaboration_format witness covers both variants" `Quick (fun () ->
-        let module T = Masc_mcp.Tool_agent in
-        let witness f =
-          let actual = T.collaboration_format_to_string f in
-          if not (List.mem actual T.valid_collaboration_format_strings) then
-            Alcotest.failf "collaboration_format_to_string %S not in valid_collaboration_format_strings" actual
-        in
-        witness T.Text; witness T.Json;
-        Alcotest.(check int) "count" 2 (List.length T.valid_collaboration_format_strings));
-      Alcotest.test_case "of_string_opt sound partial + back-compat" `Quick (fun () ->
-        let module T = Masc_mcp.Tool_agent in
-        Alcotest.(check bool) "agent_card_action 'get'" true
-          (T.agent_card_action_of_string_opt "get" = Some T.Get);
-        Alcotest.(check bool) "agent_card_action '' -> Get back-compat" true
-          (T.agent_card_action_of_string_opt "" = Some T.Get);
-        Alcotest.(check bool) "agent_card_action 'REFRESH' (case)" true
-          (T.agent_card_action_of_string_opt "REFRESH" = Some T.Refresh);
-        Alcotest.(check bool) "agent_card_action garbage rejected" true
-          (T.agent_card_action_of_string_opt "delete" = None);
-        Alcotest.(check bool) "collaboration_format 'json'" true
-          (T.collaboration_format_of_string_opt "json" = Some T.Json);
-        Alcotest.(check bool) "collaboration_format '' -> Text back-compat" true
-          (T.collaboration_format_of_string_opt "" = Some T.Text);
-        Alcotest.(check bool) "collaboration_format garbage rejected" true
-          (T.collaboration_format_of_string_opt "yaml" = None));
-      Alcotest.test_case "schema mirrors stay in sync" `Quick (fun () ->
-        Alcotest.(check (list string)) "agent_card_action mirror == SSOT"
-          Masc_mcp.Tool_agent.valid_agent_card_action_strings
-          Tool_schemas_agent.agent_card_action_enum_strings;
-        Alcotest.(check (list string)) "collaboration_format mirror == SSOT"
-          Masc_mcp.Tool_agent.valid_collaboration_format_strings
-          Tool_schemas_agent.collaboration_format_enum_strings);
     ];
     "sort_order_schema_ssot", [
       (* Issue #8513: Tool_shard.sort_order_enum_strings (used in


### PR DESCRIPTION
## Summary
- Replace oversized mixed PR #12617 with a scoped cleanup focused on live entrypoints.
- Retire legacy collaboration/A2A/team-memory front doors from MCP schemas, Tool_name parsing, catalog surfaces, permission metadata, tool policies, managed-agent profiles, and REST routing.
- Keep internal implementation modules where still covered by focused tests, but stop exposing `masc_agent_card`, `masc_collaboration_graph`, `masc_team_memory_*`, `masc_a2a_delegate`, and portal REST/resource hooks as command-plane surfaces.

## Why
#12617 mixed cascade resilience, broad archive deletion, generated scratch files, and legacy concept cleanup into a 20k+ line diff that GitHub could not review cleanly. The cascade config root cause was handled separately; this PR keeps the deletion/retirement work reviewable and tied to the actual live surfaces.

## Validation
- `scripts/dune-local.sh build test/test_types.exe test/test_tools_coverage.exe test/test_tool_agent_coverage.exe test/test_tool_misc_coverage.exe test/test_transport_coverage.exe test/test_tool_access_role.exe test/test_tool_name.exe test/test_keeper_github_read_only.exe test/test_operator_mcp_e2e.exe`
- `scripts/dune-local.sh build test/test_spawn.exe test/test_spawn_coverage.exe test/test_capability_registry.exe test/test_tool_surface_ssot.exe test/test_team_memory.exe`
- `_build/default/test/test_tools_coverage.exe`
- `_build/default/test/test_transport_coverage.exe`
- `_build/default/test/test_tool_name.exe`
- `_build/default/test/test_tool_access_role.exe`
- `_build/default/test/test_tool_agent_coverage.exe`
- `_build/default/test/test_types.exe`
- `_build/default/test/test_tool_misc_coverage.exe`
- `_build/default/test/test_keeper_github_read_only.exe`
- `_build/default/test/test_spawn.exe`
- `_build/default/test/test_spawn_coverage.exe`
- `_build/default/test/test_capability_registry.exe`
- `_build/default/test/test_team_memory.exe`
- `_build/default/test/test_operator_mcp_e2e.exe` (auth test skipped by harness)
- `git diff --check`

## Known Existing Failure
- `_build/default/test/test_tool_surface_ssot.exe` still reports unrelated orphan keeper tools: `keeper_board_delete`, `keeper_board_cleanup`, `keeper_preflight_check`, `keeper_pr_review_read`, `keeper_pr_review_comment`, `keeper_pr_review_reply`.
