### PR TITLE
feat(cascade): RFC-0027 PR-2 cascade.toml required_capability_profile parser

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -165,6 +165,7 @@ type catalog_entry = {
   name : string;
   keeper_assignable : bool;
   fallback_cascade : string option;
+  required_capability_profile : Cascade_capability_profile.profile option;
 }
 
 module StringMap = Map.Make (String)
@@ -173,6 +174,7 @@ type catalog_field =
   | Schema_field
   | Keeper_assignable_field
   | Fallback_cascade_field
+  | Required_capability_profile_field
 
 let catalog_key_specs =
   [
@@ -194,6 +196,7 @@ let catalog_key_specs =
     ("_thinking_budget", Schema_field);
     ("_keeper_assignable", Keeper_assignable_field);
     ("_fallback_cascade", Fallback_cascade_field);
+    ("_required_capability_profile", Required_capability_profile_field);
   ]
 
 let split_catalog_key key =
@@ -209,10 +212,22 @@ let split_catalog_key key =
         else None)
       catalog_key_specs
 
+(* [required_capability_profile] is a Result so unknown profile names
+   surface to [load_catalog] as a fail-closed [Error] instead of a
+   silent [None].  Keeping the error inside the builder lets us defer
+   the abort to entry-construction time after every key has been
+   visited, so the operator gets one consolidated error message even
+   when multiple profiles are misconfigured. *)
+type capability_profile_parse =
+  | Cp_unset
+  | Cp_set of Cascade_capability_profile.profile
+  | Cp_invalid of string
+
 type catalog_builder = {
   has_schema_field : bool;
   keeper_assignable : bool option;
   fallback_cascade : string option;
+  required_capability_profile : capability_profile_parse;
 }
 
 let deprecated_logical_profile_names =
@@ -255,6 +270,7 @@ let empty_catalog_builder = {
   has_schema_field = false;
   keeper_assignable = None;
   fallback_cascade = None;
+  required_capability_profile = Cp_unset;
 }
 
 let update_catalog_builder builder field value =
@@ -276,6 +292,19 @@ let update_catalog_builder builder field value =
         | _ -> builder.fallback_cascade
       in
       { builder with fallback_cascade }
+  | Required_capability_profile_field ->
+      let required_capability_profile =
+        match value with
+        | `String s ->
+            let trimmed = String.trim s in
+            if String.equal trimmed "" then Cp_unset
+            else
+              (match Cascade_capability_profile.profile_of_string trimmed with
+               | Some p -> Cp_set p
+               | None -> Cp_invalid trimmed)
+        | _ -> builder.required_capability_profile
+      in
+      { builder with required_capability_profile }
 
 (* Detect fallback_cascade cycles in a freshly loaded catalog.
 
@@ -344,21 +373,49 @@ let load_catalog ~config_path =
           StringMap.empty
           fields
       in
-      let entries =
+      let active_builders =
         builders
         |> StringMap.bindings
-        |> List.filter_map (fun (name, builder) ->
-               if (not builder.has_schema_field)
-                  || is_deprecated_logical_profile_name name
-               then None
-               else
-                 Some
-                   {
-                     name;
-                     keeper_assignable =
-                       Option.value builder.keeper_assignable ~default:true;
-                     fallback_cascade = builder.fallback_cascade;
-                   })
+        |> List.filter (fun (name, builder) ->
+               builder.has_schema_field
+               && not (is_deprecated_logical_profile_name name))
+      in
+      let invalid_profile_errors =
+        List.filter_map
+          (fun (name, builder) ->
+            match builder.required_capability_profile with
+            | Cp_invalid raw ->
+                Some
+                  (Printf.sprintf
+                     "cascade %s: unknown required_capability_profile %S \
+                      (known: %s)"
+                     name raw
+                     (Cascade_capability_profile.all_profiles
+                      |> List.map Cascade_capability_profile.profile_to_string
+                      |> String.concat ", "))
+            | _ -> None)
+          active_builders
+      in
+      if invalid_profile_errors <> [] then
+        Error (String.concat "; " invalid_profile_errors)
+      else
+      let entries =
+        List.map
+          (fun (name, builder) ->
+            let required_capability_profile =
+              match builder.required_capability_profile with
+              | Cp_set p -> Some p
+              | Cp_unset -> None
+              | Cp_invalid _ -> None  (* unreachable: filtered above *)
+            in
+            {
+              name;
+              keeper_assignable =
+                Option.value builder.keeper_assignable ~default:true;
+              fallback_cascade = builder.fallback_cascade;
+              required_capability_profile;
+            })
+          active_builders
       in
       let cycles = detect_fallback_cycles entries in
       let key = cycle_set_key cycles in

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -60,6 +60,18 @@ type catalog_entry = {
       to drop the hint when it does not match a live catalog entry.
 
       @since 0.174.0 *)
+  required_capability_profile : Cascade_capability_profile.profile option;
+  (** Optional declarative capability requirement (RFC-0027).  When
+      set, the validator (PR-3) checks that every model entry in this
+      cascade satisfies the named profile via
+      {!Cascade_capability_profile.provider_satisfies_profile}.
+
+      JSON key: ["{name}_required_capability_profile"], string-typed.
+      Unknown profile names cause [load_catalog] to return [Error _]
+      (no silent fallback — fail-closed per memory rule
+      [feedback_keeper_runtime_fail_closed_for_unknown_permissive_default]).
+
+      @since RFC-0027 PR-2 *)
 }
 
 (** Deprecated logical route keys must not be treated as concrete catalog

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -302,6 +302,17 @@ let profile_field_json ~profile_name ~field_name field_value =
       | Ok value ->
           Ok [ (profile_name ^ "_fallback_cascade", `String value) ]
       | Error _ as err -> err)
+  | "required_capability_profile" -> (
+      (* RFC-0027 PR-2.  String-typed; loader (cascade_config_loader.ml)
+         parses through Cascade_capability_profile.profile_of_string and
+         fails with a [Catalog_error] on unknown values.  Materializer
+         only enforces nonempty-string here; profile-name validity is
+         the loader's responsibility (single source of truth for the
+         enumeration). *)
+      match trimmed_nonempty_string ~path:profile_path field_value with
+      | Ok value ->
+          Ok [ (profile_name ^ "_required_capability_profile", `String value) ]
+      | Error _ as err -> err)
   | "keeper_assignable" -> (
       match bool_value ~path:profile_path field_value with
       | Ok value ->
@@ -332,7 +343,7 @@ let profile_field_json ~profile_name ~field_name field_value =
       | Error _ as err -> err)
   | other ->
       errorf
-        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, keeper_assignable, fallback_cascade, api_key_env, keep_alive, num_ctx, timeout_sec"
+        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, keeper_assignable, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec"
         other profile_name
 
 let profile_table_json_fields ~profile_name value =

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,7 @@
         test_reward_advice_artifact
         test_keeper_cascade_profile
         test_cascade_capability_profile
+        test_cascade_required_capability_profile
         test_keeper_hooks_oas_provider
         test_keeper_hooks_oas_pricing
         test_keeper_hooks_oas_telemetry
@@ -251,6 +252,7 @@
         test_reward_advice_artifact
           test_keeper_cascade_profile
           test_cascade_capability_profile
+          test_cascade_required_capability_profile
           test_keeper_hooks_oas_provider
           test_keeper_hooks_oas_pricing
           test_keeper_hooks_oas_telemetry

--- a/test/test_cascade_required_capability_profile.ml
+++ b/test/test_cascade_required_capability_profile.ml
@@ -1,0 +1,134 @@
+(** RFC-0027 PR-2: cascade.json [_required_capability_profile] parser.
+
+    Verifies the new optional field round-trips through
+    [Cascade_config_loader.load_catalog] and that an unknown profile
+    string fails closed (Error) instead of falling back to None. *)
+
+open Alcotest
+
+module Loader = Masc_mcp.Cascade_config_loader
+module CP = Masc_mcp.Cascade_capability_profile
+
+let with_temp_json contents f =
+  let dir = Filename.temp_file "cascade-rcp-" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let path = Filename.concat dir "cascade.json" in
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove path with _ -> ());
+      try Unix.rmdir dir with _ -> ())
+    (fun () -> f path)
+
+let entry_named entries name =
+  List.find_opt (fun (e : Loader.catalog_entry) -> e.name = name) entries
+
+let pp_profile_opt fmt = function
+  | None -> Format.pp_print_string fmt "None"
+  | Some p ->
+      Format.pp_print_string fmt
+        (Printf.sprintf "Some %s" (CP.profile_to_string p))
+
+let profile_opt =
+  testable pp_profile_opt ( = )
+
+let test_profile_set_to_known_value () =
+  let json =
+    {|{"big_three_models": ["claude_code:auto"],
+        "big_three_required_capability_profile": "tool_strict"}|}
+  in
+  with_temp_json json @@ fun path ->
+  match Loader.load_catalog ~config_path:path with
+  | Error msg -> failf "load failed: %s" msg
+  | Ok entries ->
+      (match entry_named entries "big_three" with
+       | None -> failf "big_three entry missing"
+       | Some e ->
+           check profile_opt "tool_strict parsed"
+             (Some CP.Tool_strict)
+             e.required_capability_profile)
+
+let test_profile_field_omitted_defaults_to_none () =
+  let json = {|{"big_three_models": ["claude_code:auto"]}|} in
+  with_temp_json json @@ fun path ->
+  match Loader.load_catalog ~config_path:path with
+  | Error msg -> failf "load failed: %s" msg
+  | Ok entries ->
+      (match entry_named entries "big_three" with
+       | None -> failf "big_three entry missing"
+       | Some e ->
+           check profile_opt "field omitted -> None" None
+             e.required_capability_profile)
+
+let test_profile_empty_string_treated_as_unset () =
+  let json =
+    {|{"big_three_models": ["claude_code:auto"],
+        "big_three_required_capability_profile": ""}|}
+  in
+  with_temp_json json @@ fun path ->
+  match Loader.load_catalog ~config_path:path with
+  | Error msg -> failf "load failed on empty string: %s" msg
+  | Ok entries ->
+      (match entry_named entries "big_three" with
+       | None -> failf "big_three entry missing"
+       | Some e ->
+           check profile_opt "empty string -> None" None
+             e.required_capability_profile)
+
+let test_unknown_profile_fails_closed () =
+  let json =
+    {|{"big_three_models": ["claude_code:auto"],
+        "big_three_required_capability_profile": "no_such_profile"}|}
+  in
+  with_temp_json json @@ fun path ->
+  match Loader.load_catalog ~config_path:path with
+  | Ok _ ->
+      fail "load should have failed for unknown profile"
+  | Error msg ->
+      check bool "error message names the bad profile" true
+        (Astring.String.is_infix ~affix:"no_such_profile" msg);
+      check bool "error message lists known profiles" true
+        (Astring.String.is_infix ~affix:"tool_strict" msg)
+
+let test_each_known_profile_parses () =
+  List.iter
+    (fun p ->
+      let s = CP.profile_to_string p in
+      let json =
+        Printf.sprintf
+          {|{"sample_models": ["claude_code:auto"],
+            "sample_required_capability_profile": "%s"}|}
+          s
+      in
+      with_temp_json json @@ fun path ->
+      match Loader.load_catalog ~config_path:path with
+      | Error msg -> failf "load failed for profile %s: %s" s msg
+      | Ok entries ->
+          (match entry_named entries "sample" with
+           | None -> failf "sample entry missing for profile %s" s
+           | Some e ->
+               check profile_opt
+                 (Printf.sprintf "%s parsed" s)
+                 (Some p) e.required_capability_profile))
+    CP.all_profiles
+
+let () =
+  run "Cascade_required_capability_profile_parser"
+    [
+      ( "field parsing",
+        [
+          test_case "known value -> Some profile" `Quick
+            test_profile_set_to_known_value;
+          test_case "field omitted -> None" `Quick
+            test_profile_field_omitted_defaults_to_none;
+          test_case "empty string -> None" `Quick
+            test_profile_empty_string_treated_as_unset;
+          test_case "unknown value -> Error (fail-closed)" `Quick
+            test_unknown_profile_fails_closed;
+          test_case "every Cascade_capability_profile.profile round-trips"
+            `Quick test_each_known_profile_parses;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
RFC-0027 PR-2 of 5+. Stack PR on top of #13003 (PR-1).

Adds optional `[profile].required_capability_profile = "<name>"` field to cascade.toml. Parsed by Cascade_config_loader into `catalog_entry.required_capability_profile : Cascade_capability_profile.profile option`.

## Behavior
- Field omitted -> `None` (legacy)
- Set to known profile name -> `Some profile`
- Set to unknown -> `load_catalog` returns `Error` (fail-closed)
- Empty string -> `None`

## Files
- `lib/cascade/cascade_config_loader.{ml,mli}` — catalog_entry extension + parse_error path
- `lib/cascade/cascade_toml_materializer.ml` — TOML field allowed_fields + JSON emit
- `test/test_cascade_required_capability_profile.ml` — 5 unit tests

## Test
```
$ dune test --root . test/test_cascade_required_capability_profile.ml
5 tests run. All passed.
```

## Stack
- Base: #13003 (PR-1) — depends on Cascade_capability_profile module
- Next: PR-3 (validator capability lint, gates the new field)

## Plan
`~/me/planning/claude-plans/inherited-toasting-moon.md` (Phase 1 PR-2)