### PR TITLE
chore(cascade_client_capacity): log auto-registration decisions

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -205,7 +205,17 @@ let () =
       (fun (url, max_concurrent) -> register ~url ~max_concurrent)
       (parse_capacity_env s)
 
-(* ── Heuristic auto-registration for ollama-like URLs ───────────── *)
+(* ── Heuristic auto-registration for ollama-like URLs ─────────────
+
+   Auto-registration runs whenever a candidate set arrives without an
+   explicit MASC_CLIENT_CAPACITY entry. The pattern check delegates to
+   [Masc_network_defaults] so the URL→provider mapping stays in one
+   place; we used to make these decisions here and elsewhere with
+   ad-hoc substring checks, so the audit (audit_derived_state #9, Kimi
+   3-7) flagged it as a hidden heuristic. Operators who want to pin
+   capacity should use MASC_CLIENT_CAPACITY (parsed above); when this
+   path fires we log it at info level so the auto-decision is visible
+   in the operations log. *)
 
 let looks_like_ollama = Masc_network_defaults.is_ollama_url
 
@@ -215,28 +225,44 @@ let auto_register_for_candidates ~base_urls =
   let max_concurrent = ollama_default_max () in
   List.iter
     (fun url ->
-       if looks_like_ollama url && not (is_registered url) then
-         register ~url ~max_concurrent)
+       if looks_like_ollama url && not (is_registered url) then begin
+         Log.Misc.info
+           "auto-registering ollama-like url=%S with max_concurrent=%d \
+            (override via MASC_CLIENT_CAPACITY)" url max_concurrent;
+         register ~url ~max_concurrent
+       end)
     base_urls
 
 let auto_register_ollama_with_override ~base_urls ~max_concurrent =
   List.iter
     (fun url ->
-       if looks_like_ollama url && not (is_registered url) then
-         register ~url ~max_concurrent)
+       if looks_like_ollama url && not (is_registered url) then begin
+         Log.Misc.info
+           "auto-registering ollama-like url=%S with override max_concurrent=%d"
+           url max_concurrent;
+         register ~url ~max_concurrent
+       end)
     base_urls
 
 let auto_register_cli_for_candidates ~capacity_keys =
   let max_concurrent = cli_default_max () in
   List.iter
     (fun key ->
-       if looks_like_cli_sentinel key && not (is_registered key) then
-         register ~url:key ~max_concurrent)
+       if looks_like_cli_sentinel key && not (is_registered key) then begin
+         Log.Misc.info
+           "auto-registering cli sentinel key=%S with max_concurrent=%d \
+            (override via MASC_CLIENT_CAPACITY)" key max_concurrent;
+         register ~url:key ~max_concurrent
+       end)
     capacity_keys
 
 let auto_register_cli_with_override ~capacity_keys ~max_concurrent =
   List.iter
     (fun key ->
-       if looks_like_cli_sentinel key && not (is_registered key) then
-         register ~url:key ~max_concurrent)
+       if looks_like_cli_sentinel key && not (is_registered key) then begin
+         Log.Misc.info
+           "auto-registering cli sentinel key=%S with override max_concurrent=%d"
+           key max_concurrent;
+         register ~url:key ~max_concurrent
+       end)
     capacity_keys


### PR DESCRIPTION
## Summary
- audit가 비판한 `cascade_client_capacity`의 URL 휴리스틱(`is_ollama_url`, `is_cli_sentinel_url`) 자체는 이미 `Masc_network_defaults`에 SSOT로 추출되어 있어 hidden heuristic은 아님
- 그러나 `auto_register_*_for_candidates` 4개 함수는 silent하게 registry에 entry를 추가 — 운영자 가시성 부족
- 이번 PR은 자동 등록 시점에 `Log.Misc.info` 한 줄을 추가해 운영 로그에서 가시화. 실제 등록 동작은 변화 없음
- 4개 함수 모두 같은 패턴으로 처리: url, max_concurrent, override 여부를 명시

## RFC
RFC-WAIVED: lib/cascade/cascade_client_capacity.ml은 lib/keeper/credential_*, lib/repo_manager/, lib/operator/operator_control*, dashboard/credential, .claude/hooks/, instructions/workflow* 어느 RFC subsystem에도 해당하지 않음.

## Test plan
- [x] `dune build @lib/check` 통과
- [ ] CI 전체 통과 확인
- [ ] 운영 환경에서 자동 등록 시 INFO 로그 출력 sample 확인 (Slack 노티 등 소음 우려 없음 — INFO 레벨)
- [ ] 후속 PR(별건): URL 휴리스틱 자체를 explicit operator 등록(`MASC_CLIENT_CAPACITY` 또는 cascade.toml 명시)으로 점진 마이그레이션. 이번 PR은 가시성만.

## 출처
- /Users/dancer/Downloads/audit_derived_state.md #9 (capacity registry URL 휴리스틱)
- /Users/dancer/Downloads/Kimi_Agent_코드 숨김 탐지/final_report.md 3-7
- Plan: Tier C C-7

## Note
Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
