### PR TITLE
feat(dashboard): keeper-aware workspace tree + file routes

### DIFF
--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { useMemo, useState, useEffect } from 'preact/hooks'
+import { activeKeeperName } from '../../keeper-state'
 import { activeIdeFile } from './ide-shell'
 import {
   createCodeDocumentStore,
@@ -154,10 +155,14 @@ export function IdeEditorMock({
   activeLayers = EMPTY_ACTIVE_LAYERS,
 }: IdeEditorMockProps) {
   const [sourceCode, setSourceCode] = useState<string[]>([])
-  
+  const [keeperName, setKeeperName] = useState(activeKeeperName.value)
+  useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
+
   useEffect(() => {
     let canceled = false;
-    fetch('/api/v1/workspace/file?path=' + encodeURIComponent(activeIdeFile.value))
+    const params = new URLSearchParams({ path: activeIdeFile.value })
+    if (keeperName) params.set('keeper', keeperName)
+    fetch('/api/v1/workspace/file?' + params.toString())
       .then(r => r.json())
       .then(d => {
         if (!canceled && d.ok && d.content) {
@@ -166,7 +171,7 @@ export function IdeEditorMock({
       })
       .catch(console.error);
     return () => { canceled = true };
-  }, [activeIdeFile.value]);
+  }, [activeIdeFile.value, keeperName]);
 
   const documentStore = useMemo(
     () => createCodeDocumentStore({

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
+import { activeKeeperName } from '../../keeper-state'
 import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
 import { activeIdeFile } from './ide-shell'
 
@@ -23,9 +24,11 @@ const FALLBACK_SEED: ReadonlyArray<FileTreeNode> = [
   { path: 'README.md', label: 'README.md', depth: 0, parent: null, hasChildren: false, diff: null, keeperId: null, hueIndex: null },
 ]
 
-async function fetchTree(depth = 3): Promise<FileTreeNode[]> {
+async function fetchTree(depth = 3, keeper = ''): Promise<FileTreeNode[]> {
   try {
-    const res = await fetch(`/api/v1/workspace/tree?depth=${depth}`)
+    const params = new URLSearchParams({ depth: String(depth) })
+    if (keeper) params.set('keeper', keeper)
+    const res = await fetch(`/api/v1/workspace/tree?${params.toString()}`)
     if (!res.ok) return FALLBACK_SEED
     const data = await res.json()
     if (!Array.isArray(data) || data.length === 0) return FALLBACK_SEED
@@ -40,11 +43,14 @@ export function IdeExplorer() {
     return s
   }, [])
 
+  const [keeperName, setKeeperName] = useState(activeKeeperName.value)
+  useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
+
   useEffect(() => {
     let cancelled = false
-    fetchTree().then(nodes => { if (!cancelled) store.seed(nodes) })
+    fetchTree(3, keeperName).then(nodes => { if (!cancelled) store.seed(nodes) })
     return () => { cancelled = true }
-  }, [store])
+  }, [store, keeperName])
 
   const [tick, setTick] = useState(0)
   useEffect(() => {
@@ -82,7 +88,7 @@ export function IdeExplorer() {
           borderBottom: '1px solid var(--color-border-divider)',
         }}
       >
-        <span>EXPLORER</span>
+        <span>EXPLORER ${keeperName ? html`· <span style=${{ color: 'var(--color-accent-fg)' }}>@${keeperName}</span>` : '· project'}</span>
         <span>${fileCount} FILES</span>
       </header>
       <ul

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -6,6 +6,38 @@ module Http = Http_server_eio
 
 let base_path_of_state state = state.Mcp_server.room_config.base_path
 
+(* Resolve the workspace base directory for tree/file reads.
+
+   Without [?keeper=<name>] the project root from [base_path_of_state]
+   is used (single shared workspace). With a keeper name the keeper's
+   private workspace root (sandbox playground) is resolved via
+   [Keeper_sandbox.host_root_abs_of_meta] and validated for existence.
+
+   Unknown keeper / missing meta / non-existent playground silently
+   fall back to the project root so the IDE always renders something
+   and never depends on disk state to render a tree. The boolean
+   return signals whether the requested keeper's playground was
+   actually found, so callers can surface "playground 없음" hints
+   without leaking the resolved absolute path back to the client. *)
+let resolve_workspace_base ~state ~uri =
+  let project_base = base_path_of_state state in
+  match Uri.get_query_param uri "keeper" with
+  | None | Some "" -> (project_base, `Project)
+  | Some keeper_name ->
+    let trimmed = String.trim keeper_name in
+    if trimmed = "" then (project_base, `Project)
+    else
+      let config = state.Mcp_server.room_config in
+      match Keeper_types.read_meta config trimmed with
+      | Ok (Some m) ->
+        let playground =
+          Keeper_sandbox.host_root_abs_of_meta ~config m
+        in
+        if Sys.file_exists playground && Sys.is_directory playground
+        then (playground, `Playground trimmed)
+        else (project_base, `PlaygroundMissing trimmed)
+      | _ -> (project_base, `KeeperUnknown trimmed)
+
 let json_error message =
   `Assoc [("ok", `Bool false); ("error", `String message)]
 
@@ -233,8 +265,8 @@ let add_routes router =
   |> Http.Router.get "/api/v1/workspace/tree" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
-           let base = base_path_of_state state in
            let uri = Uri.of_string request.target in
+           let base, _source = resolve_workspace_base ~state ~uri in
            let depth =
              match Uri.get_query_param uri "depth" with
              | Some d -> (try max 1 (min 5 (int_of_string d)) with _ -> 3)
@@ -251,8 +283,8 @@ let add_routes router =
   |> Http.Router.get "/api/v1/workspace/file" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
-           let base = base_path_of_state state in
            let uri = Uri.of_string request.target in
+           let base, _source = resolve_workspace_base ~state ~uri in
            match Uri.get_query_param uri "path" with
            | None -> json_response ~status:`Bad_request request reqd (json_error "Missing path parameter")
            | Some p ->


### PR DESCRIPTION
## Summary

Per-keeper IDE awareness — Explorer/Editor reflect the active keeper's playground (sandbox working directory) instead of always showing the single shared project workspace.

- Backend: `/api/v1/workspace/tree` + `/api/v1/workspace/file` accept optional `?keeper=<name>` query. When present, base path resolves to the keeper's `host_root_abs_of_meta` (private workspace root). When absent / unknown / missing, falls back to the project root so the IDE always renders something.
- Frontend: `IdeExplorer` + `IdeEditorMock` subscribe to `activeKeeperName` signal and refetch with the param when the active keeper changes. Explorer header surfaces `EXPLORER · @<keeper>` or `EXPLORER · project` so the active workspace is visible.

Response shapes unchanged (array for tree, `{ok, content}` for file) — this is non-breaking on the wire.

## Why

Audit reference: `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md`. Single workspace tree was confusing once multiple keepers were operating in their own playgrounds — file changes a keeper made were invisible because the IDE was reading from the project root.

## Test plan

- [x] `dune build --build-dir=_build_iso lib/masc_mcp.cma` from worktree (isolated to avoid cross-session `_build` corruption) — green
- [x] `pnpm lint src/components/ide/ide-explorer.ts src/components/ide/ide-editor-mock.ts` — 0 errors on changed files
- [x] `pnpm typecheck` — no new errors introduced (pre-existing TS errors in main also fail there)
- [ ] Manual smoke: select a keeper in dashboard, verify tree refetches with playground content
- [ ] Manual smoke: empty / unknown keeper falls back to project tree

## Out of scope

- `/api/v1/git/blame` and `/api/v1/git/diff` still operate on the project repo. Per-keeper blame/diff requires a separate plan since playgrounds may not be git repos.
- Backend tests for `resolve_workspace_base` branches (Project / Playground / PlaygroundMissing / KeeperUnknown) — follow-up.
- Empty-state UI when the resolved playground is empty (currently silently shows fallback seed). Follow-up.