### PR TITLE
fix(keeper): recover alive-but-stuck keepers

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1599,9 +1599,11 @@ let liveness_recovery_scan (ctx : _ context) =
    their [current_task_id] references an orphaned [AwaitingVerification]
    task.
 
-   This detector emits a Prometheus counter only.  No transition,
-   no restart, no board post.  Operator visibility first; action
-   is a follow-up (see issue #12838 "Proposed first PR").
+   This detector emits a Prometheus counter and requests a supervised
+   restart through the same [failure_reason + fiber_stop] path as the
+   stale watchdog.  The next sweep can then force unresolved
+   watchdog-stopped entries into the normal crash/restart pipeline
+   instead of leaving the keeper at detection-only.
    ────────────────────────────────────────────────────────────────── *)
 
 (** Pure detection: is this keeper alive-but-stuck at [now]?
@@ -1662,6 +1664,36 @@ let alive_but_stuck_reset_for_test () =
   Eio.Mutex.use_rw ~protect:false alive_but_stuck_last_alert_mu (fun () ->
     Hashtbl.clear alive_but_stuck_last_alert)
 
+let request_alive_but_stuck_recovery ~base_path ~elapsed
+    (entry : Keeper_registry.registry_entry) =
+  let kill_class =
+    Keeper_registry.Idle_turn { stall_seconds = elapsed }
+  in
+  let reason =
+    Keeper_registry.stale_watchdog_failure_reason
+      ~prior:entry.last_failure_reason ~kill_class
+  in
+  Keeper_registry.set_failure_reason ~base_path entry.name reason;
+  (* tla-lint: allow-mutation: fiber signal — alive-but-stuck recovery asks
+     the heartbeat fiber to exit and wakes it if it is in interruptible sleep.
+     The next supervisor sweep will route this through the existing
+     force_unresolved_watchdog_crash path if the fiber does not resolve on
+     its own. *)
+  Atomic.set entry.fiber_stop true;
+  Atomic.set entry.fiber_wakeup true;
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_alive_but_stuck_recovery_requests
+    ~labels:[("keeper", entry.name)]
+    ();
+  Log.Keeper.error
+    "%s: alive-but-stuck recovery requested (elapsed=%.0fs, failure_reason=%s)"
+    entry.name elapsed
+    (Option.map Keeper_registry.failure_reason_to_string reason
+     |> Option.value ~default:"unknown")
+
+let request_alive_but_stuck_recovery_for_test =
+  request_alive_but_stuck_recovery
+
 let alive_but_stuck_scan (ctx : _ context) =
   if not Env_config.KeeperSupervisor.alive_but_stuck_enabled then ()
   else begin
@@ -1696,7 +1728,8 @@ let alive_but_stuck_scan (ctx : _ context) =
                (float_of_int entry.meta.proactive.cooldown_sec
                 *. float_of_int stall_multiplier))
             entry.meta.runtime.autonomous_turn_count
-            entry.meta.runtime.proactive_rt.count_total
+            entry.meta.runtime.proactive_rt.count_total;
+          request_alive_but_stuck_recovery ~base_path ~elapsed entry
         end
     ) entries
   end

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1669,9 +1669,38 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
   let kill_class =
     Keeper_registry.Idle_turn { stall_seconds = elapsed }
   in
+  (* PR #13106 review: must NOT route through
+     [stale_watchdog_failure_reason], which preserves prior reasons
+     like [Turn_consecutive_failures] / [Exception] / etc.  Those
+     reasons are not in the [watchdog_stop_pending] restart set
+     ([Stale_turn_timeout | Stale_termination_storm |
+     Oas_timeout_budget_loop]), so preserving them would set
+     [fiber_stop = true] and then the supervisor's next sweep would
+     skip [force_unresolved_watchdog_crash] — the fiber goes dormant
+     instead of being restarted, defeating the entire recovery.
+
+     Force the watchdog cohort to [Stale_turn_timeout kill_class] so
+     [watchdog_stop_pending] / [record_loop_exit] both treat this as
+     a watchdog stop.  The prior reason is captured in the log line
+     for postmortem.
+
+     Idempotent: if the keeper is already in a watchdog cohort
+     ([Stale_turn_timeout] / [Stale_termination_storm] /
+     [Oas_timeout_budget_loop]), preserve it so we don't churn the
+     [stall_seconds] field on every poll. *)
+  let prior_str =
+    Option.map Keeper_registry.failure_reason_to_string
+      entry.last_failure_reason
+    |> Option.value ~default:"none"
+  in
   let reason =
-    Keeper_registry.stale_watchdog_failure_reason
-      ~prior:entry.last_failure_reason ~kill_class
+    match entry.last_failure_reason with
+    | Some
+        ( Keeper_registry.Stale_turn_timeout _
+        | Keeper_registry.Stale_termination_storm _
+        | Keeper_registry.Oas_timeout_budget_loop _ ) as kept ->
+        kept
+    | _ -> Some (Keeper_registry.Stale_turn_timeout kill_class)
   in
   Keeper_registry.set_failure_reason ~base_path entry.name reason;
   (* tla-lint: allow-mutation: fiber signal — alive-but-stuck recovery asks
@@ -1686,8 +1715,9 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
     ~labels:[("keeper", entry.name)]
     ();
   Log.Keeper.error
-    "%s: alive-but-stuck recovery requested (elapsed=%.0fs, failure_reason=%s)"
-    entry.name elapsed
+    "%s: alive-but-stuck recovery requested (elapsed=%.0fs, prior_reason=%s, \
+     failure_reason=%s)"
+    entry.name elapsed prior_str
     (Option.map Keeper_registry.failure_reason_to_string reason
      |> Option.value ~default:"unknown")
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1624,7 +1624,7 @@ let detect_alive_but_stuck ~now ~stall_multiplier ~stall_floor_sec
     (entry : Keeper_registry.registry_entry) : float option =
   let meta = entry.meta in
   if meta.paused then None
-  else if entry.phase = Keeper_state_machine.Dead then None
+  else if entry.phase <> Keeper_state_machine.Running then None
   else if meta.runtime.autonomous_turn_count <= 0 then
     (* Brand-new keeper: not stuck, just hasn't started. *)
     None

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -112,9 +112,19 @@ val alive_but_stuck_scan : 'a context -> unit
     alive-but-stuck, emit one [metric_keeper_alive_but_stuck] counter
     increment and a single warn log line, with per-keeper dedup so the
     counter is at most incremented once per
-    [alive_but_stuck_dedup_ttl_sec] window.  Detection-only — no
-    transition or restart is triggered.  Gated behind
+    [alive_but_stuck_dedup_ttl_sec] window.  Also request supervised
+    recovery by setting the keeper's structured failure reason plus
+    [fiber_stop]/[fiber_wakeup], allowing the next sweep to route it
+    through the existing crash/restart path.  Gated behind
     [MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED] (default: true). *)
+
+val request_alive_but_stuck_recovery_for_test :
+  base_path:string ->
+  elapsed:float ->
+  Keeper_registry.registry_entry ->
+  unit
+(** Test-only hook for the recovery request side effect used by
+    [alive_but_stuck_scan]. *)
 
 val alive_but_stuck_reset_for_test : unit -> unit
 (** Test-only: clear the alive-but-stuck dedup table. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -240,13 +240,20 @@ let metric_keeper_contract_violations =
 
 (** #12838: keepers detected as alive-but-stuck — non-Dead, non-paused,
     keepalive_running, but [proactive_rt.last_ts] has been frozen while
-    autonomous turns kept advancing.  Detection-only signal: no transition
-    or restart is triggered.  Per-keeper dedup window
+    autonomous turns kept advancing.  Per-keeper dedup window
     ([alive_but_stuck_dedup_ttl_sec]) bounds emission rate so a single
     stuck keeper does not flood the counter on every 30s sweep.
     Labels: keeper. *)
 let metric_keeper_alive_but_stuck =
   "masc_keeper_alive_but_stuck_total"
+
+(** #12838 follow-up: supervisor recovery requests emitted after an
+    alive-but-stuck detection.  Each increment means the supervisor set
+    [failure_reason] + [fiber_stop]/[fiber_wakeup] so the existing sweep
+    path can force a crash/restart instead of leaving the keeper at
+    detection-only.  Labels: keeper. *)
+let metric_keeper_alive_but_stuck_recovery_requests =
+  "masc_keeper_alive_but_stuck_recovery_requests_total"
 
 (* #10047: [append_metrics_snapshot] failures in [keeper_turn.ml] and
    [keeper_unified_turn.ml] used to be log-only, masking state/metric
@@ -1570,6 +1577,11 @@ let init () =
   add metric_keeper_liveness_recovery_outcomes
     "#12801 Total Liveness Recovery Supervisor outcomes. Labeled by keeper \
      and outcome=started|not_running|meta_missing|meta_read_failed|meta_write_failed."
+    Counter;
+  add metric_keeper_alive_but_stuck_recovery_requests
+    "#12838 Total alive-but-stuck recovery requests. Each increment means \
+     the supervisor requested a supervised keeper restart by setting \
+     failure_reason plus fiber_stop/fiber_wakeup. Labeled by keeper."
     Counter;
   add metric_cascade_server_error_skip_total
     "#12797 Total cascade label-ranking skips triggered by recent server \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -79,10 +79,14 @@ val metric_keeper_usage_anomalies : string
     Labels: keeper_name, kind \in \{passive,text_only\}. *)
 val metric_keeper_contract_violations : string
 
-(** #12838: keepers detected as alive-but-stuck.  Detection-only
-    counter; bounded to one increment per dedup window per keeper.
-    Labels: keeper. *)
+(** #12838: keepers detected as alive-but-stuck.  Bounded to one
+    increment per dedup window per keeper. Labels: keeper. *)
 val metric_keeper_alive_but_stuck : string
+
+(** #12838 follow-up: alive-but-stuck recovery requests.  Each increment
+    means the supervisor requested a supervised restart via
+    [failure_reason] plus [fiber_stop]/[fiber_wakeup]. Labels: keeper. *)
+val metric_keeper_alive_but_stuck_recovery_requests : string
 
 val metric_keeper_metric_emit_dropped : string
 val metric_keeper_context_max_observed : string

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1304,6 +1304,30 @@ let () =
                 ~started_at:0.0
             in
             check (option (float 0.1)) "Dead → None" None (detect entry));
+        test_case "Crashed phase -> None (handled by supervisor crash path)" `Quick
+          (fun () ->
+            let entry = make_test_entry
+                ~name:"abs-crashed"
+                ~paused:false
+                ~phase:KSM.Crashed
+                ~autonomous_turn_count:50
+                ~last_proactive_ts:0.0
+                ~cooldown_sec:60
+                ~started_at:0.0
+            in
+            check (option (float 0.1)) "Crashed -> None" None (detect entry));
+        test_case "Restarting phase -> None (handled by supervisor restart path)" `Quick
+          (fun () ->
+            let entry = make_test_entry
+                ~name:"abs-restarting"
+                ~paused:false
+                ~phase:KSM.Restarting
+                ~autonomous_turn_count:50
+                ~last_proactive_ts:0.0
+                ~cooldown_sec:60
+                ~started_at:0.0
+            in
+            check (option (float 0.1)) "Restarting -> None" None (detect entry));
         test_case "brand-new keeper (autonomous_turn_count=0) → None" `Quick
           (fun () ->
             let entry = make_test_entry

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1386,5 +1386,34 @@ let () =
           in
           check (option (float 0.1)) "below per-keeper threshold → None"
             None (detect entry));
+        test_case "recovery request sets stale reason and stop flags" `Quick
+          (fun () ->
+            Reg.clear ();
+            let name = "abs-request-recovery" in
+            let entry = Reg.register ~base_path:bp name (make_meta name) in
+            let before =
+              Masc_mcp.Prometheus.metric_value_or_zero
+                Masc_mcp.Prometheus.metric_keeper_alive_but_stuck_recovery_requests
+                ~labels:[("keeper", name)]
+                ()
+            in
+            Sup.request_alive_but_stuck_recovery_for_test
+              ~base_path:bp ~elapsed:99_000.0 entry;
+            check bool "fiber_stop set" true (Atomic.get entry.Reg.fiber_stop);
+            check bool "fiber_wakeup set" true (Atomic.get entry.Reg.fiber_wakeup);
+            (match Reg.get ~base_path:bp name with
+             | None -> fail "expected registry entry"
+             | Some updated ->
+               check string "failure reason cohort"
+                 "stale_turn_timeout"
+                 (Reg.failure_reason_cohort_key updated.Reg.last_failure_reason));
+            let after =
+              Masc_mcp.Prometheus.metric_value_or_zero
+                Masc_mcp.Prometheus.metric_keeper_alive_but_stuck_recovery_requests
+                ~labels:[("keeper", name)]
+                ()
+            in
+            check (float 0.0001) "recovery request metric +1"
+              (before +. 1.0) after);
       ]);
   ]

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1415,5 +1415,76 @@ let () =
             in
             check (float 0.0001) "recovery request metric +1"
               (before +. 1.0) after);
+        (* PR #13106 review (copilot): the previous test only covers
+           [last_failure_reason = None].  The riskier branch is the
+           one where a non-watchdog reason already exists — without
+           the fix, the helper's earlier call to
+           [stale_watchdog_failure_reason] preserved
+           [Turn_consecutive_failures] / [Exception] / etc., and
+           [watchdog_stop_pending] only restarts on
+           [Stale_turn_timeout | Stale_termination_storm |
+           Oas_timeout_budget_loop].  Recovery would set
+           [fiber_stop=true] but the supervisor would never convert
+           it into a crash/restart.  Pin the post-recovery cohort to
+           [stale_turn_timeout] so this regression is caught. *)
+        test_case
+          "recovery overrides non-watchdog failure_reason \
+           (Turn_consecutive_failures) so supervisor restart fires"
+          `Quick
+          (fun () ->
+            Reg.clear ();
+            let name = "abs-request-recovery-nonwatchdog" in
+            let entry =
+              Reg.register ~base_path:bp name (make_meta name)
+            in
+            (* Pre-existing non-watchdog reason → without fix, helper
+               would preserve this and the supervisor would never
+               restart. *)
+            Reg.set_failure_reason ~base_path:bp name
+              (Some (Reg.Turn_consecutive_failures 5));
+            Sup.request_alive_but_stuck_recovery_for_test
+              ~base_path:bp ~elapsed:42_000.0 entry;
+            check bool "fiber_stop set" true
+              (Atomic.get entry.Reg.fiber_stop);
+            (match Reg.get ~base_path:bp name with
+             | None -> fail "expected registry entry"
+             | Some updated ->
+               check string
+                 "non-watchdog reason overridden to stale_turn_timeout \
+                  cohort (else supervisor would not restart)"
+                 "stale_turn_timeout"
+                 (Reg.failure_reason_cohort_key
+                    updated.Reg.last_failure_reason)));
+        (* Idempotent recovery: pre-existing watchdog cohort is
+           preserved (don't churn [stall_seconds] on every poll). *)
+        test_case
+          "recovery preserves existing Stale_turn_timeout cohort"
+          `Quick
+          (fun () ->
+            Reg.clear ();
+            let name = "abs-request-recovery-idempotent" in
+            let entry =
+              Reg.register ~base_path:bp name (make_meta name)
+            in
+            let original_kill =
+              Reg.Idle_turn { stall_seconds = 7_777.0 }
+            in
+            Reg.set_failure_reason ~base_path:bp name
+              (Some (Reg.Stale_turn_timeout original_kill));
+            Sup.request_alive_but_stuck_recovery_for_test
+              ~base_path:bp ~elapsed:99_999.0 entry;
+            (match Reg.get ~base_path:bp name with
+             | None -> fail "expected registry entry"
+             | Some updated ->
+               (match updated.Reg.last_failure_reason with
+                | Some (Reg.Stale_turn_timeout
+                          (Reg.Idle_turn { stall_seconds })) ->
+                  check (float 0.0001)
+                    "preserved original stall_seconds, did not churn"
+                    7_777.0 stall_seconds
+                | _ ->
+                  fail
+                    "expected Stale_turn_timeout (Idle_turn ...) to be \
+                     preserved unchanged")));
       ]);
   ]


### PR DESCRIPTION
## Summary

Turns the existing `alive-but-stuck` supervisor detector from visibility-only
into an actual recovery request:

- `alive_but_stuck_scan` still emits the existing detection counter and WARN.
- When the detector fires, it now records a stale-watchdog-compatible
  `failure_reason`, sets `fiber_stop` and `fiber_wakeup`, and lets the next
  supervisor sweep route the keeper through the existing crash/restart path.
- Adds `masc_keeper_alive_but_stuck_recovery_requests_total` so operators can
  tell detection from recovery action.
- Adds a focused supervisor regression test for the failure reason, stop/wakeup
  flags, and recovery-request metric.

## Product impact

The 2026-05-05 GOAL LOOP logs showed keepers detected as alive-but-stuck for
days while the supervisor only logged and counted the condition. This PR closes
that specific gap: a detected alive-but-stuck keeper is no longer left in
detection-only limbo, and the recovery action is observable as its own metric.

This is intentionally smaller than a new recovery subsystem. It reuses the
existing stale-watchdog/sweep recovery path so the first ACT slice is bounded
and reviewable.

## Evidence

Pre-rebase local checks:

- `scripts/dune-local.sh build test/test_keeper_supervisor.exe`
- `./_build/default/test/test_keeper_supervisor.exe test alive_but_stuck`
- `git diff --check`

Post-rebase checks:

- `git rebase origin/main` completed without conflicts.
- `git diff --check origin/main...HEAD`

Post-rebase focused Dune retry was blocked by active shared Dune lock from
another worktree:

```text
lockf /tmp/me-dune-local.lock dune build --root .../fix-cascade-health-score-recommendations-0505 ...
```

The full `test_keeper_supervisor.exe` binary was also tried pre-rebase, but it
hung after `reconcile_gate_recovery` with the process idle in `poll`; I stopped
that run and used the affected `alive_but_stuck` group as the focused runtime
test.

## Review Focus

- Whether `Stale_turn_timeout(Idle_turn)` is the right structured reason for
  this recovery request.
- Whether setting `fiber_stop`/`fiber_wakeup` is sufficient, or whether this
  should also close any active gRPC callback in a follow-up.
- Metric naming and cardinality for
  `masc_keeper_alive_but_stuck_recovery_requests_total`.

## Linked issue

N/A - derived from the 2026-05-05 GOAL LOOP/live-log audit.
