### PR TITLE
fix(keeper): set last_blocker_class on Semaphore_wait_timeout skip path

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -708,8 +708,12 @@ let run_keepalive_unified_turn
         | Error (`Semaphore_wait_timeout wait_sec) ->
           (* Peers held the turn semaphore longer than the wait cap — not a
              keeper failure. Skip this cycle and let the next heartbeat retry
-             once a slot opens up. Meta is left untouched so failure counters
-             do not tick. *)
+             once a slot opens up. Failure counters intentionally NOT ticked
+             (this is starvation, not crash); but [last_blocker_class] IS
+             updated so the dashboard surfaces the stuck reason — without it
+             the keeper appears as [outcome=never_started, blocker_class=null]
+             and operators see "alive but invisible" (2026-05-05 fleet stuck
+             diagnosis evidence). *)
           record_semaphore_wait_observation
             ~base_path:ctx.config.base_path
             ~keeper_name:meta_after_triage.name
@@ -717,15 +721,26 @@ let run_keepalive_unified_turn
             ~kind:Semaphore_wait_timeout;
           let auto_avail = Eio.Semaphore.get_value Keeper_turn_slot.autonomous_turn_semaphore in
           let turn_avail = Eio.Semaphore.get_value Keeper_turn_slot.turn_semaphore in
+          let blocker_text =
+            Printf.sprintf
+              "skipped: semaphore wait > %.0fs, peers holding slot \
+               (cascade=%s, autonomous_available=%d turn_available=%d)"
+              wait_sec meta_after_triage.cascade_name auto_avail turn_avail
+          in
           Log.Keeper.warn
-            "%s: skipping turn (semaphore wait > %.0fs, peers holding slot, cascade=%s, autonomous_available=%d turn_available=%d)"
-            meta_after_triage.name wait_sec meta_after_triage.cascade_name
-            auto_avail turn_avail;
+            "%s: skipping turn (%s)"
+            meta_after_triage.name blocker_text;
           Prometheus.inc_counter
             Prometheus.metric_keeper_semaphore_wait_timeout
             ~labels:[("keeper", meta_after_triage.name); ("channel", (Keeper_world_observation.channel_to_string turn_decision.channel))]
             ();
-          meta_after_triage)
+          Keeper_types.map_runtime
+            (fun rt ->
+              { rt with
+                last_blocker = blocker_text;
+                last_blocker_class = Some Keeper_types.Autonomous_slot_wait_timeout;
+              })
+            meta_after_triage)
       else if (not has_message_signal) && obs.message_cursor_updates <> [] then
         meta_after_observe
       else


### PR DESCRIPTION
## Why — fleet-stuck root cause

Diagnosed 2026-05-05 fleet-wide investigation: 9 of 14 keepers reported `outcome=never_started, last_blocker_class=null` in their meta after ~1.5h of inactivity, even though the live system log contained:

```
{name}: skipping turn (semaphore wait > 60s, peers holding slot,
 cascade=big_three, autonomous_available=6 turn_available=12)
```

The `Semaphore_wait_timeout` error branch in `keeper_heartbeat_loop.ml run_one_cycle` deliberately leaves failure counters untouched (the keeper is not crashing — it is voluntarily yielding to peers and will retry on the next heartbeat).  But it was also leaving `last_blocker` / `last_blocker_class` untouched, so the dashboard reported affected keepers as "alive, no recorded reason".

User report (verbatim 2026-05-05):
> *"FSM 도 동작을 안해요. 정지 상태고 어디에서도 이유를 안 알려줍니다."*

## What

On the `Semaphore_wait_timeout` branch:

```diff
+ let blocker_text =
+   Printf.sprintf
+     "skipped: semaphore wait > %.0fs, peers holding slot \
+      (cascade=%s, autonomous_available=%d turn_available=%d)"
+     wait_sec meta.cascade_name auto_avail turn_avail
+ in
  Log.Keeper.warn "%s: skipping turn (%s)" meta.name blocker_text;
  Prometheus.inc_counter ... ;
+ Keeper_types.map_runtime
+   (fun rt -> { rt with
+     last_blocker = blocker_text;
+     last_blocker_class = Some Autonomous_slot_wait_timeout })
+   meta_after_triage
```

The `Autonomous_slot_wait_timeout` variant already exists in `Keeper_types.blocker_class` (line 162) and is exactly the right semantic — keeper waited > N seconds for a slot and gave up this cycle.

The new `last_blocker` text mirrors the WARN log so operators see the same explanation in the dashboard meta as in the log stream — no divergence to debug.

## Risk

- 1 file, +21 -6 lines.  Single hot path.
- Failure-counter behaviour intentionally **unchanged** (this is starvation, not crash) — only the typed observability fields are now populated.
- No public API change.  Race-check returned 0 matches.

## Out of scope (follow-up PRs)

- `keeper_turn_slot.ml:372` (autonomous fairness queue) and `keeper_unified_turn.ml:321` (ollama saturation) follow different caller patterns (no `meta` on the call frame; they go through `record_pre_dispatch_terminal_observation`).  Each needs its own targeted fix.
- bug A (single-provider cascade `glm_coding_plan_only` → 600s timeout w/ no fallback) — config + cascade rotation behaviour change.
- bug B (`big_three` semaphore deadlock — peer holder identification + force release) — concurrency change, separate analysis.

## Validation

- [x] `dune build @check` passes (clean output).
- [x] Race-check 0 matches for `Semaphore_wait_timeout / last_blocker_class / blocker silent`.

## References

- 2026-05-05 fleet-stuck diagnosis (analyst.json/executor.json silent state + live log seq 76134-76135)
- `lib/keeper/keeper_types.mli:162` (Autonomous_slot_wait_timeout variant)
- `lib/keeper/keeper_supervisor.ml:920-924` (existing typed-blocker pattern this PR follows)