### PR TITLE
feat(dashboard): CodeMirror 6 read-only editor (Phase 4)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,6 +21,18 @@
     "tokens:check": "node design-system/tokens/scripts/check-equivalence.mjs"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-html": "^6.4.11",
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/merge": "^6.12.1",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.41.1",
     "@formkit/auto-animate": "^0.9.0",
     "@preact/signals": "^2.9.0",
     "cytoscape": "^3.33.2",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -11,6 +11,42 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/commands':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/lang-css':
+        specifier: ^6.3.1
+        version: 6.3.1
+      '@codemirror/lang-html':
+        specifier: ^6.4.11
+        version: 6.4.11
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
+      '@codemirror/lang-json':
+        specifier: ^6.0.2
+        version: 6.0.2
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.0
+        version: 6.5.0
+      '@codemirror/lang-python':
+        specifier: ^6.2.1
+        version: 6.2.1
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
+      '@codemirror/merge':
+        specifier: ^6.12.1
+        version: 6.12.1
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/theme-one-dark':
+        specifier: ^6.1.3
+        version: 6.1.3
+      '@codemirror/view':
+        specifier: ^6.41.1
+        version: 6.41.1
       '@formkit/auto-animate':
         specifier: ^0.9.0
         version: 0.9.0
@@ -274,6 +310,48 @@ packages:
 
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/merge@6.12.1':
+    resolution: {integrity: sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.41.1':
+    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -542,11 +620,41 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/python@1.1.18':
+    resolution: {integrity: sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==}
+
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
 
   '@lit/reactive-element@1.6.3':
     resolution: {integrity: sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@material/mwc-icon@0.25.3':
     resolution: {integrity: sha512-36076AWZIRSr8qYOLjuDDkxej/HA0XAosrj7TS1ZeLlUBnLUtbDtvc1S7KSa0hqez7ouzOqGaWK24yoNnTa2OA==}
@@ -1376,6 +1484,9 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2677,6 +2788,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
@@ -2951,6 +3065,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
@@ -3219,6 +3336,114 @@ snapshots:
 
   '@chevrotain/utils@11.1.2': {}
 
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.18
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/merge@6.12.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
@@ -3418,11 +3643,58 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/python@1.1.18':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lit-labs/ssr-dom-shim@1.5.1': {}
 
   '@lit/reactive-element@1.6.3':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.5.1
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@material/mwc-icon@0.25.3':
     dependencies:
@@ -4258,6 +4530,8 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5690,6 +5964,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  style-mod@4.1.3: {}
+
   stylis@4.3.6: {}
 
   supports-color@7.2.0:
@@ -5917,6 +6193,8 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  w3c-keyname@2.2.8: {}
 
   whatwg-mimetype@3.0.0: {}
 

--- a/dashboard/src/components/ide/ide-diff-view.test.ts
+++ b/dashboard/src/components/ide/ide-diff-view.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import type { UnifiedDiffRow } from '../../api/workspace'
+import { buildSplitDiff } from './ide-diff-view'
+
+const row = (
+  kind: 'context' | 'add' | 'delete',
+  oldLine: number | null,
+  newLine: number | null,
+  text: string,
+): UnifiedDiffRow => ({ kind, oldLine, newLine, text })
+
+describe('buildSplitDiff', () => {
+  it('maps context rows to both sides', () => {
+    const result = buildSplitDiff([
+      row('context', 1, 1, 'unchanged'),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]!.before?.kind).toBe('context')
+    expect(result[0]!.after?.kind).toBe('context')
+    expect(result[0]!.before?.text).toBe('unchanged')
+  })
+
+  it('pairs deletes with adds', () => {
+    const result = buildSplitDiff([
+      row('delete', 1, null, 'old line'),
+      row('add', null, 1, 'new line'),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]!.before?.kind).toBe('delete')
+    expect(result[0]!.before?.text).toBe('old line')
+    expect(result[0]!.after?.kind).toBe('add')
+    expect(result[0]!.after?.text).toBe('new line')
+  })
+
+  it('handles unequal delete/add counts', () => {
+    const result = buildSplitDiff([
+      row('delete', 1, null, 'a'),
+      row('delete', 2, null, 'b'),
+      row('add', null, 1, 'c'),
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0]!.before?.text).toBe('a')
+    expect(result[0]!.after?.text).toBe('c')
+    expect(result[1]!.before?.text).toBe('b')
+    expect(result[1]!.after).toBeNull()
+  })
+
+  it('handles mixed context and changes', () => {
+    const result = buildSplitDiff([
+      row('context', 1, 1, 'keep'),
+      row('delete', 2, null, 'gone'),
+      row('add', null, 2, 'here'),
+      row('context', 3, 3, 'keep2'),
+    ])
+    expect(result).toHaveLength(3)
+    expect(result[0]!.before?.text).toBe('keep')
+    expect(result[1]!.before?.text).toBe('gone')
+    expect(result[1]!.after?.text).toBe('here')
+    expect(result[2]!.before?.text).toBe('keep2')
+  })
+
+  it('returns empty for no rows', () => {
+    expect(buildSplitDiff([])).toEqual([])
+  })
+
+  it('handles only adds', () => {
+    const result = buildSplitDiff([
+      row('add', null, 1, 'added'),
+      row('add', null, 2, 'more'),
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0]!.before).toBeNull()
+    expect(result[0]!.after?.text).toBe('added')
+    expect(result[1]!.before).toBeNull()
+    expect(result[1]!.after?.text).toBe('more')
+  })
+})

--- a/dashboard/src/components/ide/ide-diff-view.ts
+++ b/dashboard/src/components/ide/ide-diff-view.ts
@@ -1,0 +1,188 @@
+import { html } from 'htm/preact'
+import type { UnifiedDiffRow } from '../../api/workspace'
+
+// ── Shared diff types ─────────────────────────────────────────────
+
+type DiffTone = 'context' | 'add' | 'delete'
+
+interface SplitDiffCell {
+  readonly line: number | null
+  readonly text: string
+  readonly kind: DiffTone
+}
+
+export interface SplitDiffRow {
+  readonly before: SplitDiffCell | null
+  readonly after: SplitDiffCell | null
+}
+
+// ── Unified diff view ─────────────────────────────────────────────
+
+export function UnifiedDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
+  return html`
+    <ol
+      aria-label="Unified diff preview"
+      style=${{
+        listStyle: 'none',
+        padding: 'var(--sp-2) 0',
+        margin: 0,
+        overflow: 'auto',
+        fontFamily: 'var(--font-mono)',
+        fontSize: 'var(--fs-13)',
+        lineHeight: 1.6,
+      }}
+    >
+      ${rows.map(row => html`
+        <li
+          style=${{
+            display: 'grid',
+            gridTemplateColumns: '32px 40px 40px minmax(0, 1fr)',
+            gap: 'var(--sp-2)',
+            alignItems: 'center',
+            padding: '0 var(--sp-3)',
+            background: diffBackground(row.kind),
+            color: row.kind === 'delete' ? 'var(--color-status-danger, var(--color-fg-secondary))' : 'var(--color-fg-secondary)',
+          }}
+        >
+          <span style=${{ color: diffMarkerColor(row.kind), textAlign: 'center' }}>${diffMarker(row.kind)}</span>
+          <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${row.oldLine ?? ''}</span>
+          <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${row.newLine ?? ''}</span>
+          <span style=${{ whiteSpace: 'pre', minWidth: 0 }}>${row.text}</span>
+        </li>
+      `)}
+    </ol>
+  `
+}
+
+// ── Split diff view ───────────────────────────────────────────────
+
+export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
+  const splitRows: SplitDiffRow[] = buildSplitDiff(rows)
+  return html`
+    <div
+      aria-label="Split diff preview"
+      style=${{
+        display: 'grid',
+        gridTemplateRows: 'auto 1fr',
+        minHeight: 0,
+        overflow: 'hidden',
+        fontFamily: 'var(--font-mono)',
+        fontSize: 'var(--fs-13)',
+        lineHeight: 1.6,
+      }}
+    >
+      <div
+        style=${{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+          borderBottom: '1px solid var(--color-border-divider)',
+          font: 'var(--type-eyebrow)',
+          color: 'var(--color-fg-muted)',
+          background: 'var(--color-bg-surface)',
+        }}
+      >
+        <span style=${{ padding: 'var(--sp-2) var(--sp-3)' }}>BEFORE</span>
+        <span style=${{ padding: 'var(--sp-2) var(--sp-3)', borderLeft: '1px solid var(--color-border-divider)' }}>AFTER</span>
+      </div>
+      <div style=${{ overflow: 'auto' }}>
+        ${splitRows.map(row => html`
+          <div
+            style=${{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+            }}
+          >
+            <${SplitDiffCellView} cell=${row.before} />
+            <${SplitDiffCellView} cell=${row.after} framed=${true} />
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+function SplitDiffCellView({
+  cell,
+  framed = false,
+}: {
+  readonly cell: SplitDiffCell | null
+  readonly framed?: boolean
+}) {
+  const kind = cell?.kind ?? 'context'
+  return html`
+    <div
+      style=${{
+        display: 'grid',
+        gridTemplateColumns: '40px 24px minmax(0, 1fr)',
+        gap: 'var(--sp-2)',
+        alignItems: 'center',
+        minHeight: '24px',
+        padding: '0 var(--sp-3)',
+        borderLeft: framed ? '1px solid var(--color-border-divider)' : undefined,
+        background: cell ? diffBackground(kind) : 'var(--color-bg-muted)',
+        color: kind === 'delete' ? 'var(--color-status-danger, var(--color-fg-secondary))' : 'var(--color-fg-secondary)',
+      }}
+    >
+      <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${cell?.line ?? ''}</span>
+      <span style=${{ color: diffMarkerColor(kind), textAlign: 'center' }}>${cell ? diffMarker(kind) : ''}</span>
+      <span style=${{ whiteSpace: 'pre', minWidth: 0 }}>${cell?.text ?? ''}</span>
+    </div>
+  `
+}
+
+// ── Diff helpers ──────────────────────────────────────────────────
+
+function diffMarker(kind: string): string {
+  if (kind === 'add') return '+'
+  if (kind === 'delete') return '-'
+  return ' '
+}
+
+function diffBackground(kind: string): string {
+  if (kind === 'add') return 'var(--color-status-ok-bg, var(--color-bg-surface))'
+  if (kind === 'delete') return 'var(--color-status-danger-bg, var(--color-bg-surface))'
+  return 'transparent'
+}
+
+function diffMarkerColor(kind: string): string {
+  if (kind === 'add') return 'var(--color-status-ok, var(--ok))'
+  if (kind === 'delete') return 'var(--color-status-danger, var(--danger))'
+  return 'var(--color-fg-disabled)'
+}
+
+// ── Split diff builder ────────────────────────────────────────────
+
+export function buildSplitDiff(rows: ReadonlyArray<UnifiedDiffRow>): SplitDiffRow[] {
+  const result: SplitDiffRow[] = []
+  const adds: UnifiedDiffRow[] = []
+  const deletes: UnifiedDiffRow[] = []
+  for (const row of rows) {
+    if (row.kind === 'context') {
+      flushPending()
+      result.push({
+        before: { kind: 'context', line: row.oldLine, text: row.text },
+        after: { kind: 'context', line: row.newLine, text: row.text },
+      })
+    } else if (row.kind === 'delete') {
+      deletes.push(row)
+    } else if (row.kind === 'add') {
+      adds.push(row)
+    }
+  }
+  flushPending()
+  return result
+
+  function flushPending(): void {
+    const max = Math.max(deletes.length, adds.length)
+    for (let i = 0; i < max; i++) {
+      const del = deletes[i]
+      const add = adds[i]
+      result.push({
+        before: del ? { kind: 'delete', line: del.oldLine, text: del.text } : null,
+        after: add ? { kind: 'add', line: add.newLine, text: add.text } : null,
+      })
+    }
+    deletes.length = 0
+    adds.length = 0
+  }
+}

--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import {
+  readOnlyExt,
+  themeExt,
+  languageExt,
+  blameExtensions,
+  pushOwnership,
+  setOwnership,
+} from './ide-editor-extensions'
+import type { LineOwnership } from './keeper-line-ownership-store'
+
+function createTestView(extensions: ReturnType<typeof readOnlyExt>[]) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const state = EditorState.create({ doc: 'hello\nworld\n', extensions })
+  const view = new EditorView({ state, parent: container })
+  return { view, container }
+}
+
+describe('readOnlyExt', () => {
+  it('blocks all changes', () => {
+    const { view } = createTestView([readOnlyExt()])
+    const len = view.state.doc.length
+    view.dispatch({ changes: { from: 0, to: len, insert: 'changed' } })
+    expect(view.state.doc.toString()).toBe('hello\nworld\n')
+    view.destroy()
+  })
+})
+
+describe('themeExt', () => {
+  it('returns a non-empty extension', () => {
+    const ext = themeExt()
+    expect(ext).toBeDefined()
+    const { view, container } = createTestView([ext])
+    expect(view.dom).toBeInstanceOf(HTMLElement)
+    view.destroy()
+    container.remove()
+  })
+})
+
+describe('languageExt', () => {
+  it('returns empty extension for unknown file types', async () => {
+    const ext = await languageExt('readme.xyz')
+    expect(ext).toEqual([])
+  })
+
+  it('returns a language extension for .ts files', async () => {
+    const ext = await languageExt('index.ts')
+    expect(Array.isArray(ext) ? ext.length : ext).toBeDefined()
+  })
+
+  it('returns a language extension for .py files', async () => {
+    const ext = await languageExt('main.py')
+    expect(ext).toBeDefined()
+  })
+
+  it('returns a language extension for .json files', async () => {
+    const ext = await languageExt('package.json')
+    expect(ext).toBeDefined()
+  })
+})
+
+describe('blameExtensions', () => {
+  it('returns an array of extensions', () => {
+    const exts = blameExtensions()
+    expect(Array.isArray(exts)).toBe(true)
+    expect(exts.length).toBeGreaterThan(0)
+  })
+})
+
+describe('pushOwnership + setOwnership effect', () => {
+  it('dispatches ownership data without error', () => {
+    const exts = [readOnlyExt(), ...blameExtensions()]
+    const { view, container } = createTestView(exts)
+
+    const ownership = new Map([
+      [1, { keeper_id: 'alpha', hue_index: 0, last_edit_kind: 'write', last_edit_ms: Date.now() }],
+      [2, { keeper_id: 'beta', hue_index: 1, last_edit_kind: 'edit', last_edit_ms: Date.now() }],
+    ]) as ReadonlyMap<number, LineOwnership>
+
+    expect(() => pushOwnership(view, ownership)).not.toThrow()
+    expect(view.state.doc.toString()).toBe('hello\nworld\n')
+
+    view.destroy()
+    container.remove()
+  })
+
+  it('setOwnership effect carries the ownership map', () => {
+    const ownership = new Map([
+      [1, { keeper_id: 'gamma', hue_index: 2, last_edit_kind: 'write', last_edit_ms: 1000 }],
+    ]) as unknown as ReadonlyMap<number, LineOwnership>
+    const effect = (setOwnership as any).of(ownership)
+    expect((effect as any).is(setOwnership)).toBe(true)
+    expect((effect as any).value).toBe(ownership)
+    expect((effect as any).value.get(1)?.keeper_id).toBe('gamma')
+  })
+})

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -1,0 +1,194 @@
+import { EditorView, GutterMarker, gutter } from '@codemirror/view'
+import { EditorState, Extension, StateField, StateEffect } from '@codemirror/state'
+import type { LineOwnership } from './keeper-line-ownership-store'
+
+// ── Read-only lock ────────────────────────────────────────────────
+// Prevents all user input. CM6 6.x uses EditorState.changeFilter.
+
+export function readOnlyExt(): Extension {
+  return EditorState.changeFilter.of(() => false)
+}
+
+// ── Theme from design-system CSS variables ────────────────────────
+// Maps semantic tokens to CM6 theme facets so the editor matches the
+// dashboard light/dark theme without a hardcoded theme object.
+
+export function themeExt(): Extension {
+  return EditorView.theme({
+    '&': {
+      background: 'var(--color-bg-page)',
+      color: 'var(--color-fg-secondary)',
+      fontFamily: 'var(--font-mono)',
+      fontSize: 'var(--fs-13)',
+      lineHeight: '1.6',
+    },
+    '.cm-content': {
+      caretColor: 'transparent',
+      padding: 'var(--sp-2) 0',
+    },
+    '.cm-line': {
+      padding: '0 var(--sp-3)',
+    },
+    '.cm-gutters': {
+      background: 'var(--color-bg-page)',
+      color: 'var(--color-fg-disabled)',
+      border: 'none',
+      fontSize: 'var(--fs-11)',
+      minWidth: '40px',
+    },
+    '.cm-gutterElement': {
+      textAlign: 'right',
+      paddingRight: 'var(--sp-2)',
+    },
+    '&.cm-focused': {
+      outline: 'none',
+    },
+    '.cm-cursor': {
+      display: 'none',
+    },
+    '.cm-selectionBackground': {
+      background: 'transparent !important',
+    },
+  })
+}
+
+// ── Blame gutter ──────────────────────────────────────────────────
+// Left gutter showing keeper ownership per line. Uses a StateEffect
+// to push ownership updates into the gutter marker.
+
+interface BlameMarkerValue {
+  readonly keeperId: string
+  readonly hueIndex: number
+  readonly editKind: string
+}
+
+class BlameMarker extends GutterMarker {
+  constructor(private readonly info: BlameMarkerValue | null) {
+    super()
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span')
+    if (!this.info) {
+      el.textContent = '—'
+      el.style.color = 'var(--color-fg-disabled)'
+      el.style.fontSize = 'var(--fs-11)'
+      return el
+    }
+    const color = `var(--color-keeper-${this.info.hueIndex}-glow, var(--k-${this.info.hueIndex}))`
+    el.textContent = this.info.keeperId
+    el.title = `${this.info.keeperId} · ${this.info.editKind}`
+    el.style.color = color
+    el.style.fontSize = 'var(--fs-11)'
+    el.style.maxWidth = '80px'
+    el.style.overflow = 'hidden'
+    el.style.textOverflow = 'ellipsis'
+    el.style.whiteSpace = 'nowrap'
+    return el
+  }
+
+  eq(other: BlameMarker): boolean {
+    if (!this.info && !other.info) return true
+    if (!this.info || !other.info) return false
+    return this.info.keeperId === other.info.keeperId && this.info.editKind === other.info.editKind
+  }
+}
+
+const BLAME_EMPTY = new BlameMarker(null)
+
+const setOwnership = StateEffect.define<ReadonlyMap<number, LineOwnership>>()
+
+const blameMarkerField = StateField.define<BlameMarker[]>({
+  create() {
+    return []
+  },
+  update(markers, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setOwnership)) {
+        const ownership = effect.value
+        const newMarkers: BlameMarker[] = []
+        const doc = tr.state.doc
+        for (let i = 1; i <= doc.lines; i++) {
+          const owner = ownership.get(i)
+          if (owner) {
+            newMarkers.push(new BlameMarker({
+              keeperId: owner.keeper_id,
+              hueIndex: owner.hue_index,
+              editKind: owner.last_edit_kind,
+            }))
+          } else {
+            newMarkers.push(BLAME_EMPTY)
+          }
+        }
+        return newMarkers
+      }
+    }
+    return markers
+  },
+})
+
+function blameGutterExt(): Extension {
+  return [
+    blameMarkerField,
+    gutter({
+      class: 'cm-blame-gutter',
+      lineMarker(view, block) {
+        const line = view.state.doc.lineAt(block.from)
+        const field = view.state.field(blameMarkerField, false)
+        return field?.[line.number - 1] ?? BLAME_EMPTY
+      },
+      initialSpacer: () => BLAME_EMPTY,
+    }),
+  ]
+}
+
+export function pushOwnership(view: EditorView, ownership: ReadonlyMap<number, LineOwnership>): void {
+  view.dispatch({ effects: [setOwnership.of(ownership)] })
+}
+
+// ── Language support (dynamic import) ─────────────────────────────
+
+type LanguageModule = () => Promise<{ extension: Extension }>
+
+const LANGUAGE_MAP: Readonly<Record<string, LanguageModule>> = {
+  '.ts': () => import('@codemirror/lang-javascript').then(m => m.javascript({ typescript: true })),
+  '.tsx': () => import('@codemirror/lang-javascript').then(m => m.javascript({ typescript: true, jsx: true })),
+  '.js': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
+  '.jsx': () => import('@codemirror/lang-javascript').then(m => m.javascript({ jsx: true })),
+  '.py': () => import('@codemirror/lang-python').then(m => m.python()),
+  '.html': () => import('@codemirror/lang-html').then(m => m.html()),
+  '.css': () => import('@codemirror/lang-css').then(m => m.css()),
+  '.json': () => import('@codemirror/lang-json').then(m => m.json()),
+  '.md': () => import('@codemirror/lang-markdown').then(m => m.markdown()),
+  '.ocaml': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
+  '.ml': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
+  '.mli': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
+  '.toml': () => import('@codemirror/lang-json').then(m => m.json()),
+  '.yaml': () => import('@codemirror/lang-json').then(m => m.json()),
+  '.yml': () => import('@codemirror/lang-json').then(m => m.json()),
+}
+
+export async function languageExt(filePath: string): Promise<Extension> {
+  const ext = filePath.slice(filePath.lastIndexOf('.'))
+  const loader = LANGUAGE_MAP[ext]
+  if (!loader) return []
+  try {
+    return await loader()
+  } catch {
+    return []
+  }
+}
+
+// ── Line number gutter ────────────────────────────────────────────
+
+export function lineNumberExt(): Extension {
+  return []
+}
+
+// ── Blame mode extensions bundle ──────────────────────────────────
+
+export function blameExtensions(): Extension[] {
+  return [blameGutterExt()]
+}
+
+export { setOwnership }

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -1,0 +1,324 @@
+import { html } from 'htm/preact'
+import { useRef, useEffect, useState } from 'preact/hooks'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import type {
+  CodeDocumentStore,
+} from './code-document-store'
+import {
+  type KeeperLineOwnershipStore,
+  type LineOwnership,
+} from './keeper-line-ownership-store'
+import type { UnifiedDiffRow } from '../../api/workspace'
+import {
+  readOnlyExt,
+  themeExt,
+  languageExt,
+  blameExtensions,
+  pushOwnership,
+} from './ide-editor-extensions'
+import { SplitDiffView, UnifiedDiffView } from './ide-diff-view'
+
+// ── Types ─────────────────────────────────────────────────────────
+
+const IDE_LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'explode'] as const
+type IdeLayerKind = (typeof IDE_LAYER_ORDER)[number]
+
+export type IdeEditorView = 'source' | 'split-diff' | 'unified' | 'blame'
+
+interface IdeEditorProps {
+  readonly activeView?: IdeEditorView
+  readonly activeLayers?: ReadonlySet<string>
+  readonly documentStore: CodeDocumentStore
+  readonly ownershipStore: KeeperLineOwnershipStore
+  readonly diffRows: () => ReadonlyArray<UnifiedDiffRow>
+}
+
+const EMPTY_ACTIVE_LAYERS: ReadonlySet<string> = new Set()
+
+const VIEW_LABEL: Record<IdeEditorView, string> = {
+  source: 'SOURCE',
+  'split-diff': 'SPLIT DIFF',
+  unified: 'UNIFIED',
+  blame: 'BLAME',
+}
+
+// ── Component ─────────────────────────────────────────────────────
+
+export function IdeEditor({
+  activeView = 'source',
+  activeLayers = EMPTY_ACTIVE_LAYERS,
+  documentStore,
+  ownershipStore,
+  diffRows,
+}: IdeEditorProps) {
+  const document = documentStore.document()
+  const lines = documentStore.lines()
+  const ownership = ownershipStore.ownership()
+  const keepers = ownershipStore.knownKeepers()
+  const activeLayerKinds = activeLayersInDisplayOrder(activeLayers)
+  const currentDiffRows = diffRows()
+
+  return html`
+    <div
+      role="region"
+      aria-label="에디터 (code document store + RFC 0019 ownership)"
+      style=${{
+        display: 'grid',
+        gridTemplateRows: activeLayerKinds.length > 0 ? 'auto auto 1fr' : 'auto 1fr',
+        background: 'var(--color-bg-page)',
+        minHeight: 0,
+      }}
+    >
+      <div
+        style=${{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--sp-3)',
+          padding: 'var(--sp-2) var(--sp-3)',
+          borderBottom: '1px solid var(--color-border-divider)',
+          color: 'var(--color-fg-muted)',
+          font: 'var(--type-eyebrow)',
+        }}
+      >
+        <span>${document.file_path}</span>
+        <span style=${{ color: 'var(--color-fg-disabled)' }}>${document.language}</span>
+        <span style=${{ color: 'var(--color-accent-fg)' }}>${VIEW_LABEL[activeView]}</span>
+        <span style=${{ marginLeft: 'auto' }}>
+          ${lines.length} lines · ownership · ${keepers.length} keepers · ${activeLayerKinds.length} layers
+        </span>
+      </div>
+      ${activeLayerKinds.length > 0
+        ? LayerOverlaySummary(activeLayerKinds, ownership, keepers)
+        : null}
+      ${activeView === 'split-diff'
+        ? SplitDiffView(currentDiffRows)
+        : activeView === 'unified'
+          ? UnifiedDiffView(currentDiffRows)
+          : html`<${CodeMirrorEditor}
+              documentStore=${documentStore}
+              ownershipStore=${ownershipStore}
+              showBlame=${activeView === 'blame'}
+              keepers=${keepers}
+            />`
+      }
+    </div>
+  `
+}
+
+// ── CM6 read-only editor ──────────────────────────────────────────
+// Preact ref-based mount — no vDOM conflict with CM6's DOM management.
+
+function CodeMirrorEditor({
+  documentStore,
+  ownershipStore,
+  showBlame,
+  keepers,
+}: {
+  readonly documentStore: CodeDocumentStore
+  readonly ownershipStore: KeeperLineOwnershipStore
+  readonly showBlame: boolean
+  readonly keepers: ReadonlyArray<string>
+}) {
+  const containerRef = useRef<HTMLElement>(null)
+  const editorRef = useRef<EditorView | null>(null)
+  const [ready, setReady] = useState(false)
+
+  const document = documentStore.document()
+  const ownership = ownershipStore.ownership()
+
+  // Mount CM6 instance
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    let destroyed = false
+
+    async function mount() {
+      const lang = await languageExt(document.file_path)
+      if (destroyed) return
+
+      const blameExts = showBlame ? blameExtensions() : []
+      const state = EditorState.create({
+        doc: document.content,
+        extensions: [
+          readOnlyExt(),
+          themeExt(),
+          lang,
+          ...blameExts,
+        ],
+      })
+
+      const view = new EditorView({
+        state,
+        parent: container!,
+      })
+
+      editorRef.current = view
+      if (showBlame && ownership.size > 0) {
+        pushOwnership(view, ownership)
+      }
+      setReady(true)
+    }
+
+    mount()
+
+    return () => {
+      destroyed = true
+      editorRef.current?.destroy()
+      editorRef.current = null
+      setReady(false)
+    }
+  }, [document.file_path, showBlame])
+
+  // Push document updates
+  useEffect(() => {
+    const view = editorRef.current
+    if (!view || !ready) return
+
+    const currentDoc = view.state.doc.toString()
+    if (currentDoc === document.content) return
+
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: document.content },
+    })
+  }, [document.content, ready])
+
+  // Push ownership updates
+  useEffect(() => {
+    const view = editorRef.current
+    if (!view || !ready || !showBlame) return
+    pushOwnership(view, ownership)
+  }, [ownership, ready, showBlame])
+
+  // Subscribe to store changes for re-render
+  const [, forceRender] = useState(0)
+  useEffect(() => documentStore.subscribe(() => forceRender(n => n + 1)), [documentStore])
+  useEffect(() => ownershipStore.subscribe(() => forceRender(n => n + 1)), [ownershipStore])
+
+  return html`
+    <div style=${{ display: 'grid', gridTemplateRows: showBlame ? 'auto 1fr' : '1fr', minHeight: 0 }}>
+      ${showBlame ? BlameTimeline(ownership, keepers) : null}
+      <div ref=${containerRef} style=${{ overflow: 'auto', minHeight: 0 }} />
+    </div>
+  `
+}
+
+// ── Blame timeline header ─────────────────────────────────────────
+
+function BlameTimeline(
+  ownership: ReadonlyMap<number, LineOwnership>,
+  keepers: ReadonlyArray<string>,
+) {
+  const latestEdit = latestEditMs(ownership)
+  return html`
+    <div
+      role="status"
+      aria-label="Blame timeline"
+      style=${{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--sp-2)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        color: 'var(--color-fg-muted)',
+        background: 'var(--color-bg-surface)',
+        fontSize: 'var(--fs-11)',
+      }}
+    >
+      <span style=${{ font: 'var(--type-eyebrow)', color: 'var(--color-fg-primary)' }}>Blame timeline</span>
+      <span>${keepers.join(' / ')}</span>
+      <span style=${{ marginLeft: 'auto', color: 'var(--color-fg-secondary)' }}>
+        latest ${latestEdit === null ? 'no edits' : formatTime(latestEdit)}
+      </span>
+    </div>
+  `
+}
+
+// ── Layer overlay summary ─────────────────────────────────────────
+
+function LayerOverlaySummary(
+  activeLayerKinds: ReadonlyArray<IdeLayerKind>,
+  ownership: ReadonlyMap<number, LineOwnership>,
+  keepers: ReadonlyArray<string>,
+) {
+  const latestEdit = latestEditMs(ownership)
+  return html`
+    <div
+      role="status"
+      aria-label="Active IDE overlays"
+      style=${{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--sp-2)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        color: 'var(--color-fg-muted)',
+        background: 'var(--color-bg-surface)',
+        fontSize: 'var(--fs-11)',
+        overflowX: 'auto',
+      }}
+    >
+      <span style=${{ font: 'var(--type-eyebrow)', color: 'var(--color-fg-primary)' }}>Active overlays</span>
+      ${activeLayerKinds.map(kind => html`
+        <span
+          style=${{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 'var(--sp-1)',
+            padding: '1px var(--sp-2)',
+            border: '1px solid var(--color-border-default)',
+            borderRadius: 'var(--r-2)',
+            background: kind === 'explode' ? 'var(--color-bg-muted)' : 'var(--color-bg-elevated)',
+            color: kind === 'explode' ? 'var(--color-accent-fg)' : 'var(--color-fg-secondary)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span>${layerLabel(kind)}</span>
+          <span style=${{ color: 'var(--color-fg-muted)' }}>${layerSummary(kind, latestEdit, keepers)}</span>
+        </span>
+      `)}
+    </div>
+  `
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function activeLayersInDisplayOrder(activeLayers: ReadonlySet<string>): ReadonlyArray<IdeLayerKind> {
+  return IDE_LAYER_ORDER.filter(kind => activeLayers.has(kind))
+}
+
+function latestEditMs(ownership: ReadonlyMap<number, LineOwnership>): number | null {
+  let latest: number | null = null
+  for (const owner of ownership.values()) {
+    if (latest === null || owner.last_edit_ms > latest) latest = owner.last_edit_ms
+  }
+  return latest
+}
+
+function formatTime(ms: number): string {
+  return new Date(ms).toISOString().slice(11, 16)
+}
+
+const LAYER_LABEL: Record<IdeLayerKind, string> = {
+  time: 'Time',
+  parallel: 'Parallel',
+  tools: 'Tools',
+  approve: 'Approve',
+  notes: 'Notes',
+  explode: 'EXPLODE',
+}
+
+function layerLabel(kind: IdeLayerKind): string {
+  return LAYER_LABEL[kind]
+}
+
+function layerSummary(kind: IdeLayerKind, latestEdit: number | null, keepers: ReadonlyArray<string>): string {
+  if (kind === 'time') return latestEdit === null ? 'no edits' : `latest ${formatTime(latestEdit)}`
+  if (kind === 'parallel') return `${keepers.length} keepers`
+  if (kind === 'tools') return '0 anchored'
+  if (kind === 'approve') return '0 approval'
+  if (kind === 'notes') return '0 note'
+  if (kind === 'explode') return 'exclusive ghost view'
+  return ''
+}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -4,7 +4,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { createIdeDataCoordinator } from './ide-data-coordinator'
 import { IdeExplorer } from './ide-explorer'
-import { IdeEditorMock, type IdeEditorView } from './ide-editor-mock'
+import { IdeEditor, type IdeEditorView } from './ide-editor'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 import { IdeActivityMock } from './ide-activity-mock'
 import { IdeInterjectMock } from './ide-interject-mock'
@@ -159,7 +159,7 @@ export function IdeShell() {
             minHeight: 0,
           }}
         >
-          <${IdeEditorMock}
+          <${IdeEditor}
             activeView=${activeView}
             activeLayers=${activeLayers}
             documentStore=${coordinator.documentStore}


### PR DESCRIPTION
## Summary
- Replace mock editor with CM6-based read-only viewer (source, split-diff, unified, blame views)
- Preact ref-based mount to avoid vDOM conflicts with CM6's DOM management
- Dynamic language loading for .ts/.tsx/.js/.jsx/.py/.html/.css/.json/.md
- Blame gutter via StateField + StateEffect for keeper ownership per line
- CSS-variable theme from design system (no hardcoded colors)
- Extract split/unified diff views from ide-editor-mock into standalone module

## Files changed
- **NEW** `ide-editor-extensions.ts` — readOnly lock, theme, blame gutter, language loading
- **NEW** `ide-editor.ts` — IdeEditor component with CM6 CodeMirrorEditor
- **NEW** `ide-diff-view.ts` — extracted split/unified diff rendering
- **NEW** `ide-editor-extensions.test.ts` — 9 tests for CM6 extensions
- **NEW** `ide-diff-view.test.ts` — 6 tests for split diff builder
- **MOD** `ide-shell.ts` — import IdeEditor instead of IdeEditorMock
- **MOD** `package.json` / `pnpm-lock.yaml` — CM6 dependencies

## Verification
- `pnpm typecheck` — 0 new errors (pre-existing errors in unrelated files)
- `pnpm vitest` — 15/15 new tests pass, 567/571 existing tests pass (4 pre-existing failures)
- `pnpm build` — builds successfully

## Plan reference
Phase 4 of `planning/claude-plans/eventual-jingling-tarjan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)