### PR TITLE
feat(dashboard): IDE mock → real data coordinator (Phase 1-3)

### DIFF
--- a/dashboard/src/api/workspace.test.ts
+++ b/dashboard/src/api/workspace.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchWorkspaceTree,
+  fetchWorkspaceFile,
+  fetchGitBlame,
+  fetchGitDiff,
+} from './workspace'
+
+afterEach(() => {
+  mockFetch.mockClear()
+  vi.unstubAllGlobals()
+})
+
+const mockFetch = vi.fn()
+
+function stubFetch(response: unknown, ok = true): void {
+  mockFetch.mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? 'OK' : 'Internal Server Error',
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve(JSON.stringify(response)),
+    clone() { return this },
+  } as Response)
+  vi.stubGlobal('fetch', mockFetch)
+}
+
+describe('workspace API', () => {
+  it('fetchWorkspaceTree returns file nodes', async () => {
+    const nodes = [{ path: 'lib/main.ml', label: 'main.ml', depth: 1, parent: 'lib', hasChildren: false, diff: null, keeperId: null, hueIndex: null }]
+    stubFetch(nodes)
+
+    const result = await fetchWorkspaceTree(2)
+    expect(result).toHaveLength(1)
+    expect(result[0].path).toBe('lib/main.ml')
+
+    expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/workspace/tree?depth=2')
+  })
+
+  it('fetchWorkspaceTree appends keeper param when provided', async () => {
+    stubFetch([])
+
+    await fetchWorkspaceTree(1, { keeper: 'sangsu' })
+    expect(mockFetch.mock.calls[0][0]).toContain('keeper=sangsu')
+  })
+
+  it('fetchWorkspaceFile returns file content', async () => {
+    stubFetch({ ok: true, content: 'let x = 1\n', language: 'ocaml' })
+
+    const result = await fetchWorkspaceFile('lib/main.ml')
+    expect(result?.ok).toBe(true)
+    expect(result?.content).toBe('let x = 1\n')
+
+    expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/workspace/file?path=')
+    expect(mockFetch.mock.calls[0][0]).toContain('lib%2Fmain.ml')
+  })
+
+  it('fetchGitBlame returns blame blocks', async () => {
+    const blocks = [{ file_path: 'a.ml', line_start: 1, line_end: 5, keeper_id: 'claude', timestamp_ms: 1000, kind: 'edit' }]
+    stubFetch(blocks)
+
+    const result = await fetchGitBlame('a.ml')
+    expect(result).toHaveLength(1)
+    expect(result[0].keeper_id).toBe('claude')
+  })
+
+  it('fetchGitDiff extracts unified rows from response', async () => {
+    const unified = [{ kind: 'add', oldLine: null, newLine: 1, text: 'new line' }]
+    stubFetch({ unified })
+
+    const result = await fetchGitDiff('a.ml')
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('add')
+  })
+
+  it('fetchGitDiff defaults to empty array when unified missing', async () => {
+    stubFetch({})
+
+    const result = await fetchGitDiff('a.ml')
+    expect(result).toHaveLength(0)
+  })
+
+  it('fetchGitDiff uses HEAD as default baseRef', async () => {
+    stubFetch({ unified: [] })
+
+    await fetchGitDiff('a.ml')
+    expect(mockFetch.mock.calls[0][0]).toContain('base_ref=HEAD')
+  })
+
+  it('fetchGitDiff accepts custom baseRef', async () => {
+    stubFetch({ unified: [] })
+
+    await fetchGitDiff('a.ml', { baseRef: 'v0.19.0' })
+    expect(mockFetch.mock.calls[0][0]).toContain('base_ref=v0.19.0')
+  })
+})

--- a/dashboard/src/api/workspace.ts
+++ b/dashboard/src/api/workspace.ts
@@ -1,0 +1,91 @@
+import { get, type GetOptions } from './core'
+import type { FileTreeNode } from '../components/ide/file-tree-store'
+
+// --- Blame ---
+
+export interface BlameBlock {
+  readonly file_path: string
+  readonly line_start: number
+  readonly line_end: number
+  readonly keeper_id: string
+  readonly timestamp_ms: number
+  readonly kind: string
+}
+
+// --- Diff ---
+
+export type DiffTone = 'context' | 'add' | 'delete'
+
+export interface UnifiedDiffRow {
+  readonly kind: DiffTone
+  readonly oldLine: number | null
+  readonly newLine: number | null
+  readonly text: string
+}
+
+// --- Workspace File ---
+
+export interface WorkspaceFileResponse {
+  readonly ok: boolean
+  readonly content: string
+  readonly language?: string
+}
+
+// --- API helpers ---
+
+export interface WorkspaceApiOptions extends GetOptions {
+  readonly keeper?: string
+}
+
+function keeperParam(keeper: string | undefined): string {
+  return keeper ? `&keeper=${encodeURIComponent(keeper)}` : ''
+}
+
+export function fetchWorkspaceTree(
+  depth: number,
+  opts: WorkspaceApiOptions = {},
+): Promise<ReadonlyArray<FileTreeNode>> {
+  const keeper = keeperParam(opts.keeper)
+  return get<ReadonlyArray<FileTreeNode>>(
+    `/api/v1/workspace/tree?depth=${depth}${keeper}`,
+    opts,
+  )
+}
+
+export function fetchWorkspaceFile(
+  path: string,
+  opts: WorkspaceApiOptions = {},
+): Promise<WorkspaceFileResponse | null> {
+  const keeper = keeperParam(opts.keeper)
+  return get<WorkspaceFileResponse | null>(
+    `/api/v1/workspace/file?path=${encodeURIComponent(path)}${keeper}`,
+    opts,
+  )
+}
+
+export function fetchGitBlame(
+  path: string,
+  opts: WorkspaceApiOptions = {},
+): Promise<ReadonlyArray<BlameBlock>> {
+  const keeper = keeperParam(opts.keeper)
+  return get<ReadonlyArray<BlameBlock>>(
+    `/api/v1/git/blame?path=${encodeURIComponent(path)}${keeper}`,
+    opts,
+  )
+}
+
+interface GitDiffResponse {
+  readonly unified: ReadonlyArray<UnifiedDiffRow>
+}
+
+export function fetchGitDiff(
+  path: string,
+  opts: WorkspaceApiOptions & { baseRef?: string } = {},
+): Promise<ReadonlyArray<UnifiedDiffRow>> {
+  const baseRef = opts.baseRef ?? 'HEAD'
+  const keeper = keeperParam(opts.keeper)
+  return get<GitDiffResponse>(
+    `/api/v1/git/diff?path=${encodeURIComponent(path)}&base_ref=${encodeURIComponent(baseRef)}${keeper}`,
+    opts,
+  ).then(data => Array.isArray(data.unified) ? data.unified : [])
+}

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -14,7 +14,7 @@ export function Cockpit() {
           <iframe
             src=${COCKPIT_FRAME_SRC}
             class="h-[calc(100vh_-_300px)] min-h-0 w-full flex-1 border-0"
-            title="MASC Dream IDE Cockpit"
+            title="MASC Cockpit"
           />
         `
         : null}

--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -4,15 +4,12 @@ import { render } from 'preact'
 import { IdeActivityMock } from './ide-activity-mock'
 
 describe('IdeActivityMock', () => {
-  it('renders the activity pane with fallback mock data', () => {
+  it('renders the activity pane with empty state when no API data', () => {
     const container = document.createElement('div')
     render(h(IdeActivityMock, {}), container)
 
     const region = container.querySelector('[role="region"]')
     expect(region?.getAttribute('aria-label')).toBe('ACTIVITY')
-    expect(container.textContent).toContain('13 events · 3 keepers')
-    expect(container.textContent).toContain('nick0cave')
-    expect(container.textContent).toContain('flagged')
-    expect(container.textContent).toContain('router.ts:34')
+    expect(container.textContent).toContain('0 events · 0 keepers')
   })
 })

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -7,7 +7,6 @@ import {
   type RunActivityVerb,
 } from './run-activity-store'
 
-const FALLBACK_ROOM_ID = 'run-fallback'
 const KIND_TO_VERB: Readonly<Record<string, RunActivityVerb>> = {
   'task.created': 'noted',
   'task.claimed': 'flagged',
@@ -52,6 +51,8 @@ interface ApiActivityResponse {
 
 const EMPTY_ACTIVITY: ReadonlyArray<RunActivityEvent> = []
 
+const DEFAULT_ROOM_ID = 'run-default'
+
 function verbFromKind(kind: string): RunActivityVerb {
   return KIND_TO_VERB[kind] ?? DEFAULT_VERB
 }
@@ -88,23 +89,23 @@ function mapApiEvent(event: ApiActivityEvent, roomId: string): RunActivityEvent 
 async function fetchActivityEvents(): Promise<{ events: ReadonlyArray<RunActivityEvent>; roomId: string }> {
   try {
     const res = await fetch('/api/v1/activity/events?limit=50')
-    if (!res.ok) return { events: EMPTY_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+    if (!res.ok) return { events: EMPTY_ACTIVITY, roomId: DEFAULT_ROOM_ID }
     const data: ApiActivityResponse = await res.json()
     const rawEvents = data.events
     if (!Array.isArray(rawEvents) || rawEvents.length === 0) {
-      return { events: EMPTY_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+      return { events: EMPTY_ACTIVITY, roomId: DEFAULT_ROOM_ID }
     }
-    const roomId = rawEvents[0].room_id || FALLBACK_ROOM_ID
+    const roomId = rawEvents[0].room_id || DEFAULT_ROOM_ID
     const mapped = rawEvents.map(e => mapApiEvent(e, roomId))
     return { events: mapped, roomId }
   } catch {
-    return { events: EMPTY_ACTIVITY, roomId: FALLBACK_ROOM_ID }
+    return { events: EMPTY_ACTIVITY, roomId: DEFAULT_ROOM_ID }
   }
 }
 
 export function IdeActivityMock() {
   const store = useMemo(() => {
-    const store = createRunActivityStore(FALLBACK_ROOM_ID)
+    const store = createRunActivityStore(DEFAULT_ROOM_ID)
     store.seed(EMPTY_ACTIVITY)
     return store
   }, [])

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -1,44 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { act } from 'preact/test-utils'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 
 describe('IdeConversationRailMock', () => {
-  it('renders the conversation rail with board posts', () => {
+  it('renders the conversation rail with empty state when no API data', () => {
     const container = document.createElement('div')
     render(h(IdeConversationRailMock, {}), container)
 
     const region = container.querySelector('[role="region"]')
     expect(region?.getAttribute('aria-label')).toBe('CONVERSATION')
     expect(container.textContent).toContain('CONVERSATION')
-    expect(container.textContent).toContain('5')
-    expect(container.textContent).toContain('FLAG')
-    expect(container.textContent).toContain('nick0cave')
-    expect(container.textContent).toContain('operator')
-    expect(container.textContent).toContain('masc-improver')
-  })
-
-  it('focuses a post card when clicked', async () => {
-    const container = document.createElement('div')
-    await act(async () => {
-      render(h(IdeConversationRailMock, {}), container)
-    })
-
-    const button = container.querySelector('button')
-    expect(button?.getAttribute('aria-current')).toBe(null)
-    await act(async () => {
-      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-    expect(button?.getAttribute('aria-current')).toBe('true')
-  })
-
-  it('shows kind labels from board post content', () => {
-    const container = document.createElement('div')
-    render(h(IdeConversationRailMock, {}), container)
-
-    expect(container.textContent).toContain('APPROVE')
-    expect(container.textContent).toContain('SUGGEST')
-    expect(container.textContent).toContain('QUESTION')
+    expect(container.textContent).toContain('0')
   })
 })

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -1,0 +1,114 @@
+import { signal, effect } from '@preact/signals'
+import { activeIdeFile } from './ide-shell'
+import { activeKeeperName } from '../../keeper-state'
+import {
+  fetchWorkspaceFile,
+  fetchGitBlame,
+  fetchGitDiff,
+  fetchWorkspaceTree,
+  type UnifiedDiffRow,
+} from '../../api/workspace'
+import {
+  createCodeDocumentStore,
+  type CodeDocumentStore,
+} from './code-document-store'
+import {
+  createKeeperLineOwnershipStore,
+  type KeeperLineOwnershipStore,
+} from './keeper-line-ownership-store'
+import type { KeeperEditKind } from '../../../design-system/headless-core/keeper-line-ownership'
+import {
+  createFileTreeStore,
+  type FileTreeStore,
+} from './file-tree-store'
+
+export interface IdeDataCoordinator {
+  readonly documentStore: CodeDocumentStore
+  readonly ownershipStore: KeeperLineOwnershipStore
+  readonly fileTreeStore: FileTreeStore
+  readonly diffRows: () => ReadonlyArray<UnifiedDiffRow>
+  readonly subscribeDiffRows: (listener: () => void) => () => void
+  readonly dispose: () => void
+}
+
+export function createIdeDataCoordinator(): IdeDataCoordinator {
+  const documentStore = createCodeDocumentStore({
+    file_path: activeIdeFile.value,
+    language: 'text',
+    content: '',
+  })
+  const ownershipStore = createKeeperLineOwnershipStore(activeIdeFile.value)
+  const fileTreeStore = createFileTreeStore()
+
+  const diffRowsSignal = signal<ReadonlyArray<UnifiedDiffRow>>([])
+
+  let abortController = new AbortController()
+
+  // React to file / keeper changes
+  const disposeEffect = effect(() => {
+    const filePath = activeIdeFile.value
+    const keeper = activeKeeperName.value
+
+    // Cancel in-flight requests for previous file
+    abortController.abort()
+    abortController = new AbortController()
+    const { signal } = abortController
+
+    ownershipStore.reset(filePath)
+
+    const keeperParam = keeper || undefined
+    const opts = { keeper: keeperParam, signal }
+
+    // Load file tree
+    fetchWorkspaceTree(2, opts).then(nodes => {
+      if (signal.aborted) return
+      fileTreeStore.seed(nodes)
+    }).catch(() => {})
+
+    // Load file content
+    fetchWorkspaceFile(filePath, opts).then(response => {
+      if (signal.aborted) return
+      if (response?.ok && response.content) {
+        documentStore.load({
+          file_path: filePath,
+          language: response.language ?? 'text',
+          content: response.content,
+        })
+      }
+    }).catch(() => {})
+
+    // Load blame → ownership
+    fetchGitBlame(filePath, opts).then(blocks => {
+      if (signal.aborted) return
+      for (const block of blocks) {
+        ownershipStore.ingest({
+          file_path: block.file_path,
+          line_start: block.line_start,
+          line_end: block.line_end,
+          keeper_id: block.keeper_id,
+          timestamp_ms: block.timestamp_ms,
+          kind: block.kind as KeeperEditKind,
+        })
+      }
+    }).catch(() => {})
+
+    // Load diff
+    fetchGitDiff(filePath, { ...opts, baseRef: 'HEAD' }).then(rows => {
+      if (signal.aborted) return
+      diffRowsSignal.value = rows
+    }).catch(() => {})
+  })
+
+  return {
+    documentStore,
+    ownershipStore,
+    fileTreeStore,
+    diffRows: () => diffRowsSignal.value,
+    subscribeDiffRows: diffRowsSignal.subscribe as (listener: () => void) => () => void,
+    dispose: () => {
+      abortController.abort()
+      disposeEffect()
+      ownershipStore.dispose()
+    },
+  }
+}

--- a/dashboard/src/components/ide/ide-editor-mock.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.a11y.test.ts
@@ -4,6 +4,19 @@ import { render } from 'preact'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
 import { IdeEditorMock } from './ide-editor-mock'
+import { createCodeDocumentStore } from './code-document-store'
+import { createKeeperLineOwnershipStore } from './keeper-line-ownership-store'
+
+function makeTestStores() {
+  const documentStore = createCodeDocumentStore({
+    file_path: 'test.ts',
+    language: 'typescript',
+    content: 'const x = 1\n',
+  })
+  const ownershipStore = createKeeperLineOwnershipStore('test.ts')
+  const diffRows = () => []
+  return { documentStore, ownershipStore, diffRows }
+}
 
 describe('IdeEditorMock a11y', () => {
   let container: HTMLElement
@@ -19,7 +32,8 @@ describe('IdeEditorMock a11y', () => {
   })
 
   it('renders the code document and ownership-backed editor mock accessibly', async () => {
-    render(html`<${IdeEditorMock} />`, container)
+    const { documentStore, ownershipStore, diffRows } = makeTestStores()
+    render(html`<${IdeEditorMock} documentStore=${documentStore} ownershipStore=${ownershipStore} diffRows=${diffRows} />`, container)
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/ide/ide-editor-mock.test.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.test.ts
@@ -3,6 +3,19 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { IdeEditorMock } from './ide-editor-mock'
 import { activeIdeFile } from './ide-shell'
+import { createCodeDocumentStore } from './code-document-store'
+import { createKeeperLineOwnershipStore } from './keeper-line-ownership-store'
+
+function makeTestStores() {
+  const documentStore = createCodeDocumentStore({
+    file_path: 'runtime/cascade/router.ts',
+    language: 'typescript',
+    content: 'const x = 1\nexport { x }\n',
+  })
+  const ownershipStore = createKeeperLineOwnershipStore('runtime/cascade/router.ts')
+  const diffRows = () => []
+  return { documentStore, ownershipStore, diffRows }
+}
 
 describe('IdeEditorMock', () => {
   beforeEach(() => {
@@ -10,8 +23,9 @@ describe('IdeEditorMock', () => {
   })
 
   it('renders the code document region with file path and language', () => {
+    const { documentStore, ownershipStore, diffRows } = makeTestStores()
     const container = document.createElement('div')
-    render(h(IdeEditorMock, {}), container)
+    render(h(IdeEditorMock, { documentStore, ownershipStore, diffRows }), container)
 
     const region = container.querySelector('[role="region"]')
     expect(region?.getAttribute('aria-label')).toContain('에디터')
@@ -20,15 +34,20 @@ describe('IdeEditorMock', () => {
   })
 
   it('shows 0 keepers when no blame data is available', () => {
+    const { documentStore, ownershipStore, diffRows } = makeTestStores()
     const container = document.createElement('div')
-    render(h(IdeEditorMock, {}), container)
+    render(h(IdeEditorMock, { documentStore, ownershipStore, diffRows }), container)
 
     expect(container.textContent).toContain('0 keepers')
   })
 
   it('renders active view and layer affordances from shell state', () => {
+    const { documentStore, ownershipStore, diffRows } = makeTestStores()
     const container = document.createElement('div')
     render(h(IdeEditorMock, {
+      documentStore,
+      ownershipStore,
+      diffRows,
       activeView: 'blame',
       activeLayers: new Set(['time', 'parallel', 'tools', 'approve', 'notes']),
     }), container)
@@ -44,8 +63,9 @@ describe('IdeEditorMock', () => {
   })
 
   it('renders empty split diff body when no diff data is available', () => {
+    const { documentStore, ownershipStore, diffRows } = makeTestStores()
     const container = document.createElement('div')
-    render(h(IdeEditorMock, { activeView: 'split-diff' }), container)
+    render(h(IdeEditorMock, { documentStore, ownershipStore, diffRows, activeView: 'split-diff' }), container)
 
     expect(container.querySelector('[aria-label="Split diff preview"]')).not.toBeNull()
     expect(container.textContent).toContain('BEFORE')
@@ -53,16 +73,18 @@ describe('IdeEditorMock', () => {
   })
 
   it('renders empty unified diff body when no diff data is available', () => {
+    const { documentStore, ownershipStore, diffRows } = makeTestStores()
     const container = document.createElement('div')
-    render(h(IdeEditorMock, { activeView: 'unified' }), container)
+    render(h(IdeEditorMock, { documentStore, ownershipStore, diffRows, activeView: 'unified' }), container)
 
     expect(container.querySelector('[aria-label="Unified diff preview"]')).not.toBeNull()
-    expect(container.textContent).toContain('SOURCE')
+    expect(container.textContent).toContain('UNIFIED')
   })
 
   it('renders blame timeline metadata for the blame view', () => {
+    const { documentStore, ownershipStore, diffRows } = makeTestStores()
     const container = document.createElement('div')
-    render(h(IdeEditorMock, { activeView: 'blame' }), container)
+    render(h(IdeEditorMock, { documentStore, ownershipStore, diffRows, activeView: 'blame' }), container)
 
     expect(container.querySelector('[aria-label="Blame timeline"]')).not.toBeNull()
     expect(container.querySelector('[aria-label="Blame editor view"]')).not.toBeNull()

--- a/dashboard/src/components/ide/ide-editor-mock.ts
+++ b/dashboard/src/components/ide/ide-editor-mock.ts
@@ -1,19 +1,16 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
-import { useMemo, useState, useEffect } from 'preact/hooks'
-import { activeKeeperName } from '../../keeper-state'
-import { activeIdeFile } from './ide-shell'
+import { useState, useEffect } from 'preact/hooks'
 import {
-  createCodeDocumentStore,
+  type CodeDocumentStore,
   type CodeDocumentLine,
 } from './code-document-store'
 import { CodeLineText, useHighlightedCodeLines } from './ide-code-renderer'
 import {
-  createKeeperLineOwnershipStore,
+  type KeeperLineOwnershipStore,
   type LineOwnership,
 } from './keeper-line-ownership-store'
-import type { KeeperEditKind } from '../../../design-system/headless-core/keeper-line-ownership'
-import { languageFromPath } from './language-detection'
+import type { UnifiedDiffRow } from '../../api/workspace'
 
 const IDE_LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'explode'] as const
 type IdeLayerKind = (typeof IDE_LAYER_ORDER)[number]
@@ -23,21 +20,17 @@ type IdeLayerKind = (typeof IDE_LAYER_ORDER)[number]
 // typed contracts. The syntax renderer is deliberately read-only and keeps the
 // same CodeDocumentLine + LineOwnership contracts for a future CodeMirror swap.
 
+type DiffTone = 'context' | 'add' | 'delete'
+
 export type IdeEditorView = 'source' | 'split-diff' | 'unified' | 'blame'
 
 interface IdeEditorMockProps {
   readonly activeView?: IdeEditorView
   readonly activeLayers?: ReadonlySet<string>
+  readonly documentStore: CodeDocumentStore
+  readonly ownershipStore: KeeperLineOwnershipStore
+  readonly diffRows: () => ReadonlyArray<UnifiedDiffRow>
   readonly children?: ComponentChildren
-}
-
-type DiffTone = 'context' | 'add' | 'delete'
-
-interface UnifiedDiffRow {
-  readonly kind: DiffTone
-  readonly oldLine: number | null
-  readonly newLine: number | null
-  readonly text: string
 }
 
 interface SplitDiffCell {
@@ -52,37 +45,6 @@ interface SplitDiffRow {
 }
 
 const EMPTY_ACTIVE_LAYERS: ReadonlySet<string> = new Set()
-
-interface BlameBlock {
-  readonly file_path: string
-  readonly line_start: number
-  readonly line_end: number
-  readonly keeper_id: string
-  readonly timestamp_ms: number
-  readonly kind: string
-}
-
-async function fetchBlame(path: string, keeper = ''): Promise<BlameBlock[]> {
-  try {
-    const params = new URLSearchParams({ path })
-    if (keeper) params.set('keeper', keeper)
-    const res = await fetch('/api/v1/git/blame?' + params.toString())
-    if (!res.ok) return []
-    const data = await res.json()
-    return Array.isArray(data) ? data : []
-  } catch { return [] }
-}
-
-async function fetchDiff(path: string, baseRef = 'HEAD', keeper = ''): Promise<UnifiedDiffRow[]> {
-  try {
-    const params = new URLSearchParams({ path, base_ref: baseRef })
-    if (keeper) params.set('keeper', keeper)
-    const res = await fetch('/api/v1/git/diff?' + params.toString())
-    if (!res.ok) return []
-    const data = await res.json()
-    return Array.isArray(data.unified) ? data.unified : []
-  } catch { return [] }
-}
 
 const VIEW_LABEL: Record<IdeEditorView, string> = {
   source: 'SOURCE',
@@ -103,73 +65,17 @@ const LAYER_LABEL: Record<IdeLayerKind, string> = {
 export function IdeEditorMock({
   activeView = 'source',
   activeLayers = EMPTY_ACTIVE_LAYERS,
+  documentStore,
+  ownershipStore,
+  diffRows,
 }: IdeEditorMockProps) {
-  const [sourceCode, setSourceCode] = useState<string[]>([])
-  const [keeperName, setKeeperName] = useState(activeKeeperName.value)
-  useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
-
-  useEffect(() => {
-    let canceled = false;
-    const params = new URLSearchParams({ path: activeIdeFile.value })
-    if (keeperName) params.set('keeper', keeperName)
-    fetch('/api/v1/workspace/file?' + params.toString())
-      .then(r => r.json())
-      .then(d => {
-        if (!canceled && d.ok && d.content) {
-          setSourceCode(d.content.split('\n'));
-        }
-      })
-      .catch(console.error);
-    return () => { canceled = true };
-  }, [activeIdeFile.value, keeperName]);
-
-  const documentStore = useMemo(
-    () => createCodeDocumentStore({
-      file_path: activeIdeFile.value,
-      language: languageFromPath(activeIdeFile.value),
-      content: sourceCode,
-    }),
-    [sourceCode, activeIdeFile.value],
-  )
-  const ownershipStore = useMemo(() => {
-    const store = createKeeperLineOwnershipStore(activeIdeFile.value)
-    return store
-  }, [activeIdeFile.value])
-
-  useEffect(() => {
-    let cancelled = false
-    fetchBlame(activeIdeFile.value, keeperName).then(blocks => {
-      if (cancelled) return
-      ownershipStore.reset(activeIdeFile.value)
-      for (const block of blocks) {
-        ownershipStore.ingest({
-          file_path: block.file_path,
-          line_start: block.line_start,
-          line_end: block.line_end,
-          keeper_id: block.keeper_id,
-          timestamp_ms: block.timestamp_ms,
-          kind: block.kind as KeeperEditKind,
-        })
-      }
-    })
-    return () => { cancelled = true }
-  }, [activeIdeFile.value, keeperName, ownershipStore])
-
-  const [diffRows, setDiffRows] = useState<UnifiedDiffRow[]>([])
-  useEffect(() => {
-    let cancelled = false
-    fetchDiff(activeIdeFile.value, 'HEAD', keeperName).then(rows => {
-      if (!cancelled) setDiffRows(rows)
-    })
-    return () => { cancelled = true }
-  }, [activeIdeFile.value, keeperName])
-
   const document = documentStore.document()
   const lines = documentStore.lines()
   const ownership = ownershipStore.ownership()
   const keepers = ownershipStore.knownKeepers()
   const highlightedLines = useHighlightedCodeLines(document)
   const activeLayerKinds = activeLayersInDisplayOrder(activeLayers)
+  const currentDiffRows = diffRows()
 
   return html`
     <div
@@ -203,7 +109,7 @@ export function IdeEditorMock({
       ${activeLayerKinds.length > 0
         ? LayerOverlaySummary(activeLayerKinds, ownership, keepers)
         : null}
-      ${EditorViewport(activeView, lines, ownership, highlightedLines, activeLayerKinds, keepers, diffRows)}
+      ${EditorViewport(activeView, lines, ownership, highlightedLines, activeLayerKinds, keepers, currentDiffRows)}
     </div>
   `
 }

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -1,56 +1,16 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { activeKeeperName } from '../../keeper-state'
-import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
+import { type FileTreeStore, type FileTreeNode } from './file-tree-store'
 import { activeIdeFile } from './ide-shell'
 
-// Phase 2 PR-4: real EXPLORER backed by file-tree-store. Replaces the
-// PR-2 ide-explorer-mock placeholder. The fixture below is the same
-// 14-node tree the mock rendered; it now flows through the store so
-// future PRs can swap in keeper-artifact / repo-fs sources without
-// changing the component.
-//
-// The store handles expansion semantics; this component is a thin
-// renderer that subscribes to visibleNodes and dispatches toggle
-// clicks. Headless tree-view (RFC 0014) keyboard navigation lands
-// in a follow-up; for now click-to-expand is enough to validate the
-// store wiring.
-//
-// Audit reference:
-//   dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md
-
-const FALLBACK_SEED: ReadonlyArray<FileTreeNode> = [
-  { path: 'dune-project', label: 'dune-project', depth: 0, parent: null, hasChildren: false, diff: null, keeperId: null, hueIndex: null },
-  { path: 'README.md', label: 'README.md', depth: 0, parent: null, hasChildren: false, diff: null, keeperId: null, hueIndex: null },
-]
-
-async function fetchTree(depth = 3, keeper = ''): Promise<FileTreeNode[]> {
-  try {
-    const params = new URLSearchParams({ depth: String(depth) })
-    if (keeper) params.set('keeper', keeper)
-    const res = await fetch(`/api/v1/workspace/tree?${params.toString()}`)
-    if (!res.ok) return [...FALLBACK_SEED]
-    const data = await res.json()
-    if (!Array.isArray(data) || data.length === 0) return [...FALLBACK_SEED]
-    return data as FileTreeNode[]
-  } catch { return [...FALLBACK_SEED] }
+interface IdeExplorerProps {
+  readonly fileTreeStore: FileTreeStore
 }
 
-export function IdeExplorer() {
-  const store = useMemo(() => {
-    const s = createFileTreeStore()
-    s.seed(FALLBACK_SEED)
-    return s
-  }, [])
-
+export function IdeExplorer({ fileTreeStore: store }: IdeExplorerProps) {
   const [keeperName, setKeeperName] = useState(activeKeeperName.value)
   useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
-
-  useEffect(() => {
-    let cancelled = false
-    fetchTree(3, keeperName).then(nodes => { if (!cancelled) store.seed(nodes) })
-    return () => { cancelled = true }
-  }, [store, keeperName])
 
   const [tick, setTick] = useState(0)
   useEffect(() => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,7 +1,8 @@
 import { signal } from '@preact/signals'
 export const activeIdeFile = signal<string>('package.json')
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { createIdeDataCoordinator } from './ide-data-coordinator'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditorMock, type IdeEditorView } from './ide-editor-mock'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
@@ -80,6 +81,10 @@ function CockpitPreview() {
 }
 
 export function IdeShell() {
+  const coordinator = useMemo(() => createIdeDataCoordinator(), [])
+
+  useEffect(() => () => coordinator.dispose(), [coordinator])
+
   const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
   const activeLayers = layersFromRoute(route.value.params.layers)
 
@@ -144,7 +149,7 @@ export function IdeShell() {
         }}
       >
         <div class="ide-plane-tree">
-          <${IdeExplorer} />
+          <${IdeExplorer} fileTreeStore=${coordinator.fileTreeStore} />
         </div>
         <div
           class="ide-plane-editor"
@@ -154,7 +159,13 @@ export function IdeShell() {
             minHeight: 0,
           }}
         >
-          <${IdeEditorMock} activeView=${activeView} activeLayers=${activeLayers} />
+          <${IdeEditorMock}
+            activeView=${activeView}
+            activeLayers=${activeLayers}
+            documentStore=${coordinator.documentStore}
+            ownershipStore=${coordinator.ownershipStore}
+            diffRows=${coordinator.diffRows}
+          />
           <${CockpitPreview} />
         </div>
         <div class="ide-plane-conversation" style=${{ minHeight: 0 }}>

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -73,7 +73,7 @@ function CockpitPreview() {
       <iframe
         src=${COCKPIT_FRAME_SRC}
         class="h-full min-h-0 w-full border-0"
-        title="MASC Dream IDE Cockpit"
+        title="MASC Cockpit"
       />
     </section>
   `

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -73,7 +73,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'cockpit',
     label: 'MASC Cockpit',
     icon: 'workspace',
-    description: 'High-Fidelity MASC Cockpit (Dream IDE)',
+    description: 'High-Fidelity MASC Cockpit',
     defaultTab: 'cockpit',
     tabs: ['cockpit'],
   },


### PR DESCRIPTION
## Summary
- Phase 1: "Dream IDE" → "MASC Cockpit" branding cleanup (3 files)
- Phase 2: Workspace API client module (`api/workspace.ts`) with typed HTTP endpoints
- Phase 3: IDE data coordinator + store wiring + mock fallback removal

Components now receive stores as props; coordinator manages API → store → component pipeline. No more hardcoded mock data in any IDE component.

## Test plan
- [x] 59 IDE-specific tests pass (editor, activity, conversation rail, explorer, a11y)
- [x] `tsc --noEmit` passes
- [x] Pre-existing CSS token test failures (21) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)