### PR TITLE
fix(keeper): eliminate silent dispatch/write_meta failures + PPX fsm_guard routing

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -454,7 +454,7 @@ let keepers_section now : section =
   in
   let content = List.map format_entry sorted in
   let guard_violations =
-    Prometheus.metric_total "masc_fsm_guard_violation_total" |> int_of_float
+    Prometheus.metric_total Prometheus.metric_fsm_guard_violation |> int_of_float
   in
   let title =
     if guard_violations > 0
@@ -582,7 +582,7 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
         (List.length active_tasks) (List.length pending_tasks)
         (List.length blocked_tasks);
       let guard_violations =
-        Prometheus.metric_total "masc_fsm_guard_violation_total" |> int_of_float
+        Prometheus.metric_total Prometheus.metric_fsm_guard_violation |> int_of_float
       in
       Printf.sprintf "KEEPERS: %d running / %d dead / %d other | GUARD: %d violations"
         k_running k_dead k_other guard_violations;

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -453,7 +453,15 @@ let keepers_section now : section =
       e.name phase_str e.transition_seq since last_info
   in
   let content = List.map format_entry sorted in
-  { title = "Keepers"; content; empty_msg = "(no keepers registered)" }
+  let guard_violations =
+    Prometheus.metric_total "masc_fsm_guard_violation_total" |> int_of_float
+  in
+  let title =
+    if guard_violations > 0
+    then Printf.sprintf "Keepers (guard violations: %d)" guard_violations
+    else "Keepers"
+  in
+  { title; content; empty_msg = "(no keepers registered)" }
 
 (** Attention section: items requiring operator action *)
 let attention_section now (snapshots : room_snapshot list) : section =
@@ -573,6 +581,9 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
         working_count idle_count stuck_count offline_count
         (List.length active_tasks) (List.length pending_tasks)
         (List.length blocked_tasks);
-      Printf.sprintf "KEEPERS: %d running / %d dead / %d other"
-        k_running k_dead k_other;
+      let guard_violations =
+        Prometheus.metric_total "masc_fsm_guard_violation_total" |> int_of_float
+      in
+      Printf.sprintf "KEEPERS: %d running / %d dead / %d other | GUARD: %d violations"
+        k_running k_dead k_other guard_violations;
     ]

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -456,10 +456,16 @@ let keepers_section now : section =
   let guard_violations =
     Prometheus.metric_total Prometheus.metric_fsm_guard_violation |> int_of_float
   in
+  let write_meta_failures =
+    Prometheus.metric_total Prometheus.metric_keeper_write_meta_failures |> int_of_float
+  in
   let title =
-    if guard_violations > 0
-    then Printf.sprintf "Keepers (guard violations: %d)" guard_violations
-    else "Keepers"
+    match guard_violations, write_meta_failures with
+    | 0, 0 -> "Keepers"
+    | gv, 0 -> Printf.sprintf "Keepers (guard violations: %d)" gv
+    | 0, wm -> Printf.sprintf "Keepers (meta write errors: %d)" wm
+    | gv, wm ->
+        Printf.sprintf "Keepers (guard violations: %d, meta write errors: %d)" gv wm
   in
   { title; content; empty_msg = "(no keepers registered)" }
 
@@ -584,6 +590,9 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
       let guard_violations =
         Prometheus.metric_total Prometheus.metric_fsm_guard_violation |> int_of_float
       in
-      Printf.sprintf "KEEPERS: %d running / %d dead / %d other | GUARD: %d violations"
-        k_running k_dead k_other guard_violations;
+      let write_meta_failures =
+        Prometheus.metric_total Prometheus.metric_keeper_write_meta_failures |> int_of_float
+      in
+      Printf.sprintf "KEEPERS: %d running / %d dead / %d other | GUARD: %d | META-WRITE-ERR: %d"
+        k_running k_dead k_other guard_violations write_meta_failures;
     ]

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -97,6 +97,10 @@ let sync_current_task_id_from_backlog ~(config : Coord.config)
      with
      | Ok () -> ()
      | Error msg ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_write_meta_failures
+         ~labels:[("keeper", meta.name); ("phase", "reconcile_task_id")]
+         ();
        Log.Keeper.warn
          "keeper:%s failed to persist reconciled current_task_id=%s: %s"
          meta.name

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -178,6 +178,10 @@ let sync_keeper_meta_current_task
      with
      | Ok () -> ()
      | Error msg ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_write_meta_failures
+         ~labels:[("keeper", meta.name); ("phase", "claim_task_id")]
+         ();
        Log.Keeper.warn
          "keeper:%s failed to persist claimed current_task_id=%s: %s"
          meta.name task_id msg)

--- a/lib/keeper/keeper_goal_repair.ml
+++ b/lib/keeper/keeper_goal_repair.ml
@@ -88,6 +88,10 @@ let repair_keeper (config : Coord.config) (name : string) : (repair_action, stri
           let updated = { meta with active_goal_ids = [ goal.Goal_store.id ] } in
           (match Keeper_types.write_meta config updated with
            | Error e ->
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_write_meta_failures
+                 ~labels:[("keeper", name); ("phase", "goal_repair")]
+                 ();
                Error (Printf.sprintf "write_meta failed: %s" e)
            | Ok () ->
                Ok { keeper_name = name; goal_id = goal.Goal_store.id; goal_title = title })

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -95,9 +95,9 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
   if stale_turn_failures > 0 then begin
     Keeper_registry.reset_turn_failures
       ~base_path:ctx.config.base_path meta.name;
-    ignore (Keeper_registry.dispatch_event_and_log
+    Keeper_registry.dispatch_event_unit
       ~base_path:ctx.config.base_path meta.name
-      Keeper_state_machine.Heartbeat_ok);
+      Keeper_state_machine.Heartbeat_ok;
     Keeper_keepalive_signal.dispatch_keepalive_event ~ctx ~keeper_name:meta.name
       Keeper_state_machine.Turn_succeeded;
     Log.Keeper.info
@@ -145,19 +145,19 @@ let sync_keeper_presence
         (* RFC-0002: dispatch heartbeat failure *)
         Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_failures
           ~labels:[("keeper", meta_current.name)] ();
-        ignore (Keeper_registry.dispatch_event_and_log
+        Keeper_registry.dispatch_event_unit
           ~base_path:ctx.config.base_path meta_current.name
           (Keeper_state_machine.Heartbeat_failed {
             consecutive = !consecutive_failures;
             max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ();
-          })))
+          }))
       else (
         consecutive_failures := 0;
         last_successful_heartbeat_ts := Time_compat.now ();
         (* RFC-0002: dispatch heartbeat success *)
-        ignore (Keeper_registry.dispatch_event_and_log
+        Keeper_registry.dispatch_event_unit
           ~base_path:ctx.config.base_path meta_current.name
-          Keeper_state_machine.Heartbeat_ok);
+          Keeper_state_machine.Heartbeat_ok;
         Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_successes
           ~labels:[("keeper", meta_current.name)] ();
         maybe_recover_from_failing ~ctx ~meta:meta_current);
@@ -178,12 +178,12 @@ let sync_keeper_presence
         (Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ())
         (Printexc.to_string exn);
       (* RFC-0002: dispatch heartbeat failure *)
-      ignore (Keeper_registry.dispatch_event_and_log
+      Keeper_registry.dispatch_event_unit
         ~base_path:ctx.config.base_path meta_current.name
         (Keeper_state_machine.Heartbeat_failed {
           consecutive = !consecutive_failures;
           max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ();
-        }));
+        });
       meta_current)
 ;;
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1147,13 +1147,9 @@ let run_heartbeat_loop
               ~proactive_warmup_elapsed
               ~shared_context
           in
-          Keeper_fsm_guard_runtime.wrap_unit
-            ~action:"TurnComplete" ~stage:"pre"
-            (fun () -> Keeper_keepalive_signal.pre_turn_complete_heartbeat ~turn_running);
+          Keeper_keepalive_signal.pre_turn_complete_heartbeat ~turn_running;
           turn_running := false;
-          Keeper_fsm_guard_runtime.wrap_unit
-            ~action:"TurnComplete" ~stage:"post"
-            (fun () -> Keeper_keepalive_signal.post_turn_complete_heartbeat ~turn_running);
+          Keeper_keepalive_signal.post_turn_complete_heartbeat ~turn_running;
           r
         in
         (* Turn failure threshold: registry tracks count (via unified_turn),

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -116,12 +116,11 @@ let set_keeper_paused_state ~agent_name paused =
          }
        in
        persist_directive_meta_update entry ~updated_meta;
-       ignore
-         (Keeper_registry.dispatch_event
-            ~base_path:entry.base_path entry.name
-            (if paused
-             then Keeper_state_machine.Operator_pause
-             else Keeper_state_machine.Operator_resume));
+       Keeper_registry.dispatch_event_unit
+         ~base_path:entry.base_path entry.name
+         (if paused
+          then Keeper_state_machine.Operator_pause
+          else Keeper_state_machine.Operator_resume);
        if not paused then begin
          (* tla-lint: allow-mutation: fiber signal — Atomic flag wakes the keeper from Eio.Promise.await *)
          Atomic.set entry.fiber_wakeup true;

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -125,10 +125,10 @@ let set_keeper_paused_state ~agent_name paused =
        if not paused then begin
          (* tla-lint: allow-mutation: fiber signal — Atomic flag wakes the keeper from Eio.Promise.await *)
          Atomic.set entry.fiber_wakeup true;
-         (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition. *)
-         Keeper_fsm_guard_runtime.wrap_unit
-           ~action:"WakeupSignal" ~stage:"post"
-           (fun () -> post_wakeup_signal ~wakeup:entry.fiber_wakeup)
+         (* Cycle 43: KeeperHeartbeat.tla WakeupSignal post-condition.
+            The [@@fsm_guard] PPX routes the assertion through
+            [wrap_unit ~stage:"guard"] automatically. *)
+         post_wakeup_signal ~wakeup:entry.fiber_wakeup
        end)
 ;;
 
@@ -156,10 +156,10 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
        persist_directive_meta_update entry ~updated_meta;
        (* Cycle 44: KeeperTaskAcquisition.tla SubmitTask post-action
           guard pins that the directive successfully attached the
-          [task_id] to the keeper's meta. *)
-       Keeper_fsm_guard_runtime.wrap_unit
-         ~action:"SubmitTask" ~stage:"post"
-         (fun () -> post_submit_task ~meta:updated_meta ~task_id);
+          [task_id] to the keeper's meta. The [@@fsm_guard] PPX
+          routes the assertion through [wrap_unit ~stage:"guard"]
+          automatically. *)
+       post_submit_task ~meta:updated_meta ~task_id;
        wakeup_keeper ~base_path:entry.base_path entry.name)
 ;;
 
@@ -673,9 +673,7 @@ let stop_keepalive ?base_path name =
           even on stop_keepalive — the wakeup atomic must be observable
           as TRUE before the heartbeat fiber consumes its termination
           signal. *)
-       Keeper_fsm_guard_runtime.wrap_unit
-         ~action:"WakeupSignal" ~stage:"post"
-         (fun () -> post_wakeup_signal ~wakeup:entry.fiber_wakeup);
+       post_wakeup_signal ~wakeup:entry.fiber_wakeup;
        (match Atomic.get entry.grpc_close with
        | Some close_fn ->
           (try close_fn () with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -496,10 +496,10 @@ let record_keeper_stopped
   =
   if resolve_registry_done entry `Stopped
   then (
-    ignore (Keeper_registry.dispatch_event_and_log ~base_path keeper_name
-      Keeper_state_machine.Stop_requested);
-    ignore (Keeper_registry.dispatch_event_and_log ~base_path keeper_name
-      Keeper_state_machine.Drain_complete);
+    Keeper_registry.dispatch_event_unit ~base_path keeper_name
+      Keeper_state_machine.Stop_requested;
+    Keeper_registry.dispatch_event_unit ~base_path keeper_name
+      Keeper_state_machine.Drain_complete;
     publish_keeper_phase_lifecycle ~phase:Keeper_state_machine.Stopped
       ~keeper_name ~detail ();
     true)
@@ -518,8 +518,8 @@ let record_keeper_crashed
   if resolve_registry_done entry (`Crashed reason)
   then (
     Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);
-    ignore (Keeper_registry.dispatch_event_and_log ~base_path keeper_name
-      (Keeper_state_machine.Fiber_terminated { outcome = reason }));
+    Keeper_registry.dispatch_event_unit ~base_path keeper_name
+      (Keeper_state_machine.Fiber_terminated { outcome = reason });
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
     Keeper_registry.record_error ~base_path keeper_name reason;
     publish_keeper_phase_lifecycle ~phase:Keeper_state_machine.Crashed

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -365,8 +365,8 @@ let keepalive_entry_accepts_late_event ~(ctx : _ context) ~(keeper_name : string
 
 let dispatch_keepalive_event ~(ctx : _ context) ~(keeper_name : string) event =
   if keepalive_entry_accepts_late_event ~ctx ~keeper_name then
-    ignore (Keeper_registry.dispatch_event_and_log
-      ~base_path:ctx.config.base_path keeper_name event)
+    Keeper_registry.dispatch_event_unit
+      ~base_path:ctx.config.base_path keeper_name event
 
 let dispatch_keepalive_event_with_audit
       ~(ctx : _ context)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -103,10 +103,9 @@ let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
             Atomic.compare_and_set wakeup true false
     then (
       (* Cycle 43: post-action guard mirrors the spec's [wakeup_signaled =
-         FALSE] postcondition. Counter-mode by default. *)
-      Keeper_fsm_guard_runtime.wrap_unit
-        ~action:"HeartbeatTick" ~stage:"post"
-        (fun () -> post_heartbeat_tick ~wakeup);
+         FALSE] postcondition. The [@@fsm_guard] PPX routes the
+         assertion through [wrap_unit ~stage:"guard"] automatically. *)
+      post_heartbeat_tick ~wakeup;
       Woken)
     else if remaining <= 0.0
     then Timeout

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -377,10 +377,17 @@ let dispatch_keepalive_event_with_audit
       event
   =
   if keepalive_entry_accepts_late_event ~ctx ~keeper_name then
-    ignore (Keeper_registry.dispatch_event_with_audit_and_log
-      ~base_path:ctx.config.base_path
-      ~snapshot
-      ~events_fired
-      ~selected_event
-      keeper_name
-      event)
+    (match Keeper_registry.dispatch_event_with_audit_and_log
+       ~base_path:ctx.config.base_path
+       ~snapshot
+       ~events_fired
+       ~selected_event
+       keeper_name
+       event
+     with
+     | Ok _ -> ()
+     | Error err ->
+         Log.Keeper.warn
+           "%s: keepalive late-event dispatch rejected: %s"
+           keeper_name
+           (Keeper_state_machine.transition_error_to_string err))

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1336,10 +1336,7 @@ let dispatch_event_and_log ~base_path name event =
 let dispatch_event_unit ~base_path name event =
   match dispatch_event_and_log ~base_path name event with
   | Ok _ -> ()
-  | Error e ->
-    Log.Keeper.warn "dispatch_event_unit: keeper=%s error=%s"
-      name
-      (Keeper_state_machine.transition_error_to_string e)
+  | Error _ -> ()
 
 let dispatch_event_with_audit_and_log ~base_path ?snapshot ?events_fired ?selected_event name event =
   match dispatch_event_with_audit ~base_path ?snapshot ?events_fired ?selected_event name event with

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1333,6 +1333,14 @@ let dispatch_event_and_log ~base_path name event =
       ();
     Error e
 
+let dispatch_event_unit ~base_path name event =
+  match dispatch_event_and_log ~base_path name event with
+  | Ok _ -> ()
+  | Error e ->
+    Log.Keeper.warn "dispatch_event_unit: keeper=%s error=%s"
+      name
+      (Keeper_state_machine.transition_error_to_string e)
+
 let dispatch_event_with_audit_and_log ~base_path ?snapshot ?events_fired ?selected_event name event =
   match dispatch_event_with_audit ~base_path ?snapshot ?events_fired ?selected_event name event with
   | Ok tr -> Ok tr

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -505,9 +505,10 @@ val dispatch_event_and_log :
   base_path:string -> string -> Keeper_state_machine.event ->
   (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
 
-(** [dispatch_event_unit] calls [dispatch_event_and_log] and discards the
-    result, emitting a [Log.Keeper.warn] on [Error] instead of silently
-    ignoring transition failures.  Replaces [ignore (dispatch_event_and_log ...)]
+(** [dispatch_event_unit] is a convenience wrapper around
+    [dispatch_event_and_log] that discards the result, returning [unit].
+    Transition failures are already logged and counted by the underlying
+    [dispatch_event] call chain; this replaces [ignore (dispatch_event_and_log ...)]
     call sites. *)
 val dispatch_event_unit :
   base_path:string -> string -> Keeper_state_machine.event -> unit

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -505,6 +505,13 @@ val dispatch_event_and_log :
   base_path:string -> string -> Keeper_state_machine.event ->
   (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
 
+(** [dispatch_event_unit] calls [dispatch_event_and_log] and discards the
+    result, emitting a [Log.Keeper.warn] on [Error] instead of silently
+    ignoring transition failures.  Replaces [ignore (dispatch_event_and_log ...)]
+    call sites. *)
+val dispatch_event_unit :
+  base_path:string -> string -> Keeper_state_machine.event -> unit
+
 (** Like [dispatch_event_with_audit], but logs and emits a Prometheus
     counter on [Error]. *)
 val dispatch_event_with_audit_and_log :

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -559,6 +559,10 @@ let ensure_keeper_meta config name =
       match write_meta config updated with
       | Ok () -> Ok updated
       | Error e ->
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_write_meta_failures
+          ~labels:[("keeper", updated.name); ("phase", "ensure_meta_resync")]
+          ();
         Log.Keeper.warn "ensure_keeper_meta: write_meta re-sync failed: %s" e;
         Ok meta
     end

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -581,11 +581,19 @@ let cleanup_dead_tombstone (ctx : _ context)
           with
           | Ok () -> true
           | Error err when is_version_conflict_error err ->
+              Prometheus.inc_counter
+                Prometheus.metric_keeper_write_meta_failures
+                ~labels:[("keeper", entry.name); ("phase", "dead_cleanup_cas_race")]
+                ();
               Log.Keeper.warn
                 "%s: dead tombstone cleanup paused write lost CAS race after retries: %s"
                 entry.name err;
               false
           | Error err ->
+              Prometheus.inc_counter
+                Prometheus.metric_keeper_write_meta_failures
+                ~labels:[("keeper", entry.name); ("phase", "dead_cleanup")]
+                ();
               Log.Keeper.warn
                 "%s: dead tombstone cleanup paused write failed: %s"
                 entry.name err;
@@ -852,6 +860,10 @@ let handle_crash_auto_pause (ctx : _ context)
         with
         | Ok () -> ()
         | Error err ->
+            Prometheus.inc_counter
+              Prometheus.metric_keeper_write_meta_failures
+              ~labels:[("keeper", entry.name); ("phase", "blocker_pause")]
+              ();
             Log.Keeper.warn
               "%s: %s pause meta write failed (in-memory \
                failure_reason still gates restart, but persisted state \
@@ -1211,6 +1223,10 @@ let sweep_and_recover (ctx : _ context) =
                            (Env_config.KeeperSupervisor.auto_resume_max_sec)
                            (resume_after_sec *. 2.0))
                   | Error err ->
+                      Prometheus.inc_counter
+                        Prometheus.metric_keeper_write_meta_failures
+                        ~labels:[("keeper", name); ("phase", "auto_resume")]
+                        ();
                       Log.Keeper.warn
                         "%s: auto-resume meta write failed: %s"
                         name err)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -277,8 +277,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               Keeper_crash_persistence.enqueue_record ~keepers_dir
                 ~name:meta.name ~ts ~reason ~restart_count:rc;
               Keeper_registry.record_error ~base_path meta.name reason;
-              ignore (Keeper_registry.dispatch_event_and_log ~base_path meta.name
-                (Keeper_state_machine.Fiber_terminated { outcome = reason }));
+              Keeper_registry.dispatch_event_unit ~base_path meta.name
+                (Keeper_state_machine.Fiber_terminated { outcome = reason });
               if resolve_done (`Crashed reason) then
                 publish_phase_lifecycle ~phase:Keeper_state_machine.Crashed
                   meta.name reason ()
@@ -1005,8 +1005,8 @@ let sweep_and_recover (ctx : _ context) =
   ) !to_unregister;
   List.iter (fun ((entry : Keeper_registry.registry_entry), msg) ->
     (* RFC-0002: dispatch budget exhaustion before marking dead *)
-    ignore (Keeper_registry.dispatch_event_and_log ~base_path entry.name
-      Keeper_state_machine.Restart_budget_exhausted);
+    Keeper_registry.dispatch_event_unit ~base_path entry.name
+      Keeper_state_machine.Restart_budget_exhausted;
     Keeper_registry.mark_dead ~base_path entry.name ~at:now;
     let detail =
       Printf.sprintf "restart budget exhausted (%d), last: %s"
@@ -1058,8 +1058,8 @@ let sweep_and_recover (ctx : _ context) =
     match read_meta ctx.config old_entry.name with
     | Ok (Some meta) ->
         (* RFC-0002: dispatch restart attempt event *)
-        ignore (Keeper_registry.dispatch_event_and_log ~base_path old_entry.name
-          (Keeper_state_machine.Supervisor_restart_attempt { attempt }));
+        Keeper_registry.dispatch_event_unit ~base_path old_entry.name
+          (Keeper_state_machine.Supervisor_restart_attempt { attempt });
         let old_crash_log = old_entry.crash_log in
         let reg =
           Keeper_registry.register_restarting ~base_path old_entry.name meta

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -431,9 +431,8 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
     resumed_meta.name None;
   Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path
     resumed_meta.name;
-  ignore
-    (Keeper_registry.dispatch_event ~base_path:ctx.config.base_path
-       resumed_meta.name Keeper_state_machine.Operator_resume);
+  Keeper_registry.dispatch_event_unit ~base_path:ctx.config.base_path
+    resumed_meta.name Keeper_state_machine.Operator_resume;
   match Keeper_registry.get ~base_path:ctx.config.base_path resumed_meta.name with
   | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
       (* tla-lint: allow-mutation: fiber signal — wake the keeper after operator resume *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -365,6 +365,10 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
         (match write_meta ctx.config synced with
          | Ok () -> ()
          | Error msg ->
+           Prometheus.inc_counter
+             Prometheus.metric_keeper_write_meta_failures
+             ~labels:[("keeper", meta.name); ("phase", "presence_sync")]
+             ();
            Log.Keeper.warn
              "supervisor presence sync: write_meta failed for %s: %s"
              meta.name msg);
@@ -418,10 +422,18 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
    with
    | Ok () -> ()
    | Error err when is_version_conflict_error err ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_write_meta_failures
+         ~labels:[("keeper", resumed_meta.name); ("phase", "reconcile_resume_cas_race")]
+         ();
        Log.Keeper.warn
          "%s: reconcile gate resume write_meta lost CAS race after retries: %s"
          resumed_meta.name err
    | Error err ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_write_meta_failures
+         ~labels:[("keeper", resumed_meta.name); ("phase", "reconcile_resume")]
+         ();
        Log.Keeper.error
          "%s: reconcile gate resume write_meta failed: %s"
          resumed_meta.name err);

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -485,6 +485,16 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                with
                | Ok () -> ()
                | Error msg ->
+                   Prometheus.inc_counter
+                     Prometheus.metric_keeper_write_meta_failures
+                     ~labels:
+                       [ ("keeper", updated_meta.name);
+                         ("phase",
+                          if is_version_conflict_error msg
+                          then "keeper_msg_turn_cas_race"
+                          else "keeper_msg_turn")
+                       ]
+                     ();
                    if is_version_conflict_error msg then
                      Log.Keeper.warn
                        "write_meta lost CAS race after retries (keeper_msg turn): %s"

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -492,10 +492,18 @@ let pause_keeper_for_overflow
    with
    | Ok () -> ()
    | Error err when is_version_conflict_error err ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_write_meta_failures
+         ~labels:[("keeper", meta.name); ("phase", "overflow_pause_cas_race")]
+         ();
        Log.Keeper.warn
          "%s: overflow pause write_meta lost CAS race after retries: %s"
          meta.name err
    | Error err ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_write_meta_failures
+         ~labels:[("keeper", meta.name); ("phase", "overflow_pause")]
+         ();
        Log.Keeper.error
          "%s: overflow pause write_meta failed: %s"
          meta.name err);

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -554,6 +554,12 @@ let sync_keeper_paused_state
       config synced_meta
   with
   | Error err ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_write_meta_failures
+        ~labels:[("keeper", meta.name);
+                 ("phase",
+                  if paused then "pause_sync" else "resume_sync")]
+        ();
       Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
         ~config
         ~keeper_name:meta.name

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -49,6 +49,10 @@ let handle_keeper_down ctx args : tool_result =
          ((match write_meta ctx.config retained with
            | Ok () -> ()
            | Error err ->
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_write_meta_failures
+                 ~labels:[("keeper", name); ("phase", "keeper_down")]
+                 ();
                Log.Keeper.error "keeper_down write_meta failed: %s" err);
           Keeper_registry.update_meta ~base_path:ctx.config.base_path name retained;
           Keeper_registry.dispatch_event_unit ~base_path:ctx.config.base_path name

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -51,8 +51,8 @@ let handle_keeper_down ctx args : tool_result =
            | Error err ->
                Log.Keeper.error "keeper_down write_meta failed: %s" err);
           Keeper_registry.update_meta ~base_path:ctx.config.base_path name retained;
-          ignore (Keeper_registry.dispatch_event_and_log ~base_path:ctx.config.base_path name
-            Keeper_state_machine.Operator_pause)));
+          Keeper_registry.dispatch_event_unit ~base_path:ctx.config.base_path name
+            Keeper_state_machine.Operator_pause));
       if remove_session then (
         let rec rm_rf path =
           if Fs_compat.file_exists path then begin

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -51,9 +51,16 @@ let handle_keeper_down ctx args : tool_result =
            | Error err ->
                Prometheus.inc_counter
                  Prometheus.metric_keeper_write_meta_failures
-                 ~labels:[("keeper", name); ("phase", "keeper_down")]
+                 ~labels:[("keeper", name);
+                          ("phase",
+                           if Keeper_meta_store.is_version_conflict_error err
+                           then "keeper_down_cas_race"
+                           else "keeper_down")]
                  ();
-               Log.Keeper.error "keeper_down write_meta failed: %s" err);
+               if Keeper_meta_store.is_version_conflict_error err then
+                 Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
+               else
+                 Log.Keeper.error "keeper_down write_meta failed: %s" err);
           Keeper_registry.update_meta ~base_path:ctx.config.base_path name retained;
           Keeper_registry.dispatch_event_unit ~base_path:ctx.config.base_path name
             Keeper_state_machine.Operator_pause));

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -532,6 +532,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
       match write_initial_meta ctx.config meta with
       | Error e ->
+        Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
+          ~labels:[("keeper", p.name); ("phase", "create_keeper")] ();
         Log.Keeper.error "create_keeper failed: write_meta error for name=%s: %s" p.name e;
         Progress.stop_tracking task_id;
         (false, e)

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -308,7 +308,12 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
            (false, err)
        | Ok () ->
       (match write_meta ctx.config updated with
-       | Error e -> (false, e)
+       | Error e ->
+           Prometheus.inc_counter
+             Prometheus.metric_keeper_write_meta_failures
+             ~labels:[("keeper", updated.name); ("phase", "update_keeper")]
+             ();
+           (false, e)
        | Ok () ->
          stop_keepalive ~base_path:ctx.config.base_path updated.name;
          start_keepalive ctx updated;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -728,6 +728,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             with
             | Ok () -> ()
             | Error err ->
+                Prometheus.inc_counter
+                  Prometheus.metric_keeper_write_meta_failures
+                  ~labels:
+                    [("keeper", entry.meta.name); ("phase", "turn_start")]
+                  ();
                 Log.Keeper.warn
                   "%s: turn-start write_meta_with_merge failed: %s"
                   entry.meta.name err
@@ -1607,6 +1612,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            with
            | Ok () -> ()
            | Error msg ->
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_write_meta_failures
+                 ~labels:
+                   [ ("keeper", updated_meta.name);
+                     ("phase",
+                      if is_version_conflict_error msg
+                      then "turn_failure_cas_race"
+                      else "turn_failure")
+                   ]
+                 ();
                if is_version_conflict_error msg then
                  Log.Keeper.warn
                    "write_meta lost CAS race after retries (turn failure path): %s" msg
@@ -2101,6 +2116,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            with
            | Ok () -> ()
            | Error msg ->
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_write_meta_failures
+                 ~labels:
+                   [ ("keeper", updated_meta.name);
+                     ("phase",
+                      if is_version_conflict_error msg
+                      then "keeper_cycle_cas_race"
+                      else "keeper_cycle")
+                   ]
+                 ();
                if is_version_conflict_error msg then
                  Log.Keeper.warn
                    "write_meta lost CAS race after retries (keeper cycle): %s" msg

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -721,10 +721,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let meta =
         match Keeper_registry.get ~base_path:config.base_path meta.name with
         | Some entry ->
-          let _ =
-            write_meta_with_merge
+          let () =
+            match write_meta_with_merge
               ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
               config entry.meta
+            with
+            | Ok () -> ()
+            | Error err ->
+                Log.Keeper.warn
+                  "%s: turn-start write_meta_with_merge failed: %s"
+                  entry.meta.name err
           in
           entry.meta
         | None -> meta

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1821,16 +1821,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                if any_pending then "turn" else "scheduled_autonomous"
              in
              (* Cycle 44: KeeperTaskAcquisition.tla post-action guards
-                pin the structural invariant the decision relied on. *)
+                pin the structural invariant the decision relied on.
+                The [@@fsm_guard] PPX now routes assertions through
+                [Keeper_fsm_guard_runtime.wrap_unit ~stage:"guard"]
+                automatically, so the manual outer wrap is removed to
+                avoid double-counting Prometheus violations. *)
              if any_pending
-             then
-               Keeper_fsm_guard_runtime.wrap_unit
-                 ~action:"AssignTask" ~stage:"post"
-                 (fun () -> post_assign_task ~any_pending ~channel)
-             else
-               Keeper_fsm_guard_runtime.wrap_unit
-                 ~action:"EmptyQueueSleep" ~stage:"post"
-                 (fun () -> post_empty_queue_sleep ~any_pending ~channel);
+             then post_assign_task ~any_pending ~channel
+             else post_empty_queue_sleep ~any_pending ~channel;
              Keeper_unified_metrics.append_metrics_snapshot ~config ~meta:updated_meta ~observation
                ~result ~latency_ms ~turn_cost
                ~turn_generation:lifecycle.turn_generation
@@ -2137,11 +2135,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             Keeper_turn_fsm.Done;
           (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action
              — the cycle ran to completion and is about to return an
-             [Ok] result. *)
+             [Ok] result.  Manual [wrap_unit] removed: the PPX-injected
+             [wrap_unit ~stage:"guard"] already routes [Assert_failure]
+             to the Prometheus counter. *)
           cycle_completed := true;
-          Keeper_fsm_guard_runtime.wrap_unit
-            ~action:"TurnComplete" ~stage:"post"
-            (fun () -> post_turn_complete_task ~cycle_completed);
+          post_turn_complete_task ~cycle_completed;
           Ok updated_meta))
 
 let run_unified_turn = run_keeper_cycle

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -227,4 +227,4 @@ let () =
   test_fsm_guard_labeled_pass ();
   test_fsm_guard_labeled_fail ();
   test_wrap_unit_routing_labeled ();
-  print_endline "ppx_tla cycle 2 + 3 + 12 tests: PASS"
+  print_endline "ppx_tla cycle 2 + 3 + 15 tests: PASS"

--- a/test/ppx_tla/test_basic.ml
+++ b/test/ppx_tla/test_basic.ml
@@ -180,6 +180,32 @@ let test_wrap_unit_routing_curried () =
   assert (action = "g_curried");
   assert (stage = "guard")
 
+(* Labeled-only arguments: the PPX should inject the wrapped assert into
+   the function body regardless of whether parameters are labelled. *)
+let h_labeled ~x ~y = x * y
+[@@fsm_guard "x >= 0 && y >= 0"]
+
+let test_fsm_guard_labeled_pass () =
+  assert (h_labeled ~x:3 ~y:4 = 12)
+
+let test_fsm_guard_labeled_fail () =
+  let raised =
+    try
+      ignore (h_labeled ~x:(-1) ~y:2);
+      false
+    with Assert_failure _ -> true
+  in
+  assert raised
+
+let test_wrap_unit_routing_labeled () =
+  Keeper_fsm_guard_runtime.reset_invocations ();
+  let _ = h_labeled ~x:1 ~y:2 in
+  let invocations = Keeper_fsm_guard_runtime.get_invocations () in
+  assert (List.length invocations >= 1);
+  let (action, stage) = List.hd invocations in
+  assert (action = "h_labeled");
+  assert (stage = "guard")
+
 let () =
   test_color_to_tla_symbol ();
   test_color_all_states ();
@@ -198,4 +224,7 @@ let () =
   test_fsm_guard_curried_fail ();
   test_wrap_unit_routing ();
   test_wrap_unit_routing_curried ();
+  test_fsm_guard_labeled_pass ();
+  test_fsm_guard_labeled_fail ();
+  test_wrap_unit_routing_labeled ();
   print_endline "ppx_tla cycle 2 + 3 + 12 tests: PASS"


### PR DESCRIPTION
## Summary

### Phase 1: PPX fsm_guard assert routing
- PPX `[@@fsm_guard]` now generates `Keeper_fsm_guard_runtime.wrap_unit ~action:<fn> ~stage:"guard" (fun () -> assert expr); <body>` instead of bare `assert`
- Sequence pattern preserves return types: assert isolated in unit thunk, original body follows
- Removed 7 manual `wrap_unit ~stage:"pre"/"post"` call sites that caused double-counter bumps on assertion failure
- `keeper_turn_fsm.ml` guard_transition kept as-is (wraps direct assert, not identity helper)

### Phase 2: Silent dispatch failure elimination
- Added `Keeper_registry.dispatch_event_unit` helper: calls `dispatch_event_and_log`, logs warning on `Error`, returns `unit`
- Replaced 14 `ignore(Keeper_registry.dispatch_event_and_log ...)` / `ignore(Keeper_registry.dispatch_event ...)` call sites across 6 files with `dispatch_event_unit`
- All sites now emit `metric_keeper_dispatch_event_failures` Prometheus counter and log warnings instead of silently discarding transition errors

### Phase 3: write_meta_with_merge silent failure fix
- `keeper_unified_turn.ml` turn-start path used `let _ =` to discard `write_meta_with_merge` result
- Now matches on `Ok/Error` and logs the failure reason, matching the pattern used elsewhere in the codebase

### Phase 4: write_meta_failure Prometheus metric coverage
- 11 `write_meta` failure sites across 6 files only logged errors without emitting Prometheus counters
- The metric `masc_keeper_write_meta_failures_total` already existed but was only used in 5 sites (heartbeat_loop, keepalive)
- Each failure site now emits the counter with labels: `keeper` (name) and `phase` (specific context like `turn_start`, `turn_failure`, `keeper_cycle`, `keeper_down`, `presence_sync`, `reconcile_resume`, `overflow_pause`, `ensure_meta_resync`, `keeper_msg_turn`, plus `_cas_race` variants for CAS race exhaustion)

### Phase 5: Remaining silent failure elimination
- `keeper_keepalive_signal.ml`: replaced `ignore(dispatch_event_with_audit_and_log ...)` with proper error match + warn logging
- `keeper_turn_up_create.ml`: added `metric_keeper_write_meta_failures` to create_keeper write_meta failure path
- `keeper_turn_lifecycle.ml`: added CAS race detection to keeper_down write_meta, splitting log levels (WARN for version conflict, ERROR for genuine failures)

## Test plan
- [x] `dune runtest test/ppx_tla/` passes (wrap_unit routing verification + curried form)
- [x] `dune build --root . @check` compiles clean after all changes
- [ ] Full `dune runtest` pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)