### PR TITLE
fix: sync stale test defaults with Env_config_exec_timeout (#10426)

### DIFF
--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -24,17 +24,17 @@ let cases =
     E.Fs, 30.0;
     E.Preflight, 10.0;
     E.Repo_readiness, 10.0;
-    E.Sandbox, 2.0;
+    E.Sandbox, 10.0;
     E.Pr_review, 15.0;
     E.Pr_review_post, 30.0;
     E.Dispatch, 120.0;
     E.Memory_audit, 3.0;
     E.Alerting, 20.0;
     E.Gh_shared, 10.0;
-    E.Status_detail, 10.0;
+    E.Status_detail, 5.0;
     E.Turn_sandbox, 2.0;
     E.Turn_up, 15.0;
-    E.Git_meta, 5.0;
+    E.Git_meta, 10.0;
     E.Shell_probe, 2.0;
   ]
 


### PR DESCRIPTION
## Summary
- Fix 3 caller defaults in `test_env_config_exec_timeout_10426.ml` that drifted after #12793 updated the implementation defaults in the P1 migration
- Sandbox: `2.0` → `10.0`, Status_detail: `10.0` → `5.0`, Git_meta: `5.0` → `10.0`

## Test plan
- [x] `dune runtest test/test_env_config_exec_timeout_10426.ml --root <worktree>` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)