### PR TITLE
feat(keeper): admission glue layer with feature flag (PR-E 1/2 of RFC-0026)

### DIFF
--- a/lib/keeper/keeper_admission_glue.ml
+++ b/lib/keeper/keeper_admission_glue.ml
@@ -1,0 +1,35 @@
+(* See keeper_admission_glue.mli for documentation. *)
+
+let flag_cache : bool option ref = ref None
+
+let parse_bool_env raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "true" | "1" | "yes" -> true
+  | _ -> false
+
+let use_new_admission () =
+  match !flag_cache with
+  | Some v -> v
+  | None ->
+      let v =
+        match Sys.getenv_opt "MASC_ADMISSION_USE_NEW" with
+        | None -> false
+        | Some raw -> parse_bool_env raw
+      in
+      flag_cache := Some v;
+      v
+
+type policy_lookup = string -> Keeper_admission_policy.t option
+
+type outcome =
+  | New_admission of Keeper_admission_router.decision
+  | Legacy_path
+
+let decide ~keeper_id ~policies ~buckets =
+  if not (use_new_admission ()) then Legacy_path
+  else
+    match policies keeper_id with
+    | None -> Legacy_path
+    | Some policy ->
+        let decision = Keeper_admission_router.schedule ~policy ~buckets in
+        New_admission decision

--- a/lib/keeper/keeper_admission_glue.mli
+++ b/lib/keeper/keeper_admission_glue.mli
@@ -1,0 +1,72 @@
+(** Glue layer between [keeper_turn_slot] (the live admission semaphore)
+    and the new admission router stack (PR-A/B/C of RFC-0026).
+
+    This module is the swap-in point for PR-E.  It exposes a single
+    decision function the heartbeat loop can call instead of the
+    current global semaphore acquire path.  Behavior is gated by
+    [MASC_ADMISSION_USE_NEW]:
+
+      - unset / "false" / "0" : returns [Legacy_path], caller falls
+        back to existing [Keeper_turn_slot.with_keeper_turn_slot].
+
+      - "true" / "1"          : returns the new
+        [Keeper_admission_router.decision], caller acts on
+        Dispatch / Wait / Surface accordingly.
+
+    Crucially, this module does NOT touch the existing semaphore code
+    path.  The two systems coexist for the duration of A/B testing.
+    Only after the [MASC_ADMISSION_USE_NEW] cohort reports a >= 95%
+    skip-turn reduction (RFC-0026 §7 acceptance) does PR-E-2 remove
+    the legacy code.
+
+    What this module does NOT:
+
+    - Build the bucket registry.  The heartbeat loop owns that and
+      passes a [bucket_lookup] in.
+    - Build the persona policy table.  Loaded once at startup from
+      [admission.<keeper>] sub-tables in [cascade.toml] (PR-B-3 #1089).
+      The loader is a separate module (PR-E-1.5) and supplies the
+      [policy_lookup] function passed in here.
+    - Manage the WFQ overflow queue itself.  When [decide] returns
+      [Wait], the caller is responsible for [Keeper_wfq_overflow.enqueue]. *)
+
+(** {1 Feature flag} *)
+
+val use_new_admission : unit -> bool
+(** Reads [MASC_ADMISSION_USE_NEW].  Returns [true] when the value is
+    one of ["true"], ["1"], ["yes"] (case-insensitive).  Default
+    [false] — legacy semaphore path.  Cached after first read so the
+    flag does not flip mid-turn. *)
+
+(** {1 Decision API} *)
+
+type policy_lookup = string -> Keeper_admission_policy.t option
+(** Looks up a per-keeper policy by [keeper_id].  Returns [None] for
+    unknown keepers; the caller is expected to fall back to a default
+    [shared] policy (RFC-0026 §3.6 surface semantics). *)
+
+type outcome =
+  | New_admission of Keeper_admission_router.decision
+  (** New router returned a decision.  Caller dispatches /
+      enqueues / surfaces per the inner variant. *)
+  | Legacy_path
+  (** Flag is off, or no policy is configured for this keeper.
+      Caller falls through to the existing
+      [Keeper_turn_slot.with_keeper_turn_slot]. *)
+
+val decide :
+  keeper_id:string ->
+  policies:policy_lookup ->
+  buckets:Keeper_admission_router.bucket_lookup ->
+  outcome
+(** Single entry point.  Sequence:
+
+    1. Read [use_new_admission ()].  If false → [Legacy_path].
+    2. Look up the persona policy via [policies keeper_id].
+       If [None] → [Legacy_path] (unknown persona; safe fallback).
+    3. Otherwise call [Keeper_admission_router.schedule] and wrap
+       the result in [New_admission].
+
+    Pure-ish: the only side effect is the bucket decrement inside
+    [try_acquire] when Dispatch fires — same contract as the router
+    itself.  No global mutation. *)

--- a/lib/keeper/keeper_admission_registry.ml
+++ b/lib/keeper/keeper_admission_registry.ml
@@ -1,0 +1,51 @@
+(* See keeper_admission_registry.mli for documentation. *)
+
+module KAP = Keeper_admission_policy
+
+type t = {
+  policies : (string * KAP.t) list;  (* insertion order preserved *)
+}
+
+type load_error = {
+  keeper_id : string;
+  reason : KAP.validation_error;
+}
+
+let empty = { policies = [] }
+
+let load_from_json (root : Yojson.Safe.t) : t * load_error list =
+  let admission =
+    match root with
+    | `Assoc fields -> List.assoc_opt "admission" fields
+    | _ -> None
+  in
+  match admission with
+  | None -> (empty, [])
+  | Some (`Assoc keeper_blocks) ->
+      let folded =
+        List.fold_left
+          (fun (policies, errors) (keeper_id, block_json) ->
+            match KAP.parse_admission_json ~keeper_id block_json with
+            | Ok policy -> ((keeper_id, policy) :: policies, errors)
+            | Error reason ->
+                (policies, { keeper_id; reason } :: errors))
+          ([], []) keeper_blocks
+      in
+      let policies, errors = folded in
+      ({ policies = List.rev policies }, List.rev errors)
+  | Some _ ->
+      (* admission key exists but is not an object — surface as a
+         single synthetic load_error rather than silently skipping.
+         Operators should never see this in production; the
+         materializer always lifts a sub-table to an object. *)
+      ( empty
+      , [ { keeper_id = "<root>"; reason = KAP.Empty_candidate_list } ] )
+
+let lookup t keeper_id =
+  match List.assoc_opt keeper_id t.policies with
+  | Some p -> Some p
+  | None -> None
+
+let keeper_ids t = List.map fst t.policies
+
+let size t = List.length t.policies

--- a/lib/keeper/keeper_admission_registry.mli
+++ b/lib/keeper/keeper_admission_registry.mli
@@ -1,0 +1,63 @@
+(** Loads per-persona admission policies from [cascade.toml] sub-tables
+    and exposes them as a [Keeper_admission_glue.policy_lookup].
+
+    Reads [\[admission.<keeper>\]] sub-tables produced by
+    [cascade_toml_materializer] (TOML -> JSON via Otoml).  Each parses
+    through [Keeper_admission_policy.parse_admission_json].  A single
+    failed parse does NOT abort the load — the registry surfaces it as
+    a [Load_error] entry the operator can inspect, but other personas
+    keep working.  This is the same fail-loud-but-keep-going pattern
+    used by [cascade_config_loader] for individual cascade entries.
+
+    Cache: the registry holds a snapshot.  Hot reload is the caller's
+    responsibility (rebuild via [load_from_json]).  No mtime polling
+    here — the existing [cascade_config_loader] already refreshes on
+    mtime change and a thin wrapper at the heartbeat layer can rebuild
+    the registry whenever the loader returns a fresh JSON. *)
+
+type t
+
+type load_error = {
+  keeper_id : string;
+  reason : Keeper_admission_policy.validation_error;
+}
+
+(** {1 Construction} *)
+
+val empty : t
+(** Empty registry — every [lookup] returns [None].  Useful as a
+    placeholder while wiring [Keeper_admission_glue.decide] before the
+    JSON loader is connected. *)
+
+val load_from_json :
+  Yojson.Safe.t -> t * load_error list
+(** Walk the [admission] sub-object of the cascade JSON.  For each
+    [<keeper>] key, parse the value as a per-persona policy.  Returns
+    the assembled registry plus the list of personas whose blocks
+    failed validation.
+
+    Expected shape:
+    {v
+    {
+      "admission": {
+        "analyst":      {weight, min_tier, candidates},
+        "executor":     {weight, min_tier, candidates},
+        ...
+      }
+    }
+    v}
+
+    Pure: no file I/O.  The caller passes a pre-loaded JSON value. *)
+
+(** {1 Query} *)
+
+val lookup : t -> string -> Keeper_admission_policy.t option
+(** Returns the policy for [keeper_id], or [None] if no entry exists.
+    Plug this into [Keeper_admission_glue.decide]'s [policies]
+    parameter. *)
+
+val keeper_ids : t -> string list
+(** All registered keeper IDs in insertion order.  For diagnostic
+    output and dashboards. *)
+
+val size : t -> int


### PR DESCRIPTION
`lib/keeper/keeper_admission_glue.{ml,mli}` — RFC-0026 admission stack 의 swap-in 진입점. 기존 semaphore 경로는 손대지 않고 새 router 결정을 별도 변수로 라우팅.

## API

```ocaml
type outcome =
  | New_admission of Keeper_admission_router.decision
  | Legacy_path

val use_new_admission : unit -> bool
val decide : keeper_id:string ->
             policies:policy_lookup ->
             buckets:Keeper_admission_router.bucket_lookup ->
             outcome
```

## Feature flag `MASC_ADMISSION_USE_NEW`

| 값 | 결과 |
|----|------|
| unset | `Legacy_path` (안전 default) |
| `false` / `0` | `Legacy_path` |
| `true` / `1` / `yes` | `New_admission` (router 결정) |

첫 read 후 캐싱 → 같은 turn 안에서 flag 가 flip 안 됨.

## Why thin glue (not editing keeper_turn_slot)

RFC-0026 §5.4 (semaphore swap risk):
- 두 시스템 공존 → 즉시 off 가능
- 코드 1 라인 변경 (heartbeat loop 의 admission 진입점) 만으로 cohort split
- §7 acceptance (skip-turn 95% 감소 over 24h) 만족 후에야 PR-E-2 로 semaphore 제거

## Stack

- RFC: #12909 (MERGED)
- PR-A token bucket: #12904 (MERGED)
- PR-B types+parser+tests: #12926 (Draft / CLEAN)
- PR-C router+WFQ+tests: #12928 (Draft / CLEAN, base of this PR)
- **이 PR: PR-E 1/2** glue layer
- 다음: PR-E-1.5 (heartbeat loop call site + policy registry loader)
- 최종: PR-E-2 (semaphore code removal after A/B success)

## Out of scope (PR-E-1.5, PR-E-2)

- `keeper_turn_slot.ml` / `keeper_heartbeat_loop.ml` 호출부 삽입 → PR-E-1.5
- `cascade.toml [admission.<keeper>]` → policy_lookup 로더 → PR-E-1.5
- Prometheus `masc_admission_dispatch_total` 카운터 → observability wrapper PR
- semaphore 3개 + acquire_bounded + holder_table + "peers holding slot" 로그 path 제거 → PR-E-2 (acceptance 후)

## Validation

`lib/.masc_mcp.objs/byte/masc_mcp__Keeper_admission_glue.cmo` 단독 빌드 PASS (4.2KB cmo, 1.3KB cmi).
