### PR TITLE
fix(keeper): instrument decision record JSONL append failure

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -994,6 +994,10 @@ let append_decision_record
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_decision_audit_flush_failures
+        ~labels:[("keeper", meta.name)]
+        ();
       Log.Keeper.warn "append decision record failed for %s: %s"
         meta.name (Printexc.to_string exn)
 


### PR DESCRIPTION
## Summary
- Add metric_keeper_decision_audit_flush_failures counter to append_decision_record exception handler
- Identified during warn-level gap scan (PR #12800), landed after squash merge

## Test plan
- [x] dune build lib/ passes
- [ ] Verify metric in /metrics on append failure

Generated with Claude Code