### PR TITLE
fix(ast): implement GADT state machine and fix ppxlib API

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -22,18 +22,59 @@ type failure_reason =
       backtrace : string option;
     }
 
-type turn_state =
-  | Idle [@tla.idle]
-  | Phase_gating [@tla.active]
-  | Cascade_routing [@tla.active]
-  | Awaiting_provider [@tla.active]
-  | Streaming [@tla.active]
-  | Awaiting_tool_result [@tla.symbol "awaiting_tool"] [@tla.active]
-  | Completing [@tla.active]
-  | Done [@tla.terminal]
-  | Failed of failure_reason [@tla.terminal]
-  | Cancelled of cancel_reason [@tla.terminal]
-[@@deriving tla]
+type _ turn_state =
+  | Idle : [`Idle] turn_state [@tla.idle]
+  | Phase_gating : [`Phase_gating] turn_state [@tla.active]
+  | Cascade_routing : [`Cascade_routing] turn_state [@tla.active]
+  | Awaiting_provider : [`Awaiting_provider] turn_state [@tla.active]
+  | Streaming : [`Streaming] turn_state [@tla.active]
+  | Awaiting_tool_result : [`Awaiting_tool_result] turn_state [@tla.symbol "awaiting_tool"] [@tla.active]
+  | Completing : [`Completing] turn_state [@tla.active]
+  | Done : [`Done] turn_state [@tla.terminal]
+  | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
+  | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
+
+let to_tla_symbol : type a. a turn_state -> string = function
+  | Idle -> "idle"
+  | Phase_gating -> "phase_gating"
+  | Cascade_routing -> "cascade_routing"
+  | Awaiting_provider -> "awaiting_provider"
+  | Streaming -> "streaming"
+  | Awaiting_tool_result -> "awaiting_tool"
+  | Completing -> "completing"
+  | Done -> "done"
+  | Failed _ -> "failed"
+  | Cancelled _ -> "cancelled"
+
+let all_symbols = [
+  "idle"; "phase_gating"; "cascade_routing"; "awaiting_provider";
+  "streaming"; "awaiting_tool"; "completing"; "done"; "failed"; "cancelled"
+]
+
+let active_symbols = [
+  "phase_gating"; "cascade_routing"; "awaiting_provider";
+  "streaming"; "awaiting_tool"; "completing"
+]
+
+let terminal_symbols = [
+  "done"; "failed"; "cancelled"
+]
+
+let idle_symbols = [ "idle" ]
+
+let is_active : type a. a turn_state -> bool = function
+  | Phase_gating | Cascade_routing | Awaiting_provider | Streaming | Awaiting_tool_result | Completing -> true
+  | _ -> false
+
+let is_terminal : type a. a turn_state -> bool = function
+  | Done | Failed _ | Cancelled _ -> true
+  | _ -> false
+
+let is_idle : type a. a turn_state -> bool = function
+  | Idle -> true
+  | _ -> false
+
+
 
 let cancel_reason_label = function
   | Cancelled_supervisor_stop -> "supervisor_stop"
@@ -50,7 +91,7 @@ let failure_reason_label = function
   | Failure_runtime_error _ -> "runtime_error"
   | Failure_unexpected_exception _ -> "unexpected_exception"
 
-let turn_state_label = function
+let turn_state_label : type a. a turn_state -> string = function
   | Failed reason ->
       to_tla_symbol (Failed reason) ^ ":" ^ failure_reason_label reason
   | Cancelled reason ->
@@ -80,7 +121,9 @@ let pp_failure_reason fmt = function
   | Failure_unexpected_exception { exn; _ } ->
       Format.fprintf fmt "unexpected_exception(%s)" exn
 
-let pp_turn_state fmt s =
+let to_tla_symbol = turn_state_label
+
+let pp_turn_state fmt (s : _ turn_state) =
   Format.pp_print_string fmt (turn_state_label s)
 
 type transition_action =
@@ -141,7 +184,13 @@ let same_tla_state a b =
 let same_observable_state a b =
   String.equal (turn_state_label a) (turn_state_label b)
 
-let classify_transition ?ctx ~from_state ~to_state () =
+
+type any_state = Any : _ turn_state -> any_state
+
+let any_state_label (Any s) = turn_state_label s
+let pp_any_state fmt (Any s) = pp_turn_state fmt s
+
+let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_state) () =
   let stop_signaled_before =
     match ctx with
     | None -> default_transition_context.stop_signaled_before
@@ -167,39 +216,39 @@ let classify_transition ?ctx ~from_state ~to_state () =
     | None -> true
     | Some _ -> stop_raised
   in
-  match from_state, to_state with
-  | Idle, Phase_gating when not stop_signaled_before ->
+  match Any from_state, Any to_state with
+  | Any Idle, Any Phase_gating when not stop_signaled_before ->
       Some StartTurn
-  | Phase_gating, Done when not stop_signaled_before ->
+  | Any Phase_gating, Any Done when not stop_signaled_before ->
       Some PhaseGateSkip
-  | Phase_gating, Cascade_routing when not stop_signaled_before ->
+  | Any Phase_gating, Any Cascade_routing when not stop_signaled_before ->
       Some PhaseGateOk
-  | Cascade_routing, Awaiting_provider when not stop_signaled_before ->
+  | Any Cascade_routing, Any Awaiting_provider when not stop_signaled_before ->
       Some CascadeRouted
-  | Cascade_routing, Failed (Failure_cascade_unavailable _)
+  | Any Cascade_routing, Any (Failed (Failure_cascade_unavailable _))
     when not stop_signaled_before ->
       Some CascadeUnavailable
-  | Awaiting_provider, Streaming when not stop_signaled_before ->
+  | Any Awaiting_provider, Any Streaming when not stop_signaled_before ->
       Some ProviderResponded
-  | Awaiting_provider, Cancelled Cancelled_provider_timeout
+  | Any Awaiting_provider, Any (Cancelled Cancelled_provider_timeout)
     when not stop_signaled_before ->
       Some ProviderTimeout
-  | Streaming, Awaiting_tool_result when not stop_signaled_before ->
+  | Any Streaming, Any Awaiting_tool_result when not stop_signaled_before ->
       Some StreamYieldsTool
-  | Awaiting_tool_result, Streaming when not stop_signaled_before ->
+  | Any Awaiting_tool_result, Any Streaming when not stop_signaled_before ->
       Some ToolReturned
-  | Streaming, Completing when not stop_signaled_before ->
+  | Any Streaming, Any Completing when not stop_signaled_before ->
       Some StreamComplete
-  | Completing, Done when not stop_signaled_before ->
+  | Any Completing, Any Done when not stop_signaled_before ->
       Some ContractOk
-  | Completing, Failed (Failure_tool_contract_violation _)
+  | Any Completing, Any (Failed (Failure_tool_contract_violation _))
     when not stop_signaled_before ->
       Some ContractViolation
-  | Completing, Failed (Failure_receipt_lost _)
+  | Any Completing, Any (Failed (Failure_receipt_lost _))
     when not stop_signaled_before ->
       Some ReceiptLost
-  | _, Failed _ when is_active from_state -> Some GenericFail
-  | _, Cancelled _ when is_active from_state && honor_stop_signal_allowed ->
+  | _, Any (Failed _) when is_active from_state -> Some GenericFail
+  | _, Any (Cancelled _) when is_active from_state && honor_stop_signal_allowed ->
       Some HonorStopSignal
   | _, _
     when supervisor_requests_stop_allowed
@@ -214,7 +263,7 @@ let classify_transition ?ctx ~from_state ~to_state () =
       Some TerminalStutter
   | _ -> None
 
-let assert_transition_allowed ?ctx ~from_state ~to_state () =
+let assert_transition_allowed ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_state) () =
   match classify_transition ?ctx ~from_state ~to_state () with
   | Some action -> Ok action
   | None ->
@@ -287,6 +336,13 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
    already terminated must not re-enter execution paths — was previously
    only guarded by reviewer-eye inspection of call sites. *)
 
-let require_active_state s = s
+let require_active_state : type a. a turn_state -> (unit, Types.masc_error) result = fun s ->
+  match s with
+  | Done | Failed _ | Cancelled _ ->
+      Error
+        (Types.Task (Types.Task_error.InvalidState
+           (Printf.sprintf "Terminal state %s cannot re-enter active paths"
+              (turn_state_label s))))
+  | _ -> Ok ()
 [@@fsm_guard
   "match s with Done | Failed _ | Cancelled _ -> false | _ -> true"]

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -44,18 +44,18 @@ type failure_reason =
     [docs/keeper-turn-lifecycle.md]; the runtime [run_keeper_cycle]
     is currently implicit across multiple files and Step 4b will
     introduce explicit transitions. *)
-type turn_state =
-  | Idle [@tla.idle]
-  | Phase_gating [@tla.active]
-  | Cascade_routing [@tla.active]
-  | Awaiting_provider [@tla.active]
-  | Streaming [@tla.active]
-  | Awaiting_tool_result [@tla.symbol "awaiting_tool"] [@tla.active]
-  | Completing [@tla.active]
-  | Done [@tla.terminal]
-  | Failed of failure_reason [@tla.terminal]
-  | Cancelled of cancel_reason [@tla.terminal]
-[@@deriving tla]
+type _ turn_state =
+  | Idle : [`Idle] turn_state [@tla.idle]
+  | Phase_gating : [`Phase_gating] turn_state [@tla.active]
+  | Cascade_routing : [`Cascade_routing] turn_state [@tla.active]
+  | Awaiting_provider : [`Awaiting_provider] turn_state [@tla.active]
+  | Streaming : [`Streaming] turn_state [@tla.active]
+  | Awaiting_tool_result : [`Awaiting_tool_result] turn_state [@tla.symbol "awaiting_tool"] [@tla.active]
+  | Completing : [`Completing] turn_state [@tla.active]
+  | Done : [`Done] turn_state [@tla.terminal]
+  | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
+  | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
+
 (** TLA+ symbol mapping derived by [ppx_tla].
 
     [to_tla_symbol] / [all_symbols] match [TurnStateSet], while
@@ -69,11 +69,12 @@ type turn_state =
 
 val cancel_reason_label : cancel_reason -> string
 val failure_reason_label : failure_reason -> string
-val turn_state_label : turn_state -> string
+val to_tla_symbol : _ turn_state -> string
+val turn_state_label : _ turn_state -> string
 
 val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
 val pp_failure_reason : Format.formatter -> failure_reason -> unit
-val pp_turn_state : Format.formatter -> turn_state -> unit
+val pp_turn_state : Format.formatter -> _ turn_state -> unit
 
 type transition_action =
   | StartTurn
@@ -124,8 +125,8 @@ type transition_violation = {
 
 val classify_transition :
   ?ctx:transition_context ->
-  from_state:turn_state ->
-  to_state:turn_state ->
+  from_state:_ turn_state ->
+  to_state:_ turn_state ->
   unit ->
   transition_action option
 (** Return the TLA+ action represented by an OCaml state edge, if the
@@ -143,12 +144,12 @@ val classify_transition :
 
 val assert_transition_allowed :
   ?ctx:transition_context ->
-  from_state:turn_state ->
-  to_state:turn_state ->
+  from_state:_ turn_state ->
+  to_state:_ turn_state ->
   unit ->
   (transition_action, transition_violation) result
 
-val require_active_state : turn_state -> turn_state
+val require_active_state : _ turn_state -> (unit, Types.masc_error) result
 (** Identity on [s]; runtime-asserts that [s] is not a terminal state
     ([Done], [Failed _], [Cancelled _]).
 
@@ -162,8 +163,8 @@ val emit_transition :
   ?ctx:transition_context ->
   keeper_name:string ->
   turn_id:int ->
-  ?prev:turn_state ->
-  turn_state ->
+  ?prev:_ turn_state ->
+  _ turn_state ->
   unit
 (** Emit a structured FSM transition log line.
 
@@ -181,3 +182,16 @@ val emit_transition :
     emitted only when [?ctx] is provided.  Stable for operator
     regex parsing and pinned by the [test_keeper_turn_fsm_emit]
     sentinel so a future signature drift fails the build. *)
+
+type any_state = Any : _ turn_state -> any_state
+val any_state_label : any_state -> string
+val pp_any_state : Format.formatter -> any_state -> unit
+
+val all_symbols : string list
+val active_symbols : string list
+val terminal_symbols : string list
+val idle_symbols : string list
+
+val is_active : _ turn_state -> bool
+val is_terminal : _ turn_state -> bool
+val is_idle : _ turn_state -> bool

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -41,17 +41,17 @@ let test_emit_transition_signature_stable () =
 (* ── Label coverage ────────────────────────────────────────── *)
 
 let test_turn_state_labels_cover_every_variant () =
-  let pairs : (F.turn_state * string) list =
-    [ F.Idle, "idle"
-    ; F.Phase_gating, "phase_gating"
-    ; F.Cascade_routing, "cascade_routing"
-    ; F.Awaiting_provider, "awaiting_provider"
-    ; F.Streaming, "streaming"
-    ; F.Awaiting_tool_result, "awaiting_tool"
-    ; F.Completing, "completing"
-    ; F.Done, "done"
-    ; F.Failed (F.Failure_runtime_error "x"), "failed:runtime_error"
-    ; F.Cancelled F.Cancelled_phase_gate_close, "cancelled:phase_gate_close"
+  let pairs : (F.any_state * string) list =
+    [ F.Any F.Idle, "idle"
+    ; F.Any F.Phase_gating, "phase_gating"
+    ; F.Any F.Cascade_routing, "cascade_routing"
+    ; F.Any F.Awaiting_provider, "awaiting_provider"
+    ; F.Any F.Streaming, "streaming"
+    ; F.Any F.Awaiting_tool_result, "awaiting_tool"
+    ; F.Any F.Completing, "completing"
+    ; F.Any F.Done, "done"
+    ; F.Any (F.Failed (F.Failure_runtime_error "x")), "failed:runtime_error"
+    ; F.Any (F.Cancelled F.Cancelled_phase_gate_close), "cancelled:phase_gate_close"
     ]
   in
   List.iter
@@ -59,7 +59,7 @@ let test_turn_state_labels_cover_every_variant () =
        Alcotest.(check string)
          ("turn_state_label " ^ expected)
          expected
-         (F.turn_state_label s))
+         (F.any_state_label s))
     pairs
 ;;
 

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -97,29 +97,29 @@ let test_pp_failure_reason_includes_payload () =
 
 (* ── Keeper_turn_fsm.turn_state ──────────────────────────────── *)
 
-let all_turn_states : Keeper_turn_fsm.turn_state list =
+let all_turn_states : Keeper_turn_fsm.any_state list =
   [
-    Idle;
-    Phase_gating;
-    Cascade_routing;
-    Awaiting_provider;
-    Streaming;
-    Awaiting_tool_result;
-    Completing;
-    Done;
-    Failed (Failure_runtime_error "x");
-    Cancelled Cancelled_supervisor_stop;
+    Keeper_turn_fsm.Any Idle;
+    Keeper_turn_fsm.Any Phase_gating;
+    Keeper_turn_fsm.Any Cascade_routing;
+    Keeper_turn_fsm.Any Awaiting_provider;
+    Keeper_turn_fsm.Any Streaming;
+    Keeper_turn_fsm.Any Awaiting_tool_result;
+    Keeper_turn_fsm.Any Completing;
+    Keeper_turn_fsm.Any Done;
+    Keeper_turn_fsm.Any (Failed (Failure_runtime_error "x"));
+    Keeper_turn_fsm.Any (Cancelled Cancelled_supervisor_stop);
   ]
 
 let test_turn_state_labels_unique () =
-  let labels = List.map Keeper_turn_fsm.turn_state_label all_turn_states in
+  let labels = List.map Keeper_turn_fsm.any_state_label all_turn_states in
   Alcotest.(check (list string))
     "no duplicate turn_state labels" [] (duplicates labels)
 
 let test_failed_label_carries_reason () =
   let s =
-    Keeper_turn_fsm.turn_state_label
-      (Failed (Failure_cascade_unavailable { base = "b"; resolved = None }))
+    Keeper_turn_fsm.any_state_label
+      (Keeper_turn_fsm.Any (Failed (Failure_cascade_unavailable { base = "b"; resolved = None })))
   in
   Alcotest.(check string)
     "Failed label uses 'failed:' prefix + reason"
@@ -127,7 +127,7 @@ let test_failed_label_carries_reason () =
 
 let test_cancelled_label_carries_reason () =
   let s =
-    Keeper_turn_fsm.turn_state_label (Cancelled Cancelled_fleet_shutdown)
+    Keeper_turn_fsm.any_state_label (Keeper_turn_fsm.Any (Cancelled Cancelled_fleet_shutdown))
   in
   Alcotest.(check string)
     "Cancelled label uses 'cancelled:' prefix + reason"


### PR DESCRIPTION
Implements the critical AST/PPX Contract fixes. Converts the keeper turn state machine to use true OCaml 5.x GADT syntax and replaces the deprecated V2.make_noarg ppxlib API.