### PR TITLE
feat(metrics): Task-138 P1 — keeper cadence gauges (consecutive_idle, last_productive_ts)

### DIFF
--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -27,6 +27,10 @@ let threshold () =
 type keeper_state = {
   mutable streak : int;
   mutable detected_latched : bool;
+  (* Task-138: Unix timestamp of the most recent productive turn
+     (execution/completion class). 0.0 until the keeper has produced
+     anything in this process. *)
+  mutable last_productive_ts : float;
 }
 
 let state : (string, keeper_state) Hashtbl.t = Hashtbl.create 16
@@ -40,15 +44,28 @@ let get_or_create keeper_name =
   match Hashtbl.find_opt state keeper_name with
   | Some s -> s
   | None ->
-      let s = { streak = 0; detected_latched = false } in
+      let s = { streak = 0; detected_latched = false;
+                last_productive_ts = 0.0 } in
       Hashtbl.replace state keeper_name s;
       s
 
-let update_streak_gauge _keeper_name _value = ()
-(* Gauge metric for streak tracking is not emitted in v1.  Prometheus
-   counters (metric_keeper_passive_loop_detected_total) cover the
-   detection events; a streak gauge can be added in a follow-up PR
-   alongside the dashboard visualization. *)
+(* Task-138: streak gauge — pairs with the counter so dashboards see
+   the climb before the latch fires (counter only triggers once per
+   episode at threshold). *)
+let update_streak_gauge keeper_name value =
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_consecutive_idle
+    ~labels:[("keeper", keeper_name)]
+    (float_of_int value)
+
+(* Task-138: timestamp of the most recent productive turn.  Operators
+   plot [time() - keeper_last_productive_ts > N] as a single PromQL
+   alert per keeper. *)
+let update_last_productive_gauge keeper_name ts =
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_last_productive_ts
+    ~labels:[("keeper", keeper_name)]
+    ts
 
 (** [record_turn ~keeper_name ~progress_class] updates the passive streak
     counter for [keeper_name] based on the [tool_progress_class] of the
@@ -80,7 +97,14 @@ let record_turn ~keeper_name ~progress_class =
         if s.streak > 0 then
           update_streak_gauge keeper_name 0;
         s.streak <- 0;
-        s.detected_latched <- false)
+        s.detected_latched <- false;
+        (* Task-138: record productive turn timestamp + gauge.
+           Both internal field and external metric stay in sync so a
+           later [last_productive_ts] read returns the same value the
+           dashboard sees. *)
+        let now = Unix.time () in
+        s.last_productive_ts <- now;
+        update_last_productive_gauge keeper_name now)
 
 let current_streak ~keeper_name =
   with_lock (fun () ->
@@ -109,7 +133,11 @@ let nudge_message ~keeper_name =
 let reset ~keeper_name =
   with_lock (fun () ->
     Hashtbl.remove state keeper_name;
-    update_streak_gauge keeper_name 0)
+    update_streak_gauge keeper_name 0;
+    (* Task-138: also zero the productive-ts gauge so a recycled keeper
+       slot does not appear "alive but never produced" with the
+       previous keeper's timestamp. *)
+    update_last_productive_gauge keeper_name 0.0)
 
 let reset_all_for_test () =
   with_lock (fun () -> Hashtbl.clear state)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -906,6 +906,13 @@ let metric_cascade_server_error_skip_total =
    calls for N consecutive turns.  Labels: keeper. *)
 let metric_keeper_passive_loop_detected_total =
   "masc_keeper_passive_loop_detected_total"
+
+(* Task-138: Minimum proactive cadence — observability gauges that pair
+   with the [keeper_passive_loop_detector] streak counter so operators
+   can see "alive but unproductive" keepers in Grafana before the
+   detection latch fires.  Labels: keeper. *)
+let metric_keeper_consecutive_idle = "masc_keeper_consecutive_idle"
+let metric_keeper_last_productive_ts = "masc_keeper_last_productive_ts"
 (* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
    per keeper. Counter increments on each strike; a strike at
    [outcome=promote] means [Keeper_fiber_crash] was raised so
@@ -1468,6 +1475,16 @@ let init () =
     "#12799 Total passive-loop detections: keeper issued only read-only tool \
      calls for N consecutive turns. Labeled by keeper."
     Counter;
+  add metric_keeper_consecutive_idle
+    "Task-138 Current consecutive-idle streak (passive-only turns) per \
+     keeper.  Resets to 0 on the next execution/completion turn.  Labeled \
+     by keeper."
+    Gauge;
+  add metric_keeper_last_productive_ts
+    "Task-138 Unix timestamp of the most recent productive turn \
+     (execution/completion class) per keeper.  0 until the keeper has \
+     produced anything.  Labeled by keeper."
+    Gauge;
   add metric_keeper_tool_alias_canonicalizations
     "Total observed LLM-facing tool names canonicalized to keeper internal \
      tool names. Labeled by alias_kind, public_tool, and canonical_tool."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -283,6 +283,18 @@ val metric_keeper_passive_loop_detected_total : string
     using only passive read-only tools, violating the proactive contract.
     Incremented once per loop episode (streak resets on any execution-progress
     turn). Labels: [keeper]. *)
+
+val metric_keeper_consecutive_idle : string
+(** Task-138 Current consecutive-idle streak (passive-only turns) per
+    keeper.  Resets to 0 on the next execution/completion turn.  Pairs
+    with [metric_keeper_passive_loop_detected_total]: the counter fires
+    only at the threshold crossing, this gauge lets dashboards see the
+    streak rising before the latch.  Labels: [keeper]. *)
+
+val metric_keeper_last_productive_ts : string
+(** Task-138 Unix timestamp of the most recent productive turn
+    (execution/completion class) per keeper.  Reads as 0 until the
+    keeper has produced anything in this process.  Labels: [keeper]. *)
 val metric_keeper_ollama_saturation_skip : string
 (** PR-B: counter incremented when [run_keeper_cycle] skips a turn
     because the keeper's resolved cascade is ollama-only and the


### PR DESCRIPTION
## Why

Task-138 (*Minimum Proactive Cadence Spec*) asks for per-keeper observability so dashboards can detect "alive but unproductive" keepers before the existing `masc_keeper_passive_loop_detected_total` counter fires.  The counter only triggers once per loop episode at the threshold latch (default 5), so an operator cannot:

- See the streak rising 1 → 2 → 3 → 4 in real time (no early warning).
- Alert on staleness with a single PromQL expression like `time() - keeper_last_productive_ts{keeper="X"} > 1800` (no timestamp surface).

The Task-138 spec lists 4 metrics; this PR lands the 2 that are pure observability over the existing detector state.  The other 2 are scoped out (see "Out of scope").

## What

### Two new Prometheus gauges

| Metric | Labels | Semantics |
| --- | --- | --- |
| `masc_keeper_consecutive_idle` | `keeper` | Current passive-only streak.  Resets to 0 on the next execution/completion turn. |
| `masc_keeper_last_productive_ts` | `keeper` | Unix timestamp of the most recent productive turn. 0 until the keeper has produced anything in this process. |

Both are registered in `Prometheus.init_metrics` so `/metrics` shows a zero-value baseline before the first keeper turn.

### Wiring in `keeper_passive_loop_detector.ml`

- `keeper_state` record gains `mutable last_productive_ts : float` (in sync with the gauge).
- `update_streak_gauge` was a no-op stand-in per the v1 comment; now emits the gauge with `Prometheus.set_gauge`.
- New `update_last_productive_gauge` is called from `record_turn` on the execution/completion branch and from `reset` (to zero a recycled keeper slot — without that, an old timestamp would linger across keeper restarts and confuse `time() - ts` alerts).

## Out of scope (Task-138 P2)

- `masc_keeper_proactive_cadence{keeper}` (productive / total ratio) needs an absolute turn-count denominator that the detector does not currently track — would require a state-shape change.
- `masc_keeper_cadence_state{keeper}` enum gauge (`live|degraded|unresponsive`) requires the auto-degrade transition described in Task-138 §"Cadence Thresholds" (`max consecutive idle = 3 → Auto Degraded`); that is a behaviour change, not pure observability, and belongs in a separate PR.

## Risk

- 3 files, +65 -8.  No public API changes outside the new metric exports.
- Cardinality: both gauges labelled by `keeper` only — bounded by deployment keeper count (typically < 50).
- The detector's existing latch + counter behaviour is unchanged; gauges only mirror state that was already tracked internally.

## Validation

- [x] `dune build @check` passes (clean output, exit 0).
- [x] Race-check returns 0 matches for `consecutive_idle / last_productive / cadence_state / Task-138 cadence`.

## References

- Task-138 (Minimum Proactive Cadence Spec)
- #12799 (Passive loop detector — original infrastructure this PR extends)