### PR TITLE
fix(dashboard): tokenize acronym prefixes + de-shadow non-finite test (post-#13170)

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -276,39 +276,60 @@ let attainment_unit_to_string = function
 let contains_ci haystack needle =
   String_util.contains_substring_ci haystack needle
 
-(* Token-split that also respects camelCase boundaries.  An uppercase
-   letter that immediately follows a lowercase letter starts a new
-   token (so "successRate" → ["success"; "rate"]) — this keeps the
-   percent-inference accurate for free-form camelCase metric names
-   while still rejecting substring false positives like "iterate"
-   matching "rate".  Consecutive uppercase letters stay in the current
-   token to avoid mangling abbreviations. *)
+(* Token-split that respects camelCase AND acronym boundaries.
+
+   - lower → upper splits (so [successRate] → [success; rate])
+   - upper → upper-followed-by-lower splits (so [APIRatio] →
+     [api; ratio]; [PRCount] → [pr; count])
+   - consecutive uppercase letters not followed by a lowercase stay
+     glued (so [API] → [api], [HTTP] → [http])
+
+   Without the acronym rule, common acronym-prefixed metric names
+   regressed against percent inference: post-#13170 review noted
+   that names like [APIRatio] / [PRCount] still missed the percent
+   token even after the camelCase fix.  The split point is the
+   *last* uppercase letter in a run — that is the start of the
+   following lowercase word — not every uppercase letter, so
+   abbreviations stay intact. *)
 let metric_word_tokens raw =
+  let len = String.length raw in
   let tokens = ref [] in
   let current = Buffer.create 16 in
-  let prev_was_lower = ref false in
   let flush () =
     if Buffer.length current > 0 then (
       tokens := Buffer.contents current :: !tokens;
-      Buffer.clear current);
-    prev_was_lower := false
+      Buffer.clear current)
   in
-  String.iter
-    (fun ch ->
-      match ch with
-      | 'A' .. 'Z' ->
-          if !prev_was_lower then flush ();
-          Buffer.add_char current (Char.lowercase_ascii ch);
-          prev_was_lower := false
-      | 'a' .. 'z' ->
-          Buffer.add_char current ch;
-          prev_was_lower := true
-      | '0' .. '9' ->
-          Buffer.add_char current ch;
-          prev_was_lower := false
-      | _ ->
-          flush ())
-    raw;
+  let is_lower c = c >= 'a' && c <= 'z' in
+  let is_upper c = c >= 'A' && c <= 'Z' in
+  let is_alpha c = is_lower c || is_upper c in
+  let next_at i = if i + 1 < len then Some raw.[i + 1] else None in
+  let prev_at i = if i > 0 then Some raw.[i - 1] else None in
+  for i = 0 to len - 1 do
+    let ch = raw.[i] in
+    match ch with
+    | 'A' .. 'Z' ->
+        let prev_lower =
+          match prev_at i with Some c -> is_lower c | None -> false
+        in
+        let next_lower =
+          match next_at i with Some c -> is_lower c | None -> false
+        in
+        let prev_was_alpha =
+          match prev_at i with Some c -> is_alpha c | None -> false
+        in
+        (* Split before this uppercase letter when:
+           1. Previous char was lowercase (camelCase: aA boundary)
+           2. Previous char was uppercase AND next char is lowercase
+              (acronym→word: end-of-acronym boundary) *)
+        if prev_lower then flush ()
+        else if prev_was_alpha && next_lower then flush ();
+        Buffer.add_char current (Char.lowercase_ascii ch)
+    | 'a' .. 'z' | '0' .. '9' ->
+        Buffer.add_char current ch
+    | _ ->
+        flush ()
+  done;
   flush ();
   List.rev !tokens
 

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -598,12 +598,19 @@ let test_goal_attainment_camel_case_percent_metric_is_percent () =
   check string "camelCase metric unit is percent" "percent"
     (attainment |> member "unit" |> to_string)
 
-(* Post-#13131 follow-up: [float_of_string_opt] accepts [nan]/[inf]
-   tokens; without the [Float.is_finite] guard the resulting non-
-   finite numeric crashed [pct_of_float] via [int_of_float (floor
-   nan)].  Pin the projection at unparseable / unmeasured for the
-   "nan" target rather than relying on tests not to crash. *)
-let test_goal_attainment_rejects_non_finite_target () =
+(* Post-#13131 follow-up: [float_of_string_opt] accepts the literal
+   "nan" / "inf" tokens; without the [Float.is_finite] guard the
+   resulting non-finite numeric crashed [pct_of_float] via
+   [int_of_float (floor nan)].  Pin the projection at
+   unparseable / unmeasured for the "nan" target.
+
+   Distinct from [test_goal_attainment_rejects_non_finite_target]
+   above (which exercises overflow-to-infinity via a 400-digit
+   decimal): both cases must individually round-trip through the
+   guard.  Post-#13170 review caught the earlier instance where
+   both bindings had the same top-level name and OCaml shadowing
+   silently disabled one of them. *)
+let test_goal_attainment_rejects_non_finite_target_nan_token () =
   with_room @@ fun config ->
   let goal, _kind =
     match
@@ -627,6 +634,32 @@ let test_goal_attainment_rejects_non_finite_target () =
     (attainment |> member "target_numeric" = `Null);
   check bool "non-finite target has no pct" true
     (attainment |> member "attainment_pct" = `Null)
+
+(* Post-#13170 review: tokenizer must split acronym-prefixed
+   PascalCase metric names.  [APIRatio] / [PRCount] should infer
+   percent so dashboards keep treating these common metric forms
+   as percent targets. *)
+let test_goal_attainment_acronym_pascal_case_percent_metric_is_percent () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Acronym-prefixed percent metric"
+        ~metric:"APIRatio" ~target_value:"80" ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Done evidence";
+  let attainment =
+    Dashboard_goals.dashboard_goals_tree_json ~config
+    |> root_node
+    |> member "attainment"
+  in
+  check string "acronym-prefix metric inferred as percent target"
+    "metric_target_percent"
+    (attainment |> member "basis" |> to_string);
+  check string "acronym-prefix metric unit is percent" "percent"
+    (attainment |> member "unit" |> to_string)
 
 let test_blocked_phase_projects_blocked_health () =
   with_room @@ fun config ->
@@ -898,8 +931,11 @@ let () =
             test_goal_attainment_rejects_substring_pr_metric;
           test_case "goal attainment handles camelCase percent metric"
             `Quick test_goal_attainment_camel_case_percent_metric_is_percent;
-          test_case "goal attainment rejects non-finite target" `Quick
-            test_goal_attainment_rejects_non_finite_target;
+          test_case "goal attainment handles acronym-prefix percent metric"
+            `Quick
+            test_goal_attainment_acronym_pascal_case_percent_metric_is_percent;
+          test_case "goal attainment rejects non-finite target (nan token)"
+            `Quick test_goal_attainment_rejects_non_finite_target_nan_token;
           test_case "blocked phase maps to blocked health" `Quick
             test_blocked_phase_projects_blocked_health;
           test_case


### PR DESCRIPTION
## Summary

Post-merge follow-up for #13170. Reviewer flagged 3 substantive threads after merge.

- **acronym-prefix regression**: the camelCase tokenizer split on lower→upper, but acronym-prefixed names like `APIRatio` / `PRCount` still flattened to a single token. New rule: an uppercase letter preceded by uppercase AND followed by lowercase starts a new token. Result: `APIRatio` → `[api; ratio]`, `HTTPRate` → `[http; rate]`, abbreviations like `API` stay intact.
- **test name shadowing (P2)**: a separate PR that landed before #13170 added a `test_goal_attainment_rejects_non_finite_target` binding for the overflow-to-infinity case. #13170 added a second binding with the same name for the `"nan"` token case, and OCaml shadowing silently disabled the first — both registrations at the bottom of the file ran the same later binding. Rename my variant to `*_nan_token` and register it independently so both run.
- **acronym regression test**: pin `APIRatio` inference to `metric_target_percent` so the tokenizer cannot regress silently.

## Why a separate PR

#13170 was MERGED before these threads could be addressed in-place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
