### PR TITLE
refactor: replace manual prefix checks with Base.String.is_prefix

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -248,8 +248,7 @@ let extract_nickname (response_text : string) : string option =
     | [] -> None
     | line :: rest ->
         let trimmed = String.trim line in
-        if String.length trimmed >= String.length prefix
-           && String.sub trimmed 0 (String.length prefix) = prefix
+        if Base.String.is_prefix trimmed ~prefix
         then
           Some
             (String.trim

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -810,8 +810,7 @@ module Memory = struct
   let list_keys t ~prefix =
     with_lock t (fun () ->
       let keys = Hashtbl.fold (fun k _ acc ->
-        if String.length k >= String.length prefix &&
-           String.sub k 0 (String.length prefix) = prefix then
+        if Base.String.is_prefix k ~prefix then
           k :: acc
         else acc
       ) t.data [] in

--- a/lib/coord/coord_identity.ml
+++ b/lib/coord/coord_identity.ml
@@ -47,7 +47,7 @@ let resolve_agent_name config agent_name =
       let prefix = agent_name ^ "-" in
       match Array.find_opt (fun f ->
         String.length f > String.length prefix &&
-        String.sub f 0 (String.length prefix) = prefix
+        Base.String.is_prefix f ~prefix
       ) files with
       | Some file -> String.sub file 0 (String.length file - 5)
       | None -> agent_name

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -60,7 +60,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
           |> List.find_opt (fun f ->
                Filename.check_suffix f ".json"
                && String.length f > String.length prefix
-               && String.sub f 0 (String.length prefix) = prefix)
+               && Base.String.is_prefix f ~prefix)
           |> Option.map (fun f -> Filename.chop_suffix f ".json")
         else None
       in

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -136,7 +136,7 @@ let audit_orphan_tasks config : (Types.task * string) list =
       || let prefix = assignee ^ "-" in
          List.exists (fun name ->
            String.length name > String.length prefix
-           && String.sub name 0 (String.length prefix) = prefix
+           && Base.String.is_prefix name ~prefix
          ) active_names
     in
     let backlog = read_backlog config in

--- a/lib/coord/coord_utils_paths_backend.ml
+++ b/lib/coord/coord_utils_paths_backend.ml
@@ -178,8 +178,7 @@ let project_prefix config =
     For filesystem: returns relative path without prefix. *)
 let key_of_path_from_root config ~root path =
   let prefix = root ^ "/" in
-  if String.length path >= String.length prefix &&
-     String.sub path 0 (String.length prefix) = prefix then
+  if Base.String.is_prefix path ~prefix then
     let rel =
       String.sub path (String.length prefix) (String.length path - String.length prefix)
     in

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -65,7 +65,7 @@ let classify_failure_output (output : string) : string =
       let prefixes = ["error: "; "tool_error: "] in
       match List.find_opt (fun p ->
         String.length output > String.length p
-        && String.sub output 0 (String.length p) = p
+        && Base.String.is_prefix output ~prefix:p
       ) prefixes with
       | Some p -> String.sub output (String.length p)
                     (String.length output - String.length p)

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -425,8 +425,7 @@ module Router = struct
             String.length route.path > 7
             && String.sub route.path 0 7 = "PREFIX:"
             && let prefix = String.sub route.path 7 (String.length route.path - 7) in
-               String.length req_path >= String.length prefix
-               && String.sub req_path 0 (String.length prefix) = prefix
+               Base.String.is_prefix req_path ~prefix
             && List.mem req_method route.methods
           ) routes
         in

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -528,8 +528,7 @@ let filter_forward_looking_summary (summary : string) : string =
     List.exists
       (fun label ->
         let prefix = label ^ ":" in
-        String.length trimmed >= String.length prefix
-        && String.sub trimmed 0 (String.length prefix) = prefix)
+        Base.String.is_prefix trimmed ~prefix)
       backward_labels
   in
   let is_inert_next_line line =

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -552,10 +552,8 @@ let update_field_in_content
        else if
          !in_target_table
          && (not !found)
-         && ((String.length trimmed >= String.length key_prefix
-              && String.sub trimmed 0 (String.length key_prefix) = key_prefix)
-             || (String.length trimmed >= String.length key_prefix_eq
-                 && String.sub trimmed 0 (String.length key_prefix_eq) = key_prefix_eq))
+         && ((Base.String.is_prefix trimmed ~prefix:key_prefix)
+             || (Base.String.is_prefix trimmed ~prefix:key_prefix_eq))
        then (
          result_lines := Printf.sprintf "%s = \"%s\"" key value :: !result_lines;
          found := true;

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -52,8 +52,7 @@ let normalize_path path =
 let is_masc_write_allowed path =
   let path = normalize_path path in
   List.exists (fun prefix ->
-    String.length path >= String.length prefix
-    && String.sub path 0 (String.length prefix) = prefix
+    Base.String.is_prefix path ~prefix
   ) keeper_writable_prefixes
 
 (* -- Config-driven preset resolution -------------------------------- *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -270,8 +270,7 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
       is_gh_api_read_only cmd_lower
     else
       List.exists (fun prefix ->
-        String.length cmd_lower >= String.length prefix
-        && String.sub cmd_lower 0 (String.length prefix) = prefix
+        Base.String.is_prefix cmd_lower ~prefix
       ) gh_read_only_prefixes
   | Some (Masc Code_git) ->
     if is_effectively_read_only_tool tool_name then true

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -955,8 +955,7 @@ let append_decision_record
                 | Some e when String.length e > 0 ->
                   let e_lower = String.lowercase_ascii e in
                   let starts_with prefix =
-                    String.length e_lower >= String.length prefix
-                    && String.sub e_lower 0 (String.length prefix) = prefix
+                    Base.String.is_prefix e_lower ~prefix
                   in
                   let contains needle =
                     string_contains_substring ~needle e_lower

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -49,8 +49,7 @@ let next_jsonrpc_id () =
 
 let strip_mcp_prefix name =
   let prefix = "mcp__masc__" in
-  if String.length name >= String.length prefix
-     && String.sub name 0 (String.length prefix) = prefix
+  if Base.String.is_prefix name ~prefix
   then
     String.sub name (String.length prefix) (String.length name - String.length prefix)
   else
@@ -110,8 +109,7 @@ let normalize_mcp_body ~request_id body =
     List.filter_map
       (fun line ->
         let prefix = "data: " in
-        if String.length line >= String.length prefix
-           && String.sub line 0 (String.length prefix) = prefix
+        if Base.String.is_prefix line ~prefix
         then
           Some (String.sub line (String.length prefix) (String.length line - String.length prefix))
         else


### PR DESCRIPTION
## Summary
- Replace `String.length x >= String.length p && String.sub x 0 (String.length p) = p` with `Base.String.is_prefix x ~prefix:p` across 14 files
- `>` guards (semantically meaningful: strictly longer than prefix required) are kept alongside `is_prefix`
- Files in sub-libraries without `base` dependency (`env_config_core`, `autoresearch_file`, `repo_store`) intentionally left unchanged

## Files excluded (no `base` dependency)
- `lib/config/env_config_core.ml`
- `lib/autoresearch/autoresearch_file.ml`
- `lib/repo_manager/repo_store.ml`

## Test plan
- [x] `dune build --root . bin/main_eio.exe` passes
- [x] All changes are semantically equivalent (same prefix-matching behavior)
- [ ] `dune runtest` (running, build verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)