### PR TITLE
feat: auto-resume circuit breaker for paused keepers

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -182,6 +182,13 @@ module KeeperSupervisor = struct
       are removed from disk. Default: 86400 (24 hours). *)
   let paused_cleanup_ttl_sec =
     Float.max 300.0 (get_float ~default:Masc_time_constants.day "MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC")
+
+  (** Auto-resume cooldown: seconds after which an auto-paused keeper is
+      automatically resumed. Minimum 300s (5 min) to prevent rapid
+      resume-storm loops. Keepers with [paused_at = None] (legacy /
+      operator-initiated pauses) are never auto-resumed. *)
+  let auto_resume_after_sec =
+    Float.max 300.0 (get_float ~default:1800.0 "MASC_KEEPER_AUTO_RESUME_AFTER_SEC")
 end
 
 (** {1 Keeper Poll Intervals}

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -61,6 +61,7 @@ module KeeperSupervisor : sig
   val self_preservation_min_candidates : int
   val dead_ttl_sec : float
   val paused_cleanup_ttl_sec : float
+  val auto_resume_after_sec : float
 end
 
 (** {1 Stale-turn watchdog} *)

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -251,6 +251,7 @@ type keeper_meta =
     continuity_summary : string
   ; active_goal_ids : string list
   ; paused : bool
+  ; paused_at : float option [@default None]
   ; autoboot_enabled : bool
   ; current_task_id : Keeper_id.Task_id.t option
     (** Currently claimed task ID for cost attribution.

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -258,6 +258,7 @@ type keeper_meta = {
   continuity_summary : string;
   active_goal_ids : string list;
   paused : bool;
+  paused_at : float option;
   autoboot_enabled : bool;
   current_task_id : Keeper_id.Task_id.t option;
       (** Currently claimed task ID for cost attribution.  Set

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -125,6 +125,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
         | None -> `Null )
     ; "last_need", `String rt.last_need
     ; "paused", `Bool m.paused
+    ; "paused_at", Json_util.float_opt_to_json m.paused_at
     ; "autoboot_enabled", `Bool m.autoboot_enabled
     ; ( "current_task_id"
       , Json_util.string_opt_to_json
@@ -243,6 +244,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "last_blocker_class"
   ; "last_need"
   ; "paused"
+  ; "paused_at"
   ; "autoboot_enabled"
   ; "current_task_id"
   ; "max_context_override"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -56,6 +56,7 @@ type parsed_keeper_state =
   ; ps_continuity_summary : string
   ; ps_active_goal_ids : string list
   ; ps_paused : bool
+  ; ps_paused_at : float option
   ; ps_autoboot_enabled : bool
   ; ps_current_task_id : Keeper_id.Task_id.t option
   ; ps_max_context_override : int option
@@ -486,6 +487,7 @@ let parse_keeper_state
   in
   let last_need = cap_loaded (Safe_ops.json_string ~default:"" "last_need" json) in
   let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
+  let ps_paused_at = Safe_ops.json_float_opt "paused_at" json in
   let ps_autoboot_enabled = Safe_ops.json_bool ~default:true "autoboot_enabled" json in
   let ps_current_task_id =
     match Safe_ops.json_string_opt "current_task_id" json with
@@ -501,6 +503,7 @@ let parse_keeper_state
   ; ps_continuity_summary
   ; ps_active_goal_ids
   ; ps_paused
+  ; ps_paused_at
   ; ps_autoboot_enabled
   ; ps_current_task_id
   ; ps_max_context_override
@@ -611,6 +614,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; continuity_summary = state.ps_continuity_summary
                    ; active_goal_ids = state.ps_active_goal_ids
                    ; paused = state.ps_paused
+                   ; paused_at = state.ps_paused_at
                    ; autoboot_enabled = state.ps_autoboot_enabled
                    ; current_task_id = state.ps_current_task_id
                    ; max_context_override = state.ps_max_context_override

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -59,6 +59,7 @@ type parsed_keeper_state =
   ; ps_continuity_summary : string
   ; ps_active_goal_ids : string list
   ; ps_paused : bool
+  ; ps_paused_at : float option
   ; ps_autoboot_enabled : bool
   ; ps_current_task_id : Keeper_id.Task_id.t option
   ; ps_max_context_override : int option

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -15,6 +15,14 @@ open Keeper_execution
 
 module StringMap = Map.Make (String)
 
+let () =
+  Prometheus.register_counter
+    ~name:"masc_keeper_auto_resume_total"
+    ~help:
+      "Total keepers automatically resumed from auto-pause after cooldown. \
+       Labels: keeper."
+    ()
+
 (* ── Pure helpers ────────────────────────────────────────── *)
 
 let backoff_delay attempt =
@@ -557,7 +565,7 @@ let cleanup_dead_tombstone (ctx : _ context)
           match
             write_meta_with_merge
               ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-              ctx.config { meta with paused = true }
+              ctx.config { meta with paused = true; paused_at = Some (Time_compat.now ()) }
           with
           | Ok () -> true
           | Error err when is_version_conflict_error err ->
@@ -799,7 +807,7 @@ let handle_crash_auto_pause (ctx : _ context)
        (match
           write_meta_with_merge
             ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-            ctx.config { meta with paused = true }
+            ctx.config { meta with paused = true; paused_at = Some (Time_compat.now ()) }
         with
         | Ok () -> ()
         | Error err ->
@@ -1092,6 +1100,45 @@ let sweep_and_recover (ctx : _ context) =
                 with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                   Log.Keeper.warn "%s: paused meta prune failed: %s"
                     name (Printexc.to_string exn))
+           | _ -> ());
+  (* Phase 3b: auto-resume paused keepers past cooldown. Only keepers
+     with a recorded [paused_at] timestamp are candidates — legacy
+     pauses ([paused_at = None]) and reconcile-recovery pauses are
+     excluded so operator-initiated pauses are never overridden. *)
+  let auto_resume_sec = Env_config_keeper.KeeperSupervisor.auto_resume_after_sec in
+  Keeper_types.keeper_names ctx.config
+  |> List.iter (fun name ->
+         if Keeper_registry.is_running ~base_path name then ()
+         else
+           match read_meta ctx.config name with
+           | Ok (Some meta)
+             when meta.paused
+                  && not (paused_meta_requires_reconcile_recovery meta) ->
+               (match meta.paused_at with
+                | Some ts when now -. ts >= auto_resume_sec ->
+                  let m =
+                    { meta with paused = false; paused_at = None }
+                  in
+                  (match
+                     write_meta_with_merge
+                       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                       ctx.config m
+                   with
+                   | Ok () ->
+                     Prometheus.inc_counter
+                       Prometheus.metric_keeper_auto_resume_total
+                       ~labels:[ ("keeper", meta.name) ]
+                       ();
+                     Log.Keeper.info
+                       "%s: auto-resuming paused keeper (%.0fs since pause, \
+                        cooldown=%.0fs)"
+                       meta.name (now -. ts) auto_resume_sec
+                   | Error err ->
+                     Log.Keeper.warn
+                       "%s: auto-resume meta write failed: %s"
+                       meta.name err)
+                | Some _ -> () (* still in cooldown *)
+                | None -> () (* legacy / operator pause — never auto-resume *))
            | _ -> ());
   (* Phase 4: reconcile LAST — only orphaned durable keepers *)
   reconcile_keepalive_keepers ctx

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -434,6 +434,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         active_goal_ids =
           active_goal_ids;
         paused = false;
+        paused_at = None;
         autoboot_enabled;
         current_task_id = None;
         work_discovery_enabled = p.profile_defaults.work_discovery_enabled;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -243,6 +243,7 @@ type keeper_meta = {
   continuity_summary: string;
   active_goal_ids: string list;
   paused: bool;
+  paused_at: float option;
   autoboot_enabled: bool;
   current_task_id: Keeper_id.Task_id.t option;
   (** Currently claimed task ID for cost attribution. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -728,6 +728,8 @@ let metric_keeper_restart_outcomes =
    hours (4h+ zombie keepers observed 2026-04-26). *)
 let metric_keeper_oas_timeout_budget_strike =
   "masc_keeper_oas_timeout_budget_strike_total"
+let metric_keeper_auto_resume_total =
+  "masc_keeper_auto_resume_total"
 let metric_oas_bus_subscriber_stream_depth = "masc_oas_bus_subscriber_stream_depth"
 let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_total"
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -428,6 +428,10 @@ val metric_keeper_oas_timeout_budget_strike : string
       fiber with a fresh context budget. Counter reset on any
       successful turn. *)
 
+val metric_keeper_auto_resume_total : string
+(** Total keepers automatically resumed from auto-pause after cooldown.
+    Labels: [keeper]. *)
+
 val metric_oas_bus_subscriber_stream_depth : string
 val metric_oas_bus_publish_block_seconds : string
 val metric_oas_bus_publish : string


### PR DESCRIPTION
## Summary

- Keepers auto-paused by stale-storm or OAS timeout budget loops stay paused forever — no self-healing mechanism existed
- Adds `paused_at: float option` timestamp to `keeper_meta` record, set when auto-pause triggers
- `sweep_and_recover` Phase 3b checks paused keepers and resumes those past a configurable cooldown (default 30 min, min 5 min)
- Legacy/operator-initiated pauses (`paused_at = None`) are never auto-resumed

## Changes

| File | Change |
|------|--------|
| `keeper_meta_contract.ml/mli` | Add `paused_at : float option` field to `keeper_meta` |
| `keeper_meta_json.ml` | Serialize `paused_at` + add to canonical key names |
| `keeper_meta_json_parse.ml/mli` | Parse `paused_at` from JSON |
| `keeper_supervisor.ml` | Set `paused_at` on auto-pause + Phase 3b auto-resume logic + Prometheus counter registration |
| `keeper_turn_up_create.ml` | Add `paused_at = None` to new keeper construction |
| `keeper_types.mli` | Re-export `paused_at` field |
| `env_config_keeper.ml/mli` | Add `auto_resume_after_sec` config constant |
| `prometheus.ml/mli` | Add `masc_keeper_auto_resume_total` metric |

## Safety properties

- Minimum cooldown: 300s hard floor (env knob can't go below)
- Legacy pause protection: `paused_at = None` keepers are never auto-resumed
- Reconcile-recovery pauses are excluded
- Idempotent: meta write failure → next sweep retry
- Observable: Prometheus counter + structured log line on every auto-resume

## Test plan

- [x] `dune build` passes (type check clean)
- [ ] `dune runtest` — local test suite was blocked by concurrent dune builds from other worktrees; CI will verify
- [ ] Manual: set `MASC_KEEPER_AUTO_RESUME_AFTER_SEC=10`, trigger storm pause, observe auto-resume in logs after 10s
- [ ] Verify: `paused_at = None` keepers are NOT auto-resumed (legacy safety)

Refs: #12661

🤖 Generated with [Claude Code](https://claude.com/claude-code)