### PR TITLE
feat(dashboard): assign board posts to hearths

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   derivePostTitle,
+  createPost,
   fetchBoard,
   fetchBoardHearths,
   fetchBoardPost,
@@ -553,6 +554,30 @@ describe('fetchBoardPost', () => {
       vote_balance: 3,
       votes_up: 5,
       votes_down: 2,
+    })
+  })
+})
+
+describe('createPost', () => {
+  it('passes hearth assignment through to the board post tool', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createPost('Plan', 'Body', 'dashboard-user', { hearth: ' ops ' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/tools/masc_board_post')
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      title: 'Plan',
+      content: 'Body',
+      author: 'dashboard-user',
+      hearth: 'ops',
     })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -511,12 +511,20 @@ export function voteComment(commentId: string, direction: 'up' | 'down'): Promis
   })
 }
 
-export function createPost(title: string, content: string, author: string): Promise<unknown> {
-  return post(`/api/v1/tools/masc_board_post`, {
+export function createPost(
+  title: string,
+  content: string,
+  author: string,
+  options: { hearth?: string } = {},
+): Promise<unknown> {
+  const body: Record<string, string> = {
     title,
     content,
     author,
-  })
+  }
+  const hearth = options.hearth?.trim()
+  if (hearth) body.hearth = hearth
+  return post(`/api/v1/tools/masc_board_post`, body)
 }
 
 export function commentPost(postId: string, author: string, content: string, parentId?: string): Promise<unknown> {

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -81,6 +81,7 @@ export const replyingTo = signal<string | null>(null)
 export const showNewPostForm = signal(false)
 export const newPostTitle = signal('')
 export const newPostContent = signal('')
+export const newPostHearth = signal('')
 export const newPostSubmitting = signal(false)
 
 // ── Pagination ─────────────────────────────────────────────────────
@@ -364,15 +365,18 @@ export async function submitComment(postId: string, parentId?: string) {
 export async function submitNewPost() {
   const title = newPostTitle.value.trim()
   const content = newPostContent.value.trim()
+  const hearth = newPostHearth.value.trim() || boardHearthFilter.value.trim()
   if (!title || !content) return
   newPostSubmitting.value = true
   try {
-    await createPost(title, content, commentAuthor.value)
+    await createPost(title, content, commentAuthor.value, { hearth: hearth || undefined })
     newPostTitle.value = ''
     newPostContent.value = ''
+    newPostHearth.value = ''
     showNewPostForm.value = false
     showToast('글을 등록했습니다', 'success')
     refreshBoard()
+    void refreshBoardHearths()
   } catch (err) {
     console.warn('[board] post submit failed', err instanceof Error ? err.message : err)
     showToast('글 등록에 실패했습니다', 'error')

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
 import { route } from '../../router'
-import { boardHearths, contentCategory } from './board-state'
+import { boardHearths, contentCategory, newPostHearth } from './board-state'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -142,6 +142,7 @@ describe('BoardSurface Component', () => {
     boardAuthorFilter.value = ''
     boardHearthFilter.value = ''
     boardHearths.value = [{ name: 'ops', count: 0 }]
+    newPostHearth.value = ''
     route.value = { params: {} } as any
   })
 
@@ -200,5 +201,15 @@ describe('BoardSurface Component', () => {
 
     expect(boardHearthFilter.value).toBe('ops')
     expect(screen.getByRole('button', { name: 'hearth ops 2 posts' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('prefills the compose hearth from the active hearth filter', () => {
+    boardHearthFilter.value = 'ops'
+
+    render(h(BoardSurface, null))
+    fireEvent.click(screen.getByRole('button', { name: '+ 새 글 작성' }))
+
+    expect(screen.getByLabelText('새 글 hearth')).toHaveValue('ops')
+    expect(newPostHearth.value).toBe('ops')
   })
 })

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -47,6 +47,7 @@ import {
   showNewPostForm,
   newPostTitle,
   newPostContent,
+  newPostHearth,
   newPostSubmitting,
   PAGE_SIZE,
   categoryVisibleLimits,
@@ -205,7 +206,10 @@ function NewPostForm() {
     return html`
       <button type="button"
         class="w-full py-2.5 rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] text-sm text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-primary)] transition-colors bg-transparent"
-        onClick=${() => { showNewPostForm.value = true }}
+        onClick=${() => {
+          newPostHearth.value = boardHearthFilter.value
+          showNewPostForm.value = true
+        }}
       >+ 새 글 작성</button>
     `
   }
@@ -228,10 +232,23 @@ function NewPostForm() {
         helpText="예: ts 코드펜스, 일반 URL 링크 카드, 단독 이미지 URL 자동 인라인"
         previewLimit=${2}
       />
+      <${TextInput}
+        name="board_post_hearth"
+        ariaLabel="새 글 hearth"
+        autoComplete="off"
+        placeholder="hearth (예: ops, research)"
+        value=${newPostHearth.value}
+        onInput=${(e: Event) => { newPostHearth.value = (e.target as HTMLInputElement).value }}
+      />
       <div class="flex gap-2 justify-end">
         <button type="button"
           class="px-3 py-1.5 rounded-[var(--r-1)] text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-hover)]"
-          onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
+          onClick=${() => {
+            showNewPostForm.value = false
+            newPostTitle.value = ''
+            newPostContent.value = ''
+            newPostHearth.value = ''
+          }}
         >취소</button>
         <button type="button"
           class="px-4 py-1.5 rounded-[var(--r-1)] text-sm font-medium border border-[var(--info-border)] bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"


### PR DESCRIPTION
Stacked on #13152, which is stacked on #13147 and #13142.

Summary:
- Extend dashboard createPost to pass an optional hearth through to the existing masc_board_post backend field.
- Add a hearth field to the Board composer and prefill it from the active hearth filter.
- Clear compose hearth state after submit/cancel and refresh active hearth chips after posting.

Validation:
- pnpm exec vitest run src/components/board/board-surface.test.ts src/components/board/board-state.test.ts src/components/board/post-detail.test.ts src/api/board.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec eslint src/api/board.ts src/api/board.test.ts src/components/board/board-state.ts src/components/board/board-surface.ts src/components/board/board-surface.test.ts
- git diff --check

Note:
- ESLint exited 0; dashboard eslint config ignores API files outside its scoped match set.