### PR TITLE
Fix resilience resource measurements and execution seam

### DIFF
--- a/lib/resilience/audit.ml
+++ b/lib/resilience/audit.ml
@@ -13,6 +13,7 @@ type category =
   | SpeculativeBranchStarted
   | SpeculativeBranchCompleted
   | SpeculativeWinnerSelected
+  | RecoveryClassified
   | RecoveryAttempted
   | RecoverySucceeded
   | RecoveryFailed
@@ -27,6 +28,7 @@ let category_to_string = function
   | SpeculativeBranchStarted -> "SpeculativeBranchStarted"
   | SpeculativeBranchCompleted -> "SpeculativeBranchCompleted"
   | SpeculativeWinnerSelected -> "SpeculativeWinnerSelected"
+  | RecoveryClassified -> "RecoveryClassified"
   | RecoveryAttempted -> "RecoveryAttempted"
   | RecoverySucceeded -> "RecoverySucceeded"
   | RecoveryFailed -> "RecoveryFailed"
@@ -41,6 +43,7 @@ let category_of_string = function
   | "SpeculativeBranchStarted" -> Some SpeculativeBranchStarted
   | "SpeculativeBranchCompleted" -> Some SpeculativeBranchCompleted
   | "SpeculativeWinnerSelected" -> Some SpeculativeWinnerSelected
+  | "RecoveryClassified" -> Some RecoveryClassified
   | "RecoveryAttempted" -> Some RecoveryAttempted
   | "RecoverySucceeded" -> Some RecoverySucceeded
   | "RecoveryFailed" -> Some RecoveryFailed

--- a/lib/resilience/audit.mli
+++ b/lib/resilience/audit.mli
@@ -73,6 +73,9 @@ type category =
       (** A speculative branch finished (won, lost, or aborted). *)
   | SpeculativeWinnerSelected
       (** A winning branch was committed and losers reaped. *)
+  | RecoveryClassified
+      (** A failure was classified and a default recovery strategy was
+          selected, but no concrete executor was configured. *)
   | RecoveryAttempted
       (** A {!Recovery.strategy} was selected and dispatched. *)
   | RecoverySucceeded

--- a/lib/resilience/keeper_bridge.ml
+++ b/lib/resilience/keeper_bridge.ml
@@ -152,29 +152,62 @@ let apply_post_turn_resilience
       let kind = error_mode_kind mode in
       let strategy = Recovery.default_strategy mode in
       let strategy_class = strategy_class_of_strategy strategy in
+      (* PR #13072 review (thread 4): durable audit must exist BEFORE
+         side-effecting callbacks run.  If [Shared_audit.Store.append]
+         raises on I/O after the executor already mutated state, the
+         side effect happens with no record.  Emit the [RecoveryAttempted]
+         envelope first when an executor is wired; the outcome envelope
+         (RecoverySucceeded/RecoveryFailed) is appended after the
+         executor returns. *)
+      let attempted_envelope_id =
+        match (audit_store, strategy_executor) with
+        | Some store, Some _ ->
+            let payload =
+              `Assoc
+                [
+                  ("error_kind", `String kind);
+                  ("strategy_class", `String strategy_class);
+                  ("strategy_execution",
+                   `Assoc [ ("status", `String "dispatching") ]);
+                  ("error_detail", `String err);
+                  ("now", `Float now);
+                ]
+            in
+            let envelope =
+              Shared_audit.Store.append store
+                ~category:(Audit.category_to_string Audit.RecoveryAttempted)
+                ~payload
+            in
+            Some envelope.Shared_audit.Envelope.id
+        | _ -> None
+      in
       let strategy_execution =
         execute_strategy_if_configured strategy_executor strategy
       in
       let strategy_execution_json =
         strategy_execution_to_json strategy_execution
       in
-      (* #13072: audit category SSOT.
-         - [RecoveryAttempted] is reserved for *dispatched* recovery —
-           an executor was wired and ran (success or failure).  Audit
-           consumers (lib/resilience/audit.mli:76-81) downstream of
-           [RecoveryAttempted] / [RecoverySucceeded] / [RecoveryFailed]
-           assume the strategy was actually invoked.
-         - When [strategy_executor] is omitted the recovery surface
-           was advertised but no dispatch occurred; emit under
-           [RecoveryClassified] instead so consumers that key off the
-           category do not over-count attempted dispatches. *)
-      let audit_category =
+      (* PR #13072 review (thread 3): map the outcome to its proper
+         category instead of collapsing every dispatched run under
+         [RecoveryAttempted].  Audit consumers can now key off the
+         enum.  [Strategy_execution_completed] success-shaped
+         outcomes (Retry succeeded, Fallback applied, Handoff
+         requested) → [RecoverySucceeded].  Failure-shaped outcomes
+         (Retry exhausted/fatal, Aborted) and the explicit
+         [Strategy_execution_failed] callback-failure path →
+         [RecoveryFailed].  [Strategy_execution_not_configured] still
+         maps to [RecoveryClassified] because no dispatch happened. *)
+      let outcome_category =
         match strategy_execution with
-        | Strategy_execution_not_configured ->
-            Audit.category_to_string Audit.RecoveryClassified
-        | Strategy_execution_completed _
-        | Strategy_execution_failed _ ->
-            Audit.category_to_string Audit.RecoveryAttempted
+        | Strategy_execution_not_configured -> Audit.RecoveryClassified
+        | Strategy_execution_completed (Recovery.RetrySucceeded _)
+        | Strategy_execution_completed (Recovery.FallbackApplied _)
+        | Strategy_execution_completed (Recovery.HandoffRequested _) ->
+            Audit.RecoverySucceeded
+        | Strategy_execution_completed (Recovery.RetryExhausted _)
+        | Strategy_execution_completed (Recovery.RetryFatal _)
+        | Strategy_execution_completed (Recovery.Aborted _)
+        | Strategy_execution_failed _ -> Audit.RecoveryFailed
       in
       let envelope_id =
         match audit_store with
@@ -188,13 +221,23 @@ let apply_post_turn_resilience
                   ("strategy_execution", strategy_execution_json);
                   ("error_detail", `String err);
                   ("now", `Float now);
+                  ( "attempted_envelope_id",
+                    match attempted_envelope_id with
+                    | None -> `Null
+                    | Some s -> `String s );
                 ]
             in
             let envelope =
               Shared_audit.Store.append store
-                ~category:audit_category ~payload
+                ~category:(Audit.category_to_string outcome_category)
+                ~payload
             in
             Some envelope.Shared_audit.Envelope.id
+      in
+      let envelope_id =
+        match envelope_id with
+        | Some _ -> envelope_id
+        | None -> attempted_envelope_id
       in
       let resilience_meta =
         `Assoc

--- a/lib/resilience/keeper_bridge.ml
+++ b/lib/resilience/keeper_bridge.ml
@@ -1,9 +1,9 @@
 (* Resilience keeper_bridge — Cycle 23 / Tier A6.
    Wires Recovery classifier into the keeper post-turn lifecycle for
-   classification + audit-envelope emission only; strategy execution
-   (Retry/Fallback/Handoff/Abort) is intentionally deferred — see
-   resilience_runtime.mli §Deferred and
-   docs/audit-responses/2026-05-05-dashboard-heuristic.md §4.
+   classification, optional callback-driven strategy execution, and
+   audit-envelope emission. The bridge never fabricates keeper actions:
+   callers must supply concrete Retry/Fallback/Handoff/Abort callbacks
+   before Recovery.execute_strategy can mutate anything.
    See keeper_bridge.mli for design rationale. *)
 
 (* ── Pure helpers ─────────────────────────────────────────────── *)
@@ -41,14 +41,20 @@ let running_witness = Resilience_witness
 
 (* ── Classification helpers ───────────────────────────────────── *)
 
+type strategy_execution =
+  | Strategy_execution_not_configured
+  | Strategy_execution_completed of Recovery.execution_outcome
+  | Strategy_execution_failed of string
+
 type apply_outcome = {
   working_context : Yojson.Safe.t option;
   resilience_meta : Yojson.Safe.t option;
   audit_envelope_id : string option;
+  strategy_execution : strategy_execution option;
 }
 
-let strategy_class_of_mode (mode : Recovery.error_mode) : string =
-  match Recovery.default_strategy mode with
+let strategy_class_of_strategy : type a. a Recovery.strategy -> string =
+  function
   | Recovery.Retry _ -> "Retry"
   | Recovery.Fallback _ -> "Fallback"
   | Recovery.Handoff _ -> "Handoff"
@@ -63,11 +69,71 @@ let error_mode_kind (mode : Recovery.error_mode) : string =
   | Recovery.ConsensusError _ -> "Consensus"
   | Recovery.DegradationRequired _ -> "DegradationRequired"
 
+let execution_outcome_to_json
+    (outcome : Recovery.execution_outcome) : Yojson.Safe.t =
+  match outcome with
+  | Recovery.RetrySucceeded { attempts } ->
+      `Assoc [ ("outcome", `String "retry_succeeded"); ("attempts", `Int attempts) ]
+  | Recovery.RetryExhausted { attempts; last_error } ->
+      `Assoc
+        [
+          ("outcome", `String "retry_exhausted");
+          ("attempts", `Int attempts);
+          ( "last_error",
+            match last_error with
+            | None -> `Null
+            | Some error -> `String error );
+        ]
+  | Recovery.RetryFatal { attempt; error } ->
+      `Assoc
+        [
+          ("outcome", `String "retry_fatal");
+          ("attempt", `Int attempt);
+          ("error", `String error);
+        ]
+  | Recovery.FallbackApplied { value; confidence_delta } ->
+      `Assoc
+        [
+          ("outcome", `String "fallback_applied");
+          ("value", `String value);
+          ("confidence_delta", `Float confidence_delta);
+        ]
+  | Recovery.HandoffRequested { message; preserve_state } ->
+      `Assoc
+        [
+          ("outcome", `String "handoff_requested");
+          ("message", `String message);
+          ("preserve_state", `Bool preserve_state);
+        ]
+  | Recovery.Aborted { reason } ->
+      `Assoc [ ("outcome", `String "aborted"); ("reason", `String reason) ]
+
+let strategy_execution_to_json = function
+  | Strategy_execution_not_configured ->
+      `Assoc [ ("status", `String "not_configured") ]
+  | Strategy_execution_completed outcome ->
+      `Assoc
+        [
+          ("status", `String "completed");
+          ("result", execution_outcome_to_json outcome);
+        ]
+  | Strategy_execution_failed error ->
+      `Assoc [ ("status", `String "failed"); ("error", `String error) ]
+
+let execute_strategy_if_configured strategy_executor strategy =
+  match strategy_executor with
+  | None -> Strategy_execution_not_configured
+  | Some executor -> (
+      match Recovery.execute_strategy executor strategy with
+      | Ok outcome -> Strategy_execution_completed outcome
+      | Error error -> Strategy_execution_failed error)
+
 (* ── Main pipeline ────────────────────────────────────────────── *)
 
 let apply_post_turn_resilience
     (_witness : running_valid_for_resilience)
     ?audit_store
+    ?strategy_executor
     ~(now : float)
     ~(working_context : Yojson.Safe.t option)
     ~(maybe_error : string option)
@@ -75,11 +141,23 @@ let apply_post_turn_resilience
   match maybe_error with
   | None ->
       (* Inert pass-through: no error to classify. *)
-      { working_context; resilience_meta = None; audit_envelope_id = None }
+      {
+        working_context;
+        resilience_meta = None;
+        audit_envelope_id = None;
+        strategy_execution = None;
+      }
   | Some err ->
       let mode = Recovery.classify_string err in
       let kind = error_mode_kind mode in
-      let strategy_class = strategy_class_of_mode mode in
+      let strategy = Recovery.default_strategy mode in
+      let strategy_class = strategy_class_of_strategy strategy in
+      let strategy_execution =
+        execute_strategy_if_configured strategy_executor strategy
+      in
+      let strategy_execution_json =
+        strategy_execution_to_json strategy_execution
+      in
       let envelope_id =
         match audit_store with
         | None -> None
@@ -89,6 +167,7 @@ let apply_post_turn_resilience
                 [
                   ("error_kind", `String kind);
                   ("strategy_class", `String strategy_class);
+                  ("strategy_execution", strategy_execution_json);
                   ("error_detail", `String err);
                   ("now", `Float now);
                 ]
@@ -104,6 +183,7 @@ let apply_post_turn_resilience
           [
             ("classified_kind", `String kind);
             ("default_strategy_class", `String strategy_class);
+            ("strategy_execution", strategy_execution_json);
             ("classified_at", `Float now);
             ( "audit_envelope_id",
               match envelope_id with
@@ -116,4 +196,5 @@ let apply_post_turn_resilience
         working_context = new_wc;
         resilience_meta = Some resilience_meta;
         audit_envelope_id = envelope_id;
+        strategy_execution = Some strategy_execution;
       }

--- a/lib/resilience/keeper_bridge.ml
+++ b/lib/resilience/keeper_bridge.ml
@@ -158,6 +158,24 @@ let apply_post_turn_resilience
       let strategy_execution_json =
         strategy_execution_to_json strategy_execution
       in
+      (* #13072: audit category SSOT.
+         - [RecoveryAttempted] is reserved for *dispatched* recovery —
+           an executor was wired and ran (success or failure).  Audit
+           consumers (lib/resilience/audit.mli:76-81) downstream of
+           [RecoveryAttempted] / [RecoverySucceeded] / [RecoveryFailed]
+           assume the strategy was actually invoked.
+         - When [strategy_executor] is omitted the recovery surface
+           was advertised but no dispatch occurred; emit under
+           [RecoveryClassified] instead so consumers that key off the
+           category do not over-count attempted dispatches. *)
+      let audit_category =
+        match strategy_execution with
+        | Strategy_execution_not_configured ->
+            Audit.category_to_string Audit.RecoveryClassified
+        | Strategy_execution_completed _
+        | Strategy_execution_failed _ ->
+            Audit.category_to_string Audit.RecoveryAttempted
+      in
       let envelope_id =
         match audit_store with
         | None -> None
@@ -174,7 +192,7 @@ let apply_post_turn_resilience
             in
             let envelope =
               Shared_audit.Store.append store
-                ~category:"RecoveryAttempted" ~payload
+                ~category:audit_category ~payload
             in
             Some envelope.Shared_audit.Envelope.id
       in

--- a/lib/resilience/keeper_bridge.mli
+++ b/lib/resilience/keeper_bridge.mli
@@ -21,9 +21,10 @@
       optional error string surfaced by the just-completed turn,
       classify it via {!Recovery.classify_string}, derive the
       canonical strategy class via {!Recovery.default_strategy},
-      append an audit envelope (when an audit store is supplied),
-      and return a [`Assoc] meta sub-tree to be merged into
-      [working_context["resilience_meta"]].
+      optionally execute it through caller-supplied concrete
+      callbacks, append an audit envelope (when an audit store is
+      supplied), and return a [`Assoc] meta sub-tree to be merged
+      into [working_context["resilience_meta"]].
 
     {1 Feature flag contract}
 
@@ -81,6 +82,18 @@ val running_witness : running_valid_for_resilience
 (** {1 Main pipeline} *)
 
 (** Outcome of {!apply_post_turn_resilience}. *)
+type strategy_execution =
+  | Strategy_execution_not_configured
+      (** No concrete executor was supplied. No retry, fallback,
+          handoff, or abort side effect was attempted. *)
+  | Strategy_execution_completed of Recovery.execution_outcome
+      (** The selected strategy was consumed by
+          {!Recovery.execute_strategy}. The outcome may still be a
+          terminal recovery result such as retry exhaustion; this
+          constructor means the executor itself ran to completion. *)
+  | Strategy_execution_failed of string
+      (** The executor failed before producing a recovery outcome. *)
+
 type apply_outcome = {
   working_context : Yojson.Safe.t option;
       (** Updated [`Assoc] working_context with the new
@@ -93,11 +106,15 @@ type apply_outcome = {
       (** Identifier of the audit envelope appended for this turn,
           if any. [None] when no error was classified or when the
           [audit_store] argument was [None]. *)
+  strategy_execution : strategy_execution option;
+      (** Strategy execution result for the classified error.
+          [None] only when [maybe_error] is [None]. *)
 }
 
 val apply_post_turn_resilience :
   running_valid_for_resilience ->
   ?audit_store:Shared_audit.Store.t ->
+  ?strategy_executor:Recovery.strategy_executor ->
   now:float ->
   working_context:Yojson.Safe.t option ->
   maybe_error:string option ->
@@ -110,6 +127,13 @@ val apply_post_turn_resilience :
     @param audit_store optional handle. When omitted, no audit
            envelope is written; the [audit_envelope_id] field is
            [None].
+    @param strategy_executor optional concrete strategy executor.
+           When omitted, the selected recovery strategy is not run and
+           both metadata and [strategy_execution] report
+           {!Strategy_execution_not_configured}. When supplied, this
+           bridge consumes the default strategy through
+           {!Recovery.execute_strategy}; all retry/fallback/handoff/abort
+           side effects belong to the executor callbacks.
     @param now wall-clock seconds since epoch. Recorded in both
            the audit payload and the meta sub-tree.
     @param working_context current [`Assoc kv] tree, or [None].
@@ -121,5 +145,5 @@ val apply_post_turn_resilience :
     Side effects:
     - Audit envelope appended to [audit_store] (when supplied and
       [maybe_error] is [Some _]).
-
-    No other state is mutated. Pure with respect to OCaml memory. *)
+    - Callback side effects performed by [strategy_executor] (when
+      supplied and [maybe_error] is [Some _]). *)

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -13,8 +13,9 @@ type error_mode =
   | PermanentError of { detail : string; fallback_strategy : fallback }
   | ResourceExhausted of {
       resource : [ `Tokens | `Time | `Cost | `Memory | `Disk ];
-      consumed : float;
-      limit : float;
+      consumed : float option;
+      limit : float option;
+      detail : string option;
     }
   | AmbiguityError of { detail : string; branches : string list }
   | ConsensusError of { detail : string; dissenters : string list }
@@ -77,7 +78,12 @@ let permanent ~detail ~fallback =
   PermanentError { detail; fallback_strategy = fallback }
 
 let resource_exhausted ~resource ~consumed ~limit =
-  ResourceExhausted { resource; consumed; limit }
+  ResourceExhausted
+    { resource; consumed = Some consumed; limit = Some limit; detail = None }
+
+let resource_exhausted_unknown ~resource ~detail =
+  ResourceExhausted
+    { resource; consumed = None; limit = None; detail = Some detail }
 
 let ambiguity ~detail ~branches = AmbiguityError { detail; branches }
 
@@ -135,7 +141,7 @@ let classify_string (s : string) : error_mode =
         resource_phrases
     with
     | Some (_, resource) ->
-        resource_exhausted ~resource ~consumed:0.0 ~limit:0.0
+        resource_exhausted_unknown ~resource ~detail:s
     | None -> permanent ~detail:s ~fallback:(HumanHandoff s)
 
 (* ── Default strategy selection ───────────────────────────────── *)
@@ -176,7 +182,7 @@ let default_strategy (mode : error_mode) :
                   detail msg;
               preserve_state = true;
             })
-  | ResourceExhausted { resource; consumed; limit } ->
+  | ResourceExhausted { resource; consumed; limit; detail } ->
       let resource_str =
         match resource with
         | `Tokens -> "Tokens"
@@ -185,12 +191,22 @@ let default_strategy (mode : error_mode) :
         | `Memory -> "Memory"
         | `Disk -> "Disk"
       in
+      let measurement =
+        match consumed, limit with
+        | Some consumed, Some limit ->
+            Printf.sprintf "consumed=%.2f limit=%.2f" consumed limit
+        | _ ->
+            match detail with
+            | Some detail ->
+                Printf.sprintf "measurement=unknown detail=%S" detail
+            | None -> "measurement=unknown"
+      in
       Abort
         {
           reason =
             Printf.sprintf
-              "ResourceExhausted: %s consumed=%.2f limit=%.2f"
-              resource_str consumed limit;
+              "ResourceExhausted: %s %s"
+              resource_str measurement;
           cleanup = (fun () -> ());
         }
   | AmbiguityError { detail; branches } ->

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -114,7 +114,16 @@ let execute_strategy : type a.
                 (RetryExhausted
                    { attempts = attempt; last_error = Some error })
             else
-              let delay_s = clamp_delay_s (backoff attempt) in
+              (* PR #13072 review: the strategy's [backoff] callback is
+                 part of the public [Retry.t] API and may raise (caller
+                 typo, integer overflow on attempt, etc.).  Without this
+                 trap the exception escaped and tore down the turn,
+                 instead of being converted into the [Error ...] that
+                 [execute_strategy]'s contract promises. *)
+              let* delay_s_raw =
+                trap_call ~op:"backoff" (fun () -> backoff attempt)
+              in
+              let delay_s = clamp_delay_s delay_s_raw in
               let* () =
                 on_event (RetryBackoff { attempt; delay_s; error })
               in

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -73,17 +73,38 @@ type strategy_executor = {
 let clamp_delay_s delay_s =
   if Float.is_finite delay_s then max 0.0 delay_s else 0.0
 
+(* #13072 — every executor callback (on_event, run_retry_attempt,
+   sleep, apply_fallback, request_handoff, abort) is foreign code
+   from this module's perspective; an exception escaping any of them
+   bypasses [keeper_bridge]'s [Strategy_execution_failed] audit and
+   tears down the keeper turn. Wrap each call in [trap] so executor
+   misbehaviour surfaces as [Error <string>] like the existing
+   [cleanup] arm in [Abort]. Keep this module independent from Eio;
+   cancellation-aware callers should encode cancellation in their
+   executor result rather than adding a scheduler dependency here. *)
+let trap_call ~op f =
+  match f () with
+  | exception exn ->
+      Error (Printf.sprintf "%s raised: %s" op (Printexc.to_string exn))
+  | v -> Ok v
+
 let execute_strategy : type a.
     strategy_executor ->
     a strategy ->
     (execution_outcome, string) result =
  fun executor strategy ->
+  let ( let* ) = Result.bind in
+  let on_event evt = trap_call ~op:"on_event" (fun () -> executor.on_event evt) in
   match strategy with
   | Retry { max_attempts; backoff } ->
       let max_attempts = max 1 max_attempts in
       let rec loop attempt =
-        executor.on_event (RetryAttempt { attempt; max_attempts });
-        match executor.run_retry_attempt ~attempt with
+        let* () = on_event (RetryAttempt { attempt; max_attempts }) in
+        let* outcome =
+          trap_call ~op:"run_retry_attempt" (fun () ->
+            executor.run_retry_attempt ~attempt)
+        in
+        match outcome with
         | Retry_success -> Ok (RetrySucceeded { attempts = attempt })
         | Fatal_failure error ->
             Ok (RetryFatal { attempt; error })
@@ -94,36 +115,51 @@ let execute_strategy : type a.
                    { attempts = attempt; last_error = Some error })
             else
               let delay_s = clamp_delay_s (backoff attempt) in
-              executor.on_event
-                (RetryBackoff { attempt; delay_s; error });
-              executor.sleep delay_s;
+              let* () =
+                on_event (RetryBackoff { attempt; delay_s; error })
+              in
+              let* () =
+                trap_call ~op:"sleep" (fun () -> executor.sleep delay_s)
+              in
               loop (attempt + 1)
       in
       loop 1
   | Fallback { fallback_value; degrade_confidence_by } ->
       let confidence_delta = degrade_confidence_by in
-      executor.on_event
-        (FallbackApply { value = fallback_value; confidence_delta });
+      let* () =
+        on_event (FallbackApply { value = fallback_value; confidence_delta })
+      in
+      let* applied =
+        trap_call ~op:"apply_fallback" (fun () ->
+          executor.apply_fallback ~value:fallback_value ~confidence_delta)
+      in
       Result.map
         (fun () ->
           FallbackApplied { value = fallback_value; confidence_delta })
-        (executor.apply_fallback ~value:fallback_value ~confidence_delta)
+        applied
   | Handoff { operator_message; preserve_state } ->
-      executor.on_event
-        (HandoffRequest { message = operator_message; preserve_state });
+      let* () =
+        on_event (HandoffRequest { message = operator_message; preserve_state })
+      in
+      let* requested =
+        trap_call ~op:"request_handoff" (fun () ->
+          executor.request_handoff ~message:operator_message ~preserve_state)
+      in
       Result.map
         (fun () ->
           HandoffRequested { message = operator_message; preserve_state })
-        (executor.request_handoff ~message:operator_message
-           ~preserve_state)
-  | Abort { reason; cleanup } -> (
-      match cleanup () with
-      | exception exn -> Error (Printexc.to_string exn)
-      | () ->
-          executor.on_event (AbortRun { reason });
-          Result.map
-            (fun () -> Aborted { reason })
-            (executor.abort ~reason))
+        requested
+  | Abort { reason; cleanup } ->
+      let* () =
+        trap_call ~op:"cleanup" (fun () -> cleanup ())
+      in
+      let* () = on_event (AbortRun { reason }) in
+      let* aborted =
+        trap_call ~op:"abort" (fun () -> executor.abort ~reason)
+      in
+      Result.map
+        (fun () -> Aborted { reason })
+        aborted
 
 (* TLA+ taxonomy mirrors for specs/resilience/ResilienceDegradation.tla.
    Payload-bearing constructors cannot use ppx_tla's [all_states], so

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -1,8 +1,7 @@
 (* Recovery — Cycle 23 / Tier B6.
-   Classification surface only; strategy execution (Retry/Fallback/Handoff/
-   Abort) is intentionally deferred — see resilience_runtime.mli §Deferred
-   and docs/audit-responses/2026-05-05-dashboard-heuristic.md §4.
-   See recovery.mli for the design rationale. *)
+   Classification plus callback-driven strategy execution. Keeper-turn
+   lifecycle integration remains outside this module; see recovery.mli for
+   the design rationale. *)
 
 type error_mode =
   | TransientError of {
@@ -39,6 +38,92 @@ type _ strategy =
       -> [> `Handoff ] strategy
   | Abort : { reason : string; cleanup : unit -> unit }
       -> [> `Abort ] strategy
+
+type retry_attempt_result =
+  | Retry_success
+  | Retryable_failure of string
+  | Fatal_failure of string
+
+type execution_event =
+  | RetryAttempt of { attempt : int; max_attempts : int }
+  | RetryBackoff of { attempt : int; delay_s : float; error : string }
+  | FallbackApply of { value : string; confidence_delta : float }
+  | HandoffRequest of { message : string; preserve_state : bool }
+  | AbortRun of { reason : string }
+
+type execution_outcome =
+  | RetrySucceeded of { attempts : int }
+  | RetryExhausted of { attempts : int; last_error : string option }
+  | RetryFatal of { attempt : int; error : string }
+  | FallbackApplied of { value : string; confidence_delta : float }
+  | HandoffRequested of { message : string; preserve_state : bool }
+  | Aborted of { reason : string }
+
+type strategy_executor = {
+  run_retry_attempt : attempt:int -> retry_attempt_result;
+  sleep : float -> unit;
+  on_event : execution_event -> unit;
+  apply_fallback :
+    value:string -> confidence_delta:float -> (unit, string) result;
+  request_handoff :
+    message:string -> preserve_state:bool -> (unit, string) result;
+  abort : reason:string -> (unit, string) result;
+}
+
+let clamp_delay_s delay_s =
+  if Float.is_finite delay_s then max 0.0 delay_s else 0.0
+
+let execute_strategy : type a.
+    strategy_executor ->
+    a strategy ->
+    (execution_outcome, string) result =
+ fun executor strategy ->
+  match strategy with
+  | Retry { max_attempts; backoff } ->
+      let max_attempts = max 1 max_attempts in
+      let rec loop attempt =
+        executor.on_event (RetryAttempt { attempt; max_attempts });
+        match executor.run_retry_attempt ~attempt with
+        | Retry_success -> Ok (RetrySucceeded { attempts = attempt })
+        | Fatal_failure error ->
+            Ok (RetryFatal { attempt; error })
+        | Retryable_failure error ->
+            if attempt >= max_attempts then
+              Ok
+                (RetryExhausted
+                   { attempts = attempt; last_error = Some error })
+            else
+              let delay_s = clamp_delay_s (backoff attempt) in
+              executor.on_event
+                (RetryBackoff { attempt; delay_s; error });
+              executor.sleep delay_s;
+              loop (attempt + 1)
+      in
+      loop 1
+  | Fallback { fallback_value; degrade_confidence_by } ->
+      let confidence_delta = degrade_confidence_by in
+      executor.on_event
+        (FallbackApply { value = fallback_value; confidence_delta });
+      Result.map
+        (fun () ->
+          FallbackApplied { value = fallback_value; confidence_delta })
+        (executor.apply_fallback ~value:fallback_value ~confidence_delta)
+  | Handoff { operator_message; preserve_state } ->
+      executor.on_event
+        (HandoffRequest { message = operator_message; preserve_state });
+      Result.map
+        (fun () ->
+          HandoffRequested { message = operator_message; preserve_state })
+        (executor.request_handoff ~message:operator_message
+           ~preserve_state)
+  | Abort { reason; cleanup } -> (
+      match cleanup () with
+      | exception exn -> Error (Printexc.to_string exn)
+      | () ->
+          executor.on_event (AbortRun { reason });
+          Result.map
+            (fun () -> Aborted { reason })
+            (executor.abort ~reason))
 
 (* TLA+ taxonomy mirrors for specs/resilience/ResilienceDegradation.tla.
    Payload-bearing constructors cannot use ppx_tla's [all_states], so

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -63,10 +63,13 @@ type error_mode =
           known correct). *)
   | ResourceExhausted of {
       resource : [ `Tokens | `Time | `Cost | `Memory | `Disk ];
-      consumed : float;
-      limit : float;
+      consumed : float option;
+      limit : float option;
+      detail : string option;
     }
-      (** Budget or capacity exhausted. *)
+      (** Budget or capacity exhausted. [consumed] and [limit] are [None]
+          when the classifier only has a free-form error string and no
+          trustworthy numeric measurement. *)
   | AmbiguityError of { detail : string; branches : string list }
       (** Two or more equally plausible interpretations; speculative
           execution is the recommended response when available. *)
@@ -136,7 +139,8 @@ val all_strategy_tla_symbols : string list
 val classify_string : string -> error_mode
 (** Best-effort classification of a free-form exception or error
     string. Returns [TransientError] for known retryable phrases
-    (timeout, rate limit, connection reset, temporary), and
+    (timeout, rate limit, connection reset, temporary),
+    [ResourceExhausted] with unknown measurement for resource phrases, and
     [PermanentError { fallback_strategy = HumanHandoff _ }]
     otherwise. *)
 
@@ -168,6 +172,11 @@ val resource_exhausted :
   resource:[ `Tokens | `Time | `Cost | `Memory | `Disk ] ->
   consumed:float ->
   limit:float ->
+  error_mode
+
+val resource_exhausted_unknown :
+  resource:[ `Tokens | `Time | `Cost | `Memory | `Disk ] ->
+  detail:string ->
   error_mode
 
 val ambiguity : detail:string -> branches:string list -> error_mode

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -24,6 +24,8 @@
       structured error is available.
     - {!default_strategy}: pick the canonical strategy for an
       [error_mode]. Callers may override with a custom strategy.
+    - {!execute_strategy}: consume a selected strategy through
+      concrete retry/fallback/handoff/abort callbacks.
 
     {1 Deferred to follow-up Tiers}
 
@@ -32,9 +34,10 @@
       deferred to keep this PR's dependency footprint inside
       [shared_types]. Tier A6 (resilience keeper_bridge) introduces
       this bridge as it actually consumes OAS errors at the seam.
-    - [resolve] / [auto_resolve]: Eio-driven execution of the
-      strategy. Deferred until Tier A11 binds [Resilience_audit]
-      and [Speculative.execute].
+    - Eio-driven keeper lifecycle binding for {!execute_strategy}.
+      The executor here consumes Retry/Fallback/Handoff/Abort through
+      caller-supplied callbacks; the keeper turn loop decides which concrete
+      operation to retry or which operator channel receives a handoff.
     - [Degrade] / [Speculate] strategy constructors and the
       [DegradationRequired]'s [recommended_level] type are
       retained as plain ints here; Tier A11 retypes them with no
@@ -160,6 +163,54 @@ val default_strategy : error_mode -> [ `Retry | `Fallback | `Handoff | `Abort ] 
     - [ConsensusError]              → [Handoff]
     - [DegradationRequired]         → [Handoff] (Degrade deferred
                                         until A11) *)
+
+(** {1 Strategy execution} *)
+
+type retry_attempt_result =
+  | Retry_success
+  | Retryable_failure of string
+  | Fatal_failure of string
+
+type execution_event =
+  | RetryAttempt of { attempt : int; max_attempts : int }
+  | RetryBackoff of { attempt : int; delay_s : float; error : string }
+  | FallbackApply of { value : string; confidence_delta : float }
+  | HandoffRequest of { message : string; preserve_state : bool }
+  | AbortRun of { reason : string }
+
+type execution_outcome =
+  | RetrySucceeded of { attempts : int }
+  | RetryExhausted of { attempts : int; last_error : string option }
+  | RetryFatal of { attempt : int; error : string }
+  | FallbackApplied of { value : string; confidence_delta : float }
+  | HandoffRequested of { message : string; preserve_state : bool }
+  | Aborted of { reason : string }
+
+type strategy_executor = {
+  run_retry_attempt : attempt:int -> retry_attempt_result;
+  sleep : float -> unit;
+  on_event : execution_event -> unit;
+  apply_fallback :
+    value:string -> confidence_delta:float -> (unit, string) result;
+  request_handoff :
+    message:string -> preserve_state:bool -> (unit, string) result;
+  abort : reason:string -> (unit, string) result;
+}
+
+val execute_strategy :
+  strategy_executor ->
+  'a strategy ->
+  (execution_outcome, string) result
+(** Execute the selected strategy by invoking caller-supplied side-effect
+    callbacks.
+
+    [Retry] calls [run_retry_attempt] until success, fatal failure, or
+    exhaustion. Retryable failures sleep for the strategy backoff before the
+    next attempt and emit [RetryAttempt]/[RetryBackoff] events.
+
+    [Fallback], [Handoff], and [Abort] invoke their corresponding callbacks.
+    [Abort] always runs the strategy cleanup before calling [abort]; cleanup
+    exceptions are returned as [Error] and no abort callback is invoked. *)
 
 (** {1 Convenience constructors for [error_mode]} *)
 

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -209,8 +209,11 @@ val execute_strategy :
     next attempt and emit [RetryAttempt]/[RetryBackoff] events.
 
     [Fallback], [Handoff], and [Abort] invoke their corresponding callbacks.
-    [Abort] always runs the strategy cleanup before calling [abort]; cleanup
-    exceptions are returned as [Error] and no abort callback is invoked. *)
+    [Abort] always runs the strategy cleanup before calling [abort].
+
+    Exceptions raised by executor callbacks are returned as [Error] so the
+    keeper bridge can audit [Strategy_execution_failed] instead of letting
+    callback bugs tear down the turn. *)
 
 (** {1 Convenience constructors for [error_mode]} *)
 

--- a/test/resilience/test_audit.ml
+++ b/test/resilience/test_audit.ml
@@ -14,6 +14,7 @@ let all_categories : A.category list =
     SpeculativeBranchStarted;
     SpeculativeBranchCompleted;
     SpeculativeWinnerSelected;
+    RecoveryClassified;
     RecoveryAttempted;
     RecoverySucceeded;
     RecoveryFailed;

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -258,7 +258,7 @@ let test_pipeline_writes_audit_when_store_supplied () =
   assert (List.length recent = 1);
   match recent with
   | [ env ] ->
-      assert (env.Shared_audit.Envelope.category = "RecoveryAttempted");
+      assert (env.Shared_audit.Envelope.category = "RecoveryClassified");
       assert (Some env.Shared_audit.Envelope.id = outcome.audit_envelope_id);
       let audit_status =
         match env.Shared_audit.Envelope.payload with
@@ -270,6 +270,28 @@ let test_pipeline_writes_audit_when_store_supplied () =
         | _ -> None
       in
       assert (audit_status = Some (`String "not_configured"))
+  | _ -> assert false
+
+let test_pipeline_writes_attempted_audit_when_executor_supplied () =
+  let tmp_dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_bridge_attempted_audit_%d" (Unix.getpid ()))
+  in
+  let store = Shared_audit.Store.create ~base_dir:tmp_dir in
+  let executor =
+    make_executor
+      ~request_handoff:(fun ~message:_ ~preserve_state:_ -> Ok ())
+      ()
+  in
+  let outcome =
+    KB.apply_post_turn_resilience witness ~audit_store:store
+      ~strategy_executor:executor ~now:7.0 ~working_context:None
+      ~maybe_error:(Some "completely unknown failure mode") ()
+  in
+  assert (Option.is_some outcome.audit_envelope_id);
+  match Shared_audit.Store.recent store ~n:1 with
+  | [ env ] ->
+      assert (env.Shared_audit.Envelope.category = "RecoveryAttempted")
   | _ -> assert false
 
 let () =
@@ -289,4 +311,5 @@ let () =
   test_pipeline_classifies_resource_token ();
   test_pipeline_upserts_into_working_context ();
   test_pipeline_writes_audit_when_store_supplied ();
+  test_pipeline_writes_attempted_audit_when_executor_supplied ();
   print_endline "test_keeper_bridge: all assertions passed"

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -272,7 +272,16 @@ let test_pipeline_writes_audit_when_store_supplied () =
       assert (audit_status = Some (`String "not_configured"))
   | _ -> assert false
 
-let test_pipeline_writes_attempted_audit_when_executor_supplied () =
+(* PR #13072 review (threads 3 + 4): when an executor is supplied,
+   two audit envelopes must be written:
+   - [RecoveryAttempted] pre-flight, BEFORE the executor's callbacks
+     run, so an I/O failure on the post-flight append still leaves a
+     durable record of the attempt;
+   - the outcome envelope ([RecoverySucceeded] / [RecoveryFailed])
+     after the executor returns, so audit consumers can key off the
+     category enum instead of parsing payloads. *)
+let test_pipeline_writes_attempted_then_outcome_audit_when_executor_supplied
+    () =
   let tmp_dir =
     Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "test_keeper_bridge_attempted_audit_%d" (Unix.getpid ()))
@@ -289,9 +298,49 @@ let test_pipeline_writes_attempted_audit_when_executor_supplied () =
       ~maybe_error:(Some "completely unknown failure mode") ()
   in
   assert (Option.is_some outcome.audit_envelope_id);
-  match Shared_audit.Store.recent store ~n:1 with
-  | [ env ] ->
-      assert (env.Shared_audit.Envelope.category = "RecoveryAttempted")
+  let recent = Shared_audit.Store.recent store ~n:2 in
+  assert (List.length recent = 2);
+  (* Most recent is the outcome (HandoffRequested → RecoverySucceeded);
+     older is the pre-flight RecoveryAttempted. *)
+  match recent with
+  | [ outcome_env; attempted_env ] ->
+      assert (
+        attempted_env.Shared_audit.Envelope.category = "RecoveryAttempted");
+      assert (
+        outcome_env.Shared_audit.Envelope.category = "RecoverySucceeded");
+      assert (
+        Some outcome_env.Shared_audit.Envelope.id
+        = outcome.audit_envelope_id)
+  | _ -> assert false
+
+(* PR #13072 review (thread 3): a callback-failure path
+   ([Strategy_execution_failed]) emits [RecoveryFailed], not
+   [RecoveryAttempted]. *)
+let test_pipeline_writes_recovery_failed_when_callback_fails () =
+  let tmp_dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_bridge_recovery_failed_%d" (Unix.getpid ()))
+  in
+  let store = Shared_audit.Store.create ~base_dir:tmp_dir in
+  let executor =
+    make_executor
+      ~request_handoff:(fun ~message:_ ~preserve_state:_ ->
+        Error "synthetic callback failure")
+      ()
+  in
+  let _ =
+    KB.apply_post_turn_resilience witness ~audit_store:store
+      ~strategy_executor:executor ~now:8.0 ~working_context:None
+      ~maybe_error:(Some "completely unknown failure mode") ()
+  in
+  let recent = Shared_audit.Store.recent store ~n:2 in
+  assert (List.length recent = 2);
+  match recent with
+  | [ outcome_env; attempted_env ] ->
+      assert (
+        attempted_env.Shared_audit.Envelope.category = "RecoveryAttempted");
+      assert (
+        outcome_env.Shared_audit.Envelope.category = "RecoveryFailed")
   | _ -> assert false
 
 let () =
@@ -311,5 +360,6 @@ let () =
   test_pipeline_classifies_resource_token ();
   test_pipeline_upserts_into_working_context ();
   test_pipeline_writes_audit_when_store_supplied ();
-  test_pipeline_writes_attempted_audit_when_executor_supplied ();
+  test_pipeline_writes_attempted_then_outcome_audit_when_executor_supplied ();
+  test_pipeline_writes_recovery_failed_when_callback_fails ();
   print_endline "test_keeper_bridge: all assertions passed"

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -1,6 +1,7 @@
 (* Cycle 23 / Tier A6 — Resilience.Keeper_bridge tests. *)
 
 module KB = Resilience.Keeper_bridge
+module R = Resilience.Recovery
 
 (* ─── masc_resilience_enabled ─────────────────────────────────── *)
 
@@ -69,6 +70,31 @@ let test_upsert_replaces_prior_resilience_meta () =
 
 let witness = KB.running_witness
 
+let make_executor
+    ?(run_retry_attempt = fun ~attempt:_ -> R.Retry_success)
+    ?(sleep = fun _ -> ())
+    ?(on_event = fun _ -> ())
+    ?(apply_fallback = fun ~value:_ ~confidence_delta:_ -> Ok ())
+    ?(request_handoff = fun ~message:_ ~preserve_state:_ -> Ok ())
+    ?(abort = fun ~reason:_ -> Ok ())
+    () =
+  {
+    R.run_retry_attempt = run_retry_attempt;
+    sleep;
+    on_event;
+    apply_fallback;
+    request_handoff;
+    abort;
+  }
+
+let strategy_execution_status = function
+  | Some (`Assoc kv) -> (
+      match List.assoc_opt "strategy_execution" kv with
+      | Some (`Assoc execution_kv) ->
+          List.assoc_opt "status" execution_kv
+      | _ -> None)
+  | _ -> None
+
 let test_pipeline_no_op_when_no_error () =
   let prev_wc = Some (`Assoc [ ("autonomous_meta", `String "x") ]) in
   let outcome =
@@ -77,7 +103,8 @@ let test_pipeline_no_op_when_no_error () =
   in
   assert (outcome.working_context = prev_wc);
   assert (outcome.resilience_meta = None);
-  assert (outcome.audit_envelope_id = None)
+  assert (outcome.audit_envelope_id = None);
+  assert (outcome.strategy_execution = None)
 
 let test_pipeline_classifies_transient () =
   let outcome =
@@ -91,6 +118,69 @@ let test_pipeline_classifies_transient () =
       let strat = List.assoc "default_strategy_class" kv in
       assert (strat = `String "Retry")
   | _ -> assert false
+
+let test_pipeline_marks_execution_not_configured () =
+  let outcome =
+    KB.apply_post_turn_resilience witness ~now:2.5 ~working_context:None
+      ~maybe_error:(Some "Connection timeout while fetching") ()
+  in
+  (match outcome.strategy_execution with
+   | Some KB.Strategy_execution_not_configured -> ()
+   | _ -> assert false);
+  assert
+    (strategy_execution_status outcome.resilience_meta
+     = Some (`String "not_configured"))
+
+let test_pipeline_executes_strategy_when_executor_supplied () =
+  let attempts = ref [] in
+  let sleeps = ref [] in
+  let executor =
+    make_executor
+      ~run_retry_attempt:(fun ~attempt ->
+        attempts := attempt :: !attempts;
+        if attempt < 2 then R.Retryable_failure "not yet"
+        else R.Retry_success)
+      ~sleep:(fun delay -> sleeps := delay :: !sleeps)
+      ()
+  in
+  let outcome =
+    KB.apply_post_turn_resilience witness ~strategy_executor:executor
+      ~now:2.75 ~working_context:None
+      ~maybe_error:(Some "Connection timeout while fetching") ()
+  in
+  (match outcome.strategy_execution with
+   | Some
+       (KB.Strategy_execution_completed
+          (R.RetrySucceeded { attempts = 2 })) ->
+       ()
+   | _ -> assert false);
+  assert (!attempts = [ 2; 1 ]);
+  assert (List.length !sleeps = 1);
+  assert
+    (strategy_execution_status outcome.resilience_meta
+     = Some (`String "completed"))
+
+let test_pipeline_reports_strategy_execution_failure () =
+  let executor =
+    make_executor
+      ~request_handoff:(fun ~message:_ ~preserve_state:_ ->
+        Error "operator channel unavailable")
+      ()
+  in
+  let outcome =
+    KB.apply_post_turn_resilience witness ~strategy_executor:executor
+      ~now:2.9 ~working_context:None
+      ~maybe_error:(Some "completely unknown failure mode") ()
+  in
+  (match outcome.strategy_execution with
+   | Some
+       (KB.Strategy_execution_failed
+          "operator channel unavailable") ->
+       ()
+   | _ -> assert false);
+  assert
+    (strategy_execution_status outcome.resilience_meta
+     = Some (`String "failed"))
 
 let test_pipeline_classifies_permanent_handoff () =
   let outcome =
@@ -169,7 +259,17 @@ let test_pipeline_writes_audit_when_store_supplied () =
   match recent with
   | [ env ] ->
       assert (env.Shared_audit.Envelope.category = "RecoveryAttempted");
-      assert (Some env.Shared_audit.Envelope.id = outcome.audit_envelope_id)
+      assert (Some env.Shared_audit.Envelope.id = outcome.audit_envelope_id);
+      let audit_status =
+        match env.Shared_audit.Envelope.payload with
+        | `Assoc kv -> (
+            match List.assoc_opt "strategy_execution" kv with
+            | Some (`Assoc execution_kv) ->
+                List.assoc_opt "status" execution_kv
+            | _ -> None)
+        | _ -> None
+      in
+      assert (audit_status = Some (`String "not_configured"))
   | _ -> assert false
 
 let () =
@@ -182,6 +282,9 @@ let () =
   test_upsert_replaces_prior_resilience_meta ();
   test_pipeline_no_op_when_no_error ();
   test_pipeline_classifies_transient ();
+  test_pipeline_marks_execution_not_configured ();
+  test_pipeline_executes_strategy_when_executor_supplied ();
+  test_pipeline_reports_strategy_execution_failure ();
   test_pipeline_classifies_permanent_handoff ();
   test_pipeline_classifies_resource_token ();
   test_pipeline_upserts_into_working_context ();

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -306,6 +306,21 @@ let test_execute_abort_runs_cleanup_before_abort () =
       assert (!events = [ "abort:budget exhausted"; "cleanup" ])
   | _ -> assert false
 
+let test_execute_callback_exception_becomes_error () =
+  let executor =
+    make_executor
+      ~on_event:(fun _ -> raise (Failure "event sink down"))
+      ()
+  in
+  let strategy =
+    R.Retry { max_attempts = 1; backoff = (fun _ -> 0.0) }
+  in
+  match R.execute_strategy executor strategy with
+  | Error msg ->
+      assert (contains msg "on_event raised");
+      assert (contains msg "event sink down")
+  | _ -> assert false
+
 let () =
   test_transient_default_args ();
   test_transient_explicit_args ();
@@ -332,4 +347,5 @@ let () =
   test_execute_fallback_applies_value ();
   test_execute_handoff_requests_operator ();
   test_execute_abort_runs_cleanup_before_abort ();
+  test_execute_callback_exception_becomes_error ();
   print_endline "test_recovery: all assertions passed"

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -2,6 +2,15 @@
 
 module R = Resilience.Recovery
 
+let contains haystack needle =
+  let h = String.length haystack in
+  let n = String.length needle in
+  let rec loop i =
+    i + n <= h
+    && (String.sub haystack i n = needle || loop (i + 1))
+  in
+  n = 0 || loop 0
+
 (* ─── Convenience constructors ────────────────────────────────── *)
 
 let test_transient_default_args () =
@@ -37,10 +46,10 @@ let test_resource_exhausted () =
     R.resource_exhausted ~resource:`Tokens ~consumed:1000.0 ~limit:500.0
   in
   match e with
-  | R.ResourceExhausted { resource; consumed; limit } ->
+  | R.ResourceExhausted { resource; consumed; limit; _ } ->
       assert (resource = `Tokens);
-      assert (consumed = 1000.0);
-      assert (limit = 500.0)
+      assert (consumed = Some 1000.0);
+      assert (limit = Some 500.0)
   | _ -> assert false
 
 let test_ambiguity_branches () =
@@ -89,7 +98,10 @@ let test_classify_resource_token () =
          match resource. But "budget" matches Cost first depending
          on iteration order — accept either resource. *)
       assert false
-  | R.ResourceExhausted _ -> ()
+  | R.ResourceExhausted { consumed; limit; detail; _ } ->
+      assert (consumed = None);
+      assert (limit = None);
+      assert (detail = Some "token budget exhausted")
   | _ -> assert false
 
 let test_classify_permanent_fallback () =
@@ -133,6 +145,15 @@ let test_strategy_for_resource_is_abort () =
   in
   match R.default_strategy mode with
   | R.Abort _ -> ()
+  | _ -> assert false
+
+let test_strategy_for_unknown_resource_does_not_fake_zeroes () =
+  let mode = R.classify_string "token budget exhausted" in
+  match R.default_strategy mode with
+  | R.Abort { reason; _ } ->
+      assert (contains reason "measurement=unknown");
+      assert (not (contains reason "consumed=0.00"));
+      assert (not (contains reason "limit=0.00"))
   | _ -> assert false
 
 let test_strategy_for_ambiguity_is_handoff () =
@@ -190,6 +211,7 @@ let () =
   test_strategy_for_permanent_default_string ();
   test_strategy_for_permanent_handoff ();
   test_strategy_for_resource_is_abort ();
+  test_strategy_for_unknown_resource_does_not_fake_zeroes ();
   test_strategy_for_ambiguity_is_handoff ();
   test_strategy_for_consensus_is_handoff ();
   test_strategy_for_degradation_is_handoff ();

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -195,6 +195,117 @@ let test_strategy_phantom_tags_compile () =
   in
   ()
 
+(* ─── Strategy execution ──────────────────────────────────────── *)
+
+let make_executor
+    ?(run_retry_attempt = fun ~attempt:_ -> R.Retry_success)
+    ?(sleep = fun _ -> ())
+    ?(on_event = fun _ -> ())
+    ?(apply_fallback = fun ~value:_ ~confidence_delta:_ -> Ok ())
+    ?(request_handoff = fun ~message:_ ~preserve_state:_ -> Ok ())
+    ?(abort = fun ~reason:_ -> Ok ())
+    () =
+  {
+    R.run_retry_attempt = run_retry_attempt;
+    sleep;
+    on_event;
+    apply_fallback;
+    request_handoff;
+    abort;
+  }
+
+let test_execute_retry_until_success () =
+  let attempts = ref [] in
+  let sleeps = ref [] in
+  let executor =
+    make_executor
+      ~run_retry_attempt:(fun ~attempt ->
+        attempts := attempt :: !attempts;
+        if attempt < 3 then R.Retryable_failure "not yet"
+        else R.Retry_success)
+      ~sleep:(fun delay -> sleeps := delay :: !sleeps)
+      ()
+  in
+  let strategy =
+    R.Retry { max_attempts = 3; backoff = (fun n -> float_of_int n *. 0.5) }
+  in
+  match R.execute_strategy executor strategy with
+  | Ok (R.RetrySucceeded { attempts = 3 }) ->
+      assert (!attempts = [ 3; 2; 1 ]);
+      assert (!sleeps = [ 1.0; 0.5 ])
+  | _ -> assert false
+
+let test_execute_retry_exhausted () =
+  let executor =
+    make_executor
+      ~run_retry_attempt:(fun ~attempt ->
+        R.Retryable_failure (Printf.sprintf "attempt-%d" attempt))
+      ()
+  in
+  let strategy =
+    R.Retry { max_attempts = 2; backoff = (fun _ -> 0.0) }
+  in
+  match R.execute_strategy executor strategy with
+  | Ok (R.RetryExhausted { attempts = 2; last_error = Some "attempt-2" }) ->
+      ()
+  | _ -> assert false
+
+let test_execute_fallback_applies_value () =
+  let applied = ref None in
+  let executor =
+    make_executor
+      ~apply_fallback:(fun ~value ~confidence_delta ->
+        applied := Some (value, confidence_delta);
+        Ok ())
+      ()
+  in
+  let strategy =
+    R.Fallback { fallback_value = "cached"; degrade_confidence_by = 0.25 }
+  in
+  match R.execute_strategy executor strategy with
+  | Ok (R.FallbackApplied { value = "cached"; confidence_delta }) ->
+      assert (Float.abs (confidence_delta -. 0.25) < 1e-9);
+      assert (!applied = Some ("cached", 0.25))
+  | _ -> assert false
+
+let test_execute_handoff_requests_operator () =
+  let requested = ref None in
+  let executor =
+    make_executor
+      ~request_handoff:(fun ~message ~preserve_state ->
+        requested := Some (message, preserve_state);
+        Ok ())
+      ()
+  in
+  let strategy =
+    R.Handoff { operator_message = "rotate token"; preserve_state = true }
+  in
+  match R.execute_strategy executor strategy with
+  | Ok (R.HandoffRequested { message = "rotate token"; preserve_state = true }) ->
+      assert (!requested = Some ("rotate token", true))
+  | _ -> assert false
+
+let test_execute_abort_runs_cleanup_before_abort () =
+  let events = ref [] in
+  let executor =
+    make_executor
+      ~abort:(fun ~reason ->
+        events := ("abort:" ^ reason) :: !events;
+        Ok ())
+      ()
+  in
+  let strategy =
+    R.Abort
+      {
+        reason = "budget exhausted";
+        cleanup = (fun () -> events := "cleanup" :: !events);
+      }
+  in
+  match R.execute_strategy executor strategy with
+  | Ok (R.Aborted { reason = "budget exhausted" }) ->
+      assert (!events = [ "abort:budget exhausted"; "cleanup" ])
+  | _ -> assert false
+
 let () =
   test_transient_default_args ();
   test_transient_explicit_args ();
@@ -216,4 +327,9 @@ let () =
   test_strategy_for_consensus_is_handoff ();
   test_strategy_for_degradation_is_handoff ();
   test_strategy_phantom_tags_compile ();
+  test_execute_retry_until_success ();
+  test_execute_retry_exhausted ();
+  test_execute_fallback_applies_value ();
+  test_execute_handoff_requests_operator ();
+  test_execute_abort_runs_cleanup_before_abort ();
   print_endline "test_recovery: all assertions passed"


### PR DESCRIPTION
## Summary
- stop minting fake `consumed=0.0` / `limit=0.0` values when `classify_string` only has a free-form resource exhaustion message
- represent `ResourceExhausted` measurements as optional values while keeping the existing `resource_exhausted ~consumed ~limit` constructor for structured callers
- add `Recovery.execute_strategy`, a callback-driven consumer for Retry/Fallback/Handoff/Abort strategies, with callback-exception trapping and regression coverage for retry success, retry exhaustion, fallback application, handoff request, abort cleanup, and callback failure
- wire `Keeper_bridge.apply_post_turn_resilience` to optionally consume the default strategy through caller-supplied concrete callbacks, and record `not_configured` / `completed` / `failed` execution status in both `resilience_meta` and the audit payload
- add typed `RecoveryClassified` audit category so classified-only recovery is not over-counted as dispatched `RecoveryAttempted`

## Why it matters
The 2026-05-05 dashboard/heuristic audit flagged `recovery.ml` in two places: invented resource exhaustion measurements and strategy values that were only created, not consumed. This keeps the staged resilience rollout honest: no fake numeric budget facts, no fake keeper actions, and a typed execution seam where the keeper loop can provide real retry/fallback/handoff/abort callbacks.

## Verification
- `git diff --check`
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build @test/resilience/runtest`

## Verification Notes
- Before the shared opam switch was repinned by another process, the branch also passed `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build @test/resilience/runtest` and `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build lib/masc_mcp.cmxa` on the prior live base.
- Current local broad `lib/masc_mcp.cmxa` validation is blocked by shared-switch churn outside this PR. `scripts/check-oas-pin.sh` reports local `agent_sdk` pin source drift (`e1244c9b` observed while this repo expects `86a0e540`), and another concurrent process is actively running `opam pin add agent_sdk ...#ec5fde5b...`. With `MASC_SKIP_PIN_CHECK=1`, the broad build then fails on missing/mismatched external modules (`Httpun`, `Httpun_ws`, `Agent_sdk`, `Llm_provider`, etc.), which is consistent with the opam switch being mid-upgrade/repin rather than a resilience compile error.
- CI should be treated as the clean-switch verification surface for the broad build on this draft PR.
