### PR TITLE
feat(observability): per-candidate cascade attempt JSONL telemetry

### DIFF
--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -311,6 +311,43 @@ let record_attempt_start (capture : cascade_metrics_capture)
     }
     :: capture.attempts_rev
 
+(** [cascade_attempt_terminal_event_json] builds the structured details payload
+    emitted to system_log when a cascade candidate reaches its terminal state
+    (success: latency_ms set, error none; failure: error set). The shape is the
+    contract for downstream log analysers and external operators looking for
+    "why did the cascade exhaust" signals. Errors are recorded verbatim — no
+    string-based classification at this layer (see #12817 spirit and the
+    project memory rule "no string matching for classification"). *)
+let cascade_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
+    ~error =
+  let outcome = if Option.is_some error then "failure" else "success" in
+  `Assoc
+    [
+      ("event", `String "cascade_attempt_terminal");
+      ("model_id", `String model_id);
+      ( "model_label",
+        match model_label with Some s -> `String s | None -> `Null );
+      ( "latency_ms",
+        match latency_ms with Some n -> `Int n | None -> `Null );
+      ("outcome", `String outcome);
+      ( "error_message",
+        match error with Some s -> `String s | None -> `Null );
+    ]
+
+let log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error =
+  let outcome = if Option.is_some error then "failure" else "success" in
+  let details =
+    cascade_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
+      ~error
+  in
+  let summary =
+    Printf.sprintf
+      "cascade candidate terminal: model=%s outcome=%s latency_ms=%s" model_id
+      outcome
+      (match latency_ms with Some n -> string_of_int n | None -> "n/a")
+  in
+  Log.Telemetry.emit Log.Info ~details summary
+
 let ensure_terminal_attempt (capture : cascade_metrics_capture)
     ~(candidate_cfgs : Llm_provider.Provider_config.t list)
     ~(model_id : string) ~(latency_ms : int option) ~(error : string option) =
@@ -320,7 +357,8 @@ let ensure_terminal_attempt (capture : cascade_metrics_capture)
     && Option.is_none attempt.error
   in
   let update attempt = { attempt with latency_ms; error } in
-  match update_first_attempt_if ~predicate:is_open ~update capture.attempts_rev with
+  let model_label = model_label_option_of_model_id ~candidate_cfgs model_id in
+  (match update_first_attempt_if ~predicate:is_open ~update capture.attempts_rev with
   | Some attempts_rev -> capture.attempts_rev <- attempts_rev
   | None ->
       let attempt_index = capture.next_attempt_index in
@@ -329,11 +367,12 @@ let ensure_terminal_attempt (capture : cascade_metrics_capture)
         {
           attempt_index;
           model_id;
-          model_label = model_label_option_of_model_id ~candidate_cfgs model_id;
+          model_label;
           latency_ms;
           error;
         }
-        :: capture.attempts_rev
+        :: capture.attempts_rev);
+  log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error
 
 let record_fallback_event (capture : cascade_metrics_capture)
     ~(candidate_cfgs : Llm_provider.Provider_config.t list)

--- a/lib/oas_worker_cascade.mli
+++ b/lib/oas_worker_cascade.mli
@@ -133,6 +133,18 @@ type cascade_metrics_capture
     a {!cascade_observation} via
     {!cascade_observation_with_metrics}. *)
 
+val cascade_attempt_terminal_event_json :
+  model_id:string ->
+  model_label:string option ->
+  latency_ms:int option ->
+  error:string option ->
+  Yojson.Safe.t
+(** Builds the structured JSON payload emitted to system_log for one
+    cascade candidate's terminal state. Exposed for tests so the shape
+    contract (`event`, `model_id`, `model_label`, `latency_ms`, `outcome`,
+    `error_message`) is locked against silent drift; downstream operators
+    grep on these field names when tracing why a cascade exhausted. *)
+
 val cascade_metrics_for_candidates :
   candidate_cfgs:Llm_provider.Provider_config.t list ->
   unit ->

--- a/test/dune
+++ b/test/dune
@@ -1030,6 +1030,7 @@
 (include stanzas/test_cascade_fsm.inc)
 (include stanzas/test_cascade_health_tracker.inc)
 (include stanzas/test_cascade_inventory.inc)
+(include stanzas/test_cascade_per_candidate_telemetry.inc)
 (include stanzas/test_cascade_kimi_max_context_ssot.inc)
 (include stanzas/test_cascade_model_resolve.inc)
 (include stanzas/test_cascade_ollama_probe.inc)

--- a/test/stanzas/test_cascade_per_candidate_telemetry.inc
+++ b/test/stanzas/test_cascade_per_candidate_telemetry.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_per_candidate_telemetry)
+ (modules test_cascade_per_candidate_telemetry)
+ (libraries masc_test_deps))

--- a/test/test_cascade_per_candidate_telemetry.ml
+++ b/test/test_cascade_per_candidate_telemetry.ml
@@ -1,0 +1,112 @@
+(** test_cascade_per_candidate_telemetry — pin the JSON shape contract
+    of the per-candidate cascade attempt telemetry payload emitted into
+    [system_log_YYYY-MM-DD.jsonl] from
+    [Oas_worker_cascade.cascade_attempt_terminal_event_json].
+
+    The shape is the operator-facing contract: when a cascade exhausts
+    all 14 candidates and [selected_model: null] lands in the decision
+    record, the only way to find out *which* candidate failed *how* is
+    to grep these field names in system_log. A silent field rename or
+    drop would re-create the original "no idea why cascade exhausted"
+    blackbox.
+
+    Tests cover both terminal outcomes:
+    - success: [latency_ms] is [Some _], [error] is [None]
+    - failure: [error] is [Some _], [latency_ms] may be [Some _] or [None]
+
+    Errors are recorded *verbatim* as [error_message]; classification
+    happens externally per project memory rule "no string matching for
+    classification" and the spirit of #12817. *)
+
+open Masc_mcp
+
+let assoc_string key json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String s) -> s
+      | Some other ->
+          Alcotest.failf "field %s expected `String, got %s" key
+            (Yojson.Safe.to_string other)
+      | None -> Alcotest.failf "field %s missing from %s" key
+                  (Yojson.Safe.to_string json))
+  | _ -> Alcotest.failf "expected `Assoc, got %s" (Yojson.Safe.to_string json)
+
+let assoc_field key json =
+  match json with
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let test_success_shape () =
+  let json =
+    Oas_worker_cascade.cascade_attempt_terminal_event_json
+      ~model_id:"glm-coding:glm-4.7"
+      ~model_label:(Some "glm-coding:glm-4.7") ~latency_ms:(Some 35921)
+      ~error:None
+  in
+  Alcotest.(check string)
+    "event tag" "cascade_attempt_terminal" (assoc_string "event" json);
+  Alcotest.(check string)
+    "model_id" "glm-coding:glm-4.7" (assoc_string "model_id" json);
+  Alcotest.(check string) "outcome" "success" (assoc_string "outcome" json);
+  (match assoc_field "latency_ms" json with
+  | Some (`Int 35921) -> ()
+  | other ->
+      Alcotest.failf "latency_ms expected `Int 35921, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null)));
+  (match assoc_field "error_message" json with
+  | Some `Null -> ()
+  | other ->
+      Alcotest.failf "error_message expected `Null on success, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null)))
+
+let test_failure_shape () =
+  let json =
+    Oas_worker_cascade.cascade_attempt_terminal_event_json
+      ~model_id:"gemini_cli:gemini-2.5-pro" ~model_label:None
+      ~latency_ms:(Some 1200)
+      ~error:(Some "OAS budget timeout after 600.0s")
+  in
+  Alcotest.(check string)
+    "event tag" "cascade_attempt_terminal" (assoc_string "event" json);
+  Alcotest.(check string)
+    "model_id" "gemini_cli:gemini-2.5-pro" (assoc_string "model_id" json);
+  Alcotest.(check string) "outcome" "failure" (assoc_string "outcome" json);
+  (match assoc_field "model_label" json with
+  | Some `Null -> ()
+  | other ->
+      Alcotest.failf "model_label expected `Null when None passed, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null)));
+  Alcotest.(check string)
+    "error_message recorded verbatim — no classification at this layer"
+    "OAS budget timeout after 600.0s"
+    (assoc_string "error_message" json)
+
+let test_failure_with_no_latency () =
+  (* Provider that never started a request (e.g. CLI exit 1, DNS fail) —
+     latency_ms is None, error is Some. Outcome must still be "failure". *)
+  let json =
+    Oas_worker_cascade.cascade_attempt_terminal_event_json
+      ~model_id:"codex_cli:gpt-5.3-codex-spark"
+      ~model_label:(Some "codex_cli:gpt-5.3-codex-spark") ~latency_ms:None
+      ~error:(Some "rollout thread not found")
+  in
+  Alcotest.(check string) "outcome" "failure" (assoc_string "outcome" json);
+  match assoc_field "latency_ms" json with
+  | Some `Null -> ()
+  | other ->
+      Alcotest.failf "latency_ms expected `Null, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null))
+
+let () =
+  Alcotest.run "cascade_per_candidate_telemetry"
+    [
+      ( "shape",
+        [
+          Alcotest.test_case "success terminal shape" `Quick test_success_shape;
+          Alcotest.test_case "failure terminal shape with latency" `Quick
+            test_failure_shape;
+          Alcotest.test_case "failure terminal shape no latency" `Quick
+            test_failure_with_no_latency;
+        ] );
+    ]


### PR DESCRIPTION
## Why

When a keeper turn's cascade exhausts all candidates and the decision
record lands with `selected_model: null`, no per-candidate failure trace
exists in `~/.masc/logs/system_log_YYYY-MM-DD.jsonl`. Prometheus counters
tick but post-hoc operators cannot tell which candidate failed how — the
symptom is "the keeper just stopped, with no reason given anywhere."

Reproduced live on 2026-05-04: executor turn 95 (decision record
`dec-1777908952856-a6102e05`) had `cascade_name=big_three`, 14 candidate
models, `selected_model=null`, `tool_call_count=0`, `latency_ms=600089`,
`error="[masc_oas_error] {"kind":"turn_timeout","elapsed_sec":600.0}"` —
i.e. all 14 candidates failed and `usage_reported:false,
telemetry_reported:false`. Operator inspecting the live log saw only
periodic semaphore-skip warnings and the schema-validator noise from
\#12852, with no per-candidate trace anywhere.

## What

One structured `Log.Info` line per candidate's terminal state, emitted
from the existing `ensure_terminal_attempt` path. That path is already
wired into `Oas_compat.Metrics.{on_request_end, on_error}` callbacks, so
the new line covers every candidate that produces a terminal signal —
including providers that never start a request (CLI exit 1, DNS fail,
auth refused) because `ensure_terminal_attempt` records those via the
fall-through arm with `latency_ms=None`.

Payload (shape pinned by `test_cascade_per_candidate_telemetry`):

\`\`\`json
{
  "event":          "cascade_attempt_terminal",
  "model_id":       "glm-coding:glm-4.7",
  "model_label":    "glm-coding:glm-4.7",
  "latency_ms":     35921,
  "outcome":        "success",
  "error_message":  null
}
\`\`\`

Failures record the upstream error string verbatim — *no string-based
classification at this layer* per the project memory rule and the
spirit of \#12817 (which moved oas-compat to structured error codes
M04/M05). Downstream log analysers and alerting do classification;
this layer's job is to make the raw signal observable.

## Test

\`\`\`
$ dune exec ./test/test_cascade_per_candidate_telemetry.exe
Testing 'cascade_per_candidate_telemetry'.
[OK]  shape  0  success terminal shape.
[OK]  shape  1  failure terminal shape with latency.
[OK]  shape  2  failure terminal shape no latency.
Test Successful in 0.014s. 3 tests run.
\`\`\`

The shape contract test pins the field names because operators grep on
them when a cascade goes silent; a silent rename would re-create the
'no idea why cascade exhausted' blackbox.

## Test plan

- [x] \`dune build @check\` clean
- [x] \`dune exec ./test/test_cascade_per_candidate_telemetry.exe\` 3/3 pass
- [ ] CI green
- [ ] Manual: tail \`system_log_$(date +%Y-%m-%d).jsonl\` while a keeper
      runs a cascade — confirm one \`cascade_attempt_terminal\` line per
      candidate and that \`outcome\` flips to \`failure\` for the ones that
      time out

## Out-of-scope (follow-up)

1. **\`keeper_name\` / \`turn_id\` labels** — the current emit leaves both
   null because \`cascade_metrics_for_candidates\` does not receive
   keeper context. Threading them through changes the signature and is
   a separate, mechanical sweep.
2. **Slot-lease redesign** — the dominant operational symptom is one
   hung cascade starving 13 peer keepers for ~70 minutes
   (\`turn_wall_clock_timeout 600s\` + degraded\_retry \`ollama\_bench\`
   3585s while still holding the autonomous-fairness semaphore). That
   needs an RFC for slot lifecycle changes — not a one-PR fix.
3. **\`Safe_ops.protect\` → \`Eio.Switch.on_release\`** — the May 3
   fatal (\`Eio__core__Fiber.Not_first\` raised inside
   \`Eio_mutex.use_rw\` → \`Safe_ops.protect\` →
   \`Fun.protect\` → \`Fun.Finally_raised\` → supervisor records
   \`fiber_unresolved\`) is a known cancel-vs-error confusion in
   \`lib/core/safe_ops.ml\`. Replacing the \`Fun.protect\` shape with
   \`Switch.on_release\` is the right fix per CLAUDE.md OCaml guide,
   but \`Safe_ops.protect\` has 21 caller modules — sweep needs scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)