### PR TITLE
fix(test): exhaustive match on Keeper_event_queue.classify variants

### DIFF
--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -10,7 +10,11 @@ let () =
    | Board_signal -> ()
    | other ->
      Alcotest.fail (Printf.sprintf "expected Board_signal, got %s"
-       (match other with Bootstrap -> "Bootstrap" | Unsupported s -> "Unsupported("^s^")" | Board_signal -> "Board_signal")));
+       (match other with
+        | Bootstrap -> "Bootstrap"
+        | Unsupported s -> "Unsupported("^s^")"
+        | Board_signal -> "Board_signal"
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
 
   let live_comment_payload =
     {|{"source":"board_signal","kind":"comment","post_id":"p2","author":"alice","title":"Long board event","content":"this mirrors the long live payload that used to miss the prefix check","hearth":null,"wake_reason":"scope_message"}|}
@@ -22,7 +26,11 @@ let () =
    | Board_signal -> ()
    | other ->
      Alcotest.fail (Printf.sprintf "expected live comment Board_signal, got %s"
-       (match other with Bootstrap -> "Bootstrap" | Unsupported s -> "Unsupported("^s^")" | Board_signal -> "Board_signal")));
+       (match other with
+        | Bootstrap -> "Bootstrap"
+        | Unsupported s -> "Unsupported("^s^")"
+        | Board_signal -> "Board_signal"
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
 
   (* --- classify: bootstrap --- *)
   let bootstrap_stim = {
@@ -33,7 +41,11 @@ let () =
    | Bootstrap -> ()
    | other ->
      Alcotest.fail (Printf.sprintf "expected Bootstrap, got %s"
-       (match other with Board_signal -> "Board_signal" | Unsupported s -> "Unsupported("^s^")" | Bootstrap -> "Bootstrap")));
+       (match other with
+        | Board_signal -> "Board_signal"
+        | Unsupported s -> "Unsupported("^s^")"
+        | Bootstrap -> "Bootstrap"
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
 
   (* --- classify: unsupported --- *)
   let unknown_stim = {
@@ -63,7 +75,11 @@ let () =
    | Unsupported _ -> ()
    | other ->
      Alcotest.fail (Printf.sprintf "empty payload should be Unsupported, got %s"
-       (match other with Board_signal -> "Board_signal" | Bootstrap -> "Bootstrap" | Unsupported _ -> "Unsupported")));
+       (match other with
+        | Board_signal -> "Board_signal"
+        | Bootstrap -> "Bootstrap"
+        | Unsupported _ -> "Unsupported"
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
 
   (* --- queue operations preserved --- *)
   let q = empty in


### PR DESCRIPTION
## Summary

`Keeper_event_queue.classify` 의 새 variant `Alive_but_stuck_recovery` (lib/keeper/keeper_event_queue.ml:58, #12838 follow-up) 가 추가됐지만 `test/test_keeper_event_queue.ml` 의 4개 \`match other with ...\` arm이 stale.

main root \`_build\` 캐시 hit으로 통과하지만 cold-start (별도 build dir, CI) 에서는 dune flag로 warning 8 [partial-match] error 승격되어 fail.

4 site 모두에 \`Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"\` arm 추가.

## Caller verification

\`\`\`
$ rg -n 'Alive_but_stuck_recovery' lib test
lib/keeper/keeper_event_queue.ml:58   (variant 정의)
lib/keeper/keeper_event_queue.ml:70   (classify 사용)
lib/keeper/keeper_alive_but_stuck.ml:* (consumer)
test/test_keeper_event_queue.ml:17,33,48,82  (after fix — was missing)
\`\`\`

## Test plan

- [x] \`dune build --root <worktree> --build-dir /tmp/cold-cache test/test_keeper_event_queue.exe\` — silent success (0 lines)
- [x] push 직전 same-axis sweep clean (\`gh pr list --search\` 0건, main 머지 15분 0건)
- [ ] CI Build/Test green

## Notes

- 같은 fresh-build run에서 \`test/test_per_keeper_token_fallback.ml:131\` \`Oas_worker_exec.codex_cli_can_auth_keeper_bound_runtime_mcp\` unbound 에러도 surface됐지만:
  - lib/oas_worker_exec.mli:189 + lib/oas_worker_exec.ml:169-170 alias 정상
  - main root의 \`_build/default/test/test_per_keeper_token_fallback.exe\` 는 7:52PM 정상 빌드
  - main_eio.exe 8:07PM 정상 빌드 = lib level OK
  - 다른 16개 alias (line 160-200) 동일 패턴인데 그 함수만 fail = fresh build dir cold-start dune quirk 추정
  - 본 PR scope 밖 — CI 결과로 추가 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)