### PR TITLE
fix: isolate keeper board signal hook failures

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -128,7 +128,7 @@ let set_keeper_board_signal_hook hook =
 
 let emit_keeper_board_signal signal =
   match Atomic.get keeper_board_signal_hook with
-  | Some hook -> hook signal
+  | Some hook -> Safe_ops.protect ~default:() (fun () -> hook signal)
   | None -> ()
 
 let board_sse_hook : (board_sse_event -> unit) option Atomic.t = Atomic.make None
@@ -161,7 +161,9 @@ let init_jsonl () =
 
 let reset_for_test () =
   Atomic.set backend_state Uninitialized;
-  Atomic.set flusher_started false
+  Atomic.set flusher_started false;
+  Atomic.set keeper_board_signal_hook None;
+  Atomic.set board_sse_hook None
 
 let jsonl_forced () =
   match Env_config.Board.backend_opt () with

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -81,6 +81,19 @@ let test_create_and_get_post () =
           Alcotest.(check string) "content matches"
             "dispatch test post" fetched.content
 
+let test_keeper_signal_hook_failure_does_not_abort_create_post () =
+  Board_dispatch.set_keeper_board_signal_hook (fun _ ->
+      failwith "keeper signal hook failed");
+  match
+    Board_dispatch.create_post ~author:"test-agent"
+      ~content:"post must survive keeper wake failure"
+      ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      Alcotest.(check string) "content persisted despite hook failure"
+        "post must survive keeper wake failure" post.content
+
 let test_structured_post_roundtrip () =
   let meta = `Assoc [("source", `String "keeper_autonomy")] in
   match Board_dispatch.create_post ~author:"sangsu"
@@ -534,6 +547,8 @@ let () =
     ];
     "posts", [
       Alcotest.test_case "create and get" `Quick (with_eio test_create_and_get_post);
+      Alcotest.test_case "keeper hook failure does not abort create" `Quick
+        (with_eio test_keeper_signal_hook_failure_does_not_abort_create_post);
       Alcotest.test_case "structured roundtrip" `Quick (with_eio test_structured_post_roundtrip);
       Alcotest.test_case "list" `Quick (with_eio test_list_posts);
       Alcotest.test_case "sort orders" `Quick (with_eio test_list_posts_with_sort);


### PR DESCRIPTION
## Summary

- Wrap keeper board signal hook execution in `Safe_ops.protect`.
- Clear keeper/SSE board hooks in `reset_for_test`.
- Add a regression proving `create_post` still succeeds when the keeper wake hook raises.

Fixes #12664.

## Why This Matters

The board is the world surface. Keeper wake/observer failures must not abort the environmental trace itself. A failing hook should be isolated to logs/telemetry, while the board mutation remains durable and the reaction chain can continue.

This is a deliberately small liveness hardening slice. Dashboard stopped-reaction truth and formal leads-to specs are tracked separately in #12665 and #12666.

## Verification

- `git diff --check`
- `scripts/dune-local.sh build test/test_board_dispatch.exe`
- `./_build/default/test/test_board_dispatch.exe`

## MASC Tracking

- Goal: `goal-world-reaction-liveness`
- Task: `task-132`
