### PR TITLE
chore(dashboard): unexport 20 internal-only symbols across common/

### DIFF
--- a/dashboard/src/components/common/agent-capability.ts
+++ b/dashboard/src/components/common/agent-capability.ts
@@ -10,7 +10,7 @@
 
 import { html } from 'htm/preact'
 
-export interface ToolConfig {
+interface ToolConfig {
   icon: string
   label: string
   description: string

--- a/dashboard/src/components/common/agent-card.ts
+++ b/dashboard/src/components/common/agent-card.ts
@@ -11,14 +11,14 @@ import { AgentTrust, type TrustMetrics } from './agent-trust'
 import { AgentFailure, type FailureType } from './agent-failure'
 import { HumanInTheLoop, type ApprovalRequest } from './human-in-the-loop'
 
-export interface AgentFailureState {
+interface AgentFailureState {
   type: FailureType
   message: string
   retryCount?: number
   maxRetries?: number
 }
 
-export interface AgentCardAgent {
+interface AgentCardAgent {
   id: string
   name: string
   status: string | null | undefined

--- a/dashboard/src/components/common/agent-delegation.ts
+++ b/dashboard/src/components/common/agent-delegation.ts
@@ -7,7 +7,7 @@
 import { html } from 'htm/preact'
 import { AgentPresence } from './agent-presence'
 
-export interface DelegationNode {
+interface DelegationNode {
   agentId: string
   task: string
   status: 'pending' | 'active' | 'completed' | 'failed'

--- a/dashboard/src/components/common/agent-lifecycle.ts
+++ b/dashboard/src/components/common/agent-lifecycle.ts
@@ -6,7 +6,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 
-export interface LifecycleTransition {
+interface LifecycleTransition {
   from: string
   to: string
   label: string

--- a/dashboard/src/components/common/agent-output-announcer.ts
+++ b/dashboard/src/components/common/agent-output-announcer.ts
@@ -6,7 +6,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
 
-export interface AgentOutput {
+interface AgentOutput {
   id: string
   type: 'code' | 'text' | 'table' | 'error'
   content: string

--- a/dashboard/src/components/common/combobox.ts
+++ b/dashboard/src/components/common/combobox.ts
@@ -6,7 +6,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useId, useRef, useState } from 'preact/hooks'
 
-export interface ComboboxOption {
+interface ComboboxOption {
   value: string
   label: string
 }

--- a/dashboard/src/components/common/command-bar.ts
+++ b/dashboard/src/components/common/command-bar.ts
@@ -7,7 +7,7 @@
 import { html } from 'htm/preact'
 import { useMemo, useRef, useState } from 'preact/hooks'
 
-export interface CommandBarAction {
+interface CommandBarAction {
   id: string
   title: string
   keywords?: string

--- a/dashboard/src/components/common/data-flow-graph.ts
+++ b/dashboard/src/components/common/data-flow-graph.ts
@@ -4,7 +4,7 @@
 
 import { html } from 'htm/preact'
 
-export interface FlowNode {
+interface FlowNode {
   id: string
   label: string
   x: number
@@ -14,7 +14,7 @@ export interface FlowNode {
   color?: string
 }
 
-export interface FlowEdge {
+interface FlowEdge {
   source: string
   target: string
   value: number

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -14,7 +14,7 @@ interface ErrorBoundaryInfo {
 // retry. Adding `severity` keeps the existing default while letting callers
 // opt into the gentler recoverable framing, and the fatal default now also
 // carries an explicit reload button per spec.
-export type ErrorBoundarySeverity = 'recoverable' | 'fatal'
+type ErrorBoundarySeverity = 'recoverable' | 'fatal'
 
 interface Props {
   label?: string

--- a/dashboard/src/components/common/failure-history.ts
+++ b/dashboard/src/components/common/failure-history.ts
@@ -5,7 +5,7 @@
 
 import { html } from 'htm/preact'
 
-export interface FailureEntry {
+interface FailureEntry {
   id: string
   agentId: string
   errorType: string

--- a/dashboard/src/components/common/grid.ts
+++ b/dashboard/src/components/common/grid.ts
@@ -5,12 +5,12 @@
 import { html } from 'htm/preact'
 import { useCallback, useRef, useState } from 'preact/hooks'
 
-export interface GridColumn {
+interface GridColumn {
   key: string
   header: string
 }
 
-export interface GridRow {
+interface GridRow {
   id: string
   [key: string]: string
 }

--- a/dashboard/src/components/common/keeper-identity.ts
+++ b/dashboard/src/components/common/keeper-identity.ts
@@ -58,7 +58,7 @@ function extractGeneratedNicknamePrefix(name: string): string | null {
   return null
 }
 
-export function keeperNameFromAgentName(agentName: string | null | undefined): string | null {
+function keeperNameFromAgentName(agentName: string | null | undefined): string | null {
   const trimmed = trimmedOrNull(agentName)
   if (!trimmed) return null
 

--- a/dashboard/src/components/common/live-region.ts
+++ b/dashboard/src/components/common/live-region.ts
@@ -6,7 +6,7 @@
 
 import { html } from 'htm/preact'
 
-export interface LiveMessage {
+interface LiveMessage {
   id: string
   text: string
   priority: 'polite' | 'assertive'

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { InlineSpinner } from './inline-spinner'
 import type { MarkdownContent } from './markdown-renderer'
 
-export interface MarkdownProps {
+interface MarkdownProps {
   text: string
   class?: string
 }

--- a/dashboard/src/components/common/memory-graph.ts
+++ b/dashboard/src/components/common/memory-graph.ts
@@ -4,7 +4,7 @@
 
 import { html } from 'htm/preact'
 
-export interface MemoryNode {
+interface MemoryNode {
   id: string
   label: string
   x: number
@@ -12,7 +12,7 @@ export interface MemoryNode {
   color?: string
 }
 
-export interface MemoryEdge {
+interface MemoryEdge {
   source: string
   target: string
   label?: string

--- a/dashboard/src/components/common/pagination.ts
+++ b/dashboard/src/components/common/pagination.ts
@@ -12,7 +12,7 @@ import { useControllableState } from './use-controllable-state'
 
 type PageItem = number | 'ellipsis-start' | 'ellipsis-end'
 
-export interface PaginationProps {
+interface PaginationProps {
   page?: number
   defaultPage?: number
   totalPages: number


### PR DESCRIPTION
## Summary

Remove the `export` keyword from 20 symbols in
`dashboard/src/components/common/` that are referenced only inside
their own file — never imported by another module, never imported by
their own test, but still used internally so the declaration must
remain.

Net change: -20/+20 (public API surface shrinks by 20; line count
unchanged). Behavior unchanged because internal usage is preserved.

## Verification

For each symbol:
- `rg \b<sym>\b dashboard/src` excluding the file itself and its
  test → 0 hits
- `rg -c \b<sym>\b <file>` → > 1 (declaration + at least one
  internal use)

| File | Unexported |
|---|---|
| `agent-capability.ts` | `ToolConfig` |
| `agent-card.ts` | `AgentFailureState`, `AgentCardAgent` |
| `agent-delegation.ts` | `DelegationNode` |
| `agent-lifecycle.ts` | `LifecycleTransition` |
| `agent-output-announcer.ts` | `AgentOutput` |
| `combobox.ts` | `ComboboxOption` |
| `command-bar.ts` | `CommandBarAction` |
| `data-flow-graph.ts` | `FlowNode`, `FlowEdge` |
| `error-boundary.ts` | `ErrorBoundarySeverity` |
| `failure-history.ts` | `FailureEntry` |
| `grid.ts` | `GridColumn`, `GridRow` |
| `keeper-identity.ts` | `keeperNameFromAgentName` |
| `live-region.ts` | `LiveMessage` |
| `markdown.ts` | `MarkdownProps` |
| `memory-graph.ts` | `MemoryNode`, `MemoryEdge` |
| `pagination.ts` | `PaginationProps` |

## Why

These were unintended public-API surface points — types and helpers
that callers were never meant to depend on but were exposed because
the file declared them with `export`. Shrinking the surface makes
future refactors safer (no hidden cross-module consumers to break)
and matches the actual call graph.

If a future feature needs one of these symbols across module
boundaries, re-adding `export` is a one-line change.

## Test plan

- [x] Repo-wide grep for each symbol returns 0 external + 0 test hits
- [ ] Dashboard CI green on `Lint`, `Test`, `Build` (`tsc --noEmit`
      will still pass — symbols are used internally)

## Cleanup-pass running total (deletions only)

| PR | Scope | Lines |
|----|-------|-------|
| #12841 | deprecated `theme-hash` exports | -41 |
| #12845 | 4 orphan components | -811 |
| #12846 | 5 more orphan components | -1504 |
| #12854 | 4 orphan validation utilities | -547 |
| #12858 | 14 orphan hooks/utilities | -2001 |
| #12869 | `find-hardcoded-colors` | -105 |
| #12872 | 3 top-level modules | -974 |
| #12878 | transport-health schema (merged) | -571 |
| **Total** | | **-6554** |

This PR is a different shape (API surface shrink, not deletion) but
continues the same cleanup pass.