### PR TITLE
fix(dashboard): bound safe-autonomy sandbox probes

### DIFF
--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -768,8 +768,16 @@ let build_keeper_snapshot
 (* The safe-autonomy screen renders one row per keeper.  This probe is
    intentionally much shorter than interactive sandbox-status calls; otherwise
    a slow Docker daemon costs [timeout * keeper_count] before the dashboard can
-   return any bytes. *)
-let sandbox_live_probe_timeout_sec = 0.25
+   return any bytes.
+
+   Floor at 1.0s rather than 0.25s: [Process_eio] timeouts surface
+   through [Log.warn]-style sites that format duration with [%.0f],
+   which would render the 0.25s budget as "0s" and confuse operators
+   reading "command timed out after 0s".  1.0s keeps the per-row
+   ceiling tight enough that 50 keepers render in <60s while
+   producing a self-explanatory diagnostic when Docker is genuinely
+   slow.  See PR #13113 review. *)
+let sandbox_live_probe_timeout_sec = 1.0
 
 let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
   let meta = snapshot.meta in

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -765,6 +765,12 @@ let build_keeper_snapshot
       @ cascade_findings @ audit_findings;
   }
 
+(* The safe-autonomy screen renders one row per keeper.  This probe is
+   intentionally much shorter than interactive sandbox-status calls; otherwise
+   a slow Docker daemon costs [timeout * keeper_count] before the dashboard can
+   return any bytes. *)
+let sandbox_live_probe_timeout_sec = 0.25
+
 let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
   let meta = snapshot.meta in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
@@ -772,7 +778,7 @@ let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
   let sandbox_live =
     Keeper_sandbox_control.live_status_json
       ~include_preflight:false
-      ~config ~meta ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dashboard ()) ~verbose:false ()
+      ~config ~meta ~timeout_sec:sandbox_live_probe_timeout_sec ~verbose:false ()
   in
   let domains =
     [

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -773,10 +773,23 @@ let build_keeper_snapshot
    Floor at 1.0s rather than 0.25s: [Process_eio] timeouts surface
    through [Log.warn]-style sites that format duration with [%.0f],
    which would render the 0.25s budget as "0s" and confuse operators
-   reading "command timed out after 0s".  1.0s keeps the per-row
-   ceiling tight enough that 50 keepers render in <60s while
-   producing a self-explanatory diagnostic when Docker is genuinely
-   slow.  See PR #13113 review. *)
+   reading "command timed out after 0s".  1.0s produces a
+   self-explanatory diagnostic when Docker is genuinely slow.
+
+   Worst-case budget bookkeeping (PR #13113 review):
+   [Keeper_sandbox_runtime.list_containers] internally runs TWO
+   sequential Docker commands (`docker ps` then `docker inspect`),
+   each gated by [~timeout_sec].  The per-row worst case is
+   therefore [2 * timeout_sec], not [timeout_sec].  At 1.0s × 2
+   commands × 50 keepers the screen budget is ~100s in the
+   worst case where every Docker call stalls — well above the
+   typical 15s client deadline, but bounded.  In the common case
+   Docker responds in tens of ms and the screen returns in <1s.
+   Operators who need a tighter overall budget should either
+   reduce keeper count surfaced here, or wait for the upstream
+   "single overall probe budget" follow-up (RFC TBD) that would
+   short-circuit further probes once a wall-clock deadline is hit.
+*)
 let sandbox_live_probe_timeout_sec = 1.0
 
 let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -44,6 +44,13 @@ let write_file path contents =
   | Ok () -> ()
   | Error err -> fail ("save_file_atomic failed: " ^ err)
 
+let write_slow_fake_docker () =
+  let dir = tmpdir "safe_autonomy_fake_docker" in
+  let path = Filename.concat dir "docker.sh" in
+  write_file path "sleep 2\nexit 0\n";
+  Unix.chmod path 0o755;
+  path
+
 let make_meta ?(name = "bench-analyst") ?(trace_id = "trace-safe-autonomy") () =
   match
     KT.meta_of_json
@@ -54,6 +61,8 @@ let make_meta ?(name = "bench-analyst") ?(trace_id = "trace-safe-autonomy") () =
           ("trace_id", `String trace_id);
           ("cascade_name", `String Keeper_config.default_cascade_name);
           ("last_model_used", `String "openai:gpt-5.4");
+          ("sandbox_profile", `String "local");
+          ("network_mode", `String "inherit");
           ("goal", `String "Keep autonomy safe and observable");
           ("short_goal", `String "Handle code work with approval and sandbox guardrails");
           ("mid_goal", `String "Keep the keeper queue healthy");
@@ -98,6 +107,21 @@ let persist_keeper config =
       Fs_compat.mkdir_p repo_path;
       meta
   | Error err -> fail ("write_meta failed: " ^ err)
+
+let persist_docker_keeper config ~name =
+  let meta =
+    {
+      (make_meta ~name ~trace_id:("trace-" ^ name) ()) with
+      agent_name = KT.keeper_agent_name name;
+      sandbox_profile = KT.Docker;
+      network_mode = KT.Network_none;
+    }
+  in
+  match KT.write_meta ~force:true config meta with
+  | Ok () ->
+      Fs_compat.mkdir_p (Keeper_sandbox.host_root_abs_of_meta ~config meta);
+      meta
+  | Error err -> fail ("write docker keeper meta failed: " ^ err)
 
 let write_manifest path =
   write_file path
@@ -185,6 +209,19 @@ let test_history_dedupes_identical_payloads () =
       check bool "latest file is valid json" true
         (match latest_json with `Assoc _ -> true | _ -> false)))
 
+let test_sandbox_live_probe_is_bounded_per_keeper () =
+  with_safe_autonomy_store @@ fun config ->
+  ignore (persist_docker_keeper config ~name:"docker-a");
+  ignore (persist_docker_keeper config ~name:"docker-b");
+  let fake_docker = write_slow_fake_docker () in
+  with_env "MASC_TEST_FAKE_DOCKER_PATH" (Some fake_docker) (fun () ->
+    let started_at = Unix.gettimeofday () in
+    let json = Dashboard_safe_autonomy.json ~config () in
+    let elapsed_sec = Unix.gettimeofday () -. started_at in
+    check bool "slow docker probe is bounded" true (elapsed_sec < 1.5);
+    let per_keeper = Yojson.Safe.Util.(json |> member "per_keeper" |> to_list) in
+    check int "docker keeper count" 2 (List.length per_keeper))
+
 let () =
   run "dashboard_safe_autonomy"
     [
@@ -194,5 +231,7 @@ let () =
             test_json_emits_scorecard_and_artifacts;
           test_case "artifact history dedupes identical payloads" `Quick
             test_history_dedupes_identical_payloads;
+          test_case "sandbox live probe is bounded per keeper" `Quick
+            test_sandbox_live_probe_is_bounded_per_keeper;
         ] );
     ]

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -62,7 +62,12 @@ let make_meta ?(name = "bench-analyst") ?(trace_id = "trace-safe-autonomy") () =
           ("cascade_name", `String Keeper_config.default_cascade_name);
           ("last_model_used", `String "openai:gpt-5.4");
           ("sandbox_profile", `String "local");
-          ("network_mode", `String "inherit");
+          (* PR #13113 review: align with the canonical local-keeper
+             default — the seed config sets [network_mode = "none"]
+             when [sandbox_profile = "local"].  The previous
+             "inherit" value would render confusing dashboard rows
+             during fixture-driven tests of the safe-autonomy screen. *)
+          ("network_mode", `String "none");
           ("goal", `String "Keep autonomy safe and observable");
           ("short_goal", `String "Handle code work with approval and sandbox guardrails");
           ("mid_goal", `String "Keep the keeper queue healthy");
@@ -218,7 +223,14 @@ let test_sandbox_live_probe_is_bounded_per_keeper () =
     let started_at = Unix.gettimeofday () in
     let json = Dashboard_safe_autonomy.json ~config () in
     let elapsed_sec = Unix.gettimeofday () -. started_at in
-    check bool "slow docker probe is bounded" true (elapsed_sec < 1.5);
+    (* PR #13113: per-keeper probe timeout is 1.0s (raised from
+       0.25s so [Process_eio]'s [%.0f] log formatter prints "1s"
+       instead of the misleading "0s").  With 2 stalled docker
+       keepers serialised through the screen, the worst-case is
+       roughly 2 * 1.0s + scheduler / I-O overhead.  Bound at 3.5s
+       to keep the regression test alarm narrow without flaking on
+       slow CI runners. *)
+    check bool "slow docker probe is bounded" true (elapsed_sec < 3.5);
     let per_keeper = Yojson.Safe.Util.(json |> member "per_keeper" |> to_list) in
     check int "docker keeper count" 2 (List.length per_keeper))
 


### PR DESCRIPTION
## Summary

Safe-autonomy was still unusable on the live `/Users/dancer/me` runtime even while `/health` was healthy. The endpoint returned no bytes before a 15s curl timeout with `keeper_fibers=17` because the screen built one keeper row at a time and each row could spend up to 3s probing Docker sandbox state.

This changes the safe-autonomy dashboard row probe to use a short bounded sandbox-live timeout while leaving the interactive sandbox status path untouched. Slow Docker now degrades the row's `sandbox_live` object instead of blocking the whole operator screen.

## Root Cause

`/api/v1/dashboard/safe-autonomy` calls `Dashboard_safe_autonomy.json`, which calls `Keeper_sandbox_control.live_status_json` once per keeper. That call still lists Docker containers even with `include_preflight=false`, so a slow Docker path can cost `3.0s * keeper_count` before the dashboard returns.

## Changes

- Added a dedicated `sandbox_live_probe_timeout_sec` for safe-autonomy rows.
- Reduced that per-row probe timeout from `3.0s` to **`1.0s`** (revised up from the original draft `0.25s` after copilot review — `Process_eio` timeouts use `%.0f` formatting and would render `0.25s` as `"0s"`, confusing operators).
- Updated the in-source budget comment to reflect the actual worst case: `Keeper_sandbox_runtime.list_containers` runs two Docker commands sequentially (`ps` then `inspect`), each gated by `timeout_sec`, so the per-row ceiling is `2 * timeout_sec` and the 50-keeper worst case is ~100s (not <60s as the original comment claimed). Common case still <1s when Docker is healthy.
- Added a regression test with two Docker-profile keepers and a fake slow Docker binary so the endpoint must stay bounded across multiple rows.

## Validation

- `git diff --check HEAD~1 HEAD` passed.
- Focused build/test command attempted:
  - `DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_dashboard_safe_autonomy.exe`
- Local focused build reached link stage, then failed because this machine's local `agent_sdk` pin is not the repo-expected OAS pin:
  - `agent_sdk pin source is git+https://github.com/jeong-sik/oas.git#8bf695f6ca00e1f010434a88c8cb6c137df4a02b, expected git+https://github.com/jeong-sik/oas.git#86a0e540a8856db5ee740cb2d1deff58bf0bbbfb`
  - `repair: bash scripts/opam-pin-external-deps.sh`
- I did not repin the shared local switch from this dashboard slice. CI should validate with the expected pin.

## Review Focus

Please check the operator responsiveness tradeoff: safe-autonomy should surface bounded row status quickly, while deeper Docker diagnostics remain on the interactive sandbox status path.