### PR TITLE
fix(keeper): surface semaphore timeout phase

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -313,23 +313,35 @@ type semaphore_wait_observation_kind =
   | Semaphore_wait_pending
   | Semaphore_wait_timeout
 
-let semaphore_wait_observation_reasons ~kind ~channel =
+let semaphore_wait_observation_reasons ?phase_label ~kind ~channel () =
   let kind_reason =
     match kind with
     | Semaphore_wait_pending -> "semaphore_wait_pending"
     | Semaphore_wait_timeout -> "semaphore_wait_timeout"
   in
+  let wait_reason =
+    match phase_label with
+    | Some phase -> "phase_" ^ phase
+    | None -> "peers_holding_slot"
+  in
   [
     kind_reason;
-    "peers_holding_slot";
+    wait_reason;
     "channel_" ^ Keeper_world_observation.channel_to_string channel;
   ]
 
-let record_semaphore_wait_observation ~base_path ~keeper_name ~channel ~kind =
+let record_semaphore_wait_observation
+    ?phase_label
+    ~base_path
+    ~keeper_name
+    ~channel
+    ~kind
+    () =
   Keeper_registry.record_skip_reasons
     ~base_path
     keeper_name
-    ~reasons:(semaphore_wait_observation_reasons ~kind ~channel)
+    ~reasons:
+      (semaphore_wait_observation_reasons ?phase_label ~kind ~channel ())
 
 let oas_timeout_budget_observation_reasons =
   [
@@ -594,7 +606,8 @@ let run_keepalive_unified_turn
           ~base_path:ctx.config.base_path
           ~keeper_name:meta_after_triage.name
           ~channel:turn_decision.channel
-          ~kind:Semaphore_wait_pending;
+          ~kind:Semaphore_wait_pending
+          ();
         (* RFC-0026 PR-E-1.6+1.7 shadow: ask the new admission router
            what it WOULD have decided, increment the shadow outcome
            counter, then fall through to the existing semaphore path
@@ -740,25 +753,39 @@ let run_keepalive_unified_turn
               updated)
         with
         | Ok meta -> meta
-        | Error (`Semaphore_wait_timeout wait_sec) ->
-          (* Peers held the turn semaphore longer than the wait cap — not a
-             keeper failure. Skip this cycle and let the next heartbeat retry
-             once a slot opens up. Failure counters intentionally NOT ticked
-             (this is starvation, not crash); but [last_blocker_class] IS
-             updated so the dashboard surfaces the stuck reason — without it
-             the keeper appears as [outcome=never_started, blocker_class=null]
-             and operators see "alive but invisible" (2026-05-05 fleet stuck
-             diagnosis evidence). *)
+        | Error (`Semaphore_wait_timeout timeout) ->
+          (* Slot/queue wait exceeded the cap — not a keeper failure. Skip this
+             cycle and let the next heartbeat retry. Failure counters
+             intentionally NOT ticked (this is starvation, not crash); but
+             [last_blocker_class] IS updated so the dashboard surfaces the
+             stuck reason — without it the keeper appears as
+             [outcome=never_started, blocker_class=null] and operators see
+             "alive but invisible" (2026-05-05 fleet stuck diagnosis
+             evidence). *)
+          let phase_label =
+            Keeper_turn_slot.semaphore_wait_phase_to_string
+              timeout.timeout_phase
+          in
           record_semaphore_wait_observation
             ~base_path:ctx.config.base_path
             ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel
-            ~kind:Semaphore_wait_timeout;
-          let auto_avail = Eio.Semaphore.get_value Keeper_turn_slot.autonomous_turn_semaphore in
-          let reactive_avail = Eio.Semaphore.get_value Keeper_turn_slot.reactive_turn_semaphore in
-          let turn_avail = Eio.Semaphore.get_value Keeper_turn_slot.turn_semaphore in
-          let holder_summary =
-            Keeper_turn_slot.slot_holders_summary ~now:(Time_compat.now ()) ()
+            ~phase_label
+            ~kind:Semaphore_wait_timeout
+            ();
+          let queue_ahead_text =
+            match timeout.timeout_queue_ahead with
+            | None -> ""
+            | Some ahead -> Printf.sprintf " queue_ahead=%d" ahead
+          in
+          let holder_text =
+            match timeout.timeout_holders with
+            | [] -> "none"
+            | holders ->
+              holders
+              |> List.map (fun (name, age) ->
+                   Printf.sprintf "%s/%.0fs" name age)
+              |> String.concat ", "
           in
           (* #13099 review: [last_blocker] gets capped to 200 chars by
              [cap_blocker] on meta load (narrative budget for dashboards),
@@ -772,14 +799,29 @@ let run_keepalive_unified_turn
                still attribute the starvation to specific peers.  *)
           let persisted_blocker =
             Printf.sprintf
-              "skipped: semaphore wait > %.0fs (cascade=%s, \
-               autonomous_available=%d reactive_available=%d \
-               turn_available=%d)"
-              wait_sec meta_after_triage.cascade_name auto_avail reactive_avail
-              turn_avail
+              "skipped: semaphore wait > %.0fs phase=%s \
+               (cascade=%s%s queue_depth=%d autonomous_available=%d \
+               reactive_available=%d turn_available=%d)"
+              timeout.timeout_wait_sec
+              phase_label
+              meta_after_triage.cascade_name
+              queue_ahead_text
+              timeout.timeout_queue_depth
+              timeout.timeout_autonomous_available
+              timeout.timeout_reactive_available
+              timeout.timeout_turn_available
           in
           let log_diagnostic =
-            Printf.sprintf "%s peers=%s" persisted_blocker holder_summary
+            Printf.sprintf "%s holders=[%s]" persisted_blocker holder_text
+          in
+          let blocker_class =
+            match timeout.timeout_phase with
+            | Keeper_turn_slot.Autonomous_queue_head
+            | Keeper_turn_slot.Autonomous_slot ->
+              Keeper_types.Autonomous_slot_wait_timeout
+            | Keeper_turn_slot.Reactive_slot
+            | Keeper_turn_slot.Turn_slot ->
+              Keeper_types.Turn_timeout_after_queue_wait
           in
           Log.Keeper.warn
             "%s: skipping turn (%s)"
@@ -792,7 +834,7 @@ let run_keepalive_unified_turn
             (fun rt ->
               { rt with
                 last_blocker = persisted_blocker;
-                last_blocker_class = Some Keeper_types.Autonomous_slot_wait_timeout;
+                last_blocker_class = Some blocker_class;
               })
             meta_after_triage)
       else if (not has_message_signal) && obs.message_cursor_updates <> [] then

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -54,15 +54,19 @@ type semaphore_wait_observation_kind =
   | Semaphore_wait_timeout
 
 val semaphore_wait_observation_reasons :
+  ?phase_label:string ->
   kind:semaphore_wait_observation_kind ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
+  unit ->
   string list
 
 val record_semaphore_wait_observation :
+  ?phase_label:string ->
   base_path:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   kind:semaphore_wait_observation_kind ->
+  unit ->
   unit
 
 val oas_timeout_budget_observation_reasons : string list

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -52,12 +52,29 @@ val semaphore_wait_timeout_sec : float
     heartbeat. *)
 
 exception Semaphore_wait_timeout of float
-(** Raised inside [with_keeper_turn_slot] when acquiring either the
-    autonomous, reactive, or global turn semaphore exceeds
-    [semaphore_wait_timeout_sec]. The float carries the wait cap so the
-    caller can render it without re-reading the env var. Callers should
-    treat this as "skip this turn, retry on next heartbeat" rather than
-    a keeper failure. *)
+(** Legacy exception form. The [with_keeper_turn_slot*] result path below
+    carries {!semaphore_wait_timeout}, which includes the phase and runtime
+    snapshot. Callers should treat this as "skip this turn, retry on next
+    heartbeat" rather than a keeper failure. *)
+
+type semaphore_wait_phase =
+  | Autonomous_queue_head
+  | Autonomous_slot
+  | Reactive_slot
+  | Turn_slot
+
+val semaphore_wait_phase_to_string : semaphore_wait_phase -> string
+
+type semaphore_wait_timeout = {
+  timeout_wait_sec : float;
+  timeout_phase : semaphore_wait_phase;
+  timeout_autonomous_available : int;
+  timeout_reactive_available : int;
+  timeout_turn_available : int;
+  timeout_queue_depth : int;
+  timeout_queue_ahead : int option;
+  timeout_holders : (string * float) list;
+}
 
 (** Test-only reset for the autonomous FIFO wait queue. *)
 val reset_autonomous_turn_queue_for_test : unit -> unit
@@ -161,7 +178,7 @@ val with_keeper_turn_slot_for_test :
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->
-  ('a, [> `Semaphore_wait_timeout of float ]) result
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 (** Test-only wrapper for the in-turn liveness pulse lifecycle. *)
 val with_in_turn_liveness_pulse_for_test :

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -8,6 +8,30 @@ open Keeper_types
 
 exception Semaphore_wait_timeout of float
 
+type semaphore_wait_phase =
+  | Autonomous_queue_head
+  | Autonomous_slot
+  | Reactive_slot
+  | Turn_slot
+
+let semaphore_wait_phase_to_string = function
+  | Autonomous_queue_head -> "autonomous_queue_head"
+  | Autonomous_slot -> "autonomous_slot"
+  | Reactive_slot -> "reactive_slot"
+  | Turn_slot -> "turn_slot"
+;;
+
+type semaphore_wait_timeout = {
+  timeout_wait_sec : float;
+  timeout_phase : semaphore_wait_phase;
+  timeout_autonomous_available : int;
+  timeout_reactive_available : int;
+  timeout_turn_available : int;
+  timeout_queue_depth : int;
+  timeout_queue_ahead : int option;
+  timeout_holders : (string * float) list;
+}
+
 let int_of_env_default_with_deprecated
     ~primary
     ~deprecated
@@ -291,6 +315,22 @@ let semaphore_wait_timeout_sec =
     ~default:180.0 ~min_v:5.0 ~max_v:Float.max_float
 ;;
 
+let semaphore_wait_timeout_snapshot
+    ~phase
+    ?queue_ahead
+    ?(holders = [])
+    () : semaphore_wait_timeout =
+  {
+    timeout_wait_sec = semaphore_wait_timeout_sec;
+    timeout_phase = phase;
+    timeout_autonomous_available = Eio.Semaphore.get_value autonomous_turn_semaphore;
+    timeout_reactive_available = Eio.Semaphore.get_value reactive_turn_semaphore;
+    timeout_turn_available = Eio.Semaphore.get_value turn_semaphore;
+    timeout_queue_depth = List.length (autonomous_waiter_snapshot_for_test ());
+    timeout_queue_ahead = queue_ahead;
+    timeout_holders = holders;
+  }
+
 (** Per-keeper record of the last autonomous turn completion timestamp.
     Used by the fairness cooldown to prevent a fast-cycling keeper from
     monopolizing the autonomous slot when peers are waiting.
@@ -480,7 +520,8 @@ let maybe_yield_for_fairness ~(keeper_name : string) : unit =
   end
 
 let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
-    ~(started_at : float) : (unit, [> `Semaphore_wait_timeout of float ]) result =
+    ~(started_at : float)
+  : (unit, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result =
   if Option.equal Int.equal (autonomous_waiter_head_ticket ()) (Some ticket)
   then Ok ()
   else
@@ -509,7 +550,12 @@ let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
         ~labels:[ ("keeper", keeper_name);
                   ("channel", "autonomous_queue_head") ]
         ();
-      Error (`Semaphore_wait_timeout semaphore_wait_timeout_sec)
+      Error
+        (`Semaphore_wait_timeout
+          (semaphore_wait_timeout_snapshot
+             ~phase:Autonomous_queue_head
+             ~queue_ahead:ahead
+             ()))
     else (
       (match Eio_context.get_clock_opt () with
        | Some clock -> Eio.Time.sleep clock autonomous_queue_poll_sec
@@ -559,7 +605,7 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
       autonomous_ticket = ref None;
     }
   in
-  let acquire_bounded ~label sem =
+  let acquire_bounded ~label ~phase sem =
     match Eio_context.get_clock_opt () with
     | Some clock ->
       (try
@@ -591,7 +637,9 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
           ~labels:[ ("keeper", keeper_name);
                     ("channel", label) ]
           ();
-        Error (`Semaphore_wait_timeout semaphore_wait_timeout_sec))
+        Error
+          (`Semaphore_wait_timeout
+            (semaphore_wait_timeout_snapshot ~phase ~holders ())))
     | None ->
       (* No Eio clock available: we are running outside an Eio main loop
          (e.g. Alcotest without [Eio_main.run]). Production masc-mcp
@@ -632,7 +680,12 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
           with
           | Error _ as e -> e
           | Ok () ->
-            match acquire_bounded ~label:"autonomous" autonomous_turn_semaphore with
+            match
+              acquire_bounded
+                ~label:"autonomous"
+                ~phase:Autonomous_slot
+                autonomous_turn_semaphore
+            with
             | Error _ as e -> e
             | Ok () ->
               slot_state.acquired_autonomous := true;
@@ -648,7 +701,12 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
         let reactive_result =
           if is_autonomous then Ok ()
           else
-            match acquire_bounded ~label:"reactive" reactive_turn_semaphore with
+            match
+              acquire_bounded
+                ~label:"reactive"
+                ~phase:Reactive_slot
+                reactive_turn_semaphore
+            with
             | Error _ as e -> e
             | Ok () ->
               slot_state.acquired_reactive := true;
@@ -657,7 +715,7 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
         match reactive_result with
         | Error _ as e -> e
         | Ok () ->
-        match acquire_bounded ~label:"turn" turn_semaphore with
+        match acquire_bounded ~label:"turn" ~phase:Turn_slot turn_semaphore with
         | Error _ as e -> e
         | Ok () ->
           slot_state.acquired_turn := true;

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -1,5 +1,24 @@
 exception Semaphore_wait_timeout of float
 
+type semaphore_wait_phase =
+  | Autonomous_queue_head
+  | Autonomous_slot
+  | Reactive_slot
+  | Turn_slot
+
+val semaphore_wait_phase_to_string : semaphore_wait_phase -> string
+
+type semaphore_wait_timeout = {
+  timeout_wait_sec : float;
+  timeout_phase : semaphore_wait_phase;
+  timeout_autonomous_available : int;
+  timeout_reactive_available : int;
+  timeout_turn_available : int;
+  timeout_queue_depth : int;
+  timeout_queue_ahead : int option;
+  timeout_holders : (string * float) list;
+}
+
 (** Global turn slot cap. Safety ceiling for ALL keeper turns. *)
 val keeper_turn_throttle_limit : int
 
@@ -62,7 +81,7 @@ val wait_for_autonomous_queue_head_for_test :
   keeper_name:string ->
   ticket:int ->
   started_at:float ->
-  (unit, [> `Semaphore_wait_timeout of float ]) result
+  (unit, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 (** Pure computation: seconds keeper should yield before re-entering queue
     at time [now].  0.0 = no yield needed. *)
@@ -91,11 +110,11 @@ val with_keeper_turn_slot :
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->
-  ('a, [> `Semaphore_wait_timeout of float ]) result
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->
-  ('a, [> `Semaphore_wait_timeout of float ]) result
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -127,7 +127,8 @@ let test_wait_observation_reason_labels () =
     [ "semaphore_wait_pending"; "peers_holding_slot"; "channel_reactive" ]
     (Masc_mcp.Keeper_heartbeat_loop.semaphore_wait_observation_reasons
        ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_pending
-       ~channel:Masc_mcp.Keeper_world_observation.Reactive);
+       ~channel:Masc_mcp.Keeper_world_observation.Reactive
+       ());
   Alcotest.(check (list string))
     "timeout scheduled autonomous reasons"
     [
@@ -137,7 +138,20 @@ let test_wait_observation_reason_labels () =
     ]
     (Masc_mcp.Keeper_heartbeat_loop.semaphore_wait_observation_reasons
        ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_timeout
-       ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous)
+       ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
+       ());
+  Alcotest.(check (list string))
+    "timeout reasons can carry precise phase"
+    [
+      "semaphore_wait_timeout";
+      "phase_autonomous_queue_head";
+      "channel_scheduled_autonomous";
+    ]
+    (Masc_mcp.Keeper_heartbeat_loop.semaphore_wait_observation_reasons
+       ~phase_label:"autonomous_queue_head"
+       ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_timeout
+       ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
+       ())
 
 let test_wait_observation_updates_registry_skip_stamp () =
   let base_path =
@@ -156,7 +170,8 @@ let test_wait_observation_updates_registry_skip_stamp () =
         ~base_path
         ~keeper_name:keeper
         ~channel:Masc_mcp.Keeper_world_observation.Reactive
-        ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_pending;
+        ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_pending
+        ();
       match Masc_mcp.Keeper_registry.get ~base_path keeper with
       | Some { Masc_mcp.Keeper_registry.last_skip_observation = Some (_, reasons); _ } ->
         Alcotest.(check (list string))

--- a/test/test_keeper_semaphore_wait_queue_head_clock.ml
+++ b/test/test_keeper_semaphore_wait_queue_head_clock.ml
@@ -52,11 +52,20 @@ let test_stale_started_at_times_out_immediately () =
           ~ticket:ours
           ~started_at:stale_started_at
       with
-      | Error (`Semaphore_wait_timeout waited) ->
+      | Error (`Semaphore_wait_timeout timeout) ->
         Alcotest.(check (float 0.001))
           "timeout value is the configured cap"
           timeout_sec
-          waited
+          timeout.timeout_wait_sec;
+        Alcotest.(check string)
+          "timeout phase is queue-head wait"
+          "autonomous_queue_head"
+          (Keeper_turn_slot.semaphore_wait_phase_to_string
+             timeout.timeout_phase);
+        Alcotest.(check (option int))
+          "timeout records waiters ahead"
+          (Some 1)
+          timeout.timeout_queue_ahead
       | Ok () ->
         Alcotest.fail
           "expected Semaphore_wait_timeout from a stale [started_at] but got Ok"


### PR DESCRIPTION
## Summary
- carry semaphore timeout phase + runtime snapshot from `Keeper_turn_slot` to heartbeat handling
- replace misleading `peers holding slot` warning text with phase, queue depth/ahead, available counts, and holder summary
- stamp timeout skip reasons with `phase_<phase>` so dashboard/watchdog data can distinguish queue-head waits from real slot pressure

## Validation
- PASS: `git diff --check HEAD~1 HEAD`
- BLOCKED: `./scripts/dune-local.sh build test/test_keeper_semaphore_wait_queue_head_clock.exe test/test_keeper_turn_slot_holders.exe test/test_keeper_semaphore_wait_counter.exe` stayed queued behind `/tmp/me-dune-local.lock`; lock was held by other active Dune worktree builds, so I stopped only my queued lock waiter and did not bypass the repo wrapper.
- LIVE AUDIT: `curl http://127.0.0.1:8935/health` is OK with `effective_base_path=/Users/dancer/me`, but the live server is still running commit `1ca6722cb8`, so this PR is not live until merged and restarted.

## Operator impact
Current live warnings can say `turn_available=8` while still claiming peers hold the slot. After this change, the log/runtime blocker identifies the timed-out phase (`autonomous_queue_head`, `autonomous_slot`, `reactive_slot`, or `turn_slot`) and uses the timeout-time snapshot instead of a later, misleading sample.