### PR TITLE
fix(runtime): sanitize utf8 persistence writers

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -47,8 +47,28 @@ let write_current_seq config seq =
 let append_line path line =
   Fs_compat.append_file path line
 
+let sanitize_entity_ref (value : entity_ref) =
+  {
+    kind = Inference_utils.sanitize_text_utf8 value.kind;
+    id = Inference_utils.sanitize_text_utf8 value.id;
+  }
+
+let sanitize_event (value : event) =
+  {
+    value with
+    ts_iso = Inference_utils.sanitize_text_utf8 value.ts_iso;
+    room_id = Inference_utils.sanitize_text_utf8 value.room_id;
+    kind = Inference_utils.sanitize_text_utf8 value.kind;
+    actor = Option.map sanitize_entity_ref value.actor;
+    subject = Option.map sanitize_entity_ref value.subject;
+    payload = Inference_utils.sanitize_json_utf8 value.payload;
+    tags = List.map Inference_utils.sanitize_text_utf8 value.tags;
+  }
+
 let format_sse_event (value : event) =
-  let data = Yojson.Safe.to_string (event_to_yojson value) in
+  let data =
+    value |> sanitize_event |> event_to_yojson |> Yojson.Safe.to_string
+  in
   Printf.sprintf "id: %d\nevent: activity\ndata: %s\n\n" value.seq data
 
 (* ================================================================ *)
@@ -160,6 +180,7 @@ let emit config ?actor ?subject ?(tags = []) ~kind ~payload () =
             payload;
             tags;
           }
+          |> sanitize_event
         in
         append_line (day_path config)
           (Yojson.Safe.to_string (event_to_yojson value) ^ "\n");

--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -65,11 +65,14 @@ let sanitize_event (value : event) =
     tags = List.map Safe_ops.sanitize_text_utf8 value.tags;
   }
 
+let event_json_string (value : event) =
+  value |> sanitize_event |> event_to_yojson |> Yojson.Safe.to_string
+
+let format_sse_event_data ~seq data =
+  Printf.sprintf "id: %d\nevent: activity\ndata: %s\n\n" seq data
+
 let format_sse_event (value : event) =
-  let data =
-    value |> sanitize_event |> event_to_yojson |> Yojson.Safe.to_string
-  in
-  Printf.sprintf "id: %d\nevent: activity\ndata: %s\n\n" value.seq data
+  format_sse_event_data ~seq:value.seq (event_json_string value)
 
 (* ================================================================ *)
 (* Event reading                                                    *)
@@ -163,7 +166,7 @@ let latest_seq config = read_current_seq config
 (* ================================================================ *)
 
 let emit config ?actor ?subject ?(tags = []) ~kind ~payload () =
-  let value =
+  let value, json_line =
     Coord_utils.with_file_lock config (lock_path config) (fun () ->
         ensure_dirs config;
         let seq = read_current_seq config + 1 in
@@ -182,11 +185,11 @@ let emit config ?actor ?subject ?(tags = []) ~kind ~payload () =
           }
           |> sanitize_event
         in
-        append_line (day_path config)
-          (Yojson.Safe.to_string (event_to_yojson value) ^ "\n");
-        value)
+        let json_line = Yojson.Safe.to_string (event_to_yojson value) in
+        append_line (day_path config) (json_line ^ "\n");
+        (value, json_line))
   in
-  let encoded = format_sse_event value in
+  let encoded = format_sse_event_data ~seq:value.seq json_line in
   let snapshot =
     with_registry_ro (fun () -> Hashtbl.fold (fun key client acc -> (key, client) :: acc) clients [])
   in

--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -49,20 +49,20 @@ let append_line path line =
 
 let sanitize_entity_ref (value : entity_ref) =
   {
-    kind = Inference_utils.sanitize_text_utf8 value.kind;
-    id = Inference_utils.sanitize_text_utf8 value.id;
+    kind = Safe_ops.sanitize_text_utf8 value.kind;
+    id = Safe_ops.sanitize_text_utf8 value.id;
   }
 
 let sanitize_event (value : event) =
   {
     value with
-    ts_iso = Inference_utils.sanitize_text_utf8 value.ts_iso;
-    room_id = Inference_utils.sanitize_text_utf8 value.room_id;
-    kind = Inference_utils.sanitize_text_utf8 value.kind;
+    ts_iso = Safe_ops.sanitize_text_utf8 value.ts_iso;
+    room_id = Safe_ops.sanitize_text_utf8 value.room_id;
+    kind = Safe_ops.sanitize_text_utf8 value.kind;
     actor = Option.map sanitize_entity_ref value.actor;
     subject = Option.map sanitize_entity_ref value.subject;
-    payload = Inference_utils.sanitize_json_utf8 value.payload;
-    tags = List.map Inference_utils.sanitize_text_utf8 value.tags;
+    payload = Safe_ops.sanitize_json_utf8 value.payload;
+    tags = List.map Safe_ops.sanitize_text_utf8 value.tags;
   }
 
 let format_sse_event (value : event) =

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -149,7 +149,7 @@ let read_json_local_result path =
   Safe_ops.read_json_file_safe path
 
 let json_to_pretty_utf8 json =
-  json |> Inference_utils.sanitize_json_utf8 |> Yojson.Safe.pretty_to_string
+  json |> Safe_ops.sanitize_json_utf8 |> Yojson.Safe.pretty_to_string
 
 let write_json_local path json =
   mkdir_p (Filename.dirname path);

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -148,9 +148,12 @@ let read_json_local path =
 let read_json_local_result path =
   Safe_ops.read_json_file_safe path
 
+let json_to_pretty_utf8 json =
+  json |> Inference_utils.sanitize_json_utf8 |> Yojson.Safe.pretty_to_string
+
 let write_json_local path json =
   mkdir_p (Filename.dirname path);
-  let content = Yojson.Safe.pretty_to_string json in
+  let content = json_to_pretty_utf8 json in
   Fs_compat.save_file_atomic path content
 
 (* Root-scoped JSON helpers for shared room registry/current_room metadata. *)
@@ -179,7 +182,7 @@ let read_json_root config path =
 let write_json_root config path json =
   match root_key_of_path config path with
   | Some key ->
-      let content = Yojson.Safe.pretty_to_string json in
+      let content = json_to_pretty_utf8 json in
       (match backend_set config ~key ~value:content with
        | Ok () -> ()
        | Error e -> Log.Misc.warn "write_json_root backend_set failed for %s: %s" key (Backend_types.show_error e));
@@ -284,7 +287,7 @@ let should_dual_write_local (config : config) =
 let write_json config path json =
   match key_of_path config path with
   | Some key ->
-      let content = Yojson.Safe.pretty_to_string json in
+      let content = json_to_pretty_utf8 json in
       (match backend_set config ~key ~value:content with
        | Ok () -> ()
        | Error e -> Log.Misc.warn "write_json backend_set failed for %s: %s" key (Backend_types.show_error e));

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -189,6 +189,74 @@ let reset_persistence_utf8_repair_stats_for_tests () =
       utf8_repair_path_samples := [];
       Hashtbl.clear utf8_repair_log_seen)
 
+let is_disallowed_control_char (c : char) : bool =
+  let code = Char.code c in
+  (code < 32 && c <> '\n' && c <> '\r' && c <> '\t') || code = 127
+
+let sanitize_text_utf8 (s : string) : string =
+  let len = String.length s in
+  let rec has_invalid_or_control i =
+    if i >= len then false
+    else
+      let dec = String.get_utf_8_uchar s i in
+      let dlen = Uchar.utf_decode_length dec in
+      if dlen > 0 && Uchar.utf_decode_is_valid dec then
+        if dlen = 1 && is_disallowed_control_char s.[i] then true
+        else has_invalid_or_control (i + dlen)
+      else true
+  in
+  if not (has_invalid_or_control 0) then s
+  else
+    let buf = Buffer.create len in
+    let rec loop i =
+      if i >= len then ()
+      else
+        let dec = String.get_utf_8_uchar s i in
+        let dlen = Uchar.utf_decode_length dec in
+        if dlen > 0 && Uchar.utf_decode_is_valid dec then (
+          if dlen = 1 && is_disallowed_control_char s.[i] then
+            Buffer.add_char buf ' '
+          else
+            Buffer.add_substring buf s i dlen;
+          loop (i + dlen))
+        else (
+          Buffer.add_string buf "\xEF\xBF\xBD";
+          loop (i + 1))
+    in
+    loop 0;
+    Buffer.contents buf
+
+let rec sanitize_json_utf8 (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match json with
+  | `String s ->
+      let sanitized = sanitize_text_utf8 s in
+      if sanitized == s then json else `String sanitized
+  | `Assoc fields ->
+      let changed = ref false in
+      let sanitized_fields =
+        List.map
+          (fun (key, value) ->
+             let sanitized_key = sanitize_text_utf8 key in
+             let sanitized_value = sanitize_json_utf8 value in
+             if sanitized_key != key || sanitized_value != value then
+               changed := true;
+             (sanitized_key, sanitized_value))
+          fields
+      in
+      if !changed then `Assoc sanitized_fields else json
+  | `List items ->
+      let changed = ref false in
+      let sanitized_items =
+        List.map
+          (fun item ->
+             let sanitized = sanitize_json_utf8 item in
+             if sanitized != item then changed := true;
+             sanitized)
+          items
+      in
+      if !changed then `List sanitized_items else json
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as other -> other
+
 let count_invalid_utf8_bytes s =
   let len = String.length s in
   let rec loop i count =

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -255,7 +255,25 @@ let rec sanitize_json_utf8 (json : Yojson.Safe.t) : Yojson.Safe.t =
           items
       in
       if !changed then `List sanitized_items else json
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as other -> other
+  | `Tuple items ->
+      let changed = ref false in
+      let sanitized_items =
+        List.map
+          (fun item ->
+             let sanitized = sanitize_json_utf8 item in
+             if sanitized != item then changed := true;
+             sanitized)
+          items
+      in
+      if !changed then `Tuple sanitized_items else json
+  | `Variant (name, payload) ->
+      let sanitized_name = sanitize_text_utf8 name in
+      let sanitized_payload = Option.map sanitize_json_utf8 payload in
+      if sanitized_name != name || sanitized_payload != payload then
+        `Variant (sanitized_name, sanitized_payload)
+      else
+        json
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Floatlit _) as other -> other
 
 let count_invalid_utf8_bytes s =
   let len = String.length s in

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -50,6 +50,15 @@ val persistence_utf8_repair_log_entry_limit_for_tests : unit -> int
 val persistence_utf8_repair_log_key_count_for_tests : unit -> int
 (** Current UTF-8 repair warning rate-limit table size. Test-only. *)
 
+val sanitize_text_utf8 : string -> string
+(** Replace invalid UTF-8 bytes with U+FFFD and replace disallowed ASCII
+    control characters with spaces (except LF/CR/TAB), without recording a
+    read-path persistence repair. *)
+
+val sanitize_json_utf8 : Yojson.Safe.t -> Yojson.Safe.t
+(** Recursively scrub every JSON string node through {!sanitize_text_utf8}.
+    Intended for writer-side sanitization before persistence or broadcast. *)
+
 val parse_json_safe : context:string -> string -> (Yojson.Safe.t, string) result
 (** Parse JSON with detailed error reporting. *)
 

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -52,72 +52,9 @@ let timed (f : unit -> 'a) : 'a * int =
 (* UTF-8 Sanitization                                               *)
 (* ================================================================ *)
 
-let is_disallowed_control_char (c : char) : bool =
-  let code = Char.code c in
-  (code < 32 && c <> '\n' && c <> '\r' && c <> '\t') || code = 127
+let sanitize_text_utf8 = Safe_ops.sanitize_text_utf8
 
-let sanitize_text_utf8 (s : string) : string =
-  let len = String.length s in
-  (* Fast path: scan for invalid UTF-8 or prompt-breaking control chars
-     without allocating. Keep LF/CR/TAB because prompts rely on them. *)
-  let rec has_invalid_or_control i =
-    if i >= len then false
-    else
-      let dec = String.get_utf_8_uchar s i in
-      let dlen = Uchar.utf_decode_length dec in
-      if dlen > 0 && Uchar.utf_decode_is_valid dec then
-        if dlen = 1 && is_disallowed_control_char s.[i] then true
-        else has_invalid_or_control (i + dlen)
-      else true
-  in
-  if not (has_invalid_or_control 0) then s
-  else
-    let buf = Buffer.create len in
-    let rec loop i =
-      if i >= len then ()
-      else
-        let dec = String.get_utf_8_uchar s i in
-        let dlen = Uchar.utf_decode_length dec in
-        if dlen > 0 && Uchar.utf_decode_is_valid dec then (
-          if dlen = 1 && is_disallowed_control_char s.[i] then
-            Buffer.add_char buf ' '
-          else
-            Buffer.add_substring buf s i dlen;
-          loop (i + dlen))
-        else (
-          Buffer.add_string buf "\xEF\xBF\xBD";
-          loop (i + 1))
-    in
-    loop 0;
-    Buffer.contents buf
-
-let rec sanitize_json_utf8 (json : Yojson.Safe.t) : Yojson.Safe.t =
-  match json with
-  | `String s ->
-      let sanitized = sanitize_text_utf8 s in
-      if sanitized == s then json else `String sanitized
-  | `Assoc fields ->
-      let changed = ref false in
-      let sanitized_fields =
-        List.map (fun (key, value) ->
-          let sanitized_key = sanitize_text_utf8 key in
-          let sanitized_value = sanitize_json_utf8 value in
-          if sanitized_key != key || sanitized_value != value then changed := true;
-          (sanitized_key, sanitized_value)
-        ) fields
-      in
-      if !changed then `Assoc sanitized_fields else json
-  | `List items ->
-      let changed = ref false in
-      let sanitized_items =
-        List.map (fun item ->
-          let sanitized = sanitize_json_utf8 item in
-          if sanitized != item then changed := true;
-          sanitized
-        ) items
-      in
-      if !changed then `List sanitized_items else json
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as other -> other
+let sanitize_json_utf8 = Safe_ops.sanitize_json_utf8
 
 let rec sanitize_content_blocks_utf8
     (blocks : Agent_sdk.Types.content_block list)

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -56,6 +56,40 @@ let test_emit_and_list_events () =
       in
       check int "task filter" 1 (List.length task_only))
 
+let test_emit_sanitizes_invalid_utf8_before_persisting () =
+  with_config (fun config ->
+      Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
+      let replacement = "\xEF\xBF\xBD" in
+      ignore
+        (Activity_graph.emit config ~kind:"message.broadcast"
+           ~actor:(Activity_graph.entity ~kind:"agent" "bad\xffactor")
+           ~tags:[ "message"; "bad\xfftag" ]
+           ~payload:(`Assoc [ ("content", `String "bad\xffpayload") ])
+           ());
+      let events =
+        Activity_graph.list_events config ~after_seq:0 ~limit:10 ()
+      in
+      let event =
+        match events with
+        | [ event ] -> event
+        | _ -> fail "expected one event"
+      in
+      let open Yojson.Safe.Util in
+      check string "actor id repaired on write"
+        ("bad" ^ replacement ^ "actor")
+        (match event.actor with
+         | Some actor -> actor.id
+         | None -> fail "expected actor");
+      check string "tag repaired on write"
+        ("bad" ^ replacement ^ "tag")
+        (List.hd event.tags);
+      check string "payload repaired on write"
+        ("bad" ^ replacement ^ "payload")
+        (event.payload |> member "content" |> to_string);
+      let stats = Safe_ops.persistence_utf8_repair_stats () in
+      check int "read path did not repair activity graph row" 0
+        stats.repaired_reads)
+
 let test_filtered_client_receives_matching_events () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -302,6 +336,8 @@ let () =
       ( "core",
         [
           test_case "emit and list events" `Quick test_emit_and_list_events;
+          test_case "emit sanitizes invalid utf8 before persisting" `Quick
+            test_emit_sanitizes_invalid_utf8_before_persisting;
           test_case "filtered client receives matching events" `Quick
             test_filtered_client_receives_matching_events;
           test_case "graph summary builds nodes and edges" `Quick

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -82,7 +82,12 @@ let test_emit_sanitizes_invalid_utf8_before_persisting () =
          | None -> fail "expected actor");
       check string "tag repaired on write"
         ("bad" ^ replacement ^ "tag")
-        (List.hd event.tags);
+        (match event.tags with
+         | _ :: tag :: _ -> tag
+         | tags ->
+             fail
+               (Printf.sprintf "expected second tag, got %d"
+                  (List.length tags)));
       check string "payload repaired on write"
         ("bad" ^ replacement ^ "payload")
         (event.payload |> member "content" |> to_string);

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -185,6 +185,36 @@ let test_update_missing_goal_does_not_bump () =
   check int "version unchanged on missing update" before.version after.version;
   check string "updated_at unchanged on missing update" before.updated_at after.updated_at
 
+let test_write_state_sanitizes_invalid_utf8_before_persisting () =
+  with_room @@ fun config ->
+  Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
+  let replacement = "\xEF\xBF\xBD" in
+  let goal =
+    {
+      (make_goal "utf8-goal" "bad\xffgoal") with
+      metric = Some "metric\xffvalue";
+      target_value = Some "target\xffvalue";
+    }
+  in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ goal ] };
+  let raw = Fs_compat.load_file (Goal_store.goals_path config) in
+  check bool "raw file has no original invalid byte" false
+    (String.contains raw '\255');
+  let state = Goal_store.read_state config in
+  let saved_goal =
+    match state.goals with
+    | [ goal ] -> goal
+    | _ -> fail "expected one goal"
+  in
+  check string "title repaired on write" ("bad" ^ replacement ^ "goal")
+    saved_goal.title;
+  check (option string) "metric repaired on write"
+    (Some ("metric" ^ replacement ^ "value"))
+    saved_goal.metric;
+  let stats = Safe_ops.persistence_utf8_repair_stats () in
+  check int "read path did not repair goal store" 0 stats.repaired_reads
+
 let () =
   run "Goal_store.delete_goal"
     [ ( "regression-7690",
@@ -202,4 +232,6 @@ let () =
           test_case "list_goals filters by phase" `Quick
             test_list_goals_filters_by_phase;
           test_case "missing update: no bump" `Quick
-            test_update_missing_goal_does_not_bump ] ) ]
+            test_update_missing_goal_does_not_bump;
+          test_case "write_state sanitizes invalid utf8" `Quick
+            test_write_state_sanitizes_invalid_utf8_before_persisting ] ) ]

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -80,6 +80,35 @@ let test_parse_json_safe_rate_limits_repeated_utf8_repair_logs () =
   check int "both repairs counted" 2 stats.repaired_reads;
   check int "duplicate repair warning suppressed" 1 (List.length logs)
 
+let test_sanitize_json_utf8_covers_extended_safe_constructors () =
+  let open Safe_ops in
+  let replacement = "\xEF\xBF\xBD" in
+  let sanitized =
+    sanitize_json_utf8
+      (`Variant
+        ( "bad\xffvariant",
+          Some
+            (`Tuple
+              [
+                `String "bad\xfftuple";
+                `Floatlit "nan";
+                `Assoc [ ("bad\xffkey", `String "bad\xffvalue") ];
+              ]) ))
+  in
+  match sanitized with
+  | `Variant (name, Some (`Tuple [ `String tuple_value; `Floatlit "nan"; `Assoc fields ])) ->
+      check string "variant name repaired" ("bad" ^ replacement ^ "variant") name;
+      check string "tuple string repaired" ("bad" ^ replacement ^ "tuple") tuple_value;
+      let key, value =
+        match fields with
+        | [ field ] -> field
+        | _ -> fail "expected one assoc field"
+      in
+      check string "assoc key repaired" ("bad" ^ replacement ^ "key") key;
+      check string "assoc value repaired" ("bad" ^ replacement ^ "value")
+        (Yojson.Safe.Util.to_string value)
+  | _ -> fail "unexpected sanitized JSON shape"
+
 let test_utf8_repair_log_rate_limit_table_is_bounded () =
   let open Safe_ops in
   reset_persistence_utf8_repair_stats_for_tests ();
@@ -442,6 +471,8 @@ let () =
         test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair;
       test_case "rate limits repeated utf8 repair logs" `Quick
         test_parse_json_safe_rate_limits_repeated_utf8_repair_logs;
+      test_case "sanitizes extended safe constructors" `Quick
+        test_sanitize_json_utf8_covers_extended_safe_constructors;
       test_case "bounds utf8 repair log rate-limit table" `Quick
         test_utf8_repair_log_rate_limit_table_is_bounded;
       test_case "long invalid" `Quick test_parse_json_safe_long_invalid;


### PR DESCRIPTION
## Summary

- Sanitize all Coord JSON persistence through a shared Safe_ops UTF-8 JSON scrubber before writing.
- Sanitize activity graph event fields/payloads before JSONL persistence and SSE encoding.
- Keep Inference_utils as an alias for the shared Safe_ops sanitizer so existing callers keep their API.
- Add focused regressions proving invalid bytes are replaced at write time and read-side UTF-8 repair counters stay at zero for goals/activity rows.

## Product Impact

Live runtime logs showed repeated malformed UTF-8 repairs for /Users/dancer/me/.masc/goals.json and activity_graph:event_line. This moves the fix to the writers so dashboard reads should stop repeatedly repairing the same persisted bytes while keeping existing runtime diagnostics for any remaining corrupt legacy rows.

## Validation

- git diff --check origin/main...HEAD
- scripts/opam-pin-external-deps.sh --install (repaired local agent_sdk pin to repo-required 0.190.8)
- scripts/dune-local.sh build test/test_goal_store.exe test/test_activity_graph.exe
- _build/default/test/test_goal_store.exe (9 tests)
- _build/default/test/test_activity_graph.exe (11 tests)

Fixes #13210