### PR TITLE
chore(ratchet): bump raw_error_kind_string_signatures baseline 0→1

### DIFF
--- a/scripts/stringly-boundary-baseline.json
+++ b/scripts/stringly-boundary-baseline.json
@@ -3,7 +3,7 @@
   "_metrics": "See scripts/stringly-boundary-ratchet.sh METRICS / DESCRIPTIVE_METRICS arrays.",
   "_issue": "#11926",
   "raw_decision_string_signatures": 0,
-  "raw_error_kind_string_signatures": 0,
+  "raw_error_kind_string_signatures": 1,
   "raw_cascade_name_string_signatures": 81,
   "raw_status_string_signatures": 91
 }


### PR DESCRIPTION
## Summary

PR #13066 added `?error_kind:string` at a wire/log boundary in
`lib/worker_dev_tools.mli:144` without bumping the strict ratchet
baseline.  Every PR rebased on top now fails OCaml Structure Ratchet
with:

```
[stringly-boundary-ratchet] DRIFT UP: raw_error_kind_string_signatures
  current=1 baseline=0
[stringly-boundary-ratchet] FAIL - current exceeds baseline
```

This is a one-line baseline bump (0→1) reflecting the intentional
wire-boundary change.

## Why baseline bump (not typed wrapper)

The hint in `scripts/stringly-boundary-ratchet.sh` allows raw `string`
signatures **at wire/log boundaries**.  `worker_dev_tools.mli`'s
`emit_tool_exec` observer is exactly such a boundary (developer-tools
tool execution log).  Typed wrapper would be premature — the boundary
will eventually be migrated under the broader #11926 sweep.

## Verified

```
$ bash scripts/stringly-boundary-ratchet.sh
[stringly-boundary-ratchet] OK
```

## Unblocks

- PR #13068 (EINTR waitpid fix) — production fleet stalling every
  ~30s on `Credential_materializer.gh_auth_status_ok` EINTR (15+
  occurrences in last 5 min, 9+ keepers stuck on
  `stale_turn_timeout(idle 300+s)`).

## Follow-up

Tracked under #11926 (parent stringly-boundary sweep).  No separate
issue opened because the change is a baseline reflection of an already
intentional wire-boundary signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>