### PR TITLE
refactor: replace O(n²) fold_left (^) with String.concat

### DIFF
--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -161,11 +161,7 @@ let transaction_of_json (json : Yojson.Safe.t) : transaction option =
 
 (** {1 ID Generation} *)
 
-let generate_txn_id () =
-  let rnd = Mirage_crypto_rng.generate 8 in
-  let hex = String.concat "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
-  in
-  Printf.sprintf "txn-%s" hex
+let generate_txn_id () = Random_id.prefixed ~prefix:"txn-" ~bytes:8
 
 (** {1 Ledger Storage} *)
 

--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -163,7 +163,7 @@ let transaction_of_json (json : Yojson.Safe.t) : transaction option =
 
 let generate_txn_id () =
   let rnd = Mirage_crypto_rng.generate 8 in
-  let hex = List.fold_left (fun acc s -> acc ^ s) "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
+  let hex = String.concat "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
   in
   Printf.sprintf "txn-%s" hex
 

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -44,7 +44,7 @@ let with_loops_ro f = Eio.Mutex.use_ro loops_mu (fun () -> f ())
 
 let generate_loop_id () =
   let rnd = Mirage_crypto_rng.generate 4 in
-  let hex = List.fold_left (fun acc s -> acc ^ s) "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i)))) in
+  let hex = String.concat "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i)))) in
   "ar-" ^ hex
 
 let option_first_some left right =

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -42,10 +42,7 @@ let with_loops_rw f = Eio.Mutex.use_rw ~protect:true loops_mu (fun () -> f ())
 (** Execute [f] under shared read lock on the loops registry. *)
 let with_loops_ro f = Eio.Mutex.use_ro loops_mu (fun () -> f ())
 
-let generate_loop_id () =
-  let rnd = Mirage_crypto_rng.generate 4 in
-  let hex = String.concat "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i)))) in
-  "ar-" ^ hex
+let generate_loop_id () = Random_id.prefixed ~prefix:"ar-" ~bytes:4
 
 let option_first_some left right =
   match left with Some _ -> left | None -> right

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -686,7 +686,7 @@ let text_of_response (resp : Llm_provider.Types.api_response) : string =
   |> List.filter_map (function
     | Llm_provider.Types.Text t -> Some t
     | _ -> None)
-  |> fun lst -> List.fold_left (fun acc s -> acc ^ s) "" lst
+  |> fun lst -> String.concat "" lst
 
 (* ── Model resolution: named -> routes.keeper_turn -> built-in defaults ─── *)
 

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -334,7 +334,7 @@ let autoresearch_loops_csv ~(base_path : string) : string =
       ] ^ "\n"
     ) sorted
   in
-  List.fold_left (fun acc r -> acc ^ r) headers rows
+  headers ^ String.concat "" rows
 
 (** Build the loop detail JSON for GET /api/v1/autoresearch/loops/:loopId.
     Includes full cycle history. *)

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -334,7 +334,7 @@ let autoresearch_loops_csv ~(base_path : string) : string =
       ] ^ "\n"
     ) sorted
   in
-  headers ^ String.concat "" rows
+  String.concat "" (headers :: rows)
 
 (** Build the loop detail JSON for GET /api/v1/autoresearch/loops/:loopId.
     Includes full cycle history. *)

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -245,7 +245,7 @@ module Reflection_bridge = struct
         services
     in
     let list_response =
-      List.fold_left (fun acc msg -> acc ^ encode_length_delimited Wire.list_service_service msg) "" service_msgs
+      String.concat "" (List.map (encode_length_delimited Wire.list_service_service) service_msgs)
     in
     encode_length_delimited Wire.resp_list_services_response list_response
 
@@ -264,7 +264,7 @@ module Reflection_bridge = struct
     let payload =
       descriptors
       |> List.map (encode_length_delimited Wire.file_descriptor_proto)
-      |> fun lst -> List.fold_left (fun acc s -> acc ^ s) "" lst
+      |> fun lst -> String.concat "" lst
     in
     encode_length_delimited Wire.resp_file_descriptor_response payload
 

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -239,14 +239,13 @@ module Reflection_bridge = struct
       !result
 
   let encode_list_services_response (services : string list) : string =
-    let service_msgs =
-      List.map
-        (fun name -> encode_string_field Wire.service_name name)
-        services
-    in
-    let list_response =
-      String.concat "" (List.map (encode_length_delimited Wire.list_service_service) service_msgs)
-    in
+    let buf = Buffer.create 256 in
+    List.iter
+      (fun name ->
+        let msg = encode_string_field Wire.service_name name in
+        Buffer.add_string buf (encode_length_delimited Wire.list_service_service msg))
+      services;
+    let list_response = Buffer.contents buf in
     encode_length_delimited Wire.resp_list_services_response list_response
 
   let with_original_request ~(request : string) (payload : string) : string =
@@ -261,12 +260,11 @@ module Reflection_bridge = struct
     encode_length_delimited Wire.resp_error_response error_msg
 
   let encode_file_descriptor_response (descriptors : string list) : string =
-    let payload =
-      descriptors
-      |> List.map (encode_length_delimited Wire.file_descriptor_proto)
-      |> fun lst -> String.concat "" lst
-    in
-    encode_length_delimited Wire.resp_file_descriptor_response payload
+    let buf = Buffer.create 4096 in
+    List.iter
+      (fun d -> Buffer.add_string buf (encode_length_delimited Wire.file_descriptor_proto d))
+      descriptors;
+    encode_length_delimited Wire.resp_file_descriptor_response (Buffer.contents buf)
 
   let health_descriptor_response () =
     encode_file_descriptor_response [ grpc_health_descriptor ]

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -197,7 +197,7 @@ let flush_if_needed ~base_path ~keeper_name =
               | Some r -> gather (i + 1) ((Yojson.Safe.to_string (to_json r) ^ "\n") :: acc)
               | None -> gather (i + 1) acc
           in
-          List.fold_left (fun acc s -> acc ^ s) "" (gather 0 [])
+          String.concat "" (gather 0 [])
         in
         (try
           Fs_compat.append_file dir flush_lines;

--- a/lib/random_id/random_id.ml
+++ b/lib/random_id/random_id.ml
@@ -6,17 +6,18 @@
     site did [Mirage_crypto_rng.generate N |> hex encode] with
     slight formatting variance. *)
 
+let hex_char n = Char.chr (if n < 10 then Char.code '0' + n else Char.code 'a' + n - 10)
+
 let hex ~bytes =
   let rnd = Mirage_crypto_rng.generate bytes in
   let len = String.length rnd in
   let buf = Bytes.create (len * 2) in
-  let hex_char n = Char.chr (if n < 10 then Char.code '0' + n else Char.code 'a' + n - 10) in
   for i = 0 to len - 1 do
     let b = Char.code (String.get rnd i) in
     Bytes.set buf (i * 2) (hex_char (b lsr 4));
     Bytes.set buf (i * 2 + 1) (hex_char (b land 0x0f))
   done;
-  Bytes.unsafe_to_string buf
+  Bytes.to_string buf
 
 let prefixed ~prefix ~bytes =
   prefix ^ hex ~bytes

--- a/lib/random_id/random_id.ml
+++ b/lib/random_id/random_id.ml
@@ -8,7 +8,15 @@
 
 let hex ~bytes =
   let rnd = Mirage_crypto_rng.generate bytes in
-  String.concat "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
+  let len = String.length rnd in
+  let buf = Bytes.create (len * 2) in
+  let hex_char n = Char.chr (if n < 10 then Char.code '0' + n else Char.code 'a' + n - 10) in
+  for i = 0 to len - 1 do
+    let b = Char.code (String.get rnd i) in
+    Bytes.set buf (i * 2) (hex_char (b lsr 4));
+    Bytes.set buf (i * 2 + 1) (hex_char (b land 0x0f))
+  done;
+  Bytes.unsafe_to_string buf
 
 let prefixed ~prefix ~bytes =
   prefix ^ hex ~bytes

--- a/lib/random_id/random_id.ml
+++ b/lib/random_id/random_id.ml
@@ -8,7 +8,7 @@
 
 let hex ~bytes =
   let rnd = Mirage_crypto_rng.generate bytes in
-  List.fold_left (fun acc s -> acc ^ s) "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
+  String.concat "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
 
 let prefixed ~prefix ~bytes =
   prefix ^ hex ~bytes


### PR DESCRIPTION
## Summary
- Replace 8 sites of `List.fold_left (fun acc s -> acc ^ s) ""` with `String.concat ""`
- 7 files: random_id, autoresearch, agent_economy, grpc_server, cascade_config, dashboard_autoresearch, keeper_decision_audit
- O(n²) → O(n): String.concat precomputes total length and copies once

## Test plan
- [x] `dune build bin/main_eio.exe` passes
- [x] `rg 'List\.fold_left.*fun acc s.*acc \^ s.*""' lib/` returns 0 matches (excluding tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)