### PR TITLE
feat(dashboard): add common pagination primitive

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -43,6 +43,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - SPEC §10-11 historical PR-S/M tables consolidated into §12 audit
   - README.md tier definitions + directory tree refreshed
 
+- **Production pagination atom**
+  - `dashboard/src/components/common/pagination.ts` promotes the preview-only G4 pagination pattern into a reusable production primitive.
+  - Supports numbered page windows and cursor pagination, both covered by unit and jest-axe tests.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/src/components/common/pagination.a11y.test.ts
+++ b/dashboard/src/components/common/pagination.a11y.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { CursorPagination, Pagination } from './pagination'
+
+describe('Pagination a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders numeric pagination accessibly', async () => {
+    render(html`<${Pagination} totalPages=${12} page=${6} ariaLabel="Task pages" />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('marks the current page and hides summary from assistive tech', () => {
+    render(html`<${Pagination} totalPages=${7} page=${4} />`, container)
+    const current = container.querySelector('[aria-current="page"]')
+    expect(current?.getAttribute('aria-label')).toBe('Page 4, current page')
+    expect(container.querySelector('nav > span')?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('exposes disabled boundary controls', () => {
+    render(html`<${Pagination} totalPages=${3} page=${3} />`, container)
+    const next = container.querySelector('[aria-label="Next page"]') as HTMLButtonElement
+    expect(next.disabled).toBe(true)
+  })
+
+  it('renders cursor pagination accessibly', async () => {
+    render(
+      html`<${CursorPagination}
+        cursor="evt-2604-a3f9"
+        hasPrevious=${true}
+        hasNext=${false}
+      />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('does not fire disabled cursor actions', async () => {
+    const onNext = vi.fn()
+    render(
+      html`<${CursorPagination}
+        hasNext=${false}
+        onNext=${onNext}
+      />`,
+      container,
+    )
+    const next = container.querySelector('[aria-label="Newer"]') as HTMLButtonElement
+    expect(next.getAttribute('aria-disabled')).toBe('true')
+    next.click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onNext).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/common/pagination.test.ts
+++ b/dashboard/src/components/common/pagination.test.ts
@@ -24,6 +24,25 @@ describe('paginationItems', () => {
   it('clamps invalid current pages', () => {
     expect(paginationItems({ page: 99, totalPages: 4 })).toEqual([1, 2, 3, 4])
   })
+
+  it('falls back to a single page for non-finite totals and counts', () => {
+    expect(paginationItems({ page: 2, totalPages: Number.NaN })).toEqual([1])
+    expect(paginationItems({ page: 2, totalPages: Number.POSITIVE_INFINITY })).toEqual([1])
+    expect(paginationItems({
+      page: 9,
+      totalPages: 18,
+      siblingCount: Number.NaN,
+      boundaryCount: Number.NaN,
+    })).toEqual([
+      1,
+      'ellipsis-start',
+      8,
+      9,
+      10,
+      'ellipsis-end',
+      18,
+    ])
+  })
 })
 
 describe('Pagination', () => {
@@ -78,6 +97,13 @@ describe('Pagination', () => {
     const nav = container.querySelector('[data-testid="pager"]')
     expect(nav).not.toBeNull()
     expect(nav?.getAttribute('aria-label')).toBe('Task pages')
+  })
+
+  it('renders a safe fallback when totalPages is not finite', () => {
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: Number.NaN, defaultPage: 2 }), container)
+    expect(container.textContent).toContain('page 1 / 1')
+    expect(container.querySelectorAll('[aria-current="page"]').length).toBe(1)
   })
 })
 

--- a/dashboard/src/components/common/pagination.test.ts
+++ b/dashboard/src/components/common/pagination.test.ts
@@ -1,0 +1,117 @@
+// @ts-nocheck
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { CursorPagination, Pagination, paginationItems } from './pagination'
+
+describe('paginationItems', () => {
+  it('returns every page when the range is small', () => {
+    expect(paginationItems({ page: 2, totalPages: 5 })).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('returns ellipses around the current window', () => {
+    expect(paginationItems({ page: 9, totalPages: 18 })).toEqual([
+      1,
+      'ellipsis-start',
+      8,
+      9,
+      10,
+      'ellipsis-end',
+      18,
+    ])
+  })
+
+  it('clamps invalid current pages', () => {
+    expect(paginationItems({ page: 99, totalPages: 4 })).toEqual([1, 2, 3, 4])
+  })
+})
+
+describe('Pagination', () => {
+  it('renders nav and page buttons', () => {
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: 4, defaultPage: 2 }), container)
+    expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe('Pagination')
+    expect(container.textContent).toContain('page 2 / 4')
+    expect(container.querySelectorAll('button').length).toBe(6)
+  })
+
+  it('marks current page with aria-current', () => {
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: 8, page: 3 }), container)
+    const current = container.querySelector('[aria-current="page"]') as HTMLButtonElement
+    expect(current).not.toBeNull()
+    expect(current.textContent).toBe('3')
+    expect(current.disabled).toBe(true)
+  })
+
+  it('calls onPageChange when a numbered page is clicked', async () => {
+    const onPageChange = vi.fn()
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: 5, page: 2, onPageChange }), container)
+    const page4 = Array.from(container.querySelectorAll('button')).find(
+      (btn) => btn.textContent === '4',
+    ) as HTMLButtonElement
+    page4.click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onPageChange).toHaveBeenCalledWith(4)
+  })
+
+  it('updates uncontrolled page when next is clicked', async () => {
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: 5, defaultPage: 2 }), container)
+    const next = container.querySelector('[aria-label="Next page"]') as HTMLButtonElement
+    next.click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toBe('3')
+  })
+
+  it('disables boundary controls', () => {
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: 3, page: 1 }), container)
+    expect((container.querySelector('[aria-label="Previous page"]') as HTMLButtonElement).disabled).toBe(true)
+    expect((container.querySelector('[aria-label="Next page"]') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('applies testId and custom aria label', () => {
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: 3, ariaLabel: 'Task pages', testId: 'pager' }), container)
+    const nav = container.querySelector('[data-testid="pager"]')
+    expect(nav).not.toBeNull()
+    expect(nav?.getAttribute('aria-label')).toBe('Task pages')
+  })
+})
+
+describe('CursorPagination', () => {
+  it('renders cursor and labels', () => {
+    const container = document.createElement('div')
+    render(h(CursorPagination, { cursor: 'evt-123' }), container)
+    expect(container.textContent).toContain('evt-123')
+    expect(container.textContent).toContain('Older')
+    expect(container.textContent).toContain('Newer')
+  })
+
+  it('calls cursor callbacks', async () => {
+    const onPrevious = vi.fn()
+    const onNext = vi.fn()
+    const container = document.createElement('div')
+    render(h(CursorPagination, { onPrevious, onNext }), container)
+    const buttons = container.querySelectorAll('button')
+    ;(buttons[0] as HTMLButtonElement).click()
+    ;(buttons[1] as HTMLButtonElement).click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onPrevious).toHaveBeenCalledTimes(1)
+    expect(onNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables unavailable cursor directions', async () => {
+    const onPrevious = vi.fn()
+    const container = document.createElement('div')
+    render(h(CursorPagination, { hasPrevious: false, hasNext: false, onPrevious }), container)
+    const buttons = container.querySelectorAll('button')
+    expect((buttons[0] as HTMLButtonElement).disabled).toBe(true)
+    expect((buttons[1] as HTMLButtonElement).disabled).toBe(true)
+    ;(buttons[0] as HTMLButtonElement).click()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onPrevious).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/common/pagination.test.ts
+++ b/dashboard/src/components/common/pagination.test.ts
@@ -25,6 +25,16 @@ describe('paginationItems', () => {
     expect(paginationItems({ page: 99, totalPages: 4 })).toEqual([1, 2, 3, 4])
   })
 
+  it('respects boundaryCount=0 (sliding window only, no boundary pages)', () => {
+    expect(paginationItems({ page: 9, totalPages: 18, boundaryCount: 0 })).toEqual([
+      'ellipsis-start',
+      8,
+      9,
+      10,
+      'ellipsis-end',
+    ])
+  })
+
   it('falls back to a single page for non-finite totals and counts', () => {
     expect(paginationItems({ page: 2, totalPages: Number.NaN })).toEqual([1])
     expect(paginationItems({ page: 2, totalPages: Number.POSITIVE_INFINITY })).toEqual([1])
@@ -91,6 +101,13 @@ describe('Pagination', () => {
     expect((container.querySelector('[aria-label="Next page"]') as HTMLButtonElement).disabled).toBe(false)
   })
 
+  it('applies active classes to the current page button', () => {
+    const container = document.createElement('div')
+    render(h(Pagination, { totalPages: 5, page: 3 }), container)
+    const current = container.querySelector('[aria-current="page"]') as HTMLButtonElement
+    expect(current.className).toContain('bg-[var(--button-primary-bg)]')
+  })
+
   it('applies testId and custom aria label', () => {
     const container = document.createElement('div')
     render(h(Pagination, { totalPages: 3, ariaLabel: 'Task pages', testId: 'pager' }), container)
@@ -127,6 +144,14 @@ describe('CursorPagination', () => {
     await new Promise((r) => setTimeout(r, 0))
     expect(onPrevious).toHaveBeenCalledTimes(1)
     expect(onNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables directions when handlers are not provided', () => {
+    const container = document.createElement('div')
+    render(h(CursorPagination, { hasPrevious: true, hasNext: true }), container)
+    const buttons = container.querySelectorAll('button')
+    expect((buttons[0] as HTMLButtonElement).disabled).toBe(true)
+    expect((buttons[1] as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('disables unavailable cursor directions', async () => {

--- a/dashboard/src/components/common/pagination.ts
+++ b/dashboard/src/components/common/pagination.ts
@@ -6,8 +6,9 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChild } from 'preact'
-import { useCallback, useMemo, useState } from 'preact/hooks'
+import { useCallback, useMemo } from 'preact/hooks'
 import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-preact'
+import { useControllableState } from './use-controllable-state'
 
 type PageItem = number | 'ellipsis-start' | 'ellipsis-end'
 
@@ -49,8 +50,10 @@ const PAGE_BUTTON_CLS = [
   'hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)]',
   'disabled:cursor-not-allowed disabled:text-[var(--color-fg-disabled)] disabled:hover:bg-[var(--color-bg-surface)]',
-  'aria-current:bg-[var(--button-primary-bg)] aria-current:border-[var(--button-primary-border)]',
-  'aria-current:text-[var(--button-primary-fg)]',
+].join(' ')
+const PAGE_BUTTON_ACTIVE_CLS = [
+  'bg-[var(--button-primary-bg)] border-[var(--button-primary-border)]',
+  'text-[var(--button-primary-fg)]',
 ].join(' ')
 const CURSOR_NAV_CLS = [
   'inline-flex items-center gap-2 rounded border border-[var(--color-border-default)]',
@@ -100,7 +103,7 @@ export function paginationItems({
   const total = positiveInteger(totalPages)
   const current = clampPage(page, total)
   const siblings = Math.max(0, finiteInteger(siblingCount, 1))
-  const boundaries = positiveInteger(boundaryCount)
+  const boundaries = Math.max(0, finiteInteger(boundaryCount, 1))
   const visibleWithoutEllipsis = boundaries * 2 + siblings * 2 + 3
 
   if (total <= visibleWithoutEllipsis) return range(1, total)
@@ -150,11 +153,12 @@ export function Pagination({
   testId,
 }: PaginationProps) {
   const total = positiveInteger(totalPages)
-  const [uncontrolledPage, setUncontrolledPage] = useState(() =>
-    clampPage(defaultPage, total),
-  )
-  const isControlled = controlledPage !== undefined
-  const page = clampPage(isControlled ? controlledPage! : uncontrolledPage, total)
+  const [rawPage, setRawPage] = useControllableState<number>({
+    prop: controlledPage !== undefined ? clampPage(controlledPage, total) : undefined,
+    defaultProp: clampPage(defaultPage, total),
+    onChange: onPageChange,
+  })
+  const page = clampPage(rawPage ?? 1, total)
   const items = useMemo(
     () => paginationItems({ page, totalPages: total, siblingCount, boundaryCount }),
     [page, total, siblingCount, boundaryCount],
@@ -162,19 +166,18 @@ export function Pagination({
 
   const setPage = useCallback(
     (next: number) => {
-      const clamped = clampPage(next, total)
-      if (!isControlled) setUncontrolledPage(clamped)
-      if (clamped !== page) onPageChange?.(clamped)
+      setRawPage(clampPage(next, total))
     },
-    [isControlled, onPageChange, page, total],
+    [setRawPage, total],
   )
 
   const button = (target: number, label: string, child: ComponentChild) => {
     const current = target === page
+    const cls = current ? `${PAGE_BUTTON_CLS} ${PAGE_BUTTON_ACTIVE_CLS}` : PAGE_BUTTON_CLS
     return html`
       <button
         type="button"
-        class=${PAGE_BUTTON_CLS}
+        class=${cls}
         aria-label=${current ? `${label}, current page` : label}
         aria-current=${current ? 'page' : undefined}
         disabled=${disabled || current}
@@ -246,8 +249,8 @@ export function CursorPagination({
   class: cx,
   testId,
 }: CursorPaginationProps) {
-  const previousDisabled = disabled || !hasPrevious
-  const nextDisabled = disabled || !hasNext
+  const previousDisabled = disabled || !hasPrevious || onPrevious === undefined
+  const nextDisabled = disabled || !hasNext || onNext === undefined
 
   return html`
     <nav

--- a/dashboard/src/components/common/pagination.ts
+++ b/dashboard/src/components/common/pagination.ts
@@ -65,8 +65,17 @@ const CURSOR_BUTTON_CLS = [
   'disabled:cursor-not-allowed disabled:text-[var(--color-fg-disabled)] disabled:hover:bg-transparent',
 ].join(' ')
 
+function finiteInteger(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback
+  return Math.trunc(value)
+}
+
+function positiveInteger(value: number, fallback = 1): number {
+  return Math.max(1, finiteInteger(value, fallback))
+}
+
 function clampPage(page: number, totalPages: number): number {
-  const total = Math.max(1, Math.trunc(totalPages))
+  const total = positiveInteger(totalPages)
   if (!Number.isFinite(page)) return 1
   return Math.min(total, Math.max(1, Math.trunc(page)))
 }
@@ -88,10 +97,10 @@ export function paginationItems({
   siblingCount?: number
   boundaryCount?: number
 }): PageItem[] {
-  const total = Math.max(1, Math.trunc(totalPages))
+  const total = positiveInteger(totalPages)
   const current = clampPage(page, total)
-  const siblings = Math.max(0, Math.trunc(siblingCount))
-  const boundaries = Math.max(1, Math.trunc(boundaryCount))
+  const siblings = Math.max(0, finiteInteger(siblingCount, 1))
+  const boundaries = positiveInteger(boundaryCount)
   const visibleWithoutEllipsis = boundaries * 2 + siblings * 2 + 3
 
   if (total <= visibleWithoutEllipsis) return range(1, total)
@@ -140,7 +149,7 @@ export function Pagination({
   class: cx,
   testId,
 }: PaginationProps) {
-  const total = Math.max(1, Math.trunc(totalPages))
+  const total = positiveInteger(totalPages)
   const [uncontrolledPage, setUncontrolledPage] = useState(() =>
     clampPage(defaultPage, total),
   )

--- a/dashboard/src/components/common/pagination.ts
+++ b/dashboard/src/components/common/pagination.ts
@@ -1,0 +1,286 @@
+// Pagination — numeric and cursor pagination primitives.
+//
+// Numeric pagination uses nav + list semantics and marks the current page with
+// aria-current="page". Cursor pagination keeps previous/next batch controls
+// explicit for event streams that do not expose page numbers.
+
+import { html } from 'htm/preact'
+import type { ComponentChild } from 'preact'
+import { useCallback, useMemo, useState } from 'preact/hooks'
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-preact'
+
+type PageItem = number | 'ellipsis-start' | 'ellipsis-end'
+
+export interface PaginationProps {
+  page?: number
+  defaultPage?: number
+  totalPages: number
+  onPageChange?: (page: number) => void
+  siblingCount?: number
+  boundaryCount?: number
+  disabled?: boolean
+  showSummary?: boolean
+  ariaLabel?: string
+  class?: string
+  testId?: string
+}
+
+export interface CursorPaginationProps {
+  cursor?: string
+  hasPrevious?: boolean
+  hasNext?: boolean
+  onPrevious?: () => void
+  onNext?: () => void
+  previousLabel?: string
+  nextLabel?: string
+  ariaLabel?: string
+  disabled?: boolean
+  class?: string
+  testId?: string
+}
+
+const NAV_CLS = 'inline-flex items-center gap-2'
+const LIST_CLS = 'inline-flex items-center gap-1'
+const PAGE_BUTTON_CLS = [
+  'inline-flex h-6 min-w-6 items-center justify-center rounded-sm border px-2',
+  'border-[var(--color-border-default)] bg-[var(--color-bg-surface)]',
+  'font-mono text-2xs tabular-nums text-[var(--color-fg-secondary)]',
+  'transition-colors duration-[var(--t-fast)]',
+  'hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)]',
+  'disabled:cursor-not-allowed disabled:text-[var(--color-fg-disabled)] disabled:hover:bg-[var(--color-bg-surface)]',
+  'aria-current:bg-[var(--button-primary-bg)] aria-current:border-[var(--button-primary-border)]',
+  'aria-current:text-[var(--button-primary-fg)]',
+].join(' ')
+const CURSOR_NAV_CLS = [
+  'inline-flex items-center gap-2 rounded border border-[var(--color-border-default)]',
+  'bg-[var(--color-bg-surface)] px-3 py-2 font-mono',
+].join(' ')
+const CURSOR_BUTTON_CLS = [
+  'inline-flex h-6 items-center gap-1 rounded-sm border border-[var(--color-border-default)] px-2',
+  'text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]',
+  'transition-colors duration-[var(--t-fast)]',
+  'hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)]',
+  'disabled:cursor-not-allowed disabled:text-[var(--color-fg-disabled)] disabled:hover:bg-transparent',
+].join(' ')
+
+function clampPage(page: number, totalPages: number): number {
+  const total = Math.max(1, Math.trunc(totalPages))
+  if (!Number.isFinite(page)) return 1
+  return Math.min(total, Math.max(1, Math.trunc(page)))
+}
+
+function range(start: number, end: number): number[] {
+  const out: number[] = []
+  for (let n = start; n <= end; n += 1) out.push(n)
+  return out
+}
+
+export function paginationItems({
+  page,
+  totalPages,
+  siblingCount = 1,
+  boundaryCount = 1,
+}: {
+  page: number
+  totalPages: number
+  siblingCount?: number
+  boundaryCount?: number
+}): PageItem[] {
+  const total = Math.max(1, Math.trunc(totalPages))
+  const current = clampPage(page, total)
+  const siblings = Math.max(0, Math.trunc(siblingCount))
+  const boundaries = Math.max(1, Math.trunc(boundaryCount))
+  const visibleWithoutEllipsis = boundaries * 2 + siblings * 2 + 3
+
+  if (total <= visibleWithoutEllipsis) return range(1, total)
+
+  const startPages = range(1, Math.min(boundaries, total))
+  const endPages = range(Math.max(total - boundaries + 1, boundaries + 1), total)
+  const siblingStart = Math.max(
+    Math.min(current - siblings, total - boundaries - siblings * 2 - 1),
+    boundaries + 2,
+  )
+  const siblingEnd = Math.min(
+    Math.max(current + siblings, boundaries + siblings * 2 + 2),
+    total - boundaries - 1,
+  )
+
+  const items: PageItem[] = [...startPages]
+  if (siblingStart > boundaries + 2) {
+    items.push('ellipsis-start')
+  } else {
+    items.push(...range(boundaries + 1, siblingStart - 1))
+  }
+  items.push(...range(siblingStart, siblingEnd))
+  if (siblingEnd < total - boundaries - 1) {
+    items.push('ellipsis-end')
+  } else {
+    items.push(...range(siblingEnd + 1, total - boundaries))
+  }
+  items.push(...endPages)
+  return items
+}
+
+function icon(child: ComponentChild) {
+  return html`<span aria-hidden="true" class="inline-flex items-center">${child}</span>`
+}
+
+export function Pagination({
+  page: controlledPage,
+  defaultPage = 1,
+  totalPages,
+  onPageChange,
+  siblingCount = 1,
+  boundaryCount = 1,
+  disabled = false,
+  showSummary = true,
+  ariaLabel = 'Pagination',
+  class: cx,
+  testId,
+}: PaginationProps) {
+  const total = Math.max(1, Math.trunc(totalPages))
+  const [uncontrolledPage, setUncontrolledPage] = useState(() =>
+    clampPage(defaultPage, total),
+  )
+  const isControlled = controlledPage !== undefined
+  const page = clampPage(isControlled ? controlledPage! : uncontrolledPage, total)
+  const items = useMemo(
+    () => paginationItems({ page, totalPages: total, siblingCount, boundaryCount }),
+    [page, total, siblingCount, boundaryCount],
+  )
+
+  const setPage = useCallback(
+    (next: number) => {
+      const clamped = clampPage(next, total)
+      if (!isControlled) setUncontrolledPage(clamped)
+      if (clamped !== page) onPageChange?.(clamped)
+    },
+    [isControlled, onPageChange, page, total],
+  )
+
+  const button = (target: number, label: string, child: ComponentChild) => {
+    const current = target === page
+    return html`
+      <button
+        type="button"
+        class=${PAGE_BUTTON_CLS}
+        aria-label=${current ? `${label}, current page` : label}
+        aria-current=${current ? 'page' : undefined}
+        disabled=${disabled || current}
+        onClick=${() => setPage(target)}
+      >${child}</button>
+    `
+  }
+
+  return html`
+    <nav
+      aria-label=${ariaLabel}
+      data-testid=${testId}
+      class=${cx ? `${NAV_CLS} ${cx}` : NAV_CLS}
+    >
+      <ul class=${LIST_CLS}>
+        <li>
+          <button
+            type="button"
+            class=${PAGE_BUTTON_CLS}
+            aria-label="Previous page"
+            disabled=${disabled || page <= 1}
+            onClick=${() => setPage(page - 1)}
+          >${icon(html`<${ChevronLeft} size=${14} focusable="false" />`)}</button>
+        </li>
+        ${items.map((item) =>
+          typeof item === 'number'
+            ? html`<li key=${`page-${item}`}>${button(item, `Page ${item}`, item)}</li>`
+            : html`
+                <li key=${item}>
+                  <span
+                    aria-hidden="true"
+                    class="inline-flex h-6 min-w-6 items-center justify-center text-[var(--color-fg-disabled)]"
+                  >${icon(html`<${MoreHorizontal} size=${14} focusable="false" />`)}</span>
+                </li>
+              `,
+        )}
+        <li>
+          <button
+            type="button"
+            class=${PAGE_BUTTON_CLS}
+            aria-label="Next page"
+            disabled=${disabled || page >= total}
+            onClick=${() => setPage(page + 1)}
+          >${icon(html`<${ChevronRight} size=${14} focusable="false" />`)}</button>
+        </li>
+      </ul>
+      ${showSummary
+        ? html`
+            <span
+              aria-hidden="true"
+              class="font-mono text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]"
+            >page ${page} / ${total}</span>
+          `
+        : null}
+    </nav>
+  `
+}
+
+export function CursorPagination({
+  cursor,
+  hasPrevious = true,
+  hasNext = true,
+  onPrevious,
+  onNext,
+  previousLabel = 'Older',
+  nextLabel = 'Newer',
+  ariaLabel = 'Cursor pagination',
+  disabled = false,
+  class: cx,
+  testId,
+}: CursorPaginationProps) {
+  const previousDisabled = disabled || !hasPrevious
+  const nextDisabled = disabled || !hasNext
+
+  return html`
+    <nav
+      aria-label=${ariaLabel}
+      data-testid=${testId}
+      class=${cx ? `${CURSOR_NAV_CLS} ${cx}` : CURSOR_NAV_CLS}
+    >
+      <button
+        type="button"
+        class=${CURSOR_BUTTON_CLS}
+        aria-label=${previousLabel}
+        aria-disabled=${previousDisabled ? 'true' : undefined}
+        disabled=${previousDisabled}
+        onClick=${() => {
+          if (!previousDisabled) onPrevious?.()
+        }}
+      >
+        ${icon(html`<${ChevronLeft} size=${14} focusable="false" />`)}
+        <span>${previousLabel}</span>
+      </button>
+      ${cursor
+        ? html`
+            <span
+              class="min-w-0 flex-1 truncate px-2 text-center text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]"
+            >
+              cursor · <span class="text-[var(--color-accent-fg)]">${cursor}</span>
+            </span>
+          `
+        : null}
+      <button
+        type="button"
+        class=${CURSOR_BUTTON_CLS}
+        aria-label=${nextLabel}
+        aria-disabled=${nextDisabled ? 'true' : undefined}
+        disabled=${nextDisabled}
+        onClick=${() => {
+          if (!nextDisabled) onNext?.()
+        }}
+      >
+        <span>${nextLabel}</span>
+        ${icon(html`<${ChevronRight} size=${14} focusable="false" />`)}
+      </button>
+    </nav>
+  `
+}


### PR DESCRIPTION
## Summary
- promote the design-system G4 pagination pattern into a production common component
- add numbered Pagination and CursorPagination primitives
- cover page-window behavior, callbacks, disabled states, and jest-axe accessibility

## Verification
- pnpm vitest run --config vitest.config.ts src/components/common/pagination.test.ts src/components/common/pagination.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/common/pagination.ts src/components/common/pagination.test.ts src/components/common/pagination.a11y.test.ts