### PR TITLE
fix(ide): register discovered repositories

### DIFF
--- a/dashboard/src/api/repositories.test.ts
+++ b/dashboard/src/api/repositories.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { discoverRepositories, fetchRepositoriesList } from './repositories'
+
+const mockFetch = vi.fn()
+
+afterEach(() => {
+  mockFetch.mockClear()
+  vi.unstubAllGlobals()
+})
+
+function stubFetch(response: unknown): void {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    json: () => Promise.resolve(response),
+    text: () => Promise.resolve(JSON.stringify(response)),
+    clone() { return this },
+  } as Response)
+  vi.stubGlobal('fetch', mockFetch)
+}
+
+describe('repositories API', () => {
+  it('fetchRepositoriesList reads the configured repositories', async () => {
+    stubFetch({
+      repositories: [
+        {
+          id: 'masc',
+          name: 'masc-mcp',
+          local_path: '/Users/dancer/me/workspace/yousleepwhen/masc-mcp',
+          status: 'active',
+        },
+      ],
+    })
+
+    const repos = await fetchRepositoriesList()
+
+    expect(mockFetch.mock.calls[0]![0]).toBe('/api/v1/repositories')
+    expect(repos).toHaveLength(1)
+    expect(repos[0]!.id).toBe('masc')
+    expect(repos[0]!.default_branch).toBe('main')
+  })
+
+  it('discoverRepositories registers discovered repositories through the backend', async () => {
+    stubFetch({
+      repositories: [
+        {
+          id: 'me',
+          name: 'me',
+          local_path: '/Users/dancer/me',
+          status: 'active',
+        },
+      ],
+      discovered: true,
+      registered: true,
+    })
+
+    const repos = await discoverRepositories()
+    const call = mockFetch.mock.calls[0]!
+    const init = call[1] as RequestInit
+
+    expect(call[0]).toBe('/api/v1/repositories/discover')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe(JSON.stringify({}))
+    expect(repos).toHaveLength(1)
+    expect(repos[0]!.id).toBe('me')
+    expect(repos[0]!.local_path).toBe('/Users/dancer/me')
+  })
+})

--- a/dashboard/src/api/repositories.ts
+++ b/dashboard/src/api/repositories.ts
@@ -1,4 +1,4 @@
-import { get, type GetOptions } from './core'
+import { get, post, type GetOptions } from './core'
 
 export type RepoStatus = 'active' | 'paused' | 'error'
 
@@ -59,5 +59,10 @@ export function normalizeRepository(raw: unknown): Repository | null {
 
 export async function fetchRepositoriesList(opts: GetOptions = {}): Promise<Repository[]> {
   const raw = await get<unknown>('/api/v1/repositories', opts)
+  return repositoryRows(raw).map(normalizeRepository).filter((r): r is Repository => r !== null)
+}
+
+export async function discoverRepositories(): Promise<Repository[]> {
+  const raw = await post<unknown>('/api/v1/repositories/discover', {})
   return repositoryRows(raw).map(normalizeRepository).filter((r): r is Repository => r !== null)
 }

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -2,6 +2,7 @@ import { signal, effect } from '@preact/signals'
 import { activeIdeFile } from './ide-shell'
 import { activeKeeperName } from '../../keeper-state'
 import {
+  discoverRepositories,
   fetchRepositoriesList,
   type Repository,
 } from '../../api/repositories'
@@ -38,6 +39,7 @@ export interface IdeDataCoordinator {
   readonly repositories: () => ReadonlyArray<Repository>
   readonly activeRepositoryId: () => string | null
   readonly setActiveRepositoryId: (repoId: string | null) => void
+  readonly scanRepositories: () => Promise<ReadonlyArray<Repository>>
   readonly subscribeRepositories: (listener: () => void) => () => void
   readonly dispose: () => void
 }
@@ -63,11 +65,28 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
 
   let abortController = new AbortController()
 
-  fetchRepositoriesList()
-    .then(repositories => {
-      activeRepositoryIdSignal.value = repositories[0]?.id ?? null
-      repositoriesSignal.value = repositories
-    })
+  const applyRepositories = (repositories: ReadonlyArray<Repository>): void => {
+    const current = activeRepositoryIdSignal.value
+    const nextActive = current && repositories.some(repository => repository.id === current)
+      ? current
+      : repositories[0]?.id ?? null
+    activeRepositoryIdSignal.value = nextActive
+    repositoriesSignal.value = repositories
+  }
+
+  const refreshRepositories = async (): Promise<ReadonlyArray<Repository>> => {
+    const repositories = await fetchRepositoriesList()
+    applyRepositories(repositories)
+    return repositories
+  }
+
+  const scanRepositories = async (): Promise<ReadonlyArray<Repository>> => {
+    const registered = await discoverRepositories()
+    await refreshRepositories()
+    return registered
+  }
+
+  refreshRepositories()
     .catch(() => {
       repositoriesSignal.value = []
     })
@@ -153,6 +172,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     setActiveRepositoryId: (repoId: string | null) => {
       activeRepositoryIdSignal.value = repoId
     },
+    scanRepositories,
     subscribeRepositories: (listener: () => void) =>
       repositoriesSignal.subscribe(listener),
     dispose: () => {

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -1,10 +1,12 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
+import { Search } from 'lucide-preact'
 import { activeKeeperName } from '../../keeper-state'
 import { type FileTreeStore, type FileTreeNode } from './file-tree-store'
 import { activeIdeFile } from './ide-shell'
 import type { WorkspaceSource } from '../../api/workspace-source'
 import type { Repository } from '../../api/repositories'
+import { showToast } from '../common/toast'
 
 interface IdeExplorerProps {
   readonly fileTreeStore: FileTreeStore
@@ -19,6 +21,7 @@ interface IdeExplorerProps {
   readonly repositories?: () => ReadonlyArray<Repository>
   readonly activeRepositoryId?: () => string | null
   readonly onRepositoryChange?: (repoId: string | null) => void
+  readonly onRepositoryScan?: () => Promise<ReadonlyArray<Repository>>
   readonly subscribeRepositories?: (listener: () => void) => () => void
 }
 
@@ -29,6 +32,7 @@ export function IdeExplorer({
   repositories,
   activeRepositoryId,
   onRepositoryChange,
+  onRepositoryScan,
   subscribeRepositories,
 }: IdeExplorerProps) {
   const [keeperName, setKeeperName] = useState(activeKeeperName.value)
@@ -63,6 +67,27 @@ export function IdeExplorer({
   }, [store])
 
   const [filter, setFilter] = useState('')
+  const [isScanningRepositories, setIsScanningRepositories] = useState(false)
+
+  const handleRepositoryScan = async (): Promise<void> => {
+    if (!onRepositoryScan || isScanningRepositories) return
+    setIsScanningRepositories(true)
+    try {
+      const registered = await onRepositoryScan()
+      showToast(
+        registered.length > 0
+          ? `${registered.length}개 저장소 등록 완료`
+          : '새 저장소 없음',
+        'success',
+      )
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '저장소 스캔 실패'
+      showToast(msg, 'error')
+      throw err
+    } finally {
+      setIsScanningRepositories(false)
+    }
+  }
 
   // useMemo over `tick` so the visibleNodes call re-runs when the
   // store's expansion state changes; tick reference is intentional.
@@ -102,8 +127,8 @@ export function IdeExplorer({
         <span>EXPLORER ${keeperName ? html`· <span style=${{ color: 'var(--color-accent-fg)' }}>@${keeperName}</span>` : '· project'}</span>
         <span>${fileCount} FILES</span>
       </header>
-      ${repoList.length > 0 ? html`
-        <label
+      ${repoList.length > 0 || onRepositoryScan ? html`
+        <div
           style=${{
             display: 'grid',
             gap: 'var(--sp-1)',
@@ -111,33 +136,82 @@ export function IdeExplorer({
             font: 'var(--type-eyebrow)',
           }}
         >
-          Repository
-          <select
-            aria-label="IDE repository"
-            value=${selectedRepoId ?? repoList[0]?.id ?? ''}
-            onChange=${(event: Event) => {
-              const next = (event.currentTarget as HTMLSelectElement).value || null
-              setSelectedRepoId(next)
-              onRepositoryChange?.(next)
-            }}
+          <div
             style=${{
-              width: '100%',
-              font: 'var(--type-body)',
-              fontSize: 'var(--fs-11)',
-              color: 'var(--color-fg-primary)',
-              background: 'var(--color-bg-elevated)',
-              border: '1px solid var(--color-border-default)',
-              borderRadius: 'var(--r-1)',
-              padding: 'var(--sp-1) var(--sp-2)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 'var(--sp-2)',
             }}
           >
-            ${repoList.map(repository => html`
-              <option key=${repository.id} value=${repository.id}>
-                ${repository.name} · ${repository.local_path}
-              </option>
-            `)}
-          </select>
-        </label>
+            <span>Repository</span>
+            ${onRepositoryScan ? html`
+              <button
+                type="button"
+                title="base path 아래 git 저장소 스캔"
+                aria-label="base path 아래 git 저장소 스캔"
+                disabled=${isScanningRepositories}
+                onClick=${() => { void handleRepositoryScan() }}
+                style=${{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 'var(--sp-1)',
+                  height: '22px',
+                  padding: '0 var(--sp-2)',
+                  color: isScanningRepositories ? 'var(--color-fg-muted)' : 'var(--color-accent-fg)',
+                  background: 'var(--color-bg-elevated)',
+                  border: '1px solid var(--color-border-default)',
+                  borderRadius: 'var(--r-1)',
+                  cursor: isScanningRepositories ? 'not-allowed' : 'pointer',
+                  opacity: isScanningRepositories ? 0.65 : 1,
+                  font: 'var(--type-eyebrow)',
+                }}
+              >
+                <${Search} size=${12} aria-hidden="true" />
+                ${isScanningRepositories ? '스캔 중' : '스캔'}
+              </button>
+            ` : null}
+          </div>
+          ${repoList.length > 0 ? html`
+            <select
+              aria-label="IDE repository"
+              value=${selectedRepoId ?? repoList[0]?.id ?? ''}
+              onChange=${(event: Event) => {
+                const next = (event.currentTarget as HTMLSelectElement).value || null
+                setSelectedRepoId(next)
+                onRepositoryChange?.(next)
+              }}
+              style=${{
+                width: '100%',
+                font: 'var(--type-body)',
+                fontSize: 'var(--fs-11)',
+                color: 'var(--color-fg-primary)',
+                background: 'var(--color-bg-elevated)',
+                border: '1px solid var(--color-border-default)',
+                borderRadius: 'var(--r-1)',
+                padding: 'var(--sp-1) var(--sp-2)',
+              }}
+            >
+              ${repoList.map(repository => html`
+                <option key=${repository.id} value=${repository.id}>
+                  ${repository.name} · ${repository.local_path}
+                </option>
+              `)}
+            </select>
+          ` : html`
+            <div
+              role="status"
+              style=${{
+                font: 'var(--type-body)',
+                fontSize: 'var(--fs-11)',
+                color: 'var(--color-fg-muted)',
+                background: 'var(--color-bg-muted)',
+                borderRadius: 'var(--r-1)',
+                padding: 'var(--sp-1) var(--sp-2)',
+              }}
+            >저장소 없음</div>
+          `}
+        </div>
       ` : null}
       ${SourceHint(source)}
       <input

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -126,6 +126,7 @@ export function IdeShell() {
             repositories=${coordinator.repositories}
             activeRepositoryId=${coordinator.activeRepositoryId}
             onRepositoryChange=${coordinator.setActiveRepositoryId}
+            onRepositoryScan=${coordinator.scanRepositories}
             subscribeRepositories=${coordinator.subscribeRepositories}
           />
         </div>

--- a/dashboard/src/components/repo-sidebar.ts
+++ b/dashboard/src/components/repo-sidebar.ts
@@ -5,6 +5,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { authHeaders, post } from '../api/core'
 import {
+  discoverRepositories,
   fetchRepositoriesList,
   type Repository,
   type RepoStatus,
@@ -12,10 +13,11 @@ import {
 import { createAsyncResource } from '../lib/async-state'
 import { LoadingState, ErrorState } from './common/feedback-state'
 import { showToast } from './common/toast'
-import { Plus, GitBranch, AlertCircle, PauseCircle, CheckCircle2 } from 'lucide-preact'
+import { Plus, GitBranch, AlertCircle, PauseCircle, CheckCircle2, Search } from 'lucide-preact'
 
 export type { Repository, RepoStatus } from '../api/repositories'
 export {
+  discoverRepositories,
   normalizeRepoStatus,
   repositoryRows,
   normalizeRepository,
@@ -27,6 +29,7 @@ const reposResource = createAsyncResource<Repository[]>()
 const reposState = reposResource.state
 export const selectedRepoId = signal<string | null>(null)
 export const showAddRepoDialog = signal(false)
+export const isScanningRepositories = signal(false)
 
 // ── API ──────────────────────────────────────────────────
 
@@ -66,6 +69,27 @@ export async function deleteRepository(id: string): Promise<void> {
     const msg = err instanceof Error ? err.message : '삭제 실패'
     showToast(msg, 'error')
     throw err
+  }
+}
+
+export async function scanRepositories(): Promise<void> {
+  if (isScanningRepositories.value) return
+  isScanningRepositories.value = true
+  try {
+    const registered = await discoverRepositories()
+    await fetchRepositories()
+    showToast(
+      registered.length > 0
+        ? `${registered.length}개 저장소 등록 완료`
+        : '새 저장소 없음',
+      'success',
+    )
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '저장소 스캔 실패'
+    showToast(msg, 'error')
+    throw err
+  } finally {
+    isScanningRepositories.value = false
   }
 }
 
@@ -151,14 +175,27 @@ export function RepoSidebar() {
         <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">
           저장소 <span class="text-[var(--color-fg-muted)] font-normal">(${repos.length})</span>
         </span>
-        <button
-          type="button"
-          class="flex items-center gap-1 text-2xs px-2 py-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-accent-fg)] cursor-pointer transition-colors"
-          onClick=${() => { showAddRepoDialog.value = true }}
-        >
-          <${Plus} size=${12} aria-hidden="true" />
-          추가
-        </button>
+        <div class="flex items-center gap-1">
+          <button
+            type="button"
+            title="base path 아래 git 저장소 스캔"
+            aria-label="base path 아래 git 저장소 스캔"
+            disabled=${isScanningRepositories.value}
+            class="flex items-center gap-1 text-2xs px-2 py-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-accent-fg)] disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer transition-colors"
+            onClick=${() => { void scanRepositories() }}
+          >
+            <${Search} size=${12} aria-hidden="true" />
+            ${isScanningRepositories.value ? '스캔 중' : '스캔'}
+          </button>
+          <button
+            type="button"
+            class="flex items-center gap-1 text-2xs px-2 py-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-accent-fg)] cursor-pointer transition-colors"
+            onClick=${() => { showAddRepoDialog.value = true }}
+          >
+            <${Plus} size=${12} aria-hidden="true" />
+            추가
+          </button>
+        </div>
       </div>
 
       <div class="flex-1 overflow-y-auto py-1">

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -375,7 +375,7 @@ let handle_sync_repository state _agent_name req reqd =
 
 let handle_discover_repositories state _agent_name req reqd =
   let base_path = base_path_of_state state in
-  match Repo_store.discover_repositories ~base_path with
+  match Repo_store.register_discovered ~base_path with
   | Error msg ->
       json_response ~status:`Internal_server_error req reqd (json_error msg)
   | Ok repos ->
@@ -385,6 +385,7 @@ let handle_discover_repositories state _agent_name req reqd =
             ("repositories", `List (List.map repository_json repos));
             ("total", `Int (List.length repos));
             ("discovered", `Bool true);
+            ("registered", `Bool true);
           ]
       in
       Http.Response.json ~request:req (Yojson.Safe.to_string json) reqd


### PR DESCRIPTION
## Summary
- make `POST /api/v1/repositories/discover` persist discovered git repos via `Repo_store.register_discovered`
- add dashboard repository discovery API wiring plus scan controls in both Repository management and the Code IDE explorer
- keep the IDE selector usable even when the configured repository list is empty, so operators can scan the active base path from the broken surface itself

## Why it matters
The Code IDE was only reading already-configured repositories. A git repo under the active base path could be discovered by backend code but never registered through the dashboard path, leaving the IDE selector/tree stuck on stale config or fallback/base-path behavior. This makes discovery an explicit admin action and refreshes the IDE list immediately after registration.

## Validation
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/repositories.test.ts src/components/repo-sidebar.test.ts src/api/workspace.test.ts src/api/git-graph.test.ts src/router.test.ts src/config/navigation.test.ts`
- `scripts/dune-local.sh build test/test_repo_store.exe bin/main_eio.exe`
- `./_build/default/test/test_repo_store.exe`
- `git diff --check`
- live temp-base proof: `POST /api/v1/repositories/discover` returned `registered: true`, persisted `[repository.example]`, and `workspace/tree?repo_id=example` returned `README.md`
- browser proof: Code IDE explorer shows the scan button beside the repository selector/empty state

## Notes
- Local opam switch was bumped with `scripts/opam-pin-external-deps.sh --install` because latest `origin/main` requires `agent_sdk >= 0.190.7`.
