### PR TITLE
fix(dashboard): sync 3 test assertions with token-migrated source

### DIFF
--- a/dashboard/src/components/activity-graph-panels.test.ts
+++ b/dashboard/src/components/activity-graph-panels.test.ts
@@ -39,6 +39,8 @@ async function loadPanels(options: {
       html`<div>${message ?? children}</div>`,
     LoadingState: ({ children }: { children?: unknown }) =>
       html`<div>${children}</div>`,
+    ErrorState: ({ message }: { message?: string }) =>
+      html`<div>${message ?? ''}</div>`,
   }))
   Vitest.vi.doMock('./common/button', () => ({
     ActionButton: ({ children, onClick }: { children?: unknown; onClick?: () => void }) =>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -53,13 +53,6 @@ import {
 
 type StatusFilter = 'all' | RuntimeBand
 
-function runtimeBadgeClass(band: RuntimeBand): string {
-  if (band === 'active') return 'border-[var(--ok-border)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]'
-  if (band === 'attention') return 'border-[var(--warn-border)] bg-[var(--warn-soft)] text-[var(--color-status-warn)]'
-  if (band === 'paused') return 'border-[var(--purple-24)] bg-[var(--purple-12)] text-[var(--stalled-fg)]'
-  return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-disabled)]'
-}
-
 function stageBadgeClass(stageKey: string): string {
   if (stageKey === 'tool_use') return 'border-[var(--info-border)] bg-[var(--accent-12)] text-[var(--color-accent-fg)]'
   if (stageKey === 'scheduled_autonomous' || stageKey === 'thinking') return 'border-[var(--ok-border)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]'

--- a/dashboard/src/components/kpi-cell.test.ts
+++ b/dashboard/src/components/kpi-cell.test.ts
@@ -168,18 +168,18 @@ describe('KpiCell component', () => {
   })
 
   // ── progress prop ──
-  // The progress bar fill carries `transition: width 500ms` + a width% — a
-  // stable signature happy-dom can resolve, even though it doesn't compute
-  // layout. aria-label encodes a rounded-[var(--r-1)], clamped progress for SR users.
+  // The progress bar fill uses `transition: width var(--t-xslow) var(--ease-out)`
+  // (token-migrated) + a width%. happy-dom resolves these into the style attribute.
+  // aria-label encodes a rounded-[var(--r-1)], clamped progress for SR users.
 
   it('omits the progress bar when progress is undefined', () => {
     const el = mount({ label: 'CTX', value: '40k' })
-    expect(el.innerHTML).not.toContain('width 500ms')
+    expect(el.innerHTML).not.toContain('--t-xslow')
   })
 
   it('renders a progress bar when progress is supplied', () => {
     const el = mount({ label: 'CTX', value: '40k', progress: 73 })
-    expect(el.innerHTML).toContain('width 500ms')
+    expect(el.innerHTML).toContain('--t-xslow')
     expect(el.innerHTML).toContain('width: 73%')
   })
 

--- a/dashboard/src/styles/cockpit-token-cascade.test.ts
+++ b/dashboard/src/styles/cockpit-token-cascade.test.ts
@@ -57,7 +57,7 @@ describe('Cockpit token cascade', () => {
   })
 
   it('keeps the app shell on semantic cockpit backgrounds', () => {
-    expect(baseCss).toContain('rgb(var(--brass-glow) / 0.05)')
+    expect(baseCss).toContain('rgb(var(--brass-glow) / .05)')
     expect(baseCss).toContain('var(--color-bg-page)')
     expect(appTs).toContain('bg-[var(--color-bg-page)]')
     expect(appTs).toContain('bg-[var(--shell-header-bg)]')


### PR DESCRIPTION
## Summary
- `activity-graph-panels.test.ts`: add missing `ErrorState` to feedback-state mock (cascade-waterfall imports it)
- `kpi-cell.test.ts`: update progress-bar assertions from `width 500ms` to `--t-xslow` (token-migrated in #12769)
- `cockpit-token-cascade.test.ts`: update alpha assertion from `0.05` to `.05` (normalized in #12914)

## Context
All 3 failures are pre-existing on main — not caused by any specific PR. They block every PR that triggers Dashboard CI (currently #12997, #12982, #12989, #12985, #12984, #12990).

## Test plan
- [x] Local vitest: 35/35 pass across the 3 files
- [ ] CI Dashboard check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)