### PR TITLE
chore(test): move test_env_config_nonneg to per-file stanza (Copilot follow-up)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -90,7 +90,6 @@
         test_keeper_contract_classifier_pure
         test_keeper_compact_policy_pure
         test_heartbeat_smart
-        test_env_config_nonneg
         test_keeper_allowed_paths
         test_keeper_repo_readiness
         test_keeper_tool_surface_guard
@@ -294,7 +293,6 @@
           test_keeper_contract_classifier_pure
           test_keeper_compact_policy_pure
           test_heartbeat_smart
-          test_env_config_nonneg
           test_keeper_allowed_paths
           test_keeper_repo_readiness
           test_keeper_tool_surface_guard
@@ -1046,6 +1044,7 @@
 (include stanzas/test_env_config_exec_timeout_10426.inc)
 (include stanzas/test_env_config_keeper_bootstrap_intervals.inc)
 (include stanzas/test_env_config_keeper_poll_intervals.inc)
+(include stanzas/test_env_config_nonneg.inc)
 (include stanzas/test_env_config_sandbox.inc)
 (include stanzas/test_env_config_sidecar_timeouts.inc)
 (include stanzas/test_env_config_voice_bridge_timeouts.inc)

--- a/test/stanzas/test_env_config_nonneg.inc
+++ b/test/stanzas/test_env_config_nonneg.inc
@@ -1,0 +1,9 @@
+; Per-file dune stanza for the [Env_config_core.get_int_nonneg] /
+; [Env_config_core.get_float_nonneg] regression suite.  Lives
+; here (not in the legacy grouped stanza) per
+; test/stanzas/README.md to avoid the conflict-cascade hotspot.
+
+(test
+ (name test_env_config_nonneg)
+ (modules test_env_config_nonneg)
+ (libraries masc_test_deps))


### PR DESCRIPTION
## Summary

Follow-up to #12901. Copilot's review correctly flagged that the new `test_env_config_nonneg` test was added to the legacy grouped `(tests ...)` stanza in `test/dune` — the merge-conflict hotspot that `test/stanzas/README.md` explicitly tells contributors to avoid.

#12901 landed before I could push the stanza fix to its own branch, so this is a small follow-up that completes the migration.

## Changes

- **Add** `test/stanzas/test_env_config_nonneg.inc` — per-file dune stanza in the convention documented at `test/stanzas/README.md`.
- **Remove** `test_env_config_nonneg` from the Group 1 `(names ...)` and `(modules ...)` lists in `test/dune`.
- **Add** one `(include stanzas/test_env_config_nonneg.inc)` line at its alphabetical slot, between `test_env_config_keeper_poll_intervals.inc` and `test_env_config_sandbox.inc`.

## Test plan

- [x] `dune exec test/test_env_config_nonneg.exe` — 13/13 green
- [x] Single reference in `test/dune` post-fix (only the `(include ...)` line)
- [x] Not blocking on `dune build @check` due to an unrelated `keeper_unified_turn.mli`/`.ml` drift on current `main` (separate fix area, in flight elsewhere)
- [x] Race check pre-push: no concurrent PR touching `stanzas/test_env_config_nonneg.inc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)