### PR TITLE
feat(dashboard): keeper-aware /api/v1/git/blame + /api/v1/git/diff

### DIFF
--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -62,18 +62,22 @@ interface BlameBlock {
   readonly kind: string
 }
 
-async function fetchBlame(path: string): Promise<BlameBlock[]> {
+async function fetchBlame(path: string, keeper = ''): Promise<BlameBlock[]> {
   try {
-    const res = await fetch('/api/v1/git/blame?path=' + encodeURIComponent(path))
+    const params = new URLSearchParams({ path })
+    if (keeper) params.set('keeper', keeper)
+    const res = await fetch('/api/v1/git/blame?' + params.toString())
     if (!res.ok) return []
     const data = await res.json()
     return Array.isArray(data) ? data : []
   } catch { return [] }
 }
 
-async function fetchDiff(path: string, baseRef = 'HEAD'): Promise<UnifiedDiffRow[]> {
+async function fetchDiff(path: string, baseRef = 'HEAD', keeper = ''): Promise<UnifiedDiffRow[]> {
   try {
-    const res = await fetch('/api/v1/git/diff?path=' + encodeURIComponent(path) + '&base_ref=' + encodeURIComponent(baseRef))
+    const params = new URLSearchParams({ path, base_ref: baseRef })
+    if (keeper) params.set('keeper', keeper)
+    const res = await fetch('/api/v1/git/diff?' + params.toString())
     if (!res.ok) return []
     const data = await res.json()
     return Array.isArray(data.unified) ? data.unified : []
@@ -134,7 +138,7 @@ export function IdeEditorMock({
 
   useEffect(() => {
     let cancelled = false
-    fetchBlame(activeIdeFile.value).then(blocks => {
+    fetchBlame(activeIdeFile.value, keeperName).then(blocks => {
       if (cancelled) return
       ownershipStore.reset(activeIdeFile.value)
       for (const block of blocks) {
@@ -149,16 +153,16 @@ export function IdeEditorMock({
       }
     })
     return () => { cancelled = true }
-  }, [activeIdeFile.value, ownershipStore])
+  }, [activeIdeFile.value, keeperName, ownershipStore])
 
   const [diffRows, setDiffRows] = useState<UnifiedDiffRow[]>([])
   useEffect(() => {
     let cancelled = false
-    fetchDiff(activeIdeFile.value).then(rows => {
+    fetchDiff(activeIdeFile.value, 'HEAD', keeperName).then(rows => {
       if (!cancelled) setDiffRows(rows)
     })
     return () => { cancelled = true }
-  }, [activeIdeFile.value])
+  }, [activeIdeFile.value, keeperName])
 
   const document = documentStore.document()
   const lines = documentStore.lines()

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -317,8 +317,8 @@ let add_routes router =
   |> Http.Router.get "/api/v1/git/blame" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
-           let base = base_path_of_state state in
            let uri = Uri.of_string request.target in
+           let base, _source = resolve_workspace_base ~state ~uri in
            let file_path =
              match Uri.get_query_param uri "path" with
              | Some p -> p
@@ -345,8 +345,8 @@ let add_routes router =
   |> Http.Router.get "/api/v1/git/diff" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
-           let base = base_path_of_state state in
            let uri = Uri.of_string request.target in
+           let base, _source = resolve_workspace_base ~state ~uri in
            let file_path =
              match Uri.get_query_param uri "path" with
              | Some p -> p


### PR DESCRIPTION
## Summary

Extends the keeper-aware base resolution from #12893 to the two remaining workspace routes (`/api/v1/git/blame`, `/api/v1/git/diff`). With `?keeper=<name>`, blame/diff run inside the keeper's playground; without it (or on unknown keeper / missing playground) the project root is used, matching tree/file behavior.

## Why

After #12893, the IDE Explorer + Editor showed playground content per-keeper, but the Blame timeline and Diff views silently kept reading from the project repo. That asymmetry was confusing — a keeper's edits in their playground were invisible in the editor's blame/diff layers even though the file content was theirs.

## Design notes

- Non-git playground falls back gracefully because `git_run_lines` already returns `[]` on any non-zero exit / exception. Both blame and diff converge on the existing empty-result branches; no new error path is added.
- Frontend: `fetchBlame` / `fetchDiff` accept an optional `keeper` argument, append `&keeper=<name>` only when set, and the consuming `useEffect` blocks depend on `keeperName` so they refetch when the active keeper changes.

## Out of scope

- Per-keeper diff base ref (still `HEAD`). Cross-keeper compare (`?base_keeper=`) is a separate plan.
- A `.git`-presence check that would short-circuit the git invocation entirely. Current graceful-empty path is functionally equivalent and avoids an extra syscall.

## Known main blocker

`lib/keeper/keeper_unified_turn.mli` is out of sync with `keeper_unified_turn.ml` after #12885 added `?yield_and_reacquire_slot` and renamed `keeper_cycle_channel` → `unified_turn_channel`. Build fails on main, so this PR's Build check will fail too — not caused by this diff. Separate fix tracked in a follow-up PR.

## Test plan

- [x] Lint changed file: `pnpm lint src/components/ide/ide-editor-mock.ts` — 0 errors on this file
- [ ] Build green — blocked by the unified_turn main blocker noted above
- [ ] Manual smoke after main is unblocked: keeper select → blame/diff refetches with playground commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)