### PR TITLE
fix(ci): unbreak ci.yml — env knob catalog drift gate YAML block indent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,10 +539,7 @@ jobs:
           opam exec -- dune exec ./bin/env_knob_catalog.exe -- \
             docs/runtime-tunables.md
           if ! git diff --exit-code docs/runtime-tunables.md; then
-            echo "::error::docs/runtime-tunables.md is stale relative \
-to lib/config/env_config_*.ml. Run 'dune exec \
-./bin/env_knob_catalog.exe -- docs/runtime-tunables.md' locally and \
-commit the result."
+            echo "::error::docs/runtime-tunables.md is stale relative to lib/config/env_config_*.ml. Run 'dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md' locally and commit the result."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Same YAML block scalar break as #13050, but in the env knob catalog drift gate (line 543)
- Shell line continuation `\` in `echo "::error::..."` dropped indentation to column 0, making GitHub unable to parse the entire workflow file

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes
- [ ] CI runs on this PR (will confirm workflow file is parseable)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>