### PR TITLE
feat(dashboard): add code document store

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -63,6 +63,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `src/components/ide/interject-store.ts` adds typed active-keeper/message state for the INTERJECT rail and explicit availability reasons for Send/Approve/Pause/Drain actions.
   - `src/components/ide/ide-interject-mock.ts` now consumes the store and `keeper-actions.ts` dispatch boundary instead of rendering a disabled placeholder form.
 
+- **IDE code document store substrate**
+  - `src/components/ide/code-document-store.ts` adds a typed read-only source document store with file/language metadata, CRLF normalization, line lookup, and bounded line parsing.
+  - `src/components/ide/ide-editor-mock.ts` now consumes the code document store alongside RFC 0019 ownership data instead of embedding pre-numbered editor rows directly in the renderer.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/src/components/ide/code-document-store.test.ts
+++ b/dashboard/src/components/ide/code-document-store.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { createCodeDocumentStore } from './code-document-store'
+
+describe('createCodeDocumentStore', () => {
+  it('parses code content into stable one-indexed lines', () => {
+    const store = createCodeDocumentStore({
+      file_path: 'runtime/cascade/router.ts',
+      language: 'typescript',
+      content: 'const a = 1\r\n\r\nexport const b = 2\n',
+    })
+
+    expect(store.document().file_path).toBe('runtime/cascade/router.ts')
+    expect(store.document().language).toBe('typescript')
+    expect(store.lines()).toEqual([
+      { num: 1, text: 'const a = 1', is_blank: false },
+      { num: 2, text: '', is_blank: true },
+      { num: 3, text: 'export const b = 2', is_blank: false },
+    ])
+    expect(store.line(3)?.text).toBe('export const b = 2')
+    expect(store.line(4)).toBeNull()
+  })
+
+  it('rejects malformed document loads without replacing the current document', () => {
+    const store = createCodeDocumentStore({
+      file_path: 'a.ts',
+      language: 'typescript',
+      content: 'export {}',
+    })
+
+    expect(store.load({ file_path: '', language: 'typescript', content: 'oops' })).toBe(false)
+    expect(store.load({ file_path: 'b.ts', language: 'typescript', content: 42 })).toBe(false)
+    expect(store.document().file_path).toBe('a.ts')
+  })
+
+  it('bounds very large documents', () => {
+    const store = createCodeDocumentStore({
+      file_path: 'huge.ts',
+      language: 'typescript',
+      content: 'a\nb\nc',
+    }, { maxLines: 2 })
+
+    expect(store.lines().map(line => line.text)).toEqual(['a', 'b'])
+  })
+
+  it('notifies subscribers on successful loads', () => {
+    const store = createCodeDocumentStore({
+      file_path: 'a.ts',
+      language: 'typescript',
+      content: 'a',
+    })
+    let calls = 0
+    const unsubscribe = store.subscribe(() => {
+      calls += 1
+    })
+
+    store.load({ file_path: 'b.ts', language: 'typescript', content: 'b' })
+    store.load({ file_path: '', language: 'typescript', content: 'ignored' })
+    unsubscribe()
+    store.load({ file_path: 'c.ts', language: 'typescript', content: 'c' })
+
+    expect(calls).toBe(1)
+  })
+})

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -1,0 +1,107 @@
+import { signal } from '@preact/signals'
+
+export interface CodeDocumentSource {
+  readonly file_path: string
+  readonly language: string
+  readonly content: string
+}
+
+export interface CodeDocumentLine {
+  readonly num: number
+  readonly text: string
+  readonly is_blank: boolean
+}
+
+export interface CodeDocumentSnapshot extends CodeDocumentSource {
+  readonly lines: ReadonlyArray<CodeDocumentLine>
+}
+
+export interface CodeDocumentStore {
+  readonly load: (source: unknown) => boolean
+  readonly document: () => CodeDocumentSnapshot
+  readonly lines: () => ReadonlyArray<CodeDocumentLine>
+  readonly line: (lineNumber: number) => CodeDocumentLine | null
+  readonly subscribe: (listener: () => void) => () => void
+}
+
+const EMPTY_DOCUMENT: CodeDocumentSnapshot = {
+  file_path: '(no file)',
+  language: 'text',
+  content: '',
+  lines: [],
+}
+
+export function createCodeDocumentStore(
+  initialSource: unknown,
+  opts: { readonly maxLines?: number } = {},
+): CodeDocumentStore {
+  const maxLines = normalizeMaxLines(opts.maxLines)
+  const initial = normalizeSource(initialSource, maxLines) ?? EMPTY_DOCUMENT
+  const snapshot = signal<CodeDocumentSnapshot>(initial)
+
+  const load = (source: unknown): boolean => {
+    const next = normalizeSource(source, maxLines)
+    if (!next) return false
+    snapshot.value = next
+    return true
+  }
+
+  const subscribe = (listener: () => void): (() => void) => {
+    let sawInitialSnapshot = false
+    return snapshot.subscribe(() => {
+      if (!sawInitialSnapshot) {
+        sawInitialSnapshot = true
+        return
+      }
+      listener()
+    })
+  }
+
+  return {
+    load,
+    document: () => snapshot.value,
+    lines: () => snapshot.value.lines,
+    line: lineNumber => snapshot.value.lines[lineNumber - 1] ?? null,
+    subscribe,
+  }
+}
+
+function normalizeSource(source: unknown, maxLines: number): CodeDocumentSnapshot | null {
+  if (!isRecord(source)) return null
+  const filePath = normalizeNonEmptyString(source.file_path)
+  const language = normalizeNonEmptyString(source.language)
+  if (!filePath || !language || typeof source.content !== 'string') return null
+
+  const content = source.content.replace(/\r\n?/g, '\n')
+  return {
+    file_path: filePath,
+    language,
+    content,
+    lines: parseLines(content, maxLines),
+  }
+}
+
+function parseLines(content: string, maxLines: number): ReadonlyArray<CodeDocumentLine> {
+  if (content === '') return []
+  const rawLines = content.endsWith('\n')
+    ? content.slice(0, -1).split('\n')
+    : content.split('\n')
+  return rawLines.slice(0, maxLines).map((text, index) => ({
+    num: index + 1,
+    text,
+    is_blank: text.trim() === '',
+  }))
+}
+
+function normalizeMaxLines(value: number | undefined): number {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) return value
+  return 5_000
+}
+
+function normalizeNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -83,14 +83,25 @@ function normalizeSource(source: unknown, maxLines: number): CodeDocumentSnapsho
 
 function parseLines(content: string, maxLines: number): ReadonlyArray<CodeDocumentLine> {
   if (content === '') return []
-  const rawLines = content.endsWith('\n')
-    ? content.slice(0, -1).split('\n')
-    : content.split('\n')
-  return rawLines.slice(0, maxLines).map((text, index) => ({
-    num: index + 1,
-    text,
-    is_blank: text.trim() === '',
-  }))
+  const end = content.endsWith('\n') ? content.length - 1 : content.length
+  const lines: CodeDocumentLine[] = []
+  let start = 0
+
+  while (lines.length < maxLines && start <= end) {
+    const newlineIndex = content.indexOf('\n', start)
+    const lineEnd = newlineIndex === -1 || newlineIndex > end ? end : newlineIndex
+    const text = content.slice(start, lineEnd)
+    lines.push({
+      num: lines.length + 1,
+      text,
+      is_blank: text.trim() === '',
+    })
+
+    if (newlineIndex === -1 || newlineIndex >= end) break
+    start = newlineIndex + 1
+  }
+
+  return lines
 }
 
 function normalizeMaxLines(value: number | undefined): number {

--- a/dashboard/src/components/ide/ide-editor-mock.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.a11y.test.ts
@@ -18,7 +18,7 @@ describe('IdeEditorMock a11y', () => {
     document.body.removeChild(container)
   })
 
-  it('renders the ownership-backed editor mock accessibly', async () => {
+  it('renders the code document and ownership-backed editor mock accessibly', async () => {
     render(html`<${IdeEditorMock} />`, container)
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/dashboard/src/components/ide/ide-editor-mock.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.test.ts
@@ -4,13 +4,15 @@ import { render } from 'preact'
 import { IdeEditorMock } from './ide-editor-mock'
 
 describe('IdeEditorMock', () => {
-  it('renders the RFC 0019 ownership-backed editor mock', () => {
+  it('renders the code document and RFC 0019 ownership-backed editor mock', () => {
     const container = document.createElement('div')
     render(h(IdeEditorMock, {}), container)
 
     const region = container.querySelector('[role="region"]')
-    expect(region?.getAttribute('aria-label')).toBe('에디터 (RFC 0019 line ownership mock)')
-    expect(container.textContent).toContain('ownership · 3 keepers')
+    expect(region?.getAttribute('aria-label')).toBe('에디터 (code document store + RFC 0019 ownership mock)')
+    expect(container.textContent).toContain('runtime/cascade/router.ts')
+    expect(container.textContent).toContain('typescript')
+    expect(container.textContent).toContain('23 lines · ownership · 3 keepers')
     expect(container.textContent).toContain('nick0cave')
     expect(container.textContent).toContain('sangsu')
     expect(container.textContent).toContain('masc-improver')

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -1,48 +1,47 @@
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
 import {
+  createCodeDocumentStore,
+  type CodeDocumentLine,
+} from './code-document-store'
+import {
   createKeeperLineOwnershipStore,
   type KeeperEdit,
   type LineOwnership,
 } from './keeper-line-ownership-store'
 
-// PR-5 precursor: the editor remains a read-only mock fixture, but its
-// blame-by-keeper gutter now consumes RFC 0019's ownership store instead of
-// hardcoding keeper labels per row. Replacing the text renderer with Shiki can
-// keep the same LineOwnership contract.
-
-interface MockLine {
-  readonly num: number
-  readonly text: string
-}
+// PR-5 precursor: the editor remains a read-only fixture, but both source
+// document rows and blame-by-keeper ownership now flow through typed stores.
+// Replacing the row text renderer with Shiki/CodeMirror can keep these same
+// CodeDocumentLine + LineOwnership contracts.
 
 const EDITOR_FILE = 'runtime/cascade/router.ts'
 
-const MOCK_LINES: ReadonlyArray<MockLine> = [
-  { num: 1, text: "import { Provider, ProviderKind } from './provider'" },
-  { num: 2, text: "import { Turn, TurnId } from './turn'" },
-  { num: 3, text: "import { FsmEvent } from '../fsm/state'" },
-  { num: 4, text: "import { log } from '../log'" },
-  { num: 5, text: "import type { ToolSpec } from './tools'" },
-  { num: 6, text: "import { TokenRegistry } from '../tokens/registry'" },
-  { num: 7, text: '' },
-  { num: 8, text: 'export type CascadeReq = {' },
-  { num: 9, text: '  model: string' },
-  { num: 10, text: '  messages: Array<{ role: string; content: string }>' },
-  { num: 11, text: '  tools?: ToolSpec[]' },
-  { num: 12, text: "  tool_choice?: 'auto' | 'none'" },
-  { num: 13, text: '  max_tokens?: number' },
-  { num: 14, text: '}' },
-  { num: 15, text: '' },
-  { num: 16, text: 'export function normalizeTools(req: CascadeReq): CascadeReq {' },
-  { num: 17, text: '  // strip empty tools array' },
-  { num: 18, text: '  if (req.tools && req.tools.length === 0) {' },
-  { num: 19, text: '    const { tools, tool_choice, ...rest } = req' },
-  { num: 20, text: '    return rest as CascadeReq' },
-  { num: 21, text: '  }' },
-  { num: 22, text: '  return req' },
-  { num: 23, text: '}' },
-]
+const MOCK_SOURCE = [
+  "import { Provider, ProviderKind } from './provider'",
+  "import { Turn, TurnId } from './turn'",
+  "import { FsmEvent } from '../fsm/state'",
+  "import { log } from '../log'",
+  "import type { ToolSpec } from './tools'",
+  "import { TokenRegistry } from '../tokens/registry'",
+  '',
+  'export type CascadeReq = {',
+  '  model: string',
+  '  messages: Array<{ role: string; content: string }>',
+  '  tools?: ToolSpec[]',
+  "  tool_choice?: 'auto' | 'none'",
+  '  max_tokens?: number',
+  '}',
+  '',
+  'export function normalizeTools(req: CascadeReq): CascadeReq {',
+  '  // strip empty tools array',
+  '  if (req.tools && req.tools.length === 0) {',
+  '    const { tools, tool_choice, ...rest } = req',
+  '    return rest as CascadeReq',
+  '  }',
+  '  return req',
+  '}',
+].join('\n')
 
 const MOCK_OWNERSHIP_EVENTS: ReadonlyArray<KeeperEdit> = [
   {
@@ -74,18 +73,26 @@ const MOCK_OWNERSHIP_EVENTS: ReadonlyArray<KeeperEdit> = [
 export function IdeEditorMock() {
   // View tabs and LAYERS toggle moved to IdeToolbar (PR-3); the editor
   // mock now only shows the breadcrumb header for the open file.
+  const documentStore = useMemo(() =>
+    createCodeDocumentStore({
+      file_path: EDITOR_FILE,
+      language: 'typescript',
+      content: MOCK_SOURCE,
+    }), [])
   const ownershipStore = useMemo(() => {
     const store = createKeeperLineOwnershipStore(EDITOR_FILE)
     for (const event of MOCK_OWNERSHIP_EVENTS) store.ingest(event)
     return store
   }, [])
+  const document = documentStore.document()
+  const lines = documentStore.lines()
   const ownership = ownershipStore.ownership()
   const keepers = ownershipStore.knownKeepers()
 
   return html`
     <div
       role="region"
-      aria-label="에디터 (RFC 0019 line ownership mock)"
+      aria-label="에디터 (code document store + RFC 0019 ownership mock)"
       style=${{
         display: 'grid',
         gridTemplateRows: 'auto 1fr',
@@ -104,8 +111,9 @@ export function IdeEditorMock() {
           font: 'var(--type-eyebrow)',
         }}
       >
-        <span>runtime / cascade / router.ts</span>
-        <span style=${{ marginLeft: 'auto' }}>ownership · ${keepers.length} keepers</span>
+        <span>${document.file_path}</span>
+        <span style=${{ color: 'var(--color-fg-disabled)' }}>${document.language}</span>
+        <span style=${{ marginLeft: 'auto' }}>${lines.length} lines · ownership · ${keepers.length} keepers</span>
       </div>
       <ol
         style=${{
@@ -118,7 +126,7 @@ export function IdeEditorMock() {
           lineHeight: 1.6,
         }}
       >
-        ${MOCK_LINES.map(line => MockEditorRow(line, ownership.get(line.num)))}
+        ${lines.map(line => MockEditorRow(line, ownership.get(line.num)))}
       </ol>
     </div>
   `
@@ -130,7 +138,7 @@ function keeperColor(owner: LineOwnership | undefined): string {
     : 'var(--color-fg-disabled)'
 }
 
-function MockEditorRow(line: MockLine, owner: LineOwnership | undefined) {
+function MockEditorRow(line: CodeDocumentLine, owner: LineOwnership | undefined) {
   const color = keeperColor(owner)
   const dot = owner
     ? color


### PR DESCRIPTION
## Summary
- Add a typed code document store for the IDE editor with file/language metadata, CRLF normalization, bounded line parsing, and line lookup.
- Rewire the editor mock to consume code document lines alongside the RFC 0019 ownership store instead of embedding pre-numbered rows in the renderer.
- Update editor unit/a11y coverage and design-system changelog.

## Verification
- pnpm vitest run --config vitest.config.ts src/components/ide/code-document-store.test.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm eslint src/components/ide/code-document-store.ts src/components/ide/code-document-store.test.ts src/components/ide/ide-editor-mock.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts
- git diff --check