### PR TITLE
fix(dashboard): provider matrix review follow-up — ariaLabel, warn tone, totalMs

### DIFF
--- a/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
+++ b/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
@@ -51,7 +51,9 @@ export function CascadeTrace() {
         </span>
       </div>
 
-      ${CASCADE_TRACES.map(trace => html`
+      ${CASCADE_TRACES.map(trace => {
+        const totalMs = trace.steps.reduce((s, st) => s + st.ms, 0)
+        return html`
         <div key=${trace.id} class="border border-[var(--color-border-default)] rounded overflow-hidden">
           <div class="flex items-center justify-between px-3 py-1.5 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
             <div class="flex items-center gap-2">
@@ -60,7 +62,7 @@ export function CascadeTrace() {
                 ${cascadeTierLabel(trace.tier)}
               </span>
             </div>
-            <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(trace.steps.reduce((s, st) => s + st.ms, 0))} total</span>
+            <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(totalMs)} total</span>
           </div>
           <div class="flex items-stretch px-2 py-2">
             ${trace.steps.map((step, i) => {
@@ -72,7 +74,8 @@ export function CascadeTrace() {
             })}
           </div>
         </div>
-      `)}
+        `
+      })}
     </div>
   `
 }

--- a/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
+++ b/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
@@ -60,7 +60,7 @@ export function CascadeTrace() {
                 ${cascadeTierLabel(trace.tier)}
               </span>
             </div>
-            <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(trace.totalMs)} total</span>
+            <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(trace.steps.reduce((s, st) => s + st.ms, 0))} total</span>
           </div>
           <div class="flex items-stretch px-2 py-2">
             ${trace.steps.map((step, i) => {

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -360,7 +360,6 @@ export interface CascadeTraceScenario {
   label: string
   tier: 'typical' | 'ideal' | 'worst' | 'cooldown'
   steps: CascadeStep[]
-  totalMs: number
 }
 
 export const CASCADE_TRACES: CascadeTraceScenario[] = [
@@ -373,7 +372,6 @@ export const CASCADE_TRACES: CascadeTraceScenario[] = [
       { provider: 'OpenAI',    status: 'miss', ms: 540, reason: 'timeout' },
       { provider: 'Moonshot',  status: 'hit',  ms: 420, reason: 'ok' },
     ],
-    totalMs: 1780,
   },
   {
     id: 'ct-first-hit',
@@ -384,7 +382,6 @@ export const CASCADE_TRACES: CascadeTraceScenario[] = [
       { provider: 'OpenAI',    status: 'skipped',  ms: 0,   reason: 'skipped' },
       { provider: 'Moonshot',  status: 'skipped',  ms: 0,   reason: 'skipped' },
     ],
-    totalMs: 380,
   },
   {
     id: 'ct-exhaustion',
@@ -396,7 +393,6 @@ export const CASCADE_TRACES: CascadeTraceScenario[] = [
       { provider: 'Moonshot',  status: 'miss', ms: 650,  reason: 'auth_failure' },
       { provider: 'Ollama',    status: 'miss', ms: 320,  reason: 'model_unloaded' },
     ],
-    totalMs: 3190,
   },
   {
     id: 'ct-cooldown',
@@ -407,7 +403,6 @@ export const CASCADE_TRACES: CascadeTraceScenario[] = [
       { provider: 'OpenAI',    status: 'hit',  ms: 460, reason: 'ok' },
       { provider: 'Moonshot',  status: 'skipped', ms: 0, reason: 'skipped' },
     ],
-    totalMs: 560,
   },
 ]
 

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -68,7 +68,7 @@ function statusToSlots(status: LiveStatus | null): HeartbeatState[] {
   switch (status) {
     case 'ok':   return Array<HeartbeatState>(HB_SLOTS).fill('up')
     case 'bad':  return Array<HeartbeatState>(HB_SLOTS).fill('down')
-    case 'warn': return Array<HeartbeatState>(HB_SLOTS).fill('unknown')
+    case 'warn': return Array<HeartbeatState>(HB_SLOTS).fill('down')
   }
 }
 
@@ -112,9 +112,10 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
               ${PROVIDER_IDS.map(pid => {
                 const dot = liveStatusDot(pid, liveProviders)
                 const hb = statusToSlots(dot)
+                const label = dot ? `${PROVIDER_LABELS[pid] ?? pid}: ${dot}` : `${PROVIDER_LABELS[pid] ?? pid}: no data`
                 return html`
                   <th key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5">
-                    <${HeartbeatStrip} history=${hb} slots=${HB_SLOTS} />
+                    <${HeartbeatStrip} history=${hb} slots=${HB_SLOTS} ariaLabel=${label} />
                   </th>
                 `
               })}

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -14,6 +14,7 @@ import {
 import { StatusDot } from '../common/status-dot'
 import { StatTile } from '../common/stat-tile'
 import { HeartbeatStrip } from '../common/heartbeat-strip'
+import { statusLabel } from '../../lib/status-label'
 import type { DashboardRuntimeProviderSnapshot } from '../../api/dashboard'
 import type { HeartbeatState } from '../../lib/heartbeat-history'
 
@@ -112,7 +113,7 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
               ${PROVIDER_IDS.map(pid => {
                 const dot = liveStatusDot(pid, liveProviders)
                 const hb = statusToSlots(dot)
-                const label = dot ? `${PROVIDER_LABELS[pid] ?? pid}: ${dot}` : `${PROVIDER_LABELS[pid] ?? pid}: no data`
+                const label = dot ? `${PROVIDER_LABELS[pid] ?? pid}: ${statusLabel(dot)}` : `${PROVIDER_LABELS[pid] ?? pid}: 데이터 없음`
                 return html`
                   <th key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5">
                     <${HeartbeatStrip} history=${hb} slots=${HB_SLOTS} ariaLabel=${label} />


### PR DESCRIPTION
## Summary
- Add provider-specific `ariaLabel` to `HeartbeatStrip` for screen reader accessibility (provider name + current live status)
- Map `warn` status to `'down'` instead of `'unknown'` so degraded providers are visually distinct from truly unknown ones
- Remove `totalMs` field from `CascadeTraceScenario` interface, compute from `steps[].ms` sum at render time to prevent data drift

## Context
Follow-up to #12771 (merged). Copilot raised 3 additional review items after the initial 4 were addressed.
These were implemented on the branch but the PR was squash-merged before the push, so the changes didn't land in main.

## Test plan
- [x] TypeScript `tsc --noEmit` passes (0 errors)
- [ ] CI Dashboard check passes
- [ ] Visual: heartbeat bars in provider matrix show warn as down (not unknown)
- [ ] Accessibility: aria-label includes provider name + status

🤖 Generated with [Claude Code](https://claude.com/claude-code)