### PR TITLE
fix(repo): discover grouped workspace repositories

### DIFF
--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -330,7 +330,7 @@ let discover_repositories ~base_path =
   let git_dirs =
     try
       let cmd =
-        Printf.sprintf "find %s -name \".git\" -maxdepth 4 -type d 2>/dev/null"
+        Printf.sprintf "find %s -maxdepth 4 -name \".git\" -type d 2>/dev/null"
           (Filename.quote base_path)
       in
       let ic = Unix.open_process_in cmd in
@@ -367,7 +367,9 @@ let discover_repositories ~base_path =
         rel
         |> String.split_on_char '/'
         |> List.exists (fun segment ->
-               String.length segment > 0 && Char.equal segment.[0] '.')
+               String.length segment > 0
+               && (not (String.equal segment "." || String.equal segment ".."))
+               && Char.equal segment.[0] '.')
   in
   let candidates =
     List.filter_map

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -330,7 +330,7 @@ let discover_repositories ~base_path =
   let git_dirs =
     try
       let cmd =
-        Printf.sprintf "find %s -name \".git\" -maxdepth 3 -type d 2>/dev/null"
+        Printf.sprintf "find %s -name \".git\" -maxdepth 4 -type d 2>/dev/null"
           (Filename.quote base_path)
       in
       let ic = Unix.open_process_in cmd in
@@ -346,10 +346,28 @@ let discover_repositories ~base_path =
     with
     | Sys_error _ | Unix.Unix_error _ | Failure _ -> []
   in
-  let is_masc_dir path =
-    let masc_prefix = Filename.concat base_path ".masc" in
-    String.length path >= String.length masc_prefix
-    && String.sub path 0 (String.length masc_prefix) = masc_prefix
+  let has_hidden_segment_under_base path =
+    if String.equal path base_path then false
+    else
+      let base_prefix =
+        if String.length base_path > 0
+           && Char.equal base_path.[String.length base_path - 1] '/'
+        then base_path
+        else base_path ^ "/"
+      in
+      let prefix_len = String.length base_prefix in
+      if
+        String.length path < prefix_len
+        || not (String.equal (String.sub path 0 prefix_len) base_prefix)
+      then false
+      else
+        let rel =
+          String.sub path prefix_len (String.length path - prefix_len)
+        in
+        rel
+        |> String.split_on_char '/'
+        |> List.exists (fun segment ->
+               String.length segment > 0 && Char.equal segment.[0] '.')
   in
   let candidates =
     List.filter_map
@@ -359,7 +377,7 @@ let discover_repositories ~base_path =
           if Filename.is_relative repo_dir then Filename.concat base_path repo_dir
           else repo_dir
         in
-        if is_masc_dir abs_repo_dir then None
+        if has_hidden_segment_under_base abs_repo_dir then None
         else if List.exists (String.equal abs_repo_dir) existing_paths then None
         else
           let url_cmd =

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -44,7 +44,7 @@ val local_path : base_path:string -> repository -> string
 
 val discover_repositories : base_path:string -> (repository list, string) result
 (** [discover_repositories ~base_path] scans [base_path] for git repositories
-    (directories containing [.git] up to depth 3) and returns a list of
+    (directories containing [.git] up to depth 4) and returns a list of
     candidate {!repository} records inferred from their [origin] remote URL.
 
     Directories under [.masc/] and repositories already registered in

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -314,6 +314,26 @@ let test_discover_ignores_hidden_dirs () =
             Alcotest.(check int) "ignores hidden directory repo" 0
               (List.length repos))
 
+let test_discover_relative_base_path_keeps_visible_repos () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let repo_a = Filename.concat base_path "project-a" in
+        Unix.mkdir repo_a 0o755;
+        init_git_repo repo_a "https://github.com/test/project-a";
+        let cwd = Sys.getcwd () in
+        Fun.protect
+          ~finally:(fun () -> Sys.chdir cwd)
+          (fun () ->
+            Sys.chdir base_path;
+            match Repo_store.discover_repositories ~base_path:"." with
+            | Error e -> Alcotest.fail ("discover failed: " ^ e)
+            | Ok repos ->
+                Alcotest.(check int) "finds visible repo under relative base" 1
+                  (List.length repos);
+                let repo = List.hd repos in
+                Alcotest.(check string) "id" "project-a" repo.id))
+
 let test_migration_backward_compat_to_explicit () =
   with_temp_base_path (fun base_path ->
       (* Phase 1: no TOML — backward compat returns default repo *)
@@ -495,6 +515,8 @@ let () =
             test_discover_finds_grouped_workspace_repos;
           Alcotest.test_case "ignores hidden dirs" `Quick
             test_discover_ignores_hidden_dirs;
+          Alcotest.test_case "relative base path keeps visible repos" `Quick
+            test_discover_relative_base_path_keeps_visible_repos;
           Alcotest.test_case "skips registered repos" `Quick test_discover_skips_registered;
         ] );
       ( "migration",

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -279,6 +279,41 @@ let test_discover_ignores_masc_dir () =
         | Ok repos ->
             Alcotest.(check int) "ignores .masc repo" 0 (List.length repos))
 
+let test_discover_finds_grouped_workspace_repos () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let workspace = Filename.concat base_path "workspace" in
+        let group = Filename.concat workspace "yousleepwhen" in
+        let repo_dir = Filename.concat group "oas" in
+        Unix.mkdir workspace 0o755;
+        Unix.mkdir group 0o755;
+        Unix.mkdir repo_dir 0o755;
+        init_git_repo repo_dir "https://github.com/test/oas";
+        match Repo_store.discover_repositories ~base_path with
+        | Error e -> Alcotest.fail ("discover failed: " ^ e)
+        | Ok repos ->
+            Alcotest.(check int) "finds grouped workspace repo" 1
+              (List.length repos);
+            let repo = List.hd repos in
+            Alcotest.(check string) "id" "oas" repo.id;
+            Alcotest.(check string) "local_path" repo_dir repo.local_path)
+
+let test_discover_ignores_hidden_dirs () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+        let cache_dir = Filename.concat base_path ".cache" in
+        let cache_repo = Filename.concat cache_dir "llama.cpp" in
+        Unix.mkdir cache_dir 0o755;
+        Unix.mkdir cache_repo 0o755;
+        init_git_repo cache_repo "https://github.com/test/llama.cpp";
+        match Repo_store.discover_repositories ~base_path with
+        | Error e -> Alcotest.fail ("discover failed: " ^ e)
+        | Ok repos ->
+            Alcotest.(check int) "ignores hidden directory repo" 0
+              (List.length repos))
+
 let test_migration_backward_compat_to_explicit () =
   with_temp_base_path (fun base_path ->
       (* Phase 1: no TOML — backward compat returns default repo *)
@@ -456,6 +491,10 @@ let () =
         [
           Alcotest.test_case "finds git repos" `Quick test_discover_finds_git_repos;
           Alcotest.test_case "ignores .masc repos" `Quick test_discover_ignores_masc_dir;
+          Alcotest.test_case "finds grouped workspace repos" `Quick
+            test_discover_finds_grouped_workspace_repos;
+          Alcotest.test_case "ignores hidden dirs" `Quick
+            test_discover_ignores_hidden_dirs;
           Alcotest.test_case "skips registered repos" `Quick test_discover_skips_registered;
         ] );
       ( "migration",


### PR DESCRIPTION
## Summary
- expand repository discovery to include grouped workspace repos such as `workspace/yousleepwhen/oas`
- exclude repositories under hidden base-path segments like `.cache` and `.masc`
- add regression coverage for grouped workspace discovery and hidden-dir exclusion

## Why it matters
The Code IDE scan button from #13173 now registers discovered repositories, but the actual finder still missed repos nested one level deeper under `~/me/workspace/<group>/<repo>` and could persist hidden cache repos. This PR makes the scan usable against the real `/Users/dancer/me` base path without adding cache/runtime internals.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_repo_store.exe`
- `./_build/default/test/test_repo_store.exe` (26 tests)