### PR TITLE
fix(keeper): tighten hard_quota tests + drop redundant guard (#12818 followup)

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -281,8 +281,6 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
 
            Hard-quota 429s are already handled above by sdk_error_is_hard_quota,
            so only soft (non-hard-quota) rate limits reach this arm. *)
-        (* hard_quota was already returned above by the sdk_error_is_hard_quota
-           check, so the RateLimited arm here is necessarily soft. *)
         (match err with
          | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
              Some "rate_limit"

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -281,9 +281,10 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
 
            Hard-quota 429s are already handled above by sdk_error_is_hard_quota,
            so only soft (non-hard-quota) rate limits reach this arm. *)
+        (* hard_quota was already returned above by the sdk_error_is_hard_quota
+           check, so the RateLimited arm here is necessarily soft. *)
         (match err with
-         | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
-           when not (Oas_worker_named.sdk_error_is_hard_quota err) ->
+         | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
              Some "rate_limit"
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
            when status >= 500 ->

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -160,14 +160,15 @@ let test_soft_rate_limit_no_retry_after_is_recoverable () =
     Agent_sdk.Error.Api
       (Retry.RateLimited { retry_after = None; message = "slow down" })
   in
-  (* Only recoverable if NOT classified as hard quota *)
-  if not (Owne.sdk_error_is_hard_quota err) then begin
-    match KEC.recoverable_cascade_failure_reason err with
-    | Some reason ->
-      check string "no-retry_after rate_limit -> rate_limit" "rate_limit" reason
-    | None ->
-      fail "Non-hard-quota RateLimited without retry_after should be recoverable"
-  end
+  (* Pin the precondition explicitly so a classifier change cannot turn
+     this assertion into a silent no-op. *)
+  check bool "rate-limit fixture is not hard-quota" false
+    (Owne.sdk_error_is_hard_quota err);
+  (match KEC.recoverable_cascade_failure_reason err with
+   | Some reason ->
+     check string "no-retry_after rate_limit -> rate_limit" "rate_limit" reason
+   | None ->
+     fail "Non-hard-quota RateLimited without retry_after should be recoverable")
 
 let test_server_error_500_is_recoverable () =
   let err =
@@ -222,13 +223,13 @@ let test_hard_quota_not_reclassified_as_rate_limit () =
     Agent_sdk.Error.Api
       (Retry.RateLimited { retry_after = None; message = "resource exhausted" })
   in
-  if Owne.sdk_error_is_hard_quota err then begin
-    match KEC.recoverable_cascade_failure_reason err with
-    | Some reason ->
-      check string "hard quota keeps hard_quota label" "hard_quota" reason
-    | None ->
-      fail "Hard quota should be recoverable with hard_quota label"
-  end
+  check bool "hard-quota fixture is hard-quota" true
+    (Owne.sdk_error_is_hard_quota err);
+  (match KEC.recoverable_cascade_failure_reason err with
+   | Some reason ->
+     check string "hard quota keeps hard_quota label" "hard_quota" reason
+   | None ->
+     fail "Hard quota should be recoverable with hard_quota label")
 
 let test_server_error_400_not_recoverable_by_new_arm () =
   (* 4xx client errors below 500 should NOT be recovered by the server_error


### PR DESCRIPTION
## Why

Cleanup follow-up to #12818 (cascade rotation P0 fix, merged at 14:23Z). Three Copilot review threads on that PR flagged mechanical nits that did not block the original merge but warrant addressing now:

1. `test_keeper_error_classify_recoverable.ml:164` (rate-limit): assertion was inside `if not (sdk_error_is_hard_quota err) then begin ... end` with no `else`. If the classifier ever flips for that fixture, the test silently skips and stays green.
2. `test_keeper_error_classify_recoverable.ml:225` (hard-quota): symmetric pattern.
3. `lib/keeper/keeper_error_classify.ml:286`: `when not (sdk_error_is_hard_quota err)` guard on the RateLimited arm of `recoverable_cascade_failure_reason` is redundant because hard_quota is returned earlier in the same function.

## Changes

- Both test cases now pin the precondition with `check bool` so a regression in `sdk_error_is_hard_quota` becomes a loud failure rather than a silent skip.
- The redundant `when not` clause is removed and replaced with a comment documenting the invariant.

## Test plan

- [x] Local diff
- [ ] CI `Build and Test` — pinned tests must still pass against current classifier

## Notes

The cascade-rotation behaviour itself (the substantive change in #12818) is unchanged. This PR only removes silent-failure modes and dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)