### PR TITLE
fix(keeper): sync mli for run_unified_turn + metric_keeper_slot_yield_total

### DIFF
--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -246,5 +246,6 @@ val run_unified_turn :
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
   ?shared_context:Agent_sdk.Context.t ->
+  ?yield_and_reacquire_slot:(unit -> (int, [> `Semaphore_wait_timeout of float ]) result) ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -154,6 +154,11 @@ val metric_keeper_turn_queue_depth : string
     FIFO wait queue. Reactive turn depth is intentionally not inferred from
     semaphore availability. *)
 
+val metric_keeper_slot_yield_total : string
+(** RFC #12885: incremented each time the autonomous turn slot is
+    successfully yielded and reacquired during a cascade rotation retry.
+    Labels: [keeper]. *)
+
 val metric_timeout_policy_overshoot : string
 (** #9662: cooperative-cancel timeout overshoot counter emitted by
     [Timeout_policy].  Labels: [layer, origin]. *)


### PR DESCRIPTION
## Summary

Surgical 2-line fix for the main blocker introduced by #12885 (RFC autonomous turn slot release). All open PRs (#12907, #12906, #12904, #12901, #12896) currently fail the Build check on this; restoring main fixes them all.

## Root cause

#12885 added two new public surface elements without updating their `.mli` files:

| Symbol | .ml | .mli before | .mli after |
|---|---|---|---|
| `Keeper_unified_turn.run_unified_turn` | aliased to `run_keeper_cycle` (now takes `?yield_and_reacquire_slot`) | missing | adds the optional param |
| `Prometheus.metric_keeper_slot_yield_total` | defined + registered | missing | exposed as `string` |

OCaml type checker rejected the alias definition with:
```
The first argument is labeled ?yield_and_reacquire_slot,
but an unlabeled argument was expected
File "lib/keeper/keeper_unified_turn.mli", lines 241-250
File "lib/keeper/keeper_unified_turn.ml", line 2340
```

And:
```
Error: Unbound value Prometheus.metric_keeper_slot_yield_total
File "lib/keeper/keeper_turn_slot.ml", line 547
```

## Test plan

- [x] `dune build --build-dir=_build_iso lib/masc_mcp.cma` (isolated to avoid cross-session `_build` corruption) — green after the two-file change
- [x] No behavior change — only visibility; the actual values were already exported by `.ml` and registered with the Prometheus backend.

## Memory pattern reference

Memory `feedback_main_blockers_check_unrelated_pr_check_fails`: when an unrelated PR's check fails on a symbol the PR did not touch, treat as a main blocker, fix at root level, all open PRs auto-unblock.