### PR TITLE
fix(ci): register KeeperAdmissionLiveness.tla as known unchecked

### DIFF
--- a/scripts/ci/check-tla-harness-coverage.sh
+++ b/scripts/ci/check-tla-harness-coverage.sh
@@ -23,6 +23,9 @@ specs/keeper-state-machine/KeeperOutcomesConservation.tla
 specs/keeper-state-machine/KeeperReconcileLiveness.tla
 specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
 specs/keeper-state-machine/KeeperWorkPipeline.tla
+# KeeperAdmissionLiveness: cfg-backed spec for admission liveness invariant;
+# wiring into tla-check.sh requires TLC module deps not yet available.
+specs/keeper-state-machine/KeeperAdmissionLiveness.tla
 specs/server-state/ServerState.tla
 specs/social-state-cap/SocialStateCap.tla
 EOF


### PR DESCRIPTION
## Summary
Meta Guards CI check fails because `KeeperAdmissionLiveness.tla` has `.cfg` files but is not wired into `scripts/tla-check.sh` or listed in `known_unchecked_specs`.

This registers it as known unchecked with an audit note until TLC module dependencies are available for full wiring.

## Test plan
- [ ] Meta Guards check passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)