### PR TITLE
refactor: eliminate Buffer.add_string (^) temporary allocations

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -278,7 +278,8 @@ let rewrite_posts store =
     let path = persist_path () in
     let buf = Buffer.create 4096 in
     Hashtbl.iter (fun _ (pst : post) ->
-      Buffer.add_string buf (Yojson.Safe.to_string (post_to_yojson pst) ^ "\n")
+      Buffer.add_string buf (Yojson.Safe.to_string (post_to_yojson pst));
+      Buffer.add_char buf '\n'
     ) store.posts;
     (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
      | Ok () -> ()
@@ -291,7 +292,8 @@ let rewrite_comments store =
     let path = comments_path () in
     let buf = Buffer.create 4096 in
     Hashtbl.iter (fun _ (cmt : comment) ->
-      Buffer.add_string buf (Yojson.Safe.to_string (comment_to_yojson cmt) ^ "\n")
+      Buffer.add_string buf (Yojson.Safe.to_string (comment_to_yojson cmt));
+      Buffer.add_char buf '\n'
     ) store.comments;
     (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
      | Ok () -> ()

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -89,7 +89,8 @@ let vote_log_jsonl store =
             ("ts", `Float ts);
           ]
       in
-      Buffer.add_string buf (Yojson.Safe.to_string json ^ "\n"))
+      Buffer.add_string buf (Yojson.Safe.to_string json);
+      Buffer.add_char buf '\n')
     store.vote_log;
   Buffer.contents buf
 

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -608,7 +608,9 @@ let format_for_welcome (inst : institution) : string =
     if mission = "" then "(not defined)"
     else String_util.utf8_safe ~max_bytes:80 ~suffix:"..." mission |> String_util.to_string
   in
-  Buffer.add_string buf ("🏛️ Mission: " ^ mission_short ^ "\n");
+  Buffer.add_string buf "🏛️ Mission: ";
+  Buffer.add_string buf mission_short;
+  Buffer.add_char buf '\n';
 
   (* Top 3 values - compact *)
   if inst.culture <> [] then begin
@@ -617,13 +619,19 @@ let format_for_welcome (inst : institution) : string =
       |> List.filteri (fun i _ -> i < 3)
     in
     let value_names = List.map (fun (v : cultural_value) -> v.name) top_values in
-    Buffer.add_string buf ("💎 Values: " ^ String.concat ", " value_names ^ "\n")
+    Buffer.add_string buf "💎 Values: ";
+    Buffer.add_string buf (String.concat ", " value_names);
+    Buffer.add_char buf '\n'
   end;
 
   (* One procedural tip - pattern match for safety *)
   (match List.sort (fun a b -> compare b.success_rate a.success_rate) inst.memory.procedural with
    | best :: _ ->
-       Buffer.add_string buf ("💡 Tip: " ^ best.name ^ " → " ^ best.trigger ^ "\n")
+       Buffer.add_string buf "💡 Tip: ";
+       Buffer.add_string buf best.name;
+       Buffer.add_string buf " → ";
+       Buffer.add_string buf best.trigger;
+       Buffer.add_char buf '\n'
    | [] -> ());
 
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -312,7 +312,7 @@ let save_stats () =
   let path = stats_path () in
   try
     (* Serialise the table under the lock so a concurrent [record_*]
-       cannot [Hashtbl.replace] mid-[Hashtbl.fold] and corrupt the
+       cannot [Hashtbl.replace] mid-iteration and corrupt the
        iteration. *)
     let content, count =
       with_ts_ro (fun () ->

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -316,12 +316,12 @@ let save_stats () =
        iteration. *)
     let content, count =
       with_ts_ro (fun () ->
-        let content =
-          Hashtbl.fold (fun _ s acc ->
-            acc ^ Yojson.Safe.to_string (stats_to_json s) ^ "\n"
-          ) stats_table ""
-        in
-        (content, Hashtbl.length stats_table))
+        let buf = Buffer.create 4096 in
+        Hashtbl.iter (fun _ s ->
+          Buffer.add_string buf (Yojson.Safe.to_string (stats_to_json s));
+          Buffer.add_char buf '\n'
+        ) stats_table;
+        (Buffer.contents buf, Hashtbl.length stats_table))
     in
     Fs_compat.save_file path content;
     Log.Metrics.debug "thompson sampling saved stats for %d agents" count


### PR DESCRIPTION
## Summary
- Split `Buffer.add_string buf (a ^ b ^ "\n")` into separate `Buffer.add_string`/`Buffer.add_char` calls to avoid intermediate string allocation
- Convert `thompson_sampling.ml` Hashtbl.fold O(n²) pattern to Buffer-based iteration
- 4 files, 7 sites total

## Test plan
- [x] `dune build bin/main_eio.exe` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)