### PR TITLE
refactor(keeper_turn_slot): bounded yield fallback when Eio clock absent (D-10)

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -398,7 +398,15 @@ let maybe_yield_for_fairness ~(keeper_name : string) : unit =
       keeper_name remaining;
     match Eio_context.get_clock_opt () with
     | Some clock -> Eio.Time.sleep clock remaining
-    | None -> Eio.Fiber.yield ()
+    | None ->
+        (* No Eio clock available: bound the wait with [Unix.sleepf] so the
+           fairness loop does not spin under contention. [Eio.Fiber.yield]
+           imposes no minimum delay — under heavy keeper churn it returns
+           immediately and the caller re-enters the queue with the same
+           [last_autonomous_completion] timestamp, defeating the cooldown.
+           5ms is a fairness hint (not a tunable); production paths always
+           have a clock and take the [Some clock] branch above. *)
+        Unix.sleepf 0.005
   end
 
 let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)


### PR DESCRIPTION
## Summary

Tier D cleanup audit items D-9 + D-10 in `lib/keeper/keeper_turn_slot.ml`. Both touch the same file; this PR ships **D-10 only** and explicitly defers D-9.

### D-10 (applied)

Replaced the `Eio.Fiber.yield ()` fallback in `maybe_yield_for_fairness` (the `else` branch where `Eio_context.get_clock_opt () = None`) with `Unix.sleepf 0.005`.

- `Eio.Fiber.yield` imposes no minimum wait. Under contention it returns immediately, and the caller re-enters the FIFO with the same `last_autonomous_completion` timestamp — defeating the very cooldown it is supposed to enforce.
- `Unix.sleepf 0.005` bounds the wait at 5ms even without an Eio clock. 5ms is a fairness hint, not a tunable.
- The `Some clock` production branch (`Eio.Time.sleep clock remaining`) is unchanged.

### D-9 (deferred)

The `acquired_autonomous` / `acquired_reactive` / `acquired_turn` `bool ref` pattern in `keeper_turn_slot_state`, combined with `Fun.protect ~finally:(fun () -> release_keeper_turn_slot ...)` at L537-538, is the right thing to replace with `Eio.Switch.on_release sw release_X` registered at acquire time. The replacement would eliminate two issues:

1. `Fun.protect` finally exceptions can mask the original (`Fun.Finally_raised`).
2. The bool ref is per-fiber mutable state that exists only to coordinate cleanup.

**However:** the `with_keeper_turn_slot` signature does not take a `~sw:Eio.Switch.t`:

```
val with_keeper_turn_slot :
  keeper_name:string ->
  channel:Keeper_world_observation.keeper_cycle_channel ->
  (semaphore_wait_ms:int -> 'a) ->
  ('a, [> `Semaphore_wait_timeout of float ]) result
```

Threading a switch through every caller (heartbeat loop, supervisor, tests) is out of scope per the audit plan, which explicitly accepts split-phase migration. D-9 belongs in a follow-up PR that adds the switch to the public API.

## Risk

| Concern | Note |
|---|---|
| Production path | Unchanged — `Some clock` branch always taken when `Eio_main.run` is active. |
| Test path | `None` branch now sleeps 5ms instead of yielding. Both `test_keeper_semaphore_fairness` and `test_keeper_semaphore_wait_queue_head_clock` pass with no observable timing impact. |
| Exception masking (D-9) | Still present until D-9 follow-up. No regression introduced here. |
| Unbounded spin (D-10) | Fixed. |

## RFC

`RFC-WAIVED: lib/keeper/keeper_turn_slot.ml is concurrency surface — not credential / identity / repo_manager / operator / sandbox / hooks / workflow*.`

## Test plan

- [x] `dune build --root . @lib/check` — clean.
- [x] `dune exec --root . -- test/test_keeper_semaphore_fairness.exe` — 11/11 pass.
- [x] `dune exec --root . -- test/test_keeper_semaphore_wait_queue_head_clock.exe` — 2/2 pass.
- [ ] CI: full test suite on main runner.

## Follow-up

- Open D-9 PR once we agree on the API shape for threading `Eio.Switch.t` into `with_keeper_turn_slot` (likely making the function take `~sw` and registering each acquired-slot release via `Eio.Switch.on_release`).

Note: Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.
