### PR TITLE
feat(goal): expose attainment projection

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -468,6 +468,90 @@ describe('dashboard goals decoding', () => {
     expect(result.summary.on_track_goals).toBe(1)
   })
 
+  it('decodes goal attainment projections on tree payloads', async () => {
+    const rawResponse = {
+      tree: [
+        makeRawGoalNode({
+          metric: 'completion_pct',
+          target_value: '75%',
+          attainment: {
+            state: 'attained',
+            basis: 'metric_target_percent',
+            metric: 'completion_pct',
+            target_value: '75%',
+            target_parse_status: 'parseable',
+            unit: 'percent',
+            observed_value: 75,
+            target_numeric: 75,
+            attainment_pct: 100,
+            task_done_count: 3,
+            task_count: 4,
+            note: 'Derived from linked task completion against a percent target.',
+          },
+        }),
+      ],
+      summary: {},
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardGoalsTree()
+
+    expect(result.tree[0]?.attainment).toMatchObject({
+      state: 'attained',
+      basis: 'metric_target_percent',
+      metric: 'completion_pct',
+      target_value: '75%',
+      target_parse_status: 'parseable',
+      unit: 'percent',
+      observed_value: 75,
+      target_numeric: 75,
+      attainment_pct: 100,
+      task_done_count: 3,
+      task_count: 4,
+    })
+  })
+
+  it('falls back to unmeasured goal attainment when payloads are old', async () => {
+    const rawResponse = {
+      tree: [
+        makeRawGoalNode({
+          metric: 'latency',
+          target_value: 'fast enough',
+          task_done_count: 1,
+          task_count: 2,
+        }),
+      ],
+      summary: {},
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardGoalsTree()
+
+    expect(result.tree[0]?.attainment).toMatchObject({
+      state: 'unmeasured',
+      basis: 'unmeasured',
+      metric: 'latency',
+      target_value: 'fast enough',
+      target_parse_status: 'unparseable',
+      task_done_count: 1,
+      task_count: 2,
+    })
+  })
+
   it('retains keeper trust summary and latest event on goal detail payloads', async () => {
     const rawResponse = {
       goal: makeRawGoalNode(),

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -41,6 +41,7 @@ import type {
   GoalKeeperTrustLatestEvent,
   GoalKeeperTrustSummary,
   GoalDetailTimelineEvent,
+  GoalAttainmentProjection,
   GoalTreeNode,
   GoalTreeSummary,
   GoalTreeTask,
@@ -1371,6 +1372,47 @@ function decodeGoalKeeperTrustSummary(raw: unknown): GoalKeeperTrustSummary | nu
   }
 }
 
+function decodeGoalAttainmentProjection(
+  raw: unknown,
+  fallback: {
+    metric: string | null
+    targetValue: string | null
+    taskDoneCount: number
+    taskCount: number
+  },
+): GoalAttainmentProjection {
+  if (!isRecord(raw)) {
+    return {
+      state: 'unmeasured',
+      basis: 'unmeasured',
+      metric: fallback.metric,
+      target_value: fallback.targetValue,
+      target_parse_status: fallback.targetValue ? 'unparseable' : 'absent',
+      unit: 'unknown',
+      observed_value: null,
+      target_numeric: null,
+      attainment_pct: null,
+      task_done_count: fallback.taskDoneCount,
+      task_count: fallback.taskCount,
+      note: 'Attainment projection missing from payload.',
+    }
+  }
+  return {
+    state: asString(raw.state, 'unmeasured'),
+    basis: asString(raw.basis, 'unmeasured'),
+    metric: asNullableString(raw.metric) ?? fallback.metric,
+    target_value: asNullableString(raw.target_value) ?? fallback.targetValue,
+    target_parse_status: asString(raw.target_parse_status, 'absent'),
+    unit: asString(raw.unit, 'unknown'),
+    observed_value: asNumber(raw.observed_value) ?? null,
+    target_numeric: asNumber(raw.target_numeric) ?? null,
+    attainment_pct: asInt(raw.attainment_pct) ?? null,
+    task_done_count: asInt(raw.task_done_count) ?? fallback.taskDoneCount,
+    task_count: asInt(raw.task_count) ?? fallback.taskCount,
+    note: asString(raw.note, ''),
+  }
+}
+
 function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id)
@@ -1382,6 +1424,10 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
   const children = asRecordArray(raw.children)
     .map(decodeGoalTreeNode)
     .filter((node): node is GoalTreeNode => node !== null)
+  const metric = asNullableString(raw.metric)
+  const targetValue = asNullableString(raw.target_value)
+  const taskCount = asInt(raw.task_count) ?? tasks.length
+  const taskDoneCount = asInt(raw.task_done_count) ?? 0
   return {
     id,
     title,
@@ -1396,15 +1442,21 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
     badges: asStringArray(raw.badges),
     status_reason: asString(raw.status_reason, ''),
     priority: asInt(raw.priority) ?? 0,
-    metric: asNullableString(raw.metric),
-    target_value: asNullableString(raw.target_value),
+    metric,
+    target_value: targetValue,
     due_date: asNullableString(raw.due_date),
     parent_goal_id: asNullableString(raw.parent_goal_id),
     convergence: asNumber(raw.convergence, 0),
     convergence_pct: asInt(raw.convergence_pct) ?? 0,
+    attainment: decodeGoalAttainmentProjection(raw.attainment, {
+      metric,
+      targetValue,
+      taskDoneCount,
+      taskCount,
+    }),
     tasks,
-    task_count: asInt(raw.task_count) ?? tasks.length,
-    task_done_count: asInt(raw.task_done_count) ?? 0,
+    task_count: taskCount,
+    task_done_count: taskDoneCount,
     verification_summary: decodeGoalVerificationSummary(raw.verification_summary),
     effective_verifier_policy: decodeGoalVerificationPolicySnapshot(raw.effective_verifier_policy),
     active_verification_request: decodeGoalVerificationRequest(raw.active_verification_request),

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -539,6 +539,38 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
   `
 }
 
+function attainmentTone(attainment: GoalTreeNode['attainment']): 'default' | 'ok' | 'warn' | 'bad' {
+  if (attainment.state === 'attained') return 'ok'
+  if (attainment.state === 'unmeasured') return 'warn'
+  if (attainment.state === 'not_started') return 'bad'
+  return 'default'
+}
+
+function attainmentClass(attainment: GoalTreeNode['attainment']): string {
+  switch (attainmentTone(attainment)) {
+    case 'ok': return 'border-ok/30 bg-ok/10 text-ok'
+    case 'warn': return 'border-warn/30 bg-warn/10 text-warn'
+    case 'bad': return 'border-bad/30 bg-bad/10 text-bad'
+    default: return 'border-card-border/60 bg-[var(--color-bg-elevated)] text-text-body'
+  }
+}
+
+function attainmentLabel(attainment: GoalTreeNode['attainment']): string {
+  if (attainment.attainment_pct == null) return '달성 미측정'
+  return `달성 ${attainment.attainment_pct}%`
+}
+
+function GoalAttainmentChip({ attainment }: { attainment: GoalTreeNode['attainment'] }) {
+  return html`
+    <span
+      class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold ${attainmentClass(attainment)}"
+      title=${`${attainment.basis}; target=${attainment.target_value ?? '-'}; observed=${attainment.observed_value ?? '-'}; ${attainment.note}`}
+    >
+      ${attainmentLabel(attainment)}
+    </span>
+  `
+}
+
 function TreeSummary({
   summary,
   awaitingVerificationCount,
@@ -690,6 +722,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
                 <span aria-hidden="true">↗ </span>${node.metric}${node.target_value ? html`<span class="ml-1 text-text-strong"> · ${node.target_value}</span>` : null}
               </span>
             ` : null}
+            <${GoalAttainmentChip} attainment=${node.attainment} />
             ${(() => {
               const awaiting = countAwaitingVerificationTasks(node.tasks)
               return awaiting > 0 ? html`
@@ -1092,6 +1125,7 @@ function GoalDetailPanel({
         ` : null}
 
         <div class="grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] gap-3">
+          <${DetailMetric} label="목표 달성" value=${selectedNode.attainment.attainment_pct == null ? '미측정' : `${selectedNode.attainment.attainment_pct}%`} tone=${attainmentTone(selectedNode.attainment)} />
           <${DetailMetric} label="작업" value=${`${selectedNode.task_done_count}/${selectedNode.task_count}`} tone=${selectedNode.task_done_count === selectedNode.task_count && selectedNode.task_count > 0 ? 'ok' : 'default'} />
           <${DetailMetric} label="연결된 키퍼" value=${selectedNode.linked_keeper_names.length} />
           <${DetailMetric} label="승인 대기" value=${selectedNode.pending_approval_count} tone=${selectedNode.pending_approval_count > 0 ? 'warn' : 'default'} />

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -663,6 +663,7 @@ export interface GoalTreeNode {
   parent_goal_id: string | null
   convergence: number
   convergence_pct: number
+  attainment: GoalAttainmentProjection
   tasks: GoalTreeTask[]
   task_count: number
   task_done_count: number
@@ -689,6 +690,21 @@ export interface GoalTreeNode {
   stalled_since?: string | null
   created_at: string
   updated_at: string
+}
+
+export interface GoalAttainmentProjection {
+  state: 'attained' | 'in_progress' | 'not_started' | 'unmeasured' | string
+  basis: 'goal_phase' | 'linked_tasks' | 'metric_target_percent' | 'metric_target_count' | 'unmeasured' | string
+  metric: string | null
+  target_value: string | null
+  target_parse_status: 'absent' | 'parseable' | 'unparseable' | 'invalid_target' | 'unsupported_metric' | 'no_linked_tasks' | string
+  unit: 'percent' | 'count' | 'unknown' | string
+  observed_value: number | null
+  target_numeric: number | null
+  attainment_pct: number | null
+  task_done_count: number
+  task_count: number
+  note: string
 }
 
 export interface GoalTreeSummary {

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -289,6 +289,7 @@ module KeeperRetryBackoff : sig
   val transient_backoff_base_sec : unit -> float
   val transient_backoff_cap_sec : unit -> float
   val transient_backoff_sec : int -> float
+  val degraded_retry_slot_phase_budget_sec : float
 end
 
 (** {1 Cascade attempt liveness — RFC-0022 §9 rollout flag} *)

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -33,6 +33,11 @@ type goal_detail_keeper = {
   runtime_trust : Yojson.Safe.t;
 }
 
+type attainment_unit =
+  | Percent
+  | Count
+  | Unknown
+
 let task_is_linked_to_goal (task : Masc_domain.task) goal_id =
   Convergence.task_matches_goal ~goal_id task
 
@@ -248,6 +253,201 @@ let compute_convergence (goal : Goal_store.goal) linked_tasks children =
     child_avg
   else
     task_ratio
+
+let clamp_float lower upper value =
+  if value < lower then lower else if value > upper then upper else value
+
+let pct_of_float value =
+  int_of_float (floor (clamp_float 0.0 100.0 value +. 0.5))
+
+let json_float_opt = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let json_int_opt = function
+  | Some value -> `Int value
+  | None -> `Null
+
+let attainment_unit_to_string = function
+  | Percent -> "percent"
+  | Count -> "count"
+  | Unknown -> "unknown"
+
+let contains_ci haystack needle =
+  String_util.contains_substring_ci haystack needle
+
+let metric_implies_percent metric =
+  match metric with
+  | None -> false
+  | Some raw ->
+      contains_ci raw "percent"
+      || contains_ci raw "pct"
+      || contains_ci raw "ratio"
+      || contains_ci raw "rate"
+      || contains_ci raw "completion"
+
+let metric_supports_count_target metric =
+  match metric with
+  | None -> true
+  | Some raw ->
+      contains_ci raw "task"
+      || contains_ci raw "todo"
+      || contains_ci raw "issue"
+      || contains_ci raw "ticket"
+      || contains_ci raw "pr"
+      || contains_ci raw "done"
+
+let target_value_implies_percent raw =
+  contains_ci raw "%"
+  || contains_ci raw "percent"
+  || contains_ci raw "pct"
+
+let parse_first_float raw =
+  let len = String.length raw in
+  let is_start = function
+    | '0' .. '9' | '+' | '-' | '.' -> true
+    | _ -> false
+  in
+  let is_part = function
+    | '0' .. '9' | '+' | '-' | '.' -> true
+    | _ -> false
+  in
+  let rec token_end index =
+    if index >= len || not (is_part raw.[index]) then index
+    else token_end (index + 1)
+  in
+  let rec search index =
+    if index >= len then None
+    else if is_start raw.[index] then
+      let stop = token_end index in
+      let token = String.sub raw index (stop - index) in
+      match float_of_string_opt token with
+      | Some value -> Some value
+      | None -> search (index + 1)
+    else
+      search (index + 1)
+  in
+  search 0
+
+let parsed_target_unit metric raw =
+  if target_value_implies_percent raw || metric_implies_percent metric then
+    Percent
+  else
+    Count
+
+let build_attainment_json ~state ~basis ~task_done_count ~task_count
+    ~target_parse_status ~unit ~observed_value ~target_numeric ~attainment_pct
+    ~note (goal : Goal_store.goal) =
+  `Assoc
+    [
+      ("state", `String state);
+      ("basis", `String basis);
+      ("metric", Json_util.string_opt_to_json goal.metric);
+      ("target_value", Json_util.string_opt_to_json goal.target_value);
+      ("target_parse_status", `String target_parse_status);
+      ("unit", `String (attainment_unit_to_string unit));
+      ("observed_value", json_float_opt observed_value);
+      ("target_numeric", json_float_opt target_numeric);
+      ("attainment_pct", json_int_opt attainment_pct);
+      ("task_done_count", `Int task_done_count);
+      ("task_count", `Int task_count);
+      ("note", `String note);
+    ]
+
+let goal_attainment_to_json (goal : Goal_store.goal) (node : tree_node) =
+  let task_count = List.length node.tasks in
+  let task_done_count =
+    List.length
+      (List.filter
+         (fun ((task, _) : Masc_domain.task * string) -> task_is_done task)
+         node.tasks)
+  in
+  let task_completion_pct =
+    if task_count = 0 then None
+    else Some (float_of_int task_done_count /. float_of_int task_count *. 100.0)
+  in
+  let measured ~basis ~unit ~observed_value ~target_numeric ~target_parse_status =
+    let attainment_pct =
+      if target_numeric <= 0.0 then
+        None
+      else
+        Some (pct_of_float (observed_value /. target_numeric *. 100.0))
+    in
+    let state =
+      match attainment_pct with
+      | Some pct when pct >= 100 -> "attained"
+      | Some 0 -> "not_started"
+      | Some _ -> "in_progress"
+      | None -> "unmeasured"
+    in
+    build_attainment_json ~state ~basis ~task_done_count ~task_count
+      ~target_parse_status ~unit ~observed_value:(Some observed_value)
+      ~target_numeric:(Some target_numeric) ~attainment_pct
+      ~note:
+        (match unit with
+        | Percent -> "Derived from linked task completion against a percent target."
+        | Count -> "Derived from completed linked tasks against a count target."
+        | Unknown -> "Derived from linked goal evidence.")
+      goal
+  in
+  let unmeasured ?(unit = Unknown) ?target_numeric target_parse_status note =
+    build_attainment_json ~state:"unmeasured" ~basis:"unmeasured"
+      ~task_done_count ~task_count ~target_parse_status ~unit
+      ~observed_value:None ~target_numeric ~attainment_pct:None ~note goal
+  in
+  match goal.phase with
+  | Goal_phase.Completed ->
+      build_attainment_json ~state:"attained" ~basis:"goal_phase"
+        ~task_done_count ~task_count
+        ~target_parse_status:
+          (match goal.target_value with
+          | Some raw when parse_first_float raw <> None -> "parseable"
+          | Some _ -> "unparseable"
+          | None -> "absent")
+        ~unit:Percent ~observed_value:(Some 100.0) ~target_numeric:(Some 100.0)
+        ~attainment_pct:(Some 100)
+        ~note:"Goal lifecycle phase is completed." goal
+  | _ -> (
+      match goal.target_value with
+      | Some raw -> (
+          match parse_first_float raw with
+          | None ->
+              unmeasured "unparseable"
+                "Target value is not numeric enough for dashboard attainment."
+          | Some target_numeric when target_numeric <= 0.0 ->
+              unmeasured "invalid_target"
+                "Target value must be greater than zero."
+          | Some target_numeric -> (
+              let unit = parsed_target_unit goal.metric raw in
+              match unit with
+              | Percent -> (
+                  match task_completion_pct with
+                  | Some observed_value ->
+                      measured ~basis:"metric_target_percent" ~unit
+                        ~observed_value ~target_numeric
+                        ~target_parse_status:"parseable"
+                  | None ->
+                      unmeasured ~unit ~target_numeric "no_linked_tasks"
+                        "Percent target needs linked task evidence." )
+              | Count ->
+                  if metric_supports_count_target goal.metric then
+                    measured ~basis:"metric_target_count" ~unit
+                      ~observed_value:(float_of_int task_done_count)
+                      ~target_numeric ~target_parse_status:"parseable"
+                  else
+                    unmeasured ~unit ~target_numeric "unsupported_metric"
+                      "Numeric target is not mapped to a known count metric."
+              | Unknown ->
+                  unmeasured "unsupported_metric"
+                    "Target unit is unknown." ))
+      | None -> (
+          match task_completion_pct with
+          | Some observed_value ->
+              measured ~basis:"linked_tasks" ~unit:Percent ~observed_value
+                ~target_numeric:100.0 ~target_parse_status:"absent"
+          | None ->
+              unmeasured "absent"
+                "No target value or linked task evidence is available." ))
 
 let approval_matches_goal goal_id approval_json =
   let goal_ids =
@@ -1172,6 +1372,7 @@ let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
        | None -> `Null);
       ("convergence", `Float node.convergence);
       ("convergence_pct", `Int (int_of_float (node.convergence *. 100.0)));
+      ("attainment", goal_attainment_to_json goal node);
       ("tasks", `List (List.map task_to_tree_json node.tasks));
       ("task_count", `Int (List.length node.tasks));
       ("task_done_count",

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -276,6 +276,27 @@ let attainment_unit_to_string = function
 let contains_ci haystack needle =
   String_util.contains_substring_ci haystack needle
 
+let metric_word_tokens raw =
+  let tokens = ref [] in
+  let current = Buffer.create 16 in
+  let flush () =
+    if Buffer.length current > 0 then (
+      tokens := Buffer.contents current :: !tokens;
+      Buffer.clear current)
+  in
+  String.iter
+    (fun ch ->
+      match ch with
+      | 'A' .. 'Z' ->
+          Buffer.add_char current (Char.lowercase_ascii ch)
+      | 'a' .. 'z' | '0' .. '9' ->
+          Buffer.add_char current ch
+      | _ ->
+          flush ())
+    raw;
+  flush ();
+  List.rev !tokens
+
 let metric_implies_percent metric =
   match metric with
   | None -> false
@@ -286,34 +307,63 @@ let metric_implies_percent metric =
       || contains_ci raw "rate"
       || contains_ci raw "completion"
 
+let metric_count_token = function
+  | "task" | "tasks" | "todo" | "todos" | "issue" | "issues" | "ticket"
+  | "tickets" | "pr" | "prs" | "done" ->
+      true
+  | _ ->
+      false
+
+let metric_has_pull_request_phrase tokens =
+  let rec loop = function
+    | "pull" :: next :: _ when next = "request" || next = "requests" -> true
+    | _ :: rest -> loop rest
+    | [] -> false
+  in
+  loop tokens
+
 let metric_supports_count_target metric =
   match metric with
   | None -> true
   | Some raw ->
-      contains_ci raw "task"
-      || contains_ci raw "todo"
-      || contains_ci raw "issue"
-      || contains_ci raw "ticket"
-      || contains_ci raw "pr"
-      || contains_ci raw "done"
+      let tokens = metric_word_tokens raw in
+      List.exists metric_count_token tokens
+      || metric_has_pull_request_phrase tokens
 
 let target_value_implies_percent raw =
   contains_ci raw "%"
   || contains_ci raw "percent"
   || contains_ci raw "pct"
 
+let strip_number_group_separators token =
+  let buffer = Buffer.create (String.length token) in
+  String.iter
+    (fun ch ->
+      if ch <> ',' then
+        Buffer.add_char buffer ch)
+    token;
+  Buffer.contents buffer
+
 let parse_first_float raw =
   let len = String.length raw in
+  let is_digit = function
+    | '0' .. '9' -> true
+    | _ -> false
+  in
   let is_start = function
     | '0' .. '9' | '+' | '-' | '.' -> true
     | _ -> false
   in
-  let is_part = function
+  let is_part index =
+    match raw.[index] with
     | '0' .. '9' | '+' | '-' | '.' -> true
+    | ',' ->
+        index > 0 && index + 1 < len && is_digit raw.[index - 1]
+        && is_digit raw.[index + 1]
     | _ -> false
   in
   let rec token_end index =
-    if index >= len || not (is_part raw.[index]) then index
+    if index >= len || not (is_part index) then index
     else token_end (index + 1)
   in
   let rec search index =
@@ -321,7 +371,7 @@ let parse_first_float raw =
     else if is_start raw.[index] then
       let stop = token_end index in
       let token = String.sub raw index (stop - index) in
-      match float_of_string_opt token with
+      match float_of_string_opt (strip_number_group_separators token) with
       | Some value -> Some value
       | None -> search (index + 1)
     else

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -354,26 +354,27 @@ let parse_first_float raw =
     | '0' .. '9' | '+' | '-' | '.' -> true
     | _ -> false
   in
-  let is_part index =
+  let is_part ~start index =
     match raw.[index] with
-    | '0' .. '9' | '+' | '-' | '.' -> true
+    | '0' .. '9' | '.' -> true
+    | '+' | '-' -> index = start
     | ',' ->
         index > 0 && index + 1 < len && is_digit raw.[index - 1]
         && is_digit raw.[index + 1]
     | _ -> false
   in
-  let rec token_end index =
-    if index >= len || not (is_part index) then index
-    else token_end (index + 1)
+  let rec token_end start index =
+    if index >= len || not (is_part ~start index) then index
+    else token_end start (index + 1)
   in
   let rec search index =
     if index >= len then None
     else if is_start raw.[index] then
-      let stop = token_end index in
+      let stop = token_end index index in
       let token = String.sub raw index (stop - index) in
       match float_of_string_opt (strip_number_group_separators token) with
       | Some value -> Some value
-      | None -> search (index + 1)
+      | None -> search stop
     else
       search (index + 1)
   in

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -319,11 +319,10 @@ let next_fail_open_cascade_for_turn_with_budget
       (* The candidate is always a retry, so use per-attempt budget semantics
          regardless of whether the current attempt was itself a retry. *)
       if
-        Option.exists
-          (fun time_spent_in_turn_s ->
-            not
-              (degraded_retry_slot_phase_available ~time_spent_in_turn_s))
-          time_spent_in_turn_s
+        match time_spent_in_turn_s with
+        | Some time_spent_in_turn_s ->
+            not (degraded_retry_slot_phase_available ~time_spent_in_turn_s)
+        | None -> false
       then Degraded_retry_slot_phase_exhausted retry
       else if
         oas_retry_budget_available_for_turn

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -431,6 +431,58 @@ let test_goal_attainment_does_not_fake_unparseable_target () =
   check int "evidence task retained" 1
     (attainment |> member "task_done_count" |> to_int)
 
+let test_goal_attainment_parses_grouped_count_target () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Grouped count target goal"
+        ~metric:"task_count" ~target_value:"1,000 tasks" ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Single completed task";
+  let attainment =
+    Dashboard_goals.dashboard_goals_tree_json ~config
+    |> root_node
+    |> member "attainment"
+  in
+  check string "count target basis" "metric_target_count"
+    (attainment |> member "basis" |> to_string);
+  check string "grouped target parse status" "parseable"
+    (attainment |> member "target_parse_status" |> to_string);
+  check (float 0.001) "grouped target numeric" 1000.0
+    (attainment |> member "target_numeric" |> to_float);
+  check int "grouped target pct" 0
+    (attainment |> member "attainment_pct" |> to_int);
+  check string "grouped target not attained" "not_started"
+    (attainment |> member "state" |> to_string)
+
+let test_goal_attainment_rejects_substring_pr_metric () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Approval latency target goal"
+        ~metric:"approval_latency" ~target_value:"5" ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Completed evidence task";
+  let attainment =
+    Dashboard_goals.dashboard_goals_tree_json ~config
+    |> root_node
+    |> member "attainment"
+  in
+  check string "substring pr metric remains unmeasured" "unmeasured"
+    (attainment |> member "state" |> to_string);
+  check string "substring pr metric unsupported" "unsupported_metric"
+    (attainment |> member "target_parse_status" |> to_string);
+  check (float 0.001) "unsupported target retained" 5.0
+    (attainment |> member "target_numeric" |> to_float);
+  check bool "unsupported metric has no pct" true
+    (attainment |> member "attainment_pct" = `Null)
+
 let test_blocked_phase_projects_blocked_health () =
   with_room @@ fun config ->
   let _goal, _kind =
@@ -689,6 +741,10 @@ let () =
             test_goal_attainment_projects_percent_target;
           test_case "goal attainment does not fake unparseable targets" `Quick
             test_goal_attainment_does_not_fake_unparseable_target;
+          test_case "goal attainment parses grouped count targets" `Quick
+            test_goal_attainment_parses_grouped_count_target;
+          test_case "goal attainment rejects substring pr metrics" `Quick
+            test_goal_attainment_rejects_substring_pr_metric;
           test_case "blocked phase maps to blocked health" `Quick
             test_blocked_phase_projects_blocked_health;
           test_case

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -458,6 +458,36 @@ let test_goal_attainment_parses_grouped_count_target () =
   check string "grouped target not attained" "not_started"
     (attainment |> member "state" |> to_string)
 
+let test_goal_attainment_parses_range_target_start () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Range percent target goal"
+        ~metric:"completion_pct" ~target_value:"75-80%" ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Done task 1";
+  create_done_task config ~goal_id:goal.id ~title:"Done task 2";
+  create_done_task config ~goal_id:goal.id ~title:"Done task 3";
+  ignore
+    (Coord_task.add_task ~goal_id:goal.id config ~title:"Open task"
+       ~priority:3 ~description:"remaining work");
+  let attainment =
+    Dashboard_goals.dashboard_goals_tree_json ~config
+    |> root_node
+    |> member "attainment"
+  in
+  check string "range target basis" "metric_target_percent"
+    (attainment |> member "basis" |> to_string);
+  check string "range target parse status" "parseable"
+    (attainment |> member "target_parse_status" |> to_string);
+  check (float 0.001) "range target numeric" 75.0
+    (attainment |> member "target_numeric" |> to_float);
+  check int "range target pct" 100
+    (attainment |> member "attainment_pct" |> to_int)
+
 let test_goal_attainment_rejects_substring_pr_metric () =
   with_room @@ fun config ->
   let goal, _kind =
@@ -743,6 +773,8 @@ let () =
             test_goal_attainment_does_not_fake_unparseable_target;
           test_case "goal attainment parses grouped count targets" `Quick
             test_goal_attainment_parses_grouped_count_target;
+          test_case "goal attainment parses range target start" `Quick
+            test_goal_attainment_parses_range_target_start;
           test_case "goal attainment rejects substring pr metrics" `Quick
             test_goal_attainment_rejects_substring_pr_metric;
           test_case "blocked phase maps to blocked health" `Quick

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -367,6 +367,70 @@ let test_title_marker_links_legacy_task () =
   check string "node linkage source" "title_tag"
     (node |> member "linkage_source" |> to_string)
 
+let test_goal_attainment_projects_percent_target () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Percent target goal"
+        ~metric:"completion_pct" ~target_value:"75%" ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Done task 1";
+  create_done_task config ~goal_id:goal.id ~title:"Done task 2";
+  create_done_task config ~goal_id:goal.id ~title:"Done task 3";
+  ignore
+    (Coord_task.add_task ~goal_id:goal.id config ~title:"Open task"
+       ~priority:3 ~description:"remaining work");
+  let attainment =
+    Dashboard_goals.dashboard_goals_tree_json ~config
+    |> root_node
+    |> member "attainment"
+  in
+  check string "attainment state" "attained"
+    (attainment |> member "state" |> to_string);
+  check string "attainment basis" "metric_target_percent"
+    (attainment |> member "basis" |> to_string);
+  check string "target parse status" "parseable"
+    (attainment |> member "target_parse_status" |> to_string);
+  check int "target-relative pct" 100
+    (attainment |> member "attainment_pct" |> to_int);
+  check (float 0.001) "observed percent" 75.0
+    (attainment |> member "observed_value" |> to_float);
+  check (float 0.001) "target percent" 75.0
+    (attainment |> member "target_numeric" |> to_float);
+  check int "task count" 4 (attainment |> member "task_count" |> to_int);
+  check int "done task count" 3
+    (attainment |> member "task_done_count" |> to_int)
+
+let test_goal_attainment_does_not_fake_unparseable_target () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Unparseable target goal"
+        ~metric:"latency" ~target_value:"fast enough" ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Evidence task";
+  let attainment =
+    Dashboard_goals.dashboard_goals_tree_json ~config
+    |> root_node
+    |> member "attainment"
+  in
+  check string "unmeasured state" "unmeasured"
+    (attainment |> member "state" |> to_string);
+  check string "unmeasured basis" "unmeasured"
+    (attainment |> member "basis" |> to_string);
+  check string "unparseable target" "unparseable"
+    (attainment |> member "target_parse_status" |> to_string);
+  check bool "attainment pct omitted" true
+    (attainment |> member "attainment_pct" = `Null);
+  check int "evidence task retained" 1
+    (attainment |> member "task_done_count" |> to_int)
+
 let test_blocked_phase_projects_blocked_health () =
   with_room @@ fun config ->
   let _goal, _kind =
@@ -621,6 +685,10 @@ let () =
             test_cancelled_only_goal_is_at_risk;
           test_case "title marker links legacy task" `Quick
             test_title_marker_links_legacy_task;
+          test_case "goal attainment projects percent targets" `Quick
+            test_goal_attainment_projects_percent_target;
+          test_case "goal attainment does not fake unparseable targets" `Quick
+            test_goal_attainment_does_not_fake_unparseable_target;
           test_case "blocked phase maps to blocked health" `Quick
             test_blocked_phase_projects_blocked_health;
           test_case


### PR DESCRIPTION
Summary
- Adds a read-only goal attainment projection to dashboard goal tree JSON.
- Derives measured attainment from linked task completion plus parseable percent/count targets, and marks unparseable targets as unmeasured instead of pretending progress.
- Decodes and renders attainment in the dashboard goal tree/detail surface.
- Carries a small latest-main compile unblock for the degraded retry slot budget env knob interface while #13120 fallout is still on main.

Verification
- git diff --check
- dashboard: npx tsc --noEmit --pretty
- dashboard: npx vitest run src/api/dashboard.test.ts
- OCaml: scripts/dune-local.sh build test/test_dashboard_goals.exe
- OCaml: ./_build/default/test/test_dashboard_goals.exe