### PR TITLE
fix(keeper): wake alive-stuck keepers

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -145,6 +145,7 @@ the categorization roadmap (`@category` tags are a follow-up).
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | 128 |  |
 | `MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC` | typed:float | 253 |  |
 | `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` | typed:bool | 232 | Detection-only signal for alive-but-stuck keepers (#12838) — keepers that are not Dead/Zombie and not paused, but w... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED` | typed:bool | 238 | Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits.  The recovery uses the Event Layer queue plus [fi... |
 | `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC` | typed:float | 246 |  |
 | `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER` | typed:int | 238 | Multiplier on the keeper's own [proactive.cooldown_sec] before a stalled keeper is flagged.  Default: 10 (10 cooldown... |
 | `MASC_KEEPER_AUTONOMOUS_QUEUE_POLL_SEC` | typed:float | 292 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -223,13 +223,19 @@ module KeeperSupervisor = struct
   let liveness_recovery_max_attempts =
     max 1 (get_int ~default:5 "MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS")
 
-  (** Detection-only signal for alive-but-stuck keepers (#12838) —
+  (** Signal for alive-but-stuck keepers (#12838) —
       keepers that are not Dead/Zombie and not paused, but whose
       [proactive_rt.last_ts] has been frozen while autonomous turns
-      keep advancing.  Defaults to enabled because emission is a
-      Prometheus counter only (no board posts, no transitions). *)
+      keep advancing. *)
   let alive_but_stuck_enabled =
     get_bool ~default:true "MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED"
+
+  (** Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits.
+      The recovery uses the Event Layer queue plus [fiber_wakeup]; it does
+      not restart the keeper or create a board post.  Dedup is still bounded
+      by [alive_but_stuck_dedup_ttl_sec].  Default: true. *)
+  let alive_but_stuck_recovery_enabled =
+    get_bool ~default:true "MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED"
 
   (** Multiplier on the keeper's own [proactive.cooldown_sec] before a
       stalled keeper is flagged.  Default: 10 (10 cooldowns elapsed

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -75,9 +75,13 @@ module KeeperSupervisor : sig
   (** Maximum total liveness recovery attempts per keeper. *)
 
   val alive_but_stuck_enabled : bool
-  (** #12838 Detection-only scan for alive-but-stuck keepers
+  (** #12838 Scan for alive-but-stuck keepers
       (proactive_rt.last_ts frozen while autonomous turns advance).
-      Default: true (counter only, no transitions). *)
+      Default: true. *)
+
+  val alive_but_stuck_recovery_enabled : bool
+  (** Queue a bounded Event Layer wakeup for each deduped
+      alive-but-stuck detection. Default: true. *)
 
   val alive_but_stuck_stall_multiplier : int
   (** Multiplier on the keeper's [proactive.cooldown_sec] before

--- a/lib/keeper/keeper_event_queue.ml
+++ b/lib/keeper/keeper_event_queue.ml
@@ -55,18 +55,25 @@ let sort_by_urgency (queue : t) : t =
 type stimulus_class =
   | Board_signal
   | Bootstrap
+  | Alive_but_stuck_recovery
   | Unsupported of string
 
 let classify (s : stimulus) : stimulus_class =
+  let has_prefix prefix =
+    let payload_len = String.length s.payload in
+    let prefix_len = String.length prefix in
+    payload_len >= prefix_len
+    && String.equal (String.sub s.payload 0 prefix_len) prefix
+  in
   if String.equal s.payload "Keeper bootstrap signal" then Bootstrap
+  else if has_prefix "{\"source\":\"alive_but_stuck_recovery\"" then
+    Alive_but_stuck_recovery
+  (* Board signals carry JSON with "source":"board_signal". Lightweight
+     prefix check avoids a full Yojson parse in the data layer. *)
+  else if has_prefix "{\"source\":\"board_signal\"" then Board_signal
   else
-    (* Board signals carry JSON with "source":"board_signal". Lightweight
-       prefix check avoids a full Yojson parse in the data layer. *)
-    if String.starts_with ~prefix:"{\"source\":\"board_signal\"" s.payload
-    then Board_signal
-    else
-      Unsupported
-        (String.sub s.payload 0 (min 40 (String.length s.payload)))
+    Unsupported
+      (String.sub s.payload 0 (min 40 (String.length s.payload)))
 
 let summary (queue : t) : string =
   Printf.sprintf "%d stimulus%s pending"

--- a/lib/keeper/keeper_event_queue.mli
+++ b/lib/keeper/keeper_event_queue.mli
@@ -62,6 +62,8 @@ val summary : t -> string
 type stimulus_class =
   | Board_signal   (** JSON payload with {"source":"board_signal", ...} *)
   | Bootstrap      (** Plain string "Keeper bootstrap signal" *)
+  | Alive_but_stuck_recovery
+      (** JSON payload with {"source":"alive_but_stuck_recovery", ...} *)
   | Unsupported of string  (** Unrecognized: payload prefix (max 40 chars) for audit *)
 
 val classify : stimulus -> stimulus_class

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -416,6 +416,7 @@ let run_keepalive_unified_turn
               match Keeper_event_queue.classify stim with
               | Board_signal -> "board_signal"
               | Bootstrap -> "bootstrap"
+              | Alive_but_stuck_recovery -> "alive_but_stuck_recovery"
               | Unsupported _ -> "unsupported"
             in
             Prometheus.inc_counter
@@ -435,6 +436,11 @@ let run_keepalive_unified_turn
                  Log.Keeper.info
                    "turn entry: bootstrap stimulus consumed (keeper=%s)"
                    meta_after_triage.name;
+                 None
+             | Alive_but_stuck_recovery ->
+                 Log.Keeper.warn
+                   "turn entry: alive-but-stuck recovery stimulus consumed post_id=%s (keeper=%s)"
+                   stim.post_id meta_after_triage.name;
                  None
              | Unsupported prefix ->
                  Prometheus.inc_counter

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -438,7 +438,14 @@ let run_keepalive_unified_turn
                    meta_after_triage.name;
                  None
              | Alive_but_stuck_recovery ->
-                 Log.Keeper.warn
+                 (* PR #13123 review: the supervisor already emits a
+                    [Log.Keeper.warn] when it detects + enqueues this
+                    recovery stimulus.  Logging another warn on the
+                    consumer side doubled the alert volume for the
+                    same event.  Demote to [info]: this is just a
+                    confirmation that the wakeup arrived, not a new
+                    signal worth alerting on. *)
+                 Log.Keeper.info
                    "turn entry: alive-but-stuck recovery stimulus consumed post_id=%s (keeper=%s)"
                    stim.post_id meta_after_triage.name;
                  None

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -756,8 +756,8 @@ let start_supervisor_sweep ctx =
           (* #12838 Alive-but-stuck detector: emit a Prometheus counter
              (and a warn log) for keepers that are alive in every other
              health metric but have a frozen [proactive_rt.last_ts] while
-             autonomous turns keep advancing.  Detection-only — no
-             transition or restart is triggered. *)
+             autonomous turns keep advancing.  Running keepers also receive
+             a deduped Event Layer recovery wakeup; no restart is triggered. *)
           (try Keeper_supervisor.alive_but_stuck_scan ctx
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Prometheus.inc_counter

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -67,6 +67,8 @@ let key_to_env =
     "supervisor.backoff_base_sec",      "MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S";
     "supervisor.backoff_max_sec",       "MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S";
     "supervisor.sweep_sec",             "MASC_KEEPER_SUPERVISOR_SWEEP_SEC";
+    "supervisor.alive_but_stuck_recovery_enabled",
+                                        "MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED";
     (* [lifecycle] *)
     "lifecycle.self_preservation_ratio","MASC_KEEPER_SELF_PRESERVATION_RATIO";
     "lifecycle.self_preservation_min",  "MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES";

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1813,7 +1813,8 @@ let alive_but_stuck_scan (ctx : _ context) =
             entry.meta.runtime.autonomous_turn_count
             entry.meta.runtime.proactive_rt.count_total
             recovery;
-          request_alive_but_stuck_recovery ~base_path ~elapsed entry
+          if String.equal recovery "queued" then
+            request_alive_but_stuck_recovery ~base_path ~elapsed entry
         end
     ) entries
   end

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1601,9 +1601,10 @@ let liveness_recovery_scan (ctx : _ context) =
 
    This detector emits a Prometheus counter and requests a supervised
    restart through the same [failure_reason + fiber_stop] path as the
-   stale watchdog.  The next sweep can then force unresolved
-   watchdog-stopped entries into the normal crash/restart pipeline
-   instead of leaving the keeper at detection-only.
+   stale watchdog.  It also queues an Event Layer recovery wakeup so the
+   wake path is visible as structured stimulus.  The next sweep can then
+   force unresolved watchdog-stopped entries into the normal crash/restart
+   pipeline instead of leaving the keeper at detection-only.
    ────────────────────────────────────────────────────────────────── *)
 
 (** Pure detection: is this keeper alive-but-stuck at [now]?
@@ -1658,6 +1659,50 @@ let alive_but_stuck_should_emit ~now ~dedup_ttl_sec name =
     | _ ->
       Hashtbl.replace alive_but_stuck_last_alert name now;
       true)
+
+let alive_but_stuck_threshold ~stall_multiplier ~stall_floor_sec
+    (entry : Keeper_registry.registry_entry) =
+  Float.max stall_floor_sec
+    (float_of_int entry.meta.proactive.cooldown_sec
+     *. float_of_int stall_multiplier)
+
+let alive_but_stuck_recovery_stimulus ~now ~elapsed ~threshold
+    (entry : Keeper_registry.registry_entry) : Keeper_event_queue.stimulus =
+  let payload =
+    `Assoc [
+      "source", `String "alive_but_stuck_recovery";
+      "keeper", `String entry.name;
+      "elapsed_sec", `Float elapsed;
+      "threshold_sec", `Float threshold;
+      "autonomous_turns", `Int entry.meta.runtime.autonomous_turn_count;
+      "proactive_count_total", `Int entry.meta.runtime.proactive_rt.count_total;
+      "message",
+      `String
+        "supervisor detected a frozen scheduled-autonomous timestamp; run a recovery cycle";
+    ]
+    |> Yojson.Safe.to_string
+  in
+  {
+    Keeper_event_queue.post_id = "alive-but-stuck:" ^ entry.name;
+    urgency = Keeper_event_queue.Immediate;
+    arrived_at = now;
+    payload;
+  }
+
+let queue_alive_but_stuck_recovery ~base_path ~now ~elapsed ~threshold
+    (entry : Keeper_registry.registry_entry) =
+  if not Env_config.KeeperSupervisor.alive_but_stuck_recovery_enabled then
+    "disabled"
+  else if entry.phase <> Keeper_state_machine.Running then
+    "skipped_not_running"
+  else begin
+    let stimulus =
+      alive_but_stuck_recovery_stimulus ~now ~elapsed ~threshold entry
+    in
+    Keeper_registry.enqueue_event ~base_path entry.name stimulus;
+    Keeper_registry.wakeup ~base_path entry.name;
+    "queued"
+  end
 
 (** Test-only: clear the dedup table so each test case starts fresh. *)
 let alive_but_stuck_reset_for_test () =
@@ -1746,19 +1791,28 @@ let alive_but_stuck_scan (ctx : _ context) =
       | None -> ()
       | Some elapsed ->
         if alive_but_stuck_should_emit ~now ~dedup_ttl_sec entry.name then begin
+          let threshold =
+            alive_but_stuck_threshold ~stall_multiplier ~stall_floor_sec entry
+          in
+          let recovery =
+            queue_alive_but_stuck_recovery ~base_path ~now ~elapsed
+              ~threshold entry
+          in
           Prometheus.inc_counter
             Prometheus.metric_keeper_alive_but_stuck
             ~labels:[("keeper", entry.name)]
             ();
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_alive_but_stuck_recovery
+            ~labels:[("keeper", entry.name); ("outcome", recovery)]
+            ();
           Log.Keeper.warn
             "%s: alive-but-stuck detected (elapsed=%.0fs, threshold=%.0fs, \
-             autonomous_turns=%d, proactive_count_total=%d)"
-            entry.name elapsed
-            (Float.max stall_floor_sec
-               (float_of_int entry.meta.proactive.cooldown_sec
-                *. float_of_int stall_multiplier))
+             autonomous_turns=%d, proactive_count_total=%d, recovery=%s)"
+            entry.name elapsed threshold
             entry.meta.runtime.autonomous_turn_count
-            entry.meta.runtime.proactive_rt.count_total;
+            entry.meta.runtime.proactive_rt.count_total
+            recovery;
           request_alive_but_stuck_recovery ~base_path ~elapsed entry
         end
     ) entries

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -112,7 +112,8 @@ val alive_but_stuck_scan : 'a context -> unit
     alive-but-stuck, emit one [metric_keeper_alive_but_stuck] counter
     increment and a single warn log line, with per-keeper dedup so the
     counter is at most incremented once per
-    [alive_but_stuck_dedup_ttl_sec] window.  Also request supervised
+    [alive_but_stuck_dedup_ttl_sec] window.  Also queue a bounded Event
+    Layer recovery wakeup for Running keepers, then request supervised
     recovery by setting the keeper's structured failure reason plus
     [fiber_stop]/[fiber_wakeup], allowing the next sweep to route it
     through the existing crash/restart path.  Gated behind

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -110,14 +110,23 @@ val detect_alive_but_stuck :
 val alive_but_stuck_scan : 'a context -> unit
 (** Scan all keepers in [Keeper_registry].  For each keeper detected as
     alive-but-stuck, emit one [metric_keeper_alive_but_stuck] counter
-    increment and a single warn log line, with per-keeper dedup so the
-    counter is at most incremented once per
-    [alive_but_stuck_dedup_ttl_sec] window.  Also queue a bounded Event
-    Layer recovery wakeup for Running keepers, then request supervised
-    recovery by setting the keeper's structured failure reason plus
-    [fiber_stop]/[fiber_wakeup], allowing the next sweep to route it
-    through the existing crash/restart path.  Gated behind
-    [MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED] (default: true). *)
+    increment and write a single warn log line.  Per-keeper dedup keeps
+    counter / wakeup emission at most once per
+    [alive_but_stuck_dedup_ttl_sec] window.
+
+    The recovery side effect is queued only when BOTH gates are on:
+    - [MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED] (default: true) — the
+      detector itself; turning this off skips the entire scan, no
+      counters or warns are emitted.
+    - [MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED] (default: true)
+      — the recovery action.  When this is off, the detector still
+      runs (counter + warn), but no Event Layer wakeup or supervised
+      restart request is queued; this lets operators observe the signal
+      in production before turning on the side-effect.  When enabled,
+      [alive_but_stuck_scan] enqueues an Event Layer stimulus and sets
+      [failure_reason] plus [fiber_stop]/[fiber_wakeup] so the next
+      sweep can route the keeper through the existing crash/restart
+      path.  PR #13123. *)
 
 val request_alive_but_stuck_recovery_for_test :
   base_path:string ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -255,6 +255,11 @@ let metric_keeper_alive_but_stuck =
 let metric_keeper_alive_but_stuck_recovery_requests =
   "masc_keeper_alive_but_stuck_recovery_requests_total"
 
+(** #12838 follow-up: bounded recovery wakeups queued by
+    [alive_but_stuck_scan].  Labels: keeper, outcome. *)
+let metric_keeper_alive_but_stuck_recovery =
+  "masc_keeper_alive_but_stuck_recovery_total"
+
 (* #10047: [append_metrics_snapshot] failures in [keeper_turn.ml] and
    [keeper_unified_turn.ml] used to be log-only, masking state/metric
    divergence. Surface as a counter so dashboards can alert on silent
@@ -1615,7 +1620,7 @@ let init () =
     Counter;
   add metric_keeper_stimulus_consumed
     "Total stimuli consumed at turn entry, classified by stimulus_class. \
-     Labels: keeper, class (board_signal|bootstrap|unsupported). \
+     Labels: keeper, class (board_signal|bootstrap|alive_but_stuck_recovery|unsupported). \
      Pairs with masc_keeper_unsupported_stimulus_total for unsupported-only \
      drill-down with payload prefix."
     Counter;
@@ -1957,6 +1962,15 @@ let init () =
     Counter;
   add metric_keeper_contract_violations
     "Keeper turns rejected for required-tool-contract violations (labels: keeper_name, kind={passive|text_only}). #10530."
+    Counter;
+  add metric_keeper_alive_but_stuck
+    "Keepers detected as alive-but-stuck: non-Dead, non-paused, \
+     keepalive-running, but proactive_rt.last_ts has been frozen while \
+     autonomous turns kept advancing. Labels: keeper."
+    Counter;
+  add metric_keeper_alive_but_stuck_recovery
+    "Bounded recovery wakeups queued by alive_but_stuck_scan. \
+     Labels: keeper, outcome."
     Counter;
   (* Tool schema budget gauges — set once at boot via
      [set_tool_schema_stats]. Covers #7483 Step 1. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -88,6 +88,10 @@ val metric_keeper_alive_but_stuck : string
     [failure_reason] plus [fiber_stop]/[fiber_wakeup]. Labels: keeper. *)
 val metric_keeper_alive_but_stuck_recovery_requests : string
 
+(** #12838 follow-up: bounded recovery wakeups queued by
+    [Keeper_supervisor.alive_but_stuck_scan]. Labels: keeper, outcome. *)
+val metric_keeper_alive_but_stuck_recovery : string
+
 val metric_keeper_metric_emit_dropped : string
 val metric_keeper_context_max_observed : string
 (** #9953: bucketed counter for observed [context_max] values.
@@ -629,7 +633,8 @@ val metric_keeper_event_queue_override : string
 
 val metric_keeper_stimulus_consumed : string
 (** Total stimuli consumed at turn entry, classified by [stimulus_class].
-    Labels: [keeper], [class] (board_signal|bootstrap|unsupported).
+    Labels: [keeper], [class]
+    (board_signal|bootstrap|alive_but_stuck_recovery|unsupported).
     Pairs with [masc_keeper_unsupported_stimulus_total] for unsupported-only
     drill-down with payload prefix. *)
 

--- a/test/keeper_event_queue/test_keeper_event_queue.ml
+++ b/test/keeper_event_queue/test_keeper_event_queue.ml
@@ -112,6 +112,15 @@ let test_dequeue_only_consumes_enqueued () =
   let _, rest = Option.get (dequeue q) in
   assert (Option.is_none (dequeue rest))
 
+let test_classify_alive_but_stuck_recovery () =
+  let s =
+    make_stim "alive-but-stuck:k"
+      "{\"source\":\"alive_but_stuck_recovery\",\"keeper\":\"k\"}"
+  in
+  match classify s with
+  | Alive_but_stuck_recovery -> ()
+  | _ -> assert false
+
 let () =
   test_empty ();
   test_enqueue_dequeue_fifo ();
@@ -122,4 +131,5 @@ let () =
   test_conservation ();
   test_queue_overrides_policy ();
   test_dequeue_only_consumes_enqueued ();
+  test_classify_alive_but_stuck_recovery ();
   print_endline "Keeper_event_queue: all tests passed"

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1429,6 +1429,82 @@ let () =
                     check bool "fiber wakeup set" true
                       (Atomic.get entry.fiber_wakeup)
                 | None -> fail "expected registered keeper"));
+        (* PR #13123 review: the safety property of this change is
+           "at most one queued wakeup per dedup window".  Without a
+           repeated-scan test, a future regression could enqueue one
+           recovery stimulus on every 30s sweep without failing the
+           suite.  Run [alive_but_stuck_scan] twice within the dedup
+           window and assert the queue length stays at 1. *)
+        test_case
+          "repeated scan within dedup window queues at most one recovery"
+          `Quick
+          (fun () ->
+            Eio_main.run @@ fun env ->
+            Eio.Switch.run @@ fun sw ->
+            let base_dir = temp_dir () in
+            Fun.protect
+              ~finally:(fun () ->
+                Reg.clear ();
+                Sup.alive_but_stuck_reset_for_test ();
+                cleanup_dir base_dir)
+              (fun () ->
+                Reg.clear ();
+                Sup.alive_but_stuck_reset_for_test ();
+                let name = "abs-scan-recovery-repeat" in
+                let config = Masc_mcp.Coord.default_config base_dir in
+                let base = make_meta name in
+                let meta =
+                  {
+                    base with
+                    proactive = { base.proactive with cooldown_sec = 60 };
+                    runtime = {
+                      base.runtime with
+                      autonomous_turn_count = 7;
+                      proactive_rt = {
+                        base.runtime.proactive_rt with
+                        last_ts = 1.0;
+                      };
+                    };
+                  }
+                in
+                ignore (Reg.register ~base_path:config.base_path name meta);
+                ignore (Reg.dispatch_event ~base_path:config.base_path name
+                          KSM.Fiber_started);
+                let ctx : _ KT.context =
+                  {
+                    config;
+                    agent_name = "supervisor";
+                    sw;
+                    clock = Eio.Stdenv.clock env;
+                    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+                    net = Some (Eio.Stdenv.net env);
+                  }
+                in
+                (* Three back-to-back sweeps simulate the supervisor
+                   loop firing every 30s while the keeper is still
+                   stuck.  Without dedup the queue would have 3
+                   stimuli; with dedup it must stay at 1 (until the
+                   reset_for_test below clears the table). *)
+                Sup.alive_but_stuck_scan ctx;
+                Sup.alive_but_stuck_scan ctx;
+                Sup.alive_but_stuck_scan ctx;
+                let queue =
+                  Reg.event_queue_snapshot ~base_path:config.base_path name
+                in
+                check int
+                  "dedup window holds queue length to 1 across 3 sweeps"
+                  1
+                  (Masc_mcp.Keeper_event_queue.length queue);
+                (* Manual dedup reset → next scan re-queues. *)
+                Sup.alive_but_stuck_reset_for_test ();
+                Sup.alive_but_stuck_scan ctx;
+                let queue2 =
+                  Reg.event_queue_snapshot ~base_path:config.base_path name
+                in
+                check int
+                  "after dedup reset, the next scan re-queues (now 2 total)"
+                  2
+                  (Masc_mcp.Keeper_event_queue.length queue2)));
         test_case "never_started + autonomous + old started_at → Some" `Quick
           (fun () ->
             (* Mirrors production case: glm-coding-plan with

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1366,6 +1366,69 @@ let () =
             | None -> fail "expected stalled keeper to be detected"
             | Some elapsed ->
               check (float 1.0) "elapsed ≈ 99000s" 99_000.0 elapsed);
+        test_case "scan queues recovery wakeup for running stalled keeper" `Quick
+          (fun () ->
+            Eio_main.run @@ fun env ->
+            Eio.Switch.run @@ fun sw ->
+            let base_dir = temp_dir () in
+            Fun.protect
+              ~finally:(fun () ->
+                Reg.clear ();
+                Sup.alive_but_stuck_reset_for_test ();
+                cleanup_dir base_dir)
+              (fun () ->
+                Reg.clear ();
+                Sup.alive_but_stuck_reset_for_test ();
+                let name = "abs-scan-recovery" in
+                let config = Masc_mcp.Coord.default_config base_dir in
+                let base = make_meta name in
+                let meta =
+                  {
+                    base with
+                    proactive = { base.proactive with cooldown_sec = 60 };
+                    runtime = {
+                      base.runtime with
+                      autonomous_turn_count = 7;
+                      proactive_rt = {
+                        base.runtime.proactive_rt with
+                        last_ts = 1.0;
+                      };
+                    };
+                  }
+                in
+                ignore (Reg.register ~base_path:config.base_path name meta);
+                ignore (Reg.dispatch_event ~base_path:config.base_path name
+                          KSM.Fiber_started);
+                let ctx : _ KT.context =
+                  {
+                    config;
+                    agent_name = "supervisor";
+                    sw;
+                    clock = Eio.Stdenv.clock env;
+                    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+                    net = Some (Eio.Stdenv.net env);
+                  }
+                in
+                Sup.alive_but_stuck_scan ctx;
+                let queue =
+                  Reg.event_queue_snapshot ~base_path:config.base_path name
+                in
+                check int "one recovery stimulus queued" 1
+                  (Masc_mcp.Keeper_event_queue.length queue);
+                (match Masc_mcp.Keeper_event_queue.dequeue queue with
+                 | Some (stim, _) ->
+                    check string "post id" ("alive-but-stuck:" ^ name)
+                      stim.post_id;
+                    (match Masc_mcp.Keeper_event_queue.classify stim with
+                     | Masc_mcp.Keeper_event_queue.Alive_but_stuck_recovery ->
+                        ()
+                     | _ -> fail "expected recovery stimulus class")
+                 | None -> fail "expected queued recovery stimulus");
+                match Reg.get ~base_path:config.base_path name with
+                | Some entry ->
+                    check bool "fiber wakeup set" true
+                      (Atomic.get entry.fiber_wakeup)
+                | None -> fail "expected registered keeper"));
         test_case "never_started + autonomous + old started_at → Some" `Quick
           (fun () ->
             (* Mirrors production case: glm-coding-plan with


### PR DESCRIPTION
## Summary

Turns the alive-but-stuck supervisor scan from observation-only into a bounded recovery signal:

- deduped `alive_but_stuck_scan` emissions now enqueue an Event Layer recovery stimulus for Running keepers and flip the keeper wakeup flag
- adds a first-class `alive_but_stuck_recovery` stimulus class so the heartbeat loop consumes it without treating it as an unsupported wake -> no-signal gap
- registers a recovery outcome counter and extends tests for classifier behavior plus supervisor scan queue/wakeup side effects

## Why

Live `/Users/dancer/me` keeper logs showed `alive-but-stuck detected` warnings with huge elapsed values, but the code path explicitly said detection-only: counter and warn log, no transition, no restart, no wakeup. That means an operator can see stuck keepers in the log screen while the runtime does nothing to nudge them back into an autonomous cycle.

This keeps the fix bounded: no restart and no board post. A Running keeper gets one recovery stimulus per existing dedup window, which lets the normal heartbeat/Event Layer policy drive the next cycle.

## Validation

- `git diff --check HEAD~1 HEAD` passed.
- Focused local build was attempted with `DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/keeper_event_queue/test_keeper_event_queue.exe test/test_keeper_supervisor.exe`, but local validation is blocked by the repo pin guard: local `agent_sdk` is pinned to `git+https://github.com/jeong-sik/oas.git#16678b81a6858ba66d121a7f6194751f351299a6`, while this checkout expects `#86a0e540a8856db5ee740cb2d1deff58bf0bbbfb`.
- A bypass build was also attempted and failed before these targets on the same local switch drift, with `agent_sdk.cmi` / `Types.cmi` inconsistent assumptions and missing `Llm_provider` modules.

CI is the authoritative validation surface for this draft.