### PR TITLE
fix(keeper): tighten action signals and remove zombie field

### DIFF
--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -75,8 +75,7 @@ let classify_actionable_signal_for_tools ~(allowed_tool_names : string list) o =
   else if
     o.has_discovered_work_section
     && has_any_tool
-         [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task";
-           "keeper_board_post"; "masc_add_task"; "keeper_tasks_audit";
+         [ "keeper_board_post"; "masc_add_task"; "keeper_tasks_audit";
            "keeper_shell"; "keeper_bash"; "masc_code_git"; "keeper_fs_read" ]
   then Has_discovered_work
   else No_actionable_signal

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -136,7 +136,6 @@ let direct_turn_observation (meta : keeper_meta) :
     backlog_updated_since_last_scheduled_autonomous = false;
     active_agent_count = 0;
     last_turn_budget = None;
-    last_tools_used = [];
     work_discovery_due = false;
   }
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -43,9 +43,6 @@ type world_observation = {
   backlog_updated_since_last_scheduled_autonomous : bool;
   active_agent_count : int;
   last_turn_budget : (int * int) option;
-  last_tools_used : string list;
-    (** Tools used in the previous cycle. Empty on first cycle.
-        Used by the unified prompt to generate data-driven anti-repetition hints. *)
   work_discovery_due : bool;
 }
 
@@ -971,7 +968,6 @@ let observe ~allowed_tool_names
     backlog_updated_since_last_scheduled_autonomous;
     active_agent_count;
     last_turn_budget = None;
-    last_tools_used = [];
     work_discovery_due;
   }
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -87,10 +87,6 @@ type world_observation = {
   last_turn_budget : (int * int) option;
   (** Previous generation's turn usage as [(used, total)], if available. *)
 
-  last_tools_used : string list;
-  (** Tools used in the previous cycle. Empty on first cycle or when unavailable.
-      Used by the prompt builder to generate data-driven anti-repetition hints. *)
-
   work_discovery_due : bool;
 }
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -197,7 +197,6 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     active_agent_count = 0;
     last_turn_budget = None;
-    last_tools_used = [];
     work_discovery_due = false;
   }
 


### PR DESCRIPTION
## Summary
- Remove the unused `last_tools_used` field from keeper world observations and fixtures.
- Keep task-action classification scoped to claimable backlog by removing claim-only tools from the work-discovery fallback signal.

## Why
- `last_tools_used` was documented as an anti-repetition input but had no reader; keeping it suggested behavior that did not exist.
- After rebasing onto current `main`, `test_keeper_unified.exe` exposed that a keeper with only `keeper_task_claim` could still treat out-of-scope backlog as actionable via `work_discovery_due`. Claim tools are already handled by the claimable-backlog branch, so discovery requires a real discovery/action surface.

## Validation
- `rg -n "last_tools_used" lib test` returns no matches.
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe` (Keeper Cycle run `C00IBJ46`, 318 tests)