### PR TITLE
chore(dashboard): drop deprecated theme-hash exports

### DIFF
--- a/dashboard/src/components/common/theme-sync.test.ts
+++ b/dashboard/src/components/common/theme-sync.test.ts
@@ -1,38 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import {
-  parseThemeFromHash,
   parseThemeFromSearch,
   updateThemeSearchParam,
   syncThemeAcrossSurfaces,
   THEME_STORAGE_KEY,
   THEME_SEARCH_PARAM,
 } from './theme-sync'
-
-describe('parseThemeFromHash', () => {
-  it('parses dark theme from hash', () => {
-    expect(parseThemeFromHash('#theme=dark')).toBe('dark')
-  })
-
-  it('parses light theme from hash', () => {
-    expect(parseThemeFromHash('#theme=light')).toBe('light')
-  })
-
-  it('parses dark-fantasy theme from hash', () => {
-    expect(parseThemeFromHash('#theme=dark-fantasy')).toBe('dark-fantasy')
-  })
-
-  it('parses paper theme from hash', () => {
-    expect(parseThemeFromHash('#theme=paper')).toBe('paper')
-  })
-
-  it('returns null for invalid theme', () => {
-    expect(parseThemeFromHash('#theme=invalid')).toBeNull()
-  })
-
-  it('returns null for unrelated hash', () => {
-    expect(parseThemeFromHash('#section=1')).toBeNull()
-  })
-})
 
 describe('parseThemeFromSearch', () => {
   it('parses dark theme from search string', () => {

--- a/dashboard/src/components/common/theme-sync.ts
+++ b/dashboard/src/components/common/theme-sync.ts
@@ -11,9 +11,6 @@ import type { ThemeId } from './use-theme'
 export const THEME_STORAGE_KEY = 'masc-theme-v2'
 export const THEME_SEARCH_PARAM = 'theme'
 
-/** @deprecated Use updateThemeSearchParam — writing to location.hash breaks hash-based routing. */
-export const THEME_HASH_PREFIX = '#theme='
-
 export function updateThemeSearchParam(theme: ThemeId) {
   if (typeof location === 'undefined') return
   const url = new URL(location.href)
@@ -28,17 +25,6 @@ export function parseThemeFromSearch(search: string): ThemeId | null {
   const theme = sp.get(THEME_SEARCH_PARAM)
   if (theme === 'dark' || theme === 'light' || theme === 'dark-fantasy' || theme === 'paper') {
     return theme
-  }
-  return null
-}
-
-/** @deprecated Use parseThemeFromSearch — theme is no longer stored in location.hash. */
-export function parseThemeFromHash(hash: string): ThemeId | null {
-  if (hash.startsWith(THEME_HASH_PREFIX)) {
-    const theme = hash.slice(THEME_HASH_PREFIX.length)
-    if (theme === 'dark' || theme === 'light' || theme === 'dark-fantasy' || theme === 'paper') {
-      return theme
-    }
   }
   return null
 }


### PR DESCRIPTION
## Summary

`THEME_HASH_PREFIX` and `parseThemeFromHash` in
`dashboard/src/components/common/theme-sync.ts` were marked
`@deprecated` because writing theme to `location.hash` breaks the
hash-based router (router.ts canonicalises `#<tab>?...`). The
replacement APIs using `?theme=...` search params
(`updateThemeSearchParam` / `parseThemeFromSearch`) have been the
canonical path for a while.

A repository-wide grep before this change confirms zero production
imports of either symbol — only `theme-sync.ts` itself and its own
test file referenced them.

## Changes (-41 lines)

- `theme-sync.ts`: drop `THEME_HASH_PREFIX` const, `parseThemeFromHash`
  function, and the two `@deprecated` JSDoc blocks (14 lines).
- `theme-sync.test.ts`: drop the entire `describe('parseThemeFromHash',
  ...)` suite and the now-unused import (27 lines).

After this change `rg 'THEME_HASH_PREFIX|parseThemeFromHash' dashboard/src`
returns zero hits.

## Production behavior

Unchanged — the hash-write path was already unreachable from any
current call site.

## Test plan

- [x] `rg 'THEME_HASH_PREFIX|parseThemeFromHash' dashboard/src` returns 0
- [ ] Dashboard CI green on `Lint`, `Test`, `Build`
- [ ] Required checks green before flipping to Ready

## Note

First PR in a focused dashboard cleanup pass — removing unused
deprecated exports and duplicate components. Each cleanup ships as a
separate small PR for easy review and revert.