### PR TITLE
feat(keeper): admission router shadow-mode + lazy init (PR-E-1.6 + 1.7)

### DIFF
--- a/lib/keeper/keeper_admission_glue.ml
+++ b/lib/keeper/keeper_admission_glue.ml
@@ -33,3 +33,23 @@ let decide ~keeper_id ~policies ~buckets =
     | Some policy ->
         let decision = Keeper_admission_router.schedule ~policy ~buckets in
         New_admission decision
+
+(* Shadow-mode decision: compute the router outcome WITHOUT consulting
+   [MASC_ADMISSION_USE_NEW] and WITHOUT consuming bucket tokens.
+
+   This exists because RFC-0026 PR-E-1.6 ships in shadow mode by
+   default (flag off).  [decide] short-circuits to [Legacy_path] when
+   the flag is off, which would defeat the purpose of the
+   [metric_keeper_admission_shadow_outcome] counter — we'd only see
+   the [legacy] label.  PR-E-1.8 reads the dispatch/wait/surface
+   distribution from this counter to decide when to flip the flag,
+   so we need real outcomes regardless of flag state.
+
+   Flag still gates whether the result is APPLIED (caller checks
+   [decide]).  This function only COMPUTES. *)
+let decide_shadow ~keeper_id ~policies ~buckets =
+  match policies keeper_id with
+  | None -> Legacy_path
+  | Some policy ->
+      let decision = Keeper_admission_router.schedule_peek ~policy ~buckets in
+      New_admission decision

--- a/lib/keeper/keeper_admission_glue.mli
+++ b/lib/keeper/keeper_admission_glue.mli
@@ -70,3 +70,26 @@ val decide :
     Pure-ish: the only side effect is the bucket decrement inside
     [try_acquire] when Dispatch fires — same contract as the router
     itself.  No global mutation. *)
+
+val decide_shadow :
+  keeper_id:string ->
+  policies:policy_lookup ->
+  buckets:Keeper_admission_router.bucket_lookup ->
+  outcome
+(** Shadow-mode decision (RFC-0026 PR-E-1.6).
+
+    Computes the router outcome the live system WOULD produce, without
+    consulting [MASC_ADMISSION_USE_NEW] and without consuming bucket
+    tokens.  Calls [Keeper_admission_router.schedule_peek], which uses
+    [tokens_available] in place of [try_acquire].
+
+    Returns:
+    - [Legacy_path] when no policy is registered for [keeper_id].
+    - [New_admission Dispatch _] when a candidate has [>= 1.0] tokens.
+    - [New_admission Wait] when above-floor candidates exist but are
+      all currently empty.
+    - [New_admission (Surface _)] for misconfiguration.
+
+    Side effect: lazy refill on the inspected bucket(s) (mutates
+    [last_refill_at] only — does not consume a token).  Safe to call
+    every turn from the heartbeat loop while the flag is off. *)

--- a/lib/keeper/keeper_admission_router.ml
+++ b/lib/keeper/keeper_admission_router.ml
@@ -80,3 +80,44 @@ let schedule ~policy ~buckets =
       (match walk 0 above_floor with
        | Surface All_candidates_throttled -> Wait
        | other -> other)
+
+(* Non-mutating variant of [schedule] for shadow-mode observation.
+   Mirrors the walk above but uses [KPTB.tokens_available >= 1.0] in
+   place of [KPTB.try_acquire].  Returns the decision the live
+   scheduler WOULD have produced without consuming a token.
+
+   Note: [tokens_available] performs a lazy refill (mutates
+   [last_refill_at] inside the bucket) but does not consume.  That
+   side effect is fine for shadow — it's exactly what would happen
+   on a real call too. *)
+let schedule_peek ~policy ~buckets =
+  let preferred = KAP.top_provider policy in
+  let above_floor = KAP.candidates_above_min_tier policy in
+  let rec walk count = function
+    | [] ->
+        if count = 0 then Surface Min_tier_unsatisfiable
+        else Surface All_candidates_throttled
+    | (c : KAP.candidate) :: rest -> (
+        match buckets c.provider with
+        | None -> walk count rest
+        | Some bucket ->
+            if KPTB.tokens_available bucket >= 1.0 then
+              let drift =
+                {
+                  preferred_provider = preferred;
+                  actual_provider = c.provider;
+                  tier = c.tier;
+                  reason =
+                    classify_reason ~preferred ~actual:c.provider ~tier:c.tier;
+                }
+              in
+              Dispatch { candidate = c; drift }
+            else
+              walk (count + 1) rest)
+  in
+  match above_floor with
+  | [] -> Surface Min_tier_unsatisfiable
+  | _ ->
+      (match walk 0 above_floor with
+       | Surface All_candidates_throttled -> Wait
+       | other -> other)

--- a/lib/keeper/keeper_admission_router.mli
+++ b/lib/keeper/keeper_admission_router.mli
@@ -103,6 +103,27 @@ val schedule :
     inside the bucket; [policy] is immutable; [buckets] is a function
     the caller is responsible for making safe. *)
 
+val schedule_peek :
+  policy:Keeper_admission_policy.t ->
+  buckets:bucket_lookup ->
+  decision
+(** Non-mutating variant of [schedule] for shadow-mode observation
+    (RFC-0026 PR-E-1.6).  Returns the decision [schedule] would have
+    produced without consuming a token.
+
+    Differs from [schedule] in exactly one place: instead of
+    [Keeper_provider_token_bucket.try_acquire] it queries
+    [Keeper_provider_token_bucket.tokens_available] and treats
+    [>= 1.0] as "would dispatch".
+
+    Side effect: [tokens_available] performs a lazy refill (updates
+    the bucket's [last_refill_at] timestamp) but does not consume a
+    token.  This matches what a live call would observe.
+
+    Use case: shadow-mode counter emission while
+    [MASC_ADMISSION_USE_NEW] is off, so we can read the would-be
+    decision distribution without affecting live admission. *)
+
 (** {1 Drift classification helpers} *)
 
 val classify_reason :

--- a/lib/keeper/keeper_admission_runtime.ml
+++ b/lib/keeper/keeper_admission_runtime.ml
@@ -3,14 +3,29 @@
 let no_policy : Keeper_admission_glue.policy_lookup = fun _ -> None
 let no_bucket : Keeper_admission_router.bucket_lookup = fun _ -> None
 
-let policy_lookup_ref : Keeper_admission_glue.policy_lookup ref = ref no_policy
-let bucket_lookup_ref : Keeper_admission_router.bucket_lookup ref = ref no_bucket
+(* Use [Atomic.t] for callback refs, matching the convention in
+   [Coord_hooks] (lib/coord/coord_hooks.ml).  Plain [ref] is not safe
+   across domains in OCaml 5; the Atomic primitives provide the
+   release/acquire semantics we want for cross-fiber callback swaps. *)
+let policy_lookup_ref : Keeper_admission_glue.policy_lookup Atomic.t =
+  Atomic.make no_policy
+let bucket_lookup_ref : Keeper_admission_router.bucket_lookup Atomic.t =
+  Atomic.make no_bucket
 
+(* Three-state init flag.  We hold [init_mutex] only while transitioning
+   between states — never across the file I/O step.
+
+     Idle      : nothing tried yet.  Eligible to take ownership.
+     In_progress : one fiber is reading cascade.json right now.  Other
+                   fibers see this and skip without blocking.
+     Done      : registry installed (or load failed and we logged).
+                 Subsequent calls are no-ops. *)
+type init_state = Idle | In_progress | Done
 let init_mutex = Stdlib.Mutex.create ()
-let init_done = ref false
+let init_state = ref Idle
 
-let set_policy_lookup f = policy_lookup_ref := f
-let set_bucket_lookup f = bucket_lookup_ref := f
+let set_policy_lookup f = Atomic.set policy_lookup_ref f
+let set_bucket_lookup f = Atomic.set bucket_lookup_ref f
 
 (* Lazy per-provider bucket table.  PR-E-1.8 will replace the
    hard-coded defaults with per-provider rate config sourced from
@@ -43,45 +58,76 @@ let make_lazy_bucket_lookup () =
           Hashtbl.add table provider b;
           Some b)
 
-let init_once_from_base_path ~base_path =
+(* Try to claim the init slot.  Returns [true] if this fiber should
+   run the load now; [false] if another fiber is already running or
+   has already finished.  Mutex is held only for the state read and
+   transition, never across the file I/O. *)
+let try_claim_init () =
   Stdlib.Mutex.protect init_mutex (fun () ->
-    if !init_done then ()
-    else begin
-      init_done := true;
-      let cascade_json_path =
-        Filename.concat (Filename.concat base_path ".masc/config")
-          "cascade.json"
-      in
-      match Cascade_config_loader.load_json cascade_json_path with
-      | Error msg ->
-          Log.Keeper.warn
-            "RFC-0026 PR-E-1.6: cascade.json load failed (%s); \
-             admission registry stays empty, observe will return \
-             Legacy_path"
-            msg
-      | Ok json ->
-          let registry, errors =
-            Keeper_admission_registry.load_from_json json
-          in
-          List.iter
-            (fun (e : Keeper_admission_registry.load_error) ->
-              Log.Keeper.warn
-                "RFC-0026 PR-E-1.6: admission policy parse failed for \
-                 keeper=%s"
-                e.keeper_id)
-            errors;
-          let registered = Keeper_admission_registry.size registry in
-          set_policy_lookup (fun id ->
-            Keeper_admission_registry.lookup registry id);
-          set_bucket_lookup (make_lazy_bucket_lookup ());
-          Log.Keeper.info
-            "RFC-0026 PR-E-1.6: admission runtime initialised \
-             (policies=%d, errors=%d, base_path=%s)"
-            registered (List.length errors) base_path
-    end)
+    match !init_state with
+    | Done -> false
+    | In_progress -> false
+    | Idle ->
+        init_state := In_progress;
+        true)
 
-let policy_lookup keeper_id = !policy_lookup_ref keeper_id
-let bucket_lookup provider = !bucket_lookup_ref provider
+let mark_init_done () =
+  Stdlib.Mutex.protect init_mutex (fun () -> init_state := Done)
+
+(* Failure path: revert to Idle so a future heartbeat tick can retry.
+   Without this, a transient I/O hiccup at startup would pin the
+   process in legacy mode for its lifetime. *)
+let revert_init_to_idle () =
+  Stdlib.Mutex.protect init_mutex (fun () -> init_state := Idle)
+
+let init_once_from_base_path ~base_path =
+  if not (try_claim_init ()) then ()
+  else begin
+    (* I/O outside the critical section.  [Cascade_config_loader.load_json]
+       can call [Eio.traceln] and may block on disk — holding [init_mutex]
+       across that risks domain-wide stalls of any other fiber that hits
+       this code. *)
+    let cascade_json_path =
+      Filename.concat (Filename.concat base_path ".masc/config")
+        "cascade.json"
+    in
+    match Cascade_config_loader.load_json cascade_json_path with
+    | Error msg ->
+        (* Transient or permanent read failure — leave registry empty,
+           revert to Idle so the next heartbeat tick can retry. *)
+        revert_init_to_idle ();
+        Log.Keeper.warn
+          "RFC-0026 PR-E-1.6: cascade.json load failed (%s); \
+           admission registry stays empty, observe will return \
+           Legacy_path (will retry on next tick)"
+          msg
+    | Ok json ->
+        let registry, errors =
+          Keeper_admission_registry.load_from_json json
+        in
+        List.iter
+          (fun (e : Keeper_admission_registry.load_error) ->
+            Log.Keeper.warn
+              "RFC-0026 PR-E-1.6: admission policy parse failed for \
+               keeper=%s"
+              e.keeper_id)
+          errors;
+        let registered = Keeper_admission_registry.size registry in
+        (* Install lookups via Atomic.set, then mark Done.  Order
+           matters: a parallel fiber reading [policy_lookup] should
+           never observe Done with the default [no_policy]. *)
+        set_policy_lookup (fun id ->
+          Keeper_admission_registry.lookup registry id);
+        set_bucket_lookup (make_lazy_bucket_lookup ());
+        mark_init_done ();
+        Log.Keeper.info
+          "RFC-0026 PR-E-1.6: admission runtime initialised \
+           (policies=%d, errors=%d, base_path=%s)"
+          registered (List.length errors) base_path
+  end
+
+let policy_lookup keeper_id = (Atomic.get policy_lookup_ref) keeper_id
+let bucket_lookup provider = (Atomic.get bucket_lookup_ref) provider
 
 let outcome_label (outcome : Keeper_admission_glue.outcome) : string =
   match outcome with
@@ -93,8 +139,12 @@ let outcome_label (outcome : Keeper_admission_glue.outcome) : string =
        | Keeper_admission_router.Surface _ -> "surface")
 
 let observe ~keeper_id =
+  (* Use [decide_shadow] (not [decide]): we want the would-be outcome
+     regardless of [MASC_ADMISSION_USE_NEW], and we must not consume
+     bucket tokens since the legacy semaphore path still owns
+     dispatch.  See keeper_admission_glue.mli for the rationale. *)
   let outcome =
-    Keeper_admission_glue.decide
+    Keeper_admission_glue.decide_shadow
       ~keeper_id
       ~policies:policy_lookup
       ~buckets:bucket_lookup
@@ -106,6 +156,6 @@ let observe ~keeper_id =
 
 let reset_for_test () =
   Stdlib.Mutex.protect init_mutex (fun () ->
-    policy_lookup_ref := no_policy;
-    bucket_lookup_ref := no_bucket;
-    init_done := false)
+    Atomic.set policy_lookup_ref no_policy;
+    Atomic.set bucket_lookup_ref no_bucket;
+    init_state := Idle)

--- a/lib/keeper/keeper_admission_runtime.ml
+++ b/lib/keeper/keeper_admission_runtime.ml
@@ -1,0 +1,111 @@
+(* See keeper_admission_runtime.mli for documentation. *)
+
+let no_policy : Keeper_admission_glue.policy_lookup = fun _ -> None
+let no_bucket : Keeper_admission_router.bucket_lookup = fun _ -> None
+
+let policy_lookup_ref : Keeper_admission_glue.policy_lookup ref = ref no_policy
+let bucket_lookup_ref : Keeper_admission_router.bucket_lookup ref = ref no_bucket
+
+let init_mutex = Stdlib.Mutex.create ()
+let init_done = ref false
+
+let set_policy_lookup f = policy_lookup_ref := f
+let set_bucket_lookup f = bucket_lookup_ref := f
+
+(* Lazy per-provider bucket table.  PR-E-1.8 will replace the
+   hard-coded defaults with per-provider rate config sourced from
+   cascade.toml.  For PR-E-1.6+1.7 we just want every provider name
+   referenced by an [admission.<keeper>].candidates entry to map to a
+   non-empty bucket so [Keeper_admission_router.schedule] can return
+   [Dispatch] / [Wait] in the shadow counter — same shape it will
+   take in PR-E-1.8 once rates are real. *)
+let default_bucket_capacity = 10
+let default_bucket_refill_rate = 1.0
+let now () = Unix.gettimeofday ()
+
+let make_lazy_bucket_lookup () =
+  let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t =
+    Hashtbl.create 16
+  in
+  let table_mutex = Stdlib.Mutex.create () in
+  fun provider ->
+    Stdlib.Mutex.protect table_mutex (fun () ->
+      match Hashtbl.find_opt table provider with
+      | Some b -> Some b
+      | None ->
+          let b =
+            Keeper_provider_token_bucket.create
+              ~provider
+              ~capacity:default_bucket_capacity
+              ~refill_rate:default_bucket_refill_rate
+              ~now
+          in
+          Hashtbl.add table provider b;
+          Some b)
+
+let init_once_from_base_path ~base_path =
+  Stdlib.Mutex.protect init_mutex (fun () ->
+    if !init_done then ()
+    else begin
+      init_done := true;
+      let cascade_json_path =
+        Filename.concat (Filename.concat base_path ".masc/config")
+          "cascade.json"
+      in
+      match Cascade_config_loader.load_json cascade_json_path with
+      | Error msg ->
+          Log.Keeper.warn
+            "RFC-0026 PR-E-1.6: cascade.json load failed (%s); \
+             admission registry stays empty, observe will return \
+             Legacy_path"
+            msg
+      | Ok json ->
+          let registry, errors =
+            Keeper_admission_registry.load_from_json json
+          in
+          List.iter
+            (fun (e : Keeper_admission_registry.load_error) ->
+              Log.Keeper.warn
+                "RFC-0026 PR-E-1.6: admission policy parse failed for \
+                 keeper=%s"
+                e.keeper_id)
+            errors;
+          let registered = Keeper_admission_registry.size registry in
+          set_policy_lookup (fun id ->
+            Keeper_admission_registry.lookup registry id);
+          set_bucket_lookup (make_lazy_bucket_lookup ());
+          Log.Keeper.info
+            "RFC-0026 PR-E-1.6: admission runtime initialised \
+             (policies=%d, errors=%d, base_path=%s)"
+            registered (List.length errors) base_path
+    end)
+
+let policy_lookup keeper_id = !policy_lookup_ref keeper_id
+let bucket_lookup provider = !bucket_lookup_ref provider
+
+let outcome_label (outcome : Keeper_admission_glue.outcome) : string =
+  match outcome with
+  | Keeper_admission_glue.Legacy_path -> "legacy"
+  | Keeper_admission_glue.New_admission decision ->
+      (match decision with
+       | Keeper_admission_router.Dispatch _ -> "dispatch"
+       | Keeper_admission_router.Wait -> "wait"
+       | Keeper_admission_router.Surface _ -> "surface")
+
+let observe ~keeper_id =
+  let outcome =
+    Keeper_admission_glue.decide
+      ~keeper_id
+      ~policies:policy_lookup
+      ~buckets:bucket_lookup
+  in
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_admission_shadow_outcome
+    ~labels:[("keeper", keeper_id); ("outcome", outcome_label outcome)] ();
+  outcome
+
+let reset_for_test () =
+  Stdlib.Mutex.protect init_mutex (fun () ->
+    policy_lookup_ref := no_policy;
+    bucket_lookup_ref := no_bucket;
+    init_done := false)

--- a/lib/keeper/keeper_admission_runtime.mli
+++ b/lib/keeper/keeper_admission_runtime.mli
@@ -17,15 +17,16 @@
       -> [set_bucket_lookup]
 
     This module is the shadow-mode shim.  [observe] calls
-    [Keeper_admission_glue.decide] and increments the
-    [metric_keeper_admission_shadow_outcome] counter so we can read a
-    24h distribution of "what would the new router have done" before
-    any real swap. *)
+    [Keeper_admission_glue.decide_shadow] (not [decide]) and increments
+    the [metric_keeper_admission_shadow_outcome] counter so we can read
+    a 24h distribution of "what would the new router have done" before
+    any real swap.  The shadow path bypasses [MASC_ADMISSION_USE_NEW]
+    and does not consume tokens. *)
 
 (** {1 First-call lazy init} *)
 
 val init_once_from_base_path : base_path:string -> unit
-(** Idempotent init.  First call:
+(** Idempotent init.  First successful call:
       1. Reads [<base_path>/.masc/config/cascade.json] via
          [Cascade_config_loader.load_json] (mtime-cached).
       2. Builds [Keeper_admission_registry] from the [admission]
@@ -34,24 +35,30 @@ val init_once_from_base_path : base_path:string -> unit
       4. Sets [bucket_lookup] to a lazy per-provider hashtbl (default
          capacity 10, refill 1.0 RPS — PR-E-1.8 makes this
          configurable per-provider from cascade rate-limit blocks).
-    Subsequent calls are no-ops.
+    Once installed, subsequent calls are no-ops.
 
-    Safe to invoke from multiple keeper fibers — internal state is
-    guarded by [Mutex.protect].  Failures are logged via
-    [Log.Keeper.warn] and do not raise; the registry stays empty,
-    the call site continues to return [Legacy_path]. *)
+    Concurrency model: a three-state flag (Idle/In_progress/Done) is
+    guarded by a [Mutex.protect] that is held ONLY across state
+    transitions, never across the file I/O step.  This prevents
+    domain-wide stalls when [Cascade_config_loader.load_json] traces
+    via [Eio.traceln] or blocks on disk.
+
+    Failure model: a transient load failure logs via [Log.Keeper.warn],
+    reverts the flag to Idle, and returns.  The next heartbeat tick
+    re-enters and retries.  Until the registry is installed, the call
+    site continues to return [Legacy_path]. *)
 
 (** {1 Lookup registration (alternative entry, e.g. for tests)} *)
 
 val set_policy_lookup : Keeper_admission_glue.policy_lookup -> unit
 (** Replace the policy lookup function.  PR-E-1.7 calls this once at
-    startup with [Keeper_admission_registry.lookup registry].  Idempotent;
-    last call wins. *)
+    startup with [Keeper_admission_registry.lookup registry].  Replaces
+    the lookup atomically; last call wins. *)
 
 val set_bucket_lookup : Keeper_admission_router.bucket_lookup -> unit
 (** Replace the bucket lookup function.  PR-E-1.7 calls this once at
     startup with a [Hashtbl.find_opt] over the provider table.
-    Idempotent; last call wins. *)
+    Replaces the lookup atomically; last call wins. *)
 
 (** {1 Read-only access for the heartbeat loop} *)
 
@@ -66,21 +73,27 @@ val bucket_lookup : Keeper_admission_router.bucket_lookup
 (** {1 Shadow-mode observation} *)
 
 val observe : keeper_id:string -> Keeper_admission_glue.outcome
-(** Call [Keeper_admission_glue.decide] with the registered lookups
-    and increment [metric_keeper_admission_shadow_outcome] with one of
-    four label values: ["legacy"], ["dispatch"], ["wait"], ["surface"].
+(** Call [Keeper_admission_glue.decide_shadow] with the registered
+    lookups and increment [metric_keeper_admission_shadow_outcome]
+    with one of four label values: ["legacy"], ["dispatch"], ["wait"],
+    ["surface"].
 
     The caller is expected to *ignore* the returned outcome for now —
     PR-E-1.6 always falls through to the existing
     [Keeper_turn_slot.with_keeper_turn_slot] path.  PR-E-1.7 swaps in
     the real handler.
 
-    Side effects: Prometheus counter increment only.  No log line per
-    call (heartbeat already prints one INFO/skip per turn; doubling
-    the volume is noise). *)
+    Side effects:
+    - Prometheus counter increment.
+    - Lazy refill of inspected token buckets ([tokens_available]
+      mutates [last_refill_at]; does NOT consume tokens).
+
+    No log line per call (heartbeat already prints one INFO/skip per
+    turn; doubling the volume is noise). *)
 
 (** {1 Test seam} *)
 
 val reset_for_test : unit -> unit
-(** Reset both lookup functions to the default [fun _ -> None].
-    Tests only — production code never calls this. *)
+(** Reset both lookup functions to the default [fun _ -> None] and
+    clear the init state.  Tests only — production code never calls
+    this. *)

--- a/lib/keeper/keeper_admission_runtime.mli
+++ b/lib/keeper/keeper_admission_runtime.mli
@@ -1,0 +1,86 @@
+(** Runtime singletons for the new admission router (RFC-0026 PR-E-1.6).
+
+    Holds two lookup functions that [Keeper_admission_glue.decide] needs:
+
+      - [policy_lookup]  — keeper_id -> Keeper_admission_policy.t option
+      - [bucket_lookup]  — provider  -> Keeper_provider_token_bucket.t option
+
+    Both default to a constant [fun _ -> None].  The default is the
+    "no policies registered yet" state — [decide] returns [Legacy_path]
+    in that case, so the call site is safe to invoke before any
+    registration happens.
+
+    Population path (PR-E-1.7, separate PR):
+      cascade_config_loader -> Keeper_admission_registry.load_from_json
+      -> [set_policy_lookup]
+      provider rate-limit table -> per-provider [Keeper_provider_token_bucket.create]
+      -> [set_bucket_lookup]
+
+    This module is the shadow-mode shim.  [observe] calls
+    [Keeper_admission_glue.decide] and increments the
+    [metric_keeper_admission_shadow_outcome] counter so we can read a
+    24h distribution of "what would the new router have done" before
+    any real swap. *)
+
+(** {1 First-call lazy init} *)
+
+val init_once_from_base_path : base_path:string -> unit
+(** Idempotent init.  First call:
+      1. Reads [<base_path>/.masc/config/cascade.json] via
+         [Cascade_config_loader.load_json] (mtime-cached).
+      2. Builds [Keeper_admission_registry] from the [admission]
+         sub-object.
+      3. Sets [policy_lookup] to [Keeper_admission_registry.lookup].
+      4. Sets [bucket_lookup] to a lazy per-provider hashtbl (default
+         capacity 10, refill 1.0 RPS — PR-E-1.8 makes this
+         configurable per-provider from cascade rate-limit blocks).
+    Subsequent calls are no-ops.
+
+    Safe to invoke from multiple keeper fibers — internal state is
+    guarded by [Mutex.protect].  Failures are logged via
+    [Log.Keeper.warn] and do not raise; the registry stays empty,
+    the call site continues to return [Legacy_path]. *)
+
+(** {1 Lookup registration (alternative entry, e.g. for tests)} *)
+
+val set_policy_lookup : Keeper_admission_glue.policy_lookup -> unit
+(** Replace the policy lookup function.  PR-E-1.7 calls this once at
+    startup with [Keeper_admission_registry.lookup registry].  Idempotent;
+    last call wins. *)
+
+val set_bucket_lookup : Keeper_admission_router.bucket_lookup -> unit
+(** Replace the bucket lookup function.  PR-E-1.7 calls this once at
+    startup with a [Hashtbl.find_opt] over the provider table.
+    Idempotent; last call wins. *)
+
+(** {1 Read-only access for the heartbeat loop} *)
+
+val policy_lookup : Keeper_admission_glue.policy_lookup
+(** Current policy lookup.  Returns [None] for every keeper until
+    [set_policy_lookup] is called. *)
+
+val bucket_lookup : Keeper_admission_router.bucket_lookup
+(** Current bucket lookup.  Returns [None] for every provider until
+    [set_bucket_lookup] is called. *)
+
+(** {1 Shadow-mode observation} *)
+
+val observe : keeper_id:string -> Keeper_admission_glue.outcome
+(** Call [Keeper_admission_glue.decide] with the registered lookups
+    and increment [metric_keeper_admission_shadow_outcome] with one of
+    four label values: ["legacy"], ["dispatch"], ["wait"], ["surface"].
+
+    The caller is expected to *ignore* the returned outcome for now —
+    PR-E-1.6 always falls through to the existing
+    [Keeper_turn_slot.with_keeper_turn_slot] path.  PR-E-1.7 swaps in
+    the real handler.
+
+    Side effects: Prometheus counter increment only.  No log line per
+    call (heartbeat already prints one INFO/skip per turn; doubling
+    the volume is noise). *)
+
+(** {1 Test seam} *)
+
+val reset_for_test : unit -> unit
+(** Reset both lookup functions to the default [fun _ -> None].
+    Tests only — production code never calls this. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -588,6 +588,25 @@ let run_keepalive_unified_turn
           ~keeper_name:meta_after_triage.name
           ~channel:turn_decision.channel
           ~kind:Semaphore_wait_pending;
+        (* RFC-0026 PR-E-1.6+1.7 shadow: ask the new admission router
+           what it WOULD have decided, increment the shadow outcome
+           counter, then fall through to the existing semaphore path
+           unchanged.
+
+           [init_once_from_base_path] populates the registry from
+           [<base_path>/.masc/config/cascade.json] [admission.*]
+           sub-tables on first call.  When the JSON has no admission
+           blocks the registry stays empty and [observe] returns
+           [Legacy_path] always — counter increment still proves the
+           call site is alive.  When admission blocks are present,
+           the counter starts emitting the [dispatch]/[wait]/[surface]
+           label distribution that PR-E-1.8 will act on. *)
+        Keeper_admission_runtime.init_once_from_base_path
+          ~base_path:ctx.config.base_path;
+        let (_ : Keeper_admission_glue.outcome) =
+          Keeper_admission_runtime.observe
+            ~keeper_id:meta_after_triage.name
+        in
         match
           Keeper_turn_slot.with_keeper_turn_slot ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -470,6 +470,16 @@ let metric_keeper_tool_emission_pushes =
 let metric_keeper_path_rejection =
   "masc_keeper_path_rejection_total"
 
+(* RFC-0026 PR-E-1.6 admission router shadow observation
+   (keeper_admission_runtime.ml). Labels:
+     - keeper:  keeper_id
+     - outcome: legacy | dispatch | wait | surface
+
+   "legacy" dominates until PR-E-1.7 wires the registry + bucket
+   lookups via [Keeper_admission_runtime.set_*_lookup]. *)
+let metric_keeper_admission_shadow_outcome =
+  "masc_keeper_admission_shadow_outcome_total"
+
 (* Keeper keepalive (keeper_keepalive.ml). *)
 let metric_keeper_heartbeat_successes =
   "masc_keeper_heartbeat_successes_total"
@@ -1281,6 +1291,14 @@ let init () =
     "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;
   add metric_keeper_operator_clear
     "Total operator-invoked masc_keeper_clear calls (labels: preserve_system=true|false)" Counter;
+  (* RFC-0026 PR-E-1.6 admission router shadow observation.
+     Emitted by keeper_admission_runtime.observe before the existing
+     [Keeper_turn_slot.with_keeper_turn_slot] call. *)
+  add metric_keeper_admission_shadow_outcome
+    "RFC-0026 PR-E-1.6 admission router shadow observation \
+     (labels: keeper, outcome=legacy|dispatch|wait|surface). \
+     [legacy] dominates until PR-E-1.7 wires registry+bucket lookups."
+    Counter;
   (* Keeper heartbeat metrics — emitted by keeper_keepalive.ml *)
   add metric_keeper_heartbeat_successes
     "Total keeper heartbeat successes" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -197,6 +197,10 @@ val metric_keeper_operator_clear : string
     [kind="out_of_roots"|"not_found_relative"]. *)
 val metric_keeper_path_rejection : string
 
+val metric_keeper_admission_shadow_outcome : string
+(** RFC-0026 PR-E-1.6 shadow observation. Counter; labels
+    [keeper] and [outcome \in {legacy, dispatch, wait, surface}]. *)
+
 val metric_keeper_heartbeat_successes : string
 val metric_keeper_heartbeat_failures : string
 val metric_keeper_cleanup_tracking_failures : string

--- a/test/dune
+++ b/test/dune
@@ -1070,6 +1070,7 @@
 (include stanzas/test_k3_tool_pipeline_e2e.inc)
 (include stanzas/test_keeper_admission_policy.inc)
 (include stanzas/test_keeper_admission_router.inc)
+(include stanzas/test_keeper_admission_runtime.inc)
 (include stanzas/test_keeper_alerting_path_norms.inc)
 (include stanzas/test_keeper_auto_pause_blocker_persist_12683.inc)
 (include stanzas/test_keeper_agent_run_sandbox_source.inc)

--- a/test/stanzas/test_keeper_admission_runtime.inc
+++ b/test/stanzas/test_keeper_admission_runtime.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_admission_runtime)
+ (modules test_keeper_admission_runtime)
+ (libraries masc_mcp alcotest))

--- a/test/test_keeper_admission_runtime.ml
+++ b/test/test_keeper_admission_runtime.ml
@@ -1,12 +1,14 @@
 (** Unit tests for Keeper_admission_runtime (RFC-0026 PR-E-1.6).
 
-    The shadow-mode shim has three behaviors worth pinning:
+    The shadow-mode shim has these behaviors worth pinning:
     - default lookups return [None] (no policies registered)
     - [observe] returns [Legacy_path] when no policy is registered
-    - [set_policy_lookup] / [set_bucket_lookup] are idempotent and
-      observable through the public lookups
-    - flag-off behavior matches flag-on with [None] policy
-      (both produce [Legacy_path])
+    - [set_policy_lookup] / [set_bucket_lookup] replace atomically
+      and are observable through the public lookups
+    - [observe] uses the shadow path: when a policy IS registered,
+      it returns [New_admission ...] regardless of
+      [MASC_ADMISSION_USE_NEW] flag state, and does not consume
+      bucket tokens.
 
     The Prometheus counter increment is a side effect that lives in
     Prometheus_test territory; we verify the *outcome* the counter is
@@ -137,6 +139,37 @@ let test_init_creates_lazy_bucket_lookup () =
   | Some a, Some b -> Alcotest.(check bool) "stable identity" true (a == b)
   | _ -> Alcotest.fail "expected Some bucket on both lookups"
 
+(* ------------------------------------------------------------------ *)
+(* Shadow-mode observation                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* When a policy + bucket are registered, [observe] must return
+   [New_admission ...] WITHOUT consulting [MASC_ADMISSION_USE_NEW]
+   (flag is unset in CI by default, but [decide_shadow] bypasses it).
+   And critically, the bucket must still be full afterward — shadow
+   mode peeks via [tokens_available], it does not [try_acquire]. *)
+let test_observe_with_policy_returns_new_admission_without_flag () =
+  KAR.reset_for_test ();
+  let policy = make_policy "anthropic" in
+  KAR.set_policy_lookup (fun id ->
+    if id = "k1" then Some policy else None);
+  let bucket = KPTB.create ~provider:"anthropic"
+      ~capacity:5 ~refill_rate:1.0 ~now in
+  let tokens_before = KPTB.tokens_available bucket in
+  KAR.set_bucket_lookup (fun p ->
+    if p = "anthropic" then Some bucket else None);
+  let outcome = KAR.observe ~keeper_id:"k1" in
+  (match outcome with
+   | Keeper_admission_glue.New_admission _ -> ()
+   | Keeper_admission_glue.Legacy_path ->
+       Alcotest.fail
+         "observe with policy registered must return New_admission \
+          (shadow path bypasses MASC_ADMISSION_USE_NEW)");
+  let tokens_after = KPTB.tokens_available bucket in
+  Alcotest.(check (float 0.001))
+    "shadow observation does not consume tokens"
+    tokens_before tokens_after
+
 let () =
   Alcotest.run "keeper_admission_runtime"
     [
@@ -153,7 +186,7 @@ let () =
             test_set_policy_lookup_observable;
           Alcotest.test_case "set_bucket_lookup observable" `Quick
             test_set_bucket_lookup_observable;
-          Alcotest.test_case "set_*_lookup is idempotent (last wins)" `Quick
+          Alcotest.test_case "set_*_lookup replaces atomically (last wins)" `Quick
             test_set_lookup_is_idempotent_last_wins;
         ] );
       ( "reset",
@@ -165,5 +198,13 @@ let () =
         [
           Alcotest.test_case "lazy bucket lookup is stable per provider"
             `Quick test_init_creates_lazy_bucket_lookup;
+        ] );
+      ( "shadow",
+        [
+          Alcotest.test_case
+            "observe with policy returns New_admission without flag \
+             and does not consume tokens"
+            `Quick
+            test_observe_with_policy_returns_new_admission_without_flag;
         ] );
     ]

--- a/test/test_keeper_admission_runtime.ml
+++ b/test/test_keeper_admission_runtime.ml
@@ -1,0 +1,169 @@
+(** Unit tests for Keeper_admission_runtime (RFC-0026 PR-E-1.6).
+
+    The shadow-mode shim has three behaviors worth pinning:
+    - default lookups return [None] (no policies registered)
+    - [observe] returns [Legacy_path] when no policy is registered
+    - [set_policy_lookup] / [set_bucket_lookup] are idempotent and
+      observable through the public lookups
+    - flag-off behavior matches flag-on with [None] policy
+      (both produce [Legacy_path])
+
+    The Prometheus counter increment is a side effect that lives in
+    Prometheus_test territory; we verify the *outcome* the counter is
+    keyed off, not the counter itself. *)
+
+open Masc_mcp
+module KAR = Keeper_admission_runtime
+module KAP = Keeper_admission_policy
+module KPTB = Keeper_provider_token_bucket
+
+let now_ref = ref 0.0
+let now () = !now_ref
+
+let make_policy provider =
+  let candidate : KAP.candidate =
+    { provider; model = "m"; tier = KAP.Preferred }
+  in
+  match
+    KAP.of_fields ~keeper_id:"k1"
+      ~candidates:[candidate] ~weight:1 ~min_tier:KAP.Preferred
+  with
+  | Ok p -> p
+  | Error _ -> Alcotest.fail "of_fields rejected test policy"
+
+(* ------------------------------------------------------------------ *)
+(* Default state                                                       *)
+(* ------------------------------------------------------------------ *)
+
+let test_default_lookups_return_none () =
+  KAR.reset_for_test ();
+  Alcotest.(check (option pass))
+    "policy_lookup default = None" None
+    (KAR.policy_lookup "any-keeper");
+  Alcotest.(check (option pass))
+    "bucket_lookup default = None" None
+    (KAR.bucket_lookup "any-provider")
+
+let test_observe_default_is_legacy_path () =
+  KAR.reset_for_test ();
+  let outcome = KAR.observe ~keeper_id:"k1" in
+  match outcome with
+  | Keeper_admission_glue.Legacy_path -> ()
+  | Keeper_admission_glue.New_admission _ ->
+      Alcotest.fail "observe with no registered policy must return Legacy_path"
+
+(* ------------------------------------------------------------------ *)
+(* Registration                                                        *)
+(* ------------------------------------------------------------------ *)
+
+let test_set_policy_lookup_observable () =
+  KAR.reset_for_test ();
+  let policy = make_policy "anthropic" in
+  KAR.set_policy_lookup (fun id ->
+    if id = "k1" then Some policy else None);
+  Alcotest.(check bool)
+    "policy_lookup k1 returns Some" true
+    (KAR.policy_lookup "k1" |> Option.is_some);
+  Alcotest.(check (option pass))
+    "policy_lookup k2 returns None" None
+    (KAR.policy_lookup "k2")
+
+let test_set_bucket_lookup_observable () =
+  KAR.reset_for_test ();
+  let bucket = KPTB.create ~provider:"anthropic"
+      ~capacity:1 ~refill_rate:1.0 ~now in
+  KAR.set_bucket_lookup (fun p ->
+    if p = "anthropic" then Some bucket else None);
+  Alcotest.(check bool)
+    "bucket_lookup anthropic returns Some" true
+    (KAR.bucket_lookup "anthropic" |> Option.is_some);
+  Alcotest.(check (option pass))
+    "bucket_lookup other returns None" None
+    (KAR.bucket_lookup "other")
+
+let test_set_lookup_is_idempotent_last_wins () =
+  KAR.reset_for_test ();
+  let policy_a = make_policy "anthropic" in
+  let policy_b = make_policy "openai" in
+  KAR.set_policy_lookup (fun _ -> Some policy_a);
+  KAR.set_policy_lookup (fun _ -> Some policy_b);
+  let candidates =
+    KAR.policy_lookup "k1"
+    |> Option.map KAP.candidates
+    |> Option.value ~default:[]
+  in
+  let providers = List.map (fun (c : KAP.candidate) -> c.provider) candidates in
+  Alcotest.(check (list string))
+    "last set wins" ["openai"] providers
+
+(* ------------------------------------------------------------------ *)
+(* Reset                                                               *)
+(* ------------------------------------------------------------------ *)
+
+let test_reset_for_test_clears_lookups () =
+  let policy = make_policy "p" in
+  KAR.set_policy_lookup (fun _ -> Some policy);
+  KAR.set_bucket_lookup (fun _ ->
+    Some (KPTB.create ~provider:"p" ~capacity:1 ~refill_rate:1.0 ~now));
+  KAR.reset_for_test ();
+  Alcotest.(check (option pass))
+    "policy cleared" None (KAR.policy_lookup "k");
+  Alcotest.(check (option pass))
+    "bucket cleared" None (KAR.bucket_lookup "p")
+
+(* ------------------------------------------------------------------ *)
+(* Lazy bucket lookup wired by init                                     *)
+(* ------------------------------------------------------------------ *)
+
+let test_init_creates_lazy_bucket_lookup () =
+  KAR.reset_for_test ();
+  KAR.set_bucket_lookup (
+    let table : (string, KPTB.t) Hashtbl.t = Hashtbl.create 4 in
+    let now () = !now_ref in
+    fun provider ->
+      match Hashtbl.find_opt table provider with
+      | Some b -> Some b
+      | None ->
+          let b = KPTB.create ~provider ~capacity:10 ~refill_rate:1.0 ~now in
+          Hashtbl.add table provider b;
+          Some b);
+  let b1 = KAR.bucket_lookup "anthropic" in
+  let b2 = KAR.bucket_lookup "anthropic" in
+  Alcotest.(check bool) "first lookup creates bucket"
+    true (Option.is_some b1);
+  Alcotest.(check bool) "second lookup returns same bucket"
+    true (Option.is_some b2);
+  match b1, b2 with
+  | Some a, Some b -> Alcotest.(check bool) "stable identity" true (a == b)
+  | _ -> Alcotest.fail "expected Some bucket on both lookups"
+
+let () =
+  Alcotest.run "keeper_admission_runtime"
+    [
+      ( "defaults",
+        [
+          Alcotest.test_case "default lookups return None" `Quick
+            test_default_lookups_return_none;
+          Alcotest.test_case "observe default = Legacy_path" `Quick
+            test_observe_default_is_legacy_path;
+        ] );
+      ( "registration",
+        [
+          Alcotest.test_case "set_policy_lookup observable" `Quick
+            test_set_policy_lookup_observable;
+          Alcotest.test_case "set_bucket_lookup observable" `Quick
+            test_set_bucket_lookup_observable;
+          Alcotest.test_case "set_*_lookup is idempotent (last wins)" `Quick
+            test_set_lookup_is_idempotent_last_wins;
+        ] );
+      ( "reset",
+        [
+          Alcotest.test_case "reset_for_test clears lookups" `Quick
+            test_reset_for_test_clears_lookups;
+        ] );
+      ( "lazy_bucket",
+        [
+          Alcotest.test_case "lazy bucket lookup is stable per provider"
+            `Quick test_init_creates_lazy_bucket_lookup;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

PR-E-1.6 + PR-E-1.7 — combined into one PR for **fast validation** (14 keepers running, no need for staged shadow before real signal).

Adds shadow-mode admission router call to the live heartbeat loop **and** wires the registry from `cascade.json` `[admission.<keeper>]` blocks + lazy per-provider bucket map. The counter `metric_keeper_admission_shadow_outcome` starts emitting a real `outcome` distribution from the first turn after server restart.

**Zero behavior change**: `observe` outcome is bound to `_`, the existing `Keeper_turn_slot.with_keeper_turn_slot` match runs unchanged.

## Live evidence

2026-05-05 02:29-02:30 UTC — 10 keepers stalled with `semaphore_wait > 60s, peers holding slot (cascade=big_three, autonomous_available=14)`. The merged RFC-0026 modules (#12904, #12924, #12926, #12938, #12939) cannot affect runtime until this PR connects the call site.

## What lands

| File | LOC | Purpose |
|---|---|---|
| `lib/keeper/keeper_admission_runtime.{ml,mli}` | +197 | Singleton lookups + `init_once_from_base_path` + `observe` shim |
| `lib/prometheus.{ml,mli}` | +22 | New counter `metric_keeper_admission_shadow_outcome` |
| `lib/keeper/keeper_heartbeat_loop.ml` | +21 | `init_once` + `observe` call before existing match |
| `test/test_keeper_admission_runtime.ml` | +172 | 7 alcotest cases |

## Activation flow

```
Server restart
  → first keeper turn
  → init_once_from_base_path fires
  → reads <base_path>/.masc/config/cascade.json
  → Keeper_admission_registry.load_from_json
  → set_policy_lookup / set_bucket_lookup
  → first observe call returns:
      • Dispatch / Wait / Surface  (admission blocks present)
      • Legacy_path                (admission blocks absent)
  → counter increments by outcome label
  → caller falls through to existing semaphore path
```

## Validation timing (14 keepers active)

After server restart:
- t=0s    init_once fires on first turn
- t=10s   ~5 keepers have been observed, counter emits
- t=60s   all 14 keepers observed, label distribution visible in Prometheus
- t=300s  full distribution stable, sufficient signal for PR-E-1.8 decision

If `~/me/.masc/config/cascade.json` has `[admission.*]` blocks (PR #1089 merged in `~/me`), `dispatch`/`wait`/`surface` labels will increment immediately. If not, only `legacy` increments — still enough to verify the call path is alive.

## Failure modes

- `cascade.json` missing → `Log.Keeper.warn`, registry stays empty, all turns return `Legacy_path`
- `[admission.<keeper>]` parse error → per-keeper warn, other keepers proceed normally
- Bucket lookup miss → lazy-create with default rate 1.0 RPS / capacity 10

## Build verification

Pre-existing main blocker (`keeper_unified_turn` drift) prevents full library link. Per-module byte compile clean for every changed file:

```
$ dune build lib/.masc_mcp.objs/byte/masc_mcp__Keeper_admission_runtime.cmo  ✅
$ dune build lib/.masc_mcp.objs/byte/masc_mcp__Keeper_heartbeat_loop.cmo     ✅
$ dune build lib/.masc_mcp.objs/byte/masc_mcp__Prometheus.cmo                 ✅
$ dune build test/.test_keeper_admission_runtime.eobjs/byte/...cmo           ✅
```

## Test plan

- [x] Per-module byte compile clean
- [x] 7 unit tests covering default state, observe outcome, registration, idempotency, reset, lazy bucket stability
- [ ] Test exe link blocked by main blocker — same as PR-B/C/E
- [ ] Live activation requires server restart (init_once is process-lifetime)

## Stack

After: PR-A #12904, PR-D-3 #12924, PR-B #12926, PR-C #12938, PR-E 1+1.5 #12939, RFC docs #12947 — all MERGED.

This PR: PR-E-1.6 + PR-E-1.7 (shadow + wiring)
Next: PR-E-1.8 (flag-on real swap), PR-E-2 (semaphore retire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
