### PR TITLE
feat(keeper): alive-but-stuck detector — Prometheus signal only (#12838)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -220,6 +220,35 @@ module KeeperSupervisor = struct
       permanently.  Default: 5. *)
   let liveness_recovery_max_attempts =
     max 1 (get_int ~default:5 "MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS")
+
+  (** Detection-only signal for alive-but-stuck keepers (#12838) —
+      keepers that are not Dead/Zombie and not paused, but whose
+      [proactive_rt.last_ts] has been frozen while autonomous turns
+      keep advancing.  Defaults to enabled because emission is a
+      Prometheus counter only (no board posts, no transitions). *)
+  let alive_but_stuck_enabled =
+    get_bool ~default:true "MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED"
+
+  (** Multiplier on the keeper's own [proactive.cooldown_sec] before a
+      stalled keeper is flagged.  Default: 10 (10 cooldowns elapsed
+      without a proactive turn). *)
+  let alive_but_stuck_stall_multiplier =
+    max 1 (get_int ~default:10 "MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER")
+
+  (** Hard floor (seconds) so keepers with very small cooldowns are not
+      flagged after a few minutes of legitimate quiet.  The detector
+      uses [max(stall_floor, multiplier * cooldown)].  Default:
+      1800 (30 min). *)
+  let alive_but_stuck_stall_floor_sec =
+    Float.max 60.0 (get_float ~default:1800.0
+                      "MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC")
+
+  (** Per-keeper dedup window (seconds): once a keeper is flagged the
+      counter is incremented at most once per window, even if the
+      sweep fires every 30s.  Default: 3600 (1 hr). *)
+  let alive_but_stuck_dedup_ttl_sec =
+    Float.max 60.0 (get_float ~default:3600.0
+                      "MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC")
 end
 
 (** {1 Keeper Poll Intervals}

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -73,6 +73,25 @@ module KeeperSupervisor : sig
   (** Maximum backoff delay cap for liveness recovery (seconds). *)
   val liveness_recovery_max_attempts : int
   (** Maximum total liveness recovery attempts per keeper. *)
+
+  val alive_but_stuck_enabled : bool
+  (** #12838 Detection-only scan for alive-but-stuck keepers
+      (proactive_rt.last_ts frozen while autonomous turns advance).
+      Default: true (counter only, no transitions). *)
+
+  val alive_but_stuck_stall_multiplier : int
+  (** Multiplier on the keeper's [proactive.cooldown_sec] before
+      stalling is flagged. Default: 10. *)
+
+  val alive_but_stuck_stall_floor_sec : float
+  (** Hard floor (seconds) for stall detection — guards against
+      keepers with very small cooldowns being flagged after a few
+      minutes of legitimate quiet. Default: 1800 (30 min). *)
+
+  val alive_but_stuck_dedup_ttl_sec : float
+  (** Per-keeper dedup window: counter increments at most once per
+      window per keeper even when the sweep fires every 30s.
+      Default: 3600 (1 hr). *)
 end
 
 (** {1 Stale-turn watchdog} *)

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -753,6 +753,19 @@ let start_supervisor_sweep ctx =
                ();
              Log.Keeper.error "liveness recovery scan failed: %s"
                (Printexc.to_string exn));
+          (* #12838 Alive-but-stuck detector: emit a Prometheus counter
+             (and a warn log) for keepers that are alive in every other
+             health metric but have a frozen [proactive_rt.last_ts] while
+             autonomous turns keep advancing.  Detection-only — no
+             transition or restart is triggered. *)
+          (try Keeper_supervisor.alive_but_stuck_scan ctx
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_supervisor_sweep_failures
+               ~labels:[("origin", "alive_but_stuck")]
+               ();
+             Log.Keeper.error "alive-but-stuck scan failed: %s"
+               (Printexc.to_string exn));
           (* TOML hot-reload: re-sync declarative fields for running keepers.
              Runs after sweep_and_recover so TOML edits take effect within
              one sweep cycle (~30s) without server restart. *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1471,3 +1471,117 @@ let liveness_recovery_scan (ctx : _ context) =
       end
     ) entries
   end
+
+(* ──────────────────────────────────────────────────────────────────
+   #12838 Alive-but-stuck detector
+
+   Liveness Recovery Supervisor (#12801, [liveness_recovery_scan]
+   above) handles keepers in terminal phases (Dead, with carve-outs
+   for credential_archived and zombie_timeout_reached).  It does not
+   handle a separate failure mode observed in production on
+   2026-05-04: keepers that are alive in every metric the supervisor
+   checks but have a flat [proactive_rt.last_ts] for days because
+   their [current_task_id] references an orphaned [AwaitingVerification]
+   task.
+
+   This detector emits a Prometheus counter only.  No transition,
+   no restart, no board post.  Operator visibility first; action
+   is a follow-up (see issue #12838 "Proposed first PR").
+   ────────────────────────────────────────────────────────────────── *)
+
+(** Pure detection: is this keeper alive-but-stuck at [now]?
+
+    Returns [Some elapsed_sec] (the gap since the keeper's reference
+    timestamp) when the keeper is non-Dead, non-paused, has done at
+    least one autonomous turn, and has gone longer than
+    [max(stall_floor_sec, stall_multiplier * cooldown_sec)] without a
+    proactive turn.
+
+    Reference timestamp: [proactive_rt.last_ts] if that has ever
+    fired ([> 0.0]), otherwise [entry.started_at] — this catches the
+    "never_started" case (e.g. [glm-coding-plan] in the production
+    sample) without a separate code path.
+
+    Returns [None] when not stuck.  Pure: no I/O, no global state. *)
+let detect_alive_but_stuck ~now ~stall_multiplier ~stall_floor_sec
+    (entry : Keeper_registry.registry_entry) : float option =
+  let meta = entry.meta in
+  if meta.paused then None
+  else if entry.phase = Keeper_state_machine.Dead then None
+  else if meta.runtime.autonomous_turn_count <= 0 then
+    (* Brand-new keeper: not stuck, just hasn't started. *)
+    None
+  else
+    let cooldown_sec = float_of_int meta.proactive.cooldown_sec in
+    let stall_threshold =
+      Float.max stall_floor_sec
+        (cooldown_sec *. float_of_int stall_multiplier)
+    in
+    let last_proactive_ts = meta.runtime.proactive_rt.last_ts in
+    let reference_ts =
+      if last_proactive_ts > 0.0 then last_proactive_ts
+      else entry.started_at
+    in
+    let elapsed = now -. reference_ts in
+    if elapsed > stall_threshold then Some elapsed else None
+
+(* Per-keeper dedup table for [alive_but_stuck_scan].  Bounds counter
+   emission to one increment per [alive_but_stuck_dedup_ttl_sec] per
+   keeper, even when the sweep fires every 30s.  Mirrors the
+   [liveness_recovery_table] pattern above. *)
+let alive_but_stuck_last_alert : (string, float) Hashtbl.t =
+  Hashtbl.create 16
+
+let alive_but_stuck_last_alert_mu = Eio.Mutex.create ()
+
+let alive_but_stuck_should_emit ~now ~dedup_ttl_sec name =
+  Eio.Mutex.use_rw ~protect:false alive_but_stuck_last_alert_mu (fun () ->
+    match Hashtbl.find_opt alive_but_stuck_last_alert name with
+    | Some last_ts when now -. last_ts < dedup_ttl_sec -> false
+    | _ ->
+      Hashtbl.replace alive_but_stuck_last_alert name now;
+      true)
+
+(** Test-only: clear the dedup table so each test case starts fresh. *)
+let alive_but_stuck_reset_for_test () =
+  Eio.Mutex.use_rw ~protect:false alive_but_stuck_last_alert_mu (fun () ->
+    Hashtbl.clear alive_but_stuck_last_alert)
+
+let alive_but_stuck_scan (ctx : _ context) =
+  if not Env_config.KeeperSupervisor.alive_but_stuck_enabled then ()
+  else begin
+    let now = Time_compat.now () in
+    let stall_multiplier =
+      Env_config.KeeperSupervisor.alive_but_stuck_stall_multiplier
+    in
+    let stall_floor_sec =
+      Env_config.KeeperSupervisor.alive_but_stuck_stall_floor_sec
+    in
+    let dedup_ttl_sec =
+      Env_config.KeeperSupervisor.alive_but_stuck_dedup_ttl_sec
+    in
+    let base_path = ctx.config.base_path in
+    let entries = Keeper_registry.all ~base_path () in
+    List.iter (fun (entry : Keeper_registry.registry_entry) ->
+      match
+        detect_alive_but_stuck ~now ~stall_multiplier ~stall_floor_sec entry
+      with
+      | None -> ()
+      | Some elapsed ->
+        if alive_but_stuck_should_emit ~now ~dedup_ttl_sec entry.name then begin
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_alive_but_stuck
+            ~labels:[("keeper", entry.name)]
+            ();
+          Log.Keeper.warn
+            "%s: alive-but-stuck detected (elapsed=%.0fs, threshold=%.0fs, \
+             autonomous_turns=%d, proactive_count_total=%d)"
+            entry.name elapsed
+            (Float.max stall_floor_sec
+               (float_of_int entry.meta.proactive.cooldown_sec
+                *. float_of_int stall_multiplier))
+            entry.meta.runtime.autonomous_turn_count
+            entry.meta.runtime.proactive_rt.count_total
+        end
+    ) entries
+  end

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -90,3 +90,31 @@ val should_attempt_liveness_recovery :
   now:float -> Keeper_registry.registry_entry -> bool
 (** Pure predicate: true when a Dead keeper passes the eligibility gate for
     a liveness recovery attempt.  Exposed for tests. *)
+
+(** {1 Alive-but-stuck detector (#12838)} *)
+
+val detect_alive_but_stuck :
+  now:float ->
+  stall_multiplier:int ->
+  stall_floor_sec:float ->
+  Keeper_registry.registry_entry ->
+  float option
+(** Pure detection: returns [Some elapsed_sec] when a non-Dead, non-paused
+    keeper has gone longer than
+    [max(stall_floor_sec, stall_multiplier * proactive.cooldown_sec)]
+    without a proactive turn while autonomous turns kept advancing.
+    Reference timestamp is [proactive_rt.last_ts] if set, else
+    [entry.started_at] (covers the never-started case).  Returns [None]
+    otherwise.  Exposed for tests. *)
+
+val alive_but_stuck_scan : 'a context -> unit
+(** Scan all keepers in [Keeper_registry].  For each keeper detected as
+    alive-but-stuck, emit one [metric_keeper_alive_but_stuck] counter
+    increment and a single warn log line, with per-keeper dedup so the
+    counter is at most incremented once per
+    [alive_but_stuck_dedup_ttl_sec] window.  Detection-only — no
+    transition or restart is triggered.  Gated behind
+    [MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED] (default: true). *)
+
+val alive_but_stuck_reset_for_test : unit -> unit
+(** Test-only: clear the alive-but-stuck dedup table. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -238,6 +238,16 @@ let metric_keeper_usage_anomalies =
 let metric_keeper_contract_violations =
   "masc_keeper_contract_violations_total"
 
+(** #12838: keepers detected as alive-but-stuck — non-Dead, non-paused,
+    keepalive_running, but [proactive_rt.last_ts] has been frozen while
+    autonomous turns kept advancing.  Detection-only signal: no transition
+    or restart is triggered.  Per-keeper dedup window
+    ([alive_but_stuck_dedup_ttl_sec]) bounds emission rate so a single
+    stuck keeper does not flood the counter on every 30s sweep.
+    Labels: keeper. *)
+let metric_keeper_alive_but_stuck =
+  "masc_keeper_alive_but_stuck_total"
+
 (* #10047: [append_metrics_snapshot] failures in [keeper_turn.ml] and
    [keeper_unified_turn.ml] used to be log-only, masking state/metric
    divergence. Surface as a counter so dashboards can alert on silent

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -79,6 +79,11 @@ val metric_keeper_usage_anomalies : string
     Labels: keeper_name, kind \in \{passive,text_only\}. *)
 val metric_keeper_contract_violations : string
 
+(** #12838: keepers detected as alive-but-stuck.  Detection-only
+    counter; bounded to one increment per dedup window per keeper.
+    Labels: keeper. *)
+val metric_keeper_alive_but_stuck : string
+
 val metric_keeper_metric_emit_dropped : string
 val metric_keeper_context_max_observed : string
 (** #9953: bucketed counter for observed [context_max] values.

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1246,4 +1246,145 @@ let () =
              let result = Sup.should_attempt_liveness_recovery ~now:99999.0 entry in
              check bool "credential_archived → false" false result));
     ];
+    (* #12838 — alive-but-stuck detector. Pure function tests; dedup
+       state lives in [Sup.alive_but_stuck_*] and is not exercised here. *)
+    "alive_but_stuck", (
+      let make_test_entry ~name ~paused ~phase ~autonomous_turn_count
+          ~last_proactive_ts ~cooldown_sec ~started_at =
+        Reg.clear ();
+        let _reg = Reg.register ~base_path:bp name (make_meta name) in
+        let entry = match Reg.get ~base_path:bp name with
+          | Some e -> e
+          | None -> fail "register/get sync failure"
+        in
+        let meta = entry.meta in
+        let meta' = {
+          meta with
+          paused;
+          proactive = { meta.proactive with cooldown_sec };
+          runtime = {
+            meta.runtime with
+            autonomous_turn_count;
+            proactive_rt = {
+              meta.runtime.proactive_rt with
+              last_ts = last_proactive_ts;
+            };
+          };
+        } in
+        { entry with meta = meta'; phase; started_at }
+      in
+      let detect entry =
+        Sup.detect_alive_but_stuck
+          ~now:100_000.0
+          ~stall_multiplier:10
+          ~stall_floor_sec:1800.0
+          entry
+      in
+      [
+        test_case "paused keeper → None" `Quick (fun () ->
+          let entry = make_test_entry
+              ~name:"abs-paused"
+              ~paused:true
+              ~phase:KSM.Running
+              ~autonomous_turn_count:50
+              ~last_proactive_ts:0.0
+              ~cooldown_sec:60
+              ~started_at:0.0
+          in
+          check (option (float 0.1)) "paused → None" None (detect entry));
+        test_case "Dead phase → None (handled by liveness_recovery_scan)" `Quick
+          (fun () ->
+            let entry = make_test_entry
+                ~name:"abs-dead"
+                ~paused:false
+                ~phase:KSM.Dead
+                ~autonomous_turn_count:50
+                ~last_proactive_ts:0.0
+                ~cooldown_sec:60
+                ~started_at:0.0
+            in
+            check (option (float 0.1)) "Dead → None" None (detect entry));
+        test_case "brand-new keeper (autonomous_turn_count=0) → None" `Quick
+          (fun () ->
+            let entry = make_test_entry
+                ~name:"abs-new"
+                ~paused:false
+                ~phase:KSM.Running
+                ~autonomous_turn_count:0
+                ~last_proactive_ts:0.0
+                ~cooldown_sec:60
+                ~started_at:0.0
+            in
+            check (option (float 0.1)) "new → None" None (detect entry));
+        test_case "recent proactive turn → None" `Quick (fun () ->
+          let entry = make_test_entry
+              ~name:"abs-active"
+              ~paused:false
+              ~phase:KSM.Running
+              ~autonomous_turn_count:50
+              ~last_proactive_ts:99_500.0  (* 500s ago, within threshold *)
+              ~cooldown_sec:60
+              ~started_at:0.0
+          in
+          check (option (float 0.1)) "recent → None" None (detect entry));
+        test_case "stalled proactive_ts + autonomous advanced → Some" `Quick
+          (fun () ->
+            let entry = make_test_entry
+                ~name:"abs-stalled"
+                ~paused:false
+                ~phase:KSM.Running
+                ~autonomous_turn_count:50
+                ~last_proactive_ts:1_000.0  (* 99000s ago *)
+                ~cooldown_sec:60            (* threshold = max(1800, 600) = 1800 *)
+                ~started_at:0.0
+            in
+            match detect entry with
+            | None -> fail "expected stalled keeper to be detected"
+            | Some elapsed ->
+              check (float 1.0) "elapsed ≈ 99000s" 99_000.0 elapsed);
+        test_case "never_started + autonomous + old started_at → Some" `Quick
+          (fun () ->
+            (* Mirrors production case: glm-coding-plan with
+               proactive.last_outcome=never_started but autonomous_turn_count>0. *)
+            let entry = make_test_entry
+                ~name:"abs-never-started"
+                ~paused:false
+                ~phase:KSM.Running
+                ~autonomous_turn_count:14
+                ~last_proactive_ts:0.0       (* never started *)
+                ~cooldown_sec:60
+                ~started_at:1_000.0          (* started 99000s ago *)
+            in
+            match detect entry with
+            | None -> fail "expected never-started keeper to be detected"
+            | Some elapsed ->
+              check (float 1.0) "elapsed ≈ 99000s" 99_000.0 elapsed);
+        test_case "never_started + autonomous + recent started_at → None" `Quick
+          (fun () ->
+            let entry = make_test_entry
+                ~name:"abs-just-launched"
+                ~paused:false
+                ~phase:KSM.Running
+                ~autonomous_turn_count:1
+                ~last_proactive_ts:0.0
+                ~cooldown_sec:60
+                ~started_at:99_500.0  (* started 500s ago — under floor *)
+            in
+            check (option (float 0.1)) "just-launched → None"
+              None (detect entry));
+        test_case "high cooldown raises threshold above floor" `Quick (fun () ->
+          (* cooldown 600 * multiplier 10 = 6000s > floor 1800s, so a
+             5500s-old proactive ts is NOT stuck under this keeper's policy. *)
+          let entry = make_test_entry
+              ~name:"abs-high-cooldown"
+              ~paused:false
+              ~phase:KSM.Running
+              ~autonomous_turn_count:50
+              ~last_proactive_ts:94_500.0  (* 5500s ago *)
+              ~cooldown_sec:600            (* threshold = max(1800,6000) = 6000 *)
+              ~started_at:0.0
+          in
+          check (option (float 0.1)) "below per-keeper threshold → None"
+            None (detect entry));
+      ]);
   ]


### PR DESCRIPTION
## Summary

Closes #12838 first PR ("Proposed first PR (detection only, no auto-action)").

Adds a Prometheus counter for keepers that are alive in every metric the existing supervisor checks but have a frozen `proactive_rt.last_ts` while autonomous turns keep advancing. Detection-only — no transition, no restart, no board post.

## Why

Liveness Recovery Supervisor (#12801, `liveness_recovery_scan`) handles **terminal** phases (`Dead`, with `Zombie` excluded). It does not handle the failure mode observed in production on 2026-05-04: keepers that are not Dead but are stuck because `current_task_id` referenced an orphaned `AwaitingVerification` task.

PR #12822 fixed the underlying verification transition gap and the production keepers self-recovered. This detector is the operator-visibility layer for the same class of failure: if a future bug parks a keeper's `current_task_id` on something that never resolves, the counter surfaces it instead of leaving the keeper silent.

## Detection

Pure function `Keeper_supervisor.detect_alive_but_stuck`. Returns `Some elapsed_sec` when ALL hold:

- `meta.paused = false`
- `entry.phase <> Dead`        (Dead is handled by `liveness_recovery_scan`)
- `meta.runtime.autonomous_turn_count > 0`  (excludes brand-new keepers)
- `now - reference_ts > max(stall_floor_sec, multiplier * cooldown_sec)`
  - `reference_ts = proactive_rt.last_ts` if non-zero, else `entry.started_at` (catches the `never_started` case observed for `glm-coding-plan` in the production sample)

Defaults: multiplier=10, floor=1800s (30 min), dedup window=3600s (1 hr). All four knobs exposed as `MASC_KEEPER_ALIVE_BUT_STUCK_*`.

## Action (intentionally minimal)

- Emits `masc_keeper_alive_but_stuck_total{keeper=...}` counter.
- Emits one warn log line per detection.
- Per-keeper dedup: counter incremented at most once per `alive_but_stuck_dedup_ttl_sec` window even when the sweep fires every 30s. Mirrors the `liveness_recovery_table` pattern.
- **No board post** — intentional; avoids the same kind of feedback loop that PR #12822 just stopped.
- **No transition or restart** — those are explicit follow-up territory.

## Files

| Path | Purpose |
|---|---|
| `lib/config/env_config_keeper.{ml,mli}` | 4 env knobs (`MASC_KEEPER_ALIVE_BUT_STUCK_*`) |
| `lib/prometheus.{ml,mli}` | counter declaration |
| `lib/keeper/keeper_supervisor.{ml,mli}` | pure `detect_alive_but_stuck`, dedup table, impure `alive_but_stuck_scan` |
| `lib/keeper/keeper_runtime.ml` | wire scan into the existing sweep loop alongside `liveness_recovery_scan` (same exception-handling envelope) |
| `test/test_keeper_supervisor.ml` | 8 truth-table cases |

## Test plan

- [x] `dune build @check` clean.
- [x] `test_keeper_supervisor` `alive_but_stuck` suite: 8/8 pass.
  - paused → None
  - Dead phase → None
  - brand-new (autonomous_turn_count=0) → None
  - recent proactive turn → None
  - stalled proactive_ts + autonomous advanced → Some elapsed
  - never_started + autonomous + old started_at → Some elapsed (mirrors `glm-coding-plan` production sample)
  - never_started + autonomous + recent started_at → None
  - high cooldown raises threshold above floor → None
- [ ] CI Build and Test (covers full suite incl. `liveness_recovery` sibling, regression check).

## Self-review

- Goal: surface alive-but-stuck failure mode that the existing Dead-phase Liveness Recovery Supervisor misses.
- Files changed: 8 (5 lib/, 1 test/, 1 mli sibling, no production data).
- Local verification: full `@check` clean; new suite 8/8.
- Race-checked `gh pr list` for `alive_but_stuck`, `detect_alive_but_stuck`, `#12838` immediately before commit and before push: 0 matches.
- Impact: detection-only counter; no behavior change for existing keepers if `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` defaults to `true`. Operator can flip to `false` without code change if false-positive rate is too high during initial rollout.

## Follow-up (out of scope)

- Action layer: once the counter shows whether detection is accurate in production, decide between (a) auto-cancel the orphan task via `force_cancel_task_r`, (b) transition keeper through Dead so existing supervisor handles, or (c) operator-driven recovery only. Each requires its own RFC-level decision.
- Expand the detector to other "alive but stalled" patterns (compaction loops, board-reactive-only loops, etc.) — separate signals, separate counters.
