### PR TITLE
feat(keeper): persona admission policy types (PR-B 1/3 of RFC-0026)

### DIFF
--- a/lib/keeper/keeper_admission_policy.ml
+++ b/lib/keeper/keeper_admission_policy.ml
@@ -64,13 +64,63 @@ let of_fields ~keeper_id ~candidates ~weight ~min_tier =
           | Some p -> Error (Duplicate_provider p)
           | None -> Ok { keeper_id; candidates; weight; min_tier }
 
-let parse_toml_block ~keeper_id:_ (_toml_text : string) =
-  (* Implementation deferred to PR-B-2.  The mli signature is stable;
-     the parser will lift each TOML candidate row into a [candidate]
-     record and forward to [of_fields].  Returning [Error] from this
-     stub keeps any caller from accidentally building an empty policy
-     before the parser lands. *)
-  Error Empty_candidate_list
+(* JSON parsing helpers.  Avoid Yojson.Safe.Util to keep the diff
+   reviewable — direct match on `Assoc / `List / `String / `Int. *)
+
+let assoc_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let int_or_default ~default = function
+  | Some (`Int n) -> n
+  | _ -> default
+
+let string_field = function
+  | Some (`String s) -> Some s
+  | _ -> None
+
+let candidate_of_json json =
+  let provider = string_field (assoc_field "provider" json) in
+  let model = string_field (assoc_field "model" json) in
+  let tier_str = string_field (assoc_field "tier" json) in
+  match provider, model, tier_str with
+  | Some provider, Some model, Some tier_str ->
+      (match tier_of_label tier_str with
+       | Some tier -> Ok { provider; model; tier }
+       | None -> Error (Unknown_tier_label tier_str))
+  | _ -> Error Empty_candidate_list
+    (* Missing required field is treated as malformed input — the
+       caller's invariant is that every candidate row has provider /
+       model / tier. *)
+
+let candidates_of_json = function
+  | `List rows ->
+      let rec collect acc = function
+        | [] -> Ok (List.rev acc)
+        | row :: rest ->
+            (match candidate_of_json row with
+             | Ok c -> collect (c :: acc) rest
+             | Error e -> Error e)
+      in
+      collect [] rows
+  | _ -> Error Empty_candidate_list
+
+let parse_admission_json ~keeper_id (json : Yojson.Safe.t) =
+  let weight = int_or_default ~default:1 (assoc_field "weight" json) in
+  let min_tier_label =
+    Option.value ~default:"Acceptable"
+      (string_field (assoc_field "min_tier" json))
+  in
+  match tier_of_label min_tier_label with
+  | None -> Error (Unknown_tier_label min_tier_label)
+  | Some min_tier ->
+      (match assoc_field "candidates" json with
+       | None -> Error Empty_candidate_list
+       | Some candidates_json ->
+           (match candidates_of_json candidates_json with
+            | Error e -> Error e
+            | Ok candidates ->
+                of_fields ~keeper_id ~candidates ~weight ~min_tier))
 
 let keeper_id t = t.keeper_id
 let candidates t = t.candidates

--- a/lib/keeper/keeper_admission_policy.ml
+++ b/lib/keeper/keeper_admission_policy.ml
@@ -1,0 +1,88 @@
+(* See keeper_admission_policy.mli for documentation. *)
+
+type tier = Preferred | Acceptable | Survival
+
+type candidate = {
+  provider : string;
+  model : string;
+  tier : tier;
+}
+
+type t = {
+  keeper_id : string;
+  candidates : candidate list;
+  weight : int;
+  min_tier : tier;
+}
+
+type validation_error =
+  | Empty_candidate_list
+  | Min_tier_above_preferred
+  | Duplicate_provider of string
+  | Unknown_tier_label of string
+  | Weight_out_of_range of int
+
+let tier_label = function
+  | Preferred -> "Preferred"
+  | Acceptable -> "Acceptable"
+  | Survival -> "Survival"
+
+let tier_of_label = function
+  | "Preferred" -> Some Preferred
+  | "Acceptable" -> Some Acceptable
+  | "Survival" -> Some Survival
+  | _ -> None
+
+let tier_compare a b =
+  let rank = function
+    | Preferred -> 0
+    | Acceptable -> 1
+    | Survival -> 2
+  in
+  Stdlib.compare (rank a) (rank b)
+
+let has_duplicate_provider candidates =
+  let rec aux seen = function
+    | [] -> None
+    | c :: rest ->
+        if List.mem c.provider seen then Some c.provider
+        else aux (c.provider :: seen) rest
+  in
+  aux [] candidates
+
+let of_fields ~keeper_id ~candidates ~weight ~min_tier =
+  if candidates = [] then Error Empty_candidate_list
+  else if weight < 1 then Error (Weight_out_of_range weight)
+  else
+    match List.nth_opt candidates 0 with
+    | None -> Error Empty_candidate_list
+    | Some head_candidate ->
+        if tier_compare min_tier head_candidate.tier < 0 then
+          Error Min_tier_above_preferred
+        else
+          match has_duplicate_provider candidates with
+          | Some p -> Error (Duplicate_provider p)
+          | None -> Ok { keeper_id; candidates; weight; min_tier }
+
+let parse_toml_block ~keeper_id:_ (_toml_text : string) =
+  (* Implementation deferred to PR-B-2.  The mli signature is stable;
+     the parser will lift each TOML candidate row into a [candidate]
+     record and forward to [of_fields].  Returning [Error] from this
+     stub keeps any caller from accidentally building an empty policy
+     before the parser lands. *)
+  Error Empty_candidate_list
+
+let keeper_id t = t.keeper_id
+let candidates t = t.candidates
+let weight t = t.weight
+let min_tier t = t.min_tier
+
+let candidates_above_min_tier t =
+  List.filter (fun c -> tier_compare c.tier t.min_tier <= 0) t.candidates
+
+let top_provider t =
+  match t.candidates with
+  | c :: _ -> c.provider
+  | [] ->
+      (* Unreachable: [of_fields] rejects empty lists.  Defensive only. *)
+      ""

--- a/lib/keeper/keeper_admission_policy.mli
+++ b/lib/keeper/keeper_admission_policy.mli
@@ -77,13 +77,15 @@ val of_fields :
     - all [candidate.provider] strings are distinct
     - [weight >= 1] (default 1; persona-level priority for WFQ) *)
 
-val parse_toml_block :
-  keeper_id:string -> string -> (t, validation_error) result
-(** Parse the [\[admission\]] sub-table of a persona TOML file into a
-    policy.  Schema (informal):
+val parse_admission_json :
+  keeper_id:string -> Yojson.Safe.t -> (t, validation_error) result
+(** Parse the [admission] sub-object of a per-keeper config block (the
+    JSON view that [cascade_toml_materializer] produces from
+    [\[admission.<keeper_id>\]] sub-tables in [cascade.toml]).  Schema
+    (informal):
 
     {v
-    [admission]
+    [admission.analyst]
     weight = 1
     min_tier = "Acceptable"
     candidates = [
@@ -93,9 +95,27 @@ val parse_toml_block :
     ]
     v}
 
-    Missing block returns [Error Empty_candidate_list] — every persona
-    must declare its admission policy explicitly to make I5 (drift
-    observability) defensible. *)
+    The materializer lifts that to:
+
+    {v
+    {
+      "weight": 1,
+      "min_tier": "Acceptable",
+      "candidates": [
+        {"provider":"anthropic","model":"claude-sonnet-4-6","tier":"Preferred"},
+        ...
+      ]
+    }
+    v}
+
+    Missing fields default to: [weight = 1], [min_tier = "Acceptable"].
+    Missing or empty [candidates] returns [Error Empty_candidate_list]
+    — every persona must declare candidates explicitly to make I5
+    (drift observability) defensible.
+
+    Pure: no file I/O.  The caller is expected to read the JSON from
+    [cascade_config_loader.load_json] and select the appropriate
+    sub-object before calling this function. *)
 
 (** {1 Query} *)
 

--- a/lib/keeper/keeper_admission_policy.mli
+++ b/lib/keeper/keeper_admission_policy.mli
@@ -1,0 +1,140 @@
+(** Per-persona admission policy for the work-conserving keeper scheduler.
+
+    Part of RFC-0026 (Work-Conserving Keeper Admission, §3.3).  Owns the
+    "which providers will I accept and at what quality tier" decision
+    that the admission router consults at every keeper turn.
+
+    This module is purely declarative — it loads a TOML block, validates
+    invariants, and exposes a query API.  It performs no I/O against
+    providers and does no fairness scheduling.  Those layers are
+    [Keeper_provider_token_bucket] (PR-A, already merged) and the
+    forthcoming admission router + WFQ overflow modules (PR-C).
+
+    Layered invariants (RFC-0026 §3.1):
+
+      I5 (Drift Observability): every dispatch where [preferred(k) /=
+      actual(k)] is logged with [(keeper, preferred, actual, reason,
+      tier)].  The persona policy supplies [preferred(k)] and the tier
+      classification of every other candidate; the router emits the log
+      line.
+
+    Non-goals:
+
+    - This module does NOT decide whether a provider's bucket has
+      tokens — that is [Keeper_provider_token_bucket.try_acquire].
+    - This module does NOT enqueue starved keepers — that is the WFQ
+      overflow queue (PR-C scope).
+    - This module does NOT model in-attempt streaming liveness
+      (RFC-0022 territory). *)
+
+type tier =
+  | Preferred
+  (** Top-tier model the persona prefers.  Drift to other tiers is
+      always logged. *)
+  | Acceptable
+  (** Same-quality alternatives.  No surface event — the persona
+      considers these equivalent for its workload. *)
+  | Survival
+  (** Last-resort models (e.g. local Ollama).  Only used when all
+      higher tiers are throttled.  Always emits a Drift log line. *)
+
+type candidate = {
+  provider : string;     (* matches Keeper_provider_token_bucket.provider_id *)
+  model : string;        (* concrete model id, e.g. "claude-sonnet-4-6" *)
+  tier : tier;
+}
+(** A single (provider, model, tier) entry.  Order in the candidate
+    list is the persona's preference; the admission router walks it
+    in order and stops at the first available bucket. *)
+
+type t
+(** Opaque persona admission policy.  Built from a parsed TOML block;
+    immutable after creation. *)
+
+(** {1 Construction} *)
+
+type validation_error =
+  | Empty_candidate_list
+  | Min_tier_above_preferred
+  | Duplicate_provider of string
+  | Unknown_tier_label of string
+  | Weight_out_of_range of int
+
+val of_fields :
+  keeper_id:string ->
+  candidates:candidate list ->
+  weight:int ->
+  min_tier:tier ->
+  (t, validation_error) result
+(** Build a policy from already-typed fields.  Returns [Error] when an
+    invariant is violated.  Pure — no I/O.
+
+    Invariants enforced:
+
+    - [candidates <> []]
+    - [min_tier] is not strictly above [Preferred] (i.e. [min_tier] is
+      not "better than the most preferred candidate")
+    - all [candidate.provider] strings are distinct
+    - [weight >= 1] (default 1; persona-level priority for WFQ) *)
+
+val parse_toml_block :
+  keeper_id:string -> string -> (t, validation_error) result
+(** Parse the [\[admission\]] sub-table of a persona TOML file into a
+    policy.  Schema (informal):
+
+    {v
+    [admission]
+    weight = 1
+    min_tier = "Acceptable"
+    candidates = [
+      { provider = "anthropic", model = "claude-sonnet-4-6", tier = "Preferred" },
+      { provider = "glm-coding", model = "auto",             tier = "Acceptable" },
+      { provider = "ollama",     model = "qwen3.6:27b-coding-nvfp4", tier = "Survival" },
+    ]
+    v}
+
+    Missing block returns [Error Empty_candidate_list] — every persona
+    must declare its admission policy explicitly to make I5 (drift
+    observability) defensible. *)
+
+(** {1 Query} *)
+
+val keeper_id : t -> string
+
+val candidates : t -> candidate list
+(** Returns the candidate list in persona preference order.  The
+    admission router is expected to walk this list and call
+    [Keeper_provider_token_bucket.try_acquire] on the first whose tier
+    is not below [min_tier]. *)
+
+val candidates_above_min_tier : t -> candidate list
+(** Same as [candidates] but with entries below [min_tier] filtered
+    out.  Convenience for routers that always respect the floor. *)
+
+val weight : t -> int
+(** WFQ weight.  Default 1.  Higher weight = more frequent dispatch
+    when the overflow queue chooses among waiters. *)
+
+val min_tier : t -> tier
+(** The minimum tier this persona will accept.  When all candidates
+    above [min_tier] are throttled, the router must surface a
+    [Capacity_exhausted] event rather than silently demoting. *)
+
+val top_provider : t -> string
+(** [provider] of the head of the candidate list — the persona's
+    most-preferred provider.  Used for I5 drift logging
+    ([preferred] field). *)
+
+(** {1 Tier helpers} *)
+
+val tier_label : tier -> string
+(** ["Preferred" | "Acceptable" | "Survival"].  Stable string for log
+    lines and Prometheus labels. *)
+
+val tier_of_label : string -> tier option
+(** Inverse of [tier_label].  Returns [None] for unknown labels — the
+    parser uses this to surface [Unknown_tier_label]. *)
+
+val tier_compare : tier -> tier -> int
+(** Total order: [Preferred < Acceptable < Survival].  Lower is
+    better.  Used to filter against [min_tier]. *)

--- a/test/dune
+++ b/test/dune
@@ -1064,6 +1064,7 @@
 (include stanzas/test_join_required_guard_counter.inc)
 (include stanzas/test_k2_pipeline_e2e.inc)
 (include stanzas/test_k3_tool_pipeline_e2e.inc)
+(include stanzas/test_keeper_admission_policy.inc)
 (include stanzas/test_keeper_auto_pause_blocker_persist_12683.inc)
 (include stanzas/test_keeper_agent_run_sandbox_source.inc)
 (include stanzas/test_keeper_autoboot_supervisor_start_10125.inc)

--- a/test/stanzas/test_keeper_admission_policy.inc
+++ b/test/stanzas/test_keeper_admission_policy.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_admission_policy)
+ (modules test_keeper_admission_policy)
+ (libraries masc_mcp alcotest yojson))

--- a/test/test_keeper_admission_policy.ml
+++ b/test/test_keeper_admission_policy.ml
@@ -1,0 +1,285 @@
+(** Unit tests for Keeper_admission_policy.
+
+    Covers two surfaces in isolation:
+
+    1. [of_fields] — validated constructor, all five [validation_error]
+       branches.
+    2. [parse_admission_json] — JSON parser, default field handling,
+       and error surfacing for malformed inputs.
+
+    The constructor surface intentionally allows policies that the
+    runtime would later reject only at scheduling time (e.g. all
+    candidates throttled).  Those scheduling-time concerns belong to
+    the admission router (PR-C), not to this module. *)
+
+open Masc_mcp
+module KAP = Keeper_admission_policy
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let candidate ~p ~m ~t : KAP.candidate = { provider = p; model = m; tier = t }
+
+let assert_validation_error name (got : ('a, KAP.validation_error) result)
+    expected =
+  match got with
+  | Error e when e = expected -> ()
+  | Error _ ->
+      Alcotest.failf "%s: expected error %s, got other variant"
+        name
+        (match expected with
+         | KAP.Empty_candidate_list -> "Empty_candidate_list"
+         | KAP.Min_tier_above_preferred -> "Min_tier_above_preferred"
+         | KAP.Duplicate_provider _ -> "Duplicate_provider _"
+         | KAP.Unknown_tier_label _ -> "Unknown_tier_label _"
+         | KAP.Weight_out_of_range _ -> "Weight_out_of_range _")
+  | Ok _ -> Alcotest.failf "%s: expected Error, got Ok" name
+
+(* ------------------------------------------------------------------ *)
+(* of_fields — validation error coverage                              *)
+(* ------------------------------------------------------------------ *)
+
+let test_of_fields_valid_three_candidates () =
+  let cands =
+    [ candidate ~p:"anthropic" ~m:"claude-sonnet-4-6" ~t:KAP.Preferred
+    ; candidate ~p:"glm" ~m:"auto" ~t:KAP.Acceptable
+    ; candidate ~p:"ollama" ~m:"qwen3.6:27b-coding-nvfp4" ~t:KAP.Survival
+    ]
+  in
+  match
+    KAP.of_fields ~keeper_id:"analyst" ~candidates:cands ~weight:1
+      ~min_tier:KAP.Acceptable
+  with
+  | Ok t ->
+      Alcotest.(check string) "keeper_id" "analyst" (KAP.keeper_id t);
+      Alcotest.(check int) "weight" 1 (KAP.weight t);
+      Alcotest.(check string) "top_provider" "anthropic" (KAP.top_provider t);
+      Alcotest.(check int) "candidates count" 3 (List.length (KAP.candidates t))
+  | Error _ -> Alcotest.fail "expected Ok, got Error"
+
+let test_of_fields_empty_list () =
+  let got =
+    KAP.of_fields ~keeper_id:"analyst" ~candidates:[] ~weight:1
+      ~min_tier:KAP.Acceptable
+  in
+  assert_validation_error "empty list" got KAP.Empty_candidate_list
+
+let test_of_fields_zero_weight () =
+  let cands =
+    [ candidate ~p:"anthropic" ~m:"x" ~t:KAP.Preferred ]
+  in
+  let got =
+    KAP.of_fields ~keeper_id:"analyst" ~candidates:cands ~weight:0
+      ~min_tier:KAP.Acceptable
+  in
+  match got with
+  | Error (KAP.Weight_out_of_range 0) -> ()
+  | _ -> Alcotest.fail "expected Weight_out_of_range 0"
+
+let test_of_fields_min_tier_above_preferred () =
+  (* head candidate is Acceptable, but min_tier = Preferred — that is
+     "min_tier strictly above the most preferred candidate", which makes
+     the policy unsatisfiable on its own preference list. *)
+  let cands =
+    [ candidate ~p:"glm" ~m:"auto" ~t:KAP.Acceptable ]
+  in
+  let got =
+    KAP.of_fields ~keeper_id:"analyst" ~candidates:cands ~weight:1
+      ~min_tier:KAP.Preferred
+  in
+  assert_validation_error "min_tier above preferred"
+    got KAP.Min_tier_above_preferred
+
+let test_of_fields_duplicate_provider () =
+  let cands =
+    [ candidate ~p:"anthropic" ~m:"claude-sonnet-4-6" ~t:KAP.Preferred
+    ; candidate ~p:"anthropic" ~m:"claude-haiku-4-5" ~t:KAP.Acceptable
+    ]
+  in
+  let got =
+    KAP.of_fields ~keeper_id:"analyst" ~candidates:cands ~weight:1
+      ~min_tier:KAP.Acceptable
+  in
+  match got with
+  | Error (KAP.Duplicate_provider "anthropic") -> ()
+  | _ -> Alcotest.fail "expected Duplicate_provider \"anthropic\""
+
+(* ------------------------------------------------------------------ *)
+(* candidates_above_min_tier filtering                                *)
+(* ------------------------------------------------------------------ *)
+
+let test_candidates_above_min_tier_filters_survival () =
+  let cands =
+    [ candidate ~p:"anthropic" ~m:"x" ~t:KAP.Preferred
+    ; candidate ~p:"glm" ~m:"y" ~t:KAP.Acceptable
+    ; candidate ~p:"ollama" ~m:"z" ~t:KAP.Survival
+    ]
+  in
+  match
+    KAP.of_fields ~keeper_id:"k" ~candidates:cands ~weight:1
+      ~min_tier:KAP.Acceptable
+  with
+  | Ok t ->
+      let above = KAP.candidates_above_min_tier t in
+      Alcotest.(check int) "two above-or-equal Acceptable"
+        2 (List.length above)
+  | Error _ -> Alcotest.fail "expected Ok"
+
+(* ------------------------------------------------------------------ *)
+(* tier helpers                                                        *)
+(* ------------------------------------------------------------------ *)
+
+let test_tier_compare_total_order () =
+  let p = KAP.Preferred and a = KAP.Acceptable and s = KAP.Survival in
+  Alcotest.(check bool) "P < A" true (KAP.tier_compare p a < 0);
+  Alcotest.(check bool) "A < S" true (KAP.tier_compare a s < 0);
+  Alcotest.(check bool) "P < S" true (KAP.tier_compare p s < 0);
+  Alcotest.(check int) "P = P" 0 (KAP.tier_compare p p)
+
+let test_tier_label_roundtrip () =
+  List.iter
+    (fun t ->
+      let label = KAP.tier_label t in
+      match KAP.tier_of_label label with
+      | Some t' -> Alcotest.(check int) label 0 (KAP.tier_compare t t')
+      | None -> Alcotest.failf "tier_of_label rejected %S" label)
+    [ KAP.Preferred; KAP.Acceptable; KAP.Survival ]
+
+let test_tier_of_label_unknown_returns_none () =
+  Alcotest.(check bool) "unknown -> None" true
+    (KAP.tier_of_label "Premium" = None)
+
+(* ------------------------------------------------------------------ *)
+(* parse_admission_json                                                *)
+(* ------------------------------------------------------------------ *)
+
+let valid_json : Yojson.Safe.t =
+  `Assoc
+    [ ("weight", `Int 2)
+    ; ("min_tier", `String "Acceptable")
+    ; ( "candidates"
+      , `List
+          [ `Assoc
+              [ ("provider", `String "anthropic")
+              ; ("model", `String "claude-sonnet-4-6")
+              ; ("tier", `String "Preferred")
+              ]
+          ; `Assoc
+              [ ("provider", `String "glm")
+              ; ("model", `String "auto")
+              ; ("tier", `String "Acceptable")
+              ]
+          ] )
+    ]
+
+let test_parse_admission_json_valid () =
+  match KAP.parse_admission_json ~keeper_id:"analyst" valid_json with
+  | Ok t ->
+      Alcotest.(check int) "weight 2" 2 (KAP.weight t);
+      Alcotest.(check string) "top anthropic" "anthropic" (KAP.top_provider t);
+      Alcotest.(check int) "two candidates" 2 (List.length (KAP.candidates t))
+  | Error _ -> Alcotest.fail "expected Ok on valid_json"
+
+let test_parse_admission_json_missing_candidates () =
+  let json : Yojson.Safe.t =
+    `Assoc [ ("weight", `Int 1); ("min_tier", `String "Acceptable") ]
+  in
+  let got = KAP.parse_admission_json ~keeper_id:"analyst" json in
+  assert_validation_error "missing candidates" got KAP.Empty_candidate_list
+
+let test_parse_admission_json_empty_candidates () =
+  let json : Yojson.Safe.t =
+    `Assoc
+      [ ("weight", `Int 1)
+      ; ("min_tier", `String "Acceptable")
+      ; ("candidates", `List [])
+      ]
+  in
+  let got = KAP.parse_admission_json ~keeper_id:"analyst" json in
+  assert_validation_error "empty list" got KAP.Empty_candidate_list
+
+let test_parse_admission_json_unknown_tier () =
+  let json : Yojson.Safe.t =
+    `Assoc
+      [ ("min_tier", `String "Premium")  (* invalid label *)
+      ; ( "candidates"
+        , `List
+            [ `Assoc
+                [ ("provider", `String "x")
+                ; ("model", `String "y")
+                ; ("tier", `String "Preferred")
+                ]
+            ] )
+      ]
+  in
+  let got = KAP.parse_admission_json ~keeper_id:"analyst" json in
+  match got with
+  | Error (KAP.Unknown_tier_label "Premium") -> ()
+  | _ -> Alcotest.fail "expected Unknown_tier_label \"Premium\""
+
+let test_parse_admission_json_defaults () =
+  (* No weight, no min_tier — defaults are 1 and Acceptable.  Single
+     Preferred candidate so policy is well-formed. *)
+  let json : Yojson.Safe.t =
+    `Assoc
+      [ ( "candidates"
+        , `List
+            [ `Assoc
+                [ ("provider", `String "anthropic")
+                ; ("model", `String "claude-sonnet-4-6")
+                ; ("tier", `String "Preferred")
+                ]
+            ] )
+      ]
+  in
+  match KAP.parse_admission_json ~keeper_id:"analyst" json with
+  | Ok t ->
+      Alcotest.(check int) "weight default 1" 1 (KAP.weight t);
+      Alcotest.(check int)
+        "min_tier default = Acceptable -> tier_compare Acceptable Acceptable"
+        0
+        (KAP.tier_compare (KAP.min_tier t) KAP.Acceptable)
+  | Error _ -> Alcotest.fail "expected Ok with defaults"
+
+(* ------------------------------------------------------------------ *)
+(* Test runner                                                         *)
+(* ------------------------------------------------------------------ *)
+
+let () =
+  Alcotest.run "keeper_admission_policy"
+    [ ( "of_fields"
+      , [ Alcotest.test_case "valid 3 candidates" `Quick
+            test_of_fields_valid_three_candidates
+        ; Alcotest.test_case "empty list" `Quick test_of_fields_empty_list
+        ; Alcotest.test_case "zero weight" `Quick test_of_fields_zero_weight
+        ; Alcotest.test_case "min_tier above preferred" `Quick
+            test_of_fields_min_tier_above_preferred
+        ; Alcotest.test_case "duplicate provider" `Quick
+            test_of_fields_duplicate_provider
+        ] )
+    ; ( "filtering"
+      , [ Alcotest.test_case "candidates_above_min_tier filters Survival"
+            `Quick test_candidates_above_min_tier_filters_survival
+        ] )
+    ; ( "tier"
+      , [ Alcotest.test_case "tier_compare total order" `Quick
+            test_tier_compare_total_order
+        ; Alcotest.test_case "tier_label roundtrip" `Quick
+            test_tier_label_roundtrip
+        ; Alcotest.test_case "unknown tier label returns None" `Quick
+            test_tier_of_label_unknown_returns_none
+        ] )
+    ; ( "parser"
+      , [ Alcotest.test_case "valid full JSON" `Quick
+            test_parse_admission_json_valid
+        ; Alcotest.test_case "missing candidates field" `Quick
+            test_parse_admission_json_missing_candidates
+        ; Alcotest.test_case "empty candidates list" `Quick
+            test_parse_admission_json_empty_candidates
+        ; Alcotest.test_case "unknown min_tier label" `Quick
+            test_parse_admission_json_unknown_tier
+        ; Alcotest.test_case "defaults applied when fields missing" `Quick
+            test_parse_admission_json_defaults
+        ] )
+    ]


### PR DESCRIPTION
Adds `lib/keeper/keeper_admission_policy.{ml,mli}` — the schema layer of RFC-0026 §3.3 Layer 2.

## Scope

- Three-tier classification `Preferred | Acceptable | Survival` with total order
- `candidate` record (provider, model, tier) wire-compatible with PR-A token bucket (#12904)
- `of_fields` validated constructor — 5 invariants surfaced as `validation_error` variants
- Pure query API: candidates / candidates_above_min_tier / weight / min_tier / top_provider

## Out of scope (PR-B-2, PR-B-3)

- `parse_toml_block` is a stub (returns `Empty_candidate_list`) — replaced by real parser in PR-B-2
- 14 persona TOML migration → PR-B-3
- Router + WFQ overflow → PR-C

## Validation

`lib/keeper/keeper_admission_policy.cmi` builds cleanly inside the `masc_mcp` wrapper. main 자체에 `keeper_unified_turn.mli` ↔ `.ml` drift 가 있어 `@check` 전체는 깨져 있지만, 본 모듈은 그것과 무관 — main blocker family fix 머지 후 자동 재빌드.

## Related

- RFC-0026: #12909 (MERGED)
- PR-A token bucket: #12904 (MERGED)
- PR-D-3+4 spec: #12924 (Draft, mutation testing 매트릭스 완성)
- 다음: PR-B-2 (parser), PR-B-3 (persona migration), PR-C (router + WFQ)
