### PR TITLE
fix(keeper): surface turn slot holders on starvation

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -755,12 +755,18 @@ let run_keepalive_unified_turn
             ~channel:turn_decision.channel
             ~kind:Semaphore_wait_timeout;
           let auto_avail = Eio.Semaphore.get_value Keeper_turn_slot.autonomous_turn_semaphore in
+          let reactive_avail = Eio.Semaphore.get_value Keeper_turn_slot.reactive_turn_semaphore in
           let turn_avail = Eio.Semaphore.get_value Keeper_turn_slot.turn_semaphore in
+          let holder_summary =
+            Keeper_turn_slot.slot_holders_summary ~now:(Time_compat.now ()) ()
+          in
           let blocker_text =
             Printf.sprintf
               "skipped: semaphore wait > %.0fs, peers holding slot \
-               (cascade=%s, autonomous_available=%d turn_available=%d)"
-              wait_sec meta_after_triage.cascade_name auto_avail turn_avail
+               (cascade=%s, autonomous_available=%d reactive_available=%d \
+               turn_available=%d, %s)"
+              wait_sec meta_after_triage.cascade_name auto_avail reactive_avail
+              turn_avail holder_summary
           in
           Log.Keeper.warn
             "%s: skipping turn (%s)"

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -760,17 +760,30 @@ let run_keepalive_unified_turn
           let holder_summary =
             Keeper_turn_slot.slot_holders_summary ~now:(Time_compat.now ()) ()
           in
-          let blocker_text =
+          (* #13099 review: [last_blocker] gets capped to 200 chars by
+             [cap_blocker] on meta load (narrative budget for dashboards),
+             so the longer holder snapshot would be ellipsized after a
+             restart and lose the diagnostic value.  Split into two
+             strings:
+             - [persisted_blocker]: short narrative the dashboards see
+               and that survives the cap;
+             - [log_diagnostic]: the full holder snapshot, emitted via
+               Log.Keeper.warn (uncapped) so operators tailing logs can
+               still attribute the starvation to specific peers.  *)
+          let persisted_blocker =
             Printf.sprintf
-              "skipped: semaphore wait > %.0fs, peers holding slot \
-               (cascade=%s, autonomous_available=%d reactive_available=%d \
-               turn_available=%d, %s)"
+              "skipped: semaphore wait > %.0fs (cascade=%s, \
+               autonomous_available=%d reactive_available=%d \
+               turn_available=%d)"
               wait_sec meta_after_triage.cascade_name auto_avail reactive_avail
-              turn_avail holder_summary
+              turn_avail
+          in
+          let log_diagnostic =
+            Printf.sprintf "%s peers=%s" persisted_blocker holder_summary
           in
           Log.Keeper.warn
             "%s: skipping turn (%s)"
-            meta_after_triage.name blocker_text;
+            meta_after_triage.name log_diagnostic;
           Prometheus.inc_counter
             Prometheus.metric_keeper_semaphore_wait_timeout
             ~labels:[("keeper", meta_after_triage.name); ("channel", (Keeper_world_observation.channel_to_string turn_decision.channel))]
@@ -778,7 +791,7 @@ let run_keepalive_unified_turn
           Keeper_types.map_runtime
             (fun rt ->
               { rt with
-                last_blocker = blocker_text;
+                last_blocker = persisted_blocker;
                 last_blocker_class = Some Keeper_types.Autonomous_slot_wait_timeout;
               })
             meta_after_triage)

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -82,6 +82,14 @@ val turn_slot_holders : now:float -> (string * float) list
 val autonomous_slot_holders : now:float -> (string * float) list
 val reactive_slot_holders : now:float -> (string * float) list
 
+(** Render a compact holder list such as [[keeper-a/181s, +2 more]].
+    The input is expected to be sorted longest-first, as returned by the
+    holder accessors above. *)
+val format_slot_holders : ?limit:int -> (string * float) list -> string
+
+(** Operator-facing one-line summary of all holder pools. *)
+val slot_holders_summary : ?limit:int -> now:float -> unit -> string
+
 (** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
 val enqueue_autonomous_waiter_for_test : string -> int
 val drop_autonomous_waiter_for_test : int -> unit

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -154,12 +154,36 @@ let format_slot_holders ?(limit = 5) holders =
     "[" ^ String.concat ", " items ^ "]"
 ;;
 
+(** [snapshot_all_holders ~now] reads every pool inside ONE
+    [holder_mutex] critical section and returns the three lists in
+    the same instant.  Calling [turn_slot_holders] / [autonomous_slot_holders]
+    / [reactive_slot_holders] back-to-back from the summary builder
+    would release and re-take the mutex three times — an interleaved
+    [record_holder] / [drop_holder] could then leave the summary
+    reporting contradictory states (e.g. empty turn_holders next to
+    [turn_available=0]).  This helper closes that race. *)
+let snapshot_all_holders ~now =
+  with_holder_lock (fun () ->
+    Hashtbl.fold
+      (fun (label, name) ts (turn, auto, reactive) ->
+        let held = now -. ts in
+        match label with
+        | "turn" -> ((name, held) :: turn, auto, reactive)
+        | "autonomous" -> (turn, (name, held) :: auto, reactive)
+        | "reactive" -> (turn, auto, (name, held) :: reactive)
+        | _ -> (turn, auto, reactive))
+      holder_table ([], [], []))
+  |> fun (t, a, r) ->
+  let by_held = List.sort (fun (_, x) (_, y) -> compare y x) in
+  (by_held t, by_held a, by_held r)
+
 let slot_holders_summary ?(limit = 5) ~now () =
+  let turn, autonomous, reactive = snapshot_all_holders ~now in
   Printf.sprintf
     "turn_holders=%s autonomous_holders=%s reactive_holders=%s"
-    (format_slot_holders ~limit (turn_slot_holders ~now))
-    (format_slot_holders ~limit (autonomous_slot_holders ~now))
-    (format_slot_holders ~limit (reactive_slot_holders ~now))
+    (format_slot_holders ~limit turn)
+    (format_slot_holders ~limit autonomous)
+    (format_slot_holders ~limit reactive)
 ;;
 
 type autonomous_waiter =

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -128,6 +128,40 @@ let turn_slot_holders ~now = snapshot_holders ~label:"turn" ~now
 let autonomous_slot_holders ~now = snapshot_holders ~label:"autonomous" ~now
 let reactive_slot_holders ~now = snapshot_holders ~label:"reactive" ~now
 
+let format_slot_holders ?(limit = 5) holders =
+  let limit = max 1 limit in
+  let rec take n = function
+    | [] -> []
+    | _ when n <= 0 -> []
+    | x :: xs -> x :: take (n - 1) xs
+  in
+  match holders with
+  | [] -> "[]"
+  | _ ->
+    let shown = take limit holders in
+    let rendered =
+      List.map
+        (fun (name, held_for_sec) ->
+           Printf.sprintf "%s/%.0fs" name (max 0.0 held_for_sec))
+        shown
+    in
+    let extra = List.length holders - List.length shown in
+    let items =
+      if extra > 0
+      then rendered @ [Printf.sprintf "+%d more" extra]
+      else rendered
+    in
+    "[" ^ String.concat ", " items ^ "]"
+;;
+
+let slot_holders_summary ?(limit = 5) ~now () =
+  Printf.sprintf
+    "turn_holders=%s autonomous_holders=%s reactive_holders=%s"
+    (format_slot_holders ~limit (turn_slot_holders ~now))
+    (format_slot_holders ~limit (autonomous_slot_holders ~now))
+    (format_slot_holders ~limit (reactive_slot_holders ~now))
+;;
+
 type autonomous_waiter =
   {
     ticket : int;
@@ -519,17 +553,10 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
         let holders =
           snapshot_holders ~label ~now:(Time_compat.now ())
         in
-        let holder_summary =
-          match holders with
-          | [] -> "(none — race or empty)"
-          | _ ->
-            holders
-            |> List.map (fun (n, age) -> Printf.sprintf "%s/%.0fs" n age)
-            |> String.concat ", "
-        in
+        let holder_summary = format_slot_holders holders in
         Log.Keeper.routine
           "semaphore_wait: %s semaphore wait exceeded %.0fs \
-           (channel=%s, holders=[%s]), skipping turn"
+           (channel=%s, holders=%s), skipping turn"
           label semaphore_wait_timeout_sec
           channel_label holder_summary;
         (* #9771: per-keeper × per-acquire-channel counter so

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -41,6 +41,14 @@ val turn_slot_holders : now:float -> (string * float) list
 val autonomous_slot_holders : now:float -> (string * float) list
 val reactive_slot_holders : now:float -> (string * float) list
 
+(** Render a compact holder list such as [[keeper-a/181s, +2 more]].
+    The input is expected to be sorted longest-first, as returned by the
+    holder accessors above. *)
+val format_slot_holders : ?limit:int -> (string * float) list -> string
+
+(** Operator-facing one-line summary of all holder pools. *)
+val slot_holders_summary : ?limit:int -> now:float -> unit -> string
+
 (** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
 val enqueue_autonomous_waiter_for_test : string -> int
 val drop_autonomous_waiter_for_test : int -> unit

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -20,10 +20,32 @@ let assert_eq ~msg ~expected ~actual =
   if expected <> actual then
     failwith (Printf.sprintf "%s: expected=%d actual=%d" msg expected actual)
 
+let assert_string_eq ~msg ~expected ~actual =
+  if expected <> actual then
+    failwith (Printf.sprintf "%s: expected=%S actual=%S" msg expected actual)
+
 let test_turn_slot_holders_empty_when_no_slot_held () =
   let now = Time_compat.now () in
   let holders = KK.turn_slot_holders ~now in
   assert_eq ~msg:"turn holders empty" ~expected:0 ~actual:(List.length holders)
+
+let test_format_slot_holders_truncates_and_rounds () =
+  let rendered =
+    KK.format_slot_holders
+      ~limit:2
+      [ "oldest", 12.4; "next", 3.6; "third", 1.0 ]
+  in
+  assert_string_eq
+    ~msg:"holder summary"
+    ~expected:"[oldest/12s, next/4s, +1 more]"
+    ~actual:rendered
+
+let test_slot_holders_summary_empty_pools () =
+  let summary = KK.slot_holders_summary ~now:(Time_compat.now ()) () in
+  assert_string_eq
+    ~msg:"empty holder pool summary"
+    ~expected:"turn_holders=[] autonomous_holders=[] reactive_holders=[]"
+    ~actual:summary
 
 let test_autonomous_slot_holders_records_during_acquire () =
   let result =
@@ -74,6 +96,10 @@ let () =
     [
       "turn slot holders empty when nothing held",
         test_turn_slot_holders_empty_when_no_slot_held;
+      "format slot holders truncates and rounds",
+        test_format_slot_holders_truncates_and_rounds;
+      "slot holders summary reports empty pools",
+        test_slot_holders_summary_empty_pools;
       "autonomous slot holders records keeper during acquire",
         test_autonomous_slot_holders_records_during_acquire;
       "holders dropped after with_keeper_turn_slot exits",

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -91,6 +91,39 @@ let test_holders_released_after_slot_returned () =
   if List.mem "diag-release" names then
     failwith "diag-release still in reactive holders after release"
 
+(* PR #13099 review: pin that [slot_holders_summary] reflects the holder
+   currently inside [with_keeper_turn_slot_for_test], so a regression where
+   the WARN/last_blocker wiring drops the holder snapshot is caught
+   directly (not just at the formatter level). *)
+let test_slot_holders_summary_reflects_active_holder () =
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name:"diag-summary"
+      ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
+      (fun ~semaphore_wait_ms:_ ->
+        let summary = KK.slot_holders_summary ~now:(Time_compat.now ()) () in
+        let mentions s sub =
+          let ls = String.length s in
+          let lsub = String.length sub in
+          let rec loop i =
+            if i + lsub > ls then false
+            else if String.sub s i lsub = sub then true
+            else loop (i + 1)
+          in
+          loop 0
+        in
+        if not (mentions summary "diag-summary") then
+          failwith
+            (Printf.sprintf
+              "expected slot_holders_summary to mention 'diag-summary'; got %S"
+              summary);
+        ())
+  in
+  match result with
+  | Ok () -> ()
+  | Error (`Semaphore_wait_timeout _) ->
+      failwith "unexpected semaphore wait timeout in test"
+
 let () =
   let cases =
     [
@@ -104,6 +137,8 @@ let () =
         test_autonomous_slot_holders_records_during_acquire;
       "holders dropped after with_keeper_turn_slot exits",
         test_holders_released_after_slot_returned;
+      "slot_holders_summary mentions the active holder",
+        test_slot_holders_summary_reflects_active_holder;
     ]
   in
   List.iter


### PR DESCRIPTION
## Summary

This PR makes keeper turn-slot starvation visible in the operator-facing blocker text.

- Adds compact holder formatting for the tracked `turn`, `autonomous`, and `reactive` slot holder tables.
- Includes `turn_holders=... autonomous_holders=... reactive_holders=...` in the heartbeat skip WARN and `runtime.last_blocker`.
- Reuses the same compact holder formatter in the lower-level semaphore timeout routine.
- Adds focused holder formatter/summary coverage to `test_keeper_turn_slot_holders`.

## Live Evidence

Checked against the local runtime on 2026-05-05:

- Initial stall diagnosis: `GET http://127.0.0.1:8935/health` reported `status=ok`, `build.commit=f99b7215dd`, `paths.effective_base_path=/Users/dancer/me`, `paths.effective_masc_root=/Users/dancer/me/.masc`, and `config_root=/Users/dancer/me/.masc/config`.
- During that stall window, logs showed keepers being scheduled, for example `keepalive turn scheduled for <keeper>: channel=reactive ...`, then skipping with `semaphore wait > 180s` and `turn_available=0`.
- No keeper execution receipts were observed after the stall window; the issue was not that heartbeats never woke, but that woken turns could not get the global turn slot.
- `/api/v1/dashboard/safe-autonomy` timed out during the stall while `/health` continued to respond.
- Final re-check after later runtime restart at 2026-05-05 16:54 KST: `/health` still reports `effective_base_path=/Users/dancer/me` and `effective_masc_root=/Users/dancer/me/.masc`, now on main commit `1ca6722cb8`. This PR is not live in that process yet; holder names require this branch to be merged/deployed and the runtime restarted.

## Operator Impact

Before this change, the visible line says only that peers are holding slots. That confirms starvation, but does not name the peers causing it.

After this change, the WARN and dashboard blocker should include a compact holder snapshot such as:

`turn_holders=[verifier/534s, executor/498s, +3 more] autonomous_holders=[...] reactive_holders=[...]`

This keeps the fix diagnostic and low-risk. It does not force-release semaphores or mutate holder state.

## Verification

- `git diff --check HEAD~1 HEAD`
- `DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_turn_slot_holders.exe test/test_keeper_semaphore_wait_counter.exe`
- `./_build/default/test/test_keeper_turn_slot_holders.exe`
- `./_build/default/test/test_keeper_semaphore_wait_counter.exe`

Note: the normal local Dune wrapper lock was held by another long-running `dune runtest`; verification used the repo wrapper with one job, lock bypass enabled, and focused targets only.

## Review Focus

- Confirm the operator-facing blocker text is concise enough for logs/dashboard.
- Confirm the change stays diagnostic-only and does not introduce unsafe semaphore recovery behavior.

## Follow-Up Captured

- #13103 captures separate duplicate-port startup log spam observed while inspecting the live log tail.
