### PR TITLE
fix: probe local providers in cascade catalog

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -18,14 +18,9 @@ type candidate_runtime = {
   provider_cfg : Llm_provider.Provider_config.t;
 }
 
-(* [profile_build] is the validated profile shape. [profile_snapshot] used
-   to be a near-duplicate of this record with an extra [probes] field, but
-   the probes were never refreshed after construction and every probe was
-   produced by mapping [candidates] through [candidate_probe_skipped] with
-   the same advisory message — so the probes are derived from [candidates]
-   on demand and the snapshot can reuse [profile_build] directly. The
-   [profile_snapshot] alias is kept for documentation: a [profile_build]
-   embedded in a {!snapshot} is the validated, runtime-served form. *)
+(* [profile_build] is the validated profile shape. Provider liveness remains
+   advisory and never rejects a catalog, but the runtime snapshot carries the
+   latest probe evidence observed during validation. *)
 type profile_build = {
   name : string;
   weighted_entries : Cascade_config_loader.weighted_entry list;
@@ -35,6 +30,7 @@ type profile_build = {
   ollama_max_concurrent : int option;
   cli_max_concurrent : int option;
   candidates : candidate_runtime list;
+  probes : candidate_probe list;
 }
 
 type profile_snapshot = profile_build
@@ -128,6 +124,7 @@ let install_snapshot_for_tests ~source_path ~profile_names =
              ollama_max_concurrent = None;
              cli_max_concurrent = None;
              candidates = [];
+             probes = [];
            })
   in
   let snapshot =
@@ -202,33 +199,114 @@ let candidate_probe_skipped (candidate : candidate_runtime) reason =
     status = Probe_skipped reason;
   }
 
-(* Bootstrap-time probes are advisory: provider liveness is checked at
-   runtime, not catalog validation, so every candidate is converted via
-   [candidate_probe_skipped]. This helper is the single source of truth
-   for that mapping; [profile_snapshot] therefore stores [candidates]
-   and derives probes here on demand instead of carrying a parallel
-   [probes] field that would drift on any future refactor. *)
+let advisory_skip_reason =
+  "runtime provider health is advisory; bootstrap skips live probe"
+
+let cloud_skip_reason =
+  "cloud provider health is advisory; bootstrap probes local endpoints only"
+
 let profile_probes (profile_candidates : candidate_runtime list) =
   List.map
-    (fun candidate ->
-      candidate_probe_skipped candidate
-        "runtime provider health is advisory; bootstrap skips live probe")
+    (fun candidate -> candidate_probe_skipped candidate advisory_skip_reason)
     profile_candidates
 
-let record_advisory_probe_skips (profiles : profile_snapshot list) =
+let normalize_endpoint_url url =
+  let trimmed = String.trim url in
+  let rec drop_trailing_slash s =
+    let len = String.length s in
+    if len > 0 && s.[len - 1] = '/' then
+      drop_trailing_slash (String.sub s 0 (len - 1))
+    else
+      s
+  in
+  drop_trailing_slash trimmed
+
+let endpoint_status_for_candidate statuses (candidate : candidate_runtime) =
+  let target = normalize_endpoint_url candidate.provider_cfg.base_url in
+  List.find_opt
+    (fun (status : Llm_provider.Discovery.endpoint_status) ->
+      String.equal target (normalize_endpoint_url status.url))
+    statuses
+
+let profile_probes_from_statuses statuses profile_candidates =
+  List.map
+    (fun (candidate : candidate_runtime) ->
+      if not (Llm_provider.Provider_config.is_local candidate.provider_cfg) then
+        candidate_probe_skipped candidate cloud_skip_reason
+      else
+        match endpoint_status_for_candidate statuses candidate with
+        | Some status when status.healthy -> candidate_probe_ok candidate
+        | Some status ->
+            candidate_probe_error candidate
+              (Printf.sprintf "local endpoint unhealthy: %s" status.url)
+        | None ->
+            candidate_probe_error candidate
+              (Printf.sprintf "local endpoint was not probed: %s"
+                 candidate.provider_cfg.base_url))
+    profile_candidates
+
+let attach_probe_results ?sw ?net (profiles : profile_snapshot list) =
+  match sw, net with
+  | Some sw, Some net ->
+      let endpoints =
+        profiles
+        |> List.concat_map (fun (profile : profile_snapshot) -> profile.candidates)
+        |> List.filter (fun (candidate : candidate_runtime) ->
+               Llm_provider.Provider_config.is_local candidate.provider_cfg)
+        |> List.map (fun (candidate : candidate_runtime) ->
+               candidate.provider_cfg.base_url)
+        |> List.map normalize_endpoint_url
+        |> List.sort_uniq String.compare
+      in
+      let statuses =
+        match endpoints with
+        | [] -> []
+        | _ :: _ -> Llm_provider.Discovery.refresh_and_sync ~sw ~net ~endpoints
+      in
+      List.map
+        (fun (profile : profile_snapshot) ->
+          {
+            profile with
+            probes = profile_probes_from_statuses statuses profile.candidates;
+          })
+        profiles
+  | _ ->
+      List.map
+        (fun (profile : profile_snapshot) ->
+          { profile with probes = profile_probes profile.candidates })
+        profiles
+
+let probe_health_value = function
+  | Probe_skipped _ -> 0.0
+  | Probe_ok -> 1.0
+  | Probe_error _ -> 3.0
+
+let record_probe_metrics (profiles : profile_snapshot list) =
   List.iter
     (fun (profile : profile_snapshot) ->
       List.iter
-        (fun (candidate : candidate_runtime) ->
-          Prometheus.inc_counter
-            Prometheus.metric_provider_health_probe_skipped
+        (fun (probe : candidate_probe) ->
+          (match probe.status with
+           | Probe_skipped _ ->
+               Prometheus.inc_counter
+                 Prometheus.metric_provider_health_probe_skipped
+                 ~labels:
+                   [
+                     ("provider_name", probe.provider_kind);
+                     ("profile_name", profile.name);
+                   ]
+                 ()
+           | Probe_ok | Probe_error _ -> ());
+          Prometheus.set_gauge
+            Prometheus.metric_provider_actual_health_status
             ~labels:
               [
-                ("provider_name", provider_kind_string candidate.provider_cfg);
+                ("provider_name", probe.provider_kind);
                 ("profile_name", profile.name);
+                ("model_id", probe.model_id);
               ]
-            ())
-        profile.candidates)
+            (probe_health_value probe.status))
+        profile.probes)
     profiles
 
 let candidate_probe_to_yojson (probe : candidate_probe) =
@@ -260,8 +338,7 @@ let profile_snapshot_to_yojson (profile : profile_snapshot) =
         int_opt_to_json profile.ollama_max_concurrent );
       ("cli_max_concurrent", int_opt_to_json profile.cli_max_concurrent);
       ( "candidates",
-        `List
-          (List.map candidate_probe_to_yojson (profile_probes profile.candidates)) );
+        `List (List.map candidate_probe_to_yojson profile.probes) );
     ]
 
 let snapshot_to_yojson (snapshot : snapshot) =
@@ -499,6 +576,7 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               ollama_max_concurrent;
               cli_max_concurrent;
               candidates;
+              probes = profile_probes candidates;
             }
 
 let runtime_required_profiles ~config_path =
@@ -529,7 +607,7 @@ let runtime_required_profile_names ?config_path () =
   else
     runtime_required_profiles ~config_path
 
-let validate_path_result ~config_path =
+let validate_path_result ?sw ?net ~config_path =
   let checked_at = Unix.gettimeofday () in
   let source_state = active_source_state ~config_path in
   let source_path = source_state.info.source_path in
@@ -608,9 +686,9 @@ let validate_path_result ~config_path =
                ~checked_at
                ~errors:top_errors ~profiles:statically_rejected_profiles)
         else
-          (* profile_snapshot is an alias for profile_build, so the
-             validated builders forward directly without a copy. *)
-          let profile_snapshots : profile_snapshot list = built_profiles in
+          let profile_snapshots : profile_snapshot list =
+            attach_probe_results ?sw ?net built_profiles
+          in
           let rejected_profiles = statically_rejected_profiles in
           let default_profile_validated =
             List.exists
@@ -626,7 +704,7 @@ let validate_path_result ~config_path =
               profiles = profile_snapshots;
             }
           in
-          record_advisory_probe_skips profile_snapshots;
+          record_probe_metrics profile_snapshots;
           if rejected_profiles = [] then
             Ok { snapshot; rejected_update = None }
           else
@@ -657,10 +735,8 @@ let validate_path_result ~config_path =
               Ok { snapshot; rejected_update = Some rejection }
 
 let validate_path ?sw ?net ?clock ~config_path () =
-  let (_ : Eio.Switch.t option) = sw in
-  let (_ : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option) = net in
   let (_ : float Eio.Time.clock_ty Eio.Resource.t option) = clock in
-  match validate_path_result ~config_path with
+  match validate_path_result ?sw ?net ~config_path with
   | Ok result -> Ok result.snapshot
   | Error _ as e -> e
 
@@ -725,7 +801,7 @@ let inspect_active ?sw ?net ?clock () =
       match cached_result with
       | Some result -> result
       | None -> (
-          match validate_path_result ~config_path with
+          match validate_path_result ?sw ?net ~config_path with
           | Ok { snapshot; rejected_update = None } ->
               with_cache_lock (fun () ->
                   cache :=

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -961,6 +961,8 @@ let metric_cascade_fallback_cycle_detected_total =
   "masc_cascade_fallback_cycle_detected_total"
 let metric_provider_health_probe_skipped =
   "masc_provider_health_probe_skipped_total"
+let metric_provider_actual_health_status =
+  "masc_provider_actual_health_status"
 (* #12799: Passive loop detector — keeper emitting only read-only tool
    calls for N consecutive turns.  Labels: keeper. *)
 let metric_keeper_passive_loop_detected_total =
@@ -1602,6 +1604,11 @@ let init () =
      value means provider liveness was not actually probed at catalog \
      validation time."
     Counter;
+  add metric_provider_actual_health_status
+    "Last advisory provider health status observed by runtime catalog \
+     validation. Values: 0=unknown/skipped, 1=healthy, 3=unhealthy. Labels: \
+     provider_name, profile_name, model_id."
+    Gauge;
   add metric_keeper_passive_loop_detected_total
     "#12799 Total passive-loop detections: keeper issued only read-only tool \
      calls for N consecutive turns. Labeled by keeper."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -470,6 +470,11 @@ val metric_provider_health_probe_skipped : string
 (** Total bootstrap/runtime-catalog provider health probes intentionally
     skipped as advisory. Labels: [provider_name, profile_name]. *)
 
+val metric_provider_actual_health_status : string
+(** Last advisory provider health status observed by runtime catalog
+    validation. Values: 0=unknown/skipped, 1=healthy, 3=unhealthy.
+    Labels: [provider_name, profile_name, model_id]. *)
+
 val metric_keeper_invariant_violations : string
 
 (** PR-I: cross-FSM edge transition counter. Labels: [edge] with values

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -423,6 +423,60 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
       check bool "active profile list is included" true
         (contains_substring detail "tool_rerank")
 
+let test_valid_catalog_probes_local_endpoints_when_eio_caps_available () =
+  with_temp_dir "cascade-catalog-runtime-probe" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
+  let skip_metric () =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_provider_health_probe_skipped
+      ~labels:[("provider_name", "custom"); ("profile_name", "big_three")]
+      ()
+  in
+  let health_metric () =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_provider_actual_health_status
+      ~labels:
+        [
+          ("provider_name", "custom");
+          ("profile_name", "big_three");
+          ("model_id", "mock");
+        ]
+      ()
+  in
+  let before_skip_metric = skip_metric () in
+  let model = Printf.sprintf "custom:mock@%s/v1" dummy_base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf {|{"big_three_models": ["%s"]}|} model));
+  let snapshot =
+    match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+    | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
+    | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+        fail "expected fully validated snapshot without rejected profiles"
+    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
+        fail "expected a freshly validated snapshot"
+    | Error rejection ->
+        failf "unexpected validation rejection: %s"
+          (Yojson.Safe.to_string
+             (Cascade_catalog_runtime.rejection_to_yojson rejection))
+  in
+  let snapshot_string =
+    Yojson.Safe.to_string (Cascade_catalog_runtime.snapshot_to_yojson snapshot)
+  in
+  check bool "local probe status is error" true
+    (contains_substring snapshot_string "\"status\":\"error\"");
+  check bool "local probe reports endpoint" true
+    (contains_substring snapshot_string "local endpoint");
+  check bool "local probe is not skipped" false
+    (contains_substring snapshot_string "\"status\":\"skipped\"");
+  check (float 0.0001) "local probe does not increment skipped metric"
+    0.0
+    (skip_metric () -. before_skip_metric);
+  check (float 0.0001) "unhealthy local probe gauge" 3.0 (health_metric ())
+
 let test_invalid_hot_reload_preserves_last_known_good () =
   with_temp_dir "cascade-catalog-lkg" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
@@ -1019,6 +1073,10 @@ let () =
             "valid catalog skips live probes at bootstrap"
             `Quick
             test_valid_catalog_skips_live_probes_at_bootstrap;
+          test_case
+            "valid catalog probes local endpoints when Eio caps available"
+            `Quick
+            test_valid_catalog_probes_local_endpoints_when_eio_caps_available;
           test_case
             "route validation rejects unknown route key"
             `Quick


### PR DESCRIPTION
## Summary
- keep catalog validation advisory, but attach runtime probe evidence to catalog snapshots when Eio switch/net are available
- probe local provider endpoints through Llm_provider.Discovery.refresh_and_sync instead of marking every candidate skipped
- add masc_provider_actual_health_status gauge so unhealthy local endpoints surface as status=3 while skipped advisory probes remain status=0
- keep cloud provider bootstrap health advisory/skipped with a specific reason

## GOAL LOOP impact
This addresses the provider-health skipped slice from the 2026-05-05 Observe findings: local provider health is no longer blanket skipped during runtime catalog validation, and the snapshot JSON now records ok/error/skipped probe status per candidate.

## Verification
- PASS: git diff --check
- PASS: branch rebased onto origin/main
- PASS: GitHub lightweight checks: Draft Auto-Merge Guard, PR Live Gate, PR Sync Check, Workflow YAML syntax, Godfile size, Hardcoded model prefix, Math.random in components
- EXPECTED POLICY RED: CI Gate fails because this agent draft lacks human-approved-ready; do not add that label without human approval
- BLOCKED: scripts/dune-local.sh build test/test_cascade_catalog_runtime.exe could not acquire /tmp/me-dune-local.lock; lock is held by an existing OAS dune runtest process (PID 96843)