### PR TITLE
feat(keeper): RFC-0026 PR-E-2 admission caller integration

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -580,6 +580,40 @@ let run_keepalive_unified_turn
       then meta_after_triage
       else if should_run_turn
       then (
+        (* RFC-0026 PR-E-2 shadow probe.  Calls the new admission glue
+           but does NOT yet act on its result; the probe runs even
+           when [MASC_ADMISSION_USE_NEW] is unset (in that case the
+           glue returns [Legacy_path] immediately).  Buckets and the
+           policy registry are intentionally empty in this PR — the
+           registry loader and per-provider bucket population land in
+           later PRs (PR-E-3 / PR-E-4).  Until those land, [decide]
+           reports [Legacy_path] for every keeper, which is
+           semantically identical to the existing semaphore path.
+           The counter is what we want: a baseline distribution we
+           can diff against once the loader is wired. *)
+        let admission_path_label =
+          let empty_buckets : Keeper_admission_router.bucket_lookup =
+            fun _ -> None
+          in
+          let empty_policies : Keeper_admission_glue.policy_lookup =
+            fun _ -> None
+          in
+          match
+            Keeper_admission_glue.decide
+              ~keeper_id:meta_after_triage.name
+              ~policies:empty_policies
+              ~buckets:empty_buckets
+          with
+          | Keeper_admission_glue.Legacy_path -> "legacy"
+          | Keeper_admission_glue.New_admission (Dispatch _) -> "new_dispatch"
+          | Keeper_admission_glue.New_admission Wait -> "new_wait"
+          | Keeper_admission_glue.New_admission (Surface _) -> "new_surface"
+        in
+        Prometheus.inc_counter Prometheus.metric_keeper_admission_path
+          ~labels:[
+            ("keeper", meta_after_triage.name);
+            ("path", admission_path_label);
+          ] ();
         (* Admission wait happens before [mark_turn_started], so the stale
            watchdog would otherwise see an idle keeper while the fiber is
            legitimately blocked behind turn-capacity backpressure. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -248,6 +248,17 @@ let metric_keeper_contract_violations =
 let metric_keeper_alive_but_stuck =
   "masc_keeper_alive_but_stuck_total"
 
+(* RFC-0026 PR-E-2 shadow probe.  Records the admission decision path
+   for every turn entry, even when [MASC_ADMISSION_USE_NEW] is unset
+   (in which case [Keeper_admission_glue.decide] returns [Legacy_path]
+   immediately).  This lets us measure how often the new router would
+   fire BEFORE wiring its [Dispatch] / [Wait] / [Surface] outcomes to
+   actual semaphore-bypass behaviour.  Labels: [keeper, path] where
+   [path] is one of [legacy] / [new_dispatch] / [new_wait] /
+   [new_surface]. *)
+let metric_keeper_admission_path =
+  "masc_keeper_admission_path_total"
+
 (* #10047: [append_metrics_snapshot] failures in [keeper_turn.ml] and
    [keeper_unified_turn.ml] used to be log-only, masking state/metric
    divergence. Surface as a counter so dashboards can alert on silent

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -84,6 +84,13 @@ val metric_keeper_contract_violations : string
     Labels: keeper. *)
 val metric_keeper_alive_but_stuck : string
 
+val metric_keeper_admission_path : string
+(** RFC-0026 PR-E-2 shadow probe.  Increments on every turn entry
+    with the path the new admission router *would* have taken.
+    Labels: [keeper, path] where [path] is one of
+    [legacy] / [new_dispatch] / [new_wait] / [new_surface].
+    Behaviour is unchanged — this counter only observes. *)
+
 val metric_keeper_metric_emit_dropped : string
 val metric_keeper_context_max_observed : string
 (** #9953: bucketed counter for observed [context_max] values.


### PR DESCRIPTION
## Summary
RFC-0026 PR-E-2 1/3 — heartbeat caller scaffold.

Adds a shadow telemetry probe at the turn-entry of `Keeper_heartbeat_loop`, calling `Keeper_admission_glue.decide` with **empty** policy/bucket lookups and recording the path it would have taken. The existing `Keeper_turn_slot.with_keeper_turn_slot` semaphore path runs **exactly as before**.

## Why this is a scaffold (not the unstuck PR yet)

This PR does not act on the new admission decision. It only observes. The reason is that two prerequisites are still missing on `main`:

1. **Persona policy registry loader** — reads `[admission.<keeper>]` sub-tables from `cascade.toml`. Without this, `Keeper_admission_registry.lookup` always returns `None` → `decide` always returns `Legacy_path` (safe fallback by design). Lands as PR-E-3.
2. **Per-provider bucket population** — `Keeper_admission_router` needs a populated `bucket_lookup`. The bucket primitive was merged in #12904 but no caller registers actual provider rate limits yet. Lands as PR-E-4.

Until both land, the new router cannot make any non-Legacy decision. So this PR's job is just to wire the call site and start collecting baseline data.

## What this PR enables
- New counter `masc_keeper_admission_path_total{keeper, path}` where `path ∈ {legacy, new_dispatch, new_wait, new_surface}`
- Baseline distribution: 100% `legacy` until PR-E-3/PR-E-4 land
- Once loader + buckets are wired, the same counter shows actual `New_admission` breakdown per keeper — live A/B signal **without flipping `MASC_ADMISSION_USE_NEW`**

## Production effect
Zero. The probe runs `decide` with empty lookups and increments a counter. The legacy semaphore path is unchanged. No new env var. No config change.

## Test plan
- [x] `dune build --root . @check` exits 0
- [ ] CI green
- [ ] After PR-E-3 + PR-E-4 land, counter shows non-`legacy` paths in some keepers

## Refs
- RFC-0026 #12909 (admission router design)
- #12939 (admission glue + registry, merged 2026-05-05)
- #12938 (admission router + WFQ, merged 2026-05-05)
- #12926 (persona admission policy types, merged 2026-05-05)
- #12904 (per-provider token bucket primitive, merged earlier)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>