### PR TITLE
feat(ci): nightly health workflow on main with auto-issue creation

### DIFF
--- a/.github/workflows/main-nightly-health.yml
+++ b/.github/workflows/main-nightly-health.yml
@@ -1,0 +1,147 @@
+name: Main Nightly Health
+
+# Detect "main is broken" within 24h instead of waiting for the next PR to fail.
+# RC1 of the 2026-05-05 CHANGELOG-version-truth incident: main's Meta Guards
+# stayed red for ~36h because no scheduled job ran on main, and the failure was
+# only surfaced through PR CI on 17 unrelated open PRs.
+
+on:
+  schedule:
+    # 00:00 UTC = 09:00 KST. Aligns with morning standup so a broken main is
+    # the first thing we see, not the last thing.
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: main-nightly-health
+  cancel-in-progress: false
+
+jobs:
+  doc-truth:
+    name: Doc Truth (ROADMAP vs CHANGELOG)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep
+
+      - name: Check doc truth
+        id: doctruth
+        run: |
+          chmod +x scripts/check-version-truth.sh
+          scripts/check-version-truth.sh
+
+      - name: Open or update tracking issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '[main-health] Doc truth check failing on main';
+            const body = [
+              `Workflow: \`${context.workflow}\``,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Commit: \`${context.sha}\``,
+              '',
+              'Probable cause: ROADMAP latest release does not match CHANGELOG latest release.',
+              'Fix: bring CHANGELOG entries up to ROADMAP version, or roll ROADMAP back.',
+              '',
+              'This issue is auto-created so a broken main does not stay invisible.',
+              'Close manually after merging the fix; the workflow will not reopen unless it fails again.',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'main-health',
+              per_page: 10,
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Still failing as of run ${context.runId} (commit \`${context.sha}\`).`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['main-health', 'priority:high'],
+              });
+            }
+
+  build-smoke:
+    name: Build Smoke (dune build @install)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.4'
+
+      - name: Install deps
+        run: opam install . --deps-only --with-test --yes
+
+      - name: Build
+        run: opam exec -- dune build @install
+
+      - name: Open or update tracking issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '[main-health] dune build @install failing on main';
+            const body = [
+              `Workflow: \`${context.workflow}\``,
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `Commit: \`${context.sha}\``,
+              '',
+              'Main HEAD does not compile. PRs branched off this commit will fail CI Build & Test.',
+              'Find the offending commit with `git log --oneline` and revert or fix forward.',
+              '',
+              'This issue is auto-created so a broken main does not stay invisible.',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'main-health',
+              per_page: 10,
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Still failing as of run ${context.runId} (commit \`${context.sha}\`).`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['main-health', 'priority:high'],
+              });
+            }


### PR DESCRIPTION
## Why
2026-05-05 incident (`#12973`): main의 Meta Guards `Check doc truth`가 약 36시간 동안 fail 상태로 방치됨. 17개 open PR이 그 base에서 분기해 모두 같은 이유로 CI fail. 사람이 발견한 시점에는 이미 PR backlog가 누적된 상태.

## Root cause (RC1)
- `ci.yml`의 `push: branches: [main]` trigger는 매 push마다 실행되지만 실패가 **red dot 외 알림이 없음**
- squash-merge가 빠르게 누적되면 사람이 Actions 탭을 스크롤할 시간이 없음
- 결과: main이 깨진 상태로 24h+ 방치됨

## What this PR adds
- `.github/workflows/main-nightly-health.yml` 신규 (147 line, 단일 파일 변경)
- 매일 09:00 KST `main` HEAD에서 두 가지 검사 실행
  - `doc-truth`: `scripts/check-version-truth.sh` (1분 미만)
  - `build-smoke`: `dune build @install` (~25분)
- 실패 시 `main-health` 라벨로 GitHub Issue 자동 생성/코멘트 추가 → **이슈 트래커에서 강제로 표면화**
- `workflow_dispatch` 추가 → fix 후 다음 스케줄 24시간 대기 없이 즉시 재검증

## Why not Slack/email yet
의도적 후행 결정. main-health 이슈가 어느 정도 빈도로 발생하는지 데이터를 보고 결정. 과도 알림이 미흡 알림보다 나쁨.

## Why not full CI matrix
Nightly는 "main이 출하 가능한가"만 본다. dashboard build / lint / TLA는 PR CI 책임. 이중 실행은 minute 낭비.

## Stack relationship
- 의존: 없음. 머지 직후부터 효과 발생.
- 동시 머지 권장: `#12973` (CHANGELOG fix). 둘 다 머지되면 다음 nightly run에서 doc-truth는 green 확인 가능.

## Test plan
- [ ] `gh workflow run main-nightly-health.yml --repo jeong-sik/masc-mcp` 수동 실행 후 green 확인
- [ ] 이후 의도적으로 ROADMAP/CHANGELOG 미스매치를 만들어 fail 시 issue 자동 생성 확인 (별도 follow-up 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Co-Authored-By: Claude Opus 4.7
