### PR TITLE
feat(dashboard): add anchored thread rail store

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -51,6 +51,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `design-system/headless-core/keeper-line-ownership.ts` implements RFC 0019's line-range accumulator and deterministic keeper hue mapping.
   - `src/components/ide/keeper-line-ownership-store.ts` publishes dashboard snapshots for the IDE blame gutter; the editor mock now consumes the store instead of hardcoded row ownership.
 
+- **Anchored thread rail substrate**
+  - `design-system/headless-core/anchored-thread-rail.ts` implements RFC 0021's current-file thread scoping, line lookup, and focus coordination.
+  - `src/components/ide/anchored-thread-rail-store.ts` publishes dashboard snapshots for the CONVERSATION rail; the rail mock now consumes the store instead of hardcoded card fields.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/design-system/headless-core/anchored-thread-rail.test.ts
+++ b/dashboard/design-system/headless-core/anchored-thread-rail.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createAnchoredThreadRail,
+  type AnchoredThread,
+} from './anchored-thread-rail'
+
+const file = 'runtime/cascade/router.ts'
+
+const thread = (patch: Partial<AnchoredThread>): AnchoredThread => ({
+  id: 'thread-1',
+  kind: 'flag',
+  author_keeper_id: 'nick0cave',
+  anchor: {
+    file_path: file,
+    line_start: 34,
+    line_end: 35,
+    symbol_hint: 'if:moonshot-tool-choice',
+  },
+  body: 'Schema failure matches the live cascade logs.',
+  created_ms: 1000,
+  resolved: false,
+  reply_count: 0,
+  ...patch,
+})
+
+describe('createAnchoredThreadRail', () => {
+  it('scopes visibleThreads to the active file and keeps resolved threads visible', () => {
+    const threads = [
+      thread({ id: 'older', created_ms: 1000 }),
+      thread({ id: 'newer', created_ms: 2000, resolved: true, reply_count: 3 }),
+      thread({ id: 'other-file', anchor: { file_path: 'other.ts', line_start: 1, line_end: 1 } }),
+    ]
+    const rail = createAnchoredThreadRail({ filePath: () => file, threads: () => threads })
+
+    expect(rail.visibleThreads().map(item => item.id)).toEqual(['newer', 'older'])
+    expect(rail.visibleThreads()[0]).toMatchObject({ resolved: true, reply_count: 3 })
+  })
+
+  it('returns threads whose anchor range contains the requested line', () => {
+    const threads = [
+      thread({ id: 'wide', anchor: { file_path: file, line_start: 10, line_end: 14 } }),
+      thread({ id: 'single', anchor: { file_path: file, line_start: 12, line_end: 12 } }),
+      thread({ id: 'file-level', anchor: { file_path: file, line_start: null, line_end: null } }),
+    ]
+    const rail = createAnchoredThreadRail({ filePath: () => file, threads: () => threads })
+
+    expect(rail.threadsForLine(12).map(item => item.id)).toEqual(['single', 'wide'])
+    expect(rail.threadsForLine(15)).toEqual([])
+    expect(rail.threadsForLine(Number.NaN)).toEqual([])
+  })
+
+  it('focuses visible threads and notifies subscribers on focus changes', () => {
+    const rail = createAnchoredThreadRail({
+      filePath: () => file,
+      threads: () => [
+        thread({ id: 'visible' }),
+        thread({ id: 'hidden', anchor: { file_path: 'other.ts', line_start: 1, line_end: 1 } }),
+      ],
+    })
+    const focused: Array<string | null> = []
+    const unsubscribe = rail.subscribe(() => focused.push(rail.focusedThreadId()))
+
+    expect(rail.focusThread('hidden')).toBe(false)
+    expect(rail.focusThread('visible')).toBe(true)
+    expect(rail.focusedThreadId()).toBe('visible')
+    rail.clearFocus()
+    unsubscribe()
+    rail.focusThread('visible')
+
+    expect(focused).toEqual(['visible', null])
+  })
+
+  it('drops malformed public input before it reaches visible state', () => {
+    const rail = createAnchoredThreadRail({
+      filePath: () => file,
+      threads: () => [
+        thread({ id: '' }),
+        thread({ id: 'bad-replies', reply_count: -1 }),
+        thread({ id: 'bad-time', created_ms: Number.NaN }),
+        thread({ id: 'bad-anchor', anchor: { file_path: file, line_start: 4, line_end: 2 } }),
+        thread({ id: 'ok-file', anchor: { file_path: file, line_start: null, line_end: null } }),
+      ],
+    })
+
+    expect(rail.visibleThreads().map(item => item.id)).toEqual(['ok-file'])
+  })
+})

--- a/dashboard/design-system/headless-core/anchored-thread-rail.ts
+++ b/dashboard/design-system/headless-core/anchored-thread-rail.ts
@@ -1,0 +1,132 @@
+/**
+ * AnchoredThreadRail - framework-agnostic controller for RFC 0021.
+ *
+ * The controller scopes review/conversation threads to the active file,
+ * answers line-range lookup queries, and emits focus changes without
+ * coupling the editor viewport to the rail renderer.
+ */
+
+export type ThreadKind = 'flag' | 'question' | 'approve' | 'note' | 'suggest'
+
+export interface ThreadAnchor {
+  readonly file_path: string
+  readonly line_start: number | null
+  readonly line_end: number | null
+  readonly symbol_hint?: string
+}
+
+export interface AnchoredThread {
+  readonly id: string
+  readonly kind: ThreadKind
+  readonly author_keeper_id: string
+  readonly anchor: ThreadAnchor
+  readonly body: string
+  readonly created_ms: number
+  readonly resolved: boolean
+  readonly reply_count: number
+}
+
+export interface AnchoredThreadRailController {
+  readonly filePath: () => string
+  readonly visibleThreads: () => ReadonlyArray<AnchoredThread>
+  readonly threadsForLine: (line: number) => ReadonlyArray<AnchoredThread>
+  readonly focusedThreadId: () => string | null
+  readonly focusedThread: () => AnchoredThread | null
+  readonly focusThread: (id: string) => boolean
+  readonly clearFocus: () => void
+  readonly subscribe: (listener: () => void) => () => void
+}
+
+export function createAnchoredThreadRail(opts: {
+  readonly filePath: () => string
+  readonly threads: () => ReadonlyArray<AnchoredThread>
+}): AnchoredThreadRailController {
+  let focusedId: string | null = null
+  const listeners = new Set<() => void>()
+
+  const filePath = (): string => opts.filePath()
+
+  const visibleThreads = (): ReadonlyArray<AnchoredThread> => {
+    const activeFile = opts.filePath()
+    return opts.threads()
+      .filter(thread => validThreadForFile(thread, activeFile))
+      .slice()
+      .sort(compareThreads)
+  }
+
+  const focusedThread = (): AnchoredThread | null => {
+    if (focusedId === null) return null
+    return visibleThreads().find(thread => thread.id === focusedId) ?? null
+  }
+
+  const focusedThreadId = (): string | null => focusedThread()?.id ?? null
+
+  const emit = (): void => {
+    for (const listener of listeners) listener()
+  }
+
+  const focusThread = (id: string): boolean => {
+    const next = visibleThreads().find(thread => thread.id === id)
+    if (next === undefined) return false
+    if (focusedId === next.id) return true
+    focusedId = next.id
+    emit()
+    return true
+  }
+
+  const clearFocus = (): void => {
+    if (focusedId === null) return
+    focusedId = null
+    emit()
+  }
+
+  const threadsForLine = (line: number): ReadonlyArray<AnchoredThread> => {
+    if (!Number.isSafeInteger(line) || line < 1) return []
+    return visibleThreads().filter(thread => anchorContainsLine(thread.anchor, line))
+  }
+
+  const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  return {
+    filePath,
+    visibleThreads,
+    threadsForLine,
+    focusedThreadId,
+    focusedThread,
+    focusThread,
+    clearFocus,
+    subscribe,
+  }
+}
+
+function compareThreads(a: AnchoredThread, b: AnchoredThread): number {
+  if (a.created_ms !== b.created_ms) return b.created_ms - a.created_ms
+  return a.id.localeCompare(b.id)
+}
+
+function validThreadForFile(thread: AnchoredThread, filePath: string): boolean {
+  if (thread.id.trim() === '') return false
+  if (thread.author_keeper_id.trim() === '') return false
+  if (!Number.isFinite(thread.created_ms)) return false
+  if (!Number.isSafeInteger(thread.reply_count) || thread.reply_count < 0) return false
+  return validAnchorForFile(thread.anchor, filePath)
+}
+
+function validAnchorForFile(anchor: ThreadAnchor, filePath: string): boolean {
+  if (anchor.file_path !== filePath) return false
+  const start = anchor.line_start
+  const end = anchor.line_end
+  if (start === null && end === null) return true
+  if (start === null || end === null) return false
+  return Number.isSafeInteger(start) && Number.isSafeInteger(end) && start >= 1 && end >= start
+}
+
+function anchorContainsLine(anchor: ThreadAnchor, line: number): boolean {
+  if (anchor.line_start === null || anchor.line_end === null) return false
+  return line >= anchor.line_start && line <= anchor.line_end
+}

--- a/dashboard/src/components/ide/anchored-thread-rail-store.test.ts
+++ b/dashboard/src/components/ide/anchored-thread-rail-store.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createAnchoredThreadRailStore,
+  type AnchoredThread,
+} from './anchored-thread-rail-store'
+
+const file = 'runtime/cascade/router.ts'
+
+const thread = (patch: Partial<AnchoredThread>): AnchoredThread => ({
+  id: 'thread-1',
+  kind: 'flag',
+  author_keeper_id: 'nick0cave',
+  anchor: { file_path: file, line_start: 10, line_end: 12, symbol_hint: 'fn:resolveCascade' },
+  body: 'Check this branch before merge.',
+  created_ms: 1000,
+  resolved: false,
+  reply_count: 1,
+  ...patch,
+})
+
+describe('createAnchoredThreadRailStore', () => {
+  it('publishes visible thread snapshots after seed and addThread', () => {
+    const s = createAnchoredThreadRailStore(file)
+    s.seed([
+      thread({ id: 'older', created_ms: 1000 }),
+      thread({ id: 'hidden', anchor: { file_path: 'other.ts', line_start: 1, line_end: 1 } }),
+    ])
+    const before = s.visibleThreads()
+
+    s.addThread(thread({ id: 'newer', created_ms: 2000, author_keeper_id: 'sangsu' }))
+
+    expect(before.map(item => item.id)).toEqual(['older'])
+    expect(s.visibleThreads().map(item => item.id)).toEqual(['newer', 'older'])
+    expect(s.knownAuthors()).toEqual(['nick0cave', 'sangsu'])
+  })
+
+  it('subscribers fire for seed, resolve, and focus changes', () => {
+    const s = createAnchoredThreadRailStore(file)
+    let calls = 0
+    const unsubscribe = s.subscribe(() => {
+      calls += 1
+    })
+
+    s.seed([thread({ id: 'a' })])
+    s.resolveThread('a')
+    s.focusThread('a')
+    s.clearFocus()
+    unsubscribe()
+    s.addThread(thread({ id: 'b', created_ms: 2000 }))
+
+    expect(calls).toBe(4)
+    expect(s.visibleThreads()[0]).toMatchObject({ id: 'b' })
+  })
+
+  it('exposes line lookup and drops focus when reset switches files', () => {
+    const s = createAnchoredThreadRailStore(file)
+    s.seed([
+      thread({ id: 'a', anchor: { file_path: file, line_start: 10, line_end: 12 } }),
+      thread({ id: 'b', anchor: { file_path: file, line_start: null, line_end: null } }),
+    ])
+
+    expect(s.threadsForLine(11).map(item => item.id)).toEqual(['a'])
+    expect(s.focusThread('a')).toBe(true)
+    s.reset('runtime/fsm/lifeline.ts')
+    expect(s.filePath()).toBe('runtime/fsm/lifeline.ts')
+    expect(s.focusedThreadId()).toBe(null)
+    expect(s.visibleThreads()).toEqual([])
+  })
+})

--- a/dashboard/src/components/ide/anchored-thread-rail-store.ts
+++ b/dashboard/src/components/ide/anchored-thread-rail-store.ts
@@ -1,0 +1,125 @@
+/**
+ * anchored-thread-rail-store - Preact signal adapter for RFC 0021.
+ *
+ * The headless controller owns file scoping, line lookup, and focus events.
+ * This adapter publishes immutable snapshots for the IDE conversation rail.
+ */
+
+import { signal } from '@preact/signals'
+import {
+  createAnchoredThreadRail,
+  type AnchoredThread,
+} from '../../../design-system/headless-core/anchored-thread-rail'
+
+export type { AnchoredThread, ThreadAnchor, ThreadKind } from '../../../design-system/headless-core/anchored-thread-rail'
+
+export interface AnchoredThreadRailStore {
+  readonly filePath: () => string
+  readonly seed: (threads: ReadonlyArray<AnchoredThread>) => void
+  readonly addThread: (thread: AnchoredThread) => void
+  readonly resolveThread: (id: string, resolved?: boolean) => boolean
+  readonly visibleThreads: () => ReadonlyArray<AnchoredThread>
+  readonly threadsForLine: (line: number) => ReadonlyArray<AnchoredThread>
+  readonly focusedThreadId: () => string | null
+  readonly focusThread: (id: string) => boolean
+  readonly clearFocus: () => void
+  readonly knownAuthors: () => ReadonlyArray<string>
+  readonly reset: (filePath?: string) => void
+  readonly subscribe: (listener: () => void) => () => void
+}
+
+export function createAnchoredThreadRailStore(
+  initialFilePath: string,
+): AnchoredThreadRailStore {
+  const activeFilePath = signal(initialFilePath)
+  const allThreads = signal<ReadonlyArray<AnchoredThread>>([])
+  const visibleThreadsSignal = signal<ReadonlyArray<AnchoredThread>>([])
+  const focusedThreadIdSignal = signal<string | null>(null)
+  const authorsSignal = signal<ReadonlyArray<string>>([])
+
+  const controller = createAnchoredThreadRail({
+    filePath: () => activeFilePath.value,
+    threads: () => allThreads.value,
+  })
+
+  const publish = (): void => {
+    const visible = controller.visibleThreads()
+    visibleThreadsSignal.value = visible
+    focusedThreadIdSignal.value = controller.focusedThreadId()
+    authorsSignal.value = sortedAuthors(visible)
+  }
+
+  controller.subscribe(publish)
+
+  const seed = (threads: ReadonlyArray<AnchoredThread>): void => {
+    const hadFocus = focusedThreadIdSignal.value !== null
+    allThreads.value = [...threads]
+    if (hadFocus && controller.focusedThreadId() === null) {
+      controller.clearFocus()
+      return
+    }
+    publish()
+  }
+
+  const addThread = (thread: AnchoredThread): void => {
+    allThreads.value = [...allThreads.value, thread]
+    publish()
+  }
+
+  const resolveThread = (id: string, resolved = true): boolean => {
+    let found = false
+    allThreads.value = allThreads.value.map(thread => {
+      if (thread.id !== id) return thread
+      found = true
+      return { ...thread, resolved }
+    })
+    if (found) publish()
+    return found
+  }
+
+  const focusThread = (id: string): boolean => controller.focusThread(id)
+
+  const clearFocus = (): void => {
+    controller.clearFocus()
+  }
+
+  const reset = (filePath?: string): void => {
+    if (filePath !== undefined) activeFilePath.value = filePath
+    allThreads.value = []
+    if (focusedThreadIdSignal.value !== null) controller.clearFocus()
+    else publish()
+  }
+
+  const subscribe = (listener: () => void): (() => void) => {
+    let sawInitialSnapshot = false
+    const unsubscribe = visibleThreadsSignal.subscribe(() => {
+      if (!sawInitialSnapshot) {
+        sawInitialSnapshot = true
+        return
+      }
+      listener()
+    })
+    return unsubscribe
+  }
+
+  return {
+    filePath: () => activeFilePath.value,
+    seed,
+    addThread,
+    resolveThread,
+    visibleThreads: () => visibleThreadsSignal.value,
+    threadsForLine: controller.threadsForLine,
+    focusedThreadId: () => focusedThreadIdSignal.value,
+    focusThread,
+    clearFocus,
+    knownAuthors: () => authorsSignal.value,
+    reset,
+    subscribe,
+  }
+}
+
+function sortedAuthors(threads: ReadonlyArray<AnchoredThread>): ReadonlyArray<string> {
+  const authors = new Set<string>()
+  for (const thread of threads) authors.add(thread.author_keeper_id)
+  return [...authors].sort()
+}

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.a11y.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { IdeConversationRailMock } from './ide-conversation-rail-mock'
+
+describe('IdeConversationRailMock a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders the anchored thread rail mock accessibly', async () => {
+    render(html`<${IdeConversationRailMock} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { IdeConversationRailMock } from './ide-conversation-rail-mock'
+
+describe('IdeConversationRailMock', () => {
+  it('renders the RFC 0021 anchored thread rail mock', () => {
+    const container = document.createElement('div')
+    render(h(IdeConversationRailMock, {}), container)
+
+    const region = container.querySelector('[role="region"]')
+    expect(region?.getAttribute('aria-label')).toBe('CONVERSATION (RFC 0021 anchored thread rail mock)')
+    expect(container.textContent).toContain('CONVERSATION')
+    expect(container.textContent).toContain('5')
+    expect(container.textContent).toContain('router.ts:35')
+    expect(container.textContent).toContain('2 related')
+    expect(container.textContent).toContain('FLAG')
+    expect(container.textContent).toContain('nick0cave')
+  })
+
+  it('focuses a thread card when clicked', async () => {
+    const container = document.createElement('div')
+    await act(async () => {
+      render(h(IdeConversationRailMock, {}), container)
+    })
+
+    const button = container.querySelector('button')
+    expect(button?.getAttribute('aria-current')).toBe(null)
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(button?.getAttribute('aria-current')).toBe('true')
+  })
+})

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -1,21 +1,13 @@
 import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
+import {
+  createAnchoredThreadRailStore,
+  type AnchoredThread,
+  type ThreadKind,
+} from './anchored-thread-rail-store'
 
-// PR-2 placeholder for the CONVERSATION rail. The real rail (anchored
-// to lines, controller-mediated scroll, RFC 0021 contract) lands in
-// Phase 2 PR-6.
-
-type ThreadKind = 'flag' | 'question' | 'approve' | 'note' | 'suggest'
-
-interface MockThread {
-  readonly kind: ThreadKind
-  readonly author: string
-  readonly anchor: string
-  readonly hint: string
-  readonly time: string
-  readonly body: string
-  readonly replies: number | null
-  readonly resolved: boolean
-}
+const EDITOR_FILE = 'runtime/cascade/router.ts'
 
 const KIND_LABEL: Record<ThreadKind, string> = {
   flag: 'FLAG',
@@ -33,64 +25,77 @@ const KIND_TOKEN: Record<ThreadKind, string> = {
   suggest: 'var(--color-status-warn, var(--warn))',
 }
 
-const MOCK_THREADS: ReadonlyArray<MockThread> = [
+const MOCK_THREADS: ReadonlyArray<AnchoredThread> = [
   {
+    id: 'thread-schema-tools',
     kind: 'flag',
-    author: 'nick0cave',
-    anchor: 'router.ts:34',
-    hint: 'if:moonshot-tool-choice',
-    time: '01:41:18',
+    author_keeper_id: 'nick0cave',
+    anchor: { file_path: EDITOR_FILE, line_start: 34, line_end: 35, symbol_hint: 'if:moonshot-tool-choice' },
+    created_ms: Date.UTC(2026, 4, 2, 1, 41, 18),
     body: "This is exactly the schema error we're seeing in prod — confirmed 3× on kimi_cli with non-empty tools[].",
-    replies: 2,
+    reply_count: 2,
     resolved: false,
   },
   {
+    id: 'thread-normalize-tool-choice',
     kind: 'question',
-    author: 'operator',
-    anchor: 'router.ts:26',
-    hint: 'fn:resolveCascade',
-    time: '01:39:02',
+    author_keeper_id: 'operator',
+    anchor: { file_path: EDITOR_FILE, line_start: 26, line_end: 26, symbol_hint: 'fn:resolveCascade' },
+    created_ms: Date.UTC(2026, 4, 2, 1, 39, 2),
     body: 'Should normalizeTools also handle tool_choice=none? feels like an edge case.',
-    replies: 1,
+    reply_count: 1,
     resolved: false,
   },
   {
+    id: 'thread-budget-approve',
     kind: 'approve',
-    author: 'operator',
-    anchor: 'router.ts:60',
-    hint: 'fn:nextStep',
-    time: '01:22:41',
+    author_keeper_id: 'operator',
+    anchor: { file_path: EDITOR_FILE, line_start: 60, line_end: 60, symbol_hint: 'fn:nextStep' },
+    created_ms: Date.UTC(2026, 4, 2, 1, 22, 41),
     body: 'Budget guard reads well. Ship it when tests pass.',
-    replies: null,
+    reply_count: 0,
     resolved: false,
   },
   {
+    id: 'thread-telemetry-token',
     kind: 'note',
-    author: 'operator',
-    anchor: 'router.ts:35',
-    hint: 'token:log.warn',
-    time: '01:18:04',
+    author_keeper_id: 'operator',
+    anchor: { file_path: EDITOR_FILE, line_start: 35, line_end: 35, symbol_hint: 'token:log.warn' },
+    created_ms: Date.UTC(2026, 4, 2, 1, 18, 4),
     body: 'telemetry event name needs to match the lifeline schema — will rename later.',
-    replies: null,
+    reply_count: 0,
     resolved: false,
   },
   {
+    id: 'thread-rest-helper',
     kind: 'suggest',
-    author: 'masc-improver',
-    anchor: 'router.ts:16',
-    hint: 'fn:normalizeTools',
-    time: '01:14:52',
+    author_keeper_id: 'masc-improver',
+    anchor: { file_path: EDITOR_FILE, line_start: 16, line_end: 16, symbol_hint: 'fn:normalizeTools' },
+    created_ms: Date.UTC(2026, 4, 2, 1, 14, 52),
     body: 'Could you collapse the rest-spread into a small helper? Same pattern appears in provider.ts.',
-    replies: 3,
+    reply_count: 3,
     resolved: false,
   },
 ]
 
 export function IdeConversationRailMock() {
+  const railStore = useMemo(() => {
+    const store = createAnchoredThreadRailStore(EDITOR_FILE)
+    store.seed(MOCK_THREADS)
+    return store
+  }, [])
+  const [, forceRender] = useState(0)
+
+  useEffect(() => railStore.subscribe(() => forceRender(tick => tick + 1)), [railStore])
+
+  const threads = railStore.visibleThreads()
+  const focusedId = railStore.focusedThreadId()
+  const relatedLine35 = railStore.threadsForLine(35)
+
   return html`
     <div
       role="region"
-      aria-label="CONVERSATION (mock — PR-6 replaces with RFC 0021 anchored thread rail)"
+      aria-label="CONVERSATION (RFC 0021 anchored thread rail mock)"
       style=${{
         display: 'flex',
         flexDirection: 'column',
@@ -99,7 +104,7 @@ export function IdeConversationRailMock() {
         minHeight: 0,
       }}
     >
-      <header
+      <div
         style=${{
           display: 'flex',
           justifyContent: 'space-between',
@@ -110,8 +115,21 @@ export function IdeConversationRailMock() {
         }}
       >
         <span>CONVERSATION</span>
-        <span>${MOCK_THREADS.length}</span>
-      </header>
+        <span>${threads.length}</span>
+      </div>
+      <div
+        style=${{
+          display: 'flex',
+          gap: 'var(--sp-2)',
+          padding: 'var(--sp-2) var(--sp-3) 0',
+          color: 'var(--color-fg-muted)',
+          fontSize: 'var(--fs-11)',
+        }}
+      >
+        <span>router.ts:35</span>
+        <span>·</span>
+        <span>${relatedLine35.length} related</span>
+      </div>
       <ol
         style=${{
           listStyle: 'none',
@@ -123,41 +141,74 @@ export function IdeConversationRailMock() {
           overflow: 'auto',
         }}
       >
-        ${MOCK_THREADS.map(thread => MockThreadCard(thread))}
+        ${threads.map(thread => MockThreadCard(
+          thread,
+          focusedId === thread.id,
+          () => railStore.focusThread(thread.id),
+        ))}
       </ol>
     </div>
   `
 }
 
-function MockThreadCard(thread: MockThread) {
+function MockThreadCard(thread: AnchoredThread, focused: boolean, onFocus: () => void) {
   const kindColor = KIND_TOKEN[thread.kind]
+  const keeperSlot = keeperHueIndex(thread.author_keeper_id)
+  const keeperColor = `var(--color-keeper-${keeperSlot}-glow, var(--k-${keeperSlot}))`
   return html`
     <li
       style=${{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--sp-1)',
-        padding: 'var(--sp-2)',
-        background: 'var(--color-bg-elevated)',
-        border: '1px solid var(--color-border-default)',
-        borderLeft: `2px solid ${kindColor}`,
-        borderRadius: 'var(--r-2)',
+        display: 'block',
       }}
     >
-      <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--sp-2)' }}>
-        <span style=${{ font: 'var(--fs-11)', color: kindColor, letterSpacing: '0.05em' }}>${KIND_LABEL[thread.kind]}</span>
-        <span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${thread.author}</span>
-        <span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${thread.time}</span>
-      </div>
-      <div style=${{ display: 'flex', gap: 'var(--sp-2)', font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
-        <span>${thread.anchor}</span>
-        <span>·</span>
-        <span>${thread.hint}</span>
-      </div>
-      <p style=${{ font: 'var(--type-body)', color: 'var(--color-fg-secondary)', margin: 0 }}>${thread.body}</p>
-      <div style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
-        ${thread.replies !== null ? `${thread.replies} replies · ` : ''}${thread.resolved ? 'resolved' : 'open'}
-      </div>
+      <button
+        type="button"
+        aria-current=${focused ? 'true' : undefined}
+        onClick=${onFocus}
+        style=${{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--sp-1)',
+          width: '100%',
+          padding: 'var(--sp-2)',
+          background: focused ? 'var(--color-bg-muted)' : 'var(--color-bg-elevated)',
+          border: '1px solid var(--color-border-default)',
+          borderLeft: `2px solid ${keeperColor}`,
+          borderRadius: 'var(--r-2)',
+          color: 'inherit',
+          textAlign: 'left',
+          cursor: 'pointer',
+        }}
+      >
+        <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--sp-2)' }}>
+          <span style=${{ fontSize: 'var(--fs-11)', color: kindColor, letterSpacing: '0.05em' }}>${KIND_LABEL[thread.kind]}</span>
+          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${thread.author_keeper_id}</span>
+          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${formatThreadTime(thread.created_ms)}</span>
+        </div>
+        <div style=${{ display: 'flex', gap: 'var(--sp-2)', fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
+          <span>${anchorLabel(thread)}</span>
+          ${thread.anchor.symbol_hint
+            ? html`<span>·</span><span>${thread.anchor.symbol_hint}</span>`
+            : null}
+        </div>
+        <p style=${{ font: 'var(--type-body)', color: 'var(--color-fg-secondary)', margin: 0 }}>${thread.body}</p>
+        <div style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
+          ${thread.reply_count > 0 ? `${thread.reply_count} replies · ` : ''}${thread.resolved ? 'resolved' : 'open'}
+        </div>
+      </button>
     </li>
   `
+}
+
+function anchorLabel(thread: AnchoredThread): string {
+  const fileName = thread.anchor.file_path.split('/').at(-1) ?? thread.anchor.file_path
+  const start = thread.anchor.line_start
+  const end = thread.anchor.line_end
+  if (start === null || end === null) return fileName
+  if (start === end) return `${fileName}:${start}`
+  return `${fileName}:${start}-${end}`
+}
+
+function formatThreadTime(ms: number): string {
+  return new Date(ms).toISOString().slice(11, 19)
 }


### PR DESCRIPTION
Summary:
- add RFC 0021 anchored thread rail headless controller for file scoping, line lookup, focus, and malformed input filtering
- add dashboard signal store adapter and migrate the CONVERSATION mock rail to seeded anchored thread data
- add unit and jest-axe coverage plus design-system changelog entry

Operator impact:
- moves the IDE conversation rail off hardcoded string cards and onto the same anchored-thread contract future live review/comment events can use
- gives the editor/rail handoff a concrete focus and line lookup boundary without coupling DOM scroll behavior into the rail

Verification:
- pnpm vitest run --config vitest.config.ts design-system/headless-core/anchored-thread-rail.test.ts src/components/ide/anchored-thread-rail-store.test.ts src/components/ide/ide-conversation-rail-mock.test.ts src/components/ide/ide-conversation-rail-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/ide/anchored-thread-rail-store.ts src/components/ide/anchored-thread-rail-store.test.ts src/components/ide/ide-conversation-rail-mock.ts src/components/ide/ide-conversation-rail-mock.test.ts src/components/ide/ide-conversation-rail-mock.a11y.test.ts
- git diff --check

Review focus:
- anchored thread input validation and focus semantics
- whether the mock rail should keep the line-35 related strip or wait for editor cursor wiring