### PR TITLE
feat(dashboard): add IDE syntax renderer substrate

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -67,6 +67,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `src/components/ide/code-document-store.ts` adds a typed read-only source document store with file/language metadata, CRLF normalization, line lookup, and bounded line parsing.
   - `src/components/ide/ide-editor-mock.ts` now consumes the code document store alongside RFC 0019 ownership data instead of embedding pre-numbered editor rows directly in the renderer.
 
+- **IDE syntax renderer substrate**
+  - `src/components/common/shiki-highlighter.ts` promotes the markdown Shiki loader/sanitizer into a shared dashboard boundary with block and line-level highlighting APIs.
+  - `src/components/ide/ide-code-renderer.ts` renders read-only editor rows from sanitized Shiki line HTML while preserving the code document and RFC 0019 ownership contracts.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/src/components/common/markdown-renderer.ts
+++ b/dashboard/src/components/common/markdown-renderer.ts
@@ -10,91 +10,7 @@ import { Marked } from 'marked'
 import DOMPurify from 'dompurify'
 
 import type MermaidDefault from 'mermaid'
-
-// ── Lazy shiki loader ────────────────────────────────────────
-interface DashboardHighlighter {
-  getLoadedLanguages(): string[]
-  loadLanguage(...langs: unknown[]): Promise<void>
-  codeToHtml(code: string, options: { lang: string; theme: string }): string
-}
-
-type ShikiLanguageModule = { default: unknown | unknown[] }
-type ShikiLanguageLoader = () => Promise<ShikiLanguageModule>
-
-const SHIKI_THEME = 'vitesse-dark'
-const SHIKI_LANG_ALIASES: Record<string, string> = {
-  js: 'javascript',
-  jsx: 'javascript',
-  ts: 'typescript',
-  tsx: 'typescript',
-  py: 'python',
-  sh: 'bash',
-  shell: 'bash',
-  zsh: 'bash',
-  yml: 'yaml',
-  md: 'markdown',
-}
-const SHIKI_LANG_LOADERS: Record<string, ShikiLanguageLoader> = {
-  bash: () => import('shiki/langs/bash.mjs'),
-  css: () => import('shiki/langs/css.mjs'),
-  diff: () => import('shiki/langs/diff.mjs'),
-  go: () => import('shiki/langs/go.mjs'),
-  html: () => import('shiki/langs/html.mjs'),
-  javascript: () => import('shiki/langs/javascript.mjs'),
-  json: () => import('shiki/langs/json.mjs'),
-  markdown: () => import('shiki/langs/markdown.mjs'),
-  ocaml: () => import('shiki/langs/ocaml.mjs'),
-  python: () => import('shiki/langs/python.mjs'),
-  rust: () => import('shiki/langs/rust.mjs'),
-  sql: () => import('shiki/langs/sql.mjs'),
-  typescript: () => import('shiki/langs/typescript.mjs'),
-  yaml: () => import('shiki/langs/yaml.mjs'),
-}
-
-let shikiPromise: Promise<DashboardHighlighter> | null = null
-let loadedShikiLanguages = new Set<string>()
-
-function getShiki(): Promise<DashboardHighlighter> {
-  if (!shikiPromise) {
-    shikiPromise = Promise.all([
-      import('shiki/core'),
-      import('shiki/engine/javascript'),
-      import('shiki/themes/vitesse-dark.mjs'),
-    ]).then(async ([shiki, engine, theme]) => {
-      loadedShikiLanguages = new Set()
-      return shiki.createHighlighterCore({
-        themes: [theme.default],
-        langs: [],
-        engine: engine.createJavaScriptRegexEngine(),
-      })
-    }).catch((err) => {
-      shikiPromise = null  // allow retry on next call
-      loadedShikiLanguages = new Set()
-      throw err
-    })
-  }
-  return shikiPromise
-}
-
-function normalizeShikiLang(lang: string): string {
-  const normalized = lang.trim().toLowerCase()
-  return SHIKI_LANG_ALIASES[normalized] ?? normalized
-}
-
-async function ensureShikiLanguage(highlighter: DashboardHighlighter, lang: string): Promise<string> {
-  const normalized = normalizeShikiLang(lang)
-  if (normalized === 'text') return 'text'
-  const loader = SHIKI_LANG_LOADERS[normalized]
-  if (!loader) return 'text'
-  if (loadedShikiLanguages.has(normalized) || highlighter.getLoadedLanguages().includes(normalized)) {
-    return normalized
-  }
-  const module = await loader()
-  const registrations = Array.isArray(module.default) ? module.default : [module.default]
-  await highlighter.loadLanguage(...registrations)
-  loadedShikiLanguages.add(normalized)
-  return normalized
-}
+import { highlightCodeHtml } from './shiki-highlighter'
 
 // ── Lazy mermaid loader ──────────────────────────────────────
 type MermaidApi = typeof MermaidDefault
@@ -152,17 +68,6 @@ const PURIFY_CONFIG = {
 
 function sanitize(raw: string): string {
   return DOMPurify.sanitize(raw, PURIFY_CONFIG)
-}
-
-// Shiki generates <span style="color: ..."> for syntax tokens.
-// Allow `style` only when sanitizing trusted Shiki output.
-const SHIKI_PURIFY_CONFIG = {
-  ALLOWED_TAGS: ['pre', 'code', 'span'],
-  ALLOWED_ATTR: ['class', 'style'],
-}
-
-function sanitizeShikiHtml(raw: string): string {
-  return DOMPurify.sanitize(raw, SHIKI_PURIFY_CONFIG)
 }
 
 function sanitizeMermaidSvg(raw: string): SVGElement | null {
@@ -277,8 +182,6 @@ export function MarkdownContent({ text, class: className }: { text: string; clas
 
     let cancelled = false
     void (async () => {
-      let highlighter: DashboardHighlighter | null = null
-      
       for (const codeEl of codeBlocks) {
         if (cancelled) break
         if (codeEl.dataset.highlighted) continue
@@ -294,23 +197,10 @@ export function MarkdownContent({ text, class: className }: { text: string; clas
             break
           }
         }
-        
-        if (!highlighter) {
-          highlighter = await getShiki()
+
+        try {
+          const safeHtml = await highlightCodeHtml(code, lang)
           if (cancelled) break
-        }
-
-        try {
-          lang = await ensureShikiLanguage(highlighter, lang)
-        } catch {
-          lang = 'text'
-        }
-        
-        if (cancelled) break
-
-        try {
-          const rawHtml = highlighter.codeToHtml(code, { lang, theme: SHIKI_THEME })
-          const safeHtml = sanitizeShikiHtml(rawHtml)
 
           const div = document.createElement('div')
           div.innerHTML = safeHtml

--- a/dashboard/src/components/common/shiki-highlighter.test.ts
+++ b/dashboard/src/components/common/shiki-highlighter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { highlightCodeHtml, highlightCodeLines } from './shiki-highlighter'
+
+describe('shiki-highlighter', () => {
+  it('returns sanitized shiki block html', async () => {
+    const html = await highlightCodeHtml('const x = 1', 'typescript')
+
+    expect(html).toContain('<pre')
+    expect(html).toContain('const')
+    expect(html).toContain('x')
+    expect(html).not.toContain('<script>')
+  })
+
+  it('extracts sanitized line html for editor rows', async () => {
+    const lines = await highlightCodeLines('const x = 1\n\nreturn x', 'ts', 3)
+    const firstLine = document.createElement('span')
+    firstLine.innerHTML = lines[0] ?? ''
+
+    expect(lines).toHaveLength(3)
+    expect(firstLine.textContent).toContain('const x = 1')
+    expect(lines[1]).toBe('')
+  })
+
+  it('keeps dangerous-looking code as text, not DOM', async () => {
+    const lines = await highlightCodeLines('<script>alert("xss")</script>', 'html', 1)
+    const line = document.createElement('span')
+    line.innerHTML = lines[0] ?? ''
+
+    expect(line.querySelector('script')).toBeNull()
+    expect(line.textContent).toContain('<script>alert("xss")</script>')
+  })
+})

--- a/dashboard/src/components/common/shiki-highlighter.ts
+++ b/dashboard/src/components/common/shiki-highlighter.ts
@@ -1,0 +1,146 @@
+import DOMPurify from 'dompurify'
+
+interface DashboardHighlighter {
+  getLoadedLanguages(): string[]
+  loadLanguage(...langs: unknown[]): Promise<void>
+  codeToHtml(code: string, options: { lang: string; theme: string }): string
+}
+
+type ShikiLanguageModule = { default: unknown | unknown[] }
+type ShikiLanguageLoader = () => Promise<ShikiLanguageModule>
+
+const SHIKI_THEME = 'vitesse-dark'
+const SHIKI_LANG_ALIASES: Record<string, string> = {
+  js: 'javascript',
+  jsx: 'javascript',
+  ts: 'typescript',
+  tsx: 'typescript',
+  py: 'python',
+  sh: 'bash',
+  shell: 'bash',
+  zsh: 'bash',
+  yml: 'yaml',
+  md: 'markdown',
+}
+const SHIKI_LANG_LOADERS: Record<string, ShikiLanguageLoader> = {
+  bash: () => import('shiki/langs/bash.mjs'),
+  css: () => import('shiki/langs/css.mjs'),
+  diff: () => import('shiki/langs/diff.mjs'),
+  go: () => import('shiki/langs/go.mjs'),
+  html: () => import('shiki/langs/html.mjs'),
+  javascript: () => import('shiki/langs/javascript.mjs'),
+  json: () => import('shiki/langs/json.mjs'),
+  markdown: () => import('shiki/langs/markdown.mjs'),
+  ocaml: () => import('shiki/langs/ocaml.mjs'),
+  python: () => import('shiki/langs/python.mjs'),
+  rust: () => import('shiki/langs/rust.mjs'),
+  sql: () => import('shiki/langs/sql.mjs'),
+  typescript: () => import('shiki/langs/typescript.mjs'),
+  yaml: () => import('shiki/langs/yaml.mjs'),
+}
+
+const SHIKI_PURIFY_CONFIG = {
+  ALLOWED_TAGS: ['pre', 'code', 'span'],
+  ALLOWED_ATTR: ['class', 'style'],
+}
+
+let shikiPromise: Promise<DashboardHighlighter> | null = null
+let loadedShikiLanguages = new Set<string>()
+
+export async function highlightCodeHtml(code: string, lang: string): Promise<string> {
+  const highlighter = await getShiki()
+  const loadedLang = await ensureShikiLanguage(highlighter, lang).catch(() => 'text')
+  const rawHtml = highlighter.codeToHtml(code, { lang: loadedLang, theme: SHIKI_THEME })
+  return sanitizeShikiHtml(rawHtml)
+}
+
+export async function highlightCodeLines(
+  code: string,
+  lang: string,
+  expectedLineCount = splitCodeLines(code).length,
+): Promise<ReadonlyArray<string>> {
+  if (expectedLineCount === 0) return []
+  const safeHtml = await highlightCodeHtml(code, lang)
+  const div = document.createElement('div')
+  div.innerHTML = safeHtml
+  const codeEl = div.querySelector('code')
+  if (!codeEl) return plainEscapedLines(code, expectedLineCount)
+
+  let lineHtml = Array.from(codeEl.children)
+    .filter((child): child is HTMLElement => child instanceof HTMLElement && child.classList.contains('line'))
+    .map(line => line.innerHTML)
+  if (lineHtml.length === expectedLineCount + 1 && lineHtml[lineHtml.length - 1] === '') {
+    lineHtml = lineHtml.slice(0, expectedLineCount)
+  }
+  if (lineHtml.length !== expectedLineCount) {
+    return plainEscapedLines(code, expectedLineCount)
+  }
+  return lineHtml
+}
+
+function getShiki(): Promise<DashboardHighlighter> {
+  if (!shikiPromise) {
+    shikiPromise = Promise.all([
+      import('shiki/core'),
+      import('shiki/engine/javascript'),
+      import('shiki/themes/vitesse-dark.mjs'),
+    ]).then(async ([shiki, engine, theme]) => {
+      loadedShikiLanguages = new Set()
+      return shiki.createHighlighterCore({
+        themes: [theme.default],
+        langs: [],
+        engine: engine.createJavaScriptRegexEngine(),
+      })
+    }).catch((err) => {
+      shikiPromise = null
+      loadedShikiLanguages = new Set()
+      throw err
+    })
+  }
+  return shikiPromise
+}
+
+function normalizeShikiLang(lang: string): string {
+  const normalized = lang.trim().toLowerCase()
+  return SHIKI_LANG_ALIASES[normalized] ?? normalized
+}
+
+async function ensureShikiLanguage(highlighter: DashboardHighlighter, lang: string): Promise<string> {
+  const normalized = normalizeShikiLang(lang)
+  if (normalized === 'text') return 'text'
+  const loader = SHIKI_LANG_LOADERS[normalized]
+  if (!loader) return 'text'
+  if (loadedShikiLanguages.has(normalized) || highlighter.getLoadedLanguages().includes(normalized)) {
+    return normalized
+  }
+  const module = await loader()
+  const registrations = Array.isArray(module.default) ? module.default : [module.default]
+  await highlighter.loadLanguage(...registrations)
+  loadedShikiLanguages.add(normalized)
+  return normalized
+}
+
+function sanitizeShikiHtml(raw: string): string {
+  return DOMPurify.sanitize(raw, SHIKI_PURIFY_CONFIG)
+}
+
+function plainEscapedLines(code: string, expectedLineCount: number): ReadonlyArray<string> {
+  const lines = splitCodeLines(code)
+    .slice(0, expectedLineCount)
+    .map(escapeHtml)
+  while (lines.length < expectedLineCount) lines.push('')
+  return lines
+}
+
+function splitCodeLines(code: string): ReadonlyArray<string> {
+  const normalized = code.replace(/\r\n?/g, '\n')
+  if (normalized === '') return []
+  const body = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized
+  return body.split('\n')
+}
+
+function escapeHtml(value: string): string {
+  const span = document.createElement('span')
+  span.textContent = value
+  return span.innerHTML
+}

--- a/dashboard/src/components/ide/ide-code-renderer.ts
+++ b/dashboard/src/components/ide/ide-code-renderer.ts
@@ -1,0 +1,50 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import { highlightCodeLines } from '../common/shiki-highlighter'
+import type { CodeDocumentLine, CodeDocumentSnapshot } from './code-document-store'
+
+export function useHighlightedCodeLines(document: CodeDocumentSnapshot): ReadonlyArray<string> {
+  const [highlightedLines, setHighlightedLines] = useState<ReadonlyArray<string>>([])
+
+  useEffect(() => {
+    let cancelled = false
+    setHighlightedLines([])
+    void highlightCodeLines(document.content, document.language, document.lines.length)
+      .then(lines => {
+        if (!cancelled) setHighlightedLines(lines)
+      })
+      .catch(() => {
+        if (!cancelled) setHighlightedLines([])
+      })
+
+    return () => { cancelled = true }
+  }, [document.content, document.language, document.lines.length])
+
+  return highlightedLines
+}
+
+export function CodeLineText({
+  line,
+  highlightedHtml,
+}: {
+  line: CodeDocumentLine
+  highlightedHtml: string | undefined
+}) {
+  const style = {
+    color: 'var(--color-fg-secondary)',
+    display: 'block',
+    minWidth: 0,
+    whiteSpace: 'pre',
+  }
+  if (highlightedHtml !== undefined) {
+    return html`
+      <span
+        class="ide-code-line"
+        data-syntax="shiki"
+        style=${style}
+        dangerouslySetInnerHTML=${{ __html: highlightedHtml }}
+      ></span>
+    `
+  }
+  return html`<span class="ide-code-line" data-syntax="plain" style=${style}>${line.text}</span>`
+}

--- a/dashboard/src/components/ide/ide-editor-mock.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { IdeEditorMock } from './ide-editor-mock'
 
 describe('IdeEditorMock', () => {
@@ -24,5 +25,15 @@ describe('IdeEditorMock', () => {
     const rows = container.querySelectorAll('li')
     expect(rows[6]?.textContent).toContain('—')
     expect(rows[14]?.textContent).toContain('—')
+  })
+
+  it('upgrades editor text rows through the read-only shiki renderer', async () => {
+    const container = document.createElement('div')
+    render(h(IdeEditorMock, {}), container)
+
+    await waitFor(() => {
+      expect(container.querySelector('.ide-code-line[data-syntax="shiki"]')).not.toBeNull()
+    })
+    expect(container.textContent).toContain("import { Provider, ProviderKind } from './provider'")
   })
 })

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -4,6 +4,7 @@ import {
   createCodeDocumentStore,
   type CodeDocumentLine,
 } from './code-document-store'
+import { CodeLineText, useHighlightedCodeLines } from './ide-code-renderer'
 import {
   createKeeperLineOwnershipStore,
   type KeeperEdit,
@@ -12,8 +13,8 @@ import {
 
 // PR-5 precursor: the editor remains a read-only fixture, but both source
 // document rows and blame-by-keeper ownership now flow through typed stores.
-// Replacing the row text renderer with Shiki/CodeMirror can keep these same
-// CodeDocumentLine + LineOwnership contracts.
+// The syntax renderer is deliberately read-only and keeps the same
+// CodeDocumentLine + LineOwnership contracts for a future CodeMirror swap.
 
 const EDITOR_FILE = 'runtime/cascade/router.ts'
 
@@ -88,6 +89,7 @@ export function IdeEditorMock() {
   const lines = documentStore.lines()
   const ownership = ownershipStore.ownership()
   const keepers = ownershipStore.knownKeepers()
+  const highlightedLines = useHighlightedCodeLines(document)
 
   return html`
     <div
@@ -126,7 +128,7 @@ export function IdeEditorMock() {
           lineHeight: 1.6,
         }}
       >
-        ${lines.map(line => MockEditorRow(line, ownership.get(line.num)))}
+        ${lines.map(line => MockEditorRow(line, ownership.get(line.num), highlightedLines[line.num - 1]))}
       </ol>
     </div>
   `
@@ -138,7 +140,7 @@ function keeperColor(owner: LineOwnership | undefined): string {
     : 'var(--color-fg-disabled)'
 }
 
-function MockEditorRow(line: CodeDocumentLine, owner: LineOwnership | undefined) {
+function MockEditorRow(line: CodeDocumentLine, owner: LineOwnership | undefined, highlightedHtml: string | undefined) {
   const color = keeperColor(owner)
   const dot = owner
     ? color
@@ -163,7 +165,7 @@ function MockEditorRow(line: CodeDocumentLine, owner: LineOwnership | undefined)
       >${owner?.keeper_id ?? '—'}</span>
       <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, justifySelf: 'center' }} />
       <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', minWidth: '24px', textAlign: 'right' }}>${line.num}</span>
-      <span style=${{ color: 'var(--color-fg-secondary)', whiteSpace: 'pre' }}>${line.text}</span>
+      <${CodeLineText} line=${line} highlightedHtml=${highlightedHtml} />
     </li>
   `
 }


### PR DESCRIPTION
## Summary
- extract markdown Shiki loading/sanitization into a shared dashboard highlighter boundary
- add line-level Shiki HTML extraction for read-only IDE editor rows
- wire the IDE mock to render sanitized syntax-highlighted lines while preserving code document and RFC 0019 ownership contracts

## Validation
- pnpm vitest run --config vitest.config.ts src/components/common/shiki-highlighter.test.ts src/components/common/markdown.test.ts src/components/common/markdown-renderer.test.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm exec eslint src/components/common/markdown-renderer.ts src/components/common/shiki-highlighter.ts src/components/common/shiki-highlighter.test.ts src/components/ide/ide-code-renderer.ts src/components/ide/ide-editor-mock.ts src/components/ide/ide-editor-mock.test.ts
- git diff --check
- pnpm build
- pnpm lint (exit 0; existing unrelated unused eslint-disable warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)