### PR TITLE
test: lock keeper PR capability invariants

### DIFF
--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -1,6 +1,9 @@
 open Alcotest
 
 module KTP = Masc_mcp.Keeper_types_profile
+module KT = Masc_mcp.Keeper_types
+module KPolicy = Masc_mcp.Keeper_tool_policy
+module KPR = Masc_mcp.Keeper_tool_pr_review
 
 (** Validate that every .toml file in config/keepers/ parses successfully
     with the OCaml TOML parser.  This catches syntax that is valid standard
@@ -62,12 +65,16 @@ let test_named_keeper_docker_defaults () =
   expect_keeper ~name:"sangsu" ~persona:"sangsu"
 
 let test_committed_keepers_are_pr_work_capable () =
+  let project_root = Masc_test_deps.find_project_root () in
+  Masc_test_deps.init_keeper_tool_registry ();
+  (match KPolicy.init_policy_config ~base_path:project_root with
+   | Ok () -> ()
+   | Error e -> fail (Printf.sprintf "init_policy_config: %s" e));
   let config_dir =
     match Sys.getenv_opt "DUNE_SOURCEROOT" with
     | Some repo_root -> Filename.concat repo_root "config/keepers"
-    | None -> "config/keepers"
+    | None -> Filename.concat project_root "config/keepers"
   in
-  let pr_work_presets = [ "coding"; "research"; "delivery"; "full" ] in
   let files =
     Sys.readdir config_dir
     |> Array.to_list
@@ -83,11 +90,58 @@ let test_committed_keepers_are_pr_work_capable () =
        match KTP.load_keeper_toml path with
        | Error e -> fail (Printf.sprintf "%s: %s" file e)
        | Ok (_loaded_name, defaults) ->
-           let preset = defaults.tool_preset in
-           check bool (name ^ " preset can do PR work") true
-             (match preset with
-              | Some p -> List.mem p pr_work_presets
-              | None -> true))
+           check (option string) (name ^ " sandbox_profile") (Some "docker")
+             (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
+           check (option string) (name ^ " network_mode") (Some "inherit")
+             (Option.map KTP.network_mode_to_string defaults.network_mode);
+           check (option string) (name ^ " github_identity")
+             (Some "anyang-keepers") defaults.github_identity;
+           check (option string) (name ^ " git_identity_mode")
+             (Some "github_identity") defaults.git_identity_mode;
+           let preset =
+             match defaults.tool_preset with
+             | None -> fail (Printf.sprintf "%s: tool_access.preset is required" file)
+             | Some raw ->
+                 (match KT.tool_preset_of_string raw with
+                  | Some preset -> preset
+                  | None -> fail (Printf.sprintf "%s: unknown preset %S" file raw))
+           in
+           check bool (name ^ " preset can mutate PR reviews") true
+             (KPR.pr_review_mutation_preset_ok (Some preset));
+           let meta =
+             match
+               Masc_test_deps.meta_of_json_fixture
+                 (`Assoc [
+                    ("name", `String name);
+                    ("agent_name", `String name);
+                    ("trace_id", `String (name ^ "-capability-test"));
+                    ( "tool_access",
+                      `Assoc [
+                        ("kind", `String "preset");
+                        ("preset", `String (KT.tool_preset_to_string preset));
+                        ("also_allow", `List []);
+                      ] );
+                    ("tool_denylist", `List []);
+                  ])
+             with
+             | Ok meta -> meta
+             | Error e -> fail (Printf.sprintf "%s: meta fixture: %s" file e)
+           in
+           let lookup = KPolicy.tool_access_lookup_of_meta meta in
+           List.iter
+             (fun tool_name ->
+                check bool (name ^ " can execute " ^ tool_name) true
+                  (KPolicy.can_execute ~lookup tool_name))
+             [
+               "keeper_shell";
+               "masc_code_git";
+               "keeper_preflight_check";
+               "keeper_pr_review_read";
+               "keeper_pr_review_comment";
+               "keeper_pr_review_reply";
+             ];
+           check string (name ^ " approve event maps to gh") "--approve"
+             (KPR.pr_review_event_to_gh_flag KPR.Approve))
     files
 
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)


### PR DESCRIPTION
## Summary

- Strengthen the committed keeper TOML validation so each non-base keeper manifest must inherit the real runtime prerequisites for PR work: Docker sandboxing, inherited network mode, `anyang-keepers` GitHub identity, and `github_identity` git identity mode.
- Replace the old string-only preset check with executable policy checks for the actual PR path: `keeper_shell`, `masc_code_git`, `keeper_preflight_check`, `keeper_pr_review_read`, `keeper_pr_review_comment`, and `keeper_pr_review_reply`.
- Pin the approval path at code level by asserting `APPROVE` maps to the `gh pr review --approve` flag.

## Product impact

This turns “keepers should be able to do real PR work” into a regression test against committed keeper configuration. If a future keeper manifest loses Docker/GitHub identity wiring, git push capability, PR create shell access, or review/approve tools, CI fails before that drift reaches runtime.

## Evidence

- Static code path: `keeper_pr_review_comment` already supports `event=APPROVE`, which maps through `Keeper_tool_pr_review.Approve` to `--approve`.
- Static config path: `config/tool_policy.toml` grants coding/research/delivery/full presets the shell, coding, GitHub preflight, and GitHub review groups used by this test.

## Review evidence

- `git diff --check HEAD~1..HEAD`
- `gh pr checks 13137 --repo jeong-sik/masc-mcp --watch`: static guards passed (`Draft Auto-Merge Guard`, `Godfile size`, `Hardcoded model prefix`, `Math.random in components`, `PR Live Gate`, `PR Sync Check`, `Workflow YAML syntax`).
- `CI Gate` is red by policy because this agent-authored draft does not have `human-approved-ready`; build/test jobs are skipped while the PR remains draft/gated.
- Focused Dune verification was attempted but blocked by the shared `/tmp/me-dune-local.lock`, currently held by another worktree build.

## Linked issue

- None. Follow-up hardening from keeper autonomy/code-level capability audit.
