### PR TITLE
feat(dashboard): add run activity store

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -55,6 +55,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `design-system/headless-core/anchored-thread-rail.ts` implements RFC 0021's current-file thread scoping, line lookup, and focus coordination.
   - `src/components/ide/anchored-thread-rail-store.ts` publishes dashboard snapshots for the CONVERSATION rail; the rail mock now consumes the store instead of hardcoded card fields.
 
+- **Run activity store substrate**
+  - `src/components/ide/run-activity-store.ts` adds a typed ACTIVITY THIS RUN event store with run scoping, newest-first ordering, keeper grouping, and capped visible history.
+  - `src/components/ide/ide-activity-mock.ts` now consumes the store instead of embedding activity ordering and keeper hue mapping directly in the renderer.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/src/components/ide/ide-activity-mock.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.a11y.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { IdeActivityMock } from './ide-activity-mock'
+
+describe('IdeActivityMock a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders the run activity pane accessibly', async () => {
+    render(html`<${IdeActivityMock} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { IdeActivityMock } from './ide-activity-mock'
+
+describe('IdeActivityMock', () => {
+  it('renders the run activity store backed pane', () => {
+    const container = document.createElement('div')
+    render(h(IdeActivityMock, {}), container)
+
+    const region = container.querySelector('[role="region"]')
+    expect(region?.getAttribute('aria-label')).toBe('ACTIVITY THIS RUN (run activity store mock)')
+    expect(container.textContent).toContain('13 events · 3 keepers')
+    expect(container.textContent).toContain('nick0cave')
+    expect(container.textContent).toContain('flagged')
+    expect(container.textContent).toContain('router.ts:34')
+  })
+})

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -1,39 +1,46 @@
 import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
+import {
+  createRunActivityStore,
+  type RunActivityEvent,
+} from './run-activity-store'
 
-// PR-2 placeholder for the ACTIVITY THIS RUN pane. The real activity
-// stream (sse-store.ts pattern, virtual-list, sustained 16-keeper
-// bench) lands in Phase 2 PR-6 alongside the conversation rail.
+const RUN_ID = 'run-47'
 
-interface MockActivity {
-  readonly time: string
-  readonly keeper: string
-  readonly verb: 'flagged' | 'edited' | 'commented on' | 'approved' | 'noted' | 'suggested on' | 'committed' | 'refactored' | 'asked on'
-  readonly target: string
-  readonly hue: number
-  readonly hint?: string
-}
-
-const MOCK_ACTIVITY: ReadonlyArray<MockActivity> = [
-  { time: '01:41:18', keeper: 'nick0cave', hue: 1, verb: 'flagged', target: 'router.ts:34', hint: 'if:moonshot-tool-choice · blocker' },
-  { time: '01:40:02', keeper: 'nick0cave', hue: 1, verb: 'edited', target: 'router.ts:35', hint: '+ next.tool_choice = "auto"' },
-  { time: '01:39:02', keeper: 'operator', hue: 9, verb: 'commented on', target: 'router.ts:26', hint: 'question · resolveCascade' },
-  { time: '01:37:11', keeper: 'masc-improver', hue: 3, verb: 'edited', target: 'registry.ts:10', hint: '+8 -2 · budgetFor' },
-  { time: '01:35:22', keeper: 'masc-improver', hue: 3, verb: 'committed', target: 'improver/wt-47', hint: 'fix: init budget map lazily' },
-  { time: '01:32:08', keeper: 'masc-improver', hue: 3, verb: 'refactored', target: 'registry.ts', hint: 'extracted budgetFor' },
-  { time: '01:28:15', keeper: 'operator', hue: 9, verb: 'commented on', target: 'registry.ts:10', hint: 'note · log.warn naming' },
-  { time: '01:22:41', keeper: 'operator', hue: 9, verb: 'approved', target: 'router.ts:60', hint: 'nextStep · budget guard' },
-  { time: '01:18:04', keeper: 'operator', hue: 9, verb: 'noted', target: 'router.ts:35', hint: 'flag · race on Map init' },
-  { time: '01:14:52', keeper: 'masc-improver', hue: 3, verb: 'suggested on', target: 'router.ts:16', hint: 'suggest · extract helper' },
-  { time: '01:09:11', keeper: 'nick0cave', hue: 1, verb: 'edited', target: 'router.ts:34', hint: '+1 -0 · tool_choice guard' },
-  { time: '01:02:11', keeper: 'operator', hue: 9, verb: 'flagged', target: 'registry.ts:10', hint: 'race condition' },
-  { time: '00:58:32', keeper: 'operator', hue: 9, verb: 'asked on', target: 'router.ts:26', hint: 'question · resolveCascade' },
+const MOCK_ACTIVITY: ReadonlyArray<RunActivityEvent> = [
+  { id: 'a13', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 41, 18), keeper_id: 'nick0cave', verb: 'flagged', target: 'router.ts:34', detail: 'if:moonshot-tool-choice · blocker' },
+  { id: 'a12', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 40, 2), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:35', detail: '+ next.tool_choice = "auto"' },
+  { id: 'a11', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 39, 2), keeper_id: 'operator', verb: 'commented on', target: 'router.ts:26', detail: 'question · resolveCascade' },
+  { id: 'a10', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 37, 11), keeper_id: 'masc-improver', verb: 'edited', target: 'registry.ts:10', detail: '+8 -2 · budgetFor' },
+  { id: 'a09', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 35, 22), keeper_id: 'masc-improver', verb: 'committed', target: 'improver/wt-47', detail: 'fix: init budget map lazily' },
+  { id: 'a08', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 32, 8), keeper_id: 'masc-improver', verb: 'refactored', target: 'registry.ts', detail: 'extracted budgetFor' },
+  { id: 'a07', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 28, 15), keeper_id: 'operator', verb: 'commented on', target: 'registry.ts:10', detail: 'note · log.warn naming' },
+  { id: 'a06', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 22, 41), keeper_id: 'operator', verb: 'approved', target: 'router.ts:60', detail: 'nextStep · budget guard' },
+  { id: 'a05', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 18, 4), keeper_id: 'operator', verb: 'noted', target: 'router.ts:35', detail: 'flag · race on Map init' },
+  { id: 'a04', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 14, 52), keeper_id: 'masc-improver', verb: 'suggested on', target: 'router.ts:16', detail: 'suggest · extract helper' },
+  { id: 'a03', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 9, 11), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:34', detail: '+1 -0 · tool_choice guard' },
+  { id: 'a02', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 2, 11), keeper_id: 'operator', verb: 'flagged', target: 'registry.ts:10', detail: 'race condition' },
+  { id: 'a01', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 0, 58, 32), keeper_id: 'operator', verb: 'asked on', target: 'router.ts:26', detail: 'question · resolveCascade' },
 ]
 
 export function IdeActivityMock() {
+  const activityStore = useMemo(() => {
+    const store = createRunActivityStore(RUN_ID)
+    store.seed(MOCK_ACTIVITY)
+    return store
+  }, [])
+  const [, forceRender] = useState(0)
+
+  useEffect(() => activityStore.subscribe(() => forceRender(tick => tick + 1)), [activityStore])
+
+  const events = activityStore.events()
+  const keepers = activityStore.knownKeepers()
+
   return html`
     <div
       role="region"
-      aria-label="ACTIVITY THIS RUN (mock — PR-6 replaces with sse-store-backed stream)"
+      aria-label="ACTIVITY THIS RUN (run activity store mock)"
       style=${{
         display: 'flex',
         flexDirection: 'column',
@@ -43,7 +50,7 @@ export function IdeActivityMock() {
         minHeight: 0,
       }}
     >
-      <header
+      <div
         style=${{
           display: 'flex',
           justifyContent: 'space-between',
@@ -54,8 +61,8 @@ export function IdeActivityMock() {
         }}
       >
         <span>ACTIVITY</span>
-        <span>THIS RUN</span>
-      </header>
+        <span>${events.length} events · ${keepers.length} keepers</span>
+      </div>
       <ol
         style=${{
           listStyle: 'none',
@@ -67,14 +74,15 @@ export function IdeActivityMock() {
           overflow: 'auto',
         }}
       >
-        ${MOCK_ACTIVITY.map(item => MockActivityRow(item))}
+        ${events.map(item => MockActivityRow(item))}
       </ol>
     </div>
   `
 }
 
-function MockActivityRow(item: MockActivity) {
-  const dot = `var(--color-keeper-${item.hue}-glow, var(--k-${item.hue}))`
+function MockActivityRow(item: RunActivityEvent) {
+  const hue = keeperHueIndex(item.keeper_id)
+  const dot = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
   return html`
     <li
       style=${{
@@ -87,14 +95,18 @@ function MockActivityRow(item: MockActivity) {
         color: 'var(--color-fg-secondary)',
       }}
     >
-      <span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${item.time}</span>
+      <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${formatActivityTime(item.timestamp_ms)}</span>
       <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, alignSelf: 'center' }} />
       <div style=${{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-        <span style=${{ font: 'var(--fs-11)' }}>
-          <strong style=${{ color: dot }}>${item.keeper}</strong> ${' '}${item.verb}${' '}<span style=${{ color: 'var(--color-fg-muted)' }}>${item.target}</span>
+        <span style=${{ fontSize: 'var(--fs-11)' }}>
+          <strong style=${{ color: dot }}>${item.keeper_id}</strong> ${' '}${item.verb}${' '}<span style=${{ color: 'var(--color-fg-muted)' }}>${item.target}</span>
         </span>
-        ${item.hint ? html`<span style=${{ font: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${item.hint}</span>` : null}
+        ${item.detail ? html`<span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${item.detail}</span>` : null}
       </div>
     </li>
   `
+}
+
+function formatActivityTime(ms: number): string {
+  return new Date(ms).toISOString().slice(11, 19)
 }

--- a/dashboard/src/components/ide/run-activity-store.test.ts
+++ b/dashboard/src/components/ide/run-activity-store.test.ts
@@ -34,8 +34,23 @@ describe('createRunActivityStore', () => {
     const s = createRunActivityStore(runId)
     expect(s.append(event({ id: '' }))).toBe(false)
     expect(s.append(event({ keeper_id: '' }))).toBe(false)
+    expect(s.append({ ...event({}), keeper_id: null })).toBe(false)
+    expect(s.append({ ...event({}), verb: 'deleted' })).toBe(false)
     expect(s.append(event({ timestamp_ms: Number.NaN }))).toBe(false)
     expect(s.append(event({ id: 'ok' }))).toBe(true)
+    expect(s.events().map(item => item.id)).toEqual(['ok'])
+  })
+
+  it('filters malformed seeded public input', () => {
+    const s = createRunActivityStore(runId)
+    s.seed([
+      null,
+      event({ id: 'ok' }),
+      { ...event({ id: 'missing-keeper' }), keeper_id: null },
+      { ...event({ id: 'bad-verb' }), verb: 'deleted' },
+      { ...event({ id: 'bad-detail' }), detail: { lines: 3 } },
+    ])
+
     expect(s.events().map(item => item.id)).toEqual(['ok'])
   })
 
@@ -66,5 +81,25 @@ describe('createRunActivityStore', () => {
     ])
 
     expect(s.events().map(item => item.id)).toEqual(['c', 'b'])
+  })
+
+  it('bounds appended active-run history in sorted order', () => {
+    const s = createRunActivityStore(runId, { maxEvents: 2 })
+    expect(s.append(event({ id: 'a', timestamp_ms: 1 }))).toBe(true)
+    expect(s.append(event({ id: 'c', timestamp_ms: 3 }))).toBe(true)
+    expect(s.append(event({ id: 'b', timestamp_ms: 2 }))).toBe(true)
+
+    expect(s.events().map(item => item.id)).toEqual(['c', 'b'])
+  })
+
+  it('falls back to the default cap for invalid maxEvents values', () => {
+    const s = createRunActivityStore(runId, { maxEvents: -1 })
+    s.seed([
+      event({ id: 'a', timestamp_ms: 1 }),
+      event({ id: 'b', timestamp_ms: 2 }),
+      event({ id: 'c', timestamp_ms: 3 }),
+    ])
+
+    expect(s.events().map(item => item.id)).toEqual(['c', 'b', 'a'])
   })
 })

--- a/dashboard/src/components/ide/run-activity-store.test.ts
+++ b/dashboard/src/components/ide/run-activity-store.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createRunActivityStore,
+  type RunActivityEvent,
+} from './run-activity-store'
+
+const runId = 'run-47'
+
+const event = (patch: Partial<RunActivityEvent>): RunActivityEvent => ({
+  id: 'event-1',
+  run_id: runId,
+  keeper_id: 'nick0cave',
+  verb: 'edited',
+  target: 'router.ts:34',
+  timestamp_ms: 1000,
+  detail: '+1 -0',
+  ...patch,
+})
+
+describe('createRunActivityStore', () => {
+  it('scopes events to the active run and orders newest first', () => {
+    const s = createRunActivityStore(runId)
+    s.seed([
+      event({ id: 'older', timestamp_ms: 1000 }),
+      event({ id: 'newer', timestamp_ms: 2000, keeper_id: 'sangsu' }),
+      event({ id: 'other-run', run_id: 'run-99', timestamp_ms: 3000 }),
+    ])
+
+    expect(s.events().map(item => item.id)).toEqual(['newer', 'older'])
+    expect(s.knownKeepers()).toEqual(['nick0cave', 'sangsu'])
+  })
+
+  it('rejects malformed appended public input', () => {
+    const s = createRunActivityStore(runId)
+    expect(s.append(event({ id: '' }))).toBe(false)
+    expect(s.append(event({ keeper_id: '' }))).toBe(false)
+    expect(s.append(event({ timestamp_ms: Number.NaN }))).toBe(false)
+    expect(s.append(event({ id: 'ok' }))).toBe(true)
+    expect(s.events().map(item => item.id)).toEqual(['ok'])
+  })
+
+  it('notifies subscribers for seed, append, and reset', () => {
+    const s = createRunActivityStore(runId)
+    let calls = 0
+    const unsubscribe = s.subscribe(() => {
+      calls += 1
+    })
+
+    s.seed([event({ id: 'a' })])
+    s.append(event({ id: 'b', keeper_id: 'sangsu' }))
+    s.reset('run-48')
+    unsubscribe()
+    s.append(event({ id: 'c', run_id: 'run-48' }))
+
+    expect(calls).toBe(3)
+    expect(s.runId()).toBe('run-48')
+    expect(s.eventsForKeeper('sangsu')).toEqual([])
+  })
+
+  it('caps visible history without losing deterministic order', () => {
+    const s = createRunActivityStore(runId, { maxEvents: 2 })
+    s.seed([
+      event({ id: 'a', timestamp_ms: 1 }),
+      event({ id: 'b', timestamp_ms: 2 }),
+      event({ id: 'c', timestamp_ms: 3 }),
+    ])
+
+    expect(s.events().map(item => item.id)).toEqual(['c', 'b'])
+  })
+})

--- a/dashboard/src/components/ide/run-activity-store.ts
+++ b/dashboard/src/components/ide/run-activity-store.ts
@@ -1,0 +1,125 @@
+/**
+ * run-activity-store - typed snapshot store for the IDE ACTIVITY pane.
+ *
+ * The live SSE bridge can append the same event shape later; the current
+ * IDE mock seeds static events through this store so filtering, ordering, and
+ * keeper grouping are no longer embedded in the renderer.
+ */
+
+import { signal } from '@preact/signals'
+
+export type RunActivityVerb =
+  | 'flagged'
+  | 'edited'
+  | 'commented on'
+  | 'approved'
+  | 'noted'
+  | 'suggested on'
+  | 'committed'
+  | 'refactored'
+  | 'asked on'
+
+export interface RunActivityEvent {
+  readonly id: string
+  readonly run_id: string
+  readonly keeper_id: string
+  readonly verb: RunActivityVerb
+  readonly target: string
+  readonly timestamp_ms: number
+  readonly detail?: string
+}
+
+export interface RunActivityStore {
+  readonly runId: () => string
+  readonly seed: (events: ReadonlyArray<RunActivityEvent>) => void
+  readonly append: (event: RunActivityEvent) => boolean
+  readonly events: () => ReadonlyArray<RunActivityEvent>
+  readonly eventsForKeeper: (keeperId: string) => ReadonlyArray<RunActivityEvent>
+  readonly knownKeepers: () => ReadonlyArray<string>
+  readonly reset: (runId?: string) => void
+  readonly subscribe: (listener: () => void) => () => void
+}
+
+export function createRunActivityStore(
+  initialRunId: string,
+  opts: { readonly maxEvents?: number } = {},
+): RunActivityStore {
+  const maxEvents = opts.maxEvents ?? 200
+  const activeRunId = signal(initialRunId)
+  const allEvents = signal<ReadonlyArray<RunActivityEvent>>([])
+  const visibleEvents = signal<ReadonlyArray<RunActivityEvent>>([])
+  const keepers = signal<ReadonlyArray<string>>([])
+
+  const publish = (): void => {
+    const visible = allEvents.value
+      .filter(event => validEventForRun(event, activeRunId.value))
+      .slice()
+      .sort(compareEvents)
+      .slice(0, maxEvents)
+    visibleEvents.value = visible
+    keepers.value = sortedKeepers(visible)
+  }
+
+  const seed = (events: ReadonlyArray<RunActivityEvent>): void => {
+    allEvents.value = [...events]
+    publish()
+  }
+
+  const append = (event: RunActivityEvent): boolean => {
+    if (!validEventForRun(event, activeRunId.value)) return false
+    allEvents.value = [...allEvents.value, event]
+    publish()
+    return true
+  }
+
+  const eventsForKeeper = (keeperId: string): ReadonlyArray<RunActivityEvent> =>
+    visibleEvents.value.filter(event => event.keeper_id === keeperId)
+
+  const reset = (runId?: string): void => {
+    if (runId !== undefined) activeRunId.value = runId
+    allEvents.value = []
+    publish()
+  }
+
+  const subscribe = (listener: () => void): (() => void) => {
+    let sawInitialSnapshot = false
+    const unsubscribe = visibleEvents.subscribe(() => {
+      if (!sawInitialSnapshot) {
+        sawInitialSnapshot = true
+        return
+      }
+      listener()
+    })
+    return unsubscribe
+  }
+
+  return {
+    runId: () => activeRunId.value,
+    seed,
+    append,
+    events: () => visibleEvents.value,
+    eventsForKeeper,
+    knownKeepers: () => keepers.value,
+    reset,
+    subscribe,
+  }
+}
+
+function validEventForRun(event: RunActivityEvent, runId: string): boolean {
+  if (event.run_id !== runId) return false
+  if (event.id.trim() === '') return false
+  if (event.keeper_id.trim() === '') return false
+  if (event.target.trim() === '') return false
+  return Number.isFinite(event.timestamp_ms)
+}
+
+function compareEvents(a: RunActivityEvent, b: RunActivityEvent): number {
+  if (a.timestamp_ms !== b.timestamp_ms) return b.timestamp_ms - a.timestamp_ms
+  return a.id.localeCompare(b.id)
+}
+
+function sortedKeepers(events: ReadonlyArray<RunActivityEvent>): ReadonlyArray<string> {
+  const ids = new Set<string>()
+  for (const event of events) ids.add(event.keeper_id)
+  return [...ids].sort()
+}

--- a/dashboard/src/components/ide/run-activity-store.ts
+++ b/dashboard/src/components/ide/run-activity-store.ts
@@ -8,16 +8,21 @@
 
 import { signal } from '@preact/signals'
 
-export type RunActivityVerb =
-  | 'flagged'
-  | 'edited'
-  | 'commented on'
-  | 'approved'
-  | 'noted'
-  | 'suggested on'
-  | 'committed'
-  | 'refactored'
-  | 'asked on'
+const DEFAULT_MAX_EVENTS = 200
+const RUN_ACTIVITY_VERBS = [
+  'flagged',
+  'edited',
+  'commented on',
+  'approved',
+  'noted',
+  'suggested on',
+  'committed',
+  'refactored',
+  'asked on',
+] as const
+const RUN_ACTIVITY_VERB_SET = new Set<string>(RUN_ACTIVITY_VERBS)
+
+export type RunActivityVerb = (typeof RUN_ACTIVITY_VERBS)[number]
 
 export interface RunActivityEvent {
   readonly id: string
@@ -31,8 +36,8 @@ export interface RunActivityEvent {
 
 export interface RunActivityStore {
   readonly runId: () => string
-  readonly seed: (events: ReadonlyArray<RunActivityEvent>) => void
-  readonly append: (event: RunActivityEvent) => boolean
+  readonly seed: (events: ReadonlyArray<unknown>) => void
+  readonly append: (event: unknown) => boolean
   readonly events: () => ReadonlyArray<RunActivityEvent>
   readonly eventsForKeeper: (keeperId: string) => ReadonlyArray<RunActivityEvent>
   readonly knownKeepers: () => ReadonlyArray<string>
@@ -44,30 +49,30 @@ export function createRunActivityStore(
   initialRunId: string,
   opts: { readonly maxEvents?: number } = {},
 ): RunActivityStore {
-  const maxEvents = opts.maxEvents ?? 200
+  const maxEvents = normalizeMaxEvents(opts.maxEvents)
   const activeRunId = signal(initialRunId)
   const allEvents = signal<ReadonlyArray<RunActivityEvent>>([])
   const visibleEvents = signal<ReadonlyArray<RunActivityEvent>>([])
   const keepers = signal<ReadonlyArray<string>>([])
 
   const publish = (): void => {
-    const visible = allEvents.value
-      .filter(event => validEventForRun(event, activeRunId.value))
-      .slice()
-      .sort(compareEvents)
-      .slice(0, maxEvents)
-    visibleEvents.value = visible
-    keepers.value = sortedKeepers(visible)
+    visibleEvents.value = allEvents.value
+    keepers.value = sortedKeepers(allEvents.value)
   }
 
-  const seed = (events: ReadonlyArray<RunActivityEvent>): void => {
-    allEvents.value = [...events]
+  const seed = (events: ReadonlyArray<unknown>): void => {
+    allEvents.value = events
+      .filter((event): event is RunActivityEvent =>
+        validEventForRun(event, activeRunId.value),
+      )
+      .sort(compareEvents)
+      .slice(0, maxEvents)
     publish()
   }
 
-  const append = (event: RunActivityEvent): boolean => {
+  const append = (event: unknown): boolean => {
     if (!validEventForRun(event, activeRunId.value)) return false
-    allEvents.value = [...allEvents.value, event]
+    allEvents.value = insertEvent(allEvents.value, event, maxEvents)
     publish()
     return true
   }
@@ -105,12 +110,47 @@ export function createRunActivityStore(
   }
 }
 
-function validEventForRun(event: RunActivityEvent, runId: string): boolean {
+type UnknownRecord = Record<string, unknown>
+
+function normalizeMaxEvents(value: number | undefined): number {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value
+  return DEFAULT_MAX_EVENTS
+}
+
+function validEventForRun(event: unknown, runId: string): event is RunActivityEvent {
+  if (!isRecord(event)) return false
   if (event.run_id !== runId) return false
-  if (event.id.trim() === '') return false
-  if (event.keeper_id.trim() === '') return false
-  if (event.target.trim() === '') return false
+  if (!hasNonEmptyString(event, 'id')) return false
+  if (!hasNonEmptyString(event, 'keeper_id')) return false
+  if (!hasNonEmptyString(event, 'target')) return false
+  if (!isRunActivityVerb(event.verb)) return false
+  if (event.detail !== undefined && typeof event.detail !== 'string') return false
   return Number.isFinite(event.timestamp_ms)
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasNonEmptyString(record: UnknownRecord, key: string): boolean {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+function isRunActivityVerb(value: unknown): value is RunActivityVerb {
+  return typeof value === 'string' && RUN_ACTIVITY_VERB_SET.has(value)
+}
+
+function insertEvent(
+  events: ReadonlyArray<RunActivityEvent>,
+  event: RunActivityEvent,
+  maxEvents: number,
+): ReadonlyArray<RunActivityEvent> {
+  const next = [...events]
+  const index = next.findIndex(existing => compareEvents(event, existing) < 0)
+  if (index === -1) next.push(event)
+  else next.splice(index, 0, event)
+  return next.slice(0, maxEvents)
 }
 
 function compareEvents(a: RunActivityEvent, b: RunActivityEvent): number {


### PR DESCRIPTION
Summary:
- add typed run activity store for ACTIVITY THIS RUN with run scoping, newest-first ordering, keeper grouping, validation, and capped visible history
- migrate the IDE activity mock to consume store snapshots and derive keeper hue via the canonical keeper slot mapper
- add unit and jest-axe coverage plus design-system changelog entry

Operator impact:
- moves the ACTIVITY pane off renderer-local arrays so future SSE/live run events can feed the same contract
- keeps the IDE PR-6 activity/conversation surfaces aligned around typed stores instead of hardcoded card rows

Verification:
- pnpm vitest run --config vitest.config.ts src/components/ide/run-activity-store.test.ts src/components/ide/ide-activity-mock.test.ts src/components/ide/ide-activity-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/ide/run-activity-store.ts src/components/ide/run-activity-store.test.ts src/components/ide/ide-activity-mock.ts src/components/ide/ide-activity-mock.test.ts src/components/ide/ide-activity-mock.a11y.test.ts
- git diff --check

Review focus:
- run scoping and public input validation
- whether maxEvents default 200 is the right initial cap before virtualized live stream wiring