### PR TITLE
feat(harness): sangsu ollama bench harness + cascade toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ tmp_edit/
 data/economy/
 data/harness-pre-compact/
 data/verdicts/
+data/bench/
 memory/
 
 # End of .gitignore

--- a/scripts/harness/workload/ollama_direct_bench.sh
+++ b/scripts/harness/workload/ollama_direct_bench.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Phase 1a-1: direct Ollama API bench (no masc-mcp involvement).
+#
+# Purpose: isolate "1-hour trap" cause - is it (a) Ollama cold start, or
+# (b) masc-mcp routing overhead? Measure (a) first, then layer (b) in
+# Phase 1a-2.
+#
+# Inputs:  $1 = model id (e.g. "qwen3.6:27b-coding-nvfp4")
+#          $2 = workload key (W1=code | W2=tool | W3=reason). Default W1.
+#          $3 = output JSONL path. Default data/bench/ollama-direct/<ts>.jsonl
+#
+# Output JSONL row schema:
+#   {model, workload, ts, load_ms, prefill_tok_per_sec, decode_tok_per_sec,
+#    total_duration_ms, eval_count, prompt_eval_count, rss_runner_after_gb,
+#    response_first_120, done_reason}
+#
+# Tok/s formulas (Ollama /api/generate response, ns):
+#   prefill = prompt_eval_count / (prompt_eval_duration / 1e9)
+#   decode  = eval_count        / (eval_duration        / 1e9)
+#
+# References:
+#   docs.ollama.com/api  (durations are nanoseconds)
+
+set -euo pipefail
+
+MODEL="${1:-qwen3:8b}"
+WORKLOAD="${2:-W1}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+OUT="${3:-${REPO_ROOT}/data/bench/ollama-direct/${TS}.jsonl}"
+
+# Env knobs:
+#   THINK         "true"|"false" — Ollama /api/generate think parameter for
+#                 reasoning models (qwen3, deepseek-r1, gpt-oss, ...).
+#                 Default false: measure raw decode without <think> overhead.
+#   NUM_PREDICT   integer — output token cap. Default 200.
+#   ISOLATE       "true"|"false" — call /api/generate with keep_alive:"5m"
+#                 plus issue /api/generate {model:<prev>, keep_alive:0}
+#                 to evict prior runner before bench. Default false.
+#   PREV_MODEL    model id to evict when ISOLATE=true.
+THINK="${THINK:-false}"
+NUM_PREDICT="${NUM_PREDICT:-200}"
+ISOLATE="${ISOLATE:-false}"
+PREV_MODEL="${PREV_MODEL:-}"
+
+mkdir -p "$(dirname "$OUT")"
+
+case "$WORKLOAD" in
+  W1) PROMPT='Implement Python function `parse_iso8601(s: str) -> datetime` with timezone awareness. Return only the function body and any imports.' ;;
+  W2) PROMPT='You have a tool {"name":"read_file","args":{"path":"string"}}. Output JSON only: {"tool":"read_file","args":{"path":"README.md"}}. No prose.' ;;
+  W3) PROMPT='A merchant sells apples 3 for $1, oranges 2 for $1. He sold 30 fruits for $13. How many apples? Show steps in <=5 lines.' ;;
+  *)  echo "unknown workload: $WORKLOAD (use W1|W2|W3)" >&2; exit 2 ;;
+esac
+
+if [ "$ISOLATE" = "true" ] && [ -n "$PREV_MODEL" ]; then
+  curl -sS --max-time 10 -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg m "$PREV_MODEL" '{model:$m, keep_alive:0}')" \
+    http://localhost:11434/api/generate >/dev/null 2>&1 || true
+fi
+
+rss_before_kb="$(ps -A -o rss,command 2>/dev/null | awk '/[o]llama runner/ {sum+=$1} END {print sum+0}')"
+
+REQ_BODY="$(jq -nc \
+  --arg model "$MODEL" \
+  --arg prompt "$PROMPT" \
+  --argjson think "$THINK" \
+  --argjson num_predict "$NUM_PREDICT" \
+  '{model:$model, prompt:$prompt, stream:false, think:$think, options:{num_predict:$num_predict, temperature:0.2}}')"
+
+req_start_ns="$(python3 -c 'import time;print(int(time.time()*1e9))')"
+RESP="$(curl -sS --max-time 180 \
+  -H 'Content-Type: application/json' \
+  -d "$REQ_BODY" \
+  http://localhost:11434/api/generate)"
+req_end_ns="$(python3 -c 'import time;print(int(time.time()*1e9))')"
+
+rss_after_kb="$(ps -A -o rss,command 2>/dev/null | awk '/[o]llama runner/ {sum+=$1} END {print sum+0}')"
+
+if [ -z "$RESP" ] || ! printf '%s' "$RESP" | jq -e . >/dev/null 2>&1; then
+  printf '{"model":"%s","workload":"%s","ts":"%s","error":"empty_or_invalid_response"}\n' \
+    "$MODEL" "$WORKLOAD" "$TS" >> "$OUT"
+  echo "FAIL: invalid response from ollama for $MODEL" >&2
+  exit 1
+fi
+
+ROW="$(printf '%s' "$RESP" | jq -c \
+  --arg model "$MODEL" \
+  --arg workload "$WORKLOAD" \
+  --arg ts "$TS" \
+  --argjson rss_before "$rss_before_kb" \
+  --argjson rss_after "$rss_after_kb" \
+  --argjson req_start "$req_start_ns" \
+  --argjson req_end "$req_end_ns" \
+  --arg think "$THINK" \
+  --arg isolate "$ISOLATE" \
+  '{
+    model: $model,
+    workload: $workload,
+    ts: $ts,
+    think: ($think == "true"),
+    isolate: ($isolate == "true"),
+    load_ms: ((.load_duration // 0) / 1e6),
+    prompt_eval_count: (.prompt_eval_count // 0),
+    eval_count: (.eval_count // 0),
+    prefill_tok_per_sec: (if (.prompt_eval_duration // 0) > 0 then (.prompt_eval_count / ((.prompt_eval_duration) / 1e9)) else null end),
+    decode_tok_per_sec:  (if (.eval_duration // 0) > 0          then (.eval_count        / ((.eval_duration)        / 1e9)) else null end),
+    total_duration_ms: ((.total_duration // 0) / 1e6),
+    wallclock_ms: (($req_end - $req_start) / 1e6),
+    rss_runner_before_gb: ($rss_before / 1024 / 1024),
+    rss_runner_after_gb:  ($rss_after  / 1024 / 1024),
+    response_first_120: ((.response // "") | .[0:120]),
+    response_len: ((.response // "") | length),
+    done_reason: (.done_reason // null)
+  }')"
+
+echo "$ROW" >> "$OUT"
+
+printf '%s\n' "$ROW" | jq -r '
+  "model:               \(.model)",
+  "workload:            \(.workload)",
+  "load_ms:             \(.load_ms | floor)",
+  "prefill_tok_per_sec: \(if .prefill_tok_per_sec == null then "n/a" else (.prefill_tok_per_sec | floor | tostring) end)",
+  "decode_tok_per_sec:  \(if .decode_tok_per_sec  == null then "n/a" else (.decode_tok_per_sec  | floor | tostring) end)",
+  "total_duration_ms:   \(.total_duration_ms | floor)",
+  "wallclock_ms:        \(.wallclock_ms | floor)",
+  "rss_runner_after_gb: \(.rss_runner_after_gb)",
+  "response_head:       \(.response_first_120)"
+'
+echo "log: $OUT"

--- a/scripts/harness/workload/ollama_sweep.sh
+++ b/scripts/harness/workload/ollama_sweep.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Phase 1a-1: model sweep harness on top of ollama_direct_bench.sh.
+#
+# Iterates a model list, runs workloads W1/W2/W3, evicts the previous
+# runner via ISOLATE chaining. Default workload set is W1,W2,W3.
+#
+# Usage:
+#   scripts/harness/workload/ollama_sweep.sh           # defaults to pulled models
+#   MODELS="m1 m2 m3" scripts/harness/workload/ollama_sweep.sh
+#   WORKLOADS="W1,W3" MODELS="qwen3:8b" ./ollama_sweep.sh
+#
+# Env knobs:
+#   MODELS       space-separated model ids (default: ollama list output)
+#   WORKLOADS    comma-separated W1|W2|W3 (default: W1,W2,W3)
+#   THINK        true|false (default: false — main goal is decode tok/s)
+#   NUM_PREDICT  output cap (default: 200)
+#   OUT_PATH     JSONL aggregate path (default: data/bench/ollama-direct/sweep-<ts>.jsonl)
+#
+# Notes:
+#   - First model gets cold load. Subsequent: prev model evicted via
+#     keep_alive:0 then new model loaded. Memory contention isolated.
+#   - Each row in output is one (model, workload) measurement.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+
+OUT_PATH="${OUT_PATH:-${REPO_ROOT}/data/bench/ollama-direct/sweep-${TS}.jsonl}"
+WORKLOADS="${WORKLOADS:-W1,W2,W3}"
+THINK="${THINK:-false}"
+NUM_PREDICT="${NUM_PREDICT:-200}"
+
+if [ -z "${MODELS:-}" ]; then
+  if ! command -v ollama >/dev/null 2>&1; then
+    echo "ollama CLI required to enumerate pulled models, or set MODELS env" >&2
+    exit 1
+  fi
+  MODELS="$(ollama list 2>/dev/null | awk 'NR>1 {print $1}' | tr '\n' ' ')"
+fi
+
+mkdir -p "$(dirname "$OUT_PATH")"
+: >"$OUT_PATH"
+
+echo "sweep_start ts=$TS workloads=$WORKLOADS think=$THINK num_predict=$NUM_PREDICT"
+echo "models=$MODELS"
+echo "out=$OUT_PATH"
+echo
+
+PREV=""
+total_start="$(date +%s)"
+
+for model in $MODELS; do
+  IFS=',' read -r -a wl_arr <<<"$WORKLOADS"
+  for wl in "${wl_arr[@]}"; do
+    wl="$(printf '%s' "$wl" | tr -d ' ')"
+    [ -z "$wl" ] && continue
+
+    isolate="false"
+    if [ -n "$PREV" ] && [ "$PREV" != "$model" ]; then
+      isolate="true"
+      # Warmup the new model with a tiny prompt before the actual measurement.
+      # Without this, large MLX models (>=64GB) sometimes return zero-metadata
+      # responses on the first measured request post cold load. Warmup costs
+      # ~load_time + 100ms; measurement reliability gain is large.
+      curl -sS --max-time 90 -H 'Content-Type: application/json' \
+        -d "$(jq -nc --arg m "$model" '{model:$m, prompt:"ping", stream:false, think:false, options:{num_predict:1}}')" \
+        http://localhost:11434/api/generate >/dev/null 2>&1 || true
+    fi
+
+    row_start="$(date +%s)"
+    echo "→ $model $wl  (isolate=$isolate prev=$PREV)"
+    set +e
+    THINK="$THINK" NUM_PREDICT="$NUM_PREDICT" ISOLATE="$isolate" PREV_MODEL="$PREV" \
+      "${SCRIPT_DIR}/ollama_direct_bench.sh" "$model" "$wl" "$OUT_PATH" 2>&1 | grep -E '^(decode|prefill|wallclock|response_head|done_reason|FAIL)' || true
+    rc=$?
+    set -e
+    row_end="$(date +%s)"
+    echo "  done in $((row_end - row_start))s rc=$rc"
+    echo
+    PREV="$model"
+  done
+done
+
+# Final eviction (free RAM after sweep)
+if [ -n "$PREV" ]; then
+  curl -sS --max-time 10 -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg m "$PREV" '{model:$m, keep_alive:0}')" \
+    http://localhost:11434/api/generate >/dev/null 2>&1 || true
+fi
+
+total_end="$(date +%s)"
+elapsed=$((total_end - total_start))
+
+echo "sweep_done elapsed=${elapsed}s"
+echo "rows=$(wc -l <"$OUT_PATH" | tr -d ' ')"
+echo "summary:"
+jq -s '
+  group_by(.model) | map({
+    model: .[0].model,
+    runs: length,
+    avg_decode_tok_per_sec: (
+      [.[] | .decode_tok_per_sec // empty] |
+      if length > 0 then (add / length) else null end
+    ),
+    avg_prefill_tok_per_sec: (
+      [.[] | .prefill_tok_per_sec // empty] |
+      if length > 0 then (add / length) else null end
+    ),
+    avg_wallclock_ms: (
+      [.[] | .wallclock_ms // empty] |
+      if length > 0 then (add / length) else null end
+    ),
+    workloads: [.[] | {w: .workload, dur_ms: .wallclock_ms, tok_s: .decode_tok_per_sec, len: .response_len}]
+  })
+' "$OUT_PATH"
+echo "out=$OUT_PATH"

--- a/scripts/harness/workload/sangsu_bench_toggle.sh
+++ b/scripts/harness/workload/sangsu_bench_toggle.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Phase 1a-2: toggle sangsu's cascade between live mode and ollama_bench.
+#
+# Mutates ~/me/.masc/config/keepers/sangsu.toml in place. Backup written
+# alongside as sangsu.toml.bench-bak. Hot-reload is mtime-based so no
+# server restart needed.
+#
+# Usage:
+#   ./sangsu_bench_toggle.sh on              # backup + switch to ollama_bench
+#   ./sangsu_bench_toggle.sh off             # restore from backup
+#   ./sangsu_bench_toggle.sh status          # print current cascade_name
+#   ./sangsu_bench_toggle.sh model qwen3.6:35b-a3b-mlx-bf16
+#                                            # mutate ollama_bench profile's
+#                                            # single model slot in cascade.toml
+#
+# The "model" subcommand updates cascade.toml's [ollama_bench].models and
+# triggers materializer re-run via mtime touch.
+
+set -euo pipefail
+
+BASE_PATH="${MASC_BASE_PATH:-$HOME/me}"
+SANGSU_TOML="${BASE_PATH}/.masc/config/keepers/sangsu.toml"
+SANGSU_BAK="${SANGSU_TOML}.bench-bak"
+CASCADE_TOML="${BASE_PATH}/.masc/config/cascade.toml"
+
+cmd="${1:-status}"
+arg="${2:-}"
+
+current_cascade() {
+  awk -F' *= *' '/^cascade_name *=/ {gsub(/"/,"",$2); print $2; exit}' "$SANGSU_TOML"
+}
+
+current_bench_model() {
+  python3 - "$CASCADE_TOML" << 'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r'\[ollama_bench\][^\[]*?models\s*=\s*\[(.*?)\]', src, re.DOTALL)
+if not m:
+    print("(not found)")
+    sys.exit(0)
+mm = re.search(r'model\s*=\s*"([^"]+)"', m.group(1))
+print(mm.group(1) if mm else "(empty)")
+PY
+}
+
+case "$cmd" in
+  status)
+    printf 'sangsu cascade_name: %s\n' "$(current_cascade)"
+    printf 'ollama_bench model:  %s\n' "$(current_bench_model)"
+    if [ -f "$SANGSU_BAK" ]; then
+      printf 'backup:              %s (exists)\n' "$SANGSU_BAK"
+    fi
+    ;;
+  on)
+    cur="$(current_cascade)"
+    if [ "$cur" = "ollama_bench" ]; then
+      echo "already on ollama_bench"
+      exit 0
+    fi
+    cp "$SANGSU_TOML" "$SANGSU_BAK"
+    # shellcheck disable=SC2016
+    sed -E -i '' 's|^cascade_name *= *"[^"]+"|cascade_name = "ollama_bench"|' "$SANGSU_TOML"
+    new="$(current_cascade)"
+    if [ "$new" != "ollama_bench" ]; then
+      echo "FAIL: sed did not switch cascade_name (got: $new). Restoring from backup." >&2
+      mv "$SANGSU_BAK" "$SANGSU_TOML"
+      exit 1
+    fi
+    printf 'sangsu cascade_name: %s -> ollama_bench (backup at %s)\n' "$cur" "$SANGSU_BAK"
+    ;;
+  off)
+    if [ ! -f "$SANGSU_BAK" ]; then
+      echo "no backup at $SANGSU_BAK — refusing to restore blindly" >&2
+      exit 1
+    fi
+    mv "$SANGSU_BAK" "$SANGSU_TOML"
+    printf 'sangsu cascade_name restored to: %s\n' "$(current_cascade)"
+    ;;
+  model)
+    if [ -z "$arg" ]; then
+      echo "usage: sangsu_bench_toggle.sh model <ollama:model:tag>" >&2
+      exit 2
+    fi
+    # Match the [ollama_bench] section's first models = [ ... ] block,
+    # rewrite the single entry. Idempotent for our 1-slot profile.
+    python3 - "$CASCADE_TOML" "$arg" << 'PY'
+import re, sys, time
+
+path, model = sys.argv[1], sys.argv[2]
+src = open(path).read()
+pat = re.compile(
+    r'(\[ollama_bench\][^\[]*?models\s*=\s*\[)[^\]]*?(\])',
+    re.DOTALL,
+)
+new_block = '\n  { model = "%s", weight = 1 },\n' % model
+out, n = pat.subn(lambda m: m.group(1) + new_block + m.group(2), src, count=1)
+if n != 1:
+    print("FAIL: could not find [ollama_bench] models block", file=sys.stderr)
+    sys.exit(1)
+open(path, 'w').write(out)
+print(f"ollama_bench model -> {model}")
+PY
+    # Touch mtime to force loader cache invalidation.
+    touch "$CASCADE_TOML"
+    printf 'cascade.toml mtime: %s\n' "$(stat -f %Sm "$CASCADE_TOML" 2>/dev/null || stat -c %y "$CASCADE_TOML")"
+    ;;
+  *)
+    echo "usage: $0 {status|on|off|model <ollama:model:tag>}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/host-ollama-tune.sh
+++ b/scripts/host-ollama-tune.sh
@@ -33,23 +33,38 @@ set -euo pipefail
 
 KEEP_ALIVE_TARGET="${OLLAMA_KEEP_ALIVE_TARGET:--1}"
 NUM_PARALLEL_TARGET="${OLLAMA_NUM_PARALLEL_TARGET:-1}"
+# KV cache quantization saves ~50% (q8_0) or ~75% (q4_0) of context-cache RAM.
+# Required for 70GB BF16 models to fit under 80GB RAM ceiling with 256K ctx.
+# Requires FLASH_ATTENTION=1; falls back to f16 silently when unsupported.
+FLASH_ATTENTION_TARGET="${OLLAMA_FLASH_ATTENTION_TARGET:-1}"
+KV_CACHE_TYPE_TARGET="${OLLAMA_KV_CACHE_TYPE_TARGET:-q8_0}"
 
 usage() {
   sed -n '1,32p' "$0"
 }
 
 show_current() {
-  local ka np
+  local ka np fa kv
   ka="$(launchctl getenv OLLAMA_KEEP_ALIVE 2>/dev/null || true)"
   np="$(launchctl getenv OLLAMA_NUM_PARALLEL 2>/dev/null || true)"
-  printf 'OLLAMA_KEEP_ALIVE   current=%-6s target=%s\n' "${ka:-<unset>}" "$KEEP_ALIVE_TARGET"
-  printf 'OLLAMA_NUM_PARALLEL current=%-6s target=%s\n' "${np:-<unset>}" "$NUM_PARALLEL_TARGET"
+  fa="$(launchctl getenv OLLAMA_FLASH_ATTENTION 2>/dev/null || true)"
+  kv="$(launchctl getenv OLLAMA_KV_CACHE_TYPE 2>/dev/null || true)"
+  printf 'OLLAMA_KEEP_ALIVE       current=%-6s target=%s\n' "${ka:-<unset>}" "$KEEP_ALIVE_TARGET"
+  printf 'OLLAMA_NUM_PARALLEL     current=%-6s target=%s\n' "${np:-<unset>}" "$NUM_PARALLEL_TARGET"
+  printf 'OLLAMA_FLASH_ATTENTION  current=%-6s target=%s\n' "${fa:-<unset>}" "$FLASH_ATTENTION_TARGET"
+  printf 'OLLAMA_KV_CACHE_TYPE    current=%-6s target=%s\n' "${kv:-<unset>}" "$KV_CACHE_TYPE_TARGET"
 }
 
 apply() {
-  echo "Setting launchctl env (OLLAMA_KEEP_ALIVE=$KEEP_ALIVE_TARGET, OLLAMA_NUM_PARALLEL=$NUM_PARALLEL_TARGET)..."
+  echo "Setting launchctl env:"
+  echo "  OLLAMA_KEEP_ALIVE=$KEEP_ALIVE_TARGET"
+  echo "  OLLAMA_NUM_PARALLEL=$NUM_PARALLEL_TARGET"
+  echo "  OLLAMA_FLASH_ATTENTION=$FLASH_ATTENTION_TARGET"
+  echo "  OLLAMA_KV_CACHE_TYPE=$KV_CACHE_TYPE_TARGET"
   launchctl setenv OLLAMA_KEEP_ALIVE "$KEEP_ALIVE_TARGET"
   launchctl setenv OLLAMA_NUM_PARALLEL "$NUM_PARALLEL_TARGET"
+  launchctl setenv OLLAMA_FLASH_ATTENTION "$FLASH_ATTENTION_TARGET"
+  launchctl setenv OLLAMA_KV_CACHE_TYPE "$KV_CACHE_TYPE_TARGET"
 
   if pgrep -x Ollama >/dev/null 2>&1; then
     echo "Restarting Ollama.app to pick up new env..."
@@ -75,6 +90,8 @@ apply() {
   echo "macOS reboots, also add the following to ~/.zshenv:"
   echo "  export OLLAMA_KEEP_ALIVE=$KEEP_ALIVE_TARGET"
   echo "  export OLLAMA_NUM_PARALLEL=$NUM_PARALLEL_TARGET"
+  echo "  export OLLAMA_FLASH_ATTENTION=$FLASH_ATTENTION_TARGET"
+  echo "  export OLLAMA_KV_CACHE_TYPE=$KV_CACHE_TYPE_TARGET"
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary

Three scripts under `scripts/harness/workload/` to measure local Ollama models from sangsu's cascade slot, plus a host-tune patch to expose Ollama KV cache env knobs.

- `ollama_direct_bench.sh` — single-model `/api/generate` measurement. `THINK` env knob (default `false`) prevents reasoning-model 5× time inflation observed on Qwen3 family. `ISOLATE` chains `keep_alive:0` evict so prior runner is freed before measuring next model. Captures prefill/decode tok/s, RSS sum, response_len from raw API response.
- `ollama_sweep.sh` — rotates a model list through W1/W2/W3 workloads with ISOLATE chaining and a 1-token warmup between models. Warmup fixes a zero-metadata response observed on cold-load first request for ≥64GB MLX models (eval_count=0, total_duration=0 despite valid JSON).
- `sangsu_bench_toggle.sh` — `status` / `on` / `off` / `model` subcommands to flip `~/me/.masc/config/keepers/sangsu.toml` between live cascade (`glm_coding_plan_only`) and an additive `[ollama_bench]` profile. Auto-backup before mutation; refuses `off` without backup; cascade.toml mtime touch triggers OAS hot-reload.
- `scripts/host-ollama-tune.sh` — adds `OLLAMA_FLASH_ATTENTION=1` and `OLLAMA_KV_CACHE_TYPE=q8_0` to launchctl env + zshenv hint output. Required to actually use Ollama KV cache quantization. 70GB BF16 models need q8_0 to fit 256K context under 80GB unified memory.
- `.gitignore` — `data/bench/` mirrors existing `data/economy/` / `verdicts/` / `harness-pre-compact/` pattern. Bench JSONL output is reference data, not source.

## Why

Sangsu cascade can already route to Ollama (`local_recovery` profile uses `ollama:qwen3.6:27b-coding-nvfp4`), but there was no isolated way to measure individual models without disturbing other keepers. The toggle script adds a single-slot `[ollama_bench]` profile and lets sangsu redirect to it temporarily. The bench harness measures Ollama directly via `/api/generate` so the same numbers can be compared with cascade-routed numbers from `/api/v1/cascade/health`.

## OAS-side findings (informational, not in this PR)

While building, I found these things are already implemented:

- `cascade_config_loader.mli` line 1 documents mtime-based hot-reload; cascade.toml edits are picked up lazily on next routing call. No SIGHUP / restart needed.
- `model_inference_metrics.mli` exposes `prompt_avg_tok_per_sec`, `hw_decode_avg_tok_per_sec`, `max_peak_memory_gb`, `cache_hit_ratio`, `total_tool_calls`, plus a `provider_rollup` helper with `avg_decode_tok_per_sec` per provider.
- `cascade_client_capacity.auto_register_ollama_with_override` is invoked at boot from `oas_worker_named.ml`, so the ollama provider key shows up in `/api/v1/cascade/health` even before any traffic.

So the "OAS hot-reload" and "expose tok/s metrics" backlog items were unnecessary — they already exist. The remaining backlog is in the report file under `.tmp/`.

## Risks / non-goals

- `host-ollama-tune.sh --apply` restarts Ollama. Other keepers using `local_recovery` will see a brief unavailability while the runner reloads. The path is unchanged in shape from the existing `KEEP_ALIVE` / `NUM_PARALLEL` block.
- The `[ollama_bench]` cascade profile lives in the user dotfile (`~/me/.masc/config/cascade.toml`), so it is **not in this PR**. Anyone who wants to use the toggle needs to add the profile to their own cascade catalog.
- I did not measure long-context performance (≥64K input). Mamba2 hybrid (nemotron3) likely shows different curves there but it's out of scope for this harness.

## Self-review

Per `@~/me/agents/best-programmer/AGENT.md`:
- **Goal**: enable per-model Ollama measurement from sangsu without touching shared profiles or other keepers.
- **Changed files**: 4 scripts + 1 line in `.gitignore`. No `lib/` changes.
- **Local checks**: `bash -n` syntax pass on the 3 new scripts; `host-ollama-tune.sh` dry-run output matches the existing block (4 env vars instead of 2).
- **Unverified at PR open**: `--apply` path on host-tune was not exercised because it restarts Ollama. Same shape as the existing pre-merge `KEEP_ALIVE` / `NUM_PARALLEL` block in this script, so I'm relying on parallel structure rather than full execution.

## Test plan

- [ ] `bash -n` syntax pass on all 4 scripts (done locally)
- [ ] `host-ollama-tune.sh` dry-run shows 4 env knobs (done locally)
- [ ] `ollama_direct_bench.sh qwen3:8b W1` returns valid JSONL row with non-null prefill/decode tok/s (done locally — 34 t/s decode, 452 t/s prefill measured)
- [ ] `ollama_sweep.sh` with two models exits 0 and writes one master JSONL (done locally — 12 rows for 4 models × 3 workloads, 4 min wallclock)
- [ ] `sangsu_bench_toggle.sh on` → `off` round-trip restores `cascade_name` (done locally on live config; backup file consumed by `off`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)