### PR TITLE
fix(dashboard): bound judge bridge budgets

### DIFF
--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -6,13 +6,16 @@
       1. its default is preserved when the original literal was a
          deliberately-tuned value (autoresearch_codegen=120s,
          tool_deep_review=180s, anti_rationalization=180s);
-      2. the two "fantasy" 60s budgets ([auto_responder],
+      2. the two old "fantasy" 60s budgets ([auto_responder],
          [dashboard_provider_runs]) get raised to [default_timeout_sec]
          (300s) — the original 60s did not match observed p50 latency
          (50–700s) and produced 27 timeouts/session;
-      3. the operator can override any single caller's budget via
+      3. dashboard judge daemons stay advisory and bounded by default
+         instead of holding an OAS CLI subprocess for multiple dashboard
+         refresh intervals;
+      4. the operator can override any single caller's budget via
          [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC];
-      4. the operator can set a fallback for unknown / future callers
+      5. the operator can set a fallback for unknown / future callers
          via [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC].
 
     The lookup order is per-caller env > per-caller hardcoded default
@@ -42,6 +45,14 @@ type caller =
     we preserve the value so the fix does not regress
     autoresearch / deep_review / anti_rationalization. *)
 let global_default_sec = 300.0
+
+(** Dashboard judges are background/advisory signal generators.  They run on the
+    operator screen cadence, so a default at or above the generic 300s worker
+    budget can pin a CLI-backed OAS child for several refreshes and starve the
+    live dashboard.  Keep this below the default 60s judge interval; operators
+    can still raise it per caller when they explicitly prefer completeness over
+    responsiveness. *)
+let dashboard_judge_default_sec = 45.0
 
 let caller_key = function
   | Auto_responder -> "auto_responder"
@@ -80,20 +91,13 @@ let known_default_sec = function
   | Keeper_persona_authoring
   | Server_openai_compat -> Some 120.0
   | Tool_deep_review | Anti_rationalization -> Some 180.0
-  (* #9629: Governance + Operator judges are LLM-via-OAS-worker calls
-     with the same observed p50 latency as Auto_responder /
-     Dashboard_provider_runs (50–700s).  Pre-migration these read
-     [Env_config.Inference.{operator,dashboard_governance}_judge_timeout_seconds]
-     directly via legacy [run_safe ~timeout_s], bypassing this SSOT.
-     Operator_judge in particular fell back to the global 30s
-     inference timeout — far below p50 — and produced the
-     "Execution timed out after 60.0s" warnings reported in #9629
-     (the 60s figure came from [Env_config.Inference.timeout_seconds]
-     overrides at the time).  Aligning both judges with the
-     Auto_responder default keeps the OAS-bridge SSOT consistent and
-     ends the asymmetry where one judge waited 30s and the other
-     300s for the same shape of LLM call. *)
-  | Governance_judge | Operator_judge -> Some global_default_sec
+  (* #9629 moved both judges into this SSOT after Operator_judge inherited a
+     too-short generic inference timeout.  Live dashboard evidence showed the
+     opposite failure mode: a 300s advisory judge budget can leave a
+     CLI-backed child running for minutes while operator/health surfaces stall.
+     Keep the caller-specific env overrides, but make the checked-in default
+     bounded for dashboard responsiveness. *)
+  | Governance_judge | Operator_judge -> Some dashboard_judge_default_sec
   | Unknown _ -> None
 
 let upper_case s =
@@ -144,8 +148,9 @@ let trimmed_value_opt name =
          no legacy alias is registered for the caller.
       3. Per-caller checked-in default ([known_default_sec]).
          Preserves intentional 120/180s budgets for compute-heavy
-         callers; raises the fantasy 60s budgets to
-         [global_default_sec] (300s).
+         callers; raises the old fantasy 60s worker budgets to
+         [global_default_sec] (300s); bounds dashboard judge daemons to
+         [dashboard_judge_default_sec].
       4. Global env [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — only
          consulted for UNKNOWN callers (typo, future caller
          without a default entry).  Treating it as an override

--- a/lib/config/env_config_oas_bridge.mli
+++ b/lib/config/env_config_oas_bridge.mli
@@ -3,9 +3,9 @@
     Replaces seven hardcoded [Masc_oas_bridge.run_safe ~timeout_s:N.N]
     literals scattered across the lib tree. Each caller is named so
     its hardcoded default is preserved (compute-heavy budgets at
-    120/180s) or raised (fantasy 60s budgets at 300s), while the
-    operator can tune any single caller via env without touching the
-    others.
+    120/180s), raised (old fantasy worker budgets at 300s), or bounded
+    for advisory dashboard judges, while the operator can tune any
+    single caller via env without touching the others.
 
     Lookup order in {!timeout_sec} (top wins):
     1. Per-caller env [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC].
@@ -58,7 +58,12 @@ val known_callers : unit -> caller list
 
 val global_default_sec : float
 (** Hardcoded final fallback (seconds) — also reused as the typed
-    default for compute-heavy callers ({!Auto_responder} /
-    {!Dashboard_provider_runs} / {!Governance_judge} /
-    {!Operator_judge}). Exposed so tests can pin the per-caller
-    table without hardcoding the literal. *)
+    default for worker-style callers ({!Auto_responder} /
+    {!Dashboard_provider_runs}). Exposed so tests can pin the
+    per-caller table without hardcoding the literal. *)
+
+val dashboard_judge_default_sec : float
+(** Default timeout for advisory dashboard judge callers
+    ({!Governance_judge} / {!Operator_judge}). Kept below the default
+    judge refresh interval so a slow CLI-backed judge degrades instead
+    of pinning the dashboard for minutes. *)

--- a/test/test_oas_bridge_judge_callers_9629.ml
+++ b/test/test_oas_bridge_judge_callers_9629.ml
@@ -10,11 +10,17 @@
    issue.  Governance_judge had a 300s default but lived outside the
    per-caller Prometheus counter.
 
+   #13113 follow-up: live /Users/dancer/me evidence showed the opposite
+   failure mode once both judges shared the 300s worker default: a dashboard
+   governance judge can pin a CLI-backed child for minutes and make operator
+   surfaces / health checks stale.  Dashboard judges are advisory, so their
+   checked-in default is now bounded separately while env overrides stay
+   available.
+
    This test pins:
 
-     1. Both judges resolve to [global_default_sec] (300s) by default,
-        matching the other LLM-via-OAS-worker callers
-        (Auto_responder / Dashboard_provider_runs).
+     1. Both judges resolve to [dashboard_judge_default_sec] by default,
+        instead of inheriting the generic 300s worker budget.
      2. The legacy per-caller env vars
         ([MASC_OPERATOR_JUDGE_TIMEOUT_SEC],
         [MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC]) are still
@@ -50,15 +56,15 @@ let clear_all_envs () =
     (Cfg.known_callers ());
   List.iter (fun name -> Unix.putenv name "") legacy_envs
 
-let test_judge_defaults_match_global () =
+let test_judge_defaults_are_bounded () =
   clear_all_envs ();
   Alcotest.(check (float 0.0001))
-    "Governance_judge defaults to global_default_sec"
-    Cfg.global_default_sec
+    "Governance_judge defaults to dashboard_judge_default_sec"
+    Cfg.dashboard_judge_default_sec
     (Cfg.timeout_sec ~caller:Cfg.Governance_judge ());
   Alcotest.(check (float 0.0001))
-    "Operator_judge defaults to global_default_sec"
-    Cfg.global_default_sec
+    "Operator_judge defaults to dashboard_judge_default_sec"
+    Cfg.dashboard_judge_default_sec
     (Cfg.timeout_sec ~caller:Cfg.Operator_judge ())
 
 let test_legacy_env_honoured_as_fallback () =
@@ -118,8 +124,8 @@ let () =
     [
       ( "defaults",
         [
-          Alcotest.test_case "judge defaults match global default"
-            `Quick test_judge_defaults_match_global;
+          Alcotest.test_case "judge defaults are bounded"
+            `Quick test_judge_defaults_are_bounded;
           Alcotest.test_case "judges listed in known_callers"
             `Quick test_judges_listed_in_known_callers;
         ] );

--- a/test/test_oas_bridge_judge_callers_9629.ml
+++ b/test/test_oas_bridge_judge_callers_9629.ml
@@ -56,6 +56,21 @@ let clear_all_envs () =
     (Cfg.known_callers ());
   List.iter (fun name -> Unix.putenv name "") legacy_envs
 
+(* The PR's stated invariant is "dashboard judges resolve to a
+   bounded 45.0s default, not the 300s worker budget".  Pin the
+   numeric value of [dashboard_judge_default_sec] explicitly.
+   Without this anchor, a future widen back toward the worker
+   budget would still pass the existing
+   [judge resolves to dashboard_judge_default_sec] checks because
+   both sides of the comparison would shift in lockstep. *)
+let test_dashboard_judge_default_is_45s () =
+  Alcotest.(check (float 0.0001))
+    "dashboard_judge_default_sec is bounded at 45.0s; widening it \
+     back toward the 300s worker budget reintroduces the operator-\
+     surface stall this PR is meant to prevent — see #13113 follow-up"
+    45.0
+    Cfg.dashboard_judge_default_sec
+
 let test_judge_defaults_are_bounded () =
   clear_all_envs ();
   Alcotest.(check (float 0.0001))
@@ -124,6 +139,8 @@ let () =
     [
       ( "defaults",
         [
+          Alcotest.test_case "dashboard_judge_default_sec is 45s"
+            `Quick test_dashboard_judge_default_is_45s;
           Alcotest.test_case "judge defaults are bounded"
             `Quick test_judge_defaults_are_bounded;
           Alcotest.test_case "judges listed in known_callers"


### PR DESCRIPTION
## Summary

Live `/Users/dancer/me` debugging showed a dashboard governance judge holding a CLI-backed OAS subprocess for minutes while operator surfaces and even `/health` went stale. The child process was a `gemini --output-format json` governance judge under `main_eio.exe`, still running after 2m46s.

This PR gives advisory dashboard judge callers their own bounded default timeout (`45s`) instead of inheriting the generic 300s worker budget. The existing per-caller env overrides remain available for deployments that explicitly want a longer judge budget.

## Root Cause

`Governance_judge` and `Operator_judge` were pinned to `Env_config_oas_bridge.global_default_sec` (`300s`) after #9629. That fixed too-short judge timeouts, but it made dashboard background judges behave like long-form worker tasks. On the live runtime, the governance judge was cancelled during shutdown after already holding the OAS bridge for `145.9s`:

- `masc_oas_bridge: OAS execution cancelled caller=governance_judge wall=145.9s bucket=short_tail inner=Eio__core__Fiber.Not_first`

For an advisory dashboard loop, slow judgment should degrade to stale/offline judge state rather than pinning a CLI process across multiple operator refresh intervals.

## Changes

- Added `Env_config_oas_bridge.dashboard_judge_default_sec = 45.0`.
- Changed `Governance_judge` and `Operator_judge` defaults from `300s` to `45s`.
- Preserved the override path:
  - `MASC_OAS_BRIDGE_TIMEOUT_GOVERNANCE_JUDGE_SEC`
  - `MASC_OAS_BRIDGE_TIMEOUT_OPERATOR_JUDGE_SEC`
  - legacy `MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC`
  - legacy `MASC_OPERATOR_JUDGE_TIMEOUT_SEC`
- Updated the #9629 regression test to pin the bounded default while keeping legacy override behavior.

## Validation

- `git diff --check` passed.
- Focused wrapper attempted:
  - `DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_oas_bridge_judge_callers_9629.exe`
  - stopped at repo pin guard: local `agent_sdk` pin is `git+https://github.com/jeong-sik/oas.git#e1244c9b`, expected `git+https://github.com/jeong-sik/oas.git#86a0e540a8856db5ee740cb2d1deff58bf0bbbfb`.
- Bypass attempt for compile signal:
  - `MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_oas_bridge_judge_callers_9629.exe`
  - failed because the local switch cannot resolve base packages/modules (`Ppx_deriving_runtime`, `Eio`, `Uuidm`, `Ppx_deriving_yojson_runtime`, `Agent_sdk`).
- I did not repair or repin the shared local switch from this slice. CI should be the authoritative validation surface.

## Review Focus

Check the default budget tradeoff. This intentionally favors dashboard responsiveness and stale-but-visible judge state over waiting minutes for advisory LLM judgment. Long-form OAS callers keep their existing budgets.