### PR TITLE
docs: audit goal loop completion state

### DIFF
--- a/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
+++ b/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
@@ -1,0 +1,274 @@
+# Audit Response — 2026-05-05 GOAL LOOP Completion Audit
+
+## Source
+
+- **Input**: user-supplied GOAL LOOP integration design titled
+  `Observe -> Orient -> Decide -> Act -> Verify`, 작성일 2026-05-05.
+- **Scope**: original sections 0-9, including startup-log reproduction,
+  Observe/Orient/Decide/Act/Verify wiring, dashboard, anti-stagnation rules,
+  and expected convergence.
+- **Purpose**: completion audit only. This document does **not** mark the loop
+  complete. It freezes what is already shipped on `main`, what is still only a
+  deterministic fixture, and what still has no ACT artifact.
+
+## Evidence Snapshot
+
+- [근거] `gh pr view 13124 --json number,state,mergedAt,mergeCommit,title,url`
+  checked at 2026-05-05T11:27:03Z, confidence High:
+  #13124 merged at 2026-05-05T10:32:29Z, merge
+  `8250ca7262f4bef1834829410ae9a4856cc8cb54`.
+- [근거] `gh pr view 13123 --json number,state,mergedAt,mergeCommit,title,url`
+  checked at 2026-05-05T11:27:03Z, confidence High:
+  #13123 merged at 2026-05-05T11:02:25Z, merge
+  `8dd4b58ac8fdd4402a44cb29bfea789c1358c115`.
+- [근거] `gh pr view 13126 --json number,state,mergedAt,mergeCommit,title,url`
+  checked at 2026-05-05T11:27:03Z, confidence High:
+  #13126 merged at 2026-05-05T10:52:02Z, merge
+  `dbba4b032e29b49ffa857dcfa4436182113e940f`.
+- [근거] `gh pr view 13138 --json number,state,mergedAt,mergeCommit,title,url`
+  checked at 2026-05-05T11:27:03Z, confidence High:
+  #13138 merged at 2026-05-05T10:42:56Z, merge
+  `8fd212d968172724baa2eb707cca0558280bc811`.
+- [근거] `gh pr view 13143 --json number,state,mergedAt,mergeCommit,title,url`
+  checked at 2026-05-05T11:27:03Z, confidence High:
+  #13143 merged at 2026-05-05T10:43:25Z, merge
+  `00b45b4dcb8651c0139fd05d70b5d7e276001147`.
+- [근거] `gh pr view 13172 --json number,state,mergedAt,mergeCommit,title,url`
+  checked at 2026-05-05T11:27:03Z, confidence High:
+  #13172 merged at 2026-05-05T11:15:44Z, merge
+  `f871b55840ab96d6fe08d05a2f099aee739b70d4`.
+- [근거] `gh pr view 13178 --json number,state,mergedAt,mergeCommit,title,url`
+  checked at 2026-05-05T11:27:03Z, confidence High:
+  #13178 merged at 2026-05-05T11:23:39Z, merge
+  `23887a0101c812907ed2b7348c5cf80351f4939c`.
+- [근거] `python3 scripts/validate_goal_loop_act_map.py
+  test/fixtures/goal_loop/act-map.startup.json --known-prs-json
+  test/fixtures/goal_loop/known-prs.startup.json --require-pr-ref --fail-on any`
+  is the deterministic ACT-reference guard added by #13178.
+- [근거] `python3 scripts/goal_loop_status.py --observe-json
+  test/fixtures/goal_loop/observe.startup.json --orient-json
+  test/fixtures/goal_loop/orient.startup.json --decide-json
+  /tmp/goal-loop-decide-audit.json --verify-json
+  test/fixtures/goal_loop/verify.fail.json --loop-iteration '#fixture'
+  --format text` checked at 2026-05-05T11:30:45Z, confidence High:
+  `next_action` is `D-EMERGENCY-1`, the missing ACT item.
+
+## Current Completion State
+
+| Area | Status | Reason |
+|------|--------|--------|
+| Deterministic GOAL LOOP replay | **PARTIAL** | Fixture bundle exists and proves the loop stays critical, but it is not live production ingestion. |
+| Provider health skip ACT | **PARTIAL** | #13124 adds provider probe ACT artifact; live zero-skipped proof still requires runtime verification. |
+| Alive-but-stuck recovery ACT | **PARTIAL** | #13123 adds recovery side effect; #13126 adds timeout phase diagnostics. Runtime recovery success SLO remains unproven. |
+| Keeper TOML unknown-key visibility | **PARTIAL** | #13138 surfaces unknown keys in health; strict schema rejection is not yet enforced. |
+| Governance fallback visibility | **PARTIAL** | #13143 exposes fallback counters; strict judge-output failure policy is not complete. |
+| Slot forced reclaim + credential auto-recovery | **FAIL** | `D-EMERGENCY-1` is still `ACT_MISSING` in `act-map.startup.json`. |
+| Full 206-finding Orient engine | **NOT PROVEN** | Current deterministic fixture covers 10 startup findings, not all 206 audit findings. |
+| Full Verify pipeline | **FAIL BY DESIGN** | `verify.fail.json` intentionally keeps the replay red until missing ACT is linked and runtime checks pass. |
+
+## Section-by-Section Audit
+
+### 0. Live Startup Log Reproduction
+
+**Claimed requirement**: server-startup logs reproduce the 206-finding audit:
+provider health skipped, credential starvation, alive-but-stuck, governance
+fallback, unknown TOML keys, all-zero metrics, linear warmup.
+
+**Shipped**:
+
+- `test/fixtures/goal_loop/observe.startup.json`
+- `test/fixtures/goal_loop/orient.startup.json`
+- `test/fixtures/goal_loop/verify.fail.json`
+- `docs/examples/goal-loop-fixture.md`
+
+**Status**: **PARTIAL**.
+
+The fixture pins concrete startup evidence for NF-1, NF-2, NF-3, NF-4, and
+NF-6. It does not yet prove all 206 audit findings from live production state,
+and several prompt claims remain evidence-absent in the fixture (`NF-5`,
+`NF-7`, `NF-8`, `R-FATAL-1`, `CF-1`).
+
+**Verification command**:
+
+```bash
+python3 scripts/goal_loop_status.py \
+  --observe-json test/fixtures/goal_loop/observe.startup.json \
+  --orient-json test/fixtures/goal_loop/orient.startup.json \
+  --decide-json /tmp/goal-loop-decide.json \
+  --verify-json test/fixtures/goal_loop/verify.fail.json \
+  --loop-iteration "#fixture" \
+  --format text
+```
+
+### 1. GOAL LOOP Architecture
+
+**Claimed requirement**: Observe -> Orient -> Decide -> Act -> Verify loop with
+FAIL re-entry and phase cadence.
+
+**Shipped**:
+
+- `scripts/observe_goal_loop_logs.py`
+- `scripts/orient_goal_loop_logs.py`
+- `scripts/decide_goal_loop_findings.py`
+- `scripts/verify_goal_loop_logs.py`
+- `scripts/goal_loop_status.py`
+- `test/test_goal_loop_status.py`
+
+**Status**: **PARTIAL**.
+
+The deterministic phase chain exists. Cadence scheduling (5s Observe, 1m
+Orient, 1h Decide, 1d Act, 5m Verify) is not yet implemented as a long-running
+runtime loop.
+
+### 2. OBSERVE
+
+**Claimed requirement**: Prometheus/Grafana metrics plus automated log-pattern
+parsing.
+
+**Shipped**:
+
+- Startup-log pattern replay via `observe_goal_loop_logs.py`.
+- Fixture coverage for provider-health skipped, credential archived
+  starvation, alive-but-stuck, governance fallback, and unknown config keys.
+
+**Status**: **PARTIAL**.
+
+The log parser path exists. The complete Prometheus metric set from the prompt
+is not fully implemented as runtime metrics, and live scrape/dashboard
+evidence is still required before this can be marked PASS.
+
+### 3. ORIENT
+
+**Claimed requirement**: automated comparison between audit findings and
+current runtime/code state, including 206 findings.
+
+**Shipped**:
+
+- `orient_goal_loop_logs.py` classifies startup findings into
+  `EVIDENCE_PRESENT` and `EVIDENCE_ABSENT`.
+- `orient.startup.json` produces 10 deterministic finding rows.
+
+**Status**: **PARTIAL**.
+
+The Orient skeleton is testable, but the prompt's full 206-finding audit set is
+not encoded. Current output should be treated as startup-regression coverage,
+not complete audit closure.
+
+### 4. DECIDE
+
+**Claimed requirement**: priority algorithm and concrete P0/P1/P2 decision
+queue.
+
+**Shipped**:
+
+- `decide_goal_loop_findings.py` maps evidence-present findings to:
+  `D-EMERGENCY-1`, `D-EMERGENCY-2`, `D-P1-1`, `D-P1-2`, `D-P2-1`, `D-P2-2`.
+- `act-map.startup.json` links four decisions to real PR artifacts.
+- `validate_goal_loop_act_map.py` verifies PR-shaped ACT artifacts.
+
+**Status**: **PARTIAL**.
+
+The priority queue is deterministic. It intentionally reports
+`D-EMERGENCY-1` as `ACT_MISSING`, so Decide cannot be considered complete.
+
+### 5. ACT
+
+**Claimed requirement**: code implementation and PR merge for the selected
+decisions.
+
+| Decision | Finding | ACT status | Evidence |
+|----------|---------|------------|----------|
+| `D-EMERGENCY-1` | `NF-2` credential archived starvation | **MISSING** | No linked ACT artifact. |
+| `D-EMERGENCY-2` | `NF-1` provider health skipped | **LINKED** | #13124 `fix: probe local providers in cascade catalog`. |
+| `D-P1-1` | `NF-3`, `R-FATAL-1` recovery/fallback | **LINKED** | #13123 recovery side effect, #13126 timeout phase diagnostics. |
+| `D-P1-2` | `CF-1` pricing catalog miss | **NOT QUEUED IN FIXTURE** | `CF-1` is `EVIDENCE_ABSENT` in `orient.startup.json`; needs live-pricing audit if seen again. |
+| `D-P2-1` | `NF-6` unknown keeper TOML keys | **LINKED** | #13138 health visibility. |
+| `D-P2-2` | `NF-4` governance fallback | **LINKED** | #13143 fallback counters. |
+
+**Status**: **FAIL** until `D-EMERGENCY-1` has an ACT PR or the Orient evidence
+is disproven by live replay.
+
+### 6. VERIFY
+
+**Claimed requirement**: unit tests, regression tests, TLA+ checks, production
+log verification, metric verification, and Orient re-check.
+
+**Shipped**:
+
+- Deterministic fixture replay.
+- Regression tests for Decide/status/ACT-map validation.
+- `verify.fail.json` that keeps the loop red.
+
+**Status**: **FAIL BY DESIGN**.
+
+This is correct current behavior. A PASS would be unsafe because the fixture
+still contains `NF-2` and `D-EMERGENCY-1` is missing ACT.
+
+### 7. GOAL LOOP Dashboard
+
+**Claimed requirement**: unified real-time dashboard showing phase state,
+system health, next action, and counts.
+
+**Shipped**:
+
+- `goal_loop_status.py` emits the compact phase status and next action.
+- This audit slice changes `goal_loop_status.py` so `next_action` prefers
+  `ACT_MISSING` / `ACT_UNMAPPED` decisions over already-linked decisions.
+- `docs/examples/goal-loop-fixture.md` documents text and JSON status replay.
+
+**Status**: **PARTIAL**.
+
+The dashboard data shape exists as CLI JSON/text. It is not yet integrated into
+the operator dashboard as a real-time panel.
+
+### 8. Anti-Stagnation
+
+**Claimed requirement**: every `STILL_PRESENT` finding must have ACT, ACT must
+be created within 48h, Verify within 24h, failure within 4h, and week-old
+findings escalate.
+
+**Shipped**:
+
+- #13178 adds an ACT-reference guard so artifact strings cannot silently point
+  to nonexistent PR numbers.
+- The fixture explicitly fails when a P0 decision has no ACT artifact.
+
+**Status**: **PARTIAL**.
+
+Reference integrity is guarded. SLA timers, automatic escalation, and
+merge/rollback enforcement are not implemented.
+
+### 9. Expected Convergence
+
+**Claimed requirement**: after one week, keepers/providers/throughput should be
+healthy and `STILL_PRESENT < 20`; after one month, `STILL_PRESENT = 0`.
+
+**Status**: **NOT PROVEN**.
+
+No convergence claim is valid yet. The only safe current statement is:
+
+- The deterministic fixture still reports overall critical.
+- Four ACT artifacts are linked and merged.
+- One P0 ACT artifact is missing.
+- Live runtime replay is required before any "fixed" or "healthy" claim.
+
+## Next Concrete ACT
+
+1. Implement or disprove `D-EMERGENCY-1`: slot forced reclaim plus keeper
+   credential auto-recovery for `NF-2`.
+2. Extend Orient input from the 10 startup fixture findings to the full
+   206-finding audit corpus, or attach the corpus source path if it already
+   exists outside this repo.
+3. Wire `goal_loop_status.py` JSON into the operator dashboard only after the
+   fixture's critical state is preserved in UI tests.
+4. Add SLA state for anti-stagnation after ACT coverage is complete; otherwise
+   timers will only escalate known missing work without changing recovery.
+
+## Do-Not-Close Rule
+
+Do not mark the GOAL LOOP objective complete while any of these are true:
+
+- `D-EMERGENCY-1` remains absent from `act-map.startup.json`.
+- `verify.fail.json` is the latest Verify fixture.
+- The full 206-finding audit corpus is not replayed by Orient.
+- Live runtime evidence is not re-collected after the ACT PRs are merged.

--- a/docs/audit-responses/README.md
+++ b/docs/audit-responses/README.md
@@ -55,3 +55,7 @@ false positive를 다시 내지 않게 하는 audit memory 역할을 합니다.
   의 4-phase × 18 action item (16→36 keeper 확장 통합 재설계) 매트릭스. 정량
   클레임 70%가 stale 또는 active 트랙과 중복; 진짜 design idea(생성 CLI/API,
   N+1 batch, 3-Tier disclosure, env unification)는 RFC-0029~0032 후보로 분리.
+- `2026-05-05-goal-loop-completion-audit.md` — GOAL LOOP 원문 0-9 섹션별
+  completion audit. #13124, #13123, #13126, #13138, #13143, #13172, #13178
+  를 실제 ACT/fixture 근거로 연결하고, `D-EMERGENCY-1` credential
+  auto-recovery가 아직 `ACT_MISSING`임을 명시.

--- a/scripts/goal_loop_status.py
+++ b/scripts/goal_loop_status.py
@@ -103,7 +103,9 @@ def summarize_observe(observe: dict[str, Any] | None) -> PhaseStatus:
     status = (
         "critical"
         if critical_matches > 0
-        else "warning" if warning_matches > 0 else "ok"
+        else "warning"
+        if warning_matches > 0
+        else "ok"
     )
     return PhaseStatus(
         status=status,
@@ -136,7 +138,9 @@ def summarize_orient(orient: dict[str, Any] | None) -> PhaseStatus:
     status = (
         "critical"
         if critical_present > 0
-        else "warning" if evidence_present > 0 else "ok"
+        else "warning"
+        if evidence_present > 0
+        else "ok"
     )
     present_findings = []
     findings = orient.get("findings", [])
@@ -171,8 +175,12 @@ def decide_next_action(decide: dict[str, Any] | None) -> dict[str, Any] | None:
     decisions = decide.get("decisions", [])
     if not isinstance(decisions, list) or not decisions:
         return None
-    first = decisions[0]
-    return first if isinstance(first, dict) else None
+    typed_decisions = [decision for decision in decisions if isinstance(decision, dict)]
+    for status in ("ACT_MISSING", "ACT_UNMAPPED"):
+        for decision in typed_decisions:
+            if decision.get("act_status") == status:
+                return decision
+    return typed_decisions[0] if typed_decisions else None
 
 
 def summarize_decide(decide: dict[str, Any] | None) -> PhaseStatus:
@@ -183,11 +191,7 @@ def summarize_decide(decide: dict[str, Any] | None) -> PhaseStatus:
     p0_count = as_int(decide.get("p0_count"))
     act_missing_count = as_int(decide.get("act_missing_count"), default=-1)
     act_linked_count = as_int(decide.get("act_linked_count"), default=-1)
-    status = (
-        "critical"
-        if p0_count > 0
-        else "warning" if decisions_total > 0 else "ok"
-    )
+    status = "critical" if p0_count > 0 else "warning" if decisions_total > 0 else "ok"
     summary: dict[str, Any] = {
         "decisions_total": decisions_total,
         "p0_count": p0_count,
@@ -211,7 +215,9 @@ def summarize_act(decide: dict[str, Any] | None) -> PhaseStatus:
         status = (
             "critical"
             if act_missing_count > 0
-            else "ok" if decisions_total == 0 or act_linked_count > 0 else "warning"
+            else "ok"
+            if decisions_total == 0 or act_linked_count > 0
+            else "warning"
         )
         return PhaseStatus(
             status=status,
@@ -273,9 +279,7 @@ def system_health_signals(observe: dict[str, Any] | None) -> dict[str, Any]:
             "cas_retry": pattern_count(observe, "cas_retry"),
         },
         "governance_patterns": {
-            "governance_unparseable": pattern_count(
-                observe, "governance_unparseable"
-            ),
+            "governance_unparseable": pattern_count(observe, "governance_unparseable"),
             "lenient_json_fallback": pattern_count(observe, "lenient_json_fallback"),
         },
     }
@@ -322,7 +326,9 @@ def report_to_text(report: GoalLoopStatus) -> str:
     ]
     for name in ("observe", "orient", "decide", "act", "verify"):
         phase = report.phases[name]
-        lines.append(f"- {name}: {phase.status} {json.dumps(phase.summary, sort_keys=True)}")
+        lines.append(
+            f"- {name}: {phase.status} {json.dumps(phase.summary, sort_keys=True)}"
+        )
     if report.next_action:
         decision_id = report.next_action.get("decision_id", "unknown")
         action = report.next_action.get("action", "unknown")

--- a/test/test_goal_loop_status.py
+++ b/test/test_goal_loop_status.py
@@ -116,6 +116,38 @@ class GoalLoopStatusTest(unittest.TestCase):
         self.assertEqual(report.phases["act"].status, "ok")
         self.assertIsNone(report.next_action)
 
+    def test_next_action_prefers_missing_act_over_linked_decision(self) -> None:
+        report = goal_loop_status.build_status_report(
+            observe=None,
+            orient=None,
+            decide={
+                "decisions_total": 2,
+                "p0_count": 2,
+                "act_missing_count": 1,
+                "act_linked_count": 1,
+                "decisions": [
+                    {
+                        "decision_id": "D-EMERGENCY-2",
+                        "action": "Run bootstrap provider health checks",
+                        "act_status": "ACT_LINKED",
+                    },
+                    {
+                        "decision_id": "D-EMERGENCY-1",
+                        "action": "Slot forced reclaim + credential auto-recovery",
+                        "act_status": "ACT_MISSING",
+                    },
+                ],
+            },
+            verify=None,
+            generated_at="2026-05-05T10:00:00+00:00",
+        )
+
+        self.assertEqual(report.next_action["decision_id"], "D-EMERGENCY-1")
+        self.assertEqual(
+            report.phases["decide"].summary["next_action"]["decision_id"],
+            "D-EMERGENCY-1",
+        )
+
     def test_missing_inputs_are_unknown(self) -> None:
         report = goal_loop_status.build_status_report(
             observe=None,
@@ -288,6 +320,7 @@ class GoalLoopStatusTest(unittest.TestCase):
         self.assertEqual(payload["loop_iteration"], "#fixture")
         self.assertEqual(payload["phases"]["decide"]["summary"]["act_linked_count"], 4)
         self.assertEqual(payload["phases"]["act"]["summary"]["act_missing_count"], 1)
+        self.assertEqual(payload["next_action"]["decision_id"], "D-EMERGENCY-1")
         self.assertEqual(
             payload["system_health_signals"]["keeper_failure_patterns"][
                 "credential_archived_starvation"


### PR DESCRIPTION
## What changed

- Added `docs/audit-responses/2026-05-05-goal-loop-completion-audit.md`, mapping the GOAL LOOP prompt sections 0-9 to shipped PRs, deterministic fixture coverage, and remaining gaps.
- Updated the audit-response README to include the new completion-audit artifact.
- Fixed `goal_loop_status.py` so `next_action` prefers unresolved ACT work (`ACT_MISSING` / `ACT_UNMAPPED`) over already-linked decisions.
- Added regression coverage proving the startup fixture now points next action at `D-EMERGENCY-1`.

## Why it matters

The loop must not be marked complete while the fixture still has one missing P0 ACT. Before this patch, the status surface could show an already-linked provider-health decision as `next_action`, even though `D-EMERGENCY-1` was the actual missing action. That made the operator path ambiguous.

## Validation

- `npx pyright --outputjson scripts/goal_loop_status.py test/test_goal_loop_status.py`
- `ruff check scripts/goal_loop_status.py test/test_goal_loop_status.py`
- `ruff format --check scripts/goal_loop_status.py test/test_goal_loop_status.py`
- `python3 test/test_goal_loop_status.py`
- `python3 scripts/validate_goal_loop_act_map.py test/fixtures/goal_loop/act-map.startup.json --known-prs-json test/fixtures/goal_loop/known-prs.startup.json --require-pr-ref --fail-on any`
- `python3 scripts/goal_loop_status.py --observe-json test/fixtures/goal_loop/observe.startup.json --orient-json test/fixtures/goal_loop/orient.startup.json --decide-json /tmp/goal-loop-decide-audit.json --verify-json test/fixtures/goal_loop/verify.fail.json --loop-iteration '#fixture' --format text`
- `git diff --check`
