### PR TITLE
fix(keeper): inject stream_idle_timeout default when caller omits option

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -290,7 +290,13 @@ let run_named
                  stream_idle_timeout_s =
                    (match per_provider_timeout_s with
                     | Some _ as timeout_s -> timeout_s
-                    | None -> stream_idle_timeout_s);
+                    | None ->
+                        Some
+                          (Option.value
+                             ~default:
+                               Env_config_keeper.KeeperKeepalive
+                               .stream_idle_timeout_sec
+                             stream_idle_timeout_s));
                  temperature;
                  max_idle_turns;
                  guardrails;


### PR DESCRIPTION
## Why

The 2026-04-28 FSM reanalysis (`executor_reanalysis.md` §4 Problem 1) diagnosed the executor keeper "streaming hang" as the result of an unbounded provider-level idle timeout.  Tracing the wire-through:

1. 12 keeper-level callers of `Oas_worker.run_named` omit `~stream_idle_timeout_s` (caller-side grep returns 0 mentions).
2. `Oas_worker_named.run_named` propagates the resulting `None` directly into `Oas_worker_exec.config`.
3. `pipeline_stage_route.ml:94` forwards it as `?stream_idle_timeout_s`.
4. OAS `complete.ml:967, 984` calls `?idle_timeout:None` on the Eio stream reader, which then waits indefinitely (docstring at `complete.ml:1021`: *"indefinitely - stream_idle_timeout_s only resets when a line arrives"*).

`Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec` (default 120s, env `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC`, range [5, 600]) was already wired through the options but never injected when callers omitted the parameter.

## What

`Oas_worker_named.run_named` now injects the env-driven default in the sole `None` branch of the `stream_idle_timeout_s` resolution.  Per-provider override (`per_provider_timeout_s`) continues to take precedence.

## Risk

- All 12 keeper-level callers (verifier, dashboard, autoresearch, server openai-compat, anti_rationalization, auto_responder, keeper_persona_authoring, keeper_agent_run, tool_deep_review) gain a 120s idle ceiling, strictly below the existing 3600s OAS turn budget — no regression possible.
- Tunable via `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC`.

## Validation

- `oas_worker_named` module dependency analysis succeeded under `dune build @check` (artefacts at `_build/default/lib/.masc_mcp.objs/masc_mcp__Oas_worker_named.{intf,impl}.{d,all-deps}`).
- CI: **blocked by two unrelated main blockers** (`keeper_passive_loop_detector.ml:91-100` printf format type mismatch from #12809, and `test/test_keeper_supervisor.ml:1192` `Masc_mcp.Env_config` unbound module after rename to `Env_config_keeper`). These will be fixed in a follow-up micro-PR.

## References

- 2026-04-28 FSM reanalysis (`executor_reanalysis.md` §4 Problem 1, §5)
- `complete.ml:1021` docstring contract
- `env_config_keeper.ml:529-535` (default declaration)