### PR TITLE
feat(cascade): mode-aware runtime helper + env flag + Prometheus counter (RFC-0022 PR-2/4)

### DIFF
--- a/lib/cascade/cascade_attempt_liveness_runtime.ml
+++ b/lib/cascade/cascade_attempt_liveness_runtime.ml
@@ -1,0 +1,34 @@
+(** Cascade attempt-liveness runtime helpers (RFC-0022 PR-2/4).
+
+    Pure decision; see {!Cascade_attempt_liveness_runtime} mli for the
+    decision table. *)
+
+module Mode = Env_config_keeper.CascadeAttemptLiveness
+
+type verdict =
+  | Continue_attempt
+  | Abort_attempt of Cascade_attempt_liveness.failure
+
+type side_effect =
+  | Nothing
+  | Record_kill of {
+      kind : Cascade_attempt_liveness.failure;
+      mode_label : string;
+    }
+
+let decide
+    ~(mode : Mode.mode)
+    (out : Cascade_attempt_liveness.output)
+    : verdict * side_effect
+  =
+  match out, mode with
+  | Cascade_attempt_liveness.Continue, _ -> (Continue_attempt, Nothing)
+  | Cascade_attempt_liveness.Completed, _ -> (Continue_attempt, Nothing)
+  | Cascade_attempt_liveness.Outcome _, Mode.Off ->
+      (Continue_attempt, Nothing)
+  | Cascade_attempt_liveness.Outcome failure, Mode.Observe ->
+      ( Continue_attempt
+      , Record_kill { kind = failure; mode_label = Mode.mode_label Mode.Observe } )
+  | Cascade_attempt_liveness.Outcome failure, Mode.Enforce ->
+      ( Abort_attempt failure
+      , Record_kill { kind = failure; mode_label = Mode.mode_label Mode.Enforce } )

--- a/lib/cascade/cascade_attempt_liveness_runtime.mli
+++ b/lib/cascade/cascade_attempt_liveness_runtime.mli
@@ -1,0 +1,65 @@
+(** Cascade attempt-liveness runtime helpers (RFC-0022 PR-2/4).
+
+    Pure decision helpers that bridge {!Cascade_attempt_liveness} (the
+    PR-1 FSM) to the side effects callers will need: Prometheus
+    counter increment, log line, and the cascade-FSM-visible verdict
+    (advance vs continue).
+
+    {b Production effect of this PR}: zero. No call site in
+    [cascade_runtime.ml] or anywhere else consumes these helpers yet.
+    Wiring lands in PR-3 of the RFC-0022 stack.
+
+    @stability Evolving
+    @since 0.190.0 *)
+
+(** {1 Verdict observed by the cascade FSM} *)
+
+type verdict =
+  | Continue_attempt
+      (** Liveness gate did not fire, or fired but mode is non-enforcing.
+          Caller must NOT advance the cascade FSM on this verdict. *)
+
+  | Abort_attempt of Cascade_attempt_liveness.failure
+      (** Liveness gate fired and mode is [Enforce]. Caller must
+          advance the cascade FSM with the carried failure class. *)
+
+(** {1 Side-effect descriptor}
+
+    Returned to the caller alongside the {!verdict}. The caller
+    performs the actual emission (Prometheus, Log) so this module
+    stays IO-free and unit-testable. *)
+
+type side_effect =
+  | Nothing
+      (** No event to emit on this transition. *)
+
+  | Record_kill of {
+      kind : Cascade_attempt_liveness.failure;
+      mode_label : string;
+          (** [observe] or [enforce] at the time of the kill. *)
+    }
+      (** Kill observed; caller increments
+          [masc_cascade_attempt_liveness_kill_total]
+          and emits a structured log line. *)
+
+(** {1 Decision step}
+
+    Wraps {!Cascade_attempt_liveness.step} with mode awareness:
+
+    | Underlying FSM output | Mode | verdict | side_effect |
+    |-----------------------|------|---------|-------------|
+    | {!Cascade_attempt_liveness.Continue}  | any | [Continue_attempt] | [Nothing] |
+    | {!Cascade_attempt_liveness.Completed} | any | [Continue_attempt] | [Nothing] |
+    | {!Cascade_attempt_liveness.Outcome f} | [Off]     | [Continue_attempt] | [Nothing] |
+    | {!Cascade_attempt_liveness.Outcome f} | [Observe] | [Continue_attempt] | [Record_kill] |
+    | {!Cascade_attempt_liveness.Outcome f} | [Enforce] | [Abort_attempt f]  | [Record_kill] |
+
+    The [Completed] case is also reported as [Continue_attempt]
+    because the *cascade-attempt-level liveness* contract has nothing
+    to say about success — the caller's existing accept-predicate
+    decides what success means. *)
+
+val decide :
+  mode:Env_config_keeper.CascadeAttemptLiveness.mode ->
+  Cascade_attempt_liveness.output ->
+  verdict * side_effect

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -908,4 +908,42 @@ module KeeperRetryBackoff = struct
     Float.min cap (base *. Float.of_int (1 lsl (attempt - 1)))
 end
 
+(** RFC-0022 §9 rollout flag for the in-attempt streaming liveness gate.
+
+    Default {!CascadeAttemptLiveness.Observe} is *non-enforcing*: the
+    FSM runs, kills are logged and counted on
+    [masc_cascade_attempt_liveness_kill_total], but the cascade FSM
+    never sees them. Flip to [enforce] only after observation has
+    produced calibration data per §9 Phase B. *)
+module CascadeAttemptLiveness = struct
+  type mode =
+    | Off
+    | Observe
+    | Enforce
+
+  let mode_label = function
+    | Off -> "off"
+    | Observe -> "observe"
+    | Enforce -> "enforce"
+
+  let warned_unknown = ref false
+
+  let mode () : mode =
+    let raw = get_string ~default:"observe" "MASC_CASCADE_ATTEMPT_LIVENESS" in
+    match String.lowercase_ascii (String.trim raw) with
+    | "off" | "0" | "false" -> Off
+    | "" | "observe" -> Observe
+    | "enforce" | "on" | "1" | "true" -> Enforce
+    | other ->
+        if not !warned_unknown then begin
+          warned_unknown := true;
+          prerr_endline
+            (Printf.sprintf
+               "[env_config_keeper] WARN: MASC_CASCADE_ATTEMPT_LIVENESS=%s \
+                unrecognised, defaulting to observe"
+               other)
+        end;
+        Observe
+end
+
 (** Print configuration summary for debugging *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -290,3 +290,31 @@ module KeeperRetryBackoff : sig
   val transient_backoff_cap_sec : unit -> float
   val transient_backoff_sec : int -> float
 end
+
+(** {1 Cascade attempt liveness — RFC-0022 §9 rollout flag} *)
+
+module CascadeAttemptLiveness : sig
+  type mode =
+    | Off
+        (** No FSM driving, no counter, no kills. Equivalent to the
+            world before RFC-0022. *)
+
+    | Observe
+        (** FSM runs alongside the existing cascade attempt; would-be
+            kills are logged and counted ([masc_cascade_attempt_liveness_kill_total]),
+            but the cascade FSM never sees them. Default. *)
+
+    | Enforce
+        (** FSM runs and would-be kills are reported back to the
+            cascade FSM as [Failed_attempt], advancing to the next
+            provider. Reserved for PR-3+ once observation has produced
+            calibration data per §9 Phase B. *)
+
+  val mode : unit -> mode
+  (** Read [MASC_CASCADE_ATTEMPT_LIVENESS]. Unrecognised values fall
+      back to {!Observe} (with a one-time stderr warning). *)
+
+  val mode_label : mode -> string
+  (** Stable string label for telemetry / log output:
+      [off | observe | enforce]. *)
+end

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -867,6 +867,12 @@ let metric_anti_rationalization_excuse_pattern =
 let metric_board_truncated_posts = "masc_board_truncated_posts_total"
 let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
 let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
+
+(* RFC-0022 §9 attempt-liveness gate.  Counts would-be (Observe) and
+   actual (Enforce) liveness kills broken down by failure class.
+   Labels: [kind, mode, provider]. *)
+let metric_cascade_attempt_liveness_kill =
+  "masc_cascade_attempt_liveness_kill_total"
 let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total"
 let metric_keeper_fsm_edge_transitions =
   "masc_keeper_fsm_edge_transitions_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -409,6 +409,21 @@ val metric_anti_rationalization_excuse_pattern : string
     [advisory_to_llm | terminal_reject | advisory_safety_net_reject]. *)
 val metric_cascade_strategy_decisions : string
 val metric_cascade_capacity_events : string
+
+val metric_cascade_attempt_liveness_kill : string
+(** RFC-0022 §9 — would-be ([mode=observe]) and actual ([mode=enforce])
+    in-attempt liveness kills, broken down by failure class.
+
+    Labels: [kind, mode, provider] where:
+    - [kind] ∈ [no_first_token | inter_chunk_idle | wall_exceeded | provider_error]
+    - [mode] ∈ [observe | enforce]
+    - [provider] is the cascade label that produced the attempt
+
+    Use the {b observe}-mode counter to calibrate the per-profile
+    budgets (cloud_fast / cloud_thinking / local_27b / local_70b_plus)
+    against [scripts/diag-keeper-cycle.sh] before flipping any profile
+    to {b enforce}. *)
+
 val metric_cascade_server_error_skip_total : string
 (** #12797 Total cascade label-ranking skips triggered by recent server-error
     (5xx) score decay for a provider.  Labels: [provider_key]. *)

--- a/test/dune
+++ b/test/dune
@@ -1009,6 +1009,7 @@
 (include stanzas/test_briefing_gaps.inc)
 (include stanzas/test_briefing_json_helpers.inc)
 (include stanzas/test_cascade_attempt_liveness.inc)
+(include stanzas/test_cascade_attempt_liveness_runtime.inc)
 (include stanzas/test_cascade_capability_gate.inc)
 (include stanzas/test_cascade_catalog_runtime.inc)
 (include stanzas/test_cascade_config_validity.inc)

--- a/test/stanzas/test_cascade_attempt_liveness_runtime.inc
+++ b/test/stanzas/test_cascade_attempt_liveness_runtime.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_attempt_liveness_runtime)
+ (modules test_cascade_attempt_liveness_runtime)
+ (libraries masc_test_deps))

--- a/test/test_cascade_attempt_liveness_runtime.ml
+++ b/test/test_cascade_attempt_liveness_runtime.ml
@@ -1,0 +1,108 @@
+(** Tests for [Cascade_attempt_liveness_runtime] mode-aware decision (RFC-0022 PR-2/4). *)
+
+open Masc_mcp
+module L = Cascade_attempt_liveness
+module R = Cascade_attempt_liveness_runtime
+module Mode = Env_config_keeper.CascadeAttemptLiveness
+
+let pp_failure fmt f =
+  Format.pp_print_string fmt (L.failure_kind_label f)
+
+let check_verdict =
+  Alcotest.testable
+    (fun fmt -> function
+      | R.Continue_attempt -> Format.fprintf fmt "Continue_attempt"
+      | R.Abort_attempt f ->
+          Format.fprintf fmt "Abort_attempt(%a)" pp_failure f)
+    ( = )
+
+let check_side_effect =
+  Alcotest.testable
+    (fun fmt -> function
+      | R.Nothing -> Format.fprintf fmt "Nothing"
+      | R.Record_kill { kind; mode_label } ->
+          Format.fprintf fmt "Record_kill(kind=%a, mode=%s)"
+            pp_failure kind mode_label)
+    ( = )
+
+(* ──────────────────────── decision-table ──────────────────────── *)
+
+let test_continue_is_inert () =
+  let v, fx = R.decide ~mode:Mode.Observe L.Continue in
+  Alcotest.check check_verdict "continue" R.Continue_attempt v;
+  Alcotest.check check_side_effect "no side effect" R.Nothing fx
+
+let test_completed_is_inert () =
+  let v, fx = R.decide ~mode:Mode.Enforce L.Completed in
+  Alcotest.check check_verdict "completed" R.Continue_attempt v;
+  Alcotest.check check_side_effect "no side effect" R.Nothing fx
+
+let test_outcome_off_no_kill_no_record () =
+  let v, fx =
+    R.decide ~mode:Mode.Off (L.Outcome L.No_first_token)
+  in
+  Alcotest.check check_verdict "off swallows the kill" R.Continue_attempt v;
+  Alcotest.check check_side_effect "off does not record" R.Nothing fx
+
+let test_outcome_observe_continues_but_records () =
+  let v, fx =
+    R.decide ~mode:Mode.Observe (L.Outcome L.Inter_chunk_idle)
+  in
+  Alcotest.check check_verdict "observe never aborts"
+    R.Continue_attempt v;
+  Alcotest.check check_side_effect "observe records kill"
+    (R.Record_kill { kind = L.Inter_chunk_idle; mode_label = "observe" })
+    fx
+
+let test_outcome_enforce_aborts_and_records () =
+  let v, fx =
+    R.decide ~mode:Mode.Enforce (L.Outcome L.Wall_exceeded)
+  in
+  Alcotest.check check_verdict "enforce aborts"
+    (R.Abort_attempt L.Wall_exceeded) v;
+  Alcotest.check check_side_effect "enforce records kill"
+    (R.Record_kill { kind = L.Wall_exceeded; mode_label = "enforce" })
+    fx
+
+let test_provider_error_observe_records_with_kind () =
+  let err = L.Provider_error "HTTP 502" in
+  let v, fx = R.decide ~mode:Mode.Observe (L.Outcome err) in
+  Alcotest.check check_verdict "observe never aborts"
+    R.Continue_attempt v;
+  Alcotest.check check_side_effect
+    "kind is Provider_error preserved on observe"
+    (R.Record_kill { kind = err; mode_label = "observe" })
+    fx
+
+(* ──────────────────────── mode_label round-trip ──────────────────────── *)
+
+let test_mode_labels_are_lowercase_stable () =
+  Alcotest.(check string) "off" "off" (Mode.mode_label Mode.Off);
+  Alcotest.(check string) "observe" "observe" (Mode.mode_label Mode.Observe);
+  Alcotest.(check string) "enforce" "enforce" (Mode.mode_label Mode.Enforce)
+
+let () =
+  let case name f = Alcotest.test_case name `Quick f in
+  Alcotest.run "Cascade_attempt_liveness_runtime"
+    [
+      ( "decide",
+        [
+          case "Continue → Continue_attempt + Nothing"
+            test_continue_is_inert;
+          case "Completed → Continue_attempt + Nothing (Enforce)"
+            test_completed_is_inert;
+          case "Outcome × Off → Continue_attempt + Nothing"
+            test_outcome_off_no_kill_no_record;
+          case "Outcome × Observe → Continue_attempt + Record_kill"
+            test_outcome_observe_continues_but_records;
+          case "Outcome × Enforce → Abort_attempt + Record_kill"
+            test_outcome_enforce_aborts_and_records;
+          case "Provider_error preserved through Record_kill"
+            test_provider_error_observe_records_with_kind;
+        ] );
+      ( "mode_label",
+        [
+          case "off / observe / enforce stable lowercase"
+            test_mode_labels_are_lowercase_stable;
+        ] );
+    ]


### PR DESCRIPTION
## Stack

- PR-1 (#12968) — pure FSM + decision-table tests
- **PR-2 (this)** — mode-aware runtime helper + env flag + Prometheus counter declaration
- PR-3 (next) — wire `Stream_chunk` events from cascade attempt loop into the FSM
- PR-4 (next) — TLA+ spec lifted from RFC §5

Base: `feat/0022-pr-1-attempt-liveness-fsm` (PR #12968).
Reads cleanly only after PR-1 lands.

## Scope

RFC-0022 §9 Phase A rollout knobs. Pure logic + declarations only — no caller wiring, no production behavior change.

| File | Purpose |
|------|---------|
| `lib/config/env_config_keeper.{ml,mli}` (`CascadeAttemptLiveness` submodule) | tri-state mode `off / observe / enforce` parsed from `MASC_CASCADE_ATTEMPT_LIVENESS` (default `observe`); unrecognised values fall back to `Observe` with one-time stderr warn |
| `lib/cascade/cascade_attempt_liveness_runtime.{ml,mli}` | pure `decide : mode -> output -> verdict * side_effect` splitter so callers do Prometheus inc + log without coupling FSM to either |
| `lib/prometheus.{ml,mli}` | declares `masc_cascade_attempt_liveness_kill_total` (labels: `kind`, `mode`, `provider`); no instrumentation |
| `test/test_cascade_attempt_liveness_runtime.ml` (+ stanza) | 7 alcotest cases over the full `mode × output` matrix |

## Decision table

| `output` | `Off` | `Observe` | `Enforce` |
|---------|-------|-----------|-----------|
| `Continue` / `Completed` | `Continue_attempt + Nothing` | (same) | (same) |
| `Outcome failure` | `Continue_attempt + Nothing` | `Continue_attempt + Record_kill` | `Abort_attempt failure + Record_kill` |

`Record_kill` is just a description (`{kind; mode_label}`); the caller decides how to record it. Keeps this layer purely functional and easy to property-test.

## Verification

- `dune build lib/cascade lib/config lib/prometheus` — green
- `dune exec test/test_cascade_attempt_liveness_runtime.exe` — 7/7 PASS
- `rg 'cascade_attempt_liveness_runtime' lib/` — only declaration sites; no caller in cascade hot path (intentional — wiring is PR-3)

## Production effect

Zero. The runtime module is dormant; the env var is read only by callers that don't exist yet; the Prometheus counter is declared but never incremented. Phase A flag (`observe`) won't kill anything until PR-3 ships and a caller is added.

## Notes

- `CascadeAttemptLiveness` lives under `Env_config_keeper` to mirror the existing keeper-runtime config conventions (single namespace per concern).
- `mode_label` is stable lowercase (`off`/`observe`/`enforce`) so it's safe as a Prometheus label value.
- Unrecognised env values fall back to `Observe` — RFC §9 defaults to soft-observe, not soft-disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)