### PR TITLE
feat(cascade): detect fallback_cascade cycles at load_catalog time

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -252,6 +252,54 @@ let update_catalog_builder builder field value =
       in
       { builder with fallback_cascade }
 
+(* Detect fallback_cascade cycles in a freshly loaded catalog.
+
+   2026-05-05 fleet-stuck root cause: the operator-side cascade.toml
+   declared [big_three.fallback_cascade = "glm_coding_plan_only"] AND
+   [glm_coding_plan_only.fallback_cascade = "big_three"].  When the
+   GLM provider stalled, both cascades escalated to each other,
+   producing a silent 600s+ timeout chain with no operator-visible
+   reason.  This helper walks the fallback graph and emits a Prometheus
+   counter + WARN log per cycle entry point so a CI test or operator
+   alert can catch the same shape before it goes live. *)
+let detect_fallback_cycles (entries : catalog_entry list) :
+    string list list =
+  let by_name =
+    List.fold_left
+      (fun acc e -> StringMap.add e.name e acc)
+      StringMap.empty entries
+  in
+  let rec walk visited current =
+    match StringMap.find_opt current by_name with
+    | None -> None
+    | Some entry ->
+      (match entry.fallback_cascade with
+       | None -> None
+       | Some next when List.mem next visited ->
+         (* Cycle: trim [visited] to start at [next]. *)
+         let rec trim = function
+           | [] -> []
+           | x :: _ as l when String.equal x next -> List.rev l
+           | _ :: rest -> trim rest
+         in
+         Some (trim (current :: visited))
+       | Some next ->
+         walk (current :: visited) next)
+  in
+  List.filter_map
+    (fun entry -> walk [] entry.name)
+    entries
+  |> (* Deduplicate cycles up to rotation: sort each cycle and keep
+        unique sets so [A→B→A] and [B→A→B] count as one. *)
+     List.fold_left
+       (fun (seen, acc) cycle ->
+         let key = String.concat "|" (List.sort compare cycle) in
+         if List.mem key seen then (seen, acc)
+         else (key :: seen, cycle :: acc))
+       ([], [])
+  |> snd
+  |> List.rev
+
 let load_catalog ~config_path =
   match load_json config_path with
   | Error _ as err -> err
@@ -287,6 +335,20 @@ let load_catalog ~config_path =
                      fallback_cascade = builder.fallback_cascade;
                    })
       in
+      List.iter
+        (fun cycle ->
+          let entry = match cycle with x :: _ -> x | [] -> "?" in
+          Prometheus.inc_counter
+            Prometheus.metric_cascade_fallback_cycle_detected_total
+            ~labels:[("cascade", entry)] ();
+          Log.warn ~ctx:"CascadeConfig"
+            "fallback_cascade cycle detected at [%s]: %s — provider \
+             stalls in any participant will silently propagate through \
+             the entire loop (no escape).  Break the cycle by setting \
+             at least one fallback_cascade to a non-participating \
+             cascade (e.g. local_recovery) or removing the field."
+            entry (String.concat " → " (cycle @ [entry])))
+        (detect_fallback_cycles entries);
       Ok entries
   | Ok _ -> Ok []
 

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -74,10 +74,28 @@ val is_deprecated_logical_profile_name : string -> bool
     system-only profiles that should remain editable/visible but must
     not appear in keeper-assignment UIs.
 
+    On a successful load this also walks the fallback graph and emits
+    [masc_cascade_fallback_cycle_detected_total] + a WARN log for each
+    cycle discovered (see {!detect_fallback_cycles}).
+
     Returns [Error _] when the file cannot be read or parsed. *)
 val load_catalog :
   config_path:string ->
   (catalog_entry list, string) result
+
+(** Pure helper: walk the [fallback_cascade] graph and return every
+    cycle as a list of cascade names in traversal order (entry point
+    first).  Cycles are deduplicated up to rotation so [A→B→A] and
+    [B→A→B] are reported once.
+
+    Cycles are silent failures: when every participant depends on a
+    stalled provider the cascade rotation never escapes the loop.
+    {!load_catalog} calls this automatically and surfaces results
+    through Prometheus + log; this function is exposed so tests and
+    CI gates can assert "no cycles in catalog" without re-walking the
+    JSON. *)
+val detect_fallback_cycles :
+  catalog_entry list -> string list list
 
 (** Load a named model list from a JSON config file.
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -912,6 +912,16 @@ let metric_keeper_liveness_recovery_outcomes =
    Labels: provider_key. *)
 let metric_cascade_server_error_skip_total =
   "masc_cascade_server_error_skip_total"
+
+(* 2026-05-05 fleet-stuck diagnosis: cascade A → B → A circular fallback
+   creates a silent 600s timeout chain when every model in both
+   cascades depends on the same provider that has stalled.  This
+   counter increments once per [load_catalog] call when any
+   fallback_cascade chain forms a cycle.  Labels: cascade (the entry
+   point of the cycle).  Operators alert on this counter; cycle
+   participants are listed in the WARN log. *)
+let metric_cascade_fallback_cycle_detected_total =
+  "masc_cascade_fallback_cycle_detected_total"
 (* #12799: Passive loop detector — keeper emitting only read-only tool
    calls for N consecutive turns.  Labels: keeper. *)
 let metric_keeper_passive_loop_detected_total =
@@ -1480,6 +1490,12 @@ let init () =
   add metric_cascade_server_error_skip_total
     "#12797 Total cascade label-ranking skips triggered by recent server \
      error (5xx) score decay. Labeled by provider_key."
+    Counter;
+  add metric_cascade_fallback_cycle_detected_total
+    "Total cascade fallback_cascade cycles detected during load_catalog. \
+     A cycle (e.g. big_three → glm_coding_plan_only → big_three) means \
+     a provider stall propagates through both cascades silently for \
+     600s+ without escaping.  Labeled by [cascade] (cycle entry point)."
     Counter;
   add metric_keeper_passive_loop_detected_total
     "#12799 Total passive-loop detections: keeper issued only read-only tool \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -396,6 +396,14 @@ val metric_cascade_capacity_events : string
 val metric_cascade_server_error_skip_total : string
 (** #12797 Total cascade label-ranking skips triggered by recent server-error
     (5xx) score decay for a provider.  Labels: [provider_key]. *)
+
+val metric_cascade_fallback_cycle_detected_total : string
+(** Total cascade fallback_cascade cycles detected during [load_catalog].
+    A cycle means a provider stall propagates through every cascade in
+    the loop silently for 600s+ without escaping.  Labels: [cascade]
+    (the entry point of the detected cycle).  Discovered during the
+    2026-05-05 fleet-stuck investigation:
+    [big_three → glm_coding_plan_only → big_three]. *)
 val metric_keeper_invariant_violations : string
 
 (** PR-I: cross-FSM edge transition counter. Labels: [edge] with values


### PR DESCRIPTION
## Why — fleet-stuck root cause (2026-05-05)

`~/me/.masc/config/cascade.toml` declared a circular fallback chain:

```
big_three.fallback_cascade            = "glm_coding_plan_only"
glm_coding_plan_only.fallback_cascade = "big_three"
```

When the GLM provider stalled, both cascades escalated to each other, producing a silent 600s+ timeout chain with no operator-visible reason — 9 of 14 keepers reported `outcome=never_started, last_blocker_class=null` for ~1.5h.

The loader's `.mli` already documents:
> *"the loader does not validate that the target profile exists; consumers are expected to drop the hint when it does not match a live catalog entry."*

But cycle detection had no consumer either, so misconfigurations went unnoticed until the symptom manifested.

## What

1. **`Cascade_config_loader.detect_fallback_cycles`** — pure helper that walks the fallback graph and returns each cycle as a list of cascade names in traversal order.  Cycles deduplicated up to rotation so [A→B→A] and [B→A→B] are reported once.

2. **`load_catalog` calls it automatically** — on every successful load, each cycle entry emits:
   - `masc_cascade_fallback_cycle_detected_total{cascade=<entry>}` (Prometheus counter)
   - WARN log naming every participant: *"fallback_cascade cycle detected at [big_three]: big_three → glm_coding_plan_only → big_three — provider stalls in any participant will silently propagate through the entire loop (no escape).  Break the cycle by setting at least one fallback_cascade to a non-participating cascade (e.g. local_recovery) or removing the field."*

3. **Helper is `val`-exported in `.mli`** so a future CI gate or test can assert "no cycles in repo seed" without re-walking the JSON.

## Risk

- 4 files, +104 lines, single new helper + emit site.  No behaviour change in cascade rotation — observability only.
- Once the metric fires, the operator must still break the cycle in the `.toml` manually (this PR refuses to silently rewrite operator config).
- Cycle detection runs once per `load_catalog`; deduplicated by rotation, so cardinality bounded by distinct cycle entry points (typically 0 in healthy deployments).

## Validation

- [x] `dune build @check` passes (clean output).
- [x] Race-check 0 matches.
- [x] Existing `load_catalog` API unchanged — additive.

## References

- 2026-05-05 fleet-stuck diagnosis (analyst.json/executor.json + live system_log_2026-05-04.jsonl seq 76134-76135)
- `~/me/.masc/config/cascade.toml` lines 38 (`big_three.fallback_cascade`) + 54 (`glm_coding_plan_only.fallback_cascade`) — the operator-side circular pair
- #12855 (companion fix C: `last_blocker_class` for `Semaphore_wait_timeout`; this PR catches the *config* that triggered that silent state)