### PR TITLE
feat(observe): add GOAL LOOP log scanner

### DIFF
--- a/scripts/decide_goal_loop_findings.py
+++ b/scripts/decide_goal_loop_findings.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Decide GOAL LOOP actions from oriented live-log findings.
+
+This consumes the JSON emitted by ``orient_goal_loop_logs.py`` and maps
+evidence-present findings to a small, explicit decision queue. It is deliberately
+static: the output is an auditable recommendation list, not an auto-remediator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+
+@dataclass(frozen=True)
+class DecisionSpec:
+    decision_id: str
+    priority: str
+    finding_ids: tuple[str, ...]
+    action: str
+    owner: str
+    estimated_hours: int
+    impact: int
+    urgency: int
+    difficulty: int
+
+
+@dataclass
+class DecisionReport:
+    decision_id: str
+    priority: str
+    matched_findings: list[str]
+    action: str
+    owner: str
+    estimated_hours: int
+    score: float
+
+
+@dataclass
+class DecideReport:
+    source_findings_total: int
+    evidence_present: int
+    decisions_total: int
+    p0_count: int
+    decisions: list[DecisionReport]
+
+
+DECISIONS: tuple[DecisionSpec, ...] = (
+    DecisionSpec(
+        decision_id="D-EMERGENCY-1",
+        priority="P0",
+        finding_ids=("NF-2",),
+        action="Slot forced reclaim + keeper credential auto-recovery",
+        owner="concurrency",
+        estimated_hours=8,
+        impact=10,
+        urgency=10,
+        difficulty=8,
+    ),
+    DecisionSpec(
+        decision_id="D-EMERGENCY-2",
+        priority="P0",
+        finding_ids=("NF-1",),
+        action="Run bootstrap provider health checks instead of advisory skip",
+        owner="provider",
+        estimated_hours=4,
+        impact=10,
+        urgency=10,
+        difficulty=4,
+    ),
+    DecisionSpec(
+        decision_id="D-P1-1",
+        priority="P1",
+        finding_ids=("NF-3", "R-FATAL-1"),
+        action="Execute recovery strategy and add keeper fallback ladder",
+        owner="keeper",
+        estimated_hours=16,
+        impact=9,
+        urgency=9,
+        difficulty=8,
+    ),
+    DecisionSpec(
+        decision_id="D-P1-2",
+        priority="P1",
+        finding_ids=("CF-1",),
+        action="Add provider discovery/pricing refresh path for catalog misses",
+        owner="provider",
+        estimated_hours=24,
+        impact=8,
+        urgency=7,
+        difficulty=8,
+    ),
+    DecisionSpec(
+        decision_id="D-P2-1",
+        priority="P2",
+        finding_ids=("NF-6",),
+        action="Enforce keeper TOML schema for unknown keys",
+        owner="config",
+        estimated_hours=8,
+        impact=6,
+        urgency=5,
+        difficulty=4,
+    ),
+    DecisionSpec(
+        decision_id="D-P2-2",
+        priority="P2",
+        finding_ids=("NF-4",),
+        action="Make governance judge parse failure strict and observable",
+        owner="governance",
+        estimated_hours=8,
+        impact=6,
+        urgency=5,
+        difficulty=5,
+    ),
+)
+
+
+PRIORITY_RANK = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+
+
+def load_json_input(path: str) -> dict[str, Any]:
+    if path == "-":
+        return load_json_handle(sys.stdin)
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return load_json_handle(handle)
+
+
+def load_json_handle(handle: TextIO) -> dict[str, Any]:
+    data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("expected Orient JSON object")
+    return data
+
+
+def priority_score(spec: DecisionSpec) -> float:
+    return float(spec.impact * spec.urgency) / float(max(spec.difficulty, 1))
+
+
+def present_finding_ids(orient: dict[str, Any]) -> set[str]:
+    findings = orient.get("findings", [])
+    if not isinstance(findings, list):
+        return set()
+    present: set[str] = set()
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        if finding.get("status") != "EVIDENCE_PRESENT":
+            continue
+        finding_id = finding.get("finding_id")
+        if isinstance(finding_id, str):
+            present.add(finding_id)
+    return present
+
+
+def decide_orient(orient: dict[str, Any]) -> DecideReport:
+    present = present_finding_ids(orient)
+    decisions: list[DecisionReport] = []
+    for spec in DECISIONS:
+        matched = [
+            finding_id for finding_id in spec.finding_ids if finding_id in present
+        ]
+        if not matched:
+            continue
+        decisions.append(
+            DecisionReport(
+                decision_id=spec.decision_id,
+                priority=spec.priority,
+                matched_findings=matched,
+                action=spec.action,
+                owner=spec.owner,
+                estimated_hours=spec.estimated_hours,
+                score=round(priority_score(spec), 2),
+            )
+        )
+
+    decisions.sort(
+        key=lambda item: (
+            PRIORITY_RANK.get(item.priority, 99),
+            -item.score,
+            item.decision_id,
+        )
+    )
+    source_findings = orient.get("findings", [])
+    source_findings_total = (
+        len(source_findings) if isinstance(source_findings, list) else 0
+    )
+    return DecideReport(
+        source_findings_total=source_findings_total,
+        evidence_present=len(present),
+        decisions_total=len(decisions),
+        p0_count=sum(1 for decision in decisions if decision.priority == "P0"),
+        decisions=decisions,
+    )
+
+
+def report_to_json(report: DecideReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: DecideReport) -> str:
+    lines = [
+        "GOAL LOOP Decide Queue",
+        f"evidence_present: {report.evidence_present}/{report.source_findings_total}",
+        f"decisions_total: {report.decisions_total}",
+        f"p0_count: {report.p0_count}",
+    ]
+    for decision in report.decisions:
+        lines.append(
+            f"- {decision.decision_id} {decision.priority} score={decision.score}: "
+            f"{decision.action} "
+            f"(owner={decision.owner}, findings={','.join(decision.matched_findings)}, "
+            f"eta={decision.estimated_hours}h)"
+        )
+    return "\n".join(lines)
+
+
+def should_fail(report: DecideReport, mode: str) -> bool:
+    if mode == "none":
+        return False
+    if mode == "any":
+        return report.decisions_total > 0
+    if mode == "p0":
+        return report.p0_count > 0
+    raise ValueError(f"unknown fail mode: {mode}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "orient_json",
+        nargs="?",
+        default="-",
+        help="Orient JSON path, or '-' for stdin (default).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "any", "p0"),
+        default="none",
+        help="Exit non-zero when decisions match this condition.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    report = decide_orient(load_json_input(args.orient_json))
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    return 1 if should_fail(report, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/observe_goal_loop_logs.py
+++ b/scripts/observe_goal_loop_logs.py
@@ -117,6 +117,24 @@ PATTERNS: tuple[PatternSpec, ...] = (
         "Configuration parser ignored unknown keys after warning.",
     ),
     PatternSpec(
+        "autoboot_warmup",
+        r"warmup=\s*\d+s",
+        "warning",
+        "Keeper autoboot warmup delay marker.",
+    ),
+    PatternSpec(
+        "tool_policy_unknown_tools",
+        r"(tool[_ -]?policy.*unknown tools|unknown tools.*tool[_ -]?policy)",
+        "warning",
+        "Tool policy reported unknown tools.",
+    ),
+    PatternSpec(
+        "keeper_checkpoint_migration_data_loss",
+        r"(checkpoint migration.*data loss|data loss.*checkpoint migration)",
+        "critical",
+        "Keeper checkpoint migration reported data loss.",
+    ),
+    PatternSpec(
         "metric_all_zero",
         r"ka=0ms.*audit=0ms.*profile=0ms",
         "warning",

--- a/scripts/observe_goal_loop_logs.py
+++ b/scripts/observe_goal_loop_logs.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Scan MASC logs for GOAL LOOP Observe failure signatures.
+
+This is a lightweight bridge between raw production logs and the GOAL LOOP
+Observe phase. It intentionally does not infer recovery or root cause; it only
+counts concrete line-level signatures so operators can compare live evidence
+with audit findings without hand-grepping logs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, TextIO
+
+
+@dataclass(frozen=True)
+class PatternSpec:
+    name: str
+    regex: str
+    severity: str
+    description: str
+
+
+@dataclass
+class MatchSample:
+    path: str
+    line: int
+    text: str
+
+
+@dataclass
+class PatternReport:
+    count: int
+    severity: str
+    description: str
+    samples: list[MatchSample]
+
+
+@dataclass
+class ScanReport:
+    files: list[str]
+    total_lines: int
+    matched_lines: int
+    patterns: dict[str, PatternReport]
+
+
+PATTERNS: tuple[PatternSpec, ...] = (
+    PatternSpec(
+        "keeper_skipping_turn",
+        r"skipping turn.*semaphore wait",
+        "critical",
+        "Keeper turn skipped after semaphore wait.",
+    ),
+    PatternSpec(
+        "keeper_keepalive_only",
+        r"keepalive turn scheduled",
+        "warning",
+        "Keepalive turn scheduled marker; line-level evidence only.",
+    ),
+    PatternSpec(
+        "pricing_catalog_miss",
+        r"pricing_catalog_miss model=",
+        "critical",
+        "Pricing catalog missed a model.",
+    ),
+    PatternSpec(
+        "provider_health_skipped",
+        r"status.*skipped.*bootstrap skips",
+        "warning",
+        "Provider health probe skipped as advisory during bootstrap.",
+    ),
+    PatternSpec(
+        "credential_archived_starvation",
+        r"archived credential.*starvation",
+        "critical",
+        "Keeper credential archived because of starvation recovery.",
+    ),
+    PatternSpec(
+        "alive_but_stuck",
+        r"alive-but-stuck detected",
+        "critical",
+        "Supervisor detected alive-but-stuck keeper state.",
+    ),
+    PatternSpec(
+        "governance_unparseable",
+        r"Governance judge returned unparseable",
+        "warning",
+        "Governance judge response was unparseable.",
+    ),
+    PatternSpec(
+        "lenient_json_fallback",
+        r"Lenient_json fallback hit",
+        "warning",
+        "Lenient JSON fallback parsed an otherwise invalid response.",
+    ),
+    PatternSpec(
+        "utf8_repair",
+        r"persistence UTF-8 repaired",
+        "critical",
+        "Persistence layer repaired invalid UTF-8.",
+    ),
+    PatternSpec(
+        "cas_retry",
+        r"write_meta CAS retry",
+        "warning",
+        "Metadata write hit a CAS retry.",
+    ),
+    PatternSpec(
+        "config_unknown_key",
+        r"has unknown keys",
+        "warning",
+        "Configuration parser ignored unknown keys after warning.",
+    ),
+    PatternSpec(
+        "metric_all_zero",
+        r"ka=0ms.*audit=0ms.*profile=0ms",
+        "warning",
+        "Dashboard keeper sub-operation metrics are all zero.",
+    ),
+)
+
+
+def iter_input_lines(paths: list[str]) -> Iterable[tuple[str, int, str]]:
+    if not paths:
+        yield from iter_handle("<stdin>", sys.stdin)
+        return
+
+    for raw_path in paths:
+        if raw_path == "-":
+            yield from iter_handle("<stdin>", sys.stdin)
+            continue
+        path = Path(raw_path)
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            yield from iter_handle(str(path), handle)
+
+
+def iter_handle(path: str, handle: TextIO) -> Iterable[tuple[str, int, str]]:
+    for line_no, line in enumerate(handle, start=1):
+        yield path, line_no, line.rstrip("\n")
+
+
+def scan_logs(paths: list[str], *, max_samples: int) -> ScanReport:
+    compiled = [(spec, re.compile(spec.regex)) for spec in PATTERNS]
+    reports = {
+        spec.name: PatternReport(
+            count=0,
+            severity=spec.severity,
+            description=spec.description,
+            samples=[],
+        )
+        for spec in PATTERNS
+    }
+    files_seen: list[str] = []
+    files_seen_set: set[str] = set()
+    total_lines = 0
+    matched_lines = 0
+
+    for path, line_no, line in iter_input_lines(paths):
+        total_lines += 1
+        if path not in files_seen_set:
+            files_seen.append(path)
+            files_seen_set.add(path)
+
+        line_matched = False
+        for spec, regex in compiled:
+            if not regex.search(line):
+                continue
+            report = reports[spec.name]
+            report.count += 1
+            line_matched = True
+            if len(report.samples) < max_samples:
+                report.samples.append(MatchSample(path=path, line=line_no, text=line))
+        if line_matched:
+            matched_lines += 1
+
+    return ScanReport(
+        files=files_seen,
+        total_lines=total_lines,
+        matched_lines=matched_lines,
+        patterns=reports,
+    )
+
+
+def report_to_json(report: ScanReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: ScanReport) -> str:
+    lines = [
+        "GOAL LOOP Observe Log Scan",
+        f"files: {', '.join(report.files) if report.files else '<none>'}",
+        f"total_lines: {report.total_lines}",
+        f"matched_lines: {report.matched_lines}",
+    ]
+    for name in sorted(report.patterns):
+        item = report.patterns[name]
+        if item.count == 0:
+            continue
+        lines.append(f"- {name}: {item.count} ({item.severity})")
+        for sample in item.samples:
+            lines.append(f"  {sample.path}:{sample.line}: {sample.text}")
+    return "\n".join(lines)
+
+
+def should_fail(report: ScanReport, mode: str) -> bool:
+    if mode == "none":
+        return False
+    for item in report.patterns.values():
+        if item.count == 0:
+            continue
+        if mode == "any":
+            return True
+        if mode == "warning" and item.severity in {"warning", "critical"}:
+            return True
+        if mode == "critical" and item.severity == "critical":
+            return True
+    return False
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Log files to scan. Use '-' or omit paths to read stdin.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=3,
+        help="Maximum sample lines to retain per pattern (default: 3).",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "critical", "warning", "any"),
+        default="none",
+        help="Exit non-zero when matching patterns meet this severity.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    report = scan_logs(args.paths, max_samples=max(args.max_samples, 0))
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    return 1 if should_fail(report, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orient_goal_loop_logs.py
+++ b/scripts/orient_goal_loop_logs.py
@@ -46,6 +46,18 @@ class OrientReport:
 
 FINDINGS: tuple[FindingSpec, ...] = (
     FindingSpec(
+        "R-FATAL-1",
+        "keeper_semaphore_wait_no_fallback",
+        "critical",
+        ("keeper_skipping_turn",),
+    ),
+    FindingSpec(
+        "CF-1",
+        "pricing_catalog_miss",
+        "critical",
+        ("pricing_catalog_miss",),
+    ),
+    FindingSpec(
         "NF-1",
         "provider_health_skipped_all_models",
         "critical",

--- a/scripts/orient_goal_loop_logs.py
+++ b/scripts/orient_goal_loop_logs.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Orient GOAL LOOP live-log findings from Observe scanner JSON.
+
+This consumes the JSON emitted by ``observe_goal_loop_logs.py`` and turns raw
+pattern counts into a small finding-oriented report. It does not mark anything
+as fixed; absence of log evidence is only reported as ``EVIDENCE_ABSENT``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+
+@dataclass(frozen=True)
+class FindingSpec:
+    finding_id: str
+    title: str
+    severity: str
+    patterns: tuple[str, ...]
+
+
+@dataclass
+class FindingReport:
+    finding_id: str
+    title: str
+    severity: str
+    status: str
+    count: int
+    patterns: list[str]
+    samples: list[dict[str, Any]]
+
+
+@dataclass
+class OrientReport:
+    source_files: list[str]
+    total_lines: int
+    matched_lines: int
+    summary: dict[str, int]
+    findings: list[FindingReport]
+
+
+FINDINGS: tuple[FindingSpec, ...] = (
+    FindingSpec(
+        "NF-1",
+        "provider_health_skipped_all_models",
+        "critical",
+        ("provider_health_skipped",),
+    ),
+    FindingSpec(
+        "NF-2",
+        "credential_archived_all_keepers",
+        "critical",
+        ("credential_archived_starvation",),
+    ),
+    FindingSpec(
+        "NF-3",
+        "alive_but_stuck_no_recovery",
+        "critical",
+        ("alive_but_stuck",),
+    ),
+    FindingSpec(
+        "NF-4",
+        "governance_judge_unparseable_fallback",
+        "warning",
+        ("governance_unparseable", "lenient_json_fallback"),
+    ),
+    FindingSpec(
+        "NF-5",
+        "autoboot_warmup_delay",
+        "warning",
+        ("autoboot_warmup",),
+    ),
+    FindingSpec(
+        "NF-6",
+        "config_unknown_keys_ignored",
+        "warning",
+        ("config_unknown_key",),
+    ),
+    FindingSpec(
+        "NF-7",
+        "tool_policy_unknown_tools",
+        "warning",
+        ("tool_policy_unknown_tools",),
+    ),
+    FindingSpec(
+        "NF-8",
+        "keeper_checkpoint_migration_data_loss",
+        "critical",
+        ("keeper_checkpoint_migration_data_loss",),
+    ),
+)
+
+
+def load_json_input(path: str) -> dict[str, Any]:
+    if path == "-":
+        return load_json_handle(sys.stdin)
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return load_json_handle(handle)
+
+
+def load_json_handle(handle: TextIO) -> dict[str, Any]:
+    data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("expected Observe scanner JSON object")
+    return data
+
+
+def pattern_count(patterns: dict[str, Any], name: str) -> int:
+    raw = patterns.get(name)
+    if not isinstance(raw, dict):
+        return 0
+    count = raw.get("count", 0)
+    return count if isinstance(count, int) else 0
+
+
+def pattern_samples(patterns: dict[str, Any], name: str) -> list[dict[str, Any]]:
+    raw = patterns.get(name)
+    if not isinstance(raw, dict):
+        return []
+    samples = raw.get("samples", [])
+    if not isinstance(samples, list):
+        return []
+    return [sample for sample in samples if isinstance(sample, dict)]
+
+
+def orient_scan(scan: dict[str, Any]) -> OrientReport:
+    patterns_raw = scan.get("patterns", {})
+    patterns = patterns_raw if isinstance(patterns_raw, dict) else {}
+    files_raw = scan.get("files", [])
+    source_files = (
+        [item for item in files_raw if isinstance(item, str)]
+        if isinstance(files_raw, list)
+        else []
+    )
+
+    findings: list[FindingReport] = []
+    for spec in FINDINGS:
+        count = sum(pattern_count(patterns, name) for name in spec.patterns)
+        samples: list[dict[str, Any]] = []
+        for name in spec.patterns:
+            samples.extend(pattern_samples(patterns, name))
+        findings.append(
+            FindingReport(
+                finding_id=spec.finding_id,
+                title=spec.title,
+                severity=spec.severity,
+                status="EVIDENCE_PRESENT" if count > 0 else "EVIDENCE_ABSENT",
+                count=count,
+                patterns=list(spec.patterns),
+                samples=samples[:3],
+            )
+        )
+
+    present = sum(1 for finding in findings if finding.status == "EVIDENCE_PRESENT")
+    critical_present = sum(
+        1
+        for finding in findings
+        if finding.status == "EVIDENCE_PRESENT" and finding.severity == "critical"
+    )
+    return OrientReport(
+        source_files=source_files,
+        total_lines=int(scan.get("total_lines", 0) or 0),
+        matched_lines=int(scan.get("matched_lines", 0) or 0),
+        summary={
+            "evidence_present": present,
+            "evidence_absent": len(findings) - present,
+            "critical_present": critical_present,
+            "findings_total": len(findings),
+        },
+        findings=findings,
+    )
+
+
+def report_to_json(report: OrientReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: OrientReport) -> str:
+    lines = [
+        "GOAL LOOP Orient Log Findings",
+        f"source_files: {', '.join(report.source_files) if report.source_files else '<none>'}",
+        f"total_lines: {report.total_lines}",
+        f"matched_lines: {report.matched_lines}",
+        (
+            "summary: "
+            f"{report.summary['evidence_present']} present / "
+            f"{report.summary['findings_total']} total; "
+            f"{report.summary['critical_present']} critical present"
+        ),
+    ]
+    for finding in report.findings:
+        if finding.status == "EVIDENCE_ABSENT":
+            continue
+        lines.append(
+            f"- {finding.finding_id} {finding.title}: "
+            f"{finding.status} count={finding.count} severity={finding.severity}"
+        )
+    return "\n".join(lines)
+
+
+def should_fail(report: OrientReport, mode: str) -> bool:
+    if mode == "none":
+        return False
+    if mode == "present":
+        return report.summary["evidence_present"] > 0
+    if mode == "critical":
+        return report.summary["critical_present"] > 0
+    raise ValueError(f"unknown fail mode: {mode}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "scan_json",
+        nargs="?",
+        default="-",
+        help="Observe scanner JSON path, or '-' for stdin (default).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "present", "critical"),
+        default="none",
+        help="Exit non-zero when oriented findings match this condition.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    report = orient_scan(load_json_input(args.scan_json))
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    return 1 if should_fail(report, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_goal_loop_logs.py
+++ b/scripts/verify_goal_loop_logs.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Verify GOAL LOOP log findings after an Act step.
+
+This consumes the JSON emitted by ``orient_goal_loop_logs.py`` and reports
+whether post-fix logs still contain evidence for selected finding severities.
+It treats absence of log evidence as a verification signal, not as proof that
+the underlying bug is permanently impossible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+
+@dataclass
+class VerificationFinding:
+    finding_id: str
+    title: str
+    severity: str
+    count: int
+
+
+@dataclass
+class VerificationReport:
+    status: str
+    policy: str
+    checked_findings: int
+    failing_findings: list[VerificationFinding]
+
+
+def load_json_input(path: str) -> dict[str, Any]:
+    if path == "-":
+        return load_json_handle(sys.stdin)
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return load_json_handle(handle)
+
+
+def load_json_handle(handle: TextIO) -> dict[str, Any]:
+    data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("expected Orient JSON object")
+    return data
+
+
+def finding_fails(finding: dict[str, Any], policy: str) -> bool:
+    if finding.get("status") != "EVIDENCE_PRESENT":
+        return False
+    if policy == "present":
+        return True
+    if policy == "critical":
+        return finding.get("severity") == "critical"
+    raise ValueError(f"unknown policy: {policy}")
+
+
+def verify_orient(orient: dict[str, Any], *, policy: str) -> VerificationReport:
+    findings_raw = orient.get("findings", [])
+    findings = findings_raw if isinstance(findings_raw, list) else []
+    failing: list[VerificationFinding] = []
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        if not finding_fails(finding, policy):
+            continue
+        finding_id = finding.get("finding_id")
+        title = finding.get("title")
+        severity = finding.get("severity")
+        count = finding.get("count", 0)
+        failing.append(
+            VerificationFinding(
+                finding_id=finding_id if isinstance(finding_id, str) else "unknown",
+                title=title if isinstance(title, str) else "unknown",
+                severity=severity if isinstance(severity, str) else "unknown",
+                count=count if isinstance(count, int) else 0,
+            )
+        )
+    return VerificationReport(
+        status="PASS" if not failing else "FAIL",
+        policy=policy,
+        checked_findings=len(findings),
+        failing_findings=failing,
+    )
+
+
+def report_to_json(report: VerificationReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: VerificationReport) -> str:
+    lines = [
+        f"GOAL LOOP Verify: {report.status}",
+        f"policy: {report.policy}",
+        f"checked_findings: {report.checked_findings}",
+        f"failing_findings: {len(report.failing_findings)}",
+    ]
+    for finding in report.failing_findings:
+        lines.append(
+            f"- {finding.finding_id} {finding.title}: "
+            f"count={finding.count} severity={finding.severity}"
+        )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "orient_json",
+        nargs="?",
+        default="-",
+        help="Orient JSON path, or '-' for stdin (default).",
+    )
+    parser.add_argument(
+        "--policy",
+        choices=("critical", "present"),
+        default="critical",
+        help="Verification policy: fail on critical evidence or any evidence.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    report = verify_orient(load_json_input(args.orient_json), policy=args.policy)
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    return 0 if report.status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_observe_goal_loop_logs.py
+++ b/test/test_observe_goal_loop_logs.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "observe_goal_loop_logs.py"
+ORIENT_SCRIPT_PATH = REPO_ROOT / "scripts" / "orient_goal_loop_logs.py"
 
 spec = importlib.util.spec_from_file_location("observe_goal_loop_logs", SCRIPT_PATH)
 assert spec is not None
@@ -18,6 +19,15 @@ observe_goal_loop_logs = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 sys.modules[spec.name] = observe_goal_loop_logs
 spec.loader.exec_module(observe_goal_loop_logs)
+
+orient_spec = importlib.util.spec_from_file_location(
+    "orient_goal_loop_logs", ORIENT_SCRIPT_PATH
+)
+assert orient_spec is not None
+orient_goal_loop_logs = importlib.util.module_from_spec(orient_spec)
+assert orient_spec.loader is not None
+sys.modules[orient_spec.name] = orient_goal_loop_logs
+orient_spec.loader.exec_module(orient_goal_loop_logs)
 
 
 class ObserveGoalLoopLogsTest(unittest.TestCase):
@@ -32,6 +42,9 @@ class ObserveGoalLoopLogsTest(unittest.TestCase):
                         "[WARN] [Keeper] nick0cave: alive-but-stuck detected (elapsed=924857s)",
                         "[WARN] [Governance] Governance judge returned unparseable response (Lenient_json fallback hit; 3809 chars)",
                         "[WARN] [Keeper] keeper TOML jobsian_purist.toml has unknown keys: keeper.base",
+                        "[INFO] verifier: warmup=255s",
+                        "[WARN] tool_policy unknown tools: foo, bar, baz",
+                        "[ERROR] keeper checkpoint migration data loss detected",
                         "[keepers_json:*] sub-op: meta=12ms agent=7ms ka=0ms audit=0ms profile=0ms phase=0ms activity=0ms",
                     ]
                 )
@@ -41,13 +54,18 @@ class ObserveGoalLoopLogsTest(unittest.TestCase):
 
             report = observe_goal_loop_logs.scan_logs([str(path)], max_samples=2)
 
-        self.assertEqual(report.total_lines, 6)
+        self.assertEqual(report.total_lines, 9)
         self.assertEqual(report.patterns["provider_health_skipped"].count, 1)
         self.assertEqual(report.patterns["credential_archived_starvation"].count, 1)
         self.assertEqual(report.patterns["alive_but_stuck"].count, 1)
         self.assertEqual(report.patterns["governance_unparseable"].count, 1)
         self.assertEqual(report.patterns["lenient_json_fallback"].count, 1)
         self.assertEqual(report.patterns["config_unknown_key"].count, 1)
+        self.assertEqual(report.patterns["autoboot_warmup"].count, 1)
+        self.assertEqual(report.patterns["tool_policy_unknown_tools"].count, 1)
+        self.assertEqual(
+            report.patterns["keeper_checkpoint_migration_data_loss"].count, 1
+        )
         self.assertEqual(report.patterns["metric_all_zero"].count, 1)
 
     def test_fail_on_critical_exits_nonzero(self) -> None:
@@ -68,6 +86,52 @@ class ObserveGoalLoopLogsTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 1)
         self.assertIn("alive_but_stuck", result.stdout)
+
+    def test_orient_reports_present_findings_from_scan_json(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            empty_log = Path(raw_dir) / "empty.log"
+            empty_log.write_text("", encoding="utf-8")
+            scan = observe_goal_loop_logs.scan_logs([str(empty_log)], max_samples=1)
+        scan.patterns["provider_health_skipped"].count = 1
+        scan.patterns["provider_health_skipped"].samples.append(
+            observe_goal_loop_logs.MatchSample(
+                path="server.log",
+                line=1,
+                text="bootstrap skips live probe",
+            )
+        )
+        scan.patterns["config_unknown_key"].count = 1
+
+        report = orient_goal_loop_logs.orient_scan(
+            {
+                "files": scan.files,
+                "total_lines": scan.total_lines,
+                "matched_lines": scan.matched_lines,
+                "patterns": {
+                    name: {
+                        "count": item.count,
+                        "severity": item.severity,
+                        "description": item.description,
+                        "samples": [
+                            {
+                                "path": sample.path,
+                                "line": sample.line,
+                                "text": sample.text,
+                            }
+                            for sample in item.samples
+                        ],
+                    }
+                    for name, item in scan.patterns.items()
+                },
+            }
+        )
+
+        by_id = {finding.finding_id: finding for finding in report.findings}
+        self.assertEqual(by_id["NF-1"].status, "EVIDENCE_PRESENT")
+        self.assertEqual(by_id["NF-6"].status, "EVIDENCE_PRESENT")
+        self.assertEqual(by_id["NF-2"].status, "EVIDENCE_ABSENT")
+        self.assertEqual(report.summary["evidence_present"], 2)
+        self.assertEqual(report.summary["critical_present"], 1)
 
 
 if __name__ == "__main__":

--- a/test/test_observe_goal_loop_logs.py
+++ b/test/test_observe_goal_loop_logs.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "observe_goal_loop_logs.py"
+
+spec = importlib.util.spec_from_file_location("observe_goal_loop_logs", SCRIPT_PATH)
+assert spec is not None
+observe_goal_loop_logs = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = observe_goal_loop_logs
+spec.loader.exec_module(observe_goal_loop_logs)
+
+
+class ObserveGoalLoopLogsTest(unittest.TestCase):
+    def test_scan_counts_prompt_signatures(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            path = Path(raw_dir) / "server.log"
+            path.write_text(
+                "\n".join(
+                    [
+                        '{"status":"skipped","error":"runtime provider health is advisory; bootstrap skips live probe"}',
+                        "[WARN] [Auth] archived credential sangsu.json (reason: bare-form keeper credential is dead after PR-3b1 starvation)",
+                        "[WARN] [Keeper] nick0cave: alive-but-stuck detected (elapsed=924857s)",
+                        "[WARN] [Governance] Governance judge returned unparseable response (Lenient_json fallback hit; 3809 chars)",
+                        "[WARN] [Keeper] keeper TOML jobsian_purist.toml has unknown keys: keeper.base",
+                        "[keepers_json:*] sub-op: meta=12ms agent=7ms ka=0ms audit=0ms profile=0ms phase=0ms activity=0ms",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = observe_goal_loop_logs.scan_logs([str(path)], max_samples=2)
+
+        self.assertEqual(report.total_lines, 6)
+        self.assertEqual(report.patterns["provider_health_skipped"].count, 1)
+        self.assertEqual(report.patterns["credential_archived_starvation"].count, 1)
+        self.assertEqual(report.patterns["alive_but_stuck"].count, 1)
+        self.assertEqual(report.patterns["governance_unparseable"].count, 1)
+        self.assertEqual(report.patterns["lenient_json_fallback"].count, 1)
+        self.assertEqual(report.patterns["config_unknown_key"].count, 1)
+        self.assertEqual(report.patterns["metric_all_zero"].count, 1)
+
+    def test_fail_on_critical_exits_nonzero(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--fail-on",
+                "critical",
+                "-",
+            ],
+            input="[WARN] [Keeper] alive-but-stuck detected\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("alive_but_stuck", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_observe_goal_loop_logs.py
+++ b/test/test_observe_goal_loop_logs.py
@@ -12,6 +12,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "observe_goal_loop_logs.py"
 ORIENT_SCRIPT_PATH = REPO_ROOT / "scripts" / "orient_goal_loop_logs.py"
+DECIDE_SCRIPT_PATH = REPO_ROOT / "scripts" / "decide_goal_loop_findings.py"
 
 spec = importlib.util.spec_from_file_location("observe_goal_loop_logs", SCRIPT_PATH)
 assert spec is not None
@@ -29,6 +30,15 @@ assert orient_spec.loader is not None
 sys.modules[orient_spec.name] = orient_goal_loop_logs
 orient_spec.loader.exec_module(orient_goal_loop_logs)
 
+decide_spec = importlib.util.spec_from_file_location(
+    "decide_goal_loop_findings", DECIDE_SCRIPT_PATH
+)
+assert decide_spec is not None
+decide_goal_loop_findings = importlib.util.module_from_spec(decide_spec)
+assert decide_spec.loader is not None
+sys.modules[decide_spec.name] = decide_goal_loop_findings
+decide_spec.loader.exec_module(decide_goal_loop_findings)
+
 
 class ObserveGoalLoopLogsTest(unittest.TestCase):
     def test_scan_counts_prompt_signatures(self) -> None:
@@ -40,6 +50,8 @@ class ObserveGoalLoopLogsTest(unittest.TestCase):
                         '{"status":"skipped","error":"runtime provider health is advisory; bootstrap skips live probe"}',
                         "[WARN] [Auth] archived credential sangsu.json (reason: bare-form keeper credential is dead after PR-3b1 starvation)",
                         "[WARN] [Keeper] nick0cave: alive-but-stuck detected (elapsed=924857s)",
+                        "[WARN] keeper skipping turn after semaphore wait p99=240s",
+                        "pricing_catalog_miss model=glm-4.7",
                         "[WARN] [Governance] Governance judge returned unparseable response (Lenient_json fallback hit; 3809 chars)",
                         "[WARN] [Keeper] keeper TOML jobsian_purist.toml has unknown keys: keeper.base",
                         "[INFO] verifier: warmup=255s",
@@ -54,7 +66,9 @@ class ObserveGoalLoopLogsTest(unittest.TestCase):
 
             report = observe_goal_loop_logs.scan_logs([str(path)], max_samples=2)
 
-        self.assertEqual(report.total_lines, 9)
+        self.assertEqual(report.total_lines, 11)
+        self.assertEqual(report.patterns["keeper_skipping_turn"].count, 1)
+        self.assertEqual(report.patterns["pricing_catalog_miss"].count, 1)
         self.assertEqual(report.patterns["provider_health_skipped"].count, 1)
         self.assertEqual(report.patterns["credential_archived_starvation"].count, 1)
         self.assertEqual(report.patterns["alive_but_stuck"].count, 1)
@@ -132,6 +146,24 @@ class ObserveGoalLoopLogsTest(unittest.TestCase):
         self.assertEqual(by_id["NF-2"].status, "EVIDENCE_ABSENT")
         self.assertEqual(report.summary["evidence_present"], 2)
         self.assertEqual(report.summary["critical_present"], 1)
+
+    def test_decide_prioritizes_p0_actions_from_orient_json(self) -> None:
+        report = decide_goal_loop_findings.decide_orient(
+            {
+                "findings": [
+                    {"finding_id": "NF-1", "status": "EVIDENCE_PRESENT"},
+                    {"finding_id": "NF-2", "status": "EVIDENCE_PRESENT"},
+                    {"finding_id": "NF-6", "status": "EVIDENCE_PRESENT"},
+                    {"finding_id": "NF-3", "status": "EVIDENCE_ABSENT"},
+                ]
+            }
+        )
+
+        decision_ids = [decision.decision_id for decision in report.decisions]
+        self.assertEqual(report.p0_count, 2)
+        self.assertEqual(report.decisions_total, 3)
+        self.assertEqual(decision_ids[:2], ["D-EMERGENCY-2", "D-EMERGENCY-1"])
+        self.assertIn("D-P2-1", decision_ids)
 
 
 if __name__ == "__main__":

--- a/test/test_observe_goal_loop_logs.py
+++ b/test/test_observe_goal_loop_logs.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "observe_goal_loop_logs.py"
 ORIENT_SCRIPT_PATH = REPO_ROOT / "scripts" / "orient_goal_loop_logs.py"
 DECIDE_SCRIPT_PATH = REPO_ROOT / "scripts" / "decide_goal_loop_findings.py"
+VERIFY_SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_goal_loop_logs.py"
 
 spec = importlib.util.spec_from_file_location("observe_goal_loop_logs", SCRIPT_PATH)
 assert spec is not None
@@ -38,6 +39,15 @@ decide_goal_loop_findings = importlib.util.module_from_spec(decide_spec)
 assert decide_spec.loader is not None
 sys.modules[decide_spec.name] = decide_goal_loop_findings
 decide_spec.loader.exec_module(decide_goal_loop_findings)
+
+verify_spec = importlib.util.spec_from_file_location(
+    "verify_goal_loop_logs", VERIFY_SCRIPT_PATH
+)
+assert verify_spec is not None
+verify_goal_loop_logs = importlib.util.module_from_spec(verify_spec)
+assert verify_spec.loader is not None
+sys.modules[verify_spec.name] = verify_goal_loop_logs
+verify_spec.loader.exec_module(verify_goal_loop_logs)
 
 
 class ObserveGoalLoopLogsTest(unittest.TestCase):
@@ -164,6 +174,51 @@ class ObserveGoalLoopLogsTest(unittest.TestCase):
         self.assertEqual(report.decisions_total, 3)
         self.assertEqual(decision_ids[:2], ["D-EMERGENCY-2", "D-EMERGENCY-1"])
         self.assertIn("D-P2-1", decision_ids)
+
+    def test_verify_fails_on_critical_evidence(self) -> None:
+        report = verify_goal_loop_logs.verify_orient(
+            {
+                "findings": [
+                    {
+                        "finding_id": "NF-1",
+                        "title": "provider_health_skipped_all_models",
+                        "severity": "critical",
+                        "status": "EVIDENCE_PRESENT",
+                        "count": 1,
+                    },
+                    {
+                        "finding_id": "NF-6",
+                        "title": "config_unknown_keys_ignored",
+                        "severity": "warning",
+                        "status": "EVIDENCE_PRESENT",
+                        "count": 1,
+                    },
+                ]
+            },
+            policy="critical",
+        )
+
+        self.assertEqual(report.status, "FAIL")
+        self.assertEqual(len(report.failing_findings), 1)
+        self.assertEqual(report.failing_findings[0].finding_id, "NF-1")
+
+    def test_verify_passes_when_only_warning_and_policy_is_critical(self) -> None:
+        report = verify_goal_loop_logs.verify_orient(
+            {
+                "findings": [
+                    {
+                        "finding_id": "NF-6",
+                        "title": "config_unknown_keys_ignored",
+                        "severity": "warning",
+                        "status": "EVIDENCE_PRESENT",
+                        "count": 1,
+                    }
+                ]
+            },
+            policy="critical",
+        )
+
+        self.assertEqual(report.status, "PASS")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a standalone GOAL LOOP Observe/Orient/Decide/Verify log toolkit:

- `scripts/observe_goal_loop_logs.py` scans stdin or log files for live-log signatures from the 2026-05-05 GOAL LOOP audit.
- `scripts/orient_goal_loop_logs.py` consumes scanner JSON and classifies findings as `EVIDENCE_PRESENT` or `EVIDENCE_ABSENT`.
- `scripts/decide_goal_loop_findings.py` consumes Orient JSON and emits a scored decision queue from the prompt's decision table.
- `scripts/verify_goal_loop_logs.py` consumes Orient JSON after an Act step and returns PASS/FAIL by policy.
- `test/test_observe_goal_loop_logs.py` covers prompt-derived signatures, fail-on-critical behavior, Orient classification, Decide prioritization, and Verify pass/fail behavior.

## Product impact

Operators can turn raw startup/runtime logs into deterministic GOAL LOOP evidence, a first recommended action queue, and a post-fix verification result:

- Observe: count provider-health skip, credential starvation archive, alive-but-stuck, pricing miss, unknown TOML keys, all-zero metrics, checkpoint data loss, and related markers.
- Orient: map raw evidence to `R-FATAL-1`, `CF-1`, and `NF-1..NF-8`.
- Decide: rank concrete actions like bootstrap health checks, slot/credential recovery, fallback ladder work, pricing refresh, TOML schema enforcement, and strict governance parse handling.
- Verify: fail post-Act log verification when selected evidence remains present.

This complements PR #13085. That PR emits runtime Prometheus counters; this PR gives immediate offline/live-log scanning, finding classification, decision ranking, and verification.

## Evidence

- `python3 test/test_observe_goal_loop_logs.py`
- `ruff check scripts/observe_goal_loop_logs.py scripts/orient_goal_loop_logs.py scripts/decide_goal_loop_findings.py scripts/verify_goal_loop_logs.py test/test_observe_goal_loop_logs.py`
- `ruff format --check scripts/observe_goal_loop_logs.py scripts/orient_goal_loop_logs.py scripts/decide_goal_loop_findings.py scripts/verify_goal_loop_logs.py test/test_observe_goal_loop_logs.py`
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`

Manual pipeline proof:

```bash
python3 scripts/observe_goal_loop_logs.py --format json - \
  | python3 scripts/orient_goal_loop_logs.py --format json - \
  | python3 scripts/decide_goal_loop_findings.py --format text --fail-on p0 -
```

with provider-health-skipped, credential-archive, and unknown-key sample lines returned exit code `1` and reported P0 decisions `D-EMERGENCY-2` and `D-EMERGENCY-1`.

Verify proof:

```bash
python3 scripts/verify_goal_loop_logs.py --format text --policy critical -
```

returns PASS for warning-only evidence and FAIL for critical evidence.

`pyright --outputjson ...` could not run because `pyright` is not installed in this environment.

## Review evidence

Review focus:

- Pattern names and severities in `PATTERNS`.
- Finding mapping in `FINDINGS`.
- Decision mapping and ROI scores in `DECISIONS`.
- Verify policy semantics: `critical` vs `present`.
- Whether default output should stay JSON for automation.
- Whether `--fail-on` modes are suitable for future CI/log-gate use.

## Linked issue

N/A - derived from the 2026-05-05 GOAL LOOP/live-log audit.
