### PR TITLE
fix: error hierarchy code() granularity and validation semantics

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -493,7 +493,7 @@ let ensure_sandbox_clone_ready candidate =
       Error
         (System (System_error.IoError
            (Printf.sprintf
-              "sandbox_clone_invalid: %s has a .git marker but is not a usable \               git clone: %s"
+              "sandbox_clone_invalid: %s has a .git marker but is not a usable git clone: %s"
               candidate detail)))
 
 let keeper_toml_path ~config ~agent_name =

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -128,7 +128,7 @@ let build_verdict_sse_payload
 
 (** Validate task_id is non-empty. Prevents phantom operations on empty IDs. *)
 let validate_task_id task_id =
-  if String.equal task_id "" then Error (Types.Task (Types.Task_error.NotFound ""))
+  if String.equal task_id "" then Error (Types.Task (Types.Task_error.InvalidId "empty task ID"))
   else Ok task_id
 
 let sync_planning_current_task_with_owned_task (ctx : context) =

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -220,7 +220,10 @@ let to_yojson err =
   `String (to_string err)
 
 let code = function
+  | Auth (Auth_error.Forbidden _) -> 403
   | Auth _ -> 401
+  | Task (Task_error.NotFound _) -> 404
+  | Agent (Agent_error.NotFound _) -> 404
   | Task _ | Agent _ | Portal _ | System _ -> 400
   | RateLimitExceeded _ -> 429
   | _ -> 500


### PR DESCRIPTION
## Summary
- `code()`: `Auth(Forbidden _)` → 403, `Task(Agent NotFound _)` → 404 (was all 401/400)
- `validate_task_id`: empty input returns `InvalidId "empty task ID"` (was `NotFound ""`)
- `coord_worktree`: remove backslash from string literal in `ensure_sandbox_clone_ready`

Closes #12772

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` passes (running in background)
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)