### PR TITLE
refactor(cascade): extract big_three default to named constant + drift guard

### DIFF
--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -32,13 +32,22 @@ type route_spec = {
   fallback_policy : fallback_policy;
 }
 
+(* Default last-resort profile name for keeper routes.  Must agree with
+   [Keeper_cascade_profile.default_name] — the SSOT for the profile string
+   "big_three".  Cross-module drift is guarded by
+   [test_cascade_routes_bigthree_ssot.ml].  Direct reference to
+   [Keeper_cascade_profile] is impossible from here because that module
+   already depends on this one (see [keeper_cascade_profile.ml:31]). *)
+let keeper_default_last_resort_profile = "big_three"
+
 let keeper_route use key aliases =
   {
     use;
     key;
     aliases;
     fallback_policy =
-      Prefer_keeper_assignable { last_resort_profile = "big_three" };
+      Prefer_keeper_assignable
+        { last_resort_profile = keeper_default_last_resort_profile };
   }
 
 let system_route use key aliases ~preferred_profiles ~last_resort_profile =

--- a/lib/cascade/cascade_routes.mli
+++ b/lib/cascade/cascade_routes.mli
@@ -26,6 +26,13 @@ type logical_use =
 val logical_use_key : logical_use -> string
 val logical_use_of_string_opt : string -> logical_use option
 
+val keeper_default_last_resort_profile : string
+(** Default fallback profile name applied to every keeper route built via the
+    internal helper [keeper_route].  Equals [Keeper_cascade_profile.default_name]
+    by contract; cross-module drift is guarded by
+    [test/test_cascade_routes_bigthree_ssot.ml].  Exposed so callers and tests
+    can reference the SSOT instead of restating the literal "big_three". *)
+
 val all_logical_uses : logical_use list
 (** Logical call-site uses known by the route registry. *)
 

--- a/test/dune
+++ b/test/dune
@@ -1018,6 +1018,7 @@
 (include stanzas/test_cascade_kimi_max_context_ssot.inc)
 (include stanzas/test_cascade_model_resolve.inc)
 (include stanzas/test_cascade_ollama_probe.inc)
+(include stanzas/test_cascade_routes_bigthree_ssot.inc)
 (include stanzas/test_cascade_runtime.inc)
 (include stanzas/test_cascade_strategy.inc)
 (include stanzas/test_cascade_trust_persist.inc)

--- a/test/stanzas/test_cascade_routes_bigthree_ssot.inc
+++ b/test/stanzas/test_cascade_routes_bigthree_ssot.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_routes_bigthree_ssot)
+ (modules test_cascade_routes_bigthree_ssot)
+ (libraries masc_test_deps))

--- a/test/test_cascade_routes_bigthree_ssot.ml
+++ b/test/test_cascade_routes_bigthree_ssot.ml
@@ -1,0 +1,42 @@
+(** Cross-module SSOT drift guard.
+
+    [Cascade_routes.keeper_default_last_resort_profile] must agree with
+    [Keeper_cascade_profile.default_name] at all times.  These two strings
+    cannot reference a single SSOT directly because [Keeper_cascade_profile]
+    already depends on [Cascade_routes] (cycle prevention), so this test is
+    the guard that catches drift.
+
+    If you change either constant and this test breaks, change BOTH. *)
+
+open Masc_mcp
+
+let test_drift () =
+  Alcotest.(check string)
+    "Cascade_routes.keeper_default_last_resort_profile = \
+     Keeper_cascade_profile.default_name"
+    Keeper_cascade_profile.default_name
+    Cascade_routes.keeper_default_last_resort_profile
+
+let test_value_is_big_three () =
+  (* Belt-and-braces: pin both ends to the literal so a stealth rename of
+     either module's constant doesn't slip through with both sides
+     drifting in sync. *)
+  Alcotest.(check string)
+    "Cascade_routes side"
+    "big_three"
+    Cascade_routes.keeper_default_last_resort_profile;
+  Alcotest.(check string)
+    "Keeper_cascade_profile side"
+    "big_three"
+    Keeper_cascade_profile.default_name
+
+let () =
+  let case name f = Alcotest.test_case name `Quick f in
+  Alcotest.run "Cascade_routes_bigthree_ssot"
+    [
+      ( "drift",
+        [
+          case "cross-module equality" test_drift;
+          case "literal pin" test_value_is_big_three;
+        ] );
+    ]


### PR DESCRIPTION
## Scope

One small literal cleanup + a structural drift guard.

`lib/cascade/cascade_routes.ml:41` had `last_resort_profile = "big_three"` baked in as a raw string. The same string is the `to_string` of `Keeper_cascade_profile.Big_three` (= `Keeper_cascade_profile.default_name`). Two literal occurrences of the same profile name in code paths that must agree by contract = the AI anti-pattern flagged by `software-development.md` ("same configuration value duplicated across files as raw literal").

## Change

| File | Edit | LOC |
|------|------|-----|
| `lib/cascade/cascade_routes.ml` | Extract `let keeper_default_last_resort_profile = "big_three"`; `keeper_route` references the binding | +9 / -1 |
| `lib/cascade/cascade_routes.mli` | Expose the constant for tests / call sites | +7 |
| `test/test_cascade_routes_bigthree_ssot.ml` (new) | Two-test alcotest binary asserting cross-module equality + literal pin on both sides | +43 |
| `test/stanzas/test_cascade_routes_bigthree_ssot.inc` (new) | Standard test stanza | +4 |
| `test/dune` | Include the new stanza | +1 |

## Why a drift test, not a direct reference

`Keeper_cascade_profile` already depends on `Cascade_routes` (see `keeper_cascade_profile.ml:31` — it re-exports `type logical_use = Cascade_routes.logical_use = ...`). Importing `Keeper_cascade_profile.default_name` from `Cascade_routes` would create a dependency cycle. The test layer sits below both, so a unit test is the only place where the equality can be observed without restructuring the type graph.

## Verification

```
$ dune build @check                                   # green
$ dune exec test/test_cascade_routes_bigthree_ssot.exe
Cascade_routes_bigthree_ssot
  drift  0  cross-module equality.
  drift  1  literal pin.
Test Successful in 0.000s. 2 tests run.
```

Independent of any other in-flight RFC-0022 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
