### PR TITLE
chore(task_dispatch): convert backend_state ref to Atomic.t

### DIFF
--- a/lib/task_dispatch.ml
+++ b/lib/task_dispatch.ml
@@ -15,33 +15,36 @@ type backend_state =
   | Uninitialized
   | Active of task_backend
 
-(** Current backend state. Single ref avoids contradictory initialized/backend pairs. *)
-let backend_state : backend_state ref = ref Uninitialized
+(** Current backend state. Single Atomic.t avoids contradictory
+    initialized/backend pairs and removes the OCaml 5 multidomain data
+    race that the previous [ref] cell had. Mirrors the pattern already
+    used by Board_dispatch.backend_state. *)
+let backend_state : backend_state Atomic.t = Atomic.make Uninitialized
 
 let is_initialized () =
-  match !backend_state with
+  match Atomic.get backend_state with
   | Active _ -> true
   | Uninitialized -> false
 
 (** Initialize JSONL backend. Default fallback. *)
 let init_jsonl () =
-  if match !backend_state with Active _ -> true | Uninitialized -> false then
+  if (match Atomic.get backend_state with Active _ -> true | Uninitialized -> false) then
     Log.Task.warn "WARNING: already initialized, ignoring init_jsonl"
-  else begin
-    backend_state := Active Jsonl;
+  else if Atomic.compare_and_set backend_state Uninitialized (Active Jsonl) then
     Log.Task.info "JSONL backend initialized (using Coord.* functions)."
-  end
+  else
+    Log.Task.warn "WARNING: backend was concurrently initialized; ignoring init_jsonl"
 
 (** Reset for testing *)
 let reset_for_test () =
-  backend_state := Uninitialized
+  Atomic.set backend_state Uninitialized
 
 (** Get current backend, auto-init JSONL if not set *)
 let backend () =
-  match !backend_state with
+  match Atomic.get backend_state with
   | Active backend -> backend
   | Uninitialized ->
-      backend_state := Active Jsonl;
+      let _ = Atomic.compare_and_set backend_state Uninitialized (Active Jsonl) in
       Log.Task.info "JSONL backend initialized (using Coord.* functions).";
       Jsonl
 


### PR DESCRIPTION
## Summary
- task_dispatch.backend_state 를 [backend_state ref] → [backend_state Atomic.t] 로 전환
- board_dispatch.backend_state 와 동일한 Atomic + compare_and_set 패턴
- OCaml 5 multidomain에서 init_jsonl 동시 호출 시 발생하던 data race 제거. concurrent init 시 WARN 로그를 남기고 두 번째 호출은 무효
- mli 시그니처 변경 없음 (backend_state는 module-private)

## 출처
- /Users/dancer/Downloads/Kimi_Agent_코드 숨김 탐지/final_report.md 2-5 (Non-atomic ref → Data Race)
- Plan: Tier A A-4

## Test plan
- [x] [dune build @lib/check] 통과 (lib만 영향, test/ 의 pre-existing typecheck 에러는 별개 worktree에서 처리 중)
- [ ] full [dune runtest] 통과 (CI에서 확인)
- [ ] task_dispatch 호출 경로의 회귀 없음 — JSONL backend init/reset_for_test 동작 동일

## Note
Draft. ready 전환은 [human-approved-ready] 라벨 부여 후 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)