### PR TITLE
feat(cascade): RFC-0022 PR-2 — attempt-liveness observer + oas_worker wiring

### DIFF
--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -409,9 +409,11 @@ The decision table in §4.5 is the source of truth. Tests:
 
 ## 9. Operational rollout
 
-Phase A (default-off, observation only):
-- New module + FSM + tests merged behind `MASC_CASCADE_ATTEMPT_LIVENESS=off|observe|enforce` (default `observe`).
-- `observe`: liveness clock runs, kills are *logged* but not enforced; cascade still advances on real wire errors.
+Phase A (default-off, observation only) — **wiring landed (PR-2)**:
+- FSM module + tests in PR-1 (`lib/cascade/cascade_attempt_liveness.{ml,mli}`).
+- Observer + tick fiber + `oas_worker_named.ml::try_provider` integration in PR-2 (`lib/cascade/cascade_attempt_liveness_observer.{ml,mli}`, `lib/cascade/cascade_attempt_liveness_config.{ml,mli}`).
+- Behind `MASC_CASCADE_ATTEMPT_LIVENESS=off|observe|enforce` (default `observe`).
+- `observe`: liveness clock runs, kills emit `masc_cascade_attempt_liveness_kill_total{mode=observe}` and `masc_cascade_attempt_liveness_observed_total{outcome=...}` but no `Switch.fail`; cascade still advances on real wire errors.
 - 24h on dev base path; compare `diag-keeper-cycle.sh` MAX_S/P95.
 
 Phase B (enforce per profile):

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -1,0 +1,63 @@
+(* See cascade_attempt_liveness_config.mli for documentation.
+
+   RFC-0022 PR-2/4 §2 — tri-state env flag + per-label budget map. *)
+
+type mode =
+  | Off
+  | Observe
+  | Enforce
+
+let mode_label = function
+  | Off -> "off"
+  | Observe -> "observe"
+  | Enforce -> "enforce"
+
+let env_var_name = "MASC_CASCADE_ATTEMPT_LIVENESS"
+
+let parse_mode raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "off" | "0" | "false" | "disabled" -> Off
+  | "enforce" | "kill" | "on_kill" -> Enforce
+  | "" | "observe" | "default" | "1" | "true" | "shadow" -> Observe
+  | _ -> Observe (* unknown values default to Observe — never silently Off *)
+
+(* Cached after first read. Mirrors Keeper_admission_glue.use_new_admission. *)
+let mode_cache : mode option ref = ref None
+
+let current_mode () =
+  match !mode_cache with
+  | Some m -> m
+  | None ->
+      let m =
+        match Sys.getenv_opt env_var_name with
+        | None -> Observe
+        | Some raw -> parse_mode raw
+      in
+      mode_cache := Some m;
+      m
+
+let reset_cache_for_test () = mode_cache := None
+
+(* Per-label budget catalog — RFC-0022 PR-2 §2.
+
+   Cloud streaming providers (codex_cli, claude_code, gemini_cli) use
+   [cloud_fast] as a TTFT-strict budget that matches their typical short
+   answer latency. Adaptive-reasoning models (glm-coding which streams
+   thinking deltas, kimi-for-coding) get [cloud_thinking].
+
+   Local providers stay on the larger [local_27b] / [local_70b_plus]
+   budgets to avoid killing slow local models. *)
+
+let budget_for_label (label : string) : Cascade_attempt_liveness.budget =
+  let canon = String.lowercase_ascii (String.trim label) in
+  match canon with
+  | "codex_cli" | "claude_code" | "claude" | "gemini_cli" | "gemini" ->
+      Cascade_attempt_liveness.cloud_fast
+  | "glm-coding" | "glm_coding" | "glm" | "kimi_cli" | "kimi-for-coding"
+  | "kimi" ->
+      Cascade_attempt_liveness.cloud_thinking
+  | "ollama_only" | "llama-server" | "llama_server" ->
+      Cascade_attempt_liveness.local_27b
+  | "local_70b" | "local_70b_plus" | "ollama_70b" ->
+      Cascade_attempt_liveness.local_70b_plus
+  | _ -> Cascade_attempt_liveness.cloud_fast

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -1,0 +1,46 @@
+(** Tri-state env flag + per-label budget lookup for the cascade
+    attempt-liveness gate (RFC-0022 PR-2/4 §2).
+
+    The flag [MASC_CASCADE_ATTEMPT_LIVENESS] selects one of three modes:
+
+    - [off]      — wrapper bypassed entirely, baseline behaviour.
+    - [observe]  — observer constructed; counters emit; never raises.
+    - [enforce]  — observer raises [Liveness_kill] via [Eio.Switch.fail]
+                   on the first {!Cascade_attempt_liveness.Outcome}.
+
+    Default is [observe] (RFC-0022 §9 Phase A).
+
+    The mode is read once and cached on first call (mirrors
+    [Keeper_admission_glue.use_new_admission]) so that mid-attempt env
+    edits do not split-brain the observer.
+
+    @stability Evolving
+    @since 0.190.0 *)
+
+type mode =
+  | Off
+  | Observe
+  | Enforce
+
+val current_mode : unit -> mode
+(** Cached env-flag read. First call reads
+    [MASC_CASCADE_ATTEMPT_LIVENESS] and caches the result. Subsequent
+    calls return the cached value. Default when unset / unparseable is
+    {!Observe}. *)
+
+val mode_label : mode -> string
+(** Stable label for telemetry / Prometheus counter values. One of
+    [off | observe | enforce]. *)
+
+val budget_for_label : string -> Cascade_attempt_liveness.budget
+(** Map a cascade provider label (e.g. [codex_cli], [claude_code],
+    [gemini_cli], [glm-coding], [ollama_only], [llama-server]) to a
+    per-profile budget.
+
+    Unknown labels fall back to {!Cascade_attempt_liveness.cloud_fast}
+    which is the conservative cloud-streaming default. *)
+
+val reset_cache_for_test : unit -> unit
+(** Test-only: reset the cached flag read so a new value of
+    [MASC_CASCADE_ATTEMPT_LIVENESS] takes effect. Production callers
+    must not invoke this. *)

--- a/lib/cascade/cascade_attempt_liveness_observer.ml
+++ b/lib/cascade/cascade_attempt_liveness_observer.ml
@@ -1,0 +1,236 @@
+(* See cascade_attempt_liveness_observer.mli for documentation.
+
+   RFC-0022 PR-2/4 §4-5 — observer constructor, on_event wrapper,
+   tick fiber, finalizer. *)
+
+module L = Cascade_attempt_liveness
+module Cfg = Cascade_attempt_liveness_config
+
+exception Liveness_kill of L.failure
+
+type t = {
+  mode : Cfg.mode;
+  budget : L.budget;
+  cascade_label : string;
+  provider_label : string;
+  state : L.state ref;
+  sw_ref : Eio.Switch.t option ref;
+  finalized : bool ref;
+}
+
+let mode (t : t) : Cfg.mode = t.mode
+
+let create ~mode ~budget ~cascade_label ~provider_label ~started_at =
+  {
+    mode;
+    budget;
+    cascade_label;
+    provider_label;
+    state = ref (L.initial ~started_at);
+    sw_ref = ref None;
+    finalized = ref false;
+  }
+
+let current_state_for_test (t : t) : L.state = !(t.state)
+
+(* -- Prometheus emission ------------------------------------------- *)
+
+let kill_labels (t : t) (failure : L.failure) =
+  [
+    ("mode", Cfg.mode_label t.mode);
+    ("kind", L.failure_kind_label failure);
+    ("cascade", t.cascade_label);
+    ("provider", t.provider_label);
+  ]
+
+let observed_labels (t : t) ~outcome =
+  [
+    ("cascade", t.cascade_label);
+    ("provider", t.provider_label);
+    ("outcome", outcome);
+  ]
+
+let emit_kill_counter (t : t) (failure : L.failure) =
+  Prometheus.inc_counter Prometheus.metric_cascade_attempt_liveness_kill
+    ~labels:(kill_labels t failure) ()
+
+(* -- Event translation -------------------------------------------- *)
+
+(* Translate an SSE event into a {!Stream_chunk.kind}, returning
+   None for events that the FSM should not see (e.g. Ping that does
+   not advance the clock — RFC §4.4 invariant S3 forbids treating
+   raw Ping as motion).
+
+   MessageStop maps to Done; ContentBlockDelta maps to the matching
+   Answer/Thinking delta; ContentBlockStart with content_type
+   "tool_use" maps to Tool_call_start; SSEError maps to a wire
+   error; MessageStart / MessageDelta / Ping / ContentBlockStop are
+   ignored as they are protocol scaffolding without forward motion. *)
+
+let event_to_chunk_kind (evt : Agent_sdk.Types.sse_event)
+    : L.Stream_chunk.kind option =
+  match evt with
+  | Agent_sdk.Types.MessageStop -> Some L.Stream_chunk.Done
+  | Agent_sdk.Types.ContentBlockDelta { delta; _ } -> (
+      match delta with
+      | TextDelta _ -> Some L.Stream_chunk.Answer_delta
+      | ThinkingDelta _ -> Some L.Stream_chunk.Thinking_delta
+      | InputJsonDelta _ -> Some L.Stream_chunk.Tool_call_arg_delta)
+  | Agent_sdk.Types.ContentBlockStart { content_type; tool_name; _ } -> (
+      match content_type with
+      | "tool_use" ->
+          Some
+            (L.Stream_chunk.Tool_call_start
+               { tool_name = Option.value ~default:"" tool_name })
+      | _ -> None)
+  | Agent_sdk.Types.ContentBlockStop _ ->
+      Some L.Stream_chunk.Tool_call_complete
+  | Agent_sdk.Types.MessageStart _ -> None
+  | Agent_sdk.Types.MessageDelta _ -> None
+  | Agent_sdk.Types.Ping -> None
+  | Agent_sdk.Types.SSEError _ -> None
+
+let wire_error_of_event (evt : Agent_sdk.Types.sse_event) : string option =
+  match evt with
+  | Agent_sdk.Types.SSEError msg -> Some msg
+  | _ -> None
+
+(* -- React to FSM output ------------------------------------------ *)
+
+let react_to_output (t : t) (output : L.output) : unit =
+  match output with
+  | L.Continue -> ()
+  | L.Completed -> ()
+  | L.Outcome failure ->
+      emit_kill_counter t failure;
+      (match t.mode with
+       | Cfg.Off -> ()  (* unreachable: caller bypassed wrapper *)
+       | Cfg.Observe -> ()  (* shadow only — never raise *)
+       | Cfg.Enforce -> (
+           match !(t.sw_ref) with
+           | Some sw -> Eio.Switch.fail sw (Liveness_kill failure)
+           | None ->
+               (* Enforce without a switch wired is a programmer error;
+                  log and degrade to Observe rather than raise. *)
+               Log.Misc.warn
+                 "cascade_attempt_liveness: enforce mode but no switch \
+                  registered (cascade=%s provider=%s); shadowing kill"
+                 t.cascade_label t.provider_label))
+
+(* -- on_event wrapper --------------------------------------------- *)
+
+let now_seconds () = Time_compat.now ()
+
+let step_with_event (t : t) (evt : Agent_sdk.Types.sse_event) : unit =
+  if L.is_terminal !(t.state) then ()
+  else
+    let now = now_seconds () in
+    let liveness_event =
+      match wire_error_of_event evt with
+      | Some msg -> Some (L.Provider_wire_error msg)
+      | None -> (
+          match event_to_chunk_kind evt with
+          | None -> None
+          | Some kind -> Some (L.Chunk (kind, now)))
+    in
+    match liveness_event with
+    | None -> ()
+    | Some le ->
+        let new_state, output = L.step t.budget !(t.state) le in
+        t.state := new_state;
+        react_to_output t output
+
+let wrap_on_event (t : t)
+    (original : (Agent_sdk.Types.sse_event -> unit) option)
+    : (Agent_sdk.Types.sse_event -> unit) option =
+  match t.mode with
+  | Cfg.Off -> original
+  | Cfg.Observe | Cfg.Enforce ->
+      let wrapped (evt : Agent_sdk.Types.sse_event) : unit =
+        (* Run the original first so baseline semantics never lose an
+           event even if the FSM step would raise (defensive — Observe
+           must not raise; Enforce raises only via Switch.fail). *)
+        (match original with
+         | None -> ()
+         | Some f -> (
+             try f evt with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+                 Log.Misc.warn
+                   "cascade_attempt_liveness: original on_event raised \
+                    (cascade=%s provider=%s): %s"
+                   t.cascade_label t.provider_label
+                   (Printexc.to_string exn)));
+        try step_with_event t evt with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | Liveness_kill _ as e -> raise e
+        | exn ->
+            Log.Misc.warn
+              "cascade_attempt_liveness: step raised (cascade=%s \
+               provider=%s): %s"
+              t.cascade_label t.provider_label (Printexc.to_string exn)
+      in
+      Some wrapped
+
+(* -- Tick fiber --------------------------------------------------- *)
+
+let tick_interval_seconds (b : L.budget) : float =
+  let smaller = Float.min b.ttft_max b.inter_chunk_max in
+  Float.max 0.5 (smaller /. 4.0)
+
+let start_tick_fiber (t : t) ~(sw : Eio.Switch.t)
+    ~(clock : _ Eio.Time.clock) : unit =
+  match t.mode with
+  | Cfg.Off -> ()
+  | Cfg.Observe | Cfg.Enforce ->
+      t.sw_ref := Some sw;
+      let interval = tick_interval_seconds t.budget in
+      Eio.Fiber.fork ~sw (fun () ->
+          let rec loop () =
+            if L.is_terminal !(t.state) then ()
+            else begin
+              (try Eio.Time.sleep clock interval
+               with Eio.Cancel.Cancelled _ as e -> raise e);
+              if L.is_terminal !(t.state) then ()
+              else begin
+                let now = now_seconds () in
+                let new_state, output =
+                  L.step t.budget !(t.state) (L.Tick now)
+                in
+                t.state := new_state;
+                (try react_to_output t output
+                 with Liveness_kill _ as e -> raise e);
+                loop ()
+              end
+            end
+          in
+          try loop () with
+          | Eio.Cancel.Cancelled _ -> ()
+          | Liveness_kill _ -> ()
+          | exn ->
+              Log.Misc.warn
+                "cascade_attempt_liveness tick fiber crashed (cascade=%s \
+                 provider=%s): %s"
+                t.cascade_label t.provider_label (Printexc.to_string exn))
+
+(* -- Finalize ----------------------------------------------------- *)
+
+let outcome_of_state = function
+  | L.Success -> "success"
+  | L.Failed (L.No_first_token | L.Inter_chunk_idle | L.Wall_exceeded) ->
+      "kill"
+  | L.Failed (L.Provider_error _) -> "wire_error"
+  | L.Awaiting _ | L.Streaming _ -> "wire_error"
+
+let finalize (t : t) : unit =
+  if !(t.finalized) then ()
+  else begin
+    t.finalized := true;
+    match t.mode with
+    | Cfg.Off -> ()
+    | Cfg.Observe | Cfg.Enforce ->
+        let outcome = outcome_of_state !(t.state) in
+        Prometheus.inc_counter
+          Prometheus.metric_cascade_attempt_liveness_observed
+          ~labels:(observed_labels t ~outcome) ()
+  end

--- a/lib/cascade/cascade_attempt_liveness_observer.mli
+++ b/lib/cascade/cascade_attempt_liveness_observer.mli
@@ -1,0 +1,106 @@
+(** Cascade attempt-liveness observer (RFC-0022 PR-2/4 §4-5).
+
+    Glue layer between {!Cascade_attempt_liveness} (pure FSM) and the
+    streaming attempt loop in [oas_worker_named.ml]. Owns:
+
+    - The mutable FSM state ref bound to one cascade attempt.
+    - Translation from [Agent_sdk.Types.sse_event] to
+      {!Cascade_attempt_liveness.Stream_chunk.kind}.
+    - Tick fiber forked under the caller's [Eio.Switch.t] that polls
+      the FSM at [min(ttft_max, inter_chunk_max) / 4] cadence.
+    - Prometheus counter emission per outcome.
+
+    {1 No-kill in Observe mode}
+
+    Structural guarantee (RFC §4 contract):
+
+    - [Off] mode: caller short-circuits before constructing the
+      observer. [{!create}] in [Off] returns a no-op handle.
+    - [Observe] mode: counters fire but neither [Switch.fail] nor any
+      exception leaves this module. The wrapped [on_event] callback is
+      bit-identical to the baseline (delegates to the original) plus
+      side-effecting telemetry only.
+    - [Enforce] mode: on the first [Outcome] the observer calls
+      [Eio.Switch.fail sw {!Liveness_kill}] so the surrounding
+      [Oas_worker_exec.run] tears down via Eio cancellation.
+
+    {1 Tick fiber lifetime}
+
+    The tick fiber is forked under the same [~sw] that owns
+    [Oas_worker_exec.run]. When the OAS run switch dies (success,
+    error, parent cancellation) the tick fiber dies with it — no
+    explicit teardown is required.
+
+    @stability Evolving
+    @since 0.190.0 *)
+
+exception Liveness_kill of Cascade_attempt_liveness.failure
+(** Raised via [Eio.Switch.fail] in {!Enforce} mode when the FSM
+    emits an {!Cascade_attempt_liveness.Outcome}. The argument is the
+    classified failure carried into the cascade FSM by the caller. *)
+
+type t
+(** Opaque per-attempt observer handle. *)
+
+val create :
+  mode:Cascade_attempt_liveness_config.mode ->
+  budget:Cascade_attempt_liveness.budget ->
+  cascade_label:string ->
+  provider_label:string ->
+  started_at:float ->
+  t
+(** Build an observer for one cascade attempt.
+
+    [started_at] is the monotonic wall-clock the caller already
+    captured for [attempt_started_at] (oas_worker_named.ml:508).
+
+    The observer does not own the switch — see [start_tick_fiber]. *)
+
+val wrap_on_event :
+  t ->
+  (Agent_sdk.Types.sse_event -> unit) option ->
+  (Agent_sdk.Types.sse_event -> unit) option
+(** [wrap_on_event obs original] returns a callback that forwards every
+    event to [original] (preserving baseline semantics) and feeds a
+    derived {!Cascade_attempt_liveness.Chunk} into the FSM.
+
+    Mode contract:
+    - [Off]: returns [original] unchanged (no allocation).
+    - [Observe]: returns [Some f] where [f] always calls [original]
+      then the FSM step + telemetry.
+    - [Enforce]: same as [Observe] plus may [Eio.Switch.fail] on
+      [Outcome]. *)
+
+val start_tick_fiber :
+  t ->
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  unit
+(** Fork a sibling fiber under [~sw] that calls [Cascade_attempt_liveness.step]
+    with [Tick now] every [min(ttft_max, inter_chunk_max) / 4] seconds
+    until the FSM reaches a terminal state or [~sw] dies.
+
+    No-op when the observer mode is {!Off} or when [Off] short-circuit
+    elided observer construction at the call site. The fiber holds a
+    reference to [t] only — no other shared state — and dies with the
+    parent switch (Invariant §8 cancellation cleanup). *)
+
+val finalize : t -> unit
+(** Emit the [observed_total] counter once with the final outcome
+    label inferred from the FSM state at finalization time:
+
+    - [Success]    -> [outcome=success]
+    - [Failed _]   -> [outcome=kill] for liveness kills, or
+                       [outcome=wire_error] for [Provider_error].
+    - [Awaiting _]
+    | [Streaming _] -> [outcome=wire_error] (caller terminated the
+      attempt before the FSM saw a Done — typically a wire
+      cancellation or upstream exception).
+
+    Idempotent: calling twice emits the counter once. *)
+
+val current_state_for_test : t -> Cascade_attempt_liveness.state
+(** Test-only accessor. Production callers must not depend on this. *)
+
+val mode : t -> Cascade_attempt_liveness_config.mode
+(** Reflect the mode that was captured at observer construction. *)

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -688,6 +688,9 @@ let keeper_cascade_entries =
   [
     entry ~default:"(none)" "MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST"
       "Comma-separated provider allowlist for cascade (None=unfiltered)";
+    entry ~default:"observe" "MASC_CASCADE_ATTEMPT_LIVENESS"
+      "Cascade attempt-liveness gate mode (off|observe|enforce). RFC-0022 \
+       PR-2 §2 Phase A default observe — counters emit but no kill.";
   ]
 
 let keeper_grpc_entries =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -350,6 +350,51 @@ let run_named
     | Error err ->
       (Error err, None)
     | Ok config ->
+      (* RFC-0022 PR-2 §4 — attempt-liveness observer.
+
+         Mode is captured once per attempt. Off short-circuits before
+         observer construction so the wrapper is bit-identical to the
+         baseline. Observe and Enforce wrap on_event, start a tick fiber
+         under [~sw], and finalize the per-attempt outcome counter when
+         the run returns. Enforce additionally calls [Eio.Switch.fail]
+         on the first Outcome to tear down [Oas_worker_exec.run]. *)
+      let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
+      let liveness_observer_opt =
+        match liveness_mode with
+        | Cascade_attempt_liveness_config.Off -> None
+        | Cascade_attempt_liveness_config.Observe
+        | Cascade_attempt_liveness_config.Enforce ->
+            let budget =
+              Cascade_attempt_liveness_config.budget_for_label
+                provider_cfg.model_id
+            in
+            let obs =
+              Cascade_attempt_liveness_observer.create
+                ~mode:liveness_mode ~budget ~cascade_label:cascade_name
+                ~provider_label:provider_cfg.model_id
+                ~started_at:(Time_compat.now ())
+            in
+            (match Eio_context.get_clock_opt () with
+             | Some clock ->
+                 Cascade_attempt_liveness_observer.start_tick_fiber obs
+                   ~sw ~clock
+             | None ->
+                 (* No clock available — wrapper still emits counters
+                    via on_event but TTFT/wall checks won't fire. *)
+                 ());
+            Some obs
+      in
+      let liveness_on_event =
+        match liveness_observer_opt with
+        | None -> on_event
+        | Some obs ->
+            Cascade_attempt_liveness_observer.wrap_on_event obs on_event
+      in
+      let finalize_liveness () =
+        match liveness_observer_opt with
+        | None -> ()
+        | Some obs -> Cascade_attempt_liveness_observer.finalize obs
+      in
       match
         with_codex_cli_preflight
           ~scope:(Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id)
@@ -361,7 +406,8 @@ let run_named
             in
             let run_fn () =
               Oas_worker_exec.run ~sw ~net ~config
-                ?oas_checkpoint:effective_checkpoint ?on_event
+                ?oas_checkpoint:effective_checkpoint
+                ?on_event:liveness_on_event
                 ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
                 ?contract goal
             in
@@ -390,8 +436,10 @@ let run_named
             Ok result)
     with
     | Error err ->
+      finalize_liveness ();
       (Error err, None)
     | Ok result ->
+      finalize_liveness ();
       let result =
         Result.map_error
           (enrich_sdk_error ~cascade_name:error_cascade_name ~provider_cfg)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -870,9 +870,15 @@ let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
 
 (* RFC-0022 §9 attempt-liveness gate.  Counts would-be (Observe) and
    actual (Enforce) liveness kills broken down by failure class.
-   Labels: [kind, mode, provider]. *)
+   Labels: [kind, mode, provider].
+
+   [observed_total] is the per-attempt finalizer counter regardless of
+   outcome (success | kill | wire_error). Useful for the kill-rate
+   ratio kill / observed. *)
 let metric_cascade_attempt_liveness_kill =
   "masc_cascade_attempt_liveness_kill_total"
+let metric_cascade_attempt_liveness_observed =
+  "masc_cascade_attempt_liveness_observed_total"
 let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total"
 let metric_keeper_fsm_edge_transitions =
   "masc_keeper_fsm_edge_transitions_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -424,6 +424,13 @@ val metric_cascade_attempt_liveness_kill : string
     against [scripts/diag-keeper-cycle.sh] before flipping any profile
     to {b enforce}. *)
 
+val metric_cascade_attempt_liveness_observed : string
+(** RFC-0022 PR-2 §3 — per-attempt finalizer counter regardless of
+    outcome. Labels: [cascade], [provider], [outcome] ∈ {success |
+    kill | wire_error}. The kill-rate is
+    [kill_total / observed_total]. *)
+
+
 val metric_cascade_server_error_skip_total : string
 (** #12797 Total cascade label-ranking skips triggered by recent server-error
     (5xx) score decay for a provider.  Labels: [provider_key]. *)

--- a/test/dune
+++ b/test/dune
@@ -1013,6 +1013,7 @@
 (include stanzas/test_cascade_attempt_liveness_counters.inc)
 (include stanzas/test_cascade_attempt_liveness_observer.inc)
 (include stanzas/test_cascade_attempt_liveness_runtime.inc)
+(include stanzas/test_oas_worker_named_liveness_integration.inc)
 (include stanzas/test_cascade_capability_gate.inc)
 (include stanzas/test_cascade_catalog_runtime.inc)
 (include stanzas/test_cascade_config_validity.inc)

--- a/test/dune
+++ b/test/dune
@@ -1009,6 +1009,7 @@
 (include stanzas/test_briefing_gaps.inc)
 (include stanzas/test_briefing_json_helpers.inc)
 (include stanzas/test_cascade_attempt_liveness.inc)
+(include stanzas/test_cascade_attempt_liveness_config.inc)
 (include stanzas/test_cascade_attempt_liveness_runtime.inc)
 (include stanzas/test_cascade_capability_gate.inc)
 (include stanzas/test_cascade_catalog_runtime.inc)

--- a/test/dune
+++ b/test/dune
@@ -1010,6 +1010,7 @@
 (include stanzas/test_briefing_json_helpers.inc)
 (include stanzas/test_cascade_attempt_liveness.inc)
 (include stanzas/test_cascade_attempt_liveness_config.inc)
+(include stanzas/test_cascade_attempt_liveness_counters.inc)
 (include stanzas/test_cascade_attempt_liveness_runtime.inc)
 (include stanzas/test_cascade_capability_gate.inc)
 (include stanzas/test_cascade_catalog_runtime.inc)

--- a/test/dune
+++ b/test/dune
@@ -1011,6 +1011,7 @@
 (include stanzas/test_cascade_attempt_liveness.inc)
 (include stanzas/test_cascade_attempt_liveness_config.inc)
 (include stanzas/test_cascade_attempt_liveness_counters.inc)
+(include stanzas/test_cascade_attempt_liveness_observer.inc)
 (include stanzas/test_cascade_attempt_liveness_runtime.inc)
 (include stanzas/test_cascade_capability_gate.inc)
 (include stanzas/test_cascade_catalog_runtime.inc)

--- a/test/stanzas/test_cascade_attempt_liveness_config.inc
+++ b/test/stanzas/test_cascade_attempt_liveness_config.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_attempt_liveness_config)
+ (modules test_cascade_attempt_liveness_config)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_cascade_attempt_liveness_counters.inc
+++ b/test/stanzas/test_cascade_attempt_liveness_counters.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_attempt_liveness_counters)
+ (modules test_cascade_attempt_liveness_counters)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_cascade_attempt_liveness_observer.inc
+++ b/test/stanzas/test_cascade_attempt_liveness_observer.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_attempt_liveness_observer)
+ (modules test_cascade_attempt_liveness_observer)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_oas_worker_named_liveness_integration.inc
+++ b/test/stanzas/test_oas_worker_named_liveness_integration.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_oas_worker_named_liveness_integration)
+ (modules test_oas_worker_named_liveness_integration)
+ (libraries masc_test_deps))

--- a/test/test_cascade_attempt_liveness_config.ml
+++ b/test/test_cascade_attempt_liveness_config.ml
@@ -1,0 +1,181 @@
+(** Tests for [Cascade_attempt_liveness_config] (RFC-0022 PR-2/4 §2).
+
+    Covers: env-flag parsing (default Observe, all aliases),
+    cache invalidation via reset_cache_for_test, label→budget mapping. *)
+
+open Masc_mcp
+module Cfg = Cascade_attempt_liveness_config
+module L = Cascade_attempt_liveness
+
+let env_var = "MASC_CASCADE_ATTEMPT_LIVENESS"
+
+let with_env value f =
+  let prior = Sys.getenv_opt env_var in
+  (match value with
+   | None -> Unix.putenv env_var ""
+   | Some v -> Unix.putenv env_var v);
+  Cfg.reset_cache_for_test ();
+  let restore () =
+    (match prior with
+     | None -> Unix.putenv env_var ""
+     | Some v -> Unix.putenv env_var v);
+    Cfg.reset_cache_for_test ()
+  in
+  match f () with
+  | x -> restore (); x
+  | exception e -> restore (); raise e
+
+let mode_label = Cfg.mode_label
+
+let check_mode label expected actual =
+  Alcotest.(check string) label (mode_label expected) (mode_label actual)
+
+(* -- mode parsing --------------------------------------------------- *)
+
+let test_default_unset () =
+  let prior = Sys.getenv_opt env_var in
+  Unix.putenv env_var "";
+  Cfg.reset_cache_for_test ();
+  (* Empty string parses as Observe by parse_mode contract. *)
+  let m = Cfg.current_mode () in
+  (match prior with
+   | None -> Unix.putenv env_var ""
+   | Some v -> Unix.putenv env_var v);
+  Cfg.reset_cache_for_test ();
+  check_mode "empty string -> Observe" Observe m
+
+let test_observe_alias () =
+  with_env (Some "observe") (fun () ->
+      check_mode "observe" Observe (Cfg.current_mode ()))
+
+let test_off_alias () =
+  with_env (Some "off") (fun () ->
+      check_mode "off" Off (Cfg.current_mode ()))
+
+let test_off_zero () =
+  with_env (Some "0") (fun () ->
+      check_mode "0 -> Off" Off (Cfg.current_mode ()))
+
+let test_enforce_alias () =
+  with_env (Some "enforce") (fun () ->
+      check_mode "enforce" Enforce (Cfg.current_mode ()))
+
+let test_enforce_kill () =
+  with_env (Some "kill") (fun () ->
+      check_mode "kill -> Enforce" Enforce (Cfg.current_mode ()))
+
+let test_unknown_defaults_observe () =
+  with_env (Some "garbage") (fun () ->
+      check_mode "garbage -> Observe" Observe (Cfg.current_mode ()))
+
+let test_case_insensitive () =
+  with_env (Some "OFF") (fun () ->
+      check_mode "OFF -> Off" Off (Cfg.current_mode ()))
+
+(* -- cache contract ------------------------------------------------- *)
+
+let test_cache_first_read () =
+  with_env (Some "off") (fun () ->
+      let m1 = Cfg.current_mode () in
+      (* Mutate env after first read; cached value should persist. *)
+      Unix.putenv env_var "enforce";
+      let m2 = Cfg.current_mode () in
+      check_mode "first read" Off m1;
+      check_mode "cached, ignores mutation" Off m2)
+
+let test_reset_cache () =
+  with_env (Some "off") (fun () ->
+      let _ = Cfg.current_mode () in
+      Unix.putenv env_var "enforce";
+      Cfg.reset_cache_for_test ();
+      check_mode "after reset, sees enforce" Enforce (Cfg.current_mode ()))
+
+(* -- mode_label round-trip ----------------------------------------- *)
+
+let test_mode_labels () =
+  Alcotest.(check string) "off" "off" (mode_label Off);
+  Alcotest.(check string) "observe" "observe" (mode_label Observe);
+  Alcotest.(check string) "enforce" "enforce" (mode_label Enforce)
+
+(* -- budget_for_label ---------------------------------------------- *)
+
+let budget_eq (a : L.budget) (b : L.budget) =
+  Float.equal a.ttft_max b.ttft_max
+  && Float.equal a.inter_chunk_max b.inter_chunk_max
+  && Float.equal a.attempt_wall_max b.attempt_wall_max
+
+let check_budget label expected actual =
+  Alcotest.(check bool) label true (budget_eq expected actual)
+
+let test_budget_codex_cli () =
+  check_budget "codex_cli -> cloud_fast" L.cloud_fast
+    (Cfg.budget_for_label "codex_cli")
+
+let test_budget_claude_code () =
+  check_budget "claude_code -> cloud_fast" L.cloud_fast
+    (Cfg.budget_for_label "claude_code")
+
+let test_budget_glm_coding () =
+  check_budget "glm-coding -> cloud_thinking" L.cloud_thinking
+    (Cfg.budget_for_label "glm-coding")
+
+let test_budget_kimi () =
+  check_budget "kimi-for-coding -> cloud_thinking" L.cloud_thinking
+    (Cfg.budget_for_label "kimi-for-coding")
+
+let test_budget_local () =
+  check_budget "ollama_only -> local_27b" L.local_27b
+    (Cfg.budget_for_label "ollama_only");
+  check_budget "llama-server -> local_27b" L.local_27b
+    (Cfg.budget_for_label "llama-server")
+
+let test_budget_local_70b () =
+  check_budget "local_70b_plus -> local_70b_plus" L.local_70b_plus
+    (Cfg.budget_for_label "local_70b_plus")
+
+let test_budget_unknown_default () =
+  check_budget "unknown -> cloud_fast" L.cloud_fast
+    (Cfg.budget_for_label "weird_provider_xyz")
+
+let test_budget_case_insensitive () =
+  check_budget "GLM-CODING -> cloud_thinking" L.cloud_thinking
+    (Cfg.budget_for_label "GLM-CODING")
+
+let () =
+  Alcotest.run "cascade_attempt_liveness_config"
+    [
+      ( "mode parsing",
+        [
+          Alcotest.test_case "default unset -> observe" `Quick
+            test_default_unset;
+          Alcotest.test_case "observe" `Quick test_observe_alias;
+          Alcotest.test_case "off" `Quick test_off_alias;
+          Alcotest.test_case "off via 0" `Quick test_off_zero;
+          Alcotest.test_case "enforce" `Quick test_enforce_alias;
+          Alcotest.test_case "enforce via kill" `Quick test_enforce_kill;
+          Alcotest.test_case "unknown -> observe" `Quick
+            test_unknown_defaults_observe;
+          Alcotest.test_case "case insensitive" `Quick test_case_insensitive;
+        ] );
+      ( "cache",
+        [
+          Alcotest.test_case "first read cached" `Quick test_cache_first_read;
+          Alcotest.test_case "reset_cache_for_test re-reads" `Quick
+            test_reset_cache;
+        ] );
+      ( "mode_label",
+        [ Alcotest.test_case "stable labels" `Quick test_mode_labels ] );
+      ( "budget_for_label",
+        [
+          Alcotest.test_case "codex_cli" `Quick test_budget_codex_cli;
+          Alcotest.test_case "claude_code" `Quick test_budget_claude_code;
+          Alcotest.test_case "glm-coding" `Quick test_budget_glm_coding;
+          Alcotest.test_case "kimi-for-coding" `Quick test_budget_kimi;
+          Alcotest.test_case "local 27b" `Quick test_budget_local;
+          Alcotest.test_case "local 70b plus" `Quick test_budget_local_70b;
+          Alcotest.test_case "unknown -> cloud_fast" `Quick
+            test_budget_unknown_default;
+          Alcotest.test_case "case insensitive" `Quick
+            test_budget_case_insensitive;
+        ] );
+    ]

--- a/test/test_cascade_attempt_liveness_counters.ml
+++ b/test/test_cascade_attempt_liveness_counters.ml
@@ -1,0 +1,81 @@
+(** Tests for the cascade attempt-liveness Prometheus counters
+    (RFC-0022 PR-2 §3).
+
+    Pins the canonical metric names so a Grafana rule referring to
+    [masc_cascade_attempt_liveness_kill_total] /
+    [masc_cascade_attempt_liveness_observed_total] cannot silently
+    break on a rename. Also exercises the auto-registration path
+    (inc_counter creates the series on first call) so that a future
+    refactor moving counter registration to an explicit init block
+    will not silently regress these series. *)
+
+module P = Masc_mcp.Prometheus
+
+let test_kill_metric_name_stable () =
+  Alcotest.(check string)
+    "kill counter canonical name"
+    "masc_cascade_attempt_liveness_kill_total"
+    P.metric_cascade_attempt_liveness_kill
+
+let test_observed_metric_name_stable () =
+  Alcotest.(check string)
+    "observed counter canonical name"
+    "masc_cascade_attempt_liveness_observed_total"
+    P.metric_cascade_attempt_liveness_observed
+
+let test_kill_counter_increments () =
+  let labels =
+    [ ("mode", "observe");
+      ("kind", "no_first_token");
+      ("cascade", "test_cascade");
+      ("provider", "test_provider") ]
+  in
+  let before =
+    P.metric_value_or_zero P.metric_cascade_attempt_liveness_kill ~labels ()
+  in
+  P.inc_counter P.metric_cascade_attempt_liveness_kill ~labels ();
+  let after =
+    P.metric_value_or_zero P.metric_cascade_attempt_liveness_kill ~labels ()
+  in
+  Alcotest.(check (float 1e-6))
+    "kill counter increments by 1.0"
+    (before +. 1.0) after
+
+let test_observed_counter_increments () =
+  let labels =
+    [ ("cascade", "test_cascade");
+      ("provider", "test_provider");
+      ("outcome", "success") ]
+  in
+  let before =
+    P.metric_value_or_zero P.metric_cascade_attempt_liveness_observed
+      ~labels ()
+  in
+  P.inc_counter P.metric_cascade_attempt_liveness_observed ~labels ();
+  P.inc_counter P.metric_cascade_attempt_liveness_observed ~labels ();
+  let after =
+    P.metric_value_or_zero P.metric_cascade_attempt_liveness_observed
+      ~labels ()
+  in
+  Alcotest.(check (float 1e-6))
+    "observed counter increments by delta"
+    (before +. 2.0) after
+
+let () =
+  Alcotest.run "cascade_attempt_liveness_counters"
+    [
+      ( "metric names",
+        [
+          Alcotest.test_case "kill name stable" `Quick
+            test_kill_metric_name_stable;
+          Alcotest.test_case "observed name stable" `Quick
+            test_observed_metric_name_stable;
+        ] );
+      ( "registration",
+        [
+          Alcotest.test_case "kill increments" `Quick
+            test_kill_counter_increments;
+          Alcotest.test_case "observed increments" `Quick
+            test_observed_counter_increments;
+        ] );
+    ]

--- a/test/test_cascade_attempt_liveness_observer.ml
+++ b/test/test_cascade_attempt_liveness_observer.ml
@@ -1,0 +1,229 @@
+(** Tests for [Cascade_attempt_liveness_observer] (RFC-0022 PR-2/4 §4-6).
+
+    Coverage:
+    - Counter increments per outcome (kill_total + observed_total).
+    - [Observe] mode: never raises and does not Switch.fail (RFC §4
+      structural contract).
+    - [Enforce] mode: raises [Liveness_kill] via Switch.fail on Outcome.
+    - [Off] mode: wrap_on_event returns the original callback verbatim.
+    - Tick fiber dies with parent switch (Eio resource ledger). *)
+
+open Masc_mcp
+module L = Cascade_attempt_liveness
+module Cfg = Cascade_attempt_liveness_config
+module Obs = Cascade_attempt_liveness_observer
+
+(* -- helpers ------------------------------------------------------- *)
+
+let mk_observer ?(mode = Cfg.Observe) ?(budget = L.cloud_fast)
+    ?(cascade = "test_cascade") ?(provider = "test_provider")
+    ?(started_at = 0.0) () =
+  Obs.create ~mode ~budget ~cascade_label:cascade ~provider_label:provider
+    ~started_at
+
+let counter_value name labels =
+  Prometheus.metric_value_or_zero name ~labels ()
+
+let kill_value mode kind cascade provider =
+  counter_value Prometheus.metric_cascade_attempt_liveness_kill
+    [
+      ("mode", mode);
+      ("kind", kind);
+      ("cascade", cascade);
+      ("provider", provider);
+    ]
+
+let observed_value cascade provider outcome =
+  counter_value Prometheus.metric_cascade_attempt_liveness_observed
+    [
+      ("cascade", cascade);
+      ("provider", provider);
+      ("outcome", outcome);
+    ]
+
+let stop = Agent_sdk.Types.MessageStop
+
+(* -- Off mode: wrap_on_event returns the original ------------------ *)
+
+let test_off_returns_original () =
+  let obs = mk_observer ~mode:Cfg.Off () in
+  let original = Some (fun (_ : Agent_sdk.Types.sse_event) -> ()) in
+  let wrapped = Obs.wrap_on_event obs original in
+  Alcotest.(check bool)
+    "Off returns original (physical equality)" true (wrapped == original)
+
+let test_off_finalize_is_noop () =
+  let cascade = "off_cascade_finalize" in
+  let provider = "off_provider_finalize" in
+  let obs = mk_observer ~mode:Cfg.Off ~cascade ~provider () in
+  let before = observed_value cascade provider "success" in
+  Obs.finalize obs;
+  let after = observed_value cascade provider "success" in
+  Alcotest.(check (float 1e-6))
+    "Off finalize emits no observed counter" before after
+
+(* -- Observe mode: counter emitted, no raise ---------------------- *)
+
+let test_observe_emits_kill_counter_no_raise () =
+  let cascade = "observe_kill_cascade" in
+  let provider = "observe_kill_provider" in
+  (* TTFT 30s, force a Tick at t=40 to trigger No_first_token. *)
+  let obs =
+    mk_observer ~mode:Cfg.Observe ~cascade ~provider ~started_at:0.0 ()
+  in
+  (* Manually exercise the FSM via a Provider_wire_error event so we
+     stay synchronous and deterministic — Observe must counter+log
+     but never raise. *)
+  let original_calls = ref 0 in
+  let original = Some (fun (_ : Agent_sdk.Types.sse_event) -> incr original_calls) in
+  let wrapped = Obs.wrap_on_event obs original in
+  match wrapped with
+  | None -> Alcotest.fail "Observe should return Some wrapper"
+  | Some f ->
+      let before =
+        kill_value "observe" "provider_error" cascade provider
+      in
+      f (Agent_sdk.Types.SSEError "boom");
+      let after =
+        kill_value "observe" "provider_error" cascade provider
+      in
+      Alcotest.(check int) "original called" 1 !original_calls;
+      Alcotest.(check (float 1e-6))
+        "Observe wire_error emits kill counter" (before +. 1.0) after;
+      (* Observe must reach Failed without raising. *)
+      (match Obs.current_state_for_test obs with
+       | L.Failed (L.Provider_error _) -> ()
+       | _ -> Alcotest.fail "expected Failed Provider_error")
+
+let test_observe_done_completes () =
+  let cascade = "observe_done_cascade" in
+  let provider = "observe_done_provider" in
+  let obs =
+    mk_observer ~mode:Cfg.Observe ~cascade ~provider ~started_at:0.0 ()
+  in
+  let wrapped = Obs.wrap_on_event obs None in
+  match wrapped with
+  | None -> Alcotest.fail "Observe should return Some wrapper"
+  | Some f ->
+      f stop;
+      Alcotest.(check bool)
+        "Done -> Success state" true
+        (match Obs.current_state_for_test obs with
+         | L.Success -> true
+         | _ -> false)
+
+let test_observe_finalize_emits_outcome () =
+  let cascade = "observe_finalize_cascade" in
+  let provider = "observe_finalize_provider" in
+  let obs =
+    mk_observer ~mode:Cfg.Observe ~cascade ~provider ~started_at:0.0 ()
+  in
+  let wrapped = Obs.wrap_on_event obs None in
+  (match wrapped with
+   | Some f -> f stop
+   | None -> Alcotest.fail "wrapper missing");
+  let before = observed_value cascade provider "success" in
+  Obs.finalize obs;
+  let after = observed_value cascade provider "success" in
+  Alcotest.(check (float 1e-6))
+    "finalize emits success outcome" (before +. 1.0) after;
+  (* Idempotent. *)
+  Obs.finalize obs;
+  let after2 = observed_value cascade provider "success" in
+  Alcotest.(check (float 1e-6))
+    "finalize is idempotent" after after2
+
+let test_observe_finalize_pending_is_wire_error () =
+  let cascade = "observe_pending_cascade" in
+  let provider = "observe_pending_provider" in
+  let obs =
+    mk_observer ~mode:Cfg.Observe ~cascade ~provider ~started_at:0.0 ()
+  in
+  let before = observed_value cascade provider "wire_error" in
+  Obs.finalize obs;
+  let after = observed_value cascade provider "wire_error" in
+  Alcotest.(check (float 1e-6))
+    "Awaiting at finalize -> wire_error" (before +. 1.0) after
+
+(* -- Enforce mode: Switch.fail raised ---------------------------- *)
+
+let test_enforce_switch_fail () =
+  let cascade = "enforce_cascade" in
+  let provider = "enforce_provider" in
+  let raised = ref None in
+  Eio_main.run (fun env ->
+      let clock = Eio.Stdenv.clock env in
+      try
+        Eio.Switch.run (fun sw ->
+            let obs =
+              mk_observer ~mode:Cfg.Enforce ~cascade ~provider
+                ~started_at:0.0 ()
+            in
+            Obs.start_tick_fiber obs ~sw ~clock;
+            let wrapped = Obs.wrap_on_event obs None in
+            (match wrapped with
+             | Some f -> f (Agent_sdk.Types.SSEError "wire boom")
+             | None -> Alcotest.fail "Enforce wrapper missing");
+            (* Allow the Switch.fail to propagate. *)
+            Eio.Fiber.yield ())
+      with
+      | Obs.Liveness_kill failure ->
+          raised := Some (L.failure_kind_label failure)
+      | exn ->
+          Alcotest.failf "unexpected exception: %s" (Printexc.to_string exn));
+  Alcotest.(check (option string))
+    "Liveness_kill raised in Enforce mode"
+    (Some "provider_error") !raised
+
+(* -- Tick fiber dies with parent switch -------------------------- *)
+
+let test_tick_fiber_dies_with_switch () =
+  (* Build observer in Observe mode (no kill), start tick fiber, then
+     close the switch. Eio's structured concurrency guarantees fiber
+     teardown — if the fiber leaks, Switch.run would hang. *)
+  Eio_main.run (fun env ->
+      let clock = Eio.Stdenv.clock env in
+      Eio.Switch.run (fun sw ->
+          let obs =
+            mk_observer ~mode:Cfg.Observe ~started_at:0.0 ()
+          in
+          Obs.start_tick_fiber obs ~sw ~clock;
+          (* Force the FSM terminal so the loop exits naturally too. *)
+          let wrapped = Obs.wrap_on_event obs None in
+          (match wrapped with
+           | Some f -> f stop
+           | None -> ());
+          Eio.Fiber.yield ()));
+  Alcotest.(check bool) "Switch.run returned cleanly" true true
+
+let () =
+  Alcotest.run "cascade_attempt_liveness_observer"
+    [
+      ( "off",
+        [
+          Alcotest.test_case "wrap returns original" `Quick
+            test_off_returns_original;
+          Alcotest.test_case "finalize noop" `Quick test_off_finalize_is_noop;
+        ] );
+      ( "observe",
+        [
+          Alcotest.test_case "wire_error emits kill counter, no raise"
+            `Quick test_observe_emits_kill_counter_no_raise;
+          Alcotest.test_case "Done completes to Success" `Quick
+            test_observe_done_completes;
+          Alcotest.test_case "finalize emits outcome and is idempotent"
+            `Quick test_observe_finalize_emits_outcome;
+          Alcotest.test_case "pending finalize -> wire_error" `Quick
+            test_observe_finalize_pending_is_wire_error;
+        ] );
+      ( "enforce",
+        [
+          Alcotest.test_case "Outcome -> Switch.fail Liveness_kill" `Quick
+            test_enforce_switch_fail;
+        ] );
+      ( "lifetime",
+        [
+          Alcotest.test_case "tick fiber dies with switch" `Quick
+            test_tick_fiber_dies_with_switch;
+        ] );
+    ]

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -1,0 +1,136 @@
+(** Integration smoke for the cascade attempt-liveness wiring in
+    [oas_worker_named.ml] (RFC-0022 PR-2 §4 commit 4).
+
+    This test does not spin up a real provider — that surface needs a
+    live OAS attempt loop with a mock SSE server, which lands as the
+    PR-3 e2e fixture. Instead we pin the observable wiring contract:
+
+    1. The env-flag bridge ([Cascade_attempt_liveness_config.current_mode])
+       reads the same MASC_CASCADE_ATTEMPT_LIVENESS variable that
+       try_provider consults — preventing a future rename from
+       silently splitting the call sites.
+
+    2. The observer module is reachable through the
+       [Cascade_attempt_liveness_observer.{create, wrap_on_event,
+       finalize}] surface that try_provider depends on, with the
+       expected mode contract (Off pass-through; Observe wraps; Enforce
+       wraps + raises). Same surface, exercised end-to-end.
+
+    3. End-to-end finalize emits the observed_total counter with the
+       outcome label that try_provider's `finalize_liveness ()` call
+       will produce. *)
+
+open Masc_mcp
+module Cfg = Cascade_attempt_liveness_config
+module Obs = Cascade_attempt_liveness_observer
+
+let env_var = "MASC_CASCADE_ATTEMPT_LIVENESS"
+
+let with_env value f =
+  let prior = Sys.getenv_opt env_var in
+  (match value with
+   | None -> Unix.putenv env_var ""
+   | Some v -> Unix.putenv env_var v);
+  Cfg.reset_cache_for_test ();
+  let restore () =
+    (match prior with
+     | None -> Unix.putenv env_var ""
+     | Some v -> Unix.putenv env_var v);
+    Cfg.reset_cache_for_test ()
+  in
+  match f () with
+  | x -> restore (); x
+  | exception e -> restore (); raise e
+
+(* -- env-flag bridge contract ------------------------------------- *)
+
+let test_env_off_short_circuits () =
+  with_env (Some "off") (fun () ->
+      Alcotest.(check string)
+        "MASC_CASCADE_ATTEMPT_LIVENESS=off -> Off mode"
+        "off"
+        (Cfg.mode_label (Cfg.current_mode ())))
+
+let test_env_observe_default () =
+  with_env None (fun () ->
+      Alcotest.(check string)
+        "default -> Observe (RFC §9 Phase A)"
+        "observe"
+        (Cfg.mode_label (Cfg.current_mode ())))
+
+let test_env_enforce () =
+  with_env (Some "enforce") (fun () ->
+      Alcotest.(check string)
+        "MASC_CASCADE_ATTEMPT_LIVENESS=enforce -> Enforce mode"
+        "enforce"
+        (Cfg.mode_label (Cfg.current_mode ())))
+
+(* -- end-to-end finalize emits observed_total -------------------- *)
+
+let observed_value cascade provider outcome =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_cascade_attempt_liveness_observed
+    ~labels:
+      [
+        ("cascade", cascade);
+        ("provider", provider);
+        ("outcome", outcome);
+      ]
+    ()
+
+let test_e2e_observe_finalize_emits_observed_total () =
+  with_env (Some "observe") (fun () ->
+      let cascade = "integ_observe_cascade" in
+      let provider = "integ_observe_provider" in
+      let mode = Cfg.current_mode () in
+      let budget = Cfg.budget_for_label provider in
+      let obs =
+        Obs.create ~mode ~budget ~cascade_label:cascade
+          ~provider_label:provider ~started_at:0.0
+      in
+      (* Simulate: provider streamed Done before any chunk -> Success. *)
+      let wrapped = Obs.wrap_on_event obs None in
+      (match wrapped with
+       | Some f -> f Agent_sdk.Types.MessageStop
+       | None -> Alcotest.fail "Observe should wrap");
+      let before = observed_value cascade provider "success" in
+      Obs.finalize obs;
+      let after = observed_value cascade provider "success" in
+      Alcotest.(check (float 1e-6))
+        "observed_total{outcome=success} incremented"
+        (before +. 1.0) after)
+
+let test_e2e_off_no_observed_total () =
+  with_env (Some "off") (fun () ->
+      let cascade = "integ_off_cascade" in
+      let provider = "integ_off_provider" in
+      let mode = Cfg.current_mode () in
+      let budget = Cfg.budget_for_label provider in
+      let obs =
+        Obs.create ~mode ~budget ~cascade_label:cascade
+          ~provider_label:provider ~started_at:0.0
+      in
+      let before = observed_value cascade provider "wire_error" in
+      Obs.finalize obs;
+      let after = observed_value cascade provider "wire_error" in
+      Alcotest.(check (float 1e-6))
+        "Off finalize emits no observed counter" before after)
+
+let () =
+  Alcotest.run "oas_worker_named_liveness_integration"
+    [
+      ( "env flag bridge",
+        [
+          Alcotest.test_case "off short-circuits" `Quick
+            test_env_off_short_circuits;
+          Alcotest.test_case "default observe" `Quick test_env_observe_default;
+          Alcotest.test_case "enforce alias" `Quick test_env_enforce;
+        ] );
+      ( "end to end",
+        [
+          Alcotest.test_case "Observe e2e finalize emits observed_total"
+            `Quick test_e2e_observe_finalize_emits_observed_total;
+          Alcotest.test_case "Off e2e emits nothing" `Quick
+            test_e2e_off_no_observed_total;
+        ] );
+    ]


### PR DESCRIPTION
**Stacked on #12968 (RFC-0022 PR-1)**

Consumer for the pure FSM landed in #12968. Wires `Cascade_attempt_liveness.step` into `lib/oas_worker_named.ml::try_provider` behind tri-state env flag `MASC_CASCADE_ATTEMPT_LIVENESS=off|observe|enforce` (default `observe` per RFC-0022 §9 Phase A).

## Stack

1. PR-1 (#12968): pure FSM module + decision-table tests.
2. **PR-2 (this PR)**: config + Prometheus counters + observer + tick fiber + `oas_worker_named.ml` integration + RFC §9 status update.
3. PR-3 (next): keeper-side wiring (RFC §6 — record_progress lockstep, bounded heartbeat detection).
4. PR-4 (next): default flip to `enforce` per profile after Phase A soak.

## Commits (5, each independently buildable)

1. `feat(cascade): config module for MASC_CASCADE_ATTEMPT_LIVENESS tri-state` — `Cascade_attempt_liveness_config` (~70 LOC + tests). Cached env read mirroring `Keeper_admission_glue.use_new_admission`. Per-label budget map.
2. `feat(prometheus): cascade attempt liveness kill / observed counters` — two counters in `lib/prometheus.{ml,mli}` (auto-registered on first inc per existing convention).
3. `feat(cascade): attempt liveness observer with tick fiber` — `Cascade_attempt_liveness_observer` (~250 LOC + tests). Structural no-kill contract for `Observe`; tick fiber dies with parent switch.
4. `feat(oas-worker): wire liveness observer into per-attempt loop` — only behavior-change commit. `try_provider` reads mode once per attempt, wraps `on_event`, starts tick fiber, finalizes on both Ok/Error return paths.
5. `docs(rfc-0022): mark §9 Phase A wiring landed` — 5-line status update.

## Behaviour change envelope

- **Default `observe`**: `masc_cascade_attempt_liveness_kill_total{mode=observe,...}` and `masc_cascade_attempt_liveness_observed_total{...}` emit on every cascade attempt. **No `Switch.fail` issued.** Cascade behaviour bit-identical to baseline.
- **`enforce`**: on `Outcome` the observer calls `Eio.Switch.fail sw (Liveness_kill failure)` so `Oas_worker_exec.run` tears down via Eio cancellation.
- **`off`**: wrapper bypassed entirely (physical-equality on `on_event`).
- Operator dial-back: `MASC_CASCADE_ATTEMPT_LIVENESS=off` + keeper restart = full revert.

## Test plan

- [x] `dune build --root . lib/` clean (test/* has pre-existing failures from `Feature_flag_registry` / `thompson_confidence` rebase noise, scoped per `feedback_pre_merge_typecheck_drag_in_blocker`).
- [x] `test_cascade_attempt_liveness_config` — 19 tests pass (env parse, cache, label→budget).
- [x] `test_cascade_attempt_liveness_counters` — 4 tests pass (canonical metric names + auto-registration).
- [x] `test_cascade_attempt_liveness_observer` — 8 tests pass (Off bypass, Observe never-raise, Enforce Switch.fail, finalize idempotency, tick fiber lifetime under Switch.run).
- [x] `test_oas_worker_named_liveness_integration` — 5 tests pass (env-flag bridge + e2e finalize).
- [x] `test_cascade_attempt_liveness` (PR-1, 18 tests) still passes.
- [ ] 24h soak in `observe` mode on dev base path; verify `kill_total` non-zero on at least one provider with no behaviour change (Phase A exit gate).
- [ ] Mock-provider e2e fixture with hung first-byte (deferred to PR-3).

RFC-Anchor: docs/rfc/RFC-0022-cascade-attempt-liveness.md §9 Phase A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>