### PR TITLE
test: add goal loop fixture bundle

### DIFF
--- a/docs/examples/goal-loop-fixture.md
+++ b/docs/examples/goal-loop-fixture.md
@@ -1,0 +1,42 @@
+# GOAL LOOP fixture replay
+
+This fixture bundle is a local, deterministic replay of the startup evidence
+used by the GOAL LOOP tooling tests.  It proves that Observe, Orient, Decide,
+Act linkage, Verify, and aggregate status stay wired together without needing a
+live production log.
+
+Run from the repository root:
+
+```bash
+python3 scripts/decide_goal_loop_findings.py \
+  test/fixtures/goal_loop/orient.startup.json \
+  --act-map test/fixtures/goal_loop/act-map.startup.json \
+  > /tmp/goal-loop-decide.json
+
+python3 scripts/goal_loop_status.py \
+  --observe-json test/fixtures/goal_loop/observe.startup.json \
+  --orient-json test/fixtures/goal_loop/orient.startup.json \
+  --decide-json /tmp/goal-loop-decide.json \
+  --verify-json test/fixtures/goal_loop/verify.fail.json \
+  --loop-iteration "#fixture" \
+  --format text
+```
+
+Expected key facts:
+
+- `overall_status` is `critical`.
+- Decide reports `act_linked_count=4` and `act_missing_count=1`.
+- Act remains critical because `D-EMERGENCY-1` is still missing a linked ACT
+  artifact.
+- Verify remains `FAIL`, so the loop must not be marked complete.
+
+Use the JSON status form when another tool needs to consume the replay:
+
+```bash
+python3 scripts/goal_loop_status.py \
+  --observe-json test/fixtures/goal_loop/observe.startup.json \
+  --orient-json test/fixtures/goal_loop/orient.startup.json \
+  --decide-json /tmp/goal-loop-decide.json \
+  --verify-json test/fixtures/goal_loop/verify.fail.json \
+  --loop-iteration "#fixture"
+```

--- a/test/fixtures/goal_loop/act-map.startup.json
+++ b/test/fixtures/goal_loop/act-map.startup.json
@@ -1,0 +1,14 @@
+{
+  "D-EMERGENCY-2": [
+    "PR#13124 provider health probes"
+  ],
+  "D-P1-1": [
+    "PR#13123 alive-stuck recovery"
+  ],
+  "D-P2-1": [
+    "PR#13138 keeper TOML unknown keys"
+  ],
+  "D-P2-2": [
+    "PR#13143 governance fallback counters"
+  ]
+}

--- a/test/fixtures/goal_loop/observe.startup.json
+++ b/test/fixtures/goal_loop/observe.startup.json
@@ -1,0 +1,69 @@
+{
+  "files": [
+    "fixtures/live-startup.log"
+  ],
+  "matched_lines": 79,
+  "patterns": {
+    "alive_but_stuck": {
+      "count": 6,
+      "samples": [
+        {
+          "line": "[WARN] [Keeper] nick0cave: alive-but-stuck detected (elapsed=924857s, threshold=1800s)",
+          "line_no": 31
+        }
+      ],
+      "severity": "critical"
+    },
+    "config_unknown_key": {
+      "count": 2,
+      "samples": [
+        {
+          "line": "[WARN] [Keeper] keeper TOML jobsian_purist.toml has unknown keys: keeper.base",
+          "line_no": 58
+        }
+      ],
+      "severity": "warning"
+    },
+    "credential_archived_starvation": {
+      "count": 14,
+      "samples": [
+        {
+          "line": "[WARN] [Auth] archived credential analyst (reason: bare-form keeper credential is dead after PR-3b1 starvation)",
+          "line_no": 24
+        }
+      ],
+      "severity": "critical"
+    },
+    "governance_unparseable": {
+      "count": 1,
+      "samples": [
+        {
+          "line": "[WARN] [Governance] Governance judge returned unparseable response",
+          "line_no": 49
+        }
+      ],
+      "severity": "warning"
+    },
+    "lenient_json_fallback": {
+      "count": 1,
+      "samples": [
+        {
+          "line": "[WARN] [Governance] Lenient_json fallback hit; 3809 chars",
+          "line_no": 50
+        }
+      ],
+      "severity": "warning"
+    },
+    "provider_health_skipped": {
+      "count": 55,
+      "samples": [
+        {
+          "line": "{\"status\":\"skipped\",\"error\":\"runtime provider health is advisory; bootstrap skips live probe\"}",
+          "line_no": 4
+        }
+      ],
+      "severity": "critical"
+    }
+  },
+  "total_lines": 50005
+}

--- a/test/fixtures/goal_loop/orient.startup.json
+++ b/test/fixtures/goal_loop/orient.startup.json
@@ -1,0 +1,155 @@
+{
+  "findings": [
+    {
+      "count": 0,
+      "finding_id": "R-FATAL-1",
+      "patterns": [
+        "keeper_skipping_turn"
+      ],
+      "samples": [],
+      "severity": "critical",
+      "status": "EVIDENCE_ABSENT",
+      "title": "keeper_semaphore_wait_no_fallback"
+    },
+    {
+      "count": 0,
+      "finding_id": "CF-1",
+      "patterns": [
+        "pricing_catalog_miss"
+      ],
+      "samples": [],
+      "severity": "critical",
+      "status": "EVIDENCE_ABSENT",
+      "title": "pricing_catalog_miss"
+    },
+    {
+      "count": 55,
+      "finding_id": "NF-1",
+      "patterns": [
+        "provider_health_skipped"
+      ],
+      "samples": [
+        {
+          "line": "{\"status\":\"skipped\",\"error\":\"runtime provider health is advisory; bootstrap skips live probe\"}",
+          "line_no": 4
+        }
+      ],
+      "severity": "critical",
+      "status": "EVIDENCE_PRESENT",
+      "title": "provider_health_skipped_all_models"
+    },
+    {
+      "count": 14,
+      "finding_id": "NF-2",
+      "patterns": [
+        "credential_archived_starvation"
+      ],
+      "samples": [
+        {
+          "line": "[WARN] [Auth] archived credential analyst (reason: bare-form keeper credential is dead after PR-3b1 starvation)",
+          "line_no": 24
+        }
+      ],
+      "severity": "critical",
+      "status": "EVIDENCE_PRESENT",
+      "title": "credential_archived_all_keepers"
+    },
+    {
+      "count": 6,
+      "finding_id": "NF-3",
+      "patterns": [
+        "alive_but_stuck"
+      ],
+      "samples": [
+        {
+          "line": "[WARN] [Keeper] nick0cave: alive-but-stuck detected (elapsed=924857s, threshold=1800s)",
+          "line_no": 31
+        }
+      ],
+      "severity": "critical",
+      "status": "EVIDENCE_PRESENT",
+      "title": "alive_but_stuck_no_recovery"
+    },
+    {
+      "count": 2,
+      "finding_id": "NF-4",
+      "patterns": [
+        "governance_unparseable",
+        "lenient_json_fallback"
+      ],
+      "samples": [
+        {
+          "line": "[WARN] [Governance] Governance judge returned unparseable response",
+          "line_no": 49
+        },
+        {
+          "line": "[WARN] [Governance] Lenient_json fallback hit; 3809 chars",
+          "line_no": 50
+        }
+      ],
+      "severity": "warning",
+      "status": "EVIDENCE_PRESENT",
+      "title": "governance_judge_unparseable_fallback"
+    },
+    {
+      "count": 0,
+      "finding_id": "NF-5",
+      "patterns": [
+        "autoboot_warmup"
+      ],
+      "samples": [],
+      "severity": "warning",
+      "status": "EVIDENCE_ABSENT",
+      "title": "autoboot_warmup_delay"
+    },
+    {
+      "count": 2,
+      "finding_id": "NF-6",
+      "patterns": [
+        "config_unknown_key"
+      ],
+      "samples": [
+        {
+          "line": "[WARN] [Keeper] keeper TOML jobsian_purist.toml has unknown keys: keeper.base",
+          "line_no": 58
+        }
+      ],
+      "severity": "warning",
+      "status": "EVIDENCE_PRESENT",
+      "title": "config_unknown_keys_ignored"
+    },
+    {
+      "count": 0,
+      "finding_id": "NF-7",
+      "patterns": [
+        "tool_policy_unknown_tools"
+      ],
+      "samples": [],
+      "severity": "warning",
+      "status": "EVIDENCE_ABSENT",
+      "title": "tool_policy_unknown_tools"
+    },
+    {
+      "count": 0,
+      "finding_id": "NF-8",
+      "patterns": [
+        "keeper_checkpoint_migration_data_loss"
+      ],
+      "samples": [],
+      "severity": "critical",
+      "status": "EVIDENCE_ABSENT",
+      "title": "keeper_checkpoint_migration_data_loss"
+    }
+  ],
+  "matched_lines": 79,
+  "source_files": [
+    "fixtures/live-startup.log"
+  ],
+  "summary": {
+    "critical_present": 3,
+    "evidence_absent": 5,
+    "evidence_present": 5,
+    "findings_total": 10
+  },
+  "total_lines": 50005
+}

--- a/test/fixtures/goal_loop/verify.fail.json
+++ b/test/fixtures/goal_loop/verify.fail.json
@@ -1,0 +1,15 @@
+{
+  "failing_findings": [
+    {
+      "finding_id": "NF-2",
+      "reason": "D-EMERGENCY-1 still has no linked ACT artifact"
+    }
+  ],
+  "status": "FAIL",
+  "violations": [
+    {
+      "decision_id": "D-EMERGENCY-1",
+      "kind": "act_missing"
+    }
+  ]
+}

--- a/test/test_decide_goal_loop_findings.py
+++ b/test/test_decide_goal_loop_findings.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "decide_goal_loop_findings.py"
+FIXTURE_DIR = REPO_ROOT / "test" / "fixtures" / "goal_loop"
 
 spec = importlib.util.spec_from_file_location("decide_goal_loop_findings", SCRIPT_PATH)
 assert spec is not None
@@ -66,9 +67,7 @@ class DecideGoalLoopFindingsTest(unittest.TestCase):
             act_map={},
         )
 
-        self.assertTrue(
-            decide_goal_loop_findings.should_fail(report, "missing-act")
-        )
+        self.assertTrue(decide_goal_loop_findings.should_fail(report, "missing-act"))
 
     def test_cli_accepts_act_map_and_reports_missing_count(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:
@@ -108,6 +107,30 @@ class DecideGoalLoopFindingsTest(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn('"act_linked_count": 1', result.stdout)
         self.assertIn('"act_missing_count": 1', result.stdout)
+
+    def test_startup_fixture_keeps_unlinked_emergency_action_visible(self) -> None:
+        orient = json.loads((FIXTURE_DIR / "orient.startup.json").read_text())
+        act_map = decide_goal_loop_findings.load_act_map_input(
+            str(FIXTURE_DIR / "act-map.startup.json")
+        )
+
+        report = decide_goal_loop_findings.decide_orient(
+            orient,
+            act_map=act_map,
+        )
+        by_id = {decision.decision_id: decision for decision in report.decisions}
+
+        self.assertEqual(report.decisions_total, 5)
+        self.assertEqual(report.act_linked_count, 4)
+        self.assertEqual(report.act_missing_count, 1)
+        self.assertEqual(
+            by_id["D-EMERGENCY-1"].act_status,
+            "ACT_MISSING",
+        )
+        self.assertEqual(
+            by_id["D-P1-1"].act_artifacts,
+            ["PR#13123 alive-stuck recovery"],
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_goal_loop_status.py
+++ b/test/test_goal_loop_status.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "goal_loop_status.py"
+DECIDE_SCRIPT_PATH = REPO_ROOT / "scripts" / "decide_goal_loop_findings.py"
+FIXTURE_DIR = REPO_ROOT / "test" / "fixtures" / "goal_loop"
 
 spec = importlib.util.spec_from_file_location("goal_loop_status", SCRIPT_PATH)
 assert spec is not None
@@ -81,9 +83,7 @@ class GoalLoopStatusTest(unittest.TestCase):
         self.assertEqual(report.phases["act"].summary["act_missing_count"], 1)
         self.assertEqual(report.next_action["decision_id"], "D-P1-1")
         self.assertEqual(
-            report.system_health_signals["keeper_failure_patterns"][
-                "alive_but_stuck"
-            ],
+            report.system_health_signals["keeper_failure_patterns"]["alive_but_stuck"],
             2,
         )
 
@@ -126,7 +126,9 @@ class GoalLoopStatusTest(unittest.TestCase):
         )
 
         self.assertEqual(report.overall_status, "unknown")
-        self.assertEqual(report.phases["observe"].summary["reason"], "observe_json_missing")
+        self.assertEqual(
+            report.phases["observe"].summary["reason"], "observe_json_missing"
+        )
         self.assertEqual(report.phases["verify"].status, "unknown")
 
     def test_unknown_phase_prevents_overall_ok(self) -> None:
@@ -239,6 +241,59 @@ class GoalLoopStatusTest(unittest.TestCase):
 
         payload = json.loads(goal_loop_status.report_to_json(report))
         self.assertEqual(payload, asdict(report))
+
+    def test_fixture_bundle_reports_act_gap_from_decide_output(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            decide_path = Path(raw_dir) / "decide.json"
+            decide_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(DECIDE_SCRIPT_PATH),
+                    str(FIXTURE_DIR / "orient.startup.json"),
+                    "--act-map",
+                    str(FIXTURE_DIR / "act-map.startup.json"),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(decide_result.returncode, 0, decide_result.stderr)
+            decide_path.write_text(decide_result.stdout, encoding="utf-8")
+
+            status_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--observe-json",
+                    str(FIXTURE_DIR / "observe.startup.json"),
+                    "--orient-json",
+                    str(FIXTURE_DIR / "orient.startup.json"),
+                    "--decide-json",
+                    str(decide_path),
+                    "--verify-json",
+                    str(FIXTURE_DIR / "verify.fail.json"),
+                    "--loop-iteration",
+                    "#fixture",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(status_result.returncode, 0, status_result.stderr)
+        payload = json.loads(status_result.stdout)
+        self.assertEqual(payload["overall_status"], "critical")
+        self.assertEqual(payload["loop_iteration"], "#fixture")
+        self.assertEqual(payload["phases"]["decide"]["summary"]["act_linked_count"], 4)
+        self.assertEqual(payload["phases"]["act"]["summary"]["act_missing_count"], 1)
+        self.assertEqual(
+            payload["system_health_signals"]["keeper_failure_patterns"][
+                "credential_archived_starvation"
+            ],
+            14,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds startup GOAL LOOP fixture JSON for Observe, Orient, ACT map, and Verify, plus integration tests that feed Decide output into the aggregate status report. Validation: npx pyright --outputjson test/test_decide_goal_loop_findings.py test/test_goal_loop_status.py; ruff check test/test_decide_goal_loop_findings.py test/test_goal_loop_status.py; ruff format --check test/test_decide_goal_loop_findings.py test/test_goal_loop_status.py; python3 test/test_decide_goal_loop_findings.py; python3 test/test_goal_loop_status.py; git diff --check origin/main...HEAD.