### PR TITLE
fix(dashboard): replace htm style object with Tailwind classes (round 2)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -286,7 +286,7 @@ export function App() {
 
         <main id="main-content" tabindex=${-1} class="min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0">
           <div class="h-full overflow-y-auto p-4">
-            <div style=${{ flex: '0 0 auto', borderBottom: '1px solid var(--color-border-default)' }}><${WorldVisualizer} /></div><${DashboardMain} />
+            <div class="flex-none border-b border-solid border-[var(--color-border-default)]"><${WorldVisualizer} /></div><${DashboardMain} />
           </div>
         </main>
       </div>

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -13,7 +13,7 @@ export function Cockpit() {
         ? html`
           <iframe
             src=${COCKPIT_FRAME_SRC}
-            class="h-[calc(100vh-300px)] min-h-0 w-full flex-1 border-0"
+            class="h-[calc(100vh_-_300px)] min-h-0 w-full flex-1 border-0"
             title="MASC Dream IDE Cockpit"
           />
         `

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -102,14 +102,8 @@ function PresenceChip({ entry }: { readonly entry: KeeperPresenceEntry }) {
     >
       <span
         aria-hidden="true"
-        style=${{
-          width: '6px',
-          height: '6px',
-          borderRadius: '50%',
-          background: keeperColor,
-          opacity: entry.status === 'active' ? 0.95 : 0.45,
-          flex: '0 0 auto',
-        }}
+        class="size-[6px] shrink-0 rounded-full"
+        style=${{ background: keeperColor, opacity: entry.status === 'active' ? 0.95 : 0.45 }}
       />
       <span style=${{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
         ${entry.keeper_id}@${entry.workspace_label}


### PR DESCRIPTION
## Summary
- Convert `style=${{ flex: '0 0 auto', borderBottom: '...' }}` to Tailwind classes in `app.ts` to fix `InvalidCharacterError`
- Convert inline style object in `ide-presence-strip.ts` to Tailwind classes for the same reason

## Root Cause
htm tagged template parser interprets commas within `style=${{...}}` object literals as HTML attribute separators, producing invalid attribute names like `'0 0 auto,'`.

## Test plan
- [x] `npx vite build` succeeds
- [x] Built JS contains zero matches for `0 0 auto`
- [x] Dashboard loads at http://127.0.0.1:8935/dashboard/ without `InvalidCharacterError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)