### PR TITLE
feat(keeper): per-provider token bucket primitive (PR 1/5 of liveness scheduler)

### DIFF
--- a/lib/keeper/keeper_provider_token_bucket.ml
+++ b/lib/keeper/keeper_provider_token_bucket.ml
@@ -1,0 +1,77 @@
+type provider_id = string
+
+type state = {
+  mutable tokens : float;
+  mutable last_refill_at : float;
+}
+
+type t = {
+  provider : provider_id;
+  capacity : int;
+  refill_rate : float;
+  now : unit -> float;
+  state : state;
+  mutex : Mutex.t;
+}
+
+let refilled ~current_tokens ~capacity ~refill_rate ~elapsed_sec =
+  if elapsed_sec <= 0.0 then current_tokens
+  else
+    let added = elapsed_sec *. refill_rate in
+    let raw = current_tokens +. added in
+    let cap = float_of_int capacity in
+    if raw > cap then cap else raw
+
+let create ~provider ~capacity ~refill_rate ~now =
+  if capacity < 1 then
+    invalid_arg "Keeper_provider_token_bucket.create: capacity must be >= 1";
+  if refill_rate <= 0.0 then
+    invalid_arg
+      "Keeper_provider_token_bucket.create: refill_rate must be > 0.0";
+  {
+    provider;
+    capacity;
+    refill_rate;
+    now;
+    state = { tokens = float_of_int capacity; last_refill_at = now () };
+    mutex = Mutex.create ();
+  }
+
+let with_mutex t f =
+  Mutex.lock t.mutex;
+  match f () with
+  | v ->
+    Mutex.unlock t.mutex;
+    v
+  | exception e ->
+    Mutex.unlock t.mutex;
+    raise e
+
+let refill_locked t =
+  let now_ts = t.now () in
+  let elapsed = now_ts -. t.state.last_refill_at in
+  let new_tokens =
+    refilled
+      ~current_tokens:t.state.tokens
+      ~capacity:t.capacity
+      ~refill_rate:t.refill_rate
+      ~elapsed_sec:elapsed
+  in
+  t.state.tokens <- new_tokens;
+  t.state.last_refill_at <- now_ts
+
+let try_acquire t =
+  with_mutex t (fun () ->
+      refill_locked t;
+      if t.state.tokens >= 1.0 then begin
+        t.state.tokens <- t.state.tokens -. 1.0;
+        true
+      end
+      else false)
+
+let tokens_available t =
+  with_mutex t (fun () ->
+      refill_locked t;
+      t.state.tokens)
+
+let provider t = t.provider

--- a/lib/keeper/keeper_provider_token_bucket.mli
+++ b/lib/keeper/keeper_provider_token_bucket.mli
@@ -1,0 +1,62 @@
+(** Token bucket per LLM provider, modeling provider-side rate limits.
+
+    Part of the keeper-liveness architecture (see RFC: keeper provider
+    scheduling). This module owns the rate-respect invariant:
+
+      I3 (Rate-respect): for each provider [p] and time window [W],
+                         dispatched(p, W) <= rate_limit(p) * |W|
+
+    Non-blocking primitive: [try_acquire] returns immediately with a bool.
+    The scheduler (separate module, future PR) is responsible for picking
+    the next candidate provider when a bucket is empty — a single bucket
+    must never block a fiber, otherwise per-keeper liveness can fail.
+
+    Cross-fiber safe: protected by a [Stdlib.Mutex] internally. Critical
+    section is microseconds (lazy refill arithmetic + small field updates),
+    so blocking the carrier thread is acceptable inside an Eio context. *)
+
+type provider_id = string
+(** Opaque label, e.g. ["anthropic"], ["codex_cli"], ["glm"]. The string is
+    only used as a tag — the bucket itself does not interpret it. *)
+
+type t
+
+val create :
+  provider:provider_id ->
+  capacity:int ->
+  refill_rate:float ->
+  now:(unit -> float) ->
+  t
+(** [create ~provider ~capacity ~refill_rate ~now] builds a fresh bucket.
+
+    - [capacity]: maximum burst size (tokens). Bucket starts full.
+    - [refill_rate]: tokens added per second. Must be [> 0.0].
+    - [now]: clock injection. In production pass [Unix.gettimeofday];
+      in tests pass a controlled clock so refill behaviour is deterministic.
+
+    Raises [Invalid_argument] if [capacity < 1] or [refill_rate <= 0.0]. *)
+
+val try_acquire : t -> bool
+(** Attempt to consume one token. Returns [true] on success.
+
+    Performs a lazy refill based on elapsed time since the last access,
+    then checks for [>= 1.0] tokens. Always non-blocking. *)
+
+val tokens_available : t -> float
+(** Current token count after a fresh refill. For observability and tests.
+    Calling this performs the same lazy-refill side effect as [try_acquire]
+    (mutating [last_refill_at]) but does not consume a token. *)
+
+val provider : t -> provider_id
+(** The provider tag passed to [create]. *)
+
+val refilled :
+  current_tokens:float ->
+  capacity:int ->
+  refill_rate:float ->
+  elapsed_sec:float ->
+  float
+(** Pure function: compute the new token count after [elapsed_sec] elapse.
+    Capped at [capacity], floored at [current_tokens] when [elapsed_sec < 0]
+    (clock skew defence). Exposed for unit tests of the refill arithmetic
+    in isolation from mutex/state. *)

--- a/test/dune
+++ b/test/dune
@@ -1089,6 +1089,7 @@
 (include stanzas/test_keeper_pause_silent_failure_source.inc)
 (include stanzas/test_keeper_paused_cas_retain_9733.inc)
 (include stanzas/test_keeper_personality_round_trip.inc)
+(include stanzas/test_keeper_provider_token_bucket.inc)
 (include stanzas/test_keeper_readonly_hints.inc)
 (include stanzas/test_keeper_receipt_authoritative.inc)
 (include stanzas/test_keeper_receipt_authoritative_matrix.inc)

--- a/test/stanzas/test_keeper_provider_token_bucket.inc
+++ b/test/stanzas/test_keeper_provider_token_bucket.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_provider_token_bucket)
+ (modules test_keeper_provider_token_bucket)
+ (libraries masc_mcp alcotest))

--- a/test/test_keeper_provider_token_bucket.ml
+++ b/test/test_keeper_provider_token_bucket.ml
@@ -1,0 +1,276 @@
+(** Unit tests for [Keeper_provider_token_bucket].
+
+    The bucket is the I3 (Rate-respect) primitive in the future
+    keeper-liveness scheduler. These tests pin its contract independent
+    of any scheduler integration so future PRs can rely on the semantics
+    even as call sites evolve. *)
+
+open Masc_mcp
+
+(* Controllable clock: tests advance this directly to make refill behaviour
+   deterministic. *)
+let clock_ref = ref 0.0
+let now () = !clock_ref
+let advance dt = clock_ref := !clock_ref +. dt
+
+let reset_clock () = clock_ref := 0.0
+
+(* ------------------------------------------------------------------ *)
+(* Pure refill arithmetic                                              *)
+(* ------------------------------------------------------------------ *)
+
+let test_refilled_caps_at_capacity () =
+  let actual =
+    Keeper_provider_token_bucket.refilled
+      ~current_tokens:5.0
+      ~capacity:10
+      ~refill_rate:100.0
+      ~elapsed_sec:1.0
+  in
+  Alcotest.(check (float 0.0001))
+    "raw 5+100=105 capped at 10"
+    10.0
+    actual
+
+let test_refilled_negative_elapsed_no_change () =
+  (* Clock skew defence: time moving backward must never inflate tokens. *)
+  let actual =
+    Keeper_provider_token_bucket.refilled
+      ~current_tokens:3.5
+      ~capacity:10
+      ~refill_rate:1.0
+      ~elapsed_sec:(-2.0)
+  in
+  Alcotest.(check (float 0.0001))
+    "negative elapsed leaves tokens unchanged"
+    3.5
+    actual
+
+let test_refilled_zero_elapsed_no_change () =
+  let actual =
+    Keeper_provider_token_bucket.refilled
+      ~current_tokens:7.0
+      ~capacity:10
+      ~refill_rate:1.0
+      ~elapsed_sec:0.0
+  in
+  Alcotest.(check (float 0.0001)) "zero elapsed leaves tokens unchanged" 7.0 actual
+
+let test_refilled_partial_under_capacity () =
+  let actual =
+    Keeper_provider_token_bucket.refilled
+      ~current_tokens:2.0
+      ~capacity:10
+      ~refill_rate:0.5
+      ~elapsed_sec:4.0
+  in
+  Alcotest.(check (float 0.0001)) "2 + 0.5*4 = 4.0" 4.0 actual
+
+(* ------------------------------------------------------------------ *)
+(* Constructor invariants                                              *)
+(* ------------------------------------------------------------------ *)
+
+let test_create_starts_full () =
+  reset_clock ();
+  let t =
+    Keeper_provider_token_bucket.create
+      ~provider:"anthropic"
+      ~capacity:5
+      ~refill_rate:1.0
+      ~now
+  in
+  Alcotest.(check (float 0.0001))
+    "fresh bucket starts at full capacity"
+    5.0
+    (Keeper_provider_token_bucket.tokens_available t)
+
+let test_create_rejects_zero_capacity () =
+  Alcotest.check_raises
+    "capacity 0 rejected"
+    (Invalid_argument
+       "Keeper_provider_token_bucket.create: capacity must be >= 1")
+    (fun () ->
+      ignore
+        (Keeper_provider_token_bucket.create
+           ~provider:"x"
+           ~capacity:0
+           ~refill_rate:1.0
+           ~now))
+
+let test_create_rejects_zero_refill () =
+  Alcotest.check_raises
+    "refill_rate 0 rejected"
+    (Invalid_argument
+       "Keeper_provider_token_bucket.create: refill_rate must be > 0.0")
+    (fun () ->
+      ignore
+        (Keeper_provider_token_bucket.create
+           ~provider:"x"
+           ~capacity:1
+           ~refill_rate:0.0
+           ~now))
+
+(* ------------------------------------------------------------------ *)
+(* Acquire semantics                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let test_acquire_drains_then_fails () =
+  reset_clock ();
+  let t =
+    Keeper_provider_token_bucket.create
+      ~provider:"codex_cli"
+      ~capacity:3
+      ~refill_rate:0.001 (* effectively no refill within test horizon *)
+      ~now
+  in
+  Alcotest.(check bool) "1st acquire ok" true
+    (Keeper_provider_token_bucket.try_acquire t);
+  Alcotest.(check bool) "2nd acquire ok" true
+    (Keeper_provider_token_bucket.try_acquire t);
+  Alcotest.(check bool) "3rd acquire ok" true
+    (Keeper_provider_token_bucket.try_acquire t);
+  Alcotest.(check bool) "4th acquire fails when drained" false
+    (Keeper_provider_token_bucket.try_acquire t)
+
+let test_acquire_recovers_after_refill () =
+  reset_clock ();
+  let t =
+    Keeper_provider_token_bucket.create
+      ~provider:"glm"
+      ~capacity:1
+      ~refill_rate:1.0
+      ~now
+  in
+  Alcotest.(check bool) "drain initial token" true
+    (Keeper_provider_token_bucket.try_acquire t);
+  Alcotest.(check bool) "empty immediately after" false
+    (Keeper_provider_token_bucket.try_acquire t);
+  advance 1.5;
+  Alcotest.(check bool) "refilled after 1.5s at 1tps (>=1.0 token)" true
+    (Keeper_provider_token_bucket.try_acquire t)
+
+let test_rate_respect_invariant () =
+  (* I3: dispatched(p, W) <= rate_limit(p) * |W|.
+     Run for [horizon] seconds at fine-grained polling, count successful
+     acquires, assert <= capacity + rate * horizon. *)
+  reset_clock ();
+  let capacity = 5 in
+  let refill_rate = 2.0 in
+  let horizon = 10.0 in
+  let step = 0.1 in
+  let t =
+    Keeper_provider_token_bucket.create
+      ~provider:"anthropic"
+      ~capacity
+      ~refill_rate
+      ~now
+  in
+  let dispatched = ref 0 in
+  let elapsed = ref 0.0 in
+  while !elapsed < horizon do
+    if Keeper_provider_token_bucket.try_acquire t then incr dispatched;
+    advance step;
+    elapsed := !elapsed +. step
+  done;
+  let theoretical_max =
+    capacity + int_of_float (refill_rate *. horizon)
+  in
+  let observed = !dispatched in
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "I3: observed dispatches (%d) must not exceed capacity+rate*horizon (%d)"
+       observed
+       theoretical_max)
+    true
+    (observed <= theoretical_max)
+
+let test_provider_label_preserved () =
+  reset_clock ();
+  let t =
+    Keeper_provider_token_bucket.create
+      ~provider:"my-provider-tag"
+      ~capacity:1
+      ~refill_rate:1.0
+      ~now
+  in
+  Alcotest.(check string)
+    "provider tag round-trips"
+    "my-provider-tag"
+    (Keeper_provider_token_bucket.provider t)
+
+(* ------------------------------------------------------------------ *)
+(* Concurrent acquire (cross-fiber safety)                             *)
+(* ------------------------------------------------------------------ *)
+
+let test_concurrent_acquire_no_overdraw () =
+  (* I3 still holds when N parallel domains race for the same bucket.
+     Without the mutex, lazy refill + decrement could double-count. *)
+  reset_clock ();
+  let capacity = 100 in
+  let t =
+    Keeper_provider_token_bucket.create
+      ~provider:"shared"
+      ~capacity
+      ~refill_rate:0.001 (* near-zero refill: only initial 100 tokens available *)
+      ~now
+  in
+  let n_domains = 4 in
+  let attempts_per_domain = 200 in
+  let success_counts = Array.make n_domains 0 in
+  let domains =
+    Array.init n_domains (fun i ->
+        Domain.spawn (fun () ->
+            for _ = 1 to attempts_per_domain do
+              if Keeper_provider_token_bucket.try_acquire t then
+                success_counts.(i) <- success_counts.(i) + 1
+            done))
+  in
+  Array.iter Domain.join domains;
+  let total_success = Array.fold_left (+) 0 success_counts in
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "total successful acquires (%d) must equal capacity (%d) — no overdraw"
+       total_success
+       capacity)
+    true
+    (total_success = capacity)
+
+(* ------------------------------------------------------------------ *)
+
+let () =
+  Alcotest.run
+    "keeper_provider_token_bucket"
+    [
+      ( "refill_arithmetic"
+      , [ Alcotest.test_case "caps at capacity" `Quick
+            test_refilled_caps_at_capacity
+        ; Alcotest.test_case "negative elapsed unchanged" `Quick
+            test_refilled_negative_elapsed_no_change
+        ; Alcotest.test_case "zero elapsed unchanged" `Quick
+            test_refilled_zero_elapsed_no_change
+        ; Alcotest.test_case "partial refill under capacity" `Quick
+            test_refilled_partial_under_capacity
+        ] )
+    ; ( "constructor"
+      , [ Alcotest.test_case "starts full" `Quick test_create_starts_full
+        ; Alcotest.test_case "rejects zero capacity" `Quick
+            test_create_rejects_zero_capacity
+        ; Alcotest.test_case "rejects non-positive refill rate" `Quick
+            test_create_rejects_zero_refill
+        ] )
+    ; ( "acquire_semantics"
+      , [ Alcotest.test_case "drains then fails" `Quick
+            test_acquire_drains_then_fails
+        ; Alcotest.test_case "recovers after refill" `Quick
+            test_acquire_recovers_after_refill
+        ; Alcotest.test_case "I3 rate-respect over 10s window" `Quick
+            test_rate_respect_invariant
+        ; Alcotest.test_case "provider label preserved" `Quick
+            test_provider_label_preserved
+        ] )
+    ; ( "concurrency"
+      , [ Alcotest.test_case "no overdraw under 4-domain race" `Quick
+            test_concurrent_acquire_no_overdraw
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

First module of the keeper-liveness scheduler series.

Production symptom motivating this work: **14 keepers vs 6 autonomous slots → 8 always queued → tail wait > 60s budget → all keepers timeout simultaneously** (live log 2026-05-05 ~01:50–17:30 UTC, 245 timeouts in 30min). PR #12863 fixed a clock-phase leak that consumed 5s of budget but did not address the underlying capacity-vs-demand mismatch.

The user-stated 1st-priority invariant is **liveness**: \"어떤 keeper도 절대 막히지 않음.\" That requires a layered scheduler with provable bounded wait. This PR is the foundational primitive (Layer 1).

## Invariants (across the 5-PR series)

\`\`\`
I1 (Liveness):       ∀ keeper k. eventually-progresses(k)
I2 (Work-conserve):  ¬∃ t. (waiting(k, t) ∧ idle_provider(p, t) ∧ compatible(k, p))
I3 (Rate-respect):   ∀ provider p, t. dispatched(p, [t-1m, t]) ≤ rate_limit(p)  ← THIS PR
I4 (Bounded-wait):   ∀ k. wait(k) ≤ T_max  (from DRR fairness)
I5 (Drift-observable): ∀ rotation event. logged(keeper, preferred → actual, reason)
\`\`\`

## What this PR adds

- \`lib/keeper/keeper_provider_token_bucket.{ml,mli}\` — the I3 primitive
- Non-blocking \`try_acquire\` (returns bool, never sleeps the fiber)
- Lazy refill from injected clock (production: \`Unix.gettimeofday\`; tests: controlled)
- Cross-fiber safe via \`Stdlib.Mutex\` (microsecond critical section)
- Pure \`refilled\` helper exported for arithmetic-level testing without state

## What this PR does NOT do

- No call site changes — bucket is unused production code at merge.
- No semaphore replacement (PR 5/5).
- No cascade routing changes (PR 2/5 + PR 3/5).
- No TLA+ proof of liveness (PR 4/5).

This is intentional: PR 1 is foundation only. Future PRs depend on its semantics.

## Test plan

- [x] 12 alcotest cases (run locally, all green in 2ms)
- [x] Pure refill arithmetic (caps, negative-elapsed clock-skew, partial)
- [x] Constructor invariants (rejects capacity=0, refill_rate=0)
- [x] Drain → fail → refill → recover
- [x] **I3 rate-respect over 10s window**: empirical observation count ≤ theoretical max
- [x] **4-domain concurrency race**: 800 attempts vs 100 capacity → exactly 100 succeed (no overdraw)
- [x] \`dune build @lib/check\` clean

## Why open as Draft

Foundation PR. Human review wanted on the API surface (\`mli\`) and the test contract (especially the I3 property and the race test) before downstream PRs lock in dependencies.

## Roadmap

| PR | Scope | Est LOC | Depends |
|---|---|---|---|
| **1/5 (this)** | Per-provider token bucket primitive | ~420 | none |
| 2/5 | Cascade policy schema (tiers, drift_tolerance) + persona migration | ~500 | 1 |
| 3/5 | Adaptive scheduler + overflow queue (DRR fairness) | ~600 | 1, 2 |
| 4/5 | TLA+ spec (LivenessInvariant) + buggy/clean cfg | ~400 | 2 |
| 5/5 | Replace global semaphore with new scheduler + drift logging | ~400 | 1, 2, 3 |