### PR TITLE
feat(dashboard): record execution render phase metrics

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -118,7 +118,18 @@ let record_render_phase_timings (t : render_phase_timings_ms) =
   observe_render_phase "snapshot" t.snapshot_ms;
   observe_render_phase "operations" t.operations_ms;
   observe_render_phase "enrich" t.enrich_ms;
-  observe_render_phase "enrich_per_keeper" (per_keeper_enrich_ms t);
+  (* Idle renders (n_keepers = 0) would otherwise inject a fake 0s sample
+     that drags the per-keeper average toward zero and hides slow renders.
+     Observe once per keeper so Prometheus [sum / count] yields the actual
+     average per-keeper enrich time, weighted by fleet size, instead of
+     averaging render-level means (a 1-keeper render and a 100-keeper
+     render contributing equally). *)
+  if t.n_keepers > 0 then begin
+    let per_keeper_value = per_keeper_enrich_ms t in
+    for _ = 1 to t.n_keepers do
+      observe_render_phase "enrich_per_keeper" per_keeper_value
+    done
+  end;
   observe_render_phase "data_load" t.data_load_ms;
   observe_render_phase "assemble" t.assemble_ms
 
@@ -448,6 +459,58 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       (* Yield between heavy phases so SSE / health-check fibers can progress *)
       Eio.Fiber.yield ();
       let t_start = Time_compat.now () in
+      (* Phase markers are mutable so that the Fun.protect [finally] below can
+         emit a partial render timing even when [json_render] raises (e.g.
+         render timeout, PG stall propagated as exception).  Without this, the
+         pathologically slow renders the metric is meant to surface stay
+         invisible because the previous record_render_phase_timings call site
+         was at the very end of the function and was skipped on raise. *)
+      let t_after_snapshot : float option ref = ref None in
+      let t_after_operations : float option ref = ref None in
+      let t_after_enrich : float option ref = ref None in
+      let t_after_data_load : float option ref = ref None in
+      let n_keepers_emitted = ref 0 in
+      let timings_emitted = ref false in
+      let emit_render_timings () =
+        if not !timings_emitted then begin
+          timings_emitted := true;
+          let t_end = Time_compat.now () in
+          let phase_ms_between start_opt end_opt =
+            match start_opt, end_opt with
+            | Some s, Some e -> (e -. s) *. 1000.0
+            | _ -> 0.0
+          in
+          let timings : render_phase_timings_ms = {
+            total_ms = (t_end -. t_start) *. 1000.0;
+            snapshot_ms =
+              (match !t_after_snapshot with
+               | Some t -> (t -. t_start) *. 1000.0
+               | None -> 0.0);
+            operations_ms =
+              phase_ms_between !t_after_snapshot !t_after_operations;
+            enrich_ms =
+              phase_ms_between !t_after_operations !t_after_enrich;
+            data_load_ms =
+              phase_ms_between !t_after_enrich !t_after_data_load;
+            assemble_ms =
+              (match !t_after_data_load with
+               | Some s -> (t_end -. s) *. 1000.0
+               | None -> 0.0);
+            n_keepers = !n_keepers_emitted;
+          } in
+          record_render_phase_timings timings;
+          if timings.total_ms > 10000.0 then
+            Log.Dashboard.warn "[dashboard_execution] slow render: %s"
+              (format_slow_render_timings timings)
+          else
+            Log.Dashboard.debug
+              "[dashboard_execution] timing: total=%.0fms snapshot=%.0fms \
+               enrich=%.0fms data_load=%.0fms assemble=%.0fms"
+              timings.total_ms timings.snapshot_ms timings.enrich_ms
+              timings.data_load_ms timings.assemble_ms
+        end
+      in
+      Fun.protect ~finally:emit_render_timings (fun () ->
       let snapshot_json =
         Dashboard_projection_cache.get_or_compute_snapshot_json
           ~config ~actor:(Some effective_actor) (fun actor_name ->
@@ -460,7 +523,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
               ~lightweight_summary:true
               ctx)
       in
-      let t_after_snapshot = Time_compat.now () in
+      t_after_snapshot := Some (Time_compat.now ());
       Eio.Fiber.yield ();
       (* Yield between heavy computation phases to prevent fiber starvation.
          Eio's cooperative scheduler needs explicit yields in CPU-bound paths
@@ -472,7 +535,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let execution_queue =
         build_execution_queue session_contexts operation_contexts
       in
-      let t_after_operations = Time_compat.now () in
+      t_after_operations := Some (Time_compat.now ());
       let keepers =
         member_assoc "keepers" snapshot_json |> member_assoc "items"
         |> function
@@ -500,7 +563,8 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
               items
         | _ -> []
       in
-      let t_after_enrich = Time_compat.now () in
+      t_after_enrich := Some (Time_compat.now ());
+      n_keepers_emitted := List.length keepers;
       let execution_queue =
         merge_execution_queue execution_queue
           (build_keeper_execution_queue keepers)
@@ -512,7 +576,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
          worker_support_briefs computation. *)
       let agents = agents_safe config in
       let messages = messages_safe config in
-      let t_after_data_load = Time_compat.now () in
+      t_after_data_load := Some (Time_compat.now ());
       let now_ts = Time_compat.now () in
       let worker_rows =
         build_worker_support_briefs ~now_ts ~tasks ~agents ~messages session_contexts
@@ -603,32 +667,11 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
           ("shown", `Int (List.length all_visible));
         ]);
       ] in
-      let t_end = Time_compat.now () in
-      let phase_ms a b = (b -. a) *. 1000.0 in
-      let timings : render_phase_timings_ms = {
-        total_ms = phase_ms t_start t_end;
-        snapshot_ms = phase_ms t_start t_after_snapshot;
-        operations_ms = phase_ms t_after_snapshot t_after_operations;
-        enrich_ms = phase_ms t_after_operations t_after_enrich;
-        data_load_ms = phase_ms t_after_enrich t_after_data_load;
-        assemble_ms = phase_ms t_after_data_load t_end;
-        n_keepers = List.length keepers;
-      } in
-      record_render_phase_timings timings;
-      (* #9766: surface phase breakdown in the slow-render WARN so the
-         59.8s/9-keeper sample (~6.6s/keeper) can be attributed to a
-         specific phase without rebuilding the binary with extra
-         instrumentation.  enrich covers the per-keeper [List.map
-         enrich_keeper_with_diagnostic] which is the suspected hot path. *)
-      if timings.total_ms > 10000.0 then
-        Log.Dashboard.warn "[dashboard_execution] slow render: %s"
-          (format_slow_render_timings timings)
-      else
-        Log.Dashboard.debug
-          "[dashboard_execution] timing: total=%.0fms snapshot=%.0fms \
-           enrich=%.0fms data_load=%.0fms assemble=%.0fms"
-          timings.total_ms timings.snapshot_ms timings.enrich_ms
-          timings.data_load_ms timings.assemble_ms;
+      (* #9766: phase breakdown is emitted by [emit_render_timings] in the
+         Fun.protect [finally] above, so timeout/exception paths still
+         surface partial render telemetry.  The slow-render WARN is also
+         emitted from there, off the same captured timings. *)
+      emit_render_timings ();
       if light then
         `Assoc (base_fields @ task_fields)
       else
@@ -636,7 +679,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
         `Assoc
           (base_fields @ task_fields @ [
             ("messages", `List (List.map message_json messages));
-          ])
+          ]))
 
 let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
   let effective_actor = Dashboard_projection_cache.normalize_actor_name actor in

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -104,6 +104,24 @@ let format_slow_render_timings (t : render_phase_timings_ms) =
     t.data_load_ms
     t.assemble_ms
 
+let render_phase_seconds ms =
+  if ms <= 0.0 then 0.0 else ms /. 1000.0
+
+let observe_render_phase phase ms =
+  Prometheus.observe_histogram
+    Prometheus.metric_dashboard_execution_render_phase_sec
+    ~labels:[("phase", phase)]
+    (render_phase_seconds ms)
+
+let record_render_phase_timings (t : render_phase_timings_ms) =
+  observe_render_phase "total" t.total_ms;
+  observe_render_phase "snapshot" t.snapshot_ms;
+  observe_render_phase "operations" t.operations_ms;
+  observe_render_phase "enrich" t.enrich_ms;
+  observe_render_phase "enrich_per_keeper" (per_keeper_enrich_ms t);
+  observe_render_phase "data_load" t.data_load_ms;
+  observe_render_phase "assemble" t.assemble_ms
+
 let enrich_keeper_with_diagnostic ~(config : Coord.config) (keeper_json : Yojson.Safe.t) =
   let open Yojson.Safe.Util in
   match keeper_json with
@@ -596,6 +614,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
         assemble_ms = phase_ms t_after_data_load t_end;
         n_keepers = List.length keepers;
       } in
+      record_render_phase_timings timings;
       (* #9766: surface phase breakdown in the slow-render WARN so the
          59.8s/9-keeper sample (~6.6s/keeper) can be attributed to a
          specific phase without rebuilding the binary with extra

--- a/lib/dashboard/dashboard_execution.mli
+++ b/lib/dashboard/dashboard_execution.mli
@@ -29,3 +29,8 @@ val per_keeper_enrich_ms : render_phase_timings_ms -> float
 val format_slow_render_timings : render_phase_timings_ms -> string
 (** Render the breakdown into the WARN suffix.  Stable format so
     log scrapers can parse it. *)
+
+val record_render_phase_timings : render_phase_timings_ms -> unit
+(** Emit the render phase breakdown into Prometheus.  This mirrors the
+    slow-render log payload so dashboard N+1 / enrichment cost is visible
+    even when the render stays below the warning threshold. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2438,8 +2438,33 @@ let to_prometheus_text () =
     else
     match ms with
     | [] -> ()
-    | m :: _ ->
-      Printf.bprintf buf "# HELP %s %s\n" name m.help;
+    | _ :: _ ->
+      (* Pick HELP deterministically from the unlabeled parent row that
+         [register_histogram] created at startup; without this, the
+         exported HELP becomes nondeterministically either the real
+         description or the raw metric name once any labelled phase row
+         is added by [observe_histogram] (which fills [help = name]
+         when no entry exists yet).  Fall back to the first entry's
+         [help] when no unlabeled parent exists, then to the metric
+         name. *)
+      let chosen_help =
+        let unlabeled =
+          List.find_opt (fun (m : metric) -> m.labels = []) ms
+        in
+        match unlabeled with
+        | Some m when m.help <> "" && m.help <> m.name -> m.help
+        | _ ->
+          let descriptive =
+            List.find_opt (fun (m : metric) ->
+                m.help <> "" && m.help <> m.name)
+              ms
+          in
+          (match descriptive with
+           | Some m -> m.help
+           | None -> name)
+      in
+      let m = List.hd ms in
+      Printf.bprintf buf "# HELP %s %s\n" name chosen_help;
       (match m.metric_type with
        | Histogram ->
          (* No bucket distribution is tracked, so emit as summary

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -794,6 +794,8 @@ let metric_ws_parse_cache_hits = "masc_ws_parse_cache_hits_total"
 let metric_ws_parse_cache_misses = "masc_ws_parse_cache_misses_total"
 let metric_ws_bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
 let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
+let metric_dashboard_execution_render_phase_sec =
+  "masc_dashboard_execution_render_phase_seconds"
 (* PR-0.2.A (RFC 2026-04-masc-ide-strategy): generic cache hit/miss
    counters, labelled by [cache] = "eio" | "dashboard".  Distinct from
    the WS-specific parse/bytes cache counters above; these track the
@@ -2259,6 +2261,11 @@ let init () =
   add metric_ws_bytes_cache_misses
     "WS raw-SSE-forward Bytes cache misses (fresh allocation required)"
     Counter;
+  register_histogram ~name:metric_dashboard_execution_render_phase_sec
+    ~help:
+      "Dashboard execution render phase latency in seconds. Labels: \
+       phase=total|snapshot|operations|enrich|enrich_per_keeper|data_load|assemble."
+    ();
   (* PR-0.2.A: generic cache hit/miss counters.  Labels: cache=eio|dashboard.
      [eio] tracks Cache_eio.get; [dashboard] tracks Dashboard_cache.get_or_compute.
      Per-label series are auto-created on first inc_counter call. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -814,6 +814,13 @@ val metric_ws_parse_cache_misses : string
 val metric_ws_bytes_cache_hits : string
 val metric_ws_bytes_cache_misses : string
 
+(** Dashboard execution render phase latency histogram. Labels:
+    [phase] = total | snapshot | operations | enrich | enrich_per_keeper
+            | data_load | assemble.
+    The per-phase series let operators distinguish broad dashboard N+1 /
+    enrichment cost from unrelated snapshot or assembly latency. *)
+val metric_dashboard_execution_render_phase_sec : string
+
 (** PR-0.2.A (RFC 2026-04-masc-ide-strategy): cache lookup hit/miss
     counters. Labels: [cache] with values
     - ["eio"]      — [Cache_eio.get] (filesystem-backed key/value cache).

--- a/test/test_dashboard_render_timing_9766.ml
+++ b/test/test_dashboard_render_timing_9766.ml
@@ -65,23 +65,63 @@ let phase_count phase =
     ()
 
 let test_record_timings_observes_prometheus () =
-  let total_before = phase_sum "total" in
-  let total_count_before = phase_count "total" in
-  let per_keeper_before = phase_sum "enrich_per_keeper" in
+  let phases = [
+    "total"; "snapshot"; "operations"; "enrich";
+    "data_load"; "assemble";
+  ] in
+  let snapshot_before =
+    List.map (fun p -> p, phase_sum p, phase_count p) phases
+  in
+  let per_keeper_sum_before = phase_sum "enrich_per_keeper" in
   let per_keeper_count_before = phase_count "enrich_per_keeper" in
-  DE.record_render_phase_timings (sample_timings ());
-  check (float 1e-6) "total phase seconds +59.8"
-    (total_before +. 59.8)
-    (phase_sum "total");
-  check (float 1e-6) "total phase count +1"
-    (total_count_before +. 1.0)
-    (phase_count "total");
-  check (float 1e-6) "per-keeper enrich seconds +6"
-    (per_keeper_before +. 6.0)
+  let t = sample_timings () in
+  DE.record_render_phase_timings t;
+  let expected_increment = function
+    | "total" -> t.total_ms /. 1000.0
+    | "snapshot" -> t.snapshot_ms /. 1000.0
+    | "operations" -> t.operations_ms /. 1000.0
+    | "enrich" -> t.enrich_ms /. 1000.0
+    | "data_load" -> t.data_load_ms /. 1000.0
+    | "assemble" -> t.assemble_ms /. 1000.0
+    | other -> Alcotest.failf "unexpected phase %s" other
+  in
+  List.iter (fun (phase, sum_before, count_before) ->
+    check (float 1e-6)
+      (Printf.sprintf "%s phase seconds +%.3f" phase
+         (expected_increment phase))
+      (sum_before +. expected_increment phase)
+      (phase_sum phase);
+    check (float 1e-6)
+      (Printf.sprintf "%s phase count +1" phase)
+      (count_before +. 1.0)
+      (phase_count phase)
+  ) snapshot_before;
+  (* enrich_per_keeper is observed once per keeper (n_keepers=9) so that
+     Prometheus [sum / count] gives the actual average per-keeper enrich
+     time weighted by fleet size, instead of averaging render-level
+     means.  9 observations of 6.0s each = 54.0s sum, count +9. *)
+  check (float 1e-6) "per-keeper enrich seconds += 54.0 (9 × 6.0)"
+    (per_keeper_sum_before +. 54.0)
     (phase_sum "enrich_per_keeper");
-  check (float 1e-6) "per-keeper enrich count +1"
-    (per_keeper_count_before +. 1.0)
+  check (float 1e-6) "per-keeper enrich count += 9 (one per keeper)"
+    (per_keeper_count_before +. 9.0)
     (phase_count "enrich_per_keeper")
+
+let test_record_timings_skips_per_keeper_when_idle () =
+  let per_keeper_sum_before = phase_sum "enrich_per_keeper" in
+  let per_keeper_count_before = phase_count "enrich_per_keeper" in
+  let total_count_before = phase_count "total" in
+  let idle = { (sample_timings ()) with n_keepers = 0; enrich_ms = 0.0 } in
+  DE.record_render_phase_timings idle;
+  check (float 1e-9) "idle render does not emit enrich_per_keeper sum"
+    per_keeper_sum_before
+    (phase_sum "enrich_per_keeper");
+  check (float 1e-9) "idle render does not emit enrich_per_keeper count"
+    per_keeper_count_before
+    (phase_count "enrich_per_keeper");
+  check (float 1e-6) "idle render still records total observation"
+    (total_count_before +. 1.0)
+    (phase_count "total")
 
 let () =
   run "dashboard_render_timing_9766" [
@@ -96,5 +136,7 @@ let () =
           test_format_with_zero_keepers;
         test_case "record timings emits Prometheus phase metrics" `Quick
           test_record_timings_observes_prometheus;
+        test_case "idle render skips enrich_per_keeper observation" `Quick
+          test_record_timings_skips_per_keeper_when_idle;
       ]);
   ]

--- a/test/test_dashboard_render_timing_9766.ml
+++ b/test/test_dashboard_render_timing_9766.ml
@@ -6,6 +6,7 @@
 
 open Alcotest
 module DE = Masc_mcp.Dashboard_execution
+module Prom = Masc_mcp.Prometheus
 
 let sample_timings () : DE.render_phase_timings_ms = {
   total_ms = 59800.0;
@@ -51,6 +52,37 @@ let test_format_with_zero_keepers () =
   check bool "zero keepers reports per_keeper=0" true
     (Astring.String.is_infix ~affix:"per_keeper=0ms" s)
 
+let phase_sum phase =
+  Prom.metric_value_or_zero
+    Prom.metric_dashboard_execution_render_phase_sec
+    ~labels:[("phase", phase)]
+    ()
+
+let phase_count phase =
+  Prom.metric_value_or_zero
+    (Prom.metric_dashboard_execution_render_phase_sec ^ "_count")
+    ~labels:[("phase", phase)]
+    ()
+
+let test_record_timings_observes_prometheus () =
+  let total_before = phase_sum "total" in
+  let total_count_before = phase_count "total" in
+  let per_keeper_before = phase_sum "enrich_per_keeper" in
+  let per_keeper_count_before = phase_count "enrich_per_keeper" in
+  DE.record_render_phase_timings (sample_timings ());
+  check (float 1e-6) "total phase seconds +59.8"
+    (total_before +. 59.8)
+    (phase_sum "total");
+  check (float 1e-6) "total phase count +1"
+    (total_count_before +. 1.0)
+    (phase_count "total");
+  check (float 1e-6) "per-keeper enrich seconds +6"
+    (per_keeper_before +. 6.0)
+    (phase_sum "enrich_per_keeper");
+  check (float 1e-6) "per-keeper enrich count +1"
+    (per_keeper_count_before +. 1.0)
+    (phase_count "enrich_per_keeper")
+
 let () =
   run "dashboard_render_timing_9766" [
     ("phase_timing", [
@@ -62,5 +94,7 @@ let () =
           test_format_includes_all_phases;
         test_case "format handles zero keepers" `Quick
           test_format_with_zero_keepers;
+        test_case "record timings emits Prometheus phase metrics" `Quick
+          test_record_timings_observes_prometheus;
       ]);
   ]


### PR DESCRIPTION
## Summary
- add a Prometheus histogram for dashboard execution render phase latency
- record total/snapshot/operations/enrich/enrich_per_keeper/data_load/assemble timings on each execution dashboard render
- extend the existing render timing regression test to assert the Prometheus observations

## Verification
- `git diff --check origin/main..HEAD`
- attempted `scripts/dune-local.sh build test/test_dashboard_render_timing_9766.exe`; local Dune queue was blocked for several minutes behind other worktree builds, so this draft relies on PR checks for compilation until the local queue clears

## Review Focus
- metric label cardinality is bounded to the fixed phase vocabulary
- render path only observes existing timings; no dashboard behavior or cache semantics change
