### PR TITLE
fix(dashboard): cap workspace tree scan

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -128,6 +128,12 @@ let excluded_dirs =
 let default_tree_node_limit = 750
 let max_tree_node_limit = 2000
 
+let tree_node_limit_of_query = function
+  | Some raw -> (
+      try max 1 (min max_tree_node_limit (int_of_string raw))
+      with _ -> default_tree_node_limit)
+  | None -> default_tree_node_limit
+
 let safe_path base requested =
   let requested = String.map (fun c -> if c = '\\' then '/' else c) requested in
   let parts = String.split_on_char '/' requested in
@@ -199,12 +205,7 @@ let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
         else
           let full = Filename.concat dir f in
           let is_dir = try Sys.is_directory full with _ -> false in
-          let base_len = String.length base in
-          let rel =
-            if String.length full > base_len + 1
-            then String.sub full (base_len + 1) (String.length full - base_len - 1)
-            else f
-          in
+          let rel = rel_under base full in
           let has_children = is_dir && depth < max_depth in
           let parent = if depth = 0 then "" else Filename.dirname rel in
           let node = file_tree_node
@@ -409,11 +410,7 @@ let add_routes router =
              | None -> 3
            in
            let max_nodes =
-             match Uri.get_query_param uri "limit" with
-             | Some l ->
-               (try max 1 (min max_tree_node_limit (int_of_string l))
-                with _ -> default_tree_node_limit)
-             | None -> default_tree_node_limit
+             tree_node_limit_of_query (Uri.get_query_param uri "limit")
            in
            let nodes =
              if not (Sys.file_exists base) then []

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -125,6 +125,9 @@ let excluded_dirs =
   [ ".git"; "node_modules"; "_build"; ".obsidian"; "__pycache__";
     ".masc"; ".worktrees"; ".cache"; ".tmp"; "dist"; "build" ]
 
+let default_tree_node_limit = 750
+let max_tree_node_limit = 2000
+
 let safe_path base requested =
   let requested = String.map (fun c -> if c = '\\' then '/' else c) requested in
   let parts = String.split_on_char '/' requested in
@@ -180,34 +183,47 @@ let file_tree_node ~path ~label ~depth ~parent ~has_children =
          ; ("hasChildren", `Bool has_children)
          ; ("diff", `Null); ("keeperId", `Null); ("hueIndex", `Null) ]
 
-let rec scan_dir ~base ~depth ~max_depth acc dir =
-  if depth > max_depth then acc
+let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
+  if depth > max_depth || remaining <= 0 then (acc, remaining)
   else
     let entries =
       try Sys.readdir dir |> Array.to_list
       with _ -> []
     in
-    List.fold_left (fun acc f ->
-      if f = "." || f = ".." then acc
-      else if List.mem f excluded_dirs then acc
-      else
-        let full = Filename.concat dir f in
-        let is_dir = try Sys.is_directory full with _ -> false in
-        let base_len = String.length base in
-        let rel =
-          if String.length full > base_len + 1
-          then String.sub full (base_len + 1) (String.length full - base_len - 1)
-          else f
-        in
-        let has_children = is_dir && depth < max_depth in
-        let parent = if depth = 0 then "" else Filename.dirname rel in
-        let node = file_tree_node
-          ~path:rel ~label:f ~depth ~parent ~has_children in
-        let acc' = node :: acc in
-        if is_dir && depth < max_depth then
-          scan_dir ~base ~depth:(depth + 1) ~max_depth acc' full
-        else acc'
-    ) acc entries
+    let rec fold acc remaining = function
+      | [] -> (acc, remaining)
+      | _ when remaining <= 0 -> (acc, 0)
+      | f :: rest ->
+        if f = "." || f = ".." then fold acc remaining rest
+        else if List.mem f excluded_dirs then fold acc remaining rest
+        else
+          let full = Filename.concat dir f in
+          let is_dir = try Sys.is_directory full with _ -> false in
+          let base_len = String.length base in
+          let rel =
+            if String.length full > base_len + 1
+            then String.sub full (base_len + 1) (String.length full - base_len - 1)
+            else f
+          in
+          let has_children = is_dir && depth < max_depth in
+          let parent = if depth = 0 then "" else Filename.dirname rel in
+          let node = file_tree_node
+              ~path:rel ~label:f ~depth ~parent ~has_children in
+          let acc' = node :: acc in
+          let remaining' = remaining - 1 in
+          let acc'', remaining'' =
+            if is_dir && depth < max_depth then
+              scan_dir_bounded
+                ~base ~depth:(depth + 1) ~max_depth ~remaining:remaining'
+                acc' full
+            else (acc', remaining')
+          in
+          fold acc'' remaining'' rest
+    in
+    fold acc remaining entries
+
+let scan_dir ~base ~depth ~max_depth ~max_nodes acc dir =
+  fst (scan_dir_bounded ~base ~depth ~max_depth ~remaining:max_nodes acc dir)
 
 (* --- Git helpers --- *)
 
@@ -392,9 +408,16 @@ let add_routes router =
              | Some d -> (try max 1 (min 5 (int_of_string d)) with _ -> 3)
              | None -> 3
            in
+           let max_nodes =
+             match Uri.get_query_param uri "limit" with
+             | Some l ->
+               (try max 1 (min max_tree_node_limit (int_of_string l))
+                with _ -> default_tree_node_limit)
+             | None -> default_tree_node_limit
+           in
            let nodes =
              if not (Sys.file_exists base) then []
-             else scan_dir ~base ~depth:0 ~max_depth:depth [] base
+             else scan_dir ~base ~depth:0 ~max_depth:depth ~max_nodes [] base
            in
            let json = `List (List.rev nodes) in
            json_response_with_source ~status:`OK ~source request reqd json)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -53,6 +53,19 @@ val source_header :
     testing. *)
 val rel_under : string -> string -> string
 
+(** [scan_dir ~base ~depth ~max_depth ~max_nodes acc dir] returns at most
+    [max_nodes] tree nodes. The cap prevents a dashboard file-tree request
+    against a large workspace root from monopolizing the server event loop.
+    Exposed for regression testing. *)
+val scan_dir :
+  base:string ->
+  depth:int ->
+  max_depth:int ->
+  max_nodes:int ->
+  Yojson.Safe.t list ->
+  string ->
+  Yojson.Safe.t list
+
 (** [valid_git_ref s] is [true] iff [s] is a non-empty, ≤256-char string
     drawn from the conservative ref/SHA charset and not starting with
     ["-"]. Used to refuse query-string values that could be parsed as

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -53,6 +53,12 @@ val source_header :
     testing. *)
 val rel_under : string -> string -> string
 
+(** [tree_node_limit_of_query value] applies the workspace tree route's
+    [limit] query parameter defaulting and [1, max_tree_node_limit] clamp.
+    Invalid or missing values fall back to the route default. Exposed for
+    unit testing. *)
+val tree_node_limit_of_query : string option -> int
+
 (** [scan_dir ~base ~depth ~max_depth ~max_nodes acc dir] returns at most
     [max_nodes] tree nodes. The cap prevents a dashboard file-tree request
     against a large workspace root from monopolizing the server event loop.

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -255,6 +255,39 @@ let test_rel_under_equal () =
   Alcotest.(check string) "safe = base -> empty"
     "" (W.rel_under "/repo" "/repo")
 
+(* ─── scan_dir (bounded file-tree scan) ──────────────────────────── *)
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
+let with_temp_dir name f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-workspace-routes-%d-%s" (Unix.getpid ()) name)
+  in
+  remove_tree dir;
+  Unix.mkdir dir 0o700;
+  Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
+
+let touch path =
+  let oc = open_out path in
+  close_out oc
+
+let test_scan_dir_respects_max_nodes () =
+  with_temp_dir "wide-tree" (fun dir ->
+    for i = 1 to 80 do
+      touch (Filename.concat dir (Printf.sprintf "file-%03d.txt" i))
+    done;
+    let nodes = W.scan_dir ~base:dir ~depth:0 ~max_depth:1 ~max_nodes:25 [] dir in
+    Alcotest.(check int) "node cap" 25 (List.length nodes))
+
 (* ─── valid_git_ref (option-injection guard) ────────────────────── *)
 
 let test_valid_ref_main () =
@@ -338,6 +371,9 @@ let () =
         ; Alcotest.test_case "root base"         `Quick test_rel_under_root_base
         ; Alcotest.test_case "trailing slash"    `Quick test_rel_under_trailing_slash
         ; Alcotest.test_case "safe equals base"  `Quick test_rel_under_equal
+        ] )
+    ; ( "scan_dir"
+      , [ Alcotest.test_case "respects max node cap" `Quick test_scan_dir_respects_max_nodes
         ] )
     ; ( "valid_git_ref"
       , [ Alcotest.test_case "main"              `Quick test_valid_ref_main

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -288,6 +288,21 @@ let test_scan_dir_respects_max_nodes () =
     let nodes = W.scan_dir ~base:dir ~depth:0 ~max_depth:1 ~max_nodes:25 [] dir in
     Alcotest.(check int) "node cap" 25 (List.length nodes))
 
+let test_tree_node_limit_default () =
+  Alcotest.(check int) "default" 750 (W.tree_node_limit_of_query None)
+
+let test_tree_node_limit_invalid_falls_back () =
+  Alcotest.(check int) "invalid" 750 (W.tree_node_limit_of_query (Some "bad"))
+
+let test_tree_node_limit_clamps_low () =
+  Alcotest.(check int) "low" 1 (W.tree_node_limit_of_query (Some "0"))
+
+let test_tree_node_limit_clamps_high () =
+  Alcotest.(check int) "high" 2000 (W.tree_node_limit_of_query (Some "9000"))
+
+let test_tree_node_limit_accepts_valid () =
+  Alcotest.(check int) "valid" 42 (W.tree_node_limit_of_query (Some "42"))
+
 (* ─── valid_git_ref (option-injection guard) ────────────────────── *)
 
 let test_valid_ref_main () =
@@ -374,6 +389,11 @@ let () =
         ] )
     ; ( "scan_dir"
       , [ Alcotest.test_case "respects max node cap" `Quick test_scan_dir_respects_max_nodes
+        ; Alcotest.test_case "limit default" `Quick test_tree_node_limit_default
+        ; Alcotest.test_case "limit invalid falls back" `Quick test_tree_node_limit_invalid_falls_back
+        ; Alcotest.test_case "limit clamps low" `Quick test_tree_node_limit_clamps_low
+        ; Alcotest.test_case "limit clamps high" `Quick test_tree_node_limit_clamps_high
+        ; Alcotest.test_case "limit accepts valid" `Quick test_tree_node_limit_accepts_valid
         ] )
     ; ( "valid_git_ref"
       , [ Alcotest.test_case "main"              `Quick test_valid_ref_main


### PR DESCRIPTION
## Summary
- add a bounded workspace tree scanner with a default 750-node cap
- add a `limit` query parameter clamped to 1..2000 for `/api/v1/workspace/tree`
- cover the scanner cap with a focused regression test

## Root Cause
`/api/v1/workspace/tree` recursively scanned workspace roots without a node budget. Against `/Users/dancer/me`, that filesystem stat walk could monopolize the server loop and make `/health` time out while the dashboard requested the file tree.

## Validation
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-workspace-tree-limit-test2 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-workspace-tree-limit-0505 test/test_workspace_routes_keeper.exe`
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-workspace-tree-limit-test2 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-workspace-tree-limit-0505 test/test_workspace_routes_keeper.exe` (37 tests)
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-workspace-tree-limit-test2 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-workspace-tree-limit-0505 bin/main_eio.exe`
- live 8935 proof: `/health` ready with `cwd=/Users/dancer/me`, `roots_diverge=false`; `workspace/tree?depth=5&limit=25` returned 25 nodes; default `workspace/tree?depth=5` returned 750 nodes; `/health` stayed ready afterward