### PR TITLE
feat(keeper): add directive_failures + lifecycle callback instrumentation sites

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -109,6 +109,10 @@ let record_pre_tool_gate_attempt
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_lifecycle_callback_failures
+         ~labels:[("keeper", keeper_name); ("callback", "gate_tool_call_log")]
+         ();
        Log.Keeper.warn
          "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"
          keeper_name event.tool_name (Printexc.to_string exn));
@@ -1207,6 +1211,10 @@ let make_hooks
                 exceptions thrown from Sse.broadcast at the call boundary
                 bypass that counter.  Logging here makes the loss visible
                 at the producer site. *)
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_lifecycle_callback_failures
+               ~labels:[("keeper", meta.name); ("callback", "after_turn_sse_broadcast")]
+               ();
              Log.Keeper.warn
                "keeper:%s turn=%d sse_turn_complete broadcast failed: %s"
                meta.name turn (Printexc.to_string exn));
@@ -1303,6 +1311,10 @@ let make_hooks
                 were dropped without trace.  Loss of these rows leaves
                 downstream replay / debugging tools with gaps that look
                 identical to "no tool calls in this turn." *)
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_lifecycle_callback_failures
+               ~labels:[("keeper", (!meta_ref).name); ("callback", "post_tool_log_write")]
+               ();
              Log.Keeper.warn
                "keeper:%s tool=%s log_call write failed: %s"
                (!meta_ref).name tool_name (Printexc.to_string exn));

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -110,6 +110,9 @@ let set_keeper_paused_state ~agent_name paused =
     ~identity:agent_name
     ~on_missing:(fun () ->
       let action = if paused then "pause" else "resume" in
+      Prometheus.inc_counter Prometheus.metric_keeper_directive_failures
+        ~labels:[("keeper", agent_name); ("site", "pause_resume_not_in_registry")]
+        ();
       Log.Keeper.warn "directive %s: agent %s not in registry" action agent_name)
     (fun entry ->
        let updated_meta =
@@ -139,6 +142,9 @@ let wakeup_keeper_by_agent_name ~agent_name =
   with_keeper_entry_by_identity
     ~identity:agent_name
     ~on_missing:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_keeper_directive_failures
+        ~labels:[("keeper", agent_name); ("site", "wakeup_not_in_registry")]
+        ();
       Log.Keeper.warn "directive wakeup: agent %s not in registry" agent_name)
     (fun entry -> wakeup_keeper ~base_path:entry.base_path entry.name)
 ;;
@@ -147,6 +153,9 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
   with_keeper_entry_by_identity
     ~identity:agent_name
     ~on_missing:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_keeper_directive_failures
+        ~labels:[("keeper", agent_name); ("site", "claim_not_in_registry")]
+        ();
       Log.Keeper.warn "directive claim: agent %s not in registry" agent_name)
     (fun entry ->
        let updated_meta =
@@ -306,6 +315,9 @@ let run_grpc_heartbeat_fiber
   =
   match Eio_context.get_switch_opt (), Atomic.get grpc_env_ref with
   | None, _ | _, None ->
+    Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_failures
+      ~labels:[("keeper", agent_name); ("site", "grpc_no_eio_context")]
+      ();
     Log.Keeper.warn "gRPC heartbeat: Eio context or env not available";
     None
   | Some grpc_sw, Some env ->
@@ -383,6 +395,9 @@ let start_keeper_grpc_heartbeat
       ~interval_sec:interval
       ~clock:ctx.clock
   | Masc_grpc_transport.Grpc, None ->
+    Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_failures
+      ~labels:[("keeper", m.name); ("site", "grpc_no_client")]
+      ();
     Log.Keeper.warn "keeper %s: gRPC transport requested but no client configured" m.name;
     None
   | _ -> None

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -466,6 +466,8 @@ let metric_keeper_cleanup_tracking_failures =
   "masc_keeper_cleanup_tracking_failures_total"
 let metric_keeper_dispatch_event_failures =
   "masc_keeper_dispatch_event_failures_total"
+let metric_keeper_directive_failures =
+  "masc_keeper_directive_failures_total"
 let metric_keeper_tool_call_duration =
   "masc_keeper_tool_call_duration_seconds"
 let metric_keeper_write_meta_failures =
@@ -1639,6 +1641,9 @@ let init () =
     "Total keeper state machine dispatch_event failures in supervisor. \
      Labeled by event type."
     Counter;
+  add metric_keeper_directive_failures
+    "Total gRPC directive routing failures — target agent not in registry \
+     or directive malformed (labels: keeper, site)" Counter;
   add metric_keeper_session_cleanup_failures
     "Total session directory cleanup failures during keeper teardown."
     Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -258,6 +258,7 @@ val metric_keeper_write_meta_cycle_failures : string
 val metric_keeper_alert_persist_failures : string
 val metric_keeper_metrics_sse_failures : string
 val metric_keeper_dispatch_event_failures : string
+val metric_keeper_directive_failures : string
 val metric_keeper_session_cleanup_failures : string
 val metric_keeper_chat_store_failures : string
 val metric_keeper_observation_query_failures : string
@@ -579,6 +580,10 @@ val metric_keeper_dispatch_event_failures : string
     were previously silently dropped via [ignore].  Labels:
     [keeper, reason] where reason is [terminal_state] or
     [invalid_transition]. *)
+
+val metric_keeper_directive_failures : string
+(** gRPC directive routing failures — target agent not in registry
+    or directive malformed.  Labels: [keeper, site]. *)
 
 val metric_auth_credential_token_duplicate : string
 (** #9786 follow-up: boot-time audit counter for credentials


### PR DESCRIPTION
## Summary

Recovery of instrumentation work that stayed uncommitted in the
keeper-tool-observability worktree when #12804 was merged, so even
though sibling instrumentation from the same branch landed, these
additions are still missing on main.

## Changes

- **New metric `metric_keeper_directive_failures`** (prometheus.ml +
  .mli + init() registration with help text). Labels: `{keeper, site}`.
- **keeper_keepalive.ml** (4 sites):
  - `pause_resume_not_in_registry` for the pause/resume directive
    on_missing branch
  - `wakeup_not_in_registry` for the wakeup directive on_missing branch
  - `claim_not_in_registry` for the assign-task directive on_missing
    branch
  - `metric_keeper_heartbeat_failures` site=`grpc_no_eio_context` for
    the "no Eio context or env" gRPC heartbeat fiber-launch fall-through
- **keeper_hooks_oas.ml** (3 sites): adds
  `metric_keeper_lifecycle_callback_failures` increments on the
  `gate_tool_call_log`, `after_turn_sse_broadcast`, and
  `post_tool_log_write` exception branches. The schema matches the
  existing `(keeper, callback)` label set used by on_tool_executed /
  on_error / on_tool_error sites that are already on main.

## Production behavior

No production code path changes. Every counter increment is added
inside an existing `| exn ->` branch that was already logging the
failure — only observability changes (the silent failure paths now
have a counter to alert on).

## Test plan

- [x] `dune build --root . @check` passes clean
- [ ] CI green on `Build and Test`, `Lint`, `Health`
- [ ] Required checks green before flipping to Ready