### PR TITLE
fix(keeper): scope claimable backlog signals

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -246,6 +246,37 @@ let backlog_updated_since_last_scheduled_autonomous
     | Some updated_at -> updated_at > last_ts
     | None -> false
 
+let goal_title_matches_keeper_purpose ~(meta : keeper_meta) goal =
+  String.equal goal.Goal_store.title
+    (Keeper_goal_repair.goal_title_of_purpose meta.goal)
+
+let active_goal_ids_are_auto_keeper_goals config ~(meta : keeper_meta) goal_ids =
+  goal_ids <> []
+  && List.for_all
+       (fun goal_id ->
+         match Goal_store.get_goal config ~goal_id with
+         | Some goal -> goal_title_matches_keeper_purpose ~meta goal
+         | None -> false)
+       goal_ids
+
+let active_goal_ids_have_claim_pool_task config goal_ids =
+  Coord.get_tasks_safe config
+  |> List.exists (fun task ->
+       Coord_task_schedule.task_is_claim_pool_candidate task
+       && Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task)
+
+let claim_goal_scope_filter ~(config : Coord.config) ~(meta : keeper_meta) =
+  match meta.active_goal_ids with
+  | [] -> fun (_task : Masc_domain.task) -> true
+  | goal_ids ->
+      let scoped_filter task =
+        Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task
+      in
+      if active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
+         && not (active_goal_ids_have_claim_pool_task config goal_ids)
+      then fun (_task : Masc_domain.task) -> true
+      else scoped_filter
+
 (** Read room backlog counts. *)
 let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
     ~(meta : keeper_meta) :
@@ -258,6 +289,7 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
         backlog.tasks
     in
     let unclaimed = List.length unclaimed_tasks in
+    let claim_scope_filter = claim_goal_scope_filter ~config ~meta in
     let required_tools_allowed required_tools =
       match allowed_tool_names with
       | Some names ->
@@ -271,6 +303,7 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
         (List.filter
            (fun task ->
              Coord_task_schedule.task_is_claim_pool_candidate task
+             && claim_scope_filter task
              && required_tools_allowed
                   (Coord_task_schedule.task_required_tools task))
            unclaimed_tasks)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9,6 +9,7 @@ module EC = Masc_mcp.Keeper_error_classify
 module UM = Masc_mcp.Keeper_unified_metrics
 module KR = Masc_mcp.Keeper_registry
 module KAR = Masc_mcp.Keeper_agent_run
+module KCC = Masc_mcp.Keeper_contract_classifier
 module KTCL = Masc_mcp.Keeper_tool_call_log
 module KTD = Masc_mcp.Keeper_tool_disclosure
 module KEC = Masc_mcp.Keeper_exec_context
@@ -410,6 +411,77 @@ let test_observe_splits_absolute_and_claimable_backlog () =
       in
       check int "absolute todo backlog" 2 obs.unclaimed_task_count;
       check int "matched claimable backlog" 1 obs.claimable_task_count)
+
+let test_observe_claimable_backlog_respects_active_goal_ids () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      let goal, _ =
+        match Masc_mcp.Goal_store.upsert_goal config ~title:"Scoped goal" () with
+        | Ok payload -> payload
+        | Error msg -> fail msg
+      in
+      let other_goal, _ =
+        match Masc_mcp.Goal_store.upsert_goal config ~title:"Other goal" () with
+        | Ok payload -> payload
+        | Error msg -> fail msg
+      in
+      ignore
+        (Masc_mcp.Coord.add_task ~goal_id:other_goal.id config
+           ~title:"Out-of-scope task" ~priority:1 ~description:"desc");
+      let meta = { minimal_meta with active_goal_ids = [ goal.id ] } in
+      let obs =
+        WO.observe ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+          ~pending_board_events:(Some []) ~config ~meta
+      in
+      check int "absolute todo backlog" 1 obs.unclaimed_task_count;
+      check int "scoped claimable backlog" 0 obs.claimable_task_count;
+      let signal =
+        obs
+        |> KCC.of_keeper_world_observation
+        |> KCC.classify_actionable_signal_for_tools
+             ~allowed_tool_names:[ "keeper_task_claim" ]
+      in
+      check bool "out-of-scope backlog is not actionable" false
+        (KCC.is_actionable signal))
+
+let test_observe_claimable_backlog_uses_auto_goal_fallback_scope () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      let auto_goal, _ =
+        match
+          Masc_mcp.Goal_store.upsert_goal config
+            ~title:
+              (Masc_mcp.Keeper_goal_repair.goal_title_of_purpose
+                 minimal_meta.goal)
+            ()
+        with
+        | Ok payload -> payload
+        | Error msg -> fail msg
+      in
+      let product_goal, _ =
+        match Masc_mcp.Goal_store.upsert_goal config ~title:"Product goal" () with
+        | Ok payload -> payload
+        | Error msg -> fail msg
+      in
+      ignore
+        (Masc_mcp.Coord.add_task ~goal_id:product_goal.id config
+           ~title:"Fallback task" ~priority:1 ~description:"desc");
+      let meta = { minimal_meta with active_goal_ids = [ auto_goal.id ] } in
+      let obs =
+        WO.observe ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+          ~pending_board_events:(Some []) ~config ~meta
+      in
+      check int "absolute todo backlog" 1 obs.unclaimed_task_count;
+      check int "auto-goal fallback claimable backlog" 1
+        obs.claimable_task_count)
 
 let test_durable_signal_present_sees_claimable_backlog_for_smart_hb_gate () =
   let base_dir = temp_dir () in
@@ -6962,6 +7034,10 @@ let () =
             test_board_signal_stimulus_becomes_pending_board_event;
           test_case "splits absolute and claimable backlog" `Quick
             test_observe_splits_absolute_and_claimable_backlog;
+          test_case "claimable backlog respects active goals" `Quick
+            test_observe_claimable_backlog_respects_active_goal_ids;
+          test_case "claimable backlog mirrors auto-goal fallback" `Quick
+            test_observe_claimable_backlog_uses_auto_goal_fallback_scope;
           test_case "durable signal sees claimable backlog" `Quick
             test_durable_signal_present_sees_claimable_backlog_for_smart_hb_gate;
           test_case "durable signal filters unclaimable backlog" `Quick


### PR DESCRIPTION
## Summary

- Scope keeper world-observation `claimable_task_count` with the same `active_goal_ids` filter used by `keeper_task_claim`.
- Preserve the existing auto keeper-goal fallback: when the keeper's auto goal has no linked claim-pool tasks, claimability falls back to all claimable tasks.
- Add regression coverage for out-of-scope backlog not producing a task-claim actionable signal.

## Product impact

Live keepers were still doing useful board/task work, but Janitor hit `require_tool_use` violations with `signal=has_unclaimed_tasks` while `keeper_task_claim` reported no eligible tasks for its active goals. This made autonomy look actionable to the contract gate even when the keeper had no scoped task it could legally claim.

After this change, the observation signal and the claim tool agree on goal scope, so out-of-scope backlog does not force a keeper into a false task-claim contract failure.

## Evidence

- Live runtime on `http://127.0.0.1:8935/health` confirmed base path `/Users/dancer/me`, effective root `/Users/dancer/me/.masc`, and keeper fibers alive.
- Live tmux log showed `required tool contract violated ... signal=has_unclaimed_tasks` alongside scoped claim failures.
- `git diff --check` passed.
- `scripts/dune-local.sh build test/test_keeper_unified.exe` reached compilation and exposed one test API mistake, now fixed.
- Focused Dune validation remains blocked by unrelated current-main interface drift: `Env_config_keeper.KeeperRetryBackoff.degraded_retry_slot_phase_budget_sec` is defined in `lib/config/env_config_keeper.ml` but missing from `lib/config/env_config_keeper.mli`; reruns also timed out behind `/tmp/me-dune-local.lock`.

## Review evidence

- New tests cover a keeper with `active_goal_ids` whose only unclaimed task is under another goal; `claimable_task_count` is zero and the contract classifier is not actionable for `keeper_task_claim`.
- New tests cover the auto keeper-goal fallback path so keepers with only their generated auto goal still see claimable product backlog when no linked auto-goal tasks exist.

## Linked issue

None.
