### PR TITLE
chore(dashboard): unexport internal-only helpers across 4 components

### DIFF
--- a/dashboard/src/components/add-repo-dialog.ts
+++ b/dashboard/src/components/add-repo-dialog.ts
@@ -47,7 +47,7 @@ export function openAddRepoDialog(): void {
   void loadCredentials()
 }
 
-export function closeAddRepoDialog(): void {
+function closeAddRepoDialog(): void {
   showAddRepoDialog.value = false
   resetForm()
 }

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -123,7 +123,7 @@ export function sanitizeOptionalString(value: string | null | undefined): string
   return trimmed === '' ? null : trimmed
 }
 
-export function shellQuote(value: string): string {
+function shellQuote(value: string): string {
   return `'${value.split("'").join("'\\''")}'`
 }
 

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -74,9 +74,8 @@ export function severityChipClass(code: number): string {
   }
 }
 
-// Map exit code to atomic Pill kind. Used by callers that have
-// migrated from the bespoke severityChipClass to the Pill primitive.
-export function severityPillKind(code: number): PillKind {
+// Map exit code to atomic Pill kind.
+function severityPillKind(code: number): PillKind {
   switch (severityForExitCode(code)) {
     case 'ok':
       return 'ok'
@@ -91,7 +90,7 @@ export function severityPillKind(code: number): PillKind {
 // Mirrors severityPillKind so the band tone and the pill tone always
 // match — the SPEC pattern is "card-level state strip + body status
 // pill" reading the same severity.
-export function severityBandKind(code: number): BandKind {
+function severityBandKind(code: number): BandKind {
   switch (severityForExitCode(code)) {
     case 'ok':
       return 'ok'
@@ -119,11 +118,11 @@ export function summaryLine(summary: DoctorSummary): string {
 }
 
 // Async resource — module-scoped so the same data is shared across any
-// surface that mounts the panel (follow-up PR).
-export const doctorEnvelope: AsyncResource<DoctorEnvelope> =
+// surface that mounts the panel.
+const doctorEnvelope: AsyncResource<DoctorEnvelope> =
   createAsyncResource()
 
-export function loadDoctor(): Promise<void> {
+function loadDoctor(): Promise<void> {
   return doctorEnvelope.load(() =>
     get<DoctorEnvelope>('/api/v1/dashboard/doctor'),
   )

--- a/dashboard/src/components/repo-sidebar.ts
+++ b/dashboard/src/components/repo-sidebar.ts
@@ -117,7 +117,7 @@ export async function deleteRepository(id: string): Promise<void> {
   }
 }
 
-export function selectRepo(id: string | null): void {
+function selectRepo(id: string | null): void {
   selectedRepoId.value = id
 }
 


### PR DESCRIPTION
## Summary
camelCase export caller-count audit 결과, 4개 컴포넌트의 7개 helper 가 export 키워드만 떼면 surface 정리 가능 (동작 변경 0). Tree-shake 효율 + 리뷰어 혼란 감소.

## Unexported (still callable inside its file)
- \`add-repo-dialog.ts:closeAddRepoDialog\` — 다이얼로그 backdrop/cancel/Esc 핸들러 내부 사용.
- \`repo-sidebar.ts:selectRepo\` — sidebar 행 클릭 핸들러 내부.
- \`credential-settings.ts:shellQuote\` — \`githubLoginCommand\` 내부.
- \`doctor-panel.ts:severityPillKind\` / \`severityBandKind\` — panel row renderer 내부. (주석에 \"callers that have migrated\" 라고 적혀있지만 실제 caller는 없음 → 주석도 같이 trim.)
- \`doctor-panel.ts:doctorEnvelope\` / \`loadDoctor\` — \`refreshDoctor\` 내부에서만 사용. \`tab-refresh.ts\` 가 dynamic-import 하는 것은 \`refreshDoctor\` 한 함수뿐.

## Out of scope (별도 follow-up)
- \`add-repo-dialog.ts:openAddRepoDialog\` — caller 0건. \"Add repo\" UI가 현재 navigation에서 unreachable한지 product 판단 필요. 본 PR은 mechanical surface 정리만.

## Verification
- \`tsc --noEmit\` clean.
- \`vitest run\` impacted (credential-settings / doctor-panel / repo-sidebar) → 3 file / 52 test pass.

## Test plan
- [x] tsc 통과
- [x] impacted vitest 통과
- [ ] CI green 후 ready 전환은 \`human-approved-ready\` label 흐름

🤖 Generated with [Claude Code](https://claude.com/claude-code)