### PR TITLE
fix(dashboard): void board SSE refresh callback

### DIFF
--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -169,7 +169,7 @@ const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
 
 const REFRESH_FNS: Record<RefreshTarget, () => void> = {
   execution: () => { void refreshExecution() },
-  board:     refreshBoard,
+  board:     () => { void refreshBoard() },
   operator:  () => _refreshOperatorFn?.(),
   activity:  () => {
     for (const fn of _refreshActivityFns) fn()


### PR DESCRIPTION
## Summary

- wrap the board SSE refresh callback as `() => { void refreshBoard() }`
- keep the #13175 behavior that limits hearth-chip refreshes to board post membership events

## Why

Copilot flagged that assigning async `refreshBoard` directly to `Record<RefreshTarget, () => void>` makes the fire-and-forget contract implicit. This patch makes the async boundary explicit without restoring the previous broad hearth-chip refresh behavior.

## Validation

- `pnpm exec vitest run src/sse-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/sse-store.ts src/sse-store.test.ts`
- `git diff --check`
