### PR TITLE
feat: wire Thompson quality signal into tool_task production pipeline

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -695,6 +695,9 @@ and handle_cancel_task ctx args =
         with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(cancel) failed: %s" (Stdlib.Printexc.to_string exn));
        (* Feed failure into Thompson Sampling quality signal *)
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
+       Thompson_sampling.record_quality_signal
+         ~agent_name:ctx.agent_name
+         ~verdict:(Post_verifier.Fail "task_cancelled");
        (* Prometheus: record task failure *)
        Prometheus.record_task_failed ();
        (* Notification harness: push cancel event to all active sessions *)
@@ -1075,6 +1078,9 @@ and handle_transition ?agent_tool_names ctx args =
        (try let _ = Metrics_store_eio.record ctx.config metric in ()
         with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(transition-done) failed: %s" (Stdlib.Printexc.to_string exn));
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
+       Thompson_sampling.record_quality_signal
+         ~agent_name:ctx.agent_name
+         ~verdict:Post_verifier.Pass;
        Prometheus.record_task_completed ()
    | Ok _, Types.Cancel ->
        let metric : Metrics_store_eio.task_metric = {
@@ -1092,6 +1098,9 @@ and handle_transition ?agent_tool_names ctx args =
        (try let _ = Metrics_store_eio.record ctx.config metric in ()
         with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(transition-cancel) failed: %s" (Stdlib.Printexc.to_string exn));
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
+       Thompson_sampling.record_quality_signal
+         ~agent_name:ctx.agent_name
+         ~verdict:(Post_verifier.Fail "task_cancelled");
        Prometheus.record_task_failed ()
    | Ok _, (Types.Claim | Types.Start | Types.Submit_for_verification
             | Types.Approve_verification | Types.Reject_verification | Types.Release)


### PR DESCRIPTION
## Summary
- Added record_quality_signal calls at 3 task outcome points in tool_task.ml
- Task success → Post_verifier.Pass (alpha +0.3)
- Task cancellation → Post_verifier.Fail (beta +0.5)
- Previously: record_quality_signal had 0 production callers (test-only)

## Quality signal mapping
| Outcome | Verdict | Thompson effect |
|---------|---------|----------------|
| Done (success) | Pass | alpha +0.3 |
| Cancelled | Fail | beta +0.5 |

## Test plan
- [x] 28 Thompson sampling tests pass
- [x] 66 tool_task coverage tests pass
- [x] 3 task completion example tests pass
- [x] dune build @install passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)