### PR TITLE
chore(cascade): clarify tier_small empty-profile intent

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -60,7 +60,13 @@ max_tokens = 200
 keeper_assignable = false
 
 [tier_small]
-comment = "4B-class local models for simple tasks (classification, format, short summary). Operator opt-in: uncomment models when Ollama is running locally."
+# Operator opt-in slot for 4B-class local models. Empty by default — every
+# route that points at "tier_small" falls through to tier_medium via
+# fallback_cascade until at least one model is uncommented below (and
+# Ollama is running locally). Keeping the profile here documents the
+# intended fallback chain rather than removing it; we'd otherwise need
+# to either rewrite every "tier_small" route or silently ignore them.
+comment = "Operator opt-in slot for 4B-class local models. Empty by default; routes fall through to tier_medium."
 # models = [
 #   "ollama:llama3.2:3b",
 #   "ollama:phi-3-mini",


### PR DESCRIPTION
## Summary
- [tier_small] 빈 profile에 대한 audit 비판 응답: dead code가 아니라 fallback_cascade로 tier_medium에 위임하는 의도적 placeholder임을 comment에 명확화
- 동작 변화 없음 — comment만 변경

## 출처
- /Users/dancer/Downloads/audit_derived_state.md (Tier 하드코딩 context)
- /Users/dancer/Downloads/Kimi_Agent_코드 숨김 탐지/final_report.md 3-4 (cascade.toml tier 하드코딩)
- Plan: Tier A A-6

## Test plan
- [ ] cascade catalog parser 동작 회귀 없음 (toml 구조 동일)
- [ ] simple_task 라우트가 여전히 tier_medium 으로 fallback 되는지 확인

## Note
별도 후속 PR(별건):
- A-5 doctor_dispatch.mli/.ml 일치는 이미 fixed (2026-05-01 .ml 추가됨)
- Tier B oas derived value 정리 시작 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)