### PR TITLE
fix(keeper): include persisted sandbox fleet status

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -334,16 +334,20 @@ let identity_json (meta : keeper_meta) =
     ]
 
 let live_status_json ?(include_preflight = true)
+    ?preflight_override
     ~(config : Coord.config)
     ~(meta : keeper_meta)
     ~(timeout_sec : float)
     ~(verbose : bool)
     () =
   let preflight =
-    if include_preflight && meta.sandbox_profile = Docker then
-      preflight_status_json ~timeout_sec
-    else
-      None
+    match preflight_override with
+    | Some cached -> cached
+    | None ->
+      if include_preflight && meta.sandbox_profile = Docker then
+        preflight_status_json ~timeout_sec
+      else
+        None
   in
   let containers, container_error =
     if meta.sandbox_profile = Docker then

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -47,9 +47,24 @@ val cleanup_stale :
 
 val live_status_json :
   ?include_preflight:bool ->
+  ?preflight_override:Yojson.Safe.t option ->
   config:Coord.config ->
   meta:keeper_meta ->
   timeout_sec:float ->
   verbose:bool ->
   unit ->
   Yojson.Safe.t
+(** [preflight_override] lets a fleet caller reuse a single Docker
+    preflight probe across many keepers; when set (even to [None]),
+    the per-keeper render skips its own [docker_preflight] call.
+    Pass [Some json] for the cached result, or [None] for "preflight
+    was attempted but yielded nothing".  Without this override the
+    render falls back to its own preflight invocation. *)
+
+val preflight_status_json :
+  timeout_sec:float -> Yojson.Safe.t option
+(** Run the global Docker preflight once and return its JSON
+    representation, or [None] when no preflight result is available.
+    Exposed so fleet renderers can run it a single time and feed the
+    cached value into many [live_status_json] calls instead of
+    repeating the expensive Docker probe per keeper. *)

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -484,7 +484,7 @@ let keeper_schemas : tool_schema list = [
       ("properties", `Assoc [
         ("name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Keeper handle. When omitted, return sandbox status for all registered keepers.");
+          ("description", `String "Keeper handle. When omitted, return sandbox status for all persisted or registered keepers.");
         ]);
         ("verbose", `Assoc [
           ("type", `String "boolean");

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1089,11 +1089,21 @@ let handle_keeper_sandbox_status ctx args : tool_result =
   let timeout_sec = Stdlib.Float.min 20.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 5.0)) in
   match String.trim (get_string args "name" "") with
   | "" ->
+      let configured_names = configured_keeper_names ctx.config in
+      let candidate_names = keeper_sandbox_status_fleet_names ctx in
       let resolved =
-        keeper_sandbox_status_fleet_names ctx
+        candidate_names
         |> List.filter_map (fun name ->
              match read_meta ctx.config name with
              | Ok (Some meta) -> Some meta
+             | Ok None when List.mem name configured_names -> (
+                 match load_or_materialize_boot_meta ctx name with
+                 | Ok { meta; _ } -> Some meta
+                 | Error msg ->
+                     Log.Keeper.warn
+                       "keeper_sandbox_status fleet: failed to materialize configured keeper %s: %s"
+                       name msg;
+                     None)
              | Ok None | Error _ -> None)
       in
       let seen = Hashtbl.create 16 in
@@ -1119,9 +1129,11 @@ let handle_keeper_sandbox_status ctx args : tool_result =
           None
       in
       let render_item (meta : keeper_meta) =
+        let preflight_override =
+          if meta.sandbox_profile = Docker then cached_preflight else None
+        in
         Keeper_sandbox_control.live_status_json
-          ~include_preflight
-          ~preflight_override:cached_preflight
+          ~include_preflight ?preflight_override
           ~config:ctx.config ~meta ~timeout_sec ~verbose ()
       in
       let items = List.map render_item unique_metas in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1075,6 +1075,14 @@ let parse_network_mode_or_error raw =
         (Printf.sprintf "invalid network_mode %S (allowed: %s)" raw
            (String.concat ", " valid_network_mode_strings))
 
+let keeper_sandbox_status_fleet_names ctx =
+  let registry_names =
+    Keeper_registry.all ~base_path:ctx.config.base_path ()
+    |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
+  in
+  registry_names @ configured_keeper_names ctx.config @ keeper_names ctx.config
+  |> dedupe_sorted_strings
+
 let handle_keeper_sandbox_status ctx args : tool_result =
   let verbose = get_bool args "verbose" false in
   let include_preflight = get_bool args "include_preflight" true in
@@ -1086,12 +1094,9 @@ let handle_keeper_sandbox_status ctx args : tool_result =
   match String.trim (get_string args "name" "") with
   | "" ->
       let items =
-        Keeper_registry.all ~base_path:ctx.config.base_path ()
-        |> List.sort (fun (a : Keeper_registry.registry_entry)
-                          (b : Keeper_registry.registry_entry) ->
-             String.compare a.name b.name)
-        |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
-             match read_meta ctx.config entry.name with
+        keeper_sandbox_status_fleet_names ctx
+        |> List.filter_map (fun name ->
+             match read_meta ctx.config name with
              | Ok (Some meta) -> Some (render_item meta)
              | Ok None | Error _ -> None)
       in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1087,19 +1087,56 @@ let handle_keeper_sandbox_status ctx args : tool_result =
   let verbose = get_bool args "verbose" false in
   let include_preflight = get_bool args "include_preflight" true in
   let timeout_sec = Stdlib.Float.min 20.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 5.0)) in
-  let render_item (meta : keeper_meta) =
-    Keeper_sandbox_control.live_status_json
-      ~include_preflight ~config:ctx.config ~meta ~timeout_sec ~verbose ()
-  in
   match String.trim (get_string args "name" "") with
   | "" ->
-      let items =
+      (* Reviewer #13227 (thread 1): [keeper_sandbox_status_fleet_names]
+         dedupes by raw source name before [read_meta] resolves
+         separator aliases.  If one source exposes "issue-king" and
+         another "issue_king", both survive raw dedup and resolve to
+         the same persisted meta — re-dedupe by [meta.name] so each
+         physical keeper renders exactly once. *)
+      let resolved =
         keeper_sandbox_status_fleet_names ctx
         |> List.filter_map (fun name ->
              match read_meta ctx.config name with
-             | Ok (Some meta) -> Some (render_item meta)
+             | Ok (Some meta) -> Some meta
              | Ok None | Error _ -> None)
       in
+      let seen = Hashtbl.create 16 in
+      let unique_metas =
+        List.filter_map
+          (fun (meta : keeper_meta) ->
+            if Hashtbl.mem seen meta.name then None
+            else begin
+              Hashtbl.add seen meta.name ();
+              Some meta
+            end)
+          resolved
+      in
+      (* Reviewer #13227 (thread 3): docker_preflight is global rather
+         than per-keeper, so running it inside [live_status_json] for
+         every fleet item repeats the same expensive Docker probe N
+         times.  Probe once when at least one Docker keeper is in the
+         fleet, then feed the cached JSON into each render via
+         [preflight_override]. *)
+      let any_docker =
+        List.exists
+          (fun (m : keeper_meta) -> m.sandbox_profile = Docker)
+          unique_metas
+      in
+      let cached_preflight =
+        if include_preflight && any_docker then
+          Keeper_sandbox_control.preflight_status_json ~timeout_sec
+        else
+          None
+      in
+      let render_item (meta : keeper_meta) =
+        Keeper_sandbox_control.live_status_json
+          ~include_preflight
+          ~preflight_override:cached_preflight
+          ~config:ctx.config ~meta ~timeout_sec ~verbose ()
+      in
+      let items = List.map render_item unique_metas in
       ( true,
         Yojson.Safe.pretty_to_string
           (`Assoc
@@ -1118,7 +1155,10 @@ let handle_keeper_sandbox_status ctx args : tool_result =
                  `Assoc
                    [
                      ("keeper", `String meta.name);
-                     ("sandbox", render_item meta);
+                     ( "sandbox",
+                       Keeper_sandbox_control.live_status_json
+                         ~include_preflight ~config:ctx.config ~meta
+                         ~timeout_sec ~verbose () );
                    ]
                  |> attach_identity_reseed ?identity_reseed
                in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1089,12 +1089,6 @@ let handle_keeper_sandbox_status ctx args : tool_result =
   let timeout_sec = Stdlib.Float.min 20.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 5.0)) in
   match String.trim (get_string args "name" "") with
   | "" ->
-      (* Reviewer #13227 (thread 1): [keeper_sandbox_status_fleet_names]
-         dedupes by raw source name before [read_meta] resolves
-         separator aliases.  If one source exposes "issue-king" and
-         another "issue_king", both survive raw dedup and resolve to
-         the same persisted meta — re-dedupe by [meta.name] so each
-         physical keeper renders exactly once. *)
       let resolved =
         keeper_sandbox_status_fleet_names ctx
         |> List.filter_map (fun name ->
@@ -1113,12 +1107,6 @@ let handle_keeper_sandbox_status ctx args : tool_result =
             end)
           resolved
       in
-      (* Reviewer #13227 (thread 3): docker_preflight is global rather
-         than per-keeper, so running it inside [live_status_json] for
-         every fleet item repeats the same expensive Docker probe N
-         times.  Probe once when at least one Docker keeper is in the
-         fleet, then feed the cached JSON into each render via
-         [preflight_override]. *)
       let any_docker =
         List.exists
           (fun (m : keeper_meta) -> m.sandbox_profile = Docker)

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -179,6 +179,14 @@ let () =
             Test_operator_control_keeper
             .test_keeper_sandbox_status_fleet_includes_persisted_keeper;
           Alcotest.test_case
+            "keeper sandbox fleet includes configured keeper" `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_status_fleet_includes_configured_keeper;
+          Alcotest.test_case
+            "keeper sandbox fleet reuses docker preflight" `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_status_fleet_reuses_docker_preflight;
+          Alcotest.test_case
             "keeper sandbox status reseeds separator identity drift" `Quick
             Test_operator_control_keeper
             .test_keeper_sandbox_status_reseeds_separator_identity_drift;

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -175,6 +175,10 @@ let () =
             Test_operator_control_keeper
             .test_keeper_sandbox_status_exposes_local_summary;
           Alcotest.test_case
+            "keeper sandbox fleet includes persisted keeper" `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_status_fleet_includes_persisted_keeper;
+          Alcotest.test_case
             "keeper sandbox status reseeds separator identity drift" `Quick
             Test_operator_control_keeper
             .test_keeper_sandbox_status_reseeds_separator_identity_drift;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -348,15 +348,17 @@ let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
-      (* Reviewer #13227 (thread 2): clearing the registry while the
-         [masc_keeper_up] keepalive fiber is still tracked turns the
-         later [stop_keepalive] in [Fun.protect ~finally] into a no-op
-         (it looks up running fibers via [Keeper_registry.all]).
-         Without this, the live keeper fiber leaks into other tests
-         and makes the suite flaky.  Stop the keepalive explicitly
-         before clearing so the inline reset still observes an empty
-         registry without orphaning the fiber.  The finally block
-         keeps its own [stop_keepalive] as a defensive cleanup. *)
+      let keepers_dir =
+        Filename.concat (Coord.masc_root_dir config) "config/keepers"
+      in
+      ensure_dir keepers_dir;
+      write_file
+        (Filename.concat keepers_dir "persisted_sandbox.toml")
+        "[keeper]\n\
+         goal = \"Alias of persisted sandbox keeper\"\n\
+         sandbox_profile = \"local\"\n\
+         proactive_enabled = false\n\
+         autoboot_enabled = false\n";
       Keeper_keepalive.stop_keepalive keeper_name;
       Keeper_registry.clear ();
       let ok, body =
@@ -366,19 +368,23 @@ let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
       Alcotest.(check bool) "fleet sandbox status ok" true ok;
       let open Yojson.Safe.Util in
       let json = parse_json_exn body in
-      let item =
+      let matching_items =
         json |> member "items" |> to_list
-        |> List.find_opt (fun row ->
+        |> List.filter (fun row ->
              row |> member "keeper" |> to_string = keeper_name)
       in
-      match item with
-      | None -> Alcotest.fail "persisted keeper missing from fleet sandbox status"
-      | Some row ->
+      Alcotest.(check int) "separator alias emits one fleet row" 1
+        (List.length matching_items);
+      match matching_items with
+      | [ row ] ->
           Alcotest.(check string) "persisted effective mode" "local"
             (row |> member "effective_mode" |> to_string);
           Alcotest.(check (option string)) "persisted why_no_container"
             (Some "sandbox_profile=local")
-            (row |> member "why_no_container" |> to_string_option))
+            (row |> member "why_no_container" |> to_string_option)
+      | [] -> Alcotest.fail "persisted keeper missing from fleet sandbox status"
+      | _ :: _ :: _ ->
+          Alcotest.fail "persisted keeper duplicated in fleet sandbox status")
 
 let test_keeper_sandbox_start_status_stop_with_fake_docker () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -311,6 +311,65 @@ let test_keeper_sandbox_status_exposes_local_summary () =
           status_json |> member "sandbox_live" |> member "effective_mode"
           |> to_string))
 
+let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "sandbox-persisted" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Inspect persisted sandbox summary");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_registry.clear ();
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:(`Assoc [ ("include_preflight", `Bool false) ])
+      in
+      Alcotest.(check bool) "fleet sandbox status ok" true ok;
+      let open Yojson.Safe.Util in
+      let json = parse_json_exn body in
+      let item =
+        json |> member "items" |> to_list
+        |> List.find_opt (fun row ->
+             row |> member "keeper" |> to_string = keeper_name)
+      in
+      match item with
+      | None -> Alcotest.fail "persisted keeper missing from fleet sandbox status"
+      | Some row ->
+          Alcotest.(check string) "persisted effective mode" "local"
+            (row |> member "effective_mode" |> to_string);
+          Alcotest.(check (option string)) "persisted why_no_container"
+            (Some "sandbox_profile=local")
+            (row |> member "why_no_container" |> to_string_option))
+
 let test_keeper_sandbox_start_status_stop_with_fake_docker () =
   Eio_main.run @@ fun env ->
   ensure_fs env;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -43,6 +43,12 @@ let read_file path =
   Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
   really_input_string ic (in_channel_length ic)
 
+let count_log_lines_with_prefix log prefix =
+  log
+  |> String.split_on_char '\n'
+  |> List.filter (fun line -> String.starts_with ~prefix line)
+  |> List.length
+
 let read_keeper_meta_exn config keeper_name =
   match Keeper_types.read_meta config keeper_name with
   | Ok (Some meta) -> meta
@@ -353,7 +359,7 @@ let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
       in
       ensure_dir keepers_dir;
       write_file
-        (Filename.concat keepers_dir "persisted_sandbox.toml")
+        (Filename.concat keepers_dir "sandbox_persisted.toml")
         "[keeper]\n\
          goal = \"Alias of persisted sandbox keeper\"\n\
          sandbox_profile = \"local\"\n\
@@ -385,6 +391,144 @@ let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
       | [] -> Alcotest.fail "persisted keeper missing from fleet sandbox status"
       | _ :: _ :: _ ->
           Alcotest.fail "persisted keeper duplicated in fleet sandbox status")
+
+let test_keeper_sandbox_status_fleet_includes_configured_keeper () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "configured-sandbox" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keepers_dir =
+        Filename.concat (Coord.masc_root_dir config) "config/keepers"
+      in
+      ensure_dir keepers_dir;
+      write_file
+        (Filename.concat keepers_dir (keeper_name ^ ".toml"))
+        "[keeper]\n\
+         goal = \"Configured-only sandbox keeper\"\n\
+         sandbox_profile = \"local\"\n\
+         proactive_enabled = false\n\
+         autoboot_enabled = false\n";
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:(`Assoc [ ("include_preflight", `Bool false) ])
+      in
+      Alcotest.(check bool) "fleet sandbox status ok" true ok;
+      let open Yojson.Safe.Util in
+      let json = parse_json_exn body in
+      let matching_items =
+        json |> member "items" |> to_list
+        |> List.filter (fun row ->
+             row |> member "keeper" |> to_string = keeper_name)
+      in
+      Alcotest.(check int) "configured keeper emits one fleet row" 1
+        (List.length matching_items);
+      match matching_items with
+      | [ row ] ->
+          Alcotest.(check string) "configured effective mode" "local"
+            (row |> member "effective_mode" |> to_string);
+          Alcotest.(check (option string)) "configured why_no_container"
+            (Some "sandbox_profile=local")
+            (row |> member "why_no_container" |> to_string_option)
+      | [] -> Alcotest.fail "configured keeper missing from fleet sandbox status"
+      | _ :: _ :: _ ->
+          Alcotest.fail "configured keeper duplicated in fleet sandbox status")
+
+let test_keeper_sandbox_status_fleet_reuses_docker_preflight () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_names = [ "fleet-docker-a"; "fleet-docker-b" ] in
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter Keeper_keepalive.stop_keepalive keeper_names;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      List.iter
+        (fun keeper_name ->
+          let ok, _ =
+            dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+              ~args:
+                (`Assoc
+                  [
+                    ("name", `String keeper_name);
+                    ("goal", `String "Inspect cached Docker preflight");
+                    ("proactive_enabled", `Bool false);
+                    ("autoboot_enabled", `Bool false);
+                  ])
+          in
+          Alcotest.(check bool) ("keeper up ok: " ^ keeper_name) true ok;
+          update_keeper_sandbox_mode config keeper_name
+            ~sandbox_profile:Keeper_types.Docker
+            ~network_mode:Keeper_types.Network_none)
+        keeper_names;
+      let state_dir = Filename.concat base_dir "fake-docker" in
+      let state_file = Filename.concat state_dir "containers.tsv" in
+      let log_path = Filename.concat state_dir "docker.log" in
+      ensure_dir state_dir;
+      with_fake_docker fake_docker_managed_sandbox_script @@ fun () ->
+      with_env "KEEPER_DOCKER_STATE_FILE" state_file @@ fun () ->
+      with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:
+            (`Assoc
+              [
+                ("include_preflight", `Bool true);
+                ("timeout_sec", `Float 1.0);
+              ])
+      in
+      Alcotest.(check bool) "fleet sandbox status ok" true ok;
+      let open Yojson.Safe.Util in
+      let json = parse_json_exn body in
+      let docker_items =
+        json |> member "items" |> to_list
+        |> List.filter (fun row ->
+             List.mem (row |> member "keeper" |> to_string) keeper_names)
+      in
+      Alcotest.(check int) "docker keepers emitted" 2
+        (List.length docker_items);
+      let log = read_file log_path in
+      Alcotest.(check int) "docker preflight info once" 1
+        (count_log_lines_with_prefix log "info "))
 
 let test_keeper_sandbox_start_status_stop_with_fake_docker () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -348,6 +348,16 @@ let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
+      (* Reviewer #13227 (thread 2): clearing the registry while the
+         [masc_keeper_up] keepalive fiber is still tracked turns the
+         later [stop_keepalive] in [Fun.protect ~finally] into a no-op
+         (it looks up running fibers via [Keeper_registry.all]).
+         Without this, the live keeper fiber leaks into other tests
+         and makes the suite flaky.  Stop the keepalive explicitly
+         before clearing so the inline reset still observes an empty
+         registry without orphaning the fiber.  The finally block
+         keeps its own [stop_keepalive] as a defensive cleanup. *)
+      Keeper_keepalive.stop_keepalive keeper_name;
       Keeper_registry.clear ();
       let ok, body =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"


### PR DESCRIPTION
## Summary
- Make masc_keeper_sandbox_status fleet mode enumerate persisted/configured keeper names as well as registered keepers.
- Update the tool schema wording from registered-only to persisted-or-registered.
- Add a regression for a persisted keeper whose registry entry is absent.

## Why
The Docker validation plan is about operator-visible multi-keeper truth. A durable keeper with meta on disk should not disappear from the sandbox fleet surface just because it is not currently registered in memory.

## Validation
- git diff --check

## Notes
- Local OCaml executable validation was not run yet because the shared Dune lock is held by another long-running masc-mcp build. Intended focused checks: MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_operator_control.exe and the matching test binary.