### PR TITLE
fix(keeper): cap cascade rotation to per-attempt timeout budget

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -156,22 +156,17 @@ let resolve_bounded_oas_timeout_budget_with_turn_budget
       ~estimated_input_tokens ~max_turns
   in
   if is_retry then begin
-    (* Per-attempt budget for cascade retries: each retry gets a fresh
-       execution budget rather than inheriting the wall-clock deficit
-       from previous attempts.  The wall-clock remaining is a hard cap
-       only when it still exceeds the minimum execution budget.
+    let time_spent_in_turn = runtime.turn_timeout_sec.value -. remaining_turn_budget_s in
+    let usable_retry_budget = adaptive_timeout_sec -. time_spent_in_turn in
 
-       Without this, cascade retries after a 60s timeout arrive with
-       near-zero remaining and the OAS call times out before the model
-       even begins processing (TurnBudgetExhausted with turns_used=1).
-
-       Hard gate: if the outer turn wall-clock is already exhausted the
-       OAS call would be cancelled immediately — return None so callers
-       see a clean budget failure rather than a noisy retry/rotation. *)
-    if remaining_turn_budget_s <= 0.0 then None
+    (* Guard: cascade rotation cannot consume more than 1x per-attempt budget
+       per slot acquisition. If we've already spent more than the adaptive timeout
+       budget in this turn, do not allow further retries. This prevents a retry
+       loop from hogging the slot for the entire outer turn budget when inner
+       OAS attempts timeout early. *)
+    if remaining_turn_budget_s <= 0.0 || usable_retry_budget < min_oas_timeout_budget_sec then None
     else begin
-      let effective_timeout_sec =
-        Float.min adaptive_timeout_sec (Float.max min_oas_timeout_budget_sec remaining_turn_budget_s)
+      let effective_timeout_sec = usable_retry_budget
       in
       let source =
         match runtime.oas_timeout_override_sec.value with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5350,12 +5350,11 @@ let test_degraded_retry_budget_gate_blocks_exhausted_budget () =
   | UT.Degraded_retry_allowed _ -> fail "expected exhausted retry budget"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
 
-(* Regression: GitHub #12675 — per-attempt retry budget.
-   When is_retry=true, the budget resolution must provide a fresh
-   minimum execution budget even when wall-clock remaining is very
-   small (simulating a retry after a long first-attempt timeout).
-   Without the fix, near-zero remaining_turn_budget_s caused the
-   retry OAS call to time out before the model began processing. *)
+(* Regression: GitHub #12675 / RFC #12887 — per-attempt retry budget cap.
+   When is_retry=true, the budget resolution must refuse the retry if the
+   time spent in the current turn exceeds the adaptive per-attempt budget.
+   This prevents a retry loop from holding the outer slot for the entire
+   turn timeout (600s). *)
 let test_per_attempt_retry_budget_with_near_zero_remaining () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
@@ -5365,15 +5364,8 @@ let test_per_attempt_retry_budget_with_near_zero_remaining () =
       ~max_turns:4
       ~remaining_turn_budget_s:3.0
   with
-  | None -> fail "is_retry=true must provide budget even with tiny remaining"
-  | Some budget ->
-      check bool "effective >= min_oas_timeout_budget_sec" true
-        (budget.effective_timeout_sec >= 15.0);
-      check string "source indicates per-attempt retry"
-        "ok"
-        (if String.equal budget.source "adaptive_per_attempt_retry"
-            || String.equal budget.source "override_per_attempt_retry"
-         then "ok" else budget.source)
+  | None -> () (* expected: retry is aborted to release the slot cleanly *)
+  | Some _ -> fail "is_retry=true must refuse budget when outer turn time spent exceeds per-attempt cap"
 
 let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
   match
@@ -5438,13 +5430,9 @@ let test_degraded_retry_budget_gate_allows_retry_with_tiny_remaining () =
       ~remaining_turn_budget_s:3.0
       (oas_timeout_budget_error ())
   with
-  | UT.Degraded_retry_allowed retry ->
-      check string "retry cascade" KC.local_recovery_cascade_name
-        retry.next_cascade;
-      check string "fallback reason" "oas_timeout_budget"
-        retry.fallback_reason
-  | UT.Degraded_retry_budget_exhausted _ ->
-      fail "degraded retry should be allowed even with tiny remaining"
+  | UT.Degraded_retry_budget_exhausted _ -> ()
+  | UT.Degraded_retry_allowed _ ->
+      fail "expected retry aborted due to per-attempt cap exceeded"
   | UT.No_degraded_retry -> fail "expected degraded retry"
 
 let test_pure_local_labels_detection () =


### PR DESCRIPTION
Fixes #12887

Limits the total time a cascade rotation loop can spend retrying to the
adaptive timeout budget of a single attempt. This prevents degraded-retry
loops from hogging the autonomous turn slot for the full 600s wall-clock
timeout when inner OAS attempts time out early.

Tests updated to reflect that retries with near-zero remaining budget
are now correctly rejected instead of being granted a fresh minimum budget
that extends the slot hold.
