### PR TITLE
fix(test): unblock main build (thompson_confidence + Feature_flag_registry import)

### DIFF
--- a/test/test_feature_flag_registry.ml
+++ b/test/test_feature_flag_registry.ml
@@ -19,7 +19,7 @@
     6. [deprecated_flags] / [overridden_flags] partition
        behaviour. *)
 
-module R = Masc_mcp.Feature_flag_registry
+module R = Feature_flag_registry
 
 (* ─── (1) lifecycle_to_string exhaustiveness ──────────────────── *)
 

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -247,6 +247,7 @@ let test_agent_reputation_penalizes_unsupported_claims () =
       let unpenalized =
         Agent_reputation.compute_overall_score ~completion_rate:1.0
           ~response_rate:0.0 ~board_posts:0 ~board_comments:0
+          ~thompson_confidence:0.5
       in
       let rep =
         Agent_reputation.compute_reputation config

--- a/test/test_reputation_multi_dim.ml
+++ b/test/test_reputation_multi_dim.ml
@@ -138,6 +138,7 @@ let test_compute_overall_score_pure () =
       ~response_rate:1.0
       ~board_posts:10
       ~board_comments:10
+      ~thompson_confidence:0.5
   in
   check bool "score in [0,1]" true (score >= 0.0 && score <= 1.0)
 


### PR DESCRIPTION
## Summary

Main 빌드 깨짐 (3 test 파일) 즉시 fix. 28 PR wave 머지 직후 rebase 검증 중 발견.

## Root cause

세 테스트 파일이 main에서 컴파일 실패:

```
File "test/test_feature_flag_registry.ml", line 22, characters 11-41:
22 | module R = Masc_mcp.Feature_flag_registry
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Masc_mcp.Feature_flag_registry

File "test/test_reputation_multi_dim.ml", line 142, characters 45-48:
142 |   check bool "score in [0,1]" true (score >= 0.0 && score <= 1.0)
                                                   ^^^
Error: The constant 0.0 has type float but an expression was expected of type
         thompson_confidence:float -> float

File "test/test_keeper_accountability.ml", line 264, characters 29-40:
264 |         (rep.overall_score < unpenalized))
                                   ^^^^^^^^^^^
Error: The value unpenalized has type thompson_confidence:float -> float
       but an expression was expected of type float
```

## Fixes

### 1. `test/test_feature_flag_registry.ml` (from #12954)

`lib/config/dune` declares `(wrapped false)` for `masc_config`:

```
(library
 (name masc_config)
 (public_name masc_mcp.config)
 (wrapped false)
 ...)
```

PR #12954가 `module R = Masc_mcp.Feature_flag_registry`로 작성했지만 `Masc_config`는 wrapped:false라 prefix 없이 그냥 `Feature_flag_registry`로 접근 가능. 다른 모든 사용처도 prefix 없이 사용:

```
$ rg "Feature_flag_registry" lib/
lib/config/env_config_governance.ml:    Feature_flag_registry.get_bool "MASC_INFERENCE_CACHE_ENABLED"
lib/config/env_config_keeper.ml:    Feature_flag_registry.get_bool "MASC_KEEPER_BOOTSTRAP_ENABLED"
... (15+ matches, all unprefixed)
```

Fix: `module R = Feature_flag_registry`.

### 2. `test/test_keeper_accountability.ml` + `test/test_reputation_multi_dim.ml` (from #12979)

PR #12979가 `Agent_reputation.compute_overall_score`에 required parameter `~thompson_confidence:float`를 추가했으나 두 기존 caller (test) 미업데이트. partial application으로 평가되어 type error.

```ocaml
(* lib/agent_reputation.mli *)
val compute_overall_score :
  completion_rate:float ->
  response_rate:float ->
  board_posts:int ->
  board_comments:int ->
  thompson_confidence:float ->  (* ← #12979에서 추가 *)
  float
```

Fix: 두 call site에 `~thompson_confidence:0.5` 추가. 0.5는 `default_reputation.thompson_confidence`와 같은 neutral Beta prior 값 (`alpha=1, beta=1`).

## Verification

```sh
$ dune build --root .  # 깨끗 (이전: 3 errors)
```

## Why this matters

- main 깨진 상태로 28 PR 머지된 상태. 다음 누가 새 PR 만들면 즉시 BLOCKED 되며 원인 추적 비용 발생.
- 메모리 `feedback_pre_merge_typecheck_drag_in_blocker` 직접 적용 사례 (typecheck pre-merge gate 부재의 또 다른 증거).
- #12979 머지 시 caller-context 검증 안 한 게 원인 — 메모리 `feedback_self_audit_grep_only_false_positive_trap`의 inverse: grep만으로 check, 실제 build 안 한 채 머지.

## Test plan

- [x] `dune build --root .` green
- [ ] CI green
- [ ] 머지 후 다음 PR이 BLOCKED 안 되는지 확인
