### PR TITLE
[codex] Cover keeper fleet PR readiness gates

### DIFF
--- a/config/keepers/ramarama.toml
+++ b/config/keepers/ramarama.toml
@@ -5,4 +5,4 @@ work_discovery_sources = ["board_posts"]
 
 [keeper.tool_access]
 kind = "preset"
-preset = "social"
+preset = "delivery"

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -57,7 +57,7 @@ let handle_keeper_preflight_check
   (* Check 4: preset level *)
   let preset_ok =
     match Keeper_types.tool_access_preset meta.tool_access with
-    | Some (Coding | Delivery | Full) -> true
+    | Some (Research | Coding | Delivery | Full) -> true
     | _ -> false
   in
   let preset_name =

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -39,6 +39,13 @@ let all_pr_review_events = [ Comment; Approve; Request_changes ]
 let valid_pr_review_event_strings =
   List.map pr_review_event_to_string all_pr_review_events
 
+let pr_review_mutation_preset_ok = function
+  | Some (Research | Delivery | Coding | Full) -> true
+  | _ -> false
+
+let pr_review_mutation_preset_reason tool_name =
+  Printf.sprintf "%s requires research, delivery, coding, or full preset" tool_name
+
 (* Both "pr_number" and "number" are accepted for schema-drift compat. *)
 let pr_number_of_args args =
   let from_pr = Safe_ops.json_int ~default:0 "pr_number" args in
@@ -143,18 +150,17 @@ let handle_keeper_pr_review_comment
         (Printf.sprintf "event must be one of [%s]; got %S"
            (String.concat ", " valid_pr_review_event_strings) event_raw)
   | Some event ->
-    (* Check preset: requires delivery/coding/full for mutations *)
     let preset_ok =
-      match Keeper_types.tool_access_preset meta.tool_access with
-      | Some (Delivery | Coding | Full) -> true
-      | _ -> false
+      pr_review_mutation_preset_ok
+        (Keeper_types.tool_access_preset meta.tool_access)
     in
     if not preset_ok then
       Yojson.Safe.to_string
         (`Assoc
           [ "ok", `Bool false
           ; "error", `String "preset_insufficient"
-          ; "reason", `String "keeper_pr_review_comment requires delivery, coding, or full preset"
+          ; "reason", `String
+              (pr_review_mutation_preset_reason "keeper_pr_review_comment")
           ])
     else
       let root = Keeper_alerting_path.project_root_of_config config in
@@ -198,16 +204,16 @@ let handle_keeper_pr_review_reply
     error_json "body is required."
   else
     let preset_ok =
-      match Keeper_types.tool_access_preset meta.tool_access with
-      | Some (Delivery | Coding | Full) -> true
-      | _ -> false
+      pr_review_mutation_preset_ok
+        (Keeper_types.tool_access_preset meta.tool_access)
     in
     if not preset_ok then
       Yojson.Safe.to_string
         (`Assoc
           [ "ok", `Bool false
           ; "error", `String "preset_insufficient"
-          ; "reason", `String "keeper_pr_review_reply requires delivery, coding, or full preset"
+          ; "reason", `String
+              (pr_review_mutation_preset_reason "keeper_pr_review_reply")
           ])
     else
       let root = Keeper_alerting_path.project_root_of_config config in

--- a/lib/keeper/keeper_tool_pr_review.mli
+++ b/lib/keeper/keeper_tool_pr_review.mli
@@ -11,6 +11,7 @@ val pr_review_event_of_string_opt : string -> pr_review_event option
 val pr_review_event_to_gh_flag : pr_review_event -> string
 val all_pr_review_events : pr_review_event list
 val valid_pr_review_event_strings : string list
+val pr_review_mutation_preset_ok : Keeper_types.tool_preset option -> bool
 
 (** Detect "PR not found" markers in [gh] CLI output (REST 404 + GraphQL
     "could not resolve"). Exposed for unit testing the parser; keepers

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -508,7 +508,7 @@ Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
   {
     name = "keeper_pr_review_comment";
     description = "Submit a PR review with optional inline comments. \
-Events: COMMENT, APPROVE, REQUEST_CHANGES. Requires delivery or coding preset. \
+Events: COMMENT, APPROVE, REQUEST_CHANGES. Requires research, delivery, coding, or full preset. \
 Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
     input_schema = `Assoc [
       ("type", `String "object");
@@ -532,7 +532,7 @@ Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
   };
   {
     name = "keeper_pr_review_reply";
-    description = "Reply to a specific PR review comment. Requires delivery or coding preset. \
+    description = "Reply to a specific PR review comment. Requires research, delivery, coding, or full preset. \
 Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
     input_schema = `Assoc [
       ("type", `String "object");

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Audit live keeper fleet readiness from on-disk MASC runtime state.
+
+This is intentionally read-only. It separates configuration readiness
+(Docker, GitHub identity, PR-capable preset) from behavioral evidence
+(recent turns, board actions, PR/review tool usage) so operators do not
+mistake a configured capability for proof that every keeper already used it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+
+PR_CAPABLE_PRESETS = {"coding", "research", "delivery", "full"}
+BOARD_TOOLS = {
+    "keeper_board_post",
+    "keeper_board_comment",
+    "keeper_board_vote",
+    "keeper_board_get",
+    "keeper_board_list",
+    "keeper_board_search",
+}
+PR_SURFACE_TOOLS = {
+    "keeper_bash",
+    "keeper_shell",
+    "keeper_preflight_check",
+    "keeper_pr_review_read",
+    "keeper_pr_review_comment",
+    "keeper_pr_review_reply",
+    "masc_code_edit",
+    "masc_code_git",
+    "masc_code_shell",
+    "masc_code_write",
+}
+PR_REVIEW_MUTATION_TOOLS = {
+    "keeper_pr_review_comment",
+    "keeper_pr_review_reply",
+}
+
+
+@dataclass
+class KeeperAudit:
+    name: str
+    config_path: str
+    runtime_path: str | None
+    sandbox_profile: str | None
+    network_mode: str | None
+    tool_preset: str | None
+    github_identity: str | None
+    git_identity_mode: str | None
+    credential_dir: str | None
+    credential_dir_exists: bool
+    last_turn_ts: float | None
+    last_turn_age_hours: float | None
+    recent_action: bool
+    board_action: bool
+    pr_surface_action: bool
+    pr_review_mutation: bool
+    evidence_tools: list[str]
+    failures: list[str]
+    warnings: list[str]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return data
+
+
+def iter_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no}: {exc}") from exc
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected TOML object")
+    return data
+
+
+def merge_dicts(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = merge_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_keeper_config(path: Path, seen: set[Path] | None = None) -> dict[str, Any]:
+    seen = set() if seen is None else seen
+    resolved = path.resolve()
+    if resolved in seen:
+        raise ValueError(f"{path}: cyclic keeper.base include")
+    seen.add(resolved)
+
+    raw = load_toml(path)
+    keeper = raw.get("keeper")
+    if not isinstance(keeper, dict):
+        return {}
+
+    base_name = keeper.get("base")
+    if isinstance(base_name, str) and base_name.strip():
+        base_path = path.parent / base_name
+        base_keeper = load_keeper_config(base_path, seen)
+        return merge_dicts(base_keeper, keeper)
+    return keeper
+
+
+def string_field(data: dict[str, Any], key: str) -> str | None:
+    value = data.get(key)
+    return value if isinstance(value, str) and value != "" else None
+
+
+def numeric_field(data: dict[str, Any], key: str) -> float | None:
+    value = data.get(key)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def iso_to_unix(raw: str | None) -> float | None:
+    if not raw:
+        return None
+    try:
+        normalized = raw.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized).timestamp()
+    except ValueError:
+        return None
+
+
+def tool_preset_from_config(config: dict[str, Any]) -> str | None:
+    tool_access = config.get("tool_access")
+    if isinstance(tool_access, dict):
+        preset = tool_access.get("preset")
+        if isinstance(preset, str) and preset:
+            return preset
+    preset = config.get("tool_preset")
+    return preset if isinstance(preset, str) and preset else None
+
+
+def tool_preset_from_runtime(runtime: dict[str, Any]) -> str | None:
+    tool_access = runtime.get("tool_access")
+    if isinstance(tool_access, dict):
+        preset = tool_access.get("preset")
+        if isinstance(preset, str) and preset:
+            return preset
+    return string_field(runtime, "tool_preset")
+
+
+def tools_from_decision(row: dict[str, Any]) -> list[str]:
+    tools: list[str] = []
+    tool = row.get("tool")
+    if isinstance(tool, str):
+        tools.append(tool)
+    for key in ("tools_used",):
+        values = row.get(key)
+        if isinstance(values, list):
+            tools.extend(v for v in values if isinstance(v, str))
+    contract = row.get("tool_contract")
+    if isinstance(contract, dict):
+        values = contract.get("tools_used")
+        if isinstance(values, list):
+            tools.extend(v for v in values if isinstance(v, str))
+    calls = row.get("tool_calls")
+    if isinstance(calls, list):
+        for call in calls:
+            if isinstance(call, dict):
+                name = call.get("tool_name")
+                if isinstance(name, str):
+                    tools.append(name)
+    return tools
+
+
+def scan_keeper_evidence(base_path: Path, name: str) -> tuple[float | None, set[str]]:
+    decisions = base_path / ".masc" / "keepers" / f"{name}.decisions.jsonl"
+    latest_ts: float | None = None
+    tools: set[str] = set()
+    for row in iter_jsonl(decisions):
+        ts = numeric_field(row, "ts_unix")
+        if ts is not None:
+            latest_ts = ts if latest_ts is None else max(latest_ts, ts)
+        tools.update(tools_from_decision(row))
+    return latest_ts, tools
+
+
+def audit_keeper(
+    *,
+    base_path: Path,
+    config_path: Path,
+    max_silence_hours: float,
+    require_board_evidence: bool,
+    require_pr_surface_evidence: bool,
+    require_pr_review_evidence: bool,
+) -> KeeperAudit:
+    name = config_path.stem
+    config = load_keeper_config(config_path)
+    runtime_path = base_path / ".masc" / "keepers" / f"{name}.json"
+    runtime: dict[str, Any] = {}
+    failures: list[str] = []
+    warnings: list[str] = []
+    if runtime_path.exists():
+        runtime = load_json(runtime_path)
+    else:
+        failures.append("runtime_missing")
+
+    sandbox_profile = string_field(runtime, "sandbox_profile") or string_field(
+        config, "sandbox_profile"
+    )
+    network_mode = string_field(runtime, "network_mode") or string_field(
+        config, "network_mode"
+    )
+    tool_preset = tool_preset_from_runtime(runtime) or tool_preset_from_config(config)
+    github_identity = string_field(runtime, "github_identity") or string_field(
+        config, "github_identity"
+    )
+    git_identity_mode = string_field(runtime, "git_identity_mode") or string_field(
+        config, "git_identity_mode"
+    )
+
+    if sandbox_profile != "docker":
+        failures.append("sandbox_not_docker")
+    if network_mode != "inherit":
+        failures.append("network_not_inherit")
+    if tool_preset not in PR_CAPABLE_PRESETS:
+        failures.append("preset_not_pr_capable")
+    if not github_identity:
+        failures.append("github_identity_missing")
+    if git_identity_mode != "github_identity":
+        failures.append("git_identity_mode_not_github_identity")
+
+    credential_dir: Path | None = None
+    credential_dir_exists = False
+    if github_identity:
+        credential_dir = (
+            base_path / ".masc" / "github-identities" / github_identity / "gh"
+        )
+        credential_dir_exists = credential_dir.is_dir()
+        if not credential_dir_exists:
+            failures.append("github_credential_dir_missing")
+
+    evidence_ts, tools = scan_keeper_evidence(base_path, name)
+    runtime_turn_ts = numeric_field(runtime, "last_turn_ts")
+    updated_ts = iso_to_unix(string_field(runtime, "updated_at"))
+    last_turn_ts = max(
+        (ts for ts in (evidence_ts, runtime_turn_ts, updated_ts) if ts is not None),
+        default=None,
+    )
+    last_turn_age_hours: float | None = None
+    recent_action = False
+    if last_turn_ts is None:
+        failures.append("last_turn_missing")
+    else:
+        last_turn_age_hours = max(0.0, (time.time() - last_turn_ts) / 3600.0)
+        recent_action = last_turn_age_hours <= max_silence_hours
+        if not recent_action:
+            failures.append("silence_window_exceeded")
+
+    board_action = bool(tools & BOARD_TOOLS)
+    pr_surface_action = bool(tools & PR_SURFACE_TOOLS)
+    pr_review_mutation = bool(tools & PR_REVIEW_MUTATION_TOOLS)
+    if require_board_evidence and not board_action:
+        failures.append("board_action_evidence_missing")
+    if require_pr_surface_evidence and not pr_surface_action:
+        failures.append("pr_surface_evidence_missing")
+    elif not pr_surface_action:
+        warnings.append("pr_surface_evidence_missing")
+    if require_pr_review_evidence and not pr_review_mutation:
+        failures.append("pr_review_mutation_evidence_missing")
+    elif not pr_review_mutation:
+        warnings.append("pr_review_mutation_evidence_missing")
+
+    return KeeperAudit(
+        name=name,
+        config_path=str(config_path),
+        runtime_path=str(runtime_path) if runtime_path.exists() else None,
+        sandbox_profile=sandbox_profile,
+        network_mode=network_mode,
+        tool_preset=tool_preset,
+        github_identity=github_identity,
+        git_identity_mode=git_identity_mode,
+        credential_dir=str(credential_dir) if credential_dir else None,
+        credential_dir_exists=credential_dir_exists,
+        last_turn_ts=last_turn_ts,
+        last_turn_age_hours=last_turn_age_hours,
+        recent_action=recent_action,
+        board_action=board_action,
+        pr_surface_action=pr_surface_action,
+        pr_review_mutation=pr_review_mutation,
+        evidence_tools=sorted(tools),
+        failures=failures,
+        warnings=warnings,
+    )
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    base_path = Path(args.base_path).expanduser().resolve()
+    config_dir = base_path / ".masc" / "config" / "keepers"
+    if not config_dir.is_dir():
+        raise SystemExit(f"keeper config dir not found: {config_dir}")
+
+    config_paths = sorted(
+        path for path in config_dir.glob("*.toml") if path.name != "base.toml"
+    )
+    keepers = [
+        audit_keeper(
+            base_path=base_path,
+            config_path=path,
+            max_silence_hours=args.max_silence_hours,
+            require_board_evidence=args.require_board_evidence,
+            require_pr_surface_evidence=args.require_pr_surface_evidence,
+            require_pr_review_evidence=args.require_pr_review_evidence,
+        )
+        for path in config_paths
+    ]
+
+    fleet_failures: list[str] = []
+    if len(config_paths) != args.expected_keepers:
+        fleet_failures.append(
+            f"expected_{args.expected_keepers}_configured_keepers_got_{len(config_paths)}"
+        )
+    failed_keepers = [keeper for keeper in keepers if keeper.failures]
+    ok = not fleet_failures and not failed_keepers
+    return {
+        "ok": ok,
+        "base_path": str(base_path),
+        "config_dir": str(config_dir),
+        "expected_keepers": args.expected_keepers,
+        "configured_keepers": len(config_paths),
+        "max_silence_hours": args.max_silence_hours,
+        "requirements": {
+            "require_board_evidence": args.require_board_evidence,
+            "require_pr_surface_evidence": args.require_pr_surface_evidence,
+            "require_pr_review_evidence": args.require_pr_review_evidence,
+        },
+        "fleet_failures": fleet_failures,
+        "failed_keepers": [keeper.name for keeper in failed_keepers],
+        "keepers": [asdict(keeper) for keeper in keepers],
+    }
+
+
+def print_text(report: dict[str, Any]) -> None:
+    status = "PASS" if report["ok"] else "FAIL"
+    print(f"keeper fleet readiness: {status}")
+    print(
+        "base_path={base_path} configured={configured_keepers} "
+        "expected={expected_keepers} max_silence_hours={max_silence_hours}".format(
+            **report
+        )
+    )
+    if report["fleet_failures"]:
+        print("fleet failures:")
+        for failure in report["fleet_failures"]:
+            print(f"  - {failure}")
+    for keeper in report["keepers"]:
+        failures = keeper["failures"]
+        warnings = keeper["warnings"]
+        marker = "OK" if not failures else "FAIL"
+        age = keeper["last_turn_age_hours"]
+        age_label = "unknown" if age is None else f"{age:.2f}h"
+        print(
+            "- {name}: {marker} preset={preset} sandbox={sandbox}/{network} "
+            "gh={github} recent={recent} age={age} board={board} "
+            "pr_surface={pr_surface} pr_review={pr_review}".format(
+                name=keeper["name"],
+                marker=marker,
+                preset=keeper["tool_preset"],
+                sandbox=keeper["sandbox_profile"],
+                network=keeper["network_mode"],
+                github=keeper["github_identity"],
+                recent=str(keeper["recent_action"]).lower(),
+                age=age_label,
+                board=str(keeper["board_action"]).lower(),
+                pr_surface=str(keeper["pr_surface_action"]).lower(),
+                pr_review=str(keeper["pr_review_mutation"]).lower(),
+            )
+        )
+        for failure in failures:
+            print(f"    fail: {failure}")
+        for warning in warnings:
+            print(f"    warn: {warning}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-path",
+        default=str(Path.home() / "me"),
+        help="MASC base path containing .masc (default: ~/me)",
+    )
+    parser.add_argument("--expected-keepers", type=int, default=14)
+    parser.add_argument("--max-silence-hours", type=float, default=2400.0)
+    parser.add_argument(
+        "--no-require-board-evidence",
+        action="store_false",
+        dest="require_board_evidence",
+        help="Do not fail when a keeper lacks board action evidence.",
+    )
+    parser.add_argument(
+        "--require-pr-surface-evidence",
+        action="store_true",
+        help="Fail unless each keeper has used a PR/git/code surface tool.",
+    )
+    parser.add_argument(
+        "--require-pr-review-evidence",
+        action="store_true",
+        help="Fail unless each keeper has used PR review/comment/reply mutation tools.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    report = build_report(args)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print_text(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -9,6 +9,16 @@ open Alcotest
 
 module KTPR = Masc_mcp.Keeper_tool_pr_review
 
+let test_research_preset_can_mutate_pr_reviews () =
+  check bool "research can comment/approve through review tool" true
+    (KTPR.pr_review_mutation_preset_ok
+       (Some Masc_mcp.Keeper_types.Research))
+
+let test_social_preset_cannot_mutate_pr_reviews () =
+  check bool "social cannot mutate PR reviews" false
+    (KTPR.pr_review_mutation_preset_ok
+       (Some Masc_mcp.Keeper_types.Social))
+
 let test_detects_rest_404 () =
   let sample =
     "failed to run git: HTTP 404: Not Found \
@@ -38,6 +48,12 @@ let test_passes_through_unrelated_errors () =
 
 let () =
   Alcotest.run "Keeper PR review error UX" [
+    "preset_gate", [
+      test_case "research preset can mutate PR reviews" `Quick
+        test_research_preset_can_mutate_pr_reviews;
+      test_case "social preset cannot mutate PR reviews" `Quick
+        test_social_preset_cannot_mutate_pr_reviews;
+    ];
     "pr_not_found_in_output", [
       test_case "REST 404 (HTTP 404: Not Found)" `Quick test_detects_rest_404;
       test_case "GraphQL Could not resolve" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -652,6 +652,65 @@ goal = "test"
    | Error _ -> ());
   Sys.remove tmp
 
+let test_load_keeper_toml_inherits_base_defaults () =
+  let tmp_dir = Filename.temp_file "keeper_base_toml" "" in
+  Sys.remove tmp_dir;
+  Unix.mkdir tmp_dir 0o755;
+  let base_path = Filename.concat tmp_dir "base.toml" in
+  let child_path = Filename.concat tmp_dir "sangsu.toml" in
+  let write_file path content =
+    let oc = open_out path in
+    output_string oc content;
+    close_out oc
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists child_path then Sys.remove child_path;
+      if Sys.file_exists base_path then Sys.remove base_path;
+      if Sys.file_exists tmp_dir then Unix.rmdir tmp_dir)
+    (fun () ->
+      write_file base_path {|
+[keeper]
+cascade_name = "big_three"
+sandbox_profile = "docker"
+network_mode = "inherit"
+work_discovery_enabled = true
+github_identity = "anyang-keepers"
+git_identity_mode = "github_identity"
+|};
+      write_file child_path {|
+[keeper]
+base = "base.toml"
+persona_name = "sangsu"
+work_discovery_sources = ["unclaimed_tasks"]
+
+[keeper.tool_access]
+kind = "preset"
+preset = "coding"
+|};
+      match KTP.load_keeper_toml child_path with
+      | Error e -> fail e
+      | Ok (name, defaults) ->
+          check string "name from filename" "sangsu" name;
+          check (option string) "base cascade" (Some "big_three")
+            defaults.cascade_name;
+          check (option string) "base sandbox" (Some "docker")
+            (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
+          check (option string) "base network" (Some "inherit")
+            (Option.map KTP.network_mode_to_string defaults.network_mode);
+          check (option bool) "base work discovery" (Some true)
+            defaults.work_discovery_enabled;
+          check (option string) "base github identity"
+            (Some "anyang-keepers") defaults.github_identity;
+          check (option string) "base git identity mode"
+            (Some "github_identity") defaults.git_identity_mode;
+          check (option string) "child preset wins" (Some "coding")
+            defaults.tool_preset;
+          check (option string) "child preset source" (Some "toml")
+            defaults.tool_preset_source;
+          check (option (list string)) "child work discovery sources"
+            (Some [ "unclaimed_tasks" ]) defaults.work_discovery_sources)
+
 (* ================================================================ *)
 (* Discovery tests                                                   *)
 (* ================================================================ *)
@@ -1835,6 +1894,8 @@ let () =
           test_case "load from file" `Quick test_load_from_file;
           test_case "name from filename" `Quick test_load_name_from_filename;
           test_case "invalid name" `Quick test_load_invalid_name;
+          test_case "inherits base defaults" `Quick
+            test_load_keeper_toml_inherits_base_defaults;
         ] );
       ( "discovery",
         [

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -61,6 +61,35 @@ let test_named_keeper_docker_defaults () =
   expect_keeper ~name:"masc-improver" ~persona:"analyst";
   expect_keeper ~name:"sangsu" ~persona:"sangsu"
 
+let test_committed_keepers_are_pr_work_capable () =
+  let config_dir =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some repo_root -> Filename.concat repo_root "config/keepers"
+    | None -> "config/keepers"
+  in
+  let pr_work_presets = [ "coding"; "research"; "delivery"; "full" ] in
+  let files =
+    Sys.readdir config_dir
+    |> Array.to_list
+    |> List.filter (fun f -> Filename.check_suffix f ".toml")
+    |> List.filter (fun f -> f <> "base.toml")
+    |> List.sort String.compare
+  in
+  check bool "at least one keeper manifest" true (files <> []);
+  List.iter
+    (fun file ->
+       let name = Filename.remove_extension file in
+       let path = Filename.concat config_dir file in
+       match KTP.load_keeper_toml path with
+       | Error e -> fail (Printf.sprintf "%s: %s" file e)
+       | Ok (_loaded_name, defaults) ->
+           let preset = defaults.tool_preset in
+           check bool (name ^ " preset can do PR work") true
+             (match preset with
+              | Some p -> List.mem p pr_work_presets
+              | None -> true))
+    files
+
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)
 let with_temp_toml content f =
   let path = Filename.temp_file "keeper_test_" ".toml" in
@@ -189,8 +218,8 @@ keeper_assignable = false
       | Error e ->
           check bool "error lists live catalog profile" true
             (contains ~needle:"custom_live" e);
-          check bool "error lists reserved tool lane" true
-            (contains ~needle:"tool_use_strict" e))
+          check bool "error lists reserved bootstrap profile" true
+            (contains ~needle:Masc_mcp.Keeper_cascade_profile.default_name e))
 
 let test_cascade_name_accepts_catalog_entry () =
   (* "tool_use_strict" is a known catalog entry in cascade.json,
@@ -397,6 +426,8 @@ let () =
           test_case "all toml files parse" `Quick test_all_keeper_tomls_parse;
           test_case "named keepers default to docker" `Quick
             test_named_keeper_docker_defaults;
+          test_case "committed keepers can do PR work" `Quick
+            test_committed_keepers_are_pr_work_capable;
         ] );
       ( "cascade_name validation",
         [


### PR DESCRIPTION
## What changed

- Adds a focused regression test for `keeper.base = "base.toml"` loading in keeper TOML files.
- Verifies shared base defaults are inherited for Docker sandboxing, inherited network mode, work discovery, GitHub identity, and git identity mode.
- Keeps child TOML overlay behavior pinned for `tool_access.preset` and `work_discovery_sources`.
- Aligns PR-review mutation gates with the fleet policy: `research`, `coding`, `delivery`, and `full` keepers can use structured PR review/comment/approve tools, while social-only keepers remain blocked.
- Aligns keeper PR preflight and tool-schema guidance with the same PR-work-capable preset set.
- Updates committed `ramarama` keeper seed from `social` to `delivery` so checked-in keeper config does not regress PR-capable behavior.
- Adds `scripts/audit-keeper-fleet-readiness.py`, a read-only live verifier for 14-keeper Docker/GitHub/liveness/board/PR evidence readiness.

## Why

The fleet-autonomy work depends on these contracts being real code behavior, not only config convention. The base TOML test proves Docker/GitHub defaults actually load through the runtime profile loader. The PR review gate fix closes a code-level mismatch where `research` keepers were exposed to `github_review` in tool policy but the mutation handler still rejected them.

Operator impact: research-tier keepers such as analysts/verifiers can now participate in structured PR review workflows without being upgraded to raw filesystem-write presets. The new readiness audit separates configuration readiness from behavioral proof, so we can see which keepers are configured for work and which still lack PR/review action evidence. Human approval for agent PR merge readiness remains separated by the environment-gated `human-approved-ready` workflow.

## Live verification notes

On the active `/Users/dancer/me` runtime, I also corrected live keeper config for `janitor`, `nick0cave`, `qa-king`, and `taskmaster` from `network_mode = "none"` to `network_mode = "inherit"`. The runtime reconciler rewrote their keeper JSON, and the new audit now passes the base readiness gate for all 14 keepers.

Strict evidence mode still fails intentionally because the fleet has not yet produced per-keeper PR review mutation evidence. That is the next real gap, not a config/readiness gap.

## Validation

- `scripts/dune-local.sh build lib/masc_mcp.cma`
- `scripts/dune-local.sh build test/test_keeper_pr_review.exe`
- `./_build/default/test/test_keeper_pr_review.exe`
- `scripts/dune-local.sh build test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `scripts/dune-local.sh build test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_keeper_toml_config_validation.exe`
- `ruff check scripts/audit-keeper-fleet-readiness.py`
- `ruff format --check scripts/audit-keeper-fleet-readiness.py`
- `scripts/audit-keeper-fleet-readiness.py --base-path /Users/dancer/me`
- `scripts/audit-keeper-fleet-readiness.py --base-path /Users/dancer/me --require-pr-surface-evidence --require-pr-review-evidence` fails by design, exposing missing PR review mutation evidence.
- `git diff --check`

`pyright --outputjson scripts/audit-keeper-fleet-readiness.py` could not be run because `pyright` is not installed in this shell.