### PR TITLE
fix(meta-guards): sync CHANGELOG 0.19.4-0.19.7 with ROADMAP (carries closed #12945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,65 @@
 # Changelog
 
 
+## [0.19.7] - 2026-05-05
+
+### Added
+- Keeper-aware workspace tree + file routes in Dashboard.
+- Dashboard token system: sp-1h half-step + 5 polish tokens.
+- IDE activity and conversation rail connected to real APIs.
+
+### Fixed
+- Release current_task_id on supervisor auto-pause (Task-138).
+- Annotate intentional non-color CSS literals with inline justification.
+
+### Changed
+- Unexport 27 internal-only helpers across common/ (+ unit test cleanup).
+
+## [0.19.6] - 2026-05-04
+
+### Added
+- Semaphore holder tracking so timeouts can name the blocker.
+- Cycle detection for fallback_cascade at load_catalog time.
+- Per-candidate cascade attempt emitted to system_log.
+- Real workspace/git API endpoints replacing IDE mock data.
+
+### Fixed
+- Reset queue-head wait clock after fairness yield + enqueue.
+- Remove duplicate write_meta_failures counters and normalize phase label.
+- Scope WorldVisualizer to Cockpit/IDE surfaces.
+
+### Changed
+- Drop 14 orphan hooks/utilities (-2001 lines).
+
+## [0.19.5] - 2026-05-03
+
+### Added
+- Alive-but-stuck detector — Prometheus signal only.
+- Keeper cadence gauges (consecutive_idle, last_productive_ts).
+- Unit tests for keeper_alerting_path pure helpers.
+
+### Fixed
+- Replace 4 "unknown" stand-ins with "aggregate" placeholder.
+- Instrument decision record JSONL append failure in unified_metrics.
+
+### Changed
+- Drop 9 orphan components (-2315 lines).
+- Drop deprecated theme-hash exports.
+
+## [0.19.4] - 2026-05-02
+
+### Added
+- Passive loop action injection — nudge keeper to act when stuck in read-only loop.
+- Prometheus counters for tool setup and task load failures.
+- Issue dependency graph: liveness recovery, cascade rotation, lifecycle timeline.
+
+### Fixed
+- Inject stream_idle_timeout default when caller omits option.
+- Data accuracy sweep for Provider Capability Matrix in Dashboard.
+- Unblock main build (printf format + Env_config_keeper rename).
+- Sync stale test defaults with Env_config_exec_timeout.
+- Silent dispatch + timeout_sec SSOT migration.
+
 ## [0.19.3] - 2026-05-02
 
 ### Added


### PR DESCRIPTION
## Summary
- main의 Meta Guards가 `version truth check failed: ROADMAP latest release (0.19.7) != CHANGELOG latest release (0.19.3)`로 실패 중
- #12946 이미 머지: prometheus.ml + run_unified_turn fix
- #12945 closed, #12963는 keeper-alias collapse만 가져감 → CHANGELOG entry는 어디에도 안 들어감
- 본 PR이 closed #12945 (commit a395a1c1)에서 CHANGELOG 변경분 59 라인만 추출

## Why this is the right minimal fix
- 변경: `CHANGELOG.md` 단일 파일, +59 line
- 0.19.4-0.19.7 entry는 main에 실제 머지된 PR들과 매핑됨 (a395a1c1 시점 검증 완료)
- ROADMAP.md `Latest release: v0.19.7` ↔ 본 PR의 `## [0.19.7]` 일치

## Impact
- Meta Guards "version truth check" green
- 17 open PR이 main에 sync하면 base가 더 이상 broken이 아니므로 CI 재실행 시 본인 변경분만 평가됨

## Root cause follow-up (별도 issue로 제안)
1. Meta Guards가 ROADMAP-CHANGELOG 동기화를 _수동 강제_하는 구조 → CHANGELOG entry를 PR squash 시점에 자동 추가하는 hook 필요
2. nightly CI on `main` 미존재 → main fail이 PR을 통해서만 표면화 (이번 케이스의 원인)

## Test plan
- [ ] CI Meta Guards (`Check doc truth`) PASS
- [ ] main으로 머지 후 `gh pr list --state open` 17개의 base sync → CI 재실행 확인

## Verification needed before ready
- 사용자가 0.19.4-0.19.7 entries 항목 정확성 검토
- 사용자가 `human-approved-ready` 라벨 부여 후 ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Co-Authored-By: Claude Opus 4.7
