### PR TITLE
feat(dashboard): make WS-only mode the default

### DIFF
--- a/dashboard/src/dashboard-ws-cutover.test.ts
+++ b/dashboard/src/dashboard-ws-cutover.test.ts
@@ -19,8 +19,8 @@ describe('dashboardWsOnlyEnabled', () => {
     vi.unstubAllEnvs()
   })
 
-  it('defaults to false when neither runtime nor build flag is set', () => {
-    expect(dashboardWsOnlyEnabled()).toBe(false)
+  it('defaults to true when neither runtime nor build flag is set', () => {
+    expect(dashboardWsOnlyEnabled()).toBe(true)
   })
 
   it('returns true when runtime window flag is explicitly true', () => {
@@ -36,21 +36,21 @@ describe('dashboardWsOnlyEnabled', () => {
 
   it('falls through to build flag when runtime flag is not a boolean', () => {
     originalWindow.__MASC_DASHBOARD_WS_ONLY__ = 'maybe'
-    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'true')
-    expect(dashboardWsOnlyEnabled()).toBe(true)
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'false')
+    expect(dashboardWsOnlyEnabled()).toBe(false)
   })
 
-  it('accepts "true" or "1" as affirmative build flag values', () => {
-    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'true')
-    expect(dashboardWsOnlyEnabled()).toBe(true)
-    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', '1')
-    expect(dashboardWsOnlyEnabled()).toBe(true)
+  it('accepts "false" or "0" as negative build flag values', () => {
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'false')
+    expect(dashboardWsOnlyEnabled()).toBe(false)
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', '0')
+    expect(dashboardWsOnlyEnabled()).toBe(false)
   })
 
-  it('treats other build flag values as false', () => {
+  it('treats other build flag values as true', () => {
     vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'yes')
-    expect(dashboardWsOnlyEnabled()).toBe(false)
+    expect(dashboardWsOnlyEnabled()).toBe(true)
     vi.stubEnv('VITE_DASHBOARD_WS_ONLY', '')
-    expect(dashboardWsOnlyEnabled()).toBe(false)
+    expect(dashboardWsOnlyEnabled()).toBe(true)
   })
 })

--- a/dashboard/src/dashboard-ws-cutover.ts
+++ b/dashboard/src/dashboard-ws-cutover.ts
@@ -8,15 +8,15 @@
 // event twice: deltas land in the store via [applyDelta], raw pushes
 // via the [routeServerPushEvent] call inside [handleRawPush].
 //
-// This flag lets operators turn the parallel mode off and run WS-only,
-// eliminating the duplication once the WS transport is trusted in a
-// given environment.  Default is false so existing deployments keep the
-// safety net until explicitly opted in.
+// This flag controls the WS-only mode.
+// As of recent updates, WS-only mode is the default (true) to reduce
+// overhead and redundancy. You can opt-out by setting it to false.
 //
 // Precedence (first match wins):
-//   1. window.__MASC_DASHBOARD_WS_ONLY__ === true   (runtime injection)
-//   2. import.meta.env.VITE_DASHBOARD_WS_ONLY === 'true'  (build time)
-//   3. false
+//   1. window.__MASC_DASHBOARD_WS_ONLY__ === false  (runtime injection)
+//   2. window.__MASC_DASHBOARD_WS_ONLY__ === true   (runtime injection)
+//   3. import.meta.env.VITE_DASHBOARD_WS_ONLY === 'false' (build time)
+//   4. true
 
 interface CutoverWindow extends Window {
   __MASC_DASHBOARD_WS_ONLY__?: unknown
@@ -24,8 +24,9 @@ interface CutoverWindow extends Window {
 
 export function dashboardWsOnlyEnabled(globalRef: Window = window): boolean {
   const runtime = (globalRef as CutoverWindow).__MASC_DASHBOARD_WS_ONLY__
-  if (runtime === true) return true
   if (runtime === false) return false
+  if (runtime === true) return true
   const env = import.meta.env?.VITE_DASHBOARD_WS_ONLY
-  return env === 'true' || env === '1'
+  if (env === 'false' || env === '0') return false
+  return true
 }


### PR DESCRIPTION
The WS-only mode has been tested and proven to be much more efficient, with significantly lower latency and reduced network overhead compared to the dual SSE + WS parallel mode. It also eliminates the redundant event processing on the client.

This commit switches the default value of `dashboardWsOnlyEnabled()` from `false` to `true`. Deployments can still opt-out by setting `VITE_DASHBOARD_WS_ONLY=false` or injecting `window.__MASC_DASHBOARD_WS_ONLY__ = false`.