### PR TITLE
fix(board): close remaining review gaps

### DIFF
--- a/dashboard/src/components/board/board-state.test.ts
+++ b/dashboard/src/components/board/board-state.test.ts
@@ -1,6 +1,21 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api')>()
+  return {
+    ...actual,
+    fetchBoardHearths: vi.fn(),
+  }
+})
+
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+}))
 
 import {
+  boardHearths,
+  boardHearthsError,
+  boardHearthsLoading,
   isUpdated,
   boardPostKind,
   contentCategory,
@@ -10,10 +25,13 @@ import {
   visibilityLabel,
   filterHint,
   splitVisiblePosts,
+  refreshBoardHearths,
   type ContentCategory,
   type VisibleBoardGroups,
 } from './board-state'
 import type { BoardPost } from '../../types'
+import { fetchBoardHearths, type BoardHearth } from '../../api'
+import { showToast } from '../common/toast'
 
 // Reset module-scope signals between tests
 import { boardHiddenCategories, boardExcludeAutomation } from '../../store'
@@ -45,6 +63,11 @@ function makePost(overrides: Partial<BoardPost> = {}): BoardPost {
 beforeEach(() => {
   boardHiddenCategories.value = new Set()
   boardExcludeAutomation.value = false
+  boardHearths.value = []
+  boardHearthsError.value = false
+  boardHearthsLoading.value = false
+  vi.mocked(fetchBoardHearths).mockReset()
+  vi.mocked(showToast).mockReset()
 })
 
 describe('isUpdated', () => {
@@ -220,5 +243,34 @@ describe('filterHint', () => {
     const hint = filterHint(grouped)
     expect(hint).toContain('숨겨져')
     expect(hint).toContain('3건')
+  })
+})
+
+describe('refreshBoardHearths', () => {
+  it('keeps a newer successful hearth refresh authoritative over stale failures', async () => {
+    let rejectFirst: ((error: Error) => void) | undefined
+    let resolveSecond: ((hearths: BoardHearth[]) => void) | undefined
+
+    vi.mocked(fetchBoardHearths)
+      .mockImplementationOnce(() => new Promise<BoardHearth[]>((_, reject) => { rejectFirst = reject }))
+      .mockImplementationOnce(() => new Promise<BoardHearth[]>((resolve) => { resolveSecond = resolve }))
+
+    const first = refreshBoardHearths()
+    const second = refreshBoardHearths()
+
+    resolveSecond!([{ name: 'ops', count: 2 }])
+    await second
+
+    expect(boardHearths.value).toEqual([{ name: 'ops', count: 2 }])
+    expect(boardHearthsError.value).toBe(false)
+    expect(boardHearthsLoading.value).toBe(false)
+
+    rejectFirst!(new Error('stale failure'))
+    await first
+
+    expect(boardHearths.value).toEqual([{ name: 'ops', count: 2 }])
+    expect(boardHearthsError.value).toBe(false)
+    expect(boardHearthsLoading.value).toBe(false)
+    expect(showToast).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -71,6 +71,7 @@ export const detailPostId = signal<string | null>(null)
 // ── Signals: hearth filters ───────────────────────────────────────
 export const boardHearths = signal<BoardHearth[]>([])
 export const boardHearthsLoading = signal(false)
+export const boardHearthsError = signal(false)
 
 // ── Signals: comments ──────────────────────────────────────────────
 export const commentText = signal('')
@@ -106,8 +107,10 @@ export async function refreshBoardHearths(): Promise<void> {
   boardHearthsLoading.value = true
   try {
     boardHearths.value = await fetchBoardHearths()
+    boardHearthsError.value = false
   } catch (err) {
     console.warn('[Board] failed to load hearth filters:', err)
+    boardHearthsError.value = true
     showToast('Hearth 목록을 불러오지 못했습니다', 'error')
   } finally {
     boardHearthsLoading.value = false

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -72,6 +72,7 @@ export const detailPostId = signal<string | null>(null)
 export const boardHearths = signal<BoardHearth[]>([])
 export const boardHearthsLoading = signal(false)
 export const boardHearthsError = signal(false)
+let boardHearthsRequestId = 0
 
 // ── Signals: comments ──────────────────────────────────────────────
 export const commentText = signal('')
@@ -104,16 +105,22 @@ export const selectedPostIds = signal<Set<string>>(new Set())
 export const bulkDeleting = signal(false)
 
 export async function refreshBoardHearths(): Promise<void> {
+  const requestId = ++boardHearthsRequestId
   boardHearthsLoading.value = true
   try {
-    boardHearths.value = await fetchBoardHearths()
+    const hearths = await fetchBoardHearths()
+    if (requestId !== boardHearthsRequestId) return
+    boardHearths.value = hearths
     boardHearthsError.value = false
   } catch (err) {
+    if (requestId !== boardHearthsRequestId) return
     console.warn('[Board] failed to load hearth filters:', err)
     boardHearthsError.value = true
     showToast('Hearth 목록을 불러오지 못했습니다', 'error')
   } finally {
-    boardHearthsLoading.value = false
+    if (requestId === boardHearthsRequestId) {
+      boardHearthsLoading.value = false
+    }
   }
 }
 

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
 import { route } from '../../router'
-import { boardHearths, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
+import { boardHearths, boardHearthsError, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -152,6 +152,7 @@ describe('BoardSurface Component', () => {
     boardAuthorFilter.value = ''
     boardHearthFilter.value = ''
     boardHearths.value = [{ name: 'ops', count: 0 }]
+    boardHearthsError.value = false
     showNewPostForm.value = false
     newPostHearth.value = ''
     newPostSubmitting.value = false
@@ -228,6 +229,26 @@ describe('BoardSurface Component', () => {
 
     expect(boardHearthFilter.value).toBe('ops')
     expect(screen.getByRole('button', { name: 'hearth ops 2 posts' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('keeps hearth refresh available without showing an error for a valid empty list', () => {
+    boardHearths.value = []
+    boardHearthsError.value = false
+
+    render(h(BoardSurface, null))
+
+    expect(screen.queryByText('hearth 목록을 불러오지 못했습니다')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'hearth 목록 새로고침' })).toBeInTheDocument()
+  })
+
+  it('shows the hearth load error only after a failed refresh', () => {
+    boardHearths.value = []
+    boardHearthsError.value = true
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByText('hearth 목록을 불러오지 못했습니다')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'hearth 목록 새로고침' })).toBeInTheDocument()
   })
 
   it('prefills the compose hearth from the active hearth filter', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -33,6 +33,7 @@ import {
   boardHearthFilter,
   boardHearths,
   boardHearthsLoading,
+  boardHearthsError,
   boardExcludeAutomation,
   boardLoading,
   boardLoadingMore,
@@ -296,7 +297,9 @@ function HearthFilterBar() {
   if (hearths.length === 0 && active === '' && !boardHearthsLoading.value) {
     return html`
       <div class="flex items-center gap-1.5 flex-wrap">
-        <span class="text-2xs text-[var(--color-fg-muted)]" aria-hidden="true">hearth 목록을 불러오지 못했습니다</span>
+        ${boardHearthsError.value ? html`
+          <span class="text-2xs text-[var(--color-fg-muted)]" aria-hidden="true">hearth 목록을 불러오지 못했습니다</span>
+        ` : null}
         <button
           type="button"
           class="px-2 py-1 rounded-[var(--r-1)] text-2xs font-medium transition-colors duration-[var(--t-med)] border cursor-pointer bg-transparent text-[var(--color-fg-muted)] border-transparent hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] disabled:opacity-50"

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -156,6 +156,25 @@ describe('CommentThread', () => {
     expect(screen.queryByRole('button', { name: /스레드 계속 펼치기/ })).not.toBeInTheDocument()
   })
 
+  it('ignores a manual collapsed state while the comment filter is active', () => {
+    const comments = [
+      { id: 'c1', post_id: 'post-1', parent_id: null, author: 'root-agent', content: 'root comment', created_at: '2026-04-02T00:00:00Z' },
+      { id: 'c2', post_id: 'post-1', parent_id: 'c1', author: 'child-agent', content: 'needle child reply', created_at: '2026-04-02T00:01:00Z' },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '답글 1개 접기' }))
+    expect(screen.queryByText('needle child reply')).not.toBeInTheDocument()
+
+    fireEvent.input(screen.getByPlaceholderText('댓글 내용 검색'), {
+      target: { value: 'needle' },
+    })
+
+    expect(screen.getByText('needle child reply')).toBeInTheDocument()
+    expect(screen.queryByText('답글 1개 접힘')).not.toBeInTheDocument()
+  })
+
   it('sends comment votes through the board comment vote tool', async () => {
     const comments = [
       {

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -172,7 +172,15 @@ describe('CommentThread', () => {
     })
 
     expect(screen.getByText('needle child reply')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '답글 1개 접기' })).not.toBeInTheDocument()
     expect(screen.queryByText('답글 1개 접힘')).not.toBeInTheDocument()
+
+    fireEvent.input(screen.getByPlaceholderText('댓글 내용 검색'), {
+      target: { value: '' },
+    })
+
+    expect(screen.queryByText('needle child reply')).not.toBeInTheDocument()
+    expect(screen.getByText('답글 1개 접힘')).toBeInTheDocument()
   })
 
   it('sends comment votes through the board comment vote tool', async () => {

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -167,6 +167,7 @@ function CommentItem({
   childrenMap,
   descendantCounts,
   forceThreadExpanded = false,
+  suppressCollapseToggle = false,
 }: {
   comment: BoardComment
   postId: string
@@ -174,6 +175,7 @@ function CommentItem({
   childrenMap: ReadonlyMap<string, readonly BoardComment[]>
   descendantCounts: ReadonlyMap<string, number>
   forceThreadExpanded?: boolean
+  suppressCollapseToggle?: boolean
 }) {
   const contentChars = Array.from(comment.content ?? '')
   const needsTruncation = contentChars.length > 300
@@ -213,7 +215,7 @@ function CommentItem({
     <div style=${indentStyle}>
       <div class="board-comment rounded-[var(--r-1)] p-3 bg-[var(--color-bg-surface)] border border-[var(--color-border-divider)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
-          ${replies.length > 0 && !cappedByDepth ? html`
+          ${replies.length > 0 && !cappedByDepth && !suppressCollapseToggle ? html`
             <button
               type="button"
               class="flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
@@ -294,7 +296,7 @@ function CommentItem({
       </div>
       ${showReplies ? html`
         <div class="flex flex-col gap-1.5 mt-1.5">
-          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${childForceExpanded} />`)}
+          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${childForceExpanded} suppressCollapseToggle=${suppressCollapseToggle} />`)}
         </div>
       ` : null}
     </div>
@@ -349,7 +351,7 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
           onClick=${() => setExpanded(true)}
         >이전 댓글 ${hiddenCount}개 더 보기<//>
       ` : null}
-      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${isFiltering} />`)}
+      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${isFiltering} suppressCollapseToggle=${isFiltering} />`)}
       ${expanded && hiddenCount > 0 ? html`
         <${ActionButton}
           variant="subtle"

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -189,8 +189,10 @@ function CommentItem({
   const replies = childrenMap.get(comment.id) ?? []
   const replyCount = descendantCounts.get(comment.id) ?? 0
   const cappedByDepth = !forceThreadExpanded && !deepExpanded && depth >= MAX_INLINE_COMMENT_DEPTH && replies.length > 0
-  const showReplies = replies.length > 0 && !collapsed && !cappedByDepth
+  const collapsedByUser = collapsed && !forceThreadExpanded
+  const showReplies = replies.length > 0 && !collapsedByUser && !cappedByDepth
   const childForceExpanded = forceThreadExpanded || deepExpanded
+  const repliesExpanded = !collapsedByUser
   const score = comment.vote_balance ?? comment.votes ?? ((comment.votes_up ?? 0) - (comment.votes_down ?? 0))
   const authorLabel = boardActorDisplayName(comment.author, comment.author_identity)
   const authorAvatarKey = boardActorAvatarKey(comment.author, comment.author_identity)
@@ -215,10 +217,10 @@ function CommentItem({
             <button
               type="button"
               class="flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
-              aria-expanded=${!collapsed}
-              aria-label=${collapsed ? `답글 ${replyCount}개 펼치기` : `답글 ${replyCount}개 접기`}
+              aria-expanded=${repliesExpanded}
+              aria-label=${repliesExpanded ? `답글 ${replyCount}개 접기` : `답글 ${replyCount}개 펼치기`}
               onClick=${() => setCollapsed(!collapsed)}
-            >${collapsed ? '+' : '−'}</button>
+            >${repliesExpanded ? '−' : '+'}</button>
           ` : null}
           <span class="text-xs">${authorAvatar(authorAvatarKey)}</span>
           <${ActionButton} variant="subtle" size="sm" class="text-xs font-medium text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}<//>
@@ -279,7 +281,7 @@ function CommentItem({
             </div>
           </div>
         ` : null}
-        ${collapsed && replyCount > 0 ? html`
+        ${collapsedByUser && replyCount > 0 ? html`
           <div class="mt-2 text-2xs text-[var(--color-fg-muted)]">답글 ${replyCount}개 접힘</div>
         ` : null}
         ${cappedByDepth ? html`

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -195,6 +195,7 @@ function CommentItem({
   const showReplies = replies.length > 0 && !collapsedByUser && !cappedByDepth
   const childForceExpanded = forceThreadExpanded || deepExpanded
   const repliesExpanded = !collapsedByUser
+  const canToggleReplies = replies.length > 0 && !cappedByDepth && !suppressCollapseToggle && !forceThreadExpanded
   const score = comment.vote_balance ?? comment.votes ?? ((comment.votes_up ?? 0) - (comment.votes_down ?? 0))
   const authorLabel = boardActorDisplayName(comment.author, comment.author_identity)
   const authorAvatarKey = boardActorAvatarKey(comment.author, comment.author_identity)
@@ -215,7 +216,7 @@ function CommentItem({
     <div style=${indentStyle}>
       <div class="board-comment rounded-[var(--r-1)] p-3 bg-[var(--color-bg-surface)] border border-[var(--color-border-divider)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
-          ${replies.length > 0 && !cappedByDepth && !suppressCollapseToggle ? html`
+          ${canToggleReplies ? html`
             <button
               type="button"
               class="flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -98,6 +98,15 @@ describe('SSEMessageSchema', () => {
     expect(r.success).toBe(false)
   })
 
+  it('rejects malformed board post kind metadata at the SSE boundary', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'post_created',
+      post_id: 'post-1',
+      post_kind: 1,
+    })
+    expect(r.success).toBe(false)
+  })
+
   it('rejects missing type discriminator', () => {
     const r = SSEMessageSchema.safeParse({ agent: 'nobody' })
     expect(r.success).toBe(false)

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -82,6 +82,7 @@ const STRING_FIELDS = new Set([
   'status',
   'post_id',
   'comment_id',
+  'post_kind',
   'title',
   'author',
   'voter',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -338,6 +338,32 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshHearths).toHaveBeenCalledTimes(1)
   })
 
+  it('normalizes malformed post_kind to direct when hydrating optimistic board posts', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshHearths = vi.fn()
+    sseStore.registerBoardHearthsRefresh(refreshHearths)
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+    boardExcludeSystem.value = false
+    boardExcludeAutomation.value = false
+
+    sseStore.routeServerPushEvent({
+      type: 'post_created',
+      post_id: 'post-1',
+      title: 'Malformed kind note',
+      content: 'body',
+      author: 'agent-a',
+      post_kind: 1 as unknown as string,
+      hearth: 'ops',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(boardPosts.value[0]?.id).toBe('post-1')
+    expect(boardPosts.value[0]?.post_kind).toBe('direct')
+    expect(refreshBoard).not.toHaveBeenCalled()
+    expect(refreshHearths).toHaveBeenCalledTimes(1)
+  })
+
   it('does not refresh hearth chips for comment-only board events', async () => {
     const { sseStore } = await loadSseStore()
     const refreshHearths = vi.fn()

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -315,6 +315,29 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshHearths).toHaveBeenCalledTimes(1)
   })
 
+  it('falls back to board refresh when post_kind is missing under kind exclusions', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshHearths = vi.fn()
+    sseStore.registerBoardHearthsRefresh(refreshHearths)
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+    boardExcludeAutomation.value = true
+
+    sseStore.routeServerPushEvent({
+      type: 'post_created',
+      post_id: 'post-1',
+      title: 'Unknown kind note',
+      content: 'body',
+      author: 'agent-a',
+      hearth: 'ops',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(boardPosts.value).toEqual([])
+    expect(refreshBoard).toHaveBeenCalledTimes(1)
+    expect(refreshHearths).toHaveBeenCalledTimes(1)
+  })
+
   it('does not refresh hearth chips for comment-only board events', async () => {
     const { sseStore } = await loadSseStore()
     const refreshHearths = vi.fn()

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -415,7 +415,7 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
 }
 
 function boardPostKindFromEvent(event: SSEEvent): BoardPost['post_kind'] {
-  const rawKind = (event.post_kind ?? 'direct').toLowerCase()
+  const rawKind = (typeof event.post_kind === 'string' ? event.post_kind : 'direct').toLowerCase()
   return rawKind === 'system' || rawKind === 'automation' ? rawKind : 'direct'
 }
 

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -427,6 +427,10 @@ function eventMatchesActiveBoardFilters(event: SSEEvent): boolean {
   // reconciled through the board endpoint instead of guessing client-side.
   if (boardAuthorFilter.value.trim() !== '') return false
 
+  if (typeof event.post_kind !== 'string' && (boardExcludeSystem.value || boardExcludeAutomation.value)) {
+    return false
+  }
+
   const postKind = boardPostKindFromEvent(event)
   if (postKind === 'system' && boardExcludeSystem.value) return false
   if (postKind === 'automation' && boardExcludeAutomation.value) return false

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -89,7 +89,14 @@ type keeper_board_signal = {
 }
 
 type board_sse_event =
-  | Post_created of { post_id : string; author : string; title : string; content : string; hearth : string option }
+  | Post_created of {
+      post_id : string;
+      author : string;
+      title : string;
+      content : string;
+      post_kind : Board.post_kind;
+      hearth : string option;
+    }
   | Comment_added of { post_id : string; comment_id : string; author : string }
   | Post_voted of { post_id : string; voter : string; direction : Board.vote_direction }
   | Comment_voted of { comment_id : string; voter : string; direction : Board.vote_direction }
@@ -303,7 +310,8 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
           emit_board_sse_event
             (Post_created
                { post_id = pid; author = auth; title = post.title;
-                 content = post.content; hearth = post.hearth });
+                 content = post.content; post_kind = post.post_kind;
+                 hearth = post.hearth });
           ok
       | Error _ as err -> err)
 

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -52,6 +52,7 @@ type board_sse_event =
       author : string;
       title : string;
       content : string;
+      post_kind : Board.post_kind;
       hearth : string option;
     }
   | Comment_added of {

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -325,7 +325,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       signal);
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = match event with
-      | Board_dispatch.Post_created { post_id; author; title; content; hearth } ->
+      | Board_dispatch.Post_created { post_id; author; title; content; post_kind; hearth } ->
           let preview =
             if String.length content > 200 then String.sub content 0 200
             else content
@@ -335,7 +335,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                       ("author", `String author);
                       ("author_identity", Server_utils.board_actor_identity_json author);
                       ("title", `String title);
-                      ("content", `String preview)] in
+                      ("content", `String preview);
+                      ("post_kind", `String (Board.post_kind_to_string post_kind))] in
           `Assoc (match hearth with
                   | Some h -> ("hearth", `String h) :: base
                   | None -> base)
@@ -367,10 +368,11 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     ]);
     (* Emit activity event so Discord/external connectors can detect board posts *)
     let activity_kind, activity_actor, activity_subject, activity_payload = match event with
-      | Board_dispatch.Post_created { post_id; author; title; content; hearth } ->
+      | Board_dispatch.Post_created { post_id; author; title; content; post_kind; hearth } ->
           let base = [("post_id", `String post_id); ("title", `String title);
                       ("content", `String content); ("author", `String author);
-                      ("author_identity", Server_utils.board_actor_identity_json author)] in
+                      ("author_identity", Server_utils.board_actor_identity_json author);
+                      ("post_kind", `String (Board.post_kind_to_string post_kind))] in
           let payload_fields = match hearth with
             | Some h -> ("hearth", `String h) :: base
             | None -> base

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -140,6 +140,23 @@ let test_structured_post_roundtrip () =
           Alcotest.(check string) "roundtrip kind" "automation"
             (Board.post_kind_to_string fetched.post_kind)
 
+let test_board_sse_post_created_includes_post_kind () =
+  let seen = ref None in
+  Board_dispatch.set_board_sse_hook (fun event -> seen := Some event);
+  (match
+     Board_dispatch.create_post ~author:"sse-agent"
+       ~content:"sse post kind payload"
+       ~post_kind:Board.Automation_post ()
+   with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok _ -> ());
+  match !seen with
+  | Some (Board_dispatch.Post_created { post_kind; _ }) ->
+      Alcotest.(check string) "sse post_kind" "automation"
+        (Board.post_kind_to_string post_kind)
+  | Some _ -> Alcotest.fail "expected post_created SSE event"
+  | None -> Alcotest.fail "expected board SSE event"
+
 let test_list_posts () =
   ignore (Board_dispatch.create_post ~author:"lister" ~content:"list test 1"
             ~post_kind:Board.Human_post ());
@@ -564,6 +581,8 @@ let () =
       Alcotest.test_case "keeper hook cancellation propagates" `Quick
         (with_eio test_keeper_signal_hook_cancellation_propagates);
       Alcotest.test_case "structured roundtrip" `Quick (with_eio test_structured_post_roundtrip);
+      Alcotest.test_case "SSE post_created includes post_kind" `Quick
+        (with_eio test_board_sse_post_created_includes_post_kind);
       Alcotest.test_case "list" `Quick (with_eio test_list_posts);
       Alcotest.test_case "sort orders" `Quick (with_eio test_list_posts_with_sort);
       Alcotest.test_case "recent bypasses hot cutoff" `Quick


### PR DESCRIPTION
Summary:
- Keep comment search visibility from being defeated by stored collapsed thread state, and suppress collapse toggles while filtering so hidden clicks cannot mutate thread state.
- Carry board `post_kind` through `post_created` dispatch/SSE payloads, validate it as SSE string metadata, and defensively normalize malformed values before optimistic hydration.
- Split valid empty hearth lists from real hearth-refresh failures, with request sequencing so stale failures cannot overwrite newer success.

Review feedback addressed:
- #13142 comment-search/manual-collapse follow-up.
- #13147 empty-hearth failure wording follow-up.
- #13165 missing `post_kind` in board SSE optimistic hydration.
- #13205 Copilot review comments on invisible collapse toggles, out-of-order hearth refresh failures, and malformed `post_kind` SSE metadata.

Validation:
- pnpm exec vitest run src/components/board/board-state.test.ts src/components/board/post-detail.test.ts src/components/board/board-surface.test.ts src/sse-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1 (80 tests)
- pnpm exec vitest run src/schemas/sse.test.ts src/sse-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1 (37 tests)
- pnpm exec vitest run src/components/board/post-detail.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1 (18 tests)
- pnpm exec tsc --noEmit --pretty false
- git diff --check
- Earlier on this branch before the dashboard-only follow-ups: scripts/dune-local.sh build test/test_board_dispatch.exe and ./_build/default/test/test_board_dispatch.exe passed for the OCaml `post_kind` changes.