### PR TITLE
docs(watchdog): keeper_stale_watchdog has 3 detection modes, not 2

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -8,10 +8,22 @@ val fork_stale_watchdog :
   'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
 (** Fork a stale-turn watchdog fiber for the given keeper.
 
-    Two detection modes:
-    - Idle stall: [last_turn_ts] older than 300s while [Running].
-    - Failure loop: [consecutive_noop_count >= 3] — catches keepers in
-      LLM timeout loops where [last_turn_ts] stays fresh.
+    Three detection modes — see {!Keeper_registry.stale_kill_class}:
+    - [Idle_turn]: [last_turn_ts] older than the idle threshold while
+      the keeper phase is [Running] but no [current_turn_observation]
+      is recorded.
+    - [In_turn_hung]: a turn started ([current_turn_observation = Some])
+      and ran past [timeout_threshold] seconds — covers the
+      "Orphaned Streaming" pattern described in the executor FSM
+      analysis (TLA+ I2: [in_turn_age > grace_period → in_turn_stale]).
+    - [Noop_failure_loop]: turns kept firing but produced no tool
+      calls; the keepalive's [consecutive_noop_count] reached the
+      watchdog threshold — catches keepers in LLM timeout loops where
+      [last_turn_ts] stays fresh because each failed turn updates it.
+
+    Detection class is exposed on the
+    [masc_keeper_stale_termination_by_class] Prometheus counter for
+    per-class root-cause attribution.
 
     On detection, sets [fiber_stop] and emits a stale broadcast. The
     supervisor's [sweep_and_recover] picks up the stopped fiber and


### PR DESCRIPTION
## Why

`keeper_stale_watchdog.mli` docstring describes *"Two detection modes: Idle stall and Failure loop"* — but the implementation has been emitting 3 typed `stale_kill_class` variants:

\`\`\`ocaml
(* lib/keeper/keeper_registry.mli:34-47 *)
type stale_kill_class =
  | Idle_turn of { stall_seconds : float }
  | In_turn_hung of { active_seconds : float; timeout_threshold : float }
  | Noop_failure_loop of { noop_count : int }
\`\`\`

`In_turn_hung` is exactly what the executor FSM analysis (`executor_fsm_tla_analysis.md` §4 invariant I2 — *"in_turn_age > grace_period → in_turn_stale = TRUE"*) calls for: detecting the "Orphaned Streaming" pattern where a turn is in progress, `in_turn_age` exceeds the threshold, but neither idle nor noop-loop modes fire.

The mli outdated docstring made the watchdog's true coverage invisible to readers — the same drift class that previously caused fleet-stall regressions when emit-site code paths were silently bypassed (per the existing TLA+ bug-action note at the top of `keeper_stale_watchdog.ml`).

## What

Update `keeper_stale_watchdog.mli` `fork_stale_watchdog` docstring:
- List all three detection modes with their exact `stale_kill_class` variant names so the docs match `Keeper_registry.mli`.
- Cite `executor_fsm_tla_analysis.md` for the `In_turn_hung` rationale (TLA+ I2 invariant).
- Mention `masc_keeper_stale_termination_by_class` Prometheus counter for per-class attribution.

## Risk

- Pure docs PR, 0 code changes.  16 net lines, single .mli file.
- `dune build @check` passes (no signature changes — only doc-comment text).

## References

- 2026-04-28 `executor_fsm_tla_analysis.md` §4 (TLA+ I2 invariant)
- `lib/keeper/keeper_registry.mli:34-47` (stale_kill_class definition)
- `lib/keeper/keeper_stale_watchdog.ml:108-116` (3-class label mapping)
- PR #10670 (extracted from Keeper_supervisor; In_turn_hung added later)