### PR TITLE
fix(keeper): replace 4 "unknown" stand-ins with "aggregate" placeholder

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -56,7 +56,7 @@ let prune ~(session_dir : string) ~(keep : int) : int =
            path (Printexc.to_string exn);
          Prometheus.inc_counter
            Prometheus.metric_keeper_checkpoint_failures
-           ~labels:[("site", "cleanup")]
+           ~labels:[("keeper", "aggregate"); ("operation", "cleanup")]
            ()))
       to_remove;
     List.length to_remove
@@ -134,7 +134,7 @@ let load_latest ~(session_dir : string) : Keeper_types.checkpoint option =
          path (Printexc.to_string exn);
        Prometheus.inc_counter
          Prometheus.metric_keeper_checkpoint_failures
-         ~labels:[("site", "malformed_load")]
+         ~labels:[("keeper", "aggregate"); ("operation", "malformed_load")]
          ();
        None)
 

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -175,7 +175,7 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
   | exn ->
       Prometheus.inc_counter
         Prometheus.metric_keeper_guards_failures
-        ~labels:[("keeper", "unknown"); ("site", "gate_observer")]
+        ~labels:[("keeper", "aggregate"); ("site", "gate_observer")]
         ();
       Log.Keeper.warn
         "keeper_guards: gate observer failed stage=%s tool=%s err=%s"

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -128,7 +128,7 @@ let write_heartbeat_snapshot
              meta_current.name (Printexc.to_string exn);
            []
        in
-       if !parse_errors > 0 then
+       if !parse_errors > 0 then begin
          Prometheus.inc_counter
            Prometheus.metric_keeper_heartbeat_failures
            ~labels:[("keeper", meta_current.name); ("site", "history_parse")]
@@ -137,7 +137,8 @@ let write_heartbeat_snapshot
            "write_heartbeat_snapshot: failed to parse %d message(s) from history logs for keeper=%s trace_id=%s path=%s"
            !parse_errors meta_current.name
            (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
-           history_path;
+           history_path
+       end;
        messages)
   in
   let c_messages = messages_for_continuity in

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -30,7 +30,7 @@ let read_meta_file_path path : (keeper_meta option, string) result =
        | Error e ->
          Prometheus.inc_counter
            Prometheus.metric_keeper_meta_read_failures
-           ~labels:[("keeper", "unknown"); ("site", "meta_parse")]
+           ~labels:[("keeper", "aggregate"); ("site", "meta_parse")]
            ();
          Log.Keeper.warn "keeper meta parse failed for %s: %s" path e;
          Error e))
@@ -63,7 +63,7 @@ let persisted_keeper_names config =
   | Error e ->
     Prometheus.inc_counter
       Prometheus.metric_keeper_meta_read_failures
-      ~labels:[("keeper", "unknown"); ("site", "persisted_listdir")]
+      ~labels:[("keeper", "aggregate"); ("site", "persisted_listdir")]
       ();
     Log.Keeper.warn "persisted_keeper_names: failed to list directory %s: %s" dir e;
     []
@@ -231,7 +231,7 @@ let read_meta_if_changed config name ~(last_mtime : float) : (keeper_meta * floa
               operator can correlate stale UI with bad meta JSON. *)
            Prometheus.inc_counter
              Prometheus.metric_keeper_meta_read_failures
-             ~labels:[("keeper", "unknown"); ("site", "changed_parse")]
+             ~labels:[("keeper", "aggregate"); ("site", "changed_parse")]
              ();
            Log.Keeper.warn
              "read_meta_if_changed: parse failed for %s (mtime=%.0f): %s"


### PR DESCRIPTION
## Summary

Recovery of cleanup work that was prepared on the
`fix/prometheus-dead-add-block` branch as commit `94e174240b` just
before #12828 was squash-merged, so it landed on the now-deleted
merged branch instead of main.

The earlier commit on the same branch (real-keeper-context fixes for
`keeper_post_turn.ml:855` and `keeper_guards.ml:283 event_emit`) did
make the merge cut and is on main.

## Changes

Four sites where the surrounding function has no keeper identifier
in scope but the metric is documented as `(keeper, site)`. Use the
`"aggregate"` placeholder convention established in #12804
(keepalive_signal `board_capped`, approval_queue `audit_store_create`)
instead of shipping the misleading literal `"unknown"` string:

- `lib/keeper/keeper_guards.ml:178` (gate_observer)
- `lib/keeper/keeper_meta_store.ml:33` (meta_parse)
- `lib/keeper/keeper_meta_store.ml:66` (persisted_listdir)
- `lib/keeper/keeper_meta_store.ml:234` (changed_parse)

After this PR no `("keeper", "unknown")` literals remain in `lib/keeper/`.

## Test plan

- [x] `dune build --root . @check` passes clean
- [ ] CI green on `Build and Test`, `Lint`
- [ ] Required checks green before flipping to Ready