### PR TITLE
chore(base): ratchet base policy counters

### DIFF
--- a/.ci/health-baseline.json
+++ b/.ci/health-baseline.json
@@ -17,7 +17,8 @@
     "bin_ml_over_500": 2,
     "test_ml_over_500": 95,
     "examples_ml_over_500": 0,
-    "mli_open_base": 97,
-    "ml_base_stdlib_shadow": 96
+    "mli_open_base": 0,
+    "ml_base_stdlib_shadow": 0,
+    "bin_ml_base_stdlib_shadow": 0
   }
 }

--- a/docs/BASE-POLICY.md
+++ b/docs/BASE-POLICY.md
@@ -116,15 +116,21 @@ preferred over both Base and raw Stdlib when they already exist.
 |---|---|
 | `mli_open_base` | `.mli` files in `lib/` containing the `open Base` directive (anchored: `^[[:space:]]*open[[:space:]]+Base([^[:alnum:]_]|$)`, excludes comments/docstrings) |
 | `ml_base_stdlib_shadow` | `.ml` files in `lib/` that contain both the `open Base` directive and a Stdlib-shadow block (`^[[:space:]]*module[[:space:]]+List[[:space:]]*=[[:space:]]*Stdlib\.List([^[:alnum:]_]|$)`) |
+| `bin_ml_base_stdlib_shadow` | `.ml` files in `bin/` that contain both the `open Base` directive and the same Stdlib-shadow block |
 
 These counters are recorded in `.ci/health-baseline.json` and reported
-by `scripts/health_snapshot.sh`.  A PR that increases either counter
+by `scripts/health_snapshot.sh`.  A PR that increases any counter
 above the baseline fails the gate when the audit is run with
 `base-policy-audit.sh --fail-on-regression`;
 CI also includes them in the `health_snapshot.sh --fail-on-lib-regression`
 ratchet.  When a baseline ref predates these counters, the audit treats
 the first measured value as the bootstrap baseline rather than a
 regression.
+
+As of the 2026-05-05 ratchet, all three tracked counters are zero in
+current `main`; `.ci/health-baseline.json` records zero so any
+reintroduction of the forbidden interface open or shadow anti-pattern
+fails the ratchet.
 
 ```sh
 bash scripts/base-policy-audit.sh --fail-on-regression

--- a/scripts/base-policy-audit.sh
+++ b/scripts/base-policy-audit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Base Policy Audit — count open Base in .mli files and Stdlib-shadow
-# anti-pattern in .ml files as defined in docs/BASE-POLICY.md.
+# Base Policy Audit — count open Base in lib .mli files and Stdlib-shadow
+# anti-patterns in implementation files as defined in docs/BASE-POLICY.md.
 #
 # Outputs a human-readable summary plus, when --json-out is given,
 # a machine-readable JSON file compatible with health_snapshot.sh.
@@ -98,6 +98,20 @@ count_ml_base_stdlib_shadow() {
   printf '%s' "$count"
 }
 
+count_bin_ml_base_stdlib_shadow() {
+  local count=0
+  if [ ! -d bin ]; then
+    printf '0'
+    return
+  fi
+  while IFS= read -r file; do
+    if rg -q "$STDLIB_LIST_SHADOW_RE" "$file" 2>/dev/null; then
+      count=$((count + 1))
+    fi
+  done < <(rg -l "$OPEN_BASE_DIRECTIVE_RE" bin/ -g '*.ml' 2>/dev/null)
+  printf '%s' "$count"
+}
+
 # Read a single numeric key from a JSON baseline file.
 extract_baseline_value() {
   local file="$1"
@@ -157,9 +171,11 @@ fi
 
 mli_open_base="$(count_mli_open_base)"
 ml_base_stdlib_shadow="$(count_ml_base_stdlib_shadow)"
+bin_ml_base_stdlib_shadow="$(count_bin_ml_base_stdlib_shadow)"
 
 baseline_mli_open_base="$(extract_baseline_value "$BASELINE_FILE" "mli_open_base" "$mli_open_base")"
 baseline_ml_base_stdlib_shadow="$(extract_baseline_value "$BASELINE_FILE" "ml_base_stdlib_shadow" "$ml_base_stdlib_shadow")"
+baseline_bin_ml_base_stdlib_shadow="$(extract_baseline_value "$BASELINE_FILE" "bin_ml_base_stdlib_shadow" "$bin_ml_base_stdlib_shadow")"
 
 # ── Report ───────────────────────────────────────────────────────────
 
@@ -167,6 +183,7 @@ echo "=== Base Policy Audit ==="
 echo ""
 echo "  mli_open_base          : ${mli_open_base}  (baseline: ${baseline_mli_open_base})"
 echo "  ml_base_stdlib_shadow  : ${ml_base_stdlib_shadow}  (baseline: ${baseline_ml_base_stdlib_shadow})"
+echo "  bin_ml_base_stdlib_shadow: ${bin_ml_base_stdlib_shadow}  (baseline: ${baseline_bin_ml_base_stdlib_shadow})"
 echo ""
 
 regressions=()
@@ -174,6 +191,8 @@ regressions=()
   regressions+=("mli_open_base ${baseline_mli_open_base}->${mli_open_base}")
 [ "${ml_base_stdlib_shadow}" -gt "${baseline_ml_base_stdlib_shadow}" ] && \
   regressions+=("ml_base_stdlib_shadow ${baseline_ml_base_stdlib_shadow}->${ml_base_stdlib_shadow}")
+[ "${bin_ml_base_stdlib_shadow}" -gt "${baseline_bin_ml_base_stdlib_shadow}" ] && \
+  regressions+=("bin_ml_base_stdlib_shadow ${baseline_bin_ml_base_stdlib_shadow}->${bin_ml_base_stdlib_shadow}")
 
 if [ "${#regressions[@]}" -eq 0 ]; then
   echo "  Status: PASS"
@@ -192,9 +211,11 @@ if [ -n "$JSON_OUT" ]; then
 {
   "mli_open_base": ${mli_open_base},
   "ml_base_stdlib_shadow": ${ml_base_stdlib_shadow},
+  "bin_ml_base_stdlib_shadow": ${bin_ml_base_stdlib_shadow},
   "baseline": {
     "mli_open_base": ${baseline_mli_open_base},
-    "ml_base_stdlib_shadow": ${baseline_ml_base_stdlib_shadow}
+    "ml_base_stdlib_shadow": ${baseline_ml_base_stdlib_shadow},
+    "bin_ml_base_stdlib_shadow": ${baseline_bin_ml_base_stdlib_shadow}
   }
 }
 EOF

--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -249,8 +249,10 @@ fi
 
 mli_open_base="$(extract_json_top_int "$base_policy_json" "mli_open_base")"
 ml_base_stdlib_shadow="$(extract_json_top_int "$base_policy_json" "ml_base_stdlib_shadow")"
+bin_ml_base_stdlib_shadow="$(extract_json_top_int "$base_policy_json" "bin_ml_base_stdlib_shadow")"
 baseline_mli_open_base="$(extract_json_field "$base_policy_json" baseline mli_open_base)"
 baseline_ml_base_stdlib_shadow="$(extract_json_field "$base_policy_json" baseline ml_base_stdlib_shadow)"
+baseline_bin_ml_base_stdlib_shadow="$(extract_json_field "$base_policy_json" baseline bin_ml_base_stdlib_shadow)"
 rm -f "$base_policy_json"
 
 lib_failwith="$(count_pattern lib 'failwith')"
@@ -328,6 +330,7 @@ if [ "$FAIL_ON_LIB_REGRESSION" -eq 1 ]; then
   [ "$lib_obj_magic" -gt "$baseline_lib_obj_magic" ] && regressions+=("lib_obj_magic ${baseline_lib_obj_magic}->${lib_obj_magic}")
   [ "$mli_open_base" -gt "$baseline_mli_open_base" ] && regressions+=("mli_open_base ${baseline_mli_open_base}->${mli_open_base}")
   [ "$ml_base_stdlib_shadow" -gt "$baseline_ml_base_stdlib_shadow" ] && regressions+=("ml_base_stdlib_shadow ${baseline_ml_base_stdlib_shadow}->${ml_base_stdlib_shadow}")
+  [ "$bin_ml_base_stdlib_shadow" -gt "$baseline_bin_ml_base_stdlib_shadow" ] && regressions+=("bin_ml_base_stdlib_shadow ${baseline_bin_ml_base_stdlib_shadow}->${bin_ml_base_stdlib_shadow}")
 
   if [ "${#regressions[@]}" -eq 0 ]; then
     ratchet_status="pass"
@@ -369,7 +372,7 @@ echo "Baseline: ${baseline_label}"
 echo "Anti-fake: status=${anti_fake_label} good=${anti_fake_good} suspect=${anti_fake_suspect} fake=${anti_fake_fake} total=${anti_fake_total}"
 echo "Unsafe patterns (lib):  failwith=${lib_failwith} list_hd=${lib_list_hd} list_tl=${lib_list_tl} option_get=${lib_option_get} obj_magic=${lib_obj_magic}"
 echo "Unsafe patterns (test): failwith=${test_failwith} list_hd=${test_list_hd} list_tl=${test_list_tl} option_get=${test_option_get} obj_magic=${test_obj_magic}"
-echo "Base policy: mli_open_base=${mli_open_base} ml_base_stdlib_shadow=${ml_base_stdlib_shadow}"
+echo "Base policy: mli_open_base=${mli_open_base} ml_base_stdlib_shadow=${ml_base_stdlib_shadow} bin_ml_base_stdlib_shadow=${bin_ml_base_stdlib_shadow}"
 echo "ML line cap: manual=${manual_ml_over_500} excepted=${excepted_ml_over_500} lib=${lib_ml_over_500} bin=${bin_ml_over_500} test=${test_ml_over_500} examples=${examples_ml_over_500}"
 echo "ML line cap changed: ${ml_line_cap_changed_status} (${ml_line_cap_changed_message})"
 echo "ML line cap ratchet: ${ml_line_cap_status} (${ml_line_cap_message})"
@@ -409,7 +412,8 @@ json_payload="$(cat <<EOF
     "test_ml_over_500": ${test_ml_over_500},
     "examples_ml_over_500": ${examples_ml_over_500},
     "mli_open_base": ${mli_open_base},
-    "ml_base_stdlib_shadow": ${ml_base_stdlib_shadow}
+    "ml_base_stdlib_shadow": ${ml_base_stdlib_shadow},
+    "bin_ml_base_stdlib_shadow": ${bin_ml_base_stdlib_shadow}
   },
   "ml_line_cap": {
     "status": "${ml_line_cap_status}",
@@ -428,7 +432,8 @@ json_payload="$(cat <<EOF
       "lib_option_get": ${baseline_lib_option_get},
       "lib_obj_magic": ${baseline_lib_obj_magic},
       "mli_open_base": ${baseline_mli_open_base},
-      "ml_base_stdlib_shadow": ${baseline_ml_base_stdlib_shadow}
+      "ml_base_stdlib_shadow": ${baseline_ml_base_stdlib_shadow},
+      "bin_ml_base_stdlib_shadow": ${baseline_bin_ml_base_stdlib_shadow}
     }
   },
   "ratchet": {
@@ -471,7 +476,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "| examples | $examples_ml_over_500 | n/a |"
     echo ""
     echo "- Anti-fake: \`$anti_fake_label\` (good=$anti_fake_good suspect=$anti_fake_suspect fake=$anti_fake_fake total=$anti_fake_total)"
-    echo "- Base policy: mli_open_base=\`$mli_open_base\` ml_base_stdlib_shadow=\`$ml_base_stdlib_shadow\`"
+    echo "- Base policy: mli_open_base=\`$mli_open_base\` ml_base_stdlib_shadow=\`$ml_base_stdlib_shadow\` bin_ml_base_stdlib_shadow=\`$bin_ml_base_stdlib_shadow\`"
     echo "- ML line cap changed: \`$ml_line_cap_changed_status\` ($ml_line_cap_changed_message)"
     echo "- ML line cap ratchet: \`$ml_line_cap_status\` ($ml_line_cap_message)"
     echo "- Ratchet: \`$ratchet_status\` ($ratchet_message)"


### PR DESCRIPTION
## Summary
- Ratchet the current zero Base policy counts into `.ci/health-baseline.json` so future `open Base` interface/shadow regressions fail immediately.
- Add `bin_ml_base_stdlib_shadow` to `base-policy-audit.sh` and `health_snapshot.sh` so the Base purge gate covers the `bin/` portion of task-125.
- Document the 2026-05-05 zero-counter ratchet in `docs/BASE-POLICY.md`.

## Validation
- git diff --check
- bash -n scripts/base-policy-audit.sh
- bash -n scripts/health_snapshot.sh
- jq empty .ci/health-baseline.json
- bash scripts/base-policy-audit.sh
- bash scripts/base-policy-audit.sh --fail-on-regression
- bash scripts/base-policy-audit.sh --baseline-ref origin/main --fail-on-regression
- bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression --json-out /tmp/health-base-ratchet-pr.json

Task: task-125