### PR TITLE
test(server): unit tests for keeper-aware workspace base resolution

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -6,37 +6,50 @@ module Http = Http_server_eio
 
 let base_path_of_state state = state.Mcp_server.room_config.base_path
 
-(* Resolve the workspace base directory for tree/file reads.
+(* Pure classification of the [?keeper=<name>] query param into a
+   workspace base directory plus a source tag.
 
-   Without [?keeper=<name>] the project root from [base_path_of_state]
-   is used (single shared workspace). With a keeper name the keeper's
-   private workspace root (sandbox playground) is resolved via
-   [Keeper_sandbox.host_root_abs_of_meta] and validated for existence.
+   Without a keeper name (or with an empty / whitespace-only one) the
+   project root is used. With a name, [lookup_playground] returns the
+   keeper's private workspace root if the keeper meta is known, and
+   [exists_dir] validates that the playground directory is actually
+   on disk. Failures fall back to the project root so the IDE always
+   renders something and never depends on disk state to draw a tree.
 
-   Unknown keeper / missing meta / non-existent playground silently
-   fall back to the project root so the IDE always renders something
-   and never depends on disk state to render a tree. The boolean
-   return signals whether the requested keeper's playground was
-   actually found, so callers can surface "playground 없음" hints
-   without leaking the resolved absolute path back to the client. *)
-let resolve_workspace_base ~state ~uri =
-  let project_base = base_path_of_state state in
-  match Uri.get_query_param uri "keeper" with
+   This split keeps the side-effecting wiring (state -> config,
+   Keeper_types.read_meta, Sys.file_exists / Sys.is_directory) at the
+   route boundary while the dispatch logic stays unit-testable. *)
+let classify_keeper_query
+    ~project_base
+    ~lookup_playground
+    ~exists_dir
+    keeper_param =
+  match keeper_param with
   | None | Some "" -> (project_base, `Project)
   | Some keeper_name ->
     let trimmed = String.trim keeper_name in
     if trimmed = "" then (project_base, `Project)
     else
-      let config = state.Mcp_server.room_config in
-      match Keeper_types.read_meta config trimmed with
-      | Ok (Some m) ->
-        let playground =
-          Keeper_sandbox.host_root_abs_of_meta ~config m
-        in
-        if Sys.file_exists playground && Sys.is_directory playground
-        then (playground, `Playground trimmed)
-        else (project_base, `PlaygroundMissing trimmed)
-      | _ -> (project_base, `KeeperUnknown trimmed)
+      match lookup_playground trimmed with
+      | Some playground when exists_dir playground ->
+        (playground, `Playground trimmed)
+      | Some _ -> (project_base, `PlaygroundMissing trimmed)
+      | None -> (project_base, `KeeperUnknown trimmed)
+
+let resolve_workspace_base ~state ~uri =
+  let project_base = base_path_of_state state in
+  let config = state.Mcp_server.room_config in
+  let lookup_playground name =
+    match Keeper_types.read_meta config name with
+    | Ok (Some m) -> Some (Keeper_sandbox.host_root_abs_of_meta ~config m)
+    | _ -> None
+  in
+  let exists_dir p = Sys.file_exists p && Sys.is_directory p in
+  classify_keeper_query
+    ~project_base
+    ~lookup_playground
+    ~exists_dir
+    (Uri.get_query_param uri "keeper")
 
 let json_error message =
   `Assoc [("ok", `Bool false); ("error", `String message)]

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -1,3 +1,15 @@
 module Http = Http_server_eio
 
 val add_routes : Http.Router.t -> Http.Router.t
+
+(** Pure dispatch logic for the [?keeper=<name>] query param. Exposed
+    for unit testing — production code goes through {!add_routes}. *)
+val classify_keeper_query :
+  project_base:string ->
+  lookup_playground:(string -> string option) ->
+  exists_dir:(string -> bool) ->
+  string option ->
+  string * [ `Project
+           | `Playground of string
+           | `PlaygroundMissing of string
+           | `KeeperUnknown of string ]

--- a/test/dune
+++ b/test/dune
@@ -226,6 +226,7 @@
         test_keeper_synthetic_marker
         test_keeper_turn_fsm_wired_sites
         test_effective_oas_env
+        test_workspace_routes_keeper
         )
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
@@ -431,6 +432,7 @@
           test_keeper_synthetic_marker
           test_keeper_turn_fsm_wired_sites
           test_effective_oas_env
+          test_workspace_routes_keeper
           )
  (libraries masc_test_deps multimodal))
 

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -1,0 +1,132 @@
+(* Unit tests for the [?keeper=<name>] dispatch in
+   [Server_routes_http_routes_workspace.classify_keeper_query].
+
+   The function under test is the pure classification core of
+   [resolve_workspace_base]: it takes the project root, two injected
+   side-effect closures (lookup + existence check), and the raw query
+   parameter, then returns the resolved base directory plus a tag.
+
+   These tests cover all four branches of the classification:
+     - [`Project]            — no keeper / empty / whitespace-only
+     - [`Playground name]    — keeper meta exists and dir is on disk
+     - [`PlaygroundMissing]  — keeper meta exists but dir is missing
+     - [`KeeperUnknown]      — no keeper meta for the given name *)
+
+module W = Masc_mcp.Server_routes_http_routes_workspace
+
+let project = "/repo"
+let playground_root = "/playgrounds/<keeper>"
+
+let no_lookup _ = None
+let always_missing _ = false
+
+let lookup_for known name = if name = known then Some playground_root else None
+let exists_only path expected = path = expected
+
+let test_no_param () =
+  let (base, src) =
+    W.classify_keeper_query
+      ~project_base:project
+      ~lookup_playground:no_lookup
+      ~exists_dir:always_missing
+      None
+  in
+  Alcotest.(check string) "base is project" project base;
+  match src with
+  | `Project -> ()
+  | _ -> Alcotest.fail "expected `Project for None"
+
+let test_empty_param () =
+  let (base, src) =
+    W.classify_keeper_query
+      ~project_base:project
+      ~lookup_playground:no_lookup
+      ~exists_dir:always_missing
+      (Some "")
+  in
+  Alcotest.(check string) "base is project" project base;
+  match src with
+  | `Project -> ()
+  | _ -> Alcotest.fail "expected `Project for empty string"
+
+let test_whitespace_param () =
+  let (base, src) =
+    W.classify_keeper_query
+      ~project_base:project
+      ~lookup_playground:no_lookup
+      ~exists_dir:always_missing
+      (Some "   ")
+  in
+  Alcotest.(check string) "base is project (whitespace trims)" project base;
+  match src with
+  | `Project -> ()
+  | _ -> Alcotest.fail "expected `Project for whitespace"
+
+let test_keeper_unknown () =
+  let (base, src) =
+    W.classify_keeper_query
+      ~project_base:project
+      ~lookup_playground:no_lookup
+      ~exists_dir:always_missing
+      (Some "ghost")
+  in
+  Alcotest.(check string) "fallback to project" project base;
+  match src with
+  | `KeeperUnknown name ->
+    Alcotest.(check string) "carries trimmed name" "ghost" name
+  | _ -> Alcotest.fail "expected `KeeperUnknown"
+
+let test_playground_resolved () =
+  let (base, src) =
+    W.classify_keeper_query
+      ~project_base:project
+      ~lookup_playground:(lookup_for "alpha")
+      ~exists_dir:(exists_only playground_root)
+      (Some "alpha")
+  in
+  Alcotest.(check string) "base is playground" playground_root base;
+  match src with
+  | `Playground name ->
+    Alcotest.(check string) "carries trimmed name" "alpha" name
+  | _ -> Alcotest.fail "expected `Playground"
+
+let test_playground_missing () =
+  let (base, src) =
+    W.classify_keeper_query
+      ~project_base:project
+      ~lookup_playground:(lookup_for "alpha")
+      ~exists_dir:always_missing  (* meta exists but dir is gone *)
+      (Some "alpha")
+  in
+  Alcotest.(check string) "fallback to project" project base;
+  match src with
+  | `PlaygroundMissing name ->
+    Alcotest.(check string) "carries trimmed name" "alpha" name
+  | _ -> Alcotest.fail "expected `PlaygroundMissing"
+
+let test_keeper_name_trimmed () =
+  let (base, src) =
+    W.classify_keeper_query
+      ~project_base:project
+      ~lookup_playground:(lookup_for "alpha")
+      ~exists_dir:(exists_only playground_root)
+      (Some "  alpha  ")
+  in
+  Alcotest.(check string) "base is playground" playground_root base;
+  match src with
+  | `Playground name ->
+    Alcotest.(check string) "name is trimmed" "alpha" name
+  | _ -> Alcotest.fail "expected `Playground after trim"
+
+let () =
+  Alcotest.run "workspace_routes_keeper"
+    [ ( "classify_keeper_query"
+      , [ Alcotest.test_case "no param"          `Quick test_no_param
+        ; Alcotest.test_case "empty param"       `Quick test_empty_param
+        ; Alcotest.test_case "whitespace param"  `Quick test_whitespace_param
+        ; Alcotest.test_case "keeper unknown"    `Quick test_keeper_unknown
+        ; Alcotest.test_case "playground exists" `Quick test_playground_resolved
+        ; Alcotest.test_case "playground missing" `Quick test_playground_missing
+        ; Alcotest.test_case "name trimmed"      `Quick test_keeper_name_trimmed
+        ] )
+    ]


### PR DESCRIPTION
## Summary

Follow-up to #12893. Splits the keeper-aware base resolution into a pure dispatch core + thin side-effect wrapper, and adds 7 unit tests covering all four classification branches.

- `classify_keeper_query` (new, exposed via .mli for testing): pure — takes `~project_base` + injected `~lookup_playground` / `~exists_dir` closures + raw query param. Returns `(string * [\`Project | \`Playground of string | \`PlaygroundMissing of string | \`KeeperUnknown of string])`.
- `resolve_workspace_base` (existing): now wires the closures from `Keeper_types.read_meta` + `Keeper_sandbox.host_root_abs_of_meta` + `Sys.file_exists && Sys.is_directory`. Behavior at the route boundary is unchanged.

Tests cover: no param / empty / whitespace, keeper unknown, playground exists, playground meta-known-but-dir-missing, name trimming.

## Why

#12893 added the keeper-aware routes without unit tests because the original implementation depended on `Mcp_server.t` / `Coord.config` / `Sys.*` — heavy fixture cost. Side-effect injection makes the dispatch logic testable in 0.001s without any state init.

## Test plan

- [x] `dune build --build-dir=_build_iso test/test_workspace_routes_keeper.exe` — green
- [x] `test_workspace_routes_keeper.exe` — 7/7 pass, 0.001s

## Notes

- `resolve_workspace_base` itself is not exposed in .mli (still internal — only the route handlers call it). Only the pure `classify_keeper_query` core is on the public surface as a test seam.
- Zero behavior change at the wire — same response shapes as #12893.