### PR TITLE
fix(keeper): add fair yield meter

### DIFF
--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -50,3 +50,23 @@ let run_in_systhread f =
     Eio_unix.run_in_systhread f
   else
     f ()
+
+(** Cooperatively yield without raising [Effect.Unhandled] before
+    [Eio_main.run]. *)
+let yield_if_ready () =
+  if Atomic.get ready then Eio.Fiber.yield ()
+
+type yield_meter = {
+  interval : int;
+  mutable steps : int;
+}
+
+let create_yield_meter ?(interval = 1000) () =
+  { interval = max 1 interval; steps = 0 }
+
+let yield_step meter =
+  meter.steps <- meter.steps + 1;
+  if meter.steps >= meter.interval then begin
+    meter.steps <- 0;
+    yield_if_ready ()
+  end

--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -51,10 +51,10 @@ let run_in_systhread f =
   else
     f ()
 
-(** Cooperatively yield without raising [Effect.Unhandled] before
-    [Eio_main.run]. *)
+(** Cooperatively yield without raising if the Eio scheduler is unavailable. *)
 let yield_if_ready () =
-  if Atomic.get ready then Eio.Fiber.yield ()
+  if Atomic.get ready then
+    Safe_ops.protect ~default:() (fun () -> Eio.Fiber.yield ())
 
 type yield_meter = {
   interval : int;

--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -58,15 +58,16 @@ let yield_if_ready () =
 
 type yield_meter = {
   interval : int;
-  mutable steps : int;
+  steps : int Atomic.t;
 }
 
 let create_yield_meter ?(interval = 1000) () =
-  { interval = max 1 interval; steps = 0 }
+  { interval = max 1 interval; steps = Atomic.make 0 }
 
 let yield_step meter =
-  meter.steps <- meter.steps + 1;
-  if meter.steps >= meter.interval then begin
-    meter.steps <- 0;
-    yield_if_ready ()
-  end
+  let rec bump () =
+    let current = Atomic.get meter.steps in
+    let next = if current + 1 >= meter.interval then 0 else current + 1 in
+    if Atomic.compare_and_set meter.steps current next then next = 0 else bump ()
+  in
+  if bump () then yield_if_ready ()

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -32,7 +32,8 @@ val yield_if_ready : unit -> unit
     currently yield. *)
 
 type yield_meter
-(** Counter for periodic cooperative yields in CPU-heavy loops. *)
+(** Counter for periodic cooperative yields in CPU-heavy loops. Safe to share
+    across fibers or domains. *)
 
 val create_yield_meter : ?interval:int -> unit -> yield_meter
 (** Create a meter that yields every [interval] steps.  Non-positive

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -25,3 +25,18 @@ val with_mutex_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
 
 val run_in_systhread : (unit -> 'a) -> 'a
 (** Run [f] in a system thread if Eio is ready, directly otherwise. *)
+
+val yield_if_ready : unit -> unit
+(** Cooperatively yield to the Eio scheduler if the runtime is active.
+    No-op before {!enable}. *)
+
+type yield_meter
+(** Counter for periodic cooperative yields in CPU-heavy loops. *)
+
+val create_yield_meter : ?interval:int -> unit -> yield_meter
+(** Create a meter that yields every [interval] steps.  Non-positive
+    intervals are coerced to 1.  Default: 1000. *)
+
+val yield_step : yield_meter -> unit
+(** Count one CPU work unit and call {!yield_if_ready} whenever the
+    configured interval is reached. *)

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -28,7 +28,8 @@ val run_in_systhread : (unit -> 'a) -> 'a
 
 val yield_if_ready : unit -> unit
 (** Cooperatively yield to the Eio scheduler if the runtime is active.
-    No-op before {!enable}. *)
+    No-op before {!enable} or when called from a context where Eio cannot
+    currently yield. *)
 
 type yield_meter
 (** Counter for periodic cooperative yields in CPU-heavy loops. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -321,7 +321,11 @@ let wakeup_relevant_keeper_for_board_signal
         signal.post_id)
   in
   let selected, dropped = select_board_wakeup_candidates candidates in
-  selected |> List.iter (fun (meta, reason) -> wake_meta meta reason);
+  let yield_meter = Eio_guard.create_yield_meter ~interval:1 () in
+  selected
+  |> List.iter (fun (meta, reason) ->
+         wake_meta meta reason;
+         Eio_guard.yield_step yield_meter);
   if dropped > 0 then begin
     Prometheus.inc_counter
       Prometheus.metric_keeper_keepalive_signal_failures

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -623,7 +623,9 @@ let compact_memory_bank_if_needed
               let selected_rev = ref [] in
               let selected_count = ref 0 in
               let fallback_kind_cap = max 8 (target_notes / 8) in
+              let yield_meter = Eio_guard.create_yield_meter () in
               let add_row ~ignore_kind_cap (row : keeper_memory_row_raw) =
+                Eio_guard.yield_step yield_meter;
                 if !selected_count >= target_notes then
                   ()
                 else

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -43,6 +43,23 @@ module For_testing = struct
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
 end
 
+let filteri_with_fair_yield f xs =
+  let meter = Eio_guard.create_yield_meter ~interval:1 () in
+  List.filteri
+    (fun idx item ->
+      let keep = f idx item in
+      Eio_guard.yield_step meter;
+      keep)
+    xs
+
+let iteri_with_fair_yield f xs =
+  let meter = Eio_guard.create_yield_meter ~interval:1 () in
+  List.iteri
+    (fun idx item ->
+      f idx item;
+      Eio_guard.yield_step meter)
+    xs
+
 let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     (state : Mcp_server.server_state) =
   Progress.set_sse_callback Sse.broadcast;
@@ -735,7 +752,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
           false
       in
       (* Initial boot pass *)
-      let booted = List.filteri (fun idx name -> try_boot_one idx name) names in
+      let booted = filteri_with_fair_yield (fun idx name -> try_boot_one idx name) names in
       let booted_count = List.length booted in
       let total = List.length names in
       Log.Keeper.info "autoboot: initial pass %d/%d keepers started" booted_count total;
@@ -761,7 +778,9 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
             else begin
               Log.Keeper.info "autoboot: retry round %d/%d — %d unbooted: [%s]"
                 round max_retries (List.length unbooted) (String.concat ", " unbooted);
-              List.iteri (fun idx name -> ignore (try_boot_one idx name)) unbooted;
+              iteri_with_fair_yield
+                (fun idx name -> ignore (try_boot_one idx name))
+                unbooted;
               retry_loop (round + 1)
             end
           end

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -41,10 +41,34 @@ let test_keeper_msg_async_roundtrip () =
   Alcotest.(check int) "one pending entry" 1
     (List.length (Keeper_msg_async.list_for_keeper ~keeper_name:"alpha"))
 
+let test_yield_meter_noops_without_runnable_fiber () =
+  let meter = Eio_guard.create_yield_meter ~interval:0 () in
+  Eio_guard.enable ();
+  Fun.protect ~finally:Eio_guard.disable (fun () ->
+      Eio_guard.yield_step meter;
+      Eio_guard.yield_step meter)
+
+let test_yield_meter_can_be_shared_across_fibers () =
+  with_eio_env @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let meter = Eio_guard.create_yield_meter ~interval:2 () in
+  for _ = 1 to 8 do
+    Eio.Fiber.fork ~sw (fun () ->
+        for _ = 1 to 50 do
+          Eio_guard.yield_step meter
+        done)
+  done
+
 let () =
   run "keeper_mutex_coverage"
     [
       "keeper_msg_async", [
         test_case "submit/poll roundtrip" `Quick test_keeper_msg_async_roundtrip;
+      ];
+      "eio_guard", [
+        test_case "yield meter noops without runnable fiber" `Quick
+          test_yield_meter_noops_without_runnable_fiber;
+        test_case "yield meter can be shared across fibers" `Quick
+          test_yield_meter_can_be_shared_across_fibers;
       ];
     ]


### PR DESCRIPTION
## What changed

- Adds a small `Eio_guard.yield_meter` helper with a default interval of 1000 work units.
- Applies the meter inside keeper memory-bank compaction row selection.
- Adds per-keeper cooperative yields in autoboot initial/retry passes.
- Adds cooperative yields while dispatching board-reactive keeper wakeups.

## Why it matters

This gives long-running keeper loops a reusable cooperative-yield primitive and applies it to fleet-level keeper iteration paths where a single domain can otherwise run many keeper work items back-to-back.

## Validation

- `git diff --check HEAD~1..HEAD`
- `scripts/dune-local.sh build test/test_keeper_memory_bank_consensus_re_10399.exe test/test_smart_heartbeat_keepalive.exe test/test_env_config_keeper_bootstrap_intervals.exe`
- `_build/default/test/test_keeper_memory_bank_consensus_re_10399.exe` — 4 tests
- `_build/default/test/test_smart_heartbeat_keepalive.exe` — 30 tests
- `_build/default/test/test_env_config_keeper_bootstrap_intervals.exe` — 8 tests
