### PR TITLE
fix(keeper): reset queue-head wait clock after fairness yield + enqueue

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -479,7 +479,18 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
           maybe_yield_for_fairness ~keeper_name;
           let ticket = enqueue_autonomous_waiter ~keeper_name in
           slot_state.autonomous_ticket := Some ticket;
-          match wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at:t0 with
+          (* Reset the queue-head timeout clock to the moment we joined the
+             queue, NOT [t0] (slot-entry). Otherwise [maybe_yield_for_fairness]
+             above silently consumes the [semaphore_wait_timeout_sec] budget
+             before we even appear in the FIFO, producing the symptom
+             "skipping turn (semaphore wait > 60s, peers holding slot,
+             autonomous_available=N)" with N>0 because the slot is genuinely
+             free but we ran out of budget while sleeping in fairness yield. *)
+          let queue_entered_at = Time_compat.now () in
+          match
+            wait_for_autonomous_queue_head ~keeper_name ~ticket
+              ~started_at:queue_entered_at
+          with
           | Error _ as e -> e
           | Ok () ->
             match acquire_bounded ~label:"autonomous" autonomous_turn_semaphore with
@@ -518,4 +529,8 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
 
 let with_keeper_turn_slot_for_test ~keeper_name ~channel f =
   with_keeper_turn_slot ~keeper_name ~channel f
+;;
+
+let wait_for_autonomous_queue_head_for_test ~keeper_name ~ticket ~started_at =
+  wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at
 ;;

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -31,6 +31,17 @@ val reactive_turn_semaphore_value_for_test : unit -> int
 val enqueue_autonomous_waiter_for_test : string -> int
 val drop_autonomous_waiter_for_test : int -> unit
 
+(** Test-only: drive the queue-head wait loop directly with an injected
+    [~started_at]. Exposed so a regression test can assert that a stale
+    [started_at] (e.g. one captured before a fairness cooldown) immediately
+    returns [Error `Semaphore_wait_timeout] — proving the parameter is the
+    timing knob whose freshness must be controlled at every call site. *)
+val wait_for_autonomous_queue_head_for_test :
+  keeper_name:string ->
+  ticket:int ->
+  started_at:float ->
+  (unit, [> `Semaphore_wait_timeout of float ]) result
+
 (** Pure computation: seconds keeper should yield before re-entering queue
     at time [now].  0.0 = no yield needed. *)
 val fairness_delay_sec_at : now:float -> keeper_name:string -> float

--- a/test/dune
+++ b/test/dune
@@ -1101,6 +1101,7 @@
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
 (include stanzas/test_keeper_meta_canonical_seed.inc)
 (include stanzas/test_keeper_meta_unknown_keys_warn.inc)
+(include stanzas/test_keeper_semaphore_wait_queue_head_clock.inc)
 (include stanzas/test_keeper_meta_heartbeat_retain_9733.inc)
 (include stanzas/test_keeper_meta_merge.inc)
 (include stanzas/test_keeper_mutex_coverage.inc)

--- a/test/stanzas/test_keeper_semaphore_wait_queue_head_clock.inc
+++ b/test/stanzas/test_keeper_semaphore_wait_queue_head_clock.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_semaphore_wait_queue_head_clock)
+ (modules test_keeper_semaphore_wait_queue_head_clock)
+ (libraries masc_mcp alcotest unix eio_main))

--- a/test/test_keeper_semaphore_wait_queue_head_clock.ml
+++ b/test/test_keeper_semaphore_wait_queue_head_clock.ml
@@ -1,0 +1,103 @@
+(** Regression: queue-head wait timeout clock must be reset after the keeper
+    joins the FIFO, not inherited from slot-entry.
+
+    Production symptom (live log 2026-05-05 ~01:50 KST, masc-mcp):
+
+      [WARN] [Keeper] <name>: skipping turn (semaphore wait > 60s,
+        peers holding slot, cascade=..., autonomous_available=6
+        turn_available=12)
+
+    fired across 14 keepers simultaneously while
+    [autonomous_turn_semaphore] reported 6 free slots — i.e. capacity was
+    available, but every waiter timed out before reaching head-of-queue.
+
+    Root cause: [with_keeper_turn_slot] captured [t0] BEFORE
+    [maybe_yield_for_fairness], then passed that same [t0] to
+    [wait_for_autonomous_queue_head] as [~started_at]. Any time spent in
+    the fairness cooldown was silently subtracted from the
+    [semaphore_wait_timeout_sec] budget for the queue-head phase. With
+    cooldown ≈ 5s, every keeper had only 55s to reach head; chains of
+    slow LLM turns at the head of the queue then trip the timeout for
+    the entire tail.
+
+    Fix: [with_keeper_turn_slot] now captures a fresh [queue_entered_at]
+    after [enqueue_autonomous_waiter] and passes that to
+    [wait_for_autonomous_queue_head].
+
+    These tests exercise the parameter directly via
+    [wait_for_autonomous_queue_head_for_test]: they prove the function's
+    timeout decision is anchored on [~started_at], so passing a stale
+    timestamp causes immediate [Semaphore_wait_timeout]. The fix at
+    [with_keeper_turn_slot] removes the only path that produced a stale
+    [~started_at] in production. *)
+
+open Masc_mcp
+
+let timeout_sec = Keeper_turn_slot.semaphore_wait_timeout_sec
+
+let test_stale_started_at_times_out_immediately () =
+  Eio_main.run @@ fun _env ->
+  Keeper_turn_slot.reset_autonomous_turn_queue_for_test ();
+  let blocker = Keeper_turn_slot.enqueue_autonomous_waiter_for_test "blocker" in
+  let ours = Keeper_turn_slot.enqueue_autonomous_waiter_for_test "ours" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_turn_slot.drop_autonomous_waiter_for_test ours;
+      Keeper_turn_slot.drop_autonomous_waiter_for_test blocker)
+    (fun () ->
+      let stale_started_at = Unix.gettimeofday () -. (timeout_sec +. 5.0) in
+      match
+        Keeper_turn_slot.wait_for_autonomous_queue_head_for_test
+          ~keeper_name:"ours"
+          ~ticket:ours
+          ~started_at:stale_started_at
+      with
+      | Error (`Semaphore_wait_timeout waited) ->
+        Alcotest.(check (float 0.001))
+          "timeout value is the configured cap"
+          timeout_sec
+          waited
+      | Ok () ->
+        Alcotest.fail
+          "expected Semaphore_wait_timeout from a stale [started_at] but got Ok"
+      | Error _ ->
+        Alcotest.fail "expected Semaphore_wait_timeout variant")
+
+let test_fresh_started_at_at_head_returns_ok () =
+  Eio_main.run @@ fun _env ->
+  Keeper_turn_slot.reset_autonomous_turn_queue_for_test ();
+  let ours = Keeper_turn_slot.enqueue_autonomous_waiter_for_test "ours" in
+  Fun.protect
+    ~finally:(fun () -> Keeper_turn_slot.drop_autonomous_waiter_for_test ours)
+    (fun () ->
+      let fresh = Unix.gettimeofday () in
+      match
+        Keeper_turn_slot.wait_for_autonomous_queue_head_for_test
+          ~keeper_name:"ours"
+          ~ticket:ours
+          ~started_at:fresh
+      with
+      | Ok () ->
+        Alcotest.(check pass)
+          "head waiter with fresh clock returns Ok immediately"
+          ()
+          ()
+      | Error _ ->
+        Alcotest.fail
+          "expected Ok when this is the only waiter and clock is fresh")
+
+let () =
+  Alcotest.run
+    "keeper_semaphore_wait_queue_head_clock"
+    [ ( "queue_head_clock_freshness"
+      , [ Alcotest.test_case
+            "stale started_at causes immediate timeout (proves parameter is the knob)"
+            `Quick
+            test_stale_started_at_times_out_immediately
+        ; Alcotest.test_case
+            "fresh started_at at head returns Ok"
+            `Quick
+            test_fresh_started_at_at_head_returns_ok
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Symptom

Live OCaml log (~/me/.masc/keepers/, 2026-05-05 ~01:50 KST) shows nearly EVERY keeper hitting:

\`\`\`
[WARN] [Keeper] <name>: skipping turn (semaphore wait > 60s, peers holding slot,
  cascade=..., autonomous_available=6 turn_available=12)
\`\`\`

14 keepers (sangsu, issue_king, ramarama, qa-king, janitor, analyst, taskmaster, scholar, nick0cave, glm-coding-plan, masc-improver, verifier, velvet-hammer, executor) across two cascade families (\`big_three\`, \`glm_coding_plan_only\`). The recurring \`autonomous_available=6 turn_available=12\` says slots ARE free at log time — capacity is available, but every waiter timed out.

## Root cause

\`with_keeper_turn_slot\` at \`lib/keeper/keeper_turn_slot.ml\`:

\`\`\`ocaml
let t0 = Time_compat.now () in        (* line 408: slot-entry clock *)
...
maybe_yield_for_fairness ~keeper_name; (* line 479: may sleep ~5s *)
let ticket = enqueue_autonomous_waiter ~keeper_name in
... wait_for_autonomous_queue_head ... ~started_at:t0   (* line 482: eats budget *)
\`\`\`

\`t0\` is captured BEFORE the fairness cooldown. Time spent in \`maybe_yield_for_fairness\` is silently subtracted from the \`semaphore_wait_timeout_sec\` (60s default) budget that \`wait_for_autonomous_queue_head\` uses for its queue-head deadline. With cooldown ≈ 5s, every keeper enters the FIFO with only 55s of budget; a chain of slow LLM turns at the head trips the timeout for the entire tail.

The \`autonomous_available=N>0\` in the WARN is correct — by the time the timeout fires and the post-hoc \`Eio.Semaphore.get_value\` is read, the head waiter may have already released. The smoking-gun fingerprint is \`peers holding slot\` while the counter shows free capacity.

## Fix

Capture a fresh \`queue_entered_at\` after \`enqueue_autonomous_waiter\` returns, and pass that to \`wait_for_autonomous_queue_head ~started_at\`. The total \`semaphore_wait_ms\` (line 514) still derives from \`t0\` so the operator-facing wall-time metric is unaffected.

## Test

\`test/test_keeper_semaphore_wait_queue_head_clock.ml\` exposes \`wait_for_autonomous_queue_head_for_test\` via the .mli and asserts:

1. Stale \`~started_at\` (older than \`semaphore_wait_timeout_sec\`) → immediate \`Semaphore_wait_timeout\`. Proves the parameter is the timing knob whose freshness must be controlled at every call site.
2. Fresh \`~started_at\` at queue head → \`Ok\` immediately.

Both pass after fix.

## Risk

Bound on queue-head budget shifts from 60s − fairness_cooldown to a full 60s after enqueue. With default cooldown 5s, effective worst-case wait now \`fairness_cooldown_sec + 60s\` ≈ 65s instead of 60s. Acceptable — the prior behavior was silently truncating the contract.

## Out of scope (noted, separate)

- \`autonomous_queue_poll_sec\` poll cadence means timeout detection lags by up to one poll period; measurement-precision issue, not starvation.
- WARN-site \`get_value\` read in \`keeper_heartbeat_loop.ml:718-723\` is sampled AFTER the error returns, so it can reflect a different state than at timeout-fire. A more accurate log would carry the at-fire counters in the error payload. Cosmetic — does not change behavior.
- With 14 keepers and \`autonomous_turn_limit\` default 3 (operator currently runs with 6, per \`autonomous_turn_concurrency=6\` log), queue depth ≥ 8 even after fix. Capacity tuning is the only fix for systematic starvation if average turn duration × queue depth > 60s. This PR closes the budget-leak; capacity tuning is left to operator.

## Test plan

- [x] \`dune build @check\` clean
- [x] new test passes (2/2)
- [ ] CI green
- [ ] Live log re-tail post-deploy: \`semaphore wait > 60s\` rate drop confirmation (operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)