### PR TITLE
fix: grant research keepers pr work surface

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -223,11 +223,11 @@ masc_groups = ["essential", "coding"]
 # Step 9 (bloodflow restoration plan): the research preset is granted
 # delivery-oriented capabilities so analyst/scholar/verifier-tier keepers
 # can do real work -- git clone, PR view/diff, PR create -- instead
-# of only sharing opinions on the board.  Keep raw filesystem edit out
-# of research; code edits should flow through the structured coding tools
-# and the risk-tiered approval gate in [keeper_routine_allowlist.ml].
+# of only sharing opinions on the board.  Filesystem writes and code edits
+# still flow through the risk-tiered approval gate in
+# [keeper_routine_allowlist.ml].
 [presets.research]
-groups = ["base", "filesystem", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review"]
+groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review"]
 masc_groups = ["essential", "coordination", "coding"]
 
 # Delivery preset: research + coding for keepers that need to produce code changes.


### PR DESCRIPTION
## Summary

- Grants the `research` tool preset the same delivery-class repo surface that the existing reachability test expects.
- Aligns the comment above `[presets.research]` with the actual policy: research keepers can use filesystem write, structured code, GitHub, and PR review surfaces, still behind the existing risk-tiered runtime gates.

## Product impact

Research keepers such as analyst, scholar, verifier, and velvet-hammer should not be limited to board-only opinions when the fleet objective requires real git/PR work. This keeps them able to inspect, create, push, review, and approve PR work through the same policy surface as delivery keepers.

## Evidence

- `scripts/dune-local.sh build ./bin/main_eio.exe`
- `scripts/dune-local.sh build test/test_persona_tool_reachability.exe`
- `./_build/default/test/test_persona_tool_reachability.exe`
- `git diff --check`
- Live server restarted from latest worktree and reports commit `3dd2256fa6`, 14 keeper fibers, 0 keeper config parse errors.

## Review evidence

Review focus: confirm the broader `research` preset is intentional. The specific issue is that the merged reachability test expects `filesystem_write`, while live TOML previously omitted it and left research keepers short of the stated PR-work surface.

## Linked issue

Follow-up from keeper fleet PR readiness work and the 14-keeper live-runtime objective.
