### PR TITLE
fix: isolate dashboard verification base path input

### DIFF
--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -31,18 +31,21 @@ let rec rm_rf path =
       Sys.remove path
 
 (** Create an isolated MASC base_path for the duration of [f].
-    Restores [MASC_BASE_PATH] afterwards so subsequent tests in the same
-    binary see the original value. *)
+    Restores [MASC_BASE_PATH] and [MASC_BASE_PATH_INPUT] afterwards so
+    subsequent tests in the same binary see the original value. *)
 let with_temp_base_path f =
   let dir = Filename.temp_dir "masc_dashboard_verify_test" "" in
-  let prior =
-    try Some (Unix.getenv "MASC_BASE_PATH") with Not_found -> None
+  let prior_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  let prior_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
+  let restore_env name = function
+    | Some v -> Unix.putenv name v
+    | None -> Unix.putenv name ""
   in
   Unix.putenv "MASC_BASE_PATH" dir;
+  Unix.putenv "MASC_BASE_PATH_INPUT" dir;
   let cleanup () =
-    (match prior with
-     | Some v -> Unix.putenv "MASC_BASE_PATH" v
-     | None -> Unix.putenv "MASC_BASE_PATH" "");
+    restore_env "MASC_BASE_PATH" prior_base;
+    restore_env "MASC_BASE_PATH_INPUT" prior_input;
     rm_rf dir
   in
   Fun.protect ~finally:cleanup (fun () -> f dir)

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -39,7 +39,7 @@ let with_temp_base_path f =
   let prior_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
   let restore_env name = function
     | Some v -> Unix.putenv name v
-    | None -> Unix.putenv name ""
+    | None -> Unix.unsetenv name
   in
   Unix.putenv "MASC_BASE_PATH" dir;
   Unix.putenv "MASC_BASE_PATH_INPUT" dir;


### PR DESCRIPTION
## Summary

- Update `test_dashboard_verification.ml` so its temporary base-path helper overrides both `MASC_BASE_PATH` and `MASC_BASE_PATH_INPUT`.
- Restore both variables after each test so later tests in the same binary inherit the original environment.

## Root cause

`Env_config_core.base_path()` prefers `MASC_BASE_PATH_INPUT` over `MASC_BASE_PATH`. The CI test wrapper sets `MASC_BASE_PATH_INPUT=/tmp/me`, while this test only changed `MASC_BASE_PATH`, so verification requests were written to the temp fixture path but dashboard reads still looked under `/tmp/me`. That produced empty request lists in the quick suite.

## Validation

- `scripts/dune-local.sh build test/test_dashboard_verification.exe`
- `env MASC_BASE_PATH=/tmp/me MASC_BASE_PATH_INPUT=/tmp/me ./_build/default/test/test_dashboard_verification.exe`
- `git diff --check`