### PR TITLE
feat(coord): observable telemetry/audit drop on non-Eio dispatch (#10358 c1)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -79,14 +79,24 @@ let warn_telemetry_drop ~event_family ~event_kind exn =
         ("exception", `String exn_str);
       ]
   in
-  Log.emit Log.Warn ~module_name:"Coord" ~details
-    (Printf.sprintf
-       "telemetry/audit dropped (non-Eio context): %s/%s"
-       event_family event_kind);
-  Prometheus.inc_counter Prometheus.metric_coord_telemetry_drop
-    ~labels:
-      [ ("event_family", event_family); ("event_kind", event_kind) ]
-    ()
+  (* Inner swallow: the call sites that invoke this helper rely on the
+     "[Effect.Unhandled] is fully absorbed" contract — propagating an
+     exception out of the lifecycle hook would crash the caller. Both
+     observability side effects below can in principle raise (Log.emit
+     reaches into formatters / IO buffers; Prometheus.inc_counter takes
+     a global lock). If they do, we still drop the warn signal — the
+     primary contract is "do not break the caller". (#13096 review,
+     codex P2) *)
+  (try
+    Log.emit Log.Warn ~module_name:"Coord" ~details
+      (Printf.sprintf
+         "telemetry/audit dropped (non-Eio context): %s/%s"
+         event_family event_kind);
+    Prometheus.inc_counter Prometheus.metric_coord_telemetry_drop
+      ~labels:
+        [ ("event_family", event_family); ("event_kind", event_kind) ]
+      ()
+  with _ -> ())
 
 (* Exhaustive on [Masc_domain.task_action]: a new variant becomes a compile
    error here so the audit-log mapping cannot silently fall into the

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -79,19 +79,22 @@ let warn_telemetry_drop ~event_family ~event_kind exn =
         ("exception", `String exn_str);
       ]
   in
-  (* Inner swallow: the call sites that invoke this helper rely on the
-     "[Effect.Unhandled] is fully absorbed" contract — propagating an
-     exception out of the lifecycle hook would crash the caller. Both
-     observability side effects below can in principle raise (Log.emit
-     reaches into formatters / IO buffers; Prometheus.inc_counter takes
-     a global lock). If they do, we still drop the warn signal — the
-     primary contract is "do not break the caller". (#13096 review,
-     codex P2) *)
+  (* Isolated swallows: the call sites that invoke this helper rely on
+     the "[Effect.Unhandled] is fully absorbed" contract — propagating
+     an exception out of the lifecycle hook would crash the caller.
+     Each observability side effect is wrapped separately so a failure
+     in one (e.g. [Log.emit] hitting a sink failure) does not skip the
+     other (the counter still increments and stays observable). The
+     primary contract remains "do not break the caller". (#13096
+     review, copilot P1; supersedes the single-try wrapping noted in
+     codex P2.) *)
   (try
     Log.emit Log.Warn ~module_name:"Coord" ~details
       (Printf.sprintf
          "telemetry/audit dropped (non-Eio context): %s/%s"
-         event_family event_kind);
+         event_family event_kind)
+  with _ -> ());
+  (try
     Prometheus.inc_counter Prometheus.metric_coord_telemetry_drop
       ~labels:
         [ ("event_family", event_family); ("event_kind", event_kind) ]

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -56,6 +56,38 @@ let merge_detail_fields fields details =
   | `Null -> `Assoc fields
   | other -> `Assoc (fields @ [ ("payload", other) ])
 
+(* #10358 (c1): make non-Eio-context drops observable.
+
+   The three try/with sites below catch [Stdlib.Effect.Unhandled] so the
+   lifecycle hook does not crash when invoked outside an Eio scheduler
+   (test path / bootstrap / non-Eio handler). Before this helper the
+   handler body was [-> ()] which silently dropped the entire Audit_log
+   + Telemetry pair — exactly matching the [#10358] 5-tag → 2-tag
+   attrition pattern observed in the durable ledger. We still swallow
+   the exception (the lifecycle hook must not propagate failures into
+   the caller's control flow), but we now emit a Warn log line and
+   bump [masc_coord_telemetry_drop_total{event_family,event_kind}] so
+   operators can see in Grafana / log aggregation when production
+   paths are dispatching lifecycle outside an Eio fiber. *)
+let warn_telemetry_drop ~event_family ~event_kind exn =
+  let exn_str = Printexc.to_string exn in
+  let details =
+    `Assoc
+      [
+        ("event_family", `String event_family);
+        ("event_kind", `String event_kind);
+        ("exception", `String exn_str);
+      ]
+  in
+  Log.emit Log.Warn ~module_name:"Coord" ~details
+    (Printf.sprintf
+       "telemetry/audit dropped (non-Eio context): %s/%s"
+       event_family event_kind);
+  Prometheus.inc_counter Prometheus.metric_coord_telemetry_drop
+    ~labels:
+      [ ("event_family", event_family); ("event_kind", event_kind) ]
+    ()
+
 (* Exhaustive on [Masc_domain.task_action]: a new variant becomes a compile
    error here so the audit-log mapping cannot silently fall into the
    [Custom "task_<other>"] catch-all that the prior string-typed
@@ -113,7 +145,8 @@ let observe_agent_lifecycle config ~agent_id ~(event : Coord_hooks.agent_lifecyc
     | Lifecycle_join | Lifecycle_rejoin -> Audit_log.Join
   in
   (* Audit and telemetry require Eio context (Eio.Mutex).
-     Silently skip when running in non-Eio test context. *)
+     Skip when running outside an Eio scheduler, but emit a warn log
+     line + Prometheus counter so the drop is observable (#10358 c1). *)
   (try
     Audit_log.log_action config ~agent_id ~action
       ~details:audit_details ~outcome:Audit_log.Success ();
@@ -123,7 +156,9 @@ let observe_agent_lifecycle config ~agent_id ~(event : Coord_hooks.agent_lifecyc
           Telemetry_eio.track_agent_left config ~agent_id ~reason:"leave"
       | Lifecycle_join | Lifecycle_rejoin ->
           Telemetry_eio.track_agent_joined config ~agent_id ()
-  with Stdlib.Effect.Unhandled _ -> ())
+  with Stdlib.Effect.Unhandled _ as exn ->
+    warn_telemetry_drop ~event_family:"agent_lifecycle"
+      ~event_kind:event_kind exn)
 
 (* #8605 family: replaced four parallel string switches on [transition]
    with [Masc_domain.task_action] variant matches. The compiler now forces
@@ -177,11 +212,15 @@ let observe_task_transition_event config ~agent_name ~task_id
             ~success:false
       | (Masc_domain.Release | Masc_domain.Submit_for_verification
         | Masc_domain.Reject_verification) -> ()
-  with Stdlib.Effect.Unhandled _ -> ());
+  with Stdlib.Effect.Unhandled _ as exn ->
+    warn_telemetry_drop ~event_family:"task_transition"
+      ~event_kind:transition_s exn);
   (try
      Keeper_accountability.record_task_transition config ~agent_name ~task_id
        ~transition ~details
-  with Stdlib.Effect.Unhandled _ -> ())
+  with Stdlib.Effect.Unhandled _ as exn ->
+    warn_telemetry_drop ~event_family:"accountability"
+      ~event_kind:transition_s exn)
 
 (* force_release_task — zombie cleanup needs task management logic *)
 let () = Atomic.set Coord_hooks.force_release_task_fn (fun config ~agent_name ~task_id () ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -696,6 +696,21 @@ let metric_codex_cli_mcp_tool_omission =
 let metric_telemetry_coverage_gap =
   "masc_telemetry_coverage_gap_total"
 
+(* #10358 (c1): observability for the silent [Effect.Unhandled] catch-all
+   in [lib/coord.ml] [observe_agent_lifecycle] / [observe_task_transition_event] /
+   [Keeper_accountability.record_task_transition].  Those three try/with
+   sites swallow the exception that fires when the lifecycle hook is
+   dispatched from a non-Eio context (test path, bootstrap, certain HTTP
+   handlers).  Before this counter, the entire Audit_log + Telemetry pair
+   silently disappeared, exactly matching the 5-tag → 2-tag attrition
+   ledger pattern (only [tool_called] survives because it is wired on a
+   different fiber-bearing path).  Labels: [event_family] (one of
+   [agent_lifecycle] / [task_transition] / [accountability]) and
+   [event_kind] (the lifecycle/transition variant); both vocabularies are
+   bounded so series cardinality is at most ~12. *)
+let metric_coord_telemetry_drop =
+  "masc_coord_telemetry_drop_total"
+
 (* #10094: per-caller counter for [Masc_oas_bridge.run_safe]
    timeouts.  The [caller] string supplied at the run_safe entry
    point lets the operator see WHICH caller is timing out at
@@ -1957,6 +1972,17 @@ let init () =
      stale_reason. Any positive rate means a telemetry lane is missing, \
      stale, or failed to append and dashboards should mark the source \
      coverage_gap."
+    Counter;
+  add metric_coord_telemetry_drop
+    "Total times a Coord lifecycle/transition hook dropped its Audit_log \
+     + Telemetry emit because the dispatch happened outside an Eio \
+     scheduler. Labels: event_family (agent_lifecycle | task_transition \
+     | accountability), event_kind (the variant — join/rejoin/leave for \
+     lifecycle, claim/start/done/release/cancel/submit/approve/reject \
+     for transitions, record for accountability). Non-zero rate means a \
+     production path is firing the lifecycle outside an Eio context; \
+     before this counter the drop was silent (#10358 attrition root \
+     cause)."
     Counter;
   add metric_auth_credential_ambiguous_lookup
     "Total runtime credential lookups where N>=2 credentials share the \

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -706,8 +706,13 @@ let metric_telemetry_coverage_gap =
    ledger pattern (only [tool_called] survives because it is wired on a
    different fiber-bearing path).  Labels: [event_family] (one of
    [agent_lifecycle] / [task_transition] / [accountability]) and
-   [event_kind] (the lifecycle/transition variant); both vocabularies are
-   bounded so series cardinality is at most ~12. *)
+   [event_kind] (the lifecycle/transition variant). [event_kind] for
+   [agent_lifecycle] is one of [join] / [rejoin] / [leave] (3 values).
+   [event_kind] for both [task_transition] and [accountability] uses the
+   8 [Masc_domain.task_action_to_string] values: [claim] / [start] /
+   [done] / [cancel] / [release] / [submit_for_verification] / [approve]
+   / [reject]. Both vocabularies are bounded so series cardinality is at
+   most 19 (3 + 8 + 8). *)
 let metric_coord_telemetry_drop =
   "masc_coord_telemetry_drop_total"
 
@@ -1976,13 +1981,15 @@ let init () =
   add metric_coord_telemetry_drop
     "Total times a Coord lifecycle/transition hook dropped its Audit_log \
      + Telemetry emit because the dispatch happened outside an Eio \
-     scheduler. Labels: event_family (agent_lifecycle | task_transition \
-     | accountability), event_kind (the variant — join/rejoin/leave for \
-     lifecycle, claim/start/done/release/cancel/submit/approve/reject \
-     for transitions, record for accountability). Non-zero rate means a \
-     production path is firing the lifecycle outside an Eio context; \
-     before this counter the drop was silent (#10358 attrition root \
-     cause)."
+     scheduler. Labels: event_family (one of agent_lifecycle | \
+     task_transition | accountability) and event_kind (the variant). \
+     event_kind values: agent_lifecycle uses join | rejoin | leave (3 \
+     values); task_transition and accountability both use the 8 \
+     task_action variants claim | start | done | cancel | release | \
+     submit_for_verification | approve | reject. Cardinality bound: 19 \
+     series (3 + 8 + 8). Non-zero rate means a production path is \
+     firing the lifecycle outside an Eio context; before this counter \
+     the drop was silent (#10358 attrition root cause)."
     Counter;
   add metric_auth_credential_ambiguous_lookup
     "Total runtime credential lookups where N>=2 credentials share the \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -363,12 +363,17 @@ val metric_coord_telemetry_drop : string
     [Stdlib.Effect.Unhandled] and dropped its Audit_log + Telemetry
     pair because dispatch happened outside an Eio scheduler. Labels:
     [event_family] (one of [agent_lifecycle] / [task_transition] /
-    [accountability]) and [event_kind] (the variant — join/rejoin/leave
-    or claim/start/done/release/cancel/submit/approve/reject). Bounded
-    cardinality (~12 series). Non-zero rate means a production path is
-    firing the lifecycle outside an Eio fiber and the corresponding
-    audit/telemetry rows are missing — the silent root cause behind
-    the [#10358] 5-tag → 2-tag durable-ledger attrition. *)
+    [accountability]) and [event_kind] (the variant). For
+    [agent_lifecycle], [event_kind] is one of [join] / [rejoin] /
+    [leave] (3 values). For both [task_transition] and
+    [accountability], [event_kind] uses the 8
+    [Masc_domain.task_action_to_string] values: [claim] / [start] /
+    [done] / [cancel] / [release] / [submit_for_verification] /
+    [approve] / [reject]. Cardinality bound: 19 series (3 + 8 + 8).
+    Non-zero rate means a production path is firing the lifecycle
+    outside an Eio fiber and the corresponding audit/telemetry rows
+    are missing — the silent root cause behind the [#10358] 5-tag → 2-tag
+    durable-ledger attrition. *)
 
 val metric_oas_bridge_timeout : string
 (** #10094: labelled [caller, timeout_s] so operators can

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -358,6 +358,18 @@ val metric_telemetry_coverage_gap : string
     alertable pair to the durable
     [.masc/telemetry-coverage-gaps/YYYY-MM/DD.jsonl] store. *)
 
+val metric_coord_telemetry_drop : string
+(** #10358 (c1): total times [lib/coord.ml]'s lifecycle hook caught
+    [Stdlib.Effect.Unhandled] and dropped its Audit_log + Telemetry
+    pair because dispatch happened outside an Eio scheduler. Labels:
+    [event_family] (one of [agent_lifecycle] / [task_transition] /
+    [accountability]) and [event_kind] (the variant — join/rejoin/leave
+    or claim/start/done/release/cancel/submit/approve/reject). Bounded
+    cardinality (~12 series). Non-zero rate means a production path is
+    firing the lifecycle outside an Eio fiber and the corresponding
+    audit/telemetry rows are missing — the silent root cause behind
+    the [#10358] 5-tag → 2-tag durable-ledger attrition. *)
+
 val metric_oas_bridge_timeout : string
 (** #10094: labelled [caller, timeout_s] so operators can
     distinguish fantasy 60s budgets from intentional 120/180s

--- a/test/dune
+++ b/test/dune
@@ -91,6 +91,7 @@
         test_keeper_supervisor
         test_keeper_alerting_path
         test_coord_eio_pure
+        test_coord_telemetry_drop_non_eio
         test_keeper_contract_classifier_pure
         test_keeper_compact_policy_pure
         test_heartbeat_smart
@@ -298,6 +299,7 @@
           test_keeper_supervisor
           test_keeper_alerting_path
           test_coord_eio_pure
+          test_coord_telemetry_drop_non_eio
           test_keeper_contract_classifier_pure
           test_keeper_compact_policy_pure
           test_heartbeat_smart

--- a/test/test_coord_telemetry_drop_non_eio.ml
+++ b/test/test_coord_telemetry_drop_non_eio.ml
@@ -1,0 +1,91 @@
+(** #13096 review (copilot): regression coverage for the non-Eio drop
+    path in [Coord.observe_agent_lifecycle].  When the lifecycle hook
+    is invoked outside any Eio scheduler, [Audit_log.log_action] /
+    [Telemetry_eio.*] raise [Stdlib.Effect.Unhandled]; the helper must
+    absorb that and increment
+    [masc_coord_telemetry_drop_total{event_family=...,event_kind=...}]
+    so the drop is observable in Prometheus / Grafana. *)
+
+open Masc_mcp
+
+let counter_value ~event_family ~event_kind =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_coord_telemetry_drop
+    ~labels:[ ("event_family", event_family); ("event_kind", event_kind) ]
+    ()
+
+let with_temp_base f =
+  let dir = Filename.temp_file "masc_coord_telem_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      try
+        let cmd = Printf.sprintf "rm -rf %s" (Filename.quote dir) in
+        let _ : int = Sys.command cmd in
+        ()
+      with _ -> ())
+    (fun () -> f dir)
+
+(* Calling the lifecycle observer outside any Eio scheduler must:
+   - not raise (the hook contract is "do not break the caller"), and
+   - increment the drop counter for the matching labels. *)
+let test_lifecycle_drop_increments_counter () =
+  with_temp_base (fun base ->
+    let config = Coord.default_config base in
+    let observe = Atomic.get Coord_hooks.observe_agent_lifecycle_fn in
+    let event_family = "agent_lifecycle" in
+    let event_kind = "leave" in
+    let before = counter_value ~event_family ~event_kind in
+    (* No Eio scheduler running on this fiber: Audit_log / Telemetry_eio
+       raise Stdlib.Effect.Unhandled inside [observe_agent_lifecycle];
+       the helper must catch and warn + bump the counter. *)
+    (try
+       observe config
+         ~agent_id:"telemetry-drop-test"
+         ~event:Coord_hooks.Lifecycle_leave
+         ~details:`Null
+     with exn ->
+       Alcotest.failf
+         "lifecycle hook leaked exception in non-Eio context: %s"
+         (Printexc.to_string exn));
+    let after = counter_value ~event_family ~event_kind in
+    Alcotest.(check (float 0.001))
+      "drop counter increments by exactly 1 for the leave label"
+      1.0 (after -. before))
+
+(* Same path, join variant: the warn label switches to "join" so a
+   single regression on the wrong label key (e.g. hard-coded "leave")
+   would still pass the test above. *)
+let test_lifecycle_drop_join_label () =
+  with_temp_base (fun base ->
+    let config = Coord.default_config base in
+    let observe = Atomic.get Coord_hooks.observe_agent_lifecycle_fn in
+    let event_family = "agent_lifecycle" in
+    let event_kind = "join" in
+    let before = counter_value ~event_family ~event_kind in
+    (try
+       observe config
+         ~agent_id:"telemetry-drop-test-join"
+         ~event:Coord_hooks.Lifecycle_join
+         ~details:`Null
+     with exn ->
+       Alcotest.failf
+         "lifecycle hook leaked exception in non-Eio context: %s"
+         (Printexc.to_string exn));
+    let after = counter_value ~event_family ~event_kind in
+    Alcotest.(check (float 0.001))
+      "drop counter increments by exactly 1 for the join label"
+      1.0 (after -. before))
+
+let () =
+  Alcotest.run "coord_telemetry_drop_non_eio"
+    [
+      ( "non_eio_drop",
+        [
+          Alcotest.test_case "leave label increments counter" `Quick
+            test_lifecycle_drop_increments_counter;
+          Alcotest.test_case "join label increments counter" `Quick
+            test_lifecycle_drop_join_label;
+        ] );
+    ]

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -274,7 +274,8 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_timeout_policy_overshoot;
   check_registered Prometheus.metric_auth_credential_token_duplicate;
   check_registered Prometheus.metric_auth_credential_token_rotated;
-  check_registered Prometheus.metric_telemetry_coverage_gap
+  check_registered Prometheus.metric_telemetry_coverage_gap;
+  check_registered Prometheus.metric_coord_telemetry_drop
 
 let test_distributed_lock_metric_registered () =
   let text = Prometheus.to_prometheus_text () in


### PR DESCRIPTION
## Summary

Make the silent `Stdlib.Effect.Unhandled` swallow in
`lib/coord.ml` observable. Three try/with sites in
`observe_agent_lifecycle`, `observe_task_transition_event`, and the
sibling `Keeper_accountability.record_task_transition` call all caught
the effect with `-> ()`, dropping their **entire** `Audit_log` +
`Telemetry_eio` pair whenever the lifecycle hook ran outside an Eio
scheduler. This is the root cause I posted on
[#10358](https://github.com/jeong-sik/masc-mcp/issues/10358#issuecomment-4377043616)
for the durable-ledger 5-tag → 2-tag attrition pattern (only
`tool_called` survived because it sits on a different fiber-bearing
path).

## Change

The catch is preserved — the lifecycle hook must not propagate
failure into the caller — but the body now goes through one helper:

```ocaml
let warn_telemetry_drop ~event_family ~event_kind exn =
  ...
  Log.emit Log.Warn ~module_name:"Coord" ~details
    (Printf.sprintf
       "telemetry/audit dropped (non-Eio context): %s/%s"
       event_family event_kind);
  Prometheus.inc_counter Prometheus.metric_coord_telemetry_drop
    ~labels:
      [ ("event_family", event_family); ("event_kind", event_kind) ]
    ()
```

`masc_coord_telemetry_drop_total{event_family,event_kind}` is bounded
to ~12 series:

| event_family | event_kind |
|---|---|
| `agent_lifecycle` | `join` / `rejoin` / `leave` |
| `task_transition` | `claim` / `start` / `done` / `release` / `cancel` / `submit_for_verification` / `approve_verification` / `reject_verification` |
| `accountability` | (`task_transition`'s 8 transitions) |

## Why warn + counter, not raise

A warn log line gives operators the exception name and event kind
inline; the Prometheus counter gives Grafana an alertable rate. The
existing test path that runs lifecycle hooks outside Eio still passes
(catch unchanged), so this PR is non-breaking for the bootstrap /
non-Eio test contexts the comment originally protected. If a future
change wants to turn the drops fatal in production, the migration is
a single `raise` edit in the helper plus a TLA+ invariant; not in
scope here.

## Verification

- `dune build --root . lib/ bin/` clean.
- `dune exec test/test_prometheus_coverage.exe` 53/53 (including new
  `check_registered Prometheus.metric_coord_telemetry_drop`).
- The three call sites continue to swallow the effect (no caller
  reraise); the only behavior change is two new side-effects per
  drop (Log.warn + Prometheus.inc_counter).

## Changes

| File | LOC | Purpose |
|------|----:|---------|
| `lib/coord.ml` | +43 / -4 | `warn_telemetry_drop` helper + 3 catch arms wired |
| `lib/prometheus.ml` | +26 / -0 | metric definition + `add` registration |
| `lib/prometheus.mli` | +12 / -0 | exported value spec |
| `test/test_prometheus_coverage.ml` | +2 / -1 | registration test extended |

Total: 4 files, +83 / -5.

## Linked

- Issue [#10358](https://github.com/jeong-sik/masc-mcp/issues/10358) —
  this is the (c1) hypothesis from my correction comment
  ([#10358#issuecomment-4377043616](https://github.com/jeong-sik/masc-mcp/issues/10358#issuecomment-4377043616)).
- Companion to [#13066](https://github.com/jeong-sik/masc-mcp/pull/13066)
  (bucket a — `error_kind` wiring for `track_tool_called` failure
  paths). Together they close the two observability gaps that drove
  the 2-tag attrition.
- Out of scope: bucket (c2) `track_handoff` semantic decision (no
  cascade-routing handoff concept yet exists in masc-mcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
