### PR TITLE
fix(keeper): map require_tool_use violation to blocker_class enum

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -183,6 +183,21 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   else if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
   then
     Some Turn_timeout
+  else if
+    (* 2026-05-05: Completion contract violations (e.g. require_tool_use)
+       were text-stamped to runtime.last_blocker but left
+       runtime.last_blocker_class null because [blocker_class_of_sdk_error]
+       returned None on the [Agent_sdk.Error.Agent
+       (CompletionContractViolation _)] path and the fallthrough to
+       [blocker_class_of_string] had no matching substring.  Variant
+       [Completion_contract_violation] was already defined in
+       [Keeper_types.blocker_class] — only the mapping was missing.
+       Affected 4/14 keepers in production (glm-coding-plan, janitor,
+       velvet-hammer, verifier) where dashboard "차단된 키퍼" card and
+       Prometheus blocker-class series were silent on this failure mode. *)
+    String_util.contains_substring_ci trimmed "completion contract"
+  then
+    Some Completion_contract_violation
   else
     None
 
@@ -211,6 +226,12 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | None -> (
       match err with
       | Agent_sdk.Error.Internal msg -> blocker_class_of_string msg
+      | Agent_sdk.Error.Agent
+          (Agent_sdk.Error.CompletionContractViolation _) ->
+          (* See note on [blocker_class_of_string] above; same gap, same
+             enum target.  Direct typed match preferred over text-substring
+             fallback when the SDK gave us a structured error. *)
+          Some Completion_contract_violation
       | _ -> None)
 
 (* ── Runtime blocker surface ───────────────────────────────── *)

--- a/test/dune
+++ b/test/dune
@@ -1084,6 +1084,7 @@
 (include stanzas/test_keeper_admission_runtime.inc)
 (include stanzas/test_keeper_alerting_path_norms.inc)
 (include stanzas/test_keeper_auto_pause_blocker_persist_12683.inc)
+(include stanzas/test_keeper_blocker_class_completion_contract.inc)
 (include stanzas/test_keeper_agent_run_sandbox_source.inc)
 (include stanzas/test_keeper_autoboot_supervisor_start_10125.inc)
 (include stanzas/test_keeper_cascade_auto_pause_task074.inc)

--- a/test/stanzas/test_keeper_blocker_class_completion_contract.inc
+++ b/test/stanzas/test_keeper_blocker_class_completion_contract.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_blocker_class_completion_contract)
+ (modules test_keeper_blocker_class_completion_contract)
+ (libraries masc_test_deps))

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -1,0 +1,90 @@
+(** 2026-05-05 — pin that [Keeper_status_bridge.blocker_class_of_string]
+    maps the [require_tool_use] completion contract violation message
+    (text-stamped to runtime.last_blocker by SDK error path) to the
+    [Completion_contract_violation] enum variant.
+
+    Pre-fix bug: 4/14 production keepers had
+    [last_blocker = "Completion contract [require_tool_use] violated: …"]
+    but [last_blocker_class = null], causing the dashboard "차단된 키퍼"
+    card and Prometheus blocker-class series to silently drop this
+    failure mode.  Variant existed in [Keeper_types.blocker_class] but
+    the bridge had no mapping. *)
+
+open Alcotest
+module KT = Masc_mcp.Keeper_types
+module B = Masc_mcp.Keeper_status_bridge
+
+let check_completion_contract_class label cls_opt =
+  match cls_opt with
+  | Some KT.Completion_contract_violation -> ()
+  | Some other ->
+      let other_str = KT.blocker_class_to_string other in
+      fail (Printf.sprintf "%s mapped to %s, expected Completion_contract_violation"
+              label other_str)
+  | None ->
+      fail (Printf.sprintf "%s returned None, expected Completion_contract_violation" label)
+
+let test_completion_contract_text_maps () =
+  let msg = "Completion contract [require_tool_use] violated: actionable \
+             keeper signal was present, but the model used \
+             keeper_stay_silent without typed no-work proof: \
+             keeper_stay_silent, keeper_tasks_list, keeper_board_list" in
+  check_completion_contract_class "require_tool_use full text"
+    (B.blocker_class_of_string msg)
+
+let test_completion_contract_short_text_maps () =
+  let msg = "completion contract violated" in
+  check_completion_contract_class "short lower-case form"
+    (B.blocker_class_of_string msg)
+
+let test_completion_contract_mixed_case_maps () =
+  let msg = "COMPLETION CONTRACT [require_tool_use] VIOLATED" in
+  check_completion_contract_class "upper-case form"
+    (B.blocker_class_of_string msg)
+
+let test_unrelated_text_returns_none () =
+  let msg = "some other unrelated keeper failure text" in
+  match B.blocker_class_of_string msg with
+  | None -> ()
+  | Some cls ->
+      let s = KT.blocker_class_to_string cls in
+      fail ("unrelated text mapped to " ^ s ^ ", expected None")
+
+let test_empty_text_returns_none () =
+  match B.blocker_class_of_string "" with
+  | None -> ()
+  | Some _ -> fail "empty string should return None"
+
+let test_existing_mappings_unchanged () =
+  (* Regression guard: adding the new arm must not perturb earlier branches. *)
+  match B.blocker_class_of_string "turn wall-clock timeout exceeded" with
+  | Some KT.Turn_timeout -> ()
+  | Some other ->
+      fail ("turn wall-clock timeout mapped to " ^ KT.blocker_class_to_string other)
+  | None -> fail "turn wall-clock timeout returned None"
+
+let () =
+  run "keeper_blocker_class_completion_contract"
+    [
+      ( "require_tool_use → Completion_contract_violation",
+        [
+          test_case "full SDK error text" `Quick
+            test_completion_contract_text_maps;
+          test_case "short lower-case form" `Quick
+            test_completion_contract_short_text_maps;
+          test_case "upper-case form" `Quick
+            test_completion_contract_mixed_case_maps;
+        ] );
+      ( "negative cases",
+        [
+          test_case "unrelated text returns None" `Quick
+            test_unrelated_text_returns_none;
+          test_case "empty text returns None" `Quick
+            test_empty_text_returns_none;
+        ] );
+      ( "regression guard",
+        [
+          test_case "existing turn-timeout mapping unchanged" `Quick
+            test_existing_mappings_unchanged;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

`Keeper_status_bridge.blocker_class_of_string` 와 `blocker_class_of_sdk_error` 에 `Completion contract [require_tool_use] violated` (Agent_sdk `CompletionContractViolation`) 분류 추가. 4/14 production keeper 가 text는 stamp 됐지만 `last_blocker_class = null` 였던 텔레메트리 gap fix.

## Background

Production runtime survey (`~/me/.masc/keepers/*.json`, 2026-05-05 05:30Z 기준):

| Keeper | last_blocker_class | last_blocker (text) |
|---|---|---|
| analyst | `stale_turn_timeout` ✓ | `stale_turn_timeout(idle_turn(303s))` |
| executor | `stale_turn_timeout` ✓ | `stale_turn_timeout(idle_turn(326s))` |
| issue_king | `stale_turn_timeout` ✓ | `stale_turn_timeout(idle_turn(306s))` |
| masc-improver | `stale_turn_timeout` ✓ | … |
| nick0cave | `stale_turn_timeout` ✓ | … |
| qa-king | `stale_turn_timeout` ✓ | … |
| ramarama | `stale_turn_timeout` ✓ | … |
| sangsu | `stale_turn_timeout` ✓ | … |
| scholar | `stale_turn_timeout` ✓ | … |
| taskmaster | `stale_turn_timeout` ✓ | … |
| **glm-coding-plan** | **null** ❌ | `Completion contract [require_tool_use] violated: …` |
| **janitor** | **null** ❌ | `Completion contract [require_tool_use] violated: …` |
| **velvet-hammer** | **null** ❌ | `Completion contract [require_tool_use] violated: …` |
| **verifier** | **null** ❌ | `Completion contract [require_tool_use] violated: …` |

10/14 keeper 는 stamp 정상. 4/14 는 text는 있는데 class enum 분류 누락.

## Root cause

- `Keeper_types.blocker_class` enum 에 `Completion_contract_violation` variant **이미 정의되어 있음** (keeper_types.mli:158-169).
- 하지만 `Keeper_status_bridge.blocker_class_of_sdk_error` 는 `Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation _)` 패턴 매칭 없음. fallthrough 로 `None` 반환.
- text fallback `blocker_class_of_string` 도 "completion contract" substring case 누락.
- 결과: enum 값은 정의됐지만 실제 매핑 사이트가 비어있어서 dashboard "차단된 키퍼" card 와 Prometheus blocker-class series 가 4 keeper 의 이 failure mode 를 silent 하게 drop.

## Fix

`lib/keeper/keeper_status_bridge.ml`:

1. `blocker_class_of_string` 에 `"completion contract"` substring case → `Some Completion_contract_violation` 추가.
2. `blocker_class_of_sdk_error` 의 fallthrough match 에 `Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation _)` arm 추가 → `Some Completion_contract_violation`.

두 경로 모두 cover (text-only path 는 외부 서비스가 raw error msg 를 patch 했을 때, structured path 는 SDK error variant 직접).

## Verification

- `dune build --root .` green.
- 새 test `test/test_keeper_blocker_class_completion_contract.ml` (6 cases):
  - full SDK error text → `Completion_contract_violation`
  - short lower-case form → `Completion_contract_violation`
  - upper-case form → `Completion_contract_violation`
  - unrelated text → `None`
  - empty text → `None`
  - regression: `turn wall-clock timeout` 기존 매핑 유지

## Why not new variant

`Completion_contract_violation` variant 가 이미 정의돼 있고 `blocker_class_to_string` / `blocker_class_of_serialized_string` round-trip 도 이미 wire 돼 있음 (`test_keeper_auto_pause_blocker_persist_12683.ml` 와 동일 패턴). 신규 variant 추가하면 모든 dispatch site 의 exhaustive match 깨짐. 단순 mapping 추가만으로 충분.

## What this does NOT do

- `keeper_stay_silent` 자체의 동작 변경 안 함 (그건 별도 RFC 영역).
- text 가 아예 없는 stamp site 만들지 않음 (기존 path 들 모두 정상 stamp 중).
- `Require_tool_use` vs 다른 contract type 구별 안 함 (모두 `Completion_contract_violation` 으로 묶임 — variant scope 가 contract family).

## Reference

- `Keeper_types.blocker_class` 정의: `lib/keeper/keeper_types.mli:158-169`
- 이전 sibling fix: PR #12877 (dashboard 차단된 키퍼 card), #12943 (force_unresolved_watchdog_crash stamp), #12683 (auto-pause blocker persist).

RFC-WAIVED: 단순 enum mapping fix, no identity/credential/RFC subsystem touched. workflow-pr.md item 11 의 keeper_credential / operator_control / sandbox 영역 X.

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
