### PR TITLE
feat(env_config): add get_ratio for [0, 1]-bounded float env vars

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -66,26 +66,31 @@ let get_float_nonneg ~default name =
 
 (** Variant for [\[0.0, 1.0\]]-bounded floats — probabilities,
     score thresholds, context-ratio caps, anything where the
-    operator's mental model is "this is a fraction".  Out-of-range
-    parses ([< 0.0], [> 1.0], or non-finite) fall back to
-    [default].  The default itself is also clamped to
-    [\[0.0, 1.0\]] as defense-in-depth so a future caller cannot
-    accidentally introduce an out-of-range default.
+    operator's mental model is "this is a fraction".  Implemented
+    by delegating to {!get_float_nonneg} (which already handles
+    NaN/-∞ rejection and the negative-floor semantics) and then
+    adding the [> 1.0] upper bound.
+
+    The [default] itself is sanitised first: non-finite inputs
+    ([NaN], [+∞], [-∞]) are coerced to [0.0]; finite values
+    out of range are clamped via [Float.max 0.0 (Float.min 1.0 .)].
+    This is defense in depth so a caller passing a stale
+    out-of-range default still gets a valid ratio back.
 
     NaN-safety note: [Float.min nan 1.0] / [Float.max nan 0.0]
-    propagate NaN, so a naive [Float.max 0.0 (Float.min 1.0 v)]
-    would still return NaN when [v] is NaN.  We sanitise non-
-    finite [default] inputs to [0.0] before clamping. *)
+    propagate NaN per OCaml's IEEE 754 semantics, so a naive
+    [Float.max 0.0 (Float.min 1.0 v)] without the explicit
+    {!Float.is_finite} guard would still leak NaN. *)
 let get_ratio ~default name =
   let sanitise v =
     if not (Float.is_finite v) then 0.0
     else Float.max 0.0 (Float.min 1.0 v)
   in
   let safe_default = sanitise default in
-  let parsed = get_float ~default:safe_default name in
-  if (not (Float.is_finite parsed)) || parsed < 0.0 || parsed > 1.0
-  then safe_default
-  else parsed
+  (* Delegate to get_float_nonneg for the < 0.0 / non-finite
+     rejection, then layer the > 1.0 upper bound. *)
+  let parsed = get_float_nonneg ~default:safe_default name in
+  if parsed > 1.0 then safe_default else parsed
 
 let get_bool ~default name =
   match raw_value_opt name with

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -70,10 +70,18 @@ let get_float_nonneg ~default name =
     parses ([< 0.0], [> 1.0], or non-finite) fall back to
     [default].  The default itself is also clamped to
     [\[0.0, 1.0\]] as defense-in-depth so a future caller cannot
-    accidentally introduce an out-of-range default. *)
+    accidentally introduce an out-of-range default.
+
+    NaN-safety note: [Float.min nan 1.0] / [Float.max nan 0.0]
+    propagate NaN, so a naive [Float.max 0.0 (Float.min 1.0 v)]
+    would still return NaN when [v] is NaN.  We sanitise non-
+    finite [default] inputs to [0.0] before clamping. *)
 let get_ratio ~default name =
-  let clamp01 v = Float.max 0.0 (Float.min 1.0 v) in
-  let safe_default = clamp01 default in
+  let sanitise v =
+    if not (Float.is_finite v) then 0.0
+    else Float.max 0.0 (Float.min 1.0 v)
+  in
+  let safe_default = sanitise default in
   let parsed = get_float ~default:safe_default name in
   if (not (Float.is_finite parsed)) || parsed < 0.0 || parsed > 1.0
   then safe_default

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -64,6 +64,21 @@ let get_float_nonneg ~default name =
   if (not (Float.is_finite parsed)) || parsed < 0.0 then default
   else parsed
 
+(** Variant for [\[0.0, 1.0\]]-bounded floats — probabilities,
+    score thresholds, context-ratio caps, anything where the
+    operator's mental model is "this is a fraction".  Out-of-range
+    parses ([< 0.0], [> 1.0], or non-finite) fall back to
+    [default].  The default itself is also clamped to
+    [\[0.0, 1.0\]] as defense-in-depth so a future caller cannot
+    accidentally introduce an out-of-range default. *)
+let get_ratio ~default name =
+  let clamp01 v = Float.max 0.0 (Float.min 1.0 v) in
+  let safe_default = clamp01 default in
+  let parsed = get_float ~default:safe_default name in
+  if (not (Float.is_finite parsed)) || parsed < 0.0 || parsed > 1.0
+  then safe_default
+  else parsed
+
 let get_bool ~default name =
   match raw_value_opt name with
   | Some v ->

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -55,10 +55,18 @@ val get_float_nonneg : default:float -> string -> float
 val get_ratio : default:float -> string -> float
 (** Like {!get_float_nonneg} but additionally rejects parses [> 1.0].
     Use for env vars whose semantic is a fraction in [\[0, 1\]]:
-    score thresholds, probabilities, context-ratio caps.  The
-    [default] argument is itself clamped to [\[0, 1\]] as
-    defense-in-depth, so a caller passing a stale out-of-range
-    default still gets a valid ratio back. *)
+    score thresholds, probabilities, context-ratio caps.
+
+    The [default] argument is sanitised before clamping:
+    non-finite defaults ([NaN], [+∞], [-∞]) are coerced to
+    [0.0]; finite out-of-range defaults are clamped to
+    [\[0, 1\]] via [Float.max 0.0 (Float.min 1.0 default)].
+    [Float.min nan 1.0] propagates [NaN] in OCaml's IEEE 754
+    semantics, so a naive clamp on its own would still leak
+    [NaN]; the explicit {!Float.is_finite} check before
+    clamping is what makes this helper [NaN]-safe.  Callers
+    can rely on the return value always being a finite float
+    in [\[0, 1\]]. *)
 
 (** {1 String / path helpers} *)
 

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -52,6 +52,14 @@ val get_float_nonneg : default:float -> string -> float
     [float_of_string "inf"] succeeds and [+∞ > 0.0] would
     otherwise pass an effectively unbounded value through. *)
 
+val get_ratio : default:float -> string -> float
+(** Like {!get_float_nonneg} but additionally rejects parses [> 1.0].
+    Use for env vars whose semantic is a fraction in [\[0, 1\]]:
+    score thresholds, probabilities, context-ratio caps.  The
+    [default] argument is itself clamped to [\[0, 1\]] as
+    defense-in-depth, so a caller passing a stale out-of-range
+    default still gets a valid ratio back. *)
+
 (** {1 String / path helpers} *)
 
 val trim_opt : string option -> string option

--- a/test/dune
+++ b/test/dune
@@ -1044,6 +1044,7 @@
 (include stanzas/test_env_config_dashboard_execution_timeouts.inc)
 (include stanzas/test_env_config_dashboard_shell_prewarm.inc)
 (include stanzas/test_env_config_exec_timeout_10426.inc)
+(include stanzas/test_env_config_get_ratio.inc)
 (include stanzas/test_env_config_keeper_bootstrap_intervals.inc)
 (include stanzas/test_env_config_keeper_poll_intervals.inc)
 (include stanzas/test_env_config_sandbox.inc)

--- a/test/stanzas/test_env_config_get_ratio.inc
+++ b/test/stanzas/test_env_config_get_ratio.inc
@@ -1,0 +1,9 @@
+; Per-file dune stanza for the [Env_config_core.get_ratio]
+; regression suite.  Lives here (not in the legacy grouped
+; stanza) per test/stanzas/README.md to avoid the
+; conflict-cascade hotspot.
+
+(test
+ (name test_env_config_get_ratio)
+ (modules test_env_config_get_ratio)
+ (libraries masc_test_deps))

--- a/test/test_env_config_get_ratio.ml
+++ b/test/test_env_config_get_ratio.ml
@@ -29,6 +29,9 @@ let with_env name value f =
 let check_float label expected actual =
   Alcotest.(check (float 0.001)) label expected actual
 
+let check_bool label expected actual =
+  Alcotest.(check bool) label expected actual
+
 (* ── happy path: in-range parses ─────────────────────────────────── *)
 
 let test_in_range_zero () =
@@ -103,6 +106,41 @@ let test_default_above_one_clamped () =
     (C.get_ratio
        ~default:1.7 "MASC_TEST_RATIO_DEFAULT_GT1_XYZ123")
 
+let test_default_nan_sanitised () =
+  (* [Float.min nan 1.0] propagates NaN, so a naive clamp would
+     return NaN when default = NaN.  Pin the contract that the
+     helper must always return a finite [0, 1] value. *)
+  let r =
+    C.get_ratio
+      ~default:Float.nan "MASC_TEST_RATIO_DEFAULT_NAN_XYZ123"
+  in
+  check_bool "NaN default sanitised to finite" true
+    (Float.is_finite r);
+  check_bool "NaN default sanitised within [0, 1]" true
+    (r >= 0.0 && r <= 1.0)
+
+let test_default_pos_inf_sanitised () =
+  let r =
+    C.get_ratio
+      ~default:Float.infinity
+      "MASC_TEST_RATIO_DEFAULT_PINF_XYZ123"
+  in
+  check_bool "+inf default sanitised to finite" true
+    (Float.is_finite r);
+  check_bool "+inf default sanitised within [0, 1]" true
+    (r >= 0.0 && r <= 1.0)
+
+let test_default_neg_inf_sanitised () =
+  let r =
+    C.get_ratio
+      ~default:Float.neg_infinity
+      "MASC_TEST_RATIO_DEFAULT_NINF_XYZ123"
+  in
+  check_bool "-inf default sanitised to finite" true
+    (Float.is_finite r);
+  check_bool "-inf default sanitised within [0, 1]" true
+    (r >= 0.0 && r <= 1.0)
+
 (* ── runner ──────────────────────────────────────────────────────── *)
 
 let () =
@@ -141,5 +179,11 @@ let () =
             test_default_below_zero_clamped;
           Alcotest.test_case "default >1 clamped to 1.0" `Quick
             test_default_above_one_clamped;
+          Alcotest.test_case "default NaN sanitised to finite [0,1]"
+            `Quick test_default_nan_sanitised;
+          Alcotest.test_case "default +inf sanitised to finite [0,1]"
+            `Quick test_default_pos_inf_sanitised;
+          Alcotest.test_case "default -inf sanitised to finite [0,1]"
+            `Quick test_default_neg_inf_sanitised;
         ] );
     ]

--- a/test/test_env_config_get_ratio.ml
+++ b/test/test_env_config_get_ratio.ml
@@ -1,0 +1,145 @@
+(** Unit tests for [Env_config_core.get_ratio].
+
+    Pins the [\[0.0, 1.0\]]-bounded float contract:
+
+    - in-range parses pass through unchanged (0.0, 0.5, 1.0)
+    - out-of-range parses (negative, > 1.0, NaN, +∞, -∞) →
+      [default]
+    - non-numeric parse → [default] (delegated from {!get_float})
+    - unset env var → [default]
+    - out-of-range [default] is itself clamped to
+      [\[0.0, 1.0\]] (defense-in-depth)
+
+    Each test uses a unique env-var name so cases are independent
+    when run in parallel. *)
+
+open Masc_mcp
+module C = Env_config_core
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  Unix.putenv name value;
+  let finally () =
+    match prev with
+    | Some v -> Unix.putenv name v
+    | None -> Unix.putenv name ""
+  in
+  Fun.protect ~finally f
+
+let check_float label expected actual =
+  Alcotest.(check (float 0.001)) label expected actual
+
+(* ── happy path: in-range parses ─────────────────────────────────── *)
+
+let test_in_range_zero () =
+  with_env "MASC_TEST_RATIO_ZERO" "0.0" @@ fun () ->
+  check_float "0.0 passes through" 0.0
+    (C.get_ratio ~default:0.5 "MASC_TEST_RATIO_ZERO")
+
+let test_in_range_half () =
+  with_env "MASC_TEST_RATIO_HALF" "0.5" @@ fun () ->
+  check_float "0.5 passes through" 0.5
+    (C.get_ratio ~default:0.7 "MASC_TEST_RATIO_HALF")
+
+let test_in_range_one () =
+  with_env "MASC_TEST_RATIO_ONE" "1.0" @@ fun () ->
+  check_float "1.0 passes through" 1.0
+    (C.get_ratio ~default:0.5 "MASC_TEST_RATIO_ONE")
+
+(* ── out-of-range: rejection ─────────────────────────────────────── *)
+
+let test_negative_rejected () =
+  with_env "MASC_TEST_RATIO_NEG" "-0.1" @@ fun () ->
+  check_float "-0.1 → default 0.7" 0.7
+    (C.get_ratio ~default:0.7 "MASC_TEST_RATIO_NEG")
+
+let test_above_one_rejected () =
+  with_env "MASC_TEST_RATIO_GT1" "1.5" @@ fun () ->
+  check_float "1.5 → default 0.6" 0.6
+    (C.get_ratio ~default:0.6 "MASC_TEST_RATIO_GT1")
+
+let test_above_one_boundary_rejected () =
+  (* exactly 1.0 + epsilon should reject; 1.0 itself accepted *)
+  with_env "MASC_TEST_RATIO_GT1B" "1.0001" @@ fun () ->
+  check_float "1.0001 → default 0.4" 0.4
+    (C.get_ratio ~default:0.4 "MASC_TEST_RATIO_GT1B")
+
+let test_nan_rejected () =
+  with_env "MASC_TEST_RATIO_NAN" "nan" @@ fun () ->
+  check_float "NaN → default 0.3" 0.3
+    (C.get_ratio ~default:0.3 "MASC_TEST_RATIO_NAN")
+
+let test_pos_inf_rejected () =
+  with_env "MASC_TEST_RATIO_PINF" "inf" @@ fun () ->
+  check_float "+inf → default 0.2" 0.2
+    (C.get_ratio ~default:0.2 "MASC_TEST_RATIO_PINF")
+
+let test_neg_inf_rejected () =
+  with_env "MASC_TEST_RATIO_NINF" "-inf" @@ fun () ->
+  check_float "-inf → default 0.8" 0.8
+    (C.get_ratio ~default:0.8 "MASC_TEST_RATIO_NINF")
+
+(* ── parse fallthrough ───────────────────────────────────────────── *)
+
+let test_garbage_uses_default () =
+  with_env "MASC_TEST_RATIO_GARBAGE" "junk" @@ fun () ->
+  check_float "non-float → default 0.5" 0.5
+    (C.get_ratio ~default:0.5 "MASC_TEST_RATIO_GARBAGE")
+
+let test_unset_uses_default () =
+  check_float "unset → default 0.42" 0.42
+    (C.get_ratio ~default:0.42 "MASC_TEST_RATIO_UNSET_XYZ123")
+
+(* ── default clamping (defense in depth) ─────────────────────────── *)
+
+let test_default_below_zero_clamped () =
+  (* env unset, default itself is out of range — clamp to 0.0. *)
+  check_float "default -0.5 clamped to 0.0" 0.0
+    (C.get_ratio
+       ~default:(-0.5) "MASC_TEST_RATIO_DEFAULT_NEG_XYZ123")
+
+let test_default_above_one_clamped () =
+  check_float "default 1.7 clamped to 1.0" 1.0
+    (C.get_ratio
+       ~default:1.7 "MASC_TEST_RATIO_DEFAULT_GT1_XYZ123")
+
+(* ── runner ──────────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Env_config_core_get_ratio"
+    [
+      ( "in-range parses",
+        [
+          Alcotest.test_case "0.0 passes" `Quick test_in_range_zero;
+          Alcotest.test_case "0.5 passes" `Quick test_in_range_half;
+          Alcotest.test_case "1.0 passes" `Quick test_in_range_one;
+        ] );
+      ( "out-of-range rejection",
+        [
+          Alcotest.test_case "negative → default" `Quick
+            test_negative_rejected;
+          Alcotest.test_case ">1.0 → default" `Quick
+            test_above_one_rejected;
+          Alcotest.test_case "1.0+ε → default" `Quick
+            test_above_one_boundary_rejected;
+          Alcotest.test_case "NaN → default" `Quick test_nan_rejected;
+          Alcotest.test_case "+inf → default" `Quick
+            test_pos_inf_rejected;
+          Alcotest.test_case "-inf → default" `Quick
+            test_neg_inf_rejected;
+        ] );
+      ( "parse fallthrough",
+        [
+          Alcotest.test_case "garbage → default" `Quick
+            test_garbage_uses_default;
+          Alcotest.test_case "unset → default" `Quick
+            test_unset_uses_default;
+        ] );
+      ( "default clamping",
+        [
+          Alcotest.test_case "default <0 clamped to 0.0" `Quick
+            test_default_below_zero_clamped;
+          Alcotest.test_case "default >1 clamped to 1.0" `Quick
+            test_default_above_one_clamped;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Adds `get_ratio` to `lib/config/env_config_core.{ml,mli}` — a `[0, 1]`-bounded float env getter that delegates to `get_float_nonneg` (#12901) for the non-finite + negative rejection and adds the `> 1.0` upper bound. 16 unit tests across five property groups.

## Why

Audit P3 follow-up to #12901. Many `MASC_*` env vars are fractions where the operator's mental model is "this is a fraction in [0, 1]":

- `MASC_KEEPER_ALERT_MIN_SCORE` (0.70)
- `MASC_KEEPER_ALERT_GITHUB_MIN_SCORE` (0.85)
- `MASC_KEEPER_SELF_PRESERVATION_RATIO` (0.3)
- `MASC_CONTEXT_RATIO_HARD_CAP` (0.95)
- `MASC_COMPACT_DYN_MULTI_AGENT_RATIO` (0.80)
- `MASC_COMPACT_DYN_FOCUSED_RATIO` (0.70)
- `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` (0.95)

`get_float` / `get_float_nonneg` accept any non-negative finite value, so a typo like `0.95` → `95` silently propagates a 95× multiplier downstream. `get_ratio` rejects everything outside `[0, 1]` and falls back to the default.

## Properties pinned (16 cases)

| # | Property | Test count |
|---|---|---|
| 1 | In-range (0.0, 0.5, 1.0) passes | 3 |
| 2 | Out-of-range (negative, >1.0, 1.0+ε, NaN, +∞, -∞) → default | 6 |
| 3 | Parse fallthrough (garbage / unset) → default | 2 |
| 4 | Out-of-range *default* clamped to `[0, 1]` | 2 |
| 5 | Non-finite *default* (NaN, +∞, -∞) sanitised to finite `[0, 1]` | 3 |

## Refactor (per review)

`get_ratio` originally duplicated the parsing + non-finite + negative rejection logic from `get_float_nonneg`. After Copilot review (`9f9f1b8fb9`), it now delegates: `get_float_nonneg` does the heavy lifting, `get_ratio` just adds the `> 1.0` upper bound. Single source of truth for the rejection semantics.

## Migration

No call-site migration in this PR. Seven candidate knobs above will be migrated in a follow-up sweep (one PR per area).

## Test plan

- [x] `dune build lib/config` clean
- [x] `dune exec test/test_env_config_get_ratio.exe` — 16/16 green
- [x] Test added under `test/stanzas/test_env_config_get_ratio.inc` per `test/stanzas/README.md`
- [x] Race check pre-push: no concurrent `get_ratio` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)