### PR TITLE
style(dashboard/primitives): consume --radius-pill token in .pill rule

### DIFF
--- a/dashboard/src/styles/primitives.css
+++ b/dashboard/src/styles/primitives.css
@@ -43,7 +43,7 @@
   letter-spacing: .04em;
   color: var(--color-fg-secondary);
   background: var(--color-bg-hover);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   white-space: nowrap;
 }
 .pill.is-running { color: var(--brass-1); background: rgb(var(--brass-glow) / .12); }


### PR DESCRIPTION
## Summary

The `.pill` atom in `dashboard/src/styles/primitives.css` used a literal `border-radius: 999px` even though `--radius-pill: 999px` was already exported by the generated tokens (`tokens.generated.css:119`, source: `design-system/tokens/source.ts:225`).

This was the only `border-radius: 999px` consumer in the entire dashboard. Swapping it makes the token cascade the single source of truth for the pill idiom.

## Why this is a 1-line PR

- Token already exists; this is consumer migration only.
- No new token added — no `pnpm tokens:build` regeneration needed.
- Resolved value is identical (999px → 999px), so zero visual change.
- After this PR, `rg "border-radius:\s*9{3,}px" dashboard/src` returns 0 matches.

## Test plan

- [x] `rg "border-radius:\s*9{3,}px" dashboard/src` → 0 matches.
- [x] `rg "var\(--radius-pill\)" dashboard/src` → 1 match (this consumer).
- [x] Visual: token resolves to 999px; pixel-identical render.
- [ ] CI Build and Test (existing dashboard suite).

## Self-review

- Goal: consume the existing `--radius-pill` token instead of repeating its literal value at the call site.
- Files changed: 1 line in 1 file.
- Race-checked `gh pr list` for `radius-pill`, `pill consumer`, `primitives.css`, `999px` immediately before push: 0 conflicting PRs.
- Risk: zero — same resolved value, single consumer, no behavioral change.

## Out of scope (deliberate)

- `border-radius: 50%` (10+ consumers) is the **circle** idiom — geometrically and semantically distinct from pill. If tokenization is desired, a separate `--radius-circle: 50%` token addition would land in its own PR with `pnpm tokens:build` regen.
- The other non-color polish items audited in #12870 (1px micro-radius, 56px display, 0.9em relative, 10.5px sub-pixel, `0s` reduced-motion) remain intentional.

## References

- Issue #12870 — non-color polish audit (this PR closes the only clean swap target identified there).
- PR #12853, #12857 — earlier color-domain polish (merged).
