### PR TITLE
fix(dashboard): correctly display connection state in WS-only mode

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -5,6 +5,8 @@ import { useEffect } from 'preact/hooks'
 import type { RouteState } from '../types'
 import { route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
+import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
+import { dashboardWsConnected } from '../dashboard-ws'
 import { dashboardLoading, serverStatus } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
@@ -93,7 +95,8 @@ export function describeReconnecting(args: {
 }
 
 export function ConnectionStatus() {
-  const isConnected = connected.value
+  const wsOnly = dashboardWsOnlyEnabled()
+  const isConnected = wsOnly ? dashboardWsConnected.value : connected.value
   const snap = missionSnapshot.value
   const attentionCount = snap?.attention_queue?.length ?? 0
   const reconn = reconnectCount.value
@@ -354,7 +357,8 @@ export function dashboardRouteBoundaryKey(routeState: RouteState): string {
 }
 
 function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
-  const live = connected.value
+  const wsOnly = dashboardWsOnlyEnabled()
+  const live = wsOnly ? dashboardWsConnected.value : connected.value
   const snap = missionSnapshot.value
   const sessions = snap?.sessions ?? []
   let blockers = 0


### PR DESCRIPTION
Resolves an issue where the dashboard UI erroneously displays an 'Offline' or 'Reconnecting...' state when the operator has explicitly enabled WS-only mode (`dashboardWsOnlyEnabled() === true`).

**Root Cause:**
The `ConnectionStatus` and `HealthIndicator` components were hardcoded to check the SSE transport's `connected.value`. In WS-only mode, the SSE transport is intentionally not connected.

**Fix:**
Updated these components to respect the WS-only mode flag and check `dashboardWsConnected.value` when appropriate.