### PR TITLE
feat(keeper): raise autonomous concurrency cap 8 -> 16

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -82,10 +82,14 @@ let snapshot_holders ~label ~now =
    so they can stay responsive without consuming the full global pool.
    Default 3 = a conservative parallelism level for shared remote providers.
    Lower to 1 for single-slot local servers. For 8-slot servers,
-   MASC_KEEPER_AUTONOMOUS_CONCURRENCY=3-4 is a reasonable range. *)
+   MASC_KEEPER_AUTONOMOUS_CONCURRENCY=3-4 is a reasonable range.
+   The 16 cap accommodates fleets of 14+ keepers running on a single
+   workstation with abundant CPU and provider headroom (operator
+   judgement); below 16 is a safety net against runaway provider spend
+   during config typos, not a hard architectural ceiling. *)
 let autonomous_turn_limit =
   Keeper_config.int_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:3 ~min_v:1 ~max_v:8
+    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:3 ~min_v:1 ~max_v:16
 ;;
 
 let () =


### PR DESCRIPTION
## Why

14 keepers + cap 8 → queue depth 6 × avg turn 30-150s = wait 180-900s, blowing the 60s semaphore budget. Live 2026-05-04: 12-of-14 keepers accumulated 374-591 skips each over a few hours.

Cap moves 8 → 16. Default stays at 3.

## Trade-offs

- Operators with insufficient provider headroom can now overcommit; startup log records resolved+raw so blowups remain attributable.

## Out-of-scope

1. 174s inner Eio.Time.Timeout vs 600s outer wall_clock_timeout asymmetry — slot lifecycle redesign per #12863 out-of-scope.
2. Per-candidate cascade visibility for claude_code/gemini_cli/codex_cli — lands via #12864 once running server picks up merged code.
3. #12684 wake→no_signal gap — separate tracked issue.

## Test plan

- [x] `dune build lib/keeper/keeper_turn_slot.ml` clean
- [ ] CI green
- [ ] Operator: set `MASC_KEEPER_AUTONOMOUS_CONCURRENCY=14`, restart, confirm startup line reports 14 and bottom-6-keeper skip rate drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)