### PR TITLE
refactor(dashboard): remove remaining IDE activity/conversation mock data

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -50,21 +50,7 @@ interface ApiActivityResponse {
   readonly latest_seq?: number
 }
 
-const MOCK_ACTIVITY: ReadonlyArray<RunActivityEvent> = [
-  { id: 'a13', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 41, 18), keeper_id: 'nick0cave', verb: 'flagged', target: 'router.ts:34', detail: 'if:moonshot-tool-choice · blocker' },
-  { id: 'a12', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 40, 2), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:35', detail: '+ next.tool_choice = "auto"' },
-  { id: 'a11', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 39, 2), keeper_id: 'operator', verb: 'commented on', target: 'router.ts:26', detail: 'question · resolveCascade' },
-  { id: 'a10', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 37, 11), keeper_id: 'masc-improver', verb: 'edited', target: 'registry.ts:10', detail: '+8 -2 · budgetFor' },
-  { id: 'a09', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 35, 22), keeper_id: 'masc-improver', verb: 'committed', target: 'improver/wt-47', detail: 'fix: init budget map lazily' },
-  { id: 'a08', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 32, 8), keeper_id: 'masc-improver', verb: 'refactored', target: 'registry.ts', detail: 'extracted budgetFor' },
-  { id: 'a07', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 28, 15), keeper_id: 'operator', verb: 'commented on', target: 'registry.ts:10', detail: 'note · log.warn naming' },
-  { id: 'a06', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 22, 41), keeper_id: 'operator', verb: 'approved', target: 'router.ts:60', detail: 'nextStep · budget guard' },
-  { id: 'a05', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 18, 4), keeper_id: 'operator', verb: 'noted', target: 'router.ts:35', detail: 'flag · race on Map init' },
-  { id: 'a04', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 14, 52), keeper_id: 'masc-improver', verb: 'suggested on', target: 'router.ts:16', detail: 'suggest · extract helper' },
-  { id: 'a03', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 9, 11), keeper_id: 'nick0cave', verb: 'edited', target: 'router.ts:34', detail: '+1 -0 · tool_choice guard' },
-  { id: 'a02', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 1, 2, 11), keeper_id: 'operator', verb: 'flagged', target: 'registry.ts:10', detail: 'race condition' },
-  { id: 'a01', run_id: FALLBACK_ROOM_ID, timestamp_ms: Date.UTC(2026, 4, 2, 0, 58, 32), keeper_id: 'operator', verb: 'asked on', target: 'router.ts:26', detail: 'question · resolveCascade' },
-]
+const EMPTY_ACTIVITY: ReadonlyArray<RunActivityEvent> = []
 
 function verbFromKind(kind: string): RunActivityVerb {
   return KIND_TO_VERB[kind] ?? DEFAULT_VERB
@@ -102,24 +88,24 @@ function mapApiEvent(event: ApiActivityEvent, roomId: string): RunActivityEvent 
 async function fetchActivityEvents(): Promise<{ events: ReadonlyArray<RunActivityEvent>; roomId: string }> {
   try {
     const res = await fetch('/api/v1/activity/events?limit=50')
-    if (!res.ok) return { events: MOCK_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+    if (!res.ok) return { events: EMPTY_ACTIVITY, roomId: FALLBACK_ROOM_ID }
     const data: ApiActivityResponse = await res.json()
     const rawEvents = data.events
     if (!Array.isArray(rawEvents) || rawEvents.length === 0) {
-      return { events: MOCK_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+      return { events: EMPTY_ACTIVITY, roomId: FALLBACK_ROOM_ID }
     }
     const roomId = rawEvents[0].room_id || FALLBACK_ROOM_ID
     const mapped = rawEvents.map(e => mapApiEvent(e, roomId))
     return { events: mapped, roomId }
   } catch {
-    return { events: MOCK_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+    return { events: EMPTY_ACTIVITY, roomId: FALLBACK_ROOM_ID }
   }
 }
 
 export function IdeActivityMock() {
   const store = useMemo(() => {
     const store = createRunActivityStore(FALLBACK_ROOM_ID)
-    store.seed(MOCK_ACTIVITY)
+    store.seed(EMPTY_ACTIVITY)
     return store
   }, [])
   const [, forceRender] = useState(0)

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -30,23 +30,17 @@ const KIND_TOKEN: Record<ThreadKind, string> = {
   suggest: 'var(--color-status-warn, var(--warn))',
 }
 
-const FALLBACK_POSTS: ReadonlyArray<BoardPost> = [
-  { id: 'p-mock-1', title: '', body: "flag: tool schema edge we're seeing in prod - keep tools[] and tool_choice paired.", author_identity: 'nick0cave', votes: 2, comment_count: 2, created_at_iso: '2026-05-02T01:41:18Z' },
-  { id: 'p-mock-2', title: '', body: 'Should normalizeTools also handle tool_choice=none? feels like an edge case.', author_identity: 'operator', votes: 0, comment_count: 1, created_at_iso: '2026-05-02T01:39:02Z' },
-  { id: 'p-mock-3', title: '', body: 'Budget guard reads well. Ship it when tests pass.', author_identity: 'operator', votes: 1, comment_count: 0, created_at_iso: '2026-05-02T01:22:41Z' },
-  { id: 'p-mock-4', title: '', body: 'telemetry event name needs to match the lifeline schema - will rename later.', author_identity: 'operator', votes: 0, comment_count: 0, created_at_iso: '2026-05-02T01:18:04Z' },
-  { id: 'p-mock-5', title: '', body: 'Could you collapse the rest-spread into a small helper? Same pattern appears in provider.ts.', author_identity: 'masc-improver', votes: 0, comment_count: 3, created_at_iso: '2026-05-02T01:14:52Z' },
-]
+const EMPTY_POSTS: ReadonlyArray<BoardPost> = []
 
 async function fetchBoardPosts(): Promise<ReadonlyArray<BoardPost>> {
   try {
     const res = await fetch('/api/v1/board?limit=20&exclude_system=true&exclude_automation=true')
-    if (!res.ok) return FALLBACK_POSTS
+    if (!res.ok) return EMPTY_POSTS
     const data = await res.json()
     if (Array.isArray(data) && data.length > 0) return data as BoardPost[]
-    return FALLBACK_POSTS
+    return EMPTY_POSTS
   } catch {
-    return FALLBACK_POSTS
+    return EMPTY_POSTS
   }
 }
 
@@ -66,7 +60,7 @@ function boardKindFromPost(post: BoardPost): ThreadKind {
 }
 
 export function IdeConversationRailMock() {
-  const [posts, setPosts] = useState<ReadonlyArray<BoardPost>>(FALLBACK_POSTS)
+  const [posts, setPosts] = useState<ReadonlyArray<BoardPost>>(EMPTY_POSTS)
   const [focusedId, setFocusedId] = useState<string | null>(null)
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Remove `MOCK_ACTIVITY` (13 hardcoded events) from `ide-activity-mock.ts`, replace with empty array fallback
- Remove `FALLBACK_POSTS` (5 hardcoded board posts) from `ide-conversation-rail-mock.ts`, replace with empty array fallback
- Both components already fetch from real APIs (`/api/v1/activity/events`, `/api/v1/board`)

Follow-up to #12902 which handled editor/explorer/presence strip mock removal.

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] Dashboard `#code?section=ide-shell` loads without hardcoded mock data in ACTIVITY and CONVERSATION panels
- [ ] With running MASC server, real events and board posts appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)