### PR TITLE
fix(keeper): preserve board signal wake stimuli

### DIFF
--- a/lib/keeper/keeper_event_queue.ml
+++ b/lib/keeper/keeper_event_queue.ml
@@ -62,11 +62,7 @@ let classify (s : stimulus) : stimulus_class =
   else
     (* Board signals carry JSON with "source":"board_signal". Lightweight
        prefix check avoids a full Yojson parse in the data layer. *)
-    let len = String.length s.payload in
-    if len > 2
-       && String.equal
-            (String.sub s.payload 0 (min 30 len))
-            "{\"source\":\"board_signal\""
+    if String.starts_with ~prefix:"{\"source\":\"board_signal\"" s.payload
     then Board_signal
     else
       Unsupported

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -576,8 +576,8 @@ let json_string_null_member name fields =
   | _ -> None
 
 let board_signal_kind_of_string = function
-  | "post_created" -> Some Board_dispatch.Board_post_created
-  | "comment_added" -> Some Board_dispatch.Board_comment_added
+  | "post_created" | "post" -> Some Board_dispatch.Board_post_created
+  | "comment_added" | "comment" -> Some Board_dispatch.Board_comment_added
   | _ -> None
 
 let board_signal_of_stimulus_payload payload =

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -12,6 +12,18 @@ let () =
      Alcotest.fail (Printf.sprintf "expected Board_signal, got %s"
        (match other with Bootstrap -> "Bootstrap" | Unsupported s -> "Unsupported("^s^")" | Board_signal -> "Board_signal")));
 
+  let live_comment_payload =
+    {|{"source":"board_signal","kind":"comment","post_id":"p2","author":"alice","title":"Long board event","content":"this mirrors the long live payload that used to miss the prefix check","hearth":null,"wake_reason":"scope_message"}|}
+  in
+  let live_comment_stim =
+    { post_id = "p2"; urgency = Normal; arrived_at = 0.0; payload = live_comment_payload }
+  in
+  (match classify live_comment_stim with
+   | Board_signal -> ()
+   | other ->
+     Alcotest.fail (Printf.sprintf "expected live comment Board_signal, got %s"
+       (match other with Bootstrap -> "Bootstrap" | Unsupported s -> "Unsupported("^s^")" | Board_signal -> "Board_signal")));
+
   (* --- classify: bootstrap --- *)
   let bootstrap_stim = {
     post_id = "bootstrap"; urgency = Normal; arrived_at = 0.0;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -390,6 +390,65 @@ let test_board_signal_stimulus_becomes_pending_board_event () =
             (WO.should_run_keeper_cycle ~meta:minimal_meta
                { base_observation with pending_board_events = [ event ] }))
 
+let test_legacy_board_comment_stimulus_becomes_pending_board_event () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      Masc_mcp.Board_dispatch.init_jsonl ();
+      let post =
+        match
+          Masc_mcp.Board_dispatch.create_post ~author:"alice"
+            ~title:"Need test-keeper"
+            ~content:"@test-keeper please react from the queued stimulus"
+            ~post_kind:Masc_mcp.Board.Human_post ()
+        with
+        | Ok post -> post
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+      in
+      let post_id = Masc_mcp.Board.Post_id.to_string post.id in
+      let payload =
+        `Assoc
+          [
+            ("source", `String "board_signal");
+            ("kind", `String "comment");
+            ("post_id", `String post_id);
+            ("author", `String "bob");
+            ("title", `String "Need test-keeper");
+            ("content", `String "comment payload from live board signal");
+            ("hearth", `Null);
+            ("wake_reason", `String "scope_message");
+          ]
+        |> Yojson.Safe.to_string
+      in
+      let stimulus : Masc_mcp.Keeper_event_queue.stimulus =
+        {
+          post_id;
+          urgency = Masc_mcp.Keeper_event_queue.Normal;
+          arrived_at = Time_compat.now ();
+          payload;
+        }
+      in
+      match
+        WO.pending_board_event_of_stimulus
+          ~continuity_summary:"goal test-keeper"
+          ~meta:minimal_meta stimulus
+      with
+      | None -> fail "legacy board comment stimulus was not converted"
+      | Some event ->
+          check string "post id" post_id event.post_id;
+          check string "latest external author" "bob"
+            (Option.value ~default:"" event.latest_external_author);
+          check int "new external comment" 1 event.new_external_since;
+          check bool "schedules turn" true
+            (WO.should_run_keeper_cycle ~meta:minimal_meta
+               { base_observation with pending_board_events = [ event ] }))
+
 let test_observe_splits_absolute_and_claimable_backlog () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -6930,6 +6989,8 @@ let () =
             test_observe_uses_precollected_board_events;
           test_case "queued board stimulus becomes board event" `Quick
             test_board_signal_stimulus_becomes_pending_board_event;
+          test_case "legacy queued board comment becomes board event" `Quick
+            test_legacy_board_comment_stimulus_becomes_pending_board_event;
           test_case "splits absolute and claimable backlog" `Quick
             test_observe_splits_absolute_and_claimable_backlog;
           test_case "durable signal sees claimable backlog" `Quick


### PR DESCRIPTION
## Summary

- fix board-signal stimulus classification so long JSON payloads beginning with `{"source":"board_signal"` are consumed as `Board_signal`
- accept live/legacy board signal kind aliases `post` and `comment` when promoting queued stimuli into pending board events
- add regressions for the long live `kind:"comment"` payload and pending-board-event promotion

## Live Evidence

The active `/Users/dancer/me` runtime log showed verifier receiving a board wake but consuming it as unsupported:

- `turn entry: consumed stimulus ... class=unsupported ... (keeper=verifier)`
- `turn entry: unsupported stimulus consumed prefix="{\"source\":\"board_signal\",\"kind\":\"comment"... — wake→no_signal gap #12684`

This patch closes both observed gaps: the classifier no longer misses long board-signal JSON, and `kind:"comment"` now maps to `Board_comment_added`.

## Validation

- `git diff --check HEAD~1 HEAD`
- Attempted `scripts/dune-local.sh build test/test_keeper_event_queue.exe test/test_keeper_unified.exe`; the focused build was blocked behind the shared `/tmp/me-dune-local.lock` held by other active worktree builds, so it was not bypassed.
