### PR TITLE
feat: expose keeper PR action metrics

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -578,10 +578,21 @@ export interface MetricsWindow {
   pr_review_tool_call_count?: number
   pr_work_git_tool_call_count?: number
   pr_work_tool_call_count?: number
+  pr_review_action_attempt_count?: number
+  pr_review_action_success_count?: number
+  pr_review_comment_action_count?: number
+  pr_review_approve_action_count?: number
+  pr_review_request_changes_action_count?: number
+  pr_review_reply_action_count?: number
   observed_pr_review_tool_calls?: boolean
   observed_pr_mutation_tool_calls?: boolean
   observed_git_tool_calls?: boolean
   observed_pr_work_tool_calls?: boolean
+  observed_pr_review_work?: boolean
+  observed_pr_mutation_work?: boolean
+  observed_pr_approve_work?: boolean
+  observed_pr_request_changes_work?: boolean
+  observed_pr_reply_work?: boolean
 
   // -- Memory --
   memory_checks?: number

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -584,6 +584,13 @@ export interface MetricsWindow {
   pr_review_approve_action_count?: number
   pr_review_request_changes_action_count?: number
   pr_review_reply_action_count?: number
+  pr_work_action_attempt_count?: number
+  pr_work_action_success_count?: number
+  pr_git_add_action_count?: number
+  pr_git_commit_action_count?: number
+  pr_git_push_action_count?: number
+  pr_create_action_count?: number
+  pr_work_signal_count?: number
   observed_pr_review_tool_calls?: boolean
   observed_pr_mutation_tool_calls?: boolean
   observed_git_tool_calls?: boolean
@@ -593,6 +600,11 @@ export interface MetricsWindow {
   observed_pr_approve_work?: boolean
   observed_pr_request_changes_work?: boolean
   observed_pr_reply_work?: boolean
+  observed_pr_create_work?: boolean
+  observed_pr_push_work?: boolean
+  observed_pr_commit_work?: boolean
+  observed_git_work?: boolean
+  observed_pr_work?: boolean
 
   // -- Memory --
   memory_checks?: number

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -605,11 +605,10 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
             ) metrics_lines
           in
-	          let last_metrics =
-	            match List.rev parsed_metrics with
-	            | latest :: _ -> Some latest
-	            | [] -> None
-	          in
+          let last_metrics =
+            List.find_opt metrics_row_has_context_snapshot
+              (List.rev parsed_metrics)
+          in
 	          let (last_skill_primary, last_skill_secondary, last_skill_reason) =
 	            let open Yojson.Safe.Util in
 	            let rec find_latest = function

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -599,11 +599,17 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             if compact then (`Null, `Null)
             else keeper_metrics_24h_json ~metrics_lines:all_metrics_lines ~now_ts
           in
+          let pr_action_metrics_lines =
+            let action_store =
+              Keeper_types.keeper_pr_action_metrics_store config m.name
+            in
+            Dated_jsonl.read_recent_lines action_store metrics_cap
+          in
           let metrics_lines = all_metrics_lines in
           let parsed_metrics =
             List.filter_map (fun line ->
               try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
-            ) metrics_lines
+            ) (metrics_lines @ pr_action_metrics_lines)
           in
           let last_metrics =
             List.find_opt metrics_row_has_context_snapshot

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -47,6 +47,12 @@ type metrics_acc = {
   ma_pr_review_approve_action_count : int;
   ma_pr_review_request_changes_action_count : int;
   ma_pr_review_reply_action_count : int;
+  ma_pr_work_action_attempt_count : int;
+  ma_pr_work_action_success_count : int;
+  ma_pr_git_add_action_count : int;
+  ma_pr_git_commit_action_count : int;
+  ma_pr_git_push_action_count : int;
+  ma_pr_create_action_count : int;
   ma_proactive_previews_rev : string list;
   ma_last_handoff : Yojson.Safe.t option;
   ma_last_compaction : Yojson.Safe.t option;
@@ -96,6 +102,12 @@ let init_acc = {
   ma_pr_review_approve_action_count = 0;
   ma_pr_review_request_changes_action_count = 0;
   ma_pr_review_reply_action_count = 0;
+  ma_pr_work_action_attempt_count = 0;
+  ma_pr_work_action_success_count = 0;
+  ma_pr_git_add_action_count = 0;
+  ma_pr_git_commit_action_count = 0;
+  ma_pr_git_push_action_count = 0;
+  ma_pr_create_action_count = 0;
   ma_proactive_previews_rev = [];
   ma_last_handoff = None;
   ma_last_compaction = None;
@@ -225,6 +237,14 @@ let compute_metrics_window
         in
         let pr_review_action_success_now =
           Safe_ops.json_bool ~default:false "pr_review_action_success" j
+        in
+        let pr_work_action_now =
+          Safe_ops.json_string_opt "pr_work_action" j
+          |> Option.map (fun value -> value |> String.trim |> String.uppercase_ascii)
+          |> function Some value when value <> "" -> Some value | _ -> None
+        in
+        let pr_work_action_success_now =
+          Safe_ops.json_bool ~default:false "pr_work_action_success" j
         in
         let memory_is_weather = match memory_expected_topic with Some "weather" -> true | _ -> false in
         let work_kind =
@@ -445,6 +465,51 @@ let compute_metrics_window
                    | _ -> acc)
           else acc
         in
+        let acc =
+          if (is_interaction || is_tool_event)
+             && metric_event = "keeper_pr_work_action"
+          then
+            match pr_work_action_now with
+            | None -> acc
+            | Some action ->
+                let acc =
+                  { acc with
+                    ma_pr_work_action_attempt_count =
+                      acc.ma_pr_work_action_attempt_count + 1;
+                  }
+                in
+                if not pr_work_action_success_now then acc
+                else
+                  let acc =
+                    { acc with
+                      ma_pr_work_action_success_count =
+                        acc.ma_pr_work_action_success_count + 1;
+                    }
+                  in
+                  (match action with
+                   | "GIT_ADD" ->
+                       { acc with
+                         ma_pr_git_add_action_count =
+                           acc.ma_pr_git_add_action_count + 1;
+                       }
+                   | "GIT_COMMIT" ->
+                       { acc with
+                         ma_pr_git_commit_action_count =
+                           acc.ma_pr_git_commit_action_count + 1;
+                       }
+                   | "GIT_PUSH" ->
+                       { acc with
+                         ma_pr_git_push_action_count =
+                           acc.ma_pr_git_push_action_count + 1;
+                       }
+                   | "PR_CREATE" ->
+                       { acc with
+                         ma_pr_create_action_count =
+                           acc.ma_pr_create_action_count + 1;
+                       }
+                   | _ -> acc)
+          else acc
+        in
         let acc = if is_heartbeat then { acc with ma_heartbeat_points = acc.ma_heartbeat_points + 1 } else acc in
 
         let output_item =
@@ -492,6 +557,8 @@ let compute_metrics_window
               ("metric_event", `String metric_event);
               ("pr_review_action", Json_util.string_opt_to_json pr_review_action_now);
               ("pr_review_action_success", `Bool pr_review_action_success_now);
+              ("pr_work_action", Json_util.string_opt_to_json pr_work_action_now);
+              ("pr_work_action_success", `Bool pr_work_action_success_now);
               ("tool_call_count", `Int tool_call_count_now);
               ("tools_used", `List (List.map (fun s -> `String s) tools_used));
               ("proactive_fallback_applied", `Bool proactive_fallback_applied_now);
@@ -666,6 +733,11 @@ let compute_metrics_window
   let pr_work_tool_call_count =
     pr_review_tool_call_count + pr_work_git_tool_call_count
   in
+  let pr_review_action_signal_count = acc.ma_pr_review_action_success_count in
+  let pr_work_total_signal_count =
+    pr_work_tool_call_count + pr_review_action_signal_count
+    + acc.ma_pr_work_action_success_count
+  in
   let top_memory_kinds =
     top_counts_json ~limit:5 ~name_key:"kind" memory_kind_counts_window
   in
@@ -782,8 +854,15 @@ let compute_metrics_window
     ("pr_review_approve_action_count", `Int acc.ma_pr_review_approve_action_count);
     ("pr_review_request_changes_action_count", `Int acc.ma_pr_review_request_changes_action_count);
     ("pr_review_reply_action_count", `Int acc.ma_pr_review_reply_action_count);
+    ("pr_work_action_attempt_count", `Int acc.ma_pr_work_action_attempt_count);
+    ("pr_work_action_success_count", `Int acc.ma_pr_work_action_success_count);
+    ("pr_git_add_action_count", `Int acc.ma_pr_git_add_action_count);
+    ("pr_git_commit_action_count", `Int acc.ma_pr_git_commit_action_count);
+    ("pr_git_push_action_count", `Int acc.ma_pr_git_push_action_count);
+    ("pr_create_action_count", `Int acc.ma_pr_create_action_count);
     ("pr_work_git_tool_call_count", `Int pr_work_git_tool_call_count);
     ("pr_work_tool_call_count", `Int pr_work_tool_call_count);
+    ("pr_work_signal_count", `Int pr_work_total_signal_count);
     ("observed_pr_review_tool_calls", `Bool (pr_review_tool_call_count > 0));
     ( "observed_pr_mutation_tool_calls",
       `Bool (pr_review_mutation_tool_call_count > 0) );
@@ -800,6 +879,16 @@ let compute_metrics_window
     ("observed_pr_approve_work", `Bool (acc.ma_pr_review_approve_action_count > 0));
     ("observed_pr_request_changes_work", `Bool (acc.ma_pr_review_request_changes_action_count > 0));
     ("observed_pr_reply_work", `Bool (acc.ma_pr_review_reply_action_count > 0));
+    ("observed_pr_create_work", `Bool (acc.ma_pr_create_action_count > 0));
+    ("observed_pr_push_work", `Bool (acc.ma_pr_git_push_action_count > 0));
+    ("observed_pr_commit_work", `Bool (acc.ma_pr_git_commit_action_count > 0));
+    ( "observed_git_work",
+      `Bool
+        (pr_work_git_tool_call_count > 0
+         || acc.ma_pr_git_add_action_count > 0
+         || acc.ma_pr_git_commit_action_count > 0
+         || acc.ma_pr_git_push_action_count > 0) );
+    ("observed_pr_work", `Bool (pr_work_total_signal_count > 0));
     ("memory_checks", `Int acc.ma_memory_checks);
     ("memory_passed", `Int acc.ma_memory_passed);
     ("memory_failed", `Int memory_failed);

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -513,7 +513,7 @@ let compute_metrics_window
         let acc = if is_heartbeat then { acc with ma_heartbeat_points = acc.ma_heartbeat_points + 1 } else acc in
 
         let output_item =
-          if compact then None
+          if compact || not (metrics_row_has_context_snapshot j) then None
           else
             Some (`Assoc [
               ("ts_unix", `Float ts_unix);

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -41,6 +41,12 @@ type metrics_acc = {
   ma_memory_compaction_before_notes : int;
   ma_memory_compaction_dropped_notes : int;
   ma_memory_compaction_invalid_dropped : int;
+  ma_pr_review_action_attempt_count : int;
+  ma_pr_review_action_success_count : int;
+  ma_pr_review_comment_action_count : int;
+  ma_pr_review_approve_action_count : int;
+  ma_pr_review_request_changes_action_count : int;
+  ma_pr_review_reply_action_count : int;
   ma_proactive_previews_rev : string list;
   ma_last_handoff : Yojson.Safe.t option;
   ma_last_compaction : Yojson.Safe.t option;
@@ -84,6 +90,12 @@ let init_acc = {
   ma_memory_compaction_before_notes = 0;
   ma_memory_compaction_dropped_notes = 0;
   ma_memory_compaction_invalid_dropped = 0;
+  ma_pr_review_action_attempt_count = 0;
+  ma_pr_review_action_success_count = 0;
+  ma_pr_review_comment_action_count = 0;
+  ma_pr_review_approve_action_count = 0;
+  ma_pr_review_request_changes_action_count = 0;
+  ma_pr_review_reply_action_count = 0;
   ma_proactive_previews_rev = [];
   ma_last_handoff = None;
   ma_last_compaction = None;
@@ -117,6 +129,7 @@ let compute_metrics_window
         let channel = Safe_ops.json_string ~default:"turn" "channel" j in
         let is_turn = channel = "turn" in
         let is_heartbeat = channel = "heartbeat" in
+        let is_tool_event = channel = "tool_event" in
         let is_scheduled_autonomous = channel = "scheduled_autonomous" || channel = "proactive" in
         let is_interaction = is_turn || is_scheduled_autonomous in
         let compacted = Safe_ops.json_bool ~default:false "compacted" j in
@@ -204,6 +217,15 @@ let compute_metrics_window
           | _ -> []
         in
         let tool_call_count_now = Safe_ops.json_int ~default:(List.length tools_used) "tool_call_count" j in
+        let metric_event = Safe_ops.json_string ~default:"" "metric_event" j in
+        let pr_review_action_now =
+          Safe_ops.json_string_opt "pr_review_action" j
+          |> Option.map (fun value -> value |> String.trim |> String.uppercase_ascii)
+          |> function Some value when value <> "" -> Some value | _ -> None
+        in
+        let pr_review_action_success_now =
+          Safe_ops.json_bool ~default:false "pr_review_action_success" j
+        in
         let memory_is_weather = match memory_expected_topic with Some "weather" -> true | _ -> false in
         let work_kind =
           if work_kind_raw <> "" then work_kind_raw
@@ -378,6 +400,51 @@ let compute_metrics_window
             acc
           end else acc
         in
+        let acc =
+          if (is_interaction || is_tool_event)
+             && metric_event = "keeper_pr_review_action"
+          then
+            match pr_review_action_now with
+            | None -> acc
+            | Some action ->
+                let acc =
+                  { acc with
+                    ma_pr_review_action_attempt_count =
+                      acc.ma_pr_review_action_attempt_count + 1;
+                  }
+                in
+                if not pr_review_action_success_now then acc
+                else
+                  let acc =
+                    { acc with
+                      ma_pr_review_action_success_count =
+                        acc.ma_pr_review_action_success_count + 1;
+                    }
+                  in
+                  (match action with
+                   | "COMMENT" ->
+                       { acc with
+                         ma_pr_review_comment_action_count =
+                           acc.ma_pr_review_comment_action_count + 1;
+                       }
+                   | "APPROVE" ->
+                       { acc with
+                         ma_pr_review_approve_action_count =
+                           acc.ma_pr_review_approve_action_count + 1;
+                       }
+                   | "REQUEST_CHANGES" ->
+                       { acc with
+                         ma_pr_review_request_changes_action_count =
+                           acc.ma_pr_review_request_changes_action_count + 1;
+                       }
+                   | "REPLY" ->
+                       { acc with
+                         ma_pr_review_reply_action_count =
+                           acc.ma_pr_review_reply_action_count + 1;
+                       }
+                   | _ -> acc)
+          else acc
+        in
         let acc = if is_heartbeat then { acc with ma_heartbeat_points = acc.ma_heartbeat_points + 1 } else acc in
 
         let output_item =
@@ -422,6 +489,9 @@ let compute_metrics_window
               ("compaction_saved_tokens", `Int saved_tokens);
               ("compaction_trigger", Json_util.string_opt_to_json compaction_trigger_now);
               ("work_kind", `String work_kind);
+              ("metric_event", `String metric_event);
+              ("pr_review_action", Json_util.string_opt_to_json pr_review_action_now);
+              ("pr_review_action_success", `Bool pr_review_action_success_now);
               ("tool_call_count", `Int tool_call_count_now);
               ("tools_used", `List (List.map (fun s -> `String s) tools_used));
               ("proactive_fallback_applied", `Bool proactive_fallback_applied_now);
@@ -706,6 +776,12 @@ let compute_metrics_window
     ( "pr_review_mutation_tool_call_count",
       `Int pr_review_mutation_tool_call_count );
     ("pr_review_tool_call_count", `Int pr_review_tool_call_count);
+    ("pr_review_action_attempt_count", `Int acc.ma_pr_review_action_attempt_count);
+    ("pr_review_action_success_count", `Int acc.ma_pr_review_action_success_count);
+    ("pr_review_comment_action_count", `Int acc.ma_pr_review_comment_action_count);
+    ("pr_review_approve_action_count", `Int acc.ma_pr_review_approve_action_count);
+    ("pr_review_request_changes_action_count", `Int acc.ma_pr_review_request_changes_action_count);
+    ("pr_review_reply_action_count", `Int acc.ma_pr_review_reply_action_count);
     ("pr_work_git_tool_call_count", `Int pr_work_git_tool_call_count);
     ("pr_work_tool_call_count", `Int pr_work_tool_call_count);
     ("observed_pr_review_tool_calls", `Bool (pr_review_tool_call_count > 0));
@@ -713,6 +789,17 @@ let compute_metrics_window
       `Bool (pr_review_mutation_tool_call_count > 0) );
     ("observed_git_tool_calls", `Bool (pr_work_git_tool_call_count > 0));
     ("observed_pr_work_tool_calls", `Bool (pr_work_tool_call_count > 0));
+    ( "observed_pr_review_work",
+      `Bool
+        (pr_review_tool_call_count > 0
+         || acc.ma_pr_review_action_success_count > 0) );
+    ( "observed_pr_mutation_work",
+      `Bool
+        (pr_review_mutation_tool_call_count > 0
+         || acc.ma_pr_review_action_success_count > 0) );
+    ("observed_pr_approve_work", `Bool (acc.ma_pr_review_approve_action_count > 0));
+    ("observed_pr_request_changes_work", `Bool (acc.ma_pr_review_request_changes_action_count > 0));
+    ("observed_pr_reply_work", `Bool (acc.ma_pr_review_reply_action_count > 0));
     ("memory_checks", `Int acc.ma_memory_checks);
     ("memory_passed", `Int acc.ma_memory_passed);
     ("memory_failed", `Int memory_failed);

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -230,6 +230,21 @@ let create_keeper_24h_bucket_stats () : keeper_24h_bucket_stats =
     proactive_fallback_count = 0;
   }
 
+let metrics_row_has_context_snapshot (j : Yojson.Safe.t) : bool =
+  let open Yojson.Safe.Util in
+  let has_int = function
+    | `Int _ -> true
+    | _ -> false
+  in
+  let has_ratio = function
+    | `Float _ | `Int _ -> true
+    | _ -> false
+  in
+  has_ratio (member "context_ratio" j)
+  && has_int (member "context_tokens" j)
+  && has_int (member "context_max" j)
+  && has_int (member "message_count" j)
+
 let keeper_metrics_24h_json
     ~(metrics_lines : string list)
     ~(now_ts : float) : Yojson.Safe.t * Yojson.Safe.t =
@@ -245,7 +260,9 @@ let keeper_metrics_24h_json
       try
         let j = Yojson.Safe.from_string line in
         let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
-        if ts_unix >= start_ts && ts_unix <= (now_ts +. 60.0) then begin
+        if ts_unix >= start_ts && ts_unix <= (now_ts +. 60.0)
+           && metrics_row_has_context_snapshot j
+        then begin
           incr sample_points;
           let bucket_ts =
             int_of_float (floor (ts_unix /. 3600.0) *. 3600.0)

--- a/lib/dashboard/dashboard_http_keeper_metrics.mli
+++ b/lib/dashboard/dashboard_http_keeper_metrics.mli
@@ -98,6 +98,13 @@ val top_count_name_and_count :
     for the highest-count entry, [None] when [tbl] is empty.
     Convenience for the "primary model / tool" badge. *)
 
+(** {1 Metrics-row classification (cascade-visible)} *)
+
+val metrics_row_has_context_snapshot : Yojson.Safe.t -> bool
+(** [metrics_row_has_context_snapshot row] is true when [row] carries
+    turn/heartbeat context fields used by context health panels. Sparse
+    [tool_event] rows intentionally do not qualify. *)
+
 (** {1 24h-window aggregation (cascade-visible)} *)
 
 val keeper_metrics_24h_json :

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1060,34 +1060,41 @@ let pr_review_action_metric_event_of_tool_io
 
 let split_top_level_command_segments command =
   let len = String.length command in
-  let push_segment start stop acc =
+  let push_segment unconditional start stop acc =
     let segment = String.sub command start (stop - start) |> String.trim in
-    if segment = "" then acc else segment :: acc
+    if segment = "" then acc else (unconditional, segment) :: acc
   in
-  let rec loop acc start i in_single in_double escaped =
-    if i >= len then List.rev (push_segment start len acc)
+  let rec loop acc unconditional start i in_single in_double escaped =
+    if i >= len then List.rev (push_segment unconditional start len acc)
     else
       let c = command.[i] in
-      if escaped then loop acc start (i + 1) in_single in_double false
+      if escaped then loop acc unconditional start (i + 1) in_single in_double false
       else
         match c with
         | '\\' when not in_single ->
-            loop acc start (i + 1) in_single in_double true
+            loop acc unconditional start (i + 1) in_single in_double true
         | '\'' when not in_double ->
-            loop acc start (i + 1) (not in_single) in_double false
+            loop acc unconditional start (i + 1) (not in_single) in_double false
         | '"' when not in_single ->
-            loop acc start (i + 1) in_single (not in_double) false
+            loop acc unconditional start (i + 1) in_single (not in_double) false
         | '&' when (not in_single) && (not in_double) && i + 1 < len
                    && command.[i + 1] = '&' ->
-            let acc = push_segment start i acc in
-            loop acc (i + 2) (i + 2) in_single in_double false
+            let acc = push_segment unconditional start i acc in
+            loop acc false (i + 2) (i + 2) in_single in_double false
+        | '|' when (not in_single) && (not in_double) && i + 1 < len
+                   && command.[i + 1] = '|' ->
+            let acc = push_segment unconditional start i acc in
+            loop acc false (i + 2) (i + 2) in_single in_double false
+        | '\n' when (not in_single) && not in_double ->
+            let acc = push_segment unconditional start i acc in
+            loop acc true (i + 1) (i + 1) in_single in_double false
         | ';' when (not in_single) && not in_double ->
-            let acc = push_segment start i acc in
-            loop acc (i + 1) (i + 1) in_single in_double false
+            let acc = push_segment unconditional start i acc in
+            loop acc true (i + 1) (i + 1) in_single in_double false
         | _ ->
-            loop acc start (i + 1) in_single in_double false
+            loop acc unconditional start (i + 1) in_single in_double false
   in
-  loop [] 0 0 false false false
+  loop [] true 0 0 false false false
 
 let pr_work_action_of_git_action raw =
   match String.trim raw |> String.lowercase_ascii with
@@ -1121,10 +1128,15 @@ let pr_work_actions_of_gh_segment segment =
 
 let pr_work_actions_of_command command =
   split_top_level_command_segments command
-  |> List.concat_map (fun segment ->
-       match pr_work_actions_of_gh_segment segment with
-       | [] -> pr_work_actions_of_git_segment segment
-       | actions -> actions)
+  |> List.concat_map (fun (unconditional, segment) ->
+       (* Shell conditionals can skip later segments at runtime.  Without
+          per-segment exit data, count only top-level segments that are
+          unconditionally reached. *)
+       if not unconditional then []
+       else
+         match pr_work_actions_of_gh_segment segment with
+         | [] -> pr_work_actions_of_git_segment segment
+         | actions -> actions)
 
 let command_input_of_tool ~(tool_name : string) (input : Yojson.Safe.t) =
   match tool_name with
@@ -1204,7 +1216,7 @@ let append_pr_review_action_metric
   | None -> ()
   | Some event ->
       let now = Time_compat.now () in
-      let store = Keeper_types.keeper_metrics_store config meta.name in
+      let store = Keeper_types.keeper_pr_action_metrics_store config meta.name in
       let snapshot =
         `Assoc
           [
@@ -1246,7 +1258,7 @@ let append_pr_work_action_metrics
   match events with
   | [] -> ()
   | _ ->
-      let store = Keeper_types.keeper_metrics_store config meta.name in
+      let store = Keeper_types.keeper_pr_action_metrics_store config meta.name in
       List.iter
         (fun event ->
            let now = Time_compat.now () in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1058,18 +1058,36 @@ let pr_review_action_metric_event_of_tool_io
         }
   | _ -> None
 
-let pr_work_actions_of_command command =
-  let words = Keeper_exec_shared.lowercase_shell_words command in
-  let rec loop acc = function
-    | "gh" :: "pr" :: "create" :: rest -> loop ("PR_CREATE" :: acc) rest
-    | "pr" :: "create" :: rest -> loop ("PR_CREATE" :: acc) rest
-    | "git" :: "add" :: rest -> loop ("GIT_ADD" :: acc) rest
-    | "git" :: "commit" :: rest -> loop ("GIT_COMMIT" :: acc) rest
-    | "git" :: "push" :: rest -> loop ("GIT_PUSH" :: acc) rest
-    | _ :: rest -> loop acc rest
-    | [] -> List.rev acc
+let split_top_level_command_segments command =
+  let len = String.length command in
+  let push_segment start stop acc =
+    let segment = String.sub command start (stop - start) |> String.trim in
+    if segment = "" then acc else segment :: acc
   in
-  loop [] words
+  let rec loop acc start i in_single in_double escaped =
+    if i >= len then List.rev (push_segment start len acc)
+    else
+      let c = command.[i] in
+      if escaped then loop acc start (i + 1) in_single in_double false
+      else
+        match c with
+        | '\\' when not in_single ->
+            loop acc start (i + 1) in_single in_double true
+        | '\'' when not in_double ->
+            loop acc start (i + 1) (not in_single) in_double false
+        | '"' when not in_single ->
+            loop acc start (i + 1) in_single (not in_double) false
+        | '&' when (not in_single) && (not in_double) && i + 1 < len
+                   && command.[i + 1] = '&' ->
+            let acc = push_segment start i acc in
+            loop acc (i + 2) (i + 2) in_single in_double false
+        | ';' when (not in_single) && not in_double ->
+            let acc = push_segment start i acc in
+            loop acc (i + 1) (i + 1) in_single in_double false
+        | _ ->
+            loop acc start (i + 1) in_single in_double false
+  in
+  loop [] 0 0 false false false
 
 let pr_work_action_of_git_action raw =
   match String.trim raw |> String.lowercase_ascii with
@@ -1077,6 +1095,36 @@ let pr_work_action_of_git_action raw =
   | "commit" -> Some "GIT_COMMIT"
   | "push" -> Some "GIT_PUSH"
   | _ -> None
+
+let pr_work_actions_of_git_segment segment =
+  match Masc_exec_bash_parser.Bash.parse_string segment with
+  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple)
+    when String.equal
+           (Masc_exec.Bin.to_string simple.bin |> String.lowercase_ascii)
+           "git" ->
+      (match simple.args with
+       | Masc_exec.Shell_ir.Lit action :: _ ->
+           pr_work_action_of_git_action action |> Option.to_list
+       | _ -> [])
+  | _ -> []
+
+let pr_work_actions_of_gh_segment segment =
+  match Keeper_gh_shared.parse_simple_gh_command segment with
+  | Ok cmd ->
+      (match Keeper_gh_shared.gh_simple_command_argv cmd with
+       | subcommand :: action :: _
+         when String.equal (String.lowercase_ascii subcommand) "pr"
+              && String.equal (String.lowercase_ascii action) "create" ->
+           [ "PR_CREATE" ]
+       | _ -> [])
+  | Error _ -> []
+
+let pr_work_actions_of_command command =
+  split_top_level_command_segments command
+  |> List.concat_map (fun segment ->
+       match pr_work_actions_of_gh_segment segment with
+       | [] -> pr_work_actions_of_git_segment segment
+       | actions -> actions)
 
 let command_input_of_tool ~(tool_name : string) (input : Yojson.Safe.t) =
   match tool_name with

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -947,7 +947,146 @@ let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
   in
   loop 0 (List.rev entries)
 
+type pr_review_action_metric_event = {
+  action : string;
+  pr_number : int option;
+  comment_id : int option;
+  success : bool;
+}
+
+let normalize_pr_review_action raw =
+  let trimmed = String.trim raw |> String.uppercase_ascii in
+  match trimmed with
+  | "COMMENT" | "APPROVE" | "REQUEST_CHANGES" | "REPLY" -> Some trimmed
+  | _ -> None
+
+let json_int_opt key json = Safe_ops.json_int_opt key json
+
+let first_some a b =
+  match a with
+  | Some _ -> a
+  | None -> b
+
+let output_json_opt output_text =
+  match
+    Safe_ops.parse_json_safe
+      ~context:"Keeper_hooks_oas.pr_review_action_metric.output"
+      output_text
+  with
+  | Ok json -> Some json
+  | Error _ -> None
+
+let pr_review_action_metric_event_of_tool_io
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool) =
+  match tool_name with
+  | "keeper_pr_review_comment" ->
+      let output_json = output_json_opt output_text in
+      let action =
+        match output_json with
+        | Some json -> Safe_ops.json_string_opt "event" json
+        | None -> None
+      in
+      let action =
+        match action with
+        | Some value -> Some value
+        | None -> Safe_ops.json_string_opt "event" input
+      in
+      let success =
+        match output_json with
+        | Some json -> Safe_ops.json_bool ~default:transport_success "ok" json
+        | None -> transport_success
+      in
+      Option.map
+        (fun action ->
+             {
+               action;
+               pr_number =
+                 first_some
+                   (first_some
+                      (match output_json with
+                       | Some json -> json_int_opt "pr_number" json
+                       | None -> None)
+                      (json_int_opt "pr_number" input))
+                   (json_int_opt "number" input);
+               comment_id = None;
+               success;
+             })
+        (Option.bind action normalize_pr_review_action)
+  | "keeper_pr_review_reply" ->
+      let output_json = output_json_opt output_text in
+      let success =
+        match output_json with
+        | Some json -> Safe_ops.json_bool ~default:transport_success "ok" json
+        | None -> transport_success
+      in
+      Some
+        {
+          action = "REPLY";
+          pr_number =
+            first_some
+              (first_some
+                 (match output_json with
+                  | Some json -> json_int_opt "pr_number" json
+                  | None -> None)
+                 (json_int_opt "pr_number" input))
+              (json_int_opt "number" input);
+          comment_id =
+            first_some
+              (match output_json with
+               | Some json -> json_int_opt "comment_id" json
+               | None -> None)
+              (json_int_opt "comment_id" input);
+          success;
+        }
+  | _ -> None
+
+let append_pr_review_action_metric
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(generation : int)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool)
+    ~(duration_ms : float)
+    () =
+  match
+    pr_review_action_metric_event_of_tool_io
+      ~tool_name ~input ~output_text ~transport_success
+  with
+  | None -> ()
+  | Some event ->
+      let now = Time_compat.now () in
+      let store = Keeper_types.keeper_metrics_store config meta.name in
+      let snapshot =
+        `Assoc
+          [
+            ("ts", `String (Masc_domain.iso8601_of_unix_seconds now));
+            ("ts_unix", `Float now);
+            ("channel", `String "tool_event");
+            ("metric_event", `String "keeper_pr_review_action");
+            ("name", `String meta.name);
+            ("agent_name", `String meta.agent_name);
+            ( "trace_id",
+              `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
+            ("generation", `Int generation);
+            ("tool_name", `String tool_name);
+            ("pr_review_action", `String event.action);
+            ("pr_review_action_success", `Bool event.success);
+            ("tool_call_count", `Int 0);
+            ("tools_used", `List []);
+            ("pr_number", Json_util.int_opt_to_json event.pr_number);
+            ("comment_id", Json_util.int_opt_to_json event.comment_id);
+            ("duration_ms", `Float duration_ms);
+          ]
+      in
+      Dated_jsonl.append store (Inference_utils.sanitize_json_utf8 snapshot)
+
 let make_hooks
+    ~(config : Coord.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)
     ~(generation : int)
     ?(max_cost_usd : float option)
@@ -1318,6 +1457,31 @@ let make_hooks
              Log.Keeper.warn
                "keeper:%s tool=%s log_call write failed: %s"
                (!meta_ref).name tool_name (Printexc.to_string exn));
+        (try
+           append_pr_review_action_metric
+             ~config
+             ~meta:(!meta_ref)
+             ~generation
+             ~tool_name
+             ~input
+             ~output_text
+             ~transport_success:(outcome = "ok")
+             ~duration_ms
+             ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_lifecycle_callback_failures
+               ~labels:
+                 [
+                   ("keeper", (!meta_ref).name);
+                   ("callback", "pr_review_action_metrics_append");
+                 ]
+               ();
+             Log.Keeper.warn
+               "keeper:%s tool=%s pr_review_action metric append failed: %s"
+               (!meta_ref).name tool_name (Printexc.to_string exn));
         (match trajectory_acc with
          | None -> ()
          | Some acc ->
@@ -1474,6 +1638,11 @@ let make_hooks
      guard_chain only; non_gate_hooks has it None, so Hooks.compose
      keeps guard_chain's pre_tool_use verbatim. *)
   Agent_sdk.Hooks.compose ~outer:guard_chain ~inner:non_gate_hooks
+
+module For_testing = struct
+  let pr_review_action_metric_event_of_tool_io =
+    pr_review_action_metric_event_of_tool_io
+end
 
 (** Static introspection of hook slot configuration.
     Returns a JSON summary of which hook slots are active, their gates/effects,

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -954,6 +954,13 @@ type pr_review_action_metric_event = {
   success : bool;
 }
 
+type pr_work_action_metric_event = {
+  work_action : string;
+  work_source : string;
+  command : string option;
+  success : bool;
+}
+
 let normalize_pr_review_action raw =
   let trimmed = String.trim raw |> String.uppercase_ascii in
   match trimmed with
@@ -976,6 +983,18 @@ let output_json_opt output_text =
   | Ok json -> Some json
   | Error _ -> None
 
+let output_success ~transport_success = function
+  | Some json ->
+      (match Safe_ops.json_bool_opt "ok" json with
+       | Some value -> value
+       | None ->
+           let status =
+             Safe_ops.json_string ~default:"" "status" json
+             |> String.trim |> String.lowercase_ascii
+           in
+           if status = "ok" then true else transport_success)
+  | None -> transport_success
+
 let pr_review_action_metric_event_of_tool_io
     ~(tool_name : string)
     ~(input : Yojson.Safe.t)
@@ -995,9 +1014,7 @@ let pr_review_action_metric_event_of_tool_io
         | None -> Safe_ops.json_string_opt "event" input
       in
       let success =
-        match output_json with
-        | Some json -> Safe_ops.json_bool ~default:transport_success "ok" json
-        | None -> transport_success
+        output_success ~transport_success output_json
       in
       Option.map
         (fun action ->
@@ -1018,9 +1035,7 @@ let pr_review_action_metric_event_of_tool_io
   | "keeper_pr_review_reply" ->
       let output_json = output_json_opt output_text in
       let success =
-        match output_json with
-        | Some json -> Safe_ops.json_bool ~default:transport_success "ok" json
-        | None -> transport_success
+        output_success ~transport_success output_json
       in
       Some
         {
@@ -1042,6 +1057,87 @@ let pr_review_action_metric_event_of_tool_io
           success;
         }
   | _ -> None
+
+let pr_work_actions_of_command command =
+  let words = Keeper_exec_shared.lowercase_shell_words command in
+  let rec loop acc = function
+    | "gh" :: "pr" :: "create" :: rest -> loop ("PR_CREATE" :: acc) rest
+    | "pr" :: "create" :: rest -> loop ("PR_CREATE" :: acc) rest
+    | "git" :: "add" :: rest -> loop ("GIT_ADD" :: acc) rest
+    | "git" :: "commit" :: rest -> loop ("GIT_COMMIT" :: acc) rest
+    | "git" :: "push" :: rest -> loop ("GIT_PUSH" :: acc) rest
+    | _ :: rest -> loop acc rest
+    | [] -> List.rev acc
+  in
+  loop [] words
+
+let pr_work_action_of_git_action raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "add" -> Some "GIT_ADD"
+  | "commit" -> Some "GIT_COMMIT"
+  | "push" -> Some "GIT_PUSH"
+  | _ -> None
+
+let command_input_of_tool ~(tool_name : string) (input : Yojson.Safe.t) =
+  match tool_name with
+  | "keeper_shell" ->
+      let op =
+        Safe_ops.json_string ~default:"" "op" input
+        |> String.trim |> String.lowercase_ascii
+      in
+      if op = "gh" then
+        Safe_ops.json_string_opt "cmd" input
+        |> Option.map (fun cmd -> "gh " ^ String.trim cmd)
+      else None
+  | "keeper_bash" ->
+      Safe_ops.json_string_opt "cmd" input
+  | "masc_code_shell" ->
+      Safe_ops.json_string_opt "command" input
+  | _ -> None
+
+let pr_work_action_metric_events_of_tool_io
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool) =
+  let output_json = output_json_opt output_text in
+  let success = output_success ~transport_success output_json in
+  match tool_name with
+  | "masc_code_git" ->
+      let action =
+        match output_json with
+        | Some json -> Safe_ops.json_string_opt "action" json
+        | None -> None
+      in
+      let action =
+        match action with
+        | Some value -> Some value
+        | None -> Safe_ops.json_string_opt "action" input
+      in
+      (match Option.bind action pr_work_action_of_git_action with
+       | None -> []
+       | Some work_action ->
+           [
+             {
+               work_action;
+               work_source = "masc_code_git";
+               command = None;
+               success;
+             };
+           ])
+  | "keeper_shell" | "keeper_bash" | "masc_code_shell" ->
+      (match command_input_of_tool ~tool_name input with
+       | None -> []
+       | Some command ->
+           pr_work_actions_of_command command
+           |> List.map (fun work_action ->
+                {
+                  work_action;
+                  work_source = tool_name;
+                  command = Some command;
+                  success;
+                }))
+  | _ -> []
 
 let append_pr_review_action_metric
     ~(config : Coord.config)
@@ -1084,6 +1180,55 @@ let append_pr_review_action_metric
           ]
       in
       Dated_jsonl.append store (Inference_utils.sanitize_json_utf8 snapshot)
+
+let append_pr_work_action_metrics
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(generation : int)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool)
+    ~(duration_ms : float)
+    () =
+  let events =
+    pr_work_action_metric_events_of_tool_io
+      ~tool_name ~input ~output_text ~transport_success
+  in
+  match events with
+  | [] -> ()
+  | _ ->
+      let store = Keeper_types.keeper_metrics_store config meta.name in
+      List.iter
+        (fun event ->
+           let now = Time_compat.now () in
+           let snapshot =
+             `Assoc
+               [
+                 ("ts", `String (Masc_domain.iso8601_of_unix_seconds now));
+                 ("ts_unix", `Float now);
+                 ("channel", `String "tool_event");
+                 ("metric_event", `String "keeper_pr_work_action");
+                 ("name", `String meta.name);
+                 ("agent_name", `String meta.agent_name);
+                 ( "trace_id",
+                   `String
+                     (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
+                 ("generation", `Int generation);
+                 ("tool_name", `String tool_name);
+                 ("pr_work_action", `String event.work_action);
+                 ("pr_work_action_source", `String event.work_source);
+                 ("pr_work_action_success", `Bool event.success);
+                 ( "pr_work_command",
+                   Json_util.string_opt_to_json event.command );
+                 ("tool_call_count", `Int 0);
+                 ("tools_used", `List []);
+                 ("duration_ms", `Float duration_ms);
+               ]
+           in
+           Dated_jsonl.append store
+             (Inference_utils.sanitize_json_utf8 snapshot))
+        events
 
 let make_hooks
     ~(config : Coord.config)
@@ -1482,6 +1627,31 @@ let make_hooks
              Log.Keeper.warn
                "keeper:%s tool=%s pr_review_action metric append failed: %s"
                (!meta_ref).name tool_name (Printexc.to_string exn));
+        (try
+           append_pr_work_action_metrics
+             ~config
+             ~meta:(!meta_ref)
+             ~generation
+             ~tool_name
+             ~input
+             ~output_text
+             ~transport_success:(outcome = "ok")
+             ~duration_ms
+             ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_lifecycle_callback_failures
+               ~labels:
+                 [
+                   ("keeper", (!meta_ref).name);
+                   ("callback", "pr_work_action_metrics_append");
+                 ]
+               ();
+             Log.Keeper.warn
+               "keeper:%s tool=%s pr_work_action metric append failed: %s"
+               (!meta_ref).name tool_name (Printexc.to_string exn));
         (match trajectory_acc with
          | None -> ()
          | Some acc ->
@@ -1642,6 +1812,9 @@ let make_hooks
 module For_testing = struct
   let pr_review_action_metric_event_of_tool_io =
     pr_review_action_metric_event_of_tool_io
+
+  let pr_work_action_metric_events_of_tool_io =
+    pr_work_action_metric_events_of_tool_io
 end
 
 (** Static introspection of hook slot configuration.

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -289,9 +289,18 @@ val recent_tool_streak_count :
   ?within_sec:float -> tool_name:string -> Yojson.Safe.t list -> int
 (** Count consecutive recent calls of [tool_name] in trajectory events. *)
 
+type pr_review_action_metric_event = {
+  action : string;
+  pr_number : int option;
+  comment_id : int option;
+  success : bool;
+}
+(** Parsed PR-review action telemetry derived from keeper tool I/O. *)
+
 (** {1 Hook factory} *)
 
 val make_hooks :
+  config:Coord.config ->
   meta_ref:Keeper_types.keeper_meta ref ->
   generation:int ->
   ?max_cost_usd:float ->
@@ -315,3 +324,12 @@ val hook_introspection_json :
   ?max_cost_usd:float -> ?destructive_check:bool -> unit -> Yojson.Safe.t
 (** JSON snapshot describing which hooks are active for the dashboard
     diagnostics surface. *)
+
+module For_testing : sig
+  val pr_review_action_metric_event_of_tool_io :
+    tool_name:string ->
+    input:Yojson.Safe.t ->
+    output_text:string ->
+    transport_success:bool ->
+    pr_review_action_metric_event option
+end

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -297,6 +297,14 @@ type pr_review_action_metric_event = {
 }
 (** Parsed PR-review action telemetry derived from keeper tool I/O. *)
 
+type pr_work_action_metric_event = {
+  work_action : string;
+  work_source : string;
+  command : string option;
+  success : bool;
+}
+(** Parsed PR create/push/commit/add telemetry derived from keeper tool I/O. *)
+
 (** {1 Hook factory} *)
 
 val make_hooks :
@@ -332,4 +340,11 @@ module For_testing : sig
     output_text:string ->
     transport_success:bool ->
     pr_review_action_metric_event option
+
+  val pr_work_action_metric_events_of_tool_io :
+    tool_name:string ->
+    input:Yojson.Safe.t ->
+    output_text:string ->
+    transport_success:bool ->
+    pr_work_action_metric_event list
 end

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -976,6 +976,7 @@ let prepare_agent_setup
   let meta_ref = ref acc.meta in
   let base_hooks =
     Keeper_hooks_oas.make_hooks
+      ~config
       ~meta_ref
       ~generation
       ?max_cost_usd

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -48,6 +48,20 @@ let keeper_metrics_store config name : Dated_jsonl.t =
   in
   Eio_guard.with_mutex metrics_store_mu lookup
 
+let keeper_pr_action_metrics_store config name : Dated_jsonl.t =
+  let dir =
+    Filename.concat (keeper_dir_ config) (name ^ "/pr-action-metrics")
+  in
+  let lookup () =
+    match Hashtbl.find_opt metrics_store_cache dir with
+    | Some store -> store
+    | None ->
+      let store = Dated_jsonl.create ~base_dir:dir () in
+      Hashtbl.replace metrics_store_cache dir store;
+      store
+  in
+  Eio_guard.with_mutex metrics_store_mu lookup
+
 let execution_receipt_store_cache : (string, Dated_jsonl.t) Hashtbl.t =
   Hashtbl.create 8
 

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -28,6 +28,13 @@ val keeper_metrics_path : Coord.config -> string -> string
     Cached per keeper name so all callers share the same Eio.Mutex. *)
 val keeper_metrics_store : Coord.config -> string -> Dated_jsonl.t
 
+(** Date-split sparse PR action metrics store:
+    [.masc/keepers/<name>/pr-action-metrics/YYYY-MM/DD.jsonl].  These rows
+    are intentionally kept out of the primary metrics stream so bursts of
+    tool-event action counters cannot evict full context snapshots from
+    fixed-tail dashboard/status readers. *)
+val keeper_pr_action_metrics_store : Coord.config -> string -> Dated_jsonl.t
+
 (** Date-split execution-receipt store:
     [.masc/keepers/<name>/execution-receipts/YYYY-MM/DD.jsonl]. *)
 val keeper_execution_receipt_store : Coord.config -> string -> Dated_jsonl.t

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -24,10 +24,43 @@ let pr_review_action ?(success = true) action =
       ("tools_used", `List []);
     ]
 
+let pr_work_action ?(success = true) action =
+  `Assoc
+    [
+      ("ts_unix", `Float 3.0);
+      ("channel", `String "tool_event");
+      ("metric_event", `String "keeper_pr_work_action");
+      ("pr_work_action", `String action);
+      ("pr_work_action_success", `Bool success);
+      ("tool_call_count", `Int 0);
+      ("tools_used", `List []);
+    ]
+
+let context_snapshot ?(ts_unix = 10.0) ?(context_ratio = 0.75) () =
+  `Assoc
+    [
+      ("ts_unix", `Float ts_unix);
+      ("channel", `String "turn");
+      ("context_ratio", `Float context_ratio);
+      ("context_tokens", `Int 750);
+      ("context_max", `Int 1000);
+      ("message_count", `Int 12);
+      ("tool_call_count", `Int 0);
+      ("tools_used", `List []);
+    ]
+
+let json_line json = Yojson.Safe.to_string json
+
 let summary_int field summary =
   match Yojson.Safe.Util.(summary |> member field) with
   | `Int value -> value
   | other -> failf "expected int field %s, got %s" field (Yojson.Safe.to_string other)
+
+let summary_float field summary =
+  match Yojson.Safe.Util.(summary |> member field) with
+  | `Float value -> value
+  | `Int value -> float_of_int value
+  | other -> failf "expected float field %s, got %s" field (Yojson.Safe.to_string other)
 
 let summary_bool field summary =
   match Yojson.Safe.Util.(summary |> member field) with
@@ -83,6 +116,11 @@ let test_metrics_window_exposes_observed_pr_work () =
           pr_review_action "REQUEST_CHANGES";
           pr_review_action "REPLY";
           pr_review_action ~success:false "APPROVE";
+          pr_work_action "GIT_ADD";
+          pr_work_action "GIT_COMMIT";
+          pr_work_action "GIT_PUSH";
+          pr_work_action "PR_CREATE";
+          pr_work_action ~success:false "GIT_PUSH";
           metric ~channel:"heartbeat" [ "keeper_pr_review_comment"; "masc_code_git" ];
         ]
       ~generation:0
@@ -114,6 +152,20 @@ let test_metrics_window_exposes_observed_pr_work () =
     (summary_int "pr_review_request_changes_action_count" summary);
   check int "reply actions" 1
     (summary_int "pr_review_reply_action_count" summary);
+  check int "pr work action attempts" 5
+    (summary_int "pr_work_action_attempt_count" summary);
+  check int "pr work action successes" 4
+    (summary_int "pr_work_action_success_count" summary);
+  check int "git add actions" 1
+    (summary_int "pr_git_add_action_count" summary);
+  check int "git commit actions" 1
+    (summary_int "pr_git_commit_action_count" summary);
+  check int "git push actions" 1
+    (summary_int "pr_git_push_action_count" summary);
+  check int "pr create actions" 1
+    (summary_int "pr_create_action_count" summary);
+  check int "pr work signal count" 14
+    (summary_int "pr_work_signal_count" summary);
   check bool "observed review" true
     (summary_bool "observed_pr_review_tool_calls" summary);
   check bool "observed mutation" true
@@ -132,7 +184,75 @@ let test_metrics_window_exposes_observed_pr_work () =
     (summary_bool "observed_pr_request_changes_work" summary);
   check bool "observed reply" true
     (summary_bool "observed_pr_reply_work" summary);
-  ()
+  check bool "observed pr create" true
+    (summary_bool "observed_pr_create_work" summary);
+  check bool "observed pr push" true
+    (summary_bool "observed_pr_push_work" summary);
+  check bool "observed pr commit" true
+    (summary_bool "observed_pr_commit_work" summary);
+  check bool "observed git" true (summary_bool "observed_git_work" summary);
+  check bool "observed pr work" true
+    (summary_bool "observed_pr_work" summary)
+
+let test_metrics_window_action_rows_drive_observed_pr_work () =
+  let _, summary, _, _ =
+    Detail.compute_metrics_window
+      ~parsed_metrics:[ pr_review_action "COMMENT"; pr_work_action "GIT_PUSH" ]
+      ~generation:0
+      ~compact:false
+      ~series_points:80
+      ~metrics_window_max_bytes:200_000
+      ~primary_model_norm:""
+      ~primary_model:""
+  in
+  check int "no review tools" 0
+    (summary_int "pr_review_tool_call_count" summary);
+  check int "no git tools" 0
+    (summary_int "pr_work_git_tool_call_count" summary);
+  check int "review action successes" 1
+    (summary_int "pr_review_action_success_count" summary);
+  check int "work action successes" 1
+    (summary_int "pr_work_action_success_count" summary);
+  check int "pr work signal count" 2
+    (summary_int "pr_work_signal_count" summary);
+  check bool "observed review via action" true
+    (summary_bool "observed_pr_review_work" summary);
+  check bool "observed mutation via action" true
+    (summary_bool "observed_pr_mutation_work" summary);
+  check bool "observed git via action" true
+    (summary_bool "observed_git_work" summary);
+  check bool "observed pr work via action" true
+    (summary_bool "observed_pr_work" summary)
+
+let test_24h_context_ignores_sparse_tool_events () =
+  let rows, summary =
+    Metrics.keeper_metrics_24h_json
+      ~metrics_lines:
+        [
+          json_line (context_snapshot ~context_ratio:0.75 ());
+          json_line (pr_review_action "COMMENT");
+          json_line (pr_work_action "GIT_PUSH");
+        ]
+      ~now_ts:100.0
+  in
+  check int "sample points skip sparse rows" 1
+    (summary_int "sample_points" summary);
+  match rows with
+  | `List [ row ] ->
+      check int "bucket sample points" 1
+        (summary_int "sample_points" row);
+      check (float 0.0001) "context avg ignores sparse rows" 0.75
+        (summary_float "context_ratio_avg" row)
+  | other ->
+      failf "expected one 24h bucket, got %s" (Yojson.Safe.to_string other)
+
+let test_context_snapshot_classifier_rejects_sparse_tool_events () =
+  check bool "context row qualifies" true
+    (Metrics.metrics_row_has_context_snapshot (context_snapshot ()));
+  check bool "review action row is sparse" false
+    (Metrics.metrics_row_has_context_snapshot (pr_review_action "COMMENT"));
+  check bool "work action row is sparse" false
+    (Metrics.metrics_row_has_context_snapshot (pr_work_action "GIT_PUSH"))
 
 let () =
   run "dashboard_keeper_metrics_10286"
@@ -153,5 +273,11 @@ let () =
         [
           test_case "exposes observed PR work signals" `Quick
             test_metrics_window_exposes_observed_pr_work;
+          test_case "action rows drive observed PR work signals" `Quick
+            test_metrics_window_action_rows_drive_observed_pr_work;
+          test_case "24h context ignores sparse tool events" `Quick
+            test_24h_context_ignores_sparse_tool_events;
+          test_case "classifies sparse tool events" `Quick
+            test_context_snapshot_classifier_rejects_sparse_tool_events;
         ] );
     ]

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -254,6 +254,32 @@ let test_context_snapshot_classifier_rejects_sparse_tool_events () =
   check bool "work action row is sparse" false
     (Metrics.metrics_row_has_context_snapshot (pr_work_action "GIT_PUSH"))
 
+let test_metrics_series_ignores_sparse_tool_events () =
+  let items, summary, _, _ =
+    Detail.compute_metrics_window
+      ~parsed_metrics:
+        [
+          context_snapshot ~context_ratio:0.55 ();
+          pr_review_action "COMMENT";
+          pr_work_action "GIT_PUSH";
+        ]
+      ~generation:0
+      ~compact:false
+      ~series_points:80
+      ~metrics_window_max_bytes:200_000
+      ~primary_model_norm:""
+      ~primary_model:""
+  in
+  check int "series skips sparse rows" 1 (List.length items);
+  check int "actions still count" 2
+    (summary_int "pr_work_signal_count" summary);
+  match items with
+  | [ row ] ->
+      check (float 0.0001) "context sample preserved" 0.55
+        (summary_float "context_ratio" row)
+  | other ->
+      failf "expected one metrics series row, got %d" (List.length other)
+
 let () =
   run "dashboard_keeper_metrics_10286"
     [
@@ -279,5 +305,7 @@ let () =
             test_24h_context_ignores_sparse_tool_events;
           test_case "classifies sparse tool events" `Quick
             test_context_snapshot_classifier_rejects_sparse_tool_events;
+          test_case "series ignores sparse tool events" `Quick
+            test_metrics_series_ignores_sparse_tool_events;
         ] );
     ]

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -12,6 +12,18 @@ let metric ?(channel = "turn") tools =
       ("tool_call_count", `Int (List.length tools));
     ]
 
+let pr_review_action ?(success = true) action =
+  `Assoc
+    [
+      ("ts_unix", `Float 2.0);
+      ("channel", `String "tool_event");
+      ("metric_event", `String "keeper_pr_review_action");
+      ("pr_review_action", `String action);
+      ("pr_review_action_success", `Bool success);
+      ("tool_call_count", `Int 0);
+      ("tools_used", `List []);
+    ]
+
 let summary_int field summary =
   match Yojson.Safe.Util.(summary |> member field) with
   | `Int value -> value
@@ -66,6 +78,11 @@ let test_metrics_window_exposes_observed_pr_work () =
               "masc_worktree_create";
               "masc_code_git";
             ];
+          pr_review_action "COMMENT";
+          pr_review_action "APPROVE";
+          pr_review_action "REQUEST_CHANGES";
+          pr_review_action "REPLY";
+          pr_review_action ~success:false "APPROVE";
           metric ~channel:"heartbeat" [ "keeper_pr_review_comment"; "masc_code_git" ];
         ]
       ~generation:0
@@ -85,14 +102,37 @@ let test_metrics_window_exposes_observed_pr_work () =
     (summary_int "pr_work_git_tool_call_count" summary);
   check int "pr work tool call count" 6
     (summary_int "pr_work_tool_call_count" summary);
+  check int "review action attempts" 5
+    (summary_int "pr_review_action_attempt_count" summary);
+  check int "review action successes" 4
+    (summary_int "pr_review_action_success_count" summary);
+  check int "comment actions" 1
+    (summary_int "pr_review_comment_action_count" summary);
+  check int "approve actions" 1
+    (summary_int "pr_review_approve_action_count" summary);
+  check int "request changes actions" 1
+    (summary_int "pr_review_request_changes_action_count" summary);
+  check int "reply actions" 1
+    (summary_int "pr_review_reply_action_count" summary);
   check bool "observed review" true
     (summary_bool "observed_pr_review_tool_calls" summary);
   check bool "observed mutation" true
     (summary_bool "observed_pr_mutation_tool_calls" summary);
   check bool "observed git" true
     (summary_bool "observed_git_tool_calls" summary);
-  check bool "observed pr work" true
-    (summary_bool "observed_pr_work_tool_calls" summary)
+  check bool "observed pr work tool calls" true
+    (summary_bool "observed_pr_work_tool_calls" summary);
+  check bool "observed review work" true
+    (summary_bool "observed_pr_review_work" summary);
+  check bool "observed mutation work" true
+    (summary_bool "observed_pr_mutation_work" summary);
+  check bool "observed approve" true
+    (summary_bool "observed_pr_approve_work" summary);
+  check bool "observed request changes" true
+    (summary_bool "observed_pr_request_changes_work" summary);
+  check bool "observed reply" true
+    (summary_bool "observed_pr_reply_work" summary);
+  ()
 
 let () =
   run "dashboard_keeper_metrics_10286"

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -645,6 +645,58 @@ let test_pr_review_action_metric_extracts_reply () =
   check (option int) "reply pr" (Some 9) event.pr_number;
   check (option int) "comment id" (Some 1234) event.comment_id
 
+let pr_work_events ~tool_name ~input ~output_text =
+  Hooks.For_testing.pr_work_action_metric_events_of_tool_io
+    ~tool_name ~input ~output_text ~transport_success:true
+
+let work_actions events = List.map (fun e -> e.Hooks.work_action) events
+
+let test_pr_work_action_metric_extracts_masc_code_git_push () =
+  let events =
+    pr_work_events
+      ~tool_name:"masc_code_git"
+      ~input:(`Assoc [ ("action", `String "push") ])
+      ~output_text:{|{"status":"ok","action":"push"}|}
+  in
+  check (list string) "actions" [ "GIT_PUSH" ] (work_actions events);
+  let event =
+    match events with
+    | [ event ] -> event
+    | _ -> failf "expected one git push event"
+  in
+  check string "source" "masc_code_git" event.work_source;
+  check bool "success" true event.success
+
+let test_pr_work_action_metric_extracts_gh_pr_create () =
+  let events =
+    pr_work_events
+      ~tool_name:"keeper_shell"
+      ~input:
+        (`Assoc
+          [ ("op", `String "gh");
+            ("cmd", `String "pr create --draft --title t") ])
+      ~output_text:{|{"ok":true,"op":"gh","command":"gh pr create --draft"}|}
+  in
+  check (list string) "pr create action" [ "PR_CREATE" ]
+    (work_actions events)
+
+let test_pr_work_action_metric_extracts_bash_git_sequence_failure () =
+  let events =
+    pr_work_events
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+          [ ( "cmd",
+              `String "git add lib/foo.ml && git commit -m x && git push origin feat/x" );
+          ])
+      ~output_text:{|{"ok":false,"cmd":"git push origin feat/x"}|}
+  in
+  check (list string) "git action sequence"
+    [ "GIT_ADD"; "GIT_COMMIT"; "GIT_PUSH" ]
+    (work_actions events);
+  check bool "failure propagated to every action" true
+    (List.for_all (fun e -> not e.Hooks.success) events)
+
 let () =
   run "keeper_hooks_oas/telemetry"
     [ ( "costs_jsonl",
@@ -702,5 +754,13 @@ let () =
             test_pr_review_action_metric_marks_structured_failure
         ; test_case "extracts reply action" `Quick
             test_pr_review_action_metric_extracts_reply
+        ] )
+    ; ( "pr_work_action",
+        [ test_case "extracts masc_code_git push" `Quick
+            test_pr_work_action_metric_extracts_masc_code_git_push
+        ; test_case "extracts keeper_shell gh pr create" `Quick
+            test_pr_work_action_metric_extracts_gh_pr_create
+        ; test_case "extracts bash git sequence and failure" `Quick
+            test_pr_work_action_metric_extracts_bash_git_sequence_failure
         ] )
     ]

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -692,7 +692,7 @@ let test_pr_work_action_metric_extracts_bash_git_sequence_failure () =
       ~output_text:{|{"ok":false,"cmd":"git push origin feat/x"}|}
   in
   check (list string) "git action sequence"
-    [ "GIT_ADD"; "GIT_COMMIT"; "GIT_PUSH" ]
+    [ "GIT_ADD" ]
     (work_actions events);
   check bool "failure propagated to every action" true
     (List.for_all (fun e -> not e.Hooks.success) events)
@@ -725,6 +725,29 @@ let test_pr_work_action_metric_ignores_quoted_command_words () =
       ~output_text:{|{"ok":true}|}
   in
   check (list string) "quoted pr create is not a command" [] (work_actions gh_events)
+
+let test_pr_work_action_metric_skips_shell_control_flow_segments () =
+  let and_events =
+    pr_work_events
+      ~tool_name:"keeper_bash"
+      ~input:(`Assoc [ ("cmd", `String "false && git push origin feat/x") ])
+      ~output_text:{|{"ok":false}|}
+  in
+  check (list string) "skipped && segment" [] (work_actions and_events);
+  let or_events =
+    pr_work_events
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+          [
+            ( "cmd",
+              `String
+                "git commit -m reviewed || gh pr create --draft --title retry" );
+          ])
+      ~output_text:{|{"ok":true}|}
+  in
+  check (list string) "skipped || fallback segment" [ "GIT_COMMIT" ]
+    (work_actions or_events)
 
 let () =
   run "keeper_hooks_oas/telemetry"
@@ -789,9 +812,11 @@ let () =
             test_pr_work_action_metric_extracts_masc_code_git_push
         ; test_case "extracts keeper_shell gh pr create" `Quick
             test_pr_work_action_metric_extracts_gh_pr_create
-        ; test_case "extracts bash git sequence and failure" `Quick
+        ; test_case "extracts conservative bash git failure" `Quick
             test_pr_work_action_metric_extracts_bash_git_sequence_failure
         ; test_case "ignores quoted command words" `Quick
             test_pr_work_action_metric_ignores_quoted_command_words
+        ; test_case "skips conditional control-flow segments" `Quick
+            test_pr_work_action_metric_skips_shell_control_flow_segments
         ] )
     ]

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -697,6 +697,35 @@ let test_pr_work_action_metric_extracts_bash_git_sequence_failure () =
   check bool "failure propagated to every action" true
     (List.for_all (fun e -> not e.Hooks.success) events)
 
+let test_pr_work_action_metric_ignores_quoted_command_words () =
+  let bash_events =
+    pr_work_events
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+          [
+            ( "cmd",
+              `String
+                "git commit -m \"revert git push\" && gh issue comment 1 --body \"please pr create later\""
+            );
+          ])
+      ~output_text:{|{"ok":true}|}
+  in
+  check (list string) "quoted command words do not add actions"
+    [ "GIT_COMMIT" ] (work_actions bash_events);
+  let gh_events =
+    pr_work_events
+      ~tool_name:"keeper_shell"
+      ~input:
+        (`Assoc
+          [
+            ("op", `String "gh");
+            ("cmd", `String "issue comment 1 --body \"please pr create later\"");
+          ])
+      ~output_text:{|{"ok":true}|}
+  in
+  check (list string) "quoted pr create is not a command" [] (work_actions gh_events)
+
 let () =
   run "keeper_hooks_oas/telemetry"
     [ ( "costs_jsonl",
@@ -762,5 +791,7 @@ let () =
             test_pr_work_action_metric_extracts_gh_pr_create
         ; test_case "extracts bash git sequence and failure" `Quick
             test_pr_work_action_metric_extracts_bash_git_sequence_failure
+        ; test_case "ignores quoted command words" `Quick
+            test_pr_work_action_metric_ignores_quoted_command_words
         ] )
     ]

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -600,6 +600,51 @@ let test_hook_introspection_reports_current_runtime_slots () =
   check bool "on_context_compacted inactive" false
     (slot json "on_context_compacted" |> member "active" |> to_bool)
 
+let pr_review_event ~tool_name ~input ~output_text =
+  Hooks.For_testing.pr_review_action_metric_event_of_tool_io
+    ~tool_name ~input ~output_text ~transport_success:true
+
+let require_pr_review_event label = function
+  | Some event -> event
+  | None -> failf "expected PR review action event for %s" label
+
+let test_pr_review_action_metric_extracts_approve () =
+  let event =
+    pr_review_event
+      ~tool_name:"keeper_pr_review_comment"
+      ~input:(`Assoc [ ("pr_number", `Int 13177); ("event", `String "COMMENT") ])
+      ~output_text:
+        {|{"ok":true,"pr_number":13177,"event":"APPROVE","keeper":"sangsu"}|}
+    |> require_pr_review_event "approve"
+  in
+  check string "action from output" "APPROVE" event.action;
+  check (option int) "pr number" (Some 13177) event.pr_number;
+  check bool "success" true event.success
+
+let test_pr_review_action_metric_marks_structured_failure () =
+  let event =
+    pr_review_event
+      ~tool_name:"keeper_pr_review_comment"
+      ~input:(`Assoc [ ("number", `Int 42); ("event", `String "approve") ])
+      ~output_text:{|{"ok":false,"error":"gh_failed"}|}
+    |> require_pr_review_event "failed approve"
+  in
+  check string "action fallback from input" "APPROVE" event.action;
+  check (option int) "number fallback" (Some 42) event.pr_number;
+  check bool "structured ok=false wins" false event.success
+
+let test_pr_review_action_metric_extracts_reply () =
+  let event =
+    pr_review_event
+      ~tool_name:"keeper_pr_review_reply"
+      ~input:(`Assoc [ ("pr_number", `Int 9); ("comment_id", `Int 1234) ])
+      ~output_text:{|{"ok":true,"pr_number":9,"comment_id":1234}|}
+    |> require_pr_review_event "reply"
+  in
+  check string "reply action" "REPLY" event.action;
+  check (option int) "reply pr" (Some 9) event.pr_number;
+  check (option int) "comment id" (Some 1234) event.comment_id
+
 let () =
   run "keeper_hooks_oas/telemetry"
     [ ( "costs_jsonl",
@@ -649,5 +694,13 @@ let () =
     ; ( "hook_introspection",
         [ test_case "reports current runtime slots" `Quick
             test_hook_introspection_reports_current_runtime_slots
+        ] )
+    ; ( "pr_review_action",
+        [ test_case "extracts approve event from structured output" `Quick
+            test_pr_review_action_metric_extracts_approve
+        ; test_case "marks structured gh failure as not successful" `Quick
+            test_pr_review_action_metric_marks_structured_failure
+        ; test_case "extracts reply action" `Quick
+            test_pr_review_action_metric_extracts_reply
         ] )
     ]


### PR DESCRIPTION
## Summary
- record keeper_pr_review_comment/reply post-tool events into keeper metrics as tool_event rows
- count successful COMMENT, APPROVE, REQUEST_CHANGES, and REPLY actions separately in metrics_window
- record structured keeper PR-work actions for masc_code_git and shell-backed git/gh commands
- expose PR create, git add/commit/push, review-action counts, and observed booleans in dashboard types
- keep sparse tool_event rows out of context-snapshot health sampling

## Why this matters
The previous PR-work signal only proved that a keeper invoked a PR-related tool name. This adds runtime evidence for the actual review and delivery actions, so operators can distinguish comment-only activity, approval/request-changes work, PR creation, and git push/commit work without inferring from logs.

## Verification
- scripts/check-oas-pin.sh --local-only
- scripts/opam-pin-external-deps.sh --install
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-pr-review-action-0505-rebased scripts/dune-local.sh build test/test_dashboard_keeper_metrics_10286.exe test/test_keeper_hooks_oas_telemetry.exe
- /private/tmp/masc-dune-pr-review-action-0505-rebased/default/test/test_dashboard_keeper_metrics_10286.exe
- /private/tmp/masc-dune-pr-review-action-0505-rebased/default/test/test_keeper_hooks_oas_telemetry.exe
- pnpm install --offline --frozen-lockfile (dashboard)
- pnpm typecheck (dashboard)
- git diff --check

## Note
After rebasing onto current main, the local opam pin had to be repaired to the repo's current OAS/agent_sdk pin, agent_sdk 0.190.8 at 56e2fa32d9888b319b9a26abf0b1b9eab756ee6b. The focused build and tests passed after that repair.
