### PR TITLE
[codex] Fix keeper stall and board wake storms

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -156,12 +156,50 @@ let wakeup_all_keepers ?base_path () =
 
 let board_reactive_debounce_sec = Env_config.KeeperKeepalive.board_debounce_sec
 
+let board_reactive_generic_wakeup_limit =
+  Keeper_config.int_of_env_default
+    "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT"
+    ~default:3
+    ~min_v:0
+    ~max_v:20
+;;
+
 let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
   Keeper_registry.board_wakeup_allowed
     ~base_path
     keeper_name
     ~post_id
     ~debounce_sec:board_reactive_debounce_sec
+;;
+
+let select_board_wakeup_candidates ?(generic_limit = board_reactive_generic_wakeup_limit)
+    candidates =
+  let explicit =
+    candidates
+    |> List.filter_map (fun (item, reason) ->
+      match reason with
+      | Some "explicit_mention" -> Some (item, "explicit_mention")
+      | _ -> None)
+  in
+  match explicit with
+  | _ :: _ -> explicit, 0
+  | [] ->
+    let selected_rev, generic_seen, generic_dropped =
+      List.fold_left
+        (fun (selected, generic_seen, generic_dropped) (item, reason) ->
+          match reason with
+          | None -> selected, generic_seen, generic_dropped
+          | Some "board_activity" ->
+            let next_seen = generic_seen + 1 in
+            if generic_seen < generic_limit then
+              (item, "board_activity") :: selected, next_seen, generic_dropped
+            else
+              selected, next_seen, generic_dropped + 1
+          | Some reason -> (item, reason) :: selected, generic_seen, generic_dropped)
+        ([], 0, 0)
+        candidates
+    in
+    List.rev selected_rev, generic_dropped
 ;;
 
 let wakeup_relevant_keeper_for_board_signal
@@ -187,11 +225,6 @@ let wakeup_relevant_keeper_for_board_signal
         Some (meta, wake_reason)
       | _ -> None)
   in
-  let explicit =
-    candidates
-    |> List.filter
-         (fun (_meta, wake_reason) -> wake_reason = Some "explicit_mention")
-  in
   let wake_meta (meta : keeper_meta) reason =
     if
       board_reactive_wakeup_allowed
@@ -206,15 +239,14 @@ let wakeup_relevant_keeper_for_board_signal
         reason
         signal.post_id)
   in
-  match explicit with
-  | _ :: _ ->
-    explicit |> List.iter (fun (meta, _wake_reason) -> wake_meta meta "explicit_mention")
-  | [] ->
-    candidates
-    |> List.iter (fun (meta, wake_reason) ->
-         match wake_reason with
-         | Some reason -> wake_meta meta reason
-         | None -> ())
+  let selected, generic_dropped = select_board_wakeup_candidates candidates in
+  selected |> List.iter (fun (meta, reason) -> wake_meta meta reason);
+  if generic_dropped > 0 then
+    Log.Keeper.info
+      "board signal wakeup capped: dropped_generic=%d post=%s limit=%d"
+      generic_dropped
+      signal.post_id
+      board_reactive_generic_wakeup_limit
 ;;
 
 (* Per-stage timing accumulator for Phase 0 profiling.

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -56,8 +56,13 @@ val wakeup_all_keepers : ?base_path:string -> unit -> unit
 (** Board-reactive debounce interval (seconds), from runtime config. *)
 val board_reactive_debounce_sec : float
 
+val board_reactive_generic_wakeup_limit : int
+
 val board_reactive_wakeup_allowed :
   base_path:string -> keeper_name:string -> post_id:string -> bool
+
+val select_board_wakeup_candidates :
+  ?generic_limit:int -> ('a * string option) list -> ('a * string) list * int
 
 val wakeup_relevant_keeper_for_board_signal :
   config:Coord.config -> Board_dispatch.keeper_board_signal -> unit

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -4,7 +4,7 @@ type t = {
   default_network_override : Keeper_types.network_mode option;
   cache :
     ((bool * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
-  mutex : Mutex.t;
+  mutex : Eio.Mutex.t;
 }
 
 let create ?default_network_override
@@ -14,14 +14,11 @@ let create ?default_network_override
     meta;
     default_network_override;
     cache = Hashtbl.create 4;
-    mutex = Mutex.create ();
+    mutex = Eio.Mutex.create ();
   }
 
 let with_lock (t : t) f =
-  Mutex.lock t.mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock t.mutex)
-    f
+  Eio.Mutex.use_rw ~protect:true t.mutex f
 
 let strip_trailing_slashes path =
   let rec loop i =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -112,6 +112,13 @@ let all_network_modes = [ Network_none; Network_inherit ]
 let valid_network_mode_strings =
   List.map network_mode_to_string all_network_modes
 
+let shared_memory_scope_of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "disabled" | "room" as scope -> Some scope
+  | _ -> None
+
+let valid_shared_memory_scope_strings = [ "disabled"; "room" ]
+
 let default_sandbox_profile = Local
 
 let default_network_mode_for_profile = function
@@ -279,6 +286,7 @@ type keeper_profile_defaults = {
   sandbox_profile : sandbox_profile option;
   sandbox_image : string option;
   network_mode : network_mode option;
+  shared_memory_scope : string option;
   github_identity : string option;
   git_identity_mode : string option;
   tool_preset : string option;
@@ -453,6 +461,7 @@ let empty_keeper_profile_defaults = {
   sandbox_profile = None;
   sandbox_image = None;
   network_mode = None;
+  shared_memory_scope = None;
   github_identity = None;
   git_identity_mode = None;
   tool_preset = None;
@@ -750,8 +759,22 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                 Error
                   (Printf.sprintf
                      "invalid network_mode '%s' (allowed: none, inherit; \
-                      deprecated alias: host)"
+                     deprecated alias: host)"
                      raw))
+        | None -> Ok ())
+  in
+  let result =
+    Result.bind result (fun () ->
+        match str "shared_memory_scope" with
+        | Some raw -> (
+            match shared_memory_scope_of_string raw with
+            | Some _ -> Ok ()
+            | None ->
+                Error
+                  (Printf.sprintf
+                     "invalid shared_memory_scope '%s' (allowed: %s)"
+                     raw
+                     (String.concat ", " valid_shared_memory_scope_strings)))
         | None -> Ok ())
   in
   let result =
@@ -875,6 +898,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         sandbox_image = str "sandbox_image";
         network_mode =
           Option.bind (str "network_mode") network_mode_of_string;
+        shared_memory_scope =
+          Option.bind (str "shared_memory_scope") shared_memory_scope_of_string;
         github_identity = str "github_identity";
         git_identity_mode =
           normalize_git_identity_mode_opt (str "git_identity_mode");
@@ -935,6 +960,7 @@ let parsed_field_key_names =
   ; "sandbox_profile"
   ; "sandbox_image"
   ; "network_mode"
+  ; "shared_memory_scope"
   ; "github_identity"
   ; "git_identity_mode"
   ; "tool_access.kind"
@@ -989,6 +1015,7 @@ let canonical_keeper_toml_key_names =
   ; "sandbox_profile"
   ; "sandbox_image"
   ; "network_mode"
+  ; "shared_memory_scope"
   ; "github_identity"
   ; "git_identity_mode"
   ; "tool_access.kind"
@@ -1177,6 +1204,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 sandbox_profile = None;
                 sandbox_image = None;
                 network_mode = None;
+                shared_memory_scope = None;
                 github_identity = None;
                 git_identity_mode = None;
                 tool_preset = None;
@@ -1289,6 +1317,8 @@ let merge_keeper_profile_defaults
     sandbox_profile = prefer overlay.sandbox_profile base.sandbox_profile;
     sandbox_image = prefer overlay.sandbox_image base.sandbox_image;
     network_mode = prefer overlay.network_mode base.network_mode;
+    shared_memory_scope =
+      prefer overlay.shared_memory_scope base.shared_memory_scope;
     github_identity = prefer overlay.github_identity base.github_identity;
     git_identity_mode =
       prefer overlay.git_identity_mode base.git_identity_mode;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1468,6 +1468,38 @@ preset = "coding"
     let unknown = KTP.detect_unknown_keeper_toml_keys doc in
     check (list string) "tool_access TOML table is canonical" [] unknown
 
+let test_shared_memory_scope_is_canonical_toml () =
+  let input = {|
+[keeper]
+goal = "g"
+shared_memory_scope = "room"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "shared_memory_scope is canonical" [] unknown;
+    match KTP.profile_defaults_of_toml doc with
+    | Error e -> fail e
+    | Ok d ->
+      check (option string) "shared_memory_scope parsed"
+        (Some "room") d.KTP.shared_memory_scope
+
+let test_shared_memory_scope_rejects_invalid_value () =
+  let input = {|
+[keeper]
+goal = "g"
+shared_memory_scope = "global"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    match KTP.profile_defaults_of_toml doc with
+    | Ok _ -> fail "expected invalid shared_memory_scope to be rejected"
+    | Error e ->
+      check bool "mentions shared_memory_scope" true
+        (contains_substring e "shared_memory_scope")
+
 let test_oas_env_parses_allowed_keys () =
   let input = {|
 [keeper]
@@ -1719,6 +1751,10 @@ let () =
             test_detect_unknown_keys_flags_legacy_dead_config;
           test_case "accepts tool_access table" `Quick
             test_detect_unknown_keys_accepts_tool_access_table;
+          test_case "accepts shared_memory_scope" `Quick
+            test_shared_memory_scope_is_canonical_toml;
+          test_case "rejects invalid shared_memory_scope" `Quick
+            test_shared_memory_scope_rejects_invalid_value;
           test_case "also_allow alias flagged" `Quick
             test_detect_unknown_keys_flags_also_allow_alias;
           test_case "oas_env keys not flagged as unknown" `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -435,6 +435,7 @@ let test_keeper_sandbox_start_status_stop_with_fake_docker () =
            (final_sandbox |> member "why_no_container" |> to_string_option)))
 
 let test_keeper_turn_sandbox_factory_reuses_playground_runtime () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let keeper_name = "sandbox-docker-cache" in
   Fun.protect

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -155,6 +155,52 @@ let test_cycle_pauses_on_skip_idle () =
 
 module KKS = Masc_mcp.Keeper_keepalive_signal
 
+let test_board_wakeup_selection_caps_generic_activity () =
+  let selected, dropped =
+    KKS.select_board_wakeup_candidates
+      ~generic_limit:2
+      [
+        "a", Some "board_activity";
+        "b", Some "board_activity";
+        "c", Some "board_activity";
+        "d", None;
+      ]
+  in
+  check (list (pair string string)) "selected generic wakeups"
+    [ "a", "board_activity"; "b", "board_activity" ]
+    selected;
+  check int "dropped generic wakeups" 1 dropped
+
+let test_board_wakeup_selection_keeps_explicit_mentions () =
+  let selected, dropped =
+    KKS.select_board_wakeup_candidates
+      ~generic_limit:1
+      [
+        "a", Some "board_activity";
+        "b", Some "explicit_mention";
+        "c", Some "explicit_mention";
+      ]
+  in
+  check (list (pair string string)) "selected explicit wakeups"
+    [ "b", "explicit_mention"; "c", "explicit_mention" ]
+    selected;
+  check int "dropped generic wakeups" 0 dropped
+
+let test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap () =
+  let selected, dropped =
+    KKS.select_board_wakeup_candidates
+      ~generic_limit:1
+      [
+        "a", Some "board_activity";
+        "b", Some "thread_reply_after_self_comment";
+        "c", Some "board_activity";
+      ]
+  in
+  check (list (pair string string)) "selected mixed wakeups"
+    [ "a", "board_activity"; "b", "thread_reply_after_self_comment" ]
+    selected;
+  check int "dropped generic wakeups" 1 dropped
+
 let test_after_wake_idle_woken_continues () =
   let next = Unix.gettimeofday () +. 60.0 in
   check bool "Skip_idle + Woken -> cycle resumes" true
@@ -278,6 +324,14 @@ let () =
         `Quick test_cycle_continues_on_skip_busy;
       test_case "Emit -> cycle continues" `Quick test_cycle_continues_on_emit;
       test_case "Skip_idle -> cycle pauses" `Quick test_cycle_pauses_on_skip_idle;
+    ];
+    "board_wakeup_selection", [
+      test_case "generic board activity is capped"
+        `Quick test_board_wakeup_selection_caps_generic_activity;
+      test_case "explicit mentions bypass generic cap"
+        `Quick test_board_wakeup_selection_keeps_explicit_mentions;
+      test_case "specific reasons survive generic cap"
+        `Quick test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap;
     ];
     "missed_wakeup_gap", [
       test_case "Skip_idle + Woken -> resumes (MissedWakeup spec gap)"


### PR DESCRIPTION
## Summary
- Replace the keeper sandbox factory's stdlib mutex with `Eio.Mutex` so Eio tool execution does not trip transient `EDEADLK` during concurrent keeper shell reads.
- Cap generic board-activity wakeups while preserving explicit mentions and specific wake reasons.
- Accept and validate `keeper.shared_memory_scope` in keeper TOML to stop noisy unknown-key warnings.

## Root Cause
The live logs showed three related pressure points: a stdlib mutex being used inside Eio keeper tool execution, generic board activity waking the whole keeper fleet, and config schema drift around `shared_memory_scope`. Together these made keeper cycles collide, stall, and then surface as stale watchdog failures.

## Related
- OAS provider-boundary quota classification: https://github.com/jeong-sik/oas/pull/1317

## Validation
- `scripts/dune-local.sh build test/test_smart_heartbeat_keepalive.exe test/test_operator_control.exe test/test_keeper_toml.exe test/test_keeper_docker_read.exe`
- `./_build/default/test/test_smart_heartbeat_keepalive.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `./_build/default/test/test_operator_control.exe test operator 46`
- `./_build/default/test/test_keeper_docker_read.exe test run_command_in_container 9`
- `git diff --check`