### PR TITLE
fix(workspace-routes): clamp limit= overflow to max (post-#13191)

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -130,8 +130,44 @@ let max_tree_node_limit = 2000
 
 let tree_node_limit_of_query = function
   | Some raw -> (
-      try max 1 (min max_tree_node_limit (int_of_string raw))
-      with _ -> default_tree_node_limit)
+      match int_of_string_opt raw with
+      | Some n -> max 1 (min max_tree_node_limit n)
+      | None ->
+          (* Issue #13191 follow-up: a request like
+             [?limit=99999999999999999999] makes [int_of_string] raise
+             on overflow, which previously fell back to
+             [default_tree_node_limit] (750) instead of clamping to
+             [max_tree_node_limit] (2000).  Clients asking for a "very
+             large" limit therefore unexpectedly got fewer nodes than
+             a smaller-but-valid request would.  When the raw value is
+             purely numeric (with an optional sign / underscores /
+             leading zeros), treat the parse failure as overflow and
+             clamp to the documented maximum.  Non-numeric junk still
+             falls back to the default. *)
+          let classify_overflow s =
+            let len = String.length s in
+            if len = 0 then `Junk
+            else
+              let is_negative = s.[0] = '-' in
+              let start =
+                if s.[0] = '-' || s.[0] = '+' then 1 else 0
+              in
+              if start >= len then `Junk
+              else
+                let ok = ref true in
+                for i = start to len - 1 do
+                  let c = s.[i] in
+                  if not ((c >= '0' && c <= '9') || c = '_') then
+                    ok := false
+                done;
+                if !ok then
+                  if is_negative then `NegativeOverflow else `PositiveOverflow
+                else `Junk
+          in
+          (match classify_overflow raw with
+           | `PositiveOverflow -> max_tree_node_limit
+           | `NegativeOverflow -> 1
+           | `Junk -> default_tree_node_limit))
   | None -> default_tree_node_limit
 
 let safe_path base requested =

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -128,46 +128,63 @@ let excluded_dirs =
 let default_tree_node_limit = 750
 let max_tree_node_limit = 2000
 
+(* Strict numeric validator.  OCaml's [int_of_string] accepts forms
+   that we want to reject ("1_" -> 1, "1__2" -> 12) because they let
+   malformed inputs request meaningful tree sizes.  This validator
+   mirrors what an operator would reasonably expect of a [limit=]
+   query parameter: optional sign, at least one decimal digit,
+   underscores only between digits.  When this returns [false] we
+   fall back to the default regardless of what [int_of_string_opt]
+   would have produced. *)
+let is_strict_decimal_int_string s =
+  let len = String.length s in
+  if len = 0 then false
+  else
+    let start = if s.[0] = '-' || s.[0] = '+' then 1 else 0 in
+    if start >= len then false
+    else if Char.equal s.[start] '_' || Char.equal s.[len - 1] '_' then false
+    else
+      let ok = ref true in
+      let has_digit = ref false in
+      let prev_was_underscore = ref false in
+      for i = start to len - 1 do
+        let c = s.[i] in
+        if c >= '0' && c <= '9' then begin
+          has_digit := true;
+          prev_was_underscore := false
+        end else if c = '_' then begin
+          if !prev_was_underscore then ok := false;
+          prev_was_underscore := true
+        end else begin
+          ok := false;
+          prev_was_underscore := false
+        end
+      done;
+      !ok && !has_digit
+
 let tree_node_limit_of_query = function
-  | Some raw -> (
-      match int_of_string_opt raw with
-      | Some n -> max 1 (min max_tree_node_limit n)
-      | None ->
-          (* Issue #13191 follow-up: a request like
-             [?limit=99999999999999999999] makes [int_of_string] raise
-             on overflow, which previously fell back to
-             [default_tree_node_limit] (750) instead of clamping to
-             [max_tree_node_limit] (2000).  Clients asking for a "very
-             large" limit therefore unexpectedly got fewer nodes than
-             a smaller-but-valid request would.  When the raw value is
-             purely numeric (with an optional sign / underscores /
-             leading zeros), treat the parse failure as overflow and
-             clamp to the documented maximum.  Non-numeric junk still
-             falls back to the default. *)
-          let classify_overflow s =
-            let len = String.length s in
-            if len = 0 then `Junk
-            else
-              let is_negative = s.[0] = '-' in
-              let start =
-                if s.[0] = '-' || s.[0] = '+' then 1 else 0
-              in
-              if start >= len then `Junk
-              else
-                let ok = ref true in
-                for i = start to len - 1 do
-                  let c = s.[i] in
-                  if not ((c >= '0' && c <= '9') || c = '_') then
-                    ok := false
-                done;
-                if !ok then
-                  if is_negative then `NegativeOverflow else `PositiveOverflow
-                else `Junk
-          in
-          (match classify_overflow raw with
-           | `PositiveOverflow -> max_tree_node_limit
-           | `NegativeOverflow -> 1
-           | `Junk -> default_tree_node_limit))
+  | Some raw ->
+      (* Reject malformed numerics up front so that "1_" / "1__2" /
+         "_1" are treated as junk and fall back to default, even
+         though [int_of_string_opt] would otherwise accept them. *)
+      if not (is_strict_decimal_int_string raw) then default_tree_node_limit
+      else (
+        match int_of_string_opt raw with
+        | Some n -> max 1 (min max_tree_node_limit n)
+        | None ->
+            (* Issue #13191 follow-up: parse failure on a strict
+               numeric input means the value overflowed [int].  A
+               request like [?limit=99999999999999999999] used to fall
+               back to [default_tree_node_limit] (750) instead of
+               clamping to [max_tree_node_limit] (2000), so clients
+               asking for "very large" got fewer nodes than a
+               smaller-but-valid request would.  Positive overflow
+               clamps to the maximum; negative overflow mirrors the
+               existing in-range "clamps low" behaviour and pins to 1. *)
+            let is_negative =
+              String.length raw > 0 && Char.equal raw.[0] '-'
+            in
+            if is_negative then 1 else max_tree_node_limit)
   | None -> default_tree_node_limit
 
 let safe_path base requested =

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -303,6 +303,30 @@ let test_tree_node_limit_clamps_high () =
 let test_tree_node_limit_accepts_valid () =
   Alcotest.(check int) "valid" 42 (W.tree_node_limit_of_query (Some "42"))
 
+(* Issue #13191 follow-up: numeric overflow on [int_of_string] used to
+   fall back to the default (750) instead of clamping to the documented
+   maximum (2000), so a client asking for "very large" got fewer nodes
+   than asking for 9000. *)
+let test_tree_node_limit_overflow_clamps_to_max () =
+  Alcotest.(check int) "huge numeric input clamps to max"
+    2000
+    (W.tree_node_limit_of_query (Some "99999999999999999999"))
+
+let test_tree_node_limit_overflow_with_underscores () =
+  Alcotest.(check int) "huge underscore-separated digits clamp to max"
+    2000
+    (W.tree_node_limit_of_query (Some "99_999_999_999_999_999_999"))
+
+let test_tree_node_limit_negative_overflow_clamps_low () =
+  Alcotest.(check int) "huge negative value clamps to 1"
+    1
+    (W.tree_node_limit_of_query (Some "-99999999999999999999"))
+
+let test_tree_node_limit_non_numeric_still_default () =
+  Alcotest.(check int) "non-numeric junk falls back to default"
+    750
+    (W.tree_node_limit_of_query (Some "9000abc"))
+
 (* ─── valid_git_ref (option-injection guard) ────────────────────── *)
 
 let test_valid_ref_main () =
@@ -394,6 +418,10 @@ let () =
         ; Alcotest.test_case "limit clamps low" `Quick test_tree_node_limit_clamps_low
         ; Alcotest.test_case "limit clamps high" `Quick test_tree_node_limit_clamps_high
         ; Alcotest.test_case "limit accepts valid" `Quick test_tree_node_limit_accepts_valid
+        ; Alcotest.test_case "limit overflow clamps to max" `Quick test_tree_node_limit_overflow_clamps_to_max
+        ; Alcotest.test_case "limit overflow with underscores clamps to max" `Quick test_tree_node_limit_overflow_with_underscores
+        ; Alcotest.test_case "limit negative overflow clamps to 1" `Quick test_tree_node_limit_negative_overflow_clamps_low
+        ; Alcotest.test_case "limit non-numeric falls back to default" `Quick test_tree_node_limit_non_numeric_still_default
         ] )
     ; ( "valid_git_ref"
       , [ Alcotest.test_case "main"              `Quick test_valid_ref_main

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -327,6 +327,35 @@ let test_tree_node_limit_non_numeric_still_default () =
     750
     (W.tree_node_limit_of_query (Some "9000abc"))
 
+(* Reviewer #13222: malformed underscore forms must classify as junk and
+   fall back to the default, not be promoted to overflow.  These mirror
+   OCaml's int_of_string rejection: underscores are only valid between
+   digits, never leading/trailing/adjacent. *)
+let test_tree_node_limit_lone_underscore_is_junk () =
+  Alcotest.(check int) "'_' falls back to default"
+    750
+    (W.tree_node_limit_of_query (Some "_"))
+
+let test_tree_node_limit_trailing_underscore_is_junk () =
+  Alcotest.(check int) "'1_' falls back to default"
+    750
+    (W.tree_node_limit_of_query (Some "1_"))
+
+let test_tree_node_limit_leading_underscore_is_junk () =
+  Alcotest.(check int) "'_1' falls back to default"
+    750
+    (W.tree_node_limit_of_query (Some "_1"))
+
+let test_tree_node_limit_double_underscore_is_junk () =
+  Alcotest.(check int) "'1__2' falls back to default"
+    750
+    (W.tree_node_limit_of_query (Some "1__2"))
+
+let test_tree_node_limit_signed_lone_underscore_is_junk () =
+  Alcotest.(check int) "'+_' falls back to default"
+    750
+    (W.tree_node_limit_of_query (Some "+_"))
+
 (* ─── valid_git_ref (option-injection guard) ────────────────────── *)
 
 let test_valid_ref_main () =
@@ -422,6 +451,11 @@ let () =
         ; Alcotest.test_case "limit overflow with underscores clamps to max" `Quick test_tree_node_limit_overflow_with_underscores
         ; Alcotest.test_case "limit negative overflow clamps to 1" `Quick test_tree_node_limit_negative_overflow_clamps_low
         ; Alcotest.test_case "limit non-numeric falls back to default" `Quick test_tree_node_limit_non_numeric_still_default
+        ; Alcotest.test_case "limit lone underscore is junk" `Quick test_tree_node_limit_lone_underscore_is_junk
+        ; Alcotest.test_case "limit trailing underscore is junk" `Quick test_tree_node_limit_trailing_underscore_is_junk
+        ; Alcotest.test_case "limit leading underscore is junk" `Quick test_tree_node_limit_leading_underscore_is_junk
+        ; Alcotest.test_case "limit double underscore is junk" `Quick test_tree_node_limit_double_underscore_is_junk
+        ; Alcotest.test_case "limit signed lone underscore is junk" `Quick test_tree_node_limit_signed_lone_underscore_is_junk
         ] )
     ; ( "valid_git_ref"
       , [ Alcotest.test_case "main"              `Quick test_valid_ref_main


### PR DESCRIPTION
Follow-up to merged #13191. Reviewer flagged that ?limit=99999999999999999999 raises in int_of_string and falls back to 750 default, instead of clamping to the documented max (2000). Fix: int_of_string_opt + sign-aware overflow classifier — positive overflow → max(2000), negative overflow → 1 (mirror existing 'clamps low'), non-numeric junk → default(750). 4 regression tests added; 46/46 OK. Closes both review threads on #13191.