### PR TITLE
feat(dashboard): add board hearth filters

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   derivePostTitle,
+  createPost,
   fetchBoard,
   fetchBoardHearths,
   fetchBoardPost,
@@ -553,6 +554,30 @@ describe('fetchBoardPost', () => {
       vote_balance: 3,
       votes_up: 5,
       votes_down: 2,
+    })
+  })
+})
+
+describe('createPost', () => {
+  it('passes hearth assignment through to the board post tool', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createPost('Plan', 'Body', 'dashboard-user', { hearth: ' ops ' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/tools/masc_board_post')
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      title: 'Plan',
+      content: 'Body',
+      author: 'dashboard-user',
+      hearth: 'ops',
     })
   })
 })

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   derivePostTitle,
   fetchBoard,
+  fetchBoardHearths,
   fetchBoardPost,
   sanitizeBoardTitle,
   voteComment,
@@ -468,6 +469,47 @@ describe('fetchBoard', () => {
       source: 'keeper_alias_contract',
       runtime_agent_name: 'keeper-analyst-agent',
     })
+  })
+
+  it('passes hearth filters through to the board API', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ posts: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchBoard('recent', { hearth: 'ops' })
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/v1/board?')
+    expect(url).toContain('hearth=ops')
+    expect(url).toContain('limit=150')
+  })
+})
+
+describe('fetchBoardHearths', () => {
+  it('normalizes active hearth rows from the server', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        hearths: [
+          { name: 'ops', count: 3 },
+          { name: '  ', count: 9 },
+          { name: 'research' },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchBoardHearths()).resolves.toEqual([
+      { name: 'ops', count: 3 },
+      { name: 'research', count: 0 },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/board/hearths', expect.any(Object))
   })
 })
 

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -9,6 +9,11 @@ import type {
   GovernanceResolvedAction, GovernanceTimelineEvent, PendingConfirmation,
 } from '../types'
 
+export interface BoardHearth {
+  name: string
+  count: number
+}
+
 function toIsoTimestamp(value: unknown): string | null {
   if (typeof value === 'string' && value.trim()) return value
   if (typeof value !== 'number' || Number.isNaN(value)) return null
@@ -418,9 +423,19 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
   }
 }
 
+function normalizeBoardHearth(raw: unknown): BoardHearth | null {
+  if (!isRecord(raw)) return null
+  const name = asString(raw.name, '').trim()
+  if (!name) return null
+  return {
+    name,
+    count: asNumber(raw.count, 0),
+  }
+}
+
 export async function fetchBoard(
   sortBy?: BoardSortMode,
-  options?: { excludeSystem?: boolean; excludeAutomation?: boolean; author?: string },
+  options?: { excludeSystem?: boolean; excludeAutomation?: boolean; author?: string; hearth?: string },
 ): Promise<{ posts: BoardPost[] }> {
   return withRetries('fetchBoard', async () => {
     const params = new URLSearchParams()
@@ -428,7 +443,8 @@ export async function fetchBoard(
     if (options?.excludeSystem) params.set('exclude_system', 'true')
     if (options?.excludeAutomation) params.set('exclude_automation', 'true')
     if (options?.author) params.set('author', options.author)
-    params.set('limit', options?.excludeSystem || options?.excludeAutomation || options?.author ? '150' : '100')
+    if (options?.hearth) params.set('hearth', options.hearth)
+    params.set('limit', options?.excludeSystem || options?.excludeAutomation || options?.author || options?.hearth ? '150' : '100')
     const qs = params.toString()
     const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
     const posts = Array.isArray(raw.posts)
@@ -437,6 +453,16 @@ export async function fetchBoard(
     return { posts }
   })
 }
+
+export async function fetchBoardHearths(): Promise<BoardHearth[]> {
+  return withRetries('fetchBoardHearths', async () => {
+    const raw = await get<{ hearths?: unknown[] }>('/api/v1/board/hearths')
+    return Array.isArray(raw.hearths)
+      ? raw.hearths.map(normalizeBoardHearth).filter((row): row is BoardHearth => row !== null)
+      : []
+  })
+}
+
 export async function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
   return withRetries('fetchBoardPost', async () => {
     const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?format=flat`)

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -511,12 +511,20 @@ export function voteComment(commentId: string, direction: 'up' | 'down'): Promis
   })
 }
 
-export function createPost(title: string, content: string, author: string): Promise<unknown> {
-  return post(`/api/v1/tools/masc_board_post`, {
+export function createPost(
+  title: string,
+  content: string,
+  author: string,
+  options: { hearth?: string } = {},
+): Promise<unknown> {
+  const body: Record<string, string> = {
     title,
     content,
     author,
-  })
+  }
+  const hearth = options.hearth?.trim()
+  if (hearth) body.hearth = hearth
+  return post(`/api/v1/tools/masc_board_post`, body)
 }
 
 export function commentPost(postId: string, author: string, content: string, parentId?: string): Promise<unknown> {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -355,6 +355,7 @@ interface FetchDashboardMemoryOptions {
   excludeSystem?: boolean
   excludeAutomation?: boolean
   author?: string
+  hearth?: string
   /** Page size. Defaults to 200 when any filter is active, else 100. */
   limit?: number
   /** Number of posts to skip from the start of the sorted list. Defaults to 0. */
@@ -367,7 +368,7 @@ export function fetchDashboardMemory(
 ): Promise<DashboardMemoryResponse> {
   const params = new URLSearchParams()
   params.set('sort_by', sortMode)
-  const hasFilter = opts?.excludeSystem || opts?.excludeAutomation || opts?.author
+  const hasFilter = opts?.excludeSystem || opts?.excludeAutomation || opts?.author || opts?.hearth
   const defaultLimit = hasFilter ? 200 : 100
   const limit = Math.max(1, Math.min(500, opts?.limit ?? defaultLimit))
   const offset = Math.max(0, Math.min(5000, opts?.offset ?? 0))
@@ -376,6 +377,7 @@ export function fetchDashboardMemory(
   if (opts?.excludeSystem) params.set('exclude_system', 'true')
   if (opts?.excludeAutomation) params.set('exclude_automation', 'true')
   if (opts?.author) params.set('author', opts.author)
+  if (opts?.hearth) params.set('hearth', opts.hearth)
   return get(`/api/v1/dashboard/board${params.toString() ? `?${params}` : ''}`)
 }
 

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -81,6 +81,7 @@ export const replyingTo = signal<string | null>(null)
 export const showNewPostForm = signal(false)
 export const newPostTitle = signal('')
 export const newPostContent = signal('')
+export const newPostHearth = signal('')
 export const newPostSubmitting = signal(false)
 
 // ── Pagination ─────────────────────────────────────────────────────
@@ -364,15 +365,18 @@ export async function submitComment(postId: string, parentId?: string) {
 export async function submitNewPost() {
   const title = newPostTitle.value.trim()
   const content = newPostContent.value.trim()
+  const hearth = newPostHearth.value.trim() || boardHearthFilter.value.trim()
   if (!title || !content) return
   newPostSubmitting.value = true
   try {
-    await createPost(title, content, commentAuthor.value)
+    await createPost(title, content, commentAuthor.value, { hearth: hearth || undefined })
     newPostTitle.value = ''
     newPostContent.value = ''
+    newPostHearth.value = ''
     showNewPostForm.value = false
     showToast('글을 등록했습니다', 'success')
     refreshBoard()
+    void refreshBoardHearths()
   } catch (err) {
     console.warn('[board] post submit failed', err instanceof Error ? err.message : err)
     showToast('글 등록에 실패했습니다', 'error')

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -13,6 +13,7 @@ import {
   boardHasMore,
   boardOffset,
   boardTotal,
+  boardHearthFilter,
   lastBoardRefreshAt,
   refreshBoard,
   loadMoreBoardPosts,
@@ -20,9 +21,11 @@ import {
 import {
   votePost,
   voteComment,
+  fetchBoardHearths,
   fetchBoardPost,
   commentPost,
   createPost,
+  type BoardHearth,
 } from '../../api'
 import { deleteBoardPost } from '../../api/actions'
 import type { BoardComment, BoardPost, BoardSortMode } from '../../types'
@@ -40,6 +43,7 @@ export {
   boardHasMore,
   boardOffset,
   boardTotal,
+  boardHearthFilter,
   lastBoardRefreshAt,
   refreshBoard,
   loadMoreBoardPosts,
@@ -63,6 +67,10 @@ export const detailPost = signal<BoardPost | null>(null)
 export const detailComments = signal<BoardComment[]>([])
 export const detailLoading = signal(false)
 export const detailPostId = signal<string | null>(null)
+
+// ── Signals: hearth filters ───────────────────────────────────────
+export const boardHearths = signal<BoardHearth[]>([])
+export const boardHearthsLoading = signal(false)
 
 // ── Signals: comments ──────────────────────────────────────────────
 export const commentText = signal('')
@@ -92,6 +100,18 @@ export const categoryVisibleLimits = signal<Record<string, number>>({
 export const deletingPostId = signal<string | null>(null)
 export const selectedPostIds = signal<Set<string>>(new Set())
 export const bulkDeleting = signal(false)
+
+export async function refreshBoardHearths(): Promise<void> {
+  boardHearthsLoading.value = true
+  try {
+    boardHearths.value = await fetchBoardHearths()
+  } catch (err) {
+    console.warn('[Board] failed to load hearth filters:', err)
+    showToast('Hearth 목록을 불러오지 못했습니다', 'error')
+  } finally {
+    boardHearthsLoading.value = false
+  }
+}
 
 // ── Helper: default comment author ─────────────────────────────────
 function defaultCommentAuthor(): string {

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
 import { route } from '../../router'
-import { boardHearths, contentCategory } from './board-state'
+import { boardHearths, contentCategory, newPostHearth } from './board-state'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -142,6 +142,7 @@ describe('BoardSurface Component', () => {
     boardAuthorFilter.value = ''
     boardHearthFilter.value = ''
     boardHearths.value = [{ name: 'ops', count: 0 }]
+    newPostHearth.value = ''
     route.value = { params: {} } as any
   })
 
@@ -200,5 +201,15 @@ describe('BoardSurface Component', () => {
 
     expect(boardHearthFilter.value).toBe('ops')
     expect(screen.getByRole('button', { name: 'hearth ops 2 posts' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('prefills the compose hearth from the active hearth filter', () => {
+    boardHearthFilter.value = 'ops'
+
+    render(h(BoardSurface, null))
+    fireEvent.click(screen.getByRole('button', { name: '+ 새 글 작성' }))
+
+    expect(screen.getByLabelText('새 글 hearth')).toHaveValue('ops')
+    expect(newPostHearth.value).toBe('ops')
   })
 })

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -1,10 +1,10 @@
 import { h } from 'preact'
-import { render, screen } from '@testing-library/preact'
+import { fireEvent, render, screen } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BoardSurface } from './board-surface'
-import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter } from '../../store'
+import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
 import { route } from '../../router'
-import { contentCategory } from './board-state'
+import { boardHearths, contentCategory } from './board-state'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -26,6 +26,7 @@ vi.mock('../../router', () => ({
 vi.mock('../../api', () => ({
   fetchBoardPost: vi.fn(),
   votePost: vi.fn(),
+  fetchBoardHearths: vi.fn().mockResolvedValue([]),
   commentPost: vi.fn(),
   createPost: vi.fn(),
 }))
@@ -45,6 +46,7 @@ vi.mock('./board-state', async () => {
     fetchBoardPost: vi.fn(),
     commentPost: vi.fn(),
     createPost: vi.fn(),
+    refreshBoardHearths: vi.fn(),
   }
 })
 
@@ -125,6 +127,12 @@ describe('contentCategory', () => {
 describe('BoardSurface Component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ posts: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
     boardPosts.value = []
     boardLoading.value = false
     boardSortMode.value = 'recent'
@@ -132,6 +140,8 @@ describe('BoardSurface Component', () => {
     boardExcludeAutomation.value = false
     boardHiddenCategories.value = new Set(['system'])
     boardAuthorFilter.value = ''
+    boardHearthFilter.value = ''
+    boardHearths.value = [{ name: 'ops', count: 0 }]
     route.value = { params: {} } as any
   })
 
@@ -171,5 +181,24 @@ describe('BoardSurface Component', () => {
     ]
     render(h(BoardSurface, null))
     expect(screen.queryByText('System Post')).not.toBeInTheDocument()
+  })
+
+  it('applies a hearth filter from the server hearth list', () => {
+    boardHearths.value = [{ name: 'ops', count: 2 }]
+    boardPosts.value = [
+      makePost({
+        id: 'post-ops',
+        title: 'Ops note',
+        body: 'ops content',
+        author: 'keeper',
+        hearth: 'ops',
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+    fireEvent.click(screen.getByRole('button', { name: 'hearth ops 2 posts' }))
+
+    expect(boardHearthFilter.value).toBe('ops')
+    expect(screen.getByRole('button', { name: 'hearth ops 2 posts' })).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -1,6 +1,6 @@
 import { h } from 'preact'
 import { fireEvent, render, screen } from '@testing-library/preact'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
 import { route } from '../../router'
@@ -125,6 +125,13 @@ describe('contentCategory', () => {
 
 // ── Board component rendering tests ───────────────────────────────
 describe('BoardSurface Component', () => {
+  // PR #13152 review: vi.stubGlobal('fetch') in beforeEach without a matching
+  // unstub leaks the mocked fetch into later tests in the same worker.  Add
+  // an explicit afterEach that restores all stubbed globals.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -14,6 +14,7 @@ import { RichComposer } from '../common/rich-composer'
 import { RichContent } from '../common/rich-content'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
+import { registerBoardHearthsRefresh } from '../../sse-store'
 import { PostDetail } from './post-detail'
 import {
   boardActorAvatarKey,
@@ -598,6 +599,9 @@ function PostCard({ post }: { post: BoardPost }) {
 // ── Main Board component (public API) ──────────────────────────────
 export function BoardSurface() {
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
+  useEffect(() => registerBoardHearthsRefresh(() => {
+    void refreshBoardHearths()
+  }), [])
   useEffect(() => {
     if (boardHearths.value.length === 0) void refreshBoardHearths()
   }, [])

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -280,13 +280,34 @@ function HearthFilterBar() {
   const hearths = boardHearths.value
   const active = boardHearthFilter.value
   const activeInList = active !== '' && hearths.some(hearth => hearth.name === active)
-  if (hearths.length === 0 && active === '' && !boardHearthsLoading.value) return null
 
   const chipClass = (selected: boolean) => `px-2.5 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer ${
     selected
       ? 'bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] border-[var(--accent-20)]'
       : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
   }`
+
+  // PR #13152 review (P2): when initial refreshBoardHearths() fails the
+  // list ends up empty + not loading, and the original early-return hid
+  // the entire bar — including the refresh button — leaving users with no
+  // in-UI retry path.  Render a minimal bar (refresh button only) in that
+  // state so the manual retry stays reachable.
+  if (hearths.length === 0 && active === '' && !boardHearthsLoading.value) {
+    return html`
+      <div class="flex items-center gap-1.5 flex-wrap">
+        <span class="text-2xs text-[var(--color-fg-muted)]" aria-hidden="true">hearth 목록을 불러오지 못했습니다</span>
+        <button
+          type="button"
+          class="px-2 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-transparent hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] disabled:opacity-50"
+          aria-label="hearth 목록 새로고침"
+          disabled=${boardHearthsLoading.value}
+          onClick=${() => { void refreshBoardHearths() }}
+        >
+          <${RefreshCw} size=${12} class=${boardHearthsLoading.value ? 'animate-spin' : ''} aria-hidden="true" />
+        </button>
+      </div>
+    `
+  }
 
   return html`
     <div class="flex items-center gap-1.5 flex-wrap">

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -47,6 +47,7 @@ import {
   showNewPostForm,
   newPostTitle,
   newPostContent,
+  newPostHearth,
   newPostSubmitting,
   PAGE_SIZE,
   categoryVisibleLimits,
@@ -205,7 +206,10 @@ function NewPostForm() {
     return html`
       <button type="button"
         class="w-full py-2.5 rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] text-sm text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-primary)] transition-colors bg-transparent"
-        onClick=${() => { showNewPostForm.value = true }}
+        onClick=${() => {
+          newPostHearth.value = boardHearthFilter.value
+          showNewPostForm.value = true
+        }}
       >+ 새 글 작성</button>
     `
   }
@@ -228,10 +232,23 @@ function NewPostForm() {
         helpText="예: ts 코드펜스, 일반 URL 링크 카드, 단독 이미지 URL 자동 인라인"
         previewLimit=${2}
       />
+      <${TextInput}
+        name="board_post_hearth"
+        ariaLabel="새 글 hearth"
+        autoComplete="off"
+        placeholder="hearth (예: ops, research)"
+        value=${newPostHearth.value}
+        onInput=${(e: Event) => { newPostHearth.value = (e.target as HTMLInputElement).value }}
+      />
       <div class="flex gap-2 justify-end">
         <button type="button"
           class="px-3 py-1.5 rounded-[var(--r-1)] text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-hover)]"
-          onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
+          onClick=${() => {
+            showNewPostForm.value = false
+            newPostTitle.value = ''
+            newPostContent.value = ''
+            newPostHearth.value = ''
+          }}
         >취소</button>
         <button type="button"
           class="px-4 py-1.5 rounded-[var(--r-1)] text-sm font-medium border border-[var(--info-border)] bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
+import { RefreshCw } from 'lucide-preact'
 import { ActionButton } from '../common/button'
 import { Card } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
@@ -28,6 +29,9 @@ import {
   boardSortMode,
   boardHiddenCategories,
   boardAuthorFilter,
+  boardHearthFilter,
+  boardHearths,
+  boardHearthsLoading,
   boardExcludeAutomation,
   boardLoading,
   boardLoadingMore,
@@ -67,6 +71,7 @@ import {
   visibilityBadgeColor,
   votePost,
   deleteBoardPost,
+  refreshBoardHearths,
 } from './board-state'
 import type { BoardPost, ContentCategory } from './board-state'
 
@@ -238,6 +243,75 @@ function NewPostForm() {
   `
 }
 
+function setBoardHearthFilter(nextHearth: string) {
+  if (boardHearthFilter.value === nextHearth) return
+  boardHearthFilter.value = nextHearth
+  visibleLimit.value = PAGE_SIZE
+  automationVisibleLimit.value = PAGE_SIZE
+  systemVisibleLimit.value = PAGE_SIZE
+  categoryVisibleLimits.value = {
+    article: PAGE_SIZE,
+    review: PAGE_SIZE,
+    notice: PAGE_SIZE,
+    system: PAGE_SIZE,
+  }
+  refreshBoard()
+}
+
+function HearthFilterBar() {
+  const hearths = boardHearths.value
+  const active = boardHearthFilter.value
+  const activeInList = active !== '' && hearths.some(hearth => hearth.name === active)
+  if (hearths.length === 0 && active === '' && !boardHearthsLoading.value) return null
+
+  const chipClass = (selected: boolean) => `px-2.5 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer ${
+    selected
+      ? 'bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] border-[var(--accent-20)]'
+      : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
+  }`
+
+  return html`
+    <div class="flex items-center gap-1.5 flex-wrap">
+      <span class="text-2xs font-semibold text-[var(--color-fg-muted)]" aria-hidden="true">#</span>
+      <button
+        type="button"
+        class=${chipClass(active === '')}
+        aria-pressed=${active === ''}
+        aria-label="전체 hearth"
+        onClick=${() => setBoardHearthFilter('')}
+      >전체</button>
+      ${hearths.map(hearth => html`
+        <button
+          key=${hearth.name}
+          type="button"
+          class=${chipClass(active === hearth.name)}
+          aria-pressed=${active === hearth.name}
+          aria-label=${`hearth ${hearth.name} ${hearth.count} posts`}
+          onClick=${() => setBoardHearthFilter(hearth.name)}
+        >${hearth.name} <span class="tabular-nums opacity-70">${hearth.count}</span></button>
+      `)}
+      ${active !== '' && !activeInList ? html`
+        <button
+          type="button"
+          class=${chipClass(true)}
+          aria-pressed="true"
+          aria-label=${`hearth ${active}`}
+          onClick=${() => setBoardHearthFilter(active)}
+        >${active}</button>
+      ` : null}
+      <button
+        type="button"
+        class="px-2 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-transparent hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] disabled:opacity-50"
+        aria-label="hearth 목록 새로고침"
+        disabled=${boardHearthsLoading.value}
+        onClick=${() => { void refreshBoardHearths() }}
+      >
+        <${RefreshCw} size=${12} class=${boardHearthsLoading.value ? 'animate-spin' : ''} aria-hidden="true" />
+      </button>
+    </div>
+  `
+}
+
 // ── Sort bar ───────────────────────────────────────────────────────
 function SortBar() {
   const current = boardSortMode.value
@@ -264,6 +338,7 @@ function SortBar() {
           </button>
         `)}
       </div>
+      <${HearthFilterBar} />
       <div class="flex items-center gap-2 flex-wrap">
         ${grouped.groups.map(g => {
           const meta = CONTENT_CATEGORIES.find(c => c.id === g.category)
@@ -506,6 +581,9 @@ function PostCard({ post }: { post: BoardPost }) {
 // ── Main Board component (public API) ──────────────────────────────
 export function BoardSurface() {
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
+  useEffect(() => {
+    if (boardHearths.value.length === 0) void refreshBoardHearths()
+  }, [])
   const [contentQuery, setContentQuery] = useState('')
   const rawPosts = boardPosts.value
   const filteredPosts = useMemo(

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -56,7 +56,13 @@ vi.mock('./board-state', () => ({
   refreshBoard: vi.fn(),
 }))
 
-import { CommentThread, PostDetail, countCommentDescendants, filterCommentTree } from './post-detail'
+import {
+  CommentThread,
+  PostDetail,
+  buildCommentDescendantCounts,
+  countCommentDescendants,
+  filterCommentTree,
+} from './post-detail'
 import { voteComment } from './board-state'
 import type { BoardComment } from '../../types/core'
 
@@ -128,6 +134,28 @@ describe('CommentThread', () => {
     expect(screen.getByText('level 6 hidden')).toBeInTheDocument()
   })
 
+  it('surfaces deep matching replies while the comment filter is active', () => {
+    const comments = [
+      { id: 'c1', post_id: 'post-1', parent_id: null, author: 'agent', content: 'level 0', created_at: '2026-04-02T00:00:00Z' },
+      { id: 'c2', post_id: 'post-1', parent_id: 'c1', author: 'agent', content: 'level 1', created_at: '2026-04-02T00:01:00Z' },
+      { id: 'c3', post_id: 'post-1', parent_id: 'c2', author: 'agent', content: 'level 2', created_at: '2026-04-02T00:02:00Z' },
+      { id: 'c4', post_id: 'post-1', parent_id: 'c3', author: 'agent', content: 'level 3', created_at: '2026-04-02T00:03:00Z' },
+      { id: 'c5', post_id: 'post-1', parent_id: 'c4', author: 'agent', content: 'level 4', created_at: '2026-04-02T00:04:00Z' },
+      { id: 'c6', post_id: 'post-1', parent_id: 'c5', author: 'agent', content: 'level 5', created_at: '2026-04-02T00:05:00Z' },
+      { id: 'c7', post_id: 'post-1', parent_id: 'c6', author: 'agent', content: 'needle at level 6', created_at: '2026-04-02T00:06:00Z' },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    expect(screen.queryByText('needle at level 6')).not.toBeInTheDocument()
+    fireEvent.input(screen.getByPlaceholderText('댓글 내용 검색'), {
+      target: { value: 'needle' },
+    })
+
+    expect(screen.getByText('needle at level 6')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /스레드 계속 펼치기/ })).not.toBeInTheDocument()
+  })
+
   it('sends comment votes through the board comment vote tool', async () => {
     const comments = [
       {
@@ -188,6 +216,15 @@ describe('filterCommentTree', () => {
     expect(countCommentDescendants('r1', childrenMap)).toBe(2)
     expect(countCommentDescendants('r2', childrenMap)).toBe(1)
     expect(countCommentDescendants('missing', childrenMap)).toBe(0)
+  })
+
+  it('precomputes descendant counts for O(1) render lookups', () => {
+    const counts = buildCommentDescendantCounts(childrenMap)
+    expect(counts.get('r1')).toBe(2)
+    expect(counts.get('c11')).toBe(1)
+    expect(counts.get('c111')).toBe(0)
+    expect(counts.get('r2')).toBe(1)
+    expect(counts.get('c21')).toBe(0)
   })
 
   it('returns original references on empty query (ref-equal)', () => {

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -82,6 +82,32 @@ export function countCommentDescendants(
   )
 }
 
+export function buildCommentDescendantCounts(
+  childrenMap: ReadonlyMap<string, readonly BoardComment[]>,
+): ReadonlyMap<string, number> {
+  const counts = new Map<string, number>()
+  const visiting = new Set<string>()
+
+  const countFor = (commentId: string): number => {
+    const cached = counts.get(commentId)
+    if (cached !== undefined) return cached
+    if (visiting.has(commentId)) return 0
+
+    visiting.add(commentId)
+    const children = childrenMap.get(commentId) ?? []
+    const total = children.reduce((sum, child) => sum + 1 + countFor(child.id), 0)
+    visiting.delete(commentId)
+    counts.set(commentId, total)
+    return total
+  }
+
+  for (const [commentId, children] of childrenMap) {
+    countFor(commentId)
+    for (const child of children) countFor(child.id)
+  }
+  return counts
+}
+
 /**
  * Pure tree-aware text filter on a comment forest.
  *
@@ -139,12 +165,14 @@ function CommentItem({
   postId,
   depth = 0,
   childrenMap,
+  descendantCounts,
   forceThreadExpanded = false,
 }: {
   comment: BoardComment
   postId: string
   depth?: number
   childrenMap: ReadonlyMap<string, readonly BoardComment[]>
+  descendantCounts: ReadonlyMap<string, number>
   forceThreadExpanded?: boolean
 }) {
   const contentChars = Array.from(comment.content ?? '')
@@ -159,7 +187,7 @@ function CommentItem({
   const visualDepth = Math.min(depth, MAX_INLINE_COMMENT_DEPTH)
   const indentStyle = visualDepth > 0 ? { marginLeft: `${visualDepth * 16}px` } : undefined
   const replies = childrenMap.get(comment.id) ?? []
-  const replyCount = countCommentDescendants(comment.id, childrenMap)
+  const replyCount = descendantCounts.get(comment.id) ?? 0
   const cappedByDepth = !forceThreadExpanded && !deepExpanded && depth >= MAX_INLINE_COMMENT_DEPTH && replies.length > 0
   const showReplies = replies.length > 0 && !collapsed && !cappedByDepth
   const childForceExpanded = forceThreadExpanded || deepExpanded
@@ -264,7 +292,7 @@ function CommentItem({
       </div>
       ${showReplies ? html`
         <div class="flex flex-col gap-1.5 mt-1.5">
-          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} forceThreadExpanded=${childForceExpanded} />`)}
+          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${childForceExpanded} />`)}
         </div>
       ` : null}
     </div>
@@ -281,6 +309,10 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
   const { roots: filteredRoots, childrenMap: filteredChildrenMap } = useMemo(
     () => filterCommentTree(roots, childrenMap, query.value),
     [roots, childrenMap, query.value],
+  )
+  const descendantCounts = useMemo(
+    () => buildCommentDescendantCounts(filteredChildrenMap),
+    [filteredChildrenMap],
   )
 
   if (comments.length === 0) return html`<${EmptyState} message="아직 댓글이 없습니다" compact />`
@@ -315,7 +347,7 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
           onClick=${() => setExpanded(true)}
         >이전 댓글 ${hiddenCount}개 더 보기<//>
       ` : null}
-      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} />`)}
+      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${isFiltering} />`)}
       ${expanded && hiddenCount > 0 ? html`
         <${ActionButton}
           variant="subtle"

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -1,6 +1,6 @@
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RouteState } from './types'
+import type { BoardPost, BoardSortMode, RouteState } from './types'
 
 void vi
 
@@ -11,8 +11,12 @@ type CurrentRoute = typeof route.value
 
 const keeperHeartbeats = signal(new Map<string, number>())
 const serverStatus = signal<unknown>(null)
-const boardPosts = signal<Array<{ id: string }>>([])
-const boardSortMode = signal<'recent'>('recent')
+const boardPosts = signal<BoardPost[]>([])
+const boardSortMode = signal<BoardSortMode>('recent')
+const boardExcludeSystem = signal(true)
+const boardExcludeAutomation = signal(false)
+const boardAuthorFilter = signal('')
+const boardHearthFilter = signal('')
 const boardOffset = signal(0)
 const namespaceTruth = signal<unknown>(null)
 const namespaceTruthError = signal<unknown>(null)
@@ -56,6 +60,10 @@ async function loadSseStore() {
     serverStatus,
     boardPosts,
     boardSortMode,
+    boardExcludeSystem,
+    boardExcludeAutomation,
+    boardAuthorFilter,
+    boardHearthFilter,
     boardOffset,
     removeBoardPost,
   }))
@@ -111,6 +119,11 @@ describe('setupSSEReaction reconnect hydration', () => {
     namespaceTruth.value = null
     namespaceTruthError.value = null
     boardPosts.value = []
+    boardSortMode.value = 'recent'
+    boardExcludeSystem.value = true
+    boardExcludeAutomation.value = false
+    boardAuthorFilter.value = ''
+    boardHearthFilter.value = ''
     boardOffset.value = 0
     keeperHeartbeats.value = new Map()
     serverStatus.value = null
@@ -251,6 +264,50 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps optimistic post_created hydration inside the active hearth filter', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+    boardHearthFilter.value = 'ops'
+
+    sseStore.routeServerPushEvent({
+      type: 'post_created',
+      post_id: 'post-1',
+      title: 'Research note',
+      content: 'body',
+      author: 'agent-a',
+      hearth: 'research',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(boardPosts.value).toEqual([])
+    expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes hearth chips when an optimistic board post carries a hearth', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshHearths = vi.fn()
+    sseStore.registerBoardHearthsRefresh(refreshHearths)
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+    boardHearthFilter.value = 'ops'
+
+    sseStore.routeServerPushEvent({
+      type: 'post_created',
+      post_id: 'post-1',
+      title: 'Ops note',
+      content: 'body',
+      author: 'agent-a',
+      hearth: 'ops',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(boardPosts.value[0]?.id).toBe('post-1')
+    expect(boardPosts.value[0]?.hearth).toBe('ops')
+    expect(refreshBoard).not.toHaveBeenCalled()
+    expect(refreshHearths).toHaveBeenCalledTimes(1)
   })
 
   it('keeps websocket raw push refreshes hidden when the route does not need that surface', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -34,6 +34,10 @@ import {
   serverStatus,
   boardPosts,
   boardSortMode,
+  boardExcludeSystem,
+  boardExcludeAutomation,
+  boardAuthorFilter,
+  boardHearthFilter,
   boardOffset,
 } from './store'
 import {
@@ -89,6 +93,14 @@ export function registerActivityRefresh(fn: () => void): () => void {
   _refreshActivityFns.add(fn)
   return () => {
     _refreshActivityFns.delete(fn)
+  }
+}
+
+let _refreshBoardHearthsFn: (() => void) | null = null
+export function registerBoardHearthsRefresh(fn: () => void): () => void {
+  _refreshBoardHearthsFn = fn
+  return () => {
+    if (_refreshBoardHearthsFn === fn) _refreshBoardHearthsFn = null
   }
 }
 
@@ -151,7 +163,10 @@ const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
 
 const REFRESH_FNS: Record<RefreshTarget, () => void> = {
   execution: () => { void refreshExecution() },
-  board:     refreshBoard,
+  board:     () => {
+    void refreshBoard()
+    _refreshBoardHearthsFn?.()
+  },
   operator:  () => _refreshOperatorFn?.(),
   activity:  () => {
     for (const fn of _refreshActivityFns) fn()
@@ -165,6 +180,14 @@ function scheduleTargetRefresh(
 ): void {
   if (!routeWantsRefreshTarget(route.value, target)) return
   scheduleRefresh(target, fn, delayMs)
+}
+
+function scheduleBoardHearthsRefresh(delayMs = SSE_DEFAULT_DEBOUNCE_MS): void {
+  if (!_refreshBoardHearthsFn) return
+  if (!routeWantsRefreshTarget(route.value, 'board')) return
+  scheduleRefresh('board-hearths', () => {
+    _refreshBoardHearthsFn?.()
+  }, delayMs)
 }
 
 // --- Named handlers for complex events ---
@@ -362,6 +385,9 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
   const content = event.content as string | undefined
   if (!postId || !content) return false
   if (boardPosts.value.some(p => p.id === postId)) return false
+  const eventHearth = event.hearth?.trim() ?? ''
+  if (eventHearth) scheduleBoardHearthsRefresh()
+  if (!eventMatchesActiveBoardFilters(event)) return false
 
   const now = new Date().toISOString()
   const post: BoardPost = {
@@ -377,10 +403,25 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
     votes: 0,
     vote_balance: 0,
     comment_count: 0,
-    hearth: event.hearth ?? undefined,
+    hearth: eventHearth || undefined,
   }
   boardPosts.value = [post, ...boardPosts.value]
   boardOffset.value = boardPosts.value.length
+  return true
+}
+
+function eventMatchesActiveBoardFilters(event: SSEEvent): boolean {
+  const hearthFilter = boardHearthFilter.value.trim()
+  if (hearthFilter !== '' && (event.hearth?.trim() ?? '') !== hearthFilter) return false
+
+  // Author filtering is server-defined today, so a filtered view should be
+  // reconciled through the board endpoint instead of guessing client-side.
+  if (boardAuthorFilter.value.trim() !== '') return false
+
+  const rawKind = (event.post_kind ?? 'direct').toLowerCase()
+  const postKind = rawKind === 'system' || rawKind === 'automation' ? rawKind : 'direct'
+  if (postKind === 'system' && boardExcludeSystem.value) return false
+  if (postKind === 'automation' && boardExcludeAutomation.value) return false
   return true
 }
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -125,6 +125,7 @@ export const boardExcludeAutomation = signal(false)
 /** Content-category filter: which categories to hide */
 export const boardHiddenCategories = signal<Set<string>>(new Set(['system']))
 export const boardAuthorFilter = signal('')
+export const boardHearthFilter = signal('')
 /** Number of posts currently loaded — the offset for the next page request. */
 export const boardOffset = signal<number>(0)
 /** true when the server indicates (or we optimistically believe) more posts are available. */
@@ -868,6 +869,7 @@ function boardPageSize(): number {
     boardExcludeAutomation.value
     || boardExcludeSystem.value
     || boardAuthorFilter.value.trim() !== ''
+    || boardHearthFilter.value.trim() !== ''
   return hasFilter ? BOARD_PAGE_SIZE_FILTERED : BOARD_PAGE_SIZE_DEFAULT
 }
 
@@ -880,6 +882,7 @@ export async function refreshBoard(): Promise<void> {
       excludeSystem: boardExcludeSystem.value,
       excludeAutomation: boardExcludeAutomation.value,
       author: boardAuthorFilter.value || undefined,
+      hearth: boardHearthFilter.value || undefined,
       limit,
       offset: 0,
     })
@@ -926,6 +929,7 @@ export async function loadMoreBoardPosts(): Promise<void> {
       excludeSystem: boardExcludeSystem.value,
       excludeAutomation: boardExcludeAutomation.value,
       author: boardAuthorFilter.value || undefined,
+      hearth: boardHearthFilter.value || undefined,
       limit,
       offset,
     })

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -1,4 +1,4 @@
-import type { BoardActorIdentity } from './core'
+import type { BoardActorIdentity, BoardPost } from './core'
 
 // --- SSE Events ---
 
@@ -141,6 +141,7 @@ export interface SSEEvent {
   voter?: string
   voter_identity?: BoardActorIdentity | null
   direction?: 'up' | 'down' | string
+  post_kind?: BoardPost['post_kind'] | string
   hearth?: string
   agent_name?: string
   keeper_name?: string


### PR DESCRIPTION
Stacked on #13147, which is stacked on #13142.

Summary:
- Add dashboard API support for the existing backend hearth filter and /api/v1/board/hearths list endpoint.
- Track the selected Board hearth in the shared board store so refresh/load-more requests stay server-filtered.
- Add compact hearth chips to the Board filter bar with a refresh control and selected-state handling.

Validation:
- pnpm exec vitest run src/components/board/board-surface.test.ts src/components/board/board-state.test.ts src/components/board/post-detail.test.ts src/api/board.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec eslint src/api/board.ts src/api/board.test.ts src/api/dashboard.ts src/components/board/board-state.ts src/components/board/board-surface.ts src/components/board/board-surface.test.ts src/store.ts
- git diff --cached --check

Note:
- ESLint exited 0; repo config reports several touched non-component files as ignored by configuration.