### PR TITLE
feat(types): add Masc_error.is_retryable predicate (OAS audit follow-up)

### DIFF
--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -227,3 +227,23 @@ let code = function
   | Task _ | Agent _ | Portal _ | System _ -> 400
   | RateLimitExceeded _ -> 429
   | _ -> 500
+
+(* [is_retryable] mirrors [Error.is_retryable] in OAS so MASC-side
+   callers don't have to fall back on an OAS-only predicate when
+   reasoning about a [masc_error]. Conservative — when in doubt
+   return [false] so callers don't loop on deterministic
+   failures. Source for the audit-driven motivation:
+   2026-04-29 OAS↔MASC Implementation Quality Audit
+   §"Re-tryability". *)
+let is_retryable = function
+  | Task _ | Agent _ | Portal _ -> false
+  | Auth (Auth_error.TokenExpired _) -> true
+  | Auth (Auth_error.Unauthorized _ | Auth_error.Forbidden _
+         | Auth_error.InvalidToken _) -> false
+  | System (System_error.IoError _ | System_error.StorageError _) -> true
+  | System (System_error.NotInitialized | System_error.AlreadyInitialized
+           | System_error.InvalidJson _ | System_error.InvalidFilePath _
+           | System_error.ValidationError _) -> false
+  | RateLimitExceeded _ -> true
+  | CacheError (CacheReadFailed _ | CacheWriteFailed _ | CacheExpired _) -> true
+  | CacheError (CacheCorrupted _) -> false

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -78,3 +78,25 @@ val to_string : t -> string
 val show : t -> string
 val to_yojson : t -> Yojson.Safe.t
 val code : t -> int
+
+val is_retryable : t -> bool
+(** [is_retryable err] — would replaying the same operation, without
+    additional caller action, have a chance of succeeding?
+
+    Mirrors the [Error.is_retryable] helper that OAS exposes on
+    its [sdk_error]. Conservative: when in doubt the result is
+    [false] so callers don't loop on deterministic failures.
+
+    {ul
+    {- [Task _], [Agent _], [Portal _]: [false] (domain-state
+       errors — replaying changes nothing).}
+    {- [Auth (TokenExpired _)]: [true] (clears once
+       [masc_auth_refresh] runs); other [Auth] variants: [false].}
+    {- [System (IoError _ | StorageError _)]: [true] (transient
+       FS / backend); other [System] variants: [false]
+       (caller-provided invariants).}
+    {- [RateLimitExceeded _]: [true] (replays after the
+       advertised wait).}
+    {- [CacheError (CacheReadFailed _ | CacheWriteFailed _
+       | CacheExpired _)]: [true]; [CacheCorrupted _]: [false]
+       (persisted-data invariant violation).} } *)

--- a/test/dune
+++ b/test/dune
@@ -1125,6 +1125,7 @@
 (include stanzas/test_local_review_script.inc)
 (include stanzas/test_magentic_ledger_cap.inc)
 (include stanzas/test_masc_dirname_ssot.inc)
+(include stanzas/test_masc_error_is_retryable.inc)
 (include stanzas/test_mcp_post_sse_e2e.inc)
 (include stanzas/test_mcp_tool_matrix.inc)
 (include stanzas/test_meta_cognition_snapshot.inc)

--- a/test/stanzas/test_masc_error_is_retryable.inc
+++ b/test/stanzas/test_masc_error_is_retryable.inc
@@ -1,0 +1,9 @@
+; Per-file dune stanza for the [Masc_error.is_retryable]
+; classification suite. Lives here per test/stanzas/README.md to
+; avoid the conflict-cascade hotspot in the legacy grouped
+; (tests ...) stanza.
+
+(test
+ (name test_masc_error_is_retryable)
+ (modules test_masc_error_is_retryable)
+ (libraries masc_test_deps))

--- a/test/test_masc_error_is_retryable.ml
+++ b/test/test_masc_error_is_retryable.ml
@@ -1,0 +1,150 @@
+(** Pin the per-variant retryable classification of [masc_error].
+
+    Audit-driven addition (2026-04-29 Implementation Quality
+    Audit §"Re-tryability"): MASC was missing an
+    [is_retryable] predicate on its [masc_error] sum, so callers
+    fell back on an OAS-only helper.  This suite locks the
+    classification so future variant additions force a deliberate
+    "retryable or not" decision.
+
+    Properties pinned:
+    1. {b Domain-state errors are non-retryable} — Task / Agent /
+       Portal variants.
+    2. {b Auth — only TokenExpired retryable} — refresh-then-retry
+       semantics; Unauthorized / Forbidden / InvalidToken are not.
+    3. {b System — only transient I/O retryable} — IoError /
+       StorageError; remaining caller-invariant violations
+       (NotInitialized, InvalidJson, ValidationError, …) are not.
+    4. {b Rate limit retryable} — replay after wait_seconds.
+    5. {b Cache — corruption non-retryable, others retryable} —
+       Read/Write/Expired retry; Corrupted is data-invariant. *)
+
+module E = Masc_error
+
+(* ── (1) Domain-state errors: never retryable ──────────── *)
+
+let test_task_errors_non_retryable () =
+  assert (not (E.is_retryable (E.Task (E.Task_error.NotFound "id"))));
+  assert (
+    not
+      (E.is_retryable
+         (E.Task
+            (E.Task_error.AlreadyClaimed
+               { task_id = "id"; by = "alice" }))));
+  assert (not (E.is_retryable (E.Task (E.Task_error.NotClaimed "id"))));
+  assert (
+    not (E.is_retryable (E.Task (E.Task_error.InvalidState "x"))));
+  assert (not (E.is_retryable (E.Task (E.Task_error.InvalidId "y"))))
+
+let test_agent_errors_non_retryable () =
+  assert (
+    not (E.is_retryable (E.Agent (E.Agent_error.NotFound "n"))));
+  assert (
+    not (E.is_retryable (E.Agent (E.Agent_error.NotJoined "n"))));
+  assert (
+    not (E.is_retryable (E.Agent (E.Agent_error.AlreadyJoined "n"))));
+  assert (
+    not (E.is_retryable (E.Agent (E.Agent_error.InvalidName "x"))))
+
+let test_portal_errors_non_retryable () =
+  assert (
+    not (E.is_retryable (E.Portal (E.Portal_error.NotOpen "a"))));
+  assert (
+    not
+      (E.is_retryable
+         (E.Portal
+            (E.Portal_error.AlreadyOpen
+               { agent = "a"; target = "b" }))));
+  assert (
+    not (E.is_retryable (E.Portal (E.Portal_error.Closed "a"))))
+
+(* ── (2) Auth: only TokenExpired retryable ─────────────── *)
+
+let test_auth_token_expired_retryable () =
+  assert (
+    E.is_retryable (E.Auth (E.Auth_error.TokenExpired "agent")))
+
+let test_auth_other_non_retryable () =
+  assert (
+    not
+      (E.is_retryable (E.Auth (E.Auth_error.Unauthorized "x"))));
+  assert (
+    not
+      (E.is_retryable
+         (E.Auth
+            (E.Auth_error.Forbidden { agent = "a"; action = "x" }))));
+  assert (
+    not
+      (E.is_retryable (E.Auth (E.Auth_error.InvalidToken "x"))))
+
+(* ── (3) System: transient I/O retryable, others not ──── *)
+
+let test_system_io_retryable () =
+  assert (E.is_retryable (E.System (E.System_error.IoError "x")));
+  assert (
+    E.is_retryable (E.System (E.System_error.StorageError "x")))
+
+let test_system_caller_invariants_non_retryable () =
+  assert (
+    not (E.is_retryable (E.System E.System_error.NotInitialized)));
+  assert (
+    not
+      (E.is_retryable
+         (E.System E.System_error.AlreadyInitialized)));
+  assert (
+    not
+      (E.is_retryable (E.System (E.System_error.InvalidJson "x"))));
+  assert (
+    not
+      (E.is_retryable
+         (E.System (E.System_error.InvalidFilePath "x"))));
+  assert (
+    not
+      (E.is_retryable
+         (E.System (E.System_error.ValidationError "x"))))
+
+(* ── (4) Rate limit retryable ──────────────────────────── *)
+
+let test_rate_limit_retryable () =
+  let err =
+    {
+      E.category = E.GeneralLimit;
+      current = 11;
+      limit = 10;
+      wait_seconds = 30;
+    }
+  in
+  assert (E.is_retryable (E.RateLimitExceeded err))
+
+(* ── (5) Cache: corruption non-retryable, rest retryable  *)
+
+let test_cache_transient_retryable () =
+  assert (
+    E.is_retryable (E.CacheError (E.CacheReadFailed "/p")));
+  assert (
+    E.is_retryable (E.CacheError (E.CacheWriteFailed "/p")));
+  assert (
+    E.is_retryable
+      (E.CacheError
+         (E.CacheExpired { key = "k"; age_hours = 1.0 })))
+
+let test_cache_corrupted_non_retryable () =
+  assert (
+    not
+      (E.is_retryable
+         (E.CacheError (E.CacheCorrupted "/p"))))
+
+(* ── runner ───────────────────────────────────────────── *)
+
+let () =
+  test_task_errors_non_retryable ();
+  test_agent_errors_non_retryable ();
+  test_portal_errors_non_retryable ();
+  test_auth_token_expired_retryable ();
+  test_auth_other_non_retryable ();
+  test_system_io_retryable ();
+  test_system_caller_invariants_non_retryable ();
+  test_rate_limit_retryable ();
+  test_cache_transient_retryable ();
+  test_cache_corrupted_non_retryable ();
+  print_endline "test_masc_error_is_retryable: all assertions passed"


### PR DESCRIPTION
## Summary
Surgical follow-up to the **2026-04-29 Implementation Quality Audit (OAS↔MASC)** §"Re-tryability" finding: MASC was missing an `is_retryable` predicate on its `masc_error` sum, leaving callers to fall back on the OAS-only `Error.is_retryable` helper. This PR mirrors the OAS pattern at the MASC layer.

## What changes
- **`Masc_error.is_retryable : t -> bool`** — pure addition, no caller migration.
- Conservative classification (when in doubt → `false` so callers don't loop on deterministic failures).
- Per-variant rationale documented inline + in the `.mli` docstring.

## Pinning matrix

| Variant | retryable | Rationale |
|---|---|---|
| `Task _` / `Agent _` / `Portal _` | `false` | Domain-state errors — replay changes nothing. |
| `Auth (TokenExpired _)` | `true` | Cleared after `masc_auth_refresh`. |
| `Auth (Unauthorized / Forbidden / InvalidToken)` | `false` | Credential/authorization invariants. |
| `System (IoError _ / StorageError _)` | `true` | Transient FS / backend hiccups. |
| `System (NotInitialized / AlreadyInitialized / InvalidJson / InvalidFilePath / ValidationError)` | `false` | Caller-provided invariants. |
| `RateLimitExceeded _` | `true` | Replay after `wait_seconds`. |
| `CacheError (CacheReadFailed / CacheWriteFailed / CacheExpired)` | `true` | Transient FS / refetch on retry. |
| `CacheError (CacheCorrupted _)` | `false` | Persisted-data invariant violation. |

## Why a separate test file
`test/test_masc_error_is_retryable.ml` (10 cases / 5 property groups) locks each variant's classification. Future variant additions force a deliberate "retryable or not" decision because the impl uses an exhaustive match — incomplete coverage will fail to compile.

## Test plan
- [x] `dune exec test/test_masc_error_is_retryable.exe` → 10/10 green
- [ ] CI green
