### PR TITLE
refactor(dashboard): reuse status chip in turn fsm detail

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -6,7 +6,10 @@ import '@testing-library/jest-dom'
 import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
 import {
   AllowlistPreview,
+  BudgetSourceBadge,
   RuntimeSignals,
+  budgetSourceLabel,
+  budgetSourceTone,
   filterSignalGroups,
   resolveAllowlistPreview,
   resolveKeeperCurrentTaskLabel,
@@ -227,6 +230,25 @@ describe('resolveAllowlistPreview', () => {
       visibleTools: [],
       hiddenCount: 2,
     })
+  })
+})
+
+describe('budget source badges', () => {
+  it.each([
+    ['env', 'neutral', 'env'],
+    ['override', 'warn', 'override'],
+    ['override_invalid', 'bad', 'invalid'],
+  ] as const)('maps %s to StatusChip tone %s', (source, tone, label) => {
+    expect(budgetSourceTone(source)).toBe(tone)
+    expect(budgetSourceLabel(source)).toBe(label)
+  })
+
+  it('renders through the shared StatusChip primitive', () => {
+    render(h(BudgetSourceBadge, { source: 'override_invalid' }))
+
+    const chip = screen.getByText('invalid').closest('[data-status-chip]')
+    expect(chip).toHaveAttribute('data-status-chip-tone', 'bad')
+    expect(chip).toHaveAttribute('data-status-chip-uppercase', 'true')
   })
 })
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -10,6 +10,7 @@ import { DistributionBars, type DistributionItem } from './common/distribution-b
 import { TextInput } from './common/input'
 import { TimeAgo } from './common/time-ago'
 import { SectionHeader } from './common/section-header'
+import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { toolCategory } from './tool-call-shared'
 import type { Keeper } from '../types'
 import { serverStatus } from '../store'
@@ -174,12 +175,43 @@ function hasTurnBudgetDivergence(keeper: Keeper): boolean {
   )
 }
 
+export type BudgetSource = 'override' | 'env' | 'override_invalid'
+
 interface BudgetSlot {
   value: number
-  source: 'override' | 'env' | 'override_invalid'
+  source: BudgetSource
   env_default: number
   env_var: string
   raw_override: number | null
+}
+
+export function budgetSourceTone(source: BudgetSource): StatusChipTone {
+  switch (source) {
+    case 'override_invalid':
+      return 'bad'
+    case 'override':
+      return 'warn'
+    case 'env':
+    default:
+      return 'neutral'
+  }
+}
+
+export function budgetSourceLabel(source: BudgetSource): string {
+  switch (source) {
+    case 'override_invalid':
+      return 'invalid'
+    case 'override':
+      return 'override'
+    case 'env':
+    default:
+      return 'env'
+  }
+}
+
+export function BudgetSourceBadge({ source, children }: { source: BudgetSource; children?: unknown }) {
+  const weight = source === 'env' ? 'font-medium' : 'font-semibold'
+  return html`<${StatusChip} tone=${budgetSourceTone(source)} class=${weight}>${children ?? budgetSourceLabel(source)}</${StatusChip}>`
 }
 
 function buildBudgetTooltip(slot: BudgetSlot, manifest: string | null, clamp: { min: number; max: number }): string {
@@ -220,16 +252,12 @@ function BudgetRow({ label, slot, manifest, clamp }: {
       : `${delta} (env 기준)`
 
   let valueClass: string
-  let pill
   if (isInvalid) {
     valueClass = 'text-[var(--bad-light)] underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid</span>`
   } else if (isOverride) {
     valueClass = 'text-[var(--color-fg-secondary)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--color-status-warn)]">override</span>`
   } else {
     valueClass = 'text-[var(--color-fg-muted)] cursor-help'
-    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--color-fg-muted)]">env</span>`
   }
 
   return html`
@@ -243,7 +271,7 @@ function BudgetRow({ label, slot, manifest, clamp }: {
           class="text-xs font-medium tabular-nums ${valueClass}"
           title=${buildBudgetTooltip(slot, manifest, clamp)}
         >${slot.value}</span>
-        ${pill}
+        <${BudgetSourceBadge} source=${slot.source} />
       </div>
     </div>
   `
@@ -272,10 +300,10 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
       <div class="flex items-center gap-2 mb-1">
         <${SectionHeader} size="xs">턴 예산 (OAS 호출당)</${SectionHeader}>
         ${hasInvalid
-          ? html`<span class="rounded-sm bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid override</span>`
+          ? html`<${StatusChip} tone="bad" class="font-semibold">invalid override</${StatusChip}>`
           : hasOverride
-            ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--color-status-warn)]">override</span>`
-            : html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--color-status-ok)]">inherited</span>`}
+            ? html`<${StatusChip} tone="warn" class="font-semibold">override</${StatusChip}>`
+            : html`<${StatusChip} tone="ok" class="font-medium">inherited</${StatusChip}>`}
       </div>
       <${BudgetRow}
         label="반응형"

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -211,7 +211,7 @@ export function budgetSourceLabel(source: BudgetSource): string {
 
 export function BudgetSourceBadge({ source, children }: { source: BudgetSource; children?: unknown }) {
   const weight = source === 'env' ? 'font-medium' : 'font-semibold'
-  return html`<${StatusChip} tone=${budgetSourceTone(source)} class=${weight}>${children ?? budgetSourceLabel(source)}</${StatusChip}>`
+  return html`<${StatusChip} tone=${budgetSourceTone(source)} uppercase=${true} class=${weight}>${children ?? budgetSourceLabel(source)}</${StatusChip}>`
 }
 
 function buildBudgetTooltip(slot: BudgetSlot, manifest: string | null, clamp: { min: number; max: number }): string {

--- a/dashboard/src/components/keeper-eval-quality.test.ts
+++ b/dashboard/src/components/keeper-eval-quality.test.ts
@@ -1,16 +1,63 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { KeeperEvalResponse, EvalSnapshot } from '../api/keeper'
+import '@testing-library/jest-dom'
+import { html } from 'htm/preact'
+import {
+  fetchKeeperEval,
+  type EvalSnapshot,
+  type KeeperEvalResponse,
+} from '../api/keeper'
+import {
+  baselineLabel,
+  evalPassTone,
+  KeeperEvalQualityPanel,
+} from './keeper-eval-quality'
 
-// Mock fetchKeeperEval at the API layer
-const fetchKeeperEvalMock = vi.fn<(name: string, limit?: number) => Promise<KeeperEvalResponse>>()
+vi.mock('../api/keeper', async () => {
+  const actual = await vi.importActual<typeof import('../api/keeper')>('../api/keeper')
+  return {
+    ...actual,
+    fetchKeeperEval: vi.fn(),
+  }
+})
 
-vi.mock('../api/keeper', () => ({
-  fetchKeeperEval: (...args: Parameters<typeof fetchKeeperEvalMock>) => fetchKeeperEvalMock(...args),
-}))
+const fetchKeeperEvalMock = vi.mocked(fetchKeeperEval)
 
 afterEach(() => {
+  cleanup()
   vi.clearAllMocks()
 })
+
+function evalResponse({
+  allPassed = true,
+  baselineStatus = 'Improved',
+  coverage = 0.94,
+}: {
+  allPassed?: boolean
+  baselineStatus?: string | null
+  coverage?: number
+} = {}): KeeperEvalResponse {
+  return {
+    keeper: 'keeper-1',
+    count: 1,
+    latest_coverage: coverage,
+    latest_all_passed: allPassed,
+    snapshots: [{
+      agent_name: 'keeper-1',
+      session_id: 'session-1',
+      worker_run_id: 'run-1',
+      timestamp: Date.now() / 1000,
+      baseline_status: baselineStatus,
+      verdict: {
+        schema_version: 1,
+        all_passed: allPassed,
+        coverage,
+        layer_results: [],
+      },
+    }],
+  }
+}
 
 function makeSnapshot(overrides: Partial<EvalSnapshot> = {}): EvalSnapshot {
   return {
@@ -75,5 +122,45 @@ describe('fetchKeeperEval integration types', () => {
     expect(noBaseline.baseline_status).toBeNull()
     const improved = makeSnapshot({ baseline_status: 'Improved' })
     expect(improved.baseline_status).toBe('Improved')
+  })
+})
+
+describe('eval quality status tones', () => {
+  it.each([
+    [true, 'ok'],
+    [false, 'bad'],
+  ] as const)('maps all_passed=%s to StatusChip tone %s', (allPassed, tone) => {
+    expect(evalPassTone(allPassed)).toBe(tone)
+  })
+
+  it.each([
+    ['Improved', 'ok'],
+    ['Regressed', 'bad'],
+    ['Unchanged', 'neutral'],
+    ['Unknown', 'neutral'],
+  ] as const)('maps baseline %s to StatusChip tone %s', (status, tone) => {
+    expect(baselineLabel(status)).toEqual({ text: status, tone })
+  })
+
+  it('skips the baseline chip when status is empty', () => {
+    expect(baselineLabel(null)).toBeNull()
+  })
+})
+
+describe('KeeperEvalQualityPanel status chips', () => {
+  it('renders eval verdict and baseline through StatusChip', async () => {
+    fetchKeeperEvalMock.mockResolvedValue(evalResponse())
+
+    render(html`<${KeeperEvalQualityPanel} keeperName="keeper-status-chip" />`)
+
+    await waitFor(() => expect(fetchKeeperEvalMock).toHaveBeenCalledWith('keeper-status-chip', 20))
+
+    const verdictChip = await screen.findByText('ALL PASS')
+    const baselineChip = screen.getByText('Improved')
+
+    expect(verdictChip.closest('[data-status-chip]')).toHaveAttribute('data-status-chip-tone', 'ok')
+    expect(verdictChip.closest('[data-status-chip]')).toHaveAttribute('data-status-chip-uppercase', 'true')
+    expect(baselineChip.closest('[data-status-chip]')).toHaveAttribute('data-status-chip-tone', 'ok')
+    expect(baselineChip.closest('[data-status-chip]')).toHaveAttribute('data-status-chip-uppercase', 'false')
   })
 })

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -9,6 +9,7 @@ import { fetchKeeperEval } from '../api/keeper'
 import type { KeeperEvalResponse, EvalSnapshot, EvalLayerResult } from '../api/keeper'
 import { ProgressBar } from './common/progress-bar'
 import { Eyebrow } from './common/eyebrow'
+import { StatusChip, type StatusChipTone } from './common/status-chip'
 
 // ── Per-keeper cached state ─────────────────────────────
 
@@ -70,17 +71,25 @@ function coverageTone(coverage: number): string {
   return 'border-[var(--bad-20)] bg-[var(--bad-6)]'
 }
 
-function baselineLabel(status: string | null): { text: string; cls: string } | null {
+export function evalPassTone(allPassed: boolean): StatusChipTone {
+  return allPassed ? 'ok' : 'bad'
+}
+
+function evalPassLabel(allPassed: boolean): string {
+  return allPassed ? 'ALL PASS' : 'FAIL'
+}
+
+export function baselineLabel(status: string | null): { text: string; tone: StatusChipTone } | null {
   if (!status) return null
   switch (status) {
     case 'Improved':
-      return { text: 'Improved', cls: 'text-[var(--color-status-ok)]' }
+      return { text: 'Improved', tone: 'ok' }
     case 'Regressed':
-      return { text: 'Regressed', cls: 'text-[var(--color-status-err)]' }
+      return { text: 'Regressed', tone: 'bad' }
     case 'Unchanged':
-      return { text: 'Unchanged', cls: 'text-[var(--color-fg-muted)]' }
+      return { text: 'Unchanged', tone: 'neutral' }
     default:
-      return { text: status, cls: 'text-[var(--color-fg-muted)]' }
+      return { text: status, tone: 'neutral' }
   }
 }
 
@@ -182,11 +191,10 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       <div class="flex items-center justify-between mb-3">
         <div class="flex items-center gap-2">
           <span class="text-3xs font-semibold tracking-1 uppercase text-[var(--color-fg-muted)]">평가 품질</span>
-          ${allPassed
-            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--color-status-ok)]">ALL PASS</span>`
-            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[var(--bad-12)] text-[var(--color-status-err)]">FAIL</span>`
-          }
-          ${baseline ? html`<span class="text-3xs font-medium ${baseline.cls}">${baseline.text}</span>` : null}
+          <${StatusChip} tone=${evalPassTone(allPassed)} class="font-semibold">${evalPassLabel(allPassed)}</${StatusChip}>
+          ${baseline
+            ? html`<${StatusChip} tone=${baseline.tone} uppercase=${false} class="font-medium">${baseline.text}</${StatusChip}>`
+            : null}
         </div>
         <button
           type="button"

--- a/dashboard/src/components/keeper-memory-tier-panel.test.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
 import type { MemoryKindUsageEntry } from '../api/keeper'
-import { filterMemoryKindUsage } from './keeper-memory-tier-panel'
+import { filterMemoryKindUsage, MemoryTierBadge } from './keeper-memory-tier-panel'
 
 const sample: MemoryKindUsageEntry[] = [
   { kind: 'tool_result', used: 10, cap: 10, priority: 1 },
@@ -62,5 +65,34 @@ describe('filterMemoryKindUsage', () => {
       { kind: 'b', used: 0, cap: 5, priority: 2 },
     ]
     expect(filterMemoryKindUsage(noneSaturated, '', 'saturated')).toEqual([])
+  })
+})
+
+describe('MemoryTierBadge', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders memory tier labels through StatusChip without uppercasing', () => {
+    render(html`<${MemoryTierBadge}>KMC compacting<//>`, container)
+
+    const chip = container.querySelector('[data-status-chip]')
+    expect(chip?.textContent).toBe('KMC compacting')
+    expect(chip?.getAttribute('data-status-chip-tone')).toBe('neutral')
+    expect(chip?.getAttribute('data-status-chip-uppercase')).toBe('false')
+  })
+
+  it('passes through the compacting warning tone', () => {
+    render(html`<${MemoryTierBadge} tone="warn">compacting<//>`, container)
+
+    expect(container.querySelector('[data-status-chip]')?.getAttribute('data-status-chip-tone')).toBe('warn')
   })
 })

--- a/dashboard/src/components/keeper-memory-tier-panel.test.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.test.ts
@@ -1,9 +1,27 @@
 // @vitest-environment happy-dom
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { render } from 'preact'
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { html } from 'htm/preact'
-import type { MemoryKindUsageEntry } from '../api/keeper'
-import { filterMemoryKindUsage, MemoryTierBadge } from './keeper-memory-tier-panel'
+import {
+  fetchKeeperComposite,
+  fetchKeeperStateDiagram,
+  type KeeperCompositeSnapshot,
+  type KeeperStateDiagramResponse,
+  type MemoryKindUsageEntry,
+} from '../api/keeper'
+import { filterMemoryKindUsage, KeeperMemoryTierPanel } from './keeper-memory-tier-panel'
+
+vi.mock('../api/keeper', async () => {
+  const actual = await vi.importActual<typeof import('../api/keeper')>('../api/keeper')
+  return {
+    ...actual,
+    fetchKeeperComposite: vi.fn(),
+    fetchKeeperStateDiagram: vi.fn(),
+  }
+})
+
+const fetchKeeperCompositeMock = vi.mocked(fetchKeeperComposite)
+const fetchKeeperStateDiagramMock = vi.mocked(fetchKeeperStateDiagram)
 
 const sample: MemoryKindUsageEntry[] = [
   { kind: 'tool_result', used: 10, cap: 10, priority: 1 },
@@ -68,31 +86,55 @@ describe('filterMemoryKindUsage', () => {
   })
 })
 
-describe('MemoryTierBadge', () => {
-  let container: HTMLElement
+function mockMemoryTierFetches(usage: MemoryKindUsageEntry[]) {
+  fetchKeeperStateDiagramMock.mockResolvedValue({
+    keeper: 'keeper-1',
+    current_phase: 'Compacting',
+    mermaid: 'graph TD',
+    memory_kind_usage: usage,
+  } satisfies KeeperStateDiagramResponse)
+  fetchKeeperCompositeMock.mockResolvedValue({
+    correlation_id: 'keeper-1:run-1',
+    run_id: 'run-1',
+    ts: 0,
+    phase: 'Compacting',
+    turn_phase: 'idle',
+    decision: { stage: 'idle' },
+    cascade: { state: 'idle' },
+    compaction: { stage: 'compacting' },
+    measurement: { captured: false },
+    invariants: {
+      phase_turn_alignment: true,
+      no_cascade_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+    },
+    is_live: true,
+    last_outcome: null,
+    recommended_actions: [],
+  } as KeeperCompositeSnapshot)
+}
 
-  beforeEach(() => {
-    container = document.createElement('div')
-    document.body.appendChild(container)
-  })
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
 
-  afterEach(() => {
-    render(null, container)
-    document.body.removeChild(container)
-  })
+describe('KeeperMemoryTierPanel status chips', () => {
+  it('renders memory tier labels through StatusChip without uppercasing', async () => {
+    mockMemoryTierFetches([{ kind: 'tool_result', used: 10, cap: 10, priority: 1 }])
 
-  it('renders memory tier labels through StatusChip without uppercasing', () => {
-    render(html`<${MemoryTierBadge}>KMC compacting<//>`, container)
+    render(html`<${KeeperMemoryTierPanel} keeperName="keeper-1" />`)
 
-    const chip = container.querySelector('[data-status-chip]')
-    expect(chip?.textContent).toBe('KMC compacting')
-    expect(chip?.getAttribute('data-status-chip-tone')).toBe('neutral')
-    expect(chip?.getAttribute('data-status-chip-uppercase')).toBe('false')
-  })
+    await waitFor(() => expect(screen.getByText('KMC compacting')).toBeTruthy())
 
-  it('passes through the compacting warning tone', () => {
-    render(html`<${MemoryTierBadge} tone="warn">compacting<//>`, container)
+    const chips = Array.from(document.querySelectorAll('[data-status-chip]'))
+    const kmcChip = chips.find(chip => chip.textContent === 'KMC compacting')
+    const compactingChip = chips.find(chip => chip.textContent === 'compacting')
 
-    expect(container.querySelector('[data-status-chip]')?.getAttribute('data-status-chip-tone')).toBe('warn')
+    expect(kmcChip?.getAttribute('data-status-chip-tone')).toBe('neutral')
+    expect(kmcChip?.getAttribute('data-status-chip-uppercase')).toBe('false')
+    expect(compactingChip?.getAttribute('data-status-chip-tone')).toBe('warn')
+    expect(compactingChip?.getAttribute('data-status-chip-uppercase')).toBe('false')
   })
 })

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -12,6 +12,7 @@ import { InlineSpinner } from './common/inline-spinner'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
+import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { buildCompactionSpec } from './keeper-fsm-specs'
 import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 
@@ -24,8 +25,14 @@ interface KeeperMemoryTierPanelProps {
 
 type MemoryTierFilter = 'all' | 'saturated'
 
-function Badge({ children }: { children: unknown }) {
-  return html`<span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">${children}</span>`
+export function MemoryTierBadge({
+  tone = 'neutral',
+  children,
+}: {
+  tone?: StatusChipTone
+  children: unknown
+}) {
+  return html`<${StatusChip} tone=${tone} uppercase=${false}>${children}</${StatusChip}>`
 }
 
 /**
@@ -149,13 +156,11 @@ export function KeeperMemoryTierPanel({
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--color-fg-disabled)]">
-        <${Badge}>total ${totalUsed} / ${totalCap}</${Badge}>
-        <${Badge}>${usage.length} kinds</${Badge}>
-        <${Badge}>KMC ${compactionStage}</${Badge}>
+        <${MemoryTierBadge}>total ${totalUsed} / ${totalCap}</${MemoryTierBadge}>
+        <${MemoryTierBadge}>${usage.length} kinds</${MemoryTierBadge}>
+        <${MemoryTierBadge}>KMC ${compactionStage}</${MemoryTierBadge}>
         ${isCompacting ? html`
-          <span class="inline-flex items-center rounded-sm border border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] px-2 py-0.5 text-[var(--amber-bright)]">
-            compacting
-          </span>
+          <${MemoryTierBadge} tone="warn">compacting</${MemoryTierBadge}>
         ` : null}
       </div>
 

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -25,7 +25,7 @@ interface KeeperMemoryTierPanelProps {
 
 type MemoryTierFilter = 'all' | 'saturated'
 
-export function MemoryTierBadge({
+function MemoryTierBadge({
   tone = 'neutral',
   children,
 }: {

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom'
 import type { LogEntry } from '../api/dashboard'
-import { failureEnvelope, mergeLogEntries, renderLogMessage } from './logs'
+import { failureEnvelope, mergeLogEntries, renderLogMessage, renderLogRow } from './logs'
 
 function entry(seq: number, overrides: Partial<LogEntry> = {}): LogEntry {
   return {
@@ -17,6 +20,10 @@ function entry(seq: number, overrides: Partial<LogEntry> = {}): LogEntry {
     ...overrides,
   }
 }
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('mergeLogEntries', () => {
   it('deduplicates by seq and keeps newest payload', () => {
@@ -107,5 +114,56 @@ describe('renderLogMessage', () => {
         }),
       ),
     ).toBe('tool keeper_github: correction_pipeline fixed 2 field(s)')
+  })
+})
+
+describe('renderLogRow', () => {
+  it('renders log metadata through StatusChip', () => {
+    render(renderLogRow(entry(10, {
+      source: 'client_tool_host',
+      legacy_classified: true,
+      raw_level: 'WARN',
+      normalized_level: 'INFO',
+      details: {
+        client_name: 'codex',
+        tool_name: 'masc_status',
+        fixes: 2,
+        phase: 'tools_call',
+        request_id: 'req-10',
+        session_id: 'session-10',
+        failure_envelope: {
+          surface: 'tool_host',
+          entity_kind: 'tool_call',
+          entity_id: 'req-10',
+          cause_code: 'tool_host_timeout',
+          severity: 'bad',
+          summary: 'tool host timed out',
+          recoverability: 'operator_action_required',
+          operator_action: 'masc_operator_digest',
+          evidence_ref: {
+            request_id: 'req-10',
+          },
+        },
+      },
+    })))
+
+    const chips = Array.from(document.querySelectorAll('[data-status-chip]'))
+    expect(chips.map(chip => chip.textContent?.trim())).toEqual(expect.arrayContaining([
+      'client tool-host',
+      'classified',
+      'WARN',
+      'codex',
+      'fixes 2',
+      'tools_call',
+      'req req-10',
+      'session session-10',
+      'tool_host_timeout',
+      'operator_action_required',
+      'next masc_operator_digest',
+    ]))
+    expect(screen.getByText('client tool-host').closest('[data-status-chip]')).toHaveAttribute('data-status-chip-uppercase', 'true')
+    expect(screen.getByText('codex').closest('[data-status-chip]')).toHaveAttribute('data-status-chip-uppercase', 'false')
+    expect(screen.getByText('masc_status').closest('[data-status-chip]')).toHaveAttribute('data-status-chip-uppercase', 'false')
+    expect(screen.getByText('tool_host_timeout').closest('[data-status-chip]')).toHaveAttribute('data-status-chip-tone', 'bad')
   })
 })

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -9,6 +9,7 @@ import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { toolCategory } from './tool-call-shared'
+import { StatusChip } from './common/status-chip'
 
 interface LogData {
   entries: LogEntry[]
@@ -30,7 +31,7 @@ let moduleDebounceTimer: ReturnType<typeof setTimeout> | null = null
 let latestRequestId = 0
 
 function MetaTag({ children }: { children: unknown }) {
-  return html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">${children}</span>`
+  return html`<${StatusChip} tone="neutral" uppercase=${false}>${children}</${StatusChip}>`
 }
 
 const LEVEL_COLORS: Record<string, string> = {
@@ -227,7 +228,7 @@ async function loadLogs(mode: LoadMode = 'reset') {
   }
 }
 
-function renderLogRow(entry: LogEntry) {
+export function renderLogRow(entry: LogEntry) {
   const level = normalizedLevel(entry)
   const rawLevelChanged = entry.raw_level && entry.raw_level !== level
   const source = entry.source || 'structured'
@@ -263,9 +264,7 @@ function renderLogRow(entry: LogEntry) {
         ${entry.module || '(root)'}
       </div>
       <div class="flex flex-wrap items-start gap-1">
-        <span class="rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-1 ${sourceClass}">
-          ${sourceLabel(source)}
-        </span>
+        <${StatusChip} tone=${sourceClass}>${sourceLabel(source)}</${StatusChip}>
         ${entry.legacy_classified
           ? html`<${MetaTag}>classified</${MetaTag}>`
           : null}
@@ -273,10 +272,10 @@ function renderLogRow(entry: LogEntry) {
           ? html`<${MetaTag}>${entry.raw_level}</${MetaTag}>`
           : null}
         ${clientName
-          ? html`<span class="rounded-sm border border-[var(--color-accent-soft)] px-2 py-0.5 text-3xs text-[#dff3ff]">${clientName}</span>`
+          ? html`<${StatusChip} tone="border-[var(--color-accent-soft)] text-[#dff3ff]" uppercase=${false}>${clientName}</${StatusChip}>`
           : null}
         ${toolName
-          ? html`<span class="inline-flex items-center gap-1 rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--color-fg-muted)]">${toolName}</span></span>`
+          ? html`<${StatusChip} tone="neutral" uppercase=${false} class="gap-1"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span>${toolName}</span></${StatusChip}>`
           : null}
         ${fixes
           ? html`<${MetaTag}>fixes ${fixes}</${MetaTag}>`
@@ -291,13 +290,13 @@ function renderLogRow(entry: LogEntry) {
           ? html`<${MetaTag}>session ${sessionId}</${MetaTag}>`
           : null}
         ${failure
-          ? html`<span class="rounded-sm border border-[rgba(224,80,80,0.24)] bg-[var(--brick-soft)] px-2 py-0.5 text-3xs text-[var(--bad-light)]">${failure.cause_code}</span>`
+          ? html`<${StatusChip} tone="bad" uppercase=${false}>${failure.cause_code}</${StatusChip}>`
           : null}
         ${failure
           ? html`<${MetaTag}>${failure.recoverability}</${MetaTag}>`
           : null}
         ${failure?.operator_action
-          ? html`<span class="rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-3xs text-[#dff3ff]">next ${failure.operator_action}</span>`
+          ? html`<${StatusChip} tone="info" uppercase=${false}>next ${failure.operator_action}</${StatusChip}>`
           : null}
       </div>
       <div

--- a/dashboard/src/components/turn-fsm-detail-panel.test.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.test.ts
@@ -1,16 +1,28 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from "vitest"
-import { chipClass, terminalTone, isExactTurnProjection } from "./turn-fsm-detail-panel"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render } from "preact"
+import { html } from "htm/preact"
+import {
+  isExactTurnProjection,
+  terminalTone,
+  TurnFsmDetailPanel,
+  turnFsmChipTone,
+} from "./turn-fsm-detail-panel"
+import type { KeeperCompositeSnapshot } from "../api/keeper"
 
-describe("chipClass", () => {
+vi.mock("./common/cytoscape-fsm", () => ({
+  CytoscapeFsm: () => html`<div data-testid="fsm-graph"></div>`,
+}))
+
+describe("turnFsmChipTone", () => {
   it.each([
-    ["accent", "border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]"],
-    ["neutral", "border-[var(--white-8)] bg-[var(--white-4)] text-[var(--color-fg-muted)]"],
-    ["warn", "border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--color-status-warn)]"],
-    ["err", "border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--color-status-err)]"],
-    ["ok", "border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--color-status-ok)]"],
-  ] as const)("returns correct classes for %s tone", (tone, expected) => {
-    expect(chipClass(tone)).toBe(expected)
+    ["accent", "info"],
+    ["neutral", "neutral"],
+    ["warn", "warn"],
+    ["err", "bad"],
+    ["ok", "ok"],
+  ] as const)("maps %s to StatusChip tone %s", (tone, expected) => {
+    expect(turnFsmChipTone(tone)).toBe(expected)
   })
 })
 
@@ -43,5 +55,50 @@ describe("isExactTurnProjection", () => {
     ["", "idle", false],
   ])("isExactTurnProjection(%s, %s) → %s", (raw, projected, expected) => {
     expect(isExactTurnProjection(raw, projected)).toBe(expected)
+  })
+})
+
+describe("TurnFsmDetailPanel", () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it("renders turn state and receipt badges through StatusChip", () => {
+    const snapshot = {
+      turn_phase: "awaiting_tool",
+      execution: {
+        outcome: "failed",
+        terminal_reason_code: "tool_contract",
+        tool_contract_result: "violated",
+        model_used: "glm-4.5",
+      },
+    } as KeeperCompositeSnapshot
+
+    render(html`<${TurnFsmDetailPanel} snapshot=${snapshot} />`, container)
+
+    const chips = [...container.querySelectorAll("[data-status-chip]")]
+    expect(chips.map(chip => chip.textContent?.trim())).toEqual(expect.arrayContaining([
+      "awaiting_tool_result",
+      "KTC awaiting_tool",
+      "TLA awaiting_tool",
+      "receipt failed",
+      "reason tool_contract",
+      "tool violated",
+      "model glm-4.5",
+    ]))
+    expect(chips.map(chip => chip.getAttribute("data-status-chip-tone"))).toEqual(expect.arrayContaining([
+      "info",
+      "neutral",
+      "bad",
+    ]))
+    expect(chips.every(chip => chip.getAttribute("data-status-chip-uppercase") === "false")).toBe(true)
   })
 })

--- a/dashboard/src/components/turn-fsm-detail-panel.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.ts
@@ -3,25 +3,28 @@ import { useMemo } from 'preact/hooks'
 
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
+import { StatusChip, type StatusChipTone } from './common/status-chip'
 import {
   buildTurnFsmSpec,
   normalizeTurnFsmState,
   turnFsmTlaSymbol,
 } from './keeper-fsm-specs'
 
-export function chipClass(tone: 'accent' | 'neutral' | 'warn' | 'err' | 'ok'): string {
+type TurnChipTone = 'accent' | 'neutral' | 'warn' | 'err' | 'ok'
+
+export function turnFsmChipTone(tone: TurnChipTone): StatusChipTone {
   switch (tone) {
     case 'accent':
-      return 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
+      return 'info'
     case 'warn':
-      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--color-status-warn)]'
+      return 'warn'
     case 'err':
-      return 'border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--color-status-err)]'
+      return 'bad'
     case 'ok':
-      return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--color-status-ok)]'
+      return 'ok'
     case 'neutral':
     default:
-      return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+      return 'neutral'
   }
 }
 
@@ -76,21 +79,13 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
           </div>
         </div>
         <div class="flex flex-wrap items-center gap-1.5 text-3xs">
-          <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass(projectedState ? 'accent' : 'warn')}`}>
-            ${projectedState ?? 'unmapped'}
-          </span>
-          <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('neutral')}`}>
-            KTC ${snapshot.turn_phase}
-          </span>
+          <${StatusChip} tone=${turnFsmChipTone(projectedState ? 'accent' : 'warn')} uppercase=${false} class="font-mono">${projectedState ?? 'unmapped'}</${StatusChip}>
+          <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">KTC ${snapshot.turn_phase}</${StatusChip}>
           ${isCoarse ? html`
-            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 ${chipClass('warn')}`}>
-              coarse legacy map
-            </span>
+            <${StatusChip} tone="warn" uppercase=${false}>coarse legacy map</${StatusChip}>
           ` : null}
           ${tlaSymbol ? html`
-            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('neutral')}`}>
-              TLA ${tlaSymbol}
-            </span>
+            <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">TLA ${tlaSymbol}</${StatusChip}>
           ` : null}
         </div>
       </div>
@@ -99,23 +94,15 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
 
       ${execution ? html`
         <div class="flex flex-wrap items-center gap-1.5 text-3xs" aria-label="latest turn receipt summary">
-          <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 ${chipClass(terminalTone(execution.outcome))}`}>
-            receipt ${execution.outcome ?? 'unknown'}
-          </span>
+          <${StatusChip} tone=${turnFsmChipTone(terminalTone(execution.outcome))} uppercase=${false}>receipt ${execution.outcome ?? 'unknown'}</${StatusChip}>
           ${terminalReason ? html`
-            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass(terminalTone(execution.outcome))}`}>
-              reason ${terminalReason}
-            </span>
+            <${StatusChip} tone=${turnFsmChipTone(terminalTone(execution.outcome))} uppercase=${false} class="font-mono">reason ${terminalReason}</${StatusChip}>
           ` : null}
           ${execution.tool_contract_result ? html`
-            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass(execution.tool_contract_result === 'violated' ? 'err' : 'neutral')}`}>
-              tool ${execution.tool_contract_result}
-            </span>
+            <${StatusChip} tone=${turnFsmChipTone(execution.tool_contract_result === 'violated' ? 'err' : 'neutral')} uppercase=${false} class="font-mono">tool ${execution.tool_contract_result}</${StatusChip}>
           ` : null}
           ${execution.model_used ? html`
-            <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 font-mono ${chipClass('neutral')}`}>
-              model ${execution.model_used}
-            </span>
+            <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">model ${execution.model_used}</${StatusChip}>
           ` : null}
         </div>
       ` : null}


### PR DESCRIPTION
## Summary
- replace the Turn FSM detail panel's local chip class mapper with shared StatusChip tones
- replace the memory tier panel's local badge wrapper and compacting badge with shared StatusChip tones
- replace runtime turn-budget source/summary pills with shared StatusChip tones
- replace eval-quality verdict and baseline pills with shared StatusChip tones
- replace log-row source/client/tool/failure metadata pills with shared StatusChip tones
- add render coverage proving these panels use the shared primitive without accidental uppercasing where labels are value-like

## Verification
- ./node_modules/.bin/vitest run src/components/keeper-eval-quality.test.ts src/components/keeper-detail-runtime.test.ts src/components/keeper-memory-tier-panel.test.ts src/components/turn-fsm-detail-panel.test.ts src/components/common/status-chip.test.ts
- ./node_modules/.bin/vitest run src/components/logs.test.ts src/components/keeper-eval-quality.test.ts src/components/common/status-chip.test.ts
- ./node_modules/.bin/vitest run src/components/logs.test.ts src/components/common/status-chip.test.ts
- ./node_modules/.bin/eslint src/components/logs.ts src/components/keeper-eval-quality.ts
- ./node_modules/.bin/tsc --noEmit --pretty
- git diff --check