### PR TITLE
test(bootstrap): pin Int32 djb2 hash outputs cross-platform (#13155 §L)

### DIFF
--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -92,6 +92,29 @@ let test_autoboot_warmup_jitter_is_bounded_not_linear () =
   check bool "last keeper is not delayed by list position" true
     (List.nth warmups 13 <= 75)
 
+(* §L (tracker #13155): pin exact warmup outputs for fixed keeper
+   names so any silent regression to native-int [acc lsl 5] (which
+   wraps differently on 31-bit vs 63-bit OCaml) breaks at least one
+   assertion on at least one architecture.
+
+   Expected values come from the Int32 djb2 spec:
+     [acc := Int32.logand (Int32.add (Int32.add (acc lsl 5) acc) ch)
+            0x3FFF_FFFFl]
+
+   With [base_warmup = 0, stagger_window_sec = 99] the formula
+   reduces to [hash mod 100] which is itself stable across platforms
+   under the Int32 implementation. *)
+let test_warmup_hash_pinned_cross_platform () =
+  let warmup name =
+    Boot.autoboot_proactive_warmup_sec ~base_warmup:0
+      ~stagger_window_sec:99 ~keeper_name:name
+  in
+  check int "verifier hash mod 100 (Int32 djb2)" 25 (warmup "verifier");
+  check int "designer hash mod 100 (Int32 djb2)" 74 (warmup "designer");
+  check int "developer hash mod 100 (Int32 djb2)" 15 (warmup "developer");
+  check int "analyst hash mod 100 (Int32 djb2)" 73 (warmup "analyst");
+  check int "janitor hash mod 100 (Int32 djb2)" 4 (warmup "janitor")
+
 let test_autoboot_warmup_is_order_independent () =
   let warmup name =
     Boot.autoboot_proactive_warmup_sec ~base_warmup:60 ~stagger_window_sec:15
@@ -166,5 +189,7 @@ let () =
             test_autoboot_warmup_jitter_is_bounded_not_linear;
           test_case "warmup deterministic per keeper" `Quick
             test_autoboot_warmup_is_order_independent;
+          test_case "Int32 hash pinned cross-platform (#13155 §L)" `Quick
+            test_warmup_hash_pinned_cross_platform;
         ] );
     ]


### PR DESCRIPTION
## Summary

Pins exact `Int32` djb2 hash outputs for fixed keeper names so any silent regression to native-`int` `acc lsl 5` arithmetic — which wraps differently on 31-bit vs 63-bit OCaml — fails CI on at least one architecture.

Closes [#13155 §L](https://github.com/jeong-sik/masc-mcp/issues/13155#issuecomment-4378518200): the existing order-independence test in `test_env_config_keeper_bootstrap_intervals.ml` would still pass against the pre-#13156 native-`int` impl on 64-bit OCaml because that impl coincidentally happens not to overflow for short keeper names.  That observation matches the Copilot review on PR #13156 (`PRRT_kwDOQ7_DYc5_njfw`).

## Test plan

- [x] Test added: `test_warmup_hash_pinned_cross_platform`
- [x] Asserts `autoboot_proactive_warmup_sec ~base_warmup:0 ~stagger_window_sec:99 ~keeper_name = hash mod 100` for 5 fixed names
- [x] Expected values derived from the Int32 spec at `lib/server/server_bootstrap_loops.ml:24-32`; verified via Python `i32` wrap model:
  - `verifier` → 25
  - `designer` → 74
  - `developer` → 15
  - `analyst` → 73
  - `janitor` → 4
- [ ] CI: tests-only change, `dune build` verifies the assertions match the actual OCaml Int32 semantics

## Why these names

`analyst`, `janitor`, `verifier` are real keeper identifiers in the live fleet (also referenced by the existing `test_autoboot_warmup_jitter_is_bounded_not_linear`); `designer` and `developer` are added to make the Int32 wrap path easier to spot if values diverge between architectures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
