### PR TITLE
fix: cascade on model access denial

### DIFF
--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -289,6 +289,7 @@ module KeeperRetryBackoff : sig
   val transient_backoff_base_sec : unit -> float
   val transient_backoff_cap_sec : unit -> float
   val transient_backoff_sec : int -> float
+  val degraded_retry_slot_phase_budget_sec : float
 end
 
 (** {1 Cascade attempt liveness — RFC-0022 §9 rollout flag} *)

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -319,11 +319,10 @@ let next_fail_open_cascade_for_turn_with_budget
       (* The candidate is always a retry, so use per-attempt budget semantics
          regardless of whether the current attempt was itself a retry. *)
       if
-        Option.exists
-          (fun time_spent_in_turn_s ->
-            not
-              (degraded_retry_slot_phase_available ~time_spent_in_turn_s))
-          time_spent_in_turn_s
+        match time_spent_in_turn_s with
+        | Some time_spent_in_turn_s ->
+            not (degraded_retry_slot_phase_available ~time_spent_in_turn_s)
+        | None -> false
       then Degraded_retry_slot_phase_exhausted retry
       else if
         oas_retry_budget_available_for_turn

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -12,6 +12,12 @@ let retry_message_looks_like_not_found (message : string) : bool =
   || String_util.contains_substring_ci message "status code: 404"
   || String_util.contains_substring_ci message "404 page not found"
 
+let retry_message_looks_like_model_access_denied (message : string) : bool =
+  String_util.contains_substring_ci message "permission to access"
+  || String_util.contains_substring_ci message "not have access to"
+  || String_util.contains_substring_ci message "does not have access to"
+  || String_util.contains_substring_ci message "not authorized to access"
+
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are
     cascadeable (a different provider may succeed).  Structural agent
@@ -29,10 +35,19 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   | Agent_sdk.Error.Api api_err ->
     let http_err = match[@warning "-8"] api_err with
       | Llm_provider.Retry.InvalidRequest { message } ->
-        let code =
-          if retry_message_looks_like_not_found message then 404 else 400
-        in
-        Llm_provider.Http_client.HttpError { code; body = message }
+        if retry_message_looks_like_model_access_denied message then
+          Llm_provider.Http_client.ProviderFailure
+            {
+              kind =
+                Llm_provider.Http_client.Capability_mismatch
+                  { capability = Some "model_access" };
+              message;
+            }
+        else
+          let code =
+            if retry_message_looks_like_not_found message then 404 else 400
+          in
+          Llm_provider.Http_client.HttpError { code; body = message }
       | Llm_provider.Retry.ContextOverflow { message; _ } ->
         Llm_provider.Http_client.HttpError { code = 400; body = message }
       | Llm_provider.Retry.RateLimited { message; _ } ->

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -843,6 +843,31 @@ let test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400 () =
         "expected Some (Call_err (HttpError 400)) for ordinary InvalidRequest, got %s"
         (Cascade_fsm.provider_outcome_option_to_string outcome)
 
+let test_sdk_error_to_cascade_outcome_cascades_model_access_denied () =
+  let message = "Invalid request: You do not have permission to access glm-5-code" in
+  let err =
+    Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message })
+  in
+  match Oas_worker_named.sdk_error_to_cascade_outcome err with
+  | Some
+      (Cascade_fsm.Call_err
+         (Llm_provider.Http_client.ProviderFailure
+            {
+              kind =
+                Llm_provider.Http_client.Capability_mismatch
+                  { capability = Some "model_access" };
+              message = actual_message;
+            } as http_err)) ->
+      Alcotest.(check string) "message preserved" message actual_message;
+      Alcotest.(check bool) "failed model name visible" true
+        (contains_substring ~needle:"glm-5-code" actual_message);
+      Alcotest.(check bool) "model access denial cascades" true
+        (Oas_compat.Http_client.should_cascade http_err)
+  | outcome ->
+      Alcotest.failf
+        "expected model access InvalidRequest to cascade as ProviderFailure Capability_mismatch, got %s"
+        (Cascade_fsm.provider_outcome_option_to_string outcome)
+
 let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
   let detail = "codex_cli runtime MCP cannot carry keeper-bound auth headers" in
   let err =
@@ -4091,6 +4116,8 @@ let () =
         test_sdk_error_to_cascade_outcome_maps_not_found_to_404;
       Alcotest.test_case "sdk_error_to_cascade_outcome keeps ordinary InvalidRequest at 400" `Quick
         test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400;
+      Alcotest.test_case "sdk_error_to_cascade_outcome cascades model access denial" `Quick
+        test_sdk_error_to_cascade_outcome_cascades_model_access_denied;
       Alcotest.test_case "sdk_error_to_cascade_outcome cascades runtime MCP auth config" `Quick
         test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config;
       Alcotest.test_case "sdk_error_to_cascade_outcome cascades resumable CLI session" `Quick


### PR DESCRIPTION
## Summary

- Treat provider/model access-denied `InvalidRequest` errors as a provider-local capability mismatch instead of terminal HTTP 400.
- Keep ordinary `InvalidRequest` handling unchanged so generic bad requests still stop the cascade.
- Add a regression test for the live failure shape: `You do not have permission to access glm-5-code`.

## Product impact

This addresses a real keeper liveness failure observed in the live runtime: sangsu hit `api_error_invalid_request` for `glm-5-code` and ended the turn silently instead of trying the next candidate. With this change, a single inaccessible model can no longer terminate a keeper turn when other cascade candidates remain available.

## Evidence

- Live runtime evidence: `/Users/dancer/me/.masc/keepers/sangsu.decisions.jsonl` contains `Invalid request: You do not have permission to access glm-5-code` at `2026-05-05T09:29:47Z`.
- Code path: `sdk_error_to_cascade_outcome` now maps model access denial to `ProviderFailure Capability_mismatch { capability = Some "model_access" }`, which `Oas_compat.Http_client.should_cascade` already treats as cascadeable.

## Review evidence

- `git diff --check HEAD~1..HEAD`
- `scripts/opam-pin-external-deps.sh --install` repaired the local switch to repo SSOT `agent_sdk 0.190.4`.
- `scripts/dune-local.sh build test/test_oas_worker.exe` passed before the final main rebase.
- `./_build/default/test/test_oas_worker.exe test '^cascade_config$' 32 --show-errors` passed for the new regression before the final main rebase.
- After rebasing onto latest `origin/main`, a repeat focused build was blocked by shared opam pin drift from other sessions repinning `agent_sdk` away from the repo SSOT.

## Linked issue

- None. Follow-up from keeper live-runtime liveness audit.
