### PR TITLE
fix(dashboard): address board hearth review feedback

### DIFF
--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -365,7 +365,7 @@ export async function submitComment(postId: string, parentId?: string) {
 export async function submitNewPost() {
   const title = newPostTitle.value.trim()
   const content = newPostContent.value.trim()
-  const hearth = newPostHearth.value.trim() || boardHearthFilter.value.trim()
+  const hearth = newPostHearth.value.trim()
   if (!title || !content) return
   newPostSubmitting.value = true
   try {

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -1,10 +1,10 @@
 import { h } from 'preact'
-import { fireEvent, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
 import { route } from '../../router'
-import { boardHearths, contentCategory, newPostHearth } from './board-state'
+import { boardHearths, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -128,7 +128,10 @@ describe('BoardSurface Component', () => {
   // PR #13152 review: vi.stubGlobal('fetch') in beforeEach without a matching
   // unstub leaks the mocked fetch into later tests in the same worker.  Add
   // an explicit afterEach that restores all stubbed globals.
-  afterEach(() => {
+  afterEach(async () => {
+    cleanup()
+    await vi.dynamicImportSettled()
+    await Promise.resolve()
     vi.unstubAllGlobals()
   })
 
@@ -149,7 +152,9 @@ describe('BoardSurface Component', () => {
     boardAuthorFilter.value = ''
     boardHearthFilter.value = ''
     boardHearths.value = [{ name: 'ops', count: 0 }]
+    showNewPostForm.value = false
     newPostHearth.value = ''
+    newPostSubmitting.value = false
     route.value = { params: {} } as any
   })
 
@@ -233,5 +238,14 @@ describe('BoardSurface Component', () => {
 
     expect(screen.getByLabelText('새 글 hearth')).toHaveValue('ops')
     expect(newPostHearth.value).toBe('ops')
+  })
+
+  it('disables compose cancel while a post is submitting', () => {
+    showNewPostForm.value = true
+    newPostSubmitting.value = true
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByRole('button', { name: '취소' })).toBeDisabled()
   })
 })

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -243,7 +243,8 @@ function NewPostForm() {
       />
       <div class="flex gap-2 justify-end">
         <button type="button"
-          class="px-3 py-1.5 rounded-[var(--r-1)] text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-hover)]"
+          class="px-3 py-1.5 rounded-[var(--r-1)] text-sm border border-[var(--color-border-default)] bg-transparent text-[var(--color-fg-muted)] cursor-pointer hover:bg-[var(--color-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled=${newPostSubmitting.value}
           onClick=${() => {
             showNewPostForm.value = false
             newPostTitle.value = ''

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -268,6 +268,8 @@ describe('setupSSEReaction reconnect hydration', () => {
 
   it('keeps optimistic post_created hydration inside the active hearth filter', async () => {
     const { sseStore } = await loadSseStore()
+    const refreshHearths = vi.fn()
+    sseStore.registerBoardHearthsRefresh(refreshHearths)
     route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
     boardHearthFilter.value = 'ops'
 
@@ -284,6 +286,7 @@ describe('setupSSEReaction reconnect hydration', () => {
 
     expect(boardPosts.value).toEqual([])
     expect(refreshBoard).toHaveBeenCalledTimes(1)
+    expect(refreshHearths).toHaveBeenCalledTimes(1)
   })
 
   it('refreshes hearth chips when an optimistic board post carries a hearth', async () => {
@@ -299,6 +302,7 @@ describe('setupSSEReaction reconnect hydration', () => {
       title: 'Ops note',
       content: 'body',
       author: 'agent-a',
+      post_kind: 'automation',
       hearth: 'ops',
     })
     vi.advanceTimersByTime(1_000)
@@ -306,8 +310,27 @@ describe('setupSSEReaction reconnect hydration', () => {
 
     expect(boardPosts.value[0]?.id).toBe('post-1')
     expect(boardPosts.value[0]?.hearth).toBe('ops')
+    expect(boardPosts.value[0]?.post_kind).toBe('automation')
     expect(refreshBoard).not.toHaveBeenCalled()
     expect(refreshHearths).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refresh hearth chips for comment-only board events', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshHearths = vi.fn()
+    sseStore.registerBoardHearthsRefresh(refreshHearths)
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'comment_added',
+      post_id: 'post-1',
+      comment_id: 'comment-1',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshBoard).toHaveBeenCalledTimes(1)
+    expect(refreshHearths).not.toHaveBeenCalled()
   })
 
   it('keeps websocket raw push refreshes hidden when the route does not need that surface', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -154,6 +154,12 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   activity:             { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
 }
 
+const BOARD_HEARTH_REFRESH_EVENTS = new Set([
+  'masc/board_post',
+  'masc/board_delete',
+  'post_created',
+])
+
 // Prefix patterns for events that use startsWith matching
 const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
   { prefix: 'task_',      target: 'execution' },
@@ -163,10 +169,7 @@ const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
 
 const REFRESH_FNS: Record<RefreshTarget, () => void> = {
   execution: () => { void refreshExecution() },
-  board:     () => {
-    void refreshBoard()
-    _refreshBoardHearthsFn?.()
-  },
+  board:     refreshBoard,
   operator:  () => _refreshOperatorFn?.(),
   activity:  () => {
     for (const fn of _refreshActivityFns) fn()
@@ -386,8 +389,8 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
   if (!postId || !content) return false
   if (boardPosts.value.some(p => p.id === postId)) return false
   const eventHearth = event.hearth?.trim() ?? ''
-  if (eventHearth) scheduleBoardHearthsRefresh()
   if (!eventMatchesActiveBoardFilters(event)) return false
+  if (eventHearth) scheduleBoardHearthsRefresh()
 
   const now = new Date().toISOString()
   const post: BoardPost = {
@@ -403,11 +406,17 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
     votes: 0,
     vote_balance: 0,
     comment_count: 0,
+    post_kind: boardPostKindFromEvent(event),
     hearth: eventHearth || undefined,
   }
   boardPosts.value = [post, ...boardPosts.value]
   boardOffset.value = boardPosts.value.length
   return true
+}
+
+function boardPostKindFromEvent(event: SSEEvent): BoardPost['post_kind'] {
+  const rawKind = (event.post_kind ?? 'direct').toLowerCase()
+  return rawKind === 'system' || rawKind === 'automation' ? rawKind : 'direct'
 }
 
 function eventMatchesActiveBoardFilters(event: SSEEvent): boolean {
@@ -418,8 +427,7 @@ function eventMatchesActiveBoardFilters(event: SSEEvent): boolean {
   // reconciled through the board endpoint instead of guessing client-side.
   if (boardAuthorFilter.value.trim() !== '') return false
 
-  const rawKind = (event.post_kind ?? 'direct').toLowerCase()
-  const postKind = rawKind === 'system' || rawKind === 'automation' ? rawKind : 'direct'
+  const postKind = boardPostKindFromEvent(event)
   if (postKind === 'system' && boardExcludeSystem.value) return false
   if (postKind === 'automation' && boardExcludeAutomation.value) return false
   return true
@@ -437,6 +445,9 @@ export function routeServerPushEvent(event: SSEEvent): void {
       REFRESH_FNS[simpleRoute.target],
       simpleRoute.debounceMs,
     )
+    if (BOARD_HEARTH_REFRESH_EVENTS.has(event.type)) {
+      scheduleBoardHearthsRefresh(simpleRoute.debounceMs)
+    }
   }
 
   for (const { prefix, target } of PREFIX_ROUTES) {


### PR DESCRIPTION
## Summary

This is the late review-follow-up patch for the already-merged board hearth stack:

- respect an intentionally blank compose hearth instead of falling back to the active filter
- disable compose cancel while submit is in flight
- avoid redundant hearth-chip refreshes from board SSE events
- preserve `post_kind` in optimistic board posts
- clean up the board surface test fetch stub after each test

## Why

The earlier stack shipped the core board/SNS hearth filtering and realtime refresh work, but several review comments landed after the related PRs had already merged. This PR isolates those review fixes on current `main` so the comment threads have a concrete landing patch instead of a stale pushed branch.

## Validation

- `pnpm exec vitest run src/api/board.test.ts src/components/board/board-surface.test.ts src/components/board/board-state.test.ts src/components/board/post-detail.test.ts src/sse-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/board/board-state.ts src/components/board/board-surface.ts src/components/board/board-surface.test.ts src/sse-store.ts src/sse-store.test.ts`
- `git diff --check`
