### PR TITLE
fix(keeper): allow partial stale recovery restarts

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -103,6 +103,29 @@ val reactive_slot_holders : now:float -> (string * float) list
     classification. Returns released pool labels. *)
 val force_release_stale_holder : keeper_name:string -> string list
 
+(** Test-only: TTL used to bound orphaned force-release markers left behind
+    when a cancelled stale fiber never reaches its finalizer. *)
+val force_released_marker_ttl_sec_for_test : float
+
+(** Test-only: count force-release markers still awaiting finalizer
+    consumption or expiry pruning. *)
+val force_released_marker_count_for_test : unit -> int
+
+(** Test-only: inject a marker without touching semaphores, so marker-retention
+    behavior can be exercised without creating a double-release path. *)
+val add_force_released_marker_for_test :
+  label:string ->
+  keeper_name:string ->
+  acquisition_id:int ->
+  marked_at:float ->
+  unit
+
+(** Test-only: prune expired force-release markers using an injected clock. *)
+val purge_force_released_markers_for_test : now:float -> unit
+
+(** Test-only: clear force-release markers between tests. *)
+val clear_force_released_markers_for_test : unit -> unit
+
 (** Render a compact holder list such as [[keeper-a/181s, +2 more]].
     The input is expected to be sorted longest-first, as returned by the
     holder accessors above. *)

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -99,6 +99,10 @@ val turn_slot_holders : now:float -> (string * float) list
 val autonomous_slot_holders : now:float -> (string * float) list
 val reactive_slot_holders : now:float -> (string * float) list
 
+(** Force-release semaphore permits held by [keeper_name] after watchdog stale
+    classification. Returns released pool labels. *)
+val force_release_stale_holder : keeper_name:string -> string list
+
 (** Render a compact holder list such as [[keeper-a/181s, +2 more]].
     The input is expected to be sorted longest-first, as returned by the
     holder accessors above. *)

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -121,6 +121,21 @@ let stale_kill_class_label (cls : Keeper_registry.stale_kill_class) : string =
   | In_turn_hung _ -> "in_turn_hung"
   | Noop_failure_loop _ -> "noop_failure_loop"
 
+let slot_holder_age ~now keeper_name =
+  let holder_age holders = List.assoc_opt keeper_name holders in
+  [
+    holder_age (Keeper_turn_slot.turn_slot_holders ~now);
+    holder_age (Keeper_turn_slot.reactive_slot_holders ~now);
+    holder_age (Keeper_turn_slot.autonomous_slot_holders ~now);
+  ]
+  |> List.filter_map Fun.id
+  |> function
+  | [] -> None
+  | age :: rest -> Some (List.fold_left (fun acc age -> max acc age) age rest)
+
+let slot_holder_age_for_test ~now ~keeper_name =
+  slot_holder_age ~now keeper_name
+
 let has_recent_skip_observation ~now ~threshold
     (entry : Keeper_registry.registry_entry) : bool =
   match entry.last_skip_observation with
@@ -266,7 +281,21 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    && fiber_age >= grace_period_sec ()
                  , elapsed
                  , false )
-               | None ->
+               | None -> (
+                 match slot_holder_age ~now meta.name with
+                 | Some elapsed ->
+                   (* A keeper can still own reactive/turn semaphores even
+                      when the registry observation is absent or has been
+                      replaced by restart bookkeeping. Treat holder evidence
+                      as in-flight work; otherwise the watchdog restarts a
+                      keeper at the short idle threshold while the old fiber
+                      still owns slots, causing fleet-wide slot starvation. *)
+                   ( false
+                   , elapsed > active_turn_timeout_sec
+                     && fiber_age >= grace_period_sec ()
+                   , elapsed
+                   , false )
+                 | None ->
                  let skip_observed =
                    has_recent_skip_observation ~now ~threshold entry
                  in
@@ -276,7 +305,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    && fiber_age >= grace_period_sec ()
                    && not skip_observed
                  in
-                 (stale, false, 0.0, skip_observed)
+                 (stale, false, 0.0, skip_observed))
              in
              let noop_count =
                entry.meta.runtime.proactive_rt.consecutive_noop_count
@@ -375,6 +404,18 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                Keeper_registry.set_failure_reason ~base_path meta.name
                  (Keeper_registry.stale_watchdog_failure_reason
                     ~prior:prior_failure_reason ~kill_class);
+               let force_released_slots =
+                 if in_turn_stale then
+                   Keeper_turn_slot.force_release_stale_holder
+                     ~keeper_name:meta.name
+                 else
+                   []
+               in
+               if force_released_slots <> [] then
+                 Log.Keeper.error
+                   "%s: stale watchdog force-released holder slot(s) [%s] \
+                    before restart"
+                   meta.name (String.concat "," force_released_slots);
                (* tla-lint: allow-mutation: fiber signal — stop the wedged keeper after stale-turn classification *)
                request_watchdog_stop ();
                let window_count = record_stale_termination meta.name now in

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -271,6 +271,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                let turn_timeout = Keeper_runtime_resolved.turn_timeout_sec () in
                Float.max turn_timeout threshold
              in
+             let active_slot_holder_age = slot_holder_age ~now meta.name in
              let idle_stale, in_turn_stale, in_turn_age,
                  idle_skip_suppressed =
                match entry.current_turn_observation with
@@ -282,7 +283,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  , elapsed
                  , false )
                | None -> (
-                 match slot_holder_age ~now meta.name with
+                 match active_slot_holder_age with
                  | Some elapsed ->
                    (* A keeper can still own reactive/turn semaphores even
                       when the registry observation is absent or has been
@@ -405,7 +406,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  (Keeper_registry.stale_watchdog_failure_reason
                     ~prior:prior_failure_reason ~kill_class);
                let force_released_slots =
-                 if in_turn_stale then
+                 if in_turn_stale || Option.is_some active_slot_holder_age then
                    Keeper_turn_slot.force_release_stale_holder
                      ~keeper_name:meta.name
                  else

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -4,6 +4,12 @@
 
 open Keeper_types
 
+val slot_holder_age_for_test :
+  now:float -> keeper_name:string -> float option
+(** Test-only view of the watchdog's fallback in-flight signal.  Returns
+    the oldest slot-holder age for [keeper_name] across turn, reactive,
+    and autonomous holder tables. *)
+
 val fork_stale_watchdog :
   'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
 (** Fork a stale-turn watchdog fiber for the given keeper.

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -750,6 +750,12 @@ let cleanup_dead_tombstone (ctx : _ context)
     here on first build (the recurring P0 pattern from #10490 + #10574). *)
 let cohort_key_of_reason = Keeper_registry.failure_reason_cohort_key
 
+let stale_turn_timeout_cohort_key =
+  cohort_key_of_reason
+    (Some
+       (Keeper_registry.Stale_turn_timeout
+          (Keeper_registry.Idle_turn { stall_seconds = 0.0 })))
+
 (* #10887: persistent self-preservation lock.  Fleet log shows 125
    identical [ratio=1.00, cohort=stale_turn_timeout] events / 2 days
    with no escape — every sweep re-suppresses the same dominant
@@ -784,15 +790,26 @@ let sp_escape_state =
     not operator policy. *)
 let probe_after_n_suppressions = 10
 
+(** Bounded minority exception for partial stale recovery.
+
+    The live regression was 6/17 keepers: enough to trip the global
+    self-preservation ratio gate, but not a fleet-wide provider/cascade
+    storm.  Keep this below a majority so large-but-not-universal stale
+    cohorts still go through the circuit breaker/probe path. *)
+let partial_stale_recovery_max_ratio = 0.50
+
 (** Reset the escape-valve state.  Test-only; production code never
     needs to call this (state cycles through the [last_dominant_cohort]
     inequality branch naturally). *)
-let reset_self_preservation_escape_state () =
+let reset_self_preservation_escape_state_for_test () =
   sp_escape_state.last_dominant_cohort <- "";
   sp_escape_state.consecutive_suppressions <- 0
 
 (** Self-preservation gate. Suppresses restarts when a dominant failure
     cohort exceeds ratio threshold AND minimum candidate count.
+    Bounded minority [stale_turn_timeout] cohorts are allowed through so
+    alive-but-stuck recovery can drain partial slot starvation; larger stale
+    cohorts still use the circuit breaker/probe path.
     #10887: emits a probe restart every [probe_after_n_suppressions]
     consecutive suppressions of the same cohort. *)
 let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
@@ -817,13 +834,21 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
       ) cohorts ("", [])
     in
     if List.length dominant_entries >= sp_min then begin
-      if String.equal dominant_key "stale_turn_timeout" && ratio < 0.99 then begin
-        reset_self_preservation_escape_state ();
+      let dominant_count = List.length dominant_entries in
+      let dominant_ratio =
+        float_of_int dominant_count /. float_of_int n_total
+      in
+      if String.equal dominant_key stale_turn_timeout_cohort_key
+         && dominant_ratio <= partial_stale_recovery_max_ratio
+      then begin
+        reset_self_preservation_escape_state_for_test ();
         Log.Keeper.warn
           "self-preservation: allowing partial stale_turn_timeout recovery \
-           cohort through (%d/%d, ratio=%.2f)"
-          (List.length dominant_entries) n_total ratio;
-        to_restart
+           cohort through (dominant=%d/%d ratio_dominant=%.2f, \
+           overall_candidates=%d/%d ratio_overall=%.2f)"
+          dominant_count n_total dominant_ratio
+          n_candidates n_total ratio;
+        dominant_entries
       end else begin
       (* #10887: track consecutive suppressions of the same dominant
          cohort.  Different cohort -> counter resets to 1; same
@@ -922,12 +947,12 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
     end else begin
       (* Dominant cohort below sp_min — no suppression this cycle,
          so the streak no longer applies to this cohort. *)
-      reset_self_preservation_escape_state ();
+      reset_self_preservation_escape_state_for_test ();
       to_restart
     end
   end else begin
     (* No suppression: streak resets. *)
-    reset_self_preservation_escape_state ();
+    reset_self_preservation_escape_state_for_test ();
     to_restart
   end
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -848,7 +848,7 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
            overall_candidates=%d/%d ratio_overall=%.2f)"
           dominant_count n_total dominant_ratio
           n_candidates n_total ratio;
-        dominant_entries
+        to_restart
       end else begin
       (* #10887: track consecutive suppressions of the same dominant
          cohort.  Different cohort -> counter resets to 1; same

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -817,6 +817,14 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
       ) cohorts ("", [])
     in
     if List.length dominant_entries >= sp_min then begin
+      if String.equal dominant_key "stale_turn_timeout" && ratio < 0.99 then begin
+        reset_self_preservation_escape_state ();
+        Log.Keeper.warn
+          "self-preservation: allowing partial stale_turn_timeout recovery \
+           cohort through (%d/%d, ratio=%.2f)"
+          (List.length dominant_entries) n_total ratio;
+        to_restart
+      end else begin
       (* #10887: track consecutive suppressions of the same dominant
          cohort.  Different cohort -> counter resets to 1; same
          cohort -> counter increments. *)
@@ -910,6 +918,7 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
       List.filter (fun ((e : Keeper_registry.registry_entry), _) ->
         not (List.mem e.name suppressed_names)
       ) to_restart
+      end
     end else begin
       (* Dominant cohort below sp_min — no suppression this cycle,
          so the streak no longer applies to this cohort. *)

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -67,9 +67,12 @@ val apply_self_preservation :
   (Keeper_registry.registry_entry * string) list
 (** Self-preservation gate. Suppresses restarts when a dominant failure
     cohort exceeds ratio threshold AND minimum candidate count.
+    Bounded minority [stale_turn_timeout] cohorts are allowed through so
+    alive-but-stuck recovery can drain partial slot starvation; larger stale
+    cohorts still use the circuit breaker/probe path.
     Returns the filtered list of entries that should proceed with restart. *)
 
-val reset_self_preservation_escape_state : unit -> unit
+val reset_self_preservation_escape_state_for_test : unit -> unit
 (** Reset the self-preservation probe state. Test-only. *)
 
 (** {1 Liveness Recovery} *)

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -69,6 +69,9 @@ val apply_self_preservation :
     cohort exceeds ratio threshold AND minimum candidate count.
     Returns the filtered list of entries that should proceed with restart. *)
 
+val reset_self_preservation_escape_state : unit -> unit
+(** Reset the self-preservation probe state. Test-only. *)
+
 (** {1 Liveness Recovery} *)
 
 val liveness_recovery_scan : 'a context -> unit

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -80,6 +80,8 @@ let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
    without requiring three separate tables.  Cardinality is bounded by
    the deployment's keeper count (typically <50). *)
 let holder_table : (string * string, float) Hashtbl.t = Hashtbl.create 32
+let force_released_holders : (string * string, int) Hashtbl.t =
+  Hashtbl.create 32
 let holder_mutex = Eio.Mutex.create ()
 
 let with_holder_lock f =
@@ -89,9 +91,33 @@ let record_holder ~label ~keeper_name ~acquired_at =
   with_holder_lock (fun () ->
     Hashtbl.replace holder_table (label, keeper_name) acquired_at)
 
-let drop_holder ~label ~keeper_name =
+let mark_holder_force_released ~label ~keeper_name =
   with_holder_lock (fun () ->
-    Hashtbl.remove holder_table (label, keeper_name))
+    let key = (label, keeper_name) in
+    if Hashtbl.mem holder_table key then begin
+      Hashtbl.remove holder_table key;
+      let count =
+        Hashtbl.find_opt force_released_holders key
+        |> Option.value ~default:0
+      in
+      Hashtbl.replace force_released_holders key (count + 1);
+      true
+    end else
+      false)
+
+let consume_force_release ~label ~keeper_name =
+  with_holder_lock (fun () ->
+    let key = (label, keeper_name) in
+    match Hashtbl.find_opt force_released_holders key with
+    | Some count when count > 1 ->
+      Hashtbl.replace force_released_holders key (count - 1);
+      true
+    | Some _ ->
+      Hashtbl.remove force_released_holders key;
+      true
+    | None ->
+      Hashtbl.remove holder_table key;
+      false)
 
 (** [snapshot_holders ~label ~now] returns [(keeper_name, held_for_sec)]
     pairs for the given [label] sorted by descending hold time.  Used
@@ -151,6 +177,19 @@ let reactive_turn_semaphore_value_for_test () =
 let turn_slot_holders ~now = snapshot_holders ~label:"turn" ~now
 let autonomous_slot_holders ~now = snapshot_holders ~label:"autonomous" ~now
 let reactive_slot_holders ~now = snapshot_holders ~label:"reactive" ~now
+
+let force_release_stale_holder ~keeper_name =
+  let released = ref [] in
+  let release_if_held ~label sem =
+    if mark_holder_force_released ~label ~keeper_name then begin
+      Eio.Semaphore.release sem;
+      released := label :: !released
+    end
+  in
+  release_if_held ~label:"turn" turn_semaphore;
+  release_if_held ~label:"autonomous" autonomous_turn_semaphore;
+  release_if_held ~label:"reactive" reactive_turn_semaphore;
+  List.rev !released
 
 let format_slot_holders ?(limit = 5) holders =
   let limit = max 1 limit in
@@ -396,6 +435,20 @@ let safe_bookkeeping ~op f =
     Log.Keeper.warn "release_keeper_turn_slot: %s failed: %s"
       op (Printexc.to_string exn)
 
+let release_recorded_holder ~keeper_name ~label sem =
+  let force_released =
+    try consume_force_release ~label ~keeper_name with exn ->
+      Log.Keeper.warn "release_keeper_turn_slot: drop_holder %s failed: %s"
+        label (Printexc.to_string exn);
+      false
+  in
+  if force_released then
+    Log.Keeper.warn
+      "release_keeper_turn_slot: %s holder for %s was already force-released"
+      label keeper_name
+  else
+    Eio.Semaphore.release sem
+
 let release_keeper_turn_slot ~keeper_name state =
   safe_bookkeeping ~op:"drop_autonomous_waiter" (fun () ->
     Option.iter
@@ -405,9 +458,7 @@ let release_keeper_turn_slot ~keeper_name state =
      semaphores account for separate quotas, so release order does not affect
      permit ownership. *)
   if !(state.acquired_turn) then begin
-    safe_bookkeeping ~op:"drop_holder turn" (fun () ->
-      drop_holder ~label:"turn" ~keeper_name);
-    Eio.Semaphore.release turn_semaphore
+    release_recorded_holder ~keeper_name ~label:"turn" turn_semaphore
   end;
   if !(state.acquired_autonomous) then begin
     (* Stamp completion time BEFORE releasing the semaphore so that
@@ -415,14 +466,12 @@ let release_keeper_turn_slot ~keeper_name state =
        when this keeper's heartbeat loops back immediately. *)
     safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
       record_autonomous_completion ~keeper_name);
-    safe_bookkeeping ~op:"drop_holder autonomous" (fun () ->
-      drop_holder ~label:"autonomous" ~keeper_name);
-    Eio.Semaphore.release autonomous_turn_semaphore
+    release_recorded_holder ~keeper_name ~label:"autonomous"
+      autonomous_turn_semaphore
   end;
   if !(state.acquired_reactive) then begin
-    safe_bookkeeping ~op:"drop_holder reactive" (fun () ->
-      drop_holder ~label:"reactive" ~keeper_name);
-    Eio.Semaphore.release reactive_turn_semaphore
+    release_recorded_holder ~keeper_name ~label:"reactive"
+      reactive_turn_semaphore
   end
 
 let reset_autonomous_completion_for_test () : unit =

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -88,12 +88,20 @@ type holder_key = {
 }
 
 let holder_table : (holder_key, float) Hashtbl.t = Hashtbl.create 32
-let force_released_holders : (holder_key, unit) Hashtbl.t = Hashtbl.create 32
+let force_released_holders : (holder_key, float) Hashtbl.t = Hashtbl.create 32
 let next_holder_acquisition_id = ref 0
 let holder_mutex = Eio.Mutex.create ()
+let force_release_marker_ttl_sec = 3600.0
 
 let with_holder_lock f =
   Eio.Mutex.use_rw ~protect:true holder_mutex f
+
+let purge_expired_force_released_holders_locked ~now =
+  Hashtbl.filter_map_inplace
+    (fun _ marked_at ->
+       if now -. marked_at > force_release_marker_ttl_sec then None
+       else Some marked_at)
+    force_released_holders
 
 let record_holder ~label ~keeper_name ~acquired_at =
   with_holder_lock (fun () ->
@@ -111,6 +119,8 @@ let record_holder ~label ~keeper_name ~acquired_at =
 
 let mark_holder_force_released ~label ~keeper_name =
   with_holder_lock (fun () ->
+    let now = Time_compat.now () in
+    purge_expired_force_released_holders_locked ~now;
     let keys =
       Hashtbl.fold
         (fun key _ acc ->
@@ -123,12 +133,13 @@ let mark_holder_force_released ~label ~keeper_name =
     List.iter
       (fun key ->
          Hashtbl.remove holder_table key;
-         Hashtbl.replace force_released_holders key ())
+         Hashtbl.replace force_released_holders key now)
       keys;
     List.length keys)
 
 let consume_force_release ~label ~keeper_name ~acquisition_id =
   with_holder_lock (fun () ->
+    purge_expired_force_released_holders_locked ~now:(Time_compat.now ());
     let key =
       {
         holder_label = label;
@@ -137,7 +148,7 @@ let consume_force_release ~label ~keeper_name ~acquisition_id =
       }
     in
     match Hashtbl.find_opt force_released_holders key with
-    | Some () ->
+    | Some _ ->
       Hashtbl.remove force_released_holders key;
       true
     | None ->
@@ -466,13 +477,19 @@ let safe_bookkeeping ~op f =
     Log.Keeper.warn "release_keeper_turn_slot: %s failed: %s"
       op (Printexc.to_string exn)
 
-let release_recorded_holder ~keeper_name ~label ~acquisition_id sem =
+let release_recorded_holder
+    ?(before_release = fun () -> ())
+    ~keeper_name
+    ~label
+    ~acquisition_id
+    sem =
   match acquisition_id with
   | None ->
     Log.Keeper.warn
       "release_keeper_turn_slot: %s holder for %s missing acquisition id; \
        releasing semaphore defensively"
       label keeper_name;
+    before_release ();
     Eio.Semaphore.release sem
   | Some acquisition_id ->
     let force_released =
@@ -485,8 +502,10 @@ let release_recorded_holder ~keeper_name ~label ~acquisition_id sem =
       Log.Keeper.warn
         "release_keeper_turn_slot: %s holder for %s was already force-released"
         label keeper_name
-    else
+    else begin
+      before_release ();
       Eio.Semaphore.release sem
+    end
 
 let release_keeper_turn_slot ~keeper_name state =
   safe_bookkeeping ~op:"drop_autonomous_waiter" (fun () ->
@@ -502,13 +521,15 @@ let release_keeper_turn_slot ~keeper_name state =
       turn_semaphore
   end;
   if !(state.acquired_autonomous) then begin
-    (* Stamp completion time BEFORE releasing the semaphore so that
-       [maybe_yield_for_fairness] can measure the correct interval
-       when this keeper's heartbeat loops back immediately. *)
-    safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
-      record_autonomous_completion ~keeper_name);
     release_recorded_holder ~keeper_name ~label:"autonomous"
       ~acquisition_id:!(state.autonomous_acquisition_id)
+      ~before_release:(fun () ->
+        (* Stamp completion time only for normal completion, before releasing
+           the semaphore so that [maybe_yield_for_fairness] can measure the
+           correct interval when this keeper's heartbeat loops back
+           immediately. *)
+        safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
+          record_autonomous_completion ~keeper_name))
       autonomous_turn_semaphore
   end;
   if !(state.acquired_reactive) then begin

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -71,17 +71,25 @@ let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
    never names *which* peer.  Operators are then blind to which keeper
    is the actual blocker.
 
-   Track holders in a single Hashtbl keyed by (label, keeper_name) so
-   [acquire_bounded] can dump the live list on timeout.  Mutex-guarded
-   because Eio fibers may release/acquire concurrently.
+   Track holders in a single Hashtbl keyed by (label, keeper_name,
+   acquisition_id) so [acquire_bounded] can dump the live list on timeout.
+   Mutex-guarded because Eio fibers may release/acquire concurrently.
 
-   Holder rows are tuples [(label, keeper_name) → acquire_ts].
+   Holder rows are tuples [(label, keeper_name, acquisition_id) → acquire_ts].
    [label] disambiguates the three pools (turn / autonomous / reactive)
-   without requiring three separate tables.  Cardinality is bounded by
-   the deployment's keeper count (typically <50). *)
-let holder_table : (string * string, float) Hashtbl.t = Hashtbl.create 32
-let force_released_holders : (string * string, int) Hashtbl.t =
-  Hashtbl.create 32
+   without requiring three separate tables.  [acquisition_id] prevents a
+   restarted keeper generation from consuming a stale predecessor's
+   force-release marker when the predecessor never reaches its finalizer.
+   Cardinality is bounded by the deployment's keeper count (typically <50). *)
+type holder_key = {
+  holder_label : string;
+  holder_keeper_name : string;
+  holder_acquisition_id : int;
+}
+
+let holder_table : (holder_key, float) Hashtbl.t = Hashtbl.create 32
+let force_released_holders : (holder_key, unit) Hashtbl.t = Hashtbl.create 32
+let next_holder_acquisition_id = ref 0
 let holder_mutex = Eio.Mutex.create ()
 
 let with_holder_lock f =
@@ -89,30 +97,47 @@ let with_holder_lock f =
 
 let record_holder ~label ~keeper_name ~acquired_at =
   with_holder_lock (fun () ->
-    Hashtbl.replace holder_table (label, keeper_name) acquired_at)
+    incr next_holder_acquisition_id;
+    let acquisition_id = !next_holder_acquisition_id in
+    let key =
+      {
+        holder_label = label;
+        holder_keeper_name = keeper_name;
+        holder_acquisition_id = acquisition_id;
+      }
+    in
+    Hashtbl.replace holder_table key acquired_at;
+    acquisition_id)
 
 let mark_holder_force_released ~label ~keeper_name =
   with_holder_lock (fun () ->
-    let key = (label, keeper_name) in
-    if Hashtbl.mem holder_table key then begin
-      Hashtbl.remove holder_table key;
-      let count =
-        Hashtbl.find_opt force_released_holders key
-        |> Option.value ~default:0
-      in
-      Hashtbl.replace force_released_holders key (count + 1);
-      true
-    end else
-      false)
+    let keys =
+      Hashtbl.fold
+        (fun key _ acc ->
+           if String.equal key.holder_label label
+              && String.equal key.holder_keeper_name keeper_name
+           then key :: acc
+           else acc)
+        holder_table []
+    in
+    List.iter
+      (fun key ->
+         Hashtbl.remove holder_table key;
+         Hashtbl.replace force_released_holders key ())
+      keys;
+    List.length keys)
 
-let consume_force_release ~label ~keeper_name =
+let consume_force_release ~label ~keeper_name ~acquisition_id =
   with_holder_lock (fun () ->
-    let key = (label, keeper_name) in
+    let key =
+      {
+        holder_label = label;
+        holder_keeper_name = keeper_name;
+        holder_acquisition_id = acquisition_id;
+      }
+    in
     match Hashtbl.find_opt force_released_holders key with
-    | Some count when count > 1 ->
-      Hashtbl.replace force_released_holders key (count - 1);
-      true
-    | Some _ ->
+    | Some () ->
       Hashtbl.remove force_released_holders key;
       true
     | None ->
@@ -126,8 +151,10 @@ let consume_force_release ~label ~keeper_name =
 let snapshot_holders ~label ~now =
   with_holder_lock (fun () ->
     Hashtbl.fold
-      (fun (l, name) ts acc ->
-        if String.equal l label then (name, now -. ts) :: acc else acc)
+      (fun key ts acc ->
+        if String.equal key.holder_label label
+        then (key.holder_keeper_name, now -. ts) :: acc
+        else acc)
       holder_table [])
   |> List.sort (fun (_, a) (_, b) -> compare b a)
 
@@ -181,10 +208,11 @@ let reactive_slot_holders ~now = snapshot_holders ~label:"reactive" ~now
 let force_release_stale_holder ~keeper_name =
   let released = ref [] in
   let release_if_held ~label sem =
-    if mark_holder_force_released ~label ~keeper_name then begin
+    let release_count = mark_holder_force_released ~label ~keeper_name in
+    for _ = 1 to release_count do
       Eio.Semaphore.release sem;
       released := label :: !released
-    end
+    done
   in
   release_if_held ~label:"turn" turn_semaphore;
   release_if_held ~label:"autonomous" autonomous_turn_semaphore;
@@ -228,12 +256,12 @@ let format_slot_holders ?(limit = 5) holders =
 let snapshot_all_holders ~now =
   with_holder_lock (fun () ->
     Hashtbl.fold
-      (fun (label, name) ts (turn, auto, reactive) ->
+      (fun key ts (turn, auto, reactive) ->
         let held = now -. ts in
-        match label with
-        | "turn" -> ((name, held) :: turn, auto, reactive)
-        | "autonomous" -> (turn, (name, held) :: auto, reactive)
-        | "reactive" -> (turn, auto, (name, held) :: reactive)
+        match key.holder_label with
+        | "turn" -> ((key.holder_keeper_name, held) :: turn, auto, reactive)
+        | "autonomous" -> (turn, (key.holder_keeper_name, held) :: auto, reactive)
+        | "reactive" -> (turn, auto, (key.holder_keeper_name, held) :: reactive)
         | _ -> (turn, auto, reactive))
       holder_table ([], [], []))
   |> fun (t, a, r) ->
@@ -401,6 +429,9 @@ type keeper_turn_slot_state = {
   acquired_autonomous : bool ref;
   acquired_reactive : bool ref;
   acquired_turn : bool ref;
+  autonomous_acquisition_id : int option ref;
+  reactive_acquisition_id : int option ref;
+  turn_acquisition_id : int option ref;
   autonomous_ticket : int option ref;
 }
 
@@ -435,19 +466,27 @@ let safe_bookkeeping ~op f =
     Log.Keeper.warn "release_keeper_turn_slot: %s failed: %s"
       op (Printexc.to_string exn)
 
-let release_recorded_holder ~keeper_name ~label sem =
-  let force_released =
-    try consume_force_release ~label ~keeper_name with exn ->
-      Log.Keeper.warn "release_keeper_turn_slot: drop_holder %s failed: %s"
-        label (Printexc.to_string exn);
-      false
-  in
-  if force_released then
+let release_recorded_holder ~keeper_name ~label ~acquisition_id sem =
+  match acquisition_id with
+  | None ->
     Log.Keeper.warn
-      "release_keeper_turn_slot: %s holder for %s was already force-released"
-      label keeper_name
-  else
+      "release_keeper_turn_slot: %s holder for %s missing acquisition id; \
+       releasing semaphore defensively"
+      label keeper_name;
     Eio.Semaphore.release sem
+  | Some acquisition_id ->
+    let force_released =
+      try consume_force_release ~label ~keeper_name ~acquisition_id with exn ->
+        Log.Keeper.warn "release_keeper_turn_slot: drop_holder %s failed: %s"
+          label (Printexc.to_string exn);
+        false
+    in
+    if force_released then
+      Log.Keeper.warn
+        "release_keeper_turn_slot: %s holder for %s was already force-released"
+        label keeper_name
+    else
+      Eio.Semaphore.release sem
 
 let release_keeper_turn_slot ~keeper_name state =
   safe_bookkeeping ~op:"drop_autonomous_waiter" (fun () ->
@@ -458,7 +497,9 @@ let release_keeper_turn_slot ~keeper_name state =
      semaphores account for separate quotas, so release order does not affect
      permit ownership. *)
   if !(state.acquired_turn) then begin
-    release_recorded_holder ~keeper_name ~label:"turn" turn_semaphore
+    release_recorded_holder ~keeper_name ~label:"turn"
+      ~acquisition_id:!(state.turn_acquisition_id)
+      turn_semaphore
   end;
   if !(state.acquired_autonomous) then begin
     (* Stamp completion time BEFORE releasing the semaphore so that
@@ -467,10 +508,12 @@ let release_keeper_turn_slot ~keeper_name state =
     safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
       record_autonomous_completion ~keeper_name);
     release_recorded_holder ~keeper_name ~label:"autonomous"
+      ~acquisition_id:!(state.autonomous_acquisition_id)
       autonomous_turn_semaphore
   end;
   if !(state.acquired_reactive) then begin
     release_recorded_holder ~keeper_name ~label:"reactive"
+      ~acquisition_id:!(state.reactive_acquisition_id)
       reactive_turn_semaphore
   end
 
@@ -663,6 +706,9 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
       acquired_autonomous = ref false;
       acquired_reactive = ref false;
       acquired_turn = ref false;
+      autonomous_acquisition_id = ref None;
+      reactive_acquisition_id = ref None;
+      turn_acquisition_id = ref None;
       autonomous_ticket = ref None;
     }
   in
@@ -768,8 +814,11 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
               slot_state.acquired_autonomous := true;
               run_after_acquire_flag_hook_for_test
                 ~label:"autonomous" ~keeper_name;
-              record_holder ~label:"autonomous" ~keeper_name
-                ~acquired_at:(Time_compat.now ());
+              let acquisition_id =
+                record_holder ~label:"autonomous" ~keeper_name
+                  ~acquired_at:(Time_compat.now ())
+              in
+              slot_state.autonomous_acquisition_id := Some acquisition_id;
               drop_autonomous_waiter ~ticket;
               slot_state.autonomous_ticket := None;
               Ok ()
@@ -794,8 +843,11 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
               slot_state.acquired_reactive := true;
               run_after_acquire_flag_hook_for_test
                 ~label:"reactive" ~keeper_name;
-              record_holder ~label:"reactive" ~keeper_name
-                ~acquired_at:(Time_compat.now ());
+              let acquisition_id =
+                record_holder ~label:"reactive" ~keeper_name
+                  ~acquired_at:(Time_compat.now ())
+              in
+              slot_state.reactive_acquisition_id := Some acquisition_id;
               Ok ()
         in
         match reactive_result with
@@ -808,8 +860,11 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
           slot_state.acquired_turn := true;
           run_after_acquire_flag_hook_for_test
             ~label:"turn" ~keeper_name;
-          record_holder ~label:"turn" ~keeper_name
-            ~acquired_at:(Time_compat.now ());
+          let acquisition_id =
+            record_holder ~label:"turn" ~keeper_name
+              ~acquired_at:(Time_compat.now ())
+          in
+          slot_state.turn_acquisition_id := Some acquisition_id;
           let semaphore_wait_ms =
             int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
           Ok (f ~semaphore_wait_ms))

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -103,6 +103,34 @@ let purge_expired_force_released_holders_locked ~now =
        else Some marked_at)
     force_released_holders
 
+let force_released_marker_ttl_sec_for_test = force_release_marker_ttl_sec
+
+let force_released_marker_count_for_test () =
+  with_holder_lock (fun () ->
+    Hashtbl.length force_released_holders)
+
+let add_force_released_marker_for_test
+    ~label
+    ~keeper_name
+    ~acquisition_id
+    ~marked_at =
+  with_holder_lock (fun () ->
+    Hashtbl.replace force_released_holders
+      {
+        holder_label = label;
+        holder_keeper_name = keeper_name;
+        holder_acquisition_id = acquisition_id;
+      }
+      marked_at)
+
+let purge_force_released_markers_for_test ~now =
+  with_holder_lock (fun () ->
+    purge_expired_force_released_holders_locked ~now)
+
+let clear_force_released_markers_for_test () =
+  with_holder_lock (fun () ->
+    Hashtbl.reset force_released_holders)
+
 let record_holder ~label ~keeper_name ~acquired_at =
   with_holder_lock (fun () ->
     incr next_holder_acquisition_id;
@@ -139,7 +167,6 @@ let mark_holder_force_released ~label ~keeper_name =
 
 let consume_force_release ~label ~keeper_name ~acquisition_id =
   with_holder_lock (fun () ->
-    purge_expired_force_released_holders_locked ~now:(Time_compat.now ());
     let key =
       {
         holder_label = label;

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -71,6 +71,29 @@ val reactive_slot_holders : now:float -> (string * float) list
     predecessor's marker. *)
 val force_release_stale_holder : keeper_name:string -> string list
 
+(** Test-only: TTL used to bound orphaned force-release markers left behind
+    when a cancelled stale fiber never reaches its finalizer. *)
+val force_released_marker_ttl_sec_for_test : float
+
+(** Test-only: count force-release markers still awaiting finalizer
+    consumption or expiry pruning. *)
+val force_released_marker_count_for_test : unit -> int
+
+(** Test-only: inject a marker without touching semaphores, so marker-retention
+    behavior can be exercised without creating a double-release path. *)
+val add_force_released_marker_for_test :
+  label:string ->
+  keeper_name:string ->
+  acquisition_id:int ->
+  marked_at:float ->
+  unit
+
+(** Test-only: prune expired force-release markers using an injected clock. *)
+val purge_force_released_markers_for_test : now:float -> unit
+
+(** Test-only: clear force-release markers between tests. *)
+val clear_force_released_markers_for_test : unit -> unit
+
 (** Render a compact holder list such as [[keeper-a/181s, +2 more]].
     The input is expected to be sorted longest-first, as returned by the
     holder accessors above. *)

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -65,8 +65,10 @@ val reactive_slot_holders : now:float -> (string * float) list
 
     This is intentionally narrower than normal cleanup: it only releases
     holders still present in the diagnostic holder table, and the normal
-    [with_keeper_turn_slot] finalizer consumes the force-release marker so a
-    late-returning fiber cannot double-release the same permit. *)
+    [with_keeper_turn_slot] finalizer consumes the same acquisition's
+    force-release marker so a late-returning fiber cannot double-release the
+    same permit, and a newer keeper generation cannot consume the stale
+    predecessor's marker. *)
 val force_release_stale_holder : keeper_name:string -> string list
 
 (** Render a compact holder list such as [[keeper-a/181s, +2 more]].

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -60,6 +60,15 @@ val turn_slot_holders : now:float -> (string * float) list
 val autonomous_slot_holders : now:float -> (string * float) list
 val reactive_slot_holders : now:float -> (string * float) list
 
+(** Force-release semaphore permits held by [keeper_name] after the watchdog
+    has classified the holder as stale. Returns the labels actually released.
+
+    This is intentionally narrower than normal cleanup: it only releases
+    holders still present in the diagnostic holder table, and the normal
+    [with_keeper_turn_slot] finalizer consumes the force-release marker so a
+    late-returning fiber cannot double-release the same permit. *)
+val force_release_stale_holder : keeper_name:string -> string list
+
 (** Render a compact holder list such as [[keeper-a/181s, +2 more]].
     The input is expected to be sorted longest-first, as returned by the
     holder accessors above. *)

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -245,6 +245,29 @@ let test_self_preservation_allows_bounded_partial_stale_recovery () =
   Sup.reset_self_preservation_escape_state_for_test ();
   Reg.clear ()
 
+let test_self_preservation_allows_mixed_partial_stale_recovery () =
+  Reg.clear ();
+  Sup.reset_self_preservation_escape_state_for_test ();
+  let stale = stale_entries [ "a"; "b"; "c"; "d"; "e"; "f" ] in
+  let crash =
+    let name = "non-stale-crash" in
+    ignore (Reg.register ~base_path:bp name (make_meta name));
+    Reg.set_failure_reason ~base_path:bp name
+      (Some (Reg.Heartbeat_consecutive_failures 3));
+    match Reg.get ~base_path:bp name with
+    | Some e -> [ e, "crash" ]
+    | None -> fail name
+  in
+  let entries = stale @ crash in
+  let result =
+    Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers"
+      ~total_keepers:17 entries
+  in
+  check int "mixed partial stale recovery keeps full restart set"
+    (List.length entries) (List.length result);
+  Sup.reset_self_preservation_escape_state_for_test ();
+  Reg.clear ()
+
 let test_self_preservation_suppresses_large_partial_stale_recovery () =
   Reg.clear ();
   Sup.reset_self_preservation_escape_state_for_test ();
@@ -1204,6 +1227,8 @@ let () =
       test_case "empty input → empty output" `Quick test_self_preservation_empty_input;
       test_case "bounded partial stale recovery cohort allowed" `Quick
         test_self_preservation_allows_bounded_partial_stale_recovery;
+      test_case "mixed partial stale recovery keeps full restart set" `Quick
+        test_self_preservation_allows_mixed_partial_stale_recovery;
       test_case "large partial stale recovery cohort suppressed" `Quick
         test_self_preservation_suppresses_large_partial_stale_recovery;
       test_case "universal stale recovery cohort suppressed" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -218,30 +218,62 @@ let test_self_preservation_empty_input () =
   let result = Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers" ~total_keepers:5 [] in
   check int "empty in = empty out" 0 (List.length result)
 
-let test_self_preservation_allows_partial_stale_recovery () =
+let stale_entries names =
+  List.map
+    (fun name ->
+      ignore (Reg.register ~base_path:bp name (make_meta name));
+      Reg.set_failure_reason ~base_path:bp name
+        (Some
+           (Reg.Stale_turn_timeout
+              (Reg.Idle_turn { stall_seconds = 99_000.0 })));
+      match Reg.get ~base_path:bp name with
+      | Some e -> (e, "stale_turn_timeout")
+      | None -> fail name)
+    names
+
+let test_self_preservation_allows_bounded_partial_stale_recovery () =
   Reg.clear ();
-  Sup.reset_self_preservation_escape_state ();
+  Sup.reset_self_preservation_escape_state_for_test ();
   let names = [ "a"; "b"; "c"; "d"; "e"; "f" ] in
-  let entries =
-    List.map
-      (fun name ->
-        ignore (Reg.register ~base_path:bp name (make_meta name));
-        Reg.set_failure_reason ~base_path:bp name
-          (Some
-             (Reg.Stale_turn_timeout
-                (Reg.Idle_turn { stall_seconds = 99_000.0 })));
-        match Reg.get ~base_path:bp name with
-        | Some e -> (e, "stale_turn_timeout")
-        | None -> fail name)
-      names
-  in
+  let entries = stale_entries names in
   let result =
     Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers"
       ~total_keepers:17 entries
   in
   check int "partial stale recovery cohort allowed through"
     (List.length entries) (List.length result);
-  Sup.reset_self_preservation_escape_state ();
+  Sup.reset_self_preservation_escape_state_for_test ();
+  Reg.clear ()
+
+let test_self_preservation_suppresses_large_partial_stale_recovery () =
+  Reg.clear ();
+  Sup.reset_self_preservation_escape_state_for_test ();
+  let entries =
+    stale_entries
+      [ "a"; "b"; "c"; "d"; "e"; "f"; "g"; "h"; "i" ]
+  in
+  let result =
+    Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers"
+      ~total_keepers:17 entries
+  in
+  check int "large partial stale cohort suppressed" 0 (List.length result);
+  Sup.reset_self_preservation_escape_state_for_test ();
+  Reg.clear ()
+
+let test_self_preservation_suppresses_universal_stale_recovery () =
+  Reg.clear ();
+  Sup.reset_self_preservation_escape_state_for_test ();
+  let entries =
+    stale_entries
+      [ "a"; "b"; "c"; "d"; "e"; "f"; "g"; "h"; "i"; "j"; "k"; "l";
+        "m"; "n"; "o"; "p"; "q" ]
+  in
+  let result =
+    Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers"
+      ~total_keepers:17 entries
+  in
+  check int "universal stale cohort suppressed" 0 (List.length result);
+  Sup.reset_self_preservation_escape_state_for_test ();
   Reg.clear ()
 
 (* ── Runtime override: fiber_health_of ─────────────────── *)
@@ -1170,8 +1202,12 @@ let () =
     "self_preservation_properties", [
       test_case "output subset of input" `Quick test_self_preservation_subset;
       test_case "empty input → empty output" `Quick test_self_preservation_empty_input;
-      test_case "partial stale recovery cohort allowed" `Quick
-        test_self_preservation_allows_partial_stale_recovery;
+      test_case "bounded partial stale recovery cohort allowed" `Quick
+        test_self_preservation_allows_bounded_partial_stale_recovery;
+      test_case "large partial stale recovery cohort suppressed" `Quick
+        test_self_preservation_suppresses_large_partial_stale_recovery;
+      test_case "universal stale recovery cohort suppressed" `Quick
+        test_self_preservation_suppresses_universal_stale_recovery;
     ];
     "runtime_override", [
       test_case "fiber_health_of respects max_restarts override" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -218,6 +218,32 @@ let test_self_preservation_empty_input () =
   let result = Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers" ~total_keepers:5 [] in
   check int "empty in = empty out" 0 (List.length result)
 
+let test_self_preservation_allows_partial_stale_recovery () =
+  Reg.clear ();
+  Sup.reset_self_preservation_escape_state ();
+  let names = [ "a"; "b"; "c"; "d"; "e"; "f" ] in
+  let entries =
+    List.map
+      (fun name ->
+        ignore (Reg.register ~base_path:bp name (make_meta name));
+        Reg.set_failure_reason ~base_path:bp name
+          (Some
+             (Reg.Stale_turn_timeout
+                (Reg.Idle_turn { stall_seconds = 99_000.0 })));
+        match Reg.get ~base_path:bp name with
+        | Some e -> (e, "stale_turn_timeout")
+        | None -> fail name)
+      names
+  in
+  let result =
+    Sup.apply_self_preservation ~keepers_dir:"/tmp/test-keepers"
+      ~total_keepers:17 entries
+  in
+  check int "partial stale recovery cohort allowed through"
+    (List.length entries) (List.length result);
+  Sup.reset_self_preservation_escape_state ();
+  Reg.clear ()
+
 (* ── Runtime override: fiber_health_of ─────────────────── *)
 
 let test_fiber_health_respects_max_restarts_override () =
@@ -1144,6 +1170,8 @@ let () =
     "self_preservation_properties", [
       test_case "output subset of input" `Quick test_self_preservation_subset;
       test_case "empty input → empty output" `Quick test_self_preservation_empty_input;
+      test_case "partial stale recovery cohort allowed" `Quick
+        test_self_preservation_allows_partial_stale_recovery;
     ];
     "runtime_override", [
       test_case "fiber_health_of respects max_restarts override" `Quick

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -238,6 +238,55 @@ let test_force_release_stale_holder_restores_slots_once () =
     ~expected:reactive_before
     ~actual:(KK.reactive_turn_semaphore_value_for_test ())
 
+let test_force_release_marker_is_acquisition_scoped () =
+  let keeper_name = "diag-force-generation" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let reactive_before = KK.reactive_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ->
+        let released = KK.force_release_stale_holder ~keeper_name in
+        if not (List.mem "turn" released) then
+          failwith "force release did not report turn slot";
+        if not (List.mem "reactive" released) then
+          failwith "force release did not report reactive slot";
+        assert_eq ~msg:"turn restored by force release" ~expected:turn_before
+          ~actual:(KK.turn_semaphore_value_for_test ());
+        assert_eq ~msg:"reactive restored by force release"
+          ~expected:reactive_before
+          ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+        let nested =
+          KK.with_keeper_turn_slot_for_test
+            ~keeper_name
+            ~channel:Masc_mcp.Keeper_world_observation.Reactive
+            (fun ~semaphore_wait_ms:_ -> ())
+        in
+        (match nested with
+         | Ok () -> ()
+         | Error (`Semaphore_wait_timeout _) ->
+             failwith "unexpected nested semaphore wait timeout");
+        assert_eq
+          ~msg:"nested normal finalizer did not consume stale turn marker"
+          ~expected:turn_before
+          ~actual:(KK.turn_semaphore_value_for_test ());
+        assert_eq
+          ~msg:"nested normal finalizer did not consume stale reactive marker"
+          ~expected:reactive_before
+          ~actual:(KK.reactive_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"old turn marker consumed by old finalizer"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"old reactive marker consumed by old finalizer"
+    ~expected:reactive_before
+    ~actual:(KK.reactive_turn_semaphore_value_for_test ())
+
 let () =
   let cases =
     [
@@ -259,6 +308,8 @@ let () =
         test_watchdog_slot_holder_age_reflects_active_holder;
       "force release restores stale holder slots once",
         test_force_release_stale_holder_restores_slots_once;
+      "force release markers are acquisition scoped",
+        test_force_release_marker_is_acquisition_scoped;
     ]
   in
   List.iter

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -287,6 +287,65 @@ let test_force_release_marker_is_acquisition_scoped () =
     ~expected:reactive_before
     ~actual:(KK.reactive_turn_semaphore_value_for_test ())
 
+(* Reviewer #13190: existing tests exercise force_release_stale_holder
+   while the outer fiber's protect-finalizer eventually runs to
+   completion.  The watchdog restart path looks different — the
+   supervisor force-releases the slot from outside the stale fiber,
+   the stale fiber raises before normal cleanup, and a replacement
+   keeper takes the slot under the same keeper_name.  Pin that the
+   replacement's acquire/release cycle is unaffected by any leftover
+   marker from the previous generation: both semaphores must return
+   to baseline even after the outer fiber exits via exception, and a
+   fresh acquisition under the same keeper_name must complete cleanly
+   with semaphores still at baseline. *)
+let test_force_release_marker_does_not_leak_to_replacement () =
+  let keeper_name = "diag-replacement-leak" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let reactive_before = KK.reactive_turn_semaphore_value_for_test () in
+  let exception Outer_simulated_raise in
+  (try
+     let _ =
+       KK.with_keeper_turn_slot_for_test
+         ~keeper_name
+         ~channel:Masc_mcp.Keeper_world_observation.Reactive
+         (fun ~semaphore_wait_ms:_ ->
+           let released = KK.force_release_stale_holder ~keeper_name in
+           if not (List.mem "turn" released) then
+             failwith "force release did not report turn slot";
+           if not (List.mem "reactive" released) then
+             failwith "force release did not report reactive slot";
+           raise Outer_simulated_raise)
+     in
+     ()
+   with Outer_simulated_raise -> ());
+  assert_eq
+    ~msg:"turn semaphore restored to baseline after outer raise"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq
+    ~msg:"reactive semaphore restored to baseline after outer raise"
+    ~expected:reactive_before
+    ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ -> ())
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "replacement acquire timed out — leftover force-release \
+                 marker may have skipped the previous release");
+  assert_eq
+    ~msg:"turn semaphore baseline preserved after replacement keeper run"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq
+    ~msg:"reactive semaphore baseline preserved after replacement keeper run"
+    ~expected:reactive_before
+    ~actual:(KK.reactive_turn_semaphore_value_for_test ())
+
 let () =
   let cases =
     [
@@ -310,6 +369,8 @@ let () =
         test_force_release_stale_holder_restores_slots_once;
       "force release markers are acquisition scoped",
         test_force_release_marker_is_acquisition_scoped;
+      "force release marker does not leak to replacement",
+        test_force_release_marker_does_not_leak_to_replacement;
     ]
   in
   List.iter

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -346,6 +346,45 @@ let test_force_release_marker_does_not_leak_to_replacement () =
     ~expected:reactive_before
     ~actual:(KK.reactive_turn_semaphore_value_for_test ())
 
+let test_force_released_autonomous_holder_does_not_stamp_completion () =
+  let keeper_name = "diag-force-autonomous" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let autonomous_before = KK.autonomous_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
+      (fun ~semaphore_wait_ms:_ ->
+         let released = KK.force_release_stale_holder ~keeper_name in
+         if not (List.mem "turn" released) then
+           failwith "force release did not report turn slot";
+         if not (List.mem "autonomous" released) then
+           failwith "force release did not report autonomous slot";
+         assert_eq ~msg:"turn restored by force release" ~expected:turn_before
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous restored by force release"
+           ~expected:autonomous_before
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn not double-released by autonomous finalizer"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"autonomous not double-released by finalizer"
+    ~expected:autonomous_before
+    ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
+  let delay =
+    KK.fairness_delay_sec_at ~keeper_name ~now:(Time_compat.now ())
+  in
+  if delay <> 0.0 then
+    failwith
+      (Printf.sprintf
+         "force-released autonomous holder stamped normal completion: delay=%.3f"
+         delay)
+
 let () =
   let cases =
     [
@@ -371,6 +410,8 @@ let () =
         test_force_release_marker_is_acquisition_scoped;
       "force release marker does not leak to replacement",
         test_force_release_marker_does_not_leak_to_replacement;
+      "force released autonomous holder skips completion stamp",
+        test_force_released_autonomous_holder_does_not_stamp_completion;
     ]
   in
   List.iter

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -9,6 +9,7 @@
     requires an Eio fiber context (Eio.Mutex on holder_table). *)
 
 module KK = Masc_mcp.Keeper_keepalive
+module SW = Masc_mcp.Keeper_stale_watchdog
 
 exception After_flag_injected
 
@@ -157,6 +158,86 @@ let test_reactive_slot_released_when_hook_raises_after_flag () =
   if List.mem keeper_name names then
     failwith "reactive holder leaked after injected failure"
 
+let test_watchdog_slot_holder_age_reflects_active_holder () =
+  let keeper_name = "diag-watchdog-holder" in
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ->
+        match
+          SW.slot_holder_age_for_test ~now:(Time_compat.now ()) ~keeper_name
+        with
+        | None -> failwith "expected watchdog holder age for active holder"
+        | Some age ->
+            if age < 0.0 || age > 5.0 then
+              failwith
+                (Printf.sprintf "unreasonable watchdog holder age=%.2fs" age))
+  in
+  match result with
+  | Ok () -> ()
+  | Error (`Semaphore_wait_timeout _) ->
+      failwith "unexpected semaphore wait timeout in test"
+
+let test_force_release_stale_holder_restores_slots_once () =
+  let keeper_name = "diag-force-release" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let reactive_before = KK.reactive_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ->
+        assert_eq ~msg:"turn acquired" ~expected:(turn_before - 1)
+          ~actual:(KK.turn_semaphore_value_for_test ());
+        assert_eq ~msg:"reactive acquired" ~expected:(reactive_before - 1)
+          ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+        let released = KK.force_release_stale_holder ~keeper_name in
+        if not (List.mem "turn" released) then
+          failwith "force release did not report turn slot";
+        if not (List.mem "reactive" released) then
+          failwith "force release did not report reactive slot";
+        if List.mem "autonomous" released then
+          failwith "force release unexpectedly reported autonomous slot";
+        assert_eq ~msg:"turn restored by force release" ~expected:turn_before
+          ~actual:(KK.turn_semaphore_value_for_test ());
+        assert_eq ~msg:"reactive restored by force release"
+          ~expected:reactive_before
+          ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+        let nested =
+          KK.with_keeper_turn_slot_for_test
+            ~keeper_name
+            ~channel:Masc_mcp.Keeper_world_observation.Reactive
+            (fun ~semaphore_wait_ms:_ ->
+              let released_again =
+                KK.force_release_stale_holder ~keeper_name
+              in
+              if not (List.mem "turn" released_again) then
+                failwith "second force release did not report turn slot";
+              if not (List.mem "reactive" released_again) then
+                failwith "second force release did not report reactive slot")
+        in
+        (match nested with
+         | Ok () -> ()
+         | Error (`Semaphore_wait_timeout _) ->
+             failwith "unexpected nested semaphore wait timeout");
+        assert_eq ~msg:"nested force release preserved turn count"
+          ~expected:turn_before
+          ~actual:(KK.turn_semaphore_value_for_test ());
+        assert_eq ~msg:"nested force release preserved reactive count"
+          ~expected:reactive_before
+          ~actual:(KK.reactive_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn not double-released by finalizer" ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"reactive not double-released by finalizer"
+    ~expected:reactive_before
+    ~actual:(KK.reactive_turn_semaphore_value_for_test ())
+
 let () =
   let cases =
     [
@@ -174,6 +255,10 @@ let () =
         test_slot_holders_summary_reflects_active_holder;
       "reactive slot releases when hook raises after acquired flag",
         test_reactive_slot_released_when_hook_raises_after_flag;
+      "watchdog holder fallback sees active holder",
+        test_watchdog_slot_holder_age_reflects_active_holder;
+      "force release restores stale holder slots once",
+        test_force_release_stale_holder_restores_slots_once;
     ]
   in
   List.iter

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -16,6 +16,7 @@ exception After_flag_injected
 let with_fresh_state body () =
   Eio_main.run @@ fun _env ->
     KK.set_after_acquire_flag_hook_for_test None;
+    KK.clear_force_released_markers_for_test ();
     KK.reset_autonomous_completion_for_test ();
     KK.reset_autonomous_turn_queue_for_test ();
     body ()
@@ -377,13 +378,32 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
     ~expected:autonomous_before
     ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
   let delay =
-    KK.fairness_delay_sec_at ~keeper_name ~now:(Time_compat.now ())
+    let ticket = KK.enqueue_autonomous_waiter_for_test "diag-waiting-peer" in
+    Fun.protect
+      ~finally:(fun () -> KK.drop_autonomous_waiter_for_test ticket)
+      (fun () ->
+         KK.fairness_delay_sec_at ~keeper_name ~now:(Time_compat.now ()))
   in
   if delay <> 0.0 then
     failwith
       (Printf.sprintf
          "force-released autonomous holder stamped normal completion: delay=%.3f"
          delay)
+
+let test_force_release_marker_ttl_bounds_unfinalized_fibers () =
+  KK.clear_force_released_markers_for_test ();
+  let marked_at = 1_000.0 in
+  KK.add_force_released_marker_for_test
+    ~label:"turn"
+    ~keeper_name:"diag-orphan-marker"
+    ~acquisition_id:42
+    ~marked_at;
+  assert_eq ~msg:"orphan marker recorded" ~expected:1
+    ~actual:(KK.force_released_marker_count_for_test ());
+  KK.purge_force_released_markers_for_test
+    ~now:(marked_at +. KK.force_released_marker_ttl_sec_for_test +. 1.0);
+  assert_eq ~msg:"expired orphan marker purged" ~expected:0
+    ~actual:(KK.force_released_marker_count_for_test ())
 
 let () =
   let cases =
@@ -412,6 +432,8 @@ let () =
         test_force_release_marker_does_not_leak_to_replacement;
       "force released autonomous holder skips completion stamp",
         test_force_released_autonomous_holder_does_not_stamp_completion;
+      "force release marker ttl bounds unfinalized fibers",
+        test_force_release_marker_ttl_bounds_unfinalized_fibers;
     ]
   in
   List.iter


### PR DESCRIPTION
## Summary

- Let bounded-minority `stale_turn_timeout` recovery cohorts bypass supervisor self-preservation.
- Keep majority and universal stale-turn suppression intact for fleet-wide restart loops.
- Treat active turn-slot holder evidence as in-flight work when the stale watchdog has no `current_turn_observation`, so it does not restart a keeper while the old fiber still owns reactive/turn slots.
- Scope force-release markers by acquisition, skip autonomous fairness stamps after watchdog force-release, and prune orphaned markers left by fibers that never finalize.

## Product Impact

The `/Users/dancer/me` runtime first recovered six alive-but-stuck keepers, then self-preservation suppressed the same six `stale_turn_timeout` restarts and left the fleet at 11/17 keeper fibers.

After the existing escape path eventually restarted the fleet to 17/17, live logs exposed the next failure mode: the watchdog was still terminating keepers at roughly the 300s idle threshold while they were listed as reactive/turn slot holders for 500s+. That creates duplicate/restarted keepers while the old fiber still holds scarce slots, which turns autonomy into reactive-slot starvation.

This PR keeps the fleet-restart guard for true full-fleet stale storms, but allows bounded partial stale recovery and prevents the watchdog from mistaking slot-held in-flight work for idle silence.

## Live Evidence

- `/health`: `effective_base_path=/Users/dancer/me`, `effective_masc_root=/Users/dancer/me/.masc`, startup `ready`.
- Earlier live log: `alive-but-stuck detected ... recovery=queued`, followed by `self-preservation: suppressing 6/17 restarts (ratio=0.35, cohort=stale_turn_timeout, streak=1)`.
- Later live `/health`: `keeper_fibers=17`; dashboard shell: `counts.keepers=17`, `configured_keepers=17`.
- Later live logs: `semaphore wait > 180s phase=reactive_slot ... holders=[.../575s...]` followed by `stale watchdog terminating fiber (idle 300s+)`, showing holder evidence and registry turn observation diverged.

## Review Evidence

- The self-preservation bypass only applies when the dominant cohort is `stale_turn_timeout` and its dominant-cohort ratio is `<= 0.50`.
- Larger stale cohorts, including near-universal and universal stale storms, stay on the circuit-breaker/probe path.
- Mixed restart sets are preserved: a 6/17 stale cohort plus an unrelated crashed keeper returns the full restart candidate list instead of dropping the non-stale candidate.
- Force-release markers are keyed by `(label, keeper_name, acquisition_id)` so replacement keepers cannot consume stale predecessor markers.
- Force-released autonomous finalizers skip the normal completion stamp, so watchdog-killed turns do not trigger fairness cooldown as if they completed normally.
- Orphaned force-release markers carry timestamps and are pruned after the marker TTL when the original fiber never finalizes.
- `git diff --check` passed.

## Validation Notes

- Focused validation was attempted with `scripts/dune-local.sh build test/test_keeper_supervisor.exe test/test_keeper_turn_slot_holders.exe`; it queued behind `/tmp/me-dune-local.lock` for over a minute and the local waiter was killed to avoid adding more host contention.
- Full build/test proof is left to GitHub CI because this host currently has multiple long-running Dune jobs across worktrees.

## Linked issue

None.
