### PR TITLE
refactor: remove base dependency from all dune files (Phase 3)

### DIFF
--- a/lib/backend/dune
+++ b/lib/backend/dune
@@ -24,6 +24,5 @@
   uri
   str
   mtime
-  zstd
-  base)
+  zstd)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -57,6 +57,5 @@
   uri
   uuidm
   digestif
-  masc_random_id
-  base)
+  masc_random_id)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -4,4 +4,4 @@
  (public_name masc_mcp.masc_core)
  (wrapped false)
  (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util)
- (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events base))
+ (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -15,7 +15,7 @@ val parse_iso_opt : string option -> float option
 (** {1 Strings} *)
 
 val first_some : 'a option -> 'a option -> 'a option
-(** Re-export of [Base.Option.first_some]. *)
+(** Return the first [Some], or the second. *)
 
 val string_contains : needle:string -> string -> bool
 (** Case-sensitive substring test. *)
@@ -27,7 +27,7 @@ val trim_to_option : string -> string option
 (** [Some s] for non-empty trimmed text, [None] otherwise. *)
 
 val dedup_strings : string list -> string list
-(** Order-preserving deduplication via [Base.Set]. *)
+(** Order-preserving deduplication via local [String_set]. *)
 
 val compact_text : ?max_len:int -> string -> string
 (** Collapse newlines/whitespace into single spaces, then truncate to a

--- a/lib/dashboard_utils/dune
+++ b/lib/dashboard_utils/dune
@@ -5,4 +5,4 @@
  (public_name masc_mcp.dashboard_utils)
  (modules dashboard_utils)
  (wrapped false)
- (libraries masc_types masc_core base unix yojson))
+ (libraries masc_types masc_core unix yojson))

--- a/lib/dune
+++ b/lib/dune
@@ -212,8 +212,6 @@
    ;; ctypes/ctypes-foreign removed (was only used by webrtc_bindings.ml)
    ;; WebRTC DataChannel transport (ocaml-webrtc library)
    ocaml-webrtc
-   ;; Jane Street Base — qualified access only (no `open Base`)
-   base
    ;; OCaml 5.x Eio concurrency (required for *_eio.ml modules)
    eio
    eio_main

--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -5,4 +5,4 @@
  (name masc_exec)
  (public_name masc_mcp.masc_exec)
  (wrapped true)
- (libraries masc_process masc_core eio unix yojson base re))
+ (libraries masc_process masc_core eio unix yojson re))

--- a/lib/exec/string_util.mli
+++ b/lib/exec/string_util.mli
@@ -1,3 +1,3 @@
 val contains_substring : string -> string -> bool
 (** [contains_substring haystack needle] returns [true] if [needle] is a
-    substring of [haystack]. Uses [Base.String.is_substring] internally. *)
+    substring of [haystack]. Sliding-window implementation. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -6,4 +6,4 @@
         test_history_insight test_exec_cache test_exec_budget
         test_exec_adaptive_timeout test_risk_classifier test_egress_policy)
  (libraries masc_exec masc_exec_bash_parser masc_process
-            masc_core alcotest eio eio_main yojson unix base re))
+            masc_core alcotest eio eio_main yojson unix re))

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -3,4 +3,4 @@
  (name fs_compat)
  (public_name masc_mcp.fs_compat)
  (modules fs_compat)
- (libraries base eio eio.unix unix yojson optint))
+ (libraries eio eio.unix unix yojson optint))

--- a/lib/time_compat/dune
+++ b/lib/time_compat/dune
@@ -3,4 +3,4 @@
  (name time_compat)
  (public_name masc_mcp.time_compat)
  (modules time_compat)
- (libraries base eio unix mcp_protocol.eio))
+ (libraries eio unix mcp_protocol.eio))


### PR DESCRIPTION
## Summary
- Remove `base` library from 9 dune library declarations (code already migrated to Stdlib in Phase 2, #12766)
- Update 3 stale `.mli` doc comments that referenced `Base.*` internals
- Follows Phase 2 (#12766) which replaced all `Base.*` qualified calls with OCaml Stdlib equivalents

## Changed files
- **dune (9)**: time_compat, dashboard_utils, fs_compat, exec, exec/test, core, coord, backend, main lib
- **mli (2)**: dashboard_utils.mli, exec/string_util.mli — removed Base references from doc comments

## Test plan
- [x] `dune build` passes without `base` linked
- [x] `dune runtest lib/exec/test/` passes
- [ ] CI Build/Lint/Health checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)