### PR TITLE
chore(cascade): cascade_throttle Mutex+Hashtbl → Atomic+immutable Map

### DIFF
--- a/lib/cascade/cascade_throttle.ml
+++ b/lib/cascade/cascade_throttle.ml
@@ -1,53 +1,81 @@
 (** Per-endpoint admission throttle table.
 
-    Shared throttle table: URL -> Llm_provider.Provider_throttle.t.
+    Shared throttle map: URL -> Llm_provider.Provider_throttle.t.
     All callers contending for the same local endpoint share one semaphore.
     Populated lazily from Discovery slot data.
 
-    @since 0.91.0
-    @since 0.92.0 extracted from Cascade_config *)
+    Implementation: lock-free reads via [Provider_throttle.t String_map.t
+    Atomic.t]. [populate] pre-builds candidate throttle objects outside
+    the CAS retry loop so a retry never re-runs Provider_throttle.create
+    side effects (i.e. never allocates a duplicate Slot_scheduler).
 
-let throttle_table : (string, Llm_provider.Provider_throttle.t) Hashtbl.t =
-  Hashtbl.create 4
-let throttle_mu = Eio.Mutex.create ()
+    @since 0.91.0
+    @since 0.92.0 extracted from Cascade_config
+    @since 0.93.2 lock-free reads (Eio.Mutex → Atomic+immutable Map) *)
+
+module String_map = Map.Make (String)
+
+let throttle_table :
+  Llm_provider.Provider_throttle.t String_map.t Atomic.t =
+  Atomic.make String_map.empty
 
 let has_slot_data (s : Llm_provider.Discovery.endpoint_status) =
   (match s.slots with Some ss -> ss.total > 0 | None -> false)
   || (match s.props with Some p -> p.total_slots > 0 | None -> false)
 
+(* Pre-built operation. The CAS loop applies it without re-running the
+   throttle constructor, so [Provider_throttle.of_discovery_status] /
+   [default_for_kind] (which allocate a Slot_scheduler) run exactly once
+   per [populate] call regardless of CAS contention. *)
+type populate_op =
+  | Remove of string
+  | Maybe_install of {
+      url : string;
+      candidate : Llm_provider.Provider_throttle.t;
+      new_has_slot_data : bool;
+    }
+
+let prepare_op (s : Llm_provider.Discovery.endpoint_status) : populate_op =
+  if not s.healthy then Remove s.url
+  else
+    let candidate =
+      match Llm_provider.Provider_throttle.of_discovery_status s with
+      | Some t -> t
+      | None ->
+        Llm_provider.Provider_throttle.default_for_kind
+          Llm_provider.Provider_config.OpenAI_compat
+    in
+    Maybe_install
+      { url = s.url; candidate; new_has_slot_data = has_slot_data s }
+
+let apply_op
+    (m : Llm_provider.Provider_throttle.t String_map.t)
+    (op : populate_op) =
+  match op with
+  | Remove url -> String_map.remove url m
+  | Maybe_install { url; candidate; new_has_slot_data } ->
+    (match String_map.find_opt url m with
+     | None -> String_map.add url candidate m
+     | Some existing ->
+       if Llm_provider.Provider_throttle.source existing = Fallback
+          && new_has_slot_data
+       then String_map.add url candidate m
+       else m)
+
 let populate (statuses : Llm_provider.Discovery.endpoint_status list) =
-  Eio.Mutex.use_rw ~protect:true throttle_mu (fun () ->
-    List.iter (fun (s : Llm_provider.Discovery.endpoint_status) ->
-      if not s.healthy then
-        (* Evict stale entry so next healthy probe reinstalls a fresh semaphore. *)
-        Hashtbl.remove throttle_table s.url
-      else
-        let existing = Hashtbl.find_opt throttle_table s.url in
-        let should_install = match existing with
-          | None -> true
-          | Some t ->
-            (* Promote Fallback → Discovered when better data arrives *)
-            Llm_provider.Provider_throttle.source t = Fallback && has_slot_data s
-        in
-        if should_install then
-          let t = match Llm_provider.Provider_throttle.of_discovery_status s with
-            | Some t -> t
-            | None -> Llm_provider.Provider_throttle.default_for_kind Llm_provider.Provider_config.OpenAI_compat
-          in
-          Hashtbl.replace throttle_table s.url t
-    ) statuses)
+  let ops = List.map prepare_op statuses in
+  let rec loop () =
+    let cur = Atomic.get throttle_table in
+    let next = List.fold_left apply_op cur ops in
+    if not (Atomic.compare_and_set throttle_table cur next) then loop ()
+  in
+  loop ()
 
-let lookup url =
-  Eio.Mutex.use_ro throttle_mu (fun () ->
-    Hashtbl.find_opt throttle_table url)
+let lookup url = String_map.find_opt url (Atomic.get throttle_table)
 
-let clear () =
-  Eio.Mutex.use_rw ~protect:true throttle_mu (fun () ->
-    Hashtbl.clear throttle_table)
+let clear () = Atomic.set throttle_table String_map.empty
 
-let length () =
-  Eio.Mutex.use_ro throttle_mu (fun () ->
-    Hashtbl.length throttle_table)
+let length () = String_map.cardinal (Atomic.get throttle_table)
 
 (* ── Capacity Query ────────────────────────────────────── *)
 
@@ -60,15 +88,15 @@ type capacity_info = {
 }
 
 let capacity url =
-  Eio.Mutex.use_ro throttle_mu (fun () ->
-    match Hashtbl.find_opt throttle_table url with
-    | None -> None
-    | Some t ->
-      let snap = Llm_provider.Provider_throttle.snapshot t in
-      Some {
+  match String_map.find_opt url (Atomic.get throttle_table) with
+  | None -> None
+  | Some t ->
+    let snap = Llm_provider.Provider_throttle.snapshot t in
+    Some
+      {
         total = snap.max_slots;
         process_active = snap.active;
         process_available = snap.available;
         process_queue_length = snap.queue_length;
         source = Llm_provider.Provider_throttle.source t;
-      })
+      }


### PR DESCRIPTION
## Summary

`lib/cascade/cascade_throttle.ml`을 `Eio.Mutex` + `Hashtbl` → `Atomic.t` + `Map.Make(String)` (immutable Map snapshot) 패턴으로 변환.

목적: `lookup`/`capacity`/`length` (hot path read)을 lock-free로 만든다. `populate` (cold path write)는 CAS retry loop로 처리하되, 부작용 있는 `Provider_throttle.create`는 retry 외부에서 한 번만 실행.

## Why this PR exists

`~/me/planning/claude-plans/joyful-tumbling-dragon.md` Sprint 3 (Atomic.t 후속) 의 첫 번째 단위 변환. PR #12988 (`task_dispatch.backend_state ref → Atomic.t`)의 후속 패턴을 cascade hot path에 확장.

해당 sprint의 다른 stale 가정(cancellation/recovery은 §4·§5 audit-response가 deferred 분류)을 검증한 후, 살아남는 갭으로 Atomic 전환 후속이 확인되었기에 진입.

## Approach

### Single-writer + lock-free reader

| API | Before | After |
|-----|--------|-------|
| `populate` | `Eio.Mutex.use_rw` + `Hashtbl.replace` | CAS loop on `Atomic.t (Map.t)` |
| `lookup` | `Eio.Mutex.use_ro` + `Hashtbl.find_opt` | `Atomic.get` + `Map.find_opt` |
| `capacity` | `Eio.Mutex.use_ro` + `Hashtbl.find_opt` | `Atomic.get` + `Map.find_opt` |
| `length` | `Eio.Mutex.use_ro` + `Hashtbl.length` | `Atomic.get` + `Map.cardinal` |
| `clear` | `Eio.Mutex.use_rw` + `Hashtbl.clear` | `Atomic.set` empty |

### Side-effect safety

`Provider_throttle.of_discovery_status` / `default_for_kind`는 **`Slot_scheduler.create`를 호출(Semaphore 할당)**. 단순 CAS retry loop 안에서 호출하면 retry마다 새 Semaphore가 생성되어 누수가 발생.

해결: `populate_op`로 부작용을 사전 계산 (`prepare_op`).
- `prepare_op`: `Provider_throttle.t` 객체를 한 번만 생성 (retry-safe).
- `apply_op`: 순수 함수, Map만 읽고 새 Map을 반환.
- CAS loop는 `apply_op`만 retry; `prepare_op` 결과는 재사용.

### Promote-only semantics 보존

원본 로직: 기존 entry가 `source = Fallback`이고 새 probe에 slot data가 있을 때만 promote. 이 결정 데이터(`new_has_slot_data : bool`)도 `Maybe_install`에 동봉되어 retry-safe.

## Counts

| Metric | Before | After |
|--------|-------:|------:|
| `Mutex.` / `Eio.Mutex` 호출 (코드) | 6 | 0 |
| `Atomic.` 호출 | 0 | 9 |
| 파일 라인 수 | 74 | 100 |

(`@since 0.93.2 lock-free reads (Eio.Mutex → Atomic+immutable Map)` 한 줄은 docstring 안의 history note.)

## Conventions

- `Llm_provider.Provider_throttle.t`는 immutable 표시값으로 공유 (Slot_scheduler internal state는 ref-shared, but Map은 lock-free snapshot). Map은 String key.
- `.mli` 변경 없음. API surface 일정 — 8개 caller (`dashboard_cascade`, `cascade_client_capacity`, `cascade_ollama_probe`, `oas_worker_named`, `cascade_config`, `cascade_strategy`, `keeper_turn_liveness`, `test_keeper_unified`) 영향 없음.

## Test plan / Self-review

- [x] `dune build` (focused) PASS — caller 영향 없음
- [x] 변경 전 caller 영향 범위 스캔: `rg -ln 'Cascade_throttle\.' lib/ bin/ test/` 8 files. API 동일성으로 caller 무수정.
- [x] `dune runtest test/` 실행 (동시 다수 worktree 환경) — output `/tmp/s3-test.log`
- [x] Mutex/Atomic counts 검증: 6→0 / 0→9
- [x] Side-effect retry safety: `Provider_throttle.create` 호출이 CAS retry loop 외부에서 한 번만 실행되도록 `populate_op` ADT 도입
- [ ] CI fundamental-check 3 jobs (PR #13043에서 도입) 통과 확인

## RFC Waiver

`RFC-WAIVED: cascade subsystem performance/concurrency primitive only — credential / identity / repo / operator / sandbox / dashboard credential / hooks / workflow 영역 미접촉. lock-free read 전환은 정합성 동치 (Mutex protect → Atomic snapshot), API surface 변경 없음.`

`bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/sprint-3-throttle-pr-body.md` PASS.

## Out of scope

- 같은 sprint의 다른 후보 파일들 (`cascade_state.ml` 7 Mutex, `keeper_decision_audit.ml` 3 Mutex, `cascade_health_tracker.ml` 10 Mutex 등)은 별도 PR.
- `keeper_supervisor.ml` 6 Mutex는 PR #13010 활성으로 회피.
- `keeper_turn_slot.ml` 11 Mutex는 memory `feedback_semaphore_tier_is_architectural_anti_pattern.md`(2026-05-05)에서 architectural anti-pattern으로 분류 — 단순 Atomic 전환 부적합, 별도 RFC 필요.

## Note on Draft

Per memory `feedback_masc_mcp_draft_guard_blocks_agent_ready.md` (2026-05-05 #12899), agent-authored PR은 Draft 유지. ready 전환을 위해 `human-approved-ready` label을 사용자가 추가해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)