### PR TITLE
feat(server): auto-repair empty active_goal_ids on keeper autoboot

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -586,6 +586,43 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       Log.Keeper.info
         "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
         config.base_path masc_root keeper_dir all_count;
+      (* 2026-05-05 — auto-repair active_goal_ids=[] keepers before boot.
+         Newer keepers (created via persona autoboot or
+         masc_keeper_create_from_persona) start with active_goal_ids=[] and
+         have no automatic path to populate it, so they enter a "frozen"
+         state where work_discovery runs but no desire fires (no goal →
+         keeper_stay_silent → completion contract violation, then
+         contract violation was previously class=null per #13055).
+         Keeper_goal_repair was previously only invokable via
+         masc_keeper_persona_audit(repair=true) MCP tool — manual operator
+         action.  Default-on so keepers self-heal on next server restart;
+         opt out with MASC_KEEPER_AUTO_GOAL_REPAIR=false.  Idempotent:
+         skips keepers that already have non-empty active_goal_ids. *)
+      let auto_repair_enabled =
+        match Sys.getenv_opt "MASC_KEEPER_AUTO_GOAL_REPAIR" with
+        | Some ("0" | "false" | "FALSE" | "off" | "OFF") -> false
+        | _ -> true
+      in
+      (if auto_repair_enabled then
+         try
+           let result = Keeper_goal_repair.run config in
+           let action_count = List.length result.actions in
+           let error_count = List.length result.errors in
+           let skipped_count = List.length result.skipped in
+           if action_count > 0 || error_count > 0 then
+             Log.Keeper.info
+               "autoboot: goal_repair created=%d errors=%d skipped=%d \
+                (set MASC_KEEPER_AUTO_GOAL_REPAIR=false to disable)"
+               action_count error_count skipped_count
+           else
+             Log.Keeper.info
+               "autoboot: goal_repair scanned, all keepers have \
+                active_goal_ids (skipped=%d)"
+               skipped_count
+         with exn ->
+           Log.Keeper.warn
+             "autoboot: goal_repair failed (continuing without repair): %s"
+             (Printexc.to_string exn));
       let names = Keeper_runtime.bootable_keeper_names config in
       let keeper_boot_ctx : _ Keeper_types.context = {
         config;


### PR DESCRIPTION
## Summary

Server autoboot (keeper_autoboot subsystem) 에서 keeper 부팅 직전 `Keeper_goal_repair.run` 자동 호출. 이전엔 `masc_keeper_persona_audit(repair=true)` MCP tool 의 manual operator 호출만 path였음. Default-on, opt-out via `MASC_KEEPER_AUTO_GOAL_REPAIR=false`.

## Background

2026-05-05 production runtime survey:

| Keeper | active_goal_ids | total_turns | last_speech_act | 상태 |
|---|---|---:|---|---|
| sangsu (4/29 생성) | 5 | 정상 | … | working |
| analyst (older) | … | 143 | … | working |
| **velvet-hammer (5/2 생성)** | **[]** | **7** | post_board | **frozen** |
| **verifier (5/2 생성)** | **[]** | **8** | post_board | **frozen** |

Mechanism (frozen):
1. Newer keeper 가 `active_goal_ids=[]` 으로 시작.
2. `Keeper_goal_repair.run` 가 비어있는 keeper 자동 발견 + goal 생성 + assign 기능 보유 (lib/keeper/keeper_goal_repair.ml, 128 LOC).
3. 그러나 caller 단 1곳: `tool_keeper.ml:1031-1036` 의 `masc_keeper_persona_audit` MCP tool 의 `repair=true` 인자.
4. supervisor / autoboot / heartbeat 자동 호출 없음 → 사용자가 명시 호출 안 하면 영원 stuck.
5. `work_discovery_enabled=null` 은 `keeper_world_observation.ml:898` 에서 default-enabled 처리되어 work_discovery 는 도는데, goal 없으면 desire 발동 불가 → `keeper_stay_silent` 만 가능 → completion contract violation.
6. (sibling fix #13055): contract violation 의 `last_blocker_class` enum 분류 누락 fix 됨 (visibility 회복).

## Fix

`lib/server/server_bootstrap_loops.ml` `keeper_autoboot` subsystem, `wait_for_lazy_startup` 직후 + keeper boot 직전:

- Env flag `MASC_KEEPER_AUTO_GOAL_REPAIR` 확인 (default-on, `false`/`0`/`off`로 opt-out).
- `Keeper_goal_repair.run config` 호출 (idempotent — 이미 active_goal_ids 있는 keeper 는 skip).
- 결과 logging: `goal_repair created=N errors=M skipped=K`.
- `try ... with exn ->` 로 보호 — repair 실패가 server boot 막지 않음.

총 변경 +35 LOC, 1 file.

## Why default-on

- 현재 production 4/14 keepers 가 frozen state. 사용자 명시 호출 누적 의존 = 운영 부담.
- Repair 동작 자체는 idempotent + safe (이미 goal 있는 keeper 는 skip). risk 없음.
- 실패 시 `Log.Keeper.warn` 하고 계속 — server boot fail-safe.
- Opt-out env var 로 기존 작업/실험에서 disable 가능.

## What this does NOT do

- Periodic auto-repair 추가 안 함 (server lifetime 동안 한 번만, autoboot 시점). 새 keeper 가 runtime 중 생성되는 케이스는 별도 후속 작업.
- Goal lifecycle 자체 변경 안 함 — 기존 `Keeper_goal_repair.run` 동작 그대로 사용.
- Velvet-hammer/verifier 만 repair 하는 것이 아니라, 모든 active_goal_ids=[] keeper 에 적용 (감지된 frozen pattern 의 root behavior fix).

## Verification

- `dune build --root .` green.
- 기존 `test/test_keeper_goal_repair.ml` 통과 (회귀 없음).
- 통합 테스트 (server boot + file system) 추가 안 함 — 이미 Keeper_goal_repair unit test 가 동작 검증 중. server_bootstrap_loops integration test 는 환경 setup 헤비 + 가치 낮음.

## Reference

- Sibling visibility fix: PR #13055 (last_blocker_class stamp gap).
- Memory: `~/.claude/projects/-Users-dancer-me/memory/project_keeper_active_goal_ids_empty_no_auto_repair.md`
- Existing repair caller: `lib/tool_keeper.ml:1031-1036` (manual MCP path).
- Repair impl: `lib/keeper/keeper_goal_repair.ml` (128 LOC, idempotent, well-tested).

RFC-WAIVED: lib/server/server_bootstrap_loops.ml 의 surgical addition (1 file, 35 LOC). Identity/credential/operator subsystem touched X. workflow-pr.md item 11 의 RFC subsystem list 외. Existing module (`Keeper_goal_repair`) 의 caller 1추가만 — 새 동작 introduce X (manual MCP path 와 동일 결과).

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
