### PR TITLE
fix(keeper): emit FSM action label in transition telemetry (#12751)

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -191,17 +191,28 @@ let emit_transition ~keeper_name ~turn_id ?prev state =
     | Some s -> turn_state_label s
     | None -> "-"
   in
+  let classified =
+    match prev with
+    | Some from_state -> classify_transition ~from_state ~to_state:state
+    | None -> None
+  in
   (match prev with
    | Some from_state ->
        guard_transition ~keeper_name ~turn_id ~from_state ~to_state:state
    | None -> ());
   let state_label = turn_state_label state in
+  let action_label =
+    match classified with
+    | Some action -> transition_action_label action
+    | None -> "unknown"
+  in
   Log.Keeper.info ~keeper_name ~turn_id
-    "[fsm:transition] %s -> %s" prev_label state_label;
+    "[fsm:transition] %s -> %s action=%s" prev_label state_label action_label;
   Prometheus.inc_counter Prometheus.metric_keeper_turn_fsm_transitions
     ~labels:
       [ ("from", prev_label);
         ("to", state_label);
+        ("action", action_label);
         ("keeper", keeper_name);
       ]
     ()


### PR DESCRIPTION
## Summary

- Add `classify_transition` result as `action` label to `emit_transition` in `keeper_turn_fsm.ml`
- `Phase_gating → Done` was already classified as `PhaseGateSkip` by `classify_transition`, but the action name was never surfaced in logs or Prometheus — only `from`/`to` state labels were emitted
- This change makes all 16 FSM transition actions observable by name in Prometheus queries (`masc_keeper_turn_fsm_transitions_total{action="PhaseGateSkip"}`) and structured logs

## Test plan

- [x] `dune build --root=.` passes
- [x] `test_keeper_turn_fsm_emit` — 6/6 tests pass (signature anchor + label coverage unchanged)
- [x] Existing `test_transition_actions_cover_tla_next` already pins `PhaseGateSkip` classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)