### PR TITLE
fix: harden cockpit accessibility controls

### DIFF
--- a/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
@@ -233,10 +233,17 @@ function Lifeline() {
   }));
   return (
     <div className={"life" + (col ? " wx-collapsed" : "")}>
-      <span className="life-label" onClick={toggleLife} title={col ? "expand lifeline" : "collapse lifeline"} style={{cursor:"pointer"}}>
+      <button
+        type="button"
+        className="life-label"
+        onClick={toggleLife}
+        title={col ? "expand lifeline" : "collapse lifeline"}
+        aria-expanded={!col}
+        aria-controls="cockpit-lifeline-trace"
+        style={{ cursor:"pointer", background:"none", border:0, padding:0 }}>
         {col ? "▸" : "▾"} Lifeline · 60s
-      </span>
-      <div className="life-trace">
+      </button>
+      <div className="life-trace" id="cockpit-lifeline-trace">
         <svg viewBox="0 0 600 20" preserveAspectRatio="none">
           <path d={d} stroke="var(--color-accent-fg)" strokeWidth="1" fill="none" />
           {markers.map((m, i) => (

--- a/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
@@ -372,9 +372,17 @@ function Drawer() {
   if (window.__drawerHotkey) return;
   window.__drawerHotkey = true;
 
+  const isEditableTarget = (target) => {
+    const tag = target && target.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" ||
+      (target && target.isContentEditable) ||
+      (target && target.closest && target.closest("[contenteditable]:not([contenteditable='false'])"));
+  };
+
   // ctrl/cmd + ` toggles open/closed
   document.addEventListener("keydown", (e) => {
-    if ((e.ctrlKey || e.metaKey) && e.key === "`") {
+    if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.key === "`") {
+      if (isEditableTarget(e.target)) return;
       e.preventDefault();
       window.dispatchEvent(new CustomEvent("masc-drawer-toggle"));
     }
@@ -383,13 +391,7 @@ function Drawer() {
   // listen for programmatic events (from IDE's drawer hint button etc.)
   window.addEventListener("masc-drawer-toggle", () => {
     if (!window.useCockpitState) return;
-    // bypass hook: read singleton directly via the module-internal __state
-    const ev = window.__cockpit_state || null;
-    // simpler: push a custom postMessage that any mounted Drawer hook will receive via state singleton
-    // we trigger by directly invoking the persist with a flipped open flag
-    const cur = (window.MASC_EXT && window.MASC_EXT.initialState) ? null : null;
-    // Use a global helper installed below
-    if (window.__drawerToggle) window.__drawerToggle();
+    window.__drawerToggle?.();
   });
   window.addEventListener("masc-drawer-set", (e) => {
     if (window.__drawerSet) window.__drawerSet(e.detail || {});

--- a/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
@@ -379,9 +379,14 @@ function Drawer() {
       (target && target.closest && target.closest("[contenteditable]:not([contenteditable='false'])"));
   };
 
-  // ctrl/cmd + ` toggles open/closed
+  const isDrawerHotkey = (e) => {
+    const altGraph = e.getModifierState && e.getModifierState("AltGraph");
+    return !altGraph && (e.ctrlKey || e.metaKey) && e.code === "Backquote";
+  };
+
+  // ctrl/cmd + physical Backquote toggles open/closed
   document.addEventListener("keydown", (e) => {
-    if ((e.ctrlKey || e.metaKey) && e.code === "Backquote") {
+    if (isDrawerHotkey(e)) {
       if (isEditableTarget(e.target)) return;
       e.preventDefault();
       window.dispatchEvent(new CustomEvent("masc-drawer-toggle"));

--- a/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Drawer.jsx
@@ -381,7 +381,7 @@ function Drawer() {
 
   // ctrl/cmd + ` toggles open/closed
   document.addEventListener("keydown", (e) => {
-    if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.key === "`") {
+    if ((e.ctrlKey || e.metaKey) && e.code === "Backquote") {
       if (isEditableTarget(e.target)) return;
       e.preventDefault();
       window.dispatchEvent(new CustomEvent("masc-drawer-toggle"));

--- a/dashboard/design-system/ui_kits/cockpit/Panels.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Panels.jsx
@@ -52,7 +52,20 @@ function Sidebar({ keepers, goals, selKeeper, setSelKeeper, selGoal, setSelGoal,
   const [colSide, toggleSide] = _useCol("sidebar");
   if (colSide) {
     return (
-      <aside className="side wx-collapsed" onClick={toggleSide} title="expand sidebar">
+      <aside
+        className="side wx-collapsed"
+        onClick={toggleSide}
+        onKeyDown={(e) => {
+          if (e.repeat) return;
+          if (_isToggleKey(e)) {
+            e.preventDefault();
+            toggleSide();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        title="expand sidebar"
+        aria-label="expand sidebar">
         <div className="wx-rail-vlabel">FLEET · GOALS</div>
       </aside>
     );
@@ -364,7 +377,20 @@ function Rail({ events, cascade }) {
   const [colRail, toggleRail] = _useCol("rail");
   if (colRail) {
     return (
-      <aside className="rail wx-collapsed" onClick={toggleRail} title="expand activity rail">
+      <aside
+        className="rail wx-collapsed"
+        onClick={toggleRail}
+        onKeyDown={(e) => {
+          if (e.repeat) return;
+          if (_isToggleKey(e)) {
+            e.preventDefault();
+            toggleRail();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        title="expand activity rail"
+        aria-label="expand activity rail">
         <div className="wx-rail-vlabel">ACTIVITY · NUDGES</div>
       </aside>
     );

--- a/dashboard/design-system/ui_kits/cockpit/Panels.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Panels.jsx
@@ -65,7 +65,8 @@ function Sidebar({ keepers, goals, selKeeper, setSelKeeper, selGoal, setSelGoal,
         role="button"
         tabIndex={0}
         title="expand sidebar"
-        aria-label="expand sidebar">
+        aria-label="expand sidebar"
+        aria-expanded={!colSide}>
         <div className="wx-rail-vlabel">FLEET · GOALS</div>
       </aside>
     );
@@ -390,7 +391,8 @@ function Rail({ events, cascade }) {
         role="button"
         tabIndex={0}
         title="expand activity rail"
-        aria-label="expand activity rail">
+        aria-label="expand activity rail"
+        aria-expanded={!colRail}>
         <div className="wx-rail-vlabel">ACTIVITY · NUDGES</div>
       </aside>
     );


### PR DESCRIPTION
## Summary
- add keyboard activation to collapsed cockpit sidebar/rail expand controls
- turn the Lifeline collapse label into a real button
- guard the drawer hotkey while typing and remove stale drawer-toggle dead code

## Review context
Follow-up for Copilot review threads on merged #12612. The original PR was already merged, so this carries the remaining small a11y/dead-code fixes on top of current main.

## Verification
- git diff --check
- attempted: pnpm --dir dashboard exec tsc --noEmit (blocked: local dashboard dependencies are not installed; tsc command not found)