### PR TITLE
test: bind remaining domain aliases explicitly

### DIFF
--- a/lib/types/types.mli
+++ b/lib/types/types.mli
@@ -1,0 +1,9 @@
+(** Backward-compatible [Types] facade.
+
+    This module intentionally mirrors {!Masc_domain}; it exists for legacy
+    callers that still import [Types] while the domain surface lives in the
+    explicit {!Masc_domain} facade. *)
+
+include module type of struct
+  include Masc_domain
+end

--- a/test/test_briefing_compactors.ml
+++ b/test/test_briefing_compactors.ml
@@ -35,7 +35,7 @@
        - capabilities list capped at 2 (take 2). *)
 
 module C = Masc_mcp.Briefing_compactors
-module T = Types
+module T = Masc_domain
 
 (* ── Fixtures ──────────────────────────────────────────────── *)
 

--- a/test/test_task_completion_path_10449.ml
+++ b/test/test_task_completion_path_10449.ml
@@ -7,7 +7,7 @@
 open Alcotest
 module CT = Masc_mcp.Coord
 module L = Coord_task_lifecycle
-module T = Types
+module T = Masc_domain
 
 let empty_links : T.task_execution_links = {
   operation_id = None;

--- a/test/test_task_status_label_10421.ml
+++ b/test/test_task_status_label_10421.ml
@@ -8,7 +8,7 @@
 
 open Alcotest
 module C = Masc_mcp.Coord
-module T = Types
+module T = Masc_domain
 
 let check_label expected status =
   check string ("label of " ^ expected) expected


### PR DESCRIPTION
## Summary

- Bind the remaining domain-status tests to `Masc_domain` instead of ambiguous `Types`.
- Add the thin `lib/types/types.mli` facade so the follow-up stays within the OCaml structure ratchet baseline.
- Keeps the #13078 follow-up diff limited to CI compile/ratchet fallout from the keeper durable-signal fix.

## Why this matters

PR #13078 was merged while the manual full CI Health job still showed stale test aliases. These tests exercise MASC task/status/domain records; resolving `Types` through the current SDK namespace produces compile errors such as unbound `task_execution_links` and `Claimed`.

The manual full CI also surfaced `lib_other_mli_missing: 2 > baseline 1`. `types_core.ml` remains the existing baseline debt; the newly exposed `Types` compatibility facade needed its sibling `.mli` to keep the ratchet at 1.

## Validation

- `git diff --check --cached` passed before commit amend.
- `scripts/ocaml-structure-ratchet.sh` passed.
- `scripts/stringly-boundary-ratchet.sh` passed.
- `rg "module T = Types" test -n` returned no matches before the follow-up commit.
- Local focused Dune was attempted, but `scripts/dune-local.sh` correctly aborted because the shared opam switch is pinned to `agent_sdk` `16678b81...` while this repo expects `86a0e540...`; leaving this to PR CI avoids mutating the shared switch mid-session.

## Review focus

- Confirm the three aliases are genuinely MASC domain types.
- Confirm `Types.mli` mirrors `Masc_domain` without narrowing or widening the legacy facade.
- Confirm the PR remains a narrow compile/ratchet follow-up to #13078.
