### PR TITLE
feat(reactivity): enforce minimum proactive heartbeat cadence

### DIFF
--- a/lib/keeper/heartbeat_smart.ml
+++ b/lib/keeper/heartbeat_smart.ml
@@ -70,6 +70,11 @@ let should_emit ~config ~agent_status ~last_activity ~last_heartbeat =
       Emit
     else
       (* Calculate next emit time *)
+      let max_silence = 900.0 in
+    if time_since_last >= max_silence then
+      Emit
+    else
+      (* Calculate next emit time *)
       let next_emit = last_heartbeat +. interval in
       Skip_idle next_emit
 


### PR DESCRIPTION
## Description
Implements Phase 21 (MASC Task 138) to ensure Keepers maintain a minimum level of reactivity in the world.

## Changes
- Modified `Heartbeat_smart.should_emit` to enforce a `max_silence` threshold of 900 seconds (15 minutes). 
- If a Keeper hasn't emitted a heartbeat in over 15 minutes, it will now force an `Emit` even if it would otherwise be classified as idle.

This prevents Keepers from being prematurely garbage collected or becoming stale during long idleness windows.