### PR TITLE
ci: narrow odoc Pages library build target

### DIFF
--- a/.github/workflows/odoc.yml
+++ b/.github/workflows/odoc.yml
@@ -40,7 +40,7 @@ jobs:
           install-flags: --with-doc
 
       - name: Build library
-        run: opam exec -- dune build
+        run: opam exec -- dune build @install
 
       - name: Build documentation
         run: opam exec -- dune build @doc


### PR DESCRIPTION
## Summary
- avoid pulling the default/test alias in the odoc Pages workflow
- build `@install` before `@doc` so the workflow matches `--with-doc` dependency installation and does not require test-only packages such as `alcotest`

## Why
The post-merge odoc Pages run `25220677067` failed in `Build library` because plain `dune build` pulled `test/all`, while the workflow installed only `--with-doc` dependencies. The failure surfaced as repeated `Error: Library "alcotest" not found` messages.

## Verification
- `scripts/dune-local.sh build @install @doc`
- `git diff --check origin/main..HEAD`

Draft until CI confirms the workflow path on GitHub.
