### PR TITLE
feat(ide): deeply hydrate Ticker and Rail with live telemetry

### DIFF
--- a/dashboard/public/cockpit/MASC Cockpit (Full).html
+++ b/dashboard/public/cockpit/MASC Cockpit (Full).html
@@ -40,6 +40,22 @@
         status: g.status,
         progress: 0
       }));
+      // Phase 19: Deep Data Hydration
+      window.MASC_DATA.tasks = live.tasks.map(t => ({
+        id: t.task_id,
+        keeper: t.assignee || '-',
+        title: t.title,
+        status: t.status,
+        goal: t.goal_id || '-',
+        t: 'now'
+      }));
+      window.MASC_DATA.events = live.events.map(e => ({
+        t: new Date(e.timestamp).toLocaleTimeString(),
+        keeper: e.agent,
+        kind: e.kind || 'note',
+        text: e.text
+      }));
+      
       // trigger rerender event
       window.dispatchEvent(new Event('masc_data_updated'));
     }


### PR DESCRIPTION
## Description
Completes Phase 19: Deep Data Hydration for the Cockpit Components.

- Previously, only `keepers` and `goals` were hydrated from the live MASC server telemetry.
- Expanded the `MASC_HYDRATION` listener in `MASC Cockpit (Full).html` to also map `tasks` and `events`.
- The Ticker, Swimlanes, Deck, and Rail components now render live execution tasks and runtime events instead of static mock data.

This brings the High-Fidelity UI fully online with the actual MASC server operations.