### PR TITLE
feat: expose observed keeper PR work metrics

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -573,6 +573,15 @@ export interface MetricsWindow {
 
   // -- Tool --
   tool_call_count?: number
+  pr_review_read_tool_count?: number
+  pr_review_mutation_tool_count?: number
+  pr_review_tool_count?: number
+  pr_work_git_tool_count?: number
+  pr_work_signal_count?: number
+  observed_pr_review_work?: boolean
+  observed_pr_mutation_work?: boolean
+  observed_git_work?: boolean
+  observed_pr_work?: boolean
 
   // -- Memory --
   memory_checks?: number

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -580,6 +580,20 @@ let compute_metrics_window
   let top_tools =
     top_counts_json ~limit:5 ~name_key:"tool" tool_counts_window
   in
+  let tool_count name = Option.value ~default:0 (Hashtbl.find_opt tool_counts_window name) in
+  let pr_review_read_tool_count = tool_count "keeper_pr_review_read" in
+  let pr_review_mutation_tool_count =
+    tool_count "keeper_pr_review_comment" + tool_count "keeper_pr_review_reply"
+  in
+  let pr_review_tool_count =
+    pr_review_read_tool_count + pr_review_mutation_tool_count
+  in
+  let pr_work_git_tool_count =
+    tool_count "keeper_preflight_check"
+    + tool_count "masc_worktree_create"
+    + tool_count "masc_code_git"
+  in
+  let pr_work_signal_count = pr_review_tool_count + pr_work_git_tool_count in
   let top_memory_kinds =
     top_counts_json ~limit:5 ~name_key:"kind" memory_kind_counts_window
   in
@@ -686,6 +700,15 @@ let compute_metrics_window
     ("proactive_preview_similarity_method", `String "jaccard_adjacent_preview");
     ("proactive_preview_similarity_window", `Int proactive_similarity_window);
     ("tool_call_count", `Int acc.ma_tool_call_count);
+    ("pr_review_read_tool_count", `Int pr_review_read_tool_count);
+    ("pr_review_mutation_tool_count", `Int pr_review_mutation_tool_count);
+    ("pr_review_tool_count", `Int pr_review_tool_count);
+    ("pr_work_git_tool_count", `Int pr_work_git_tool_count);
+    ("pr_work_signal_count", `Int pr_work_signal_count);
+    ("observed_pr_review_work", `Bool (pr_review_tool_count > 0));
+    ("observed_pr_mutation_work", `Bool (pr_review_mutation_tool_count > 0));
+    ("observed_git_work", `Bool (pr_work_git_tool_count > 0));
+    ("observed_pr_work", `Bool (pr_work_signal_count > 0));
     ("memory_checks", `Int acc.ma_memory_checks);
     ("memory_passed", `Int acc.ma_memory_passed);
     ("memory_failed", `Int memory_failed);

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -1,6 +1,26 @@
 open Alcotest
 
 module Metrics = Masc_mcp.Dashboard_http_keeper_metrics
+module Detail = Masc_mcp.Dashboard_http_keeper_detail
+
+let metric ?(channel = "turn") tools =
+  `Assoc
+    [
+      ("ts_unix", `Float 1.0);
+      ("channel", `String channel);
+      ("tools_used", `List (List.map (fun tool -> `String tool) tools));
+      ("tool_call_count", `Int (List.length tools));
+    ]
+
+let summary_int field summary =
+  match Yojson.Safe.Util.(summary |> member field) with
+  | `Int value -> value
+  | other -> failf "expected int field %s, got %s" field (Yojson.Safe.to_string other)
+
+let summary_bool field summary =
+  match Yojson.Safe.Util.(summary |> member field) with
+  | `Bool value -> value
+  | other -> failf "expected bool field %s, got %s" field (Yojson.Safe.to_string other)
 
 let test_contains_ci_preserves_literal_ascii_semantics () =
   check bool "ascii case-insensitive hit" true
@@ -32,6 +52,47 @@ let test_proactive_preview_similarity_stats_semantics () =
   check (float 0.0001) "max" 1.0 max_sim;
   check bool "warn" true warn
 
+let test_metrics_window_exposes_observed_pr_work () =
+  let _, summary, _, _ =
+    Detail.compute_metrics_window
+      ~parsed_metrics:
+        [
+          metric
+            [
+              "keeper_pr_review_read";
+              "keeper_pr_review_comment";
+              "keeper_pr_review_reply";
+              "keeper_preflight_check";
+              "masc_worktree_create";
+              "masc_code_git";
+            ];
+          metric ~channel:"heartbeat" [ "keeper_pr_review_comment"; "masc_code_git" ];
+        ]
+      ~generation:0
+      ~compact:false
+      ~series_points:80
+      ~metrics_window_max_bytes:200_000
+      ~primary_model_norm:""
+      ~primary_model:""
+  in
+  check int "review read tools" 1
+    (summary_int "pr_review_read_tool_count" summary);
+  check int "review mutation tools" 2
+    (summary_int "pr_review_mutation_tool_count" summary);
+  check int "review tools" 3
+    (summary_int "pr_review_tool_count" summary);
+  check int "git/preflight tools" 3
+    (summary_int "pr_work_git_tool_count" summary);
+  check int "pr work signal count" 6
+    (summary_int "pr_work_signal_count" summary);
+  check bool "observed review" true
+    (summary_bool "observed_pr_review_work" summary);
+  check bool "observed mutation" true
+    (summary_bool "observed_pr_mutation_work" summary);
+  check bool "observed git" true (summary_bool "observed_git_work" summary);
+  check bool "observed pr work" true
+    (summary_bool "observed_pr_work" summary)
+
 let () =
   run "dashboard_keeper_metrics_10286"
     [
@@ -46,5 +107,10 @@ let () =
             test_similarity_normalization_semantics;
           test_case "preview stats semantics" `Quick
             test_proactive_preview_similarity_stats_semantics;
+        ] );
+      ( "metrics_window",
+        [
+          test_case "exposes observed PR work signals" `Quick
+            test_metrics_window_exposes_observed_pr_work;
         ] );
     ]


### PR DESCRIPTION
## Summary

- Add metrics_window fields that expose observed keeper PR work signals from tool usage.
- Count PR review read/mutation tools separately from git/preflight/worktree signals.
- Add OCaml regression coverage and dashboard TypeScript fields for the new metrics.

## Product impact

This makes the dashboard distinguish configured capability from observed behavior. Operators can now see whether a keeper actually used PR review or git/worktree/preflight tools during the metrics window, instead of inferring that from top_tools manually.

## Review evidence

- scripts/check-oas-pin.sh --local-only
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-pr-work-metrics-0505-v3 scripts/dune-local.sh build test/test_dashboard_keeper_metrics_10286.exe
- /private/tmp/masc-dune-pr-work-metrics-0505-v3/default/test/test_dashboard_keeper_metrics_10286.exe
- npx tsc --noEmit --pretty
- git diff --check

## Notes

This is an observed-signal metric only. The current metrics stream records tool names, not tool arguments, so approve-vs-comment detail still needs richer event logging if we want exact approval counts later.