### PR TITLE
feat(ppx): route fsm_guard asserts through wrap_unit for Prometheus observability

### DIFF
--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -620,31 +620,50 @@ let parse_guard_expression ~loc s =
       "[@@fsm_guard]: payload is not a valid OCaml boolean expression: %S"
       s
 
-(* OCaml 5.4 / ppxlib 0.37 unified function representation:
-   [Pexp_function (params, constraint_, body)] where [body] is either
-   [Pfunction_body expr] (right-hand expression of [let f x y = expr])
-   or [Pfunction_cases cases] (pattern-matching [function]).
+(* Build [Keeper_fsm_guard_runtime.wrap_unit ~action:<s> ~stage:"guard" <thunk>]. *)
+let make_wrap_unit_call ~loc ~action_str thunk =
+  let open Asttypes in
+  let lid : Longident.t Location.loc =
+    { Location.txt = Longident.Ldot (Longident.Lident "Keeper_fsm_guard_runtime", "wrap_unit"); loc }
+  in
+  let wrap_unit_ref = Ast_builder.Default.pexp_ident ~loc lid in
+  let action_label = Ast_builder.Default.estring ~loc action_str in
+  let stage_label = Ast_builder.Default.estring ~loc "guard" in
+  Ast_builder.Default.pexp_apply ~loc wrap_unit_ref
+    [ (Labelled "action", action_label)
+    ; (Labelled "stage", stage_label)
+    ; (Nolabel, thunk)
+    ]
 
-   For [Pfunction_body], inject the assert at the head of [expr] so the
-   guard fires per application of the innermost lambda — partial
-   applications do not trigger.
+(* Generate: [wrap_unit ~action ~stage (fun () -> assert expr); body]
+   The assert is isolated inside a unit thunk so that [wrap_unit] can
+   catch [Assert_failure] and bump a Prometheus counter.  The original
+   body follows as a sequence expression so its return type is preserved.
 
-   For [Pfunction_cases] and non-function expressions, sequence the
-   assert before the expression itself; the timing differs (per
-   binding-creation rather than per call) but no equivalent injection
-   point is portable across the unified representation. *)
-let inject_into_body assert_expr expr =
+   Result for [let f x = body [@@fsm_guard "expr"]]:
+     let f x =
+       (Keeper_fsm_guard_runtime.wrap_unit ~action:"f" ~stage:"guard"
+          (fun () -> assert (expr)));
+       body
+*)
+let inject_wrapped_body ~action_str assert_expr expr =
+  let loc = expr.pexp_loc in
+  let wrap_assert_as_unit =
+    let thunk =
+      Ast_builder.Default.pexp_fun ~loc Asttypes.Nolabel None
+        (Ast_helper.Pat.any ~loc ()) assert_expr
+    in
+    make_wrap_unit_call ~loc ~action_str thunk
+  in
   match expr.pexp_desc with
   | Pexp_function (params, constraint_, Pfunction_body body) ->
       let new_body =
         Ast_builder.Default.pexp_sequence ~loc:body.pexp_loc
-          assert_expr body
+          wrap_assert_as_unit body
       in
-      { expr with
-        pexp_desc =
-          Pexp_function (params, constraint_, Pfunction_body new_body); }
+      { expr with pexp_desc = Pexp_function (params, constraint_, Pfunction_body new_body) }
   | _ ->
-      Ast_builder.Default.pexp_sequence ~loc:expr.pexp_loc assert_expr expr
+      Ast_builder.Default.pexp_sequence ~loc wrap_assert_as_unit expr
 
 let fsm_guard_attr =
   Attribute.declare "ppx_tla.fsm_guard"
@@ -666,7 +685,12 @@ class fsm_guard_mapper =
           let assert_expr =
             Ast_builder.Default.pexp_assert ~loc parsed
           in
-          let new_expr = inject_into_body assert_expr vb.pvb_expr in
+          let action_str =
+            match vb.pvb_pat.ppat_desc with
+            | Ppat_var { txt } -> txt
+            | _ -> "_"
+          in
+          let new_expr = inject_wrapped_body ~action_str assert_expr vb.pvb_expr in
           { vb with pvb_expr = new_expr }
   end
 

--- a/ppx_tla/ppx_tla.ml
+++ b/ppx_tla/ppx_tla.ml
@@ -595,14 +595,19 @@ let _ : Deriving.t =
 
    becomes (conceptually):
      let start_turn state input =
-       assert (state.phase = `Idle && not state.stop_signaled);
+       Keeper_fsm_guard_runtime.wrap_unit
+         ~action:"start_turn"
+         ~stage:"guard"
+         (fun () -> assert (state.phase = `Idle && not state.stop_signaled));
        body
 
-   For curried definitions ([let f x y = body]) the assert is injected
-   into the innermost lambda body, so it fires per-application rather
-   than per-partial-application.
+   [wrap_unit] records guard assertion failures in the Prometheus FSM
+   guard counter and follows the runtime re-raise policy. For curried
+   definitions ([let f x y = body]) the wrapped assert is injected into
+   the innermost lambda body, so it fires per-application rather than
+   per-partial-application.
 
-   Constant ([non-lambda]) bindings get the assert evaluated at
+   Constant ([non-lambda]) bindings get the wrapped assert evaluated at
    binding-creation time (rare in practice for FSM transition tables).
 
    Honest about scope: this is a lightweight runtime check that only
@@ -649,9 +654,14 @@ let make_wrap_unit_call ~loc ~action_str thunk =
 let inject_wrapped_body ~action_str assert_expr expr =
   let loc = expr.pexp_loc in
   let wrap_assert_as_unit =
+    let unit_pat =
+      Ast_builder.Default.ppat_construct ~loc
+        (Loc.make ~loc (Longident.Lident "()"))
+        None
+    in
     let thunk =
       Ast_builder.Default.pexp_fun ~loc Asttypes.Nolabel None
-        (Ast_helper.Pat.any ~loc ()) assert_expr
+        unit_pat assert_expr
     in
     make_wrap_unit_call ~loc ~action_str thunk
   in
@@ -688,7 +698,9 @@ class fsm_guard_mapper =
           let action_str =
             match vb.pvb_pat.ppat_desc with
             | Ppat_var { txt } -> txt
-            | _ -> "_"
+            | _ ->
+                Location.raise_errorf ~loc:vb.pvb_pat.ppat_loc
+                  "[@@fsm_guard]: expected a simple let-binding name so the guard metric has a stable action label"
           in
           let new_expr = inject_wrapped_body ~action_str assert_expr vb.pvb_expr in
           { vb with pvb_expr = new_expr }

--- a/test/ppx_tla/dune
+++ b/test/ppx_tla/dune
@@ -1,4 +1,5 @@
 (tests
  (names test_basic test_records test_gadt test_phantom_param)
+ (modules test_basic test_records test_gadt test_phantom_param keeper_fsm_guard_runtime)
  (preprocess
   (pps ppx_tla)))

--- a/test/ppx_tla/keeper_fsm_guard_runtime.ml
+++ b/test/ppx_tla/keeper_fsm_guard_runtime.ml
@@ -1,7 +1,17 @@
 (* Stub for [Keeper_fsm_guard_runtime] used by ppx_tla tests.
    The PPX generates [Keeper_fsm_guard_runtime.wrap_unit] calls;
    this stub provides the same signature so tests compile without
-   the full keeper runtime. *)
+   the full keeper runtime.
 
-let wrap_unit ~action:_ ~stage:_ thunk =
+   Unlike the production version which bumps a Prometheus counter,
+   this stub tracks invocations in a mutable ref for test inspection. *)
+
+let invocations : (string * string) list ref = ref []
+
+let wrap_unit ~action ~stage thunk =
+  invocations := (action, stage) :: !invocations;
   thunk ()
+
+let get_invocations () = List.rev !invocations
+
+let reset_invocations () = invocations := []

--- a/test/ppx_tla/keeper_fsm_guard_runtime.ml
+++ b/test/ppx_tla/keeper_fsm_guard_runtime.ml
@@ -8,7 +8,7 @@
 
 let invocations : (string * string) list ref = ref []
 
-let wrap_unit ~action ~stage thunk =
+let wrap_unit ~(action : string) ~(stage : string) (thunk : unit -> unit) : unit =
   invocations := (action, stage) :: !invocations;
   thunk ()
 

--- a/test/ppx_tla/keeper_fsm_guard_runtime.ml
+++ b/test/ppx_tla/keeper_fsm_guard_runtime.ml
@@ -1,0 +1,7 @@
+(* Stub for [Keeper_fsm_guard_runtime] used by ppx_tla tests.
+   The PPX generates [Keeper_fsm_guard_runtime.wrap_unit] calls;
+   this stub provides the same signature so tests compile without
+   the full keeper runtime. *)
+
+let wrap_unit ~action:_ ~stage:_ thunk =
+  thunk ()

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -119,9 +119,9 @@ let test_classified_predicates () =
 
 (* Cycle 12 (PR #11450): [@@fsm_guard "expr"] runtime assertion injection.
    The guard is parsed as an OCaml boolean expression at PPX time and
-   injected as [assert (...)] into the function body. For curried
-   bindings the assert lands in the innermost lambda so it fires per
-   application, not per partial application. *)
+   injected through [Keeper_fsm_guard_runtime.wrap_unit] into the function
+   body. For curried bindings the wrapped assert lands in the innermost
+   lambda so it fires per application, not per partial application. *)
 
 let f_with_guard x = x + 1
 [@@fsm_guard "x >= 0"]

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -160,6 +160,26 @@ let test_fsm_guard_curried_fail () =
   in
   assert raised
 
+(* Verify that [wrap_unit] was actually called by the PPX-generated code,
+   not just a bare assert.  The stub tracks invocations. *)
+let test_wrap_unit_routing () =
+  Keeper_fsm_guard_runtime.reset_invocations ();
+  let _ = f_with_guard 5 in
+  let invocations = Keeper_fsm_guard_runtime.get_invocations () in
+  assert (List.length invocations >= 1);
+  let (action, stage) = List.hd invocations in
+  assert (action = "f_with_guard");
+  assert (stage = "guard")
+
+let test_wrap_unit_routing_curried () =
+  Keeper_fsm_guard_runtime.reset_invocations ();
+  let _ = g_curried 2 3 in
+  let invocations = Keeper_fsm_guard_runtime.get_invocations () in
+  assert (List.length invocations >= 1);
+  let (action, stage) = List.hd invocations in
+  assert (action = "g_curried");
+  assert (stage = "guard")
+
 let () =
   test_color_to_tla_symbol ();
   test_color_all_states ();
@@ -176,4 +196,6 @@ let () =
   test_fsm_guard_fail ();
   test_fsm_guard_curried_pass ();
   test_fsm_guard_curried_fail ();
+  test_wrap_unit_routing ();
+  test_wrap_unit_routing_curried ();
   print_endline "ppx_tla cycle 2 + 3 + 12 tests: PASS"


### PR DESCRIPTION
## Summary

- `[@@fsm_guard "expr"]` PPX now generates `Keeper_fsm_guard_runtime.wrap_unit ~action ~stage:"guard" (fun () -> assert expr); body` instead of bare `assert expr`
- Assert failures are caught by `wrap_unit`, which bumps a Prometheus counter and optionally re-raises via `MASC_FSM_GUARD_ASSERT=1`
- Original function return type is preserved via sequence expression
- Test stub module (`keeper_fsm_guard_runtime.ml`) for PPX test compilation

## What changed

| File | Change |
|------|--------|
| `ppx_tla/ppx_tla.ml` | New `make_wrap_unit_call` + `inject_wrapped_body` replaces old `inject_into_body` |
| `test/ppx_tla/dune` | Added `keeper_fsm_guard_runtime` to modules list |
| `test/ppx_tla/keeper_fsm_guard_runtime.ml` | New stub: identity `wrap_unit` for tests |

## Before (bare assert, crashes production)

```ocaml
let require_active_state s = assert (s = Active); s [@@fsm_guard "s = Active"]
(* expands to: *)
let require_active_state s = assert (s = Active); s
```

## After (wrapped, Prometheus counter)

```ocaml
(* expands to: *)
let require_active_state s =
  (Keeper_fsm_guard_runtime.wrap_unit ~action:"require_active_state" ~stage:"guard"
     (fun () -> assert (s = Active)));
  s
```

## Test plan

- [x] `dune build @check` passes (full project type-check)
- [x] `dune runtest test/ppx_tla/` passes (4 test executables)
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)