### PR TITLE
fix(dashboard): surface admission ownership and strict test indexing

### DIFF
--- a/dashboard/src/components/flow-control/flow-control-panel.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.test.ts
@@ -2,6 +2,17 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+type MockOperatorSnapshot = {
+  admission_queue?: {
+    mode: string
+    throttle_owner: string
+    max_concurrent: number
+    active: number
+    available: number
+    queue_depth: number
+  } | null
+} | null
+
 const {
   fetchPauseStatus,
   pauseRoom,
@@ -13,6 +24,7 @@ const {
   maintenanceResult,
   maintenanceLoading,
   shellAuthSummary,
+  operatorSnapshot,
 } = vi.hoisted(() => ({
   fetchPauseStatus: vi.fn().mockResolvedValue(undefined),
   pauseRoom: vi.fn().mockResolvedValue(undefined),
@@ -24,6 +36,7 @@ const {
   maintenanceResult: { value: null as string | null },
   maintenanceLoading: { value: false },
   shellAuthSummary: { value: null },
+  operatorSnapshot: { value: null as MockOperatorSnapshot },
 }))
 
 vi.mock('./flow-control-state', () => ({
@@ -40,6 +53,10 @@ vi.mock('./flow-control-state', () => ({
 
 vi.mock('../../store', () => ({
   shellAuthSummary,
+}))
+
+vi.mock('../../operator-store', () => ({
+  operatorSnapshot,
 }))
 
 vi.mock('../../lib/dashboard-auth-access', () => ({
@@ -69,6 +86,7 @@ describe('FlowControlPanel', () => {
     maintenanceResult.value = null
     maintenanceLoading.value = false
     shellAuthSummary.value = null
+    operatorSnapshot.value = null
   })
 
   afterEach(() => {
@@ -85,5 +103,27 @@ describe('FlowControlPanel', () => {
     expect(container.textContent).toContain('Pause')
     expect(container.textContent).toContain('Resume')
     expect(container.textContent).not.toContain('Refresh')
+  })
+
+  it('shows admission queue mode and throttle owner when present', async () => {
+    operatorSnapshot.value = {
+      admission_queue: {
+        mode: 'passthrough',
+        throttle_owner: 'oas_cascade',
+        max_concurrent: 3,
+        active: 1,
+        available: 2,
+        queue_depth: 0,
+      },
+    }
+
+    render(html`<${FlowControlPanel} />`, container)
+    await flushUi()
+
+    const status = container.querySelector('[data-testid="flow-admission-mode"]')
+    expect(status).not.toBeNull()
+    expect(status!.textContent).toContain('passthrough')
+    expect(status!.textContent).toContain('OAS cascade')
+    expect(status!.textContent).toContain('1/3')
   })
 })

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -5,6 +5,7 @@ import { SurfaceCard } from '../common/card'
 import { ActionButton } from '../common/button'
 import { CountBadge } from '../common/badge'
 import { shellAuthSummary } from '../../store'
+import { operatorSnapshot } from '../../operator-store'
 import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
 import {
   flowState, flowLoading, fetchPauseStatus, pauseRoom, resumeRoom,
@@ -33,12 +34,24 @@ export function FlowControlPanel() {
   const isRunning = state === 'running'
   const isInitializing = state === 'initializing'
   const mutationAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+  const admission = operatorSnapshot.value?.admission_queue ?? null
+  const admissionMode = admission?.mode ?? 'unknown'
+  const admissionOwner = admission?.throttle_owner === 'oas_cascade'
+    ? 'OAS cascade'
+    : admission?.throttle_owner ?? 'unknown'
   return html`
     <${SurfaceCard} variant="compact" class="mb-4">
       <div class="flex items-center gap-3 mb-3">
         <h3 class="text-sm text-[var(--color-fg-secondary)] font-medium">Flow Control</h3>
         <${CountBadge} tone=${stateTone(state)}>${stateLabel(state)}<//>
       </div>
+      ${admission ? html`
+        <div class="mb-3 flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]" data-testid="flow-admission-mode">
+          <${CountBadge} tone=${admissionMode === 'passthrough' ? 'default' : 'warn'}>${admissionMode}<//>
+          <span>Throttle: ${admissionOwner}</span>
+          <span>${admission.active}/${admission.max_concurrent} observed inflight</span>
+        </div>
+      ` : null}
       ${mutationAccess.allowed ? null : html`
         <p class="mb-3 text-2xs text-[var(--color-status-warn)]">
           Control blocked: ${mutationAccess.reason ?? 'worker role is required.'}

--- a/dashboard/src/components/ide/ide-presence-strip.test.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.test.ts
@@ -57,8 +57,8 @@ describe('parseWorktreeSSE', () => {
 
     const result = parseWorktreeSSE(body)
     expect(result).toHaveLength(2)
-    expect(result[0].branch).toBe('nick0cave/wt-run-47')
-    expect(result[1].branch).toBe('improver/p0a-worktree-status-sse')
+    expect(result[0]?.branch).toBe('nick0cave/wt-run-47')
+    expect(result[1]?.branch).toBe('improver/p0a-worktree-status-sse')
   })
 
   it('skips empty data payload and non-data lines', () => {
@@ -76,7 +76,7 @@ describe('parseWorktreeSSE', () => {
     const body = 'data: {not valid json}\ndata: ' + JSON.stringify(sampleWorktrees[0])
     const result = parseWorktreeSSE(body)
     expect(result).toHaveLength(1)
-    expect(result[0].branch).toBe('nick0cave/wt-run-47')
+    expect(result[0]?.branch).toBe('nick0cave/wt-run-47')
   })
 
   it('workspace_label is populated from workspaceLabelForAgent using parsed SSE', () => {

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -167,6 +167,7 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.sessions).toEqual([])
     expect(result.keepers).toEqual([])
     expect(result.persistent_agents).toEqual([])
+    expect(result.admission_queue).toBeNull()
     expect(result.recent_messages).toEqual([])
     expect(result.pending_confirms).toEqual([])
     expect(result.available_actions).toEqual([])
@@ -430,6 +431,27 @@ describe('normalizeOperatorSnapshot', () => {
     })
     expect(result.operator_judge_runtime).not.toBeNull()
     expect(result.operator_judge_runtime!.enabled).toBe(true)
+  })
+
+  it('normalizes admission queue ownership metadata', () => {
+    const result = normalizeOperatorSnapshot({
+      admission_queue: {
+        mode: 'passthrough',
+        throttle_owner: 'oas_cascade',
+        max_concurrent: 3,
+        active: 1,
+        available: 2,
+        queue_depth: 0,
+      },
+    })
+    expect(result.admission_queue).toEqual({
+      mode: 'passthrough',
+      throttle_owner: 'oas_cascade',
+      max_concurrent: 3,
+      active: 1,
+      available: 2,
+      queue_depth: 0,
+    })
   })
 
   it('extracts persistent_agents using same keeper normalizer', () => {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -7,6 +7,7 @@ import {
 } from './pending-confirm'
 import { normalizeKeeperTrust } from './keeper-store-normalize'
 import type {
+  AdmissionQueueSnapshot,
   Message,
   OperatorActionDescriptor,
   OperatorAttentionItem,
@@ -105,6 +106,18 @@ function normalizeOperatorJudgeRuntime(raw: unknown): OperatorJudgeRuntime | nul
     model_used: asString(raw.model_used) ?? null,
     keeper_name: asString(raw.keeper_name) ?? null,
     last_error: asString(raw.last_error) ?? null,
+  }
+}
+
+function normalizeAdmissionQueue(raw: unknown): AdmissionQueueSnapshot | null {
+  if (!isRecord(raw)) return null
+  return {
+    mode: asString(raw.mode) ?? 'unknown',
+    throttle_owner: asString(raw.throttle_owner) ?? 'unknown',
+    max_concurrent: asNumber(raw.max_concurrent) ?? 0,
+    active: asNumber(raw.active) ?? 0,
+    available: asNumber(raw.available) ?? 0,
+    queue_depth: asNumber(raw.queue_depth) ?? 0,
   }
 }
 
@@ -306,6 +319,7 @@ export function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
     keepers: extractArray(root.keepers, ['items', 'keepers'])
       .map(normalizeKeeper)
       .filter((item): item is OperatorKeeperSnapshot => item !== null),
+    admission_queue: normalizeAdmissionQueue(root.admission_queue),
     operator_judge_runtime: normalizeOperatorJudgeRuntime(root.operator_judge_runtime),
     persistent_agents: extractArray(root.persistent_agents, ['items', 'persistent_agents'])
       .map(normalizeKeeper)

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -517,10 +517,20 @@ export interface KeeperRecoverResult {
   up?: unknown
 }
 
+export interface AdmissionQueueSnapshot {
+  mode: string
+  throttle_owner: string
+  max_concurrent: number
+  active: number
+  available: number
+  queue_depth: number
+}
+
 export interface OperatorSnapshot {
   root: OperatorNamespaceSnapshot
   sessions: OperatorSessionSnapshot[]
   keepers: OperatorKeeperSnapshot[]
+  admission_queue?: AdmissionQueueSnapshot | null
   operator_judge_runtime?: OperatorJudgeRuntime | null
   persistent_agents?: OperatorKeeperSnapshot[]
   recent_messages: Message[]

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -1421,6 +1421,7 @@ let snapshot_json ?actor ?view ?(include_messages = true)
          ("operator_judge_runtime", operator_judge_runtime_json config);
          ("judgment_owner", `String "fallback_read_model");
          ("authoritative_judgment_available", `Bool false);
+         ("admission_queue", Admission_queue.snapshot_json ());
          ("root", room_json config);
        ]
       @ (

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -529,6 +529,13 @@ let test_snapshot_has_expected_sections () =
         Yojson.Safe.Util.(json |> member "judgment_owner" |> to_string);
       Alcotest.(check bool) "no authoritative judgment" false
         Yojson.Safe.Util.(json |> member "authoritative_judgment_available" |> to_bool);
+      let admission = Yojson.Safe.Util.member "admission_queue" json in
+      Alcotest.(check bool) "admission queue present" true
+        (admission <> `Null);
+      Alcotest.(check string) "admission mode" "passthrough"
+        Yojson.Safe.Util.(admission |> member "mode" |> to_string);
+      Alcotest.(check string) "admission throttle owner" "oas_cascade"
+        Yojson.Safe.Util.(admission |> member "throttle_owner" |> to_string);
       Alcotest.(check bool) "recent_actions list present" true
         (match Yojson.Safe.Util.member "recent_actions" json with
         | `List _ -> true


### PR DESCRIPTION
## Summary
- Fix the strict dashboard presence-strip test indexing that broke `tsc --noEmit`.
- Add `admission_queue` to the operator snapshot and normalize it into the dashboard model.
- Show Flow Control admission status as passthrough, with OAS cascade called out as the throttle owner and observed inflight count.

## Why it matters
The audit follow-up around Flow Control was not asking for MASC to become the throttle. MASC admission is intentionally passthrough while OAS cascade owns throttling, but the dashboard did not say that, so operators could misread zero wait time as missing backpressure telemetry. This PR makes that ownership visible without changing runtime behavior.

## Validation
- `git diff --check`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/operator-normalizers.test.ts src/components/flow-control/flow-control-panel.test.ts src/components/ide/ide-presence-strip.test.ts --no-file-parallelism --maxWorkers=1` (3 files, 50 tests)

## Backend validation note
- Focused Dune command attempted: `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_operator_control.exe test/test_admission_queue_coverage.exe`
- The first attempt rejected `test/test_operator_control_snapshot.exe` because that module is part of the aggregate operator-control test binary.
- The aggregate build then failed outside this patch path in `lib/keeper/keeper_turn.ml` with `Unbound module Llm_provider`, after an earlier shared-cache `rmdir(.../.cache/dune/db/temp/...)` warning. This branch does not touch `lib/keeper/keeper_turn.ml`.
