### PR TITLE
feat(metrics): emit capability_drop on cascade-empty rejection

### DIFF
--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -258,6 +258,19 @@ let filter_candidate_providers_for_tool_support
     in
     if kept = [] && provider_cfgs <> [] then begin
       let signature = signature_of_rejected_providers rejected in
+      (* Forward each rejection to the Prometheus capability_drop counter so
+         operators can alert on cascade-empty silently dropping requests.
+         The WARN log below describes the systemic cause; the per-rejection
+         metric records every provider lost so dashboards can attribute
+         which provider/reason combination drove the drop. *)
+      List.iter
+        (fun (provider_cfg, reason) ->
+          Llm_metric_bridge.emit_capability_drop
+            ~model_id:provider_cfg.Llm_provider.Provider_config.model_id
+            ~field:
+              (Printf.sprintf "cascade_empty:%s"
+                 (filter_rejection_reason_label reason)))
+        rejected;
       if cascade_empty_should_emit_first ~label ~signature then
         Log.Misc.error
           "[#11060/#11356] cascade %s: provider-normalized tool-use gate \


### PR DESCRIPTION
## Why

The 2026-05-02 LLM Provider Compatibility report §6.6.1 (Silent Failure → Explicit Error) targets every \"capability drop\" path in the system — drops should be observable as structured metrics, not just stderr WARN lines.

Today the cascade-empty path in \`oas_worker_named_cascade.ml:259-278\` matches that anti-pattern: when the provider-normalized tool-use gate empties a cascade (every configured provider rejected — e.g. \`keeper_unified\` with only \`codex_cli\` providers under a keeper-bound runtime MCP policy), only a WARN log is emitted.  Operators alerting on \`masc_llm_provider_capability_drops_total\` get **zero signal** even though every request to that cascade is silently failing.

\`Llm_metric_bridge.emit_capability_drop\` already exists, OAS \`backend_openai.ml\` already calls it for \`top_k\`/\`min_p\`/\`max_tokens:clamp\` drops, and \`oas_worker_cascade.ml:377\` wires it as the OAS-level callback — masc-mcp's own cascade-empty path was the missing emit site.

## What

For each \`(provider_cfg, reason)\` in the rejected list, call:

\`\`\`
Llm_metric_bridge.emit_capability_drop
  ~model_id:provider_cfg.Llm_provider.Provider_config.model_id
  ~field:(Printf.sprintf \"cascade_empty:%s\" (filter_rejection_reason_label reason))
\`\`\`

The systemic WARN/DEBUG message is preserved for narrative diagnosis; this adds the per-rejection structured metric counterpart.  No throttling — every rejection contributes to the counter so dashboards can attribute drops to specific provider/reason pairs.

## Risk

- 13 net lines, single hot path.
- The metric counter is unbounded by cardinality of \`(model_id, field)\` pairs but \`field\` values are drawn from a fixed enum (\`filter_rejection_reason_label\`) plus the prefix \`cascade_empty:\`, so cardinality stays bounded.
- The systemic-cause WARN log is not modified — narrative diagnosis preserved.

## Validation

- [x] \`dune build @check\` passes (clean output, exit 0).
- [x] \`git diff --stat\`: 1 file changed, +13 lines.
- [x] No public API changes.

## References

- §6.6.1 Silent Failure → Explicit Error (2026-05-02 LLM compat report)
- \`lib/llm_metric_bridge.ml:53\` (\`emit_capability_drop\` definition)
- \`lib/prometheus.ml:765\` (\`masc_llm_provider_capability_drops_total\`)
- \`oas/lib/llm_provider/backend_openai.ml:43-48\` (existing OAS-level call pattern)