### PR TITLE
feat(server): X-Workspace-Source response header for keeper-aware routes

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -58,6 +58,22 @@ let json_response ~status req reqd json =
   Http.Response.json ~status ~request:req
     (Yojson.Safe.to_string json) reqd
 
+(* Encode the workspace source tag as a single header value so the
+   frontend can render hints ("Playground 없음 — 프로젝트로 fallback")
+   without parsing the JSON body. *)
+let source_header source =
+  let v = match source with
+    | `Project -> "project"
+    | `Playground name -> "playground:" ^ name
+    | `PlaygroundMissing name -> "playground_missing:" ^ name
+    | `KeeperUnknown name -> "keeper_unknown:" ^ name
+  in
+  [("X-Workspace-Source", v)]
+
+let json_response_with_source ~status ~source req reqd json =
+  Http.Response.json ~status ~extra_headers:(source_header source)
+    ~request:req (Yojson.Safe.to_string json) reqd
+
 (* --- Safe path --- *)
 
 let is_digit c = c >= '0' && c <= '9'
@@ -279,7 +295,7 @@ let add_routes router =
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            let depth =
              match Uri.get_query_param uri "depth" with
              | Some d -> (try max 1 (min 5 (int_of_string d)) with _ -> 3)
@@ -290,14 +306,14 @@ let add_routes router =
              else scan_dir ~base ~depth:0 ~max_depth:depth [] base
            in
            let json = `List (List.rev nodes) in
-           json_response ~status:`OK request reqd json)
+           json_response_with_source ~status:`OK ~source request reqd json)
          request reqd)
 
   |> Http.Router.get "/api/v1/workspace/file" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            match Uri.get_query_param uri "path" with
            | None -> json_response ~status:`Bad_request request reqd (json_error "Missing path parameter")
            | Some p ->
@@ -308,7 +324,7 @@ let add_routes router =
                  try
                    let content = Fs_compat.load_file path in
                    let json = `Assoc [("ok", `Bool true); ("content", `String content)] in
-                   json_response ~status:`OK request reqd json
+                   json_response_with_source ~status:`OK ~source request reqd json
                  with _ -> json_response ~status:`Internal_server_error request reqd (json_error "Failed to read file")
                else
                  json_response ~status:`Not_found request reqd (json_error "File not found"))
@@ -318,7 +334,7 @@ let add_routes router =
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            let file_path =
              match Uri.get_query_param uri "path" with
              | Some p -> p
@@ -335,18 +351,18 @@ let add_routes router =
              else
                match git_run_lines ~cwd:base ["blame"; "--porcelain"; file_path] with
                | [] ->
-                 json_response ~status:`OK request reqd (`List [])
+                 json_response_with_source ~status:`OK ~source request reqd (`List [])
                | lines ->
                  let entries = parse_blame_porcelain lines in
                  let grouped = group_blame_entries file_path entries in
-                 json_response ~status:`OK request reqd (`List grouped))
+                 json_response_with_source ~status:`OK ~source request reqd (`List grouped))
          request reqd)
 
   |> Http.Router.get "/api/v1/git/diff" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
            let uri = Uri.of_string request.target in
-           let base, _source = resolve_workspace_base ~state ~uri in
+           let base, source = resolve_workspace_base ~state ~uri in
            let file_path =
              match Uri.get_query_param uri "path" with
              | Some p -> p
@@ -366,10 +382,10 @@ let add_routes router =
              else
                match git_run_lines ~cwd:base ["diff"; base_ref; "--"; file_path] with
                | [] ->
-                 json_response ~status:`OK request reqd
+                 json_response_with_source ~status:`OK ~source request reqd
                    (`Assoc [("unified", `List []); ("has_changes", `Bool false)])
                | diff_lines ->
                  let unified = parse_unified_diff diff_lines in
                  let json = `Assoc [("unified", `List unified); ("has_changes", `Bool true)] in
-                 json_response ~status:`OK request reqd json)
+                 json_response_with_source ~status:`OK ~source request reqd json)
          request reqd)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -13,3 +13,14 @@ val classify_keeper_query :
            | `Playground of string
            | `PlaygroundMissing of string
            | `KeeperUnknown of string ]
+
+(** Encode the workspace source tag as the [X-Workspace-Source] header
+    so the frontend can render hints (e.g. "Playground 없음 — 프로젝트로
+    fallback") without parsing the JSON body. Exposed for unit
+    testing. *)
+val source_header :
+  [ `Project
+  | `Playground of string
+  | `PlaygroundMissing of string
+  | `KeeperUnknown of string ] ->
+  (string * string) list

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -118,6 +118,29 @@ let test_keeper_name_trimmed () =
     Alcotest.(check string) "name is trimmed" "alpha" name
   | _ -> Alcotest.fail "expected `Playground after trim"
 
+(* ─── source_header ─────────────────────────────────────────────── *)
+
+let header_value headers =
+  match headers with
+  | [(k, v)] when k = "X-Workspace-Source" -> v
+  | _ -> Alcotest.fail "expected single X-Workspace-Source header"
+
+let test_header_project () =
+  let v = header_value (W.source_header `Project) in
+  Alcotest.(check string) "project" "project" v
+
+let test_header_playground () =
+  let v = header_value (W.source_header (`Playground "alpha")) in
+  Alcotest.(check string) "playground encoding" "playground:alpha" v
+
+let test_header_playground_missing () =
+  let v = header_value (W.source_header (`PlaygroundMissing "alpha")) in
+  Alcotest.(check string) "missing encoding" "playground_missing:alpha" v
+
+let test_header_keeper_unknown () =
+  let v = header_value (W.source_header (`KeeperUnknown "ghost")) in
+  Alcotest.(check string) "unknown encoding" "keeper_unknown:ghost" v
+
 let () =
   Alcotest.run "workspace_routes_keeper"
     [ ( "classify_keeper_query"
@@ -128,5 +151,11 @@ let () =
         ; Alcotest.test_case "playground exists" `Quick test_playground_resolved
         ; Alcotest.test_case "playground missing" `Quick test_playground_missing
         ; Alcotest.test_case "name trimmed"      `Quick test_keeper_name_trimmed
+        ] )
+    ; ( "source_header"
+      , [ Alcotest.test_case "project"           `Quick test_header_project
+        ; Alcotest.test_case "playground"        `Quick test_header_playground
+        ; Alcotest.test_case "playground missing" `Quick test_header_playground_missing
+        ; Alcotest.test_case "keeper unknown"    `Quick test_header_keeper_unknown
         ] )
     ]


### PR DESCRIPTION
## Summary

Backend split of #12934 — adds the `X-Workspace-Source` response header to the four keeper-aware workspace routes so the frontend can render a fallback notice without parsing the JSON body.

The original PR #12934 became architecturally stale after main #12921 (IDE mock → real data coordinator) refactored `IdeExplorer` to a props-based component with external data injection. This PR ships only the backend half, which is conflict-free against the new architecture; the frontend hint will land as a follow-up rebuilt on top of the data-coordinator pattern.

## Encoding

| Tag | Meaning |
|---|---|
| `project` | no keeper / empty / whitespace; or keeper resolved cleanly to project root |
| `playground:<name>` | keeper meta + playground dir present |
| `playground_missing:<name>` | meta exists, directory missing |
| `keeper_unknown:<name>` | no meta for that keeper name |

Error responses keep using the plain `json_response` helper without the header — only successful resolutions advertise their source.

## Why this design

- **Header, not body** — keeps the wire shape unchanged; existing clients ignore it, new clients opt in.
- **Encoded in a single field** — `<tag>` or `<tag>:<keeper>`. Single string parse on the frontend, single match on the backend. No JSON nesting.
- **Helper function exposed** — `source_header` lives in the `.mli` so the encoding can be unit-tested without spinning up an HTTP fixture.

## Tests

`test_workspace_routes_keeper.ml` extended from 7 to 11 cases:
- Existing `classify_keeper_query` group: 7 cases (unchanged)
- New `source_header` group: 4 cases — one per variant of the encoding

```
$ dune exec test/test_workspace_routes_keeper.exe
11 tests run · Test Successful in 0.002s
```

## Test plan

- [x] OCaml unit tests pass (11/11)
- [ ] CI Build/Lint green
- [ ] Best Programmer self-review notes resolved
- [ ] Frontend follow-up PR opened (decoder + EXPLORER hint on data-coordinator)
- [ ] `human-approved-ready` label applied by reviewer before Ready transition (Draft Auto-Merge Guard requires human approval for agent-authored PRs)

## Out of scope

- Frontend `parseWorkspaceSource` decoder + `SourceHint` UX — separate PR after this lands.
- Editor pane source surfacing — separate PR.
- HTTP-fixture integration test for the actual header on the wire — current tests cover the helper, not route wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)