### PR TITLE
fix(dashboard): scope WorldVisualizer to Cockpit/IDE surfaces

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -2,7 +2,6 @@
 // Sticky app shell with tab routing and live status rail
 
 import { html } from 'htm/preact'
-import { WorldVisualizer } from './components/world-visualizer'
 import { useEffect } from 'preact/hooks'
 import { lazy, Suspense } from 'preact/compat'
 import { signal } from '@preact/signals'
@@ -286,7 +285,7 @@ export function App() {
 
         <main id="main-content" tabindex=${-1} class="min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0">
           <div class="h-full overflow-y-auto p-4">
-            <div class="flex-none border-b border-solid border-[var(--color-border-default)]"><${WorldVisualizer} /></div><${DashboardMain} />
+            <${DashboardMain} />
           </div>
         </main>
       </div>


### PR DESCRIPTION
## Summary
- The Yjs-backed `WorldVisualizer` ("Dream IDE: 7 Physical Laws Visualization") was mounted globally in `App()` above `DashboardMain`. Every tab (Logs, Overview, Monitor, Command, Connectors, Workspace, Lab, …) rendered the title bar + an empty 800×300 canvas, taking ~360px of vertical real estate while doing nothing on those routes.
- The visualization is already mounted intentionally in the two surfaces that own the dream-IDE concept: `cockpit.ts:9` (MASC COCKPIT tab) and `ide-shell.ts:137` (Code IDE). The global mount in `app.ts:289` was a leftover from #12733 (`feat(dashboard): migrate WorldVisualizer and Yjs bindings…`).
- This PR removes the global duplicate. Cockpit and IDE Shell continue to render it as before.

## Why this is the right scope
- Reported symptom: "Dream IDE 박스가 모든 페이지 상단에 계속 보이는데 아무것도 안 함" — root cause is the unconditional mount, not the component itself. Component is intentional in its dream-IDE surfaces.
- Surgical 1-file change: 1 import + 1 JSX line removed.
- No behavior change for Cockpit / IDE Shell users.

## Files changed
- `dashboard/src/app.ts` — drop unused `WorldVisualizer` import and the global wrapper above `DashboardMain`.

## Test plan
- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint` (only 3 pre-existing unused-disable warnings, unchanged)
- [x] `pnpm exec vitest run src/components/world-visualizer.test.ts` — 9/9 pass (URL resolution helper)
- [ ] Manual: `/dashboard#logs`, `#overview`, `#monitor`, `#command`, `#connectors`, `#workspace`, `#lab` no longer render the "Dream IDE" panel
- [ ] Manual: `/dashboard#cockpit` and `/dashboard#code` still render the WorldVisualizer (untouched mounts)