### PR TITLE
fix(cascade): unblock validate_path_result on warning 16

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -607,7 +607,7 @@ let runtime_required_profile_names ?config_path () =
   else
     runtime_required_profiles ~config_path
 
-let validate_path_result ?sw ?net ~config_path =
+let validate_path_result ?sw ?net ~config_path () =
   let checked_at = Unix.gettimeofday () in
   let source_state = active_source_state ~config_path in
   let source_path = source_state.info.source_path in
@@ -736,7 +736,7 @@ let validate_path_result ?sw ?net ~config_path =
 
 let validate_path ?sw ?net ?clock ~config_path () =
   let (_ : float Eio.Time.clock_ty Eio.Resource.t option) = clock in
-  match validate_path_result ?sw ?net ~config_path with
+  match validate_path_result ?sw ?net ~config_path () with
   | Ok result -> Ok result.snapshot
   | Error _ as e -> e
 
@@ -801,7 +801,7 @@ let inspect_active ?sw ?net ?clock () =
       match cached_result with
       | Some result -> result
       | None -> (
-          match validate_path_result ?sw ?net ~config_path with
+          match validate_path_result ?sw ?net ~config_path () with
           | Ok { snapshot; rejected_update = None } ->
               with_cache_lock (fun () ->
                   cache :=


### PR DESCRIPTION
## Summary

main 빌드 차단 — `lib/cascade/cascade_catalog_runtime.ml:610` `validate_path_result`가 모두 labeled 인자(`?sw ?net ~config_path`)만 가져 warning 16 (`unerasable-optional-argument`) 발생, dune flags가 error로 승격.

형제 함수 `validate_path ?sw ?net ?clock ~config_path ()`와 일관되게 trailing `()` 추가, 동일 파일 내 caller 2곳(line 739, 804)도 동반 수정.

## Caller verification

```
$ rg -n 'validate_path_result' -g '*.ml' -g '*.mli' -g '!_build/**'
lib/cascade/cascade_catalog_runtime.ml:610   (definition)
lib/cascade/cascade_catalog_runtime.ml:739   (caller, fixed)
lib/cascade/cascade_catalog_runtime.ml:804   (caller, fixed)
```

외부 caller 0건. mli 미존재 — signature 영향 없음.

## Test plan

- [x] `dune build --root .` 진행 (이 모듈 warning 16 사라지고 다음 unrelated 모듈로 넘어감 — 별개 axis는 별도 PR)
- [ ] CI Build/Test/Lint green

## Notes

- 별도 main blocker (`Env_config_keeper.KeeperRetryBackoff.degraded_retry_slot_phase_budget_sec` mli 미export, #13120 잔재)는 본 PR 범위 밖 — 별도 PR로 분리.
- 같은 axis 열린 PR 0건 sweep (`gh pr list --search "validate_path_result OR cascade_catalog_runtime OR unerasable-optional"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)