### PR TITLE
feat(metrics): unified masc_fallback_triggered_total counter (§7.3.2)

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -55,6 +55,22 @@ let emit_capability_drop ~model_id ~field =
     ~labels:[("model", model_id); ("field", field)]
     ()
 
+(** Canonical metric name for the unified fallback counter (§7.3.2 Zero
+    Silent Failure). Per-class counters (capability_drops,
+    cross_cascade_fallback) remain for drill-down; this is the single
+    numerator across all classes for the dashboard panel. *)
+let fallback_triggered_metric = Prometheus.metric_fallback_triggered
+
+(** Emit a fallback observation to the unified counter.
+    [kind]   one of: cross_cascade | cascade_empty | capability_drop
+                   | cli_unsupported | provider_error_fallback | …
+    [detail] free-form drill-down (rejection_reason, target provider,
+             dropped field, …). Cardinality bounded by callers. *)
+let emit_fallback_triggered ~kind ~detail =
+  Prometheus.inc_counter fallback_triggered_metric
+    ~labels:[("kind", kind); ("detail", detail)]
+    ()
+
 (** Per-HTTP-request latency histogram.  Distinct from
     [masc_llm_inference_duration_seconds] (turn-scope, populated by the
     keeper AfterTurn hook): this metric is per provider HTTP call, so

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -31,6 +31,17 @@ val emit_request_latency : model_id:string -> latency_ms:int -> unit
 (** Emit a capability drop observation to the Prometheus counter. *)
 val emit_capability_drop : model_id:string -> field:string -> unit
 
+(** Canonical metric name for the §7.3.2 unified fallback counter. *)
+val fallback_triggered_metric : string
+
+(** Emit a fallback observation to the unified counter.
+    [kind] enumerates the fallback class (cross_cascade | cascade_empty |
+    capability_drop | cli_unsupported | provider_error_fallback | …);
+    [detail] carries the specific reason within the kind. Detail counters
+    (capability_drops, cross_cascade_fallback) remain for per-class
+    drill-down — this is the single numerator across all classes. *)
+val emit_fallback_triggered : kind:string -> detail:string -> unit
+
 (** Construct the OAS Metrics.t sink without installing it.  Useful
     for tests that want to pass [~metrics] explicitly without
     touching global state. *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -209,6 +209,14 @@ let run_named
                   Provider_tool_support.provider_debug_label provider_cfg);
                ]
                ();
+             (* §7.3.2 Zero Silent Failure: feed the unified fallback
+                counter so the dashboard panel sees a single numerator
+                across all fallback classes (cross_cascade,
+                cascade_empty, capability_drop, …). *)
+             Llm_metric_bridge.emit_fallback_triggered
+               ~kind:"cross_cascade"
+               ~detail:
+                 (Printf.sprintf "%s->%s" cascade_name source_cascade);
              Log.Misc.info
                "cascade %s: cross-cascade fallback to %s from %s \
                 (original had no tool-capable providers)"

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -265,11 +265,16 @@ let filter_candidate_providers_for_tool_support
          which provider/reason combination drove the drop. *)
       List.iter
         (fun (provider_cfg, reason) ->
+          let reason_label = filter_rejection_reason_label reason in
           Llm_metric_bridge.emit_capability_drop
             ~model_id:provider_cfg.Llm_provider.Provider_config.model_id
-            ~field:
-              (Printf.sprintf "cascade_empty:%s"
-                 (filter_rejection_reason_label reason)))
+            ~field:(Printf.sprintf "cascade_empty:%s" reason_label);
+          (* §7.3.2 Zero Silent Failure: also feed the unified
+             fallback counter so the dashboard panel sees a single
+             numerator across all fallback classes. *)
+          Llm_metric_bridge.emit_fallback_triggered
+            ~kind:"cascade_empty"
+            ~detail:reason_label)
         rejected;
       if cascade_empty_should_emit_first ~label ~signature then
         Log.Misc.error

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -764,6 +764,8 @@ let metric_llm_provider_request_latency =
   "masc_llm_provider_request_latency_seconds"
 let metric_llm_provider_capability_drops =
   "masc_llm_provider_capability_drops_total"
+let metric_fallback_triggered =
+  "masc_fallback_triggered_total"
 
 (* Domain-specific counters not yet constant-ised. *)
 let metric_anti_rationalization_fallback =
@@ -1186,6 +1188,10 @@ let init () =
     Counter;
   add metric_llm_provider_capability_drops
     "Total OAS capability drops from LLM providers, labeled by model and field"
+    Counter;
+  add metric_fallback_triggered
+    "Total fallback events across the LLM cascade pipeline, labeled by kind \
+     (cross_cascade|cascade_empty|capability_drop|cli_unsupported|...) and detail"
     Counter;
   (* Orphan metrics — used via inc_counter/set_gauge but previously
      never registered.  Auto-create still works, but registering here

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -330,6 +330,17 @@ val metric_tool_call_duration : string
 val metric_llm_provider_http_status : string
 val metric_llm_provider_request_latency : string
 val metric_llm_provider_capability_drops : string
+val metric_fallback_triggered : string
+(** §7.3.2 Zero Silent Failure measurement: aggregate counter for every
+    fallback event across the cascade pipeline. Labels: [kind] enumerates
+    the fallback class (cross_cascade, cascade_empty, capability_drop,
+    cli_unsupported, …); [detail] carries the specific reason within
+    the kind (e.g. for cross_cascade: source provider; for cascade_empty:
+    rejection_reason_label). Detail counters
+    ([masc_cross_cascade_fallback_total],
+    [masc_llm_provider_capability_drops_total]) remain for per-class
+    drill-down; this counter exists so the "Zero Silent Failure"
+    dashboard panel has a single numerator across all classes. *)
 val metric_board_truncated_posts : string
 val metric_anti_rationalization_fallback : string
 val metric_anti_rationalization_excuse_pattern : string


### PR DESCRIPTION
## Why

The 2026-05-02 LLM Provider Compatibility report §7.3.2 (*Zero Silent Failure measurement*) requires a single Prometheus counter that aggregates **all** fallback events across the cascade pipeline so the "Zero Silent Failure" Grafana panel has one numerator across classes.

Existing per-class counters provide drill-down detail but no unified view:
- `masc_llm_provider_capability_drops_total` — silent capability misses (top_k, min_p, …; cascade_empty rejections via #12820)
- `masc_cross_cascade_fallback_total` — when a cascade has no tool-capable providers and we walk to a sibling cascade

A new fallback class added in the future (e.g. `cli_unsupported`, `provider_error_fallback`) currently requires registering yet another per-class counter and updating the dashboard panel.  §7.3.2 wants a single counter that answers *"is anything silently falling back at all?"* — kind/detail labels keep drill-down available.

## What

1. **`lib/prometheus.ml` + `.mli`**: register `masc_fallback_triggered_total` with HELP describing the kind enum and label semantics.
2. **`lib/llm_metric_bridge.ml` + `.mli`**: expose `emit_fallback_triggered ~kind ~detail`.
3. **`lib/oas_worker_named_cascade.ml:259`** (cascade-empty rejection, originally introduced in #12820): emit `kind=cascade_empty, detail=<filter_rejection_reason_label>` for every rejected provider.
4. **`lib/oas_worker_named.ml:204`** (cross-cascade health-aware fallback): emit `kind=cross_cascade, detail=<from>-><to>` for the cascade pair.

Per-class counters are **kept** — operators get drill-down for free, and the unified counter answers the §7.3.2 panel query.

## Risk

- 6 files, +60 -3.  No public API changes outside the new metric exports.
- Label cardinality:
  - `kind` is a fixed enum (≤ 8 expected values).
  - `detail` for `cross_cascade` is `<from>-><to>` cascade name pair — bounded by deployment cascade count (typically < 30 cascades, so < 900 pairs).
  - `detail` for `cascade_empty` is `filter_rejection_reason_label` (3 enum variants) — trivially bounded.
- New emit sites only run on already-error paths, so cardinality growth tracks anomaly volume not request volume.

## Validation

- [x] `dune build @check` passes (clean output, exit 0).
- [x] No conflict with #1336 (OAS) — different repo.
- [x] No conflict with current open masc-mcp PRs (race-check returned 0).
- [x] Per-class counters preserved for drill-down.

## References

- §7.3.2 Zero Silent Failure (2026-05-02 LLM compat report)
- #12820 (cascade-empty capability_drop emit, introduced previous emit site)
- `lib/oas_worker_named_error.ml:166` (`masc_cross_cascade_fallback_total` definition)
- `lib/llm_metric_bridge.ml:53` (`emit_capability_drop` pattern this PR follows)