### PR TITLE
fix(dashboard): log keeper sub-op timings after row build

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -780,9 +780,8 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                          meta.name (Printexc.to_string exn);
                        `Null
                  in
-                 emit_timing_log (Time_compat.now () -. t_work_start);
-                 Some
-                   (`Assoc
+                 let row =
+                   `Assoc
                      ([
                        ("runtime_class", `String "keeper");
                        ("pipeline_stage", `String pipeline_stage);
@@ -971,7 +970,10 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                      @ keeper_context_snapshot_fields context_snapshot
                      @ Keeper_status_bridge.runtime_blocker_fields_json config meta
                      @ Keeper_status_bridge.attention_fields_json config meta
-                     @ [ ("runtime_trust", runtime_trust) ]))
+                     @ [ ("runtime_trust", runtime_trust) ])
+                 in
+                 emit_timing_log (Time_compat.now () -. t_work_start);
+                 Some row
                  end
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Dashboard.error "keepers_json fiber error (%s): %s"

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -34,6 +34,10 @@ let () =
             Test_operator_control_snapshot
             .test_snapshot_prefers_metrics_context_truth_over_usage_counters;
           Alcotest.test_case
+            "snapshot sub-op timing logs after profile and activity" `Quick
+            Test_operator_control_snapshot
+            .test_keeper_subop_timing_log_after_profile_activity;
+          Alcotest.test_case
             "snapshot summary surfaces paused keeper runtime trust" `Quick
             Test_operator_control_snapshot
             .test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust;

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -1,6 +1,53 @@
 open Masc_mcp
 open Test_operator_control_support
 
+let last_substring_index haystack needle =
+  let h_len = String.length haystack in
+  let n_len = String.length needle in
+  if n_len = 0 || n_len > h_len then None
+  else
+    let rec loop i last =
+      if i + n_len > h_len then last
+      else
+        let last =
+          if String.sub haystack i n_len = needle then Some i else last
+        in
+        loop (i + 1) last
+    in
+    loop 0 None
+
+let expect_source_marker source marker =
+  match last_substring_index source marker with
+  | Some idx -> idx
+  | None -> Alcotest.failf "source marker not found: %s" marker
+
+let test_keeper_subop_timing_log_after_profile_activity () =
+  let root = Masc_test_deps.find_project_root () in
+  let path =
+    Filename.concat root "lib/operator/operator_control_snapshot.ml"
+  in
+  let source =
+    match Safe_ops.read_file_safe path with
+    | Ok text -> text
+    | Error err -> Alcotest.failf "read %s failed: %s" path err
+  in
+  let profile_idx =
+    expect_source_marker source
+      "dt_profile := Time_compat.now () -. t_profile"
+  in
+  let activity_idx =
+    expect_source_marker source
+      "dt_activity := Time_compat.now () -. t_act"
+  in
+  let emit_idx =
+    expect_source_marker source
+      "emit_timing_log (Time_compat.now () -. t_work_start)"
+  in
+  Alcotest.(check bool) "profile timing computed before log" true
+    (profile_idx < emit_idx);
+  Alcotest.(check bool) "activity timing computed before log" true
+    (activity_idx < emit_idx)
+
 let test_align_keeper_runtime_status_promotes_fresh_runtime_signal () =
   let status =
     Operator_control_snapshot.align_keeper_runtime_status

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -16,11 +16,50 @@ let last_substring_index haystack needle =
     in
     loop 0 None
 
+(* Find the FIRST occurrence of [needle] in [haystack] at or after
+   [from].  Used by the regression below to anchor on the emit that
+   actually follows the timing computations, rather than the last
+   occurrence in the file (which can be unrelated, e.g. an early
+   paused-branch emit at a higher offset, or a new caller added later
+   anywhere in the source). *)
+let first_substring_index_after haystack needle ~from =
+  let h_len = String.length haystack in
+  let n_len = String.length needle in
+  if n_len = 0 || n_len > h_len || from >= h_len then None
+  else
+    let rec loop i =
+      if i + n_len > h_len then None
+      else if String.sub haystack i n_len = needle then Some i
+      else loop (i + 1)
+    in
+    loop (max 0 from)
+
 let expect_source_marker source marker =
   match last_substring_index source marker with
   | Some idx -> idx
   | None -> Alcotest.failf "source marker not found: %s" marker
 
+(* PR #13114 regression guard.
+
+   The regression we defend against: the non-paused branch of
+   [keepers_json] computed [dt_profile] / [dt_activity] AFTER calling
+   [emit_timing_log], so the timing log always reported zero for the
+   profile and activity fields.
+
+   The invariant: in the non-paused branch, both timing assignments
+   must precede the [emit_timing_log] call that consumes them.  The
+   file also contains an early [emit_timing_log] call in the paused
+   branch (which intentionally exits before the timing
+   computations), so a literal "last emit in file" anchor is fragile
+   — Copilot correctly flagged this could mask a real regression if
+   a new [emit_timing_log] caller appeared anywhere later in the
+   file.
+
+   Robust formulation: anchor on the FIRST [emit_timing_log] that
+   appears at or after both [dt_profile :=] and [dt_activity :=].
+   That is exactly the "timing log emitted after the timing
+   computations" the PR enforces, regardless of how many other
+   [emit_timing_log] callers exist before or after. *)
 let test_keeper_subop_timing_log_after_profile_activity () =
   let root = Masc_test_deps.find_project_root () in
   let path =
@@ -39,13 +78,25 @@ let test_keeper_subop_timing_log_after_profile_activity () =
     expect_source_marker source
       "dt_activity := Time_compat.now () -. t_act"
   in
+  let timings_done_idx = max profile_idx activity_idx in
   let emit_idx =
-    expect_source_marker source
-      "emit_timing_log (Time_compat.now () -. t_work_start)"
+    match
+      first_substring_index_after source
+        "emit_timing_log (Time_compat.now () -. t_work_start)"
+        ~from:timings_done_idx
+    with
+    | Some idx -> idx
+    | None ->
+        Alcotest.failf
+          "no [emit_timing_log (Time_compat.now () -. t_work_start)] found \
+           after the latest dt_profile/dt_activity assignment (last at byte \
+           %d).  PR #13114 requires the non-paused branch to call the \
+           timing log AFTER computing both deltas."
+          timings_done_idx
   in
-  Alcotest.(check bool) "profile timing computed before log" true
+  Alcotest.(check bool) "profile timing computed before non-paused log" true
     (profile_idx < emit_idx);
-  Alcotest.(check bool) "activity timing computed before log" true
+  Alcotest.(check bool) "activity timing computed before non-paused log" true
     (activity_idx < emit_idx)
 
 let test_align_keeper_runtime_status_promotes_fresh_runtime_signal () =


### PR DESCRIPTION
## Summary

Fixes the GOAL LOOP dashboard timing evidence path for
`[keepers_json:*] sub-op` logs:

- Builds the full keeper JSON row before emitting the sub-op timing log.
- This lets the `turn_budget` and `recent_activity` field builders update
  `dt_profile` and `dt_activity` before logging.
- Adds a focused source-order regression test so the log cannot move back
  above the profile/activity timing updates.

## Product impact

The 2026-05-05 audit showed keeper snapshot logs like:

```text
ka=0ms audit=0ms profile=0ms phase=0ms activity=0ms
```

One concrete cause was that `emit_timing_log` ran before the row fields that
populate `profile` and `activity` timing. Operators reading this log could not
separate a genuinely cheap sub-op from a measurement that was emitted too
early. This PR makes that evidence path measure the work it claims to report.

## Evidence

- `git diff --check origin/main...HEAD`
- Source-order check:

```text
dt_profile := ...          line 932
dt_activity := ...         line 967
emit_timing_log ...        line 975
```

Focused Dune validation attempted:

```bash
MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_operator_control.exe
```

Result:

```text
agent_sdk pin source is git+https://github.com/jeong-sik/oas.git#e1244c9b,
expected git+https://github.com/jeong-sik/oas.git#86a0e540a8856db5ee740cb2d1deff58bf0bbbfb
[dune-local] agent_sdk pin drift detected -- aborting build
```

I did not run `scripts/opam-pin-external-deps.sh --install` because active Dune
builds were using the shared switch.

## Review Focus

- Whether the source-order regression is sufficient for this measurement-order
  bug, or whether a heavier runtime fixture is worth adding after the shared
  opam switch settles.
- Whether paused keeper rows should get their own reduced timing log shape in a
  follow-up, since they intentionally skip profile/activity work.

## Linked issue

N/A - derived from the 2026-05-05 GOAL LOOP/live-log audit.
