### PR TITLE
ci: gate heavy PR jobs on live draft state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     name: PR Live Gate
     runs-on: ubuntu-latest
     needs: [pr-sync-check]
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ always() && !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     timeout-minutes: 2
     permissions:
       pull-requests: read
@@ -63,10 +63,19 @@ jobs:
         id: live
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           LIVE_PR_GATE_SETTLE_SEC: 15
         run: |
           set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "run_heavy=true" >> "$GITHUB_OUTPUT"
+            echo "live_is_draft=false" >> "$GITHUB_OUTPUT"
+            echo "live_state=NON_PR" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR live gate: non-PR event=${GITHUB_EVENT_NAME}; run_heavy=true"
+            exit 0
+          fi
 
           # Give pull_request_target draft automation a short window to restore
           # draft state before this workflow decides whether to spend runners on
@@ -74,7 +83,10 @@ jobs:
           # full CI after the PR has already been converted back to draft.
           sleep "${LIVE_PR_GATE_SETTLE_SEC}"
 
-          live_fields="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state,isDraft --jq '.state + " " + (.isDraft | tostring)')"
+          if ! live_fields="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state,isDraft --jq '.state + " " + (.isDraft | tostring)' 2>&1)"; then
+            echo "::error::Could not resolve live PR state for #${PR_NUMBER}: ${live_fields}"
+            exit 1
+          fi
           live_state="${live_fields%% *}"
           live_is_draft="${live_fields#* }"
 
@@ -99,8 +111,8 @@ jobs:
     name: Detect Changed Surfaces
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check, pr-live-gate]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' }}
     outputs:
       build: ${{ steps.scope.outputs.build }}
       lint: ${{ steps.scope.outputs.lint }}
@@ -259,8 +271,8 @@ jobs:
     name: Meta Guards
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [pr-sync-check, pr-live-gate, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' }}
 
     steps:
       - name: Checkout
@@ -364,8 +376,8 @@ jobs:
     name: Health
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [pr-sync-check, pr-live-gate, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.health == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.health == 'true' }}
 
     steps:
       - name: Checkout
@@ -448,8 +460,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [pr-sync-check, pr-live-gate, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.build == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.build == 'true' }}
     outputs:
       advisory_status: ${{ steps.build_advisory_status.outputs.advisory_status }}
 
@@ -699,8 +711,8 @@ jobs:
     # Dependency installation plus @install warn-error build regularly exceeds
     # 20 minutes on cold runners; keep this above the install-only worst case.
     timeout-minutes: 40
-    needs: [pr-sync-check, pr-live-gate, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.lint == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.lint == 'true' }}
 
     steps:
       - name: Checkout
@@ -781,8 +793,8 @@ jobs:
     name: Dashboard
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check, pr-live-gate, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.dashboard == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.dashboard == 'true' }}
 
     steps:
       - name: Checkout
@@ -827,8 +839,8 @@ jobs:
     name: OCaml Structure Ratchet
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check, pr-live-gate, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') }}
 
     steps:
       - name: Checkout
@@ -850,8 +862,8 @@ jobs:
     name: Keeper Cwd Leak Gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check, pr-live-gate]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' }}
 
     steps:
       - name: Checkout
@@ -864,8 +876,8 @@ jobs:
     name: TLA+ Model Checking
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: [pr-sync-check, pr-live-gate, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.tla == 'true' }}
 
     steps:
       - name: Checkout
@@ -891,7 +903,7 @@ jobs:
     name: CI Gate
     runs-on: ubuntu-latest
     needs: [pr-sync-check, pr-live-gate, changes, meta, build, lint, dashboard, health, structure-ratchet, tla-specs]
-    if: ${{ !cancelled() }}
+    if: ${{ always() && !cancelled() }}
     timeout-minutes: 10
 
     steps:
@@ -986,8 +998,8 @@ jobs:
             fi
           }
           check "pr-sync-check"   "$PR_SYNC_RESULT"
-          # pr-live-gate is pull_request-only; on push/workflow_dispatch it is
-          # skipped, and check() intentionally treats skipped as non-blocking.
+          # pr-live-gate folds skipped non-PR sync checks into run_heavy=true,
+          # while failed live-state lookup remains a hard merge blocker.
           check "pr-live-gate"    "$PR_LIVE_GATE_RESULT"
           check "changes"         "$CHANGES_RESULT"
           check "meta"            "$META_RESULT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,60 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --expected-head-sha "$PR_HEAD_SHA"
 
+  pr-live-gate:
+    name: PR Live Gate
+    runs-on: ubuntu-latest
+    needs: [pr-sync-check]
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    timeout-minutes: 2
+    outputs:
+      run_heavy: ${{ steps.live.outputs.run_heavy }}
+      live_is_draft: ${{ steps.live.outputs.live_is_draft }}
+      live_state: ${{ steps.live.outputs.live_state }}
+
+    steps:
+      - name: Resolve live PR state before heavy CI
+        id: live
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LIVE_PR_GATE_SETTLE_SEC: 15
+        run: |
+          set -euo pipefail
+
+          # Give pull_request_target draft automation a short window to restore
+          # draft state before this workflow decides whether to spend runners on
+          # the heavy matrix. This avoids stale ready_for_review payloads running
+          # full CI after the PR has already been converted back to draft.
+          sleep "${LIVE_PR_GATE_SETTLE_SEC}"
+
+          live_fields="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state,isDraft --jq '.state + " " + (.isDraft | tostring)')"
+          live_state="${live_fields%% *}"
+          live_is_draft="${live_fields#* }"
+
+          if [ -z "$live_state" ] || { [ "$live_is_draft" != "true" ] && [ "$live_is_draft" != "false" ]; }; then
+            echo "::error::Could not resolve live PR state for #${PR_NUMBER}: ${live_fields}"
+            exit 1
+          fi
+
+          run_heavy=true
+          if [ "$live_state" != "OPEN" ]; then
+            run_heavy=false
+          elif [ "$live_is_draft" = "true" ]; then
+            run_heavy=false
+          fi
+
+          echo "run_heavy=${run_heavy}" >> "$GITHUB_OUTPUT"
+          echo "live_is_draft=${live_is_draft}" >> "$GITHUB_OUTPUT"
+          echo "live_state=${live_state}" >> "$GITHUB_OUTPUT"
+          echo "::notice::PR live gate: state=${live_state:-unknown} draft=${live_is_draft:-unknown} run_heavy=${run_heavy}"
+
   changes:
     name: Detect Changed Surfaces
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     outputs:
       build: ${{ steps.scope.outputs.build }}
       lint: ${{ steps.scope.outputs.lint }}
@@ -209,8 +257,8 @@ jobs:
     name: Meta Guards
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate, changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -314,8 +362,8 @@ jobs:
     name: Health
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.health == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate, changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.health == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -398,8 +446,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.build == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate, changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.build == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     outputs:
       advisory_status: ${{ steps.build_advisory_status.outputs.advisory_status }}
 
@@ -649,8 +697,8 @@ jobs:
     # Dependency installation plus @install warn-error build regularly exceeds
     # 20 minutes on cold runners; keep this above the install-only worst case.
     timeout-minutes: 40
-    needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.lint == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate, changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.lint == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -731,8 +779,8 @@ jobs:
     name: Dashboard
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.dashboard == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate, changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.dashboard == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -777,8 +825,8 @@ jobs:
     name: OCaml Structure Ratchet
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate, changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -800,8 +848,8 @@ jobs:
     name: Keeper Cwd Leak Gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -814,8 +862,8 @@ jobs:
     name: TLA+ Model Checking
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: [pr-sync-check, changes]
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, pr-live-gate, changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.pr-live-gate.outputs.run_heavy == 'true') && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -840,7 +888,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [pr-sync-check, changes, meta, build, lint, dashboard, health, structure-ratchet, tla-specs]
+    needs: [pr-sync-check, pr-live-gate, changes, meta, build, lint, dashboard, health, structure-ratchet, tla-specs]
     if: ${{ !cancelled() }}
     timeout-minutes: 10
 
@@ -887,6 +935,7 @@ jobs:
       - name: Aggregate required check status
         env:
           PR_SYNC_RESULT: ${{ needs.pr-sync-check.result }}
+          PR_LIVE_GATE_RESULT: ${{ needs.pr-live-gate.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           META_RESULT: ${{ needs.meta.result }}
           BUILD_RESULT: ${{ needs.build.result }}
@@ -935,6 +984,7 @@ jobs:
             fi
           }
           check "pr-sync-check"   "$PR_SYNC_RESULT"
+          check "pr-live-gate"    "$PR_LIVE_GATE_RESULT"
           check "changes"         "$CHANGES_RESULT"
           check "meta"            "$META_RESULT"
           check "build"           "$BUILD_RESULT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
     needs: [pr-sync-check]
     if: ${{ !cancelled() && github.event_name == 'pull_request' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     timeout-minutes: 2
+    permissions:
+      pull-requests: read
     outputs:
       run_heavy: ${{ steps.live.outputs.run_heavy }}
       live_is_draft: ${{ steps.live.outputs.live_is_draft }}
@@ -984,6 +986,8 @@ jobs:
             fi
           }
           check "pr-sync-check"   "$PR_SYNC_RESULT"
+          # pr-live-gate is pull_request-only; on push/workflow_dispatch it is
+          # skipped, and check() intentionally treats skipped as non-blocking.
           check "pr-live-gate"    "$PR_LIVE_GATE_RESULT"
           check "changes"         "$CHANGES_RESULT"
           check "meta"            "$META_RESULT"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -110,6 +110,23 @@ let test_ci_sync_and_asset_contracts () =
      policy script so already-merged PRs do not flip red. *)
   check bool "ci gate refreshes live PR state" true
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_STATE");
+  check bool "ci workflow has live PR gate before heavy matrix" true
+    (file_contains_pattern ".github/workflows/ci.yml" "PR Live Gate");
+  check bool "live PR gate waits for draft automation to settle" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "LIVE_PR_GATE_SETTLE_SEC");
+  check bool "changes job depends on live PR gate" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "needs: [pr-sync-check, pr-live-gate]");
+  check bool "heavy CI uses live PR gate output" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "needs.pr-live-gate.outputs.run_heavy == 'true'");
+  check bool "ci gate aggregates live PR gate" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "PR_LIVE_GATE_RESULT");
+  check bool "heavy CI no longer trusts stale draft payload" true
+    (file_not_contains_pattern ".github/workflows/ci.yml"
+       "github.event.pull_request.draft == false");
   check bool "pr hygiene no longer checks dashboard assets (gitignored)" true
     (not (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated"))
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -115,12 +115,24 @@ let test_ci_sync_and_asset_contracts () =
   check bool "live PR gate has explicit pull request read permission" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "pull-requests: read");
+  check bool "live PR gate can run after skipped non-PR sync check" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "always() && !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped')");
+  check bool "live PR gate defaults non-PR triggers to heavy CI" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       {|[ "${GITHUB_EVENT_NAME}" != "pull_request" ]|});
   check bool "live PR gate waits for draft automation to settle" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "LIVE_PR_GATE_SETTLE_SEC");
+  check bool "live PR gate annotates gh lookup failures" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       {|if ! live_fields="$(gh pr view "$PR_NUMBER"|});
   check bool "heavy CI uses live PR gate output" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "needs.pr-live-gate.outputs.run_heavy == 'true'");
+  check bool "heavy CI waits for changed-surface detection" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "needs.changes.result == 'success'");
   check bool "ci gate allows skipped live PR gate on non-PR triggers" true
     (file_contains_pattern ".github/workflows/ci.yml"
        {|"$result" == "success" || "$result" == "skipped"|});

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -111,16 +111,19 @@ let test_ci_sync_and_asset_contracts () =
   check bool "ci gate refreshes live PR state" true
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_STATE");
   check bool "ci workflow has live PR gate before heavy matrix" true
-    (file_contains_pattern ".github/workflows/ci.yml" "PR Live Gate");
+    (file_contains_pattern ".github/workflows/ci.yml" "pr-live-gate:");
+  check bool "live PR gate has explicit pull request read permission" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "pull-requests: read");
   check bool "live PR gate waits for draft automation to settle" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "LIVE_PR_GATE_SETTLE_SEC");
-  check bool "changes job depends on live PR gate" true
-    (file_contains_pattern ".github/workflows/ci.yml"
-       "needs: [pr-sync-check, pr-live-gate]");
   check bool "heavy CI uses live PR gate output" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "needs.pr-live-gate.outputs.run_heavy == 'true'");
+  check bool "ci gate allows skipped live PR gate on non-PR triggers" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       {|"$result" == "success" || "$result" == "skipped"|});
   check bool "ci gate aggregates live PR gate" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "PR_LIVE_GATE_RESULT");


### PR DESCRIPTION
## Summary
- add a live PR gate before heavy CI jobs so stale pull_request payloads do not keep running full CI after draft automation restores draft state
- make live-state lookup fail closed by feeding PR Live Gate into CI Gate aggregation
- add source-guard coverage for the live-gate contract

## Validation
- git diff --check
- ruby -e require-yaml parse of .github/workflows/ci.yml
- scripts/dune-local.sh build test/test_ci_hardening_source.exe
- ./_build/default/test/test_ci_hardening_source.exe test source_guard 0
- ./_build/default/test/test_ci_hardening_source.exe

## Queue impact
This keeps draft or already-closed PR events from spending runners on Build/Lint/Dashboard/Health/TLA after PR Automation has already restored the live draft or closed state. CI Gate remains authoritative because the live gate result is now part of the aggregate.