### PR TITLE
fix(dashboard): tokenize remaining inline-SVG strokes (handoff arc + sparkline gridlines)

### DIFF
--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -335,7 +335,7 @@ export function HandoffTimeline({
                         <line
                           x1=${`${a.xPct}%`} y1=${rowCenterY(a.fromIdx)}
                           x2=${`${a.xPct}%`} y2=${rowCenterY(a.toIdx)}
-                          stroke="rgb(251 146 60)" stroke-width="1.5"
+                          stroke="var(--amber-bright)" stroke-width="1.5"
                           stroke-dasharray="3,3" opacity="0.8"
                         ><title>${`${a.fromAgent} → ${a.toAgent} · ${new Date(a.ts).toLocaleTimeString()}`}</title></line>
                       `)}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -548,8 +548,8 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
   return html`
     <${DetailCard} class="flex items-center gap-3 mb-5">
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)]" role="img" aria-label="컨텍스트 비율 스파크라인" style="background:var(--bg-deepest);">
-        <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
-        <line x1="${pad}" y1="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
+        <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="var(--color-line-3)" stroke-dasharray="3,3" stroke-width="0.5"/>
+        <line x1="${pad}" y1="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="var(--color-line-3)" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - (CTX_CRITICAL_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_CRITICAL_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="${CTX_COLOR_WARN}" stroke-dasharray="3,3" stroke-width="0.5"/>
         ${pts.filter(({ p }) => p.is_handoff).map(({ x }) => html`
           <line x1="${x.toFixed(1)}" y1="${pad}" x2="${x.toFixed(1)}" y2="${H - pad}" stroke="var(--color-status-err)" stroke-width="1.5" opacity="0.7"/>


### PR DESCRIPTION
## Summary

Two adjacent inline-SVG sites in `dashboard/src/components` were drawing strokes with literal hex/rgb attributes, bypassing the token cascade. This PR routes both through the existing dashboard tokens.

After this PR, `rg 'stroke="(rgb|#)|fill="(rgb|#)' dashboard/src/components` returns 0 matches.

## Changes

| File | Before | After | Rationale |
|---|---|---|---|
| `handoff-timeline.ts:338` | `stroke="rgb(251 146 60)"` (Tailwind orange-400) | `stroke="var(--amber-bright)"` (#f59e0b) | Aligns with the same lit-html SVG idiom in `keeper-detail-panels.ts:713` ("totalLine"). Hue shifts ~14° toward yellow; both tones are bright accents on the warm-brass canvas, so the visual role ("in-flight crossover") is preserved. |
| `keeper-detail-panels.ts:551,552` | `stroke="#444"` (cool neutral gray) | `stroke="var(--color-line-3)"` (#4a4137) | Reference gridlines should follow the dashboard's warm-brass line palette rather than introducing a one-off cool gray. `--color-line-3` is the lightest of three line tokens — appropriate for low-emphasis horizontals on a dark surface. |

## Why this is a small PR

- 3 lines changed across 2 files. No behavioral change; pure presentation token migration.
- Both replacements use existing tokens (no new token introduced).
- The `var()` form in SVG presentation attributes is already established in this same codebase (`keeper-detail-panels.ts` lines 555, 633, 634, 713, 1017, 1030, 1043, 1107, 1109, etc.) — modern browsers (Chrome 80+, Firefox 79+, Safari 14+) resolve CSS custom properties in SVG presentation attributes natively.

## Test plan

- [x] `rg 'stroke="(rgb|#)|fill="(rgb|#)' dashboard/src/components` → 0 matches after this change.
- [x] No new tokens introduced; both `--amber-bright` and `--color-line-3` are defined in `tokens.generated.css` and `variables.css`.
- [x] Race-checked `gh pr list` for `handoff-timeline`, `amber-bright`, `keeper-detail-panels`, `sparkline gridline` immediately before push: only #12811 (broader design polish PR) matched, but it touches 100 different files and **does not overlap** with these two paths (verified via `gh pr view 12811 --json files`).
- [ ] CI Build and Test (existing dashboard test suite covers cascade integrity via `cockpit-token-cascade.test.ts`).

## Self-review

- Goal: complete the inline-SVG color token migration started in PR #12853 (a11y skip-link) for the remaining matches in `dashboard/src/components`.
- 2 commits, intentionally split per file so reviewers can ack each tokenization independently.
- The first commit's body originally claimed "zero remaining hardcoded SVG stroke/fill colors" — that was a self-check failure caught and corrected by the second commit. Per the project's no-amend rule, the correction is a follow-up commit rather than a rewrite.

## Sequence in the design-system polish stream

- PR #12853 (a11y skip-link stale fallbacks) — merged-pending.
- This PR (handoff arc + sparkline gridlines) — Draft.
- Follow-up cycle (next): scan `paper-theme.css` consumers to see whether any code path still imports the cool-slate fallback shapes; if not, the warm-brass canon is fully unified.
