### PR TITLE
fix(keeper): inject stream_idle_timeout default in run_model_by_label paths

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -70,6 +70,10 @@ let effective_provider_attempt_timeout_s
   | None ->
       provider_default_attempt_timeout_s constraints
 
+let apply_stream_idle_timeout_default = function
+  | Some _ as v -> v
+  | None -> Some Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
+
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
 (* ================================================================ *)
@@ -1026,6 +1030,7 @@ let run_model_by_label
     ?net
     ()
   : (Oas_worker_exec.run_result, Agent_sdk.Error.sdk_error) result =
+  let stream_idle_timeout_s = apply_stream_idle_timeout_default stream_idle_timeout_s in
   let* config =
     config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
       ~tools ~max_turns ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature
@@ -1158,6 +1163,7 @@ let run_model_with_masc_tools
     ?net
     ()
   : (Oas_worker_exec.run_result, Agent_sdk.Error.sdk_error) result =
+  let stream_idle_timeout_s = apply_stream_idle_timeout_default stream_idle_timeout_s in
   let* config =
     config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
       ~tools:[] ~max_turns ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -30,6 +30,14 @@ val effective_provider_attempt_timeout_s :
   Llm_provider.Provider_config.t ->
   float option
 
+(** [apply_stream_idle_timeout_default opt] returns [opt] when the caller
+    supplied a value, otherwise injects
+    [Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec]. Used at
+    every {!run_model_by_label} / {!run_model_with_masc_tools} entry so a
+    single-agent dashboard run cannot block forever on a stalled HTTP
+    stream. *)
+val apply_stream_idle_timeout_default : float option -> float option
+
 (** {1 Named cascade execution} *)
 
 val run_named :

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1210,6 +1210,20 @@ let test_oas_worker_exec_build_applies_stream_idle_timeout () =
       Agent_sdk.Agent.close agent
   | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
 
+let test_apply_stream_idle_timeout_default_passes_through_caller_value () =
+  let provided = Some 7.5 in
+  let result = Oas_worker_named.apply_stream_idle_timeout_default provided in
+  Alcotest.(check (option (float 0.0001)))
+    "explicit Some passes through unchanged" provided result
+
+let test_apply_stream_idle_timeout_default_injects_keepalive_default () =
+  let result = Oas_worker_named.apply_stream_idle_timeout_default None in
+  let expected =
+    Some Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
+  in
+  Alcotest.(check (option (float 0.0001)))
+    "omitted timeout receives keepalive default" expected result
+
 let test_oas_worker_exec_build_default_priority_unset () =
   let config =
     Oas_worker_exec.default_config
@@ -4040,6 +4054,10 @@ let () =
         test_oas_worker_exec_build_applies_retry_policy;
       Alcotest.test_case "oas_worker applies stream idle timeout" `Quick
         test_oas_worker_exec_build_applies_stream_idle_timeout;
+      Alcotest.test_case "apply_stream_idle_timeout_default passes Some through" `Quick
+        test_apply_stream_idle_timeout_default_passes_through_caller_value;
+      Alcotest.test_case "apply_stream_idle_timeout_default injects keepalive default for None" `Quick
+        test_apply_stream_idle_timeout_default_injects_keepalive_default;
       Alcotest.test_case "oas_worker default priority remains unset" `Quick
         test_oas_worker_exec_build_default_priority_unset;
       Alcotest.test_case "oas_worker applies explicit priority" `Quick


### PR DESCRIPTION
## Summary

Followup to #12814 addressing the unresolved Copilot review on `lib/oas_worker_named.ml:298`:

> `run_model_by_label` still forwards `?stream_idle_timeout_s` unchanged via `config_for_label`, and `dashboard_provider_runs.ml` calls that API without a timeout, so single-agent dashboard runs can still block forever on a stalled HTTP stream.

`#12814` fixed only the named-cascade path inside `run_named`. This PR extends the same default injection to the two single-model entry points and adds the regression test that was requested in the second Copilot thread.

## Changes

- `lib/oas_worker_named.ml` — extract `apply_stream_idle_timeout_default` helper (pass-through for `Some _`, inject `Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec` for `None`). Apply at entry of `run_model_by_label` and `run_model_with_masc_tools` so `config_for_label` remains a dumb pass-through.
- `lib/oas_worker_named.mli` — expose the helper for direct unit testing.
- `test/test_oas_worker.ml` — two new `Quick` tests pinning the pass-through and default-injection branches.

## Why a helper instead of inline match

- One canonical default keeps the three public paths (`run_named` per-provider override, `run_model_by_label`, `run_model_with_masc_tools`) consistent.
- A directly testable function lets the regression test pin both branches without spinning up an Eio context or a real `config_for_label` call.

## Test plan

- [ ] CI `Build and Test`
- [ ] CI `Lint`
- [x] Local diff inspection vs main
- [ ] No new public surface beyond the documented helper

## Notes

- This intentionally does not touch `run_named` because that path already injects the default per-provider at `lib/oas_worker_named.ml:290` and a second injection at the entry would bypass the per-provider override semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)