### PR TITLE
fix(keeper): refresh hook introspection surface

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1478,6 +1478,25 @@ let make_hooks
 (** Static introspection of hook slot configuration.
     Returns a JSON summary of which hook slots are active, their gates/effects,
     and the deny list. Used by the dashboard to display hook status. *)
+let hook_slot_json ?(features = []) ?(gates = []) ?(effects = [])
+    ?reason ~(active : bool) ~(source : string) () : Yojson.Safe.t =
+  let list_field name values =
+    match values with
+    | [] -> []
+    | xs -> [ (name, `List (List.map (fun s -> `String s) xs)) ]
+  in
+  `Assoc
+    ([
+       ("active", `Bool active);
+       ("source", `String source);
+     ]
+     @ (match reason with
+       | None -> []
+       | Some value -> [ ("reason", `String value) ])
+     @ list_field "features" features
+     @ list_field "gates" gates
+     @ list_field "effects" effects)
+
 let hook_introspection_json
     ?(max_cost_usd : float option)
     ?(destructive_check : bool = true)
@@ -1489,64 +1508,156 @@ let hook_introspection_json
   let destructive_json =
     `String "dynamic_boundary (Tool_dispatch.is_destructive)"
   in
+  let slot_entries =
+    [
+      ( "before_turn",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_hooks_oas"
+          ~features:
+            [
+              "work_discovery_nudge";
+              "passive_loop_nudge";
+              "utf8_guard";
+            ]
+          () );
+      ( "before_turn_params",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_run_tools"
+          ~features:
+            [
+              "dynamic_context";
+              "adaptive_thinking_budget";
+              "tool_surface_selection";
+              "memory_injection";
+            ]
+          () );
+      ( "after_turn",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_hooks_oas"
+          ~effects:
+            [
+              "sse_broadcast";
+              "cost_event";
+              "metrics";
+              "usage_trust";
+              "tool_streak_reset";
+            ]
+          () );
+      ( "pre_tool_use",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_guards"
+          ~gates:
+            [
+              "timing";
+              "custom_guard";
+              "streak_gate";
+              "keeper_deny_list";
+              (if Option.is_some max_cost_usd
+               then "cost_budget"
+               else "cost_budget_off");
+              (if destructive_check
+               then "destructive_pattern"
+               else "destructive_pattern_off");
+              "governance_approval";
+            ]
+          () );
+      ( "post_tool_use",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_hooks_oas"
+          ~features:
+            [
+              "tool_callback";
+              "tool_call_log";
+              "trajectory";
+              "board_write_detection";
+              "tool_emission_capture";
+            ]
+          () );
+      ( "post_tool_use_failure",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_hooks_oas"
+          ~effects:[ "tool_use_failure_metric" ]
+          () );
+      ( "on_stop",
+        hook_slot_json
+          ~active:false
+          ~source:"not_registered"
+          ~reason:"keeper runtime has no stop hook"
+          () );
+      ( "on_idle",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_hooks_oas"
+          ~features:[ "repeated_tool_nudge"; "stay_silent_skip" ]
+          () );
+      ( "on_idle_escalated",
+        hook_slot_json
+          ~active:false
+          ~source:"not_registered"
+          ~reason:"keeper runtime uses legacy on_idle hook"
+          () );
+      ( "on_error",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_hooks_oas"
+          ~effects:[ "wirein_failure_metric"; "keeper_error_log" ]
+          () );
+      ( "on_tool_error",
+        hook_slot_json
+          ~active:true
+          ~source:"keeper_hooks_oas"
+          ~effects:[ "wirein_failure_metric"; "keeper_error_log" ]
+          () );
+      ( "pre_compact",
+        hook_slot_json
+          ~active:false
+          ~source:"not_registered"
+          ~reason:"compaction is handled by keeper_post_turn"
+          () );
+      ( "post_compact",
+        hook_slot_json
+          ~active:false
+          ~source:"not_registered"
+          ~reason:"compaction is handled by keeper_post_turn"
+          () );
+      ( "on_context_compacted",
+        hook_slot_json
+          ~active:false
+          ~source:"not_registered"
+          ~reason:"compaction is handled by keeper_post_turn"
+          () );
+    ]
+  in
+  let slot_active = function
+    | _, `Assoc fields -> (
+        match List.assoc_opt "active" fields with
+        | Some (`Bool true) -> true
+        | _ -> false)
+    | _ -> false
+  in
+  let active_count =
+    List.fold_left
+      (fun acc slot -> if slot_active slot then acc + 1 else acc)
+      0 slot_entries
+  in
+  let total_count = List.length slot_entries in
+  let inactive_count = total_count - active_count in
+  let slot_names =
+    `List (List.map (fun (name, _) -> `String name) slot_entries)
+  in
   `Assoc [
-    ("slots", `Assoc [
-      ("before_turn_params", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_agent_run");
-        ("features", `List [
-          `String "dynamic_context";
-          `String "bm25_progressive_disclosure";
-        ]);
-      ]);
-      ("pre_tool_use", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_hooks_oas");
-        ("gates", `List [
-          `String "keeper_deny_list";
-          `String (if Option.is_some max_cost_usd
-                   then "cost_budget" else "cost_budget_off");
-          `String (if destructive_check
-                   then "destructive_pattern" else "destructive_pattern_off");
-        ]);
-      ]);
-      ("after_turn", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_hooks_oas");
-        ("effects", `List [
-          `String "sse_broadcast";
-          `String "cost_event";
-          `String "metrics";
-        ]);
-      ]);
-      ("post_tool_use", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_hooks_oas");
-        ("features", `List [
-          `String "tool_callback";
-          `String "board_write_detection";
-        ]);
-      ]);
-      ("on_idle", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_hooks_oas");
-      ]);
-      ("on_error", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_hooks_oas");
-      ]);
-      ("on_tool_error", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_hooks_oas");
-      ]);
-      ("post_tool_use_failure", `Assoc [
-        ("active", `Bool true);
-        ("source", `String "keeper_hooks_oas");
-        ("effects", `List [
-          `String "heuristic_metrics";
-        ]);
-      ]);
-    ]);
+    ("scope", `String "keeper_runtime_composite");
+    ("slots", `Assoc slot_entries);
+    ("slot_names", slot_names);
+    ("slot_count", `Int total_count);
+    ("active_slot_count", `Int active_count);
+    ("inactive_slot_count", `Int inactive_count);
     ("deny_list", denied_json);
     ("deny_list_count", `Int (List.length keeper_denied_tools));
     ("destructive_check_tools", destructive_json);

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1508,152 +1508,152 @@ let hook_introspection_json
   let destructive_json =
     `String "dynamic_boundary (Tool_dispatch.is_destructive)"
   in
+  (* Build (name, active, json) triples in one place so the active
+     flag is captured at construction time rather than recovered by
+     re-inspecting the just-built JSON later. *)
+  let slot ?features ?gates ?effects ?reason ~active ~source name =
+    let features = Option.value features ~default:[] in
+    let gates = Option.value gates ~default:[] in
+    let effects = Option.value effects ~default:[] in
+    let json =
+      hook_slot_json ~features ~gates ~effects ?reason ~active ~source ()
+    in
+    (name, active, json)
+  in
   let slot_entries =
     [
-      ( "before_turn",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_hooks_oas"
-          ~features:
-            [
-              "work_discovery_nudge";
-              "passive_loop_nudge";
-              "utf8_guard";
-            ]
-          () );
-      ( "before_turn_params",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_run_tools"
-          ~features:
-            [
-              "dynamic_context";
-              "adaptive_thinking_budget";
-              "tool_surface_selection";
-              "memory_injection";
-            ]
-          () );
-      ( "after_turn",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_hooks_oas"
-          ~effects:
-            [
-              "sse_broadcast";
-              "cost_event";
-              "metrics";
-              "usage_trust";
-              "tool_streak_reset";
-            ]
-          () );
-      ( "pre_tool_use",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_guards"
-          ~gates:
-            [
-              "timing";
-              "custom_guard";
-              "streak_gate";
-              "keeper_deny_list";
-              (if Option.is_some max_cost_usd
-               then "cost_budget"
-               else "cost_budget_off");
-              (if destructive_check
-               then "destructive_pattern"
-               else "destructive_pattern_off");
-              "governance_approval";
-            ]
-          () );
-      ( "post_tool_use",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_hooks_oas"
-          ~features:
-            [
-              "tool_callback";
-              "tool_call_log";
-              "trajectory";
-              "board_write_detection";
-              "tool_emission_capture";
-            ]
-          () );
-      ( "post_tool_use_failure",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_hooks_oas"
-          ~effects:[ "tool_use_failure_metric" ]
-          () );
-      ( "on_stop",
-        hook_slot_json
-          ~active:false
-          ~source:"not_registered"
-          ~reason:"keeper runtime has no stop hook"
-          () );
-      ( "on_idle",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_hooks_oas"
-          ~features:[ "repeated_tool_nudge"; "stay_silent_skip" ]
-          () );
-      ( "on_idle_escalated",
-        hook_slot_json
-          ~active:false
-          ~source:"not_registered"
-          ~reason:"keeper runtime uses legacy on_idle hook"
-          () );
-      ( "on_error",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_hooks_oas"
-          ~effects:[ "wirein_failure_metric"; "keeper_error_log" ]
-          () );
-      ( "on_tool_error",
-        hook_slot_json
-          ~active:true
-          ~source:"keeper_hooks_oas"
-          ~effects:[ "wirein_failure_metric"; "keeper_error_log" ]
-          () );
-      ( "pre_compact",
-        hook_slot_json
-          ~active:false
-          ~source:"not_registered"
-          ~reason:"compaction is handled by keeper_post_turn"
-          () );
-      ( "post_compact",
-        hook_slot_json
-          ~active:false
-          ~source:"not_registered"
-          ~reason:"compaction is handled by keeper_post_turn"
-          () );
-      ( "on_context_compacted",
-        hook_slot_json
-          ~active:false
-          ~source:"not_registered"
-          ~reason:"compaction is handled by keeper_post_turn"
-          () );
+      slot
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~features:
+          [
+            "work_discovery_nudge";
+            "passive_loop_nudge";
+            "utf8_guard";
+          ]
+        "before_turn";
+      slot
+        ~active:true
+        ~source:"keeper_run_tools"
+        ~features:
+          [
+            "dynamic_context";
+            "adaptive_thinking_budget";
+            "tool_surface_selection";
+            "memory_injection";
+          ]
+        "before_turn_params";
+      slot
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~effects:
+          [
+            "sse_broadcast";
+            "cost_event";
+            "metrics";
+            "usage_trust";
+            "tool_streak_reset";
+          ]
+        "after_turn";
+      slot
+        ~active:true
+        ~source:"keeper_guards"
+        ~gates:
+          [
+            "timing";
+            "custom_guard";
+            "streak_gate";
+            "keeper_deny_list";
+            (if Option.is_some max_cost_usd
+             then "cost_budget"
+             else "cost_budget_off");
+            (if destructive_check
+             then "destructive_pattern"
+             else "destructive_pattern_off");
+            "governance_approval";
+          ]
+        "pre_tool_use";
+      slot
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~features:
+          [
+            "tool_callback";
+            "tool_call_log";
+            "trajectory";
+            "board_write_detection";
+            "tool_emission_capture";
+          ]
+        "post_tool_use";
+      slot
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~effects:[ "tool_use_failure_metric" ]
+        "post_tool_use_failure";
+      slot
+        ~active:false
+        ~source:"not_registered"
+        ~reason:"keeper runtime has no stop hook"
+        "on_stop";
+      slot
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~features:[ "repeated_tool_nudge"; "stay_silent_skip" ]
+        "on_idle";
+      slot
+        ~active:false
+        ~source:"not_registered"
+        ~reason:"keeper runtime uses legacy on_idle hook"
+        "on_idle_escalated";
+      slot
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~effects:[ "wirein_failure_metric"; "keeper_error_log" ]
+        "on_error";
+      slot
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~effects:[ "wirein_failure_metric"; "keeper_error_log" ]
+        "on_tool_error";
+      slot
+        ~active:false
+        ~source:"not_registered"
+        ~reason:"compaction is handled by keeper_post_turn"
+        "pre_compact";
+      slot
+        ~active:false
+        ~source:"not_registered"
+        ~reason:"compaction is handled by keeper_post_turn"
+        "post_compact";
+      slot
+        ~active:false
+        ~source:"not_registered"
+        ~reason:"compaction is handled by keeper_post_turn"
+        "on_context_compacted";
     ]
   in
-  let slot_active = function
-    | _, `Assoc fields -> (
-        match List.assoc_opt "active" fields with
-        | Some (`Bool true) -> true
-        | _ -> false)
-    | _ -> false
-  in
+  (* Reviewer #13225: counts used to be derived by re-parsing the
+     just-built JSON [Assoc] for an "active" field.  If
+     [hook_slot_json]'s shape ever drifts (extra wrapper, renamed
+     field) the counts would silently desync from reality.  Track
+     [active] alongside each slot at build time so the counts are
+     decided where the slot is constructed, not by inspecting JSON. *)
   let active_count =
     List.fold_left
-      (fun acc slot -> if slot_active slot then acc + 1 else acc)
+      (fun acc (_name, active, _json) -> if active then acc + 1 else acc)
       0 slot_entries
   in
   let total_count = List.length slot_entries in
   let inactive_count = total_count - active_count in
   let slot_names =
-    `List (List.map (fun (name, _) -> `String name) slot_entries)
+    `List (List.map (fun (name, _, _) -> `String name) slot_entries)
+  in
+  let slot_assoc =
+    List.map (fun (name, _active, json) -> (name, json)) slot_entries
   in
   `Assoc [
     ("scope", `String "keeper_runtime_composite");
-    ("slots", `Assoc slot_entries);
+    ("slots", `Assoc slot_assoc);
     ("slot_names", slot_names);
     ("slot_count", `Int total_count);
     ("active_slot_count", `Int active_count);

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -533,6 +533,73 @@ let test_record_llm_tok_s_metrics_none_telemetry_is_noop () =
   check (float 0.001) "prompt count unchanged" 0.0
     (prompt_count_after -. prompt_count_before)
 
+let slot json name = json |> member "slots" |> member name
+
+let string_list_field json key =
+  match json |> member key with
+  | `List values -> List.map to_string values
+  | `Null -> []
+  | other ->
+      failf "expected %s list, got %s" key (Yojson.Safe.to_string other)
+
+let check_string_list_contains label needle values =
+  check bool label true (List.mem needle values)
+
+let check_string_list_not_contains label needle values =
+  check bool label false (List.mem needle values)
+
+let test_hook_introspection_reports_current_runtime_slots () =
+  let json =
+    Hooks.hook_introspection_json
+      ~max_cost_usd:0.25
+      ~destructive_check:false
+      ()
+  in
+  check string "scope" "keeper_runtime_composite"
+    (json |> member "scope" |> to_string);
+  check int "slot_count" 14 (json |> member "slot_count" |> to_int);
+  check int "active slots" 9
+    (json |> member "active_slot_count" |> to_int);
+  check int "inactive slots" 5
+    (json |> member "inactive_slot_count" |> to_int);
+  check bool "before_turn active" true
+    (slot json "before_turn" |> member "active" |> to_bool);
+  check_string_list_contains "before_turn includes work discovery"
+    "work_discovery_nudge"
+    (string_list_field (slot json "before_turn") "features");
+  check bool "before_turn_params active" true
+    (slot json "before_turn_params" |> member "active" |> to_bool);
+  check string "before_turn_params source" "keeper_run_tools"
+    (slot json "before_turn_params" |> member "source" |> to_string);
+  let pre_tool_gates = string_list_field (slot json "pre_tool_use") "gates" in
+  List.iter
+    (fun gate ->
+      check_string_list_contains ("pre_tool gate " ^ gate) gate pre_tool_gates)
+    [
+      "timing";
+      "custom_guard";
+      "streak_gate";
+      "keeper_deny_list";
+      "cost_budget";
+      "destructive_pattern_off";
+      "governance_approval";
+    ];
+  let failure_effects =
+    string_list_field (slot json "post_tool_use_failure") "effects"
+  in
+  check_string_list_contains "failure hook records counter"
+    "tool_use_failure_metric" failure_effects;
+  check_string_list_not_contains "failure hook no stale heuristic label"
+    "heuristic_metrics" failure_effects;
+  check bool "on_idle_escalated inactive" false
+    (slot json "on_idle_escalated" |> member "active" |> to_bool);
+  check bool "pre_compact inactive" false
+    (slot json "pre_compact" |> member "active" |> to_bool);
+  check bool "post_compact inactive" false
+    (slot json "post_compact" |> member "active" |> to_bool);
+  check bool "on_context_compacted inactive" false
+    (slot json "on_context_compacted" |> member "active" |> to_bool)
+
 let () =
   run "keeper_hooks_oas/telemetry"
     [ ( "costs_jsonl",
@@ -578,5 +645,9 @@ let () =
             test_record_llm_tok_s_metrics_zero_value_is_skipped
         ; test_case "telemetry=None is a safe no-op" `Quick
             test_record_llm_tok_s_metrics_none_telemetry_is_noop
+        ] )
+    ; ( "hook_introspection",
+        [ test_case "reports current runtime slots" `Quick
+            test_hook_introspection_reports_current_runtime_slots
         ] )
     ]


### PR DESCRIPTION
## Summary

- Refresh `Keeper_hooks_oas.hook_introspection_json` so the dashboard sees the current keeper runtime hook surface.
- Add the real `before_turn` slot, keep `before_turn_params` sourced to `keeper_run_tools`, include newer Agent SDK slots as explicit inactive entries, and derive slot counts from the table.
- Correct stale details such as `post_tool_use_failure` reporting `tool_use_failure_metric` rather than the old heuristic label.
- Add a regression for active/inactive counts, pre-tool guard chain labels, and stale effect removal.

## Why

The old dashboard introspection was stale: it omitted active slots, omitted newer inactive SDK slots, and still described some effects with old labels. Operators reading the dashboard could not distinguish real hook wiring from no-op gaps.

## Validation

- `git diff --check origin/main..HEAD` after rebase
- `scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe` passed before the clean rebase
- `_build/default/test/test_keeper_hooks_oas_telemetry.exe` passed before the clean rebase: 19 tests

Note: the post-rebase focused Dune retry was queued behind `/tmp/me-dune-local.lock` for several minutes and was stopped without bypassing the host throttle.