### PR TITLE
chore(bonsai): replace fabricated keeper fixtures with empty-state (audit response)

### DIFF
--- a/dashboard_bonsai/src/ctx_chart.ml
+++ b/dashboard_bonsai/src/ctx_chart.ml
@@ -161,20 +161,25 @@ let points_of (samples : Keepers_types.ctx_sample list) : string =
   |> String.concat ~sep:" "
 ;;
 
-(** Static fallback — mirrors the hand-coded 4 polyline mock. *)
-let polylines_static () =
-  [ polyline
-      ~points:"0,62 100,60 200,63 300,60 400,58 500,62 600,58"
-      ~stroke_var:"var(--t-llm)" ~dashed:false
-  ; polyline
-      ~points:"0,60 100,54 200,48 300,42 400,38 500,35 600,33"
-      ~stroke_var:"var(--t-tool)" ~dashed:false
-  ; polyline
-      ~points:"0,90 100,89 200,90 300,88 400,88 500,90 600,88"
-      ~stroke_var:"var(--t-wait)" ~dashed:false
-  ; polyline
-      ~points:"0,55 100,35 200,15 260,5"
-      ~stroke_var:"var(--t-err)" ~dashed:true
+(** Empty-state baseline — single dashed midline rendered when no keeper
+    telemetry is available. Mirrors cockpit-kit Spark/Heartbeat empty branch
+    (cb-shared.jsx:14-23, 29-50): a [data-empty="true"] svg with a dashed
+    baseline communicates absence rather than fabricating a curve that looks
+    like real data. Audit response 2026-05-05 §1.1. *)
+let empty_baseline () =
+  [ Node.create_svg "line"
+      ~attrs:
+        [ svg_a "x1" "0"
+        ; svg_a "y1" "50"
+        ; svg_a "x2" "600"
+        ; svg_a "y2" "50"
+        ; svg_a "stroke" "var(--color-fg-muted)"
+        ; svg_a "stroke-width" "1"
+        ; svg_a "stroke-dasharray" "3,3"
+        ; svg_a "opacity" "0.6"
+        ; svg_a "vector-effect" "non-scaling-stroke"
+        ]
+      []
   ]
 ;;
 
@@ -212,29 +217,35 @@ let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
     ; guide ~y:10 ~stroke_var:"var(--accent-blood)"     (* 90% danger *)
     ]
   in
+  let is_empty = List.is_empty keepers.keepers in
   let polylines =
-    match keepers.keepers with
-    | [] -> polylines_static ()
-    | live_keepers -> polylines_of_keepers live_keepers
+    if is_empty then empty_baseline ()
+    else polylines_of_keepers keepers.keepers
   in
   let meta_lines =
-    match keepers.keepers with
-    | [] -> [ "luna 38 · brass-owl 67"; "moth 12 · ash ×" ]
-    | live -> meta_lines_of live
+    if is_empty then [ "no keeper data" ]
+    else meta_lines_of keepers.keepers
   in
   let aria_desc =
-    "Context usage chart over 60 minutes. " ^ String.concat ~sep:"; " meta_lines
+    if is_empty then
+      "Context usage chart over 60 minutes. No keeper data available."
+    else
+      "Context usage chart over 60 minutes. "
+      ^ String.concat ~sep:"; " meta_lines
+  in
+  let svg_attrs =
+    let base =
+      [ svg_a "viewBox" "0 0 600 100"
+      ; svg_a "preserveAspectRatio" "none"
+      ; Style.svg
+      ; Attr.role "img"
+      ; Attr.create "aria-label" aria_desc
+      ]
+    in
+    if is_empty then base @ [ Attr.create "data-empty" "true" ] else base
   in
   let svg =
-    Node.create_svg "svg"
-      ~attrs:
-        [ svg_a "viewBox" "0 0 600 100"
-        ; svg_a "preserveAspectRatio" "none"
-        ; Style.svg
-        ; Attr.role "img"
-        ; Attr.create "aria-label" aria_desc
-        ]
-      (hairlines @ guides @ polylines)
+    Node.create_svg "svg" ~attrs:svg_attrs (hairlines @ guides @ polylines)
   in
   Node.div
     ~attrs:[ Swim.Style.swim ]

--- a/dashboard_bonsai/src/roster.ml
+++ b/dashboard_bonsai/src/roster.ml
@@ -205,24 +205,34 @@ let view_slot_of_keeper (k : Keepers_types.keeper) =
     ~when_
 ;;
 
-(** 서버 응답이 비었을 때 보이는 fixture. 4명 1-row, 4개 상태 다 노출. *)
-let view_static () =
-  [ view_slot ~sigil:"P" ~name:"keeper · poe" ~state:`Live
-      ~state_label:"speaking" ~when_:"3s"
-  ; view_slot ~sigil:"J" ~name:"janitor" ~state:`Thinking
-      ~state_label:"thinking" ~when_:"12s"
-  ; view_slot ~sigil:"G" ~name:"governance" ~state:`Idle
-      ~state_label:"idle · ok" ~when_:"2m"
-  ; view_slot ~sigil:"I" ~name:"improver" ~state:`Failed
-      ~state_label:"paused · auth" ~when_:"7m"
-  ]
+(** Empty-state placeholder slot — rendered when no keeper response is
+    available. Replaces the prior fictional fixture (poe/janitor/governance/
+    improver) per audit response 2026-05-05 §1.1. Mirrors cockpit-kit
+    Spark/Heartbeat empty branch: communicate absence explicitly. *)
+let empty_slot () =
+  view_slot
+    ~sigil:"·"
+    ~name:"no keeper data"
+    ~state:`Idle
+    ~state_label:"awaiting telemetry"
+    ~when_:"—"
 ;;
 
 let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
+  let is_empty = List.is_empty keepers.keepers in
   let slots =
-    match keepers.keepers with
-    | [] -> view_static ()
-    | live -> List.map live ~f:view_slot_of_keeper
+    if is_empty
+    then [ empty_slot () ]
+    else List.map keepers.keepers ~f:view_slot_of_keeper
   in
-  Node.div ~attrs:[ Style.roster; Attr.role "list"; Attr.create "aria-label" "Keeper slots" ] slots
+  let aria_label =
+    if is_empty then "Keeper slots (no keeper data)" else "Keeper slots"
+  in
+  let root_attrs =
+    let base =
+      [ Style.roster; Attr.role "list"; Attr.create "aria-label" aria_label ]
+    in
+    if is_empty then Attr.create "data-empty" "true" :: base else base
+  in
+  Node.div ~attrs:root_attrs slots
 ;;

--- a/dashboard_bonsai/src/swim.ml
+++ b/dashboard_bonsai/src/swim.ml
@@ -247,50 +247,6 @@ let view_lane_of_keeper (k : Keepers_types.keeper) =
     ~frames:fs
 ;;
 
-(** Static fallback — matches the hand-coded mock before live wiring. *)
-let view_static () =
-  [ view_lane
-      ~name:"luna"
-      ~stat:"reading"
-      ~status:`Live
-      ~frames:
-        [ frame ~kind:`Llm ~left:5 ~width:18 ~label:"llm"
-        ; frame ~kind:`Tool ~left:28 ~width:10 ~label:"read"
-        ; frame ~kind:`Think ~left:42 ~width:8 ~label:"think"
-        ; frame ~kind:`Llm ~left:54 ~width:22 ~label:"llm"
-        ; frame ~kind:`Tool ~left:80 ~width:14 ~label:"edit"
-        ]
-  ; view_lane
-      ~name:"brass-owl"
-      ~stat:"retrying"
-      ~status:`Warn
-      ~frames:
-        [ frame ~kind:`Llm ~left:3 ~width:20 ~label:"llm"
-        ; frame ~kind:`Tool ~left:26 ~width:12 ~label:"fetch"
-        ; frame ~kind:`Wait ~left:40 ~width:24 ~label:"wait"
-        ; frame ~kind:`Tool ~left:66 ~width:10 ~label:"fetch"
-        ]
-  ; view_lane
-      ~name:"moth"
-      ~stat:"idle · listening"
-      ~status:`Live
-      ~frames:
-        [ frame ~kind:`Wait ~left:0 ~width:40 ~label:"wait"
-        ; frame ~kind:`Llm ~left:42 ~width:14 ~label:"llm"
-        ; frame ~kind:`Wait ~left:58 ~width:40 ~label:"wait"
-        ]
-  ; view_lane
-      ~name:"ash-hound"
-      ~stat:"crashed t-34"
-      ~status:`Dead
-      ~frames:
-        [ frame ~kind:`Llm ~left:2 ~width:18 ~label:"llm"
-        ; frame ~kind:`Tool ~left:22 ~width:8 ~label:"exec"
-        ; frame ~kind:`Err ~left:32 ~width:6 ~label:"err"
-        ]
-  ]
-;;
-
 let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
   let axis_ticks =
     List.init 6 ~f:(fun i ->
@@ -305,19 +261,38 @@ let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
             [ Node.text (Printf.sprintf "t-%d" ((5 - i) * 12)) ]
         ])
   in
-  let lanes =
-    match keepers.keepers with
-    | [] -> view_static ()
-    | live_keepers -> List.map live_keepers ~f:view_lane_of_keeper
+  let is_empty = List.is_empty keepers.keepers in
+  let lanes = List.map keepers.keepers ~f:view_lane_of_keeper in
+  let aria_label =
+    if is_empty
+    then "Keeper activity timeline (no keeper data)"
+    else "Keeper activity timeline"
+  in
+  let root_attrs =
+    let base =
+      [ Style.swim; Attr.role "list"; Attr.create "aria-label" aria_label ]
+    in
+    if is_empty then Attr.create "data-empty" "true" :: base else base
+  in
+  let empty_notice =
+    if is_empty
+    then
+      [ Node.div
+          ~attrs:[ Style.axis_sp ]
+          [ Node.text "no keeper data" ]
+      ]
+    else []
   in
   Node.div
-    ~attrs:[ Style.swim; Attr.role "list"; Attr.create "aria-label" "Keeper activity timeline" ]
+    ~attrs:root_attrs
     ([ Node.div
          ~attrs:[ Style.axis ]
-         [ Node.div
-             ~attrs:[ Style.axis_sp ]
-             [ Node.text "keeper · cycle" ]
-         ; Node.div ~attrs:[ Style.axis_ax ] axis_ticks
-         ]
-     ] @ lanes)
+         ([ Node.div
+              ~attrs:[ Style.axis_sp ]
+              [ Node.text "keeper · cycle" ]
+          ; Node.div ~attrs:[ Style.axis_ax ] axis_ticks
+          ]
+          @ empty_notice)
+     ]
+     @ lanes)
 ;;


### PR DESCRIPTION
## Summary

`dashboard_bonsai/src/{ctx_chart,swim,roster}.ml` 세 view가 빈 keepers 응답일 때
하드코딩된 픽션 keeper 데이터(`luna 38 · brass-owl 67`, `moth 12 · ash ×`,
`keeper · poe`, `janitor`, `governance`, `improver`)를 렌더하던 anti-pattern을 제거.

`Keepers_var.fixture`가 빈 list로 시작하므로, 첫 페이지 로드 + 일시적 fetch 실패 시
사용자가 fictitious 이름을 실제 keeper로 오인할 수 있던 상태였습니다. 이는
2026-05-05 PR #12986 (`7c128530de`)에서 cockpit-kit Spark/Heartbeat/StatusTray
fallback을 제거한 것과 같은 audit response Tier-A 패턴입니다.

## What changed

- **ctx_chart.ml**: `polylines_static ()` 정적 4-polyline 가짜 데이터 + `meta_lines`
  픽션 리터럴 제거 → `empty_baseline ()` 단일 dashed midline + `["no keeper data"]`
  meta + `data-empty="true"` SVG 어트리뷰트 + aria-label "No keeper data available."
- **swim.ml**: `view_static ()` 4-lane fictitious mock 제거 → 빈 list 렌더 + 축 `axis_sp`
  영역에 `"no keeper data"` notice + `data-empty="true"` root + aria-label
  `(no keeper data)` 보강
- **roster.ml**: `view_static ()` 4-slot fictitious mock 제거 → `empty_slot ()`
  단일 placeholder slot (`sigil:"·"` / `name:"no keeper data"` / `state_label:
  "awaiting telemetry"` / `when_:"—"`) + `data-empty="true"` root + aria-label

## Why this is the right fix (not a patch on a patch)

- `Keepers_types.fixture`의 docstring(`keepers_types.ml:125-127`)이 명시한
  "Views should degrade gracefully (show '— no data —' or fall back to the static
  mock)" 의도 중, 세 view가 **잘못된 갈래**(static mock)를 택해 사용자에게
  fictitious 데이터를 노출하던 것을 정정. 이제 `Keepers_var`의 graceful 의도와
  실 동작이 일치.
- cockpit-kit empty branch (cb-shared.jsx:14-23, 29-50) 패턴을 그대로 mirror —
  프로젝트 내 일관된 empty state convention.
- audit이 지적한 production-facing 가짜 데이터를 제거하면서, 같은 안티패턴이 있던
  swim/roster까지 동일 fix로 처리해 다음 audit이 같은 false positive를 다시 내지
  않도록 차단.

## Test plan

- [x] `dune build --root .` (bonsai-dashboard switch) → exit 0, 세 모듈 .cmi/.cmo
      정상 산출
- [x] `dune runtest --root .` → exit 0
- [x] `rg -n "luna|brass-owl|moth|ash-hound|view_static\b|polylines_static|poe|janitor|governance|improver" dashboard_bonsai/`
      → 코멘트(audit response 명시)에만 잔존, 실데이터 0건
- [ ] 시각 확인: bonsai dev server에서 (a) 빈 keepers (b) live keepers 두 상태
      모두 점검 (Reviewer 권장 — 본 PR 작성자는 시각 확인 미수행)

## Self-review (workflow-pr.md)

- 변경 파일: 3개 (`ctx_chart.ml`, `swim.ml`, `roster.ml`)
- 검증: 빌드 + 테스트 통과, fictitious 이름 grep 0건
- 미검증: 시각 회귀 테스트 (Playwright snapshot 미수행). 동일 layout/Style만 사용했고
  CSS 토큰 변경 없음.
- 위험: data-empty 어트리뷰트가 기존 CSS selector와 충돌할 가능성은 낮음(grep으로
  `data-empty` selector 미사용 확인). 시각 검증으로 보완 권장.

## RFC 발견 체크

본 PR은 dashboard_bonsai surface-level 변경(가짜 데이터 → empty state)으로
credential / identity / operator control / keeper sandbox / dashboard credential
component / .claude/hooks / instructions/workflow* 어디에도 해당하지 않습니다.

`RFC-WAIVED: dashboard surface anti-pattern removal, no architectural change`

## Refs

- audit source: `deep_audit_dashboard_heuristic.md` §1.1 (file-only audit, deep-review CI)
- prior audit Tier-A response: PR #12986 (`7c128530de`)
- verification matrix (24 claims): docs/audit-responses/2026-05-05-dashboard-heuristic.md (PR-B 따라옴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)