### PR TITLE
feat(cascade): add Cascade_complexity heuristic classifier (RFC-0025 §3.1)

### DIFF
--- a/lib/cascade/cascade_complexity.ml
+++ b/lib/cascade/cascade_complexity.ml
@@ -1,0 +1,68 @@
+(** See {!Cascade_complexity} interface. *)
+
+type t = Simple | Moderate | Complex
+
+let to_string = function
+  | Simple -> "simple"
+  | Moderate -> "moderate"
+  | Complex -> "complex"
+
+let of_string raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "simple" -> Some Simple
+  | "moderate" -> Some Moderate
+  | "complex" -> Some Complex
+  | _ -> None
+
+(** Env-driven thresholds with safe fallback. *)
+
+let threshold_int env_key default =
+  match Sys.getenv_opt env_key with
+  | None | Some "" -> default
+  | Some s ->
+    (match int_of_string_opt (String.trim s) with
+     | Some n -> n
+     | None ->
+       Log.Misc.warn "Invalid int for %s=%S, using default %d" env_key s default;
+       default)
+
+let simple_goal_chars_max =
+  threshold_int "MASC_COMPLEXITY_SIMPLE_GOAL_CHARS" 2000
+
+let simple_max_tokens_max =
+  threshold_int "MASC_COMPLEXITY_SIMPLE_MAX_TOKENS" 1000
+
+let moderate_goal_chars_max =
+  threshold_int "MASC_COMPLEXITY_MODERATE_GOAL_CHARS" 8000
+
+let moderate_max_tokens_max =
+  threshold_int "MASC_COMPLEXITY_MODERATE_MAX_TOKENS" 4000
+
+let detect ?(goal = "") ?(tools = []) ?(max_tokens = 0) () =
+  let goal_chars = String.length goal in
+  let has_tools = tools <> [] in
+  (* Tools or high token counts always escalate to Complex — the
+     provider must support tool_choice / structured output. *)
+  if has_tools || max_tokens > moderate_max_tokens_max || goal_chars > moderate_goal_chars_max
+  then Complex
+  else if max_tokens > simple_max_tokens_max || goal_chars > simple_goal_chars_max
+  then Moderate
+  else Simple
+
+let cascade_profile_of_complexity = function
+  | Simple -> "tier_small"
+  | Moderate -> "tier_medium"
+  | Complex -> "big_three"
+
+(** Kill switch: when [MASC_COMPLEXITY_ROUTING_ENABLED] is not ["true"],
+    [maybe_reroute] returns the original cascade name unchanged.  This
+    lets operators deploy the complexity classifier in observe-only mode
+    alongside the existing cascade routing. *)
+let routing_enabled =
+  match Sys.getenv_opt "MASC_COMPLEXITY_ROUTING_ENABLED" with
+  | Some s -> String.equal (String.trim s |> String.lowercase_ascii) "true"
+  | None -> false
+
+let maybe_reroute ~original_cascade_name complexity =
+  if not routing_enabled then original_cascade_name
+  else cascade_profile_of_complexity complexity

--- a/lib/cascade/cascade_complexity.mli
+++ b/lib/cascade/cascade_complexity.mli
@@ -1,0 +1,77 @@
+(** Heuristic task-complexity classification for tiered cascade routing.
+
+    Classifies a pending LLM call as [Simple], [Moderate], or [Complex]
+    based on request metadata (goal length, tool presence, max_tokens).
+    The classification maps to a cascade profile name so keepers can
+    route simple tasks to local/small models and reserve expensive cloud
+    models for complex ones.
+
+    RFC-0025 §3.1: heuristic first, ML later.  Thresholds are env-tunable
+    for online calibration.
+
+    @since 0.185.0 *)
+
+(** {1 Complexity classification} *)
+
+type t = Simple | Moderate | Complex
+(** Task complexity tiers.  [Simple] targets local 4B-class models,
+    [Moderate] targets 9B-class, [Complex] targets 70B+ cloud models. *)
+
+val to_string : t -> string
+val of_string : string -> t option
+
+(** {1 Detection}
+
+    Thresholds default to the values from RFC-0025 §3.1 and are tunable
+    via env vars for online calibration. *)
+
+val detect :
+  ?goal:string ->
+  ?tools:(** any type with length *) 'a list ->
+  ?max_tokens:int ->
+  unit ->
+  t
+(** Classify task complexity from request metadata.
+
+    @param goal  the prompt / user message.  Length in characters is
+      compared against [MASC_COMPLEXITY_SIMPLE_GOAL_CHARS] and
+      [MASC_COMPLEXITY_MODERATE_GOAL_CHARS].
+    @param tools  non-empty list triggers [Complex] (tool_choice required).
+    @param max_tokens  compared against
+      [MASC_COMPLEXITY_SIMPLE_MAX_TOKENS] and
+      [MASC_COMPLEXITY_MODERATE_MAX_TOKENS].
+
+    Tools always escalate to [Complex] — tool use requires structured
+    output support that small models may lack. *)
+
+(** {1 Thresholds (env-tunable)} *)
+
+val simple_goal_chars_max : int
+(** Default 2000, env [MASC_COMPLEXITY_SIMPLE_GOAL_CHARS]. *)
+
+val simple_max_tokens_max : int
+(** Default 1000, env [MASC_COMPLEXITY_SIMPLE_MAX_TOKENS]. *)
+
+val moderate_goal_chars_max : int
+(** Default 8000, env [MASC_COMPLEXITY_MODERATE_GOAL_CHARS]. *)
+
+val moderate_max_tokens_max : int
+(** Default 4000, env [MASC_COMPLEXITY_MODERATE_MAX_TOKENS]. *)
+
+(** {1 Routing} *)
+
+val cascade_profile_of_complexity : t -> string
+(** Map complexity tier to a cascade profile name:
+    [Simple] → ["tier_small"], [Moderate] → ["tier_medium"],
+    [Complex] → ["big_three"]. *)
+
+val routing_enabled : bool
+(** [true] iff [MASC_COMPLEXITY_ROUTING_ENABLED=true].  When [false],
+    {!maybe_reroute} returns the original cascade name unchanged —
+    observe-only mode. *)
+
+val maybe_reroute : original_cascade_name:string -> t -> string
+(** When {!routing_enabled}, return the complexity-appropriate cascade
+    profile.  Otherwise return [original_cascade_name] unchanged.
+    This lets operators deploy the classifier alongside existing routing
+    and enable enforcement with a single env flip. *)


### PR DESCRIPTION
## Summary

Adds a self-contained heuristic complexity classifier mapping pending LLM calls to a cascade profile name based on goal length, tool presence, and `max_tokens`. Thresholds are env-tunable for online calibration. Wire-up free in this PR — `MASC_COMPLEXITY_ROUTING_ENABLED` defaults to `false`, observe-only mode.

## Why orphan-first

- Avoids coupling the classifier surface to a specific call site before the dispatch contract is settled.
- Dashboards/tests can link against the module without forcing routing changes in production.
- Kill switch via env flag — flipping back is a single variable.

## Tradeoffs

- Module compiles and ships unused until a caller integrates it. If `dead_code_analyzer` flags it, that is expected during staged rollout.
- Heuristic boundaries (2000/8000 chars, 1000/4000 tokens) are not validated against real traffic yet. RFC-0025 §3.1 baseline.

## Test plan
- [ ] CI: dune build lib/ passes
- [ ] CI: lint passes (no Log/Stdlib drift)
- [ ] Followup PR: wire-up in `oas_worker_named.ml` behind env flag
- [ ] Followup PR: property test for tier escalation (Simple → Moderate → Complex)

## Followups

1. Wire `Cascade_complexity.maybe_reroute` into `oas_worker_named.ml` between request capture and cascade resolution.
2. Property test: verify `detect` is monotonic in goal_chars and max_tokens.
3. Threshold calibration via traffic replay (post-merge data collection).