### PR TITLE
refactor(dashboard): replace hardcoded colors with Cockpit design tokens

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.test.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.test.ts
@@ -4,6 +4,11 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { CytoscapeFsm } from './cytoscape-fsm'
 
+const mockStyleApi = {
+  fromJson: vi.fn(() => mockStyleApi),
+  update: vi.fn(),
+}
+
 const mockCyInstance = {
   destroy: vi.fn(),
   elements: vi.fn(() => ({ remove: vi.fn() })),
@@ -12,6 +17,7 @@ const mockCyInstance = {
   layout: vi.fn(() => ({ run: vi.fn() })),
   on: vi.fn(),
   fit: vi.fn(),
+  style: vi.fn(() => mockStyleApi),
 }
 
 vi.mock('cytoscape', () => ({
@@ -28,6 +34,11 @@ describe('CytoscapeFsm', () => {
     mockCyInstance.layout.mockClear()
     mockCyInstance.on.mockClear()
     mockCyInstance.fit.mockClear()
+    mockCyInstance.style.mockClear()
+    mockStyleApi.fromJson.mockClear()
+    mockStyleApi.update.mockClear()
+    document.documentElement.removeAttribute('data-theme')
+    document.documentElement.removeAttribute('style')
   })
 
   const baseSpec = {
@@ -103,5 +114,34 @@ describe('CytoscapeFsm', () => {
     )
     await new Promise((r) => setTimeout(r, 10))
     expect(mockCyInstance.elements).toHaveBeenCalled()
+  })
+
+  it('passes resolved token colors to cytoscape', async () => {
+    document.documentElement.style.setProperty('--color-fg-1', 'rgb(1, 2, 3)')
+    document.documentElement.style.setProperty('--color-bg-2', 'rgb(4, 5, 6)')
+
+    const container = document.createElement('div')
+    render(h(CytoscapeFsm, { spec: baseSpec }), container)
+    await new Promise((r) => setTimeout(r, 10))
+
+    const cytoscape = (await import('cytoscape')).default
+    const options = cytoscape.mock.calls.at(-1)?.[0]
+    const nodeStyle = options.style.find((block) => block.selector === 'node').style
+    expect(nodeStyle.color).toBe('rgb(1, 2, 3)')
+    expect(nodeStyle['background-color']).toBe('rgb(4, 5, 6)')
+    expect(nodeStyle['border-color']).toBe('#4a4137')
+  })
+
+  it('refreshes stylesheet when root theme attributes change', async () => {
+    const container = document.createElement('div')
+    render(h(CytoscapeFsm, { spec: baseSpec }), container)
+    await new Promise((r) => setTimeout(r, 10))
+
+    document.documentElement.setAttribute('data-theme', 'high-contrast')
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(mockCyInstance.style).toHaveBeenCalled()
+    expect(mockStyleApi.fromJson).toHaveBeenCalled()
+    expect(mockStyleApi.update).toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -68,8 +68,8 @@ function resolveCssVar(token: string): string {
 }
 
 // Color palette using Cockpit Design System tokens. Values are resolved
-// lazily inside buildStylesheet so that token changes (theme switch)
-// propagate on next render.
+// when building the Cytoscape stylesheet because Cytoscape does not
+// accept `var(...)` color strings.
 const NODE_COLOR_TOKENS: Record<FsmNode['type'], { bg: string; border: string; text: string }> = {
   state:    { bg: '--color-bg-2', border: '--color-line-3', text: '--color-fg-1' },
   active:   { bg: '--color-bg-2', border: '--color-status-ok', text: '--color-fg-1' },
@@ -329,6 +329,29 @@ export function CytoscapeFsm({ spec, height = '280px', class: className = '' }: 
       }
     }
   }, []) // mount only
+
+  // Cytoscape keeps resolved literal colors after initialization, so
+  // refresh the stylesheet when root theme/token attributes change.
+  useEffect(() => {
+    if (typeof document === 'undefined' || typeof MutationObserver === 'undefined') {
+      return undefined
+    }
+
+    const refreshStylesheet = () => {
+      const cy = cyRef.current
+      if (!cy) return
+      cy.style()
+        .fromJson(buildStylesheet() as cytoscape.StylesheetJsonBlock[])
+        .update()
+    }
+
+    const observer = new MutationObserver(refreshStylesheet)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme', 'style'],
+    })
+    return () => observer.disconnect()
+  }, [])
 
   // Update elements when spec changes (without full re-init)
   useEffect(() => {

--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -55,16 +55,25 @@ const TOKEN_FALLBACKS: Record<string, string> = {
   '--color-brass-1': '#d4a14a',
 }
 
-function resolveCssVar(token: string): string {
-  // token may be the bare name "--frost-100" or a "var(--frost-100)" wrapper.
-  const m = token.match(/^var\((--[a-z0-9-]+)\)$/i)
-  const name = m ? m[1] : token.startsWith('--') ? token : null
-  if (!name) return token
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return TOKEN_FALLBACKS[name] ?? token
+function createCssVarResolver(): (token: string) => string {
+  const computedStyle =
+    typeof window === 'undefined' || typeof document === 'undefined'
+      ? null
+      : getComputedStyle(document.documentElement)
+  const cache = new Map<string, string>()
+
+  return (token: string): string => {
+    // token may be the bare name "--frost-100" or a "var(--frost-100)" wrapper.
+    const m = token.match(/^var\((--[a-z0-9-]+)\)$/i)
+    const name = m ? m[1] : token.startsWith('--') ? token : null
+    if (!name) return token
+    const cached = cache.get(name)
+    if (cached !== undefined) return cached
+    const v = computedStyle?.getPropertyValue(name).trim()
+    const resolved = v || TOKEN_FALLBACKS[name] || token
+    cache.set(name, resolved)
+    return resolved
   }
-  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
-  return v || TOKEN_FALLBACKS[name] || token
 }
 
 // Color palette using Cockpit Design System tokens. Values are resolved
@@ -157,6 +166,7 @@ function nodeHeight(ele: { data: (key: string) => unknown }): number {
 }
 
 function buildStylesheet() {
+  const resolveCssVar = createCssVarResolver()
   const styles: Array<{ selector: string; style: Record<string, unknown> }> = [
     {
       selector: 'node',

--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -32,17 +32,27 @@ export interface FsmGraphSpec {
 // Cytoscape's style parser does not resolve CSS variables — `var(--x)`
 // strings are rejected. Resolve once per render against `:root` and
 // pass literal hex/rgb values into the stylesheet.
+// Fallback values mirror the Cockpit Design System defaults from
+// tokens.generated.css so SSR / missing-CSS degrades gracefully.
 const TOKEN_FALLBACKS: Record<string, string> = {
-  '--slate-800': '#1e293b',
-  '--slate-600': '#475569',
-  '--slate-500': '#64748b',
-  '--slate-400': '#94a3b8',
-  '--frost-100': '#e2e8f0',
-  '--emerald': '#22c55e',
-  '--amber-bright': '#f59e0b',
-  '--color-status-err': '#ef4444',
-  '--white-pure': '#ffffff',
-  '--panel-dark': '#0f172a',
+  '--color-bg-0': '#0c0b08',
+  '--color-bg-1': '#141210',
+  '--color-bg-2': '#1a1815',
+  '--color-bg-3': '#211e1a',
+  '--color-bg-4': '#2a2621',
+  '--color-line-1': '#2a2520',
+  '--color-line-2': '#3a332c',
+  '--color-line-3': '#4a4137',
+  '--color-fg-1': '#f0e9dc',
+  '--color-fg-2': '#b8ad9a',
+  '--color-fg-3': '#7a7065',
+  '--color-fg-4': '#4a453e',
+  '--color-status-ok': '#6b9e6b',
+  '--color-status-err': '#c46a5a',
+  '--color-status-warn': '#c9a24a',
+  '--color-status-info': '#6a8eb0',
+  '--color-status-idle': '#6a6a6a',
+  '--color-brass-1': '#d4a14a',
 }
 
 function resolveCssVar(token: string): string {
@@ -57,27 +67,27 @@ function resolveCssVar(token: string): string {
   return v || TOKEN_FALLBACKS[name] || token
 }
 
-// Color palette matching dashboard dark theme. Values are resolved
-// lazily inside buildStylesheet/buildNodeColors so that token changes
-// (theme switch) propagate on next render.
+// Color palette using Cockpit Design System tokens. Values are resolved
+// lazily inside buildStylesheet so that token changes (theme switch)
+// propagate on next render.
 const NODE_COLOR_TOKENS: Record<FsmNode['type'], { bg: string; border: string; text: string }> = {
-  state:    { bg: '--slate-800', border: '--slate-600', text: '--frost-100' },
-  active:   { bg: '#065f46',     border: '--emerald',   text: '--white-pure' },
-  buffer:   { bg: '#78350f',     border: '--amber-bright', text: '--white-pure' },
-  terminal: { bg: '#7f1d1d',     border: '--color-status-err', text: '--white-pure' },
-  start:    { bg: '--slate-800', border: '#6366f1',     text: '#c7d2fe' },
-  end:      { bg: '--slate-800', border: '#6b7280',     text: '#9ca3af' },
-  ok:       { bg: '#065f46',     border: '--emerald',   text: '--white-pure' },
-  warn:     { bg: '#78350f',     border: '--amber-bright', text: '--white-pure' },
-  err:      { bg: '#7f1d1d',     border: '--color-status-err', text: '--white-pure' },
-  dim:      { bg: '--slate-800', border: '#374151',     text: '#6b7280' },
+  state:    { bg: '--color-bg-2', border: '--color-line-3', text: '--color-fg-1' },
+  active:   { bg: '--color-bg-2', border: '--color-status-ok', text: '--color-fg-1' },
+  buffer:   { bg: '--color-bg-2', border: '--color-status-warn', text: '--color-fg-1' },
+  terminal: { bg: '--color-bg-2', border: '--color-status-err', text: '--color-fg-1' },
+  start:    { bg: '--color-bg-2', border: '--color-status-info', text: '--color-fg-1' },
+  end:      { bg: '--color-bg-2', border: '--color-status-idle', text: '--color-fg-3' },
+  ok:       { bg: '--color-bg-2', border: '--color-status-ok', text: '--color-fg-1' },
+  warn:     { bg: '--color-bg-2', border: '--color-status-warn', text: '--color-fg-1' },
+  err:      { bg: '--color-bg-2', border: '--color-status-err', text: '--color-fg-1' },
+  dim:      { bg: '--color-bg-2', border: '--color-line-1', text: '--color-fg-3' },
 }
 
 const EDGE_COLOR_TOKENS: Record<string, string> = {
-  normal: '--slate-500',
+  normal: '--color-fg-3',
   error: '--color-status-err',
-  recovery: '--emerald',
-  cascade: '--amber-bright',
+  recovery: '--color-status-ok',
+  cascade: '--color-status-warn',
 }
 
 interface CytoscapeFsmProps {
@@ -156,10 +166,10 @@ function buildStylesheet() {
         'text-halign': 'center',
         'font-size': '11px',
         'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-        color: resolveCssVar('--frost-100'),
-        'background-color': resolveCssVar('--slate-800'),
+        color: resolveCssVar('--color-fg-1'),
+        'background-color': resolveCssVar('--color-bg-2'),
         'border-width': 2,
-        'border-color': resolveCssVar('--slate-600'),
+        'border-color': resolveCssVar('--color-line-3'),
         shape: 'roundrectangle',
         width: nodeWidth,
         height: nodeHeight,
@@ -173,16 +183,16 @@ function buildStylesheet() {
       style: {
         'curve-style': 'bezier',
         'target-arrow-shape': 'triangle',
-        'target-arrow-color': resolveCssVar('--slate-500'),
-        'line-color': resolveCssVar('--slate-500'),
+        'target-arrow-color': resolveCssVar('--color-fg-3'),
+        'line-color': resolveCssVar('--color-fg-3'),
         width: 1.5,
         label: 'data(label)',
         'font-size': '9px',
         'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-        color: resolveCssVar('--slate-400'),
+        color: resolveCssVar('--color-fg-3'),
         'text-rotation': 'autorotate',
         'text-margin-y': -8,
-        'text-background-color': resolveCssVar('--panel-dark'),
+        'text-background-color': resolveCssVar('--color-bg-0'),
         'text-background-opacity': 0.85,
         'text-background-padding': '2px',
         'text-background-shape': 'roundrectangle',
@@ -191,15 +201,15 @@ function buildStylesheet() {
     {
       selector: ':parent',
       style: {
-        'background-color': resolveCssVar('--panel-dark'),
-        'border-color': '#334155',
+        'background-color': resolveCssVar('--color-bg-1'),
+        'border-color': resolveCssVar('--color-line-2'),
         'border-width': 1,
         'border-style': 'dashed',
         'text-valign': 'top',
         'text-halign': 'center',
         padding: '16px',
         'font-size': '10px',
-        color: resolveCssVar('--slate-500'),
+        color: resolveCssVar('--color-fg-3'),
       },
     },
   ]
@@ -223,7 +233,7 @@ function buildStylesheet() {
     selector: 'node[nodeType="active"]',
     style: {
       'border-width': 4,
-      'overlay-color': resolveCssVar('--emerald'),
+      'overlay-color': resolveCssVar('--color-status-ok'),
       'overlay-opacity': 0.18,
       'overlay-padding': 6,
     },

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -45,23 +45,24 @@ function yjsWebsocketUrl(): string | null {
 /** Cached CSS custom property resolver for Canvas 2D. Invalidated on theme change. */
 const cssVarCache = new Map<string, string>()
 
-function cssVar(prop: string, fallback: string): string {
-  if (typeof window === 'undefined') return fallback
+function cssVar(prop: string): string {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return 'CanvasText'
   const cached = cssVarCache.get(prop)
   if (cached !== undefined) return cached
-  const value = getComputedStyle(document.documentElement).getPropertyValue(prop).trim() || fallback
+  const value = getComputedStyle(document.documentElement).getPropertyValue(prop).trim()
+  if (!value) {
+    console.warn(`WorldVisualizer missing CSS token ${prop}; using CanvasText fallback`)
+    cssVarCache.set(prop, 'CanvasText')
+    return 'CanvasText'
+  }
   cssVarCache.set(prop, value)
   return value
-}
-
-if (typeof window !== 'undefined' && typeof MutationObserver !== 'undefined') {
-  new MutationObserver(() => { cssVarCache.clear() })
-    .observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'class'] })
 }
 
 export function WorldVisualizer() {
   const [keepers, setKeepers] = useState<KeeperState[]>([])
   const [traces, setTraces] = useState<Trace[]>([])
+  const [paletteVersion, setPaletteVersion] = useState(0)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const providerRef = useRef<WebsocketProvider | null>(null)
 
@@ -104,16 +105,34 @@ export function WorldVisualizer() {
   }, [])
 
   useEffect(() => {
+    if (typeof document === 'undefined' || typeof MutationObserver === 'undefined') {
+      return undefined
+    }
+
+    const refreshPalette = () => {
+      cssVarCache.clear()
+      setPaletteVersion(version => version + 1)
+    }
+
+    const observer = new MutationObserver(refreshPalette)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme', 'style'],
+    })
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
     // Resolve design tokens for canvas rendering (Cockpit SPEC compliance)
-    const activeColor = cssVar('--color-status-ok', '#6b9e6b')
-    const pausedColor = cssVar('--color-status-err', '#c46a5a')
-    const traceColor = cssVar('--agent-working', '#7ae09a')
-    const textColor = cssVar('--fg-1', '#f0e9dc')
+    const activeColor = cssVar('--color-status-ok')
+    const pausedColor = cssVar('--color-status-err')
+    const traceColor = cssVar('--agent-working')
+    const textColor = cssVar('--fg-1')
 
     // Clear canvas
     ctx.clearRect(0, 0, canvas.width, canvas.height)
@@ -162,7 +181,7 @@ export function WorldVisualizer() {
         ctx.globalAlpha = 1.0
       })
     })
-  }, [keepers, traces])
+  }, [keepers, traces, paletteVersion])
 
   return html`
     <div style=${{ padding: '20px', background: 'var(--bg-0)', color: 'var(--fg-1)', borderRadius: '8px', marginBottom: '20px' }}>

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -76,7 +76,7 @@ export function WorldVisualizer() {
     try {
       provider = new WebsocketProvider(url, 'masc-telemetry', ydoc)
     } catch (err) {
-      console.warn('[world-visualizer] WebSocket init failed:', err instanceof Error ? err.message : err)
+      console.warn('[world-visualizer] WebSocket init failed:', err)
       ydoc.destroy()
       return
     }

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -42,6 +42,12 @@ function yjsWebsocketUrl(): string | null {
   )
 }
 
+/** Resolve a CSS custom property for Canvas 2D fillStyle/strokeStyle. */
+function cssVar(prop: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback
+  return getComputedStyle(document.documentElement).getPropertyValue(prop).trim() || fallback
+}
+
 export function WorldVisualizer() {
   const [keepers, setKeepers] = useState<KeeperState[]>([])
   const [traces, setTraces] = useState<Trace[]>([])
@@ -91,9 +97,15 @@ export function WorldVisualizer() {
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
+    // Resolve design tokens for canvas rendering (Cockpit SPEC compliance)
+    const activeColor = cssVar('--color-status-ok', '#6b9e6b')
+    const pausedColor = cssVar('--color-status-err', '#c46a5a')
+    const traceColor = cssVar('--agent-working', '#7ae09a')
+    const textColor = cssVar('--fg-1', '#f0e9dc')
+
     // Clear canvas
     ctx.clearRect(0, 0, canvas.width, canvas.height)
-    
+
     const centerX = canvas.width / 2
     const centerY = canvas.height / 2
 
@@ -103,8 +115,10 @@ export function WorldVisualizer() {
       const x = centerX + Math.cos(trace.position) * (trace.position % 100)
       const y = centerY + Math.sin(trace.position) * (trace.position % 100)
       ctx.arc(x, y, 3, 0, 2 * Math.PI)
-      ctx.fillStyle = 'rgba(0, 255, 128, 0.4)'
+      ctx.globalAlpha = 0.4
+      ctx.fillStyle = traceColor
       ctx.fill()
+      ctx.globalAlpha = 1.0
     })
 
     // Draw Keepers
@@ -115,18 +129,14 @@ export function WorldVisualizer() {
       const x = centerX + Math.cos(angle) * radius
       const y = centerY + Math.sin(angle) * radius
 
-      if (keeper.state === 'active') {
-        ctx.fillStyle = '#00FF00'
-      } else {
-        ctx.fillStyle = '#FF0000'
-      }
+      ctx.fillStyle = keeper.state === 'active' ? activeColor : pausedColor
 
       ctx.arc(x, y, 8, 0, 2 * Math.PI)
       ctx.fill()
-      ctx.fillStyle = '#FFF'
+      ctx.fillStyle = textColor
       ctx.font = '10px monospace'
       ctx.fillText(keeper.name, x + 12, y + 4)
-      
+
       // Local Sight lines
       traces.slice(-6).forEach(trace => {
         const tx = centerX + Math.cos(trace.position) * (trace.position % 100)
@@ -134,21 +144,23 @@ export function WorldVisualizer() {
         ctx.beginPath()
         ctx.moveTo(x, y)
         ctx.lineTo(tx, ty)
-        ctx.strokeStyle = 'rgba(0, 255, 128, 0.1)'
+        ctx.globalAlpha = 0.1
+        ctx.strokeStyle = traceColor
         ctx.stroke()
+        ctx.globalAlpha = 1.0
       })
     })
   }, [keepers, traces])
 
   return html`
-    <div style=${{ padding: '20px', background: '#111', color: '#FFF', borderRadius: '8px', marginBottom: '20px' }}>
+    <div style=${{ padding: '20px', background: 'var(--bg-0)', color: 'var(--fg-1)', borderRadius: '8px', marginBottom: '20px' }}>
       <h2 style=${{ margin: 0, paddingBottom: '10px' }}>Dream IDE: 7 Physical Laws Visualization</h2>
-      <p style=${{ fontSize: '12px', color: '#AAA' }}>Stigmergy Intensity • Local Sight (Max 6) • Active Inference</p>
-      <canvas 
-        ref=${canvasRef} 
-        width=${800} 
-        height=${300} 
-        style=${{ border: '1px solid #333', background: '#000', display: 'block', margin: '0 auto' }} 
+      <p style=${{ fontSize: '12px', color: 'var(--fg-3)' }}>Stigmergy Intensity · Local Sight (Max 6) · Active Inference</p>
+      <canvas
+        ref=${canvasRef}
+        width=${800}
+        height=${300}
+        style=${{ border: '1px solid var(--line-1)', background: 'var(--bg-0)', display: 'block', margin: '0 auto' }}
       />
     </div>
   `

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -42,10 +42,21 @@ function yjsWebsocketUrl(): string | null {
   )
 }
 
-/** Resolve a CSS custom property for Canvas 2D fillStyle/strokeStyle. */
+/** Cached CSS custom property resolver for Canvas 2D. Invalidated on theme change. */
+const cssVarCache = new Map<string, string>()
+
 function cssVar(prop: string, fallback: string): string {
   if (typeof window === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(prop).trim() || fallback
+  const cached = cssVarCache.get(prop)
+  if (cached !== undefined) return cached
+  const value = getComputedStyle(document.documentElement).getPropertyValue(prop).trim() || fallback
+  cssVarCache.set(prop, value)
+  return value
+}
+
+if (typeof window !== 'undefined' && typeof MutationObserver !== 'undefined') {
+  new MutationObserver(() => { cssVarCache.clear() })
+    .observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'class'] })
 }
 
 export function WorldVisualizer() {
@@ -63,7 +74,8 @@ export function WorldVisualizer() {
     let provider: WebsocketProvider
     try {
       provider = new WebsocketProvider(url, 'masc-telemetry', ydoc)
-    } catch {
+    } catch (err) {
+      console.warn('[world-visualizer] WebSocket init failed:', err instanceof Error ? err.message : err)
       ydoc.destroy()
       return
     }

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -76,7 +76,7 @@ export function WorldVisualizer() {
     try {
       provider = new WebsocketProvider(url, 'masc-telemetry', ydoc)
     } catch (err) {
-      console.warn('[world-visualizer] WebSocket init failed:', err)
+      console.warn('[world-visualizer] WebSocket init failed:', { url, err })
       ydoc.destroy()
       return
     }


### PR DESCRIPTION
## Summary
- Replace hardcoded hex/rgba colors in `world-visualizer.ts` with Cockpit Design System tokens via `cssVar()` helper
- Replace hardcoded colors in `cytoscape-fsm.ts` with design tokens via `resolveCssVar()` + `TOKEN_FALLBACKS` map
- Canvas 2D and Cytoscape.js do not support CSS `var()` — runtime resolution via `getComputedStyle()` required

## Changes

### world-visualizer.ts (6 hex + 2 rgba → 7 tokens)
- `cssVar()` helper resolves CSS custom properties with fallback for Canvas 2D `fillStyle`/`strokeStyle`
- `--color-status-ok`, `--color-status-err`, `--agent-working`, `--fg-1`, `--fg-3`, `--bg-0`, `--line-1`
- Transparency via `ctx.globalAlpha` instead of hardcoded rgba

### cytoscape-fsm.ts (20 hardcoded colors → 19 tokens)
- `TOKEN_FALLBACKS` map: 19 Cockpit tokens with `#hex` fallbacks
- `NODE_COLOR_TOKENS` record: per-node-type `{bg, border, text}` token references
- `EDGE_COLOR_TOKENS` record: per-edge-type token references
- `buildStylesheet()` resolves all tokens at render time

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [ ] Visual: WorldVisualizer renders with theme colors
- [ ] Visual: FSM graph renders with theme colors
- [ ] Theme switch: colors update on dark/light toggle