### PR TITLE
fix(ci): remove conflicting legacy Types facade

### DIFF
--- a/lib/types/dune
+++ b/lib/types/dune
@@ -3,6 +3,6 @@
  (name masc_types)
  (public_name masc_mcp.masc_types)
  (wrapped false)
- (modules rate_limit_types masc_error ids types_core types_auth masc_domain types task_stage severity)
+ (modules rate_limit_types masc_error ids types_core types_auth masc_domain task_stage severity)
  (libraries yojson unix time_compat masc_core base64 uuidm)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/types/types.ml
+++ b/lib/types/types.ml
@@ -1,1 +1,0 @@
-include Masc_domain

--- a/lib/types/types.mli
+++ b/lib/types/types.mli
@@ -1,9 +1,0 @@
-(** Backward-compatible [Types] facade.
-
-    This module intentionally mirrors {!Masc_domain}; it exists for legacy
-    callers that still import [Types] while the domain surface lives in the
-    explicit {!Masc_domain} facade. *)
-
-include module type of struct
-  include Masc_domain
-end

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1036,16 +1036,22 @@ let test_http_cancel_response_contracts () =
     (file_contains_nearby_line_with_patterns "bin/main_eio.ml"
        ~anchor:{|else dispatch_route ~routes ~request ~path reqd|}
        ~patterns:[ {|Eio.Cancel.Cancelled _ as exn|}; {|raise exn|} ]
-       ~max_lines:3);
+       ~max_lines:8);
   check bool "main_eio suppresses stale httpun response writes" true
-    (file_contains_pattern "bin/main_eio.ml"
-       {|httpun.Reqd.respond_with_string: invalid state|});
+    (file_contains_pattern "bin/main_eio.ml" {|let safe_reqd_respond|}
+    && file_contains_pattern "bin/main_eio.ml"
+         {|invalid state, currently handling error|}
+    && file_contains_pattern "bin/main_eio.ml" {|reqd respond skipped|});
   check bool "main_eio 500 fallback is best-effort" true
     (file_contains_pattern "bin/main_eio.ml"
        {|try_internal_error_response|});
   check bool "standalone ws closed writer is not warning noise" true
     (file_contains_pattern "lib/server/server_ws_standalone.ml"
-       {|Failure "cannot write to closed writer"|})
+       {|Http_server_eio.Late_response.classify_write_failure|}
+    && file_contains_pattern "lib/server/server_ws_standalone.ml"
+         {|send_pong skipped|}
+    && file_contains_pattern "lib/server/server_ws_standalone.ml"
+         {|WS standalone handler closed before write completed|})
 
 let test_worktree_list_contracts () =
   check bool "worktree list stays read-only" true


### PR DESCRIPTION
## Root cause
Current main CI had two overlapping issues:
- `masc_types` still emitted a top-level `Types.cmi` through the legacy facade, colliding with Agent_sdk/OAS `Types` assumptions in CI.
- New HTTP source guards were asserting old literal layouts after runtime moved to `safe_reqd_respond` and `Late_response.classify_write_failure`.

## Changes
- Removed legacy `lib/types/types.ml{i}` and `types` from the `masc_types` module list.
- Updated source guards to assert the current cancellation and late-response handling paths.

## Validation
- `git diff --check HEAD~1..HEAD`
- `MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_ci_hardening_source.exe test/test_dune_local_script.exe`
- `_build/default/test/test_ci_hardening_source.exe` (39/39)
- `_build/default/test/test_dune_local_script.exe` (7/7)

Local note: `scripts/check-oas-pin.sh --local-only` is blocked by shared opam switch pin drift (`c6cb1e6bba41618862a63f2c7c24bf586e4bbbef` vs expected `16678b81a6858ba66d121a7f6194751f351299a6`); not changed in this PR.