### PR TITLE
fix(ci): update dangling spec ref in Cancellation.tla

### DIFF
--- a/specs/boundary/Cancellation.tla
+++ b/specs/boundary/Cancellation.tla
@@ -1,7 +1,7 @@
 ---- MODULE Cancellation ----
 \* Boundary spec for the keeper cancellation token (lib/cancellation.ml).
 \*
-\* Runtime truth (lib/cancellation.ml:150-160):
+\* Runtime truth (archived: lib/cancellation.ml):
 \*
 \*   let cancel ?(reason : string option) (token : token) : unit =
 \*     (* Write reason first, then atomically transition cancelled to true.


### PR DESCRIPTION
## Summary
- Remove dangling `lib/cancellation.ml:150-160` path ref from `specs/boundary/Cancellation.tla:4`
- PR #13044 archived `lib/cancellation.ml`, leaving this ref pointing to a nonexistent file
- Meta Guards `spec-line-refs` gate fails with exit 2 on any dangling ref, blocking all PRs

## Test plan
- [x] `bash scripts/lint/spec-line-refs.sh` → 0 dangling (was 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)