### PR TITLE
feat(dashboard): X-Workspace-Source header + EXPLORER fallback hint

### DIFF
--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { parseWorkspaceSource } from './ide-explorer'
+
+describe('parseWorkspaceSource', () => {
+  it('treats null header as project', () => {
+    expect(parseWorkspaceSource(null)).toEqual({ kind: 'project' })
+  })
+
+  it('treats empty header as project', () => {
+    expect(parseWorkspaceSource('')).toEqual({ kind: 'project' })
+  })
+
+  it('decodes plain "project" tag', () => {
+    expect(parseWorkspaceSource('project')).toEqual({ kind: 'project' })
+  })
+
+  it('decodes "playground:<name>"', () => {
+    expect(parseWorkspaceSource('playground:alpha'))
+      .toEqual({ kind: 'playground', keeper: 'alpha' })
+  })
+
+  it('decodes "playground_missing:<name>"', () => {
+    expect(parseWorkspaceSource('playground_missing:alpha'))
+      .toEqual({ kind: 'playground_missing', keeper: 'alpha' })
+  })
+
+  it('decodes "keeper_unknown:<name>"', () => {
+    expect(parseWorkspaceSource('keeper_unknown:ghost'))
+      .toEqual({ kind: 'keeper_unknown', keeper: 'ghost' })
+  })
+
+  it('preserves colons inside the keeper name', () => {
+    // Keeper names should not contain ':', but the parser splits on the
+    // first colon only so any trailing colons stay in the name verbatim.
+    expect(parseWorkspaceSource('playground:weird:name'))
+      .toEqual({ kind: 'playground', keeper: 'weird:name' })
+  })
+
+  it('falls back to project for unknown tags', () => {
+    expect(parseWorkspaceSource('unrecognized:foo'))
+      .toEqual({ kind: 'project' })
+  })
+
+  it('falls back to project when no colon and not "project"', () => {
+    expect(parseWorkspaceSource('garbage'))
+      .toEqual({ kind: 'project' })
+  })
+})

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -24,16 +24,44 @@ const FALLBACK_SEED: ReadonlyArray<FileTreeNode> = [
   { path: 'README.md', label: 'README.md', depth: 0, parent: null, hasChildren: false, diff: null, keeperId: null, hueIndex: null },
 ]
 
-async function fetchTree(depth = 3, keeper = ''): Promise<FileTreeNode[]> {
+// Decoded form of the X-Workspace-Source header. The empty string in the
+// playground / playgroundMissing / keeperUnknown variants represents the
+// keeper name the server attempted to resolve.
+export type WorkspaceSource =
+  | { kind: 'project' }
+  | { kind: 'playground'; keeper: string }
+  | { kind: 'playground_missing'; keeper: string }
+  | { kind: 'keeper_unknown'; keeper: string }
+
+export function parseWorkspaceSource(header: string | null): WorkspaceSource {
+  if (!header) return { kind: 'project' }
+  if (header === 'project') return { kind: 'project' }
+  const colon = header.indexOf(':')
+  if (colon === -1) return { kind: 'project' }
+  const tag = header.slice(0, colon)
+  const keeper = header.slice(colon + 1)
+  if (tag === 'playground') return { kind: 'playground', keeper }
+  if (tag === 'playground_missing') return { kind: 'playground_missing', keeper }
+  if (tag === 'keeper_unknown') return { kind: 'keeper_unknown', keeper }
+  return { kind: 'project' }
+}
+
+interface TreeFetchResult {
+  readonly nodes: FileTreeNode[]
+  readonly source: WorkspaceSource
+}
+
+async function fetchTree(depth = 3, keeper = ''): Promise<TreeFetchResult> {
   try {
     const params = new URLSearchParams({ depth: String(depth) })
     if (keeper) params.set('keeper', keeper)
     const res = await fetch(`/api/v1/workspace/tree?${params.toString()}`)
-    if (!res.ok) return [...FALLBACK_SEED]
+    const source = parseWorkspaceSource(res.headers.get('X-Workspace-Source'))
+    if (!res.ok) return { nodes: [...FALLBACK_SEED], source }
     const data = await res.json()
-    if (!Array.isArray(data) || data.length === 0) return [...FALLBACK_SEED]
-    return data as FileTreeNode[]
-  } catch { return [...FALLBACK_SEED] }
+    if (!Array.isArray(data) || data.length === 0) return { nodes: [...FALLBACK_SEED], source }
+    return { nodes: data as FileTreeNode[], source }
+  } catch { return { nodes: [...FALLBACK_SEED], source: { kind: 'project' } } }
 }
 
 export function IdeExplorer() {
@@ -46,9 +74,15 @@ export function IdeExplorer() {
   const [keeperName, setKeeperName] = useState(activeKeeperName.value)
   useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
 
+  const [source, setSource] = useState<WorkspaceSource>({ kind: 'project' })
+
   useEffect(() => {
     let cancelled = false
-    fetchTree(3, keeperName).then(nodes => { if (!cancelled) store.seed(nodes) })
+    fetchTree(3, keeperName).then(({ nodes, source }) => {
+      if (cancelled) return
+      store.seed(nodes)
+      setSource(source)
+    })
     return () => { cancelled = true }
   }, [store, keeperName])
 
@@ -91,6 +125,7 @@ export function IdeExplorer() {
         <span>EXPLORER ${keeperName ? html`· <span style=${{ color: 'var(--color-accent-fg)' }}>@${keeperName}</span>` : '· project'}</span>
         <span>${fileCount} FILES</span>
       </header>
+      ${SourceHint(source)}
       <ul
         role="tree"
         aria-label="File tree"
@@ -102,6 +137,27 @@ export function IdeExplorer() {
         }))}
       </ul>
     </div>
+  `
+}
+
+function SourceHint(source: WorkspaceSource) {
+  if (source.kind === 'project' || source.kind === 'playground') return null
+  const message = source.kind === 'playground_missing'
+    ? `@${source.keeper} 의 playground 디렉토리가 아직 없어 프로젝트 트리로 fallback`
+    : `@${source.keeper} 키퍼 메타를 찾지 못해 프로젝트 트리로 fallback`
+  return html`
+    <div
+      role="status"
+      aria-live="polite"
+      style=${{
+        font: 'var(--type-body)',
+        fontSize: 'var(--fs-11)',
+        color: 'var(--color-fg-muted)',
+        background: 'var(--color-bg-muted)',
+        padding: 'var(--sp-1) var(--sp-2)',
+        borderRadius: 'var(--r-1)',
+      }}
+    >${message}</div>
   `
 }
 

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -58,6 +58,22 @@ let json_response ~status req reqd json =
   Http.Response.json ~status ~request:req
     (Yojson.Safe.to_string json) reqd
 
+(* Encode the workspace source tag as a single header value so the
+   frontend can render hints ("Playground 없음 — 프로젝트로 fallback")
+   without parsing the JSON body. *)
+let source_header source =
+  let v = match source with
+    | `Project -> "project"
+    | `Playground name -> "playground:" ^ name
+    | `PlaygroundMissing name -> "playground_missing:" ^ name
+    | `KeeperUnknown name -> "keeper_unknown:" ^ name
+  in
+  [("X-Workspace-Source", v)]
+
+let json_response_with_source ~status ~source req reqd json =
+  Http.Response.json ~status ~extra_headers:(source_header source)
+    ~request:req (Yojson.Safe.to_string json) reqd
+
 (* --- Safe path --- *)
 
 let is_digit c = c >= '0' && c <= '9'
@@ -279,7 +295,7 @@ let add_routes router =
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            let depth =
              match Uri.get_query_param uri "depth" with
              | Some d -> (try max 1 (min 5 (int_of_string d)) with _ -> 3)
@@ -290,14 +306,14 @@ let add_routes router =
              else scan_dir ~base ~depth:0 ~max_depth:depth [] base
            in
            let json = `List (List.rev nodes) in
-           json_response ~status:`OK request reqd json)
+           json_response_with_source ~status:`OK ~source request reqd json)
          request reqd)
 
   |> Http.Router.get "/api/v1/workspace/file" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            match Uri.get_query_param uri "path" with
            | None -> json_response ~status:`Bad_request request reqd (json_error "Missing path parameter")
            | Some p ->
@@ -308,7 +324,7 @@ let add_routes router =
                  try
                    let content = Fs_compat.load_file path in
                    let json = `Assoc [("ok", `Bool true); ("content", `String content)] in
-                   json_response ~status:`OK request reqd json
+                   json_response_with_source ~status:`OK ~source request reqd json
                  with _ -> json_response ~status:`Internal_server_error request reqd (json_error "Failed to read file")
                else
                  json_response ~status:`Not_found request reqd (json_error "File not found"))
@@ -318,7 +334,7 @@ let add_routes router =
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            let file_path =
              match Uri.get_query_param uri "path" with
              | Some p -> p
@@ -335,18 +351,18 @@ let add_routes router =
              else
                match git_run_lines ~cwd:base ["blame"; "--porcelain"; file_path] with
                | [] ->
-                 json_response ~status:`OK request reqd (`List [])
+                 json_response_with_source ~status:`OK ~source request reqd (`List [])
                | lines ->
                  let entries = parse_blame_porcelain lines in
                  let grouped = group_blame_entries file_path entries in
-                 json_response ~status:`OK request reqd (`List grouped))
+                 json_response_with_source ~status:`OK ~source request reqd (`List grouped))
          request reqd)
 
   |> Http.Router.get "/api/v1/git/diff" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            let file_path =
              match Uri.get_query_param uri "path" with
              | Some p -> p
@@ -366,10 +382,10 @@ let add_routes router =
              else
                match git_run_lines ~cwd:base ["diff"; base_ref; "--"; file_path] with
                | [] ->
-                 json_response ~status:`OK request reqd
+                 json_response_with_source ~status:`OK ~source request reqd
                    (`Assoc [("unified", `List []); ("has_changes", `Bool false)])
                | diff_lines ->
                  let unified = parse_unified_diff diff_lines in
                  let json = `Assoc [("unified", `List unified); ("has_changes", `Bool true)] in
-                 json_response ~status:`OK request reqd json)
+                 json_response_with_source ~status:`OK ~source request reqd json)
          request reqd)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -13,3 +13,14 @@ val classify_keeper_query :
            | `Playground of string
            | `PlaygroundMissing of string
            | `KeeperUnknown of string ]
+
+(** Encode the workspace source tag as the [X-Workspace-Source] header
+    so the frontend can render hints (e.g. "Playground 없음 — 프로젝트로
+    fallback") without parsing the JSON body. Exposed for unit
+    testing. *)
+val source_header :
+  [ `Project
+  | `Playground of string
+  | `PlaygroundMissing of string
+  | `KeeperUnknown of string ] ->
+  (string * string) list

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -118,6 +118,29 @@ let test_keeper_name_trimmed () =
     Alcotest.(check string) "name is trimmed" "alpha" name
   | _ -> Alcotest.fail "expected `Playground after trim"
 
+(* ─── source_header ─────────────────────────────────────────────── *)
+
+let header_value headers =
+  match headers with
+  | [(k, v)] when k = "X-Workspace-Source" -> v
+  | _ -> Alcotest.fail "expected single X-Workspace-Source header"
+
+let test_header_project () =
+  let v = header_value (W.source_header `Project) in
+  Alcotest.(check string) "project" "project" v
+
+let test_header_playground () =
+  let v = header_value (W.source_header (`Playground "alpha")) in
+  Alcotest.(check string) "playground encoding" "playground:alpha" v
+
+let test_header_playground_missing () =
+  let v = header_value (W.source_header (`PlaygroundMissing "alpha")) in
+  Alcotest.(check string) "missing encoding" "playground_missing:alpha" v
+
+let test_header_keeper_unknown () =
+  let v = header_value (W.source_header (`KeeperUnknown "ghost")) in
+  Alcotest.(check string) "unknown encoding" "keeper_unknown:ghost" v
+
 let () =
   Alcotest.run "workspace_routes_keeper"
     [ ( "classify_keeper_query"
@@ -128,5 +151,11 @@ let () =
         ; Alcotest.test_case "playground exists" `Quick test_playground_resolved
         ; Alcotest.test_case "playground missing" `Quick test_playground_missing
         ; Alcotest.test_case "name trimmed"      `Quick test_keeper_name_trimmed
+        ] )
+    ; ( "source_header"
+      , [ Alcotest.test_case "project"           `Quick test_header_project
+        ; Alcotest.test_case "playground"        `Quick test_header_playground
+        ; Alcotest.test_case "playground missing" `Quick test_header_playground_missing
+        ; Alcotest.test_case "keeper unknown"    `Quick test_header_keeper_unknown
         ] )
     ]


### PR DESCRIPTION
## Summary

Closes the keeper-aware workspace UX loop (#12893 → #12907) by surfacing *how* the resolution succeeded back to the frontend. Without this, the IDE silently shows the project tree even when the user expected playground content (because the keeper has no playground yet, or the meta lookup failed).

- Backend: tree/file/blame/diff success responses emit `X-Workspace-Source` header with `project` / `playground:<name>` / `playground_missing:<name>` / `keeper_unknown:<name>`. Wire-shape unchanged (header only, JSON body identical).
- Frontend: `IdeExplorer` parses the header into a discriminated union and renders a small fallback notice below the EXPLORER header when the resolution fell back. `role="status" aria-live="polite"` so screen readers are notified without stealing focus.

## Why

Today the IDE silently swallows resolution failures — when a keeper is selected but the playground doesn't exist on disk, users see the project tree and assume they're looking at the keeper's working state. The fallback hint makes the actual source visible without leaking the absolute path back to the client.

## Test plan

- [x] `dune build --build-dir=_build_iso lib/masc_mcp.cma` — green
- [x] `dune exec test/test_workspace_routes_keeper.exe` — 11/11 pass (was 7, +4 source_header cases)
- [x] `pnpm vitest run src/components/ide/ide-explorer.test.ts` — 9/9 pass (new file, parseWorkspaceSource decoder)
- [x] `pnpm lint src/components/ide/ide-explorer.ts` — 0 errors on changed file

## Out of scope

- Hint styling polish (currently uses `--color-bg-muted` block — design system review pending)
- Surfacing the source on the Editor pane (only the EXPLORER renders the hint today; Editor file-load failures are still silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)