### PR TITLE
fix(http): preserve cancellation on late responses

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -318,15 +318,6 @@ let dispatch_route ~routes ~request ~path reqd =
       Http.Response.json ~status body reqd
   | _ -> Http.Router.dispatch routes request reqd
 
-let response_write_failure_msg = function
-  | Failure msg
-    when String.starts_with msg
-           ~prefix:"httpun.Reqd.respond_with_string: invalid state" ->
-      Some msg
-  | Failure "cannot write to closed writer" ->
-      Some "cannot write to closed writer"
-  | _ -> None
-
 let log_late_response_failure ~context msg =
   Log.Http.warn "%s: response already unwritable; skipped late response (%s)"
     context msg
@@ -335,7 +326,7 @@ let try_internal_error_response reqd msg =
   try Http.Response.internal_error msg reqd with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> (
-      match response_write_failure_msg exn with
+      match Http.Late_response.classify_write_failure exn with
       | Some failure_msg ->
           log_late_response_failure ~context:"main_eio internal_error"
             failure_msg
@@ -369,7 +360,7 @@ let make_extended_handler routes =
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> (
       let msg = Printexc.to_string exn in
-      match response_write_failure_msg exn with
+      match Http.Late_response.classify_write_failure exn with
       | Some failure_msg ->
           log_late_response_failure ~context:"main_eio request handler"
             failure_msg

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -318,6 +318,31 @@ let dispatch_route ~routes ~request ~path reqd =
       Http.Response.json ~status body reqd
   | _ -> Http.Router.dispatch routes request reqd
 
+let response_write_failure_msg = function
+  | Failure msg
+    when String.starts_with msg
+           ~prefix:"httpun.Reqd.respond_with_string: invalid state" ->
+      Some msg
+  | Failure "cannot write to closed writer" ->
+      Some "cannot write to closed writer"
+  | _ -> None
+
+let log_late_response_failure ~context msg =
+  Log.Http.warn "%s: response already unwritable; skipped late response (%s)"
+    context msg
+
+let try_internal_error_response reqd msg =
+  try Http.Response.internal_error msg reqd with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> (
+      match response_write_failure_msg exn with
+      | Some failure_msg ->
+          log_late_response_failure ~context:"main_eio internal_error"
+            failure_msg
+      | None ->
+          Log.Http.warn "main_eio internal_error response failed: %s"
+            (Printexc.to_string exn))
+
 (** Extended router to handle OPTIONS *)
 let make_extended_handler routes =
   fun client_addr gluten_reqd ->
@@ -341,19 +366,14 @@ let make_extended_handler routes =
        Previously the catch-all swallowed Cancelled and tried to write a 500
        response; that masks shutdown signals and interferes with per-connection
        switch cleanup. *)
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> (
       let msg = Printexc.to_string exn in
-      (* Http.Response.internal_error → Response.text → safe_respond_with_string
-         already guards against the "invalid state" Failure (2026-05-05 cycle9
-         OAS cancellation race), but the extra try here makes the intent explicit
-         and guards against any future refactoring that bypasses safe_respond. *)
-      (try Http.Response.internal_error msg reqd
-       with Eio.Cancel.Cancelled _ as e -> raise e
-          | inner ->
-              Log.Server.warn
-                "[http] error response skipped (reqd invalid state after %s): %s"
-                msg (Printexc.to_string inner))
+      match response_write_failure_msg exn with
+      | Some failure_msg ->
+          log_late_response_failure ~context:"main_eio request handler"
+            failure_msg
+      | None -> try_internal_error_response reqd msg)
 
 (** Main server loop *)
 let run_server ~sw:_ ~env ~host ~port ~base_path =

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -249,6 +249,35 @@ module Response = struct
     text ~status:`Internal_server_error ("500 Internal Server Error: " ^ msg) reqd
 end
 
+(** Late-response failure classifier (#13059).
+
+    [Failure] string-literal patterns are fragile (warning 52) — the
+    upstream library is free to change them.  We accept that risk
+    because:
+
+    - These exact strings ARE the public API surface for the upstream
+      libraries (httpun + the [Faraday]-style writer).  Library
+      authors treat the message text as user-facing diagnostics.
+    - This module is a defensive log-and-skip path only — if a
+      future library version reshapes the message we lose the
+      log-downgrade and revert to the fallback 500 attempt, not a
+      crash.
+    - Substring-match guards (via [String.starts_with] /
+      [String.equal]) localise the dependency rather than spreading
+      the literal across many call sites. *)
+[@@@warning "-52"]
+module Late_response = struct
+  let classify_write_failure = function
+    | Failure msg
+      when String.starts_with msg
+             ~prefix:"httpun.Reqd.respond_with_string: invalid state" ->
+        Some msg
+    | Failure msg when String.equal msg "cannot write to closed writer" ->
+        Some "cannot write to closed writer"
+    | _ -> None
+end
+[@@@warning "+52"]
+
 (** Request helpers *)
 module Request = struct
   (** Read request body - loops until EOF (httpun requires repeated schedule_read) *)

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -84,6 +84,35 @@ module Compression = struct
       with Zstd.Error _ -> (data, false)
 end
 
+(** Late-response failure classifier (#13059).
+
+    [Failure] string-literal patterns are fragile (warning 52) — the
+    upstream library is free to change them.  We accept that risk
+    because:
+
+    - These exact strings ARE the public API surface for the upstream
+      libraries (httpun + the [Faraday]-style writer).  Library
+      authors treat the message text as user-facing diagnostics.
+    - This module is a defensive log-and-skip path only — if a
+      future library version reshapes the message we lose the
+      log-downgrade and revert to the fallback 500 attempt, not a
+      crash.
+    - Substring-match guards (via [String.starts_with] /
+      [String.equal]) localise the dependency rather than spreading
+      the literal across many call sites. *)
+[@@@warning "-52"]
+module Late_response = struct
+  let classify_write_failure = function
+    | Failure msg
+      when String.starts_with msg
+             ~prefix:"httpun.Reqd.respond_with_string: invalid state" ->
+        Some msg
+    | Failure msg when String.equal msg "cannot write to closed writer" ->
+        Some "cannot write to closed writer"
+    | _ -> None
+end
+[@@@warning "+52"]
+
 (** [safe_respond_with_string reqd response body] wraps
     [Httpun.Reqd.respond_with_string] to silently discard the
     [Failure "...invalid state..."] that httpun raises when the
@@ -93,22 +122,29 @@ end
     2026-05-05 cycle9 FATAL race).
 
     [Eio.Cancel.Cancelled] is always re-raised so structured
-    concurrency cancellation is never swallowed.  Any other
-    unexpected exception is logged at WARN level so the incident
-    remains observable without crashing the server. *)
+    concurrency cancellation is never swallowed.
+
+    Recognized late-response failures route through the shared
+    [Late_response.classify_write_failure] SSOT (#13082 review,
+    copilot thread on safe_respond_with_string drift) so the
+    classifier and this helper cannot diverge silently — anything
+    the classifier owns is logged identically here.  Genuinely
+    unexpected exceptions still log at WARN. *)
 let safe_respond_with_string reqd response body =
   try Httpun.Reqd.respond_with_string reqd response body
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | Failure msg ->
-      Log.Http.warn
-        "[http-eio] respond_with_string skipped (reqd already in \
-         error-handling state; 2026-05-05 OAS cancellation race): %s"
-        msg
-  | exn ->
-      Log.Http.warn
-        "[http-eio] respond_with_string unexpected exception: %s"
-        (Printexc.to_string exn)
+  | exn -> (
+      match Late_response.classify_write_failure exn with
+      | Some msg ->
+          Log.Http.warn
+            "[http-eio] respond_with_string skipped (reqd already in \
+             error-handling state; classifier match — 2026-05-05 OAS \
+             cancellation race): %s" msg
+      | None ->
+          Log.Http.warn
+            "[http-eio] respond_with_string unexpected exception: %s"
+            (Printexc.to_string exn))
 
 (** Simple response helpers *)
 module Response = struct
@@ -248,35 +284,6 @@ module Response = struct
   let internal_error msg reqd =
     text ~status:`Internal_server_error ("500 Internal Server Error: " ^ msg) reqd
 end
-
-(** Late-response failure classifier (#13059).
-
-    [Failure] string-literal patterns are fragile (warning 52) — the
-    upstream library is free to change them.  We accept that risk
-    because:
-
-    - These exact strings ARE the public API surface for the upstream
-      libraries (httpun + the [Faraday]-style writer).  Library
-      authors treat the message text as user-facing diagnostics.
-    - This module is a defensive log-and-skip path only — if a
-      future library version reshapes the message we lose the
-      log-downgrade and revert to the fallback 500 attempt, not a
-      crash.
-    - Substring-match guards (via [String.starts_with] /
-      [String.equal]) localise the dependency rather than spreading
-      the literal across many call sites. *)
-[@@@warning "-52"]
-module Late_response = struct
-  let classify_write_failure = function
-    | Failure msg
-      when String.starts_with msg
-             ~prefix:"httpun.Reqd.respond_with_string: invalid state" ->
-        Some msg
-    | Failure msg when String.equal msg "cannot write to closed writer" ->
-        Some "cannot write to closed writer"
-    | _ -> None
-end
-[@@@warning "+52"]
 
 (** Request helpers *)
 module Request = struct

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -164,6 +164,35 @@ module Response : sig
       concatenated with the caller-supplied message). *)
 end
 
+(** {1 Late-response failure classifier (#13059)} *)
+
+(** Classification helper for the cancellation-vs-late-write race.
+
+    When a handler's request is cancelled (peer closed, deadline hit,
+    or upstream switch failed) the underlying writer enters either
+    "invalid state" or "closed writer" — calling
+    {!Response.internal_error} from a top-level handler
+    [exception] arm at that point raises a *secondary* failure that
+    masks the original cancellation.  The classifier identifies the
+    two well-known failure shapes so callers can downgrade to a
+    log-and-skip rather than emit a 500 onto a closed wire. *)
+module Late_response : sig
+  val classify_write_failure : exn -> string option
+  (** [classify_write_failure exn] returns [Some msg] when [exn] is
+      one of the two well-known late-response failure modes:
+
+      - [Failure "httpun.Reqd.respond_with_string: invalid state ..."]
+        — httpun rejected a write because the response handle
+        already moved past the writable state.
+      - [Failure "cannot write to closed writer"] — the underlying
+        writer was closed while a deferred handler was still
+        attempting to drain.
+
+      Returns [None] for every other exception (including
+      [Eio.Cancel.Cancelled] which the caller MUST re-raise rather
+      than classify). *)
+end
+
 (** {1 Request helpers} *)
 
 (** Per-request projections + body readers.  Body size is

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -152,6 +152,9 @@ let start
                     try connection_handler client_addr flow
                     with
                     | Eio.Cancel.Cancelled _ as e -> raise e
+                    | Failure "cannot write to closed writer" ->
+                      Log.Server.debug
+                        "WS standalone handler closed before write completed"
                     | exn ->
                       Log.Server.warn "WS standalone handler error: %s"
                         (Printexc.to_string exn)));

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -152,12 +152,17 @@ let start
                     try connection_handler client_addr flow
                     with
                     | Eio.Cancel.Cancelled _ as e -> raise e
-                    | Failure "cannot write to closed writer" ->
-                      Log.Server.debug
-                        "WS standalone handler closed before write completed"
-                    | exn ->
-                      Log.Server.warn "WS standalone handler error: %s"
-                        (Printexc.to_string exn)));
+                    | exn -> (
+                      match
+                        Http_server_eio.Late_response.classify_write_failure
+                          exn
+                      with
+                      | Some _ ->
+                          Log.Server.debug
+                            "WS standalone handler closed before write completed"
+                      | None ->
+                          Log.Server.warn "WS standalone handler error: %s"
+                            (Printexc.to_string exn))));
                 accept_loop 0.05
               with
               | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -68,13 +68,28 @@ let make_websocket_handler ~on_message _client_addr (wsd : Ws.Wsd.t) :
            closed during a cancel/disconnect race (2026-05-05 cycle9 incident).
            The outer connection_handler catch already swallows these, but
            wrapping here makes the intent explicit and avoids an intermediate
-           httpun-ws state-machine inconsistency. *)
+           httpun-ws state-machine inconsistency.
+
+           Use the centralized [Late_response.classify_write_failure]
+           SSOT so the recognized "writer closed during cancel" race
+           is downgraded to debug here too — matching the outer
+           connection_handler.  Anything the classifier does not own
+           (genuine bugs / unexpected exceptions) still warns.  This
+           closes the warn-noise gap reported in #13082 review. *)
         (try Ws.Wsd.send_pong wsd
          with Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
-                Log.Server.warn
-                  "[ws-standalone] send_pong failed (closed wsd race): %s"
-                  (Printexc.to_string exn));
+                (match
+                   Http_server_eio.Late_response.classify_write_failure exn
+                 with
+                 | Some _ ->
+                     Log.Server.debug
+                       "[ws-standalone] send_pong skipped (writer closed during \
+                        cancel race)"
+                 | None ->
+                     Log.Server.warn
+                       "[ws-standalone] send_pong failed: %s"
+                       (Printexc.to_string exn)));
         Ws.Payload.close payload
       | `Connection_close ->
         Server_mcp_transport_ws.cleanup_session session_id;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1,5 +1,3 @@
-module Types = Masc_domain
-
 (** CI/dashboard hardening source guards. *)
 
 open Alcotest

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1033,6 +1033,22 @@ let test_transport_health_contracts () =
           {|Coord.get_messages_raw_in_room|}))
   (* command plane topology reads guard removed (CP purge: Command_plane_v2 deleted) *)
 
+let test_http_cancel_response_contracts () =
+  check bool "main_eio preserves cancellation propagation before 500 fallback" true
+    (file_contains_nearby_line_with_patterns "bin/main_eio.ml"
+       ~anchor:{|else dispatch_route ~routes ~request ~path reqd|}
+       ~patterns:[ {|Eio.Cancel.Cancelled _ as exn|}; {|raise exn|} ]
+       ~max_lines:3);
+  check bool "main_eio suppresses stale httpun response writes" true
+    (file_contains_pattern "bin/main_eio.ml"
+       {|httpun.Reqd.respond_with_string: invalid state|});
+  check bool "main_eio 500 fallback is best-effort" true
+    (file_contains_pattern "bin/main_eio.ml"
+       {|try_internal_error_response|});
+  check bool "standalone ws closed writer is not warning noise" true
+    (file_contains_pattern "lib/server/server_ws_standalone.ml"
+       {|Failure "cannot write to closed writer"|})
+
 let test_worktree_list_contracts () =
   check bool "worktree list stays read-only" true
     (file_contains_pattern "lib/tool_worktree.ml"
@@ -1401,6 +1417,8 @@ let () =
              test_transport_route_contracts;
            test_case "transport health contracts" `Quick
              test_transport_health_contracts;
+           test_case "http cancel response contracts (#13059)" `Quick
+             test_http_cancel_response_contracts;
            test_case "worktree list contracts" `Quick
              test_worktree_list_contracts;
            test_case "oas worker capability threading contracts" `Quick

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -254,6 +254,84 @@ let request_tests = [
   "header", `Quick, test_request_header;
 ]
 
+(* ===== Late_response classifier (#13059) ===== *)
+
+(* Behavioural regression for the cancellation-vs-late-write race.
+   Before #13059 a top-level handler [exception] arm caught
+   [Eio.Cancel.Cancelled] and converted it into a 500 — that 500
+   write itself would fail because the underlying writer was already
+   in "invalid state" / "closed", and the *secondary* failure shadowed
+   the original cancellation.  The fix re-raises [Cancelled] and
+   downgrades the two well-known late-response failure shapes to a
+   warning.  The classifier below is the SSOT for "what counts as a
+   recognised late-response failure" — these tests pin its truth
+   table so a future refactor cannot silently widen or narrow it. *)
+
+let test_late_response_classifies_invalid_state_failure () =
+  let exn =
+    Failure
+      "httpun.Reqd.respond_with_string: invalid state, response already \
+       written"
+  in
+  match Late_response.classify_write_failure exn with
+  | Some msg ->
+      Alcotest.(check bool) "preserves the original message"
+        true (String.length msg > 0);
+      Alcotest.(check bool) "message is the failure payload"
+        true
+        (String.starts_with msg
+           ~prefix:"httpun.Reqd.respond_with_string: invalid state")
+  | None -> Alcotest.fail "expected Some _ for httpun invalid state failure"
+
+let test_late_response_classifies_closed_writer_failure () =
+  match
+    Late_response.classify_write_failure
+      (Failure "cannot write to closed writer")
+  with
+  | Some msg ->
+      Alcotest.(check string) "stable closed-writer label"
+        "cannot write to closed writer" msg
+  | None -> Alcotest.fail "expected Some _ for closed-writer failure"
+
+let test_late_response_does_not_classify_cancellation () =
+  (* Cancellation MUST NOT be classified as a late-response failure —
+     callers re-raise [Cancelled] before invoking the classifier so
+     that the cancellation propagates out of the request handler. *)
+  let cancelled = Eio.Cancel.Cancelled (Failure "test cancellation") in
+  Alcotest.(check (option string))
+    "Cancelled is not a late-response failure"
+    None
+    (Late_response.classify_write_failure cancelled)
+
+let test_late_response_ignores_unrelated_failures () =
+  let cases =
+    [
+      ("Failure with unrelated message", Failure "boom");
+      ("Failure with empty message", Failure "");
+      ("Not_found", Not_found);
+      ("Division_by_zero", Division_by_zero);
+      ( "Failure mentioning httpun without invalid state prefix",
+        Failure "httpun.Reqd: nothing to do" );
+    ]
+  in
+  List.iter
+    (fun (label, exn) ->
+      Alcotest.(check (option string))
+        label None
+        (Late_response.classify_write_failure exn))
+    cases
+
+let late_response_tests = [
+  "invalid state failure -> Some msg", `Quick,
+  test_late_response_classifies_invalid_state_failure;
+  "closed writer failure -> Some 'cannot write to closed writer'", `Quick,
+  test_late_response_classifies_closed_writer_failure;
+  "Eio.Cancel.Cancelled -> None (caller re-raises)", `Quick,
+  test_late_response_does_not_classify_cancellation;
+  "unrelated exceptions -> None", `Quick,
+  test_late_response_ignores_unrelated_failures;
+]
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -263,4 +341,5 @@ let () =
     "router", router_tests;
     "config", config_tests;
     "request", request_tests;
+    "late_response", late_response_tests;
   ]


### PR DESCRIPTION
## Summary
- keep Eio cancellations out of the generic HTTP 500 fallback path
- treat stale httpun response writes as late closed-request events instead of process-fatal exceptions
- downgrade standalone WebSocket closed-writer teardown to debug noise

## Root cause
The top-level HTTP handler caught every exception and tried to write a 500 response on the same Httpun.Reqd. During OAS cancellation or client-close/error handling, that Reqd may already be unwritable, producing the observed 'httpun.Reqd.respond_with_string: invalid state' failure.

## Verification
- git diff --check
- source guard patterns for the cancellation and closed-writer contracts
- focused Dune build was not run locally because the shared Dune lock is held by long-running jobs; CI should be used after #13079 clears the current generated-config drift blocker.

Closes #13059.