### PR TITLE
test: validate goal loop ACT map PR refs

### DIFF
--- a/docs/examples/goal-loop-fixture.md
+++ b/docs/examples/goal-loop-fixture.md
@@ -40,3 +40,16 @@ python3 scripts/goal_loop_status.py \
   --verify-json test/fixtures/goal_loop/verify.fail.json \
   --loop-iteration "#fixture"
 ```
+
+Validate that the fixture's ACT artifacts point at known PR numbers:
+
+```bash
+python3 scripts/validate_goal_loop_act_map.py \
+  test/fixtures/goal_loop/act-map.startup.json \
+  --known-prs-json test/fixtures/goal_loop/known-prs.startup.json \
+  --require-pr-ref \
+  --fail-on any
+```
+
+For live validation, capture a current PR snapshot first and pass that file as
+`--known-prs-json`.

--- a/scripts/validate_goal_loop_act_map.py
+++ b/scripts/validate_goal_loop_act_map.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Validate GOAL LOOP ACT map artifact references.
+
+The Decide phase only knows that a decision points at an ACT artifact string.
+This guard checks that PR-shaped artifact refs, such as ``PR#13123``, are
+present in an explicit known-PR snapshot.  The snapshot can be a deterministic
+test fixture or a JSON file captured from ``gh pr list/view``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+PR_REF_RE = re.compile(r"\bPR#(?P<number>[0-9]+)\b")
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    decision_id: str
+    artifact: str
+    pr_number: int | None
+
+
+@dataclass(frozen=True)
+class MissingPrRef:
+    decision_id: str
+    artifact: str
+    pr_number: int
+
+
+@dataclass(frozen=True)
+class ActMapValidationReport:
+    artifact_count: int
+    known_pr_count: int
+    pr_ref_count: int
+    missing_pr_count: int
+    malformed_artifact_count: int
+    missing_prs: list[MissingPrRef]
+    malformed_artifacts: list[ArtifactRef]
+
+
+def load_json(path: str) -> Any:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def normalize_act_map(raw: Any) -> dict[str, list[str]]:
+    if not isinstance(raw, dict):
+        raise ValueError("expected ACT map JSON object")
+    act_map: dict[str, list[str]] = {}
+    for decision_id, value in raw.items():
+        if not isinstance(decision_id, str):
+            continue
+        if isinstance(value, str):
+            act_map[decision_id] = [value]
+        elif isinstance(value, list):
+            act_map[decision_id] = [item for item in value if isinstance(item, str)]
+    return act_map
+
+
+def artifact_refs(act_map: dict[str, list[str]]) -> list[ArtifactRef]:
+    refs: list[ArtifactRef] = []
+    for decision_id, artifacts in sorted(act_map.items()):
+        for artifact in artifacts:
+            match = PR_REF_RE.search(artifact)
+            refs.append(
+                ArtifactRef(
+                    decision_id=decision_id,
+                    artifact=artifact,
+                    pr_number=int(match.group("number")) if match else None,
+                )
+            )
+    return refs
+
+
+def known_pr_numbers(raw: Any) -> set[int]:
+    if raw is None:
+        return set()
+    if isinstance(raw, dict):
+        if isinstance(raw.get("prs"), list):
+            return known_pr_numbers(raw["prs"])
+        numbers: set[int] = set()
+        for key, value in raw.items():
+            if isinstance(key, str) and key.isdigit():
+                numbers.add(int(key))
+            if isinstance(value, dict):
+                number = value.get("number")
+                if isinstance(number, int):
+                    numbers.add(number)
+        return numbers
+    if isinstance(raw, list):
+        numbers = set()
+        for item in raw:
+            if isinstance(item, int):
+                numbers.add(item)
+            elif isinstance(item, dict):
+                number = item.get("number")
+                if isinstance(number, int):
+                    numbers.add(number)
+        return numbers
+    raise ValueError("expected known PR JSON object or array")
+
+
+def validate_act_map(
+    act_map: dict[str, list[str]],
+    *,
+    known_prs: set[int],
+    require_pr_ref: bool,
+) -> ActMapValidationReport:
+    refs = artifact_refs(act_map)
+    missing = [
+        MissingPrRef(
+            decision_id=ref.decision_id,
+            artifact=ref.artifact,
+            pr_number=ref.pr_number,
+        )
+        for ref in refs
+        if ref.pr_number is not None and ref.pr_number not in known_prs
+    ]
+    malformed = [ref for ref in refs if require_pr_ref and ref.pr_number is None]
+    return ActMapValidationReport(
+        artifact_count=len(refs),
+        known_pr_count=len(known_prs),
+        pr_ref_count=sum(1 for ref in refs if ref.pr_number is not None),
+        missing_pr_count=len(missing),
+        malformed_artifact_count=len(malformed),
+        missing_prs=missing,
+        malformed_artifacts=malformed,
+    )
+
+
+def report_to_json(report: ActMapValidationReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def should_fail(report: ActMapValidationReport, mode: str) -> bool:
+    if mode == "none":
+        return False
+    if mode == "missing":
+        return report.missing_pr_count > 0
+    if mode == "malformed":
+        return report.malformed_artifact_count > 0
+    if mode == "any":
+        return report.missing_pr_count > 0 or report.malformed_artifact_count > 0
+    raise ValueError(f"unknown fail mode: {mode}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("act_map_json", help="ACT map JSON file.")
+    parser.add_argument(
+        "--known-prs-json",
+        required=True,
+        help="Known PR JSON object/array. Accepts gh-style objects with number fields.",
+    )
+    parser.add_argument(
+        "--require-pr-ref",
+        action="store_true",
+        help="Treat artifacts without a PR#number token as malformed.",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "missing", "malformed", "any"),
+        default="missing",
+        help="Exit non-zero for this validation class (default: missing).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    report = validate_act_map(
+        normalize_act_map(load_json(args.act_map_json)),
+        known_prs=known_pr_numbers(load_json(args.known_prs_json)),
+        require_pr_ref=args.require_pr_ref,
+    )
+    print(report_to_json(report))
+    return 1 if should_fail(report, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/fixtures/goal_loop/known-prs.startup.json
+++ b/test/fixtures/goal_loop/known-prs.startup.json
@@ -1,0 +1,24 @@
+{
+  "prs": [
+    {
+      "number": 13123,
+      "state": "MERGED",
+      "title": "fix(keeper): wake alive-stuck keepers"
+    },
+    {
+      "number": 13124,
+      "state": "MERGED",
+      "title": "fix: run provider health probes at bootstrap"
+    },
+    {
+      "number": 13138,
+      "state": "MERGED",
+      "title": "fix: surface keeper toml unknown keys in health"
+    },
+    {
+      "number": 13143,
+      "state": "MERGED",
+      "title": "fix: surface governance fallback counters"
+    }
+  ]
+}

--- a/test/test_validate_goal_loop_act_map.py
+++ b/test/test_validate_goal_loop_act_map.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_goal_loop_act_map.py"
+FIXTURE_DIR = REPO_ROOT / "test" / "fixtures" / "goal_loop"
+
+spec = importlib.util.spec_from_file_location("validate_goal_loop_act_map", SCRIPT_PATH)
+assert spec is not None
+validate_goal_loop_act_map = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = validate_goal_loop_act_map
+spec.loader.exec_module(validate_goal_loop_act_map)
+
+
+class ValidateGoalLoopActMapTest(unittest.TestCase):
+    def test_fixture_act_map_pr_refs_exist_in_known_pr_snapshot(self) -> None:
+        report = validate_goal_loop_act_map.validate_act_map(
+            validate_goal_loop_act_map.normalize_act_map(
+                json.loads((FIXTURE_DIR / "act-map.startup.json").read_text())
+            ),
+            known_prs=validate_goal_loop_act_map.known_pr_numbers(
+                json.loads((FIXTURE_DIR / "known-prs.startup.json").read_text())
+            ),
+            require_pr_ref=True,
+        )
+
+        self.assertEqual(report.artifact_count, 4)
+        self.assertEqual(report.pr_ref_count, 4)
+        self.assertEqual(report.known_pr_count, 4)
+        self.assertEqual(report.missing_pr_count, 0)
+        self.assertEqual(report.malformed_artifact_count, 0)
+
+    def test_missing_pr_ref_fails_when_known_snapshot_does_not_include_it(self) -> None:
+        report = validate_goal_loop_act_map.validate_act_map(
+            {"D-TEST": ["PR#99999 missing"]},
+            known_prs={13123},
+            require_pr_ref=True,
+        )
+
+        self.assertTrue(validate_goal_loop_act_map.should_fail(report, "missing"))
+        self.assertEqual(report.missing_prs[0].pr_number, 99999)
+
+    def test_artifact_without_pr_ref_is_malformed_when_required(self) -> None:
+        report = validate_goal_loop_act_map.validate_act_map(
+            {"D-TEST": ["manual runbook"]},
+            known_prs={13123},
+            require_pr_ref=True,
+        )
+
+        self.assertTrue(validate_goal_loop_act_map.should_fail(report, "malformed"))
+        self.assertEqual(report.malformed_artifacts[0].artifact, "manual runbook")
+
+    def test_cli_reports_missing_pr_with_nonzero_exit(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            act_map_path = root / "act-map.json"
+            known_path = root / "known.json"
+            act_map_path.write_text(
+                json.dumps({"D-TEST": ["PR#99999 missing"]}),
+                encoding="utf-8",
+            )
+            known_path.write_text(
+                json.dumps({"prs": [{"number": 13123}]}),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(act_map_path),
+                    "--known-prs-json",
+                    str(known_path),
+                    "--require-pr-ref",
+                    "--fail-on",
+                    "any",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["missing_pr_count"], 1)
+        self.assertEqual(payload["missing_prs"][0]["pr_number"], 99999)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a deterministic ACT-map validator for GOAL LOOP fixture artifacts. It extracts PR# refs, checks them against a known PR snapshot, and fails on missing or malformed refs so Decide/Act linkage cannot silently point at non-existent PRs.\n\nValidation:\n- npx pyright --outputjson scripts/validate_goal_loop_act_map.py test/test_validate_goal_loop_act_map.py\n- ruff check scripts/validate_goal_loop_act_map.py test/test_validate_goal_loop_act_map.py\n- ruff format --check scripts/validate_goal_loop_act_map.py test/test_validate_goal_loop_act_map.py\n- python3 test/test_validate_goal_loop_act_map.py\n- python3 scripts/validate_goal_loop_act_map.py test/fixtures/goal_loop/act-map.startup.json --known-prs-json test/fixtures/goal_loop/known-prs.startup.json --require-pr-ref --fail-on any\n- git diff --check origin/main...HEAD