### PR TITLE
chore(persona): scaffold ramarama + taskmaster profile.json placeholders

### DIFF
--- a/config/personas/ramarama/profile.json
+++ b/config/personas/ramarama/profile.json
@@ -1,0 +1,10 @@
+{
+  "name": "OPERATOR_TODO: ramarama display name",
+  "role": "OPERATOR_TODO: define the keeper role (what ramarama does in the system)",
+  "trait": "OPERATOR_TODO: define personality / operating style",
+  "keeper": {
+    "goal": "OPERATOR_TODO: define ramarama's core purpose — what it pursues in every session (required; keeper spawn is blocked until this is filled in)",
+    "mention_targets": ["ramarama"],
+    "proactive_enabled": false
+  }
+}

--- a/config/personas/taskmaster/profile.json
+++ b/config/personas/taskmaster/profile.json
@@ -1,0 +1,10 @@
+{
+  "name": "OPERATOR_TODO: taskmaster display name",
+  "role": "OPERATOR_TODO: define the keeper role (what taskmaster does in the system)",
+  "trait": "OPERATOR_TODO: define personality / operating style",
+  "keeper": {
+    "goal": "OPERATOR_TODO: define taskmaster's core purpose — what it pursues in every session (required; keeper spawn is blocked until this is filled in)",
+    "mention_targets": ["taskmaster"],
+    "proactive_enabled": false
+  }
+}


### PR DESCRIPTION
## Context

Follow-up to #12363 (fix/sangsu-keeper-ssot, merged).

`#12363` fixed the same drift pattern for `sangsu` and noted in its "Out of scope" section:

> `ramarama` / `taskmaster` profile.json missing (same drift pattern as sangsu — needs persona tone from operator)

This PR scaffolds the missing files so the SSOT gap is closed structurally. The keeper runtime (`masc_keeper_create_from_persona`) will now find a `profile.json` for both handles instead of failing silently.

## What's in this PR

Two new files, each with **only the structurally required fields**:

| file | required field present | persona voice |
|---|---|---|
| `config/personas/ramarama/profile.json` | `keeper.goal` ✓ | `OPERATOR_TODO` placeholder |
| `config/personas/taskmaster/profile.json` | `keeper.goal` ✓ | `OPERATOR_TODO` placeholder |

## What the operator must do before merging

The persona voice (goal, instructions, tone, role, trait) for both keepers belongs to **Vincent / yousleepwhen** and was intentionally left as `OPERATOR_TODO` placeholders. **Do not merge until every `OPERATOR_TODO` string is replaced with real operator-authored content.**

Minimum edits needed per file:
- `name` — display label shown in keeper discovery
- `role` — human-readable role description
- `trait` — operating style / personality summary
- `keeper.goal` — concrete keeper purpose (spawn is blocked without this)
- Optionally: `keeper.instructions`, `keeper.will`, `keeper.needs`, `keeper.desires`, `keeper.short_goal`, `keeper.mid_goal`, `keeper.long_goal`

The `tool_preset` and `work_discovery_sources` are already set in the respective `.toml` files and must NOT be duplicated in `profile.json` (the runtime force-sets `tool_preset` to `None` for profile-owned fields — see `keeper_types_profile.ml:1112`).

## Schema reference

`lib/keeper/keeper_persona_authoring.ml` — `field_catalog_entries` list defines all supported `profile.json` fields. `issue_king/profile.json` is the canonical filled-in example.

---

*Opened by 24h follow-up agent after #12363 merged.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQtN4acySoGBfFgEMbbubK)_