### PR TITLE
refactor(dashboard): migrate provider-matrix to design system semantic tokens

### DIFF
--- a/dashboard/src/components/provider-capability-matrix/anti-patterns.ts
+++ b/dashboard/src/components/provider-capability-matrix/anti-patterns.ts
@@ -29,57 +29,49 @@ export function AntiPatternList() {
         <div class="flex gap-1">
           <button
             type="button"
-            class="px-2 py-0.5 rounded text-[10px] font-mono border transition-colors ${
-              categoryFilter.value === 'all'
-                ? 'border-[var(--color-border-strong)] bg-[var(--white-8)] text-[var(--color-fg-primary)]'
-                : 'border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:border-[var(--color-border-strong)]'
-            }"
+            class="pm-filter ${categoryFilter.value === 'all' ? 'is-active' : ''}"
             onClick=${() => { categoryFilter.value = 'all' }}
           >전체 (${ANTI_PATTERNS.length})</button>
           ${categories.map(cat => html`
             <button
               key=${cat}
               type="button"
-              class="px-2 py-0.5 rounded text-[10px] font-mono border transition-colors ${
-                categoryFilter.value === cat
-                  ? 'border-[var(--color-border-strong)] bg-[var(--white-8)] text-[var(--color-fg-primary)]'
-                  : 'border-[var(--color-border-default)] text-[var(--color-fg-muted)] hover:border-[var(--color-border-strong)]'
-              }"
+              class="pm-filter ${categoryFilter.value === cat ? 'is-active' : ''}"
               onClick=${() => { categoryFilter.value = cat }}
             >${categoryLabel(cat)} (${ANTI_PATTERNS.filter(ap => ap.category === cat).length})</button>
           `)}
         </div>
-        <div class="flex gap-2 text-[10px] font-mono text-[var(--color-fg-muted)]">
-          <span>C:<strong class="text-[var(--color-status-err)]">${riskCounts.C}</strong></span>
-          <span>H:<strong class="text-[var(--color-status-err)]">${riskCounts.H}</strong></span>
-          <span>M:<strong class="text-[var(--color-status-warn)]">${riskCounts.M}</strong></span>
-          <span>L:<strong class="text-[var(--color-fg-muted)]">${riskCounts.L}</strong></span>
+        <div class="flex gap-2 t-caption">
+          <span>C:<strong class="t-err">${riskCounts.C}</strong></span>
+          <span>H:<strong class="t-err">${riskCounts.H}</strong></span>
+          <span>M:<strong class="t-warn">${riskCounts.M}</strong></span>
+          <span>L:<strong>${riskCounts.L}</strong></span>
         </div>
       </div>
 
-      <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-        <table class="w-full text-xs border-collapse">
-          <thead>
-            <tr class="bg-[var(--white-4)]">
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] w-[50px]">ID</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] w-[100px]">분류</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">설명</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] w-[160px]">위치</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] w-[60px]">리스크</th>
+      <div class="pm-scroll">
+        <table class="pm-table">
+          <thead class="pm-thead">
+            <tr>
+              <th class="pm-th w-[50px]">ID</th>
+              <th class="pm-th w-[100px]">분류</th>
+              <th class="pm-th">설명</th>
+              <th class="pm-th w-[160px]">위치</th>
+              <th class="pm-th w-[60px]">리스크</th>
             </tr>
           </thead>
           <tbody>
-            ${filtered.map((ap, i) => html`
-              <tr key=${ap.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 font-mono text-[var(--color-fg-muted)]">${ap.id}</td>
-                <td class="border-b border-[var(--color-border-default)] px-3 py-1.5">
-                  <span class="inline-block rounded border px-1.5 py-0.5 text-[10px] font-mono ${categoryColor(ap.category)}">
+            ${filtered.map((ap) => html`
+              <tr key=${ap.id} class="pm-row-alt">
+                <td class="pm-td pm-td--mono">${ap.id}</td>
+                <td class="pm-td">
+                  <span class="chip sm ${categoryColor(ap.category)}">
                     ${categoryLabel(ap.category)}
                   </span>
                 </td>
-                <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-[var(--color-fg-secondary)]">${ap.description}</td>
-                <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 font-mono text-[10px] text-[var(--color-fg-muted)]">${ap.location}</td>
-                <td class="border-b border-[var(--color-border-default)] px-3 py-1.5">
+                <td class="pm-td t-meta">${ap.description}</td>
+                <td class="pm-td t-caption">${ap.location}</td>
+                <td class="pm-td">
                   <${StatusChip} tone=${riskTone(ap.risk)}>${riskLabel(ap.risk)}<//>
                 </td>
               </tr>

--- a/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
+++ b/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
@@ -13,24 +13,24 @@ import {
 
 function V4CategoryTable() {
   return html`
-    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-      <table class="w-full text-xs border-collapse">
-        <thead>
-          <tr class="bg-[var(--white-4)]">
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">카테고리</th>
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">설명</th>
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">가중치</th>
+    <div class="pm-scroll">
+      <table class="pm-table">
+        <thead class="pm-thead">
+          <tr>
+            <th class="pm-th">카테고리</th>
+            <th class="pm-th">설명</th>
+            <th class="pm-th pm-th--center">가중치</th>
           </tr>
         </thead>
         <tbody>
           ${BFCL_V4_CATEGORIES.map((cat, i) => html`
-            <tr key=${cat.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-              <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 font-medium text-[var(--color-fg-primary)]">${cat.label}</td>
-              <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-[var(--color-fg-secondary)]">${cat.description}</td>
-              <td class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-mono text-[11px] ${
-                cat.weight === '40%' ? 'text-[var(--color-status-ok)] font-bold'
-                : cat.weight === '30%' ? 'text-[var(--color-status-warn)] font-bold'
-                : 'text-[var(--color-fg-muted)]'
+            <tr key=${cat.id} class="pm-row-alt">
+              <td class="pm-td t-semi">${cat.label}</td>
+              <td class="pm-td t-meta">${cat.description}</td>
+              <td class="pm-td pm-td--center pm-td--mono ${
+                cat.weight === '40%' ? 't-err t-bold'
+                : cat.weight === '30%' ? 't-warn t-bold'
+                : 't-dim'
               }">
                 ${cat.weight}
               </td>
@@ -44,26 +44,26 @@ function V4CategoryTable() {
 
 function ModelBreakdownTable() {
   return html`
-    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-      <table class="w-full text-xs border-collapse">
-        <thead>
-          <tr class="bg-[var(--white-4)]">
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[120px]">모델</th>
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[60px]">Overall</th>
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Simple</th>
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Parallel</th>
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Multi-turn</th>
-            <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Agentic</th>
+    <div class="pm-scroll">
+      <table class="pm-table">
+        <thead class="pm-thead">
+          <tr>
+            <th class="pm-th min-w-[120px]">모델</th>
+            <th class="pm-th pm-th--center min-w-[60px]">Overall</th>
+            <th class="pm-th pm-th--center">Simple</th>
+            <th class="pm-th pm-th--center">Parallel</th>
+            <th class="pm-th pm-th--center">Multi-turn</th>
+            <th class="pm-th pm-th--center">Agentic</th>
           </tr>
         </thead>
         <tbody>
           ${BFCL_MODEL_BREAKDOWN.map((m, i) => html`
-            <tr key=${m.model} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-              <td class="border-b border-[var(--color-border-default)] px-3 py-1 font-medium text-[var(--color-fg-primary)]">${m.model}</td>
-              <td class="border-b border-[var(--color-border-default)] px-3 py-1 text-center font-mono font-bold text-[11px]">${m.overall}</td>
+            <tr key=${m.model} class="pm-row-alt">
+              <td class="pm-td t-semi">${m.model}</td>
+              <td class="pm-td pm-td--center pm-td--mono t-bold">${m.overall}</td>
               ${([m.simple, m.parallel, m.multiTurn, m.agentic] as const).map((level, j) => html`
-                <td key=${j} class="border-b border-[var(--color-border-default)] px-2 py-1 text-center">
-                  <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${categoryLevelClass(level)}">
+                <td key=${j} class="pm-td pm-td--center">
+                  <span class="pm-cell-badge ${categoryLevelClass(level)}">
                     ${categoryLevelLabel(level)}
                   </span>
                 </td>
@@ -78,44 +78,44 @@ function ModelBreakdownTable() {
 
 function HarnessCaseStudy() {
   return html`
-    <div class="border border-[var(--color-border-default)] rounded overflow-hidden">
-      <div class="flex items-center justify-between px-3 py-2 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
+    <div class="pm-card">
+      <div class="pm-card-head">
         <div class="flex items-center gap-2">
-          <span class="text-xs font-semibold text-[var(--color-fg-primary)]">Function Calling Harness</span>
-          <span class="text-[10px] text-[var(--color-fg-muted)]">Sam Chon / Wrtn Technologies</span>
+          <span class="t-label t-semi">Function Calling Harness</span>
+          <span class="t-micro t-dim">Sam Chon / Wrtn Technologies</span>
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-[11px] font-mono text-[var(--bad-light)]">6.75%</span>
-          <span class="text-[10px] text-[var(--color-fg-muted)]">→</span>
-          <span class="text-[11px] font-mono font-bold text-[var(--color-status-ok)]">100%</span>
+          <span class="pm-td--mono t-caption t-err">6.75%</span>
+          <span class="t-micro t-dim">→</span>
+          <span class="pm-td--mono t-caption t-ok t-bold">100%</span>
         </div>
       </div>
       <div class="px-3 py-2 bg-[var(--shell-rail-bg)]">
-        <p class="text-[11px] text-[var(--color-fg-secondary)] mb-2">
+        <p class="t-caption t-meta mb-2">
           확률적 모델을 결정론적 검증 루프로 감싸는 패턴. Typia 컴파일러 기반 타입 스키마 제약 +
           컴파일러 피드백 + LLM self-healing 루프. P0 Verification Loop의 참조 사례.
         </p>
-        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-          <table class="w-full text-xs border-collapse">
-            <thead>
-              <tr class="bg-[var(--white-2)]">
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">모델</th>
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">파라미터</th>
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-muted)]">컴파일 성공률</th>
+        <div class="pm-scroll">
+          <table class="pm-table">
+            <thead class="pm-thead">
+              <tr>
+                <th class="pm-th">모델</th>
+                <th class="pm-th">파라미터</th>
+                <th class="pm-th pm-th--center">컴파일 성공률</th>
               </tr>
             </thead>
             <tbody>
               ${HARNESS_MODELS.map((hm, i) => html`
-                <tr key=${hm.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium text-[var(--color-fg-primary)]">${hm.id}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-secondary)]">${hm.params}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px] font-bold text-[var(--color-status-ok)]">${hm.compileRate}</td>
+                <tr key=${hm.id} class="pm-row-alt">
+                  <td class="pm-td pm-td--mono t-semi">${hm.id}</td>
+                  <td class="pm-td t-micro t-meta">${hm.params}</td>
+                  <td class="pm-td pm-td--center pm-td--mono t-ok t-bold">${hm.compileRate}</td>
                 </tr>
               `)}
             </tbody>
           </table>
         </div>
-        <p class="mt-1.5 text-[10px] text-[var(--color-fg-muted)]">
+        <p class="mt-1.5 t-micro t-dim">
           재귀 유니언 타입 10 variant × 3단계 = 1,000 경로. 30 variant면 27,000 경로.
           LLM 1회 통과율이 구조적으로 낮은 것은 능력 부족이 아닌 조합 폭발의 결과.
         </p>
@@ -127,24 +127,24 @@ function HarnessCaseStudy() {
 export function BfclRankings() {
   return html`
     <div class="flex flex-col gap-4">
-      <div class="flex items-center gap-3 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+      <div class="t-micro t-mono t-dim px-1">
         <span>BFCL = 스키마 준수율 측정</span>
-        <span class="text-[var(--color-border-default)]">|</span>
+        <span class="text-[var(--color-border-default)] mx-2">|</span>
         <span>MCPMark = 작업 완료율 측정</span>
-        <span class="text-[var(--color-border-default)]">|</span>
+        <span class="text-[var(--color-border-default)] mx-2">|</span>
         <span>GPT-5: BFCL 7위(59.22%) vs MCPMark 1위(52.6%)</span>
       </div>
 
-      <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-        <table class="w-full text-xs border-collapse">
-          <thead>
-            <tr class="bg-[var(--white-4)]">
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] w-[40px]">#</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[160px]">모델</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-right font-medium text-[var(--color-fg-secondary)] min-w-[90px]">BFCL V3</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-right font-medium text-[var(--color-fg-secondary)] min-w-[90px]">BFCL V4</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">특징</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] w-[90px]">라이선스</th>
+      <div class="pm-scroll">
+        <table class="pm-table">
+          <thead class="pm-thead">
+            <tr>
+              <th class="pm-th pm-th--center w-[40px]">#</th>
+              <th class="pm-th min-w-[160px]">모델</th>
+              <th class="pm-th pm-th--right min-w-[90px]">BFCL V3</th>
+              <th class="pm-th pm-th--right min-w-[90px]">BFCL V4</th>
+              <th class="pm-th">특징</th>
+              <th class="pm-th w-[90px]">라이선스</th>
             </tr>
           </thead>
           <tbody>
@@ -152,25 +152,25 @@ export function BfclRankings() {
               const hasV3 = entry.bfclV3 !== '—' && entry.bfclV3 !== '경쟁력' && entry.bfclV3 !== '개선됨'
               const hasV4 = entry.bfclV4 !== '—' && entry.bfclV4 !== '경쟁력'
               return html`
-                <tr key=${entry.model} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 text-center font-mono text-[var(--color-fg-muted)]">${entry.rank}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 font-medium text-[var(--color-fg-primary)]">${entry.model}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 text-right font-mono ${
-                    hasV3 ? 'text-[var(--color-fg-primary)]' : 'text-[var(--color-fg-muted)]'
+                <tr key=${entry.model} class="pm-row-alt">
+                  <td class="pm-td pm-td--center pm-td--mono t-dim">${entry.rank}</td>
+                  <td class="pm-td t-semi">${entry.model}</td>
+                  <td class="pm-td pm-td--right pm-td--mono ${
+                    hasV3 ? 't-bold' : 't-dim'
                   }">
-                    ${hasV3 ? html`<span class="font-bold">${entry.bfclV3}</span>` : entry.bfclV3}
+                    ${hasV3 ? html`<span class="t-bold">${entry.bfclV3}</span>` : entry.bfclV3}
                   </td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 text-right font-mono ${
-                    hasV4 ? 'text-[var(--color-status-ok)] font-bold' : 'text-[var(--color-fg-muted)]'
+                  <td class="pm-td pm-td--right pm-td--mono ${
+                    hasV4 ? 't-ok t-bold' : 't-dim'
                   }">
-                    ${hasV4 ? html`<span class="font-bold">${entry.bfclV4}</span>` : entry.bfclV4}
+                    ${hasV4 ? html`<span class="t-bold">${entry.bfclV4}</span>` : entry.bfclV4}
                   </td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 text-[var(--color-fg-secondary)]">${entry.feature}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2">
-                    <span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono ${
+                  <td class="pm-td t-meta">${entry.feature}</td>
+                  <td class="pm-td">
+                    <span class="chip sm ${
                       entry.license === '오픈웨이트' || entry.license === 'Apache 2.0' || entry.license === 'Modified MIT'
-                        ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
-                        : 'bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+                        ? 'is-ok'
+                        : 'is-ghost'
                     }">
                       ${entry.license}
                     </span>
@@ -183,16 +183,16 @@ export function BfclRankings() {
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">BFCL V4 카테고리 구성</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">
+        <h4 class="t-label t-semi mb-2">BFCL V4 카테고리 구성</h4>
+        <p class="t-micro t-dim mb-2">
           Multi-turn(30%) + Agentic(40%) = 70%가 실제 에이전트 시나리오 평가. AST 기반 코드 수준 평가로 텍스트 매칭 한계 극복.
         </p>
         <${V4CategoryTable} />
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">모델별 카테고리 성능 분포</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">
+        <h4 class="t-label t-semi mb-2">모델별 카테고리 성능 분포</h4>
+        <p class="t-micro t-dim mb-2">
           상위 3개 모델(GLM-4.5, Claude Opus 4.1, Sonnet 4)은 모든 카테고리에서 '높음'.
           GPT-5는 Agentic에서만 '높음', Simple/Parallel은 '중간'.
         </p>
@@ -200,14 +200,14 @@ export function BfclRankings() {
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Harness 사례: 6.75% → 100%</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">
+        <h4 class="t-label t-semi mb-2">Harness 사례: 6.75% → 100%</h4>
+        <p class="t-micro t-dim mb-2">
           검증-피드백-수정 루프(Typia)로 소형 모델도 복잡 스키마 100% 달성. P0 Verification Loop의 참조 구현.
         </p>
         <${HarnessCaseStudy} />
       </div>
 
-      <div class="text-[10px] text-[var(--color-fg-muted)] px-1">
+      <div class="t-micro t-dim px-1">
         출처: BFCL V3/V4 (UC Berkeley), MCPMark pass@1 (Sam Chon), SWE-Bench Pro (K2.6).
         Harness: Sam Chon, Wrtn Technologies. CoT Compliance 9.91%→100% 후속 연구.
       </div>

--- a/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
+++ b/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
@@ -25,11 +25,11 @@ function V4CategoryTable() {
         <tbody>
           ${BFCL_V4_CATEGORIES.map((cat, i) => html`
             <tr key=${cat.id} class="pm-row-alt">
-              <td class="pm-td t-semi">${cat.label}</td>
+              <td class="pm-td font-semibold">${cat.label}</td>
               <td class="pm-td t-meta">${cat.description}</td>
               <td class="pm-td pm-td--center pm-td--mono ${
-                cat.weight === '40%' ? 't-err t-bold'
-                : cat.weight === '30%' ? 't-warn t-bold'
+                cat.weight === '40%' ? 't-ok font-bold'
+                : cat.weight === '30%' ? 't-warn font-bold'
                 : 't-dim'
               }">
                 ${cat.weight}
@@ -59,8 +59,8 @@ function ModelBreakdownTable() {
         <tbody>
           ${BFCL_MODEL_BREAKDOWN.map((m, i) => html`
             <tr key=${m.model} class="pm-row-alt">
-              <td class="pm-td t-semi">${m.model}</td>
-              <td class="pm-td pm-td--center pm-td--mono t-bold">${m.overall}</td>
+              <td class="pm-td font-semibold">${m.model}</td>
+              <td class="pm-td pm-td--center pm-td--mono font-bold">${m.overall}</td>
               ${([m.simple, m.parallel, m.multiTurn, m.agentic] as const).map((level, j) => html`
                 <td key=${j} class="pm-td pm-td--center">
                   <span class="pm-cell-badge ${categoryLevelClass(level)}">
@@ -81,13 +81,13 @@ function HarnessCaseStudy() {
     <div class="pm-card">
       <div class="pm-card-head">
         <div class="flex items-center gap-2">
-          <span class="t-label t-semi">Function Calling Harness</span>
+          <span class="t-label font-semibold">Function Calling Harness</span>
           <span class="t-micro t-dim">Sam Chon / Wrtn Technologies</span>
         </div>
         <div class="flex items-center gap-2">
           <span class="pm-td--mono t-caption t-err">6.75%</span>
           <span class="t-micro t-dim">→</span>
-          <span class="pm-td--mono t-caption t-ok t-bold">100%</span>
+          <span class="pm-td--mono t-caption t-ok font-bold">100%</span>
         </div>
       </div>
       <div class="px-3 py-2 bg-[var(--shell-rail-bg)]">
@@ -107,9 +107,9 @@ function HarnessCaseStudy() {
             <tbody>
               ${HARNESS_MODELS.map((hm, i) => html`
                 <tr key=${hm.id} class="pm-row-alt">
-                  <td class="pm-td pm-td--mono t-semi">${hm.id}</td>
+                  <td class="pm-td pm-td--mono font-semibold">${hm.id}</td>
                   <td class="pm-td t-micro t-meta">${hm.params}</td>
-                  <td class="pm-td pm-td--center pm-td--mono t-ok t-bold">${hm.compileRate}</td>
+                  <td class="pm-td pm-td--center pm-td--mono t-ok font-bold">${hm.compileRate}</td>
                 </tr>
               `)}
             </tbody>
@@ -127,7 +127,7 @@ function HarnessCaseStudy() {
 export function BfclRankings() {
   return html`
     <div class="flex flex-col gap-4">
-      <div class="t-micro t-mono t-dim px-1">
+      <div class="t-micro mono t-dim px-1">
         <span>BFCL = 스키마 준수율 측정</span>
         <span class="text-[var(--color-border-default)] mx-2">|</span>
         <span>MCPMark = 작업 완료율 측정</span>
@@ -154,16 +154,16 @@ export function BfclRankings() {
               return html`
                 <tr key=${entry.model} class="pm-row-alt">
                   <td class="pm-td pm-td--center pm-td--mono t-dim">${entry.rank}</td>
-                  <td class="pm-td t-semi">${entry.model}</td>
+                  <td class="pm-td font-semibold">${entry.model}</td>
                   <td class="pm-td pm-td--right pm-td--mono ${
-                    hasV3 ? 't-bold' : 't-dim'
+                    hasV3 ? 'font-bold' : 't-dim'
                   }">
-                    ${hasV3 ? html`<span class="t-bold">${entry.bfclV3}</span>` : entry.bfclV3}
+                    ${hasV3 ? html`<span class="font-bold">${entry.bfclV3}</span>` : entry.bfclV3}
                   </td>
                   <td class="pm-td pm-td--right pm-td--mono ${
-                    hasV4 ? 't-ok t-bold' : 't-dim'
+                    hasV4 ? 't-ok font-bold' : 't-dim'
                   }">
-                    ${hasV4 ? html`<span class="t-bold">${entry.bfclV4}</span>` : entry.bfclV4}
+                    ${hasV4 ? html`<span class="font-bold">${entry.bfclV4}</span>` : entry.bfclV4}
                   </td>
                   <td class="pm-td t-meta">${entry.feature}</td>
                   <td class="pm-td">
@@ -183,7 +183,7 @@ export function BfclRankings() {
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">BFCL V4 카테고리 구성</h4>
+        <h4 class="t-label font-semibold mb-2">BFCL V4 카테고리 구성</h4>
         <p class="t-micro t-dim mb-2">
           Multi-turn(30%) + Agentic(40%) = 70%가 실제 에이전트 시나리오 평가. AST 기반 코드 수준 평가로 텍스트 매칭 한계 극복.
         </p>
@@ -191,7 +191,7 @@ export function BfclRankings() {
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">모델별 카테고리 성능 분포</h4>
+        <h4 class="t-label font-semibold mb-2">모델별 카테고리 성능 분포</h4>
         <p class="t-micro t-dim mb-2">
           상위 3개 모델(GLM-4.5, Claude Opus 4.1, Sonnet 4)은 모든 카테고리에서 '높음'.
           GPT-5는 Agentic에서만 '높음', Simple/Parallel은 '중간'.
@@ -200,7 +200,7 @@ export function BfclRankings() {
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">Harness 사례: 6.75% → 100%</h4>
+        <h4 class="t-label font-semibold mb-2">Harness 사례: 6.75% → 100%</h4>
         <p class="t-micro t-dim mb-2">
           검증-피드백-수정 루프(Typia)로 소형 모델도 복잡 스키마 100% 달성. P0 Verification Loop의 참조 구현.
         </p>

--- a/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
+++ b/dashboard/src/components/provider-capability-matrix/cascade-trace.ts
@@ -37,7 +37,7 @@ function ArrowConnector() {
 export function CascadeTrace() {
   return html`
     <div class="flex flex-col gap-4">
-      <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+      <div class="flex items-center gap-4 t-caption px-1">
         <span>OAS Cascade = Provider 순차 시도 + Cooldown 게이트</span>
         <span class="text-[var(--color-border-default)]">|</span>
         <span class="flex items-center gap-1">
@@ -54,15 +54,15 @@ export function CascadeTrace() {
       ${CASCADE_TRACES.map(trace => {
         const totalMs = trace.steps.reduce((s, st) => s + st.ms, 0)
         return html`
-        <div key=${trace.id} class="border border-[var(--color-border-default)] rounded overflow-hidden">
-          <div class="flex items-center justify-between px-3 py-1.5 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
+        <div key=${trace.id} class="pm-card">
+          <div class="pm-card-head">
             <div class="flex items-center gap-2">
-              <span class="text-xs font-medium text-[var(--color-fg-primary)]">${trace.label}</span>
-              <span class="inline-block rounded px-1.5 py-0.5 text-[9px] font-mono font-bold ${cascadeTierStyle(trace.tier)}">
+              <span class="t-label">${trace.label}</span>
+              <span class="chip sm ${cascadeTierStyle(trace.tier)}">
                 ${cascadeTierLabel(trace.tier)}
               </span>
             </div>
-            <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(totalMs)} total</span>
+            <span class="t-caption">${formatMs(totalMs)} total</span>
           </div>
           <div class="flex items-stretch px-2 py-2">
             ${trace.steps.map((step, i) => {
@@ -83,12 +83,12 @@ export function CascadeTrace() {
 function StepBlock({ step }: { step: typeof CASCADE_TRACES[number]['steps'][number] }) {
   return html`
     <div class="flex-1 flex flex-col items-center gap-1 min-w-[100px]">
-      <span class="text-[10px] font-medium text-[var(--color-fg-secondary)]">${step.provider}</span>
-      <span class="inline-block rounded border px-2.5 py-0.5 text-[10px] font-mono font-bold ${cascadeStepColor(step.status)}">
+      <span class="t-caption t-dim">${step.provider}</span>
+      <span class="chip sm ${cascadeStepColor(step.status)}">
         ${stepStatusLabel(step.status)}
       </span>
-      <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${formatMs(step.ms)}</span>
-      <span class="text-[9px] text-[var(--color-fg-disabled)] max-w-[100px] truncate" title=${step.reason}>${step.reason}</span>
+      <span class="t-caption">${formatMs(step.ms)}</span>
+      <span class="t-micro max-w-[100px] truncate" title=${step.reason}>${step.reason}</span>
     </div>
   `
 }

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -184,12 +184,10 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
               </tr>
               ${catFeatures.map((feat, j) => {
                 if (!feat) return null
-                const isAltRow = j % 2 !== 0
-                const rowClass = isAltRow ? 'pm-row--alt' : ''
-                const stickyBg = isAltRow ? 'pm-td--alt-bg' : ''
+                const rowClass = j % 2 !== 0 ? 'pm-row--alt' : ''
                 return html`
                   <tr key=${feat.id} class="${rowClass}">
-                    <td class="pm-td pm-td--sticky ${stickyBg} pm-td--indent">
+                    <td class="pm-td pm-td--sticky pm-td--indent">
                       ${feat.label}
                     </td>
                     ${PROVIDER_IDS.map(pid => {

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -81,9 +81,9 @@ function statusToHeartbeatSample(status: LiveStatus | null): HeartbeatState {
 
 function providerCategoryBadge(cat: string): string {
   switch (cat) {
-    case 'cloud': return 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
-    case 'cli':   return 'bg-[var(--warn-10)] text-[var(--color-status-warn)]'
-    case 'local': return 'bg-[var(--white-4)] text-[var(--color-fg-muted)]'
+    case 'cloud': return 'chip sm is-ok'
+    case 'cli':   return 'chip sm is-warn'
+    case 'local': return 'chip sm is-ghost'
     default:      return ''
   }
 }
@@ -140,33 +140,33 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
         <${StatTile} label="CLI Wrapper" value=${cliCount} hint="usage: strip" />
       </div>
 
-      <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-        <table class="w-full text-xs border-collapse">
-          <thead>
-            <tr class="bg-[var(--white-4)]">
-              <th class="sticky left-0 z-10 bg-[var(--shell-rail-bg)] border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[140px]">
+      <div class="pm-scroll">
+        <table class="pm-table">
+          <thead class="pm-thead">
+            <tr>
+              <th class="pm-th pm-th--sticky min-w-[140px]">
                 기능
               </th>
               ${PROVIDER_IDS.map(pid => {
                 const dot = liveStatusDot(pid, liveProviders)
                 const cat = PROVIDER_CATEGORY[pid] ?? 'cloud'
                 return html`
-                  <th key=${pid} class="border-b border-[var(--color-border-default)] px-1.5 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[60px]">
+                  <th key=${pid} class="pm-th pm-th--center min-w-[60px]">
                     <div class="flex flex-col items-center gap-0.5">
                       ${dot ? html`<${StatusDot} size="xs" class=${liveStatusDotClass(dot)} />` : null}
                       <span>${PROVIDER_LABELS[pid] ?? pid}</span>
-                      <span class="inline-block rounded px-1 py-px text-[7px] font-mono font-bold ${providerCategoryBadge(cat)}">${providerCategoryLabel(cat)}</span>
+                      <span class="${providerCategoryBadge(cat)}">${providerCategoryLabel(cat)}</span>
                     </div>
                   </th>
                 `
               })}
             </tr>
-            <tr class="bg-[var(--white-4)]">
-              <th class="sticky left-0 z-10 bg-[var(--shell-rail-bg)] border-b border-r border-[var(--color-border-default)]"></th>
+            <tr>
+              <th class="pm-th pm-th--sticky"></th>
               ${PROVIDER_IDS.map(pid => {
                 const dot = liveStatusDot(pid, liveProviders)
                 return html`
-                  <th key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5">
+                  <th key=${pid} class="pm-th pm-th--center">
                     <${ProviderHeartbeatCell} providerId=${pid} status=${dot} />
                   </th>
                 `
@@ -177,23 +177,24 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
           ${FEATURE_CATEGORIES.map(cat => {
             const catFeatures = cat.featureIds.map(id => featById.get(id)).filter(Boolean)
             return html`
-              <tr key=${`cat-${cat.id}`} class="bg-[var(--white-4)]">
-                <td class="sticky left-0 z-10 bg-[var(--white-4)] border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] font-semibold text-[var(--color-fg-muted)] uppercase tracking-wider" colSpan=${PROVIDER_IDS.length + 1}>
+              <tr key=${`cat-${cat.id}`} class="pm-cat-row">
+                <td class="pm-th--sticky" colSpan=${PROVIDER_IDS.length + 1}>
                   ${cat.label}
                 </td>
               </tr>
               ${catFeatures.map((feat, j) => {
                 if (!feat) return null
+                const stickyBg = j % 2 === 0 ? '' : 'pm-td--alt-bg'
                 return html`
-                  <tr key=${feat.id} class="${j % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                    <td class="sticky left-0 z-10 ${j % 2 === 0 ? 'bg-[var(--shell-rail-bg)]' : 'bg-[var(--white-2)]'} border-r border-b border-[var(--color-border-default)] px-2 py-1 pl-4 font-medium text-[var(--color-fg-primary)]">
+                  <tr key=${feat.id} class="pm-row-alt">
+                    <td class="pm-th--sticky ${stickyBg} pm-td--indent">
                       ${feat.label}
                     </td>
                     ${PROVIDER_IDS.map(pid => {
                       const v = feat.providers[pid] ?? '—'
                       return html`
-                        <td key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5 text-center">
-                          <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${supportCellClass(v)}">
+                        <td key=${pid} class="pm-td pm-td--center">
+                          <span class="pm-cell-badge ${supportCellClass(v)}">
                             ${v}
                           </span>
                         </td>
@@ -213,17 +214,17 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
 
 export function MatrixLegend() {
   return html`
-    <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1 flex-wrap">
-      <span class="flex items-center gap-1"><span class="inline-block w-4 h-3 rounded bg-[var(--ok-10)] text-center text-[var(--color-status-ok)]">●</span> 네이티브</span>
-      <span class="flex items-center gap-1"><span class="inline-block w-4 h-3 rounded bg-[var(--warn-10)] text-center text-[var(--color-status-warn)]">◐</span> 부분 지원</span>
-      <span class="flex items-center gap-1"><span class="inline-block w-4 h-3 rounded bg-[var(--bad-10)] text-center text-[var(--bad-light)]">○</span> 미지원</span>
+    <div class="flex items-center gap-4 t-caption px-1 flex-wrap">
+      <span class="flex items-center gap-1"><span class="chip sm is-ok">●</span> 네이티브</span>
+      <span class="flex items-center gap-1"><span class="chip sm is-warn">◐</span> 부분 지원</span>
+      <span class="flex items-center gap-1"><span class="chip sm is-err">○</span> 미지원</span>
       <span class="text-[var(--color-border-default)]">|</span>
       <span class="flex items-center gap-1"><${StatusDot} size="xs" class="bg-[var(--color-status-ok)]" /> 런타임 활성</span>
       <span class="flex items-center gap-1"><${StatusDot} size="xs" class="bg-[var(--color-status-err)]" /> 런타임 오류</span>
       <span class="text-[var(--color-border-default)]">|</span>
-      <span class="flex items-center gap-1"><span class="inline-block rounded px-1 py-px text-[7px] font-bold ${providerCategoryBadge('cloud')}">Cloud</span> API 직접</span>
-      <span class="flex items-center gap-1"><span class="inline-block rounded px-1 py-px text-[7px] font-bold ${providerCategoryBadge('cli')}">CLI</span> Subprocess</span>
-      <span class="flex items-center gap-1"><span class="inline-block rounded px-1 py-px text-[7px] font-bold ${providerCategoryBadge('local')}">Local</span> Self-hosted</span>
+      <span class="flex items-center gap-1"><span class="${providerCategoryBadge('cloud')}">Cloud</span> API 직접</span>
+      <span class="flex items-center gap-1"><span class="${providerCategoryBadge('cli')}">CLI</span> Subprocess</span>
+      <span class="flex items-center gap-1"><span class="${providerCategoryBadge('local')}">Local</span> Self-hosted</span>
     </div>
   `
 }

--- a/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
+++ b/dashboard/src/components/provider-capability-matrix/feature-matrix.ts
@@ -184,10 +184,12 @@ export function FeatureMatrix({ liveProviders }: { liveProviders: DashboardRunti
               </tr>
               ${catFeatures.map((feat, j) => {
                 if (!feat) return null
-                const stickyBg = j % 2 === 0 ? '' : 'pm-td--alt-bg'
+                const isAltRow = j % 2 !== 0
+                const rowClass = isAltRow ? 'pm-row--alt' : ''
+                const stickyBg = isAltRow ? 'pm-td--alt-bg' : ''
                 return html`
-                  <tr key=${feat.id} class="pm-row-alt">
-                    <td class="pm-th--sticky ${stickyBg} pm-td--indent">
+                  <tr key=${feat.id} class="${rowClass}">
+                    <td class="pm-td pm-td--sticky ${stickyBg} pm-td--indent">
                       ${feat.label}
                     </td>
                     ${PROVIDER_IDS.map(pid => {

--- a/dashboard/src/components/provider-capability-matrix/index.ts
+++ b/dashboard/src/components/provider-capability-matrix/index.ts
@@ -91,7 +91,7 @@ export function ProviderCapabilityMatrix() {
           onChange=${(v: CapView) => { activeView.value = v }}
         />
         ${updatedAt ? html`
-          <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">
+          <span class="t-caption">
             프로바이더 상태: ${updatedAt}
           </span>
         ` : null}
@@ -99,10 +99,10 @@ export function ProviderCapabilityMatrix() {
 
       ${activeView.value === 'providers' ? html`
         <${Card}>
-          <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">OAS Provider Capability 정의</h3>
-          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+          <h3 class="t-title mb-2">OAS Provider Capability 정의</h3>
+          <p class="t-meta mb-3">
             sec02 Table 1 — 12개 런타임 provider kind의 capability flag와 한계값.
-            CLI wrapper 3종은 <code class="font-mono text-[10px] bg-[var(--white-4)] px-1 rounded">usage: strip</code>으로 토큰 카운트를 노출하지 않음.
+            CLI wrapper 3종은 <code class="t-code">usage: strip</code>으로 토큰 카운트를 노출하지 않음.
           </p>
           <${OasProviderTable} />
         <//>
@@ -114,7 +114,7 @@ export function ProviderCapabilityMatrix() {
       ` : activeView.value === 'models' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">Provider 모델 카탈로그</h3>
-          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+          <p class="t-meta mb-3">
             Provider별 공식 모델 목록, 가격($/1M tokens), Context 한계, CLI transport 구현 비교.
             GLM Coding Plan은 Claude Code 호환 엔드포인트를 통한 별도 모델 매핑 사용.
           </p>
@@ -123,7 +123,7 @@ export function ProviderCapabilityMatrix() {
       ` : activeView.value === 'cascade' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">OAS Cascade 라우팅 트레이스</h3>
-          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+          <p class="t-meta mb-3">
             sec03 분석 — Provider cascade 경로의 4가지 대표 시나리오.
             Rate-limit/Timeout → Cooldown 게이트 → 다음 Provider 순차 시도.
             Exhaustion 시 turn 실패로 보고.
@@ -133,7 +133,7 @@ export function ProviderCapabilityMatrix() {
       ` : activeView.value === 'benchmarks' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">BFCL Function Calling 순위</h3>
-          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+          <p class="t-meta mb-3">
             sec04 Table 4.2.2 — 2026년 4월 기준 BFCL V3/V4 성능 순위.
             GLM-4.5(70.85%)과 Claude 계열(70%대)이 스키마 준수에서 상위.
           </p>
@@ -142,7 +142,7 @@ export function ProviderCapabilityMatrix() {
       ` : activeView.value === 'wiring' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">OAS 배선 vs 공식 API 지원</h3>
-          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+          <p class="t-meta mb-3">
             OAS가 선언한 capability와 실제 프로바이더 API 동작 사이의 불일치.
             High 영향도 항목은 tool calling 비활성화로 이어져 OAS 라우팅 정확도에 직접 영향.
           </p>
@@ -151,7 +151,7 @@ export function ProviderCapabilityMatrix() {
       ` : activeView.value === 'roadmap' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">P0–P7 개선 로드맵</h3>
-          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+          <p class="t-meta mb-3">
             sec06 종합 개선 계획 — 비결정론적 구현 경계를 결정론적으로 전환하는 8개 우선순위.
             P0(Verification Loop)이 기반 인프라로 다른 모든 개선의 토대.
           </p>
@@ -160,7 +160,7 @@ export function ProviderCapabilityMatrix() {
       ` : activeView.value === 'anti-patterns' ? html`
         <${Card}>
           <h3 class="text-sm font-semibold text-[var(--color-fg-primary)] mb-2">안티패턴 레지스트리</h3>
-          <p class="text-xs text-[var(--color-fg-muted)] mb-3">
+          <p class="t-meta mb-3">
             sec05 분석에서 식별된 32개 안티패턴. Silent Failure가 운영 가시성에 가장 큰 위협.
           </p>
           <${AntiPatternList} />

--- a/dashboard/src/components/provider-capability-matrix/model-catalog.ts
+++ b/dashboard/src/components/provider-capability-matrix/model-catalog.ts
@@ -37,8 +37,8 @@ function ModelTable({ group }: { group: typeof PROVIDER_MODELS[number] }) {
   return html`
     <div class="pm-card">
       <div class="pm-card-head">
-        <span class="t-label t-semi">${PROVIDER_LABELS[group.providerId] ?? group.providerId}</span>
-        <span class="t-micro t-mono t-dim">${group.models.length} models · ${catBadge}</span>
+        <span class="t-label font-semibold">${PROVIDER_LABELS[group.providerId] ?? group.providerId}</span>
+        <span class="t-micro mono t-dim">${group.models.length} models · ${catBadge}</span>
       </div>
       <table class="pm-table">
         <thead class="pm-thead">
@@ -60,7 +60,7 @@ function ModelTable({ group }: { group: typeof PROVIDER_MODELS[number] }) {
             </tr>
           ` : group.models.map((m, i) => html`
               <tr key=${m.id} class="pm-row-alt">
-                <td class="pm-td pm-td--mono t-semi">${m.id}</td>
+                <td class="pm-td pm-td--mono font-semibold">${m.id}</td>
                 <td class="pm-td pm-td--center">
                   <span class="chip sm ${modelTierStyle(m.tier)}">${tierLabel(m.tier)}</span>
                 </td>
@@ -94,7 +94,7 @@ function CliTransportTable() {
         <tbody>
           ${CLI_TRANSPORTS.map((t, i) => html`
             <tr key=${t.providerId} class="pm-row-alt">
-              <td class="pm-td t-semi">${PROVIDER_LABELS[t.providerId] ?? t.providerId}</td>
+              <td class="pm-td font-semibold">${PROVIDER_LABELS[t.providerId] ?? t.providerId}</td>
               <td class="pm-td pm-td--mono">${t.binary}</td>
               <td class="pm-td pm-td--right pm-td--mono">${t.loc.toLocaleString()}</td>
               <td class="pm-td pm-td--center pm-td--mono">${t.promptMode}</td>
@@ -113,7 +113,7 @@ function GlmCodingPlanSection() {
   return html`
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
       <div>
-        <h5 class="t-label t-semi mb-2">Claude Code → GLM Coding Plan 매핑</h5>
+        <h5 class="t-label font-semibold mb-2">Claude Code → GLM Coding Plan 매핑</h5>
         <div class="pm-scroll">
           <table class="pm-table">
             <thead class="pm-thead">
@@ -127,7 +127,7 @@ function GlmCodingPlanSection() {
               ${GLM_CODING_PLAN_MAP.map((m, i) => html`
                 <tr key=${i} class="pm-row-alt">
                   <td class="pm-td pm-td--mono t-micro">${m.envVar}</td>
-                  <td class="pm-td pm-td--mono t-semi">${m.glmModel}</td>
+                  <td class="pm-td pm-td--mono font-semibold">${m.glmModel}</td>
                   <td class="pm-td t-micro t-dim">${m.note}</td>
                 </tr>
               `)}
@@ -136,7 +136,7 @@ function GlmCodingPlanSection() {
         </div>
       </div>
       <div>
-        <h5 class="t-label t-semi mb-2">OAS vs 공식 문서 간격</h5>
+        <h5 class="t-label font-semibold mb-2">OAS vs 공식 문서 간격</h5>
         <div class="pm-scroll">
           <table class="pm-table">
             <thead class="pm-thead">
@@ -149,7 +149,7 @@ function GlmCodingPlanSection() {
             <tbody>
               ${GLM_WIRING_GAPS.map((g, i) => html`
                 <tr key=${i} class="pm-row-alt">
-                  <td class="pm-td t-caption t-semi">${g.area}</td>
+                  <td class="pm-td t-caption font-semibold">${g.area}</td>
                   <td class="pm-td pm-td--mono t-micro t-err">${g.oasCurrent}</td>
                   <td class="pm-td pm-td--mono t-micro t-ok">${g.official}</td>
                 </tr>
@@ -168,7 +168,7 @@ function GlmCodingPlanSection() {
 export function ModelCatalog() {
   return html`
     <div class="flex flex-col gap-4">
-      <div class="t-micro t-mono t-dim px-1">
+      <div class="t-micro mono t-dim px-1">
         <span>Provider별 공식 모델 카탈로그 + 가격 + Context 한계</span>
         <span class="text-[var(--color-border-default)] mx-2">|</span>
         <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--ok-10)]"></span> Flagship</span>
@@ -184,13 +184,13 @@ export function ModelCatalog() {
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">CLI Transport 구현 비교</h4>
+        <h4 class="t-label font-semibold mb-2">CLI Transport 구현 비교</h4>
         <p class="t-micro t-dim mb-2">OAS CLI transport 계층의 구현 복잡도와 프로토콜 차이</p>
         <${CliTransportTable} />
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">GLM Coding Plan 특수 매핑</h4>
+        <h4 class="t-label font-semibold mb-2">GLM Coding Plan 특수 매핑</h4>
         <p class="t-micro t-dim mb-2">Claude Code 호환 엔드포인트를 통한 GLM 모델 매핑 + OAS wiring 간격</p>
         <${GlmCodingPlanSection} />
       </div>

--- a/dashboard/src/components/provider-capability-matrix/model-catalog.ts
+++ b/dashboard/src/components/provider-capability-matrix/model-catalog.ts
@@ -35,39 +35,39 @@ function ModelTable({ group }: { group: typeof PROVIDER_MODELS[number] }) {
   const catBadge = cat === 'cloud' ? 'Cloud' : cat === 'cli' ? 'CLI' : 'Local'
 
   return html`
-    <div class="border border-[var(--color-border-default)] rounded overflow-hidden">
-      <div class="flex items-center justify-between px-3 py-1.5 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
-        <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${PROVIDER_LABELS[group.providerId] ?? group.providerId}</span>
-        <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${group.models.length} models · ${catBadge}</span>
+    <div class="pm-card">
+      <div class="pm-card-head">
+        <span class="t-label t-semi">${PROVIDER_LABELS[group.providerId] ?? group.providerId}</span>
+        <span class="t-micro t-mono t-dim">${group.models.length} models · ${catBadge}</span>
       </div>
-      <table class="w-full text-xs border-collapse">
-        <thead>
-          <tr class="bg-[var(--white-2)]">
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">Model</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-muted)]">Tier</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-muted)]">Context</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-medium text-[var(--color-fg-muted)]">In/1M</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-medium text-[var(--color-fg-muted)]">Out/1M</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-muted)]">Notes</th>
+      <table class="pm-table">
+        <thead class="pm-thead">
+          <tr>
+            <th class="pm-th">Model</th>
+            <th class="pm-th pm-th--center">Tier</th>
+            <th class="pm-th pm-th--center">Context</th>
+            <th class="pm-th pm-th--right">In/1M</th>
+            <th class="pm-th pm-th--right">Out/1M</th>
+            <th class="pm-th">Notes</th>
           </tr>
         </thead>
         <tbody>
           ${group.models.length === 0 ? html`
             <tr>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-2 text-[10px] text-[var(--color-fg-muted)]" colSpan=${6}>
+              <td class="pm-td t-micro t-dim" colSpan=${6}>
                 공식 모델 카탈로그 미등록. Provider capability는 matrix/providers 탭에서 추적.
               </td>
             </tr>
           ` : group.models.map((m, i) => html`
-              <tr key=${m.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium text-[var(--color-fg-primary)]">${m.id}</td>
-                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center">
-                  <span class="inline-block rounded px-1 py-px text-[9px] font-bold ${modelTierStyle(m.tier)}">${tierLabel(m.tier)}</span>
+              <tr key=${m.id} class="pm-row-alt">
+                <td class="pm-td pm-td--mono t-semi">${m.id}</td>
+                <td class="pm-td pm-td--center">
+                  <span class="chip sm ${modelTierStyle(m.tier)}">${tierLabel(m.tier)}</span>
                 </td>
-                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${m.context}</td>
-                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.inputPrice ?? '—'}</td>
-                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${m.outputPrice ?? '—'}</td>
-                <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${m.notes ?? ''}</td>
+                <td class="pm-td pm-td--center pm-td--mono">${m.context}</td>
+                <td class="pm-td pm-td--right pm-td--mono">${m.inputPrice ?? '—'}</td>
+                <td class="pm-td pm-td--right pm-td--mono">${m.outputPrice ?? '—'}</td>
+                <td class="pm-td t-micro t-dim">${m.notes ?? ''}</td>
               </tr>
             `)}
         </tbody>
@@ -78,29 +78,29 @@ function ModelTable({ group }: { group: typeof PROVIDER_MODELS[number] }) {
 
 function CliTransportTable() {
   return html`
-    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-      <table class="w-full text-xs border-collapse">
-        <thead>
-          <tr class="bg-[var(--white-4)]">
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">Provider</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">Binary</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-right font-medium text-[var(--color-fg-secondary)]">LOC</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Prompt</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Stream</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)]">Argv Thresh</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">Notes</th>
+    <div class="pm-scroll">
+      <table class="pm-table">
+        <thead class="pm-thead">
+          <tr>
+            <th class="pm-th">Provider</th>
+            <th class="pm-th">Binary</th>
+            <th class="pm-th pm-th--right">LOC</th>
+            <th class="pm-th pm-th--center">Prompt</th>
+            <th class="pm-th pm-th--center">Stream</th>
+            <th class="pm-th pm-th--center">Argv Thresh</th>
+            <th class="pm-th">Notes</th>
           </tr>
         </thead>
         <tbody>
           ${CLI_TRANSPORTS.map((t, i) => html`
-            <tr key=${t.providerId} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-medium text-[var(--color-fg-primary)]">${PROVIDER_LABELS[t.providerId] ?? t.providerId}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px]">${t.binary}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-right font-mono text-[11px]">${t.loc.toLocaleString()}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${t.promptMode}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${t.streamFormat}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${t.argvThreshold}</td>
-              <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${t.notes}</td>
+            <tr key=${t.providerId} class="pm-row-alt">
+              <td class="pm-td t-semi">${PROVIDER_LABELS[t.providerId] ?? t.providerId}</td>
+              <td class="pm-td pm-td--mono">${t.binary}</td>
+              <td class="pm-td pm-td--right pm-td--mono">${t.loc.toLocaleString()}</td>
+              <td class="pm-td pm-td--center pm-td--mono">${t.promptMode}</td>
+              <td class="pm-td pm-td--center pm-td--mono">${t.streamFormat}</td>
+              <td class="pm-td pm-td--center pm-td--mono">${t.argvThreshold}</td>
+              <td class="pm-td t-micro t-dim">${t.notes}</td>
             </tr>
           `)}
         </tbody>
@@ -113,22 +113,22 @@ function GlmCodingPlanSection() {
   return html`
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
       <div>
-        <h5 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Claude Code → GLM Coding Plan 매핑</h5>
-        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-          <table class="w-full text-xs border-collapse">
-            <thead>
-              <tr class="bg-[var(--white-4)]">
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">Claude Code 변수</th>
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">GLM 모델</th>
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">비고</th>
+        <h5 class="t-label t-semi mb-2">Claude Code → GLM Coding Plan 매핑</h5>
+        <div class="pm-scroll">
+          <table class="pm-table">
+            <thead class="pm-thead">
+              <tr>
+                <th class="pm-th">Claude Code 변수</th>
+                <th class="pm-th">GLM 모델</th>
+                <th class="pm-th">비고</th>
               </tr>
             </thead>
             <tbody>
               ${GLM_CODING_PLAN_MAP.map((m, i) => html`
-                <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[10px]">${m.envVar}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] font-medium">${m.glmModel}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-muted)]">${m.note}</td>
+                <tr key=${i} class="pm-row-alt">
+                  <td class="pm-td pm-td--mono t-micro">${m.envVar}</td>
+                  <td class="pm-td pm-td--mono t-semi">${m.glmModel}</td>
+                  <td class="pm-td t-micro t-dim">${m.note}</td>
                 </tr>
               `)}
             </tbody>
@@ -136,29 +136,29 @@ function GlmCodingPlanSection() {
         </div>
       </div>
       <div>
-        <h5 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">OAS vs 공식 문서 간격</h5>
-        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-          <table class="w-full text-xs border-collapse">
-            <thead>
-              <tr class="bg-[var(--white-4)]">
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">영역</th>
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">OAS 현재</th>
-                <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-left font-medium text-[var(--color-fg-secondary)]">공식</th>
+        <h5 class="t-label t-semi mb-2">OAS vs 공식 문서 간격</h5>
+        <div class="pm-scroll">
+          <table class="pm-table">
+            <thead class="pm-thead">
+              <tr>
+                <th class="pm-th">영역</th>
+                <th class="pm-th">OAS 현재</th>
+                <th class="pm-th">공식</th>
               </tr>
             </thead>
             <tbody>
               ${GLM_WIRING_GAPS.map((g, i) => html`
-                <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[11px] font-medium">${g.area}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] font-mono text-[var(--bad-light)]">${g.oasCurrent}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] font-mono text-[var(--color-status-ok)]">${g.official}</td>
+                <tr key=${i} class="pm-row-alt">
+                  <td class="pm-td t-caption t-semi">${g.area}</td>
+                  <td class="pm-td pm-td--mono t-micro t-err">${g.oasCurrent}</td>
+                  <td class="pm-td pm-td--mono t-micro t-ok">${g.official}</td>
                 </tr>
               `)}
             </tbody>
           </table>
         </div>
         <div class="mt-2">
-          <p class="text-[10px] text-[var(--color-fg-muted)]">Gap: ${GLM_WIRING_GAPS.map(g => g.gap).join(', ')}</p>
+          <p class="t-micro t-dim">Gap: ${GLM_WIRING_GAPS.map(g => g.gap).join(', ')}</p>
         </div>
       </div>
     </div>
@@ -168,9 +168,9 @@ function GlmCodingPlanSection() {
 export function ModelCatalog() {
   return html`
     <div class="flex flex-col gap-4">
-      <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+      <div class="t-micro t-mono t-dim px-1">
         <span>Provider별 공식 모델 카탈로그 + 가격 + Context 한계</span>
-        <span class="text-[var(--color-border-default)]">|</span>
+        <span class="text-[var(--color-border-default)] mx-2">|</span>
         <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--ok-10)]"></span> Flagship</span>
         <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--white-4)]"></span> Standard</span>
         <span class="flex items-center gap-1"><span class="inline-block w-3 h-2 rounded-sm bg-[var(--warn-10)]"></span> Fast</span>
@@ -184,14 +184,14 @@ export function ModelCatalog() {
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">CLI Transport 구현 비교</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">OAS CLI transport 계층의 구현 복잡도와 프로토콜 차이</p>
+        <h4 class="t-label t-semi mb-2">CLI Transport 구현 비교</h4>
+        <p class="t-micro t-dim mb-2">OAS CLI transport 계층의 구현 복잡도와 프로토콜 차이</p>
         <${CliTransportTable} />
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">GLM Coding Plan 특수 매핑</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">Claude Code 호환 엔드포인트를 통한 GLM 모델 매핑 + OAS wiring 간격</p>
+        <h4 class="t-label t-semi mb-2">GLM Coding Plan 특수 매핑</h4>
+        <p class="t-micro t-dim mb-2">Claude Code 호환 엔드포인트를 통한 GLM 모델 매핑 + OAS wiring 간격</p>
         <${GlmCodingPlanSection} />
       </div>
     </div>

--- a/dashboard/src/components/provider-capability-matrix/oas-provider-table.ts
+++ b/dashboard/src/components/provider-capability-matrix/oas-provider-table.ts
@@ -19,7 +19,7 @@ export function OasProviderTable() {
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex items-center gap-3 text-[10px] font-mono text-[var(--color-fg-muted)]">
+      <div class="flex items-center gap-3 t-caption">
         <span class="flex items-center gap-1">
           <${StatusDot} size="sm" class="bg-[var(--color-status-ok)]" />
           Direct API (${isDirectApi})
@@ -30,57 +30,46 @@ export function OasProviderTable() {
         </span>
       </div>
 
-      <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-        <table class="w-full text-xs border-collapse">
-          <thead>
-            <tr class="bg-[var(--white-4)]">
-              <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] sticky left-0 z-10 bg-[var(--white-4)] min-w-[100px]">Provider</th>
-              <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[90px]">Kind</th>
-              <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-right font-medium text-[var(--color-fg-secondary)] min-w-[70px]">Max Context</th>
-              <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-right font-medium text-[var(--color-fg-secondary)] min-w-[70px]">Max Output</th>
+      <div class="pm-scroll">
+        <table class="pm-table">
+          <thead class="pm-thead">
+            <tr>
+              <th class="pm-th pm-th--sticky min-w-[100px]">Provider</th>
+              <th class="pm-th min-w-[90px]">Kind</th>
+              <th class="pm-th pm-th--right min-w-[70px]">Max Context</th>
+              <th class="pm-th pm-th--right min-w-[70px]">Max Output</th>
               ${CAP_BOOLEAN_FIELDS.map(f => html`
-                <th key=${f.key} class="border-b border-[var(--color-border-default)] px-1.5 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">${f.label}</th>
+                <th key=${f.key} class="pm-th pm-th--center min-w-[55px]">${f.label}</th>
               `)}
-              <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[50px]">Usage</th>
+              <th class="pm-th pm-th--center min-w-[50px]">Usage</th>
             </tr>
           </thead>
           <tbody>
             ${OAS_PROVIDER_CAPS.map((prov, i) => {
               const isCli = prov.usage === 'strip'
-              const rowBg = isCli
-                ? 'bg-[var(--warn-10)]'
-                : i % 2 === 0 ? '' : 'bg-[var(--white-2)]'
               return html`
-                <tr key=${prov.id} class="${rowBg}">
-                  <td class="sticky left-0 z-10 ${rowBg || 'bg-[var(--shell-rail-bg)]'} border-r border-[var(--color-border-default)] px-2 py-1.5 font-medium text-[var(--color-fg-primary)]">
+                <tr key=${prov.id} class="pm-row-alt ${isCli ? 'pm-row--cli' : ''}">
+                  <td class="pm-th--sticky pm-td">
                     <div class="flex items-center gap-1.5">
                       <${StatusDot} size="xs" class=${isCli ? 'bg-[var(--color-status-warn)]' : 'bg-[var(--color-status-ok)]'} />
                       ${prov.label}
                     </div>
                   </td>
-                  <td class="border-r border-[var(--color-border-default)] px-2 py-1.5 font-mono text-[10px] text-[var(--color-fg-muted)]">${prov.kind}</td>
-                  <td class="border-r border-[var(--color-border-default)] px-2 py-1.5 text-right font-mono text-[var(--color-fg-secondary)]">${formatTokens(prov.maxContext)}</td>
-                  <td class="border-r border-[var(--color-border-default)] px-2 py-1.5 text-right font-mono text-[var(--color-fg-secondary)]">${formatTokens(prov.maxOutput)}</td>
+                  <td class="pm-td pm-td--right-border pm-td--mono">${prov.kind}</td>
+                  <td class="pm-td pm-td--right-border pm-td--mono">${formatTokens(prov.maxContext)}</td>
+                  <td class="pm-td pm-td--right-border pm-td--mono pm-td--right">${formatTokens(prov.maxOutput)}</td>
                   ${CAP_BOOLEAN_FIELDS.map(f => {
                     const val = prov[f.key]
                     return html`
-                      <td key=${String(f.key)} class="border-r border-[var(--color-border-default)] px-1 py-0.5 text-center">
-                        <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${
-                          val
-                            ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
-                            : 'bg-[var(--bad-10)] text-[var(--bad-light)]'
-                        }">
+                      <td key=${String(f.key)} class="pm-td pm-td--right-border pm-td--center">
+                        <span class="pm-cell-badge ${val ? 'chip sm is-ok' : 'chip sm is-err'}">
                           ${val ? 'O' : 'X'}
                         </span>
                       </td>
                     `
                   })}
-                  <td class="px-2 py-0.5 text-center">
-                    <span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono ${
-                      isCli
-                        ? 'bg-[var(--warn-10)] text-[var(--color-status-warn)]'
-                        : 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
-                    }">
+                  <td class="pm-td pm-td--center">
+                    <span class="chip sm ${isCli ? 'is-warn' : 'is-ok'}">
                       ${prov.usage}
                     </span>
                   </td>

--- a/dashboard/src/components/provider-capability-matrix/oas-provider-table.ts
+++ b/dashboard/src/components/provider-capability-matrix/oas-provider-table.ts
@@ -49,7 +49,7 @@ export function OasProviderTable() {
               const isCli = prov.usage === 'strip'
               return html`
                 <tr key=${prov.id} class="pm-row-alt ${isCli ? 'pm-row--cli' : ''}">
-                  <td class="pm-th--sticky pm-td">
+                  <td class="pm-td pm-td--sticky">
                     <div class="flex items-center gap-1.5">
                       <${StatusDot} size="xs" class=${isCli ? 'bg-[var(--color-status-warn)]' : 'bg-[var(--color-status-ok)]'} />
                       ${prov.label}

--- a/dashboard/src/components/provider-capability-matrix/roadmap.ts
+++ b/dashboard/src/components/provider-capability-matrix/roadmap.ts
@@ -21,10 +21,10 @@ function PhaseCard({ item }: { item: typeof ROADMAP_ITEMS[number] }) {
     <div class="pm-card ${phaseColor(item.id)}">
       <div class="pm-card-head">
         <div class="flex items-center gap-2">
-          <span class="t-label t-bold t-mono">${item.id}</span>
+          <span class="t-label font-bold mono">${item.id}</span>
           <span class="t-label">${item.area}</span>
         </div>
-        <span class="t-micro t-mono t-dim">${item.timeline}</span>
+        <span class="t-micro mono t-dim">${item.timeline}</span>
       </div>
       <div class="px-3 py-2 bg-[var(--shell-rail-bg)]">
         <p class="t-caption mb-1.5">${item.goal}</p>
@@ -37,7 +37,7 @@ function PhaseCard({ item }: { item: typeof ROADMAP_ITEMS[number] }) {
           <span class="t-dim">참조:</span>
           <span class="t-meta">${item.reference}</span>
         </div>
-        <div class="mt-1 t-micro t-ok t-semi">${item.effect}</div>
+        <div class="mt-1 t-micro t-ok font-semibold">${item.effect}</div>
         ${item.deps.length > 0 ? html`
           <div class="mt-1 flex items-center gap-1 t-micro t-dim">
             <span>선행:</span>
@@ -54,7 +54,7 @@ function PhaseCard({ item }: { item: typeof ROADMAP_ITEMS[number] }) {
 function DependencyGraph() {
   const phases = ROADMAP_ITEMS.map(r => r.id)
   return html`
-    <div class="flex items-center gap-1 t-micro t-mono flex-wrap">
+    <div class="flex items-center gap-1 t-micro mono flex-wrap">
       ${phases.map((p, i) => html`
         <span key=${p} class="inline-flex items-center gap-0.5">
           ${i > 0 ? html`<span class="t-dim px-0.5">→</span>` : null}
@@ -98,7 +98,7 @@ function Timeline() {
                 </td>
                 <td class="pm-td pm-td--right-border t-caption">${row.work}</td>
                 <td class="pm-td pm-td--right-border t-meta">${row.deliverable}</td>
-                <td class="pm-td t-micro t-mono t-dim">${row.deps}</td>
+                <td class="pm-td t-micro mono t-dim">${row.deps}</td>
               </tr>
             `
           })}
@@ -134,7 +134,7 @@ function ResourceTable() {
         <tbody>
           ${RESOURCE_ALLOCATION.map((row, i) => html`
             <tr key=${i} class="pm-row-alt">
-              <td class="pm-td pm-td--right-border t-semi">${row.track}</td>
+              <td class="pm-td pm-td--right-border font-semibold">${row.track}</td>
               <td class="pm-td pm-td--right-border t-micro t-meta">${row.scope}</td>
               <td class="pm-td pm-td--right-border pm-td--center pm-td--mono">${row.headcount}인</td>
               ${row.pct.map((p, j) => html`
@@ -162,7 +162,7 @@ function SuccessMetrics() {
         <div key=${m.id} class="pm-card">
           <div class="pm-card-head">
             <div class="flex items-center gap-2">
-              <span class="t-label t-semi">${m.title}</span>
+              <span class="t-label font-semibold">${m.title}</span>
               <span class="chip sm is-ok">Target: ${m.target}</span>
             </div>
           </div>
@@ -189,12 +189,12 @@ function SuccessMetrics() {
 export function Roadmap() {
   return html`
     <div class="flex flex-col gap-4">
-      <div class="t-micro t-mono t-dim px-1">
+      <div class="t-micro mono t-dim px-1">
         <span>sec06–07 — P0–P7 순차-병렬 하이브리드 개선 계획 + 16주 구현 로드맵</span>
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">의존성 그래프</h4>
+        <h4 class="t-label font-semibold mb-2">의존성 그래프</h4>
         <${DependencyGraph} />
       </div>
 
@@ -205,7 +205,7 @@ export function Roadmap() {
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">Per-Provider 적용 매트릭스</h4>
+        <h4 class="t-label font-semibold mb-2">Per-Provider 적용 매트릭스</h4>
         <p class="t-micro t-dim mb-2">sec06 Table 6-2 — ✅ 직접 적용, ⚠️ 제한적, ❌ 불가, — 해당 없음</p>
         <div class="pm-scroll">
           <table class="pm-table">
@@ -220,7 +220,7 @@ export function Roadmap() {
             <tbody>
               ${ROADMAP_ITEMS.map((item, i) => html`
                 <tr key=${item.id} class="pm-row-alt">
-                  <td class="pm-td pm-th--sticky pm-td--mono t-bold">${item.id}</td>
+                  <td class="pm-td pm-td--sticky pm-td--mono font-bold">${item.id}</td>
                   ${PROVIDER_IDS.map(pid => {
                     const a = APPLICABILITY_MATRIX[item.id][pid] ?? 'na'
                     return html`
@@ -239,19 +239,19 @@ export function Roadmap() {
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">Phase별 구현 타임라인</h4>
+        <h4 class="t-label font-semibold mb-2">Phase별 구현 타임라인</h4>
         <p class="t-micro t-dim mb-2">sec07 Table 7-1 — 16주 4-Phase 순차-병렬 하이브리드 로드맵</p>
         <${Timeline} />
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">리소스 할당</h4>
+        <h4 class="t-label font-semibold mb-2">리소스 할당</h4>
         <p class="t-micro t-dim mb-2">sec07 Table 7-2 — 3 트랙 × 4 Phase 병렬 진행</p>
         <${ResourceTable} />
       </div>
 
       <div>
-        <h4 class="t-label t-semi mb-2">성공 지표</h4>
+        <h4 class="t-label font-semibold mb-2">성공 지표</h4>
         <p class="t-micro t-dim mb-2">sec07 §7.3 — 16주 로드맵 완료 판정 기준 (3개 교차 검증 지표)</p>
         <${SuccessMetrics} />
       </div>

--- a/dashboard/src/components/provider-capability-matrix/roadmap.ts
+++ b/dashboard/src/components/provider-capability-matrix/roadmap.ts
@@ -57,7 +57,7 @@ function DependencyGraph() {
     <div class="flex items-center gap-1 t-micro t-mono flex-wrap">
       ${phases.map((p, i) => html`
         <span key=${p} class="inline-flex items-center gap-0.5">
-          ${i > 0 ? html`<span class="t-disabled px-0.5">→</span>` : null}
+          ${i > 0 ? html`<span class="t-dim px-0.5">→</span>` : null}
           <span class="chip sm ${phaseColor(p)}">${p}</span>
         </span>
       `)}

--- a/dashboard/src/components/provider-capability-matrix/roadmap.ts
+++ b/dashboard/src/components/provider-capability-matrix/roadmap.ts
@@ -18,35 +18,31 @@ import {
 
 function PhaseCard({ item }: { item: typeof ROADMAP_ITEMS[number] }) {
   return html`
-    <div class="border rounded overflow-hidden ${phaseColor(item.id)}">
-      <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--color-border-default)]">
+    <div class="pm-card ${phaseColor(item.id)}">
+      <div class="pm-card-head">
         <div class="flex items-center gap-2">
-          <span class="text-xs font-bold font-mono">${item.id}</span>
-          <span class="text-xs font-medium">${item.area}</span>
+          <span class="t-label t-bold t-mono">${item.id}</span>
+          <span class="t-label">${item.area}</span>
         </div>
-        <span class="text-[10px] font-mono text-[var(--color-fg-muted)]">${item.timeline}</span>
+        <span class="t-micro t-mono t-dim">${item.timeline}</span>
       </div>
-      <div class="px-3 py-2 bg-[var(--shell-rail-bg)] text-[var(--color-fg-primary)]">
-        <p class="text-[11px] leading-snug mb-1.5">${item.goal}</p>
+      <div class="px-3 py-2 bg-[var(--shell-rail-bg)]">
+        <p class="t-caption mb-1.5">${item.goal}</p>
         <div class="flex flex-wrap gap-1 mb-1.5">
           ${item.targetAntiPatterns.map(ap => html`
-            <span key=${ap} class="inline-block rounded px-1 py-px text-[9px] font-mono bg-[var(--bad-10)] text-[var(--bad-light)]">
-              ${ap}
-            </span>
+            <span key=${ap} class="chip sm is-err">${ap}</span>
           `)}
         </div>
-        <div class="flex items-center gap-2 text-[10px]">
-          <span class="text-[var(--color-fg-muted)]">참조:</span>
-          <span class="text-[var(--color-fg-secondary)]">${item.reference}</span>
+        <div class="flex items-center gap-2 t-micro">
+          <span class="t-dim">참조:</span>
+          <span class="t-meta">${item.reference}</span>
         </div>
-        <div class="mt-1 text-[10px] font-medium text-[var(--color-status-ok)]">
-          ${item.effect}
-        </div>
+        <div class="mt-1 t-micro t-ok t-semi">${item.effect}</div>
         ${item.deps.length > 0 ? html`
-          <div class="mt-1 flex items-center gap-1 text-[9px] text-[var(--color-fg-muted)]">
+          <div class="mt-1 flex items-center gap-1 t-micro t-dim">
             <span>선행:</span>
             ${item.deps.map(d => html`
-              <span key=${d} class="rounded px-1 py-px bg-[var(--white-4)] font-mono">${d}</span>
+              <span key=${d} class="chip sm is-ghost">${d}</span>
             `)}
           </div>
         ` : null}
@@ -58,11 +54,11 @@ function PhaseCard({ item }: { item: typeof ROADMAP_ITEMS[number] }) {
 function DependencyGraph() {
   const phases = ROADMAP_ITEMS.map(r => r.id)
   return html`
-    <div class="flex items-center gap-1 text-[10px] font-mono flex-wrap">
+    <div class="flex items-center gap-1 t-micro t-mono flex-wrap">
       ${phases.map((p, i) => html`
         <span key=${p} class="inline-flex items-center gap-0.5">
-          ${i > 0 ? html`<span class="text-[var(--color-fg-disabled)] px-0.5">→</span>` : null}
-          <span class="rounded px-1.5 py-0.5 ${phaseColor(p)}">${p}</span>
+          ${i > 0 ? html`<span class="t-disabled px-0.5">→</span>` : null}
+          <span class="chip sm ${phaseColor(p)}">${p}</span>
         </span>
       `)}
     </div>
@@ -80,29 +76,29 @@ function formatFte(value: number): string {
 
 function Timeline() {
   return html`
-    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-      <table class="w-full text-xs border-collapse">
-        <thead>
-          <tr class="bg-[var(--white-4)]">
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[50px]">주차</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[60px]">Phase</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">작업</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">산출물</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[70px]">의존</th>
+    <div class="pm-scroll">
+      <table class="pm-table">
+        <thead class="pm-thead">
+          <tr>
+            <th class="pm-th pm-th--right-border min-w-[50px]">주차</th>
+            <th class="pm-th pm-th--right-border min-w-[60px]">Phase</th>
+            <th class="pm-th pm-th--right-border">작업</th>
+            <th class="pm-th pm-th--right-border">산출물</th>
+            <th class="pm-th min-w-[70px]">의존</th>
           </tr>
         </thead>
         <tbody>
           ${PHASE_TIMELINE.map((row, i) => {
             const phaseClass = PHASE_COLORS[row.phase] ?? ''
             return html`
-              <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[11px] text-[var(--color-fg-muted)]">${row.week}</td>
-                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1">
-                  <span class="inline-block rounded px-1.5 py-0.5 text-[9px] font-bold ${phaseClass}">${row.phase}</span>
+              <tr key=${i} class="pm-row-alt">
+                <td class="pm-td pm-td--right-border pm-td--mono t-dim">${row.week}</td>
+                <td class="pm-td pm-td--right-border">
+                  <span class="chip sm ${phaseClass}">${row.phase}</span>
                 </td>
-                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[11px]">${row.work}</td>
-                <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-secondary)]">${row.deliverable}</td>
-                <td class="border-b border-[var(--color-border-default)] px-2 py-1 font-mono text-[10px] text-[var(--color-fg-muted)]">${row.deps}</td>
+                <td class="pm-td pm-td--right-border t-caption">${row.work}</td>
+                <td class="pm-td pm-td--right-border t-meta">${row.deliverable}</td>
+                <td class="pm-td t-micro t-mono t-dim">${row.deps}</td>
               </tr>
             `
           })}
@@ -122,35 +118,35 @@ function ResourceTable() {
   ) ?? []
 
   return html`
-    <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-      <table class="w-full text-xs border-collapse">
-        <thead>
-          <tr class="bg-[var(--white-4)]">
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">트랙</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">범위</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-center font-medium text-[var(--color-fg-secondary)] min-w-[40px]">인력</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">0–4주</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">4–8주</th>
-            <th class="border-b border-r border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">8–12주</th>
-            <th class="border-b border-[var(--color-border-default)] px-2 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[55px]">12–16주</th>
+    <div class="pm-scroll">
+      <table class="pm-table">
+        <thead class="pm-thead">
+          <tr>
+            <th class="pm-th pm-th--right-border">트랙</th>
+            <th class="pm-th pm-th--right-border">범위</th>
+            <th class="pm-th pm-th--center pm-th--right-border min-w-[40px]">인력</th>
+            <th class="pm-th pm-th--center pm-th--right-border min-w-[55px]">0–4주</th>
+            <th class="pm-th pm-th--center pm-th--right-border min-w-[55px]">4–8주</th>
+            <th class="pm-th pm-th--center pm-th--right-border min-w-[55px]">8–12주</th>
+            <th class="pm-th pm-th--center min-w-[55px]">12–16주</th>
           </tr>
         </thead>
         <tbody>
           ${RESOURCE_ALLOCATION.map((row, i) => html`
-            <tr key=${i} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-              <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 font-medium text-[var(--color-fg-primary)]">${row.track}</td>
-              <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-fg-secondary)]">${row.scope}</td>
-              <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${row.headcount}인</td>
+            <tr key=${i} class="pm-row-alt">
+              <td class="pm-td pm-td--right-border t-semi">${row.track}</td>
+              <td class="pm-td pm-td--right-border t-micro t-meta">${row.scope}</td>
+              <td class="pm-td pm-td--right-border pm-td--center pm-td--mono">${row.headcount}인</td>
               ${row.pct.map((p, j) => html`
-                <td key=${j} class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px] text-[var(--color-fg-muted)]">${p}</td>
+                <td key=${j} class="pm-td pm-td--right-border pm-td--center pm-td--mono t-micro t-dim">${p}</td>
               `)}
             </tr>
           `)}
-          <tr class="bg-[var(--white-4)] font-medium">
-            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1" colSpan=${2}>합계 FTE</td>
-            <td class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[11px]">${totalHeadcount}인</td>
+          <tr class="pm-cat-row">
+            <td class="pm-td" colSpan=${2}>합계 FTE</td>
+            <td class="pm-td pm-td--center pm-td--mono">${totalHeadcount}인</td>
             ${phaseTotals.map((total, i) => html`
-              <td key=${i} class="border-r border-b border-[var(--color-border-default)] px-2 py-1 text-center font-mono text-[10px]">${formatFte(total)}</td>
+              <td key=${i} class="pm-td pm-td--center pm-td--mono t-micro">${formatFte(total)}</td>
             `)}
           </tr>
         </tbody>
@@ -163,24 +159,22 @@ function SuccessMetrics() {
   return html`
     <div class="grid grid-cols-1 gap-3">
       ${SUCCESS_METRICS.map(m => html`
-        <div key=${m.id} class="border border-[var(--color-border-default)] rounded overflow-hidden">
-          <div class="flex items-center justify-between px-3 py-2 bg-[var(--white-4)] border-b border-[var(--color-border-default)]">
+        <div key=${m.id} class="pm-card">
+          <div class="pm-card-head">
             <div class="flex items-center gap-2">
-              <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${m.title}</span>
-              <span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono font-bold bg-[var(--ok-10)] text-[var(--color-status-ok)]">
-                Target: ${m.target}
-              </span>
+              <span class="t-label t-semi">${m.title}</span>
+              <span class="chip sm is-ok">Target: ${m.target}</span>
             </div>
           </div>
           <div class="px-3 py-2">
-            <p class="text-[11px] leading-snug text-[var(--color-fg-secondary)] mb-2">${m.description}</p>
+            <p class="t-caption t-meta mb-2">${m.description}</p>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
               ${Object.entries(m.phases).map(([phase, desc]) => {
                 const phaseClass = PHASE_COLORS[phase] ?? ''
                 return html`
-                  <div key=${phase} class="border border-[var(--color-border-default)] rounded px-2 py-1.5">
-                    <span class="inline-block rounded px-1 py-px text-[9px] font-bold ${phaseClass} mb-1">${phase}</span>
-                    <p class="text-[10px] leading-snug text-[var(--color-fg-muted)]">${desc}</p>
+                  <div key=${phase} class="pm-card px-2 py-1.5">
+                    <span class="chip sm ${phaseClass} mb-1">${phase}</span>
+                    <p class="t-micro t-dim">${desc}</p>
                   </div>
                 `
               })}
@@ -195,12 +189,12 @@ function SuccessMetrics() {
 export function Roadmap() {
   return html`
     <div class="flex flex-col gap-4">
-      <div class="flex items-center gap-4 text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+      <div class="t-micro t-mono t-dim px-1">
         <span>sec06–07 — P0–P7 순차-병렬 하이브리드 개선 계획 + 16주 구현 로드맵</span>
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">의존성 그래프</h4>
+        <h4 class="t-label t-semi mb-2">의존성 그래프</h4>
         <${DependencyGraph} />
       </div>
 
@@ -211,33 +205,27 @@ export function Roadmap() {
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Per-Provider 적용 매트릭스</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec06 Table 6-2 — ✅ 직접 적용, ⚠️ 제한적, ❌ 불가, — 해당 없음</p>
-        <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-          <table class="w-full text-xs border-collapse">
-            <thead>
-              <tr class="bg-[var(--white-4)]">
-                <th class="sticky left-0 z-10 bg-[var(--shell-rail-bg)] border-b border-r border-[var(--color-border-default)] px-2 py-1.5 text-left font-medium text-[var(--color-fg-secondary)] min-w-[60px]">
-                  항목
-                </th>
+        <h4 class="t-label t-semi mb-2">Per-Provider 적용 매트릭스</h4>
+        <p class="t-micro t-dim mb-2">sec06 Table 6-2 — ✅ 직접 적용, ⚠️ 제한적, ❌ 불가, — 해당 없음</p>
+        <div class="pm-scroll">
+          <table class="pm-table">
+            <thead class="pm-thead">
+              <tr>
+                <th class="pm-th pm-th--sticky min-w-[60px]">항목</th>
                 ${PROVIDER_IDS.map(pid => html`
-                  <th key=${pid} class="border-b border-[var(--color-border-default)] px-1.5 py-1 text-center font-medium text-[var(--color-fg-secondary)] min-w-[50px]">
-                    ${PROVIDER_LABELS[pid] ?? pid}
-                  </th>
+                  <th key=${pid} class="pm-th pm-th--center min-w-[50px]">${PROVIDER_LABELS[pid] ?? pid}</th>
                 `)}
               </tr>
             </thead>
             <tbody>
               ${ROADMAP_ITEMS.map((item, i) => html`
-                <tr key=${item.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                  <td class="sticky left-0 z-10 ${i % 2 === 0 ? 'bg-[var(--shell-rail-bg)]' : 'bg-[var(--white-2)]'} border-r border-b border-[var(--color-border-default)] px-2 py-1 font-mono font-bold text-[11px]">
-                    ${item.id}
-                  </td>
+                <tr key=${item.id} class="pm-row-alt">
+                  <td class="pm-td pm-th--sticky pm-td--mono t-bold">${item.id}</td>
                   ${PROVIDER_IDS.map(pid => {
                     const a = APPLICABILITY_MATRIX[item.id][pid] ?? 'na'
                     return html`
-                      <td key=${pid} class="border-b border-[var(--color-border-default)] px-1 py-0.5 text-center">
-                        <span class="inline-block w-full rounded px-1 py-0.5 text-[10px] font-mono font-bold ${applicabilityCellClass(a)}">
+                      <td key=${pid} class="pm-td pm-td--center">
+                        <span class="pm-cell-badge ${applicabilityCellClass(a)}">
                           ${applicabilitySymbol(a)}
                         </span>
                       </td>
@@ -251,20 +239,20 @@ export function Roadmap() {
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">Phase별 구현 타임라인</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec07 Table 7-1 — 16주 4-Phase 순차-병렬 하이브리드 로드맵</p>
+        <h4 class="t-label t-semi mb-2">Phase별 구현 타임라인</h4>
+        <p class="t-micro t-dim mb-2">sec07 Table 7-1 — 16주 4-Phase 순차-병렬 하이브리드 로드맵</p>
         <${Timeline} />
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">리소스 할당</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec07 Table 7-2 — 3 트랙 × 4 Phase 병렬 진행</p>
+        <h4 class="t-label t-semi mb-2">리소스 할당</h4>
+        <p class="t-micro t-dim mb-2">sec07 Table 7-2 — 3 트랙 × 4 Phase 병렬 진행</p>
         <${ResourceTable} />
       </div>
 
       <div>
-        <h4 class="text-xs font-semibold text-[var(--color-fg-primary)] mb-2">성공 지표</h4>
-        <p class="text-[10px] text-[var(--color-fg-muted)] mb-2">sec07 §7.3 — 16주 로드맵 완료 판정 기준 (3개 교차 검증 지표)</p>
+        <h4 class="t-label t-semi mb-2">성공 지표</h4>
+        <p class="t-micro t-dim mb-2">sec07 §7.3 — 16주 로드맵 완료 판정 기준 (3개 교차 검증 지표)</p>
         <${SuccessMetrics} />
       </div>
     </div>

--- a/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
+++ b/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
@@ -31,37 +31,37 @@ export function WiringGaps() {
         <${StatTile} label="정확" value=${correct.length} variant="gold" hint=${`${WIRING_GAPS.length} 중`} />
       </div>
 
-      <div class="flex items-center gap-2 flex-wrap text-[10px] font-mono text-[var(--color-fg-muted)] px-1">
+      <div class="flex items-center gap-2 flex-wrap t-micro t-mono t-dim px-1">
         ${providerCounts.map(([prov, cnt]) => html`
           <span key=${prov} class="inline-flex items-center gap-1">
-            <span class="font-medium text-[var(--color-fg-secondary)]">${prov}</span>
-            <span class="text-[var(--color-fg-disabled)]">${cnt}건</span>
+            <span class="t-semi t-meta">${prov}</span>
+            <span class="t-disabled">${cnt}건</span>
           </span>
         `)}
       </div>
 
-      <div class="overflow-x-auto rounded border border-[var(--color-border-default)]">
-        <table class="w-full text-xs border-collapse">
-          <thead>
-            <tr class="bg-[var(--white-4)]">
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">ID</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">프로바이더</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">기능</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">OAS 선언</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">실제 동작</th>
-              <th class="border-b border-[var(--color-border-default)] px-3 py-1.5 text-left font-medium text-[var(--color-fg-secondary)]">영향도</th>
+      <div class="pm-scroll">
+        <table class="pm-table">
+          <thead class="pm-thead">
+            <tr>
+              <th class="pm-th">ID</th>
+              <th class="pm-th">프로바이더</th>
+              <th class="pm-th">기능</th>
+              <th class="pm-th">OAS 선언</th>
+              <th class="pm-th">실제 동작</th>
+              <th class="pm-th">영향도</th>
             </tr>
           </thead>
           <tbody>
             ${gaps.map((gap, i) => {
               return html`
-                <tr key=${gap.id} class="${i % 2 === 0 ? '' : 'bg-[var(--white-2)]'}">
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 font-mono text-[var(--color-fg-muted)]">${gap.id}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 font-medium text-[var(--color-fg-primary)]">${gap.provider}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 text-[var(--color-fg-secondary)]">${gap.capability}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 font-mono text-[var(--color-fg-muted)]">${gap.oasDeclares}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2 text-[var(--color-fg-secondary)]">${gap.actualBehavior}</td>
-                  <td class="border-b border-[var(--color-border-default)] px-3 py-2">
+                <tr key=${gap.id} class="pm-row-alt">
+                  <td class="pm-td pm-td--mono t-dim">${gap.id}</td>
+                  <td class="pm-td t-semi">${gap.provider}</td>
+                  <td class="pm-td t-meta">${gap.capability}</td>
+                  <td class="pm-td pm-td--mono t-dim">${gap.oasDeclares}</td>
+                  <td class="pm-td t-meta">${gap.actualBehavior}</td>
+                  <td class="pm-td">
                     <${StatusChip} tone=${impactTone(gap.impact)}>${gap.impact.toUpperCase()}<//>
                   </td>
                 </tr>

--- a/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
+++ b/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
@@ -35,7 +35,7 @@ export function WiringGaps() {
         ${providerCounts.map(([prov, cnt]) => html`
           <span key=${prov} class="inline-flex items-center gap-1">
             <span class="t-semi t-meta">${prov}</span>
-            <span class="t-disabled">${cnt}건</span>
+            <span class="t-dim">${cnt}건</span>
           </span>
         `)}
       </div>

--- a/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
+++ b/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
@@ -31,10 +31,10 @@ export function WiringGaps() {
         <${StatTile} label="정확" value=${correct.length} variant="gold" hint=${`${WIRING_GAPS.length} 중`} />
       </div>
 
-      <div class="flex items-center gap-2 flex-wrap t-micro t-mono t-dim px-1">
+      <div class="flex items-center gap-2 flex-wrap t-micro mono t-dim px-1">
         ${providerCounts.map(([prov, cnt]) => html`
           <span key=${prov} class="inline-flex items-center gap-1">
-            <span class="t-semi t-meta">${prov}</span>
+            <span class="font-semibold t-meta">${prov}</span>
             <span class="t-dim">${cnt}건</span>
           </span>
         `)}
@@ -57,7 +57,7 @@ export function WiringGaps() {
               return html`
                 <tr key=${gap.id} class="pm-row-alt">
                   <td class="pm-td pm-td--mono t-dim">${gap.id}</td>
-                  <td class="pm-td t-semi">${gap.provider}</td>
+                  <td class="pm-td font-semibold">${gap.provider}</td>
                   <td class="pm-td t-meta">${gap.capability}</td>
                   <td class="pm-td pm-td--mono t-dim">${gap.oasDeclares}</td>
                   <td class="pm-td t-meta">${gap.actualBehavior}</td>

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -33,6 +33,7 @@ import './styles/governance.css'
 import './styles/governance-agent.css'
 import './styles/ops.css'
 import './styles/tools.css'
+import './styles/provider-matrix.css'
 import './styles/paper-theme.css'
 
 import { render } from 'preact'

--- a/dashboard/src/styles/provider-matrix.css
+++ b/dashboard/src/styles/provider-matrix.css
@@ -1,0 +1,165 @@
+/* provider-matrix.css — Design-system-aligned styles for Provider Capability Matrix.
+   Leverages tokens.css + primitives.css semantic classes.
+   Layout utilities (flex, grid, gap) remain inline via Tailwind. */
+
+/* ════════ TABLE BASE ════════ */
+.pm-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-11);
+}
+
+/* ════════ TABLE HEADER ════════ */
+.pm-thead tr {
+  background: var(--color-bg-surface);
+}
+
+.pm-th {
+  border-bottom: 1px solid var(--color-border-default);
+  padding: var(--sp-1h) var(--sp-2);
+  text-align: left;
+  font-weight: var(--fw-semi);
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+}
+
+.pm-th--center { text-align: center; }
+.pm-th--right  { text-align: right; }
+
+.pm-th--sticky {
+  position: sticky;
+  left: 0;
+  z-index: 10;
+  background: var(--shell-rail-bg, var(--color-bg-surface));
+  border-right: 1px solid var(--color-border-default);
+}
+
+/* ════════ TABLE BODY ════════ */
+.pm-td {
+  border-bottom: 1px solid var(--color-border-default);
+  padding: var(--sp-1h) var(--sp-2);
+}
+
+.pm-td--center { text-align: center; }
+.pm-td--right  { text-align: right; }
+
+.pm-td--mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+}
+
+.pm-td--right-border {
+  border-right: 1px solid var(--color-border-default);
+}
+
+/* alternating row — apply to tr */
+.pm-row-alt:nth-child(even) {
+  background: var(--color-bg-hover);
+}
+
+/* ════════ CARD ════════
+   Replaces: border border-[var(--color-border-default)] rounded overflow-hidden */
+.pm-card {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+
+.pm-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--sp-3);
+  min-height: 28px;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+/* ════════ TABLE WRAPPER (scroll container) ════════ */
+.pm-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+}
+
+/* ════════ CATEGORY HEADER ROW ════════ */
+.pm-cat-row td {
+  background: var(--color-bg-surface);
+  border-right: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--color-border-default);
+  padding: var(--sp-1) var(--sp-2);
+  font-size: var(--fs-10);
+  font-weight: var(--fw-semi);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--track-caps);
+}
+
+/* ════════ FILTER BUTTON ════════
+   Replaces inline px-2 py-0.5 rounded text-[10px] font-mono border */
+.pm-filter {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--sp-2);
+  height: var(--ctrl-h-xs);
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-border-default);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  color: var(--color-fg-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: border-color var(--motion-swap), background var(--motion-swap), color var(--motion-swap);
+}
+
+.pm-filter:hover {
+  border-color: var(--color-border-strong);
+}
+
+.pm-filter.is-active {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+}
+
+/* ════════ CELL BADGE ════════
+   Inline indicator inside matrix cells (support level symbols). */
+.pm-cell-badge {
+  display: inline-block;
+  width: 100%;
+  border-radius: var(--r-1);
+  padding: 0 var(--sp-1);
+  font-size: var(--fs-10);
+  font-family: var(--font-mono);
+  font-weight: var(--fw-bold);
+  text-align: center;
+}
+
+/* ════════ CELL VARIANTS ════════ */
+.pm-td--indent {
+  padding-left: var(--sp-4);
+  font-weight: var(--fw-semi);
+  color: var(--color-fg-primary);
+}
+
+.pm-td--alt-bg {
+  background: var(--color-bg-hover);
+}
+
+/* ════════ CHIP EXTENSIONS ════════
+   Map to primitives.css .chip base for matrix-specific badges. */
+/* ════════ CLI WRAPPER ROW ════════ */
+.pm-row--cli {
+  opacity: 0.85;
+}
+
+.pm-row--cli .pm-td {
+  font-style: italic;
+}
+
+/* ════════ CHIP EXTENSIONS ════════
+   Map to primitives.css .chip base for matrix-specific badges. */
+.chip.sm.is-ghost {
+  background: var(--white-4, var(--color-bg-hover));
+  color: var(--color-fg-muted);
+}

--- a/dashboard/src/styles/provider-matrix.css
+++ b/dashboard/src/styles/provider-matrix.css
@@ -26,6 +26,10 @@
 .pm-th--center { text-align: center; }
 .pm-th--right  { text-align: right; }
 
+.pm-th--right-border {
+  border-right: 1px solid var(--color-border-default);
+}
+
 .pm-th--sticky {
   position: sticky;
   left: 0;

--- a/dashboard/src/styles/provider-matrix.css
+++ b/dashboard/src/styles/provider-matrix.css
@@ -38,6 +38,15 @@
   border-right: 1px solid var(--color-border-default);
 }
 
+/* sticky td — inherits row background so alternating stripes show through */
+.pm-td--sticky {
+  position: sticky;
+  left: 0;
+  z-index: 5;
+  background: inherit;
+  border-right: 1px solid var(--color-border-default);
+}
+
 /* ════════ TABLE BODY ════════ */
 .pm-td {
   border-bottom: 1px solid var(--color-border-default);
@@ -58,6 +67,11 @@
 
 /* alternating row — apply to tr */
 .pm-row-alt:nth-child(even) {
+  background: var(--color-bg-hover);
+}
+
+/* explicit alt row — use when nth-child is unreliable (e.g. interleaved header rows) */
+.pm-row--alt {
   background: var(--color-bg-hover);
 }
 
@@ -162,8 +176,8 @@
 }
 
 /* ════════ CHIP EXTENSIONS ════════
-   Map to primitives.css .chip base for matrix-specific badges. */
-.chip.sm.is-ghost {
+   Scoped ghost chip override for provider-matrix cards only. */
+.pm-card .chip.sm.is-ghost {
   background: var(--white-4, var(--color-bg-hover));
   color: var(--color-fg-muted);
 }


### PR DESCRIPTION
## Summary
- Replace inline Tailwind arbitrary values (`bg-[var(--ok-10)]`, `text-[var(--color-fg-primary)]`) with design-system-aligned CSS bridge classes (`.pm-table`, `.pm-card`, `.pm-scroll`, `.pm-filter`) and semantic type role classes (`.t-title`, `.t-meta`, `.t-caption`, `.t-micro`, `.t-label`)
- New CSS module `provider-matrix.css` with `.pm-*` bridge classes referencing `tokens.css` + `primitives.css` design tokens
- All 8 provider-capability-matrix sub-components refactored: feature-matrix, index, oas-provider-table, cascade-trace, anti-patterns, roadmap, model-catalog, wiring-gaps, bfcl-rankings

## Files changed (11)
- **New**: `dashboard/src/styles/provider-matrix.css` — bridge CSS module (20 classes)
- **Modified**: `dashboard/src/main.ts` — import new CSS
- **Modified**: 8 component files under `provider-capability-matrix/`

## Verification
- [x] `npx vite build` passes with 0 errors (8.36s build, 4247 modules)
- [x] Static CSS audit: 34 design system classes all present in built output (0 missing)
- [x] Unit tests: 5/5 pass (`runtimeProviderToMatrixId`, `liveStatusDot`, `FeatureMatrix`, `WiringGaps`, `AntiPatternList`)
- [x] Runtime JS errors: 0 (Playwright console check)
- [x] Fix: `t-disabled` (undefined class) → `t-dim`
- [x] Fix: `pm-th--right-border` (missing definition) → added to provider-matrix.css
- [ ] Visual regression: requires MASC backend (API proxy dependency) — verify in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)