### PR TITLE
fix(keeper): close cancel-race in keeper_turn_slot record_holder vs flag

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -611,8 +611,15 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
       (try
         Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
           Eio.Semaphore.acquire sem);
-        record_holder ~label ~keeper_name
-          ~acquired_at:(Time_compat.now ());
+        (* Cancel-race fix: do NOT [record_holder] here. The caller
+           records the holder AFTER setting the matching [acquired_*]
+           flag in [slot_state]. If a fiber is cancelled between
+           [Eio.Semaphore.acquire] returning and the caller's flag
+           assignment, the release path stays consistent — flag=false
+           means semaphore is treated as not-yet-held and the previous
+           record_holder-here pattern would have left a stale entry
+           visible in [holder_table] (the 16x1500s "ghost holders"
+           symptom of 2026-05-05). *)
         Ok ()
       with Eio.Time.Timeout ->
         (* Routine, not WARN: the keeper-specific heartbeat loop already
@@ -650,7 +657,8 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
         "semaphore_wait: no Eio clock available — %s acquire will be unbounded (environment drift?)"
         label;
       Eio.Semaphore.acquire sem;
-      record_holder ~label ~keeper_name ~acquired_at:(Time_compat.now ());
+      (* Cancel-race fix: see comment in the with-clock branch above.
+         record_holder is the caller's responsibility, after flag set. *)
       Ok ()
   in
   Fun.protect
@@ -688,7 +696,17 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
             with
             | Error _ as e -> e
             | Ok () ->
+              (* Cancel-race fix (see acquire_bounded comment): set the
+                 [acquired_*] flag BEFORE [record_holder]. The flag is a
+                 plain ref assignment (no cancel point); record_holder
+                 acquires a [~protect:true] mutex (cancel-safe within
+                 the lock). If a cancel arrives between [acquire] and
+                 here the semaphore is reported as not-held and never
+                 leaks; if it arrives after the flag set, release path
+                 calls drop_holder (no-op when no entry exists). *)
               slot_state.acquired_autonomous := true;
+              record_holder ~label:"autonomous" ~keeper_name
+                ~acquired_at:(Time_compat.now ());
               drop_autonomous_waiter ~ticket;
               slot_state.autonomous_ticket := None;
               Ok ()
@@ -709,7 +727,10 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
             with
             | Error _ as e -> e
             | Ok () ->
+              (* Cancel-race fix: flag THEN record_holder. *)
               slot_state.acquired_reactive := true;
+              record_holder ~label:"reactive" ~keeper_name
+                ~acquired_at:(Time_compat.now ());
               Ok ()
         in
         match reactive_result with
@@ -718,7 +739,10 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
         match acquire_bounded ~label:"turn" ~phase:Turn_slot turn_semaphore with
         | Error _ as e -> e
         | Ok () ->
+          (* Cancel-race fix: flag THEN record_holder. *)
           slot_state.acquired_turn := true;
+          record_holder ~label:"turn" ~keeper_name
+            ~acquired_at:(Time_compat.now ());
           let semaphore_wait_ms =
             int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
           Ok (f ~semaphore_wait_ms))


### PR DESCRIPTION
## Problem

Production observation 2026-05-05 12:00 KST:

```
phase=reactive_slot (cascade=tier_fast queue_depth=0 autonomous_available=18 reactive_available=0 turn_available=8)
holders=[verifier/1501s, jobsian_purist/1499s, taskmaster/1498s, scholar/1498s, ramarama/1497s,
         velvet-hammer/1495s, tech_glutton/1472s, sangsu/1470s, qa-king/1469s, imseonghan/1468s,
         glm-coding-plan/1462s, nick0cave/1259s, executor/1228s, analyst/1228s, issue_king/1228s,
         masc-improver/1228s]
keeper:* skipping turn (skipped: semaphore wait > 180s)
```

16 keeper × 25분 동안 reactive_slot에 묶인 것처럼 보였으나, 실제로는 `Eio.Semaphore` permit이 leak되고 `holder_table`에 stale entry가 남은 ghost 상태.

## Root cause

`lib/keeper/keeper_turn_slot.ml`의 `acquire_bounded`가 `record_holder`를 `Eio.Semaphore.acquire` 직후 호출하고, caller가 그 다음 라인에서 `slot_state.acquired_* := true` 플래그를 set하는 분리 구조였습니다.

`record_holder`는 `Eio.Mutex.use_rw`로 진입하므로 mutex acquire 시점이 cancel point. 두 가지 cancel 시나리오가 모두 leak으로 이어집니다.

**시나리오 A — record_holder mutex acquire 직전 cancel:**
1. `Eio.Semaphore.acquire sem` 통과 → counter -1 (permit 점유)
2. `record_holder`의 mutex acquire 시도 → `Eio.Cancel.Cancelled` raise → holder_table 진입 X
3. caller가 line 712 `slot_state.acquired_reactive := true`까지 도달 못함 → flag = false

`Fun.protect ~finally`로 호출되는 `release_keeper_turn_slot` (line 387-414)는 `if !(state.acquired_reactive) then ...` 가드. flag = false라 `drop_holder`도 `Eio.Semaphore.release`도 skip → **semaphore permit 영구 leak** + 다음 acquire 시도 시 같은 fiber가 다시 시도하면 누적됨.

**시나리오 B — record_holder 통과 후 flag := true 사이 cancel:**
1. `Eio.Semaphore.acquire` ✅ counter -1
2. `record_holder` 통과 (mutex `~protect:true`라 진입 후 cancel은 보호) → holder_table에 stale entry
3. `acquired_* := true` 직전 cancel → flag = false
→ release path skip → **semaphore leak + holder_table stale entry**

production 로그의 "16 keepers × 1500s holders" 패턴은 시나리오 B 다중 누적.

## Fix

`acquire_bounded` 내부의 `record_holder` 호출을 제거하고, 3개 caller (autonomous / reactive / turn)가 각자 flag set **직후** record_holder를 호출하도록 옮겼습니다.

```ocaml
| Ok () ->
  slot_state.acquired_reactive := true;            (* ref assign — no cancel point *)
  record_holder ~label:"reactive" ~keeper_name     (* mutex ~protect:true *)
    ~acquired_at:(Time_compat.now ());
  Ok ()
```

Cancel race 분석:
- `acquire OK` → `flag := true`: ref assignment은 yield 없음 → cancel-safe.
- `flag set` → `record_holder` 사이 cancel: release path가 `drop_holder` 호출 (entry 없으면 `Hashtbl.remove`는 no-op) + `Eio.Semaphore.release` ✅.
- `record_holder` 진입 후 cancel: `~protect:true`라 `Hashtbl.replace` 완료 보장 → release path가 정상 cleanup.

## Variations

3 acquire site 모두 같은 패턴 → 한 fix shape로 통일 적용:
- Autonomous slot (line 690-697): flag + record_holder + drop_autonomous_waiter + ticket clear
- Reactive slot (line 712-715): flag + record_holder
- Turn slot (line 723-726): flag + record_holder

`acquire_bounded` 내부의 with-clock branch (line 614)와 no-clock branch (line 653) 둘 다에서 record_holder 호출 제거.

## Plan §3.1 reclassification

`~/me/planning/claude-plans/users-dancer-downloads-deep-audit-dashb-encapsulated-galaxy.md`의 §3.1은 `admission_queue.with_permit`을 "B (intentional passthrough)"로 분류. 본 fix는 그 분류가 release path만 보고 caller-side acquire race를 missed한 점을 드러냅니다.

따라서 §3.1을 **A (cancel-unsafe critical bookkeeping race)**로 재분류해야 합니다. `docs/audit-responses/2026-05-05-dashboard-heuristic.md` follow-up PR에 정식 반영 예정.

## Test plan

- [x] `dune build` 통과 (이번 PR diff 27+/3-, 단일 파일).
- [ ] 회귀 테스트: simulated `Eio.Cancel.cancel` during acquire — follow-up PR에서 추가. deterministic 재현이 까다로워 별도 검증.
- [ ] production 배포 후 dashboard에서 "16 keepers × 1500s holder" 패턴 사라짐 확인.
- [ ] 24h 관찰 후 `metric_keeper_semaphore_wait_timeout` 신규 발생 0건 확인.

## Rollback plan

Single-file revert (`lib/keeper/keeper_turn_slot.ml`, 5 hunks). 동작 영향 평가: `record_holder`가 호출되는 시점이 acquire 직후 → flag set 직후로 옮겨졌을 뿐, 동일 조건에 동일 entry를 holder_table에 추가하므로 정상 path 위험 0.

## RFC-WAIVED

Critical production fix; agent_delegation 영역 (lib/keeper/credential_\*, keeper_gh_\*, host_config_\*) 변경 없음. RFC trail은 follow-up audit-responses 문서에 위치.

## Related

- IDE Plane v1 분배 (#13211, #13197-#13201): 본 fix 머지 후 production 재기동 시 16 keeper 깨어나며 자율 picker 정상 작동.
- Plan §3.1 reclassification: 별도 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
