### PR TITLE
fix: surface keeper toml unknown keys in health

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1046,6 +1046,8 @@ let canonical_keeper_toml_key_names =
   ; "cascade_name"
   ]
 
+let loader_level_keeper_toml_key_names = [ "base" ]
+
 let () =
   assert (
     List.sort String.compare canonical_keeper_toml_key_names
@@ -1056,7 +1058,7 @@ let () =
     assert on the key list without mocking the Log subsystem. *)
 let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
   let known =
-    canonical_keeper_toml_key_names
+    (canonical_keeper_toml_key_names @ loader_level_keeper_toml_key_names)
     |> List.map (fun k -> "keeper." ^ k)
   in
   let oas_env_prefix = oas_env_key_prefix in
@@ -1611,6 +1613,12 @@ type keeper_toml_config_error = {
   reason : string;
 }
 
+type keeper_toml_unknown_keys = {
+  keeper_name : string;
+  path : string;
+  unknown_keys : string list;
+}
+
 let keeper_toml_config_error_to_json
     ({ keeper_name; path; error; reason } : keeper_toml_config_error)
     : Yojson.Safe.t =
@@ -1623,8 +1631,37 @@ let keeper_toml_config_error_to_json
       ("terminal_reason", `String "config_parse_failed");
     ]
 
+let keeper_toml_unknown_keys_to_json
+    ({ keeper_name; path; unknown_keys } : keeper_toml_unknown_keys)
+    : Yojson.Safe.t =
+  `Assoc
+    [
+      ("keeper", `String keeper_name);
+      ("path", `String path);
+      ("unknown_key_count", `Int (List.length unknown_keys));
+      ("unknown_keys", `List (List.map (fun key -> `String key) unknown_keys));
+      ("terminal_reason", `String "config_unknown_keys");
+    ]
+
 let keeper_name_of_toml_path path =
   Filename.basename path |> Filename.remove_extension
+
+let keeper_toml_unknown_keys_of_path path =
+  match Safe_ops.read_file_safe path with
+  | Error _ -> None
+  | Ok content -> (
+      match Keeper_toml_loader.parse_toml content with
+      | Error _ -> None
+      | Ok doc -> (
+          match detect_unknown_keeper_toml_keys doc with
+          | [] -> None
+          | unknown_keys ->
+              Some
+                {
+                  keeper_name = keeper_name_of_toml_path path;
+                  path;
+                  unknown_keys = normalize_unknown_keeper_toml_keys unknown_keys;
+                }))
 
 let keeper_toml_config_error_of_path path =
   match load_keeper_toml path with
@@ -1649,8 +1686,22 @@ let keeper_toml_config_errors_in_dir dir =
     |> List.filter_map (fun f ->
          keeper_toml_config_error_of_path (Filename.concat dir f))
 
+let keeper_toml_unknown_keys_in_dir dir =
+  if not (Fs_compat.file_exists dir && Sys.is_directory dir) then []
+  else
+    dir
+    |> Sys.readdir
+    |> Array.to_list
+    |> List.filter (fun f -> Filename.check_suffix f ".toml")
+    |> List.sort String.compare
+    |> List.filter_map (fun f ->
+         keeper_toml_unknown_keys_of_path (Filename.concat dir f))
+
 let keeper_toml_config_errors () =
   keeper_toml_config_errors_in_dir (Config_dir_resolver.keepers_dir ())
+
+let keeper_toml_unknown_keys () =
+  keeper_toml_unknown_keys_in_dir (Config_dir_resolver.keepers_dir ())
 
 let keeper_toml_config_errors_json () =
   `List (List.map keeper_toml_config_error_to_json (keeper_toml_config_errors ()))

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -118,6 +118,25 @@ let make_health_json ?(listener = "http/1.1") request =
           };
         ]
   in
+  let keeper_config_unknown_keys =
+    try Keeper_types_profile.keeper_toml_unknown_keys () with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+        [
+          {
+            Keeper_types_profile.keeper_name = "unknown";
+            path = "";
+            unknown_keys = [ "health_probe_failed: " ^ Printexc.to_string exn ];
+          };
+        ]
+  in
+  let keeper_config_unknown_key_count =
+    List.fold_left
+      (fun acc (entry : Keeper_types_profile.keeper_toml_unknown_keys) ->
+        acc + List.length entry.unknown_keys)
+      0
+      keeper_config_unknown_keys
+  in
   `Assoc [
     ("status", `String "ok");
     ("server", `String "masc-mcp");
@@ -155,6 +174,12 @@ let make_health_json ?(listener = "http/1.1") request =
       `List
         (List.map Keeper_types_profile.keeper_toml_config_error_to_json
            keeper_config_parse_errors) );
+    ( "keeper_config_unknown_key_count",
+      `Int keeper_config_unknown_key_count );
+    ( "keeper_config_unknown_keys",
+      `List
+        (List.map Keeper_types_profile.keeper_toml_unknown_keys_to_json
+           keeper_config_unknown_keys) );
     (* P2 silent-failure fix: lazy_task_boot_guard fires when a keeper
        startup task exceeds the boot timeout (server_bootstrap_loops.ml:116).
        The Prometheus counter `masc_lazy_task_boot_guard_fired_total`

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -112,7 +112,9 @@ val make_health_json :
     [build] / [protocol] (default + listener + supported list) /
     [transport] / [paths] / [uptime] / [sse_clients] /
     [startup] / [subsystems] / [feature_flags] / [gc] /
-    [keeper_fibers] / [lazy_task_boot_guard_fires_total].
+    [keeper_fibers] / [keeper_config_parse_error_count] /
+    [keeper_config_parse_errors] / [keeper_config_unknown_key_count] /
+    [keeper_config_unknown_keys] / [lazy_task_boot_guard_fires_total].
 
     {2 lazy_task_boot_guard_fires_total contract (P2 silent-
     failure fix)}

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -4,6 +4,7 @@ module TL = Masc_mcp.Keeper_toml_loader
 module KTP = Masc_mcp.Keeper_types_profile
 module KPA = Masc_mcp.Keeper_persona_authoring
 module KEP = Masc_mcp.Keeper_exec_persona
+module Runtime = Masc_mcp.Server_routes_http_runtime
 
 let contains_substring s needle =
   let s_len = String.length s in
@@ -1527,6 +1528,20 @@ preset = "coding"
     let unknown = KTP.detect_unknown_keeper_toml_keys doc in
     check (list string) "tool_access TOML table is canonical" [] unknown
 
+let test_detect_unknown_keys_accepts_loader_base () =
+  let input = {|
+[keeper]
+goal = "g"
+base = "base.toml"
+legacy_scope = "removed"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "base include is a loader key"
+      ["keeper.legacy_scope"] unknown
+
 let test_shared_memory_scope_is_canonical_toml () =
   let input = {|
 [keeper]
@@ -1722,6 +1737,83 @@ typo_field = 42
       2.0
       (unknown_metric () -. before_unknown_metric)
 
+let test_keeper_toml_unknown_keys_in_dir_reports_files () =
+  with_temp_dir "keeper-unknown-dir" @@ fun dir ->
+  write_file (Filename.concat dir "alpha.toml")
+    {|
+[keeper]
+name = "alpha"
+goal = "g"
+base = "base.toml"
+legacy_scope = "removed"
+|};
+  write_file (Filename.concat dir "beta.toml")
+    {|
+[keeper]
+name = "beta"
+goal = "g"
+base = "base.toml"
+|};
+  write_file (Filename.concat dir "bad.toml")
+    {|
+[keeper
+name = "bad"
+|};
+  let rows = KTP.keeper_toml_unknown_keys_in_dir dir in
+  match rows with
+  | [ row ] ->
+    check string "keeper name" "alpha" row.KTP.keeper_name;
+    check string "path"
+      (Filename.concat dir "alpha.toml")
+      row.KTP.path;
+    check (list string) "unknown keys"
+      [ "keeper.legacy_scope" ]
+      row.KTP.unknown_keys
+  | _ ->
+    fail
+      (Printf.sprintf "expected one unknown-key row, got %d"
+         (List.length rows))
+
+let test_health_json_surfaces_keeper_toml_unknown_keys () =
+  with_config_dir @@ fun config_dir ->
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  mkdir_p keepers_dir;
+  write_file (Filename.concat keepers_dir "alpha.toml")
+    {|
+[keeper]
+name = "alpha"
+goal = "g"
+base = "base.toml"
+legacy_scope = "removed"
+|};
+  let unknown_metric () =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_config_unknown_keys_ignored
+      ~labels:[("file_path", Filename.concat keepers_dir "alpha.toml")]
+      ()
+  in
+  let before_unknown_metric = unknown_metric () in
+  let request = Httpun.Request.create `GET "/health" in
+  let json = Runtime.make_health_json request in
+  let open Yojson.Safe.Util in
+  check int "unknown key count" 1
+    (json |> member "keeper_config_unknown_key_count" |> to_int);
+  let rows = json |> member "keeper_config_unknown_keys" |> to_list in
+  (match rows with
+   | [ row ] ->
+     check string "keeper" "alpha" (row |> member "keeper" |> to_string);
+     check string "terminal reason" "config_unknown_keys"
+       (row |> member "terminal_reason" |> to_string);
+     check (list string) "unknown keys"
+       [ "keeper.legacy_scope" ]
+       (row |> member "unknown_keys" |> to_list |> List.map to_string)
+   | _ ->
+     fail
+       (Printf.sprintf "expected one health unknown-key row, got %d"
+          (List.length rows)));
+  check (float 0.0001) "health scan does not increment warning metric"
+    before_unknown_metric (unknown_metric ())
+
 let test_unknown_toml_warning_key_normalizes_unknown_order () =
   let path =
     Printf.sprintf "/tmp/keeper-warning-order-%06x.toml" (Random.bits ())
@@ -1868,6 +1960,8 @@ let () =
             test_detect_unknown_keys_flags_legacy_dead_config;
           test_case "accepts tool_access table" `Quick
             test_detect_unknown_keys_accepts_tool_access_table;
+          test_case "accepts loader base include" `Quick
+            test_detect_unknown_keys_accepts_loader_base;
           test_case "accepts shared_memory_scope" `Quick
             test_shared_memory_scope_is_canonical_toml;
           test_case "rejects invalid shared_memory_scope" `Quick
@@ -1878,6 +1972,10 @@ let () =
             test_oas_env_not_flagged_as_unknown;
           test_case "load_keeper_toml captures unknown keys on profile" `Quick
             test_load_keeper_toml_captures_unknown_keys_on_profile;
+          test_case "unknown-key scanner reports files" `Quick
+            test_keeper_toml_unknown_keys_in_dir_reports_files;
+          test_case "health JSON surfaces unknown keys" `Quick
+            test_health_json_surfaces_keeper_toml_unknown_keys;
           test_case "unknown TOML warning key normalizes order" `Quick
             test_unknown_toml_warning_key_normalizes_unknown_order;
           test_case "unknown TOML warning key uses full path not basename" `Quick


### PR DESCRIPTION
## Summary
- Treat keeper.base as a loader-level keeper TOML key so base-file inheritance no longer raises unknown-key drift.
- Add a side-effect-free keeper TOML unknown-key scanner and expose keeper_config_unknown_key_count plus keeper_config_unknown_keys in /health.
- Keep parse errors separate from unknown-key drift, and add tests for detector, scanner, and health JSON behavior.

## Why
Live startup logs showed keeper TOML unknown-key warnings as an Observe signal, but /health only summarized parse failures. Operators could miss configuration drift unless they tailed logs or inspected per-keeper dashboard details.

## Validation
- git diff --check origin/main...HEAD
- ocamlc -stop-after parsing lib/keeper/keeper_types_profile.ml lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli test/test_keeper_toml.ml

## Local verification note
scripts/dune-local.sh build test/test_keeper_toml.exe could not run locally because /tmp/me-dune-local.lock was held by an unrelated OAS focused Dune build: lockf PID 34684, target test/test_discovery.exe. A direct fallback build was attempted only with DUNE_JOBS=1 and a separate build dir, but it was stopped after hitting environment-level agent_sdk/Llm_provider interface mismatch outside this patch scope. CI should provide the authoritative Dune result.