### PR TITLE
chore(build): dune-local.sh — guard missing opam deps + OCaml < 5.1 early

### DIFF
--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -59,6 +59,43 @@ else
   cmd+=("${args[@]}")
 fi
 
+# Detect the actual dune subcommand by skipping global options and their
+# values.  PR #13117 review (P2): `args[0]` misclassified valid invocations
+# like `scripts/dune-local.sh --root . clean` as non-clean, making the
+# guards below fire on a clean target that never compiles.  The subcommand
+# is the first positional token after any leading global-option flags.
+_value_taking_flags=(--root --workspace --profile --build-dir --display \
+                     --default-target -j --jobs --config-file --cache \
+                     --cache-storage-backend --auto-promote --diff-command \
+                     --error-reporting --terminal-persistence)
+_detect_subcommand() {
+  local i=0
+  while (( i < ${#args[@]} )); do
+    local a="${args[i]}"
+    # `--flag=value` form: single token, skip it.
+    if [[ "$a" == --*=* ]]; then
+      i=$((i + 1)); continue
+    fi
+    # Known value-taking flag: skip flag + its value.
+    local _value_taking=0
+    for _vf in "${_value_taking_flags[@]}"; do
+      if [[ "$a" == "$_vf" ]]; then _value_taking=1; break; fi
+    done
+    if [[ "$_value_taking" -eq 1 ]]; then
+      i=$((i + 2)); continue
+    fi
+    # Other option-shaped tokens: skip just the flag.
+    if [[ "$a" == -* ]]; then
+      i=$((i + 1)); continue
+    fi
+    # First non-option token = subcommand.
+    printf '%s\n' "$a"
+    return
+  done
+  printf 'build\n'
+}
+_subcommand="$(_detect_subcommand)"
+
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
   export DUNE_JOBS="${DUNE_JOBS:-${DUNE_LOCAL_JOBS:-2}}"
   export DUNE_BUILD_DIR="${DUNE_BUILD_DIR:-$repo_root/_build}"
@@ -81,7 +118,7 @@ fi
 if [[ "${GITHUB_ACTIONS:-}" != "true" \
       && "${MASC_SKIP_PIN_CHECK:-0}" != "1" \
       && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
-      && "${args[0]:-build}" != "clean" ]]; then
+      && "${_subcommand}" != "clean" ]]; then
   _pin_check="${repo_root}/scripts/check-oas-pin.sh"
   if [[ -x "${_pin_check}" ]] && command -v opam >/dev/null 2>&1; then
     printf '[dune-local] checking agent_sdk pin...\n' >&2
@@ -116,7 +153,7 @@ fi
 if [[ "${GITHUB_ACTIONS:-}" != "true" \
       && "${MASC_SKIP_DEPS_CHECK:-0}" != "1" \
       && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
-      && "${args[0]:-build}" != "clean" ]]; then
+      && "${_subcommand}" != "clean" ]]; then
   if command -v opam >/dev/null 2>&1; then
     _core_deps=(httpun httpun-eio httpun-ws agent_sdk)
     _missing=()
@@ -151,7 +188,7 @@ fi
 if [[ "${GITHUB_ACTIONS:-}" != "true" \
       && "${MASC_SKIP_OCAML_VERSION_CHECK:-0}" != "1" \
       && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
-      && "${args[0]:-build}" != "clean" ]]; then
+      && "${_subcommand}" != "clean" ]]; then
   if command -v ocaml >/dev/null 2>&1; then
     _ocaml_v="$(ocaml -version 2>/dev/null \
                 | sed -nE 's/.*version ([0-9]+\.[0-9]+).*/\1/p')"

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -64,10 +64,19 @@ fi
 # like `scripts/dune-local.sh --root . clean` as non-clean, making the
 # guards below fire on a clean target that never compiles.  The subcommand
 # is the first positional token after any leading global-option flags.
+#
+# Two follow-up reviews (codex-connector P2, 2026-05-05):
+#   - `--auto-promote` is a boolean flag, NOT value-taking (per
+#     `dune build --help` common options).  Removed from value list.
+#   - `-p PACKAGES` and `-x VAL` ARE value-taking short options
+#     (also common options).  Added to value list — the prior
+#     fallback `[[ "$a" == -* ]]` consumed only the flag and then
+#     misread the value as the subcommand.
 _value_taking_flags=(--root --workspace --profile --build-dir --display \
-                     --default-target -j --jobs --config-file --cache \
-                     --cache-storage-backend --auto-promote --diff-command \
-                     --error-reporting --terminal-persistence)
+                     --default-target -j --jobs -p --only-packages \
+                     -x --config-file --cache --cache-storage-backend \
+                     --diff-command --error-reporting \
+                     --terminal-persistence)
 _detect_subcommand() {
   local i=0
   while (( i < ${#args[@]} )); do

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -72,9 +72,13 @@ fi
 #     (also common options).  Added to value list — the prior
 #     fallback `[[ "$a" == -* ]]` consumed only the flag and then
 #     misread the value as the subcommand.
+#   - `--cache-storage-mode VAL` and `--cache-check-probability VAL`
+#     are value-taking Dune cache options; do not treat their values
+#     as subcommands.
 _value_taking_flags=(--root --workspace --profile --build-dir --display \
                      --default-target -j --jobs -p --only-packages \
-                     -x --config-file --cache --cache-storage-backend \
+                     -x --config-file --cache --cache-check-probability \
+                     --cache-storage-mode \
                      --diff-command --error-reporting \
                      --terminal-persistence)
 _detect_subcommand() {

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -92,6 +92,85 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
 fi
 # -----------------------------------------------------------------------
 
+# --- core opam-deps installed guard ------------------------------------
+# Catch the "deps declared but not installed" failure mode before Dune
+# emits a wall of cryptic abstract-cmi errors:
+#
+#   Error: Unbound module Httpun
+#   Type Httpun.Method.t is abstract because no corresponding cmi file
+#   was found in path.
+#
+# Pin guard above checks that agent_sdk *would resolve to* the right
+# SHA, but does not catch the case where the operator added a new opam
+# switch and forgot `opam install . --deps-only -y`.  Hardcoded list
+# covers the four packages whose absence produces the worst error
+# spew; full validation belongs to opam itself (the wrapper deliberately
+# stays cheap).
+#
+# Skipped under the same envelope as the pin guard plus
+# MASC_SKIP_DEPS_CHECK=1.
+if [[ "${GITHUB_ACTIONS:-}" != "true" \
+      && "${MASC_SKIP_DEPS_CHECK:-0}" != "1" \
+      && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
+      && "${args[0]:-build}" != "clean" ]]; then
+  if command -v opam >/dev/null 2>&1; then
+    _core_deps=(httpun httpun-eio httpun-ws agent_sdk)
+    _missing=()
+    for _pkg in "${_core_deps[@]}"; do
+      if ! opam list --installed --short "${_pkg}" 2>/dev/null \
+           | grep -qx "${_pkg}"; then
+        _missing+=("${_pkg}")
+      fi
+    done
+    if [[ ${#_missing[@]} -gt 0 ]]; then
+      printf '[dune-local] missing opam packages in switch %s: %s\n' \
+        "$(opam switch show 2>/dev/null || echo '?')" \
+        "${_missing[*]}" >&2
+      printf '[dune-local] symptom you would otherwise see:\n' >&2
+      printf '[dune-local]   Error: Unbound module <Pkg>\n' >&2
+      printf '[dune-local]   Type <Pkg>.<T>.t is abstract because no corresponding cmi file...\n' >&2
+      printf '[dune-local] repair: opam install . --deps-only -y\n' >&2
+      printf '[dune-local] set MASC_SKIP_DEPS_CHECK=1 to bypass this guard\n' >&2
+      exit 1
+    fi
+  fi
+fi
+# -----------------------------------------------------------------------
+
+# --- OCaml minimum version guard ---------------------------------------
+# Several lib/ call sites use stdlib APIs added in OCaml 5.1 (notably
+# [Unix.mkdtemp], used by test/test_dune_local_script.ml).  Building
+# under a 4.x switch surfaces as:
+#
+#   Error: Unbound value Unix.mkdtemp
+#   Hint: Did you mean Unix.mktime?
+#
+# which is the same misleading "did-you-mean" pattern the dependency
+# guard above protects against.  Fail fast with the explicit minimum.
+if [[ "${GITHUB_ACTIONS:-}" != "true" \
+      && "${MASC_SKIP_OCAML_VERSION_CHECK:-0}" != "1" \
+      && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
+      && "${args[0]:-build}" != "clean" ]]; then
+  if command -v ocaml >/dev/null 2>&1; then
+    _ocaml_v="$(ocaml -version 2>/dev/null \
+                | sed -nE 's/.*version ([0-9]+\.[0-9]+).*/\1/p')"
+    if [[ -n "${_ocaml_v}" ]]; then
+      _major="${_ocaml_v%%.*}"
+      _minor="${_ocaml_v##*.}"
+      if [[ "${_major}" -lt 5 \
+            || ( "${_major}" -eq 5 && "${_minor}" -lt 1 ) ]]; then
+        printf '[dune-local] OCaml %s detected; this repo requires >= 5.1\n' \
+          "${_ocaml_v}" >&2
+        printf '[dune-local] symptom under older switch: Error: Unbound value Unix.mkdtemp\n' >&2
+        printf '[dune-local] repair: opam switch create 5.4.1 + opam install . --deps-only -y\n' >&2
+        printf '[dune-local] set MASC_SKIP_OCAML_VERSION_CHECK=1 to bypass this guard\n' >&2
+        exit 1
+      fi
+    fi
+  fi
+fi
+# -----------------------------------------------------------------------
+
 printf '[dune-local] DUNE_JOBS=%s DUNE_BUILD_DIR=%s\n' \
   "${DUNE_JOBS:-auto}" "${DUNE_BUILD_DIR:-_build}" >&2
 printf '[dune-local] command:' >&2

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -13,10 +13,14 @@ Local Dune wrapper for multi-agent development:
   - defaults local concurrency to DUNE_LOCAL_JOBS, or 2
   - injects --root <repo-root> unless --root is already present
   - asserts agent_sdk opam pin matches the repo SSOT before each build
+  - asserts core opam dependencies are installed in the active switch
+  - asserts OCaml is at or above the repo floor (5.4)
 
 Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
 Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
 Set MASC_SKIP_PIN_CHECK=1 to skip the agent_sdk pin guard.
+Set MASC_SKIP_DEPS_CHECK=1 to skip the core-deps installed guard.
+Set MASC_SKIP_OCAML_VERSION_CHECK=1 to skip the OCaml minimum version guard.
 USAGE
 }
 
@@ -138,15 +142,12 @@ fi
 # -----------------------------------------------------------------------
 
 # --- OCaml minimum version guard ---------------------------------------
-# Several lib/ call sites use stdlib APIs added in OCaml 5.1 (notably
-# [Unix.mkdtemp], used by test/test_dune_local_script.ml).  Building
-# under a 4.x switch surfaces as:
-#
-#   Error: Unbound value Unix.mkdtemp
-#   Hint: Did you mean Unix.mktime?
-#
-# which is the same misleading "did-you-mean" pattern the dependency
-# guard above protects against.  Fail fast with the explicit minimum.
+# dune-project line 28 and masc_mcp.opam line 14 both declare a 5.4
+# floor.  Older switches build the early lib/ deps fine but fail later
+# during opam dependency resolution or in stdlib calls added between
+# 5.1 and 5.4.  Catch the mismatch up-front so the error mentions the
+# real floor rather than the trailing symptom (e.g. an "Unbound value"
+# from a 5.4-only stdlib API).
 if [[ "${GITHUB_ACTIONS:-}" != "true" \
       && "${MASC_SKIP_OCAML_VERSION_CHECK:-0}" != "1" \
       && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
@@ -158,11 +159,14 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
       _major="${_ocaml_v%%.*}"
       _minor="${_ocaml_v##*.}"
       if [[ "${_major}" -lt 5 \
-            || ( "${_major}" -eq 5 && "${_minor}" -lt 1 ) ]]; then
-        printf '[dune-local] OCaml %s detected; this repo requires >= 5.1\n' \
+            || ( "${_major}" -eq 5 && "${_minor}" -lt 4 ) ]]; then
+        printf '[dune-local] OCaml %s detected; this repo requires >= 5.4 (dune-project:28, masc_mcp.opam:14)\n' \
           "${_ocaml_v}" >&2
-        printf '[dune-local] symptom under older switch: Error: Unbound value Unix.mkdtemp\n' >&2
-        printf '[dune-local] repair: opam switch create 5.4.1 + opam install . --deps-only -y\n' >&2
+        printf '[dune-local] symptom under older switch: opam dep resolution fails or stdlib API missing\n' >&2
+        printf '[dune-local] repair (run each line in turn):\n' >&2
+        printf '[dune-local]   opam switch create 5.4.1\n' >&2
+        printf '[dune-local]   eval $(opam env)\n' >&2
+        printf '[dune-local]   opam install . --deps-only -y\n' >&2
         printf '[dune-local] set MASC_SKIP_OCAML_VERSION_CHECK=1 to bypass this guard\n' >&2
         exit 1
       fi

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -309,6 +309,45 @@ let test_clean_subcommand_with_eq_flag_skips_pin_guard () =
         0 code;
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
+(* Codex-connector follow-ups (#13117, 2026-05-05):
+   - `--auto-promote` is a BOOLEAN common option (no arg).  Treating
+     it as value-taking made `--auto-promote clean` skip both tokens
+     and fall back to `build`.
+   - `-p PACKAGES` and `-x VAL` are SHORT value-taking common
+     options; the original `[[ "$a" == -* ]]` fallback consumed
+     only the flag and misread the value as the subcommand. *)
+let test_clean_subcommand_after_auto_promote_skips_pin_guard () =
+  with_temp_dir "dune-local-clean-auto-promote" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+          "--auto-promote clean"
+      in
+      check int
+        "`--auto-promote clean` (boolean flag, NOT value-taking) skips guards"
+        0 code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
+let test_clean_subcommand_after_short_packages_flag_skips_pin_guard () =
+  with_temp_dir "dune-local-clean-short-p" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+          "-p mypkg clean"
+      in
+      check int
+        "`-p mypkg clean` (short value-taking flag) skips guards"
+        0 code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_pin_ok_build_proceeds () =
   with_temp_dir "dune-local-pin-ok" (fun dir ->
       let bin_dir, dune_log =
@@ -476,6 +515,14 @@ let () =
             "`--display=quiet clean` (--flag=value before subcommand) skips \
              pin guard"
             `Quick test_clean_subcommand_with_eq_flag_skips_pin_guard;
+          test_case
+            "`--auto-promote clean` (boolean flag is NOT value-taking) skips \
+             pin guard"
+            `Quick test_clean_subcommand_after_auto_promote_skips_pin_guard;
+          test_case
+            "`-p mypkg clean` (short -p IS value-taking) skips pin guard"
+            `Quick
+            test_clean_subcommand_after_short_packages_flag_skips_pin_guard;
           test_case "pin OK allows build to proceed" `Quick
             test_pin_ok_build_proceeds;
           test_case "MASC_DUNE_DRY_RUN=1 skips pin check" `Quick

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -113,8 +113,18 @@ exit 0
       pin_check_exit_code
   in
   write_executable (Filename.concat scripts_dir "check-oas-pin.sh") pin_check_content;
-  (* Fake opam: just needs to be present in PATH *)
-  write_executable (Filename.concat bin_dir "opam") "#!/bin/sh\nexit 0\n";
+  (* Fake opam: present in PATH and echoes back the queried package
+     for `opam list --installed --short PKG` so the deps-installed
+     guard treats core deps (httpun/agent_sdk/...) as present.  Other
+     subcommands return 0 with empty stdout. *)
+  write_executable (Filename.concat bin_dir "opam")
+    {|#!/bin/sh
+if [ "$1" = "list" ] && [ "$2" = "--installed" ] && [ -n "$4" ]; then
+  printf '%s\n' "$4"; exit 0
+fi
+if [ "$1" = "switch" ] && [ "$2" = "show" ]; then printf 'fake-switch\n'; exit 0; fi
+exit 0
+|};
   (* Fake dune: log subcommand and exit 0 *)
   let dune_log = Filename.concat base "dune-calls.log" in
   write_executable
@@ -292,6 +302,121 @@ let test_dry_run_skips_pin_check () =
       check int "exits zero for dry run" 0 code;
       check bool "dune not actually invoked" false (Sys.file_exists dune_log))
 
+(* --- deps guard tests (#13117 review) ---------------------------------
+   Helper: fake a missing-deps environment by overriding [opam] in PATH
+   with one that responds to [list --installed --short <pkg>] with an
+   empty body (the case the guard is supposed to catch).  pin check
+   passes so the test isolates the deps-guard branch. *)
+
+let setup_repo_with_missing_deps base =
+  let bin_dir, dune_log = setup_fake_repo base ~pin_check_exit_code:0
+                            ~pin_check_stderr_msg:"" in
+  let opam_path = Filename.concat bin_dir "opam" in
+  let opam_script =
+    {|#!/bin/sh
+case "$1 $2 $3" in
+  "list --installed")
+    case "$5" in
+      *) ;;
+    esac
+    exit 0 ;;
+  "switch show "*) printf 'fake-switch\n' ;;
+esac
+exit 0
+|}
+  in
+  write_executable opam_path opam_script;
+  (bin_dir, dune_log)
+
+let test_missing_deps_aborts_build () =
+  with_temp_dir "dune-local-missing-deps" (fun dir ->
+    let bin_dir, dune_log = setup_repo_with_missing_deps dir in
+    let code, _stdout, stderr =
+      run_dune_local dir bin_dir
+        ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK"; "MASC_SKIP_DEPS_CHECK" ]
+        "build"
+    in
+    check int "exits non-zero on missing deps" 1 code;
+    check bool "missing deps message present" true
+      (contains_substring stderr "missing opam packages");
+    check bool "repair hint present" true
+      (contains_substring stderr "opam install . --deps-only");
+    check bool "skip hint present" true
+      (contains_substring stderr "MASC_SKIP_DEPS_CHECK=1");
+    check bool "dune not invoked" false (Sys.file_exists dune_log))
+
+let test_skip_deps_check_env_bypasses_guard () =
+  with_temp_dir "dune-local-skip-deps" (fun dir ->
+    let bin_dir, dune_log = setup_repo_with_missing_deps dir in
+    let code, _stdout, _stderr =
+      run_dune_local dir bin_dir
+        ~env:[ ("MASC_SKIP_DEPS_CHECK", "1") ]
+        ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+        "build"
+    in
+    check int "exits zero when MASC_SKIP_DEPS_CHECK=1" 0 code;
+    check bool "dune was invoked" true (Sys.file_exists dune_log))
+
+(* --- OCaml minimum version guard tests (#13117 review) ---------------- *)
+
+let setup_repo_with_old_ocaml base =
+  let bin_dir, dune_log = setup_fake_repo base ~pin_check_exit_code:0
+                            ~pin_check_stderr_msg:"" in
+  (* opam list --installed --short returns the dep so deps-guard passes;
+     we test the OCaml branch in isolation. *)
+  let opam_path = Filename.concat bin_dir "opam" in
+  let opam_script =
+    {|#!/bin/sh
+# Echo back the requested package name for `opam list --installed --short PKG`
+# (args: $1=list $2=--installed $3=--short $4=PKG) so the deps-installed
+# guard sees every package as present and we can isolate the OCaml-version
+# branch in this fixture.
+if [ "$1" = "list" ] && [ "$2" = "--installed" ] && [ -n "$4" ]; then
+  printf '%s\n' "$4"; exit 0
+fi
+if [ "$1" = "switch" ] && [ "$2" = "show" ]; then printf 'fake-switch\n'; exit 0; fi
+exit 0
+|}
+  in
+  write_executable opam_path opam_script;
+  (* Fake ocaml that reports an old version. *)
+  let ocaml_path = Filename.concat bin_dir "ocaml" in
+  write_executable ocaml_path
+    "#!/bin/sh\nif [ \"$1\" = \"-version\" ]; then printf 'The OCaml toplevel, version 5.0.0\\n'; fi\nexit 0\n";
+  (bin_dir, dune_log)
+
+let test_old_ocaml_aborts_build () =
+  with_temp_dir "dune-local-old-ocaml" (fun dir ->
+    let bin_dir, dune_log = setup_repo_with_old_ocaml dir in
+    let code, _stdout, stderr =
+      run_dune_local dir bin_dir
+        ~unset_env:
+          [ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK"
+          ; "MASC_SKIP_DEPS_CHECK"; "MASC_SKIP_OCAML_VERSION_CHECK" ]
+        "build"
+    in
+    check int "exits non-zero on old OCaml" 1 code;
+    check bool "OCaml version message present" true
+      (contains_substring stderr "OCaml 5.0 detected");
+    check bool "minimum 5.4 mentioned" true
+      (contains_substring stderr ">= 5.4");
+    check bool "skip hint present" true
+      (contains_substring stderr "MASC_SKIP_OCAML_VERSION_CHECK=1");
+    check bool "dune not invoked" false (Sys.file_exists dune_log))
+
+let test_skip_ocaml_version_env_bypasses_guard () =
+  with_temp_dir "dune-local-skip-ocaml" (fun dir ->
+    let bin_dir, dune_log = setup_repo_with_old_ocaml dir in
+    let code, _stdout, _stderr =
+      run_dune_local dir bin_dir
+        ~env:[ ("MASC_SKIP_OCAML_VERSION_CHECK", "1") ]
+        ~unset_env:
+          [ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK"; "MASC_SKIP_DEPS_CHECK" ]
+        "build"
+    in
+    check int "exits zero when MASC_SKIP_OCAML_VERSION_CHECK=1" 0 code;
+    check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let () =
   run "dune_local_script"
     [
@@ -311,5 +436,19 @@ let () =
             test_pin_ok_build_proceeds;
           test_case "MASC_DUNE_DRY_RUN=1 skips pin check" `Quick
             test_dry_run_skips_pin_check;
+        ] );
+      ( "deps_guard",
+        [
+          test_case "missing deps abort build with clear message" `Quick
+            test_missing_deps_aborts_build;
+          test_case "MASC_SKIP_DEPS_CHECK=1 bypasses deps guard" `Quick
+            test_skip_deps_check_env_bypasses_guard;
+        ] );
+      ( "ocaml_version_guard",
+        [
+          test_case "old OCaml aborts build with clear message" `Quick
+            test_old_ocaml_aborts_build;
+          test_case "MASC_SKIP_OCAML_VERSION_CHECK=1 bypasses ocaml guard"
+            `Quick test_skip_ocaml_version_env_bypasses_guard;
         ] );
     ]

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -272,6 +272,43 @@ let test_clean_subcommand_skips_pin_guard () =
       check int "exits zero for clean subcommand" 0 code;
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
+(* PR #13117 review (P2): the original guards checked args[0], so prefixing
+   global options like `--root .` before `clean` misclassified the call as
+   a non-clean target and ran pin/deps/ocaml-version guards on a target
+   that does not compile.  Pin the new subcommand-detection helper so
+   guard-skipping still kicks in. *)
+let test_clean_subcommand_with_global_flag_skips_pin_guard () =
+  with_temp_dir "dune-local-clean-flag" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+          "--root . clean"
+      in
+      check int
+        "exits zero for `--root . clean` even when pin guard would fail"
+        0 code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
+let test_clean_subcommand_with_eq_flag_skips_pin_guard () =
+  with_temp_dir "dune-local-clean-eq-flag" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+          "--display=quiet clean"
+      in
+      check int
+        "exits zero for `--display=quiet clean` even when pin guard would fail"
+        0 code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_pin_ok_build_proceeds () =
   with_temp_dir "dune-local-pin-ok" (fun dir ->
       let bin_dir, dune_log =
@@ -432,6 +469,13 @@ let () =
             test_opam_absent_skips_pin_guard;
           test_case "clean subcommand skips pin guard" `Quick
             test_clean_subcommand_skips_pin_guard;
+          test_case
+            "`--root . clean` (global flag before subcommand) skips pin guard"
+            `Quick test_clean_subcommand_with_global_flag_skips_pin_guard;
+          test_case
+            "`--display=quiet clean` (--flag=value before subcommand) skips \
+             pin guard"
+            `Quick test_clean_subcommand_with_eq_flag_skips_pin_guard;
           test_case "pin OK allows build to proceed" `Quick
             test_pin_ok_build_proceeds;
           test_case "MASC_DUNE_DRY_RUN=1 skips pin check" `Quick

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -363,6 +363,38 @@ let test_clean_subcommand_after_short_x_flag_skips_pin_guard () =
         code;
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
+let test_clean_subcommand_after_cache_storage_mode_skips_pin_guard () =
+  with_temp_dir "dune-local-clean-cache-storage-mode" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+          "--cache-storage-mode copy clean"
+      in
+      check int
+        "`--cache-storage-mode copy clean` (value-taking flag) skips guards"
+        0 code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
+let test_clean_subcommand_after_cache_check_probability_skips_pin_guard () =
+  with_temp_dir "dune-local-clean-cache-check-probability" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+          "--cache-check-probability 0.5 clean"
+      in
+      check int
+        "`--cache-check-probability 0.5 clean` (value-taking flag) skips guards"
+        0 code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_pin_ok_build_proceeds () =
   with_temp_dir "dune-local-pin-ok" (fun dir ->
       let bin_dir, dune_log =
@@ -541,6 +573,14 @@ let () =
           test_case
             "`-x dev clean` (short -x IS value-taking) skips pin guard"
             `Quick test_clean_subcommand_after_short_x_flag_skips_pin_guard;
+          test_case
+            "`--cache-storage-mode copy clean` skips pin guard"
+            `Quick
+            test_clean_subcommand_after_cache_storage_mode_skips_pin_guard;
+          test_case
+            "`--cache-check-probability 0.5 clean` skips pin guard"
+            `Quick
+            test_clean_subcommand_after_cache_check_probability_skips_pin_guard;
           test_case "pin OK allows build to proceed" `Quick
             test_pin_ok_build_proceeds;
           test_case "MASC_DUNE_DRY_RUN=1 skips pin check" `Quick

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -348,6 +348,21 @@ let test_clean_subcommand_after_short_packages_flag_skips_pin_guard () =
         0 code;
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
+let test_clean_subcommand_after_short_x_flag_skips_pin_guard () =
+  with_temp_dir "dune-local-clean-short-x" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let code, _stdout, _stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_SKIP_PIN_CHECK" ]
+          "-x dev clean"
+      in
+      check int "`-x dev clean` (short value-taking flag) skips guards" 0
+        code;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_pin_ok_build_proceeds () =
   with_temp_dir "dune-local-pin-ok" (fun dir ->
       let bin_dir, dune_log =
@@ -523,6 +538,9 @@ let () =
             "`-p mypkg clean` (short -p IS value-taking) skips pin guard"
             `Quick
             test_clean_subcommand_after_short_packages_flag_skips_pin_guard;
+          test_case
+            "`-x dev clean` (short -x IS value-taking) skips pin guard"
+            `Quick test_clean_subcommand_after_short_x_flag_skips_pin_guard;
           test_case "pin OK allows build to proceed" `Quick
             test_pin_ok_build_proceeds;
           test_case "MASC_DUNE_DRY_RUN=1 skips pin check" `Quick


### PR DESCRIPTION
## Quick repair (read first if you hit the build error today)

Run in the repo root:

```bash
opam install . --deps-only -y
```

If you also see `Unix.mkdtemp` errors, your active switch is OCaml < 5.1.
Create a 5.4 switch:

```bash
opam switch create 5.4.1 ocaml-base-compiler.5.4.1
opam install . --deps-only -y
```

This PR adds guards so the next operator hitting the same state gets
the repair command upfront instead of decoding a 30-line abstract-cmi
trace.

## Summary

`scripts/dune-local.sh` gains two pre-Dune guards:

1. **Core opam-deps installed guard.** Aborts when any of `httpun`,
   `httpun-eio`, `httpun-ws`, `agent_sdk` are declared but not
   installed in the active switch. Prints the exact `opam install . --deps-only -y` repair line.
2. **OCaml minimum-version guard.** Aborts when `ocaml -version` < 5.1
   (the version that introduced `Unix.mkdtemp`, used by
   `test/test_dune_local_script.ml`).

Both guards share the existing skip envelope
(`GITHUB_ACTIONS=true` / `MASC_DUNE_DRY_RUN=1` / `subcommand == clean`)
plus per-guard opt-outs (`MASC_SKIP_DEPS_CHECK=1`,
`MASC_SKIP_OCAML_VERSION_CHECK=1`).

## Why

The pasted symptom set:

```
File "lib/server/server_routes_http_routes_credentials.ml", line 371...
       Type Httpun.Method.t is abstract because no corresponding cmi
       file was found in path.

File "test/test_dune_local_script.ml", line 50...
       Error: Unbound value Unix.mkdtemp
       Hint:   Did you mean Unix.mktime?

File "lib/server/server_routes_http_pages.ml", line 450...
       Type Httpun.Status.t is abstract because no corresponding cmi
       file was found in path.
```

is the textbook outcome of building with declared-but-not-installed
opam packages (or a sub-5.1 OCaml). The existing `agent_sdk pin`
guard checks pin SHA, not install state, so it misses this case.
Hardcoded list covers the four packages whose absence produces the
worst error spew; full validation belongs to opam itself.

## Files

- `scripts/dune-local.sh` (+79 / -0): two new guard blocks between
  the existing `agent_sdk pin guard` and the `printf DUNE_JOBS=` line.

`scripts/ci-run-tests.sh` already wraps `dune-local.sh` at line 21-25,
so no change needed there.

## Local verification

In a switch where `agent_sdk` is pinned but not installed:

```
$ MASC_SKIP_PIN_CHECK=1 bash scripts/dune-local.sh build @lib/check
[dune-local] missing opam packages in switch 5.4.1: agent_sdk
[dune-local] symptom you would otherwise see:
[dune-local]   Error: Unbound module <Pkg>
[dune-local]   Type <Pkg>.<T>.t is abstract because no corresponding cmi file...
[dune-local] repair: opam install . --deps-only -y
[dune-local] set MASC_SKIP_DEPS_CHECK=1 to bypass this guard
```

Exit 1 fired before Dune was invoked — the operator sees the repair
command, not the cryptic abstract-cmi spew.

`bash -n scripts/dune-local.sh` → syntax OK.

## Self-review (Best Programmer baseline)

- **Goal**: turn a recurring 30-line build-error decode into a one-line
  repair instruction.
- **Files**: 1 file, comment-rich shell, single concern.
- **Testing**: manual repro under both states (deps installed → guard
  passes; deps missing → guard aborts with repair line).
- **Untested**: OCaml < 5.1 path (no convenient downgrade switch
  available locally). Logic mirrors the deps guard's structure; the
  version comparison is straightforward shell arithmetic.

## Test plan

- [ ] Reviewer runs `bash scripts/dune-local.sh build @lib/check` in
      a switch with deps fully installed → guard reports OK and Dune
      runs.
- [ ] Reviewer (optionally) creates a temp switch with only the pin
      declarations and re-runs; expects the deps guard to fire with
      the repair line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>