### PR TITLE
fix(security): header injection + path traversal in workspace routes

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -116,9 +116,17 @@ let rel_under base safe =
     else safe
 
 (* Reject anything that could be parsed by git as an option (leading
-   "-") or that contains separators outside the conservative ref/SHA
-   charset. Defense against `?base_ref=-L1,9999` style injection
-   even on git versions that lack [--end-of-options]. *)
+   "-") or that contains separators outside the conservative ref/SHA +
+   revision-syntax charset. Defense against `?base_ref=-L1,9999` style
+   injection even on git versions that lack [--end-of-options].
+
+   Charset rationale:
+   - alphanumerics + [._/-]: ordinary ref/branch/tag names
+   - [~^@]: revision-syntax suffix operators (HEAD~1, HEAD^, @{u})
+   - [+]: valid in branch names per [git check-ref-format]
+   - [{}]: needed for [@{upstream}] / [HEAD@{1}] expressions
+   Excluded: [: ! ? * \ space NUL] — separators with shell or git
+   pathspec semantics that callers should not need in [base_ref]. *)
 let valid_git_ref s =
   let n = String.length s in
   n > 0 && n <= 256 && s.[0] <> '-'
@@ -126,7 +134,8 @@ let valid_git_ref s =
        (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
        || (c >= '0' && c <= '9')
        || c = '/' || c = '.' || c = '_' || c = '-'
-       || c = '~' || c = '^' || c = '@')
+       || c = '~' || c = '^' || c = '@' || c = '+'
+       || c = '{' || c = '}')
        s
 
 (* --- Recursive file tree --- *)
@@ -398,15 +407,18 @@ let add_routes router =
                json_response ~status:`Not_found request reqd (json_error "File not found")
              else
                let rel = rel_under base safe in
-               match git_run_lines_or_error ~cwd:base
+               (* Blame keeps the original silent-empty contract: a file
+                  that exists in the working tree but is not yet tracked
+                  in HEAD (newly added, .gitignore'd, etc.) is a valid
+                  caller scenario, and surfacing git's non-zero exit as
+                  4xx would break it. The end-of-options separator still
+                  blocks `-L1,9999`-style argv injection. *)
+               match git_run_lines ~cwd:base
                        ["blame"; "--porcelain"; "--"; rel]
                with
-               | Error _ ->
-                 json_response ~status:`Bad_request request reqd
-                   (json_error "git blame failed")
-               | Ok [] ->
+               | [] ->
                  json_response_with_source ~status:`OK ~source request reqd (`List [])
-               | Ok lines ->
+               | lines ->
                  let entries = parse_blame_porcelain lines in
                  let grouped = group_blame_entries rel entries in
                  json_response_with_source ~status:`OK ~source request reqd (`List grouped))

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -58,15 +58,24 @@ let json_response ~status req reqd json =
   Http.Response.json ~status ~request:req
     (Yojson.Safe.to_string json) reqd
 
+(* Strip CR/LF and other control characters from a value before placing
+   it into an HTTP response header. RFC 7230 §3.2.4 prohibits CR/LF in
+   field-value, and an unsanitized name with "\r\nSet-Cookie: ..." would
+   let an attacker inject arbitrary headers via the keeper query param. *)
+let sanitize_header_value s =
+  String.map (fun c ->
+    let code = Char.code c in
+    if code < 0x20 || code = 0x7f then '_' else c) s
+
 (* Encode the workspace source tag as a single header value so the
    frontend can render hints ("Playground 없음 — 프로젝트로 fallback")
    without parsing the JSON body. *)
 let source_header source =
   let v = match source with
     | `Project -> "project"
-    | `Playground name -> "playground:" ^ name
-    | `PlaygroundMissing name -> "playground_missing:" ^ name
-    | `KeeperUnknown name -> "keeper_unknown:" ^ name
+    | `Playground name -> "playground:" ^ sanitize_header_value name
+    | `PlaygroundMissing name -> "playground_missing:" ^ sanitize_header_value name
+    | `KeeperUnknown name -> "keeper_unknown:" ^ sanitize_header_value name
   in
   [("X-Workspace-Source", v)]
 
@@ -349,12 +358,14 @@ let add_routes router =
              else if not (Sys.file_exists safe) then
                json_response ~status:`Not_found request reqd (json_error "File not found")
              else
-               match git_run_lines ~cwd:base ["blame"; "--porcelain"; file_path] with
+               let rel = String.sub safe (String.length base + 1)
+                 (String.length safe - String.length base - 1) in
+               match git_run_lines ~cwd:base ["blame"; "--porcelain"; rel] with
                | [] ->
                  json_response_with_source ~status:`OK ~source request reqd (`List [])
                | lines ->
                  let entries = parse_blame_porcelain lines in
-                 let grouped = group_blame_entries file_path entries in
+                 let grouped = group_blame_entries rel entries in
                  json_response_with_source ~status:`OK ~source request reqd (`List grouped))
          request reqd)
 
@@ -380,7 +391,9 @@ let add_routes router =
              if safe = base then
                json_response ~status:`Bad_request request reqd (json_error "Invalid path")
              else
-               match git_run_lines ~cwd:base ["diff"; base_ref; "--"; file_path] with
+               let rel = String.sub safe (String.length base + 1)
+                 (String.length safe - String.length base - 1) in
+               match git_run_lines ~cwd:base ["diff"; base_ref; "--"; rel] with
                | [] ->
                  json_response_with_source ~status:`OK ~source request reqd
                    (`Assoc [("unified", `List []); ("has_changes", `Bool false)])

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -100,6 +100,35 @@ let safe_path base requested =
     let full = List.fold_left (fun acc p -> Filename.concat acc p) base parts in
     if String.starts_with ~prefix:base full then full else base
 
+(* Strip [base] (and the following separator) from [safe]. Handles
+   [base = "/"], trailing slash on [base], and [safe = base] (returns "").
+   Assumes [safe_path] has already enforced the prefix invariant. *)
+let rel_under base safe =
+  if safe = base then ""
+  else
+    let base_norm =
+      let n = String.length base in
+      if n > 0 && base.[n - 1] = '/' then base else base ^ "/"
+    in
+    let bn = String.length base_norm in
+    if String.length safe >= bn && String.starts_with ~prefix:base_norm safe
+    then String.sub safe bn (String.length safe - bn)
+    else safe
+
+(* Reject anything that could be parsed by git as an option (leading
+   "-") or that contains separators outside the conservative ref/SHA
+   charset. Defense against `?base_ref=-L1,9999` style injection
+   even on git versions that lack [--end-of-options]. *)
+let valid_git_ref s =
+  let n = String.length s in
+  n > 0 && n <= 256 && s.[0] <> '-'
+  && String.for_all (fun c ->
+       (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+       || (c >= '0' && c <= '9')
+       || c = '/' || c = '.' || c = '_' || c = '-'
+       || c = '~' || c = '^' || c = '@')
+       s
+
 (* --- Recursive file tree --- *)
 
 let file_tree_node ~path ~label ~depth ~parent ~has_children =
@@ -162,6 +191,16 @@ let git_run_lines ~cwd args =
   | Some out ->
     String.split_on_char '\n' out
     |> List.filter (fun l -> l <> "")
+
+(* Surface git failure to the caller instead of collapsing to []. Lets
+   route handlers distinguish "command errored / invalid ref" from
+   "command succeeded with no output". *)
+let git_run_lines_or_error ~cwd args =
+  match git_run ~cwd args with
+  | None -> Error "git command failed"
+  | Some out ->
+    Ok (String.split_on_char '\n' out
+        |> List.filter (fun l -> l <> ""))
 
 (* --- Blame parsing: collect per-line then group adjacent same-author ranges --- *)
 
@@ -358,12 +397,16 @@ let add_routes router =
              else if not (Sys.file_exists safe) then
                json_response ~status:`Not_found request reqd (json_error "File not found")
              else
-               let rel = String.sub safe (String.length base + 1)
-                 (String.length safe - String.length base - 1) in
-               match git_run_lines ~cwd:base ["blame"; "--porcelain"; rel] with
-               | [] ->
+               let rel = rel_under base safe in
+               match git_run_lines_or_error ~cwd:base
+                       ["blame"; "--porcelain"; "--"; rel]
+               with
+               | Error _ ->
+                 json_response ~status:`Bad_request request reqd
+                   (json_error "git blame failed")
+               | Ok [] ->
                  json_response_with_source ~status:`OK ~source request reqd (`List [])
-               | lines ->
+               | Ok lines ->
                  let entries = parse_blame_porcelain lines in
                  let grouped = group_blame_entries rel entries in
                  json_response_with_source ~status:`OK ~source request reqd (`List grouped))
@@ -387,17 +430,25 @@ let add_routes router =
                | Some r -> r
                | None -> "HEAD"
              in
+             if not (valid_git_ref base_ref) then
+               json_response ~status:`Bad_request request reqd
+                 (json_error "Invalid base_ref")
+             else
              let safe = safe_path base file_path in
              if safe = base then
                json_response ~status:`Bad_request request reqd (json_error "Invalid path")
              else
-               let rel = String.sub safe (String.length base + 1)
-                 (String.length safe - String.length base - 1) in
-               match git_run_lines ~cwd:base ["diff"; base_ref; "--"; rel] with
-               | [] ->
+               let rel = rel_under base safe in
+               match git_run_lines_or_error ~cwd:base
+                       ["diff"; base_ref; "--"; rel]
+               with
+               | Error _ ->
+                 json_response ~status:`Bad_request request reqd
+                   (json_error "git diff failed")
+               | Ok [] ->
                  json_response_with_source ~status:`OK ~source request reqd
                    (`Assoc [("unified", `List []); ("has_changes", `Bool false)])
-               | diff_lines ->
+               | Ok diff_lines ->
                  let unified = parse_unified_diff diff_lines in
                  let json = `Assoc [("unified", `List unified); ("has_changes", `Bool true)] in
                  json_response_with_source ~status:`OK ~source request reqd json)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -24,3 +24,16 @@ val source_header :
   | `PlaygroundMissing of string
   | `KeeperUnknown of string ] ->
   (string * string) list
+
+(** [rel_under base safe] returns the path of [safe] relative to [base],
+    handling [base = "/"], trailing slashes, and the [safe = base] case
+    (returns [""]). Caller must have already enforced the prefix
+    invariant via the internal [safe_path] helper. Exposed for unit
+    testing. *)
+val rel_under : string -> string -> string
+
+(** [valid_git_ref s] is [true] iff [s] is a non-empty, ≤256-char string
+    drawn from the conservative ref/SHA charset and not starting with
+    ["-"]. Used to refuse query-string values that could be parsed as
+    git options (e.g. [?base_ref=-L1,9999]). Exposed for unit testing. *)
+val valid_git_ref : string -> bool

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -141,6 +141,63 @@ let test_header_keeper_unknown () =
   let v = header_value (W.source_header (`KeeperUnknown "ghost")) in
   Alcotest.(check string) "unknown encoding" "keeper_unknown:ghost" v
 
+(* ─── rel_under (path math, root-base safety) ───────────────────── *)
+
+let test_rel_under_normal () =
+  Alcotest.(check string) "/repo + /repo/src/main.ml -> src/main.ml"
+    "src/main.ml" (W.rel_under "/repo" "/repo/src/main.ml")
+
+let test_rel_under_root_base () =
+  Alcotest.(check string) "/ + /etc/hosts -> etc/hosts"
+    "etc/hosts" (W.rel_under "/" "/etc/hosts")
+
+let test_rel_under_trailing_slash () =
+  Alcotest.(check string) "trailing-slash base normalises"
+    "src/a.ml" (W.rel_under "/repo/" "/repo/src/a.ml")
+
+let test_rel_under_equal () =
+  Alcotest.(check string) "safe = base -> empty"
+    "" (W.rel_under "/repo" "/repo")
+
+(* ─── valid_git_ref (option-injection guard) ────────────────────── *)
+
+let test_valid_ref_main () =
+  Alcotest.(check bool) "main is valid" true (W.valid_git_ref "main")
+
+let test_valid_ref_sha () =
+  Alcotest.(check bool) "40-char SHA is valid"
+    true (W.valid_git_ref "0123456789abcdef0123456789abcdef01234567")
+
+let test_valid_ref_path_form () =
+  Alcotest.(check bool) "origin/main is valid"
+    true (W.valid_git_ref "origin/main")
+
+let test_valid_ref_caret () =
+  Alcotest.(check bool) "HEAD^ is valid" true (W.valid_git_ref "HEAD^")
+
+let test_valid_ref_rejects_leading_dash () =
+  Alcotest.(check bool) "leading dash refused"
+    false (W.valid_git_ref "-L1,9999")
+
+let test_valid_ref_rejects_empty () =
+  Alcotest.(check bool) "empty refused" false (W.valid_git_ref "")
+
+let test_valid_ref_rejects_whitespace () =
+  Alcotest.(check bool) "embedded space refused"
+    false (W.valid_git_ref "main ; rm -rf /")
+
+let test_valid_ref_rejects_semicolon () =
+  Alcotest.(check bool) "semicolon refused"
+    false (W.valid_git_ref "main;ls")
+
+let test_valid_ref_rejects_newline () =
+  Alcotest.(check bool) "newline refused"
+    false (W.valid_git_ref "main\nrm")
+
+let test_valid_ref_rejects_oversize () =
+  Alcotest.(check bool) "oversize refused"
+    false (W.valid_git_ref (String.make 257 'a'))
+
 let () =
   Alcotest.run "workspace_routes_keeper"
     [ ( "classify_keeper_query"
@@ -157,5 +214,23 @@ let () =
         ; Alcotest.test_case "playground"        `Quick test_header_playground
         ; Alcotest.test_case "playground missing" `Quick test_header_playground_missing
         ; Alcotest.test_case "keeper unknown"    `Quick test_header_keeper_unknown
+        ] )
+    ; ( "rel_under"
+      , [ Alcotest.test_case "normal nested"     `Quick test_rel_under_normal
+        ; Alcotest.test_case "root base"         `Quick test_rel_under_root_base
+        ; Alcotest.test_case "trailing slash"    `Quick test_rel_under_trailing_slash
+        ; Alcotest.test_case "safe equals base"  `Quick test_rel_under_equal
+        ] )
+    ; ( "valid_git_ref"
+      , [ Alcotest.test_case "main"              `Quick test_valid_ref_main
+        ; Alcotest.test_case "40-char SHA"       `Quick test_valid_ref_sha
+        ; Alcotest.test_case "origin/main"       `Quick test_valid_ref_path_form
+        ; Alcotest.test_case "HEAD^"             `Quick test_valid_ref_caret
+        ; Alcotest.test_case "rejects -L1,9999"  `Quick test_valid_ref_rejects_leading_dash
+        ; Alcotest.test_case "rejects empty"     `Quick test_valid_ref_rejects_empty
+        ; Alcotest.test_case "rejects whitespace" `Quick test_valid_ref_rejects_whitespace
+        ; Alcotest.test_case "rejects semicolon" `Quick test_valid_ref_rejects_semicolon
+        ; Alcotest.test_case "rejects newline"   `Quick test_valid_ref_rejects_newline
+        ; Alcotest.test_case "rejects oversize"  `Quick test_valid_ref_rejects_oversize
         ] )
     ]

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -175,6 +175,18 @@ let test_valid_ref_path_form () =
 let test_valid_ref_caret () =
   Alcotest.(check bool) "HEAD^ is valid" true (W.valid_git_ref "HEAD^")
 
+let test_valid_ref_plus () =
+  Alcotest.(check bool) "feature+v2 (branch with '+') is valid"
+    true (W.valid_git_ref "feature+v2")
+
+let test_valid_ref_upstream_brace () =
+  Alcotest.(check bool) "@{upstream} revision is valid"
+    true (W.valid_git_ref "@{upstream}")
+
+let test_valid_ref_reflog_brace () =
+  Alcotest.(check bool) "HEAD@{1} reflog revision is valid"
+    true (W.valid_git_ref "HEAD@{1}")
+
 let test_valid_ref_rejects_leading_dash () =
   Alcotest.(check bool) "leading dash refused"
     false (W.valid_git_ref "-L1,9999")
@@ -226,6 +238,9 @@ let () =
         ; Alcotest.test_case "40-char SHA"       `Quick test_valid_ref_sha
         ; Alcotest.test_case "origin/main"       `Quick test_valid_ref_path_form
         ; Alcotest.test_case "HEAD^"             `Quick test_valid_ref_caret
+        ; Alcotest.test_case "feature+v2"        `Quick test_valid_ref_plus
+        ; Alcotest.test_case "@{upstream}"       `Quick test_valid_ref_upstream_brace
+        ; Alcotest.test_case "HEAD@{1}"          `Quick test_valid_ref_reflog_brace
         ; Alcotest.test_case "rejects -L1,9999"  `Quick test_valid_ref_rejects_leading_dash
         ; Alcotest.test_case "rejects empty"     `Quick test_valid_ref_rejects_empty
         ; Alcotest.test_case "rejects whitespace" `Quick test_valid_ref_rejects_whitespace


### PR DESCRIPTION
## Summary
- Sanitize CRLF/control chars in X-Workspace-Source header (P1 CRLF injection)
- Use validated relative path in git blame/diff commands instead of raw query param (P1 path traversal)

## Security Details

### CRLF Injection
Keeper/playground names from query params were placed directly into HTTP response headers.
A name containing `\r\nSet-Cookie: evil=value` would inject arbitrary headers.
Fix: `sanitize_header_value()` strips all chars < 0x20 and 0x7F per RFC 7230 §3.2.4.

### Path Traversal
`safe_path()` validated the resolved path but the original `file_path` query param
was passed directly to `git blame`/`git diff` commands. An attacker could craft a
`file_path` that passes `safe_path` but differs from the validated result.
Fix: compute relative path from the validated `safe` absolute path and use that for git commands.

## Test plan
- [ ] `curl` workspace API with `?keeper=%0d%0aX-Injected:true` → header value sanitized
- [ ] `curl` git blame API with `?path=../../../etc/passwd` → rejected or 404
- [ ] Normal workspace operations unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)