### PR TITLE
style(dashboard): normalize opacity notation to 0.N form

### DIFF
--- a/dashboard/src/styles/center.css
+++ b/dashboard/src/styles/center.css
@@ -24,8 +24,8 @@
 .wf-bar.s-err { background: var(--err); }
 .wf-bar.s-info { background: var(--info); }
 .wf-bar.s-tool { background: var(--brass-2); }
-.wf-bar.s-text { background: var(--info); opacity: .6; }
-.wf-bar.s-noop { background: var(--idle); opacity: .4; }
+.wf-bar.s-text { background: var(--info); opacity: 0.6; }
+.wf-bar.s-noop { background: var(--idle); opacity: 0.4; }
 .wf-bar:hover { outline: 1px solid var(--color-fg-primary); z-index: 2; }
 
 .wf-scale-ctrl { display: flex; gap: var(--sp-0h); margin-left: auto; }

--- a/dashboard/src/styles/kpi.css
+++ b/dashboard/src/styles/kpi.css
@@ -89,7 +89,7 @@
   position: absolute;
   bottom: var(--grid-half);
   right: var(--grid-half);
-  opacity: .6;
+  opacity: 0.6;
   pointer-events: none;
   transition: opacity var(--motion-swap);
 }
@@ -100,7 +100,7 @@
   fill: none;
   stroke: var(--brass-1);
   stroke-width: 1;
-  opacity: .7;
+  opacity: 0.7;
 }
 .spark.s-err polyline { stroke: var(--err-fg); }
 .spark.s-ok  polyline { stroke: var(--ok-fg); }

--- a/dashboard/src/styles/layers.css
+++ b/dashboard/src/styles/layers.css
@@ -167,9 +167,9 @@ body[data-explode="1"] .lyr::before {
   transition: opacity var(--t-med) var(--ease), top var(--t-slow) var(--ease-out), height var(--t-slow) var(--ease-out);
 }
 .time-stripe.age-recent   { opacity: 1;   background: var(--warn);   box-shadow: 0 0 8px rgb(var(--warn-glow) / .6); }
-.time-stripe.age-near     { opacity: .7;  background: var(--warn); }
-.time-stripe.age-mid      { opacity: .4;  background: var(--color-fg-muted); }
-.time-stripe.age-far      { opacity: .2;  background: var(--color-fg-disabled); }
+.time-stripe.age-near     { opacity: 0.7;  background: var(--warn); }
+.time-stripe.age-mid      { opacity: 0.4;  background: var(--color-fg-muted); }
+.time-stripe.age-far      { opacity: 0.2;  background: var(--color-fg-disabled); }
 .time-stripe .time-label {
   position: absolute; left: 6px; top: 0;
   font-family: var(--font-mono); font-size: var(--fs-9);

--- a/dashboard/src/styles/lifeline.css
+++ b/dashboard/src/styles/lifeline.css
@@ -119,7 +119,7 @@
 .ll-cell.k-tool  { background: var(--brass-2); }
 .ll-cell.k-claim { background: var(--ok); }
 .ll-cell.k-text  { background: var(--info); }
-.ll-cell.k-noop  { background: var(--idle); opacity: .45; }
+.ll-cell.k-noop  { background: var(--idle); opacity: 0.45; }
 .ll-cell.k-error { background: var(--err); }
 
 /* turn separator — thin dashed vertical */
@@ -127,7 +127,7 @@
   flex: 0 0 auto;
   width: 0;
   border-left: 1px dashed var(--color-border-strong);
-  opacity: .5;
+  opacity: 0.5;
   height: 100%;
   margin: 0 2px;
   align-self: stretch;

--- a/dashboard/src/styles/primitives.css
+++ b/dashboard/src/styles/primitives.css
@@ -318,7 +318,7 @@ body[data-grid="1"]::before {
 @keyframes anim-slide-left  { from { opacity: 0; transform: translateX(8px); }  to { opacity: 1; transform: none; } }
 @keyframes anim-slide-right { from { opacity: 0; transform: translateX(-8px); } to { opacity: 1; transform: none; } }
 @keyframes anim-pop         { from { opacity: 0; transform: scale(.92); } to { opacity: 1; transform: none; } }
-@keyframes anim-pulse       { 0%,100% { opacity: 1; } 50% { opacity: .55; } }
+@keyframes anim-pulse       { 0%,100% { opacity: 1; } 50% { opacity: 0.55; } }
 @keyframes anim-pulse-glow  { 0%,100% { box-shadow: 0 0 0 rgb(var(--brass-glow) / 0); } 50% { box-shadow: 0 0 10px rgb(var(--brass-glow) / .5); } }
 @keyframes anim-pulse-err   { 0%,100% { box-shadow: 0 0 0 rgb(var(--err-glow)   / 0); } 50% { box-shadow: 0 0 10px rgb(var(--err-glow)   / .55); } }
 @keyframes anim-pulse-warn  { 0%,100% { box-shadow: 0 0 0 rgb(var(--warn-glow)  / 0); } 50% { box-shadow: 0 0 10px rgb(var(--warn-glow)  / .5); } }
@@ -372,7 +372,7 @@ body[data-grid="1"]::before {
 }
 .interactive:hover:not([aria-disabled="true"]) { background: var(--hover-overlay); color: var(--color-fg-primary); }
 .interactive:active:not([aria-disabled="true"]) { background: var(--active-overlay); }
-.interactive[aria-disabled="true"] { opacity: .4; cursor: not-allowed; }
+.interactive[aria-disabled="true"] { opacity: 0.4; cursor: not-allowed; }
 
 .is-loading {
   position: relative;

--- a/dashboard/src/styles/swimlanes.css
+++ b/dashboard/src/styles/swimlanes.css
@@ -152,7 +152,7 @@
   animation: sl-pulse 2.6s var(--ease-inout) infinite;
 }
 @keyframes sl-pulse {
-  0%, 100% { opacity: .5; }
+  0%, 100% { opacity: 0.5; }
   50% { opacity: 1; }
 }
 
@@ -181,10 +181,10 @@
 /* collapsed empty lane — smaller, muted */
 .sl-row-collapsed {
   height: 14px;
-  opacity: .45;
+  opacity: 0.45;
   border-bottom: 1px solid transparent;
 }
-.sl-row-collapsed:hover { opacity: .9; }
+.sl-row-collapsed:hover { opacity: 0.9; }
 .sl-row-collapsed .sl-label { font-size: var(--fs-10); }
 .sl-row-collapsed .sl-meta { font-size: var(--fs-9); }
 .sl-track-empty { position: relative; }
@@ -237,7 +237,7 @@
   display: inline-flex; align-items: flex-end;
   height: 10px; width: 28px;
   gap: 1px; flex-shrink: 0;
-  opacity: .55;
+  opacity: 0.55;
 }
 .sl-row:hover .sl-spark,
 .sl-row.is-active .sl-spark { opacity: 1; }
@@ -273,19 +273,19 @@
   position: absolute; top: 0; bottom: 0;
   width: 1px;
   background: var(--color-border-default);
-  opacity: .4;
+  opacity: 0.4;
   pointer-events: none;
 }
 .sl-grid.is-major {
   background: var(--color-border-strong);
-  opacity: .7;
+  opacity: 0.7;
 }
 
 .sl-crosshair {
   position: absolute; top: 0; bottom: 0;
   width: 1px;
   background: var(--brass-1);
-  opacity: .8;
+  opacity: 0.8;
   pointer-events: none;
   box-shadow: 0 0 3px rgb(var(--brass-glow) / .7);
   z-index: 2;
@@ -329,7 +329,7 @@
 /* text = thin line, info */
 .sl-glyph.k-text .sl-glyph-mark {
   background: var(--info);
-  opacity: .75;
+  opacity: 0.75;
   height: 40%;
   min-width: 2px;
 }
@@ -341,7 +341,7 @@
 .sl-glyph.k-noop .sl-glyph-mark {
   background: var(--color-fg-disabled);
   min-width: 2px;
-  opacity: .6;
+  opacity: 0.6;
 }
 /* error = cross, red */
 .sl-glyph.k-error .sl-glyph-mark {
@@ -404,22 +404,22 @@
   fill: none;
   stroke: var(--brass-3);
   stroke-width: 1;
-  opacity: .35;
+  opacity: 0.35;
   stroke-linecap: round;
   transition: stroke var(--t-fast), stroke-width var(--t-fast), opacity var(--t-fast);
   stroke-dasharray: 2 3;
 }
 .sl-ho-head {
   fill: var(--brass-2);
-  opacity: .6;
+  opacity: 0.6;
   transition: r var(--t-fast), fill var(--t-fast), opacity var(--t-fast);
 }
 .sl-ho-tail {
   fill: var(--brass-3);
-  opacity: .45;
+  opacity: 0.45;
 }
-.sl-ho.is-involved .sl-ho-line { stroke: var(--brass-1); opacity: .65; stroke-dasharray: none; }
-.sl-ho.is-involved .sl-ho-head { fill: var(--brass-1); opacity: .9; }
+.sl-ho.is-involved .sl-ho-line { stroke: var(--brass-1); opacity: 0.65; stroke-dasharray: none; }
+.sl-ho.is-involved .sl-ho-head { fill: var(--brass-1); opacity: 0.9; }
 .sl-ho:hover .sl-ho-line {
   stroke: var(--brass-1);
   stroke-width: 1.6;


### PR DESCRIPTION
## Summary

Normalizes 25 sites of bare-decimal `opacity: .N;` to explicit-zero `opacity: 0.N;`. Pure formatting consolidation — no rendered diff.

The codebase was previously split 25/28 between the two notations. This PR consolidates on the explicit form (now 53/53).

## Why this PR

Surfaced during the post-token-cascade audit as the only remaining mass *inconsistency* after the design-system sweep (#12881, #12884) closed out the tokenizable surfaces. Both `.4` and `0.4` are valid CSS and resolve identically — but mixed notation makes search/replace and lint rules brittle. Choosing one form once removes a class of small future PRs.

## Scope

| File | Sites |
|---|---|
| swimlanes.css | 14 |
| layers.css | 3 |
| center.css | 2 |
| kpi.css | 2 |
| lifeline.css | 2 |
| primitives.css | 2 |

Bulk-applied via:

```sh
perl -i -pe 's/(opacity:\s*)\.([0-9]+;)/${1}0.${2}/g'
```

The pattern is anchored to the `opacity:` property name + trailing `;` so that `rgb(255 255 255 / .4)`-style alpha channels (a separate concern; see #12865) are untouched.

## Test plan

- [x] `rg "opacity:\s*\.[0-9]+;" dashboard/src/styles` → 0 matches.
- [x] `rg "opacity:\s*0\.[0-9]+;" dashboard/src/styles` → 53 matches (28 pre-existing + 25 normalized).
- [x] No CSS property *values* changed; only literal *spelling* is normalized.
- [x] Race-checked `gh pr list` for `opacity notation` immediately before push: 0 conflicts.
- [ ] CI Build and Test (existing dashboard test suite).

## Visual delta

**None.** `0.4` and `.4` are byte-different but value-identical CSS literals. Browsers parse both to the same `<alpha-value>`.

## Cross-PR references

- PR #12892 — sp-1h spacing rhythm sweep (Draft).
- PR #12884 — non-color audit annotations (merged).
- PR #12881 — 5 polish tokens + consumers (merged).

## Future polish (out of scope)

`rgb(...) / .N` and `rgba(...,.N)` alpha channels follow a similar split inside color expressions — handled separately when the rgba() audit (#12865 close-out) chooses a notation. Tackling them in this PR would conflate "literal opacity property" with "color-expression alpha".
