### PR TITLE
fix(autoresearch): move git timeouts into exec SSOT

### DIFF
--- a/lib/autoresearch/autoresearch_git.ml
+++ b/lib/autoresearch/autoresearch_git.ml
@@ -24,7 +24,17 @@ let is_in_git_repo workdir =
 let exec_gate_raw_source argv =
   String.concat " " (List.map Filename.quote argv)
 
-let run_git_with_status ?(timeout_sec = 30.0) ~workdir argv =
+let git_meta_timeout_sec () =
+  Env_config_exec_timeout.timeout_sec
+    ~caller:Env_config_exec_timeout.Autoresearch_git_meta
+    ()
+
+let git_mutation_timeout_sec () =
+  Env_config_exec_timeout.timeout_sec
+    ~caller:Env_config_exec_timeout.Autoresearch_git_mutation
+    ()
+
+let run_git_with_status ?(timeout_sec = git_mutation_timeout_sec ()) ~workdir argv =
   let full_argv = "git" :: "-C" :: workdir :: argv in
   let raw_source = exec_gate_raw_source full_argv in
   Masc_exec.Exec_gate.run_argv_with_status
@@ -34,7 +44,7 @@ let run_git_with_status ?(timeout_sec = 30.0) ~workdir argv =
     ~timeout_sec
     full_argv
 
-let run_capture_lines ~workdir ?(timeout_sec = 30.0) argv =
+let run_capture_lines ~workdir ?(timeout_sec = git_mutation_timeout_sec ()) argv =
   let status, raw_output = run_git_with_status ~timeout_sec ~workdir argv in
   let lines =
     if String.length raw_output = 0 then []
@@ -48,7 +58,10 @@ let git_head_short ~workdir =
   if not (is_in_git_repo workdir) then None
   else
   let status, raw_output =
-    run_git_with_status ~timeout_sec:10.0 ~workdir [ "rev-parse"; "--short"; "HEAD" ]
+    run_git_with_status
+      ~timeout_sec:(git_meta_timeout_sec ())
+      ~workdir
+      [ "rev-parse"; "--short"; "HEAD" ]
   in
   match status with
   | Unix.WEXITED 0 ->
@@ -64,12 +77,15 @@ let git_commit ~workdir ~message
     Result.error "not inside a git repository"
   else
   let add_status, add_output =
-    run_git_with_status ~timeout_sec:30.0 ~workdir [ "add"; "--update" ]
+    run_git_with_status
+      ~timeout_sec:(git_mutation_timeout_sec ())
+      ~workdir
+      [ "add"; "--update" ]
   in
   match add_status with
   | Unix.WEXITED 0 -> (
     let check_status, _check_output =
-      run_git_with_status ~timeout_sec:30.0 ~workdir
+      run_git_with_status ~timeout_sec:(git_mutation_timeout_sec ()) ~workdir
         [ "diff"; "--cached"; "--quiet" ]
     in
     match check_status with
@@ -78,12 +94,17 @@ let git_commit ~workdir ~message
     Result.ok None
     | Unix.WEXITED 1 ->
     let status, raw_output =
-      run_git_with_status ~timeout_sec:30.0 ~workdir [ "commit"; "-m"; message ]
+      run_git_with_status
+        ~timeout_sec:(git_mutation_timeout_sec ())
+        ~workdir
+        [ "commit"; "-m"; message ]
     in
     (match status with
      | Unix.WEXITED 0 ->
        let hash_status, hash_output =
-         run_git_with_status ~timeout_sec:10.0 ~workdir
+         run_git_with_status
+           ~timeout_sec:(git_meta_timeout_sec ())
+           ~workdir
            [ "rev-parse"; "--short"; "HEAD" ]
        in
        (match hash_status with
@@ -109,7 +130,7 @@ let git_restore_head ~workdir =
   else
   (try
     let (status, _output) =
-      run_git_with_status ~timeout_sec:30.0 ~workdir
+      run_git_with_status ~timeout_sec:(git_mutation_timeout_sec ()) ~workdir
         [ "restore"; "--source=HEAD"; "--worktree"; "--"; "." ]
     in
     match status with
@@ -123,7 +144,7 @@ let git_reset_last ~workdir =
   else
   (try
     let (status, _output) =
-      run_git_with_status ~timeout_sec:30.0 ~workdir
+      run_git_with_status ~timeout_sec:(git_mutation_timeout_sec ()) ~workdir
         [ "reset"; "--soft"; "HEAD~1" ]
     in
     match status with
@@ -150,7 +171,7 @@ let git_tag_best ~workdir ~cycle ~score =
   let tag = Printf.sprintf "ar-best-c%d-%.4f" cycle score in
   (try
      let (_status, _output) =
-       run_git_with_status ~timeout_sec:10.0 ~workdir
+       run_git_with_status ~timeout_sec:(git_meta_timeout_sec ()) ~workdir
          [ "tag"; "-f"; tag ]
      in
      ()

--- a/lib/autoresearch/dune
+++ b/lib/autoresearch/dune
@@ -17,6 +17,7 @@
    fs_compat
    masc_log
    masc_core
+   masc_mcp.config
    masc_process
    masc_mcp.masc_exec
    agent_sdk

--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -28,7 +28,9 @@ type caller =
   | Status_detail             (** keeper_status_detail health probes (5/10s) *)
   | Turn_sandbox              (** keeper_turn_sandbox_runtime (2/5s) *)
   | Turn_up                   (** keeper_turn_up_create / _update sandbox (15s) *)
-  | Git_meta                  (** local git metadata (rev-parse, remote get-url) (5s) *)
+  | Git_meta                  (** local git metadata (rev-parse, remote get-url) (10s) *)
+  | Autoresearch_git_meta     (** autoresearch local git metadata reads (10s) *)
+  | Autoresearch_git_mutation (** autoresearch local git mutations (30s) *)
   | Shell_probe               (** PATH probes via [command -v] (2s) *)
   | Unknown of string
 
@@ -52,6 +54,8 @@ let caller_key = function
   | Turn_sandbox -> "turn_sandbox"
   | Turn_up -> "turn_up"
   | Git_meta -> "git_meta"
+  | Autoresearch_git_meta -> "autoresearch_git_meta"
+  | Autoresearch_git_mutation -> "autoresearch_git_mutation"
   | Shell_probe -> "shell_probe"
   | Unknown caller -> caller
 
@@ -73,6 +77,8 @@ let known_callers () =
     Turn_sandbox;
     Turn_up;
     Git_meta;
+    Autoresearch_git_meta;
+    Autoresearch_git_mutation;
     Shell_probe;
   ]
 
@@ -93,7 +99,8 @@ let known_default_sec = function
   | Pr_review_post -> Some 30.0
   | Dispatch -> Some 120.0
   | Memory_audit -> Some 3.0
-  | Git_meta -> Some 10.0
+  | Git_meta | Autoresearch_git_meta -> Some 10.0
+  | Autoresearch_git_mutation -> Some 30.0
   | Unknown _ -> None
 
 let upper_case s =

--- a/lib/config/env_config_exec_timeout.mli
+++ b/lib/config/env_config_exec_timeout.mli
@@ -31,6 +31,14 @@ type caller =
           that should complete in <1s; however, some sites invoke
           [git remote] over network-origin remotes where DNS and TLS
           add latency, so 10s provides a reasonable ceiling. *)
+  | Autoresearch_git_meta
+      (** Autoresearch local git metadata commands. Default 10.0s,
+          preserving the previous inline budget for rev-parse/tag
+          metadata reads inside the experiment loop. *)
+  | Autoresearch_git_mutation
+      (** Autoresearch local git mutation commands. Default 30.0s,
+          preserving the previous inline budget for add/commit/reset/
+          worktree cleanup inside managed experiment loops. *)
   | Shell_probe
       (** PATH availability probes (e.g. [command -v <name>]).
           Default 2.0s — pure OS lookup; longer timeouts mask

--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -35,6 +35,8 @@ let cases =
     E.Turn_sandbox, 2.0;
     E.Turn_up, 15.0;
     E.Git_meta, 10.0;
+    E.Autoresearch_git_meta, 10.0;
+    E.Autoresearch_git_mutation, 30.0;
     E.Shell_probe, 2.0;
   ]
 
@@ -118,6 +120,9 @@ let test_env_var_name_shape () =
   check string "Pr_review env var name"
     "MASC_EXEC_TIMEOUT_PR_REVIEW_SEC"
     (E.per_caller_env_var ~caller:E.Pr_review);
+  check string "Autoresearch git mutation env var name"
+    "MASC_EXEC_TIMEOUT_AUTORESEARCH_GIT_MUTATION_SEC"
+    (E.per_caller_env_var ~caller:E.Autoresearch_git_mutation);
   check string "Unknown env var name lowercases"
     "MASC_EXEC_TIMEOUT_FUTURE_X_SEC"
     (E.per_caller_env_var ~caller:(E.Unknown "future-x"))


### PR DESCRIPTION
Summary
- add typed exec-timeout callers for autoresearch git metadata and mutation operations
- route autoresearch git subprocess budgets through Env_config_exec_timeout instead of inline 10s/30s literals
- keep previous defaults pinned while enabling per-caller env overrides

Validation
- scripts/dune-local.sh build test/test_env_config_exec_timeout_10426.exe
- ./_build/default/test/test_env_config_exec_timeout_10426.exe