### PR TITLE
fix(dashboard): stabilize cockpit IDE tests

### DIFF
--- a/dashboard/src/components/cockpit/cockpit-frame.ts
+++ b/dashboard/src/components/cockpit/cockpit-frame.ts
@@ -1,0 +1,7 @@
+import { runningUnderVitest } from '../../lib/test-env'
+
+export const COCKPIT_FRAME_SRC = '/cockpit/MASC Cockpit (Full).html'
+
+export function shouldLoadCockpitFrame(): boolean {
+  return !runningUnderVitest()
+}

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -1,20 +1,23 @@
 import { html } from 'htm/preact'
 import { WorldVisualizer } from '../world-visualizer'
+import { COCKPIT_FRAME_SRC, shouldLoadCockpitFrame } from './cockpit-frame'
 
 export function Cockpit() {
   return html`
     <div style=${{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%', backgroundColor: '#000' }}>
-      <!-- 7 Physical Laws Canvas rendering the Stigmergy traces -->
       <div style=${{ flex: '0 0 auto', borderBottom: '1px solid #333' }}>
-         <${WorldVisualizer} />
+        <${WorldVisualizer} />
       </div>
-      
-      <!-- The High-Fidelity UI Mockup ported from the user downloads -->
-      <iframe 
-        src="/cockpit/MASC Cockpit (Full).html" 
-        style=${{ flex: 1, border: 'none', width: '100%', height: 'calc(100vh - 300px)' }} 
-        title="MASC Dream IDE Cockpit"
-      />
+
+      ${shouldLoadCockpitFrame()
+        ? html`
+          <iframe
+            src=${COCKPIT_FRAME_SRC}
+            style=${{ flex: 1, border: 'none', width: '100%', height: 'calc(100vh - 300px)' }}
+            title="MASC Dream IDE Cockpit"
+          />
+        `
+        : null}
     </div>
   `
 }

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,20 +1,183 @@
 import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import { IdeExplorer } from './ide-explorer'
+import { IdeEditorMock, type IdeEditorView } from './ide-editor-mock'
+import { IdeConversationRailMock } from './ide-conversation-rail-mock'
+import { IdeActivityMock } from './ide-activity-mock'
+import { IdeInterjectMock } from './ide-interject-mock'
+import { IdePresenceStrip } from './ide-presence-strip'
+import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { WorldVisualizer } from '../world-visualizer'
+import { COCKPIT_FRAME_SRC, shouldLoadCockpitFrame } from '../cockpit/cockpit-frame'
+import { navigate, route } from '../../router'
+import {
+  parseActive,
+  serializeActive,
+} from '../../../design-system/headless-core/layered-overlay'
 
-export function IdeShell() {
+type ViewTab = IdeEditorView
+const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
+
+function viewFromRoute(raw: string | null | undefined): ViewTab {
+  const normalized = raw
+    ?.trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-')
+  if (normalized === 'split' || normalized === 'split-diff' || normalized === 'merge') return 'split-diff'
+  if (normalized === 'unified') return 'unified'
+  if (normalized === 'blame') return 'blame'
+  return 'source'
+}
+
+function layersFromRoute(raw: string | null | undefined): ReadonlySet<string> {
+  return parseActive(raw ?? '', IDE_LAYER_KINDS)
+}
+
+function paramsWithLayers(
+  params: Record<string, string>,
+  view: ViewTab,
+  activeLayers: ReadonlySet<string>,
+): Record<string, string> {
+  const next: Record<string, string> = { ...params, section: 'ide-shell', view }
+  const serialized = serializeActive(activeLayers)
+  if (serialized) {
+    next.layers = serialized
+  } else {
+    delete next.layers
+  }
+  return next
+}
+
+function CockpitPreview() {
+  if (!shouldLoadCockpitFrame()) {
+    return html`
+      <section
+        aria-label="MASC Cockpit preview"
+        style=${{
+          minHeight: 0,
+          borderTop: '1px solid var(--color-border-divider)',
+          background: '#000',
+        }}
+      />
+    `
+  }
+
   return html`
-    <section class="ide-plane-shell" style=${{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - var(--h-topnav) - var(--h-kpi))', width: '100%', backgroundColor: '#000' }}>
-      <!-- 7 Physical Laws Canvas rendering the Stigmergy traces -->
-      <div style=${{ flex: '0 0 auto', borderBottom: '1px solid #333' }}>
-         <${WorldVisualizer} />
+    <section
+      aria-label="MASC Cockpit preview"
+      style=${{
+        display: 'grid',
+        gridTemplateRows: 'auto 1fr',
+        minHeight: 0,
+        borderTop: '1px solid var(--color-border-divider)',
+        background: '#000',
+      }}
+    >
+      <div
+        style=${{
+          padding: 'var(--sp-2) var(--sp-3)',
+          borderBottom: '1px solid rgba(255,255,255,0.12)',
+          color: 'rgba(255,255,255,0.68)',
+          font: 'var(--type-eyebrow)',
+        }}
+      >
+        MASC Cockpit
       </div>
-      
-      <!-- The High-Fidelity UI Mockup ported from the user downloads -->
-      <iframe 
-        src="/cockpit/MASC Cockpit (Full).html" 
-        style=${{ flex: 1, border: 'none', width: '100%', height: '100%' }} 
+      <iframe
+        src=${COCKPIT_FRAME_SRC}
+        style=${{ width: '100%', height: '100%', minHeight: 0, border: 'none' }}
         title="MASC Dream IDE Cockpit"
       />
+    </section>
+  `
+}
+
+export function IdeShell() {
+  const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
+  const activeLayers = layersFromRoute(route.value.params.layers)
+
+  useEffect(() => {
+    const next = viewFromRoute(route.value.params.view)
+    setActiveView(current => current === next ? current : next)
+  }, [route.value.params.view])
+
+  const handleViewChange = (next: ViewTab) => {
+    setActiveView(next)
+    navigate('code', { ...route.value.params, section: 'ide-shell', view: next })
+  }
+
+  const handleLayersChange = (nextLayers: ReadonlySet<string>) => {
+    navigate('code', paramsWithLayers(route.value.params, activeView, nextLayers))
+  }
+
+  return html`
+    <section
+      class="ide-plane-shell"
+      role="region"
+      aria-label="Code IDE shell"
+      style=${{
+        display: 'grid',
+        gridTemplateRows: 'auto auto auto 1fr auto',
+        background: 'var(--color-bg-page)',
+        color: 'var(--color-fg-primary)',
+        minHeight: 'calc(100vh - var(--h-topbar) - var(--h-kpi))',
+      }}
+    >
+      <header
+        style=${{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--sp-3)',
+          padding: 'var(--sp-2) var(--sp-3)',
+          background: 'var(--color-bg-surface)',
+          borderBottom: '1px solid var(--color-border-default)',
+          font: 'var(--type-eyebrow)',
+          color: 'var(--color-fg-muted)',
+        }}
+      >
+        <span style=${{ color: 'var(--color-fg-secondary)' }}>코드 IDE</span>
+        <span>·</span>
+        <${IdePresenceStrip} />
+        <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok, var(--ok))' }}>● mcp · connected</span>
+      </header>
+      <${IdeToolbar}
+        activeView=${activeView}
+        activeLayers=${activeLayers}
+        onViewChange=${handleViewChange}
+        onLayersChange=${handleLayersChange}
+      />
+      <div style=${{ borderBottom: '1px solid var(--color-border-divider)' }}>
+        <${WorldVisualizer} />
+      </div>
+      <div
+        class="ide-plane-grid"
+        role="presentation"
+        style=${{
+          minHeight: 0,
+        }}
+      >
+        <div class="ide-plane-tree">
+          <${IdeExplorer} />
+        </div>
+        <div
+          class="ide-plane-editor"
+          style=${{
+            display: 'grid',
+            gridTemplateRows: 'minmax(280px, 1fr) minmax(260px, 38vh)',
+            minHeight: 0,
+          }}
+        >
+          <${IdeEditorMock} activeView=${activeView} activeLayers=${activeLayers} />
+          <${CockpitPreview} />
+        </div>
+        <div class="ide-plane-conversation" style=${{ minHeight: 0 }}>
+          <${IdeConversationRailMock} />
+        </div>
+        <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
+          <${IdeActivityMock} />
+        </div>
+      </div>
+      <${IdeInterjectMock} />
     </section>
   `
 }

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import * as Y from 'yjs'
 import { WebsocketProvider } from 'y-websocket'
+import { runningUnderVitest } from '../lib/test-env'
 
 interface KeeperState {
   id: string
@@ -18,8 +19,9 @@ interface Trace {
 }
 
 function yjsWebsocketUrl(): string | null {
-  const configured = import.meta.env?.VITE_MASC_YJS_WS_URL
-  if (configured && configured.trim() !== '') return configured
+  const configured = import.meta.env?.VITE_MASC_YJS_WS_URL?.trim()
+  if (configured) return configured
+  if (runningUnderVitest()) return null
   if (typeof window === 'undefined' || !window.location?.host) return null
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
   return `${protocol}//${window.location.host}/yjs`

--- a/dashboard/src/lib/test-env.ts
+++ b/dashboard/src/lib/test-env.ts
@@ -1,0 +1,13 @@
+function truthyEnvFlag(value: unknown): boolean {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return normalized !== '' && normalized !== '0' && normalized !== 'false'
+  }
+  return value === true
+}
+
+export function runningUnderVitest(): boolean {
+  return import.meta.env?.MODE === 'test'
+    || truthyEnvFlag(import.meta.env?.VITEST)
+    || truthyEnvFlag(typeof process !== 'undefined' ? process.env.VITEST : undefined)
+}


### PR DESCRIPTION
## Summary
- restore the Code IDE shell toolbar/view/layer route contract around the cockpit iframe
- disable cockpit iframe/Yjs websocket side effects under Vitest so dashboard tests do not attempt localhost:3000 connections
- keep the latest cockpit visualizer/frame available in the Cockpit surface and Code IDE preview

## Verification
- pnpm typecheck
- pnpm exec vitest run --config vitest.config.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1 --reporter verbose
- pnpm exec vitest run --config vitest.config.ts src/cockpit-entrypoints.test.ts --no-file-parallelism --maxWorkers=1 --reporter verbose
- pnpm exec vitest run --config vitest.config.ts src/styles/cockpit-token-cascade.test.ts --no-file-parallelism --maxWorkers=1 --reporter verbose
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 (591 files / 7328 tests passed before rebase; rebase only reconciled cockpit.ts with origin/main)
- pnpm lint (0 errors, 3 existing warnings)
- pnpm build
- git diff --check

Note: local pnpm test runs the Solid config through a symlinked worktree node_modules and fails to resolve @testing-library/jest-dom from the root checkout path; CI should validate this in a normal checkout.