### PR TITLE
fix: surface receipt-level operator reasons

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -836,6 +836,8 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
   const latestTerminalSummary = trust?.latest_terminal_reason?.summary?.trim() || null
   const latestNextAction = trust?.latest_next_action?.trim() || null
   const operatorDispositionReason = trust?.operator_disposition_reason?.trim() || null
+  const shouldShowOperatorDispositionReason =
+    operatorDispositionReason !== null && operatorDispositionReason !== trustSummary
 
   return html`
     <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3">
@@ -889,11 +891,8 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
             ${latestNextAction ? html`
               <span>권장 ${latestNextAction}</span>
             ` : null}
-            ${/* Show operator_disposition_reason only when trustSummary is absent to avoid
-               repeating the root-cause twice. trustSummary coalesces attention_reason,
-               disposition_reason, sandbox_summary, and mutation_guard_summary — any of
-               those already convey the stopped-reaction context. */
-              operatorDispositionReason && !trustSummary ? html`
+            ${/* Show receipt-level operator cause when it adds detail beyond trustSummary. */
+              shouldShowOperatorDispositionReason ? html`
               <span>운영자 ${operatorDispositionReason}</span>
             ` : null}
           </div>

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -827,11 +827,11 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
   const trust = keeper.runtime_trust
   const latestEvent = keeper.latest_causal_event ?? trust?.latest_causal_event ?? null
   const trustSummary =
-    trust?.attention_reason
-    ?? trust?.disposition_reason
-    ?? trust?.execution_summary?.mutation_guard_summary
-    ?? trust?.execution_summary?.sandbox_summary
-    ?? null
+    trust?.attention_reason?.trim()
+    || trust?.disposition_reason?.trim()
+    || trust?.execution_summary?.mutation_guard_summary?.trim()
+    || trust?.execution_summary?.sandbox_summary?.trim()
+    || null
   const latestTerminalCode = trust?.latest_terminal_reason?.code?.trim() || null
   const latestTerminalSummary = trust?.latest_terminal_reason?.summary?.trim() || null
   const latestNextAction = trust?.latest_next_action?.trim() || null

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -226,6 +226,8 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const latestTerminalSummary = latestTerminalReason?.summary?.trim() || null
   const latestNextAction = keeper.trust?.latest_next_action?.trim() || null
   const operatorDispositionReason = keeper.trust?.operator_disposition_reason?.trim() || null
+  const shouldShowOperatorDispositionReason =
+    operatorDispositionReason !== null && operatorDispositionReason !== trustSummary
   const executionSummary = keeper.trust?.execution_summary ?? null
   const runtimeProofStatus =
     executionSummary?.runtime_proof_status?.trim()
@@ -448,12 +450,8 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${latestNextAction
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${latestNextAction}</span>`
           : null}
-        ${/* Show operator_disposition_reason only when trustSummary is absent to avoid
-             repeating the same root-cause text twice. trustSummary coalesces
-             attention_reason, disposition_reason, and mutation_guard_summary — any of
-             those already convey the stopped-reaction context that operator_disposition_reason
-             would otherwise supply. */
-          operatorDispositionReason && !trustSummary
+        ${/* Show receipt-level operator cause when it adds detail beyond trustSummary. */
+          shouldShowOperatorDispositionReason
           ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReason}</span>`
           : null}
         ${trustDisposition


### PR DESCRIPTION
## Summary
- follow up on #12689 after it auto-merged before the review-response commit landed
- show operator_disposition_reason when it adds receipt-level detail beyond the coalesced trust summary
- apply the same condition in keeper detail and goal keeper cards

## Verification
- pnpm install --offline --frozen-lockfile
- pnpm run typecheck