### PR TITLE
fix(keeper): reuse turn sandbox runtime across cwd

### DIFF
--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -46,30 +46,31 @@ let in_playground_of_cwd (t : t) ~cwd =
 let resolve (t : t) ~cwd =
   with_lock t (fun () ->
     let in_playground = in_playground_of_cwd t ~cwd in
-    let cwd_norm = normalize cwd in
-    let key = (in_playground, cwd_norm) in
-    match Hashtbl.find_opt t.cache key with
-    | Some r -> Some r
-    | None ->
-      let (effective_profile, effective_network) =
-        Keeper_shell_docker.effective_sandbox_profile
-          ~meta:t.meta ~in_playground
+    let (effective_profile, effective_network) =
+      Keeper_shell_docker.effective_sandbox_profile
+        ~meta:t.meta ~in_playground
+    in
+    let actual_network =
+      Option.value t.default_network_override ~default:effective_network
+    in
+    match effective_profile with
+    | Keeper_types.Local -> None
+    | Keeper_types.Docker ->
+      let key =
+        (in_playground, Keeper_types.network_mode_to_string actual_network)
       in
-      let actual_network =
-        Option.value t.default_network_override ~default:effective_network
-      in
-      (match effective_profile with
-       | Keeper_types.Docker ->
-         let r =
-           Keeper_turn_sandbox_runtime.create
-             ~config:t.config
-             ~meta:t.meta
-             ~network_mode:actual_network
-             ()
-         in
-         Hashtbl.add t.cache key r;
-         Some r
-       | Keeper_types.Local -> None))
+      match Hashtbl.find_opt t.cache key with
+      | Some r -> Some r
+      | None ->
+        let r =
+          Keeper_turn_sandbox_runtime.create
+            ~config:t.config
+            ~meta:t.meta
+            ~network_mode:actual_network
+            ()
+        in
+        Hashtbl.add t.cache key r;
+        Some r)
 
 let resolve_opt t_opt ~cwd =
   Option.bind t_opt (fun t -> resolve t ~cwd)

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -4,9 +4,10 @@
     each implying a different [in_playground] state.  The factory
     centralizes the {!Keeper_shell_docker.effective_sandbox_profile}
     invariant, evaluates [in_playground] from the call-site [cwd], and
-    memoizes one runtime per [(in_playground, cwd)] so a Docker
-    container is created at most once per distinct dispatch context
-    within a turn.
+    memoizes one runtime per [(in_playground, network_mode)] so a Docker
+    container is created at most once per compatible dispatch context
+    within a turn.  The runtime can still execute from different cwd
+    values via [Keeper_turn_sandbox_runtime.container_cwd_of_host].
 
     Background: pre-PR-3b, [keeper_tools_oas.make_tool_bundle] inspected
     [meta.sandbox_profile] eagerly at turn-start and produced [None]
@@ -40,7 +41,7 @@ val resolve :
 (** Returns [Some runtime] when {!Keeper_shell_docker.effective_sandbox_profile}
     yields [Docker] (with [in_playground] derived from [cwd] vs the
     keeper's playground root); [None] when [Local].  Memoizes per
-    [(in_playground, cwd)] so subsequent calls reuse the same
+    [(in_playground, network_mode)] so subsequent calls reuse the same
     container. *)
 
 val resolve_opt :

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -179,6 +179,10 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_keeper_sandbox_start_status_stop_with_fake_docker;
+          Alcotest.test_case
+            "keeper turn sandbox factory reuses playground runtime" `Quick
+            Test_operator_control_keeper
+            .test_keeper_turn_sandbox_factory_reuses_playground_runtime;
           Alcotest.test_case "keeper config exposes live runtime and sources"
             `Quick
             Test_operator_control_keeper

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -434,6 +434,52 @@ let test_keeper_sandbox_start_status_stop_with_fake_docker () =
         (Option.is_some
            (final_sandbox |> member "why_no_container" |> to_string_option)))
 
+let test_keeper_turn_sandbox_factory_reuses_playground_runtime () =
+  let base_dir = temp_dir () in
+  let keeper_name = "sandbox-docker-cache" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let meta =
+        match
+          Masc_test_deps.meta_of_json_fixture
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("agent_name", `String (Keeper_types.keeper_agent_name keeper_name));
+                ("trace_id", `String ("test-trace-" ^ keeper_name));
+                ("goal", `String "exercise turn sandbox runtime cache");
+              ])
+        with
+        | Ok m ->
+            {
+              m with
+              sandbox_profile = Keeper_types.Docker;
+              network_mode = Keeper_types.Network_none;
+            }
+        | Error err -> Alcotest.fail ("keeper meta fixture failed: " ^ err)
+      in
+      let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+      let nested_cwd = Filename.concat host_root "repos/masc-mcp" in
+      ensure_dir nested_cwd;
+      let factory = Keeper_sandbox_factory.create ~config ~meta () in
+      match
+        Keeper_sandbox_factory.resolve factory ~cwd:host_root,
+        Keeper_sandbox_factory.resolve factory ~cwd:nested_cwd
+      with
+      | Some root_runtime, Some nested_runtime ->
+          Alcotest.(check bool)
+            "same turn sandbox runtime reused across playground cwd values"
+            true
+            (root_runtime == nested_runtime);
+          Keeper_sandbox_factory.cleanup factory
+      | _ -> Alcotest.fail "docker keeper should resolve a turn sandbox runtime")
+
 let test_snapshot_exposes_keeper_and_social_actions () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary

- Reuse the keeper turn Docker sandbox runtime across different cwd values inside the same playground.
- Keep separate runtimes for outside-vs-inside playground execution and for different network modes.
- Add a regression test proving nested playground cwd dispatch reuses the same turn sandbox runtime.

## Root Cause

The turn sandbox factory cached Docker runtimes by `(in_playground, cwd)`. A single keeper turn can dispatch tools with multiple cwd values under the same playground root, while `Keeper_turn_sandbox_runtime` already maps each host cwd into the container. That meant a keeper such as `nick0cave` could start more than one `masc-keeper-turn-...` container in one turn before stale cleanup had a chance to reclaim anything.

## Operator Impact

This should stop same-turn duplicate Docker containers caused by cwd drift. Existing stale cleanup still covers stopped containers, expired TTL containers, and owner-pid-dead containers.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_operator_control.exe`
- `./_build/default/test/test_operator_control.exe test operator 45,46 --show-errors --compact`
