### PR TITLE
fix: unblock main build (printf format + Env_config_keeper rename)

### DIFF
--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -91,12 +91,12 @@ let current_streak ~keeper_name =
 let nudge_message_text ~streak =
   Printf.sprintf
     ("ACTION REQUIRED — PASSIVE LOOP DETECTED: You have completed %d"
-     ^ " consecutive turns using only read-only or status tools without any"
-     ^ " execution or completion action. This violates the keeper turn"
-     ^ " contract. You MUST call an execution or completion tool this turn"
-     ^ " (e.g. keeper_task_done, keeper_task_claim, keeper_shell,"
-     ^ " keeper_board_post with a concrete update, or another write tool)."
-     ^ " Do not call read-only tools again without first taking an action.")
+     ^^ " consecutive turns using only read-only or status tools without any"
+     ^^ " execution or completion action. This violates the keeper turn"
+     ^^ " contract. You MUST call an execution or completion tool this turn"
+     ^^ " (e.g. keeper_task_done, keeper_task_claim, keeper_shell,"
+     ^^ " keeper_board_post with a concrete update, or another write tool)."
+     ^^ " Do not call read-only tools again without first taking an action.")
     streak
 
 let nudge_message ~keeper_name =

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1189,14 +1189,14 @@ let () =
     ];
     "liveness_recovery", [
       test_case "backoff_base * 2^attempt, capped at max" `Quick (fun () ->
-        let base = Masc_mcp.Env_config.KeeperSupervisor.liveness_recovery_backoff_base_sec in
-        let max_s = Masc_mcp.Env_config.KeeperSupervisor.liveness_recovery_backoff_max_sec in
+        let base = Env_config_keeper.KeeperSupervisor.liveness_recovery_backoff_base_sec in
+        let max_s = Env_config_keeper.KeeperSupervisor.liveness_recovery_backoff_max_sec in
         let d0 = Sup.liveness_recovery_backoff 0 in
         let d1 = Sup.liveness_recovery_backoff 1 in
         check (float 0.1) "attempt 0 = base" base d0;
         check (float 0.1) "attempt 1 = 2*base" (Float.min max_s (base *. 2.0)) d1);
       test_case "backoff capped at max" `Quick (fun () ->
-        let max_s = Masc_mcp.Env_config.KeeperSupervisor.liveness_recovery_backoff_max_sec in
+        let max_s = Env_config_keeper.KeeperSupervisor.liveness_recovery_backoff_max_sec in
         let d_big = Sup.liveness_recovery_backoff 100 in
         check (float 0.1) "large attempt capped" max_s d_big);
       test_case "should_attempt: Dead phase + elapsed → true" `Quick (fun () ->


### PR DESCRIPTION
## Why

Two unrelated regressions are blocking every PR since 2026-05-04:

```
File "lib/keeper/keeper_passive_loop_detector.ml", lines 93-99:
Error: This expression has type string but an expression was expected of type
       ('a -> 'b, unit, string) format

File "test/test_keeper_supervisor.ml", line 1192:
Error: Unbound module Masc_mcp.Env_config_keeper
```

Both surfaced after #12809 (passive loop action injection) and #12803 (issue dependency graph) merged into main without the test/format sweep.

## What

**1. `keeper_passive_loop_detector.ml:91-100` — printf format**

`Printf.sprintf` was given a `%d` format string concatenated with plain string literals via `^`.  `^` returns `string`, not `format6`, so type inference breaks.  Replace with `^^` (the format string concat operator).

**2. `test/test_keeper_supervisor.ml` lines 1192/1193/1199 — Env_config_keeper rename**

Test referenced `Masc_mcp.Env_config.KeeperSupervisor`, but `KeeperSupervisor` lives in `lib/config/env_config_keeper.ml` which is a separate `masc_config` library with `(wrapped false)`.  The correct path is `Env_config_keeper.KeeperSupervisor` (no `Masc_mcp` prefix), matching the existing pattern in `test_keeper_turn_timeout_default_10456.ml` and `test_keeper_docker_read.ml`.

## Validation

- [x] `dune build @check` passes (clean output, exit 0).
- [x] `git diff --stat`: 2 files changed, 9 insertions(+), 9 deletions(-).
- [x] No semantic change to the test assertions or the nudge message text.

## References

- #12809, #12803 (introduced the regressions)
- #12814 (blocked by these errors; will pass CI once this merges)
- `test/test_keeper_turn_timeout_default_10456.ml`, `test/test_keeper_docker_read.ml` (existing `Env_config_keeper.X` reference pattern)