### PR TITLE
feat(zone-C2): kickoff — C2 Messages Broadcast

### DIFF
--- a/docs/zones/C2-messages-broadcast.md
+++ b/docs/zones/C2-messages-broadcast.md
@@ -1,0 +1,34 @@
+# Zone C2 — C2 Messages Broadcast
+
+**Phase**: phase2
+**Source spec**: `dashboard/design-system/preview/scope-phase2.html` (anchor `#c2`)
+**Status**: kickoff skeleton (2026-05-05)
+
+## Audit (2026-05-05)
+
+Self-reported coverage from `dashboard/src/cockpit-entrypoints.ts` does not match real component state. See knowledge/research/ audit doc for cross-reference.
+
+## Feature Checklist
+
+- [ ] room-timeline
+- [ ] mention-inbox
+- [ ] STATE-block-focus
+
+## Existing References
+
+(Populate during implementation — point at concrete files in `dashboard/src/`.)
+
+## Backend Dependencies
+
+(Populate — note schema/API surfaces required.)
+
+## Implementation Plan
+
+1. (TBD) Extract concrete component contract from scope HTML.
+2. (TBD) Identify minimum-viable slice that ships with no backend change.
+3. (TBD) RFC any backend additions in `docs/rfc/` before merging UI.
+
+## Related
+
+- Spec source: `dashboard/design-system/preview/scope-phase2.html`
+- Cockpit entrypoint aliases: `dashboard/src/cockpit-entrypoints.ts`


### PR DESCRIPTION
## 목적

`C2 Messages Broadcast` zone의 병렬 multi-track 구현을 위한 **coordination anchor**.

## 배경

2026-05-05 cockpit-zones audit (12 zone, ~3.5/12 = 29% coverage 확인) 결과,
사용자 결정으로 **12 zone 동시 kickoff** 진행. 본 PR은 그 12개 중 1개.

## 본 PR의 스코프

- `docs/zones/C2-messages-broadcast.md` 1개 파일 추가 (skeleton spec)
- 기능 구현 0건 — 후속 commit으로 점진 구현

## Feature Checklist (이 zone)

room-timeline · mention-inbox · STATE-block-focus

## Spec 출처

- `dashboard/design-system/preview/scope-phase2.html` (anchor `#c2`)
- `dashboard/src/cockpit-entrypoints.ts` (alias mapping — self-reported coverage는 신뢰 불가)

## 다음 단계

이 PR은 anchor만 제공. 실 구현은:
1. **Existing References** 섹션을 spec 파일에 채움 — 어떤 `dashboard/src/` 파일을 확장/대체할지 명시
2. **Backend Dependencies** 명시 — schema/API 신설 필요 시 별도 RFC
3. Minimum-viable slice 선정 후 commit 추가

## 12-track Kickoff 동기

- I0 IDE Backbone, E1 File Tree, E2 Editor Surfaces, E3 PR Inspector,
  E4 Git Graph, E5 Terminal/Search, G1 Goal Zone, G2 Task Zone,
  G3 Accountability, C1 Board, C2 Messages, C3 Composer v2

각 track 독립 PR. 의존성 그래프는 spec 파일들이 채워지면서 명확해짐.

## Done 기준 (이 PR)

- [x] skeleton spec 파일 추가
- [ ] Existing References 채움
- [ ] Backend Dependencies 정리
- [ ] Minimum-viable slice 1개 commit 추가
- [ ] (Ready 시점) typecheck + vitest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)