### PR TITLE
feat(dashboard): render IDE layer affordances

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -75,6 +75,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `design-system/headless-core/layered-overlay.ts` now accepts external active-layer snapshots for URL hydration while preserving RFC 0020 exclusive-layer semantics.
   - `src/components/ide/ide-shell.ts` persists the LAYERS bar to the route `layers=` param, so editor overlay state survives deep links and view-tab changes.
 
+- **IDE overlay rendering affordances**
+  - `src/components/ide/ide-shell.ts` now passes active view/layer route state into the editor pane instead of leaving LAYERS as toolbar-only state.
+  - `src/components/ide/ide-editor-mock.ts` renders read-only active-overlay summaries and line-level affordance chips from the code document and RFC 0019 ownership snapshots.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/src/components/ide/ide-editor-mock.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.test.ts
@@ -19,6 +19,24 @@ describe('IdeEditorMock', () => {
     expect(container.textContent).toContain('masc-improver')
   })
 
+  it('renders active view and layer affordances from shell state', () => {
+    const container = document.createElement('div')
+    render(h(IdeEditorMock, {
+      activeView: 'blame',
+      activeLayers: new Set(['time', 'parallel', 'tools', 'approve']),
+    }), container)
+
+    expect(container.textContent).toContain('BLAME')
+    expect(container.textContent).toContain('4 layers')
+    expect(container.textContent).toContain('Active overlays')
+    expect(container.textContent).toContain('Time')
+    expect(container.textContent).toContain('Parallel')
+    expect(container.textContent).toContain('Tools')
+    expect(container.textContent).toContain('Approve')
+    expect(container.textContent).toContain('tool')
+    expect(container.textContent).toContain('approve')
+  })
+
   it('leaves blank lines unowned', () => {
     const container = document.createElement('div')
     render(h(IdeEditorMock, {}), container)

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
 import { useMemo } from 'preact/hooks'
 import {
   createCodeDocumentStore,
@@ -11,12 +12,38 @@ import {
   type LineOwnership,
 } from './keeper-line-ownership-store'
 
-// PR-5 precursor: the editor remains a read-only fixture, but both source
-// document rows and blame-by-keeper ownership now flow through typed stores.
-// The syntax renderer is deliberately read-only and keeps the same
-// CodeDocumentLine + LineOwnership contracts for a future CodeMirror swap.
+// PR-5 precursor: the editor remains a read-only fixture, but source document,
+// blame-by-keeper ownership, view state, and layer affordances now flow through
+// typed contracts. The syntax renderer is deliberately read-only and keeps the
+// same CodeDocumentLine + LineOwnership contracts for a future CodeMirror swap.
+
+export type IdeEditorView = 'source' | 'split-diff' | 'unified' | 'blame'
+
+interface IdeEditorMockProps {
+  readonly activeView?: IdeEditorView
+  readonly activeLayers?: ReadonlySet<string>
+  readonly children?: ComponentChildren
+}
 
 const EDITOR_FILE = 'runtime/cascade/router.ts'
+const EMPTY_ACTIVE_LAYERS: ReadonlySet<string> = new Set()
+const LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'explode'] as const
+
+const VIEW_LABEL: Record<IdeEditorView, string> = {
+  source: 'SOURCE',
+  'split-diff': 'SPLIT DIFF',
+  unified: 'UNIFIED',
+  blame: 'BLAME',
+}
+
+const LAYER_LABEL: Record<(typeof LAYER_ORDER)[number], string> = {
+  time: 'Time',
+  parallel: 'Parallel',
+  tools: 'Tools',
+  approve: 'Approve',
+  notes: 'Notes',
+  explode: 'EXPLODE',
+}
 
 const MOCK_SOURCE = [
   "import { Provider, ProviderKind } from './provider'",
@@ -71,9 +98,10 @@ const MOCK_OWNERSHIP_EVENTS: ReadonlyArray<KeeperEdit> = [
   },
 ]
 
-export function IdeEditorMock() {
-  // View tabs and LAYERS toggle moved to IdeToolbar (PR-3); the editor
-  // mock now only shows the breadcrumb header for the open file.
+export function IdeEditorMock({
+  activeView = 'source',
+  activeLayers = EMPTY_ACTIVE_LAYERS,
+}: IdeEditorMockProps) {
   const documentStore = useMemo(() =>
     createCodeDocumentStore({
       file_path: EDITOR_FILE,
@@ -90,6 +118,7 @@ export function IdeEditorMock() {
   const ownership = ownershipStore.ownership()
   const keepers = ownershipStore.knownKeepers()
   const highlightedLines = useHighlightedCodeLines(document)
+  const activeLayerKinds = activeLayersInDisplayOrder(activeLayers)
 
   return html`
     <div
@@ -97,7 +126,7 @@ export function IdeEditorMock() {
       aria-label="에디터 (code document store + RFC 0019 ownership mock)"
       style=${{
         display: 'grid',
-        gridTemplateRows: 'auto 1fr',
+        gridTemplateRows: activeLayerKinds.length > 0 ? 'auto auto 1fr' : 'auto 1fr',
         background: 'var(--color-bg-page)',
         minHeight: 0,
       }}
@@ -115,8 +144,14 @@ export function IdeEditorMock() {
       >
         <span>${document.file_path}</span>
         <span style=${{ color: 'var(--color-fg-disabled)' }}>${document.language}</span>
-        <span style=${{ marginLeft: 'auto' }}>${lines.length} lines · ownership · ${keepers.length} keepers</span>
+        <span style=${{ color: 'var(--color-accent-fg)' }}>${VIEW_LABEL[activeView]}</span>
+        <span style=${{ marginLeft: 'auto' }}>
+          ${lines.length} lines · ownership · ${keepers.length} keepers · ${activeLayerKinds.length} layers
+        </span>
       </div>
+      ${activeLayerKinds.length > 0
+        ? LayerOverlaySummary(activeLayerKinds, ownership, keepers)
+        : null}
       <ol
         style=${{
           listStyle: 'none',
@@ -128,7 +163,12 @@ export function IdeEditorMock() {
           lineHeight: 1.6,
         }}
       >
-        ${lines.map(line => MockEditorRow(line, ownership.get(line.num), highlightedLines[line.num - 1]))}
+        ${lines.map(line => MockEditorRow(
+          line,
+          ownership.get(line.num),
+          highlightedLines[line.num - 1],
+          activeLayerKinds,
+        ))}
       </ol>
     </div>
   `
@@ -140,16 +180,22 @@ function keeperColor(owner: LineOwnership | undefined): string {
     : 'var(--color-fg-disabled)'
 }
 
-function MockEditorRow(line: CodeDocumentLine, owner: LineOwnership | undefined, highlightedHtml: string | undefined) {
+function MockEditorRow(
+  line: CodeDocumentLine,
+  owner: LineOwnership | undefined,
+  highlightedHtml: string | undefined,
+  activeLayerKinds: ReadonlyArray<string>,
+) {
   const color = keeperColor(owner)
   const dot = owner
     ? color
     : 'transparent'
+  const chips = rowLayerChips(line, owner, activeLayerKinds)
   return html`
     <li
       style=${{
         display: 'grid',
-        gridTemplateColumns: '88px 16px auto 1fr',
+        gridTemplateColumns: '88px 16px 32px minmax(0, 1fr) max-content',
         gap: 'var(--sp-2)',
         alignItems: 'center',
         padding: '0 var(--sp-3)',
@@ -166,6 +212,123 @@ function MockEditorRow(line: CodeDocumentLine, owner: LineOwnership | undefined,
       <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, justifySelf: 'center' }} />
       <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', minWidth: '24px', textAlign: 'right' }}>${line.num}</span>
       <${CodeLineText} line=${line} highlightedHtml=${highlightedHtml} />
+      <span
+        aria-label=${chips.length > 0 ? `line ${line.num} active overlays: ${chips.join(', ')}` : undefined}
+        style=${{
+          display: 'inline-flex',
+          gap: 'var(--sp-1)',
+          minWidth: '72px',
+          justifyContent: 'flex-end',
+        }}
+      >
+        ${chips.map(chip => html`
+          <span
+            style=${{
+              padding: '0 var(--sp-1)',
+              border: '1px solid var(--color-border-muted)',
+              borderRadius: 'var(--r-1)',
+              color: 'var(--color-fg-muted)',
+              background: 'var(--color-bg-surface)',
+              fontSize: 'var(--fs-10)',
+              lineHeight: 1.4,
+            }}
+          >${chip}</span>
+        `)}
+      </span>
     </li>
   `
+}
+
+function activeLayersInDisplayOrder(activeLayers: ReadonlySet<string>): ReadonlyArray<string> {
+  return LAYER_ORDER.filter(kind => activeLayers.has(kind))
+}
+
+function LayerOverlaySummary(
+  activeLayerKinds: ReadonlyArray<string>,
+  ownership: ReadonlyMap<number, LineOwnership>,
+  keepers: ReadonlyArray<string>,
+) {
+  const latestEdit = latestEditMs(ownership)
+  return html`
+    <div
+      role="status"
+      aria-label="Active IDE overlays"
+      style=${{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--sp-2)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        color: 'var(--color-fg-muted)',
+        background: 'var(--color-bg-surface)',
+        fontSize: 'var(--fs-11)',
+        overflowX: 'auto',
+      }}
+    >
+      <span style=${{ font: 'var(--type-eyebrow)', color: 'var(--color-fg-primary)' }}>Active overlays</span>
+      ${activeLayerKinds.map(kind => html`
+        <span
+          style=${{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 'var(--sp-1)',
+            padding: '1px var(--sp-2)',
+            border: '1px solid var(--color-border-default)',
+            borderRadius: 'var(--r-2)',
+            background: kind === 'explode' ? 'var(--color-bg-muted)' : 'var(--color-bg-elevated)',
+            color: kind === 'explode' ? 'var(--color-accent-fg)' : 'var(--color-fg-secondary)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span>${layerLabel(kind)}</span>
+          <span style=${{ color: 'var(--color-fg-muted)' }}>${layerSummary(kind, latestEdit, keepers)}</span>
+        </span>
+      `)}
+    </div>
+  `
+}
+
+function rowLayerChips(
+  line: CodeDocumentLine,
+  owner: LineOwnership | undefined,
+  activeLayerKinds: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const chips: string[] = []
+  for (const kind of activeLayerKinds) {
+    if (kind === 'time' && owner) chips.push(formatTime(owner.last_edit_ms))
+    if (kind === 'parallel' && owner) chips.push(owner.last_edit_kind)
+    if (kind === 'tools' && /\btools?\b|tool_choice/.test(line.text)) chips.push('tool')
+    if (kind === 'approve' && owner?.last_edit_kind === 'refactor') chips.push('approve')
+    if (kind === 'notes' && line.text.trim().startsWith('//')) chips.push('note')
+    if (kind === 'explode' && owner) chips.push('ghost')
+  }
+  return chips
+}
+
+function latestEditMs(ownership: ReadonlyMap<number, LineOwnership>): number | null {
+  let latest: number | null = null
+  for (const owner of ownership.values()) {
+    if (latest === null || owner.last_edit_ms > latest) latest = owner.last_edit_ms
+  }
+  return latest
+}
+
+function layerLabel(kind: string): string {
+  return kind in LAYER_LABEL
+    ? LAYER_LABEL[kind as keyof typeof LAYER_LABEL]
+    : kind
+}
+
+function layerSummary(kind: string, latestEdit: number | null, keepers: ReadonlyArray<string>): string {
+  if (kind === 'time') return latestEdit === null ? 'no edits' : `latest ${formatTime(latestEdit)}`
+  if (kind === 'parallel') return `${keepers.length} keepers`
+  if (kind === 'tools') return 'tool-call lines'
+  if (kind === 'approve') return 'refactor approvals'
+  if (kind === 'notes') return 'comment notes'
+  if (kind === 'explode') return 'exclusive ghost view'
+  return ''
+}
+
+function formatTime(ms: number): string {
+  return new Date(ms).toISOString().slice(11, 16)
 }

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -39,6 +39,9 @@ describe('IdeShell', () => {
     expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')
+    expect(container.textContent).toContain('Active overlays')
+    expect(container.textContent).toContain('Time')
+    expect(container.textContent).toContain('Approve')
   })
 
   it('persists layer toggles back to the route', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { IdeExplorer } from './ide-explorer'
-import { IdeEditorMock } from './ide-editor-mock'
+import { IdeEditorMock, type IdeEditorView } from './ide-editor-mock'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 import { IdeActivityMock } from './ide-activity-mock'
 import { IdeInterjectMock } from './ide-interject-mock'
@@ -28,7 +28,7 @@ import {
 // Audit reference:
 //   dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md
 
-type ViewTab = 'source' | 'split-diff' | 'unified' | 'blame'
+type ViewTab = IdeEditorView
 const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
 
 function viewFromRoute(raw: string | null | undefined): ViewTab {
@@ -126,7 +126,7 @@ export function IdeShell() {
           <${IdeExplorer} />
         </div>
         <div class="ide-plane-editor" style=${{ minHeight: 0 }}>
-          <${IdeEditorMock} />
+          <${IdeEditorMock} activeView=${activeView} activeLayers=${activeLayers} />
         </div>
         <div class="ide-plane-conversation" style=${{ minHeight: 0 }}>
           <${IdeConversationRailMock} />


### PR DESCRIPTION
## Summary
- pass IDE route view/layer state into the editor pane instead of keeping LAYERS as toolbar-only state
- render read-only active-overlay summaries and line-level chips from the code document plus RFC 0019 ownership snapshots
- cover editor state rendering and shell route hydration in focused tests

## Validation
- pnpm vitest run --config vitest.config.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm exec eslint src/components/ide/ide-editor-mock.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts
- git diff --check
- pnpm build
  - completed with existing Vite dynamic import/chunk-size warnings