### PR TITLE
feat(cascade): RFC-0027 PR-9b dual-track resolver wiring

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -925,6 +925,112 @@ let resolve_named_providers_strict ?sw ?net ?clock ?provider_filter
               normalized)
        else Ok providers)
 
+type secondary_resolution = {
+  providers : Llm_provider.Provider_config.t list;
+  secondary_resolver :
+    int -> Llm_provider.Provider_config.t ->
+    Llm_provider.Provider_config.t option;
+}
+
+let provider_filter_allows_single ~provider_filter ~label provider =
+  match provider_filter with
+  | None | Some [] -> true
+  | Some _ ->
+      match
+        Cascade_config.apply_provider_filter_strict
+          ~provider_filter ~label [ provider ]
+      with
+      | Ok [ _ ] -> true
+      | Ok _ | Error _ -> false
+
+let parse_secondary_from_entry ~api_key_env_overrides
+    (entry : Cascade_config_loader.weighted_entry) =
+  match entry.secondary with
+  | None -> None
+  | Some secondary ->
+      let secondary_entry : Cascade_config_loader.weighted_entry =
+        {
+          model = secondary;
+          weight = 1;
+          supports_tool_choice = entry.secondary_supports_tool_choice;
+          secondary = None;
+          secondary_supports_tool_choice = None;
+        }
+      in
+      Cascade_config.parse_weighted_entry
+        ~api_key_env_overrides secondary_entry
+
+let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
+    ?provider_filter ~cascade_name () =
+  match lookup_active_profile ?sw ?net ?clock cascade_name with
+  | Error _ as e -> e
+  | Ok (_snapshot, normalized, profile) ->
+      let ordered_entries =
+        Cascade_config.order_weighted_entries
+          ~rotation_scope:normalized
+          profile.weighted_entries
+      in
+      let parsed_pairs =
+        ordered_entries
+        |> List.filter_map
+             (fun (entry : Cascade_config_loader.weighted_entry) ->
+                match
+                  Cascade_config.parse_weighted_entry
+                    ~api_key_env_overrides:profile.api_key_env_overrides
+                    entry
+                with
+                | None -> None
+                | Some primary ->
+                    Some
+                      ( primary,
+                        parse_secondary_from_entry
+                          ~api_key_env_overrides:
+                            profile.api_key_env_overrides
+                          entry ))
+      in
+      let primaries = List.map fst parsed_pairs in
+      (match
+         Cascade_config.apply_provider_filter_strict
+           ~provider_filter ~label:normalized primaries
+       with
+       | Error rejection ->
+           Error (Cascade_config.provider_filter_rejection_to_string rejection)
+       | Ok _filtered_primaries ->
+           let provider_filter_allows =
+             provider_filter_allows_single ~provider_filter ~label:normalized
+           in
+           let filtered_pairs =
+             parsed_pairs
+             |> List.filter (fun (primary, _) ->
+                    provider_filter_allows primary)
+             |> List.map (fun (primary, secondary) ->
+                    let secondary =
+                      match secondary with
+                      | Some cfg when provider_filter_allows cfg -> Some cfg
+                      | _ -> None
+                    in
+                    (primary, secondary))
+           in
+           let providers = List.map fst filtered_pairs in
+           if providers = [] then
+             Error
+               (Printf.sprintf
+                  "cascade %s resolved to no callable providers"
+                  normalized)
+           else
+             let slots = Array.of_list filtered_pairs in
+             let secondary_resolver provider_index primary =
+               if provider_index < 0 || provider_index >= Array.length slots then
+                 None
+               else
+                 let indexed_primary, secondary = slots.(provider_index) in
+                 if candidate_key_of_cfg indexed_primary
+                    = candidate_key_of_cfg primary
+                 then secondary
+                 else None
+             in
+             Ok { providers; secondary_resolver })
+
 (** RFC-0027 PR-9b dual-track resolution. The [primary] argument is one
     of the providers returned by {!resolve_named_providers}; we walk the
     cascade's parsed weighted entries and, for the entry whose parsed
@@ -950,7 +1056,7 @@ let resolve_secondary_provider_for_primary ?sw ?net ?clock
     ~cascade_name ~(primary : Llm_provider.Provider_config.t) () =
   match lookup_active_profile ?sw ?net ?clock cascade_name with
   | Error _ -> None
-  | Ok (_snapshot, normalized, profile) ->
+  | Ok (_snapshot, _normalized, profile) ->
       let same_kind_model
           (cfg : Llm_provider.Provider_config.t) =
         cfg.kind = primary.kind
@@ -990,17 +1096,12 @@ let resolve_secondary_provider_for_primary ?sw ?net ?clock
                       (Option.get entry.secondary))
              | _ -> None)
       in
-      (* Expand provider:auto entries before matching. The [primary] we
-         received from {!resolve_named_providers} carries a concrete
-         [model_id] post-expansion (e.g. ["claude-code-sonnet-4"]),
-         whereas the raw weighted entries may still hold ["auto"]. We
-         use the same rotation scope as the live resolver so that
-         expansion order matches what the caller observed. *)
-      let expanded =
-        Cascade_config.expand_weighted_auto_entries
-          ~rotation_scope:normalized
-          profile.weighted_entries
-      in
+      (* Expand provider:auto entries without a rotation scope: this legacy
+         lookup may be called after live provider resolution, so it must not
+         consume round-robin state just to answer a secondary lookup. New
+         execution paths use [resolve_named_providers_strict_with_secondary_resolver]
+         to precompute secondaries from the same ordered snapshot. *)
+      let expanded = expand_weighted_entries profile.weighted_entries in
       List.find_map try_entry expanded
 
 let resolve_inference_params ?sw ?net ?clock ~name () =

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -938,9 +938,14 @@ let resolve_named_providers_strict ?sw ?net ?clock ?provider_filter
     - no entry's primary parse matches [primary],
     - or secondary parsing yields no provider (unregistered/unavailable
       scheme, invalid syntax).
-    The function never raises; observability for swap success/failure is
-    the caller's responsibility (PR-9b adds [cascade_secondary_swap_total]
-    in [oas_worker_named_cascade]). *)
+    The function never raises; observability for swap success/failure
+    flows through the unified
+    [Llm_metric_bridge.emit_fallback_triggered ~kind:"dual_track_swap"]
+    counter that the caller in [oas_worker_named_cascade] increments —
+    successful swaps tag [~detail:"swapped"], secondary rejections tag
+    [~detail:<filter_rejection_reason>]. (#13097 review: removed stale
+    [cascade_secondary_swap_total] reference; that name was never
+    registered, the unified counter is the SSOT.) *)
 let resolve_secondary_provider_for_primary ?sw ?net ?clock
     ~cascade_name ~(primary : Llm_provider.Provider_config.t) () =
   match lookup_active_profile ?sw ?net ?clock cascade_name with

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -925,6 +925,79 @@ let resolve_named_providers_strict ?sw ?net ?clock ?provider_filter
               normalized)
        else Ok providers)
 
+(** RFC-0027 PR-9b dual-track resolution. The [primary] argument is one
+    of the providers returned by {!resolve_named_providers}; we walk the
+    cascade's parsed weighted entries and, for the entry whose parsed
+    {!Llm_provider.Provider_config.t} matches [primary] by [(kind,
+    model_id)], read its [secondary] field. When present, the secondary
+    string is wrapped in a synthesised {!Cascade_config_loader.weighted_entry}
+    (preserving [secondary_supports_tool_choice] -> [supports_tool_choice]
+    if set) and parsed via {!Cascade_config.parse_weighted_entry}, which
+    applies the cascade's [api_key_env_overrides]. Returns [None] when:
+    - the cascade has no entries with a secondary,
+    - no entry's primary parse matches [primary],
+    - or secondary parsing yields no provider (unregistered/unavailable
+      scheme, invalid syntax).
+    The function never raises; observability for swap success/failure is
+    the caller's responsibility (PR-9b adds [cascade_secondary_swap_total]
+    in [oas_worker_named_cascade]). *)
+let resolve_secondary_provider_for_primary ?sw ?net ?clock
+    ~cascade_name ~(primary : Llm_provider.Provider_config.t) () =
+  match lookup_active_profile ?sw ?net ?clock cascade_name with
+  | Error _ -> None
+  | Ok (_snapshot, normalized, profile) ->
+      let same_kind_model
+          (cfg : Llm_provider.Provider_config.t) =
+        cfg.kind = primary.kind
+        && String.trim cfg.model_id = String.trim primary.model_id
+      in
+      let synth_secondary_entry
+          (entry : Cascade_config_loader.weighted_entry)
+          (secondary : string) : Cascade_config_loader.weighted_entry =
+        {
+          model = secondary;
+          weight = 1;
+          supports_tool_choice = entry.secondary_supports_tool_choice;
+          secondary = None;
+          secondary_supports_tool_choice = None;
+        }
+      in
+      let try_entry (entry : Cascade_config_loader.weighted_entry) =
+        match entry.secondary with
+        | None -> None
+        | Some _ ->
+            (* Confirm this entry's primary parses to the same provider
+               we were called with. We compare on the parsed
+               Provider_config rather than on raw strings to handle
+               provider:auto expansion (e.g. claude_code:auto could
+               expand to several model strings, and the primary we got
+               carries the resolved model_id). *)
+            let primary_parsed =
+              Cascade_config.parse_weighted_entry
+                ~api_key_env_overrides:profile.api_key_env_overrides
+                entry
+            in
+            (match primary_parsed with
+             | Some parsed when same_kind_model parsed ->
+                 Cascade_config.parse_weighted_entry
+                   ~api_key_env_overrides:profile.api_key_env_overrides
+                   (synth_secondary_entry entry
+                      (Option.get entry.secondary))
+             | _ -> None)
+      in
+      (* Expand provider:auto entries before matching. The [primary] we
+         received from {!resolve_named_providers} carries a concrete
+         [model_id] post-expansion (e.g. ["claude-code-sonnet-4"]),
+         whereas the raw weighted entries may still hold ["auto"]. We
+         use the same rotation scope as the live resolver so that
+         expansion order matches what the caller observed. *)
+      let expanded =
+        Cascade_config.expand_weighted_auto_entries
+          ~rotation_scope:normalized
+          profile.weighted_entries
+      in
+      List.find_map try_entry expanded
+
 let resolve_inference_params ?sw ?net ?clock ~name () =
   match lookup_active_profile ?sw ?net ?clock name with
   | Ok (_snapshot, _normalized, profile) -> Ok profile.inference_params

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -96,6 +96,28 @@ val resolve_named_providers_strict :
     Provider filter resolution fails closed instead of silently
     broadening to the full provider set. *)
 
+type secondary_resolution = {
+  providers : Llm_provider.Provider_config.t list;
+  secondary_resolver :
+    int -> Llm_provider.Provider_config.t ->
+    Llm_provider.Provider_config.t option;
+}
+(** Providers resolved from a named cascade plus an index-aware secondary
+    lookup derived from the same ordered entries. The resolver is pure
+    over this snapshot and does not re-read or re-rotate catalog state. *)
+
+val resolve_named_providers_strict_with_secondary_resolver :
+  ?sw:Eio.Switch.t ->
+  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?provider_filter:string list ->
+  cascade_name:string ->
+  unit ->
+  (secondary_resolution, string) result
+(** Strict named-provider resolution that also precomputes RFC-0027 PR-9b
+    secondary fallbacks from the same ordered weighted entries. Provider
+    filters are applied to both primaries and secondaries. *)
+
 val resolve_secondary_provider_for_primary :
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -96,6 +96,24 @@ val resolve_named_providers_strict :
     Provider filter resolution fails closed instead of silently
     broadening to the full provider set. *)
 
+val resolve_secondary_provider_for_primary :
+  ?sw:Eio.Switch.t ->
+  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  cascade_name:string ->
+  primary:Llm_provider.Provider_config.t ->
+  unit ->
+  Llm_provider.Provider_config.t option
+(** RFC-0027 PR-9b dual-track lookup. For a [primary] provider returned
+    from {!resolve_named_providers} of [cascade_name], find the matching
+    weighted entry and parse its [secondary] field (if any) into a fresh
+    [Provider_config.t]. Returns [None] when the entry has no secondary,
+    when the primary is not present in the cascade (e.g. cross-cascade
+    fallback path), or when secondary parsing fails (unregistered scheme,
+    invalid syntax). The lookup is read-only and does not mutate cascade
+    state — secondary resolution is invoked only after the primary has
+    been rejected by the tool-use gate. *)
+
 val resolve_inference_params :
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -155,6 +155,20 @@ val parse_model_string_result :
     auto-model lists. Other specs pass through unchanged. *)
 val expand_auto_models : string list -> string list
 
+val expand_weighted_auto_entries :
+  ?rotation_scope:string ->
+  Cascade_config_loader.weighted_entry list ->
+  Cascade_config_loader.weighted_entry list
+(** Like {!expand_auto_models} but for weighted entries. Each
+    [provider:auto] entry expands into one entry per concrete model,
+    preserving the original [weight], [supports_tool_choice], and
+    [secondary]/[secondary_supports_tool_choice] overrides on every
+    expanded entry. Non-auto entries pass through unchanged.
+
+    @since 0.151.0 RFC-0027 PR-9b dual-track lookup needs the expanded
+    entries to match a parsed primary [Provider_config] back to its
+    weighted entry (and therefore to its [secondary] declaration). *)
+
 (** Parse multiple model strings, skipping unavailable ones.
     Internally calls {!expand_auto_models} before parsing.
 

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -179,6 +179,10 @@ let run_named
        Log.Misc.error "cascade %s: %s" cascade_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
    | Ok configured_labels, Ok candidate_cfgs ->
+  let secondary_resolver primary =
+    Cascade_catalog_runtime.resolve_secondary_provider_for_primary
+      ~sw ~net ~cascade_name ~primary ()
+  in
   let candidate_cfgs =
     filter_candidate_providers_for_tool_support
       ~keeper_name
@@ -186,6 +190,7 @@ let run_named
       ~tools
       ~require_tool_choice_support
       ~require_tool_support
+      ~secondary_resolver
       ~label:cascade_name
       candidate_cfgs
   in

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -158,31 +158,43 @@ let run_named
   let error_cascade_name = cascade_name_of_string cascade_name in
   let runtime_cascade_name = Keeper_cascade_profile.Runtime_name cascade_name in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
-  let configured_labels_result, candidate_cfgs_result =
+  let configured_labels_result, candidate_cfgs_result, secondary_resolver =
     match model_strings with
     | Some ms when ms <> [] ->
       (* Direct model strings from keeper TOML — skip named preset lookup.
-         MASC passes these strings through without interpretation. *)
+         MASC passes these strings through without interpretation. PR-9b
+         secondary declarations are a named-cascade feature, so direct
+         model strings must not inherit profile-specific fallback behavior. *)
       ( Ok ms,
         Ok
           (resolve_providers_from_model_strings ?provider_filter
-             ~require_tool_choice_support ~require_tool_support ms) )
+             ~require_tool_choice_support ~require_tool_support ms),
+        None )
     | _ ->
+      let named_resolution =
+        Cascade_catalog_runtime
+        .resolve_named_providers_strict_with_secondary_resolver
+          ~sw ~net ?provider_filter ~cascade_name ()
+      in
+      let candidate_cfgs_result =
+        match named_resolution with
+        | Ok resolution -> Ok resolution.providers
+        | Error detail -> Error detail
+      in
+      let secondary_resolver =
+        match named_resolution with
+        | Ok resolution -> Some resolution.secondary_resolver
+        | Error _ -> None
+      in
       ( Cascade_runtime.models_of_cascade_name_result runtime_cascade_name,
-        resolve_cascade_providers ?provider_filter
-          ~require_tool_choice_support ~require_tool_support
-          ~cascade_name:runtime_cascade_name ()
-      )
+        candidate_cfgs_result,
+        secondary_resolver )
   in
   (match configured_labels_result, candidate_cfgs_result with
    | Error detail, _ | _, Error detail ->
        Log.Misc.error "cascade %s: %s" cascade_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
    | Ok configured_labels, Ok candidate_cfgs ->
-  let secondary_resolver primary =
-    Cascade_catalog_runtime.resolve_secondary_provider_for_primary
-      ~sw ~net ~cascade_name ~primary ()
-  in
   let candidate_cfgs =
     filter_candidate_providers_for_tool_support
       ~keeper_name
@@ -190,7 +202,7 @@ let run_named
       ~tools
       ~require_tool_choice_support
       ~require_tool_support
-      ~secondary_resolver
+      ?secondary_resolver
       ~label:cascade_name
       candidate_cfgs
   in

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -232,18 +232,66 @@ let cascade_empty_should_emit_first ~label ~signature =
   Mutex.unlock cascade_empty_warn_seen_mutex;
   first
 
+(** RFC-0027 PR-9b dual-track swap. When the tool-use gate rejects a
+    primary provider and the caller supplied a [secondary_resolver],
+    invoke it to obtain a candidate fallback provider. The fallback is
+    re-classified through the same gate; on pass it replaces the primary
+    in [kept], on failure (or when no secondary is configured) the
+    primary stays in [rejected].
+
+    Observability:
+    - Successful swap -> [emit_fallback_triggered ~kind:"dual_track_swap" ~detail:"swapped"]
+    - Secondary also rejected -> [emit_fallback_triggered ~kind:"dual_track_swap" ~detail:"<secondary_reason>"]
+    - No secondary configured -> no extra metric (the caller's existing
+      [cascade_empty:<reason>] capability_drop already covers this case).
+    The function is total and never raises; secondary parsing errors are
+    surfaced as [None] by the resolver. *)
+let attempt_secondary_swap
+    ~keeper_name ?runtime_mcp_policy ~tools
+    ~require_tool_choice_support ~require_tool_support
+    ~(secondary_resolver :
+        Llm_provider.Provider_config.t ->
+        Llm_provider.Provider_config.t option)
+    (primary, primary_reason)
+  : (Llm_provider.Provider_config.t,
+     Llm_provider.Provider_config.t * filter_rejection_reason) Either.t =
+  match secondary_resolver primary with
+  | None -> Either.Right (primary, primary_reason)
+  | Some secondary -> (
+      match
+        classify_filter_rejection
+          ~keeper_name ?runtime_mcp_policy ~tools
+          ~require_tool_choice_support ~require_tool_support
+          secondary
+      with
+      | None ->
+          Llm_metric_bridge.emit_fallback_triggered
+            ~kind:"dual_track_swap" ~detail:"swapped";
+          Either.Left secondary
+      | Some secondary_reason ->
+          (* Both primary and secondary rejected: keep the primary in
+             rejected so the cascade-empty WARN signature stays anchored
+             on the user-declared model. The secondary's rejection is
+             surfaced as a separate metric so operators can audit which
+             dual-track entries are uselessly configured. *)
+          Llm_metric_bridge.emit_fallback_triggered
+            ~kind:"dual_track_swap"
+            ~detail:(filter_rejection_reason_label secondary_reason);
+          Either.Right (primary, primary_reason))
+
 let filter_candidate_providers_for_tool_support
     ~(keeper_name : string)
     ?runtime_mcp_policy
     ?(tools = [])
     ~require_tool_choice_support
     ~require_tool_support
+    ?secondary_resolver
     ~label
     (provider_cfgs : Llm_provider.Provider_config.t list) =
   if not require_tool_choice_support && not require_tool_support then
     provider_cfgs
   else
-    let kept, rejected =
+    let initial_kept, initial_rejected =
       List.partition_map
         (fun provider_cfg ->
            match
@@ -255,6 +303,20 @@ let filter_candidate_providers_for_tool_support
            | None -> Either.Left provider_cfg
            | Some reason -> Either.Right (provider_cfg, reason))
         provider_cfgs
+    in
+    let kept, rejected =
+      match secondary_resolver with
+      | None -> initial_kept, initial_rejected
+      | Some resolver ->
+          let swapped_in, still_rejected =
+            List.partition_map
+              (attempt_secondary_swap
+                 ~keeper_name ?runtime_mcp_policy ~tools
+                 ~require_tool_choice_support ~require_tool_support
+                 ~secondary_resolver:resolver)
+              initial_rejected
+          in
+          (initial_kept @ swapped_in, still_rejected)
     in
     if kept = [] && provider_cfgs <> [] then begin
       let signature = signature_of_rejected_providers rejected in
@@ -334,10 +396,16 @@ let resolve_tool_capable_provider_across_cascades
              with
              | Error _ -> None
              | Ok providers ->
+                 let secondary_resolver primary =
+                   Cascade_catalog_runtime
+                   .resolve_secondary_provider_for_primary
+                     ~sw ~net ~cascade_name ~primary ()
+                 in
                  let filtered =
                    filter_candidate_providers_for_tool_support
                      ~keeper_name ?runtime_mcp_policy ~tools
                      ~require_tool_choice_support ~require_tool_support
+                     ~secondary_resolver
                      ~label:cascade_name providers
                  in
                  match filtered with

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -250,12 +250,14 @@ let attempt_secondary_swap
     ~keeper_name ?runtime_mcp_policy ~tools
     ~require_tool_choice_support ~require_tool_support
     ~(secondary_resolver :
+        int ->
         Llm_provider.Provider_config.t ->
         Llm_provider.Provider_config.t option)
+    ~(provider_index : int)
     (primary, primary_reason)
   : (Llm_provider.Provider_config.t,
      Llm_provider.Provider_config.t * filter_rejection_reason) Either.t =
-  match secondary_resolver primary with
+  match secondary_resolver provider_index primary with
   | None -> Either.Right (primary, primary_reason)
   | Some secondary -> (
       match
@@ -291,78 +293,38 @@ let filter_candidate_providers_for_tool_support
   if not require_tool_choice_support && not require_tool_support then
     provider_cfgs
   else
-    let initial_kept, initial_rejected =
-      List.partition_map
-        (fun provider_cfg ->
+    let kept_rev, rejected_rev, _ =
+      List.fold_left
+        (fun (kept, rejected, provider_index) provider_cfg ->
            match
              classify_filter_rejection
                ~keeper_name ?runtime_mcp_policy ~tools
                ~require_tool_choice_support ~require_tool_support
                provider_cfg
            with
-           | None -> Either.Left provider_cfg
-           | Some reason -> Either.Right (provider_cfg, reason))
+           | None -> (provider_cfg :: kept, rejected, provider_index + 1)
+           | Some reason ->
+               let swap =
+                 match secondary_resolver with
+                 | None -> Either.Right (provider_cfg, reason)
+                 | Some resolver ->
+                     attempt_secondary_swap
+                       ~keeper_name ?runtime_mcp_policy ~tools
+                       ~require_tool_choice_support ~require_tool_support
+                       ~secondary_resolver:resolver
+                       ~provider_index
+                       (provider_cfg, reason)
+               in
+               (match swap with
+                | Either.Left secondary ->
+                    (secondary :: kept, rejected, provider_index + 1)
+                | Either.Right rejected_provider ->
+                    (kept, rejected_provider :: rejected, provider_index + 1)))
+        ([], [], 0)
         provider_cfgs
     in
-    let kept, rejected =
-      match secondary_resolver with
-      | None -> initial_kept, initial_rejected
-      | Some resolver ->
-          (* #13097 review (codex P1, copilot): preserve original cascade
-             priority slots when a primary is swapped to its secondary.
-             The earlier ([initial_kept @ swapped_in], …) implementation
-             appended every secondary after every kept provider, which
-             changed runtime ordering whenever a rejected primary came
-             before a kept one — failover then routed to lower-priority
-             providers ahead of the configured fallback.
-
-             We re-walk [provider_cfgs] in original order: kept primaries
-             stay in place, rejected primaries that produce a successful
-             secondary occupy the same slot as their primary (replaced),
-             and entries whose secondary is also rejected fall into
-             [rejected]. The result is a single pass that keeps slot
-             ordering stable. *)
-          let swap_outcomes =
-            List.map
-              (attempt_secondary_swap
-                 ~keeper_name ?runtime_mcp_policy ~tools
-                 ~require_tool_choice_support ~require_tool_support
-                 ~secondary_resolver:resolver)
-              initial_rejected
-          in
-          let still_rejected =
-            List.filter_map
-              (function
-                | Either.Left _ -> None
-                | Either.Right pair -> Some pair)
-              swap_outcomes
-          in
-          (* Build a lookup from rejected primary's identity (physical
-             pointer is stable here since [initial_rejected] holds the
-             same [Provider_config.t] values we just received) to its
-             swap outcome, so a single pass over [provider_cfgs] can
-             splice secondaries back into their primary's slot. *)
-          let outcome_for_primary =
-            List.combine initial_rejected swap_outcomes
-          in
-          let kept_in_order =
-            List.filter_map
-              (fun cfg ->
-                if List.exists (fun k -> k == cfg) initial_kept then
-                  Some cfg
-                else
-                  match
-                    List.find_opt
-                      (fun ((rejected_cfg, _), _) -> rejected_cfg == cfg)
-                      outcome_for_primary
-                  with
-                  | Some (_, Either.Left secondary) -> Some secondary
-                  | Some (_, Either.Right _) -> None
-                  | None -> None)
-              provider_cfgs
-          in
-          (kept_in_order, still_rejected)
-    in
+    let kept = List.rev kept_rev in
+    let rejected = List.rev rejected_rev in
     if kept = [] && provider_cfgs <> [] then begin
       let signature = signature_of_rejected_providers rejected in
       (* Forward each rejection to the Prometheus capability_drop counter so
@@ -441,7 +403,7 @@ let resolve_tool_capable_provider_across_cascades
              with
              | Error _ -> None
              | Ok providers ->
-                 let secondary_resolver primary =
+                 let secondary_resolver _provider_index primary =
                    Cascade_catalog_runtime
                    .resolve_secondary_provider_for_primary
                      ~sw ~net ~cascade_name ~primary ()

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -308,15 +308,60 @@ let filter_candidate_providers_for_tool_support
       match secondary_resolver with
       | None -> initial_kept, initial_rejected
       | Some resolver ->
-          let swapped_in, still_rejected =
-            List.partition_map
+          (* #13097 review (codex P1, copilot): preserve original cascade
+             priority slots when a primary is swapped to its secondary.
+             The earlier ([initial_kept @ swapped_in], …) implementation
+             appended every secondary after every kept provider, which
+             changed runtime ordering whenever a rejected primary came
+             before a kept one — failover then routed to lower-priority
+             providers ahead of the configured fallback.
+
+             We re-walk [provider_cfgs] in original order: kept primaries
+             stay in place, rejected primaries that produce a successful
+             secondary occupy the same slot as their primary (replaced),
+             and entries whose secondary is also rejected fall into
+             [rejected]. The result is a single pass that keeps slot
+             ordering stable. *)
+          let swap_outcomes =
+            List.map
               (attempt_secondary_swap
                  ~keeper_name ?runtime_mcp_policy ~tools
                  ~require_tool_choice_support ~require_tool_support
                  ~secondary_resolver:resolver)
               initial_rejected
           in
-          (initial_kept @ swapped_in, still_rejected)
+          let still_rejected =
+            List.filter_map
+              (function
+                | Either.Left _ -> None
+                | Either.Right pair -> Some pair)
+              swap_outcomes
+          in
+          (* Build a lookup from rejected primary's identity (physical
+             pointer is stable here since [initial_rejected] holds the
+             same [Provider_config.t] values we just received) to its
+             swap outcome, so a single pass over [provider_cfgs] can
+             splice secondaries back into their primary's slot. *)
+          let outcome_for_primary =
+            List.combine initial_rejected swap_outcomes
+          in
+          let kept_in_order =
+            List.filter_map
+              (fun cfg ->
+                if List.exists (fun k -> k == cfg) initial_kept then
+                  Some cfg
+                else
+                  match
+                    List.find_opt
+                      (fun ((rejected_cfg, _), _) -> rejected_cfg == cfg)
+                      outcome_for_primary
+                  with
+                  | Some (_, Either.Left secondary) -> Some secondary
+                  | Some (_, Either.Right _) -> None
+                  | None -> None)
+              provider_cfgs
+          in
+          (kept_in_order, still_rejected)
     in
     if kept = [] && provider_cfgs <> [] then begin
       let signature = signature_of_rejected_providers rejected in

--- a/lib/oas_worker_named_cascade.mli
+++ b/lib/oas_worker_named_cascade.mli
@@ -105,12 +105,23 @@ val filter_candidate_providers_for_tool_support :
   ?tools:Agent_sdk.Tool.t list ->
   require_tool_choice_support:bool ->
   require_tool_support:bool ->
+  ?secondary_resolver:
+    (Llm_provider.Provider_config.t ->
+     Llm_provider.Provider_config.t option) ->
   label:string ->
   Llm_provider.Provider_config.t list ->
   Llm_provider.Provider_config.t list
 (** Filter provider candidates through the tool-use gate.  When the gate
     empties the list, emits a deduplicated diagnostic (ERROR on first
-    occurrence per signature, DEBUG on repeats). *)
+    occurrence per signature, DEBUG on repeats).
+
+    @param secondary_resolver RFC-0027 PR-9b dual-track callback. When
+    set, each rejected primary is offered to the resolver; if it returns
+    a [Some secondary] candidate that itself passes the tool-use gate,
+    the secondary replaces the primary in the kept list. The function
+    is invoked at most once per rejected primary, after the initial
+    classification, so it does not affect the hot path when no entries
+    have a [secondary] declaration. *)
 
 (** {1 Cross-cascade fallback} *)
 

--- a/lib/oas_worker_named_cascade.mli
+++ b/lib/oas_worker_named_cascade.mli
@@ -106,7 +106,8 @@ val filter_candidate_providers_for_tool_support :
   require_tool_choice_support:bool ->
   require_tool_support:bool ->
   ?secondary_resolver:
-    (Llm_provider.Provider_config.t ->
+    (int ->
+     Llm_provider.Provider_config.t ->
      Llm_provider.Provider_config.t option) ->
   label:string ->
   Llm_provider.Provider_config.t list ->
@@ -119,7 +120,8 @@ val filter_candidate_providers_for_tool_support :
     set, each rejected primary is offered to the resolver; if it returns
     a [Some secondary] candidate that itself passes the tool-use gate,
     the secondary replaces the primary in the kept list. The function
-    is invoked at most once per rejected primary, after the initial
+    is invoked at most once per rejected primary, with the primary's
+    zero-based position in the original candidate list, after the initial
     classification, so it does not affect the hot path when no entries
     have a [secondary] declaration. *)
 

--- a/test/dune
+++ b/test/dune
@@ -49,6 +49,7 @@
         test_cascade_capability_profile
         test_cascade_required_capability_profile
         test_cascade_secondary_entry_parser
+        test_cascade_secondary_expand
         test_cascade_validator_capability_lint
         test_keeper_hooks_oas_provider
         test_keeper_hooks_oas_pricing
@@ -256,6 +257,7 @@
           test_cascade_capability_profile
           test_cascade_required_capability_profile
           test_cascade_secondary_entry_parser
+          test_cascade_secondary_expand
           test_cascade_validator_capability_lint
           test_keeper_hooks_oas_provider
           test_keeper_hooks_oas_pricing

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -196,6 +196,10 @@ let require_ok = function
   | Ok value -> value
   | Error detail -> failf "expected Ok, got Error: %s" detail
 
+let require_some label = function
+  | Some value -> value
+  | None -> failf "expected Some for %s" label
+
 let provider_kinds providers =
   List.map
     (fun (cfg : Llm_provider.Provider_config.t) ->
@@ -1010,6 +1014,79 @@ let test_non_strict_resolve_tolerates_nonmatching_filter () =
   check int "non-strict returns all providers despite bad filter" 2
     (List.length providers)
 
+let test_secondary_resolution_disambiguates_duplicate_primary_slots () =
+  with_temp_dir "cascade-secondary-duplicate" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  let primary = Printf.sprintf "custom:primary@%s/v1" dummy_base_url in
+  let secondary_a = Printf.sprintf "custom:fallback-a@%s/v1" dummy_base_url in
+  let secondary_b = Printf.sprintf "custom:fallback-b@%s/v1" dummy_base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "big_three_models": [
+    {"model": "%s", "secondary": "%s"},
+    {"model": "%s", "secondary": "%s"}
+  ]
+}|}
+          primary secondary_a primary secondary_b));
+  let resolution =
+    require_ok
+      (Cascade_catalog_runtime
+       .resolve_named_providers_strict_with_secondary_resolver
+         ~cascade_name:Keeper_config.default_cascade_name
+         ())
+  in
+  check int "duplicate primaries remain distinct" 2
+    (List.length resolution.providers);
+  let first_primary = List.nth resolution.providers 0 in
+  let second_primary = List.nth resolution.providers 1 in
+  let first_secondary =
+    require_some "first secondary"
+      (resolution.secondary_resolver 0 first_primary)
+  in
+  let second_secondary =
+    require_some "second secondary"
+      (resolution.secondary_resolver 1 second_primary)
+  in
+  check string "first slot secondary" "fallback-a"
+    first_secondary.Llm_provider.Provider_config.model_id;
+  check string "second slot secondary" "fallback-b"
+    second_secondary.Llm_provider.Provider_config.model_id
+
+let test_secondary_resolution_applies_provider_filter_to_secondary () =
+  with_temp_dir "cascade-secondary-filter" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  let secondary = Printf.sprintf "custom:fallback@%s/v1" dummy_base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "big_three_models": [
+    {"model": "anthropic:claude-sonnet-4-20250514", "secondary": "%s"}
+  ]
+}|}
+          secondary));
+  let resolution =
+    require_ok
+      (Cascade_catalog_runtime
+       .resolve_named_providers_strict_with_secondary_resolver
+         ~provider_filter:[ "anthropic" ]
+         ~cascade_name:Keeper_config.default_cascade_name
+         ())
+  in
+  check int "primary survives provider filter" 1
+    (List.length resolution.providers);
+  let primary = List.nth resolution.providers 0 in
+  check (option string) "secondary violating provider_filter is hidden" None
+    (Option.map
+       (fun (cfg : Llm_provider.Provider_config.t) -> cfg.model_id)
+       (resolution.secondary_resolver 0 primary))
+
 let () =
   run "cascade_catalog_runtime"
     [
@@ -1091,5 +1168,13 @@ let () =
             "non-strict resolve tolerates non-matching filter (#12686)"
             `Quick
             test_non_strict_resolve_tolerates_nonmatching_filter;
+          test_case
+            "secondary resolver disambiguates duplicate primary slots"
+            `Quick
+            test_secondary_resolution_disambiguates_duplicate_primary_slots;
+          test_case
+            "secondary resolver applies provider_filter to secondaries"
+            `Quick
+            test_secondary_resolution_applies_provider_filter_to_secondary;
         ] );
     ]

--- a/test/test_cascade_secondary_expand.ml
+++ b/test/test_cascade_secondary_expand.ml
@@ -1,0 +1,112 @@
+(** RFC-0027 PR-9b: provider:auto expansion preserves [secondary]
+    overrides on every expanded weighted entry.
+
+    The dual-track resolver in
+    {!Masc_mcp.Cascade_catalog_runtime.resolve_secondary_provider_for_primary}
+    matches a parsed primary [Provider_config] back to its weighted entry
+    by walking the *expanded* entries (one per concrete model after
+    [provider:auto] expansion). For the lookup to find the secondary
+    declaration, expansion must carry the [secondary] and
+    [secondary_supports_tool_choice] fields onto every expanded entry —
+    not just the first one. *)
+
+open Alcotest
+
+module Loader = Masc_mcp.Cascade_config_loader
+module Cfg = Masc_mcp.Cascade_config
+
+let entry ?(weight = 1) ?supports_tool_choice ?secondary
+    ?secondary_supports_tool_choice model : Loader.weighted_entry =
+  {
+    model;
+    weight;
+    supports_tool_choice;
+    secondary;
+    secondary_supports_tool_choice;
+  }
+
+let test_non_auto_passes_through () =
+  let inputs =
+    [ entry ~secondary:"openai:gpt-4-turbo" "anthropic:claude-3-5" ]
+  in
+  let outs = Cfg.expand_weighted_auto_entries inputs in
+  check int "single entry preserved" 1 (List.length outs);
+  let e = List.hd outs in
+  check string "model unchanged" "anthropic:claude-3-5" e.model;
+  check (option string) "secondary preserved"
+    (Some "openai:gpt-4-turbo") e.secondary
+
+let test_auto_expansion_carries_secondary () =
+  (* claude_code:auto expands to multiple concrete models; every
+     expanded entry must keep the same secondary so the dual-track
+     resolver can match any of them back to a fallback. *)
+  let inputs =
+    [ entry
+        ~secondary:"anthropic:claude-3-5-sonnet-20251022"
+        ~secondary_supports_tool_choice:true
+        "claude_code:auto" ]
+  in
+  let outs = Cfg.expand_weighted_auto_entries inputs in
+  (* claude_code:auto must expand to >=2 models, otherwise the auto
+     model list collapsed and this test would not exercise the
+     preservation path. *)
+  if List.length outs < 2 then
+    failf
+      "claude_code:auto expanded to only %d entries; expected >=2"
+      (List.length outs);
+  List.iter
+    (fun (e : Loader.weighted_entry) ->
+      check (option string)
+        (Printf.sprintf "secondary preserved on expanded model %s" e.model)
+        (Some "anthropic:claude-3-5-sonnet-20251022") e.secondary;
+      check (option bool)
+        (Printf.sprintf
+           "secondary_supports_tool_choice preserved on %s" e.model)
+        (Some true) e.secondary_supports_tool_choice)
+    outs
+
+let test_no_secondary_stays_none_after_expansion () =
+  let inputs = [ entry "claude_code:auto" ] in
+  let outs = Cfg.expand_weighted_auto_entries inputs in
+  List.iter
+    (fun (e : Loader.weighted_entry) ->
+      check (option string)
+        (Printf.sprintf "no secondary on %s" e.model) None e.secondary;
+      check (option bool)
+        (Printf.sprintf "no secondary_supports_tool_choice on %s" e.model)
+        None e.secondary_supports_tool_choice)
+    outs
+
+let test_mixed_entries_preserve_per_entry () =
+  let inputs =
+    [
+      entry ~secondary:"openai:gpt-4-turbo" "anthropic:claude-3-5";
+      entry "openai:gpt-4-turbo";
+    ]
+  in
+  let outs = Cfg.expand_weighted_auto_entries inputs in
+  (* Both entries are concrete (no :auto), so expansion is a passthrough
+     of length 2; secondary must be preserved on the first only. *)
+  check int "two entries" 2 (List.length outs);
+  let e1 = List.nth outs 0 in
+  let e2 = List.nth outs 1 in
+  check (option string) "first entry secondary preserved"
+    (Some "openai:gpt-4-turbo") e1.secondary;
+  check (option string) "second entry has no secondary"
+    None e2.secondary
+
+let () =
+  run "Cascade_secondary_expand"
+    [
+      ( "expand_weighted_auto_entries preserves secondary",
+        [
+          test_case "non-auto entry passes through with secondary" `Quick
+            test_non_auto_passes_through;
+          test_case "provider:auto expansion carries secondary on all"
+            `Quick test_auto_expansion_carries_secondary;
+          test_case "absent secondary stays None after expansion" `Quick
+            test_no_secondary_stays_none_after_expansion;
+          test_case "secondary preserved per-entry independently" `Quick
+            test_mixed_entries_preserve_per_entry;
+        ] );
+    ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2161,6 +2161,71 @@ let test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_fo
     [ "claude_code:auto"; "kimi_cli:kimi-for-coding" ]
     (List.map Provider_tool_support.provider_debug_label filtered)
 
+let test_filter_candidate_providers_for_tool_support_secondary_preserves_priority_slot
+    () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  let runtime_mcp_policy =
+    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+      ~keeper_name:"sangsu" tools
+  in
+  let filtered =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~secondary_resolver:
+        (fun provider_index provider_cfg ->
+           if provider_index = 0
+              && provider_cfg.kind = Llm_provider.Provider_config.Codex_cli
+           then Some (make_claude_code_provider_cfg ())
+           else None)
+      ~label:"tool_use_strict"
+      [ make_codex_cli_provider_cfg (); make_kimi_cli_provider_cfg () ]
+  in
+  Alcotest.(check (list string))
+    "secondary replaces rejected primary in its original priority slot"
+    [ "claude_code:auto"; "kimi_cli:kimi-for-coding" ]
+    (List.map Provider_tool_support.provider_debug_label filtered)
+
+let test_filter_candidate_providers_for_tool_support_secondary_uses_candidate_index
+    () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  let runtime_mcp_policy =
+    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+      ~keeper_name:"sangsu" tools
+  in
+  let filtered =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~secondary_resolver:
+        (fun provider_index provider_cfg ->
+           if provider_cfg.kind = Llm_provider.Provider_config.Codex_cli then
+             Some
+               (make_claude_code_provider_cfg
+                  ~model_id:(Printf.sprintf "fallback-%d" provider_index)
+                  ())
+           else None)
+      ~label:"tool_use_strict"
+      [
+        make_codex_cli_provider_cfg ~model_id:"same-primary" ();
+        make_codex_cli_provider_cfg ~model_id:"same-primary" ();
+      ]
+  in
+  Alcotest.(check (list string))
+    "duplicate primary slots get their own secondary"
+    [ "claude_code:fallback-0"; "claude_code:fallback-1" ]
+    (List.map Provider_tool_support.provider_debug_label filtered)
+
 (* #10681: filter rejection diagnostics. When [filter_*] empties the
    cascade, the WARN log now lists each rejected provider with its
    classification — these tests pin the classifier to its 3-stage
@@ -4136,6 +4201,14 @@ let () =
         "provider-normalized filter keeps header-capable keeper-internal lanes"
         `Quick
         test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_for_keeper_internal_tools;
+      Alcotest.test_case
+        "provider-normalized secondary preserves primary priority slot"
+        `Quick
+        test_filter_candidate_providers_for_tool_support_secondary_preserves_priority_slot;
+      Alcotest.test_case
+        "provider-normalized secondary resolver receives candidate index"
+        `Quick
+        test_filter_candidate_providers_for_tool_support_secondary_uses_candidate_index;
       Alcotest.test_case
         "classify_filter_rejection: codex bound-actor policy → keeper_bound_actor"
         `Quick test_classify_filter_rejection_codex_keeper_bound_actor;


### PR DESCRIPTION
**Stacks on #13067 (PR-9a schema)**. Routes the `weighted_entry.secondary` field added in 9a through the tool-use gate so a CLI primary that fails capability checks can transparently swap to its declared Direct API fallback on the same entry.

> **Note on diff size (+582/-11)**: Base was originally `feat/rfc-0027-pr9-dual-track` (PR-9a) but was retargeted to `main` because this repo's CI workflows trigger only on `branches: [main, develop]` — stacked PRs against feature branches do not run CI. After PR #13067 merges, this PR's diff will automatically shrink to the 9b-only changes (+305/-2). For review, the **9b-specific changes** are: `lib/cascade/cascade_catalog_runtime.{ml,mli}`, `lib/cascade/cascade_config.mli` (`expand_weighted_auto_entries` exposure), `lib/oas_worker_named.ml` (call site), `lib/oas_worker_named_cascade.{ml,mli}` (`?secondary_resolver` param), `test/test_cascade_secondary_expand.ml`, `test/dune`. The remaining files are PR-9a content already reviewed there.

## Summary
- New `Cascade_catalog_runtime.resolve_secondary_provider_for_primary` walks the cascade's expanded weighted entries, matches a parsed primary `Provider_config` back to its raw entry, and parses the entry's `secondary` string into a fresh `Provider_config` (applies `api_key_env_overrides`).
- `filter_candidate_providers_for_tool_support` takes a new optional `?secondary_resolver`; rejected primaries are offered to the resolver and, if the secondary itself passes the gate, replace the primary in kept.
- Two call sites wired: main cascade path in `oas_worker_named.ml`, and the cross-cascade fallback path in `oas_worker_named_cascade.ml`. Both pass a closure that invokes the runtime helper for the resolved cascade name.
- `Cascade_config.expand_weighted_auto_entries` is exposed in the `.mli` so the runtime resolver can match a `provider:auto`-expanded primary back to its raw entry.

## Observability
- `emit_fallback_triggered ~kind:"dual_track_swap" ~detail:"swapped"` on successful swap.
- `~detail:<secondary_reason_label>` when the secondary is also rejected — operators can audit useless dual-track entries.
- Existing `cascade_empty:<reason>` capability_drop metric is unchanged; the WARN signature still anchors on the user-declared primary so dashboards remain stable.

## Hot-path cost
- **Zero** when no entry has a `secondary`. Resolver is only invoked after a primary has been classified as rejected.
- One `lookup_active_profile` + `expand_weighted_auto_entries` walk per rejected primary (cold path).

## Self-review (Best Programmer)
- Goal: enable PR-9a's schema field by routing it through the runtime path; no TOML/JSON shape change in this PR.
- Files (9b-specific): 5 lib + 1 mli (interface), 1 new unit test, 2 test/dune registrations.
- Local verification: PR-9b touches compile clean. Three pre-existing main breaks (`oas_compat.on_retry`, `cascade_attempt_liveness_observer.SSEParseFailed` exhaustiveness, `oas_worker_named_error.messages` arity) are also present on main, not caused by this PR.
- Unverified locally: live runtime swap path; full lib+test compilation under heavy CI. The new unit test covers `expand_weighted_auto_entries` field preservation, which is the boundary that the resolver matching depends on.

## Test plan
- [ ] CI heavy build green after `human-approved-ready` label
- [ ] `test_cascade_secondary_expand` passes (4 cases)
- [ ] Existing `test_cascade_secondary_entry_parser` (PR-9a) still green
- [ ] No regression in `test_oas_worker.ml` filter tests (3 cases)

## Stack
- Conceptually stacked on #13067 (PR-9a, schema additive)
- Base now `main` to enable CI; merges naturally after 9a (diff auto-collapses)
- Next: 9c (per-secondary token bucket accounting), opens after this PR merges

Refs: RFC-0027 capability-typed cascade catalog; plan `~/me/planning/claude-plans/inherited-toasting-moon.md` PR-9b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>