### PR TITLE
feat(cascade): RFC-0027 PR-9c — per-secondary metric label for dual_track_swap

### DIFF
--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -260,6 +260,22 @@ let attempt_secondary_swap
   match secondary_resolver provider_index primary with
   | None -> Either.Right (primary, primary_reason)
   | Some secondary -> (
+      (* RFC-0027 PR-9c: per-secondary accounting label.
+         The secondary's [provider_kind] is a closed enum from
+         [Llm_provider.Provider_config.string_of_provider_kind] so
+         label cardinality stays bounded (≤ kind count). This lets
+         dashboards split [dual_track_swap] swap volume by which
+         backend the cascade is actually leaning on (CLI vs Direct
+         API), without inflating the [detail] axis. The lookup of
+         the matching [Keeper_provider_token_bucket] for the
+         secondary continues to flow through the keeper admission
+         router, which is provider-name keyed and lazy-creates a
+         distinct bucket per concrete provider — so accounting
+         already separates primary and secondary draws as a
+         consequence of [provider_kind] differing. *)
+      let secondary_kind_label =
+        Llm_provider.Provider_config.string_of_provider_kind secondary.kind
+      in
       match
         classify_filter_rejection
           ~keeper_name ?runtime_mcp_policy ~tools
@@ -268,17 +284,23 @@ let attempt_secondary_swap
       with
       | None ->
           Llm_metric_bridge.emit_fallback_triggered
-            ~kind:"dual_track_swap" ~detail:"swapped";
+            ~kind:"dual_track_swap"
+            ~detail:(Printf.sprintf "swapped:%s" secondary_kind_label);
           Either.Left secondary
       | Some secondary_reason ->
           (* Both primary and secondary rejected: keep the primary in
              rejected so the cascade-empty WARN signature stays anchored
              on the user-declared model. The secondary's rejection is
              surfaced as a separate metric so operators can audit which
-             dual-track entries are uselessly configured. *)
+             dual-track entries are uselessly configured. The kind label
+             rides on the rejection detail too, so the same
+             [secondary_kind] series is queryable across swap success /
+             swap failure outcomes. *)
           Llm_metric_bridge.emit_fallback_triggered
             ~kind:"dual_track_swap"
-            ~detail:(filter_rejection_reason_label secondary_reason);
+            ~detail:(Printf.sprintf "rejected:%s:%s"
+                       secondary_kind_label
+                       (filter_rejection_reason_label secondary_reason));
           Either.Right (primary, primary_reason))
 
 let filter_candidate_providers_for_tool_support

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2226,6 +2226,78 @@ let test_filter_candidate_providers_for_tool_support_secondary_uses_candidate_in
     [ "claude_code:fallback-0"; "claude_code:fallback-1" ]
     (List.map Provider_tool_support.provider_debug_label filtered)
 
+(* RFC-0027 PR-9c: per-secondary accounting. Successful and failed
+   dual-track swaps must label the [masc_fallback_triggered_total]
+   counter with the secondary's [provider_kind] so dashboards can
+   split CLI-vs-DirectAPI fallback volume. *)
+let count_swap_metric ~detail =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_fallback_triggered
+    ~labels:[ ("kind", "dual_track_swap"); ("detail", detail) ]
+    ()
+
+let test_dual_track_swap_emits_secondary_kind_label_on_success () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  let runtime_mcp_policy =
+    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+      ~keeper_name:"sangsu" tools
+  in
+  let before = count_swap_metric ~detail:"swapped:claude_code" in
+  let _ =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~secondary_resolver:
+        (fun _ provider_cfg ->
+           if provider_cfg.kind = Llm_provider.Provider_config.Codex_cli
+           then Some (make_claude_code_provider_cfg ())
+           else None)
+      ~label:"tool_use_strict"
+      [ make_codex_cli_provider_cfg () ]
+  in
+  let after = count_swap_metric ~detail:"swapped:claude_code" in
+  Alcotest.(check (float 0.0001))
+    "successful swap bumps swapped:<secondary_kind>"
+    (before +. 1.0) after
+
+let test_dual_track_swap_emits_secondary_kind_label_on_rejection () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  let runtime_mcp_policy =
+    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+      ~keeper_name:"sangsu" tools
+  in
+  (* Rejected primary, secondary that *also* fails the gate (another
+     codex_cli with bound-actor tools). Detail format is
+     [rejected:<secondary_kind>:<rejection_reason_label>]. *)
+  let detail = "rejected:codex_cli:codex_keeper_bound_actor_required" in
+  let before = count_swap_metric ~detail in
+  let _ =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~secondary_resolver:
+        (fun _ provider_cfg ->
+           if provider_cfg.kind = Llm_provider.Provider_config.Codex_cli
+           then Some (make_codex_cli_provider_cfg ())
+           else None)
+      ~label:"tool_use_strict"
+      [ make_codex_cli_provider_cfg () ]
+  in
+  let after = count_swap_metric ~detail in
+  Alcotest.(check (float 0.0001))
+    "doubly-rejected swap bumps rejected:<secondary_kind>:<reason>"
+    (before +. 1.0) after
+
 (* #10681: filter rejection diagnostics. When [filter_*] empties the
    cascade, the WARN log now lists each rejected provider with its
    classification — these tests pin the classifier to its 3-stage
@@ -4209,6 +4281,14 @@ let () =
         "provider-normalized secondary resolver receives candidate index"
         `Quick
         test_filter_candidate_providers_for_tool_support_secondary_uses_candidate_index;
+      Alcotest.test_case
+        "RFC-0027 PR-9c: successful swap labels metric with secondary kind"
+        `Quick
+        test_dual_track_swap_emits_secondary_kind_label_on_success;
+      Alcotest.test_case
+        "RFC-0027 PR-9c: rejected secondary labels metric with kind+reason"
+        `Quick
+        test_dual_track_swap_emits_secondary_kind_label_on_rejection;
       Alcotest.test_case
         "classify_filter_rejection: codex bound-actor policy → keeper_bound_actor"
         `Quick test_classify_filter_rejection_codex_keeper_bound_actor;


### PR DESCRIPTION
## Summary

PR-9c of the [RFC-0027 capability-typed cascade](docs/rfc/RFC-0027-capability-typed-cascade.md) series. Builds on #13097 (PR-9b dual-track resolver wiring).

Adds the secondary provider's \`provider_kind\` to the \`masc_fallback_triggered_total{kind=\"dual_track_swap\",detail=...}\` detail axis so dashboards can split swap volume by which backend the cascade is actually leaning on (CLI vs Direct API).

### Detail format

| Outcome | Detail label |
|---|---|
| Swap success | \`swapped:<secondary_kind>\` |
| Secondary also rejected | \`rejected:<secondary_kind>:<rejection_reason_label>\` |

### Cardinality

Bounded by:
- \`Llm_provider.Provider_config.provider_kind\` (closed enum, ~12 values)
- \`filter_rejection_reason_label\` (closed set already in production label sets)

No new high-cardinality risk; both axes are already in use elsewhere.

### Why this matters

Operators currently see swap volume only as \`swapped\` / \`<reason>\` — no way to tell whether the swap landed on a Direct API path or another CLI. The next step (per-secondary token bucket accounting) keys on the same \`provider_kind\`, so this metric becomes the SSOT panel for confirming the bucket being drawn on.

## Changes

- \`lib/oas_worker_named_cascade.ml\` (+25 LOC): label \`emit_fallback_triggered\` with \`<secondary_kind>\` on both swap success and double-rejection branches of \`attempt_secondary_swap\`.
- \`test/test_oas_worker.ml\` (+80 LOC): two cases pinning the label format, asserting \`Prometheus.metric_value_or_zero\` increments by exactly \`1.0\`.

## Test plan

- [x] \`dune build\` clean (lib + test_oas_worker.exe)
- [x] Two new tests pass on this branch (40 \`PR-9c: successful swap\`, 41 \`PR-9c: rejected secondary\` — both \`[OK]\`)
- [x] Same 22 pre-existing \`test_oas_worker.exe\` failures observed on origin/main without our changes (main brokenness from in-flight \`lib/types\` refactor, unrelated)
- [ ] CI Build/Health/Lint green once main brokenness clears

## RFC scope check

\`lib/oas_worker_named_cascade.ml\` is cascade-routing surface, not in the RFC-mandatory subsystems list (no credential/identity/keeper-sandbox/dashboard-credential/hooks files touched). RFC waiver not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)