### PR TITLE
fix(oas): enable codex cli keeper mcp approval

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -166,6 +166,9 @@ let runtime_mcp_tool_requires_bound_actor =
 let runtime_mcp_policy_with_masc_agent_name =
   Oas_worker_exec_transport.runtime_mcp_policy_with_masc_agent_name
 
+let codex_cli_can_auth_keeper_bound_runtime_mcp =
+  Oas_worker_exec_transport.codex_cli_can_auth_keeper_bound_runtime_mcp
+
 let runtime_mcp_policy_for_provider =
   Oas_worker_exec_transport.runtime_mcp_policy_for_provider
 

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -186,6 +186,10 @@ val runtime_mcp_policy_with_masc_agent_name :
   agent_name:string ->
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   Llm_provider.Llm_transport.runtime_mcp_policy
+val codex_cli_can_auth_keeper_bound_runtime_mcp :
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  bool
 val runtime_mcp_policy_for_provider :
   provider_cfg:Llm_provider.Provider_config.t ->
   agent_name:string ->

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -306,6 +306,71 @@ let runtime_mcp_policy_without_http_headers
   in
   { policy with servers }
 
+let is_authorization_header (key, value) =
+  String.equal (String.lowercase_ascii (String.trim key)) "authorization"
+  && String.starts_with ~prefix:"Bearer " (String.trim value)
+
+let authorization_header_from_policy
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  List.find_map
+    (function
+      | Llm_provider.Llm_transport.Http_server { name = "masc"; headers; _ } ->
+          List.find_opt is_authorization_header headers
+      | _ -> None)
+    policy.servers
+
+let per_keeper_authorization_header ~agent_name =
+  match keeper_name_of_agent_name agent_name with
+  | None -> None
+  | Some _ ->
+      let base_path = Env_config_core.base_path () in
+      Auth.load_raw_token base_path ~agent_name
+      |> Option.map (fun raw -> ("Authorization", "Bearer " ^ raw))
+
+let runtime_mcp_policy_uses_bound_actor_tools
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  List.exists Tool_catalog.requires_actor_binding policy.allowed_tool_names
+
+let add_masc_authorization_header authorization_header
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  let servers =
+    List.map
+      (function
+        | Llm_provider.Llm_transport.Http_server ({ name = "masc"; headers; _ } as server) ->
+            Llm_provider.Llm_transport.Http_server
+              {
+                server with
+                headers =
+                  upsert_http_header
+                    ~key:(fst authorization_header)
+                    ~value:(snd authorization_header)
+                    headers;
+              }
+        | server -> server)
+      policy.servers
+  in
+  { policy with servers }
+
+let codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
+  runtime_mcp_policy_uses_bound_actor_tools policy
+  && Option.is_some (per_keeper_authorization_header ~agent_name)
+
+let codex_runtime_mcp_policy_for_agent ~agent_name policy =
+  let stripped =
+    runtime_mcp_policy_without_http_headers policy
+    |> runtime_mcp_policy_with_masc_agent_name
+         ~include_internal_token:false ~agent_name
+  in
+  let authorization_header =
+    if runtime_mcp_policy_uses_bound_actor_tools policy then
+      per_keeper_authorization_header ~agent_name
+    else
+      authorization_header_from_policy policy
+  in
+  match authorization_header with
+  | Some header -> add_masc_authorization_header header stripped
+  | None -> stripped
+
 let runtime_mcp_policy_for_provider
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(agent_name : string)
@@ -316,20 +381,11 @@ let runtime_mcp_policy_for_provider
   in
   match policy_opt, provider_cfg.kind, agent_name with
   | Some policy, Llm_provider.Provider_config.Codex_cli, Some agent_name ->
-      (* PR-F (Plan v3 Leak 2a): Codex CLI runtime MCP rejects most
-         per-request HTTP headers, but the masc HTTP server still needs
-         the keeper's identity to avoid collapsing to
-         [Auth.find_credential_by_token]'s alphabetical first-match
-         (the #9786 root cause behind the [bearer token belongs to X]
-         rejection storm).  Strip ambient/auth headers as before, then
-         re-inject the non-secret identity-only whitelist
-         (x-masc-agent-name, x-masc-keeper-name)
-         so the server side resolves the requester correctly even when
-         ambient-env auth is the primary channel. *)
-      let stripped = runtime_mcp_policy_without_http_headers policy in
-      Some
-        (runtime_mcp_policy_with_masc_agent_name
-           ~include_internal_token:false ~agent_name stripped)
+      (* Codex CLI still cannot carry arbitrary per-request headers, but OAS
+         routes [Authorization: Bearer ...] through [bearer_token_env_var].
+         Keep only that auth path plus non-secret identity headers so Codex can
+         pre-approve runtime MCP tools without leaking tokens through argv. *)
+      Some (codex_runtime_mcp_policy_for_agent ~agent_name policy)
   | Some policy, Llm_provider.Provider_config.Codex_cli, None ->
       (* No agent_name to inject — preserve the legacy strip-all behavior. *)
       Some (runtime_mcp_policy_without_http_headers policy)

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -138,11 +138,20 @@ val runtime_mcp_policy_with_masc_agent_name :
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   Llm_provider.Llm_transport.runtime_mcp_policy
 
+val codex_cli_can_auth_keeper_bound_runtime_mcp :
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  bool
+(** [true] when [agent_name] maps to a keeper with a persisted raw bearer
+    token and [policy] contains actor-bound runtime MCP tools.  Codex CLI
+    can carry that token via OAS [bearer_token_env_var] without placing it in
+    argv. *)
+
 (** Provider-specific shaping of the runtime MCP policy.  For Codex_cli the
-    policy is stripped of HTTP headers (provider rejects most per-request
-    headers) and the identity-only whitelist is re-injected.  Other providers
-    receive the policy with [runtime_mcp_policy_with_masc_agent_name]
-    applied when [agent_name] is non-empty. *)
+    policy is stripped to Codex-safe headers: [Authorization: Bearer ...]
+    plus non-secret MASC identity headers.  Other providers receive the policy
+    with [runtime_mcp_policy_with_masc_agent_name] applied when [agent_name] is
+    non-empty. *)
 val runtime_mcp_policy_for_provider :
   provider_cfg:Llm_provider.Provider_config.t ->
   agent_name:string ->

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -111,6 +111,9 @@ let codex_cli_cannot_carry_keeper_bound_runtime_mcp
     ->
       List.exists Oas_worker_exec.runtime_mcp_tool_requires_bound_actor
         policy.allowed_tool_names
+      && not
+           (Oas_worker_exec.codex_cli_can_auth_keeper_bound_runtime_mcp
+              ~agent_name policy)
   | _ -> false
 
 (* #10681: per-provider rejection reason produced by the cascade filter.

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -102,8 +102,15 @@ let runtime_mcp_policy_requires_http_headers
 let normalize_header_key key = String.lowercase_ascii (String.trim key)
 
 let codex_cli_identity_runtime_mcp_header key =
+  (* OAS Codex transport turns [Authorization: Bearer ...] into
+     bearer_token_env_var, so the token is carried through the subprocess
+     environment rather than argv. Other auth-bearing headers remain
+     unsupported. *)
   match normalize_header_key key with
-  | "x-masc-agent-name" | "x-masc-keeper-name" -> true
+  | "authorization"
+  | "x-masc-agent-name"
+  | "x-masc-keeper-name" ->
+      true
   | _ -> false
 
 let provider_supports_runtime_mcp_http_header

--- a/test/test_per_keeper_token_fallback.ml
+++ b/test/test_per_keeper_token_fallback.ml
@@ -41,6 +41,47 @@ let seed_raw_token base_path agent_name raw =
   end;
   Auth.save_private_text_file (raw_token_path base_path agent_name) raw
 
+let with_env name value f =
+  let old = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some previous -> Unix.putenv name previous
+      | None -> Unix.putenv name "")
+    f
+
+let require_some label = function
+  | Some value -> value
+  | None -> failf "%s returned None" label
+
+let header_value key headers =
+  List.find_map
+    (fun (candidate, value) ->
+      if String.equal
+           (String.lowercase_ascii (String.trim key))
+           (String.lowercase_ascii (String.trim candidate))
+      then Some value
+      else None)
+    headers
+
+let masc_headers
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  List.find_map
+    (function
+      | Llm_provider.Llm_transport.Http_server { name = "masc"; headers; _ } ->
+          Some headers
+      | _ -> None)
+    policy.servers
+  |> require_some "masc runtime MCP server"
+
+let codex_provider_cfg () =
+  match Oas_worker_exec.resolve_provider_config_of_label "codex_cli:auto" with
+  | Ok cfg -> cfg
+  | Error err ->
+      fail
+        (Oas_worker_exec.label_resolution_error_to_string err)
+
 let test_load_raw_token_reads_seeded_file () =
   with_temp_dir "f1-load-raw" @@ fun base_path ->
   seed_raw_token base_path "keeper-analyst-agent" "secret-bearer-abc123";
@@ -72,6 +113,45 @@ let test_per_keeper_token_label_is_observable () =
     "per_keeper_token_file"
     (Auth_resolve.token_source_label Per_keeper_token_file)
 
+let test_codex_keeper_bound_policy_uses_per_keeper_bearer () =
+  with_temp_dir "f1-codex-keeper-bound" @@ fun base_path ->
+  let agent_name = "keeper-analyst-agent" in
+  seed_raw_token base_path agent_name "keeper-bearer-xyz";
+  with_env "MASC_BASE_PATH" base_path @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  let policy =
+    Oas_worker_exec.runtime_mcp_policy_of_tool_names ~agent_name
+      [ "masc_transition" ]
+    |> require_some "runtime_mcp_policy_of_tool_names"
+  in
+  check bool "actor-bound approval tool preserved" true
+    (List.mem "masc_transition" policy.allowed_tool_names);
+  check bool "codex can authenticate keeper-bound policy" true
+    (Oas_worker_exec.codex_cli_can_auth_keeper_bound_runtime_mcp
+       ~agent_name policy);
+  let codex = codex_provider_cfg () in
+  let codex_policy =
+    Oas_worker_exec.runtime_mcp_policy_for_provider ~provider_cfg:codex
+      ~agent_name (Some policy)
+    |> require_some "runtime_mcp_policy_for_provider"
+  in
+  check (list string) "codex approval list"
+    [ "masc_transition" ] codex_policy.allowed_tool_names;
+  check bool "codex tool-support gate accepts generated approval policy" true
+    (Provider_tool_support.supports_required_tool_use
+       ~runtime_mcp_policy:codex_policy
+       ~require_tool_choice_support:false ~require_tool_support:true codex);
+  let headers = masc_headers codex_policy in
+  check (option string) "Bearer is routed through codex-safe auth"
+    (Some "Bearer keeper-bearer-xyz") (header_value "authorization" headers);
+  check (option string) "internal token is not carried by codex"
+    None (header_value "x-masc-internal-token" headers);
+  check (option string) "agent identity retained"
+    (Some agent_name) (header_value "x-masc-agent-name" headers);
+  check (option string) "keeper identity retained"
+    (Some "analyst") (header_value "x-masc-keeper-name" headers)
+
 let () =
   Alcotest.run "per_keeper_token_fallback"
     [
@@ -88,5 +168,10 @@ let () =
         [
           test_case "Per_keeper_token_file label stable" `Quick
             test_per_keeper_token_label_is_observable;
+        ] );
+      ( "codex_cli",
+        [
+          test_case "keeper-bound policy uses per-keeper bearer approval" `Quick
+            test_codex_keeper_bound_policy_uses_per_keeper_bearer;
         ] );
     ]


### PR DESCRIPTION
## Summary
- task-150 / goal-codex-cli-cascade-usability: allow codex_cli to carry keeper-bound runtime MCP when a per-keeper bearer token exists
- keep Codex headers narrow: Authorization: Bearer plus non-secret MASC identity headers; strip internal-token headers so secrets do not land in argv
- preserve runtime MCP allowed_tool_names so OAS emits mcp_servers.masc.tools.<tool>.approval_mode=approve for policy-derived tools
- add regression coverage for actor-bound masc_transition using a per-keeper token

## Notes
- This complements PR #13149: #13149 logs/skips the unsafe path when codex_cli still cannot carry the policy; this PR enables the safe per-keeper bearer path for task-150.
- MASC task claim remains blocked for codex-mcp-client because task-150 requires keeper_bash.

## Validation
- git diff --check
- ./scripts/check-oas-pin.sh --local-only
- scripts/dune-local.sh build ./test/test_per_keeper_token_fallback.exe
- ./_build/default/test/test_per_keeper_token_fallback.exe