### PR TITLE
docs(watchdog): finish 3-modes update — supervisor.mli + .ml header

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -4,13 +4,19 @@
     [Keeper_keepalive]. Both modules call [fork_stale_watchdog] through
     this shared implementation.
 
-    Two stall detection modes:
-    1. Idle stall: [last_turn_ts] older than 300s while [Running],
-       with no recent keepalive skip verdict proving the fiber is still
-       evaluating work.
-    2. Failure loop: [consecutive_noop_count >= 3] — catches keepers in
-       LLM timeout loops where [last_turn_ts] stays fresh because each
-       failed turn updates it.
+    Three stall detection modes — see {!Keeper_registry.stale_kill_class}:
+    1. [Idle_turn]: [last_turn_ts] older than the idle threshold while
+       the keeper phase is [Running] but no [current_turn_observation]
+       is recorded, with no recent keepalive skip verdict proving the
+       fiber is still evaluating work.
+    2. [In_turn_hung]: a turn started ([current_turn_observation = Some])
+       and ran past [timeout_threshold] seconds — covers the
+       "Orphaned Streaming" pattern (executor FSM analysis §4 I2:
+       [in_turn_age > grace_period → in_turn_stale]).
+    3. [Noop_failure_loop]: turns kept firing but produced no tool
+       calls; the keepalive's [consecutive_noop_count] reached the
+       watchdog threshold — catches keepers in LLM timeout loops where
+       [last_turn_ts] stays fresh because each failed turn updates it.
 
     On detection, sets [fiber_stop] and emits a stale broadcast so the
     supervisor's [sweep_and_recover] can restart the keeper.

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -24,16 +24,11 @@ val supervise_keepalive :
 
 val fork_stale_watchdog :
   'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
-(** Fork a stale-turn watchdog fiber for the given keeper.
-
-    Two detection modes:
-    - Idle stall: [last_turn_ts] older than 300s while [Running].
-    - Failure loop: [consecutive_noop_count >= 3] — catches keepers in
-      LLM timeout loops where [last_turn_ts] stays fresh.
-
-    On detection, sets [fiber_stop] and emits a stale broadcast. The
-    supervisor's [sweep_and_recover] picks up the stopped fiber and
-    restarts with exponential backoff. *)
+(** Fork a stale-turn watchdog fiber for the given keeper.  This is a
+    re-export of {!Keeper_stale_watchdog.fork_stale_watchdog}; see
+    that module's docstring for the authoritative description of the
+    three detection modes ([Idle_turn] / [In_turn_hung] /
+    [Noop_failure_loop]) and per-class Prometheus counter. *)
 
 (** {1 Sweep and Recovery} *)
 


### PR DESCRIPTION
## Why

#12827 updated `keeper_stale_watchdog.mli` to reflect the actual three detection modes ([Idle_turn] / [In_turn_hung] / [Noop_failure_loop]) but two sibling docstrings carry the same outdated *"Two detection modes"* text inherited from the original #10670 extraction:

\`\`\`bash
$ grep -nB1 -A2 'Two stall\|Two detection' lib/keeper/keeper_stale_watchdog.ml lib/keeper/keeper_supervisor.mli
lib/keeper/keeper_stale_watchdog.ml:7:    Two stall detection modes:
lib/keeper/keeper_supervisor.mli:29:    Two detection modes:
\`\`\`

This is the same drift class that PR #12827 fixed — same root cause, same risk: an operator reading either of these surfaces would conclude that `In_turn_hung` doesn't exist and either rebuild duplicate logic or write an RFC for a feature already implemented.

## What

- **\`lib/keeper/keeper_supervisor.mli:29\`** — facade re-exporting \`Keeper_stale_watchdog.fork_stale_watchdog\`. Replaced inline mode list with a pointer to the authoritative module to avoid a third copy that can drift independently.
- **\`lib/keeper/keeper_stale_watchdog.ml:7\`** — the implementation file's own header. Now mirrors the \`.mli\` with all three variants and the executor FSM analysis §4 I2 citation.

## Risk

- Pure docs, 0 code change. \`dune build @check\` passes.
- The supervisor.mli reduction (15 → 7 lines) intentionally avoids a third inline copy of the mode list — there's now a single authoritative source (\`Keeper_stale_watchdog.fork_stale_watchdog\` mli docstring) and one cross-reference.

## References

- #12827 (mli first-pass update — this completes the sweep)
- #10670 (original extraction that introduced the duplicated docstring)
- 2026-04-28 \`executor_fsm_tla_analysis.md\` §4 (TLA+ I2 invariant)