### PR TITLE
feat(cascade): add tier_fast seed profile (cheap+fast keepers)

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -80,3 +80,18 @@ temperature = 0.2
 max_tokens = 4096
 keeper_assignable = false
 fallback_cascade = "big_three"
+
+[tier_fast]
+comment = "Cheap+fast tool-capable cloud models for keeper turns. Bias toward latency and cost over reasoning depth. All entries support tool calling. Falls back to big_three on exhaustion."
+models = [
+  "claude_code:claude-haiku-4-5-20251001",
+  "codex_cli:gpt-5.3-codex-spark",
+  "gemini_cli:gemini-3-flash-preview",
+  "gemini_cli:gemini-3.1-flash-lite-preview",
+  "glm-coding:glm-5-turbo",
+  "glm-coding:glm-4.7-flashx",
+]
+temperature = 0.2
+max_tokens = 8192
+keeper_assignable = true
+fallback_cascade = "big_three"


### PR DESCRIPTION
## Summary
Add `tier_fast` profile to seed `config/cascade.toml`. Cheap+fast tool-capable cloud lane composed of low-latency models. Mirrors the operator-side live config addition in jeong-sik/me#feat/cascade-tier-fast (which carries the weighted variant + api_key_env).

## Models
- `claude_code:claude-haiku-4-5-20251001`
- `codex_cli:gpt-5.3-codex-spark`
- `gemini_cli:gemini-3-flash-preview`
- `gemini_cli:gemini-3.1-flash-lite-preview`
- `glm-coding:glm-5-turbo`
- `glm-coding:glm-4.7-flashx`

All IDs verified against `lib/provider_adapter.ml` canonical lists and `lib/cascade/cascade_model_resolve.ml` (`glm-5-turbo = fast tool calling`).

## Profile fields
- `temperature = 0.2`, `max_tokens = 8192`
- `keeper_assignable = true`
- `fallback_cascade = "big_three"` (cycle-free since seed has no inverse fallback)

## Tradeoffs
- 가벼운 turn에서 latency/cost 모두 낮음. reasoning depth는 big_three보다 낮음.
- Operator config (live)와 seed가 분리된 것은 의도 — seed는 minimal, live는 weighted_random + api_key_env로 정밀 튜닝.
- Not auto-routed via `[routes]`; opt-in only.

## Test plan
- [x] TOML parse via tomllib
- [x] All 6 model IDs canonical (rg in provider_adapter.ml)
- [x] fallback chain to big_three exists in same file
- [ ] No effect until consumer opts in (no behavior change in CI)