### PR TITLE
fix(dashboard): resolve InvalidCharacterError and spurious WebSocket console error

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -286,7 +286,7 @@ export function App() {
 
         <main id="main-content" tabindex=${-1} class="min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0">
           <div class="h-full overflow-y-auto p-4">
-            <div style=${{ flex: '0 0 auto', borderBottom: '1px solid var(--color-border-default)' }}><${WorldVisualizer} /></div><${DashboardMain} />
+            <div class="flex-none border-b border-solid border-[var(--color-border-default)]"><${WorldVisualizer} /></div><${DashboardMain} />
           </div>
         </main>
       </div>

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -19,12 +19,9 @@ interface Trace {
 }
 
 function yjsWebsocketUrl(): string | null {
-  const configured = import.meta.env?.VITE_MASC_YJS_WS_URL?.trim()
-  if (configured) return configured
   if (runningUnderVitest()) return null
-  if (typeof window === 'undefined' || !window.location?.host) return null
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${protocol}//${window.location.host}/yjs`
+  const configured = import.meta.env?.VITE_MASC_YJS_WS_URL?.trim()
+  return configured || null
 }
 
 export function WorldVisualizer() {
@@ -39,7 +36,13 @@ export function WorldVisualizer() {
     if (!url) return
 
     const ydoc = new Y.Doc()
-    const provider = new WebsocketProvider(url, 'masc-telemetry', ydoc)
+    let provider: WebsocketProvider
+    try {
+      provider = new WebsocketProvider(url, 'masc-telemetry', ydoc)
+    } catch {
+      ydoc.destroy()
+      return
+    }
     const yKeepers = ydoc.getMap<KeeperState>('keepers')
     const yTraces = ydoc.getArray<Trace>('traces')
     providerRef.current = provider


### PR DESCRIPTION
## Summary
- Fix last remaining `style=${{ flex: '0 0 auto', ... }}` in `app.ts:289` that PR #12741 missed — htm tagged template misinterprets this as a DOM attribute `'0 0 auto,'`, causing `InvalidCharacterError`
- Remove auto-detection of Y.js WebSocket URL from `window.location.host` in `world-visualizer.ts` — was causing spurious `WebSocket connection to 'ws://localhost:1234/masc-telemetry' failed` console errors when no Y.js server is running
- Add try-catch around `WebsocketProvider` construction for resilience

## Test plan
- [x] `npx vite build` succeeds
- [x] Built output contains `flex-none border-b border-solid` (not `0 0 auto`)
- [x] Built output contains no `stopImmediatePropagation`
- [ ] Manual: open dashboard in browser, verify no `InvalidCharacterError` in console
- [ ] Manual: verify no `WebSocket connection to ... failed` when `VITE_MASC_YJS_WS_URL` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)