### PR TITLE
fix(dashboard): restore transport-health schema and clean IDE typecheck

### DIFF
--- a/dashboard/src/api/schemas/transport-health.test.ts
+++ b/dashboard/src/api/schemas/transport-health.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseTransportHealthData,
+  TransportHealthSchemaDriftError,
+} from './transport-health'
+
+describe('parseTransportHealthData', () => {
+  const minimalValid = {
+    summary: {},
+    sse: {},
+    grpc: {},
+    websocket: {},
+    webrtc: {},
+    streamable_http: {},
+    http2: {},
+    cluster: {},
+    agent_health: {},
+    generated_at: '2024-01-01T00:00:00Z',
+  }
+
+  it('parses minimal valid data with all fallback defaults', () => {
+    const result = parseTransportHealthData(minimalValid)
+    expect(result.generated_at).toBe('2024-01-01T00:00:00Z')
+    expect(result.summary.primary_path).toBe('unknown')
+    expect(result.summary.recent_messages).toBeNull()
+    expect(result.summary.recent_messages_available).toBe(false)
+    expect(result.summary.external_fanout_targets).toBe(0)
+    expect(result.sse.sessions_total).toBe(0)
+    expect(result.sse.hot_sessions).toEqual([])
+    expect(result.grpc.enabled).toBe(false)
+    expect(result.grpc.port).toBe(0)
+    expect(result.websocket.mode).toBe('unknown')
+    expect(result.websocket.delivery.parse_cache_hits).toBe(0)
+    expect(result.webrtc.signaling_mode).toBe('unknown')
+    expect(result.streamable_http.endpoint).toBe('/mcp')
+    expect(result.http2.listener_mode).toBe('unknown')
+    expect(result.cluster.cluster).toBe('default')
+    expect(result.cluster.total_units).toBeNull()
+    expect(result.agent_health.stale_total).toBe(0)
+    expect(result.projection_diagnostics).toBeUndefined()
+  })
+
+  it('throws TransportHealthSchemaDriftError when generated_at is empty', () => {
+    expect(() =>
+      parseTransportHealthData({
+        ...minimalValid,
+        generated_at: '',
+      }),
+    ).toThrow(TransportHealthSchemaDriftError)
+  })
+
+  it('throws TransportHealthSchemaDriftError when generated_at is missing', () => {
+    const { generated_at: _, ...missing } = minimalValid
+    expect(() => parseTransportHealthData(missing)).toThrow(
+      TransportHealthSchemaDriftError,
+    )
+  })
+
+  it('throws TransportHealthSchemaDriftError when a required subsection is missing', () => {
+    const { grpc: _, ...missingGrpc } = minimalValid
+    expect(() => parseTransportHealthData(missingGrpc)).toThrow(
+      TransportHealthSchemaDriftError,
+    )
+  })
+
+  it('parses hot_sessions filtering invalid entries', () => {
+    const result = parseTransportHealthData({
+      ...minimalValid,
+      sse: {
+        hot_sessions: [
+          { session_id: 's1', kind: 'observer' },
+          { session_id: 's2' },
+          'invalid',
+          { session_id: 's3', kind: 'coordinator', queue_depth: 5 },
+        ],
+      },
+    })
+    expect(result.sse.hot_sessions).toHaveLength(3)
+    expect(result.sse.hot_sessions[0]).toEqual({
+      session_id: 's1',
+      kind: 'observer',
+      queue_depth: 0,
+      last_event_id: 0,
+      idle_seconds: 0,
+    })
+    expect(result.sse.hot_sessions[1]).toEqual({
+      session_id: 's2',
+      kind: 'unknown',
+      queue_depth: 0,
+      last_event_id: 0,
+      idle_seconds: 0,
+    })
+    expect(result.sse.hot_sessions[2]).toEqual({
+      session_id: 's3',
+      kind: 'coordinator',
+      queue_depth: 5,
+      last_event_id: 0,
+      idle_seconds: 0,
+    })
+  })
+
+  it('returns empty hot_sessions for non-array input', () => {
+    const result = parseTransportHealthData({
+      ...minimalValid,
+      sse: { hot_sessions: 'not-array' },
+    })
+    expect(result.sse.hot_sessions).toEqual([])
+  })
+
+  it('parses projection_diagnostics when present', () => {
+    const result = parseTransportHealthData({
+      ...minimalValid,
+      projection_diagnostics: {
+        source: 'test-source',
+        cache_state: 'warm',
+        last_success_at: '2024-01-01T00:00:00Z',
+        stale_reason: null,
+      },
+    })
+    expect(result.projection_diagnostics).toBeDefined()
+    expect(result.projection_diagnostics?.source).toBe('test-source')
+    expect(result.projection_diagnostics?.cache_state).toBe('warm')
+    expect(result.projection_diagnostics?.last_success_at).toBe('2024-01-01T00:00:00Z')
+    expect(result.projection_diagnostics?.last_attempt_at).toBeNull()
+    expect(result.projection_diagnostics?.last_error_at).toBeNull()
+    expect(result.projection_diagnostics?.stale_reason).toBeNull()
+    expect(result.projection_diagnostics?.stale_age_ms).toBeNull()
+  })
+
+  it('parses populated subsection fields', () => {
+    const result = parseTransportHealthData({
+      summary: {
+        primary_path: '/events',
+        queue_pressure: 'low',
+        recent_messages: 42,
+        recent_messages_available: true,
+        recent_messages_source: 'memory',
+        external_fanout_targets: 3,
+      },
+      sse: {
+        sessions_observer: 1,
+        sessions_coordinator: 2,
+        sessions_presence: 3,
+        sessions_total: 6,
+        external_subscribers: 10,
+        broadcast_avg_seconds: 0.5,
+        broadcast_count: 100,
+        queue_avg_depth: 2,
+        queue_max_depth: 10,
+        relay_queue_depth: 0,
+        relay_retry_total: 1,
+        relay_retry_append: 0,
+        relay_retry_broadcast: 1,
+        relay_drop_total: 0,
+        relay_drop_queue: 0,
+        relay_drop_append: 0,
+        relay_drop_broadcast: 0,
+      },
+      grpc: {
+        enabled: true,
+        configured: true,
+        listening: true,
+        port: 50051,
+        active_streams: 5,
+        subscribers: 3,
+        heartbeat_avg_seconds: 30,
+        events_delivered: 1000,
+        events_dropped: 2,
+      },
+      websocket: {
+        enabled: true,
+        configured: true,
+        listening: true,
+        mode: 'relay',
+        port: 8080,
+        sessions: 15,
+        relay_source: 'sse',
+        delivery: {
+          parse_cache_hits: 100,
+          parse_cache_misses: 5,
+          bytes_cache_hits: 200,
+          bytes_cache_misses: 10,
+          client_acks: 95,
+          throttled_deliveries: 2,
+          client_buffered_bytes_sum: 1024,
+          client_buffered_bytes_count: 10,
+        },
+      },
+      webrtc: {
+        enabled: true,
+        configured: true,
+        signaling_available: true,
+        signaling_mode: 'auto',
+        pending_offers: 0,
+        active_peers: 4,
+        live_connections: 2,
+        connected_channels: 2,
+        ice_server_count: 3,
+      },
+      streamable_http: {
+        endpoint: '/mcp',
+        observer_stream: '/mcp?sse_kind=observer',
+        presence_stream: '/events/presence',
+        managed_endpoint: '/mcp/managed',
+        operator_endpoint: '/mcp/operator',
+        delete_endpoint: '/mcp',
+        legacy_sse_endpoint: '/sse',
+        legacy_messages_endpoint: '/messages',
+        default_transport: 'streamable_http',
+        supports_post: true,
+        supports_sse_upgrade: true,
+        supports_delete: true,
+      },
+      http2: {
+        listener_mode: 'prior_knowledge',
+        multiplex_ready: true,
+        prior_knowledge_path: '/mcp',
+      },
+      cluster: {
+        cluster: 'alpha',
+        room_id: 'room-1',
+        topology_available: true,
+        topology_source: 'consul',
+        total_units: 10,
+        managed_units: 8,
+        live_agents: 6,
+        active_operations: 4,
+        stale_units: 0,
+      },
+      agent_health: {
+        stale_total: 0,
+        lifecycle_dispatch_rejections_total: 1,
+      },
+      generated_at: '2024-01-01T00:00:00Z',
+    })
+
+    expect(result.summary.primary_path).toBe('/events')
+    expect(result.summary.recent_messages).toBe(42)
+    expect(result.sse.sessions_total).toBe(6)
+    expect(result.sse.broadcast_avg_seconds).toBe(0.5)
+    expect(result.grpc.port).toBe(50051)
+    expect(result.grpc.events_delivered).toBe(1000)
+    expect(result.websocket.mode).toBe('relay')
+    expect(result.websocket.delivery.client_acks).toBe(95)
+    expect(result.webrtc.active_peers).toBe(4)
+    expect(result.streamable_http.default_transport).toBe('streamable_http')
+    expect(result.http2.multiplex_ready).toBe(true)
+    expect(result.cluster.cluster).toBe('alpha')
+    expect(result.cluster.total_units).toBe(10)
+    expect(result.agent_health.lifecycle_dispatch_rejections_total).toBe(1)
+  })
+
+  it('parses nullable cluster fields as null when explicitly null', () => {
+    const result = parseTransportHealthData({
+      ...minimalValid,
+      cluster: {
+        total_units: null,
+        managed_units: null,
+        live_agents: null,
+        active_operations: null,
+        stale_units: null,
+      },
+    })
+    expect(result.cluster.total_units).toBeNull()
+    expect(result.cluster.managed_units).toBeNull()
+    expect(result.cluster.live_agents).toBeNull()
+    expect(result.cluster.active_operations).toBeNull()
+    expect(result.cluster.stale_units).toBeNull()
+  })
+})

--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -1,0 +1,301 @@
+// Transport health schema — schema-at-boundary for
+// `GET /api/v1/dashboard/transport-health`.
+//
+// The largest endpoint on the dashboard: 10 nested transport surfaces
+// (summary, sse, grpc, websocket, webrtc, streamable_http, http2,
+// cluster, agent_health, plus optional projection_diagnostics). The
+// prior hand-rolled decoder returned `null` if ANY of the 9 required
+// subsections or `generated_at` was missing — this PR preserves that
+// contract via the thin null-returning wrapper in `api/transport-health.ts`.
+//
+// Uses the shared `SchemaDriftError` base landed in #7732.
+
+import {
+  boolean,
+  check,
+  fallback,
+  nullable,
+  number,
+  object,
+  optional,
+  pipe,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
+
+// --- Hot session (per-entry lenient in sse.hot_sessions) ---
+
+const HotSessionSchema = object({
+  session_id: string(),
+  kind: fallback(string(), 'unknown'),
+  queue_depth: fallback(number(), 0),
+  last_event_id: fallback(number(), 0),
+  idle_seconds: fallback(number(), 0),
+})
+
+export type HotSession = InferOutput<typeof HotSessionSchema>
+
+// --- Subsection schemas (each field uses fallback matching the prior
+//     `asString(raw.X, DEFAULT)` / `asNumber(raw.X, 0)` decoder) ---
+
+const SummarySchema = object({
+  primary_path: fallback(string(), 'unknown'),
+  queue_pressure: fallback(string(), 'unknown'),
+  // `asNumber(x) ?? null` — absent/non-number → null, not undefined.
+  recent_messages: fallback(nullable(number()), null),
+  recent_messages_available: fallback(boolean(), false),
+  recent_messages_source: fallback(string(), 'unknown'),
+  external_fanout_targets: fallback(number(), 0),
+})
+
+const SseOuterSchema = object({
+  sessions_observer: fallback(number(), 0),
+  sessions_coordinator: fallback(number(), 0),
+  sessions_presence: fallback(number(), 0),
+  sessions_total: fallback(number(), 0),
+  external_subscribers: fallback(number(), 0),
+  broadcast_avg_seconds: fallback(number(), 0),
+  broadcast_count: fallback(number(), 0),
+  queue_avg_depth: fallback(number(), 0),
+  queue_max_depth: fallback(number(), 0),
+  relay_queue_depth: fallback(number(), 0),
+  relay_retry_total: fallback(number(), 0),
+  relay_retry_append: fallback(number(), 0),
+  relay_retry_broadcast: fallback(number(), 0),
+  relay_drop_total: fallback(number(), 0),
+  relay_drop_queue: fallback(number(), 0),
+  relay_drop_append: fallback(number(), 0),
+  relay_drop_broadcast: fallback(number(), 0),
+  // Lenient per-entry on hot_sessions handled in parseSse below.
+  hot_sessions: optional(unknown()),
+})
+
+interface SseSection {
+  sessions_observer: number
+  sessions_coordinator: number
+  sessions_presence: number
+  sessions_total: number
+  external_subscribers: number
+  broadcast_avg_seconds: number
+  broadcast_count: number
+  queue_avg_depth: number
+  queue_max_depth: number
+  relay_queue_depth: number
+  relay_retry_total: number
+  relay_retry_append: number
+  relay_retry_broadcast: number
+  relay_drop_total: number
+  relay_drop_queue: number
+  relay_drop_append: number
+  relay_drop_broadcast: number
+  hot_sessions: HotSession[]
+}
+
+const GrpcSchema = object({
+  enabled: fallback(boolean(), false),
+  configured: fallback(boolean(), false),
+  listening: fallback(boolean(), false),
+  port: fallback(number(), 0),
+  active_streams: fallback(number(), 0),
+  subscribers: fallback(number(), 0),
+  heartbeat_avg_seconds: fallback(number(), 0),
+  events_delivered: fallback(number(), 0),
+  events_dropped: fallback(number(), 0),
+})
+
+// Diagnostic counters for the WS delivery path.  Each field falls back
+// to 0 so this remains forward-compatible with servers that have not
+// yet landed the corresponding Prometheus metric (e.g. a dashboard
+// pointed at an older build should not surface schema errors, it
+// should show zeroes and let the operator know the metric is absent).
+const WebsocketDeliverySchema = object({
+  parse_cache_hits: fallback(number(), 0),
+  parse_cache_misses: fallback(number(), 0),
+  bytes_cache_hits: fallback(number(), 0),
+  bytes_cache_misses: fallback(number(), 0),
+  client_acks: fallback(number(), 0),
+  throttled_deliveries: fallback(number(), 0),
+  client_buffered_bytes_sum: fallback(number(), 0),
+  client_buffered_bytes_count: fallback(number(), 0),
+})
+
+const WebsocketSchema = object({
+  enabled: fallback(boolean(), false),
+  configured: fallback(boolean(), false),
+  listening: fallback(boolean(), false),
+  mode: fallback(string(), 'unknown'),
+  port: fallback(number(), 0),
+  sessions: fallback(number(), 0),
+  relay_source: fallback(string(), 'unknown'),
+  delivery: fallback(WebsocketDeliverySchema, {
+    parse_cache_hits: 0,
+    parse_cache_misses: 0,
+    bytes_cache_hits: 0,
+    bytes_cache_misses: 0,
+    client_acks: 0,
+    throttled_deliveries: 0,
+    client_buffered_bytes_sum: 0,
+    client_buffered_bytes_count: 0,
+  }),
+})
+
+const WebrtcSchema = object({
+  enabled: fallback(boolean(), false),
+  configured: fallback(boolean(), false),
+  signaling_available: fallback(boolean(), false),
+  signaling_mode: fallback(string(), 'unknown'),
+  pending_offers: fallback(number(), 0),
+  active_peers: fallback(number(), 0),
+  live_connections: fallback(number(), 0),
+  connected_channels: fallback(number(), 0),
+  ice_server_count: fallback(number(), 0),
+})
+
+const StreamableHttpSchema = object({
+  endpoint: fallback(string(), '/mcp'),
+  observer_stream: fallback(string(), '/mcp?sse_kind=observer'),
+  presence_stream: fallback(string(), '/events/presence'),
+  managed_endpoint: fallback(string(), '/mcp/managed'),
+  operator_endpoint: fallback(string(), '/mcp/operator'),
+  delete_endpoint: fallback(string(), '/mcp'),
+  legacy_sse_endpoint: fallback(string(), '/sse'),
+  legacy_messages_endpoint: fallback(string(), '/messages'),
+  default_transport: fallback(string(), 'unknown'),
+  supports_post: fallback(boolean(), false),
+  supports_sse_upgrade: fallback(boolean(), false),
+  supports_delete: fallback(boolean(), false),
+})
+
+const Http2Schema = object({
+  listener_mode: fallback(string(), 'unknown'),
+  multiplex_ready: fallback(boolean(), false),
+  prior_knowledge_path: fallback(string(), '/mcp'),
+})
+
+const ClusterSchema = object({
+  cluster: fallback(string(), 'default'),
+  room_id: fallback(string(), 'default'),
+  topology_available: fallback(boolean(), false),
+  topology_source: fallback(string(), 'unknown'),
+  // These five use `asNumber(x) ?? null` — absent → null, not undefined.
+  total_units: fallback(nullable(number()), null),
+  managed_units: fallback(nullable(number()), null),
+  live_agents: fallback(nullable(number()), null),
+  active_operations: fallback(nullable(number()), null),
+  stale_units: fallback(nullable(number()), null),
+})
+
+const AgentHealthSchema = object({
+  stale_total: fallback(number(), 0),
+  lifecycle_dispatch_rejections_total: fallback(number(), 0),
+})
+
+// `projection_diagnostics` is only present when the backend explicitly
+// includes it. When omitted, downstream sees `undefined` (matches prior
+// `projectionDiagnostics ? {...} : undefined`).
+const ProjectionDiagnosticsSchema = object({
+  source: fallback(string(), 'unknown'),
+  cache_state: fallback(string(), 'unknown'),
+  // Prior decoder: `asString(x) ?? null` — absent/non-string → null.
+  last_success_at: fallback(nullable(string()), null),
+  last_attempt_at: fallback(nullable(string()), null),
+  last_error_at: fallback(nullable(string()), null),
+  stale_reason: fallback(nullable(string()), null),
+  stale_age_ms: fallback(nullable(number()), null),
+})
+
+// --- Outer schema: all 9 subsections required + generated_at non-empty ---
+
+const TransportHealthOuterSchema = object({
+  summary: SummarySchema,
+  sse: SseOuterSchema,
+  grpc: GrpcSchema,
+  websocket: WebsocketSchema,
+  webrtc: WebrtcSchema,
+  streamable_http: StreamableHttpSchema,
+  http2: Http2Schema,
+  cluster: ClusterSchema,
+  agent_health: AgentHealthSchema,
+  // Prior decoder: `if (!generatedAt) return null` — empty string must
+  // also cause rejection, matching that guard exactly.
+  generated_at: pipe(
+    string(),
+    check(s => s.length > 0, 'generated_at must be non-empty'),
+  ),
+  projection_diagnostics: optional(ProjectionDiagnosticsSchema),
+})
+
+export interface TransportHealthData {
+  summary: InferOutput<typeof SummarySchema>
+  sse: SseSection
+  grpc: InferOutput<typeof GrpcSchema>
+  websocket: InferOutput<typeof WebsocketSchema>
+  webrtc: InferOutput<typeof WebrtcSchema>
+  streamable_http: InferOutput<typeof StreamableHttpSchema>
+  http2: InferOutput<typeof Http2Schema>
+  cluster: InferOutput<typeof ClusterSchema>
+  agent_health: InferOutput<typeof AgentHealthSchema>
+  generated_at: string
+  projection_diagnostics?: InferOutput<typeof ProjectionDiagnosticsSchema>
+}
+
+export class TransportHealthSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('transport-health', issues)
+  }
+}
+
+function parseSseHotSessions(raw: unknown): HotSession[] {
+  if (!Array.isArray(raw)) return []
+  const out: HotSession[] = []
+  for (const item of raw) {
+    const parsed = safeParse(HotSessionSchema, item, { abortEarly: true })
+    if (parsed.success) out.push(parsed.output)
+  }
+  return out
+}
+
+export function parseTransportHealthData(data: unknown): TransportHealthData {
+  const outer = parseOrThrow(
+    TransportHealthSchemaDriftError,
+    TransportHealthOuterSchema,
+    data,
+  )
+  return {
+    summary: outer.summary,
+    sse: {
+      sessions_observer: outer.sse.sessions_observer,
+      sessions_coordinator: outer.sse.sessions_coordinator,
+      sessions_presence: outer.sse.sessions_presence,
+      sessions_total: outer.sse.sessions_total,
+      external_subscribers: outer.sse.external_subscribers,
+      broadcast_avg_seconds: outer.sse.broadcast_avg_seconds,
+      broadcast_count: outer.sse.broadcast_count,
+      queue_avg_depth: outer.sse.queue_avg_depth,
+      queue_max_depth: outer.sse.queue_max_depth,
+      relay_queue_depth: outer.sse.relay_queue_depth,
+      relay_retry_total: outer.sse.relay_retry_total,
+      relay_retry_append: outer.sse.relay_retry_append,
+      relay_retry_broadcast: outer.sse.relay_retry_broadcast,
+      relay_drop_total: outer.sse.relay_drop_total,
+      relay_drop_queue: outer.sse.relay_drop_queue,
+      relay_drop_append: outer.sse.relay_drop_append,
+      relay_drop_broadcast: outer.sse.relay_drop_broadcast,
+      hot_sessions: parseSseHotSessions(outer.sse.hot_sessions),
+    },
+    grpc: outer.grpc,
+    websocket: outer.websocket,
+    webrtc: outer.webrtc,
+    streamable_http: outer.streamable_http,
+    http2: outer.http2,
+    cluster: outer.cluster,
+    agent_health: outer.agent_health,
+    generated_at: outer.generated_at,
+    projection_diagnostics: outer.projection_diagnostics,
+  }
+}

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -1,12 +1,7 @@
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
-import {
-  IDE_MOCK_FILE_PATH,
-  IDE_MOCK_RELATED_LINE,
-  IDE_MOCK_THREADS,
-} from './ide-mock-data'
-import type { AnchoredThread, ThreadKind } from './anchored-thread-rail-store'
+import type { ThreadKind } from './anchored-thread-rail-store'
 
 interface BoardPost {
   readonly id: string
@@ -17,10 +12,6 @@ interface BoardPost {
   readonly comment_count: number
   readonly created_at_iso: string
   readonly hearth?: string | null
-}
-
-interface BoardListResponse {
-  readonly posts?: ReadonlyArray<BoardPost>
 }
 
 const KIND_LABEL: Record<ThreadKind, string> = {

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -9,11 +9,11 @@ import {
 import { CodeLineText, useHighlightedCodeLines } from './ide-code-renderer'
 import {
   createKeeperLineOwnershipStore,
+  type KeeperEdit,
   type LineOwnership,
 } from './keeper-line-ownership-store'
 import {
   IDE_LAYER_ORDER,
-  IDE_MOCK_FILE_PATH,
   IDE_MOCK_OWNERSHIP_EVENTS,
   IDE_MOCK_SOURCE,
   ideMockAnnotationsForLayer,
@@ -114,40 +114,6 @@ const UNIFIED_DIFF_ROWS: ReadonlyArray<UnifiedDiffRow> = [
   { kind: 'context', oldLine: 21, newLine: 23, text: '}' },
 ]
 
-const SPLIT_DIFF_ROWS: ReadonlyArray<SplitDiffRow> = [
-  {
-    before: { kind: 'context', line: 16, text: 'export function normalizeTools(req: CascadeReq): CascadeReq {' },
-    after: { kind: 'context', line: 16, text: 'export function normalizeTools(req: CascadeReq): CascadeReq {' },
-  },
-  {
-    before: { kind: 'delete', line: 17, text: '  if (req.tools === undefined) {' },
-    after: { kind: 'add', line: 17, text: '  // strip empty tools array' },
-  },
-  {
-    before: { kind: 'delete', line: 18, text: '    return req' },
-    after: { kind: 'add', line: 18, text: '  if (req.tools && req.tools.length === 0) {' },
-  },
-  {
-    before: { kind: 'delete', line: 19, text: '  }' },
-    after: { kind: 'add', line: 19, text: '    const { tools, tool_choice, ...rest } = req' },
-  },
-  {
-    before: null,
-    after: { kind: 'add', line: 20, text: '    return rest as CascadeReq' },
-  },
-  {
-    before: null,
-    after: { kind: 'add', line: 21, text: '  }' },
-  },
-  {
-    before: { kind: 'context', line: 20, text: '  return req' },
-    after: { kind: 'context', line: 22, text: '  return req' },
-  },
-  {
-    before: { kind: 'context', line: 21, text: '}' },
-    after: { kind: 'context', line: 23, text: '}' },
-  },
-]
 
 export function IdeEditorMock({
   activeView = 'source',
@@ -197,7 +163,7 @@ export function IdeEditorMock({
           line_end: block.line_end,
           keeper_id: block.keeper_id,
           timestamp_ms: block.timestamp_ms,
-          kind: block.kind,
+          kind: block.kind as KeeperEdit['kind'],
         })
       }
     })
@@ -208,7 +174,7 @@ export function IdeEditorMock({
   useEffect(() => {
     let cancelled = false
     fetchDiff(activeIdeFile.value).then(rows => {
-      if (!cancelled) setDiffRows(rows.length > 0 ? rows : UNIFIED_DIFF_ROWS)
+      if (!cancelled) setDiffRows(rows.length > 0 ? rows : (UNIFIED_DIFF_ROWS as UnifiedDiffRow[]))
     })
     return () => { cancelled = true }
   }, [activeIdeFile.value])
@@ -655,9 +621,11 @@ function buildSplitDiff(rows: ReadonlyArray<UnifiedDiffRow>): SplitDiffRow[] {
   function flushPending(): void {
     const max = Math.max(deletes.length, adds.length)
     for (let i = 0; i < max; i++) {
+      const del = deletes[i]
+      const add = adds[i]
       result.push({
-        before: deletes[i] ? { kind: 'delete', line: deletes[i].oldLine, text: deletes[i].text } : null,
-        after: adds[i] ? { kind: 'add', line: adds[i].newLine, text: adds[i].text } : null,
+        before: del ? { kind: 'delete', line: del.oldLine, text: del.text } : null,
+        after: add ? { kind: 'add', line: add.newLine, text: add.text } : null,
       })
     }
     deletes.length = 0

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -23,13 +23,13 @@ const FALLBACK_SEED: ReadonlyArray<FileTreeNode> = [
   { path: 'README.md', label: 'README.md', depth: 0, parent: null, hasChildren: false, diff: null, keeperId: null, hueIndex: null },
 ]
 
-async function fetchTree(depth = 3): Promise<FileTreeNode[]> {
+async function fetchTree(depth = 3): Promise<ReadonlyArray<FileTreeNode>> {
   try {
     const res = await fetch(`/api/v1/workspace/tree?depth=${depth}`)
     if (!res.ok) return FALLBACK_SEED
     const data = await res.json()
     if (!Array.isArray(data) || data.length === 0) return FALLBACK_SEED
-    return data as FileTreeNode[]
+    return data as ReadonlyArray<FileTreeNode>
   } catch { return FALLBACK_SEED }
 }
 


### PR DESCRIPTION
## Symptom

`main` Dashboard CI is failing on `tsc --noEmit` (run #25334115069):

- `src/api/transport-health.ts(6,8|9,49)` — Cannot find module `./schemas/transport-health`
- `src/components/ide/ide-conversation-rail-mock.ts` — 4 unused-imports/types (TS6133/6192/6196)
- `src/components/ide/ide-editor-mock.ts` — TS6133 unused vars (×2), TS2322 string→KeeperEditKind, TS2345 readonly→mutable for setState, TS2532 possibly-undefined (×4)
- `src/components/ide/ide-explorer.ts` — TS4104 readonly→mutable (×3)

## Root cause

Two independent drifts merged in close sequence:

1. **#12878 dropped `dashboard/src/api/schemas/transport-health.{ts,test.ts}`** based on a symbol-name grep that returned 0 hits, but the path-import chain `api/transport-health.ts → components/transport-health.ts → sse-store.ts` is still live (lazy-loaded via `import('./components/transport-health')` in `sse-store.ts:232`). Symbol-grep missed those imports. This commit reverts #12878 to restore the schema while a more careful orphan analysis happens separately.
2. **#12886 wired IDE Activity / Conversation rail to real APIs** but left several unused mock symbols, returned `Promise<FileTreeNode[]>` against a `ReadonlyArray<FileTreeNode>` fallback, and triggered `noUncheckedIndexedAccess` on `deletes[i]`/`adds[i]` access in `buildSplitDiff`.

## Changes

| File | Change |
|------|--------|
| `dashboard/src/api/schemas/transport-health.ts` + `.test.ts` | Restored via `git revert fb245734d1` |
| `ide-conversation-rail-mock.ts` | Drop unused `useMemo`, `IDE_MOCK_*` imports, `AnchoredThread`, `BoardListResponse` |
| `ide-editor-mock.ts` | Drop unused `IDE_MOCK_FILE_PATH`, `SPLIT_DIFF_ROWS`. Narrow `blame.kind` to `KeeperEdit['kind']`. Cast `UNIFIED_DIFF_ROWS` fallback as mutable for `setDiffRows`. Hoist `deletes[i]`/`adds[i]` into temp vars |
| `ide-explorer.ts` | Change `fetchTree` return type to `ReadonlyArray<FileTreeNode>` (matches `FALLBACK_SEED`) |

## Verification

```bash
cd dashboard && pnpm run typecheck   # 0 errors
cd dashboard && pnpm run lint        # 0 errors (3 pre-existing warnings)
```

## Cross-refs

- Reverts: #12878 (drop orphan transport-health schema)
- Surfaces drift from: #12886 (connect IDE activity and conversation rail to real APIs)
- Memory: see no-string-matching-classification feedback — symbol-grep alone misses path imports

## Out of scope

- A more thorough orphan analysis to remove the whole `transport-health` chain if `sse-store.ts` integration is no longer wanted (separate PR)
- Pre-existing eslint warnings on `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`