### PR TITLE
fix(dashboard): unblock typecheck on main (workspace.test + unused StatCell)

### DIFF
--- a/dashboard/src/api/workspace.test.ts
+++ b/dashboard/src/api/workspace.test.ts
@@ -37,17 +37,17 @@ describe('workspace API', () => {
 
     const result = await fetchWorkspaceTree(2)
     expect(result.nodes).toHaveLength(1)
-    expect(result.nodes[0].path).toBe('lib/main.ml')
+    expect(result.nodes[0]!.path).toBe('lib/main.ml')
     expect(result.source).toEqual({ kind: 'project' })
 
-    expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/workspace/tree?depth=2')
+    expect(mockFetch.mock.calls[0]![0]).toContain('/api/v1/workspace/tree?depth=2')
   })
 
   it('fetchWorkspaceTree appends keeper param when provided', async () => {
     stubFetch([])
 
     await fetchWorkspaceTree(1, { keeper: 'sangsu' })
-    expect(mockFetch.mock.calls[0][0]).toContain('keeper=sangsu')
+    expect(mockFetch.mock.calls[0]![0]).toContain('keeper=sangsu')
   })
 
   it('fetchWorkspaceTree decodes X-Workspace-Source playground header', async () => {
@@ -74,8 +74,8 @@ describe('workspace API', () => {
     expect(result?.ok).toBe(true)
     expect(result?.content).toBe('let x = 1\n')
 
-    expect(mockFetch.mock.calls[0][0]).toContain('/api/v1/workspace/file?path=')
-    expect(mockFetch.mock.calls[0][0]).toContain('lib%2Fmain.ml')
+    expect(mockFetch.mock.calls[0]![0]).toContain('/api/v1/workspace/file?path=')
+    expect(mockFetch.mock.calls[0]![0]).toContain('lib%2Fmain.ml')
   })
 
   it('fetchGitBlame returns blame blocks', async () => {
@@ -84,7 +84,7 @@ describe('workspace API', () => {
 
     const result = await fetchGitBlame('a.ml')
     expect(result).toHaveLength(1)
-    expect(result[0].keeper_id).toBe('claude')
+    expect(result[0]!.keeper_id).toBe('claude')
   })
 
   it('fetchGitDiff extracts unified rows from response', async () => {
@@ -93,7 +93,7 @@ describe('workspace API', () => {
 
     const result = await fetchGitDiff('a.ml')
     expect(result).toHaveLength(1)
-    expect(result[0].kind).toBe('add')
+    expect(result[0]!.kind).toBe('add')
   })
 
   it('fetchGitDiff defaults to empty array when unified missing', async () => {
@@ -107,13 +107,13 @@ describe('workspace API', () => {
     stubFetch({ unified: [] })
 
     await fetchGitDiff('a.ml')
-    expect(mockFetch.mock.calls[0][0]).toContain('base_ref=HEAD')
+    expect(mockFetch.mock.calls[0]![0]).toContain('base_ref=HEAD')
   })
 
   it('fetchGitDiff accepts custom baseRef', async () => {
     stubFetch({ unified: [] })
 
     await fetchGitDiff('a.ml', { baseRef: 'v0.19.0' })
-    expect(mockFetch.mock.calls[0][0]).toContain('base_ref=v0.19.0')
+    expect(mockFetch.mock.calls[0]![0]).toContain('base_ref=v0.19.0')
   })
 })

--- a/dashboard/src/components/git-graph-panel.ts
+++ b/dashboard/src/components/git-graph-panel.ts
@@ -12,16 +12,6 @@ import {
   refreshGitGraph,
 } from './git-graph-store'
 
-function StatCell({ label, value }: { label: string; value: number }) {
-  return html`
-    <div class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
-      <div class="text-2xs font-medium uppercase tracking-[var(--track-section)] text-[var(--color-fg-muted)]">${label}</div>
-      <div class="mt-1 text-xl font-semibold tabular-nums text-[var(--color-fg-primary)]">${value}</div>
-    </div>
-  `
-}
-
-
 export function GitGraphPanel() {
   const state = gitGraphResource.state.value
   const graph = state.data


### PR DESCRIPTION
## Summary

**main blocker fix** — Dashboard typecheck CI was failing on every dashboard PR since #12957 merged its $workspace.test.ts$ extension without strict-array-access-safe patterns. Combined with a pre-existing unused $StatCell$ in $git-graph-panel.ts$, three dashboard cleanup PRs (#12953, #12942, #12933) auto-disabled their own auto-merge because CI Gate was failing on a typecheck error those PRs didn't introduce.

## Changes

- $workspace.test.ts$ — add $!$ non-null assertions on $mockFetch.mock.calls[0]$ and $result[0]$ accesses that follow $expect(...).toHaveLength(1)$. The array access is provably safe at runtime (length just checked), but TS strict mode requires the assertion. 9 errors resolved.
- $git-graph-panel.ts$ — remove the unused local $StatCell$ component (8 lines). Never wired into $GitGraphPanel$. $StatTile$ from $./common/stat-tile$ is the live equivalent and remains imported.

## Why this matters now

The 24 PRs I just queued for auto-merge will retry CI as soon as this lands. Without it, the dashboard cleanup family (#12953, #12942, #12933) and any future PR touching dashboard will see Dashboard CI fail and auto-merge auto-disabled.

After:
~~~
tsc --noEmit  → only 6 pre-existing unused-symbol warnings in unrelated files
                ($governance.test.ts$, $ide-editor-mock.ts$, $mission-utils.ts$)
~~~

These 6 were already passing CI before — they live in different paths from our two changed files.

## Test plan

- [x] $tsc --noEmit$ → 0 new errors, 6 pre-existing unused warnings in unrelated files
- [x] No production code touched (test assertions only + dead component removal)
- [ ] CI Build/Lint/Dashboard green
- [ ] $human-approved-ready$ label applied by reviewer before Ready transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)