### PR TITLE
fix(build): restore keeper budget compile surface

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -607,7 +607,7 @@ let runtime_required_profile_names ?config_path () =
   else
     runtime_required_profiles ~config_path
 
-let validate_path_result ?sw ?net ~config_path =
+let validate_path_result ?sw ?net ~config_path () =
   let checked_at = Unix.gettimeofday () in
   let source_state = active_source_state ~config_path in
   let source_path = source_state.info.source_path in
@@ -736,7 +736,7 @@ let validate_path_result ?sw ?net ~config_path =
 
 let validate_path ?sw ?net ?clock ~config_path () =
   let (_ : float Eio.Time.clock_ty Eio.Resource.t option) = clock in
-  match validate_path_result ?sw ?net ~config_path with
+  match validate_path_result ?sw ?net ~config_path () with
   | Ok result -> Ok result.snapshot
   | Error _ as e -> e
 
@@ -801,7 +801,7 @@ let inspect_active ?sw ?net ?clock () =
       match cached_result with
       | Some result -> result
       | None -> (
-          match validate_path_result ?sw ?net ~config_path with
+          match validate_path_result ?sw ?net ~config_path () with
           | Ok { snapshot; rejected_update = None } ->
               with_cache_lock (fun () ->
                   cache :=

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -289,6 +289,7 @@ module KeeperRetryBackoff : sig
   val transient_backoff_base_sec : unit -> float
   val transient_backoff_cap_sec : unit -> float
   val transient_backoff_sec : int -> float
+  val degraded_retry_slot_phase_budget_sec : float
 end
 
 (** {1 Cascade attempt liveness — RFC-0022 §9 rollout flag} *)

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -319,11 +319,11 @@ let next_fail_open_cascade_for_turn_with_budget
       (* The candidate is always a retry, so use per-attempt budget semantics
          regardless of whether the current attempt was itself a retry. *)
       if
-        Option.exists
-          (fun time_spent_in_turn_s ->
-            not
-              (degraded_retry_slot_phase_available ~time_spent_in_turn_s))
-          time_spent_in_turn_s
+        (match time_spent_in_turn_s with
+         | Some time_spent_in_turn_s ->
+             not
+               (degraded_retry_slot_phase_available ~time_spent_in_turn_s)
+         | None -> false)
       then Degraded_retry_slot_phase_exhausted retry
       else if
         oas_retry_budget_available_for_turn


### PR DESCRIPTION
## Summary

- Expose `KeeperRetryBackoff.degraded_retry_slot_phase_budget_sec` in `env_config_keeper.mli` to match the implementation.
- Keep cascade catalog probe optional arguments erasable by giving the private validation helper a final unit argument.
- Replace `Option.exists` with an explicit match in keeper retry budgeting for compatibility with the local OCaml switch.

## Product impact

Latest `origin/main` could not compile the focused keeper target used to validate autonomy fixes. This blocks rebuilding a current-main local runtime and hides the real keeper behavior regressions behind build-surface failures.

This restores the keeper budget/cascade compile surface so subsequent autonomy fixes can be validated against current `main`.

## Evidence

- `git show origin/main:lib/config/env_config_keeper.ml` shows `degraded_retry_slot_phase_budget_sec` is implemented.
- `git show origin/main:lib/config/env_config_keeper.mli` showed the value missing from the signature.
- `scripts/dune-local.sh build test/test_keeper_unified.exe` passed after this patch.

## Review evidence

- The change is limited to the missing signature value, the private helper call shape, and an equivalent `Option.exists` replacement.
- No runtime policy or cascade selection behavior is changed.

## Linked issue

None.
