### PR TITLE
fix: print cleanup script help block

### DIFF
--- a/scripts/cleanup-copilot-zero-diff-prs.sh
+++ b/scripts/cleanup-copilot-zero-diff-prs.sh
@@ -23,7 +23,21 @@ CLOSE=0
 COMMENT="Closing this stale Copilot [WIP] draft because it is draft-only, authored by copilot-swe-agent, and currently has zero changed files. Reopen or recreate it if work resumes with a real diff."
 
 usage() {
-  sed -n '1,18p' "$0"
+  awk '
+    NR == 1 { next }
+    /^[[:space:]]*$/ {
+      if (started) print ""
+      next
+    }
+    /^#/ {
+      line = $0
+      sub(/^# ?/, "", line)
+      print line
+      started = 1
+      next
+    }
+    started { exit }
+  ' "$0"
 }
 
 die() {


### PR DESCRIPTION
## Summary
- make cleanup-copilot-zero-diff-prs --help print only the header comment block
- strip leading comment markers so operator help excludes implementation details

## Review context
Follow-up for Copilot review on merged #12613.

## Verification
- scripts/cleanup-copilot-zero-diff-prs.sh --help
- git diff --check