### PR TITLE
fix(ci): unbreak ci.yml — env knob catalog drift gate YAML block indent (#13050 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,10 +539,7 @@ jobs:
           opam exec -- dune exec ./bin/env_knob_catalog.exe -- \
             docs/runtime-tunables.md
           if ! git diff --exit-code docs/runtime-tunables.md; then
-            echo "::error::docs/runtime-tunables.md is stale relative \
-to lib/config/env_config_*.ml. Run 'dune exec \
-./bin/env_knob_catalog.exe -- docs/runtime-tunables.md' locally and \
-commit the result."
+            echo "::error::docs/runtime-tunables.md is stale relative to lib/config/env_config_*.ml. Run 'dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md' locally and commit the result."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

PR #13050 fixed the cascade drift gate's `\<newline>column-1` pattern at line 529-530. **The same pattern exists in the env knob catalog drift gate (line 542-545) added in the same batch**. main has been workflow-file-failure since #13057 merge (~06:30 UTC), required check `CI Gate` is not registering, all open PRs BLOCKED.

## Diagnosis

```python
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
# yaml.scanner.ScannerError: while scanning a simple key
#   in "ci.yml", line 543, column 1
#   could not find expected ':'
#   in "ci.yml", line 544, column 1
```

Cause: `run: |` block contains a shell command with line continuation that dedents the continuation lines to column 1. YAML scanner reads the dedent as block scalar termination and expects a new top-level key.

```yaml
          if ! git diff --exit-code docs/runtime-tunables.md; then
            echo "::error::docs/runtime-tunables.md is stale relative \
to lib/config/env_config_*.ml. Run 'dune exec \         ← column 1
./bin/env_knob_catalog.exe -- docs/runtime-tunables.md' locally and \   ← column 1
commit the result."
            exit 1
          fi
```

## Fix

Collapse the continuation into a single long line. The CI error annotation renders as one line in the GitHub Actions UI regardless of source formatting (`::error::` is a single message).

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — no exception (was `ScannerError` at line 543).
- [x] No remaining same-pattern occurrences in ci.yml (`awk` scan for `\<newline>` followed by column-1 alpha).
- [x] No other workflow files affected.

## RFC Waiver

`RFC-WAIVED: ci.yml YAML syntax fix only — no semantic change to drift gate behavior, no credential / identity / repo / operator / sandbox area touched. Direct continuation of #13050 (RFC-waived) for an identical YAML pattern in the same merge batch. main blocker requires immediate fix.`

## Related

- #13050 — first half of this fix (cascade drift gate, line 529-530)
- #13057 — last successful main (just before #13050) — failure observed in main starting from #13057's merge time when CI started failing globally
- #13058 (mine) — currently BLOCKED by this same workflow-file-failure on main; will unblock once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)