### PR TITLE
feat(dashboard): add interject store

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -59,6 +59,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `src/components/ide/run-activity-store.ts` adds a typed ACTIVITY THIS RUN event store with run scoping, newest-first ordering, keeper grouping, and capped visible history.
   - `src/components/ide/ide-activity-mock.ts` now consumes the store instead of embedding activity ordering and keeper hue mapping directly in the renderer.
 
+- **IDE INTERJECT store substrate**
+  - `src/components/ide/interject-store.ts` adds typed active-keeper/message state for the INTERJECT rail and explicit availability reasons for Send/Approve/Pause/Drain actions.
+  - `src/components/ide/ide-interject-mock.ts` now consumes the store and `keeper-actions.ts` dispatch boundary instead of rendering a disabled placeholder form.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/src/components/ide/ide-interject-mock.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.a11y.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { IdeInterjectMock } from './ide-interject-mock'
+
+describe('IdeInterjectMock a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders the interject input and action rail accessibly', async () => {
+    render(html`<${IdeInterjectMock} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/ide/ide-interject-mock.test.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { activeKeeperName } from '../../keeper-state'
+import { IdeInterjectMock } from './ide-interject-mock'
+
+describe('IdeInterjectMock', () => {
+  beforeEach(() => {
+    activeKeeperName.value = 'nick0cave'
+  })
+
+  afterEach(() => {
+    activeKeeperName.value = ''
+  })
+
+  it('renders the interject store backed active keeper controls', async () => {
+    const container = document.createElement('div')
+    await act(async () => {
+      render(h(IdeInterjectMock, {}), container)
+    })
+
+    const region = container.querySelector('[role="region"]')
+    expect(region?.getAttribute('aria-label')).toBe('INTERJECT (interject store active keeper wiring)')
+    expect(container.textContent).toContain('INTERJECT')
+    expect(container.textContent).toContain('nick0cave')
+
+    const input = container.querySelector('input')
+    expect(input?.readOnly).toBe(false)
+    expect(input?.getAttribute('aria-label')).toBe('Interject input')
+
+    const buttons = [...container.querySelectorAll('button')]
+    expect(buttons.map(button => button.textContent)).toEqual(['Send', 'Approve', 'Pause', 'Drain'])
+    expect(buttons[0]?.disabled).toBe(true)
+    expect(buttons[1]?.disabled).toBe(true)
+    expect(buttons[2]?.getAttribute('aria-label')).toContain('Keeper-scoped pause')
+  })
+
+  it('enables Send after text is entered', async () => {
+    const container = document.createElement('div')
+    await act(async () => {
+      render(h(IdeInterjectMock, {}), container)
+    })
+
+    const input = container.querySelector('input') as HTMLInputElement
+    const send = container.querySelector('button') as HTMLButtonElement
+    expect(send.disabled).toBe(true)
+
+    await act(async () => {
+      input.value = 'please inspect this change'
+      input.dispatchEvent(new InputEvent('input', { bubbles: true }))
+    })
+
+    expect(send.disabled).toBe(false)
+  })
+})

--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -1,21 +1,45 @@
 import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { dispatchKeeperInterjectAction } from '../../keeper-actions'
+import { activeKeeperName } from '../../keeper-state'
+import {
+  createInterjectStore,
+  type InterjectActionState,
+  type InterjectDispatchRequest,
+} from './interject-store'
 
-// PR-2 placeholder for the INTERJECT input. The real wiring (input
-// store + active-keeper resolution + Send/Approve/Pause/Drain action
-// dispatch through keeper-actions.ts) lands in Phase 2 PR-7.
+// The input and button states flow through the same store/dispatch boundary
+// that live active-keeper wiring uses. Send remains disabled until the global
+// keeper selection signal resolves to a concrete keeper.
 
-const ACTIONS: ReadonlyArray<{ id: string; label: string; primary: boolean }> = [
-  { id: 'send', label: 'Send', primary: true },
-  { id: 'approve', label: 'Approve', primary: false },
-  { id: 'pause', label: 'Pause', primary: false },
-  { id: 'drain', label: 'Drain', primary: false },
-]
+async function dispatchInterject(request: InterjectDispatchRequest): Promise<void> {
+  await dispatchKeeperInterjectAction({
+    kind: request.kind,
+    keeperName: request.keeper_id,
+    message: request.message,
+  })
+}
 
 export function IdeInterjectMock() {
+  const interjectStore = useMemo(() =>
+    createInterjectStore({
+      initialActiveKeeper: activeKeeperName.value,
+      dispatch: dispatchInterject,
+    }), [])
+  const [, forceRender] = useState(0)
+
+  useEffect(() => interjectStore.subscribe(() => forceRender(tick => tick + 1)), [interjectStore])
+  useEffect(() => activeKeeperName.subscribe(name => {
+    interjectStore.setActiveKeeper(name)
+  }), [interjectStore])
+
+  const snapshot = interjectStore.snapshot()
+  const actions = interjectStore.actions()
+
   return html`
     <div
       role="region"
-      aria-label="INTERJECT (mock — PR-7 replaces with active-keeper wiring)"
+      aria-label="INTERJECT (interject store active keeper wiring)"
       style=${{
         display: 'grid',
         gridTemplateColumns: 'auto 1fr auto',
@@ -26,18 +50,29 @@ export function IdeInterjectMock() {
         alignItems: 'center',
       }}
     >
-      <span
+      <div
         style=${{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '2px',
           font: 'var(--type-eyebrow)',
           color: 'var(--color-fg-muted)',
           padding: '0 var(--sp-2)',
         }}
-      >INTERJECT</span>
+      >
+        <span>INTERJECT</span>
+        <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-secondary)' }}>
+          ${snapshot.active_keeper_id ?? 'No active keeper'}
+        </span>
+      </div>
       <input
         type="text"
         placeholder="Send message to active keeper..."
-        aria-label="Interject input (mock)"
-        readOnly
+        aria-label="Interject input"
+        value=${snapshot.message}
+        disabled=${snapshot.busy_action !== null}
+        onInput=${(event: Event) =>
+          interjectStore.setMessage((event.currentTarget as HTMLInputElement).value)}
         style=${{
           width: '100%',
           padding: 'var(--sp-2)',
@@ -49,24 +84,44 @@ export function IdeInterjectMock() {
         }}
       />
       <div style=${{ display: 'flex', gap: 'var(--sp-1)' }}>
-        ${ACTIONS.map(action => html`
-          <button
-            type="button"
-            disabled
-            aria-label=${`${action.label} (mock — PR-7 wires action)`}
-            style=${{
-              padding: '6px 12px',
-              background: action.primary ? 'var(--color-accent-fg)' : 'var(--color-bg-surface)',
-              color: action.primary ? 'var(--color-bg-page)' : 'var(--color-fg-secondary)',
-              border: action.primary ? 'none' : '1px solid var(--color-border-default)',
-              borderRadius: 'var(--r-1)',
-              font: 'var(--type-body)',
-              cursor: 'not-allowed',
-              opacity: 0.85,
-            }}
-          >${action.label}</button>
-        `)}
+        ${actions.map(action => InterjectButton(action, () => {
+          void interjectStore.submit(action.kind)
+        }))}
       </div>
+      ${snapshot.error
+        ? html`<span
+            role="status"
+            style=${{
+              gridColumn: '2 / 4',
+              color: 'var(--color-status-warn, var(--warn))',
+              fontSize: 'var(--fs-11)',
+            }}
+          >${snapshot.error}</span>`
+        : null}
     </div>
+  `
+}
+
+function InterjectButton(action: InterjectActionState, onClick: () => void) {
+  return html`
+    <button
+      type="button"
+      disabled=${!action.enabled}
+      aria-label=${action.disabled_reason
+        ? `${action.label} (${action.disabled_reason})`
+        : action.label}
+      title=${action.disabled_reason ?? action.label}
+      onClick=${onClick}
+      style=${{
+        padding: '6px 12px',
+        background: action.primary ? 'var(--color-accent-fg)' : 'var(--color-bg-surface)',
+        color: action.primary ? 'var(--color-bg-page)' : 'var(--color-fg-secondary)',
+        border: action.primary ? 'none' : '1px solid var(--color-border-default)',
+        borderRadius: 'var(--r-1)',
+        font: 'var(--type-body)',
+        cursor: action.enabled ? 'pointer' : 'not-allowed',
+        opacity: action.enabled ? 1 : 0.65,
+      }}
+    >${action.label}</button>
   `
 }

--- a/dashboard/src/components/ide/interject-store.test.ts
+++ b/dashboard/src/components/ide/interject-store.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createInterjectStore,
+  type InterjectDispatchRequest,
+} from './interject-store'
+
+describe('createInterjectStore', () => {
+  it('enables send only when an active keeper and message are present', async () => {
+    const dispatch = vi.fn<(request: InterjectDispatchRequest) => Promise<void>>()
+      .mockResolvedValue(undefined)
+    const store = createInterjectStore({
+      initialActiveKeeper: ' nick0cave ',
+      dispatch,
+      now: () => 42,
+    })
+
+    expect(store.snapshot().active_keeper_id).toBe('nick0cave')
+    expect(store.actions().find(action => action.kind === 'send')?.enabled).toBe(false)
+
+    store.setMessage('  ship the fix  ')
+    expect(store.actions().find(action => action.kind === 'send')?.enabled).toBe(true)
+
+    await expect(store.submit('send')).resolves.toBe(true)
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: 'send',
+      keeper_id: 'nick0cave',
+      message: 'ship the fix',
+      timestamp_ms: 42,
+    })
+    expect(store.snapshot().message).toBe('')
+    expect(store.snapshot().last_dispatch?.kind).toBe('send')
+  })
+
+  it('keeps unsupported keeper actions disabled by default', async () => {
+    const dispatch = vi.fn()
+    const store = createInterjectStore({
+      initialActiveKeeper: 'nick0cave',
+      dispatch,
+    })
+
+    const pause = store.actions().find(action => action.kind === 'pause')
+    expect(pause?.enabled).toBe(false)
+    expect(pause?.disabled_reason).toContain('Keeper-scoped pause')
+
+    await expect(store.submit('pause')).resolves.toBe(false)
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(store.snapshot().error).toContain('Keeper-scoped pause')
+  })
+
+  it('dispatches explicitly enabled non-message actions', async () => {
+    const dispatch = vi.fn<(request: InterjectDispatchRequest) => Promise<void>>()
+      .mockResolvedValue(undefined)
+    const store = createInterjectStore({
+      initialActiveKeeper: 'sangsu',
+      actionPolicy: {
+        approve: { enabled: true },
+      },
+      dispatch,
+      now: () => 100,
+    })
+
+    await expect(store.submit('approve')).resolves.toBe(true)
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: 'approve',
+      keeper_id: 'sangsu',
+      message: undefined,
+      timestamp_ms: 100,
+    })
+  })
+
+  it('notifies subscribers when snapshots change', () => {
+    const store = createInterjectStore({
+      initialActiveKeeper: 'nick0cave',
+      dispatch: vi.fn(),
+    })
+    let calls = 0
+    const unsubscribe = store.subscribe(() => {
+      calls += 1
+    })
+
+    store.setMessage('hello')
+    store.setActiveKeeper('masc-improver')
+    unsubscribe()
+    store.setMessage('ignored')
+
+    expect(calls).toBe(2)
+  })
+})

--- a/dashboard/src/components/ide/interject-store.ts
+++ b/dashboard/src/components/ide/interject-store.ts
@@ -1,0 +1,222 @@
+import { signal } from '@preact/signals'
+
+export type InterjectActionKind = 'send' | 'approve' | 'pause' | 'drain'
+
+export interface InterjectDispatchRequest {
+  readonly kind: InterjectActionKind
+  readonly keeper_id: string
+  readonly message?: string
+  readonly timestamp_ms: number
+}
+
+export interface InterjectActionState {
+  readonly kind: InterjectActionKind
+  readonly label: string
+  readonly primary: boolean
+  readonly requires_message: boolean
+  readonly enabled: boolean
+  readonly disabled_reason: string | null
+}
+
+export interface InterjectSnapshot {
+  readonly active_keeper_id: string | null
+  readonly message: string
+  readonly busy_action: InterjectActionKind | null
+  readonly error: string | null
+  readonly last_dispatch: InterjectDispatchRequest | null
+}
+
+export type InterjectActionAvailability = {
+  readonly enabled: boolean
+  readonly disabled_reason?: string
+}
+
+export type InterjectActionPolicy = Partial<Record<InterjectActionKind, InterjectActionAvailability>>
+
+export interface InterjectStore {
+  readonly snapshot: () => InterjectSnapshot
+  readonly actions: () => ReadonlyArray<InterjectActionState>
+  readonly setActiveKeeper: (keeperId: string | null | undefined) => void
+  readonly setMessage: (message: string) => void
+  readonly submit: (kind: InterjectActionKind) => Promise<boolean>
+  readonly reset: () => void
+  readonly subscribe: (listener: () => void) => () => void
+}
+
+const ACTIONS: ReadonlyArray<{
+  readonly kind: InterjectActionKind
+  readonly label: string
+  readonly primary: boolean
+  readonly requires_message: boolean
+}> = [
+  { kind: 'send', label: 'Send', primary: true, requires_message: true },
+  { kind: 'approve', label: 'Approve', primary: false, requires_message: false },
+  { kind: 'pause', label: 'Pause', primary: false, requires_message: false },
+  { kind: 'drain', label: 'Drain', primary: false, requires_message: false },
+]
+
+const DEFAULT_ACTION_POLICY: Required<InterjectActionPolicy> = {
+  send: { enabled: true },
+  approve: {
+    enabled: false,
+    disabled_reason: 'No active approval token is attached to the IDE interject rail.',
+  },
+  pause: {
+    enabled: false,
+    disabled_reason: 'Keeper-scoped pause is not advertised by the operator action surface.',
+  },
+  drain: {
+    enabled: false,
+    disabled_reason: 'Keeper-scoped drain is not advertised by the operator action surface.',
+  },
+}
+
+export function createInterjectStore({
+  initialActiveKeeper,
+  actionPolicy = {},
+  dispatch,
+  now = () => Date.now(),
+}: {
+  readonly initialActiveKeeper?: string | null
+  readonly actionPolicy?: InterjectActionPolicy
+  readonly dispatch: (request: InterjectDispatchRequest) => Promise<void>
+  readonly now?: () => number
+}): InterjectStore {
+  const snapshotSignal = signal<InterjectSnapshot>({
+    active_keeper_id: normalizeKeeper(initialActiveKeeper),
+    message: '',
+    busy_action: null,
+    error: null,
+    last_dispatch: null,
+  })
+  const policy = { ...DEFAULT_ACTION_POLICY, ...actionPolicy }
+
+  const setSnapshot = (next: InterjectSnapshot): void => {
+    snapshotSignal.value = next
+  }
+
+  const setActiveKeeper = (keeperId: string | null | undefined): void => {
+    const nextKeeper = normalizeKeeper(keeperId)
+    const current = snapshotSignal.value
+    if (current.active_keeper_id === nextKeeper) return
+    setSnapshot({ ...current, active_keeper_id: nextKeeper, error: null })
+  }
+
+  const setMessage = (message: string): void => {
+    const current = snapshotSignal.value
+    if (current.message === message) return
+    setSnapshot({ ...current, message, error: null })
+  }
+
+  const actions = (): ReadonlyArray<InterjectActionState> =>
+    ACTIONS.map(action => deriveActionState(action, snapshotSignal.value, policy))
+
+  const submit = async (kind: InterjectActionKind): Promise<boolean> => {
+    const action = actions().find(item => item.kind === kind)
+    const current = snapshotSignal.value
+    if (!action) {
+      setSnapshot({ ...current, error: `Unknown INTERJECT action: ${kind}` })
+      return false
+    }
+    if (!action.enabled) {
+      setSnapshot({ ...current, error: action.disabled_reason ?? `${action.label} is unavailable` })
+      return false
+    }
+
+    const keeperId = current.active_keeper_id
+    if (!keeperId) {
+      setSnapshot({ ...current, error: 'Choose an active keeper before using INTERJECT.' })
+      return false
+    }
+
+    const message = current.message.trim()
+    const request: InterjectDispatchRequest = {
+      kind,
+      keeper_id: keeperId,
+      message: message === '' ? undefined : message,
+      timestamp_ms: now(),
+    }
+
+    setSnapshot({ ...current, busy_action: kind, error: null })
+    try {
+      await dispatch(request)
+      const after = snapshotSignal.value
+      setSnapshot({
+        ...after,
+        message: kind === 'send' ? '' : after.message,
+        busy_action: null,
+        error: null,
+        last_dispatch: request,
+      })
+      return true
+    } catch (err) {
+      const after = snapshotSignal.value
+      setSnapshot({
+        ...after,
+        busy_action: null,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return false
+    }
+  }
+
+  const reset = (): void => {
+    const current = snapshotSignal.value
+    setSnapshot({ ...current, message: '', busy_action: null, error: null, last_dispatch: null })
+  }
+
+  const subscribe = (listener: () => void): (() => void) => {
+    let sawInitialSnapshot = false
+    return snapshotSignal.subscribe(() => {
+      if (!sawInitialSnapshot) {
+        sawInitialSnapshot = true
+        return
+      }
+      listener()
+    })
+  }
+
+  return {
+    snapshot: () => snapshotSignal.value,
+    actions,
+    setActiveKeeper,
+    setMessage,
+    submit,
+    reset,
+    subscribe,
+  }
+}
+
+function deriveActionState(
+  action: (typeof ACTIONS)[number],
+  snapshot: InterjectSnapshot,
+  policy: Required<InterjectActionPolicy>,
+): InterjectActionState {
+  const availability = policy[action.kind]
+  const message = snapshot.message.trim()
+  let disabledReason: string | null = null
+
+  if (snapshot.busy_action !== null) {
+    disabledReason = `${snapshot.busy_action} is still running.`
+  } else if (!snapshot.active_keeper_id) {
+    disabledReason = 'Choose an active keeper before using INTERJECT.'
+  } else if (action.requires_message && message === '') {
+    disabledReason = 'Type a message before sending.'
+  } else if (!availability.enabled) {
+    disabledReason = availability.disabled_reason ?? `${action.label} is not available.`
+  }
+
+  return {
+    kind: action.kind,
+    label: action.label,
+    primary: action.primary,
+    requires_message: action.requires_message,
+    enabled: disabledReason === null,
+    disabled_reason: disabledReason,
+  }
+}
+
+function normalizeKeeper(value: string | null | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -37,6 +37,14 @@ import {
   KEEPER_STREAM_IDLE_TIMEOUT_MS,
 } from './config/constants'
 
+export type KeeperInterjectActionKind = 'send' | 'approve' | 'pause' | 'drain'
+
+export interface KeeperInterjectCommand {
+  readonly kind: KeeperInterjectActionKind
+  readonly keeperName: string
+  readonly message?: string
+}
+
 async function refreshDashboardState(): Promise<void> {
   invalidateDashboardCache()
   try {
@@ -48,6 +56,22 @@ async function refreshDashboardState(): Promise<void> {
 
 export function selectKeeper(name: string): void {
   activeKeeperName.value = name.trim()
+}
+
+export async function dispatchKeeperInterjectAction(command: KeeperInterjectCommand): Promise<void> {
+  const keeperName = command.keeperName.trim()
+  if (!keeperName) throw new Error('INTERJECT requires an active keeper.')
+
+  if (command.kind === 'send') {
+    const message = command.message?.trim() ?? ''
+    if (!message) throw new Error('INTERJECT send requires a message.')
+    await sendKeeperThreadMessage(keeperName, message)
+    return
+  }
+
+  throw new Error(
+    `INTERJECT ${command.kind} requires a keeper-scoped backend operator action before dispatch.`,
+  )
 }
 
 export async function hydrateKeeperStatus(name: string, force = false): Promise<KeeperStatusDetail | null> {

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -17,6 +17,7 @@ export {
 export { abortKeeperThreadMessage } from './keeper-stream'
 export {
   selectKeeper,
+  dispatchKeeperInterjectAction,
   hydrateKeeperStatus,
   loadFullKeeperHistory,
   sendKeeperThreadMessage,


### PR DESCRIPTION
## Summary
- Add a typed IDE INTERJECT store for active keeper, message, busy/error, and action availability state.
- Rewire the INTERJECT rail to use the store and keeper-actions dispatch boundary instead of a disabled placeholder form.
- Keep Approve/Pause/Drain disabled with explicit reasons until keeper-scoped backend actions exist; Send is enabled only when a real active keeper is selected and a message is present.

## Verification
- pnpm vitest run --config vitest.config.ts src/components/ide/interject-store.test.ts src/components/ide/ide-interject-mock.test.ts src/components/ide/ide-interject-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/ide/interject-store.ts src/components/ide/interject-store.test.ts src/components/ide/ide-interject-mock.ts src/components/ide/ide-interject-mock.test.ts src/components/ide/ide-interject-mock.a11y.test.ts
- git diff --check