### PR TITLE
chore: bump dune-project version to 0.19.8

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.19.7)
+(version 0.19.8)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
- Bump `dune-project` version from `0.19.7` to `0.19.8` to sync with published tag `v0.19.8`
- Release train guard currently blocks **all 4 Ready PRs** (#12955, #12968, #12977, #12983) because `dune-project` version is behind the latest tag

## Context
Tag `v0.19.8` was cut at PR #12950 without bumping `dune-project`. The `check-release-train-guard.sh` script (run inside Meta Guards CI job) detects `base_package_version (0.19.7) < latest_tag_version (0.19.8)` and fails.

## Test plan
- [x] `dune-project` version matches `v0.19.8` tag
- [ ] Meta Guards CI check passes after merge
- [ ] All blocked PRs unblocked after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)