### PR TITLE
test(keeper): drop shared_memory_scope from canonical seed drift gate

### DIFF
--- a/test/test_keeper_meta_canonical_seed.ml
+++ b/test/test_keeper_meta_canonical_seed.ml
@@ -13,10 +13,12 @@
 
 open Masc_mcp
 
+(* [shared_memory_scope] removed in commit e3f4d82c60 ("refactor: remove
+   shared_memory_scope and all related logic"). Drop from the drift gate so
+   it does not pin a key the JSON serialisation no longer emits. *)
 let target_keys =
   [ "sandbox_profile"
   ; "network_mode"
-  ; "shared_memory_scope"
   ; "tool_preset_source"
   ; "max_checkpoint_messages"
   ; "always_approve"


### PR DESCRIPTION
## Summary

`test/test_keeper_meta_canonical_seed.ml::target_keys` pinned `shared_memory_scope` as a key that must appear in `Keeper_meta_json.canonical_keeper_meta_key_names`. That field was removed from the JSON serialisation in commit `e3f4d82c60` (\"refactor: remove shared_memory_scope and all related logic\"). The test has been red on \`main\` since.

Drop the stale entry. Other entries (`sandbox_profile`, `network_mode`, `tool_preset_source`, `max_checkpoint_messages`, `always_approve`, `keeper_id`, `meta_version`) verified present.

## Test

- Before: 1 failure / 2 tests run (`FAIL canonical_keeper_meta_key_names contains shared_memory_scope`).
- After: 2/2 pass.

## Out of scope

The TOML-side `shared_memory_scope` plumbing in `keeper_types_profile.ml` (lines 115-1368) was NOT touched by `e3f4d82c60` and stays intact. No production code change in this PR.

## Test plan

- [x] `dune test test/test_keeper_meta_canonical_seed.exe --force` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)