### PR TITLE
feat(dashboard): add keeper line ownership store

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -47,6 +47,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `dashboard/src/components/common/pagination.ts` promotes the preview-only G4 pagination pattern into a reusable production primitive.
   - Supports numbered page windows and cursor pagination, both covered by unit and jest-axe tests.
 
+- **Keeper line ownership substrate**
+  - `design-system/headless-core/keeper-line-ownership.ts` implements RFC 0019's line-range accumulator and deterministic keeper hue mapping.
+  - `src/components/ide/keeper-line-ownership-store.ts` publishes dashboard snapshots for the IDE blame gutter; the editor mock now consumes the store instead of hardcoded row ownership.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/design-system/headless-core/keeper-line-ownership.test.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createKeeperLineOwnershipAccumulator,
+  keeperHueIndex,
+  type KeeperEdit,
+} from './keeper-line-ownership'
+
+const file = 'runtime/cascade/router.ts'
+
+const edit = (patch: Partial<KeeperEdit>): KeeperEdit => ({
+  file_path: file,
+  line_start: 1,
+  line_end: 1,
+  keeper_id: 'nick0cave',
+  timestamp_ms: 1000,
+  kind: 'edit',
+  ...patch,
+})
+
+describe('createKeeperLineOwnershipAccumulator', () => {
+  it('starts empty for the active file', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    expect(s.filePath()).toBe(file)
+    expect([...s.ownership().entries()]).toEqual([])
+    expect(s.knownKeepers()).toEqual([])
+  })
+
+  it('expands multi-line edits into per-line ownership', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    expect(s.ingest(edit({ line_start: 2, line_end: 4 }))).toBe(true)
+    expect([...s.ownership().keys()]).toEqual([2, 3, 4])
+    expect(s.ownership().get(3)).toMatchObject({
+      keeper_id: 'nick0cave',
+      last_edit_kind: 'edit',
+      last_edit_ms: 1000,
+    })
+  })
+
+  it('uses latest timestamp per line and preserves line history', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    s.ingest(edit({ line_start: 3, line_end: 3, keeper_id: 'nick0cave', timestamp_ms: 2000 }))
+    s.ingest(edit({ line_start: 3, line_end: 3, keeper_id: 'sangsu', timestamp_ms: 1500, kind: 'refactor' }))
+    s.ingest(edit({ line_start: 3, line_end: 3, keeper_id: 'masc-improver', timestamp_ms: 2500, kind: 'revert' }))
+
+    expect(s.ownership().get(3)).toMatchObject({
+      keeper_id: 'masc-improver',
+      last_edit_kind: 'revert',
+      last_edit_ms: 2500,
+    })
+    expect(s.eventsForLine(3).map((event) => event.keeper_id)).toEqual([
+      'nick0cave',
+      'sangsu',
+      'masc-improver',
+    ])
+  })
+
+  it('ignores events for other files and invalid ranges', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    expect(s.ingest(edit({ file_path: 'other.ts' }))).toBe(false)
+    expect(s.ingest(edit({ line_start: 4, line_end: 2 }))).toBe(false)
+    expect(s.ingest(edit({ line_start: 0, line_end: 1 }))).toBe(false)
+    expect(s.ingest(edit({ line_start: Number.NaN, line_end: 1 }))).toBe(false)
+    expect(s.ingest(edit({ line_start: 1, line_end: Number.POSITIVE_INFINITY }))).toBe(false)
+    expect(s.ingest(edit({ line_start: Number.MAX_SAFE_INTEGER + 1, line_end: Number.MAX_SAFE_INTEGER + 1 }))).toBe(false)
+    expect(s.ownership().size).toBe(0)
+  })
+
+  it('rejects non-finite timestamps without poisoning ownership comparisons', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    expect(s.ingest(edit({ line_start: 2, line_end: 2, timestamp_ms: 1000 }))).toBe(true)
+    expect(s.ingest(edit({ line_start: 2, line_end: 2, keeper_id: 'sangsu', timestamp_ms: Number.NaN }))).toBe(false)
+    expect(s.ingest(edit({ line_start: 2, line_end: 2, keeper_id: 'rama', timestamp_ms: Number.POSITIVE_INFINITY }))).toBe(false)
+
+    expect(s.ownership().get(2)).toMatchObject({
+      keeper_id: 'nick0cave',
+      last_edit_ms: 1000,
+    })
+    expect(s.eventsForLine(2).map((event) => event.keeper_id)).toEqual(['nick0cave'])
+    expect(s.knownKeepers()).toEqual(['nick0cave'])
+  })
+
+  it('knownKeepers is sorted and de-duplicated', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    s.ingest(edit({ keeper_id: 'sangsu', line_start: 1, line_end: 1 }))
+    s.ingest(edit({ keeper_id: 'nick0cave', line_start: 2, line_end: 2 }))
+    s.ingest(edit({ keeper_id: 'sangsu', line_start: 3, line_end: 3 }))
+    expect(s.knownKeepers()).toEqual(['nick0cave', 'sangsu'])
+  })
+
+  it('reset keeps subscribers possible by clearing in place and optionally switches file', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    s.ingest(edit({ line_start: 1, line_end: 2 }))
+    s.reset('runtime/fsm/lifeline.ts')
+    expect(s.filePath()).toBe('runtime/fsm/lifeline.ts')
+    expect(s.ownership().size).toBe(0)
+    expect(s.knownKeepers()).toEqual([])
+    expect(s.ingest(edit({ line_start: 1, line_end: 1 }))).toBe(false)
+  })
+})
+
+describe('keeperHueIndex', () => {
+  it('is deterministic and maps to the existing 1..12 keeper token slots', () => {
+    expect(keeperHueIndex('nick0cave')).toBe(keeperHueIndex('nick0cave'))
+    for (const keeper of ['nick0cave', 'sangsu', 'masc-improver', 'rama']) {
+      expect(keeperHueIndex(keeper)).toBeGreaterThanOrEqual(1)
+      expect(keeperHueIndex(keeper)).toBeLessThanOrEqual(12)
+    }
+  })
+})

--- a/dashboard/design-system/headless-core/keeper-line-ownership.test.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.test.ts
@@ -62,6 +62,8 @@ describe('createKeeperLineOwnershipAccumulator', () => {
     expect(s.ingest(edit({ line_start: Number.NaN, line_end: 1 }))).toBe(false)
     expect(s.ingest(edit({ line_start: 1, line_end: Number.POSITIVE_INFINITY }))).toBe(false)
     expect(s.ingest(edit({ line_start: Number.MAX_SAFE_INTEGER + 1, line_end: Number.MAX_SAFE_INTEGER + 1 }))).toBe(false)
+    expect(s.ingest(edit({ line_start: 1.2, line_end: 2 }))).toBe(false)
+    expect(s.ingest(edit({ line_start: 1, line_end: 2.8 }))).toBe(false)
     expect(s.ownership().size).toBe(0)
   })
 
@@ -76,6 +78,7 @@ describe('createKeeperLineOwnershipAccumulator', () => {
       last_edit_ms: 1000,
     })
     expect(s.eventsForLine(2).map((event) => event.keeper_id)).toEqual(['nick0cave'])
+    expect(s.eventsForLine(2.8)).toEqual([])
     expect(s.knownKeepers()).toEqual(['nick0cave'])
   })
 

--- a/dashboard/design-system/headless-core/keeper-line-ownership.test.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.test.ts
@@ -90,6 +90,19 @@ describe('createKeeperLineOwnershipAccumulator', () => {
     expect(s.knownKeepers()).toEqual(['nick0cave', 'sangsu'])
   })
 
+  it('returns snapshots that cannot mutate accumulator state', () => {
+    const s = createKeeperLineOwnershipAccumulator(file)
+    s.ingest(edit({ line_start: 2, line_end: 2 }))
+
+    const ownership = s.ownership() as Map<number, unknown>
+    ownership.clear()
+    expect(s.ownership().get(2)).toMatchObject({ keeper_id: 'nick0cave' })
+
+    const events = s.eventsForLine(2) as KeeperEdit[]
+    events.push(edit({ keeper_id: 'sangsu' }))
+    expect(s.eventsForLine(2).map((event) => event.keeper_id)).toEqual(['nick0cave'])
+  })
+
   it('reset keeps subscribers possible by clearing in place and optionally switches file', () => {
     const s = createKeeperLineOwnershipAccumulator(file)
     s.ingest(edit({ line_start: 1, line_end: 2 }))

--- a/dashboard/design-system/headless-core/keeper-line-ownership.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.ts
@@ -41,10 +41,9 @@ export function keeperHueIndex(keeperId: string): AgentColorSlot {
 }
 
 function validLineRange(event: KeeperEdit): { start: number; end: number } | null {
-  if (!Number.isFinite(event.line_start) || !Number.isFinite(event.line_end)) return null
-  const start = Math.trunc(event.line_start)
-  const end = Math.trunc(event.line_end)
-  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) return null
+  if (!Number.isSafeInteger(event.line_start) || !Number.isSafeInteger(event.line_end)) return null
+  const start = event.line_start
+  const end = event.line_end
   if (start < 1 || end < 1 || end < start) return null
   return { start, end }
 }
@@ -69,7 +68,7 @@ export function createKeeperLineOwnershipAccumulator(
   const filePath = (): string => activeFilePath
   const ownership = (): ReadonlyMap<number, LineOwnership> => ownershipByLine
   const eventsForLine = (line: number): ReadonlyArray<KeeperEdit> =>
-    eventsByLine.get(Math.trunc(line)) ?? []
+    Number.isSafeInteger(line) ? eventsByLine.get(line) ?? [] : []
   const knownKeepers = (): ReadonlyArray<string> => [...keepers].sort()
 
   const ingest = (event: KeeperEdit): boolean => {

--- a/dashboard/design-system/headless-core/keeper-line-ownership.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.ts
@@ -1,0 +1,116 @@
+/**
+ * KeeperLineOwnership — framework-agnostic accumulator for RFC 0019.
+ *
+ * Consumers feed keeper edit events for one active file. The accumulator
+ * derives the latest owner per 1-indexed line plus the event history for each
+ * line. UI adapters can render a blame gutter without duplicating the
+ * line-range expansion or hue mapping rules.
+ */
+
+import { kSlot, type AgentColorSlot } from './agent-presence'
+
+export type KeeperEditKind = 'edit' | 'create' | 'refactor' | 'revert'
+
+export interface KeeperEdit {
+  readonly file_path: string
+  readonly line_start: number
+  readonly line_end: number
+  readonly keeper_id: string
+  readonly timestamp_ms: number
+  readonly kind: KeeperEditKind
+}
+
+export interface LineOwnership {
+  readonly keeper_id: string
+  readonly hue_index: AgentColorSlot
+  readonly last_edit_kind: KeeperEditKind
+  readonly last_edit_ms: number
+}
+
+export interface KeeperLineOwnershipAccumulator {
+  readonly filePath: () => string
+  readonly ownership: () => ReadonlyMap<number, LineOwnership>
+  readonly eventsForLine: (line: number) => ReadonlyArray<KeeperEdit>
+  readonly knownKeepers: () => ReadonlyArray<string>
+  readonly ingest: (event: KeeperEdit) => boolean
+  readonly reset: (filePath?: string) => void
+}
+
+export function keeperHueIndex(keeperId: string): AgentColorSlot {
+  return kSlot(keeperId)
+}
+
+function validLineRange(event: KeeperEdit): { start: number; end: number } | null {
+  if (!Number.isFinite(event.line_start) || !Number.isFinite(event.line_end)) return null
+  const start = Math.trunc(event.line_start)
+  const end = Math.trunc(event.line_end)
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) return null
+  if (start < 1 || end < 1 || end < start) return null
+  return { start, end }
+}
+
+function validTimestamp(event: KeeperEdit): boolean {
+  return Number.isFinite(event.timestamp_ms)
+}
+
+function shouldReplace(existing: LineOwnership | undefined, event: KeeperEdit): boolean {
+  if (existing === undefined) return true
+  return event.timestamp_ms >= existing.last_edit_ms
+}
+
+export function createKeeperLineOwnershipAccumulator(
+  initialFilePath: string,
+): KeeperLineOwnershipAccumulator {
+  let activeFilePath = initialFilePath
+  const ownershipByLine = new Map<number, LineOwnership>()
+  const eventsByLine = new Map<number, KeeperEdit[]>()
+  const keepers = new Set<string>()
+
+  const filePath = (): string => activeFilePath
+  const ownership = (): ReadonlyMap<number, LineOwnership> => ownershipByLine
+  const eventsForLine = (line: number): ReadonlyArray<KeeperEdit> =>
+    eventsByLine.get(Math.trunc(line)) ?? []
+  const knownKeepers = (): ReadonlyArray<string> => [...keepers].sort()
+
+  const ingest = (event: KeeperEdit): boolean => {
+    if (event.file_path !== activeFilePath) return false
+    if (!validTimestamp(event)) return false
+    const range = validLineRange(event)
+    if (range === null) return false
+
+    keepers.add(event.keeper_id)
+    const next: LineOwnership = Object.freeze({
+      keeper_id: event.keeper_id,
+      hue_index: keeperHueIndex(event.keeper_id),
+      last_edit_kind: event.kind,
+      last_edit_ms: event.timestamp_ms,
+    })
+
+    for (let line = range.start; line <= range.end; line += 1) {
+      const history = eventsByLine.get(line)
+      if (history) history.push(event)
+      else eventsByLine.set(line, [event])
+
+      if (shouldReplace(ownershipByLine.get(line), event)) {
+        ownershipByLine.set(line, next)
+      }
+    }
+    return true
+  }
+
+  const reset = (filePath?: string): void => {
+    if (filePath !== undefined) activeFilePath = filePath
+    ownershipByLine.clear()
+    eventsByLine.clear()
+    keepers.clear()
+  }
+
+  return {
+    filePath,
+    ownership,
+    eventsForLine,
+    knownKeepers,
+    ingest,
+    reset,
+  }
+}

--- a/dashboard/design-system/headless-core/keeper-line-ownership.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.ts
@@ -66,9 +66,9 @@ export function createKeeperLineOwnershipAccumulator(
   const keepers = new Set<string>()
 
   const filePath = (): string => activeFilePath
-  const ownership = (): ReadonlyMap<number, LineOwnership> => ownershipByLine
+  const ownership = (): ReadonlyMap<number, LineOwnership> => new Map(ownershipByLine)
   const eventsForLine = (line: number): ReadonlyArray<KeeperEdit> =>
-    Number.isSafeInteger(line) ? eventsByLine.get(line) ?? [] : []
+    Number.isSafeInteger(line) ? [...(eventsByLine.get(line) ?? [])] : []
   const knownKeepers = (): ReadonlyArray<string> => [...keepers].sort()
 
   const ingest = (event: KeeperEdit): boolean => {

--- a/dashboard/src/components/ide/ide-editor-mock.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.a11y.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { IdeEditorMock } from './ide-editor-mock'
+
+describe('IdeEditorMock a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders the ownership-backed editor mock accessibly', async () => {
+    render(html`<${IdeEditorMock} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/ide/ide-editor-mock.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { IdeEditorMock } from './ide-editor-mock'
+
+describe('IdeEditorMock', () => {
+  it('renders the RFC 0019 ownership-backed editor mock', () => {
+    const container = document.createElement('div')
+    render(h(IdeEditorMock, {}), container)
+
+    const region = container.querySelector('[role="region"]')
+    expect(region?.getAttribute('aria-label')).toBe('에디터 (RFC 0019 line ownership mock)')
+    expect(container.textContent).toContain('ownership · 3 keepers')
+    expect(container.textContent).toContain('nick0cave')
+    expect(container.textContent).toContain('sangsu')
+    expect(container.textContent).toContain('masc-improver')
+  })
+
+  it('leaves blank lines unowned', () => {
+    const container = document.createElement('div')
+    render(h(IdeEditorMock, {}), container)
+    const rows = container.querySelectorAll('li')
+    expect(rows[6]?.textContent).toContain('—')
+    expect(rows[14]?.textContent).toContain('—')
+  })
+})

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -1,50 +1,91 @@
 import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+import {
+  createKeeperLineOwnershipStore,
+  type KeeperEdit,
+  type LineOwnership,
+} from './keeper-line-ownership-store'
 
-// PR-2 placeholder for the editor pane. The real Shiki-backed read-
-// only viewer + blame-by-keeper overlay lands in Phase 2 PR-5 (cites
-// RFC 0019). The 'attribution' label echoes the cockpit IdePlane
-// prototype's IxEditAttrib (Planes.jsx:155).
+// PR-5 precursor: the editor remains a read-only mock fixture, but its
+// blame-by-keeper gutter now consumes RFC 0019's ownership store instead of
+// hardcoding keeper labels per row. Replacing the text renderer with Shiki can
+// keep the same LineOwnership contract.
 
 interface MockLine {
   readonly num: number
   readonly text: string
-  readonly keeper: 'nick0cave' | 'sangsu' | 'masc-improver' | null
-  readonly hue: number | null
 }
 
+const EDITOR_FILE = 'runtime/cascade/router.ts'
+
 const MOCK_LINES: ReadonlyArray<MockLine> = [
-  { num: 1, text: "import { Provider, ProviderKind } from './provider'", keeper: 'nick0cave', hue: 1 },
-  { num: 2, text: "import { Turn, TurnId } from './turn'", keeper: 'nick0cave', hue: 1 },
-  { num: 3, text: "import { FsmEvent } from '../fsm/state'", keeper: 'nick0cave', hue: 1 },
-  { num: 4, text: "import { log } from '../log'", keeper: 'nick0cave', hue: 1 },
-  { num: 5, text: "import type { ToolSpec } from './tools'", keeper: 'nick0cave', hue: 1 },
-  { num: 6, text: "import { TokenRegistry } from '../tokens/registry'", keeper: 'nick0cave', hue: 1 },
-  { num: 7, text: '', keeper: null, hue: null },
-  { num: 8, text: 'export type CascadeReq = {', keeper: 'sangsu', hue: 5 },
-  { num: 9, text: '  model: string', keeper: 'sangsu', hue: 5 },
-  { num: 10, text: '  messages: Array<{ role: string; content: string }>', keeper: 'sangsu', hue: 5 },
-  { num: 11, text: '  tools?: ToolSpec[]', keeper: 'sangsu', hue: 5 },
-  { num: 12, text: "  tool_choice?: 'auto' | 'none'", keeper: 'sangsu', hue: 5 },
-  { num: 13, text: '  max_tokens?: number', keeper: 'sangsu', hue: 5 },
-  { num: 14, text: '}', keeper: 'sangsu', hue: 5 },
-  { num: 15, text: '', keeper: null, hue: null },
-  { num: 16, text: 'export function normalizeTools(req: CascadeReq): CascadeReq {', keeper: 'masc-improver', hue: 3 },
-  { num: 17, text: '  // strip empty tools array', keeper: 'masc-improver', hue: 3 },
-  { num: 18, text: '  if (req.tools && req.tools.length === 0) {', keeper: 'masc-improver', hue: 3 },
-  { num: 19, text: '    const { tools, tool_choice, ...rest } = req', keeper: 'masc-improver', hue: 3 },
-  { num: 20, text: '    return rest as CascadeReq', keeper: 'masc-improver', hue: 3 },
-  { num: 21, text: '  }', keeper: 'masc-improver', hue: 3 },
-  { num: 22, text: '  return req', keeper: 'masc-improver', hue: 3 },
-  { num: 23, text: '}', keeper: 'masc-improver', hue: 3 },
+  { num: 1, text: "import { Provider, ProviderKind } from './provider'" },
+  { num: 2, text: "import { Turn, TurnId } from './turn'" },
+  { num: 3, text: "import { FsmEvent } from '../fsm/state'" },
+  { num: 4, text: "import { log } from '../log'" },
+  { num: 5, text: "import type { ToolSpec } from './tools'" },
+  { num: 6, text: "import { TokenRegistry } from '../tokens/registry'" },
+  { num: 7, text: '' },
+  { num: 8, text: 'export type CascadeReq = {' },
+  { num: 9, text: '  model: string' },
+  { num: 10, text: '  messages: Array<{ role: string; content: string }>' },
+  { num: 11, text: '  tools?: ToolSpec[]' },
+  { num: 12, text: "  tool_choice?: 'auto' | 'none'" },
+  { num: 13, text: '  max_tokens?: number' },
+  { num: 14, text: '}' },
+  { num: 15, text: '' },
+  { num: 16, text: 'export function normalizeTools(req: CascadeReq): CascadeReq {' },
+  { num: 17, text: '  // strip empty tools array' },
+  { num: 18, text: '  if (req.tools && req.tools.length === 0) {' },
+  { num: 19, text: '    const { tools, tool_choice, ...rest } = req' },
+  { num: 20, text: '    return rest as CascadeReq' },
+  { num: 21, text: '  }' },
+  { num: 22, text: '  return req' },
+  { num: 23, text: '}' },
+]
+
+const MOCK_OWNERSHIP_EVENTS: ReadonlyArray<KeeperEdit> = [
+  {
+    file_path: EDITOR_FILE,
+    line_start: 1,
+    line_end: 6,
+    keeper_id: 'nick0cave',
+    timestamp_ms: 1_774_960_000_000,
+    kind: 'create',
+  },
+  {
+    file_path: EDITOR_FILE,
+    line_start: 8,
+    line_end: 14,
+    keeper_id: 'sangsu',
+    timestamp_ms: 1_774_960_180_000,
+    kind: 'edit',
+  },
+  {
+    file_path: EDITOR_FILE,
+    line_start: 16,
+    line_end: 23,
+    keeper_id: 'masc-improver',
+    timestamp_ms: 1_774_960_420_000,
+    kind: 'refactor',
+  },
 ]
 
 export function IdeEditorMock() {
   // View tabs and LAYERS toggle moved to IdeToolbar (PR-3); the editor
   // mock now only shows the breadcrumb header for the open file.
+  const ownershipStore = useMemo(() => {
+    const store = createKeeperLineOwnershipStore(EDITOR_FILE)
+    for (const event of MOCK_OWNERSHIP_EVENTS) store.ingest(event)
+    return store
+  }, [])
+  const ownership = ownershipStore.ownership()
+  const keepers = ownershipStore.knownKeepers()
+
   return html`
     <div
       role="region"
-      aria-label="에디터 (mock — PR-5 replaces with Shiki + blame-by-keeper)"
+      aria-label="에디터 (RFC 0019 line ownership mock)"
       style=${{
         display: 'grid',
         gridTemplateRows: 'auto 1fr',
@@ -52,7 +93,7 @@ export function IdeEditorMock() {
         minHeight: 0,
       }}
     >
-      <header
+      <div
         style=${{
           display: 'flex',
           alignItems: 'center',
@@ -64,7 +105,8 @@ export function IdeEditorMock() {
         }}
       >
         <span>runtime / cascade / router.ts</span>
-      </header>
+        <span style=${{ marginLeft: 'auto' }}>ownership · ${keepers.length} keepers</span>
+      </div>
       <ol
         style=${{
           listStyle: 'none',
@@ -76,15 +118,22 @@ export function IdeEditorMock() {
           lineHeight: 1.6,
         }}
       >
-        ${MOCK_LINES.map(line => MockEditorRow(line))}
+        ${MOCK_LINES.map(line => MockEditorRow(line, ownership.get(line.num)))}
       </ol>
     </div>
   `
 }
 
-function MockEditorRow(line: MockLine) {
-  const dot = line.hue !== null
-    ? `var(--color-keeper-${line.hue}-glow, var(--k-${line.hue}))`
+function keeperColor(owner: LineOwnership | undefined): string {
+  return owner
+    ? `var(--color-keeper-${owner.hue_index}-glow, var(--k-${owner.hue_index}))`
+    : 'var(--color-fg-disabled)'
+}
+
+function MockEditorRow(line: MockLine, owner: LineOwnership | undefined) {
+  const color = keeperColor(owner)
+  const dot = owner
+    ? color
     : 'transparent'
   return html`
     <li
@@ -97,12 +146,13 @@ function MockEditorRow(line: MockLine) {
       }}
     >
       <span
+        title=${owner ? `${owner.keeper_id} · ${owner.last_edit_kind}` : undefined}
         style=${{
-          color: line.keeper ? `var(--color-keeper-${line.hue}-glow, var(--k-${line.hue}))` : 'var(--color-fg-disabled)',
+          color,
           font: 'var(--fs-11)',
           textAlign: 'right',
         }}
-      >${line.keeper ?? '—'}</span>
+      >${owner?.keeper_id ?? '—'}</span>
       <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, justifySelf: 'center' }} />
       <span style=${{ color: 'var(--color-fg-disabled)', font: 'var(--fs-11)', minWidth: '24px', textAlign: 'right' }}>${line.num}</span>
       <span style=${{ color: 'var(--color-fg-secondary)', whiteSpace: 'pre' }}>${line.text}</span>

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -114,7 +114,7 @@ export function IdeEditorMock() {
           margin: 0,
           overflow: 'auto',
           fontFamily: 'var(--font-mono)',
-          font: 'var(--fs-13)',
+          fontSize: 'var(--fs-13)',
           lineHeight: 1.6,
         }}
       >
@@ -149,12 +149,12 @@ function MockEditorRow(line: MockLine, owner: LineOwnership | undefined) {
         title=${owner ? `${owner.keeper_id} · ${owner.last_edit_kind}` : undefined}
         style=${{
           color,
-          font: 'var(--fs-11)',
+          fontSize: 'var(--fs-11)',
           textAlign: 'right',
         }}
       >${owner?.keeper_id ?? '—'}</span>
       <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, justifySelf: 'center' }} />
-      <span style=${{ color: 'var(--color-fg-disabled)', font: 'var(--fs-11)', minWidth: '24px', textAlign: 'right' }}>${line.num}</span>
+      <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', minWidth: '24px', textAlign: 'right' }}>${line.num}</span>
       <span style=${{ color: 'var(--color-fg-secondary)', whiteSpace: 'pre' }}>${line.text}</span>
     </li>
   `

--- a/dashboard/src/components/ide/keeper-line-ownership-store.test.ts
+++ b/dashboard/src/components/ide/keeper-line-ownership-store.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createKeeperLineOwnershipStore,
+  type KeeperEdit,
+} from './keeper-line-ownership-store'
+
+const file = 'runtime/cascade/router.ts'
+
+const event = (patch: Partial<KeeperEdit>): KeeperEdit => ({
+  file_path: file,
+  line_start: 1,
+  line_end: 1,
+  keeper_id: 'nick0cave',
+  timestamp_ms: 1000,
+  kind: 'edit',
+  ...patch,
+})
+
+describe('createKeeperLineOwnershipStore', () => {
+  it('publishes immutable ownership snapshots after ingest', () => {
+    const s = createKeeperLineOwnershipStore(file)
+    const before = s.ownership()
+    expect(s.ingest(event({ line_start: 2, line_end: 3 }))).toBe(true)
+    const after = s.ownership()
+    expect(before).not.toBe(after)
+    expect([...after.keys()]).toEqual([2, 3])
+  })
+
+  it('subscribers fire only for accepted events and reset', () => {
+    const s = createKeeperLineOwnershipStore(file)
+    let calls = 0
+    const unsubscribe = s.subscribe(() => {
+      calls += 1
+    })
+
+    s.ingest(event({ file_path: 'other.ts' }))
+    s.ingest(event({ line_start: 1, line_end: 1 }))
+    s.reset()
+    unsubscribe()
+    s.ingest(event({ line_start: 2, line_end: 2 }))
+
+    expect(calls).toBe(2)
+  })
+
+  it('exposes line history and sorted known keepers', () => {
+    const s = createKeeperLineOwnershipStore(file)
+    s.ingest(event({ line_start: 5, line_end: 5, keeper_id: 'sangsu' }))
+    s.ingest(event({ line_start: 5, line_end: 5, keeper_id: 'nick0cave', timestamp_ms: 2000 }))
+
+    expect(s.eventsForLine(5).map((item) => item.keeper_id)).toEqual([
+      'sangsu',
+      'nick0cave',
+    ])
+    expect(s.knownKeepers()).toEqual(['nick0cave', 'sangsu'])
+  })
+
+  it('reset can switch active file', () => {
+    const s = createKeeperLineOwnershipStore(file)
+    s.reset('runtime/fsm/lifeline.ts')
+    expect(s.filePath()).toBe('runtime/fsm/lifeline.ts')
+    expect(s.ingest(event({ line_start: 1, line_end: 1 }))).toBe(false)
+    expect(s.ingest(event({ file_path: 'runtime/fsm/lifeline.ts' }))).toBe(true)
+  })
+})

--- a/dashboard/src/components/ide/keeper-line-ownership-store.ts
+++ b/dashboard/src/components/ide/keeper-line-ownership-store.ts
@@ -1,0 +1,79 @@
+/**
+ * keeper-line-ownership-store — Preact signal adapter for RFC 0019.
+ *
+ * The accumulator in design-system/headless-core owns the line-range and
+ * hue-index rules. This store only publishes immutable snapshots for dashboard
+ * consumers and keeps the mock editor on the same contract future live events
+ * will use.
+ */
+
+import { signal } from '@preact/signals'
+import {
+  createKeeperLineOwnershipAccumulator,
+  type KeeperEdit,
+  type LineOwnership,
+} from '../../../design-system/headless-core/keeper-line-ownership'
+
+export type { KeeperEdit, LineOwnership }
+
+export interface KeeperLineOwnershipStore {
+  readonly filePath: () => string
+  readonly ownership: () => ReadonlyMap<number, LineOwnership>
+  readonly eventsForLine: (line: number) => ReadonlyArray<KeeperEdit>
+  readonly knownKeepers: () => ReadonlyArray<string>
+  readonly ingest: (event: KeeperEdit) => boolean
+  readonly reset: (filePath?: string) => void
+  readonly subscribe: (listener: () => void) => () => void
+  readonly dispose: () => void
+}
+
+export function createKeeperLineOwnershipStore(
+  initialFilePath: string,
+): KeeperLineOwnershipStore {
+  const accumulator = createKeeperLineOwnershipAccumulator(initialFilePath)
+  const ownershipSignal = signal<ReadonlyMap<number, LineOwnership>>(new Map())
+  const keepersSignal = signal<ReadonlyArray<string>>([])
+
+  const publish = (): void => {
+    ownershipSignal.value = new Map(accumulator.ownership())
+    keepersSignal.value = accumulator.knownKeepers()
+  }
+
+  const ingest = (event: KeeperEdit): boolean => {
+    const accepted = accumulator.ingest(event)
+    if (accepted) publish()
+    return accepted
+  }
+
+  const reset = (filePath?: string): void => {
+    accumulator.reset(filePath)
+    publish()
+  }
+
+  const subscribe = (listener: () => void): (() => void) => {
+    let sawInitialSnapshot = false
+    const unsubscribe = ownershipSignal.subscribe(() => {
+      if (!sawInitialSnapshot) {
+        sawInitialSnapshot = true
+        return
+      }
+      listener()
+    })
+    return unsubscribe
+  }
+
+  const dispose = (): void => {
+    reset()
+  }
+
+  return {
+    filePath: accumulator.filePath,
+    ownership: () => ownershipSignal.value,
+    eventsForLine: accumulator.eventsForLine,
+    knownKeepers: () => keepersSignal.value,
+    ingest,
+    reset,
+    subscribe,
+    dispose,
+  }
+}


### PR DESCRIPTION
## Summary
- add RFC 0019 headless keeper line ownership accumulator
- add dashboard signal store adapter for IDE blame-gutter ownership snapshots
- switch the IDE editor mock from hardcoded row owners to the ownership store contract
- add unit and jest-axe coverage for the accumulator, store, and editor mock

## Verification
- pnpm vitest run --config vitest.config.ts design-system/headless-core/keeper-line-ownership.test.ts src/components/ide/keeper-line-ownership-store.test.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/ide/keeper-line-ownership-store.ts src/components/ide/keeper-line-ownership-store.test.ts src/components/ide/ide-editor-mock.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts

Note: dashboard ESLint config does not cover design-system/headless-core files; those are covered by Vitest and typecheck here.