### PR TITLE
fix(dashboard): keep board sse hearth filters coherent

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   derivePostTitle,
+  createPost,
   fetchBoard,
   fetchBoardHearths,
   fetchBoardPost,
@@ -553,6 +554,30 @@ describe('fetchBoardPost', () => {
       vote_balance: 3,
       votes_up: 5,
       votes_down: 2,
+    })
+  })
+})
+
+describe('createPost', () => {
+  it('passes hearth assignment through to the board post tool', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createPost('Plan', 'Body', 'dashboard-user', { hearth: ' ops ' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/tools/masc_board_post')
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      title: 'Plan',
+      content: 'Body',
+      author: 'dashboard-user',
+      hearth: 'ops',
     })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -511,12 +511,20 @@ export function voteComment(commentId: string, direction: 'up' | 'down'): Promis
   })
 }
 
-export function createPost(title: string, content: string, author: string): Promise<unknown> {
-  return post(`/api/v1/tools/masc_board_post`, {
+export function createPost(
+  title: string,
+  content: string,
+  author: string,
+  options: { hearth?: string } = {},
+): Promise<unknown> {
+  const body: Record<string, string> = {
     title,
     content,
     author,
-  })
+  }
+  const hearth = options.hearth?.trim()
+  if (hearth) body.hearth = hearth
+  return post(`/api/v1/tools/masc_board_post`, body)
 }
 
 export function commentPost(postId: string, author: string, content: string, parentId?: string): Promise<unknown> {

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -81,6 +81,7 @@ export const replyingTo = signal<string | null>(null)
 export const showNewPostForm = signal(false)
 export const newPostTitle = signal('')
 export const newPostContent = signal('')
+export const newPostHearth = signal('')
 export const newPostSubmitting = signal(false)
 
 // ── Pagination ─────────────────────────────────────────────────────
@@ -364,15 +365,18 @@ export async function submitComment(postId: string, parentId?: string) {
 export async function submitNewPost() {
   const title = newPostTitle.value.trim()
   const content = newPostContent.value.trim()
+  const hearth = newPostHearth.value.trim() || boardHearthFilter.value.trim()
   if (!title || !content) return
   newPostSubmitting.value = true
   try {
-    await createPost(title, content, commentAuthor.value)
+    await createPost(title, content, commentAuthor.value, { hearth: hearth || undefined })
     newPostTitle.value = ''
     newPostContent.value = ''
+    newPostHearth.value = ''
     showNewPostForm.value = false
     showToast('글을 등록했습니다', 'success')
     refreshBoard()
+    void refreshBoardHearths()
   } catch (err) {
     console.warn('[board] post submit failed', err instanceof Error ? err.message : err)
     showToast('글 등록에 실패했습니다', 'error')

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
 import { route } from '../../router'
-import { boardHearths, contentCategory } from './board-state'
+import { boardHearths, contentCategory, newPostHearth } from './board-state'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -142,6 +142,7 @@ describe('BoardSurface Component', () => {
     boardAuthorFilter.value = ''
     boardHearthFilter.value = ''
     boardHearths.value = [{ name: 'ops', count: 0 }]
+    newPostHearth.value = ''
     route.value = { params: {} } as any
   })
 
@@ -200,5 +201,15 @@ describe('BoardSurface Component', () => {
 
     expect(boardHearthFilter.value).toBe('ops')
     expect(screen.getByRole('button', { name: 'hearth ops 2 posts' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('prefills the compose hearth from the active hearth filter', () => {
+    boardHearthFilter.value = 'ops'
+
+    render(h(BoardSurface, null))
+    fireEvent.click(screen.getByRole('button', { name: '+ 새 글 작성' }))
+
+    expect(screen.getByLabelText('새 글 hearth')).toHaveValue('ops')
+    expect(newPostHearth.value).toBe('ops')
   })
 })

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -14,6 +14,7 @@ import { RichComposer } from '../common/rich-composer'
 import { RichContent } from '../common/rich-content'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
+import { registerBoardHearthsRefresh } from '../../sse-store'
 import { PostDetail } from './post-detail'
 import {
   boardActorAvatarKey,
@@ -598,6 +599,9 @@ function PostCard({ post }: { post: BoardPost }) {
 // ── Main Board component (public API) ──────────────────────────────
 export function BoardSurface() {
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
+  useEffect(() => registerBoardHearthsRefresh(() => {
+    void refreshBoardHearths()
+  }), [])
   useEffect(() => {
     if (boardHearths.value.length === 0) void refreshBoardHearths()
   }, [])

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -47,6 +47,7 @@ import {
   showNewPostForm,
   newPostTitle,
   newPostContent,
+  newPostHearth,
   newPostSubmitting,
   PAGE_SIZE,
   categoryVisibleLimits,
@@ -205,7 +206,10 @@ function NewPostForm() {
     return html`
       <button type="button"
         class="w-full py-2.5 rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] text-sm text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-primary)] transition-colors bg-transparent"
-        onClick=${() => { showNewPostForm.value = true }}
+        onClick=${() => {
+          newPostHearth.value = boardHearthFilter.value
+          showNewPostForm.value = true
+        }}
       >+ 새 글 작성</button>
     `
   }
@@ -228,10 +232,23 @@ function NewPostForm() {
         helpText="예: ts 코드펜스, 일반 URL 링크 카드, 단독 이미지 URL 자동 인라인"
         previewLimit=${2}
       />
+      <${TextInput}
+        name="board_post_hearth"
+        ariaLabel="새 글 hearth"
+        autoComplete="off"
+        placeholder="hearth (예: ops, research)"
+        value=${newPostHearth.value}
+        onInput=${(e: Event) => { newPostHearth.value = (e.target as HTMLInputElement).value }}
+      />
       <div class="flex gap-2 justify-end">
         <button type="button"
           class="px-3 py-1.5 rounded-[var(--r-1)] text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-hover)]"
-          onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
+          onClick=${() => {
+            showNewPostForm.value = false
+            newPostTitle.value = ''
+            newPostContent.value = ''
+            newPostHearth.value = ''
+          }}
         >취소</button>
         <button type="button"
           class="px-4 py-1.5 rounded-[var(--r-1)] text-sm font-medium border border-[var(--info-border)] bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -1,6 +1,6 @@
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RouteState } from './types'
+import type { BoardPost, BoardSortMode, RouteState } from './types'
 
 void vi
 
@@ -11,8 +11,12 @@ type CurrentRoute = typeof route.value
 
 const keeperHeartbeats = signal(new Map<string, number>())
 const serverStatus = signal<unknown>(null)
-const boardPosts = signal<Array<{ id: string }>>([])
-const boardSortMode = signal<'recent'>('recent')
+const boardPosts = signal<BoardPost[]>([])
+const boardSortMode = signal<BoardSortMode>('recent')
+const boardExcludeSystem = signal(true)
+const boardExcludeAutomation = signal(false)
+const boardAuthorFilter = signal('')
+const boardHearthFilter = signal('')
 const boardOffset = signal(0)
 const namespaceTruth = signal<unknown>(null)
 const namespaceTruthError = signal<unknown>(null)
@@ -56,6 +60,10 @@ async function loadSseStore() {
     serverStatus,
     boardPosts,
     boardSortMode,
+    boardExcludeSystem,
+    boardExcludeAutomation,
+    boardAuthorFilter,
+    boardHearthFilter,
     boardOffset,
     removeBoardPost,
   }))
@@ -111,6 +119,11 @@ describe('setupSSEReaction reconnect hydration', () => {
     namespaceTruth.value = null
     namespaceTruthError.value = null
     boardPosts.value = []
+    boardSortMode.value = 'recent'
+    boardExcludeSystem.value = true
+    boardExcludeAutomation.value = false
+    boardAuthorFilter.value = ''
+    boardHearthFilter.value = ''
     boardOffset.value = 0
     keeperHeartbeats.value = new Map()
     serverStatus.value = null
@@ -251,6 +264,50 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps optimistic post_created hydration inside the active hearth filter', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+    boardHearthFilter.value = 'ops'
+
+    sseStore.routeServerPushEvent({
+      type: 'post_created',
+      post_id: 'post-1',
+      title: 'Research note',
+      content: 'body',
+      author: 'agent-a',
+      hearth: 'research',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(boardPosts.value).toEqual([])
+    expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes hearth chips when an optimistic board post carries a hearth', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshHearths = vi.fn()
+    sseStore.registerBoardHearthsRefresh(refreshHearths)
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+    boardHearthFilter.value = 'ops'
+
+    sseStore.routeServerPushEvent({
+      type: 'post_created',
+      post_id: 'post-1',
+      title: 'Ops note',
+      content: 'body',
+      author: 'agent-a',
+      hearth: 'ops',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(boardPosts.value[0]?.id).toBe('post-1')
+    expect(boardPosts.value[0]?.hearth).toBe('ops')
+    expect(refreshBoard).not.toHaveBeenCalled()
+    expect(refreshHearths).toHaveBeenCalledTimes(1)
   })
 
   it('keeps websocket raw push refreshes hidden when the route does not need that surface', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -34,6 +34,10 @@ import {
   serverStatus,
   boardPosts,
   boardSortMode,
+  boardExcludeSystem,
+  boardExcludeAutomation,
+  boardAuthorFilter,
+  boardHearthFilter,
   boardOffset,
 } from './store'
 import {
@@ -89,6 +93,14 @@ export function registerActivityRefresh(fn: () => void): () => void {
   _refreshActivityFns.add(fn)
   return () => {
     _refreshActivityFns.delete(fn)
+  }
+}
+
+let _refreshBoardHearthsFn: (() => void) | null = null
+export function registerBoardHearthsRefresh(fn: () => void): () => void {
+  _refreshBoardHearthsFn = fn
+  return () => {
+    if (_refreshBoardHearthsFn === fn) _refreshBoardHearthsFn = null
   }
 }
 
@@ -151,7 +163,10 @@ const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
 
 const REFRESH_FNS: Record<RefreshTarget, () => void> = {
   execution: () => { void refreshExecution() },
-  board:     refreshBoard,
+  board:     () => {
+    void refreshBoard()
+    _refreshBoardHearthsFn?.()
+  },
   operator:  () => _refreshOperatorFn?.(),
   activity:  () => {
     for (const fn of _refreshActivityFns) fn()
@@ -165,6 +180,14 @@ function scheduleTargetRefresh(
 ): void {
   if (!routeWantsRefreshTarget(route.value, target)) return
   scheduleRefresh(target, fn, delayMs)
+}
+
+function scheduleBoardHearthsRefresh(delayMs = SSE_DEFAULT_DEBOUNCE_MS): void {
+  if (!_refreshBoardHearthsFn) return
+  if (!routeWantsRefreshTarget(route.value, 'board')) return
+  scheduleRefresh('board-hearths', () => {
+    _refreshBoardHearthsFn?.()
+  }, delayMs)
 }
 
 // --- Named handlers for complex events ---
@@ -362,6 +385,9 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
   const content = event.content as string | undefined
   if (!postId || !content) return false
   if (boardPosts.value.some(p => p.id === postId)) return false
+  const eventHearth = event.hearth?.trim() ?? ''
+  if (eventHearth) scheduleBoardHearthsRefresh()
+  if (!eventMatchesActiveBoardFilters(event)) return false
 
   const now = new Date().toISOString()
   const post: BoardPost = {
@@ -377,10 +403,25 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
     votes: 0,
     vote_balance: 0,
     comment_count: 0,
-    hearth: event.hearth ?? undefined,
+    hearth: eventHearth || undefined,
   }
   boardPosts.value = [post, ...boardPosts.value]
   boardOffset.value = boardPosts.value.length
+  return true
+}
+
+function eventMatchesActiveBoardFilters(event: SSEEvent): boolean {
+  const hearthFilter = boardHearthFilter.value.trim()
+  if (hearthFilter !== '' && (event.hearth?.trim() ?? '') !== hearthFilter) return false
+
+  // Author filtering is server-defined today, so a filtered view should be
+  // reconciled through the board endpoint instead of guessing client-side.
+  if (boardAuthorFilter.value.trim() !== '') return false
+
+  const rawKind = (event.post_kind ?? 'direct').toLowerCase()
+  const postKind = rawKind === 'system' || rawKind === 'automation' ? rawKind : 'direct'
+  if (postKind === 'system' && boardExcludeSystem.value) return false
+  if (postKind === 'automation' && boardExcludeAutomation.value) return false
   return true
 }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -1,4 +1,4 @@
-import type { BoardActorIdentity } from './core'
+import type { BoardActorIdentity, BoardPost } from './core'
 
 // --- SSE Events ---
 
@@ -141,6 +141,7 @@ export interface SSEEvent {
   voter?: string
   voter_identity?: BoardActorIdentity | null
   direction?: 'up' | 'down' | string
+  post_kind?: BoardPost['post_kind'] | string
   hearth?: string
   agent_name?: string
   keeper_name?: string


### PR DESCRIPTION
## Summary
- register board hearth filter refreshes with the SSE board surface
- keep optimistic post_created hydration inside the active board filters
- refresh hearth chips when optimistic board events introduce or update a hearth

## Validation
- pnpm exec vitest run src/sse-store.test.ts src/components/board/board-surface.test.ts src/components/board/board-state.test.ts src/components/board/post-detail.test.ts src/api/board.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard exec eslint src/sse-store.ts src/sse-store.test.ts src/components/board/board-surface.ts src/types/sse.ts