### PR TITLE
feat(keeper): inject bootstrap signal on startup (task-137)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -132,6 +132,15 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
          meta.name
          (Keeper_state_machine.transition_error_to_string err));
   fork_stale_watchdog ctx meta reg;
+  (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs
+     and break the initial proactive deadlock. *)
+  let bootstrap_signal : Keeper_event_queue.stimulus = {
+    post_id = "bootstrap";
+    urgency = Keeper_event_queue.Normal;
+    arrived_at = Unix.gettimeofday ();
+    payload = "Keeper bootstrap signal";
+  } in
+  Keeper_registry.enqueue_event ~base_path meta.name bootstrap_signal;
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let resolved = ref false in
     let resolve_done value =


### PR DESCRIPTION
Resolves task-137 and implements Phase 1 of issue #12662.

### Changes:
- Modified 'launch_supervised_fiber' in 'lib/keeper/keeper_supervisor.ml' to enqueue a synthetic 'bootstrap' stimulus to the keeper's event queue immediately before forking the heartbeat loop.

### Rationale:
A freshly started keeper with no tasks has no observable work, causing the 'keeper_cycle_decision' to yield without running a proactive turn. Since proactive turns are responsible for discovering new work and generating signals, this resulted in a deadlock. Injecting a bootstrap signal ensures the keeper runs at least one warm-up turn to initialize properly.