### PR TITLE
refactor(board_dispatch): fold flusher_started into Active variant

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -59,9 +59,21 @@ let sort_order_of_string_opt s =
 type board_backend =
   | Jsonl of Board.store
 
+(** Marker carried inside [Active] tracking whether the flusher fiber has
+    been spawned for the current backend.  [Eio.Fiber.fork_daemon] returns
+    [unit], so there's no cancel handle to thread through; the [bool]
+    placeholder keeps the structural fact - "we are active and the flusher
+    is (or is not) running" - inseparable from the backend itself.
+
+    Tier D D-7: this used to live in a sibling [flusher_started : bool
+    Atomic.t], which allowed [Active && not flusher_started] /
+    [not Active && flusher_started] to be representable across two
+    independent CAS sites.  Folding the flag in collapses that surface. *)
+type flusher_handle = bool
+
 type backend_state =
   | Uninitialized
-  | Active of board_backend
+  | Active of board_backend * flusher_handle
 
 type keeper_board_signal_kind =
   | Board_post_created
@@ -83,7 +95,6 @@ type board_sse_event =
   | Comment_voted of { comment_id : string; voter : string; direction : Board.vote_direction }
 
 let backend_state : backend_state Atomic.t = Atomic.make Uninitialized
-let flusher_started : bool Atomic.t = Atomic.make false
 
 let start_flusher_actor ~sw store =
   Eio.Fiber.fork_daemon ~sw (fun () ->
@@ -105,19 +116,39 @@ let start_flusher_actor ~sw store =
     done
   )
 
+(** CAS [Active (b, false) -> Active (b, true)] for the current [b], then
+    spawn the flusher daemon.  If the CAS loses (someone else flipped the
+    flag concurrently, or the state went back to [Uninitialized]), bail
+    out without spawning.  On daemon-spawn failure, roll the flag back so
+    a later caller can retry.
+
+    Pre-D-7 this was a sibling [Atomic.compare_and_set flusher_started
+    false true]; the flag now lives in the variant so it cannot drift
+    away from the [Active] state. *)
 let ensure_flusher_actor store =
   match Eio_context.get_switch_opt () with
   | None -> ()
   | Some sw ->
-      if Atomic.compare_and_set flusher_started false true then
-        try start_flusher_actor ~sw store
-        with exn ->
-          Atomic.set flusher_started false;
-          match exn with
-          | Invalid_argument msg when String.equal msg "Switch finished!" ->
-              Log.BoardLog.warn
-                "Skipping board flusher actor startup on finished switch"
-          | _ -> raise exn
+      let current = Atomic.get backend_state in
+      (match current with
+       | Uninitialized -> ()
+       | Active (_, true) -> ()
+       | Active (b, false) ->
+           if Atomic.compare_and_set backend_state current (Active (b, true)) then
+             try start_flusher_actor ~sw store
+             with exn ->
+               (* Roll the flag back so a future caller can retry.  Only
+                  roll back if the state hasn't been swapped out from
+                  under us. *)
+               let _ : bool =
+                 Atomic.compare_and_set backend_state
+                   (Active (b, true)) (Active (b, false))
+               in
+               match exn with
+               | Invalid_argument msg when String.equal msg "Switch finished!" ->
+                   Log.BoardLog.warn
+                     "Skipping board flusher actor startup on finished switch"
+               | _ -> raise exn)
 
 
 let keeper_board_signal_hook : (keeper_board_signal -> unit) option Atomic.t = Atomic.make None
@@ -156,7 +187,7 @@ let init_jsonl () =
     Log.BoardLog.warn "already initialized, ignoring init_jsonl"
   else begin
     let store = Board.global () in
-    let backend = Active (Jsonl store) in
+    let backend = Active (Jsonl store, false) in
     if Atomic.compare_and_set backend_state Uninitialized backend then begin
       ensure_flusher_actor store;
       Log.BoardLog.info "JSONL backend initialized"
@@ -165,8 +196,9 @@ let init_jsonl () =
   end
 
 let reset_for_test () =
+  (* D-7: dropping [Active] also drops the flusher-started flag, since
+     it now lives inside the variant. *)
   Atomic.set backend_state Uninitialized;
-  Atomic.set flusher_started false;
   Atomic.set keeper_board_signal_hook None;
   Atomic.set board_sse_hook None
 
@@ -177,17 +209,17 @@ let jsonl_forced () =
 
 let backend () =
   match Atomic.get backend_state with
-  | Active (Jsonl store as backend) ->
+  | Active (Jsonl store as backend, _) ->
       ensure_flusher_actor store;
       backend
   | Uninitialized ->
       Log.BoardLog.warn "backend() called before server init, auto-initializing JSONL";
       let store = Board.global () in
       let b = Jsonl store in
-      let backend_val = Active b in
+      let backend_val = Active (b, false) in
       let _ = Atomic.compare_and_set backend_state Uninitialized backend_val in
       match Atomic.get backend_state with
-      | Active (Jsonl active_store as active_b) ->
+      | Active (Jsonl active_store as active_b, _) ->
           ensure_flusher_actor active_store;
           active_b
       | Uninitialized ->
@@ -449,7 +481,7 @@ let search ~query ~limit =
 
 let flush () =
   match Atomic.get backend_state with
-  | Active (Jsonl store) -> Board.flush_dirty store
+  | Active (Jsonl store, _) -> Board.flush_dirty store
   | Uninitialized -> ()
 
 let sweep () =
@@ -473,5 +505,5 @@ let reclassify_posts ?(limit = 5200) ?(dry_run = true) () =
 
 let backend_name () =
   match Atomic.get backend_state with
-  | Active (Jsonl _) -> "jsonl"
+  | Active (Jsonl _, _) -> "jsonl"
   | Uninitialized -> "uninitialized"

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -6,8 +6,9 @@
     out-bound hook channels (keeper board signals + board SSE
     events).
 
-    Internal state and helpers ([backend_state] / [flusher_started]
-    Atomics, [start_flusher_actor], [ensure_flusher_actor],
+    Internal state and helpers ([backend_state] Atomic carrying the
+    flusher-started flag inside the [Active] variant since Tier D D-7,
+    [start_flusher_actor], [ensure_flusher_actor],
     [keeper_board_signal_hook] / [board_sse_hook] Atomics,
     [emit_keeper_board_signal], [backend], [sort_posts_in_memory],
     [normalize_author_filter], [agent_matches_author_filter],


### PR DESCRIPTION
## Summary

Tier D D-7 — fold `flusher_started` into the `Active` variant of `backend_state`.

- `lib/board_dispatch.ml` previously held active-state across **two atomics**: `backend_state : Uninitialized | Active of board_backend` and a separate `flusher_started : bool Atomic.t`. The two can drift: `Active && not flusher_started` (active without a running flusher) or `not Active && flusher_started` (flusher flag stale across re-init) are both representable.
- Collapse the flag into the variant as `Active of board_backend * flusher_handle` (`flusher_handle = bool` placeholder, since `Eio.Fiber.fork_daemon` returns `unit` — no cancel surface to thread). Now "are we active and is the flusher running" is a single match on a single atomic.
- `ensure_flusher_actor` CAS now goes `Active (b, false) -> Active (b, true)` and rolls back on daemon-spawn failure, instead of CAS'ing a sibling bool.
- `init_jsonl`, `backend()` auto-init, `flush ()`, `backend_name ()`, `reset_for_test ()` updated for the new variant shape. `is_initialized ()` is unchanged (still pattern-matches on `Active _`).

## Out of scope

- The audit also recommended removing `backend_state` entirely in favour of `Board.is_initialized()` to eliminate the `Board.global` shadow. That requires adding `Board.is_initialized()` to the upstream `Board` module — kept for a separate PR to keep this one minimal.

## Test plan

- [x] `dune build lib/` — clean.
- [x] `dune build test/test_board_dispatch.exe test/test_board_ttl.exe test/test_types.exe test/test_tool_board_coverage.exe test/test_vote_ts_preservation_10086.exe` — clean.
- [x] `dune exec test/test_board_dispatch.exe` — 31/31 pass (including `misc/flush`).
- [x] `dune exec test/test_tool_board_coverage.exe` — 61/61 pass.
- [x] `dune exec test/test_types.exe` — 114/114 pass.
- [x] `dune exec test/test_vote_ts_preservation_10086.exe` — 2/2 pass.
- [x] `test_board_ttl.exe` shows 8 failures **on origin/main as well as on this branch** (pre-existing, unrelated to this change). Confirmed by `git stash` + rebuild + rerun on the same checkout.
- [x] `test/test_cascade_strategy.ml` build error on `scoring` field is also pre-existing on origin/main, unrelated to this change.

## RFC

`RFC-WAIVED: lib/board_dispatch.ml is concurrency surface, not credential / identity / repo_manager / operator / sandbox / hooks / workflow*.`

## Note

Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
