### PR TITLE
fix: bound keeper autoboot warmup jitter

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -496,7 +496,7 @@ let keeper_bootstrap_stagger_step_sec_rp =
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_STAGGER_STEP_SEC"
                           ~default:15 ~min_v:0 ~max_v:120)
     ~min_v:0 ~max_v:120
-    ~description:"Bootstrap stagger interval between keepers (seconds)" ()
+    ~description:"Bootstrap warmup deterministic jitter window (seconds)" ()
 let keeper_bootstrap_stagger_step_sec () : int =
   Runtime_params.get keeper_bootstrap_stagger_step_sec_rp
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -6,6 +6,26 @@
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
   Governance_pipeline.install ~config:state.room_config ~governance_level
 
+let stable_keeper_name_hash name =
+  let acc = ref 5381 in
+  String.iter
+    (fun ch ->
+      acc := (((!acc lsl 5) + !acc) + Char.code ch) land max_int)
+    name;
+  !acc
+
+let autoboot_proactive_warmup_sec ~base_warmup ~stagger_window_sec ~keeper_name =
+  let base_warmup = max 0 base_warmup in
+  let stagger_window_sec = max 0 stagger_window_sec in
+  if stagger_window_sec = 0 then base_warmup
+  else
+    base_warmup
+    + (stable_keeper_name_hash keeper_name mod (stagger_window_sec + 1))
+
+module For_testing = struct
+  let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
+end
+
 let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     (state : Mcp_server.server_state) =
   Progress.set_sse_callback Sse.broadcast;
@@ -637,9 +657,9 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         (List.length names) Keeper_keepalive.keeper_turn_throttle_limit;
       Log.Keeper.info "autoboot: keeper set [%s]" (String.concat ", " names);
       let base_warmup = Keeper_config.keeper_bootstrap_proactive_warmup_sec () in
-      let stagger_step = Keeper_config.keeper_bootstrap_stagger_step_sec () in
+      let stagger_window = Keeper_config.keeper_bootstrap_stagger_step_sec () in
       (* Attempt to boot a single keeper. Returns true if started. *)
-      let try_boot_one idx name =
+      let try_boot_one _idx name =
         try
           Log.Keeper.info "autoboot: loading meta for %s" name;
           match Keeper_runtime.load_or_materialize_boot_meta keeper_boot_ctx name with
@@ -654,7 +674,10 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                 (if materialized then " (materialized from TOML)" else "");
               true
             ) else begin
-              let warmup = base_warmup + (idx * stagger_step) in
+              let warmup =
+                autoboot_proactive_warmup_sec ~base_warmup
+                  ~stagger_window_sec:stagger_window ~keeper_name:name
+              in
               Log.Keeper.info "autoboot: calling start_keepalive for %s (warmup=%ds)"
                 name warmup;
               let ctx : _ Keeper_types.context = {

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -6,11 +6,23 @@
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
   Governance_pipeline.install ~config:state.room_config ~governance_level
 
+(* Stable djb2-style hash for the autoboot warmup jitter.
+
+   The 0x3FFF_FFFF mask (30 bits) is intentional — using OCaml's
+   [max_int] would tie the result to the platform [int] width
+   (31-bit on 32-bit OCaml, 63-bit on 64-bit OCaml), so the same
+   keeper name would warm up at different offsets depending on
+   architecture.  The 30-bit mask gives ~1G distinct buckets, far
+   more than any realistic [stagger_window_sec], and is identical
+   on every supported runtime. *)
+let stable_keeper_name_hash_mask = 0x3FFF_FFFF
+
 let stable_keeper_name_hash name =
   let acc = ref 5381 in
   String.iter
     (fun ch ->
-      acc := (((!acc lsl 5) + !acc) + Char.code ch) land max_int)
+      acc :=
+        (((!acc lsl 5) + !acc) + Char.code ch) land stable_keeper_name_hash_mask)
     name;
   !acc
 

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -24,6 +24,11 @@ val start_keeper_loops :
     fibers under [sw].  Each fiber is bound to the switch so a graceful
     shutdown cancels them in order. *)
 
+module For_testing : sig
+  val autoboot_proactive_warmup_sec :
+    base_warmup:int -> stagger_window_sec:int -> keeper_name:string -> int
+end
+
 val start_background_maintenance :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -24,6 +24,7 @@
 open Alcotest
 
 module KB = Env_config_keeper.KeeperBootstrap
+module Boot = Masc_mcp.Server_bootstrap_loops.For_testing
 
 let approx = float 0.001
 
@@ -60,6 +61,48 @@ let test_smoke_call_sites_compile () =
   let _ = KB.post_startup_settle_sec in
   check bool "all three accessors are reachable" true true
 
+let test_autoboot_warmup_jitter_is_bounded_not_linear () =
+  let names =
+    [
+      "analyst";
+      "executor";
+      "glm-coding-plan";
+      "issue_king";
+      "janitor";
+      "masc-improver";
+      "nick0cave";
+      "qa-king";
+      "ramarama";
+      "sangsu";
+      "scholar";
+      "taskmaster";
+      "velvet-hammer";
+      "verifier";
+    ]
+  in
+  let warmups =
+    List.map
+      (fun keeper_name ->
+        Boot.autoboot_proactive_warmup_sec ~base_warmup:60
+          ~stagger_window_sec:15 ~keeper_name)
+      names
+  in
+  check bool "every warmup stays inside the 60..75s jitter window" true
+    (List.for_all (fun value -> value >= 60 && value <= 75) warmups);
+  check bool "last keeper is not delayed by list position" true
+    (List.nth warmups 13 <= 75)
+
+let test_autoboot_warmup_is_order_independent () =
+  let warmup name =
+    Boot.autoboot_proactive_warmup_sec ~base_warmup:60 ~stagger_window_sec:15
+      ~keeper_name:name
+  in
+  check int "same keeper gets same warmup independent of boot order"
+    (warmup "verifier") (warmup "verifier");
+  check int "zero jitter keeps exact base warmup" 60
+    (Boot.autoboot_proactive_warmup_sec ~base_warmup:60
+       ~stagger_window_sec:0 ~keeper_name:"verifier")
+
 let () =
   run "env_config_keeper_bootstrap_intervals"
     [
@@ -81,5 +124,12 @@ let () =
         [
           test_case "all three accessors reachable" `Quick
             test_smoke_call_sites_compile;
+        ] );
+      ( "autoboot warmup fairness",
+        [
+          test_case "jitter bounded, not linear by boot order" `Quick
+            test_autoboot_warmup_jitter_is_bounded_not_linear;
+          test_case "warmup deterministic per keeper" `Quick
+            test_autoboot_warmup_is_order_independent;
         ] );
     ]

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -97,11 +97,46 @@ let test_autoboot_warmup_is_order_independent () =
     Boot.autoboot_proactive_warmup_sec ~base_warmup:60 ~stagger_window_sec:15
       ~keeper_name:name
   in
+  (* PR #13119 review: previously this test called [warmup "verifier"]
+     twice with identical inputs, which would still pass even if the
+     implementation depended on list position.  The actual invariant
+     is "permuting the keeper boot list does not change any individual
+     keeper's warmup".  Compute warmups for an ordered name list and
+     for its reverse, then assert per-name equality. *)
+  let names = [
+    "verifier"; "designer"; "developer"; "operator"; "supervisor";
+    "tester"; "auditor"; "researcher"; "writer"; "scheduler";
+  ] in
+  let warmups_forward = List.map (fun n -> (n, warmup n)) names in
+  let warmups_reverse = List.map (fun n -> (n, warmup n)) (List.rev names) in
+  List.iter
+    (fun (name, w_fwd) ->
+      let w_rev = List.assoc name warmups_reverse in
+      check int
+        (Printf.sprintf "%s gets identical warmup regardless of list position"
+           name)
+        w_fwd w_rev)
+    warmups_forward;
   check int "same keeper gets same warmup independent of boot order"
     (warmup "verifier") (warmup "verifier");
   check int "zero jitter keeps exact base warmup" 60
     (Boot.autoboot_proactive_warmup_sec ~base_warmup:60
-       ~stagger_window_sec:0 ~keeper_name:"verifier")
+       ~stagger_window_sec:0 ~keeper_name:"verifier");
+  (* Coverage smoke: the test assumes the hash actually distributes
+     names across the stagger window — if every name collapsed to
+     a single offset the previous "no list-position dependency"
+     check would degenerate to a tautology.  Assert ≥3 distinct
+     warmup values across the 10-name list (with stagger=15 the
+     hash buckets collide naturally; ≥3 still proves the hash is
+     producing a non-trivial distribution). *)
+  let distinct =
+    warmups_forward
+    |> List.map snd
+    |> List.sort_uniq compare
+    |> List.length
+  in
+  check bool "stagger produces ≥3 distinct warmups across 10 names" true
+    (distinct >= 3)
 
 let () =
   run "env_config_keeper_bootstrap_intervals"


### PR DESCRIPTION
## Summary

This ACT slice fixes the GOAL LOOP autoboot warmup finding where keeper boot order turned the default warmup into a linear delay chain (`60s, 75s, ... 255s`).

The bootstrap path now computes proactive warmup as `base_warmup + deterministic_jitter(keeper_name)` inside the configured stagger window, instead of `base_warmup + idx * stagger_step`. The existing runtime parameter is preserved, but its description now reflects the safer behavior: a bounded deterministic jitter window.

## Why It Matters

Boot order should not decide which keeper gets to observe board events and take proactive turns first. With the old formula, the last keeper in a 14-keeper boot list waited more than four minutes before it could act. With the default `base=60` and `window=15`, every keeper lands in `60..75s`, independent of list position.

## Changes

- Added a stable keeper-name hash helper for order-independent warmup jitter.
- Replaced `idx * stagger_step` warmup growth in `server_bootstrap_loops.ml`.
- Exposed the pure warmup helper through `Server_bootstrap_loops.For_testing`.
- Added a regression covering the 14 keeper names from the live log and asserting the window stays bounded.

## Validation

- PASS: `git diff --check origin/main...HEAD`
- PASS: source proof grep confirmed the old `idx * stagger` path is gone and the new bounded helper is used.
- BLOCKED: `scripts/dune-local.sh build test/test_env_config_keeper_bootstrap_intervals.exe` did not reach the test. The local shared opam install is missing `agent_sdk` artifacts such as `/Users/dancer/.opam/5.4.1/lib/agent_sdk/agent_sdk__Api_anthropic.cmi` and many related `.cmi/.cmx` files. I did not repair the shared switch because other Dune builds are active.