### PR TITLE
fix(keeper): keep repair backlog claimable

### DIFF
--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -31,15 +31,38 @@ let is_legacy_auto_cycle_do_not_reclaim_reason reason =
   parse_suffix " releases" || parse_suffix " cancellations"
 ;;
 
+let is_routing_handoff_do_not_reclaim_reason reason =
+  let lower = String.trim reason |> String.lowercase_ascii in
+  let markers =
+    [ "auto_goal_fallback"
+    ; "releasing for keeper"
+    ; "release for keeper"
+    ; "executor pickup"
+    ; "needs executor"
+    ; "preset blocks code-write"
+    ; "sandbox-isolated keeper"
+    ; "no access to masc-mcp source"
+    ; "routing warning"
+    ; "tool-surface trap"
+    ]
+  in
+  List.exists
+    (fun marker -> String_util.contains_substring lower marker)
+    markers
+;;
+
 let do_not_reclaim_reason_blocks_claim = function
   | Some reason when is_legacy_auto_cycle_do_not_reclaim_reason reason -> None
+  | Some reason when is_routing_handoff_do_not_reclaim_reason reason -> None
   | Some _ as reason -> reason
   | None -> None
 ;;
 
 let clear_soft_do_not_reclaim_reason (task : Masc_domain.task) =
   match task.do_not_reclaim_reason with
-  | Some reason when is_legacy_auto_cycle_do_not_reclaim_reason reason ->
+  | Some reason
+    when is_legacy_auto_cycle_do_not_reclaim_reason reason
+         || is_routing_handoff_do_not_reclaim_reason reason ->
     { task with do_not_reclaim_reason = None }
   | Some _ | None -> task
 ;;
@@ -314,11 +337,8 @@ let release_handoff_texts handoff_context =
 
 let release_hard_stop_markers =
   [ "do not reclaim"
-  ; "scope mismatch"
-  ; "wrong keeper"
   ; "not found"
   ; "phantom"
-  ; "repo access"
   ; "repo unavailable"
   ; "already done"
   ; "already completed"

--- a/lib/coord/coord_task_claim.mli
+++ b/lib/coord/coord_task_claim.mli
@@ -14,10 +14,11 @@ val is_legacy_auto_cycle_do_not_reclaim_reason : string -> bool
 val do_not_reclaim_reason_blocks_claim : string option -> string option
 (** Returns [Some reason] only when [reason] is an explicit hard-stop that
     should still block claiming. Legacy automatic cycle reasons such as
-    ["auto: 3 releases"] are treated as soft and return [None]. *)
+    ["auto: 3 releases"] and routing handoff reasons such as tool-surface or
+    sandbox mismatch are treated as soft and return [None]. *)
 
 val clear_soft_do_not_reclaim_reason : Masc_domain.task -> Masc_domain.task
-(** Clears legacy automatic cycle block reasons before a task is claimed. *)
+(** Clears soft cycle/routing reasons before a task is claimed. *)
 
 (** {1 Task claiming} *)
 

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -74,8 +74,8 @@ let latest_verification_status_by_task config =
 let verification_blocks_claim latest_status_by_task (task : Masc_domain.task) =
   match Hashtbl.find_opt latest_status_by_task task.id with
   | Some (_, `Pending)
-  | Some (_, `Assigned)
-  | Some (_, `Rejected) -> true
+  | Some (_, `Assigned) -> true
+  | Some (_, `Rejected) -> false
   | Some (_, `Passed)
   | None -> false
 

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -532,6 +532,43 @@ let test_claim_next_uses_legacy_auto_cycle_as_fallback () =
       Alcotest.fail "expected one fallback-claimable task"
     | Coord.Claim_next_error msg -> Alcotest.fail msg)
 
+let test_claim_next_uses_routing_handoff_as_fallback () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Coord.add_task config ~title:"Rerouted coding task" ~priority:1
+        ~description:""
+    in
+    let backlog = Coord.read_backlog config in
+    let tasks =
+      List.map
+        (fun (t : Masc_domain.task) ->
+           if String.equal t.id "task-001"
+           then
+             { t with
+               cycle_count = 1
+             ; do_not_reclaim_reason =
+                 Some
+                   "Auto-claimed via auto_goal_fallback; sandbox-isolated \
+                    keeper has no access to masc-mcp source. Releasing for \
+                    keeper with repo access."
+             }
+           else t)
+        backlog.tasks
+    in
+    write_tasks config tasks;
+    match Coord.claim_next_r config ~agent_name:claude () with
+    | Coord.Claim_next_claimed { task_id; _ } ->
+      Alcotest.(check string) "fallback claim" "task-001" task_id;
+      let task = task_by_id config task_id in
+      Alcotest.(check (option string)) "routing handoff cleared" None
+        task.do_not_reclaim_reason
+    | Coord.Claim_next_no_eligible _ ->
+      Alcotest.fail "routing handoff reason should be fallback claimable"
+    | Coord.Claim_next_no_unclaimed ->
+      Alcotest.fail "expected one fallback-claimable task"
+    | Coord.Claim_next_error msg -> Alcotest.fail msg)
+
 let test_claim_next_prefers_unblocked_over_legacy_auto_cycle () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
@@ -589,6 +626,39 @@ let test_release_cycles_do_not_create_auto_do_not_reclaim () =
     | Error e ->
       Alcotest.fail
         ("retryable task should remain claimable: " ^ Masc_domain.masc_error_to_string e))
+
+let test_claim_next_allows_failed_verification_repair () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Coord.add_task config ~title:"Repair rejected task" ~priority:1
+        ~description:""
+    in
+    let req =
+      match
+        Verification.create_request ~base_path:config.Coord.base_path
+          ~task_id:"task-001" ~output:(`Assoc [])
+          ~criteria:[ Verification.Custom "tests pass" ] ~worker:"worker" ()
+      with
+      | Ok req -> req
+      | Error msg -> Alcotest.fail ("create verification failed: " ^ msg)
+    in
+    (match
+       Verification.submit_verdict ~base_path:config.Coord.base_path
+         ~req_id:req.id ~verifier:"verifier-agent"
+         ~verdict:(Verification.Fail "missing evidence")
+     with
+     | Ok _ -> ()
+     | Error msg -> Alcotest.fail ("submit verdict failed: " ^ msg));
+    match Coord.claim_next_r config ~agent_name:claude () with
+    | Coord.Claim_next_claimed { task_id; _ } ->
+      Alcotest.(check string) "rejected task is repair-claimable" "task-001"
+        task_id
+    | Coord.Claim_next_no_eligible _ ->
+      Alcotest.fail "failed verification should not permanently block repair"
+    | Coord.Claim_next_no_unclaimed ->
+      Alcotest.fail "expected failed verification task to remain in backlog"
+    | Coord.Claim_next_error msg -> Alcotest.fail msg)
 
 (* ============================================================ *)
 (* Update Priority Tests                                         *)
@@ -1395,10 +1465,14 @@ let () =
         test_release_hard_stop_blocks_direct_reclaim;
       Alcotest.test_case "legacy auto-cycle block is fallback claimable" `Quick
         test_claim_next_uses_legacy_auto_cycle_as_fallback;
+      Alcotest.test_case "routing handoff block is fallback claimable" `Quick
+        test_claim_next_uses_routing_handoff_as_fallback;
       Alcotest.test_case "unblocked tasks beat legacy auto-cycle fallback" `Quick
         test_claim_next_prefers_unblocked_over_legacy_auto_cycle;
       Alcotest.test_case "release cycles do not create auto block" `Quick
         test_release_cycles_do_not_create_auto_do_not_reclaim;
+      Alcotest.test_case "failed verification stays repair-claimable" `Quick
+        test_claim_next_allows_failed_verification_repair;
     ];
 
     (* === Update Priority === *)


### PR DESCRIPTION
## Summary
- let failed verification return TODO tasks to the claim pool for repair instead of permanently blocking them
- treat routing and handoff do_not_reclaim_reason text as a soft fallback claim block, while keeping true hard-stop markers blocked
- add regressions for routing handoff fallback and failed-verification repair claims

## Root Cause
Live keeper state under /Users/dancer/me showed 5 TODO tasks but claimable_task_count=0. Auto-goal fallback was already clearing effective_goal_ids, but the scheduler excluded every candidate below that layer: three tasks had latest verification=fail and two tasks carried routing handoff do_not_reclaim_reason text.

## Operator Impact
This changes the deadlock from keepers reacting to scope-lock board posts into repairable TODO work becoming claimable again. Hard-stop releases such as explicit do-not-reclaim, phantom/not-found, repo-unavailable, already-completed, and invalid artifact cases still block claims.

## Validation
- `env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-repair-claim-build scripts/dune-local.sh build test/test_room_coverage.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false /private/tmp/masc-repair-claim-build/default/test/test_room_coverage.exe test claim_next 14,17`

## Local Note
The final rebase onto current main was clean. A later local pin check was blocked by another worktree rewriting the shared opam switch back to agent_sdk 0.190.7; the focused build and regression tests above passed after restoring the repo pin, and CI should be the clean validation surface.