### PR TITLE
fix(verification): transition AwaitingVerification on deadline timeout

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -766,6 +766,22 @@ let force_done_task_r config ~agent_name ~task_id ~notes () : string Types.masc_
     ()
 ;;
 
+(** Force-cancel a task regardless of assignee. System privilege.
+    Used by [Verification_protocol.check_timeouts] to expire
+    [AwaitingVerification] tasks whose verifier deadline has passed,
+    so the FSM does not stall and re-emit Timeout posts forever. *)
+let force_cancel_task_r config ~agent_name ~task_id ~reason ()
+  : string Types.masc_result =
+  transition_task_r
+    config
+    ~agent_name
+    ~task_id
+    ~action:Types.Cancel
+    ~reason
+    ~force:true
+    ()
+;;
+
 (** Cancel a task - A2A compatible *)
 let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result =
   if not (is_initialized config)

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -61,6 +61,13 @@ val cancel_task_r :
   config -> agent_name:string -> task_id:string ->
   reason:string -> string Types.masc_result
 
+(** Force-cancel a task regardless of assignee. System privilege.
+    Used by {!Verification_protocol.check_timeouts} to expire
+    [AwaitingVerification] tasks whose verifier deadline has passed. *)
+val force_cancel_task_r :
+  config -> agent_name:string -> task_id:string ->
+  reason:string -> unit -> string Types.masc_result
+
 val link_task_execution_artifacts_r :
   config -> task_id:string ->
   ?session_id:string -> ?operation_id:string -> ?autoresearch_loop_id:string ->

--- a/lib/coord/coord_task_lifecycle.ml
+++ b/lib/coord/coord_task_lifecycle.ml
@@ -92,7 +92,11 @@ let decide
     if same_agent assignee || force
     then ok (cancelled_status ~agent_name ~now ~reason)
     else Error Invalid_transition
-  | Types.Cancel, (Types.AwaitingVerification _ | Types.Done _) ->
+  | Types.Cancel, Types.AwaitingVerification _ ->
+    if force
+    then ok (cancelled_status ~agent_name ~now ~reason)
+    else Error Invalid_transition
+  | Types.Cancel, Types.Done _ ->
     Error Invalid_transition
   (* ── Release ──────────────────────────────────── *)
   | Types.Release, (Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ }) ->

--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -91,12 +91,12 @@ let current_streak ~keeper_name =
 let nudge_message_text ~streak =
   Printf.sprintf
     ("ACTION REQUIRED — PASSIVE LOOP DETECTED: You have completed %d"
-     ^ " consecutive turns using only read-only or status tools without any"
-     ^ " execution or completion action. This violates the keeper turn"
-     ^ " contract. You MUST call an execution or completion tool this turn"
-     ^ " (e.g. keeper_task_done, keeper_task_claim, keeper_shell,"
-     ^ " keeper_board_post with a concrete update, or another write tool)."
-     ^ " Do not call read-only tools again without first taking an action.")
+     ^^ " consecutive turns using only read-only or status tools without any"
+     ^^ " execution or completion action. This violates the keeper turn"
+     ^^ " contract. You MUST call an execution or completion tool this turn"
+     ^^ " (e.g. keeper_task_done, keeper_task_claim, keeper_shell,"
+     ^^ " keeper_board_post with a concrete update, or another write tool)."
+     ^^ " Do not call read-only tools again without first taking an action.")
     streak
 
 let nudge_message ~keeper_name =

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -357,7 +357,30 @@ let check_timeouts ~(config : Coord.config) =
                ("verification_id", `String verification_id);
                ("assignee", `String assignee);
                ("timestamp", `Float now);
-             ])
+             ]);
+             (* Transition the task out of AwaitingVerification so the next
+                check_timeouts cycle does not re-emit the same Timeout post.
+                Without this, deadline > now stays true forever and every
+                cycle re-creates the same board entry. *)
+             let cancel_reason =
+               Printf.sprintf
+                 "verification deadline exceeded (assignee=%s, vrf=%s, deadline=%s)"
+                 assignee verification_id dl
+             in
+             (match
+                Coord.force_cancel_task_r
+                  config
+                  ~agent_name:"system"
+                  ~task_id:task.id
+                  ~reason:cancel_reason
+                  ()
+              with
+              | Ok _ -> ()
+              | Error e ->
+                Log.Task.error
+                  "verification timeout transition failed (task=%s vrf=%s): %s"
+                  task.id verification_id
+                  (Types.show_masc_error e))
            | Some _ -> ()
            | None -> ())
         | Todo | Claimed _ | InProgress _ | AwaitingVerification { deadline = None; _ } | Done _ | Cancelled _ -> ()

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1189,14 +1189,14 @@ let () =
     ];
     "liveness_recovery", [
       test_case "backoff_base * 2^attempt, capped at max" `Quick (fun () ->
-        let base = Masc_mcp.Env_config.KeeperSupervisor.liveness_recovery_backoff_base_sec in
-        let max_s = Masc_mcp.Env_config.KeeperSupervisor.liveness_recovery_backoff_max_sec in
+        let base = Env_config_keeper.KeeperSupervisor.liveness_recovery_backoff_base_sec in
+        let max_s = Env_config_keeper.KeeperSupervisor.liveness_recovery_backoff_max_sec in
         let d0 = Sup.liveness_recovery_backoff 0 in
         let d1 = Sup.liveness_recovery_backoff 1 in
         check (float 0.1) "attempt 0 = base" base d0;
         check (float 0.1) "attempt 1 = 2*base" (Float.min max_s (base *. 2.0)) d1);
       test_case "backoff capped at max" `Quick (fun () ->
-        let max_s = Masc_mcp.Env_config.KeeperSupervisor.liveness_recovery_backoff_max_sec in
+        let max_s = Env_config_keeper.KeeperSupervisor.liveness_recovery_backoff_max_sec in
         let d_big = Sup.liveness_recovery_backoff 100 in
         check (float 0.1) "large attempt capped" max_s d_big);
       test_case "should_attempt: Dead phase + elapsed → true" `Quick (fun () ->

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -619,6 +619,68 @@ let test_fsm_disabled_submit_fails () =
         (Astring.String.is_infix ~affix:"not enabled" msg))
 
 (* ================================================================ *)
+(* Verification timeout transition (check_timeouts)                  *)
+(* ================================================================ *)
+
+(* Move a task's deadline far into the past so the next check_timeouts
+   cycle sees [now > deadline_ts] without sleeping. *)
+let force_deadline_past config task_id =
+  let backlog = Coord.read_backlog config in
+  let past_iso =
+    Types.iso8601_of_unix_seconds (Time_compat.now () -. 3600.0)
+  in
+  let new_tasks =
+    List.map (fun (t : Types.task) ->
+      if t.id <> task_id then t
+      else match t.task_status with
+        | Types.AwaitingVerification fields ->
+          { t with task_status =
+              Types.AwaitingVerification { fields with deadline = Some past_iso } }
+        | _ -> t)
+      backlog.tasks
+  in
+  Coord.write_backlog config { backlog with tasks = new_tasks }
+
+let test_check_timeouts_transitions_awaiting_to_cancelled () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    (match Coord.transition_task_r config ~agent_name:"worker"
+             ~task_id ~action:Types.Submit_for_verification () with
+     | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e)
+     | Ok _ -> ());
+    Alcotest.(check string) "pre-check status" "awaiting_verification"
+      (status_string config task_id);
+    force_deadline_past config task_id;
+    Verification_protocol.check_timeouts ~config;
+    Alcotest.(check string) "post-check status" "cancelled"
+      (status_string config task_id);
+    match get_task config task_id with
+    | Some { task_status = Types.Cancelled { cancelled_by; reason; _ }; _ } ->
+      Alcotest.(check string) "cancelled_by system" "system" cancelled_by;
+      let reason_str = Option.value reason ~default:"" in
+      Alcotest.(check bool)
+        "reason mentions verification deadline" true
+        (Astring.String.is_infix ~affix:"verification deadline" reason_str)
+    | _ -> Alcotest.fail "task is not Cancelled after check_timeouts")
+
+let test_check_timeouts_idempotent_after_cancel () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    (match Coord.transition_task_r config ~agent_name:"worker"
+             ~task_id ~action:Types.Submit_for_verification () with
+     | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e)
+     | Ok _ -> ());
+    force_deadline_past config task_id;
+    Verification_protocol.check_timeouts ~config;
+    let status_after_first = status_string config task_id in
+    Verification_protocol.check_timeouts ~config;
+    let status_after_second = status_string config task_id in
+    Alcotest.(check string) "first check cancels" "cancelled" status_after_first;
+    Alcotest.(check string) "second check is no-op" "cancelled" status_after_second)
+
+(* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
 
@@ -665,5 +727,11 @@ let () =
         test_submit_verdict_pass;
       Alcotest.test_case "submit_verdict Fail preserves reason" `Quick
         test_submit_verdict_fail;
+    ]);
+    ("timeout_check", [
+      Alcotest.test_case "check_timeouts transitions AwaitingVerification to Cancelled"
+        `Quick test_check_timeouts_transitions_awaiting_to_cancelled;
+      Alcotest.test_case "check_timeouts is idempotent after cancellation"
+        `Quick test_check_timeouts_idempotent_after_cancel;
     ]);
   ]


### PR DESCRIPTION
## Summary

`Verification_protocol.check_timeouts` posted a `Timeout: ...` board entry on every cycle for tasks whose verifier deadline had passed, but never transitioned the task out of `AwaitingVerification`. The next cycle saw the same `now > deadline_ts` and re-emitted the same post forever. Stuck `AwaitingVerification` tasks held keepers' `current_task_id` forever, so `proactive` turns were never started — keepers fell silent except for heartbeat keepalive.

This PR adds the missing transition: on deadline timeout, the task moves to `Cancelled` (with a system-authored reason), making `check_timeouts` self-terminating per task.

## Changes

**Core fix**
- `lib/coord/coord_task_lifecycle.ml`: allow `Cancel` from `AwaitingVerification` when `~force:true`. Existing assignee-only `cancel_task_r` is unaffected.
- `lib/coord/coord_task.ml` + `.mli`: add `Coord.force_cancel_task_r ~agent_name ~task_id ~reason ()` mirroring `force_done_task_r` / `force_release_task_r`.
- `lib/verification_protocol.ml`: in `check_timeouts`, after the existing board post + event push, call `force_cancel_task_r` with `agent_name="system"` and a reason citing assignee/verification id/deadline. Errors are logged only.

**Tests**
- `test/test_verification_fsm.ml`: new `timeout_check` suite (2 cases).
  - `check_timeouts transitions AwaitingVerification to Cancelled` — deadline forced into past, single check, expect `cancelled` with `cancelled_by="system"` and reason containing "verification deadline".
  - `check_timeouts is idempotent after cancellation` — two consecutive checks, expect `cancelled` after both (the existing `Done _ | Cancelled _ -> ()` arm short-circuits the second pass).

**Bundled main blocker fixes** (separate commit, see history)

Two `dune build @check` failures from #12803 (commit 851d9fb64d) blocked this PR's CI. Bundled to make this PR self-consistent:

- `lib/keeper/keeper_passive_loop_detector.ml`: `Printf.sprintf ("..." ^ "...")` → `Printf.sprintf ("..." ^^ "...")`. Format-typing fix only, no semantic change.
- `test/test_keeper_supervisor.ml`: `Masc_mcp.Env_config.KeeperSupervisor` → `Env_config_keeper.KeeperSupervisor`. `Env_config_keeper` lives in `masc_config` library, reachable bare from tests (cf. `test_keeper_docker_read.ml`).

## Self-review

- [x] Goal: stop the verification timeout retry loop; restore keeper proactive turns.
- [x] Files changed: 7 (5 lib/ + test/, 2 main-blocker fix-along).
- [x] Local verification:
  - `dune build @check` clean.
  - `test_verification_fsm`: 20/20 (incl. 2 new cases).
  - `test_lifecycle`: 7/7.
  - `test_goal_verification`: 2/2.
  - `liveness_recovery` suite: 5/6 — see follow-up below.
- [x] Race-checked `gh pr list` for parallel verification/check_timeouts/force_cancel and main-blocker PRs immediately before push: 0 matches.

## Follow-up

`test_keeper_supervisor.ml` `liveness_recovery_2` (`should_attempt: Dead + elapsed → true`) fails at runtime: expected `true`, got `false`. This was lurking on main behind the `Unbound module` compile error and is now visible. The logic lives in `Sup.should_attempt_liveness_recovery` (lib/keeper/keeper_supervisor.ml) — out of scope for this PR. Filing a separate issue.

## Operational impact (production observation 2026-05-04)

Prior to this fix, the production board accumulated ~7 timeout posts per minute for 7 stuck `AwaitingVerification` tasks. Two keepers (`executor`, `glm-coding-plan`) had been silent for 7+ days because their `current_task_id` referenced one of these orphans. After this change, those tasks transition to `Cancelled` on the next `check_timeouts` cycle and keepers can claim new work.