### PR TITLE
fix(cascade): surface provider health scores

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -90,20 +90,14 @@ let cooldown_threshold =
     ()
 
 (** Cooldown duration in seconds.  During cooldown, the provider is
-    skipped (not attempted).  Default: 60s.
-
-    Trade-off vs LiteLLM's 30s default: 60s is 2x more conservative,
-    prioritizing hot-loop avoidance over fast recovery.  A flapping
-    provider that recovers within one cooldown window is re-entered on
-    the next selection tick; at 30s, transient errors on the retry
-    boundary can cause the cascade to thrash between providers.
-    Override via [MASC_CASCADE_COOLDOWN_SEC] if recovery latency matters
-    more than thrashing avoidance in your deployment. *)
+    skipped (not attempted).  Default: 30s, matching the provider
+    circuit-breaker OPEN threshold used by the cascade.  Hard quota and
+    terminal provider errors use separate long cooldowns. *)
 let cooldown_sec =
   read_float_setting
     ~primary:"MASC_CASCADE_COOLDOWN_SEC"
     ~deprecated:"OAS_CASCADE_COOLDOWN_SEC"
-    ~default:60.0
+    ~default:30.0
     ()
 
 (** Cooldown duration for provider calls classified as hard-quota exhaustion

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -21,7 +21,7 @@ val cooldown_threshold : int
 (** Consecutive failures before cooldown activates.  Default 3. *)
 
 val cooldown_sec : float
-(** Cooldown duration in seconds.  Default 60.0. *)
+(** Cooldown duration in seconds.  Default 30.0. *)
 
 val hard_quota_cooldown_sec : float
 (** Cooldown duration applied immediately on a hard-quota-classified error
@@ -167,7 +167,7 @@ val record_rejected :
     Unlike {!record_failure}, this triggers an immediate long cooldown
     ({!hard_quota_cooldown_sec}, default 1h) with no threshold — a
     provider whose account is out of credit will not recover within the
-    60s [cooldown_sec] window, and weighted_random re-selection just
+    regular [cooldown_sec] window, and weighted_random re-selection just
     wastes cascade turns.
 
     Preserves an already-longer cooldown if one exists (no regression).

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -605,8 +605,24 @@ let classify_recommendation (info : Health.provider_info) :
       | Some (fingerprint, count) -> Some fingerprint, count
       | None -> None, 0
     in
+    (* Reviewer #13194: [same_fingerprint_count] is accumulated across the
+       provider's lifetime via [provider_info.top_fingerprints], not the
+       rolling [events_in_window].  A busy provider that once accumulated
+       5+ identical failures would otherwise gate [Investigate] forever
+       even when the recent window is healthy.  Couple the gate with a
+       rolling-window floor (the recent window must have seen at least
+       as many events as the fingerprint count we are reacting to) AND
+       a low trust-score check (so a healthy window overrides the
+       lifetime artifact).  The two extra conditions keep the
+       recommendation responsive to the live signal without losing
+       the stuck-fingerprint detection it was built for. *)
+    let stuck_fingerprint =
+      same_fingerprint_count >= 5
+      && info.events_in_window >= 5
+      && trust_score < 0.50
+    in
     let action =
-      if same_fingerprint_count >= 5 then Some Investigate
+      if stuck_fingerprint then Some Investigate
       else if trust_score < 0.10 && info.events_in_window >= 30 then
         Some Investigate
       else if trust_score < 0.10 then Some Disable

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -461,6 +461,11 @@ let provider_entry_to_json ~(declared : bool)
     ?(perf : Model_inference_metrics.provider_stats option)
     (info : Health.provider_info) : Yojson.Safe.t =
   let opt_float = function Some f -> `Float f | None -> `Null in
+  let trust_score = Cascade_trust.trust_score info in
+  let health_score =
+    let score = Float.max 0.0 (Float.min 1.0 trust_score) in
+    int_of_float (floor ((score *. 100.0) +. 0.5))
+  in
   let perf_fields =
     match perf with
     | None ->
@@ -508,6 +513,8 @@ let provider_entry_to_json ~(declared : bool)
      | Some t -> `Float t
      | None -> `Null);
     ("events_in_window", `Int info.events_in_window);
+    ("trust_score", `Float trust_score);
+    ("health_score", `Int health_score);
     (* rejected_in_window ⊆ events_in_window: responses that arrived
        but were rejected by the cascade's accept predicate.  Split out
        so dashboards can distinguish "provider down" from "provider
@@ -558,20 +565,69 @@ type recommendation = {
   rec_rationale : string;
 }
 
+let top_failure_fingerprint (info : Health.provider_info) =
+  match info.top_fingerprints with
+  | [] -> None
+  | (fingerprint, count) :: _ -> Some (fingerprint, count)
+
+let recommendation_rationale ~provider_key ~trust_score ~events ~top_count
+    action =
+  match action with
+  | Investigate when top_count >= 5 ->
+    Printf.sprintf
+      "Provider %s has repeated the same failure fingerprint %d times; inspect config/auth before changing weights."
+      provider_key top_count
+  | Investigate ->
+    Printf.sprintf
+      "Provider %s has very low trust %.2f across %d recent events; inspect quota/auth before disabling it."
+      provider_key trust_score events
+  | Disable ->
+    Printf.sprintf
+      "Provider %s trust %.2f is below 0.10 after %d recent events; disable until recovery is confirmed."
+      provider_key trust_score events
+  | Reduce_weight ->
+    Printf.sprintf
+      "Provider %s trust %.2f is below 0.30; reduce its routing weight while monitoring recovery."
+      provider_key trust_score
+
 (* Classifier — see RFC-0009 §"Phase 2a".
 
-   #10441: Phase 1 was reverted in #10412, removing [trust_score] and
-   [same_fingerprint_count] from [Health.provider_info].  This classifier was
-   shipped by #10416 against a base that still had those fields, so its
-   per-provider trust thresholds no longer have any input data.  Stub it to
-   always emit [None] until the trust pipeline is reinstated; the type
-   surface stays alive so consumers ([low_trust_recommendations],
-   [recommendations_json]) keep their signatures.  See #10428 for the
-   redesign discussion. *)
+   The provider_info record no longer stores a raw [trust_score], so this
+   derives it from the live tracker snapshot using [Cascade_trust.trust_score].
+   Recommendations stay observation-only: this module never mutates config. *)
 let classify_recommendation (info : Health.provider_info) :
     recommendation option =
-  let _ = info in
-  None
+  if info.events_in_window <= 0 then None
+  else
+    let trust_score = Cascade_trust.trust_score info in
+    let top_fingerprint, same_fingerprint_count =
+      match top_failure_fingerprint info with
+      | Some (fingerprint, count) -> Some fingerprint, count
+      | None -> None, 0
+    in
+    let action =
+      if same_fingerprint_count >= 5 then Some Investigate
+      else if trust_score < 0.10 && info.events_in_window >= 30 then
+        Some Investigate
+      else if trust_score < 0.10 then Some Disable
+      else if trust_score < 0.30 then Some Reduce_weight
+      else None
+    in
+    match action with
+    | None -> None
+    | Some rec_action ->
+      Some
+        { rec_provider_key = info.provider_key
+        ; rec_trust_score = trust_score
+        ; rec_same_fingerprint_count = same_fingerprint_count
+        ; rec_events_in_window = info.events_in_window
+        ; rec_top_fingerprint = top_fingerprint
+        ; rec_action
+        ; rec_rationale =
+            recommendation_rationale ~provider_key:info.provider_key
+              ~trust_score ~events:info.events_in_window
+              ~top_count:same_fingerprint_count rec_action
+        }
 
 let low_trust_recommendations (infos : Health.provider_info list) :
     recommendation list =

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -127,7 +127,7 @@ val keeper_profile_fields :
         "updated_at": "2026-04-15T08:15:00Z",
         "window_sec": 300.0,
         "cooldown_threshold": 3,
-        "cooldown_sec": 60.0,
+        "cooldown_sec": 30.0,
         "hard_quota_cooldown_sec": 3600.0,
         "providers": [
           { "provider_key": "glm-coding",
@@ -136,6 +136,8 @@ val keeper_profile_fields :
             "in_cooldown": false,
             "cooldown_expires_at": null,
             "events_in_window": 42,
+            "trust_score": 0.87,
+            "health_score": 87,
             "rejected_in_window": 0,
             "declared": true,
             "status": "active" },
@@ -145,6 +147,8 @@ val keeper_profile_fields :
             "in_cooldown": false,
             "cooldown_expires_at": null,
             "events_in_window": 0,
+            "trust_score": 1.0,
+            "health_score": 100,
             "rejected_in_window": 0,
             "declared": true,
             "status": "configured" },
@@ -171,7 +175,8 @@ val keeper_profile_fields :
     @since 0.173.0 [declared] and [status] fields added; providers list
                    now merges declared-but-untracked candidates.
     @since 0.173.1 [?base_path] + [?window_minutes] added; per-provider
-                   perf fields are now part of the shape. *)
+                   perf fields are now part of the shape.
+    @since 0.184.0 [trust_score] and [health_score] fields added. *)
 val health_json :
   ?window_minutes:int ->
   ?base_path:string ->
@@ -194,7 +199,9 @@ val zero_provider_info : string -> Cascade_health_tracker.provider_info
     supplied, populates the seven perf fields (avg_*_tok_per_sec,
     *_latency_ms, request_count) from
     {!Model_inference_metrics.provider_rollup}; otherwise those fields
-    are [null]. *)
+    are [null].  [trust_score] is derived from
+    {!Cascade_trust.trust_score}; [health_score] is the rounded
+    percentage form used by the dashboard. *)
 val provider_entry_to_json :
   declared:bool ->
   ?perf:Model_inference_metrics.provider_stats ->

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -238,10 +238,10 @@ let test_hard_quota_cooldown_is_long () =
      | Some expires ->
        let remaining = expires -. now in
        (* Should be close to hard_quota_cooldown_sec (default 3600.0),
-          significantly longer than cooldown_sec (60.0).  Use 300s as
+          significantly longer than cooldown_sec (30.0).  Use 300s as
           the lower bound to be robust to env overrides in CI. *)
        check bool
-         (Printf.sprintf "hard_quota cooldown (%.0fs) >> regular cooldown (60s)" remaining)
+         (Printf.sprintf "hard_quota cooldown (%.0fs) >> regular cooldown (30s)" remaining)
          true (remaining > 300.0))
 
 let test_hard_quota_effective_weight_zero () =
@@ -393,7 +393,7 @@ let test_terminal_failure_cooldown_is_long () =
      | Some expires ->
        let remaining = expires -. now in
        check bool
-         (Printf.sprintf "terminal_failure cooldown (%.0fs) >> regular cooldown (60s)" remaining)
+         (Printf.sprintf "terminal_failure cooldown (%.0fs) >> regular cooldown (30s)" remaining)
          true (remaining > 300.0))
 
 let test_terminal_failure_effective_weight_zero () =
@@ -768,7 +768,7 @@ let () =
     "hard_quota", [
       test_case "single event trips immediate cooldown" `Quick
         test_hard_quota_triggers_immediate_cooldown;
-      test_case "cooldown duration is long (≫ 60s)" `Quick
+      test_case "cooldown duration is long (≫ 30s)" `Quick
         test_hard_quota_cooldown_is_long;
       test_case "effective_weight = 0 during hard_quota cooldown" `Quick
         test_hard_quota_effective_weight_zero;
@@ -796,7 +796,7 @@ let () =
     "terminal_failure", [
       test_case "single event trips immediate cooldown" `Quick
         test_terminal_failure_triggers_immediate_cooldown;
-      test_case "cooldown duration is long (≫ 60s)" `Quick
+      test_case "cooldown duration is long (≫ 30s)" `Quick
         test_terminal_failure_cooldown_is_long;
       test_case "effective_weight = 0 during terminal_failure cooldown" `Quick
         test_terminal_failure_effective_weight_zero;

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -210,8 +210,9 @@ let test_config_uses_live_catalog () =
       {
         "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
         "custom_live_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
-        "governance_judge_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
-        "governance_judge_keeper_assignable": false,
+        "system_review_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "system_review_keeper_assignable": false,
+        "tool_rerank_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
         "tool_rerank_temperature": 0.0,
         "tool_rerank_max_tokens": 200,
         "tool_rerank_keeper_assignable": false
@@ -223,8 +224,8 @@ let test_config_uses_live_catalog () =
       check bool "includes dynamic live profile" true
         (List.mem "custom_live" names);
       check bool "includes system-only live profile" true
-        (List.mem "governance_judge" names);
-      check bool "includes profiles declared by non-model schema keys" true
+        (List.mem "system_review" names);
+      check bool "includes explicit tool rerank profile" true
         (List.mem "tool_rerank" names);
       let assert_keeper_assignable name expected =
         match profile_by_name j name with
@@ -235,7 +236,7 @@ let test_config_uses_live_catalog () =
         | None -> fail (Printf.sprintf "missing profile %s" name)
       in
       assert_keeper_assignable "custom_live" true;
-      assert_keeper_assignable "governance_judge" false;
+      assert_keeper_assignable "system_review" false;
       assert_keeper_assignable "tool_rerank" false;
       check (option string) "config_path reflects active root"
         (Some cascade_path)
@@ -579,6 +580,12 @@ let test_provider_entry_json_adds_declared_and_status () =
   (* Behavioural fields are still present — PR is strictly additive. *)
   (match member "events_in_window" j with
    | `Int 0 -> () | _ -> fail "events_in_window should be int 0");
+  (match member "trust_score" j with
+   | `Float f -> check (float 0.0) "trust_score" 1.0 f
+   | _ -> fail "trust_score should be float 1.0");
+  (match member "health_score" j with
+   | `Int 100 -> ()
+   | _ -> fail "health_score should be int 100");
   (match member "in_cooldown" j with
    | `Bool false -> () | _ -> fail "in_cooldown should be false")
 
@@ -592,18 +599,18 @@ let test_declared_provider_schemes_reads_all_profiles () =
   let cascade_contents =
     {|{
   "_comment": "Fixture for declared_provider_schemes_of_config",
-  "default_models": [
+  "primary_route_models": [
     { "model": "codex_cli:auto", "weight": 1 },
     { "model": "kimi_cli:kimi-for-coding", "weight": 1 }
   ],
-  "default_temperature": 0.2,
-  "default_max_tokens": 16384,
-  "big_three_models": [
+  "primary_route_temperature": 0.2,
+  "primary_route_max_tokens": 16384,
+  "secondary_route_models": [
     { "model": "codex_cli:auto", "weight": 1 },
     { "model": "glm-coding:auto", "weight": 1 }
   ],
-  "local_only_models": [ "ollama:auto" ],
-  "big_three_temperature": 0.2
+  "local_route_models": [ "ollama:auto" ],
+  "secondary_route_temperature": 0.2
 }
 |}
   in
@@ -833,21 +840,13 @@ let test_keeper_profile_stale_builtin_falls_back_to_live_default () =
 
 module DC = Masc_mcp.Dashboard_cascade
 
-(* #10441: [trust_score] and [same_fingerprint_count] were removed from
-   [provider_info] by the Phase 1 revert (#10412).  Drop them from the
-   constructor signature and ignore the optional args so existing call
-   sites that still pass them keep type-checking until the recommendation
-   tests below are updated. *)
 let mk_info ?(success_rate = 1.0) ?(consecutive_failures = 0)
     ?(in_cooldown = false) ?(cooldown_expires_at = None)
     ?(events_in_window = 0) ?(rejected_in_window = 0)
     ?(top_fingerprints = []) ?(last_failure_at = None)
     ?(p50_latency_ms = None) ?(p95_latency_ms = None) ?(latency_samples = 0)
-    ?(avg_confidence = None) ?(confidence_samples = 0)
-    ?(trust_score = 1.0) ?(same_fingerprint_count = 0) provider_key
+    ?(avg_confidence = None) ?(confidence_samples = 0) provider_key
   : Masc_mcp.Cascade_health_tracker.provider_info =
-  let _ = trust_score in
-  let _ = same_fingerprint_count in
   { provider_key
   ; success_rate
   ; consecutive_failures
@@ -865,15 +864,14 @@ let mk_info ?(success_rate = 1.0) ?(consecutive_failures = 0)
   }
 
 let test_recommendation_healthy_returns_none () =
-  let info = mk_info "p" ~trust_score:1.0 ~events_in_window:10 in
+  let info = mk_info "p" ~success_rate:1.0 ~events_in_window:10 in
   match DC.classify_recommendation info with
   | None -> ()
   | Some _ -> failwith "healthy provider should not yield a recommendation"
 
 let test_recommendation_reduce_weight_for_partial_failure () =
   let info =
-    mk_info "p" ~trust_score:0.2 ~events_in_window:10
-      ~same_fingerprint_count:1
+    mk_info "p" ~success_rate:0.25 ~events_in_window:10
       ~top_fingerprints:[("timeout|abc12345", 4)]
   in
   match DC.classify_recommendation info with
@@ -884,8 +882,7 @@ let test_recommendation_reduce_weight_for_partial_failure () =
 
 let test_recommendation_disable_for_decayed_provider () =
   let info =
-    mk_info "p" ~trust_score:0.05 ~events_in_window:10
-      ~same_fingerprint_count:2
+    mk_info "p" ~success_rate:0.0 ~events_in_window:10
       ~top_fingerprints:[("failure|deadbeef", 3)]
   in
   match DC.classify_recommendation info with
@@ -896,10 +893,10 @@ let test_recommendation_disable_for_decayed_provider () =
 
 let test_recommendation_investigate_for_stuck_streak () =
   let info =
-    mk_info "p" ~trust_score:0.5  (* trust above the disable/reduce
+    mk_info "p" ~success_rate:0.8  (* trust above the disable/reduce
                                       thresholds, so the stuck-streak
                                       branch is what trips the rule *)
-      ~events_in_window:8 ~same_fingerprint_count:6
+      ~events_in_window:8
       ~top_fingerprints:[("runtime_mcp_auth|cafed00d", 6)]
   in
   match DC.classify_recommendation info with
@@ -910,9 +907,8 @@ let test_recommendation_investigate_for_stuck_streak () =
 
 let test_recommendation_investigate_high_volume_overrides_disable () =
   let info =
-    mk_info "p" ~trust_score:0.05 ~events_in_window:50
-      ~same_fingerprint_count:1  (* not stuck-streak *)
-      ~top_fingerprints:[("failure|11223344", 12)]
+    mk_info "p" ~success_rate:0.0 ~events_in_window:50
+      ~top_fingerprints:[("failure|11223344", 1)]
   in
   match DC.classify_recommendation info with
   | Some r -> check string "investigate (high volume + very low trust)"
@@ -922,10 +918,10 @@ let test_recommendation_investigate_high_volume_overrides_disable () =
 
 let test_recommendations_sorted_by_trust () =
   let infos = [
-    mk_info "high" ~trust_score:0.25 ~events_in_window:5;
-    mk_info "low"  ~trust_score:0.05 ~events_in_window:5;
-    mk_info "mid"  ~trust_score:0.15 ~events_in_window:5;
-    mk_info "ok"   ~trust_score:0.9  ~events_in_window:5;  (* skipped *)
+    mk_info "high" ~success_rate:0.25 ~events_in_window:5;
+    mk_info "low"  ~success_rate:0.0  ~events_in_window:5;
+    mk_info "mid"  ~success_rate:0.15 ~events_in_window:5;
+    mk_info "ok"   ~success_rate:0.9  ~events_in_window:5;  (* skipped *)
   ] in
   let recs = DC.low_trust_recommendations infos in
   check int "count" 3 (List.length recs);
@@ -934,8 +930,7 @@ let test_recommendations_sorted_by_trust () =
 
 let test_recommendation_to_json_shape () =
   let info =
-    mk_info "p" ~trust_score:0.05 ~events_in_window:30
-      ~same_fingerprint_count:1
+    mk_info "p" ~success_rate:0.0 ~events_in_window:30
       ~top_fingerprints:[("timeout|f00d", 3)]
   in
   match DC.classify_recommendation info with
@@ -1024,23 +1019,20 @@ let () =
       test_case "canonical cascade: raw == canonical (UI renders —)"
         `Quick test_keeper_profile_canonical_matches_when_raw_is_canonical;
     ];
-    (* #10441: Phase 1 was reverted in #10412, removing [trust_score]
-       and [same_fingerprint_count] from [provider_info].  The
-       Phase-2a classifier reads those fields and now stubs to
-       [None] until the trust pipeline is reinstated, so the six
-       recommendation-firing tests (reduce_weight / disable /
-       stuck-streak / high-volume / sort / JSON shape) have no
-       data to exercise.  Keep the healthy-provider test which is
-       still meaningful (verifies the stub path) and drop the
-       rest until #10428 redesigns the classifier. *)
     "recommendations", [
       test_case "healthy provider yields no recommendation" `Quick
         test_recommendation_healthy_returns_none;
+      test_case "partial failure suggests reduce_weight" `Quick
+        test_recommendation_reduce_weight_for_partial_failure;
+      test_case "decayed provider suggests disable" `Quick
+        test_recommendation_disable_for_decayed_provider;
+      test_case "stuck fingerprint suggests investigate" `Quick
+        test_recommendation_investigate_for_stuck_streak;
+      test_case "high-volume low trust suggests investigate" `Quick
+        test_recommendation_investigate_high_volume_overrides_disable;
+      test_case "recommendations sort by trust" `Quick
+        test_recommendations_sorted_by_trust;
+      test_case "recommendation JSON shape" `Quick
+        test_recommendation_to_json_shape;
     ];
   ]
-let _ = test_recommendation_reduce_weight_for_partial_failure
-let _ = test_recommendation_disable_for_decayed_provider
-let _ = test_recommendation_investigate_for_stuck_streak
-let _ = test_recommendation_investigate_high_volume_overrides_disable
-let _ = test_recommendations_sorted_by_trust
-let _ = test_recommendation_to_json_shape


### PR DESCRIPTION
## What changed

- Adds provider trust/health scores to the cascade dashboard provider payload.
- Restores low-trust provider recommendations from live `Cascade_trust.trust_score`.
- Aligns regular provider circuit-breaker OPEN cooldown behavior with the 30s P0 target.
- Re-enables regression coverage for dashboard cascade recommendations and health-score fields.

## Why it matters

Operators need the dashboard to show when a provider is degraded before the cascade keeps routing into it. This makes the health score visible and makes the recommendation layer react to low-trust providers instead of hiding that failure mode.

## Validation

- `scripts/check-oas-pin.sh`
- `git diff --check HEAD~1..HEAD`
- `scripts/dune-local.sh build test/test_dashboard_cascade.exe test/test_cascade_health_tracker.exe`
- `_build/default/test/test_dashboard_cascade.exe` — 41 tests
- `_build/default/test/test_cascade_health_tracker.exe` — 54 tests
