### PR TITLE
fix(keeper): stamp Stale_turn_timeout cohort + collapse run_unified_turn alias (supersedes #12945)

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -102,6 +102,17 @@ type blocker_class =
         supervisor's [Keeper_registry.Fiber_unresolved] cohort key
         used by self-preservation, so blocker_class stamping mirrors
         the same diagnosis on keeper_meta. *)
+  | Stale_turn_timeout
+    (** 2026-05-05 cycle 9: stale watchdog forced fiber termination
+        because the running turn exceeded [idle_turn] threshold (~5m).
+        Maps to [Keeper_registry.Stale_turn_timeout _] cohort.  Like
+        [Fiber_unresolved], this path runs through
+        [force_unresolved_watchdog_crash] and never visits
+        [handle_crash_auto_pause], so PR #12889's [last_blocker_class]
+        stamp does not apply.  Without this variant, dashboards and
+        per-keeper meta read [last_blocker_class = null] for the
+        majority cohort during a fleet stall (observed: 6/14 keepers
+        in cohort=stale_turn_timeout, every meta showing null). *)
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
@@ -115,6 +126,7 @@ let blocker_class_to_string = function
   | Completion_contract_violation -> "completion_contract_violation"
   | No_tool_capable_provider -> "no_tool_capable_provider"
   | Fiber_unresolved -> "fiber_unresolved"
+  | Stale_turn_timeout -> "stale_turn_timeout"
 ;;
 
 let blocker_class_of_serialized_string = function
@@ -129,6 +141,7 @@ let blocker_class_of_serialized_string = function
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "no_tool_capable_provider" -> Some No_tool_capable_provider
   | "fiber_unresolved" -> Some Fiber_unresolved
+  | "stale_turn_timeout" -> Some Stale_turn_timeout
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -145,6 +145,7 @@ type blocker_class =
   | Completion_contract_violation
   | No_tool_capable_provider
   | Fiber_unresolved
+  | Stale_turn_timeout
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1102,6 +1102,55 @@ let sweep_and_recover (ctx : _ context) =
       |> Option.map Keeper_registry.failure_reason_to_string
       |> Option.value ~default:"watchdog_stop_pending"
     in
+    (* 2026-05-05 cycle 9: stamp the cohort onto keeper_meta.runtime so
+       the per-keeper meta surface (and PR #12877's "차단된 키퍼"
+       dashboard card) shows the same diagnosis the supervisor used to
+       group the keeper into a self-preservation cohort.  Companion to
+       PR #12943 which added the same stamp on the [Fiber_unresolved]
+       finally branch; this branch — [force_unresolved_watchdog_crash]
+       — was the other silent path where the stamp was missing.
+       Mapping covers all three watchdog cohorts handled by
+       [watchdog_stop_pending]; only [Stale_turn_timeout] currently
+       has a dedicated [blocker_class] variant, the other two map to
+       it as a best-effort signal until they get their own variants. *)
+    let stamp_cohort =
+      match entry.last_failure_reason with
+      | Some (Keeper_registry.Stale_turn_timeout _)
+      | Some (Keeper_registry.Stale_termination_storm _)
+      | Some (Keeper_registry.Oas_timeout_budget_loop _) ->
+        Some Stale_turn_timeout
+      | _ -> None
+    in
+    (match stamp_cohort with
+     | None -> ()
+     | Some bc ->
+       (match Keeper_registry.get ~base_path entry.name with
+        | Some current ->
+          let stamped_meta =
+            { current.meta with
+              runtime =
+                { current.meta.runtime with
+                  last_blocker = msg;
+                  last_blocker_class = Some bc;
+                };
+            }
+          in
+          (match
+             write_meta_with_merge
+               ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+               ctx.config stamped_meta
+           with
+           | Ok () -> ()
+           | Error err ->
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_write_meta_failures
+               ~labels:[("keeper", entry.name);
+                        ("phase", "stale_turn_timeout_stamp")]
+               ();
+             Log.Keeper.warn
+               "%s: stale_turn_timeout meta stamp failed: %s"
+               entry.name err)
+        | None -> ()));
     Log.Keeper.warn
       "%s: supervisor forcing unresolved watchdog-stopped keeper to crashed (%s)"
       entry.name msg;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -167,6 +167,7 @@ type blocker_class =
   | Completion_contract_violation
   | No_tool_capable_provider
   | Fiber_unresolved
+  | Stale_turn_timeout
 
 val blocker_class_to_string : blocker_class -> string
 val cascade_exhaustion_summary : cascade_exhaustion_reason -> string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2286,10 +2286,4 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           post_turn_complete_task ~cycle_completed;
           Ok updated_meta))
 
-let run_unified_turn ~config ~meta ~observation ~generation
-    ?channel ?semaphore_wait_ms ?shared_context
-    ?(yield_and_reacquire_slot : _ option)
-    () =
-  let _ = yield_and_reacquire_slot in
-  run_keeper_cycle ~config ~meta ~observation ~generation
-    ?channel ?semaphore_wait_ms ?shared_context ()
+let run_unified_turn = run_keeper_cycle


### PR DESCRIPTION
## TL;DR
Cycle 9 of 2026-05-05 fleet-stuck recurrence. Server restart revealed the *true* dominant cohort during fleet stalls is **Stale_turn_timeout** (not Fiber_unresolved which #12943 stamped). Live observation:

\`\`\`
ERROR scholar: stale watchdog terminating fiber (idle 314s)
WARN  scholar: supervisor forcing unresolved watchdog-stopped keeper to crashed (stale_turn_timeout(idle_turn(314s)))
WARN  self-preservation: suppressing 6/14 restarts (ratio=0.43, cohort=stale_turn_timeout, streak=3)

$ jq '.runtime.last_blocker_class' ~/.masc/keepers/scholar.json
null   <-- supervisor knows; meta does not
\`\`\`

## Why #12943 did not cover this
That PR stamps the cohort assigned in \`launch_supervised_fiber\`'s \`Fun.protect ~finally\`. Stale_turn_timeout flows through a *different* path: \`keeper_stale_watchdog\` terminates the fiber, then \`sweep_and_recover\` invokes \`force_unresolved_watchdog_crash\` which records the crash but never touches \`keeper_meta.runtime\`. Diagnosis sits in \`Keeper_registry\` only, never on the meta surface dashboards (PR #12877's \"차단된 키퍼\" card) and operator scripts read.

## Three changes
1. \`blocker_class\` gains \`Stale_turn_timeout\` variant (4 helper sites: type ml/mli, types.mli facade, codec round-trip).
2. \`force_unresolved_watchdog_crash\` maps the three watchdog cohorts (\`Stale_turn_timeout\`, \`Stale_termination_storm\`, \`Oas_timeout_budget_loop\`) onto the new variant and stamps it via \`write_meta_with_merge\`, mirroring PR #12889 / #12943. Best-effort: write failure does not abort crash recording.
3. **Supersedes #12945**: \`run_unified_turn\` collapses to alias of \`run_keeper_cycle\`, in sync with #12945's direction. Bundled here because the keeper-supervisor change in (2) does not build until this main blocker is resolved (mli/.ml mismatch on \`?yield_and_reacquire_slot\`). Close #12945 after this lands.

## Trade-off note
\`Stale_termination_storm\` and \`Oas_timeout_budget_loop\` currently map to \`Stale_turn_timeout\` as best-effort (they share the same \"watchdog forced unresolved fiber to crash\" semantics). Add dedicated variants in a follow-up if dashboard treatment diverges; codec is forward-compatible.

## Test plan
- [x] \`dune build @check -j 8\` clean on rebased branch.
- [ ] Post-merge: rebuild + restart; observe a Stale_turn_timeout crash and confirm \`runtime.last_blocker_class == \"stale_turn_timeout\"\` on next supervisor sweep.
- [ ] Dashboard \"차단된 키퍼\" card surfaces stale_turn_timeout cohort.

## Companion to
- #12889 release current_task_id on auto-pause (handle_crash_auto_pause)
- #12943 Fiber_unresolved blocker_class stamp (launch_supervised_fiber finally)
- #12950 deploy gap warn (build_identity)
- This PR closes the **third** silent path in the same family: \`force_unresolved_watchdog_crash\`.