### PR TITLE
fix: feed queued board stimuli into keeper turns

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -355,24 +355,44 @@ let run_keepalive_unified_turn
          a real runtime transition: a stimulus that triggered the
          heartbeat override (PR-C2 #12412) is now actually consumed
          here. *)
-      (match
-         Keeper_registry.dequeue_event
-           ~base_path:ctx.config.base_path
-           meta_after_triage.name
-       with
-       | None -> ()
-       | Some stim ->
-           let urgency_str =
-             match stim.urgency with
-             | Keeper_event_queue.Immediate -> "immediate"
-             | Keeper_event_queue.Normal -> "normal"
-             | Keeper_event_queue.Low -> "low"
-           in
-           Log.Keeper.info
-             "turn entry: consumed stimulus stimulus_id=%s urgency=%s payload_len=%d (keeper=%s)"
-             stim.post_id urgency_str
-             (String.length stim.payload)
-             meta_after_triage.name);
+      let queued_board_event =
+        match
+          Keeper_registry.dequeue_event
+            ~base_path:ctx.config.base_path
+            meta_after_triage.name
+        with
+        | None -> None
+        | Some stim ->
+            let urgency_str =
+              match stim.urgency with
+              | Keeper_event_queue.Immediate -> "immediate"
+              | Keeper_event_queue.Normal -> "normal"
+              | Keeper_event_queue.Low -> "low"
+            in
+            Log.Keeper.info
+              "turn entry: consumed stimulus stimulus_id=%s urgency=%s payload_len=%d (keeper=%s)"
+              stim.post_id urgency_str
+              (String.length stim.payload)
+              meta_after_triage.name;
+            Keeper_world_observation.pending_board_event_of_stimulus
+              ~continuity_summary:meta_after_triage.continuity_summary
+              ~meta:meta_after_triage stim
+      in
+      let pending_board_events =
+        match queued_board_event with
+        | None -> pending_board_events
+        | Some event
+          when List.exists
+                 (fun existing -> String.equal existing.Keeper_world_observation.post_id event.post_id)
+                 pending_board_events ->
+            pending_board_events
+        | Some event ->
+            Log.Keeper.info
+              "turn entry: promoted queued board stimulus post_id=%s keeper=%s"
+              event.Keeper_world_observation.post_id
+              meta_after_triage.name;
+            event :: pending_board_events
+      in
       let obs =
         let allowed_tool_names =
           Keeper_tool_policy.keeper_allowed_tool_names meta_after_triage

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -552,6 +552,119 @@ let board_signal_wake_reason
          | `Never | `No_new_external -> None)
     | Board_dispatch.Board_post_created -> None
 
+let json_string_member name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Some value
+  | _ -> None
+
+let json_string_null_member name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Some value
+  | Some `Null | None -> None
+  | _ -> None
+
+let board_signal_kind_of_string = function
+  | "post_created" -> Some Board_dispatch.Board_post_created
+  | "comment_added" -> Some Board_dispatch.Board_comment_added
+  | _ -> None
+
+let board_signal_of_stimulus_payload payload =
+  try
+    match Yojson.Safe.from_string payload with
+    | `Assoc fields
+      when Option.equal String.equal
+             (json_string_member "source" fields)
+             (Some "board_signal") ->
+        (match
+           ( json_string_member "kind" fields,
+             json_string_member "post_id" fields,
+             json_string_member "author" fields,
+             json_string_member "title" fields,
+             json_string_member "content" fields )
+         with
+         | Some kind, Some post_id, Some author, Some title, Some content ->
+             Option.map
+               (fun kind ->
+                 {
+                   Board_dispatch.kind;
+                   post_id;
+                   author;
+                   title;
+                   content;
+                   hearth = json_string_null_member "hearth" fields;
+                 })
+               (board_signal_kind_of_string kind)
+         | _ -> None)
+    | _ -> None
+  with Yojson.Json_error _ -> None
+
+let pending_board_event_of_board_signal ~continuity_summary ~(meta : keeper_meta)
+    ~(arrived_at : float) (signal : Board_dispatch.keeper_board_signal) :
+    pending_board_event =
+  let self_tokens = self_identity_tokens meta in
+  let matched = board_signal_match ~continuity_summary ~meta ~signal in
+  let post_snapshot =
+    match Board_dispatch.get_post ~post_id:signal.post_id with
+    | Ok post -> Some post
+    | Error _ -> None
+  in
+  let title, preview, hearth, post_kind, updated_at =
+    match post_snapshot with
+    | Some (post : Board.post) ->
+        ( post.title,
+          short_preview ~max_len:80 post.content,
+          post.hearth,
+          post.post_kind,
+          post.updated_at )
+    | None ->
+        ( signal.title,
+          short_preview ~max_len:80 signal.content,
+          signal.hearth,
+          Board.Human_post,
+          arrived_at )
+  in
+  let self_commented, new_external_since, latest_external_author,
+      latest_external_preview =
+    match signal.kind with
+    | Board_dispatch.Board_post_created -> (false, 0, None, None)
+    | Board_dispatch.Board_comment_added ->
+        (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
+         | `New_external (count, author, preview) ->
+             (true, count, Some author, Some preview)
+         | `No_new_external ->
+             ( true,
+               0,
+               Some signal.author,
+               Some (short_preview ~max_len:60 signal.content) )
+         | `Never ->
+             ( false,
+               1,
+               Some signal.author,
+               Some (short_preview ~max_len:60 signal.content) ))
+  in
+  {
+    post_id = signal.post_id;
+    author = signal.author;
+    title;
+    preview;
+    hearth;
+    post_kind;
+    updated_at;
+    explicit_mention = matched.explicit_mention;
+    matched_targets = matched.matched_targets;
+    self_commented;
+    new_external_since;
+    latest_external_author;
+    latest_external_preview;
+  }
+
+let pending_board_event_of_stimulus ~continuity_summary ~(meta : keeper_meta)
+    (stimulus : Keeper_event_queue.stimulus) : pending_board_event option =
+  board_signal_of_stimulus_payload stimulus.payload
+  |> Option.map
+       (pending_board_event_of_board_signal ~continuity_summary ~meta
+          ~arrived_at:stimulus.arrived_at)
+
 (** Collect recent board activity using cursor-based tracking.
     Cursor state lives in Keeper_registry as [(updated_at, post_id)].
     Returns (structured events, new post count, mention count).

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -193,6 +193,14 @@ val board_signal_wake_reason :
   signal:Board_dispatch.keeper_board_signal ->
   string option
 
+(** Convert a queued Event Layer stimulus back into structured board activity
+    for the next keeper prompt. Returns [None] for non-board stimuli. *)
+val pending_board_event_of_stimulus :
+  continuity_summary:string ->
+  meta:Keeper_types.keeper_meta ->
+  Keeper_event_queue.stimulus ->
+  pending_board_event option
+
 (** Read the best available continuity summary for a keeper.
     Recovery order is progress log -> checkpoint snapshot -> meta summary. *)
 val read_continuity_summary :

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -326,6 +326,68 @@ let test_observe_uses_precollected_board_events () =
       check bool "board event schedules turn" true
         (WO.should_run_keeper_cycle ~meta:minimal_meta obs))
 
+let test_board_signal_stimulus_becomes_pending_board_event () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      Masc_mcp.Board_dispatch.init_jsonl ();
+      let post =
+        match
+          Masc_mcp.Board_dispatch.create_post ~author:"alice"
+            ~title:"Need test-keeper"
+            ~content:"@test-keeper please react from the queued stimulus"
+            ~post_kind:Masc_mcp.Board.Human_post ()
+        with
+        | Ok post -> post
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+      in
+      let post_id = Masc_mcp.Board.Post_id.to_string post.id in
+      let payload =
+        `Assoc
+          [
+            ("source", `String "board_signal");
+            ("kind", `String "post_created");
+            ("post_id", `String post_id);
+            ("author", `String "alice");
+            ("title", `String "Need test-keeper");
+            ( "content",
+              `String "@test-keeper please react from the queued stimulus" );
+            ("hearth", `Null);
+            ("wake_reason", `String "explicit_mention");
+          ]
+        |> Yojson.Safe.to_string
+      in
+      let stimulus : Masc_mcp.Keeper_event_queue.stimulus =
+        {
+          post_id;
+          urgency = Masc_mcp.Keeper_event_queue.Immediate;
+          arrived_at = Time_compat.now ();
+          payload;
+        }
+      in
+      match
+        WO.pending_board_event_of_stimulus
+          ~continuity_summary:"goal test-keeper"
+          ~meta:minimal_meta stimulus
+      with
+      | None -> fail "queued board stimulus was not converted"
+      | Some event ->
+          check string "post id" post_id event.post_id;
+          check string "author" "alice" event.author;
+          check string "title from board snapshot" "Need test-keeper" event.title;
+          check bool "explicit mention" true event.explicit_mention;
+          check (list string) "matched target" [ "test-keeper" ]
+            event.matched_targets;
+          check bool "schedules turn" true
+            (WO.should_run_keeper_cycle ~meta:minimal_meta
+               { base_observation with pending_board_events = [ event ] }))
+
 let test_observe_splits_absolute_and_claimable_backlog () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -6429,6 +6491,8 @@ let () =
           test_case "with mentions" `Quick test_observation_with_mentions;
           test_case "uses precollected board events" `Quick
             test_observe_uses_precollected_board_events;
+          test_case "queued board stimulus becomes board event" `Quick
+            test_board_signal_stimulus_becomes_pending_board_event;
           test_case "splits absolute and claimable backlog" `Quick
             test_observe_splits_absolute_and_claimable_backlog;
           test_case "default keepers ignore unmatched non-mention board events" `Quick


### PR DESCRIPTION
## Summary
- parse `board_signal` Event Layer stimuli back into `pending_board_event` records
- merge the dequeued board stimulus into the same heartbeat observation when cursor collection did not already include that post
- keep duplicate cursor-collected events deduped by post id
- add a focused regression for queued board stimulus -> pending board activity -> runnable keeper cycle

## Why it matters
The board hook can wake a Keeper and enqueue the authoritative stimulus payload, but the turn path previously only logged the dequeued stimulus before building the prompt. If cursor-based board collection missed the post/comment, the Keeper woke up with no board activity in context and could immediately skip as `no_signal`. This patch makes the wake payload part of the atomic reaction turn.

## Verification
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test world_observation 3`

## Known unrelated local failure
- `./_build/default/test/test_keeper_unified.exe` currently fails at existing case `transient_network_error 44 bounded OAS timeout reserves degraded retry` on this machine: expected `592.5`, received `300`. The new world_observation regression passed before that failure and passes when filtered.

Fixes #12680