### PR TITLE
fix(test): finish Masc_domain alias migration

### DIFF
--- a/test/keeper_tool_matrix_case_runner.ml
+++ b/test/keeper_tool_matrix_case_runner.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 module Cases = Test_keeper_tool_matrix_cases
 
 let result_prefix = "__KEEPER_TOOL_MATRIX_RESULT__"

--- a/test/test_accountability_emit_skip_10314.ml
+++ b/test/test_accountability_emit_skip_10314.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** #10314 — pin the accountability ledger emit-skip counter.
 
     Pre-fix [is_keeper_agent_name] silently dropped any

--- a/test/test_auth_ambiguous_lookup_9786.ml
+++ b/test/test_auth_ambiguous_lookup_9786.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (* test/test_auth_ambiguous_lookup_9786.ml
 
    #9786 runtime complement: when N>=2 credentials share a

--- a/test/test_auth_bearer_mismatch_9786.ml
+++ b/test/test_auth_bearer_mismatch_9786.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (* test/test_auth_bearer_mismatch_9786.ml
 
    #9786: agent A presents a token that resolves to credential

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 open Masc_mcp
 

--- a/test/test_auth_error_kind.ml
+++ b/test/test_auth_error_kind.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Round-trip + classification tests for [Auth_error_kind].
 
     Guards the closed-enum contract that prometheus dashboards depend on

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 open Masc_mcp
 

--- a/test/test_auth_rotate_shared_tokens_10304.ml
+++ b/test/test_auth_rotate_shared_tokens_10304.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** #10304 — pin the shared-token rotation contract.
 
     #9786 shipped detection only ([Auth.audit_token_uniqueness] +

--- a/test/test_auto_recall_activity_coverage.ml
+++ b/test/test_auto_recall_activity_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Coverage tests for auto_recall (pure functions) and activity_feed (JSON roundtrip).
     Also covers filesystem-backed activity_feed read-path regressions. *)
 

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 module Lib = Masc_mcp
 
 open Alcotest

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** CI/dashboard hardening source guards. *)
 
 open Alcotest

--- a/test/test_claim_post_provision_hook.ml
+++ b/test/test_claim_post_provision_hook.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Regression test for [Coord_hooks.claim_post_provision_fn] dispatch.
 
     task-103: a successful [Coord.claim_task_r] must invoke the

--- a/test/test_coord_bootstrap.ml
+++ b/test/test_coord_bootstrap.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Unit tests for [Coord_bootstrap].
 
     Audit P2 follow-up (2026-04-29 §3.1.2) — closes the

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Coordination_product — Goal x Task x Board x Reward. *)
 
 open Masc_mcp

--- a/test/test_credential_alias_10440.ml
+++ b/test/test_credential_alias_10440.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** #10440: pin [Auth.ensure_credential_alias] semantics so the
     short-form alias [<keeper_name>.json] resolves to the same
     UUID file as the canonical long-form

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Dashboard Execution read-model regression tests. *)
 
 let () = Masc_mcp.Server_startup_state.mark_state_ready ~backend_mode:"test"

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 open Masc_mcp
 open Coord_types

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Dashboard governance regression tests. *)
 
 module Lib = Masc_mcp

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 module Lib = Masc_mcp
 module Auth = Masc_mcp.Auth
 

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Dashboard Labels unit tests *)
 
 module Lib = Masc_mcp

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Dashboard Mission read-model regression tests. *)
 
 module Lib = Masc_mcp

--- a/test/test_dashboard_mission_briefing.ml
+++ b/test/test_dashboard_mission_briefing.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 
 module Dashboard_mission_briefing = Masc_mcp.Dashboard_mission_briefing

--- a/test/test_goal_janitor.ml
+++ b/test/test_goal_janitor.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Goal_janitor — stale goal cleanup. *)
 
 open Alcotest

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Goal_store.delete_goal — Issue #7690 regression.
 
     Bug: the previous implementation used [{ st with goals = ...; updated_at }]

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Goal tool coverage — shared Goal Store surface through Tool_coord. *)
 
 open Alcotest

--- a/test/test_heartbeat_smart.ml
+++ b/test/test_heartbeat_smart.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Unit tests for [Heartbeat_smart].
 
     Pure functions: [make_config] clamping, [effective_interval] idle

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for the HITL approval pipeline (#5907).
 
     Proves:

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 open Masc_mcp
 

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for keeper-agent tool isolation.
 
     Validates the structural invariant that keeper tools and agent

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for [Keeper_tool_registry.is_read_only_with_input].
 
     Validates input-aware read-only classification for keeper_shell op=gh:

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Test keeper masc_* tool bridge under preset/custom tool policy. *)
 
 module Coord = Masc_mcp.Coord

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** test_keeper_retrieval_quality — BM25 retrieval quality for keeper tool selection.
 
     Verifies that the BM25 tool index retrieves the correct tool for

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Test ensure_keeper_meta TOML→JSON SSOT reconciliation.
     Verifies that ALL declarative fields from config/keepers/<name>.toml
     overwrite stale runtime JSON on bootstrap, and that unspecified fields

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for keeper_task_claim and keeper_task_done tool dispatch. *)
 
 open Alcotest

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Keeper Tool Exposure Tests
 
     Verifies that keeper_allowed_tool_names returns the full tool set

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 
 module Cases = Test_keeper_tool_matrix_cases

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 module Generic = Test_mcp_tool_matrix_cases
 module KET = Masc_mcp.Keeper_exec_tools
 module KTO = Masc_mcp.Keeper_tools_oas

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 
 module WO = Masc_mcp.Keeper_world_observation

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Test suite for Mcp_server_eio module
 
     Tests the Eio-native MCP server implementation.

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 
 module U = Yojson.Safe.Util

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Mcp_session Module Coverage Tests
 
     Tests for MCP HTTP Session ID management:

--- a/test/test_mcp_tool_matrix.ml
+++ b/test/test_mcp_tool_matrix.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 
 module Cases = Test_mcp_tool_matrix_cases

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Config = Masc_mcp.Config
 

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for OAS integration modules: oas_events, message conversion. *)
 
 module Masc_log = Log

--- a/test/test_ocaml_north_star_task_lifecycle.ml
+++ b/test/test_ocaml_north_star_task_lifecycle.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Behavior-locking tests for the current task lifecycle.
 
     These tests document existing semantics before any north-star refactor.

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 open Test_operator_control_support
 

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 open Test_operator_control_support
 

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 open Test_operator_control_support
 

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 open Test_operator_control_support
 

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 
 let () = Mirage_crypto_rng_unix.use_default ()

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 
 module U = Yojson.Safe.Util

--- a/test/test_response.ml
+++ b/test/test_response.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** MASC Response Module Tests
 
     Tests for the standardized API response envelope:

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Coord module *)
 
 open Masc_mcp

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Comprehensive coverage tests for Coord module
 
     Target: 35+ additional tests covering:

--- a/test/test_room_git_coverage.ml
+++ b/test/test_room_git_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Coord Git Module Coverage Tests
 
     Tests for git utility functions:

--- a/test/test_room_messages_raw.ml
+++ b/test/test_room_messages_raw.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 
 let with_test_env f =

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 open Masc_mcp
 

--- a/test/test_sandbox_clone_conflict.ml
+++ b/test/test_sandbox_clone_conflict.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Alcotest
 
 let contains s sub =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 
 let () = Mirage_crypto_rng_unix.use_default ()

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for smart heartbeat integration in keeper_keepalive.
 
     Verifies that the Heartbeat_smart module decisions correctly map

--- a/test/test_task_dispatch.ml
+++ b/test/test_task_dispatch.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 
 let with_temp_config f =

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Task_sandbox unit tests.
 
     Tests sandbox type construction, path extraction, and error paths.

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** test_telemetry_unified — Tests for unified telemetry read aggregation. *)
 
 open Masc_mcp

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Tool_access_policy — shared allow/deny selector ADT.
 
     Covers: selector variants, normalize_names edge cases, deny-wins

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Tool_access_role — role-based policy equivalence and properties.
 
     The equivalence test is the critical gate: it verifies that the new

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 open Masc_mcp
 
 (** {1 Test helpers} *)

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Coverage tests for Tool_code — Code search, symbols, and file reading
 
     Tests dispatch routing, input validation, and error paths

--- a/test/test_tool_code_read_containment.ml
+++ b/test/test_tool_code_read_containment.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Coverage tests for #6637 iter11 — per-agent playground containment
     in [Tool_code.validate_read_path].
 

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Coverage tests for Tool_code_write — git clone URL parsing
     and org allowlist validation. Pure function tests only. *)
 

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Coverage tests for Tool_coord *)
 
 open Masc_mcp

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for tool exposure consistency across MCP profiles.
 
     Validates that:

--- a/test/test_tool_help_registry_shard_coverage_10101.ml
+++ b/test/test_tool_help_registry_shard_coverage_10101.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (* test/test_tool_help_registry_shard_coverage_10101.ml
 
    #10101: [Config.raw_all_tool_schemas] is the authoritative

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Unit tests for Tool_input_validation — OAS-delegated validation with coercion.
 
     Tests the integration: MASC JSON Schema -> Tool_bridge.params_of_json_schema

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Test Tool_name: roundtrip, coverage, and invariant checks. *)
 
 open Masc_mcp

--- a/test/test_tool_prefilter.ml
+++ b/test/test_tool_prefilter.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Unit tests for Tool_prefilter — TF-IDF cosine similarity. *)
 
 open Alcotest

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Structural linter: verifies tool registration consistency.
 
     1. Every tool referenced in Workflow_guide must exist in Config.all_tool_schemas.

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Tool_spec — unified tool specification and registration. *)
 
 module Tool_spec = Masc_mcp.Tool_spec

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** test_tool_surface_ssot — Shadow parity test for Tool_catalog surface SSOT.
 
     Verifies that [Tool_catalog.tools_for_surface] produces exactly the same

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Coverage tests for Tool_task *)
 
 open Masc_mcp

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tool_worktree Module Coverage Tests *)
 
 module Tool_args = Masc_mcp.Tool_args

--- a/test/test_turn_id_propagation.ml
+++ b/test/test_turn_id_propagation.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** test_turn_id_propagation — Step 15 partial.
 
     Compile-time sentinel for the Step 0a (PR #11154 + #11156 + #11159)

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Comprehensive coverage tests for Types, Coord_utils, and Coord_eio modules *)
 
 (* Initialize RNG for crypto operations *)

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** test_verification_fsm -- FSM transition tests for AwaitingVerification state.
 
     Tests Phase B+C transitions with MASC_VERIFICATION_FSM_ENABLED=true:

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 module Lib = Masc_mcp
 
 open Alcotest

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (** Tests for Workflow_guide — Golden Path encoding and next_steps. *)
 
 (* Use canonical prefix due to OCaml 5.x -H flag interaction *)

--- a/test/tool_inventory_gen.ml
+++ b/test/tool_inventory_gen.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 (* Generates test_mcp_tool_matrix_names_gen.ml from runtime tool registry.
    Run via dune rule — do not edit the generated file manually. *)
 

--- a/test/tool_matrix_case_runner.ml
+++ b/test/tool_matrix_case_runner.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 module Cases = Test_mcp_tool_matrix_cases
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 

--- a/test/tool_matrix_manifest.ml
+++ b/test/tool_matrix_manifest.ml
@@ -1,3 +1,5 @@
+module Types = Masc_domain
+
 let sorted_unique values =
   List.sort_uniq String.compare values
 


### PR DESCRIPTION
## Summary
- add local `module Types = Masc_domain` aliases to test modules still using the old bare `Types` name
- keep the production `Types -> Masc_domain` rename intact; this is test migration cleanup only

## Root cause
PR #13089 renamed the domain module but only migrated part of the test suite. CI Health on current `main` still compiles coverage and operator-control tests that reference bare `Types`, producing `Unbound module Types` failures. This also blocks approved PR #13068 after it rebases onto current `main`.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build ./test/test_tool_coord_coverage.exe ./test/test_tool_task_coverage.exe ./test/test_types_utils_coverage.exe`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build ./test/test_operator_control.exe`

## Review focus
- This PR intentionally touches only tests and adds local aliases instead of resurrecting a global `Types` module.