### PR TITLE
fix(test): align test_cascade_strategy mk_t with scoring field (#12990 follow-up)

### DIFF
--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -62,8 +62,9 @@ let mk_ctx ?(health = H.create ())
 let mk_t ?(cycle = S.default_cycle_policy)
          ?(tiers = [])
          ?(sticky_ttl_ms = 0)
+         ?(scoring = S.default_scoring_params)
          kind : S.t =
-  { kind; cycle; tiers; sticky_ttl_ms }
+  { kind; cycle; tiers; sticky_ttl_ms; scoring }
 
 (* ── S1 Failover ─────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

Main 빌드 깨짐 fix. PR #12990가 `Cascade_strategy.t`에 required `scoring : scoring_params` 필드 추가, #12995가 align 시도했으나 `test/test_cascade_strategy.ml::mk_t`를 누락.

## Build error on main (ac0f8c6280)

```
File "test/test_cascade_strategy.ml", line 66, characters 2-39:
66 |   { kind; cycle; tiers; sticky_ttl_ms }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Some record fields are undefined: scoring
```

## Fix

`mk_t`에 optional `?scoring` 파라미터 추가 (기존 `?cycle`/`?tiers` 패턴 준수), default `S.default_scoring_params`. 1 file, +2/-1.

## Why

세션 메모리 `feedback_pre_merge_typecheck_drag_in_blocker` + `feedback_check_open_prs_before_fixing_pasted_build_error` 동일 패턴 반복. #12990 머지 시 `dune build --root .` 사후 검증 누락 → #12995 partial fix → 이 PR 보충 fix.

## Verification

- [x] `dune build --root .` green
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
