### PR TITLE
fix: auto-recoverable cascade exhaustion must increment failure counter (#12674)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1555,8 +1555,19 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              the keeper fiber for a transient API blip is an overreaction
              that causes unnecessary restarts and context loss.
              Only persistent errors (auth failure, config error, context
-             overflow after compaction) increment the crash counter. *)
-          if not is_auto_recoverable then
+             overflow after compaction) increment the crash counter.
+
+             EXCEPTION: cascade exhaustion errors always increment the
+             counter regardless of auto-recoverable classification.
+             Auto-recoverable cascade subtypes (Candidates_filtered_after_cycles,
+             Max_turns_exceeded) were skipping the counter, preventing
+             auto-pause from ever triggering. The keeper would loop
+             indefinitely on a broken cascade without operator notification.
+             Retry eligibility != failure tracking. *)
+          let counts_toward_crash =
+            not is_auto_recoverable || EC.is_cascade_exhausted_error err
+          in
+          if counts_toward_crash then
             Keeper_registry.increment_turn_failures ~base_path meta.name
           else
             Log.Keeper.info

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -94,6 +94,27 @@ let test_accept_rejected_non_recoverable () =
       (Printf.sprintf "Accept_rejected should stay None, got %s" reason)
   | None -> ()
 
+(* Regression: auto-recoverable cascade exhaustion must still be
+   classified as cascade_exhausted so that the unified turn loop's
+   [counts_toward_crash] condition correctly increments the failure
+   counter.  If is_auto_recoverable but NOT is_cascade_exhausted,
+   the keeper loops forever without auto-pause. *)
+let test_auto_recoverable_cascade_exhausted_is_still_cascade_exhausted () =
+  let cases =
+    [ (KT.Candidates_filtered_after_cycles, "Candidates_filtered_after_cycles")
+    ; (KT.Max_turns_exceeded, "Max_turns_exceeded")
+    ]
+  in
+  List.iter (fun (reason, label) ->
+      let err = make_cascade_exhausted reason in
+      (* These are auto-recoverable *)
+      check bool (label ^ " is auto-recoverable") true
+        (KEC.is_auto_recoverable_turn_error err);
+      (* But they MUST also be cascade_exhausted *)
+      check bool (label ^ " is cascade_exhausted") true
+        (KEC.is_cascade_exhausted_error err)
+    ) cases
+
 let test_catalog_rotation_preserves_order_without_base_injection () =
   let err = make_cascade_exhausted KT.All_providers_failed in
   match
@@ -115,6 +136,8 @@ let () =
     [
       ( "recoverable_cascade_failure_reason",
         [
+          test_case "auto-recoverable cascade is still cascade_exhausted" `Quick
+            test_auto_recoverable_cascade_exhausted_is_still_cascade_exhausted;
           test_case "Other_detail (non-quota) is recoverable" `Quick
             test_other_detail_generic_recoverable;
           test_case "All_providers_failed is recoverable" `Quick


### PR DESCRIPTION
## Summary

- **Root cause**: `is_auto_recoverable_turn_error` classifies certain cascade exhaustion subtypes (`Candidates_filtered_after_cycles`, `Max_turns_exceeded`) as auto-recoverable, causing `increment_turn_failures` to be skipped at `keeper_unified_turn.ml:1559`
- **Effect**: auto-pause threshold (`turn_fail_streak_threshold=3`) never reached, keepers loop indefinitely on broken cascades without operator notification — the "멈춤" problem
- **Fix**: `counts_toward_crash = not is_auto_recoverable || is_cascade_exhausted_error` — cascade exhaustion always increments the failure counter regardless of retry eligibility

## Corrected diagnosis

The original #12674 title ("Cascade_exhausted returns None") was wrong. That was already fixed on 2026-04-25. The actual bug is the **classification asymmetry**: auto-recoverable cascade subtypes bypass the crash counter while auto-pause depends on that counter.

## Test plan

- [x] Regression test: auto-recoverable cascade exhaustion is still classified as `is_cascade_exhausted_error`
- [x] `dune build @check` passes
- [x] `dune runtest test/test_keeper_error_classify_recoverable.exe` — 9/9 pass
- [ ] CI full suite

## Files changed

| File | Change |
|------|--------|
| `lib/keeper/keeper_unified_turn.ml` | Add `counts_toward_crash` condition that includes cascade exhaustion |
| `test/test_keeper_error_classify_recoverable.ml` | Regression test for auto-recoverable + is_cascade_exhausted_error overlap |

🤖 Generated with [Claude Code](https://claude.com/claude-code)