### PR TITLE
fix(cascade): pass [admission.*] sub-tables through to JSON (live regression fix)

### DIFF
--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -348,6 +348,43 @@ let profile_table_json_fields ~profile_name value =
       in
       loop [] fields
 
+(* Generic Otoml -> Yojson conversion used for namespaces that the
+   materializer should pass through verbatim instead of treating as a
+   cascade profile.  Currently used for the [admission] namespace
+   introduced by RFC-0026 PR-B (#12926, #1089).
+
+   Without this, every [admission.<keeper>] sub-table breaks the
+   materializer (treated as a profile, sub-table keys rejected as
+   "unknown field"), which fails cascade.json materialization and
+   takes down every keeper that resolves a cascade through cascade.toml
+   — not just the keepers with admission blocks.  The error is a
+   single fleet-wide regression, so the materializer needs to know
+   about the admission namespace explicitly. *)
+let rec otoml_to_yojson (value : Otoml.t) : Yojson.Safe.t =
+  match value with
+  | Otoml.TomlString s -> `String s
+  | Otoml.TomlInteger n -> `Int n
+  | Otoml.TomlFloat f -> `Float f
+  | Otoml.TomlBoolean b -> `Bool b
+  | Otoml.TomlOffsetDateTime s
+  | Otoml.TomlLocalDateTime s
+  | Otoml.TomlLocalDate s
+  | Otoml.TomlLocalTime s -> `String s
+  | Otoml.TomlArray items ->
+      `List (List.map otoml_to_yojson items)
+  | Otoml.TomlTable fields ->
+      `Assoc
+        (List.map
+           (fun (k, v) -> (k, otoml_to_yojson v))
+           fields)
+  | Otoml.TomlInlineTable fields ->
+      `Assoc
+        (List.map
+           (fun (k, v) -> (k, otoml_to_yojson v))
+           fields)
+  | Otoml.TomlTableArray items ->
+      `List (List.map otoml_to_yojson items)
+
 let render_toml_to_yojson toml =
   match table_fields ~path:"<root>" toml with
   | Error _ as err -> err
@@ -363,6 +400,12 @@ let render_toml_to_yojson toml =
               match routes_json ~path:"routes" value with
               | Ok routes -> loop ([ ("routes", routes) ] :: acc) rest
               | Error _ as err -> err
+            else if String.equal key "admission" then
+              (* RFC-0026 admission namespace — pass through to JSON
+                 verbatim.  The schema is owned by
+                 [Keeper_admission_policy.parse_admission_json] in
+                 lib/keeper/, not by the cascade profile schema. *)
+              loop ([ ("admission", otoml_to_yojson value) ] :: acc) rest
             else (
               match profile_table_json_fields ~profile_name:key value with
               | Ok rendered -> loop (rendered :: acc) rest

--- a/test/dune
+++ b/test/dune
@@ -1060,6 +1060,7 @@
 (include stanzas/test_governance_response_model_empty_9880.inc)
 (include stanzas/test_heartbeat_integration.inc)
 (include stanzas/test_heuristic_metrics_diagnostics.inc)
+(include stanzas/test_cascade_toml_materializer_admission.inc)
 (include stanzas/test_heuristic_metrics_scrub.inc)
 (include stanzas/test_join_required_guard_counter.inc)
 (include stanzas/test_k2_pipeline_e2e.inc)

--- a/test/stanzas/test_cascade_toml_materializer_admission.inc
+++ b/test/stanzas/test_cascade_toml_materializer_admission.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_toml_materializer_admission)
+ (modules test_cascade_toml_materializer_admission)
+ (libraries masc_mcp alcotest yojson))

--- a/test/test_cascade_toml_materializer_admission.ml
+++ b/test/test_cascade_toml_materializer_admission.ml
@@ -1,0 +1,156 @@
+(** Regression test for cascade_toml_materializer admission namespace
+    pass-through.
+
+    Without the special-case [admission] handling in
+    [render_toml_to_yojson], a TOML with [admission.<keeper>] sub-tables
+    fails the materializer with "unknown field <keeper> in profile
+    admission" — bringing down every keeper that resolves a cascade
+    through cascade.toml, not just the keepers with admission blocks.
+
+    Live regression observed 2026-05-05 02:55 UTC: appending RFC-0026
+    [admission.*] blocks to live cascade.toml triggered fleet-wide
+    materialize failure → all 5 watchdog-killed keepers (glm-coding-plan,
+    qa-king, sangsu, scholar, velvet-hammer) had idle stalls 302-314s. *)
+
+open Masc_mcp
+
+let render content =
+  Cascade_toml_materializer.render_toml_string_to_json_string content
+
+let parse_json_string (s : string) : Yojson.Safe.t =
+  Yojson.Safe.from_string s
+
+let test_admission_namespace_passthrough () =
+  let toml =
+    {|
+[big_three]
+models = [
+  { model = "anthropic:claude_code:auto", weight = 1 },
+]
+temperature = 0.2
+max_tokens = 30000
+keeper_assignable = true
+strategy = "weighted_random"
+
+[admission.analyst]
+weight = 1
+min_tier = "Preferred"
+candidates = [
+  { provider = "anthropic", model = "claude_code:auto", tier = "Preferred" },
+  { provider = "openai", model = "codex_cli:gpt-5", tier = "Acceptable" },
+]
+|}
+  in
+  match render toml with
+  | Error msg ->
+      Alcotest.failf "render failed: %s" msg
+  | Ok json_str ->
+      let json = parse_json_string json_str in
+      (match json with
+       | `Assoc fields ->
+           let admission = List.assoc_opt "admission" fields in
+           Alcotest.(check bool)
+             "admission key present at top level"
+             true (Option.is_some admission);
+           (match admission with
+            | Some (`Assoc admission_fields) ->
+                let analyst = List.assoc_opt "analyst" admission_fields in
+                Alcotest.(check bool)
+                  "admission.analyst sub-table present"
+                  true (Option.is_some analyst);
+                (match analyst with
+                 | Some (`Assoc analyst_fields) ->
+                     Alcotest.(check bool)
+                       "analyst has weight"
+                       true (List.mem_assoc "weight" analyst_fields);
+                     Alcotest.(check bool)
+                       "analyst has min_tier"
+                       true (List.mem_assoc "min_tier" analyst_fields);
+                     Alcotest.(check bool)
+                       "analyst has candidates"
+                       true (List.mem_assoc "candidates" analyst_fields)
+                 | _ -> Alcotest.fail "analyst should be an object")
+            | _ -> Alcotest.fail "admission should be an object")
+       | _ -> Alcotest.fail "top level should be an object")
+
+let test_admission_with_no_blocks_still_renders () =
+  (* Sanity: removing the admission namespace shouldn't break the
+     materializer; existing cascade.toml without admission blocks must
+     still render cleanly. *)
+  let toml =
+    {|
+[big_three]
+models = [
+  { model = "anthropic:claude_code:auto", weight = 1 },
+]
+temperature = 0.2
+max_tokens = 30000
+keeper_assignable = true
+strategy = "weighted_random"
+|}
+  in
+  match render toml with
+  | Error msg -> Alcotest.failf "render failed: %s" msg
+  | Ok _ -> ()
+
+let test_admission_candidates_array_preserved () =
+  (* Each candidate should be a JSON object with provider/model/tier
+     fields — the schema [Keeper_admission_policy.parse_admission_json]
+     reads. *)
+  let toml =
+    {|
+[admission.executor]
+weight = 2
+min_tier = "Acceptable"
+candidates = [
+  { provider = "anthropic", model = "m1", tier = "Preferred" },
+  { provider = "openai", model = "m2", tier = "Acceptable" },
+  { provider = "ollama", model = "m3", tier = "Survival" },
+]
+|}
+  in
+  match render toml with
+  | Error msg -> Alcotest.failf "render failed: %s" msg
+  | Ok json_str ->
+      let json = parse_json_string json_str in
+      let candidates =
+        match json with
+        | `Assoc fields ->
+            (match List.assoc_opt "admission" fields with
+             | Some (`Assoc adm) ->
+                 (match List.assoc_opt "executor" adm with
+                  | Some (`Assoc ex) -> List.assoc_opt "candidates" ex
+                  | _ -> None)
+             | _ -> None)
+        | _ -> None
+      in
+      match candidates with
+      | Some (`List rows) ->
+          Alcotest.(check int) "3 candidates" 3 (List.length rows);
+          (match List.hd rows with
+           | `Assoc r ->
+               Alcotest.(check (option pass)) "provider"
+                 (Some (`String "anthropic"))
+                 (List.assoc_opt "provider" r);
+               Alcotest.(check (option pass)) "tier"
+                 (Some (`String "Preferred"))
+                 (List.assoc_opt "tier" r)
+           | _ -> Alcotest.fail "candidate should be object")
+      | _ -> Alcotest.fail "candidates should be a JSON list"
+
+let () =
+  Alcotest.run "cascade_toml_materializer_admission"
+    [
+      ( "admission_passthrough",
+        [
+          Alcotest.test_case
+            "admission.<keeper> sub-table renders to JSON without unknown-field error"
+            `Quick test_admission_namespace_passthrough;
+          Alcotest.test_case
+            "candidates array preserves provider/model/tier"
+            `Quick test_admission_candidates_array_preserved;
+          Alcotest.test_case
+            "no admission blocks still renders cleanly (regression guard)"
+            `Quick test_admission_with_no_blocks_still_renders;
+        ] );
+    ]


### PR DESCRIPTION
## 🚨 Live regression fix

Adding RFC-0026 `[admission.<keeper>]` blocks (PR #1089, #12926) to live cascade.toml triggers fleet-wide cascade.json materialization failure within seconds, killing every keeper that resolves a cascade.

**Live evidence (2026-05-05 02:55 UTC, masc-mcp on basepath=~/me)**:
```
ERROR  invalid profile.cascade_name "big_three" for keeper analyst:
       active cascade source could not be loaded:
       failed to materialize ~/me/.masc/config/cascade.json
       from ~/me/.masc/config/cascade.toml:
       unknown field "analyst" in profile admission;
       allowed fields are comment, models, temperature, max_tokens, ...
```

5 keepers (glm-coding-plan, qa-king, sangsu, scholar, velvet-hammer) terminated by stale watchdog after idle 302-314s. Self-preservation circuit breaker suppressed 9/14 restarts. FLEET BATCH TERMINATION events emitted.

## Root cause

`render_toml_to_yojson` at `lib/cascade/cascade_toml_materializer.ml:351` treats every top-level TOML key that isn't `comment` or `routes` as a cascade *profile*, routing it to `profile_table_json_fields` whose strict schema rejects every field name not in the cascade profile whitelist.

The `admission` namespace introduced by RFC-0026 PR-B has its own schema (owned by `Keeper_admission_policy.parse_admission_json` in `lib/keeper/`) and must NOT be processed by the cascade profile whitelist.

## Fix

```ocaml
else if String.equal key "admission" then
  loop ([ ("admission", otoml_to_yojson value) ] :: acc) rest
else (
  match profile_table_json_fields ~profile_name:key value with
  ...)
```

`otoml_to_yojson` is a new straightforward Otoml -> Yojson recursive converter (string, int, float, bool, datetime, array, table, inline table, table array). Used only for the admission namespace.

## Test plan

3 alcotest cases added at `test/test_cascade_toml_materializer_admission.ml`:

```
Testing `cascade_toml_materializer_admission'.
  [OK]  admission_passthrough  0  admission.<keeper> sub-table renders to JSON without unknown-field error
  [OK]  admission_passthrough  1  candidates array preserves provider/model/tier
  [OK]  admission_passthrough  2  no admission blocks still renders cleanly (regression guard)
Test Successful in 0.001s. 3 tests run.
```

## Why the bug went undetected

PR #12926 (parser) and PR #1089 (toml blocks) treated the materializer as a black box. PR #1089's test plan said "verifying the policy table independently of the router swap-in" — but did not round-trip through the materializer. Live deployment of the blocks was the first observation of cascade.toml with `[admission.*]` entries.

## Without this fix

RFC-0026 PR-E-1.6 / 1.7 / 1.8 cannot ship — adding `[admission.*]` blocks is the activation prerequisite for the registry.

## Stack

Independent fix. Unblocks:
- jeong-sik/me #1089 (admission blocks) — currently safe to apply only after this lands
- jeong-sik/masc-mcp #12955 (PR-E-1.6 + 1.7) — registry only emits non-`legacy` outcomes after admission blocks are in cascade.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)
