### PR TITLE
fix(build): unblock #13120 leftovers (mli export + Option.exists)

### DIFF
--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -289,6 +289,12 @@ module KeeperRetryBackoff : sig
   val transient_backoff_base_sec : unit -> float
   val transient_backoff_cap_sec : unit -> float
   val transient_backoff_sec : int -> float
+
+  val degraded_retry_slot_phase_budget_sec : float
+  (** Phase budget (seconds) for the degraded-retry slot guard.
+      Read once at module-load from
+      [MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC] (default 60.0,
+      floor 5.0); consumed by [keeper_turn_cascade_budget.ml]. *)
 end
 
 (** {1 Cascade attempt liveness — RFC-0022 §9 rollout flag} *)

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -319,8 +319,8 @@ let next_fail_open_cascade_for_turn_with_budget
       (* The candidate is always a retry, so use per-attempt budget semantics
          regardless of whether the current attempt was itself a retry. *)
       if
-        Option.exists
-          (fun time_spent_in_turn_s ->
+        Option.fold ~none:false
+          ~some:(fun time_spent_in_turn_s ->
             not
               (degraded_retry_slot_phase_available ~time_spent_in_turn_s))
           time_spent_in_turn_s


### PR DESCRIPTION
## Summary

main 빌드 차단 — PR #13120의 두 잔재.

1. **`degraded_retry_slot_phase_budget_sec` mli 미export.** `lib/config/env_config_keeper.ml:925`에 `let` 정의가 있지만 `lib/config/env_config_keeper.mli:287` `KeeperRetryBackoff` 시그니처에 `val`이 누락. caller `keeper_turn_cascade_budget.ml:271`이 module 경계를 통해 접근하려 unbound. 1줄 export 추가.
2. **`Option.exists` unbound** at `keeper_turn_cascade_budget.ml:322`. OCaml 5.x stdlib `Option`에는 `exists`가 없음 (`Base`/`Core`에는 `~f:` label 버전 존재 — `lib/keeper`는 Base scope 아님). 표준 처방 `Option.fold ~none:false ~some:p`로 교체 (call shape 동일).

## Caller verification

\`\`\`
$ rg -n 'degraded_retry_slot_phase_budget_sec' -g '*.ml' -g '*.mli' -g '!_build/**'
lib/config/env_config_keeper.ml:925   (definition)
lib/config/env_config_keeper.mli:293  (now exported)
lib/keeper/keeper_turn_cascade_budget.ml:271 (caller, fixed via export)
lib/keeper/keeper_turn_cascade_budget.ml:275 (consumer, unchanged)

$ rg -n 'Option\.exists' lib/ -g '*.ml' -g '!_build/**'
(0 hits — last call site replaced)
\`\`\`

dashboard_bonsai의 `Option.exists ~f:`는 Bonsai/Base scope이므로 영향 없음.

## Test plan

- [x] `dune build --root . @check` 진행 — 본 PR의 두 axis 통과, 남은 cascade warning 16은 PR #13159 영역
- [ ] CI Build/Test/Lint green

## Notes

- 별도 main blocker (cascade `validate_path_result` warning 16, #13124 잔재)는 PR #13159에서 fix 중. 두 PR 합쳐져야 main 빌드 회복.
- 같은 axis 열린 PR 0건 sweep (`gh pr list --search "degraded_retry_slot_phase_budget_sec OR env_config_keeper.mli OR KeeperRetryBackoff"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)