### PR TITLE
fix(keeper): surface runtime attention in fleet UI

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -29,6 +29,7 @@ export type {
   KeeperCompositeMeasurement,
   KeeperLastOutcome,
   KeeperCompositeExecution,
+  KeeperRuntimeAttention,
   KeeperPhaseDiagnosis,
   KeeperPhaseDiagnosisRow,
   KeeperCompositePhase,

--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -158,6 +158,26 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.recommended_actions[0]!.confirm_required).toBe(true)
   })
 
+  it('parses backend runtime_attention', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      runtime_attention: {
+        state: 'blocked',
+        needs_attention: true,
+        blocked: true,
+        fiber_stop_requested: false,
+        reason: 'passive_only',
+        raw_phase: 'Running',
+        is_live: false,
+        source: 'execution_receipt',
+      },
+    })
+
+    expect(result.runtime_attention?.state).toBe('blocked')
+    expect(result.runtime_attention?.reason).toBe('passive_only')
+    expect(result.runtime_attention?.fiber_stop_requested).toBe(false)
+  })
+
   it('parses snapshot with measurement auto_rules', () => {
     const result = parseKeeperCompositeSnapshot({
       ...VALID_SNAPSHOT,

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -161,6 +161,17 @@ const KeeperCompositeExecutionSchema = object({
   ),
 })
 
+const KeeperRuntimeAttentionSchema = object({
+  state: string(),
+  needs_attention: boolean(),
+  blocked: boolean(),
+  fiber_stop_requested: optional(boolean()),
+  reason: nullable(string()),
+  raw_phase: nullable(string()),
+  is_live: boolean(),
+  source: string(),
+})
+
 const OperatorRecommendedActionSchema = object({
   action_type: string(),
   target_type: string(),
@@ -201,6 +212,7 @@ export const KeeperCompositeSnapshotSchema = object({
   is_live: boolean(),
   last_outcome: nullable(KeeperLastOutcomeSchema),
   execution: optional(KeeperCompositeExecutionSchema),
+  runtime_attention: optional(KeeperRuntimeAttentionSchema),
   recommended_actions: fallback(array(OperatorRecommendedActionSchema), []),
   /** @deprecated kept only for old backend experiments; new payloads use `execution`. */
   latest_receipt: optional(unknown()),
@@ -213,6 +225,7 @@ export type KeeperPhaseDiagnosis = InferOutput<typeof KeeperPhaseDiagnosisSchema
 export type KeeperPhaseDiagnosisRow = InferOutput<typeof KeeperPhaseDiagnosisRowSchema>
 export type KeeperLastOutcome = InferOutput<typeof KeeperLastOutcomeSchema>
 export type KeeperCompositeExecution = InferOutput<typeof KeeperCompositeExecutionSchema>
+export type KeeperRuntimeAttention = InferOutput<typeof KeeperRuntimeAttentionSchema>
 export type KeeperCompositePhase = InferOutput<typeof KeeperCompositePhaseSchema>
 export type KeeperCompositeTurnPhase = InferOutput<typeof KeeperCompositeTurnPhaseSchema>
 export type KeeperCompositeDecisionStage = InferOutput<typeof KeeperCompositeDecisionStageSchema>

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -222,6 +222,59 @@ describe('runtimeAttentionForSnapshot', () => {
     expect(attention.title).toContain('latest activity 10m ago')
   })
 
+  it('prefers backend runtime_attention over narrower frontend heuristics', () => {
+    const snap = snapshot({
+      is_live: false,
+      execution: execution({
+        outcome: 'ok',
+        terminal_reason_code: 'completed',
+        operator_disposition: 'pass',
+        operator_disposition_reason: 'healthy',
+        tool_contract_result: 'passive_only',
+      }),
+      runtime_attention: {
+        state: 'blocked',
+        needs_attention: true,
+        blocked: true,
+        fiber_stop_requested: false,
+        reason: 'passive_only',
+        raw_phase: 'Running',
+        is_live: false,
+        source: 'execution_receipt',
+      },
+    })
+
+    const attention = runtimeAttentionForSnapshot(snap, generatedAt)
+    expect(attention.level).toBe('blocked')
+    expect(attention.cause).toContain('execution_receipt')
+    expect(attention.cause).toContain('passive_only')
+    expect(attention.reason).toContain('backend runtime_attention')
+  })
+
+  it('maps backend stop-requested attention to shutdown follow-up', () => {
+    const snap = snapshot({
+      is_live: true,
+      runtime_attention: {
+        state: 'stop_requested',
+        needs_attention: true,
+        blocked: false,
+        fiber_stop_requested: true,
+        reason: 'fiber stop requested',
+        raw_phase: 'Running',
+        is_live: true,
+        source: 'composite_snapshot',
+      },
+    })
+
+    const attention = runtimeAttentionForSnapshot(snap, generatedAt)
+    expect(attention.level).toBe('blocked')
+    expect(attention.label).toBe('정지 요청')
+    expect(attention.reason).toContain('backend runtime_attention')
+    expect(attention.reason).toContain('stop_requested')
+    expect(attention.cause).toContain('fiber stop requested')
+    expect(attention.nextStep).toContain('shutdown 완료')
+  })
+
   it('keeps recent healthy non-live keepers waiting instead of stale', () => {
     const snap = snapshot({
       is_live: false,
@@ -229,6 +282,16 @@ describe('runtimeAttentionForSnapshot', () => {
       execution: execution({
         recorded_at: '2026-04-25T07:38:30Z',
       }),
+      runtime_attention: {
+        state: 'ok',
+        needs_attention: false,
+        blocked: false,
+        fiber_stop_requested: false,
+        reason: null,
+        raw_phase: 'Running',
+        is_live: false,
+        source: 'composite_snapshot',
+      },
     })
 
     const attention = runtimeAttentionForSnapshot(snap, generatedAt)

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -288,6 +288,74 @@ function hasBlockingExecutionEvidence(snapshot: KeeperCompositeSnapshot): boolea
   return false
 }
 
+function backendRuntimeAttentionLevel(
+  state: string,
+  blocked: boolean,
+): FleetRuntimeAttentionLevel {
+  if (blocked || state === 'blocked' || state === 'stop_requested') return 'blocked'
+  if (state === 'idle_stale') return 'idle'
+  if (state === 'stale') return 'stale'
+  return 'ok'
+}
+
+function backendRuntimeAttentionLabel(
+  level: FleetRuntimeAttentionLevel,
+  state: string,
+): string {
+  if (state === 'stop_requested') return '정지 요청'
+  if (level === 'blocked') return '정체'
+  if (level === 'stale') return 'stale'
+  if (level === 'idle') return '무전환'
+  return 'live'
+}
+
+function backendRuntimeAttentionNextStep(
+  level: FleetRuntimeAttentionLevel,
+  state: string,
+  reason: string,
+): string {
+  if (state === 'stop_requested') return 'supervisor 회수 또는 shutdown 완료 여부 확인'
+  if (level === 'blocked') return `backend runtime_attention blocker 확인: ${reason}`
+  if (level === 'stale') return 'latest runtime evidence refresh 또는 keeper_probe 실행'
+  if (level === 'idle') return 'backlog, admission, trigger가 없는지 확인'
+  return '조치 불필요'
+}
+
+function runtimeAttentionFromBackend(
+  snapshot: KeeperCompositeSnapshot,
+  ageSec: number | null,
+  ageText: string,
+  evidenceText: string,
+): FleetRuntimeAttention | null {
+  const backend = snapshot.runtime_attention
+  if (!backend) return null
+  if (
+    backend.state === 'ok' &&
+    !backend.needs_attention &&
+    !backend.blocked &&
+    !backend.fiber_stop_requested
+  ) {
+    return null
+  }
+  const reason = backend.reason ?? backend.state
+  const level = backendRuntimeAttentionLevel(backend.state, backend.blocked)
+  const label = backendRuntimeAttentionLabel(level, backend.state)
+  const cause = `${backend.source}: ${backend.state}${reason ? ` · ${reason}` : ''}`
+  const nextStep = backendRuntimeAttentionNextStep(level, backend.state, reason)
+  const reasonText = backend.needs_attention
+    ? `backend runtime_attention · ${backend.state}${reason ? ` · ${reason}` : ''}`
+    : `backend runtime_attention · ${backend.state}`
+  return {
+    level,
+    label,
+    reason: reasonText,
+    cause,
+    nextStep,
+    title: `원인: ${cause} · 다음: ${nextStep} · 증거: ${evidenceText} · latest activity ${ageText}`,
+    ageSec,
+  }
+}
+
 function hasHealthyExecutionEvidence(snapshot: KeeperCompositeSnapshot): boolean {
   const execution = snapshot.execution
   if (!execution || hasBlockingExecutionEvidence(snapshot)) return false
@@ -508,6 +576,13 @@ export function runtimeAttentionForSnapshot(
   const ageText = formatAge(ageSec)
   const evidence = executionEvidence(snapshot)
   const evidenceText = evidence.length > 0 ? evidence.join(' · ') : 'no blocking evidence'
+  const backendAttention = runtimeAttentionFromBackend(
+    snapshot,
+    ageSec,
+    ageText,
+    evidenceText,
+  )
+  if (backendAttention) return backendAttention
   const blocked = hasBlockingExecutionEvidence(snapshot)
   const idleComposite = isIdleComposite(snapshot)
 

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -116,25 +116,30 @@ Operational contract:
 
 Missing file is not an error (returns 0 overrides, uses env/defaults).
 Parse errors log a warning and fall back to env defaults.
+For compatibility keys that runtime still reads, the legacy process env
+also preempts TOML. Example: `MASC_KEEPER_AUTOBOT_MAX` preempts
+`bootstrap.autoboot_max` even though TOML writes the canonical
+`MASC_KEEPER_AUTOBOOT_MAX` boot override.
 
 Legacy compatibility names that are no longer read by the unified turn path
 are intentionally excluded from this TOML surface.
 
-**Sections** (69 knobs total):
+**Sections** (80 knobs total):
 
 | Section | Count | Key examples |
 | --- | --- | --- |
 | `[bootstrap]` | 5 | `enabled`, `max_active_keepers`, `autoboot_max` |
 | `[autonomous]` | 6 | `max_turns_per_call`, `semaphore_wait_timeout_sec`, `concurrency` |
-| `[reactive]` | 2 | `max_turns_per_call`, `max_idle_turns` |
-| `[heartbeat]` | 7 | `interval_sec`, `max_silence_sec`, `smart_heartbeat` |
-| `[turn]` | 17 | `timeout_sec`, `stream_idle_timeout_sec`, `tool_cost_max_usd`, `temperature` |
+| `[reactive]` | 3 | `max_turns_per_call`, `concurrency`, `max_idle_turns` |
+| `[heartbeat]` | 10 | `interval_sec`, `max_silence_sec`, `smart_heartbeat`, `board_generic_wakeup_limit` |
+| `[turn]` | 18 | `timeout_sec`, `stream_idle_timeout_sec`, `tool_cost_max_usd`, `temperature` |
 | `[watchdog]` | 4 | `stale_sec`, `grace_sec`, `noop_threshold` |
 | `[supervisor]` | 4 | `max_restarts`, `backoff_base_sec`, `backoff_max_sec` |
 | `[lifecycle]` | 4 | `self_preservation_ratio`, `dead_ttl_sec` |
 | `[budget]` | 1 | `daily_usd` |
 | `[metrics]` | 2 | `max_bytes`, `max_rotated` |
-| `[alert]` | 16 | `slack_enabled`, `slack_dm_user_id`, `github_enabled` |
+| `[memory]` | 5 | `max_notes`, `compact_trigger_bytes`, `consensus_pattern` |
+| `[alert]` | 17 | `slack_enabled`, `slack_dm_user_id`, `github_enabled`, `github_min_score` |
 | `[debug]` | 1 | `enabled` |
 
 **Example** (`<active config root>/keeper_runtime.toml`):
@@ -146,6 +151,12 @@ semaphore_wait_timeout_sec = 150 # default: 60
 
 [reactive]
 max_turns_per_call = 15
+concurrency = 4
+
+[heartbeat]
+board_generic_wakeup_limit = 3 # caps non-explicit board_activity fanout; explicit mentions bypass this cap
+board_debounce_sec = 30
+board_wakeup_max = 4 # caps total non-explicit board wakeups after reason prioritization
 
 [bootstrap]
 max_active_keepers = 12

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -53,10 +53,11 @@ val semaphore_wait_timeout_sec : float
 
 exception Semaphore_wait_timeout of float
 (** Raised inside [with_keeper_turn_slot] when acquiring either the
-    autonomous or turn semaphore exceeds [semaphore_wait_timeout_sec].
-    The float carries the wait cap so the caller can render it without
-    re-reading the env var. Callers should treat this as "skip this
-    turn, retry on next heartbeat" rather than a keeper failure. *)
+    autonomous, reactive, or global turn semaphore exceeds
+    [semaphore_wait_timeout_sec]. The float carries the wait cap so the
+    caller can render it without re-reading the env var. Callers should
+    treat this as "skip this turn, retry on next heartbeat" rather than
+    a keeper failure. *)
 
 (** Test-only reset for the autonomous FIFO wait queue. *)
 val reset_autonomous_turn_queue_for_test : unit -> unit

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -218,11 +218,9 @@ let select_board_wakeup_candidates
       List.rev selected_rev, generic_dropped
     in
     let prioritized =
-      let non_generic =
-        List.filter (fun (_, r) -> r <> "board_activity") selected_by_reason
-      in
-      let generic =
-        List.filter (fun (_, r) -> r = "board_activity") selected_by_reason
+      let non_generic, generic =
+        List.partition (fun (_, reason) -> reason <> "board_activity")
+          selected_by_reason
       in
       non_generic @ generic
     in

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -101,6 +101,16 @@ let key_to_env =
     "debug.enabled",                    "MASC_KEEPER_DEBUG";
   ]
 
+let preempting_env_names env_name =
+  match env_name with
+  | "MASC_KEEPER_AUTOBOOT_MAX" ->
+      [ "MASC_KEEPER_AUTOBOOT_MAX"; "MASC_KEEPER_AUTOBOT_MAX" ]
+  | _ -> [ env_name ]
+
+let env_is_set env_lookup env_name =
+  preempting_env_names env_name
+  |> List.exists (fun name -> Option.is_some (env_lookup name))
+
 let resolved_config_root ~base_path =
   let inputs = Config_dir_resolver.inputs_from_env () in
   let resolution =
@@ -142,11 +152,10 @@ let apply_one
     ?(env_lookup = Env_config_core.raw_value_opt)
     ?(env_set = Config_boot_overrides.set)
     (doc : Keeper_toml_loader.toml_doc) (toml_key, env_name) =
-  match env_lookup env_name with
-  | Some _ ->
+  if env_is_set env_lookup env_name then
     (* Caller env override — leave alone. *)
     false
-  | None ->
+  else
     match List.assoc_opt toml_key doc with
     | None -> false
     | Some v ->
@@ -166,9 +175,8 @@ let resolve_overrides
   let count =
     List.fold_left
       (fun acc (toml_key, env_name) ->
-        match env_lookup env_name with
-        | Some _ -> acc
-        | None ->
+        if env_is_set env_lookup env_name then acc
+        else
           match List.assoc_opt toml_key doc with
           | None -> acc
           | Some v ->

--- a/lib/keeper/keeper_runtime_config.mli
+++ b/lib/keeper/keeper_runtime_config.mli
@@ -11,6 +11,9 @@
       2. TOML value from [<resolved config root>/keeper_runtime.toml]
       3. Hardcoded default in [Env_config_keeper.KeeperKeepalive].
 
+    Legacy env names that are still honored at runtime also count as
+    process env overrides for their canonical TOML key.
+
     The TOML loader runs at server startup, before any module that reads
     these env vars initializes. It stores boot defaults in a process-local
     override table so existing config readers can resolve TOML-backed values
@@ -53,9 +56,17 @@ val resolve_overrides :
       [autonomous]
       max_turns_per_call          = 7
       semaphore_wait_timeout_sec  = 60
+      concurrency                 = 3
 
       [reactive]
       max_turns_per_call          = 15
+      concurrency                 = 4
+
+      [heartbeat]
+      sleep_chunk_sec             = 1.5
+      board_debounce_sec          = 30
+      board_generic_wakeup_limit  = 3
+      board_wakeup_max            = 4
 
       [turn]
       stream_idle_timeout_sec   = 120

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -921,9 +921,9 @@ let sweep_and_recover (ctx : _ context) =
       let ts = Time_compat.now () in
       Keeper_registry.record_crash ~base_path entry.name ts msg;
       Keeper_registry.record_error ~base_path entry.name msg;
-      match Keeper_registry.get ~base_path entry.name with
-      | Some updated -> queue_crashed_entry updated msg
-      | None -> ()
+      (match Keeper_registry.get ~base_path entry.name with
+       | Some updated -> queue_crashed_entry updated msg
+       | None -> ())
     end
   in
   List.iter (fun (entry : Keeper_registry.registry_entry) ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -132,6 +132,35 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
         ("detail", `Null);
       ])
 
+let transient_mutex_contention_error_class = "transient_mutex_contention"
+
+let transient_mutex_contention_tool_error
+    ~(tool_name : string)
+    ~(error_text : string)
+    ?backtrace
+    () : string =
+  let message =
+    Printf.sprintf
+      "tool %s hit transient mutex contention (EDEADLK); not counted toward consecutive-failure budget. Retry the same call or wait for the contending operation to finish."
+      tool_name
+  in
+  Yojson.Safe.to_string
+    (`Assoc [
+      ("ok", `Bool false);
+      ("error", `String message);
+      ("error_class", `String transient_mutex_contention_error_class);
+      ("recoverable", `Bool true);
+      ("transient", `Bool true);
+      ("retry_recommended", `Bool true);
+      ( "detail",
+        `Assoc [
+          ("tool_name", `String tool_name);
+          ("exception", `String error_text);
+          ("operator_action", `String "retry_same_call_or_wait");
+          ("backtrace_available", `Bool (Option.is_some backtrace));
+        ] );
+    ])
+
 (** Max chars for SSE error preview. Short enough for dashboard display,
     long enough to include the actionable portion of the error. *)
 let sse_error_preview_max_chars = 300
@@ -373,7 +402,7 @@ let make_keeper_tool_handler
         !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
         (* Tool-call observability via OAS Event_bus. See above. *)
         (try Sse.broadcast
-          (`Assoc [
+          (`Assoc ([
             ("type", `String "keeper_tool_call");
             ("name", `String meta.name);
             ("tool_name", `String name);
@@ -381,7 +410,15 @@ let make_keeper_tool_handler
             ("success", `Bool false);
             ("error_text", `String error_text);
             ("ts_unix", `Float ts);
-          ])
+          ]
+          @
+          if is_edeadlk then
+            [
+              ( "error_class",
+                `String transient_mutex_contention_error_class );
+              ("recoverable", `Bool true);
+            ]
+          else []))
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         let msg =
           if is_edeadlk then
@@ -400,11 +437,17 @@ let make_keeper_tool_handler
              Log.Keeper.error
                "tool %s EDEADLK backtrace (#10682):\n%s" name bt
          | None -> ());
-        let normalized_exn = normalize_tool_result ~success:false msg in
+        let normalized_exn =
+          if is_edeadlk then
+            transient_mutex_contention_tool_error
+              ~tool_name:name ~error_text ?backtrace:edeadlk_backtrace ()
+          else
+            normalize_tool_result ~success:false msg
+        in
         (try
           Keeper_types_support.append_jsonl_line
             (Keeper_types_support.keeper_decision_log_path config meta.name)
-            (`Assoc [
+            (`Assoc ([
               "ts_unix", `Float ts;
               "event", `String "tool_exec";
               "keeper_name", `String meta.name;
@@ -413,7 +456,15 @@ let make_keeper_tool_handler
               "result_bytes", `Int (String.length normalized_exn);
               "ok", `Bool false;
               "error", `String error_text;
-            ])
+            ]
+            @
+            if is_edeadlk then
+              [
+                ( "error_class",
+                  `String transient_mutex_contention_error_class );
+                ("recoverable", `Bool true);
+              ]
+            else []))
         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         Keeper_tool_call_log.set_truncation_info
           ~keeper_name:meta.name

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -47,6 +47,15 @@ val max_consecutive_failures : int
     as a string under [result] / [error]. *)
 val normalize_tool_result : success:bool -> string -> string
 
+(** Build the structured, recoverable envelope used when a keeper tool
+    raises mutex EDEADLK / "Resource deadlock avoided". *)
+val transient_mutex_contention_tool_error :
+  tool_name:string ->
+  error_text:string ->
+  ?backtrace:string ->
+  unit ->
+  string
+
 (** Max chars for the SSE error preview rendered to dashboards. *)
 val sse_error_preview_max_chars : int
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -661,6 +661,7 @@ let composite_execution_blocked execution =
 
 type composite_runtime_attention = {
   cra_is_live : bool;
+  cra_fiber_stop_requested : bool;
   cra_stale_long_enough : bool;
   cra_idle_attention : bool;
   cra_blocked : bool;
@@ -672,6 +673,9 @@ type composite_runtime_attention = {
 
 let composite_runtime_attention ~snapshot ~execution =
   let is_live = Option.value ~default:false (json_bool "is_live" snapshot) in
+  let fiber_stop_requested =
+    Option.value ~default:false (json_bool "fiber_stop_flag" snapshot)
+  in
   let latest = composite_latest_activity_epoch snapshot execution in
   let now = Unix.gettimeofday () in
   let stale_long_enough =
@@ -684,13 +688,16 @@ let composite_runtime_attention ~snapshot ~execution =
   in
   let blocked = composite_execution_blocked execution in
   let stale_without_live_turn = (not is_live) && stale_long_enough in
-  let needs_attention = blocked || stale_without_live_turn || idle_attention in
+  let needs_attention =
+    blocked || fiber_stop_requested || stale_without_live_turn || idle_attention
+  in
   let reason =
     match json_string "operator_disposition_reason" execution with
     | Some value when String.trim value <> "" -> Some value
     | _ -> (
         match json_string "terminal_reason_code" execution with
         | Some value when String.trim value <> "" -> Some value
+        | _ when fiber_stop_requested -> Some "fiber_stop_requested"
         | _ when idle_attention -> Some "idle_composite"
         | _ when stale_without_live_turn -> Some "not_live"
         | _ when blocked -> Some "runtime_blocked"
@@ -698,12 +705,14 @@ let composite_runtime_attention ~snapshot ~execution =
   in
   let state =
     if blocked then "blocked"
+    else if fiber_stop_requested then "stop_requested"
     else if idle_attention then "idle_stale"
     else if stale_without_live_turn then "stale"
     else "ok"
   in
   {
     cra_is_live = is_live;
+    cra_fiber_stop_requested = fiber_stop_requested;
     cra_stale_long_enough = stale_long_enough;
     cra_idle_attention = idle_attention;
     cra_blocked = blocked;
@@ -718,12 +727,15 @@ let composite_runtime_attention_json attention ~snapshot =
     [ "state", `String attention.cra_state
     ; "needs_attention", `Bool attention.cra_needs_attention
     ; "blocked", `Bool attention.cra_blocked
+    ; "fiber_stop_requested", `Bool attention.cra_fiber_stop_requested
     ; "reason", Json_util.string_opt_to_json attention.cra_reason
     ; "raw_phase", Json_util.string_opt_to_json (json_string "phase" snapshot)
     ; "is_live", `Bool attention.cra_is_live
     ; ( "source",
         `String
-          (if attention.cra_blocked then "execution_receipt" else "composite_snapshot") )
+          (if attention.cra_blocked then "execution_receipt"
+           else if attention.cra_fiber_stop_requested then "registry_fiber_stop"
+           else "composite_snapshot") )
     ]
 
 let fleet_fsm_action_payload ~keeper_name ~kind ~reason ~snapshot ~execution =
@@ -795,6 +807,11 @@ let composite_recommended_actions_json ~keeper_name ~snapshot ~execution ~attent
       [
         probe ("Inspect configuration/auth blocker: " ^ reason);
         message ("Resolve configuration/auth blocker: " ^ reason);
+      ]
+    else if attention.cra_fiber_stop_requested then
+      [
+        probe ("Inspect stop-requested keeper shutdown: " ^ reason);
+        message ("Confirm keeper shutdown or supervisor reap: " ^ reason);
       ]
     else if composite_execution_saturated execution && not stale_long_enough then
       [ probe ("Inspect local runtime saturation: " ^ reason) ]

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -102,13 +102,48 @@ let maybe_externalize ?(mime = "text/plain") (msg : string) : string =
 
 (** {1 Result Conversion} *)
 
-let make_tool_error ?(recoverable = false) message : Agent_sdk.Types.tool_result =
-  Error { Agent_sdk.Types.message; recoverable; error_class = None }
+let make_tool_error ?(recoverable = false) ?error_class message
+  : Agent_sdk.Types.tool_result =
+  Error { Agent_sdk.Types.message; recoverable; error_class }
+
+let tool_error_class_of_string s =
+  match String.lowercase_ascii (String.trim s) with
+  | "" -> None
+  | "transient" | "transient_mutex_contention" -> Some Agent_sdk.Types.Transient
+  | "deterministic" | "validation_error" -> Some Agent_sdk.Types.Deterministic
+  | "unknown" -> Some Agent_sdk.Types.Unknown
+  | _ -> Some Agent_sdk.Types.Unknown
+
+let tool_error_metadata_from_json_message msg =
+  try
+    match Yojson.Safe.from_string msg with
+    | `Assoc fields ->
+        let recoverable =
+          match List.assoc_opt "recoverable" fields with
+          | Some (`Bool true) -> true
+          | _ -> false
+        in
+        let error_class =
+          match List.assoc_opt "error_class" fields with
+          | Some (`String s) -> tool_error_class_of_string s
+          | _ -> None
+        in
+        (recoverable, error_class)
+    | _ -> (false, None)
+  with Yojson.Json_error _ -> (false, None)
+
+let recoverable_from_json_message msg =
+  fst (tool_error_metadata_from_json_message msg)
 
 let to_oas_tool_result ?(recoverable = false) (success, msg)
   : Agent_sdk.Types.tool_result =
   if success then Ok { Agent_sdk.Types.content = maybe_externalize msg }
-  else make_tool_error ~recoverable (maybe_externalize msg)
+  else
+    let json_recoverable, error_class =
+      tool_error_metadata_from_json_message msg
+    in
+    let recoverable = recoverable || json_recoverable in
+    make_tool_error ~recoverable ?error_class (maybe_externalize msg)
 
 let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
   | Ok { content } -> (true, content)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -514,7 +514,7 @@ let keeper_profile_cascade_name body keeper_name =
   | None -> fail ("keeper profile missing from cascade config: " ^ keeper_name)
 ;;
 
-let make_keeper_meta_json ?(name = "route_shadow_demo") () =
+let make_keeper_meta_json ?(name = "route_shadow_demo") ?(paused = true) () =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
@@ -524,7 +524,7 @@ let make_keeper_meta_json ?(name = "route_shadow_demo") () =
           ; "goal", `String "Route shadow regression fixture"
           ; "cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name
           ; "updated_at", `String "2026-04-04T00:00:00Z"
-          ; "paused", `Bool true
+          ; "paused", `Bool paused
           ])
   with
   | Ok meta -> Masc_mcp.Keeper_types.meta_to_json meta |> Yojson.Safe.pretty_to_string
@@ -1335,6 +1335,61 @@ let test_composite_routes_surface_runtime_recommended_actions () =
        actions)
 ;;
 
+let test_composite_runtime_attention_surfaces_fiber_stop () =
+  let base_path = Filename.temp_file "dashboard-keeper-fiber-stop-" "" in
+  (try Sys.remove base_path with
+   | _ -> ());
+  Unix.mkdir base_path 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "stop_requested_demo" in
+      let config = Masc_mcp.Coord.default_config base_path in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "bootstrap-admin"));
+      Fs_compat.mkdir_p (Masc_mcp.Keeper_types.keeper_dir config);
+      write_file
+        (Masc_mcp.Keeper_types.keeper_meta_path config keeper_name)
+        (make_keeper_meta_json ~name:keeper_name ~paused:false ());
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "keeper meta missing for fiber-stop composite test"
+        | Error err -> fail ("read_meta failed: " ^ err)
+      in
+      let entry =
+        Masc_mcp.Keeper_registry.register
+          ~base_path:config.base_path keeper_name meta
+      in
+      Atomic.set entry.fiber_stop true;
+      let open Yojson.Safe.Util in
+      let json =
+        Masc_mcp.Server_dashboard_http.dashboard_keeper_composite_json
+          ~config entry
+      in
+      let runtime_attention = json |> member "runtime_attention" in
+      check string "fiber-stop runtime state" "stop_requested"
+        (runtime_attention |> member "state" |> to_string);
+      check bool "fiber-stop runtime attention needed" true
+        (runtime_attention |> member "needs_attention" |> to_bool);
+      check bool "fiber-stop flag surfaced" true
+        (runtime_attention |> member "fiber_stop_requested" |> to_bool);
+      check string "fiber-stop runtime reason" "fiber_stop_requested"
+        (runtime_attention |> member "reason" |> to_string);
+      check string "fiber-stop runtime source" "registry_fiber_stop"
+        (runtime_attention |> member "source" |> to_string);
+      let actions = json |> member "recommended_actions" |> to_list in
+      check bool "fiber-stop does not recommend keeper_recover" false
+        (List.exists
+           (fun row -> row |> member "action_type" |> to_string = "keeper_recover")
+           actions);
+      check bool "fiber-stop recommends keeper_probe" true
+        (List.exists
+           (fun row -> row |> member "action_type" |> to_string = "keeper_probe")
+           actions))
+;;
+
 let test_composite_routes_skip_recent_successful_idle_recovery () =
   with_seeded_server
   @@ fun ~port ~config ~admin_token ~keeper_name ->
@@ -1585,6 +1640,10 @@ let () =
             "composite routes surface runtime recommended actions"
             `Slow
             test_composite_routes_surface_runtime_recommended_actions
+        ; test_case
+            "composite runtime attention surfaces fiber stop"
+            `Quick
+            test_composite_runtime_attention_surfaces_fiber_stop
         ; test_case
             "composite routes skip recent successful idle recovery"
             `Slow

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -309,6 +309,15 @@ let test_caller_env_wins_over_toml () =
   check int "applied 0 (env preempts)" 0 count;
   check int "no overrides" 0 (List.length overrides)
 
+let test_deprecated_autoboot_env_wins_over_toml () =
+  let doc = parse_or_fail "[bootstrap]\nautoboot_max = 12\n" in
+  let fake_env = env_with [("MASC_KEEPER_AUTOBOT_MAX", "2")] in
+  let count, overrides =
+    Keeper_runtime_config.resolve_overrides ~env_lookup:fake_env doc
+  in
+  check int "applied 0 (deprecated env preempts canonical TOML)" 0 count;
+  check int "no overrides" 0 (List.length overrides)
+
 let test_unknown_keys_ignored () =
   let doc = parse_or_fail
     "[autonomous]\n\
@@ -510,6 +519,7 @@ let () =
         ; test_case "applies memory overrides" `Quick test_applies_memory_overrides
         ; test_case "memory bank reads boot override knobs" `Quick test_memory_bank_reads_boot_override_knobs
         ; test_case "caller env wins over TOML" `Quick test_caller_env_wins_over_toml
+        ; test_case "deprecated autoboot env wins over TOML" `Quick test_deprecated_autoboot_env_wins_over_toml
         ; test_case "unknown keys ignored" `Quick test_unknown_keys_ignored
         ; test_case "parse error returns Error" `Quick test_parse_error_returns_error
         ; test_case "load_and_apply records boot override" `Quick test_load_and_apply_records_boot_override

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -520,6 +520,27 @@ let test_normalize_failure_plain_text () =
   check bool "ok is false" false (json_bool "ok" json);
   check string "error is raw text" raw (json_string "error" json)
 
+let test_transient_mutex_contention_envelope () =
+  let normalized =
+    Keeper_tools_oas.transient_mutex_contention_tool_error
+      ~tool_name:"keeper_shell"
+      ~error_text:"Sys_error(\"Mutex.lock: Resource deadlock avoided\")"
+      ~backtrace:"Raised at Mutex.lock" ()
+  in
+  let json = parse normalized in
+  check bool "ok is false" false (json_bool "ok" json);
+  check bool "recoverable" true
+    Yojson.Safe.Util.(member "recoverable" json |> to_bool);
+  check string "error_class" "transient_mutex_contention"
+    Yojson.Safe.Util.(member "error_class" json |> to_string);
+  check bool "retry recommended" true
+    Yojson.Safe.Util.(member "retry_recommended" json |> to_bool);
+  let detail = Yojson.Safe.Util.member "detail" json in
+  check string "tool_name" "keeper_shell"
+    Yojson.Safe.Util.(member "tool_name" detail |> to_string);
+  check bool "backtrace available" true
+    Yojson.Safe.Util.(member "backtrace_available" detail |> to_bool)
+
 (* ── Tool_output_validation tests (memory cap) ──────────────── *)
 
 let test_cap_short_unchanged () =
@@ -573,6 +594,8 @@ let () =
       test_case "failure extracts message from status:error" `Quick test_normalize_failure_status_error;
       test_case "failure handles ok:false hybrid" `Quick test_normalize_failure_ok_false;
       test_case "failure plain text wraps as error" `Quick test_normalize_failure_plain_text;
+      test_case "EDEADLK envelope is recoverable" `Quick
+        test_transient_mutex_contention_envelope;
     ];
     "research_profile", [
       test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -105,6 +105,20 @@ let test_to_oas_error_inlined () =
       Alcotest.(check string) "message" "fail" message;
       Alcotest.(check bool) "default recoverable=false" false recoverable
 
+let test_to_oas_error_uses_json_recoverable_flag () =
+  Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
+  let msg =
+    {|{"ok":false,"error":"try again","recoverable":true,"error_class":"transient_mutex_contention"}|}
+  in
+  match B.to_oas_tool_result (false, msg) with
+  | Ok _ -> Alcotest.fail "expected Error"
+  | Error { message; recoverable; error_class } ->
+      Alcotest.(check string) "message" msg message;
+      Alcotest.(check bool) "recoverable from JSON" true recoverable;
+      (match error_class with
+       | Some Agent_sdk.Types.Transient -> ()
+       | _ -> Alcotest.fail "expected transient error_class from JSON")
+
 (* --- Externalize round-trip needs an isolated test process due to the
        lazy singleton. We exercise it via the env-aware path. --- *)
 
@@ -165,6 +179,8 @@ let () =
         [
           Alcotest.test_case "small inlined" `Quick test_to_oas_small_inlined;
           Alcotest.test_case "error inlined" `Quick test_to_oas_error_inlined;
+          Alcotest.test_case "error recoverable from JSON" `Quick
+            test_to_oas_error_uses_json_recoverable_flag;
           Alcotest.test_case "round-trip through OAS" `Quick
             test_round_trip_through_oas;
         ] );


### PR DESCRIPTION
## Summary

- Follow-up to #12650: make backend `runtime_attention` the fleet UI source of truth when present, while preserving frontend healthy-idle fallback for benign backend `state="ok"`.
- Surface `fiber_stop_flag=true` as `runtime_attention.state="stop_requested"` so Running-but-stop-requested keepers do not look healthy between watchdog/supervisor sweeps.
- Mark keeper tool `EDEADLK` / "Resource deadlock avoided" as structured, recoverable `transient_mutex_contention` instead of an opaque hard failure.
- Preserve env precedence for legacy `MASC_KEEPER_AUTOBOT_MAX` and refresh keeper runtime TOML docs/schema comments.

## Changes

- Dashboard composite JSON now includes `fiber_stop_requested` and marks stop-requested registry state as attention-worthy.
- Recommended actions for stop-requested keepers now point operators at probe/confirm flow instead of `keeper_recover`.
- Dashboard schema parses `runtime_attention`; Fleet FSM matrix prefers backend attention when it is actionable, with fallback for older or healthy backends.
- Keeper tool exceptions for EDEADLK now emit `{recoverable:true,error_class:"transient_mutex_contention",retry_recommended:true}` and SSE/decision logs carry the same class.
- `Tool_bridge.to_oas_tool_result` propagates a JSON `recoverable:true` envelope into the `Agent_sdk` tool error.
- Runtime TOML resolution treats deprecated `MASC_KEEPER_AUTOBOT_MAX` as a caller env override for canonical `bootstrap.autoboot_max`.
- Docs and `.mli` comments now mention reactive concurrency, board generic/total wakeup caps, and reactive semaphore timeout behavior.

## Validation

- `scripts/dune-local.sh build test/test_keeper_runtime_toml.exe test/test_smart_heartbeat_keepalive.exe test/test_keeper_semaphore_fairness.exe test/test_dashboard_keeper_routes.exe bin/main_eio.exe`
- `scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe test/test_keeper_tools_oas.exe test/test_tool_bridge_externalize.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_runtime_toml.exe`
- `./_build/default/test/test_smart_heartbeat_keepalive.exe test board_wakeup_selection`
- `./_build/default/test/test_keeper_semaphore_fairness.exe`
- `MASC_E2E_TESTS=true ./_build/default/test/test_dashboard_keeper_routes.exe`
- `./_build/default/test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_tool_bridge_externalize.exe`
- `pnpm install --offline` in `dashboard/` to restore worktree-local node_modules from local store
- `pnpm typecheck`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/schemas/keeper-composite.test.ts src/components/fleet-fsm-matrix.test.ts`
