### PR TITLE
fix(dashboard/a11y): drop stale hex fallbacks in skip-link

### DIFF
--- a/dashboard/src/styles/a11y.css
+++ b/dashboard/src/styles/a11y.css
@@ -60,8 +60,8 @@
   clip: auto;
   white-space: normal;
   border-width: 1px;
-  background: var(--color-bg-page, #0a0f1a);
-  color: var(--color-fg-primary, #e2e8f0);
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
   border-color: var(--accent-45, rgb(var(--brass-glow) / .45));
   border-radius: 6px;
   font-size: var(--fs-14);


### PR DESCRIPTION
## Summary

`dashboard/src/styles/a11y.css` `.skip-link` rule used `var(--color-bg-page, #0a0f1a)` and `var(--color-fg-primary, #e2e8f0)`. The fallback hex values are leftovers from a prior cool-slate palette and no longer match the current warm-brass canon. Both tokens are defined in `tokens.generated.css` (lines 273, 278) and `variables.css` (lines 400, 406), so the fallbacks are dead code — they only fire if the token cascade itself is broken, in which case rendering a cool-slate skip-link on a warm-bg page is a worse outcome than letting the cascade error surface.

This is a 2-line change: drop the literal hex fallbacks; the token cascade is now the single source of truth.

## Why this is the right kind of dead-code fix

- **No call site depends on the literal**: `rg "#0a0f1a"` over `dashboard/src` returns 0 hits. `rg "#e2e8f0"` returns hits only in unrelated `--color-frost-100` definitions (different semantic role, not a fallback chain).
- **Visible regression possibility goes down**: with the fallback present, a cascade misconfiguration draws skip-link as cool slate. Without the fallback, the same misconfiguration draws skip-link as `currentColor` — which inherits the page palette and stays visually consistent.
- **Token cascade SSOT is the documented architecture**: `dashboard/CSS-ARCHITECTURE.md` describes `tokens.generated.css → variables.css → consumer` as the canonical chain. The `var(token, hex)` form short-circuits that chain.

## Test plan

- [x] `rg "var\(--[a-z0-9-]+,\s*#[0-9a-fA-F]{3,6}\b" dashboard/src/styles` — 0 remaining occurrences after this change.
- [x] `rg "#0a0f1a|#e2e8f0" dashboard/src` — only unrelated `--color-frost-100` hits remain.
- [ ] CI Build and Test (existing `dashboard/src/styles/cockpit-token-cascade.test.ts` will exercise the cascade).

## Self-review

- Goal: remove the only remaining `var(token, hex)` stale-fallback pattern in `dashboard/src/styles/`. The two occurrences in `a11y.css` were identified by a project-wide scan as the only matches.
- Scope: 2 lines changed in 1 file.
- Race-checked `gh pr list` for `a11y.css`, `skip-link`, `stale fallback` immediately before push: 0 conflicting PRs.
- Risk: low. The `.skip-link` rule only renders on keyboard focus of the WCAG 2.4.1 skip nav.
