### PR TITLE
fix: add missing metric_keeper_slot_yield_total and run_unified_turn wrapper

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2286,4 +2286,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           post_turn_complete_task ~cycle_completed;
           Ok updated_meta))
 
-let run_unified_turn = run_keeper_cycle
+let run_unified_turn ~config ~meta ~observation ~generation
+    ?channel ?semaphore_wait_ms ?shared_context
+    ?(yield_and_reacquire_slot : _ option)
+    () =
+  let _ = yield_and_reacquire_slot in
+  run_keeper_cycle ~config ~meta ~observation ~generation
+    ?channel ?semaphore_wait_ms ?shared_context ()

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -402,6 +402,9 @@ let metric_tool_join_required_guard =
 let metric_keeper_semaphore_wait_timeout =
   "masc_keeper_semaphore_wait_timeout_total"
 
+let metric_keeper_slot_yield_total =
+  "masc_keeper_slot_yield_total"
+
 let metric_timeout_policy_overshoot =
   "masc_timeout_policy_overshoot_total"
 
@@ -1240,6 +1243,10 @@ let init () =
   register_histogram ~name:metric_keeper_provider_block_duration_sec
     ~help:"Duration in seconds for which a provider is placed into cooldown \
            (observed each time a cooldown is applied or extended). Labels: provider." ();
+  add metric_keeper_slot_yield_total
+    "Total autonomous turn slot yields (successfully yielded and reacquired). \
+     Labels: keeper."
+    Counter;
   add metric_timeout_policy_overshoot
     "Total cooperative-cancel timeout overshoots \
      (labels: layer, origin)"


### PR DESCRIPTION
## Summary
Two mli/ml mismatches blocking `dune build` on main:

1. **prometheus.ml**: `metric_keeper_slot_yield_total` declared in `.mli` but missing from `.ml` — added definition + `add` registration
2. **keeper_unified_turn.ml**: `run_unified_turn` was `let run_unified_turn = run_keeper_cycle` but `.mli` expects `?yield_and_reacquire_slot` param (RFC #12885) — converted to wrapper that accepts and ignores the param

## Test plan
- [x] `dune build --root .` passes (0 errors)
- [ ] CI pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)