### PR TITLE
feat(dashboard): deep-link IDE layers

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -71,6 +71,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `src/components/common/shiki-highlighter.ts` promotes the markdown Shiki loader/sanitizer into a shared dashboard boundary with block and line-level highlighting APIs.
   - `src/components/ide/ide-code-renderer.ts` renders read-only editor rows from sanitized Shiki line HTML while preserving the code document and RFC 0019 ownership contracts.
 
+- **IDE LAYERS deep-link substrate**
+  - `design-system/headless-core/layered-overlay.ts` now accepts external active-layer snapshots for URL hydration while preserving RFC 0020 exclusive-layer semantics.
+  - `src/components/ide/ide-shell.ts` persists the LAYERS bar to the route `layers=` param, so editor overlay state survives deep links and view-tab changes.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/design-system/headless-core/layered-overlay.test.ts
+++ b/dashboard/design-system/headless-core/layered-overlay.test.ts
@@ -113,6 +113,29 @@ describe('createLayeredOverlay', () => {
     expect(count).toBe(0)
   })
 
+  it('sets active layers from external state in registration order', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.setActive(new Set(['approve', 'bogus', 'time']))
+    expect([...c.active()]).toEqual(['time', 'approve'])
+  })
+
+  it('normalizes exclusive layer conflicts when setting external state', () => {
+    const c = createLayeredOverlay(LAYERS)
+    c.setActive(new Set(['time', 'explode', 'notes']))
+    expect([...c.active()]).toEqual(['explode'])
+  })
+
+  it('setActive is a no-op when the normalized active set is unchanged', () => {
+    const c = createLayeredOverlay(LAYERS)
+    let count = 0
+    c.setActive(new Set(['time']))
+    c.subscribe(() => {
+      count += 1
+    })
+    c.setActive(new Set(['time']))
+    expect(count).toBe(0)
+  })
+
   it('active() snapshots are isolated from internal state', () => {
     const c = createLayeredOverlay(LAYERS)
     c.toggle('time')

--- a/dashboard/design-system/headless-core/layered-overlay.ts
+++ b/dashboard/design-system/headless-core/layered-overlay.ts
@@ -34,6 +34,7 @@ export interface LayeredOverlayController {
   readonly layers: ReadonlyArray<OverlayLayer>
   readonly active: () => ReadonlySet<string>
   readonly toggle: (kind: string) => void
+  readonly setActive: (active: ReadonlySet<string>) => void
   readonly clear: () => void
   readonly isActive: (kind: string) => boolean
   readonly subscribe: (listener: (active: ReadonlySet<string>) => void) => () => void
@@ -59,6 +60,25 @@ export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): Layer
   }
 
   const isExclusive = (kind: string): boolean => layerByKind.get(kind)?.mutuallyExclusive === true
+
+  const sameActive = (left: ReadonlySet<string>, right: ReadonlySet<string>): boolean => {
+    if (left.size !== right.size) return false
+    for (const kind of left) {
+      if (!right.has(kind)) return false
+    }
+    return true
+  }
+
+  const normalizeActive = (active: ReadonlySet<string>): Set<string> => {
+    const requested = new Set([...active].filter(kind => layerByKind.has(kind)))
+    const exclusive = layers.find(layer => layer.mutuallyExclusive === true && requested.has(layer.kind))
+    if (exclusive) return new Set([exclusive.kind])
+    const next = new Set<string>()
+    for (const layer of layers) {
+      if (requested.has(layer.kind)) next.add(layer.kind)
+    }
+    return next
+  }
 
   const hasExclusiveActive = (): string | null => {
     for (const kind of activeSet) {
@@ -89,6 +109,13 @@ export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): Layer
     emit()
   }
 
+  const setActive = (active: ReadonlySet<string>): void => {
+    const next = normalizeActive(active)
+    if (sameActive(activeSet, next)) return
+    activeSet = next
+    emit()
+  }
+
   const clear = (): void => {
     if (activeSet.size === 0) return
     activeSet = new Set()
@@ -105,7 +132,7 @@ export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): Layer
     }
   }
 
-  return { layers, active, toggle, clear, isActive, subscribe }
+  return { layers, active, toggle, setActive, clear, isActive, subscribe }
 }
 
 /**

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { IdeShell } from './ide-shell'
+import { route } from '../../router'
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button'))
+    .find(candidate => candidate.textContent === text)
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`missing button: ${text}`)
+  }
+  return button
+}
+
+describe('IdeShell', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+  })
+
+  afterEach(() => {
+    render(null, container)
+    window.location.hash = ''
+    route.value = { tab: 'overview', params: {}, postId: null }
+  })
+
+  it('hydrates layer buttons from the route layers param', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', layers: 'time,approve' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('persists layer toggles back to the route', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'split-diff', layers: 'time,approve' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    fireEvent.click(buttonByText(container, 'Tools'))
+
+    expect(route.value.params.view).toBe('split-diff')
+    expect(route.value.params.layers).toBe('approve,time,tools')
+
+    fireEvent.click(buttonByText(container, 'EXPLODE'))
+    expect(route.value.params.layers).toBe('explode')
+  })
+})

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -5,8 +5,12 @@ import { IdeEditorMock } from './ide-editor-mock'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 import { IdeActivityMock } from './ide-activity-mock'
 import { IdeInterjectMock } from './ide-interject-mock'
-import { IdeToolbar } from './ide-toolbar'
+import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { navigate, route } from '../../router'
+import {
+  parseActive,
+  serializeActive,
+} from '../../../design-system/headless-core/layered-overlay'
 
 // PR-3: 4-pane CODE mode shell with editor toolbar (view tabs + LAYERS
 // toggle, RFC 0020 controller). Layout matches the cockpit IdePlane
@@ -25,6 +29,7 @@ import { navigate, route } from '../../router'
 //   dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md
 
 type ViewTab = 'source' | 'split-diff' | 'unified' | 'blame'
+const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
 
 function viewFromRoute(raw: string | null | undefined): ViewTab {
   const normalized = raw
@@ -37,8 +42,28 @@ function viewFromRoute(raw: string | null | undefined): ViewTab {
   return 'source'
 }
 
+function layersFromRoute(raw: string | null | undefined): ReadonlySet<string> {
+  return parseActive(raw ?? '', IDE_LAYER_KINDS)
+}
+
+function paramsWithLayers(
+  params: Record<string, string>,
+  view: ViewTab,
+  activeLayers: ReadonlySet<string>,
+): Record<string, string> {
+  const next: Record<string, string> = { ...params, section: 'ide-shell', view }
+  const serialized = serializeActive(activeLayers)
+  if (serialized) {
+    next.layers = serialized
+  } else {
+    delete next.layers
+  }
+  return next
+}
+
 export function IdeShell() {
   const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
+  const activeLayers = layersFromRoute(route.value.params.layers)
 
   useEffect(() => {
     const next = viewFromRoute(route.value.params.view)
@@ -48,6 +73,10 @@ export function IdeShell() {
   const handleViewChange = (next: ViewTab) => {
     setActiveView(next)
     navigate('code', { ...route.value.params, section: 'ide-shell', view: next })
+  }
+
+  const handleLayersChange = (nextLayers: ReadonlySet<string>) => {
+    navigate('code', paramsWithLayers(route.value.params, activeView, nextLayers))
   }
 
   return html`
@@ -80,7 +109,12 @@ export function IdeShell() {
         <span>* runtime / main / nick0cave@dkr-a1 / improver@wt-run-47</span>
         <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok, var(--ok))' }}>● mcp · connected</span>
       </header>
-      <${IdeToolbar} activeView=${activeView} onViewChange=${handleViewChange} />
+      <${IdeToolbar}
+        activeView=${activeView}
+        activeLayers=${activeLayers}
+        onViewChange=${handleViewChange}
+        onLayersChange=${handleLayersChange}
+      />
       <div
         class="ide-plane-grid"
         role="presentation"

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useMemo } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
 import {
   createLayeredOverlay,
   type OverlayLayer,
@@ -22,7 +22,7 @@ const VIEW_TABS: ReadonlyArray<{ readonly id: ViewTab; readonly label: string }>
   { id: 'blame', label: 'BLAME' },
 ]
 
-const LAYERS: ReadonlyArray<OverlayLayer> = [
+export const IDE_LAYERS: ReadonlyArray<OverlayLayer> = [
   { kind: 'time', label: 'Time', description: '변경 timestamp gradient' },
   { kind: 'parallel', label: 'Parallel', description: '동시 keeper 작업 표시' },
   { kind: 'tools', label: 'Tools', description: 'MCP tool 호출' },
@@ -33,12 +33,27 @@ const LAYERS: ReadonlyArray<OverlayLayer> = [
 
 interface IdeToolbarProps {
   readonly activeView: ViewTab
+  readonly activeLayers: ReadonlySet<string>
   readonly onViewChange: (id: ViewTab) => void
+  readonly onLayersChange: (active: ReadonlySet<string>) => void
 }
 
-export function IdeToolbar({ activeView, onViewChange }: IdeToolbarProps) {
-  const controller = useMemo(() => createLayeredOverlay(LAYERS), [])
-  const { active, toggle, isActive } = useLayeredOverlay(controller)
+export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersChange }: IdeToolbarProps) {
+  const controller = useMemo(() => {
+    const next = createLayeredOverlay(IDE_LAYERS)
+    next.setActive(activeLayers)
+    return next
+  }, [])
+  const { active, isActive } = useLayeredOverlay(controller)
+
+  useEffect(() => {
+    controller.setActive(activeLayers)
+  }, [controller, activeLayers])
+
+  const handleLayerToggle = (kind: string) => {
+    controller.toggle(kind)
+    onLayersChange(controller.active())
+  }
 
   return html`
     <div
@@ -86,11 +101,11 @@ export function IdeToolbar({ activeView, onViewChange }: IdeToolbarProps) {
         }}
       >
         <span>LAYERS</span>
-        ${LAYERS.map(layer => html`
+        ${IDE_LAYERS.map(layer => html`
           <button
             type="button"
             aria-pressed=${isActive(layer.kind) ? 'true' : 'false'}
-            onClick=${() => toggle(layer.kind)}
+            onClick=${() => handleLayerToggle(layer.kind)}
             title=${layer.description}
             style=${{
               padding: '2px 8px',


### PR DESCRIPTION
## Summary
- add external active-layer hydration to the layered overlay controller while preserving exclusive-layer normalization
- wire IDE LAYERS state through the code route layers= param for deep links and reload persistence
- cover route hydration, route persistence, and controller normalization with focused tests

## Validation
- pnpm vitest run --config vitest.config.ts design-system/headless-core/layered-overlay.test.ts src/components/ide/ide-shell.test.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm vitest run --config vitest.config.ts design-system/headless-core/layered-overlay.test.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm exec eslint design-system/headless-core/layered-overlay.ts design-system/headless-core/layered-overlay.test.ts src/components/ide/ide-toolbar.ts src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts
  - eslint exited 0; headless-core files are ignored by the current dashboard ESLint config
- git diff --check
- pnpm build
  - completed with existing Vite dynamic import/chunk-size warnings