### PR TITLE
ci: add odoc GitHub Pages deployment

### DIFF
--- a/.github/workflows/odoc.yml
+++ b/.github/workflows/odoc.yml
@@ -13,8 +13,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: odoc-pages-${{ github.ref }}
@@ -38,9 +36,8 @@ jobs:
 
       - name: Install system and OCaml dependencies
         uses: ./.github/actions/install-ocaml-deps
-
-      - name: Install odoc
-        run: opam install -y odoc
+        with:
+          install-flags: --with-doc
 
       - name: Build library
         run: opam exec -- dune build
@@ -55,9 +52,13 @@ jobs:
 
   deploy:
     name: Deploy to Pages
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-doc
     timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/odoc.yml
+++ b/.github/workflows/odoc.yml
@@ -1,0 +1,68 @@
+name: odoc Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lib/**'
+      - 'bin/**'
+      - 'dune-project'
+      - 'dune-workspace'
+      - '*.opam'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: odoc-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-doc:
+    name: Build odoc
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup OCaml toolchain
+        uses: ./.github/actions/setup-ocaml-toolchain
+
+      - name: Pin external OCaml dependencies
+        uses: ./.github/actions/pin-ocaml-deps
+
+      - name: Install system and OCaml dependencies
+        uses: ./.github/actions/install-ocaml-deps
+
+      - name: Install odoc
+        run: opam install -y odoc
+
+      - name: Build library
+        run: opam exec -- dune build
+
+      - name: Build documentation
+        run: opam exec -- dune build @doc
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _build/default/_doc/_html
+
+  deploy:
+    name: Deploy to Pages
+    runs-on: ubuntu-latest
+    needs: build-doc
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Generate and deploy OCaml API documentation to GitHub Pages via odoc.

Part of audit follow-up: odoc GitHub Pages deployment.

## Summary
- Adds `.github/workflows/odoc.yml` that builds odoc documentation and deploys to GitHub Pages
- Triggers on push to `main` when `lib/**`, `bin/**`, `dune-project`, `dune-workspace`, or `*.opam` change
- Manual trigger via `workflow_dispatch`
- Uses the same composite actions as CI: `setup-ocaml-toolchain`, `pin-ocaml-deps`, `install-ocaml-deps`
- Two-job pattern: `build-doc` (builds `_build/default/_doc/_html`) then `deploy` (deploys via `actions/deploy-pages`)

## Test plan
- [ ] Merge and verify GitHub Pages is enabled for the repo (Settings > Pages > Source: GitHub Actions)
- [ ] Trigger `workflow_dispatch` manually to confirm build succeeds
- [ ] Verify documentation is accessible at the GitHub Pages URL