### PR TITLE
feat(dashboard): provider capability matrix with 8 sub-views

### DIFF
--- a/dashboard/src/components/provider-capability-matrix.test.ts
+++ b/dashboard/src/components/provider-capability-matrix.test.ts
@@ -53,8 +53,10 @@ describe('ProviderCapabilityMatrix', () => {
     const el = container()
     render(html`<${WiringGaps} />`, el)
 
-    expect(el.textContent).toContain('과소선언: 6건')
-    expect(el.textContent).toContain('정확한 선언: 6건')
+    expect(el.textContent).toContain('HIGH')
+    expect(el.textContent).toContain('MEDIUM')
+    expect(el.textContent).toContain('LOW')
+    expect(el.textContent).toContain('정확')
     expect(el.textContent).toContain('W01')
     expect(el.textContent).not.toContain('W07')
   })

--- a/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
+++ b/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
@@ -1,11 +1,132 @@
 // BfclRankings — BFCL Function Calling benchmark rankings.
+// Includes V4 category breakdown, per-model analysis, and Harness case study.
 
 import { html } from 'htm/preact'
-import { BFCL_RANKINGS } from './data'
+import {
+  BFCL_RANKINGS,
+  BFCL_V4_CATEGORIES,
+  BFCL_MODEL_BREAKDOWN,
+  HARNESS_MODELS,
+  categoryLevelClass,
+  categoryLevelLabel,
+} from './data'
+
+function V4CategoryTable() {
+  return html`
+    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+      <table class="w-full text-xs border-collapse">
+        <thead>
+          <tr class="bg-[var(--white-4)]">
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">카테고리</th>
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">설명</th>
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">가중치</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${BFCL_V4_CATEGORIES.map((cat, i) => html`
+            <tr key=${cat.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+              <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 font-medium text-[var(--color-fg-primary)]">${cat.label}</td>
+              <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-[var(--color-fg-secondary)]">${cat.description}</td>
+              <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-mono text-[11px] ${
+                cat.weight === '40%' ? 'text-[var(--color-status-ok)] font-bold'
+                : cat.weight === '30%' ? 'text-[var(--color-status-warn)] font-bold'
+                : 'text-[var(--color-fg-muted)]'
+              }">
+                ${cat.weight}
+              </td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function ModelBreakdownTable() {
+  return html`
+    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+      <table class="w-full text-xs border-collapse">
+        <thead>
+          <tr class="bg-[var(--white-4)]">
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[120px]">모델</th>
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[60px]">Overall</th>
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Simple</th>
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Parallel</th>
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Multi-turn</th>
+            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Agentic</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${BFCL_MODEL_BREAKDOWN.map((m, i) => html`
+            <tr key=${m.model} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+              <td class="border-b border-[var(--color-border-default)] px-3 py-1 font-medium text-[var(--color-fg-primary)]">${m.model}</td>
+              <td class="border-b border-[var(--color-border-default)] px-3 py-1 text-center font-mono font-bold text-[11px]">${m.overall}</td>
+              ${([m.simple, m.parallel, m.multiTurn, m.agentic] as const).map((level, j) => html`
+                <td key=${j} class="border-b border-[var(--color-border-default)] px-2 py-1 text-center">
+                  <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${categoryLevelClass(level)}">
+                    ${categoryLevelLabel(level)}
+                  </span>
+                </td>
+              `)}
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function HarnessCaseStudy() {
+  return html`
+    <div class="border border-[var(--color-border-default)] rounded overflow-hidden">
+      <div class="flex items-center justify-between px-3 py-2 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-semibold text-[var(--color-fg-primary)]">Function Calling Harness</span>
+          <span class="text-[10px] text-[var(--color-fg-muted)]">Sam Chon / Wrtn Technologies</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="text-[11px] font-mono text-[var(--bad-light)]">6.75%</span>
+          <span class="text-[10px] text-[var(--color-fg-muted)]">→</span>
+          <span class="text-[11px] font-mono font-bold text-[var(--color-status-ok)]">100%</span>
+        </div>
+      </div>
+      <div class="px-3 py-2 bg-[var(--shell-rail-bg)]">
+        <p class="text-[11px] text-[var(--color-fg-secondary)] mb-2">
+          확률적 모델을 결정론적 검증 루프로 감싸는 패턴. Typia 컴파일러 기반 타입 스키마 제약 +
+          컴파일러 피드백 + LLM self-healing 루프. P0 Verification Loop의 참조 사례.
+        </p>
+        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+          <table class="w-full text-xs border-collapse">
+            <thead>
+              <tr class="bg-[var(--white-2)]">
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">모델</th>
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">파라미터</th>
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-muted)]">컴파일 성공률</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${HARNESS_MODELS.map((hm, i) => html`
+                <tr key=${hm.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium text-[var(--color-fg-primary)]">${hm.id}</td>
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-secondary)]">${hm.params}</td>
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px] font-bold text-[var(--color-status-ok)]">${hm.compileRate}</td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+        <p class="mt-1.5 text-[10px] text-[var(--color-fg-muted)]">
+          재귀 유니언 타입 10 variant × 3단계 = 1,000 경로. 30 variant면 27,000 경로.
+          LLM 1회 통과율이 구조적으로 낮은 것은 능력 부족이 아닌 조합 폭발의 결과.
+        </p>
+      </div>
+    </div>
+  `
+}
 
 export function BfclRankings() {
   return html`
-    <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-4">
       <div class="flex items-center gap-3 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
         <span>BFCL = 스키마 준수율 측정</span>
         <span class="text-[var(--color-border-default)]">|</span>
@@ -61,9 +182,34 @@ export function BfclRankings() {
         </table>
       </div>
 
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">BFCL V4 카테고리 구성</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">
+          Multi-turn(30%) + Agentic(40%) = 70%가 실제 에이전트 시나리오 평가. AST 기반 코드 수준 평가로 텍스트 매칭 한계 극복.
+        </p>
+        <${V4CategoryTable} />
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">모델별 카테고리 성능 분포</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">
+          상위 3개 모델(GLM-4.5, Claude Opus 4.1, Sonnet 4)은 모든 카테고리에서 '높음'.
+          GPT-5는 Agentic에서만 '높음', Simple/Parallel은 '중간'.
+        </p>
+        <${ModelBreakdownTable} />
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Harness 사례: 6.75% → 100%</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">
+          검증-피드백-수정 루프(Typia)로 소형 모델도 복잡 스키마 100% 달성. P0 Verification Loop의 참조 구현.
+        </p>
+        <${HarnessCaseStudy} />
+      </div>
+
       <div class="text-[10px] text-[var(--color-fg-muted)] px-1">
         출처: BFCL V3/V4 (UC Berkeley), MCPMark pass@1 (Sam Chon), SWE-Bench Pro (K2.6).
-        Harness 패턴: Qwen 3.5 6.75%→100% (Typia 기반 검증-피드백-수정 루프).
+        Harness: Sam Chon, Wrtn Technologies. CoT Compliance 9.91%→100% 후속 연구.
       </div>
     </div>
   `

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -553,6 +553,48 @@ export function phaseColor(id: RoadmapPhase): string {
   return 'bg-[var(--white-4)] text-[var(--color-fg-secondary)] border-[var(--color-border-default)]'
 }
 
+// ── Phase Timeline (sec07 Table 7-1) ──────────────────────────
+
+export interface PhaseMilestone {
+  week: string
+  phase: string
+  work: string
+  deliverable: string
+  deps: string
+}
+
+export const PHASE_TIMELINE: PhaseMilestone[] = [
+  { week: '0–1', phase: 'Phase 1', work: 'P0-1: Function Calling Harness 핵심 루프', deliverable: 'ToolValidationLoop 모듈, 최대 3회 retry', deps: '—' },
+  { week: '1–2', phase: 'Phase 1', work: 'P0-2: PPX 기반 컴파일 시점 타입-스키마 검증', deliverable: 'SchemaViolationError 타입', deps: 'P0-1' },
+  { week: '2–3', phase: 'Phase 1', work: 'P0-3: Per-provider 통합 테스트 스위트 (13 provider × 5 scenario)', deliverable: 'Integration test suite', deps: 'P0-1' },
+  { week: '3–4', phase: 'Phase 1', work: 'P5-1: S01–S05, F01–F02 안티패턴 제거', deliverable: 'CapabilityDrop, FallbackTriggered 이벤트', deps: 'P0-1' },
+  { week: '4–5', phase: 'Phase 2', work: 'P1-1: cache_control 자동화', deliverable: 'system/tool cache 삽입 최적화', deps: 'Phase 1' },
+  { week: '5–6', phase: 'Phase 2', work: 'P1-2: Context Reducer ceiling (target = max_tokens × 0.5)', deliverable: '동적 compaction budget, 최근 4turn 보존', deps: 'P1-1' },
+  { week: '6–7', phase: 'Phase 2', work: 'P3-1: thinking_control_format 4-variant capability', deliverable: '25필드 capability 레코드, 문자열 매칭 제거', deps: 'Phase 1' },
+  { week: '7–8', phase: 'Phase 2', work: 'P3-2: Provider별 thinking 직렬화 표준화', deliverable: 'thinking_config 공통 타입, wire format 매핑', deps: 'P3-1' },
+  { week: '8–9', phase: 'Phase 3', work: 'P2-1: CLI Provider MCP 활성화', deliverable: 'validate strict mode, cross-tool context', deps: 'Phase 1' },
+  { week: '9–10', phase: 'Phase 3', work: 'P2-2: Ollama runtime tool discovery (/api/show)', deliverable: '동적 ollama_capabilities 오버라이드', deps: 'P2-1' },
+  { week: '10–11', phase: 'Phase 3', work: 'P6-1: Nemotron API, Gemma 4 추가', deliverable: '2개 신규 capability 집합', deps: 'Phase 1' },
+  { week: '11–12', phase: 'Phase 3', work: 'P6-2: Ollama Cloud + ToolResult schema validation', deliverable: 'Ollama Cloud 지원, ToolResultValidationError', deps: 'P6-1, P2-2' },
+  { week: '12–13', phase: 'Phase 4', work: 'P4-1: supports_seed, supports_seed_with_images', deliverable: '27필드 capability 레코드', deps: 'Phase 1–2' },
+  { week: '13–14', phase: 'Phase 4', work: 'P4-2: temperature=0 한계 문서화, 이미지 seed 무효화', deliverable: '결정론 제한 경고 (warn_once)', deps: 'P4-1' },
+  { week: '14–15', phase: 'Phase 4', work: 'P7-1: Usage tokens 복원 + Capability drift 감지', deliverable: 'Usage 추출, CapabilityDriftAlert', deps: 'Phase 1–3' },
+  { week: '15–16', phase: 'Phase 4', work: 'P7-2: Per-provider metrics, Grafana 대시보드', deliverable: '5개 메트릭 OTLP, 대시보드', deps: 'P7-1' },
+]
+
+export const PHASE_COLORS: Record<string, string> = {
+  'Phase 1': 'bg-[var(--ok-10)] text-[var(--color-status-ok)]',
+  'Phase 2': 'bg-[var(--warn-10)] text-[var(--color-status-warn)]',
+  'Phase 3': 'bg-[var(--info-10)] text-[var(--color-status-info)]',
+  'Phase 4': 'bg-[var(--white-4)] text-[var(--color-fg-secondary)]',
+}
+
+export const RESOURCE_ALLOCATION = [
+  { track: 'OAS 코어 수정', scope: 'Backend 직렬화/파싱, Capabilities, Config', headcount: 2, pct: ['100%', '80%', '50%', '30%'] },
+  { track: 'MASC 확장', scope: 'Provider_tool_support, Cascade, Metrics', headcount: 1, pct: ['50%', '80%', '100%', '80%'] },
+  { track: '인프라', scope: 'Integration test, CI/CD, Grafana, Prometheus', headcount: 1, pct: ['80%', '100%', '100%', '100%'] },
+]
+
 // ── Shared helpers ──────────────────────────────────────────────
 
 export function supportCellClass(v: FeatureSupport): string {

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -187,6 +187,26 @@ export const PROVIDER_KIND: Record<string, 'direct' | 'cli'> = {
   gemini_cli: 'cli', codex_cli: 'cli',
 }
 
+// Provider category (Cloud API / CLI / Local). Source: sec01 §1.2.
+export type ProviderCategory = 'cloud' | 'cli' | 'local'
+
+export const PROVIDER_CATEGORY: Record<string, ProviderCategory> = {
+  openai: 'cloud', claude: 'cloud', gemini: 'cloud', deepseek: 'cloud',
+  qwen35: 'cloud', mistral: 'cloud', nemotron: 'cloud', kimi: 'cloud',
+  ollama: 'local', llamacpp: 'local', glm: 'cloud',
+  gemini_cli: 'cli', codex_cli: 'cli',
+}
+
+// Feature grouping by functional category. Source: sec01 §1.3 Table.
+export const FEATURE_CATEGORIES: Array<{ id: string; label: string; featureIds: string[] }> = [
+  { id: 'tool-use', label: 'Tool Use / Function Calling', featureIds: ['tool-calling', 'parallel-tools', 'tool-choice', 'streaming-tools'] },
+  { id: 'thinking', label: 'Thinking / Reasoning', featureIds: ['thinking', 'interleaved-thinking'] },
+  { id: 'structured-output', label: 'Structured Output', featureIds: ['structured-output', 'constrained-decoding'] },
+  { id: 'sampling', label: 'Sampling & Reproducibility', featureIds: ['seed'] },
+  { id: 'context', label: 'Context & Caching', featureIds: ['prompt-caching', 'max-context'] },
+  { id: 'extended', label: 'Multimodal / Extended', featureIds: ['multimodal', 'mcp', 'code-execution', 'computer-use'] },
+]
+
 export function computeMatrixSummary() {
   let native = 0, partial = 0, unsupported = 0, total = 0
   for (const feat of FEATURES) {

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -246,6 +246,79 @@ export const BFCL_RANKINGS: BfclEntry[] = [
   { rank: 10, model: 'Kimi K2.6',               bfclV3: '—',      bfclV4: '경쟁력',  feature: 'SWE-Bench Pro 58.6%, 256K 컨텍스트',    license: 'Modified MIT' },
 ]
 
+// ── BFCL V4 Category Breakdown ──────────────────────────────────
+
+export interface BfclV4Category {
+  id: string
+  label: string
+  description: string
+  weight: string
+}
+
+export const BFCL_V4_CATEGORIES: BfclV4Category[] = [
+  { id: 'simple',      label: 'Simple Function Calling',   description: '단일 함수 호출',                   weight: '기본' },
+  { id: 'parallel',    label: 'Parallel Function Calling', description: '다중 동시 함수 호출',               weight: '기본' },
+  { id: 'multi-select', label: 'Multiple Function Selection', description: '여러 옵션 중 정확한 도구 선택',   weight: '기본' },
+  { id: 'relevance',   label: 'Relevance Detection',       description: '함수를 호출하지 말아야 할 때 판별', weight: '10% (Irrelevance)' },
+  { id: 'multi-turn',  label: 'Multi-turn Interactions',   description: '맥락 유지 지속 대화',               weight: '30%' },
+  { id: 'agentic',     label: 'Agentic (Holistic)',        description: '전체 에이전트 평가',                 weight: '40%' },
+]
+
+type CategoryLevel = 'high' | 'mid' | 'low'
+
+export interface BfclModelCategoryBreakdown {
+  model: string
+  overall: string
+  simple: CategoryLevel
+  parallel: CategoryLevel
+  multiTurn: CategoryLevel
+  agentic: CategoryLevel
+}
+
+export const BFCL_MODEL_BREAKDOWN: BfclModelCategoryBreakdown[] = [
+  { model: 'GLM-4.5',         overall: '70.85%', simple: 'high', parallel: 'high', multiTurn: 'high', agentic: 'high' },
+  { model: 'Claude Opus 4.1', overall: '70.36%', simple: 'high', parallel: 'high', multiTurn: 'high', agentic: 'high' },
+  { model: 'Claude Sonnet 4', overall: '70.29%', simple: 'high', parallel: 'high', multiTurn: 'high', agentic: 'high' },
+  { model: 'Claude Haiku 4.5',overall: '80.6%',  simple: 'high', parallel: 'high', multiTurn: 'mid',  agentic: 'mid'  },
+  { model: 'GPT-5',           overall: '59.22%', simple: 'mid',  parallel: 'mid',  multiTurn: 'mid',  agentic: 'high' },
+  { model: 'GPT-4.1-mini',    overall: '78.8%',  simple: 'mid',  parallel: 'mid',  multiTurn: 'mid',  agentic: 'mid'  },
+  { model: 'Qwen 3-Coder',    overall: '경쟁력', simple: 'mid',  parallel: 'mid',  multiTurn: 'mid',  agentic: 'mid'  },
+  { model: 'DeepSeek V3.1',   overall: '개선됨', simple: 'mid',  parallel: 'mid',  multiTurn: 'mid',  agentic: 'mid'  },
+  { model: 'Gemma 4 27B',     overall: '76.9%',  simple: 'mid',  parallel: 'mid',  multiTurn: 'mid',  agentic: 'mid'  },
+]
+
+export function categoryLevelClass(level: CategoryLevel): string {
+  switch (level) {
+    case 'high': return 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+    case 'mid':  return 'bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'low':  return 'bg-[var(--bad-10)] text-[var(--bad-light)]'
+  }
+}
+
+export function categoryLevelLabel(level: CategoryLevel): string {
+  switch (level) {
+    case 'high': return '높음'
+    case 'mid':  return '중간'
+    case 'low':  return '낮음'
+  }
+}
+
+// ── Function Calling Harness Case Study ──────────────────────────
+
+export interface HarnessModel {
+  id: string
+  params: string
+  compileRate: string
+}
+
+export const HARNESS_MODELS: HarnessModel[] = [
+  { id: 'qwen3.5-397b-a17b', params: '17B/397B MoE',  compileRate: '100%' },
+  { id: 'qwen3.5-122b-a10b', params: '10B/122B MoE',  compileRate: '100%' },
+  { id: 'qwen3.5-27b',       params: '27B Dense',     compileRate: '100%' },
+  { id: 'qwen3.5-35b-a3b',   params: '3B/35B MoE',    compileRate: '100%' },
+  { id: 'qwen3-coder-next',  params: '3B/80B Coding', compileRate: '100%' },
+]
+
 // ── OAS Provider Capabilities (sec02 Table 1) ──────────────────
 
 export type UsageBehavior = 'emit' | 'strip'

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -823,7 +823,7 @@ export const PHASE_TIMELINE: PhaseMilestone[] = [
 export const PHASE_COLORS: Record<string, string> = {
   'Phase 1': 'bg-[var(--ok-10)] text-[var(--color-status-ok)]',
   'Phase 2': 'bg-[var(--warn-10)] text-[var(--color-status-warn)]',
-  'Phase 3': 'bg-[var(--info-10)] text-[var(--color-status-info)]',
+  'Phase 3': 'bg-[var(--info-soft)] text-[var(--color-status-info)]',
   'Phase 4': 'bg-[var(--white-4)] text-[var(--color-fg-secondary)]',
 }
 

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -363,6 +363,151 @@ export const ANTI_PATTERNS: AntiPattern[] = [
   { id: 'H12', category: 'hardcoding', description: 'BFCL score threshold가 상수 아닌 리터럴', location: 'model_selector.ml', risk: 'L' },
 ]
 
+// ── Provider Model Catalog ──────────────────────────────────────
+// Per-provider model listings with context/pricing. Source: supplement research + official docs.
+
+export interface ProviderModel {
+  id: string
+  context: string
+  tier: 'flagship' | 'standard' | 'fast' | 'coding' | 'legacy'
+  inputPrice?: string
+  outputPrice?: string
+  notes?: string
+}
+
+export interface ProviderModelGroup {
+  providerId: string
+  models: ProviderModel[]
+}
+
+export const PROVIDER_MODELS: ProviderModelGroup[] = [
+  {
+    providerId: 'openai',
+    models: [
+      { id: 'gpt-4.1', context: '1M', tier: 'flagship', inputPrice: '$2.00', outputPrice: '$8.00', notes: 'Multimodal' },
+      { id: 'gpt-4.1-mini', context: '1M', tier: 'standard', inputPrice: '$0.40', outputPrice: '$1.60' },
+      { id: 'gpt-4.1-nano', context: '1M', tier: 'fast', inputPrice: '$0.10', outputPrice: '$0.40' },
+      { id: 'o4-mini', context: '200K', tier: 'standard', inputPrice: '$1.10', outputPrice: '$4.40', notes: 'Reasoning' },
+    ],
+  },
+  {
+    providerId: 'claude',
+    models: [
+      { id: 'claude-opus-4-7', context: '200K', tier: 'flagship', inputPrice: '$15.00', outputPrice: '$75.00', notes: 'Thinking' },
+      { id: 'claude-sonnet-4-6', context: '200K', tier: 'standard', inputPrice: '$3.00', outputPrice: '$15.00', notes: 'Thinking' },
+      { id: 'claude-haiku-4-5', context: '200K', tier: 'fast', inputPrice: '$0.80', outputPrice: '$4.00' },
+    ],
+  },
+  {
+    providerId: 'gemini',
+    models: [
+      { id: 'gemini-2.5-pro', context: '1M', tier: 'flagship', inputPrice: '$1.25', outputPrice: '$10.00', notes: 'Thinking' },
+      { id: 'gemini-2.5-flash', context: '1M', tier: 'standard', inputPrice: '$0.15', outputPrice: '$0.60', notes: 'Thinking' },
+      { id: 'gemini-2.0-flash', context: '1M', tier: 'fast', inputPrice: '$0.10', outputPrice: '$0.40' },
+    ],
+  },
+  {
+    providerId: 'deepseek',
+    models: [
+      { id: 'deepseek-r1', context: '128K', tier: 'flagship', inputPrice: '$0.55', outputPrice: '$2.19', notes: 'Reasoning' },
+      { id: 'deepseek-v3-0324', context: '128K', tier: 'standard', inputPrice: '$0.27', outputPrice: '$1.10' },
+      { id: 'deepseek-chat', context: '128K', tier: 'fast', inputPrice: '$0.14', outputPrice: '$0.28' },
+    ],
+  },
+  {
+    providerId: 'qwen35',
+    models: [
+      { id: 'qwen3-235b-a22b', context: '128K', tier: 'flagship', inputPrice: '$0.40', outputPrice: '$1.20', notes: 'MoE, Thinking' },
+      { id: 'qwen3-32b', context: '128K', tier: 'standard', inputPrice: '$0.12', outputPrice: '$0.36' },
+      { id: 'qwen3-8b', context: '128K', tier: 'fast', inputPrice: '$0.02', outputPrice: '$0.06' },
+    ],
+  },
+  {
+    providerId: 'mistral',
+    models: [
+      { id: 'mistral-large-2411', context: '128K', tier: 'flagship', inputPrice: '$2.00', outputPrice: '$6.00' },
+      { id: 'mistral-medium-2505', context: '128K', tier: 'standard', inputPrice: '$0.40', outputPrice: '$2.00' },
+      { id: 'codestral-latest', context: '256K', tier: 'coding', inputPrice: '$0.30', outputPrice: '$0.90', notes: 'Code' },
+    ],
+  },
+  {
+    providerId: 'glm',
+    models: [
+      { id: 'glm-5', context: '200K', tier: 'flagship', inputPrice: '$1.00', outputPrice: '$0.20', notes: 'General' },
+      { id: 'glm-5-code', context: '128K', tier: 'coding', inputPrice: '$1.20', outputPrice: '$0.30', notes: 'Coding Plan 전용' },
+      { id: 'glm-4.7', context: '128K', tier: 'standard', inputPrice: '$0.60', outputPrice: '—', notes: 'Coding Plan 기본' },
+      { id: 'glm-4.5-air', context: '128K', tier: 'fast', inputPrice: '—', outputPrice: '—', notes: 'Coding Plan 경량' },
+    ],
+  },
+  {
+    providerId: 'kimi',
+    models: [
+      { id: 'kimi-k2.6', context: '256K', tier: 'flagship', inputPrice: '—', outputPrice: '—', notes: 'Multimodal, Thinking' },
+      { id: 'kimi-k2.5', context: '256K', tier: 'standard', inputPrice: '—', outputPrice: '—', notes: 'SoTA Agent/Code' },
+      { id: 'kimi-k2-thinking', context: '256K', tier: 'standard', inputPrice: '—', outputPrice: '—', notes: '장기 사고' },
+      { id: 'kimi-k2-turbo-preview', context: '256K', tier: 'fast', inputPrice: '—', outputPrice: '—', notes: '60-100 tok/s' },
+      { id: 'moonshot-v1-128k', context: '128K', tier: 'legacy', inputPrice: '—', outputPrice: '—' },
+    ],
+  },
+  {
+    providerId: 'ollama',
+    models: [
+      { id: '(local models)', context: 'varies', tier: 'standard', notes: 'Self-hosted' },
+    ],
+  },
+  {
+    providerId: 'llamacpp',
+    models: [
+      { id: '(local models)', context: 'varies', tier: 'standard', notes: 'Self-hosted' },
+    ],
+  },
+]
+
+export function modelTierStyle(tier: ProviderModel['tier']): string {
+  switch (tier) {
+    case 'flagship': return 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+    case 'standard': return 'bg-[var(--white-4)] text-[var(--color-fg-secondary)]'
+    case 'fast':     return 'bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'coding':   return 'bg-[var(--bad-10)] text-[var(--bad-light)]'
+    case 'legacy':   return 'bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+  }
+}
+
+// ── CLI Transport Comparison ──────────────────────────────────
+// CLI transport implementation details. Source: cli_noninteractive_deep_dive.md.
+
+export interface CliTransportInfo {
+  providerId: string
+  binary: string
+  loc: number
+  promptMode: string
+  streamFormat: string
+  argvThreshold: string
+  notes: string
+}
+
+export const CLI_TRANSPORTS: CliTransportInfo[] = [
+  { providerId: 'claude', binary: 'claude', loc: 1282, promptMode: '-p', streamFormat: 'stream-json', argvThreshold: '512KB', notes: 'thinking+tool_use 보존 위해 내부 stream 사용' },
+  { providerId: 'gemini_cli', binary: 'gemini', loc: 949, promptMode: '--prompt', streamFormat: 'JSON chunks', argvThreshold: '—', notes: 'SSE-style chunked 응답' },
+  { providerId: 'codex_cli', binary: 'codex', loc: 1340, promptMode: 'stdin', streamFormat: 'NDJSON', argvThreshold: '—', notes: '5-model 내부 rotation' },
+  { providerId: 'kimi', binary: 'kimi-for-coding', loc: 693, promptMode: '-p', streamFormat: 'NDJSON', argvThreshold: '—', notes: '단일 모델 기본 (kimi-for-coding)' },
+]
+
+// ── GLM Coding Plan Mapping ───────────────────────────────────
+// Claude Code internal env vars → GLM model mapping. Source: supplement research.
+
+export const GLM_CODING_PLAN_MAP: Array<{ envVar: string; glmModel: string; note: string }> = [
+  { envVar: 'ANTHROPIC_DEFAULT_OPUS_MODEL', glmModel: 'GLM-4.7', note: '최고 성능 코딩' },
+  { envVar: 'ANTHROPIC_DEFAULT_SONNET_MODEL', glmModel: 'GLM-4.7', note: '표준 코딩' },
+  { envVar: 'ANTHROPIC_DEFAULT_HAIKU_MODEL', glmModel: 'GLM-4.5-Air', note: '빠른/경량 코딩' },
+]
+
+export const GLM_WIRING_GAPS: Array<{ area: string; oasCurrent: string; official: string; gap: string }> = [
+  { area: 'Coding 전용 모델', oasCurrent: 'glm-5.1, glm-5, glm-5-turbo (auto 목록)', official: 'GLM-5-Code (별도 모델군)', gap: 'Coding 전용 모델 미식별' },
+  { area: '모델 에일리어스', oasCurrent: 'auto, flash, turbo, vision, air, ocr', official: 'GLM-4.7, GLM-4.5-Air, GLM-5-Code', gap: 'Coding-specific alias 부재' },
+  { area: 'Context ceiling', oasCurrent: '200K (General과 동일)', official: '128K (GLM-5-Code)', gap: 'Context 과다 선언' },
+]
+
 // ── Cascade Traces ────────────────────────────────────────────
 // OAS cascade routing trace scenarios. Source: sec03 cascade flow analysis.
 

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -595,6 +595,56 @@ export const RESOURCE_ALLOCATION = [
   { track: '인프라', scope: 'Integration test, CI/CD, Grafana, Prometheus', headcount: 1, pct: ['80%', '100%', '100%', '100%'] },
 ]
 
+// ── Success Metrics (sec07 §7.3) ──────────────────────────────
+// Three cross-cutting success indicators for the 16-week roadmap.
+
+export interface SuccessMetric {
+  id: string
+  title: string
+  target: string
+  description: string
+  phases: Record<string, string>
+}
+
+export const SUCCESS_METRICS: SuccessMetric[] = [
+  {
+    id: 'bfcl-accuracy',
+    title: 'BFCL 90%+ Tool Use Accuracy',
+    target: '90%',
+    description: '주요 6개 제공자(OpenAI, Claude, Gemini, DeepSeek, Qwen, Mistral)의 OAS 파이프라인 정확도. 모델 자체 성능이 아닌 직렬화→전송→파싱→검증 파이프라인의 정확도를 측정.',
+    phases: {
+      'Phase 1': '13 providers × 5 scenario = 65 test cases 100% pass',
+      'Phase 2': 'thinking 복합 스키마 검증 성공률 95%+',
+      'Phase 3': 'CLI Provider MCP E2E 성공률 100%, 신규 3 provider 통합 테스트 100%',
+      'Phase 4': 'BFCL V4 Simple/Parallel/Relevance 6 provider 전체 90%+',
+    },
+  },
+  {
+    id: 'zero-silent-failure',
+    title: 'Zero Silent Failure',
+    target: '0건',
+    description: '모든 비정상 동작이 WARN+ 로그 레벨로 기록, Prometheus 메트릭이나 structured event로 포착. masc_capability_drop_total, masc_fallback_triggered_total counter 기준.',
+    phases: {
+      'Phase 1': 'S01–S05 (5건) Silent Failure 완전 제거 → counter 증가 0',
+      'Phase 2': 'S06–S08 제거, F01–F04 Fake Fallback 제거',
+      'Phase 3': 'S09–S10 제거, M01–M06 String Match 중 3건 제거',
+      'Phase 4': '잔여 안티패턴 제거 완료 (28/32 = 87.5%), Grafana "Zero Silent Failure" panel OK',
+    },
+  },
+  {
+    id: 'capability-accuracy',
+    title: 'Capability Accuracy 100%',
+    target: '100%',
+    description: 'Llm_provider.Capabilities 레코드 각 필드가 실제 API 동작과 일치. capability_mismatch rejection 비율 < 1%.',
+    phases: {
+      'Phase 1': 'supports_tools, supports_tool_choice 통합 테스트 100% pass',
+      'Phase 2': 'thinking_control_format 4-variant 정합성 검증',
+      'Phase 3': 'supports_seed, supports_seed_with_images 선언 정합성',
+      'Phase 4': 'emits_usage_tokens 정합성 + drift 감지 24h 이내',
+    },
+  },
+]
+
 // ── Shared helpers ──────────────────────────────────────────────
 
 export function supportCellClass(v: FeatureSupport): string {

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -2,7 +2,7 @@
 // Features grouped by sec01 §1.3 categories (Tool Use, Thinking, etc.).
 
 import { html } from 'htm/preact'
-import { useMemo } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
 import {
   FEATURES,
   PROVIDER_IDS,
@@ -18,7 +18,11 @@ import { StatTile } from '../common/stat-tile'
 import { HeartbeatStrip } from '../common/heartbeat-strip'
 import { statusLabel } from '../../lib/status-label'
 import type { DashboardRuntimeProviderSnapshot } from '../../api/dashboard'
-import type { HeartbeatState } from '../../lib/heartbeat-history'
+import {
+  recordHeartbeat,
+  useHeartbeatHistory,
+  type HeartbeatState,
+} from '../../lib/heartbeat-history'
 
 type LiveStatus = 'ok' | 'bad' | 'warn' | 'neutral'
 
@@ -63,12 +67,15 @@ export function liveStatusDot(
 
 const HB_SLOTS = 12
 
-function statusToSlots(status: LiveStatus | null): HeartbeatState[] {
-  if (status === null || status === 'neutral') return Array<HeartbeatState>(HB_SLOTS).fill('unknown')
+function providerHeartbeatId(providerId: string): string {
+  return `provider-capability:${providerId}`
+}
+
+function statusToHeartbeatSample(status: LiveStatus | null): HeartbeatState {
+  if (status === null || status === 'neutral' || status === 'warn') return 'unknown'
   switch (status) {
-    case 'ok':   return Array<HeartbeatState>(HB_SLOTS).fill('up')
-    case 'bad':  return Array<HeartbeatState>(HB_SLOTS).fill('down')
-    case 'warn': return Array<HeartbeatState>(HB_SLOTS).fill('down')
+    case 'ok':  return 'up'
+    case 'bad': return 'down'
   }
 }
 
@@ -92,11 +99,35 @@ function providerCategoryLabel(cat: string): string {
 
 const featById = new Map(FEATURES.map(f => [f.id, f]))
 
+function ProviderHeartbeatCell({
+  providerId,
+  status,
+}: {
+  providerId: string
+  status: LiveStatus | null
+}) {
+  const history = useHeartbeatHistory(providerHeartbeatId(providerId))
+  const label = status
+    ? `${PROVIDER_LABELS[providerId] ?? providerId}: ${statusLabel(status)}`
+    : `${PROVIDER_LABELS[providerId] ?? providerId}: 데이터 없음`
+  return html`<${HeartbeatStrip} history=${history} slots=${HB_SLOTS} ariaLabel=${label} />`
+}
+
 export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRuntimeProviderSnapshot[] }) {
   const summary = useMemo(() => computeMatrixSummary(), [])
   const cloudCount = Object.values(PROVIDER_CATEGORY).filter(c => c === 'cloud').length
   const localCount = Object.values(PROVIDER_CATEGORY).filter(c => c === 'local').length
   const cliCount = Object.values(PROVIDER_CATEGORY).filter(c => c === 'cli').length
+
+  useEffect(() => {
+    const sampled = new Set<string>()
+    for (const p of liveProviders) {
+      const matrixId = runtimeProviderToMatrixId(p.provider, p.runtime_kind ?? p.kind)
+      if (!matrixId || sampled.has(matrixId)) continue
+      sampled.add(matrixId)
+      recordHeartbeat(providerHeartbeatId(matrixId), statusToHeartbeatSample(liveProviderStatus(p)))
+    }
+  }, [liveProviders])
 
   return html`
     <div class="flex flex-col gap-2">
@@ -134,11 +165,9 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
               <th class="sticky left-0 z-10 bg-[var(--shell-rail-bg)] border-b border-r border-[var(--color-border-default)]"></th>
               ${PROVIDER_IDS.map(pid => {
                 const dot = liveStatusDot(pid, liveProviders)
-                const hb = statusToSlots(dot)
-                const label = dot ? `${PROVIDER_LABELS[pid] ?? pid}: ${statusLabel(dot)}` : `${PROVIDER_LABELS[pid] ?? pid}: 데이터 없음`
                 return html`
                   <th key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5">
-                    <${HeartbeatStrip} history=${hb} slots=${HB_SLOTS} ariaLabel=${label} />
+                    <${ProviderHeartbeatCell} providerId=${pid} status=${dot} />
                   </th>
                 `
               })}

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -1,4 +1,5 @@
 // FeatureMatrix — 15 features × 13 providers with live provider overlay.
+// Features grouped by sec01 §1.3 categories (Tool Use, Thinking, etc.).
 
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
@@ -6,7 +7,8 @@ import {
   FEATURES,
   PROVIDER_IDS,
   PROVIDER_LABELS,
-  PROVIDER_KIND,
+  PROVIDER_CATEGORY,
+  FEATURE_CATEGORIES,
   supportCellClass,
   computeMatrixSummary,
   runtimeProviderToMatrixId,
@@ -61,9 +63,6 @@ export function liveStatusDot(
 
 const HB_SLOTS = 12
 
-/** Derive a flat, uniform slot array from the current live status.
- *  No fake historical patterns — all slots share the same state so the
- *  bar is a present-tense status indicator rather than a history chart. */
 function statusToSlots(status: LiveStatus | null): HeartbeatState[] {
   if (status === null || status === 'neutral') return Array<HeartbeatState>(HB_SLOTS).fill('unknown')
   switch (status) {
@@ -73,18 +72,41 @@ function statusToSlots(status: LiveStatus | null): HeartbeatState[] {
   }
 }
 
+function providerCategoryBadge(cat: string): string {
+  switch (cat) {
+    case 'cloud': return 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+    case 'cli':   return 'bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'local': return 'bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+    default:      return ''
+  }
+}
+
+function providerCategoryLabel(cat: string): string {
+  switch (cat) {
+    case 'cloud': return 'Cloud'
+    case 'cli':   return 'CLI'
+    case 'local': return 'Local'
+    default:      return ''
+  }
+}
+
+const featById = new Map(FEATURES.map(f => [f.id, f]))
+
 export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRuntimeProviderSnapshot[] }) {
   const summary = useMemo(() => computeMatrixSummary(), [])
-  const liveOk = liveProviders.filter(p => liveProviderStatus(p) === 'ok').length
+  const cloudCount = Object.values(PROVIDER_CATEGORY).filter(c => c === 'cloud').length
+  const localCount = Object.values(PROVIDER_CATEGORY).filter(c => c === 'local').length
+  const cliCount = Object.values(PROVIDER_CATEGORY).filter(c => c === 'cli').length
 
   return html`
     <div class="flex flex-col gap-2">
-      <div class="grid grid-cols-5 gap-2">
+      <div class="grid grid-cols-6 gap-2">
         <${StatTile} label="네이티브" value=${summary.native} variant="gold" hint=${`${((summary.native / summary.total) * 100).toFixed(0)}%`} />
         <${StatTile} label="부분 지원" value=${summary.partial} hint="◐" />
         <${StatTile} label="미지원" value=${summary.unsupported} variant="warn" hint="○" />
-        <${StatTile} label="런타임 활성" value=${liveOk} variant="accent" hint=${`${liveProviders.length} 중`} />
-        <${StatTile} label="CLI Wrapper" value=${Object.values(PROVIDER_KIND).filter(k => k === 'cli').length} hint="usage: strip" />
+        <${StatTile} label="Cloud API" value=${cloudCount} hint="direct" />
+        <${StatTile} label="Local" value=${localCount} hint="self-host" />
+        <${StatTile} label="CLI Wrapper" value=${cliCount} hint="usage: strip" />
       </div>
 
       <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
@@ -96,13 +118,13 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
               </th>
               ${PROVIDER_IDS.map(pid => {
                 const dot = liveStatusDot(pid, liveProviders)
-                const kind = PROVIDER_KIND[pid]
+                const cat = PROVIDER_CATEGORY[pid] ?? 'cloud'
                 return html`
                   <th key=${pid} class="border-b border-[var(--color-border-default)] px-1.5 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[60px]">
                     <div class="flex flex-col items-center gap-0.5">
                       ${dot ? html`<${StatusDot} size="xs" class=${liveStatusDotClass(dot)} />` : null}
                       <span>${PROVIDER_LABELS[pid] ?? pid}</span>
-                      ${kind === 'cli' ? html`<span class="text-[8px] font-mono text-[var(--color-fg-disabled)] uppercase">cli</span>` : null}
+                      <span class="inline-block rounded px-1 py-px text-[7px] font-mono font-bold ${providerCategoryBadge(cat)}">${providerCategoryLabel(cat)}</span>
                     </div>
                   </th>
                 `
@@ -123,23 +145,36 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
             </tr>
           </thead>
         <tbody>
-          ${FEATURES.map((feat, i) => html`
-            <tr key=${feat.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-              <td class="sticky left-0 z-10 ${i % 2 === 0 ? 'bg-[var(--shell-rail-bg)]' : 'bg-[var(--white-2)]'} border-r border-[var(--color-border-default)] px-2 py-1 font-medium text-[var(--color-fg-primary)]">
-                ${feat.label}
-              </td>
-              ${PROVIDER_IDS.map(pid => {
-                const v = feat.providers[pid] ?? '—'
+          ${FEATURE_CATEGORIES.map(cat => {
+            const catFeatures = cat.featureIds.map(id => featById.get(id)).filter(Boolean)
+            return html`
+              <tr key=${`cat-${cat.id}`} class="bg-[var(--white-4)]">
+                <td class="sticky left-0 z-10 bg-[var(--white-4)] border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] font-semibold text-[var(--color-fg-muted)] uppercase tracking-wider" colSpan=${PROVIDER_IDS.length + 1}>
+                  ${cat.label}
+                </td>
+              </tr>
+              ${catFeatures.map((feat, j) => {
+                if (!feat) return null
                 return html`
-                  <td key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5 text-center">
-                    <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${supportCellClass(v)}">
-                      ${v}
-                    </span>
-                  </td>
+                  <tr key=${feat.id} class="${j % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+                    <td class="sticky left-0 z-10 ${j % 2 === 0 ? 'bg-[var(--shell-rail-bg)]' : 'bg-[var(--white-2)]'} border-r border-b border-[var(--color-border-default)] px-2 py-1 pl-4 font-medium text-[var(--color-fg-primary)]">
+                      ${feat.label}
+                    </td>
+                    ${PROVIDER_IDS.map(pid => {
+                      const v = feat.providers[pid] ?? '—'
+                      return html`
+                        <td key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5 text-center">
+                          <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${supportCellClass(v)}">
+                            ${v}
+                          </span>
+                        </td>
+                      `
+                    })}
+                  </tr>
                 `
               })}
-            </tr>
-          `)}
+            `
+          })}
         </tbody>
       </table>
       </div>
@@ -149,12 +184,17 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
 
 export function MatrixLegend() {
   return html`
-    <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+    <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1 flex-wrap">
       <span class="flex items-center gap-1"><span class="inline-block w-4 h-3 rounded bg-[var(--ok-10)] text-center text-[var(--color-status-ok)]">●</span> 네이티브</span>
       <span class="flex items-center gap-1"><span class="inline-block w-4 h-3 rounded bg-[var(--warn-10)] text-center text-[var(--color-status-warn)]">◐</span> 부분 지원</span>
       <span class="flex items-center gap-1"><span class="inline-block w-4 h-3 rounded bg-[var(--bad-10)] text-center text-[var(--bad-light)]">○</span> 미지원</span>
+      <span class="text-[var(--color-border-default)]">|</span>
       <span class="flex items-center gap-1"><${StatusDot} size="xs" class="bg-[var(--color-status-ok)]" /> 런타임 활성</span>
       <span class="flex items-center gap-1"><${StatusDot} size="xs" class="bg-[var(--color-status-err)]" /> 런타임 오류</span>
+      <span class="text-[var(--color-border-default)]">|</span>
+      <span class="flex items-center gap-1"><span class="inline-block rounded px-1 py-px text-[7px] font-bold ${providerCategoryBadge('cloud')}">Cloud</span> API 직접</span>
+      <span class="flex items-center gap-1"><span class="inline-block rounded px-1 py-px text-[7px] font-bold ${providerCategoryBadge('cli')}">CLI</span> Subprocess</span>
+      <span class="flex items-center gap-1"><span class="inline-block rounded px-1 py-px text-[7px] font-bold ${providerCategoryBadge('local')}">Local</span> Self-hosted</span>
     </div>
   `
 }

--- a/dashboard/src/components/provider-capability-matrix/index.ts
+++ b/dashboard/src/components/provider-capability-matrix/index.ts
@@ -10,6 +10,7 @@
 //   benchmarks   — BFCL V3/V4 rankings
 //   wiring       — OAS wiring mismatches vs official API
 //   roadmap     — P0–P7 improvement priorities (sec06 Table 6-1/6-2)
+//   models      — Per-provider model catalog with pricing/context
 //   anti-patterns — 32 anti-patterns (S/F/M/H categories)
 
 import { html } from 'htm/preact'
@@ -28,12 +29,14 @@ import { WiringGaps } from './wiring-gaps'
 import { AntiPatternList } from './anti-patterns'
 import { OasProviderTable } from './oas-provider-table'
 import { Roadmap } from './roadmap'
+import { ModelCatalog } from './model-catalog'
 
-type CapView = 'providers' | 'matrix' | 'cascade' | 'benchmarks' | 'wiring' | 'roadmap' | 'anti-patterns'
+type CapView = 'providers' | 'matrix' | 'models' | 'cascade' | 'benchmarks' | 'wiring' | 'roadmap' | 'anti-patterns'
 
 const CAP_VIEWS: Array<{ key: CapView; label: string }> = [
   { key: 'providers', label: 'OAS 프로바이더' },
   { key: 'matrix', label: '기능 매트릭스' },
+  { key: 'models', label: '모델 카탈로그' },
   { key: 'cascade', label: '캐스케이드 트레이스' },
   { key: 'benchmarks', label: 'BFCL 벤치마크' },
   { key: 'wiring', label: 'OAS 배선 갭' },
@@ -91,6 +94,15 @@ export function ProviderCapabilityMatrix() {
           <${MatrixLegend} />
           <${FeatureMatrix} liveProviders=${liveProviders.value} />
         </div>
+      ` : activeView.value === 'models' ? html`
+        <${Card}>
+          <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">Provider 모델 카탈로그</h3>
+          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+            Provider별 공식 모델 목록, 가격($/1M tokens), Context 한계, CLI transport 구현 비교.
+            GLM Coding Plan은 Claude Code 호환 엔드포인트를 통한 별도 모델 매핑 사용.
+          </p>
+          <${ModelCatalog} />
+        <//>
       ` : activeView.value === 'cascade' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">OAS Cascade 라우팅 트레이스</h3>

--- a/dashboard/src/components/provider-capability-matrix/index.ts
+++ b/dashboard/src/components/provider-capability-matrix/index.ts
@@ -44,23 +44,40 @@ const CAP_VIEWS: Array<{ key: CapView; label: string }> = [
   { key: 'anti-patterns', label: '안티패턴' },
 ]
 
+const PROVIDER_REFRESH_MS = 30_000
+
 export function ProviderCapabilityMatrix() {
   const activeView = useSignal<CapView>('matrix')
   const liveProviders = useSignal<DashboardRuntimeProviderSnapshot[]>([])
   const updatedLabel = useSignal<string | null>(null)
 
   useEffect(() => {
-    const ctrl = new AbortController()
-    void fetchRuntimeProviders({ signal: ctrl.signal })
-      .then(res => {
-        liveProviders.value = res.providers
-        updatedLabel.value = res.updated_at ?? null
-      })
-      .catch(err => {
-        if (err instanceof DOMException && err.name === 'AbortError') return
-        console.warn('[capability-matrix] provider fetch failed', err instanceof Error ? err.message : err)
-      })
-    return () => { ctrl.abort() }
+    let disposed = false
+    let inFlight: AbortController | null = null
+
+    const refresh = () => {
+      inFlight?.abort()
+      const ctrl = new AbortController()
+      inFlight = ctrl
+      void fetchRuntimeProviders({ signal: ctrl.signal })
+        .then(res => {
+          if (disposed || ctrl.signal.aborted) return
+          liveProviders.value = res.providers
+          updatedLabel.value = res.updated_at ?? null
+        })
+        .catch(err => {
+          if (err instanceof DOMException && err.name === 'AbortError') return
+          console.warn('[capability-matrix] provider fetch failed', err instanceof Error ? err.message : err)
+        })
+    }
+
+    refresh()
+    const timer = window.setInterval(refresh, PROVIDER_REFRESH_MS)
+    return () => {
+      disposed = true
+      window.clearInterval(timer)
+      inFlight?.abort()
+    }
   }, [])
 
   const updatedAt = updatedLabel.value

--- a/dashboard/src/components/provider-capability-matrix/model-catalog.ts
+++ b/dashboard/src/components/provider-capability-matrix/model-catalog.ts
@@ -1,0 +1,186 @@
+// ModelCatalog — Per-provider model listings with pricing and context.
+// Shows provider model tiers, GLM Coding Plan mapping, and CLI transport comparison.
+
+import { html } from 'htm/preact'
+import {
+  PROVIDER_MODELS,
+  PROVIDER_LABELS,
+  PROVIDER_CATEGORY,
+  CLI_TRANSPORTS,
+  GLM_CODING_PLAN_MAP,
+  GLM_WIRING_GAPS,
+  modelTierStyle,
+} from './data'
+
+function tierLabel(tier: string): string {
+  switch (tier) {
+    case 'flagship': return 'Flagship'
+    case 'standard': return 'Standard'
+    case 'fast':     return 'Fast'
+    case 'coding':   return 'Coding'
+    case 'legacy':   return 'Legacy'
+    default:         return tier
+  }
+}
+
+function ModelTable({ group }: { group: typeof PROVIDER_MODELS[number] }) {
+  const cat = PROVIDER_CATEGORY[group.providerId] ?? 'cloud'
+  const catBadge = cat === 'cloud' ? 'Cloud' : cat === 'cli' ? 'CLI' : 'Local'
+
+  return html`
+    <div class="border border-[var(--color-border-default)] rounded overflow-hidden">
+      <div class="flex items-center justify-between px-3 py-1.5 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
+        <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${PROVIDER_LABELS[group.providerId] ?? group.providerId}</span>
+        <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${group.models.length} models · ${catBadge}</span>
+      </div>
+      <table class="w-full text-xs border-collapse">
+        <thead>
+          <tr class="bg-[var(--white-2)]">
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">Model</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-muted)]">Tier</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-muted)]">Context</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-medium text-[var(--color-fg-muted)]">In/1M</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-medium text-[var(--color-fg-muted)]">Out/1M</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${group.models.map((m, i) => html`
+            <tr key=${m.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium text-[var(--color-fg-primary)]">${m.id}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center">
+                <span class="inline-block rounded px-1 py-px text-[9px] font-bold ${modelTierStyle(m.tier)}">${tierLabel(m.tier)}</span>
+              </td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${m.context}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.inputPrice ?? '—'}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.outputPrice ?? '—'}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${m.notes ?? ''}</td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function CliTransportTable() {
+  return html`
+    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+      <table class="w-full text-xs border-collapse">
+        <thead>
+          <tr class="bg-[var(--white-4)]">
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">Provider</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">Binary</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-right font-medium text-[var(--color-fg-secondary)]">LOC</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Prompt</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Stream</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Argv Thresh</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${CLI_TRANSPORTS.map((t, i) => html`
+            <tr key=${t.providerId} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-medium text-[var(--color-fg-primary)]">${PROVIDER_LABELS[t.providerId] ?? t.providerId}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px]">${t.binary}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${t.loc.toLocaleString()}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${t.promptMode}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${t.streamFormat}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${t.argvThreshold}</td>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${t.notes}</td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function GlmCodingPlanSection() {
+  return html`
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div>
+        <h5 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Claude Code → GLM Coding Plan 매핑</h5>
+        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+          <table class="w-full text-xs border-collapse">
+            <thead>
+              <tr class="bg-[var(--white-4)]">
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">Claude Code 변수</th>
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">GLM 모델</th>
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">비고</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${GLM_CODING_PLAN_MAP.map((m, i) => html`
+                <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[10px]">${m.envVar}</td>
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium">${m.glmModel}</td>
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${m.note}</td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div>
+        <h5 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">OAS vs 공식 문서 간격</h5>
+        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+          <table class="w-full text-xs border-collapse">
+            <thead>
+              <tr class="bg-[var(--white-4)]">
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">영역</th>
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">OAS 현재</th>
+                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">공식</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${GLM_WIRING_GAPS.map((g, i) => html`
+                <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[11px] font-medium">${g.area}</td>
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] font-mono text-[var(--bad-light)]">${g.oasCurrent}</td>
+                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] font-mono text-[var(--color-status-ok)]">${g.official}</td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+        <div class="mt-2">
+          <p class="text-[10px] text-[var(--color-fg-muted)]">Gap: ${GLM_WIRING_GAPS.map(g => g.gap).join(', ')}</p>
+        </div>
+      </div>
+    </div>
+  `
+}
+
+export function ModelCatalog() {
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+        <span>Provider별 공식 모델 카탈로그 + 가격 + Context 한계</span>
+        <span class="text-[var(--color-border-default)]">|</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--ok-10)]"></span> Flagship</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--white-4)]"></span> Standard</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--warn-10)]"></span> Fast</span>
+        <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--bad-10)]"></span> Coding</span>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        ${PROVIDER_MODELS.map(g => html`
+          <${ModelTable} key=${g.providerId} group=${g} />
+        `)}
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">CLI Transport 구현 비교</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">OAS CLI transport 계층의 구현 복잡도와 프로토콜 차이</p>
+        <${CliTransportTable} />
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">GLM Coding Plan 특수 매핑</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">Claude Code 호환 엔드포인트를 통한 GLM 모델 매핑 + OAS wiring 간격</p>
+        <${GlmCodingPlanSection} />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/provider-capability-matrix/model-catalog.ts
+++ b/dashboard/src/components/provider-capability-matrix/model-catalog.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import {
+  PROVIDER_IDS,
   PROVIDER_MODELS,
   PROVIDER_LABELS,
   PROVIDER_CATEGORY,
@@ -10,7 +11,13 @@ import {
   GLM_CODING_PLAN_MAP,
   GLM_WIRING_GAPS,
   modelTierStyle,
+  type ProviderModelGroup,
 } from './data'
+
+const MODEL_GROUPS_BY_PROVIDER = new Map(PROVIDER_MODELS.map(group => [group.providerId, group]))
+const MODEL_CATALOG_GROUPS: ProviderModelGroup[] = PROVIDER_IDS.map(providerId =>
+  MODEL_GROUPS_BY_PROVIDER.get(providerId) ?? { providerId, models: [] },
+)
 
 function tierLabel(tier: string): string {
   switch (tier) {
@@ -45,18 +52,24 @@ function ModelTable({ group }: { group: typeof PROVIDER_MODELS[number] }) {
           </tr>
         </thead>
         <tbody>
-          ${group.models.map((m, i) => html`
-            <tr key=${m.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium text-[var(--color-fg-primary)]">${m.id}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center">
-                <span class="inline-block rounded px-1 py-px text-[9px] font-bold ${modelTierStyle(m.tier)}">${tierLabel(m.tier)}</span>
+          ${group.models.length === 0 ? html`
+            <tr>
+              <td class="border-b border-[var(--color-border-default)] px-2 py-2 text-[10px] text-[var(--color-fg-muted)]" colSpan=${6}>
+                공식 모델 카탈로그 미등록. Provider capability는 matrix/providers 탭에서 추적.
               </td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${m.context}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.inputPrice ?? '—'}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.outputPrice ?? '—'}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${m.notes ?? ''}</td>
             </tr>
-          `)}
+          ` : group.models.map((m, i) => html`
+              <tr key=${m.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+                <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium text-[var(--color-fg-primary)]">${m.id}</td>
+                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center">
+                  <span class="inline-block rounded px-1 py-px text-[9px] font-bold ${modelTierStyle(m.tier)}">${tierLabel(m.tier)}</span>
+                </td>
+                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${m.context}</td>
+                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.inputPrice ?? '—'}</td>
+                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.outputPrice ?? '—'}</td>
+                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${m.notes ?? ''}</td>
+              </tr>
+            `)}
         </tbody>
       </table>
     </div>
@@ -165,7 +178,7 @@ export function ModelCatalog() {
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        ${PROVIDER_MODELS.map(g => html`
+        ${MODEL_CATALOG_GROUPS.map(g => html`
           <${ModelTable} key=${g.providerId} group=${g} />
         `)}
       </div>

--- a/dashboard/src/components/provider-capability-matrix/roadmap.ts
+++ b/dashboard/src/components/provider-capability-matrix/roadmap.ts
@@ -69,6 +69,15 @@ function DependencyGraph() {
   `
 }
 
+function parsePercentRatio(value: string): number {
+  const parsed = Number.parseFloat(value.replace('%', ''))
+  return Number.isFinite(parsed) ? parsed / 100 : 0
+}
+
+function formatFte(value: number): string {
+  return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1)}인`
+}
+
 function Timeline() {
   return html`
     <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
@@ -104,6 +113,14 @@ function Timeline() {
 }
 
 function ResourceTable() {
+  const totalHeadcount = RESOURCE_ALLOCATION.reduce((sum, row) => sum + row.headcount, 0)
+  const phaseTotals = RESOURCE_ALLOCATION[0]?.pct.map((_, phaseIndex) =>
+    RESOURCE_ALLOCATION.reduce(
+      (sum, row) => sum + (row.headcount * parsePercentRatio(row.pct[phaseIndex] ?? '0%')),
+      0,
+    ),
+  ) ?? []
+
   return html`
     <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
       <table class="w-full text-xs border-collapse">
@@ -130,12 +147,11 @@ function ResourceTable() {
             </tr>
           `)}
           <tr class="bg-[var(--white-4)] font-medium">
-            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1" colSpan=${2}>합계</td>
-            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">4인</td>
-            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">330%</td>
-            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">340%</td>
-            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">310%</td>
-            <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">240%</td>
+            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1" colSpan=${2}>합계 FTE</td>
+            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${totalHeadcount}인</td>
+            ${phaseTotals.map((total, i) => html`
+              <td key=${i} class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">${formatFte(total)}</td>
+            `)}
           </tr>
         </tbody>
       </table>

--- a/dashboard/src/components/provider-capability-matrix/roadmap.ts
+++ b/dashboard/src/components/provider-capability-matrix/roadmap.ts
@@ -1,5 +1,5 @@
 // Roadmap — P0–P7 improvement priority visualization.
-// Shows dependency graph, per-provider applicability, and timeline.
+// Shows dependency graph, per-provider applicability, phase timeline, and resource allocation.
 
 import { html } from 'htm/preact'
 import {
@@ -7,6 +7,9 @@ import {
   PROVIDER_IDS,
   PROVIDER_LABELS,
   APPLICABILITY_MATRIX,
+  PHASE_TIMELINE,
+  PHASE_COLORS,
+  RESOURCE_ALLOCATION,
   applicabilitySymbol,
   applicabilityCellClass,
   phaseColor,
@@ -65,11 +68,85 @@ function DependencyGraph() {
   `
 }
 
+function Timeline() {
+  return html`
+    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+      <table class="w-full text-xs border-collapse">
+        <thead>
+          <tr class="bg-[var(--white-4)]">
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[50px]">주차</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[60px]">Phase</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">작업</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">산출물</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[70px]">의존</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${PHASE_TIMELINE.map((row, i) => {
+            const phaseClass = PHASE_COLORS[row.phase] ?? ''
+            return html`
+              <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] text-[var(--color-fg-muted)]">${row.week}</td>
+                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1">
+                  <span class="inline-block rounded px-1.5 py-0.5 text-[9px] font-bold ${phaseClass}">${row.phase}</span>
+                </td>
+                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[11px]">${row.work}</td>
+                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-secondary)]">${row.deliverable}</td>
+                <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[10px] text-[var(--color-fg-muted)]">${row.deps}</td>
+              </tr>
+            `
+          })}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function ResourceTable() {
+  return html`
+    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
+      <table class="w-full text-xs border-collapse">
+        <thead>
+          <tr class="bg-[var(--white-4)]">
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">트랙</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">범위</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[40px]">인력</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">0–4주</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">4–8주</th>
+            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">8–12주</th>
+            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">12–16주</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${RESOURCE_ALLOCATION.map((row, i) => html`
+            <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
+              <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 font-medium text-[var(--color-fg-primary)]">${row.track}</td>
+              <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-secondary)]">${row.scope}</td>
+              <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${row.headcount}인</td>
+              ${row.pct.map((p, j) => html`
+                <td key=${j} class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px] text-[var(--color-fg-muted)]">${p}</td>
+              `)}
+            </tr>
+          `)}
+          <tr class="bg-[var(--white-4)] font-medium">
+            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1" colSpan=${2}>합계</td>
+            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">4인</td>
+            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">330%</td>
+            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">340%</td>
+            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">310%</td>
+            <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">240%</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
 export function Roadmap() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
-        <span>sec06 Table 6-1 — P0–P7 순차-병렬 하이브리드 개선 계획</span>
+        <span>sec06–07 — P0–P7 순차-병렬 하이브리드 개선 계획 + 16주 구현 로드맵</span>
       </div>
 
       <div>
@@ -121,6 +198,18 @@ export function Roadmap() {
             </tbody>
           </table>
         </div>
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Phase별 구현 타임라인</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec07 Table 7-1 — 16주 4-Phase 순차-병렬 하이브리드 로드맵</p>
+        <${Timeline} />
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">리소스 할당</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec07 Table 7-2 — 3 트랙 × 4 Phase 병렬 진행</p>
+        <${ResourceTable} />
       </div>
     </div>
   `

--- a/dashboard/src/components/provider-capability-matrix/roadmap.ts
+++ b/dashboard/src/components/provider-capability-matrix/roadmap.ts
@@ -10,6 +10,7 @@ import {
   PHASE_TIMELINE,
   PHASE_COLORS,
   RESOURCE_ALLOCATION,
+  SUCCESS_METRICS,
   applicabilitySymbol,
   applicabilityCellClass,
   phaseColor,
@@ -142,6 +143,39 @@ function ResourceTable() {
   `
 }
 
+function SuccessMetrics() {
+  return html`
+    <div class="grid grid-cols-1 gap-3">
+      ${SUCCESS_METRICS.map(m => html`
+        <div key=${m.id} class="border border-[var(--color-border-default)] rounded overflow-hidden">
+          <div class="flex items-center justify-between px-3 py-2 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
+            <div class="flex items-center gap-2">
+              <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${m.title}</span>
+              <span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono font-bold bg-[var(--ok-10)] text-[var(--color-status-ok)]">
+                Target: ${m.target}
+              </span>
+            </div>
+          </div>
+          <div class="px-3 py-2">
+            <p class="text-[11px] leading-snug text-[var(--color-fg-secondary)] mb-2">${m.description}</p>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+              ${Object.entries(m.phases).map(([phase, desc]) => {
+                const phaseClass = PHASE_COLORS[phase] ?? ''
+                return html`
+                  <div key=${phase} class="border border-[var(--color-border-default)] rounded px-2 py-1.5">
+                    <span class="inline-block rounded px-1 py-px text-[9px] font-bold ${phaseClass} mb-1">${phase}</span>
+                    <p class="text-[10px] leading-snug text-[var(--color-fg-muted)]">${desc}</p>
+                  </div>
+                `
+              })}
+            </div>
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 export function Roadmap() {
   return html`
     <div class="flex flex-col gap-4">
@@ -210,6 +244,12 @@ export function Roadmap() {
         <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">리소스 할당</h4>
         <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec07 Table 7-2 — 3 트랙 × 4 Phase 병렬 진행</p>
         <${ResourceTable} />
+      </div>
+
+      <div>
+        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">성공 지표</h4>
+        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec07 §7.3 — 16주 로드맵 완료 판정 기준 (3개 교차 검증 지표)</p>
+        <${SuccessMetrics} />
       </div>
     </div>
   `

--- a/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
+++ b/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
@@ -1,19 +1,49 @@
 // WiringGaps — OAS wiring mismatches vs official API support.
+// Severity-sorted (HIGH → MEDIUM → LOW) with summary stat tiles
+// and per-provider gap count chips.
 
 import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
 import { StatusChip } from '../common/status-chip'
+import { StatTile } from '../common/stat-tile'
 import { WIRING_GAPS, impactTone } from './data'
 
+const SEVERITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2, correct: 3 }
+const severityRank = (impact: string): number => SEVERITY_ORDER[impact] ?? 99
+
 export function WiringGaps() {
-  const gaps = WIRING_GAPS.filter(g => g.impact !== 'correct')
-  const correct = WIRING_GAPS.filter(g => g.impact === 'correct')
+  const sorted = useMemo(() =>
+    [...WIRING_GAPS].sort((a, b) => severityRank(a.impact) - severityRank(b.impact)),
+    [],
+  )
+  const gaps = sorted.filter(g => g.impact !== 'correct')
+  const correct = sorted.filter(g => g.impact === 'correct')
+  const high = gaps.filter(g => g.impact === 'high').length
+  const medium = gaps.filter(g => g.impact === 'medium').length
+  const low = gaps.filter(g => g.impact === 'low').length
+
+  const providerCounts = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const g of gaps) m.set(g.provider, (m.get(g.provider) ?? 0) + 1)
+    return [...m.entries()].sort((a, b) => b[1] - a[1])
+  }, [gaps.length])
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex items-center gap-3 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
-        <span>과소선언: ${gaps.length}건</span>
-        <span class="text-[var(--color-border-default)]">|</span>
-        <span>정확한 선언: ${correct.length}건</span>
+      <div class="grid grid-cols-4 gap-2">
+        <${StatTile} label="HIGH" value=${high} variant="warn" hint="tool calling 직접 영향" />
+        <${StatTile} label="MEDIUM" value=${medium} hint="기능 제한" />
+        <${StatTile} label="LOW" value=${low} hint="사소한 불일치" />
+        <${StatTile} label="정확" value=${correct.length} variant="gold" hint=${`${WIRING_GAPS.length} 중`} />
+      </div>
+
+      <div class="flex items-center gap-2 flex-wrap text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+        ${providerCounts.map(([prov, cnt]) => html`
+          <span key=${prov} class="inline-flex items-center gap-1">
+            <span class="font-medium text-[var(--color-fg-secondary)]">${prov}</span>
+            <span class="text-[var(--color-fg-disabled)]">${cnt}건</span>
+          </span>
+        `)}
       </div>
 
       <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">

--- a/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
+++ b/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
@@ -3,7 +3,6 @@
 // and per-provider gap count chips.
 
 import { html } from 'htm/preact'
-import { useMemo } from 'preact/hooks'
 import { StatusChip } from '../common/status-chip'
 import { StatTile } from '../common/stat-tile'
 import { WIRING_GAPS, impactTone } from './data'
@@ -12,21 +11,16 @@ const SEVERITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2, cor
 const severityRank = (impact: string): number => SEVERITY_ORDER[impact] ?? 99
 
 export function WiringGaps() {
-  const sorted = useMemo(() =>
-    [...WIRING_GAPS].sort((a, b) => severityRank(a.impact) - severityRank(b.impact)),
-    [],
-  )
+  const sorted = [...WIRING_GAPS].sort((a, b) => severityRank(a.impact) - severityRank(b.impact))
   const gaps = sorted.filter(g => g.impact !== 'correct')
   const correct = sorted.filter(g => g.impact === 'correct')
   const high = gaps.filter(g => g.impact === 'high').length
   const medium = gaps.filter(g => g.impact === 'medium').length
   const low = gaps.filter(g => g.impact === 'low').length
 
-  const providerCounts = useMemo(() => {
-    const m = new Map<string, number>()
-    for (const g of gaps) m.set(g.provider, (m.get(g.provider) ?? 0) + 1)
-    return [...m.entries()].sort((a, b) => b[1] - a[1])
-  }, [gaps.length])
+  const providerCountMap = new Map<string, number>()
+  for (const g of gaps) providerCountMap.set(g.provider, (providerCountMap.get(g.provider) ?? 0) + 1)
+  const providerCounts = [...providerCountMap.entries()].sort((a, b) => b[1] - a[1])
 
   return html`
     <div class="flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- Provider Capability Matrix 대시보드 컴포넌트 (8 sub-views)
- **providers**: OAS 12개 provider kind capability 정의 (sec02 Table 1)
- **matrix**: 15 features x 13 providers with live runtime overlay, category grouping
- **models**: Per-provider model catalog with pricing/context/CLI transport/GLM mapping, plus placeholders for every PROVIDER_IDS entry without a curated catalog
- **cascade**: OAS cascade routing trace (normal, rate-limit, timeout, exhaustion)
- **benchmarks**: BFCL V3/V4 rankings, V4 category breakdown, Harness case study
- **wiring**: 12 OAS wiring gaps vs official API with severity/provider summaries
- **roadmap**: P0-P7 improvement priorities with dependency graph, 16-week timeline, FTE resource totals, success metrics
- **anti-patterns**: 32 anti-patterns (S/F/M/H categories) from sec05 analysis

## Data Sources
- sec02-sec07 analysis documents
- research/external_research.md (BFCL V4 categories, Harness case study, CLI transport details)
- research/supplement_glm_kimi_cli_kv_small_model.md (GLM Coding Plan, provider models)
- Live provider status via periodic /api/v1/providers snapshot refresh every 30s

## Files Changed
- data.ts - Central data store (pure data constants)
- index.ts - Router with FilterChips, 8 sub-views, periodic provider refresh
- feature-matrix.ts - 15x13 matrix with category grouping and heartbeat history
- model-catalog.ts - Model catalog + CLI transport + GLM mapping
- bfcl-rankings.ts - BFCL rankings + V4 categories + Harness case study
- cascade-trace.ts, wiring-gaps.ts, roadmap.ts, anti-patterns.ts, oas-provider-table.ts

## Test plan
- [x] npm run typecheck -- --pretty false
- [x] npx vitest run --config vitest.config.ts src/components/provider-capability-matrix.test.ts --no-file-parallelism --maxWorkers=1
- [x] npm run build
- [x] bash scripts/lint/no-hardcoded-colors-dashboard.sh
- [x] bash scripts/check-pr-hygiene.sh --base origin/main --head HEAD
- [ ] CI green