### PR TITLE
fix(cascade): fail closed for strict provider filter resolution (#12686)

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -871,6 +871,47 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
              (String.concat ", " returned));
         Ok providers)
 
+let resolve_named_providers_strict ?sw ?net ?clock ?provider_filter
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    ?runtime_mcp_policy ~cascade_name () =
+  match lookup_active_profile ?sw ?net ?clock cascade_name with
+  | Error _ as e -> e
+  | Ok (_snapshot, normalized, profile) ->
+      let ordered_entries =
+        Cascade_config.order_weighted_entries
+          ~rotation_scope:normalized
+          profile.weighted_entries
+      in
+      let parsed_declared_providers =
+        Cascade_config.parse_weighted_entries
+             ~api_key_env_overrides:profile.api_key_env_overrides
+             ~cascade_name:normalized
+          ordered_entries
+      in
+      let filtered_declared_providers =
+        match Cascade_config.apply_provider_filter_strict
+                ~provider_filter ~label:normalized parsed_declared_providers with
+        | Error rejection ->
+            Error (Cascade_config.provider_filter_rejection_to_string rejection)
+        | Ok ps -> Ok ps
+      in
+      (match filtered_declared_providers with
+       | Error _ as e -> e
+       | Ok filtered ->
+       let providers =
+         Provider_tool_support.apply_required_tool_use_filter
+           ?runtime_mcp_policy
+           ~require_tool_choice_support ~require_tool_support
+           ~label:normalized filtered
+       in
+       if providers = [] then
+         Error
+           (Printf.sprintf
+              "cascade %s resolved to no callable providers"
+              normalized)
+       else Ok providers)
+
 let resolve_inference_params ?sw ?net ?clock ~name () =
   match lookup_active_profile ?sw ?net ?clock name with
   | Ok (_snapshot, _normalized, profile) -> Ok profile.inference_params

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -81,6 +81,21 @@ val resolve_named_providers :
   unit ->
   (Llm_provider.Provider_config.t list, string) result
 
+val resolve_named_providers_strict :
+  ?sw:Eio.Switch.t ->
+  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?provider_filter:string list ->
+  ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  cascade_name:string ->
+  unit ->
+  (Llm_provider.Provider_config.t list, string) result
+(** Strict variant of {!resolve_named_providers} for execution paths.
+    Provider filter resolution fails closed instead of silently
+    broadening to the full provider set. *)
+
 val resolve_inference_params :
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -620,6 +620,11 @@ let parse_model_strings
 (* Health filtering (extracted to Cascade_health_filter) *)
 let is_local_provider = Cascade_health_filter.is_local_provider
 let filter_healthy = Cascade_health_filter.filter_healthy
+let filter_healthy_strict = Cascade_health_filter.filter_healthy_strict
+let health_filter_rejection_to_string = Cascade_health_filter.health_filter_rejection_to_string
+type health_filter_rejection = Cascade_health_filter.health_filter_rejection =
+  | All_missing_api_key of int
+  | All_local_unhealthy of { local_count : int; cloud_count : int }
 
 (* ── Context window resolution ──────────────────────────── *)
 
@@ -1033,6 +1038,18 @@ let expand_model_strings_for_execution ?rotation_scope (items : string list) =
   |> List.concat_map (expand_auto_model_string ?rotation_scope)
   |> dedupe_stable
 
+(* ── Provider filter rejection (strict mode) ───────────── *)
+
+type provider_filter_rejection =
+  | Filter_matched_none of { filter : string list; available_kinds : string list }
+
+let provider_filter_rejection_to_string = function
+  | Filter_matched_none { filter; available_kinds } ->
+    Printf.sprintf
+      "provider_filter matched no providers: filter=[%s] available=[%s]"
+      (String.concat "," filter)
+      (String.concat "," available_kinds)
+
 (* Filter providers by kind name (exact, case-insensitive).
    Valid filter values: "ollama", "glm", "anthropic", "gemini", "openai_compat",
    "claude_code", "kimi", "kimi_cli", "gemini_cli", "codex_cli".
@@ -1055,6 +1072,27 @@ let apply_provider_filter ~provider_filter ~label providers =
           Llm_provider.Provider_config.string_of_provider_kind p.kind) providers));
       providers)
     else filtered
+
+let apply_provider_filter_strict ~provider_filter ~label providers =
+  match provider_filter with
+  | None | Some [] -> Ok providers
+  | Some filters ->
+    let lc_filters = List.map String.lowercase_ascii filters in
+    let matches (p : Llm_provider.Provider_config.t) =
+      List.mem (Llm_provider.Provider_config.string_of_provider_kind p.kind) lc_filters
+    in
+    let filtered = List.filter matches providers in
+    if filtered = [] then
+      Error
+        (Filter_matched_none
+           { filter = filters
+           ; available_kinds =
+             providers
+             |> List.map (fun (p : Llm_provider.Provider_config.t) ->
+               Llm_provider.Provider_config.string_of_provider_kind p.kind)
+             |> List.sort_uniq String.compare
+           })
+    else Ok filtered
 
 (* ── Local Capacity Query ──────────────────────────────── *)
 

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -386,6 +386,19 @@ val filter_healthy :
   Llm_provider.Provider_config.t list ->
   Llm_provider.Provider_config.t list
 
+type health_filter_rejection =
+  Cascade_health_filter.health_filter_rejection =
+  | All_missing_api_key of int
+  | All_local_unhealthy of { local_count : int; cloud_count : int }
+
+val health_filter_rejection_to_string : health_filter_rejection -> string
+
+val filter_healthy_strict :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  Llm_provider.Provider_config.t list ->
+  (Llm_provider.Provider_config.t list, health_filter_rejection) result
+
 (** {1 Context Window Resolution} *)
 
 (** Resolve the Kimi context window from the OAS capability SSOT.
@@ -441,11 +454,26 @@ val filter_by_capabilities :
     Joins all {!Llm_provider.Types.Text} blocks. Useful for accept validators. *)
 val text_of_response : Llm_provider.Types.api_response -> string
 
+type provider_filter_rejection =
+  | Filter_matched_none of { filter : string list; available_kinds : string list }
+
+val provider_filter_rejection_to_string : provider_filter_rejection -> string
+
 val apply_provider_filter :
   provider_filter:string list option ->
   label:string ->
   Llm_provider.Provider_config.t list ->
   Llm_provider.Provider_config.t list
+
+val apply_provider_filter_strict :
+  provider_filter:string list option ->
+  label:string ->
+  Llm_provider.Provider_config.t list ->
+  (Llm_provider.Provider_config.t list, provider_filter_rejection) result
+(** Strict variant of {!apply_provider_filter}. Returns [Error] when
+    the explicit provider_filter matches no available providers instead
+    of silently broadening to the full set. Use for execution paths
+    where provider drift must surface as a typed blocker. *)
 
 (** {1 Local Capacity Query} *)
 

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -5,6 +5,20 @@
 
     @since 0.99.5 *)
 
+(* ── Strict-mode rejection type ────────────────────────── *)
+
+type health_filter_rejection =
+  | All_missing_api_key of int
+  | All_local_unhealthy of { local_count : int; cloud_count : int }
+
+let health_filter_rejection_to_string = function
+  | All_missing_api_key n ->
+    Printf.sprintf "all %d provider(s) lack required API key" n
+  | All_local_unhealthy { local_count; cloud_count } ->
+    Printf.sprintf
+      "all %d local endpoint(s) unhealthy, %d cloud provider(s) available but strict mode disallows fallback"
+      local_count cloud_count
+
 (* ── Cascade-level error classification ────────────────── *)
 
 (** Decide whether an error should cascade to the next provider.
@@ -100,5 +114,50 @@ let filter_healthy_internal ~sw ~net (providers : Llm_provider.Provider_config.t
 
 let filter_healthy ~sw ~net providers =
   fst (filter_healthy_internal ~sw ~net providers)
+
+let filter_healthy_strict ~sw ~net (providers : Llm_provider.Provider_config.t list)
+    : (Llm_provider.Provider_config.t list, health_filter_rejection) result =
+  let initial_count = List.length providers in
+  (* Step 0: Remove cloud providers missing required API keys — fail closed *)
+  let with_keys = List.filter has_required_api_key providers in
+  if with_keys = [] && initial_count > 0 then
+    Error (All_missing_api_key initial_count)
+  else
+    let providers =
+      let dropped = initial_count - List.length with_keys in
+      if dropped > 0 then begin
+        Llm_provider.Diag.debug "cascade_health_filter"
+          "strict: dropped %d provider(s) missing API keys" dropped
+      end;
+      with_keys
+    in
+    let local_providers = List.filter is_local_provider providers in
+    let cloud_providers =
+      List.filter (fun cfg -> not (is_local_provider cfg)) providers
+    in
+    if local_providers = [] then
+      Ok providers
+    else
+      let endpoints =
+        local_providers
+        |> List.map (fun (cfg : Llm_provider.Provider_config.t) -> cfg.base_url)
+        |> List.sort_uniq String.compare
+      in
+      let statuses =
+        Llm_provider.Discovery.refresh_and_sync ~sw ~net ~endpoints
+      in
+      let any_healthy =
+        List.exists
+          (fun (s : Llm_provider.Discovery.endpoint_status) -> s.healthy)
+          statuses
+      in
+      if any_healthy then
+        Ok providers
+      else
+        Error
+          (All_local_unhealthy
+             { local_count = List.length local_providers
+             ; cloud_count = List.length cloud_providers
+             })
 
 (* ── Inline tests ──────────────────────────────────────── *)

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -11,6 +11,16 @@
     helpers ([has_required_api_key], [filter_healthy_internal]) stay
     hidden. *)
 
+(* ── Strict-mode rejection ──────────────────────────────── *)
+
+type health_filter_rejection =
+  | All_missing_api_key of int
+      (** All N providers lack required API key credentials. *)
+  | All_local_unhealthy of { local_count : int; cloud_count : int }
+      (** All local endpoints unhealthy; strict mode disallows cloud fallback. *)
+
+val health_filter_rejection_to_string : health_filter_rejection -> string
+
 (** Mirror of [Oas_compat.Http_client.cascade_failure_class] so callers
     can pattern-match without having to depend on the OAS surface. *)
 type cascade_failure_class =
@@ -67,3 +77,20 @@ val filter_healthy :
          (logged at info via [Diag]).}}
 
     The function is invoked at startup and on each cascade reload. *)
+
+val filter_healthy_strict :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  Llm_provider.Provider_config.t list ->
+  (Llm_provider.Provider_config.t list, health_filter_rejection) result
+(** Strict variant of {!filter_healthy} for execution paths.
+
+    Returns [Error] when:
+    {ul
+      {- all providers lack required API keys ([All_missing_api_key]);}
+      {- all local endpoints are unhealthy and strict mode disallows
+         automatic cloud fallback ([All_local_unhealthy]).}}
+
+    Use this for keeper execution paths where provider drift must be
+    surfaced as a typed blocker. Use {!filter_healthy} for diagnostic
+    and startup contexts where fail-open is acceptable. *)

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -326,6 +326,28 @@ let resolve_named_providers_result ?provider_filter
            ~require_tool_choice_support
            ~require_tool_support ~label providers)
 
+let resolve_named_providers_result_strict ?provider_filter
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    ?runtime_mcp_policy
+    ~cascade_name ()
+    : (Llm_provider.Provider_config.t list, string) result =
+  let cascade_name_string = cascade_name_to_string cascade_name in
+  let label =
+    Keeper_cascade_profile.normalize_declared_name cascade_name_string
+  in
+  match
+    Cascade_catalog_runtime.resolve_named_providers_strict ?provider_filter
+      ?runtime_mcp_policy ~require_tool_choice_support:false
+      ~cascade_name:cascade_name_string ()
+  with
+  | Error _ as e -> e
+  | Ok providers ->
+      Ok
+        (apply_required_tool_choice_filter ?runtime_mcp_policy
+           ~require_tool_choice_support
+           ~require_tool_support ~label providers)
+
 let resolve_named_providers ?provider_filter
     ?(require_tool_choice_support = false)
     ?(require_tool_support = false)

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -44,6 +44,17 @@ val resolve_named_providers_result :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   unit ->
   (Llm_provider.Provider_config.t list, string) result
+val resolve_named_providers_result_strict :
+  ?provider_filter:string list ->
+  ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  cascade_name:Keeper_cascade_profile.runtime_name ->
+  unit ->
+  (Llm_provider.Provider_config.t list, string) result
+(** Strict variant of {!resolve_named_providers_result} for execution paths.
+    Provider filter resolution fails closed instead of silently
+    broadening to the full provider set. *)
 val resolve_named_providers :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -563,30 +563,34 @@ let prepare_agent_setup
                Keeper_config.keeper_llm_rerank_cascade ()
              in
              (match
-                Cascade_catalog_runtime.resolve_named_providers
+                Cascade_catalog_runtime.resolve_named_providers_strict
                   ~sw ~net
                   ~cascade_name:rerank_cascade
                   ()
               with
               | Error detail ->
                   Log.Keeper.warn
-                    "keeper:%s TopK_llm: invalid rerank cascade '%s' (%s), falling back to core+prefilter+discovered"
+                    "keeper:%s TopK_llm: strict cascade resolution failed for '%s' (%s), falling back to core+prefilter+discovered"
                     meta.name
                     rerank_cascade
                     detail;
                   []
               | Ok providers ->
-                  let healthy =
-                    Cascade_config.filter_healthy ~sw ~net providers
-                  in
-                  (match healthy with
-                   | [] ->
+                  (match Cascade_config.filter_healthy_strict ~sw ~net providers with
+                   | Error rejection ->
+                       Log.Keeper.warn
+                         "keeper:%s TopK_llm: strict health filter rejected cascade '%s' (%s), falling back to core+prefilter+discovered"
+                         meta.name
+                         rerank_cascade
+                         (Cascade_config.health_filter_rejection_to_string rejection);
+                       []
+                   | Ok [] ->
                        Log.Keeper.warn
                          "keeper:%s TopK_llm: no healthy provider for cascade '%s', falling back to core+prefilter+discovered"
                          meta.name
                          rerank_cascade;
                        []
-                   | first_provider :: _ ->
+                   | Ok (first_provider :: _) ->
                        let rerank_fn =
                          Agent_sdk.Tool_selector.default_rerank_fn
                            ~sw

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -39,7 +39,7 @@ let resolve_cascade_providers ?provider_filter
     ?(require_tool_support = false)
     ?runtime_mcp_policy
     ~cascade_name () =
-  Cascade_runtime.resolve_named_providers_result ?provider_filter
+  Cascade_runtime.resolve_named_providers_result_strict ?provider_filter
     ?runtime_mcp_policy
     ~require_tool_choice_support ~require_tool_support ~cascade_name ()
 

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -923,6 +923,83 @@ let test_config_doctor_live_warns_on_partial_catalog_validation () =
         (contains_substring (Yojson.Safe.to_string json)
            "__nonexistent_provider_sentinel__:fake")
 
+(* #12686: strict variant tests *)
+
+let test_strict_resolve_rejects_nonmatching_provider_filter () =
+  with_temp_dir "cascade-strict-filter" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  ignore
+    (write_cascade_json config_dir
+       {|{
+  "big_three_models": [
+    "anthropic:claude-sonnet-4-20250514",
+    "openrouter:auto"
+  ]
+}|});
+  match
+    Cascade_catalog_runtime.resolve_named_providers_strict
+      ~provider_filter:[ "ollama"; "codex_cli" ]
+      ~cascade_name:Keeper_config.default_cascade_name
+      ()
+  with
+  | Ok providers ->
+      failf "strict should reject when no provider matches filter, got %d providers"
+        (List.length providers)
+  | Error detail ->
+      check bool "error mentions filter mismatch" true
+        (contains_substring detail "provider_filter matched no providers")
+
+let test_strict_resolve_ok_when_filter_matches () =
+  with_temp_dir "cascade-strict-match" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  ignore
+    (write_cascade_json config_dir
+       {|{
+  "big_three_models": [
+    "anthropic:claude-sonnet-4-20250514",
+    "openrouter:auto"
+  ]
+}|});
+  let providers =
+    require_ok
+      (Cascade_catalog_runtime.resolve_named_providers_strict
+         ~provider_filter:[ "anthropic" ]
+         ~cascade_name:Keeper_config.default_cascade_name
+         ())
+  in
+  check int "only anthropic providers survive" 1 (List.length providers);
+  check bool "provider kind is anthropic" true
+    (List.mem "anthropic" (provider_kinds providers))
+
+let test_non_strict_resolve_tolerates_nonmatching_filter () =
+  with_temp_dir "cascade-nonstrict-filter" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  ignore
+    (write_cascade_json config_dir
+       {|{
+  "big_three_models": [
+    "anthropic:claude-sonnet-4-20250514",
+    "openrouter:auto"
+  ]
+}|});
+  (* Non-strict resolve should NOT error on non-matching filter.
+     It returns whatever the catalog provides (silently ignores filter). *)
+  let providers =
+    require_ok
+      (Cascade_catalog_runtime.resolve_named_providers
+         ~provider_filter:[ "nonexistent_provider_xyz" ]
+         ~cascade_name:Keeper_config.default_cascade_name
+         ())
+  in
+  check int "non-strict returns all providers despite bad filter" 2
+    (List.length providers)
+
 let () =
   run "cascade_catalog_runtime"
     [
@@ -992,5 +1069,17 @@ let () =
             "config doctor live warns on partial catalog validation"
             `Quick
             test_config_doctor_live_warns_on_partial_catalog_validation;
+          test_case
+            "strict resolve rejects non-matching provider filter (#12686)"
+            `Quick
+            test_strict_resolve_rejects_nonmatching_provider_filter;
+          test_case
+            "strict resolve ok when filter matches (#12686)"
+            `Quick
+            test_strict_resolve_ok_when_filter_matches;
+          test_case
+            "non-strict resolve tolerates non-matching filter (#12686)"
+            `Quick
+            test_non_strict_resolve_tolerates_nonmatching_filter;
         ] );
     ]


### PR DESCRIPTION
## Summary

Closes #12686 — three fail-open paths in cascade provider filtering that silently broadened provider sets instead of surfacing errors.

### Problem
When a `provider_filter` matched no providers, the non-strict path silently returned the full unfiltered set. When all providers lacked API keys, the health filter silently returned an empty list. These two combined in `resolve_named_providers` meant operators saw "no providers" without knowing why.

### Changes
- **`cascade_health_filter`**: Added `health_filter_rejection` type + `filter_healthy_strict` — returns `Error (All_missing_api_key n)` or `Error (All_local_unhealthy {...})` instead of silent empty
- **`cascade_config`**: Added `provider_filter_rejection` type + `apply_provider_filter_strict` — returns `Error (Filter_matched_none {...})` when filter matches nothing
- **`cascade_catalog_runtime`**: Added `resolve_named_providers_strict` — uses strict filter, propagates errors
- **`cascade_runtime`**: Added `resolve_named_providers_result_strict` wrapper with tool choice filter
- **`keeper_run_tools`**: Execution path now uses strict variants with structured error logging
- **`oas_worker_named_cascade`**: OAS execution path now uses strict resolution

### What this does NOT change
- Non-strict variants (`resolve_named_providers`, `filter_healthy`) are unchanged — startup/diagnostic paths keep fail-open behavior
- Provider filter `None` / `[]` still passes through (no filter = no rejection)
- Existing tests pass unchanged

## Test plan
- [x] `dune build --root=.` passes (11 files, 343 LOC added)
- [x] 3 new regression tests in `test_cascade_catalog_runtime.ml`:
  - strict rejects non-matching provider_filter
  - strict returns Ok when filter matches
  - non-strict tolerates non-matching filter (backward compat)
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)