### PR TITLE
test(multimodal): unit tests for Payload + Provenance_stub

### DIFF
--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -1,3 +1,3 @@
 (tests
- (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge test_workspace_holder test_wirein_helpers test_keeper_emitter test_tool_emission)
- (libraries multimodal shared_types yojson str unix))
+ (names test_artifact test_multimodal_hydrator test_create test_workspace test_workspace_id test_multimodal_keeper_bridge test_workspace_holder test_wirein_helpers test_keeper_emitter test_tool_emission test_payload test_provenance_stub)
+ (libraries multimodal shared_types astring yojson str unix))

--- a/test/multimodal/test_payload.ml
+++ b/test/multimodal/test_payload.ml
@@ -119,6 +119,33 @@ let test_of_json_blob_ref_missing_ref () =
   | Error _ -> ()
   | Ok _ -> assert false
 
+let test_of_json_streaming_missing_bytes () =
+  (* Symmetric to blob_ref_missing_ref — Copilot review caught
+     this branch was untested. *)
+  let j = `Assoc [ ("kind", `String "streaming") ] in
+  match P.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_streaming_wrong_type_bytes () =
+  (* "bytes" present but not `Int — must reject. *)
+  let j =
+    `Assoc
+      [ ("kind", `String "streaming"); ("bytes", `String "4096") ]
+  in
+  match P.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_blob_ref_wrong_type_ref () =
+  (* "ref" present but not `String. *)
+  let j =
+    `Assoc [ ("kind", `String "blob_ref"); ("ref", `Int 42) ]
+  in
+  match P.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
 let test_of_json_not_object () =
   let j = `String "scalar" in
   match P.of_json j with
@@ -139,5 +166,8 @@ let () =
   test_of_json_unknown_kind ();
   test_of_json_missing_kind ();
   test_of_json_blob_ref_missing_ref ();
+  test_of_json_streaming_missing_bytes ();
+  test_of_json_streaming_wrong_type_bytes ();
+  test_of_json_blob_ref_wrong_type_ref ();
   test_of_json_not_object ();
   print_endline "test_payload: all assertions passed"

--- a/test/multimodal/test_payload.ml
+++ b/test/multimodal/test_payload.ml
@@ -1,0 +1,143 @@
+(* Cycle 24 / Tier B8 — Multimodal.Payload JSON round-trip tests.
+
+   Pins the explicit lossy contract documented in payload.mli:
+
+   - [Lazy_payload _] serialises to [{"kind":"lazy"}] and the
+     closure is *intentionally* dropped on round-trip; [of_json]
+     reconstructs a stub closure that returns "".  This is not
+     a bug — payload.mli §40 calls it out explicitly.
+   - [Blob_ref s] round-trips the string verbatim.
+   - [Streaming n] round-trips the byte counter verbatim.
+   - Garbage / missing-field JSON returns [Error _]. *)
+
+module P = Multimodal.Payload
+
+(* ─── to_json shape ───────────────────────────────────────────── *)
+
+let test_to_json_lazy_drops_closure () =
+  let p = P.Lazy_payload (fun () -> "secret payload") in
+  let j = P.to_json p in
+  let kind =
+    Yojson.Safe.Util.member "kind" j |> Yojson.Safe.Util.to_string
+  in
+  assert (kind = "lazy");
+  (* The "secret payload" string must NOT appear anywhere in the
+     serialised JSON — closures are intentionally dropped. *)
+  let serialised = Yojson.Safe.to_string j in
+  assert (
+    not (Astring.String.is_infix ~affix:"secret payload" serialised))
+
+let test_to_json_blob_ref () =
+  let p = P.Blob_ref "blob://store/abc123" in
+  let j = P.to_json p in
+  let kind =
+    Yojson.Safe.Util.member "kind" j |> Yojson.Safe.Util.to_string
+  in
+  let r =
+    Yojson.Safe.Util.member "ref" j |> Yojson.Safe.Util.to_string
+  in
+  assert (kind = "blob_ref");
+  assert (r = "blob://store/abc123")
+
+let test_to_json_streaming () =
+  let p = P.Streaming 4096 in
+  let j = P.to_json p in
+  let kind =
+    Yojson.Safe.Util.member "kind" j |> Yojson.Safe.Util.to_string
+  in
+  let n =
+    Yojson.Safe.Util.member "bytes" j |> Yojson.Safe.Util.to_int
+  in
+  assert (kind = "streaming");
+  assert (n = 4096)
+
+(* ─── of_json ─────────────────────────────────────────────────── *)
+
+let test_of_json_lazy_returns_empty_closure () =
+  let j = `Assoc [ ("kind", `String "lazy") ] in
+  match P.of_json j with
+  | Ok (P.Lazy_payload f) ->
+      (* mli §40: the reconstructed closure always returns "". *)
+      assert (f () = "")
+  | Ok _ -> assert false
+  | Error e ->
+      Printf.eprintf "unexpected error: %s\n" e;
+      assert false
+
+let test_of_json_blob_ref () =
+  let j =
+    `Assoc
+      [ ("kind", `String "blob_ref"); ("ref", `String "blob://x/1") ]
+  in
+  match P.of_json j with
+  | Ok (P.Blob_ref s) -> assert (s = "blob://x/1")
+  | Ok _ -> assert false
+  | Error _ -> assert false
+
+let test_of_json_streaming () =
+  let j =
+    `Assoc [ ("kind", `String "streaming"); ("bytes", `Int 8192) ]
+  in
+  match P.of_json j with
+  | Ok (P.Streaming n) -> assert (n = 8192)
+  | Ok _ -> assert false
+  | Error _ -> assert false
+
+(* ─── Round-trip for non-lazy variants ────────────────────────── *)
+
+let test_round_trip_blob_ref () =
+  let original = P.Blob_ref "blob://round/trip" in
+  let restored = P.of_json (P.to_json original) in
+  match restored with
+  | Ok (P.Blob_ref s) -> assert (s = "blob://round/trip")
+  | _ -> assert false
+
+let test_round_trip_streaming () =
+  let original = P.Streaming 1234 in
+  let restored = P.of_json (P.to_json original) in
+  match restored with
+  | Ok (P.Streaming n) -> assert (n = 1234)
+  | _ -> assert false
+
+(* ─── Error paths ─────────────────────────────────────────────── *)
+
+let test_of_json_unknown_kind () =
+  let j = `Assoc [ ("kind", `String "unknown_variant") ] in
+  match P.of_json j with
+  | Error _ -> ()  (* expected *)
+  | Ok _ -> assert false
+
+let test_of_json_missing_kind () =
+  let j = `Assoc [ ("ref", `String "x") ] in
+  match P.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_blob_ref_missing_ref () =
+  let j = `Assoc [ ("kind", `String "blob_ref") ] in
+  match P.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_not_object () =
+  let j = `String "scalar" in
+  match P.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+(* ─── runner ──────────────────────────────────────────────────── *)
+
+let () =
+  test_to_json_lazy_drops_closure ();
+  test_to_json_blob_ref ();
+  test_to_json_streaming ();
+  test_of_json_lazy_returns_empty_closure ();
+  test_of_json_blob_ref ();
+  test_of_json_streaming ();
+  test_round_trip_blob_ref ();
+  test_round_trip_streaming ();
+  test_of_json_unknown_kind ();
+  test_of_json_missing_kind ();
+  test_of_json_blob_ref_missing_ref ();
+  test_of_json_not_object ();
+  print_endline "test_payload: all assertions passed"

--- a/test/multimodal/test_payload.ml
+++ b/test/multimodal/test_payload.ml
@@ -51,6 +51,30 @@ let test_to_json_streaming () =
   assert (kind = "streaming");
   assert (n = 4096)
 
+(* ─── strict to_json shape: pin exact key set per variant ──── *)
+(* Copilot review: previous to_json tests checked selected
+   fields via [member ...] but a wire-format regression like
+   adding extra keys (e.g. "format_version") would still pass.
+   Pin the EXACT key set of each variant so any addition or
+   removal fails. *)
+
+let assoc_keys_sorted = function
+  | `Assoc kv ->
+      List.map fst kv |> List.sort String.compare
+  | _ -> assert false
+
+let test_to_json_lazy_strict_keys () =
+  let j = P.to_json (P.Lazy_payload (fun () -> "x")) in
+  assert (assoc_keys_sorted j = [ "kind" ])
+
+let test_to_json_blob_ref_strict_keys () =
+  let j = P.to_json (P.Blob_ref "blob://x") in
+  assert (assoc_keys_sorted j = [ "kind"; "ref" ])
+
+let test_to_json_streaming_strict_keys () =
+  let j = P.to_json (P.Streaming 8) in
+  assert (assoc_keys_sorted j = [ "bytes"; "kind" ])
+
 (* ─── of_json ─────────────────────────────────────────────────── *)
 
 let test_of_json_lazy_returns_empty_closure () =
@@ -170,4 +194,7 @@ let () =
   test_of_json_streaming_wrong_type_bytes ();
   test_of_json_blob_ref_wrong_type_ref ();
   test_of_json_not_object ();
+  test_to_json_lazy_strict_keys ();
+  test_to_json_blob_ref_strict_keys ();
+  test_to_json_streaming_strict_keys ();
   print_endline "test_payload: all assertions passed"

--- a/test/multimodal/test_provenance_stub.ml
+++ b/test/multimodal/test_provenance_stub.ml
@@ -73,10 +73,94 @@ let test_of_json_missing_created_by () =
   | Error _ -> ()
   | Ok _ -> assert false
 
+let test_of_json_missing_created_at () =
+  (* Symmetric to missing_created_by — Copilot review caught
+     the [created_at] branch was untested. *)
+  let j = `Assoc [ ("created_by", `String "k") ] in
+  match Pr.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_origin_artifact_ids_not_list () =
+  (* "origin_artifact_ids" present but not a JSON list. *)
+  let j =
+    `Assoc
+      [
+        ("origin_artifact_ids", `String "wrong-type");
+        ("created_by", `String "k");
+        ("created_at", `Float 1.0);
+      ]
+  in
+  match Pr.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_origin_artifact_ids_invalid_member () =
+  (* "origin_artifact_ids" is a list, but a member is not a
+     valid Artifact_id JSON shape. *)
+  let j =
+    `Assoc
+      [
+        ( "origin_artifact_ids",
+          `List [ `Int 42 (* not a string-shaped Aid *) ] );
+        ("created_by", `String "k");
+        ("created_at", `Float 1.0);
+      ]
+  in
+  match Pr.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_created_by_wrong_type () =
+  let j =
+    `Assoc
+      [
+        ("created_by", `Int 42);
+        ("created_at", `Float 1.0);
+      ]
+  in
+  match Pr.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_created_at_wrong_type () =
+  let j =
+    `Assoc
+      [
+        ("created_by", `String "k");
+        ("created_at", `String "not-a-number");
+      ]
+  in
+  match Pr.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_created_at_int_accepted () =
+  (* Implementation accepts both `Float and `Int for created_at
+     (line 46: float_of_int i).  Pin that behavior. *)
+  let j =
+    `Assoc
+      [
+        ("created_by", `String "k");
+        ("created_at", `Int 1700000000);
+      ]
+  in
+  match Pr.of_json j with
+  | Ok r -> assert (r.created_at = 1700000000.0)
+  | Error e ->
+      Printf.eprintf "unexpected error: %s\n" e;
+      assert false
+
 let () =
   test_empty_no_origins ();
   test_round_trip_empty ();
   test_round_trip_with_origins ();
   test_of_json_garbage ();
   test_of_json_missing_created_by ();
+  test_of_json_missing_created_at ();
+  test_of_json_origin_artifact_ids_not_list ();
+  test_of_json_origin_artifact_ids_invalid_member ();
+  test_of_json_created_by_wrong_type ();
+  test_of_json_created_at_wrong_type ();
+  test_of_json_created_at_int_accepted ();
   print_endline "test_provenance_stub: all assertions passed"

--- a/test/multimodal/test_provenance_stub.ml
+++ b/test/multimodal/test_provenance_stub.ml
@@ -1,0 +1,82 @@
+(* Cycle 24 / Tier B8 — Multimodal.Provenance_stub JSON round-trip tests.
+
+   Pins:
+
+   - [empty ~created_by ~created_at] yields the documented shape
+     (no origin artifacts).
+   - [to_json]/[of_json] round-trip for empty + multi-origin
+     records.
+   - Garbage JSON returns [Error _]. *)
+
+module Pr = Multimodal.Provenance_stub
+module Aid = Shared_types.Artifact_id
+
+let test_empty_no_origins () =
+  let p = Pr.empty ~created_by:"keeper-A" ~created_at:1700000000.0 in
+  assert (p.origin_artifact_ids = []);
+  assert (p.created_by = "keeper-A");
+  assert (p.created_at = 1700000000.0)
+
+let test_round_trip_empty () =
+  let original =
+    Pr.empty ~created_by:"keeper-B" ~created_at:1700000123.5
+  in
+  let restored = Pr.of_json (Pr.to_json original) in
+  match restored with
+  | Ok r ->
+      assert (r.origin_artifact_ids = []);
+      assert (r.created_by = "keeper-B");
+      assert (r.created_at = 1700000123.5)
+  | Error e ->
+      Printf.eprintf "unexpected error: %s\n" e;
+      assert false
+
+let test_round_trip_with_origins () =
+  (* [Aid.of_string] requires a 36-char UUID, so use [Aid.generate]
+     for fixture data and pin only the count + string round-trip
+     through [to_string], not the literal value. *)
+  let id1 = Aid.generate () in
+  let id2 = Aid.generate () in
+  let original =
+    {
+      Pr.origin_artifact_ids = [ id1; id2 ];
+      created_by = "keeper-C";
+      created_at = 1700000456.0;
+    }
+  in
+  let restored = Pr.of_json (Pr.to_json original) in
+  match restored with
+  | Ok r ->
+      assert (List.length r.origin_artifact_ids = 2);
+      assert (r.created_by = "keeper-C");
+      assert (r.created_at = 1700000456.0);
+      (* Serialised form survives intact when restored. *)
+      let want1 = Aid.to_string id1 in
+      let want2 = Aid.to_string id2 in
+      let got1 = List.nth r.origin_artifact_ids 0 |> Aid.to_string in
+      let got2 = List.nth r.origin_artifact_ids 1 |> Aid.to_string in
+      assert (got1 = want1);
+      assert (got2 = want2)
+  | Error e ->
+      Printf.eprintf "unexpected error: %s\n" e;
+      assert false
+
+let test_of_json_garbage () =
+  let j = `String "not_an_object" in
+  match Pr.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let test_of_json_missing_created_by () =
+  let j = `Assoc [ ("created_at", `Float 1.0) ] in
+  match Pr.of_json j with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let () =
+  test_empty_no_origins ();
+  test_round_trip_empty ();
+  test_round_trip_with_origins ();
+  test_of_json_garbage ();
+  test_of_json_missing_created_by ();
+  print_endline "test_provenance_stub: all assertions passed"

--- a/test/multimodal/test_provenance_stub.ml
+++ b/test/multimodal/test_provenance_stub.ml
@@ -135,6 +135,28 @@ let test_of_json_created_at_wrong_type () =
   | Error _ -> ()
   | Ok _ -> assert false
 
+let test_of_json_origin_artifact_ids_omitted_defaults_to_empty () =
+  (* Copilot review: of_json has a separate branch
+     [None -> Ok []] for an omitted [origin_artifact_ids] key.
+     Without a positive test that behavior could change
+     silently.  Pin: omitted key produces an empty origin list,
+     not an error. *)
+  let j =
+    `Assoc
+      [
+        ("created_by", `String "k");
+        ("created_at", `Float 1700000000.0);
+      ]
+  in
+  match Pr.of_json j with
+  | Ok r ->
+      assert (r.origin_artifact_ids = []);
+      assert (r.created_by = "k");
+      assert (r.created_at = 1700000000.0)
+  | Error e ->
+      Printf.eprintf "unexpected error: %s\n" e;
+      assert false
+
 let test_of_json_created_at_int_accepted () =
   (* Implementation accepts both `Float and `Int for created_at
      (line 46: float_of_int i).  Pin that behavior. *)
@@ -162,5 +184,6 @@ let () =
   test_of_json_origin_artifact_ids_invalid_member ();
   test_of_json_created_by_wrong_type ();
   test_of_json_created_at_wrong_type ();
+  test_of_json_origin_artifact_ids_omitted_defaults_to_empty ();
   test_of_json_created_at_int_accepted ();
   print_endline "test_provenance_stub: all assertions passed"


### PR DESCRIPTION
## Summary

Closes the test-coverage gap on the only two `lib/multimodal/` mli files without paired test files:
- `lib/multimodal/payload.mli` (42 LOC) → `test/multimodal/test_payload.ml` (12 cases)
- `lib/multimodal/provenance_stub.mli` (30 LOC) → `test/multimodal/test_provenance_stub.ml` (5 cases)

12 of 12 multimodal mli files now have paired tests.

## Why

Audit P2 follow-up. All other `lib/multimodal/*.mli` modules already have unit tests (`test_artifact.ml`, `test_create.ml`, `test_workspace.ml`, `test_workspace_id.ml`, `test_keeper_emitter.ml`, `test_multimodal_hydrator.ml`, `test_multimodal_keeper_bridge.ml`, `test_tool_emission.ml`, `test_wirein_helpers.ml`, `test_workspace_holder.ml`). These two were missed.

## Properties pinned

**Multimodal.Payload** (12 cases):
- `to_json`: `Lazy_payload` drops the closure — the "secret payload" string MUST NOT appear in the serialised JSON (explicit lossy contract from `payload.mli` §40)
- `to_json`: `Blob_ref` / `Streaming` round-trip verbatim
- `of_json`: `Lazy_payload` reconstructs a stub closure returning `""` (mli §40)
- `of_json`: error paths for unknown kind, missing kind, missing `ref` field, non-object input
- Round-trip for non-lazy variants

**Multimodal.Provenance_stub** (5 cases):
- `empty ~created_by ~created_at` yields documented shape
- Round-trip empty record (no origins)
- Round-trip multi-origin record (uses `Aid.generate` since `Aid.of_string` requires a 36-char UUID — fixture-independent)
- Garbage / missing-field JSON → `Error _`

## Style

Follows existing assert-based pattern in `test/multimodal/*` (vs Alcotest used elsewhere) for local consistency.

## Test plan

- [x] `dune exec test/multimodal/test_payload.exe` — all assertions passed
- [x] `dune exec test/multimodal/test_provenance_stub.exe` — all assertions passed
- [x] Race check pre-push: no concurrent payload/provenance test PR
- [x] dune dep added: `astring` (for `Astring.String.is_infix` substring check in payload's "closure-not-leaked" assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)