### PR TITLE
fix(logs): rate limit utf8 repair warnings

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -72,6 +72,11 @@ let utf8_repair_path_samples = ref []
 let utf8_repair_path_sample_limit = 8
 let utf8_repair_log_restate_sec = 60.0
 let utf8_repair_log_entry_limit = 1024
+(* Reviewer #13206: idle entries that have not been seen for this long
+   are dropped on the next insert.  Bounds memory growth even when the
+   distinct-(surface,path) count never reaches [entry_limit] but the
+   workload churns through new keys faster than restate emissions. *)
+let utf8_repair_log_idle_eviction_sec = 3600.0
 
 type utf8_repair_log_entry =
   { last_emit : float
@@ -84,7 +89,23 @@ let utf8_repair_log_seen : (string, utf8_repair_log_entry) Hashtbl.t =
 
 let utf8_repair_log_key ~surface ~path = surface ^ "\x00" ^ path
 
-let prune_utf8_repair_log_seen_if_needed () =
+let prune_utf8_repair_log_seen_if_needed ~now =
+  (* Sweep first: drop any entry whose [last_seen] is older than
+     [idle_eviction_sec], or whose [last_seen] is in the future
+     relative to [now] (a wall clock that jumped backwards via NTP /
+     VM suspend would otherwise leave entries that look "young"
+     forever and never restate).  Then, if still at or above the
+     hard cap, evict the single oldest entry. *)
+  let to_drop =
+    Hashtbl.fold
+      (fun key entry acc ->
+        let elapsed = now -. entry.last_seen in
+        if elapsed >= utf8_repair_log_idle_eviction_sec || elapsed < 0.0
+        then key :: acc
+        else acc)
+      utf8_repair_log_seen []
+  in
+  List.iter (fun k -> Hashtbl.remove utf8_repair_log_seen k) to_drop;
   if Hashtbl.length utf8_repair_log_seen >= utf8_repair_log_entry_limit then
     let oldest =
       Hashtbl.fold
@@ -115,12 +136,20 @@ let record_utf8_repair ~surface ~path ~invalid_bytes =
       let now = Time_compat.now () in
       match Hashtbl.find_opt utf8_repair_log_seen key with
       | None ->
-          prune_utf8_repair_log_seen_if_needed ();
+          prune_utf8_repair_log_seen_if_needed ~now;
           Hashtbl.replace utf8_repair_log_seen key
             { last_emit = now; last_seen = now; suppressed = 0 };
           Some 0
       | Some entry
-        when now -. entry.last_emit >= utf8_repair_log_restate_sec ->
+        when (let elapsed = now -. entry.last_emit in
+              elapsed >= utf8_repair_log_restate_sec || elapsed < 0.0) ->
+          (* Reviewer #13206: Time_compat.now resolves to Eio.Time.now
+             or Unix.gettimeofday — both wall clocks that can step
+             backwards (NTP / VM suspend) or forward by a large jump.
+             A negative [elapsed] would otherwise suppress the next
+             warning until the clock catches back up to the recorded
+             [last_emit].  Treat backwards motion as a forced restate
+             so the rate limiter recovers within one record call. *)
           Hashtbl.replace utf8_repair_log_seen key
             { last_emit = now; last_seen = now; suppressed = 0 };
           Some entry.suppressed

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -70,19 +70,74 @@ let utf8_repaired_reads = ref 0
 let utf8_repaired_bytes = ref 0
 let utf8_repair_path_samples = ref []
 let utf8_repair_path_sample_limit = 8
+let utf8_repair_log_restate_sec = 60.0
+let utf8_repair_log_entry_limit = 1024
+
+type utf8_repair_log_entry =
+  { last_emit : float
+  ; last_seen : float
+  ; suppressed : int
+  }
+
+let utf8_repair_log_seen : (string, utf8_repair_log_entry) Hashtbl.t =
+  Hashtbl.create 16
+
+let utf8_repair_log_key ~surface ~path = surface ^ "\x00" ^ path
+
+let prune_utf8_repair_log_seen_if_needed () =
+  if Hashtbl.length utf8_repair_log_seen >= utf8_repair_log_entry_limit then
+    let oldest =
+      Hashtbl.fold
+        (fun key entry acc ->
+          match acc with
+          | None -> Some (key, entry.last_seen)
+          | Some (_, oldest_seen) when entry.last_seen < oldest_seen ->
+              Some (key, entry.last_seen)
+          | Some _ -> acc)
+        utf8_repair_log_seen None
+    in
+    match oldest with
+    | Some (key, _) -> Hashtbl.remove utf8_repair_log_seen key
+    | None -> ()
 
 let record_utf8_repair ~surface ~path ~invalid_bytes =
   let surface = if String.trim surface = "" then "persistence" else surface in
   let path = match path with Some p when String.trim p <> "" -> p | _ -> "(unknown)" in
-  Stdlib.Mutex.protect utf8_repair_mu (fun () ->
+  let log_decision =
+    Stdlib.Mutex.protect utf8_repair_mu (fun () ->
       incr utf8_repaired_reads;
       utf8_repaired_bytes := !utf8_repaired_bytes + invalid_bytes;
       if not (List.mem path !utf8_repair_path_samples) then
         utf8_repair_path_samples :=
           (path :: !utf8_repair_path_samples)
-          |> List.filteri (fun i _ -> i < utf8_repair_path_sample_limit));
-  Log.Misc.warn "[%s] persistence UTF-8 repaired path=%s invalid_bytes=%d"
-    surface path invalid_bytes
+          |> List.filteri (fun i _ -> i < utf8_repair_path_sample_limit);
+      let key = utf8_repair_log_key ~surface ~path in
+      let now = Time_compat.now () in
+      match Hashtbl.find_opt utf8_repair_log_seen key with
+      | None ->
+          prune_utf8_repair_log_seen_if_needed ();
+          Hashtbl.replace utf8_repair_log_seen key
+            { last_emit = now; last_seen = now; suppressed = 0 };
+          Some 0
+      | Some entry
+        when now -. entry.last_emit >= utf8_repair_log_restate_sec ->
+          Hashtbl.replace utf8_repair_log_seen key
+            { last_emit = now; last_seen = now; suppressed = 0 };
+          Some entry.suppressed
+      | Some entry ->
+          Hashtbl.replace utf8_repair_log_seen key
+            { entry with last_seen = now; suppressed = entry.suppressed + 1 };
+          None)
+  in
+  match log_decision with
+  | None -> ()
+  | Some 0 ->
+      Log.Misc.warn "[%s] persistence UTF-8 repaired path=%s invalid_bytes=%d"
+        surface path invalid_bytes
+  | Some suppressed_repeats ->
+      Log.Misc.warn
+        "[%s] persistence UTF-8 repaired path=%s invalid_bytes=%d suppressed_repeats=%d"
+        surface path invalid_bytes suppressed_repeats
 
 let persistence_utf8_repair_stats () =
   Stdlib.Mutex.protect utf8_repair_mu (fun () ->
@@ -91,11 +146,19 @@ let persistence_utf8_repair_stats () =
       ; path_samples = List.rev !utf8_repair_path_samples
       })
 
+let persistence_utf8_repair_log_entry_limit_for_tests () =
+  utf8_repair_log_entry_limit
+
+let persistence_utf8_repair_log_key_count_for_tests () =
+  Stdlib.Mutex.protect utf8_repair_mu (fun () ->
+      Hashtbl.length utf8_repair_log_seen)
+
 let reset_persistence_utf8_repair_stats_for_tests () =
   Stdlib.Mutex.protect utf8_repair_mu (fun () ->
       utf8_repaired_reads := 0;
       utf8_repaired_bytes := 0;
-      utf8_repair_path_samples := [])
+      utf8_repair_path_samples := [];
+      Hashtbl.clear utf8_repair_log_seen)
 
 let count_invalid_utf8_bytes s =
   let len = String.length s in

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -44,6 +44,12 @@ val persistence_utf8_repair_stats : unit -> utf8_repair_stats
 val reset_persistence_utf8_repair_stats_for_tests : unit -> unit
 (** Reset {!persistence_utf8_repair_stats}. Test-only. *)
 
+val persistence_utf8_repair_log_entry_limit_for_tests : unit -> int
+(** Current UTF-8 repair warning rate-limit table bound. Test-only. *)
+
+val persistence_utf8_repair_log_key_count_for_tests : unit -> int
+(** Current UTF-8 repair warning rate-limit table size. Test-only. *)
+
 val parse_json_safe : context:string -> string -> (Yojson.Safe.t, string) result
 (** Parse JSON with detailed error reporting. *)
 

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -54,6 +54,47 @@ let test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair () =
   let stats = persistence_utf8_repair_stats () in
   check int "repair was observed" 1 stats.repaired_reads
 
+let latest_log_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | (entry : Log.Ring.entry) :: _ -> entry.seq
+  | [] -> -1
+
+let has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.equal prefix (String.sub value 0 prefix_len)
+
+let test_parse_json_safe_rate_limits_repeated_utf8_repair_logs () =
+  let open Safe_ops in
+  reset_persistence_utf8_repair_stats_for_tests ();
+  let baseline = latest_log_seq () in
+  ignore (parse_json_safe ~context:"utf8-repeat" "{\"msg\":\"a\xff\"}");
+  ignore (parse_json_safe ~context:"utf8-repeat" "{\"msg\":\"b\xff\"}");
+  let logs =
+    Log.Ring.recent ~limit:20 ~module_filter:"Misc" ~since_seq:baseline ()
+    |> List.filter (fun (entry : Log.Ring.entry) ->
+           has_prefix ~prefix:"[json] persistence UTF-8 repaired path=utf8-repeat"
+             entry.message)
+  in
+  let stats = persistence_utf8_repair_stats () in
+  check int "both repairs counted" 2 stats.repaired_reads;
+  check int "duplicate repair warning suppressed" 1 (List.length logs)
+
+let test_utf8_repair_log_rate_limit_table_is_bounded () =
+  let open Safe_ops in
+  reset_persistence_utf8_repair_stats_for_tests ();
+  let limit = persistence_utf8_repair_log_entry_limit_for_tests () in
+  for i = 1 to limit + 32 do
+    ignore
+      (repair_utf8_text ~surface:"bounded"
+         ~path:(Printf.sprintf "path-%04d" i)
+         "\xff")
+  done;
+  let stats = persistence_utf8_repair_stats () in
+  check int "all repairs counted" (limit + 32) stats.repaired_reads;
+  check bool "rate-limit keys stay bounded" true
+    (persistence_utf8_repair_log_key_count_for_tests () <= limit)
+
 let test_read_file_safe_not_found () =
   let open Safe_ops in
   let result = read_file_safe "/nonexistent/path/file.txt" in
@@ -399,6 +440,10 @@ let () =
         test_parse_json_safe_repairs_invalid_utf8_inside_string;
       test_case "malformed json still rejected after utf8 repair" `Quick
         test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair;
+      test_case "rate limits repeated utf8 repair logs" `Quick
+        test_parse_json_safe_rate_limits_repeated_utf8_repair_logs;
+      test_case "bounds utf8 repair log rate-limit table" `Quick
+        test_utf8_repair_log_rate_limit_table_is_bounded;
       test_case "long invalid" `Quick test_parse_json_safe_long_invalid;
     ];
     "read_file_safe", [


### PR DESCRIPTION
## Summary

- Rate-limit repeated malformed UTF-8 repair WARN logs per `(surface,path)`.
- Preserve exact cumulative repair counters and path samples for dashboard diagnostics.
- Add a focused regression test that verifies repeated corrupt reads are counted but only one duplicate warning is emitted immediately.

## Product Impact

While watching the live `/Users/dancer/me` keeper runtime, the dashboard/log pane was flooded by repeated `persistence UTF-8 repaired` warnings from `activity_graph:event_line` and `.masc/goals.json`. Those lines were hiding the keeper lifecycle signals needed to debug autonomy, including stale-watchdog terminations and semaphore wait starvation.

This keeps the data-quality signal visible without letting one corrupt path dominate the operator log view.

## Evidence

- Live logs showed repeated WARN rows for `activity_graph:event_line` and `/Users/dancer/me/.masc/goals.json`.
- `git diff --check` passed.

## Validation Notes

- Focused Dune validation is pending; the shared `/tmp/me-dune-local.lock` is currently held by other long-running masc-mcp validation jobs.

## Linked issue

None.
