### PR TITLE
docs: align keeper mapping credential contract

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -125,10 +125,12 @@ let allowed_repositories ~keeper_id ~base_path =
     bridge (RFC-0019 PR-A): a keeper without a mapping continues to use
     the legacy [Keeper_gh_env.keeper_binding] resolver.
 
+    Repository IDs from the mapping are resolved against the loaded
+    repositories; unknown repository IDs are ignored by this resolution path.
+
     Returns [Error _] on mapping load failures (including
-    parse/validation failures) or dangling references
-    (repository not found, credential not found).  Absence of mapping is
-    not an error. *)
+    parse/validation failures) or when a credential referenced by a mapped
+    repository cannot be found.  Absence of mapping is not an error. *)
 let credentials_for_keeper ~base_path ~keeper_id =
   match lookup_mapping ~base_path keeper_id with
   | Mapping_missing _ -> Ok []

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -21,9 +21,11 @@ val credentials_for_keeper :
 
     Returns [Ok []] when the keeper has no mapping (backward-compatibility
     signal consumed by the RFC-0019 PR-A credential provider bridge).
+
+    Repository IDs from the mapping are resolved against the loaded
+    repositories; unknown repository IDs are ignored by this resolution.
     Returns [Error _] on mapping load failures (including parse/validation
-    failures) or dangling references (repository not found, credential not
-    found). *)
+    failures) or when a referenced credential cannot be found. *)
 
 val is_allowed :
   keeper_id:string -> repository_id:repository_id -> base_path:string -> bool


### PR DESCRIPTION
## Summary
- align credentials_for_keeper implementation docs with current behavior: unknown repository IDs are ignored by this resolution path
- keep Error contract focused on mapping load/parse validation failures and missing referenced credentials

## Verification
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_repo_mapping.exe @lib/check
- ./_build/default/test/test_keeper_repo_mapping.exe
- git diff --check

Follow-up for Copilot threads on #12631: PRRT_kwDOQ7_DYc5-_p6Q, PRRT_kwDOQ7_DYc5-_p6s