### PR TITLE
feat(dashboard): keeper presence store & IDE strip

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -1,0 +1,119 @@
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
+import {
+  createKeeperPresenceStore,
+  type KeeperPresenceEntry,
+  type KeeperPresenceSnapshot,
+} from './keeper-presence-store'
+
+export const IDE_MOCK_PRESENCE: KeeperPresenceSnapshot = {
+  runtime_id: 'runtime',
+  branch: 'main',
+  supervisor: 'local',
+  connected: true,
+  entries: [
+    {
+      keeper_id: 'nick0cave',
+      workspace_label: 'dkr-a1',
+      branch: 'main',
+      role: 'driver',
+      status: 'active',
+      last_seen_ms: Date.UTC(2026, 4, 2, 1, 43, 18),
+    },
+    {
+      keeper_id: 'masc-improver',
+      workspace_label: 'wt-run-47',
+      branch: 'feature/normalize-tools',
+      role: 'improver',
+      status: 'active',
+      last_seen_ms: Date.UTC(2026, 4, 2, 1, 42, 58),
+    },
+  ],
+}
+
+interface IdePresenceStripProps {
+  readonly snapshot?: KeeperPresenceSnapshot
+}
+
+export function IdePresenceStrip({
+  snapshot = IDE_MOCK_PRESENCE,
+}: IdePresenceStripProps) {
+  const presenceStore = useMemo(() => createKeeperPresenceStore(snapshot), [])
+  const [, forceRender] = useState(0)
+
+  useEffect(() => presenceStore.subscribe(() => forceRender(tick => tick + 1)), [presenceStore])
+  useEffect(() => {
+    presenceStore.seed(snapshot)
+  }, [presenceStore, snapshot])
+
+  const current = presenceStore.snapshot()
+  const entries = presenceStore.entries()
+
+  return html`
+    <div
+      role="status"
+      aria-label="IDE keeper presence"
+      style=${{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--sp-2)',
+        minWidth: 0,
+        color: 'var(--color-fg-muted)',
+      }}
+    >
+      <span style=${{ color: current.connected ? 'var(--color-status-ok, var(--ok))' : 'var(--color-fg-disabled)' }}>●</span>
+      <span>${current.runtime_id}</span>
+      <span>/</span>
+      <span>${current.branch}</span>
+      <span>/</span>
+      <span>${current.supervisor}</span>
+      <ul
+        style=${{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 'var(--sp-2)',
+          listStyle: 'none',
+          margin: 0,
+          padding: 0,
+          minWidth: 0,
+        }}
+      >
+        ${entries.map(entry => html`<${PresenceChip} entry=${entry} />`)}
+      </ul>
+    </div>
+  `
+}
+
+function PresenceChip({ entry }: { readonly entry: KeeperPresenceEntry }) {
+  const hue = keeperHueIndex(entry.keeper_id)
+  const keeperColor = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
+  return html`
+    <li
+      title=${`${entry.keeper_id} · ${entry.role} · ${entry.branch}`}
+      style=${{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--sp-1)',
+        maxWidth: '180px',
+        color: 'var(--color-fg-secondary)',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style=${{
+          width: '6px',
+          height: '6px',
+          borderRadius: '50%',
+          background: keeperColor,
+          opacity: entry.status === 'active' ? 0.95 : 0.45,
+          flex: '0 0 auto',
+        }}
+      />
+      <span style=${{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        ${entry.keeper_id}@${entry.workspace_label}
+      </span>
+    </li>
+  `
+}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -5,6 +5,7 @@ import { IdeEditorMock, type IdeEditorView } from './ide-editor-mock'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 import { IdeActivityMock } from './ide-activity-mock'
 import { IdeInterjectMock } from './ide-interject-mock'
+import { IdePresenceStrip } from './ide-presence-strip'
 import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { navigate, route } from '../../router'
 import {
@@ -106,7 +107,7 @@ export function IdeShell() {
       >
         <span style=${{ color: 'var(--color-fg-secondary)' }}>코드 IDE</span>
         <span>·</span>
-        <span>* runtime / main / nick0cave@dkr-a1 / improver@wt-run-47</span>
+        <${IdePresenceStrip} />
         <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok, var(--ok))' }}>● mcp · connected</span>
       </header>
       <${IdeToolbar}

--- a/dashboard/src/components/ide/keeper-presence-store.test.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createKeeperPresenceStore,
+  type KeeperPresenceSnapshot,
+} from './keeper-presence-store'
+
+const sample: KeeperPresenceSnapshot = {
+  runtime_id: 'runtime',
+  branch: 'main',
+  supervisor: 'local',
+  connected: true,
+  entries: [
+    {
+      keeper_id: 'idle-keeper',
+      workspace_label: 'wt-idle',
+      branch: 'main',
+      role: 'observer',
+      status: 'idle',
+      last_seen_ms: 1000,
+    },
+    {
+      keeper_id: 'nick0cave',
+      workspace_label: 'dkr-a1',
+      branch: 'main',
+      role: 'driver',
+      status: 'active',
+      last_seen_ms: 2000,
+    },
+  ],
+}
+
+describe('createKeeperPresenceStore', () => {
+  it('seeds a sorted presence snapshot', () => {
+    const store = createKeeperPresenceStore(sample)
+
+    expect(store.snapshot()).toMatchObject({
+      runtime_id: 'runtime',
+      branch: 'main',
+      supervisor: 'local',
+      connected: true,
+    })
+    expect(store.entries().map(entry => entry.keeper_id)).toEqual(['nick0cave', 'idle-keeper'])
+    expect(store.activeEntries().map(entry => entry.keeper_id)).toEqual(['nick0cave'])
+    expect(store.entryForKeeper('nick0cave')?.workspace_label).toBe('dkr-a1')
+  })
+
+  it('rejects malformed snapshots without replacing the current one', () => {
+    const store = createKeeperPresenceStore(sample)
+
+    expect(store.seed({ runtime_id: '', entries: [] })).toBe(false)
+    expect(store.entries().map(entry => entry.keeper_id)).toEqual(['nick0cave', 'idle-keeper'])
+  })
+
+  it('publishes subscribers on seed and reset', () => {
+    const store = createKeeperPresenceStore()
+    let calls = 0
+    const unsubscribe = store.subscribe(() => {
+      calls += 1
+    })
+
+    expect(store.seed(sample)).toBe(true)
+    store.reset()
+    unsubscribe()
+    store.seed(sample)
+
+    expect(calls).toBe(2)
+    expect(store.entries().map(entry => entry.keeper_id)).toEqual(['nick0cave', 'idle-keeper'])
+  })
+})

--- a/dashboard/src/components/ide/keeper-presence-store.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.ts
@@ -1,0 +1,150 @@
+import { signal } from '@preact/signals'
+
+export type KeeperPresenceStatus = 'active' | 'idle' | 'blocked'
+
+export interface KeeperPresenceEntry {
+  readonly keeper_id: string
+  readonly workspace_label: string
+  readonly branch: string
+  readonly role: string
+  readonly status: KeeperPresenceStatus
+  readonly last_seen_ms: number
+}
+
+export interface KeeperPresenceSnapshot {
+  readonly runtime_id: string
+  readonly branch: string
+  readonly supervisor: string
+  readonly connected: boolean
+  readonly entries: ReadonlyArray<KeeperPresenceEntry>
+}
+
+export interface KeeperPresenceStore {
+  readonly seed: (snapshot: unknown) => boolean
+  readonly snapshot: () => KeeperPresenceSnapshot
+  readonly entries: () => ReadonlyArray<KeeperPresenceEntry>
+  readonly activeEntries: () => ReadonlyArray<KeeperPresenceEntry>
+  readonly entryForKeeper: (keeperId: string) => KeeperPresenceEntry | null
+  readonly reset: () => void
+  readonly subscribe: (listener: () => void) => () => void
+}
+
+const EMPTY_SNAPSHOT: KeeperPresenceSnapshot = Object.freeze({
+  runtime_id: 'runtime',
+  branch: 'main',
+  supervisor: 'local',
+  connected: false,
+  entries: [],
+})
+
+const STATUS_ORDER: Record<KeeperPresenceStatus, number> = {
+  active: 0,
+  blocked: 1,
+  idle: 2,
+}
+
+const VALID_STATUS = new Set<string>(['active', 'idle', 'blocked'])
+
+export function createKeeperPresenceStore(
+  initialSnapshot: unknown = EMPTY_SNAPSHOT,
+): KeeperPresenceStore {
+  const snapshotSignal = signal<KeeperPresenceSnapshot>(EMPTY_SNAPSHOT)
+
+  const seed = (snapshot: unknown): boolean => {
+    const normalized = normalizeSnapshot(snapshot)
+    if (normalized === null) return false
+    snapshotSignal.value = normalized
+    return true
+  }
+
+  const reset = (): void => {
+    snapshotSignal.value = EMPTY_SNAPSHOT
+  }
+
+  const subscribe = (listener: () => void): (() => void) => {
+    let sawInitialSnapshot = false
+    return snapshotSignal.subscribe(() => {
+      if (!sawInitialSnapshot) {
+        sawInitialSnapshot = true
+        return
+      }
+      listener()
+    })
+  }
+
+  seed(initialSnapshot)
+
+  return {
+    seed,
+    snapshot: () => snapshotSignal.value,
+    entries: () => snapshotSignal.value.entries,
+    activeEntries: () => snapshotSignal.value.entries.filter(entry => entry.status === 'active'),
+    entryForKeeper: (keeperId: string) =>
+      snapshotSignal.value.entries.find(entry => entry.keeper_id === keeperId) ?? null,
+    reset,
+    subscribe,
+  }
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function normalizeSnapshot(value: unknown): KeeperPresenceSnapshot | null {
+  if (!isRecord(value)) return null
+  if (!hasNonEmptyString(value, 'runtime_id')) return null
+  if (!hasNonEmptyString(value, 'branch')) return null
+  if (!hasNonEmptyString(value, 'supervisor')) return null
+  if (typeof value.connected !== 'boolean') return null
+  if (!Array.isArray(value.entries)) return null
+
+  const entries = value.entries
+    .map(normalizeEntry)
+    .filter((entry): entry is KeeperPresenceEntry => entry !== null)
+    .sort(compareEntries)
+
+  return {
+    runtime_id: value.runtime_id as string,
+    branch: value.branch as string,
+    supervisor: value.supervisor as string,
+    connected: value.connected as boolean,
+    entries,
+  }
+}
+
+function normalizeEntry(value: unknown): KeeperPresenceEntry | null {
+  if (!isRecord(value)) return null
+  if (!hasNonEmptyString(value, 'keeper_id')) return null
+  if (!hasNonEmptyString(value, 'workspace_label')) return null
+  if (!hasNonEmptyString(value, 'branch')) return null
+  if (!hasNonEmptyString(value, 'role')) return null
+  if (!isKeeperPresenceStatus(value.status)) return null
+  if (!Number.isFinite(value.last_seen_ms)) return null
+
+  return {
+    keeper_id: value.keeper_id as string,
+    workspace_label: value.workspace_label as string,
+    branch: value.branch as string,
+    role: value.role as string,
+    status: value.status as KeeperPresenceStatus,
+    last_seen_ms: value.last_seen_ms as unknown as number,
+  }
+}
+
+function compareEntries(a: KeeperPresenceEntry, b: KeeperPresenceEntry): number {
+  const statusDelta = STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
+  if (statusDelta !== 0) return statusDelta
+  if (a.last_seen_ms !== b.last_seen_ms) return b.last_seen_ms - a.last_seen_ms
+  return a.keeper_id.localeCompare(b.keeper_id)
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasNonEmptyString(record: UnknownRecord, key: string): record is UnknownRecord & Record<typeof key, string> {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+function isKeeperPresenceStatus(value: unknown): value is KeeperPresenceStatus {
+  return typeof value === 'string' && VALID_STATUS.has(value)
+}


### PR DESCRIPTION
## Summary
- Add signals-based `KeeperPresenceStore` with snapshot normalization, status sorting, and reactive subscriptions
- Add `IdePresenceStrip` Preact component rendering keeper presence chips with hue-coded indicators
- Replace hardcoded presence text in `ide-shell.ts` header with the new strip component
- Add 3 vitest tests covering seed/sort, malformed rejection, and subscribe lifecycle

## Test plan
- [x] `tsc --noEmit` passes (0 errors)
- [x] `vitest run` keeper-presence-store.test.ts (3/3 pass)
- [ ] Dashboard visual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)