### PR TITLE
refactor: strict compiler-level tool validation

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -28,6 +28,54 @@ module Float = Stdlib.Float
     Must be called after all tool schemas are registered (server init).
 
     Tools without a registered schema are allowed through (permissive). *)
+let is_internal_marker_key key =
+  String.length key > 0 && Char.equal key.[0] '_'
+
+let strip_internal_marker_args (args : Yojson.Safe.t) : Yojson.Safe.t =
+  match args with
+  | `Assoc fields ->
+      `Assoc (List.filter (fun (key, _) -> not (is_internal_marker_key key)) fields)
+  | _ -> args
+
+let normalize_transition_args (args : Yojson.Safe.t) : Yojson.Safe.t =
+  match args with
+  | `Assoc fields ->
+      let has key =
+        List.exists (fun (field, _) -> String.equal field key) fields
+      in
+      let fields =
+        if has "note" && not (has "notes") then
+          List.map
+            (fun (key, value) ->
+              if String.equal key "note" then ("notes", value) else (key, value))
+            fields
+        else
+          List.filter
+            (fun (key, _) -> not (String.equal key "note" && has "notes"))
+            fields
+      in
+      let has key =
+        List.exists (fun (field, _) -> String.equal field key) fields
+      in
+      let fields =
+        if has "to" && not (has "action") then
+          List.map
+            (fun (key, value) ->
+              if String.equal key "to" then ("action", value) else (key, value))
+            fields
+        else
+          List.filter
+            (fun (key, _) -> not (String.equal key "to" && has "action"))
+            fields
+      in
+      `Assoc fields
+  | _ -> args
+
+let prepare_args ~name args =
+  let args = strip_internal_marker_args args in
+  if String.equal name "masc_transition" then normalize_transition_args args
+  else args
+
 let register_pre_hook () =
   let lookup name =
     Option.map
@@ -36,7 +84,12 @@ let register_pre_hook () =
   in
   let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
   Tool_dispatch.register_pre_hook (fun ~name ~args ->
-    match hook ~name ~args with
+    let prepared_args = prepare_args ~name args in
+    match hook ~name ~args:prepared_args with
+    | Agent_sdk.Tool_middleware.Pass
+      when not (Yojson.Safe.equal prepared_args args) ->
+      Log.debug "tool_input_validation normalized args for %s" name;
+      Proceed prepared_args
     | Agent_sdk.Tool_middleware.Pass -> Pass
     | Agent_sdk.Tool_middleware.Proceed coerced ->
       Log.debug "tool_input_validation coerced args for %s" name;
@@ -52,4 +105,3 @@ let register_pre_hook () =
         tool_name = name;
         duration_ms = 0.0;
       })
-

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -28,164 +28,6 @@ module Float = Stdlib.Float
     Must be called after all tool schemas are registered (server init).
 
     Tools without a registered schema are allowed through (permissive). *)
-let normalize_transition_token (raw : string) : string =
-  raw
-  |> String.trim
-  |> String.lowercase_ascii
-  |> String.map (function
-       | ' ' | '-' -> '_'
-       | c -> c)
-
-let canonical_transition_action_string (raw : string) : string option =
-  match normalize_transition_token raw with
-  | "claim" | "claimed" -> Some "claim"
-  | "start" | "started" | "in_progress" | "inprogress" | "working" ->
-      Some "start"
-  | "done" | "complete" | "completed" | "finish" | "finished" ->
-      Some "done"
-  | "cancel" | "cancelled" | "canceled" -> Some "cancel"
-  | "release" | "released" | "todo" | "pending" | "backlog" | "open"
-    | "unclaimed" ->
-      Some "release"
-  | "submit_for_verification" | "awaiting_verification"
-    | "needs_verification" | "verification_requested" ->
-      Some "submit_for_verification"
-  | "approve" | "approved" | "verified" -> Some "approve"
-  | "reject" | "rejected" | "changes_requested" | "changesrequested" ->
-      Some "reject"
-  | _ -> None
-
-let upsert_assoc key value fields =
-  (key, value) :: List.remove_assoc key fields
-
-let strip_internal_marker_args (args : Yojson.Safe.t) : Yojson.Safe.t =
-  match args with
-  | `Assoc fields ->
-      `Assoc
-        (List.filter
-           (fun (key, _) -> String.length key = 0 || not (Char.equal key.[0] '_'))
-           fields)
-  | _ -> args
-
-let normalize_transition_args (args : Yojson.Safe.t) : Yojson.Safe.t =
-  match args with
-  | `Assoc fields ->
-      let action_override, consume_to =
-        match List.assoc_opt "action" fields with
-        | Some (`String raw) -> (
-            match canonical_transition_action_string raw with
-            | Some canonical when not (String.equal canonical raw) ->
-                (Some (`String canonical), false)
-            | _ -> (None, false))
-        | Some _ -> (None, false)
-        | None -> (
-            match List.assoc_opt "to" fields with
-            | Some (`String raw) -> (
-                match canonical_transition_action_string raw with
-                | Some canonical -> (Some (`String canonical), true)
-                | None -> (None, false))
-            | _ -> (None, false))
-      in
-      let notes_override, consume_note =
-        if List.mem_assoc "notes" fields then
-          (None, false)
-        else
-          match List.assoc_opt "note" fields with
-          | Some (`String value) -> (Some (`String value), true)
-          | _ -> (None, false)
-      in
-      if Option.is_none action_override && Option.is_none notes_override then
-        args
-      else
-        let filtered =
-          List.filter
-            (fun (key, _) ->
-              not
-                ((consume_to && String.equal key "to")
-                 || (consume_note && String.equal key "note")))
-            fields
-        in
-        let with_action =
-          match action_override with
-          | Some value -> upsert_assoc "action" value filtered
-          | None -> filtered
-        in
-        let with_notes =
-          match notes_override with
-          | Some value -> upsert_assoc "notes" value with_action
-          | None -> with_action
-        in
-        `Assoc with_notes
-  | _ -> args
-
-(* #9785: OAS validation messages list missing required fields as
-   `  "<field>": MISSING (required: <type>)`. When the LLM emitted a
-   similarly-named key (e.g. sent "name" while the schema requires
-   "tool_name"), surface the closest match so the next turn can self-
-   correct in one shot. Pure string transformation over the OAS-emitted
-   message — no OAS API change needed. *)
-let missing_field_re =
-  Re.Pcre.re {|"([^"]+)":\s*MISSING|} |> Re.compile
-
-(* Substring containment in either direction is a strong signal for
-   parameter-name confusion ("name" ⊂ "tool_name"). For short identifiers
-   pure Jaccard underweights this case (tool_name ↔ name ≈ 0.36) so we
-   blend the two with a containment bonus. *)
-let string_contains haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen = 0 || nlen > hlen then false
-  else
-    let rec scan i =
-      if i + nlen > hlen then false
-      else if String.equal (Stdlib.String.sub haystack i nlen) needle then true
-      else scan (i + 1)
-    in
-    scan 0
-
-let param_name_similarity a b =
-  let la = String.lowercase_ascii a and lb = String.lowercase_ascii b in
-  if String.equal la lb then 1.0
-  else if string_contains la lb || string_contains lb la then
-    (* one contained in the other — very likely the LLM confusion case *)
-    0.8
-  else Text_similarity.jaccard_similarity a b
-
-let augment_missing_param_hint ~(args : Yojson.Safe.t) (oas_message : string) =
-  let arg_keys =
-    match args with
-    | `Assoc fields -> List.map fst fields
-    | _ -> []
-  in
-  if Stdlib.List.length arg_keys = 0 then oas_message
-  else
-    let suggestions =
-      Re.all missing_field_re oas_message
-      |> List.filter_map (fun g ->
-        let missing = Re.Group.get g 1 in
-        if List.mem missing arg_keys then None
-        else
-          let scored =
-            List.filter_map
-              (fun k ->
-                let s = param_name_similarity missing k in
-                if Stdlib.Float.compare s 0.4 >= 0 then Some (s, k) else None)
-              arg_keys
-          in
-          let sorted =
-            List.sort (fun (a, _) (b, _) -> Float.compare b a) scored
-          in
-          match sorted with
-          | (_, closest) :: _ ->
-            Some
-              (Printf.sprintf
-                 "  hint: you sent \"%s\"; rename it to \"%s\""
-                 closest missing)
-          | [] -> None)
-    in
-    if Stdlib.List.length suggestions = 0 then oas_message
-    else oas_message ^ "\n\nDid you mean:\n" ^ String.concat "\n" suggestions
-
 let register_pre_hook () =
   let lookup name =
     Option.map
@@ -194,31 +36,20 @@ let register_pre_hook () =
   in
   let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
   Tool_dispatch.register_pre_hook (fun ~name ~args ->
-    let compat_args =
-      let args = strip_internal_marker_args args in
-      if String.equal name "masc_transition" then
-        normalize_transition_args args
-      else
-        args
-    in
-    match hook ~name ~args:compat_args with
-    | Agent_sdk.Tool_middleware.Pass
-      when not (Yojson.Safe.equal compat_args args) ->
-      Log.debug "tool_input_validation coerced args for %s" name;
-      Proceed compat_args
+    match hook ~name ~args with
     | Agent_sdk.Tool_middleware.Pass -> Pass
     | Agent_sdk.Tool_middleware.Proceed coerced ->
       Log.debug "tool_input_validation coerced args for %s" name;
       Proceed coerced
     | Agent_sdk.Tool_middleware.Reject { message; _ } ->
-      let augmented = augment_missing_param_hint ~args:compat_args message in
-      Log.info "tool_input_validation rejected %s: %s" name augmented;
+      Log.info "tool_input_validation rejected %s: %s" name message;
       Reject {
         Tool_result.success = false;
         data = `Assoc [
-          ("error", `String augmented);
+          ("error", `String message);
           ("validation", `String "oas_tool_middleware");
         ];
         tool_name = name;
         duration_ms = 0.0;
       })
+

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -3,7 +3,10 @@ open Base
 (** Tool_input_validation — Pre-dispatch validation via OAS Tool_middleware.
 
     Delegates to [Agent_sdk.Tool_middleware.make_validation_hook] for strict
-    type coercion and structured error feedback. *)
+    type coercion and structured error feedback.  The pre-hook preserves the
+    MASC transport contract by stripping underscore-prefixed protocol markers
+    before validation and by normalising [masc_transition] [to]/[note] aliases
+    to [action]/[notes] without changing action vocabulary. *)
 
 (** Register input validation as a Tool_dispatch pre-hook.
     Must be called after all tool schemas are registered (server init). *)

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -1,102 +1,10 @@
 open Base
 
-(** Tool_input_validation — pre-dispatch input validation hook.
+(** Tool_input_validation — Pre-dispatch validation via OAS Tool_middleware.
 
-    Registers a {!Tool_dispatch.register_pre_hook} that runs the
-    OAS [Tool_middleware.make_validation_hook] over every incoming
-    tool call.  Two MASC-specific responsibilities layered on top
-    of the generic OAS hook:
+    Delegates to [Agent_sdk.Tool_middleware.make_validation_hook] for strict
+    type coercion and structured error feedback. *)
 
-    1. [masc_transition] arg normalisation — accepts a wide set of
-       human-friendly aliases for the [action] / [to] field
-       ([claim/claimed], [start/started/in_progress], etc.) and
-       canonicalises them before validation.
-    2. Missing-required-field hint augmentation — when OAS reports
-       [`"<field>": MISSING (required: ...)`], surface the closest
-       similarly-named key from the actual args so the next turn
-       can self-correct in one shot (#9785).
-
-    @since 2.220.0 — OAS delegation
-    @since 2.221.0 — use Tool_middleware.make_validation_hook *)
-
-val augment_missing_param_hint :
-  args:Yojson.Safe.t -> string -> string
-(** [augment_missing_param_hint ~args oas_message] returns
-    [oas_message] augmented with a [Did you mean:] block listing
-    suggestions when the OAS message reports a missing required
-    field that has a similarly-named key in [args].
-
-    {2 Similarity scoring}
-
-    | Condition | Score |
-    |---|---|
-    | Exact match (case-insensitive) | 1.0 |
-    | One contains the other (e.g. [name ⊂ tool_name]) | 0.8 |
-    | otherwise | {!Text_similarity.jaccard_similarity} |
-
-    Only suggestions with score [>= 0.4] are listed.  The
-    threshold is operator-tunable only by code change — pinning at
-    the contract seam so a future "be more lenient" PR must touch
-    this explicitly.
-
-    {2 Output format}
-
-    When at least one suggestion exists, the message is suffixed
-    with:
-    {[
-      <oas_message>
-
-      Did you mean:
-        hint: you sent "<closest>"; rename it to "<missing>"
-        ...
-    ]}
-
-    The literal [Did you mean:] header and [hint: you sent ...; rename it to ...]
-    line format are pinned — the LLM is expected to match this
-    pattern when self-correcting.
-
-    Pure transformation — no side effects, can be called outside
-    the validation hook (e.g. tests).  Exposed for unit testing
-    via {!test_tool_input_validation}. *)
-
+(** Register input validation as a Tool_dispatch pre-hook.
+    Must be called after all tool schemas are registered (server init). *)
 val register_pre_hook : unit -> unit
-(** [register_pre_hook ()] installs the validation hook on
-    {!Tool_dispatch}.
-
-    {b Must be called after} all tool schemas are registered
-    (server init, post-{!Tool_dispatch.register_schema} sweeps).
-    Tools without a registered schema are allowed through
-    permissively — the absence of a schema is treated as "no
-    validation requested", not "reject by default".
-
-    {2 Hook behaviour}
-
-    For each [(name, args)] tool call:
-
-    1. Strip internal marker args (keys starting with [_]).
-    2. If [name = "masc_transition"], normalise [action] / [to] /
-       [note] aliases via {!normalize_transition_args} (private).
-    3. Run the OAS validation hook on the (possibly-modified)
-       args.
-
-    Result mapping:
-
-    | OAS verdict | MASC pre-hook action |
-    |---|---|
-    | [Pass], args unchanged | [Pass] |
-    | [Pass], args coerced by aliasing | [Proceed coerced] (info-logged) |
-    | [Proceed coerced] | [Proceed coerced] (info-logged) |
-    | [Reject { message; _ }] | [Reject { ...; data = augmented }] (info-logged) |
-
-    On reject, the [data] payload is:
-    {[
-      `Assoc [
-        ("error", `String <augmented_message>);
-        ("validation", `String "oas_tool_middleware");
-      ]
-    ]}
-    The [validation: "oas_tool_middleware"] string is operator-
-    visible — runbooks key off it to distinguish OAS-rejected
-    calls from other failure modes.  [duration_ms] is always
-    [0.0] because validation rejection precedes the dispatch
-    timing instrumentation. *)

--- a/test/dune
+++ b/test/dune
@@ -162,7 +162,6 @@
         test_worktree_live_context
         test_git_graph_snapshot
         test_worktree_status_single_flight_9632
-        test_tool_input_validation
         test_failure_learnings_10325
         test_agent_stress_emit_10341
         test_autoresearch_codegen
@@ -357,7 +356,6 @@
           test_worktree_live_context
           test_git_graph_snapshot
           test_worktree_status_single_flight_9632
-          test_tool_input_validation
           test_failure_learnings_10325
           test_agent_stress_emit_10341
           test_autoresearch_codegen

--- a/test/dune
+++ b/test/dune
@@ -162,6 +162,7 @@
         test_worktree_live_context
         test_git_graph_snapshot
         test_worktree_status_single_flight_9632
+        test_tool_input_validation
         test_failure_learnings_10325
         test_agent_stress_emit_10341
         test_autoresearch_codegen
@@ -356,6 +357,7 @@
           test_worktree_live_context
           test_git_graph_snapshot
           test_worktree_status_single_flight_9632
+          test_tool_input_validation
           test_failure_learnings_10325
           test_agent_stress_emit_10341
           test_autoresearch_codegen

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -336,7 +336,7 @@ let test_registered_hook_transition_compat_to_and_note () =
       ()
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check string) "to -> action claim" "claim"
+  Alcotest.(check string) "to -> action, value preserved for handler" "claimed"
     (assoc_string "action" forwarded);
   Alcotest.(check string) "note -> notes" "PR #8308 Draft"
     (assoc_string "notes" forwarded);
@@ -362,7 +362,7 @@ let test_registered_hook_transition_compat_status_action () =
       ()
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check string) "claimed -> claim" "claim"
+  Alcotest.(check string) "status-like action value preserved for handler" "claimed"
     (assoc_string "action" forwarded)
 
 let test_registered_hook_transition_strips_internal_agent_marker () =
@@ -387,63 +387,6 @@ let test_registered_hook_transition_strips_internal_agent_marker () =
     (Yojson.Safe.Util.member "_agent_name" forwarded = `Null);
   Alcotest.(check string) "agent_name preserved" "codex-local-admin"
     (assoc_string "agent_name" forwarded)
-
-(* ================================================================ *)
-(* #9785: missing-required-param hint augmentation                   *)
-(* ================================================================ *)
-
-let test_augment_suggests_closest_arg_key () =
-  (* Schema requires "tool_name" but LLM sent "name". *)
-  let oas_msg =
-    "Your call to \"masc_tool_help\":\n{\"name\":\"masc_board_post\"}\n\n\
-     Errors (fix these and call again):\n\
-    \  \"tool_name\": MISSING (required: string)"
-  in
-  let args = `Assoc [("name", `String "masc_board_post")] in
-  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
-  Alcotest.(check bool) "appends Did you mean section" true
-    (string_contains augmented "Did you mean:");
-  Alcotest.(check bool) "names actual key sent" true
-    (string_contains augmented "you sent \"name\"");
-  Alcotest.(check bool) "names required key" true
-    (string_contains augmented "rename it to \"tool_name\"")
-
-let test_augment_skips_when_missing_field_present_in_args () =
-  (* Field is missing because the value is wrong type, not absent. *)
-  let oas_msg =
-    "Your call to \"x\":\n{\"task_id\":\"...\"}\n\n\
-     Errors (fix these and call again):\n\
-    \  \"task_id\": MISSING (required: string)"
-  in
-  let args = `Assoc [("task_id", `String "abc")] in
-  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
-  Alcotest.(check string) "message is unchanged" oas_msg augmented
-
-let test_augment_skips_when_no_similar_arg_key () =
-  let oas_msg =
-    "Errors (fix these and call again):\n\
-    \  \"tool_name\": MISSING (required: string)"
-  in
-  let args = `Assoc [("zzzz_unrelated_xyzqq", `String "value")] in
-  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
-  Alcotest.(check string) "message is unchanged when nothing similar" oas_msg augmented
-
-let test_augment_handles_non_object_args () =
-  let oas_msg =
-    "Errors (fix these and call again):\n\
-    \  \"x\": MISSING (required: string)"
-  in
-  let augmented = Tool_input_validation.augment_missing_param_hint ~args:`Null oas_msg in
-  Alcotest.(check string) "message unchanged for null args" oas_msg augmented
-
-let test_augment_handles_no_missing_section () =
-  let oas_msg =
-    "Errors (fix these and call again):\n\
-    \  \"x\": wrong type — expected: integer, got: string"
-  in
-  let args = `Assoc [("x", `String "abc")] in
-  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
-  Alcotest.(check string) "message unchanged when nothing MISSING" oas_msg augmented
 
 (* ================================================================ *)
 (* Runner                                                            *)
@@ -485,23 +428,11 @@ let () =
         test_registered_hook_bypasses_unknown_tool;
       Alcotest.test_case "empty schema bypasses validation" `Quick
         test_registered_hook_bypasses_empty_schema;
-      Alcotest.test_case "masc_transition compat: to/note aliases" `Quick
+      Alcotest.test_case "masc_transition compat: to/note keys" `Quick
         test_registered_hook_transition_compat_to_and_note;
-      Alcotest.test_case "masc_transition compat: status-like action" `Quick
+      Alcotest.test_case "masc_transition compat: status-like action value" `Quick
         test_registered_hook_transition_compat_status_action;
       Alcotest.test_case "masc_transition strips internal markers" `Quick
         test_registered_hook_transition_strips_internal_agent_marker;
-    ]);
-    ("missing_param_hint_9785", [
-      Alcotest.test_case "suggests closest arg key as rename target" `Quick
-        test_augment_suggests_closest_arg_key;
-      Alcotest.test_case "skips when missing field is already present" `Quick
-        test_augment_skips_when_missing_field_present_in_args;
-      Alcotest.test_case "skips when no arg key is similar" `Quick
-        test_augment_skips_when_no_similar_arg_key;
-      Alcotest.test_case "handles non-object args" `Quick
-        test_augment_handles_non_object_args;
-      Alcotest.test_case "ignores wrong-type errors with no MISSING" `Quick
-        test_augment_handles_no_missing_section;
     ]);
   ]


### PR DESCRIPTION
Removes heuristic string matching and fake fallbacks from tool input validation, migrating fully to Agent_sdk.Tool_middleware.make_validation_hook. Ensures strict type-driven schema enforcement.