### PR TITLE
fix(coord): allow PR evidence submission for gated todo tasks

### DIFF
--- a/lib/coord/coord_task_lifecycle.ml
+++ b/lib/coord/coord_task_lifecycle.ml
@@ -107,6 +107,18 @@ let decide
   | Masc_domain.Release, (Masc_domain.AwaitingVerification _ | Masc_domain.Done _ | Masc_domain.Cancelled _) ->
     Error Invalid_transition
   (* ── Submit for verification ──────────────────── *)
+  | Masc_domain.Submit_for_verification, Masc_domain.Todo ->
+    if not verification_enabled then Error Verification_disabled
+    else ok
+           (Masc_domain.AwaitingVerification
+              { assignee = agent_name
+              ; submitted_at = now
+              ; verification_id = new_verification_id ()
+              ; deadline =
+                  verification_deadline
+                    ~now
+                    ~timeout_seconds:verification_timeout_seconds
+              })
   | Masc_domain.Submit_for_verification,
     (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ }) ->
     if not verification_enabled then Error Verification_disabled
@@ -123,7 +135,7 @@ let decide
               })
     else Error Invalid_transition
   | Masc_domain.Submit_for_verification,
-    (Masc_domain.Todo | Masc_domain.AwaitingVerification _ | Masc_domain.Done _ | Masc_domain.Cancelled _) ->
+    (Masc_domain.AwaitingVerification _ | Masc_domain.Done _ | Masc_domain.Cancelled _) ->
     if verification_enabled then Error Invalid_transition
     else Error Verification_disabled
   (* ── Approve verification ─────────────────────── *)

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -110,6 +110,13 @@ let assert_task_claimed_by ctx agent_name =
   | Masc_domain.Claimed { assignee; _ } -> assert (assignee = agent_name)
   | _ -> failwith "expected task to be claimed"
 
+let assert_task_awaiting_verification_by ctx agent_name =
+  match (only_task ctx).Masc_domain.task_status with
+  | Masc_domain.AwaitingVerification { assignee; verification_id; _ } ->
+      assert (assignee = agent_name);
+      assert (verification_id <> "")
+  | _ -> failwith "expected task to be awaiting verification"
+
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -1002,6 +1009,41 @@ let () = test "transition_claim_blocks_required_tools_even_with_force" (fun () -
   assert (not success);
   assert (str_contains result "requires tool(s) unavailable");
   assert_task_todo ctx;
+  assert (Planning_eio.get_current_task ctx.config = None)
+)
+
+let () = test "transition_submit_for_verification_accepts_todo_pr_evidence_without_required_tool" (fun () ->
+  let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+  add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "keeper_bash" ];
+  let claim_success, claim_result =
+    Tool_task.handle_transition
+      ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+      ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "claim");
+        ])
+  in
+  assert (not claim_success);
+  assert (str_contains claim_result "requires tool(s) unavailable");
+  assert_task_todo ctx;
+  let submit_success, submit_result =
+    Tool_task.handle_transition
+      ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+      ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "submit_for_verification");
+          ("pr_url", `String "https://github.com/jeong-sik/masc-mcp/pull/13169");
+          ( "notes",
+            `String
+              "Implementation is already merged; submit PR evidence for independent verification." );
+        ])
+  in
+  if not submit_success then failwith submit_result;
+  assert_task_awaiting_verification_by ctx "codex-mcp-client";
   assert (Planning_eio.get_current_task ctx.config = None)
 )
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -93,6 +93,20 @@ let add_task_requiring_tools ctx ~title tools =
   in
   if not success then failwith result
 
+let set_only_task_do_not_reclaim_reason ctx reason =
+  let config = ctx.Tool_task.config in
+  let backlog = Coord.read_backlog config in
+  match backlog.Masc_domain.tasks with
+  | [ task ] ->
+      Coord.write_backlog config
+        { Masc_domain.tasks = [ { task with do_not_reclaim_reason = Some reason } ];
+          last_updated = Masc_domain.now_iso ();
+          version = backlog.version + 1;
+        }
+  | tasks ->
+      failwith
+        (Printf.sprintf "expected exactly one task, got %d" (List.length tasks))
+
 let only_task ctx =
   match Coord.get_tasks_raw ctx.Tool_task.config with
   | [ task ] -> task
@@ -1040,6 +1054,49 @@ let () = test "transition_submit_for_verification_accepts_todo_pr_evidence_witho
           ( "notes",
             `String
               "Implementation is already merged; submit PR evidence for independent verification." );
+        ])
+  in
+  if not submit_success then failwith submit_result;
+  assert_task_awaiting_verification_by ctx "codex-mcp-client";
+  assert (Planning_eio.get_current_task ctx.config = None)
+)
+
+let () = test "transition_submit_for_verification_accepts_todo_pr_evidence_with_stale_do_not_reclaim_reason" (fun () ->
+  let ctx = make_test_ctx_with_agent "codex-mcp-client" in
+  let success, result =
+    Tool_task.handle_add_task ctx
+      (`Assoc
+        [
+          ("title", `String "Strict accessor PR evidence");
+          ("priority", `Int 1);
+        ])
+  in
+  if not success then failwith result;
+  set_only_task_do_not_reclaim_reason ctx
+    "Auto-claimed via auto_goal_fallback by issue_king without repo write tools";
+  let claim_success, claim_result =
+    Tool_task.handle_transition ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "claim");
+        ])
+  in
+  assert (not claim_success);
+  assert (str_contains claim_result "blocked from re-claim");
+  assert_task_todo ctx;
+  let submit_success, submit_result =
+    Tool_task.handle_transition
+      ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+      ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "submit_for_verification");
+          ("pr_url", `String "https://github.com/jeong-sik/masc-mcp/pull/13185");
+          ( "notes",
+            `String
+              "A stale do_not_reclaim_reason blocks claim, but merged PR evidence can still enter verification." );
         ])
   in
   if not submit_success then failwith submit_result;


### PR DESCRIPTION
## Summary
- Allow submit_for_verification directly from todo so merged PR evidence can enter the verifier FSM even when claim is blocked by required_tools or a stale do_not_reclaim_reason.
- Keep required_tools and do_not_reclaim_reason enforcement on claim; approval still requires a separate verifier.
- Add regression coverage for both gated cases: keeper_bash remains unavailable for claim, and stale reclaim blockers still allow PR evidence submission to awaiting_verification.
- Covers the live stuck evidence for task-150, task-151, task-185, task-186, and task-125 recorded on #13171.

## Validation
- git diff --check
- scripts/check-oas-pin.sh --local-only
- scripts/dune-local.sh build test/test_tool_task_coverage.exe
- _build/default/test/test_tool_task_coverage.exe (68 tests)

Closes #13171