### PR TITLE
fix(dashboard): restore dev yjs proxy fallback

### DIFF
--- a/dashboard/src/components/world-visualizer.test.ts
+++ b/dashboard/src/components/world-visualizer.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { resolveYjsWebsocketUrl } from './world-visualizer'
+
+describe('resolveYjsWebsocketUrl', () => {
+  it('uses an explicitly configured URL', () => {
+    expect(resolveYjsWebsocketUrl(' ws://127.0.0.1:8935/yjs ', true, {
+      host: 'localhost:5173',
+      protocol: 'http:',
+    })).toBe('ws://127.0.0.1:8935/yjs')
+  })
+
+  it('falls back to the same-origin /yjs proxy in dev', () => {
+    expect(resolveYjsWebsocketUrl(undefined, true, {
+      host: 'localhost:5173',
+      protocol: 'http:',
+    })).toBe('ws://localhost:5173/yjs')
+  })
+
+  it('uses wss for https dev origins', () => {
+    expect(resolveYjsWebsocketUrl(undefined, true, {
+      host: 'dashboard.local',
+      protocol: 'https:',
+    })).toBe('wss://dashboard.local/yjs')
+  })
+
+  it('stays quiet outside dev without an explicit URL', () => {
+    expect(resolveYjsWebsocketUrl(undefined, false, {
+      host: 'dashboard.example',
+      protocol: 'https:',
+    })).toBeNull()
+  })
+})

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -18,10 +18,28 @@ interface Trace {
   position: number
 }
 
+type YjsLocation = Pick<Location, 'host' | 'protocol'>
+
+export function resolveYjsWebsocketUrl(
+  configuredUrl: string | undefined,
+  dev: boolean,
+  location: YjsLocation | null,
+): string | null {
+  const configured = configuredUrl?.trim()
+  if (configured) return configured
+  if (!dev || !location?.host) return null
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${location.host}/yjs`
+}
+
 function yjsWebsocketUrl(): string | null {
   if (runningUnderVitest()) return null
-  const configured = import.meta.env?.VITE_MASC_YJS_WS_URL?.trim()
-  return configured || null
+  const location = typeof window === 'undefined' ? null : window.location
+  return resolveYjsWebsocketUrl(
+    import.meta.env?.VITE_MASC_YJS_WS_URL,
+    import.meta.env?.DEV === true,
+    location,
+  )
 }
 
 export function WorldVisualizer() {


### PR DESCRIPTION
## Summary

- restore the dashboard dev same-origin `/yjs` proxy fallback while keeping production quiet without `VITE_MASC_YJS_WS_URL`
- add a resolver regression test for explicit URL, dev proxy fallback, https `wss`, and production no-op behavior

Follow-up for the unresolved #12746 Copilot review thread on `dashboard/src/components/world-visualizer.ts`.

## Verification

- `pnpm exec vitest run --config vitest.config.ts src/components/world-visualizer.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `pnpm build`
