### PR TITLE
fix(keeper): make tool policy config accessors strict

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -9,15 +9,6 @@
 open Keeper_types
 open Keeper_alerting
 
-(* Config defaults when no policy_config is loaded. *)
-let default_clone_timeout_sec = 120.0
-let default_push_timeout_sec = 60.0
-let default_pr_create_timeout_sec = 30.0
-let default_gh_cache_ttl_sec = 120.0
-let default_gh_cache_fetch_page_size = 100
-let default_gh_cache_fetch_timeout_sec = 10.0
-let default_gh_cache_max_alternatives = 20
-let default_gh_cache_max_output_bytes = 8192
 open Keeper_tool_registry
 
 (* -- E6: .masc/ write protection whitelist ----------------------------- *)
@@ -96,6 +87,16 @@ let with_policy_config_or ?(on_none = fun () -> ()) ~accessor ~default f =
     default
   | Some cfg -> f cfg
 
+let require_policy_config ~accessor =
+  match !policy_config with
+  | Some cfg -> cfg
+  | None ->
+    observe_unloaded_policy_config ~accessor;
+    invalid_arg
+      (Printf.sprintf
+         "tool_policy.%s requires init_policy_config; config/tool_policy.toml is not loaded"
+         accessor)
+
 let reset_policy_config_for_test () =
   policy_config := None;
   Stdlib.Mutex.lock policy_config_unloaded_mutex;
@@ -147,50 +148,42 @@ let git_clone_denied_repos () : string list option =
     (fun cfg -> Some (Keeper_tool_policy_config.git_clone_denied_repos cfg))
 
 let clone_depth () : int =
-  with_policy_config_or ~accessor:"clone_depth" ~default:0
-    Keeper_tool_policy_config.clone_depth
+  require_policy_config ~accessor:"clone_depth"
+  |> Keeper_tool_policy_config.clone_depth
 
 let clone_timeout_sec () : float =
-  with_policy_config_or ~accessor:"clone_timeout_sec"
-    ~default:default_clone_timeout_sec
-    Keeper_tool_policy_config.clone_timeout_sec
+  require_policy_config ~accessor:"clone_timeout_sec"
+  |> Keeper_tool_policy_config.clone_timeout_sec
 
 let push_timeout_sec () : float =
-  with_policy_config_or ~accessor:"push_timeout_sec"
-    ~default:default_push_timeout_sec
-    Keeper_tool_policy_config.push_timeout_sec
+  require_policy_config ~accessor:"push_timeout_sec"
+  |> Keeper_tool_policy_config.push_timeout_sec
 
 let pr_create_timeout_sec () : float =
-  with_policy_config_or ~accessor:"pr_create_timeout_sec"
-    ~default:default_pr_create_timeout_sec
-    Keeper_tool_policy_config.pr_create_timeout_sec
+  require_policy_config ~accessor:"pr_create_timeout_sec"
+  |> Keeper_tool_policy_config.pr_create_timeout_sec
 
 (* ── GH cache config accessors (config-driven) ─────────────── *)
 
 let gh_cache_ttl_sec () : float =
-  with_policy_config_or ~accessor:"gh_cache_ttl_sec"
-    ~default:default_gh_cache_ttl_sec
-    Keeper_tool_policy_config.gh_cache_ttl_sec
+  require_policy_config ~accessor:"gh_cache_ttl_sec"
+  |> Keeper_tool_policy_config.gh_cache_ttl_sec
 
 let gh_cache_fetch_page_size () : int =
-  with_policy_config_or ~accessor:"gh_cache_fetch_page_size"
-    ~default:default_gh_cache_fetch_page_size
-    Keeper_tool_policy_config.gh_cache_fetch_page_size
+  require_policy_config ~accessor:"gh_cache_fetch_page_size"
+  |> Keeper_tool_policy_config.gh_cache_fetch_page_size
 
 let gh_cache_fetch_timeout_sec () : float =
-  with_policy_config_or ~accessor:"gh_cache_fetch_timeout_sec"
-    ~default:default_gh_cache_fetch_timeout_sec
-    Keeper_tool_policy_config.gh_cache_fetch_timeout_sec
+  require_policy_config ~accessor:"gh_cache_fetch_timeout_sec"
+  |> Keeper_tool_policy_config.gh_cache_fetch_timeout_sec
 
 let gh_cache_max_alternatives () : int =
-  with_policy_config_or ~accessor:"gh_cache_max_alternatives"
-    ~default:default_gh_cache_max_alternatives
-    Keeper_tool_policy_config.gh_cache_max_alternatives
+  require_policy_config ~accessor:"gh_cache_max_alternatives"
+  |> Keeper_tool_policy_config.gh_cache_max_alternatives
 
 let gh_cache_max_output_bytes () : int =
-  with_policy_config_or ~accessor:"gh_cache_max_output_bytes"
-    ~default:default_gh_cache_max_output_bytes
-    Keeper_tool_policy_config.gh_cache_max_output_bytes
+  require_policy_config ~accessor:"gh_cache_max_output_bytes"
+  |> Keeper_tool_policy_config.gh_cache_max_output_bytes
 
 (* ── Preset subsumption (config-driven) ──────────────────────── *)
 

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -73,7 +73,7 @@ let warn_unloaded_policy_config_once ~accessor ~outcome =
       "tool_policy.%s called before init_policy_config loaded config/tool_policy.toml; %s"
       accessor outcome
 
-(* PR #13185 review: the warn message originally hard-coded
+(* PR #13129 review: the warn message originally hard-coded
    "returning fallback", which is misleading on the strict
    accessor path that raises [Invalid_argument] instead.  Take
    [outcome] from the caller so the log line accurately describes

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -56,7 +56,7 @@ let policy_config_unloaded_mutex = Stdlib.Mutex.create ()
 
 let policy_config_for_validation () = !policy_config
 
-let warn_unloaded_policy_config_once ~accessor =
+let warn_unloaded_policy_config_once ~accessor ~outcome =
   let should_warn =
     Stdlib.Mutex.lock policy_config_unloaded_mutex;
     Fun.protect
@@ -70,19 +70,24 @@ let warn_unloaded_policy_config_once ~accessor =
   in
   if should_warn then
     Log.Keeper.warn
-      "tool_policy.%s called before init_policy_config loaded config/tool_policy.toml; returning fallback"
-      accessor
+      "tool_policy.%s called before init_policy_config loaded config/tool_policy.toml; %s"
+      accessor outcome
 
-let observe_unloaded_policy_config ~accessor =
+(* PR #13185 review: the warn message originally hard-coded
+   "returning fallback", which is misleading on the strict
+   accessor path that raises [Invalid_argument] instead.  Take
+   [outcome] from the caller so the log line accurately describes
+   what the call site did. *)
+let observe_unloaded_policy_config ~accessor ~outcome =
   Prometheus.inc_counter Prometheus.metric_tool_policy_unloaded_query
     ~labels:[("accessor", accessor)]
     ();
-  warn_unloaded_policy_config_once ~accessor
+  warn_unloaded_policy_config_once ~accessor ~outcome
 
 let with_policy_config_or ?(on_none = fun () -> ()) ~accessor ~default f =
   match !policy_config with
   | None ->
-    observe_unloaded_policy_config ~accessor;
+    observe_unloaded_policy_config ~accessor ~outcome:"returning fallback";
     on_none ();
     default
   | Some cfg -> f cfg
@@ -91,7 +96,8 @@ let require_policy_config ~accessor =
   match !policy_config with
   | Some cfg -> cfg
   | None ->
-    observe_unloaded_policy_config ~accessor;
+    observe_unloaded_policy_config ~accessor
+      ~outcome:"raising Invalid_argument";
     invalid_arg
       (Printf.sprintf
          "tool_policy.%s requires init_policy_config; config/tool_policy.toml is not loaded"

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -51,6 +51,12 @@ val git_clone_allowed_orgs : unit -> string list option
 val git_clone_denied_repos : unit -> string list option
 (** [None] if policy config has not been loaded; [Some repos] otherwise
     (empty list means no repos are denied). *)
+
+(** Numeric tool-policy accessors require [init_policy_config] to have
+    loaded [config/tool_policy.toml]. They raise [Invalid_argument] when
+    queried before policy initialization instead of silently using
+    permissive runtime defaults. Missing TOML keys still use the parser
+    defaults in {!Keeper_tool_policy_config} after the config is loaded. *)
 val clone_depth : unit -> int
 val clone_timeout_sec : unit -> float
 val push_timeout_sec : unit -> float
@@ -58,6 +64,8 @@ val pr_create_timeout_sec : unit -> float
 
 (** {1 GH Cache Config} *)
 
+(** These accessors follow the same loaded-policy requirement as the
+    numeric git/gh timeout accessors above. *)
 val gh_cache_ttl_sec : unit -> float
 val gh_cache_fetch_page_size : unit -> int
 val gh_cache_fetch_timeout_sec : unit -> float

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -256,6 +256,24 @@ let tool_policy_unloaded_metric accessor =
     ~labels:[("accessor", accessor)]
     ()
 
+let string_contains text needle =
+  try
+    ignore (Str.search_forward (Str.regexp_string needle) text 0);
+    true
+  with Not_found -> false
+
+let check_policy_not_loaded_raises accessor call =
+  match call () with
+  | () -> failf "%s should raise when tool_policy config is unloaded" accessor
+  | exception Invalid_argument msg ->
+      check bool (accessor ^ " error names accessor") true
+        (string_contains msg accessor);
+      check bool (accessor ^ " error names init_policy_config") true
+        (string_contains msg "init_policy_config")
+  | exception exn ->
+      failf "%s raised unexpected exception: %s" accessor
+        (Printexc.to_string exn)
+
 let test_tool_policy_unloaded_accessors_emit_metric () =
   Keeper_tool_policy.reset_policy_config_for_test ();
   let allowed_orgs_before =
@@ -268,16 +286,35 @@ let test_tool_policy_unloaded_accessors_emit_metric () =
   in
   check bool "allowed_orgs pre-init query increments metric" true
     (allowed_orgs_after >= allowed_orgs_before +. 1.0);
-  let clone_depth_before =
-    tool_policy_unloaded_metric "clone_depth"
+  let strict_accessors =
+    [
+      ("clone_depth", fun () -> ignore (Keeper_tool_policy.clone_depth ()));
+      ( "clone_timeout_sec",
+        fun () -> ignore (Keeper_tool_policy.clone_timeout_sec ()) );
+      ( "push_timeout_sec",
+        fun () -> ignore (Keeper_tool_policy.push_timeout_sec ()) );
+      ( "pr_create_timeout_sec",
+        fun () -> ignore (Keeper_tool_policy.pr_create_timeout_sec ()) );
+      ( "gh_cache_ttl_sec",
+        fun () -> ignore (Keeper_tool_policy.gh_cache_ttl_sec ()) );
+      ( "gh_cache_fetch_page_size",
+        fun () -> ignore (Keeper_tool_policy.gh_cache_fetch_page_size ()) );
+      ( "gh_cache_fetch_timeout_sec",
+        fun () -> ignore (Keeper_tool_policy.gh_cache_fetch_timeout_sec ()) );
+      ( "gh_cache_max_alternatives",
+        fun () -> ignore (Keeper_tool_policy.gh_cache_max_alternatives ()) );
+      ( "gh_cache_max_output_bytes",
+        fun () -> ignore (Keeper_tool_policy.gh_cache_max_output_bytes ()) );
+    ]
   in
-  check int "pre-init clone_depth fallback unchanged" 0
-    (Keeper_tool_policy.clone_depth ());
-  let clone_depth_after =
-    tool_policy_unloaded_metric "clone_depth"
-  in
-  check bool "clone_depth pre-init query increments metric" true
-    (clone_depth_after >= clone_depth_before +. 1.0);
+  List.iter
+    (fun (accessor, call) ->
+      let before = tool_policy_unloaded_metric accessor in
+      check_policy_not_loaded_raises accessor call;
+      let after = tool_policy_unloaded_metric accessor in
+      check bool (accessor ^ " pre-init query increments metric") true
+        (after >= before +. 1.0))
+    strict_accessors;
   init_registry ()
 
 let tool_policy_init_failed_metric base_path =


### PR DESCRIPTION
## Summary

- Adds a strict `require_policy_config` path for clone depth, clone timeout, push timeout, PR timeout, and GH cache accessors.
- Keeps the existing #13129 warning/counter behavior, but these numeric accessors now raise instead of silently using permissive unloaded-policy defaults.
- Updates the focused warning-root-cause regression to assert `Invalid_argument` plus `masc_tool_policy_unloaded_query_total{accessor=...}` increments for each strict accessor.
- Documents the loaded-policy requirement in `keeper_tool_policy.mli`.

## Task / Lineage

- Task: `task-186` — Fix 7 silent-empty accessor antipatterns in `keeper_tool_policy.ml`.
- Complements #13129 / `task-185`, which made unloaded access visible but intentionally preserved fallback behavior.
- MASC claim attempt for `task-186` timed out and the board still shows it `todo`; this PR carries implementation evidence because the FSM did not claim cleanly.

## Validation

- `git diff --check origin/main..HEAD` passed.
- `./scripts/check-oas-pin.sh --local-only` passed: OAS pin `d8b98a2773c0b056cfae43eafce20ab28ff2d256`.
- Attempted `scripts/dune-local.sh build ./test/test_warn_root_causes.exe`; pin check passed, but the command remained queued on `/tmp/me-dune-local.lock` for ~2 minutes and I stopped only my lock waiter to avoid build-lane contention. CI should run the focused target on a runner.