### PR TITLE
refactor: replace last-char indexing with String.ends_with

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -108,7 +108,7 @@ module FileSystem = struct
       Error (InvalidKey "Slash not allowed (use ':' as separator)")
     else if key.[0] = ':' then
       Error (InvalidKey "Key cannot start with ':'")
-    else if String.ends_with key ~suffix:":" then
+    else if String.ends_with ~suffix:":" key then
       Error (InvalidKey "Key cannot end with ':'")
     else
       (* Check segments *)
@@ -330,7 +330,7 @@ module FileSystem = struct
     | Ok () ->
         let segments = String.split_on_char ':' prefix in
         let complete_segments =
-          if prefix <> "" && String.ends_with prefix ~suffix:":" then
+          if prefix <> "" && String.ends_with ~suffix:":" prefix then
             List.filter (fun segment -> segment <> "") segments
           else
             match List.rev segments with

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -108,7 +108,7 @@ module FileSystem = struct
       Error (InvalidKey "Slash not allowed (use ':' as separator)")
     else if key.[0] = ':' then
       Error (InvalidKey "Key cannot start with ':'")
-    else if key.[String.length key - 1] = ':' then
+    else if String.ends_with key ~suffix:":" then
       Error (InvalidKey "Key cannot end with ':'")
     else
       (* Check segments *)
@@ -330,7 +330,7 @@ module FileSystem = struct
     | Ok () ->
         let segments = String.split_on_char ':' prefix in
         let complete_segments =
-          if prefix <> "" && prefix.[String.length prefix - 1] = ':' then
+          if prefix <> "" && String.ends_with prefix ~suffix:":" then
             List.filter (fun segment -> segment <> "") segments
           else
             match List.rev segments with

--- a/lib/cascade/cascade_ollama_probe.ml
+++ b/lib/cascade/cascade_ollama_probe.ml
@@ -84,7 +84,7 @@ let parse_response ?(total = 1) ?now json =
 (* Build [<base_url>/api/ps], normalising the trailing slash. *)
 let probe_endpoint_of base_url =
   let stripped =
-    if String.ends_with base_url ~suffix:"/"
+    if String.ends_with ~suffix:"/" base_url
     then String.sub base_url 0 (String.length base_url - 1)
     else base_url
   in

--- a/lib/cascade/cascade_ollama_probe.ml
+++ b/lib/cascade/cascade_ollama_probe.ml
@@ -84,8 +84,7 @@ let parse_response ?(total = 1) ?now json =
 (* Build [<base_url>/api/ps], normalising the trailing slash. *)
 let probe_endpoint_of base_url =
   let stripped =
-    if String.length base_url > 0
-       && String.get base_url (String.length base_url - 1) = '/'
+    if String.ends_with base_url ~suffix:"/"
     then String.sub base_url 0 (String.length base_url - 1)
     else base_url
   in

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -140,7 +140,7 @@ let maybe_resolve_missing_relative_read_path ~(roots : string list) ~(raw_path :
 let allows_missing_leaf_read ~(raw : string) ~(candidate : string) : bool =
   let parts = split_relative_components raw in
   let trailing_slash =
-    String.ends_with raw ~suffix:"/"
+    String.ends_with ~suffix:"/" raw
   in
   parent_exists candidate
   && List.length parts > 1

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -140,7 +140,7 @@ let maybe_resolve_missing_relative_read_path ~(roots : string list) ~(raw_path :
 let allows_missing_leaf_read ~(raw : string) ~(candidate : string) : bool =
   let parts = split_relative_components raw in
   let trailing_slash =
-    String.length raw > 0 && raw.[String.length raw - 1] = '/'
+    String.ends_with raw ~suffix:"/"
   in
   parent_exists candidate
   && List.length parts > 1

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -518,8 +518,7 @@ let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
      slash so we can append "/repos/..." cleanly. *)
   let playground_bundle = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
   let playground =
-    if String.length playground_bundle > 0
-       && playground_bundle.[String.length playground_bundle - 1] = '/'
+    if String.ends_with playground_bundle ~suffix:"/"
     then String.sub playground_bundle 0 (String.length playground_bundle - 1)
     else playground_bundle
   in

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -518,7 +518,7 @@ let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
      slash so we can append "/repos/..." cleanly. *)
   let playground_bundle = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
   let playground =
-    if String.ends_with playground_bundle ~suffix:"/"
+    if String.ends_with ~suffix:"/" playground_bundle
     then String.sub playground_bundle 0 (String.length playground_bundle - 1)
     else playground_bundle
   in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -830,7 +830,7 @@ let trim_opt = function
 
 let normalize_base_url value =
   let trimmed = String.trim value in
-  if String.length trimmed > 1 && trimmed.[String.length trimmed - 1] = '/' then
+  if String.length trimmed > 1 && String.ends_with trimmed ~suffix:"/" then
     String.sub trimmed 0 (String.length trimmed - 1)
   else
     trimmed

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -830,7 +830,7 @@ let trim_opt = function
 
 let normalize_base_url value =
   let trimmed = String.trim value in
-  if String.length trimmed > 1 && String.ends_with trimmed ~suffix:"/" then
+  if String.length trimmed > 1 && String.ends_with ~suffix:"/" trimmed then
     String.sub trimmed 0 (String.length trimmed - 1)
   else
     trimmed

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -264,7 +264,7 @@ let apply_mapping ~keeper_id ~base_path ~repositories =
 (* Path normalization for prefix comparison. *)
 let normalize_path_for_prefix_check path =
   let p = String.trim path in
-  if String.length p > 0 && p.[String.length p - 1] = '/' then
+  if String.ends_with p ~suffix:"/" then
     String.sub p 0 (String.length p - 1)
   else p
 

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -264,7 +264,7 @@ let apply_mapping ~keeper_id ~base_path ~repositories =
 (* Path normalization for prefix comparison. *)
 let normalize_path_for_prefix_check path =
   let p = String.trim path in
-  if String.ends_with p ~suffix:"/" then
+  if String.ends_with ~suffix:"/" p then
     String.sub p 0 (String.length p - 1)
   else p
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -796,7 +796,7 @@ type codex_mcp_config_sync_status =
 
 let split_lines_with_trailing_newline content =
   let has_trailing_newline =
-    String.length content > 0 && content.[String.length content - 1] = '\n'
+    String.ends_with content ~suffix:"\n"
   in
   let lines = String.split_on_char '\n' content in
   let lines =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -796,7 +796,7 @@ type codex_mcp_config_sync_status =
 
 let split_lines_with_trailing_newline content =
   let has_trailing_newline =
-    String.ends_with content ~suffix:"\n"
+    String.ends_with ~suffix:"\n" content
   in
   let lines = String.split_on_char '\n' content in
   let lines =


### PR DESCRIPTION
## Summary
- Replace `s.[String.length s - 1] = '/'` with `String.ends_with s ~suffix:"/"` across 7 files (8 sites)
- Remove redundant `String.length x > 0` guards since `ends_with "" ~suffix:...` returns `false`
- Preserve `> 1` guard in `provider_adapter.ml` to prevent stripping lone `/` to empty string

## Files
- `lib/backend/backend.ml` — trailing colon check (2 sites)
- `lib/cascade/cascade_ollama_probe.ml` — trailing slash strip
- `lib/keeper/keeper_alerting_path.ml` — trailing slash detection
- `lib/keeper/keeper_shell_shared.ml` — playground path normalization
- `lib/provider_adapter.ml` — base URL normalization
- `lib/repo_manager/keeper_repo_mapping.ml` — path normalization
- `lib/server/server_runtime_bootstrap.ml` — trailing newline check

## Test plan
- [x] `dune build bin/main_eio.exe --root=$(pwd)` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)