### PR TITLE
refactor: remove emojis + replace Base.* with Stdlib (Phase 2)

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -334,7 +334,7 @@ type archetype =
   | Melchior   (** 🔬 Scientist - technical analysis, implementation *)
   | Balthasar  (** 🪞 Mirror - ethics, value alignment, review *)
   | Casper     (** ♟️ Strategist - planning, coordination *)
-  | Athena     (** 🧠 Reasoner - logic, math, deep thinking *)
+  | Athena     (** Reasoner - logic, math, deep thinking *)
   | Generalist (** 🌐 No specialization *)
 
 let archetype_to_string = function

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -248,7 +248,7 @@ let extract_nickname (response_text : string) : string option =
     | [] -> None
     | line :: rest ->
         let trimmed = String.trim line in
-        if Base.String.is_prefix trimmed ~prefix
+        if String.starts_with trimmed ~prefix
         then
           Some
             (String.trim

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -120,7 +120,7 @@ module FileSystem = struct
               Error (InvalidKey "Consecutive colons not allowed")
             else if seg = "." || seg = ".." then
               Error (InvalidKey "Path traversal detected")
-            else if Base.String.is_prefix seg ~prefix:".." then
+            else if String.starts_with seg ~prefix:".." then
               Error (InvalidKey "Path traversal detected")
             else
               (* Blocklist: reject only dangerous characters, allow UTF-8 *)
@@ -197,7 +197,7 @@ module FileSystem = struct
   let _decompress = Compression.decompress_auto
 
   let has_zstd_header content =
-    Base.String.is_prefix content ~prefix:"ZSTD"
+    String.starts_with content ~prefix:"ZSTD"
 
   let decompress_with_context ~context content =
     let had_header = has_zstd_header content in
@@ -810,7 +810,7 @@ module Memory = struct
   let list_keys t ~prefix =
     with_lock t (fun () ->
       let keys = Hashtbl.fold (fun k _ acc ->
-        if Base.String.is_prefix k ~prefix then
+        if String.starts_with k ~prefix then
           k :: acc
         else acc
       ) t.data [] in

--- a/lib/backend/backend_compression.ml
+++ b/lib/backend/backend_compression.ml
@@ -51,7 +51,7 @@ let encode_with_header ~(used_dict : bool) (orig_size : int) (compressed : strin
 let decode_header (data : string) : (int * string * bool) option =
   if String.length data < 8 then None
   (* Check dictionary header FIRST (ZSTDD) *)
-  else if Base.String.is_prefix data ~prefix:magic_dict then begin
+  else if String.starts_with data ~prefix:magic_dict then begin
     (* Dictionary header: ZSTDD *)
     let orig_size =
       (Char.code data.[5] lsl 24) lor

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -151,7 +151,7 @@ let discover_profiles = function
       fields
       |> List.filter_map (fun (key, value) ->
              match value with
-             | `List _ when Base.String.is_suffix ~suffix:"_models" key ->
+             | `List _ when String.ends_with ~suffix:"_models" key ->
                  let suffix_len = String.length "_models" in
                  let profile =
                    String.sub key 0 (String.length key - suffix_len)

--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -69,10 +69,10 @@ let register_capabilities config ~agent_name ~capabilities =
 
           Printf.sprintf "📡 %s capabilities: %s" actual_name (String.concat ", " capabilities)
       | Error _ ->
-          Printf.sprintf "⚠ Invalid agent file for %s" actual_name
+          Printf.sprintf "Invalid agent file for %s" actual_name
     )
   end else
-    Printf.sprintf "⚠ Agent %s not found. Join first!" agent_name
+    Printf.sprintf "Agent %s not found. Join first!" agent_name
 
 (** Update agent metadata (status/capabilities).
     Since #4638 agent metadata always lives under the root agents_dir. *)
@@ -139,7 +139,7 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
                               ("capabilities", `List (List.map (fun s -> `String s) updated_caps));
                               ("ts", `String (now_iso ()));
                             ]);
-                            Ok (Printf.sprintf "✅ %s updated" actual_name)
+                            Ok (Printf.sprintf "%s updated" actual_name)
                        ))
             )
           in

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -25,13 +25,13 @@ let heartbeat config ~agent_name =
       | Ok agent ->
           let updated = { agent with last_seen = now_iso () } in
           write_json config agent_file (agent_to_yojson updated);
-          Printf.sprintf "💓 %s heartbeat updated" actual_name
+          Printf.sprintf "%s heartbeat updated" actual_name
       | Error e ->
           Log.Coord.debug "heartbeat: invalid agent JSON for %s: %s" actual_name e;
-          Printf.sprintf "⚠ Invalid agent file for %s" actual_name
+          Printf.sprintf "Invalid agent file for %s" actual_name
     )
   end else
-    Printf.sprintf "⚠ Agent %s not found" agent_name
+    Printf.sprintf "Agent %s not found" agent_name
 
 (** Cleanup zombie agents - removes stale agents.
     [keeper_threshold_sec] and [agent_threshold_sec] control the inactivity
@@ -48,7 +48,7 @@ let cleanup_zombies
     if Sys.file_exists agents_path then [ agents_path ] else []
   in
   if scan_paths = [] then
-    "📋 No agents directory"
+    "No agents directory"
   else begin
     (* Phase 1: Detect zombie agents (no side effects) *)
     let zombie_entries = ref [] in (* (name, path) list *)
@@ -99,7 +99,7 @@ let cleanup_zombies
     ) scan_paths;
 
     if !zombie_entries = [] then
-      "✅ No zombie agents found"
+      "No zombie agents found"
     else begin
       (* Phase 2: Transition status to Inactive + stop heartbeats + stop keeper fibers.
          Note: If later phases fail (task release or file deletion), the agent
@@ -185,10 +185,10 @@ let cleanup_zombies
         else Printf.sprintf ", released %d orphan task(s)" (List.length !released_tasks)
       in
       if skipped > 0 then
-        Printf.sprintf "🧟 Cleaned %d/%d zombie(s): %s%s (⚠ %d skipped due to errors)"
+        Printf.sprintf "Cleaned %d/%d zombie(s): %s%s (%d skipped due to errors)"
           cleaned total (String.concat ", " !successfully_cleaned) task_note skipped
       else
-        Printf.sprintf "🧟 Cleaned up %d zombie agent(s): %s%s"
+        Printf.sprintf "Cleaned up %d zombie agent(s): %s%s"
           cleaned (String.concat ", " !successfully_cleaned) task_note
     end
   end
@@ -238,9 +238,9 @@ let gc config ?(days=7) () =
       version = backlog.version + 1;
     } in
     write_backlog config new_backlog;
-    results := Printf.sprintf "📦 Archived %d stale task(s) (older than %d days)" !stale_count days :: !results
+    results := Printf.sprintf "Archived %d stale task(s) (older than %d days)" !stale_count days :: !results
   end else
-    results := Printf.sprintf "✅ No stale tasks (threshold: %d days)" days :: !results;
+    results := Printf.sprintf "No stale tasks (threshold: %d days)" days :: !results;
 
   (* 3. Cleanup old messages - but preserve messages referencing open tasks *)
   let messages_path = messages_dir config in
@@ -295,21 +295,21 @@ let gc config ?(days=7) () =
 
   if !old_msg_count > 0 || !preserved_count > 0 then begin
     if !old_msg_count > 0 then
-      results := Printf.sprintf "🗑️ Deleted %d old message(s) (older than %d days)" !old_msg_count days :: !results;
+      results := Printf.sprintf "Deleted %d old message(s) (older than %d days)" !old_msg_count days :: !results;
     if !preserved_count > 0 then
-      results := Printf.sprintf "🔒 Preserved %d message(s) referencing open tasks" !preserved_count :: !results
+      results := Printf.sprintf "Preserved %d message(s) referencing open tasks" !preserved_count :: !results
   end else
-    results := Printf.sprintf "✅ No old messages (threshold: %d days)" days :: !results;
+    results := Printf.sprintf "No old messages (threshold: %d days)" days :: !results;
 
   (* 4. Cleanup backend pubsub - no-op for filesystem backend *)
   let pubsub_cleanup_count = ref 0 in
   (match backend_cleanup_pubsub config ~days ~max_messages:10000 with
    | Ok count when count > 0 ->
        pubsub_cleanup_count := count;
-       results := Printf.sprintf "🗃️ Cleaned %d pubsub message(s) from backend" count :: !results
+       results := Printf.sprintf "Cleaned %d pubsub message(s) from backend" count :: !results
    | Ok _ -> ()  (* No messages to clean *)
    | Error e ->
-       results := Printf.sprintf "⚠️ Backend pubsub cleanup failed: %s" (Backend_types.show_error e) :: !results);
+       results := Printf.sprintf "Backend pubsub cleanup failed: %s" (Backend_types.show_error e) :: !results);
 
   (* 5. Cleanup orphan keeper sidecar files (.metrics.jsonl/.memory.jsonl without .json)
         and orphan date-split metrics directories (<name>/metrics/ without <name>.json) *)
@@ -373,9 +373,9 @@ let gc config ?(days=7) () =
     ) entries
   end;
   if !keeper_orphan_count > 0 then
-    results := Printf.sprintf "🧹 Removed %d orphan keeper sidecar file(s)" !keeper_orphan_count :: !results
+    results := Printf.sprintf "Removed %d orphan keeper sidecar file(s)" !keeper_orphan_count :: !results
   else
-    results := "✅ No orphan keeper files" :: !results;
+    results := "No orphan keeper files" :: !results;
 
   (* 6. Archive completed/interrupted team sessions older than N days *)
   let session_archive_count = ref 0 in
@@ -411,23 +411,23 @@ let gc config ?(days=7) () =
     )
   end;
   if !session_archive_count > 0 then
-    results := Printf.sprintf "📦 Archived %d completed/interrupted/cancelled team session(s)" !session_archive_count :: !results
+    results := Printf.sprintf "Archived %d completed/interrupted/cancelled team session(s)" !session_archive_count :: !results
   else
-    results := "✅ No team sessions to archive" :: !results;
+    results := "No team sessions to archive" :: !results;
 
   (* 7. Hard-delete board artifacts (via hooks) *)
   let board_artifact_count = (Atomic.get Coord_hooks.cleanup_board_artifacts_fn) () in
   if board_artifact_count > 0 then
     results :=
-      Printf.sprintf "🧽 Removed %d board artifact post(s)"
+      Printf.sprintf "Removed %d board artifact post(s)"
         board_artifact_count
       :: !results
   else
-    results := "✅ No board artifacts" :: !results;
+    results := "No board artifacts" :: !results;
 
   (* 9. Coord archival removed — rooms are flattened (#4638).
      Startup migration (migrate_room_to_flat) moves active room to root. *)
-  results := "✅ Rooms flattened (no room archival needed)" :: !results;
+  results := "Rooms flattened (no room archival needed)" :: !results;
 
   log_event config (`Assoc [
     ("type", `String "gc");

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -204,7 +204,7 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
 
         if Sys.file_exists worktree_path then
           Ok
-            (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
+            (Printf.sprintf "Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
                worktree_path branch_name worktree_path)
         else (
           (* Fetch origin first; never create from a silently stale remote ref.
@@ -245,7 +245,7 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
               if exit_code = 0 then
                 Ok
                   (Printf.sprintf
-                     "✅ Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work && gh pr create --draft"
+                     "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work && gh pr create --draft"
                      worktree_path branch_name note worktree_path)
               else Error (IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base)))
 
@@ -274,11 +274,11 @@ let remove ~base_path ~agent_name ~task_id : string masc_result =
             |> List.filter_map Fun.id
           in
           let msg =
-            Printf.sprintf "✅ Worktree removed: %s\n   Branch: %s" worktree_path branch_name
+            Printf.sprintf "Worktree removed: %s\n   Branch: %s" worktree_path branch_name
           in
           match warnings with
           | [] -> Ok msg
-          | ws -> Ok (msg ^ "\n   ⚠️  Warnings: " ^ String.concat "; " ws))
+          | ws -> Ok (msg ^ "\n    Warnings: " ^ String.concat "; " ws))
         else Error (IoError "Failed to remove worktree. It may have uncommitted changes.")
 
 (** List all worktrees in the repository *)

--- a/lib/coord/coord_identity.ml
+++ b/lib/coord/coord_identity.ml
@@ -47,7 +47,7 @@ let resolve_agent_name config agent_name =
       let prefix = agent_name ^ "-" in
       match Array.find_opt (fun f ->
         String.length f > String.length prefix &&
-        Base.String.is_prefix f ~prefix
+        String.starts_with f ~prefix
       ) files with
       | Some file -> String.sub file 0 (String.length file - 5)
       | None -> agent_name

--- a/lib/coord/coord_init.ml
+++ b/lib/coord/coord_init.ml
@@ -93,7 +93,7 @@ let init config ~agent_name =
     then (
       let backlog = { tasks = []; last_updated = now_iso (); version = 1 } in
       write_backlog config backlog);
-    let result = "✅ MASC room created!" in
+    let result = "MASC room created!" in
     (* Auto-join if agent specified — uses Coord_lifecycle.join via the caller *)
     match agent_name with
     | Some _name -> result (* Caller is responsible for joining after init *)
@@ -144,7 +144,7 @@ let resume config ~by =
 (** Reset room - delete .masc/ folder *)
 let reset config =
   if not (is_initialized config)
-  then "⚠ MASC not initialized. Nothing to reset."
+  then "MASC not initialized. Nothing to reset."
   else (
     (* Recursive delete *)
     let rec rm_rf path =
@@ -158,5 +158,5 @@ let reset config =
       else Sys.remove path
     in
     rm_rf (masc_dir config);
-    Printf.sprintf "🗑️ MASC room reset! (.masc/ deleted at %s)" config.base_path)
+    Printf.sprintf "MASC room reset! (.masc/ deleted at %s)" config.base_path)
 ;;

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -134,7 +134,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
          Log.Coord.warn
            "agent rejoin: invalid agent JSON for %s: %s | snapshot=%s"
            nickname e (Yojson.Safe.to_string snapshot));
-    Printf.sprintf "✅ %s already in the namespace (last_seen updated)" nickname
+    Printf.sprintf "%s already in the namespace (last_seen updated)" nickname
   end else begin
     (* Collect metadata *)
   let session_id = generate_session_id () in
@@ -198,7 +198,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
             `List (List.map (fun s -> `String s) capabilities) );
         ]);
 
-  Printf.sprintf "✅ %s joined\n  Nickname: %s\n  Type: %s\n  Session: %s"
+  Printf.sprintf "%s joined\n  Nickname: %s\n  Type: %s\n  Session: %s"
     nickname nickname agent_type session_id
   end
 
@@ -261,6 +261,6 @@ let leave config ~agent_name =
        Log.Coord.error "relation-materializer leave hook error: %s"
          (Printexc.to_string exn));
 
-    Printf.sprintf "✅ %s left the namespace" actual_name
+    Printf.sprintf "%s left the namespace" actual_name
   end else
-    Printf.sprintf "⚠ %s was not in the namespace" actual_name
+    Printf.sprintf "%s was not in the namespace" actual_name

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -60,7 +60,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
           |> List.find_opt (fun f ->
                Filename.check_suffix f ".json"
                && String.length f > String.length prefix
-               && Base.String.is_prefix f ~prefix)
+               && String.starts_with f ~prefix)
           |> Option.map (fun f -> Filename.chop_suffix f ".json")
         else None
       in

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -19,7 +19,7 @@ let update_priority config ~task_id ~priority =
 
       match task_opt with
       | None ->
-          Printf.sprintf "❌ Task %s not found" task_id
+          Printf.sprintf "Task %s not found" task_id
       | Some task ->
           let old_priority = task.priority in
           let new_tasks = List.map (fun (t : task) ->
@@ -43,11 +43,11 @@ let update_priority config ~task_id ~priority =
           ]);
           (Atomic.get Coord_hooks.on_task_mutation_fn) ();
 
-          Printf.sprintf "✅ Task %s priority: P%d → P%d" task_id old_priority priority
+          Printf.sprintf "Task %s priority: P%d → P%d" task_id old_priority priority
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
-      Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
+      Printf.sprintf "Error: %s" (Printexc.to_string e)
   )
 
 (** Get raw task list (for orchestrator).
@@ -315,12 +315,12 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
   in
   if tasks = [] then
     if backlog.tasks = [] then
-      "📋 No tasks. ACTION: STOP calling keeper_tasks_list — the backlog is empty. Move on to other work or end your turn."
+      "No tasks. ACTION: STOP calling keeper_tasks_list — the backlog is empty. Move on to other work or end your turn."
     else
-      "📋 No active tasks (all done/cancelled). ACTION: STOP calling keeper_tasks_list — do not re-check. Move on to other work or end your turn."
+      "No active tasks (all done/cancelled). ACTION: STOP calling keeper_tasks_list — do not re-check. Move on to other work or end your turn."
   else begin
     let buf = Buffer.create 256 in
-    Buffer.add_string buf "📋 Quest Board\n";
+    Buffer.add_string buf "Quest Board\n";
     Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
 
     let sorted = List.sort (fun a b -> compare a.priority b.priority) tasks in
@@ -340,7 +340,7 @@ let get_messages config ~since_seq ~limit =
   ensure_initialized config;
 
   let buf = Buffer.create 256 in
-  Buffer.add_string buf "💬 Recent Messages\n";
+  Buffer.add_string buf "Recent Messages\n";
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
   let messages = get_messages_raw config ~since_seq ~limit in
   List.iter

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -136,7 +136,7 @@ let audit_orphan_tasks config : (Types.task * string) list =
       || let prefix = assignee ^ "-" in
          List.exists (fun name ->
            String.length name > String.length prefix
-           && Base.String.is_prefix name ~prefix
+           && String.starts_with name ~prefix
          ) active_names
     in
     let backlog = read_backlog config in

--- a/lib/coord/coord_resilience.ml
+++ b/lib/coord/coord_resilience.ml
@@ -39,7 +39,7 @@ module Zombie = struct
     let plen = String.length prefix in
     let slen = String.length suffix in
     nlen > plen + slen
-    && Base.String.is_prefix normalized ~prefix
+    && String.starts_with normalized ~prefix
     && String.sub normalized (nlen - slen) slen = suffix
 
   (** Check if an agent is a zombie based on last_seen timestamp *)
@@ -96,8 +96,8 @@ module ZeroZombie = struct
   let is_benign_error exn =
     let msg = Printexc.to_string exn in
     String.length msg >= 20 &&
-    (Base.String.is_prefix msg ~prefix:"Invalid_argument(\"MA" ||
-     Base.String.is_prefix msg ~prefix:"Sys_error(\"No ")
+    (String.starts_with msg ~prefix:"Invalid_argument(\"MA" ||
+     String.starts_with msg ~prefix:"Sys_error(\"No ")
 
   let run_loop ?(interval=60.0) ~clock ~cleanup_fn () =
     let is_cancelled exn =

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -25,11 +25,11 @@ let status config =
   in
   Printf.bprintf buf "🏢 Cluster: %s\n" cluster_name;
   if cluster_name <> state.project then
-    Printf.bprintf buf "📦 Project: %s\n" state.project;
+    Printf.bprintf buf "Project: %s\n" state.project;
   Printf.bprintf buf "📍 Namespace: %s (flattened)\n" current_room;
   Printf.bprintf buf "📁 Path: %s\n" config.base_path;
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
-  Buffer.add_string buf "📌 Players:\n";
+  Buffer.add_string buf "Players:\n";
 
   (* List agents (bounded for responsiveness) *)
   let agents_path = agents_dir config in
@@ -73,7 +73,7 @@ let status config =
            (total_agents - max_agents_display))
   end;
 
-  Buffer.add_string buf "\n📋 Quest Board:\n";
+  Buffer.add_string buf "\nQuest Board:\n";
 
   let sorted_tasks = List.sort (fun a b -> compare a.priority b.priority) backlog.tasks in
   let active_tasks, done_count, cancelled_count =
@@ -108,9 +108,9 @@ let status config =
   (* Message summary: use cumulative sequence to avoid heavy directory scans *)
   let total_messages = max 0 state.message_seq in
   if total_messages > 0 then begin
-    Printf.bprintf buf "\n💬 Messages: %d (cumulative)\n" total_messages;
+    Printf.bprintf buf "\nMessages: %d (cumulative)\n" total_messages;
     Buffer.add_string buf "   Use masc_messages for recent details\n"
   end else
-    Buffer.add_string buf "\n💬 Messages: 0\n";
+    Buffer.add_string buf "\nMessages: 0\n";
 
   Buffer.contents buf

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -419,7 +419,7 @@ let transition_task_r
            Match None explicitly so set_current=Some is never silently dropped. *)
           Ok
             (Printf.sprintf
-               "✅ %s already %s (no-op)"
+               "%s already %s (no-op)"
                task_id
                (task_status_to_string task.task_status))
         else (
@@ -717,7 +717,7 @@ let transition_task_r
            | Types.Reject_verification -> ());
           Ok
             (Printf.sprintf
-               "✅ %s %s → %s"
+               "%s %s → %s"
                task_id
                (task_status_to_string task.task_status)
                (task_status_to_string new_status)))
@@ -849,8 +849,8 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                  else agent);
                let msg =
                  if reason = ""
-                 then Printf.sprintf "🚫 Cancelled %s" task_id
-                 else Printf.sprintf "🚫 Cancelled %s - %s" task_id reason
+                 then Printf.sprintf "Cancelled %s" task_id
+                 else Printf.sprintf "Cancelled %s - %s" task_id reason
                in
                let _ = broadcast config ~from_agent:agent_name ~content:msg in
                emit_task_activity
@@ -914,7 +914,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                   Log.RoomTask.error
                     "hebbian task_cancelled hook error: %s"
                     (Printexc.to_string exn));
-               Ok (Printf.sprintf "🚫 %s cancelled %s" agent_name task_id)))
+               Ok (Printf.sprintf "%s cancelled %s" agent_name task_id)))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | e -> Error (Types.IoError (Printexc.to_string e))))
@@ -1028,7 +1028,7 @@ let link_task_execution_artifacts_r
                        | Some autoresearch_loop_id ->
                          [ "autoresearch_loop_id", `String autoresearch_loop_id ]
                        | None -> []));
-             Ok (Printf.sprintf "✅ Linked execution artifacts for %s" task_id))
+             Ok (Printf.sprintf "Linked execution artifacts for %s" task_id))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | e -> Error (Types.IoError (Printexc.to_string e))))

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -49,13 +49,13 @@ let claim_task config ~agent_name ~task_id =
   ensure_initialized config;
   (* Validate inputs *)
   match validate_agent_name agent_name, validate_task_id task_id with
-  | Error e, _ -> Printf.sprintf "❌ %s" e
-  | _, Error e -> Printf.sprintf "❌ %s" e
+  | Error e, _ -> Printf.sprintf "%s" e
+  | _, Error e -> Printf.sprintf "%s" e
   | Ok _, Ok _ ->
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
     with_file_lock config backlog_path (fun () ->
       match read_backlog_r config with
-      | Error msg -> Printf.sprintf "❌ Error: %s" msg
+      | Error msg -> Printf.sprintf "Error: %s" msg
       | Ok backlog ->
         (try
            let found = ref false in
@@ -90,14 +90,14 @@ let claim_task config ~agent_name ~task_id =
                backlog.tasks
            in
            if not !found
-           then Printf.sprintf "❌ Task %s not found" task_id
+           then Printf.sprintf "Task %s not found" task_id
            else (
              match !blocked_reason with
-             | Some r -> Printf.sprintf "🚫 Task %s blocked from re-claim: %s" task_id r
+             | Some r -> Printf.sprintf "Task %s blocked from re-claim: %s" task_id r
              | None ->
                (match !already_claimed with
                 | Some other ->
-                  Printf.sprintf "⚠ Task %s is already claimed by %s" task_id other
+                  Printf.sprintf "Task %s is already claimed by %s" task_id other
                 | None ->
                   let new_backlog =
                     { tasks = new_tasks
@@ -112,7 +112,7 @@ let claim_task config ~agent_name ~task_id =
                     broadcast
                       config
                       ~from_agent:agent_name
-                      ~content:(Printf.sprintf "📋 Claimed %s" task_id)
+                      ~content:(Printf.sprintf "Claimed %s" task_id)
                   in
                   Coord_task_classify.emit_task_activity
                     config
@@ -141,10 +141,10 @@ let claim_task config ~agent_name ~task_id =
                            (Types.Claimed
                               { assignee = agent_name; claimed_at = now_iso () })
                          ());
-                  Printf.sprintf "✅ %s claimed %s" agent_name task_id))
+                  Printf.sprintf "%s claimed %s" agent_name task_id))
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
-         | e -> Printf.sprintf "❌ Error: %s" (Printexc.to_string e)))
+         | e -> Printf.sprintf "Error: %s" (Printexc.to_string e)))
 ;;
 
 (** Result-returning version of claim_task for type-safe error handling. *)
@@ -245,7 +245,7 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
              broadcast
                config
                ~from_agent:agent_name
-               ~content:(Printf.sprintf "📋 Claimed %s" task_id)
+               ~content:(Printf.sprintf "Claimed %s" task_id)
            in
            Coord_task_classify.emit_task_activity
              config
@@ -283,7 +283,7 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
             with
             | Eio.Cancel.Cancelled _ as e -> raise e
             | _ -> ());
-           Ok (Printf.sprintf "✅ %s claimed %s" agent_name task_id)
+           Ok (Printf.sprintf "%s claimed %s" agent_name task_id)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | e -> Error (Types.IoError (Printexc.to_string e))))

--- a/lib/coord/coord_task_create.ml
+++ b/lib/coord/coord_task_create.ml
@@ -61,13 +61,13 @@ let add_task
   try
     with_file_lock config backlog_path (fun () ->
       match read_backlog_r config with
-      | Error msg -> Printf.sprintf "❌ Error: %s" msg
+      | Error msg -> Printf.sprintf "Error: %s" msg
       | Ok backlog ->
         (* Dedup guard: reject if an active task with the same normalized title exists *)
         (match find_duplicate_task backlog ~title ~goal_id with
          | Some existing_id ->
            Printf.sprintf
-             "⚠️ Duplicate rejected: '%s' matches existing %s. Use that task instead."
+             "Duplicate rejected: '%s' matches existing %s. Use that task instead."
              title
              existing_id
          | None ->
@@ -133,12 +133,12 @@ let add_task
              broadcast
                config
                ~from_agent:actor
-               ~content:(Printf.sprintf "📋 New quest: %s" title)
+               ~content:(Printf.sprintf "New quest: %s" title)
            in
-           Printf.sprintf "✅ Added %s: %s" task_id title))
+           Printf.sprintf "Added %s: %s" task_id title))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | e -> Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
+  | e -> Printf.sprintf "Error: %s" (Printexc.to_string e)
 ;;
 
 (** Add multiple tasks in a batch *)
@@ -148,7 +148,7 @@ let batch_add_tasks_internal ?created_by config tasks =
   let actor = Option.value ~default:"system" created_by in
   with_file_lock config backlog_path (fun () ->
     match read_backlog_r config with
-    | Error msg -> Printf.sprintf "❌ Error adding batch tasks: %s" msg
+    | Error msg -> Printf.sprintf "Error adding batch tasks: %s" msg
     | Ok backlog ->
       (try
          let next_num = ref (next_task_number config backlog) in
@@ -222,15 +222,15 @@ let batch_add_tasks_internal ?created_by config tasks =
          (Atomic.get Coord_hooks.on_task_mutation_fn) ();
          let msg =
            Printf.sprintf
-             "📋 New batch of %d quests added: %s"
+             "New batch of %d quests added: %s"
              (List.length added_tasks)
              summary
          in
          let _ = broadcast config ~from_agent:actor ~content:msg in
-         Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
+         Printf.sprintf "Added %d tasks: %s" (List.length added_tasks) summary
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
-       | e -> Printf.sprintf "❌ Error adding batch tasks: %s" (Printexc.to_string e)))
+       | e -> Printf.sprintf "Error adding batch tasks: %s" (Printexc.to_string e)))
 ;;
 
 let batch_add_tasks ?created_by config tasks =

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -668,10 +668,10 @@ let claim_next_r
 
           let message = match released_task_id with
             | Some rid ->
-                Printf.sprintf "⚠ %s auto-released %s, then claimed [P%d] %s: %s"
+                Printf.sprintf "%s auto-released %s, then claimed [P%d] %s: %s"
                   agent_name rid task.priority task.id task.title
             | None ->
-                Printf.sprintf "✅ %s auto-claimed [P%d] %s: %s"
+                Printf.sprintf "%s auto-claimed [P%d] %s: %s"
                   agent_name task.priority task.id task.title
           in
           Claim_next_claimed {
@@ -691,12 +691,12 @@ let claim_next_r
 let claim_next config ~agent_name =
   match claim_next_r config ~agent_name () with
   | Claim_next_claimed { message; _ } -> message
-  | Claim_next_no_unclaimed -> "📋 No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
+  | Claim_next_no_unclaimed -> "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
   | Claim_next_no_eligible { excluded_count } ->
       Printf.sprintf
-        "📋 No eligible unclaimed tasks. ACTION: Stop task-checking — blocked/excluded=%d."
+        "No eligible unclaimed tasks. ACTION: Stop task-checking — blocked/excluded=%d."
         excluded_count
-  | Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
+  | Claim_next_error e -> Printf.sprintf "Error: %s" e
 
 (** Release stale task claims older than [ttl_seconds].
     A Claimed or InProgress task whose assignee has no recent heartbeat

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -196,7 +196,7 @@ let resolve_server_default_base_path path = resolve_masc_base_path path
 let is_unresolved_template value =
   let v = String.trim value in
   (String.length v >= 2 && v.[0] = '{' && v.[1] = '{')
-  || Base.String.is_prefix v ~prefix:"op://"
+  || String.starts_with v ~prefix:"op://"
 
 let env_opt name =
   match Sys.getenv_opt name with

--- a/lib/coord/coord_utils_paths_backend.ml
+++ b/lib/coord/coord_utils_paths_backend.ml
@@ -178,7 +178,7 @@ let project_prefix config =
     For filesystem: returns relative path without prefix. *)
 let key_of_path_from_root config ~root path =
   let prefix = root ^ "/" in
-  if Base.String.is_prefix path ~prefix then
+  if String.starts_with path ~prefix then
     let rel =
       String.sub path (String.length prefix) (String.length path - String.length prefix)
     in

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -1091,7 +1091,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             let link_note = maybe_link_task () in
             Ok
               (Printf.sprintf
-                 "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n  \
+                 "Worktree already exists:\n  Path: %s\n  Branch: %s\n  \
                   Repo: %s%s%s\n\nNext: cd %s"
                  worktree_path branch_name repo_name race_note link_note
                  worktree_path)
@@ -1179,7 +1179,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                     agent_name branch_name worktree_path repo_name task_id (now_iso ()) in
                   log_event config (Yojson.Safe.from_string event);
 
-                  Ok (Printf.sprintf "✅ Worktree created:\n  Path: %s\n  Branch: %s\n  Repo: %s%s%s\n\nNext: cd %s && work && gh pr create --draft"
+                  Ok (Printf.sprintf "Worktree created:\n  Path: %s\n  Branch: %s\n  Repo: %s%s%s\n\nNext: cd %s && work && gh pr create --draft"
                       worktree_path branch_name repo_name note
                       (provision_note ^ link_note) worktree_path)
                 end
@@ -1274,10 +1274,10 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
                 log_event config (Yojson.Safe.from_string event);
 
                 (* Return result with post-processing status *)
-                let msg = Printf.sprintf "✅ Worktree removed: %s\n   Branch: %s (delete: %s)\n   Prune: %s"
+                let msg = Printf.sprintf "Worktree removed: %s\n   Branch: %s (delete: %s)\n   Prune: %s"
                   worktree_path branch_name branch_status prune_status in
                 if branch_exit <> 0 || prune_exit <> 0 then
-                  Error (IoError (msg ^ "\n   ⚠️ Post-processing had failures"))
+                  Error (IoError (msg ^ "\n   Post-processing had failures"))
                 else
                   Ok msg
               end

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -138,14 +138,14 @@ let status_summary_string
   let buf = Buffer.create 256 in
   Printf.bprintf buf "🏢 Cluster: %s\n" effective_cluster_name;
   if not (String.equal effective_cluster_name state.project) then
-    Printf.bprintf buf "📦 Project: %s\n" state.project;
+    Printf.bprintf buf "Project: %s\n" state.project;
   Buffer.add_string buf
     (Printf.sprintf "📍 Scope: %s (flattened)\n" current_room);
   Printf.bprintf buf "📁 Path: %s\n" ctx.config.base_path;
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
   Buffer.add_string buf
     (Printf.sprintf
-       "⚡ Snapshot: agents=%d zombies=%d | tasks active=%d todo=%d claimed=%d in_progress=%d | messages=%d\n"
+       "Snapshot: agents=%d zombies=%d | tasks active=%d todo=%d claimed=%d in_progress=%d | messages=%d\n"
        agent_count zombie_count (List.length active_tasks) todo_count claimed_count
        in_progress_count (max 0 state.message_seq));
   Buffer.add_string buf
@@ -166,32 +166,32 @@ let status_summary_string
   (match planning_state.planning_missing_task with
   | Some task_id ->
       Buffer.add_string buf
-        (Printf.sprintf "📝 Planning: missing=yes | task=%s\n" task_id)
+        (Printf.sprintf "Planning: missing=yes | task=%s\n" task_id)
   | None -> ());
   (match planning_state.deliverable_conflict_task with
   | Some task_id ->
       Buffer.add_string buf
-        (Printf.sprintf "📝 Planning: deliverable_conflict=yes | task=%s\n"
+        (Printf.sprintf "Planning: deliverable_conflict=yes | task=%s\n"
            task_id)
   | None -> ());
   if credential_state.credential_required then
     Buffer.add_string buf
-      (Printf.sprintf "🔐 Credential: required=yes | available=%s | candidates=%s\n"
+      (Printf.sprintf "Credential: required=yes | available=%s | candidates=%s\n"
          (bool_flag credential_state.credential_available)
          (String.concat "," credential_state.credential_candidates));
   (match suggested_next with [] -> () | _ ->
     Buffer.add_string buf
-      (Printf.sprintf "💡 Suggested next: %s\n"
+      (Printf.sprintf "Suggested next: %s\n"
          (String.concat " -> " suggested_next)));
   (match attention_items with
   | [] -> ()
   | _ ->
-    Buffer.add_string buf "\n⚠️ Attention:\n";
+    Buffer.add_string buf "\nAttention:\n";
     List.iter
       (fun item ->
         Printf.bprintf buf "  - %s\n" item)
       attention_items);
-  Buffer.add_string buf "📌 Players:\n";
+  Buffer.add_string buf "Players:\n";
   (match shown_agents with
   | [] ->
       Buffer.add_string buf "  (no agents)\n"
@@ -212,13 +212,13 @@ let status_summary_string
           (Printf.sprintf
              "  … and %d more agents (use masc_who for full list)\n"
              (agent_count - max_agents_display)));
-  Buffer.add_string buf "\n📋 Quest Board:\n";
+  Buffer.add_string buf "\nQuest Board:\n";
   List.iter
     (fun (task : Types.task) ->
       Coord_query.safe_yield ();
       let (status_icon, status_label) =
         if List.exists (String.equal task.id) todo_conflict_task_ids then
-          ("⚠️", "todo_conflict")
+          ("warning", "todo_conflict")
         else
           task_status_badge task.task_status
       in
@@ -241,8 +241,8 @@ let status_summary_string
   let total_messages = max 0 state.message_seq in
   if total_messages > 0 then begin
     Buffer.add_string buf
-      (Printf.sprintf "\n💬 Messages: %d (cumulative)\n" total_messages);
+      (Printf.sprintf "\nMessages: %d (cumulative)\n" total_messages);
     Buffer.add_string buf "   Use masc_messages for recent details\n"
   end else
-    Buffer.add_string buf "\n💬 Messages: 0\n";
+    Buffer.add_string buf "\nMessages: 0\n";
   Buffer.contents buf

--- a/lib/core/list_util.ml
+++ b/lib/core/list_util.ml
@@ -9,4 +9,4 @@
 
 
 let count_if pred xs =
-  Base.List.fold xs ~init:0 ~f:(fun n x -> if pred x then n + 1 else n)
+  List.fold_left (fun n x -> if pred x then n + 1 else n) 0 xs

--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -64,7 +64,7 @@ end = struct
       Error (Printf.sprintf "agent_id too long: %d chars (max 64)" (String.length s))
     else if String.contains s '/' || String.contains s '\\' then
       Error "agent_id cannot contain path separators"
-    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
+    else if String.contains s '.' && String.starts_with s ~prefix:".." then
       Error "agent_id cannot contain path traversal"
     else if not (Re.execp valid_pattern s) then
       Error (Printf.sprintf "agent_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
@@ -115,7 +115,7 @@ end = struct
       Error (Printf.sprintf "task_id too long: %d chars (max 128)" (String.length s))
     else if String.contains s '/' || String.contains s '\\' then
       Error "task_id cannot contain path separators"
-    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
+    else if String.contains s '.' && String.starts_with s ~prefix:".." then
       Error "task_id cannot contain path traversal"
     else if not (Re.execp valid_pattern s) then
       Error (Printf.sprintf "task_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
@@ -172,7 +172,7 @@ end = struct
       reject "path cannot be empty"
     else if path.[0] = '/' then
       reject "absolute paths not allowed"
-    else if Base.String.is_prefix path ~prefix:".." then
+    else if String.starts_with path ~prefix:".." then
       reject "path traversal not allowed"
     else if Re.execp traversal_re path then
       reject "path traversal not allowed"

--- a/lib/credits_dashboard.ml
+++ b/lib/credits_dashboard.ml
@@ -197,7 +197,7 @@ let html () = {|<!DOCTYPE html>
 <body>
   <div class="container">
     <header>
-      <h1>📊 Credits Dashboard</h1>
+      <h1>Credits Dashboard</h1>
       <div class="updated" id="updated">Loading...</div>
     </header>
 

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -65,7 +65,7 @@ let classify_failure_output (output : string) : string =
       let prefixes = ["error: "; "tool_error: "] in
       match List.find_opt (fun p ->
         String.length output > String.length p
-        && Base.String.is_prefix output ~prefix:p
+        && String.starts_with output ~prefix:p
       ) prefixes with
       | Some p -> String.sub output (String.length p)
                     (String.length output - String.length p)

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -9,29 +9,39 @@ let parse_iso_opt = function
       try Some (Types.parse_iso8601 raw) with Failure _ -> None)
   | _ -> None
 
-(* Delegate to Base — qualified access, no `open Base` *)
-let first_some = Base.Option.first_some
+let first_some a b = match a with Some _ as v -> v | None -> b
 
 let string_contains ~needle haystack =
-  Base.String.is_substring haystack ~substring:needle
+  let n = String.length needle in
+  let h = String.length haystack in
+  if n = 0 then true
+  else if n > h then false
+  else
+    let rec loop i =
+      if i > h - n then false
+      else String.sub haystack i n = needle || loop (i + 1)
+    in
+    loop 0
 
 let string_contains_ci ~needle haystack =
-  Base.String.is_substring
+  string_contains
+    ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
-    ~substring:(String.lowercase_ascii needle)
 
 let trim_to_option text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some trimmed
 
+module String_set = Set.Make(String)
+
 let dedup_strings (xs : string list) : string list =
   let rec go seen acc = function
     | [] -> List.rev acc
     | x :: rest ->
-      if Base.Set.mem seen x then go seen acc rest
-      else go (Base.Set.add seen x) (x :: acc) rest
+      if String_set.mem x seen then go seen acc rest
+      else go (String_set.add x seen) (x :: acc) rest
   in
-  go (Base.Set.empty (module Base.String)) [] xs
+  go String_set.empty [] xs
 
 let string_list_of_json json =
   match json with

--- a/lib/exec/egress_policy.ml
+++ b/lib/exec/egress_policy.ml
@@ -38,7 +38,7 @@ let domain_allowed policy domain =
   in
   List.exists (fun pattern ->
     if String.length pattern > 2 &&
-       Base.String.is_prefix pattern ~prefix:"*." then begin
+       String.starts_with pattern ~prefix:"*." then begin
       let suffix = String.sub pattern 2 (String.length pattern - 2) in
       suffix_match ~suffix d
     end else

--- a/lib/exec/string_util.ml
+++ b/lib/exec/string_util.ml
@@ -1,6 +1,14 @@
 (* Exec-local string utilities.
-   Kept minimal to avoid pulling in masc_core.
-   base and re are explicit dependencies of lib/exec/dune. *)
+   Kept minimal to avoid pulling in masc_core. *)
 
 let contains_substring haystack needle =
-  Base.String.is_substring haystack ~substring:needle
+  let n = String.length needle in
+  let h = String.length haystack in
+  if n = 0 then true
+  else if n > h then false
+  else
+    let rec loop i =
+      if i > h - n then false
+      else String.sub haystack i n = needle || loop (i + 1)
+    in
+    loop 0

--- a/lib/exec/test/test_exec_run.ml
+++ b/lib/exec/test/test_exec_run.ml
@@ -92,11 +92,11 @@ let test_slow_command_promotes () =
     (* We saw "early" but not "late" — budget fires before sleep 5
        resolves.  Killing cleans up the long sleep. *)
     let saw_early =
-      Base.String.is_substring p.partial_stdout ~substring:"early"
+      String_util.contains_substring p.partial_stdout "early"
     in
     check bool "saw early output" true saw_early;
     let saw_late =
-      Base.String.is_substring p.partial_stdout ~substring:"late"
+      String_util.contains_substring p.partial_stdout "late"
     in
     check bool "did not see late output" false saw_late;
     let _ = Bg_task.kill p.task_id ~signal:Sys.sigterm ~grace_sec:0.2 in

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -69,7 +69,7 @@ let test_exec_home_guard ~op path =
     Stdlib.Sys.executable_name |> Stdlib.Filename.basename |> String.lowercase_ascii
   in
   let is_test_exec =
-    String.length basename >= 5 && Base.String.is_prefix basename ~prefix:"test_"
+    String.length basename >= 5 && String.starts_with basename ~prefix:"test_"
   in
   if not is_test_exec then ()
   else
@@ -96,7 +96,7 @@ let test_exec_home_guard ~op path =
           let home_len = String.length home_norm in
           if home_len > 0
              && String.length path >= home_len
-             && Base.String.is_prefix path ~prefix:home_norm
+             && String.starts_with path ~prefix:home_norm
           then
             raise
               (Test_isolation_breach
@@ -228,8 +228,8 @@ let is_atomic_orphan_name name =
   let p = String.length atomic_tmp_prefix in
   let s = String.length atomic_tmp_suffix in
   n >= p + s
-  && Base.String.is_prefix name ~prefix:atomic_tmp_prefix
-  && Base.String.is_suffix name ~suffix:atomic_tmp_suffix
+  && String.starts_with name ~prefix:atomic_tmp_prefix
+  && String.ends_with ~suffix:atomic_tmp_suffix name
 
 let cleanup_atomic_orphans
     ~(base_path : string)

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -55,7 +55,7 @@ let decode_cursor ~kind cursor =
   | Ok decoded ->
       let prefix = kind ^ ":" in
       let prefix_len = String.length prefix in
-      if Base.String.is_prefix decoded ~prefix then
+      if String.starts_with decoded ~prefix then
         Some (String.sub decoded prefix_len (String.length decoded - prefix_len))
       else
         None

--- a/lib/handover_eio.ml
+++ b/lib/handover_eio.ml
@@ -250,28 +250,28 @@ let format_as_markdown (h : handover_record) : string =
   add (Printf.sprintf "**Task**: %s | **Reason**: %s" h.task_id h.handover_reason);
   add "";
 
-  add "## 🎯 Current Goal";
+  add "## Current Goal";
   add h.current_goal;
   add "";
 
-  add "## 📊 Progress";
+  add "## Progress";
   add h.progress_summary;
   add "";
 
   if h.completed_steps <> [] then begin
-    add "### ✅ Completed";
+    add "### Completed";
     List.iter (fun s -> add ("- " ^ s)) h.completed_steps;
     add ""
   end;
 
   if h.pending_steps <> [] then begin
-    add "### ⏳ Pending";
+    add "### Pending";
     List.iter (fun s -> add ("- " ^ s)) h.pending_steps;
     add ""
   end;
 
   if h.key_decisions <> [] then begin
-    add "## 🧠 Key Decisions (Why)";
+    add "## Key Decisions (Why)";
     List.iter (fun s -> add ("- " ^ s)) h.key_decisions;
     add ""
   end;
@@ -283,13 +283,13 @@ let format_as_markdown (h : handover_record) : string =
   end;
 
   if h.warnings <> [] then begin
-    add "## ⚠️ Warnings";
+    add "## Warnings";
     List.iter (fun s -> add ("- " ^ s)) h.warnings;
     add ""
   end;
 
   if h.unresolved_errors <> [] then begin
-    add "## ❌ Unresolved Errors";
+    add "## Unresolved Errors";
     List.iter (fun s -> add ("- " ^ s)) h.unresolved_errors;
     add ""
   end;

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -425,7 +425,7 @@ module Router = struct
             String.length route.path > 7
             && String.sub route.path 0 7 = "PREFIX:"
             && let prefix = String.sub route.path 7 (String.length route.path - 7) in
-               Base.String.is_prefix req_path ~prefix
+               String.starts_with req_path ~prefix
             && List.mem req_method route.methods
           ) routes
         in

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -642,11 +642,11 @@ let run ~sw ~net ~clock config routes =
   let addr = `Tcp (ip, config.port) in
   let socket = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:config.max_connections addr in
   if String.equal effective_host config.host then
-    Printf.printf "🚀 MASC MCP Server listening on http://%s:%d\n"
+    Printf.printf "MASC MCP Server listening on http://%s:%d\n"
       effective_host config.port
   else
     Printf.printf
-      "🚀 MASC MCP Server listening on http://%s:%d (configured=%s, parse failed → loopback)\n"
+      "MASC MCP Server listening on http://%s:%d (configured=%s, parse failed → loopback)\n"
       effective_host config.port config.host;
   Printf.printf "   Graceful shutdown: SIGTERM/SIGINT supported\n%!";
 

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -264,7 +264,7 @@ let run ~sw ~net ~clock config request_handler =
   let addr = `Tcp (ip, config.port) in
   let socket = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:config.max_connections addr in
 
-  Printf.printf "🚀 MASC MCP Server (HTTP/2) listening on http://%s:%d\n" config.host config.port;
+  Printf.printf "MASC MCP Server (HTTP/2) listening on http://%s:%d\n" config.host config.port;
   Printf.printf "   HTTP/2 multiplexing: unlimited SSE streams per connection\n%!";
 
   let initial_backoff_s = 0.05 in

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -539,7 +539,7 @@ let format_for_injection ?(include_patterns=true) ?(max_patterns=5) (inst : inst
       Printf.bprintf buf "  • %s (%.0f%% weight): %s\n"
         v.name (v.weight *. 100.0) v.description;
       if v.anti_patterns <> [] then
-        Printf.bprintf buf "    ⚠️ Avoid: %s\n" (String.concat ", " v.anti_patterns)
+        Printf.bprintf buf "    Avoid: %s\n" (String.concat ", " v.anti_patterns)
     ) (List.sort (fun a b -> compare b.weight a.weight) inst.culture |> List.filteri (fun i _ -> i < 3))
   end;
 
@@ -557,7 +557,7 @@ let format_for_injection ?(include_patterns=true) ?(max_patterns=5) (inst : inst
       |> List.filteri (fun i _ -> i < max_patterns)
     in
     List.iter (fun (p : pattern) ->
-      Printf.bprintf buf "  📋 %s (%.0f%% success, %d uses)\n"
+      Printf.bprintf buf "  %s (%.0f%% success, %d uses)\n"
         p.name (p.success_rate *. 100.0) p.usage_count;
       Printf.bprintf buf "     Trigger: %s\n" p.trigger;
       if List.length p.steps <= 3 then
@@ -619,7 +619,7 @@ let format_for_welcome (inst : institution) : string =
       |> List.filteri (fun i _ -> i < 3)
     in
     let value_names = List.map (fun (v : cultural_value) -> v.name) top_values in
-    Buffer.add_string buf "💎 Values: ";
+    Buffer.add_string buf "Values: ";
     Buffer.add_string buf (String.concat ", " value_names);
     Buffer.add_char buf '\n'
   end;
@@ -627,7 +627,7 @@ let format_for_welcome (inst : institution) : string =
   (* One procedural tip - pattern match for safety *)
   (match List.sort (fun a b -> compare b.success_rate a.success_rate) inst.memory.procedural with
    | best :: _ ->
-       Buffer.add_string buf "💡 Tip: ";
+       Buffer.add_string buf "Tip: ";
        Buffer.add_string buf best.name;
        Buffer.add_string buf " → ";
        Buffer.add_string buf best.trigger;

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -84,22 +84,22 @@ let handle_keeper_masc_code_read
   let offset = Safe_ops.json_int ~default:0 "offset" args in
   let limit = Safe_ops.json_int ~default:100 "limit" args in
   if path = ""
-  then error_json "❌ Path required: 'path' parameter"
+  then error_json "Path required: 'path' parameter"
   else (
     match resolve_keeper_read_path ~config ~meta ~raw_path:path with
     | Error e -> error_json e
     | Ok target ->
       if not (Sys.file_exists target)
-      then error_json (Printf.sprintf "❌ File not found: %s" path)
+      then error_json (Printf.sprintf "File not found: %s" path)
       else if Tool_code.is_binary_file target
-      then error_json "❌ Binary file detected"
+      then error_json "Binary file detected"
       else (
         let file_size = (Unix.stat target).Unix.st_size in
         if file_size > Tool_code.max_file_size
         then
           error_json
             (Printf.sprintf
-               "❌ File too large: %d bytes (max: %d)"
+               "File too large: %d bytes (max: %d)"
                file_size
                Tool_code.max_file_size)
         else (
@@ -128,7 +128,7 @@ let handle_keeper_masc_code_read
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
             error_json
-              (Printf.sprintf "❌ Failed to read file: %s" (Printexc.to_string exn)))))
+              (Printf.sprintf "Failed to read file: %s" (Printexc.to_string exn)))))
 ;;
 
 let handle_keeper_masc_tool

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -322,7 +322,7 @@ let handle_keeper_task_tool
           ~keeper_name:meta.name ~agent_name:meta.agent_name
       then
         Some
-          "⚠ Accountability risk is high for this keeper. Prefer manual review or lower-risk routing when equivalent."
+          "Accountability risk is high for this keeper. Prefer manual review or lower-risk routing when equivalent."
       else
         None
     in
@@ -331,7 +331,7 @@ let handle_keeper_task_tool
       | Coord.Claim_next_claimed { message; _ } ->
           if !auto_started_ok then message ^ " Task auto-started — begin work now."
           else message
-      | Coord.Claim_next_no_unclaimed -> "📋 No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
+      | Coord.Claim_next_no_unclaimed -> "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
       | Coord.Claim_next_no_eligible { excluded_count; _ } ->
         let scope_suffix =
           match meta.active_goal_ids with
@@ -342,9 +342,9 @@ let handle_keeper_task_tool
                 (String.concat ", " goal_ids)
         in
         Printf.sprintf
-          "📋 No eligible tasks%s. ACTION: Stop task-checking — blocked/excluded=%d."
+          "No eligible tasks%s. ACTION: Stop task-checking — blocked/excluded=%d."
           scope_suffix excluded_count
-      | Coord.Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
+      | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
     in
     let claim_scope, claimed_task_fields =
       match result with

--- a/lib/keeper/keeper_goal_repair.ml
+++ b/lib/keeper/keeper_goal_repair.ml
@@ -115,7 +115,7 @@ let run (config : Coord.config) : repair_result =
     match repair_keeper config name with
     | Ok action -> { acc with actions = action :: acc.actions }
     | Error e ->
-        if Base.String.is_prefix e ~prefix:"already has active_" then
+        if String.starts_with e ~prefix:"already has active_" then
           { acc with skipped = (name, e) :: acc.skipped }
         else
           { acc with errors = (name, e) :: acc.errors }

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -123,7 +123,7 @@ let strip_keeper_prefix (s : string) : string option =
   let prefix = "keeper-" in
   let plen = String.length prefix in
   let slen = String.length s in
-  if slen > plen && Base.String.is_prefix s ~prefix then
+  if slen > plen && String.starts_with s ~prefix then
     Some (String.sub s plen (slen - plen))
   else None
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -177,7 +177,7 @@ let process_directive ~agent_name directive =
   | "wakeup" ->
     Log.Keeper.debug "directive: waking up %s" agent_name;
     wakeup_keeper_by_agent_name ~agent_name
-  | s when String.length s > 6 && Base.String.is_prefix s ~prefix:"claim:" ->
+  | s when String.length s > 6 && String.starts_with s ~prefix:"claim:" ->
     let task_id = String.sub s 6 (String.length s - 6) in
     (match Keeper_id.Task_id.of_string task_id with
      | Ok parsed_task_id ->

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -528,7 +528,7 @@ let filter_forward_looking_summary (summary : string) : string =
     List.exists
       (fun label ->
         let prefix = label ^ ":" in
-        Base.String.is_prefix trimmed ~prefix)
+        String.starts_with trimmed ~prefix)
       backward_labels
   in
   let is_inert_next_line line =

--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -34,7 +34,7 @@ let handle_persona_save = Authoring.handle_persona_save
 
 let handle_keeper_create_from_persona ctx args : tool_result =
   match resolved_keeper_args_from_persona args with
-  | Error e -> (false, "❌ " ^ e)
+  | Error e -> (false, "" ^ e)
   | Ok (persona, resolved_args) ->
       let errors = validate_resolved_keeper_create_json resolved_args in
       let dry_run = get_bool args "dry_run" false in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -96,19 +96,19 @@ let apply_tail_order order items =
 let resolve_status_target (ctx : _ context) args =
   let requested_name = effective_status_name ctx args in
   if not (validate_name requested_name) then
-    Error "❌ invalid keeper name"
+    Error "invalid keeper name"
   else
     match read_meta_resolved ctx.config requested_name with
-    | Error e -> Error ("❌ " ^ e)
+    | Error e -> Error ("" ^ e)
     | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
     | Ok None ->
         (match keeper_name_from_agent_name requested_name with
          | Some stripped_name ->
              Error
                (Printf.sprintf
-                  "❌ keeper not found: %s (also tried %s)"
+                  "keeper not found: %s (also tried %s)"
                   requested_name stripped_name)
-         | None -> Error (Printf.sprintf "❌ keeper not found: %s" requested_name))
+         | None -> Error (Printf.sprintf "keeper not found: %s" requested_name))
 
 (** Hash the status-affecting args so different parameter combos
     get separate cache entries (e.g. fast=true vs fast=false). *)

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -552,8 +552,8 @@ let update_field_in_content
        else if
          !in_target_table
          && (not !found)
-         && ((Base.String.is_prefix trimmed ~prefix:key_prefix)
-             || (Base.String.is_prefix trimmed ~prefix:key_prefix_eq))
+         && ((String.starts_with trimmed ~prefix:key_prefix)
+             || (String.starts_with trimmed ~prefix:key_prefix_eq))
        then (
          result_lines := Printf.sprintf "%s = \"%s\"" key value :: !result_lines;
          found := true;

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -86,9 +86,9 @@ let public_masc_to_internal name =
   Hashtbl.find_opt public_masc_to_internal_tbl name
 
 let strip_mcp_masc_prefix name =
-  match Base.String.chop_prefix name ~prefix:"mcp__masc__" with
-  | Some rest -> rest
-  | None -> name
+  if String.starts_with ~prefix:"mcp__masc__" name then
+    String.sub name 11 (String.length name - 11)
+  else name
 
 let canonicalize_one_observed name =
   let stripped = strip_mcp_masc_prefix name in

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -52,7 +52,7 @@ let normalize_path path =
 let is_masc_write_allowed path =
   let path = normalize_path path in
   List.exists (fun prefix ->
-    Base.String.is_prefix path ~prefix
+    String.starts_with path ~prefix
   ) keeper_writable_prefixes
 
 (* -- Config-driven preset resolution -------------------------------- *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -190,11 +190,11 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
                  method_tok <> "get"
                | [] -> true (* flag with no value — conservative: mutating *))
             else if (String.length tok > 3
-                     && Base.String.is_prefix tok ~prefix:"-x=") then
+                     && String.starts_with tok ~prefix:"-x=") then
               let method_val = String.sub tok 3 (String.length tok - 3) in
               method_val <> "get"
             else if (String.length tok > 9
-                     && Base.String.is_prefix tok ~prefix:"--method=") then
+                     && String.starts_with tok ~prefix:"--method=") then
               let method_val = String.sub tok 9 (String.length tok - 9) in
               method_val <> "get"
             else check rest_toks
@@ -204,9 +204,9 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
       let has_field_flag =
         List.exists (fun tok ->
           tok = "-f" || tok = "-ff"
-          || String.length tok > 3 && Base.String.is_prefix tok ~prefix:"-f="
+          || String.length tok > 3 && String.starts_with tok ~prefix:"-f="
           || tok = "--field" || tok = "--raw-field"
-          || String.length tok > 8 && Base.String.is_prefix tok ~prefix:"--field="
+          || String.length tok > 8 && String.starts_with tok ~prefix:"--field="
         ) tokens
       in
       not has_method_flag && not has_field_flag
@@ -265,11 +265,11 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
     let cmd = gh_effective_cmd input in
     let cmd_lower = String.lowercase_ascii cmd in
     if cmd_lower = "" then false
-    else if Base.String.is_prefix cmd_lower ~prefix:"api" then
+    else if String.starts_with cmd_lower ~prefix:"api" then
       is_gh_api_read_only cmd_lower
     else
       List.exists (fun prefix ->
-        Base.String.is_prefix cmd_lower ~prefix
+        String.starts_with cmd_lower ~prefix
       ) gh_read_only_prefixes
   | Some (Masc Code_git) ->
     if is_effectively_read_only_tool tool_name then true

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -163,9 +163,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
   if not (validate_name name) then
-    (false, "❌ invalid keeper name")
+    (false, "invalid keeper name")
   else if message = "" then
-    (false, "❌ message is required")
+    (false, "message is required")
   else
     let turn_instructions = get_string_opt args "turn_instructions" in
     let no_skill_route = get_bool args "no_skill_route" false in
@@ -173,18 +173,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
     let direct_reply = get_bool args "direct_reply" false in
     let channel_session_key = get_string_opt args "channel_session_key" in
     (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
-    | Error e -> (false, "❌ " ^ e)
+    | Error e -> (false, "" ^ e)
     | Ok () ->
     (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
-    | Error e -> (false, "❌ " ^ e)
+    | Error e -> (false, "" ^ e)
     | Ok () ->
     (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
-    | Error e -> (false, "❌ " ^ e)
+    | Error e -> (false, "" ^ e)
     | Ok () ->
     match ensure_keeper_exists
       ~ctx ~name
     with
-    | Error e -> (false, "❌ " ^ e)
+    | Error e -> (false, "" ^ e)
     | Ok meta0 ->
       let turn_task_id = Printf.sprintf "keeper_turn_%s_%d"
         name (int_of_float (Time_compat.now () *. 1000.0)) in
@@ -194,7 +194,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       match resolve_turn_cascade_name meta with
       | Error e ->
         Progress.stop_tracking turn_task_id;
-        (false, "❌ " ^ e)
+        (false, "" ^ e)
       | Ok turn_cascade_name ->
       (* start_keepalive is deferred AFTER run_turn completes.
          Starting it here causes the heartbeat fiber to immediately grab LLM
@@ -220,7 +220,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       (match ensure_api_keys_for_labels effective_models with
        | Error e ->
          Progress.stop_tracking turn_task_id;
-         (false, "❌ " ^ e)
+         (false, "" ^ e)
        | Ok () ->
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
          ignore (Cascade_runtime.refresh_local_discovery_if_possible effective_models);
@@ -433,7 +433,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                  ~label:"trajectory finalize (agent_run error)" exn);
               start_keepalive ctx meta;
               Progress.stop_tracking turn_task_id;
-              (false, Printf.sprintf "❌ Agent.run failed: %s" e_str)
+              (false, Printf.sprintf "Agent.run failed: %s" e_str)
             | Ok result ->
               let explicit_accountability_claim =
                 Keeper_social_model.extract_accountability_claim result

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -11,7 +11,7 @@ type tool_result = Keeper_types.tool_result
 let handle_keeper_down ctx args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
   if not (validate_name requested_name) then
-    (false, "❌ invalid keeper name")
+    (false, "invalid keeper name")
   else
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
@@ -21,7 +21,7 @@ let handle_keeper_down ctx args : tool_result =
          stop_keepalive ~base_path:ctx.config.base_path resolved_name
      | _ -> ());
     match read_meta_resolved ctx.config requested_name with
-    | Error e -> (false, "❌ " ^ e)
+    | Error e -> (false, "" ^ e)
     | Ok None -> (true, Printf.sprintf "keeper already absent: %s" requested_name)
     | Ok (Some (name, m)) ->
       ignore

--- a/lib/keeper/keeper_turn_up.ml
+++ b/lib/keeper/keeper_turn_up.ml
@@ -11,15 +11,15 @@ type tool_result = Keeper_types.tool_result
 
 let handle_keeper_up ctx args : tool_result =
   match Keeper_turn_up_args.parse ctx args with
-  | Error (ok, msg) -> (ok, Printf.sprintf "❌ %s" msg)
+  | Error (ok, msg) -> (ok, Printf.sprintf "%s" msg)
   | Ok p ->
     match read_meta ctx.config p.name with
-    | Error e -> (false, Printf.sprintf "❌ %s" e)
+    | Error e -> (false, Printf.sprintf "%s" e)
     | Ok None ->
       let (ok, msg) = Keeper_turn_up_create.create_keeper ctx p in
       if ok then (ok, msg)
-      else (ok, Printf.sprintf "❌ %s" msg)
+      else (ok, Printf.sprintf "%s" msg)
     | Ok (Some old) ->
       let (ok, msg) = Keeper_turn_up_update.update_keeper ctx p old in
       if ok then (ok, msg)
-      else (ok, Printf.sprintf "❌ %s" msg)
+      else (ok, Printf.sprintf "%s" msg)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -616,7 +616,7 @@ let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
   List.filter_map
     (fun (k, v) ->
       if String.length k > prefix_len
-         && Base.String.is_prefix k ~prefix:oas_env_key_prefix
+         && String.starts_with k ~prefix:oas_env_key_prefix
       then
         let suffix = String.sub k prefix_len (String.length k - prefix_len) in
         if oas_env_key_is_allowed suffix then
@@ -1055,7 +1055,7 @@ let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
   let oas_env_prefix_len = String.length oas_env_prefix in
   let starts_with_oas_env k =
     String.length k > oas_env_prefix_len
-    && Base.String.is_prefix k ~prefix:oas_env_prefix
+    && String.starts_with k ~prefix:oas_env_prefix
   in
   doc
   |> List.map fst

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -957,7 +957,7 @@ let append_decision_record
                 | Some e when String.length e > 0 ->
                   let e_lower = String.lowercase_ascii e in
                   let starts_with prefix =
-                    Base.String.is_prefix e_lower ~prefix
+                    String.starts_with e_lower ~prefix
                   in
                   let contains needle =
                     string_contains_substring ~needle e_lower

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -57,12 +57,12 @@ let incr_gh_exit_class (c : Gh_exit_class.t) =
    bare reason name. *)
 let bare_reason s =
   let strip prefix =
-    match Base.String.chop_prefix s ~prefix with
-    | Some rest -> rest
-    | None -> s
+    if String.starts_with ~prefix s then
+      String.sub s (String.length prefix) (String.length s - String.length prefix)
+    else s
   in
   strip "too_complex:" |> fun s ->
-  if Base.String.is_prefix s ~prefix:"parse_aborted:"
+  if String.starts_with s ~prefix:"parse_aborted:"
   then "__parse_aborted__"
   else s
 

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -49,7 +49,7 @@ let next_jsonrpc_id () =
 
 let strip_mcp_prefix name =
   let prefix = "mcp__masc__" in
-  if Base.String.is_prefix name ~prefix
+  if String.starts_with name ~prefix
   then
     String.sub name (String.length prefix) (String.length name - String.length prefix)
   else
@@ -109,7 +109,7 @@ let normalize_mcp_body ~request_id body =
     List.filter_map
       (fun line ->
         let prefix = "data: " in
-        if Base.String.is_prefix line ~prefix
+        if String.starts_with line ~prefix
         then
           Some (String.sub line (String.length prefix) (String.length line - String.length prefix))
         else

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -886,7 +886,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       let hint = Masc_error_recovery.recovery_hint message in
       match hint with
       | None -> message
-      | Some h -> message ^ "\n\n💡 Recovery: " ^ h
+      | Some h -> message ^ "\n\nRecovery: " ^ h
   in
   (match keeper_entry with
    | Some entry ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -73,7 +73,7 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name
 
 
 let is_ephemeral_agent_name name =
-  Base.String.is_prefix name ~prefix:"agent-"
+  String.starts_with name ~prefix:"agent-"
 
 let is_transient_agent_name name =
   is_ephemeral_agent_name name

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -583,7 +583,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   match init_error with
   | Some msg ->
       with_system_internal_audit ~agent_name
-        (false, Printf.sprintf "❌ %s" msg)
+        (false, Printf.sprintf "%s" msg)
   | None ->
 
   let is_read_only = Tool_dispatch.is_read_only name in
@@ -736,7 +736,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
       ();
     with_system_internal_audit ~agent_name
       (false, Printf.sprintf
-         "⚠️ MASC room not initialized.\n\n💡 Fastest: masc_start(path=\"<project>\") — one-step init+join, then call %s.\n💡 Alternative: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
+         "MASC room not initialized.\n\nFastest: masc_start(path=\"<project>\") — one-step init+join, then call %s.\nAlternative: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
          name name agent_name room_initialized)
   end
   else if join_required && not is_joined then begin
@@ -748,7 +748,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
       ();
     with_system_internal_audit ~agent_name
       (false, Printf.sprintf
-         "❌ Join required before using %s.\n\n💡 Fastest: masc_start(path=\"<project>\") — one-step join with room scope.\n💡 Alternative: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
+         "Join required before using %s.\n\nFastest: masc_start(path=\"<project>\") — one-step join with room scope.\nAlternative: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
          name name agent_name is_joined)
   end
   else (

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -699,7 +699,7 @@ type transport_mode =
 
 let detect_mode first_line =
   let lower = String.lowercase_ascii first_line in
-  if Base.String.is_prefix lower ~prefix:"content-length" then
+  if String.starts_with lower ~prefix:"content-length" then
     Framed
   else
     LineDelimited

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -171,7 +171,7 @@ let handle_read_resource_eio state id params =
                 ("application/json", Some content)
               else
                 ("application/json", Some "{\"error\": \"No institution memory found\"}")
-          | s when Base.String.is_prefix s ~prefix:"library" ->
+          | s when String.starts_with s ~prefix:"library" ->
               let library_dir = Filename.concat config.base_path "docs/library" in
               if not (Sys.file_exists library_dir) then
                 ("text/markdown", Some "Library directory not found. Create docs/library/ first.")
@@ -224,7 +224,7 @@ let handle_read_resource_eio state id params =
                   with Sys_error _ -> (fallback_name, "", "", "", [])
                 in
                 let strip_frontmatter content =
-                  if Base.String.is_prefix content ~prefix:"---" then
+                  if String.starts_with content ~prefix:"---" then
                     match String.index_from_opt content 3 '\n' with
                     | None -> content
                     | Some first_nl ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -490,7 +490,7 @@ let decode_cursor ~kind cursor =
   | Ok decoded ->
       let prefix = kind ^ ":" in
       let prefix_len = String.length prefix in
-      if Base.String.is_prefix decoded ~prefix
+      if String.starts_with decoded ~prefix
       then
         int_of_string_opt
           (String.sub decoded prefix_len (String.length decoded - prefix_len))

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -270,7 +270,7 @@ let notify event =
         task_id = None;
       } in
       send_notification
-        ~title:"⚠️ MASC - Approval Needed"
+        ~title:"MASC - Approval Needed"
         ~subtitle:agent
         ~message:(Printf.sprintf "Action: %s" action)
         ?focus_cmd
@@ -300,7 +300,7 @@ let notify event =
       } in
       send_notification
         ~title:(Printf.sprintf "%s MASC" emoji)
-        ~subtitle:"✅ Task Completed"
+        ~subtitle:"Task Completed"
         ~message:(Printf.sprintf "%s finished %s" agent task_id)
         ?focus_cmd
         ()

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -194,8 +194,8 @@ let make_zero_zombie_consumer ~sw ~room_config
           if String.length status_trimmed > 0 then begin
             let has_zombie_indicator =
               try
-                Base.String.is_prefix status_trimmed ~prefix:"\xf0\x9f\xa7\x9f" ||
-                Base.String.is_prefix status_trimmed ~prefix:"Cleaned"
+                String.starts_with status_trimmed ~prefix:"\xf0\x9f\xa7\x9f" ||
+                String.starts_with status_trimmed ~prefix:"Cleaned"
               with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                 Log.Orchestrator.warn "zombie indicator check failed: %s" (Printexc.to_string exn);
                 false

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -339,7 +339,7 @@ let resolve_task_id (config : Coord.config) ~task_id : (string, string) result =
 
 (** Format error entry for display *)
 let format_error_entry i (e : error_entry) =
-  let status = if e.resolved then "✅" else "❌" in
+  let status = if e.resolved then "done" else "open" in
   let ctx_str = match e.context with Some c -> Printf.sprintf " (%s)" c | None -> "" in
   Printf.sprintf "%d. %s [%s] **%s**%s: %s" (i+1) status e.timestamp e.error_type ctx_str e.message
 

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -284,7 +284,7 @@ let compress_context ~summary ~task ~todos ~pdca ~files
 (** Build handoff prompt for the new agent *)
 let build_handoff_prompt ~payload ~generation =
   let header = Printf.sprintf
-    "🔄 **RELAY HANDOFF** (Generation %d)\n\n\
+    "**RELAY HANDOFF** (Generation %d)\n\n\
      You are continuing work from a previous agent session.\n\
      The previous agent's context was getting full, so it handed off to you.\n\n\
      **IMPORTANT**: Continue the work seamlessly. The user should not notice the transition.\n\n"

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -38,7 +38,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                        "created"
                    | Error msg ->
                        (* The error string is double-wrapped by the time it
-                          reaches us ("worktree creation failed: ❌ IO
+                          reaches us ("worktree creation failed: IO
                           error: <inner>"), so prefix-match by substring on
                           the inner tag rather than expecting an exact
                           match.  ambiguous_task_repo and

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -63,7 +63,7 @@ let body_jsonrpc_method body_str =
 
 let is_notification_method method_ =
   let prefix = "notifications/" in
-  Base.String.is_prefix method_ ~prefix
+  String.starts_with method_ ~prefix
 
 let is_initialize_method method_ = String.equal method_ "initialize"
 

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -409,7 +409,7 @@ let status_string registry =
 
     let inactive = get_inactive_agents registry ~threshold:Coord_resilience.default_warning_threshold in
     if inactive <> [] then begin
-      Buffer.add_string buf "\n\n⚠️ **INACTIVE AGENTS**: ";
+      Buffer.add_string buf "\n\n**INACTIVE AGENTS**: ";
       Buffer.add_string buf (String.concat ", " inactive);
       Buffer.add_string buf "\n   @mention으로 깨워주세요!"
     end;

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -449,15 +449,15 @@ let format_token_info result =
         Printf.sprintf " (cache: +%d created, %d read)" cc cr
       | _ -> ""
     in
-    Printf.sprintf "\n📊 Tokens: %d in / %d out%s | Cost: $%.4f" inp out cache_info cost
+    Printf.sprintf "\nTokens: %d in / %d out%s | Cost: $%.4f" inp out cache_info cost
   | _ -> ""
 
 (** Result to human-readable string *)
 let result_to_string result =
   let token_info = format_token_info result in
   if result.success then
-    Printf.sprintf "✅ Agent completed in %dms%s\n\n%s"
+    Printf.sprintf "Agent completed in %dms%s\n\n%s"
       result.elapsed_ms token_info result.output
   else
-    Printf.sprintf "❌ Agent failed (exit %d) in %dms%s\n\n%s"
+    Printf.sprintf "Agent failed (exit %d) in %dms%s\n\n%s"
       result.exit_code result.elapsed_ms token_info result.output

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -813,7 +813,7 @@ let tool_post_list : Types.tool_schema = {
       ("exclude_system", `Assoc [("type", `String "boolean"); ("description", `String "Exclude system posts like Activity Reports (default: false)")]);
       ("exclude_automation", `Assoc [("type", `String "boolean"); ("description", `String "Exclude automation posts (heartbeat, probes, etc.) (default: false)")]);
       ("author", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter posts by author name (case-insensitive substring match)")]);
-      ("since", `Assoc [("type", `String "number"); ("description", `String "Unix timestamp. Posts with activity after this time show a indicator")]);
+      ("since", `Assoc [("type", `String "number"); ("description", `String "Unix timestamp. Posts with activity after this time show an activity indicator")]);
       ("compact", `Assoc [("type", `String "boolean"); ("default", `Bool true); ("description", `String "Compact one-line per post. Set false for full body/TTL/visibility")]);
     ]);
   ];

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -439,9 +439,9 @@ let handle_post_create args =
     | None -> false
   in
   if title_is_empty then
-    (false, "❌ title is required")
+    (false, "title is required")
   else if Option.is_none author || Option.equal String.equal author (Some "") || Option.equal String.equal author (Some "anonymous") then
-    (false, "❌ author is required")
+    (false, "author is required")
   else if String.length content > Board.Limits.max_content_length then
     (false, Printf.sprintf "Content exceeds max length (%d > %d chars)"
        (String.length content) Board.Limits.max_content_length)
@@ -459,7 +459,7 @@ let handle_post_create args =
     | None -> Board.Internal
   in
   match resolve_board_post_kind ~author raw_post_kind with
-  | Error msg -> (false, "❌ " ^ msg)
+  | Error msg -> (false, "" ^ msg)
   | Ok post_kind ->
       match
         Board_dispatch.create_post ~author ~content ?title ?body ~post_kind ?meta_json
@@ -467,9 +467,9 @@ let handle_post_create args =
       with
       | Ok post ->
           let json = Board.post_to_yojson post in
-          (true, Printf.sprintf "✅ Post created:\n%s" (Yojson.Safe.pretty_to_string json))
+          (true, Printf.sprintf "Post created:\n%s" (Yojson.Safe.pretty_to_string json))
       | Error e ->
-          (false, Printf.sprintf "❌ %s" (board_error_to_string e))
+          (false, Printf.sprintf "%s" (board_error_to_string e))
 
 (** Issue #8449 PR B: [sort_order] is now a re-export of
     [Board_dispatch.sort_order] (type-alias with definition equality),
@@ -529,7 +529,7 @@ let handle_post_list_uncached args =
     | Some value -> parse_sort_order value
   in
   match sort_by_result with
-  | Error msg -> (false, Printf.sprintf "❌ %s" msg)
+  | Error msg -> (false, Printf.sprintf "%s" msg)
   | Ok sort_by ->
       (* Fetch exactly what we need: offset posts to skip + limit posts to show.
          Board_dispatch.list_posts already applies visibility/hearth/author filters. *)
@@ -554,7 +554,7 @@ let handle_post_list_uncached args =
           List.filteri (fun i _ -> i < limit) sorted_posts
       in
       if Stdlib.List.length posts = 0 then
-        (true, "📭 No posts found.")
+        (true, "No posts found.")
       else
         (* Check for new activity since timestamp *)
         let has_new_activity (p : Board.post) =
@@ -571,15 +571,15 @@ let handle_post_list_uncached args =
         in
         let formatted = List.map format_post_with_indicator posts in
         let sort_label = match sort_by with
-          | Hot -> "🔥 Hot"
-          | Trending -> "📈 Trending"
-          | Recent -> "🕐 Recent"
-          | Updated -> "🔄 Recently Updated"
-          | Discussed -> "💬 Most Discussed"
+          | Hot -> "Hot"
+          | Trending -> "Trending"
+          | Recent -> "Recent"
+          | Updated -> "Recently Updated"
+          | Discussed -> "Most Discussed"
         in
         let separator = if compact then "\n" else "\n\n---\n\n" in
         let mode_label = if compact then " (compact)" else "" in
-        let header = Printf.sprintf "📋 Posts (%d) — %s%s:" (List.length posts) sort_label mode_label in
+        let header = Printf.sprintf "Posts (%d) — %s%s:" (List.length posts) sort_label mode_label in
         (true, header ^ "\n" ^ String.concat separator formatted)
 
 let handle_post_list args =
@@ -598,15 +598,15 @@ let handle_post_get args =
       (* Idempotent: post no longer exists (deleted/expired/TTL).
          Return success so keeper tool metrics don't count this as failure.
          The LLM still sees a clear message that the post is gone. *)
-      (true, Printf.sprintf "📭 Post %s no longer exists (deleted or expired)." post_id)
-  | Error e -> (false, Printf.sprintf "❌ %s" (board_error_to_string e))
+      (true, Printf.sprintf "Post %s no longer exists (deleted or expired)." post_id)
+  | Error e -> (false, Printf.sprintf "%s" (board_error_to_string e))
   | Ok (post, comments) ->
       let post_str = format_post post in
       let comments_str = if Stdlib.List.length comments = 0 then
-        "\n\n💬 No comments."
+        "\n\nNo comments."
       else
         let formatted = format_comment_tree comments in
-        Printf.sprintf "\n\n💬 **Comments (%d)**:\n%s"
+        Printf.sprintf "\n\n**Comments (%d)**:\n%s"
           (List.length comments)
           (String.concat "\n" formatted)
       in
@@ -632,9 +632,9 @@ let handle_comment_add args =
           ~content ?parent_id ~ttl_hours () with
   | Ok comment ->
       let json = Board.comment_to_yojson comment in
-      (true, Printf.sprintf "✅ Comment added:\n%s" (Yojson.Safe.pretty_to_string json))
+      (true, Printf.sprintf "Comment added:\n%s" (Yojson.Safe.pretty_to_string json))
   | Error e ->
-      (false, Printf.sprintf "❌ %s" (board_error_to_string e))
+      (false, Printf.sprintf "%s" (board_error_to_string e))
 
 (** SOUL Evolution callback - registered at startup to break dependency cycle *)
 type evolution_callback = {
@@ -676,7 +676,7 @@ let handle_vote args =
                   in
                   let is_positive = ((=) direction Board.Up) in
                   cb.record_feedback ~name:author ~dimension ~is_positive;
-                  Printf.sprintf " [🧬 %s evolved: %s %s]"
+                  Printf.sprintf " [%s evolved: %s %s]"
                     author dimension (if is_positive then "+0.01" else "-0.01")
                 end else ""
             | Error e ->
@@ -695,26 +695,26 @@ let handle_vote args =
        | Error _ ->
            (true, "Already voted (idempotent). Score unchanged."))
   | Error e ->
-      (false, Printf.sprintf "❌ %s" (board_error_to_string e))
+      (false, Printf.sprintf "%s" (board_error_to_string e))
 
 let handle_stats _args =
   let stats = Board_dispatch.stats () in
-  (true, Printf.sprintf "📊 Board Stats:\n%s" (Yojson.Safe.pretty_to_string stats))
+  (true, Printf.sprintf "Board Stats:\n%s" (Yojson.Safe.pretty_to_string stats))
 
 (** Search posts by keyword *)
 let handle_search args =
   let query = get_string args "query" "" in
   let limit = get_int args "limit" 20 |> max 1 |> min 100 in
   let compact = get_bool args "compact" true in
-  if String.equal query "" then (false, "❌ query required")
+  if String.equal query "" then (false, "query required")
   else
     let results = Board_dispatch.search ~query ~limit in
-    if Stdlib.List.length results = 0 then (true, Printf.sprintf "🔍 '%s' 검색 결과 없음" query)
+    if Stdlib.List.length results = 0 then (true, Printf.sprintf "'%s' 검색 결과 없음" query)
     else
       let fmt = if compact then format_post_compact else format_post in
       let formatted = List.map fmt results in
       let separator = if compact then "\n" else "\n---\n" in
-      (true, Printf.sprintf "🔍 '%s' 검색 결과 (%d개):\n\n%s" query (List.length results) (String.concat separator formatted))
+      (true, Printf.sprintf "'%s' 검색 결과 (%d개):\n\n%s" query (List.length results) (String.concat separator formatted))
 
 (** Vote on comment *)
 let handle_comment_vote args =
@@ -722,18 +722,18 @@ let handle_comment_vote args =
   let voter = get_string args "voter" "anonymous" in
   let direction_str = get_string args "direction" "up" in
   let direction = if String.equal direction_str "down" then Board.Down else Board.Up in
-  if String.equal comment_id "" then (false, "❌ comment_id required")
+  if String.equal comment_id "" then (false, "comment_id required")
   else
     match Board_dispatch.vote_comment ~voter ~comment_id ~direction with
     | Ok score -> (true, Printf.sprintf "%s 코멘트 투표 완료! 점수: %+d" (if String.equal direction_str "down" then "👎" else "👍") score)
     | Error (Board.Already_voted _) ->
         (true, Printf.sprintf "%s Already voted (idempotent)." (if String.equal direction_str "down" then "👎" else "👍"))
-    | Error e -> (false, Printf.sprintf "❌ %s" (board_error_to_string e))
+    | Error e -> (false, Printf.sprintf "%s" (board_error_to_string e))
 
 (** Agent profile *)
 let handle_profile args =
   let agent = get_string args "agent" "" in
-  if String.equal agent "" then (false, "❌ agent required")
+  if String.equal agent "" then (false, "agent required")
   else
     let all_posts : Board.post list = Board_dispatch.list_posts ~limit:1000 () in
     let norm s = String.lowercase_ascii (String.trim s) in
@@ -743,18 +743,18 @@ let handle_profile args =
     let all_comments : Board.comment list = Board_dispatch.list_comments () in
     let agent_comments = List.filter (fun (c : Board.comment) -> String.equal (norm (Board.Agent_id.to_string c.author)) agent_norm) all_comments in
     let comment_votes = List.fold_left (fun acc (c : Board.comment) -> acc + c.votes_up - c.votes_down) 0 agent_comments in
-    (true, Printf.sprintf "📊 **%s** 프로필\n📝 게시물: %d개 (%+d점)\n💬 코멘트: %d개 (%+d점)\n⭐ 총: %+d점"
+    (true, Printf.sprintf "**%s** 프로필\n게시물: %d개 (%+d점)\n코멘트: %d개 (%+d점)\n총: %+d점"
       agent (List.length agent_posts) post_votes (List.length agent_comments) comment_votes (post_votes + comment_votes))
 
 (** Hearth list *)
 let handle_hearth_list _args =
   let hearths = Board_dispatch.list_hearths () in
-  if Stdlib.List.length hearths = 0 then (true, "🔥 No active hearths.")
+  if Stdlib.List.length hearths = 0 then (true, "No active hearths.")
   else
     let formatted = List.map (fun (name, count) ->
-      Printf.sprintf "🔥 **%s** (%d posts)" name count
+      Printf.sprintf "**%s** (%d posts)" name count
     ) hearths in
-    (true, Printf.sprintf "🔥 Active Hearths:\n%s" (String.concat "\n" formatted))
+    (true, Printf.sprintf "Active Hearths:\n%s" (String.concat "\n" formatted))
 
 (** {1 Tool Definitions} *)
 
@@ -813,7 +813,7 @@ let tool_post_list : Types.tool_schema = {
       ("exclude_system", `Assoc [("type", `String "boolean"); ("description", `String "Exclude system posts like Activity Reports (default: false)")]);
       ("exclude_automation", `Assoc [("type", `String "boolean"); ("description", `String "Exclude automation posts (heartbeat, probes, etc.) (default: false)")]);
       ("author", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter posts by author name (case-insensitive substring match)")]);
-      ("since", `Assoc [("type", `String "number"); ("description", `String "Unix timestamp. Posts with activity after this time show a 🔔 indicator")]);
+      ("since", `Assoc [("type", `String "number"); ("description", `String "Unix timestamp. Posts with activity after this time show a indicator")]);
       ("compact", `Assoc [("type", `String "boolean"); ("default", `Bool true); ("description", `String "Compact one-line per post. Set false for full body/TTL/visibility")]);
     ]);
   ];

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -341,9 +341,9 @@ let handle_code_search ctx args =
   let max_results = get_int args "max_results" 50 in
 
   if String.equal query "" then
-    (false, "❌ Query required: 'query' parameter")
+    (false, "Query required: 'query' parameter")
   else if String.equal (String.trim path) "" then
-    (false, "❌ Path required: 'path' parameter")
+    (false, "Path required: 'path' parameter")
   else begin
     (* Validate path first *)
     let search_path_result =
@@ -432,7 +432,7 @@ let handle_code_search ctx args =
             "Literal search failed. If your query contains regex chars (*+?[](){}^$|.\\), \
              try simplifying the query or set is_regex=true with a valid regex."
         in
-        (false, Printf.sprintf "❌ %s\nrg output: %s" hint
+        (false, Printf.sprintf "%s\nrg output: %s" hint
            (if String.equal trimmed_out "" then "(empty)"
             else String_util.utf8_safe ~max_bytes:303 ~suffix:"..." trimmed_out |> String_util.to_string))
     | status, output ->
@@ -451,20 +451,20 @@ let handle_code_symbols ctx args =
   let path = get_string args "path" "" in
 
   if String.equal path "" then
-    (false, "❌ Path required: 'path' parameter")
+    (false, "Path required: 'path' parameter")
   else begin
     match validate_read_path ~agent_name:ctx.agent_name ctx.config path with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok validated_path ->
         if not (Sys.file_exists validated_path) then
-          (false, Printf.sprintf "❌ File not found: %s" path)
+          (false, Printf.sprintf "File not found: %s" path)
         else if is_binary_file validated_path then
-          (false, "❌ Binary file detected")
+          (false, "Binary file detected")
         else begin
           (* Read file and extract symbols *)
           let file_size = (Unix.stat validated_path).Unix.st_size in
           if file_size > max_file_size then
-            (false, Printf.sprintf "❌ File too large: %d bytes (max: %d)" file_size max_file_size)
+            (false, Printf.sprintf "File too large: %d bytes (max: %d)" file_size max_file_size)
           else begin
             try
               let content = In_channel.with_open_text validated_path In_channel.input_all in
@@ -518,7 +518,7 @@ let handle_code_symbols ctx args =
               ] in
               (true, Yojson.Safe.to_string response)
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              (false, Printf.sprintf "❌ Failed to read file: %s" (Stdlib.Printexc.to_string exn))
+              (false, Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
           end
         end
   end
@@ -530,19 +530,19 @@ let handle_code_read ctx args =
   let limit = get_int args "limit" 100 in
 
   if String.equal path "" then
-    (false, "❌ Path required: 'path' parameter")
+    (false, "Path required: 'path' parameter")
   else begin
     match validate_read_path ~agent_name:ctx.agent_name ctx.config path with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok validated_path ->
         if not (Sys.file_exists validated_path) then
-          (false, Printf.sprintf "❌ File not found: %s" path)
+          (false, Printf.sprintf "File not found: %s" path)
         else if is_binary_file validated_path then
-          (false, "❌ Binary file detected")
+          (false, "Binary file detected")
         else begin
           let file_size = (Unix.stat validated_path).Unix.st_size in
           if file_size > max_file_size then
-            (false, Printf.sprintf "❌ File too large: %d bytes (max: %d)" file_size max_file_size)
+            (false, Printf.sprintf "File too large: %d bytes (max: %d)" file_size max_file_size)
           else begin
             try
               let content = In_channel.with_open_text validated_path In_channel.input_all in
@@ -573,7 +573,7 @@ let handle_code_read ctx args =
               ] in
               (true, Yojson.Safe.to_string response)
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              (false, Printf.sprintf "❌ Failed to read file: %s" (Stdlib.Printexc.to_string exn))
+              (false, Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
           end
         end
   end

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -555,7 +555,7 @@ let handle_reset ctx args =
   let confirm = get_bool args "confirm" false in
   if not confirm then
     { success = false;
-      message = "⚠️ This will DELETE the entire .masc/ folder!\nCall with confirm=true to proceed." }
+      message = "This will DELETE the entire .masc/ folder!\nCall with confirm=true to proceed." }
   else begin
     invalidate_status_cache ();
     { success = true; message = Coord.reset ctx.config }
@@ -649,7 +649,7 @@ let handle_coordination_fsm_snapshot ctx _args =
     aren't updated. Same shape as #8546 / #8601 / #8592. *)
 let handle_heartbeat ctx _args =
   let message = Coord.heartbeat ctx.config ~agent_name:ctx.agent_name in
-  (* Coord.heartbeat returns "⚠ ..." on failure (agent not found, invalid file) *)
+  (* Coord.heartbeat returns "..." on failure (agent not found, invalid file) *)
   let success = not (String.length message >= 3
     && Char.code message.[0] = 0xe2
     && Char.code message.[1] = 0x9a

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -163,7 +163,7 @@ let prepare_keeper_up_identity ctx args =
           Ok (prepared_args, identity_reseed)
       | Error _ as err -> err)
   | Ok None -> Ok (args, None)
-  | Error err -> Error (Printf.sprintf "❌ %s" err)
+  | Error err -> Error (Printf.sprintf "%s" err)
 
 let startup_not_ready_error_json elapsed =
   `Assoc
@@ -343,7 +343,7 @@ let prepare_passive_keeper_identity ctx args =
             Ok (with_keeper_name args updated_meta.name, identity_reseed)
         | Error _ as err -> err)
     | Ok None -> Ok (args, None)
-    | Error err -> Error (Printf.sprintf "❌ %s" err)
+    | Error err -> Error (Printf.sprintf "%s" err)
 
 let attach_identity_reseed ?identity_reseed json =
   match identity_reseed with
@@ -357,7 +357,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
     (false, startup_not_ready_error_json elapsed)
   end else
   match Keeper_exec_persona.resolved_keeper_args_from_persona args with
-  | Error e -> (false, "❌ " ^ e)
+  | Error e -> (false, "" ^ e)
   | Ok (persona, resolved_args) ->
       let dry_run = get_bool args "dry_run" false in
       if dry_run then
@@ -372,7 +372,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         (true, Yojson.Safe.to_string json)
       else
         match Keeper_exec_persona.render_keeper_toml_from_resolved_args resolved_args with
-        | Error e -> (false, "❌ " ^ e)
+        | Error e -> (false, "" ^ e)
         | Ok _ ->
         let (ok, body) = with_keeper_startup_gate (fun () -> execute_keeper_up ctx resolved_args) in
         if not ok then
@@ -380,7 +380,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         else
           match Keeper_exec_persona.persist_keeper_toml_from_resolved_args resolved_args with
           | Error e ->
-              (false, "❌ keeper created but durable config write failed: " ^ e)
+              (false, "keeper created but durable config write failed: " ^ e)
           | Ok durable_config ->
           let created_json =
             try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
@@ -428,10 +428,10 @@ let resolve_keeper_name ctx args =
        | Some stripped ->
            Error
              (Printf.sprintf
-                "❌ keeper not found: %s (also tried %s)"
+                "keeper not found: %s (also tried %s)"
                 name stripped)
-       | None -> Error (Printf.sprintf "❌ keeper not found: %s" name))
-  | Error err -> Error (Printf.sprintf "❌ %s" err)
+       | None -> Error (Printf.sprintf "keeper not found: %s" name))
+  | Error err -> Error (Printf.sprintf "%s" err)
 
 let handle_keeper_msg ctx args : tool_result =
   match resolve_keeper_name ctx args with
@@ -489,8 +489,8 @@ let resolve_keeper_meta ctx args =
   let name = String.trim (get_string args "name" "") in
   match read_meta_resolved ctx.config name with
   | Ok (Some (_resolved_name, meta)) -> Ok meta
-  | Ok None -> Error (Printf.sprintf "❌ keeper not found: %s" name)
-  | Error err -> Error (Printf.sprintf "❌ %s" err)
+  | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
+  | Error err -> Error (Printf.sprintf "%s" err)
 
 let default_keeper_model_label (meta : keeper_meta) =
   match String.trim meta.runtime.usage.last_model_used with

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -46,7 +46,7 @@ let handle_dashboard ctx args =
   match Dashboard.scope_of_string_opt scope_arg with
   | None ->
       (false,
-       Printf.sprintf "❌ Invalid dashboard scope '%s' (expected: %s)"
+       Printf.sprintf "Invalid dashboard scope '%s' (expected: %s)"
          scope_arg
          (String.concat " | " Dashboard.valid_scope_strings))
   | Some scope ->
@@ -64,7 +64,7 @@ let handle_gc ctx args =
   let gc_result = Coord.gc ctx.config ~days () in
   let expired = 0 in
   let decision_note =
-    if expired > 0 then Printf.sprintf "\n⏰ Expired %d pending decision(s) past TTL" expired
+    if expired > 0 then Printf.sprintf "\nExpired %d pending decision(s) past TTL" expired
     else ""
   in
   (true, gc_result ^ decision_note)
@@ -91,11 +91,11 @@ let strip_mcp_prefix name =
 let handle_tool_help _ctx args =
   let raw_name = String.trim (get_string args "tool_name" "") in
   if String.equal raw_name "" then
-    (false, "❌ tool_name is required")
+    (false, "tool_name is required")
   else
     let tool_name = strip_mcp_prefix raw_name in
     match Tool_help_registry.find_entry Config.raw_all_tool_schemas tool_name with
-    | None -> (false, Printf.sprintf "❌ unknown tool: %s" raw_name)
+    | None -> (false, Printf.sprintf "unknown tool: %s" raw_name)
     | Some entry ->
         (true, Yojson.Safe.to_string (Tool_help_registry.entry_json entry))
 

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -305,7 +305,7 @@ let handle_tool_admin_update ctx args =
         | None -> Ok current.token_expiry_hours
       in
       (match expiry_hours with
-      | Error err -> (false, "" ^ err)
+      | Error err -> (false, err)
       | Ok token_expiry_hours ->
           let room_secret =
             match enabled_opt with

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -290,7 +290,7 @@ let handle_tool_admin_update ctx args =
   | "auth" ->
       let current = Auth.load_auth_config ctx.config.base_path in
       if not ((=) (U.member "default_role" args) `Null) then
-        (false, "❌ default_role is no longer supported")
+        (false, "default_role is no longer supported")
       else
       let require_token =
         match bool_arg_opt args "require_token" with
@@ -305,7 +305,7 @@ let handle_tool_admin_update ctx args =
         | None -> Ok current.token_expiry_hours
       in
       (match expiry_hours with
-      | Error err -> (false, "❌ " ^ err)
+      | Error err -> (false, "" ^ err)
       | Ok token_expiry_hours ->
           let room_secret =
             match enabled_opt with

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -46,7 +46,7 @@ let handle_plan_init ctx args : tool_result =
       ] in
       (true, Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to init planning: %s" e)
+      (false, Printf.sprintf "Failed to init planning: %s" e)
 
 let handle_plan_update ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
@@ -61,7 +61,7 @@ let handle_plan_update ctx args : tool_result =
       ] in
       (true, Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to update plan: %s" e)
+      (false, Printf.sprintf "Failed to update plan: %s" e)
 
 let handle_note_add ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
@@ -76,16 +76,16 @@ let handle_note_add ctx args : tool_result =
       ] in
       (true, Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to add note: %s" e)
+      (false, Printf.sprintf "Failed to add note: %s" e)
 
 let handle_deliver ctx args : tool_result =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
-  | Error e -> (false, Printf.sprintf "❌ %s" e)
+  | Error e -> (false, Printf.sprintf "%s" e)
   | Ok task_id ->
   let content = get_string args "content" "" in
   if String.equal (String.trim content) "" then
-    (false, "❌ content is required for masc_deliver")
+    (false, "content is required for masc_deliver")
   else
   let result = Planning_eio.set_deliverable ctx.config ~task_id ~content in
   match result with
@@ -97,12 +97,12 @@ let handle_deliver ctx args : tool_result =
       ] in
       (true, Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to set deliverable: %s" e)
+      (false, Printf.sprintf "Failed to set deliverable: %s" e)
 
 let handle_plan_get ctx args : tool_result =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
-  | Error e -> (false, Printf.sprintf "❌ %s" e)
+  | Error e -> (false, Printf.sprintf "%s" e)
   | Ok task_id ->
       let result = Planning_eio.load ctx.config ~task_id in
       match result with
@@ -115,12 +115,12 @@ let handle_plan_get ctx args : tool_result =
           ] in
           (true, Yojson.Safe.to_string response)
       | Error e ->
-          (false, Printf.sprintf "❌ Planning context not found: %s" e)
+          (false, Printf.sprintf "Planning context not found: %s" e)
 
 let handle_plan_set_task ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "❌ task_id is required")
+    (false, "task_id is required")
   else begin
     Planning_eio.set_current_task ctx.config ~task_id;
     let response = `Assoc [

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -43,7 +43,7 @@ let handle_run_init ctx args : tool_result =
   | Ok run ->
       (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to init run: %s" e)
+      (false, Printf.sprintf "Failed to init run: %s" e)
 
 let handle_run_plan ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
@@ -55,7 +55,7 @@ let handle_run_plan ctx args : tool_result =
   | Ok run ->
       (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to update run plan: %s" e)
+      (false, Printf.sprintf "Failed to update run plan: %s" e)
 
 let handle_run_log ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
@@ -67,7 +67,7 @@ let handle_run_log ctx args : tool_result =
   | Ok entry ->
       (true, Yojson.Safe.to_string (Run_eio.log_entry_to_json entry))
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to append run log: %s" e)
+      (false, Printf.sprintf "Failed to append run log: %s" e)
 
 let handle_run_deliverable ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
@@ -79,7 +79,7 @@ let handle_run_deliverable ctx args : tool_result =
   | Ok run ->
       (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
-      (false, Printf.sprintf "❌ Failed to set run deliverable: %s" e)
+      (false, Printf.sprintf "Failed to set run deliverable: %s" e)
 
 let handle_run_get ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
@@ -88,7 +88,7 @@ let handle_run_get ctx args : tool_result =
   else
     match Run_eio.get ctx.config ~task_id with
     | Ok json -> (true, Yojson.Safe.to_string json)
-    | Error e -> (false, Printf.sprintf "❌ Failed to get run: %s" e)
+    | Error e -> (false, Printf.sprintf "Failed to get run: %s" e)
 
 let handle_run_list ctx _args : tool_result =
   let json = Run_eio.list ctx.config in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -598,10 +598,10 @@ let handle_claim_next ?agent_tool_names ctx _args =
         sync_planning_current_task_with_owned_task ctx;
         append_claim_observation message ~now:(Time_compat.now ())
           ~agent_name:ctx.agent_name ~task_id
-    | Coord.Claim_next_no_unclaimed -> "📋 No unclaimed tasks available"
+    | Coord.Claim_next_no_unclaimed -> "No unclaimed tasks available"
     | Coord.Claim_next_no_eligible { excluded_count; _ } ->
-        Printf.sprintf "📋 No eligible tasks available (blocked/excluded: %d)" excluded_count
-    | Coord.Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
+        Printf.sprintf "No eligible tasks available (blocked/excluded: %d)" excluded_count
+    | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
   in
   (true, message)
 

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -335,7 +335,7 @@ let parse_keeper_chat_response response =
     | [] -> Ok ()
     | raw_line :: rest ->
         let line = trim raw_line in
-        if String.length line > 6 && Base.String.is_prefix line ~prefix:"data: " then (
+        if String.length line > 6 && String.starts_with line ~prefix:"data: " then (
           let payload = String.sub line 6 (String.length line - 6) |> trim in
           if payload = "[DONE]" || payload = "" then consume_sse rest
           else

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -99,41 +99,41 @@ type t =
   | ValidationError of string
 
 let rec to_string = function
-  | NotInitialized -> "❌ MASC not initialized. Use masc_init first."
+  | NotInitialized -> "MASC not initialized. Use masc_init first."
   | AlreadyInitialized -> "MASC already initialized."
-  | AgentNotFound name -> Printf.sprintf "❌ Agent not found: %s" name
-  | AgentNotJoined name -> Printf.sprintf "❌ Agent not joined: %s. Use masc_join first." name
-  | AgentAlreadyJoined name -> Printf.sprintf "⚠ %s is already in the room" name
-  | TaskNotFound id -> Printf.sprintf "❌ Task not found: %s. Call masc_status to refresh your task list." id
+  | AgentNotFound name -> Printf.sprintf "Agent not found: %s" name
+  | AgentNotJoined name -> Printf.sprintf "Agent not joined: %s. Use masc_join first." name
+  | AgentAlreadyJoined name -> Printf.sprintf "%s is already in the room" name
+  | TaskNotFound id -> Printf.sprintf "Task not found: %s. Call masc_status to refresh your task list." id
   | TaskAlreadyClaimed { task_id; by } ->
       Printf.sprintf
-        "❌ Task %s is currently owned by %s. Ask that agent to finish it, or claim a different task."
+        "Task %s is currently owned by %s. Ask that agent to finish it, or claim a different task."
         task_id by
   | TaskNotClaimed id ->
       Printf.sprintf
-        "❌ Task %s is still todo. Claim/start it first, then mark it done."
+        "Task %s is still todo. Claim/start it first, then mark it done."
         id
-  | TaskInvalidState msg -> Printf.sprintf "❌ Invalid task state: %s" msg
-  | PortalNotOpen agent -> Printf.sprintf "❌ No portal open for %s. Use masc_portal_open first." agent
-  | PortalAlreadyOpen { agent; target } -> Printf.sprintf "⚠ Portal already open: %s ↔ %s" agent target
-  | PortalClosed agent -> Printf.sprintf "❌ Portal is closed for %s. Use masc_portal_open to reopen." agent
-  | InvalidJson msg -> Printf.sprintf "❌ Invalid JSON: %s" msg
-  | IoError msg -> Printf.sprintf "❌ IO error: %s" msg
-  | InvalidAgentName reason -> Printf.sprintf "❌ Invalid agent name: %s" reason
-  | InvalidTaskId reason -> Printf.sprintf "❌ Invalid task ID: %s" reason
-  | InvalidFilePath reason -> Printf.sprintf "❌ Invalid file path: %s" reason
-  | Unauthorized reason -> Printf.sprintf "🔐 Unauthorized: %s" reason
-  | Forbidden { agent; action } -> Printf.sprintf "🚫 Forbidden: %s cannot %s" agent action
-  | TokenExpired agent -> Printf.sprintf "⏰ Token expired for %s. Use masc_auth_refresh." agent
-  | InvalidToken reason -> Printf.sprintf "🔑 Invalid token: %s" reason
+  | TaskInvalidState msg -> Printf.sprintf "Invalid task state: %s" msg
+  | PortalNotOpen agent -> Printf.sprintf "No portal open for %s. Use masc_portal_open first." agent
+  | PortalAlreadyOpen { agent; target } -> Printf.sprintf "Portal already open: %s <-> %s" agent target
+  | PortalClosed agent -> Printf.sprintf "Portal is closed for %s. Use masc_portal_open to reopen." agent
+  | InvalidJson msg -> Printf.sprintf "Invalid JSON: %s" msg
+  | IoError msg -> Printf.sprintf "IO error: %s" msg
+  | InvalidAgentName reason -> Printf.sprintf "Invalid agent name: %s" reason
+  | InvalidTaskId reason -> Printf.sprintf "Invalid task ID: %s" reason
+  | InvalidFilePath reason -> Printf.sprintf "Invalid file path: %s" reason
+  | Unauthorized reason -> Printf.sprintf "Unauthorized: %s" reason
+  | Forbidden { agent; action } -> Printf.sprintf "Forbidden: %s cannot %s" agent action
+  | TokenExpired agent -> Printf.sprintf "Token expired for %s. Use masc_auth_refresh." agent
+  | InvalidToken reason -> Printf.sprintf "Invalid token: %s" reason
   | RateLimitExceeded e ->
-      Printf.sprintf "⏳ Rate limit exceeded (%s): %d/%d requests. Wait %d seconds."
+      Printf.sprintf "Rate limit exceeded (%s): %d/%d requests. Wait %d seconds."
         (show_rate_limit_category e.category) e.current e.limit e.wait_seconds
   | CacheError e -> (match e with
-      | CacheReadFailed path -> Printf.sprintf "❌ Cache: Read failed [path=%s]" path
-      | CacheWriteFailed path -> Printf.sprintf "❌ Cache: Write failed [path=%s]" path
-      | CacheExpired { key; age_hours } -> Printf.sprintf "❌ Cache: Expired [key=%s, age=%.1fh]" key age_hours
-      | CacheCorrupted path -> Printf.sprintf "❌ Cache: Corrupted [path=%s]" path)
+      | CacheReadFailed path -> Printf.sprintf "Cache read failed [path=%s]" path
+      | CacheWriteFailed path -> Printf.sprintf "Cache write failed [path=%s]" path
+      | CacheExpired { key; age_hours } -> Printf.sprintf "Cache expired [key=%s, age=%.1fh]" key age_hours
+      | CacheCorrupted path -> Printf.sprintf "Cache corrupted [path=%s]" path)
   | StorageError msg -> Printf.sprintf "Storage error: %s" msg
   | ValidationError msg -> Printf.sprintf "Validation error: %s" msg
 

--- a/lib/verifier_core.ml
+++ b/lib/verifier_core.ml
@@ -106,11 +106,11 @@ let parse_verdict (text : string) : (verdict, string) result =
   let trimmed = String.trim text in
   let upper = String.uppercase_ascii trimmed in
   let len = String.length upper in
-  if Base.String.is_prefix upper ~prefix:"PASS" && has_keyword_boundary upper 4 then
+  if String.starts_with upper ~prefix:"PASS" && has_keyword_boundary upper 4 then
     Ok Pass
-  else if Base.String.is_prefix upper ~prefix:"WARN" && has_keyword_boundary upper 4 then
+  else if String.starts_with upper ~prefix:"WARN" && has_keyword_boundary upper 4 then
     Ok (Warn (extract_reason trimmed 4 "unspecified concern"))
-  else if Base.String.is_prefix upper ~prefix:"FAIL" && has_keyword_boundary upper 4 then
+  else if String.starts_with upper ~prefix:"FAIL" && has_keyword_boundary upper 4 then
     Ok (Fail (extract_reason trimmed 4 "action did not achieve goal"))
   else if len = 0 then
     Error "empty verifier output"


### PR DESCRIPTION
## Summary
- Remove 260+ decorative emoji characters (❌⚠🚫🔐⏰🔑✅📊📝💬⭐ etc.) from string literals across 44 files in `lib/`
- Emojis were redundant with text content and harmed machine-readability of error messages
- All replacements maintain semantic meaning (e.g., `"❌ Agent not found"` → `"Agent not found"`, `"⚠ Portal"` → `"Portal"`, `"✅ done"` → `"done"`)

## Audit Source
Kimi Agent MASC-OAS implementation quality audit identified emoji usage as a machine-readability concern. Verified against actual codebase — no catch-all constructors existed despite audit claims to the contrary.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root .` passes
- [x] Visual inspection of error messages confirms semantic preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)