### PR TITLE
fix: repair supervisor test module reference

### DIFF
--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -815,7 +815,7 @@ let test_storm_pause_sets_auto_resume_after_sec () =
            (* updated_at must be refreshed by the pause write so Phase 3.5
               timer (now - updated_at) is anchored to the pause time, not to
               some earlier heartbeat write. *)
-           (match Masc_mcp.Coord_resilience.Time.parse_iso8601_opt m.updated_at with
+           (match Coord_resilience.Time.parse_iso8601_opt m.updated_at with
             | None ->
                 fail (Printf.sprintf "updated_at not parseable as ISO-8601: %s"
                         m.updated_at)


### PR DESCRIPTION
## Summary
- fix the supervisor test compile break introduced by #12671 by referencing the unwrapped Coord_resilience module directly

## Validation
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build test/test_keeper_supervisor.exe passed in the #12671 worktree with this same one-line fix before extracting it to main
- ./_build/default/test/test_keeper_supervisor.exe test self_healing_circuit_breaker passed in the #12671 worktree

Note: the fix branch Dune run was stopped while waiting on the shared /tmp/me-dune-local.lock; CI is the current verification surface for this exact branch.