### PR TITLE
fix: add logging before Result.to_option error discard

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -1295,7 +1295,13 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
    | Error Not_found ->
        Log.Keeper.debug "keeper:%s OAS checkpoint not found, falling back to legacy loader" trace_id
    | Ok _ -> ());
-  let oas_checkpoint = Result.to_option oas_result in
+  let oas_checkpoint = match oas_result with
+    | Ok v -> Some v
+    | Error Not_found -> None
+    | Error _ ->
+      Log.Keeper.warn "keeper:%s OAS checkpoint error discarded at to_option" trace_id;
+      None
+  in
   let legacy_checkpoint =
     try load_latest_checkpoint session
     with ex ->
@@ -1317,7 +1323,12 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
       "keeper:%s checkpoint migration fallback: legacy newer than OAS"
       trace_id;
   let oas_checkpoint =
-    Result.to_option oas_result
+    (match oas_result with
+     | Ok v -> Some v
+     | Error Not_found -> None
+     | Error _ ->
+       Log.Keeper.warn "keeper:%s OAS checkpoint error discarded at sanitize to_option" trace_id;
+       None)
     |> Option.map (fun checkpoint ->
       let sanitized, stats = sanitize_oas_checkpoint checkpoint in
       if checkpoint_sanitize_changed stats then begin

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -572,7 +572,12 @@ let inject_repo_flag_cmd ~repo_slug cmd =
 
 let repo_slug_of_remote_url url =
   match Tool_code_write.extract_github_org_repo url with
-  | Some slug -> validate_repo_slug slug |> Result.to_option
+  | Some slug ->
+    (match validate_repo_slug slug with
+     | Ok v -> Some v
+     | Error detail ->
+       Log.Misc.warn "repo slug validation error discarded: %s" detail;
+       None)
   | None -> None
 
 (** Read an origin slug from a concrete git config path without invoking git.

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -694,7 +694,13 @@ let recover_latest_checkpoint_for_overflow_retry
          (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
    | Ok _ -> ());
   let oas_checkpoint =
-    Result.to_option oas_result
+    (match oas_result with
+     | Ok v -> Some v
+     | Error Not_found -> None
+     | Error _ ->
+       Log.Keeper.warn "keeper:%s overflow-retry OAS checkpoint error discarded at to_option"
+         (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+       None)
     |> Option.map (fun checkpoint ->
       let sanitized, stats =
         sanitize_oas_checkpoint ~repair_orphans:false checkpoint

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -223,7 +223,11 @@ let load_worker_checkpoint ~base_path ~worker_name =
   if Sys.file_exists path then
     try
       let raw = In_channel.with_open_text path In_channel.input_all in
-      Agent_sdk.Checkpoint.of_string raw |> Result.to_option
+      (match Agent_sdk.Checkpoint.of_string raw with
+       | Ok v -> Some v
+       | Error detail ->
+         Log.LocalWorker.warn "checkpoint parse error discarded for %s: %s" worker_name (Agent_sdk.Error.to_string detail);
+         None)
     with Sys_error _ -> None
   else
     None

--- a/lib/mcp_server_eio_governance.ml
+++ b/lib/mcp_server_eio_governance.ml
@@ -79,7 +79,11 @@ let mcp_sessions_path (config : Coord.config) =
 let mcp_session_to_json = mcp_session_record_to_yojson
 
 let mcp_session_of_json (json : Yojson.Safe.t) : mcp_session_record option =
-  mcp_session_record_of_yojson json |> Result.to_option
+  match mcp_session_record_of_yojson json with
+  | Ok v -> Some v
+  | Error detail ->
+    Log.Misc.warn "MCP session JSON decode error discarded: %s" detail;
+    None
 
 let load_mcp_sessions (config : Coord.config) : mcp_session_record list =
   let path = mcp_sessions_path config in


### PR DESCRIPTION
## Summary

Replace bare `Result.to_option` calls with explicit match expressions that log a warning before discarding non-trivial errors. Previously silent parse/validation failures are now observable in keeper logs.

## Files changed (6 sites across 5 files)

| File | Site | Error source |
|------|------|-------------|
| `lib/keeper/keeper_context_core.ml` | OAS checkpoint load | OAS parse error |
| `lib/keeper/keeper_context_core.ml` | OAS checkpoint sanitize | OAS parse error |
| `lib/keeper/keeper_gh_shared.ml` | Repo slug validation | `validate_repo_slug` error |
| `lib/keeper/keeper_post_turn.ml` | Overflow-retry OAS checkpoint | OAS parse error |
| `lib/local/worker_container.ml` | Worker checkpoint parse | `Checkpoint.of_string` error |
| `lib/mcp_server_eio_governance.ml` | MCP session JSON decode | `mcp_session_record_of_yojson` error |

## Approach

Each `Result.to_option` is replaced with a match that:
1. Returns `Some v` on `Ok`
2. Returns `None` on `Error Not_found` (expected, no log)
3. Logs `Log.warn` with context and returns `None` on other `Error`

## Test plan

- [ ] `dune build` passes
- [ ] `dune runtest` passes
- [ ] Verify log output on keeper startup with corrupted checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)