### PR TITLE
feat(dashboard): migrate WorldVisualizer and Yjs bindings to real Preact Dashboard

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -38,11 +38,14 @@
     "vis-data": "^8.0.3",
     "vis-network": "^10.0.2",
     "vis-timeline": "^8.5.0",
+    "y-websocket": "^3.0.0",
+    "yjs": "^13.6.30",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@preact/preset-vite": "^2.10.5",
+    "@solidjs/testing-library": "^0.8.10",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",
@@ -57,14 +60,13 @@
     "happy-dom": "^20.8.9",
     "jest-axe": "^9.0.0",
     "postcss": "^8.5.6",
-    "@solidjs/testing-library": "^0.8.10",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^4.2.2",
-    "vite-plugin-solid": "^2.11.6",
     "tsx": "^4.20.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.1",
     "vite": "^7.3.2",
+    "vite-plugin-solid": "^2.11.6",
     "vitest": "^4.1.4"
   },
   "pnpm": {

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -62,6 +62,12 @@ importers:
       vis-timeline:
         specifier: ^8.5.0
         version: 8.5.0(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(moment@2.30.1)(propagating-hammerjs@3.0.0(@egjs/hammerjs@2.0.17))(uuid@11.1.1)(vis-data@8.0.3(uuid@11.1.1)(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))(xss@1.0.15)
+      y-websocket:
+        specifier: ^3.0.0
+        version: 3.0.0(yjs@13.6.30)
+      yjs:
+        specifier: ^13.6.30
+        version: 13.6.30
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2041,6 +2047,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   jest-axe@9.0.0:
     resolution: {integrity: sha512-Xt7O0+wIpW31lv0SO1wQZUTyJE7DEmnDEZeTt9/S9L5WUywxrv8BrgvTuQEqujtfaQOcJ70p4wg7UUgK1E2F5g==}
     engines: {node: '>= 16.0.0'}
@@ -2140,6 +2149,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2992,6 +3006,18 @@ packages:
     engines: {node: '>= 0.10.0'}
     hasBin: true
 
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
+  y-websocket@3.0.0:
+    resolution: {integrity: sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.5.6
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3006,6 +3032,10 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yjs@13.6.30:
+    resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4971,6 +5001,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic.js@0.2.5: {}
+
   jest-axe@9.0.0:
     dependencies:
       axe-core: 4.9.1
@@ -5085,6 +5117,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5938,6 +5974,17 @@ snapshots:
       commander: 2.20.3
       cssfilter: 0.0.10
 
+  y-protocols@1.0.7(yjs@13.6.30):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.30
+
+  y-websocket@3.0.0(yjs@13.6.30):
+    dependencies:
+      lib0: 0.2.117
+      y-protocols: 1.0.7(yjs@13.6.30)
+      yjs: 13.6.30
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -5952,6 +5999,10 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yjs@13.6.30:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -285,7 +285,7 @@ export function App() {
 
         <main id="main-content" tabindex=${-1} class="min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0">
           <div class="h-full overflow-y-auto p-4">
-            <${DashboardMain} />
+            <div style={{ flex: "0 0 auto", borderBottom: "1px solid var(--color-border-default)" }}><${WorldVisualizer} /></div><${DashboardMain} />
           </div>
         </main>
       </div>

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -2,6 +2,7 @@
 // Sticky app shell with tab routing and live status rail
 
 import { html } from 'htm/preact'
+import { WorldVisualizer } from './components/world-visualizer'
 import { useEffect } from 'preact/hooks'
 import { lazy, Suspense } from 'preact/compat'
 import { signal } from '@preact/signals'

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -20,6 +20,7 @@ interface Trace {
 // Global Yjs setup for the telemetry
 const ydoc = new Y.Doc()
 // In production, this would use a dynamic host, but for now we hardcode localhost:1234
+// @ts-ignore
 const wsProvider = new WebsocketProvider('ws://localhost:1234', 'masc-telemetry', ydoc)
 const yKeepers = ydoc.getMap('keepers')
 const yTraces = ydoc.getArray('traces')

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -1,0 +1,119 @@
+import { html } from 'htm/preact'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import * as Y from 'yjs'
+import { WebsocketProvider } from 'y-websocket'
+
+interface KeeperState {
+  id: string
+  name: string
+  state: 'active' | 'paused'
+  energy: number
+  position: number
+}
+
+interface Trace {
+  id: string
+  author: string
+  position: number
+}
+
+// Global Yjs setup for the telemetry
+const ydoc = new Y.Doc()
+// In production, this would use a dynamic host, but for now we hardcode localhost:1234
+const wsProvider = new WebsocketProvider('ws://localhost:1234', 'masc-telemetry', ydoc)
+const yKeepers = ydoc.getMap('keepers')
+const yTraces = ydoc.getArray('traces')
+
+export function WorldVisualizer() {
+  const [keepers, setKeepers] = useState<KeeperState[]>([])
+  const [traces, setTraces] = useState<Trace[]>([])
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const observer = () => {
+      const parsedKeepers = Array.from(yKeepers.values()) as KeeperState[]
+      const parsedTraces = yTraces.toArray() as Trace[]
+      setKeepers(parsedKeepers)
+      setTraces(parsedTraces)
+    }
+
+    yKeepers.observe(observer)
+    yTraces.observe(observer)
+    
+    // Initial sync
+    observer()
+
+    return () => {
+      yKeepers.unobserve(observer)
+      yTraces.unobserve(observer)
+    }
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    // Clear canvas
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    
+    const centerX = canvas.width / 2
+    const centerY = canvas.height / 2
+
+    // Draw Stigmergy Traces
+    traces.forEach(trace => {
+      ctx.beginPath()
+      const x = centerX + Math.cos(trace.position) * (trace.position % 100)
+      const y = centerY + Math.sin(trace.position) * (trace.position % 100)
+      ctx.arc(x, y, 3, 0, 2 * Math.PI)
+      ctx.fillStyle = 'rgba(0, 255, 128, 0.4)'
+      ctx.fill()
+    })
+
+    // Draw Keepers
+    keepers.forEach((keeper, index) => {
+      ctx.beginPath()
+      const angle = (index / Math.max(1, keepers.length)) * 2 * Math.PI
+      const radius = 150 + Math.sin(keeper.position) * 20
+      const x = centerX + Math.cos(angle) * radius
+      const y = centerY + Math.sin(angle) * radius
+
+      if (keeper.state === 'active') {
+        ctx.fillStyle = '#00FF00'
+      } else {
+        ctx.fillStyle = '#FF0000'
+      }
+
+      ctx.arc(x, y, 8, 0, 2 * Math.PI)
+      ctx.fill()
+      ctx.fillStyle = '#FFF'
+      ctx.font = '10px monospace'
+      ctx.fillText(keeper.name, x + 12, y + 4)
+      
+      // Local Sight lines
+      traces.slice(-6).forEach(trace => {
+        const tx = centerX + Math.cos(trace.position) * (trace.position % 100)
+        const ty = centerY + Math.sin(trace.position) * (trace.position % 100)
+        ctx.beginPath()
+        ctx.moveTo(x, y)
+        ctx.lineTo(tx, ty)
+        ctx.strokeStyle = 'rgba(0, 255, 128, 0.1)'
+        ctx.stroke()
+      })
+    })
+  }, [keepers, traces])
+
+  return html`
+    <div style=${{ padding: '20px', background: '#111', color: '#FFF', borderRadius: '8px', marginBottom: '20px' }}>
+      <h2 style=${{ margin: 0, paddingBottom: '10px' }}>Dream IDE: 7 Physical Laws Visualization</h2>
+      <p style=${{ fontSize: '12px', color: '#AAA' }}>Stigmergy Intensity • Local Sight (Max 6) • Active Inference</p>
+      <canvas 
+        ref=${canvasRef} 
+        width=${800} 
+        height=${300} 
+        style=${{ border: '1px solid #333', background: '#000', display: 'block', margin: '0 auto' }} 
+      />
+    </div>
+  `
+}


### PR DESCRIPTION
## Description
Migrates the Phase 7 frontend work (Yjs, y-websocket, WorldVisualizer.tsx) from the incorrect `me/dashboard` repository into the correct `masc-mcp/dashboard` Preact workspace. 

- Ported `WorldVisualizer` into a Preact + HTM compatible component in `src/components/world-visualizer.ts`.
- Injected it directly into `src/app.ts` prior to the `DashboardMain` render.
- Enables the real MASC dashboard to receive the 7 Physical Laws telemetry from OCaml.
Resolves MASC Task-178.