### PR TITLE
fix(oas_compat): add on_retry / on_token_usage defaults — main blocker after #13062

### DIFF
--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -235,13 +235,23 @@ module Metrics = struct
   let default_error ~model_id:_ ~error:_ = ()
   let default_http_status ~provider:_ ~model_id:_ ~status:_ = ()
   let default_capability_drop ~model_id:_ ~field:_ = ()
+  (* agent_sdk 0.185.0 added [on_retry] and [on_token_usage] to
+     Llm_provider.Metrics.t.  PR #13062 bumped the pin to 0.190.1
+     in main, so the record now has 9 fields and these two must be
+     supplied.  Default to no-op so existing callers that only
+     supply legacy hooks keep compiling unchanged. *)
+  let default_retry ~provider:_ ~model_id:_ ~attempt:_ = ()
+  let default_token_usage ~provider:_ ~model_id:_ ~input_tokens:_
+      ~output_tokens:_ = ()
 
   let make ?(on_cache_hit = default_model_hook)
       ?(on_cache_miss = default_model_hook)
       ?(on_request_start = default_model_hook)
       ?(on_request_end = default_request_end) ?(on_error = default_error)
       ?(on_http_status = default_http_status)
-      ?(on_capability_drop = default_capability_drop) ()
+      ?(on_capability_drop = default_capability_drop)
+      ?(on_retry = default_retry)
+      ?(on_token_usage = default_token_usage) ()
       : Llm_provider.Metrics.t =
     {
       on_cache_hit;
@@ -251,5 +261,7 @@ module Metrics = struct
       on_error;
       on_http_status;
       on_capability_drop;
+      on_retry;
+      on_token_usage;
     }
 end

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -149,6 +149,12 @@ module Metrics : sig
     ?on_error:(model_id:string -> error:string -> unit) ->
     ?on_http_status:(provider:string -> model_id:string -> status:int -> unit) ->
     ?on_capability_drop:(model_id:string -> field:string -> unit) ->
+    ?on_retry:(provider:string -> model_id:string -> attempt:int -> unit) ->
+    ?on_token_usage:(provider:string ->
+                     model_id:string ->
+                     input_tokens:int ->
+                     output_tokens:int ->
+                     unit) ->
     unit ->
     Llm_provider.Metrics.t
   (** Construct a [Llm_provider.Metrics.t] value.


### PR DESCRIPTION
## Summary

**Main blocker hotfix.** PR #13062 bumped the `agent_sdk` opam pin
to 0.190.1, which carries 0.185.0's addition of `on_retry` and
`on_token_usage` fields to `Llm_provider.Metrics.t`. After
`74c0121429 chore(oas): bump agent sdk pin to 0.190.1` landed,
`lib/oas_compat/oas_compat.ml` still constructs the record literal
without these fields:

```
File "lib/oas_compat/oas_compat.ml", lines 246-254, characters 4-5:
246 | ....{
247 |       on_cache_hit;
...
253 |       on_capability_drop;
254 |     }
Error: Some record fields are undefined: on_retry on_token_usage
```

Any non-cached compile of `masc_mcp` now fails.

## Fix

Add no-op `default_retry` / `default_token_usage` and thread them
through `Metrics.make` + the `.mli` signature. 7 → 9 optional args.

```ocaml
let default_retry ~provider:_ ~model_id:_ ~attempt:_ = ()
let default_token_usage ~provider:_ ~model_id:_ ~input_tokens:_
    ~output_tokens:_ = ()
```

The .mli rationale already calls out this exact case:

> "Construct a `Llm_provider.Metrics.t` value. Each callback is
> optional; unset callbacks and any OAS fields MASC does not
> consume receive no-op defaults. Adding a new field upstream
> forces an update in exactly one place — this module — rather
> than at every record-literal site."

So this is the single site that needed editing.

## Why no-op (not Prometheus-wired)

`on_retry` and `on_token_usage` are observability hooks. MASC
doesn't currently surface either. If a host wants those metrics it
can pass `~on_retry` / `~on_token_usage` explicitly when calling
`Metrics.make`. Wiring them to `lib/prometheus.ml` is out of scope
for an unblocking hotfix — that should be a deliberate separate PR
after operators decide which Prometheus counters to define.

## Verification

- `dune build --root . lib/oas_compat` clean.
- Full-tree `dune build --root .` still surfaces the separate
  "make inconsistent assumptions over interface Types" cascade
  tracked in #13073 (unrelated to this fix; pre-existing).
- `lib/` grep confirms `oas_compat.ml::Metrics.make` is the only
  `Llm_provider.Metrics.t` record literal in the codebase, so no
  other call sites need editing.

## Changes

| File | LOC | Purpose |
|------|----:|---------|
| `lib/oas_compat/oas_compat.ml` | +12 / −0 | 2 default no-ops + 2 optional args + 2 record fields |
| `lib/oas_compat/oas_compat.mli` | +7 / −1 | Signature update |

Total: 2 files, +19 / −1.

## Linked

- PR #13062 — `chore(oas): bump agent sdk pin to 0.190.1` (the
  trigger)
- Issue #13073 — separate `lib/types` facade collision (still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
