### PR TITLE
refactor(keeper_agent_prompt_metrics): replace 0 sentinel with int option

### DIFF
--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -222,7 +222,7 @@ let build_ctx_composition_metrics
     ~(temporal_context : string)
     ~(user_message : string)
     ~(history_messages : Agent_sdk.Types.message list)
-    ~(actual_input_tokens : int) : ctx_composition_metrics =
+    ~(actual_input_tokens : int option) : ctx_composition_metrics =
   let totals : (string, prompt_segment_metrics) Hashtbl.t = Hashtbl.create 16 in
   let add_text_segment bucket text =
     let metric = prompt_segment_metrics_of_text text in
@@ -253,7 +253,9 @@ let build_ctx_composition_metrics
       0 segments
   in
   let actual_input_tokens =
-    if actual_input_tokens > 0 then Some actual_input_tokens else None
+    match actual_input_tokens with
+    | Some n when n > 0 -> Some n
+    | Some _ | None -> None
   in
   let display_total_tokens =
     match actual_input_tokens with

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -87,6 +87,9 @@ val metric_of_block :
 val history_bucket_of_block :
   role:Agent_sdk.Types.role -> Agent_sdk.Types.content_block -> string
 
+(** [actual_input_tokens] is the LLM-reported input token count and is
+    only known after a provider response. Pre-call sites (prompt build)
+    must pass [None]; post-response sites pass [Some n]. *)
 val build_ctx_composition_metrics :
   system_prompt:string ->
   dynamic_context:string ->
@@ -94,7 +97,7 @@ val build_ctx_composition_metrics :
   temporal_context:string ->
   user_message:string ->
   history_messages:Agent_sdk.Types.message list ->
-  actual_input_tokens:int ->
+  actual_input_tokens:int option ->
   ctx_composition_metrics
 
 val ctx_composition_to_json : ctx_composition_metrics -> Yojson.Safe.t

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -632,7 +632,7 @@ let run_turn
              ~temporal_context
              ~user_message
              ~history_messages
-             ~actual_input_tokens:usage.input_tokens
+             ~actual_input_tokens:(Some usage.input_tokens)
          in
          (* Classify the most-specific actionable signal from the structured
             keeper world snapshot. This deliberately avoids re-parsing the

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -171,6 +171,9 @@ val build_prompt_metrics :
   -> user_message:string
   -> prompt_metrics
 
+(** [actual_input_tokens] is the LLM-reported input token count and is
+    only known after a provider response. Pre-call sites (prompt build)
+    must pass [None]; post-response sites pass [Some n]. *)
 val build_ctx_composition_metrics :
      system_prompt:string
   -> dynamic_context:string
@@ -178,7 +181,7 @@ val build_ctx_composition_metrics :
   -> temporal_context:string
   -> user_message:string
   -> history_messages:Agent_sdk.Types.message list
-  -> actual_input_tokens:int
+  -> actual_input_tokens:int option
   -> ctx_composition_metrics
 
 val prompt_metrics_to_json : prompt_metrics -> Yojson.Safe.t

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -97,6 +97,9 @@ let build_turn_context
       (Keeper_exec_context.messages_of_context ctx_work)
   in
   let estimated_input_tokens =
+    (* Prompt build runs before the LLM call, so the actual input-token
+       count is unknown here; post-response code paths in
+       [Keeper_agent_run] pass the provider-reported value. *)
     let composition =
       Keeper_agent_prompt_metrics.build_ctx_composition_metrics
         ~system_prompt:turn_system_prompt
@@ -105,7 +108,7 @@ let build_turn_context
         ~temporal_context
         ~user_message
         ~history_messages
-        ~actual_input_tokens:0
+        ~actual_input_tokens:None
     in
     max prompt_metrics.Keeper_agent_prompt_metrics.estimated_total_tokens
         composition.Keeper_agent_prompt_metrics.display_total_tokens

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -284,7 +284,7 @@ let test_ctx_composition_splits_history_and_residual () =
       ~temporal_context:"Temporal context"
       ~user_message:"Current user message"
       ~history_messages
-      ~actual_input_tokens:1000
+      ~actual_input_tokens:(Some 1000)
   in
   let segment_tokens key =
     metrics.segments

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2053,7 +2053,7 @@ let sample_prompt_metrics ?(system_prompt = "You are a keeper.")
 let sample_ctx_composition ?(system_prompt = "You are a keeper.")
     ?(dynamic_context = "")
     ?(user_message = "Check the board.")
-    ?(actual_input_tokens = 0)
+    ?(actual_input_tokens : int option = None)
     () =
   KAR.build_ctx_composition_metrics
     ~system_prompt
@@ -2094,7 +2094,10 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     response_text = text;
     model_used = model;
     prompt_metrics = sample_prompt_metrics ();
-    ctx_composition = sample_ctx_composition ~actual_input_tokens:input_tok ();
+    ctx_composition =
+      sample_ctx_composition
+        ~actual_input_tokens:(if input_tok > 0 then Some input_tok else None)
+        ();
     cascade_observation;
     turn_count = 1;
     tool_calls_made = List.length tools;


### PR DESCRIPTION
## Summary
- audit Tier C C-6: `Keeper_run_prompt.build_turn_context`가 `~actual_input_tokens:0` sentinel을 전달
- 의미: "prompt 빌드 시점, LLM 미호출 → actual 측정 불가". 내부에서 `if > 0 then Some else None` 변환됨
- sentinel 0은 작동하지만, 의도가 call site에서 보이지 않아 readers가 3개 모듈을 추적해야 의미를 파악
- Fix: `int` → `int option` 으로 정직화. caller가 직접 `None`/`Some _` 명시
  - `Keeper_run_prompt`: `None` + 주석 ("prompt build runs before the LLM call")
  - `Keeper_agent_run`: `Some usage.input_tokens` (응답 후 측정값)
  - 테스트 fixture: 동일 패턴으로 변환
- 동작 변화 없음. `ctx_composition_metrics.actual_input_tokens` JSON 필드 그대로

## RFC
RFC-WAIVED: lib/keeper/keeper_agent_prompt_metrics.ml은 lib/keeper/credential_*, lib/repo_manager/, lib/operator/operator_control*, dashboard/credential, .claude/hooks/, instructions/workflow* 어느 RFC subsystem에도 해당하지 않음. observability surface (prompt token metrics).

## 호환성
- `build_ctx_composition_metrics` mli 시그니처 변경: `actual_input_tokens:int` → `actual_input_tokens:int option`
- 외부 caller 0건 (in-tree caller 5건 모두 이번 PR에서 변환)

## Test plan
- [x] `dune build @lib/check` 통과
- [x] `dune build test/test_keeper_prompt_metrics.exe test/test_keeper_unified.exe` 통과
- [ ] CI 전체 통과 확인
- [ ] (별건 follow-up) `Keeper_run_prompt`에서 `build_ctx_composition_metrics` 호출 자체의 적절성 — prompt 빌드 시점에는 estimated만 있으면 충분하고, post-response 단일 호출로 정리하는 것이 더 깨끗할 수 있음

## 출처
- /Users/dancer/Downloads/audit_derived_state.md (Tier C C-6 sentinel)
- Plan: Tier C C-6 (cleanup-audit-2026-05)

## Note
Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
