### PR TITLE
refactor: Buffer.add_string(Printf.sprintf) → Printf.bprintf

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -10,7 +10,7 @@ open Types
 let generate_token () =
   let random_bytes = Mirage_crypto_rng.generate 32 in
   let hex = Buffer.create 64 in
-  String.iter (fun c -> Buffer.add_string hex (Printf.sprintf "%02x" (Char.code c))) random_bytes;
+  String.iter (fun c -> Printf.bprintf hex "%02x" (Char.code c)) random_bytes;
   Buffer.contents hex
 
 (** SHA256 hash of a string using Digestif *)

--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -58,7 +58,7 @@ let url_encode value =
       | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '-' | '_' | '.' | '~') as c
         ->
           Buffer.add_char buf c
-      | c -> Buffer.add_string buf (Printf.sprintf "%%%02X" (Char.code c)))
+      | c -> Printf.bprintf buf "%%%02X" (Char.code c))
     value;
   Buffer.contents buf
 

--- a/lib/cancellation.ml
+++ b/lib/cancellation.ml
@@ -63,7 +63,7 @@ module TokenStore = struct
     let bytes = Mirage_crypto_rng.generate 8 in
     let buf = Buffer.create 16 in
     for i = 0 to String.length bytes - 1 do
-      Buffer.add_string buf (Printf.sprintf "%02x" (Char.code (String.get bytes i)))
+      Printf.bprintf buf "%02x" (Char.code (String.get bytes i))
     done;
     Printf.sprintf "cancel_%s" (Buffer.contents buf)
 

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -328,8 +328,8 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
       let status_icon = Types.task_status_icon task.task_status in
       let assignee = Types.task_display_assignee task.task_status in
       let status_str = Types.string_of_task_status task.task_status in
-      Buffer.add_string buf (Printf.sprintf "%s [%d] %s: %s\n" status_icon task.priority task.id task.title);
-      Buffer.add_string buf (Printf.sprintf "   └─ %s | %s\n" status_str assignee)
+      Printf.bprintf buf "%s [%d] %s: %s\n" status_icon task.priority task.id task.title;
+      Printf.bprintf buf "   └─ %s | %s\n" status_str assignee
     ) sorted;
 
     Buffer.contents buf

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -23,11 +23,11 @@ let status config =
     | "" -> state.project
     | name -> name
   in
-  Buffer.add_string buf (Printf.sprintf "🏢 Cluster: %s\n" cluster_name);
+  Printf.bprintf buf "🏢 Cluster: %s\n" cluster_name;
   if cluster_name <> state.project then
-    Buffer.add_string buf (Printf.sprintf "📦 Project: %s\n" state.project);
-  Buffer.add_string buf (Printf.sprintf "📍 Namespace: %s (flattened)\n" current_room);
-  Buffer.add_string buf (Printf.sprintf "📁 Path: %s\n" config.base_path);
+    Printf.bprintf buf "📦 Project: %s\n" state.project;
+  Printf.bprintf buf "📍 Namespace: %s (flattened)\n" current_room;
+  Printf.bprintf buf "📁 Path: %s\n" config.base_path;
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
   Buffer.add_string buf "📌 Players:\n";
 
@@ -64,7 +64,7 @@ let status config =
     let total_agents = List.length agents in
     let shown_agents = take max_agents_display agents in
     List.iter (fun (name, icon, task) ->
-      Buffer.add_string buf (Printf.sprintf "  %s %s → %s\n" icon name task)
+      Printf.bprintf buf "  %s %s → %s\n" icon name task
     ) shown_agents;
     if total_agents > max_agents_display then
       Buffer.add_string buf
@@ -90,7 +90,7 @@ let status config =
   List.iter (fun task ->
     let status_icon = Types.task_status_icon task.task_status in
     let assignee = Types.task_display_assignee task.task_status in
-    Buffer.add_string buf (Printf.sprintf "  %s %s: %s (%s)\n" status_icon task.id task.title assignee)
+    Printf.bprintf buf "  %s %s: %s (%s)\n" status_icon task.id task.title assignee
   ) shown_active_tasks;
 
   if active_tasks = [] then
@@ -108,7 +108,7 @@ let status config =
   (* Message summary: use cumulative sequence to avoid heavy directory scans *)
   let total_messages = max 0 state.message_seq in
   if total_messages > 0 then begin
-    Buffer.add_string buf (Printf.sprintf "\n💬 Messages: %d (cumulative)\n" total_messages);
+    Printf.bprintf buf "\n💬 Messages: %d (cumulative)\n" total_messages;
     Buffer.add_string buf "   Use masc_messages for recent details\n"
   end else
     Buffer.add_string buf "\n💬 Messages: 0\n";

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -79,7 +79,7 @@ let safe_filename name =
     if valid then
       Buffer.add_char buf c_lower
     else
-      Buffer.add_string buf (Printf.sprintf "_%02x" (Char.code c))
+      Printf.bprintf buf "_%02x" (Char.code c)
   ) name;
   Buffer.contents buf
 

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -137,12 +137,12 @@ let status_summary_string
   let current_room = "default" in
 
   let buf = Buffer.create 256 in
-  Buffer.add_string buf (Printf.sprintf "🏢 Cluster: %s\n" effective_cluster_name);
+  Printf.bprintf buf "🏢 Cluster: %s\n" effective_cluster_name;
   if not (String.equal effective_cluster_name state.project) then
-    Buffer.add_string buf (Printf.sprintf "📦 Project: %s\n" state.project);
+    Printf.bprintf buf "📦 Project: %s\n" state.project;
   Buffer.add_string buf
     (Printf.sprintf "📍 Scope: %s (flattened)\n" current_room);
-  Buffer.add_string buf (Printf.sprintf "📁 Path: %s\n" ctx.config.base_path);
+  Printf.bprintf buf "📁 Path: %s\n" ctx.config.base_path;
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
   Buffer.add_string buf
     (Printf.sprintf
@@ -190,7 +190,7 @@ let status_summary_string
     Buffer.add_string buf "\n⚠️ Attention:\n";
     List.iter
       (fun item ->
-        Buffer.add_string buf (Printf.sprintf "  - %s\n" item))
+        Printf.bprintf buf "  - %s\n" item)
       attention_items);
   Buffer.add_string buf "📌 Players:\n";
   (match shown_agents with

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -526,20 +526,20 @@ let format_for_injection ?(include_patterns=true) ?(max_patterns=5) (inst : inst
 
   (* Mission Statement *)
   Buffer.add_string buf "---\n[INSTITUTIONAL MEMORY - Cultural Inheritance]\n\n";
-  Buffer.add_string buf (Printf.sprintf "🏛️ **Mission**: %s\n" inst.identity.mission);
-  Buffer.add_string buf (Printf.sprintf "📅 Generation: %d | Founded: %s\n\n"
+  Printf.bprintf buf "🏛️ **Mission**: %s\n" inst.identity.mission;
+  Printf.bprintf buf "📅 Generation: %d | Founded: %s\n\n"
     inst.identity.generation
     (let t = Unix.gmtime inst.identity.founded_at in
-     Printf.sprintf "%04d-%02d-%02d" (t.Unix.tm_year + 1900) (t.Unix.tm_mon + 1) t.Unix.tm_mday));
+     Printf.sprintf "%04d-%02d-%02d" (t.Unix.tm_year + 1900) (t.Unix.tm_mon + 1) t.Unix.tm_mday);
 
   (* Cultural Values *)
   if inst.culture <> [] then begin
     Buffer.add_string buf "**Core Values** (inherited from predecessors):\n";
     List.iter (fun (v : cultural_value) ->
-      Buffer.add_string buf (Printf.sprintf "  • %s (%.0f%% weight): %s\n"
-        v.name (v.weight *. 100.0) v.description);
+      Printf.bprintf buf "  • %s (%.0f%% weight): %s\n"
+        v.name (v.weight *. 100.0) v.description;
       if v.anti_patterns <> [] then
-        Buffer.add_string buf (Printf.sprintf "    ⚠️ Avoid: %s\n" (String.concat ", " v.anti_patterns))
+        Printf.bprintf buf "    ⚠️ Avoid: %s\n" (String.concat ", " v.anti_patterns)
     ) (List.sort (fun a b -> compare b.weight a.weight) inst.culture |> List.filteri (fun i _ -> i < 3))
   end;
 
@@ -557,12 +557,12 @@ let format_for_injection ?(include_patterns=true) ?(max_patterns=5) (inst : inst
       |> List.filteri (fun i _ -> i < max_patterns)
     in
     List.iter (fun (p : pattern) ->
-      Buffer.add_string buf (Printf.sprintf "  📋 %s (%.0f%% success, %d uses)\n"
-        p.name (p.success_rate *. 100.0) p.usage_count);
-      Buffer.add_string buf (Printf.sprintf "     Trigger: %s\n" p.trigger);
+      Printf.bprintf buf "  📋 %s (%.0f%% success, %d uses)\n"
+        p.name (p.success_rate *. 100.0) p.usage_count;
+      Printf.bprintf buf "     Trigger: %s\n" p.trigger;
       if List.length p.steps <= 3 then
         List.iter (fun step ->
-          Buffer.add_string buf (Printf.sprintf "     → %s\n" step)
+          Printf.bprintf buf "     → %s\n" step
         ) p.steps
     ) sorted_patterns
   end;
@@ -570,14 +570,14 @@ let format_for_injection ?(include_patterns=true) ?(max_patterns=5) (inst : inst
   (* Onboarding Steps *)
   Buffer.add_string buf "\n**Onboarding** (your first steps):\n";
   List.iteri (fun i step ->
-    Buffer.add_string buf (Printf.sprintf "  %d. %s\n" (i + 1) step)
+    Printf.bprintf buf "  %d. %s\n" (i + 1) step
   ) inst.succession.onboarding_steps;
 
   (* Alumni Network *)
   if inst.alumni <> [] then begin
     let recent_alumni = List.filteri (fun i _ -> i < 3) inst.alumni in
-    Buffer.add_string buf (Printf.sprintf "\n👥 Recent predecessors: %s\n"
-      (String.concat ", " recent_alumni))
+    Printf.bprintf buf "\n👥 Recent predecessors: %s\n"
+      (String.concat ", " recent_alumni)
   end;
 
   Buffer.add_string buf "---\n";

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -985,19 +985,19 @@ let render_state_block (snapshot : keeper_state_snapshot) : string =
   Buffer.add_string buf "[STATE]\n";
   (match snapshot.done_summary with
    | Some d when String.trim d <> "" ->
-     Buffer.add_string buf (Printf.sprintf "DONE: %s\n" d)
+     Printf.bprintf buf "DONE: %s\n" d
    | Some _ | None ->
      (match snapshot.progress with
       | Some p when String.trim p <> "" ->
-        Buffer.add_string buf (Printf.sprintf "DONE: %s\n" p)
+        Printf.bprintf buf "DONE: %s\n" p
       | Some _ | None -> ()));
   (match snapshot.next_summary with
    | Some n when String.trim n <> "" ->
-     Buffer.add_string buf (Printf.sprintf "NEXT: %s\n" n)
+     Printf.bprintf buf "NEXT: %s\n" n
    | Some _ | None -> ());
   (match snapshot.goal with
    | Some g when String.trim g <> "" ->
-     Buffer.add_string buf (Printf.sprintf "Goal: %s\n" g)
+     Printf.bprintf buf "Goal: %s\n" g
    | Some _ | None -> ());
   (match snapshot.next_items with
    | [] -> ()

--- a/lib/process/exec_tap.ml
+++ b/lib/process/exec_tap.ml
@@ -61,7 +61,7 @@ let add_json_escaped buf s =
       | '\r' -> Buffer.add_string buf "\\r"
       | '\t' -> Buffer.add_string buf "\\t"
       | c when Char.code c < 0x20 ->
-          Buffer.add_string buf (Printf.sprintf "\\u%04x" (Char.code c))
+          Printf.bprintf buf "\\u%04x" (Char.code c)
       | c -> Buffer.add_char buf c)
     s
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1562,12 +1562,12 @@ let to_prometheus_text () =
     match ms with
     | [] -> ()
     | m :: _ ->
-      Buffer.add_string buf (Printf.sprintf "# HELP %s %s\n" name m.help);
+      Printf.bprintf buf "# HELP %s %s\n" name m.help;
       (match m.metric_type with
        | Histogram ->
          (* No bucket distribution is tracked, so emit as summary
             (sum + count) which is the closest valid Prometheus type. *)
-         Buffer.add_string buf (Printf.sprintf "# TYPE %s summary\n" name);
+         Printf.bprintf buf "# TYPE %s summary\n" name;
          List.iter (fun (metric : metric) ->
            let ls = labels_to_string metric.labels in
            Buffer.add_string buf
@@ -1586,8 +1586,8 @@ let to_prometheus_text () =
          Buffer.add_string buf
            (Printf.sprintf "# TYPE %s %s\n" name (type_to_string m.metric_type));
          List.iter (fun (metric : metric) ->
-           Buffer.add_string buf (Printf.sprintf "%s%s %g\n"
-             metric.name (labels_to_string metric.labels) metric.value)
+           Printf.bprintf buf "%s%s %g\n"
+             metric.name (labels_to_string metric.labels) metric.value
          ) ms)
   ) by_name;
   Buffer.contents buf

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -928,7 +928,7 @@ let escape_toml_string s =
     | '\r' -> Buffer.add_string buf "\\r"
     | '\t' -> Buffer.add_string buf "\\t"
     | c when Char.code c < 0x20 ->
-        Buffer.add_string buf (Printf.sprintf "\\u%04x" (Char.code c))
+        Printf.bprintf buf "\\u%04x" (Char.code c)
     | c -> Buffer.add_char buf c
   ) s;
   Buffer.contents buf

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -390,7 +390,7 @@ let status_string registry =
     "📡 No agents connected."
   else begin
     let buf = Buffer.create 256 in
-    Buffer.add_string buf (Printf.sprintf "📡 Connected agents (%d):\n" (List.length statuses));
+    Printf.bprintf buf "📡 Connected agents (%d):\n" (List.length statuses);
     Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
 
     List.iter (fun status ->
@@ -401,7 +401,7 @@ let status_string registry =
       let listening = status |> U.member "listening" |> U.to_bool in
       let idle_info = if idle > 30 then Printf.sprintf "(idle %ds)" idle else "" in
       let listen_info = if listening then "리스닝중" else "" in
-      Buffer.add_string buf (Printf.sprintf "  %s %s %s %s\n" icon name listen_info idle_info)
+      Printf.bprintf buf "  %s %s %s %s\n" icon name listen_info idle_info
     ) statuses;
 
     Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
@@ -464,7 +464,7 @@ module McpSessionStore = struct
         let bytes = Mirage_crypto_rng.generate 16 in
         let buf = Buffer.create 32 in
         for i = 0 to String.length bytes - 1 do
-          Buffer.add_string buf (Printf.sprintf "%02x" (Char.code (String.get bytes i)))
+          Printf.bprintf buf "%02x" (Char.code (String.get bytes i))
         done;
         let id = Printf.sprintf "mcp_%s" (Buffer.contents buf) in
         Eio.Promise.resolve p id;
@@ -474,7 +474,7 @@ module McpSessionStore = struct
         let bytes = Mirage_crypto_rng.generate 16 in
         let buf = Buffer.create 32 in
         for i = 0 to String.length bytes - 1 do
-          Buffer.add_string buf (Printf.sprintf "%02x" (Char.code (String.get bytes i)))
+          Printf.bprintf buf "%02x" (Char.code (String.get bytes i))
         done;
         let id = Printf.sprintf "mcp_%s" (Buffer.contents buf) in
         let session = {

--- a/lib/subscriptions.ml
+++ b/lib/subscriptions.ml
@@ -70,7 +70,7 @@ module SubscriptionStore = struct
     let bytes = Mirage_crypto_rng.generate 8 in
     let buf = Buffer.create 16 in
     for i = 0 to String.length bytes - 1 do
-      Buffer.add_string buf (Printf.sprintf "%02x" (Char.code (String.get bytes i)))
+      Printf.bprintf buf "%02x" (Char.code (String.get bytes i))
     done;
     Printf.sprintf "sub_%s" (Buffer.contents buf)
 

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -95,20 +95,20 @@ let to_prompt_section ctx =
     let buf = Buffer.create 512 in
     Buffer.add_string buf "--- Team Context ---\n";
     if String.trim ctx.team_goal <> "" then
-      Buffer.add_string buf (Printf.sprintf "Goal: %s\n" ctx.team_goal);
+      Printf.bprintf buf "Goal: %s\n" ctx.team_goal;
     (match truncate_list max_decisions ctx.prior_decisions with
      | [] -> ()
      | decisions ->
          Buffer.add_string buf "\nPrior decisions:\n";
          List.iter
-           (fun d -> Buffer.add_string buf (Printf.sprintf "- %s\n" d))
+           (fun d -> Printf.bprintf buf "- %s\n" d)
            decisions);
     (match truncate_list max_findings ctx.shared_findings with
      | [] -> ()
      | findings ->
          Buffer.add_string buf "\nTeam findings:\n";
          List.iter
-           (fun f -> Buffer.add_string buf (Printf.sprintf "- %s\n" f))
+           (fun f -> Printf.bprintf buf "- %s\n" f)
            findings);
     (match ctx.active_workers with
      | [] -> ()


### PR DESCRIPTION
## Summary
- Replace 43 sites across 15 files where `Buffer.add_string buf (Printf.sprintf ...)` was used
- `Printf.bprintf` writes formatted output directly to `Buffer.t` without intermediate string allocation
- Pure refactor, no behavior change

## Test plan
- [x] `dune build bin/main_eio.exe` passes
- [x] `rg 'Buffer\.add_string.*Printf\.sprintf' lib/` returns 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)