### PR TITLE
feat(dashboard): connect IDE activity & conversation rail to real APIs

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -4,12 +4,12 @@ import { render } from 'preact'
 import { IdeActivityMock } from './ide-activity-mock'
 
 describe('IdeActivityMock', () => {
-  it('renders the run activity store backed pane', () => {
+  it('renders the activity pane with fallback mock data', () => {
     const container = document.createElement('div')
     render(h(IdeActivityMock, {}), container)
 
     const region = container.querySelector('[role="region"]')
-    expect(region?.getAttribute('aria-label')).toBe('ACTIVITY THIS RUN (run activity store mock)')
+    expect(region?.getAttribute('aria-label')).toBe('ACTIVITY')
     expect(container.textContent).toContain('13 events · 3 keepers')
     expect(container.textContent).toContain('nick0cave')
     expect(container.textContent).toContain('flagged')

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -4,43 +4,145 @@ import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line
 import {
   createRunActivityStore,
   type RunActivityEvent,
+  type RunActivityVerb,
 } from './run-activity-store'
 
-const RUN_ID = 'run-47'
+const FALLBACK_ROOM_ID = 'run-fallback'
+const KIND_TO_VERB: Readonly<Record<string, RunActivityVerb>> = {
+  'task.created': 'noted',
+  'task.claimed': 'flagged',
+  'task.started': 'edited',
+  'task.released': 'noted',
+  'task.done': 'committed',
+  'task.cancelled': 'noted',
+  'task.submit_for_verification': 'noted',
+  'task.approved': 'approved',
+  'task.rejected': 'flagged',
+  'task.linked': 'noted',
+  'message.broadcast': 'commented on',
+  'message.mentioned': 'asked on',
+  'board.posted': 'noted',
+  'board.commented': 'commented on',
+  'board.voted': 'noted',
+  'board.deleted': 'noted',
+  'keeper.turn_completed': 'committed',
+  'keeper.contract_verdict': 'noted',
+  'keeper.friction': 'flagged',
+  'keeper.operator_broadcast_required': 'asked on',
+  'episode.flush': 'noted',
+}
+const DEFAULT_VERB: RunActivityVerb = 'noted'
+
+interface ApiActivityEvent {
+  readonly seq: number
+  readonly ts_ms: number
+  readonly ts_iso: string
+  readonly room_id: string
+  readonly kind: string
+  readonly actor?: { readonly kind: string; readonly id: string } | null
+  readonly subject?: { readonly kind: string; readonly id: string } | null
+  readonly payload?: unknown
+  readonly tags?: ReadonlyArray<string>
+}
+
+interface ApiActivityResponse {
+  readonly events?: ReadonlyArray<ApiActivityEvent>
+  readonly latest_seq?: number
+}
 
 const MOCK_ACTIVITY: ReadonlyArray<RunActivityEvent> = [
-  { id: 'a13', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 41, 18), keeper_id: 'nick0cave', verb: 'flagged', target: 'router.ts:34', detail: 'if:moonshot-tool-choice · blocker' },
-  { id: 'a12', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 40, 2), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:35', detail: '+ next.tool_choice = "auto"' },
-  { id: 'a11', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 39, 2), keeper_id: 'operator', verb: 'commented on', target: 'router.ts:26', detail: 'question · resolveCascade' },
-  { id: 'a10', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 37, 11), keeper_id: 'masc-improver', verb: 'edited', target: 'registry.ts:10', detail: '+8 -2 · budgetFor' },
-  { id: 'a09', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 35, 22), keeper_id: 'masc-improver', verb: 'committed', target: 'improver/wt-47', detail: 'fix: init budget map lazily' },
-  { id: 'a08', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 32, 8), keeper_id: 'masc-improver', verb: 'refactored', target: 'registry.ts', detail: 'extracted budgetFor' },
-  { id: 'a07', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 28, 15), keeper_id: 'operator', verb: 'commented on', target: 'registry.ts:10', detail: 'note · log.warn naming' },
-  { id: 'a06', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 22, 41), keeper_id: 'operator', verb: 'approved', target: 'router.ts:60', detail: 'nextStep · budget guard' },
-  { id: 'a05', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 18, 4), keeper_id: 'operator', verb: 'noted', target: 'router.ts:35', detail: 'flag · race on Map init' },
-  { id: 'a04', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 14, 52), keeper_id: 'masc-improver', verb: 'suggested on', target: 'router.ts:16', detail: 'suggest · extract helper' },
-  { id: 'a03', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 9, 11), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:34', detail: '+1 -0 · tool_choice guard' },
-  { id: 'a02', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 2, 11), keeper_id: 'operator', verb: 'flagged', target: 'registry.ts:10', detail: 'race condition' },
-  { id: 'a01', run_id: RUN_ID, timestamp_ms: Date.UTC(2026, 4, 2, 0, 58, 32), keeper_id: 'operator', verb: 'asked on', target: 'router.ts:26', detail: 'question · resolveCascade' },
+  { id: 'a13', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 41, 18), keeper_id: 'nick0cave', verb: 'flagged', target: 'router.ts:34', detail: 'if:moonshot-tool-choice · blocker' },
+  { id: 'a12', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 40, 2), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:35', detail: '+ next.tool_choice = "auto"' },
+  { id: 'a11', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 39, 2), keeper_id: 'operator', verb: 'commented on', target: 'router.ts:26', detail: 'question · resolveCascade' },
+  { id: 'a10', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 37, 11), keeper_id: 'masc-improver', verb: 'edited', target: 'registry.ts:10', detail: '+8 -2 · budgetFor' },
+  { id: 'a09', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 35, 22), keeper_id: 'masc-improver', verb: 'committed', target: 'improver/wt-47', detail: 'fix: init budget map lazily' },
+  { id: 'a08', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 32, 8), keeper_id: 'masc-improver', verb: 'refactored', target: 'registry.ts', detail: 'extracted budgetFor' },
+  { id: 'a07', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 28, 15), keeper_id: 'operator', verb: 'commented on', target: 'registry.ts:10', detail: 'note · log.warn naming' },
+  { id: 'a06', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 22, 41), keeper_id: 'operator', verb: 'approved', target: 'router.ts:60', detail: 'nextStep · budget guard' },
+  { id: 'a05', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 18, 4), keeper_id: 'operator', verb: 'noted', target: 'router.ts:35', detail: 'flag · race on Map init' },
+  { id: 'a04', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 14, 52), keeper_id: 'masc-improver', verb: 'suggested on', target: 'router.ts:16', detail: 'suggest · extract helper' },
+  { id: 'a03', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 9, 11), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:34', detail: '+1 -0 · tool_choice guard' },
+  { id: 'a02', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 2, 11), keeper_id: 'operator', verb: 'flagged', target: 'registry.ts:10', detail: 'race condition' },
+  { id: 'a01', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 0, 58, 32), keeper_id: 'operator', verb: 'asked on', target: 'router.ts:26', detail: 'question · resolveCascade' },
 ]
 
+function verbFromKind(kind: string): RunActivityVerb {
+  return KIND_TO_VERB[kind] ?? DEFAULT_VERB
+}
+
+function targetFromSubject(subject: ApiActivityEvent['subject']): string {
+  if (!subject) return ''
+  return `${subject.kind}:${subject.id}`
+}
+
+function detailFromPayload(payload: unknown, kind: string): string | undefined {
+  if (typeof payload === 'object' && payload !== null && !Array.isArray(payload)) {
+    const record = payload as Record<string, unknown>
+    const summary = record['summary'] ?? record['title'] ?? record['body'] ?? record['reason']
+    if (typeof summary === 'string' && summary.trim() !== '') {
+      const truncated = summary.length > 120 ? summary.slice(0, 117) + '...' : summary
+      return truncated
+    }
+  }
+  return kind
+}
+
+function mapApiEvent(event: ApiActivityEvent, roomId: string): RunActivityEvent {
+  return {
+    id: `evt-${event.seq}`,
+    run_id: roomId,
+    timestamp_ms: event.ts_ms,
+    keeper_id: event.actor?.id ?? 'system',
+    verb: verbFromKind(event.kind),
+    target: targetFromSubject(event.subject),
+    detail: detailFromPayload(event.payload, event.kind),
+  }
+}
+
+async function fetchActivityEvents(): Promise<{ events: ReadonlyArray<RunActivityEvent>; roomId: string }> {
+  try {
+    const res = await fetch('/api/v1/activity/events?limit=50')
+    if (!res.ok) return { events: MOCK_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+    const data: ApiActivityResponse = await res.json()
+    const rawEvents = data.events
+    if (!Array.isArray(rawEvents) || rawEvents.length === 0) {
+      return { events: MOCK_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+    }
+    const roomId = rawEvents[0].room_id || FALLBACK_ROOM_ID
+    const mapped = rawEvents.map(e => mapApiEvent(e, roomId))
+    return { events: mapped, roomId }
+  } catch {
+    return { events: MOCK_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+  }
+}
+
 export function IdeActivityMock() {
-  const activityStore = useMemo(() => {
-    const store = createRunActivityStore(RUN_ID)
+  const store = useMemo(() => {
+    const store = createRunActivityStore(FALLBACK_ROOM_ID)
     store.seed(MOCK_ACTIVITY)
     return store
   }, [])
   const [, forceRender] = useState(0)
 
-  useEffect(() => activityStore.subscribe(() => forceRender(tick => tick + 1)), [activityStore])
+  useEffect(() => {
+    let cancelled = false
+    fetchActivityEvents().then(({ events, roomId }) => {
+      if (cancelled) return
+      store.reset(roomId)
+      store.seed(events)
+    })
+    return () => { cancelled = true }
+  }, [store])
 
-  const events = activityStore.events()
-  const keepers = activityStore.knownKeepers()
+  useEffect(() => store.subscribe(() => forceRender(tick => tick + 1)), [store])
+
+  const events = store.events()
+  const keepers = store.knownKeepers()
 
   return html`
     <div
       role="region"
-      aria-label="ACTIVITY THIS RUN (run activity store mock)"
+      aria-label="ACTIVITY"
       style=${{
         display: 'flex',
         flexDirection: 'column',
@@ -74,13 +176,13 @@ export function IdeActivityMock() {
           overflow: 'auto',
         }}
       >
-        ${events.map(item => MockActivityRow(item))}
+        ${events.map(item => ActivityRow(item))}
       </ol>
     </div>
   `
 }
 
-function MockActivityRow(item: RunActivityEvent) {
+function ActivityRow(item: RunActivityEvent) {
   const hue = keeperHueIndex(item.keeper_id)
   const dot = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
   return html`

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -3,24 +3,23 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
-import { IDE_MOCK_RELATED_LINE, IDE_MOCK_THREADS } from './ide-mock-data'
 
 describe('IdeConversationRailMock', () => {
-  it('renders the RFC 0021 anchored thread rail mock', () => {
+  it('renders the conversation rail with board posts', () => {
     const container = document.createElement('div')
     render(h(IdeConversationRailMock, {}), container)
 
     const region = container.querySelector('[role="region"]')
-    expect(region?.getAttribute('aria-label')).toBe('CONVERSATION (RFC 0021 anchored thread rail mock)')
+    expect(region?.getAttribute('aria-label')).toBe('CONVERSATION')
     expect(container.textContent).toContain('CONVERSATION')
-    expect(container.textContent).toContain(String(IDE_MOCK_THREADS.length))
-    expect(container.textContent).toContain(`router.ts:${IDE_MOCK_RELATED_LINE}`)
-    expect(container.textContent).toContain('2 related')
+    expect(container.textContent).toContain('5')
     expect(container.textContent).toContain('FLAG')
     expect(container.textContent).toContain('nick0cave')
+    expect(container.textContent).toContain('operator')
+    expect(container.textContent).toContain('masc-improver')
   })
 
-  it('focuses a thread card when clicked', async () => {
+  it('focuses a post card when clicked', async () => {
     const container = document.createElement('div')
     await act(async () => {
       render(h(IdeConversationRailMock, {}), container)
@@ -32,5 +31,14 @@ describe('IdeConversationRailMock', () => {
       button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(button?.getAttribute('aria-current')).toBe('true')
+  })
+
+  it('shows kind labels from board post content', () => {
+    const container = document.createElement('div')
+    render(h(IdeConversationRailMock, {}), container)
+
+    expect(container.textContent).toContain('APPROVE')
+    expect(container.textContent).toContain('SUGGEST')
+    expect(container.textContent).toContain('QUESTION')
   })
 })

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -2,15 +2,26 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import {
-  createAnchoredThreadRailStore,
-  type AnchoredThread,
-  type ThreadKind,
-} from './anchored-thread-rail-store'
-import {
   IDE_MOCK_FILE_PATH,
   IDE_MOCK_RELATED_LINE,
   IDE_MOCK_THREADS,
 } from './ide-mock-data'
+import type { AnchoredThread, ThreadKind } from './anchored-thread-rail-store'
+
+interface BoardPost {
+  readonly id: string
+  readonly title: string
+  readonly body: string
+  readonly author_identity: string
+  readonly votes: number
+  readonly comment_count: number
+  readonly created_at_iso: string
+  readonly hearth?: string | null
+}
+
+interface BoardListResponse {
+  readonly posts?: ReadonlyArray<BoardPost>
+}
 
 const KIND_LABEL: Record<ThreadKind, string> = {
   flag: 'FLAG',
@@ -28,25 +39,55 @@ const KIND_TOKEN: Record<ThreadKind, string> = {
   suggest: 'var(--color-status-warn, var(--warn))',
 }
 
+const FALLBACK_POSTS: ReadonlyArray<BoardPost> = [
+  { id: 'p-mock-1', title: '', body: "flag: tool schema edge we're seeing in prod - keep tools[] and tool_choice paired.", author_identity: 'nick0cave', votes: 2, comment_count: 2, created_at_iso: '2026-05-02T01:41:18Z' },
+  { id: 'p-mock-2', title: '', body: 'Should normalizeTools also handle tool_choice=none? feels like an edge case.', author_identity: 'operator', votes: 0, comment_count: 1, created_at_iso: '2026-05-02T01:39:02Z' },
+  { id: 'p-mock-3', title: '', body: 'Budget guard reads well. Ship it when tests pass.', author_identity: 'operator', votes: 1, comment_count: 0, created_at_iso: '2026-05-02T01:22:41Z' },
+  { id: 'p-mock-4', title: '', body: 'telemetry event name needs to match the lifeline schema - will rename later.', author_identity: 'operator', votes: 0, comment_count: 0, created_at_iso: '2026-05-02T01:18:04Z' },
+  { id: 'p-mock-5', title: '', body: 'Could you collapse the rest-spread into a small helper? Same pattern appears in provider.ts.', author_identity: 'masc-improver', votes: 0, comment_count: 3, created_at_iso: '2026-05-02T01:14:52Z' },
+]
+
+async function fetchBoardPosts(): Promise<ReadonlyArray<BoardPost>> {
+  try {
+    const res = await fetch('/api/v1/board?limit=20&exclude_system=true&exclude_automation=true')
+    if (!res.ok) return FALLBACK_POSTS
+    const data = await res.json()
+    if (Array.isArray(data) && data.length > 0) return data as BoardPost[]
+    return FALLBACK_POSTS
+  } catch {
+    return FALLBACK_POSTS
+  }
+}
+
+function parseIsoToMs(iso: string): number {
+  return new Date(iso).getTime()
+}
+
+function boardKindFromPost(post: BoardPost): ThreadKind {
+  const body = (post.body ?? '').toLowerCase()
+  const title = (post.title ?? '').toLowerCase()
+  const text = `${title} ${body}`
+  if (text.includes('approve') || text.includes('ship it') || text.includes('looks good')) return 'approve'
+  if (text.includes('flag') || text.includes('blocker') || text.includes('race condition')) return 'flag'
+  if (text.includes('suggest') || text.includes('could you') || text.includes('recommend')) return 'suggest'
+  if (text.includes('?') || text.includes('question') || text.includes('should')) return 'question'
+  return 'note'
+}
+
 export function IdeConversationRailMock() {
-  const railStore = useMemo(() => {
-    const store = createAnchoredThreadRailStore(IDE_MOCK_FILE_PATH)
-    store.seed(IDE_MOCK_THREADS)
-    return store
+  const [posts, setPosts] = useState<ReadonlyArray<BoardPost>>(FALLBACK_POSTS)
+  const [focusedId, setFocusedId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchBoardPosts().then(data => { if (!cancelled) setPosts(data) })
+    return () => { cancelled = true }
   }, [])
-  const [, forceRender] = useState(0)
-
-  useEffect(() => railStore.subscribe(() => forceRender(tick => tick + 1)), [railStore])
-
-  const threads = railStore.visibleThreads()
-  const focusedId = railStore.focusedThreadId()
-  const relatedThreads = railStore.threadsForLine(IDE_MOCK_RELATED_LINE)
-  const relatedFile = IDE_MOCK_FILE_PATH.split('/').at(-1) ?? IDE_MOCK_FILE_PATH
 
   return html`
     <div
       role="region"
-      aria-label="CONVERSATION (RFC 0021 anchored thread rail mock)"
+      aria-label="CONVERSATION"
       style=${{
         display: 'flex',
         flexDirection: 'column',
@@ -66,20 +107,7 @@ export function IdeConversationRailMock() {
         }}
       >
         <span>CONVERSATION</span>
-        <span>${threads.length}</span>
-      </div>
-      <div
-        style=${{
-          display: 'flex',
-          gap: 'var(--sp-2)',
-          padding: 'var(--sp-2) var(--sp-3) 0',
-          color: 'var(--color-fg-muted)',
-          fontSize: 'var(--fs-11)',
-        }}
-      >
-        <span>${relatedFile}:${IDE_MOCK_RELATED_LINE}</span>
-        <span>·</span>
-        <span>${relatedThreads.length} related</span>
+        <span>${posts.length}</span>
       </div>
       <ol
         style=${{
@@ -92,26 +120,26 @@ export function IdeConversationRailMock() {
           overflow: 'auto',
         }}
       >
-        ${threads.map(thread => MockThreadCard(
-          thread,
-          focusedId === thread.id,
-          () => railStore.focusThread(thread.id),
+        ${posts.map(post => PostCard(
+          post,
+          focusedId === post.id,
+          () => setFocusedId(focusedId === post.id ? null : post.id),
         ))}
       </ol>
     </div>
   `
 }
 
-function MockThreadCard(thread: AnchoredThread, focused: boolean, onFocus: () => void) {
-  const kindColor = KIND_TOKEN[thread.kind]
-  const keeperSlot = keeperHueIndex(thread.author_keeper_id)
+function PostCard(post: BoardPost, focused: boolean, onFocus: () => void) {
+  const kind = boardKindFromPost(post)
+  const kindColor = KIND_TOKEN[kind]
+  const keeperSlot = keeperHueIndex(post.author_identity)
   const keeperColor = `var(--color-keeper-${keeperSlot}-glow, var(--k-${keeperSlot}))`
+  const createdMs = parseIsoToMs(post.created_at_iso)
+  const bodyText = post.body || post.title || ''
+
   return html`
-    <li
-      style=${{
-        display: 'block',
-      }}
-    >
+    <li style=${{ display: 'block' }}>
       <button
         type="button"
         aria-current=${focused ? 'true' : undefined}
@@ -132,34 +160,25 @@ function MockThreadCard(thread: AnchoredThread, focused: boolean, onFocus: () =>
         }}
       >
         <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--sp-2)' }}>
-          <span style=${{ fontSize: 'var(--fs-11)', color: kindColor, letterSpacing: '0.05em' }}>${KIND_LABEL[thread.kind]}</span>
-          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${thread.author_keeper_id}</span>
-          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${formatThreadTime(thread.created_ms)}</span>
+          <span style=${{ fontSize: 'var(--fs-11)', color: kindColor, letterSpacing: '0.05em' }}>${KIND_LABEL[kind]}</span>
+          <span style=${{ fontSize: 'var(--fs-11)', color: keeperColor }}>${post.author_identity}</span>
+          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${formatThreadTime(createdMs)}</span>
         </div>
-        <div style=${{ display: 'flex', gap: 'var(--sp-2)', fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
-          <span>${anchorLabel(thread)}</span>
-          ${thread.anchor.symbol_hint
-            ? html`<span>·</span><span>${thread.anchor.symbol_hint}</span>`
-            : null}
-        </div>
-        <p style=${{ font: 'var(--type-body)', color: 'var(--color-fg-secondary)', margin: 0 }}>${thread.body}</p>
+        ${post.hearth ? html`
+          <div style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
+            ${post.hearth}
+          </div>
+        ` : null}
+        <p style=${{ font: 'var(--type-body)', color: 'var(--color-fg-secondary)', margin: 0 }}>${bodyText}</p>
         <div style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
-          ${thread.reply_count > 0 ? `${thread.reply_count} replies · ` : ''}${thread.resolved ? 'resolved' : 'open'}
+          ${post.comment_count > 0 ? `${post.comment_count} replies · ` : ''}${post.votes > 0 ? `${post.votes} votes` : ''}
         </div>
       </button>
     </li>
   `
 }
 
-function anchorLabel(thread: AnchoredThread): string {
-  const fileName = thread.anchor.file_path.split('/').at(-1) ?? thread.anchor.file_path
-  const start = thread.anchor.line_start
-  const end = thread.anchor.line_end
-  if (start === null || end === null) return fileName
-  if (start === end) return `${fileName}:${start}`
-  return `${fileName}:${start}-${end}`
-}
-
 function formatThreadTime(ms: number): string {
+  if (!Number.isFinite(ms)) return ''
   return new Date(ms).toISOString().slice(11, 19)
 }


### PR DESCRIPTION
## Summary
- Activity panel (`ide-activity-mock.ts`): Replace hardcoded mock events with `/api/v1/activity/events?limit=50` fetch, mapping activity graph event kinds to RunActivityVerb via `KIND_TO_VERB` lookup table. Falls back to mock data on API failure.
- Conversation rail (`ide-conversation-rail-mock.ts`): Replace AnchoredThread store with direct `/api/v1/board` fetch. Board posts lack file/line anchors required by `AnchoredThreadRailStore`, so posts render directly with text-based kind classification (`boardKindFromPost`).
- Both components updated with `useEffect` fetch-on-mount, cleanup on unmount, and mock fallback.

## Test plan
- [x] `vitest` — 43/43 tests pass (5 file-level failures from pre-existing lucide-preact mocking issue)
- [x] `curl /api/v1/activity/events?limit=50` returns mapped events
- [x] `curl /api/v1/board?limit=20` returns board posts
- [ ] Dashboard `#code?section=ide-shell` — ACTIVITY pane shows live events
- [ ] Dashboard `#code?section=ide-shell` — CONVERSATION rail shows live board posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)