### PR TITLE
fix(review): address post-merge review cleanup

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -573,15 +573,15 @@ export interface MetricsWindow {
 
   // -- Tool --
   tool_call_count?: number
-  pr_review_read_tool_count?: number
-  pr_review_mutation_tool_count?: number
-  pr_review_tool_count?: number
-  pr_work_git_tool_count?: number
-  pr_work_signal_count?: number
-  observed_pr_review_work?: boolean
-  observed_pr_mutation_work?: boolean
-  observed_git_work?: boolean
-  observed_pr_work?: boolean
+  pr_review_read_tool_call_count?: number
+  pr_review_mutation_tool_call_count?: number
+  pr_review_tool_call_count?: number
+  pr_work_git_tool_call_count?: number
+  pr_work_tool_call_count?: number
+  observed_pr_review_tool_calls?: boolean
+  observed_pr_mutation_tool_calls?: boolean
+  observed_git_tool_calls?: boolean
+  observed_pr_work_tool_calls?: boolean
 
   // -- Memory --
   memory_checks?: number

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -581,19 +581,21 @@ let compute_metrics_window
     top_counts_json ~limit:5 ~name_key:"tool" tool_counts_window
   in
   let tool_count name = Option.value ~default:0 (Hashtbl.find_opt tool_counts_window name) in
-  let pr_review_read_tool_count = tool_count "keeper_pr_review_read" in
-  let pr_review_mutation_tool_count =
+  let pr_review_read_tool_call_count = tool_count "keeper_pr_review_read" in
+  let pr_review_mutation_tool_call_count =
     tool_count "keeper_pr_review_comment" + tool_count "keeper_pr_review_reply"
   in
-  let pr_review_tool_count =
-    pr_review_read_tool_count + pr_review_mutation_tool_count
+  let pr_review_tool_call_count =
+    pr_review_read_tool_call_count + pr_review_mutation_tool_call_count
   in
-  let pr_work_git_tool_count =
+  let pr_work_git_tool_call_count =
     tool_count "keeper_preflight_check"
     + tool_count "masc_worktree_create"
     + tool_count "masc_code_git"
   in
-  let pr_work_signal_count = pr_review_tool_count + pr_work_git_tool_count in
+  let pr_work_tool_call_count =
+    pr_review_tool_call_count + pr_work_git_tool_call_count
+  in
   let top_memory_kinds =
     top_counts_json ~limit:5 ~name_key:"kind" memory_kind_counts_window
   in
@@ -700,15 +702,17 @@ let compute_metrics_window
     ("proactive_preview_similarity_method", `String "jaccard_adjacent_preview");
     ("proactive_preview_similarity_window", `Int proactive_similarity_window);
     ("tool_call_count", `Int acc.ma_tool_call_count);
-    ("pr_review_read_tool_count", `Int pr_review_read_tool_count);
-    ("pr_review_mutation_tool_count", `Int pr_review_mutation_tool_count);
-    ("pr_review_tool_count", `Int pr_review_tool_count);
-    ("pr_work_git_tool_count", `Int pr_work_git_tool_count);
-    ("pr_work_signal_count", `Int pr_work_signal_count);
-    ("observed_pr_review_work", `Bool (pr_review_tool_count > 0));
-    ("observed_pr_mutation_work", `Bool (pr_review_mutation_tool_count > 0));
-    ("observed_git_work", `Bool (pr_work_git_tool_count > 0));
-    ("observed_pr_work", `Bool (pr_work_signal_count > 0));
+    ("pr_review_read_tool_call_count", `Int pr_review_read_tool_call_count);
+    ( "pr_review_mutation_tool_call_count",
+      `Int pr_review_mutation_tool_call_count );
+    ("pr_review_tool_call_count", `Int pr_review_tool_call_count);
+    ("pr_work_git_tool_call_count", `Int pr_work_git_tool_call_count);
+    ("pr_work_tool_call_count", `Int pr_work_tool_call_count);
+    ("observed_pr_review_tool_calls", `Bool (pr_review_tool_call_count > 0));
+    ( "observed_pr_mutation_tool_calls",
+      `Bool (pr_review_mutation_tool_call_count > 0) );
+    ("observed_git_tool_calls", `Bool (pr_work_git_tool_call_count > 0));
+    ("observed_pr_work_tool_calls", `Bool (pr_work_tool_call_count > 0));
     ("memory_checks", `Int acc.ma_memory_checks);
     ("memory_passed", `Int acc.ma_memory_passed);
     ("memory_failed", `Int memory_failed);

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -75,23 +75,24 @@ let test_metrics_window_exposes_observed_pr_work () =
       ~primary_model_norm:""
       ~primary_model:""
   in
-  check int "review read tools" 1
-    (summary_int "pr_review_read_tool_count" summary);
-  check int "review mutation tools" 2
-    (summary_int "pr_review_mutation_tool_count" summary);
-  check int "review tools" 3
-    (summary_int "pr_review_tool_count" summary);
-  check int "git/preflight tools" 3
-    (summary_int "pr_work_git_tool_count" summary);
-  check int "pr work signal count" 6
-    (summary_int "pr_work_signal_count" summary);
+  check int "review read tool calls" 1
+    (summary_int "pr_review_read_tool_call_count" summary);
+  check int "review mutation tool calls" 2
+    (summary_int "pr_review_mutation_tool_call_count" summary);
+  check int "review tool calls" 3
+    (summary_int "pr_review_tool_call_count" summary);
+  check int "git/preflight tool calls" 3
+    (summary_int "pr_work_git_tool_call_count" summary);
+  check int "pr work tool call count" 6
+    (summary_int "pr_work_tool_call_count" summary);
   check bool "observed review" true
-    (summary_bool "observed_pr_review_work" summary);
+    (summary_bool "observed_pr_review_tool_calls" summary);
   check bool "observed mutation" true
-    (summary_bool "observed_pr_mutation_work" summary);
-  check bool "observed git" true (summary_bool "observed_git_work" summary);
+    (summary_bool "observed_pr_mutation_tool_calls" summary);
+  check bool "observed git" true
+    (summary_bool "observed_git_tool_calls" summary);
   check bool "observed pr work" true
-    (summary_bool "observed_pr_work" summary)
+    (summary_bool "observed_pr_work_tool_calls" summary)
 
 let () =
   run "dashboard_keeper_metrics_10286"

--- a/test/test_decide_goal_loop_findings.py
+++ b/test/test_decide_goal_loop_findings.py
@@ -109,7 +109,9 @@ class DecideGoalLoopFindingsTest(unittest.TestCase):
         self.assertIn('"act_missing_count": 1', result.stdout)
 
     def test_startup_fixture_keeps_unlinked_emergency_action_visible(self) -> None:
-        orient = json.loads((FIXTURE_DIR / "orient.startup.json").read_text())
+        orient = json.loads(
+            (FIXTURE_DIR / "orient.startup.json").read_text(encoding="utf-8")
+        )
         act_map = decide_goal_loop_findings.load_act_map_input(
             str(FIXTURE_DIR / "act-map.startup.json")
         )


### PR DESCRIPTION
Summary:
- Rename PR-work metric JSON fields from tool-count wording to tool-call wording.
- Pin UTF-8 fixture reads in the goal-loop findings test.

Review feedback addressed:
- #13177 PR-work metric field semantics.
- #13172 fixture read encoding.

Board review note:
- The #13147 empty-hearth UI review is intentionally handled in separate board follow-up PR #13205, so this PR no longer overlaps dashboard board files.

Validation:
- git diff --check origin/main...HEAD
- python3 -m pytest -q test/test_decide_goal_loop_findings.py
- pnpm --dir dashboard run typecheck
- scripts/dune-local.sh build test/test_dashboard_keeper_metrics_10286.exe and ./_build/default/test/test_dashboard_keeper_metrics_10286.exe passed before the board-only split; duplicate post-amend Dune rerun was stopped due /tmp/me-dune-local.lock contention, with the OCaml delta unchanged.