### PR TITLE
fix(keeper): hydrate timeout budget strikes after restart

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -352,6 +352,13 @@ let clear_oas_timeout_budget_failure_reason ~base_path ~keeper_name =
       Keeper_registry.set_failure_reason ~base_path keeper_name None
   | _ -> ()
 
+let prior_oas_timeout_budget_strikes ~base_path ~keeper_name =
+  match Keeper_registry.get ~base_path keeper_name with
+  | Some { Keeper_registry.last_failure_reason =
+             Some (Keeper_registry.Oas_timeout_budget_loop { count }); _ } ->
+      count
+  | _ -> 0
+
 let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
   match Oas_worker_named.classify_masc_internal_error err with
   | Some (Oas_worker_named.Oas_timeout_budget _) -> true
@@ -660,7 +667,16 @@ let run_keepalive_unified_turn
               if is_oas_timeout_budget_error err
               then begin
                 let keeper_name = meta_after_observe.name in
-                let strikes = Keeper_turn_slot.bump_budget_exhaustion ~keeper_name in
+                let prior_strikes =
+                  prior_oas_timeout_budget_strikes
+                    ~base_path:ctx.config.base_path
+                    ~keeper_name
+                in
+                let strikes =
+                  Keeper_turn_slot.bump_budget_exhaustion_seeded
+                    ~keeper_name
+                    ~prior_strikes
+                in
                 Keeper_registry.set_failure_reason
                   ~base_path:ctx.config.base_path keeper_name
                   (Some (Keeper_registry.Oas_timeout_budget_loop

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -110,14 +110,20 @@ val reset_autonomous_completion_for_test : unit -> unit
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
     per keeper. Promoted to [Keeper_fiber_crash] at
     [oas_timeout_budget_strike_limit]; reset on any successful turn.
-    Counter survives within a server lifetime — restart resets it,
-    which is the desired behavior since the new fiber starts with
-    a fresh budget context. *)
+    Counter survives within a server lifetime. After restart, callers
+    may hydrate the first bump from persisted [Oas_timeout_budget_loop]
+    state so multi-process loops still reach the supervisor gate. *)
 val oas_timeout_budget_strike_limit : int
+
+val bump_budget_exhaustion_seeded :
+  keeper_name:string -> prior_strikes:int -> int
+(** Increment the strike count for [keeper_name] and return the new
+    count. If no in-memory count exists, [prior_strikes] is used as
+    the non-negative starting point. Thread-safe under [Eio.Mutex]. *)
 
 val bump_budget_exhaustion : keeper_name:string -> int
 (** Increment the strike count for [keeper_name] and return the new
-    count.  Thread-safe under [Eio.Mutex]. *)
+    count from the in-memory counter only. Thread-safe under [Eio.Mutex]. *)
 
 val reset_budget_exhaustion : keeper_name:string -> unit
 (** Drop any strike count for [keeper_name].  Idempotent. *)

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -307,8 +307,14 @@ let reset_autonomous_completion_for_test () : unit =
    window with 0 restart.
 
    Promote to [Keeper_fiber_crash] after [oas_timeout_budget_strike_limit]
-   consecutive strikes so a fresh fiber retries with a clean context.
-   Counter is reset on any successful turn (see [Ok updated] branch). *)
+   consecutive strikes so the supervisor pauses the keeper instead of
+   restarting into the same budget loop.
+
+   Counter is in-memory for the common same-server case and is reset on
+   any successful turn (see [Ok updated] branch). On first bump after a
+   process restart, callers may seed it from the persisted
+   [Oas_timeout_budget_loop] failure reason so restart cannot erase a
+   partially observed loop. *)
 let consecutive_budget_exhaustions : (string, int) Hashtbl.t =
   Hashtbl.create 16
 let consecutive_budget_exhaustions_mutex = Eio.Mutex.create ()
@@ -317,15 +323,19 @@ let oas_timeout_budget_strike_limit = 3
 let with_budget_exhaustions f =
   Eio.Mutex.use_rw ~protect:true consecutive_budget_exhaustions_mutex f
 
-let bump_budget_exhaustion ~keeper_name : int =
+let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes : int =
   with_budget_exhaustions (fun () ->
     let prior =
-      Hashtbl.find_opt consecutive_budget_exhaustions keeper_name
-      |> Option.value ~default:0
+      match Hashtbl.find_opt consecutive_budget_exhaustions keeper_name with
+      | Some strikes -> strikes
+      | None -> max 0 prior_strikes
     in
     let next = prior + 1 in
     Hashtbl.replace consecutive_budget_exhaustions keeper_name next;
     next)
+
+let bump_budget_exhaustion ~keeper_name : int =
+  bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes:0
 
 let reset_budget_exhaustion ~keeper_name : unit =
   with_budget_exhaustions (fun () ->

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -56,6 +56,8 @@ val reset_autonomous_completion_for_test : unit -> unit
     per keeper. Promoted to [Keeper_fiber_crash] at this limit. *)
 val oas_timeout_budget_strike_limit : int
 
+val bump_budget_exhaustion_seeded :
+  keeper_name:string -> prior_strikes:int -> int
 val bump_budget_exhaustion : keeper_name:string -> int
 val reset_budget_exhaustion : keeper_name:string -> unit
 val peek_budget_exhaustion_for_test : keeper_name:string -> int

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -9,6 +9,7 @@
      2. reset wipes the count back to 0
      3. distinct keeper names get independent counters
      4. set_for_test with strikes <= 0 is equivalent to remove
+     5. first bump can hydrate from persisted restart state
 *)
 
 open Masc_mcp
@@ -83,6 +84,21 @@ let test_set_zero_or_negative_removes () =
     "negative also removes" 0
     (KK.peek_budget_exhaustion_for_test ~keeper_name:k)
 
+let test_first_bump_hydrates_from_prior () =
+  let k = "zeta" in
+  reset_table k;
+  Alcotest.(check int)
+    "prior 2 becomes strike 3" 3
+    (KK.bump_budget_exhaustion_seeded ~keeper_name:k ~prior_strikes:2);
+  Alcotest.(check int)
+    "in-memory count wins after hydration" 4
+    (KK.bump_budget_exhaustion_seeded ~keeper_name:k ~prior_strikes:2);
+  reset_table k;
+  Alcotest.(check int)
+    "negative prior clamps to 0" 1
+    (KK.bump_budget_exhaustion_seeded ~keeper_name:k ~prior_strikes:(-9));
+  reset_table k
+
 (* The strike table is guarded by [Eio.Mutex], which requires an Eio
    fiber context. Run every case inside [Eio_main.run]. *)
 let in_eio f () = Eio_main.run (fun _env -> f ())
@@ -97,5 +113,7 @@ let () =
             (in_eio test_keepers_are_independent)
         ; Alcotest.test_case "set_for_test 0 or negative removes" `Quick
             (in_eio test_set_zero_or_negative_removes)
+        ; Alcotest.test_case "first bump hydrates from prior" `Quick
+            (in_eio test_first_bump_hydrates_from_prior)
         ] )
     ]


### PR DESCRIPTION
Summary
- hydrate oas_timeout_budget strike bumps from persisted Oas_timeout_budget_loop counts after process restart
- keep in-memory same-server behavior unchanged and reset on success
- add focused regression coverage for seeded first bump, table-wins behavior, and negative prior clamping

Validation
- scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe
- ./_build/default/test/test_oas_timeout_budget_strike.exe