### PR TITLE
chore: add GOAL LOOP ACT checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,17 @@
 <!-- Tests, harness runs, screenshots, logs, or other proof. -->
 - If tool-call behavior or provider tool support changed: include replay-harness or `ToolCallContract` evidence.
 
+## GOAL LOOP ACT checklist
+
+<!-- Complete this section for operational/runtime fixes. Leave unchecked items with a brief N/A reason. -->
+
+- [ ] Observe — metric/log/trace evidence for the failure or drift is linked or pasted above
+- [ ] Orient — mapped to a finding, live-log pattern, audit item, or explicit new finding
+- [ ] Decide — priority/risk rationale is stated, including why this scope is the next action
+- [ ] Act — code/config/docs changed in the smallest bounded scope; rollback path is clear
+- [ ] Verify — regression test, focused local command, CI job, or production-log check proves PASS/FAIL
+- [ ] Loop — remaining follow-up is linked as an issue/PR/handoff, or explicitly marked none
+
 ## Review evidence
 
 <!-- Cross-model review result, reviewer model, and fallback reason if any. -->


### PR DESCRIPTION
## Summary
- Add a GOAL LOOP ACT checklist to the default pull request template.
- Require PR authors to name Observe, Orient, Decide, Act, Verify, and Loop evidence or mark a reason when not applicable.

## Why
The GOAL LOOP design says fixes should not stop at code changes: every ACT needs measured evidence, finding alignment, decision rationale, verification, and a loop continuation record. Putting this in the PR template makes that operational contract visible on every future PR.

## Validation
- git diff --check origin/main...HEAD

## Local verification note
Template-only change. No Dune target is required.