### PR TITLE
fix(keeper): release current_task_id on supervisor auto-pause (Task-138)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -907,6 +907,22 @@ let handle_crash_auto_pause (ctx : _ context)
          | Some cls -> blocker_class_to_string cls
          | None -> reason_tag
        in
+       (* Task-138 §"Max no-task-progress 30min = release claimed":
+          when the supervisor pauses a keeper because the same blocker
+          class is looping (stale_storm or oas_timeout_budget_loop),
+          the keeper is no longer making progress on its claimed task.
+          Releasing [current_task_id] here lets a peer pick the task
+          up while this keeper sits in [paused=true] back-off.
+
+          Without this release the diagnostic state is "executor.json:
+          current_task_id=task-147, paused=true, last_blocker_class=
+          oas_timeout_budget" — task is stuck forever because (a) this
+          keeper cannot run while paused and (b) other keepers see the
+          claim and skip.  The released task ID is not separately audited
+          here; [last_blocker_class] + [last_blocker] in [runtime] already
+          carry the pause reason, and Prometheus
+          [keeper_paused_total] is incremented below.
+          Discovered 2026-05-05 fleet-stuck. *)
        (match
           write_meta_with_merge
             ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
@@ -915,6 +931,7 @@ let handle_crash_auto_pause (ctx : _ context)
               paused = true;
               auto_resume_after_sec;
               updated_at = now_iso ();
+              current_task_id = None;
               runtime =
                 { meta.runtime with
                   last_blocker = blocker_text;


### PR DESCRIPTION
## Summary
- `handle_crash_auto_pause` now resets `current_task_id = None` when persisting `paused = true`, so a stale_storm/oas_timeout_budget pause does not leave a task claim that no peer can pick up.
- Audit signal stays in `runtime.last_blocker_class` + `runtime.last_blocker`; no schema change to `keeper_meta`.

## Why
Fleet-stuck repro on 2026-05-05 (executor.json):
```
current_task_id   = task-147
paused            = true
last_blocker_class = oas_timeout_budget
last_latency_ms   = 600089
```
Task-147 sat idle ~10 minutes:
- the paused keeper cannot run the claim,
- peers see the claim and skip.

This is the silent path Task-138 calls out under §"Max no-task-progress 30min = release claimed". Cycle 25 of the fleet-stuck reaction-chain plan; closes the last keeper-side leak after #12855 (last_blocker_class on slot timeout), #12866 (cascade circular fallback detector), #12873 (keeper_turn_slot holder identity), and #12877 (dashboard blocked-keeper card).

## Test plan
- [x] `dune build @check -j 8` clean on rebased branch (origin/main = c14c6847fe).
- [ ] Post-merge: rebuild + restart `bin/main_eio.exe`, observe `current_task_id` clears on next supervisor auto-pause cycle (tail `~/me/.masc/keepers/<name>.json`).
- [ ] Confirm `keeper_paused_total{reason="stale_storm"}` still increments alongside the cleared claim.

## Risk
Low — single-field reset, type-checked diff, no behavior change when `current_task_id = None` already. Restart cost ≈ rebuild only.