### PR TITLE
fix(keeper): surface unloaded tool policy accessors

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -60,8 +60,48 @@ let is_masc_write_allowed path =
 (* Loaded by init_policy_config at server startup.
    None = config not yet loaded (init_policy_config not yet called). *)
 let policy_config : Keeper_tool_policy_config.t option ref = ref None
+let policy_config_unloaded_warned : (string, unit) Hashtbl.t = Hashtbl.create 16
+let policy_config_unloaded_mutex = Stdlib.Mutex.create ()
 
 let policy_config_for_validation () = !policy_config
+
+let warn_unloaded_policy_config_once ~accessor =
+  let should_warn =
+    Stdlib.Mutex.lock policy_config_unloaded_mutex;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock policy_config_unloaded_mutex)
+      (fun () ->
+        if Hashtbl.mem policy_config_unloaded_warned accessor then
+          false
+        else (
+          Hashtbl.replace policy_config_unloaded_warned accessor ();
+          true))
+  in
+  if should_warn then
+    Log.Keeper.warn
+      "tool_policy.%s called before init_policy_config loaded config/tool_policy.toml; returning fallback"
+      accessor
+
+let observe_unloaded_policy_config ~accessor =
+  Prometheus.inc_counter Prometheus.metric_tool_policy_unloaded_query
+    ~labels:[("accessor", accessor)]
+    ();
+  warn_unloaded_policy_config_once ~accessor
+
+let with_policy_config_or ?(on_none = fun () -> ()) ~accessor ~default f =
+  match !policy_config with
+  | None ->
+    observe_unloaded_policy_config ~accessor;
+    on_none ();
+    default
+  | Some cfg -> f cfg
+
+let reset_policy_config_for_test () =
+  policy_config := None;
+  Stdlib.Mutex.lock policy_config_unloaded_mutex;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock policy_config_unloaded_mutex)
+    (fun () -> Hashtbl.clear policy_config_unloaded_warned)
 
 let init_policy_config ~base_path =
   match Keeper_tool_policy_config.load ~base_path with
@@ -99,77 +139,72 @@ let allows_shell_write_for_preset (preset : tool_preset) : bool =
 (* ── Git clone config accessors (config-driven) ──────────────── *)
 
 let git_clone_allowed_orgs () : string list option =
-  match !policy_config with
-  | None -> None
-  | Some cfg -> Some (Keeper_tool_policy_config.git_clone_allowed_orgs cfg)
+  with_policy_config_or ~accessor:"git_clone_allowed_orgs" ~default:None
+    (fun cfg -> Some (Keeper_tool_policy_config.git_clone_allowed_orgs cfg))
 
 let git_clone_denied_repos () : string list option =
-  match !policy_config with
-  | None -> None
-  | Some cfg -> Some (Keeper_tool_policy_config.git_clone_denied_repos cfg)
+  with_policy_config_or ~accessor:"git_clone_denied_repos" ~default:None
+    (fun cfg -> Some (Keeper_tool_policy_config.git_clone_denied_repos cfg))
 
 let clone_depth () : int =
-  match !policy_config with
-  | None -> 0
-  | Some cfg -> Keeper_tool_policy_config.clone_depth cfg
+  with_policy_config_or ~accessor:"clone_depth" ~default:0
+    Keeper_tool_policy_config.clone_depth
 
 let clone_timeout_sec () : float =
-  match !policy_config with
-  | None -> default_clone_timeout_sec
-  | Some cfg -> Keeper_tool_policy_config.clone_timeout_sec cfg
+  with_policy_config_or ~accessor:"clone_timeout_sec"
+    ~default:default_clone_timeout_sec
+    Keeper_tool_policy_config.clone_timeout_sec
 
 let push_timeout_sec () : float =
-  match !policy_config with
-  | None -> default_push_timeout_sec
-  | Some cfg -> Keeper_tool_policy_config.push_timeout_sec cfg
+  with_policy_config_or ~accessor:"push_timeout_sec"
+    ~default:default_push_timeout_sec
+    Keeper_tool_policy_config.push_timeout_sec
 
 let pr_create_timeout_sec () : float =
-  match !policy_config with
-  | None -> default_pr_create_timeout_sec
-  | Some cfg -> Keeper_tool_policy_config.pr_create_timeout_sec cfg
+  with_policy_config_or ~accessor:"pr_create_timeout_sec"
+    ~default:default_pr_create_timeout_sec
+    Keeper_tool_policy_config.pr_create_timeout_sec
 
 (* ── GH cache config accessors (config-driven) ─────────────── *)
 
 let gh_cache_ttl_sec () : float =
-  match !policy_config with
-  | None -> default_gh_cache_ttl_sec
-  | Some cfg -> Keeper_tool_policy_config.gh_cache_ttl_sec cfg
+  with_policy_config_or ~accessor:"gh_cache_ttl_sec"
+    ~default:default_gh_cache_ttl_sec
+    Keeper_tool_policy_config.gh_cache_ttl_sec
 
 let gh_cache_fetch_page_size () : int =
-  match !policy_config with
-  | None -> default_gh_cache_fetch_page_size
-  | Some cfg -> Keeper_tool_policy_config.gh_cache_fetch_page_size cfg
+  with_policy_config_or ~accessor:"gh_cache_fetch_page_size"
+    ~default:default_gh_cache_fetch_page_size
+    Keeper_tool_policy_config.gh_cache_fetch_page_size
 
 let gh_cache_fetch_timeout_sec () : float =
-  match !policy_config with
-  | None -> default_gh_cache_fetch_timeout_sec
-  | Some cfg -> Keeper_tool_policy_config.gh_cache_fetch_timeout_sec cfg
+  with_policy_config_or ~accessor:"gh_cache_fetch_timeout_sec"
+    ~default:default_gh_cache_fetch_timeout_sec
+    Keeper_tool_policy_config.gh_cache_fetch_timeout_sec
 
 let gh_cache_max_alternatives () : int =
-  match !policy_config with
-  | None -> default_gh_cache_max_alternatives
-  | Some cfg -> Keeper_tool_policy_config.gh_cache_max_alternatives cfg
+  with_policy_config_or ~accessor:"gh_cache_max_alternatives"
+    ~default:default_gh_cache_max_alternatives
+    Keeper_tool_policy_config.gh_cache_max_alternatives
 
 let gh_cache_max_output_bytes () : int =
-  match !policy_config with
-  | None -> default_gh_cache_max_output_bytes
-  | Some cfg -> Keeper_tool_policy_config.gh_cache_max_output_bytes cfg
+  with_policy_config_or ~accessor:"gh_cache_max_output_bytes"
+    ~default:default_gh_cache_max_output_bytes
+    Keeper_tool_policy_config.gh_cache_max_output_bytes
 
 (* ── Preset subsumption (config-driven) ──────────────────────── *)
 
 let preset_can_satisfy ~(agent_preset : string) ~(required_preset : string) : bool =
-  match !policy_config with
-  | None -> false
-  | Some cfg ->
-    Keeper_tool_policy_config.preset_can_satisfy cfg ~agent_preset ~required_preset
+  with_policy_config_or ~accessor:"preset_can_satisfy" ~default:false
+    (fun cfg ->
+      Keeper_tool_policy_config.preset_can_satisfy cfg ~agent_preset ~required_preset)
 
 (** Return configured preset names (excluding "full") for schema enum generation. *)
 let configured_preset_names () : string list =
-  match !policy_config with
-  | None -> []
-  | Some cfg ->
-    Keeper_tool_policy_config.preset_names cfg
-    |> List.filter (fun n -> not (String.equal n "full"))
+  with_policy_config_or ~accessor:"configured_preset_names" ~default:[]
+    (fun cfg ->
+      Keeper_tool_policy_config.preset_names cfg
+      |> List.filter (fun n -> not (String.equal n "full")))
 
 (* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
 
@@ -270,9 +305,8 @@ let is_keeper_maintenance_only_tool name =
 
 let keeper_base_candidate_tool_names () =
   let config_tools =
-    match !policy_config with
-    | None -> []
-    | Some cfg -> Keeper_tool_policy_config.all_group_tools cfg
+    with_policy_config_or ~accessor:"keeper_base_candidate_tool_names"
+      ~default:[] Keeper_tool_policy_config.all_group_tools
   in
   dedupe_tool_names
     ( config_tools
@@ -283,15 +317,16 @@ let keeper_base_candidate_tool_names () =
 (** Resolve a named group from tool_policy.toml.  Returns the hardcoded
     fallback when config is not loaded. *)
 let resolve_policy_group ~(fallback : string list) (group_name : string) : string list =
-  match !policy_config with
-  | Some cfg ->
-    (match Keeper_tool_policy_config.resolve_group cfg group_name with
-     | Some tools -> dedupe_tool_names tools
-     | None ->
-       Log.Keeper.warn "tool_policy group %S not found, using fallback (%d tools)"
-         group_name (List.length fallback);
-       fallback)
-  | None -> fallback
+  with_policy_config_or
+    ~accessor:("resolve_policy_group." ^ group_name)
+    ~default:fallback
+    (fun cfg ->
+      match Keeper_tool_policy_config.resolve_group cfg group_name with
+      | Some tools -> dedupe_tool_names tools
+      | None ->
+        Log.Keeper.warn "tool_policy group %S not found, using fallback (%d tools)"
+          group_name (List.length fallback);
+        fallback)
 
 (** Optional tools that require explicit opt-in via also_allow.
     Reads [groups.optional] from tool_policy.toml; falls back to
@@ -323,29 +358,28 @@ let explicit_optional_candidate_tool_names (meta : keeper_meta) =
 
 let preset_allowlist preset =
   let name = preset_name_of_tool_preset preset in
-  match !policy_config with
-  | None ->
-    Prometheus.inc_counter
-      Prometheus.metric_keeper_tool_policy_failures
-      ~labels:[("site", "policy_config_not_loaded"); ("preset", name)]
-      ();
-    Log.Keeper.error
-      "tool policy config not loaded; preset '%s' returns empty. \
-       Call init_policy_config at startup." name;
-    []
-  | Some cfg ->
-    let injected = injected_masc_tool_names () in
-    let injected_lookup = Hashtbl.create (List.length injected) in
-    List.iter (fun n -> Hashtbl.replace injected_lookup n ()) injected;
-    let masc_filter tool_name = Hashtbl.mem injected_lookup tool_name in
-    match Keeper_tool_policy_config.resolve_preset cfg name ~masc_filter () with
-    | Some Keeper_tool_policy_config.All_candidates ->
-      (* all_candidates = true: return full candidate set *)
-      keeper_base_candidate_tool_names ()
-    | Some (Keeper_tool_policy_config.Subset tools) -> dedupe_tool_names tools
-    | None ->
-      Log.Keeper.warn "preset '%s' not defined in config/tool_policy.toml, returning empty" name;
-      []
+  with_policy_config_or ~accessor:("preset_allowlist." ^ name) ~default:[]
+    ~on_none:(fun () ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_tool_policy_failures
+        ~labels:[("site", "policy_config_not_loaded"); ("preset", name)]
+        ();
+      Log.Keeper.error
+        "tool policy config not loaded; preset '%s' returns empty. \
+         Call init_policy_config at startup." name)
+    (fun cfg ->
+      let injected = injected_masc_tool_names () in
+      let injected_lookup = Hashtbl.create (List.length injected) in
+      List.iter (fun n -> Hashtbl.replace injected_lookup n ()) injected;
+      let masc_filter tool_name = Hashtbl.mem injected_lookup tool_name in
+      match Keeper_tool_policy_config.resolve_preset cfg name ~masc_filter () with
+      | Some Keeper_tool_policy_config.All_candidates ->
+        (* all_candidates = true: return full candidate set *)
+        keeper_base_candidate_tool_names ()
+      | Some (Keeper_tool_policy_config.Subset tools) -> dedupe_tool_names tools
+      | None ->
+        Log.Keeper.warn "preset '%s' not defined in config/tool_policy.toml, returning empty" name;
+        [])
 
 let tool_policy_of_meta (meta : keeper_meta) =
   let allow =

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -21,6 +21,10 @@ val init_policy_config :
 val policy_config_for_validation :
   unit -> Keeper_tool_policy_config.t option
 
+(** Reset the loaded policy config and one-shot unloaded-accessor warning
+    state. Intended for isolated regression tests only. *)
+val reset_policy_config_for_test : unit -> unit
+
 (** {1 Preset Names and Mapping} *)
 
 (** Convert a [tool_preset] variant to its string name. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -605,6 +605,8 @@ let metric_keeper_tool_policy_failures =
   "masc_keeper_tool_policy_failures_total"
 let metric_tool_policy_unloaded_query =
   "masc_tool_policy_unloaded_query_total"
+let metric_tool_policy_init_failed =
+  "masc_tool_policy_init_failed_total"
 let metric_keeper_reconcile_failures =
   "masc_keeper_reconcile_failures_total"
 let metric_keeper_decision_audit_flush_failures =
@@ -1643,6 +1645,10 @@ let init () =
   add metric_tool_policy_unloaded_query
     "Total tool-policy accessors called before init_policy_config loaded \
      config/tool_policy.toml. Labeled by accessor."
+    Counter;
+  add metric_tool_policy_init_failed
+    "Total server startup tool-policy initialization failures. \
+     Labeled by base_path."
     Counter;
   add metric_keeper_reconcile_failures
     "Total current-task reconciliation failures. \

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -603,6 +603,8 @@ let metric_keeper_tool_selection_failures =
   "masc_keeper_tool_selection_failures_total"
 let metric_keeper_tool_policy_failures =
   "masc_keeper_tool_policy_failures_total"
+let metric_tool_policy_unloaded_query =
+  "masc_tool_policy_unloaded_query_total"
 let metric_keeper_reconcile_failures =
   "masc_keeper_reconcile_failures_total"
 let metric_keeper_decision_audit_flush_failures =
@@ -1637,6 +1639,10 @@ let init () =
      Labels: site, preset. The policy layer runs at module-init and preset \
      resolution time so it does not carry keeper context; keeper attribution \
      is recovered from the surrounding Log.Keeper line."
+    Counter;
+  add metric_tool_policy_unloaded_query
+    "Total tool-policy accessors called before init_policy_config loaded \
+     config/tool_policy.toml. Labeled by accessor."
     Counter;
   add metric_keeper_reconcile_failures
     "Total current-task reconciliation failures. \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -268,6 +268,7 @@ val metric_keeper_rollover_failures : string
 val metric_keeper_task_load_failures : string
 val metric_keeper_tool_selection_failures : string
 val metric_keeper_tool_policy_failures : string
+val metric_tool_policy_unloaded_query : string
 val metric_keeper_reconcile_failures : string
 val metric_keeper_decision_audit_flush_failures : string
 val metric_keeper_oas_cancel : string

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -269,6 +269,7 @@ val metric_keeper_task_load_failures : string
 val metric_keeper_tool_selection_failures : string
 val metric_keeper_tool_policy_failures : string
 val metric_tool_policy_unloaded_query : string
+val metric_tool_policy_init_failed : string
 val metric_keeper_reconcile_failures : string
 val metric_keeper_decision_audit_flush_failures : string
 val metric_keeper_oas_cancel : string

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -268,6 +268,15 @@ let init_runtime_context env =
   let fs = Eio.Stdenv.fs env in
   (clock, mono_clock, net, domain_mgr, proc_mgr, fs)
 
+let record_tool_policy_init_failure ~base_path msg =
+  Prometheus.inc_counter Prometheus.metric_tool_policy_init_failed
+    ~labels:[("base_path", base_path)]
+    ();
+  Prometheus.inc_counter Prometheus.metric_error_events
+    ~labels:[("type", "missing_config")]
+    ();
+  Log.Server.error "Fatal tool policy config load failure: %s" msg
+
 let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     : Mcp_server.server_state =
   let input_base_path =
@@ -313,8 +322,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   (match Keeper_exec_tools.init_policy_config ~base_path with
    | Ok () -> ()
    | Error msg ->
-       Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "missing_config")] ();
-      Log.Server.error "Fatal tool policy config load failure: %s" msg;
+       record_tool_policy_init_failure ~base_path msg;
        exit 1);
   (* Validate Tool_spec <-> TOML coverage *)
   let validation = Tool_registration_check.validate () in

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -46,6 +46,11 @@ val runtime_path_diagnostics :
   Mcp_server.server_state ->
   Server_base_path_diagnostics.t
 
+val record_tool_policy_init_failure : base_path:string -> string -> unit
+(** Record and log a fatal startup failure while loading
+    [config/tool_policy.toml]. Exposed for focused regression tests and
+    used before the startup path exits. *)
+
 val restore_persisted_sessions : Mcp_server.server_state -> unit
 val reconcile_active_agents_gauge : Mcp_server.server_state -> unit
 val bootstrap_server_state_blocking : Mcp_server.server_state -> unit

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -224,6 +224,18 @@ let _policy_config_cache : policy_config_cache_entry option ref = ref None
 (** Reset internal config cache — for test isolation only. *)
 let reset_policy_config_cache () = _policy_config_cache := None
 
+let observe_policy_config_load_error ~base_path ~env_config_dir msg =
+  let config_dir =
+    Option.value ~default:"<resolved-from-base-path>" env_config_dir
+  in
+  Prometheus.inc_counter Prometheus.metric_keeper_tool_policy_failures
+    ~labels:[("site", "tool_code_write_load_failed"); ("preset", "n/a")]
+    ();
+  Log.Keeper.warn
+    "tool_code_write: tool_policy.toml load failed; git clone policy is \
+     unavailable (base_path=%S config_dir=%S): %s"
+    base_path config_dir msg
+
 let get_policy_config_result ~base_path =
   let env_config_dir = Env_config.config_dir_opt () in
   match !_policy_config_cache with
@@ -232,6 +244,10 @@ let get_policy_config_result ~base_path =
     result
   | _ ->
     let result = Keeper_tool_policy_config.load ~base_path in
+    (match result with
+     | Ok _ -> ()
+     | Error msg ->
+         observe_policy_config_load_error ~base_path ~env_config_dir msg);
     _policy_config_cache := Some { base_path; env_config_dir; result };
     result
 

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -7,6 +7,7 @@ open Alcotest
 
 module Tool_code_write = Masc_mcp.Tool_code_write
 module Coord = Masc_mcp.Coord
+module Prometheus = Masc_mcp.Prometheus
 
 let msg_contains ~needle haystack =
   let hlen = String.length haystack in
@@ -17,6 +18,12 @@ let msg_contains ~needle haystack =
     else loop (i + 1)
   in
   nlen = 0 || loop 0
+
+let tool_code_write_policy_load_failure_metric () =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_keeper_tool_policy_failures
+    ~labels:[("site", "tool_code_write_load_failed"); ("preset", "n/a")]
+    ()
 
 (* OCaml's Unix module does not expose unsetenv; for config overrides that are
    read via Env_config_core.trim_opt, an empty string is equivalent to unset. *)
@@ -268,6 +275,19 @@ let test_missing_policy_does_not_reuse_previous_cache () =
       check bool "mentions unavailable policy" true
         (msg_contains ~needle:"Git clone policy unavailable" reason)
   | Ok () -> fail "missing policy should not reuse prior cached config"
+
+let test_policy_load_error_emits_metric () =
+  Tool_code_write.reset_policy_config_cache ();
+  Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
+    with_trimmed_env "MASC_CONFIG_DIR" None @@ fun () ->
+    let before = tool_code_write_policy_load_failure_metric () in
+    (match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
+       "https://github.com/jeong-sik/repo.git" with
+     | Error _ -> ()
+     | Ok () -> fail "missing policy should fail closed");
+    let after = tool_code_write_policy_load_failure_metric () in
+    check bool "policy load failure increments metric" true
+      (after >= before +. 1.0))
 
 let test_explicit_config_dir_override_still_validates () =
   with_temp_dir "tool-code-write-env-policy" @@ fun root ->
@@ -582,6 +602,8 @@ let () =
       test_case "missing config fails closed" `Quick test_missing_base_path_without_config_fails_closed;
       test_case "missing policy does not reuse previous cache" `Quick
         test_missing_policy_does_not_reuse_previous_cache;
+      test_case "policy load error emits metric" `Quick
+        test_policy_load_error_emits_metric;
       test_case "explicit config dir override still validates" `Quick test_explicit_config_dir_override_still_validates;
       test_case "mixed-case org" `Quick test_mixed_case_org;
       test_case "normalize ssh clone url to https" `Quick

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -280,6 +280,20 @@ let test_tool_policy_unloaded_accessors_emit_metric () =
     (clone_depth_after >= clone_depth_before +. 1.0);
   init_registry ()
 
+let tool_policy_init_failed_metric base_path =
+  Prometheus.metric_value_or_zero Prometheus.metric_tool_policy_init_failed
+    ~labels:[("base_path", base_path)]
+    ()
+
+let test_tool_policy_init_failure_emits_metric () =
+  let base_path = "/tmp/masc-test-tool-policy-init-failed" in
+  let before = tool_policy_init_failed_metric base_path in
+  Server_runtime_bootstrap.record_tool_policy_init_failure ~base_path
+    "synthetic test failure";
+  let after = tool_policy_init_failed_metric base_path in
+  check bool "tool policy init failure increments metric" true
+    (after >= before +. 1.0)
+
 (* ── Runner ───────────────────────────────────────────────────── *)
 
 let () =
@@ -311,5 +325,7 @@ let () =
             test_oas_mainline_warns_are_promoted_in_bridge;
           test_case "tool policy pre-init accessors emit metric" `Quick
             test_tool_policy_unloaded_accessors_emit_metric;
+          test_case "tool policy init failure emits metric" `Quick
+            test_tool_policy_init_failure_emits_metric;
         ] );
     ]

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -251,6 +251,35 @@ let test_oas_mainline_warns_are_promoted_in_bridge () =
     (file_contains_pattern "lib/oas_log_bridge.ml"
        {|Warn, "agent_tools", "ApprovalRequired but no approval callback — executing"|})
 
+let tool_policy_unloaded_metric accessor =
+  Prometheus.metric_value_or_zero Prometheus.metric_tool_policy_unloaded_query
+    ~labels:[("accessor", accessor)]
+    ()
+
+let test_tool_policy_unloaded_accessors_emit_metric () =
+  Keeper_tool_policy.reset_policy_config_for_test ();
+  let allowed_orgs_before =
+    tool_policy_unloaded_metric "git_clone_allowed_orgs"
+  in
+  check bool "pre-init allowed_orgs remains fail-closed" true
+    (Option.is_none (Keeper_tool_policy.git_clone_allowed_orgs ()));
+  let allowed_orgs_after =
+    tool_policy_unloaded_metric "git_clone_allowed_orgs"
+  in
+  check bool "allowed_orgs pre-init query increments metric" true
+    (allowed_orgs_after >= allowed_orgs_before +. 1.0);
+  let clone_depth_before =
+    tool_policy_unloaded_metric "clone_depth"
+  in
+  check int "pre-init clone_depth fallback unchanged" 0
+    (Keeper_tool_policy.clone_depth ());
+  let clone_depth_after =
+    tool_policy_unloaded_metric "clone_depth"
+  in
+  check bool "clone_depth pre-init query increments metric" true
+    (clone_depth_after >= clone_depth_before +. 1.0);
+  init_registry ()
+
 (* ── Runner ───────────────────────────────────────────────────── *)
 
 let () =
@@ -280,5 +309,7 @@ let () =
             test_keeper_mainline_failures_log_at_error;
           test_case "oas mainline warns are promoted in bridge" `Quick
             test_oas_mainline_warns_are_promoted_in_bridge;
+          test_case "tool policy pre-init accessors emit metric" `Quick
+            test_tool_policy_unloaded_accessors_emit_metric;
         ] );
     ]


### PR DESCRIPTION
## Summary

This PR turns the remaining config-driven keeper tool-policy fallbacks into visible runtime signals instead of silent/default-only behavior.

- Adds `masc_tool_policy_unloaded_query_total{accessor=...}` for tool-policy accessors called before `init_policy_config` has loaded `config/tool_policy.toml`.
- Emits a one-shot keeper warning per unloaded accessor while preserving each accessor's existing fallback behavior.
- Logs discarded `Keeper_tool_policy_config.load` errors from `tool_code_write` and increments `masc_keeper_tool_policy_failures_total{site="tool_code_write_load_failed",preset="n/a"}` when clone-policy validation cannot load config.
- Records fatal startup policy-load failures as `masc_tool_policy_init_failed_total{base_path=...}` before exiting, while preserving the existing missing-config error counter and server error log.
- Adds focused regression coverage for unloaded accessor metrics, `tool_code_write` load-failure metrics, and bootstrap init-failure metrics.

## Why

Live task lineage:

- `task-185` (`goal-nick0cave`) asks for pre-init accessor warning/counter coverage, discarded `tool_code_write` load-error visibility, and a bootstrap init-failure counter.
- `task-186` (`goal-masc-improver`) tracks the same silent-empty accessor class from the docs/audit thread, but its stricter return-shape/raise variant is intentionally not bundled here.

Without these signals, operators can see downstream empty or reduced keeper tool surfaces without a direct runtime clue that the config-load boundary caused them.

## Coverage

The signal is installed at the accessor layer via `with_policy_config_or`, so every existing caller observes the same metric/warn behavior without per-call-site patches. That includes the previously flagged `keeper_exec_shell` `git_clone` path as well as the dashboard, keeper-agent-run, and keeper-turn-up-create paths.

Current wrapped accessors:

- `git_clone_allowed_orgs`
- `git_clone_denied_repos`
- `clone_depth`
- `clone_timeout_sec`
- `push_timeout_sec`
- `pr_create_timeout_sec`
- `gh_cache_ttl_sec`
- `gh_cache_fetch_page_size`
- `gh_cache_fetch_timeout_sec`
- `gh_cache_max_alternatives`
- `gh_cache_max_output_bytes`
- `preset_can_satisfy`
- `configured_preset_names`

## Validation

- `git diff --check` passed.
- `scripts/check-oas-pin.sh` passed: repo OAS pin/API fingerprint verified at `86a0e540a8856db5ee740cb2d1deff58bf0bbbfb`; it warned that upstream OAS has drifted to `c310b2d2fc31db2f83ce2fa447376be4df21f9c8`.
- Focused local Dune verification is currently blocked by shared opam-switch drift: `scripts/check-oas-pin.sh --local-only` reports local `agent_sdk` pinned to `c310b2d2fc31db2f83ce2fa447376be4df21f9c8`, expected `86a0e540a8856db5ee740cb2d1deff58bf0bbbfb`. I ran `scripts/opam-pin-external-deps.sh --install` successfully once, but the shared switch flipped back before retry. CI should validate this branch on a clean runner.
