### PR TITLE
feat(keeper_prompt): externalize behavior prompt loader (infra)

### DIFF
--- a/config/prompts/behavior/profile_policy.md
+++ b/config/prompts/behavior/profile_policy.md
@@ -1,0 +1,6 @@
+---
+description: baseline reasoning/grounding/communication standard injected into every keeper system prompt
+category: keeper.behavior
+loader: Keeper_prompt_external
+---
+Maintain high standard of reasoning, factual grounding, and clear communication.

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -80,7 +80,21 @@ let build_keeper_system_prompt
     resolve_goal_horizons ~goal ~short_goal_opt:(Some short_goal)
       ~mid_goal_opt:(Some mid_goal) ~long_goal_opt:(Some long_goal)
   in
-  let profile_policy = "Maintain high standard of reasoning, factual grounding, and clear communication." in
+  (* Tier C C-5a: profile_policy is the first behavior block migrated
+     out of OCaml source.  The .md file lives at
+     [<prompts_dir>/behavior/profile_policy.md] and is read once per
+     process via [Keeper_prompt_external.get].  The original literal
+     is kept as a fallback so a missing/unreadable file does not
+     brick keepers — instead the loader emits a WARN and we use the
+     in-source string.  Subsequent C-5b PRs migrate the remaining
+     blocks in this function. *)
+  let profile_policy =
+    Option.value
+      (Keeper_prompt_external.get "profile_policy")
+      ~default:
+        "Maintain high standard of reasoning, factual grounding, and clear communication."
+  in
+  let profile_policy = String.trim profile_policy in
   (* Layer 2 PR-B (commit 7): three normalize_self_model_text calls
      consolidated through [Keeper_personality_io.to_prompt_form]. The
      fallback strings below are the same; only the trim+truncate path

--- a/lib/keeper/keeper_prompt_external.ml
+++ b/lib/keeper/keeper_prompt_external.ml
@@ -1,0 +1,88 @@
+(** Keeper_prompt_external — loader for behavior prompt blocks living
+    in [<prompts_dir>/behavior/<name>.md].  See [.mli] for the
+    contract. *)
+
+module Mutex = Stdlib.Mutex
+
+(* Cache stores the *result* of the lookup (Some content or None) so
+   missing-file lookups are not retried on every keeper turn — the
+   warn fires once and subsequent calls return the same [None]. *)
+let cache : (string, string option) Hashtbl.t = Hashtbl.create 16
+let cache_mutex = Mutex.create ()
+
+let behavior_path name =
+  let prompts_dir = Config_dir_resolver.prompts_dir () in
+  Filename.concat (Filename.concat prompts_dir "behavior") (name ^ ".md")
+
+(* Strip a leading YAML frontmatter block ("---\n...\n---\n") if
+   present so callers receive only the prompt body.  Keeps the loader
+   independent of [Prompt_registry]'s internal frontmatter parser. *)
+let strip_frontmatter (content : string) : string =
+  let lines = String.split_on_char '\n' content in
+  match lines with
+  | first :: rest when String.trim first = "---" ->
+      let rec drop_until_close = function
+        | [] -> None
+        | line :: remaining when String.trim line = "---" -> Some remaining
+        | _ :: remaining -> drop_until_close remaining
+      in
+      (match drop_until_close rest with
+       | Some body_lines ->
+           (* Drop one leading blank line if the file uses "---\n\nbody" style. *)
+           let body_lines =
+             match body_lines with
+             | "" :: tl -> tl
+             | _ -> body_lines
+           in
+           String.concat "\n" body_lines
+       | None -> content)
+  | _ -> content
+
+let read_file path =
+  try
+    let raw = In_channel.with_open_text path In_channel.input_all in
+    Some (strip_frontmatter raw)
+  with
+  | Sys_error _ -> None
+  | End_of_file -> None
+
+let load_uncached name =
+  let path = behavior_path name in
+  if Sys.file_exists path && not (Sys.is_directory path) then (
+    match read_file path with
+    | Some content -> Some content
+    | None ->
+        Log.Keeper.warn
+          "keeper_prompt_external: failed to read %s (returning None; \
+           caller will use fallback)"
+          path;
+        None)
+  else (
+    Log.Keeper.warn
+      "keeper_prompt_external: missing %s (returning None; caller will \
+       use fallback)"
+      path;
+    None)
+
+let get name =
+  Mutex.lock cache_mutex;
+  match Hashtbl.find_opt cache name with
+  | Some cached ->
+      Mutex.unlock cache_mutex;
+      cached
+  | None ->
+      Mutex.unlock cache_mutex;
+      (* Read outside the lock so concurrent first-time lookups for
+         different names do not serialize on disk I/O.  Worst case:
+         two domains read the same file once each before either
+         caches; the resulting [Hashtbl.replace] is idempotent. *)
+      let result = load_uncached name in
+      Mutex.lock cache_mutex;
+      Hashtbl.replace cache name result;
+      Mutex.unlock cache_mutex;
+      result
+
+let reset_cache () =
+  Mutex.lock cache_mutex;
+  Hashtbl.clear cache;
+  Mutex.unlock cache_mutex

--- a/lib/keeper/keeper_prompt_external.mli
+++ b/lib/keeper/keeper_prompt_external.mli
@@ -1,0 +1,30 @@
+(** Keeper_prompt_external — loader for behavior prompt blocks living
+    outside the OCaml source.
+
+    Each named block is read from
+    [<Config_dir_resolver.prompts_dir ()>/behavior/<name>.md] on first
+    access and cached for the remainder of the process lifetime.  The
+    cache key is the block name; file content (frontmatter and all) is
+    returned verbatim to keep the loader free of markdown semantics.
+
+    Missing files do not crash.  [get name] returns [None] and emits a
+    [WARN] (once per name) so callers can fall back to an in-source
+    string while operators iterate on the external file.
+
+    This module is a thin sibling of [Prompt_registry]: that registry
+    handles versioned, override-able, frontmatter-aware system prompts.
+    [Keeper_prompt_external] is for the long tail of operator-facing
+    *behavior* blocks that today live as OCaml string literals in
+    [keeper_prompt.ml] — content that operators want to tune without
+    rebuilding the binary, but that does not need version management
+    or runtime overrides. *)
+
+val get : string -> string option
+(** [get name] returns the contents of
+    [<prompts_dir>/behavior/<name>.md] on success, or [None] if the
+    file is missing/unreadable.  Cached after the first call so the
+    file is read at most once per process per [name]. *)
+
+val reset_cache : unit -> unit
+(** Drop the cache so the next [get] re-reads from disk.  Intended for
+    tests; no callers in production code. *)

--- a/test/dune
+++ b/test/dune
@@ -628,6 +628,7 @@
         test_keeper_guards
         test_eval_gate_evasion
         test_prompt_registry_defaults
+        test_keeper_prompt_external
         test_keeper_recurring
         test_cdal_types
         test_cdal_loader
@@ -822,6 +823,7 @@
         test_keeper_guards
         test_eval_gate_evasion
         test_prompt_registry_defaults
+        test_keeper_prompt_external
         test_keeper_recurring
         test_cdal_types
         test_cdal_loader

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -1,0 +1,95 @@
+(** Tier C C-5a: smoke test for the externalized behavior prompt
+    loader.  Verifies that the demonstration migration
+    ([profile_policy]) loads from
+    [config/prompts/behavior/profile_policy.md] (relative to the
+    repo root, which Config_dir_resolver locates via [_build/]
+    proximity) and yields a non-empty body. *)
+
+module Lib = Masc_mcp
+
+let with_repo_root_cwd f =
+  let original_cwd = Sys.getcwd () in
+  (* Test runs out of [_build/default/test]; walk up until we find the
+     [config/prompts/behavior] anchor that this PR introduces. *)
+  let rec find_root dir hops =
+    if hops > 8 then None
+    else if Sys.file_exists (Filename.concat dir "config/prompts/behavior") then
+      Some dir
+    else
+      let parent = Filename.dirname dir in
+      if parent = dir then None else find_root parent (hops + 1)
+  in
+  match find_root original_cwd 0 with
+  | None ->
+      Alcotest.fail
+        "could not locate repo root (config/prompts/behavior) from test cwd"
+  | Some root ->
+      (* Pin [Config_dir_resolver] to this worktree's [config/]
+         directory via [MASC_CONFIG_DIR] (highest-priority resolution
+         source) so the test does not depend on the test runner's
+         HOME / MASC_BASE_PATH inheritance.  Reset the cached
+         resolution so the new env var takes effect. *)
+      let prev_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+      let config_dir = Filename.concat root "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Sys.chdir root;
+      Lib.Config_dir_resolver.reset ();
+      Fun.protect
+        ~finally:(fun () ->
+          Sys.chdir original_cwd;
+          (match prev_config_dir with
+           | Some v -> Unix.putenv "MASC_CONFIG_DIR" v
+           | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+          Lib.Config_dir_resolver.reset ())
+        f
+
+let test_loads_profile_policy () =
+  with_repo_root_cwd (fun () ->
+      Lib.Keeper_prompt_external.reset_cache ();
+      match Lib.Keeper_prompt_external.get "profile_policy" with
+      | Some content ->
+          Alcotest.(check bool)
+            "non-empty body" true
+            (String.length (String.trim content) > 0);
+          Alcotest.(check bool)
+            "frontmatter stripped" false
+            (String.length content >= 3
+             && String.sub content 0 3 = "---")
+      | None ->
+          Alcotest.fail
+            "expected profile_policy.md to load from \
+             config/prompts/behavior/")
+
+let test_missing_returns_none () =
+  with_repo_root_cwd (fun () ->
+      Lib.Keeper_prompt_external.reset_cache ();
+      match
+        Lib.Keeper_prompt_external.get
+          "definitely_not_a_real_block_name_xyz_c5a"
+      with
+      | None -> ()
+      | Some _ ->
+          Alcotest.fail
+            "missing file should return None (caller handles fallback)")
+
+let test_cache_is_used () =
+  with_repo_root_cwd (fun () ->
+      Lib.Keeper_prompt_external.reset_cache ();
+      let first = Lib.Keeper_prompt_external.get "profile_policy" in
+      let second = Lib.Keeper_prompt_external.get "profile_policy" in
+      Alcotest.(check (option string))
+        "cache returns identical content" first second)
+
+let () =
+  Alcotest.run "Keeper_prompt_external"
+    [
+      ( "load",
+        [
+          Alcotest.test_case "loads profile_policy" `Quick
+            test_loads_profile_policy;
+          Alcotest.test_case "missing returns None" `Quick
+            test_missing_returns_none;
+          Alcotest.test_case "second lookup uses cache" `Quick
+            test_cache_is_used;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Tier C C-5a infrastructure PR: introduces an external loader for keeper behavior prompt blocks. Today `lib/keeper/keeper_prompt.ml` embeds ~150 lines of operator-facing prompt content as OCaml string literals — every wording change requires a rebuild and pollutes diffs with text unrelated to logic.

- New module `Keeper_prompt_external.get : string -> string option` reads `<prompts_dir>/behavior/<name>.md`, strips YAML frontmatter, caches the result, and returns `None` with a WARN on missing files.
- Base path comes from the existing `Config_dir_resolver.prompts_dir ()` SSOT — no new path scheme.
- Cache is a `Hashtbl` guarded by `Stdlib.Mutex`; each `(name)` is read from disk at most once per process (success or miss).
- One prompt block (`profile_policy`) is migrated as a demonstration; the remaining blocks in `build_keeper_system_prompt` will move in a follow-up PR (C-5b).

## Why fallback matters

Callers wrap the loader with `Option.value ... ~default:original_string`. The original in-source literal is retained verbatim. Missing or unreadable `.md` files do not brick keepers — the loader logs a WARN once per name and the keeper continues with the previous in-source text. Behaviour is byte-identical to before when the `.md` file is present (post `String.trim`).

## Migrated block

`profile_policy` — a single sentence (`"Maintain high standard of reasoning, factual grounding, and clear communication."`) injected into every keeper system prompt. Small but exemplary: it exercises both the success path (file loads, frontmatter stripped) and the fallback path (file deleted → WARN + original literal).

## C-5b follow-up scope

The remaining content in lines 148–172 (autonomous-behavior bullets, GH CLI syntax block, task-lifecycle rules) will batch-migrate in a separate PR using the same loader. Splitting keeps this PR reviewable for the loader's correctness and concurrency model independently from prompt-content review.

RFC-WAIVED: `lib/keeper/keeper_prompt` is content surface, not credential / identity / repo_manager / operator / sandbox / hooks / workflow*.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `dune build --root . test/test_keeper_prompt_external.exe` clean
- [x] `dune exec --root . -- test/test_keeper_prompt_external.exe` — 3/3 passing (loads + frontmatter stripped, missing → None, cache returns identical content)
- [x] `dune exec --root . -- test/test_keeper_prompt_metrics.exe` — 9/9 passing (existing keeper_prompt coverage)
- [ ] Manual smoke: rename `config/prompts/behavior/profile_policy.md` → confirm WARN logged once and keeper system prompt still contains the policy line via the OCaml fallback (out of scope for CI; documented for reviewer)

Note: the test pre-existing failure in `test_cascade_strategy.ml` (PR #12990 added a `scoring` field without updating this test) is on `origin/main` and not introduced here.

## Note

Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
