### PR TITLE
fix(prometheus+keeper): cleanup dead duplicate add() block + 2 "unknown" stand-ins

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -280,7 +280,7 @@ let emit_gate_event
     | exn ->
       Prometheus.inc_counter
         Prometheus.metric_keeper_guards_failures
-        ~labels:[("keeper", "unknown"); ("site", "event_emit")]
+        ~labels:[("keeper", agent_name); ("site", "event_emit")]
         ();
       Log.Keeper.warn
         "keeper_guards: event emit failed stage=%s tool=%s err=%s"

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -852,7 +852,7 @@ let recover_latest_checkpoint_for_overflow_retry
                 "overflow retry checkpoint save failed: %s" e;
               Prometheus.inc_counter
                 Prometheus.metric_keeper_checkpoint_failures
-                ~labels:[("keeper", "unknown"); ("phase", "overflow_save")]
+                ~labels:[("keeper", retry_meta.agent_name); ("operation", "overflow_save")]
                 ();
               None)
         with

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1880,34 +1880,17 @@ let init () =
   add metric_sse_external_subscribers
     "Active non-SSE subscribers bridged from the SSE fanout path" Gauge;
 
-  add metric_keeper_turn_livelock_blocks
-    "Total livelock-block events where keeper found a turn already in-progress      during unified_turn start. Labels: keeper." Counter;
-  add metric_keeper_turn_timeout_committed
-    "Total wall-clock timeout events after tools were committed but before      response completed. Labels: keeper." Counter;
-  add metric_keeper_turn_error_after_tools
-    "Total errors after tool calls were committed in unified_turn.      Labels: keeper." Counter;
-  add metric_keeper_cascade_sync_failures
-    "Total failures to sync cascade state during turn pause/rejection.      Labels: keeper, site." Counter;
-  add metric_keeper_thinking_persist_failures
-    "Total failures persisting thinking content to disk. Labels: keeper." Counter;
-  add metric_keeper_checkpoint_failures
-    "Total checkpoint save/restore failures. Labels: keeper, operation." Counter;
-  add metric_keeper_memory_write_failures
-    "Total failures writing keeper memory to disk. Labels: keeper." Counter;
-  add metric_keeper_write_meta_cycle_failures
-    "Total CAS-race or write failures in write_meta during turn cycle.      Labels: keeper." Counter;
-  add metric_keeper_alert_persist_failures
-    "Total failures persisting alert notifications. Labels: keeper." Counter;
-  add metric_keeper_metrics_sse_failures
-    "Total failures pushing metrics via SSE to dashboard. Labels: keeper." Counter;
-  add metric_keeper_dispatch_event_failures
-    "Total failures dispatching state events to keeper event bus.      Labels: keeper, event." Counter;
-  add metric_keeper_session_cleanup_failures
-    "Total failures cleaning up keeper session directories on shutdown." Counter;
-  add metric_keeper_chat_store_failures
-    "Total failures in keeper chat store append/load operations.      Labels: operation." Counter;
-  add metric_keeper_observation_query_failures
-    "Total failures in world observation queries (backlog, agents, board).      Labels: operation." Counter;
+  (* The keeper turn / cascade / persistence-failure metrics
+     (turn_livelock_blocks .. session_cleanup_failures, plus
+     chat_store_failures and observation_query_failures) are registered
+     earlier in init() — see line ~1171 for turn_livelock_blocks and
+     lines ~1579-1628 for the rest, with detailed help text. Because
+     `add` is no-op when the name already exists, every help string
+     in this duplicate block was silently dropped, while still making
+     the file look like every metric had two declaration sites with
+     conflicting documentation. The original block is removed so
+     edits to help/labels land on the canonical site instead of a
+     dead one. *)
   add metric_keeper_stale_termination_total
     "Total stale watchdog terminations (all classes). Labels: keeper." Counter;
   add metric_keeper_stale_termination_by_class
@@ -1951,7 +1934,7 @@ let init () =
   add metric_keeper_stay_silent_loop_detected
     "Stay-silent loop detector triggered. Labels: keeper." Counter;
   add metric_keeper_usage_trust
-    "Keeper usage trust level. Labels: keeper, trust." Counter;
+    "Keeper usage trust outcome. Labels: keeper, outcome." Counter;
   add metric_keeper_usage_anomaly_reason
     "Keeper usage anomaly reason. Labels: keeper, reason." Counter;
   add metric_keeper_config_env_parse_failures


### PR DESCRIPTION
## Summary

Recovery of cleanup work that did not land before #12804 squash-merged
(prometheus dead-block removal) plus two more `"unknown"` stand-ins
identified during the cycle-21 sweep that had real keeper context in
scope.

## prometheus.ml — drop dead duplicate `add()` block

A second registration block for keeper turn / cascade / persistence
/ observation failure metrics had grown next to the SSE registrations.
Each metric was already registered earlier in init() with detailed
help text — see `add metric_keeper_turn_livelock_blocks` at line ~1171
and the `turn_livelock_blocks .. session_cleanup_failures` block at
lines ~1579-1628.

`add` is a no-op when the metric name already exists, so every help
string in the duplicate block was silently dropped. Several recent
review threads on #12804 tried to "fix" help/labels in the duplicate
copy and had no observable effect on `/metrics` output.

The duplicate block (12 metrics, 24 lines) is removed and replaced
with a tombstone comment pointing future readers at the canonical
registration sites. The non-duplicated registrations next to the
dropped block (`stale_termination_*`,
`oas_timeout_budget_watchdog_termination`, `tool_use_failure`) are
preserved intact.

Also align `metric_keeper_usage_trust` help text with what the only
call site emits — `keeper_unified_metrics.ml` uses label key `outcome`,
not `trust`.

## keeper modules — drop `"unknown"` stand-ins where agent_name is in scope

- `lib/keeper/keeper_post_turn.ml:855` (overflow_save): the surrounding
  `save_oas_checkpoint` call reads `~agent_name:retry_meta.agent_name`.
  Replace `"unknown"` with `retry_meta.agent_name` and align the
  second label key from `phase` to `operation` to match the rest of
  `metric_keeper_checkpoint_failures` (documented as `(keeper, operation)`
  after the cycle-9 unification).
- `lib/keeper/keeper_guards.ml:283` (event_emit): `agent_name` is in
  scope on the surrounding log line. Use it instead of `"unknown"`.

Production behaviour unchanged — every counter still fires from inside
the same exception handler, only the label series gains keeper
attribution.

## Out of scope (separate cleanup)

Four more `"unknown"` stand-ins live in functions that have no keeper
context to fall back on (`keeper_meta_store.ml` 3 sites,
`keeper_guards.ml:178` gate_observer). They need either an
`"aggregate"` placeholder fix (matching the cycle-10/14 keepalive_signal
+ approval_queue audit_store_create pattern) or function-signature
plumbing — separate review.

## Test plan

- [x] `dune build --root . @check` passes clean after each commit
- [ ] CI green on `Build and Test`, `Lint`, `Health`
- [ ] Required checks green before flipping to Ready

## Context

This is a recovery PR. The dead-block cleanup was prepared as commit
`bc20d79f95` on the `keeper-tool-observability` branch in the cycle
just before #12804 was merged, but #12804 squash-merged before that
commit landed.