### PR TITLE
feat(keeper): add cascade health check before auto-pause (task-136)

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -387,6 +387,24 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  "%s: stale watchdog terminating fiber (%s) [cascade=%s window_count=%d/6h]"
                  meta.name reason_desc meta.cascade_name window_count;
                if window_count >= escalation_threshold then begin
+                 let cascade_recovered () =
+                   match ctx.net with
+                   | None -> false
+                   | Some net ->
+                       (match Cascade_catalog_runtime.resolve_named_providers_strict
+                                ~sw:ctx.sw ~net ~cascade_name:meta.cascade_name () with
+                        | Error _ -> false
+                        | Ok candidates ->
+                            (match Cascade_health_filter.filter_healthy_strict ~sw:ctx.sw ~net candidates with
+                             | Error _ -> false
+                             | Ok healthy ->
+                                 List.exists (fun (p : Llm_provider.Provider_config.t) ->
+                                   Result.is_ok (Cascade_health_tracker.check_circuit_breaker Cascade_health_tracker.global ~provider_key:p.model_id)
+                                 ) healthy))
+                 in
+                 if cascade_recovered () then
+                   Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name meta.cascade_name
+                 else begin
                  Prometheus.inc_counter
                    "masc_keeper_stale_termination_threshold_breached_total"
                    ~labels:[ ("keeper", meta.name) ]
@@ -412,6 +430,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                     See issue #10765."
                    meta.name window_count termination_window_sec
                    escalation_threshold
+               end
                end;
                (* #10765 phase 2: fleet batch detection.  See module-level
                   comment on [batch_terminations] for rationale. *)

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -395,12 +395,29 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                                 ~sw:ctx.sw ~net ~cascade_name:meta.cascade_name () with
                         | Error _ -> false
                         | Ok candidates ->
-                            (match Cascade_health_filter.filter_healthy_strict ~sw:ctx.sw ~net candidates with
-                             | Error _ -> false
-                             | Ok healthy ->
-                                 List.exists (fun (p : Llm_provider.Provider_config.t) ->
-                                   Result.is_ok (Cascade_health_tracker.check_circuit_breaker Cascade_health_tracker.global ~provider_key:p.model_id)
-                                 ) healthy))
+                            let healthy =
+                              Cascade_health_filter.filter_healthy ~sw:ctx.sw
+                                ~net candidates
+                            in
+                            let has_recovery_evidence
+                                (p : Llm_provider.Provider_config.t) =
+                              let provider_key = p.model_id in
+                              match
+                                Cascade_health_tracker.provider_info
+                                  Cascade_health_tracker.global
+                                  ~provider_key
+                              with
+                              | None -> false
+                              | Some info ->
+                                  info.events_in_window > 0
+                                  && info.success_rate > 0.0
+                                  && (not info.in_cooldown)
+                                  && Result.is_ok
+                                       (Cascade_health_tracker.check_circuit_breaker
+                                          Cascade_health_tracker.global
+                                          ~provider_key)
+                            in
+                            List.exists has_recovery_evidence healthy)
                  in
                  if cascade_recovered () then
                    Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name meta.cascade_name


### PR DESCRIPTION
Resolves task-136 and addresses Issue #12661 Phase 2.

### Changes:
- Added a `cascade_recovered` check in `keeper_stale_watchdog.ml` before escalating a stale termination storm to an auto-pause.
- The check uses `Cascade_catalog_runtime.resolve_named_providers_strict` and `Cascade_health_filter.filter_healthy_strict` to get candidate providers, then checks if at least one provider is healthy according to `Cascade_health_tracker.check_circuit_breaker`.
- If the cascade has recovered, it logs an info message and skips the auto-pause, allowing the supervisor to restart the keeper normally.

### Rationale:
This provides cascade-awareness to the pause mechanism. If a transient provider outage caused the keeper to stall and die repeatedly, but the provider is now healthy again, we shouldn't auto-pause the keeper (which requires human intervention to unpause). Instead, we skip the auto-pause so the supervisor can successfully restart it.