### PR TITLE
chore(lint): remove stale hardcoded-color allowlist entries

### DIFF
--- a/scripts/lint/no-hardcoded-colors-dashboard.allowlist
+++ b/scripts/lint/no-hardcoded-colors-dashboard.allowlist
@@ -12,17 +12,3 @@
 # New violations must NOT be added here — fix them instead.
 # See fix options in the script header.
 #
-# ── git-graph-view.ts — Cytoscape stylesheet (11 violations) ──────────────
-dashboard/src/components/git-graph-view.ts:77
-dashboard/src/components/git-graph-view.ts:108
-dashboard/src/components/git-graph-view.ts:116
-dashboard/src/components/git-graph-view.ts:120
-dashboard/src/components/git-graph-view.ts:131
-dashboard/src/components/git-graph-view.ts:132
-dashboard/src/components/git-graph-view.ts:136
-dashboard/src/components/git-graph-view.ts:144
-dashboard/src/components/git-graph-view.ts:145
-dashboard/src/components/git-graph-view.ts:151
-dashboard/src/components/git-graph-view.ts:152
-# ── activity-heatmap-draw.ts — Canvas background fill (1 violation) ───────
-dashboard/src/components/activity-heatmap-draw.ts:56


### PR DESCRIPTION
## Summary
- Remove 12 stale allowlist entries from `scripts/lint/no-hardcoded-colors-dashboard.allowlist`
- PR #12769 (design-system token migration) eliminated all hardcoded color violations in `git-graph-view.ts` and `activity-heatmap-draw.ts`
- These entries cause Lint check to fail on all open PRs that merge with current main

## Test plan
- [ ] `bash scripts/lint/no-hardcoded-colors-dashboard.sh` exits 0
- [ ] CI Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)