### PR TITLE
fix(dashboard): unblock main typecheck — CategoryLevel + drop 9 unused i

### DIFF
--- a/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
+++ b/dashboard/src/components/provider-capability-matrix/bfcl-rankings.ts
@@ -23,7 +23,7 @@ function V4CategoryTable() {
           </tr>
         </thead>
         <tbody>
-          ${BFCL_V4_CATEGORIES.map((cat, i) => html`
+          ${BFCL_V4_CATEGORIES.map((cat) => html`
             <tr key=${cat.id} class="pm-row-alt">
               <td class="pm-td font-semibold">${cat.label}</td>
               <td class="pm-td t-meta">${cat.description}</td>
@@ -54,7 +54,7 @@ function ModelBreakdownTable() {
           </tr>
         </thead>
         <tbody>
-          ${BFCL_MODEL_BREAKDOWN.map((m, i) => html`
+          ${BFCL_MODEL_BREAKDOWN.map((m) => html`
             <tr key=${m.model} class="pm-row-alt">
               <td class="pm-td font-semibold">${m.model}</td>
               <td class="pm-td pm-td--center pm-td--mono font-bold">${m.overall}</td>
@@ -98,7 +98,7 @@ function HarnessCaseStudy() {
               </tr>
             </thead>
             <tbody>
-              ${HARNESS_MODELS.map((hm, i) => html`
+              ${HARNESS_MODELS.map((hm) => html`
                 <tr key=${hm.id} class="pm-row-alt">
                   <td class="pm-td pm-td--mono font-semibold">${hm.id}</td>
                   <td class="pm-td t-micro t-meta">${hm.params}</td>
@@ -184,7 +184,7 @@ export function BfclRankings() {
             </tr>
           </thead>
           <tbody>
-            ${BFCL_RANKINGS.map((entry, i) => {
+            ${BFCL_RANKINGS.map((entry) => {
               const hasV3 = entry.bfclV3 !== '—' && entry.bfclV3 !== '경쟁력' && entry.bfclV3 !== '개선됨'
               const hasV4 = entry.bfclV4 !== '—' && entry.bfclV4 !== '경쟁력'
               return html`

--- a/dashboard/src/components/provider-capability-matrix/data.ts
+++ b/dashboard/src/components/provider-capability-matrix/data.ts
@@ -6,6 +6,8 @@
 
 export type FeatureSupport = '●' | '◐' | '○' | '—'
 
+export type CategoryLevel = 'high' | 'mid' | 'low'
+
 export interface FeatureDef {
   id: string
   label: string

--- a/dashboard/src/components/provider-capability-matrix/model-catalog.ts
+++ b/dashboard/src/components/provider-capability-matrix/model-catalog.ts
@@ -60,7 +60,7 @@ function ModelTable({ group }: { group: typeof PROVIDER_MODELS[number] }) {
                 공식 모델 카탈로그 미등록. Provider capability는 matrix/providers 탭에서 추적.
               </td>
             </tr>
-          ` : group.models.map((m, i) => html`
+          ` : group.models.map((m) => html`
               <tr key=${m.id} class="pm-row-alt">
                 <td class="pm-td pm-td--mono font-semibold">${m.id}</td>
                 <td class="pm-td pm-td--center">
@@ -94,7 +94,7 @@ function CliTransportTable() {
           </tr>
         </thead>
         <tbody>
-          ${CLI_TRANSPORTS.map((t, i) => html`
+          ${CLI_TRANSPORTS.map((t) => html`
             <tr key=${t.providerId} class="pm-row-alt">
               <td class="pm-td font-semibold">${PROVIDER_LABELS[t.providerId] ?? t.providerId}</td>
               <td class="pm-td pm-td--mono">${t.binary}</td>
@@ -164,7 +164,7 @@ function ClaudeCodeArchSection() {
               </tr>
             </thead>
             <tbody>
-              ${CLAUDE_CODE_EXTENSIONS.map((ext, i) => html`
+              ${CLAUDE_CODE_EXTENSIONS.map((ext) => html`
                 <tr key=${ext.name} class="pm-row-alt">
                   <td class="pm-td pm-td--mono font-semibold">${ext.name}</td>
                   <td class="pm-td pm-td--center pm-td--mono t-dim">${ext.since}</td>

--- a/dashboard/src/components/provider-capability-matrix/oas-provider-table.ts
+++ b/dashboard/src/components/provider-capability-matrix/oas-provider-table.ts
@@ -45,7 +45,7 @@ export function OasProviderTable() {
             </tr>
           </thead>
           <tbody>
-            ${OAS_PROVIDER_CAPS.map((prov, i) => {
+            ${OAS_PROVIDER_CAPS.map((prov) => {
               const isCli = prov.usage === 'strip'
               return html`
                 <tr key=${prov.id} class="pm-row-alt ${isCli ? 'pm-row--cli' : ''}">

--- a/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
+++ b/dashboard/src/components/provider-capability-matrix/wiring-gaps.ts
@@ -53,7 +53,7 @@ export function WiringGaps() {
             </tr>
           </thead>
           <tbody>
-            ${gaps.map((gap, i) => {
+            ${gaps.map((gap) => {
               return html`
                 <tr key=${gap.id} class="pm-row-alt">
                   <td class="pm-td pm-td--mono t-dim">${gap.id}</td>


### PR DESCRIPTION
## Why

main is currently red on Dashboard `tsc --noEmit` (introduced by #12813). Every dashboard-touching PR inherits the failure. See e.g. #12810 Dashboard job 74228403206.

13 type errors in `dashboard/src/components/provider-capability-matrix/`:
- `data.ts:295/303` — `CategoryLevel` referenced but undeclared (TS2304) + cascading TS2366 "lacks ending return statement"
- `bfcl-rankings.ts` (4), `model-catalog.ts` (3), `oas-provider-table.ts` (1), `wiring-gaps.ts` (1) — `(item, i) =>` callbacks where `i` is unused (`noUnusedParameters`)

## What

- `data.ts`: add `export type CategoryLevel = 'high' | 'mid' | 'low'` next to the existing `FeatureSupport` declaration. Switches in `categoryLevelClass` and `categoryLevelLabel` were already exhaustive, so TS now treats them as total functions and the missing-return error disappears.
- 5 component files: drop unused `, i` from each affected `.map`. Every callback keys by `item.something`, not `i`, so removing the index is purely mechanical.

## Test plan

- [x] Local diff inspection
- [ ] CI `Dashboard` job (this PR's primary purpose — it must go from fail → pass)
- [ ] Build/Lint/etc. — should be unaffected

## Notes

This is the surgical unblock; deeper review concerns from #12813 (BFCL footer reconciliation, GLM unverified flagging, H05 location format) are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)