### PR TITLE
chore(dashboard): drop dead persona-schema computed signals (–6 LOC)

### DIFF
--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -176,13 +176,6 @@ export async function loadPersonas(): Promise<void> {
   })
 }
 
-export const personaSchema = computed(() => getData(personaSchemaResource.state.value) ?? null)
-export const personaSchemaLoading = computed(() => personaSchemaResource.state.value.status === 'loading')
-export const personaSchemaError = computed<string | null>(() => {
-  const s = personaSchemaResource.state.value
-  return s.status === 'error' ? s.message : null
-})
-
 export async function loadPersonaSchema(): Promise<void> {
   await personaSchemaResource.load(async () => {
     const raw = await callMcpTool('masc_persona_schema', {})


### PR DESCRIPTION
## Summary
\`keeper-spawn-state.ts\` 의 \`personaSchema\` / \`personaSchemaLoading\` / \`personaSchemaError\` 3개 \`computed()\` signal 이 export 만 되고 어디서도 \`.value\` 가 읽히지 않음. 자기 파일 내부, 다른 \`dashboard/src/\` 모듈, 테스트 모두 0건 — 미래의 schema-driven UI를 위한 prophylactic plumbing 이었으나 wiring 이 들어오지 않음.

## Removed
- \`personaSchema\` (line 179)
- \`personaSchemaLoading\` (line 180)
- \`personaSchemaError\` (lines 181-184)

**Net: –6 LOC** (–7 incl. blank).

## Kept
- \`personaSchemaResource\` + \`loadPersonaSchema()\` — \`masc_persona_schema\` MCP tool 경로를 유지. 나중에 schema-driven 패널이 mount 되면 loader 부활 가능.
- \`PersonaSchema\` interface + \`normalizePersonaSchema()\` — \`keeper-spawn-state.test.ts:105\` 가 normalizer 를 검증 → contract anchor 로 보존.

## Verification
- \`tsc --noEmit\` clean.
- \`vitest run src/components/keeper-spawn\` → 3 file / 26 test pass.

## Test plan
- [x] tsc 통과
- [x] keeper-spawn vitest 통과
- [ ] CI green 후 ready 전환은 \`human-approved-ready\` label 흐름

🤖 Generated with [Claude Code](https://claude.com/claude-code)