### PR TITLE
feat(dashboard): share IDE annotation seed

### DIFF
--- a/dashboard/design-system/CHANGELOG.md
+++ b/dashboard/design-system/CHANGELOG.md
@@ -83,6 +83,10 @@ Stage: legacy alias cleanup + KeeperBadge migration completion + token codificat
   - `src/components/ide/ide-editor-mock.ts` now renders distinct source, split diff, unified diff, and blame bodies instead of changing only the toolbar label.
   - The split/unified views preview the `normalizeTools` tool-call cleanup diff, while blame view adds a keeper timeline strip over the ownership-backed source rows.
 
+- **IDE shared annotation seed**
+  - `src/components/ide/ide-mock-data.ts` centralizes the mock source document, keeper ownership events, anchored rail threads, and layer annotations.
+  - The editor overlay chips and CONVERSATION rail now resolve against the same line anchors, replacing divergent regex/comment/refactor heuristics in the editor fixture.
+
 ### Removed — Hand-written CSS purge across all surfaces
 
 - **Preview surface** — PR #11250

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -3,6 +3,7 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
+import { IDE_MOCK_RELATED_LINE, IDE_MOCK_THREADS } from './ide-mock-data'
 
 describe('IdeConversationRailMock', () => {
   it('renders the RFC 0021 anchored thread rail mock', () => {
@@ -12,8 +13,8 @@ describe('IdeConversationRailMock', () => {
     const region = container.querySelector('[role="region"]')
     expect(region?.getAttribute('aria-label')).toBe('CONVERSATION (RFC 0021 anchored thread rail mock)')
     expect(container.textContent).toContain('CONVERSATION')
-    expect(container.textContent).toContain('5')
-    expect(container.textContent).toContain('router.ts:35')
+    expect(container.textContent).toContain(String(IDE_MOCK_THREADS.length))
+    expect(container.textContent).toContain(`router.ts:${IDE_MOCK_RELATED_LINE}`)
     expect(container.textContent).toContain('2 related')
     expect(container.textContent).toContain('FLAG')
     expect(container.textContent).toContain('nick0cave')

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -6,8 +6,11 @@ import {
   type AnchoredThread,
   type ThreadKind,
 } from './anchored-thread-rail-store'
-
-const EDITOR_FILE = 'runtime/cascade/router.ts'
+import {
+  IDE_MOCK_FILE_PATH,
+  IDE_MOCK_RELATED_LINE,
+  IDE_MOCK_THREADS,
+} from './ide-mock-data'
 
 const KIND_LABEL: Record<ThreadKind, string> = {
   flag: 'FLAG',
@@ -25,63 +28,10 @@ const KIND_TOKEN: Record<ThreadKind, string> = {
   suggest: 'var(--color-status-warn, var(--warn))',
 }
 
-const MOCK_THREADS: ReadonlyArray<AnchoredThread> = [
-  {
-    id: 'thread-schema-tools',
-    kind: 'flag',
-    author_keeper_id: 'nick0cave',
-    anchor: { file_path: EDITOR_FILE, line_start: 34, line_end: 35, symbol_hint: 'if:moonshot-tool-choice' },
-    created_ms: Date.UTC(2026, 4, 2, 1, 41, 18),
-    body: "This is exactly the schema error we're seeing in prod — confirmed 3× on kimi_cli with non-empty tools[].",
-    reply_count: 2,
-    resolved: false,
-  },
-  {
-    id: 'thread-normalize-tool-choice',
-    kind: 'question',
-    author_keeper_id: 'operator',
-    anchor: { file_path: EDITOR_FILE, line_start: 26, line_end: 26, symbol_hint: 'fn:resolveCascade' },
-    created_ms: Date.UTC(2026, 4, 2, 1, 39, 2),
-    body: 'Should normalizeTools also handle tool_choice=none? feels like an edge case.',
-    reply_count: 1,
-    resolved: false,
-  },
-  {
-    id: 'thread-budget-approve',
-    kind: 'approve',
-    author_keeper_id: 'operator',
-    anchor: { file_path: EDITOR_FILE, line_start: 60, line_end: 60, symbol_hint: 'fn:nextStep' },
-    created_ms: Date.UTC(2026, 4, 2, 1, 22, 41),
-    body: 'Budget guard reads well. Ship it when tests pass.',
-    reply_count: 0,
-    resolved: false,
-  },
-  {
-    id: 'thread-telemetry-token',
-    kind: 'note',
-    author_keeper_id: 'operator',
-    anchor: { file_path: EDITOR_FILE, line_start: 35, line_end: 35, symbol_hint: 'token:log.warn' },
-    created_ms: Date.UTC(2026, 4, 2, 1, 18, 4),
-    body: 'telemetry event name needs to match the lifeline schema — will rename later.',
-    reply_count: 0,
-    resolved: false,
-  },
-  {
-    id: 'thread-rest-helper',
-    kind: 'suggest',
-    author_keeper_id: 'masc-improver',
-    anchor: { file_path: EDITOR_FILE, line_start: 16, line_end: 16, symbol_hint: 'fn:normalizeTools' },
-    created_ms: Date.UTC(2026, 4, 2, 1, 14, 52),
-    body: 'Could you collapse the rest-spread into a small helper? Same pattern appears in provider.ts.',
-    reply_count: 3,
-    resolved: false,
-  },
-]
-
 export function IdeConversationRailMock() {
   const railStore = useMemo(() => {
-    const store = createAnchoredThreadRailStore(EDITOR_FILE)
-    store.seed(MOCK_THREADS)
+    const store = createAnchoredThreadRailStore(IDE_MOCK_FILE_PATH)
+    store.seed(IDE_MOCK_THREADS)
     return store
   }, [])
   const [, forceRender] = useState(0)
@@ -90,7 +40,8 @@ export function IdeConversationRailMock() {
 
   const threads = railStore.visibleThreads()
   const focusedId = railStore.focusedThreadId()
-  const relatedLine35 = railStore.threadsForLine(35)
+  const relatedThreads = railStore.threadsForLine(IDE_MOCK_RELATED_LINE)
+  const relatedFile = IDE_MOCK_FILE_PATH.split('/').at(-1) ?? IDE_MOCK_FILE_PATH
 
   return html`
     <div
@@ -126,9 +77,9 @@ export function IdeConversationRailMock() {
           fontSize: 'var(--fs-11)',
         }}
       >
-        <span>router.ts:35</span>
+        <span>${relatedFile}:${IDE_MOCK_RELATED_LINE}</span>
         <span>·</span>
-        <span>${relatedLine35.length} related</span>
+        <span>${relatedThreads.length} related</span>
       </div>
       <ol
         style=${{

--- a/dashboard/src/components/ide/ide-editor-mock.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.test.ts
@@ -3,6 +3,7 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { waitFor } from '@testing-library/preact'
 import { IdeEditorMock } from './ide-editor-mock'
+import { IDE_MOCK_RELATED_LINE } from './ide-mock-data'
 
 describe('IdeEditorMock', () => {
   it('renders the code document and RFC 0019 ownership-backed editor mock', () => {
@@ -23,18 +24,33 @@ describe('IdeEditorMock', () => {
     const container = document.createElement('div')
     render(h(IdeEditorMock, {
       activeView: 'blame',
-      activeLayers: new Set(['time', 'parallel', 'tools', 'approve']),
+      activeLayers: new Set(['time', 'parallel', 'tools', 'approve', 'notes']),
     }), container)
 
     expect(container.textContent).toContain('BLAME')
-    expect(container.textContent).toContain('4 layers')
+    expect(container.textContent).toContain('5 layers')
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Time')
     expect(container.textContent).toContain('Parallel')
     expect(container.textContent).toContain('Tools')
     expect(container.textContent).toContain('Approve')
+    expect(container.textContent).toContain('Notes')
     expect(container.textContent).toContain('tool')
     expect(container.textContent).toContain('approve')
+    expect(container.textContent).toContain('note')
+  })
+
+  it('renders line overlay chips from shared anchored annotation seed data', () => {
+    const container = document.createElement('div')
+    render(h(IdeEditorMock, {
+      activeLayers: new Set(['tools', 'approve', 'notes']),
+    }), container)
+
+    const overlayLabels = Array.from(container.querySelectorAll('[aria-label]'))
+      .map(node => node.getAttribute('aria-label'))
+    expect(overlayLabels).toContain(`line ${IDE_MOCK_RELATED_LINE} active overlays: tool`)
+    expect(overlayLabels).toContain('line 17 active overlays: note')
+    expect(overlayLabels).toContain('line 20 active overlays: approve')
   })
 
   it('renders a split diff body for the split-diff view', () => {

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -8,9 +8,17 @@ import {
 import { CodeLineText, useHighlightedCodeLines } from './ide-code-renderer'
 import {
   createKeeperLineOwnershipStore,
-  type KeeperEdit,
   type LineOwnership,
 } from './keeper-line-ownership-store'
+import {
+  IDE_LAYER_ORDER,
+  IDE_MOCK_FILE_PATH,
+  IDE_MOCK_OWNERSHIP_EVENTS,
+  IDE_MOCK_SOURCE,
+  ideMockAnnotationsForLayer,
+  ideMockAnnotationsForLine,
+  type IdeLayerKind,
+} from './ide-mock-data'
 
 // PR-5 precursor: the editor remains a read-only fixture, but source document,
 // blame-by-keeper ownership, view state, and layer affordances now flow through
@@ -45,9 +53,7 @@ interface SplitDiffRow {
   readonly after: SplitDiffCell | null
 }
 
-const EDITOR_FILE = 'runtime/cascade/router.ts'
 const EMPTY_ACTIVE_LAYERS: ReadonlySet<string> = new Set()
-const LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'explode'] as const
 
 const VIEW_LABEL: Record<IdeEditorView, string> = {
   source: 'SOURCE',
@@ -56,7 +62,7 @@ const VIEW_LABEL: Record<IdeEditorView, string> = {
   blame: 'BLAME',
 }
 
-const LAYER_LABEL: Record<(typeof LAYER_ORDER)[number], string> = {
+const LAYER_LABEL: Record<IdeLayerKind, string> = {
   time: 'Time',
   parallel: 'Parallel',
   tools: 'Tools',
@@ -64,32 +70,6 @@ const LAYER_LABEL: Record<(typeof LAYER_ORDER)[number], string> = {
   notes: 'Notes',
   explode: 'EXPLODE',
 }
-
-const MOCK_SOURCE = [
-  "import { Provider, ProviderKind } from './provider'",
-  "import { Turn, TurnId } from './turn'",
-  "import { FsmEvent } from '../fsm/state'",
-  "import { log } from '../log'",
-  "import type { ToolSpec } from './tools'",
-  "import { TokenRegistry } from '../tokens/registry'",
-  '',
-  'export type CascadeReq = {',
-  '  model: string',
-  '  messages: Array<{ role: string; content: string }>',
-  '  tools?: ToolSpec[]',
-  "  tool_choice?: 'auto' | 'none'",
-  '  max_tokens?: number',
-  '}',
-  '',
-  'export function normalizeTools(req: CascadeReq): CascadeReq {',
-  '  // strip empty tools array',
-  '  if (req.tools && req.tools.length === 0) {',
-  '    const { tools, tool_choice, ...rest } = req',
-  '    return rest as CascadeReq',
-  '  }',
-  '  return req',
-  '}',
-].join('\n')
 
 const UNIFIED_DIFF_ROWS: ReadonlyArray<UnifiedDiffRow> = [
   { kind: 'context', oldLine: 16, newLine: 16, text: 'export function normalizeTools(req: CascadeReq): CascadeReq {' },
@@ -140,46 +120,21 @@ const SPLIT_DIFF_ROWS: ReadonlyArray<SplitDiffRow> = [
   },
 ]
 
-const MOCK_OWNERSHIP_EVENTS: ReadonlyArray<KeeperEdit> = [
-  {
-    file_path: EDITOR_FILE,
-    line_start: 1,
-    line_end: 6,
-    keeper_id: 'nick0cave',
-    timestamp_ms: 1_774_960_000_000,
-    kind: 'create',
-  },
-  {
-    file_path: EDITOR_FILE,
-    line_start: 8,
-    line_end: 14,
-    keeper_id: 'sangsu',
-    timestamp_ms: 1_774_960_180_000,
-    kind: 'edit',
-  },
-  {
-    file_path: EDITOR_FILE,
-    line_start: 16,
-    line_end: 23,
-    keeper_id: 'masc-improver',
-    timestamp_ms: 1_774_960_420_000,
-    kind: 'refactor',
-  },
-]
-
 export function IdeEditorMock({
   activeView = 'source',
   activeLayers = EMPTY_ACTIVE_LAYERS,
 }: IdeEditorMockProps) {
-  const documentStore = useMemo(() =>
-    createCodeDocumentStore({
-      file_path: EDITOR_FILE,
+  const documentStore = useMemo(
+    () => createCodeDocumentStore({
+      file_path: IDE_MOCK_FILE_PATH,
       language: 'typescript',
-      content: MOCK_SOURCE,
-    }), [])
+      content: IDE_MOCK_SOURCE,
+    }),
+    [],
+  )
   const ownershipStore = useMemo(() => {
-    const store = createKeeperLineOwnershipStore(EDITOR_FILE)
-    for (const event of MOCK_OWNERSHIP_EVENTS) store.ingest(event)
+    const store = createKeeperLineOwnershipStore(IDE_MOCK_FILE_PATH)
+    for (const event of IDE_MOCK_OWNERSHIP_EVENTS) store.ingest(event)
     return store
   }, [])
   const document = documentStore.document()
@@ -231,7 +186,7 @@ function EditorViewport(
   lines: ReadonlyArray<CodeDocumentLine>,
   ownership: ReadonlyMap<number, LineOwnership>,
   highlightedLines: ReadonlyArray<string>,
-  activeLayerKinds: ReadonlyArray<string>,
+  activeLayerKinds: ReadonlyArray<IdeLayerKind>,
   keepers: ReadonlyArray<string>,
 ) {
   if (activeView === 'split-diff') return SplitDiffView()
@@ -251,7 +206,7 @@ function SourceRows(
   lines: ReadonlyArray<CodeDocumentLine>,
   ownership: ReadonlyMap<number, LineOwnership>,
   highlightedLines: ReadonlyArray<string>,
-  activeLayerKinds: ReadonlyArray<string>,
+  activeLayerKinds: ReadonlyArray<IdeLayerKind>,
   ariaLabel: string,
 ) {
   return html`
@@ -428,7 +383,7 @@ function MockEditorRow(
   line: CodeDocumentLine,
   owner: LineOwnership | undefined,
   highlightedHtml: string | undefined,
-  activeLayerKinds: ReadonlyArray<string>,
+  activeLayerKinds: ReadonlyArray<IdeLayerKind>,
 ) {
   const color = keeperColor(owner)
   const dot = owner
@@ -501,12 +456,12 @@ function diffMarkerColor(kind: DiffTone): string {
   return 'var(--color-fg-disabled)'
 }
 
-function activeLayersInDisplayOrder(activeLayers: ReadonlySet<string>): ReadonlyArray<string> {
-  return LAYER_ORDER.filter(kind => activeLayers.has(kind))
+function activeLayersInDisplayOrder(activeLayers: ReadonlySet<string>): ReadonlyArray<IdeLayerKind> {
+  return IDE_LAYER_ORDER.filter(kind => activeLayers.has(kind))
 }
 
 function LayerOverlaySummary(
-  activeLayerKinds: ReadonlyArray<string>,
+  activeLayerKinds: ReadonlyArray<IdeLayerKind>,
   ownership: ReadonlyMap<number, LineOwnership>,
   keepers: ReadonlyArray<string>,
 ) {
@@ -553,18 +508,24 @@ function LayerOverlaySummary(
 function rowLayerChips(
   line: CodeDocumentLine,
   owner: LineOwnership | undefined,
-  activeLayerKinds: ReadonlyArray<string>,
+  activeLayerKinds: ReadonlyArray<IdeLayerKind>,
 ): ReadonlyArray<string> {
   const chips: string[] = []
   for (const kind of activeLayerKinds) {
-    if (kind === 'time' && owner) chips.push(formatTime(owner.last_edit_ms))
-    if (kind === 'parallel' && owner) chips.push(owner.last_edit_kind)
-    if (kind === 'tools' && /\btools?\b|tool_choice/.test(line.text)) chips.push('tool')
-    if (kind === 'approve' && owner?.last_edit_kind === 'refactor') chips.push('approve')
-    if (kind === 'notes' && line.text.trim().startsWith('//')) chips.push('note')
-    if (kind === 'explode' && owner) chips.push('ghost')
+    if (kind === 'time' && owner) pushUnique(chips, formatTime(owner.last_edit_ms))
+    else if (kind === 'parallel' && owner) pushUnique(chips, owner.last_edit_kind)
+    else if (kind === 'explode' && owner) pushUnique(chips, 'ghost')
+    else {
+      for (const annotation of ideMockAnnotationsForLine(line.num)) {
+        if (annotation.layers.includes(kind)) pushUnique(chips, annotation.chip)
+      }
+    }
   }
   return chips
+}
+
+function pushUnique(items: string[], item: string): void {
+  if (!items.includes(item)) items.push(item)
 }
 
 function latestEditMs(ownership: ReadonlyMap<number, LineOwnership>): number | null {
@@ -575,18 +536,16 @@ function latestEditMs(ownership: ReadonlyMap<number, LineOwnership>): number | n
   return latest
 }
 
-function layerLabel(kind: string): string {
-  return kind in LAYER_LABEL
-    ? LAYER_LABEL[kind as keyof typeof LAYER_LABEL]
-    : kind
+function layerLabel(kind: IdeLayerKind): string {
+  return LAYER_LABEL[kind]
 }
 
-function layerSummary(kind: string, latestEdit: number | null, keepers: ReadonlyArray<string>): string {
+function layerSummary(kind: IdeLayerKind, latestEdit: number | null, keepers: ReadonlyArray<string>): string {
   if (kind === 'time') return latestEdit === null ? 'no edits' : `latest ${formatTime(latestEdit)}`
   if (kind === 'parallel') return `${keepers.length} keepers`
-  if (kind === 'tools') return 'tool-call lines'
-  if (kind === 'approve') return 'refactor approvals'
-  if (kind === 'notes') return 'comment notes'
+  if (kind === 'tools') return `${ideMockAnnotationsForLayer(kind).length} anchored`
+  if (kind === 'approve') return `${ideMockAnnotationsForLayer(kind).length} approval`
+  if (kind === 'notes') return `${ideMockAnnotationsForLayer(kind).length} note`
   if (kind === 'explode') return 'exclusive ghost view'
   return ''
 }

--- a/dashboard/src/components/ide/ide-mock-data.test.ts
+++ b/dashboard/src/components/ide/ide-mock-data.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { createAnchoredThreadRailStore } from './anchored-thread-rail-store'
+import {
+  IDE_MOCK_ANNOTATIONS,
+  IDE_MOCK_FILE_PATH,
+  IDE_MOCK_RELATED_LINE,
+  IDE_MOCK_SOURCE,
+  IDE_MOCK_THREADS,
+  ideMockAnnotationsForLayer,
+  ideMockAnnotationsForLine,
+} from './ide-mock-data'
+
+describe('IDE mock data', () => {
+  it('keeps annotation anchors inside the editor source document', () => {
+    const lineCount = IDE_MOCK_SOURCE.split('\n').length
+
+    expect(IDE_MOCK_THREADS).toEqual(IDE_MOCK_ANNOTATIONS.map(annotation => annotation.thread))
+    for (const annotation of IDE_MOCK_ANNOTATIONS) {
+      const { anchor } = annotation.thread
+      expect(anchor.file_path).toBe(IDE_MOCK_FILE_PATH)
+      if (anchor.line_start === null || anchor.line_end === null) {
+        throw new Error(`annotation ${annotation.thread.id} must be line anchored`)
+      }
+      expect(anchor.line_start).toBeGreaterThanOrEqual(1)
+      expect(anchor.line_end).toBeLessThanOrEqual(lineCount)
+    }
+  })
+
+  it('drives editor layer lookup and rail line lookup from the same anchors', () => {
+    const railStore = createAnchoredThreadRailStore(IDE_MOCK_FILE_PATH)
+    railStore.seed(IDE_MOCK_THREADS)
+
+    expect(ideMockAnnotationsForLine(IDE_MOCK_RELATED_LINE).map(annotation => annotation.thread.id))
+      .toEqual(railStore.threadsForLine(IDE_MOCK_RELATED_LINE).map(thread => thread.id))
+    expect(ideMockAnnotationsForLayer('tools').map(annotation => annotation.thread.id))
+      .toContain('thread-normalize-tool-choice')
+  })
+})

--- a/dashboard/src/components/ide/ide-mock-data.ts
+++ b/dashboard/src/components/ide/ide-mock-data.ts
@@ -1,0 +1,158 @@
+import type { AnchoredThread } from './anchored-thread-rail-store'
+import type { KeeperEdit } from './keeper-line-ownership-store'
+
+export const IDE_MOCK_FILE_PATH = 'runtime/cascade/router.ts'
+export const IDE_MOCK_RELATED_LINE = 18
+
+export const IDE_LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'explode'] as const
+export type IdeLayerKind = (typeof IDE_LAYER_ORDER)[number]
+
+export interface IdeMockAnnotation {
+  readonly thread: AnchoredThread
+  readonly layers: ReadonlyArray<IdeLayerKind>
+  readonly chip: string
+}
+
+export const IDE_MOCK_SOURCE = [
+  "import { Provider, ProviderKind } from './provider'",
+  "import { Turn, TurnId } from './turn'",
+  "import { FsmEvent } from '../fsm/state'",
+  "import { log } from '../log'",
+  "import type { ToolSpec } from './tools'",
+  "import { TokenRegistry } from '../tokens/registry'",
+  '',
+  'export type CascadeReq = {',
+  '  model: string',
+  '  messages: Array<{ role: string; content: string }>',
+  '  tools?: ToolSpec[]',
+  "  tool_choice?: 'auto' | 'none'",
+  '  max_tokens?: number',
+  '}',
+  '',
+  'export function normalizeTools(req: CascadeReq): CascadeReq {',
+  '  // strip empty tools array',
+  '  if (req.tools && req.tools.length === 0) {',
+  '    const { tools, tool_choice, ...rest } = req',
+  '    return rest as CascadeReq',
+  '  }',
+  '  return req',
+  '}',
+].join('\n')
+
+export const IDE_MOCK_OWNERSHIP_EVENTS: ReadonlyArray<KeeperEdit> = [
+  {
+    file_path: IDE_MOCK_FILE_PATH,
+    line_start: 1,
+    line_end: 6,
+    keeper_id: 'nick0cave',
+    timestamp_ms: 1_774_960_000_000,
+    kind: 'create',
+  },
+  {
+    file_path: IDE_MOCK_FILE_PATH,
+    line_start: 8,
+    line_end: 14,
+    keeper_id: 'sangsu',
+    timestamp_ms: 1_774_960_180_000,
+    kind: 'edit',
+  },
+  {
+    file_path: IDE_MOCK_FILE_PATH,
+    line_start: 16,
+    line_end: 23,
+    keeper_id: 'masc-improver',
+    timestamp_ms: 1_774_960_420_000,
+    kind: 'refactor',
+  },
+]
+
+export const IDE_MOCK_ANNOTATIONS: ReadonlyArray<IdeMockAnnotation> = [
+  {
+    thread: {
+      id: 'thread-schema-tools',
+      kind: 'flag',
+      author_keeper_id: 'nick0cave',
+      anchor: { file_path: IDE_MOCK_FILE_PATH, line_start: 11, line_end: 12, symbol_hint: 'type:CascadeReq.tools' },
+      created_ms: Date.UTC(2026, 4, 2, 1, 41, 18),
+      body: "This is exactly the tool schema edge we're seeing in prod - keep tools[] and tool_choice paired.",
+      reply_count: 2,
+      resolved: false,
+    },
+    layers: ['tools'],
+    chip: 'tool',
+  },
+  {
+    thread: {
+      id: 'thread-normalize-tool-choice',
+      kind: 'question',
+      author_keeper_id: 'operator',
+      anchor: { file_path: IDE_MOCK_FILE_PATH, line_start: 18, line_end: 19, symbol_hint: 'fn:normalizeTools' },
+      created_ms: Date.UTC(2026, 4, 2, 1, 39, 2),
+      body: 'Should normalizeTools also handle tool_choice=none? feels like an edge case.',
+      reply_count: 1,
+      resolved: false,
+    },
+    layers: ['tools'],
+    chip: 'tool',
+  },
+  {
+    thread: {
+      id: 'thread-budget-approve',
+      kind: 'approve',
+      author_keeper_id: 'operator',
+      anchor: { file_path: IDE_MOCK_FILE_PATH, line_start: 20, line_end: 20, symbol_hint: 'return:normalized-rest' },
+      created_ms: Date.UTC(2026, 4, 2, 1, 22, 41),
+      body: 'Budget guard reads well. Ship it when tests pass.',
+      reply_count: 0,
+      resolved: false,
+    },
+    layers: ['approve'],
+    chip: 'approve',
+  },
+  {
+    thread: {
+      id: 'thread-empty-tools-note',
+      kind: 'note',
+      author_keeper_id: 'operator',
+      anchor: { file_path: IDE_MOCK_FILE_PATH, line_start: 17, line_end: 17, symbol_hint: 'comment:empty-tools' },
+      created_ms: Date.UTC(2026, 4, 2, 1, 18, 4),
+      body: 'telemetry event name needs to match the lifeline schema - will rename later.',
+      reply_count: 0,
+      resolved: false,
+    },
+    layers: ['notes'],
+    chip: 'note',
+  },
+  {
+    thread: {
+      id: 'thread-rest-helper',
+      kind: 'suggest',
+      author_keeper_id: 'masc-improver',
+      anchor: { file_path: IDE_MOCK_FILE_PATH, line_start: 18, line_end: 19, symbol_hint: 'fn:normalizeTools' },
+      created_ms: Date.UTC(2026, 4, 2, 1, 14, 52),
+      body: 'Could you collapse the rest-spread into a small helper? Same pattern appears in provider.ts.',
+      reply_count: 3,
+      resolved: false,
+    },
+    layers: ['tools'],
+    chip: 'tool',
+  },
+]
+
+export const IDE_MOCK_THREADS: ReadonlyArray<AnchoredThread> =
+  IDE_MOCK_ANNOTATIONS.map(annotation => annotation.thread)
+
+export function ideMockAnnotationsForLine(line: number): ReadonlyArray<IdeMockAnnotation> {
+  if (!Number.isSafeInteger(line) || line < 1) return []
+  return IDE_MOCK_ANNOTATIONS.filter(annotation => anchorContainsLine(annotation.thread, line))
+}
+
+export function ideMockAnnotationsForLayer(layer: IdeLayerKind): ReadonlyArray<IdeMockAnnotation> {
+  return IDE_MOCK_ANNOTATIONS.filter(annotation => annotation.layers.includes(layer))
+}
+
+function anchorContainsLine(thread: AnchoredThread, line: number): boolean {
+  const { line_start: start, line_end: end } = thread.anchor
+  if (start === null || end === null) return false
+  return line >= start && line <= end
+}


### PR DESCRIPTION
## Summary

- Add a shared IDE mock data fixture for the source document, ownership events, anchored rail threads, and layer annotations.
- Update the editor overlay chips and CONVERSATION rail to consume the same anchored thread seed instead of keeping divergent line coordinates and regex/comment/refactor heuristics.
- Add fixture coverage so editor layer lookup and rail line lookup stay aligned.

## Product impact

The IDE mock now behaves like a single coherent surface: the line chips in the editor and the CONVERSATION cards point at the same source lines. This keeps the design-system path closer to the intended live anchored-thread model and removes misleading rail anchors that referenced lines outside the mock document.

## Evidence

- `pnpm vitest run --config vitest.config.ts src/components/ide/ide-mock-data.test.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-conversation-rail-mock.test.ts src/components/ide/ide-editor-mock.a11y.test.ts src/components/ide/ide-conversation-rail-mock.a11y.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `pnpm exec eslint src/components/ide/ide-mock-data.ts src/components/ide/ide-mock-data.test.ts src/components/ide/ide-editor-mock.ts src/components/ide/ide-editor-mock.test.ts src/components/ide/ide-conversation-rail-mock.ts src/components/ide/ide-conversation-rail-mock.test.ts`
- `git diff --check origin/main`
- `pnpm build`

## Review evidence

- Review `dashboard/src/components/ide/ide-mock-data.ts` for the new shared fixture contract and line anchors.
- Review `dashboard/src/components/ide/ide-editor-mock.ts` to confirm overlay chips now come from anchored annotations for Tools/Approve/Notes layers.
- Review `dashboard/src/components/ide/ide-conversation-rail-mock.ts` to confirm the rail seeds and related-line summary use the same fixture.

## Linked issue

Follow-up from the IDE design-system implementation queue; no GitHub issue currently attached.
