### PR TITLE
revert: #12885 heuristic yield-and-reacquire — pursuing mathematical scheduler instead

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -589,10 +589,8 @@ let run_keepalive_unified_turn
           ~channel:turn_decision.channel
           ~kind:Semaphore_wait_pending;
         match
-          Keeper_turn_slot.with_keeper_turn_slot_yieldable
-            ~keeper_name:meta_after_triage.name
-            ~channel:turn_decision.channel
-            (fun ~semaphore_wait_ms ~yield_and_reacquire ->
+          Keeper_turn_slot.with_keeper_turn_slot ~keeper_name:meta_after_triage.name
+            ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
             match
               with_in_turn_liveness_pulse ~ctx ~meta:meta_after_observe ~stop
                 (fun () ->
@@ -604,7 +602,6 @@ let run_keepalive_unified_turn
                     ~channel:turn_decision.channel
                     ~semaphore_wait_ms:semaphore_wait_ms
                     ~shared_context
-                    ~yield_and_reacquire_slot:yield_and_reacquire
                     ())
             with
             | Error err ->

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -439,173 +439,7 @@ let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
            Eio.Fiber.yield ());
       wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at)
 
-(* Module-level bounded-acquire helper extracted from [with_keeper_turn_slot]
-   so it can also be used by [yield_and_reacquire_keeper_turn_slot]. *)
-let acquire_sem_bounded ~label ~keeper_name ~channel_label sem =
-  match Eio_context.get_clock_opt () with
-  | Some clock ->
-    (try
-      Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
-        Eio.Semaphore.acquire sem);
-      record_holder ~label ~keeper_name
-        ~acquired_at:(Time_compat.now ());
-      Ok ()
-    with Eio.Time.Timeout ->
-      (* Routine, not WARN: the keeper-specific heartbeat loop already
-         emits the operator-facing skip warning with owner/cascade
-         context, while the metric below preserves attribution.
-         2026-05-05: also dump the actual holders so operators are
-         not blind to *which* peer is starving the queue. *)
-      let holders =
-        snapshot_holders ~label ~now:(Time_compat.now ())
-      in
-      let holder_summary =
-        match holders with
-        | [] -> "(none — race or empty)"
-        | _ ->
-          holders
-          |> List.map (fun (n, age) -> Printf.sprintf "%s/%.0fs" n age)
-          |> String.concat ", "
-      in
-      Log.Keeper.routine
-        "semaphore_wait: %s semaphore wait exceeded %.0fs \
-         (channel=%s, holders=[%s]), skipping turn"
-        label semaphore_wait_timeout_sec
-        channel_label holder_summary;
-      (* #9771: per-keeper × per-acquire-channel counter so
-         operators can attribute slot starvation to autonomous
-         vs turn semaphore pressure. *)
-      Prometheus.inc_counter
-        Prometheus.metric_keeper_semaphore_wait_timeout
-        ~labels:[ ("keeper", keeper_name);
-                  ("channel", label) ]
-        ();
-      Error (`Semaphore_wait_timeout semaphore_wait_timeout_sec))
-  | None ->
-    (* No Eio clock available: we are running outside an Eio main loop
-       (e.g. Alcotest without [Eio_main.run]). Production masc-mcp
-       always provides a clock via [Masc_eio_env.init]; reaching this
-       branch at runtime would indicate an environment-setup drift,
-       so log it prominently before falling back to unbounded acquire. *)
-    Log.Keeper.warn
-      "semaphore_wait: no Eio clock available — %s acquire will be unbounded (environment drift?)"
-      label;
-    Eio.Semaphore.acquire sem;
-    record_holder ~label ~keeper_name ~acquired_at:(Time_compat.now ());
-    Ok ()
-
-(** Two-tier slot lifecycle (RFC: release autonomous turn slot at inner cancel).
-
-    Release the current autonomous slot, re-enter the FIFO fairness queue,
-    and reacquire the slot.  Peer keepers can acquire the slot during the
-    interval between release and reacquisition, preventing a single hung turn
-    from monopolizing the slot for the full outer wall-clock budget while
-    cascade-rotation retries run.
-
-    Returns [Ok new_wait_ms] on successful reacquisition, where [new_wait_ms]
-    is the milliseconds spent waiting.  Returns
-    [Error `Semaphore_wait_timeout] if the reacquisition exceeds
-    [semaphore_wait_timeout_sec].
-
-    No-op (returns [Ok 0]) for reactive-channel turns or when the autonomous
-    slot is not currently held.
-
-    Precondition: [state] must be the live [keeper_turn_slot_state] from the
-    enclosing [with_keeper_turn_slot_yieldable] callback. *)
-let yield_and_reacquire_keeper_turn_slot ~keeper_name ~channel state =
-  let is_autonomous =
-    match channel with
-    | Keeper_world_observation.Scheduled_autonomous -> true
-    | Keeper_world_observation.Reactive -> false
-  in
-  if not is_autonomous || not !(state.acquired_autonomous) then
-    (* Reactive turns or turns not holding the autonomous slot: nothing to yield. *)
-    Ok 0
-  else begin
-    (* channel_label is only needed once we confirm there is work to do. *)
-    let channel_label = Keeper_world_observation.channel_to_string channel in
-    let t0 = Time_compat.now () in
-    (* 1. Release the shared turn semaphore first (outer gate). *)
-    if !(state.acquired_turn) then begin
-      drop_holder ~label:"turn" ~keeper_name;
-      Eio.Semaphore.release turn_semaphore;
-      state.acquired_turn := false
-    end;
-    (* 2. Stamp completion time BEFORE releasing the autonomous semaphore,
-          mirroring [release_keeper_turn_slot]'s ordering so that
-          [maybe_yield_for_fairness] on the NEXT re-entry sees a correct
-          completion timestamp. *)
-    record_autonomous_completion ~keeper_name;
-    drop_holder ~label:"autonomous" ~keeper_name;
-    Eio.Semaphore.release autonomous_turn_semaphore;
-    state.acquired_autonomous := false;
-    Log.Keeper.info
-      "slot_yield: keeper=%s released autonomous slot for cascade rotation \
-       (peers may now acquire)"
-      keeper_name;
-    Prometheus.inc_counter
-      Prometheus.metric_keeper_slot_yield_total
-      ~labels:[("keeper", keeper_name)]
-      ();
-    (* 3. Fairness cooldown so a fast-cycling keeper does not monopolize the
-          slot on the very next re-entry. *)
-    maybe_yield_for_fairness ~keeper_name;
-    (* 4. Re-enter the FIFO queue. *)
-    let ticket = enqueue_autonomous_waiter ~keeper_name in
-    state.autonomous_ticket := Some ticket;
-    (* Helper to consistently clear ticket bookkeeping. *)
-    let clear_ticket () =
-      drop_autonomous_waiter ~ticket;
-      state.autonomous_ticket := None
-    in
-    let queue_entered_at = Time_compat.now () in
-    (* 5. Wait for this keeper to reach head of the FIFO queue. *)
-    match
-      wait_for_autonomous_queue_head ~keeper_name ~ticket
-        ~started_at:queue_entered_at
-    with
-    | Error _ as e ->
-        clear_ticket ();
-        e
-    | Ok () ->
-    (* 6. Reacquire the autonomous semaphore. *)
-    match
-      acquire_sem_bounded ~label:"autonomous" ~keeper_name ~channel_label
-        autonomous_turn_semaphore
-    with
-    | Error _ as e ->
-        clear_ticket ();
-        e
-    | Ok () ->
-        state.acquired_autonomous := true;
-        clear_ticket ();
-    (* 7. Reacquire the shared turn semaphore. *)
-    match
-      acquire_sem_bounded ~label:"turn" ~keeper_name ~channel_label
-        turn_semaphore
-    with
-    | Error _ as e ->
-        (* [acquired_autonomous] is true; [acquired_turn] stays false.
-           The Fun.protect finally block in [with_keeper_turn_slot_yieldable]
-           will release the autonomous semaphore correctly via
-           [release_keeper_turn_slot]. *)
-        e
-    | Ok () ->
-        state.acquired_turn := true;
-        let new_semaphore_wait_ms =
-          int_of_float ((Time_compat.now () -. t0) *. 1000.0)
-        in
-        Log.Keeper.info
-          "slot_yield: keeper=%s reacquired autonomous slot after %dms"
-          keeper_name new_semaphore_wait_ms;
-        Ok new_semaphore_wait_ms
-  end
-
-(* Shared implementation for [with_keeper_turn_slot] and
-   [with_keeper_turn_slot_yieldable].  [make_result] is called with the
-   elapsed semaphore wait and the live slot state once all semaphores are
-   held; its return value becomes the [Ok] payload. *)
-let with_keeper_turn_slot_impl ~keeper_name ~channel make_result =
+let with_keeper_turn_slot ~keeper_name ~channel f =
   let is_autonomous =
     match channel with
     | Keeper_world_observation.Scheduled_autonomous -> true
@@ -644,6 +478,59 @@ let with_keeper_turn_slot_impl ~keeper_name ~channel make_result =
       autonomous_ticket = ref None;
     }
   in
+  let acquire_bounded ~label sem =
+    match Eio_context.get_clock_opt () with
+    | Some clock ->
+      (try
+        Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
+          Eio.Semaphore.acquire sem);
+        record_holder ~label ~keeper_name
+          ~acquired_at:(Time_compat.now ());
+        Ok ()
+      with Eio.Time.Timeout ->
+        (* Routine, not WARN: the keeper-specific heartbeat loop already
+           emits the operator-facing skip warning with owner/cascade
+           context, while the metric below preserves attribution.
+           2026-05-05: also dump the actual holders so operators are
+           not blind to *which* peer is starving the queue. *)
+        let holders =
+          snapshot_holders ~label ~now:(Time_compat.now ())
+        in
+        let holder_summary =
+          match holders with
+          | [] -> "(none — race or empty)"
+          | _ ->
+            holders
+            |> List.map (fun (n, age) -> Printf.sprintf "%s/%.0fs" n age)
+            |> String.concat ", "
+        in
+        Log.Keeper.routine
+          "semaphore_wait: %s semaphore wait exceeded %.0fs \
+           (channel=%s, holders=[%s]), skipping turn"
+          label semaphore_wait_timeout_sec
+          channel_label holder_summary;
+        (* #9771: per-keeper × per-acquire-channel counter so
+           operators can attribute slot starvation to autonomous
+           vs turn semaphore pressure. *)
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_semaphore_wait_timeout
+          ~labels:[ ("keeper", keeper_name);
+                    ("channel", label) ]
+          ();
+        Error (`Semaphore_wait_timeout semaphore_wait_timeout_sec))
+    | None ->
+      (* No Eio clock available: we are running outside an Eio main loop
+         (e.g. Alcotest without [Eio_main.run]). Production masc-mcp
+         always provides a clock via [Masc_eio_env.init]; reaching this
+         branch at runtime would indicate an environment-setup drift,
+         so log it prominently before falling back to unbounded acquire. *)
+      Log.Keeper.warn
+        "semaphore_wait: no Eio clock available — %s acquire will be unbounded (environment drift?)"
+        label;
+      Eio.Semaphore.acquire sem;
+      record_holder ~label ~keeper_name ~acquired_at:(Time_compat.now ());
+      Ok ()
+  in
   Fun.protect
     ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
     (fun () ->
@@ -671,8 +558,7 @@ let with_keeper_turn_slot_impl ~keeper_name ~channel make_result =
           with
           | Error _ as e -> e
           | Ok () ->
-            match acquire_sem_bounded ~label:"autonomous" ~keeper_name ~channel_label
-                    autonomous_turn_semaphore with
+            match acquire_bounded ~label:"autonomous" autonomous_turn_semaphore with
             | Error _ as e -> e
             | Ok () ->
               slot_state.acquired_autonomous := true;
@@ -688,8 +574,7 @@ let with_keeper_turn_slot_impl ~keeper_name ~channel make_result =
         let reactive_result =
           if is_autonomous then Ok ()
           else
-            match acquire_sem_bounded ~label:"reactive" ~keeper_name ~channel_label
-                    reactive_turn_semaphore with
+            match acquire_bounded ~label:"reactive" reactive_turn_semaphore with
             | Error _ as e -> e
             | Ok () ->
               slot_state.acquired_reactive := true;
@@ -698,35 +583,13 @@ let with_keeper_turn_slot_impl ~keeper_name ~channel make_result =
         match reactive_result with
         | Error _ as e -> e
         | Ok () ->
-        match acquire_sem_bounded ~label:"turn" ~keeper_name ~channel_label
-                turn_semaphore with
+        match acquire_bounded ~label:"turn" turn_semaphore with
         | Error _ as e -> e
         | Ok () ->
           slot_state.acquired_turn := true;
           let semaphore_wait_ms =
             int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
-          Ok (make_result ~semaphore_wait_ms slot_state))
-
-let with_keeper_turn_slot ~keeper_name ~channel f =
-  with_keeper_turn_slot_impl ~keeper_name ~channel
-    (fun ~semaphore_wait_ms _slot_state -> f ~semaphore_wait_ms)
-;;
-
-(** Variant of [with_keeper_turn_slot] that also provides a
-    [~yield_and_reacquire] callback to the body function.  The callback
-    releases the autonomous slot mid-turn (for cascade rotation retries)
-    and reacquires it before returning.  See
-    [yield_and_reacquire_keeper_turn_slot] for the full contract.
-
-    The [Fun.protect] cleanup still covers all paths: whether the body
-    returns normally, raises, or the reacquisition fails partway through. *)
-let with_keeper_turn_slot_yieldable ~keeper_name ~channel f =
-  with_keeper_turn_slot_impl ~keeper_name ~channel
-    (fun ~semaphore_wait_ms slot_state ->
-      let yield_fn () =
-        yield_and_reacquire_keeper_turn_slot ~keeper_name ~channel slot_state
-      in
-      f ~semaphore_wait_ms ~yield_and_reacquire:yield_fn)
+          Ok (f ~semaphore_wait_ms))
 ;;
 
 let with_keeper_turn_slot_for_test ~keeper_name ~channel f =

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -69,35 +69,6 @@ val with_keeper_turn_slot :
   (semaphore_wait_ms:int -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of float ]) result
 
-(** Release the current autonomous slot, re-enter the FIFO fairness queue,
-    and reacquire the slot.  Peer keepers can acquire the slot during the
-    interval between release and reacquisition.
-
-    Returns [Ok new_wait_ms] on successful reacquisition, or
-    [Error `Semaphore_wait_timeout] if reacquisition exceeds
-    [semaphore_wait_timeout_sec].  No-op ([Ok 0]) for reactive turns or
-    when the autonomous slot is not held.
-
-    Must be called with the live [keeper_turn_slot_state] from the enclosing
-    [with_keeper_turn_slot_yieldable] callback. *)
-val yield_and_reacquire_keeper_turn_slot :
-  keeper_name:string ->
-  channel:Keeper_world_observation.keeper_cycle_channel ->
-  keeper_turn_slot_state ->
-  (int, [> `Semaphore_wait_timeout of float ]) result
-
-(** Variant of [with_keeper_turn_slot] that also passes a
-    [~yield_and_reacquire] callback to the body function.  The callback
-    releases the autonomous slot between cascade rotation attempts and
-    reacquires it before returning. *)
-val with_keeper_turn_slot_yieldable :
-  keeper_name:string ->
-  channel:Keeper_world_observation.keeper_cycle_channel ->
-  (semaphore_wait_ms:int ->
-   yield_and_reacquire:(unit -> (int, [> `Semaphore_wait_timeout of float ]) result) ->
-   'a) ->
-  ('a, [> `Semaphore_wait_timeout of float ]) result
-
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
   keeper_name:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -80,7 +80,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
     ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
     ?(semaphore_wait_ms = 0)
     ?shared_context
-    ?yield_and_reacquire_slot
     () : (keeper_meta, Agent_sdk.Error.sdk_error) result =
   (* Spec navigation (OCaml -> TLA+) — plan §19 Cycle 28 anchor for
      B2 (Task Acquisition).  Authoritative spec mirror is
@@ -1241,64 +1240,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                              | Some requested -> string_of_int requested
                              | None -> "none")
                             (short_preview (Agent_sdk.Error.to_string err));
-                          (* RFC: release the autonomous turn slot before the
-                             degraded retry so peer keepers can acquire it during
-                             the inter-attempt window (two-tier slot lifecycle).
-                             Without this, the slot is held for the full outer
-                             wall-clock budget even when the inner LLM op
-                             cancelled much earlier. *)
-                          let can_retry =
-                            match yield_and_reacquire_slot with
-                            | None -> true
-                            | Some yield_fn ->
-                                (match yield_fn () with
-                                 | Ok _new_wait_ms -> true
-                                 | Error (`Semaphore_wait_timeout timeout_sec) ->
-                                     Log.Keeper.warn
-                                       "%s: slot_yield: autonomous slot \
-                                        reacquisition timed out after %.0fs; \
-                                        aborting degraded retry to %s"
-                                       meta.name timeout_sec
-                                       next_execution_cascade_name;
-                                     Prometheus.inc_counter
-                                       Prometheus.metric_keeper_semaphore_wait_timeout
-                                       ~labels:[
-                                         ("keeper", meta.name);
-                                         ("channel", "autonomous_slot_yield");
-                                       ]
-                                       ();
-                                     false
-                                 | Error _ ->
-                                     (* Unknown acquisition error (not a
-                                        Semaphore_wait_timeout).  Abort the
-                                        cascade retry conservatively to avoid
-                                        running without a valid slot.
-                                        To investigate: check logs for
-                                        preceding slot_yield lines for
-                                        keeper=%s, and review any new error
-                                        variants introduced to
-                                        yield_and_reacquire_keeper_turn_slot. *)
-                                     Log.Keeper.warn
-                                       "%s: slot_yield: unexpected autonomous slot \
-                                        acquisition error; aborting degraded retry \
-                                        to %s (check slot_yield log lines for \
-                                        this keeper)"
-                                       meta.name next_execution_cascade_name;
-                                     false)
-                          in
-                          if not can_retry then begin
-                            mark_terminal_error err;
-                            Error err
-                          end else begin
-                            Eio.Fiber.yield ();
-                            retry_loop ~run_meta ~execution:next_execution
-                              ~run_generation
-                              ~attempt:1
-                              ~is_retry:true
-                              ~overflow_retry_used
-                              ~attempted_cascades:
-                                (next_execution_cascade_name :: attempted_cascades)
-                          end)
+                          Eio.Fiber.yield ();
+                          retry_loop ~run_meta ~execution:next_execution
+                            ~run_generation
+                            ~attempt:1
+                            ~is_retry:true
+                            ~overflow_retry_used
+                            ~attempted_cascades:
+                              (next_execution_cascade_name :: attempted_cascades))
                   | Degraded_retry_budget_exhausted degraded_retry ->
                       Log.Keeper.warn
                         "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but remaining turn budget %.1fs is below the OAS retry guard/minimum; ending this cycle: %s"

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -234,7 +234,6 @@ val run_keeper_cycle :
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
   ?shared_context:Agent_sdk.Context.t ->
-  ?yield_and_reacquire_slot:(unit -> (int, [> `Semaphore_wait_timeout of float ]) result) ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -402,13 +402,6 @@ let metric_tool_join_required_guard =
 let metric_keeper_semaphore_wait_timeout =
   "masc_keeper_semaphore_wait_timeout_total"
 
-(* Two-tier slot lifecycle (RFC #12885): autonomous slot released at inner
-   cancel and reacquired before the degraded-retry cascade attempt.
-   Labels: [keeper].  Incremented each time the slot is successfully
-   yielded and reacquired during a cascade rotation retry. *)
-let metric_keeper_slot_yield_total =
-  "masc_keeper_slot_yield_total"
-
 let metric_timeout_policy_overshoot =
   "masc_timeout_policy_overshoot_total"
 
@@ -1239,11 +1232,6 @@ let init () =
   add metric_keeper_turn_queue_depth
     "Current keeper turn wait queue depth (labels: channel=autonomous_queue)"
     Gauge;
-  add metric_keeper_slot_yield_total
-    "Total autonomous slot yield-and-reacquire cycles during cascade rotation \
-     retries (RFC: release autonomous turn slot at inner cancel). \
-     Labels: keeper."
-    Counter;
   (* P-DASH-13: provider block duration histogram.
      Records the duration (in seconds) for which a provider is placed in
      cooldown each time a cooldown is applied or extended.  Labels: provider. *)

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -276,16 +276,6 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_auth_credential_token_rotated;
   check_registered Prometheus.metric_telemetry_coverage_gap
 
-let test_slot_yield_metric_registered () =
-  let text = Prometheus.to_prometheus_text () in
-  check bool "has slot yield HELP" true
-    (text_has_literal text
-       ("# HELP " ^ Prometheus.metric_keeper_slot_yield_total ^ " "));
-  check bool "has slot yield TYPE" true
-    (text_has_literal text
-       ("# TYPE " ^ Prometheus.metric_keeper_slot_yield_total
-        ^ " counter"))
-
 let test_distributed_lock_metric_registered () =
   let text = Prometheus.to_prometheus_text () in
   check bool "has distributed lock HELP" true
@@ -469,8 +459,6 @@ let () =
         test_review_blocker_metrics_registered;
       test_case "distributed lock metric registered" `Quick
         test_distributed_lock_metric_registered;
-      test_case "slot yield metric registered" `Quick
-        test_slot_yield_metric_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
     ];


### PR DESCRIPTION
Reverts #12885 per project-owner directive (2026-05-05): no heuristic stop-gaps in the keeper turn-slot lifecycle. Pursuing the principled mathematical scheduler (RFC #12908) instead.

## Why revert (not layer-on)

#12885 is sound code as a heuristic, but it does not satisfy the project's first-class invariant `∀ keeper k. eventually-progresses(k)` with mathematical guarantees:

- Bounded wait not provable — `semaphore_wait_timeout_sec` hardcoded; on timeout keeper *skips* rather than gets dispatched, so worst case is still starvation.
- Work-conserving not enforced — yield relies on peer races; no invariant blocks `idle_provider(p, t) ∧ waiting_keeper(k, t) ∧ compatible(k, p)`.
- Provider rate-limit implicit — cascade rotation is heuristic; no per-provider token bucket means rate violations possible under burst.
- TLA+ coverage missing — no `LivenessInvariant` / `WorkConserving` predicates.

The heuristic adds ~313 LOC of code that L5 of the mathematical RFC will need to remove anyway. Reverting now keeps `main` clean for the L1→L5 build-out instead of adding revert work later.

## Verification

```bash
dune build --root . @check    # clean
git diff main..HEAD --stat    # 7 files, +68 -313
```

Files reverted to `main` HEAD pre-#12885 state:
- `lib/keeper/keeper_heartbeat_loop.ml`
- `lib/keeper/keeper_turn_slot.ml`, `.mli`
- `lib/keeper/keeper_unified_turn.ml`, `.mli`
- `lib/prometheus.ml`
- `test/test_prometheus_coverage.ml`

## Production impact

None — running production binary (PID 38838, mtime 2026-05-05 03:02 KST) was built **12 minutes before #12885 merged at 03:14 KST**. Live server never ran the heuristic. Reverting `main` restores the clean baseline that production was already on.

Slot-leak symptoms (8 keepers always held, 6 waiting, `cascade_attempt_terminal=0`) will continue until the L1→L5 mathematical scheduler lands. Operator-side mitigation via `keeper_down` for low-priority keepers is the only short-term lever.

## Cross-refs

- Reverts: #12885
- Replaces with: #12908 (RFC: Mathematical scheduler)
- Earlier RFC subsumed: #12888 (slot lifecycle redesign)
- Owner statement: "어떤 keeper도 절대 막히지 않음. 이 가장 중요한 가치고 그걸 위한 고도의 수학적 설계여야함" (2026-05-05)