### PR TITLE
fix(keeper): fallback when active goal claim pool is empty

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -144,7 +144,7 @@ persona_name = "analyst"
 | `tool_preset` | Optional | Deployment-specific policy override | Only when intentionally overriding persona default. |
 | `github_identity` | Optional | Bound GitHub CLI identity bundle | Resolves to `.masc/github-identities/<identity>/gh` for keeper-scoped `gh` auth. Required when `MASC_KEEPER_SANDBOX_HARD_MODE=true`. |
 | `git_identity_mode` | Optional | Commit identity policy | `keeper_alias` keeps git author separate from GitHub auth; `github_identity` is reserved for future explicit coupling. |
-| `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` only considers tasks linked to these goals. |
+| `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` prefers tasks linked to these goals, then falls back to all claimable tasks if the scoped pool has no task claimable with the keeper's current capabilities. |
 
 ### Additional supported overlay fields
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -282,7 +282,7 @@ spawn 시 인자로 직접 설정하는 필드.
 | `shared_memory_scope` | string | `disabled` | typed shared-memory lane. `room`이면 keeper-authorized `masc_team_memory_*`를 flattened `default` namespace에서 사용 가능 | `masc_keeper_up`의 `shared_memory_scope` 인자 |
 | `github_identity` | string | 없음 | keeper에 바인딩된 GitHub CLI identity 이름. `.masc/github-identities/<identity>/gh` bundle을 사용한다. | `keeper.toml` 선언 |
 | `git_identity_mode` | string | `keeper_alias` | git author를 keeper alias로 유지할지, GitHub identity 기반 author로 결합할지 결정 | `keeper.toml` 선언 |
-| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 해당 goal에 링크된 task만 claim | `keeper.toml` 선언 |
+| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task를 우선 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 전체 claimable task로 fallback | `keeper.toml` 선언 |
 
 ### 3.1.1 Sandbox Core V1 사용법
 

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -85,71 +85,6 @@ let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
   `Assoc fields
 ;;
 
-type claim_goal_scope = {
-  task_filter : Masc_domain.task -> bool;
-  mode : string;
-  effective_goal_ids : string list;
-  fallback_reason : string option;
-}
-
-let goal_title_matches_keeper_purpose ~(meta : keeper_meta) goal =
-  String.equal goal.Goal_store.title
-    (Keeper_goal_repair.goal_title_of_purpose meta.goal)
-;;
-
-let active_goal_ids_are_auto_keeper_goals config ~(meta : keeper_meta) goal_ids =
-  goal_ids <> []
-  && List.for_all
-       (fun goal_id ->
-         match Goal_store.get_goal config ~goal_id with
-         | Some goal -> goal_title_matches_keeper_purpose ~meta goal
-         | None -> false)
-       goal_ids
-;;
-
-let active_goal_ids_have_claim_pool_task config goal_ids =
-  Coord.get_tasks_safe config
-  |> List.exists (fun task ->
-       Coord.task_is_claim_pool_candidate task
-       && Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task)
-;;
-
-let resolve_claim_goal_scope ~(config : Coord.config) ~(meta : keeper_meta) =
-  match meta.active_goal_ids with
-  | [] ->
-    { task_filter = (fun (_task : Masc_domain.task) -> true);
-      mode = "all_tasks";
-      effective_goal_ids = [];
-      fallback_reason = None;
-    }
-  | goal_ids ->
-    let scoped_filter task =
-      Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task
-    in
-    if not (active_goal_ids_have_claim_pool_task config goal_ids) then
-      let is_auto_goal =
-        active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
-      in
-      { task_filter = (fun (_task : Masc_domain.task) -> true);
-        mode =
-          (if is_auto_goal then "auto_goal_fallback_all_tasks"
-           else "empty_goal_scope_fallback_all_tasks");
-        effective_goal_ids = [];
-        fallback_reason =
-          Some
-            (if is_auto_goal then
-               "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks"
-             else
-               "active goal scope has no claimable linked tasks; falling back to all claimable tasks");
-      }
-    else
-      { task_filter = scoped_filter;
-        mode = "active_goal_ids";
-        effective_goal_ids = goal_ids;
-        fallback_reason = None;
-      }
-;;
-
 let find_task_goal_id config task_id =
   Coord.get_tasks_raw config
   |> List.find_map (fun (task : Masc_domain.task) ->
@@ -306,8 +241,13 @@ let handle_keeper_task_tool
                     "goal_id", Json_util.string_opt_to_json goal_id;
                   ])))
   | "keeper_task_claim" ->
-    let claim_goal_scope = resolve_claim_goal_scope ~config ~meta in
     let agent_tool_names = Keeper_tool_policy.keeper_allowed_tool_names meta in
+    let claim_goal_scope =
+      Keeper_runtime_contract.resolve_claim_goal_scope
+        ~agent_tool_names
+        ~config
+        ~meta
+    in
     let result =
       Coord.claim_next_r config ~agent_name:meta.agent_name ~agent_tool_names
         ~task_filter:claim_goal_scope.task_filter ()

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -126,15 +126,21 @@ let resolve_claim_goal_scope ~(config : Coord.config) ~(meta : keeper_meta) =
     let scoped_filter task =
       Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task
     in
-    if active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
-       && not (active_goal_ids_have_claim_pool_task config goal_ids)
-    then
+    if not (active_goal_ids_have_claim_pool_task config goal_ids) then
+      let is_auto_goal =
+        active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
+      in
       { task_filter = (fun (_task : Masc_domain.task) -> true);
-        mode = "auto_goal_fallback_all_tasks";
+        mode =
+          (if is_auto_goal then "auto_goal_fallback_all_tasks"
+           else "empty_goal_scope_fallback_all_tasks");
         effective_goal_ids = [];
         fallback_reason =
           Some
-            "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks";
+            (if is_auto_goal then
+               "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks"
+             else
+               "active goal scope has no claimable linked tasks; falling back to all claimable tasks");
       }
     else
       { task_filter = scoped_filter;

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -18,6 +18,95 @@ let task_is_linked_to_keeper_goals goal_ids (task : Masc_domain.task) =
     (fun goal_id -> Convergence.task_matches_goal ~goal_id task)
     goal_ids
 
+type claim_goal_scope = {
+  task_filter : Masc_domain.task -> bool;
+  mode : string;
+  effective_goal_ids : string list;
+  fallback_reason : string option;
+}
+
+let goal_title_matches_keeper_purpose ~(meta : keeper_meta) goal =
+  String.equal goal.Goal_store.title
+    (Keeper_goal_repair.goal_title_of_purpose meta.goal)
+
+let active_goal_ids_are_auto_keeper_goals config ~(meta : keeper_meta) goal_ids =
+  goal_ids <> []
+  && List.for_all
+       (fun goal_id ->
+         match Goal_store.get_goal config ~goal_id with
+         | Some goal -> goal_title_matches_keeper_purpose ~meta goal
+         | None -> false)
+       goal_ids
+
+let task_is_eligible_for_claim ?agent_tool_names latest_verification_status task =
+  Coord_task_schedule.task_is_claim_pool_candidate task
+  && not
+       (Coord_task_schedule.verification_blocks_claim
+          latest_verification_status
+          task)
+  && Coord_task_schedule.required_tools_allowed
+       ?agent_tool_names
+       (Coord_task_schedule.task_required_tools task)
+
+let active_goal_ids_have_eligible_claim_task
+    ?agent_tool_names
+    config
+    goal_ids
+  =
+  let latest_verification_status =
+    Coord_task_schedule.latest_verification_status_by_task config
+  in
+  Coord.get_tasks_safe config
+  |> List.exists (fun task ->
+       task_is_linked_to_keeper_goals goal_ids task
+       && task_is_eligible_for_claim
+            ?agent_tool_names
+            latest_verification_status
+            task)
+
+let resolve_claim_goal_scope ?agent_tool_names ~(config : Coord.config)
+    ~(meta : keeper_meta) =
+  match meta.active_goal_ids with
+  | [] ->
+      {
+        task_filter = (fun (_task : Masc_domain.task) -> true);
+        mode = "all_tasks";
+        effective_goal_ids = [];
+        fallback_reason = None;
+      }
+  | goal_ids ->
+      let scoped_filter task = task_is_linked_to_keeper_goals goal_ids task in
+      if
+        not
+          (active_goal_ids_have_eligible_claim_task
+             ?agent_tool_names
+             config
+             goal_ids)
+      then
+        let is_auto_goal =
+          active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
+        in
+        {
+          task_filter = (fun (_task : Masc_domain.task) -> true);
+          mode =
+            (if is_auto_goal then "auto_goal_fallback_all_tasks"
+             else "empty_goal_scope_fallback_all_tasks");
+          effective_goal_ids = [];
+          fallback_reason =
+            Some
+              (if is_auto_goal then
+                 "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks"
+               else
+                 "active goal scope has no claimable linked tasks; falling back to all claimable tasks");
+        }
+      else
+        {
+          task_filter = scoped_filter;
+          mode = "active_goal_ids";
+          effective_goal_ids = goal_ids;
+          fallback_reason = None;
+        }
+
 let task_is_blocked (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.AwaitingVerification _ -> true

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -3,6 +3,20 @@ val primary_goal_id_opt : Keeper_types.keeper_meta -> string option
 val backend_of_meta : Keeper_types.keeper_meta -> string
 val task_is_linked_to_keeper_goals :
   string list -> Masc_domain.task -> bool
+
+type claim_goal_scope = {
+  task_filter : Masc_domain.task -> bool;
+  mode : string;
+  effective_goal_ids : string list;
+  fallback_reason : string option;
+}
+
+val resolve_claim_goal_scope :
+  ?agent_tool_names:string list ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  claim_goal_scope
+
 val runtime_contract_json :
   ?config:Coord.config -> Keeper_types.keeper_meta -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -243,36 +243,15 @@ let backlog_updated_since_last_scheduled_autonomous
     | Some updated_at -> updated_at > last_ts
     | None -> false
 
-let goal_title_matches_keeper_purpose ~(meta : keeper_meta) goal =
-  String.equal goal.Goal_store.title
-    (Keeper_goal_repair.goal_title_of_purpose meta.goal)
-
-let active_goal_ids_are_auto_keeper_goals config ~(meta : keeper_meta) goal_ids =
-  goal_ids <> []
-  && List.for_all
-       (fun goal_id ->
-         match Goal_store.get_goal config ~goal_id with
-         | Some goal -> goal_title_matches_keeper_purpose ~meta goal
-         | None -> false)
-       goal_ids
-
-let active_goal_ids_have_claim_pool_task config goal_ids =
-  Coord.get_tasks_safe config
-  |> List.exists (fun task ->
-       Coord_task_schedule.task_is_claim_pool_candidate task
-       && Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task)
-
-let claim_goal_scope_filter ~(config : Coord.config) ~(meta : keeper_meta) =
-  match meta.active_goal_ids with
-  | [] -> fun (_task : Masc_domain.task) -> true
-  | goal_ids ->
-      let scoped_filter task =
-        Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task
-      in
-      if active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
-         && not (active_goal_ids_have_claim_pool_task config goal_ids)
-      then fun (_task : Masc_domain.task) -> true
-      else scoped_filter
+let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
+    ~(meta : keeper_meta) =
+  let scope =
+    Keeper_runtime_contract.resolve_claim_goal_scope
+      ?agent_tool_names
+      ~config
+      ~meta
+  in
+  scope.task_filter
 
 (** Read room backlog counts. *)
 let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
@@ -286,7 +265,12 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
         backlog.tasks
     in
     let unclaimed = List.length unclaimed_tasks in
-    let claim_scope_filter = claim_goal_scope_filter ~config ~meta in
+    let claim_scope_filter =
+      claim_goal_scope_filter
+        ?agent_tool_names:allowed_tool_names
+        ~config
+        ~meta
+    in
     let required_tools_allowed required_tools =
       match allowed_tool_names with
       | Some names ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -737,7 +737,9 @@ Use for status updates, announcements, warnings, or coordination.";
     name = "keeper_task_claim";
     description = "Claim the next unclaimed todo task that matches your capabilities. \
 Returns claimed task details (task_id, title, description) or empty if none available. \
-If the keeper has active_goal_ids configured, only goal-linked tasks are eligible.";
+If active_goal_ids are configured, goal-linked tasks are preferred; when that scoped \
+pool has no claimable task for your current capabilities, the claim falls back to all \
+claimable tasks.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -48,6 +48,13 @@ let only_task config =
     failwith
       (Printf.sprintf "expected exactly one task, got %d" (List.length tasks))
 
+let task_by_title config title =
+  Coord.get_tasks_raw config
+  |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.title title)
+  |> function
+  | Some task -> task
+  | None -> failwith (Printf.sprintf "task not found: %s" title)
+
 let strict_contract ?(verify_gate_evidence = []) () : Masc_domain.task_contract =
   {
     strict = true;
@@ -79,6 +86,20 @@ let contract_requiring_tools required_tools : Masc_domain.task_contract =
         autoresearch_loop_id = None;
       };
   }
+
+let create_pending_verification_request config ~task_id =
+  match
+    Verification.create_request
+      ~base_path:config.Coord.base_path
+      ~task_id
+      ~output:`Null
+      ~criteria:[]
+      ~worker:"test-worker"
+      ~request_id:(Printf.sprintf "vrf-%s" task_id)
+      ()
+  with
+  | Ok _ -> ()
+  | Error msg -> failwith (Printf.sprintf "create_request failed: %s" msg)
 
 (* Temp directory setup following test_keeper_tools_oas.ml pattern.
    Force filesystem backend by unsetting PG env vars. *)
@@ -422,6 +443,94 @@ let test_claim_falls_back_from_empty_persisted_goal_scope () =
           scope |> member "fallback_reason" |> to_string |> fun s ->
           String.length s > 0)
     | None -> fail "expected fallback to claim a product task")
+
+let test_claim_falls_back_when_scoped_task_requires_missing_tool () =
+  with_room (fun config ->
+    let scoped_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let product_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Product goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta =
+      { (make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ]) with
+        active_goal_ids = [ scoped_goal.id ];
+      }
+    in
+    let _ =
+      Coord_task.add_task
+        ~contract:(contract_requiring_tools [ "keeper_bash" ])
+        ~goal_id:scoped_goal.id
+        config
+        ~title:"Scoped task needing bash"
+        ~priority:1
+        ~description:"requires shell execution"
+    in
+    let _ =
+      Coord_task.add_task ~goal_id:product_goal.id config
+        ~title:"Product fallback task" ~priority:2 ~description:"desc"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    let claimed_task =
+      Coord.get_tasks_raw config
+      |> List.find_opt (fun (task : Masc_domain.task) ->
+           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
+    in
+    match claimed_task with
+    | Some task ->
+      check string "claimed fallback task" "Product fallback task" task.title;
+      let scope = Yojson.Safe.Util.member "claim_scope" json in
+      check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
+      check string "claim scope matched product goal" product_goal.id
+        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string)
+    | None -> fail "expected fallback to claim product task")
+
+let test_claim_falls_back_when_scoped_task_is_verification_blocked () =
+  with_room (fun config ->
+    let scoped_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Scoped verification goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let product_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Product goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta = make_goal_scoped_meta [ scoped_goal.id ] in
+    let _ =
+      Coord_task.add_task ~goal_id:scoped_goal.id config
+        ~title:"Scoped task pending verification" ~priority:1
+        ~description:"verification pending"
+    in
+    let scoped_task = task_by_title config "Scoped task pending verification" in
+    create_pending_verification_request config ~task_id:scoped_task.id;
+    let _ =
+      Coord_task.add_task ~goal_id:product_goal.id config
+        ~title:"Product fallback task" ~priority:2 ~description:"desc"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    let claimed_task =
+      Coord.get_tasks_raw config
+      |> List.find_opt (fun (task : Masc_domain.task) ->
+           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
+    in
+    match claimed_task with
+    | Some task ->
+      check string "claimed fallback task" "Product fallback task" task.title;
+      let scope = Yojson.Safe.Util.member "claim_scope" json in
+      check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
+      check string "claim scope matched product goal" product_goal.id
+        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string)
+    | None -> fail "expected fallback to claim product task")
 
 let test_claim_skips_required_tools_without_access () =
   with_room (fun config ->
@@ -888,6 +997,10 @@ let () =
         test_claim_falls_back_from_empty_auto_goal_scope;
       test_case "claim falls back from empty persisted goal scope" `Quick
         test_claim_falls_back_from_empty_persisted_goal_scope;
+      test_case "claim falls back when scoped task requires missing tool" `Quick
+        test_claim_falls_back_when_scoped_task_requires_missing_tool;
+      test_case "claim falls back when scoped task is verification blocked" `Quick
+        test_claim_falls_back_when_scoped_task_is_verification_blocked;
       test_case "claim skips tasks requiring missing tools" `Quick
         test_claim_skips_required_tools_without_access;
       test_case "claim allows tasks requiring available tools" `Quick

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -378,6 +378,51 @@ let test_claim_falls_back_from_empty_auto_goal_scope () =
           String.length s > 0)
     | None -> fail "expected fallback to claim a product task")
 
+let test_claim_falls_back_from_empty_persisted_goal_scope () =
+  with_room (fun config ->
+    let keeper_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Masc improver" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let product_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Product goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta =
+      { (make_test_meta ~name:"masc-improver" ()) with
+        active_goal_ids = [ keeper_goal.id ];
+      }
+    in
+    let _ =
+      Coord_task.add_task ~goal_id:product_goal.id config
+        ~title:"Product task" ~priority:1 ~description:"desc"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    let claimed_task =
+      Coord.get_tasks_raw config
+      |> List.find_opt (fun (task : Masc_domain.task) ->
+           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
+    in
+    match claimed_task with
+    | Some task ->
+      check string "claimed product task" "Product task" task.title;
+      let scope = Yojson.Safe.Util.member "claim_scope" json in
+      check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
+      check int "effective goal ids cleared" 0
+        Yojson.Safe.Util.(
+          scope |> member "effective_goal_ids" |> to_list |> List.length);
+      check string "claim scope matched product goal" product_goal.id
+        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string);
+      check bool "fallback reason present" true
+        Yojson.Safe.Util.(
+          scope |> member "fallback_reason" |> to_string |> fun s ->
+          String.length s > 0)
+    | None -> fail "expected fallback to claim a product task")
+
 let test_claim_skips_required_tools_without_access () =
   with_room (fun config ->
     let meta = make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ] in
@@ -841,6 +886,8 @@ let () =
         test_claim_respects_active_goal_ids;
       test_case "claim falls back from empty auto goal scope" `Quick
         test_claim_falls_back_from_empty_auto_goal_scope;
+      test_case "claim falls back from empty persisted goal scope" `Quick
+        test_claim_falls_back_from_empty_persisted_goal_scope;
       test_case "claim skips tasks requiring missing tools" `Quick
         test_claim_skips_required_tools_without_access;
       test_case "claim allows tasks requiring available tools" `Quick


### PR DESCRIPTION
## Summary
- fallback `keeper_task_claim` to the global claim pool when a keeper's `active_goal_ids` have no claimable linked tasks
- preserve strict scoped claiming when a scoped task exists, and preserve the existing auto-goal fallback mode
- add a regression for persisted non-auto keeper scopes such as `goal-masc-improver`

## Root Cause
Live `/Users/dancer/me` proof after #13220 showed `masc-improver` still rejected all 5 unclaimed tasks: `active_goal_scope=goal-masc-improver`, `excluded_count=5`, `fallback=None`. The code only applied all-task fallback for auto keeper goals whose title matched `Keeper_goal_repair.goal_title_of_purpose`, so persisted keeper goals with an empty claim pool remained scope-locked forever.

## Operator Impact
A keeper whose active goal has no claimable tasks can now pick up globally available repair work instead of posting another scope-lock analysis. If the active goal has an eligible linked task, scoped claiming still wins.

## Validation
- `git diff --check`
- PR checks: `CI Gate`, `PR Live Gate`, `PR Sync Check`, `Draft Auto-Merge Guard`, and meta guards passed; heavy build jobs skipped by draft/surface gating
- Local focused Dune build attempted with `scripts/dune-local.sh build test/test_keeper_task_dispatch.exe`
- Local build blocker: shared opam/OAS switch drift. `scripts/opam-pin-external-deps.sh` temporarily moved `agent_sdk` to `0.190.8`, but another concurrent process repinned the shared switch back to `agent_sdk 0.190.7`; the focused build then failed before this patch's test target on OAS dependency modules (`Llm_provider`, `Agent_sdk_base.Types`). Tracked separately in #13230.