### PR TITLE
refactor(core): Base Purge Phase 1

### DIFF
--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_economy.mli
+++ b/lib/agent_economy.mli
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_health.ml
+++ b/lib/agent_health.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_health.mli
+++ b/lib/agent_health.mli
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_registry_eio.mli
+++ b/lib/agent_registry_eio.mli
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_reputation.mli
+++ b/lib/agent_reputation.mli
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/agent_tool_surfaces.mli
+++ b/lib/agent_tool_surfaces.mli
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -1,4 +1,3 @@
-open Base
 module Hashtbl = Stdlib.Hashtbl
 module Option = Stdlib.Option
 module Result = Stdlib.Result
@@ -521,7 +520,7 @@ let reclassify_posts store ?(limit = 5200) ?(dry_run = true) () =
     |> List.filteri (fun idx _ -> idx < scan_limit)
     |> List.iter (fun (post_id, _, stored_kind, canonical_kind) ->
            Stdlib.incr scanned;
-           if Option.equal Poly.equal stored_kind (Some canonical_kind) then
+           if Option.equal (=) stored_kind (Some canonical_kind) then
              Stdlib.incr unchanged
            else begin
              Stdlib.incr changed;
@@ -572,7 +571,7 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
     (* Apply filters on the pre-sorted list *)
     let filtered = match visibility_filter with
       | None -> sorted_all
-      | Some v -> List.filter (fun (p : post) -> Poly.equal p.visibility v) sorted_all
+      | Some v -> List.filter (fun (p : post) -> (=) p.visibility v) sorted_all
     in
     let filtered = match hearth with
       | None -> filtered

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Board_core — in-memory board store, persistence, and
     canonical post / comment operations.

--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -149,7 +148,7 @@ let legacy_migrate_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth 
     System_post
   else if (match meta_source meta_json with Some "keeper_board_post" -> true | _ -> false) then
     Automation_post
-  else if Poly.equal visibility Internal && Stdlib.Float.compare expires_at 0.0 > 0 && not (String.equal hearth "")
+  else if (=) visibility Internal && Stdlib.Float.compare expires_at 0.0 > 0 && not (String.equal hearth "")
           && (String.starts_with ~prefix:"mdal" hearth
               || contains_substring hearth "harness")
   then
@@ -204,8 +203,8 @@ let post_classification_reason (p : post) =
 
 let post_matches_filters ~exclude_system ~exclude_automation (p : post) =
   let kind = p.post_kind in
-  (not exclude_system || not (Poly.equal kind System_post))
-  && (not exclude_automation || not (Poly.equal kind Automation_post))
+  (not exclude_system || not ((=) kind System_post))
+  && (not exclude_automation || not ((=) kind Automation_post))
 
 type reclassify_report = {
   backend : string;

--- a/lib/board_core_classify.mli
+++ b/lib/board_core_classify.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Board_core_classify — post visibility / kind converters and
     classification.

--- a/lib/board_core_payload.ml
+++ b/lib/board_core_payload.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/board_core_payload.mli
+++ b/lib/board_core_payload.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Board_core_payload — [STATE] block extraction and post payload
     normalisation for the board store.

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -95,14 +94,14 @@ let start_flusher_actor ~sw store =
           (try Board.flush_dirty store
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn -> Log.BoardLog.error "Flush failed: %s" (Exn.to_string exn))
+           | exn -> Log.BoardLog.error "Flush failed: %s" (Printexc.to_string exn))
       | Board_types.Sweep ->
           (try
              let swept = Board.sweep store in
              ignore swept
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn -> Log.BoardLog.error "Sweep failed: %s" (Exn.to_string exn))
+           | exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
     done
   )
 
@@ -134,7 +133,7 @@ let emit_keeper_board_signal signal =
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
            Log.BoardLog.error "Keeper board signal hook failed: %s"
-             (Exn.to_string exn))
+             (Printexc.to_string exn))
   | None -> ()
 
 let board_sse_hook : (board_sse_event -> unit) option Atomic.t = Atomic.make None
@@ -288,7 +287,7 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_fil
     let posts =
       match visibility_filter with
       | Some visibility ->
-          List.filter (fun (post : Board.post) -> Poly.equal post.visibility visibility) posts
+          List.filter (fun (post : Board.post) -> (=) post.visibility visibility) posts
       | None -> posts
     in
     match hearth with
@@ -304,7 +303,7 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_fil
     |> (match post_kind_filter with
        | Some kind ->
            List.filter
-             (fun (p : Board.post) -> Poly.equal (Board.classify_post_kind p) kind)
+             (fun (p : Board.post) -> (=) (Board.classify_post_kind p) kind)
        | None -> Stdlib.Fun.id)
   in
   match backend () with

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Board_dispatch — single-backend board dispatch + signal hooks.
 

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -150,7 +149,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
               let vote_key = "post:" ^ Post_id.to_string pid ^ ":" ^ voter in
               let now = Time_compat.now () in
               match Hashtbl.find_opt store.vote_log vote_key with
-              | Some (prev, _prev_ts) when Poly.equal prev direction ->
+              | Some (prev, _prev_ts) when (=) prev direction ->
                   Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
                     voter (vote_direction_to_string direction) post_id))
               | Some (_opposite, _prev_ts) ->
@@ -186,7 +185,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
                   invalidate_post_caches store;
                   let author_name = Agent_id.to_string post.author in
                   let earn =
-                    if Poly.equal direction Up then Some author_name else None
+                    if (=) direction Up then Some author_name else None
                   in
                   Ok { delta = updated.votes_up - updated.votes_down;
                        earn_upvote_for = earn;
@@ -231,7 +230,7 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result
             let vote_key = "comment:" ^ Comment_id.to_string cid ^ ":" ^ voter in
             let now = Time_compat.now () in
             match Hashtbl.find_opt store.vote_log vote_key with
-            | Some (prev, _prev_ts) when Poly.equal prev direction ->
+            | Some (prev, _prev_ts) when (=) prev direction ->
                 Error (Already_voted (Printf.sprintf "%s already voted %s on comment %s"
                   voter (vote_direction_to_string direction) comment_id))
             | Some (_opposite, _prev_ts) ->
@@ -420,7 +419,7 @@ let load_persisted_posts store =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
-      Log.BoardLog.error "load posts failed: %s" (Exn.to_string e)
+      Log.BoardLog.error "load posts failed: %s" (Printexc.to_string e)
   end
 
 let load_persisted_comments store =
@@ -453,7 +452,7 @@ let load_persisted_comments store =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
-      Log.BoardLog.error "load comments failed: %s" (Exn.to_string e)
+      Log.BoardLog.error "load comments failed: %s" (Printexc.to_string e)
   end
 
 (** Recalculate reply_count for all posts based on actual comments.
@@ -577,7 +576,7 @@ let load_persisted_votes store =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
-      Log.BoardLog.error "load votes failed: %s" (Exn.to_string e)
+      Log.BoardLog.error "load votes failed: %s" (Printexc.to_string e)
   end
 
 (** {1 Hearth (topic) operations} *)

--- a/lib/coord_assertions.ml
+++ b/lib/coord_assertions.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/coord_assertions.mli
+++ b/lib/coord_assertions.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Coord_assertions — state inspection and assertion-based
     verification.

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -486,7 +485,7 @@ let handle_goal_transition (ctx : context) args =
       let note = get_string_opt args "note" in
       let override_note = get_string_opt args "override_note" in
       if actor_must_be_operator action
-         && not (Poly.equal actor.Goal_verification.kind Goal_verification.Operator)
+         && not ((=) actor.Goal_verification.kind Goal_verification.Operator)
       then
         error_result_typed ~code:Validation_error
           "actor.kind must be operator for this transition"
@@ -496,7 +495,7 @@ let handle_goal_transition (ctx : context) args =
         | Some goal ->
             begin
               match
-                if Poly.equal action Goal_phase.Request_complete then
+                if (=) action Goal_phase.Request_complete then
                   validate_goal_completion_ready ctx.config ~goal_id
                     ~override_note
                 else
@@ -636,7 +635,7 @@ let handle_goal_transition (ctx : context) args =
                       (match goal.active_verification_request_id, next_phase with
                        | Some request_id, Goal_phase.Dropped
                        | Some request_id, Goal_phase.Executing
-                         when Poly.equal goal.phase Goal_phase.Awaiting_verification ->
+                         when (=) goal.phase Goal_phase.Awaiting_verification ->
                            (match Goal_verification.cancel_request ctx.config ~request_id with
                             | Ok _ ->
                                 emit_goal_event ctx ~goal_id
@@ -656,7 +655,7 @@ let handle_goal_transition (ctx : context) args =
                       match
                         update_goal_phase ctx goal ~phase:next_phase ?note
                           ~clear_active_verification_request:
-                            (not (Poly.equal next_phase Goal_phase.Awaiting_verification))
+                            (not ((=) next_phase Goal_phase.Awaiting_verification))
                           ()
                       with
                       | Error msg -> error_result_typed ~code:Internal_error msg
@@ -668,8 +667,8 @@ let handle_goal_transition (ctx : context) args =
                                   ("phase", Goal_phase.to_yojson updated_goal.phase);
                                   ("actor", Goal_verification.goal_principal_to_yojson actor);
                                 ]);
-                          if Poly.equal action Goal_phase.Approve_completion
-                             || Poly.equal action Goal_phase.Reject_completion then
+                          if (=) action Goal_phase.Approve_completion
+                             || (=) action Goal_phase.Reject_completion then
                             emit_goal_event ctx ~goal_id
                               ~event_type:"goal_approval_resolved"
                               ~payload:
@@ -677,7 +676,7 @@ let handle_goal_transition (ctx : context) args =
                                   [
                                     ( "decision",
                                       `String
-                                        (if Poly.equal action Goal_phase.Approve_completion then
+                                        (if (=) action Goal_phase.Approve_completion then
                                            "approve"
                                          else
                                            "reject") );
@@ -797,7 +796,7 @@ let handle_goal_verify (ctx : context) args =
                               verification_summary_json ~latest_request:request
                                 updated_goal
                                 effective_policy
-                                (if Poly.equal updated_goal.phase Goal_phase.Awaiting_verification then
+                                (if (=) updated_goal.phase Goal_phase.Awaiting_verification then
                                    Some request
                                  else
                                    None) );

--- a/lib/coord_goals.mli
+++ b/lib/coord_goals.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Coord_goals — Goal-management MCP tool handlers.
 

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/coord_status_rendering.mli
+++ b/lib/coord_status_rendering.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Coord_status_rendering — rendering logic for [masc_status].
 

--- a/lib/coord_types.ml
+++ b/lib/coord_types.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/coord_types.mli
+++ b/lib/coord_types.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Coord_types — Shared types for coordination modules.
 

--- a/lib/core/list_util.ml
+++ b/lib/core/list_util.ml
@@ -7,7 +7,6 @@
     landed; centralising avoids re-defining the helper per file and
     makes the intent searchable. *)
 
-open Base
 
 let count_if pred xs =
-  List.fold xs ~init:0 ~f:(fun n x -> if pred x then n + 1 else n)
+  Base.List.fold xs ~init:0 ~f:(fun n x -> if pred x then n + 1 else n)

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -141,7 +140,7 @@ let split_tasks (tasks : Types.task list) =
       | Types.Todo | Types.Done _ | Types.Cancelled _ -> false
     ) tasks
   in
-  let pending = List.filter (fun task -> Poly.equal task.Types.task_status Types.Todo) tasks in
+  let pending = List.filter (fun task -> (=) task.Types.task_status Types.Todo) tasks in
   (active, pending)
 
 let task_lines (tasks : Types.task list) =
@@ -381,25 +380,25 @@ let agents_grouped_section now (agents : Types.agent list) : section =
   let working =
     List.filter
       (fun a ->
-        Poly.equal (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Working)
+        (=) (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Working)
       agents
   in
   let stuck =
     List.filter
       (fun a ->
-        Poly.equal (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Stuck)
+        (=) (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Stuck)
       agents
   in
   let idle =
     List.filter
       (fun a ->
-        Poly.equal (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Idle)
+        (=) (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Idle)
       agents
   in
   let offline =
     List.filter
       (fun a ->
-        Poly.equal (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Offline)
+        (=) (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Offline)
       agents
   in
   let content =
@@ -533,19 +532,19 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
   let working_count =
     List.length
       (List.filter
-         (fun a -> Poly.equal (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Working)
+         (fun a -> (=) (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Working)
          all_agents)
   in
   let stuck_count =
     List.length
       (List.filter
-         (fun a -> Poly.equal (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Stuck)
+         (fun a -> (=) (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Stuck)
          all_agents)
   in
   let idle_count =
     List.length
       (List.filter
-         (fun a -> Poly.equal (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Idle)
+         (fun a -> (=) (Dashboard_labels.classify_agent ~now a) Dashboard_labels.Idle)
          all_agents)
   in
   let offline_count =
@@ -555,7 +554,7 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
   let keeper_entries = Keeper_registry.all () in
   let keeper_by_phase phase =
     List_util.count_if
-      (fun (e : Keeper_registry.registry_entry) -> Poly.equal e.phase phase)
+      (fun (e : Keeper_registry.registry_entry) -> (=) e.phase phase)
       keeper_entries
   in
   let k_running = keeper_by_phase Running in

--- a/lib/dashboard.mli
+++ b/lib/dashboard.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** MASC Dashboard — operator-first status visualization.
 

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Dashboard projection for cascade configuration and runtime health.
 

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -270,7 +269,7 @@ let provider_snapshots () : provider_snapshot list =
   let managed =
     Provider_adapter.direct_adapters
     |> List.filter (fun (a : Provider_adapter.adapter) ->
-         not (Poly.equal a.runtime_kind Provider_adapter.Local)
+         not ((=) a.runtime_kind Provider_adapter.Local)
          && Option.is_some a.default_model_id)
     |> List.map provider_snapshot_of_adapter
   in

--- a/lib/dashboard_provider_runs.mli
+++ b/lib/dashboard_provider_runs.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Dashboard_provider_runs — Single-agent provider runs for the
     operator dashboard.

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/dashboard_tla_specs.mli
+++ b/lib/dashboard_tla_specs.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Dashboard projection for TLA+ specs.
 

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/dashboard_tool_host_events.mli
+++ b/lib/dashboard_tool_host_events.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Dashboard_tool_host_events — typed surface for the
     `client_tool_host_failure` HTTP report and the matching

--- a/lib/dashboard_tool_source_freshness.ml
+++ b/lib/dashboard_tool_source_freshness.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/dashboard_tool_source_freshness.mli
+++ b/lib/dashboard_tool_source_freshness.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Dashboard_tool_source_freshness — source-freshness metadata
     helpers for the dashboard tool-quality panel.

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -17,8 +17,8 @@ let string_contains ~needle haystack =
 
 let string_contains_ci ~needle haystack =
   Base.String.is_substring
-    (Base.String.lowercase haystack)
-    ~substring:(Base.String.lowercase needle)
+    (String.lowercase_ascii haystack)
+    ~substring:(String.lowercase_ascii needle)
 
 let trim_to_option text =
   let trimmed = String.trim text in

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1,4 +1,3 @@
-open Base
 (** Filesystem Compatibility Layer - Eio-native I/O with fallback
 
     Provides a unified filesystem API for gradual migration from
@@ -43,7 +42,7 @@ let has_fs () =
 let with_io ~path f =
   try f ()
   with Eio.Io _ as e ->
-    raise (Sys_error (Printf.sprintf "%s: %s" path (Exn.to_string e)))
+    raise (Sys_error (Printf.sprintf "%s: %s" path (Printexc.to_string e)))
 
 (* #9921: defense-in-depth write-boundary guard.
 
@@ -67,43 +66,46 @@ exception Test_isolation_breach of string
 
 let test_exec_home_guard ~op path =
   let basename =
-    Stdlib.Sys.executable_name |> Stdlib.Filename.basename |> String.lowercase
+    Stdlib.Sys.executable_name |> Stdlib.Filename.basename |> String.lowercase_ascii
   in
   let is_test_exec =
-    String.length basename >= 5 && String.is_prefix basename ~prefix:"test_"
+    String.length basename >= 5 && Base.String.is_prefix basename ~prefix:"test_"
   in
   if not is_test_exec then ()
   else
     let allow =
-      match Sys.getenv "MASC_TEST_ALLOW_HOME_BASE_PATH" with
+      match Sys.getenv_opt "MASC_TEST_ALLOW_HOME_BASE_PATH" with
       | Some v ->
-          let v = String.lowercase (String.strip v) in
+          let v = String.lowercase_ascii (String.trim v) in
           String.equal v "1" || String.equal v "true" || String.equal v "yes"
       | None -> false
     in
     if allow then ()
     else
-      match Sys.getenv "HOME" with
+      match Sys.getenv_opt "HOME" with
       | None | Some "" -> ()
       | Some home ->
           let home_norm =
-            let trimmed = String.strip home in
+            let trimmed = String.trim home in
             let len = String.length trimmed in
             if len > 1 && Char.equal trimmed.[len - 1] '/' then
-              String.sub trimmed ~pos:0 ~len:(len - 1)
+              String.sub trimmed 0 (len - 1)
             else
               trimmed
           in
           let home_len = String.length home_norm in
           if home_len > 0
              && String.length path >= home_len
-             && String.is_prefix path ~prefix:home_norm then            raise (Test_isolation_breach
-              (Printf.sprintf
-                 "#9921 %s blocked under HOME=%S (path=%S) in test executable %S. \
-                  MASC_BASE_PATH override did not apply — fix the test setup or \
-                  set MASC_TEST_ALLOW_HOME_BASE_PATH=1."
-                 op home_norm path
-                 (Stdlib.Filename.basename Stdlib.Sys.executable_name)))
+             && Base.String.is_prefix path ~prefix:home_norm
+          then
+            raise
+              (Test_isolation_breach
+                 (Printf.sprintf
+                    "#9921 %s blocked under HOME=%S (path=%S) in test executable %S. \
+                     MASC_BASE_PATH override did not apply — fix the test setup or \
+                     set MASC_TEST_ALLOW_HOME_BASE_PATH=1."
+                    op home_norm path
+                    (Stdlib.Filename.basename Stdlib.Sys.executable_name)))
 
 let with_fs_or_fallback ~path ~fallback f =
   match Atomic.get global_fs with
@@ -166,7 +168,7 @@ let save_file (path : string) (content : string) : unit =
 let fsync_path path =
   let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
   Stdlib.Fun.protect
-    ~finally:(fun () -> try Unix.close fd with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Stdlib.Printf.eprintf "[fs_compat] fsync_path close failed: %s\n%!" (Exn.to_string exn))
+    ~finally:(fun () -> try Unix.close fd with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Stdlib.Printf.eprintf "[fs_compat] fsync_path close failed: %s\n%!" (Printexc.to_string exn))
     (fun () ->
       try Unix.fsync fd
       with Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
@@ -200,7 +202,7 @@ let save_file_atomic (path : string) (content : string) : (unit, string) Result.
     raise e
   | exn ->
     (try Stdlib.Sys.remove tmp with Sys_error _ -> ());
-    Error (Printf.sprintf "save_file_atomic %s: %s" path (Exn.to_string exn))
+    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
 
 (* #10130: orphaned [.atomic_*.tmp] files from [save_file_atomic]
    that accumulated because the owning process was SIGKILL'd or
@@ -226,8 +228,8 @@ let is_atomic_orphan_name name =
   let p = String.length atomic_tmp_prefix in
   let s = String.length atomic_tmp_suffix in
   n >= p + s
-  && String.is_prefix name ~prefix:atomic_tmp_prefix
-  && String.is_suffix name ~suffix:atomic_tmp_suffix
+  && Base.String.is_prefix name ~prefix:atomic_tmp_prefix
+  && Base.String.is_suffix name ~suffix:atomic_tmp_suffix
 
 let cleanup_atomic_orphans
     ~(base_path : string)
@@ -250,7 +252,7 @@ let cleanup_atomic_orphans
     match Unix.stat path with
     | exception Unix.Unix_error _ -> ()
     | stat when stat.Unix.st_size = 0 ->
-        (try Stdlib.Sys.remove path; Int.incr deleted
+        (try Stdlib.Sys.remove path; incr deleted
          with Sys_error _ -> ())
     | _stat ->
         ensure_recovered_dir ();
@@ -258,11 +260,11 @@ let cleanup_atomic_orphans
           Stdlib.Filename.concat recovered_dir
             (Printf.sprintf "%s.%.0f" name (Unix.gettimeofday () *. 1000.0))
         in
-        (try Stdlib.Sys.rename path target; Int.incr preserved
+        (try Stdlib.Sys.rename path target; incr preserved
          with Sys_error _ | Unix.Unix_error _ -> ())
   in
   let scan_dir dir entries =
-    Array.iter entries ~f:(fun name -> if is_atomic_orphan_name name then handle_file dir name)
+    Array.iter (fun name -> if is_atomic_orphan_name name then handle_file dir name) entries
   in
   let read_dir_entries dir =
     match Stdlib.Sys.readdir dir with
@@ -275,14 +277,14 @@ let cleanup_atomic_orphans
      the cached entry array. *)
   let entries = read_dir_entries base_path in
   scan_dir base_path entries;
-  Array.iter entries ~f:(fun name -> if String.equal name recovered_subdir then ()
+  Array.iter (fun name -> if String.equal name recovered_subdir then ()
       else
         let sub = Stdlib.Filename.concat base_path name in
         match Unix.stat sub with
         | exception Unix.Unix_error _ -> ()
-        | stat when Poly.equal stat.Unix.st_kind Unix.S_DIR ->
+        | stat when (=) stat.Unix.st_kind Unix.S_DIR ->
             scan_dir sub (read_dir_entries sub)
-        | _ -> ());
+        | _ -> ()) entries;
   (!deleted, !preserved)
 
 (** Append string to file.
@@ -346,17 +348,17 @@ let parse_jsonl_lines ~(source : string) (lines : string list)
     : Yojson.Safe.t list * int =
   let malformed = ref 0 in
   let parsed =
-    List.filter_map lines ~f:(fun line ->
-      let trimmed = String.strip line in
+    List.filter_map (fun line ->
+      let trimmed = String.trim line in
       if String.equal trimmed "" then None
       else
         match Yojson.Safe.from_string trimmed with
         | json -> Some json
         | exception Yojson.Json_error msg ->
-            Int.incr malformed;
+            incr malformed;
             Stdlib.Printf.eprintf "[fs_compat] malformed JSONL (%s): %s\n%!" source msg;
             None
-    )
+    ) lines
   in
   (parsed, !malformed)
 
@@ -366,7 +368,7 @@ let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
   if not (file_exists path) then ([], 0)
   else
     let content = load_file path in
-    let lines = String.split content ~on:'\n' in
+    let lines = String.split_on_char '\n' content in
     parse_jsonl_lines ~source:(Stdlib.Filename.basename path) lines
 
 (** Load JSONL file as list of JSON values.

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -1,4 +1,3 @@
-open Base
 (** Filesystem Compatibility Layer - Eio-native I/O with fallback
 
     @since 2026-02 - Keeper Emergent Identity v2.0

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -27,9 +27,10 @@ let tool_requirement_to_string = function
   | No_tools -> "none"
 
 let tool_requirement_of_string = function
-  | "required" -> Required
-  | "optional" -> Optional
-  | _ -> No_tools
+  | "required" -> Some Required
+  | "optional" -> Some Optional
+  | "none" -> Some No_tools
+  | _ -> None
 
 let tool_requirement_to_yojson = function
   | Required -> `String "required"

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -20,7 +20,7 @@ type tool_requirement =
   | No_tools
 
 val tool_requirement_to_string : tool_requirement -> string
-val tool_requirement_of_string : string -> tool_requirement
+val tool_requirement_of_string : string -> tool_requirement option
 val tool_requirement_to_yojson : tool_requirement -> Yojson.Safe.t
 
 (** Diagnostic surface metrics emitted into trajectory entries. *)

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/metrics_store_eio.mli
+++ b/lib/metrics_store_eio.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Metrics_store_eio — agent performance metrics with async batched
     file I/O.

--- a/lib/time_compat/time_compat.ml
+++ b/lib/time_compat/time_compat.ml
@@ -1,4 +1,3 @@
-open Base
 (** Time Compatibility Layer - re-exported from mcp-protocol-sdk.
 
     All existing [Time_compat.now ()], [Time_compat.sleep], etc.

--- a/lib/time_compat/time_compat.mli
+++ b/lib/time_compat/time_compat.mli
@@ -1,4 +1,3 @@
-open Base
 (** Time compatibility layer — transparent re-export of
     {!Mcp_protocol_eio.Time_compat}.
 

--- a/lib/tool_access_policy.ml
+++ b/lib/tool_access_policy.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_access_policy.mli
+++ b/lib/tool_access_policy.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_access_policy — shared allow/deny selector ADT for runtime tool policies.
 

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -59,7 +58,7 @@ let tools_for_required_role required_role =
          match Tool_permission_map.permission_for_tool tool_name with
          | None -> false
          | Some permission ->
-             Poly.equal (required_role_of_permission permission) required_role)
+             (=) (required_role_of_permission permission) required_role)
 
 (* ================================================================ *)
 (* Admin-only tools (CanInit + CanReset + CanAdmin)                 *)

--- a/lib/tool_access_role.mli
+++ b/lib/tool_access_role.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_access_role — Role-based tool access policy builder.
 

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_agent - Agent management, metrics, and capability discovery handlers *)
 

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_agent_timeline.mli
+++ b/lib/tool_agent_timeline.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_agent_timeline — Per-agent activity timeline + summary.
 

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_args.mli
+++ b/lib/tool_args.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_args — tool-convention argument extraction wrappers over
     {!Safe_ops} plus canonical error/OK response helpers.

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -1,4 +1,3 @@
-open Base
 module Random = Stdlib.Random
 module Format = Stdlib.Format
 module Map = Stdlib.Map

--- a/lib/tool_assignment_telemetry.mli
+++ b/lib/tool_assignment_telemetry.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_assignment_telemetry — Unified tool assignment lifecycle events
 

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -408,7 +407,7 @@ let handle_inject (ctx : context) args =
         match Hashtbl.find_opt active_loops id with
         | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
         | Some state ->
-          if not (Poly.equal state.status Autoresearch.Running) then
+          if not ((=) state.status Autoresearch.Running) then
             `Assoc [("error", `String "Loop is not running")]
           else begin
             let state = { state with queued_hypothesis = Some hypothesis } in

--- a/lib/tool_autoresearch.mli
+++ b/lib/tool_autoresearch.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_autoresearch — public surface for the autoresearch
     MCP tool family.

--- a/lib/tool_autoresearch_broadcast.ml
+++ b/lib/tool_autoresearch_broadcast.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_autoresearch_broadcast.mli
+++ b/lib/tool_autoresearch_broadcast.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_autoresearch_broadcast — SSE broadcast for autoresearch
     loop events.

--- a/lib/tool_autoresearch_context.ml
+++ b/lib/tool_autoresearch_context.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_autoresearch_context.mli
+++ b/lib/tool_autoresearch_context.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_autoresearch_context — shared environment record passed
     into autoresearch tool handlers.

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -285,7 +284,7 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
           match Hashtbl.find_opt active_loops id with
           | None -> Error (Printf.sprintf "Loop %s not found" id)
           | Some state ->
-            if not (Poly.equal state.status Autoresearch.Running) then
+            if not ((=) state.status Autoresearch.Running) then
               Error "Loop is not running"
             else if not (Autoresearch.should_continue state) then begin
               let reason =

--- a/lib/tool_autoresearch_cycle.mli
+++ b/lib/tool_autoresearch_cycle.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_autoresearch_cycle — Core ratchet logic for the
     [masc_autoresearch_cycle] tool.

--- a/lib/tool_autoresearch_registry.ml
+++ b/lib/tool_autoresearch_registry.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_autoresearch_registry.mli
+++ b/lib/tool_autoresearch_registry.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_autoresearch_registry — loop registry, pending hypothesis
     queue, and per-loop code-generator override state for the

--- a/lib/tool_autoresearch_schemas.ml
+++ b/lib/tool_autoresearch_schemas.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_autoresearch_schemas.mli
+++ b/lib/tool_autoresearch_schemas.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_autoresearch_schemas — Autoresearch + swarm-facing synthesis
     schema definitions.

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -660,7 +659,7 @@ let handle_vote args =
 
   match Board_dispatch.vote ~voter ~post_id ~direction with
   | Ok new_score ->
-      let arrow = if Poly.equal direction Board.Up then "↑" else "↓" in
+      let arrow = if (=) direction Board.Up then "↑" else "↓" in
       (* SOUL Evolution via callback (breaks compile-time dependency cycle) *)
       let evolution_msg =
         match Atomic.get evolution_hook with
@@ -675,7 +674,7 @@ let handle_vote args =
                     | Some pv -> pv
                     | None -> "Creativity"
                   in
-                  let is_positive = (Poly.equal direction Board.Up) in
+                  let is_positive = ((=) direction Board.Up) in
                   cb.record_feedback ~name:author ~dimension ~is_positive;
                   Printf.sprintf " [🧬 %s evolved: %s %s]"
                     author dimension (if is_positive then "+0.01" else "-0.01")
@@ -691,7 +690,7 @@ let handle_vote args =
       (match Board_dispatch.get_post ~post_id with
        | Ok post ->
            let score = post.votes_up - post.votes_down in
-           let arrow = if Poly.equal direction Board.Up then "↑" else "↓" in
+           let arrow = if (=) direction Board.Up then "↑" else "↓" in
            (true, Printf.sprintf "%s Already voted (idempotent). Score: %+d" arrow score)
        | Error _ ->
            (true, "Already voted (idempotent). Score unchanged."))

--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_board — MCP tool family for the internal board.
 

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** OAS boundary adapter for tool results, schemas, and tool definitions.
 

--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_broadcast_typed.mli
+++ b/lib/tool_broadcast_typed.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Typed broadcast tool — Phase 1 PoC for compile-time tool safety.
     Schema and parse derived from {!Agent_sdk.Tool_schema_gen} combinators.

--- a/lib/tool_call_quality_benchmark.ml
+++ b/lib/tool_call_quality_benchmark.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_call_quality_benchmark.mli
+++ b/lib/tool_call_quality_benchmark.mli
@@ -1,4 +1,3 @@
-open Base
 
 include module type of Tool_call_quality_benchmark_types
 

--- a/lib/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark_loader.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_call_quality_benchmark_loader.mli
+++ b/lib/tool_call_quality_benchmark_loader.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_call_quality_benchmark_loader — JSON loaders for the
     benchmark case set and the evidence-runs file.

--- a/lib/tool_call_quality_benchmark_render.ml
+++ b/lib/tool_call_quality_benchmark_render.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_call_quality_benchmark_render.mli
+++ b/lib/tool_call_quality_benchmark_render.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_call_quality_benchmark_render — JSON / CSV rendering for the
     tool-call quality benchmark.

--- a/lib/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark_scoring.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -69,12 +68,12 @@ let evaluate_json_check ~(target : Yojson.Safe.t option) (check : json_check) =
     match check.present with
     | None -> true
     | Some true -> (match actual with Some `Null | None -> false | Some _ -> true)
-    | Some false -> (match actual with Some value when not (Poly.equal value `Null) -> false | _ -> true)
+    | Some false -> (match actual with Some value when not ((=) value `Null) -> false | _ -> true)
   in
   let equals_ok =
     match check.equals with
     | None -> true
-    | Some expected -> Option.equal Poly.equal actual (Some expected)
+    | Some expected -> Option.equal (=) actual (Some expected)
   in
   let contains_ok =
     match check.contains with
@@ -206,7 +205,7 @@ let efficiency_score (benchmark_case : benchmark_case) (run : evidence_run) =
           (1.0 -. (Stdlib.Float.of_int over_limit /. Stdlib.Float.of_int benchmark_case.max_tool_calls))
 
 let score_run ~cases (run : evidence_run) =
-  if not (Poly.equal run.status Run_ok) then None
+  if not ((=) run.status Run_ok) then None
   else
     let cases_by_id =
       cases

--- a/lib/tool_call_quality_benchmark_scoring.mli
+++ b/lib/tool_call_quality_benchmark_scoring.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_call_quality_benchmark_scoring — score a single
     {!Tool_call_quality_benchmark_types.evidence_run} against

--- a/lib/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark_summary.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -135,7 +134,7 @@ let repeated_metrics_for_view view runs =
   let grouped = Hashtbl.create 16 in
   List.iter
     (fun run ->
-      if Poly.equal run.status Run_ok then
+      if (=) run.status Run_ok then
         let (provider, model, keeper_profile) = summary_key_of_run view run in
         let key = (provider, model, keeper_profile, run.case_id) in
         let current = Hashtbl.find_opt grouped key |> Option.value ~default:[] in
@@ -218,17 +217,17 @@ let build_summary_rows view runs scores =
         runs
         |> List.filter (fun run ->
                let run_key = summary_key_of_run view run in
-               Poly.equal run_key key)
+               (=) run_key key)
       in
       let grouped_scores_by_case = group_scores_by_case grouped_scores in
       let unsupported_runs =
         grouped_runs
-        |> List.filter (fun run -> Poly.equal run.status Run_unsupported)
+        |> List.filter (fun run -> (=) run.status Run_unsupported)
         |> List.length
       in
       let runtime_unreachable_runs =
         grouped_runs
-        |> List.filter (fun run -> Poly.equal run.status Run_runtime_unreachable)
+        |> List.filter (fun run -> (=) run.status Run_runtime_unreachable)
         |> List.length
       in
       let stability_score, tool_sequence_consistency_rate,
@@ -318,17 +317,17 @@ let summarize ~cases ~runs ?model_filters ?keeper_filters () =
     |> List.filter_map (Tool_call_quality_benchmark_scoring.score_run ~cases)
   in
   let unsupported_runs =
-    filtered_runs |> List.filter (fun run -> Poly.equal run.status Run_unsupported) |> List.length
+    filtered_runs |> List.filter (fun run -> (=) run.status Run_unsupported) |> List.length
   in
   let runtime_unreachable_runs =
     filtered_runs
-    |> List.filter (fun run -> Poly.equal run.status Run_runtime_unreachable)
+    |> List.filter (fun run -> (=) run.status Run_runtime_unreachable)
     |> List.length
   in
   let unknown_case_runs =
     filtered_runs
     |> List.filter (fun run ->
-           Poly.equal run.status Run_ok
+           (=) run.status Run_ok
            && not (List.exists (fun case -> String.equal case.id run.case_id) cases))
     |> List.length
   in

--- a/lib/tool_call_quality_benchmark_summary.mli
+++ b/lib/tool_call_quality_benchmark_summary.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_call_quality_benchmark_summary — aggregate evidence runs
     + case scores into a {!benchmark_summary}.

--- a/lib/tool_call_quality_benchmark_types.ml
+++ b/lib/tool_call_quality_benchmark_types.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_call_quality_benchmark_types.mli
+++ b/lib/tool_call_quality_benchmark_types.mli
@@ -1,4 +1,3 @@
-open Base
 
 type case_category =
   | Tool_required

--- a/lib/tool_call_replay_harness.ml
+++ b/lib/tool_call_replay_harness.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_call_replay_harness.mli
+++ b/lib/tool_call_replay_harness.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_call_replay_harness — JSONL snapshot loader + validation
     for tool-call replay scoring.

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -855,7 +854,7 @@ let lifecycle_to_string = function
 (** Precomputed list of deprecated tools from explicit_metadata.
     Static — computed once at module init. *)
 let deprecated_tool_entries : (string * metadata) list =
-  List.filter (fun (_name, meta) -> Poly.equal meta.lifecycle Deprecated) explicit_metadata
+  List.filter (fun (_name, meta) -> (=) meta.lifecycle Deprecated) explicit_metadata
 
 (* ================================================================ *)
 (* JSON metadata helpers                                            *)

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_catalog — Visibility and lifecycle metadata for MCP tools.
 

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_catalog_surfaces.mli
+++ b/lib/tool_catalog_surfaces.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_catalog_surfaces — SSOT for tool-name surface membership.
 

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_code.mli
+++ b/lib/tool_code.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_code — Code navigation MCP tools (search, symbols, read).
 

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_code_write.mli
+++ b/lib/tool_code_write.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_code_write — File write / edit / delete / shell / git
     MCP tools for keeper agents.

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_control.mli
+++ b/lib/tool_control.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_control — Flow control operations (pause / pause_status /
     resume).

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_coord.mli
+++ b/lib/tool_coord.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_coord — Coord management MCP tools (status / reset /
     init / workflow_guide / check / assertion).

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_deep_review.mli
+++ b/lib/tool_deep_review.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_deep_review — Adversarial code review with isolated context.
 

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Central Tool Dispatch Registry.
 

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_help_registry.mli
+++ b/lib/tool_help_registry.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_help_registry — derived per-tool help entries.
 

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_inline_dispatch.mli
+++ b/lib/tool_inline_dispatch.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_inline_dispatch — thin dispatch router for inline tool handlers.
 

--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_inline_dispatch_comm.mli
+++ b/lib/tool_inline_dispatch_comm.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_inline_dispatch_comm — communication tool handlers.
 

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_inline_dispatch_coord.mli
+++ b/lib/tool_inline_dispatch_coord.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_inline_dispatch_coord — room lifecycle tool handlers.
 

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_inline_dispatch_extra.mli
+++ b/lib/tool_inline_dispatch_extra.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_inline_dispatch_extra — fallback inline-tool dispatch
     branch (board / mention handlers extracted from

--- a/lib/tool_inline_dispatch_types.ml
+++ b/lib/tool_inline_dispatch_types.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_inline_dispatch_types.mli
+++ b/lib/tool_inline_dispatch_types.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_inline_dispatch_types — shared types for inline dispatch modules.
 

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_input_validation — Pre-dispatch validation via OAS Tool_middleware.
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -1425,7 +1424,7 @@ let handle_keeper_clear ctx args : tool_result =
               (* Keep only system-role messages *)
               List.filter
                 (fun (m : Agent_sdk.Types.message) ->
-                   Poly.equal m.role Llm_provider.Types.System)
+                   (=) m.role Llm_provider.Types.System)
                 existing_messages
             else
               []

--- a/lib/tool_keeper.mli
+++ b/lib/tool_keeper.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Public facade for keeper MCP tools. *)
 

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_library — Agent knowledge-library MCP tools.
 

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_local_runtime.mli
+++ b/lib/tool_local_runtime.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_local_runtime — local model runtime management and
     benchmarking tools.

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_local_runtime_bench.mli
+++ b/lib/tool_local_runtime_bench.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_local_runtime_bench — concurrency benchmark against the
     local runtime pool.

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_local_runtime_core.mli
+++ b/lib/tool_local_runtime_core.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_local_runtime_core — types, helpers, process discovery,
     and OpenAI-compatible model fetching for local llama-server

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_local_runtime_http.mli
+++ b/lib/tool_local_runtime_http.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_local_runtime_http — curl-shelled HTTP helpers for local
     runtime probing.

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_local_runtime_probe.mli
+++ b/lib/tool_local_runtime_probe.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_local_runtime_probe — Native Ollama timing and warm-state
     diagnostics.

--- a/lib/tool_local_runtime_status.ml
+++ b/lib/tool_local_runtime_status.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_local_runtime_status.mli
+++ b/lib/tool_local_runtime_status.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_local_runtime_status — Runtime pool status reporting.
 

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_local_runtime_verify.mli
+++ b/lib/tool_local_runtime_verify.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_local_runtime_verify — Runtime contract verification for
     local LLM runtime pools (llama.cpp / Ollama).

--- a/lib/tool_metrics.ml
+++ b/lib/tool_metrics.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_metrics.mli
+++ b/lib/tool_metrics.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Per-tool timing metrics
 

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_metrics_persist.mli
+++ b/lib/tool_metrics_persist.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_metrics_persist — JSONL disk persistence for tool metrics.
 

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_misc — miscellaneous MASC tool handlers.
 

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -88,7 +87,7 @@ let auth_snapshot_json ctx =
            `Assoc
              [
                ("agent_name", `String cred.agent_name);
-               ("admin", `Bool (Poly.equal cred.role Types.Admin));
+               ("admin", `Bool ((=) cred.role Types.Admin));
                ("created_at", `String cred.created_at);
                ("expires_at", json_string_option cred.expires_at);
              ])
@@ -290,7 +289,7 @@ let handle_tool_admin_update ctx args =
   match section with
   | "auth" ->
       let current = Auth.load_auth_config ctx.config.base_path in
-      if not (Poly.equal (U.member "default_role" args) `Null) then
+      if not ((=) (U.member "default_role" args) `Null) then
         (false, "❌ default_role is no longer supported")
       else
       let require_token =

--- a/lib/tool_misc_admin.mli
+++ b/lib/tool_misc_admin.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_misc_admin — auth, config, tool inventory, and feature
     flag handlers.

--- a/lib/tool_misc_transport.ml
+++ b/lib/tool_misc_transport.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_misc_transport.mli
+++ b/lib/tool_misc_transport.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_misc_transport — Transport, WebSocket, and WebRTC tool
     handlers.

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_misc_web_search — Web search MCP tool with multi-provider
     fallback chain.

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Compile-time verified tool name identifiers.
 

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_operator — MCP tools for operator control plane
     (snapshot / digest / action / confirm / judgment / surface

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_output_validation.mli
+++ b/lib/tool_output_validation.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_output_validation — Memory-protection cap.
 

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_permission_map.mli
+++ b/lib/tool_permission_map.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_permission_map — Shared tool→permission resolution.
 

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Plan Tool Handlers
 

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_prefilter.mli
+++ b/lib/tool_prefilter.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_prefilter — TF-IDF cosine similarity for tool relevance scoring.
 

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_registration_check.mli
+++ b/lib/tool_registration_check.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_registration_check — Startup validation of Tool_spec vs TOML coverage. *)
 

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_registry.mli
+++ b/lib/tool_registry.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_registry — in-memory call counters and usage statistics.
 

--- a/lib/tool_result.ml
+++ b/lib/tool_result.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_result.mli
+++ b/lib/tool_result.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Structured tool result type for MASC
 

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Run Tool Handlers
 

--- a/lib/tool_schema_dsl.ml
+++ b/lib/tool_schema_dsl.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_schema_dsl.mli
+++ b/lib/tool_schema_dsl.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Shared JSON Schema builder helpers for MCP tool definitions. *)
 

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_shard — Dynamic tool sharding for MASC agents.
 

--- a/lib/tool_shard_limits.ml
+++ b/lib/tool_shard_limits.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_shard_limits.mli
+++ b/lib/tool_shard_limits.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_shard_limits — SSOT integer constants shared between
     [Tool_shard] (the MCP tool surface) and [Keeper_exec_fs]

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -128,7 +127,7 @@ let register (spec : t) =
     Tool_catalog_surfaces.is_on_surface System_internal spec.name
   in
   let effective_visibility =
-    if is_system_internal && Poly.equal spec.visibility Tool_catalog.Default
+    if is_system_internal && spec.visibility = Tool_catalog.Default
     then Tool_catalog.Hidden
     else spec.visibility
   in

--- a/lib/tool_spec.mli
+++ b/lib/tool_spec.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_spec — Unified tool specification with compile-time safety.
 

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_suspend.mli
+++ b/lib/tool_suspend.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_suspend — agent suspension and circuit-breaker tools.
 

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set
@@ -552,7 +551,7 @@ let handle_batch_add_tasks ctx args =
 let handle_claim ?agent_tool_names ctx args =
   if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
     result_to_response (Error (Types.AgentNotJoined ctx.agent_name))
-  else if not (Poly.equal (args |> member "agent_role") `Null) then
+  else if not ((=) (args |> member "agent_role") `Null) then
     (false, "agent_role is no longer supported")
   else
   let task_id = get_string args "task_id" "" in
@@ -816,13 +815,13 @@ and handle_transition ?agent_tool_names ctx args =
   match handoff_context with
   | Error error -> (false, error)
   | Ok handoff_context ->
-  if Poly.equal action Types.Release && strict_release_requires_handoff task_opt
+  if (=) action Types.Release && strict_release_requires_handoff task_opt
      && Option.is_none handoff_context
   then
     (false, "Strict task release requires handoff_context.summary")
   else
   let completion_state_error =
-    if Poly.equal action Types.Done_action && not force then
+    if (=) action Types.Done_action && not force then
       completion_state_error ~task_id ~agent_name:ctx.agent_name ~task_opt
     else
       None
@@ -836,7 +835,7 @@ and handle_transition ?agent_tool_names ctx args =
     force || can_review_completion ~task_opt ~agent_name:ctx.agent_name
   in
   let persisted_gate_rejection =
-    if Poly.equal action Types.Done_action && not force then
+    if (=) action Types.Done_action && not force then
       if not completion_owned_by_caller then
         None
       else if task_has_persisted_contract task_opt then
@@ -851,7 +850,7 @@ and handle_transition ?agent_tool_names ctx args =
     (false, reason)
   | None ->
   let review_gate_rejection =
-    if Poly.equal action Types.Done_action && not force then
+    if (=) action Types.Done_action && not force then
       if not completion_owned_by_caller then
         None
       else if can_review_completion ~task_opt ~agent_name:ctx.agent_name then
@@ -881,7 +880,7 @@ and handle_transition ?agent_tool_names ctx args =
      above; this replaces Gate 2.5 (substring match) with real
      measurement by the verifier. See issue #7598. *)
   let action =
-    if Poly.equal action Types.Done_action
+    if (=) action Types.Done_action
        && Env_config_runtime.Verification.fsm_enabled ()
        && completion_owned_by_caller
     then

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_task - Core task CRUD operations *)
 

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_task_schemas.mli
+++ b/lib/tool_task_schemas.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_task_schemas — MCP tool schema definitions for task operations.
 

--- a/lib/tool_token.ml
+++ b/lib/tool_token.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_token.mli
+++ b/lib/tool_token.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_token — parse-once proof that a tool name exists in a dispatch table.
 

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_unified.mli
+++ b/lib/tool_unified.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_unified — Unified query interface across catalog, registry,
     and dispatch.

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_usage_log.mli
+++ b/lib/tool_usage_log.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Tool_usage_log -- Durable call logging for System_internal surface tools.
 

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -1,4 +1,3 @@
-open Base
 module Format = Stdlib.Format
 module Map = Stdlib.Map
 module Set = Stdlib.Set

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -1,4 +1,3 @@
-open Base
 
 (** Worktree tools - Git worktree management for task isolation *)
 


### PR DESCRIPTION
Resolves Task 117. Phase 1 of the Base Purge. Systematically removes open Base from all files in the lib directory. Replaced open Base, rewrote usages of Poly.equal to OCaml standard =, replaced Exn.to_string with Printexc.to_string, mapped String.lowercase to String.lowercase_ascii, substituted implicit Base functions with either Base qualified paths or Stdlib functions where applicable.