### PR TITLE
fix(keeper): surface mapping parse errors

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -117,12 +117,14 @@ let allowed_repositories ~keeper_id ~base_path =
 let credentials_for_keeper ~base_path ~keeper_id =
   match find_mapping ~base_path keeper_id with
   | Error msg ->
-      if not (String.starts_with ~prefix:"No mapping found" msg) then
+      if String.starts_with ~prefix:"No mapping found" msg then
+        Ok []
+      else (
         Log.Misc.warn
           "[KeeperRepoMapping] credentials_for_keeper: mapping store error \
            for keeper %s (error: %s)"
           keeper_id msg;
-      Ok []
+        Error msg)
   | Ok mapping ->
       let resolve_credential id =
         match Credential_store.find ~base_path id with

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -90,11 +90,11 @@ let load_all ~base_path =
 type mapping_lookup =
   | Mapping_found of keeper_repo_mapping
   | Mapping_missing of string
-  | Mapping_store_error of string
+  | Mapping_load_error of string
 
 let lookup_mapping ~base_path keeper_id =
   match load_all ~base_path with
-  | Error msg -> Mapping_store_error msg
+  | Error msg -> Mapping_load_error msg
   | Ok mappings -> (
       match
         List.find_opt
@@ -109,7 +109,7 @@ let find_mapping ~base_path keeper_id =
   | Mapping_found mapping -> Ok mapping
   | Mapping_missing keeper_id ->
       Error (Printf.sprintf "No mapping found for keeper: %s" keeper_id)
-  | Mapping_store_error msg -> Error msg
+  | Mapping_load_error msg -> Error msg
 
 let allowed_repositories ~keeper_id ~base_path =
   let* mapping = find_mapping ~base_path keeper_id in
@@ -125,14 +125,14 @@ let allowed_repositories ~keeper_id ~base_path =
     bridge (RFC-0019 PR-A): a keeper without a mapping continues to use
     the legacy [Keeper_gh_env.keeper_binding] resolver.
 
-    Returns [Error _] on mapping store infrastructure failures,
-    mapping parse/validation failures, or dangling references
+    Returns [Error _] on mapping load failures (including
+    parse/validation failures) or dangling references
     (repository not found, credential not found).  Absence of mapping is
     not an error. *)
 let credentials_for_keeper ~base_path ~keeper_id =
   match lookup_mapping ~base_path keeper_id with
   | Mapping_missing _ -> Ok []
-  | Mapping_store_error msg -> Error msg
+  | Mapping_load_error msg -> Error msg
   | Mapping_found mapping ->
       let resolve_credential id =
         match Credential_store.find ~base_path id with
@@ -191,11 +191,11 @@ let credentials_for_keeper ~base_path ~keeper_id =
 let is_allowed ~keeper_id ~repository_id ~base_path =
   match lookup_mapping ~base_path keeper_id with
   | Mapping_missing _ -> true
-  | Mapping_store_error msg ->
+  | Mapping_load_error msg ->
       if not (Hashtbl.mem logged_mapping_errors keeper_id) then begin
         Hashtbl.add logged_mapping_errors keeper_id ();
         Log.Misc.warn
-          "[KeeperRepoMapping] is_allowed: mapping store error for keeper %s \
+          "[KeeperRepoMapping] is_allowed: mapping load error for keeper %s \
            — access control bypassed (error: %s)"
           keeper_id msg
       end;
@@ -244,9 +244,9 @@ let save_mapping ~base_path mapping =
 let apply_mapping ~keeper_id ~base_path ~repositories =
   match lookup_mapping ~base_path keeper_id with
   | Mapping_missing _ -> repositories
-  | Mapping_store_error msg ->
+  | Mapping_load_error msg ->
       Log.Misc.warn
-        "[KeeperRepoMapping] apply_mapping: mapping store error for \
+        "[KeeperRepoMapping] apply_mapping: mapping load error for \
          keeper %s — returning unfiltered repositories (error: %s)"
         keeper_id msg;
       repositories

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -125,18 +125,14 @@ let allowed_repositories ~keeper_id ~base_path =
     bridge (RFC-0019 PR-A): a keeper without a mapping continues to use
     the legacy [Keeper_gh_env.keeper_binding] resolver.
 
-    Returns [Error _] only on infrastructure failure (mapping store
-    unreadable, repository not found, credential not found).  Absence of
-    mapping is not an error. *)
+    Returns [Error _] on mapping store infrastructure failures,
+    mapping parse/validation failures, or dangling references
+    (repository not found, credential not found).  Absence of mapping is
+    not an error. *)
 let credentials_for_keeper ~base_path ~keeper_id =
   match lookup_mapping ~base_path keeper_id with
   | Mapping_missing _ -> Ok []
-  | Mapping_store_error msg ->
-      Log.Misc.warn
-        "[KeeperRepoMapping] credentials_for_keeper: mapping store error \
-         for keeper %s (error: %s)"
-        keeper_id msg;
-      Error msg
+  | Mapping_store_error msg -> Error msg
   | Mapping_found mapping ->
       let resolve_credential id =
         match Credential_store.find ~base_path id with

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -87,15 +87,29 @@ let load_all ~base_path =
             loop [] fields
         | Ok _ -> Ok [])
 
+type mapping_lookup =
+  | Mapping_found of keeper_repo_mapping
+  | Mapping_missing of string
+  | Mapping_store_error of string
+
+let lookup_mapping ~base_path keeper_id =
+  match load_all ~base_path with
+  | Error msg -> Mapping_store_error msg
+  | Ok mappings -> (
+      match
+        List.find_opt
+          (fun (m : keeper_repo_mapping) -> String.equal m.keeper_id keeper_id)
+          mappings
+      with
+      | Some mapping -> Mapping_found mapping
+      | None -> Mapping_missing keeper_id)
+
 let find_mapping ~base_path keeper_id =
-  let* mappings = load_all ~base_path in
-  match
-    List.find_opt
-      (fun (m : keeper_repo_mapping) -> String.equal m.keeper_id keeper_id)
-      mappings
-  with
-  | Some mapping -> Ok mapping
-  | None -> Error (Printf.sprintf "No mapping found for keeper: %s" keeper_id)
+  match lookup_mapping ~base_path keeper_id with
+  | Mapping_found mapping -> Ok mapping
+  | Mapping_missing keeper_id ->
+      Error (Printf.sprintf "No mapping found for keeper: %s" keeper_id)
+  | Mapping_store_error msg -> Error msg
 
 let allowed_repositories ~keeper_id ~base_path =
   let* mapping = find_mapping ~base_path keeper_id in
@@ -115,17 +129,15 @@ let allowed_repositories ~keeper_id ~base_path =
     unreadable, repository not found, credential not found).  Absence of
     mapping is not an error. *)
 let credentials_for_keeper ~base_path ~keeper_id =
-  match find_mapping ~base_path keeper_id with
-  | Error msg ->
-      if String.starts_with ~prefix:"No mapping found" msg then
-        Ok []
-      else (
-        Log.Misc.warn
-          "[KeeperRepoMapping] credentials_for_keeper: mapping store error \
-           for keeper %s (error: %s)"
-          keeper_id msg;
-        Error msg)
-  | Ok mapping ->
+  match lookup_mapping ~base_path keeper_id with
+  | Mapping_missing _ -> Ok []
+  | Mapping_store_error msg ->
+      Log.Misc.warn
+        "[KeeperRepoMapping] credentials_for_keeper: mapping store error \
+         for keeper %s (error: %s)"
+        keeper_id msg;
+      Error msg
+  | Mapping_found mapping ->
       let resolve_credential id =
         match Credential_store.find ~base_path id with
         | Ok c -> Ok c
@@ -181,11 +193,10 @@ let credentials_for_keeper ~base_path ~keeper_id =
       resolve_creds [] cred_ids)
 
 let is_allowed ~keeper_id ~repository_id ~base_path =
-  match find_mapping ~base_path keeper_id with
-  | Error msg ->
-      if not (String.starts_with ~prefix:"No mapping found" msg)
-         && not (Hashtbl.mem logged_mapping_errors keeper_id)
-      then begin
+  match lookup_mapping ~base_path keeper_id with
+  | Mapping_missing _ -> true
+  | Mapping_store_error msg ->
+      if not (Hashtbl.mem logged_mapping_errors keeper_id) then begin
         Hashtbl.add logged_mapping_errors keeper_id ();
         Log.Misc.warn
           "[KeeperRepoMapping] is_allowed: mapping store error for keeper %s \
@@ -193,7 +204,7 @@ let is_allowed ~keeper_id ~repository_id ~base_path =
           keeper_id msg
       end;
       true
-  | Ok mapping ->
+  | Mapping_found mapping ->
       List.exists
         (fun id -> String.equal id repository_id || String.equal id "*")
         mapping.repository_ids
@@ -235,15 +246,15 @@ let save_mapping ~base_path mapping =
   save_all ~base_path (mapping :: filtered)
 
 let apply_mapping ~keeper_id ~base_path ~repositories =
-  match find_mapping ~base_path keeper_id with
-  | Error msg ->
-      if not (String.starts_with ~prefix:"No mapping found" msg) then
-        Log.Misc.warn
-          "[KeeperRepoMapping] apply_mapping: mapping store error for \
-           keeper %s — returning unfiltered repositories (error: %s)"
-          keeper_id msg;
+  match lookup_mapping ~base_path keeper_id with
+  | Mapping_missing _ -> repositories
+  | Mapping_store_error msg ->
+      Log.Misc.warn
+        "[KeeperRepoMapping] apply_mapping: mapping store error for \
+         keeper %s — returning unfiltered repositories (error: %s)"
+        keeper_id msg;
       repositories
-  | Ok mapping ->
+  | Mapping_found mapping ->
       if List.exists (String.equal "*") mapping.repository_ids then
         repositories
       else

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -21,8 +21,9 @@ val credentials_for_keeper :
 
     Returns [Ok []] when the keeper has no mapping (backward-compatibility
     signal consumed by the RFC-0019 PR-A credential provider bridge).
-    Returns [Error _] only on infrastructure failure (mapping store
-    unreadable, referenced credential missing). *)
+    Returns [Error _] on mapping load failures (including parse/validation
+    failures) or dangling references (repository not found, credential not
+    found). *)
 
 val is_allowed :
   keeper_id:string -> repository_id:repository_id -> base_path:string -> bool

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -438,6 +438,25 @@ let test_credentials_for_keeper_direct_wrong_type () =
                  true
                  (contains_substring msg "Local")))
 
+let test_credentials_for_keeper_mapping_parse_error () =
+  with_temp_base_path (fun base_path ->
+      let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
+      let oc = open_out path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () ->
+          output_string oc
+            "[mapping.keeper-1]\nrepositories = [\"*\"]\ncredential_id = 42\n");
+      match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"keeper-1" with
+      | Ok creds ->
+          Alcotest.failf "expected mapping parse error, got %d creds"
+            (List.length creds)
+      | Error msg ->
+          Alcotest.(check bool)
+            "mentions credential_id"
+            true
+            (contains_substring msg "credential_id"))
+
 let test_credentials_for_keeper_no_mapping () =
   with_temp_base_path (fun base_path ->
       match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"unknown" with
@@ -490,6 +509,8 @@ let () =
           Alcotest.test_case "direct credential overrides repo" `Quick test_credentials_for_keeper_direct_credential_overrides_repo;
           Alcotest.test_case "direct credential missing" `Quick test_credentials_for_keeper_direct_missing_credential;
           Alcotest.test_case "direct credential wrong type" `Quick test_credentials_for_keeper_direct_wrong_type;
+          Alcotest.test_case "mapping parse error" `Quick
+            test_credentials_for_keeper_mapping_parse_error;
           Alcotest.test_case "no mapping" `Quick test_credentials_for_keeper_no_mapping;
         ] );
     ]

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -441,12 +441,14 @@ let test_credentials_for_keeper_direct_wrong_type () =
 let test_credentials_for_keeper_mapping_parse_error () =
   with_temp_base_path (fun base_path ->
       let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
-      let oc = open_out path in
-      Fun.protect
-        ~finally:(fun () -> close_out_noerr oc)
-        (fun () ->
-          output_string oc
-            "[mapping.keeper-1]\nrepositories = [\"*\"]\ncredential_id = 42\n");
+      let () =
+        let oc = open_out path in
+        Fun.protect
+          ~finally:(fun () -> close_out_noerr oc)
+          (fun () ->
+            output_string oc
+              "[mapping.keeper-1]\nrepositories = [\"*\"]\ncredential_id = 42\n")
+      in
       match Keeper_repo_mapping.credentials_for_keeper ~base_path ~keeper_id:"keeper-1" with
       | Ok creds ->
           Alcotest.failf "expected mapping parse error, got %d creds"


### PR DESCRIPTION
Follow-up to #12624. `credentials_for_keeper` keeps the no-mapping fallback, but returns `Error` for mapping store/parse failures instead of silently falling back to legacy credential resolution.

Verification:
- `scripts/dune-local.sh build test/test_keeper_repo_mapping.exe`
- `./_build/default/test/test_keeper_repo_mapping.exe` (24 tests)