### PR TITLE
fix: surface credential starvation monitoring

### DIFF
--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -215,6 +215,26 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
     ("judge_online", `Bool runtime.judge_online);
   ], true)
 
+let credential_monitoring_json () : Yojson.Safe.t =
+  let archived_starvation =
+    int_of_float
+      (Prometheus.metric_total
+         Prometheus.metric_config_credential_archived_starvation)
+  in
+  let needs_attention = archived_starvation > 0 in
+  `Assoc [
+    ("alert_level", `String (if needs_attention then "bad" else "ok"));
+    ("needs_attention", `Bool needs_attention);
+    ( "credential_archived_starvation_total",
+      `Int archived_starvation );
+    ( "metric_name",
+      `String Prometheus.metric_config_credential_archived_starvation );
+    ( "reason",
+      if needs_attention then
+        `String "bare_form_keeper_credential_archived_after_starvation"
+      else `Null );
+  ]
+
 let slot_monitoring_json () : Yojson.Safe.t =
   try
     let idle = Discovery_cache.idle_slot_count () in

--- a/lib/dashboard/dashboard_http_monitoring.mli
+++ b/lib/dashboard/dashboard_http_monitoring.mli
@@ -22,6 +22,11 @@ val board_monitoring_json : now_ts:float -> Yojson.Safe.t * bool
 val governance_monitoring_json :
   now_ts:float -> base_path:string -> Yojson.Safe.t * bool
 
+(** Snapshot of auth/credential runtime drift counters that should
+    page an operator, including keeper credential archival after
+    starvation recovery. *)
+val credential_monitoring_json : unit -> Yojson.Safe.t
+
 (** Point-in-time slot occupancy / queue depth snapshot. *)
 val slot_monitoring_json : unit -> Yojson.Safe.t
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -147,6 +147,7 @@ let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Saf
       ("monitoring", `Assoc [
         ("board", board_monitor_json);
         ("governance", governance_monitor_json);
+        ("credentials", credential_monitoring_json ());
         ("room_state", Coord_eio.state_health_counters ());
         ("executor", executor_outcomes_json config);
         ("slots", slot_monitoring_json ());

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -275,6 +275,54 @@ let test_dashboard_planning_http_json_includes_coordination_fsm () =
      | `List _ -> true
      | _ -> false)
 
+let credential_archived_starvation_total () =
+  int_of_float
+    (Lib.Prometheus.metric_total
+       Lib.Prometheus.metric_config_credential_archived_starvation)
+
+let record_test_credential_archive () =
+  let keeper_name =
+    Printf.sprintf "goal-loop-monitor-%d-%d"
+      (Unix.getpid ())
+      (Random.bits ())
+  in
+  Lib.Prometheus.inc_counter
+    Lib.Prometheus.metric_config_credential_archived_starvation
+    ~labels:[("keeper_name", keeper_name)]
+    ()
+
+let test_credential_monitoring_json_surfaces_archive_counter () =
+  let before = credential_archived_starvation_total () in
+  record_test_credential_archive ();
+  let json = Lib.Dashboard_http_monitoring.credential_monitoring_json () in
+  let open Yojson.Safe.Util in
+  check int "credential archive total"
+    (before + 1)
+    (json |> member "credential_archived_starvation_total" |> to_int);
+  check string "metric name"
+    Lib.Prometheus.metric_config_credential_archived_starvation
+    (json |> member "metric_name" |> to_string);
+  check string "alert level" "bad"
+    (json |> member "alert_level" |> to_string);
+  check bool "needs attention" true
+    (json |> member "needs_attention" |> to_bool)
+
+let test_dashboard_batch_json_includes_credential_monitoring () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
+  let before = credential_archived_starvation_total () in
+  record_test_credential_archive ();
+  let json = Lib.Server_dashboard_http_core.dashboard_batch_json config in
+  let open Yojson.Safe.Util in
+  let credentials =
+    json |> member "status" |> member "monitoring" |> member "credentials"
+  in
+  check int "batch credential archive total"
+    (before + 1)
+    (credentials |> member "credential_archived_starvation_total" |> to_int);
+  check string "batch credential alert" "bad"
+    (credentials |> member "alert_level" |> to_string)
+
 let test_dashboard_shell_auth_json_canonicalizes_token_owner () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let cfg =
@@ -391,6 +439,10 @@ let () =
             test_dashboard_shell_http_json_prefers_last_good_while_prewarming;
           test_case "planning payload includes coordination FSM" `Quick
             test_dashboard_planning_http_json_includes_coordination_fsm;
+          test_case "credential monitoring surfaces archive counter" `Quick
+            test_credential_monitoring_json_surfaces_archive_counter;
+          test_case "batch payload includes credential monitoring" `Quick
+            test_dashboard_batch_json_includes_credential_monitoring;
           test_case "shell auth canonicalizes token owner" `Quick
             test_dashboard_shell_auth_json_canonicalizes_token_owner;
           test_case "shell auth reports missing token" `Quick


### PR DESCRIPTION
## Summary

- Add `Dashboard_http_monitoring.credential_monitoring_json` backed by `masc_config_credential_archived_starvation_total`.
- Include the snapshot in the dashboard batch payload at `status.monitoring.credentials`.
- Add dashboard regression coverage for the direct monitoring JSON and the batch payload wiring.

## Why

GOAL LOOP Observe already emits the credential archival/starvation counter, but the operator dashboard batch payload did not expose it. This made the NF-2 class visible in logs/Prometheus only, while the runtime dashboard could still look silent. This PR turns that existing counter into an operator-visible `needs_attention` signal.

## ACT Checklist

- Observe: uses the existing `masc_config_credential_archived_starvation_total` metric.
- Orient: maps credential starvation/archive drift into dashboard `monitoring.credentials`.
- Decide: keeps the slice scoped to dashboard surfacing to avoid overlapping `/health` changes.
- Act: adds the monitoring helper, batch payload field, and focused tests.
- Verify: static checks passed; focused Dune was attempted but blocked by the shared Dune lock queue.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing lib/dashboard/dashboard_http_monitoring.ml lib/dashboard/dashboard_http_monitoring.mli lib/server/server_dashboard_http_core.ml test/test_dashboard_http_core.ml`
- `rg -n "Stdlib\\.Lazy\\.(force|from_val)|Fun\\.protect|Mutex\\.(lock|unlock)|failwith|assert false|Eio\\.traceln|Sys\\.(readdir|command)" ...` found only pre-existing helper/server patterns, no new diff hits.
- `scripts/dune-local.sh build --cache=disabled test/test_dashboard_http_core.exe` was attempted and stopped after waiting on `/tmp/me-dune-local.lock` behind other local Dune jobs.