### PR TITLE
style(dashboard): clean up goal manager UI labels and counter math

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -18,7 +18,6 @@ import { StatusBadge } from '../common/status-badge'
 import { ringFocusClasses } from '../common/ring'
 import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
-import { Tk } from '../tk'
 import type {
   DashboardGoalDetailResponse,
   DashboardCoordinationFsmViolation,
@@ -219,6 +218,19 @@ function blockerSourceLabel(source: GoalTreeNode['blocking_source']): string {
     case 'goal_linkage': return 'Goal 연결'
     case 'stalled': return '정체'
     default: return source
+  }
+}
+
+function humanizeBlockingReason(reason: string): string {
+  switch (reason) {
+    case 'tool_required_unsatisfied': return '필요한 도구가 충족되지 않음'
+    case 'degraded_retry': return '재시도 중 (성능 저하)'
+    case 'reaction_chain_break': return '반응 체인 단절'
+    case 'awaiting_verification': return '검증 대기'
+    case 'awaiting_approval': return '승인 대기'
+    case 'stagnant': return '정체'
+    case 'no_recent_activity': return '최근 활동 없음'
+    default: return reason
   }
 }
 
@@ -542,8 +554,8 @@ function TreeSummary({
         <div class="font-mono text-xl font-semibold text-[var(--color-fg-primary)] tabular-nums">${summary.total_goals}</div>
         <div class="mt-1 ${DECK_LABEL}">전체 목표</div>
       </div>
-      <div class="rounded-[var(--r-0)] border border-ok/25 bg-ok/10 p-3 text-center">
-        <div class="font-mono text-xl font-semibold text-ok tabular-nums">${summary.active_goals}</div>
+      <div class="rounded-[var(--r-0)] border border-ok/25 bg-ok/10 p-3 text-center" title="위험·차단·일시정지가 아닌 진행 중 목표">
+        <div class="font-mono text-xl font-semibold text-ok tabular-nums">${summary.on_track_goals}</div>
         <div class="mt-1 font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-ok/80">정상</div>
       </div>
       <div class="rounded-[var(--r-0)] border border-warn/25 bg-warn/10 p-3 text-center">
@@ -739,7 +751,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
 
           ${node.blocking_source !== 'none' && node.blocking_reason ? html`
             <div class="mt-2 text-xs leading-relaxed text-text-muted">
-              ${node.blocking_reason}
+              ${humanizeBlockingReason(node.blocking_reason)}
             </div>
           ` : null}
 
@@ -1064,7 +1076,7 @@ function GoalDetailPanel({
                 ${blockerSourceLabel(selectedNode.blocking_source)}
               </span>
             </div>
-            <div class="text-sm leading-relaxed text-text-body">${selectedNode.blocking_reason || selectedNode.status_reason}</div>
+            <div class="text-sm leading-relaxed text-text-body">${selectedNode.blocking_reason ? humanizeBlockingReason(selectedNode.blocking_reason) : selectedNode.status_reason}</div>
             <div class="mt-3 flex flex-wrap gap-2 text-3xs text-text-muted">
               ${selectedNode.latest_keeper_ref ? html`
                 <span>keeper ${selectedNode.latest_keeper_ref}</span>
@@ -1186,7 +1198,8 @@ export function GoalTree() {
   const visibleTree = useMemo(
     () => {
       if (!data) return []
-      return filterGoalTree(filterGoalTreeByPhase(data.tree, activePhaseFilter), query)
+      const filtered = filterGoalTree(filterGoalTreeByPhase(data.tree, activePhaseFilter), query)
+      return [...filtered].sort((a, b) => (a.priority ?? 99) - (b.priority ?? 99))
     },
     [activePhaseFilter, data, query],
   )
@@ -1256,12 +1269,7 @@ export function GoalTree() {
       <section class=${GOAL_PANEL} aria-label="목표 관리자">
         <div class="mb-4 flex flex-wrap items-start justify-between gap-4">
           <div class="max-w-190">
-            <div class="text-2xs font-semibold uppercase tracking-[var(--track-label)] text-text-muted">목표 관리자</div>
-            <h3 class="mt-1 text-2xl font-semibold tracking-[-0.02em] text-text-strong">목표 중심 계획 뷰</h3>
-            <p class="mt-1.5 text-sm leading-relaxed text-text-muted">
-              goal-task 연결, keeper evidence, approval 대기, sandbox/cascade 신호를 한 표면에서 봅니다.
-              신규 태스크는 <${Tk}>goal_id<//>로 직접 연결됩니다.
-            </p>
+            <h3 class="text-2xl font-semibold tracking-[-0.02em] text-text-strong">목표 관리자</h3>
           </div>
           <div class="flex flex-wrap items-center gap-2">
             ${data && data.tree.length > 0 ? html`
@@ -1330,7 +1338,7 @@ export function GoalTree() {
       ${loading && !data ? html`
         <${LoadingState}>goal manager 로드 중...<//>
       ` : data && data.tree.length === 0 ? html`
-        <${EmptyState} message="등록된 목표가 없습니다. masc_goal_upsert로 목표를 등록하세요. 연결 태스크는 task.goal_id가 우선이고, 제목의 [goal:<id>]는 레거시 fallback으로만 읽습니다." />
+        <${EmptyState} message="등록된 목표가 없습니다." />
       ` : data && isFiltering && visibleTree.length === 0 ? html`
         <section class="py-4 text-center text-xs text-text-dim" aria-label="필터 결과 없음">
           필터 결과 없음 (${data.tree.length} 목표)

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -138,7 +138,6 @@ function CoordinationHealthPanel() {
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <div class="text-sm font-semibold text-text-strong">협력 상태</div>
-          <div class="text-2xs text-text-dim">Goal x Task x Board x Reward · ${snapshot.mode ?? 'advisory'}</div>
         </div>
         <div class="flex flex-wrap items-center gap-2 text-3xs font-medium">
           <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 text-text-body">
@@ -164,7 +163,7 @@ function CoordinationHealthPanel() {
         </div>
       ` : null}
       ${violations.length === 0 ? html`
-        <div class="mt-2 text-xs text-text-muted">정합</div>
+        <div class="mt-2 text-xs text-text-muted">위반 없음</div>
       ` : html`
         <ul class="mt-2 grid gap-2">
           ${topViolations.map((violation, index) => html`
@@ -172,7 +171,7 @@ function CoordinationHealthPanel() {
           `)}
         </ul>
       `}
-      ${topEvidence.length > 0 ? html`
+      ${violations.length > 0 && topEvidence.length > 0 ? html`
         <div class="mt-3">
           <div class="mb-1 text-3xs font-semibold uppercase text-text-muted">근거</div>
           <ul class="grid gap-1 md:grid-cols-2">


### PR DESCRIPTION
## Summary

5개 UI 정리. 사용자 리뷰에서 "이상한 설명·하드코딩 raw 문자열" 로 지적된 부분.

### 1. 카운터 partition 정합 (가장 임팩트)

`정상` 카드가 `active_goals` (= "완료/중단 안된 목표") 에 묶여 있어서 같은 줄의 `위험`/`차단`과 **중첩**됐습니다. 결과: `정상 32 + 위험 20 + 차단 3 = 55 ≠ total 33` 같이 합산이 안 맞아 보임.

스키마에 이미 존재하던 깨끗한 partition 필드 `on_track_goals` 로 전환. 이제 `정상 + 위험 + 차단 + 일시정지 + 완료 + 중단 = total` 로 정합화됩니다.

| | Before | After |
|---|---|---|
| `정상` source | `active_goals` (33-done-dropped) | `on_track_goals` (위험·차단·일시정지 제외) |
| 합산 | overlap, 55≠33 | partition, 합 = total |

### 2. blocker reason humanize

`tool_required_unsatisfied`, `degraded_retry` 같은 백엔드 disposition code 가 tree 카드 / 상세 패널 두 곳에서 raw 영어로 노출. 사용자 화면에서 그대로 보였던 문제.

`humanizeBlockingReason()` 추가 (`lib/dashboard/dashboard_goals.ml` 에서 실제 발행되는 7개 code 매핑). 미지의 code 는 그대로 fallthrough.

### 3. priority 정렬

top-level tree 노드를 `priority` 오름차순 정렬. P0/P1 이 백엔드 응답 순서 무관하게 항상 위로.

### 4. meta-jargon copy 제거

- 헤더 설명 5줄 ("goal-task 연결, keeper evidence, approval 대기, sandbox/cascade 신호를 한 표면에서 봅니다. 신규 태스크는 goal_id로 직접 연결됩니다.") → 제거. 사용자에게 의미 없는 dev-note.
- `CoordinationHealthPanel` 부제 "Goal x Task x Board x Reward · advisory" → 제거. axis 나열은 사용자 액션 동력 0.
- 빈 상태 메시지 "masc_goal_upsert로 목표를 등록하세요. 연결 태스크는 task.goal_id가 우선이고, 제목의 [goal:<id>]는 레거시 fallback으로만 읽습니다." → "등록된 목표가 없습니다." (백엔드 함수명 유출 제거).
- 단일 단어 `정합` 상태 → `위반 없음` (서술형).
- `근거` (top-evidence) 리스트 — `violations=0` 일 때 숨김. 같은 정보가 goal 카드에 이미 노출되어 중복.

## Scope

- `dashboard/src/components/goals/goal-tree.ts` (+19 / −13)
- `dashboard/src/components/planning-panel.ts` (+2 / −3)

스키마/데이터 흐름 변경 없음. 모든 카운터는 `GoalTreeSummary` 의 기존 필드만 읽음.

## Test plan

- [x] `pnpm typecheck` — `goal-tree.ts` + `planning-panel.ts` clean. 다른 에러는 main 에서 이미 존재 (workspace.test.ts undefined-index, git-graph-panel unused import, ide-editor-mock unused import).
- [x] `pnpm vitest run src/components/goals src/components/planning-panel.test.ts` → 96/96 passed.
- [ ] CI Build and Test.

## Visual delta

| | Before | After |
|---|---|---|
| 정상 카운터 | overlap (active_goals) | partition (on_track_goals) |
| 카드 blocker subtext | `tool_required_unsatisfied` | `필요한 도구가 충족되지 않음` |
| 헤더 설명 | 5줄 dev-note | 제목만 |
| 협력 상태 부제 | `Goal x Task x Board x Reward · advisory` | (없음) |
| 정렬 | 백엔드 순서 | priority 오름차순 |
