### PR TITLE
feat(keeper): admission glue + registry (PR-E 1+1.5, rebased after #12938)

### DIFF
--- a/lib/keeper/keeper_admission_glue.ml
+++ b/lib/keeper/keeper_admission_glue.ml
@@ -1,0 +1,35 @@
+(* See keeper_admission_glue.mli for documentation. *)
+
+let flag_cache : bool option ref = ref None
+
+let parse_bool_env raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "true" | "1" | "yes" -> true
+  | _ -> false
+
+let use_new_admission () =
+  match !flag_cache with
+  | Some v -> v
+  | None ->
+      let v =
+        match Sys.getenv_opt "MASC_ADMISSION_USE_NEW" with
+        | None -> false
+        | Some raw -> parse_bool_env raw
+      in
+      flag_cache := Some v;
+      v
+
+type policy_lookup = string -> Keeper_admission_policy.t option
+
+type outcome =
+  | New_admission of Keeper_admission_router.decision
+  | Legacy_path
+
+let decide ~keeper_id ~policies ~buckets =
+  if not (use_new_admission ()) then Legacy_path
+  else
+    match policies keeper_id with
+    | None -> Legacy_path
+    | Some policy ->
+        let decision = Keeper_admission_router.schedule ~policy ~buckets in
+        New_admission decision

--- a/lib/keeper/keeper_admission_glue.mli
+++ b/lib/keeper/keeper_admission_glue.mli
@@ -1,0 +1,72 @@
+(** Glue layer between [keeper_turn_slot] (the live admission semaphore)
+    and the new admission router stack (PR-A/B/C of RFC-0026).
+
+    This module is the swap-in point for PR-E.  It exposes a single
+    decision function the heartbeat loop can call instead of the
+    current global semaphore acquire path.  Behavior is gated by
+    [MASC_ADMISSION_USE_NEW]:
+
+      - unset / "false" / "0" : returns [Legacy_path], caller falls
+        back to existing [Keeper_turn_slot.with_keeper_turn_slot].
+
+      - "true" / "1"          : returns the new
+        [Keeper_admission_router.decision], caller acts on
+        Dispatch / Wait / Surface accordingly.
+
+    Crucially, this module does NOT touch the existing semaphore code
+    path.  The two systems coexist for the duration of A/B testing.
+    Only after the [MASC_ADMISSION_USE_NEW] cohort reports a >= 95%
+    skip-turn reduction (RFC-0026 §7 acceptance) does PR-E-2 remove
+    the legacy code.
+
+    What this module does NOT:
+
+    - Build the bucket registry.  The heartbeat loop owns that and
+      passes a [bucket_lookup] in.
+    - Build the persona policy table.  Loaded once at startup from
+      [admission.<keeper>] sub-tables in [cascade.toml] (PR-B-3 #1089).
+      The loader is a separate module (PR-E-1.5) and supplies the
+      [policy_lookup] function passed in here.
+    - Manage the WFQ overflow queue itself.  When [decide] returns
+      [Wait], the caller is responsible for [Keeper_wfq_overflow.enqueue]. *)
+
+(** {1 Feature flag} *)
+
+val use_new_admission : unit -> bool
+(** Reads [MASC_ADMISSION_USE_NEW].  Returns [true] when the value is
+    one of ["true"], ["1"], ["yes"] (case-insensitive).  Default
+    [false] — legacy semaphore path.  Cached after first read so the
+    flag does not flip mid-turn. *)
+
+(** {1 Decision API} *)
+
+type policy_lookup = string -> Keeper_admission_policy.t option
+(** Looks up a per-keeper policy by [keeper_id].  Returns [None] for
+    unknown keepers; the caller is expected to fall back to a default
+    [shared] policy (RFC-0026 §3.6 surface semantics). *)
+
+type outcome =
+  | New_admission of Keeper_admission_router.decision
+  (** New router returned a decision.  Caller dispatches /
+      enqueues / surfaces per the inner variant. *)
+  | Legacy_path
+  (** Flag is off, or no policy is configured for this keeper.
+      Caller falls through to the existing
+      [Keeper_turn_slot.with_keeper_turn_slot]. *)
+
+val decide :
+  keeper_id:string ->
+  policies:policy_lookup ->
+  buckets:Keeper_admission_router.bucket_lookup ->
+  outcome
+(** Single entry point.  Sequence:
+
+    1. Read [use_new_admission ()].  If false → [Legacy_path].
+    2. Look up the persona policy via [policies keeper_id].
+       If [None] → [Legacy_path] (unknown persona; safe fallback).
+    3. Otherwise call [Keeper_admission_router.schedule] and wrap
+       the result in [New_admission].
+
+    Pure-ish: the only side effect is the bucket decrement inside
+    [try_acquire] when Dispatch fires — same contract as the router
+    itself.  No global mutation. *)

--- a/lib/keeper/keeper_admission_registry.ml
+++ b/lib/keeper/keeper_admission_registry.ml
@@ -1,0 +1,51 @@
+(* See keeper_admission_registry.mli for documentation. *)
+
+module KAP = Keeper_admission_policy
+
+type t = {
+  policies : (string * KAP.t) list;  (* insertion order preserved *)
+}
+
+type load_error = {
+  keeper_id : string;
+  reason : KAP.validation_error;
+}
+
+let empty = { policies = [] }
+
+let load_from_json (root : Yojson.Safe.t) : t * load_error list =
+  let admission =
+    match root with
+    | `Assoc fields -> List.assoc_opt "admission" fields
+    | _ -> None
+  in
+  match admission with
+  | None -> (empty, [])
+  | Some (`Assoc keeper_blocks) ->
+      let folded =
+        List.fold_left
+          (fun (policies, errors) (keeper_id, block_json) ->
+            match KAP.parse_admission_json ~keeper_id block_json with
+            | Ok policy -> ((keeper_id, policy) :: policies, errors)
+            | Error reason ->
+                (policies, { keeper_id; reason } :: errors))
+          ([], []) keeper_blocks
+      in
+      let policies, errors = folded in
+      ({ policies = List.rev policies }, List.rev errors)
+  | Some _ ->
+      (* admission key exists but is not an object — surface as a
+         single synthetic load_error rather than silently skipping.
+         Operators should never see this in production; the
+         materializer always lifts a sub-table to an object. *)
+      ( empty
+      , [ { keeper_id = "<root>"; reason = KAP.Empty_candidate_list } ] )
+
+let lookup t keeper_id =
+  match List.assoc_opt keeper_id t.policies with
+  | Some p -> Some p
+  | None -> None
+
+let keeper_ids t = List.map fst t.policies
+
+let size t = List.length t.policies

--- a/lib/keeper/keeper_admission_registry.mli
+++ b/lib/keeper/keeper_admission_registry.mli
@@ -1,0 +1,63 @@
+(** Loads per-persona admission policies from [cascade.toml] sub-tables
+    and exposes them as a [Keeper_admission_glue.policy_lookup].
+
+    Reads [\[admission.<keeper>\]] sub-tables produced by
+    [cascade_toml_materializer] (TOML -> JSON via Otoml).  Each parses
+    through [Keeper_admission_policy.parse_admission_json].  A single
+    failed parse does NOT abort the load — the registry surfaces it as
+    a [Load_error] entry the operator can inspect, but other personas
+    keep working.  This is the same fail-loud-but-keep-going pattern
+    used by [cascade_config_loader] for individual cascade entries.
+
+    Cache: the registry holds a snapshot.  Hot reload is the caller's
+    responsibility (rebuild via [load_from_json]).  No mtime polling
+    here — the existing [cascade_config_loader] already refreshes on
+    mtime change and a thin wrapper at the heartbeat layer can rebuild
+    the registry whenever the loader returns a fresh JSON. *)
+
+type t
+
+type load_error = {
+  keeper_id : string;
+  reason : Keeper_admission_policy.validation_error;
+}
+
+(** {1 Construction} *)
+
+val empty : t
+(** Empty registry — every [lookup] returns [None].  Useful as a
+    placeholder while wiring [Keeper_admission_glue.decide] before the
+    JSON loader is connected. *)
+
+val load_from_json :
+  Yojson.Safe.t -> t * load_error list
+(** Walk the [admission] sub-object of the cascade JSON.  For each
+    [<keeper>] key, parse the value as a per-persona policy.  Returns
+    the assembled registry plus the list of personas whose blocks
+    failed validation.
+
+    Expected shape:
+    {v
+    {
+      "admission": {
+        "analyst":      {weight, min_tier, candidates},
+        "executor":     {weight, min_tier, candidates},
+        ...
+      }
+    }
+    v}
+
+    Pure: no file I/O.  The caller passes a pre-loaded JSON value. *)
+
+(** {1 Query} *)
+
+val lookup : t -> string -> Keeper_admission_policy.t option
+(** Returns the policy for [keeper_id], or [None] if no entry exists.
+    Plug this into [Keeper_admission_glue.decide]'s [policies]
+    parameter. *)
+
+val keeper_ids : t -> string list
+(** All registered keeper IDs in insertion order.  For diagnostic
+    output and dashboards. *)
+
+val size : t -> int


### PR DESCRIPTION
PR-E 1+1.5 swap-in glue + registry, **rebased onto main** after PR-C (#12938) merged.

원래 #12932 가 #12928 (closed) base였으므로 main 으로 재조정.

## 변경

- `keeper_admission_glue.{ml,mli}` — 107 LOC. flag-gated swap-in (MASC_ADMISSION_USE_NEW)
- `keeper_admission_registry.{ml,mli}` — 114 LOC. `[admission.*]` JSON loader

총 +221 LOC.

## API

```ocaml
(* Glue *)
val use_new_admission : unit -> bool
val decide : keeper_id -> policies -> buckets ->
  | New_admission of Keeper_admission_router.decision
  | Legacy_path

(* Registry *)
val load_from_json : Yojson.Safe.t -> t * load_error list
val lookup : t -> string -> Keeper_admission_policy.t option
```

## 의의

- 기존 semaphore 코드 0줄 변경 → A/B test 안전성 보장
- `MASC_ADMISSION_USE_NEW=true` cohort 가 RFC-0026 §7 acceptance 만족 시 PR-E-2 (semaphore 영구 제거) 진행

## Stack

- PR-A token bucket: #12904 (MERGED)
- PR-B types/parser/tests: #12926 (MERGED)
- PR-D-3 spec: #12924 (MERGED)
- PR-C router+WFQ+tests: #12938 (MERGED)
- **이 PR**: PR-E 1+1.5 glue+registry
- 다음: PR-E-1.6 heartbeat call site, PR-E-2 semaphore retire (acceptance 후)

## 원본 PR

#12932 — #12928 base 가 closed → 본 PR 이 후속.
