### PR TITLE
fix(ci): normalize suffixed release tag versions

### DIFF
--- a/scripts/check-release-train-guard.sh
+++ b/scripts/check-release-train-guard.sh
@@ -47,7 +47,7 @@ version_from_stream() {
 }
 
 version_from_ref() {
-  git show "$1:dune-project" 2>/dev/null | version_from_stream
+  git show "$1:dune-project" 2>/dev/null | version_from_stream || true
 }
 
 major_from_version() {

--- a/scripts/check-release-train-guard.sh
+++ b/scripts/check-release-train-guard.sh
@@ -59,6 +59,17 @@ latest_tag_for_major() {
   git tag --list "v${major}.*" --sort=-v:refname | head -n1
 }
 
+version_from_tag() {
+  local tag="$1"
+  local package_version
+  package_version="$(version_from_ref "$tag")"
+  if [[ -n "$package_version" ]]; then
+    printf '%s\n' "$package_version"
+  else
+    printf '%s\n' "${tag#v}"
+  fi
+}
+
 version_gt() {
   local left="$1"
   local right="$2"
@@ -77,7 +88,7 @@ if [[ -z "$base_ref" ]]; then
     exit 0
   fi
 
-  latest_tag_version="${latest_tag#v}"
+  latest_tag_version="$(version_from_tag "$latest_tag")"
   printf 'Release train guard OK: no base ref provided, head=%s latest_tag=%s\n' \
     "$head_package_version" "$latest_tag_version"
   exit 0
@@ -91,7 +102,7 @@ latest_tag="$(latest_tag_for_major "$base_major")"
 if [[ "$head_major" != "$base_major" ]]; then
   head_latest_tag="$(latest_tag_for_major "$head_major")"
   if [[ -n "$head_latest_tag" ]]; then
-    head_latest_tag_version="${head_latest_tag#v}"
+    head_latest_tag_version="$(version_from_tag "$head_latest_tag")"
     if version_gt "$head_latest_tag_version" "$head_package_version"; then
       fail "head ref $head_ref uses package version $head_package_version, which is older than latest tag v$head_latest_tag_version in major $head_major; pick a newer version before crossing release lines"
     fi
@@ -110,7 +121,7 @@ if [[ -z "$latest_tag" ]]; then
   fail "base ref $base_ref starts bootstrap release line $base_package_version with no published v${base_major}.* tag, and head changes package version to $head_package_version; publish/tag v$base_package_version before widening the release line"
 fi
 
-latest_tag_version="${latest_tag#v}"
+latest_tag_version="$(version_from_tag "$latest_tag")"
 
 if [[ "$base_package_version" == "$latest_tag_version" ]]; then
   printf 'Release train guard OK: base=%s head=%s latest_tag=%s\n' \

--- a/test/test_release_train_guard_script.ml
+++ b/test/test_release_train_guard_script.ml
@@ -199,6 +199,27 @@ let test_suffixed_release_tag_uses_tagged_package_version () =
         (contains_substring stdout
            "Release train guard OK: base=0.2.0 head=0.2.0 latest_tag=0.2.0"))
 
+let test_legacy_tag_without_dune_project_falls_back_to_tag_version () =
+  with_temp_dir "release-train-legacy-tag" (fun dir ->
+      init_repo_with_release_tags dir;
+      let script = install_script_under_test dir in
+      ignore
+        (run_shell_ok ~cwd:dir
+           "git checkout --orphan legacy-no-dune && git rm -qf dune-project && git commit --allow-empty -q -m legacy-no-dune && git tag v0.3.0 && git checkout main");
+      ignore
+        (commit_on_branch ~dir ~branch:"version-reset" ~version:"0.3.0"
+           ~message:"reset active line");
+      let cmd =
+        Printf.sprintf "/bin/bash %s --base version-reset --head version-reset"
+          (quote script)
+      in
+      let code, stdout, stderr = run_shell ~cwd:dir cmd in
+      if code <> 0 then
+        failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
+      check bool "falls back to raw tag version" true
+        (contains_substring stdout
+           "Release train guard OK: base=0.3.0 head=0.3.0 latest_tag=0.3.0"))
+
 let () =
   run "release_train_guard_script"
     [
@@ -214,5 +235,7 @@ let () =
             test_pending_bootstrap_series_blocks_next_train_until_tagged;
           test_case "suffixed release tag uses tagged package version" `Quick
             test_suffixed_release_tag_uses_tagged_package_version;
+          test_case "legacy tag without dune-project falls back" `Quick
+            test_legacy_tag_without_dune_project_falls_back_to_tag_version;
         ] );
     ]

--- a/test/test_release_train_guard_script.ml
+++ b/test/test_release_train_guard_script.ml
@@ -180,6 +180,25 @@ let test_pending_bootstrap_series_blocks_next_train_until_tagged () =
         (contains_substring stderr
            "publish/tag v0.2.0 before widening the release train"))
 
+let test_suffixed_release_tag_uses_tagged_package_version () =
+  with_temp_dir "release-train-suffixed-tag" (fun dir ->
+      init_repo_with_release_tags dir;
+      let script = install_script_under_test dir in
+      ignore
+        (commit_on_branch ~dir ~branch:"suffixed-release" ~version:"0.2.0"
+           ~message:"reset active line");
+      ignore (run_shell_ok ~cwd:dir "git tag v0.2.0-505");
+      let cmd =
+        Printf.sprintf "/bin/bash %s --base suffixed-release --head suffixed-release"
+          (quote script)
+      in
+      let code, stdout, stderr = run_shell ~cwd:dir cmd in
+      if code <> 0 then
+        failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
+      check bool "uses package version from suffixed tag" true
+        (contains_substring stdout
+           "Release train guard OK: base=0.2.0 head=0.2.0 latest_tag=0.2.0"))
+
 let () =
   run "release_train_guard_script"
     [
@@ -193,5 +212,7 @@ let () =
             test_pending_bootstrap_series_warns_without_blocking_same_version;
           test_case "pending bootstrap series blocks next train" `Quick
             test_pending_bootstrap_series_blocks_next_train_until_tagged;
+          test_case "suffixed release tag uses tagged package version" `Quick
+            test_suffixed_release_tag_uses_tagged_package_version;
         ] );
     ]


### PR DESCRIPTION
## Summary
- compare release-train tags using the package version stored at the tag ref
- keep raw tag suffixes such as v0.19.10-505 from falsely blocking PRs whose base package version is 0.19.10
- add a regression test for suffixed release tags

## Validation
- bash scripts/check-release-train-guard.sh --base origin/main --head HEAD
- git diff --check
- MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_release_train_guard_script.exe
- _build/default/test/test_release_train_guard_script.exe