### PR TITLE
feat(dashboard): worktree status scaffold for RFC-0033

### DIFF
--- a/lib/dashboard/dashboard_worktree_status.ml
+++ b/lib/dashboard/dashboard_worktree_status.ml
@@ -235,14 +235,6 @@ let list_entries ~base_path =
 (* JSON serialisation                                                   *)
 (* ------------------------------------------------------------------ *)
 
-let opt_int_json = function
-  | Some n -> `Int n
-  | None -> `Null
-
-let opt_string_json = function
-  | Some s -> `String s
-  | None -> `Null
-
 let entry_to_json entry =
   `Assoc
     [
@@ -251,8 +243,8 @@ let entry_to_json entry =
       ("changed_count", `Int entry.changed_count);
       ("staged_count", `Int entry.staged_count);
       ("head_sha", `String entry.head_sha);
-      ("pr_number", opt_int_json entry.pr_number);
-      ("pr_state", opt_string_json entry.pr_state);
+      ("pr_number", Json_util.int_opt_to_json entry.pr_number);
+      ("pr_state", Json_util.string_opt_to_json entry.pr_state);
       ("keeper_attached", `Bool entry.keeper_attached);
     ]
 


### PR DESCRIPTION
## 목적

RFC-0033 (Worktree Status SSE Channel) §4.1 모듈 시그니처 + 타입 + JSON serializer + stub 등록. 이후 `lib/dashboard/dashboard_worktree_status.ml`을 호출할 다른 모듈 (server route handler, presence-store mapper) 이 타입을 import 가능해진다.

## 컨텐츠

- `lib/dashboard/dashboard_worktree_status.mli` — RFC-0033 §4.1 signature 그대로
- `lib/dashboard/dashboard_worktree_status.ml` — type 구현 + `entry_to_yojson` + `entries_to_yojson` + `snapshot`/`sse_handler` stub (`failwith` with TODO 마커)
- `lib/dune` — `dashboard_worktree_status` private module 등록 (`dashboard_goals` 다음 라인)

## 의존

- Sister umbrella RFC PR (`feature/ide-plane-rfc-umbrella`) 이 RFC-0033 정의 추가. 본 PR은 정의에 부합.

## 미구현 (P0-A keeper sangsu에게)

- `snapshot ~sw ~base_path`: `Coord_worktree.run_argv_lines ["git"; "worktree"; "list"; "--porcelain"]` + per-worktree `git -C <path> status --porcelain` + `gh pr list --json number,state,isDraft,headRefName --limit 200` join
- `sse_handler`: snapshot → patch event 흐름, FS watcher debounce 1s
- 5초 TTL cache + coalesce 락 (concurrent miss 보호)
- 33 worktree 환경 응답 < 500ms 측정

## Test plan

- [ ] `dune build lib/dashboard/dashboard_worktree_status.cmxa` (이번 PR — type compile)
- [ ] `test/test_dashboard_worktree_status.ml` 작성 (PR-2)
- [ ] localhost SSE 구독 + JSON event 검증 (PR-2)
- [ ] benchmark: 33 worktree cold response < 500ms (PR-2)

## 영향 영역

`lib/dashboard/dashboard_worktree_status.ml(i)`, `lib/dune` (1 line). caller 0건 (새 module).

## RFC-WAIVED

scaffold-only PR. 타입 정의 + stub. 실제 wire-up + 테스트는 후속 PR. agent_delegation 룰 (CLAUDE.md) 영역 매칭: `lib/repo_manager/`, `lib/keeper/credential_*`, `lib/keeper/keeper_gh_*`, `lib/keeper/host_config_*` 모두 변경 없음. dashboard 영역도 `dashboard/src/components/credential-settings`, `dashboard/src/components/keeper-repo-mapping` 변경 없음.

## GitHub Issue

Closes 일부 of #13197 [P0-A] Worktree-aware IDE Plane (scaffold portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (auto mode 2026-05-05)
