### PR TITLE
fix: aggregate goal loop phase status

### DIFF
--- a/scripts/goal_loop_status.py
+++ b/scripts/goal_loop_status.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Build a compact GOAL LOOP status report from Observe/Orient/Decide/Verify JSON.
+
+The phase-specific tools intentionally stay small and focused. This script is
+the glue layer for operators: it accepts any subset of their JSON outputs and
+emits one machine-readable snapshot with phase status, next action, and the raw
+counts that drove the decision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+STATUS_RANK = {"ok": 0, "unknown": 1, "warning": 2, "critical": 3}
+
+
+@dataclass
+class PhaseStatus:
+    status: str
+    summary: dict[str, Any]
+
+
+@dataclass
+class GoalLoopStatus:
+    schema_version: int
+    generated_at: str
+    loop_iteration: str
+    overall_status: str
+    phases: dict[str, PhaseStatus]
+    next_action: dict[str, Any] | None
+    system_health_signals: dict[str, Any]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_json_file(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def as_int(value: Any, default: int = 0) -> int:
+    return value if isinstance(value, int) else default
+
+
+def status_max(statuses: list[str]) -> str:
+    if not statuses:
+        return "unknown"
+    return max(statuses, key=lambda item: STATUS_RANK.get(item, 0))
+
+
+def pattern_count(observe: dict[str, Any] | None, name: str) -> int:
+    if observe is None:
+        return 0
+    patterns = observe.get("patterns", {})
+    if not isinstance(patterns, dict):
+        return 0
+    raw = patterns.get(name)
+    if not isinstance(raw, dict):
+        return 0
+    return as_int(raw.get("count"))
+
+
+def summarize_observe(observe: dict[str, Any] | None) -> PhaseStatus:
+    if observe is None:
+        return PhaseStatus(status="unknown", summary={"reason": "observe_json_missing"})
+
+    patterns = observe.get("patterns", {})
+    pattern_items = patterns if isinstance(patterns, dict) else {}
+    critical_matches = 0
+    warning_matches = 0
+    active_patterns: list[dict[str, Any]] = []
+
+    for name, raw in pattern_items.items():
+        if not isinstance(name, str) or not isinstance(raw, dict):
+            continue
+        count = as_int(raw.get("count"))
+        if count <= 0:
+            continue
+        severity = raw.get("severity")
+        severity_text = severity if isinstance(severity, str) else "unknown"
+        if severity_text == "critical":
+            critical_matches += count
+        elif severity_text == "warning":
+            warning_matches += count
+        active_patterns.append(
+            {"name": name, "count": count, "severity": severity_text}
+        )
+
+    status = (
+        "critical"
+        if critical_matches > 0
+        else "warning" if warning_matches > 0 else "ok"
+    )
+    return PhaseStatus(
+        status=status,
+        summary={
+            "files": observe.get("files", []),
+            "total_lines": as_int(observe.get("total_lines")),
+            "matched_lines": as_int(observe.get("matched_lines")),
+            "critical_matches": critical_matches,
+            "warning_matches": warning_matches,
+            "active_patterns": sorted(
+                active_patterns,
+                key=lambda item: (
+                    -as_int(item.get("count")),
+                    str(item.get("name", "")),
+                ),
+            ),
+        },
+    )
+
+
+def summarize_orient(orient: dict[str, Any] | None) -> PhaseStatus:
+    if orient is None:
+        return PhaseStatus(status="unknown", summary={"reason": "orient_json_missing"})
+
+    summary_raw = orient.get("summary", {})
+    summary = summary_raw if isinstance(summary_raw, dict) else {}
+    critical_present = as_int(summary.get("critical_present"))
+    evidence_present = as_int(summary.get("evidence_present"))
+    findings_total = as_int(summary.get("findings_total"))
+    status = (
+        "critical"
+        if critical_present > 0
+        else "warning" if evidence_present > 0 else "ok"
+    )
+    present_findings = []
+    findings = orient.get("findings", [])
+    if isinstance(findings, list):
+        for raw in findings:
+            if not isinstance(raw, dict):
+                continue
+            if raw.get("status") != "EVIDENCE_PRESENT":
+                continue
+            present_findings.append(
+                {
+                    "finding_id": raw.get("finding_id", "unknown"),
+                    "title": raw.get("title", "unknown"),
+                    "severity": raw.get("severity", "unknown"),
+                    "count": as_int(raw.get("count")),
+                }
+            )
+    return PhaseStatus(
+        status=status,
+        summary={
+            "evidence_present": evidence_present,
+            "critical_present": critical_present,
+            "findings_total": findings_total,
+            "present_findings": present_findings[:10],
+        },
+    )
+
+
+def decide_next_action(decide: dict[str, Any] | None) -> dict[str, Any] | None:
+    if decide is None:
+        return None
+    decisions = decide.get("decisions", [])
+    if not isinstance(decisions, list) or not decisions:
+        return None
+    first = decisions[0]
+    return first if isinstance(first, dict) else None
+
+
+def summarize_decide(decide: dict[str, Any] | None) -> PhaseStatus:
+    if decide is None:
+        return PhaseStatus(status="unknown", summary={"reason": "decide_json_missing"})
+
+    decisions_total = as_int(decide.get("decisions_total"))
+    p0_count = as_int(decide.get("p0_count"))
+    act_missing_count = as_int(decide.get("act_missing_count"), default=-1)
+    act_linked_count = as_int(decide.get("act_linked_count"), default=-1)
+    status = (
+        "critical"
+        if p0_count > 0
+        else "warning" if decisions_total > 0 else "ok"
+    )
+    summary: dict[str, Any] = {
+        "decisions_total": decisions_total,
+        "p0_count": p0_count,
+        "next_action": decide_next_action(decide),
+    }
+    if act_missing_count >= 0:
+        summary["act_missing_count"] = act_missing_count
+    if act_linked_count >= 0:
+        summary["act_linked_count"] = act_linked_count
+    return PhaseStatus(status=status, summary=summary)
+
+
+def summarize_act(decide: dict[str, Any] | None) -> PhaseStatus:
+    if decide is None:
+        return PhaseStatus(status="unknown", summary={"reason": "decide_json_missing"})
+
+    decisions_total = as_int(decide.get("decisions_total"))
+    act_missing_count = as_int(decide.get("act_missing_count"), default=-1)
+    act_linked_count = as_int(decide.get("act_linked_count"), default=-1)
+    if act_missing_count >= 0:
+        status = (
+            "critical"
+            if act_missing_count > 0
+            else "ok" if decisions_total == 0 or act_linked_count > 0 else "warning"
+        )
+        return PhaseStatus(
+            status=status,
+            summary={
+                "decisions_total": decisions_total,
+                "act_linked_count": max(act_linked_count, 0),
+                "act_missing_count": act_missing_count,
+            },
+        )
+    if decisions_total > 0:
+        return PhaseStatus(
+            status="unknown",
+            summary={
+                "decisions_total": decisions_total,
+                "reason": "act_map_not_evaluated",
+            },
+        )
+    return PhaseStatus(status="ok", summary={"decisions_total": 0})
+
+
+def summarize_verify(verify: dict[str, Any] | None) -> PhaseStatus:
+    if verify is None:
+        return PhaseStatus(status="unknown", summary={"reason": "verify_json_missing"})
+
+    raw_status = verify.get("status")
+    verify_status = raw_status if isinstance(raw_status, str) else "UNKNOWN"
+    failing_findings = verify.get("failing_findings", [])
+    violations = verify.get("violations", [])
+    failing_count = len(failing_findings) if isinstance(failing_findings, list) else 0
+    violation_count = len(violations) if isinstance(violations, list) else 0
+    status = "ok" if verify_status == "PASS" else "critical"
+    return PhaseStatus(
+        status=status,
+        summary={
+            "verify_status": verify_status,
+            "failing_findings": failing_count,
+            "violations": violation_count,
+        },
+    )
+
+
+def system_health_signals(observe: dict[str, Any] | None) -> dict[str, Any]:
+    signals = {
+        "keeper_failure_patterns": {
+            "keeper_skipping_turn": pattern_count(observe, "keeper_skipping_turn"),
+            "credential_archived_starvation": pattern_count(
+                observe, "credential_archived_starvation"
+            ),
+            "alive_but_stuck": pattern_count(observe, "alive_but_stuck"),
+        },
+        "provider_failure_patterns": {
+            "provider_health_skipped": pattern_count(
+                observe, "provider_health_skipped"
+            ),
+            "pricing_catalog_miss": pattern_count(observe, "pricing_catalog_miss"),
+        },
+        "data_integrity_patterns": {
+            "utf8_repair": pattern_count(observe, "utf8_repair"),
+            "cas_retry": pattern_count(observe, "cas_retry"),
+        },
+        "governance_patterns": {
+            "governance_unparseable": pattern_count(
+                observe, "governance_unparseable"
+            ),
+            "lenient_json_fallback": pattern_count(observe, "lenient_json_fallback"),
+        },
+    }
+    return signals
+
+
+def build_status_report(
+    *,
+    observe: dict[str, Any] | None,
+    orient: dict[str, Any] | None,
+    decide: dict[str, Any] | None,
+    verify: dict[str, Any] | None,
+    generated_at: str | None = None,
+    loop_iteration: str = "unknown",
+) -> GoalLoopStatus:
+    phases = {
+        "observe": summarize_observe(observe),
+        "orient": summarize_orient(orient),
+        "decide": summarize_decide(decide),
+        "act": summarize_act(decide),
+        "verify": summarize_verify(verify),
+    }
+    overall = status_max([phase.status for phase in phases.values()])
+    return GoalLoopStatus(
+        schema_version=1,
+        generated_at=generated_at or utc_now_iso(),
+        loop_iteration=loop_iteration,
+        overall_status=overall,
+        phases=phases,
+        next_action=decide_next_action(decide),
+        system_health_signals=system_health_signals(observe),
+    )
+
+
+def report_to_json(report: GoalLoopStatus) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: GoalLoopStatus) -> str:
+    lines = [
+        f"GOAL LOOP Status: {report.overall_status}",
+        f"loop_iteration: {report.loop_iteration}",
+        f"generated_at: {report.generated_at}",
+    ]
+    for name in ("observe", "orient", "decide", "act", "verify"):
+        phase = report.phases[name]
+        lines.append(f"- {name}: {phase.status} {json.dumps(phase.summary, sort_keys=True)}")
+    if report.next_action:
+        decision_id = report.next_action.get("decision_id", "unknown")
+        action = report.next_action.get("action", "unknown")
+        lines.append(f"next_action: {decision_id} {action}")
+    return "\n".join(lines)
+
+
+def should_fail(report: GoalLoopStatus, mode: str) -> bool:
+    if mode == "none":
+        return False
+    rank = STATUS_RANK.get(report.overall_status, 0)
+    if mode == "warning":
+        return rank >= STATUS_RANK["warning"]
+    if mode == "critical":
+        return rank >= STATUS_RANK["critical"]
+    raise ValueError(f"unknown fail mode: {mode}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--observe-json", help="JSON from observe_goal_loop_logs.py")
+    parser.add_argument("--orient-json", help="JSON from orient_goal_loop_logs.py")
+    parser.add_argument("--decide-json", help="JSON from decide_goal_loop_findings.py")
+    parser.add_argument("--verify-json", help="JSON from verify_goal_loop_logs.py")
+    parser.add_argument("--loop-iteration", default="unknown")
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "warning", "critical"),
+        default="none",
+        help="Exit non-zero when the aggregate status reaches this severity.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    report = build_status_report(
+        observe=load_json_file(args.observe_json),
+        orient=load_json_file(args.orient_json),
+        decide=load_json_file(args.decide_json),
+        verify=load_json_file(args.verify_json),
+        loop_iteration=args.loop_iteration,
+    )
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    return 1 if should_fail(report, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_goal_loop_status.py
+++ b/test/test_goal_loop_status.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import asdict
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "goal_loop_status.py"
+
+spec = importlib.util.spec_from_file_location("goal_loop_status", SCRIPT_PATH)
+assert spec is not None
+goal_loop_status = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = goal_loop_status
+spec.loader.exec_module(goal_loop_status)
+
+
+class GoalLoopStatusTest(unittest.TestCase):
+    def test_build_status_report_marks_critical_and_next_action(self) -> None:
+        report = goal_loop_status.build_status_report(
+            observe={
+                "files": ["server.log"],
+                "total_lines": 12,
+                "matched_lines": 3,
+                "patterns": {
+                    "alive_but_stuck": {
+                        "count": 2,
+                        "severity": "critical",
+                    },
+                    "metric_all_zero": {
+                        "count": 1,
+                        "severity": "warning",
+                    },
+                },
+            },
+            orient={
+                "summary": {
+                    "evidence_present": 2,
+                    "critical_present": 1,
+                    "findings_total": 10,
+                },
+                "findings": [
+                    {
+                        "finding_id": "NF-3",
+                        "title": "alive_but_stuck_no_recovery",
+                        "severity": "critical",
+                        "status": "EVIDENCE_PRESENT",
+                        "count": 2,
+                    }
+                ],
+            },
+            decide={
+                "decisions_total": 1,
+                "p0_count": 1,
+                "act_missing_count": 1,
+                "act_linked_count": 0,
+                "decisions": [
+                    {
+                        "decision_id": "D-P1-1",
+                        "action": "Execute recovery strategy",
+                    }
+                ],
+            },
+            verify={
+                "status": "FAIL",
+                "failing_findings": [{"finding_id": "NF-3"}],
+            },
+            generated_at="2026-05-05T10:00:00+00:00",
+            loop_iteration="#1",
+        )
+
+        self.assertEqual(report.overall_status, "critical")
+        self.assertEqual(report.phases["observe"].status, "critical")
+        self.assertEqual(report.phases["act"].summary["act_missing_count"], 1)
+        self.assertEqual(report.next_action["decision_id"], "D-P1-1")
+        self.assertEqual(
+            report.system_health_signals["keeper_failure_patterns"][
+                "alive_but_stuck"
+            ],
+            2,
+        )
+
+    def test_clean_inputs_produce_ok_status(self) -> None:
+        report = goal_loop_status.build_status_report(
+            observe={
+                "files": ["server.log"],
+                "total_lines": 5,
+                "matched_lines": 0,
+                "patterns": {},
+            },
+            orient={
+                "summary": {
+                    "evidence_present": 0,
+                    "critical_present": 0,
+                    "findings_total": 10,
+                },
+                "findings": [],
+            },
+            decide={
+                "decisions_total": 0,
+                "p0_count": 0,
+                "decisions": [],
+            },
+            verify={"status": "PASS", "failing_findings": []},
+            generated_at="2026-05-05T10:00:00+00:00",
+        )
+
+        self.assertEqual(report.overall_status, "ok")
+        self.assertEqual(report.phases["act"].status, "ok")
+        self.assertIsNone(report.next_action)
+
+    def test_missing_inputs_are_unknown(self) -> None:
+        report = goal_loop_status.build_status_report(
+            observe=None,
+            orient=None,
+            decide=None,
+            verify=None,
+            generated_at="2026-05-05T10:00:00+00:00",
+        )
+
+        self.assertEqual(report.overall_status, "unknown")
+        self.assertEqual(report.phases["observe"].summary["reason"], "observe_json_missing")
+        self.assertEqual(report.phases["verify"].status, "unknown")
+
+    def test_unknown_phase_prevents_overall_ok(self) -> None:
+        report = goal_loop_status.build_status_report(
+            observe={
+                "files": ["server.log"],
+                "total_lines": 1,
+                "matched_lines": 0,
+                "patterns": {},
+            },
+            orient=None,
+            decide={"decisions_total": 0, "p0_count": 0, "decisions": []},
+            verify={"status": "PASS", "failing_findings": []},
+            generated_at="2026-05-05T10:00:00+00:00",
+        )
+
+        self.assertEqual(report.phases["observe"].status, "ok")
+        self.assertEqual(report.phases["orient"].status, "unknown")
+        self.assertEqual(report.overall_status, "unknown")
+
+    def test_cli_reads_phase_json_and_fails_on_critical(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            observe_path = root / "observe.json"
+            orient_path = root / "orient.json"
+            decide_path = root / "decide.json"
+            verify_path = root / "verify.json"
+            observe_path.write_text(
+                json.dumps(
+                    {
+                        "files": ["server.log"],
+                        "total_lines": 1,
+                        "matched_lines": 1,
+                        "patterns": {
+                            "provider_health_skipped": {
+                                "count": 1,
+                                "severity": "critical",
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            orient_path.write_text(
+                json.dumps(
+                    {
+                        "summary": {
+                            "evidence_present": 1,
+                            "critical_present": 1,
+                            "findings_total": 10,
+                        },
+                        "findings": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            decide_path.write_text(
+                json.dumps(
+                    {
+                        "decisions_total": 1,
+                        "p0_count": 1,
+                        "decisions": [{"decision_id": "D-EMERGENCY-2"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            verify_path.write_text(
+                json.dumps({"status": "PASS", "failing_findings": []}),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--observe-json",
+                    str(observe_path),
+                    "--orient-json",
+                    str(orient_path),
+                    "--decide-json",
+                    str(decide_path),
+                    "--verify-json",
+                    str(verify_path),
+                    "--fail-on",
+                    "critical",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["overall_status"], "critical")
+        self.assertEqual(
+            payload["system_health_signals"]["provider_failure_patterns"][
+                "provider_health_skipped"
+            ],
+            1,
+        )
+
+    def test_report_json_is_machine_readable(self) -> None:
+        report = goal_loop_status.build_status_report(
+            observe=None,
+            orient=None,
+            decide=None,
+            verify=None,
+            generated_at="2026-05-05T10:00:00+00:00",
+        )
+
+        payload = json.loads(goal_loop_status.report_to_json(report))
+        self.assertEqual(payload, asdict(report))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/goal_loop_status.py` to aggregate Observe/Orient/Decide/Act/Verify JSON into one status snapshot.
- Emit phase status, aggregate `overall_status`, `next_action`, and system-health signal counts derived from Observe patterns.
- Treat missing phase JSON as `unknown`, and keep `unknown` above `ok` in aggregate status so partial evidence cannot look healthy.
- Add focused coverage in `test/test_goal_loop_status.py`.

## Why

The GOAL LOOP design has a unified dashboard concept, but the current tooling emits separate Observe, Orient, Decide, and Verify artifacts. This PR adds the glue layer that turns those artifacts into a machine-readable dashboard payload without coupling it to live GitHub PR numbers or requiring every phase tool to merge at the same time.

## ACT Checklist

- Observe: summarizes scanner pattern counts and system-health signal buckets.
- Orient: summarizes evidence-present and critical-present findings.
- Decide: summarizes decision/P0 counts and next action; accepts future ACT linkage fields if present.
- Act: reports ACT linkage as `unknown` until Decide output includes ACT-map counts, then reflects missing/linked counts.
- Verify: summarizes PASS/FAIL outputs and raw log-contract violations.

## Validation

- `npx pyright --outputjson scripts/goal_loop_status.py test/test_goal_loop_status.py`
- `ruff check scripts/goal_loop_status.py test/test_goal_loop_status.py`
- `python3 -m py_compile scripts/goal_loop_status.py test/test_goal_loop_status.py`
- `python3 test/test_goal_loop_status.py`
- `python3 test/test_observe_goal_loop_logs.py`
- `git diff --check origin/main...HEAD`