### PR TITLE
feat(harness): validate model exists before toggling sangsu cascade

### DIFF
--- a/scripts/harness/workload/sangsu_bench_toggle.sh
+++ b/scripts/harness/workload/sangsu_bench_toggle.sh
@@ -78,8 +78,25 @@ case "$cmd" in
     ;;
   model)
     if [ -z "$arg" ]; then
-      echo "usage: sangsu_bench_toggle.sh model <ollama:model:tag>" >&2
+      echo "usage: sangsu_bench_toggle.sh model <ollama:model:tag> [--force]" >&2
       exit 2
+    fi
+    # Validate the model is actually pulled before mutating cascade.toml.
+    # Without this, a typo (e.g., `ollama:gemma:e2b` instead of
+    # `ollama:gemma4:e2b`) silently writes a bad cascade entry — the swap
+    # itself succeeds but sangsu's next turn fails at provider dispatch.
+    # Pass `--force` (any position after `model`) to bypass when offline.
+    bypass="false"
+    for a in "$@"; do
+      if [ "$a" = "--force" ]; then bypass="true"; fi
+    done
+    if [ "$bypass" != "true" ]; then
+      tag="${arg#ollama:}"  # strip "ollama:" prefix if present
+      if ! ollama list 2>/dev/null | awk 'NR>1 {print $1}' | grep -qx "$tag"; then
+        echo "FAIL: model '$tag' not found in ollama list" >&2
+        echo "      run \`ollama pull $tag\` first, or pass --force to bypass" >&2
+        exit 3
+      fi
     fi
     # Match the [ollama_bench] section's first models = [ ... ] block,
     # rewrite the single entry. Idempotent for our 1-slot profile.


### PR DESCRIPTION
## Summary

`sangsu_bench_toggle.sh model <tag>` previously accepted any string and wrote it straight into `cascade.toml`'s `[ollama_bench]` block. A typo like `ollama:gemma:e2b` instead of `ollama:gemma4:e2b` would silently succeed at the file-mutation level, but sangsu's next turn would then dispatch to a non-existent provider runner and either fall back to `local_recovery` or error out.

## Fix

Cross-check the requested tag against `ollama list` before mutating the file.

| Path | Behavior |
|---|---|
| existing tag | mutate cascade.toml, exit 0 |
| missing tag | print FAIL with the exact `ollama pull` command, exit 3, leave file untouched |
| `--force` (any position after `model`) | bypass validation — useful when pulling in another terminal or staging cascade ahead of time |

Validation strips the `ollama:` prefix before matching, so both `ollama:qwen3:8b` and `qwen3:8b` work.

## Test plan

- [x] `bash -n` syntax pass
- [x] Happy path with `ollama:qwen3:8b` → mutation, exit 0
- [x] Typo path with `ollama:nonexistent:99b` → FAIL message, exit 3, no mutation
- [x] Force bypass with `--force` → mutation despite missing model, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)