### PR TITLE
test(dashboard): unit tests for Briefing_gaps

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1008,6 +1008,7 @@
 (include stanzas/test_auth_token_uniqueness_audit.inc)
 (include stanzas/test_base_path_prod_guard.inc)
 (include stanzas/test_board_api_e2e.inc)
+(include stanzas/test_briefing_gaps.inc)
 (include stanzas/test_cascade_capability_gate.inc)
 (include stanzas/test_cascade_catalog_runtime.inc)
 (include stanzas/test_cascade_config_validity.inc)

--- a/test/stanzas/test_briefing_gaps.inc
+++ b/test/stanzas/test_briefing_gaps.inc
@@ -1,0 +1,9 @@
+; Per-file dune stanza for the [Briefing_gaps] regression suite.
+; Lives here per test/stanzas/README.md to avoid the
+; conflict-cascade hotspot in the legacy grouped (tests ...)
+; stanza.
+
+(test
+ (name test_briefing_gaps)
+ (modules test_briefing_gaps)
+ (libraries masc_test_deps))

--- a/test/test_briefing_gaps.ml
+++ b/test/test_briefing_gaps.ml
@@ -1,0 +1,279 @@
+(** Pure-function unit tests for [Briefing_gaps].
+
+    Audit P2 follow-up (2026-04-29 §3.1.2) — second of the four
+    briefing_*.ml modules in the "테스트 완전 부재" group.
+
+    [Briefing_gaps] turns sentinel strings ("unassigned",
+    "unknown", "not_recorded") in briefing fact JSON into
+    structured gap records and buckets them per briefing section
+    (Communication / Alignment / Watch).  Properties pinned:
+
+    1. {b Sentinel detection} — each documented sentinel produces
+       the right kind of gap record with the right scope_type.
+    2. {b Cap on gap count} — collect_metadata_gaps returns at
+       most 8 records (mli §22).
+    3. {b Section bucketing} — gap kinds map to the right
+       section: Communication = {communication_mode_missing,
+       keeper_last_reply_missing}, Alignment = {session_goal_missing,
+       agent_focus_missing}, Watch = {} (empty allow-list).
+    4. {b Active-agent guard} — agent_focus_missing only fires
+       for agents whose [status] is "active" or "busy"; idle
+       agents are skipped.
+    5. {b evidence_of_metadata_gaps caps at 2} per section. *)
+
+module G = Masc_mcp.Briefing_gaps
+
+let json_string s = `String s
+
+(* Helpers to construct fixture JSON ---------------------------- *)
+
+let session ?(session_id = "s1") ?(goal = "x") ?(comm = "x") () =
+  `Assoc
+    [
+      ("session_id", json_string session_id);
+      ("goal", json_string goal);
+      ("communication_mode", json_string comm);
+    ]
+
+let keeper ?(name = "k1") ?(status = "ok") () =
+  `Assoc
+    [
+      ("name", json_string name);
+      ("last_reply_status", json_string status);
+    ]
+
+let agent ?(name = "a1") ?(status = "active") ?(assignment = "x") () =
+  `Assoc
+    [
+      ("name", json_string name);
+      ("status", json_string status);
+      ("assignment_status", json_string assignment);
+    ]
+
+let kind_of j =
+  match j with
+  | `Assoc kv -> (
+      match List.assoc_opt "kind" kv with
+      | Some (`String s) -> s
+      | _ -> "")
+  | _ -> ""
+
+let scope_type_of j =
+  match j with
+  | `Assoc kv -> (
+      match List.assoc_opt "scope_type" kv with
+      | Some (`String s) -> s
+      | _ -> "")
+  | _ -> ""
+
+(* ── (1) Sentinel detection ────────────────────────────────── *)
+
+let test_session_goal_unassigned () =
+  let s = session ~goal:"unassigned" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[ s ] ~keepers:[] ~agents:[] in
+  assert (List.length gaps = 1);
+  let g = List.hd gaps in
+  assert (kind_of g = "session_goal_missing");
+  assert (scope_type_of g = "session")
+
+let test_session_communication_mode_unknown () =
+  let s = session ~comm:"unknown" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[ s ] ~keepers:[] ~agents:[] in
+  assert (List.length gaps = 1);
+  assert (kind_of (List.hd gaps) = "session_communication_mode_missing")
+
+let test_keeper_last_reply_not_recorded () =
+  let k = keeper ~status:"not_recorded" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[ k ] ~agents:[] in
+  assert (List.length gaps = 1);
+  let g = List.hd gaps in
+  assert (kind_of g = "keeper_last_reply_missing");
+  assert (scope_type_of g = "keeper")
+
+let test_agent_focus_missing_when_active () =
+  let a = agent ~status:"active" ~assignment:"unassigned" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[] ~agents:[ a ] in
+  assert (List.length gaps = 1);
+  let g = List.hd gaps in
+  assert (kind_of g = "agent_focus_missing");
+  assert (scope_type_of g = "agent")
+
+let test_no_gaps_when_no_sentinels () =
+  let s = session ~goal:"finished" ~comm:"async" () in
+  let k = keeper ~status:"replied" () in
+  let a = agent ~status:"active" ~assignment:"task-1" () in
+  let gaps =
+    G.collect_metadata_gaps ~sessions:[ s ] ~keepers:[ k ]
+      ~agents:[ a ]
+  in
+  assert (gaps = [])
+
+let test_session_id_omitted_when_blank () =
+  (* session with empty session_id should still produce gap, but
+     scope_id field projects to Null *)
+  let s =
+    `Assoc
+      [
+        ("session_id", `String "");
+        ("goal", `String "unassigned");
+        ("communication_mode", `String "x");
+      ]
+  in
+  let gaps = G.collect_metadata_gaps ~sessions:[ s ] ~keepers:[] ~agents:[] in
+  assert (List.length gaps = 1);
+  match List.hd gaps with
+  | `Assoc kv -> (
+      match List.assoc_opt "scope_id" kv with
+      | Some `Null -> ()
+      | _ -> assert false)
+  | _ -> assert false
+
+(* ── (2) take 8 cap ──────────────────────────────────────── *)
+
+let test_collect_caps_at_eight () =
+  (* Build > 8 sessions, each with 2 sentinel gaps (goal +
+     comm).  collect should cap at 8. *)
+  let many_sessions =
+    List.init 6 (fun i ->
+        session
+          ~session_id:(Printf.sprintf "s%d" i)
+          ~goal:"unassigned" ~comm:"unknown" ())
+  in
+  let gaps =
+    G.collect_metadata_gaps ~sessions:many_sessions ~keepers:[]
+      ~agents:[]
+  in
+  assert (List.length gaps = 8)
+
+(* ── (3) Section bucketing ─────────────────────────────────── *)
+
+let make_gap kind =
+  `Assoc [ ("kind", `String kind); ("summary", `String "x") ]
+
+let test_count_communication_section () =
+  let gaps =
+    [
+      make_gap "session_communication_mode_missing";
+      make_gap "keeper_last_reply_missing";
+      make_gap "session_goal_missing";  (* Alignment, not counted *)
+    ]
+  in
+  assert (G.count_metadata_gaps_for_section ~section:G.Communication gaps = 2)
+
+let test_count_alignment_section () =
+  let gaps =
+    [
+      make_gap "session_goal_missing";
+      make_gap "agent_focus_missing";
+      make_gap "keeper_last_reply_missing";  (* Communication *)
+    ]
+  in
+  assert (G.count_metadata_gaps_for_section ~section:G.Alignment gaps = 2)
+
+let test_count_watch_section_always_zero () =
+  (* Watch's allow-list is empty per impl line 79 — no gap kind
+     ever counts toward Watch. *)
+  let gaps =
+    [
+      make_gap "session_goal_missing";
+      make_gap "agent_focus_missing";
+      make_gap "session_communication_mode_missing";
+      make_gap "keeper_last_reply_missing";
+    ]
+  in
+  assert (G.count_metadata_gaps_for_section ~section:G.Watch gaps = 0)
+
+let test_count_unknown_kind_ignored () =
+  let gaps = [ make_gap "completely_unknown_kind" ] in
+  assert (G.count_metadata_gaps_for_section ~section:G.Communication gaps = 0);
+  assert (G.count_metadata_gaps_for_section ~section:G.Alignment gaps = 0)
+
+(* ── (4) Active-agent guard ────────────────────────────────── *)
+
+let test_idle_agent_skipped () =
+  (* Idle agent with assignment_status=unassigned must NOT
+     produce a focus_missing gap. *)
+  let a = agent ~status:"idle" ~assignment:"unassigned" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[] ~agents:[ a ] in
+  assert (gaps = [])
+
+let test_busy_agent_triggers () =
+  let a = agent ~status:"busy" ~assignment:"unassigned" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[] ~agents:[ a ] in
+  assert (List.length gaps = 1)
+
+let test_status_case_insensitive () =
+  (* impl uses [String.lowercase_ascii (String.trim ...)] — pin
+     case insensitivity. *)
+  let a = agent ~status:"ACTIVE" ~assignment:"unassigned" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[] ~agents:[ a ] in
+  assert (List.length gaps = 1)
+
+let test_status_with_whitespace () =
+  let a = agent ~status:"  active  " ~assignment:"unassigned" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[] ~agents:[ a ] in
+  assert (List.length gaps = 1)
+
+let test_active_with_assignment_no_gap () =
+  (* Active + assignment != "unassigned" → no gap. *)
+  let a = agent ~status:"active" ~assignment:"task-1" () in
+  let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[] ~agents:[ a ] in
+  assert (gaps = [])
+
+(* ── (5) evidence_of_metadata_gaps cap at 2 ──────────────── *)
+
+let test_evidence_caps_at_two () =
+  let gaps =
+    List.init 5 (fun _ -> make_gap "session_goal_missing")
+    @ [ make_gap "agent_focus_missing" ]
+  in
+  let evidence =
+    G.evidence_of_metadata_gaps ~section:G.Alignment gaps
+  in
+  assert (List.length evidence = 2)
+
+let test_evidence_returns_summaries () =
+  let gap =
+    `Assoc
+      [
+        ("kind", `String "session_goal_missing");
+        ("summary", `String "specific summary text");
+      ]
+  in
+  let evidence =
+    G.evidence_of_metadata_gaps ~section:G.Alignment [ gap ]
+  in
+  assert (evidence = [ "specific summary text" ])
+
+let test_evidence_filters_by_section () =
+  (* Communication-only gap shouldn't appear when section =
+     Alignment. *)
+  let gap = make_gap "keeper_last_reply_missing" in
+  let evidence =
+    G.evidence_of_metadata_gaps ~section:G.Alignment [ gap ]
+  in
+  assert (evidence = [])
+
+(* ── runner ──────────────────────────────────────────────── *)
+
+let () =
+  test_session_goal_unassigned ();
+  test_session_communication_mode_unknown ();
+  test_keeper_last_reply_not_recorded ();
+  test_agent_focus_missing_when_active ();
+  test_no_gaps_when_no_sentinels ();
+  test_session_id_omitted_when_blank ();
+  test_collect_caps_at_eight ();
+  test_count_communication_section ();
+  test_count_alignment_section ();
+  test_count_watch_section_always_zero ();
+  test_count_unknown_kind_ignored ();
+  test_idle_agent_skipped ();
+  test_busy_agent_triggers ();
+  test_status_case_insensitive ();
+  test_status_with_whitespace ();
+  test_active_with_assignment_no_gap ();
+  test_evidence_caps_at_two ();
+  test_evidence_returns_summaries ();
+  test_evidence_filters_by_section ();
+  print_endline "test_briefing_gaps: all assertions passed"


### PR DESCRIPTION
Audit P2 follow-up (2026-04-29 §3.1.2) — second of the 4 briefing_*.ml modules in the "테스트 완전 부재" group, after #12977 (briefing_json_helpers). 19 cases across 5 property groups.

## Properties pinned

| Group | Cases | Coverage |
|---|---:|---|
| (1) Sentinel detection | 6 | session goal/comm/keeper status/active-agent unassigned → correct kind+scope_type; blank session_id → scope_id=Null |
| (2) `take 8` cap | 1 | collect caps at 8 records (mli §22) |
| (3) Section bucketing | 4 | Communication/Alignment/Watch allow-lists; Watch always 0; unknown kind ignored |
| (4) Active-agent guard | 5 | focus_missing only fires for active/busy (case-insensitive, whitespace-trimmed); idle skipped; active+assigned → no gap |
| (5) `evidence_of_metadata_gaps` | 3 | caps at 2; returns summary strings; filters by section |

## Test plan

- [x] Test added under `test/stanzas/test_briefing_gaps.inc` per `test/stanzas/README.md`
- [x] Race check pre-push: no concurrent `briefing_gaps` test PR
- [x] `dune build + exec` — 19/19 cases passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)