### PR TITLE
feat(oas): insert Eio.Fiber.yield () in try_cascade (Task 4-3)

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -473,6 +473,7 @@ let run_named
       Error
         terminal_error
     | (provider_cfg : Llm_provider.Provider_config.t) :: rest ->
+      Eio.Fiber.yield (); (* Task 4-3: Prevent starvation during fast-fail cascades *)
       match Cascade_health_tracker.check_circuit_breaker Cascade_health_tracker.global ~provider_key:provider_cfg.model_id with
       | Error msg ->
           Log.Misc.debug "cascade %s: skipping %s (provider cooldown: %s)" cascade_name provider_cfg.model_id msg;


### PR DESCRIPTION
Resolves Task 4-3.

### Changes:
- Added `Eio.Fiber.yield ()` inside the `try_cascade` recursive loop in `lib/oas_worker_named.ml`.

### Rationale:
In scenarios where multiple providers are skipped rapidly (e.g. because their circuit breakers are Open), the cascade iteration loop could become CPU-bound and block the Eio scheduler, starving other tasks like the heartbeat or dashboard telemetry. Explicitly yielding control ensures fairness and liveness for the rest of the application.