### PR TITLE
fix: log keeper board hook failures

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -128,7 +128,13 @@ let set_keeper_board_signal_hook hook =
 
 let emit_keeper_board_signal signal =
   match Atomic.get keeper_board_signal_hook with
-  | Some hook -> Safe_ops.protect ~default:() (fun () -> hook signal)
+  | Some hook ->
+      (try hook signal
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.BoardLog.error "Keeper board signal hook failed: %s"
+             (Exn.to_string exn))
   | None -> ()
 
 let board_sse_hook : (board_sse_event -> unit) option Atomic.t = Atomic.make None

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -94,6 +94,18 @@ let test_keeper_signal_hook_failure_does_not_abort_create_post () =
       Alcotest.(check string) "content persisted despite hook failure"
         "post must survive keeper wake failure" post.content
 
+let test_keeper_signal_hook_cancellation_propagates () =
+  Board_dispatch.set_keeper_board_signal_hook (fun _ ->
+      raise (Eio.Cancel.Cancelled (Failure "synthetic-cancel")));
+  let raised = ref false in
+  (try
+     ignore
+       (Board_dispatch.create_post ~author:"test-agent"
+          ~content:"cancel should propagate through keeper wake hook"
+          ~post_kind:Board.Human_post ());
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  Alcotest.(check bool) "cancellation propagated" true !raised
+
 let test_structured_post_roundtrip () =
   let meta = `Assoc [("source", `String "keeper_autonomy")] in
   match Board_dispatch.create_post ~author:"sangsu"
@@ -549,6 +561,8 @@ let () =
       Alcotest.test_case "create and get" `Quick (with_eio test_create_and_get_post);
       Alcotest.test_case "keeper hook failure does not abort create" `Quick
         (with_eio test_keeper_signal_hook_failure_does_not_abort_create_post);
+      Alcotest.test_case "keeper hook cancellation propagates" `Quick
+        (with_eio test_keeper_signal_hook_cancellation_propagates);
       Alcotest.test_case "structured roundtrip" `Quick (with_eio test_structured_post_roundtrip);
       Alcotest.test_case "list" `Quick (with_eio test_list_posts);
       Alcotest.test_case "sort orders" `Quick (with_eio test_list_posts_with_sort);


### PR DESCRIPTION
## Summary
- replace the keeper board signal hook boundary with explicit cancel-aware try/logging
- keep ordinary hook failures isolated from board persistence while making them visible in board logs
- add a regression proving `Eio.Cancel.Cancelled` still propagates

## Why it matters
This is a narrow follow-up to #12664 / PR #12667. Board writes must survive wake hook failures, but broken reaction plumbing cannot be silent; otherwise the world appears to accept stimuli while keepers stop reacting. Cancellation also has to keep flowing so supervisor shutdown and fiber cancellation remain correct.

## Verification
- `git diff --check`
- `scripts/dune-local.sh build test/test_board_dispatch.exe`
- `./_build/default/test/test_board_dispatch.exe`

Fixes #12677