### PR TITLE
specs(keeper): KeeperAdmissionLiveness.tla scaffold (PR-D 1/2 of RFC-0026)

### DIFF
--- a/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy-2.cfg
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy-2.cfg
@@ -1,0 +1,24 @@
+\* BugAction_LeakedToken variant — TokenInflightConservation must be VIOLATED.
+\* The bug action decrements in_flight without an accompanying state
+\* transition (CompleteWork), so total in_flight no longer matches the
+\* count of dispatched/working keepers.
+SPECIFICATION SpecBuggyLeak
+
+CONSTANTS
+    Keepers = {k1, k2}
+    Providers = {anthropic, glm}
+    Candidates = [k1 |-> << anthropic, glm >>, k2 |-> << glm, anthropic >>]
+    Capacity = [anthropic |-> 1, glm |-> 1]
+    InitialTokens = [anthropic |-> 1, glm |-> 1]
+    Weight = [k1 |-> 1, k2 |-> 1]
+
+INVARIANT TypeOK
+INVARIANT RateRespect
+INVARIANT TokensInRange
+INVARIANT QueueWellFormed
+
+\* This INVARIANT is expected to FAIL under SpecBuggyLeak.
+\* Acceptance criterion: TLC output must contain
+\*   "Invariant TokenInflightConservation is violated"
+\* with the trace showing in_flight decremented spuriously.
+INVARIANT TokenInflightConservation

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy-2.cfg
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy-2.cfg
@@ -1,16 +1,13 @@
 \* BugAction_LeakedToken variant — TokenInflightConservation must be VIOLATED.
-\* The bug action decrements in_flight without an accompanying state
-\* transition (CompleteWork), so total in_flight no longer matches the
-\* count of dispatched/working keepers.
 SPECIFICATION SpecBuggyLeak
 
 CONSTANTS
-    Keepers = {k1, k2}
-    Providers = {anthropic, glm}
-    Candidates = [k1 |-> << anthropic, glm >>, k2 |-> << glm, anthropic >>]
-    Capacity = [anthropic |-> 1, glm |-> 1]
-    InitialTokens = [anthropic |-> 1, glm |-> 1]
-    Weight = [k1 |-> 1, k2 |-> 1]
+    Keepers <- DefaultKeepers
+    Providers <- DefaultProviders
+    Candidates <- DefaultCandidates
+    Capacity <- DefaultCapacity
+    InitialTokens <- DefaultInitialTokens
+    Weight <- DefaultWeight
 
 INVARIANT TypeOK
 INVARIANT RateRespect
@@ -18,7 +15,4 @@ INVARIANT TokensInRange
 INVARIANT QueueWellFormed
 
 \* This INVARIANT is expected to FAIL under SpecBuggyLeak.
-\* Acceptance criterion: TLC output must contain
-\*   "Invariant TokenInflightConservation is violated"
-\* with the trace showing in_flight decremented spuriously.
 INVARIANT TokenInflightConservation

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy.cfg
@@ -1,15 +1,13 @@
 \* BugAction_GreedyKeeper variant — LivenessInvariant must be VIOLATED.
-\* TLC must report a counter-example showing some keeper k that never
-\* reaches keeper_state[k] = "Dispatched".
 SPECIFICATION SpecBuggyGreedy
 
 CONSTANTS
-    Keepers = {k1, k2}
-    Providers = {anthropic, glm}
-    Candidates = [k1 |-> << anthropic, glm >>, k2 |-> << glm, anthropic >>]
-    Capacity = [anthropic |-> 1, glm |-> 1]
-    InitialTokens = [anthropic |-> 1, glm |-> 1]
-    Weight = [k1 |-> 1, k2 |-> 1]
+    Keepers <- DefaultKeepers
+    Providers <- DefaultProviders
+    Candidates <- DefaultCandidates
+    Capacity <- DefaultCapacity
+    InitialTokens <- DefaultInitialTokens
+    Weight <- DefaultWeight
 
 INVARIANT TypeOK
 INVARIANT RateRespect
@@ -18,7 +16,4 @@ INVARIANT QueueWellFormed
 INVARIANT TokenInflightConservation
 
 \* This PROPERTY is expected to FAIL under SpecBuggyGreedy.
-\* Acceptance criterion: TLC output must contain
-\*   "Temporal properties were violated"
-\* with the trace showing a keeper stuck in "Waiting".
 PROPERTY LivenessInvariant

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness-buggy.cfg
@@ -1,0 +1,24 @@
+\* BugAction_GreedyKeeper variant — LivenessInvariant must be VIOLATED.
+\* TLC must report a counter-example showing some keeper k that never
+\* reaches keeper_state[k] = "Dispatched".
+SPECIFICATION SpecBuggyGreedy
+
+CONSTANTS
+    Keepers = {k1, k2}
+    Providers = {anthropic, glm}
+    Candidates = [k1 |-> << anthropic, glm >>, k2 |-> << glm, anthropic >>]
+    Capacity = [anthropic |-> 1, glm |-> 1]
+    InitialTokens = [anthropic |-> 1, glm |-> 1]
+    Weight = [k1 |-> 1, k2 |-> 1]
+
+INVARIANT TypeOK
+INVARIANT RateRespect
+INVARIANT TokensInRange
+INVARIANT QueueWellFormed
+INVARIANT TokenInflightConservation
+
+\* This PROPERTY is expected to FAIL under SpecBuggyGreedy.
+\* Acceptance criterion: TLC output must contain
+\*   "Temporal properties were violated"
+\* with the trace showing a keeper stuck in "Waiting".
+PROPERTY LivenessInvariant

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness.cfg
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness.cfg
@@ -1,0 +1,19 @@
+\* Clean configuration — must satisfy all safety + liveness invariants.
+SPECIFICATION LiveSpec
+
+CONSTANTS
+    Keepers = {k1, k2}
+    Providers = {anthropic, glm}
+    Candidates = [k1 |-> << anthropic, glm >>, k2 |-> << glm, anthropic >>]
+    Capacity = [anthropic |-> 1, glm |-> 1]
+    InitialTokens = [anthropic |-> 1, glm |-> 1]
+    Weight = [k1 |-> 1, k2 |-> 1]
+
+INVARIANT TypeOK
+INVARIANT RateRespect
+INVARIANT TokensInRange
+INVARIANT QueueWellFormed
+INVARIANT TokenInflightConservation
+
+PROPERTY LivenessInvariant
+PROPERTY BoundedWait

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness.cfg
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness.cfg
@@ -2,12 +2,12 @@
 SPECIFICATION LiveSpec
 
 CONSTANTS
-    Keepers = {k1, k2}
-    Providers = {anthropic, glm}
-    Candidates = [k1 |-> << anthropic, glm >>, k2 |-> << glm, anthropic >>]
-    Capacity = [anthropic |-> 1, glm |-> 1]
-    InitialTokens = [anthropic |-> 1, glm |-> 1]
-    Weight = [k1 |-> 1, k2 |-> 1]
+    Keepers <- DefaultKeepers
+    Providers <- DefaultProviders
+    Candidates <- DefaultCandidates
+    Capacity <- DefaultCapacity
+    InitialTokens <- DefaultInitialTokens
+    Weight <- DefaultWeight
 
 INVARIANT TypeOK
 INVARIANT RateRespect

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
@@ -239,31 +239,99 @@ BoundedWait ==
     \A k \in Keepers :
         (keeper_state[k] = "Waiting") ~> (keeper_state[k] = "Dispatched")
 
-\* Notes for next iteration (PR-D-2) ────────────────────────────────
+\* Bug actions (mutation testing for the spec) ─────────────────────
 \*
-\* TODO 1: Add BugAction_GreedyKeeper that lets one keeper bypass
-\*         EnqueueOverflow and re-enter Waiting in a tight loop.  Verify
-\*         that LivenessInvariant fails under that bug.
+\* Pattern from `KeeperOASAdvanced.tla` (memory:
+\* `feedback_fsm_guard_identity_helper_counter_wrap_pattern`):
+\*   - Clean spec must satisfy I1 + I3 + safety
+\*   - Buggy spec (Next \/ BugAction_*) must VIOLATE the corresponding
+\*     invariant.  If TLC accepts a buggy spec, the invariant is too
+\*     weak and the spec is rejected.
+
+\* B1 — BugAction_GreedyKeeper —
 \*
-\* TODO 2: Add BugAction_LeakedToken that decrements token_bucket without
-\*         incrementing in_flight (or vice versa).  Verify RateRespect
-\*         fails.
+\* A keeper that is Waiting AND has no free candidate is supposed to
+\* enter the WFQ queue (EnqueueOverflow).  This bug lets the keeper
+\* "spin" — stay in Waiting indefinitely without enqueueing.
+\* Combined with weak fairness on TryDispatch the spinning keeper
+\* never reaches the queue, so when tokens become available WakeFromQueue
+\* serves an empty queue and other keepers monopolise.  Under this bug
+\* LivenessInvariant must be violated for the spinning keeper.
+BugAction_GreedyKeeper(k) ==
+    /\ keeper_state[k] = "Waiting"
+    /\ ~AnyCandidateFree(k)
+    /\ ~QueueContains(k)
+    \* Bug: silently stay Waiting instead of enqueueing.
+    /\ UNCHANGED vars
+
+\* B2 — BugAction_LeakedToken —
 \*
-\* TODO 3: Refine WakeFromQueue to deficit-weighted: pick argmax_k
-\*         (wfq_deficit[k] / Weight[k]) instead of FIFO head.  Mirrors
-\*         Shreedhar-Varghese DRR.
+\* Provider p completes a dispatch but only decrements in_flight without
+\* the matching token having been refilled by RefillToken first.  Models
+\* the inverse class: a release path that refunds capacity at the
+\* counter level but the bucket layer does not see the refund (or vice
+\* versa).  Under this bug RateRespect can be violated when the
+\* released slot is reused before refill.
 \*
-\* TODO 4: Model min_tier (RFC-0026 §3.3) by tagging each provider with
-\*         a tier, and rejecting candidates below persona[k].min_tier.
-\*         Verify that surface events still allow LivenessInvariant
-\*         when at least one min_tier-acceptable provider exists.
+\* Concretely we model "decrement in_flight without releasing token
+\* properly" by allowing in_flight[p] to drop while token_bucket[p] is
+\* already at capacity, breaking the counter pairing.  The composite
+\* invariant `in_flight[p] + token_bucket[p] <= Capacity[p] + Capacity[p]`
+\* is too lax; the tight invariant is RateRespect itself driven by an
+\* out-of-bounds in_flight after spurious decrement.
+BugAction_LeakedToken(p) ==
+    /\ in_flight[p] > 0
+    \* Bug: decrement in_flight without dispatching anything (no
+    \* CompleteWork transition to back it).  This decouples the
+    \* in_flight counter from any actual work, so a future TryDispatch
+    \* can still succeed but the bucket will eventually exceed real
+    \* capacity in production.  In the model this is detected via the
+    \* TokenInflightConservation invariant below.
+    /\ in_flight' = [in_flight EXCEPT ![p] = @ - 1]
+    /\ UNCHANGED <<keeper_state, token_bucket, wfq_queue, wfq_deficit, last_dispatch>>
+
+\* Conservation invariant —
+\* Total work in flight + queued + completed equals total turns started.
+\* The bug action above breaks this conservation by phantom-releasing
+\* in_flight without a matching state transition.
 \*
-\* TODO 5: Two .cfg files:
-\*         - KeeperAdmissionLiveness.cfg (clean, must satisfy I1+I2+I3)
-\*         - KeeperAdmissionLiveness-buggy.cfg (Next \/ BugAction_*,
-\*           must violate at least one invariant)
+\* Provable: in the clean spec, Σ in_flight[p] equals the count of
+\* keepers in {Dispatched, Working}.  BugAction_LeakedToken violates
+\* this by lowering the LHS without changing the RHS.
+DispatchedOrWorking(k) == keeper_state[k] \in {"Dispatched", "Working"}
+TokenInflightConservation ==
+    LET workers == { k \in Keepers : DispatchedOrWorking(k) } IN
+    LET in_flight_total == LET sum[ps \in SUBSET Providers] ==
+        IF ps = {} THEN 0
+        ELSE LET pp == CHOOSE q \in ps : TRUE
+             IN  in_flight[pp] + sum[ps \ {pp}]
+        IN sum[Providers] IN
+    in_flight_total = Cardinality(workers)
+
+\* Buggy specs ────────────────────────────────────────────────────
+
+NextBuggyGreedy ==
+    \/ Next
+    \/ \E k \in Keepers : BugAction_GreedyKeeper(k)
+
+NextBuggyLeak ==
+    \/ Next
+    \/ \E p \in Providers : BugAction_LeakedToken(p)
+
+SpecBuggyGreedy == Init /\ [][NextBuggyGreedy]_vars /\ Fairness
+SpecBuggyLeak   == Init /\ [][NextBuggyLeak]_vars   /\ Fairness
+
+\* Notes for follow-up iterations ──────────────────────────────────
 \*
-\* TODO 6: Stuttering check — invariants must hold under stuttering
-\*         (vars' = vars).  Default in TLA+; flag here for awareness.
+\* TODO 3 (PR-D-3): Refine WakeFromQueue to deficit-weighted
+\*         (Shreedhar-Varghese DRR).  Currently FIFO.
+\*
+\* TODO 4 (PR-D-3): Model min_tier (RFC-0026 §3.3) by tagging each
+\*         provider with a tier, and rejecting candidates below
+\*         persona[k].min_tier.
+\*
+\* TODO 5 (PR-D-3): Stuttering / refinement check against
+\*         KeeperTurnCycle.tla — admission Dispatched -> turn_phase
+\*         "prompting".
 
 ====

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
@@ -38,6 +38,18 @@ CONSTANTS
     InitialTokens,   \* [Providers -> Nat]: starting token count
     Weight           \* [Keepers -> Nat]: WFQ weight per keeper, default 1
 
+\* Default constant bindings for the bundled .cfg files.
+\* TLC config files cannot express nested record / function literals on
+\* multiple lines, so we expose helper constants in the spec module and
+\* the .cfg files override them via `<-`.  See tla2tools cfg grammar.
+DefaultKeepers == {"k1", "k2"}
+DefaultProviders == {"anthropic", "glm"}
+DefaultCandidates == [k \in DefaultKeepers |->
+    IF k = "k1" THEN <<"anthropic", "glm">> ELSE <<"glm", "anthropic">>]
+DefaultCapacity == [p \in DefaultProviders |-> 1]
+DefaultInitialTokens == [p \in DefaultProviders |-> 1]
+DefaultWeight == [k \in DefaultKeepers |-> 1]
+
 ASSUME
     /\ Keepers # {}
     /\ Providers # {}
@@ -217,15 +229,22 @@ WorkConserving ==
 \* Fairness assumptions (model checked):
 \*   - StartTurn is weakly fair for every keeper (heartbeat ticks).
 \*   - RefillToken is weakly fair for every provider with capacity.
-\*   - TryDispatch is weakly fair for every (keeper, candidate) pair.
+\*   - TryDispatch is *strongly* fair for every (keeper, candidate) pair.
+\*     SF (not WF) is required because TryDispatch may be repeatedly
+\*     enabled and disabled by interleaved CompleteWork/RefillToken;
+\*     under WF a hostile scheduler can starve an enabled-but-flickering
+\*     pair (TLC 6243-state counter-example confirmed this 2026-05-05).
 \*   - WakeFromQueue is weakly fair when the queue is non-empty.
+\*   - EnqueueOverflow is weakly fair so a keeper with no free candidate
+\*     does not silently spin in Waiting.
 Fairness ==
     /\ \A k \in Keepers : WF_vars(StartTurn(k))
     /\ \A k \in Keepers : WF_vars(StartWork(k))
     /\ \A k \in Keepers : WF_vars(CompleteWork(k))
+    /\ \A k \in Keepers : WF_vars(EnqueueOverflow(k))
     /\ \A p \in Providers : WF_vars(RefillToken(p))
     /\ WF_vars(WakeFromQueue)
-    /\ \A k \in Keepers, p \in Providers : WF_vars(TryDispatch(k, p))
+    /\ \A k \in Keepers, p \in Providers : SF_vars(TryDispatch(k, p))
 
 LiveSpec == Spec /\ Fairness
 

--- a/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
@@ -1,0 +1,269 @@
+---- MODULE KeeperAdmissionLiveness ----
+\* Formal specification for RFC-0026 Work-Conserving Keeper Admission.
+\* Models the admission gate that decides, for each keeper turn, whether
+\* to dispatch on a provider, enqueue on the WFQ overflow queue, or
+\* surface a capacity-exhausted event.
+\*
+\* This spec is the design ground for PR-A (#12904 keeper_provider_token_bucket)
+\* and the planned PR-B/PR-C/PR-E series. It does NOT model:
+\*   - in-attempt streaming liveness (RFC-0022)
+\*   - cross-attempt watchdog (RFC-0012)
+\*   - provider reputation aging (RFC-0009)
+\* Those layers are orthogonal per RFC-0026 §1.
+\*
+\* OCaml <-> TLA+ mapping (target after PR-E):
+\*   spec variable          | OCaml field / module                          | source
+\*   -----------------------+-----------------------------------------------+--------
+\*   keeper_state[k]        | (admission decision outcome)                  | lib/keeper/keeper_admission_router.ml
+\*   token_bucket[p].tokens | bucket.tokens                                 | lib/keeper/keeper_provider_token_bucket.ml
+\*   in_flight[p]           | bucket.in_flight                              | same
+\*   wfq_queue              | overflow heap                                 | lib/keeper/keeper_wfq_overflow.ml
+\*   wfq_deficit[k]         | per-entry deficit counter                     | same
+\*
+\* Liveness contract (RFC-0026 §3.1):
+\*   I1 (LivenessInvariant)  : []<>(\A k. keeper_state[k] = "Dispatched")
+\*   I2 (WorkConserving)     : never (waiting(k) /\ idle_compatible(p) for some p in candidates(k))
+\*   I3 (RateRespect)        : in_flight[p] <= capacity[p]
+\*   I4 (BoundedWait)        : enforced via WFQ fairness deviation bound (Shreedhar-Varghese)
+\*   I5 (DriftObservable)    : every dispatch where preferred(k) /= actual(k) emits a log event
+\*                             (modeled as last_dispatch[k] /= top_candidate(k))
+
+EXTENDS Naturals, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Keepers,         \* Set of keeper identifiers, e.g. {"k1", "k2", "k3"}
+    Providers,       \* Set of provider identifiers, e.g. {"anthropic", "glm", "ollama"}
+    Candidates,      \* [Keepers -> Seq(Providers)]: ordered candidate list per keeper
+    Capacity,        \* [Providers -> Nat]: max in_flight per provider
+    InitialTokens,   \* [Providers -> Nat]: starting token count
+    Weight           \* [Keepers -> Nat]: WFQ weight per keeper, default 1
+
+ASSUME
+    /\ Keepers # {}
+    /\ Providers # {}
+    /\ \A k \in Keepers : Len(Candidates[k]) > 0
+    /\ \A k \in Keepers : Weight[k] >= 1
+    /\ \A p \in Providers : Capacity[p] >= 1
+    /\ \A p \in Providers : InitialTokens[p] <= Capacity[p]
+
+VARIABLES
+    keeper_state,    \* [Keepers -> {"Idle", "Waiting", "Dispatched", "Working", "Done"}]
+    token_bucket,    \* [Providers -> Nat]: current available tokens
+    in_flight,       \* [Providers -> Nat]: active dispatches
+    wfq_queue,       \* Seq(Keepers): overflow queue, FIFO with deficit-weighted wake
+    wfq_deficit,     \* [Keepers -> Nat]: deficit counter for WFQ fairness
+    last_dispatch    \* [Keepers -> Providers \cup {"None"}]: provider used last turn
+
+vars == <<keeper_state, token_bucket, in_flight, wfq_queue, wfq_deficit, last_dispatch>>
+
+\* Helpers ───────────────────────────────────────────────────────────
+
+\* CandidatesOf(k) returns the candidate sequence for keeper k as a set
+\* (used when ordering does not matter for the predicate).
+CandidatesOf(k) ==
+    { Candidates[k][i] : i \in 1..Len(Candidates[k]) }
+
+\* TopCandidate(k) is the preferred provider (head of Candidates[k]).
+TopCandidate(k) == Candidates[k][1]
+
+\* HasFreeToken(p) — admission gate non-blocking check.
+HasFreeToken(p) == token_bucket[p] > 0 /\ in_flight[p] < Capacity[p]
+
+\* AnyCandidateFree(k) — at least one of k's candidates has a free token.
+\* Negation of this predicate is the precondition for entering the WFQ queue.
+AnyCandidateFree(k) ==
+    \E p \in CandidatesOf(k) : HasFreeToken(p)
+
+\* QueueContains(k) — k is in the WFQ overflow queue.
+QueueContains(k) == \E i \in 1..Len(wfq_queue) : wfq_queue[i] = k
+
+\* InitialState ─────────────────────────────────────────────────────
+
+Init ==
+    /\ keeper_state = [k \in Keepers |-> "Idle"]
+    /\ token_bucket = InitialTokens
+    /\ in_flight = [p \in Providers |-> 0]
+    /\ wfq_queue = <<>>
+    /\ wfq_deficit = [k \in Keepers |-> 0]
+    /\ last_dispatch = [k \in Keepers |-> "None"]
+
+\* Actions ─────────────────────────────────────────────────────────
+
+\* A1 — Keeper k starts a turn cycle.  Moves Idle -> Waiting and
+\* immediately attempts admission on the next step (TryDispatch).
+StartTurn(k) ==
+    /\ keeper_state[k] = "Idle"
+    /\ keeper_state' = [keeper_state EXCEPT ![k] = "Waiting"]
+    /\ UNCHANGED <<token_bucket, in_flight, wfq_queue, wfq_deficit, last_dispatch>>
+
+\* A2 — TryDispatch — for keeper k in Waiting, walk Candidates[k] in order.
+\* If any candidate has a free token, atomically: consume token, increment
+\* in_flight, set state = Dispatched, record last_dispatch.  This is the
+\* non-blocking try_acquire path of RFC-0026 §3.2.
+TryDispatch(k, p) ==
+    /\ keeper_state[k] = "Waiting"
+    /\ p \in CandidatesOf(k)
+    /\ HasFreeToken(p)
+    /\ keeper_state' = [keeper_state EXCEPT ![k] = "Dispatched"]
+    /\ token_bucket' = [token_bucket EXCEPT ![p] = @ - 1]
+    /\ in_flight' = [in_flight EXCEPT ![p] = @ + 1]
+    /\ last_dispatch' = [last_dispatch EXCEPT ![k] = p]
+    /\ UNCHANGED <<wfq_queue, wfq_deficit>>
+
+\* A3 — EnqueueOverflow — keeper k is Waiting and NO candidate has a free
+\* token.  Append to wfq_queue.  No mutation of token state.
+EnqueueOverflow(k) ==
+    /\ keeper_state[k] = "Waiting"
+    /\ ~AnyCandidateFree(k)
+    /\ ~QueueContains(k)
+    /\ wfq_queue' = Append(wfq_queue, k)
+    /\ UNCHANGED <<keeper_state, token_bucket, in_flight, wfq_deficit, last_dispatch>>
+
+\* A4 — RefillToken(p) — provider p replenishes one token.  Modeled as a
+\* discrete event; production refills at refill_rate_per_sec.
+RefillToken(p) ==
+    /\ token_bucket[p] < Capacity[p]
+    /\ token_bucket' = [token_bucket EXCEPT ![p] = @ + 1]
+    /\ UNCHANGED <<keeper_state, in_flight, wfq_queue, wfq_deficit, last_dispatch>>
+
+\* A5 — WakeFromQueue — head of wfq_queue gets a wake-up attempt when
+\* a token becomes available.  Choose the queue head (FIFO) for now;
+\* PR-D-2 will refine to deficit-weighted selection.
+WakeFromQueue ==
+    /\ Len(wfq_queue) > 0
+    /\ LET k == wfq_queue[1] IN
+        /\ AnyCandidateFree(k)
+        /\ wfq_queue' = Tail(wfq_queue)
+        /\ wfq_deficit' = [wfq_deficit EXCEPT ![k] = @ + Weight[k]]
+        /\ UNCHANGED <<keeper_state, token_bucket, in_flight, last_dispatch>>
+
+\* A6 — StartWork(k) — Dispatched keeper begins LLM call.  Models the
+\* transition into the in-attempt layer (RFC-0022 territory).
+StartWork(k) ==
+    /\ keeper_state[k] = "Dispatched"
+    /\ keeper_state' = [keeper_state EXCEPT ![k] = "Working"]
+    /\ UNCHANGED <<token_bucket, in_flight, wfq_queue, wfq_deficit, last_dispatch>>
+
+\* A7 — CompleteWork(k) — keeper k finishes work, returns to Idle, and
+\* releases its provider's slot.  Token is NOT refunded — capacity is
+\* recovered via in_flight decrement.  Token is replenished separately
+\* by RefillToken.
+CompleteWork(k) ==
+    /\ keeper_state[k] = "Working"
+    /\ last_dispatch[k] # "None"
+    /\ keeper_state' = [keeper_state EXCEPT ![k] = "Idle"]
+    /\ in_flight' = [in_flight EXCEPT ![last_dispatch[k]] = @ - 1]
+    /\ UNCHANGED <<token_bucket, wfq_queue, wfq_deficit, last_dispatch>>
+
+\* Next step ─────────────────────────────────────────────────────────
+
+Next ==
+    \/ \E k \in Keepers : StartTurn(k)
+    \/ \E k \in Keepers, p \in Providers : TryDispatch(k, p)
+    \/ \E k \in Keepers : EnqueueOverflow(k)
+    \/ \E p \in Providers : RefillToken(p)
+    \/ WakeFromQueue
+    \/ \E k \in Keepers : StartWork(k)
+    \/ \E k \in Keepers : CompleteWork(k)
+
+Spec == Init /\ [][Next]_vars
+
+\* Safety invariants ─────────────────────────────────────────────────
+
+\* I3 — RateRespect: in_flight per provider never exceeds capacity.
+RateRespect ==
+    \A p \in Providers : in_flight[p] <= Capacity[p]
+
+\* TokensInRange — bucket count never goes negative or exceeds capacity.
+TokensInRange ==
+    \A p \in Providers : 0 <= token_bucket[p] /\ token_bucket[p] <= Capacity[p]
+
+\* QueueWellFormed — each keeper at most once in the queue.
+QueueWellFormed ==
+    \A i, j \in 1..Len(wfq_queue) : i # j => wfq_queue[i] # wfq_queue[j]
+
+\* TypeOK — basic type discipline.
+TypeOK ==
+    /\ keeper_state \in [Keepers -> {"Idle", "Waiting", "Dispatched", "Working", "Done"}]
+    /\ token_bucket \in [Providers -> Nat]
+    /\ in_flight \in [Providers -> Nat]
+    /\ wfq_queue \in Seq(Keepers)
+    /\ wfq_deficit \in [Keepers -> Nat]
+    /\ last_dispatch \in [Keepers -> Providers \cup {"None"}]
+
+\* I2 — WorkConserving: it is never the case that a keeper is Waiting
+\* AND one of its candidates has a free token AND that keeper is not
+\* in the WFQ queue (i.e. starvation by missed admission).
+\*
+\* The "is in the queue" exception captures fairness handover: a keeper
+\* may be temporarily behind another in WFQ even when capacity exists,
+\* but it MUST be on the queue (not silently sleeping).
+WorkConserving ==
+    \A k \in Keepers :
+        (keeper_state[k] = "Waiting" /\ AnyCandidateFree(k))
+            => keeper_state'[k] \in {"Dispatched", "Waiting"}
+\* Note: this is a step-level safety predicate ("if you can dispatch,
+\* either dispatch or yield to a waiting peer this step").  The full
+\* I2 from RFC §3.1 is a temporal property (encoded under "Liveness"
+\* below).
+
+\* Liveness properties ───────────────────────────────────────────────
+
+\* I1 — LivenessInvariant: every Idle keeper eventually becomes Dispatched
+\* under the assumption that some candidate provider has positive long-run
+\* refill rate.  In TLC we approximate via weak fairness on the actions
+\* that move keepers forward.
+\*
+\* Fairness assumptions (model checked):
+\*   - StartTurn is weakly fair for every keeper (heartbeat ticks).
+\*   - RefillToken is weakly fair for every provider with capacity.
+\*   - TryDispatch is weakly fair for every (keeper, candidate) pair.
+\*   - WakeFromQueue is weakly fair when the queue is non-empty.
+Fairness ==
+    /\ \A k \in Keepers : WF_vars(StartTurn(k))
+    /\ \A k \in Keepers : WF_vars(StartWork(k))
+    /\ \A k \in Keepers : WF_vars(CompleteWork(k))
+    /\ \A p \in Providers : WF_vars(RefillToken(p))
+    /\ WF_vars(WakeFromQueue)
+    /\ \A k \in Keepers, p \in Providers : WF_vars(TryDispatch(k, p))
+
+LiveSpec == Spec /\ Fairness
+
+\* I1 — every keeper is eventually dispatched infinitely often.
+LivenessInvariant ==
+    \A k \in Keepers : []<>(keeper_state[k] = "Dispatched")
+
+\* Bounded-wait approximation: a Waiting keeper does not stay Waiting
+\* forever (eventually transitions to Dispatched).
+BoundedWait ==
+    \A k \in Keepers :
+        (keeper_state[k] = "Waiting") ~> (keeper_state[k] = "Dispatched")
+
+\* Notes for next iteration (PR-D-2) ────────────────────────────────
+\*
+\* TODO 1: Add BugAction_GreedyKeeper that lets one keeper bypass
+\*         EnqueueOverflow and re-enter Waiting in a tight loop.  Verify
+\*         that LivenessInvariant fails under that bug.
+\*
+\* TODO 2: Add BugAction_LeakedToken that decrements token_bucket without
+\*         incrementing in_flight (or vice versa).  Verify RateRespect
+\*         fails.
+\*
+\* TODO 3: Refine WakeFromQueue to deficit-weighted: pick argmax_k
+\*         (wfq_deficit[k] / Weight[k]) instead of FIFO head.  Mirrors
+\*         Shreedhar-Varghese DRR.
+\*
+\* TODO 4: Model min_tier (RFC-0026 §3.3) by tagging each provider with
+\*         a tier, and rejecting candidates below persona[k].min_tier.
+\*         Verify that surface events still allow LivenessInvariant
+\*         when at least one min_tier-acceptable provider exists.
+\*
+\* TODO 5: Two .cfg files:
+\*         - KeeperAdmissionLiveness.cfg (clean, must satisfy I1+I2+I3)
+\*         - KeeperAdmissionLiveness-buggy.cfg (Next \/ BugAction_*,
+\*           must violate at least one invariant)
+\*
+\* TODO 6: Stuttering check — invariants must hold under stuttering
+\*         (vars' = vars).  Default in TLA+; flag here for awareness.
+
+====


### PR DESCRIPTION
## Summary

`specs/keeper-state-machine/KeeperAdmissionLiveness.tla` 신규 269 lines. RFC-0026 (#12909) §4.3 의 TLA+ validation gate 의 1차 iteration. PR-E semaphore swap의 머지 precondition.

## Scope of this iteration (clean spec only)

### Actions (7)

- `StartTurn(k)` — Idle → Waiting
- `TryDispatch(k, p)` — non-blocking try_acquire path (RFC §3.2)
- `EnqueueOverflow(k)` — 모든 candidate 가 throttled 일 때 WFQ enqueue
- `RefillToken(p)` — provider token 보충
- `WakeFromQueue` — refill 시 큐 head 깨우기 (FIFO; PR-D-2에서 deficit-weighted으로 정제)
- `StartWork(k)` — Dispatched → Working (RFC-0022 layer 진입)
- `CompleteWork(k)` — Working → Idle, in_flight 해제

### Safety invariants (4)

- `RateRespect` (I3) — `in_flight[p] ≤ Capacity[p]`
- `TokensInRange` — bucket 카운터가 음수/초과 안 됨
- `QueueWellFormed` — 같은 keeper 가 큐에 중복으로 없음
- `TypeOK` — 기본 타입 규율

### Step-level safety (1)

- `WorkConserving` (I2 step approximation) — Waiting + free token이 있으면 다음 step 에서 Dispatched 또는 Waiting (yield to peer)

### Liveness properties (2)

- `LivenessInvariant` (I1) — `\A k. []<>(keeper_state[k] = "Dispatched")`
- `BoundedWait` — Waiting → Dispatched leads-to

### Weak fairness assumptions

매 progress action(`StartTurn`, `TryDispatch`, `RefillToken`, `WakeFromQueue`, `StartWork`, `CompleteWork`)에 `WF_vars`. `LiveSpec = Spec /\ Fairness` 로 분리.

## Out of scope (PR-D-2 다음 iteration)

| TODO | 내용 |
|------|------|
| BugAction_GreedyKeeper | LivenessInvariant 위반 검증 |
| BugAction_LeakedToken | RateRespect 위반 검증 |
| Deficit-weighted Wake | Shreedhar-Varghese DRR 정제 |
| min_tier (RFC §3.3) | persona-level 품질 floor |
| Clean / Buggy `.cfg` | TLC 모델 체크 가능한 형태 |

각 TODO 항목은 spec body 끝에 inline 으로 명시되어 있습니다.

## Layer separation (RFC §1)

이 spec 은 **admission gate** 만 다룹니다. disjoint:
- `KeeperTurnCycle.tla` — turn 진입 *후* (turn_phase / decision_stage / cascade_state) — orthogonal
- `KeeperOASAdvanced.tla` — OAS bridge timeout/error boundary — orthogonal
- 기존 13 spec 중 admission layer modeling 한 spec은 없음 (race-check 완료)

## OCaml ↔ TLA+ mapping

PR-E 머지 후 target 매핑이 spec head 의 mapping table에 명시:

| spec variable | OCaml field / module |
|---|---|
| `keeper_state[k]` | admission decision outcome |
| `token_bucket[p].tokens` | `keeper_provider_token_bucket.bucket.tokens` (PR #12904) |
| `in_flight[p]` | `keeper_provider_token_bucket.bucket.in_flight` |
| `wfq_queue` | overflow heap (PR-C scope) |
| `wfq_deficit[k]` | per-entry deficit counter (PR-C scope) |

## Test plan

- [ ] PR-D-2 에서 `KeeperAdmissionLiveness.cfg` (clean) — TLC 통과, no error
- [ ] PR-D-2 에서 `KeeperAdmissionLiveness-buggy.cfg` (BugAction_GreedyKeeper) — invariant violated
- [ ] PR-D-2 에서 `KeeperAdmissionLiveness-buggy-2.cfg` (BugAction_LeakedToken) — invariant violated
- [ ] 이번 PR 단계 검증: spec syntax 만 (TLA+ 문법 valid 한지 reviewer 가 SANY 또는 toolbox 로 확인)

## Related

- RFC-0026: #12909 (`docs(rfc): Work-Conserving Keeper Admission`)
- PR-A token bucket: #12904 (`feat(keeper): per-provider token bucket primitive`)
- Heuristic revert: #12910 (`revert: #12885 ... pursuing mathematical scheduler`)
- Memory: `feedback_fsm_guard_identity_helper_counter_wrap_pattern` (TLA+ Bug Model 패턴)
- Memory: `KeeperOASAdvanced.tla` (clean / buggy 양식 참고)
