### PR TITLE
fix: surface governance fallback counters

### DIFF
--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -23,6 +23,8 @@ let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot
       ("model_used", string_option_json runtime.model_used);
       ("keeper_name", `String runtime.keeper_name);
       ("last_error", string_option_json runtime.last_error);
+      ( "lenient_json_fallback",
+        Judge_diagnostics.lenient_fallback_metrics_json ~judge_label:"Governance" );
     ]
 
 let summary_json_of_runtime ?base_path

--- a/lib/dashboard/judge_diagnostics.ml
+++ b/lib/dashboard/judge_diagnostics.ml
@@ -34,3 +34,22 @@ let record_lenient_fallback ~judge_label raw =
     ~labels
     ();
   format_lenient_fallback ~judge_label raw
+
+let int_metric_value metric_name ~labels =
+  int_of_float (Prometheus.metric_value_or_zero metric_name ~labels ())
+
+let lenient_fallback_metrics_json ~judge_label =
+  let judge = String.lowercase_ascii judge_label in
+  let labels = [("judge", judge)] in
+  `Assoc
+    [
+      ("judge", `String judge);
+      ( "governance_judge_unparseable_total",
+        `Int
+          (int_metric_value Prometheus.metric_governance_judge_unparseable
+             ~labels) );
+      ( "governance_lenient_json_fallback_hit_total",
+        `Int
+          (int_metric_value
+             Prometheus.metric_governance_lenient_json_fallback_hit ~labels) );
+    ]

--- a/lib/dashboard/judge_diagnostics.mli
+++ b/lib/dashboard/judge_diagnostics.mli
@@ -13,3 +13,7 @@ val format_lenient_fallback : judge_label:string -> string -> string
 val record_lenient_fallback : judge_label:string -> string -> string
 (** Increment the judge fallback metrics and return
     {!format_lenient_fallback}. *)
+
+val lenient_fallback_metrics_json : judge_label:string -> Yojson.Safe.t
+(** Current Prometheus counter values for a judge label, formatted for
+    dashboard/runtime JSON surfaces. *)

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -95,12 +95,66 @@ let test_empty_governance_structure () =
         (judge |> member "degraded_reason" = `Null);
       check string "keeper_name is governance-judge" "governance-judge"
         (judge |> member "keeper_name" |> to_string);
+      let fallback = judge |> member "lenient_json_fallback" in
+      check string "fallback metrics label is governance" "governance"
+        (fallback |> member "judge" |> to_string);
+      ignore
+        (fallback |> member "governance_judge_unparseable_total" |> to_int);
+      ignore
+        (fallback
+         |> member "governance_lenient_json_fallback_hit_total"
+         |> to_int);
       check bool "model_used is null when no judge started" true
         (judge |> member "model_used" = `Null);
       let judgments = json |> member "judgments" |> to_list in
       check int "judgments empty" 0 (List.length judgments);
       let pending = json |> member "pending_actions" |> to_list in
       check int "pending_actions empty" 0 (List.length pending))
+
+let governance_fallback_count metric_name =
+  int_of_float
+    (Lib.Prometheus.metric_value_or_zero
+       metric_name
+       ~labels:[("judge", "governance")]
+       ())
+
+let test_dashboard_surfaces_lenient_fallback_metrics () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let config = Coord_utils.default_config dir in
+      ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
+      let before_unparseable =
+        governance_fallback_count
+          Lib.Prometheus.metric_governance_judge_unparseable
+      in
+      let before_fallback =
+        governance_fallback_count
+          Lib.Prometheus.metric_governance_lenient_json_fallback_hit
+      in
+      ignore
+        (Lib.Judge_diagnostics.record_lenient_fallback
+           ~judge_label:"Governance"
+           "not-json");
+      let json =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20
+          ~offset:0 ~status_filter:None
+      in
+      let open Yojson.Safe.Util in
+      let fallback =
+        json |> member "judge" |> member "lenient_json_fallback"
+      in
+      check int "unparseable fallback count surfaced"
+        (before_unparseable + 1)
+        (fallback |> member "governance_judge_unparseable_total" |> to_int);
+      check int "lenient fallback hit count surfaced"
+        (before_fallback + 1)
+        (fallback
+         |> member "governance_lenient_json_fallback_hit_total"
+         |> to_int))
 
 let test_runtime_status_and_judgments_are_live () =
   let dir = test_dir () in
@@ -651,6 +705,8 @@ let () =
         [
           test_case "empty governance structure" `Quick
             test_empty_governance_structure;
+          test_case "dashboard surfaces lenient fallback metrics" `Quick
+            test_dashboard_surfaces_lenient_fallback_metrics;
           test_case "runtime status and judgments are live" `Quick
             test_runtime_status_and_judgments_are_live;
           test_case "empty judgment disk scan uses cooldown" `Quick

--- a/test/test_judge_diagnostics.ml
+++ b/test/test_judge_diagnostics.ml
@@ -89,6 +89,41 @@ let test_record_lenient_fallback_increments_metrics () =
        ~labels
        ())
 
+let test_lenient_fallback_metrics_json_reads_counters () =
+  let raw = "still-not-json" in
+  let labels = [("judge", "governance")] in
+  let before_unparseable =
+    int_of_float
+      (Prometheus.metric_value_or_zero
+         Prometheus.metric_governance_judge_unparseable
+         ~labels
+         ())
+  in
+  let before_fallback =
+    int_of_float
+      (Prometheus.metric_value_or_zero
+         Prometheus.metric_governance_lenient_json_fallback_hit
+         ~labels
+         ())
+  in
+  ignore
+    (Judge_diagnostics.record_lenient_fallback
+       ~judge_label:"Governance"
+       raw);
+  let json =
+    Judge_diagnostics.lenient_fallback_metrics_json
+      ~judge_label:"Governance"
+  in
+  let open Yojson.Safe.Util in
+  check string "judge label" "governance"
+    (json |> member "judge" |> to_string);
+  check int "unparseable total"
+    (before_unparseable + 1)
+    (json |> member "governance_judge_unparseable_total" |> to_int);
+  check int "fallback total"
+    (before_fallback + 1)
+    (json |> member "governance_lenient_json_fallback_hit_total" |> to_int)
+
 let () =
   run "judge_diagnostics (#9774)"
     [
@@ -106,5 +141,7 @@ let () =
             test_format_lenient_fallback_truncates_huge_raw;
           test_case "record increments metrics" `Quick
             test_record_lenient_fallback_increments_metrics;
+          test_case "metrics JSON reads counters" `Quick
+            test_lenient_fallback_metrics_json_reads_counters;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Expose current governance judge unparseable and Lenient_json fallback counters in the dashboard governance judge JSON.
- Add a shared Judge_diagnostics JSON helper that reads the existing Prometheus counters by judge label.
- Cover both the helper and /api/v1/dashboard/governance JSON projection with regression tests.

## Why
The live GOAL LOOP logs showed Governance judge returned unparseable response with Lenient_json fallback hit. The counters already existed, but the dashboard governance surface did not show them, so operators could miss the silent-failure signal unless they queried Prometheus or tailed logs.

## Validation
- git diff --check origin/main...HEAD
- ocamlc -stop-after parsing lib/dashboard/judge_diagnostics.ml lib/dashboard/judge_diagnostics.mli lib/dashboard/dashboard_governance.ml test/test_judge_diagnostics.ml test/test_dashboard_governance.ml

## Local verification note
I ran scripts/opam-pin-external-deps.sh --install to align agent_sdk with the current repo pin. Focused Dune still could not complete locally: scripts/dune-local.sh build --cache=disabled test/test_judge_diagnostics.exe test/test_dashboard_governance.exe failed outside this patch at lib/keeper/keeper_deliberation.ml with Agent_sdk.Structured aliasing a missing Agent_sdk__Structured module. The installed package does contain Agent_sdk__Structured artifacts, so this looks like a local stale artifact/package environment issue rather than a compile failure in the changed files. CI should provide the authoritative Dune result.