### PR TITLE
fix(test): add scoring field to test_cascade_strategy mk_t

### DIFF
--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -62,8 +62,9 @@ let mk_ctx ?(health = H.create ())
 let mk_t ?(cycle = S.default_cycle_policy)
          ?(tiers = [])
          ?(sticky_ttl_ms = 0)
+         ?(scoring = S.default_scoring_params)
          kind : S.t =
-  { kind; cycle; tiers; sticky_ttl_ms }
+  { kind; cycle; tiers; sticky_ttl_ms; scoring }
 
 (* ── S1 Failover ─────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## 문제

origin/main이 `dune build @check` 단계에서 깨짐:

```
File "test/test_cascade_strategy.ml", line 66, characters 2-39:
   { kind; cycle; tiers; sticky_ttl_ms }
Error: Some record fields are undefined: scoring
```

근거: PR #12990 (`refactor(cascade): externalize scoring magic numbers into configurable parameters`)이 `Cascade_strategy.t`에 `scoring : scoring_params` 필드를 필수로 추가했으나 `test/test_cascade_strategy.ml::mk_t` helper가 업데이트되지 않음.

PR #12995 (`align 3 test files with API/UX changes that landed unverified`)이 다른 3개 테스트는 보정했지만 이 케이스는 누락.

## 수정

`mk_t`에 `?(scoring = S.default_scoring_params)` optional 파라미터 추가하고 record에 포함. `default_scoring_params`는 `cascade_strategy.mli`에 이미 export되어 있으며 env-var 오버라이드를 해석하므로 #12990 이전 hardcoded 동작과 동치.

## 검증

```
dune build --root . @check                          clean
dune exec --root . test/test_cascade_strategy.exe   71/71 PASS
```

## Production effect

테스트 전용. 라이브러리 코드 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)