### PR TITLE
style(dashboard): normalize modern alpha notation to bare-decimal

### DIFF
--- a/dashboard/src/styles/a11y.css
+++ b/dashboard/src/styles/a11y.css
@@ -23,14 +23,14 @@
   outline: none;
   box-shadow:
     0 0 0 1px var(--color-accent-brass),
-    0 0 0 3px rgb(var(--brass-glow) / 0.25);
+    0 0 0 3px rgb(var(--brass-glow) / .25);
 }
 
 .focusable.is-err:focus-visible {
   outline: none;
   box-shadow:
     0 0 0 1px var(--color-status-err),
-    0 0 0 3px rgb(var(--color-status-err-glow) / 0.3);
+    0 0 0 3px rgb(var(--color-status-err-glow) / .3);
 }
 
 /* Screen-reader only utility — visually hidden but accessible to assistive tech. */

--- a/dashboard/src/styles/base.css
+++ b/dashboard/src/styles/base.css
@@ -19,7 +19,7 @@ body {
   line-height: var(--lh-body);
   background-color: var(--color-bg-page);
   background-image:
-    radial-gradient(circle at 88% 14%, rgb(var(--brass-glow) / 0.05), transparent 20%);
+    radial-gradient(circle at 88% 14%, rgb(var(--brass-glow) / .05), transparent 20%);
   background-attachment: fixed;
   position: relative;
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -74,7 +74,7 @@
 .agent-card:hover {
   box-shadow: inset 2px 0 0 var(--brass-1);
   transform: none;
-  border-color: rgb(var(--brass-glow) / 0.30);
+  border-color: rgb(var(--brass-glow) / .30);
 }
 
 @utility logs-refresh-btn { &:hover { border-color: var(--brass-1); } }
@@ -175,7 +175,7 @@
 
 .swimlane-vis-container .vis-labelset .vis-label.activity-swimlane-group-highlighted,
 .swimlane-vis-container .vis-center .vis-group.activity-swimlane-group-highlighted {
-  background: rgb(var(--brass-glow) / 0.08);
+  background: rgb(var(--brass-glow) / .08);
 }
 
 .swimlane-vis-container .vis-labelset .vis-label.activity-swimlane-group-highlighted {
@@ -208,7 +208,7 @@
 .swimlane-vis-container .vis-item.vis-selected {
   border-color: var(--warn);
   border-width: 2px;
-  box-shadow: 0 0 5px rgb(var(--brass-glow) / 0.5);
+  box-shadow: 0 0 5px rgb(var(--brass-glow) / .5);
   z-index: 10;
 }
 

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -199,7 +199,7 @@ tbody tr:hover {
 #app > div > header {
   border-color: var(--color-border-default);
   padding-block: 6px;
-  box-shadow: inset 0 -1px 0 rgb(var(--brass-glow) / 0.08);
+  box-shadow: inset 0 -1px 0 rgb(var(--brass-glow) / .08);
 }
 
 #app > div > div.flex-1 {
@@ -211,7 +211,7 @@ tbody tr:hover {
 #main-content {
   border-color: var(--color-border-default);
   border-radius: var(--r-1);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.015);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / .015);
 }
 
 #main-content > div {

--- a/dashboard/src/styles/governance-agent.css
+++ b/dashboard/src/styles/governance-agent.css
@@ -4,7 +4,7 @@
   background:
     linear-gradient(
       135deg,
-      rgb(var(--color-accent-glow) / 0.03) 0%,
+      rgb(var(--color-accent-glow) / .03) 0%,
       var(--color-bg-page) 100%
     );
   box-shadow:

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -4,8 +4,8 @@
 /* ═══ Governance ═══ */
 
 button.governance-row.selected {
-  border-color: rgb(var(--info-glow) / 0.5);
-  background: rgb(var(--brass-glow) / 0.14);
+  border-color: rgb(var(--info-glow) / .5);
+  background: rgb(var(--brass-glow) / .14);
 }
 
 /* ── Responsive ── */
@@ -25,7 +25,7 @@ button.governance-row.selected {
   background:
     linear-gradient(
       135deg,
-      rgb(var(--color-accent-glow) / 0.03) 0%,
+      rgb(var(--color-accent-glow) / .03) 0%,
       var(--color-bg-page) 100%
     );
   box-shadow:

--- a/dashboard/src/styles/live-monitor.css
+++ b/dashboard/src/styles/live-monitor.css
@@ -15,7 +15,7 @@
 @utility pulse-selected {
   border-color: var(--color-accent-fg);
   background: var(--color-bg-elevated);
-  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / 0.3);
+  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / .3);
 }
 
 @utility activity-item {

--- a/dashboard/src/styles/paper-theme.css
+++ b/dashboard/src/styles/paper-theme.css
@@ -89,11 +89,11 @@
   --color-info-glow: 62 74 92;
   --color-stalled-glow: 92 62 86;
 
-  --color-ok-soft: rgb(var(--color-ok-glow) / 0.10);
-  --color-warn-soft: rgb(var(--color-warn-glow) / 0.12);
-  --color-err-soft: rgb(var(--color-err-glow) / 0.12);
-  --color-info-soft: rgb(var(--color-info-glow) / 0.12);
-  --color-stalled-soft: rgb(var(--color-stalled-glow) / 0.12);
+  --color-ok-soft: rgb(var(--color-ok-glow) / .10);
+  --color-warn-soft: rgb(var(--color-warn-glow) / .12);
+  --color-err-soft: rgb(var(--color-err-glow) / .12);
+  --color-info-soft: rgb(var(--color-info-glow) / .12);
+  --color-stalled-soft: rgb(var(--color-stalled-glow) / .12);
   --color-idle-soft: rgba(135, 131, 121, 0.10);
 
   /* =====================================================================

--- a/dashboard/src/styles/pipeline.css
+++ b/dashboard/src/styles/pipeline.css
@@ -18,8 +18,8 @@
 }
 
 .pipeline-stage-node.active.stage-idle .pipeline-stage-dot {
-  background: rgb(var(--color-fg-muted-rgb, 148 163 184) / 0.6);
-  border-color: rgb(var(--color-fg-muted-rgb, 148 163 184) / 0.8);
+  background: rgb(var(--color-fg-muted-rgb, 148 163 184) / .6);
+  border-color: rgb(var(--color-fg-muted-rgb, 148 163 184) / .8);
 }
 
 .pipeline-stage-node.active.stage-thinking .pipeline-stage-dot {
@@ -50,8 +50,8 @@
 }
 
 .pipeline-stage-node.active.stage-offline .pipeline-stage-dot {
-  background: rgb(var(--color-fg-disabled-rgb, 75 75 85) / 0.6);
-  border-color: rgb(var(--color-fg-disabled-rgb, 75 75 85) / 0.8);
+  background: rgb(var(--color-fg-disabled-rgb, 75 75 85) / .6);
+  border-color: rgb(var(--color-fg-disabled-rgb, 75 75 85) / .8);
 }
 
 /* Transient runtime states (failing, crashed, draining, paused, restarting) */
@@ -87,7 +87,7 @@
 
 /* ── Pipeline stage badge variants ── */
 @utility pipeline-stage-badge {
-  &.stage-offline { color: var(--color-fg-muted); background: rgb(var(--color-accent-glow) / 0.04); border-color: var(--color-border-default); }
+  &.stage-offline { color: var(--color-fg-muted); background: rgb(var(--color-accent-glow) / .04); border-color: var(--color-border-default); }
   &.stage-failing, &.stage-crashed { color: rgb(var(--err-glow) / .85); background: rgb(var(--err-glow) / .12); border-color: rgb(var(--err-glow) / .2); }
   &.stage-draining { color: rgb(var(--warn-glow) / .85); background: rgb(var(--warn-glow) / .12); border-color: rgb(var(--warn-glow) / .2); }
   &.stage-restarting { color: rgb(var(--info-glow) / .85); background: rgb(var(--info-glow) / .12); border-color: rgb(var(--info-glow) / .2); }

--- a/dashboard/src/styles/pixel-avatar.css
+++ b/dashboard/src/styles/pixel-avatar.css
@@ -65,7 +65,7 @@
 
 @utility activity-dot--live-pulse {
   background: var(--color-agent-working);
-  box-shadow: 0 0 4px rgb(var(--ok-glow) / 0.8);
+  box-shadow: 0 0 4px rgb(var(--ok-glow) / .8);
   animation: pulse 1.5s var(--ease-inout) infinite;
 }
 

--- a/dashboard/src/styles/rail.css
+++ b/dashboard/src/styles/rail.css
@@ -78,7 +78,7 @@
 .tool-chip.is-last {
   border-color: var(--brass-1);
   color: var(--brass-1);
-  background: rgb(var(--brass-glow) / 0.08);
+  background: rgb(var(--brass-glow) / .08);
 }
 .tool-count {
   font-size: var(--fs-9); color: var(--color-fg-muted);
@@ -87,7 +87,7 @@
 }
 .tool-chip.is-last .tool-count {
   color: var(--brass-1);
-  background: rgb(var(--brass-glow) / 0.15);
+  background: rgb(var(--brass-glow) / .15);
 }
 
 /* Tool Timeline (inspector tab) */
@@ -123,7 +123,7 @@
   width: 7px; height: 7px; border-radius: var(--radius-circle);
   top: 50%; transform: translate(-50%, -50%);
   cursor: pointer;
-  border: 1px solid rgb(0 0 0 / 0.3);
+  border: 1px solid rgb(0 0 0 / .3);
   transition: transform var(--t-fast);
 }
 .tl-dot:hover { transform: translate(-50%, -50%) scale(1.6); z-index: 2; }

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -38,8 +38,8 @@
      SPEC selectors). Triplets decompose the corresponding hex semantic
      color (--accent / --ok / --warn / --bad / --purple) so callers
      compose the alpha at use site:
-       box-shadow: 0 0 8px rgb(var(--ok-glow) / 0.35)
-       background: rgb(var(--err-glow) / 0.08)
+       box-shadow: 0 0 8px rgb(var(--ok-glow) / .35)
+       background: rgb(var(--err-glow) / .08)
      SPEC source: dashboard/design-system/source_styles/tokens.css §
      "Status glow triplets". The live shell previously decomposed the
      retired bright-blue palette; this bridge follows the generated
@@ -53,42 +53,42 @@
   --brass-glow: var(--color-brass-glow);
 
   /* Semantic - Accent (Brass) */
-  --accent-soft: rgb(var(--brass-glow) / 0.16);
-  --accent-6: rgb(var(--brass-glow) / 0.06);
-  --accent-8: rgb(var(--brass-glow) / 0.08);
-  --accent-10: rgb(var(--brass-glow) / 0.10);
-  --accent-12: rgb(var(--brass-glow) / 0.12);
-  --accent-20: rgb(var(--brass-glow) / 0.20);
-  --accent-30: rgb(var(--brass-glow) / 0.30);
+  --accent-soft: rgb(var(--brass-glow) / .16);
+  --accent-6: rgb(var(--brass-glow) / .06);
+  --accent-8: rgb(var(--brass-glow) / .08);
+  --accent-10: rgb(var(--brass-glow) / .10);
+  --accent-12: rgb(var(--brass-glow) / .12);
+  --accent-20: rgb(var(--brass-glow) / .20);
+  --accent-30: rgb(var(--brass-glow) / .30);
   /* Off-alpha accent tokens absorbed from Phase B inline-rgba sweep.
      Same brass hue, opacity buckets that were already spread across
      components. Naming follows the --accent-N (N = opacity %) convention.
      Note: --accent-18 was previously pruned as unused; this PR reintroduces
      it with 5 active callsites. */
-  --accent-15: rgb(var(--brass-glow) / 0.15);
-  --accent-18: rgb(var(--brass-glow) / 0.18);
-  --accent-36: rgb(var(--brass-glow) / 0.36);
+  --accent-15: rgb(var(--brass-glow) / .15);
+  --accent-18: rgb(var(--brass-glow) / .18);
+  --accent-36: rgb(var(--brass-glow) / .36);
   /* --accent-45 reserved for focus-ring strength (high-contrast keyboard
      focus halo). Distinct semantic from -30 so the role is grep-able. */
-  --accent-45: rgb(var(--brass-glow) / 0.45);
-  --accent-5: rgb(var(--brass-glow) / 0.05);
-  --accent-25: rgb(var(--brass-glow) / 0.25);
-  --accent-35: rgb(var(--brass-glow) / 0.35);
-  --accent-40: rgb(var(--brass-glow) / 0.40);
-  --accent-50: rgb(var(--brass-glow) / 0.50);
-  --accent-60: rgb(var(--brass-glow) / 0.60);
+  --accent-45: rgb(var(--brass-glow) / .45);
+  --accent-5: rgb(var(--brass-glow) / .05);
+  --accent-25: rgb(var(--brass-glow) / .25);
+  --accent-35: rgb(var(--brass-glow) / .35);
+  --accent-40: rgb(var(--brass-glow) / .40);
+  --accent-50: rgb(var(--brass-glow) / .50);
+  --accent-60: rgb(var(--brass-glow) / .60);
 
   /* Semantic - Success (Green) */
-  --ok-soft: rgb(var(--ok-glow) / 0.15);
-  --ok-10: rgb(var(--ok-glow) / 0.10);
-  --ok-20: rgb(var(--ok-glow) / 0.20);
-  --ok-35: rgb(var(--ok-glow) / 0.35);
+  --ok-soft: rgb(var(--ok-glow) / .15);
+  --ok-10: rgb(var(--ok-glow) / .10);
+  --ok-20: rgb(var(--ok-glow) / .20);
+  --ok-35: rgb(var(--ok-glow) / .35);
 
   /* Semantic - Warning (Yellow) */
   /* --warn-bright lifted to source.ts (Iter 2c-10); FSM Compacting tint */
-  --warn-soft: rgb(var(--warn-glow) / 0.15);
-  --warn-10: rgb(var(--warn-glow) / 0.10);
-  --warn-20: rgb(var(--warn-glow) / 0.20);
+  --warn-soft: rgb(var(--warn-glow) / .15);
+  --warn-10: rgb(var(--warn-glow) / .10);
+  --warn-20: rgb(var(--warn-glow) / .20);
 
   /* Vote button Reddit-pattern colors lifted to source.ts (Iter 2c-9).
      Reddit upvote = #ff4500 remains canonical; see source.ts. */
@@ -103,13 +103,13 @@
 
   /* Semantic - Critical (Red) */
   /* --bad-light lifted to source.ts (Iter 2c-10); softer red for toasts */
-  --bad-soft: rgb(var(--err-glow) / 0.15);
+  --bad-soft: rgb(var(--err-glow) / .15);
   --err-soft: var(--bad-soft);
-  --bad-6: rgb(var(--err-glow) / 0.06);
-  --bad-10: rgb(var(--err-glow) / 0.10);
-  --bad-20: rgb(var(--err-glow) / 0.20);
-  --bad-30: rgb(var(--err-glow) / 0.30);
-  --bad-50: rgb(var(--err-glow) / 0.50);
+  --bad-6: rgb(var(--err-glow) / .06);
+  --bad-10: rgb(var(--err-glow) / .10);
+  --bad-20: rgb(var(--err-glow) / .20);
+  --bad-30: rgb(var(--err-glow) / .30);
+  --bad-50: rgb(var(--err-glow) / .50);
 
   /* Semantic - Critical Sister (Rose). Pink-red distinct from --bad
      (which leans toward warm red); used for "this provider failed"
@@ -122,9 +122,9 @@
 
   /* Extended warn off-alpha — covers densely-stacked warning chips
      where -10/-20 buckets felt either too pale or too saturated. */
-  --warn-8: rgb(var(--warn-glow) / 0.08);
-  --warn-14: rgb(var(--warn-glow) / 0.14);
-  --warn-24: rgb(var(--warn-glow) / 0.24);
+  --warn-8: rgb(var(--warn-glow) / .08);
+  --warn-14: rgb(var(--warn-glow) / .14);
+  --warn-24: rgb(var(--warn-glow) / .24);
 
   /* Semantic - Emerald. Brighter green than --ok (4ade80); used for
      "all healthy" diff badges in the config resolution panel where
@@ -204,12 +204,12 @@
   --gold-15: rgba(255, 215, 0, 0.15);
 
   /* Family extensions */
-  --ok-6: rgb(var(--ok-glow) / 0.06);
+  --ok-6: rgb(var(--ok-glow) / .06);
   --emerald-30: rgba(34, 197, 94, 0.30);
   --purple-24: rgba(167, 139, 250, 0.24);
   --slate-gray-14: rgba(148, 163, 184, 0.14);
   --slate-gray-16: rgba(148, 163, 184, 0.16);
-  --accent-22: rgb(var(--brass-glow) / 0.22);
+  --accent-22: rgb(var(--brass-glow) / .22);
 
   /* Semantic - Paused (Plum). Introduced for the 12-keeper-state spec
      in the Anyang Sleepers design system. On dark theme a lightened
@@ -416,7 +416,7 @@
   --color-accent-fg-dim: var(--brass-3);
   --color-accent-soft: var(--brass-soft);
   --color-accent-glow: var(--accent-glow);
-      /* rgb triplet form for use with rgb(var(--color-accent-glow) / 0.12)
+      /* rgb triplet form for use with rgb(var(--color-accent-glow) / .12)
          alpha math.  Previously aliased --accent (hex), but had zero
          callers; safe to repurpose as a triplet for SPEC primitives. */
 


### PR DESCRIPTION
## Summary

Normalizes 65 sites of explicit-zero `rgb(... / 0.N)` to bare-decimal `rgb(... / .N)`, aligning with the dominant codebase convention. Pure formatting consolidation — no rendered diff.

The modern color-function alpha slot was previously split 455/66 between bare and explicit decimal. This PR consolidates on the bare form (now 521/0).

## Why this PR follows #12897 with the *opposite* convention

PR #12897 standardized `opacity:` property values on the **explicit** `0.N` form. This PR standardizes modern alpha channels on the **bare** `.N` form. Different conventions for different contexts is intentional — each follows its codebase-majority tendency:

| Context | Convention | Sites (after this PR) |
|---|---|---|
| `opacity: 0.N;` (property value) | explicit `0.N` | 53/53 ✓ |
| `rgb(R G B / .N)` (modern alpha) | bare `.N` | 521/0 ✓ |
| `rgba(R, G, B, 0.N)` (legacy) | explicit `0.N` | 110/0 ✓ (untouched) |

Three syntactic contexts, each with a coherent internal convention. Forcing one global convention would mean churning the larger of the two against the codebase grain — net loss.

## Scope

12 CSS files, 65 substitutions:

| File | Sites |
|---|---|
| variables.css | 38 |
| paper-theme.css | 5 |
| pipeline.css | 5 |
| dashboard.css | 3 |
| governance.css | 3 |
| rail.css | 3 |
| a11y.css | 2 |
| global.css | 2 |
| base.css | 1 |
| governance-agent.css | 1 |
| live-monitor.css | 1 |
| pixel-avatar.css | 1 |

Bulk-applied via:

```sh
perl -i -pe 's{/ 0\.([0-9]+)\)}{/ .${1})}g'
```

Anchored to `/ 0.` prefix + `)` suffix to scope strictly to the modern color-function alpha slot. Legacy `rgba(R, G, B, 0.N)` (110 sites, 100% consistent) is intentionally untouched.

## Test plan

- [x] `rg "/ 0\.[0-9]+\)" dashboard/src/styles` → 0 matches.
- [x] `rg "/ \.[0-9]+\)"  dashboard/src/styles` → 521 matches.
- [x] `rg ",\s*0\.[0-9]+\)" dashboard/src/styles` → 110 (legacy rgba untouched).
- [x] No CSS *values* changed; only literal *spelling*.
- [x] Test suite delta vs origin/main: +1 / -6 in flaky happy-dom tests (unrelated to CSS notation — async observatory fetch races vs control/observatory/mermaid sub-tests). Pre-existing flakiness, not introduced by this PR.
- [x] Race-checked `gh pr list` for `alpha notation`, `rgb /` immediately before push: 0 conflicts.
- [ ] CI Build and Test (existing dashboard test suite).

## Visual delta

**None.** `0.4` and `.4` are byte-different but value-identical CSS literals. Browsers parse both to the same `<alpha-value>`.

## Out of scope (filed for follow-up)

- `cockpit-token-cascade.test.ts:60` asserts `'rgb(var(--brass-glow) / 0.08)'` but `base.css` contains `0.05` — pre-existing assertion/source drift discovered during this sweep. The test was already failing on `origin/main` before this PR. Test file left untouched in this PR; should be addressed separately along with the broader test-flakiness review.
- `rgba(R, G, B, 0.N)` legacy notation (110 sites) — 100% internally consistent, no normalization needed.

## Cross-PR references

- PR #12897 — opacity notation `0.N` consolidation (merged).
- PR #12892 — sp-1h half-step + spacing consumers (merged).
- PR #12881 — 5 polish tokens + consumers (merged).
- PR #12884 — non-color audit annotations (merged).
