### PR TITLE
Fix OAS LLM metric bridge callback gaps

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -28,10 +28,17 @@
     Upper bound ≈ 6 × 10 × 10 = 600 series.  No runtime cardinality
     guard; if a deployment introduces unbounded custom model ids,
     revisit with an allowlist or drop the [model] label. *)
-let http_status_metric = "masc_llm_provider_http_status_total"
+let http_status_metric = Prometheus.metric_llm_provider_http_status
 
 (** Canonical metric name for silent capability drops. *)
 let capability_drop_metric = Prometheus.metric_llm_provider_capability_drops
+let cache_hit_metric = Prometheus.metric_llm_provider_cache_hits
+let cache_miss_metric = Prometheus.metric_llm_provider_cache_misses
+let request_start_metric = Prometheus.metric_llm_provider_requests_started
+let error_metric = Prometheus.metric_llm_provider_errors
+let retry_metric = Prometheus.metric_llm_provider_retries
+let input_tokens_metric = Prometheus.metric_llm_provider_input_tokens
+let output_tokens_metric = Prometheus.metric_llm_provider_output_tokens
 
 (** Emit a single HTTP status observation to the Prometheus counter.
 
@@ -54,6 +61,48 @@ let emit_capability_drop ~model_id ~field =
   Prometheus.inc_counter capability_drop_metric
     ~labels:[("model", model_id); ("field", field)]
     ()
+
+let emit_cache_hit ~model_id =
+  Prometheus.inc_counter cache_hit_metric
+    ~labels:[("model", model_id)]
+    ()
+
+let emit_cache_miss ~model_id =
+  Prometheus.inc_counter cache_miss_metric
+    ~labels:[("model", model_id)]
+    ()
+
+let emit_request_start ~model_id =
+  Prometheus.inc_counter request_start_metric
+    ~labels:[("model", model_id)]
+    ()
+
+let emit_error ~model_id =
+  Prometheus.inc_counter error_metric
+    ~labels:[("model", model_id)]
+    ()
+
+let emit_retry ~provider ~model_id ~attempt =
+  Prometheus.inc_counter retry_metric
+    ~labels:
+      [
+        ("provider", provider);
+        ("model", model_id);
+        ("attempt", string_of_int attempt);
+      ]
+    ()
+
+let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
+  if input_tokens > 0 then
+    Prometheus.inc_counter input_tokens_metric
+      ~labels:[("provider", provider); ("model", model_id)]
+      ~delta:(Float.of_int input_tokens)
+      ();
+  if output_tokens > 0 then
+    Prometheus.inc_counter output_tokens_metric
+      ~labels:[("provider", provider); ("model", model_id)]
+      ~delta:(Float.of_int output_tokens)
+      ()
 
 (** Canonical metric name for the unified fallback counter (§7.3.2 Zero
     Silent Failure). Per-class counters (capability_drops,
@@ -80,7 +129,7 @@ let emit_fallback_triggered ~kind ~detail =
     which fires for every completed HTTP request regardless of whether
     the AfterTurn hook later runs.  Provides redundant latency
     observability so a broken hook does not blank out the dashboard. *)
-let request_latency_metric = "masc_llm_provider_request_latency_seconds"
+let request_latency_metric = Prometheus.metric_llm_provider_request_latency
 
 (** Emit a single latency observation to the Prometheus histogram.
 
@@ -96,17 +145,19 @@ let emit_request_latency ~model_id ~latency_ms =
 (** Build the OAS Metrics.t sink.
 
     Currently wired through:
+    - [on_cache_hit]    → masc_llm_provider_cache_hits_total
+    - [on_cache_miss]   → masc_llm_provider_cache_misses_total
+    - [on_request_start] → masc_llm_provider_requests_started_total
     - [on_http_status]   → masc_llm_provider_http_status_total
     - [on_request_end]   → masc_llm_provider_request_latency_seconds
-
-    Other callbacks ([on_cache_hit/miss], [on_request_start], [on_error],
-    transport-independent extras) inherit the default no-op from
-    [Llm_provider.Metrics.noop].  Add more relays here as their
-    consuming dashboards land. *)
+    - [on_error]        → masc_llm_provider_errors_total
+    - [on_retry]        → masc_llm_provider_retries_total
+    - [on_token_usage]  → masc_llm_provider_{input,output}_tokens_total *)
 let make_sink () : Llm_provider.Metrics.t =
-  let open Llm_provider.Metrics in
   {
-    noop with
+    on_cache_hit = emit_cache_hit;
+    on_cache_miss = emit_cache_miss;
+    on_request_start = emit_request_start;
     on_http_status =
       (fun ~provider ~model_id ~status ->
         emit_http_status ~provider ~model_id ~status);
@@ -116,6 +167,9 @@ let make_sink () : Llm_provider.Metrics.t =
     on_capability_drop =
       (fun ~model_id ~field ->
         emit_capability_drop ~model_id ~field);
+    on_error = (fun ~model_id ~error:_ -> emit_error ~model_id);
+    on_retry = emit_retry;
+    on_token_usage = emit_token_usage;
   }
 
 (** Install the sink as the process-wide default.  Idempotent — calling

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -31,6 +31,21 @@ val emit_request_latency : model_id:string -> latency_ms:int -> unit
 (** Emit a capability drop observation to the Prometheus counter. *)
 val emit_capability_drop : model_id:string -> field:string -> unit
 
+(** Emit cache hit/miss observations from OAS metrics callbacks. *)
+val emit_cache_hit : model_id:string -> unit
+val emit_cache_miss : model_id:string -> unit
+
+(** Emit request lifecycle observations from OAS metrics callbacks. *)
+val emit_request_start : model_id:string -> unit
+val emit_error : model_id:string -> unit
+val emit_retry : provider:string -> model_id:string -> attempt:int -> unit
+val emit_token_usage :
+  provider:string ->
+  model_id:string ->
+  input_tokens:int ->
+  output_tokens:int ->
+  unit
+
 (** Canonical metric name for the §7.3.2 unified fallback counter. *)
 val fallback_triggered_metric : string
 

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -395,8 +395,13 @@ let cascade_metrics_for_candidates
   in
   let metrics =
     Oas_compat.Metrics.make
+      ~on_cache_hit:(fun ~model_id ->
+        Llm_metric_bridge.emit_cache_hit ~model_id)
+      ~on_cache_miss:(fun ~model_id ->
+        Llm_metric_bridge.emit_cache_miss ~model_id)
       ~on_request_start:(fun ~model_id ->
-        record_attempt_start capture ~candidate_cfgs ~model_id)
+        record_attempt_start capture ~candidate_cfgs ~model_id;
+        Llm_metric_bridge.emit_request_start ~model_id)
       ~on_request_end:(fun ~model_id ~latency_ms ->
         ensure_terminal_attempt capture ~candidate_cfgs ~model_id
           ~latency_ms:(Some latency_ms) ~error:None;
@@ -408,7 +413,8 @@ let cascade_metrics_for_candidates
         Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms)
       ~on_error:(fun ~model_id ~error ->
         ensure_terminal_attempt capture ~candidate_cfgs ~model_id
-          ~latency_ms:None ~error:(Some error))
+          ~latency_ms:None ~error:(Some error);
+        Llm_metric_bridge.emit_error ~model_id)
       ~on_capability_drop:(fun ~model_id ~field ->
         (* The explicit cascade metrics object bypasses the global
            Llm_metric_bridge sink, so capability-drop telemetry must be
@@ -423,6 +429,11 @@ let cascade_metrics_for_candidates
            Delegating to [Llm_metric_bridge.emit_http_status] keeps
            the label shape a single source of truth. *)
         Llm_metric_bridge.emit_http_status ~provider ~model_id ~status)
+      ~on_retry:(fun ~provider ~model_id ~attempt ->
+        Llm_metric_bridge.emit_retry ~provider ~model_id ~attempt)
+      ~on_token_usage:(fun ~provider ~model_id ~input_tokens ~output_tokens ->
+        Llm_metric_bridge.emit_token_usage
+          ~provider ~model_id ~input_tokens ~output_tokens)
       ()
   in
   (capture, metrics)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -853,6 +853,14 @@ let metric_llm_provider_request_latency =
   "masc_llm_provider_request_latency_seconds"
 let metric_llm_provider_capability_drops =
   "masc_llm_provider_capability_drops_total"
+let metric_llm_provider_cache_hits = "masc_llm_provider_cache_hits_total"
+let metric_llm_provider_cache_misses = "masc_llm_provider_cache_misses_total"
+let metric_llm_provider_requests_started =
+  "masc_llm_provider_requests_started_total"
+let metric_llm_provider_errors = "masc_llm_provider_errors_total"
+let metric_llm_provider_retries = "masc_llm_provider_retries_total"
+let metric_llm_provider_input_tokens = "masc_llm_provider_input_tokens_total"
+let metric_llm_provider_output_tokens = "masc_llm_provider_output_tokens_total"
 let metric_fallback_triggered =
   "masc_fallback_triggered_total"
 
@@ -1405,6 +1413,27 @@ let init () =
     Counter;
   add metric_llm_provider_capability_drops
     "Total OAS capability drops from LLM providers, labeled by model and field"
+    Counter;
+  add metric_llm_provider_cache_hits
+    "Total OAS LLM cache hits, labeled by model"
+    Counter;
+  add metric_llm_provider_cache_misses
+    "Total OAS LLM cache misses, labeled by model"
+    Counter;
+  add metric_llm_provider_requests_started
+    "Total OAS LLM requests started, labeled by model"
+    Counter;
+  add metric_llm_provider_errors
+    "Total OAS LLM request errors, labeled by model"
+    Counter;
+  add metric_llm_provider_retries
+    "Total OAS LLM retries, labeled by provider, model, and attempt"
+    Counter;
+  add metric_llm_provider_input_tokens
+    "Total OAS LLM input tokens, labeled by provider and model"
+    Counter;
+  add metric_llm_provider_output_tokens
+    "Total OAS LLM output tokens, labeled by provider and model"
     Counter;
   add metric_fallback_triggered
     "Total fallback events across the LLM cascade pipeline, labeled by kind \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -413,6 +413,13 @@ val metric_tool_call_duration : string
 val metric_llm_provider_http_status : string
 val metric_llm_provider_request_latency : string
 val metric_llm_provider_capability_drops : string
+val metric_llm_provider_cache_hits : string
+val metric_llm_provider_cache_misses : string
+val metric_llm_provider_requests_started : string
+val metric_llm_provider_errors : string
+val metric_llm_provider_retries : string
+val metric_llm_provider_input_tokens : string
+val metric_llm_provider_output_tokens : string
 val metric_fallback_triggered : string
 (** §7.3.2 Zero Silent Failure measurement: aggregate counter for every
     fallback event across the cascade pipeline. Labels: [kind] enumerates

--- a/test/dune
+++ b/test/dune
@@ -57,6 +57,7 @@
         test_keeper_tool_use_failure_counter
         test_keeper_compaction_outcome_counter
         test_keeper_usage_trust_counter
+        test_llm_metric_bridge
         test_cost_usd_source_attribution_10318
         test_cost_ledger_pricing_model_10318
         test_response_model_empty_10083
@@ -264,6 +265,7 @@
           test_keeper_tool_use_failure_counter
           test_keeper_compaction_outcome_counter
           test_keeper_usage_trust_counter
+          test_llm_metric_bridge
           test_cost_usd_source_attribution_10318
           test_cost_ledger_pricing_model_10318
           test_response_model_empty_10083

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -1,0 +1,104 @@
+module Bridge = Masc_mcp.Llm_metric_bridge
+module Prom = Masc_mcp.Prometheus
+
+let metric name ~labels =
+  Prom.metric_value_or_zero name ~labels ()
+
+let check_metric_delta label name ~labels ~before ~delta =
+  Alcotest.(check (float 0.0001))
+    label
+    (before +. delta)
+    (metric name ~labels)
+
+let test_metric_names_stable () =
+  Alcotest.(check string)
+    "cache hits metric"
+    "masc_llm_provider_cache_hits_total"
+    Prom.metric_llm_provider_cache_hits;
+  Alcotest.(check string)
+    "cache misses metric"
+    "masc_llm_provider_cache_misses_total"
+    Prom.metric_llm_provider_cache_misses;
+  Alcotest.(check string)
+    "requests started metric"
+    "masc_llm_provider_requests_started_total"
+    Prom.metric_llm_provider_requests_started;
+  Alcotest.(check string)
+    "errors metric"
+    "masc_llm_provider_errors_total"
+    Prom.metric_llm_provider_errors;
+  Alcotest.(check string)
+    "retries metric"
+    "masc_llm_provider_retries_total"
+    Prom.metric_llm_provider_retries;
+  Alcotest.(check string)
+    "input tokens metric"
+    "masc_llm_provider_input_tokens_total"
+    Prom.metric_llm_provider_input_tokens;
+  Alcotest.(check string)
+    "output tokens metric"
+    "masc_llm_provider_output_tokens_total"
+    Prom.metric_llm_provider_output_tokens
+
+let test_sink_records_oas_callbacks () =
+  let sink : Llm_provider.Metrics.t = Bridge.make_sink () in
+  let model_id = Printf.sprintf "bridge-test-model-%d" (Unix.getpid ()) in
+  let provider = "bridge-test-provider" in
+  let model_labels = [ ("model", model_id) ] in
+  let provider_model_labels = [ ("provider", provider); ("model", model_id) ] in
+  let retry_labels =
+    [ ("provider", provider); ("model", model_id); ("attempt", "2") ]
+  in
+  let before_hit = metric Prom.metric_llm_provider_cache_hits ~labels:model_labels in
+  let before_miss = metric Prom.metric_llm_provider_cache_misses ~labels:model_labels in
+  let before_start =
+    metric Prom.metric_llm_provider_requests_started ~labels:model_labels
+  in
+  let before_error = metric Prom.metric_llm_provider_errors ~labels:model_labels in
+  let before_retry = metric Prom.metric_llm_provider_retries ~labels:retry_labels in
+  let before_input =
+    metric Prom.metric_llm_provider_input_tokens ~labels:provider_model_labels
+  in
+  let before_output =
+    metric Prom.metric_llm_provider_output_tokens ~labels:provider_model_labels
+  in
+  sink.on_cache_hit ~model_id;
+  sink.on_cache_miss ~model_id;
+  sink.on_request_start ~model_id;
+  sink.on_error ~model_id ~error:"ignored-freeform-error";
+  sink.on_retry ~provider ~model_id ~attempt:2;
+  sink.on_token_usage
+    ~provider ~model_id ~input_tokens:17 ~output_tokens:23;
+  check_metric_delta "cache hit +1"
+    Prom.metric_llm_provider_cache_hits
+    ~labels:model_labels ~before:before_hit ~delta:1.0;
+  check_metric_delta "cache miss +1"
+    Prom.metric_llm_provider_cache_misses
+    ~labels:model_labels ~before:before_miss ~delta:1.0;
+  check_metric_delta "request start +1"
+    Prom.metric_llm_provider_requests_started
+    ~labels:model_labels ~before:before_start ~delta:1.0;
+  check_metric_delta "error +1"
+    Prom.metric_llm_provider_errors
+    ~labels:model_labels ~before:before_error ~delta:1.0;
+  check_metric_delta "retry +1"
+    Prom.metric_llm_provider_retries
+    ~labels:retry_labels ~before:before_retry ~delta:1.0;
+  check_metric_delta "input tokens +17"
+    Prom.metric_llm_provider_input_tokens
+    ~labels:provider_model_labels ~before:before_input ~delta:17.0;
+  check_metric_delta "output tokens +23"
+    Prom.metric_llm_provider_output_tokens
+    ~labels:provider_model_labels ~before:before_output ~delta:23.0
+
+let () =
+  Alcotest.run "llm_metric_bridge"
+    [
+      ( "metrics",
+        [
+          Alcotest.test_case "metric names are stable" `Quick
+            test_metric_names_stable;
+          Alcotest.test_case "sink records OAS callbacks" `Quick
+            test_sink_records_oas_callbacks;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- wire OAS `Metrics.t` cache hit/miss, request-start, error, retry, and token-usage callbacks into bounded Prometheus counters
- forward the same callbacks from the explicit cascade metrics sink, which bypasses the global bridge
- add `test_llm_metric_bridge` coverage for stable metric names and `make_sink` callback increments

## Why

The incident/audit notes called out dashboard LLM sub-metrics that looked present but were effectively no-op callbacks. `Llm_metric_bridge.make_sink` only forwarded HTTP status, request latency, and capability drops; the remaining OAS callbacks inherited `Metrics.noop`. For captured cascade calls, the explicit per-call metrics object bypassed the global sink, so those counters also needed helper forwarding.

Labels stay bounded: cache/start/error use `model`; retry uses `provider`, `model`, `attempt`; token usage uses `provider`, `model` with numeric deltas.

## Validation

- PASS: `git diff --check`
- ATTEMPTED: `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_llm_metric_bridge.exe`
  - First run found a real patch issue: `warning 23 [useless-record-with]` in `llm_metric_bridge.ml`; fixed by removing `noop with` after every callback became explicit.
  - Rerun no longer reported that patch warning, then hit the shared local switch failure: `agent_sdk.cmi` and `lib/types/.masc_types.../types.cmi` make inconsistent assumptions over `Types` across unrelated modules. I stopped my own Dune process after recording the blocker to avoid adding more host load.