### PR TITLE
chore(dashboard): remove fabricated telemetry placeholders (Tier A — audit response)

### DIFF
--- a/dashboard/cockpit-kit/App.jsx
+++ b/dashboard/cockpit-kit/App.jsx
@@ -4,10 +4,21 @@
 const { useState, useCallback, useEffect } = React;
 
 function App() {
-  // sync mode/branch with the cockpit-state singleton (URL+localStorage)
-  const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{}, () => {}]);
+  // sync mode/branch with the cockpit-state singleton (URL+localStorage).
+  // If the hook is not available we surface that loudly: previously the
+  // fallback was a silent stub which made cockpit state look functional
+  // while every write was dropped on the floor.
+  const [cs, setCs] = (() => {
+    if (window.useCockpitState) return window.useCockpitState();
+    console.error("[App] window.useCockpitState missing — cockpit state hook did not load; mode/branch changes will not persist");
+    return [{}, () => {}];
+  })();
   // run layout profile — auto-collapses chrome per mode
-  if (window.useLayoutProfile) window.useLayoutProfile();
+  if (window.useLayoutProfile) {
+    window.useLayoutProfile();
+  } else {
+    console.error("[App] window.useLayoutProfile missing — layout auto-collapse disabled");
+  }
   const [mode, setModeRaw] = useState(cs.mode || "Dashboard");
   const [density, setDensity] = useState("normal");
   const [selKeeper, setSelKeeper] = useState("nick0cave");
@@ -25,6 +36,19 @@ function App() {
   const setBranch = useCallback((b) => { setBranchRaw(b); setCs({ branch: b }); }, [setCs]);
 
   const D = window.MASC_DATA;
+  // Without the data layer the cockpit cannot render anything meaningful.
+  // Show a visible error instead of crashing on D.goals.find below.
+  if (!D || !Array.isArray(D.goals)) {
+    return (
+      <div className="app app-error" role="alert" data-error="missing-masc-data">
+        <h1>Cockpit data unavailable</h1>
+        <p>
+          <code>window.MASC_DATA</code> is missing or malformed. Verify the data
+          layer script loaded before App.jsx.
+        </p>
+      </div>
+    );
+  }
   const activeGoal = D.goals.find(g => g.id === selGoal) || D.goals[0];
 
   const toggleKeeper = useCallback((id) => {

--- a/dashboard/cockpit-kit/StatusTray.jsx
+++ b/dashboard/cockpit-kit/StatusTray.jsx
@@ -10,7 +10,7 @@
    Lives in bottom-left so it doesn't fight the FocusToggle (bottom-right)
    or the Composer (which is hidden in focus mode anyway). */
 
-const { useState: _stUseState, useEffect: _stUseEffect, useRef: _stUseRef } = React;
+const { useState: _stUseState, useEffect: _stUseEffect, useRef: _stUseRef, useMemo: _stUseMemo } = React;
 
 function _useTrayPop() {
   const [open, setOpen] = _stUseState(null); // 'kpi' | 'life' | 'ticker' | 'keepers' | null
@@ -31,13 +31,44 @@ function _useTrayPop() {
   return [open, setOpen, ref];
 }
 
-function _kpiSpotlight(D) {
+// Count events + keepers in a single pass each. The previous version
+// iterated `events` and `keepers` four times and used `Array.filter` for
+// pure counts; this version is allocation-free and easier to extend.
+function _statusCounts(D) {
   const evs = (D && D.events) || [];
-  const fails = evs.filter(e => e.kind === "fail").length;
-  const cascades = evs.filter(e => e.kind === "cascade").length;
-  if (fails >= 3) return { l: "Fails", v: fails, t: "err",  u: "/47", urgent: true };
-  if (cascades >= 2) return { l: "Cascade", v: cascades, t: "info", u: "@step" };
-  return { l: "tps", v: "1.24", t: "brass", u: "tps" };
+  let fails = 0;
+  let cascades = 0;
+  for (const e of evs) {
+    if (!e) continue;
+    if (e.kind === "fail") fails++;
+    else if (e.kind === "cascade") cascades++;
+  }
+  const keepers = (D && D.keepers) || [];
+  let active = 0;
+  let stalled = 0;
+  for (const k of keepers) {
+    if (!k) continue;
+    if (k.status !== "idle") active++;
+    if (k.status === "stalled") stalled++;
+  }
+  return {
+    fails,
+    cascades,
+    evCount: evs.length,
+    lastEvent: evs.length > 0 ? evs[evs.length - 1] : null,
+    keepersTotal: keepers.length,
+    active,
+    stalled,
+  };
+}
+
+// Pick the dot to spotlight in the KPI slot. Only the urgent paths
+// have real meaning today; for the calm path we expose the raw event
+// count rather than a fabricated TPS number.
+function _kpiSpotlight(counts) {
+  if (counts.fails >= 3) return { l: "fails", v: counts.fails, t: "err", u: "", urgent: true };
+  if (counts.cascades >= 2) return { l: "cascade", v: counts.cascades, t: "info", u: "" };
+  return { l: "events", v: counts.evCount, t: "brass", u: "" };
 }
 
 function StatusTray() {
@@ -45,12 +76,13 @@ function StatusTray() {
   const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{trayHidden:false}, ()=>{}]);
   const hidden = !!cs.trayHidden;
   const [open, setOpen, ref] = _useTrayPop();
-  const spot = _kpiSpotlight(D);
-  const events = (D.events || []).slice(-1)[0];
-  const evCount = (D.events || []).length;
-  const keepers = (D.keepers || []);
-  const activeK = keepers.filter(k => k.status !== "idle").length;
-  const stalled = keepers.filter(k => k.status === "stalled").length;
+  const counts = _stUseMemo(() => _statusCounts(D), [D.events, D.keepers]);
+  const spot = _kpiSpotlight(counts);
+  const events = counts.lastEvent;
+  const evCount = counts.evCount;
+  const keepers = D.keepers || [];
+  const activeK = counts.active;
+  const stalled = counts.stalled;
 
   if (hidden) return null;
 

--- a/dashboard/cockpit-kit/cb-shared.jsx
+++ b/dashboard/cockpit-kit/cb-shared.jsx
@@ -8,37 +8,43 @@ function Dot({ kind = 'idle', size = 'md', beat = false, style }) {
   return <span className={`cb-dot ${kind} ${size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : ''} ${beat ? 'beat' : ''}`} style={style} aria-hidden="true" />;
 }
 
-// Mini sparkline (random but seeded bars) — used in KPI + lifeline
+// Mini sparkline — renders supplied bar heights (0..100). When `data`
+// is absent we render an empty container instead of fabricating bars,
+// so missing telemetry is visible rather than hidden behind noise.
 function Spark({ data, color = 'brass', bars = 14 }) {
-  const d = data || Array.from({ length: bars }, (_, i) => 30 + Math.sin(i * 0.7) * 20 + Math.random() * 30);
+  if (!Array.isArray(data) || data.length === 0) {
+    return <span className={`spark is-${color} is-empty`} style={{ height: 16 }} aria-label="no data" data-empty="true" />;
+  }
   return (
     <span className={`spark is-${color}`} style={{ height: 16 }} aria-hidden="true">
-      {d.map((h, i) => <i key={i} style={{ height: `${Math.max(5, Math.min(100, h))}%` }} />)}
+      {data.map((h, i) => <i key={i} style={{ height: `${Math.max(5, Math.min(100, h))}%` }} />)}
     </span>
   );
 }
 
-// Lifeline-style sine+spike svg path
-function Heartbeat({ height = 32, width = 320, phase = 0 }) {
-  const points = [];
-  const segs = 60;
-  for (let i = 0; i <= segs; i++) {
-    const t = i / segs;
-    const x = t * width;
-    // mostly flat with a spike every ~12 samples
-    let y = height / 2 + Math.sin((t + phase) * 6) * 1.5;
-    const s = (i + Math.floor(phase * 60)) % 12;
-    if (s === 3) y -= height * 0.35;
-    if (s === 4) y += height * 0.4;
-    if (s === 5) y -= height * 0.15;
-    points.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+// Lifeline-style svg path. Caller passes `data` (array of y-samples in
+// 0..100) plus optional `min`/`max` bounds. Without data we render a
+// dashed baseline so the indicator visibly reflects "no signal" rather
+// than animating a fake heartbeat.
+function Heartbeat({ height = 32, width = 320, data, min = 0, max = 100 }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return (
+      <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-label="no data" data-empty="true" focusable="false">
+        <line x1="0" y1={height / 2} x2={width} y2={height / 2} stroke="var(--color-fg-muted)" strokeWidth="1" strokeDasharray="3 3" />
+      </svg>
+    );
   }
+  const span = Math.max(1, max - min);
+  const segs = data.length - 1 || 1;
+  const points = data.map((v, i) => {
+    const x = (i / segs) * width;
+    const clamped = Math.max(min, Math.min(max, v));
+    const y = height - ((clamped - min) / span) * height;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
   return (
     <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-hidden="true" focusable="false">
       <polyline points={points.join(' ')} fill="none" stroke="var(--color-accent-fg)" strokeWidth="1.2" />
-      <circle cx={width - 2} cy={height / 2} r="2" fill="var(--color-accent-fg)">
-        <animate attributeName="r" values="2;3.5;2" dur="1.4s" repeatCount="indefinite" />
-      </circle>
     </svg>
   );
 }

--- a/dashboard/public/cockpit/cockpit-kit/App.jsx
+++ b/dashboard/public/cockpit/cockpit-kit/App.jsx
@@ -4,10 +4,21 @@
 const { useState, useCallback, useEffect } = React;
 
 function App() {
-  // sync mode/branch with the cockpit-state singleton (URL+localStorage)
-  const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{}, () => {}]);
+  // sync mode/branch with the cockpit-state singleton (URL+localStorage).
+  // If the hook is not available we surface that loudly: previously the
+  // fallback was a silent stub which made cockpit state look functional
+  // while every write was dropped on the floor.
+  const [cs, setCs] = (() => {
+    if (window.useCockpitState) return window.useCockpitState();
+    console.error("[App] window.useCockpitState missing — cockpit state hook did not load; mode/branch changes will not persist");
+    return [{}, () => {}];
+  })();
   // run layout profile — auto-collapses chrome per mode
-  if (window.useLayoutProfile) window.useLayoutProfile();
+  if (window.useLayoutProfile) {
+    window.useLayoutProfile();
+  } else {
+    console.error("[App] window.useLayoutProfile missing — layout auto-collapse disabled");
+  }
   const [mode, setModeRaw] = useState(cs.mode || "Dashboard");
   const [density, setDensity] = useState("normal");
   const [selKeeper, setSelKeeper] = useState("nick0cave");
@@ -25,6 +36,19 @@ function App() {
   const setBranch = useCallback((b) => { setBranchRaw(b); setCs({ branch: b }); }, [setCs]);
 
   const D = window.MASC_DATA;
+  // Without the data layer the cockpit cannot render anything meaningful.
+  // Show a visible error instead of crashing on D.goals.find below.
+  if (!D || !Array.isArray(D.goals)) {
+    return (
+      <div className="app app-error" role="alert" data-error="missing-masc-data">
+        <h1>Cockpit data unavailable</h1>
+        <p>
+          <code>window.MASC_DATA</code> is missing or malformed. Verify the data
+          layer script loaded before App.jsx.
+        </p>
+      </div>
+    );
+  }
   const activeGoal = D.goals.find(g => g.id === selGoal) || D.goals[0];
 
   const toggleKeeper = useCallback((id) => {

--- a/dashboard/public/cockpit/cockpit-kit/StatusTray.jsx
+++ b/dashboard/public/cockpit/cockpit-kit/StatusTray.jsx
@@ -10,7 +10,7 @@
    Lives in bottom-left so it doesn't fight the FocusToggle (bottom-right)
    or the Composer (which is hidden in focus mode anyway). */
 
-const { useState: _stUseState, useEffect: _stUseEffect, useRef: _stUseRef } = React;
+const { useState: _stUseState, useEffect: _stUseEffect, useRef: _stUseRef, useMemo: _stUseMemo } = React;
 
 function _useTrayPop() {
   const [open, setOpen] = _stUseState(null); // 'kpi' | 'life' | 'ticker' | 'keepers' | null
@@ -31,13 +31,44 @@ function _useTrayPop() {
   return [open, setOpen, ref];
 }
 
-function _kpiSpotlight(D) {
+// Count events + keepers in a single pass each. The previous version
+// iterated `events` and `keepers` four times and used `Array.filter` for
+// pure counts; this version is allocation-free and easier to extend.
+function _statusCounts(D) {
   const evs = (D && D.events) || [];
-  const fails = evs.filter(e => e.kind === "fail").length;
-  const cascades = evs.filter(e => e.kind === "cascade").length;
-  if (fails >= 3) return { l: "Fails", v: fails, t: "err",  u: "/47", urgent: true };
-  if (cascades >= 2) return { l: "Cascade", v: cascades, t: "info", u: "@step" };
-  return { l: "tps", v: "1.24", t: "brass", u: "tps" };
+  let fails = 0;
+  let cascades = 0;
+  for (const e of evs) {
+    if (!e) continue;
+    if (e.kind === "fail") fails++;
+    else if (e.kind === "cascade") cascades++;
+  }
+  const keepers = (D && D.keepers) || [];
+  let active = 0;
+  let stalled = 0;
+  for (const k of keepers) {
+    if (!k) continue;
+    if (k.status !== "idle") active++;
+    if (k.status === "stalled") stalled++;
+  }
+  return {
+    fails,
+    cascades,
+    evCount: evs.length,
+    lastEvent: evs.length > 0 ? evs[evs.length - 1] : null,
+    keepersTotal: keepers.length,
+    active,
+    stalled,
+  };
+}
+
+// Pick the dot to spotlight in the KPI slot. Only the urgent paths
+// have real meaning today; for the calm path we expose the raw event
+// count rather than a fabricated TPS number.
+function _kpiSpotlight(counts) {
+  if (counts.fails >= 3) return { l: "fails", v: counts.fails, t: "err", u: "", urgent: true };
+  if (counts.cascades >= 2) return { l: "cascade", v: counts.cascades, t: "info", u: "" };
+  return { l: "events", v: counts.evCount, t: "brass", u: "" };
 }
 
 function StatusTray() {
@@ -45,12 +76,13 @@ function StatusTray() {
   const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{trayHidden:false}, ()=>{}]);
   const hidden = !!cs.trayHidden;
   const [open, setOpen, ref] = _useTrayPop();
-  const spot = _kpiSpotlight(D);
-  const events = (D.events || []).slice(-1)[0];
-  const evCount = (D.events || []).length;
-  const keepers = (D.keepers || []);
-  const activeK = keepers.filter(k => k.status !== "idle").length;
-  const stalled = keepers.filter(k => k.status === "stalled").length;
+  const counts = _stUseMemo(() => _statusCounts(D), [D.events, D.keepers]);
+  const spot = _kpiSpotlight(counts);
+  const events = counts.lastEvent;
+  const evCount = counts.evCount;
+  const keepers = D.keepers || [];
+  const activeK = counts.active;
+  const stalled = counts.stalled;
 
   if (hidden) return null;
 

--- a/dashboard/public/cockpit/cockpit-kit/cb-shared.jsx
+++ b/dashboard/public/cockpit/cockpit-kit/cb-shared.jsx
@@ -8,37 +8,43 @@ function Dot({ kind = 'idle', size = 'md', beat = false, style }) {
   return <span className={`cb-dot ${kind} ${size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : ''} ${beat ? 'beat' : ''}`} style={style} aria-hidden="true" />;
 }
 
-// Mini sparkline (random but seeded bars) — used in KPI + lifeline
+// Mini sparkline — renders supplied bar heights (0..100). When `data`
+// is absent we render an empty container instead of fabricating bars,
+// so missing telemetry is visible rather than hidden behind noise.
 function Spark({ data, color = 'brass', bars = 14 }) {
-  const d = data || Array.from({ length: bars }, (_, i) => 30 + Math.sin(i * 0.7) * 20 + Math.random() * 30);
+  if (!Array.isArray(data) || data.length === 0) {
+    return <span className={`spark is-${color} is-empty`} style={{ height: 16 }} aria-label="no data" data-empty="true" />;
+  }
   return (
     <span className={`spark is-${color}`} style={{ height: 16 }} aria-hidden="true">
-      {d.map((h, i) => <i key={i} style={{ height: `${Math.max(5, Math.min(100, h))}%` }} />)}
+      {data.map((h, i) => <i key={i} style={{ height: `${Math.max(5, Math.min(100, h))}%` }} />)}
     </span>
   );
 }
 
-// Lifeline-style sine+spike svg path
-function Heartbeat({ height = 32, width = 320, phase = 0 }) {
-  const points = [];
-  const segs = 60;
-  for (let i = 0; i <= segs; i++) {
-    const t = i / segs;
-    const x = t * width;
-    // mostly flat with a spike every ~12 samples
-    let y = height / 2 + Math.sin((t + phase) * 6) * 1.5;
-    const s = (i + Math.floor(phase * 60)) % 12;
-    if (s === 3) y -= height * 0.35;
-    if (s === 4) y += height * 0.4;
-    if (s === 5) y -= height * 0.15;
-    points.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+// Lifeline-style svg path. Caller passes `data` (array of y-samples in
+// 0..100) plus optional `min`/`max` bounds. Without data we render a
+// dashed baseline so the indicator visibly reflects "no signal" rather
+// than animating a fake heartbeat.
+function Heartbeat({ height = 32, width = 320, data, min = 0, max = 100 }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return (
+      <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-label="no data" data-empty="true" focusable="false">
+        <line x1="0" y1={height / 2} x2={width} y2={height / 2} stroke="var(--color-fg-muted)" strokeWidth="1" strokeDasharray="3 3" />
+      </svg>
+    );
   }
+  const span = Math.max(1, max - min);
+  const segs = data.length - 1 || 1;
+  const points = data.map((v, i) => {
+    const x = (i / segs) * width;
+    const clamped = Math.max(min, Math.min(max, v));
+    const y = height - ((clamped - min) / span) * height;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
   return (
     <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-hidden="true" focusable="false">
       <polyline points={points.join(' ')} fill="none" stroke="var(--color-accent-fg)" strokeWidth="1.2" />
-      <circle cx={width - 2} cy={height / 2} r="2" fill="var(--color-accent-fg)">
-        <animate attributeName="r" values="2;3.5;2" dur="1.4s" repeatCount="indefinite" />
-      </circle>
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- 운영 dashboard에서 가짜 telemetry로 보이게 하던 폴백 제거 (audit 보고서 Tier A 첫 묶음)
- Spark / Heartbeat: data 없으면 명시적 empty state. Math.random·sin·spike 시연 코드 제거
- StatusTray: \"1.24\" tps 하드코딩 제거. fails/cascade urgent path는 유지하고 default는 실제 evCount 노출. count 4번 .filter → single-pass + useMemo
- App.jsx: window.useCockpitState / useLayoutProfile silent stub 제거 → console.error. window.MASC_DATA 부재 시 throw 대신 visible error panel
- design-system/preview/cb-shared.jsx 는 의도적 시연 영역이라 손대지 않음
- KEEPER_REGISTRY 하드코딩 제거는 5명 캐노니컬 keeper의 시각적 정체성 변경이 따라오므로 별도 후속 PR로 분리

## 출처
- /Users/dancer/Downloads/audit_derived_state.md #25, #27, #28, #29
- /Users/dancer/Downloads/Kimi_Agent_코드 숨김 탐지/final_report.md 4-1, 4-2, 4-3, 4-4
- Plan: /Users/dancer/me/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-oas-gleaming-wirth.md (Tier A A-1/A-2/A-3)

## Test plan
- [ ] dashboard 로컬 띄워 데이터 누락 시 sparkline/heartbeat가 가짜 파형 없이 명시적 empty state 표시되는지 확인
- [ ] StatusTray default kpi 가 \"1.24\" 가 아닌 실제 event count 표시
- [ ] window.useCockpitState 미로드 상태로 reload 시 console에 \"\[App\] window.useCockpitState missing ...\" 에러 나오는지
- [ ] window.MASC_DATA 미정의 상태에서 throw 대신 \"Cockpit data unavailable\" 패널 노출
- [ ] vite build / pnpm tsc --noEmit (dashboard) 통과
- [ ] cb-group-f.jsx Spark 호출처 (sa.history 데이터 전달)에서 시각 회귀 없는지 확인

## 다음 단계 (이 PR과 별개)
- KEEPER_REGISTRY → runtime persona config 마이그레이션 (시각적 정체성 변경 동반)
- task_dispatch.ml ref → Atomic.t (Tier A A-4)
- doctor_dispatch.mli/.ml 일치 확인 (A-5)
- cascade.toml tier_small 빈 프로필 처리 (A-6)
- Tier B(oas derived value), Tier C(capability JSON, guardrails default), Tier D(escalation ladder)는 RFC-0026 / oas #1347 머지 추이 보면서 진행

## Note
이 PR은 agent-authored Draft. ready 전환은 Vincent가 직접 \`human-approved-ready\` 라벨 부여 후 진행 부탁드립니다 (Draft Auto-Merge Guard 가 agent ready 시도를 revert 하기 때문).

🤖 Generated with [Claude Code](https://claude.com/claude-code)