### PR TITLE
feat(cascade): TOML-as-SSOT + CI drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,25 @@ jobs:
         run: |
           opam exec -- dune build
 
+      - name: Cascade TOML/JSON drift gate
+        # Detects when config/cascade.toml has been edited but
+        # config/cascade.json was not regenerated.  The runtime
+        # auto-materializes JSON from TOML at boot, so a stale
+        # checked-in JSON does not break production — but it
+        # misleads readers and dashboards that read JSON directly
+        # (e.g., dashboard_cascade.ml).  This gate enforces parity
+        # in the repo so every commit stays self-describing.
+        # See: cascade_toml_materializer.ml, dashboard_cascade.ml:309.
+        run: |
+          opam exec -- dune exec ./bin/cascade_materialize.exe -- \
+            config/cascade.json
+          if ! git diff --exit-code config/cascade.json; then
+            echo "::error::config/cascade.json is stale relative to \
+config/cascade.toml.  Run 'dune exec ./bin/cascade_materialize.exe -- \
+config/cascade.json' locally and commit the result."
+            exit 1
+          fi
+
       - name: Install eio-trace
         run: |
           opam install -y eio-trace || echo "eio-trace install skipped"

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -16,7 +16,10 @@
     "openai_compat": "big_three",
     "persona_generation": "big_three",
     "provider_benchmark": "big_three",
-    "llm_rerank": "tool_rerank"
+    "llm_rerank": "tool_rerank",
+    "simple_task": "tier_small",
+    "moderate_task": "tier_medium",
+    "complex_task": "big_three"
   },
   "_comment_big_three": "Canonical keeper/workflow profile. Keep operator-chosen providers here; code must route logical usages through [routes] instead of hardcoding extra profile names.",
   "big_three_models": [
@@ -42,5 +45,28 @@
   ],
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
-  "tool_rerank_keeper_assignable": false
+  "tool_rerank_keeper_assignable": false,
+  "_comment_tier_small": "4B-class local models for simple tasks (classification, format, short summary). Operator opt-in: uncomment models when Ollama is running locally.",
+  "tier_small_models": [],
+  "tier_small_temperature": 0.3,
+  "tier_small_max_tokens": 1000,
+  "tier_small_keeper_assignable": false,
+  "tier_small_fallback_cascade": "tier_medium",
+  "_comment_tier_medium": "9B-class models for moderate tasks (extraction, reformat, medium-length generation). Falls back to big_three on exhaustion.",
+  "tier_medium_models": [ "glm-coding:glm-4.7-flashx" ],
+  "tier_medium_temperature": 0.2,
+  "tier_medium_max_tokens": 4096,
+  "tier_medium_keeper_assignable": false,
+  "tier_medium_fallback_cascade": "big_three",
+  "_comment_tier_fast": "Cheap+fast tool-capable cloud models for keeper turns. Bias toward latency and cost over reasoning depth. All entries support tool calling. Falls back to big_three on exhaustion.",
+  "tier_fast_models": [
+    "claude_code:claude-haiku-4-5-20251001", "codex_cli:gpt-5.3-codex-spark",
+    "gemini_cli:gemini-3-flash-preview",
+    "gemini_cli:gemini-3.1-flash-lite-preview", "glm-coding:glm-5-turbo",
+    "glm-coding:glm-4.7-flashx"
+  ],
+  "tier_fast_temperature": 0.2,
+  "tier_fast_max_tokens": 8192,
+  "tier_fast_keeper_assignable": true,
+  "tier_fast_fallback_cascade": "big_three"
 }


### PR DESCRIPTION
## Summary

Resolves cascade.toml ↔ cascade.json drift and prevents recurrence
with a CI gate.

`config/cascade.json` was 4 days behind `config/cascade.toml`,
missing three [routes] entries (`simple_task`, `moderate_task`,
`complex_task`) and three profile sections (`tier_small`,
`tier_medium`, `tier_fast`). The runtime auto-materializes JSON
from TOML at boot via `lib/cascade/cascade_toml_materializer.ml`,
so production was unaffected — but the checked-in JSON misled
dashboard readers (`lib/dashboard_cascade.ml:309` even has a
comment about "silently served the stale [raw_json] file, hiding
cascade.toml") and made code review harder.

## Changes

| File | Lines | Purpose |
|------|-------|---------|
| `config/cascade.json` | +28 / −2 | Regenerated from `cascade.toml` |
| `.github/workflows/ci.yml` | +19 | New "Cascade TOML/JSON drift gate" step in Build and Test job |

## How it works

The new CI step runs after `dune build`:

```yaml
- name: Cascade TOML/JSON drift gate
  run: |
    opam exec -- dune exec ./bin/cascade_materialize.exe -- \
      config/cascade.json
    if ! git diff --exit-code config/cascade.json; then
      echo "::error::config/cascade.json is stale ..."
      exit 1
    fi
```

If a future PR touches `cascade.toml` without regenerating the
JSON, this gate hard-fails the Build and Test job (no
continue-on-error). Local fix: `dune exec
./bin/cascade_materialize.exe -- config/cascade.json` and commit.

## Verification

- Materializer ran twice locally:
  - 1st run: `wrote_json=true` (regenerated)
  - 2nd run: `wrote_json=false` (idempotent, no further drift)
- `git diff --exit-code config/cascade.json` is clean after
  regeneration.
- The new step uses `opam exec -- dune exec` — same toolchain as
  the existing Build step, so no extra setup overhead.

## Out of scope

- Removing `config/cascade.json` from the repo and gitignoring it:
  defer until the gate proves stable. The current arrangement
  preserves auditability (you can `cat` cascade.json to see the
  shape the runtime sees).
- A pre-commit hook locally: nice-to-have, not load-bearing once
  the CI gate is in place.

## Linked

- `lib/cascade/cascade_toml_materializer.ml` — materializer impl.
- `lib/dashboard_cascade.ml:309` — original "stale raw_json" note.
- Recent commit `4ef4ab1800 fix(cascade): pass [admission.*]
  sub-tables through to JSON unchanged` — showed the materializer
  evolves; without this gate that work would have produced new
  drift.
