### PR TITLE
fix(keeper): stamp Fiber_unresolved blocker_class + clean up #12910 revert leftovers (MAIN BLOCKER)

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -94,6 +94,14 @@ type blocker_class =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Fiber_unresolved
+    (** 2026-05-05: turn fiber finished without invoking [resolve_done]
+        (cancelled mid-turn, raised an exception not handled by the
+        body, or the OAS request returned but the keeper switch tore
+        down before completion bookkeeping ran).  Maps 1:1 to the
+        supervisor's [Keeper_registry.Fiber_unresolved] cohort key
+        used by self-preservation, so blocker_class stamping mirrors
+        the same diagnosis on keeper_meta. *)
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
@@ -106,6 +114,7 @@ let blocker_class_to_string = function
   | Turn_timeout -> "turn_timeout"
   | Completion_contract_violation -> "completion_contract_violation"
   | No_tool_capable_provider -> "no_tool_capable_provider"
+  | Fiber_unresolved -> "fiber_unresolved"
 ;;
 
 let blocker_class_of_serialized_string = function
@@ -119,6 +128,7 @@ let blocker_class_of_serialized_string = function
   | "turn_timeout" -> Some Turn_timeout
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "no_tool_capable_provider" -> Some No_tool_capable_provider
+  | "fiber_unresolved" -> Some Fiber_unresolved
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -144,6 +144,7 @@ type blocker_class =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Fiber_unresolved
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -296,6 +296,41 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                   Keeper_registry.Fiber_unresolved in
               Keeper_registry.set_failure_reason ~base_path meta.name
                 (Some Keeper_registry.Fiber_unresolved);
+              (* 2026-05-05 fleet-stuck cycle: keeper meta runtime
+                 [last_blocker]/[last_blocker_class] stayed null for 5+ hours
+                 while supervisor self-preservation suppressed restarts under
+                 [cohort=fiber_unresolved].  The diagnosis was buried in the
+                 crash registry but invisible on the per-keeper meta surface
+                 dashboards read.  Stamp the same cohort onto runtime so
+                 operators (and the dashboard "차단된 키퍼" card) see why a
+                 keeper is silent.  Best-effort: write_meta failure does not
+                 abort cleanup, mirroring [handle_crash_auto_pause]. *)
+              (match Keeper_registry.get ~base_path meta.name with
+               | Some entry ->
+                 let stamped_meta =
+                   { entry.meta with
+                     runtime =
+                       { entry.meta.runtime with
+                         last_blocker = "fiber_unresolved";
+                         last_blocker_class = Some Fiber_unresolved;
+                       };
+                   }
+                 in
+                 (match
+                    write_meta_with_merge
+                      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                      ctx.config stamped_meta
+                  with
+                  | Ok () -> ()
+                  | Error err ->
+                    Prometheus.inc_counter
+                      Prometheus.metric_keeper_write_meta_failures
+                      ~labels:[("keeper", meta.name); ("phase", "fiber_unresolved_stamp")]
+                      ();
+                    Log.Keeper.warn
+                      "%s: fiber_unresolved meta stamp failed: %s"
+                      meta.name err)
+               | None -> ());
               let ts = Time_compat.now () in
               Keeper_registry.record_crash ~base_path
                 meta.name ts reason;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -166,6 +166,7 @@ type blocker_class =
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
+  | Fiber_unresolved
 
 val blocker_class_to_string : blocker_class -> string
 val cascade_exhaustion_summary : cascade_exhaustion_reason -> string

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -245,6 +245,5 @@ val run_unified_turn :
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
   ?shared_context:Agent_sdk.Context.t ->
-  ?yield_and_reacquire_slot:(unit -> (int, [> `Semaphore_wait_timeout of float ]) result) ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -154,11 +154,6 @@ val metric_keeper_turn_queue_depth : string
     FIFO wait queue. Reactive turn depth is intentionally not inferred from
     semaphore availability. *)
 
-val metric_keeper_slot_yield_total : string
-(** RFC #12885: incremented each time the autonomous turn slot is
-    successfully yielded and reacquired during a cascade rotation retry.
-    Labels: [keeper]. *)
-
 val metric_timeout_policy_overshoot : string
 (** #9662: cooperative-cancel timeout overshoot counter emitted by
     [Timeout_policy].  Labels: [layer, origin]. *)


### PR DESCRIPTION
## TL;DR
Fleet-stuck recurrence on 2026-05-05 03:13~08:59. 7/14 keepers entered the **\`fiber_unresolved\`** self-preservation cohort, supervisor correctly suppressed restarts, but every keeper meta carried \`last_blocker_class = null\` so dashboards / operator scripts had nothing to show. This PR exposes the cohort on the meta surface (so PR #12877's dashboard card actually has data) and incidentally fixes a main-build blocker leaked by the #12910 revert.

## Three changes

### (A) MAIN BLOCKER — 1 + 5 line cleanup
PR #12910 reverted #12885 but left two interface symbols that #12912 had added:
- \`lib/keeper/keeper_unified_turn.mli:248\` declared \`?yield_and_reacquire_slot\` on \`run_unified_turn\` while the implementation no longer takes it.
- \`lib/prometheus.mli:157\` declared \`metric_keeper_slot_yield_total\` while \`prometheus.ml\` no longer defines it.

Result: any PR touching keeper internals fails CI build (\"Unbound value\" + \"mli does not match\"). Found while validating (B). Confirmed via \`git log -p origin/main -- lib/keeper/keeper_unified_turn.mli\` showing #12912 added the line, #12910 only reverted half of it.

### (B) Fiber_unresolved blocker_class stamp — 24 lines
\`keeper_supervisor.ml:285-313\` finally branch runs when a keeper's body fiber finishes without invoking \`resolve_done\` (cancelled mid-turn, OAS request returned but switch tore down, etc.). Today it correctly:
- assigns \`Keeper_registry.Fiber_unresolved\` failure reason
- records the crash
- triggers the supervisor self-preservation cohort grouping

But it never stamps the corresponding \`runtime.last_blocker_class\` on \`keeper_meta\`. So when the suppression line fires:
\`\`\`
WARN self-preservation: suppressing 7/14 restarts
  (ratio=0.50, cohort=fiber_unresolved, streak=9)
\`\`\`
the per-keeper meta dashboards / scripts read shows \`last_blocker_class: null\`. Operators see PR #12877's \"차단된 키퍼\" card empty even though 7 keepers are demonstrably stuck.

This PR adds a \`Fiber_unresolved\` variant to \`blocker_class\` (in both \`keeper_meta_contract\` and \`keeper_types\` facades) and stamps it onto runtime in the same finally branch that records the cohort. Best-effort write_meta failure does not abort cleanup, mirroring \`handle_crash_auto_pause\` (#12889).

### (C) Codec round-trip
\`blocker_class_to_string\` and \`blocker_class_of_serialized_string\` both gain the new variant so persisted meta survives restart.

## Why one PR
The Fiber_unresolved stamp lives in \`keeper_supervisor.ml\`, which imports the broken \`keeper_unified_turn\` and \`prometheus\` modules through the keeper library compilation unit. Without (A), the supervisor change never builds in CI, so they ship together rather than as a stack.

## Test plan
- [x] \`dune build @check -j 8\` clean on rebased branch (origin/main = 01403aab3a).
- [ ] Post-merge: rebuild + restart; force a fiber_unresolved condition (e.g. kill -9 a keeper's OAS subprocess mid-turn) and confirm \`keeper_meta.runtime.last_blocker_class == \"fiber_unresolved\"\` on next supervisor sweep.
- [ ] Dashboard \"차단된 키퍼\" card surfaces the cohort that has been invisible since #12877.

## Risk
Low. Variant addition is exhaustive across the 4 helper sites. Stamp is best-effort and uses the same \`heartbeat_fields_from_disk\` merge as #12889. Main-blocker fix is exactly the inverse of #12912's diff.

## Companion to
- #12889 release current_task_id on auto-pause (different finally branch — handle_crash_auto_pause vs supervised_fiber finally)
- #12866 cascade circular fallback detector
- #12898 cycle WARN dedup
- #12877 dashboard blocked-keeper card (this PR is what gives it Fiber_unresolved data to render)

Note: This is the **7th** silent-path fix in the 2026-05-05 fleet-stuck recurrence chain. The user invoked the same prompt 7 times across the day; each invocation surfaced a previously-unaccounted-for silent path. The Fiber_unresolved cohort is the worst because the supervisor *did* correctly diagnose 50% of the fleet but the diagnosis only landed in the crash registry, never on the meta surface that operators check.