### PR TITLE
fix(keeper): let sandbox stop target turn containers

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -1,13 +1,36 @@
 (** Operator-facing keeper sandbox control.
 
     This module keeps Docker lifecycle operations scoped to MASC keeper labels
-    and the active base path.  It deliberately manages only containers with
-    [container_kind=managed]; turn/oneshot containers remain owned by their
-    existing execution paths and stale cleanup. *)
+    and the active base path.  Start operations deliberately manage only
+    [container_kind=managed]; stop operations default to that same safe scope,
+    but can target [turn] or [all] when an operator needs to clear abandoned
+    turn containers before TTL cleanup. *)
 
 open Keeper_types
 
 let managed_kind = "managed"
+let turn_kind = "turn"
+
+type stop_scope =
+  | Stop_managed
+  | Stop_turn
+  | Stop_all
+
+let stop_scope_to_string = function
+  | Stop_managed -> managed_kind
+  | Stop_turn -> turn_kind
+  | Stop_all -> "all"
+
+let parse_stop_scope raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "managed" -> Ok Stop_managed
+  | "turn" -> Ok Stop_turn
+  | "all" -> Ok Stop_all
+  | other ->
+      Error
+        (Printf.sprintf
+           "invalid container_kind %S; expected managed, turn, or all"
+           other)
 
 let now_ms () =
   int_of_float (Unix.gettimeofday () *. 1000.0)
@@ -201,14 +224,24 @@ let start_managed_container
                     Error message))
     | Error err -> Error err
 
-let stop_managed_containers ?keeper_name ~(config : Coord.config)
+let stop_containers ?keeper_name ~scope ~(config : Coord.config)
     ~(timeout_sec : float) () =
+  let container_kind =
+    match scope with
+    | Stop_managed -> Some managed_kind
+    | Stop_turn -> Some turn_kind
+    | Stop_all -> None
+  in
   Keeper_sandbox_runtime.stop_containers
     ?keeper_name
-    ~container_kind:managed_kind
+    ?container_kind
     ~base_path:config.base_path
     ~timeout_sec
     ()
+
+let stop_managed_containers ?keeper_name ~(config : Coord.config)
+    ~(timeout_sec : float) () =
+  stop_containers ?keeper_name ~scope:Stop_managed ~config ~timeout_sec ()
 
 let cleanup_stale ~(config : Coord.config) ~(timeout_sec : float) () =
   Keeper_sandbox_runtime.cleanup_stale_containers

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -10,6 +10,7 @@ open Keeper_types
 
 let managed_kind = "managed"
 let turn_kind = "turn"
+let all_kind = "all"
 
 type stop_scope =
   | Stop_managed
@@ -19,13 +20,14 @@ type stop_scope =
 let stop_scope_to_string = function
   | Stop_managed -> managed_kind
   | Stop_turn -> turn_kind
-  | Stop_all -> "all"
+  | Stop_all -> all_kind
 
 let parse_stop_scope raw =
   match String.lowercase_ascii (String.trim raw) with
-  | "" | "managed" -> Ok Stop_managed
-  | "turn" -> Ok Stop_turn
-  | "all" -> Ok Stop_all
+  | "" -> Ok Stop_managed
+  | kind when String.equal kind managed_kind -> Ok Stop_managed
+  | kind when String.equal kind turn_kind -> Ok Stop_turn
+  | kind when String.equal kind all_kind -> Ok Stop_all
   | other ->
       Error
         (Printf.sprintf

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -4,6 +4,8 @@ val managed_kind : string
 
 val turn_kind : string
 
+val all_kind : string
+
 type stop_scope =
   | Stop_managed
   | Stop_turn

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -2,6 +2,17 @@ open Keeper_types
 
 val managed_kind : string
 
+val turn_kind : string
+
+type stop_scope =
+  | Stop_managed
+  | Stop_turn
+  | Stop_all
+
+val parse_stop_scope : string -> (stop_scope, string) result
+
+val stop_scope_to_string : stop_scope -> string
+
 val start_managed_container :
   config:Coord.config ->
   meta:keeper_meta ->
@@ -13,6 +24,14 @@ val start_managed_container :
 
 val stop_managed_containers :
   ?keeper_name:string ->
+  config:Coord.config ->
+  timeout_sec:float ->
+  unit ->
+  Keeper_sandbox_runtime.stop_result
+
+val stop_containers :
+  ?keeper_name:string ->
+  scope:stop_scope ->
   config:Coord.config ->
   timeout_sec:float ->
   unit ->

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -532,17 +532,22 @@ let keeper_schemas : tool_schema list = [
 
   {
     name = "masc_keeper_sandbox_stop";
-    description = "Stop managed keeper sandbox containers. By default stops all managed keeper sandbox containers in the current base path.";
+    description = "Stop keeper sandbox containers scoped to this base path. Defaults to managed containers; pass container_kind=turn or all to clean abandoned turn containers.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional keeper handle. When omitted, stop all managed keeper sandbox containers for this base path.");
+          ("description", `String "Optional keeper handle. When omitted, stop matching keeper sandbox containers for this base path.");
+        ]);
+        ("container_kind", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "managed"; `String "turn"; `String "all"]);
+          ("description", `String "Container kind to stop. Defaults to managed; use turn for turn-scoped containers such as masc-keeper-turn-*.");
         ]);
         ("prune_stale", `Assoc [
           ("type", `String "boolean");
-          ("description", `String "Also run stale keeper sandbox cleanup after stopping managed containers.");
+          ("description", `String "Also run stale keeper sandbox cleanup after stopping matching containers.");
         ]);
         ("timeout_sec", `Assoc [
           ("type", `String "number");

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -532,7 +532,7 @@ let keeper_schemas : tool_schema list = [
 
   {
     name = "masc_keeper_sandbox_stop";
-    description = "Stop keeper sandbox containers scoped to this base path. Defaults to managed containers; pass container_kind=turn or all to clean abandoned turn containers.";
+    description = "Stop keeper sandbox containers scoped to this base path. Defaults to managed containers; pass container_kind=turn or container_kind=all to clean abandoned turn containers.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1162,7 +1162,7 @@ let handle_keeper_sandbox_stop ctx args : tool_result =
     | name -> Some name
   in
   match Keeper_sandbox_control.parse_stop_scope container_kind_raw with
-  | Error err -> (false, err)
+  | Error err -> error_result_typed ~code:Validation_error err
   | Ok scope ->
       let stop_result =
         Keeper_sandbox_control.stop_containers

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1153,55 +1153,62 @@ let handle_keeper_sandbox_start ctx args : tool_result =
 let handle_keeper_sandbox_stop ctx args : tool_result =
   let timeout_sec = Stdlib.Float.min 30.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 10.0)) in
   let prune_stale = get_bool args "prune_stale" false in
+  let container_kind_raw =
+    get_string args "container_kind" Keeper_sandbox_control.managed_kind
+  in
   let keeper_name =
     match String.trim (get_string args "name" "") with
     | "" -> None
     | name -> Some name
   in
-  let stop_result =
-    Keeper_sandbox_control.stop_managed_containers
-      ?keeper_name ~config:ctx.config ~timeout_sec ()
-  in
-  let stale_cleanup =
-    if prune_stale then
-      Some
-        (Keeper_sandbox_control.cleanup_stale ~config:ctx.config
-           ~timeout_sec:(Stdlib.Float.min timeout_sec 5.0) ())
-    else
-      None
-  in
-  (match keeper_name with
-   | Some name -> invalidate_status_cache name
-   | None -> Keeper_status_detail.invalidate_status_cache_all ());
-  let stop_json =
-    `Assoc
-      [
-        ("matched", `Int stop_result.matched);
-        ("removed", `Int stop_result.removed);
-        ("errors", `List (List.map (fun err -> `String err) stop_result.errors));
-      ]
-  in
-  let stale_json =
-    match stale_cleanup with
-    | None -> `Null
-    | Some cleanup ->
+  match Keeper_sandbox_control.parse_stop_scope container_kind_raw with
+  | Error err -> (false, err)
+  | Ok scope ->
+      let stop_result =
+        Keeper_sandbox_control.stop_containers
+          ?keeper_name ~scope ~config:ctx.config ~timeout_sec ()
+      in
+      let stale_cleanup =
+        if prune_stale then
+          Some
+            (Keeper_sandbox_control.cleanup_stale ~config:ctx.config
+               ~timeout_sec:(Stdlib.Float.min timeout_sec 5.0) ())
+        else
+          None
+      in
+      (match keeper_name with
+       | Some name -> invalidate_status_cache name
+       | None -> Keeper_status_detail.invalidate_status_cache_all ());
+      let stop_json =
         `Assoc
           [
-            ("scanned", `Int cleanup.scanned);
-            ("removed", `Int cleanup.removed);
-            ("errors",
-             `List (List.map (fun err -> `String err) cleanup.errors));
+            ("matched", `Int stop_result.matched);
+            ("removed", `Int stop_result.removed);
+            ("errors", `List (List.map (fun err -> `String err) stop_result.errors));
           ]
-  in
-  ( true,
-    Yojson.Safe.pretty_to_string
-      (`Assoc
-         [
-           ("action", `String "stop");
-           ("keeper", Json_util.string_opt_to_json keeper_name);
-           ("stop_result", stop_json);
-           ("stale_cleanup", stale_json);
-         ]) )
+      in
+      let stale_json =
+        match stale_cleanup with
+        | None -> `Null
+        | Some cleanup ->
+            `Assoc
+              [
+                ("scanned", `Int cleanup.scanned);
+                ("removed", `Int cleanup.removed);
+                ("errors",
+                 `List (List.map (fun err -> `String err) cleanup.errors));
+              ]
+      in
+      ( true,
+        Yojson.Safe.pretty_to_string
+          (`Assoc
+             [
+               ("action", `String "stop");
+               ("keeper", Json_util.string_opt_to_json keeper_name);
+               ("container_kind", `String (Keeper_sandbox_control.stop_scope_to_string scope));
+               ("stop_result", stop_json);
+               ("stale_cleanup", stale_json);
+             ]) )
 
 (* masc_keeper_reconcile tool removed along with the manual_reconcile
    blocker mechanism. Failed turns record evidence via Keeper_registry;

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -180,6 +180,10 @@ let () =
             Test_operator_control_keeper
             .test_keeper_sandbox_start_status_stop_with_fake_docker;
           Alcotest.test_case
+            "keeper sandbox stop targets turn containers with kind" `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_stop_targets_turn_containers_with_kind;
+          Alcotest.test_case
             "keeper turn sandbox factory reuses playground runtime" `Quick
             Test_operator_control_keeper
             .test_keeper_turn_sandbox_factory_reuses_playground_runtime;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -522,6 +522,10 @@ let test_keeper_sandbox_stop_targets_turn_containers_with_kind () =
       Alcotest.(check bool) "invalid kind message actionable" true
         (contains_substring invalid_body
            "expected managed, turn, or all");
+      let invalid_json = parse_json_exn invalid_body in
+      Alcotest.(check string) "invalid kind typed validation error"
+        "validation_error"
+        (invalid_json |> member "error_code" |> to_string);
       let ok_turn, turn_body =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_stop"
           ~args:
@@ -540,6 +544,13 @@ let test_keeper_sandbox_stop_targets_turn_containers_with_kind () =
       Alcotest.(check int) "turn stop removes turn container" 1
         (turn_json |> member "stop_result" |> member "removed" |> to_int);
       let log = read_file log_path in
+      Alcotest.(check bool) "turn stop filters by kind label" true
+        (contains_substring log "--filter label=masc.mcp.kind=turn");
+      Alcotest.(check bool) "turn stop filters by keeper label" true
+        (contains_substring log
+           ("--filter label=masc.mcp.keeper=" ^ keeper_name));
+      Alcotest.(check bool) "turn stop filters by base path hash label" true
+        (contains_substring log "--filter label=masc.mcp.base_path_hash=");
       Alcotest.(check bool) "turn container removed by id" true
         (contains_substring log "rm -f turn-1"))
 

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -116,7 +116,21 @@ case \"$cmd\" in\n\
     exit 0\n\
     ;;\n\
   ps)\n\
-    if read_state; then\n\
+    want_kind=''\n\
+    while [ \"$#\" -gt 0 ]; do\n\
+      case \"$1\" in\n\
+        --filter)\n\
+          case \"$2\" in\n\
+            label=masc.mcp.kind=*) want_kind=${2#label=masc.mcp.kind=} ;;\n\
+          esac\n\
+          shift 2\n\
+          ;;\n\
+        *)\n\
+          shift\n\
+          ;;\n\
+      esac\n\
+    done\n\
+    if read_state && { [ -z \"$want_kind\" ] || [ \"$kind\" = \"$want_kind\" ]; }; then\n\
       printf '%s\\n' \"$cid\"\n\
     fi\n\
     exit 0\n\
@@ -433,6 +447,101 @@ let test_keeper_sandbox_start_status_stop_with_fake_docker () =
       Alcotest.(check bool) "why_no_container restored" true
         (Option.is_some
            (final_sandbox |> member "why_no_container" |> to_string_option)))
+
+let test_keeper_sandbox_stop_targets_turn_containers_with_kind () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "nick0cave" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let state_dir = Filename.concat base_dir "fake-docker" in
+      let state_file = Filename.concat state_dir "containers.tsv" in
+      let log_path = Filename.concat state_dir "docker.log" in
+      ensure_dir state_dir;
+      let turn_state =
+        String.concat "\t"
+          [
+            "turn-1";
+            "masc-keeper-turn-nick0cave-none-1-1";
+            "alpine:test";
+            "running";
+            "true";
+            "2026-05-02T00:00:00Z";
+            keeper_name;
+            "turn";
+            "none";
+            string_of_int (Unix.getpid ());
+            "1000";
+            "1800";
+          ]
+        ^ "\n"
+      in
+      with_fake_docker fake_docker_managed_sandbox_script @@ fun () ->
+      with_env "KEEPER_DOCKER_STATE_FILE" state_file @@ fun () ->
+      with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+      write_file state_file turn_state;
+      let ok_default, default_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_stop"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      Alcotest.(check bool) "default sandbox stop ok" true ok_default;
+      let default_json = parse_json_exn default_body in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "default stop scope managed" "managed"
+        (default_json |> member "container_kind" |> to_string);
+      Alcotest.(check int) "default stop ignores turn container" 0
+        (default_json |> member "stop_result" |> member "matched" |> to_int);
+      let ok_invalid, invalid_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_stop"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("container_kind", `String "future");
+              ])
+      in
+      Alcotest.(check bool) "invalid kind rejected" false ok_invalid;
+      Alcotest.(check bool) "invalid kind message actionable" true
+        (contains_substring invalid_body
+           "expected managed, turn, or all");
+      let ok_turn, turn_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_stop"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("container_kind", `String "turn");
+              ])
+      in
+      Alcotest.(check bool) "turn sandbox stop ok" true ok_turn;
+      let turn_json = parse_json_exn turn_body in
+      Alcotest.(check string) "turn stop scope surfaced" "turn"
+        (turn_json |> member "container_kind" |> to_string);
+      Alcotest.(check int) "turn stop matches turn container" 1
+        (turn_json |> member "stop_result" |> member "matched" |> to_int);
+      Alcotest.(check int) "turn stop removes turn container" 1
+        (turn_json |> member "stop_result" |> member "removed" |> to_int);
+      let log = read_file log_path in
+      Alcotest.(check bool) "turn container removed by id" true
+        (contains_substring log "rm -f turn-1"))
 
 let test_keeper_turn_sandbox_factory_reuses_playground_runtime () =
   let base_dir = temp_dir () in


### PR DESCRIPTION
## Summary

- Extend `masc_keeper_sandbox_stop` with `container_kind=managed|turn|all`.
- Keep the existing safe default: no argument still stops only managed sandbox containers.
- Allow operators to explicitly remove fresh/running turn-scoped containers such as `masc-keeper-turn-*` when a turn was abandoned before TTL cleanup.
- Add regression coverage proving default stop ignores turn containers, invalid kinds fail closed, and `container_kind=turn` removes the turn container by Docker label scope.

## Root Cause

The prior cleanup surface could stop managed prewarm containers and prune stale containers, but it had no direct operator path for fresh/running `container_kind=turn` containers. After the duplicate-container bug, existing turn containers could remain visible until TTL/stale cleanup even after the underlying cache behavior was fixed.

## Operator Impact

For the screenshot-style case, an operator can now run `masc_keeper_sandbox_stop` with `name=<keeper>` and `container_kind=turn` to clear that keeper's turn containers immediately. `container_kind=all` is available for base-path-scoped full sandbox cleanup, while the default remains managed-only.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_operator_control.exe`
- `./_build/default/test/test_operator_control.exe test operator 44,45,46,47 --show-errors --compact`
