### PR TITLE
feat(dashboard): add board SNS comment controls

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   derivePostTitle,
   fetchBoard,
+  fetchBoardPost,
   sanitizeBoardTitle,
+  voteComment,
   asNullableIsoTimestamp,
   normalizePendingConfirmation,
   normalizeKeeperApprovalQueueItem,
@@ -465,6 +467,75 @@ describe('fetchBoard', () => {
       raw: 'keeper-analyst-agent',
       source: 'keeper_alias_contract',
       runtime_agent_name: 'keeper-analyst-agent',
+    })
+  })
+})
+
+describe('fetchBoardPost', () => {
+  it('normalizes comment vote fields from the server detail payload', async () => {
+    const rawResponse = {
+      post: {
+        id: 'post-1',
+        author: 'analyst',
+        title: 'Status',
+        body: 'Working',
+        created_at: 1_713_000_000,
+        updated_at: 1_713_000_000,
+      },
+      comments: [
+        {
+          id: 'comment-1',
+          post_id: 'post-1',
+          author: 'reviewer',
+          content: 'Useful',
+          created_at: 1_713_000_100,
+          votes_up: 5,
+          votes_down: 2,
+          score: 3,
+        },
+      ],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoardPost('post-1')
+
+    expect(result.comments[0]).toMatchObject({
+      id: 'comment-1',
+      votes: 3,
+      vote_balance: 3,
+      votes_up: 5,
+      votes_down: 2,
+    })
+  })
+})
+
+describe('voteComment', () => {
+  it('posts to the comment vote tool with the dashboard voter', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-reviewer')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await voteComment('comment-1', 'down')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/tools/masc_board_comment_vote')
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      comment_id: 'comment-1',
+      direction: 'down',
+      vote: 'down',
+      voter: 'dashboard-reviewer',
     })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -399,6 +399,10 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
   const author = asString(raw.author, '').trim()
   if (!id || !author) return null
   const parentId = asString(raw.parent_id, '').trim() || null
+  const votesUp = asNumber(raw.votes_up, 0)
+  const votesDown = asNumber(raw.votes_down, 0)
+  const score = asNumber(raw.score, votesUp - votesDown)
+  const votes = asNumber(raw.votes, score)
   return {
     id,
     post_id: postId,
@@ -407,6 +411,10 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     author_identity: normalizeBoardActorIdentity(raw.author_identity, author),
     content: asString(raw.content, ''),
     created_at: toIsoTimestamp(raw.created_at) ?? '',
+    votes,
+    vote_balance: score,
+    votes_up: votesUp,
+    votes_down: votesDown,
   }
 }
 
@@ -462,6 +470,15 @@ export async function fetchBoardPost(postId: string): Promise<BoardPost & { comm
 export function votePost(postId: string, direction: 'up' | 'down'): Promise<unknown> {
   return post('/api/v1/tools/masc_board_vote', {
     post_id: postId,
+    direction,
+    vote: direction,
+    voter: defaultBoardVoter(),
+  })
+}
+
+export function voteComment(commentId: string, direction: 'up' | 'down'): Promise<unknown> {
+  return post('/api/v1/tools/masc_board_comment_vote', {
+    comment_id: commentId,
     direction,
     vote: direction,
     voter: defaultBoardVoter(),

--- a/dashboard/src/components/memory-post-detail.test.ts
+++ b/dashboard/src/components/memory-post-detail.test.ts
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { cleanup, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
@@ -52,10 +52,12 @@ vi.mock('./memory-state', () => ({
   visibilityBadgeColor: () => '',
   boardPostKind: () => 'direct',
   votePost: vi.fn(),
+  voteComment: vi.fn().mockResolvedValue(undefined),
   refreshBoard: vi.fn(),
 }))
 
-import { CommentThread, PostDetail, filterCommentTree } from './memory-post-detail'
+import { CommentThread, PostDetail, countCommentDescendants, filterCommentTree } from './memory-post-detail'
+import { voteComment } from './memory-state'
 import type { BoardComment } from '../types/core'
 
 afterEach(() => {
@@ -87,6 +89,65 @@ describe('CommentThread', () => {
 
     expect(screen.getByText('orphan reply still visible')).toBeInTheDocument()
     expect(screen.getByText(/댓글 1개/)).toBeInTheDocument()
+  })
+
+  it('collapses and expands a reply subtree from the thread control', () => {
+    const comments = [
+      { id: 'c1', post_id: 'post-1', parent_id: null, author: 'root-agent', content: 'root comment', created_at: '2026-04-02T00:00:00Z' },
+      { id: 'c2', post_id: 'post-1', parent_id: 'c1', author: 'child-agent', content: 'child reply', created_at: '2026-04-02T00:01:00Z' },
+      { id: 'c3', post_id: 'post-1', parent_id: 'c2', author: 'grandchild-agent', content: 'grandchild reply', created_at: '2026-04-02T00:02:00Z' },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '답글 2개 접기' }))
+    expect(screen.queryByText('child reply')).not.toBeInTheDocument()
+    expect(screen.getByText('답글 2개 접힘')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '답글 2개 펼치기' }))
+    expect(screen.getByText('child reply')).toBeInTheDocument()
+  })
+
+  it('keeps replies past depth five behind an explicit continue control', () => {
+    const comments = [
+      { id: 'c1', post_id: 'post-1', parent_id: null, author: 'agent', content: 'level 0', created_at: '2026-04-02T00:00:00Z' },
+      { id: 'c2', post_id: 'post-1', parent_id: 'c1', author: 'agent', content: 'level 1', created_at: '2026-04-02T00:01:00Z' },
+      { id: 'c3', post_id: 'post-1', parent_id: 'c2', author: 'agent', content: 'level 2', created_at: '2026-04-02T00:02:00Z' },
+      { id: 'c4', post_id: 'post-1', parent_id: 'c3', author: 'agent', content: 'level 3', created_at: '2026-04-02T00:03:00Z' },
+      { id: 'c5', post_id: 'post-1', parent_id: 'c4', author: 'agent', content: 'level 4', created_at: '2026-04-02T00:04:00Z' },
+      { id: 'c6', post_id: 'post-1', parent_id: 'c5', author: 'agent', content: 'level 5', created_at: '2026-04-02T00:05:00Z' },
+      { id: 'c7', post_id: 'post-1', parent_id: 'c6', author: 'agent', content: 'level 6 hidden', created_at: '2026-04-02T00:06:00Z' },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    expect(screen.getByText('level 5')).toBeInTheDocument()
+    expect(screen.queryByText('level 6 hidden')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /스레드 계속 펼치기/ }))
+    expect(screen.getByText('level 6 hidden')).toBeInTheDocument()
+  })
+
+  it('sends comment votes through the board comment vote tool', async () => {
+    const comments = [
+      {
+        id: 'c1',
+        post_id: 'post-1',
+        parent_id: null,
+        author: 'agent',
+        content: 'vote on me',
+        created_at: '2026-04-02T00:00:00Z',
+        vote_balance: 4,
+      },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '댓글 추천' }))
+    await Promise.resolve()
+
+    expect(voteComment).toHaveBeenCalledWith('c1', 'up')
+    expect(screen.getByText('4')).toBeInTheDocument()
   })
 })
 
@@ -122,6 +183,12 @@ describe('filterCommentTree', () => {
     ['c11', [c111]],
     ['r2', [c21]],
   ])
+
+  it('counts all descendants for collapse labels', () => {
+    expect(countCommentDescendants('r1', childrenMap)).toBe(2)
+    expect(countCommentDescendants('r2', childrenMap)).toBe(1)
+    expect(countCommentDescendants('missing', childrenMap)).toBe(0)
+  })
 
   it('returns original references on empty query (ref-equal)', () => {
     const out = filterCommentTree(roots, childrenMap, '')

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -34,9 +34,12 @@ import {
   visibilityBadgeColor,
   boardPostKind,
   votePost,
+  voteComment,
   refreshBoard,
 } from './memory-state'
 import type { BoardComment, BoardPost } from './memory-state'
+
+const MAX_INLINE_COMMENT_DEPTH = 5
 
 // ── Expiry chip (returns html, kept in UI layer) ───────────────────
 function expiryChip(post: BoardPost) {
@@ -62,6 +65,21 @@ function buildCommentTree(comments: BoardComment[]): { roots: BoardComment[]; ch
     }
   }
   return { roots, childrenMap }
+}
+
+export function countCommentDescendants(
+  commentId: string,
+  childrenMap: ReadonlyMap<string, readonly BoardComment[]>,
+  seen: ReadonlySet<string> = new Set(),
+): number {
+  if (seen.has(commentId)) return 0
+  const nextSeen = new Set(seen)
+  nextSeen.add(commentId)
+  const children = childrenMap.get(commentId) ?? []
+  return children.reduce(
+    (sum, child) => sum + 1 + countCommentDescendants(child.id, childrenMap, nextSeen),
+    0,
+  )
 }
 
 /**
@@ -121,36 +139,81 @@ function CommentItem({
   postId,
   depth = 0,
   childrenMap,
+  forceThreadExpanded = false,
 }: {
   comment: BoardComment
   postId: string
   depth?: number
   childrenMap: ReadonlyMap<string, readonly BoardComment[]>
+  forceThreadExpanded?: boolean
 }) {
   const contentChars = Array.from(comment.content ?? '')
   const needsTruncation = contentChars.length > 300
   const [expanded, setExpanded] = useState(false)
+  const [collapsed, setCollapsed] = useState(false)
+  const [deepExpanded, setDeepExpanded] = useState(false)
   const displayText = needsTruncation && !expanded
     ? `${contentChars.slice(0, 297).join('')}...`
     : comment.content
   const isReplying = replyingTo.value === comment.id
-  const indent = depth > 0 ? `ml-${Math.min(depth * 4, 12)}` : ''
+  const visualDepth = Math.min(depth, MAX_INLINE_COMMENT_DEPTH)
+  const indentStyle = visualDepth > 0 ? { marginLeft: `${visualDepth * 16}px` } : undefined
   const replies = childrenMap.get(comment.id) ?? []
+  const replyCount = countCommentDescendants(comment.id, childrenMap)
+  const cappedByDepth = !forceThreadExpanded && !deepExpanded && depth >= MAX_INLINE_COMMENT_DEPTH && replies.length > 0
+  const showReplies = replies.length > 0 && !collapsed && !cappedByDepth
+  const childForceExpanded = forceThreadExpanded || deepExpanded
+  const score = comment.vote_balance ?? comment.votes ?? ((comment.votes_up ?? 0) - (comment.votes_down ?? 0))
   const authorLabel = boardActorDisplayName(comment.author, comment.author_identity)
   const authorAvatarKey = boardActorAvatarKey(comment.author, comment.author_identity)
   const authorTitle = boardActorTitle(comment.author, comment.author_identity)
 
+  const handleCommentVote = async (dir: 'up' | 'down') => {
+    try {
+      await voteComment(comment.id, dir)
+      await loadPostDetail(postId)
+      refreshBoard()
+    } catch (err) {
+      console.warn(`[board] comment vote failed (comment=${comment.id}, dir=${dir})`, err instanceof Error ? err.message : err)
+      showToast('댓글 투표에 실패했습니다', 'error')
+    }
+  }
+
   return html`
-    <div class="${indent}">
+    <div style=${indentStyle}>
       <div class="board-comment rounded-[var(--r-1)] p-3 bg-[var(--color-bg-surface)] border border-[var(--color-border-divider)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
+          ${replies.length > 0 && !cappedByDepth ? html`
+            <button
+              type="button"
+              class="flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
+              aria-expanded=${!collapsed}
+              aria-label=${collapsed ? `답글 ${replyCount}개 펼치기` : `답글 ${replyCount}개 접기`}
+              onClick=${() => setCollapsed(!collapsed)}
+            >${collapsed ? '+' : '−'}</button>
+          ` : null}
           <span class="text-xs">${authorAvatar(authorAvatarKey)}</span>
           <${ActionButton} variant="subtle" size="sm" class="text-xs font-medium text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}<//>
           <span class="text-2xs text-[var(--color-fg-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
+          <div class="ml-auto flex items-center gap-1">
+            <button
+              type="button"
+              class="h-5 w-6 rounded-[var(--r-1)] border-0 bg-transparent text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--warn-10)] hover:text-[var(--warn-bright)]"
+              aria-label="댓글 추천"
+              onClick=${() => handleCommentVote('up')}
+            >▲</button>
+            <span class="min-w-5 text-center text-2xs font-semibold tabular-nums text-[var(--color-fg-secondary)]">${score}</span>
+            <button
+              type="button"
+              class="h-5 w-6 rounded-[var(--r-1)] border-0 bg-transparent text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--accent-10)] hover:text-[var(--color-accent-fg)]"
+              aria-label="댓글 비추천"
+              onClick=${() => handleCommentVote('down')}
+            >▼</button>
+          </div>
           <${ActionButton}
             variant="subtle"
             size="sm"
-            class="text-2xs hover:text-[var(--color-accent-fg)] bg-transparent border-0 ml-auto"
+            class="text-2xs hover:text-[var(--color-accent-fg)] bg-transparent border-0"
             onClick=${() => { replyingTo.value = isReplying ? null : comment.id; commentText.value = '' }}
           >${isReplying ? '취소' : '답글'}<//>
         </div>
@@ -188,10 +251,20 @@ function CommentItem({
             </div>
           </div>
         ` : null}
+        ${collapsed && replyCount > 0 ? html`
+          <div class="mt-2 text-2xs text-[var(--color-fg-muted)]">답글 ${replyCount}개 접힘</div>
+        ` : null}
+        ${cappedByDepth ? html`
+          <button
+            type="button"
+            class="mt-2 rounded-[var(--r-1)] border border-dashed border-[var(--accent-20)] bg-transparent px-2 py-1 text-left text-2xs text-[var(--color-accent-fg)] hover:bg-[var(--accent-10)]"
+            onClick=${() => setDeepExpanded(true)}
+          >스레드 계속 펼치기 · 답글 ${replyCount}개</button>
+        ` : null}
       </div>
-      ${replies.length > 0 ? html`
+      ${showReplies ? html`
         <div class="flex flex-col gap-1.5 mt-1.5">
-          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} />`)}
+          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} forceThreadExpanded=${childForceExpanded} />`)}
         </div>
       ` : null}
     </div>

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -19,6 +19,7 @@ import {
 } from '../store'
 import {
   votePost,
+  voteComment,
   fetchBoardPost,
   commentPost,
   createPost,
@@ -44,6 +45,7 @@ export {
   loadMoreBoardPosts,
 }
 export { votePost }
+export { voteComment }
 export { deleteBoardPost }
 export type { BoardComment, BoardPost, BoardSortMode }
 
@@ -286,6 +288,7 @@ export async function loadPostDetail(postId: string) {
     detailPost.value = {
       id: data.id,
       author: data.author,
+      author_identity: data.author_identity,
       title: data.title,
       body: data.body,
       content: data.content,
@@ -297,6 +300,7 @@ export async function loadPostDetail(postId: string) {
       created_at: data.created_at,
       updated_at: data.updated_at,
       post_kind: data.post_kind,
+      classification_reason: data.classification_reason,
       flair: data.flair,
       hearth: data.hearth,
       visibility: data.visibility,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -157,6 +157,10 @@ export interface BoardComment {
   author_identity?: BoardActorIdentity | null
   content: string
   created_at: string
+  votes?: number
+  vote_balance?: number
+  votes_up?: number
+  votes_down?: number
 }
 
 // --- Keeper Metrics ---


### PR DESCRIPTION
Summary
- Wire board comment scores through the dashboard API and types.
- Add comment up/down voting through the existing masc_board_comment_vote tool.
- Add Reddit-style thread collapse plus depth-5 continue controls for deep reply chains.

Validation
- pnpm exec vitest run src/api/board.test.ts src/components/memory-post-detail.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check

Context
- Based on /Users/dancer/Downloads/masc_sns.agent.final. The report premise that Board UI was absent is stale on current main, so this PR strengthens the existing Workspace Board surface instead of adding a parallel greenfield route.