### PR TITLE
fix(oas_compat): include truncated body in all error_message fallback paths

### DIFF
--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -208,15 +208,25 @@ module Http_client = struct
     | Llm_provider.Http_client.ProviderFailure { kind; message } ->
         Llm_provider.Http_client.provider_failure_to_string ~kind ~message
     | Llm_provider.Http_client.HttpError { code; body } -> (
+        let truncate_body b =
+          let max_len =
+            Llm_provider.Constants.Truncation.max_error_body_length
+          in
+          if String.length b <= max_len then b
+          else String.sub b 0 max_len ^ "…"
+        in
         try
           let json = Yojson.Safe.from_string body in
           match Yojson.Safe.Util.member "error" json with
           | `Assoc fields -> (
               match List.assoc_opt "message" fields with
               | Some (`String msg) -> msg
-              | _ -> Printf.sprintf "HTTP %d" code)
-          | _ -> Printf.sprintf "HTTP %d" code
-        with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
+              | _ ->
+                Printf.sprintf "HTTP %d (body: %s)" code (truncate_body body))
+          | _ ->
+            Printf.sprintf "HTTP %d (body: %s)" code (truncate_body body)
+        with Yojson.Json_error _ ->
+          Printf.sprintf "HTTP %d (body: %s)" code (truncate_body body))
 end
 
 module Metrics = struct


### PR DESCRIPTION
## Summary

- `Http_client.error_message` dropped the response body in 3 JSON parse failure paths, returning only `"HTTP <code>"` with no diagnostic information
- All 3 fallback paths now include the first 200 chars of the body (using `Constants.Truncation.max_error_body_length`)
- Consistent with `cascade_fsm.ml` which already uses the same truncation constant

## Problem

When a provider returns a malformed error response (e.g. non-JSON body, JSON without `.error.message`), `error_message` returned `"HTTP 400"` — losing the actual error text. Cascade debugging required raw HTTP logs instead of structured error messages.

## Test plan
- [x] `dune build lib/masc_mcp.cma` succeeds
- [x] `test_cascade_fsm` (4/4 tests pass) — exercises `error_message` indirectly
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)