### PR TITLE
feat(dashboard): add '차단된 키퍼' summary card to fleet telemetry

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -742,7 +742,7 @@ export function FleetTelemetryPanel() {
 
       <${WarningBanner} warnings=${value.warnings} />
 
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
         <${SummaryCard}
           title="키퍼 가동률"
           value=${`${counts.live}/${value.rows.length || 0}`}
@@ -754,6 +754,14 @@ export function FleetTelemetryPanel() {
           value=${`${counts.hot} hot / ${counts.warn} warn`}
           detail=${counts.stale > 0 ? `${counts.stale}개 키퍼가 ${Math.round(STALE_ACTIVITY_SEC / 60)}분 이상 정체 중입니다.` : '정체된 키퍼가 활동 임계값을 넘기지 않았습니다.'}
           tone=${toneForPressure(counts.hot, counts.warn)}
+        />
+        <${SummaryCard}
+          title="차단된 키퍼"
+          value=${counts.blocked.toString()}
+          detail=${counts.blocked > 0
+            ? '런타임은 살아있지만 typed blocker_class를 가진 키퍼 — 행 필터에서 blocker 클래스 이름으로 검색해 원인 확인.'
+            : '활성 차단 사유가 보고된 키퍼가 없습니다 (semaphore_wait_timeout, oas_timeout_budget 등).'}
+          tone=${counts.blocked > 0 ? 'warn' : 'ok'}
         />
         <${SummaryCard}
           title="도구 성공률"

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -721,5 +721,17 @@ export function summaryCounts(rows: FleetRow[]) {
     && row.last_activity_ago_s != null
     && row.last_activity_ago_s >= STALE_ACTIVITY_SEC,
   ).length
-  return { live, toolCovered, hot, warn, stale }
+  // 2026-05-05 fleet-stuck visibility: count keepers carrying a typed
+  // [runtime_blocker_class] (semaphore_wait_timeout, oas_timeout_budget,
+  // contract_violation, …).  These are alive-but-blocked keepers that
+  // the live/stale gauges miss — fiber is up, but the next turn cannot
+  // start.  Pairs with the `Semaphore_wait_timeout` typing fix
+  // (#12855) and the cascade fallback-cycle detector (#12866) so
+  // operators have a single panel that surfaces "alive but stuck".
+  const blocked = rows.filter(row =>
+    row.keepalive_running
+    && typeof row.runtime_blocker_class === 'string'
+    && row.runtime_blocker_class.trim() !== '',
+  ).length
+  return { live, toolCovered, hot, warn, stale, blocked }
 }


### PR DESCRIPTION
## Why — 시각화 마무리 (cycle 24, fleet-stuck investigation)

The 2026-05-05 fleet-stuck investigation produced three keeper-side fixes:

- **#12855** — `Semaphore_wait_timeout` skip path now writes `last_blocker_class = Some Autonomous_slot_wait_timeout` (was silent).
- **#12866** — `Cascade_config_loader.detect_fallback_cycles` catches circular `cascade.toml` configs (`big_three ↔ glm_coding_plan_only`).
- **#12873** — `keeper_turn_slot.ml` now records semaphore holders so the WARN names *which* peer is starving the queue.

All three populate `keeper.runtime_blocker_class` when keepers go silently stuck — but the fleet panel had no top-level card showing **"alive but stuck"** count.  Operators had to open each keeper's detail panel to see the value.

## What

- `summaryCounts` (`fleet-telemetry-utils.ts`) gains a `blocked` counter: `keepalive_running && runtime_blocker_class != null && trim() != ''`.
- `fleet-telemetry-panel.ts` adds a 5th `SummaryCard` in the top grid (grid-cols-4 → grid-cols-5):
  - **Title**: 차단된 키퍼
  - **Value**: blocked count
  - **Detail**: when 0 — *"활성 차단 사유가 보고된 키퍼가 없습니다 (semaphore_wait_timeout, oas_timeout_budget 등)"*; when >0 — *"런타임은 살아있지만 typed blocker_class를 가진 키퍼 — 행 필터에서 blocker 클래스 이름으로 검색"*.
  - **Tone**: warn when >0, ok when 0.

The existing row table already filters by `runtime_blocker_class` substring (`fleet-telemetry-panel.ts:80`), so operators can drill into specific blocker classes from the same panel.

## Risk

- 2 files, +22 -2 lines.  Pure presentational change; no backend or schema change.
- Grid layout: 4 → 5 columns at `xl` breakpoint; cards already responsive at `md` (2-col) and `sm` (1-col).
- New `blocked` field on the `summaryCounts` return is additive — no existing callers break.

## Validation

- `pnpm typecheck` was attempted but `tsc` is not available in worktree node_modules; will be verified by CI on this PR.
- Diff inspection: `summaryCounts` callers (lines 676, 247-265, 745-773) — all use destructured access so additive field is safe.
- Race-check 0 matches.

## References

- 2026-05-05 fleet-stuck diagnosis (companion PRs #12855, #12866, #12873 are the data sources this card surfaces)