### PR TITLE
fix(test_board_ttl): restore green build on main

### DIFF
--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -2,6 +2,19 @@
 
 open Masc_mcp.Board
 
+(* #9903 test isolation: [create_post] now persists through
+   [Env_config_core.base_path ()], which raises [Config_error] in test
+   executables when the resolved path falls under HOME (PR #12584 moved
+   persistence outside the board lock and onto the live ledger path).
+   Pin [MASC_BASE_PATH] to a per-run tmp dir so the persist guard is
+   satisfied and ledger writes stay isolated from production. *)
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-board-ttl-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
 let () = Mirage_crypto_rng_unix.use_default ()
 
 let with_eio f () =


### PR DESCRIPTION
## Summary

`test_board_ttl` was failing 8/13 cases on `origin/main`. All 8 raised `Env_config_core.Config_error: #9903 test isolation breach` from `Eio.Mutex.use_rw` inside `Masc_mcp__Board_core.create_post` — the test never set `MASC_BASE_PATH`, so the persist guard tripped.

## Root Cause

PR #12584 (`fix(board): move persistence outside board locks`) moved `append_post` and `Agent_economy.earn` onto the `create_post` hot path. Both go through `Env_config_core.base_path ()`. The #9903 guard in `lib/config/env_config_core.ml:379` raises `Config_error` when a `test_*` executable resolves `base_path` under `$HOME`, to prevent fixture data from overwriting the live JSONL ledger (the original failure mode wrote 112 hot-voter-* rows into `~/me/.masc/board_votes.jsonl`).

`test_board_ttl.ml` did not set `MASC_BASE_PATH`, so once persistence entered `create_post`, the guard correctly tripped on every call.

## Failure modes

All 8 failures were the same exception class — `Config_error #9903 test isolation breach`:

- `ttl/permanent post`
- `ttl/expiring post`
- `ttl/sweeper skips permanent`
- `post_kind/direct default`
- `post_kind/automation contract`
- `post_kind/system contract`
- `post_kind/prefers explicit judgment`
- `post_kind/keeper provenance upgrade`

The 5 SSOT enum tests (`visibility_ssot`, `sort_order_ssot`) do not call `create_post` and were already passing.

## Fix

Set `MASC_BASE_PATH` to a per-run tmp dir at test module init. Mirrors the established pattern in `test_oas_bridge_judge_callers_9629.ml`, `test_credential_store.ml`, and others. No lib behaviour change.

```ocaml
let () =
  let dir =
    Filename.concat (Filename.get_temp_dir_name ())
      (Printf.sprintf "masc-test-board-ttl-%06x" (Random.bits ()))
  in
  Unix.putenv "MASC_BASE_PATH" dir
```

## Verification

```
$ dune exec --root . test/test_board_ttl.exe
Test Successful in 0.012s. 13 tests run.
```

`dune build --root . @lib/check` clean.

## Test plan

- [x] `dune build --root . test/test_board_ttl.exe`
- [x] `dune exec --root . test/test_board_ttl.exe` — all 13 pass
- [x] `dune build --root . @lib/check` — clean
- [ ] CI green on PR

Note: Draft. ready 전환은 `human-approved-ready` 라벨 부여 후 부탁드립니다.
