### PR TITLE
feat(cascade): kimi-coding provider + tiered cascade profiles

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -17,6 +17,9 @@ openai_compat = "big_three"
 persona_generation = "big_three"
 provider_benchmark = "big_three"
 llm_rerank = "tool_rerank"
+simple_task = "tier_small"
+moderate_task = "tier_medium"
+complex_task = "big_three"
 
 [big_three]
 comment = "Canonical keeper/workflow profile. Keep operator-chosen providers here; code must route logical usages through [routes] instead of hardcoding extra profile names."
@@ -55,3 +58,25 @@ models = [
 temperature = 0.0
 max_tokens = 200
 keeper_assignable = false
+
+[tier_small]
+comment = "4B-class local models for simple tasks (classification, format, short summary). Operator opt-in: uncomment models when Ollama is running locally."
+# models = [
+#   "ollama:llama3.2:3b",
+#   "ollama:phi-3-mini",
+# ]
+models = []
+temperature = 0.3
+max_tokens = 1000
+keeper_assignable = false
+fallback_cascade = "tier_medium"
+
+[tier_medium]
+comment = "9B-class models for moderate tasks (extraction, reformat, medium-length generation). Falls back to big_three on exhaustion."
+models = [
+  "glm-coding:glm-4.7-flashx",
+]
+temperature = 0.2
+max_tokens = 4096
+keeper_assignable = false
+fallback_cascade = "big_three"

--- a/docs/rfc/RFC-0023-kimi-coding-api-provider.md
+++ b/docs/rfc/RFC-0023-kimi-coding-api-provider.md
@@ -1,0 +1,65 @@
+# RFC-0023: Kimi Coding API Provider (3-way Split Completion)
+
+- **Status**: Draft
+- **Author**: vincent (with Claude)
+- **Created**: 2026-05-03
+- **Related**: provider_adapter.ml, transport_kimi_cli.ml, config/cascade.toml
+
+## 1. Problem
+
+Kimi (Moonshot AI) has 3 distinct API surfaces, but masc-mcp only integrates 2:
+
+| Provider | Endpoint | Type | Status |
+|---|---|---|---|
+| `kimi` (CLI) | local binary `kimi-for-coding` | `Cli_agent` | Active in cascade |
+| `kimi-api` | `api.moonshot.ai` | `Direct_api` | Registered, not in cascade |
+| `kimi-coding` | `api.kimi.com/coding` | `Direct_api` | **Missing** |
+
+The `kimi-coding` endpoint is a coding-optimized API with different rate limits, pricing, and model routing.
+
+## 2. Design Principles
+
+| # | Principle | Rationale |
+|---|-----------|-----------|
+| P1 | Separate provider, not endpoint toggle. | Current architecture treats each variant as a separate provider. Third follows same pattern. |
+| P2 | Reuse Direct_api transport. | Same OpenAI-compatible HTTP transport as `kimi-api`. Different endpoint and API key. |
+| P3 | Cascade opt-in. | New provider starts outside cascade profiles. Operators add after validation. |
+
+## 3. Implementation
+
+### 3.1 Provider Registry Entry
+
+In `lib/provider_adapter.ml`, add:
+
+```ocaml
+{ canonical_name = "kimi-coding";
+  runtime_kind = Direct_api;
+  auth_mode = Api_key "KIMI_CODING_API_KEY";
+  cascade_prefix = "kimi_coding";
+  endpoint_url = Some "https://api.kimi.com/coding/v1";
+  default_model = "kimi-coding-auto";
+  aliases = ["kimi-coding"; "kimi_coding"];
+}
+```
+
+### 3.2 Environment Variable
+
+`KIMI_CODING_API_KEY` with fallback to `KIMI_API_KEY_SB`.
+
+### 3.3 No New Transport Module
+
+Reuse existing OpenAI-compatible `Direct_api` transport. Only differences are base URL and API key env var.
+
+## 4. Files to Modify
+
+| File | Change |
+|------|--------|
+| `lib/provider_adapter.ml` | Add `kimi-coding` provider entry |
+| `lib/provider_adapter.mli` | Expose if needed |
+| `config/cascade.toml` | Optional: add to cascade profile after validation |
+
+## 5. Validation
+
+1. Unit: provider registry lookup by alias
+2. Integration: HTTP request to `api.kimi.com/coding` with test key
+3. Smoke: add to cascade, run keeper turn, verify routing

--- a/docs/rfc/RFC-0024-ollama-cascade-integration.md
+++ b/docs/rfc/RFC-0024-ollama-cascade-integration.md
@@ -1,0 +1,94 @@
+# RFC-0024: Ollama Cascade Integration + KV Cache Optimization
+
+- **Status**: Draft
+- **Author**: vincent (with Claude)
+- **Created**: 2026-05-03
+- **Related**: backend_ollama.ml (agent_sdk), provider_adapter.ml, config/cascade.toml
+
+## 1. Problem
+
+agent_sdk에 이미 `backend_ollama.ml`이 완전 구현되어 있으나 (`/api/chat`, `think` 제어, `keep_alive=-1` 기본, 스트리밍), masc-mcp의 `provider_adapter.ml`과 `cascade.toml`에 Ollama provider가 등록되어 있지 않아 로컬 모델을 cascade에서 사용할 수 없음.
+
+## 2. Current State
+
+agent_sdk `backend_ollama.ml` 지원:
+- `/api/chat` 엔드포인트 (native API)
+- `think` 파라미터 (boolean, 기본 false)
+- `keep_alive`: 해석 순서 config → `OAS_OLLAMA_KEEP_ALIVE` env → 기본 `-1` (영구 상주)
+- `num_predict` → `max_tokens` 매핑
+- `options` 객체 내 샘플링 파라미터
+- `tool_use_recovery.ml`에서 Ollama 오류 복구 지원
+- provider.ml에 `Ollama` variant 이미 정의
+
+masc-mcp 누락:
+- `provider_adapter.ml`에 Ollama adapter entry 없음
+- `cascade.toml`에 Ollama model 없음
+- 로컬 런타임 프로브는 `tool_local_runtime_probe.ml`에 존재하나 cascade 라우팅과 연결 안 됨
+
+## 3. Design Principles
+
+| # | Principle | Rationale |
+|---|-----------|-----------|
+| P1 | **Register, don't build.** | Transport는 agent_sdk에 이미 있음. masc-mcp는 등록만. |
+| P2 | **Optional cascade inclusion.** | Ollama는 로컬 전용. 기본 cascade에서 제외, operator가 명시적으로 추가. |
+| P3 | **keep_alive=-1 고정.** | 자동화 환경에서 모델 언로드 방지. 이미 agent_sdk 기본값. |
+
+## 4. Implementation
+
+### 4.1 Provider Adapter Entry
+
+In `lib/provider_adapter.ml`, add Ollama adapter:
+
+```ocaml
+{ canonical_name = "ollama";
+  runtime_kind = Direct_api;  (* HTTP API, not CLI *)
+  auth_mode = No_auth;  (* Ollama is local, no auth *)
+  cascade_prefix = "ollama";
+  endpoint_url = Some "http://127.0.0.1:11434";
+  default_model_id = "llama3.2";
+  aliases = ["ollama"; "local"];
+}
+```
+
+### 4.2 Cascade Profile (optional, operator opt-in)
+
+```toml
+[local_small]
+comment = "Local Ollama models for cost-free routing. Operator opt-in."
+models = [
+  "ollama:llama3.2:3b",
+  "ollama:phi-3-mini",
+]
+temperature = 0.3
+max_tokens = 4096
+keeper_assignable = true
+```
+
+### 4.3 KV Cache Optimization (Server-side)
+
+Not a code change. Ollama 서버 설정:
+
+```bash
+# ~/.config/ollama/config.json 또는 환경변수
+OLLAMA_FLASH_ATTENTION=1    # Flash Attention 활성화
+OLLAMA_KEEP_ALIVE=-1        # 모델 영구 상주 (이미 agent_sdk 기본값)
+```
+
+모델 풀 시 Q8_0 quantization 권장:
+```bash
+ollama pull llama3.2:3b-q8_0
+```
+
+## 5. Files to Modify
+
+| File | Change |
+|------|--------|
+| `lib/provider_adapter.ml` | Ollama adapter entry 추가 |
+| `lib/provider_adapter.mli` | 필요시 expose |
+| `config/cascade.toml` | `[local_small]` 프로파일 추가 (주석처리, opt-in) |
+
+## 6. Scope Exclusions
+
+- agent_sdk transport 변경 없음 (이미 완전 구현)
+- flash_attention 설정은 서버 환경변수 (코드 아님)
+- 자동 모델 티어 분류는 P12에서 다룸

--- a/docs/rfc/RFC-0025-tiered-small-model-cascade.md
+++ b/docs/rfc/RFC-0025-tiered-small-model-cascade.md
@@ -1,0 +1,106 @@
+# RFC-0025: Tiered Small-Model Cascade (4B → 9B → 70B+)
+
+- **Status**: Draft
+- **Author**: vincent (with Claude)
+- **Created**: 2026-05-03
+- **Related**: RFC-0024 (Ollama integration), oas_worker_named_cascade.ml, cascade_fsm.ml, config/cascade.toml
+
+## 1. Problem
+
+현재 cascade는 모든 요청을 동일한 고비용 클라우드 모델로 라우팅. 간단한 분류/요약/리포맷 작업도 70B+ 모델을 사용하여 비용 낭비. Ollama 로컬 모델(RFC-0024)을 활용한 티어드 라우팅이 필요.
+
+## 2. Current Architecture
+
+```
+keeper_turn → [big_three] → codex_cli → gemini_cli → kimi_cli → glm-coding → claude_code
+                                    ↓ timeout/error
+                              [keeper_diverse] → claude_code → gemini_cli → codex_cli
+```
+
+모든 요청이 동일 프로파일을 순차 순회. 태스크 복잡도에 따른 라우팅 없음.
+
+## 3. Proposed Architecture
+
+### 3.1 Task Complexity Detection
+
+```ocaml
+type task_complexity = Simple | Moderate | Complex
+
+let detect_complexity ~messages ~tools ~max_tokens =
+  let ctx_len = List.fold_left (fun acc m -> acc + String.length m.content) 0 messages in
+  match ctx_len, tools, max_tokens with
+  | len, [], mt when len < 2000 && mt <= 1000 -> Simple
+  | len, [], mt when len < 8000 && mt <= 4000 -> Moderate
+  | _ -> Complex
+```
+
+### 3.2 Tier Cascade Profiles
+
+```toml
+[routes]
+simple_task = "tier_small"
+moderate_task = "tier_medium"
+complex_task = "big_three"
+
+[tier_small]
+comment = "4B-class local models for simple tasks. Cost ≈ $0."
+models = [
+  "ollama:llama3.2:3b",
+  "ollama:phi-3-mini",
+]
+temperature = 0.3
+max_tokens = 1000
+fallback_cascade = "tier_medium"
+
+[tier_medium]
+comment = "9B-class models. Cost optimized."
+models = [
+  "ollama:llama3.2:8b",
+  "codex_cli:gpt-5.3-codex-spark",
+]
+temperature = 0.2
+max_tokens = 4096
+fallback_cascade = "big_three"
+
+# big_three stays as-is for complex tasks
+```
+
+### 3.3 Injection Point
+
+`lib/oas_worker_named_cascade.ml`의 `resolve_cascade_providers` 이전에 complexity detection 삽입:
+
+```
+request → detect_complexity → select tier profile → resolve_cascade_providers → FSM execution
+```
+
+## 4. Design Principles
+
+| # | Principle | Rationale |
+|---|-----------|-----------|
+| P1 | **Heuristic first, ML later.** | Context length + tool presence + max_tokens로 초기 분류. 정확도 측정 후 ML 분류기 도입 검토. |
+| P2 | **Always fallback up.** | tier_small 실패 → tier_medium → big_three. 하위 티어 실패 시 상위로. |
+| P3 | **Operator override.** | keeper가 명시적으로 `complex_task` 라우트를 요청하면 감지 스킵. |
+| P4 | **Metrics per tier.** | 각 티어의 성공률, 지연시간, 비용을 개별 추적. |
+
+## 5. Files to Modify
+
+| File | Change | Priority |
+|------|--------|----------|
+| `lib/oas_worker_named_cascade.ml` | Complexity detection + tier routing | High |
+| `config/cascade.toml` | `[tier_small]`, `[tier_medium]` 프로파일 | High |
+| `lib/cascade/cascade_config.ml` | Tier 설정 스키마 | Medium |
+| `lib/oas_worker_named.ml` | Tier metadata 전달 | Medium |
+| `lib/cascade/cascade_inventory.ml` | Tier-aware scoring | Low |
+
+## 6. Validation
+
+1. Unit: `detect_complexity` 분류 정확도 (hand-labeled test set)
+2. Integration: tier 라우팅 end-to-end
+3. Benchmark: 100개 요청에 대해 tier 분포 + 비용 절감 측정
+4. Fallback: small 실패 시 medium → large 자동 escalation
+
+## 7. Scope Exclusions
+
+- ML 기반 task classifier (P4 — 후속 작업)
+- 자동 model download/pull (운영 자동화)
+- Cross-tier context caching (cache tier 분리)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -160,17 +160,21 @@ let cn_claude_api = "claude-api"
 let cn_codex_api = "codex-api"
 let cn_gemini_api = "gemini-api"
 let cn_kimi_api = "kimi-api"
+let cn_kimi_coding = "kimi-coding"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
 let cn_openrouter = "openrouter"
 
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
 
+let kimi_coding_key_envs = [ "KIMI_CODING_API_KEY"; "KIMI_API_KEY_SB" ]
+
 let display_provider_name label =
   match normalize_label label with
   | "glm" | "glm-api" -> cn_glm
   | "glm-coding" | "glm-coding-plan" -> cn_glm_coding_plan
   | "kimi-api" -> cn_kimi
+  | "kimi-coding" | "kimi_coding" -> cn_kimi_coding
   | _ -> String.trim label
 
 (** Default API base URLs — overridable via env var for proxying/testing.
@@ -218,6 +222,11 @@ let moonshot_compat_base_url = "https://api.moonshot.ai/v1"
 
 let kimi_api_url () =
   env_url_or ~env:"KIMI_BASE_URL" ~default:moonshot_compat_base_url
+
+let kimi_coding_base_url = "https://api.kimi.com/coding/v1"
+
+let kimi_coding_api_url () =
+  env_url_or ~env:"KIMI_CODING_BASE_URL" ~default:kimi_coding_base_url
 (** SSOT cascade prefix for local llama-server instances.
     All cascade label construction for local models must use this constant.
     Format: [local_cascade_prefix ^ ":" ^ model_id] → e.g. "llama:qwen3.5" *)
@@ -524,6 +533,27 @@ let direct_adapters =
         {
           default_model_env = Some "KIMI_DEFAULT_MODEL";
           default_model_fallback = Some "kimi-k2.5";
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Kimi_api_family;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
+    };
+    {
+      canonical_name = cn_kimi_coding;
+      runtime_kind = Direct_api;
+      auth_mode = Api_key "KIMI_CODING_API_KEY";
+      aliases = [ cn_kimi_coding; "kimi_coding" ];
+      spawn_key = None;
+      cascade_prefix = "kimi_coding";
+      default_voice = None;
+      endpoint_url = Some (kimi_coding_api_url ());
+      default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "KIMI_CODING_DEFAULT_MODEL";
+          default_model_fallback = Some "kimi-coding-auto";
           auto_models = No_auto_models;
           expand_auto = false;
           family = Kimi_api_family;
@@ -1104,6 +1134,8 @@ let provider_auth_available label =
            env_present env_name
            || (adapter.canonical_name = cn_kimi_api
                && List.exists env_present kimi_api_key_envs)
+           || (adapter.canonical_name = cn_kimi_coding
+               && List.exists env_present kimi_coding_key_envs)
        | Vertex_adc { project_env; _ } -> env_present project_env)
   | None -> false
 
@@ -1114,6 +1146,8 @@ let auth_kind_for_canonical_name name =
   | Some adapter ->
       if adapter.canonical_name = cn_kimi_api then
         "api_key:KIMI_API_KEY_SB|KIMI_API_KEY"
+      else if adapter.canonical_name = cn_kimi_coding then
+        "api_key:KIMI_CODING_API_KEY|KIMI_API_KEY_SB"
       else
         string_of_auth_mode adapter.auth_mode
   | None -> "unknown"


### PR DESCRIPTION
## Summary
- **P9**: Add `kimi-coding` Direct_api provider (api.kimi.com/coding) with dedicated auth key and cascade prefix
- **P12**: Add tiered cascade profiles (`tier_small` → `tier_medium` → `big_three`) for cost-optimized routing
- **P8/P11**: Confirmed already implemented (GLM coding plan, Ollama adapter) — no changes needed
- **P10**: Research-only (tool catalog surface analysis, transport feasibility)

## Changes
| File | Change |
|------|--------|
| `lib/provider_adapter.ml` | +34 lines: kimi-coding adapter entry, URL, auth fallback |
| `config/cascade.toml` | +25 lines: tier_small/tier_medium profiles + routing entries |
| `docs/rfc/RFC-0023-*.md` | P9: Kimi coding API provider RFC |
| `docs/rfc/RFC-0024-*.md` | P11: Ollama cascade integration RFC (documentation only — already implemented) |
| `docs/rfc/RFC-0025-*.md` | P12: Tiered small-model cascade RFC |

## Key design decisions
- `kimi-coding` uses `KIMI_CODING_API_KEY` with `KIMI_API_KEY_SB` fallback — same pattern as `kimi-api`
- `tier_small.models = []` (empty) — safe default since Ollama is local-only; operator uncomments when running
- `fallback_cascade` chain: `tier_small` → `tier_medium` → `big_three` — always fallback up

## Test plan
- [x] `dune build lib/provider_adapter.ml` passes
- [x] TOML syntax validated
- [ ] Cascade routing integration test (kimi-coding model resolution)
- [ ] Tier fallback chain test (tier_small empty → tier_medium → big_three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)