### PR TITLE
refactor: domain-specific error hierarchy

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -449,21 +449,21 @@ let ensure_credential_alias config ~canonical_name ~alias_name :
     let canonical_file = credential_file config canonical_name in
     if not (file_exists canonical_file) then
       Error
-        (IoError
+        (System (System_error.IoError
            (Printf.sprintf
               "canonical credential not found for alias setup: \
                canonical=%s alias=%s"
-              canonical_name alias_name))
+              canonical_name alias_name)))
     else
       match load_redirect_target config canonical_file with
       | None ->
           Error
-            (IoError
+            (System (System_error.IoError
                (Printf.sprintf
                   "canonical credential %s is not a redirect stub; \
                    cannot create alias %s without a UUID-backed \
                    credential"
-                  canonical_name alias_name))
+                  canonical_name alias_name)))
       | Some uuid_file ->
           let uuid_basename = Filename.basename uuid_file in
           let alias_file = credential_file config alias_name in
@@ -487,11 +487,11 @@ let ensure_credential_alias config ~canonical_name ~alias_name :
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn ->
                  Error
-                   (IoError
+                   (System (System_error.IoError
                       (Printf.sprintf
                          "Failed to write alias %s -> %s: %s"
                          alias_name canonical_name
-                         (Printexc.to_string exn))))
+                         (Printexc.to_string exn)))))
 
 let load_raw_token config ~agent_name =
   let file = raw_token_file config agent_name in
@@ -621,7 +621,7 @@ let find_credential_by_token config ~token : (agent_credential, masc_error) resu
       (list_credentials config)
   in
   match matches with
-  | [] -> Error (InvalidToken "Token mismatch")
+  | [] -> Error (Auth (Auth_error.InvalidToken "Token mismatch"))
   | first :: rest ->
       (match rest with
        | [] -> ()
@@ -646,7 +646,7 @@ let find_credential_by_token config ~token : (agent_credential, masc_error) resu
        | None -> Ok first
        | Some exp_str ->
            let now = now_iso () in
-           if now > exp_str then Error (TokenExpired first.agent_name)
+           if now > exp_str then Error (Auth (Auth_error.TokenExpired first.agent_name))
            else Ok first)
 
 (** Resolve agent_name from raw token *)
@@ -688,7 +688,7 @@ let save_raw_token_credential_with_expiry config ~agent_name ~role ~raw_token
         (Printexc.to_string exn)
     in
     Log.Auth.error "%s" msg;
-    Error (IoError msg)
+    Error (System (System_error.IoError msg))
 
 let save_raw_token_credential config ~agent_name ~role ~raw_token :
     (agent_credential, masc_error) result =
@@ -756,7 +756,7 @@ let save_rotated_raw_token config (cred : agent_credential) ~raw_token :
         rotated.agent_name (Printexc.to_string exn)
     in
     Log.Auth.error "%s" msg;
-    Error (IoError msg)
+    Error (System (System_error.IoError msg))
 
 let rotate_shared_tokens_matching config ~include_agent : rotation_outcome list =
   group_credentials_by_token config
@@ -827,10 +827,10 @@ let missing_credential_error config ~agent_name ~token : masc_error =
   | Ok owner when owner.agent_name <> agent_name ->
       record_bearer_token_mismatch
         ~expected_agent:agent_name ~actual_agent:owner.agent_name;
-      Unauthorized
+      Auth (Auth_error.Unauthorized
         (bearer_token_owner_mismatch_message ~requested_agent:agent_name
-           ~token_owner:owner.agent_name)
-  | _ -> Unauthorized ("No credential found for " ^ agent_name)
+           ~token_owner:owner.agent_name))
+  | _ -> Auth (Auth_error.Unauthorized ("No credential found for " ^ agent_name))
 
 (** Verify a token.
 
@@ -856,9 +856,9 @@ let verify_token_owner_alias config ~agent_name ~token =
       record_bearer_token_mismatch
         ~expected_agent:agent_name ~actual_agent:owner.agent_name;
       Error
-        (Unauthorized
+        (Auth (Auth_error.Unauthorized
            (bearer_token_owner_mismatch_message ~requested_agent:agent_name
-              ~token_owner:owner.agent_name))
+              ~token_owner:owner.agent_name)))
   | Error e -> Error e
 
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =
@@ -877,7 +877,7 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
         if Option.is_some (keeper_transport_alias_stable_name agent_name) then
           verify_token_owner_alias config ~agent_name ~token
         else
-          Error (InvalidToken "Token mismatch")
+          Error (Auth (Auth_error.InvalidToken "Token mismatch"))
       else
         (* Check expiry *)
         match cred.expires_at with
@@ -886,7 +886,7 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
             (* Simple ISO string comparison works for UTC *)
             let now = now_iso () in
             if now > exp_str then
-              Error (TokenExpired agent_name)
+              Error (Auth (Auth_error.TokenExpired agent_name))
             else
               Ok cred
 
@@ -999,7 +999,7 @@ let ensure_keeper_credential config ~agent_name :
           (Printexc.to_string exn)
       in
       Log.Auth.error "%s" msg;
-      Error (IoError msg)
+      Error (System (System_error.IoError msg))
   in
   (match result with
    | Ok _ ->
@@ -1025,10 +1025,10 @@ let audit_keeper_credentials config ~keeper_names =
 (** Refresh a token (generate new one, update credential) *)
 let refresh_token config ~agent_name ~old_token : (string * agent_credential, masc_error) result =
   match verify_token config ~agent_name ~token:old_token with
-  | Error (TokenExpired _) ->
+  | Error (Auth (Auth_error.TokenExpired _)) ->
       (* Allow refresh even if expired *)
       (match load_credential_with_aliases config agent_name with
-       | None -> Error (Unauthorized ("No credential found for " ^ agent_name))
+       | None -> Error (Auth (Auth_error.Unauthorized ("No credential found for " ^ agent_name)))
        | Some old_cred -> create_token config ~agent_name ~role:old_cred.role)
   | Error e -> Error e
   | Ok old_cred -> create_token config ~agent_name ~role:old_cred.role
@@ -1065,7 +1065,7 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
     if has_permission Worker permission then
       Ok ()
     else
-      Error (Forbidden { agent = agent_name; action = show_permission permission })
+      Error (Auth (Auth_error.Forbidden { agent = agent_name; action = show_permission permission }))
   else
     match verify_optional_token config ~agent_name ~token with
     | Error e -> Error e
@@ -1073,7 +1073,7 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
         if has_permission cred.role permission then
           Ok ()
         else
-          Error (Forbidden { agent = agent_name; action = show_permission permission })
+          Error (Auth (Auth_error.Forbidden { agent = agent_name; action = show_permission permission }))
     | Ok None ->
         if not auth_cfg.require_token then
           (* Optional-token mode: anonymous callers are always treated as
@@ -1081,9 +1081,9 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
           if has_permission Worker permission then
             Ok ()
           else
-            Error (Forbidden { agent = agent_name; action = show_permission permission })
+            Error (Auth (Auth_error.Forbidden { agent = agent_name; action = show_permission permission }))
         else
-          Error (Unauthorized "Token required")
+          Error (Auth (Auth_error.Unauthorized "Token required"))
 
 let permission_for_tool tool_name =
   Tool_permission_map.permission_for_tool tool_name
@@ -1143,11 +1143,11 @@ let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) res
       else
         let () = record_strict_unknown_tool_denial ~agent_name ~tool_name in
         Error
-          (Forbidden
+          (Auth (Auth_error.Forbidden
              {
                agent = agent_name;
                action = "use unknown non-masc tool: " ^ tool_name;
-             })
+             }))
   | Some perm -> check_permission config ~agent_name ~token ~permission:perm
 
 (* ============================================ *)
@@ -1176,7 +1176,7 @@ let resolve_role_with_auth_config config ~auth_cfg ~agent_name ~token :
     | Ok (Some cred) -> Ok cred.role
     | Ok None ->
         if auth_cfg.require_token then
-          Error (Unauthorized "Token required")
+          Error (Auth (Auth_error.Unauthorized "Token required"))
         else
           Ok Worker
 
@@ -1188,7 +1188,7 @@ let authorize_tool_for_role ~agent_name ~role ~tool_name :
     (unit, masc_error) result =
   let policy = Tool_access_role.policy_for_role role in
   if not (Tool_access_policy.allows_name policy tool_name) then
-    Error (Forbidden { agent = agent_name; action = tool_name })
+    Error (Auth (Auth_error.Forbidden { agent = agent_name; action = tool_name }))
   else if not (is_tool_auth_strict_enabled ()) then
     Ok ()  (* Non-strict: policy check is sufficient *)
   else
@@ -1199,15 +1199,15 @@ let authorize_tool_for_role ~agent_name ~role ~tool_name :
         if is_unmapped_internal_tool_name tool_name then
           (* Unmapped internal tool: require at least Worker *)
           if has_permission role CanBroadcast then Ok ()
-          else Error (Forbidden { agent = agent_name; action = tool_name })
+          else Error (Auth (Auth_error.Forbidden { agent = agent_name; action = tool_name }))
         else
           let () = record_strict_unknown_tool_denial ~agent_name ~tool_name in
           Error
-            (Forbidden
+            (Auth (Auth_error.Forbidden
                {
                  agent = agent_name;
                  action = "use unknown non-masc tool: " ^ tool_name;
-               })
+               }))
 
 (** Policy-based tool authorization.
     Replaces authorize_tool with a single Tool_access_policy check.

--- a/lib/auth_error_kind.ml
+++ b/lib/auth_error_kind.ml
@@ -43,13 +43,13 @@ let of_string = function
   | _ -> None
 
 let classify : Types.t -> t = function
-  | Types.InvalidToken _ -> Token_mismatch
-  | Types.TokenExpired _ -> Token_expired
-  | Types.Unauthorized _ -> Unauthorized
-  | Types.Forbidden _ -> Forbidden
-  | Types.AgentNotFound _ -> Agent_not_found
-  | Types.IoError _ -> Io_error
-  | Types.InvalidJson _ -> Invalid_json
+  | Types.Auth (Types.Auth_error.InvalidToken _) -> Token_mismatch
+  | Types.Auth (Types.Auth_error.TokenExpired _) -> Token_expired
+  | Types.Auth (Types.Auth_error.Unauthorized _) -> Unauthorized
+  | Types.Auth (Types.Auth_error.Forbidden _) -> Forbidden
+  | Types.Agent (Types.Agent_error.NotFound _) -> Agent_not_found
+  | Types.System (Types.System_error.IoError _) -> Io_error
+  | Types.System (Types.System_error.InvalidJson _) -> Invalid_json
   | _ -> Other
 
 let all =

--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -77,7 +77,7 @@ let register_capabilities config ~agent_name ~capabilities =
 (** Update agent metadata (status/capabilities).
     Since #4638 agent metadata always lives under the root agents_dir. *)
 let update_agent_r config ~agent_name ?status ?capabilities () : string Types.masc_result =
-  if not (is_initialized config) then Error Types.NotInitialized
+  if not (is_initialized config) then Error (Types.System Types.System_error.NotInitialized)
   else match validate_agent_name_r agent_name with
     | Error e -> Error e
     | Ok _ ->
@@ -86,12 +86,12 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
         (* Since #4638 rooms are flattened; agents always in root agents_dir *)
         let agent_file = Filename.concat (agents_dir config) filename in
         if not (Sys.file_exists agent_file) then
-          Error (Types.AgentNotFound actual_name)
+          Error (Types.Agent (Types.Agent_error.NotFound actual_name))
         else
           let locked =
             with_file_lock_r config agent_file (fun () ->
               match read_agent_with_repair config agent_file with
-              | Error _ -> Error (Types.InvalidJson "Invalid agent file")
+              | Error _ -> Error (Types.System (Types.System_error.InvalidJson "Invalid agent file"))
               | Ok agent ->
                   let status_opt =
                     match status with
@@ -99,7 +99,7 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
                     | Some s ->
                         (match Types.agent_status_of_string_opt (String.lowercase_ascii s) with
                          | Some st -> Ok (Some st)
-                         | None -> Error (Types.InvalidJson ("Unknown status: " ^ s)))
+                         | None -> Error (Types.System (Types.System_error.InvalidJson ("Unknown status: " ^ s))))
                   in
                   (match status_opt with
                    | Error e -> Error e
@@ -113,7 +113,7 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
                          | _ -> None
                        in
                        (match invalid with
-                        | Some msg -> Error (Types.TaskInvalidState msg)
+                        | Some msg -> Error (Types.Task (Types.Task_error.InvalidState msg))
                         | None ->
                             let updated_caps =
                               match capabilities with

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -169,18 +169,18 @@ let resolve_base_branch root base_branch =
     | Some resolved -> Ok (resolved, None)
     | None ->
         Error
-          (IoError
-             "Base branch auto-detect failed: no origin/HEAD, origin/main, origin/master, or origin/develop found.")
+          (System (System_error.IoError
+             "Base branch auto-detect failed: no origin/HEAD, origin/main, origin/master, or origin/develop found."))
   else if remote_branch_exists root base_branch then Ok (base_branch, None)
   else
     match List.find_opt (remote_branch_exists root) (auto_base_branch_candidates root) with
     | Some fallback -> Ok (fallback, Some base_branch)
     | None ->
         Error
-          (IoError
+          (System (System_error.IoError
              (Printf.sprintf
                 "Base branch origin/%s not found and no origin/HEAD, origin/main, origin/master, or origin/develop fallback detected."
-                base_branch))
+                base_branch)))
 
 (* ============================================ *)
 (* Worktree Operations                          *)
@@ -189,10 +189,10 @@ let resolve_base_branch root base_branch =
 (** Create worktree for agent *)
 let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_git_repo ~base_path) then
-    Error (IoError "Not a git repository. MASC v2 requires .git directory for worktree isolation.")
+    Error (System (System_error.IoError "Not a git repository. MASC v2 requires .git directory for worktree isolation."))
   else
     match git_root ~base_path with
-    | None -> Error (IoError "Cannot determine git root")
+    | None -> Error (System (System_error.IoError "Cannot determine git root"))
     | Some root ->
         let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
         let worktree_path = Filename.concat root (Filename.concat ".worktrees" worktree_name) in
@@ -217,7 +217,7 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
               ["git"; "-C"; root; "fetch"; "origin"]
           in
           if fetch_exit <> 0 then
-            Error (IoError "Failed to fetch origin before worktree creation.")
+            Error (System (System_error.IoError "Failed to fetch origin before worktree creation."))
           else match resolve_base_branch root base_branch with
           | Error e -> Error e
           | Ok (resolved_base, fallback_from) ->
@@ -247,19 +247,19 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
                   (Printf.sprintf
                      "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work && gh pr create --draft"
                      worktree_path branch_name note worktree_path)
-              else Error (IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base)))
+              else Error (System (System_error.IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base))))
 
 (** Remove worktree after work is merged *)
 let remove ~base_path ~agent_name ~task_id : string masc_result =
   match git_root ~base_path with
-  | None -> Error (IoError "Cannot determine git root")
+  | None -> Error (System (System_error.IoError "Cannot determine git root"))
   | Some root ->
       let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
       let worktree_path = Filename.concat root (Filename.concat ".worktrees" worktree_name) in
       let branch_name = Playground_paths.worktree_branch_name agent_name task_id in
 
       if not (Sys.file_exists worktree_path) then
-        Error (IoError (Printf.sprintf "Worktree not found: %s" worktree_path))
+        Error (System (System_error.IoError (Printf.sprintf "Worktree not found: %s" worktree_path)))
       else
         let exit_code =
           run_argv_exit ["git"; "-C"; root; "worktree"; "remove"; worktree_path]
@@ -278,8 +278,16 @@ let remove ~base_path ~agent_name ~task_id : string masc_result =
           in
           match warnings with
           | [] -> Ok msg
+<<<<<<< HEAD
           | ws -> Ok (msg ^ "\n    Warnings: " ^ String.concat "; " ws))
         else Error (IoError "Failed to remove worktree. It may have uncommitted changes.")
+||||||| parent of ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
+          | ws -> Ok (msg ^ "\n   ⚠️  Warnings: " ^ String.concat "; " ws))
+        else Error (IoError "Failed to remove worktree. It may have uncommitted changes.")
+=======
+          | ws -> Ok (msg ^ "\n   ⚠️  Warnings: " ^ String.concat "; " ws))
+        else Error (System (System_error.IoError "Failed to remove worktree. It may have uncommitted changes."))
+>>>>>>> ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
 
 (** List all worktrees in the repository *)
 let list ~base_path =

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -25,7 +25,7 @@ type activity_entity = { kind: string; id: string }
 let force_release_task_fn
   : (Coord_utils_backend_setup.config -> agent_name:string -> task_id:string -> unit -> string masc_result) Atomic.t
   = Atomic.make (fun _config ~agent_name:_ ~task_id:_ () ->
-      Error (Types.TaskInvalidState "Coord_hooks: force_release_task_fn not connected"))
+      Error (Types.Task (Types.Task_error.InvalidState "Coord_hooks: force_release_task_fn not connected")))
 
 (* ============================================ *)
 (* New callback refs (Phase 4A)                 *)

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -33,7 +33,7 @@ let transition_task_r
   : string Types.masc_result
   =
   let open Result.Syntax in
-  let* () = if not (is_initialized config) then Error Types.NotInitialized else Ok () in
+  let* () = if not (is_initialized config) then Error (Types.System Types.System_error.NotInitialized) else Ok () in
   let* () =
     match validate_agent_name_r agent_name, validate_task_id_r task_id with
     | Error e, _ -> Error e
@@ -50,23 +50,23 @@ let transition_task_r
   with_file_lock config backlog_path (fun () ->
     try
       match read_backlog_r config with
-      | Error msg -> Error (Types.IoError msg)
+      | Error msg -> Error (Types.System (Types.System_error.IoError msg))
       | Ok backlog ->
         let* () =
           match expected_version with
           | Some v when backlog.version <> v ->
             Error
-              (Types.TaskInvalidState
+              (Types.Task (Types.Task_error.InvalidState
                  (Printf.sprintf
                     "Version mismatch (expected %d, got %d)"
                     v
-                    backlog.version))
+                    backlog.version)))
           | _ -> Ok ()
         in
         let task_opt = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
         let* task =
           match task_opt with
-          | None -> Error (Types.TaskNotFound task_id)
+          | None -> Error (Types.Task (Types.Task_error.NotFound task_id))
           | Some task -> Ok task
         in
         let* () =
@@ -86,8 +86,8 @@ let transition_task_r
           match action, do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
           | Types.Claim, Some r ->
             Error
-              (Types.TaskInvalidState
-                 (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r))
+              (Types.Task (Types.Task_error.InvalidState
+                 (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
           | _ -> Ok ()
         in
         let now = now_iso () in
@@ -112,16 +112,16 @@ let transition_task_r
           | Ok decision -> Ok decision
           | Error Coord_task_lifecycle.Self_approval ->
             Error
-              (Types.TaskInvalidState
-                 "Self-approval not allowed: verifier must be a different agent")
+              (Types.Task (Types.Task_error.InvalidState
+                 "Self-approval not allowed: verifier must be a different agent"))
           | Error Coord_task_lifecycle.Self_rejection ->
             Error
-              (Types.TaskInvalidState
-                 "Self-rejection not allowed: verifier must be a different agent")
+              (Types.Task (Types.Task_error.InvalidState
+                 "Self-rejection not allowed: verifier must be a different agent"))
           | Error Coord_task_lifecycle.Verification_disabled ->
             Error
-              (Types.TaskInvalidState
-                 "Verification FSM not enabled (MASC_VERIFICATION_FSM_ENABLED=false)")
+              (Types.Task (Types.Task_error.InvalidState
+                 "Verification FSM not enabled (MASC_VERIFICATION_FSM_ENABLED=false)"))
           | Error Coord_task_lifecycle.Invalid_transition ->
             let assignee_hint =
               match task_assignee_of_status task.task_status with
@@ -182,7 +182,7 @@ let transition_task_r
               | _ -> ""
             in
             Error
-              (Types.TaskInvalidState
+              (Types.Task (Types.Task_error.InvalidState
                  (Printf.sprintf
                     "Invalid transition: %s -> %s (%s, agent=%s%s%s).%s"
                     (task_status_to_string task.task_status)
@@ -191,7 +191,7 @@ let transition_task_r
                     agent_name
                     assignee_hint
                     actions_hint
-                    remediation))
+                    remediation)))
         in
         let new_status = decision.Coord_task_lifecycle.new_status in
         let set_current = decision.set_current in
@@ -210,20 +210,20 @@ let transition_task_r
              | Ok () -> Ok ()
              | Error e ->
                Error
-                 (Types.IoError
+                 (Types.System (Types.System_error.IoError
                     (Printf.sprintf
                        "verification request creation failed before status transition \
                         (task=%s vrf=%s): %s"
                        task_id
                        verification_id
-                       e)))
+                       e))))
           | Types.Submit_for_verification, _, _, Some _ ->
             Error
-              (Types.TaskInvalidState
+              (Types.Task (Types.Task_error.InvalidState
                  (Printf.sprintf
                     "submit_for_verification did not produce AwaitingVerification \
                      for task %s"
-                    task_id))
+                    task_id)))
           | ( Types.Claim
             | Types.Start
             | Types.Done_action
@@ -263,13 +263,13 @@ let transition_task_r
              | Ok () -> Ok ()
              | Error e ->
                Error
-                 (Types.IoError
+                 (Types.System (Types.System_error.IoError
                     (Printf.sprintf
                        "verification verdict persistence failed before status transition \
                         (task=%s vrf=%s): %s"
                        task_id
                        verification_id
-                       e)))
+                       e))))
           | ( Types.Reject_verification,
               Types.AwaitingVerification { verification_id; _ },
               Some prepare ) ->
@@ -284,20 +284,20 @@ let transition_task_r
              | Ok () -> Ok ()
              | Error e ->
                Error
-                 (Types.IoError
+                 (Types.System (Types.System_error.IoError
                     (Printf.sprintf
                        "verification verdict persistence failed before status transition \
                         (task=%s vrf=%s): %s"
                        task_id
                        verification_id
-                       e)))
+                       e))))
           | (Types.Approve_verification | Types.Reject_verification), _, Some _ ->
             Error
-              (Types.TaskInvalidState
+              (Types.Task (Types.Task_error.InvalidState
                  (Printf.sprintf
                     "verification verdict action did not start from AwaitingVerification \
                      for task %s"
-                    task_id))
+                    task_id)))
           | ( Types.Claim
             | Types.Start
             | Types.Done_action
@@ -723,7 +723,7 @@ let transition_task_r
                (task_status_to_string new_status)))
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Error (Types.IoError (Printexc.to_string e)))
+    | e -> Error (Types.System (Types.System_error.IoError (Printexc.to_string e))))
 ;;
 
 (** Release task back to backlog - transition wrapper *)
@@ -769,18 +769,18 @@ let force_done_task_r config ~agent_name ~task_id ~notes () : string Types.masc_
 (** Cancel a task - A2A compatible *)
 let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result =
   if not (is_initialized config)
-  then Error Types.NotInitialized
+  then Error (Types.System Types.System_error.NotInitialized)
   else (
     let agent_name = resolve_agent_name_strict config agent_name in
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
     with_file_lock config backlog_path (fun () ->
       try
         match read_backlog_r config with
-        | Error msg -> Error (Types.IoError msg)
+        | Error msg -> Error (Types.System (Types.System_error.IoError msg))
         | Ok backlog ->
           let task_opt = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
           (match task_opt with
-           | None -> Error (Types.TaskNotFound task_id)
+           | None -> Error (Types.Task (Types.Task_error.NotFound task_id))
            | Some task ->
              (* Can cancel if: Todo, Claimed by me, or InProgress by me *)
              let can_cancel =
@@ -794,11 +794,11 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
              if not can_cancel
              then
                Error
-                 (Types.TaskInvalidState
+                 (Types.Task (Types.Task_error.InvalidState
                     (Printf.sprintf
                        "Cannot cancel task %s (already done/cancelled or owned by \
                         another agent)"
-                       task_id))
+                       task_id)))
              else (
                let new_tasks =
                  List.map
@@ -917,7 +917,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                Ok (Printf.sprintf "%s cancelled %s" agent_name task_id)))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
-      | e -> Error (Types.IoError (Printexc.to_string e))))
+      | e -> Error (Types.System (Types.System_error.IoError (Printexc.to_string e)))))
 ;;
 
 (* Scheduling functions are in Coord_task_schedule.
@@ -944,16 +944,16 @@ let link_task_execution_artifacts_r
   : string Types.masc_result
   =
   if not (is_initialized config)
-  then Error Types.NotInitialized
+  then Error (Types.System Types.System_error.NotInitialized)
   else (
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
     with_file_lock config backlog_path (fun () ->
       try
         match read_backlog_r config with
-        | Error msg -> Error (Types.IoError msg)
+        | Error msg -> Error (Types.System (Types.System_error.IoError msg))
         | Ok backlog ->
           (match List.find_opt (fun (task : task) -> task.id = task_id) backlog.tasks with
-           | None -> Error (Types.TaskNotFound task_id)
+           | None -> Error (Types.Task (Types.Task_error.NotFound task_id))
            | Some task ->
              let existing_contract =
                ensure_task_contract_for_verification
@@ -1031,5 +1031,5 @@ let link_task_execution_artifacts_r
              Ok (Printf.sprintf "Linked execution artifacts for %s" task_id))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
-      | e -> Error (Types.IoError (Printexc.to_string e))))
+      | e -> Error (Types.System (Types.System_error.IoError (Printexc.to_string e)))))
 ;;

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -152,7 +152,7 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
   : string Types.masc_result
   =
   let open Result.Syntax in
-  let* () = if not (is_initialized config) then Error Types.NotInitialized else Ok () in
+  let* () = if not (is_initialized config) then Error (Types.System Types.System_error.NotInitialized) else Ok () in
   let* () =
     match validate_agent_name_r agent_name, validate_task_id_r task_id with
     | Error e, _ -> Error e
@@ -165,19 +165,19 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
   let agent_path = Filename.concat (agents_dir config) filename in
   let agent_joined = path_exists config agent_path in
   let* () =
-    if not agent_joined then Error (Types.AgentNotJoined actual_name) else Ok ()
+    if not agent_joined then Error (Types.Agent (Types.Agent_error.NotJoined actual_name)) else Ok ()
   in
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     match read_backlog_r config with
-    | Error msg -> Error (Types.IoError msg)
+    | Error msg -> Error (Types.System (Types.System_error.IoError msg))
     | Ok backlog ->
       (try
          (* Check role constraint before attempting claim *)
          let target_task = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
          let* task =
            match target_task with
-           | None -> Error (Types.TaskNotFound task_id)
+           | None -> Error (Types.Task (Types.Task_error.NotFound task_id))
            | Some task -> Ok task
          in
          let* () =
@@ -191,8 +191,8 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
            | None -> Ok ()
            | Some r ->
              Error
-               (Types.TaskInvalidState
-                  (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r))
+               (Types.Task (Types.Task_error.InvalidState
+                  (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
          in
          (* fold_left to find+transform in a single pass without mutable refs.
          Uses polymorphic variants for inline state tracking. *)
@@ -227,8 +227,8 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
          in
          let new_tasks = List.rev new_tasks in
          match claim_state with
-         | `Not_found -> Error (Types.TaskNotFound task_id)
-         | `Claimed_by other -> Error (Types.TaskAlreadyClaimed { task_id; by = other })
+         | `Not_found -> Error (Types.Task (Types.Task_error.NotFound task_id))
+         | `Claimed_by other -> Error (Types.Task (Types.Task_error.AlreadyClaimed { task_id; by = other }))
          | `Already_mine ->
            Ok (Printf.sprintf "Task %s is already claimed by you" task_id)
          | `Claimed_ok ->
@@ -286,7 +286,7 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
            Ok (Printf.sprintf "%s claimed %s" agent_name task_id)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
-       | e -> Error (Types.IoError (Printexc.to_string e))))
+       | e -> Error (Types.System (Types.System_error.IoError (Printexc.to_string e)))))
 ;;
 
 (** Unified task transition (single entrypoint).

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -210,12 +210,12 @@ let required_tool_claim_guard config ~agent_name ?agent_tool_names task =
            ; "ts", `String (now_iso ())
            ]);
       Error
-        (Types.TaskInvalidState
+        (Types.Task (Types.Task_error.InvalidState
            (Printf.sprintf
               "Task %s requires tool(s) unavailable to %s: %s"
               task.id
               agent_name
-              (String.concat ", " missing))))
+              (String.concat ", " missing)))))
 ;;
 
 let default_verification_evidence_refs =

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -91,22 +91,22 @@ let validate_agent_name_r name : (string, masc_error) result =
   (* Delegate to Validation module, convert error type *)
   match Validation.Agent_id.validate name with
   | Ok _ -> Ok name
-  | Error msg -> Error (InvalidAgentName msg)
+  | Error msg -> Error (Agent (Agent_error.InvalidName msg))
 
 let validate_task_id_r id : (string, masc_error) result =
   (* Delegate to Validation module, convert error type *)
   match Validation.Task_id.validate id with
   | Ok _ -> Ok id
-  | Error msg -> Error (InvalidTaskId msg)
+  | Error msg -> Error (Task (Task_error.InvalidId msg))
 
 let validate_file_path_r path : (string, masc_error) result =
   (* Delegate to Validation module, convert error type *)
-  if String.length path > 500 then Error (InvalidFilePath "too long (max 500 chars)")
+  if String.length path > 500 then Error (System (System_error.InvalidFilePath "too long (max 500 chars)"))
   else if contains_substring path "<" || contains_substring path ">" then
-    Error (InvalidFilePath "invalid characters (security)")
+    Error (System (System_error.InvalidFilePath "invalid characters (security)"))
   else match Validation.Safe_path.validate_relative path with
   | Ok _ -> Ok path
-  | Error msg -> Error (InvalidFilePath msg)
+  | Error msg -> Error (System (System_error.InvalidFilePath msg))
 
 (* ============================================ *)
 (* Ensure initialized                           *)
@@ -118,7 +118,7 @@ let ensure_initialized config =
 
 let ensure_initialized_r config : (unit, masc_error) result =
   if is_initialized config then Ok ()
-  else Error NotInitialized
+  else Error (System System_error.NotInitialized)
 
 (* ============================================ *)
 (* File I/O helpers                             *)
@@ -515,9 +515,9 @@ let with_distributed_lock_r ?clock config path key f : ('a, masc_error) result =
     (Atomic.get Coord_hooks.distributed_lock_acquire_failed_fn)
       ~key ~attempts:50;
     Error
-      (IoError
+      (System (System_error.IoError
          (Printf.sprintf "Failed to acquire distributed lock for %s"
-            path))
+            path)))
   end
 
 let with_file_lock_impl ?clock config path f =

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -276,10 +276,10 @@ let require_repository_root_with_git config =
     Ok root
   | `Missing ->
     Error
-      (IoError
+      (System (System_error.IoError
          (Printf.sprintf
             "Worktree isolation requires repository root with .git: %s (current base path: %s)"
-            root config.base_path))
+            root config.base_path)))
 
 let ensure_worktree_path root worktree_name =
   let worktrees_dir = Filename.concat root ".worktrees" in
@@ -287,7 +287,7 @@ let ensure_worktree_path root worktree_name =
   if Filename.dirname worktree_path = worktrees_dir then
     Ok (worktree_path, worktrees_dir)
   else
-    Error (IoError "Invalid worktree path: must be created under .worktrees/")
+    Error (System (System_error.IoError "Invalid worktree path: must be created under .worktrees/"))
 
 let safe_file_exists path =
   try Sys.file_exists path with
@@ -411,11 +411,11 @@ let restore_sandbox_clone_checkout candidate =
   in
   if checkout_status <> Unix.WEXITED 0 then
     Error
-      (IoError
+      (System (System_error.IoError
          (Printf.sprintf
             "sandbox_clone_checkout_restore_failed: could not restore tracked \
              files in %s: %s"
-            candidate (trim_output_detail checkout_output)))
+            candidate (trim_output_detail checkout_output))))
   else
     match inspect_sandbox_clone candidate with
     | Ready ->
@@ -425,18 +425,18 @@ let restore_sandbox_clone_checkout candidate =
               worktree creation.")
     | Needs_checkout relpath ->
         Error
-          (IoError
+          (System (System_error.IoError
              (Printf.sprintf
                 "sandbox_clone_checkout_restore_failed: %s is still missing \
                  tracked path %s after checkout."
-                candidate relpath))
+                candidate relpath)))
     | Broken_git detail ->
         Error
-          (IoError
+          (System (System_error.IoError
              (Printf.sprintf
                 "sandbox_clone_checkout_restore_failed: %s is still not a \
                  usable git clone after checkout: %s"
-                candidate detail))
+                candidate detail)))
 
 let ensure_sandbox_clone_ready candidate =
   match inspect_sandbox_clone candidate with
@@ -444,11 +444,10 @@ let ensure_sandbox_clone_ready candidate =
   | Needs_checkout _ -> restore_sandbox_clone_checkout candidate
   | Broken_git detail ->
       Error
-        (IoError
+        (System (System_error.IoError
            (Printf.sprintf
-              "sandbox_clone_invalid: %s has a .git marker but is not a usable \
-               git clone: %s"
-              candidate detail))
+              "sandbox_clone_invalid: %s has a .git marker but is not a usable \               git clone: %s"
+              candidate detail)))
 
 let keeper_toml_path ~config ~agent_name =
   let keeper_name = Playground_paths.sanitize_keeper_name agent_name in
@@ -727,11 +726,11 @@ let infer_task_repo_name config ~agent_name ~task_id =
       | [ candidate ] -> Ok (Some candidate.name)
       | _ ->
           Error
-            (IoError
+            (System (System_error.IoError
                (Printf.sprintf
                   "ambiguous_task_repo: task %s is not in backlog and sandbox has multiple repos [%s]"
                   task_id
-                  (String.concat ", " (List.map (fun c -> c.name) candidates)))))
+                  (String.concat ", " (List.map (fun c -> c.name) candidates))))))
   | Some task -> (
       match candidates with
       | [] -> (
@@ -775,12 +774,12 @@ let infer_task_repo_name config ~agent_name ~task_id =
                | [ name ] -> Ok (Some name)
                | many ->
                    Error
-                     (IoError
+                     (System (System_error.IoError
                         (Printf.sprintf
                            "ambiguous_task_repo: task %s has no sandbox \
                             clone, and task evidence mentions multiple \
                             workspace repos [%s]"
-                           task_id (String.concat ", " many)))))
+                           task_id (String.concat ", " many))))))
       | [ candidate ] -> Ok (Some candidate.name)
       | _ ->
           let tokens = tokenize_repo_evidence (task_repo_text task) in
@@ -808,18 +807,18 @@ let infer_task_repo_name config ~agent_name ~task_id =
                 |> List.map (fun (_, candidate) -> candidate.name)
               in
               Error
-                (IoError
+                (System (System_error.IoError
                    (Printf.sprintf
                       "ambiguous_task_repo: task %s matches multiple repos with equal score [%s]"
-                      task_id (String.concat ", " tied)))
+                      task_id (String.concat ", " tied))))
           | _ ->
               Error
-                (IoError
+                (System (System_error.IoError
                    (Printf.sprintf
                       "ambiguous_task_repo: task %s has no repo evidence; sandbox repos=[%s]"
                       task_id
                       (String.concat ", "
-                         (List.map (fun c -> c.name) candidates)))))
+                         (List.map (fun c -> c.name) candidates))))))
 
 let rec rm_rf path =
   if safe_file_exists path then
@@ -844,33 +843,33 @@ let missing_sandbox_clone_error ~agent_name ~repos_dir ~repo_name =
         "keeper_shell op=git_clone url=\"https://github.com/<org>/<repo>.git\" \
          path=\"repos/<repo>\"" )
   in
-  IoError
+  System (System_error.IoError
     (Printf.sprintf
        "missing_sandbox_clone: no sandbox git clone found for agent %s under %s \
         (expected %s). Recovery: %s"
-       agent_name repos_dir rel_target clone_hint)
+       agent_name repos_dir rel_target clone_hint))
 
 let workspace_repo_not_found_error ~agent_name ~repos_dir ~repo_name
     ~search_root =
-  IoError
+  System (System_error.IoError
     (Printf.sprintf
        "missing_sandbox_clone: no sandbox git clone found for agent %s under %s \
         and no workspace git repo named %s was found under %s. Recovery: \
         keeper_shell op=git_clone url=\"https://github.com/<org>/%s.git\" \
         path=\"repos/%s\""
-       agent_name repos_dir repo_name search_root repo_name repo_name)
+       agent_name repos_dir repo_name search_root repo_name repo_name))
 
 let workspace_repo_ambiguous_error ~repo_name ~search_root ~matches =
-  IoError
+  System (System_error.IoError
     (Printf.sprintf
        "ambiguous_workspace_repo: found multiple git repos named %s under %s: \
         [%s]. Auto-provision is blocked until the repo is disambiguated; use \
         keeper_shell op=git_clone explicitly."
-       repo_name search_root (String.concat ", " matches))
+       repo_name search_root (String.concat ", " matches)))
 
 let partial_clone_error ~clone_path ~msg =
   rm_rf clone_path;
-  IoError msg
+  System (System_error.IoError msg)
 
 let git_origin_url root =
   match run_argv_with_status [ "git"; "-C"; root; "remote"; "get-url"; "origin" ] with
@@ -907,29 +906,29 @@ let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
           |> Result.map (fun repair_note -> (clone_path, repair_note))
         else
           Error
-            (IoError
+            (System (System_error.IoError
                (Printf.sprintf
                   "sandbox_clone_conflict: %s already exists under %s but is not \
                    a git clone. Remove or repair it, or use keeper_shell \
                    op=git_clone explicitly."
-                  repo_name repos_dir))
+                  repo_name repos_dir)))
       else
         (match git_origin_url source_root with
          | None ->
              Error
-               (IoError
+               (System (System_error.IoError
                   (Printf.sprintf
                      "auto_provision_clone_failed: workspace repo %s has no origin remote. \
                       Sandbox auto-provision requires cloning from origin, not from the local checkout."
-                     source_root))
+                     source_root)))
          | Some origin_url -> (
              match validate_clone_origin_url ~base_path:config.base_path origin_url with
              | Error err ->
                  Error
-                   (IoError
+                   (System (System_error.IoError
                       (Printf.sprintf
                          "auto_provision_clone_failed: origin %s rejected by clone policy: %s"
-                         origin_url err))
+                         origin_url err)))
              | Ok () ->
                  let origin_url = normalize_github_clone_url origin_url in
                  let status, output =
@@ -962,10 +961,10 @@ let link_worktree_to_task config ~task_id ~worktree_info =
   let backlog_file = Filename.concat (tasks_dir config) "backlog.json" in
   let json = read_json config backlog_file in
   match backlog_of_yojson json with
-  | Error e -> Error (IoError e)
+  | Error e -> Error (System (System_error.IoError e))
   | Ok backlog ->
       if backlog.tasks = [] then
-        Error (IoError "Backlog not found")
+        Error (System (System_error.IoError "Backlog not found"))
       else
         let found = ref false in
         let new_tasks = List.map (fun (task : task) ->
@@ -975,7 +974,7 @@ let link_worktree_to_task config ~task_id ~worktree_info =
           end else task
         ) backlog.tasks in
         if not !found then
-          Error (TaskNotFound task_id)
+          Error (Task (Task_error.NotFound task_id))
         else begin
           let new_backlog = { backlog with tasks = new_tasks; last_updated = now_iso () } in
           write_json config backlog_file (backlog_to_yojson new_backlog);
@@ -991,9 +990,9 @@ let link_worktree_to_task config ~task_id ~worktree_info =
            sandbox repo clone is required. *)
 let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_initialized config) then
-    Error NotInitialized
+    Error (System System_error.NotInitialized)
   else if not (is_git_repo config) then
-    Error (IoError "Not a git repository. MASC v2 requires .git directory for worktree isolation.")
+    Error (System (System_error.IoError "Not a git repository. MASC v2 requires .git directory for worktree isolation."))
   else match validate_agent_name_r agent_name, validate_task_id_r task_id with
   | Error e, _ -> Error e
   | _, Error e -> Error e
@@ -1003,10 +1002,10 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
       match repo_name with
       | Some name when String.trim name <> "" && not (safe_repo_name name) ->
           Error
-            (IoError
+            (System (System_error.IoError
                (Printf.sprintf
                   "invalid_repo_name: %S must be a single repo directory name under repos/"
-                  name))
+                  name)))
       | Some name when String.trim name <> "" -> Ok (Some name)
       | _ -> infer_task_repo_name config ~agent_name ~task_id
     in
@@ -1076,7 +1075,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             if link_task then begin
               match link_worktree_to_task config ~task_id ~worktree_info:wt_info with
               | Ok () -> ""
-              | Error (TaskNotFound _) -> "\n  Note: Task not found in backlog, worktree not linked"
+              | Error (Task (Task_error.NotFound _)) -> "\n  Note: Task not found in backlog, worktree not linked"
               | Error _ -> "\n  Note: Could not link worktree to task"
             end else ""
           in
@@ -1106,11 +1105,11 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
               existing_worktree_ok ()
             else
               Error
-                (IoError
+                (System (System_error.IoError
                    (Printf.sprintf
                       "worktree_path_conflict: %s already exists but is not a \
                        usable git worktree. Remove or repair it before retrying."
-                      worktree_path))
+                      worktree_path)))
           end else begin
             (* Fetch origin first; stale remotes must be explicit, not hidden.
                Use the longer git_fetch_timeout_sec budget — the default
@@ -1124,8 +1123,8 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             in
             if fetch_exit <> 0 then
               Error
-                (IoError
-                   "Failed to fetch origin before worktree creation. Verify network/auth and retry so the task starts from the latest remote ref.")
+                (System (System_error.IoError
+                   "Failed to fetch origin before worktree creation. Verify network/auth and retry so the task starts from the latest remote ref."))
             else match Coord_git.resolve_base_branch root base_branch with
             | Error e -> Error e
             | Ok (resolved_base, fallback_from) ->
@@ -1188,8 +1187,8 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                 else begin
                   rm_rf worktree_path;
                   let detail = String.trim git_output in
-                  Error (IoError (Printf.sprintf "Failed to create worktree from origin/%s: %s"
-                    resolved_base (if detail = "" then "(no output)" else detail)))
+                  Error (System (System_error.IoError (Printf.sprintf "Failed to create worktree from origin/%s: %s"
+                    resolved_base (if detail = "" then "(no output)" else detail))))
                 end
           end
   end
@@ -1197,7 +1196,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
 (** Remove worktree - Result version *)
 let worktree_remove_r config ~agent_name ~task_id : string masc_result =
   if not (is_initialized config) then
-    Error NotInitialized
+    Error (System System_error.NotInitialized)
   else match validate_agent_name_r agent_name, validate_task_id_r task_id with
   | Error e, _ -> Error e
   | _, Error e -> Error e
@@ -1238,10 +1237,10 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
       | Some root -> Ok root
       | None ->
         Error
-          (IoError
+          (System (System_error.IoError
              (Printf.sprintf
                 "Worktree %s not found under sandbox repo clones in %s"
-                worktree_name repos_dir))
+                worktree_name repos_dir)))
     in
     match resolve_existing_worktree_root () with
     | Error e -> Error e
@@ -1253,7 +1252,7 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
             let branch_name = Playground_paths.worktree_branch_name agent_name task_id in
 
             if not (Sys.file_exists worktree_path) then
-              Error (IoError (Printf.sprintf "Worktree not found: %s" worktree_path))
+              Error (System (System_error.IoError (Printf.sprintf "Worktree not found: %s" worktree_path)))
             else begin
               (* Remove worktree *)
               let exit_code = run_argv_exit ["git"; "-C"; root; "worktree"; "remove"; worktree_path] in
@@ -1277,12 +1276,18 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
                 let msg = Printf.sprintf "Worktree removed: %s\n   Branch: %s (delete: %s)\n   Prune: %s"
                   worktree_path branch_name branch_status prune_status in
                 if branch_exit <> 0 || prune_exit <> 0 then
+<<<<<<< HEAD
                   Error (IoError (msg ^ "\n   Post-processing had failures"))
+||||||| parent of ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
+                  Error (IoError (msg ^ "\n   ⚠️ Post-processing had failures"))
+=======
+                  Error (System (System_error.IoError (msg ^ "\n   ⚠️ Post-processing had failures")))
+>>>>>>> ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
                 else
                   Ok msg
               end
               else
-                Error (IoError "Failed to remove worktree. It may have uncommitted changes.")
+                Error (System (System_error.IoError "Failed to remove worktree. It may have uncommitted changes."))
 	    end
     end
 

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -628,7 +628,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
        let trace = Printexc.get_backtrace () in
        let err_detail = if String.length trace > 0 then err ^ "\n" ^ trace else err in
        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-         (false, Types.masc_error_to_string Types.NotInitialized)
+         (false, Types.masc_error_to_string (Types.System Types.System_error.NotInitialized))
        else
          (Log.Mcp.error "tools/call crashed: %s" err_detail;
           false, Printf.sprintf "Internal error: %s" err_detail)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -80,9 +80,9 @@ let is_transient_agent_name name =
   || Nickname.is_dictionary_generated_nickname name
 
 let silent_auth_token_error_kind = function
-  | Types.InvalidToken _ -> "token_mismatch"
-  | Types.TokenExpired _ -> "token_expired"
-  | Types.Unauthorized _ -> "unauthorized"
+  | Types.Auth (Types.Auth_error.InvalidToken _) -> "token_mismatch"
+  | Types.Auth (Types.Auth_error.TokenExpired _) -> "token_expired"
+  | Types.Auth (Types.Auth_error.Unauthorized _) -> "unauthorized"
   | _ -> "other"
 
 let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -680,7 +680,7 @@ let handle_request
                  with
                  | Invalid_argument msg
                    when contains_casefold msg "masc not initialized" ->
-                     make_error ~id (-32603) (Types.masc_error_to_string Types.NotInitialized)
+                     make_error ~id (-32603) (Types.masc_error_to_string (Types.System Types.System_error.NotInitialized))
                    | Eio.Cancel.Cancelled _ as exn -> raise exn
                    | exn ->
                        let err = Printexc.to_string exn in

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -150,8 +150,8 @@ let resolve_agent_name_for_auth_raw ~base_path request ~token :
        | Some agent_name -> Ok (Some agent_name)
        | None ->
            Error
-             (Types.Unauthorized
-                "Internal keeper auth requires x-masc-keeper-name header."))
+             (Types.Auth (Types.Auth_error.Unauthorized
+                "Internal keeper auth requires x-masc-keeper-name header.")))
   | Some t -> (
       match Auth.resolve_agent_from_token base_path ~token:t with
       | Ok agent_name -> Ok (Some agent_name)
@@ -441,9 +441,9 @@ let ensure_same_origin_browser_request request :
   | None ->
     if allow_anonymous_mutations then Ok ()
     else
-      Error (Types.Unauthorized
+      Error (Types.Auth (Types.Auth_error.Unauthorized
         "Authentication required: provide a bearer token or Origin header. \
-         Set MASC_ALLOW_ANONYMOUS_MUTATIONS=true for local development.")
+         Set MASC_ALLOW_ANONYMOUS_MUTATIONS=true for local development."))
   | Some origin -> (
       match host_port_scheme_of_origin origin, host_port_of_request request with
       | Some (origin_host, origin_port, scheme),
@@ -471,9 +471,9 @@ let ensure_same_origin_browser_request request :
               (match Httpun.Headers.get request.Httpun.Request.headers "host" with
                | Some h -> Printf.sprintf "%S" h | None -> "<absent>");
             Error
-              (Types.Forbidden
+              (Types.Auth (Types.Auth_error.Forbidden
                  { agent = "browser";
-                   action = "cross-origin HTTP mutation" }))
+                   action = "cross-origin HTTP mutation" })))
       | _ ->
           Log.Auth.debug
             "same-origin check failed: origin=%S host=%s"
@@ -481,13 +481,13 @@ let ensure_same_origin_browser_request request :
             (match Httpun.Headers.get request.Httpun.Request.headers "host" with
              | Some h -> Printf.sprintf "%S" h | None -> "<absent>");
           Error
-            (Types.Forbidden
+            (Types.Auth (Types.Auth_error.Forbidden
                { agent = "browser";
-                 action = "cross-origin HTTP mutation" }))
+                 action = "cross-origin HTTP mutation" })))
 
 let http_status_of_auth_error = function
-  | Types.Unauthorized _ | Types.InvalidToken _ | Types.TokenExpired _ -> `Unauthorized
-  | Types.Forbidden _ -> `Forbidden
+  | Types.Auth (Types.Auth_error.Unauthorized _ | Types.Auth_error.InvalidToken _ | Types.Auth_error.TokenExpired _) -> `Unauthorized
+  | Types.Auth (Types.Auth_error.Forbidden _) -> `Forbidden
   | _ -> `Internal_server_error
 
 (** Server state - initialized at startup *)
@@ -689,7 +689,7 @@ let authorize_permission_request ~base_path ~permission request :
   let auth_cfg = Auth.load_auth_config base_path in
   let token = auth_token_from_request request in
   match ensure_strict_http_token_auth ~endpoint:"HTTP read access" auth_cfg with
-  | Error msg -> Error (Types.Unauthorized msg)
+  | Error msg -> Error (Types.Auth (Types.Auth_error.Unauthorized msg))
   | Ok auth_cfg -> (
       match resolve_agent_name_for_auth ~base_path request ~token with
       | Error err -> Error err
@@ -700,8 +700,8 @@ let authorize_permission_request ~base_path ~permission request :
             && agent_name_opt = None
           then
             Error
-              (Types.Unauthorized
-                 "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound credential)")
+              (Types.Auth (Types.Auth_error.Unauthorized
+                 "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound credential)"))
           else
             Auth.check_permission base_path ~agent_name ~token ~permission)
 
@@ -721,7 +721,7 @@ let authorize_tool_request ~base_path ~tool_name request :
       (match ensure_strict_http_token_auth
                ~endpoint:("HTTP tool access for " ^ tool_name) auth_cfg
        with
-  | Error msg -> Error (Types.Unauthorized msg)
+  | Error msg -> Error (Types.Auth (Types.Auth_error.Unauthorized msg))
   | Ok auth_cfg -> (
       match resolve_agent_name_for_auth ~base_path request ~token with
       | Error err -> Error err
@@ -732,8 +732,8 @@ let authorize_tool_request ~base_path ~tool_name request :
             && agent_name_opt = None
           then
             Error
-              (Types.Unauthorized
-                 "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound credential)")
+              (Types.Auth (Types.Auth_error.Unauthorized
+                 "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound credential)"))
           else
             Auth.authorize_tool_v2 base_path ~agent_name ~token ~tool_name))
 
@@ -742,18 +742,18 @@ let authorize_token_bound_permission_request ~base_path ~permission request :
   let auth_cfg = Auth.load_auth_config base_path in
   if not auth_cfg.enabled then
     Error
-      (Types.Unauthorized
-         "HTTP mutation requires room auth enabled with require_token=true.")
+      (Types.Auth (Types.Auth_error.Unauthorized
+         "HTTP mutation requires room auth enabled with require_token=true."))
   else if not auth_cfg.require_token then
     Error
-      (Types.Unauthorized
-         "HTTP mutation requires bearer token auth (require_token=true).")
+      (Types.Auth (Types.Auth_error.Unauthorized
+         "HTTP mutation requires bearer token auth (require_token=true)."))
   else
     match auth_token_from_request request with
     | None ->
         Error
-          (Types.Unauthorized
-             "Authentication required. Use 'Authorization: Bearer <token>' header.")
+          (Types.Auth (Types.Auth_error.Unauthorized
+             "Authentication required. Use 'Authorization: Bearer <token>' header."))
     | Some token -> (
         match Auth.find_credential_by_token base_path ~token with
         | Error err -> Error err
@@ -762,11 +762,11 @@ let authorize_token_bound_permission_request ~base_path ~permission request :
               Ok cred.agent_name
             else
               Error
-                (Types.Forbidden
+                (Types.Auth (Types.Auth_error.Forbidden
                    {
                      agent = cred.agent_name;
                      action = Types.show_permission permission;
-                   }))
+                   })))
 
 let is_dashboard_bootstrap_path path =
   String.starts_with ~prefix:"/api/v1/dashboard/" path

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1069,12 +1069,12 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
     String.length needle > 0 && String_util.contains_substring haystack needle
   in
   let dashboard_auth_error_code = function
-    | Types.InvalidToken _ -> Some "invalid_token"
-    | Types.TokenExpired _ -> Some "token_expired"
-    | Types.Forbidden { agent = "browser"; action = "cross-origin HTTP mutation" } ->
+    | Types.Auth (Types.Auth_error.InvalidToken _) -> Some "invalid_token"
+    | Types.Auth (Types.Auth_error.TokenExpired _) -> Some "token_expired"
+    | Types.Auth (Types.Auth_error.Forbidden { agent = "browser"; action = "cross-origin HTTP mutation" }) ->
         Some "same_origin_blocked"
-    | Types.Forbidden _ -> Some "insufficient_role"
-    | Types.Unauthorized reason ->
+    | Types.Auth (Types.Auth_error.Forbidden _) -> Some "insufficient_role"
+    | Types.Auth (Types.Auth_error.Unauthorized reason) ->
         let normalized = String.lowercase_ascii reason in
         if contains_substring normalized "bearer token belongs to" then
           Some "actor_mismatch"
@@ -1112,8 +1112,8 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
     | None ->
         if auth_cfg.enabled && auth_cfg.require_token && token_present then
           Error
-            (Types.Unauthorized
-               "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound credential)")
+            (Types.Auth (Types.Auth_error.Unauthorized
+               "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound credential)"))
         else
           Ok "dashboard"
   in
@@ -1141,7 +1141,7 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
             ~endpoint:"HTTP tool access for masc_keeper_msg" auth_cfg
         with
         | Ok _ -> Ok ()
-        | Error msg -> Error (Types.Unauthorized msg))
+        | Error msg -> Error (Types.Auth (Types.Auth_error.Unauthorized msg)))
   in
   let keeper_authorization_result =
     match endpoint_gate_result with
@@ -1170,8 +1170,8 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
   in
   let auth_error =
     match token_credential_result with
-    | Some (Error (Types.InvalidToken _ as err)) -> Some err
-    | Some (Error (Types.TokenExpired _ as err)) -> Some err
+    | Some (Error (Types.Auth (Types.Auth_error.InvalidToken _) as err)) -> Some err
+    | Some (Error (Types.Auth (Types.Auth_error.TokenExpired _) as err)) -> Some err
     | Some (Error err) -> Some err
     | _ -> (
         match keeper_authorization_result with

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -57,7 +57,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     | exn ->
         let err = Printexc.to_string exn in
         if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-          (false, Types.masc_error_to_string Types.NotInitialized)
+          (false, Types.masc_error_to_string (Types.System Types.System_error.NotInitialized))
         else (
           Log.Mcp.error "tools/call crashed: %s" err;
           (false, Printf.sprintf "Internal error: %s" err))
@@ -288,7 +288,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
     | exn ->
         let err = Printexc.to_string exn in
         if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-          (false, Types.masc_error_to_string Types.NotInitialized)
+          (false, Types.masc_error_to_string (Types.System Types.System_error.NotInitialized))
         else (
           Log.Mcp.error "tools/call crashed (stream): %s" err;
           (false, Printf.sprintf "Internal error: %s" err))

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -139,7 +139,7 @@ let classify_dashboard_dev_token_candidate ~base_path raw :
         Ok (Reusable trimmed)
     | Ok _owner ->
         Ok Rotate
-    | Error (Types.InvalidToken _ | Types.TokenExpired _ | Types.Unauthorized _) ->
+    | Error (Types.Auth (Types.Auth_error.InvalidToken _ | Types.Auth_error.TokenExpired _ | Types.Auth_error.Unauthorized _)) ->
         Ok Rotate
     | Error err ->
         Error (Types.masc_error_to_string err)

--- a/lib/task_dispatch.ml
+++ b/lib/task_dispatch.ml
@@ -82,9 +82,12 @@ let list_tasks config ?(include_done=false) ?(include_cancelled=false) () =
 let validate_transition ~(current : task_status) ~(next : task_status) ~task_id =
   match current, next with
   | Done _, Done _ | Done _, Cancelled _ | Cancelled _, Done _ | Cancelled _, Cancelled _ ->
-      Error (TaskInvalidState
-        (Printf.sprintf "task %s: cannot transition from %s to %s"
-           task_id (task_status_to_string current) (task_status_to_string next)))
+      Error (Task (Task_error.InvalidState
+               (Printf.sprintf
+                  "task %s: cannot transition from %s to %s"
+                  task_id
+                  (task_status_to_string current)
+                  (task_status_to_string next))))
   | _ -> Ok ()
 
 (** Update task status (claim, start, complete, cancel) *)
@@ -94,7 +97,7 @@ let update_status config ~task_id ~status =
       let backlog = Coord.read_backlog config in
       let task_opt = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
       (match task_opt with
-       | None -> Error (TaskNotFound task_id)
+       | None -> Error (Task (Task_error.NotFound task_id))
        | Some t ->
           match validate_transition ~current:t.task_status ~next:status ~task_id with
           | Error e -> Error e

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -153,10 +153,10 @@ let normalize_agent_relative_path ~(config : Coord.config) ~(agent_name : string
 let validate_path config path =
   try
     if String.contains path '\x00' then
-      Error (IoError "Path contains null byte")
+      Error (System (System_error.IoError "Path contains null byte"))
     else
     match Coord_git.git_root ~base_path:config.Coord.base_path with
-    | None -> Error (IoError "Not in a git repository")
+    | None -> Error (System (System_error.IoError "Not in a git repository"))
     | Some git_root ->
     let absolute_path =
       if Filename.is_relative path then
@@ -187,10 +187,10 @@ let validate_path config path =
       | _ -> within canonical_root canonical
     in
     if allowed then Ok canonical
-    else Error (IoError "Path traversal detected: access outside git root")
+    else Error (System (System_error.IoError "Path traversal detected: access outside git root"))
   with
-  | Invalid_argument msg -> Error (IoError msg)
-  | exn -> Error (IoError (Stdlib.Printexc.to_string exn))
+  | Invalid_argument msg -> Error (System (System_error.IoError msg))
+  | exn -> Error (System (System_error.IoError (Stdlib.Printexc.to_string exn)))
 
 (* #6637 iter11 — per-agent playground containment for code-read tools.
 
@@ -236,10 +236,10 @@ let validate_read_path ~agent_name config path =
                (racy deletion, or a broken symlink). Treat as a
                containment failure rather than silently accepting. *)
             Error
-              (IoError
+              (System (System_error.IoError
                  (Printf.sprintf
                     "target path %S is not accessible (dangling \
-                     symlink or racy deletion)" path))
+                     symlink or racy deletion)" path)))
       with
       | Error e -> Error e
       | Ok canonical ->
@@ -270,13 +270,13 @@ let validate_read_path ~agent_name config path =
           try Ok (Unix.realpath playground_tree_abs_raw) with
           | Unix.Unix_error _ ->
               Error
-                (IoError
+                (System (System_error.IoError
                    (Printf.sprintf
                       "keeper playground tree %S does not exist; cannot \
                        validate cross-keeper containment. Clone via \
                        keeper_shell op=git_clone to provision your \
                        playground first. See #6527/#6637."
-                      playground_tree_rel))
+                      playground_tree_rel)))
         with
         | Error e -> Error e
         | Ok playground_tree_canonical ->
@@ -308,13 +308,13 @@ let validate_read_path ~agent_name config path =
               try Ok (Unix.realpath own_abs_raw) with
               | Unix.Unix_error _ ->
                   Error
-                    (IoError
+                    (System (System_error.IoError
                        (Printf.sprintf
                           "keeper playground bundle %S does not exist \
                            yet; cannot validate containment. Provision \
                            via git_clone or masc_worktree_create first. \
                            See #6527/#6637."
-                          own_rel_trailing))
+                          own_rel_trailing)))
             with
             | Error e -> Error e
             | Ok own_canonical ->
@@ -322,13 +322,13 @@ let validate_read_path ~agent_name config path =
                    || String.starts_with ~prefix:(own_canonical ^ "/") canonical
                 then Ok canonical
                 else
-                  Error (IoError (Printf.sprintf
+                  Error (System (System_error.IoError (Printf.sprintf
                     "cross-keeper playground read blocked: agent=%S tried to \
                      read path %S which is under another keeper's playground. \
                      Only %s is readable for this caller; reads outside your \
                      own playground must target the shared codebase (lib/, \
                      test/, config/, etc.). See #6527/#6637."
-                    agent_name path own_rel_trailing))
+                    agent_name path own_rel_trailing)))
 
 
 (* Handler: masc_code_search - Search code using ripgrep *)

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -133,7 +133,7 @@ let validate_writable_path ~(agent_name : string) config path =
        || String.starts_with ~prefix:agent_playground_prefix canonical_path then
       Ok canonical_path
     else
-      Error (IoError (Printf.sprintf
+      Error (System (System_error.IoError (Printf.sprintf
         "Write restricted to allowed sandboxes for agent %s. \
          Expected path prefix: %s (or /.worktrees/ for server ops). \
          Got: %s. Cross-agent playground writes are blocked — write \
@@ -141,7 +141,7 @@ let validate_writable_path ~(agent_name : string) config path =
          unsure of your agent_name."
         agent_name
         agent_playground_prefix
-        canonical_path))
+        canonical_path)))
 
 (* Issue #8522: Variant SSOT for git action.  Adding a constructor
    forces compilation in [git_action_to_string] AND extends
@@ -381,7 +381,7 @@ let validate_clone_cwd ~(agent_name : string) config cwd =
   | Error e -> Error e
   | Ok canonical_path ->
     match Coord_git.git_root ~base_path:config.Coord.base_path with
-    | None -> Error (IoError "Not in a git repository")
+    | None -> Error (System (System_error.IoError "Not in a git repository"))
     | Some root ->
       let worktree_prefix = Tool_code.normalize_path
         (Filename.concat root ".worktrees") in
@@ -412,7 +412,7 @@ let validate_clone_cwd ~(agent_name : string) config cwd =
       if in_worktrees || in_agent_playground_repos then
         Ok canonical_path
       else
-        Error (IoError (Printf.sprintf
+        Error (System (System_error.IoError (Printf.sprintf
           "Clone restricted to /.worktrees/ or this agent's own \
            %srepos/ (got: %s). Cross-agent playground clones are blocked \
            — clone into %srepos/<repo-name> instead. Call masc_status \
@@ -420,7 +420,7 @@ let validate_clone_cwd ~(agent_name : string) config cwd =
           agent_playground_prefix
           canonical_path
           agent_playground_prefix
-          agent_name))
+          agent_name)))
 
 (* Handler: masc_code_write — Create or overwrite a file *)
 let handle_code_write ctx args =
@@ -734,7 +734,7 @@ let handle_code_git ctx args =
     else begin
       let cwd_result =
         if String.equal cwd "" then (false, "cwd parameter required for git operations") |> fun (ok, msg) ->
-          if ok then Ok None else Error (IoError msg)
+          if ok then Ok None else Error (System (System_error.IoError msg))
         else match validate_writable_path ~agent_name:ctx.agent_name ctx.config cwd with
           | Ok abs_cwd -> Ok (Some abs_cwd)
           | Error e -> Error e

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -128,7 +128,7 @@ let build_verdict_sse_payload
 
 (** Validate task_id is non-empty. Prevents phantom operations on empty IDs. *)
 let validate_task_id task_id =
-  if String.equal task_id "" then Error (Types.TaskNotFound "")
+  if String.equal task_id "" then Error (Types.Task (Types.Task_error.NotFound ""))
   else Ok task_id
 
 let sync_planning_current_task_with_owned_task (ctx : context) =
@@ -372,33 +372,33 @@ let strict_release_requires_handoff = function
 let completion_state_error ~(task_id : string) ~(agent_name : string)
     ~(task_opt : Types.task option) =
   match task_opt with
-  | None -> Some (Types.TaskNotFound task_id)
+  | None -> Some (Types.Task (Types.Task_error.NotFound task_id))
   | Some task ->
     match task.task_status with
     | Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ } ->
       if String.equal assignee agent_name then
         None
       else
-        Some (Types.TaskAlreadyClaimed { task_id; by = assignee })
-    | Types.Todo -> Some (Types.TaskNotClaimed task_id)
+        Some (Types.Task (Types.Task_error.AlreadyClaimed { task_id; by = assignee }))
+    | Types.Todo -> Some (Types.Task (Types.Task_error.NotClaimed task_id))
     | Types.Done { assignee; _ } ->
       Some
-        (Types.TaskInvalidState
+        (Types.Task (Types.Task_error.InvalidState
            (Printf.sprintf
               "task %s is already done by %s; inspect task history instead of calling masc_transition(action=done) again"
-              task_id assignee))
+              task_id assignee)))
     | Types.Cancelled { cancelled_by; _ } ->
       Some
-        (Types.TaskInvalidState
+        (Types.Task (Types.Task_error.InvalidState
            (Printf.sprintf
               "task %s was cancelled by %s; reopen or create a new task instead of calling masc_transition(action=done)"
-              task_id cancelled_by))
+              task_id cancelled_by)))
     | Types.AwaitingVerification { assignee; _ } ->
       Some
-        (Types.TaskInvalidState
+        (Types.Task (Types.Task_error.InvalidState
            (Printf.sprintf
               "task %s is awaiting verification by %s; approve or reject before marking done"
-              task_id assignee))
+              task_id assignee)))
 
 let persisted_contract_rejection ~(ctx : context)
     ~(task_opt : Types.task option) ~(notes : string) =
@@ -550,7 +550,7 @@ let handle_batch_add_tasks ctx args =
 
 let handle_claim ?agent_tool_names ctx args =
   if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
-    result_to_response (Error (Types.AgentNotJoined ctx.agent_name))
+    result_to_response (Error (Types.Agent (Types.Agent_error.NotJoined ctx.agent_name)))
   else if not ((=) (args |> member "agent_role") `Null) then
     (false, "agent_role is no longer supported")
   else
@@ -915,7 +915,7 @@ and handle_transition ?agent_tool_names ctx args =
   let max_cas_retries = 3 in
   let cas_retry_delay_s = 0.05 in
   let is_version_mismatch = function
-    | Error (Types.TaskInvalidState msg) ->
+    | Error (Types.Task (Types.Task_error.InvalidState msg)) ->
         let prefix = "Version mismatch" in
         String.length msg >= String.length prefix
         && String.equal (Stdlib.String.sub msg 0 (String.length prefix)) prefix

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -71,33 +71,92 @@ type cache_error =
   | CacheExpired of { key: string; age_hours: float }
   | CacheCorrupted of string
 
+module Task_error = struct
+  type t =
+    | NotFound of string
+    | AlreadyClaimed of { task_id: string; by: string }
+    | NotClaimed of string
+    | InvalidState of string
+    | InvalidId of string
+
+  let to_string = function
+    | NotFound id -> Printf.sprintf "[TaskError] Task not found: %s" id
+    | AlreadyClaimed { task_id; by } -> Printf.sprintf "[TaskError] Task %s is currently owned by %s." task_id by
+    | NotClaimed id -> Printf.sprintf "[TaskError] Task %s is still todo." id
+    | InvalidState msg -> Printf.sprintf "[TaskError] Invalid task state: %s" msg
+    | InvalidId reason -> Printf.sprintf "[TaskError] Invalid task ID: %s" reason
+end
+
+module Agent_error = struct
+  type t =
+    | NotFound of string
+    | NotJoined of string
+    | AlreadyJoined of string
+    | InvalidName of string
+
+  let to_string = function
+    | NotFound name -> Printf.sprintf "[AgentError] Agent not found: %s" name
+    | NotJoined name -> Printf.sprintf "[AgentError] Agent not joined: %s" name
+    | AlreadyJoined name -> Printf.sprintf "[AgentError] Agent already joined: %s" name
+    | InvalidName reason -> Printf.sprintf "[AgentError] Invalid agent name: %s" reason
+end
+
+module Auth_error = struct
+  type t =
+    | Unauthorized of string
+    | Forbidden of { agent: string; action: string }
+    | TokenExpired of string
+    | InvalidToken of string
+
+  let to_string = function
+    | Unauthorized reason -> Printf.sprintf "[AuthError] Unauthorized: %s" reason
+    | Forbidden { agent; action } -> Printf.sprintf "[AuthError] Forbidden: %s cannot %s" agent action
+    | TokenExpired agent -> Printf.sprintf "[AuthError] Token expired for %s" agent
+    | InvalidToken reason -> Printf.sprintf "[AuthError] Invalid token: %s" reason
+end
+
+module Portal_error = struct
+  type t =
+    | NotOpen of string
+    | AlreadyOpen of { agent: string; target: string }
+    | Closed of string
+
+  let to_string = function
+    | NotOpen agent -> Printf.sprintf "[PortalError] No portal open for %s" agent
+    | AlreadyOpen { agent; target } -> Printf.sprintf "[PortalError] Portal already open: %s <-> %s" agent target
+    | Closed agent -> Printf.sprintf "[PortalError] Portal is closed for %s" agent
+end
+
+module System_error = struct
+  type t =
+    | NotInitialized
+    | AlreadyInitialized
+    | InvalidJson of string
+    | IoError of string
+    | InvalidFilePath of string
+    | StorageError of string
+    | ValidationError of string
+
+  let to_string = function
+    | NotInitialized -> "[SystemError] MASC not initialized."
+    | AlreadyInitialized -> "[SystemError] MASC already initialized."
+    | InvalidJson msg -> Printf.sprintf "[SystemError] Invalid JSON: %s" msg
+    | IoError msg -> Printf.sprintf "[SystemError] IO error: %s" msg
+    | InvalidFilePath reason -> Printf.sprintf "[SystemError] Invalid file path: %s" reason
+    | StorageError msg -> Printf.sprintf "[SystemError] Storage error: %s" msg
+    | ValidationError msg -> Printf.sprintf "[SystemError] Validation error: %s" msg
+end
+
 type t =
-  | NotInitialized
-  | AlreadyInitialized
-  | AgentNotFound of string
-  | AgentNotJoined of string
-  | AgentAlreadyJoined of string
-  | TaskNotFound of string
-  | TaskAlreadyClaimed of { task_id: string; by: string }
-  | TaskNotClaimed of string
-  | TaskInvalidState of string
-  | PortalNotOpen of string
-  | PortalAlreadyOpen of { agent: string; target: string }
-  | PortalClosed of string
-  | InvalidJson of string
-  | IoError of string
-  | InvalidAgentName of string
-  | InvalidTaskId of string
-  | InvalidFilePath of string
-  | Unauthorized of string
-  | Forbidden of { agent: string; action: string }
-  | TokenExpired of string
-  | InvalidToken of string
+  | Task of Task_error.t
+  | Agent of Agent_error.t
+  | Auth of Auth_error.t
+  | Portal of Portal_error.t
+  | System of System_error.t
   | RateLimitExceeded of rate_limit_error
   | CacheError of cache_error
-  | StorageError of string
-  | ValidationError of string
 
+<<<<<<< HEAD
 let rec to_string = function
   | NotInitialized -> "MASC not initialized. Use masc_init first."
   | AlreadyInitialized -> "MASC already initialized."
@@ -126,16 +185,73 @@ let rec to_string = function
   | Forbidden { agent; action } -> Printf.sprintf "Forbidden: %s cannot %s" agent action
   | TokenExpired agent -> Printf.sprintf "Token expired for %s. Use masc_auth_refresh." agent
   | InvalidToken reason -> Printf.sprintf "Invalid token: %s" reason
+||||||| parent of ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
+let rec to_string = function
+  | NotInitialized -> "❌ MASC not initialized. Use masc_init first."
+  | AlreadyInitialized -> "MASC already initialized."
+  | AgentNotFound name -> Printf.sprintf "❌ Agent not found: %s" name
+  | AgentNotJoined name -> Printf.sprintf "❌ Agent not joined: %s. Use masc_join first." name
+  | AgentAlreadyJoined name -> Printf.sprintf "⚠ %s is already in the room" name
+  | TaskNotFound id -> Printf.sprintf "❌ Task not found: %s. Call masc_status to refresh your task list." id
+  | TaskAlreadyClaimed { task_id; by } ->
+      Printf.sprintf
+        "❌ Task %s is currently owned by %s. Ask that agent to finish it, or claim a different task."
+        task_id by
+  | TaskNotClaimed id ->
+      Printf.sprintf
+        "❌ Task %s is still todo. Claim/start it first, then mark it done."
+        id
+  | TaskInvalidState msg -> Printf.sprintf "❌ Invalid task state: %s" msg
+  | PortalNotOpen agent -> Printf.sprintf "❌ No portal open for %s. Use masc_portal_open first." agent
+  | PortalAlreadyOpen { agent; target } -> Printf.sprintf "⚠ Portal already open: %s ↔ %s" agent target
+  | PortalClosed agent -> Printf.sprintf "❌ Portal is closed for %s. Use masc_portal_open to reopen." agent
+  | InvalidJson msg -> Printf.sprintf "❌ Invalid JSON: %s" msg
+  | IoError msg -> Printf.sprintf "❌ IO error: %s" msg
+  | InvalidAgentName reason -> Printf.sprintf "❌ Invalid agent name: %s" reason
+  | InvalidTaskId reason -> Printf.sprintf "❌ Invalid task ID: %s" reason
+  | InvalidFilePath reason -> Printf.sprintf "❌ Invalid file path: %s" reason
+  | Unauthorized reason -> Printf.sprintf "🔐 Unauthorized: %s" reason
+  | Forbidden { agent; action } -> Printf.sprintf "🚫 Forbidden: %s cannot %s" agent action
+  | TokenExpired agent -> Printf.sprintf "⏰ Token expired for %s. Use masc_auth_refresh." agent
+  | InvalidToken reason -> Printf.sprintf "🔑 Invalid token: %s" reason
+=======
+let to_string = function
+  | Task e -> Task_error.to_string e
+  | Agent e -> Agent_error.to_string e
+  | Auth e -> Auth_error.to_string e
+  | Portal e -> Portal_error.to_string e
+  | System e -> System_error.to_string e
+>>>>>>> ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
   | RateLimitExceeded e ->
+<<<<<<< HEAD
       Printf.sprintf "Rate limit exceeded (%s): %d/%d requests. Wait %d seconds."
+||||||| parent of ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
+      Printf.sprintf "⏳ Rate limit exceeded (%s): %d/%d requests. Wait %d seconds."
+=======
+      Printf.sprintf "[RateLimit] Rate limit exceeded (%s): %d/%d requests. Wait %d seconds."
+>>>>>>> ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
         (show_rate_limit_category e.category) e.current e.limit e.wait_seconds
   | CacheError e -> (match e with
+<<<<<<< HEAD
       | CacheReadFailed path -> Printf.sprintf "Cache read failed [path=%s]" path
       | CacheWriteFailed path -> Printf.sprintf "Cache write failed [path=%s]" path
       | CacheExpired { key; age_hours } -> Printf.sprintf "Cache expired [key=%s, age=%.1fh]" key age_hours
       | CacheCorrupted path -> Printf.sprintf "Cache corrupted [path=%s]" path)
   | StorageError msg -> Printf.sprintf "Storage error: %s" msg
   | ValidationError msg -> Printf.sprintf "Validation error: %s" msg
+||||||| parent of ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
+      | CacheReadFailed path -> Printf.sprintf "❌ Cache: Read failed [path=%s]" path
+      | CacheWriteFailed path -> Printf.sprintf "❌ Cache: Write failed [path=%s]" path
+      | CacheExpired { key; age_hours } -> Printf.sprintf "❌ Cache: Expired [key=%s, age=%.1fh]" key age_hours
+      | CacheCorrupted path -> Printf.sprintf "❌ Cache: Corrupted [path=%s]" path)
+  | StorageError msg -> Printf.sprintf "Storage error: %s" msg
+  | ValidationError msg -> Printf.sprintf "Validation error: %s" msg
+=======
+      | CacheReadFailed path -> Printf.sprintf "[CacheError] Read failed [path=%s]" path
+      | CacheWriteFailed path -> Printf.sprintf "[CacheError] Write failed [path=%s]" path
+      | CacheExpired { key; age_hours } -> Printf.sprintf "[CacheError] Expired [key=%s, age=%.1fh]" key age_hours
+      | CacheCorrupted path -> Printf.sprintf "[CacheError] Corrupted [path=%s]" path)
+>>>>>>> ce3ebfb29e (refactor: domain-specific error hierarchy for MASC-MCP)
 
 let show = to_string
 
@@ -143,9 +259,7 @@ let to_yojson err =
   `String (to_string err)
 
 let code = function
-  | Unauthorized _ | TokenExpired _ | InvalidToken _ -> 401
-  | Forbidden _ -> 403
-  | AgentNotFound _ | TaskNotFound _ -> 404
+  | Auth _ -> 401
+  | Task _ | Agent _ | Portal _ | System _ -> 400
   | RateLimitExceeded _ -> 429
-  | InvalidJson _ | InvalidAgentName _ | InvalidTaskId _ | InvalidFilePath _ | ValidationError _ -> 400
   | _ -> 500

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -5,10 +5,11 @@ include module type of Rate_limit_types
 val default_rate_limit : rate_limit_config
 val rate_limit_config_to_yojson : rate_limit_config -> Yojson.Safe.t
 val rate_limit_config_of_yojson : Yojson.Safe.t -> (rate_limit_config, string) result
-
+val show_rate_limit_category : rate_limit_category -> string
+val show_rate_limit_error : rate_limit_error -> string
 val limit_for_category : rate_limit_config -> rate_limit_category -> int
-val category_for_tool_opt : string -> rate_limit_category option
 val category_for_tool : string -> rate_limit_category
+val category_for_tool_opt : string -> rate_limit_category option
 
 type cache_error =
   | CacheReadFailed of string
@@ -16,32 +17,62 @@ type cache_error =
   | CacheExpired of { key: string; age_hours: float }
   | CacheCorrupted of string
 
+module Task_error : sig
+  type t =
+    | NotFound of string
+    | AlreadyClaimed of { task_id: string; by: string }
+    | NotClaimed of string
+    | InvalidState of string
+    | InvalidId of string
+  val to_string : t -> string
+end
+
+module Agent_error : sig
+  type t =
+    | NotFound of string
+    | NotJoined of string
+    | AlreadyJoined of string
+    | InvalidName of string
+  val to_string : t -> string
+end
+
+module Auth_error : sig
+  type t =
+    | Unauthorized of string
+    | Forbidden of { agent: string; action: string }
+    | TokenExpired of string
+    | InvalidToken of string
+  val to_string : t -> string
+end
+
+module Portal_error : sig
+  type t =
+    | NotOpen of string
+    | AlreadyOpen of { agent: string; target: string }
+    | Closed of string
+  val to_string : t -> string
+end
+
+module System_error : sig
+  type t =
+    | NotInitialized
+    | AlreadyInitialized
+    | InvalidJson of string
+    | IoError of string
+    | InvalidFilePath of string
+    | StorageError of string
+    | ValidationError of string
+  val to_string : t -> string
+end
+
 type t =
-  | NotInitialized
-  | AlreadyInitialized
-  | AgentNotFound of string
-  | AgentNotJoined of string
-  | AgentAlreadyJoined of string
-  | TaskNotFound of string
-  | TaskAlreadyClaimed of { task_id: string; by: string }
-  | TaskNotClaimed of string
-  | TaskInvalidState of string
-  | PortalNotOpen of string
-  | PortalAlreadyOpen of { agent: string; target: string }
-  | PortalClosed of string
-  | InvalidJson of string
-  | IoError of string
-  | InvalidAgentName of string
-  | InvalidTaskId of string
-  | InvalidFilePath of string
-  | Unauthorized of string
-  | Forbidden of { agent: string; action: string }
-  | TokenExpired of string
-  | InvalidToken of string
+  | Task of Task_error.t
+  | Agent of Agent_error.t
+  | Auth of Auth_error.t
+  | Portal of Portal_error.t
+  | System of System_error.t
   | RateLimitExceeded of rate_limit_error
   | CacheError of cache_error
-  | StorageError of string
-  | ValidationError of string
 
 val to_string : t -> string
 val show : t -> string

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -246,7 +246,7 @@ let test_verify_wrong_token () =
   match create_result, verify_result with
   | Ok _, Ok _ ->
       fail "verify_token should fail with wrong token"
-  | Ok _, Error (Types.InvalidToken _) ->
+  | Ok _, Error (Types.Auth (Types.Auth_error.InvalidToken _)) ->
       (* Expected *)
       ()
   | Ok _, Error e ->
@@ -264,8 +264,8 @@ let test_verify_token_reports_token_owner_on_agent_mismatch () =
   in
   cleanup_test_room dir;
   match create_result, verify_result with
-  | Ok _, Error (Types.Unauthorized msg) ->
-      let rendered = Types.masc_error_to_string (Types.Unauthorized msg) in
+  | Ok _, Error (Types.Auth (Types.Auth_error.Unauthorized msg)) ->
+      let rendered = Types.masc_error_to_string (Types.Auth (Types.Auth_error.Unauthorized msg)) in
       check bool "mismatch message names token owner" true
         (String.contains rendered '('
          && contains_substring rendered "bearer token belongs to codex");
@@ -392,7 +392,7 @@ let test_delete_uuid_backed_credential_removes_redirect_target () =
         (Option.is_none
            (Auth.load_credential dir (Types.Credential_id.to_string id)));
       (match Auth.find_credential_by_token dir ~token:raw_token with
-       | Error (Types.InvalidToken _) -> ()
+       | Error (Types.Auth (Types.Auth_error.InvalidToken _)) -> ()
        | Error e ->
            fail
              (Printf.sprintf
@@ -829,7 +829,7 @@ let test_auth_enabled_requires_token () =
   cleanup_test_room dir;
   match result with
   | Ok () -> fail "should require token"
-  | Error (Types.Unauthorized _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Unauthorized _)) -> ()
   | Error _ -> fail "wrong error type"
 
 let test_auth_enabled_with_valid_token () =
@@ -858,7 +858,7 @@ let test_permission_denied_for_worker_admin_action () =
   cleanup_test_room dir;
   match check_result with
   | Ok () -> fail "worker should not get admin action"
-  | Error (Types.Forbidden _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Forbidden _)) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
 let test_authorize_unknown_masc_tool_strict_worker_allowed () =
@@ -897,7 +897,7 @@ let test_authorize_unknown_non_masc_tool_strict_denied () =
   cleanup_test_room dir;
   match result with
   | Ok () -> fail "unknown non-masc tool should be denied in strict mode"
-  | Error (Types.Forbidden _) ->
+  | Error (Types.Auth (Types.Auth_error.Forbidden _)) ->
       check (float 0.0001) "denial counter increments"
         (before +. 1.0)
         (strict_unknown_tool_denial_count
@@ -987,7 +987,7 @@ let test_authorize_tool_v2_unknown_keeper_prefix_strict_denied () =
   in
   match result with
   | Ok () -> fail "unknown keeper_* prefix should not bypass strict auth"
-  | Error (Types.Forbidden _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Forbidden _)) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
 let test_declared_tool_permission_from_tool_spec () =

--- a/test/test_auth_bearer_mismatch_9786.ml
+++ b/test/test_auth_bearer_mismatch_9786.ml
@@ -80,7 +80,7 @@ let test_cross_agent_mismatch_advances_counter () =
     Auth.verify_token dir ~agent_name:"agent-a-9786" ~token:"token-b-raw"
   in
   (match result with
-   | Error (Types.Unauthorized _) -> ()
+   | Error (Types.Auth (Types.Auth_error.Unauthorized _)) -> ()
    | Error e ->
      Alcotest.failf "expected Unauthorized, got: %s"
        (Types.masc_error_to_string e)

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -274,7 +274,7 @@ let test_same_origin_browser_request_rejects_missing_origin () =
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
   | Ok () -> fail "expected Unauthorized when Origin header is missing"
-  | Error (Types.Unauthorized _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Unauthorized _)) -> ()
   | Error e -> fail (Printf.sprintf "expected Unauthorized, got %s" (Types.masc_error_to_string e))
 
 let test_same_origin_browser_request_allows_matching_origin () =
@@ -303,7 +303,7 @@ let test_same_origin_browser_request_rejects_cross_origin () =
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
   | Ok () -> fail "expected cross-origin browser request to be rejected"
-  | Error (Types.Forbidden _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Forbidden _)) -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
 let test_same_origin_https_tunnel_same_host () =
@@ -360,7 +360,7 @@ let test_same_origin_rejects_non_allowlisted_loopback_cross_port () =
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
   | Ok () -> fail "expected non-allowlisted loopback cross-port request to be rejected"
-  | Error (Types.Forbidden _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Forbidden _)) -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
 let test_same_origin_rejects_different_explicit_port_on_public_host () =
@@ -375,7 +375,7 @@ let test_same_origin_rejects_different_explicit_port_on_public_host () =
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
   | Ok () -> fail "expected different-port public host request to be rejected"
-  | Error (Types.Forbidden _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Forbidden _)) -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
 let test_same_origin_allows_explicit_default_port_https () =
@@ -977,7 +977,7 @@ let test_resolve_agent_name_rejects_invalid_token () =
         SA.resolve_agent_name_for_auth
           ~base_path:dir request ~token:(Some invalid_token)
       with
-      | Error (Types.InvalidToken _) -> ()
+      | Error (Types.Auth (Types.Auth_error.InvalidToken _)) -> ()
       | Error e -> failf "expected InvalidToken, got %s" (Types.masc_error_to_string e)
       | Ok _ -> fail "expected invalid token failure")
 
@@ -1073,7 +1073,7 @@ let test_resolve_agent_name_rejects_internal_keeper_without_name () =
       let request = Httpun.Request.create ~headers `POST "/mcp" in
       match SA.resolve_agent_name_for_auth ~base_path:dir request ~token:(Some raw_token) with
       | Ok _ -> fail "expected missing keeper name header to be rejected"
-      | Error (Types.Unauthorized msg) ->
+      | Error (Types.Auth (Types.Auth_error.Unauthorized msg)) ->
           check bool "mentions keeper header" true
             (Astring.String.is_infix ~affix:"x-masc-keeper-name" msg)
       | Error e -> fail (Types.masc_error_to_string e))

--- a/test/test_auth_error_kind.ml
+++ b/test/test_auth_error_kind.ml
@@ -29,7 +29,7 @@ let test_of_string_unknown_returns_none () =
       Alcotest.fail "of_string should return None for unknown label"
 
 let test_classify_invalid_token () =
-  match Aek.classify (Types.InvalidToken "x") with
+  match Aek.classify (Types.Auth (Types.Auth_error.InvalidToken "x")) with
   | Aek.Token_mismatch -> ()
   | other ->
       Alcotest.failf
@@ -37,7 +37,7 @@ let test_classify_invalid_token () =
         (Aek.to_string other)
 
 let test_classify_token_expired () =
-  match Aek.classify (Types.TokenExpired "x") with
+  match Aek.classify (Types.Auth (Types.Auth_error.TokenExpired "x")) with
   | Aek.Token_expired -> ()
   | other ->
       Alcotest.failf
@@ -45,7 +45,7 @@ let test_classify_token_expired () =
         (Aek.to_string other)
 
 let test_classify_unauthorized () =
-  match Aek.classify (Types.Unauthorized "x") with
+  match Aek.classify (Types.Auth (Types.Auth_error.Unauthorized "x")) with
   | Aek.Unauthorized -> ()
   | other ->
       Alcotest.failf
@@ -53,7 +53,7 @@ let test_classify_unauthorized () =
         (Aek.to_string other)
 
 let test_classify_forbidden () =
-  match Aek.classify (Types.Forbidden { agent = "a"; action = "b" }) with
+  match Aek.classify (Types.Auth (Types.Auth_error.Forbidden { agent = "a"; action = "b" })) with
   | Aek.Forbidden -> ()
   | other ->
       Alcotest.failf
@@ -61,7 +61,7 @@ let test_classify_forbidden () =
         (Aek.to_string other)
 
 let test_classify_agent_not_found () =
-  match Aek.classify (Types.AgentNotFound "x") with
+  match Aek.classify (Types.Agent (Types.Agent_error.NotFound "x")) with
   | Aek.Agent_not_found -> ()
   | other ->
       Alcotest.failf
@@ -69,7 +69,7 @@ let test_classify_agent_not_found () =
         (Aek.to_string other)
 
 let test_classify_io_error () =
-  match Aek.classify (Types.IoError "x") with
+  match Aek.classify (Types.System (Types.System_error.IoError "x")) with
   | Aek.Io_error -> ()
   | other ->
       Alcotest.failf
@@ -77,7 +77,7 @@ let test_classify_io_error () =
         (Aek.to_string other)
 
 let test_classify_invalid_json () =
-  match Aek.classify (Types.InvalidJson "x") with
+  match Aek.classify (Types.System (Types.System_error.InvalidJson "x")) with
   | Aek.Invalid_json -> ()
   | other ->
       Alcotest.failf
@@ -88,7 +88,7 @@ let test_classify_unmodelled_falls_to_other () =
   (* IoError is not auth-relevant and intentionally falls through
      to [Other]. If a future PR moves it under an explicit arm, this
      test is the breakpoint. *)
-  match Aek.classify (Types.IoError "disk") with
+  match Aek.classify (Types.System (Types.System_error.IoError "disk")) with
   | Aek.Other -> ()
   | other ->
       Alcotest.failf

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -821,7 +821,7 @@ let test_approval_get_rejects_worker_role () =
     Masc_mcp.Auth.authorize_tool_for_role ~agent_name:"worker"
       ~role:Types.Worker ~tool_name:"masc_approval_get"
   with
-  | Error (Types.Forbidden _) -> ()
+  | Error (Types.Auth (Types.Auth_error.Forbidden _)) -> ()
   | Error err ->
       Alcotest.fail
         (Printf.sprintf "expected forbidden, got %s"

--- a/test/test_ocaml_north_star_task_lifecycle.ml
+++ b/test/test_ocaml_north_star_task_lifecycle.ml
@@ -72,7 +72,7 @@ let expect_ok label = function
 ;;
 
 let expect_invalid_transition label = function
-  | Error (Types.TaskInvalidState msg) -> msg
+  | Error (Types.Task (Types.Task_error.InvalidState msg)) -> msg
   | Error err -> fail (label ^ ": unexpected error " ^ Types.masc_error_to_string err)
   | Ok msg -> fail (label ^ ": unexpectedly succeeded: " ^ msg)
 ;;

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -473,7 +473,7 @@ let test_release_hard_stop_blocks_direct_reclaim () =
     | Ok _ -> ()
     | Error e -> Alcotest.fail (Types.masc_error_to_string e));
     match Coord.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
-    | Error (Types.TaskInvalidState message) ->
+    | Error (Types.Task (Types.Task_error.InvalidState message)) ->
         Alcotest.(check bool) "direct claim blocked by do_not_reclaim_reason" true
           (str_contains message "blocked from re-claim")
     | Error e ->
@@ -653,7 +653,7 @@ let test_cancel_task_nonexistent () =
   with_test_env (fun config ->
     let result = Coord.cancel_task_r config ~agent_name:"claude" ~task_id:"task-999" ~reason:"" in
     match result with
-    | Error Types.TaskNotFound _ -> ()
+    | Error (Types.Task (Types.Task_error.NotFound _)) -> ()
     | _ -> Alcotest.fail "Expected TaskNotFound"
   )
 
@@ -665,7 +665,7 @@ let test_cancel_done_task () =
 
     let result = Coord.cancel_task_r config ~agent_name:"claude" ~task_id:"task-001" ~reason:"" in
     match result with
-    | Error Types.TaskInvalidState _ -> ()
+    | Error (Types.Task (Types.Task_error.InvalidState _)) -> ()
     | _ -> Alcotest.fail "Expected TaskInvalidState"
   )
 
@@ -722,7 +722,7 @@ let test_transition_invalid () =
     (* Try to start without claiming first *)
     let result = Coord.transition_task_r config ~agent_name:"claude" ~task_id:"task-001" ~action:Types.Start () in
     match result with
-    | Error Types.TaskInvalidState _ -> ()
+    | Error (Types.Task (Types.Task_error.InvalidState _)) -> ()
     | _ -> Alcotest.fail "Expected TaskInvalidState"
   )
 
@@ -734,7 +734,7 @@ let test_transition_version_mismatch () =
     let result = Coord.transition_task_r config ~agent_name:"claude" ~task_id:"task-001"
                    ~action:Types.Claim ~expected_version:999 () in
     match result with
-    | Error Types.TaskInvalidState _ -> ()
+    | Error (Types.Task (Types.Task_error.InvalidState _)) -> ()
     | _ -> Alcotest.fail "Expected TaskInvalidState for version mismatch"
   )
 
@@ -1196,7 +1196,7 @@ let test_transition_done_r_not_claimed () =
 
     let result = transition_done_r config ~agent_name:"claude" ~task_id:"task-001" ~notes:"" in
     match result with
-    | Error (Types.TaskInvalidState msg) ->
+    | Error (Types.Task (Types.Task_error.InvalidState msg)) ->
         Alcotest.(check bool) "mentions todo state" true (str_contains msg "todo")
     | _ -> Alcotest.fail "Expected TaskInvalidState"
   )
@@ -1205,7 +1205,7 @@ let test_transition_done_r_not_found () =
   with_test_env (fun config ->
     let result = transition_done_r config ~agent_name:"claude" ~task_id:"task-999" ~notes:"" in
     match result with
-    | Error Types.TaskNotFound _ -> ()
+    | Error (Types.Task (Types.Task_error.NotFound _)) -> ()
     | _ -> Alcotest.fail "Expected TaskNotFound"
   )
 
@@ -1226,7 +1226,7 @@ let test_claim_task_r_already_claimed () =
 
     let result = Coord.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" () in
     match result with
-    | Error Types.TaskAlreadyClaimed _ -> ()
+    | Error (Types.Task (Types.Task_error.AlreadyClaimed _)) -> ()
     | _ -> Alcotest.fail "Expected TaskAlreadyClaimed"
   )
 
@@ -1321,7 +1321,7 @@ let test_update_agent_not_found () =
   with_test_env (fun config ->
     let result = Coord.update_agent_r config ~agent_name:"nonexistent" ~status:"active" () in
     match result with
-    | Error Types.AgentNotFound _ -> ()
+    | Error (Types.Agent (Types.Agent_error.NotFound _)) -> ()
     | _ -> Alcotest.fail "Expected AgentNotFound"
   )
 

--- a/test/test_sandbox_clone_conflict.ml
+++ b/test/test_sandbox_clone_conflict.ml
@@ -52,7 +52,7 @@ let test_auto_provision_rejects_plain_dir_clone_conflict () =
       ~agent_name:"test-agent" ~repos_dir ~repo_name:"masc-mcp"
   with
   | Ok _ -> fail "expected sandbox_clone_conflict error"
-  | Error (Types.IoError msg) ->
+  | Error (Types.System (Types.System_error.IoError msg)) ->
       check_contains "message mentions sandbox_clone_conflict"
         "sandbox_clone_conflict" msg;
       check_contains "message mentions not a git clone" "not a git clone" msg

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -410,7 +410,7 @@ let contains needle haystack =
 let error_msg result =
   match result with
   | Ok _ -> ""
-  | Error (Types.IoError m) -> m
+  | Error (Types.System (Types.System_error.IoError m)) -> m
   | Error _ -> "<non-IoError>"
 
 let make_config base_path : Masc_mcp.Coord.config =

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -642,7 +642,7 @@ let test_worktree_path_rejects_traversal_name () =
   match Masc_mcp.Coord.ensure_worktree_path root "../escape" with
   | Ok (worktree_path, _) ->
       fail ("expected invalid worktree path, got: " ^ worktree_path)
-  | Error (Types.IoError msg) ->
+  | Error (Types.System (Types.System_error.IoError msg)) ->
       check_contains "message mentions invalid worktree path"
         "Invalid worktree path" msg
   | Error err ->

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -720,27 +720,27 @@ let test_portal_state_of_yojson_wrong_type () =
    ============================================================ *)
 
 let test_masc_error_not_initialized () =
-  let s = Types.masc_error_to_string Types.NotInitialized in
+  let s = Types.masc_error_to_string (Types.System Types.System_error.NotInitialized) in
   check bool "contains not initialized" true (String.length s > 0)
 
 let test_masc_error_already_initialized () =
-  let s = Types.masc_error_to_string Types.AlreadyInitialized in
+  let s = Types.masc_error_to_string (Types.System Types.System_error.AlreadyInitialized) in
   check bool "contains already" true (String.length s > 0)
 
 let test_masc_error_agent_not_found () =
-  let s = Types.masc_error_to_string (Types.AgentNotFound "claude") in
+  let s = Types.masc_error_to_string (Types.Agent (Types.Agent_error.NotFound "claude")) in
   check bool "contains claude" true
     (try let _ = Str.search_forward (Str.regexp "claude") s 0 in true
      with Not_found -> false)
 
 let test_masc_error_task_not_found () =
-  let s = Types.masc_error_to_string (Types.TaskNotFound "task-1") in
+  let s = Types.masc_error_to_string (Types.Task (Types.Task_error.NotFound "task-1")) in
   check bool "contains task-1" true
     (try let _ = Str.search_forward (Str.regexp "task-1") s 0 in true
      with Not_found -> false)
 
 let test_masc_error_task_already_claimed () =
-  let s = Types.masc_error_to_string (Types.TaskAlreadyClaimed { task_id = "t1"; by = "agent" }) in
+  let s = Types.masc_error_to_string (Types.Task (Types.Task_error.AlreadyClaimed { task_id = "t1"; by = "agent" })) in
   check bool "contains owner guidance" true
     (try let _ = Str.search_forward (Str.regexp "currently owned by agent") s 0 in true
      with Not_found -> false)
@@ -1099,65 +1099,65 @@ let test_category_for_tool_general () =
    ============================================================ *)
 
 let test_masc_error_agent_already_joined () =
-  let s = Types.masc_error_to_string (Types.AgentAlreadyJoined "agent1") in
+  let s = Types.masc_error_to_string (Types.Agent (Types.Agent_error.AlreadyJoined "agent1")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_task_not_claimed () =
-  let s = Types.masc_error_to_string (Types.TaskNotClaimed "t1") in
+  let s = Types.masc_error_to_string (Types.Task (Types.Task_error.NotClaimed "t1")) in
   check bool "contains claim guidance" true
     (try let _ = Str.search_forward (Str.regexp "Claim/start it first") s 0 in true
      with Not_found -> false)
 
 let test_masc_error_task_invalid_state () =
-  let s = Types.masc_error_to_string (Types.TaskInvalidState "cancelled") in
+  let s = Types.masc_error_to_string (Types.Task (Types.Task_error.InvalidState "cancelled")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_portal_not_open () =
-  let s = Types.masc_error_to_string (Types.PortalNotOpen "agent") in
+  let s = Types.masc_error_to_string (Types.Portal (Types.Portal_error.NotOpen "agent")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_portal_already_open () =
-  let s = Types.masc_error_to_string (Types.PortalAlreadyOpen { agent = "a1"; target = "a2" }) in
+  let s = Types.masc_error_to_string (Types.Portal (Types.Portal_error.AlreadyOpen { agent = "a1"; target = "a2" })) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_portal_closed () =
-  let s = Types.masc_error_to_string (Types.PortalClosed "agent") in
+  let s = Types.masc_error_to_string (Types.Portal (Types.Portal_error.Closed "agent")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_invalid_json () =
-  let s = Types.masc_error_to_string (Types.InvalidJson "bad json") in
+  let s = Types.masc_error_to_string (Types.System (Types.System_error.InvalidJson "bad json")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_io_error () =
-  let s = Types.masc_error_to_string (Types.IoError "read failed") in
+  let s = Types.masc_error_to_string (Types.System (Types.System_error.IoError "read failed")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_invalid_agent_name () =
-  let s = Types.masc_error_to_string (Types.InvalidAgentName "bad name") in
+  let s = Types.masc_error_to_string (Types.Agent (Types.Agent_error.InvalidName "bad name")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_invalid_task_id () =
-  let s = Types.masc_error_to_string (Types.InvalidTaskId "bad id") in
+  let s = Types.masc_error_to_string (Types.Task (Types.Task_error.InvalidId "bad id")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_invalid_file_path () =
-  let s = Types.masc_error_to_string (Types.InvalidFilePath "bad path") in
+  let s = Types.masc_error_to_string (Types.System (Types.System_error.InvalidFilePath "bad path")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_unauthorized () =
-  let s = Types.masc_error_to_string (Types.Unauthorized "missing token") in
+  let s = Types.masc_error_to_string (Types.Auth (Types.Auth_error.Unauthorized "missing token")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_forbidden () =
-  let s = Types.masc_error_to_string (Types.Forbidden { agent = "a1"; action = "reset" }) in
+  let s = Types.masc_error_to_string (Types.Auth (Types.Auth_error.Forbidden { agent = "a1"; action = "reset" })) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_token_expired () =
-  let s = Types.masc_error_to_string (Types.TokenExpired "agent") in
+  let s = Types.masc_error_to_string (Types.Auth (Types.Auth_error.TokenExpired "agent")) in
   check bool "nonempty" true (String.length s > 0)
 
 let test_masc_error_invalid_token () =
-  let s = Types.masc_error_to_string (Types.InvalidToken "bad token") in
+  let s = Types.masc_error_to_string (Types.Auth (Types.Auth_error.InvalidToken "bad token")) in
   check bool "nonempty" true (String.length s > 0)
 
 (* ============================================================

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -398,12 +398,12 @@ let test_rate_limit_config_roundtrip () =
 
 let test_masc_error_to_string () =
   check bool "NotInitialized" true
-    (String.length (Types.masc_error_to_string Types.NotInitialized) > 0);
+    (String.length (Types.masc_error_to_string (Types.System Types.System_error.NotInitialized)) > 0);
   check bool "AgentNotFound" true
-    (String.length (Types.masc_error_to_string (Types.AgentNotFound "test")) > 0);
+    (String.length (Types.masc_error_to_string (Types.Agent (Types.Agent_error.NotFound "test"))) > 0);
   check bool "TaskAlreadyClaimed" true
     (String.length (Types.masc_error_to_string
-      (Types.TaskAlreadyClaimed { task_id = "t1"; by = "agent" })) > 0);
+      (Types.Task (Types.Task_error.AlreadyClaimed { task_id = "t1"; by = "agent" }))) > 0);
   check bool "RateLimitExceeded" true
     (String.length (Types.masc_error_to_string
       (Types.RateLimitExceeded {


### PR DESCRIPTION
Implements Phase 1 & 2 of the Error Hierarchy Refactoring. Eliminates flat catch-all errors in masc_error.ml and adopts a domain-specific 2-level structure. Fixes all associated compiler errors across the codebase.