### PR TITLE
fix(keeper): bound reactive wakeups and reap stopped fibers

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -484,11 +484,7 @@ let resolve_registry_done
       (value : [ `Stopped | `Crashed of string ])
   : bool
   =
-  if Option.is_none (Eio.Promise.peek entry.done_p)
-  then (
-    Eio.Promise.resolve entry.done_r value;
-    true)
-  else false
+  Keeper_registry.try_resolve_done entry value
 ;;
 
 let record_keeper_stopped

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -67,6 +67,7 @@ val autonomous_waiter_snapshot_for_test : unit -> string list
 (** Test-only snapshots of the current semaphore availability. *)
 val turn_semaphore_value_for_test : unit -> int
 val autonomous_turn_semaphore_value_for_test : unit -> int
+val reactive_turn_semaphore_value_for_test : unit -> int
 
 (** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
 val enqueue_autonomous_waiter_for_test : string -> int

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -217,8 +217,17 @@ let select_board_wakeup_candidates
       |> fun (selected_rev, _generic_seen, generic_dropped) ->
       List.rev selected_rev, generic_dropped
     in
-    let selected = take total_limit selected_by_reason in
-    let total_dropped = List.length selected_by_reason - List.length selected in
+    let prioritized =
+      let non_generic =
+        List.filter (fun (_, r) -> r <> "board_activity") selected_by_reason
+      in
+      let generic =
+        List.filter (fun (_, r) -> r = "board_activity") selected_by_reason
+      in
+      non_generic @ generic
+    in
+    let selected = take total_limit prioritized in
+    let total_dropped = List.length prioritized - List.length selected in
     selected, generic_dropped + total_dropped
 ;;
 

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -164,6 +164,11 @@ let board_reactive_generic_wakeup_limit =
     ~max_v:20
 ;;
 
+let board_reactive_wakeup_max =
+  Keeper_config.int_of_env_default
+    "MASC_KEEPER_BOARD_WAKEUP_MAX" ~default:4 ~min_v:1 ~max_v:64
+;;
+
 let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
   Keeper_registry.board_wakeup_allowed
     ~base_path
@@ -172,7 +177,18 @@ let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
     ~debounce_sec:board_reactive_debounce_sec
 ;;
 
-let select_board_wakeup_candidates ?(generic_limit = board_reactive_generic_wakeup_limit)
+let take n xs =
+  let rec loop acc remaining = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n xs
+;;
+
+let select_board_wakeup_candidates
+    ?(generic_limit = board_reactive_generic_wakeup_limit)
+    ?(total_limit = board_reactive_wakeup_max)
     candidates =
   let explicit =
     candidates
@@ -184,7 +200,7 @@ let select_board_wakeup_candidates ?(generic_limit = board_reactive_generic_wake
   match explicit with
   | _ :: _ -> explicit, 0
   | [] ->
-    let selected_rev, generic_seen, generic_dropped =
+    let selected_by_reason, generic_dropped =
       List.fold_left
         (fun (selected, generic_seen, generic_dropped) (item, reason) ->
           match reason with
@@ -198,8 +214,41 @@ let select_board_wakeup_candidates ?(generic_limit = board_reactive_generic_wake
           | Some reason -> (item, reason) :: selected, generic_seen, generic_dropped)
         ([], 0, 0)
         candidates
+      |> fun (selected_rev, _generic_seen, generic_dropped) ->
+      List.rev selected_rev, generic_dropped
     in
-    List.rev selected_rev, generic_dropped
+    let selected = take total_limit selected_by_reason in
+    let total_dropped = List.length selected_by_reason - List.length selected in
+    selected, generic_dropped + total_dropped
+;;
+
+let board_signal_kind_to_string = function
+  | Board_dispatch.Board_post_created -> "post_created"
+  | Board_dispatch.Board_comment_added -> "comment_added"
+;;
+
+let board_signal_stimulus ~(reason : string) (signal : Board_dispatch.keeper_board_signal) =
+  let payload =
+    `Assoc
+      [ "source", `String "board_signal"
+      ; "kind", `String (board_signal_kind_to_string signal.kind)
+      ; "post_id", `String signal.post_id
+      ; "author", `String signal.author
+      ; "title", `String signal.title
+      ; "content", `String signal.content
+      ; "hearth", (match signal.hearth with Some v -> `String v | None -> `Null)
+      ; "wake_reason", `String reason
+      ]
+    |> Yojson.Safe.to_string
+  in
+  { Keeper_event_queue.post_id = signal.post_id
+  ; urgency =
+      (if String.equal reason "explicit_mention"
+       then Keeper_event_queue.Immediate
+       else Keeper_event_queue.Normal)
+  ; arrived_at = Time_compat.now ()
+  ; payload
+  }
 ;;
 
 let wakeup_relevant_keeper_for_board_signal
@@ -232,21 +281,25 @@ let wakeup_relevant_keeper_for_board_signal
         ~keeper_name:meta.name
         ~post_id:signal.post_id
     then (
-      wakeup_keeper ~base_path:config.base_path meta.name;
+      wakeup_keeper
+        ~base_path:config.base_path
+        ~stimulus:(board_signal_stimulus ~reason signal)
+        meta.name;
       Log.Keeper.info
         "board signal wakeup: keeper=%s reason=%s post=%s"
         meta.name
         reason
         signal.post_id)
   in
-  let selected, generic_dropped = select_board_wakeup_candidates candidates in
+  let selected, dropped = select_board_wakeup_candidates candidates in
   selected |> List.iter (fun (meta, reason) -> wake_meta meta reason);
-  if generic_dropped > 0 then
-    Log.Keeper.info
-      "board signal wakeup capped: dropped_generic=%d post=%s limit=%d"
-      generic_dropped
+  if dropped > 0 then
+    Log.Keeper.warn
+      "board signal wakeup capped: dropped=%d post=%s generic_limit=%d total_limit=%d"
+      dropped
       signal.post_id
       board_reactive_generic_wakeup_limit
+      board_reactive_wakeup_max
 ;;
 
 (* Per-stage timing accumulator for Phase 0 profiling.

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -58,11 +58,16 @@ val board_reactive_debounce_sec : float
 
 val board_reactive_generic_wakeup_limit : int
 
+val board_reactive_wakeup_max : int
+
 val board_reactive_wakeup_allowed :
   base_path:string -> keeper_name:string -> post_id:string -> bool
 
 val select_board_wakeup_candidates :
-  ?generic_limit:int -> ('a * string option) list -> ('a * string) list * int
+  ?generic_limit:int ->
+  ?total_limit:int ->
+  ('a * string option) list ->
+  ('a * string) list * int
 
 val wakeup_relevant_keeper_for_board_signal :
   config:Coord.config -> Board_dispatch.keeper_board_signal -> unit

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -234,6 +234,16 @@ and completed_turn_observation = {
   ct_selected_model : string option;
 }
 
+let try_resolve_done entry value =
+  match Eio.Promise.peek entry.done_p with
+  | Some _ -> false
+  | None ->
+    (try
+       Eio.Promise.resolve entry.done_r value;
+       true
+     with
+     | Invalid_argument _ -> false)
+;;
 
 let registry : registry_entry StringMap.t Atomic.t = Atomic.make StringMap.empty
 let running_count_atomic = Atomic.make 0

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -247,6 +247,11 @@ and completed_turn_observation = {
   ct_selected_model : string option;
 }
 
+(** Resolve a keeper run completion promise at most once.
+    Returns [false] if another fiber won the resolve race. *)
+val try_resolve_done :
+  registry_entry -> [ `Stopped | `Crashed of string ] -> bool
+
 (** Register a keeper with an already-live fiber. Primarily used by tests and
     direct fixtures that want a keeper to begin in [Running]. *)
 val register : base_path:string -> string -> keeper_meta -> registry_entry

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -21,6 +21,7 @@ let key_to_env =
     "autonomous.max_idle_turns",        "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS";
     (* [reactive] *)
     "reactive.max_turns_per_call",      "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL";
+    "reactive.concurrency",             "MASC_KEEPER_REACTIVE_CONCURRENCY";
     "reactive.max_idle_turns",          "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE";
     (* [heartbeat] *)
     "heartbeat.interval_sec",           "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC";
@@ -31,6 +32,8 @@ let key_to_env =
     "heartbeat.jitter_factor",          "MASC_KEEPER_HEARTBEAT_JITTER_FACTOR";
     "heartbeat.sleep_chunk_sec",        "MASC_KEEPER_SLEEP_CHUNK_SEC";
     "heartbeat.board_debounce_sec",     "MASC_KEEPER_BOARD_DEBOUNCE_SEC";
+    "heartbeat.board_generic_wakeup_limit", "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT";
+    "heartbeat.board_wakeup_max",       "MASC_KEEPER_BOARD_WAKEUP_MAX";
     (* [turn] *)
     "turn.timeout_sec",                 "MASC_KEEPER_TURN_TIMEOUT_SEC";
     "turn.oas_timeout_sec",             "MASC_KEEPER_OAS_TIMEOUT_SEC";

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -212,6 +212,12 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
     Env_config_keeper.KeeperWatchdog.grace_period_sec
   in
   let last_broadcast_ts = ref 0.0 in
+  let request_watchdog_stop () =
+    (* tla-lint: allow-mutation: fiber signal — stale watchdog asks the
+       heartbeat fiber to exit and wakes it if it is in interruptible sleep. *)
+    Atomic.set reg.fiber_stop true;
+    Atomic.set reg.fiber_wakeup true
+  in
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let rec watchdog_loop () =
       if Atomic.get reg.fiber_stop then ()
@@ -295,7 +301,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  (* tla-lint: allow-mutation: fiber signal — stop the keeper
                     through the provider-timeout path, preserving the typed
                     root cause for supervisor auto-pause. *)
-                 Atomic.set reg.fiber_stop true;
+                 request_watchdog_stop ();
                  Prometheus.inc_counter
                    "masc_keeper_oas_timeout_budget_watchdog_termination_total"
                    ~labels:[ ("keeper", meta.name) ]
@@ -364,7 +370,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  (Keeper_registry.stale_watchdog_failure_reason
                     ~prior:prior_failure_reason ~kill_class);
                (* tla-lint: allow-mutation: fiber signal — stop the wedged keeper after stale-turn classification *)
-               Atomic.set reg.fiber_stop true;
+               request_watchdog_stop ();
                let window_count = record_stale_termination meta.name now in
                Prometheus.inc_counter
                  "masc_keeper_stale_termination_total"

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -135,9 +135,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let resolved = ref false in
     let resolve_done value =
-      if not !resolved && Option.is_none (Eio.Promise.peek reg.done_p) then begin
+      if not !resolved && Keeper_registry.try_resolve_done reg value then begin
         resolved := true;
-        Eio.Promise.resolve reg.done_r value;
         true
       end else
         false
@@ -866,6 +865,66 @@ let sweep_and_recover (ctx : _ context) =
   let to_unregister = ref [] in
   let to_mark_dead = ref [] in
   let to_cleanup_dead = ref [] in
+  let queue_crashed_entry (entry : Keeper_registry.registry_entry) msg =
+    match entry.last_failure_reason with
+    | Some (Keeper_registry.Stale_termination_storm { count }) ->
+        (* #10765 Phase 2: skip [to_restart] AND in-memory unregister.
+           The watchdog detected a termination storm (>= escalation_
+           threshold within the 6h window).  [handle_stale_storm_pause]
+           persists [meta.paused = true] so reconcile + future sweeps
+           honor the pause across server restarts; we then add the
+           entry to [to_unregister] so the in-memory registry slot is
+           cleared and subsequent sweep ticks within the same server
+           do NOT re-fire the storm-pause path (counter must increment
+           once per storm, not once per sweep tick). *)
+        handle_stale_storm_pause ctx entry ~count;
+        to_unregister := entry :: !to_unregister
+    | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
+        (* Repeated OAS budget exhaustion means the active
+           cascade/model is not producing within the turn budget.
+           Restarting the same keeper preserves that bad routing and
+           burns another multi-minute budget, so pause instead. *)
+        handle_oas_timeout_budget_pause ctx entry ~count;
+        to_unregister := entry :: !to_unregister
+    | _ ->
+        if entry.restart_count >= max_restarts then
+          to_mark_dead := (entry, msg) :: !to_mark_dead
+        else begin
+          let delay = backoff_delay entry.restart_count in
+          if now -. entry.last_restart_ts >= delay then
+            to_restart := (entry, msg) :: !to_restart
+        end
+  in
+  let watchdog_stop_pending (entry : Keeper_registry.registry_entry) =
+    Atomic.get entry.fiber_stop
+    &&
+    match entry.last_failure_reason with
+    | Some (Keeper_registry.Stale_turn_timeout _)
+    | Some (Keeper_registry.Stale_termination_storm _)
+    | Some (Keeper_registry.Oas_timeout_budget_loop _) -> true
+    | _ -> false
+  in
+  let force_unresolved_watchdog_crash (entry : Keeper_registry.registry_entry) =
+    let msg =
+      entry.last_failure_reason
+      |> Option.map Keeper_registry.failure_reason_to_string
+      |> Option.value ~default:"watchdog_stop_pending"
+    in
+    Log.Keeper.warn
+      "%s: supervisor forcing unresolved watchdog-stopped keeper to crashed (%s)"
+      entry.name msg;
+    ignore (Keeper_registry.try_resolve_done entry (`Crashed msg));
+    ignore
+      (Keeper_registry.dispatch_event_and_log
+         ~base_path entry.name
+         (Keeper_state_machine.Fiber_terminated { outcome = msg }));
+    let ts = Time_compat.now () in
+    Keeper_registry.record_crash ~base_path entry.name ts msg;
+    Keeper_registry.record_error ~base_path entry.name msg;
+    match Keeper_registry.get ~base_path entry.name with
+    | Some updated -> queue_crashed_entry updated msg
+    | None -> ()
+  in
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     match entry.phase with
     | Keeper_state_machine.Dead | Keeper_state_machine.Zombie ->
@@ -884,38 +943,13 @@ let sweep_and_recover (ctx : _ context) =
       (match Eio.Promise.peek entry.done_p with
       | None when entry.phase = Keeper_state_machine.Stopped ->
           to_unregister := entry :: !to_unregister
+      | None when watchdog_stop_pending entry ->
+          force_unresolved_watchdog_crash entry
       | None -> ()  (* Alive — skip *)
       | Some `Stopped ->
           to_unregister := entry :: !to_unregister
       | Some (`Crashed msg) ->
-          (match entry.last_failure_reason with
-           | Some (Keeper_registry.Stale_termination_storm { count }) ->
-               (* #10765 Phase 2: skip [to_restart] AND in-memory unregister.
-                  The watchdog detected a termination storm (>= escalation_
-                  threshold within the 6h window).  [handle_stale_storm_pause]
-                  persists [meta.paused = true] so reconcile + future sweeps
-                  honor the pause across server restarts; we then add the
-                  entry to [to_unregister] so the in-memory registry slot is
-                  cleared and subsequent sweep ticks within the same server
-                  do NOT re-fire the storm-pause path (counter must increment
-                  once per storm, not once per sweep tick). *)
-               handle_stale_storm_pause ctx entry ~count;
-               to_unregister := entry :: !to_unregister
-           | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
-               (* Repeated OAS budget exhaustion means the active
-                  cascade/model is not producing within the turn budget.
-                  Restarting the same keeper preserves that bad routing and
-                  burns another multi-minute budget, so pause instead. *)
-               handle_oas_timeout_budget_pause ctx entry ~count;
-               to_unregister := entry :: !to_unregister
-           | _ ->
-               if entry.restart_count >= max_restarts then
-                 to_mark_dead := (entry, msg) :: !to_mark_dead
-               else begin
-                 let delay = backoff_delay entry.restart_count in
-                 if now -. entry.last_restart_ts >= delay then
-                   to_restart := (entry, msg) :: !to_restart
-               end))
+          queue_crashed_entry entry msg)
   ) entries;
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     Keeper_registry.unregister ~base_path entry.name;

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -913,17 +913,18 @@ let sweep_and_recover (ctx : _ context) =
     Log.Keeper.warn
       "%s: supervisor forcing unresolved watchdog-stopped keeper to crashed (%s)"
       entry.name msg;
-    ignore (Keeper_registry.try_resolve_done entry (`Crashed msg));
-    ignore
-      (Keeper_registry.dispatch_event_and_log
-         ~base_path entry.name
-         (Keeper_state_machine.Fiber_terminated { outcome = msg }));
-    let ts = Time_compat.now () in
-    Keeper_registry.record_crash ~base_path entry.name ts msg;
-    Keeper_registry.record_error ~base_path entry.name msg;
-    match Keeper_registry.get ~base_path entry.name with
-    | Some updated -> queue_crashed_entry updated msg
-    | None -> ()
+    if Keeper_registry.try_resolve_done entry (`Crashed msg) then begin
+      ignore
+        (Keeper_registry.dispatch_event_and_log
+           ~base_path entry.name
+           (Keeper_state_machine.Fiber_terminated { outcome = msg }));
+      let ts = Time_compat.now () in
+      Keeper_registry.record_crash ~base_path entry.name ts msg;
+      Keeper_registry.record_error ~base_path entry.name msg;
+      match Keeper_registry.get ~base_path entry.name with
+      | Some updated -> queue_crashed_entry updated msg
+      | None -> ()
+    end
   in
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     match entry.phase with

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -8,19 +8,39 @@ open Keeper_types
 
 exception Semaphore_wait_timeout of float
 
+let int_of_env_default_with_deprecated
+    ~primary
+    ~deprecated
+    ~default
+    ~min_v
+    ~max_v
+  =
+  match Env_config_core.resolve_deprecated ~primary ~deprecated with
+  | None -> default
+  | Some raw ->
+      let v =
+        Option.value ~default (int_of_string_opt (String.trim raw))
+      in
+      Keeper_config.clamp_int v ~min_v ~max_v
+;;
+
 (* Global turn slot cap. Safety ceiling for ALL keeper turns (autonomous
    + reactive). Default 12 = headroom for up to 12 keepers. *)
 let keeper_turn_throttle_limit =
-  Keeper_config.int_of_env_default
-    "MASC_KEEPER_AUTOBOT_MAX" ~default:12 ~min_v:1 ~max_v:20
+  int_of_env_default_with_deprecated
+    ~primary:"MASC_KEEPER_AUTOBOOT_MAX"
+    ~deprecated:"MASC_KEEPER_AUTOBOT_MAX"
+    ~default:12
+    ~min_v:1
+    ~max_v:20
 ;;
 
 let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
 
 (* Autonomous turn concurrency cap. Prevents thundering-herd when all
    keepers fire scheduled turns simultaneously on a shared LLM server.
-   Reactive turns (explicit mentions, board events) bypass this gate
-   so they are never starved by slow autonomous turns.
+   Reactive turns (explicit mentions, board events) use a separate gate
+   so they can stay responsive without consuming the full global pool.
    Default 3 = a conservative parallelism level for shared remote providers.
    Lower to 1 for single-slot local servers. For 8-slot servers,
    MASC_KEEPER_AUTONOMOUS_CONCURRENCY=3-4 is a reasonable range. *)
@@ -37,11 +57,27 @@ let () =
 
 let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
 
+let reactive_turn_limit =
+  Keeper_config.int_of_env_default
+    "MASC_KEEPER_REACTIVE_CONCURRENCY" ~default:4 ~min_v:1 ~max_v:12
+;;
+
+let () =
+  Log.Keeper.info "reactive_turn_concurrency=%d (env=%s)"
+    reactive_turn_limit
+    (Option.value ~default:"<unset>"
+       (Env_config_core.raw_value_opt "MASC_KEEPER_REACTIVE_CONCURRENCY"))
+
+let reactive_turn_semaphore = Eio.Semaphore.make reactive_turn_limit
+
 let turn_semaphore_value_for_test () =
   Eio.Semaphore.get_value turn_semaphore
 
 let autonomous_turn_semaphore_value_for_test () =
   Eio.Semaphore.get_value autonomous_turn_semaphore
+
+let reactive_turn_semaphore_value_for_test () =
+  Eio.Semaphore.get_value reactive_turn_semaphore
 
 type autonomous_waiter =
   {
@@ -176,6 +212,7 @@ let record_autonomous_completion ~(keeper_name : string) : unit =
 
 type keeper_turn_slot_state = {
   acquired_autonomous : bool ref;
+  acquired_reactive : bool ref;
   acquired_turn : bool ref;
   autonomous_ticket : int option ref;
 }
@@ -184,8 +221,9 @@ let release_keeper_turn_slot ~keeper_name state =
   Option.iter
     (fun ticket -> drop_autonomous_waiter ~ticket)
     !(state.autonomous_ticket);
-  (* Release exactly what we acquired. Order does not matter because
-     these two semaphores do not contend with each other. *)
+  (* Release exactly what we acquired. The turn, autonomous, and reactive
+     semaphores account for separate quotas, so release order does not affect
+     permit ownership. *)
   if !(state.acquired_turn) then Eio.Semaphore.release turn_semaphore;
   if !(state.acquired_autonomous) then begin
     (* Stamp completion time BEFORE releasing the semaphore so that
@@ -193,7 +231,9 @@ let release_keeper_turn_slot ~keeper_name state =
        when this keeper's heartbeat loops back immediately. *)
     record_autonomous_completion ~keeper_name;
     Eio.Semaphore.release autonomous_turn_semaphore
-  end
+  end;
+  if !(state.acquired_reactive) then
+    Eio.Semaphore.release reactive_turn_semaphore
 
 let reset_autonomous_completion_for_test () : unit =
   with_completion_table (fun () ->
@@ -384,6 +424,7 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
   let slot_state =
     {
       acquired_autonomous = ref false;
+      acquired_reactive = ref false;
       acquired_turn = ref false;
       autonomous_ticket = ref None;
     }
@@ -454,6 +495,18 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
       match autonomous_result with
       | Error _ as e -> e
       | Ok () ->
+        let reactive_result =
+          if is_autonomous then Ok ()
+          else
+            match acquire_bounded ~label:"reactive" reactive_turn_semaphore with
+            | Error _ as e -> e
+            | Ok () ->
+              slot_state.acquired_reactive := true;
+              Ok ()
+        in
+        match reactive_result with
+        | Error _ as e -> e
+        | Ok () ->
         match acquire_bounded ~label:"turn" turn_semaphore with
         | Error _ as e -> e
         | Ok () ->

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -5,6 +5,7 @@ val keeper_turn_throttle_limit : int
 
 val turn_semaphore : Eio.Semaphore.t
 val autonomous_turn_semaphore : Eio.Semaphore.t
+val reactive_turn_semaphore : Eio.Semaphore.t
 
 (** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
     turn slot. Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
@@ -24,6 +25,7 @@ val autonomous_waiter_snapshot_for_test : unit -> string list
 (** Test-only snapshots of the current semaphore availability. *)
 val turn_semaphore_value_for_test : unit -> int
 val autonomous_turn_semaphore_value_for_test : unit -> int
+val reactive_turn_semaphore_value_for_test : unit -> int
 
 (** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
 val enqueue_autonomous_waiter_for_test : string -> int

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1079,7 +1079,7 @@ let normalize_unknown_keeper_toml_keys unknown =
 let warn_unknown_keeper_toml_keys_once ~path unknown =
   let normalized_unknown = normalize_unknown_keeper_toml_keys unknown in
   let warning_key =
-    Filename.basename path ^ "\x1f" ^ String.concat "," normalized_unknown
+    path ^ "\x1f" ^ String.concat "," normalized_unknown
   in
   let rec loop () =
     let seen = Atomic.get unknown_keeper_toml_warning_keys in

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1063,14 +1063,49 @@ let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
        not (List.mem key known) && not (starts_with_oas_env key))
   |> dedupe_keep_order
 
+let unknown_keeper_toml_warning_key_limit = 256
+let unknown_keeper_toml_warning_keys : string list Atomic.t = Atomic.make []
+
+let rec take_warning_keys n keys =
+  match n, keys with
+  | n, _ when n <= 0 -> []
+  | _, [] -> []
+  | n, key :: rest -> key :: take_warning_keys (n - 1) rest
+
+let normalize_unknown_keeper_toml_keys unknown =
+  List.sort_uniq String.compare unknown
+;;
+
+let warn_unknown_keeper_toml_keys_once ~path unknown =
+  let normalized_unknown = normalize_unknown_keeper_toml_keys unknown in
+  let warning_key =
+    Filename.basename path ^ "\x1f" ^ String.concat "," normalized_unknown
+  in
+  let rec loop () =
+    let seen = Atomic.get unknown_keeper_toml_warning_keys in
+    if List.mem warning_key seen then
+      false
+    else
+      let next =
+        take_warning_keys unknown_keeper_toml_warning_key_limit (warning_key :: seen)
+      in
+      if Atomic.compare_and_set unknown_keeper_toml_warning_keys seen next then
+        true
+      else
+        loop ()
+  in
+  loop ()
+
 let warn_unknown_keeper_toml_keys ~path (doc : Keeper_toml_loader.toml_doc) =
   match detect_unknown_keeper_toml_keys doc with
   | [] -> ()
   | unknown ->
-    Log.Keeper.warn
-      "keeper TOML %s has unknown keys: %s"
-      path
-      (String.concat ", " unknown)
+    let unknown = normalize_unknown_keeper_toml_keys unknown in
+    if warn_unknown_keeper_toml_keys_once ~path unknown then
+      Log.Keeper.warn
+        "keeper TOML %s has unknown keys: %s"
+        path
+        (String.concat ", " unknown)
 
 let load_keeper_toml (path : string)
     : (string * keeper_profile_defaults, string) result =

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -655,6 +655,73 @@ let composite_execution_blocked execution =
       | `Assoc _ as error -> string_opt_present (json_string "kind" error)
       | _ -> false)
 
+type composite_runtime_attention = {
+  cra_is_live : bool;
+  cra_stale_long_enough : bool;
+  cra_idle_attention : bool;
+  cra_blocked : bool;
+  cra_stale_without_live_turn : bool;
+  cra_needs_attention : bool;
+  cra_reason : string option;
+  cra_state : string;
+}
+
+let composite_runtime_attention ~snapshot ~execution =
+  let is_live = Option.value ~default:false (json_bool "is_live" snapshot) in
+  let latest = composite_latest_activity_epoch snapshot execution in
+  let now = Unix.gettimeofday () in
+  let stale_long_enough =
+    match latest with
+    | Some ts -> now -. ts >= 600.0
+    | None -> not is_live
+  in
+  let idle_attention =
+    is_live && composite_snapshot_is_idle snapshot && stale_long_enough
+  in
+  let blocked = composite_execution_blocked execution in
+  let stale_without_live_turn = (not is_live) && stale_long_enough in
+  let needs_attention = blocked || stale_without_live_turn || idle_attention in
+  let reason =
+    match json_string "operator_disposition_reason" execution with
+    | Some value when String.trim value <> "" -> Some value
+    | _ -> (
+        match json_string "terminal_reason_code" execution with
+        | Some value when String.trim value <> "" -> Some value
+        | _ when idle_attention -> Some "idle_composite"
+        | _ when stale_without_live_turn -> Some "not_live"
+        | _ when blocked -> Some "runtime_blocked"
+        | _ -> None )
+  in
+  let state =
+    if blocked then "blocked"
+    else if idle_attention then "idle_stale"
+    else if stale_without_live_turn then "stale"
+    else "ok"
+  in
+  {
+    cra_is_live = is_live;
+    cra_stale_long_enough = stale_long_enough;
+    cra_idle_attention = idle_attention;
+    cra_blocked = blocked;
+    cra_stale_without_live_turn = stale_without_live_turn;
+    cra_needs_attention = needs_attention;
+    cra_reason = reason;
+    cra_state = state;
+  }
+
+let composite_runtime_attention_json attention ~snapshot =
+  `Assoc
+    [ "state", `String attention.cra_state
+    ; "needs_attention", `Bool attention.cra_needs_attention
+    ; "blocked", `Bool attention.cra_blocked
+    ; "reason", Json_util.string_opt_to_json attention.cra_reason
+    ; "raw_phase", Json_util.string_opt_to_json (json_string "phase" snapshot)
+    ; "is_live", `Bool attention.cra_is_live
+    ; ( "source",
+        `String
+          (if attention.cra_blocked then "execution_receipt" else "composite_snapshot") )
+    ]
+
 let fleet_fsm_action_payload ~keeper_name ~kind ~reason ~snapshot ~execution =
   `Assoc
     [
@@ -683,31 +750,10 @@ let fleet_fsm_message_payload ~keeper_name ~reason ~snapshot ~execution =
            ])
   | other -> other
 
-let composite_recommended_actions_json ~keeper_name ~snapshot ~execution =
-  let is_live = Option.value ~default:false (json_bool "is_live" snapshot) in
-  let latest = composite_latest_activity_epoch snapshot execution in
-  let now = Unix.gettimeofday () in
-  let stale_long_enough =
-    match latest with
-    | Some ts -> now -. ts >= 600.0
-    | None -> not is_live
-  in
-  let idle_attention =
-    is_live && composite_snapshot_is_idle snapshot && stale_long_enough
-  in
-  let blocked = composite_execution_blocked execution in
-  let stale_without_live_turn = (not is_live) && stale_long_enough in
-  let needs_attention = blocked || stale_without_live_turn || idle_attention in
-  let reason =
-    match json_string "operator_disposition_reason" execution with
-    | Some value when String.trim value <> "" -> value
-    | _ -> (
-        match json_string "terminal_reason_code" execution with
-        | Some value when String.trim value <> "" -> value
-        | _ when idle_attention -> "idle_composite"
-        | _ when stale_without_live_turn -> "not_live"
-        | _ -> "runtime_attention" )
-  in
+let composite_recommended_actions_json ~keeper_name ~snapshot ~execution ~attention =
+  let stale_long_enough = attention.cra_stale_long_enough in
+  let idle_attention = attention.cra_idle_attention in
+  let reason = Option.value ~default:"runtime_attention" attention.cra_reason in
   let make action_type severity reason suggested_payload =
     let action : Operator_digest_types.recommended_action =
       {
@@ -735,7 +781,7 @@ let composite_recommended_actions_json ~keeper_name ~snapshot ~execution =
          ~snapshot ~execution)
   in
   let actions =
-    if not needs_attention then []
+    if not attention.cra_needs_attention then []
     else if composite_execution_tool_required execution then
       [
         probe ("Inspect tool-contract blocker: " ^ reason);
@@ -773,18 +819,25 @@ let enrich_composite_snapshot_json ~(config : Coord.config) ~keeper_name json =
             not
               (String.equal name "keeper"
                || String.equal name "execution"
+               || String.equal name "runtime_attention"
                || String.equal name "recommended_actions"))
           fields
       in
       let execution = composite_execution_receipt_json ~config ~keeper_name in
+      let attention = composite_runtime_attention ~snapshot:json ~execution in
       let recommended_actions =
         composite_recommended_actions_json ~keeper_name ~snapshot:json ~execution
+          ~attention
+      in
+      let runtime_attention =
+        composite_runtime_attention_json attention ~snapshot:json
       in
       `Assoc
         (fields
          @ [
              ("keeper", `String keeper_name);
              ("execution", execution);
+             ("runtime_attention", runtime_attention);
              ("recommended_actions", recommended_actions);
            ])
   | other -> other

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1065,19 +1065,18 @@ let test_available_cascade_profiles_filter_invalid_catalog_entries () =
     (Printf.sprintf
        {|
       {
-        "default_models": ["%s"],
+        "routes": {"keeper_turn": "good"},
         "good_models": ["%s"],
         "broken_models": ["__nonexistent_provider_sentinel__:fake-model"]
       }
     |}
-       valid_model
        valid_model)
   @@ fun config_root ->
   with_config_dir config_root @@ fun () ->
   check
     (list string)
     "assignable cascades exclude invalid presets"
-    [ "default"; "good" ]
+    [ "good" ]
     (Routes.available_cascade_profiles ());
   let invalid = Routes.invalid_cascade_profiles () in
   check bool "invalid preset is surfaced separately" true
@@ -1090,12 +1089,11 @@ let test_keeper_cascade_routes_filter_invalid_catalog_entries () =
     (Printf.sprintf
        {|
       {
-        "default_models": ["%s"],
+        "routes": {"keeper_turn": "good"},
         "good_models": ["%s"],
         "broken_models": ["__nonexistent_provider_sentinel__:fake-model"]
       }
     |}
-       valid_model
        valid_model)
   @@ fun config_root ->
   with_seeded_server
@@ -1132,7 +1130,7 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
   with_mock_model @@ fun valid_model ->
   with_temp_config_root
     (Printf.sprintf
-       {|{"default_models":["%s"],"keeper_unified_models":["%s"]}|}
+       {|{"routes":{"keeper_turn":"big_three"},"big_three_models":["%s"],"keeper_diverse_models":["%s"]}|}
        valid_model
        valid_model)
   @@ fun config_root ->
@@ -1158,7 +1156,7 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
     run_curl_post
       ~body:
         (Printf.sprintf
-           {|{"keeper":"%s","cascade_name":"keeper_unified"}|}
+           {|{"keeper":"%s","cascade_name":"keeper_diverse"}|}
            keeper_name)
       ~token:admin_token
       ~port
@@ -1175,12 +1173,12 @@ let test_keeper_cascade_assignment_updates_dashboard_projection () =
   in
   require_status "cascade config GET after assignment returns 200" 200 after;
   check string "dashboard projection reflects assigned cascade"
-    "keeper_unified"
+    "keeper_diverse"
     (keeper_profile_cascade_name after.body keeper_name);
   (match Masc_mcp.Keeper_types.read_meta config keeper_name with
    | Ok (Some meta) ->
        check string "persistent meta cascade updated"
-         "keeper_unified" meta.cascade_name
+         "keeper_diverse" meta.cascade_name
    | Ok None -> fail "keeper meta missing after cascade assignment"
    | Error msg -> fail ("read_meta failed after cascade assignment: " ^ msg))
 ;;
@@ -1218,7 +1216,7 @@ let test_execution_trust_route_surfaces_trust_summary_fields () =
   check bool "route surfaces trust outcome" true
     (List.mem
        (row |> member "trust" |> member "last_outcome" |> to_string)
-       [ "ok"; "not_run" ]);
+       [ "receipt_done"; "ok"; "not_run"; "completed" ]);
   check string "route surfaces trust sandbox kind" "local"
     (row |> member "trust" |> member "sandbox" |> member "kind"
      |> to_string);
@@ -1304,6 +1302,20 @@ let test_composite_routes_surface_runtime_recommended_actions () =
   require_status "per-keeper composite GET returns 200" 200 result;
   let open Yojson.Safe.Util in
   let json = Yojson.Safe.from_string result.body in
+  let runtime_attention = json |> member "runtime_attention" in
+  (match runtime_attention with
+   | `Assoc _ -> ()
+   | other ->
+       Alcotest.failf
+         "expected runtime_attention object, got %s in body %s"
+         (Yojson.Safe.to_string other)
+         result.body);
+  check string "composite surfaces blocked runtime attention" "blocked"
+    (runtime_attention |> member "state" |> to_string);
+  check bool "composite runtime attention needs action" true
+    (runtime_attention |> member "needs_attention" |> to_bool);
+  check string "composite runtime attention reason" "tool_required_unsatisfied"
+    (runtime_attention |> member "reason" |> to_string);
   let actions = json |> member "recommended_actions" |> to_list in
   check bool "composite recommends keeper_probe" true
     (List.exists

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -776,6 +776,16 @@ let test_fiber_health_crashed () =
   | Keeper_types.Fiber_zombie -> ()
   | _ -> fail "expected Fiber_zombie for crashed"
 
+let test_try_resolve_done_wins_once () =
+  R.clear ();
+  let entry = R.register ~base_path:bp "resolve-once" (make_meta "resolve-once") in
+  check bool "first resolve wins" true (R.try_resolve_done entry `Stopped);
+  check bool "second resolve loses" false
+    (R.try_resolve_done entry (`Crashed "late crash"));
+  match Eio.Promise.await entry.done_p with
+  | `Stopped -> ()
+  | `Crashed reason -> fail ("expected stopped, got crashed: " ^ reason)
+
 let test_fiber_health_crashed_state_without_done_signal () =
   R.clear ();
   let _entry = R.register ~base_path:bp "fh3-state" (make_meta "fh3-state") in
@@ -1131,8 +1141,14 @@ let test_board_signal_wakeup_only_wakes_opted_in_scope_keeper () =
         in
         KK.wakeup_relevant_keeper_for_board_signal ~config signal;
         check bool "opted-in keeper woken" true (Atomic.get entry_a.fiber_wakeup);
+        check int "opted-in keeper queued board stimulus" 1
+          (R.event_queue_snapshot ~base_path:base_dir "opted-in"
+           |> Masc_mcp.Keeper_event_queue.length);
         check bool "defaulted keeper stays asleep" false
-          (Atomic.get entry_b.fiber_wakeup)))
+          (Atomic.get entry_b.fiber_wakeup);
+        check int "defaulted keeper has no stimulus" 0
+          (R.event_queue_snapshot ~base_path:base_dir "defaulted"
+           |> Masc_mcp.Keeper_event_queue.length)))
 
 let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
   R.clear ();
@@ -1193,8 +1209,14 @@ let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
         KK.wakeup_relevant_keeper_for_board_signal ~config signal;
         check bool "participant keeper woken" true
           (Atomic.get entry_a.fiber_wakeup);
+        check int "participant keeper queued board stimulus" 1
+          (R.event_queue_snapshot ~base_path:base_dir "participant"
+           |> Masc_mcp.Keeper_event_queue.length);
         check bool "bystander keeper stays asleep" false
-          (Atomic.get entry_b.fiber_wakeup)))
+          (Atomic.get entry_b.fiber_wakeup);
+        check int "bystander keeper has no stimulus" 0
+          (R.event_queue_snapshot ~base_path:base_dir "bystander"
+           |> Masc_mcp.Keeper_event_queue.length)))
 
 let test_effective_keepalive_meta_prefers_registry_when_disk_unchanged () =
   R.clear ();
@@ -1319,6 +1341,7 @@ let () =
           eio_test "fiber_health unknown" test_fiber_health_unknown;
           eio_test "fiber_health stopped" test_fiber_health_stopped;
           eio_test "fiber_health crashed" test_fiber_health_crashed;
+          eio_test "try_resolve_done wins once" test_try_resolve_done_wins_once;
           eio_test "fiber_health explicit crashed state" test_fiber_health_crashed_state_without_done_signal;
           eio_test "fiber_health dead state" test_fiber_health_dead_state;
           eio_test "shared refs" test_shared_refs;

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -110,6 +110,67 @@ let test_applies_multiple_overrides () =
     (Some "20")
     (List.assoc_opt "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL" overrides)
 
+let test_applies_sleep_and_throttle_overrides () =
+  let doc = parse_or_fail
+    "[bootstrap]\n\
+     autoboot_max = 6\n\
+     [autonomous]\n\
+     concurrency = 2\n\
+     slot_wait_timeout_sec = 45\n\
+     fairness_cooldown_sec = 3\n\
+     [reactive]\n\
+     concurrency = 4\n\
+     [heartbeat]\n\
+     sleep_chunk_sec = 1.5\n\
+     board_debounce_sec = 30\n\
+     board_generic_wakeup_limit = 5\n\
+     board_wakeup_max = 6\n\
+     [turn]\n\
+     admission_wait_timeout_sec = 20\n\
+     batch_limit = 9\n\
+     board_event_limit = 7\n"
+  in
+  let count, overrides =
+    Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
+  in
+  check int "applied sleep/throttle overrides" 12 count;
+  check (option string) "autoboot max canonical env"
+    (Some "6")
+    (List.assoc_opt "MASC_KEEPER_AUTOBOOT_MAX" overrides);
+  check (option string) "autonomous concurrency"
+    (Some "2")
+    (List.assoc_opt "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" overrides);
+  check (option string) "autonomous slot wait"
+    (Some "45")
+    (List.assoc_opt "MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC" overrides);
+  check (option string) "autonomous fairness cooldown"
+    (Some "3")
+    (List.assoc_opt "MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC" overrides);
+  check (option string) "reactive concurrency"
+    (Some "4")
+    (List.assoc_opt "MASC_KEEPER_REACTIVE_CONCURRENCY" overrides);
+  check (option string) "sleep chunk"
+    (Some "1.5")
+    (List.assoc_opt "MASC_KEEPER_SLEEP_CHUNK_SEC" overrides);
+  check (option string) "board debounce"
+    (Some "30")
+    (List.assoc_opt "MASC_KEEPER_BOARD_DEBOUNCE_SEC" overrides);
+  check (option string) "board generic wakeup limit"
+    (Some "5")
+    (List.assoc_opt "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT" overrides);
+  check (option string) "board wakeup max"
+    (Some "6")
+    (List.assoc_opt "MASC_KEEPER_BOARD_WAKEUP_MAX" overrides);
+  check (option string) "admission wait"
+    (Some "20")
+    (List.assoc_opt "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC" overrides);
+  check (option string) "batch limit"
+    (Some "9")
+    (List.assoc_opt "MASC_KEEPER_BATCH_LIMIT" overrides);
+  check (option string) "board event limit"
+    (Some "7")
+    (List.assoc_opt "MASC_KEEPER_BOARD_EVENT_LIMIT" overrides)
+
 let test_applies_turn_execution_overrides () =
   let doc = parse_or_fail
     "[turn]\n\
@@ -443,6 +504,7 @@ let () =
         ; test_case "missing file keeps cost gate disabled by default" `Quick test_missing_file_keeps_cost_gate_disabled_by_default
         ; test_case "applies autonomous max_turns_per_call" `Quick test_applies_autonomous_max_turns
         ; test_case "applies multiple overrides" `Quick test_applies_multiple_overrides
+        ; test_case "applies sleep/throttle overrides" `Quick test_applies_sleep_and_throttle_overrides
         ; test_case "applies turn execution overrides" `Quick test_applies_turn_execution_overrides
         ; test_case "applies watchdog overrides" `Quick test_applies_watchdog_overrides
         ; test_case "applies memory overrides" `Quick test_applies_memory_overrides

--- a/test/test_keeper_semaphore_fairness.ml
+++ b/test/test_keeper_semaphore_fairness.ml
@@ -125,6 +125,7 @@ let test_delay_decreases_with_elapsed_time () =
 
 let test_reactive_slot_released_when_body_raises () =
   let before = KK.turn_semaphore_value_for_test () in
+  let before_reactive = KK.reactive_turn_semaphore_value_for_test () in
   let completed =
     try
       Some
@@ -136,7 +137,9 @@ let test_reactive_slot_released_when_body_raises () =
   Alcotest.(check bool) "body exception propagated" true
     (Option.is_none completed);
   Alcotest.(check int) "turn semaphore restored" before
-    (KK.turn_semaphore_value_for_test ())
+    (KK.turn_semaphore_value_for_test ());
+  Alcotest.(check int) "reactive semaphore restored" before_reactive
+    (KK.reactive_turn_semaphore_value_for_test ())
 
 let test_autonomous_slot_released_when_body_raises () =
   let before_turn = KK.turn_semaphore_value_for_test () in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -642,6 +642,50 @@ let test_oas_timeout_budget_loop_pause_skips_restart () =
       check bool "registry entry unregistered after OAS budget loop pause"
         false (Reg.is_registered ~base_path:config.base_path name))
 
+let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let name = "unresolved-watchdog-stopped" in
+      let meta = make_meta name in
+      (match KT.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      Atomic.set reg.fiber_stop true;
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+      Reg.set_failure_reason ~base_path:config.base_path name
+        (Some (Reg.Oas_timeout_budget_loop { count = 3 }));
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      (match KT.read_meta config name with
+       | Ok (Some m) ->
+           check bool "meta.paused = true after unresolved watchdog stop"
+             true m.paused
+       | Ok None -> fail "meta missing after unresolved watchdog stop"
+       | Error err -> fail ("read_meta failed: " ^ err));
+      check bool "unresolved watchdog-stopped entry reaped"
+        false (Reg.is_registered ~base_path:config.base_path name))
+
 (* Regression guard: a `Crashed entry whose last_failure_reason is NOT a
    storm must still flow through the existing restart-or-mark-dead branch.
    Verifies the new gate is variant-specific, not a blanket short-circuit. *)
@@ -759,6 +803,8 @@ let () =
         test_stale_storm_pause_skips_restart;
       test_case "Oas_timeout_budget_loop skips restart, persists paused, increments counter" `Quick
         test_oas_timeout_budget_loop_pause_skips_restart;
+      test_case "unresolved watchdog-stopped budget loop is reaped" `Quick
+        test_unresolved_watchdog_stopped_budget_loop_is_reaped;
       test_case "non-storm Crashed still routes to restart (regression guard)" `Quick
         test_non_storm_crashed_restarts_normally;
     ];

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1652,6 +1652,39 @@ typo_field = 42
       [ "keeper.legacy_scope"; "keeper.typo_field" ]
       defaults.KTP.unknown_toml_keys
 
+let test_unknown_toml_warning_key_normalizes_unknown_order () =
+  let path =
+    Printf.sprintf "/tmp/keeper-warning-order-%06x.toml" (Random.bits ())
+  in
+  check bool "first ordered warning emits" true
+    (KTP.warn_unknown_keeper_toml_keys_once ~path
+       [ "keeper.zeta"; "keeper.alpha" ]);
+  check bool "same set in different order is deduped" false
+    (KTP.warn_unknown_keeper_toml_keys_once ~path
+       [ "keeper.alpha"; "keeper.zeta" ])
+
+let string_starts_with ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.sub value 0 prefix_len = prefix
+
+let test_unknown_toml_warning_key_cache_is_bounded () =
+  let prefix =
+    Printf.sprintf "keeper-warning-bound-%06x-" (Random.bits ())
+  in
+  for idx = 0 to KTP.unknown_keeper_toml_warning_key_limit + 3 do
+    ignore
+      (KTP.warn_unknown_keeper_toml_keys_once
+         ~path:("/tmp/" ^ prefix ^ string_of_int idx ^ ".toml")
+         [ "keeper.typo_field" ])
+  done;
+  let matching =
+    Atomic.get KTP.unknown_keeper_toml_warning_keys
+    |> List.filter (string_starts_with ~prefix)
+  in
+  check bool "warning cache stays bounded for this prefix" true
+    (List.length matching <= KTP.unknown_keeper_toml_warning_key_limit)
+
 (* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
@@ -1761,6 +1794,10 @@ let () =
             test_oas_env_not_flagged_as_unknown;
           test_case "load_keeper_toml captures unknown keys on profile" `Quick
             test_load_keeper_toml_captures_unknown_keys_on_profile;
+          test_case "unknown TOML warning key normalizes order" `Quick
+            test_unknown_toml_warning_key_normalizes_unknown_order;
+          test_case "unknown TOML warning key cache is bounded" `Quick
+            test_unknown_toml_warning_key_cache_is_bounded;
         ] );
       ( "oas_env",
         [

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1663,6 +1663,20 @@ let test_unknown_toml_warning_key_normalizes_unknown_order () =
     (KTP.warn_unknown_keeper_toml_keys_once ~path
        [ "keeper.alpha"; "keeper.zeta" ])
 
+let test_unknown_toml_warning_key_full_path_not_basename () =
+  (* Two files that share the same basename but live in different directories
+     must each emit their own warning — using only the basename would incorrectly
+     suppress the second warning as a duplicate. *)
+  let suffix =
+    Printf.sprintf "keeper-warning-path-%06x.toml" (Random.bits ())
+  in
+  let path_a = "/tmp/dir-a/" ^ suffix in
+  let path_b = "/tmp/dir-b/" ^ suffix in
+  check bool "first file (dir-a) emits warning" true
+    (KTP.warn_unknown_keeper_toml_keys_once ~path:path_a [ "keeper.typo_x" ]);
+  check bool "second file (dir-b) also emits warning (different full path)" true
+    (KTP.warn_unknown_keeper_toml_keys_once ~path:path_b [ "keeper.typo_x" ])
+
 let string_starts_with ~prefix value =
   let prefix_len = String.length prefix in
   String.length value >= prefix_len
@@ -1796,6 +1810,8 @@ let () =
             test_load_keeper_toml_captures_unknown_keys_on_profile;
           test_case "unknown TOML warning key normalizes order" `Quick
             test_unknown_toml_warning_key_normalizes_unknown_order;
+          test_case "unknown TOML warning key uses full path not basename" `Quick
+            test_unknown_toml_warning_key_full_path_not_basename;
           test_case "unknown TOML warning key cache is bounded" `Quick
             test_unknown_toml_warning_key_cache_is_bounded;
         ] );

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -201,6 +201,23 @@ let test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap () =
     selected;
   check int "dropped generic wakeups" 1 dropped
 
+let test_board_wakeup_selection_caps_total_non_explicit () =
+  let selected, dropped =
+    KKS.select_board_wakeup_candidates
+      ~generic_limit:4
+      ~total_limit:2
+      [
+        "a", Some "board_activity";
+        "b", Some "thread_reply_after_self_comment";
+        "c", Some "board_activity";
+        "d", Some "thread_reply_after_self_comment";
+      ]
+  in
+  check (list (pair string string)) "selected total wakeups"
+    [ "a", "board_activity"; "b", "thread_reply_after_self_comment" ]
+    selected;
+  check int "dropped total wakeups" 2 dropped
+
 let test_after_wake_idle_woken_continues () =
   let next = Unix.gettimeofday () +. 60.0 in
   check bool "Skip_idle + Woken -> cycle resumes" true
@@ -332,6 +349,8 @@ let () =
         `Quick test_board_wakeup_selection_keeps_explicit_mentions;
       test_case "specific reasons survive generic cap"
         `Quick test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap;
+      test_case "total non-explicit fanout is capped"
+        `Quick test_board_wakeup_selection_caps_total_non_explicit;
     ];
     "missed_wakeup_gap", [
       test_case "Skip_idle + Woken -> resumes (MissedWakeup spec gap)"

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -197,11 +197,12 @@ let test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap () =
       ]
   in
   check (list (pair string string)) "selected mixed wakeups"
-    [ "a", "board_activity"; "b", "thread_reply_after_self_comment" ]
+    [ "b", "thread_reply_after_self_comment"; "a", "board_activity" ]
     selected;
   check int "dropped generic wakeups" 1 dropped
 
 let test_board_wakeup_selection_caps_total_non_explicit () =
+  (* Non-generic reasons are prioritized over board_activity before total cap *)
   let selected, dropped =
     KKS.select_board_wakeup_candidates
       ~generic_limit:4
@@ -214,9 +215,28 @@ let test_board_wakeup_selection_caps_total_non_explicit () =
       ]
   in
   check (list (pair string string)) "selected total wakeups"
-    [ "a", "board_activity"; "b", "thread_reply_after_self_comment" ]
+    [ "b", "thread_reply_after_self_comment"; "d", "thread_reply_after_self_comment" ]
     selected;
   check int "dropped total wakeups" 2 dropped
+
+let test_board_wakeup_selection_total_limit_prefers_non_generic () =
+  (* A late non-generic entry must survive when a generic entry would displace it
+     under candidate order alone.  After prioritization the two non-generic items
+     fill the cap and the generic one is dropped instead. *)
+  let selected, dropped =
+    KKS.select_board_wakeup_candidates
+      ~generic_limit:5
+      ~total_limit:2
+      [
+        "a", Some "board_activity";
+        "b", Some "board_activity";
+        "c", Some "thread_reply_after_self_comment";
+      ]
+  in
+  check (list (pair string string)) "non-generic survives cap"
+    [ "c", "thread_reply_after_self_comment"; "a", "board_activity" ]
+    selected;
+  check int "dropped generic" 1 dropped
 
 let test_after_wake_idle_woken_continues () =
   let next = Unix.gettimeofday () +. 60.0 in
@@ -351,6 +371,8 @@ let () =
         `Quick test_board_wakeup_selection_keeps_specific_reasons_past_generic_cap;
       test_case "total non-explicit fanout is capped"
         `Quick test_board_wakeup_selection_caps_total_non_explicit;
+      test_case "total limit prefers non-generic over board_activity"
+        `Quick test_board_wakeup_selection_total_limit_prefers_non_generic;
     ];
     "missed_wakeup_gap", [
       test_case "Skip_idle + Woken -> resumes (MissedWakeup spec gap)"


### PR DESCRIPTION
## Summary

- Fix keeper sleep where watchdog-stopped fibers could stay reported as Running when `done_p=None`.
- Add bounded reactive keeper turns and cap generic non-explicit board wakeup fanout so board activity does not wake the whole fleet by default.
- Surface execution-receipt blockers in dashboard composite output via `runtime_attention` and dedupe repeated unknown keeper TOML warnings.

## Root Cause

- The global turn cap reader used the typo `MASC_KEEPER_AUTOBOT_MAX` while config/docs/logs use `MASC_KEEPER_AUTOBOOT_MAX`, so TOML `bootstrap.autoboot_max` did not affect the runtime cap.
- Reactive turns shared the global turn pool without their own bound, and board wakeups could fan out across matching running keepers.
- The stale watchdog set `fiber_stop`, but the supervisor treated unresolved `done_p=None` fibers as alive, leaving operators with `Running` keepers that were effectively stopped.
- Composite keeper state showed raw registry phase without overlaying the latest blocked execution receipt.

## Changes

- Canonical env read for `MASC_KEEPER_AUTOBOOT_MAX` with legacy typo fallback.
- New `MASC_KEEPER_REACTIVE_CONCURRENCY` and `reactive.concurrency` TOML mapping.
- New TOML mapping for `heartbeat.board_generic_wakeup_limit` to `MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT`.
- Board wakeup event-layer stimulus now records source/kind/post metadata for the woken keeper.
- Watchdog stop now wakes the supervisor path; unresolved watchdog-stopped fibers are reaped and enter existing crash/pause recovery handling.
- Dashboard composite keeper payload now includes `runtime_attention` with blocked/degraded state derived from latest execution receipt.
- Unknown keeper TOML key warnings are deduped per file/key set.

## Validation

- `scripts/dune-local.sh build test/test_keeper_runtime_toml.exe test/test_smart_heartbeat_keepalive.exe test/test_keeper_registry.exe test/test_keeper_supervisor.exe test/test_keeper_semaphore_fairness.exe test/test_dashboard_keeper_routes.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_runtime_toml.exe`
- `./_build/default/test/test_smart_heartbeat_keepalive.exe test board_wakeup_selection`
- `./_build/default/test/test_keeper_registry.exe test directives 11-13`
- `./_build/default/test/test_keeper_supervisor.exe test stale_storm_phase2`
- `./_build/default/test/test_keeper_semaphore_fairness.exe`
- `MASC_E2E_TESTS=true ./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 10`
- `git diff --check`

Note: before rebasing onto current `main`, full `MASC_E2E_TESTS=true ./_build/default/test/test_dashboard_keeper_routes.exe` still had 3 existing cascade/config fixture failures outside this patch: dashboard keeper route tests 5, 7, and 8.
