### PR TITLE
fix: surface keeper stopped-reaction truth

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.sort.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.sort.test.ts
@@ -121,4 +121,47 @@ describe('buildFleetRows sort order', () => {
 
     expect(rows.map(row => row.name)).toEqual(['queue-blocked', 'healthy-busy'])
   })
+
+  it('treats runtime trust terminal reasons as fleet attention signals', () => {
+    const keepers = [
+      {
+        name: 'trust-blocked',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.1,
+        total_turns: 12,
+        trust: {
+          needs_attention: true,
+          latest_terminal_reason: {
+            code: 'required_tool_use_unsatisfied',
+            severity: 'bad',
+            summary: 'required keeper tool use was not satisfied',
+          },
+          latest_next_action: 'inspect_provider_tool_contract',
+        },
+      },
+      {
+        name: 'healthy-busy',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.4,
+        total_turns: 50,
+      },
+    ] satisfies Keeper[]
+
+    const rows = buildFleetRows(
+      keepers,
+      toolQualityByKeeper([
+        { name: 'trust-blocked', calls: 0, success_pct: 100 },
+        { name: 'healthy-busy', calls: 20, success_pct: 100 },
+      ]),
+    )
+
+    expect(rows.map(row => row.name)).toEqual(['trust-blocked', 'healthy-busy'])
+    expect(rows[0]).toMatchObject({
+      runtime_trust_attention: true,
+      terminal_reason_code: 'required_tool_use_unsatisfied',
+      runtime_trust_next_action: 'inspect_provider_tool_contract',
+    })
+  })
 })

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -384,6 +384,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
             const diagnosticState = row.diagnostic_health_state?.trim().toLowerCase() ?? null
             const rowHint =
               row.runtime_blocker_summary
+              ?? row.runtime_trust_reason
               ?? (
                 diagnosticState
                 && diagnosticState !== 'healthy'
@@ -430,6 +431,18 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   </span>
                   ${row.decision_required
                     ? html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs text-[var(--bad-light)]">decision</span>`
+                    : null}
+                  ${row.terminal_reason_code
+                    ? html`
+                      <span
+                        class=${row.terminal_reason_severity === 'bad'
+                          ? 'rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs text-[var(--bad-light)]'
+                          : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
+                        title=${row.runtime_trust_next_action ?? row.runtime_trust_reason ?? row.terminal_reason_code}
+                      >
+                        ${row.terminal_reason_code}
+                      </span>
+                    `
                     : null}
                 </div>
                 ${row.goal_label

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -38,6 +38,11 @@ export interface FleetRow {
   recent_tools: string[]
   runtime_blocker_class: Keeper['runtime_blocker_class'] | null
   runtime_blocker_summary: string | null
+  runtime_trust_attention?: boolean
+  runtime_trust_reason?: string | null
+  runtime_trust_next_action?: string | null
+  terminal_reason_code?: string | null
+  terminal_reason_severity?: string | null
   tool_audit_at: string | null
   goal_label: string | null
   goal_linked: boolean
@@ -318,6 +323,9 @@ export function fleetBand(row: FleetRow): FleetBand {
     isAttentionDiagnosticHealthState(diagnosticHealthState)
     || normalizedStatus === 'inactive'
     || row.runtime_blocker_class != null
+    || row.runtime_trust_attention === true
+    || row.terminal_reason_severity === 'bad'
+    || row.terminal_reason_severity === 'warn'
     || row.context_ratio >= PRESSURE_WARN_RATIO
     || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
     || (row.tool_success_pct != null && row.tool_success_pct < 90)
@@ -338,6 +346,9 @@ export function fleetBandScore(row: FleetRow): number {
 export function rowUrgencyScore(row: FleetRow): number {
   let score = 0
   if (row.runtime_blocker_class != null) score += 100
+  if (row.runtime_trust_attention === true) score += 120
+  if (row.terminal_reason_severity === 'bad') score += 110
+  if (row.terminal_reason_severity === 'warn') score += 60
   if (row.context_ratio >= PRESSURE_WARN_RATIO) score += row.context_ratio * 100
   if (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC) {
     score += Math.min(row.last_activity_ago_s / STALE_ACTIVITY_SEC, 5)
@@ -413,6 +424,22 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             runtime_blocker_class: keeper.runtime_blocker_class ?? null,
             runtime_blocker_summary:
               firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker) ?? null,
+            runtime_trust_attention: keeper.trust?.needs_attention === true,
+            runtime_trust_reason:
+              firstNonEmptyString(
+                keeper.trust?.attention_reason,
+                keeper.trust?.latest_terminal_reason?.summary,
+                keeper.trust?.operator_disposition_reason,
+                keeper.trust?.disposition_reason,
+              ) ?? null,
+            runtime_trust_next_action:
+              firstNonEmptyString(
+                keeper.trust?.next_human_action,
+                keeper.trust?.latest_next_action,
+                keeper.trust?.latest_terminal_reason?.next_action,
+              ) ?? null,
+            terminal_reason_code: keeper.trust?.latest_terminal_reason?.code ?? null,
+            terminal_reason_severity: keeper.trust?.latest_terminal_reason?.severity ?? null,
             tool_audit_at: keeper.tool_audit_at ?? null,
             goal_label: keeperGoalLabel(keeper),
             goal_linked: (keeper.active_goal_ids?.length ?? 0) > 0 || keeperGoalLabel(keeper) != null,
@@ -455,6 +482,11 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           recent_tools: [],
           runtime_blocker_class: null,
           runtime_blocker_summary: null,
+          runtime_trust_attention: false,
+          runtime_trust_reason: null,
+          runtime_trust_next_action: null,
+          terminal_reason_code: null,
+          terminal_reason_severity: null,
           tool_audit_at: null,
           goal_label: null,
           goal_linked: false,
@@ -505,6 +537,8 @@ export function statusClass(row: FleetRow): string {
     isAttentionDiagnosticHealthState(diagnosticHealthState)
     || normalizedStatus === 'inactive'
     || row.runtime_blocker_class != null
+    || row.runtime_trust_attention === true
+    || row.terminal_reason_severity === 'bad'
   ) {
     return 'text-[var(--color-status-warn)]'
   }

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -5,6 +5,7 @@ import { missionSnapshot } from '../mission-store'
 import { journal } from '../sse'
 import {
   executionContinuityBriefs,
+  executionQueue,
   executionSessionBriefs,
   executionWorkerSupportBriefs,
   keepers,
@@ -12,6 +13,7 @@ import {
 } from '../store'
 import type {
   DashboardExecutionContinuityBrief,
+  DashboardExecutionQueueItem,
   DashboardExecutionSessionBrief,
   DashboardExecutionWorkerSupportBrief,
   JournalEntry,
@@ -510,6 +512,48 @@ function TileHint({ text }: { text: string }) {
   return html`<div class="text-xs leading-relaxed text-[var(--color-fg-muted)]">${text}</div>`
 }
 
+function executionQueueTone(severity?: string | null): string {
+  if (severity === 'bad') return 'bad'
+  if (severity === 'warn') return 'warn'
+  if (severity === 'ok') return 'ok'
+  return 'neutral'
+}
+
+function ExecutionQueuePanel({ items }: { items: DashboardExecutionQueueItem[] }) {
+  if (items.length === 0) return null
+  return html`
+    <div class="rounded border border-[var(--color-border-default)] bg-[var(--white-2)] p-3">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Execution Queue</div>
+        <${StatusChip} tone=${items.some(item => item.severity === 'bad') ? 'bad' : 'warn'} uppercase=${false}>${items.length}<//>
+      </div>
+      <div class="mt-3 grid gap-2 md:grid-cols-2">
+        ${items.slice(0, 6).map(item => html`
+          <div key=${item.id} class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
+            <div class="flex items-center justify-between gap-2">
+              <div class="min-w-0 truncate font-mono text-2xs text-[var(--color-fg-secondary)]">${item.target_id}</div>
+              <${StatusChip} tone=${executionQueueTone(item.severity)} uppercase=${false}>${item.kind}<//>
+            </div>
+            <div class="mt-1 text-xs leading-relaxed text-[var(--color-fg-primary)]">${trimText(item.summary, 120) ?? item.summary}</div>
+            ${item.terminal_reason_code || item.next_human_action
+              ? html`
+                <div class="mt-1 flex flex-wrap gap-1">
+                  ${item.terminal_reason_code
+                    ? html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-mono text-[var(--color-status-warn)]">${item.terminal_reason_code}</span>`
+                    : null}
+                  ${item.next_human_action
+                    ? html`<span class="rounded bg-[var(--white-8)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-muted)]">${item.next_human_action}</span>`
+                    : null}
+                </div>
+              `
+              : null}
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
 function JourneyCard({ record }: { record: JourneyRecord }) {
   const task = record.task
   const keeper = record.keeper
@@ -779,6 +823,7 @@ export function JourneyPanel() {
     missionSessions,
     journalEntries: journal.value,
   })
+  const priorityItems = executionQueue.value.filter((item) => item.kind === 'keeper' || item.severity === 'bad')
   const visible = filterJourneyRecords(records, query.value)
   const taskCount = records.filter((record) => record.kind === 'task').length
   const keeperCount = records.filter((record) => record.kind === 'keeper').length
@@ -812,6 +857,8 @@ export function JourneyPanel() {
           <${MetricChip} label="blocked" value=${blockedCount} tone=${blockedCount > 0 ? 'bad' : 'ok'} />
           <${MetricChip} label="thinking/memory" value=${`${thinkingCount} / ${memoryHotCount}`} tone="warn" />
         </div>
+
+        <${ExecutionQueuePanel} items=${priorityItems} />
 
         <div class="flex flex-wrap items-center gap-3">
           <${TextInput}

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -375,6 +375,66 @@ describe('normalizeKeepers lifecycle metrics', () => {
     })
   })
 
+  it('accepts live runtime_trust payloads and preserves terminal reason fields', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'runtime-trust-keeper',
+        status: 'active',
+        runtime_trust: {
+          disposition: 'Pause',
+          operator_disposition: 'pause_human',
+          operator_disposition_reason: 'required_tool_use_unsatisfied',
+          needs_attention: true,
+          approval: {
+            state: 'ready',
+            summary: 'no pending approvals',
+            pending_count: 0,
+          },
+          execution: {
+            tool_contract_result: 'violated',
+            required_tools: ['masc_board_post'],
+            missing_required_tools: ['masc_board_post'],
+            provider_attempt_count: 2,
+            provider_fallback_applied: true,
+          },
+          latest_terminal_reason: {
+            code: 'required_tool_use_unsatisfied',
+            source: 'execution_receipt',
+            severity: 'bad',
+            summary: 'required keeper tool use was not satisfied',
+            next_action: 'inspect_provider_tool_contract',
+          },
+          latest_next_action: 'inspect_provider_tool_contract',
+        },
+      },
+    ])
+
+    expect(keeper?.trust).toMatchObject({
+      disposition: 'Pause',
+      operator_disposition: 'pause_human',
+      operator_disposition_reason: 'required_tool_use_unsatisfied',
+      needs_attention: true,
+      approval_state: {
+        state: 'ready',
+        summary: 'no pending approvals',
+        pending_count: 0,
+      },
+      execution_summary: {
+        tool_contract_result: 'violated',
+        required_tools: ['masc_board_post'],
+        missing_required_tools: ['masc_board_post'],
+        provider_attempt_count: 2,
+        provider_fallback_applied: true,
+      },
+      latest_terminal_reason: {
+        code: 'required_tool_use_unsatisfied',
+        severity: 'bad',
+        next_action: 'inspect_provider_tool_contract',
+      },
+      latest_next_action: 'inspect_provider_tool_contract',
+    })
+  })
+
   it('preserves runtime cascade identity and metric provider observations', () => {
     const [keeper] = normalizeKeepers([
       {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -167,48 +167,65 @@ function normalizeKeeperTrustLatestEvent(raw: unknown): KeeperTrustLatestEvent |
   }
 }
 
-function normalizeKeeperTrust(raw: unknown): Keeper['trust'] {
+function normalizeKeeperTrustTerminalReason(raw: unknown): NonNullable<Keeper['trust']>['latest_terminal_reason'] {
   if (!isRecord(raw)) return null
+  return {
+    code: asString(raw.code) ?? null,
+    source: asString(raw.source) ?? null,
+    severity: asString(raw.severity) ?? null,
+    summary: asString(raw.summary) ?? null,
+    next_action: asString(raw.next_action) ?? null,
+  }
+}
+
+export function normalizeKeeperTrust(raw: unknown): Keeper['trust'] {
+  if (!isRecord(raw)) return null
+  const approvalRaw = isRecord(raw.approval_state) ? raw.approval_state : raw.approval
+  const executionRaw = isRecord(raw.execution_summary) ? raw.execution_summary : raw.execution
   return {
     disposition: asString(raw.disposition) ?? null,
     disposition_reason: asString(raw.disposition_reason) ?? null,
+    operator_disposition: asString(raw.operator_disposition) ?? null,
+    operator_disposition_reason: asString(raw.operator_disposition_reason) ?? null,
     needs_attention:
       typeof raw.needs_attention === 'boolean' ? raw.needs_attention : null,
     attention_reason: asString(raw.attention_reason) ?? null,
     next_human_action: asString(raw.next_human_action) ?? null,
-    approval_state: isRecord(raw.approval_state)
+    approval_state: isRecord(approvalRaw)
       ? {
-          state: asString(raw.approval_state.state) ?? null,
-          summary: asString(raw.approval_state.summary) ?? null,
-          pending_count: asNumber(raw.approval_state.pending_count) ?? null,
+          state: asString(approvalRaw.state) ?? null,
+          summary: asString(approvalRaw.summary) ?? null,
+          pending_count: asNumber(approvalRaw.pending_count) ?? null,
         }
       : null,
-    execution_summary: isRecord(raw.execution_summary)
+    execution_summary: isRecord(executionRaw)
       ? {
-          tool_contract_result: asString(raw.execution_summary.tool_contract_result) ?? null,
-          runtime_proof_status: asString(raw.execution_summary.runtime_proof_status) ?? null,
-          required_tools: asStringArray(raw.execution_summary.required_tools) ?? [],
+          tool_contract_result: asString(executionRaw.tool_contract_result) ?? null,
+          runtime_proof_status: asString(executionRaw.runtime_proof_status) ?? null,
+          required_tools: asStringArray(executionRaw.required_tools) ?? [],
           missing_required_tools:
-            asStringArray(raw.execution_summary.missing_required_tools) ?? [],
-          requested_tools: asStringArray(raw.execution_summary.requested_tools) ?? [],
-          tools_used: asStringArray(raw.execution_summary.tools_used) ?? [],
+            asStringArray(executionRaw.missing_required_tools) ?? [],
+          requested_tools: asStringArray(executionRaw.requested_tools) ?? [],
+          tools_used: asStringArray(executionRaw.tools_used) ?? [],
           requested_tool_count:
-            asNumber(raw.execution_summary.requested_tool_count) ?? null,
-          tools_used_count: asNumber(raw.execution_summary.tools_used_count) ?? null,
+            asNumber(executionRaw.requested_tool_count) ?? null,
+          tools_used_count: asNumber(executionRaw.tools_used_count) ?? null,
           provider_attempt_count:
-            asNumber(raw.execution_summary.provider_attempt_count) ?? null,
+            asNumber(executionRaw.provider_attempt_count) ?? null,
           provider_fallback_applied:
-            asBoolean(raw.execution_summary.provider_fallback_applied) ?? null,
+            asBoolean(executionRaw.provider_fallback_applied) ?? null,
           provider_selected_model:
-            asString(raw.execution_summary.provider_selected_model) ?? null,
-          cascade_outcome: asString(raw.execution_summary.cascade_outcome) ?? null,
-          sandbox_summary: asString(raw.execution_summary.sandbox_summary) ?? null,
-          sandbox_root: asString(raw.execution_summary.sandbox_root) ?? null,
+            asString(executionRaw.provider_selected_model) ?? null,
+          cascade_outcome: asString(executionRaw.cascade_outcome) ?? null,
+          sandbox_summary: asString(executionRaw.sandbox_summary) ?? null,
+          sandbox_root: asString(executionRaw.sandbox_root) ?? null,
           mutation_guard_summary:
-            asString(raw.execution_summary.mutation_guard_summary) ?? null,
-          latest_receipt_at: asString(raw.execution_summary.latest_receipt_at) ?? null,
+            asString(executionRaw.mutation_guard_summary) ?? null,
+          latest_receipt_at: asString(executionRaw.latest_receipt_at) ?? null,
         }
       : null,
+    latest_terminal_reason: normalizeKeeperTrustTerminalReason(raw.latest_terminal_reason),
+    latest_next_action: asString(raw.latest_next_action) ?? null,
     latest_causal_event: normalizeKeeperTrustLatestEvent(raw.latest_causal_event),
   }
 }
@@ -513,7 +530,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           typeof row.needs_attention === 'boolean' ? row.needs_attention : null,
         attention_reason: asString(row.attention_reason) ?? null,
         next_human_action: asString(row.next_human_action) ?? null,
-        trust: normalizeKeeperTrust(row.trust),
+        trust: normalizeKeeperTrust(row.runtime_trust ?? row.trust),
         active_goal_ids: asStringArray(row.active_goal_ids) ?? [],
         goal: asString(row.goal) ?? null,
         short_goal: asString(row.short_goal) ?? null,

--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -3,6 +3,7 @@ import {
   normalizeAttentionItem,
   normalizeRecommendedAction,
 } from './store-normalizers'
+import { normalizeKeeperTrust } from './keeper-store-normalize'
 import {
   normalizeAgentBrief,
   normalizeAttentionQueueItem,
@@ -184,6 +185,7 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,
     last_turn_ago_s: asNumber(raw.last_turn_ago_s),
     model: asString(raw.model),
+    runtime_trust: normalizeKeeperTrust(raw.runtime_trust ?? raw.trust),
   }
 }
 

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -235,6 +235,44 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers[0]!.generation).toBe(10)
   })
 
+  it('preserves keeper runtime_trust terminal reason fields', () => {
+    const result = normalizeOperatorSnapshot({
+      keepers: [
+        {
+          name: 'sangsu',
+          status: 'paused',
+          runtime_trust: {
+            needs_attention: true,
+            operator_disposition: 'pause_human',
+            execution: {
+              tool_contract_result: 'violated',
+              missing_required_tools: ['masc_board_post'],
+            },
+            latest_terminal_reason: {
+              code: 'required_tool_use_unsatisfied',
+              severity: 'bad',
+              summary: 'required keeper tool use was not satisfied',
+              next_action: 'inspect_provider_tool_contract',
+            },
+          },
+        },
+      ],
+    })
+
+    expect(result.keepers[0]?.runtime_trust).toMatchObject({
+      needs_attention: true,
+      operator_disposition: 'pause_human',
+      execution_summary: {
+        tool_contract_result: 'violated',
+        missing_required_tools: ['masc_board_post'],
+      },
+      latest_terminal_reason: {
+        code: 'required_tool_use_unsatisfied',
+        severity: 'bad',
+      },
+    })
+  })
+
   it('preserves keeper context fields from nested context payloads', () => {
     const result = normalizeOperatorSnapshot({
       keepers: [

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -5,6 +5,7 @@ import {
   normalizePendingConfirmEnvelope,
   normalizePendingConfirmSummary,
 } from './pending-confirm'
+import { normalizeKeeperTrust } from './keeper-store-normalize'
 import type {
   Message,
   OperatorActionDescriptor,
@@ -287,6 +288,7 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,
     last_turn_ago_s: asNumber(raw.last_turn_ago_s),
     model: asString(raw.model) ?? asString(raw.active_model) ?? asString(raw.primary_model),
+    runtime_trust: normalizeKeeperTrust(raw.runtime_trust ?? raw.trust),
   }
 }
 

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeExecutionSessionBrief } from './store-normalizers'
+import { normalizeExecutionQueueItem, normalizeExecutionSessionBrief } from './store-normalizers'
 
 describe('normalizeExecutionSessionBrief', () => {
   it('promotes legacy room-only payloads to namespace while keeping the room alias', () => {
@@ -40,6 +40,41 @@ describe('normalizeExecutionSessionBrief', () => {
       goal: 'dual payload',
       namespace: 'default',
       room: 'default',
+    })
+  })
+})
+
+describe('normalizeExecutionQueueItem', () => {
+  it('accepts keeper stopped-reaction items with runtime trust', () => {
+    expect(normalizeExecutionQueueItem({
+      id: 'keeper-sangsu',
+      kind: 'keeper',
+      severity: 'bad',
+      status: 'paused',
+      summary: 'required keeper tool use was not satisfied',
+      target_type: 'keeper',
+      target_id: 'sangsu',
+      attention_reason: 'required_tool_use_unsatisfied',
+      next_human_action: 'inspect_provider_tool_contract',
+      terminal_reason_code: 'required_tool_use_unsatisfied',
+      runtime_trust: {
+        needs_attention: true,
+        latest_terminal_reason: {
+          code: 'required_tool_use_unsatisfied',
+          severity: 'bad',
+        },
+      },
+    })).toMatchObject({
+      id: 'keeper-sangsu',
+      kind: 'keeper',
+      terminal_reason_code: 'required_tool_use_unsatisfied',
+      runtime_trust: {
+        needs_attention: true,
+        latest_terminal_reason: {
+          code: 'required_tool_use_unsatisfied',
+          severity: 'bad',
+        },
+      },
     })
   })
 })

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -1,4 +1,5 @@
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
+import { normalizeKeeperTrust } from './keeper-store-normalize'
 import type {
   Agent, Task, Message, ServerStatus,
   DashboardExecutionSummary, DashboardExecutionHandoff,
@@ -211,7 +212,7 @@ export function normalizeExecutionQueueItem(raw: unknown): DashboardExecutionQue
   const summary = asString(raw.summary)
   const targetType = asString(raw.target_type)
   const targetId = asString(raw.target_id)
-  if (!id || !summary || !targetType || !targetId || (kind !== 'session' && kind !== 'operation')) {
+  if (!id || !summary || !targetType || !targetId || (kind !== 'session' && kind !== 'operation' && kind !== 'keeper')) {
     return null
   }
   return {
@@ -225,6 +226,10 @@ export function normalizeExecutionQueueItem(raw: unknown): DashboardExecutionQue
     linked_session_id: asString(raw.linked_session_id) ?? null,
     linked_operation_id: asString(raw.linked_operation_id) ?? null,
     last_seen_at: asString(raw.last_seen_at) ?? null,
+    attention_reason: asString(raw.attention_reason) ?? null,
+    next_human_action: asString(raw.next_human_action) ?? null,
+    terminal_reason_code: asString(raw.terminal_reason_code) ?? null,
+    runtime_trust: normalizeKeeperTrust(raw.runtime_trust ?? raw.trust),
     top_handoff: normalizeExecutionHandoff(raw.top_handoff),
     intervene_handoff: normalizeExecutionHandoff(raw.intervene_handoff),
     command_handoff: normalizeExecutionHandoff(raw.command_handoff),

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -13,6 +13,7 @@ import type {
   BoardSortMode,
   Goal,
   DashboardExecutionSessionBrief,
+  DashboardExecutionQueueItem,
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardExecutionResponse,
@@ -49,6 +50,7 @@ import { isRecord, asString, asNumber } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
+  normalizeExecutionQueueItem,
   normalizeExecutionWorkerSupportBrief,
   normalizeExecutionContinuityBrief,
   mergeMessages,
@@ -85,6 +87,7 @@ export const executionLoaded = signal(false)
 export const executionLoading = signal(false)
 export const executionError = signal<string | null>(null)
 export const executionSessionBriefs = signal<DashboardExecutionSessionBrief[]>([])
+export const executionQueue = signal<DashboardExecutionQueueItem[]>([])
 export const executionWorkerSupportBriefs = signal<DashboardExecutionWorkerSupportBrief[]>([])
 export const executionContinuityBriefs = signal<DashboardExecutionContinuityBrief[]>([])
 
@@ -741,6 +744,10 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
     .filter((row): row is Message => row !== null)
   messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
   keepers.value = normalizeKeepers(data.keepers)
+  const normalizedQueue = (Array.isArray(data.execution_queue) ? data.execution_queue : Array.isArray(data.priority_queue) ? data.priority_queue : [])
+    .map(normalizeExecutionQueueItem)
+    .filter((row): row is DashboardExecutionQueueItem => row !== null)
+  setArrayByKeyIfChanged(executionQueue, normalizedQueue, row => row.id)
   const normalizedWorkerBriefs = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
     .map(normalizeExecutionWorkerSupportBrief)
     .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -282,14 +282,26 @@ export interface KeeperTrustExecutionSummary {
   latest_receipt_at?: string | null
 }
 
+export interface KeeperTrustTerminalReason {
+  code?: string | null
+  source?: string | null
+  severity?: 'ok' | 'warn' | 'bad' | string | null
+  summary?: string | null
+  next_action?: string | null
+}
+
 export interface KeeperTrustSummary {
   disposition?: string | null
   disposition_reason?: string | null
+  operator_disposition?: string | null
+  operator_disposition_reason?: string | null
   needs_attention?: boolean | null
   attention_reason?: string | null
   next_human_action?: string | null
   approval_state?: KeeperTrustApprovalState | null
   execution_summary?: KeeperTrustExecutionSummary | null
+  latest_terminal_reason?: KeeperTrustTerminalReason | null
+  latest_next_action?: string | null
   latest_causal_event?: KeeperTrustLatestEvent | null
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -249,7 +249,7 @@ export interface ServerBuildIdentity {
 type DashboardExecutionTone = 'ok' | 'warn' | 'bad'
 type DashboardExecutionWorkerState = 'working' | 'watching' | 'quiet' | 'offline'
 type DashboardExecutionContinuityState = 'healthy' | 'warning' | 'critical'
-type DashboardExecutionQueueKind = 'session' | 'operation'
+type DashboardExecutionQueueKind = 'session' | 'operation' | 'keeper'
 
 export interface DashboardExecutionSummary {
   active_sessions?: number
@@ -289,6 +289,10 @@ export interface DashboardExecutionQueueItem {
   linked_session_id?: string | null
   linked_operation_id?: string | null
   last_seen_at?: string | null
+  attention_reason?: string | null
+  next_human_action?: string | null
+  terminal_reason_code?: string | null
+  runtime_trust?: GoalKeeperTrustSummary | null
   top_handoff?: DashboardExecutionHandoff | null
   intervene_handoff?: DashboardExecutionHandoff | null
   command_handoff?: DashboardExecutionHandoff | null
@@ -599,19 +603,43 @@ export interface GoalKeeperTrustApprovalState {
 
 export interface GoalKeeperTrustExecutionSummary {
   tool_contract_result?: string | null
+  runtime_proof_status?: string | null
+  required_tools?: string[] | null
+  missing_required_tools?: string[] | null
+  requested_tools?: string[] | null
+  tools_used?: string[] | null
+  requested_tool_count?: number | null
+  tools_used_count?: number | null
+  provider_attempt_count?: number | null
+  provider_fallback_applied?: boolean | null
+  provider_selected_model?: string | null
+  cascade_outcome?: string | null
   sandbox_summary?: string | null
+  sandbox_root?: string | null
   mutation_guard_summary?: string | null
   latest_receipt_at?: string | null
+}
+
+export interface GoalKeeperTrustTerminalReason {
+  code?: string | null
+  source?: string | null
+  severity?: 'ok' | 'warn' | 'bad' | string | null
+  summary?: string | null
+  next_action?: string | null
 }
 
 export interface GoalKeeperTrustSummary {
   disposition?: string | null
   disposition_reason?: string | null
+  operator_disposition?: string | null
+  operator_disposition_reason?: string | null
   needs_attention?: boolean | null
   attention_reason?: string | null
   next_human_action?: string | null
   approval_state?: GoalKeeperTrustApprovalState | null
   execution_summary?: GoalKeeperTrustExecutionSummary | null
+  latest_terminal_reason?: GoalKeeperTrustTerminalReason | null
+  latest_next_action?: string | null
   latest_causal_event?: GoalKeeperTrustLatestEvent | null
 }
 

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -1,4 +1,4 @@
-import type { KeeperDiagnostic, Message } from './core'
+import type { KeeperDiagnostic, KeeperTrustSummary, Message } from './core'
 import type { PendingConfirmEnvelope, PendingConfirmation, PendingConfirmSummary, OperatorActionDescriptor } from './governance'
 
 export interface DashboardMissionSummary {
@@ -395,6 +395,7 @@ export interface OperatorKeeperSnapshot {
   active_model?: string
   active_model_label?: string | null
   diagnostic?: Record<string, unknown>
+  runtime_trust?: KeeperTrustSummary | null
   recent_activity?: Record<string, unknown>[]
 }
 

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -54,11 +54,15 @@ let compact_keeper_trust_json ~(config : Coord.config) ~(meta : Keeper_types.kee
     [
       ("disposition", member "disposition");
       ("disposition_reason", member "disposition_reason");
+      ("operator_disposition", member "operator_disposition");
+      ("operator_disposition_reason", member "operator_disposition_reason");
       ("needs_attention", member "needs_attention");
       ("attention_reason", member "attention_reason");
       ("next_human_action", member "next_human_action");
       ("approval_state", member "approval");
       ("execution_summary", member "execution");
+      ("latest_terminal_reason", member "latest_terminal_reason");
+      ("latest_next_action", member "latest_next_action");
       ("latest_causal_event", member "latest_causal_event");
     ]
 
@@ -138,10 +142,180 @@ let enrich_keeper_with_diagnostic ~(config : Coord.config) (keeper_json : Yojson
               in
               let fields = assoc_upsert fields "diagnostic" diagnostic in
               let fields = assoc_upsert fields "trust" trust in
+              let fields = assoc_upsert fields "runtime_trust" trust in
               `Assoc fields
           | Ok None | Error _ -> keeper_json)
       | _ -> keeper_json)
   | _ -> keeper_json
+
+let bool_field ?(default = false) key json =
+  match member_assoc key json with
+  | `Bool value -> value
+  | _ -> default
+
+let keeper_runtime_trust_json keeper =
+  match member_assoc "runtime_trust" keeper with
+  | `Assoc _ as trust -> trust
+  | _ -> member_assoc "trust" keeper
+
+let lowercase_json_string key json =
+  string_field_opt key json |> Option.map String.lowercase_ascii
+
+let terminal_reason_json trust =
+  member_assoc "latest_terminal_reason" trust
+
+let terminal_reason_code trust =
+  terminal_reason_json trust |> string_field_opt "code"
+
+let terminal_reason_severity trust =
+  terminal_reason_json trust |> lowercase_json_string "severity"
+
+let terminal_reason_requires_attention trust =
+  match terminal_reason_severity trust with
+  | Some ("bad" | "warn") -> true
+  | _ -> (
+      match terminal_reason_code trust |> Option.map String.lowercase_ascii with
+      | Some ("success" | "completed") | None -> false
+      | Some _ -> true)
+
+let trust_disposition_requires_attention trust =
+  match lowercase_json_string "disposition" trust with
+  | Some ("alert" | "pause") -> true
+  | _ -> false
+
+let keeper_queue_severity keeper trust =
+  match terminal_reason_severity trust with
+  | Some "bad" -> "bad"
+  | Some "warn" -> "warn"
+  | _ -> (
+      match lowercase_json_string "disposition" trust with
+      | Some "alert" -> "bad"
+      | Some "pause" -> "warn"
+      | _ ->
+          if Option.is_some (string_field_opt "runtime_blocker_class" keeper) then
+            "bad"
+          else
+            "warn")
+
+let first_text values =
+  List.find_map
+    (function
+      | Some value ->
+          let compacted = compact_text value in
+          if compacted = "" then None else Some compacted
+      | None -> None)
+    values
+
+let keeper_queue_summary keeper trust =
+  let terminal = terminal_reason_json trust in
+  first_text
+    [
+      string_field_opt "attention_reason" trust;
+      string_field_opt "summary" terminal;
+      string_field_opt "runtime_blocker_summary" keeper;
+      string_field_opt "operator_disposition_reason" trust;
+      string_field_opt "disposition_reason" trust;
+      string_field_opt "latest_next_action" trust;
+      Some "keeper needs operator attention";
+    ]
+  |> Option.value ~default:"keeper needs operator attention"
+
+let keeper_queue_last_seen keeper trust =
+  let latest_causal = member_assoc "latest_causal_event" trust in
+  let last_seen_at =
+    latest_iso_timestamp
+      [
+        string_field_opt "ts" latest_causal;
+        string_field_opt "observed_at" latest_causal;
+        string_field_opt "last_autonomous_action_at" keeper;
+        string_field_opt "last_heartbeat" keeper;
+        string_field_opt "updated_at" keeper;
+        string_field_opt "created_at" keeper;
+      ]
+  in
+  (last_seen_at, parse_iso_opt last_seen_at |> Option.value ~default:0.0)
+
+let build_keeper_execution_queue keepers =
+  keepers
+  |> List.filter_map (fun keeper ->
+         match string_field_opt "name" keeper with
+         | None -> None
+         | Some keeper_name ->
+             let trust = keeper_runtime_trust_json keeper in
+             let trust_needs_attention =
+               bool_field "needs_attention" trust
+               || trust_disposition_requires_attention trust
+               || terminal_reason_requires_attention trust
+             in
+             let runtime_blocked =
+               Option.is_some (string_field_opt "runtime_blocker_class" keeper)
+             in
+             if not (trust_needs_attention || runtime_blocked) then None
+             else
+               let severity = keeper_queue_severity keeper trust in
+               let summary = keeper_queue_summary keeper trust in
+               let last_seen_at, last_seen_ts = keeper_queue_last_seen keeper trust in
+               let terminal_code = terminal_reason_code trust in
+               let next_human_action =
+                 match string_field_opt "next_human_action" trust with
+                 | Some _ as value -> value
+                 | None ->
+                     (match string_field_opt "latest_next_action" trust with
+                      | Some _ as value -> value
+                      | None ->
+                          terminal_reason_json trust
+                          |> string_field_opt "next_action")
+               in
+               let intervene_handoff =
+                 handoff_json ~surface:"intervene"
+                   ~label:"Keeper 상태 보기"
+                   ~target_type:"keeper"
+                   ~target_id:keeper_name
+                   ~focus_kind:"keeper"
+                   ()
+               in
+               let command_handoff =
+                 handoff_json ~surface:"command"
+                   ~command_surface:"agents"
+                   ~label:"Keeper 원인 보기"
+                   ~target_type:"keeper"
+                   ~target_id:keeper_name
+                   ~focus_kind:"keeper"
+                   ()
+               in
+               Some
+                 {
+                   severity_rank = severity_rank severity;
+                   last_seen_ts;
+                   json =
+                     `Assoc
+                       [
+                         ("id", `String ("keeper-" ^ keeper_name));
+                         ("kind", `String "keeper");
+                         ("severity", `String severity);
+                         ("status", member_assoc "status" keeper);
+                         ("summary", `String summary);
+                         ("target_type", `String "keeper");
+                         ("target_id", `String keeper_name);
+                         ("linked_session_id", `Null);
+                         ("linked_operation_id", `Null);
+                         ("last_seen_at", json_string_option last_seen_at);
+                         ("attention_reason", member_assoc "attention_reason" trust);
+                         ("next_human_action", json_string_option next_human_action);
+                         ("terminal_reason_code", json_string_option terminal_code);
+                         ("runtime_trust", trust);
+                         ("top_handoff", command_handoff);
+                         ("intervene_handoff", intervene_handoff);
+                         ("command_handoff", command_handoff);
+                       ];
+                 })
+
+let merge_execution_queue left right =
+  (left @ right)
+  |> List.sort (fun left right ->
+         let by_severity = Int.compare right.severity_rank left.severity_rank in
+         if by_severity <> 0 then by_severity
+         else Float.compare right.last_seen_ts left.last_seen_ts)
 
 let model_map_of_keeper_rows keepers =
   let model_map : (string, string) Hashtbl.t = Hashtbl.create 8 in
@@ -309,6 +483,10 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
         | _ -> []
       in
       let t_after_enrich = Time_compat.now () in
+      let execution_queue =
+        merge_execution_queue execution_queue
+          (build_keeper_execution_queue keepers)
+      in
       Eio.Fiber.yield ();
       (* Load tasks/agents/messages — needed for worker_support_briefs.
          In light mode, tasks and messages are NOT serialized in the

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -450,7 +450,11 @@ let create_keeper env sw config name =
   | Some (false, err) -> fail err
   | None -> fail "missing masc_keeper_up dispatch"
 
-let append_execution_receipt config ~keeper_name =
+let append_execution_receipt ?(outcome = "ok")
+    ?(terminal_reason_code = "completed")
+    ?(tool_contract_result = "satisfied")
+    ?(stop_reason = Some "completed")
+    config ~keeper_name =
   let meta =
     match Lib.Keeper_types.read_meta config keeper_name with
     | Ok (Some meta) -> meta
@@ -468,8 +472,8 @@ let append_execution_receipt config ~keeper_name =
       turn_count = Some 3;
       current_task_id = None;
       goal_ids = meta.active_goal_ids;
-      outcome = "ok";
-      terminal_reason_code = "completed";
+      outcome;
+      terminal_reason_code;
       response_text_present = true;
       model_used = Some "custom:mock";
       requested_tools = [ "keeper_task_claim"; "keeper_fs_read" ];
@@ -478,7 +482,7 @@ let append_execution_receipt config ~keeper_name =
       canonical_tools = [ "keeper_fs_read" ];
       unexpected_tools = [ "WebSearch" ];
       tools_used = [ "keeper_fs_read" ];
-      tool_contract_result = "satisfied";
+      tool_contract_result;
       tool_surface =
         {
           turn_lane = "tool";
@@ -525,7 +529,7 @@ let append_execution_receipt config ~keeper_name =
             recorded_at = ended_at;
           };
         ];
-      stop_reason = Some "completed";
+      stop_reason;
       error_kind = None;
       error_message = None;
       started_at;
@@ -800,6 +804,54 @@ let test_execution_trust_surfaces_latest_receipt () =
               (execution_row |> member "trust" |> member "execution_summary"
              |> member "cascade_outcome" |> to_string))))
 
+let test_dashboard_execution_queue_surfaces_keeper_runtime_trust () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord_utils.default_config dir in
+      ignore (Lib.Coord.init config ~agent_name:None);
+      Eio.Switch.run (fun sw ->
+        Fun.protect
+          ~finally:(fun () ->
+            Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu")
+          (fun () ->
+            create_keeper env sw config "sangsu";
+            append_execution_receipt config ~keeper_name:"sangsu"
+              ~outcome:"error"
+              ~terminal_reason_code:"required_tool_use_unsatisfied"
+              ~tool_contract_result:"violated"
+              ~stop_reason:(Some "completion_contract_violation:require_tool_use");
+            let execution_json =
+              Lib.Dashboard_execution.json
+                ~config
+                ~sw
+                ~clock:(Eio.Stdenv.clock env)
+                ~proc_mgr:None
+                ()
+            in
+            let open Yojson.Safe.Util in
+            let keeper_item =
+              execution_json |> member "execution_queue" |> to_list
+              |> List.find (fun row ->
+                     row |> member "kind" |> to_string = "keeper"
+                     && row |> member "target_id" |> to_string = "sangsu")
+            in
+            check string "keeper queue item exposes target" "sangsu"
+              (keeper_item |> member "target_id" |> to_string);
+            check string "keeper queue item exposes terminal reason"
+              "required_tool_use_unsatisfied"
+              (keeper_item |> member "terminal_reason_code" |> to_string);
+            check string "keeper queue item carries runtime trust terminal reason"
+              "required_tool_use_unsatisfied"
+              (keeper_item |> member "runtime_trust"
+             |> member "latest_terminal_reason"
+             |> member "code" |> to_string);
+            check bool "keeper queue item exposes next action" true
+              (keeper_item |> member "next_human_action" <> `Null))))
+
 let test_execution_trust_surfaces_coverage_gap_health () =
   let dir = test_dir () in
   Fun.protect
@@ -962,6 +1014,8 @@ let () =
             test_dashboard_execution_surfaces_keeper_diagnostic;
           Alcotest.test_case "execution trust surfaces latest receipt" `Quick
             test_execution_trust_surfaces_latest_receipt;
+          Alcotest.test_case "execution queue surfaces keeper runtime trust" `Quick
+            test_dashboard_execution_queue_surfaces_keeper_runtime_trust;
           Alcotest.test_case "execution trust surfaces coverage gap health" `Quick
             test_execution_trust_surfaces_coverage_gap_health;
           Alcotest.test_case "lifecycle patch tolerates null agent" `Quick


### PR DESCRIPTION
## Summary

- Preserve keeper `runtime_trust` terminal/operator fields across execution, operator, mission, and store normalizers.
- Add keeper stopped-reaction items to `/dashboard/execution.execution_queue` with terminal reason, next action, and runtime trust payload.
- Render the execution queue in the Journey panel and surface terminal-reason chips in Fleet telemetry.

## Why

Stopped keeper reactions were present in backend runtime trust, but the execution dashboard compact path and frontend hydration dropped the fields operators need: terminal reason, next action, and provider/tool-contract summary. That made a stopped reaction look like a quiet keeper instead of an actionable queue item.

## Verification

- `git diff --check origin/main`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/keeper-store-normalize.test.ts src/operator-normalizers.test.ts src/store-normalizers.test.ts src/components/fleet-telemetry-panel.sort.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `scripts/dune-local.sh build test/test_dashboard_execution.exe`
- `./_build/default/test/test_dashboard_execution.exe test read_model 12`

Note: full local `test_dashboard_execution.exe` still fails on two pre-existing config-sensitive expectations in this workspace (`big_three` vs current local cascade `glm_coding_plan_only`, and `ok` vs current compact trust `receipt_done`). The new regression case passes.

Fixes #12665
Tracking: `goal-world-reaction-liveness`, `task-133`
