### PR TITLE
feat(keeper): emit metric_keeper_board_signal_no_wake_total for silent board-signal drops

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -266,6 +266,11 @@ let wakeup_relevant_keeper_for_board_signal
     |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
       if e.phase = Keeper_state_machine.Running then Some e.name else None)
   in
+  let signal_kind_label =
+    match signal.kind with
+    | Board_dispatch.Board_post_created -> "post_created"
+    | Board_dispatch.Board_comment_added -> "comment_added"
+  in
   let candidates =
     running_names
     |> List.filter_map (fun name ->
@@ -277,6 +282,24 @@ let wakeup_relevant_keeper_for_board_signal
             ~meta
             ~signal
         in
+        (* Visibility for the REPO_WAKE_UP audit finding: a [None]
+           wake_reason means the running keeper had no explicit_mention
+           match, scope feed disabled, and (for comments) no external
+           reply after a self-comment. Without this counter, operators
+           cannot distinguish between a board post that legitimately
+           had no addressee and one that was silently dropped by a
+           keeper whose [room_signal_prompt_enabled] / mention_targets
+           configuration is too narrow. *)
+        (match wake_reason with
+         | None ->
+           Prometheus.inc_counter
+             Prometheus.metric_keeper_board_signal_no_wake_total
+             ~labels:[
+               ("keeper", meta.name);
+               ("kind", signal_kind_label);
+             ]
+             ()
+         | Some _ -> ());
         Some (meta, wake_reason)
       | _ -> None)
   in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -507,6 +507,8 @@ let metric_keeper_generation_lineage_failures =
   "masc_keeper_generation_lineage_failures_total"
 let metric_keeper_keepalive_signal_failures =
   "masc_keeper_keepalive_signal_failures_total"
+let metric_keeper_board_signal_no_wake_total =
+  "masc_keeper_board_signal_no_wake_total"
 let metric_keeper_meta_json_failures =
   "masc_keeper_meta_json_failures_total"
 let metric_keeper_tools_oas_failures =
@@ -1372,6 +1374,16 @@ let init () =
     Counter;
   add metric_keeper_keepalive_signal_failures
     "Total keeper keepalive signal failures (board capped/late-event rejected), labeled by keeper and site"
+    Counter;
+  add metric_keeper_board_signal_no_wake_total
+    "Total board signals (post_created/comment_added) that did not produce a \
+     wake decision for a running keeper. Increments per (keeper, kind) when \
+     [Keeper_world_observation.board_signal_wake_reason] returns [None] — i.e. \
+     no explicit_mention, scope feed disabled, and (for comments) no external \
+     reply after a self-comment. Operators alert on this counter when keepers \
+     should be reacting to a known board signal: a high rate identifies \
+     keepers whose [room_signal_prompt_enabled] / mention-target configuration \
+     drops legitimate signals. Labels: keeper, kind=post_created|comment_added."
     Counter;
   add metric_keeper_meta_json_failures
     "Total keeper meta JSON failures (seed parse/unknown keys), labeled by site"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -211,6 +211,18 @@ val metric_keeper_fs_failures : string
 val metric_keeper_crash_persistence_failures : string
 val metric_keeper_generation_lineage_failures : string
 val metric_keeper_keepalive_signal_failures : string
+
+val metric_keeper_board_signal_no_wake_total : string
+(** Total board signals that did not produce a wake decision for a
+    running keeper. Increments per (keeper, kind) when
+    [Keeper_world_observation.board_signal_wake_reason] returns
+    [None] — no explicit_mention, scope feed disabled, and no
+    external reply after a self-comment. Discoverability for the
+    REPO_WAKE_UP audit finding: keepers with
+    [room_signal_prompt_enabled = false] (Minimal preset default)
+    silently drop board posts. Labels: keeper,
+    kind=post_created|comment_added. *)
+
 val metric_keeper_meta_json_failures : string
 val metric_keeper_tools_oas_failures : string
 val metric_keeper_turn_up_update_failures : string


### PR DESCRIPTION
## Summary

Adds `masc_keeper_board_signal_no_wake_total{keeper, kind}` to expose silent board-signal drops. Increments per (keeper, kind) when `Keeper_world_observation.board_signal_wake_reason` returns `None` for a running keeper — i.e. the board post/comment was dispatched but the keeper's configuration silently dropped it.

## Why (REPO_WAKE_UP audit finding)

`default_room_signal_prompt_enabled = false` (`keeper_config.ml:121`). A Minimal-preset keeper without the board tool in `also_allow` retains this default. For such keepers, `board_signal_wake_reason` returns `None` on every `Board_post_created` that lacks an explicit `@`-mention. Wake never fires. Operators currently cannot distinguish:

- "the post had no addressee" — legitimate skip
- "the keeper's `mention_targets` / `room_signal_prompt_enabled` is too narrow and silently swallowed a signal that should have woken it"

This counter surfaces the second case so operators can alert on per-keeper rate-of-no-wake.

## Trade-offs

- **No behavioural change.** Wake decisions and dispatch order are unchanged. Only adds observability.
- The increment site is the caller (`wakeup_relevant_keeper_for_board_signal`), not `board_signal_wake_reason` itself, because the function has callers outside the wake path (diagnostic dumps, tests) that should not pollute production metrics.
- Label cardinality is bounded: `keeper` (small fleet) × `kind` (2 values: post_created/comment_added) = small Cartesian product per cluster.

## Test plan
- [ ] CI: dune build lib/ passes
- [ ] CI: lint passes (no Log/Stdlib drift, metric registration is symmetric with existing keeper-area metrics)
- [ ] Followup: dashboard panel + alert rule on rate-of-no-wake per keeper

## Followups

1. Dashboard panel under "Keeper signals" surfacing top-N keepers by no-wake rate.
2. Alert rule: per-keeper p99 rate threshold to flag operator-side configuration drift.
3. Decide whether to also emit a [debug-level] structured log alongside the counter for trace context (post_id, signal author).