### PR TITLE
fix(dashboard): make Yjs telemetry fanout reviewable

### DIFF
--- a/lib/chronicle_index.ml
+++ b/lib/chronicle_index.ml
@@ -39,8 +39,6 @@ let active_epochs (idx : index) =
     idx.epochs
 
 let add_or_replace_epoch (idx : index) (summary : epoch_summary) =
-  Dashboard_yjs.broadcast_trace_telemetry ~author:summary.id ~position:100;
-
   let filtered =
     List.filter (fun (s : epoch_summary) -> not (String.equal s.id summary.id)) idx.epochs
   in

--- a/lib/dashboard/dashboard_yjs.ml
+++ b/lib/dashboard/dashboard_yjs.ml
@@ -14,23 +14,55 @@ let encode_uint (n : int) : string =
 (** Dashboard_yjs — Yjs WebSocket Projection Layer for Live Telemetry
     @since Project World Building (Big Bang) *)
 
-let broadcast_update payload =
-  let buf = Buffer.create 16 in
+let frame_update payload =
+  let buf = Buffer.create (String.length payload + 8) in
   Buffer.add_char buf (Char.chr 0);
   Buffer.add_char buf (Char.chr 2);
   Buffer.add_string buf (encode_uint (String.length payload));
   Buffer.add_string buf payload;
-  let bin_msg = Buffer.contents buf in
-  (* Prototype: In a real system, this forwards the binary message to Httpun-ws clients *)
-  ignore bin_msg;
-  ()
+  Buffer.contents buf
 
-let broadcast_keeper_telemetry ~keeper_name ~trace_id:_ ~turn_index ~model_id:_ =
-  (* Prototype: Mocking a Yjs binary update payload for a YMap *)
-  let payload = Printf.sprintf "keeper_update:%s:%d" keeper_name turn_index in
-  broadcast_update payload
+let broadcast_update ~kind payload =
+  let frame = frame_update payload in
+  let json =
+    `Assoc
+      [
+        ("type", `String "dashboard_yjs_update");
+        ("kind", `String kind);
+        ("payload", `String payload);
+        ("payload_len", `Int (String.length payload));
+        ("frame_base64", `String (Base64.encode_string frame));
+        ("encoding", `String "yjs_update_v1_base64");
+      ]
+  in
+  try Sse.broadcast_to Sse.Observers json with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Dashboard.warn "dashboard Yjs SSE broadcast failed: %s"
+        (Printexc.to_string exn)
+
+let broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id =
+  let payload =
+    `Assoc
+      [
+        ("kind", `String "keeper_update");
+        ("keeper_name", `String keeper_name);
+        ("trace_id", `String trace_id);
+        ("turn_index", `Int turn_index);
+        ("model_id", `String model_id);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  broadcast_update ~kind:"keeper_update" payload
 
 let broadcast_trace_telemetry ~author ~position =
-  (* Prototype: Mocking a Yjs binary update payload for a YArray *)
-  let payload = Printf.sprintf "trace_update:%s:%d" author position in
-  broadcast_update payload
+  let payload =
+    `Assoc
+      [
+        ("kind", `String "trace_update");
+        ("author", `String author);
+        ("position", `Int position);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  broadcast_update ~kind:"trace_update" payload

--- a/lib/dashboard/dashboard_yjs.mli
+++ b/lib/dashboard/dashboard_yjs.mli
@@ -1,5 +1,21 @@
 (** Dashboard_yjs — Yjs WebSocket Projection Layer for Live Telemetry
     @since Project World Building (Big Bang) *)
 
-val broadcast_keeper_telemetry : keeper_name:string -> trace_id:string -> turn_index:int -> model_id:string -> unit
+(** [frame_update payload] returns the Yjs update frame used by dashboard
+    telemetry broadcasts: sync step 0, update message type 2, varint payload
+    byte length, then the payload bytes. It is pure and preserves caller order
+    only through the caller's own sequencing. *)
+val frame_update : string -> string
+
+(** [broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id]
+    publishes a keeper Yjs telemetry update to dashboard observer sessions.
+    The payload includes all four routing fields. Delivery is synchronous and
+    best-effort through the in-process SSE observer fanout; exceptions from
+    disconnected observers are logged, while cancellation is propagated. *)
+val broadcast_keeper_telemetry :
+  keeper_name:string -> trace_id:string -> turn_index:int -> model_id:string -> unit
+
+(** [broadcast_trace_telemetry ~author ~position] publishes a trace Yjs
+    telemetry update to dashboard observer sessions. Ordering follows local
+    caller invocation order; no cross-process ordering is guaranteed. *)
 val broadcast_trace_telemetry : author:string -> position:int -> unit

--- a/test/dune
+++ b/test/dune
@@ -1162,3 +1162,8 @@
 (include stanzas/test_transport_bridge_seal.inc)
 (include stanzas/test_work_as_heartbeat.inc)
 (include stanzas/test_worker_safety_gates.inc)
+
+(test
+ (name test_dashboard_yjs)
+ (modules test_dashboard_yjs)
+ (libraries masc_test_deps))

--- a/test/test_dashboard_yjs.ml
+++ b/test/test_dashboard_yjs.ml
@@ -1,0 +1,31 @@
+module DY = Masc_mcp.Dashboard_yjs
+
+let byte_codes s =
+  List.init (String.length s) (fun i -> Char.code s.[i])
+
+let check_frame name payload expected_prefix =
+  let frame = DY.frame_update payload in
+  let expected = expected_prefix @ byte_codes payload in
+  Alcotest.(check (list int)) name expected (byte_codes frame)
+
+let test_empty_payload () =
+  check_frame "empty payload frame" "" [ 0; 2; 0 ]
+
+let test_small_payload () =
+  check_frame "small payload frame" "abc" [ 0; 2; 3 ]
+
+let test_multibyte_varint_payload () =
+  let payload = String.make 130 'x' in
+  check_frame "130-byte payload frame" payload [ 0; 2; 0x82; 0x01 ]
+
+let () =
+  Alcotest.run "dashboard_yjs"
+    [
+      ( "frame_update",
+        [
+          Alcotest.test_case "empty payload" `Quick test_empty_payload;
+          Alcotest.test_case "small payload" `Quick test_small_payload;
+          Alcotest.test_case "multi-byte varint payload" `Quick
+            test_multibyte_varint_payload;
+        ] );
+    ]


### PR DESCRIPTION
## Why
#12724 merged with unresolved review feedback around the dashboard Yjs telemetry path. The merged code built a frame and discarded it, ignored keeper routing fields, coupled Chronicle_index to dashboard broadcasting, and lacked frame encoding tests.

## Changes
- Expose a pure Dashboard_yjs.frame_update helper and cover empty, small, and >127 byte payload frames.
- Send dashboard Yjs updates through the existing SSE observer fanout with a base64 encoded binary frame.
- Include trace_id and model_id in keeper telemetry payloads.
- Remove the Dashboard_yjs side effect and hard-coded position from Chronicle_index.add_or_replace_epoch.
- Add per-value interface docs describing payloads, ordering, and cancellation behavior.

## Validation
- scripts/dune-local.sh build test/test_dashboard_yjs.exe
- ./_build/default/test/test_dashboard_yjs.exe
- scripts/dune-local.sh build bin/main_eio.exe
- git diff --check