### PR TITLE
Fix heuristic metrics late init buffering

### DIFF
--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -100,6 +100,7 @@ let buffer_cap = 64
    30 s default stand. *)
 let flush_interval_sec_ref = ref 30.0
 let last_flush_ref = ref 0.0
+let uninitialized_record_warned_ref = ref false
 
 let set_flush_interval_for_test sec = flush_interval_sec_ref := sec
 
@@ -108,6 +109,7 @@ let set_flush_interval_for_test sec = flush_interval_sec_ref := sec
 let reset_for_test () =
   Stdlib.Mutex.protect mu (fun () ->
     store_path_ref := None;
+    uninitialized_record_warned_ref := false;
     Queue.clear buffer;
     (* Initialize the clock to "now" rather than 0.0 so tests that pin a
        large flush interval can verify batching without the [now -.
@@ -149,6 +151,14 @@ let do_flush () =
   (* #10348: bump last_flush even on no-op / failed open so the time-based
      re-evaluation in [record] doesn't hammer this path on every event. *)
   last_flush_ref := Unix.gettimeofday ()
+
+let warn_uninitialized_record_once () =
+  if not !uninitialized_record_warned_ref then begin
+    uninitialized_record_warned_ref := true;
+    Log.warn ~ctx:"heuristic_metrics"
+      "record called before init; buffering metric events until init \
+       installs a base_path"
+  end
 
 (* #9919: the pre-fix emit at [keeper_hooks_oas.post_tool_use_failure]
    produced an exact tuple [(site="post_tool_use_failure", raw=1.0,
@@ -232,10 +242,12 @@ let init ~base_path =
       let masc_dir = Coord_utils.masc_dir_from_base_path ~base_path in
       let path = Filename.concat masc_dir "heuristic_metrics.jsonl" in
       let _ = scrub_legacy_degenerate_rows path in
-      store_path_ref := Some path)
+      store_path_ref := Some path;
+      if not (Queue.is_empty buffer) then do_flush ())
 
 let record (e : event) =
   Stdlib.Mutex.protect mu (fun () ->
+    if !store_path_ref = None then warn_uninitialized_record_once ();
     let json = event_to_json e in
     Queue.add json buffer;
     let now = Unix.gettimeofday () in

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -46,7 +46,9 @@ type coverage_report = {
 }
 
 val record : event -> unit
-(** Append a metric event.  Thread-safe.  No-op if storage is not initialized. *)
+(** Append a metric event.  Thread-safe.  If storage is not initialized yet,
+    the event is buffered in memory and a warning is emitted once; a later
+    {!init} flushes the pending buffer to the resolved store. *)
 
 val init : base_path:string -> unit
 (** Initialize the JSONL store under [base_path/.masc/heuristic_metrics.jsonl].

--- a/test/test_heuristic_metrics_periodic_flush_10348.ml
+++ b/test/test_heuristic_metrics_periodic_flush_10348.ml
@@ -85,6 +85,21 @@ let test_large_interval_still_batches () =
   HM.flush ();
   Alcotest.(check int) "explicit flush still works" 1 (count_lines path)
 
+(* Audit regression: [record] before [init] used to leave data only in the
+   volatile in-memory buffer, with no warning and no flush when [init] finally
+   installed the store path.  Late init must make already-buffered rows durable. *)
+let test_late_init_flushes_preinit_buffer () =
+  let base = tmp_base () in
+  HM.reset_for_test ();
+  HM.set_flush_interval_for_test 1e9;
+  HM.record (make_event ~site:"preinit");
+  let path = ledger_path base in
+  Alcotest.(check int) "pre-init record is not durable yet" 0
+    (count_lines path);
+  HM.init ~base_path:base;
+  Alcotest.(check int) "late init flushes buffered record" 1
+    (count_lines path)
+
 let () =
   Random.self_init ();
   Alcotest.run "heuristic_metrics_periodic_flush_10348" [
@@ -95,5 +110,7 @@ let () =
         `Quick test_multiple_records_below_cap;
       Alcotest.test_case "large interval batches; explicit flush works"
         `Quick test_large_interval_still_batches;
+      Alcotest.test_case "late init flushes pre-init buffer"
+        `Quick test_late_init_flushes_preinit_buffer;
     ];
   ]


### PR DESCRIPTION
## Summary

- warn once when `Heuristic_metrics.record` is called before storage is initialized
- flush any buffered pre-init metric events immediately when `init ~base_path` installs the durable store
- add a regression test for `record` before `init`, followed by late `init`

## Why

The audit flagged `heuristic_metrics.ml` as silently losing signal when `init` is missed or delayed. Current behavior buffered the JSON in memory but did not surface the state or flush the buffer when `init` eventually supplied the store path. This made callers believe metrics were being persisted while dashboard reads could still see no rows.

This PR keeps the existing base-path ownership model: `record` still does not guess a filesystem root. Instead, it makes the pre-init state visible and makes late initialization durable.

## Validation

- PASS: `git diff --check`
- NOT RUN: `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_heuristic_metrics_periodic_flush_10348.exe`
  - Local blocker: the shared opam switch was actively locked by `opam install --yes mcp_protocol agent_sdk ocaml-webrtc grpc-direct-core grpc-direct neo4j_packstream neo4j_bolt_common neo4j_bolt neo4j_bolt_eio` during the validation window, after earlier focused MASC builds failed with `Agent_sdk` / `Llm_provider` / `Types` CMI inconsistency from the same switch churn.