### PR TITLE
fix(dashboard): address world visualizer review

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -12,6 +12,7 @@ MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935
 # VITE_MAX_JOURNAL_ENTRIES=200         # dashboard journal feed (sse.ts)
 # VITE_OAS_AGENT_EVENT_BUFFER=50       # OAS agent event ring (store.ts)
 # VITE_OAS_KEEPER_SNAPSHOT_MAX=20      # keeper snapshot map bound (store.ts)
+# VITE_MASC_YJS_WS_URL=ws://127.0.0.1:8935/yjs
 
 # OAS telemetry replay on page load. 500 is the UI-safe default for an
 # unvirtualised list. If you raise this past ~1000, plan on adding a

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -286,7 +286,7 @@ export function App() {
 
         <main id="main-content" tabindex=${-1} class="min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0">
           <div class="h-full overflow-y-auto p-4">
-            <div style={{ flex: "0 0 auto", borderBottom: "1px solid var(--color-border-default)" }}><${WorldVisualizer} /></div><${DashboardMain} />
+            <div style=${{ flex: '0 0 auto', borderBottom: '1px solid var(--color-border-default)' }}><${WorldVisualizer} /></div><${DashboardMain} />
           </div>
         </main>
       </div>

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -17,36 +17,48 @@ interface Trace {
   position: number
 }
 
-// Global Yjs setup for the telemetry
-const ydoc = new Y.Doc()
-// In production, this would use a dynamic host, but for now we hardcode localhost:1234
-// @ts-ignore
-const wsProvider = new WebsocketProvider('ws://localhost:1234', 'masc-telemetry', ydoc)
-const yKeepers = ydoc.getMap('keepers')
-const yTraces = ydoc.getArray('traces')
+function yjsWebsocketUrl(): string | null {
+  const configured = import.meta.env?.VITE_MASC_YJS_WS_URL
+  if (configured && configured.trim() !== '') return configured
+  if (typeof window === 'undefined' || !window.location?.host) return null
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${window.location.host}/yjs`
+}
 
 export function WorldVisualizer() {
   const [keepers, setKeepers] = useState<KeeperState[]>([])
   const [traces, setTraces] = useState<Trace[]>([])
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const providerRef = useRef<WebsocketProvider | null>(null)
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof WebSocket === 'undefined') return
+    const url = yjsWebsocketUrl()
+    if (!url) return
+
+    const ydoc = new Y.Doc()
+    const provider = new WebsocketProvider(url, 'masc-telemetry', ydoc)
+    const yKeepers = ydoc.getMap<KeeperState>('keepers')
+    const yTraces = ydoc.getArray<Trace>('traces')
+    providerRef.current = provider
+
     const observer = () => {
-      const parsedKeepers = Array.from(yKeepers.values()) as KeeperState[]
-      const parsedTraces = yTraces.toArray() as Trace[]
-      setKeepers(parsedKeepers)
-      setTraces(parsedTraces)
+      setKeepers(Array.from(yKeepers.values()))
+      setTraces(yTraces.toArray())
     }
 
     yKeepers.observe(observer)
     yTraces.observe(observer)
-    
+
     // Initial sync
     observer()
 
     return () => {
       yKeepers.unobserve(observer)
       yTraces.unobserve(observer)
+      if (providerRef.current === provider) providerRef.current = null
+      provider.destroy()
+      ydoc.destroy()
     }
   }, [])
 

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -67,6 +67,7 @@ export default defineConfig(({ command }) => {
             '/mcp': { target: proxyTarget },
             '/sse': { target: proxyTarget },
             '/ws': { target: proxyTarget },
+            '/yjs': { target: proxyTarget, ws: true },
           },
         }
       : undefined,


### PR DESCRIPTION
## Summary
- move WorldVisualizer Yjs provider/doc creation into component lifecycle with cleanup
- replace hardcoded localhost Yjs URL with env/current-origin resolution
- fix HTM style binding and add /yjs dev proxy/env example

## Verification
- pnpm typecheck
- pnpm lint (0 errors; existing warnings only)
- pnpm build
- git diff --check

Follow-up for #12733 review threads.