### PR TITLE
Fix closed PR CI cleanup workflow lookup

### DIFF
--- a/.github/workflows/ci-cancel-closed-pr.yml
+++ b/.github/workflows/ci-cancel-closed-pr.yml
@@ -27,7 +27,7 @@ jobs:
           for status in queued in_progress pending; do
             gh run list \
               --repo "$GITHUB_REPOSITORY" \
-              --workflow CI \
+              --workflow ci.yml \
               --event pull_request \
               --branch "$PR_HEAD_REF" \
               --status "$status" \


### PR DESCRIPTION
## Summary
- change Closed PR CI Cleanup to query the actual CI workflow file name, ci.yml
- keep the existing branch/headSha filtering and cancel behavior unchanged

## Why it matters
Merged PRs #13042 and #13048 both ran the closed-PR cleanup job after merge and failed with 'could not find any workflows named CI'. GitHub lists the workflow as .github/workflows/ci.yml / ci.yml, so the cleanup job was failing before it could inspect in-flight pull_request CI runs.

## Evidence
- gh workflow view ci.yml resolves workflow ID 224607590
- gh run list --workflow ci.yml --limit 1 returns the current CI workflow runs

## Tests
- git diff --check
- gh workflow view ci.yml
- gh run list --workflow ci.yml --limit 1 --json databaseId,workflowName,status,headBranch