### PR TITLE
fix(dashboard): collapse fleet polling artifacts into one heartbeat group

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -384,7 +384,7 @@ describe('TelemetryUnified', () => {
     expect(displayItems[0]).toMatchObject({
       kind: 'group',
       category: 'heartbeat',
-      label: 'keeper-heart heartbeat',
+      label: 'fleet heartbeat',
       count: 2,
     })
     expect(displayItems[1]).toMatchObject({
@@ -397,7 +397,69 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('하트비트 · keeper-heart heartbeat · 2 events')
+    expect(container.textContent).toContain('하트비트 · fleet heartbeat · 2 events')
+  })
+
+  it('collapses interleaved heartbeat + oas snapshot polling across multiple keepers into one group (#13002)', async () => {
+    const { buildTelemetryDisplayItems } = await loadPanel(
+      vi.fn().mockResolvedValue(baseTelemetry),
+      vi.fn().mockResolvedValue(baseSummary),
+    )
+    // Reproduces the screenshot: 14 keepers each emit alternating
+    // [oas_event masc:keeper:snapshot] + [keeper_metric heartbeat] within
+    // the same 60s window, so the 100-entry stream is 100% polling and
+    // real activity is invisible.  Expectation: one collapsed
+    // 'fleet heartbeat' group plus the real entry.
+    type Entry = Parameters<typeof buildTelemetryDisplayItems>[0][number]
+    const keepers = Array.from({ length: 14 }, (_, i) => `keeper-${i}`)
+    const polling: Entry[] = keepers.flatMap((name, i) => {
+      const ts = 1_775_709_400 - i
+      return [
+        {
+          source: 'oas_event' as const,
+          ts,
+          event_type: 'masc:keeper:snapshot',
+          agent_name: name,
+        },
+        {
+          source: 'keeper_metric' as const,
+          ts,
+          name,
+          channel: 'heartbeat',
+          model_used: '',
+          tool_call_count: 0,
+        },
+      ]
+    })
+    const realActivity: Entry = {
+      source: 'tool_call_io',
+      ts: 1_775_709_500,
+      keeper: 'keeper-3',
+      tool: 'board_post',
+    }
+
+    const items = buildTelemetryDisplayItems([realActivity, ...polling])
+
+    // The 28 polling rows must collapse to a single fleet-heartbeat group.
+    const heartbeatGroups = items.filter(
+      i => i.kind === 'group' && i.category === 'heartbeat',
+    )
+    expect(heartbeatGroups).toHaveLength(1)
+    expect(heartbeatGroups[0]).toMatchObject({
+      kind: 'group',
+      category: 'heartbeat',
+      label: 'fleet heartbeat',
+      count: 28,
+    })
+
+    // Real activity entry must still surface.
+    const realRow = items.find(
+      i => i.kind === 'entry' && i.entry.source === 'tool_call_io',
+    )
+    expect(realRow).toBeTruthy()
+
+    // Total visible rows = 1 fleet-heartbeat group + 1 real entry.
+    expect(items).toHaveLength(2)
   })
 
   it('uses trajectory and execution receipt fields for telemetry previews', async () => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -196,18 +196,44 @@ function canonicalToolName(value: string | null): string | null {
   return normalizeText(value)
 }
 
+/** Per-keeper polling artifacts that fill the 100-entry window with no
+ *  per-event signal: keeper_metric/heartbeat snapshots and the matching
+ *  oas_event/masc:keeper:{snapshot,lifecycle} relays. We classify them as
+ *  one fleet-wide "heartbeat" category so all instances collapse into a
+ *  single group regardless of (a) which keeper emitted it or
+ *  (b) whether they are consecutive in the stream — see #13002 for the
+ *  before/after screenshot. */
+const FLEET_POLLING_OAS_EVENT_TYPES = new Set([
+  'masc:keeper:snapshot',
+  'masc:keeper:lifecycle',
+  'oas:masc:keeper:snapshot',
+  'oas:masc:keeper:lifecycle',
+])
+
+function isFleetPollingEntry(entry: TelemetryEntry): boolean {
+  if (entry.source === 'keeper_metric' && normalizeText(entry.channel) === 'heartbeat') {
+    return true
+  }
+  if (entry.source === 'oas_event') {
+    const eventType = normalizeText(entry.event_type) ?? normalizeText(entry.type)
+    if (eventType != null && FLEET_POLLING_OAS_EVENT_TYPES.has(eventType)) return true
+  }
+  return false
+}
+
 function entryGroupingDescriptor(entry: TelemetryEntry): {
   key: string
   category: TelemetryCondensedCategory
   label: string
 } | null {
-  if (entry.source === 'keeper_metric' && normalizeText(entry.channel) === 'heartbeat') {
-    const keeper = normalizeText(entry.name) ?? 'unknown'
-    const scope = normalizeText(entry.session_id) ?? normalizeText(entry.operation_id) ?? keeper
+  if (isFleetPollingEntry(entry)) {
     return {
-      key: `heartbeat:${scope}:${keeper}`,
+      // Fleet-wide single key so ALL polling artifacts (heartbeat + snapshot
+      // + lifecycle, across every keeper) merge into one group regardless of
+      // arrival order.
+      key: 'heartbeat:fleet',
       category: 'heartbeat',
-      label: `${keeper} heartbeat`,
+      label: 'fleet heartbeat',
     }
   }
 
@@ -353,7 +379,8 @@ export function filterTelemetryDisplayItems(
 export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): TelemetryDisplayItem[] {
   const items: TelemetryDisplayItem[] = []
   let nextItemId = 0
-  let activeGroup: {
+
+  type ActiveGroup = {
     key: string
     category: TelemetryCondensedCategory
     label: string
@@ -362,60 +389,109 @@ export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): Telemetry
     oldestTs: number
     sourceKeys: Set<TelemetrySource>
     scopeBadges: string[]
-  } | null = null
+    /** Position in [items] where this group's row will eventually be
+     *  inserted via [flushGroup]. Used by the fleet-heartbeat group so it
+     *  stays at the position of its first entry even when intervening
+     *  rows of other categories have already been pushed past it. */
+    insertIndex: number
+  }
+
+  let activeGroup: ActiveGroup | null = null
+
+  /** A persistent group for the fleet polling/heartbeat category. Heartbeat
+   *  entries arrive interleaved with real activity, so we accumulate ALL
+   *  of them here regardless of position and only emit the merged row at
+   *  the end. The row is then spliced into [items] at the position of the
+   *  first heartbeat we saw — preserving rough chronology while collapsing
+   *  the noise. */
+  let fleetHeartbeat: ActiveGroup | null = null
+
+  const renderGroup = (g: ActiveGroup): TelemetryDisplayItem => {
+    if (g.entries.length === 1) {
+      const entry = g.entries[0] as TelemetryEntry
+      const item: TelemetryDisplayItem = {
+        kind: 'entry',
+        key: `${g.key}:${g.latestTs}:${nextItemId}`,
+        entry,
+      }
+      nextItemId += 1
+      return item
+    }
+    const item: TelemetryDisplayItem = {
+      kind: 'group',
+      key: `${g.key}:${g.latestTs}:${g.entries.length}:${nextItemId}`,
+      category: g.category,
+      label: g.label,
+      count: g.entries.length,
+      latestTs: g.latestTs,
+      oldestTs: g.oldestTs,
+      entries: g.entries,
+      sourceKeys: Array.from(g.sourceKeys),
+      scopeBadges: g.scopeBadges,
+    }
+    nextItemId += 1
+    return item
+  }
 
   const flushGroup = () => {
     if (!activeGroup) return
-    if (activeGroup.entries.length === 1) {
-      const entry = activeGroup.entries[0] as TelemetryEntry
-      items.push({
-        kind: 'entry',
-        key: `${activeGroup.key}:${activeGroup.latestTs}:${nextItemId}`,
-        entry,
-      })
-      nextItemId += 1
-    } else {
-      items.push({
-        kind: 'group',
-        key: `${activeGroup.key}:${activeGroup.latestTs}:${activeGroup.entries.length}:${nextItemId}`,
-        category: activeGroup.category,
-        label: activeGroup.label,
-        count: activeGroup.entries.length,
-        latestTs: activeGroup.latestTs,
-        oldestTs: activeGroup.oldestTs,
-        entries: activeGroup.entries,
-        sourceKeys: Array.from(activeGroup.sourceKeys),
-        scopeBadges: activeGroup.scopeBadges,
-      })
-      nextItemId += 1
-    }
+    items.push(renderGroup(activeGroup))
     activeGroup = null
+  }
+
+  const accumulate = (target: ActiveGroup, entry: TelemetryEntry, ts: number) => {
+    target.entries.push(entry)
+    if (target.latestTs === 0 && ts !== 0) target.latestTs = ts
+    else if (ts !== 0) target.latestTs = Math.max(target.latestTs, ts)
+    if (target.oldestTs === 0) target.oldestTs = ts
+    else if (ts !== 0) target.oldestTs = Math.min(target.oldestTs, ts)
+    target.sourceKeys.add(entry.source)
+    target.scopeBadges = uniqueStrings([
+      ...target.scopeBadges,
+      ...telemetryScopeBadges(entry),
+    ])
   }
 
   for (const entry of entries) {
     const descriptor = entryGroupingDescriptor(entry)
+    const ts = entryTimestamp(entry)
+
+    // Special path: fleet-wide polling/heartbeat artifacts always merge
+    // into a single group regardless of position. Without this, 14
+    // keepers heartbeating every 60s produce 14 separate single-entry
+    // rows that drown out real activity (#13002).
+    if (descriptor && descriptor.key === 'heartbeat:fleet') {
+      if (!fleetHeartbeat) {
+        fleetHeartbeat = {
+          key: descriptor.key,
+          category: descriptor.category,
+          label: descriptor.label,
+          entries: [entry],
+          latestTs: ts,
+          oldestTs: ts,
+          sourceKeys: new Set([entry.source]),
+          scopeBadges: telemetryScopeBadges(entry),
+          insertIndex: items.length + (activeGroup ? 1 : 0),
+        }
+      } else {
+        accumulate(fleetHeartbeat, entry, ts)
+      }
+      continue
+    }
+
     if (!descriptor) {
       flushGroup()
       items.push({
         kind: 'entry',
-        key: `${entry.source}:${entryTimestamp(entry)}:${nextItemId}`,
+        key: `${entry.source}:${ts}:${nextItemId}`,
         entry,
       })
       nextItemId += 1
       continue
     }
 
-    const ts = entryTimestamp(entry)
     if (activeGroup && activeGroup.key === descriptor.key) {
-      activeGroup.entries.push(entry)
-      if (activeGroup.latestTs === 0 && ts !== 0) activeGroup.latestTs = ts
-      if (activeGroup.oldestTs === 0) activeGroup.oldestTs = ts
-      else if (ts !== 0) activeGroup.oldestTs = Math.min(activeGroup.oldestTs, ts)
-      activeGroup.sourceKeys.add(entry.source)
-      activeGroup.scopeBadges = uniqueStrings([
-        ...activeGroup.scopeBadges,
-        ...telemetryScopeBadges(entry),
-      ])
+      accumulate(activeGroup, entry, ts)
       continue
     }
 
@@ -429,10 +505,17 @@ export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): Telemetry
       oldestTs: ts,
       sourceKeys: new Set([entry.source]),
       scopeBadges: telemetryScopeBadges(entry),
+      insertIndex: items.length,
     }
   }
 
   flushGroup()
+
+  if (fleetHeartbeat) {
+    const idx = Math.max(0, Math.min(fleetHeartbeat.insertIndex, items.length))
+    items.splice(idx, 0, renderGroup(fleetHeartbeat))
+  }
+
   return items
 }
 


### PR DESCRIPTION
## 문제

Fleet Telemetry 모니터 스트림이 polling 아티팩트로 100% 차고, 실제 활동이 안 보임.

근거 — 사용자 스크린샷: 14 keeper × 60s polling = `O 2분 전 masc:keeper:snapshot: <name>` + `K 2분 전 <name> [heartbeat] model=- tools=0` 28 row/min로 100-entry 윈도우(대략 마지막 3-4분 분량)를 가득 채움. 우측 tool counter(`board_get 60`, `task_claim 41`, `bash 29` 등)는 도구가 활발히 호출됨을 보여주지만, 좌측 stream에서는 그 어떤 `tool_call_io` / `agent_event task_completed` / `execution_receipt`도 보이지 않음.

## 원인

| 위치 | 동작 | 문제 |
|------|------|------|
| `entryGroupingDescriptor` (`telemetry-unified.ts`) | heartbeat descriptor 키가 `heartbeat:${scope}:${keeper}` | 키퍼별 별도 키 → 14개 단일-entry 그룹 |
| `buildTelemetryDisplayItems` | 동일 키 **연속** entry만 그루핑 | `O/K/O/K/…` 인터리브에서 같은 키퍼 entry 사이에 다른 키퍼 entry가 끼어 그루핑 단절 |
| `oas_event masc:keeper:{snapshot,lifecycle}` | descriptor 분류 없음 | polling 아티팩트인데 일반 entry로 별도 라인 차지 |

## 수정

| 변경 | 의미 |
|------|------|
| `isFleetPollingEntry` 헬퍼 신설 | `keeper_metric/heartbeat` + `oas_event/masc:keeper:{snapshot,lifecycle}`을 하나의 polling 카테고리로 통합 |
| descriptor 키를 `heartbeat:fleet` 단일값으로 통일 | 키퍼/세션 무관 하나로 합쳐짐 |
| `buildTelemetryDisplayItems`에 persistent `fleetHeartbeat` 누산기 추가 | 위치 무관 모든 polling row를 하나로 누적, 마지막에 첫 heartbeat 위치에 splice. 다른 카테고리는 기존 consecutive 그루핑 유지 |

## 테스트

26/26 PASS (vitest):
- 기존 "groups heartbeat keeper metrics" 테스트 라벨만 `fleet heartbeat`로 업데이트.
- **신규 회귀 테스트** `collapses interleaved heartbeat + oas snapshot polling across multiple keepers into one group (#13002)`: 14 키퍼 × [snapshot, heartbeat] 인터리브 + 실제 `tool_call_io` 1건 시나리오. 단일 `fleet heartbeat` 그룹 (count=28) + 실제 entry 1개 = 정확히 2 row만 노출.

## 검증

```
pnpm install --frozen-lockfile
npx vitest run src/components/telemetry-unified.test.ts   # 26/26 PASS
npx tsc --noEmit                                          # no new errors
```

## Production effect

Dashboard 표시 전용. 백엔드 스키마/SSE/metric 수집 일체 변경 없음. polling 아티팩트는 여전히 적재되고 per-source summary에도 카운트됨; 리스트 렌더링만 condense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
