### PR TITLE
fix(keeper): sync run_unified_turn .mli with .ml wrapper signature (unblocks 14 open PRs)

### DIFF
--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -245,5 +245,12 @@ val run_unified_turn :
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
   ?shared_context:Agent_sdk.Context.t ->
+  ?yield_and_reacquire_slot:'a ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
+(** [yield_and_reacquire_slot] is accepted and ignored.  Retained as a
+    no-op parameter for backward compatibility with #12885 callers
+    that were not all updated when the heuristic was reverted in
+    #12910.  The wrapper in {!val:run_unified_turn} (defined in
+    [keeper_unified_turn.ml]) discards the argument and forwards the
+    rest to {!val:run_keeper_cycle}. *)


### PR DESCRIPTION
## Summary
Single-line `.mli` fix that completes #12946 / unblocks all 14 open PRs.

`main` has had a silent `.mli/.ml` mismatch since #12910 reverted #12885's yield-and-reacquire heuristic:

- `.ml` wrapper at `keeper_unified_turn.ml:2287-2294` accepts and discards `?yield_and_reacquire_slot` (the wrapper #12946 added).
- `.mli` at `keeper_unified_turn.mli:240-249` does NOT declare the param.

The result is a quiet `is not included in` error during `dune build @all`, confirmed by **every open PR reporting CI Build/Test FAILURE for unrelated changes**. #12955 explicitly calls this out in its body ("Pre-existing main blocker (`keeper_unified_turn.mli/ml ?yield_and_reacquire_slot drift`) prevents a full library link, same as #12926/#12938/#12939").

## Fix
Add the param to the `.mli` signature with a docstring explaining the no-op semantics. 7 insertions, single file.

## Orthogonal to other open fixes
- **#12945** fixes the `.ml` side (CHANGELOG + prometheus.ml + keeper_unified_turn.ml wrapper) — independent file.
- **#12946** (already merged) added the `.ml` wrapper but did not sync `.mli`.
- This PR closes the loop.

## Verification
```
$ dune build --root . @check  → exit 0, no errors
$ dune build --root . @all    → exit 0, no errors
```

Without this PR, `@all` emits the cited mismatch error even though `@check` passes (the alias is permissive).

## Impact
Fixing main unblocks every open Ready PR currently stuck on CI Build/Test FAILURE:
#12923, #12925, #12927, #12929, #12930, #12931, #12933, #12936, #12942, #12948, #12953, #12954.

## Test plan
- [x] Local `@check` clean
- [x] Local `@all` clean
- [ ] CI Meta Guards passes
- [ ] CI Build & Test passes

## Refs
- #12910 (revert origin of the mismatch)
- #12946 (partial fix — `.ml` only)
- #12945 (parallel `.ml`/CHANGELOG fix)
- #12955 (independent confirmation in PR body)
