### PR TITLE
Fix admission snapshot inflight observability

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -97,6 +97,29 @@ let () = Admission_queue_metrics.set_max_concurrent global.max_slots
 let now_ts () = Unix.gettimeofday ()
 let wait_ms_since enqueue_ts = int_of_float ((now_ts () -. enqueue_ts) *. 1000.0)
 
+let bump_active delta =
+  Eio.Mutex.use_rw ~protect:true global.mutex (fun () ->
+    global.active <- max 0 (global.active + delta))
+
+let with_inflight_observation ~keeper_name ~cascade_name f =
+  bump_active 1;
+  (match
+     Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0
+   with
+   | () -> ()
+   | exception exn ->
+       bump_active (-1);
+       raise exn);
+  Fun.protect
+    ~finally:(fun () ->
+      (match Admission_queue_metrics.on_release ~keeper_name ~cascade_name with
+       | () -> ()
+       | exception exn ->
+           bump_active (-1);
+           raise exn);
+      bump_active (-1))
+    f
+
 (* ── Public API ────────────────────────────────────────── *)
 
 (* #10745: track previous rejection per keeper so successive rejection
@@ -160,29 +183,16 @@ let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
          and handles 429/timeout by falling to the next provider.
          Gating here starves cloud-routed keepers behind a serial local
          decode and cannot express per-provider capacity.
-         Metric observation tracks real inflight even though gating is off.
+         Metric and snapshot observation track real inflight even though
+         gating is off.
          RFC-0026 PR-E-1.6/1.7; audit response 2026-05-05 §3.1. *)
-      Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0;
-      match f () with
-      | result ->
-        Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
-        Ok result
-      | exception exn ->
-        Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
-        raise exn
+      Ok (with_inflight_observation ~keeper_name ~cascade_name f)
 
 let try_with_permit ~priority:_ ~keeper_name ~cascade_name f =
   match check_host_resources ~keeper_name with
   | Error _ -> None
   | Ok () ->
-      Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0;
-      match f () with
-      | result ->
-        Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
-        Some result
-      | exception exn ->
-        Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
-        raise exn
+      Some (with_inflight_observation ~keeper_name ~cascade_name f)
 
 let snapshot () =
   Eio.Mutex.use_ro global.mutex (fun () ->
@@ -196,6 +206,8 @@ let snapshot_json () =
   let s = snapshot () in
   let now = now_ts () in
   `Assoc [
+    ("mode", `String "passthrough");
+    ("throttle_owner", `String "oas_cascade");
     ("max_concurrent", `Int s.max_concurrent);
     ("active", `Int s.active);
     ("available", `Int s.available);

--- a/lib/admission_queue.mli
+++ b/lib/admission_queue.mli
@@ -1,14 +1,13 @@
-(** Admission_queue — MASC-layer priority admission queue for inference calls.
+(** Admission_queue — MASC-layer admission observability for inference calls.
 
-    Sits between MASC callers and OAS Agent.run(). Provides:
-    - Configurable concurrency limits per queue partition
-    - Priority-aware FIFO scheduling (reuses OAS Request_priority ranking)
-    - Per-waiter metadata for observability (keeper_name, enqueue_ts)
-    - Cancel-safe via Eio.Promise + Atomic cancellation flag
+    Current runtime mode is passthrough: provider-level throttling and retry
+    ownership live in the OAS cascade layer. This module still records
+    MASC-visible inflight state, host-resource rejection, and the configured
+    capacity hint used by dashboards.
 
-    The implementation mirrors OAS Slot_scheduler semantics (priority sorted
-    waiter list, Eio.Promise blocking) at the MASC layer with MASC-visible
-    metadata.
+    The waiter metadata and priority helpers are retained as observability
+    scaffolding for the RFC-0026 cascade-layer admission router. They are not
+    an active MASC-side scheduler in the current call path.
 
     @since 3.0.0 *)
 
@@ -43,12 +42,12 @@ val with_permit :
   cascade_name:Keeper_cascade_profile.runtime_name ->
   (unit -> 'a) ->
   ('a, [> `Host_resource_saturated of string ]) result
-(** Acquire a permit, run [f], release permit on exit (normal or exception).
-    Returns [Error (`Host_resource_saturated msg)] if host FD count exceeds
-    the safety threshold. Otherwise returns [Ok (f ())].
+(** Run [f] in passthrough mode and record inflight observation for metrics
+    and snapshots. Returns [Error (`Host_resource_saturated msg)] if host FD
+    count exceeds the safety threshold. Otherwise returns [Ok (f ())].
 
-    Emits Prometheus metrics via [Admission_queue_metrics] on
-    enqueue/dequeue/acquire/release. *)
+    No MASC-side concurrency gate is applied here; OAS cascade owns provider
+    capacity, retry, and timeout behavior. *)
 
 val try_with_permit :
   priority:Llm_provider.Request_priority.t ->
@@ -65,9 +64,8 @@ val snapshot_json : unit -> Yojson.Safe.t
 (** JSON representation of [snapshot] for dashboard/MCP consumption. *)
 
 val set_max_concurrent : int -> unit
-(** Runtime reconfiguration. If lowered while permits are active,
-    no permits are revoked — new acquires block until active drops
-    below the new limit.
+(** Runtime reconfiguration of the dashboard capacity hint. In passthrough
+    mode this does not block new calls or revoke active calls.
 
     @raise Invalid_argument if [n < 1]. *)
 

--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -24,14 +24,17 @@ let test_with_permit_runs () =
 
 let test_with_permit_propagates_exception () =
   Eio_main.run (fun _env ->
-    match
+    AQ.reset_for_test ~max_slots:3;
+    (match
       AQ.with_permit ~priority:Interactive
         ~keeper_name:"test" ~cascade_name:(cascade_name "test")
         (fun () -> failwith "boom")
     with
     | Ok _ -> fail "should raise"
     | exception Failure msg -> check string "exception propagates" "boom" msg
-    | Error _ -> fail "unexpected error")
+    | Error _ -> fail "unexpected error");
+    let s = AQ.snapshot () in
+    check int "active not leaked after exception" 0 s.active)
 
 let test_try_always_succeeds () =
   Eio_main.run (fun _env ->
@@ -102,6 +105,32 @@ let test_wait_timeout_passthrough_no_leak () =
     check int "no leaked slots" 0 s.active;
     check int "queue cleared" 0 s.queue_depth)
 
+let test_snapshot_tracks_passthrough_inflight () =
+  Eio_main.run (fun _env ->
+    AQ.reset_for_test ~max_slots:3;
+    let started_p, started_r = Eio.Promise.create () in
+    let release_p, release_r = Eio.Promise.create () in
+    Eio.Fiber.both
+      (fun () ->
+         match AQ.with_permit ~priority:Background
+           ~keeper_name:"snapshot-active" ~cascade_name:(cascade_name "test")
+           (fun () ->
+             Eio.Promise.resolve started_r ();
+             Eio.Promise.await release_p)
+         with
+         | Ok () -> ()
+         | Error _ -> fail "unexpected error")
+      (fun () ->
+         Eio.Promise.await started_p;
+         let s = AQ.snapshot () in
+         check int "active tracks running callback" 1 s.active;
+         check int "available subtracts active" 2 s.available;
+         check int "passthrough leaves queue empty" 0 s.queue_depth;
+         Eio.Promise.resolve release_r ());
+    let s = AQ.snapshot () in
+    check int "active returns to zero" 0 s.active;
+    check int "available restored" 3 s.available)
+
 (* ============================================================
    Configuration Tests
    ============================================================ *)
@@ -137,6 +166,14 @@ let test_snapshot_json_shape () =
     let json = AQ.snapshot_json () in
     match json with
     | `Assoc fields ->
+      let string_field name =
+        match List.assoc_opt name fields with
+        | Some (`String value) -> value
+        | _ -> failf "expected string field %s" name
+      in
+      check string "mode" "passthrough" (string_field "mode");
+      check string "throttle owner" "oas_cascade"
+        (string_field "throttle_owner");
       check bool "has max_concurrent" true
         (List.mem_assoc "max_concurrent" fields);
       check bool "has queue_depth" true
@@ -240,6 +277,8 @@ let () =
       test_case "concurrent all run" `Quick test_concurrent_all_run;
       test_case "wait timeout passthrough no leak" `Quick
         test_wait_timeout_passthrough_no_leak;
+      test_case "snapshot tracks passthrough inflight" `Quick
+        test_snapshot_tracks_passthrough_inflight;
     ];
     "config", [
       test_case "initial default" `Quick test_initial_max_concurrent_default;


### PR DESCRIPTION
## Summary
- track passthrough Admission_queue active count alongside metrics
- keep queue_depth/waiters passthrough-empty; no MASC admission gating is reintroduced
- expose snapshot_json mode/throttle_owner so dashboard consumers do not misread passthrough as idle capacity
- update the public .mli contract to match the OAS-owned throttling boundary
- add regression coverage for active/available while a callback is running and active cleanup after exceptions

## Why it matters
The 2026-05-05 dashboard/heuristic audit section 3 flagged Admission_queue.snapshot as operator-misleading: active stayed 0 and available stayed max while keepers were actually inside with_permit. This keeps OAS-owned provider throttling intact, but makes the MASC dashboard snapshot reflect live passthrough inflight work and explicitly labels the ownership boundary.

## Tests
- scripts/dune-local.sh build test/test_admission_queue_coverage.exe
- ./_build/default/test/test_admission_queue_coverage.exe (18 tests)