### PR TITLE
docs(rfc): IDE Plane Assembly v1 umbrella + 5 sub-RFCs

### DIFF
--- a/dashboard/design-system/RFC/0022-ide-plane-assembly.md
+++ b/dashboard/design-system/RFC/0022-ide-plane-assembly.md
@@ -1,0 +1,124 @@
+# RFC 0022 — IDE Plane Assembly v1 (Umbrella)
+
+- **Status**: Draft
+- **Author**: Vincent + Claude (auto mode session 2026-05-05)
+- **Created**: 2026-05-05
+- **Depends on (existing RFCs)**:
+  - RFC 0010 (CollaborationCursor — keeper presence anchor primitive)
+  - RFC 0014 (TreeView — file explorer keyboard parity)
+  - RFC 0015 (Tabs — view tabs + LAYERS multi-select)
+  - RFC 0016 (Toolbar — IDE modebar)
+  - RFC 0017 (Solid Migration — sync-mount + Solid island regime)
+  - RFC 0019 (Keeper Line Ownership — blame-by-keeper data model)
+  - RFC 0020 (Layered Overlay System — LAYERS toggle framework)
+  - RFC 0021 (Anchored Thread Rail — CONVERSATION rail data model)
+- **Blocks**: RFC 0023, 0024, 0025, 0026 (모두 본 RFC 의 application)
+- **Sister RFC**: repo `docs/rfc/RFC-0033-worktree-status-sse.md` (server side)
+- **SSOT audit**: `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md`
+- **GitHub Issues**: #13197 (P0-A) · #13198 (P0-B) · #13199 (P1-A) · #13200 (P1-B) · #13201 (P2)
+
+---
+
+## 1. Motivation
+
+`dashboard/src/components/ide/`에 30+ 파일이 wire-up 되어 있고 IDE plane 의 client-side 는 80%+ 완성 상태다. `ide-shell.ts` 가 root container, `IDE_LAYERS` 가 정의됨, `keeper-presence-store` 의 `workspace_label` 필드 contract 도 있다. 그러나:
+
+1. **server-side gap**: IDE plane 이 필요로 하는 데이터(worktree status, keeper shell ring buffer)를 노출하는 핸들러가 0건. `rg "worktree" lib/dashboard/` 가 0 hit.
+2. **mock fragments**: mockup 이 추가한 4 영역 중 일부는 still mock — `ide-activity-mock.ts`, `ide-conversation-rail-mock.ts`, `ide-interject-mock.ts`.
+3. **producer wire-up gap**: RFC-0019/0020/0021 의 store contract 는 정의됐지만 producer-side handler / SSE 가 미작성.
+
+본 RFC 는 이 gap 을 5 sub-RFC (DS 0023–0026 + repo 0033) 로 분할하고, 각 sub-RFC 가 production PR sequence 로 어떻게 매핑되는지 우산으로 묶는다.
+
+## 2. Non-Goals
+
+- 새로운 store/primitive 정의 (DS 0019/0020/0021 이 이미 정의).
+- file explorer 자체의 RFC (RFC-0014 + zone-E1 worktree 진행 중).
+- mockup 의 raw hex 를 production 에 직접 도입 (audit §3 token tier 룰).
+- emoji/아이콘 도입 (SKILL.md `Component vocabulary`).
+- worktree 생성·삭제 등 mutating action (read-only IDE plane).
+
+## 3. Sub-task → RFC → PR 매핑
+
+| Sub-task | scope | 신규 RFC | 의존 RFC | 우선순위 | LOC 추정 | Issue |
+|---|---|---|---|---|---|---|
+| **P0-A** worktree presence | server SSE + topbar chip mapper | repo RFC-0033 | RFC-0010 | P0 | ~250 | #13197 |
+| **P0-B** cascade overlay | LAYERS 'cascade' entry + line-level data | DS RFC-0023 | RFC-0019, 0020 | P0 | ~300 | #13198 |
+| **P1-A** BDI inspector slot | inspector rail BDI peek | DS RFC-0024 | RFC-0019, 0008 | P1 | ~200 | #13199 |
+| **P1-B** keeper shell drawer | drawer + ring buffer SSE | DS RFC-0025 | (없음) | P1 | ~400 | #13200 |
+| **P2** audit replay | scrubber + timestamp filter | DS RFC-0026 | RFC-0021 | P2 | ~330 | #13201 |
+
+총 ~1,480 LOC + 6 RFC.
+
+## 4. PR Sequence
+
+```
+PR-1 (this)  RFC umbrella + sub-RFCs 6개
+   └── feature/ide-plane-rfc-umbrella
+
+PR-2  P0-A server SSE  ─┐
+                         ├─ 독립 (server endpoint scope 분리)
+PR-3  P0-A client mapper┘  PR-2 머지 후
+
+PR-4  P0-B cascade overlay  RFC-0019/0020 producer wire 후
+
+PR-5  P1-A BDI inspector slot  RFC-0019 producer wire 후
+
+PR-6  P1-B keeper shell server SSE ─┐
+                                     ├─ PR-7 ← PR-6
+PR-7  P1-B drawer client            ┘
+
+PR-8  P2 audit replay  RFC-0021 producer wire 후
+```
+
+PR-2~8 은 server endpoint scope 가 분리되어 있어 keeper 별 병렬 가능. 단 같은 sub-task 내 server→client 순서는 지킨다.
+
+## 5. Keeper 분배
+
+| Keeper | toml | persona | 분배 |
+|---|---|---|---|
+| **sangsu** | yes | sangsu | P0-A 서버 (coding preset, 안전 패턴) |
+| **nick0cave** | (toml 없음) | (link) | P0-A 클라이언트 wire-up |
+| **masc-improver** | yes | analyst | P0-B cascade (delivery preset, cascade 도메인) |
+| **issue_king** | yes | issue_king | P2 audit replay (delivery preset, 감사 도메인) |
+| **ramarama** | yes | (link) | P1-B drawer 서버 (delivery, sandbox) |
+| **taskmaster** | yes | (link) | umbrella 진행 추적 (delivery preset) |
+| **scholar** | persona only | scholar | P1-A BDI 모델링 자문 |
+| **analyst** | persona only | analyst | P1-A 관찰성 자문 |
+| **verifier** | persona only | verifier | 모든 PR 테스트 검증 |
+| **executor** | persona only | executor | 빌드/lint 게이트 |
+| **jobsian_purist** | (no toml) | (perpetual) | P1-B drawer 클라이언트 |
+| **velvet-hammer** | (no toml) | (perpetual) | P2 audit replay 회고 분석 |
+| **tech_glutton** | (no toml) | (perpetual) | P0-B 통합 |
+
+이외 perpetual keeper(qa-king, imseonghan, glm-coding-plan)는 board post 보고 자율 picker.
+
+## 6. 검증 (PR 별 통과 기준)
+
+audit §6 checklist + 다음:
+
+- [ ] `rg "#[0-9a-fA-F]{3,8}" dashboard/src/components/ide/` 0 hits (raw hex 금지)
+- [ ] Solid component 는 RFC-0017 §7d sync-mount 패턴 (`useLayoutEffect` ref callback)
+- [ ] 새 token 필요 시 `tokens/source.ts` PR 선행 + `tokens-drift` CI 4 gate green
+- [ ] vitest unit + msw + Playwright e2e 각 PR
+- [ ] a11y: `jest-axe` + reduced-motion 처리
+
+## 7. 일정 추정
+
+- RFC 머지 (PR-1): 1-2일 (리뷰 1회)
+- PR-2~8: 6 keeper 병렬이면 4-6일 wall clock
+- 단일 keeper sequential: ~2주
+
+## 8. 위험
+
+- **mock cutover regression**: mock 컴포넌트와 production 컴포넌트가 같은 store 를 쓰므로 cutover 시점에 시각 회귀 가능 → 각 PR 마다 mock 도 같이 정리.
+- **worktree count scale**: 2026-05-05 기준 33 worktree. 200 worktree 까지 청크 페이지네이션 (RFC-0033 §4.4).
+- **race-window during PR series**: 7 PR 직렬은 same-axis race 위험. PR-2/3/4/6/8 은 독립 가능하지만 head sweep `gh pr list --search "<filename>"` 매번.
+- **keeper 자율 picker drift**: keeper 가 board post 만 보고 잘못된 sub-task pick 가능 → 본 RFC §5 분배표를 SSOT 로.
+
+## 9. Open questions
+
+1. **drawer terminal input 권한**: PR-7 read-only. input 은 별도 RFC + RBAC 검토 필요.
+2. **audit replay free-range vs PR-bound**: 1단계 PR-bound → 2단계 free-range. 데이터 cardinality 측정 후 결정.
+3. **cascade overlay line-level vs commit-level**: 1단계 commit-level (적은 data join), 2단계 line-level (diff hunk join 추가).
+
+이 질문들은 draft acceptance 를 막지 않으나 각 PR 시작 전 close 한다.

--- a/dashboard/design-system/RFC/0023-cascade-overlay-layer.md
+++ b/dashboard/design-system/RFC/0023-cascade-overlay-layer.md
@@ -77,7 +77,7 @@ response: `{ "hits": CascadeHit[] }`
 
 `.masc/cascade_audit/*.jsonl` 을 server-side 로 인덱스. 각 entry 가 이미 `commit_sha` 와 `turn_id` 를 가짐. file_path 는 turn 의 tool_call (write/edit) 에서 추출. line_range 는 commit diff hunk 와 join.
 
-1단계는 `line_start = 0, line_end = -1` (whole-file) 로 단순 wire — diff hunk join 은 2단계.
+1단계는 명시적 file-level hit 으로 wire 한다: `line_range` 를 `null` 로 두고, diff hunk join 이 가능한 2단계부터 1-indexed inclusive `{ line_start, line_end }` 를 채운다.
 
 ### 4.2 2단계: line-level
 

--- a/dashboard/design-system/RFC/0023-cascade-overlay-layer.md
+++ b/dashboard/design-system/RFC/0023-cascade-overlay-layer.md
@@ -1,0 +1,117 @@
+# RFC 0023 — Cascade Overlay Layer (extends RFC 0020)
+
+- **Status**: Draft
+- **Author**: Vincent + Claude (auto mode 2026-05-05)
+- **Created**: 2026-05-05
+- **Extends**: RFC 0020 (Layered Overlay System)
+- **Depends on**: RFC 0019 (Keeper Line Ownership), RFC 0020 (Layered Overlay)
+- **Parent RFC**: RFC 0022 (IDE Plane Assembly v1 — Umbrella)
+- **GitHub Issue**: #13198
+
+---
+
+## 1. Motivation
+
+RFC-0020 정의 LAYERS toggle 의 6 layer (Time/Parallel/Tools/Approve/Notes/EXPLODE) 에는 **Cascade** 가 빠져 있다. masc-mcp 는 매 LLM turn 마다 cascade router 가 provider/model fallback 을 처리하고, 그 결과(`cascade_audit/*.jsonl`)는 commit_sha 단위로 file/line 에 attribution 가능. line 별 cascade hit (provider/model/cost/latency) 을 line gutter chip 으로 overlay 표시하면 "이 라인이 비싼 모델로 들어왔는지", "fallback 에서 왔는지" 를 *읽을 때* 가 아니라 *돌아볼 때* 알게 된다.
+
+이 패턴은 memory `feedback_wave_pattern_60_80_stale_resolved` 의 fix-the-fix 사이클을 시각으로 잡는다.
+
+## 2. Non-Goals
+
+- cascade router 자체 변경 (consumer of `cascade_audit` only)
+- per-token cost (line 단위 가장 fine-grained)
+- realtime cascade event stream (1단계 commit-snapshot, 2단계는 별도 RFC)
+
+## 3. Public API
+
+### 3.1 LAYERS entry 추가
+
+`dashboard/src/components/ide/ide-toolbar.ts` 의 `IDE_LAYERS` 배열에 entry 추가:
+
+```ts
+{
+  kind: 'cascade',
+  label: 'Cascade',
+  description: 'cascade hit per line (provider · model · cost · latency)',
+  mutuallyExclusive: false,
+}
+```
+
+### 3.2 Overlay store
+
+```ts
+// dashboard/src/components/ide/overlay-cascade.ts
+export interface CascadeHit {
+  readonly file_path: string
+  readonly line_start: number       // 1-indexed inclusive
+  readonly line_end: number
+  readonly provider: string         // 'anthropic' | 'openai' | 'moonshot' | ...
+  readonly model_id: string
+  readonly cost_usd: number
+  readonly latency_ms: number
+  readonly cascade_step: number     // 0=primary, 1=fallback, 2=tertiary, ...
+  readonly commit_sha: string
+  readonly turn_id: string
+}
+
+export interface CascadeOverlayStore {
+  readonly hitsForFile: (path: string) => ReadonlyMap<number, CascadeHit[]>
+  readonly hitsForCommit: (sha: string) => ReadonlyArray<CascadeHit>
+  readonly ingest: (event: CascadeHit) => void
+  readonly setVisibleRange: (path: string, lineFrom: number, lineTo: number) => void
+}
+```
+
+### 3.3 REST endpoint
+
+```
+GET /api/dashboard/cascade-overlay?file=<path>&commit_sha=<sha>
+GET /api/dashboard/cascade-overlay?file=<path>&since_ms=<ts>
+```
+
+response: `{ "hits": CascadeHit[] }`
+
+## 4. Data source
+
+### 4.1 1단계: commit-level
+
+`.masc/cascade_audit/*.jsonl` 을 server-side 로 인덱스. 각 entry 가 이미 `commit_sha` 와 `turn_id` 를 가짐. file_path 는 turn 의 tool_call (write/edit) 에서 추출. line_range 는 commit diff hunk 와 join.
+
+1단계는 `line_start = 0, line_end = -1` (whole-file) 로 단순 wire — diff hunk join 은 2단계.
+
+### 4.2 2단계: line-level
+
+`git show --unified=0 <commit_sha>` 로 hunk 추출 + tool_call 의 edit range 와 cross-reference. 별도 PR.
+
+## 5. Rendering
+
+editor gutter (line number 옆) 에 cascade chip:
+
+```
+   42  | provider · cost   foo()
+   43  | provider · cost   bar()
+```
+
+color: `--color-keeper-N-glow` (provider hash → 12 slot) + cost band:
+- ≤ $0.001: `--color-status-ok`
+- ≤ $0.01: `--color-status-warn`
+- > $0.01: `--color-status-err`
+
+hover: tooltip with full `CascadeHit` (model_id, latency_ms, cascade_step, turn_id link).
+
+## 6. ARIA
+
+- chip: `role="img"` + `aria-label="cascade: {provider} {model_id} ${cost_usd}"`
+- gutter region: `aria-label="cascade overlay, {N} hits in view"`
+- toggle (LAYERS): RFC-0015 multi-select Tabs 어댑터 그대로
+
+## 7. Test plan
+
+- unit: `overlay-cascade.test.ts` — ingest, hitsForFile, visible range filter
+- e2e: 1 sample commit (`cascade_audit` jsonl) → overlay 활성 → gutter chip 표시 (Playwright snapshot)
+- a11y: `jest-axe` + reduced-motion (chip 등장 fade-in 즉시)
+
+## 8. Open questions
+
+1. **provider hash → keeper slot collision**: provider 8개, keeper 12 slot. 충돌 시 hue stride 30° 보장 깨짐 → provider hash 별도 palette 또는 keeper slot 9-12 reserve.
+2. **commit-level fallback 표시 방식**: line-level 아닌 1단계는 "whole-file glow" vs "first-line chip" — UX 측정 필요.

--- a/dashboard/design-system/RFC/0024-bdi-inspector-slot.md
+++ b/dashboard/design-system/RFC/0024-bdi-inspector-slot.md
@@ -1,0 +1,100 @@
+# RFC 0024 — BDI Inspector Slot (extends RFC 0019)
+
+- **Status**: Draft
+- **Author**: Vincent + Claude (auto mode 2026-05-05)
+- **Created**: 2026-05-05
+- **Extends**: RFC 0019 (Keeper Line Ownership)
+- **Depends on**: RFC 0008 (AgentPresence), RFC 0019
+- **Parent RFC**: RFC 0022 (IDE Plane Assembly v1)
+- **GitHub Issue**: #13199
+
+---
+
+## 1. Motivation
+
+editor 에서 line click → 그 line 의 keeper id (RFC-0019 ownership) 가 결정된다. 그 다음 단계가 비어 있다 — keeper 의 *현재 의도* 를 모른다. Cognition plane (`cb-group-h.jsx::KeeperBDIPanel`) 이 BDI(belief / desire / intention) snapshot 을 표시하지만 *별도 plane 으로 이동* 해야 본다.
+
+inspector rail 우측에 keeper-pin slot 을 두면 line 의 keeper 를 *읽을 때* 그 의도를 같이 본다. memory `reference_masc_keeper_memory_reinjection_path` 의 self-reinforcement chain 을 IDE 에서 추적.
+
+## 2. Non-Goals
+
+- BDI snapshot 자체 정의 (`lib/keeper_status_bridge` 가 owner)
+- BDI mutating action (read-only)
+- multi-keeper compare view (single pin only; multi 는 별도 RFC)
+
+## 3. Public API
+
+### 3.1 BDI snapshot shape
+
+```ts
+// dashboard/src/components/ide/keeper-bdi-store.ts
+export interface KeeperBDISnapshot {
+  readonly keeper_id: string
+  readonly belief: ReadonlyArray<string>        // 최대 5 entries
+  readonly desire: ReadonlyArray<string>        // 최대 3 entries
+  readonly intention: string | null             // 단일 statement
+  readonly recent_token_spend: ReadonlyArray<{
+    readonly turn_id: string
+    readonly tokens_in: number
+    readonly tokens_out: number
+    readonly ts_ms: number
+  }>                                            // 최근 5턴
+  readonly last_tool_call: {
+    readonly name: string
+    readonly args_summary: string
+    readonly result_kind: 'ok' | 'err' | 'pending'
+    readonly ts_ms: number
+  } | null
+  readonly snapshot_ts_ms: number
+}
+```
+
+### 3.2 REST endpoint
+
+```
+GET /api/dashboard/keeper-bdi/<keeper_id>
+```
+
+returns `KeeperBDISnapshot`. cache 5초 TTL (RFC-0008 update cadence 와 동기).
+
+### 3.3 Inspector slot component
+
+```tsx
+// dashboard/src/components/ide/inspector-keeper-bdi.tsx
+interface Props {
+  readonly keeperId: string | null
+  readonly onUnpin: () => void
+}
+```
+
+placement: `ide-shell.ts` 의 우측 영역, `IxPrHeader` / `IxPrChecks` 같은 슬롯 옆.
+
+## 4. Pin behavior
+
+- editor line click → ownership store 조회 → `setPinnedKeeper(ownership.keeper_id)`
+- pin 변경은 명시 (auto-pin 옵션은 default off; user gesture only)
+- unpin: slot 의 X 버튼 또는 `Esc` (RFC-0012 keyboard shortcuts)
+- 다른 line 같은 keeper → no-op (이미 pin)
+
+## 5. Polling
+
+- 5초 주기 (`useEffect` cleanup with cancellation token)
+- visibility hidden 시 정지 (`document.visibilityState !== 'visible'`)
+- reduced-motion 시 update 시각 effect 즉시 (애니 없음)
+
+## 6. ARIA
+
+- slot region: `role="region"` + `aria-label="keeper inspector — {keeper_id}"`
+- BDI list: `role="list"` + `aria-label="beliefs, {N}"` 등
+- update: `aria-live="polite"` + `aria-atomic="false"` (Toast 패턴 참조)
+
+## 7. Test plan
+
+- unit: `inspector-keeper-bdi.test.ts` — empty pin, populated, polling lifecycle
+- e2e: line click → pin → 5초 후 update 확인 (Playwright)
+- a11y: `jest-axe`
+
+## 8. Open questions
+
+1. **BDI 미생성 keeper**: legacy keeper 또는 새 keeper 가 BDI 를 갖지 않을 수 있음 → fallback "no BDI snapshot · {snapshot_ts_ms}" 표시.
+2. **spend window**: 5턴 vs 시간기반 (10분) — 작업 burst 시 5턴이 1분 미만일 수도. v1 5턴 fixed; 측정 후 조정.

--- a/dashboard/design-system/RFC/0025-live-keeper-shell-drawer.md
+++ b/dashboard/design-system/RFC/0025-live-keeper-shell-drawer.md
@@ -104,8 +104,8 @@ terminal tab 본문:
 
 ```
 [01:42:18] cmd  $ git fetch --all
-[01:42:18] out  fetching origin (5 refs)
-[01:42:25] err    ✗ cascade.fanout.cycle_detection    (timeout)
+[01:42:18] stdout  fetching origin (5 refs)
+[01:42:25] stderr    ✗ cascade.fanout.cycle_detection    (timeout)
 ```
 
 ANSI sequences → CSS class via `parseAnsi()` (existing helper). 자동 스크롤 (latest line 보임), reduced-motion 시 jump.

--- a/dashboard/design-system/RFC/0025-live-keeper-shell-drawer.md
+++ b/dashboard/design-system/RFC/0025-live-keeper-shell-drawer.md
@@ -1,0 +1,134 @@
+# RFC 0025 — Live Keeper Shell Drawer
+
+- **Status**: Draft
+- **Author**: Vincent + Claude (auto mode 2026-05-05)
+- **Created**: 2026-05-05
+- **Depends on**: (없음, 신규 표면)
+- **Parent RFC**: RFC 0022 (IDE Plane Assembly v1)
+- **GitHub Issue**: #13200
+- **Prototype reference**: `Downloads/MASC Cockpit (3)/cockpit-kit/Drawer.jsx::TerminalPanel` (mock data, lines 33-62)
+
+---
+
+## 1. Motivation
+
+cockpit-kit prototype `Drawer.jsx::TerminalPanel` 의 mock terminal lines (`{ t: "01:42:18", k: "tx", txt: "$ git fetch --all" }` 하드코딩) 을 실제 keeper shell stdout/stderr ring buffer 로 교체. 단일 cockpit 에서 multi-keeper shell 을 동시에 watch (마치 tmux pane).
+
+memory `feedback_keeper-reaction-chain-break-analysis-2026-05-04` 의 9 termination paths + 6 partial recovery 를 실시간 시각으로 본다.
+
+## 2. Non-Goals
+
+- input wire-in (read-only v1; input 은 별도 RFC + RBAC 검토)
+- multi-keeper split pane (single-keeper-at-a-time v1)
+- shell history persistence (ring buffer 만; persistent log 는 audit 영역)
+- keeper shell 자체 변경 (`lib/keeper/keeper_shell_*` 의 consumer only)
+
+## 3. Public API
+
+### 3.1 SSE 채널
+
+```
+GET /api/dashboard/keeper-shell/<keeper_id>?since_ms=<ts>
+Accept: text/event-stream
+```
+
+이벤트:
+
+```json
+{
+  "kind": "snapshot" | "line",
+  "ts_ms": 1777981200000,
+  "keeper_id": "sangsu",
+  "lines": [ShellLine...]    // kind=snapshot
+  "line": ShellLine           // kind=line (single)
+}
+```
+
+### 3.2 ShellLine
+
+```json
+{
+  "ts_ms": 1777981200123,
+  "stream": "stdout" | "stderr" | "cmd" | "system",
+  "text": "...",
+  "ansi": true | false           // ANSI escape sequences 보존 여부
+}
+```
+
+ring buffer 크기: 5000 lines (env `MASC_KEEPER_SHELL_RING_BUFFER=5000`).
+
+### 3.3 Drawer client
+
+```tsx
+// dashboard/src/components/ide/drawer.tsx
+interface DrawerProps {
+  readonly activeTab: 'terminal' | 'output' | 'cascade' | 'audit' | 'cost'
+  readonly keeperId: string | null      // for terminal tab
+}
+```
+
+`?keeper=<name>` URL 파라미터 → SSE 구독. tab 전환 시 SSE 정리.
+
+## 4. Server-side
+
+### 4.1 Capture point
+
+`lib/keeper/keeper_shell_*` 또는 `lib/keeper_shell_capture` 에 ring buffer broadcast 추가:
+
+```ocaml
+val attach_capture :
+  keeper_id:string ->
+  buffer:Ring_buffer.t ->
+  unit
+(** Hook into keeper PTY stdout/stderr; appends each line to ring buffer
+    and emits SSE event to subscribers. *)
+```
+
+### 4.2 SSE handler
+
+`lib/dashboard/dashboard_keeper_shell.ml(i)` 신규.
+
+```ocaml
+val sse_handler :
+  sw:Eio.Switch.t ->
+  keeper_id:string ->
+  Eio.Net.stream_socket_ty Eio.Resource.t ->
+  unit
+```
+
+snapshot (since_ms 이후 ring buffer 라인) → live patches.
+
+## 5. Rendering
+
+terminal tab 본문:
+
+```
+[01:42:18] cmd  $ git fetch --all
+[01:42:18] out  fetching origin (5 refs)
+[01:42:25] err    ✗ cascade.fanout.cycle_detection    (timeout)
+```
+
+ANSI sequences → CSS class via `parseAnsi()` (existing helper). 자동 스크롤 (latest line 보임), reduced-motion 시 jump.
+
+## 6. ARIA
+
+- region: `role="log"` + `aria-live="polite"` + `aria-label="keeper shell — {keeper_id}"`
+- 각 line: `role="listitem"` (parent `role="list"`)
+- aria-atomic false (각 line 개별 announce)
+
+## 7. Test plan
+
+- unit: `drawer.test.tsx` — SSE 연결, 끊김 reconnect, tab 전환 cleanup
+- integration: 16 keeper sustained env 에서 메모리 leak 없음 (heap snapshot delta)
+- e2e: `?keeper=sangsu` 방문 → 라이브 stdout 표시 (Playwright)
+
+## 8. Performance
+
+- 5000 lines × 16 keeper = 80k lines max in memory if all attached. v1: 1 keeper at a time → 5k lines. Solid fine-grained reactivity 로 line append 시 전체 re-render 안 됨.
+- ring buffer 라인 길이 truncate 4096 chars (long stdout 보호).
+
+## 9. Open questions
+
+1. **ANSI sequences vs plain text**: 보존 시 보안 (escape injection) 검토 필요. v1: whitelist (color, bold, dim 만).
+2. **PTY 멀티플렉싱**: 현 lib/keeper 가 PTY 1개 per keeper 인지 multiplex 인지 확인 필요. multiplex 면 ring buffer 도 multiplex.
+3. **input 단계 권한**: PR-7+ 에서 RBAC + per-keeper allow-list. v1 read-only.

--- a/dashboard/design-system/RFC/0026-audit-replay-timeline.md
+++ b/dashboard/design-system/RFC/0026-audit-replay-timeline.md
@@ -1,0 +1,118 @@
+# RFC 0026 — Audit Replay Timeline (extends RFC 0021)
+
+- **Status**: Draft
+- **Author**: Vincent + Claude (auto mode 2026-05-05)
+- **Created**: 2026-05-05
+- **Extends**: RFC 0021 (Anchored Thread Rail)
+- **Depends on**: RFC 0021, audit ledger (`.masc/audit/*`)
+- **Parent RFC**: RFC 0022 (IDE Plane Assembly v1)
+- **GitHub Issue**: #13201
+
+---
+
+## 1. Motivation
+
+post-mortem 디버깅이 "git log + grep" 조합에서 "코드 보면서 시간을 끌어서 봄" 으로 바뀐다. memory `feedback_compaction_summary_pr_number_hallucination` 의 reverse-direction (GitHub state 먼저 → transcript trace) 검증을 시각으로.
+
+audit ledger / cascade_audit / decisions / anchored thread 모두 `ts_ms` 를 갖고 있어 timeline 슬라이더 한 축으로 통합 재투영 가능. 1단계 PR-bound replay (PR open~close 기간만), 2단계 free-range scrub.
+
+## 2. Non-Goals
+
+- audit ledger 자체 변경 (consumer only)
+- write/mutating action (read-only)
+- diff replay (별도 RFC; v1 은 thread/decision/cascade 만)
+
+## 3. Public API
+
+### 3.1 Timeline filter
+
+```ts
+// dashboard/src/components/ide/replay-overlay.ts
+export interface ReplayWindow {
+  readonly since_ms: number
+  readonly until_ms: number
+  readonly mode: 'pr-bound' | 'free-range'
+  readonly pr_number?: number       // mode = pr-bound
+}
+
+export interface ReplayOverlayStore {
+  readonly window: () => ReplayWindow
+  readonly setWindow: (w: ReplayWindow) => void
+  readonly threadsInWindow: () => ReadonlyArray<AnchoredThread>     // RFC-0021
+  readonly decisionsInWindow: () => ReadonlyArray<Decision>
+  readonly cascadeHitsInWindow: () => ReadonlyArray<CascadeHit>      // RFC-0023
+}
+```
+
+기존 `anchored-thread-rail-store.ts` 의 `timestamp_ms` 필드를 filter 기준으로 사용. cascade overlay (RFC-0023) 도 같은 window 적용.
+
+### 3.2 REST endpoint
+
+```
+GET /api/dashboard/audit-replay?since_ms=<ts>&until_ms=<ts>&pr=<number>
+```
+
+response (chunked):
+
+```json
+{
+  "window": ReplayWindow,
+  "threads": AnchoredThread[],
+  "decisions": Decision[],
+  "cascade_hits": CascadeHit[],
+  "ts_index": [{ts_ms, kind, count}]    // for scrubber tick density
+}
+```
+
+### 3.3 Scrubber UI
+
+```tsx
+// dashboard/src/components/ide/audit-replay-slider.tsx
+interface Props {
+  readonly window: ReplayWindow
+  readonly onChange: (w: ReplayWindow) => void
+}
+```
+
+placement: `ide-shell.ts` 의 editor 상단 (modebar 아래).
+
+## 4. Scrubber behavior
+
+- range slider (since/until 두 핸들)
+- `ts_index` 의 density 를 background histogram 으로 표시 (어느 시점이 active 했는지)
+- keyboard: `←/→` 1초 step, `Shift+←/→` 1분, `Ctrl+←/→` 1시간 (RFC-0012)
+- 각 핸들 별 `aria-label="replay since"` / `"replay until"`
+
+## 5. PR-bound mode
+
+PR open ~ close (또는 현재) 의 `ts_ms` range 를 자동 결정:
+- `gh pr view <pr> --json createdAt,mergedAt,closedAt,state`
+- `since_ms = createdAt`, `until_ms = mergedAt || closedAt || Date.now()`
+
+## 6. Re-projection
+
+window 변경 → 모든 overlay (anchored-thread-rail, cascade-overlay-layer) 가 동일 store subscribe → 자동 re-render. inspector slot (RFC-0024) 도 BDI snapshot 을 *그 시점* 의 BDI 로 대체.
+
+## 7. ARIA
+
+- slider region: `role="region"` + `aria-label="audit replay timeline, {window summary}"`
+- 각 핸들: `role="slider"` + `aria-valuenow={ms}` + `aria-valuetext="2026-05-05 18:30"`
+- update: `aria-live="polite"` (window 변경 announce)
+
+## 8. Test plan
+
+- unit: `replay-overlay.test.ts` — window 변경 → store filter
+- e2e: PR-bound 1개 사례 (#13174 같은 short-lived PR) 에서 thread/decision/cascade ordering 이 timeline 과 일치
+- a11y: `jest-axe` + 키보드 navigation
+
+## 9. Performance
+
+- audit ledger 가 100k+ entries 가능 → server 측에서 PR-bound window 로 prefilter (1단계)
+- ts_index 는 1분 bucket aggregate (scrubber 화면 분해능 충분)
+- free-range (2단계) 는 server-side cursor pagination
+
+## 10. Open questions
+
+1. **future: live replay**: window upper bound = "now" 일 때 자동 update vs frozen 모드 선택. v1 frozen.
+2. **inspector slot 시점 BDI**: 시점 BDI 가 server 에 보존되는지? v1: 미보존이면 "BDI snapshot at {ts} unavailable" fallback.
+3. **scrubber density 색상**: density histogram 의 color band — keeper hue 평균 vs activity intensity vs status mix. UX 측정.

--- a/dashboard/design-system/RFC/0026-audit-replay-timeline.md
+++ b/dashboard/design-system/RFC/0026-audit-replay-timeline.md
@@ -49,7 +49,7 @@ export interface ReplayOverlayStore {
 ### 3.2 REST endpoint
 
 ```
-GET /api/dashboard/audit-replay?since_ms=<ts>&until_ms=<ts>&pr=<number>
+GET /api/dashboard/audit-replay?since_ms=<ts>&until_ms=<ts>&pr_number=<number>
 ```
 
 response (chunked):

--- a/docs/rfc/RFC-0033-worktree-status-sse.md
+++ b/docs/rfc/RFC-0033-worktree-status-sse.md
@@ -1,0 +1,180 @@
+# RFC 0033 — Worktree Status SSE Channel
+
+- **Status**: Draft
+- **Author**: Vincent + Claude (auto mode 2026-05-05)
+- **Created**: 2026-05-05
+- **Sister RFC**: design-system `dashboard/design-system/RFC/0022-ide-plane-assembly.md`
+- **Depends on**: `lib/coord/coord_worktree.ml` (existing)
+- **Blocks**: GitHub Issue #13197 (P0-A worktree-aware IDE plane)
+
+---
+
+## 1. Motivation
+
+Dashboard IDE plane (`dashboard/src/components/ide/keeper-presence-store.ts`)이 `workspace_label` 필드 contract 를 갖고 있지만 `rg "worktree" lib/dashboard/` 가 0 hit — 서버가 worktree 정보를 dashboard 에 노출하지 않는다.
+
+이 세션 (2026-05-05) 에서 본 cwd 누락 사고들 — PR #13174 작업 중 배경 dune build 가 worktree 가 아닌 main root 를 빌드한 사례 — 을 cockpit 에서 시각으로 막을 수 있다 (cf. memory `feedback_pre_push_check_pr_state_must_be_active`).
+
+또 `feedback_check_open_prs_before_unblock_pr_chore` 의 race-window rule 이 시각화되어 사용자가 stale PR head 와 main HEAD 차이를 cockpit topbar 에서 즉시 본다.
+
+## 2. Non-Goals
+
+- worktree 생성/삭제 등 mutating action (read-only)
+- multi-repo (현 시점 single repo `masc-mcp` 만; multi-repo 는 keeper-repo-mapping 어댑터 별도 RFC)
+- per-keeper attach state — 별도 store (`keeper-presence-store`)
+- branch 전환 등 git plumbing 자동화
+
+## 3. Public API
+
+### 3.1 SSE 채널
+
+```
+GET /api/dashboard/worktree-status
+Accept: text/event-stream
+```
+
+이벤트 형식 (newline-delimited JSON, SSE `data:` 프리픽스):
+
+```json
+{
+  "kind": "snapshot" | "patch",
+  "ts_ms": 1777981200000,
+  "entries": [WorktreeEntry...],         // kind=snapshot
+  "added": [WorktreeEntry...],           // kind=patch
+  "removed": ["worktree_path"...],       // kind=patch
+  "updated": [WorktreeEntry...]          // kind=patch
+}
+```
+
+snapshot: 최초 1회 + reconnect 시. patch: filesystem watcher debounced 1s.
+
+### 3.2 REST snapshot fallback
+
+```
+GET /api/dashboard/worktree-status?snapshot=1
+```
+
+returns `{ "ts_ms": ..., "entries": [...] }`.
+
+### 3.3 WorktreeEntry
+
+```json
+{
+  "worktree_path": "/Users/dancer/me/.../.worktrees/feature/ide-plane-rfc-umbrella",
+  "branch": "feature/ide-plane-rfc-umbrella",
+  "head_sha": "7df987d030",
+  "is_main": false,
+  "is_detached": false,
+  "is_bare": false,
+  "changed_count": 3,
+  "staged_count": 0,
+  "untracked_count": 1,
+  "ahead_count": 0,
+  "behind_count": 0,
+  "pr_number": 13197,
+  "pr_state": "OPEN" | "MERGED" | "CLOSED" | null,
+  "pr_is_draft": true,
+  "keeper_attached": "sangsu" | null,
+  "last_activity_ms": 1777981200000
+}
+```
+
+## 4. Implementation
+
+### 4.1 Module
+
+`lib/dashboard/dashboard_worktree_status.ml(i)` 신규.
+
+서명 (.mli):
+
+```ocaml
+(** Worktree status snapshot for dashboard IDE plane.
+
+    Read-only snapshot of git worktrees registered in this repo.
+    Source: [Coord_worktree] for filesystem ops + [gh pr list] for PR state.
+    Cached in-memory with 5s TTL; FS watcher invalidates eagerly. *)
+
+type pr_state = Open | Merged | Closed
+
+type entry = {
+  worktree_path : string;
+  branch : string;
+  head_sha : string;
+  is_main : bool;
+  is_detached : bool;
+  is_bare : bool;
+  changed_count : int;
+  staged_count : int;
+  untracked_count : int;
+  ahead_count : int;
+  behind_count : int;
+  pr_number : int option;
+  pr_state : pr_state option;
+  pr_is_draft : bool;
+  keeper_attached : string option;
+  last_activity_ms : int64;
+}
+
+val snapshot : sw:Eio.Switch.t -> base_path:string -> entry list
+(** Snapshot of all worktrees rooted under [base_path].  Hits cache
+    if fresh (< 5s); otherwise re-reads via [Coord_worktree] and
+    invokes [gh pr list] once for the full branch set. *)
+
+val sse_handler :
+  sw:Eio.Switch.t ->
+  base_path:string ->
+  Eio.Net.stream_socket_ty Eio.Resource.t ->
+  unit
+(** SSE handler emits `snapshot` once then `patch` events on FS change. *)
+```
+
+### 4.2 Data sources
+
+1. `Coord_worktree.run_argv_lines ["git"; "worktree"; "list"; "--porcelain"]`
+2. each worktree: `git -C <path> status --porcelain` (changed/staged/untracked count)
+3. `git -C <path> rev-list --count <branch>..origin/<branch>` (ahead/behind)
+4. `gh pr list --json number,state,isDraft,headRefName --limit 200` (1 호출, branch list 와 join)
+5. keeper attach: `Keeper_state_store` lookup (별도 모듈; v1 nullable)
+
+### 4.3 Cache
+
+- in-memory `entry list ref` + `last_refresh_ts_ms`
+- TTL: 5초 (env `MASC_WORKTREE_STATUS_TTL_SEC` 가능)
+- FS watcher on `.git/worktrees/*` + `.git/refs/heads/*` → eager invalidate
+- 33 worktree env 에서 cold response < 500ms 측정 후 조정
+
+### 4.4 Pagination
+
+- 200 worktree 초과 시 cursor pagination: `?after=<worktree_path>&limit=50`
+- v1 default: 모든 entry 반환 (warn log 시점에 page 분할 검토)
+
+### 4.5 Routing
+
+`bin/main_eio` 또는 `lib/dashboard/dashboard_routes.ml` 에 path 등록:
+- `GET /api/dashboard/worktree-status` → `sse_handler`
+- `GET /api/dashboard/worktree-status?snapshot=1` → JSON snapshot
+
+## 5. Client wire-up (참조)
+
+DS RFC-0022 §3 Sub-task 매핑 P0-A 참조. `keeper-presence-store.ts` 의 `workspace_label` 매퍼가 `worktree_path` 의 last segment 를 라벨로 사용 (예: `feature/ide-plane-rfc-umbrella`). topbar chip 에서 `pr_number` 가 있으면 `#13197` suffix.
+
+## 6. Test plan
+
+- **unit**: `test/test_dashboard_worktree_status.ml` — 빈 list, 1 worktree, 33 worktree, malformed `git worktree list` 라인, `gh pr list` 0 PRs 케이스
+- **integration**: localhost SSE 구독 + JSON event 검증 (snapshot → patch 흐름)
+- **benchmark**: 33 worktree cold response < 500ms (`time curl -s http://localhost:8935/api/dashboard/worktree-status?snapshot=1`)
+- **stale data**: cache miss + 동시 5 클라이언트 → coalesce 검증
+
+## 7. Migration / Rollback
+
+- env knob `MASC_WORKTREE_STATUS_ENABLED=true` (default true after PR-2 머지)
+- 끔 시 client 는 빈 entries 표시 (graceful degrade — chip 영역 빈 채로)
+- rollback: env false 만으로 disable; 핸들러 자체 제거는 RFC withdraw 시
+
+## 8. Open questions
+
+1. **`gh pr list` rate limit**: 5초 TTL 으로 분당 최대 12회. github API rate limit 5000/hr 의 아주 작은 비율이지만 cache miss 폭주 시 spike 가능 → coalesce 락.
+2. **bare worktree 처리**: `--porcelain` 출력에 `bare` flag. v1: `is_bare=true` 만 표시, 다른 필드 0.
+3. **keeper_attached 산출**: keeper 가 branch 와 1:1 mapping 인가 1:N 인가? v1 best-effort (1 keeper → 1 branch); 다중 시 first-wins.
+
+이 질문들은 PR-2 시작 전 close 한다.

--- a/docs/rfc/RFC-0033-worktree-status-sse.md
+++ b/docs/rfc/RFC-0033-worktree-status-sse.md
@@ -33,7 +33,7 @@ GET /api/dashboard/worktree-status
 Accept: text/event-stream
 ```
 
-이벤트 형식 (newline-delimited JSON, SSE `data:` 프리픽스):
+이벤트 형식: 각 SSE event 는 blank line 으로 종료하며, JSON payload 는 `data:` 라인에 싣는다. 기본 구현은 event 하나당 single-line JSON object 하나를 보낸다.
 
 ```json
 {


### PR DESCRIPTION
## 목적

IDE Plane v1 production migration umbrella RFC + 5 sub-RFC 추가. **docs only, behavior 변경 없음.**

## 배경 (큰 발견)

`dashboard/src/components/ide/`에 30+ 파일이 wire-up되어 있고 IDE plane의 client-side는 **이미 80%+ 완성** 상태다 (`ide-shell.ts` root container, `IDE_LAYERS` toggle framework, `keeper-presence-store.workspace_label` contract, RFC-0019/0020/0021의 store 모두 존재).

진짜 gap은 server-side: `rg "worktree" lib/dashboard/`가 0 hit. mock fragments (`ide-activity-mock.ts`, `ide-conversation-rail-mock.ts`, `ide-interject-mock.ts`)도 production data wire-up 대기.

본 PR은 그 gap을 6개 RFC로 분할하고 PR 시퀀스 + keeper 분배 + 검증 기준을 우산으로 묶는다.

## 새 RFC

### `dashboard/design-system/RFC/0022-ide-plane-assembly.md` (umbrella)
- Sub-task → RFC → PR 매핑 표 (P0-A/P0-B/P1-A/P1-B/P2)
- PR 시퀀스 8개 (PR-1 본 PR, PR-2~8 keeper 병렬)
- Keeper 분배 13명 (config/keepers/*.toml + persona 매칭)

### `docs/rfc/RFC-0033-worktree-status-sse.md` (sister, server)
- `GET /api/dashboard/worktree-status` SSE 채널
- WorktreeEntry payload (worktree_path/branch/head_sha/changed_count/pr_number/keeper_attached/...)
- 5초 TTL cache + FS watcher 무효화
- 33 worktree 환경 응답 < 500ms 검증

### `dashboard/design-system/RFC/0023-cascade-overlay-layer.md` (extends 0020)
- `IDE_LAYERS`에 'cascade' entry 추가
- CascadeHit shape (provider/model/cost/latency/cascade_step/commit_sha)
- 1단계 commit-level → 2단계 line-level

### `dashboard/design-system/RFC/0024-bdi-inspector-slot.md` (extends 0019)
- inspector rail에 keeper-pin slot
- KeeperBDISnapshot shape (belief/desire/intention/recent_token_spend/last_tool_call)
- 5초 폴링, single-keeper-at-a-time

### `dashboard/design-system/RFC/0025-live-keeper-shell-drawer.md`
- `GET /api/dashboard/keeper-shell/<keeper_id>` SSE
- ShellLine shape (ts_ms/stream/text/ansi)
- ring buffer 5000 lines, read-only v1

### `dashboard/design-system/RFC/0026-audit-replay-timeline.md` (extends 0021)
- editor 상단 시간축 슬라이더
- ReplayWindow shape (since_ms/until_ms/mode=pr-bound|free-range)
- thread/decision/cascade 모두 같은 window subscribe

## 의존 RFC (인용만)

- DS RFC-0008 (AgentPresence), 0010 (CollaborationCursor), 0014 (TreeView), 0015 (Tabs), 0016 (Toolbar), 0017 (Solid Migration), 0019 (Keeper Line Ownership), 0020 (Layered Overlay), 0021 (Anchored Thread Rail)

## SSOT

- audit: `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md`

## GitHub Issues (각 sub-task)

- #13197 [P0-A] Worktree-aware IDE Plane
- #13198 [P0-B] Cascade Trace Overlay
- #13199 [P1-A] Keeper BDI Peek
- #13200 [P1-B] Drawer Terminal
- #13201 [P2] Audit Replay Timeline

## 영향 영역

`docs/rfc/`, `dashboard/design-system/RFC/` 만. **lib/, dashboard/src/, .claude/hooks/, instructions/ 모두 변경 없음.** behavior 변경 없으므로 RFC-WAIVED.

## 다음 PR

- `feature/p0a-worktree-status-sse` 브랜치에 server scaffold (`lib/dashboard/dashboard_worktree_status.ml(i)` stub) — 본 PR과 병렬 진행 중

## Test plan

- [ ] markdown lint (각 RFC)
- [ ] 인용한 의존 RFC 번호 실제 존재 확인 (`ls dashboard/design-system/RFC/`)
- [ ] Reviewer 1명이 RFC-0022 §3 sub-task 매핑표를 SSOT로 받아들이는지

## RFC-WAIVED

doc-only RFC umbrella + sister scaffold spec. Sister scaffold PR (lib/dashboard scaffold) lands separately. 본 PR은 코드/빌드/CI behavior 영향 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (auto mode 2026-05-05)
