### PR TITLE
fix: address audit and voice review follow-ups

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -715,6 +715,9 @@ let release_stale_claims config ~ttl_seconds =
     | Ok backlog ->
         let now_str = now_iso () in
         let now_f = Time_compat.now () in
+        let age_seconds_json ts =
+          `Float (max 0.0 (now_f -. ts))
+        in
         let stale_tasks = ref [] in
         let updated_tasks = List.map (fun (task : task) ->
           match task.task_status with
@@ -726,7 +729,7 @@ let release_stale_claims config ~ttl_seconds =
                   ("type", `String "stale_claim_released");
                   ("task_id", `String task.id);
                   ("assignee", `String assignee);
-                  ("age_s", `Float (now_f -. ts));
+                  ("age_s", age_seconds_json ts);
                   ("ts", `String now_str);
                 ]);
                 { task with task_status = Todo }
@@ -739,7 +742,7 @@ let release_stale_claims config ~ttl_seconds =
                   ("type", `String "stale_inprogress_released");
                   ("task_id", `String task.id);
                   ("assignee", `String assignee);
-                  ("age_s", `Float (now_f -. ts));
+                  ("age_s", age_seconds_json ts);
                   ("ts", `String now_str);
                 ]);
                 { task with task_status = Todo }

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -31,9 +31,13 @@ let read_jsonl_file path =
          while true do
            let line = input_line ic in
            if String.length line > 0 then
-             match Yojson.Safe.from_string line |> Envelope.of_json with
-             | Ok env -> entries := env :: !entries
-             | Error _ -> ()
+             match Yojson.Safe.from_string line with
+             | json -> (
+                 match Envelope.of_json json with
+                 | Ok env -> entries := env :: !entries
+                 | Error _ -> () )
+             | exception Yojson.Json_error _ -> ()
+             | exception Yojson.Safe.Util.Type_error (_, _) -> ()
          done
        with End_of_file -> ());
       List.rev !entries)

--- a/lib/shared_audit/store.ml
+++ b/lib/shared_audit/store.ml
@@ -21,6 +21,10 @@ let rec mkdir_p dir =
 
 let ensure_dir_exists path = mkdir_p (Filename.dirname path)
 
+let parse_jsonl_line line =
+  try Yojson.Safe.from_string line |> Envelope.of_json with
+  | Yojson.Json_error msg -> Error msg
+
 let read_jsonl_file path =
   let ic = open_in path in
   Fun.protect
@@ -31,13 +35,9 @@ let read_jsonl_file path =
          while true do
            let line = input_line ic in
            if String.length line > 0 then
-             match Yojson.Safe.from_string line with
-             | json -> (
-                 match Envelope.of_json json with
-                 | Ok env -> entries := env :: !entries
-                 | Error _ -> () )
-             | exception Yojson.Json_error _ -> ()
-             | exception Yojson.Safe.Util.Type_error (_, _) -> ()
+             match parse_jsonl_line line with
+             | Ok env -> entries := env :: !entries
+             | Error _ -> ()
          done
        with End_of_file -> ());
       List.rev !entries)

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -40,12 +40,12 @@ let resolve_api_key endpoint =
           else
             Error
               (Printf.sprintf
-                 "voice provider %s (endpoint %s) expects %s to be set"
+                 "voice provider %s (endpoint %s) expects %s to be set to a non-empty value"
                  adapter.canonical_name endpoint.id env_name)
       | None ->
           Error
             (Printf.sprintf
-               "voice provider %s (endpoint %s) expects %s to be set"
+               "voice provider %s (endpoint %s) expects %s to be set to a non-empty value"
                adapter.canonical_name endpoint.id env_name) )
   | None -> Ok ""
 

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -31,6 +31,14 @@ let cleanup_dir dir =
   in
   try rm_rf dir with _ -> ()
 
+let audit_path ~base_dir ~ts =
+  let tm = Unix.gmtime ts in
+  let yyyy_mm =
+    Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1)
+  in
+  let dd = Printf.sprintf "%02d" tm.Unix.tm_mday in
+  Filename.concat (Filename.concat base_dir yyyy_mm) (dd ^ ".jsonl")
+
 (* ──────────────────────────────────────────────────────────── *)
 (* Envelope                                                      *)
 (* ──────────────────────────────────────────────────────────── *)
@@ -197,6 +205,21 @@ let test_store_resume_continues_chain () =
       "resumed chain: e2.prev_hash = hash of e1"
       (Some (Env.hash_for_chain e1)) e2.prev_hash)
 
+let test_store_skips_malformed_jsonl_lines () =
+  let dir = unique_temp_dir "audit_malformed" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let valid = Store.append store ~category:"X" ~payload:(`Int 1) in
+    let path = audit_path ~base_dir:dir ~ts:valid.ts in
+    let oc = open_out_gen [ Open_append; Open_wronly ] 0o644 path in
+    output_string oc "{not json\n";
+    close_out oc;
+    let entries = Store.recent store ~n:10 in
+    check int "malformed line skipped" 1 (List.length entries);
+    match entries with
+    | [ entry ] -> check string "valid entry preserved" valid.id entry.id
+    | _ -> fail "expected exactly one valid audit entry")
+
 let test_store_base_dir_inspector () =
   let dir = unique_temp_dir "audit_inspector" in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
@@ -226,6 +249,7 @@ let () =
       test_case "verify_chain intact" `Quick test_store_verify_chain_intact;
       test_case "verify_chain detects tampering" `Quick test_store_verify_chain_detects_tampering;
       test_case "resume continues chain" `Quick test_store_resume_continues_chain;
+      test_case "skips malformed JSONL lines" `Quick test_store_skips_malformed_jsonl_lines;
       test_case "base_dir inspector" `Quick test_store_base_dir_inspector;
     ];
   ]

--- a/test/shared_audit/test_shared_audit.ml
+++ b/test/shared_audit/test_shared_audit.ml
@@ -220,6 +220,38 @@ let test_store_skips_malformed_jsonl_lines () =
     | [ entry ] -> check string "valid entry preserved" valid.id entry.id
     | _ -> fail "expected exactly one valid audit entry")
 
+let test_store_skips_invalid_envelope_jsonl_lines () =
+  let dir = unique_temp_dir "audit_invalid_envelope" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let valid = Store.append store ~category:"X" ~payload:(`Int 1) in
+    let path = audit_path ~base_dir:dir ~ts:valid.ts in
+    let oc = open_out_gen [ Open_append; Open_wronly ] 0o644 path in
+    output_string oc
+      {|{"id":"bad-envelope","ts":1.0,"payload":{"kind":"missing-category"}}|};
+    output_char oc '\n';
+    close_out oc;
+    let entries = Store.recent store ~n:10 in
+    check int "invalid envelope line skipped" 1 (List.length entries);
+    match entries with
+    | [ entry ] -> check string "valid entry preserved" valid.id entry.id
+    | _ -> fail "expected exactly one valid audit entry")
+
+let test_store_resume_skips_malformed_jsonl_lines () =
+  let dir = unique_temp_dir "audit_malformed_resume" in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let store = Store.create ~base_dir:dir in
+    let valid = Store.append store ~category:"X" ~payload:(`Int 1) in
+    let path = audit_path ~base_dir:dir ~ts:valid.ts in
+    let oc = open_out_gen [ Open_append; Open_wronly ] 0o644 path in
+    output_string oc "{not json\n";
+    close_out oc;
+    let resumed = Store.create ~base_dir:dir in
+    let next = Store.append resumed ~category:"X" ~payload:(`Int 2) in
+    check (option string)
+      "resume links to last valid entry after malformed line"
+      (Some (Env.hash_for_chain valid)) next.prev_hash)
+
 let test_store_base_dir_inspector () =
   let dir = unique_temp_dir "audit_inspector" in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
@@ -250,6 +282,8 @@ let () =
       test_case "verify_chain detects tampering" `Quick test_store_verify_chain_detects_tampering;
       test_case "resume continues chain" `Quick test_store_resume_continues_chain;
       test_case "skips malformed JSONL lines" `Quick test_store_skips_malformed_jsonl_lines;
+      test_case "skips invalid envelope JSONL lines" `Quick test_store_skips_invalid_envelope_jsonl_lines;
+      test_case "resume skips malformed JSONL lines" `Quick test_store_resume_skips_malformed_jsonl_lines;
       test_case "base_dir inspector" `Quick test_store_base_dir_inspector;
     ];
   ]


### PR DESCRIPTION
## Summary
- clarify voice auth errors for blank env vars as requiring a non-empty value
- make shared audit JSONL loading skip malformed parse/type errors instead of aborting the file
- add shared_audit regression coverage for malformed JSONL lines

## Context
Follow-up for Copilot review comments left on merged PR #12652.

## Validation
- git diff --check -- lib/voice/voice_bridge.ml lib/shared_audit/store.ml test/shared_audit/test_shared_audit.ml
- scripts/dune-local.sh build lib/masc_mcp.cma test/shared_audit/test_shared_audit.exe
- ./_build/default/test/shared_audit/test_shared_audit.exe