### PR TITLE
fix(types): stabilize keeper facade cmi

### DIFF
--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -44,7 +44,9 @@
     long-term memory recall.  This module re-exports policy types
     only — no behavior. *)
 
-include module type of Keeper_types_profile
+include module type of struct
+  include Keeper_types_profile
+end
 
 (** {1 Policy types (remain in keeper_meta top-level)} *)
 
@@ -400,7 +402,9 @@ val read_meta_if_changed :
 
 (** {1 Re-exports from Keeper_types_support} *)
 
-include module type of Keeper_types_support
+include module type of struct
+  include Keeper_types_support
+end
 
 (** {1 Fiber health (for keeper supervisor)} *)
 


### PR DESCRIPTION
## Summary

- strengthen `Keeper_types.mli` re-exports with `struct include ... end` so the facade keeps manifest type identity across included keeper modules
- keep the explicit `lib/types/types.mli` facade from #13121 instead of deleting it
- leave the OCaml structure baseline at the current `lib_other_mli_missing = 1`

## Why this matters

#13121 added an explicit `Types` facade, then full CI failed with inconsistent assumptions over interface `Types` between `Masc_mcp__Keeper_types.cmi` and `lib/types/types.cmi`.

The first #13130 attempt deleted `lib/types/types.mli`, but manual full CI still reproduced the same `.cmi` failure in Health and Lint. The actual unstable edge was `Keeper_types.mli` using plain `include module type of Keeper_types_profile` and `Keeper_types_support`. Strengthening those includes makes the keeper facade use the same manifest type identity as the `Types` facade.

## Evidence

- Failing full CI after #13121: https://github.com/jeong-sik/masc-mcp/actions/runs/25367680962
- Failed first #13130 manual CI: https://github.com/jeong-sik/masc-mcp/actions/runs/25368662149
- Follow-up issue with the failed first hypothesis: #13128

## Local checks

- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=... scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Keeper_run_context.cmi`
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=... scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Server_dashboard_http_keeper_api.cmi`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `git diff --check`
