### PR TITLE
feat(observe): expose GOAL LOOP warning metrics

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -921,7 +921,13 @@ let archive_credential_file config ~agent_name ~reason =
       Sys.rename src dest;
       Log.Auth.warn
         "archived credential %s -> %s (reason: %s)"
-        src dest reason
+        src dest reason;
+      if String.equal reason "bare-form keeper credential is dead after PR-3b1 starvation"
+      then
+        Prometheus.inc_counter
+          Prometheus.metric_config_credential_archived_starvation
+          ~labels:[("keeper_name", agent_name)]
+          ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -215,6 +215,22 @@ let profile_probes (profile_candidates : candidate_runtime list) =
         "runtime provider health is advisory; bootstrap skips live probe")
     profile_candidates
 
+let record_advisory_probe_skips (profiles : profile_snapshot list) =
+  List.iter
+    (fun (profile : profile_snapshot) ->
+      List.iter
+        (fun (candidate : candidate_runtime) ->
+          Prometheus.inc_counter
+            Prometheus.metric_provider_health_probe_skipped
+            ~labels:
+              [
+                ("provider_name", provider_kind_string candidate.provider_cfg);
+                ("profile_name", profile.name);
+              ]
+            ())
+        profile.candidates)
+    profiles
+
 let candidate_probe_to_yojson (probe : candidate_probe) =
   `Assoc
     [
@@ -610,6 +626,7 @@ let validate_path_result ~config_path =
               profiles = profile_snapshots;
             }
           in
+          record_advisory_probe_skips profile_snapshots;
           if rejected_profiles = [] then
             Ok { snapshot; rejected_update = None }
           else

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -538,7 +538,9 @@ let compute_judgments
             (* #9774: surface a preview of the raw text so the next
                diagnostic pass can see what shape the LLM is producing
                without having to enable raw provider logging. *)
-            let msg = Judge_diagnostics.format_lenient_fallback ~judge_label:"Governance" raw in
+            let msg =
+              Judge_diagnostics.record_lenient_fallback ~judge_label:"Governance" raw
+            in
             Log.Governance.warn "%s" msg;
             Error msg
         | _ ->

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -223,7 +223,9 @@ let compute_judgments
         | `Assoc [("raw", `String raw)] ->
             (* #9774: include a preview so the failure diagnostic doesn't
                require enabling raw provider logging. *)
-            let msg = Judge_diagnostics.format_lenient_fallback ~judge_label:"Operator" raw in
+            let msg =
+              Judge_diagnostics.record_lenient_fallback ~judge_label:"Operator" raw
+            in
             Log.Governance.warn "%s" msg;
             Error msg
         | parsed -> Ok (response.model, parsed)

--- a/lib/dashboard/judge_diagnostics.ml
+++ b/lib/dashboard/judge_diagnostics.ml
@@ -1,5 +1,7 @@
 (* #9774: shared helpers for governance / operator judge LLM-output
-   diagnostics. Pure string transforms — no logging, no I/O. *)
+   diagnostics. Formatting remains pure; [record_lenient_fallback]
+   is the explicit metric-emitting wrapper used by production fallback
+   branches. *)
 
 (* Truncate a string to at most [max_bytes] bytes, appending an ellipsis
    marker that records how many bytes were dropped. Byte-count is
@@ -20,3 +22,15 @@ let format_lenient_fallback ~judge_label raw =
     judge_label
     (String.length raw)
     (truncate_with_marker raw)
+
+let record_lenient_fallback ~judge_label raw =
+  let labels = [("judge", String.lowercase_ascii judge_label)] in
+  Prometheus.inc_counter
+    Prometheus.metric_governance_judge_unparseable
+    ~labels
+    ();
+  Prometheus.inc_counter
+    Prometheus.metric_governance_lenient_json_fallback_hit
+    ~labels
+    ();
+  format_lenient_fallback ~judge_label raw

--- a/lib/dashboard/judge_diagnostics.mli
+++ b/lib/dashboard/judge_diagnostics.mli
@@ -9,3 +9,7 @@ val format_lenient_fallback : judge_label:string -> string -> string
     the [Lenient_json.parse] [\`Assoc [("raw", _)]] fallback. The
     output is consumed both as the warn log payload and as the [Error]
     returned upstream. *)
+
+val record_lenient_fallback : judge_label:string -> string -> string
+(** Increment the judge fallback metrics and return
+    {!format_lenient_fallback}. *)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1109,11 +1109,17 @@ let warn_unknown_keeper_toml_keys ~path (doc : Keeper_toml_loader.toml_doc) =
   | [] -> ()
   | unknown ->
     let unknown = normalize_unknown_keeper_toml_keys unknown in
-    if warn_unknown_keeper_toml_keys_once ~path unknown then
+    if warn_unknown_keeper_toml_keys_once ~path unknown then begin
+      Prometheus.inc_counter
+        Prometheus.metric_config_unknown_keys_ignored
+        ~labels:[("file_path", path)]
+        ~delta:(float_of_int (List.length unknown))
+        ();
       Log.Keeper.warn
         "keeper TOML %s has unknown keys: %s"
         path
         (String.concat ", " unknown)
+    end
 
 let merge_string_list ~base overlay =
   match overlay with [] -> base | xs -> xs

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -959,6 +959,8 @@ let metric_cascade_server_error_skip_total =
    participants are listed in the WARN log. *)
 let metric_cascade_fallback_cycle_detected_total =
   "masc_cascade_fallback_cycle_detected_total"
+let metric_provider_health_probe_skipped =
+  "masc_provider_health_probe_skipped_total"
 (* #12799: Passive loop detector — keeper emitting only read-only tool
    calls for N consecutive turns.  Labels: keeper. *)
 let metric_keeper_passive_loop_detected_total =
@@ -1028,6 +1030,8 @@ let metric_auth_credential_token_duplicate =
    bounded repair scope. *)
 let metric_auth_credential_token_rotated =
   "masc_auth_credential_token_rotated_total"
+let metric_config_credential_archived_starvation =
+  "masc_config_credential_archived_starvation_total"
 
 (* #9786 runtime complement: every [find_credential_by_token]
    lookup that hits N>=2 matches fires this counter.  The
@@ -1079,6 +1083,12 @@ let metric_empty_tool_universe_observed =
    [metric_silent_auth_token_resolve_error] for auth/name drift diagnosis. *)
 let metric_coord_join_normalize_outcome =
   "masc_coord_join_normalize_outcome_total"
+let metric_config_unknown_keys_ignored =
+  "masc_config_unknown_keys_ignored_total"
+let metric_governance_judge_unparseable =
+  "masc_governance_judge_unparseable_total"
+let metric_governance_lenient_json_fallback_hit =
+  "masc_governance_lenient_json_fallback_hit_total"
 
 
 
@@ -1581,6 +1591,12 @@ let init () =
      a provider stall propagates through both cascades silently for \
      600s+ without escaping.  Labeled by [cascade] (cycle entry point)."
     Counter;
+  add metric_provider_health_probe_skipped
+    "Total bootstrap/runtime-catalog provider health probes intentionally \
+     skipped as advisory. Labels: provider_name, profile_name. Any non-zero \
+     value means provider liveness was not actually probed at catalog \
+     validation time."
+    Counter;
   add metric_keeper_passive_loop_detected_total
     "#12799 Total passive-loop detections: keeper issued only read-only tool \
      calls for N consecutive turns. Labeled by keeper."
@@ -1926,6 +1942,10 @@ let init () =
      group (labels: token_hash_prefix, scope). Any positive value means \
      boot-time prevention repaired ambiguous credential state."
     Counter;
+  add metric_config_credential_archived_starvation
+    "Total bare-form keeper credential files archived because they are dead \
+     after PR-3b1 starvation. Labels: keeper_name."
+    Counter;
   add metric_telemetry_coverage_gap
     "Total telemetry coverage gaps recorded before append to the durable \
      coverage-gap store. Labels: source, producer, dashboard_surface, \
@@ -1977,6 +1997,19 @@ let init () =
      Non-ok outcomes reject masc_join at the fail-closed identity gate; pair \
      with masc_silent_auth_token_resolve_error_total for auth/name drift \
      diagnosis."
+    Counter;
+  add metric_config_unknown_keys_ignored
+    "Total unknown config keys ignored after warning. Labels: file_path. \
+     The counter increments by the number of unknown keys in a newly-observed \
+     keeper TOML warning set."
+    Counter;
+  add metric_governance_judge_unparseable
+    "Total governance/operator judge responses that remained unparseable \
+     after deterministic JSON recovery. Labels: judge."
+    Counter;
+  add metric_governance_lenient_json_fallback_hit
+    "Total Lenient_json fallback hits for governance/operator judge output. \
+     Labels: judge."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -465,6 +465,11 @@ val metric_cascade_fallback_cycle_detected_total : string
     (the entry point of the detected cycle).  Discovered during the
     2026-05-05 fleet-stuck investigation:
     [big_three → glm_coding_plan_only → big_three]. *)
+
+val metric_provider_health_probe_skipped : string
+(** Total bootstrap/runtime-catalog provider health probes intentionally
+    skipped as advisory. Labels: [provider_name, profile_name]. *)
+
 val metric_keeper_invariant_violations : string
 
 (** PR-I: cross-FSM edge transition counter. Labels: [edge] with values
@@ -682,6 +687,10 @@ val metric_auth_credential_token_rotated : string
     boot-time repair rotates out of a shared bearer-token group.
     Labels: [token_hash_prefix, scope]. *)
 
+val metric_config_credential_archived_starvation : string
+(** Bare-form keeper credential files archived because they are dead after
+    PR-3b1 starvation. Labels: [keeper_name]. *)
+
 val metric_auth_credential_ambiguous_lookup : string
 (** #9786 runtime complement: every [find_credential_by_token]
     lookup that hits N>=2 matches fires this counter.
@@ -729,6 +738,17 @@ val metric_coord_join_normalize_outcome : string
     Non-ok outcomes reject [masc_join] at the fail-closed identity gate.
     Cross-reference [metric_silent_auth_token_resolve_error] for auth/name
     drift diagnosis. *)
+
+val metric_config_unknown_keys_ignored : string
+(** Unknown config keys ignored after warning. Labels: [file_path]. *)
+
+val metric_governance_judge_unparseable : string
+(** Governance/operator judge responses that remained unparseable after
+    deterministic JSON recovery. Labels: [judge]. *)
+
+val metric_governance_lenient_json_fallback_hit : string
+(** Lenient_json fallback hits for governance/operator judge output.
+    Labels: [judge]. *)
 
 
 (** {1 Transport metrics} *)

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -647,6 +647,13 @@ let test_ensure_keeper_credential_archives_dual_identity_bare () =
       in
       let bare_path = Auth.credential_file dir "sangsu" in
       check bool "bare credential pre-exists" true (Sys.file_exists bare_path);
+      let archive_metric () =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_config_credential_archived_starvation
+          ~labels:[("keeper_name", "sangsu")]
+          ()
+      in
+      let before_archive_metric = archive_metric () in
       (* Now ensure the canonical is created — should self-heal. *)
       (match
          Auth.ensure_keeper_credential dir
@@ -658,6 +665,9 @@ let test_ensure_keeper_credential_archives_dual_identity_bare () =
         (Sys.file_exists bare_path);
       check bool "bare credential archived" true
         (archive_contains dir "sangsu.json");
+      check (float 0.0001) "starvation archive metric increments"
+        (before_archive_metric +. 1.0)
+        (archive_metric ());
       let canonical_path =
         Auth.credential_file dir "keeper-sangsu-agent"
       in

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -331,6 +331,13 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
   let config_dir = Filename.concat dir "config" in
   init_config_root config_dir;
   with_config_dir config_dir @@ fun () ->
+  let skip_metric () =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_provider_health_probe_skipped
+      ~labels:[("provider_name", "custom"); ("profile_name", "big_three")]
+      ()
+  in
+  let before_skip_metric = skip_metric () in
   let shared_model = Printf.sprintf "custom:mock@%s/v1" dummy_base_url in
   let custom_exec_model =
     Printf.sprintf "custom:custom-exec@%s/v1" dummy_base_url
@@ -364,6 +371,9 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
   check int "profile_count" 4 (json_int_field "profile_count" snapshot_json);
   check bool "bootstrap probe status is skipped" true
     (contains_substring (Yojson.Safe.to_string snapshot_json) "\"status\":\"skipped\"");
+  check (float 0.0001) "bootstrap skip metric increments for big_three"
+    1.0
+    (skip_metric () -. before_skip_metric);
   let blank_name =
     require_ok
       (Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" ())

--- a/test/test_judge_diagnostics.ml
+++ b/test/test_judge_diagnostics.ml
@@ -51,6 +51,44 @@ let test_format_lenient_fallback_truncates_huge_raw () =
   check bool "preview is bounded" true
     (String.length out < 1500)
 
+let test_record_lenient_fallback_increments_metrics () =
+  let raw = "not-json" in
+  let labels = [("judge", "governance")] in
+  let unparseable_before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_governance_judge_unparseable
+      ~labels
+      ()
+  in
+  let fallback_before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_governance_lenient_json_fallback_hit
+      ~labels
+      ()
+  in
+  let out =
+    Judge_diagnostics.record_lenient_fallback
+      ~judge_label:"Governance"
+      raw
+  in
+  check bool "returns formatted diagnostic" true
+    (try
+       let re = Re.Pcre.re "Governance judge returned unparseable" |> Re.compile in
+       ignore (Re.exec re out); true
+     with Not_found -> false);
+  check (float 0.0001) "unparseable counter increments"
+    (unparseable_before +. 1.0)
+    (Prometheus.metric_value_or_zero
+       Prometheus.metric_governance_judge_unparseable
+       ~labels
+       ());
+  check (float 0.0001) "fallback counter increments"
+    (fallback_before +. 1.0)
+    (Prometheus.metric_value_or_zero
+       Prometheus.metric_governance_lenient_json_fallback_hit
+       ~labels
+       ())
+
 let () =
   run "judge_diagnostics (#9774)"
     [
@@ -66,5 +104,7 @@ let () =
             test_format_lenient_fallback_includes_label;
           test_case "preview is bounded for huge raw" `Quick
             test_format_lenient_fallback_truncates_huge_raw;
+          test_case "record increments metrics" `Quick
+            test_record_lenient_fallback_increments_metrics;
         ] );
     ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1702,6 +1702,13 @@ legacy_scope = "removed"
 typo_field = 42
 |};
   close_out oc;
+  let unknown_metric () =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_config_unknown_keys_ignored
+      ~labels:[("file_path", tmp)]
+      ()
+  in
+  let before_unknown_metric = unknown_metric () in
   match KTP.load_keeper_toml tmp with
   | Error e -> Sys.remove tmp; fail e
   | Ok (_, defaults) ->
@@ -1709,7 +1716,11 @@ typo_field = 42
     check (slist string String.compare)
       "unknown keys captured on profile defaults"
       [ "keeper.legacy_scope"; "keeper.typo_field" ]
-      defaults.KTP.unknown_toml_keys
+      defaults.KTP.unknown_toml_keys;
+    check (float 0.0001)
+      "unknown-key metric increments by key count"
+      2.0
+      (unknown_metric () -. before_unknown_metric)
 
 let test_unknown_toml_warning_key_normalizes_unknown_order () =
   let path =


### PR DESCRIPTION
## Summary

Adds the first concrete Observe slice for the GOAL LOOP work: live warning and fallback paths now emit Prometheus counters instead of remaining log-only evidence.

- Registers counters for provider health probe skips, keeper TOML unknown-key warnings, starvation credential archives, and governance/operator lenient JSON fallback.
- Wires the counters at the existing runtime call sites.
- Adds focused regression assertions around each new metric.

## Product impact

Operators can now alert and dashboard on several GOAL LOOP failure signals that were previously only visible in logs:

- bootstrap/provider health probes skipped as advisory
- keeper credential archives caused by PR-3b1 starvation repair
- unknown keeper TOML keys being ignored after warning
- governance/operator judge output falling into lenient fallback

This does not claim to fix the underlying provider, recovery, or keeper starvation failures. It makes the first Observe layer measurable so later Orient/Decide/Act work can be driven by counters rather than grep.

## Evidence

- `git diff --check`
- GitHub checks on head `63524d6c99570a5b19c8744ee5c8d0ced9146fb8`:
  - `PR Sync Check`: success
  - `PR Live Gate`: success
  - `Hardcoded model prefix`: success
  - `Math.random in components`: success
  - `Godfile size`: success
- `CI Gate`: expected failure while this remains a draft `agent-pr` without `human-approved-ready`.

Local focused OCaml proof was attempted but is blocked by the shared machine toolchain state:

- `scripts/dune-local.sh build test/test_auth.exe test/test_cascade_catalog_runtime.exe test/test_judge_diagnostics.exe test/test_keeper_toml.exe` queued behind `/tmp/me-dune-local.lock`, held by an unrelated `dune runtest --root .../.worktrees/sprint-3-cascade-throttle-atomic test/` for over an hour.
- Isolated fallback:

```text
env DUNE_BUILD_DIR=.../_build-codex-13085 DUNE_JOBS=1 dune build --root ... test/test_auth.exe test/test_cascade_catalog_runtime.exe test/test_judge_diagnostics.exe test/test_keeper_toml.exe
```

failed before compiling this PR because the local opam switch is missing the required `agent_sdk` compiled artifacts, for example:

```text
Error: File unavailable:
/Users/dancer/.opam/5.4.1/lib/agent_sdk/base/completion_contract_id.cmi
```

## Review evidence

Review focus:

- Counter labels and names in `lib/prometheus.{ml,mli}`.
- Whether `record_advisory_probe_skips` belongs only in catalog validation and not read-only JSON rendering.
- Whether the starvation credential counter should remain tied to the exact PR-3b1 archive reason or be generalized.
- Whether governance and operator judge fallbacks should share the same counter family with a `judge` label.

## Linked issue

N/A - derived from the 2026-05-05 GOAL LOOP/live-log audit.
