### PR TITLE
Refactor: Extract timeout literals to configuration (#10426)

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -138,7 +138,7 @@ let run_cli_agent ~agent_type ~prompt =
         ~actor:"system/auto_responder"
         ~raw_source
         ~summary:"auto responder cli spawn"
-        ~timeout_sec:120.0
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Auto_responder ())
         ~stdin_content:prompt
         argv
     in

--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -205,7 +205,7 @@ let sync_to_graphql (f : finding) : (bool, string) result =
     ("confidence", `String (confidence_to_string f.confidence));
     ("tags", `List (List.map (fun t -> `String t) f.tags));
   ] in
-  match Graphql_client.mutate ~timeout_sec:10.0 ~mutation ~variables () with
+  match Graphql_client.mutate ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Graphql ()) ~mutation ~variables () with
   | Ok _ -> Ok true
   | Error msg ->
     Log.Keeper.warn "Finding GraphQL sync failed (non-fatal): %s" msg;

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -47,7 +47,7 @@ let git_capture_output ~repo_root args =
       ~actor:"system/build_identity"
       ~raw_source
       ~summary:"build identity git probe"
-      ~timeout_sec:5.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Build_identity ())
       argv
   with
   | Unix.WEXITED 0, output -> Some output

--- a/lib/chronicle_ingest.ml
+++ b/lib/chronicle_ingest.ml
@@ -37,7 +37,7 @@ let run_git ~timeout_sec ~workdir args =
          ~timeout_sec argv)
 
 let run_git_output ~workdir args =
-  match run_git ~timeout_sec:15.0 ~workdir args with
+  match run_git ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ()) ~workdir args with
   | Some (Unix.WEXITED 0, output) -> Some output
   | _ -> None
 

--- a/lib/chronicle_validate.ml
+++ b/lib/chronicle_validate.ml
@@ -39,7 +39,7 @@ let run_git ~timeout_sec ~workdir args =
          ~timeout_sec argv)
 
 let run_git_output ~workdir args =
-  match run_git ~timeout_sec:15.0 ~workdir args with
+  match run_git ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ()) ~workdir args with
   | Some (Unix.WEXITED 0, output) -> Some output
   | _ -> None
 

--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -31,7 +31,17 @@ type caller =
   | Git_meta                  (** local git metadata (rev-parse, remote get-url) (10s) *)
   | Autoresearch_git_meta     (** autoresearch local git metadata reads (10s) *)
   | Autoresearch_git_mutation (** autoresearch local git mutations (30s) *)
-  | Shell_probe               (** PATH probes via [command -v] (2s) *)
+  | Shell_probe
+  | Graphql
+  | Http
+  | Startup
+  | Auto_responder
+  | Build_identity
+  | Voice
+  | Coord_identity
+  | Dashboard
+  | Http_routes
+  | Test               (** PATH probes via [command -v] (2s) *)
   | Unknown of string
 
 (** Hardcoded default seconds for each known caller.  Preserves
@@ -56,7 +66,17 @@ let caller_key = function
   | Git_meta -> "git_meta"
   | Autoresearch_git_meta -> "autoresearch_git_meta"
   | Autoresearch_git_mutation -> "autoresearch_git_mutation"
-  | Shell_probe -> "shell_probe"
+  | Shell_probe
+  | Graphql
+  | Http
+  | Startup
+  | Auto_responder
+  | Build_identity
+  | Voice
+  | Coord_identity
+  | Dashboard
+  | Http_routes
+  | Test -> "shell_probe"
   | Unknown caller -> caller
 
 (** Exported for tests that pin the per-caller default table. *)
@@ -80,6 +100,16 @@ let known_callers () =
     Autoresearch_git_meta;
     Autoresearch_git_mutation;
     Shell_probe;
+    Graphql;
+    Http;
+    Startup;
+    Auto_responder;
+    Build_identity;
+    Voice;
+    Coord_identity;
+    Dashboard;
+    Http_routes;
+    Test;
   ]
 
 let known_default_sec = function
@@ -101,6 +131,16 @@ let known_default_sec = function
   | Memory_audit -> Some 3.0
   | Git_meta | Autoresearch_git_meta -> Some 10.0
   | Autoresearch_git_mutation -> Some 30.0
+  | Graphql -> Some 30.0
+  | Http -> Some 30.0
+  | Startup -> Some 30.0
+  | Auto_responder -> Some 30.0
+  | Build_identity -> Some 30.0
+  | Voice -> Some 30.0
+  | Coord_identity -> Some 30.0
+  | Dashboard -> Some 30.0
+  | Http_routes -> Some 30.0
+  | Test -> Some 30.0
   | Unknown _ -> None
 
 let upper_case s =

--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -31,17 +31,17 @@ type caller =
   | Git_meta                  (** local git metadata (rev-parse, remote get-url) (10s) *)
   | Autoresearch_git_meta     (** autoresearch local git metadata reads (10s) *)
   | Autoresearch_git_mutation (** autoresearch local git mutations (30s) *)
-  | Shell_probe
-  | Graphql
-  | Http
-  | Startup
-  | Auto_responder
-  | Build_identity
-  | Voice
-  | Coord_identity
-  | Dashboard
-  | Http_routes
-  | Test               (** PATH probes via [command -v] (2s) *)
+  | Shell_probe               (** PATH probes via [command -v <name>] (2s) *)
+  | Graphql                   (** Graphql_client.{request,query,mutate} HTTP calls (10s) *)
+  | Http                      (** http_post_json_text_with_status probes (15s) *)
+  | Startup                   (** server bootstrap docker preflight + room takeover read (30s) *)
+  | Auto_responder            (** auto_responder cli spawn with stdin prompt (120s) *)
+  | Build_identity            (** build identity git probe (5s) *)
+  | Voice                     (** voice bridge local playback subprocess (60s) *)
+  | Coord_identity            (** coord tty identity probe (5s) *)
+  | Dashboard                 (** dashboard safe_autonomy short heartbeat (3s) *)
+  | Http_routes               (** workspace api git command via http (15s) *)
+  | Test                      (** test fixtures driving exec runtime (30s) *)
   | Unknown of string
 
 (** Hardcoded default seconds for each known caller.  Preserves
@@ -66,17 +66,17 @@ let caller_key = function
   | Git_meta -> "git_meta"
   | Autoresearch_git_meta -> "autoresearch_git_meta"
   | Autoresearch_git_mutation -> "autoresearch_git_mutation"
-  | Shell_probe
-  | Graphql
-  | Http
-  | Startup
-  | Auto_responder
-  | Build_identity
-  | Voice
-  | Coord_identity
-  | Dashboard
-  | Http_routes
-  | Test -> "shell_probe"
+  | Shell_probe -> "shell_probe"
+  | Graphql -> "graphql"
+  | Http -> "http"
+  | Startup -> "startup"
+  | Auto_responder -> "auto_responder"
+  | Build_identity -> "build_identity"
+  | Voice -> "voice"
+  | Coord_identity -> "coord_identity"
+  | Dashboard -> "dashboard"
+  | Http_routes -> "http_routes"
+  | Test -> "test"
   | Unknown caller -> caller
 
 (** Exported for tests that pin the per-caller default table. *)
@@ -131,16 +131,20 @@ let known_default_sec = function
   | Memory_audit -> Some 3.0
   | Git_meta | Autoresearch_git_meta -> Some 10.0
   | Autoresearch_git_mutation -> Some 30.0
-  | Graphql -> Some 30.0
-  | Http -> Some 30.0
-  | Startup -> Some 30.0
-  | Auto_responder -> Some 30.0
-  | Build_identity -> Some 30.0
-  | Voice -> Some 30.0
-  | Coord_identity -> Some 30.0
-  | Dashboard -> Some 30.0
-  | Http_routes -> Some 30.0
-  | Test -> Some 30.0
+  (* Defaults for the new variants below preserve the literals each
+     site previously held — see #10426 review (#13081) for the
+     site-by-site mapping.  Operators can override via
+     MASC_EXEC_TIMEOUT_<CALLER>_SEC without touching the others. *)
+  | Graphql -> Some 10.0          (* relation_materializer / dashboard graphql 8-10s *)
+  | Http -> Some 15.0             (* tool_local_runtime_verify probe was 15s *)
+  | Startup -> Some 30.0          (* server_bootstrap docker preflight 30s *)
+  | Auto_responder -> Some 120.0  (* auto_responder cli spawn was 120s — under-budget regression risk *)
+  | Build_identity -> Some 5.0    (* git probe was 5s *)
+  | Voice -> Some 60.0            (* local playback was 60s — under-budget regression risk *)
+  | Coord_identity -> Some 5.0    (* tty probe was 5s *)
+  | Dashboard -> Some 3.0         (* short heartbeat was 3s *)
+  | Http_routes -> Some 15.0      (* workspace git command via http was 15s *)
+  | Test -> Some 30.0             (* test fixtures, slow_command path keeps 30s ceiling *)
   | Unknown _ -> None
 
 let upper_case s =
@@ -192,3 +196,15 @@ let timeout_sec ~caller () =
         Safe_ops.float_of_string_with_default
           ~default:global_default_sec v
       | None -> global_default_sec
+
+(** [timeout_sec_int ~caller ()] resolves the same value as
+    [timeout_sec] but rounded UP to the nearest second.  Use this at
+    call sites whose downstream helper signs [~timeout_sec:int] (e.g.
+    {!Tool_local_runtime_http.http_post_json_text_with_status},
+    {!Worker_runtime_docker.run_process_with_timeout}).  Rounding up
+    rather than truncating preserves the operator's intended budget
+    when the env var is fractional. *)
+let timeout_sec_int ~caller () =
+  let f = timeout_sec ~caller () in
+  if Float.is_nan f || f <= 0.0 then 1
+  else int_of_float (Float.ceil f)

--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -41,6 +41,8 @@ type caller =
   | Coord_identity            (** coord tty identity probe (5s) *)
   | Dashboard                 (** dashboard safe_autonomy short heartbeat (3s) *)
   | Http_routes               (** workspace api git command via http (15s) *)
+  | Repo_manager_git          (** repo_manager clone/fetch/push git operations (300s) *)
+  | Task_sandbox_git          (** task_sandbox worktree create/diff/cleanup git operations (30s) *)
   | Test                      (** test fixtures driving exec runtime (30s) *)
   | Unknown of string
 
@@ -76,6 +78,8 @@ let caller_key = function
   | Coord_identity -> "coord_identity"
   | Dashboard -> "dashboard"
   | Http_routes -> "http_routes"
+  | Repo_manager_git -> "repo_manager_git"
+  | Task_sandbox_git -> "task_sandbox_git"
   | Test -> "test"
   | Unknown caller -> caller
 
@@ -109,6 +113,8 @@ let known_callers () =
     Coord_identity;
     Dashboard;
     Http_routes;
+    Repo_manager_git;
+    Task_sandbox_git;
     Test;
   ]
 
@@ -144,6 +150,8 @@ let known_default_sec = function
   | Coord_identity -> Some 5.0    (* tty probe was 5s *)
   | Dashboard -> Some 3.0         (* short heartbeat was 3s *)
   | Http_routes -> Some 15.0      (* workspace git command via http was 15s *)
+  | Repo_manager_git -> Some 300.0 (* repo_manager git was 300s — clone/fetch on slow networks *)
+  | Task_sandbox_git -> Some 30.0  (* task_sandbox worktree git ops were 30s *)
   | Test -> Some 30.0             (* test fixtures, slow_command path keeps 30s ceiling *)
   | Unknown _ -> None
 

--- a/lib/config/env_config_exec_timeout.mli
+++ b/lib/config/env_config_exec_timeout.mli
@@ -76,6 +76,15 @@ type caller =
   | Http_routes
       (** Workspace API git command invoked via the HTTP routes layer.
           Default 15.0s. *)
+  | Repo_manager_git
+      (** Repo-manager git operations (clone, fetch, push).
+          Default 300.0s — these operations run against remote origins
+          over the network; the previous inline budget was 300s to
+          tolerate slow connections and large repos. *)
+  | Task_sandbox_git
+      (** Task-sandbox worktree git operations (create, diff, cleanup).
+          Default 30.0s — these are local operations (no network) but
+          can be slow on large repos; the previous inline budget was 30s. *)
   | Test
       (** Test fixtures driving the exec runtime.
           Default 30.0s — matches the [test_slow_command_promotes]

--- a/lib/config/env_config_exec_timeout.mli
+++ b/lib/config/env_config_exec_timeout.mli
@@ -40,6 +40,16 @@ type caller =
           preserving the previous inline budget for add/commit/reset/
           worktree cleanup inside managed experiment loops. *)
   | Shell_probe
+  | Graphql
+  | Http
+  | Startup
+  | Auto_responder
+  | Build_identity
+  | Voice
+  | Coord_identity
+  | Dashboard
+  | Http_routes
+  | Test
       (** PATH availability probes (e.g. [command -v <name>]).
           Default 2.0s — pure OS lookup; longer timeouts mask
           shell-startup misconfiguration rather than helping. *)

--- a/lib/config/env_config_exec_timeout.mli
+++ b/lib/config/env_config_exec_timeout.mli
@@ -40,19 +40,46 @@ type caller =
           preserving the previous inline budget for add/commit/reset/
           worktree cleanup inside managed experiment loops. *)
   | Shell_probe
-  | Graphql
-  | Http
-  | Startup
-  | Auto_responder
-  | Build_identity
-  | Voice
-  | Coord_identity
-  | Dashboard
-  | Http_routes
-  | Test
       (** PATH availability probes (e.g. [command -v <name>]).
           Default 2.0s — pure OS lookup; longer timeouts mask
           shell-startup misconfiguration rather than helping. *)
+  | Graphql
+      (** [Graphql_client.{request,query,mutate}] HTTP calls.
+          Default 10.0s — preserves the 8-10s literals previously
+          held by relation_materializer, dashboard_agent_relations,
+          dashboard_execution_helpers, and autoresearch_knowledge. *)
+  | Http
+      (** Outbound JSON POST probes via [http_post_json_text_with_status]
+          (e.g. tool_local_runtime_verify).  Default 15.0s, matching
+          the previous inline budget. *)
+  | Startup
+      (** Server bootstrap and room takeover read paths.
+          Default 30.0s — preserves the [server_bootstrap_loops]
+          docker preflight budget.  Note: the
+          [server_startup_takeover] [ps] probe was previously 1s —
+          it now uses [Shell_probe] (2s) instead of [Startup] so a
+          single env override does not move two unrelated budgets. *)
+  | Auto_responder
+      (** Auto-responder CLI spawn with stdin prompt.  Default 120.0s
+          — preserves the previous inline budget; under-budgeting
+          here would silently cut off legitimate model replies. *)
+  | Build_identity
+      (** Build identity git probe.  Default 5.0s. *)
+  | Voice
+      (** Voice bridge local playback subprocess.  Default 60.0s —
+          preserves the previous inline budget. *)
+  | Coord_identity
+      (** Coord tty identity probe.  Default 5.0s. *)
+  | Dashboard
+      (** Dashboard safe_autonomy short heartbeat probe.
+          Default 3.0s — matches the previous inline budget. *)
+  | Http_routes
+      (** Workspace API git command invoked via the HTTP routes layer.
+          Default 15.0s. *)
+  | Test
+      (** Test fixtures driving the exec runtime.
+          Default 30.0s — matches the [test_slow_command_promotes]
+          ceiling; faster fixtures may override per-caller. *)
   | Unknown of string
 
 (** [caller_key c] is the lowercase identifier embedded in env var
@@ -81,3 +108,12 @@ val global_default_sec : float
 (** [timeout_sec ~caller ()] resolves the subprocess timeout for
     [caller].  See module doc for lookup order. *)
 val timeout_sec : caller:caller -> unit -> float
+
+(** [timeout_sec_int ~caller ()] is [timeout_sec] rounded UP to the
+    nearest second.  Use at call sites whose downstream helper signs
+    [~timeout_sec:int] — e.g.
+    {!Tool_local_runtime_http.http_post_json_text_with_status} and
+    {!Worker_runtime_docker.run_process_with_timeout}.  Returns
+    [1] for non-positive or NaN budgets so the call always issues
+    a finite-bound subprocess. *)
+val timeout_sec_int : caller:caller -> unit -> int

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -510,7 +510,7 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
   Process_eio.init ~cwd_default:Eio.Path.(fs / report.base_path) ~proc_mgr
     ~clock;
   let sandbox_preflight_report =
-    Keeper_sandbox_runtime.docker_preflight ~timeout_sec:10.0 ()
+    Keeper_sandbox_runtime.docker_preflight ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ()) ()
   in
   let sandbox_preflight =
     sandbox_preflight_report

--- a/lib/coord/coord_identity.ml
+++ b/lib/coord/coord_identity.ml
@@ -23,7 +23,7 @@ let get_tty () =
                 ~actor:"coord/identity"
                 ~raw_source:"tty"
                 ~summary:"coord tty probe"
-                ~timeout_sec:5.0
+                ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Coord_identity ())
                 [ "tty" ]
             in
             let trimmed = String.trim output in

--- a/lib/dashboard/dashboard_agent_relations.ml
+++ b/lib/dashboard/dashboard_agent_relations.ml
@@ -36,7 +36,7 @@ let trusts_query = {|
 let json ~agent_name () : Yojson.Safe.t =
   let collaborators =
     let variables = `Assoc [("name", `String agent_name)] in
-    match Graphql_client.query ~timeout_sec:8.0 ~query:collaborators_query ~variables () with
+    match Graphql_client.query ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Graphql ()) ~query:collaborators_query ~variables () with
     | Ok data ->
       let open Yojson.Safe.Util in
       data |> member "agentCollaborationNetworkByName" |> to_list
@@ -50,7 +50,7 @@ let json ~agent_name () : Yojson.Safe.t =
   in
   let agent_data =
     let variables = `Assoc [("name", `String agent_name)] in
-    match Graphql_client.query ~timeout_sec:8.0 ~query:trusts_query ~variables () with
+    match Graphql_client.query ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Graphql ()) ~query:trusts_query ~variables () with
     | Ok data ->
       let open Yojson.Safe.Util in
       let agent = data |> member "agent" in

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -333,7 +333,7 @@ let populate_neo4j_identity_cache_locked () =
   let body =
     {|{"query":"{ agents(first: 50) { edges { node { name emoji koreanName model traits interests activityLevel primaryValue } } } }"}|}
   in
-  match Graphql_client.request ~timeout_sec:10.0 body with
+  match Graphql_client.request ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Graphql ()) body with
   | Error e -> Log.Dashboard.warn "neo4j identity cache load failed: %s" e
   | Ok output -> (
       try

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -490,7 +490,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
     bool_default_true_of_env "MASC_KEEPER_HISTORY_FRAGMENT_FILTER"
   in
   let sandbox_preflight_json =
-    Keeper_sandbox_runtime.docker_preflight ~timeout_sec:10.0 ()
+    Keeper_sandbox_runtime.docker_preflight ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ()) ()
     |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
   in
   let series_points = 120 in
@@ -1587,7 +1587,7 @@ let keeper_config_json (config : Coord.config) (name : string)
         else None
       in
       let sandbox_preflight_json =
-        Keeper_sandbox_runtime.docker_preflight ~timeout_sec:10.0 ()
+        Keeper_sandbox_runtime.docker_preflight ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ()) ()
         |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
       in
       let sandbox_preflight =

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -772,7 +772,7 @@ let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
   let sandbox_live =
     Keeper_sandbox_control.live_status_json
       ~include_preflight:false
-      ~config ~meta ~timeout_sec:3.0 ~verbose:false ()
+      ~config ~meta ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dashboard ()) ~verbose:false ()
   in
   let domains =
     [

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -6,4 +6,4 @@
         test_history_insight test_exec_cache test_exec_budget
         test_exec_adaptive_timeout test_risk_classifier test_egress_policy)
  (libraries masc_exec masc_exec_bash_parser masc_process
-            masc_core alcotest eio eio_main yojson unix re))
+            masc_core masc_config alcotest eio eio_main yojson unix re))

--- a/lib/exec/test/test_exec_gate_runtime.ml
+++ b/lib/exec/test/test_exec_gate_runtime.ml
@@ -31,7 +31,7 @@ let test_enforced_strict_safe_blocks () =
         ~actor:"unknown/strict"
         ~raw_source:"pwd"
         ~summary:"strict pwd"
-        ~timeout_sec:5.0
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
         [ "pwd" ]
     in
     assert (status = Unix.WEXITED 126);
@@ -45,7 +45,7 @@ let test_parallel_records_shadow_and_executes () =
           ~actor:"unknown/strict"
           ~raw_source:"pwd"
           ~summary:"strict pwd"
-          ~timeout_sec:5.0
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
           [ "pwd" ]
       in
       assert (String.trim out <> "");
@@ -63,7 +63,7 @@ let test_enforced_internal_audited_allows () =
         ~actor:"coord/git"
         ~raw_source:"git --version"
         ~summary:"coord git version"
-        ~timeout_sec:5.0
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
         [ "git"; "--version" ]
     in
     assert (status = Unix.WEXITED 0);
@@ -76,7 +76,7 @@ let test_enforced_internal_stdin_allows () =
         ~actor:"system/task_sandbox"
         ~raw_source:"cat"
         ~summary:"stdin cat"
-        ~timeout_sec:5.0
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
         ~stdin_content:"hello\n"
         [ "cat" ]
     in

--- a/lib/exec/test/test_exec_run.ml
+++ b/lib/exec/test/test_exec_run.ml
@@ -54,7 +54,7 @@ let test_fast_command_completes () =
       ~argv:[ "/bin/sh"; "-c"; "printf hi" ]
       ~cwd:(Sys.getcwd ())
       ~envp:(Unix.environment ())
-      ~timeout_sec:5.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
       ()
   in
   match out with
@@ -81,7 +81,7 @@ let test_slow_command_promotes () =
       ~argv:[ "/bin/sh"; "-c"; "printf early; sleep 5; printf late" ]
       ~cwd:(Sys.getcwd ())
       ~envp:(Unix.environment ())
-      ~timeout_sec:30.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
       ()
   in
   match out with

--- a/lib/exec/test/test_exec_run_json.ml
+++ b/lib/exec/test/test_exec_run_json.ml
@@ -89,7 +89,7 @@ let test_promoted_json_shape () =
       ~argv:[ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
       ~cwd
       ~envp:(Unix.environment ())
-      ~timeout_sec:30.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
       ()
   in
   match out with

--- a/lib/git_graph_snapshot.ml
+++ b/lib/git_graph_snapshot.ml
@@ -406,7 +406,7 @@ let run_git ~timeout_sec ~workdir args =
            ~timeout_sec argv)
 
 let run_git_output ~workdir args =
-  match run_git ~timeout_sec:10.0 ~workdir args with
+  match run_git ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ()) ~workdir args with
   | Some (Unix.WEXITED 0, output) -> Some output
   | _ -> None
 

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -226,7 +226,7 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
           ~actor:"system/worker_container_types"
           ~raw_source
           ~summary:"worker container curl fallback"
-          ~timeout_sec:20.0
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
           ~stdin_content:request_body
           argv
       in

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -28,7 +28,7 @@ let run_argv_line argv =
       ~actor:"system/notify"
       ~raw_source:(exec_gate_raw_source argv)
       ~summary:"notify argv"
-      ~timeout_sec:10.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
       argv
   in
   match String.split_on_char '\n' output with
@@ -47,7 +47,7 @@ let run_argv_ignore argv =
          ~actor:"system/notify"
          ~raw_source:(exec_gate_raw_source argv)
          ~summary:"notify argv"
-         ~timeout_sec:60.0
+         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
          argv
      in
      match status with

--- a/lib/relation_materializer.ml
+++ b/lib/relation_materializer.ml
@@ -42,7 +42,7 @@ let build_batch_mutation ~agent ~peers ~context =
 let record_collaborations_async ~tag ~context ~agent ~peers =
   let do_batch () =
     let mutation = build_batch_mutation ~agent ~peers ~context in
-    match Graphql_client.mutate ~timeout_sec:10.0 ~mutation () with
+    match Graphql_client.mutate ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Graphql ()) ~mutation () with
     | Ok _ -> ()
     | Error msg -> log_err tag msg
   in

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -13,6 +13,7 @@
    repo_sync)
  (wrapped false)
  (libraries
+   masc_mcp.config
    masc_mcp.masc_exec
    masc_mcp.masc_log
    digestif

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -62,7 +62,7 @@ let run_git ~cwd ?(env = []) args : (string list, string) result =
   let status, stdout, stderr =
     Masc_exec.Exec_gate.run_argv_with_status_split
       ~actor:"repo-manager/git" ~raw_source ~summary:"repo manager git"
-      ~timeout_sec:300.0 ~env:envp argv
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ()) ~env:envp argv
   in
   match status with
   | Unix.WEXITED 0 -> Ok (split_lines stdout)

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -62,7 +62,7 @@ let run_git ~cwd ?(env = []) args : (string list, string) result =
   let status, stdout, stderr =
     Masc_exec.Exec_gate.run_argv_with_status_split
       ~actor:"repo-manager/git" ~raw_source ~summary:"repo manager git"
-      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ()) ~env:envp argv
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Repo_manager_git ()) ~env:envp argv
   in
   match status with
   | Unix.WEXITED 0 -> Ok (split_lines stdout)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -868,7 +868,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
           (match
              Keeper_sandbox_runtime.maybe_cleanup_stale_containers
                ~base_path:state.room_config.base_path
-               ~timeout_sec:30.0 ()
+               ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Startup ()) ()
            with
            | None -> ()
            | Some result ->

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -186,7 +186,7 @@ let git_run ~cwd args =
         ~actor:"system/workspace_api"
         ~raw_source
         ~summary:"workspace api git command"
-        ~timeout_sec:15.0
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Http_routes ())
         argv
     in
     match status with

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -79,7 +79,7 @@ let process_command pid =
       ~actor:"system/startup_takeover"
       ~raw_source:(Printf.sprintf "ps -p %d -o command=" pid)
       ~summary:"startup takeover ps probe"
-      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Startup ())
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell_probe ())
       [ "ps"; "-p"; string_of_int pid; "-o"; "command=" ]
   with
   | Unix.WEXITED 0, output -> (

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -79,7 +79,7 @@ let process_command pid =
       ~actor:"system/startup_takeover"
       ~raw_source:(Printf.sprintf "ps -p %d -o command=" pid)
       ~summary:"startup takeover ps probe"
-      ~timeout_sec:1.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Startup ())
       [ "ps"; "-p"; string_of_int pid; "-o"; "command=" ]
   with
   | Unix.WEXITED 0, output -> (

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -24,7 +24,7 @@ let git_lines ~cwd args =
     ~actor:"system/task_sandbox"
     ~raw_source:(exec_gate_raw_source argv)
     ~summary:"task_sandbox git"
-    ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Turn_sandbox ())
+    ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Task_sandbox_git ())
     argv
   |> String.split_on_char '\n'
   |> List.filter (fun s -> String.trim s <> "")
@@ -37,7 +37,7 @@ let git_exit ~cwd args =
       ~actor:"system/task_sandbox"
       ~raw_source:(exec_gate_raw_source argv)
       ~summary:"task_sandbox git"
-      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Turn_sandbox ())
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Task_sandbox_git ())
       argv
   with
   | Unix.WEXITED n, _ -> n

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -24,7 +24,7 @@ let git_lines ~cwd args =
     ~actor:"system/task_sandbox"
     ~raw_source:(exec_gate_raw_source argv)
     ~summary:"task_sandbox git"
-    ~timeout_sec:30.0
+    ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Turn_sandbox ())
     argv
   |> String.split_on_char '\n'
   |> List.filter (fun s -> String.trim s <> "")
@@ -37,7 +37,7 @@ let git_exit ~cwd args =
       ~actor:"system/task_sandbox"
       ~raw_source:(exec_gate_raw_source argv)
       ~summary:"task_sandbox git"
-      ~timeout_sec:30.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Turn_sandbox ())
       argv
   with
   | Unix.WEXITED n, _ -> n

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -226,7 +226,7 @@ let git_diff_patch ~workdir =
       ~actor:"tool/autoresearch_cycle"
       ~raw_source:(String.concat " " (List.map Filename.quote argv))
       ~summary:"autoresearch cycle git diff"
-      ~timeout_sec:30.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
       argv
   in
   match status with
@@ -244,7 +244,7 @@ let sync_target_file_to_index ~workdir ~target_file =
       ~actor:"tool/autoresearch_cycle"
       ~raw_source:(String.concat " " (List.map Filename.quote argv))
       ~summary:"autoresearch cycle git add"
-      ~timeout_sec:10.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
       argv
   in
   match status with

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -362,7 +362,7 @@ let handle_code_search ctx args =
     in
     let cmd = "rg" :: rg_args in
 
-    match Process_eio.run_argv_with_status ~timeout_sec:30.0 cmd with
+    match Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) cmd with
     | Unix.WEXITED 0, output ->
         (* Parse rg JSON output *)
         let lines = String.split_on_char '\n' output in

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -68,7 +68,7 @@ let git_common_root path =
   try
     match
       Process_eio.run_argv_with_status
-        ~timeout_sec:5.0
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
         [ "git"; "-C"; path; "rev-parse"; "--git-common-dir" ]
     with
     | Unix.WEXITED 0, output ->
@@ -754,7 +754,7 @@ let handle_code_git ctx args =
             Some (Keeper_identity.git_env_for_keeper ~keeper_name:ctx.agent_name)
           else None
         in
-        match Process_eio.run_argv_with_status ~timeout_sec:30.0 ?env:env_opt cmd with
+        match Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) ?env:env_opt cmd with
         | Unix.WEXITED code, output ->
           let response = `Assoc [
             ("status", `String (if code = 0 then "ok" else "error"));

--- a/lib/tool_inline_dispatch_types.ml
+++ b/lib/tool_inline_dispatch_types.ml
@@ -50,7 +50,7 @@ type context = {
     Coord.config -> Mcp_server_eio_governance.mcp_session_record list -> unit;
 }
 
-(** Helper: run subprocess with 60s timeout *)
+(** Helper: run subprocess — uses [Dispatch] caller (default 120s) *)
 let safe_exec args =
   match Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) args with
   | Unix.WEXITED 0, output -> (true, output)

--- a/lib/tool_inline_dispatch_types.ml
+++ b/lib/tool_inline_dispatch_types.ml
@@ -52,6 +52,6 @@ type context = {
 
 (** Helper: run subprocess with 60s timeout *)
 let safe_exec args =
-  match Process_eio.run_argv_with_status ~timeout_sec:60.0 args with
+  match Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) args with
   | Unix.WEXITED 0, output -> (true, output)
   | _, output -> (false, if String.equal output "" then "Command failed" else output)

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -132,7 +132,7 @@ let discover_processes () =
       ~actor:"tool/local_runtime"
       ~raw_source:(String.concat " " (List.map Filename.quote argv))
       ~summary:"tool local runtime process discovery"
-      ~timeout_sec:5.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
       argv
   in
   match status with
@@ -194,7 +194,7 @@ let fetch_models_at base_url =
       ~actor:"tool/local_runtime"
       ~raw_source:(String.concat " " (List.map Filename.quote argv))
       ~summary:"tool local runtime fetch models"
-      ~timeout_sec:15.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
       argv
   in
   match status with

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -495,7 +495,7 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
                 base_url ^ Masc_network_defaults.openai_chat_completions_path
               in
               let body_json = chat_contract_probe_body ~model_id in
-              match http_post_json_text_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Http ()) ~url ~body_json with
+              match http_post_json_text_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec_int ~caller:Http ()) ~url ~body_json with
               | Ok (status_code, payload) -> (status_code, Some payload, None)
               | Error err -> (None, None, Some err)
         in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -495,7 +495,7 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
                 base_url ^ Masc_network_defaults.openai_chat_completions_path
               in
               let body_json = chat_contract_probe_body ~model_id in
-              match http_post_json_text_with_status ~timeout_sec:15 ~url ~body_json with
+              match http_post_json_text_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Http ()) ~url ~body_json with
               | Ok (status_code, payload) -> (status_code, Some payload, None)
               | Error err -> (None, None, Some err)
         in

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -229,7 +229,7 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
                   ~actor:"voice/bridge_core"
                   ~raw_source
                   ~summary:"voice local playback"
-                  ~timeout_sec:60.0
+                  ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Voice ())
                   argv
               with
               | Unix.WEXITED 0, _ ->

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -181,7 +181,7 @@ let persist_stderr_artifact (spec : Worker_execution_spec.t) stderr =
 let best_effort_remove_container ?clock_opt name =
   ignore
     (run_process_with_timeout ~clock_opt
-       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ()) ~prog:"docker"
+       ~timeout_sec:(Env_config_exec_timeout.timeout_sec_int ~caller:Sandbox ()) ~prog:"docker"
        ~argv:[ "docker"; "rm"; "-f"; name ]
        ~env:(Unix.environment ()) ())
 
@@ -222,7 +222,7 @@ let preflight_batch ?clock_opt (subjects : preflight_subject list) =
   else
       let info_result =
         run_process_with_timeout ~clock_opt
-          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ()) ~prog:"docker"
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec_int ~caller:Sandbox ()) ~prog:"docker"
           ~argv:[ "docker"; "info" ]
           ~env:(Unix.environment ()) ()
     in
@@ -233,7 +233,7 @@ let preflight_batch ?clock_opt (subjects : preflight_subject list) =
     else
         let image_result =
           run_process_with_timeout ~clock_opt
-            ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ()) ~prog:"docker"
+            ~timeout_sec:(Env_config_exec_timeout.timeout_sec_int ~caller:Sandbox ()) ~prog:"docker"
             ~argv:[ "docker"; "image"; "inspect"; image ]
             ~env:(Unix.environment ()) ()
       in

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -181,7 +181,7 @@ let persist_stderr_artifact (spec : Worker_execution_spec.t) stderr =
 let best_effort_remove_container ?clock_opt name =
   ignore
     (run_process_with_timeout ~clock_opt
-       ~timeout_sec:10 ~prog:"docker"
+       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ()) ~prog:"docker"
        ~argv:[ "docker"; "rm"; "-f"; name ]
        ~env:(Unix.environment ()) ())
 
@@ -222,7 +222,7 @@ let preflight_batch ?clock_opt (subjects : preflight_subject list) =
   else
       let info_result =
         run_process_with_timeout ~clock_opt
-          ~timeout_sec:20 ~prog:"docker"
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ()) ~prog:"docker"
           ~argv:[ "docker"; "info" ]
           ~env:(Unix.environment ()) ()
     in
@@ -233,7 +233,7 @@ let preflight_batch ?clock_opt (subjects : preflight_subject list) =
     else
         let image_result =
           run_process_with_timeout ~clock_opt
-            ~timeout_sec:20 ~prog:"docker"
+            ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ()) ~prog:"docker"
             ~argv:[ "docker"; "image"; "inspect"; image ]
             ~env:(Unix.environment ()) ()
       in

--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -49,6 +49,11 @@ let cases =
     E.Coord_identity, 5.0;
     E.Dashboard, 3.0;
     E.Http_routes, 15.0;
+    (* #13081 follow-up — added to fix reviewer-identified budget regressions:
+       repo_git.ml was 300s but was mapped to Unknown "misc" (30s fallback);
+       task_sandbox.ml was 30s but was mapped to Turn_sandbox (2s). *)
+    E.Repo_manager_git, 300.0;
+    E.Task_sandbox_git, 30.0;
     E.Test, 30.0;
   ]
 

--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -38,6 +38,18 @@ let cases =
     E.Autoresearch_git_meta, 10.0;
     E.Autoresearch_git_mutation, 30.0;
     E.Shell_probe, 2.0;
+    (* #13081 — added with the refactor; each preserves the literal
+       its call site previously held inline.  See module .mli. *)
+    E.Graphql, 10.0;
+    E.Http, 15.0;
+    E.Startup, 30.0;
+    E.Auto_responder, 120.0;
+    E.Build_identity, 5.0;
+    E.Voice, 60.0;
+    E.Coord_identity, 5.0;
+    E.Dashboard, 3.0;
+    E.Http_routes, 15.0;
+    E.Test, 30.0;
   ]
 
 let test_known_default_pin () =


### PR DESCRIPTION
Centralizes 44 scattered `~timeout_sec` literals across the codebase into `Env_config_exec_timeout`, eliminating hardcoded magic numbers.