### PR TITLE
test(keeper): unit tests for keeper_compact_policy pure helpers

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -93,6 +93,7 @@
         test_keeper_supervisor
         test_keeper_alerting_path
         test_coord_eio_pure
+        test_keeper_compact_policy_pure
         test_keeper_allowed_paths
         test_keeper_repo_readiness
         test_keeper_tool_surface_guard
@@ -292,6 +293,7 @@
           test_keeper_supervisor
           test_keeper_alerting_path
           test_coord_eio_pure
+          test_keeper_compact_policy_pure
           test_keeper_allowed_paths
           test_keeper_repo_readiness
           test_keeper_tool_surface_guard

--- a/test/test_keeper_compact_policy_pure.ml
+++ b/test/test_keeper_compact_policy_pure.ml
@@ -1,0 +1,115 @@
+(** Pure-function unit tests for [Keeper_compact_policy].
+
+    Covers the deterministic ADT mappers that don't require a
+    [keeper_meta] / [working_context] fixture. *)
+
+open Masc_mcp
+module KCP = Keeper_compact_policy
+
+let check_string label expected actual =
+  Alcotest.(check string) label expected actual
+
+let check_bool label expected actual =
+  Alcotest.(check bool) label expected actual
+
+(* ── compaction_decision_to_string ───────────────────────────────────── *)
+
+let test_to_string_applied () =
+  check_string "Applied carries reason"
+    "applied:tool_heavy"
+    (KCP.compaction_decision_to_string (KCP.Applied "tool_heavy"))
+
+let test_to_string_blocked () =
+  check_string "Blocked_below_thresholds"
+    "blocked:below_thresholds"
+    (KCP.compaction_decision_to_string KCP.Blocked_below_thresholds)
+
+let test_to_string_skipped_no_checkpoint () =
+  check_string "Skipped_no_checkpoint"
+    "skipped:no_checkpoint"
+    (KCP.compaction_decision_to_string KCP.Skipped_no_checkpoint)
+
+let test_to_string_skipped_continuity () =
+  check_string "Skipped_continuity_reflection includes hold/cooldown"
+    "skipped:continuity_reflection(45s<60s)"
+    (KCP.compaction_decision_to_string
+       (KCP.Skipped_continuity_reflection { hold_s = 45.0; cooldown_sec = 60 }))
+
+let test_to_string_skipped_continuity_zero () =
+  check_string "Skipped_continuity_reflection at boundaries"
+    "skipped:continuity_reflection(0s<0s)"
+    (KCP.compaction_decision_to_string
+       (KCP.Skipped_continuity_reflection { hold_s = 0.0; cooldown_sec = 0 }))
+
+(* ── compaction_decision_applied ─────────────────────────────────────── *)
+
+let test_applied_true_for_applied () =
+  check_bool "Applied → true" true
+    (KCP.compaction_decision_applied (KCP.Applied "anything"))
+
+let test_applied_false_for_blocked () =
+  check_bool "Blocked_below_thresholds → false" false
+    (KCP.compaction_decision_applied KCP.Blocked_below_thresholds)
+
+let test_applied_false_for_skipped_no_checkpoint () =
+  check_bool "Skipped_no_checkpoint → false" false
+    (KCP.compaction_decision_applied KCP.Skipped_no_checkpoint)
+
+let test_applied_false_for_skipped_continuity () =
+  check_bool "Skipped_continuity_reflection → false" false
+    (KCP.compaction_decision_applied
+       (KCP.Skipped_continuity_reflection { hold_s = 1.0; cooldown_sec = 1 }))
+
+(* ── threshold constants ─────────────────────────────────────────────── *)
+
+let test_emergency_threshold_in_range () =
+  let v = KCP.emergency_compact_ratio_threshold in
+  Alcotest.(check bool) "emergency threshold is a meaningful ratio (0,1]"
+    true (v > 0.0 && v <= 1.0)
+
+let test_tool_heavy_threshold_positive () =
+  Alcotest.(check bool)
+    "tool_heavy_msg_threshold > 0" true (KCP.tool_heavy_msg_threshold > 0)
+
+let test_tool_heavy_floor_in_range () =
+  let v = KCP.tool_heavy_ratio_floor in
+  Alcotest.(check bool) "tool_heavy_ratio_floor is a meaningful ratio [0,1]"
+    true (v >= 0.0 && v <= 1.0)
+
+(* ── runner ──────────────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Keeper_compact_policy_pure"
+    [
+      ( "compaction_decision_to_string",
+        [
+          Alcotest.test_case "Applied" `Quick test_to_string_applied;
+          Alcotest.test_case "Blocked_below_thresholds" `Quick
+            test_to_string_blocked;
+          Alcotest.test_case "Skipped_no_checkpoint" `Quick
+            test_to_string_skipped_no_checkpoint;
+          Alcotest.test_case "Skipped_continuity_reflection 45/60" `Quick
+            test_to_string_skipped_continuity;
+          Alcotest.test_case "Skipped_continuity_reflection 0/0" `Quick
+            test_to_string_skipped_continuity_zero;
+        ] );
+      ( "compaction_decision_applied",
+        [
+          Alcotest.test_case "Applied → true" `Quick test_applied_true_for_applied;
+          Alcotest.test_case "Blocked → false" `Quick
+            test_applied_false_for_blocked;
+          Alcotest.test_case "Skipped_no_checkpoint → false" `Quick
+            test_applied_false_for_skipped_no_checkpoint;
+          Alcotest.test_case "Skipped_continuity → false" `Quick
+            test_applied_false_for_skipped_continuity;
+        ] );
+      ( "thresholds",
+        [
+          Alcotest.test_case "emergency threshold in (0,1]" `Quick
+            test_emergency_threshold_in_range;
+          Alcotest.test_case "tool_heavy msg threshold > 0" `Quick
+            test_tool_heavy_threshold_positive;
+          Alcotest.test_case "tool_heavy ratio in [0,1]" `Quick
+            test_tool_heavy_floor_in_range;
+        ] );
+    ]


### PR DESCRIPTION
## Why

Third P2 test-gap closure from the 2026-04-29 audit (tracker #12842, after #12847 keeper_alerting_path and #12859 coord_eio_pure). `keeper_compact_policy.ml` (235 LOC) had no direct test coverage despite gating emergency compaction behaviour referenced in #5634.

## What

12 `Quick` Alcotest cases across 3 groups:

| Group | Coverage |
|---|---|
| `compaction_decision_to_string` | All 4 constructors, including parameterised `Skipped_continuity_reflection` at typical and boundary (0/0) values |
| `compaction_decision_applied` | Boolean projection: only `Applied` is true |
| Threshold sanity | `emergency_compact_ratio_threshold ∈ (0,1]`, `tool_heavy_msg_threshold > 0`, `tool_heavy_ratio_floor ∈ [0,1]` |

The threshold sanity tests catch a class of regressions where the constants drift out of meaningful range — currently those values gate `#5634`-style emergency compaction, so silent drift would surface as production context overflow rather than a CI failure.

## Out of scope

The pipeline functions (`compact_if_needed_typed`, `compact_if_needed`) need a `keeper_meta` + `working_context` fixture; targeting in a follow-up PR.

## Test plan

- [x] Local: `dune build test/test_keeper_compact_policy_pure.exe` clean
- [x] Local: 12/12 cases pass
- [ ] CI `Build and Test` adds 12 Quick cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)