### PR TITLE
fix(dashboard): address status chip review debt

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -300,10 +300,10 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
       <div class="flex items-center gap-2 mb-1">
         <${SectionHeader} size="xs">턴 예산 (OAS 호출당)</${SectionHeader}>
         ${hasInvalid
-          ? html`<${StatusChip} tone="bad" class="font-semibold">invalid override</${StatusChip}>`
+          ? html`<${StatusChip} tone="bad" uppercase=${true} class="font-semibold">invalid override</${StatusChip}>`
           : hasOverride
-            ? html`<${StatusChip} tone="warn" class="font-semibold">override</${StatusChip}>`
-            : html`<${StatusChip} tone="ok" class="font-medium">inherited</${StatusChip}>`}
+            ? html`<${StatusChip} tone="warn" uppercase=${true} class="font-semibold">override</${StatusChip}>`
+            : html`<${StatusChip} tone="ok" uppercase=${true} class="font-medium">inherited</${StatusChip}>`}
       </div>
       <${BudgetRow}
         label="반응형"

--- a/dashboard/src/components/keeper-memory-tier-panel.test.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.test.ts
@@ -93,7 +93,7 @@ function mockMemoryTierFetches(usage: MemoryKindUsageEntry[]) {
     mermaid: 'graph TD',
     memory_kind_usage: usage,
   } satisfies KeeperStateDiagramResponse)
-  fetchKeeperCompositeMock.mockResolvedValue({
+  const composite = {
     correlation_id: 'keeper-1:run-1',
     run_id: 'run-1',
     ts: 0,
@@ -112,7 +112,8 @@ function mockMemoryTierFetches(usage: MemoryKindUsageEntry[]) {
     is_live: true,
     last_outcome: null,
     recommended_actions: [],
-  } as KeeperCompositeSnapshot)
+  } satisfies KeeperCompositeSnapshot
+  fetchKeeperCompositeMock.mockResolvedValue(composite)
 }
 
 afterEach(() => {

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 
 import {
@@ -30,7 +31,7 @@ function MemoryTierBadge({
   children,
 }: {
   tone?: StatusChipTone
-  children: unknown
+  children: ComponentChildren
 }) {
   return html`<${StatusChip} tone=${tone} uppercase=${false}>${children}</${StatusChip}>`
 }

--- a/dashboard/src/components/turn-fsm-detail-panel.test.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.test.ts
@@ -14,6 +14,41 @@ vi.mock("./common/cytoscape-fsm", () => ({
   CytoscapeFsm: () => html`<div data-testid="fsm-graph"></div>`,
 }))
 
+function keeperCompositeSnapshot(
+  overrides: Partial<KeeperCompositeSnapshot> = {},
+): KeeperCompositeSnapshot {
+  const base: KeeperCompositeSnapshot = {
+    correlation_id: "keeper-1:run-1",
+    run_id: "run-1",
+    ts: 0,
+    phase: "Running",
+    turn_phase: "idle",
+    decision: { stage: "undecided" },
+    cascade: { state: "idle" },
+    compaction: { stage: "accumulating" },
+    measurement: { captured: false },
+    invariants: {
+      phase_turn_alignment: true,
+      no_cascade_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+    },
+    is_live: false,
+    last_outcome: null,
+    recommended_actions: [],
+  }
+
+  return {
+    ...base,
+    ...overrides,
+    decision: { ...base.decision, ...(overrides.decision ?? {}) },
+    cascade: { ...base.cascade, ...(overrides.cascade ?? {}) },
+    compaction: { ...base.compaction, ...(overrides.compaction ?? {}) },
+    measurement: { ...base.measurement, ...(overrides.measurement ?? {}) },
+    invariants: { ...base.invariants, ...(overrides.invariants ?? {}) },
+  }
+}
+
 describe("turnFsmChipTone", () => {
   it.each([
     ["accent", "info"],
@@ -72,15 +107,24 @@ describe("TurnFsmDetailPanel", () => {
   })
 
   it("renders turn state and receipt badges through StatusChip", () => {
-    const snapshot = {
+    const snapshot = keeperCompositeSnapshot({
       turn_phase: "awaiting_tool",
       execution: {
+        latest_receipt_present: true,
+        recorded_at: "2026-05-01T16:00:00Z",
         outcome: "failed",
         terminal_reason_code: "tool_contract",
+        operator_disposition: null,
+        operator_disposition_reason: null,
         tool_contract_result: "violated",
         model_used: "glm-4.5",
+        stop_reason: null,
+        duration_ms: null,
+        error: null,
+        cascade: null,
+        tool_surface: null,
       },
-    } as KeeperCompositeSnapshot
+    })
 
     render(html`<${TurnFsmDetailPanel} snapshot=${snapshot} />`, container)
 


### PR DESCRIPTION
## Summary
- Make turn-budget summary StatusChip casing explicit after #12636 review.
- Type MemoryTierBadge children with Preact ComponentChildren.
- Replace KeeperCompositeSnapshot casts in dashboard tests with typed fixtures so schema drift is caught by typecheck.

## Review Threads Addressed
- Follow-up for unresolved Copilot threads on merged PR #12636.

## Verification
- pnpm typecheck
- pnpm exec vitest run --config vitest.config.ts src/components/turn-fsm-detail-panel.test.ts src/components/keeper-memory-tier-panel.test.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1