### PR TITLE
ci(fundamental-check): add workflow YAML syntax gate

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -53,5 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install PyYAML
+        run: python -m pip install --upgrade pip pyyaml
       - name: Run lint
         run: bash scripts/lint/yaml-syntax.sh

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -47,3 +47,11 @@ jobs:
         env:
           BASE: ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
         run: bash scripts/lint/godfile-size-regression.sh
+
+  yaml-syntax:
+    name: Workflow YAML syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: bash scripts/lint/yaml-syntax.sh

--- a/scripts/lint/yaml-syntax.sh
+++ b/scripts/lint/yaml-syntax.sh
@@ -10,9 +10,18 @@
 # files were not parsed at PR-time — invalid syntax silently fails the
 # workflow run as "workflow-file-issue" rather than failing the PR.
 #
-# This script parses every workflow file with PyYAML and exits non-zero
-# on the first ScannerError or ParserError. Run as a PR check so the
-# same partial-fix shape cannot reach main again.
+# This script parses every workflow file with PyYAML, aggregates parse
+# failures across all files, prints one ::error annotation per failing
+# file, and exits non-zero if any file failed (i.e. it does not
+# fail-fast — operators get the full list of broken files in a single
+# CI run). Run as a PR check so the same partial-fix shape cannot
+# reach main again.
+#
+# Dependency: PyYAML. The .github/workflows/fundamental-check.yml
+# job that invokes this script installs it explicitly via
+# `python -m pip install pyyaml` so the gate does not silently rely
+# on whatever happens to be preinstalled on ubuntu-latest at the
+# moment.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -30,6 +39,18 @@ python3 - "${files[@]}" <<'PY'
 import sys
 import yaml
 
+
+def gha_escape(s: str) -> str:
+    """Escape a string for a GitHub Actions workflow command line.
+
+    Workflow commands (`::error ...::message`) interpret newlines and
+    `%` specially.  The official sequences are %25, %0A, %0D — applied
+    in that order so the literal `%` in the input does not get
+    re-escaped after being emitted as `%25`.
+    """
+    return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
 failed = 0
 for path in sys.argv[1:]:
     try:
@@ -37,7 +58,8 @@ for path in sys.argv[1:]:
             yaml.safe_load(fh)
     except yaml.YAMLError as exc:
         failed += 1
-        print(f"::error file={path}::YAML parse error: {exc}", file=sys.stderr)
+        msg = gha_escape(f"YAML parse error: {exc}")
+        print(f"::error file={path}::{msg}", file=sys.stderr)
 
 if failed:
     print(f"yaml-syntax: {failed} workflow file(s) failed to parse", file=sys.stderr)

--- a/scripts/lint/yaml-syntax.sh
+++ b/scripts/lint/yaml-syntax.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Validate YAML syntax for every .github/workflows/*.yml.
+#
+# Why: 2026-05-05 PR #13042 added two `run: |` blocks to ci.yml that both
+# contained the `\<newline>column-1-text` line-continuation pattern. PR
+# #13050 fixed one of them (line 529-530) but missed the identical
+# pattern in the env_knob_catalog gate (line 542-545) introduced in the
+# same batch. main was a 30+ minute merge blocker until PR #13064
+# collapsed the second occurrence. The miss happened because workflow
+# files were not parsed at PR-time — invalid syntax silently fails the
+# workflow run as "workflow-file-issue" rather than failing the PR.
+#
+# This script parses every workflow file with PyYAML and exits non-zero
+# on the first ScannerError or ParserError. Run as a PR check so the
+# same partial-fix shape cannot reach main again.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+shopt -s nullglob
+files=(.github/workflows/*.yml .github/workflows/*.yaml)
+shopt -u nullglob
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "yaml-syntax: no workflow files found"
+  exit 0
+fi
+
+python3 - "${files[@]}" <<'PY'
+import sys
+import yaml
+
+failed = 0
+for path in sys.argv[1:]:
+    try:
+        with open(path) as fh:
+            yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        failed += 1
+        print(f"::error file={path}::YAML parse error: {exc}", file=sys.stderr)
+
+if failed:
+    print(f"yaml-syntax: {failed} workflow file(s) failed to parse", file=sys.stderr)
+    sys.exit(1)
+
+print(f"yaml-syntax: {len(sys.argv) - 1} workflow file(s) parsed OK")
+PY


### PR DESCRIPTION
## Summary

`.github/workflows/*.yml` 파일을 PyYAML로 파싱하는 lint job을 `Fundamental Check` workflow에 추가. 한 batch에 같은 line-continuation 결함이 다중 등장했을 때 부분 수정 후 main 머지 동결되는 패턴 방지.

## Why

2026-05-05 본 세션에서 발생한 정확한 사고 재현:

1. **PR #13042**: ci.yml에 `cascade drift gate`(line 529-530) + `env knob catalog drift gate`(line 542-545)를 한 batch로 추가. 두 곳 다 `run: \|` 블록 안에 `echo "::error::..." \<newline>column-1-text` 패턴.
2. **PR #13050**: line 529-530만 fix → main 머지 → line 542-545 동일 결함 잔존 → main `CI Gate` 30+분 fail → PR #13064 hotfix가 line 542-545 collapse로 해소.

부분 fix가 통과한 이유: workflow file 자체의 YAML syntax를 PR-time에 검증하는 가드 부재. invalid syntax workflow는 GitHub가 "workflow-file-issue"로 silent fail 처리 — 결함을 도입한 PR에서 fail이 표면화되지 않음.

## What

### `scripts/lint/yaml-syntax.sh` 신규

```bash
python3 - "${files[@]}" <<'PY'
import yaml
for path in sys.argv[1:]:
    with open(path) as fh:
        yaml.safe_load(fh)
PY
```

`.github/workflows/*.yml` + `*.yaml` 전수 `yaml.safe_load`. 한 곳이라도 `YAMLError` raise 시 `::error file=<path>::...` 출력 + exit 1.

### `fundamental-check.yml` 4번째 job 추가

```yaml
yaml-syntax:
  name: Workflow YAML syntax
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@v4
    - name: Run lint
      run: bash scripts/lint/yaml-syntax.sh
```

기존 3 job(hardcoding, telemetry, godfile)와 동일 구조. ubuntu-latest의 system Python3 + PyYAML 사용 (별도 install 불필요).

## Self-review

- [x] **현재 main에 fail 안 남**: `bash scripts/lint/yaml-syntax.sh` 출력 `yaml-syntax: 15 workflow file(s) parsed OK`.
- [x] **PR #13050 결함 catch 확인**: `\<newline>column-1` 패턴을 가진 synthetic YAML에 대해 `ScannerError: could not find expected ':' in ".tmp/test-bad.yml", line 10, column 1` 정확히 raise. 즉 PR #13042 시점에 가드가 있었으면 line 542-545를 PR-time에 fail.
- [x] **memory `feedback_yaml_lint_guard_for_workflow_changes.md` (2026-05-05) 명시 권고 1번** 그대로 구현.
- [ ] CI fundamental-check 5 job (3 기존 + yaml-syntax + 본 PR 자체) PASS 확인 — push 후 모니터.

## RFC Waiver

`RFC-WAIVED: CI lint additive only, .github/workflows/* 영역 한정. credential / identity / repo / operator / sandbox / dashboard credential / hooks 영역 무접촉. 회귀 가드 추가는 RFC-0008 §6 "regression-only guards do not require RFC" 적용.`

## Out of scope

- ci.yml 자체의 line-continuation 패턴 grep 가드 (별도 PR로 분리 — 같은 패턴이 ci.yml 외부에도 존재할 수 있음)
- `actionlint` 도입 (외부 binary 의존 — 본 가드는 stdlib PyYAML로 충분)

## Note on Draft

Per `feedback_masc_mcp_draft_guard_blocks_agent_ready.md` (2026-05-05 #12899) Draft 유지. `human-approved-ready` label 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)