### PR TITLE
feat(dashboard): X-Workspace-Source decoder + EXPLORER fallback hint

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -528,6 +528,40 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
   return data
 }
 
+// Same wire shape as [get<T>] but exposes selected response headers
+// alongside the parsed body. Use when a route returns metadata via
+// header (e.g. [X-Workspace-Source]) so callers can read it without
+// parsing the JSON body or breaking the existing return type.
+//
+// On bootstrap-warm fallback the returned [headers] is empty: warm
+// payloads are synthesized locally and have no upstream response.
+export async function getWithResponse<T>(
+  path: string,
+  opts: GetOptions = {},
+): Promise<{ readonly data: T; readonly headers: Headers }> {
+  const res = await fetchWithTimeout(
+    path,
+    {
+      headers: authHeaders({ includeActor: opts.includeActorHeader }),
+      signal: opts.signal,
+    },
+    opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
+  )
+  if (!res.ok) {
+    const warmPayload = await bootstrapWarmPayload(path, res.clone())
+    if (warmPayload !== null) {
+      return { data: warmPayload as T, headers: new Headers() }
+    }
+    throw await apiRequestErrorFromResponse('GET', path, res)
+  }
+  const data = await parseJsonResponse<T>('GET', path, res)
+  if (DASHBOARD_BOOTSTRAP_WARM_PATHS.has(path) && isNotInitializedEnvelope(data)) {
+    const payload = bootstrapInitializingPayload(path)
+    if (payload !== null) return { data: payload as T, headers: new Headers() }
+  }
+  return { data, headers: res.headers }
+}
+
 export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/dashboard/src/api/workspace-source.test.ts
+++ b/dashboard/src/api/workspace-source.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { parseWorkspaceSource } from './workspace-source'
+
+describe('parseWorkspaceSource', () => {
+  it('treats null header as project', () => {
+    expect(parseWorkspaceSource(null)).toEqual({ kind: 'project' })
+  })
+
+  it('treats empty header as project', () => {
+    expect(parseWorkspaceSource('')).toEqual({ kind: 'project' })
+  })
+
+  it('decodes plain "project" tag', () => {
+    expect(parseWorkspaceSource('project')).toEqual({ kind: 'project' })
+  })
+
+  it('decodes "playground:<name>"', () => {
+    expect(parseWorkspaceSource('playground:alpha'))
+      .toEqual({ kind: 'playground', keeper: 'alpha' })
+  })
+
+  it('decodes "playground_missing:<name>"', () => {
+    expect(parseWorkspaceSource('playground_missing:alpha'))
+      .toEqual({ kind: 'playground_missing', keeper: 'alpha' })
+  })
+
+  it('decodes "keeper_unknown:<name>"', () => {
+    expect(parseWorkspaceSource('keeper_unknown:ghost'))
+      .toEqual({ kind: 'keeper_unknown', keeper: 'ghost' })
+  })
+
+  it('preserves colons inside the keeper name', () => {
+    // Keeper names should not contain ':', but the parser splits on
+    // the first colon only so any trailing colons stay in the name.
+    expect(parseWorkspaceSource('playground:weird:name'))
+      .toEqual({ kind: 'playground', keeper: 'weird:name' })
+  })
+
+  it('falls back to project for unknown tags', () => {
+    expect(parseWorkspaceSource('unrecognized:foo'))
+      .toEqual({ kind: 'project' })
+  })
+
+  it('falls back to project when no colon and not "project"', () => {
+    expect(parseWorkspaceSource('garbage'))
+      .toEqual({ kind: 'project' })
+  })
+})

--- a/dashboard/src/api/workspace-source.ts
+++ b/dashboard/src/api/workspace-source.ts
@@ -1,0 +1,27 @@
+// Decoded form of the [X-Workspace-Source] response header used by
+// the keeper-aware workspace routes. The encoding is mirrored in
+// [Server_routes_http_routes_workspace.source_header] and lets
+// the dashboard render a fallback notice when the requested keeper
+// resolved to project root (missing playground dir or unknown
+// keeper meta).
+export type WorkspaceSource =
+  | { kind: 'project' }
+  | { kind: 'playground'; keeper: string }
+  | { kind: 'playground_missing'; keeper: string }
+  | { kind: 'keeper_unknown'; keeper: string }
+
+// Decode the [X-Workspace-Source] header value. Unknown / null /
+// empty / malformed inputs collapse to [{ kind: 'project' }] so
+// callers never need to handle a "header missing" branch.
+export function parseWorkspaceSource(header: string | null): WorkspaceSource {
+  if (!header) return { kind: 'project' }
+  if (header === 'project') return { kind: 'project' }
+  const colon = header.indexOf(':')
+  if (colon === -1) return { kind: 'project' }
+  const tag = header.slice(0, colon)
+  const keeper = header.slice(colon + 1)
+  if (tag === 'playground') return { kind: 'playground', keeper }
+  if (tag === 'playground_missing') return { kind: 'playground_missing', keeper }
+  if (tag === 'keeper_unknown') return { kind: 'keeper_unknown', keeper }
+  return { kind: 'project' }
+}

--- a/dashboard/src/api/workspace.test.ts
+++ b/dashboard/src/api/workspace.test.ts
@@ -13,11 +13,16 @@ afterEach(() => {
 
 const mockFetch = vi.fn()
 
-function stubFetch(response: unknown, ok = true): void {
+function stubFetch(
+  response: unknown,
+  ok = true,
+  headers: Record<string, string> = {},
+): void {
   mockFetch.mockResolvedValue({
     ok,
     status: ok ? 200 : 500,
     statusText: ok ? 'OK' : 'Internal Server Error',
+    headers: new Headers(headers),
     json: () => Promise.resolve(response),
     text: () => Promise.resolve(JSON.stringify(response)),
     clone() { return this },
@@ -26,13 +31,14 @@ function stubFetch(response: unknown, ok = true): void {
 }
 
 describe('workspace API', () => {
-  it('fetchWorkspaceTree returns file nodes', async () => {
+  it('fetchWorkspaceTree returns file nodes and project source by default', async () => {
     const nodes = [{ path: 'lib/main.ml', label: 'main.ml', depth: 1, parent: 'lib', hasChildren: false, diff: null, keeperId: null, hueIndex: null }]
     stubFetch(nodes)
 
     const result = await fetchWorkspaceTree(2)
-    expect(result).toHaveLength(1)
-    expect(result[0].path).toBe('lib/main.ml')
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].path).toBe('lib/main.ml')
+    expect(result.source).toEqual({ kind: 'project' })
 
     expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/workspace/tree?depth=2')
   })
@@ -42,6 +48,23 @@ describe('workspace API', () => {
 
     await fetchWorkspaceTree(1, { keeper: 'sangsu' })
     expect(mockFetch.mock.calls[0][0]).toContain('keeper=sangsu')
+  })
+
+  it('fetchWorkspaceTree decodes X-Workspace-Source playground header', async () => {
+    stubFetch([], true, { 'X-Workspace-Source': 'playground:alpha' })
+
+    const result = await fetchWorkspaceTree(1, { keeper: 'alpha' })
+    expect(result.source).toEqual({ kind: 'playground', keeper: 'alpha' })
+  })
+
+  it('fetchWorkspaceTree decodes X-Workspace-Source fallback variants', async () => {
+    stubFetch([], true, { 'X-Workspace-Source': 'playground_missing:beta' })
+    expect((await fetchWorkspaceTree(1, { keeper: 'beta' })).source)
+      .toEqual({ kind: 'playground_missing', keeper: 'beta' })
+
+    stubFetch([], true, { 'X-Workspace-Source': 'keeper_unknown:ghost' })
+    expect((await fetchWorkspaceTree(1, { keeper: 'ghost' })).source)
+      .toEqual({ kind: 'keeper_unknown', keeper: 'ghost' })
   })
 
   it('fetchWorkspaceFile returns file content', async () => {

--- a/dashboard/src/api/workspace.ts
+++ b/dashboard/src/api/workspace.ts
@@ -1,5 +1,13 @@
-import { get, type GetOptions } from './core'
+import { get, getWithResponse, type GetOptions } from './core'
 import type { FileTreeNode } from '../components/ide/file-tree-store'
+import { parseWorkspaceSource, type WorkspaceSource } from './workspace-source'
+
+export type { WorkspaceSource } from './workspace-source'
+
+export interface WorkspaceTreeResult {
+  readonly nodes: ReadonlyArray<FileTreeNode>
+  readonly source: WorkspaceSource
+}
 
 // --- Blame ---
 
@@ -41,15 +49,19 @@ function keeperParam(keeper: string | undefined): string {
   return keeper ? `&keeper=${encodeURIComponent(keeper)}` : ''
 }
 
-export function fetchWorkspaceTree(
+export async function fetchWorkspaceTree(
   depth: number,
   opts: WorkspaceApiOptions = {},
-): Promise<ReadonlyArray<FileTreeNode>> {
+): Promise<WorkspaceTreeResult> {
   const keeper = keeperParam(opts.keeper)
-  return get<ReadonlyArray<FileTreeNode>>(
+  const { data, headers } = await getWithResponse<ReadonlyArray<FileTreeNode>>(
     `/api/v1/workspace/tree?depth=${depth}${keeper}`,
     opts,
   )
+  return {
+    nodes: data,
+    source: parseWorkspaceSource(headers.get('X-Workspace-Source')),
+  }
 }
 
 export function fetchWorkspaceFile(

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -7,6 +7,7 @@ import {
   fetchGitDiff,
   fetchWorkspaceTree,
   type UnifiedDiffRow,
+  type WorkspaceSource,
 } from '../../api/workspace'
 import {
   createCodeDocumentStore,
@@ -28,6 +29,8 @@ export interface IdeDataCoordinator {
   readonly fileTreeStore: FileTreeStore
   readonly diffRows: () => ReadonlyArray<UnifiedDiffRow>
   readonly subscribeDiffRows: (listener: () => void) => () => void
+  readonly workspaceSource: () => WorkspaceSource
+  readonly subscribeWorkspaceSource: (listener: () => void) => () => void
   readonly dispose: () => void
 }
 
@@ -41,6 +44,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
   const fileTreeStore = createFileTreeStore()
 
   const diffRowsSignal = signal<ReadonlyArray<UnifiedDiffRow>>([])
+  const workspaceSourceSignal = signal<WorkspaceSource>({ kind: 'project' })
 
   let abortController = new AbortController()
 
@@ -60,9 +64,10 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     const opts = { keeper: keeperParam, signal }
 
     // Load file tree
-    fetchWorkspaceTree(2, opts).then(nodes => {
+    fetchWorkspaceTree(2, opts).then(({ nodes, source }) => {
       if (signal.aborted) return
       fileTreeStore.seed(nodes)
+      workspaceSourceSignal.value = source
     }).catch(() => {})
 
     // Load file content
@@ -105,6 +110,14 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     fileTreeStore,
     diffRows: () => diffRowsSignal.value,
     subscribeDiffRows: diffRowsSignal.subscribe as (listener: () => void) => () => void,
+    workspaceSource: () => workspaceSourceSignal.value,
+    // Wrap [Signal.subscribe] in an arrow so [this] stays bound when
+    // the property is destructured by callers (the [as (listener: () =>
+    // void) => () => void] cast on a method reference loses [this] and
+    // crashes with "Cannot read properties of undefined" inside the
+    // signal core's internal tracking).
+    subscribeWorkspaceSource: (listener: () => void) =>
+      workspaceSourceSignal.subscribe(listener),
     dispose: () => {
       abortController.abort()
       disposeEffect()

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -3,14 +3,35 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import { activeKeeperName } from '../../keeper-state'
 import { type FileTreeStore, type FileTreeNode } from './file-tree-store'
 import { activeIdeFile } from './ide-shell'
+import type { WorkspaceSource } from '../../api/workspace-source'
 
 interface IdeExplorerProps {
   readonly fileTreeStore: FileTreeStore
+  // Optional source-hint wiring: when provided, [SourceHint] renders a
+  // small status block under the EXPLORER header on
+  // [playground_missing] / [keeper_unknown] resolutions. Decoded from
+  // the [X-Workspace-Source] header by the data coordinator. When
+  // omitted (e.g. tests), the hint stays hidden — default is
+  // [{ kind: 'project' }] which renders nothing.
+  readonly workspaceSource?: () => WorkspaceSource
+  readonly subscribeWorkspaceSource?: (listener: () => void) => () => void
 }
 
-export function IdeExplorer({ fileTreeStore: store }: IdeExplorerProps) {
+export function IdeExplorer({
+  fileTreeStore: store,
+  workspaceSource,
+  subscribeWorkspaceSource,
+}: IdeExplorerProps) {
   const [keeperName, setKeeperName] = useState(activeKeeperName.value)
   useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
+
+  const [source, setSource] = useState<WorkspaceSource>(
+    workspaceSource ? workspaceSource() : { kind: 'project' },
+  )
+  useEffect(() => {
+    if (!subscribeWorkspaceSource || !workspaceSource) return
+    return subscribeWorkspaceSource(() => setSource(workspaceSource()))
+  }, [subscribeWorkspaceSource, workspaceSource])
 
   const [tick, setTick] = useState(0)
   useEffect(() => {
@@ -51,6 +72,7 @@ export function IdeExplorer({ fileTreeStore: store }: IdeExplorerProps) {
         <span>EXPLORER ${keeperName ? html`· <span style=${{ color: 'var(--color-accent-fg)' }}>@${keeperName}</span>` : '· project'}</span>
         <span>${fileCount} FILES</span>
       </header>
+      ${SourceHint(source)}
       <ul
         role="tree"
         aria-label="File tree"
@@ -62,6 +84,27 @@ export function IdeExplorer({ fileTreeStore: store }: IdeExplorerProps) {
         }))}
       </ul>
     </div>
+  `
+}
+
+function SourceHint(source: WorkspaceSource) {
+  if (source.kind === 'project' || source.kind === 'playground') return null
+  const message = source.kind === 'playground_missing'
+    ? `@${source.keeper} 의 playground 디렉토리가 아직 없어 프로젝트 트리로 fallback`
+    : `@${source.keeper} 키퍼 메타를 찾지 못해 프로젝트 트리로 fallback`
+  return html`
+    <div
+      role="status"
+      aria-live="polite"
+      style=${{
+        font: 'var(--type-body)',
+        fontSize: 'var(--fs-11)',
+        color: 'var(--color-fg-muted)',
+        background: 'var(--color-bg-muted)',
+        padding: 'var(--sp-1) var(--sp-2)',
+        borderRadius: 'var(--r-1)',
+      }}
+    >${message}</div>
   `
 }
 

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -149,7 +149,11 @@ export function IdeShell() {
         }}
       >
         <div class="ide-plane-tree">
-          <${IdeExplorer} fileTreeStore=${coordinator.fileTreeStore} />
+          <${IdeExplorer}
+            fileTreeStore=${coordinator.fileTreeStore}
+            workspaceSource=${coordinator.workspaceSource}
+            subscribeWorkspaceSource=${coordinator.subscribeWorkspaceSource}
+          />
         </div>
         <div
           class="ide-plane-editor"


### PR DESCRIPTION
## Summary

Frontend half of the source-hint feature, paired with **#12951** (backend `X-Workspace-Source` response header). Surfaces a small `[role=\"status\"]` block under the EXPLORER header when a keeper-aware route falls back to project root (missing playground dir or unknown keeper meta), without parsing the JSON body or breaking the existing return shape.

This is a rebuild of the frontend half of the original #12934 on top of the [ide-data-coordinator](dashboard/src/components/ide/ide-data-coordinator.ts) pattern introduced in #12921 — the original PR went stale architecturally when the IDE moved from inline `fetchTree`/`useEffect` to props-based components fed by an external coordinator.

Depends on #12951 for the actual header to be present at runtime, but the code itself is independent (frontend defaults to `{ kind: 'project' }` when the header is missing, so it ships safely on its own).

## Architecture

| Layer | What landed |
|---|---|
| `dashboard/src/api/workspace-source.ts` (new) | `WorkspaceSource` type + `parseWorkspaceSource` decoder. In `api/`, not `components/ide/`, so the Editor / blame / diff panes can adopt the same hint without taking a UI dependency. |
| `dashboard/src/api/core.ts` | New `getWithResponse<T>` helper — same wire shape as `get<T>` but returns `{ data, headers }` so callers can read response headers without rewriting body parsing. Bootstrap-warm fallback returns empty `Headers` (warm payloads are local, no upstream response). |
| `dashboard/src/api/workspace.ts` | `fetchWorkspaceTree` now returns `{ nodes, source }` instead of bare `ReadonlyArray<FileTreeNode>`. Other workspace fetchers (file/blame/diff) keep their old signatures — they don't surface source today. |
| `dashboard/src/components/ide/ide-data-coordinator.ts` | Hosts a `workspaceSource` signal, updated on every tree fetch. Exposes `workspaceSource()` + `subscribeWorkspaceSource(listener)` alongside the existing diff pair. |
| `dashboard/src/components/ide/ide-explorer.ts` | Takes optional `workspaceSource` / `subscribeWorkspaceSource` props. When omitted, defaults to `{ kind: 'project' }` and renders nothing — backwards-compatible for existing call sites and tests. |
| `dashboard/src/components/ide/ide-shell.ts` | Wires the coordinator's source pair into `IdeExplorer`. |

## Subtle bug fixed in passing

The existing `subscribeDiffRows: diffRowsSignal.subscribe as ...` cast has a latent `this`-binding bug: when the property is destructured (e.g. `const { subscribeFoo } = coordinator; subscribeFoo(fn)`), `this` is undefined and the signal core crashes with *\"Cannot read properties of undefined (reading 'value')\"* in its internal tracking. The new `subscribeWorkspaceSource` wraps the call in an arrow function to keep `this` bound. The pre-existing diffRows export wasn't crashing only because no current caller actually subscribes to it.

## Tests

```
$ vitest run src/components/ide/ src/api/
Test Files  42 passed (42)
Tests       376 passed (376)
```

New cases:
- **`workspace-source.test.ts`** (9): null / empty / `project` / `playground:<n>` / `playground_missing:<n>` / `keeper_unknown:<n>` / multi-colon keeper name / unknown tag / no-colon non-project.
- **`workspace.test.ts`** (3 added): `fetchWorkspaceTree` default-`project` source, `playground:<n>` decoded, `playground_missing` / `keeper_unknown` fallback variants. `stubFetch` was extended to attach response headers.

## Test plan

- [x] Vitest 376/376 in scope (`src/components/ide/` + `src/api/`)
- [x] Decoder unit-tested in isolation (9 cases)
- [x] Fetcher header decoding unit-tested (3 cases via mocked `Response`)
- [ ] CI Build/Lint green
- [ ] `human-approved-ready` label applied by reviewer before Ready transition (Draft Auto-Merge Guard)

## Out of scope

- Editor pane source surfacing — same coordinator signal is available; follow-up PR can wire it.
- HTTP-fixture integration test for the actual header on the wire — unit tests cover decoder + fetcher, not the route.
- Hint visual polish / design-system token review.

## Stack

- Backend: **#12951** (must merge first, or hint will silently no-op until then)
- Original (now stale): #12934 — recommend close after #12951 + this PR land

🤖 Generated with [Claude Code](https://claude.com/claude-code)