### PR TITLE
fix(keeper): publish list cache atomically

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -47,10 +47,13 @@ type text_cache = {
   key : string option;
   value : string option;
   expires_at : float;
+  generation : int;
 }
 
-let empty_text_cache = { key = None; value = None; expires_at = 0.0 }
-let _keeper_list_cache = Atomic.make empty_text_cache
+let empty_text_cache ~generation =
+  { key = None; value = None; expires_at = 0.0; generation }
+
+let _keeper_list_cache = Atomic.make (empty_text_cache ~generation:0)
 
 let cache_ttl_seconds env_var ~default =
   match Sys.getenv_opt env_var with
@@ -63,9 +66,17 @@ let cache_ttl_seconds env_var ~default =
 let keeper_list_cache_ttl_s () =
   cache_ttl_seconds "MASC_KEEPER_LIST_CACHE_TTL_S" ~default:2.0
 
-let invalidate_keeper_list_cache () = Atomic.set _keeper_list_cache empty_text_cache
+let invalidate_text_cache cache_ref =
+  let rec loop () =
+    let current = Atomic.get cache_ref in
+    let next = empty_text_cache ~generation:(current.generation + 1) in
+    if not (Atomic.compare_and_set cache_ref current next) then loop ()
+  in
+  loop ()
 
-let cached_text_by_key cache_ref ~key ~ttl_s compute =
+let invalidate_keeper_list_cache () = invalidate_text_cache _keeper_list_cache
+
+let rec cached_text_by_key cache_ref ~key ~ttl_s compute =
   let now = Time_compat.now () in
   let cache = Atomic.get cache_ref in
   match cache.key, cache.value with
@@ -74,8 +85,26 @@ let cached_text_by_key cache_ref ~key ~ttl_s compute =
       value
   | _ ->
       let value = compute () in
-      Atomic.set cache_ref { key = Some key; value = Some value; expires_at = now +. ttl_s };
-      value
+      let next =
+        {
+          key = Some key;
+          value = Some value;
+          expires_at = Time_compat.now () +. ttl_s;
+          generation = cache.generation;
+        }
+      in
+      if Atomic.compare_and_set cache_ref cache next then value
+      else cached_text_by_key cache_ref ~key ~ttl_s compute
+
+module For_testing = struct
+  let reset_keeper_list_cache () =
+    Atomic.set _keeper_list_cache (empty_text_cache ~generation:0)
+
+  let invalidate_keeper_list_cache = invalidate_keeper_list_cache
+
+  let cached_keeper_list_text ~key ~ttl_s compute =
+    cached_text_by_key _keeper_list_cache ~key ~ttl_s compute
+end
 
 let annotate_keeper_json ~runtime_class json =
   match json with

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -44,12 +44,13 @@ type tool_result = Keeper_types.tool_result
 let schemas = Keeper_types.schemas
 
 type text_cache = {
-  mutable key : string option;
-  mutable value : string option;
-  mutable expires_at : float;
+  key : string option;
+  value : string option;
+  expires_at : float;
 }
 
-let _keeper_list_cache = { key = None; value = None; expires_at = 0.0 }
+let empty_text_cache = { key = None; value = None; expires_at = 0.0 }
+let _keeper_list_cache = Atomic.make empty_text_cache
 
 let cache_ttl_seconds env_var ~default =
   match Sys.getenv_opt env_var with
@@ -62,22 +63,18 @@ let cache_ttl_seconds env_var ~default =
 let keeper_list_cache_ttl_s () =
   cache_ttl_seconds "MASC_KEEPER_LIST_CACHE_TTL_S" ~default:2.0
 
-let invalidate_keeper_list_cache () =
-  _keeper_list_cache.key <- None;
-  _keeper_list_cache.value <- None;
-  _keeper_list_cache.expires_at <- 0.0
+let invalidate_keeper_list_cache () = Atomic.set _keeper_list_cache empty_text_cache
 
-let cached_text_by_key cache ~key ~ttl_s compute =
+let cached_text_by_key cache_ref ~key ~ttl_s compute =
   let now = Time_compat.now () in
+  let cache = Atomic.get cache_ref in
   match cache.key, cache.value with
   | Some cached_key, Some value
     when String.equal cached_key key && Stdlib.Float.compare now cache.expires_at < 0 ->
       value
   | _ ->
       let value = compute () in
-      cache.key <- Some key;
-      cache.value <- Some value;
-      cache.expires_at <- now +. ttl_s;
+      Atomic.set cache_ref { key = Some key; value = Some value; expires_at = now +. ttl_s };
       value
 
 let annotate_keeper_json ~runtime_class json =

--- a/lib/tool_keeper.mli
+++ b/lib/tool_keeper.mli
@@ -17,6 +17,14 @@ val schemas : Masc_domain.tool_schema list
 val dispatch :
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
+module For_testing : sig
+  val reset_keeper_list_cache : unit -> unit
+  val invalidate_keeper_list_cache : unit -> unit
+
+  val cached_keeper_list_text :
+    key:string -> ttl_s:float -> (unit -> string) -> string
+end
+
 (** Streaming dispatch: handles keeper_msg with real-time text delta callback.
     The [on_text_delta] callback receives each text fragment from the MODEL
     as it arrives. Returns [None] for tool names other than [masc_keeper_msg].

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -698,6 +698,20 @@ let test_keeper_direct_reply_contracts () =
     (file_contains_pattern "lib/keeper/keeper_turn.ml"
        "Keeper_prompt.append_direct_reply_mode_prompt")
 
+let test_keeper_list_cache_atomic_contracts () =
+  check bool "keeper list cache uses atomic snapshot storage" true
+    (file_contains_pattern "lib/tool_keeper.ml"
+       "let _keeper_list_cache = Atomic.make empty_text_cache");
+  check bool "keeper list cache invalidation publishes whole snapshot" true
+    (file_contains_pattern "lib/tool_keeper.ml"
+       "let invalidate_keeper_list_cache () = Atomic.set _keeper_list_cache empty_text_cache");
+  check bool "keeper list cache no longer mutates key field in place" true
+    (file_not_contains_pattern "lib/tool_keeper.ml" "_keeper_list_cache.key <-");
+  check bool "keeper list cache no longer mutates value field in place" true
+    (file_not_contains_pattern "lib/tool_keeper.ml" "_keeper_list_cache.value <-");
+  check bool "keeper list cache no longer mutates expiry field in place" true
+    (file_not_contains_pattern "lib/tool_keeper.ml" "_keeper_list_cache.expires_at <-")
+
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
@@ -1400,6 +1414,8 @@ let () =
              test_tool_admin_snapshot_auth_contracts;
            test_case "keeper direct reply contracts" `Quick
              test_keeper_direct_reply_contracts;
+           test_case "keeper list cache atomic contracts" `Quick
+             test_keeper_list_cache_atomic_contracts;
            test_case "dashboard warm hydration contracts" `Quick
              test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -699,12 +699,15 @@ let test_keeper_direct_reply_contracts () =
        "Keeper_prompt.append_direct_reply_mode_prompt")
 
 let test_keeper_list_cache_atomic_contracts () =
-  check bool "keeper list cache uses atomic snapshot storage" true
+  check bool "keeper list cache uses versioned atomic snapshot storage" true
     (file_contains_pattern "lib/tool_keeper.ml"
-       "let _keeper_list_cache = Atomic.make empty_text_cache");
-  check bool "keeper list cache invalidation publishes whole snapshot" true
+       "generation : int");
+  check bool "keeper list cache invalidation bumps generation" true
     (file_contains_pattern "lib/tool_keeper.ml"
-       "let invalidate_keeper_list_cache () = Atomic.set _keeper_list_cache empty_text_cache");
+       "generation:(current.generation + 1)");
+  check bool "keeper list cache publish uses CAS" true
+    (file_contains_pattern "lib/tool_keeper.ml"
+       "Atomic.compare_and_set cache_ref cache next");
   check bool "keeper list cache no longer mutates key field in place" true
     (file_not_contains_pattern "lib/tool_keeper.ml" "_keeper_list_cache.key <-");
   check bool "keeper list cache no longer mutates value field in place" true

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -654,6 +654,30 @@ let test_keeper_list_preserves_known_social_model () =
             Yojson.Safe.Util.(keeper |> member "social_model" |> to_string)
       | None -> fail "expected sangsu row in keeper list")
 
+let test_keeper_list_cache_retries_after_inflight_invalidation () =
+  Tool_keeper.For_testing.reset_keeper_list_cache ();
+  Fun.protect
+    ~finally:Tool_keeper.For_testing.reset_keeper_list_cache
+    (fun () ->
+      let calls = ref 0 in
+      let body =
+        Tool_keeper.For_testing.cached_keeper_list_text ~key:"race"
+          ~ttl_s:60.0 (fun () ->
+            incr calls;
+            if !calls = 1 then (
+              Tool_keeper.For_testing.invalidate_keeper_list_cache ();
+              "stale")
+            else
+              "fresh")
+      in
+      check string "in-flight invalidation forces recompute" "fresh" body;
+      check int "compute retried after invalidation" 2 !calls;
+      let cached =
+        Tool_keeper.For_testing.cached_keeper_list_text ~key:"race"
+          ~ttl_s:60.0 (fun () -> "unexpected")
+      in
+      check string "fresh recompute was cached" "fresh" cached)
+
 let () =
   run "keeper_meta_listing"
     [
@@ -673,6 +697,8 @@ let () =
             test_keeper_list_normalizes_unknown_social_model;
           test_case "tool keeper list preserves known social model" `Quick
             test_keeper_list_preserves_known_social_model;
+          test_case "keeper list cache retries after in-flight invalidation"
+            `Quick test_keeper_list_cache_retries_after_inflight_invalidation;
           test_case "tool keeper list exposes last social transition reason"
             `Quick test_keeper_list_exposes_last_social_transition_reason;
           test_case "keeper persona audit reports durable live keeper" `Quick


### PR DESCRIPTION
## Summary
- Replace the keeper-list cache's in-place mutable fields with an atomic immutable snapshot.
- Add a source contract regression so the cache cannot drift back to direct field mutation.

## Why
The Kimi multi-keeper validation plan flagged keeper list cache mutation as an immediate concurrency gap. Publishing the cache as one snapshot avoids torn reads during concurrent keeper-list callers and invalidation paths.

## Validation
- scripts/dune-local.sh build test/test_ci_hardening_source.exe
- ./_build/default/test/test_ci_hardening_source.exe (40 tests)
- bash scripts/check-oas-pin.sh --local-only
- git diff --check

## Notes
- Attempted scripts/dune-local.sh build test/test_keeper_meta_listing.exe after the pin repair; local Dune validation was blocked behind the shared /tmp/me-dune-local.lock held by another long-running build.