### PR TITLE
chore(cascade): cascade_state Mutex+Hashtbl → Atomic+immutable Map

### DIFF
--- a/lib/cascade/cascade_state.ml
+++ b/lib/cascade/cascade_state.ml
@@ -7,45 +7,65 @@ type sticky_entry = {
   expires_at : float;
 }
 
-let sticky_table : (string * string, sticky_entry) Hashtbl.t =
-  Hashtbl.create 32
+module Sticky_key = struct
+  type t = string * string
+  let compare (k1, c1) (k2, c2) =
+    let r = String.compare k1 k2 in
+    if r <> 0 then r else String.compare c1 c2
+end
 
-let sticky_mutex = Eio.Mutex.create ()
+module Sticky_map = Map.Make (Sticky_key)
+
+let sticky_table : sticky_entry Sticky_map.t Atomic.t =
+  Atomic.make Sticky_map.empty
 
 let record_sticky_choice ~keeper ~cascade ~provider ~ttl_ms ~now =
   if ttl_ms <= 0 then ()
   else
     let expires_at = now +. (float_of_int ttl_ms /. 1000.) in
-    Eio.Mutex.use_rw ~protect:false sticky_mutex (fun () ->
-        Hashtbl.replace sticky_table (keeper, cascade)
-          { provider; expires_at })
+    let entry = { provider; expires_at } in
+    let key = (keeper, cascade) in
+    let rec loop () =
+      let cur = Atomic.get sticky_table in
+      let next = Sticky_map.add key entry cur in
+      if not (Atomic.compare_and_set sticky_table cur next) then loop ()
+    in
+    loop ()
 
 let lookup_sticky ~keeper ~cascade ~now =
-  Eio.Mutex.use_ro sticky_mutex (fun () ->
-      match Hashtbl.find_opt sticky_table (keeper, cascade) with
-      | Some entry when now < entry.expires_at -> Some entry.provider
-      | _ -> None)
+  match Sticky_map.find_opt (keeper, cascade) (Atomic.get sticky_table) with
+  | Some entry when now < entry.expires_at -> Some entry.provider
+  | _ -> None
 
-let clear_sticky () =
-  Eio.Mutex.use_rw ~protect:false sticky_mutex (fun () ->
-      Hashtbl.clear sticky_table)
+let clear_sticky () = Atomic.set sticky_table Sticky_map.empty
 
 (* ── Round-robin ────────────────────────────────────────────────── *)
 
-let rr_table : (string, int Atomic.t) Hashtbl.t = Hashtbl.create 16
-let rr_mutex = Eio.Mutex.create ()
+module String_map = Map.Make (String)
+
+let rr_table : int Atomic.t String_map.t Atomic.t =
+  Atomic.make String_map.empty
 
 let get_or_create_cursor cascade =
-  match Hashtbl.find_opt rr_table cascade with
+  match String_map.find_opt cascade (Atomic.get rr_table) with
   | Some a -> a
   | None ->
-    Eio.Mutex.use_rw ~protect:false rr_mutex (fun () ->
-        match Hashtbl.find_opt rr_table cascade with
-        | Some a -> a
-        | None ->
-          let a = Atomic.make 0 in
-          Hashtbl.add rr_table cascade a;
-          a)
+    (* Allocate a fresh cursor outside the CAS loop. If a concurrent
+       writer beats us in, we return their cursor; the orphan
+       allocation is GC'd. The fresh cursor is started at 0 so the
+       semantics match the original Mutex-protected double-checked
+       lookup (Atomic.make 0). *)
+    let candidate = Atomic.make 0 in
+    let rec loop () =
+      let cur = Atomic.get rr_table in
+      match String_map.find_opt cascade cur with
+      | Some winner -> winner
+      | None ->
+        let next = String_map.add cascade candidate cur in
+        if Atomic.compare_and_set rr_table cur next then candidate
+        else loop ()
+    in
+    loop ()
 
 let rotate_round_robin ~cascade ~bound =
   if bound <= 0 then 0
@@ -56,13 +76,11 @@ let rotate_round_robin ~cascade ~bound =
     if m < 0 then m + bound else m
 
 let peek_round_robin ~cascade =
-  match Hashtbl.find_opt rr_table cascade with
+  match String_map.find_opt cascade (Atomic.get rr_table) with
   | Some a -> Atomic.get a
   | None -> 0
 
-let clear_round_robin () =
-  Eio.Mutex.use_rw ~protect:false rr_mutex (fun () ->
-      Hashtbl.clear rr_table)
+let clear_round_robin () = Atomic.set rr_table String_map.empty
 
 (* ── Bulk ───────────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

`lib/cascade/cascade_state.ml`을 `Eio.Mutex` + `Hashtbl` → `Atomic.t` + `Map` (immutable Map snapshot) 패턴으로 변환. PR #13058 (cascade_throttle)의 후속 단위.

## Why

Sprint 3 (joyful-tumbling-dragon plan) 두 번째 module. `.mli` 자체가 *"every operation uses [Atomic.t] or short critical sections under [Eio.Mutex.t]"*로 표기 — Atomic-first 의도 명시. 두 개의 별개 state store를 모두 lock-free read로 전환:

1. **Sticky** ((keeper, cascade) → provider entry, TTL): `record_sticky_choice` write (CAS loop), `lookup_sticky` read (lock-free).
2. **Round-robin** (cascade → cursor `int Atomic.t`): `get_or_create_cursor` (CAS-on-insert, fast path lock-free), `rotate_round_robin`, `peek_round_robin` (lock-free), `clear_round_robin`.

## Approach

### Sticky (simple snapshot pattern)

```ocaml
module Sticky_key = struct
  type t = string * string
  let compare (k1, c1) (k2, c2) = ...lex compare...
end
module Sticky_map = Map.Make (Sticky_key)
let sticky_table : sticky_entry Sticky_map.t Atomic.t = Atomic.make Sticky_map.empty
```

`record_sticky_choice`: `entry`/`key`를 사전 계산 → CAS loop 안에서 `Sticky_map.add` 만 retry (순수 함수). `lookup_sticky`/`clear_sticky`: lock-free.

### Round-robin (subtle — value is itself Atomic.t)

```ocaml
let rr_table : int Atomic.t String_map.t Atomic.t = Atomic.make String_map.empty
```

값(`int Atomic.t`)은 mutable Atomic counter. Map은 카운터 *참조*만 보유 — 카운터 internal mutation은 Map 보호 밖에서 lock-free하게 일어남 (원본 의도와 동일).

`get_or_create_cursor`:
- Fast path: `String_map.find_opt` + `Atomic.get` (lock-free).
- Slow path: `Atomic.make 0`을 **CAS 외부**에서 한 번 할당. CAS retry 시 race winner의 cursor 발견하면 그쪽 반환, 우리 `candidate`는 GC. 원본 double-checked Mutex의 의미적 등가물.

## .mli 변경 없음

```
record_sticky_choice / lookup_sticky / clear_sticky
rotate_round_robin / peek_round_robin / clear_round_robin
clear_all
```

API surface 동일. 4 caller (`cascade_config`, `cascade_strategy`, `cascade_strategy.mli`, `test_cascade_strategy`) 영향 없음.

## Counts

| Metric | Before | After |
|---|---:|---:|
| `Mutex.` / `Eio.Mutex` (코드) | 7 | 0 |
| `Atomic.` | 4 | 17 |
| 라인 수 | 71 | 89 |

## Test plan / Self-review

- [x] `dune build` (focused) 진행 — caller 영향 무
- [x] `rg -ln 'Cascade_state\.' lib/ test/ bin/` 4 files. API 변경 없음으로 caller 무수정
- [x] `peek_round_robin`은 원본도 mutex 안 잡고 있던 latent design — 변환 후에도 동일 무 잡음 (regression 아님)
- [ ] CI fundamental-check 4 jobs PASS 확인

## RFC Waiver

`RFC-WAIVED: cascade subsystem performance/concurrency primitive only — credential / identity / repo / operator / sandbox / dashboard credential / hooks / workflow 영역 미접촉. Lock-free read 전환은 정합성 동치, API surface 변경 없음.`

## Out of scope

- `cascade_health_tracker.ml` (10 Mutex, 다음 후보)
- `keeper_decision_audit.ml` (3 Mutex, 4번째 후보)
- `cascade_strategy_trace.ml` / `cascade_config_loader.ml` (각 6 Mutex)

## Note on Draft

Per `feedback_masc_mcp_draft_guard_blocks_agent_ready.md` (2026-05-05 #12899) Draft 유지. `human-approved-ready` label 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)