### PR TITLE
fix(harness): warmup very first model in ollama_sweep

### DIFF
--- a/scripts/harness/workload/ollama_sweep.sh
+++ b/scripts/harness/workload/ollama_sweep.sh
@@ -51,8 +51,21 @@ echo
 PREV=""
 total_start="$(date +%s)"
 
+# Warmup helper. Without this, large MLX models (>=64GB) sometimes return
+# zero-metadata responses on the first measured request post cold load.
+# Warmup costs ~load_time + 100ms; measurement reliability gain is large.
+warmup_model() {
+  local m="$1"
+  curl -sS --max-time 90 -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg m "$m" '{model:$m, prompt:"ping", stream:false, think:false, options:{num_predict:1}}')" \
+    http://localhost:11434/api/generate >/dev/null 2>&1 || true
+}
+
+first_model=true
+
 for model in $MODELS; do
   IFS=',' read -r -a wl_arr <<<"$WORKLOADS"
+  first_workload_for_model=true
   for wl in "${wl_arr[@]}"; do
     wl="$(printf '%s' "$wl" | tr -d ' ')"
     [ -z "$wl" ] && continue
@@ -60,14 +73,13 @@ for model in $MODELS; do
     isolate="false"
     if [ -n "$PREV" ] && [ "$PREV" != "$model" ]; then
       isolate="true"
-      # Warmup the new model with a tiny prompt before the actual measurement.
-      # Without this, large MLX models (>=64GB) sometimes return zero-metadata
-      # responses on the first measured request post cold load. Warmup costs
-      # ~load_time + 100ms; measurement reliability gain is large.
-      curl -sS --max-time 90 -H 'Content-Type: application/json' \
-        -d "$(jq -nc --arg m "$model" '{model:$m, prompt:"ping", stream:false, think:false, options:{num_predict:1}}')" \
-        http://localhost:11434/api/generate >/dev/null 2>&1 || true
+      warmup_model "$model"
+    elif [ "$first_model" = "true" ] && [ "$first_workload_for_model" = "true" ]; then
+      # Cover cold-load case for the very first model in the sweep too.
+      # ISOLATE branch never fires (PREV is empty), so warmup happens here.
+      warmup_model "$model"
     fi
+    first_workload_for_model=false
 
     row_start="$(date +%s)"
     echo "→ $model $wl  (isolate=$isolate prev=$PREV)"
@@ -81,6 +93,7 @@ for model in $MODELS; do
     echo
     PREV="$model"
   done
+  first_model=false
 done
 
 # Final eviction (free RAM after sweep)


### PR DESCRIPTION
## Summary

The ISOLATE branch in `ollama_sweep.sh` calls `warmup_model` only when `PREV` is set and differs from the current model. The first model of any sweep has empty `PREV` and skips warmup entirely.

The warmup exists because >=64GB MLX models sometimes return zero-metadata responses on the first cold-load request (`eval_count=0`, `total_duration=0` despite valid JSON). The original logic left the first row of every sweep exposed to that failure mode.

## Fix

- Factor the warmup body into a `warmup_model` helper.
- Add an `elif` branch that fires on `first_model && first_workload_for_model`, so the very first measurement also gets the 1-token ping.
- Flip `first_model` to false after the first outer iteration.

## Cost

One extra cold-load duration per sweep — already paid for the first model anyway. The duration moves from "inside W1 measurement" to "before W1 measurement" so the W1 row no longer eats the load.

## Reliability gain

Removes the asymmetric "first row drops" pattern observed during the original 22-model run (PR #12833).

## Test plan

- [x] `bash -n` syntax pass
- [ ] Run a fresh `MODELS="qwen3.6:35b-a3b-mlx-bf16" WORKLOADS="W1" ollama_sweep.sh` and verify the first row has non-null tok/s

🤖 Generated with [Claude Code](https://claude.com/claude-code)