### PR TITLE
refactor: replace String.sub prefix checks with Base.String.is_prefix (round 2)

### DIFF
--- a/lib/coord/coord_resilience.ml
+++ b/lib/coord/coord_resilience.ml
@@ -39,7 +39,7 @@ module Zombie = struct
     let plen = String.length prefix in
     let slen = String.length suffix in
     nlen > plen + slen
-    && String.sub normalized 0 plen = prefix
+    && Base.String.is_prefix normalized ~prefix
     && String.sub normalized (nlen - slen) slen = suffix
 
   (** Check if an agent is a zombie based on last_seen timestamp *)
@@ -95,9 +95,9 @@ module ZeroZombie = struct
   (** Check if error is benign (e.g., not initialized - normal at startup) *)
   let is_benign_error exn =
     let msg = Printexc.to_string exn in
-    String.length msg >= 20 && 
-    (String.sub msg 0 20 = "Invalid_argument(\"MA" ||  (* MASC not initialized *)
-     String.sub msg 0 14 = "Sys_error(\"No ")         (* No such file - transient *)
+    String.length msg >= 20 &&
+    (Base.String.is_prefix msg ~prefix:"Invalid_argument(\"MA" ||
+     Base.String.is_prefix msg ~prefix:"Sys_error(\"No ")
 
   let run_loop ?(interval=60.0) ~clock ~cleanup_fn () =
     let is_cancelled exn =

--- a/lib/exec/egress_policy.ml
+++ b/lib/exec/egress_policy.ml
@@ -38,7 +38,7 @@ let domain_allowed policy domain =
   in
   List.exists (fun pattern ->
     if String.length pattern > 2 &&
-       String.sub pattern 0 2 = "*." then begin
+       Base.String.is_prefix pattern ~prefix:"*." then begin
       let suffix = String.sub pattern 2 (String.length pattern - 2) in
       suffix_match ~suffix d
     end else

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -55,8 +55,7 @@ let decode_cursor ~kind cursor =
   | Ok decoded ->
       let prefix = kind ^ ":" in
       let prefix_len = String.length prefix in
-      if String.length decoded >= prefix_len &&
-         String.sub decoded 0 prefix_len = prefix then
+      if Base.String.is_prefix decoded ~prefix then
         Some (String.sub decoded prefix_len (String.length decoded - prefix_len))
       else
         None

--- a/lib/keeper/keeper_goal_repair.ml
+++ b/lib/keeper/keeper_goal_repair.ml
@@ -115,7 +115,7 @@ let run (config : Coord.config) : repair_result =
     match repair_keeper config name with
     | Ok action -> { acc with actions = action :: acc.actions }
     | Error e ->
-        if String.length e >= 18 && String.sub e 0 18 = "already has active_" then
+        if Base.String.is_prefix e ~prefix:"already has active_" then
           { acc with skipped = (name, e) :: acc.skipped }
         else
           { acc with errors = (name, e) :: acc.errors }

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -123,7 +123,7 @@ let strip_keeper_prefix (s : string) : string option =
   let prefix = "keeper-" in
   let plen = String.length prefix in
   let slen = String.length s in
-  if slen > plen && String.sub s 0 plen = prefix then
+  if slen > plen && Base.String.is_prefix s ~prefix then
     Some (String.sub s plen (slen - plen))
   else None
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -177,7 +177,7 @@ let process_directive ~agent_name directive =
   | "wakeup" ->
     Log.Keeper.debug "directive: waking up %s" agent_name;
     wakeup_keeper_by_agent_name ~agent_name
-  | s when String.length s > 6 && String.sub s 0 6 = "claim:" ->
+  | s when String.length s > 6 && Base.String.is_prefix s ~prefix:"claim:" ->
     let task_id = String.sub s 6 (String.length s - 6) in
     (match Keeper_id.Task_id.of_string task_id with
      | Ok parsed_task_id ->

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -190,11 +190,11 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
                  method_tok <> "get"
                | [] -> true (* flag with no value — conservative: mutating *))
             else if (String.length tok > 3
-                     && String.sub tok 0 3 = "-x=") then
+                     && Base.String.is_prefix tok ~prefix:"-x=") then
               let method_val = String.sub tok 3 (String.length tok - 3) in
               method_val <> "get"
             else if (String.length tok > 9
-                     && String.sub tok 0 9 = "--method=") then
+                     && Base.String.is_prefix tok ~prefix:"--method=") then
               let method_val = String.sub tok 9 (String.length tok - 9) in
               method_val <> "get"
             else check rest_toks
@@ -204,9 +204,9 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
       let has_field_flag =
         List.exists (fun tok ->
           tok = "-f" || tok = "-ff"
-          || String.length tok > 3 && String.sub tok 0 3 = "-f="
+          || String.length tok > 3 && Base.String.is_prefix tok ~prefix:"-f="
           || tok = "--field" || tok = "--raw-field"
-          || String.length tok > 8 && String.sub tok 0 8 = "--field="
+          || String.length tok > 8 && Base.String.is_prefix tok ~prefix:"--field="
         ) tokens
       in
       not has_method_flag && not has_field_flag
@@ -265,13 +265,11 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
     let cmd = gh_effective_cmd input in
     let cmd_lower = String.lowercase_ascii cmd in
     if cmd_lower = "" then false
-    else if String.length cmd_lower >= 3
-            && String.sub cmd_lower 0 3 = "api" then
+    else if Base.String.is_prefix cmd_lower ~prefix:"api" then
       is_gh_api_read_only cmd_lower
     else
       List.exists (fun prefix ->
-        String.length cmd_lower >= String.length prefix
-        && String.sub cmd_lower 0 (String.length prefix) = prefix
+        Base.String.is_prefix cmd_lower ~prefix
       ) gh_read_only_prefixes
   | Some (Masc Code_git) ->
     if is_effectively_read_only_tool tool_name then true

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -616,7 +616,7 @@ let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
   List.filter_map
     (fun (k, v) ->
       if String.length k > prefix_len
-         && String.sub k 0 prefix_len = oas_env_key_prefix
+         && Base.String.is_prefix k ~prefix:oas_env_key_prefix
       then
         let suffix = String.sub k prefix_len (String.length k - prefix_len) in
         if oas_env_key_is_allowed suffix then
@@ -1055,7 +1055,7 @@ let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
   let oas_env_prefix_len = String.length oas_env_prefix in
   let starts_with_oas_env k =
     String.length k > oas_env_prefix_len
-    && String.sub k 0 oas_env_prefix_len = oas_env_prefix
+    && Base.String.is_prefix k ~prefix:oas_env_prefix
   in
   doc
   |> List.map fst

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -699,8 +699,7 @@ type transport_mode =
 
 let detect_mode first_line =
   let lower = String.lowercase_ascii first_line in
-  if String.length lower >= 14 &&
-     String.sub lower 0 14 = "content-length" then
+  if Base.String.is_prefix lower ~prefix:"content-length" then
     Framed
   else
     LineDelimited

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -490,8 +490,7 @@ let decode_cursor ~kind cursor =
   | Ok decoded ->
       let prefix = kind ^ ":" in
       let prefix_len = String.length prefix in
-      if String.length decoded >= prefix_len
-         && String.sub decoded 0 prefix_len = prefix
+      if Base.String.is_prefix decoded ~prefix
       then
         int_of_string_opt
           (String.sub decoded prefix_len (String.length decoded - prefix_len))

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -63,9 +63,7 @@ let body_jsonrpc_method body_str =
 
 let is_notification_method method_ =
   let prefix = "notifications/" in
-  let prefix_len = String.length prefix in
-  String.length method_ >= prefix_len
-  && String.sub method_ 0 prefix_len = prefix
+  Base.String.is_prefix method_ ~prefix
 
 let is_initialize_method method_ = String.equal method_ "initialize"
 

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -335,7 +335,7 @@ let parse_keeper_chat_response response =
     | [] -> Ok ()
     | raw_line :: rest ->
         let line = trim raw_line in
-        if String.length line > 6 && String.sub line 0 6 = "data: " then (
+        if String.length line > 6 && Base.String.is_prefix line ~prefix:"data: " then (
           let payload = String.sub line 6 (String.length line - 6) |> trim in
           if payload = "[DONE]" || payload = "" then consume_sse rest
           else

--- a/lib/verifier_core.ml
+++ b/lib/verifier_core.ml
@@ -106,11 +106,11 @@ let parse_verdict (text : string) : (verdict, string) result =
   let trimmed = String.trim text in
   let upper = String.uppercase_ascii trimmed in
   let len = String.length upper in
-  if len >= 4 && String.sub upper 0 4 = "PASS" && has_keyword_boundary upper 4 then
+  if Base.String.is_prefix upper ~prefix:"PASS" && has_keyword_boundary upper 4 then
     Ok Pass
-  else if len >= 4 && String.sub upper 0 4 = "WARN" && has_keyword_boundary upper 4 then
+  else if Base.String.is_prefix upper ~prefix:"WARN" && has_keyword_boundary upper 4 then
     Ok (Warn (extract_reason trimmed 4 "unspecified concern"))
-  else if len >= 4 && String.sub upper 0 4 = "FAIL" && has_keyword_boundary upper 4 then
+  else if Base.String.is_prefix upper ~prefix:"FAIL" && has_keyword_boundary upper 4 then
     Ok (Fail (extract_reason trimmed 4 "action did not achieve goal"))
   else if len = 0 then
     Error "empty verifier output"


### PR DESCRIPTION
## Summary
- Replace remaining hand-rolled prefix comparison patterns (`String.sub x 0 len = prefix`) with `Base.String.is_prefix` across 13 files
- Remove redundant `>=` length guard when semantically identical to `is_prefix`; keep `>` (strictly-greater) guard where semantics require it
- Follow-up to #12709 which covered the first batch of files

## Changed files (13)
- `graphql_api.ml`, `mcp_server_eio_tool_profile.ml`, `mcp_server_eio_protocol.ml`
- `server/server_mcp_transport_http_headers.ml`
- `keeper/keeper_types_profile.ml`, `keeper/keeper_identity.ml`, `keeper/keeper_keepalive.ml`
- `keeper/keeper_tool_registry.ml`, `keeper/keeper_goal_repair.ml`
- `coord/coord_resilience.ml`, `exec/egress_policy.ml`
- `tui_decode.ml`, `verifier_core.ml`

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)