### PR TITLE
fix(test): unblock main — repair test_dune_local_script + test_ci_hardening_source

### DIFF
--- a/test/stanzas/test_ci_hardening_source.inc
+++ b/test/stanzas/test_ci_hardening_source.inc
@@ -1,4 +1,4 @@
 (test
  (name test_ci_hardening_source)
  (modules test_ci_hardening_source)
- (libraries alcotest unix str))
+ (libraries alcotest unix str masc_mcp.masc_types))

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -481,7 +481,7 @@ let test_oas_pin_source_contracts () =
      is intentionally drifting (e.g. mid-bump). *)
   check bool "dune-local.sh asserts oas pin before invoking dune" true
     (file_contains_pattern "scripts/dune-local.sh"
-       "scripts/check-oas-pin.sh\" --local-only");
+       "_pin_check}\" --local-only");
   check bool "dune-local.sh exposes MASC_SKIP_PIN_CHECK bypass" true
     (file_contains_pattern "scripts/dune-local.sh"
        "MASC_SKIP_PIN_CHECK");
@@ -611,10 +611,10 @@ let test_http_write_auth_contracts () =
        "else ensure_same_origin_browser_request request");
   check bool "broadcast route requires token-bound broadcast permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
-       {|with_token_permission_auth ~permission:Types.CanBroadcast|});
+       {|with_token_permission_auth ~permission:Masc_domain.CanBroadcast|});
   check bool "keeper config update requires admin permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
-       {|with_token_permission_auth ~permission:Types.CanAdmin|});
+       {|with_token_permission_auth ~permission:Masc_domain.CanAdmin|});
   check bool "board vote route requires board vote tool auth" true
     (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
        {|with_tool_auth ~tool_name:"masc_board_vote"|});
@@ -635,10 +635,10 @@ let test_http_write_auth_contracts () =
        {|with_tool_auth ~tool_name:"masc_broadcast"|});
   check bool "provider runs post requires admin permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
-       {|with_token_permission_auth ~permission:Types.CanAdmin|});
+       {|with_token_permission_auth ~permission:Masc_domain.CanAdmin|});
   check bool "dashboard delete actions require token-bound admin permission" true
     (file_contains_pattern "lib/server/server_dashboard_http_delete_actions.ml"
-       {|with_token_permission_auth ~permission:Types.CanAdmin|});
+       {|with_token_permission_auth ~permission:Masc_domain.CanAdmin|});
   check bool "server auth defines public-read cors origin helper" true
     (file_contains_pattern "lib/server/server_auth.ml"
        "let public_read_cors_origin_opt");
@@ -666,7 +666,7 @@ let test_tool_admin_snapshot_auth_contracts () =
   check bool "tool admin snapshot metadata requires admin permission" true
     (file_contains_pattern "lib/tool_misc.ml"
        {|"masc_tool_admin_snapshot" | "masc_tool_admin_update" ->
-      Some Types.CanAdmin|});
+      Some Masc_domain.CanAdmin|});
   check bool "tool admin snapshot legacy permission map requires admin" true
     (file_contains_pattern "lib/tool_permission_map.ml"
        {|("masc_tool_admin_snapshot", CanAdmin)|})

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -46,10 +46,7 @@ let rec rm_rf path =
     end else Sys.remove path
 
 let with_temp_dir prefix f =
-  let dir =
-    Unix.mkdtemp
-      (Filename.concat (Filename.get_temp_dir_name ()) (prefix ^ "XXXXXX"))
-  in
+  let dir = Filename.temp_dir prefix "" in
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
 let run_shell ?(env = []) ?(unset_env = []) ~cwd cmd =


### PR DESCRIPTION
## Summary

Main has been failing **Build/Health/Lint** since #13095 (agent_sdk pin v0.190.2, merged 2026-05-05 09:14 UTC) because two pre-existing test issues surfaced together. Any PR whose changed surface triggers the heavy CI via PR Live Gate (e.g. #13097 RFC-0027 PR-9b, #13096) is currently blocked on these failures, even when its own diff is clean.

## Failures repaired

### 1. `test_dune_local_script.ml` — non-existent stdlib value
\`\`\`
File "test/test_dune_local_script.ml", line 50, characters 4-16:
50 |     Unix.mkdtemp
         ^^^^^^^^^^^^
Error: Unbound value Unix.mkdtemp
Hint:   Did you mean Unix.mktime?
\`\`\`
\`Unix.mkdtemp\` does not exist in OCaml's stdlib (the hint suggests \`mktime\`, which is the time-conversion function — not what we want). Replaced with \`Filename.temp_dir prefix ""\` (available since 4.14; default \`temp_dir = Filename.get_temp_dir_name ()\`, so behavior is preserved).

### 2. `test_ci_hardening_source.ml` — missing library + stale grep patterns
- **Compile error**: \`module Types = Masc_domain\` raised \`warning 49 [no-cmi-file]\` because the dune stanza didn't include the \`masc_types\` library. Added \`masc_mcp.masc_types\` to \`(libraries ...)\`.
- **Source-pattern asserts went stale** after #13089 (\`Types\` -> \`Masc_domain\` rename) and the dune-local.sh variable refactor:
  - 5× \`Types.Can{Broadcast,Admin}\` -> \`Masc_domain.Can{Broadcast,Admin}\` (lines 614, 617, 638, 641, 669)
  - dune-local.sh pattern aligned with current \`"${_pin_check}"\` form (the literal path is no longer in source, but the \`--local-only\` invocation still must be present)

## Local verification

\`\`\`
$ dune build test/test_dune_local_script.exe test/test_ci_hardening_source.exe
$ dune exec test/test_dune_local_script.exe
Test Successful in 2.600s. 7 tests run.
$ dune exec test/test_ci_hardening_source.exe
Test Successful in 0.735s. 38 tests run.
\`\`\`

## Why test-only

These are pure test repairs — no production code changes. The contracts the tests intend to enforce are still enforced; only the grep needles were updated to reflect the post-rename source.

## Out of scope

- The original brokenness was not introduced by this PR's author; this is a triage repair so the merge queue can move. Whoever wants the long-term contract changes (looser pattern? stricter?) can iterate on top.

## Test plan

- [x] `dune build` clean locally
- [x] both repaired test executables pass (7/7 + 38/38)
- [ ] CI Build/Health/Lint green on this branch (will confirm once PR Live Gate fans out)
- [ ] After merge, #13097 (RFC-0027 PR-9b) heavy CI re-runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)