### PR TITLE
feat(dashboard): cascade trace + heartbeat bars in provider matrix

### DIFF
--- a/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
+++ b/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
@@ -1,0 +1,91 @@
+// CascadeTrace — OAS cascade routing trace visualization.
+// Shows miss/hit/skipped steps with timing for each provider attempt.
+
+import { html } from 'htm/preact'
+import {
+  CASCADE_TRACES,
+  cascadeStepColor,
+  cascadeTierLabel,
+  cascadeTierStyle,
+  type CascadeStepStatus,
+} from './data'
+
+function stepStatusLabel(status: CascadeStepStatus): string {
+  switch (status) {
+    case 'hit':     return 'HIT'
+    case 'miss':    return 'MISS'
+    case 'skipped': return 'SKIP'
+  }
+}
+
+function formatMs(ms: number): string {
+  if (ms === 0) return '—'
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function ArrowConnector() {
+  return html`
+    <div class="flex items-center px-1 text-[var(--color-fg-disabled)]">
+      <svg width="16" height="12" viewBox="0 0 16 12" fill="none" aria-hidden="true" focusable="false">
+        <path d="M0 6H12M12 6L8 2M12 6L8 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </div>
+  `
+}
+
+export function CascadeTrace() {
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+        <span>OAS Cascade = Provider 순차 시도 + Cooldown 게이트</span>
+        <span class="text-[var(--color-border-default)]">|</span>
+        <span class="flex items-center gap-1">
+          <span class="inline-block w-3 h-2 rounded-sm bg-[var(--ok-10)]"></span> HIT
+        </span>
+        <span class="flex items-center gap-1">
+          <span class="inline-block w-3 h-2 rounded-sm bg-[var(--bad-10)]"></span> MISS
+        </span>
+        <span class="flex items-center gap-1">
+          <span class="inline-block w-3 h-2 rounded-sm bg-[var(--white-4)]"></span> SKIP
+        </span>
+      </div>
+
+      ${CASCADE_TRACES.map(trace => html`
+        <div key=${trace.id} class="border border-[var(--color-border-default)] rounded overflow-hidden">
+          <div class="flex items-center justify-between px-3 py-1.5 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
+            <div class="flex items-center gap-2">
+              <span class="text-xs font-medium text-[var(--color-fg-primary)]">${trace.label}</span>
+              <span class="inline-block rounded px-1.5 py-0.5 text-[9px] font-mono font-bold ${cascadeTierStyle(trace.tier)}">
+                ${cascadeTierLabel(trace.tier)}
+              </span>
+            </div>
+            <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(trace.totalMs)} total</span>
+          </div>
+          <div class="flex items-stretch px-2 py-2">
+            ${trace.steps.map((step, i) => {
+              const isLast = i === trace.steps.length - 1
+              return html`
+                <${StepBlock} key=${i} step=${step} />
+                ${!isLast ? html`<${ArrowConnector} />` : null}
+              `
+            })}
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function StepBlock({ step }: { step: typeof CASCADE_TRACES[number]['steps'][number] }) {
+  return html`
+    <div class="flex-1 flex flex-col items-center gap-1 min-w-[100px]">
+      <span class="text-[10px] font-medium text-[var(--color-fg-secondary)]">${step.provider}</span>
+      <span class="inline-block rounded border px-2.5 py-0.5 text-[10px] font-mono font-bold ${cascadeStepColor(step.status)}">
+        ${stepStatusLabel(step.status)}
+      </span>
+      <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(step.ms)}</span>
+      <span class="text-[9px] text-[var(--color-fg-disabled)] max-w-[100px] truncate" title=${step.reason}>${step.reason}</span>
+    </div>
+  `
+}

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -437,6 +437,127 @@ export function cascadeTierStyle(tier: CascadeTraceScenario['tier']): string {
   }
 }
 
+// ── P0–P7 Improvement Roadmap ────────────────────────────────────
+// Source: sec06 Table 6-1
+
+export type RoadmapPhase = 'P0' | 'P1' | 'P2' | 'P3' | 'P4' | 'P5' | 'P6' | 'P7'
+
+export interface RoadmapItem {
+  id: RoadmapPhase
+  area: string
+  goal: string
+  targetAntiPatterns: string[]
+  reference: string
+  effect: string
+  timeline: string
+  deps: RoadmapPhase[]
+}
+
+export const ROADMAP_ITEMS: RoadmapItem[] = [
+  {
+    id: 'P0', area: 'Verification Loop',
+    goal: '모든 tool calling 결과를 JSON Schema로 검증, 실패 시 self-healing 루프',
+    targetAntiPatterns: ['S01-S10', 'F01-F04'],
+    reference: 'Sam Chon Harness, Typia',
+    effect: '복잡한 스키마 tool call 성공률 6.75%→100%',
+    timeline: '1-4주', deps: [],
+  },
+  {
+    id: 'P1', area: 'Context Compaction',
+    goal: 'KV Cache 압축, capability 기반 context ceiling, cache_control 자동화',
+    targetAntiPatterns: ['H04-H05', 'S08'],
+    reference: 'Claude Code compaction',
+    effect: '장기 세션 60-70% 컨텍스트 해제',
+    timeline: '2-6주', deps: ['P0'],
+  },
+  {
+    id: 'P2', area: 'MCP Integration',
+    goal: 'CLI Provider MCP 활성화, runtime tool discovery, ToolResult 타입 검증',
+    targetAntiPatterns: ['F02-F03', 'M04-M05'],
+    reference: 'MCPMark, Claude Code MCP',
+    effect: 'CLI Provider tool 사용률 0→100%',
+    timeline: '3-8주', deps: ['P0'],
+  },
+  {
+    id: 'P3', area: 'Thinking Unification',
+    goal: 'thinking_control_format capability 필드, provider별 직렬화 표준화',
+    targetAntiPatterns: ['M01-M03', 'S03'],
+    reference: 'BFCL, Gemini thinking config',
+    effect: 'thinking 처리 결정론적 분기 보장',
+    timeline: '2-6주', deps: ['P0'],
+  },
+  {
+    id: 'P4', area: 'Deterministic Output',
+    goal: 'seed 파라미터 지원, temperature=0 한계 문서화, 이미지 입력 처리',
+    targetAntiPatterns: ['H10', 'S05'],
+    reference: 'OpenAI seed docs, PyTorch determinism',
+    effect: '텍스트 전용 프롬프트 재생 가능한 출력',
+    timeline: '4-10주', deps: ['P0', 'P3'],
+  },
+  {
+    id: 'P5', area: 'Anti-pattern Removal',
+    goal: 'Silent Failure→Explicit Error, Fake Fallback→Capability Honesty, String→Metadata, Hardcode→Config',
+    targetAntiPatterns: ['S01-S10', 'F01-F04', 'M01-M06', 'H01-H12'],
+    reference: 'Ch5 분석 결과',
+    effect: '32개 안티패턴 중 28개 제거 (87.5%)',
+    timeline: '2-16주', deps: ['P0', 'P2', 'P4'],
+  },
+  {
+    id: 'P6', area: 'New Provider Support',
+    goal: 'Nemotron API, Gemma 4, Ollama Cloud 지원 추가',
+    targetAntiPatterns: ['H11-H12'],
+    reference: 'NVIDIA NIM docs, Gemma 4 docs',
+    effect: '3개 신규 제공자 지원',
+    timeline: '4-12주', deps: [],
+  },
+  {
+    id: 'P7', area: 'Monitoring & Observability',
+    goal: 'usage tokens 복원, capability drift 감지, per-provider metrics',
+    targetAntiPatterns: ['S05', 'H10-H12'],
+    reference: 'Claude Code metrics',
+    effect: 'provider API 변경 시 24시간 이내 감지',
+    timeline: '4-16주', deps: [],
+  },
+]
+
+export type Applicability = 'full' | 'partial' | 'none' | 'na'
+
+export const APPLICABILITY_MATRIX: Record<RoadmapPhase, Record<string, Applicability>> = {
+  P0: { openai:'full',claude:'full',gemini:'full',deepseek:'full',qwen35:'full',mistral:'full',ollama:'full',llamacpp:'full',glm:'full',nemotron:'full',kimi:'full',gemini_cli:'partial',codex_cli:'partial' },
+  P1: { openai:'full',claude:'full',gemini:'full',deepseek:'full',qwen35:'full',mistral:'full',ollama:'full',llamacpp:'full',glm:'full',nemotron:'full',kimi:'full',gemini_cli:'full',codex_cli:'full' },
+  P2: { openai:'na',claude:'na',gemini:'na',deepseek:'na',qwen35:'na',mistral:'na',ollama:'full',llamacpp:'na',glm:'na',nemotron:'na',kimi:'na',gemini_cli:'full',codex_cli:'full' },
+  P3: { openai:'full',claude:'full',gemini:'full',deepseek:'full',qwen35:'full',mistral:'partial',ollama:'full',llamacpp:'full',glm:'partial',nemotron:'full',kimi:'partial',gemini_cli:'na',codex_cli:'na' },
+  P4: { openai:'full',claude:'none',gemini:'full',deepseek:'partial',qwen35:'partial',mistral:'full',ollama:'full',llamacpp:'full',glm:'partial',nemotron:'partial',kimi:'partial',gemini_cli:'none',codex_cli:'none' },
+  P5: { openai:'full',claude:'full',gemini:'full',deepseek:'full',qwen35:'full',mistral:'full',ollama:'full',llamacpp:'full',glm:'full',nemotron:'full',kimi:'full',gemini_cli:'full',codex_cli:'full' },
+  P6: { openai:'na',claude:'na',gemini:'na',deepseek:'na',qwen35:'na',mistral:'na',ollama:'na',llamacpp:'na',glm:'na',nemotron:'full',kimi:'na',gemini_cli:'na',codex_cli:'na' },
+  P7: { openai:'full',claude:'full',gemini:'full',deepseek:'full',qwen35:'full',mistral:'full',ollama:'full',llamacpp:'full',glm:'full',nemotron:'full',kimi:'full',gemini_cli:'full',codex_cli:'full' },
+}
+
+export function applicabilitySymbol(a: Applicability): string {
+  switch (a) {
+    case 'full': return '✅'
+    case 'partial': return '⚠️'
+    case 'none': return '❌'
+    case 'na': return '—'
+  }
+}
+
+export function applicabilityCellClass(a: Applicability): string {
+  switch (a) {
+    case 'full': return 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+    case 'partial': return 'bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'none': return 'bg-[var(--bad-10)] text-[var(--bad-light)]'
+    case 'na': return 'bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+  }
+}
+
+export function phaseColor(id: RoadmapPhase): string {
+  const idx = ROADMAP_ITEMS.findIndex(r => r.id === id)
+  if (idx <= 1) return 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
+  if (idx <= 4) return 'bg-[var(--warn-10)] text-[var(--color-status-warn)] border-[var(--warn-20)]'
+  return 'bg-[var(--white-4)] text-[var(--color-fg-secondary)] border-[var(--color-border-default)]'
+}
+
 // ── Shared helpers ──────────────────────────────────────────────
 
 export function supportCellClass(v: FeatureSupport): string {

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -355,7 +355,7 @@ export interface CascadeStep {
   reason: string
 }
 
-export interface CascadeTrace {
+export interface CascadeTraceScenario {
   id: string
   label: string
   tier: 'typical' | 'ideal' | 'worst' | 'cooldown'
@@ -363,7 +363,7 @@ export interface CascadeTrace {
   totalMs: number
 }
 
-export const CASCADE_TRACES: CascadeTrace[] = [
+export const CASCADE_TRACES: CascadeTraceScenario[] = [
   {
     id: 'ct-rate-limit',
     label: 'Rate-limit → Fallback',
@@ -419,7 +419,7 @@ export function cascadeStepColor(status: CascadeStepStatus): string {
   }
 }
 
-export function cascadeTierLabel(tier: CascadeTrace['tier']): string {
+export function cascadeTierLabel(tier: CascadeTraceScenario['tier']): string {
   switch (tier) {
     case 'typical':  return '일반'
     case 'ideal':    return '이상'
@@ -428,7 +428,7 @@ export function cascadeTierLabel(tier: CascadeTrace['tier']): string {
   }
 }
 
-export function cascadeTierStyle(tier: CascadeTrace['tier']): string {
+export function cascadeTierStyle(tier: CascadeTraceScenario['tier']): string {
   switch (tier) {
     case 'typical':  return 'bg-[var(--white-4)] text-[var(--color-fg-secondary)]'
     case 'ideal':    return 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -343,6 +343,100 @@ export const ANTI_PATTERNS: AntiPattern[] = [
   { id: 'H12', category: 'hardcoding', description: 'BFCL score threshold가 상수 아닌 리터럴', location: 'model_selector.ml', risk: 'L' },
 ]
 
+// ── Cascade Traces ────────────────────────────────────────────
+// OAS cascade routing trace scenarios. Source: sec03 cascade flow analysis.
+
+export type CascadeStepStatus = 'hit' | 'miss' | 'skipped'
+
+export interface CascadeStep {
+  provider: string
+  status: CascadeStepStatus
+  ms: number
+  reason: string
+}
+
+export interface CascadeTrace {
+  id: string
+  label: string
+  tier: 'typical' | 'ideal' | 'worst' | 'cooldown'
+  steps: CascadeStep[]
+  totalMs: number
+}
+
+export const CASCADE_TRACES: CascadeTrace[] = [
+  {
+    id: 'ct-rate-limit',
+    label: 'Rate-limit → Fallback',
+    tier: 'typical',
+    steps: [
+      { provider: 'Anthropic', status: 'miss', ms: 820, reason: 'rate-limit.soft' },
+      { provider: 'OpenAI',    status: 'miss', ms: 540, reason: 'timeout' },
+      { provider: 'Moonshot',  status: 'hit',  ms: 420, reason: 'ok' },
+    ],
+    totalMs: 1780,
+  },
+  {
+    id: 'ct-first-hit',
+    label: 'Primary Hit',
+    tier: 'ideal',
+    steps: [
+      { provider: 'Anthropic', status: 'hit',     ms: 380, reason: 'ok' },
+      { provider: 'OpenAI',    status: 'skipped',  ms: 0,   reason: 'skipped' },
+      { provider: 'Moonshot',  status: 'skipped',  ms: 0,   reason: 'skipped' },
+    ],
+    totalMs: 380,
+  },
+  {
+    id: 'ct-exhaustion',
+    label: '전체 Exhaustion',
+    tier: 'worst',
+    steps: [
+      { provider: 'Anthropic', status: 'miss', ms: 1240, reason: 'rate-limit.hard' },
+      { provider: 'OpenAI',    status: 'miss', ms: 980,  reason: 'server_error' },
+      { provider: 'Moonshot',  status: 'miss', ms: 650,  reason: 'auth_failure' },
+      { provider: 'Ollama',    status: 'miss', ms: 320,  reason: 'model_unloaded' },
+    ],
+    totalMs: 3190,
+  },
+  {
+    id: 'ct-cooldown',
+    label: 'Cooldown Bypass',
+    tier: 'cooldown',
+    steps: [
+      { provider: 'Anthropic', status: 'miss', ms: 100, reason: 'cooldown (30s remaining)' },
+      { provider: 'OpenAI',    status: 'hit',  ms: 460, reason: 'ok' },
+      { provider: 'Moonshot',  status: 'skipped', ms: 0, reason: 'skipped' },
+    ],
+    totalMs: 560,
+  },
+]
+
+export function cascadeStepColor(status: CascadeStepStatus): string {
+  switch (status) {
+    case 'hit':     return 'bg-[var(--ok-10)] text-[var(--color-status-ok)] border-[var(--ok-20)]'
+    case 'miss':    return 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]'
+    case 'skipped': return 'bg-[var(--white-4)] text-[var(--color-fg-muted)] border-[var(--color-border-default)]'
+  }
+}
+
+export function cascadeTierLabel(tier: CascadeTrace['tier']): string {
+  switch (tier) {
+    case 'typical':  return '일반'
+    case 'ideal':    return '이상'
+    case 'worst':    return '최악'
+    case 'cooldown': return 'Cooldown'
+  }
+}
+
+export function cascadeTierStyle(tier: CascadeTrace['tier']): string {
+  switch (tier) {
+    case 'typical':  return 'bg-[var(--white-4)] text-[var(--color-fg-secondary)]'
+    case 'ideal':    return 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+    case 'worst':    return 'bg-[var(--bad-10)] text-[var(--bad-light)]'
+    case 'cooldown': return 'bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+  }
+}
+
 // ── Shared helpers ──────────────────────────────────────────────
 
 export function supportCellClass(v: FeatureSupport): string {

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -13,6 +13,7 @@ import {
 } from './data'
 import { StatusDot } from '../common/status-dot'
 import { StatTile } from '../common/stat-tile'
+import { HeartbeatStrip } from '../common/heartbeat-strip'
 import type { DashboardRuntimeProviderSnapshot } from '../../api/dashboard'
 import type { HeartbeatState } from '../../lib/heartbeat-history'
 
@@ -59,35 +60,16 @@ export function liveStatusDot(
 
 const HB_SLOTS = 12
 
-function mockHeartbeat(status: LiveStatus | null): HeartbeatState[] {
-  if (status === null) return Array(HB_SLOTS).fill('unknown')
+/** Derive a flat, uniform slot array from the current live status.
+ *  No fake historical patterns — all slots share the same state so the
+ *  bar is a present-tense status indicator rather than a history chart. */
+function statusToSlots(status: LiveStatus | null): HeartbeatState[] {
+  if (status === null || status === 'neutral') return Array<HeartbeatState>(HB_SLOTS).fill('unknown')
   switch (status) {
-    case 'ok':      return ['up','up','up','up','down','up','up','up','up','up','up','up']
-    case 'bad':     return ['down','down','down','up','down','down','down','down','down','down','down','down']
-    case 'warn':    return ['up','up','down','up','up','down','up','down','up','up','down','up']
-    case 'neutral': return Array(HB_SLOTS).fill('unknown')
+    case 'ok':   return Array<HeartbeatState>(HB_SLOTS).fill('up')
+    case 'bad':  return Array<HeartbeatState>(HB_SLOTS).fill('down')
+    case 'warn': return Array<HeartbeatState>(HB_SLOTS).fill('unknown')
   }
-}
-
-const HB_COLOR: Record<HeartbeatState, string> = {
-  up: 'bg-[var(--ok-10)]',
-  down: 'bg-[var(--bad-10)]',
-  unknown: 'bg-[var(--white-8)]',
-}
-
-function MiniHeartbeat({ history }: { history: HeartbeatState[] }) {
-  const upCount = history.filter(h => h === 'up').length
-  const observed = history.filter(h => h !== 'unknown').length
-  const label = observed === 0
-    ? '상태 데이터 없음'
-    : `${upCount}/${observed} 정상`
-  return html`
-    <div class="flex items-end gap-px justify-center" title=${label}>
-      ${history.map((s, i) => html`
-        <span key=${i} class="w-0.5 h-1.5 rounded-sm ${HB_COLOR[s]}"></span>
-      `)}
-    </div>
-  `
 }
 
 export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRuntimeProviderSnapshot[] }) {
@@ -129,10 +111,10 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
               <th class="sticky left-0 z-10 bg-[var(--shell-rail-bg)] border-b border-r border-[var(--color-border-default)]"></th>
               ${PROVIDER_IDS.map(pid => {
                 const dot = liveStatusDot(pid, liveProviders)
-                const hb = mockHeartbeat(dot)
+                const hb = statusToSlots(dot)
                 return html`
                   <th key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5">
-                    <${MiniHeartbeat} history=${hb} />
+                    <${HeartbeatStrip} history=${hb} slots=${HB_SLOTS} />
                   </th>
                 `
               })}

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -14,6 +14,7 @@ import {
 import { StatusDot } from '../common/status-dot'
 import { StatTile } from '../common/stat-tile'
 import type { DashboardRuntimeProviderSnapshot } from '../../api/dashboard'
+import type { HeartbeatState } from '../../lib/heartbeat-history'
 
 type LiveStatus = 'ok' | 'bad' | 'warn' | 'neutral'
 
@@ -56,6 +57,39 @@ export function liveStatusDot(
   return null
 }
 
+const HB_SLOTS = 12
+
+function mockHeartbeat(status: LiveStatus | null): HeartbeatState[] {
+  if (status === null) return Array(HB_SLOTS).fill('unknown')
+  switch (status) {
+    case 'ok':      return ['up','up','up','up','down','up','up','up','up','up','up','up']
+    case 'bad':     return ['down','down','down','up','down','down','down','down','down','down','down','down']
+    case 'warn':    return ['up','up','down','up','up','down','up','down','up','up','down','up']
+    case 'neutral': return Array(HB_SLOTS).fill('unknown')
+  }
+}
+
+const HB_COLOR: Record<HeartbeatState, string> = {
+  up: 'bg-[var(--ok-10)]',
+  down: 'bg-[var(--bad-10)]',
+  unknown: 'bg-[var(--white-8)]',
+}
+
+function MiniHeartbeat({ history }: { history: HeartbeatState[] }) {
+  const upCount = history.filter(h => h === 'up').length
+  const observed = history.filter(h => h !== 'unknown').length
+  const label = observed === 0
+    ? '상태 데이터 없음'
+    : `${upCount}/${observed} 정상`
+  return html`
+    <div class="flex items-end gap-px justify-center" title=${label}>
+      ${history.map((s, i) => html`
+        <span key=${i} class="w-0.5 h-1.5 rounded-sm ${HB_COLOR[s]}"></span>
+      `)}
+    </div>
+  `
+}
+
 export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRuntimeProviderSnapshot[] }) {
   const summary = useMemo(() => computeMatrixSummary(), [])
   const liveOk = liveProviders.filter(p => liveProviderStatus(p) === 'ok').length
@@ -87,6 +121,18 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
                       <span>${PROVIDER_LABELS[pid] ?? pid}</span>
                       ${kind === 'cli' ? html`<span class="text-[8px] font-mono text-[var(--color-fg-disabled)] uppercase">cli</span>` : null}
                     </div>
+                  </th>
+                `
+              })}
+            </tr>
+            <tr class="bg-[var(--white-4)]">
+              <th class="sticky left-0 z-10 bg-[var(--shell-rail-bg)] border-b border-r border-[var(--color-border-default)]"></th>
+              ${PROVIDER_IDS.map(pid => {
+                const dot = liveStatusDot(pid, liveProviders)
+                const hb = mockHeartbeat(dot)
+                return html`
+                  <th key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5">
+                    <${MiniHeartbeat} history=${hb} />
                   </th>
                 `
               })}

--- a/dashboard/src/components/provider-capability-matrix/index.ts
+++ b/dashboard/src/components/provider-capability-matrix/index.ts
@@ -1,10 +1,12 @@
 // ProviderCapabilityMatrix — Feature × Provider matrix, OAS wiring gaps,
-// and anti-pattern registry. Static data from sec02/sec04/sec05 analysis
-// with live provider overlay from /api/v1/providers.
+// cascade routing traces, and anti-pattern registry. Static data from
+// sec02/sec03/sec04/sec05 analysis with live provider overlay from
+// /api/v1/providers.
 //
 // Sub-views (via FilterChips):
 //   providers    — OAS provider kind definitions (sec02 Table 1)
 //   matrix       — 15 features × 13 providers
+//   cascade      — OAS cascade routing trace scenarios (sec03)
 //   benchmarks   — BFCL V3/V4 rankings
 //   wiring       — OAS wiring mismatches vs official API
 //   anti-patterns — 32 anti-patterns (S/F/M/H categories)
@@ -20,15 +22,17 @@ import {
 } from '../../api/dashboard'
 import { FeatureMatrix, MatrixLegend } from './feature-matrix'
 import { BfclRankings } from './bfcl-rankings'
+import { CascadeTrace } from './cascade-trace'
 import { WiringGaps } from './wiring-gaps'
 import { AntiPatternList } from './anti-patterns'
 import { OasProviderTable } from './oas-provider-table'
 
-type CapView = 'providers' | 'matrix' | 'benchmarks' | 'wiring' | 'anti-patterns'
+type CapView = 'providers' | 'matrix' | 'cascade' | 'benchmarks' | 'wiring' | 'anti-patterns'
 
 const CAP_VIEWS: Array<{ key: CapView; label: string }> = [
   { key: 'providers', label: 'OAS 프로바이더' },
   { key: 'matrix', label: '기능 매트릭스' },
+  { key: 'cascade', label: '캐스케이드 트레이스' },
   { key: 'benchmarks', label: 'BFCL 벤치마크' },
   { key: 'wiring', label: 'OAS 배선 갭' },
   { key: 'anti-patterns', label: '안티패턴' },
@@ -84,6 +88,16 @@ export function ProviderCapabilityMatrix() {
           <${MatrixLegend} />
           <${FeatureMatrix} liveProviders=${liveProviders.value} />
         </div>
+      ` : activeView.value === 'cascade' ? html`
+        <${Card}>
+          <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">OAS Cascade 라우팅 트레이스</h3>
+          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+            sec03 분석 — Provider cascade 경로의 4가지 대표 시나리오.
+            Rate-limit/Timeout → Cooldown 게이트 → 다음 Provider 순차 시도.
+            Exhaustion 시 turn 실패로 보고.
+          </p>
+          <${CascadeTrace} />
+        <//>
       ` : activeView.value === 'benchmarks' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">BFCL Function Calling 순위</h3>

--- a/dashboard/src/components/provider-capability-matrix/index.ts
+++ b/dashboard/src/components/provider-capability-matrix/index.ts
@@ -9,6 +9,7 @@
 //   cascade      — OAS cascade routing trace scenarios (sec03)
 //   benchmarks   — BFCL V3/V4 rankings
 //   wiring       — OAS wiring mismatches vs official API
+//   roadmap     — P0–P7 improvement priorities (sec06 Table 6-1/6-2)
 //   anti-patterns — 32 anti-patterns (S/F/M/H categories)
 
 import { html } from 'htm/preact'
@@ -26,8 +27,9 @@ import { CascadeTrace } from './cascade-trace'
 import { WiringGaps } from './wiring-gaps'
 import { AntiPatternList } from './anti-patterns'
 import { OasProviderTable } from './oas-provider-table'
+import { Roadmap } from './roadmap'
 
-type CapView = 'providers' | 'matrix' | 'cascade' | 'benchmarks' | 'wiring' | 'anti-patterns'
+type CapView = 'providers' | 'matrix' | 'cascade' | 'benchmarks' | 'wiring' | 'roadmap' | 'anti-patterns'
 
 const CAP_VIEWS: Array<{ key: CapView; label: string }> = [
   { key: 'providers', label: 'OAS 프로바이더' },
@@ -35,6 +37,7 @@ const CAP_VIEWS: Array<{ key: CapView; label: string }> = [
   { key: 'cascade', label: '캐스케이드 트레이스' },
   { key: 'benchmarks', label: 'BFCL 벤치마크' },
   { key: 'wiring', label: 'OAS 배선 갭' },
+  { key: 'roadmap', label: '개선 로드맵' },
   { key: 'anti-patterns', label: '안티패턴' },
 ]
 
@@ -115,6 +118,15 @@ export function ProviderCapabilityMatrix() {
             High 영향도 항목은 tool calling 비활성화로 이어져 OAS 라우팅 정확도에 직접 영향.
           </p>
           <${WiringGaps} />
+        <//>
+      ` : activeView.value === 'roadmap' ? html`
+        <${Card}>
+          <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">P0–P7 개선 로드맵</h3>
+          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+            sec06 종합 개선 계획 — 비결정론적 구현 경계를 결정론적으로 전환하는 8개 우선순위.
+            P0(Verification Loop)이 기반 인프라로 다른 모든 개선의 토대.
+          </p>
+          <${Roadmap} />
         <//>
       ` : activeView.value === 'anti-patterns' ? html`
         <${Card}>

--- a/dashboard/src/components/provider-capability-matrix/roadmap.ts
+++ b/dashboard/src/components/provider-capability-matrix/roadmap.ts
@@ -1,0 +1,127 @@
+// Roadmap — P0–P7 improvement priority visualization.
+// Shows dependency graph, per-provider applicability, and timeline.
+
+import { html } from 'htm/preact'
+import {
+  ROADMAP_ITEMS,
+  PROVIDER_IDS,
+  PROVIDER_LABELS,
+  APPLICABILITY_MATRIX,
+  applicabilitySymbol,
+  applicabilityCellClass,
+  phaseColor,
+} from './data'
+
+function PhaseCard({ item }: { item: typeof ROADMAP_ITEMS[number] }) {
+  return html`
+    <div class="border rounded overflow-hidden ${phaseColor(item.id)}">
+      <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--color-border-default)]">
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-bold font-mono">${item.id}</span>
+          <span class="text-xs font-medium">${item.area}</span>
+        </div>
+        <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${item.timeline}</span>
+      </div>
+      <div class="px-3 py-2 bg-[var(--shell-rail-bg)] text-[var(--color-fg-primary)]">
+        <p class="text-[11px] leading-snug mb-1.5">${item.goal}</p>
+        <div class="flex flex-wrap gap-1 mb-1.5">
+          ${item.targetAntiPatterns.map(ap => html`
+            <span key=${ap} class="inline-block rounded px-1 py-px text-[9px] font-mono bg-[var(--bad-10)] text-[var(--bad-light)]">
+              ${ap}
+            </span>
+          `)}
+        </div>
+        <div class="flex items-center gap-2 text-[10px]">
+          <span class="text-[var(--color-fg-muted)]">참조:</span>
+          <span class="text-[var(--color-fg-secondary)]">${item.reference}</span>
+        </div>
+        <div class="mt-1 text-[10px] font-medium text-[var(--color-status-ok)]">
+          ${item.effect}
+        </div>
+        ${item.deps.length > 0 ? html`
+          <div class="mt-1 flex items-center gap-1 text-[9px] text-[var(--color-fg-muted)]">
+            <span>선행:</span>
+            ${item.deps.map(d => html`
+              <span key=${d} class="rounded px-1 py-px bg-[var(--white-4)] font-mono">${d}</span>
+            `)}
+          </div>
+        ` : null}
+      </div>
+    </div>
+  `
+}
+
+function DependencyGraph() {
+  const phases = ROADMAP_ITEMS.map(r => r.id)
+  return html`
+    <div class="flex items-center gap-1 text-[10px] font-mono flex-wrap">
+      ${phases.map((p, i) => html`
+        <span key=${p} class="inline-flex items-center gap-0.5">
+          ${i > 0 ? html`<span class="text-[var(--color-fg-disabled)] px-0.5">→</span>` : null}
+          <span class="rounded px-1.5 py-0.5 ${phaseColor(p)}">${p}</span>
+        </span>
+      `)}
+    </div>
+  `
+}
+
+export function Roadmap() {
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+        <span>sec06 Table 6-1 — P0–P7 순차-병렬 하이브리드 개선 계획</span>
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">의존성 그래프</h4>
+        <${DependencyGraph} />
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+        ${ROADMAP_ITEMS.map(item => html`
+          <${PhaseCard} key=${item.id} item=${item} />
+        `)}
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Per-Provider 적용 매트릭스</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec06 Table 6-2 — ✅ 직접 적용, ⚠️ 제한적, ❌ 불가, — 해당 없음</p>
+        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+          <table class="w-full text-xs border-collapse">
+            <thead>
+              <tr class="bg-[var(--white-4)]">
+                <th class="sticky left-0 z-10 bg-[var(--shell-rail-bg)] border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[60px]">
+                  항목
+                </th>
+                ${PROVIDER_IDS.map(pid => html`
+                  <th key=${pid} class="border-b border-[var(--color-border-default)] px-1.5 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[50px]">
+                    ${PROVIDER_LABELS[pid] ?? pid}
+                  </th>
+                `)}
+              </tr>
+            </thead>
+            <tbody>
+              ${ROADMAP_ITEMS.map((item, i) => html`
+                <tr key=${item.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+                  <td class="sticky left-0 z-10 ${i % 2 === 0 ? 'bg-[var(--shell-rail-bg)]' : 'bg-[var(--white-2)]'} border-r border-b border-[var(--color-border-default)] px-2 py-1 font-mono font-bold text-[11px]">
+                    ${item.id}
+                  </td>
+                  ${PROVIDER_IDS.map(pid => {
+                    const a = APPLICABILITY_MATRIX[item.id][pid] ?? 'na'
+                    return html`
+                      <td key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5 text-center">
+                        <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${applicabilityCellClass(a)}">
+                          ${applicabilitySymbol(a)}
+                        </span>
+                      </td>
+                    `
+                  })}
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  `
+}


### PR DESCRIPTION
## Summary
- Add OAS cascade routing trace visualization with 4 representative scenarios (rate-limit fallback, primary hit, full exhaustion, cooldown bypass)
- Add mini heartbeat health bars to feature matrix provider column headers, derived from live provider status
- New sub-view "캐스케이드 트레이스" in Provider Capability Matrix dashboard

## Test plan
- [x] `npm run build` passes
- [x] `eslint` passes on changed files
- [ ] Visual verification in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)