### PR TITLE
fix(oas): codex_cli MCP blockade when all tools are bound-actor

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -605,13 +605,53 @@ let resolve_tool_lane_for_oas_tools
   let runtime_tool_names =
     dedupe_preserve_order (public_tool_names @ keeper_internal_tool_names)
   in
+  (* #12676: When all tools were bound-actor and got stripped for codex_cli,
+     runtime_tool_names is empty. The keeper still needs an MCP connection so
+     it can discover and call non-bound tools dynamically. Build a minimal
+     connect-only policy with the server URL and auth but no allowed_tool_names
+     — codex_cli will see the MCP server without per-tool approval overrides. *)
   let runtime_mcp_policy =
-    runtime_mcp_policy_of_tool_names
-      ?agent_name:requested_agent_name
-      ~allow_keeper_internal:(keeper_internal_tool_names <> [])
-      runtime_tool_names
-    |> runtime_mcp_policy_for_provider ~provider_cfg
-         ~agent_name:(Option.value ~default:"" requested_agent_name)
+    if runtime_tool_names = [] && codex_keeper_bound_actor_tools <> [] then
+      (* Minimal connect-only policy: server + auth, empty allowed_tool_names.
+         Codex_cli will connect to MCP but have no pre-approved tools. *)
+      let env_token = first_nonempty_env [ "MASC_MCP_TOKEN" ] in
+      let per_keeper_token =
+        match env_token, requested_agent_name with
+        | None, Some name ->
+            let base_path = Env_config_core.base_path () in
+            Auth.load_raw_token base_path ~agent_name:name
+        | _ -> None
+      in
+      let auth_headers =
+        match env_token, per_keeper_token with
+        | Some raw, _ -> [ ("Authorization", "Bearer " ^ raw) ]
+        | None, Some raw -> [ ("Authorization", "Bearer " ^ raw) ]
+        | None, None -> []
+      in
+      Some
+        { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+          servers =
+            [
+              Llm_provider.Llm_transport.Http_server
+                { name = "masc";
+                  url = Env_config_runtime.Local_runtime.mcp_url ();
+                  headers = auth_headers;
+                };
+            ];
+          allowed_server_names = [ "masc" ];
+          allowed_tool_names = [];
+          strict = false;
+          disable_builtin_tools = false;
+        }
+      |> runtime_mcp_policy_for_provider ~provider_cfg
+           ~agent_name:(Option.value ~default:"" requested_agent_name)
+    else
+      runtime_mcp_policy_of_tool_names
+        ?agent_name:requested_agent_name
+        ~allow_keeper_internal:(keeper_internal_tool_names <> [])
+        runtime_tool_names
+      |> runtime_mcp_policy_for_provider ~provider_cfg
+           ~agent_name:(Option.value ~default:"" requested_agent_name)
   in
   match runtime_mcp_policy with
   | Some runtime_mcp_policy


### PR DESCRIPTION
## Summary
- Fixes #12676
- When codex_cli keeper's entire tool set consists of bound-actor tools (masc_claim_next, masc_transition, etc.), all tools get stripped because codex_cli cannot carry request-scoped actor bindings
- This left `runtime_tool_names` empty → `runtime_mcp_policy=None` → `legacy_env_extra_args()` disabling MCP entirely
- Fix: detect this scenario and build a minimal connect-only policy (server URL + auth, no per-tool approval) so codex_cli maintains MCP connection

## Root Cause
`resolve_tool_lane_for_oas_tools` in `oas_worker_exec_transport.ml`:
1. Bound-actor tools (5 total: masc_join, masc_leave, masc_claim_next, masc_transition, masc_plan_set_task) are stripped for codex_cli
2. If ALL tools are bound-actor → `runtime_tool_names = []`
3. `tool_names_are_runtime_mcp []` → `false` (empty list check)
4. Policy = `None` → `legacy_env_extra_args()` → `mcp_servers={}`
5. Codex_cli has zero MCP tools → contract violation

## Fix Strategy
Instead of returning `None` policy when all tools were bound-actor, build a minimal connect-only policy:
- Server URL + auth headers (same as normal path)
- `allowed_tool_names = []` (no per-tool approval overrides)
- `strict = false`, `disable_builtin_tools = false`
- Codex_cli connects to MCP and can discover tools at runtime

## Test Plan
- [ ] `dune build` passes (verified locally)
- [ ] Deploy to dev environment with codex_cli keeper
- [ ] Verify keeper with bound-actor-only tool set maintains MCP connection
- [ ] Verify non-bound-actor tool sets still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)