### PR TITLE
fix: World Visualizer overview tab missing keeper fleet data

### DIFF
--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -355,7 +355,7 @@ export function WorldVisualizer() {
         </div>
       ` : html`
         <p class="mt-3 text-3xs text-[var(--color-fg-muted)] m-0">
-          keeper 플릿 데이터 대기 중 — SSE가 keeper 상태를 수신하면 자동으로 시각화됩니다.
+          keeper 플릿 데이터 대기 중 — 서버에서 keeper 상태를 수신하면 자동으로 시각화됩니다.
         </p>
       `}
     </div>

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -138,6 +138,7 @@ afterEach(() => {
 describe('dashboardSlicesForRoute', () => {
   it('keeps global shell namespace and transport slices on every route', () => {
     expect(dashboardSlicesForRoute({ tab: 'overview', params: {} })).toEqual([
+      'execution',
       'namespace',
       'shell',
       'transport',

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -158,6 +158,10 @@ function routeKey(routeState: DashboardRouteState): string {
 export function dashboardSlicesForRoute(routeState: DashboardRouteState): string[] {
   const slices = new Set(['shell', 'namespace', 'transport'])
 
+  // Overview tab needs execution slice for World Visualizer keeper fleet data.
+  if (routeState.tab === 'overview') {
+    slices.add('execution')
+  }
   if (routeState.tab === 'workspace' && routeState.params.section === 'planning') {
     slices.add('execution')
     slices.add('goals')

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -61,7 +61,7 @@ describe('refreshPlanForRoute', () => {
     expect(refreshPlanForRoute({
       tab: 'overview',
       params: {},
-    })).toEqual(['shell', 'namespaceTruth', 'missionSnapshot'])
+    })).toEqual(['shell', 'namespaceTruth', 'missionSnapshot', 'execution'])
   })
 
   it('uses the current monitoring sections', () => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -75,7 +75,7 @@ type RefreshTask =
 export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): RefreshTask[] {
   switch (routeState.tab) {
     case 'overview':
-      return ['shell', 'namespaceTruth', 'missionSnapshot']
+      return ['shell', 'namespaceTruth', 'missionSnapshot', 'execution']
     case 'monitoring':
       if (routeState.params.section === 'observatory') {
         return ['namespaceTruth', 'execution', 'missionSnapshot', 'observatory', 'activityGraph']


### PR DESCRIPTION
## Summary
- Subscribe overview tab to `execution` WS slice so World Visualizer receives keeper fleet data
- Add `execution` to overview tab's HTTP refresh plan in `refreshPlanForRoute`
- Fix misleading empty-state message ("SSE가" → "서버에서") since WS-only mode is default

## Root cause
`dashboardSlicesForRoute` omitted `execution` for overview tab, so the WS connection never
subscribed to execution deltas. Similarly, `refreshPlanForRoute` didn't trigger execution
HTTP fetch on overview navigation. Both paths are now fixed.

## Test plan
- [x] `dashboard-ws.test.ts` — updated assertion for overview slices
- [x] `tab-refresh.test.ts` — updated assertion for overview refresh plan
- [x] All 30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)