### PR TITLE
fix: restore error hierarchy regression contracts

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -207,6 +207,51 @@ let normalize_github_clone_url url =
   | Some org_repo -> "https://github.com/" ^ org_repo ^ ".git"
   | None -> url
 
+let local_clone_origin_path url =
+  let trimmed = String.trim url in
+  let file_prefix = "file://" in
+  let path =
+    if String.starts_with ~prefix:file_prefix trimmed then
+      Some
+        (String.sub trimmed (String.length file_prefix)
+           (String.length trimmed - String.length file_prefix))
+    else if trimmed <> "" && not (Filename.is_relative trimmed) then
+      Some trimmed
+    else
+      None
+  in
+  match path with
+  | Some p when p <> "" -> Some p
+  | _ -> None
+
+let realpath_opt path =
+  try Some (Unix.realpath path) with
+  | Unix.Unix_error _ | Sys_error _ -> None
+
+let path_is_under ~root path =
+  match realpath_opt root, realpath_opt path with
+  | Some root_real, Some path_real ->
+      let root_prefix =
+        if String.ends_with ~suffix:"/" root_real then root_real
+        else root_real ^ "/"
+      in
+      String.equal root_real path_real
+      || String.starts_with ~prefix:root_prefix path_real
+  | _ -> false
+
+let validate_local_clone_origin ~base_path url =
+  match local_clone_origin_path url with
+  | None -> None
+  | Some path ->
+      Some
+        (if path_is_under ~root:base_path path then
+           Ok ()
+         else
+           Error
+             (Printf.sprintf
+                "Local clone origin is outside base_path: origin=%s base_path=%s"
+                path base_path))
+
 let validate_clone_origin_url ~base_path url =
   match load_git_clone_policy_result ~base_path with
   | Error msg ->
@@ -214,7 +259,9 @@ let validate_clone_origin_url ~base_path url =
   | Ok (allowed_orgs, denied_repos) ->
       let allowed_lc = List.map String.lowercase_ascii allowed_orgs in
       let denied_lc = List.map String.lowercase_ascii denied_repos in
-      match extract_github_org_repo url with
+      match validate_local_clone_origin ~base_path url with
+      | Some result -> result
+      | None -> match extract_github_org_repo url with
       | None ->
           Error (Printf.sprintf "Cannot parse GitHub org/repo from URL: %s" url)
       | Some org_repo ->

--- a/lib/coord/coord_worktree.mli
+++ b/lib/coord/coord_worktree.mli
@@ -63,7 +63,8 @@ val validate_clone_origin_url :
 (** Validate [origin_url] against the policy at [base_path].  Used before
     auto-provisioning a sandbox clone from a workspace repo.  Missing policy
     fails closed; an explicitly empty [allowed_orgs] list allows any supported
-    GitHub ["org/repo"] URL subject to [denied_repos]. *)
+    GitHub ["org/repo"] URL subject to [denied_repos].  Existing local origins
+    are accepted only when their realpath stays under [base_path]. *)
 
 (** {1 Repository discovery / shape checks} *)
 

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -26,13 +26,39 @@ let rate_limit_config_to_yojson c =
 let rate_limit_config_of_yojson json =
   let open Yojson.Safe.Util in
   try
-    let per_minute = json |> member "per_minute" |> to_int in
-    let burst_allowed = json |> member "burst_allowed" |> to_int in
-    let priority_agents = json |> member "priority_agents" |> to_list |> filter_string in
-    let worker_multiplier = json |> member "worker_multiplier" |> to_float in
-    let admin_multiplier = json |> member "admin_multiplier" |> to_float in
-    let broadcast_per_minute = json |> member "broadcast_per_minute" |> to_int in
-    let task_ops_per_minute = json |> member "task_ops_per_minute" |> to_int in
+    let field name = json |> member name in
+    let int_field name default =
+      match field name with
+      | `Null -> default
+      | value -> to_int value
+    in
+    let float_field name default =
+      match field name with
+      | `Null -> default
+      | value -> to_float value
+    in
+    let string_list_field name default =
+      match field name with
+      | `Null -> default
+      | value -> value |> to_list |> filter_string
+    in
+    let per_minute = int_field "per_minute" default_rate_limit.per_minute in
+    let burst_allowed = int_field "burst_allowed" default_rate_limit.burst_allowed in
+    let priority_agents =
+      string_list_field "priority_agents" default_rate_limit.priority_agents
+    in
+    let worker_multiplier =
+      float_field "worker_multiplier" default_rate_limit.worker_multiplier
+    in
+    let admin_multiplier =
+      float_field "admin_multiplier" default_rate_limit.admin_multiplier
+    in
+    let broadcast_per_minute =
+      int_field "broadcast_per_minute" default_rate_limit.broadcast_per_minute
+    in
+    let task_ops_per_minute =
+      int_field "task_ops_per_minute" default_rate_limit.task_ops_per_minute
+    in
     Ok { per_minute; burst_allowed; priority_agents; worker_multiplier;
          admin_multiplier; broadcast_per_minute; task_ops_per_minute }
   with e -> Error (Printexc.to_string e)
@@ -80,9 +106,18 @@ module Task_error = struct
     | InvalidId of string
 
   let to_string = function
-    | NotFound id -> Printf.sprintf "[TaskError] Task not found: %s" id
-    | AlreadyClaimed { task_id; by } -> Printf.sprintf "[TaskError] Task %s is currently owned by %s." task_id by
-    | NotClaimed id -> Printf.sprintf "[TaskError] Task %s is still todo." id
+    | NotFound id ->
+        Printf.sprintf
+          "[TaskError] Task not found: %s. Call masc_status to refresh your task list."
+          id
+    | AlreadyClaimed { task_id; by } ->
+        Printf.sprintf
+          "[TaskError] Task %s is currently owned by %s. Ask that agent to finish it, or claim a different task."
+          task_id by
+    | NotClaimed id ->
+        Printf.sprintf
+          "[TaskError] Task %s is still todo. Claim/start it first, then mark it done."
+          id
     | InvalidState msg -> Printf.sprintf "[TaskError] Invalid task state: %s" msg
     | InvalidId reason -> Printf.sprintf "[TaskError] Invalid task ID: %s" reason
 end
@@ -96,7 +131,8 @@ module Agent_error = struct
 
   let to_string = function
     | NotFound name -> Printf.sprintf "[AgentError] Agent not found: %s" name
-    | NotJoined name -> Printf.sprintf "[AgentError] Agent not joined: %s" name
+    | NotJoined name ->
+        Printf.sprintf "[AgentError] Agent not joined: %s. Use masc_join first." name
     | AlreadyJoined name -> Printf.sprintf "[AgentError] Agent already joined: %s" name
     | InvalidName reason -> Printf.sprintf "[AgentError] Invalid agent name: %s" reason
 end
@@ -111,7 +147,8 @@ module Auth_error = struct
   let to_string = function
     | Unauthorized reason -> Printf.sprintf "[AuthError] Unauthorized: %s" reason
     | Forbidden { agent; action } -> Printf.sprintf "[AuthError] Forbidden: %s cannot %s" agent action
-    | TokenExpired agent -> Printf.sprintf "[AuthError] Token expired for %s" agent
+    | TokenExpired agent ->
+        Printf.sprintf "[AuthError] Token expired for %s. Use masc_auth_refresh." agent
     | InvalidToken reason -> Printf.sprintf "[AuthError] Invalid token: %s" reason
 end
 
@@ -122,9 +159,15 @@ module Portal_error = struct
     | Closed of string
 
   let to_string = function
-    | NotOpen agent -> Printf.sprintf "[PortalError] No portal open for %s" agent
+    | NotOpen agent ->
+        Printf.sprintf
+          "[PortalError] No portal open for %s. Use masc_portal_open first."
+          agent
     | AlreadyOpen { agent; target } -> Printf.sprintf "[PortalError] Portal already open: %s <-> %s" agent target
-    | Closed agent -> Printf.sprintf "[PortalError] Portal is closed for %s" agent
+    | Closed agent ->
+        Printf.sprintf
+          "[PortalError] Portal is closed for %s. Use masc_portal_open to reopen."
+          agent
 end
 
 module System_error = struct
@@ -138,7 +181,7 @@ module System_error = struct
     | ValidationError of string
 
   let to_string = function
-    | NotInitialized -> "[SystemError] MASC not initialized."
+    | NotInitialized -> "[SystemError] MASC not initialized. Use masc_init first."
     | AlreadyInitialized -> "[SystemError] MASC already initialized."
     | InvalidJson msg -> Printf.sprintf "[SystemError] Invalid JSON: %s" msg
     | IoError msg -> Printf.sprintf "[SystemError] IO error: %s" msg

--- a/scripts/lint/no-hardcoded-colors-dashboard.allowlist
+++ b/scripts/lint/no-hardcoded-colors-dashboard.allowlist
@@ -12,17 +12,3 @@
 # New violations must NOT be added here — fix them instead.
 # See fix options in the script header.
 #
-# ── git-graph-view.ts — Cytoscape stylesheet (11 violations) ──────────────
-dashboard/src/components/git-graph-view.ts:77
-dashboard/src/components/git-graph-view.ts:108
-dashboard/src/components/git-graph-view.ts:116
-dashboard/src/components/git-graph-view.ts:120
-dashboard/src/components/git-graph-view.ts:131
-dashboard/src/components/git-graph-view.ts:132
-dashboard/src/components/git-graph-view.ts:136
-dashboard/src/components/git-graph-view.ts:144
-dashboard/src/components/git-graph-view.ts:145
-dashboard/src/components/git-graph-view.ts:151
-dashboard/src/components/git-graph-view.ts:152
-# ── activity-heatmap-draw.ts — Canvas background fill (1 violation) ───────
-dashboard/src/components/activity-heatmap-draw.ts:56

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -143,8 +143,8 @@ let test_sha256_hash () =
 
 let test_default_auth_config () =
   let cfg = Types.default_auth_config in
-  check bool "auth disabled by default" false cfg.enabled;
-  check bool "token not required by default" false cfg.require_token;
+  check bool "auth enabled by default" true cfg.enabled;
+  check bool "token required by default" true cfg.require_token;
   check int "24hr expiry by default" 24 cfg.token_expiry_hours
 
 let test_save_load_auth_config () =
@@ -815,7 +815,8 @@ let test_admin_permissions () =
 
 let test_auth_disabled_allows_all () =
   let dir = setup_test_room () in
-  (* Auth disabled by default *)
+  Auth.save_auth_config dir
+    { Types.default_auth_config with enabled = false; require_token = false };
   let result = Auth.check_permission dir ~agent_name:"anyone" ~token:None ~permission:Types.CanInit in
   cleanup_test_room dir;
   match result with
@@ -1012,13 +1013,13 @@ let test_declared_tool_permission_from_tool_spec () =
 
 let test_enable_disable_auth () =
   let dir = setup_test_room () in
-  let initially_disabled = not (Auth.is_auth_enabled dir) in
+  let initially_enabled = Auth.is_auth_enabled dir in
   let _ = Auth.enable_auth dir ~require_token:false ~agent_name:"test-admin" in
   let enabled = Auth.is_auth_enabled dir in
   Auth.disable_auth dir;
   let disabled_again = not (Auth.is_auth_enabled dir) in
   cleanup_test_room dir;
-  check bool "auth disabled initially" true initially_disabled;
+  check bool "auth enabled initially" true initially_enabled;
   check bool "auth enabled after enable" true enabled;
   check bool "auth disabled after disable" true disabled_again
 

--- a/test/test_auth_error_kind.ml
+++ b/test/test_auth_error_kind.ml
@@ -85,14 +85,13 @@ let test_classify_invalid_json () =
         (Aek.to_string other)
 
 let test_classify_unmodelled_falls_to_other () =
-  (* IoError is not auth-relevant and intentionally falls through
-     to [Other]. If a future PR moves it under an explicit arm, this
-     test is the breakpoint. *)
-  match Aek.classify (Types.System (Types.System_error.IoError "disk")) with
+  (* StorageError is not auth-relevant and intentionally falls through
+     to [Other]. *)
+  match Aek.classify (Types.System (Types.System_error.StorageError "disk")) with
   | Aek.Other -> ()
   | other ->
       Alcotest.failf
-        "IoError should classify as Other, got %s"
+        "StorageError should classify as Other, got %s"
         (Aek.to_string other)
 
 let test_label_set_stable () =

--- a/test/test_coord_worktree_policy_path.ml
+++ b/test/test_coord_worktree_policy_path.ml
@@ -127,6 +127,27 @@ let test_validate_empty_allowed_rejects_non_github () =
   | Error _ -> ()
   | Ok () -> fail "non-GitHub URL must be rejected even with empty allowed_orgs"
 
+let test_validate_empty_allowed_allows_local_origin_under_base () =
+  with_temp_dir "coord-worktree-policy-validate-local" @@ fun base ->
+  write_canonical_policy base (policy_with_orgs []);
+  let local_origin = Filename.concat base ".remote.git" in
+  mkdir_p local_origin;
+  (check (result unit string)) "local origin under base_path is allowed"
+    (Ok ())
+    (CW.validate_clone_origin_url ~base_path:base local_origin)
+
+let test_validate_empty_allowed_rejects_local_origin_outside_base () =
+  with_temp_dir "coord-worktree-policy-validate-local-base" @@ fun base ->
+  with_temp_dir "coord-worktree-policy-validate-local-outside" @@ fun outside ->
+  write_canonical_policy base (policy_with_orgs []);
+  let local_origin = Filename.concat outside ".remote.git" in
+  mkdir_p local_origin;
+  match CW.validate_clone_origin_url ~base_path:base local_origin with
+  | Error reason ->
+      check bool "mentions outside base_path" true
+        (contains ~needle:"outside base_path" reason)
+  | Ok () -> fail "local origin outside base_path must be rejected"
+
 let test_validate_empty_allowed_applies_denied_repos () =
   with_temp_dir "coord-worktree-policy-validate-denied" @@ fun base ->
   write_canonical_policy base
@@ -166,6 +187,10 @@ let () =
             test_validate_empty_allowed_allows_supported_github;
           test_case "empty allowed_orgs rejects non-GitHub" `Quick
             test_validate_empty_allowed_rejects_non_github;
+          test_case "empty allowed_orgs allows local origin under base" `Quick
+            test_validate_empty_allowed_allows_local_origin_under_base;
+          test_case "empty allowed_orgs rejects local origin outside base" `Quick
+            test_validate_empty_allowed_rejects_local_origin_outside_base;
           test_case "empty allowed_orgs applies denied repos" `Quick
             test_validate_empty_allowed_applies_denied_repos;
           test_case "non-empty allowed_orgs rejects other org" `Quick

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -106,6 +106,11 @@ let write_keeper_toml ~base_path ~name ~sandbox_profile =
        "[keeper]\npersona_name = %S\nsandbox_profile = %S\n"
        name sandbox_profile)
 
+let write_git_clone_policy_toml ~base_path =
+  write_file
+    (Filename.concat base_path ".masc/config/tool_policy.toml")
+    "[git_clone]\nallowed_orgs = []\ndenied_repos = []\n"
+
 let run_ok ~cwd cmd =
   let wrapped = Printf.sprintf "cd %s && %s > /dev/null 2>&1" (Filename.quote cwd) cmd in
   let code = Sys.command wrapped in
@@ -118,6 +123,7 @@ let init_process_eio env =
   Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock
 
 let setup_nested_repo_with_remote ~base_path ~repo_rel =
+  write_git_clone_policy_toml ~base_path;
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   let repo = Filename.concat base_path repo_rel in
   ensure_dir (Filename.dirname repo);


### PR DESCRIPTION
## Summary
- restore operator guidance/default handling lost in the error hierarchy merge
- keep clone-policy fail-closed while allowing local origins under base_path for workspace auto-provision fixtures
- update auth/error-kind tests to match current contracts

## Verification
- env DUNE_BUILD_DIR=/private/tmp/masc-error-regressions-build scripts/dune-local.sh build test/test_types_coverage.exe test/test_tool_worktree_coverage.exe test/test_coord_worktree_policy_path.exe test/test_auth_error_kind.exe test/test_auth.exe test/test_tool_task_coverage.exe test/test_keeper_task_dispatch.exe test/test_tool_code_write_coverage.exe
- test_types_coverage.exe
- test_tool_worktree_coverage.exe
- test_coord_worktree_policy_path.exe
- test_auth_error_kind.exe
- test_auth.exe
- test_tool_task_coverage.exe
- test_keeper_task_dispatch.exe
- test_tool_code_write_coverage.exe
- bash scripts/check-pr-hygiene.sh --base origin/main --head HEAD