### PR TITLE
test(keeper): pin slot reclaim after acquire flag

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -144,6 +144,11 @@ val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float ->
 (** Test-only: clear all per-keeper completion timestamps. *)
 val reset_autonomous_completion_for_test : unit -> unit
 
+(** Test-only: inject a callback immediately after an acquire flag is set
+    and before the diagnostic holder row is recorded. *)
+val set_after_acquire_flag_hook_for_test :
+  (label:string -> keeper_name:string -> unit) option -> unit
+
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
     per keeper. Promoted to [Keeper_fiber_crash] at
     [oas_timeout_budget_strike_limit]; reset on any successful turn.

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -365,6 +365,18 @@ type keeper_turn_slot_state = {
   autonomous_ticket : int option ref;
 }
 
+let after_acquire_flag_hook_for_test :
+  (label:string -> keeper_name:string -> unit) option ref =
+  ref None
+
+let set_after_acquire_flag_hook_for_test hook =
+  after_acquire_flag_hook_for_test := hook
+
+let run_after_acquire_flag_hook_for_test ~label ~keeper_name =
+  match !after_acquire_flag_hook_for_test with
+  | None -> ()
+  | Some hook -> hook ~label ~keeper_name
+
 (* Cancel-safe wrapper for bookkeeping calls that touch [Eio.Mutex.use_rw].
    Reached from [Fun.protect ~finally] in [with_keeper_turn_slot] when the
    keeper fiber is being cancelled.  If a mutex acquisition raises
@@ -705,6 +717,8 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
                  leaks; if it arrives after the flag set, release path
                  calls drop_holder (no-op when no entry exists). *)
               slot_state.acquired_autonomous := true;
+              run_after_acquire_flag_hook_for_test
+                ~label:"autonomous" ~keeper_name;
               record_holder ~label:"autonomous" ~keeper_name
                 ~acquired_at:(Time_compat.now ());
               drop_autonomous_waiter ~ticket;
@@ -729,6 +743,8 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
             | Ok () ->
               (* Cancel-race fix: flag THEN record_holder. *)
               slot_state.acquired_reactive := true;
+              run_after_acquire_flag_hook_for_test
+                ~label:"reactive" ~keeper_name;
               record_holder ~label:"reactive" ~keeper_name
                 ~acquired_at:(Time_compat.now ());
               Ok ()
@@ -741,6 +757,8 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
         | Ok () ->
           (* Cancel-race fix: flag THEN record_holder. *)
           slot_state.acquired_turn := true;
+          run_after_acquire_flag_hook_for_test
+            ~label:"turn" ~keeper_name;
           record_holder ~label:"turn" ~keeper_name
             ~acquired_at:(Time_compat.now ());
           let semaphore_wait_ms =

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -93,6 +93,13 @@ val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float ->
 (** Test-only: clear all per-keeper completion timestamps. *)
 val reset_autonomous_completion_for_test : unit -> unit
 
+(** Test-only: inject a callback immediately after an acquire flag is set
+    and before the diagnostic holder row is recorded.  Used to pin that
+    exception/cancel paths reclaim the semaphore even when no holder row
+    exists yet. *)
+val set_after_acquire_flag_hook_for_test :
+  (label:string -> keeper_name:string -> unit) option -> unit
+
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
     per keeper. Promoted to [Keeper_fiber_crash] at this limit. *)
 val oas_timeout_budget_strike_limit : int

--- a/test/fixtures/goal_loop/act-map.startup.json
+++ b/test/fixtures/goal_loop/act-map.startup.json
@@ -1,6 +1,7 @@
 {
   "D-EMERGENCY-1": [
-    "PR#13218 keeper credential auto-recovery"
+    "PR#13218 keeper credential auto-recovery",
+    "PR#13231 keeper slot forced-reclaim regression"
   ],
   "D-EMERGENCY-2": [
     "PR#13124 provider health probes"

--- a/test/fixtures/goal_loop/known-prs.startup.json
+++ b/test/fixtures/goal_loop/known-prs.startup.json
@@ -1,6 +1,11 @@
 {
   "prs": [
     {
+      "number": 13231,
+      "state": "OPEN",
+      "title": "test(keeper): pin slot reclaim after acquire flag"
+    },
+    {
       "number": 13218,
       "state": "OPEN",
       "title": "fix(keeper): self-heal archived credentials"

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -10,8 +10,11 @@
 
 module KK = Masc_mcp.Keeper_keepalive
 
+exception After_flag_injected
+
 let with_fresh_state body () =
   Eio_main.run @@ fun _env ->
+    KK.set_after_acquire_flag_hook_for_test None;
     KK.reset_autonomous_completion_for_test ();
     KK.reset_autonomous_turn_queue_for_test ();
     body ()
@@ -124,6 +127,36 @@ let test_slot_holders_summary_reflects_active_holder () =
   | Error (`Semaphore_wait_timeout _) ->
       failwith "unexpected semaphore wait timeout in test"
 
+let test_reactive_slot_released_when_hook_raises_after_flag () =
+  let keeper_name = "diag-after-flag" in
+  let before = KK.reactive_turn_semaphore_value_for_test () in
+  KK.set_after_acquire_flag_hook_for_test
+    (Some
+       (fun ~label ~keeper_name:seen ->
+          if label = "reactive" && seen = keeper_name then
+            raise After_flag_injected));
+  let clear_hook () = KK.set_after_acquire_flag_hook_for_test None in
+  (try
+     ignore
+       (KK.with_keeper_turn_slot_for_test
+          ~keeper_name
+          ~channel:Masc_mcp.Keeper_world_observation.Reactive
+          (fun ~semaphore_wait_ms:_ ->
+             failwith "hook should raise before user callback"));
+     clear_hook ();
+     failwith "expected injected hook to raise"
+   with
+   | After_flag_injected -> clear_hook ()
+   | exn ->
+       clear_hook ();
+       raise exn);
+  let after = KK.reactive_turn_semaphore_value_for_test () in
+  assert_eq ~msg:"reactive slot released after injected failure"
+    ~expected:before ~actual:after;
+  let names = List.map fst (KK.reactive_slot_holders ~now:(Time_compat.now ())) in
+  if List.mem keeper_name names then
+    failwith "reactive holder leaked after injected failure"
+
 let () =
   let cases =
     [
@@ -139,6 +172,8 @@ let () =
         test_holders_released_after_slot_returned;
       "slot_holders_summary mentions the active holder",
         test_slot_holders_summary_reflects_active_holder;
+      "reactive slot releases when hook raises after acquired flag",
+        test_reactive_slot_released_when_hook_raises_after_flag;
     ]
   in
   List.iter

--- a/test/test_validate_goal_loop_act_map.py
+++ b/test/test_validate_goal_loop_act_map.py
@@ -34,9 +34,9 @@ class ValidateGoalLoopActMapTest(unittest.TestCase):
             require_pr_ref=True,
         )
 
-        self.assertEqual(report.artifact_count, 4)
-        self.assertEqual(report.pr_ref_count, 4)
-        self.assertEqual(report.known_pr_count, 4)
+        self.assertEqual(report.artifact_count, 6)
+        self.assertEqual(report.pr_ref_count, 6)
+        self.assertEqual(report.known_pr_count, 6)
         self.assertEqual(report.missing_pr_count, 0)
         self.assertEqual(report.malformed_artifact_count, 0)
 


### PR DESCRIPTION
## Summary
- add a test-only hook immediately after a keeper turn slot acquired flag is set and before holder recording
- add a regression proving a reactive-slot exception at that point still releases the semaphore and leaves no stale holder row
- link PR#13231 into the GOAL LOOP ACT map as the slot forced-reclaim artifact for D-EMERGENCY-1
- closes the deterministic regression gap called out in #13219 for the D-EMERGENCY-1 slot forced reclaim path

## Verification
- ocamlc -stop-after parsing lib/keeper/keeper_turn_slot.ml
- ocamlc -stop-after parsing lib/keeper/keeper_turn_slot.mli
- ocamlc -stop-after parsing lib/keeper/keeper_keepalive.mli
- ocamlc -stop-after parsing test/test_keeper_turn_slot_holders.ml
- git diff --check HEAD~1
- scripts/dune-local.sh build test/test_keeper_turn_slot_holders.exe
- ./_build/default/test/test_keeper_turn_slot_holders.exe
- python3 scripts/validate_goal_loop_act_map.py test/fixtures/goal_loop/act-map.startup.json --known-prs-json test/fixtures/goal_loop/known-prs.startup.json --require-pr-ref --fail-on any
- python3 test/test_goal_loop_status.py
- python3 test/test_validate_goal_loop_act_map.py
- npx pyright --outputjson test/test_validate_goal_loop_act_map.py test/test_goal_loop_status.py scripts/validate_goal_loop_act_map.py
- ruff check test/test_validate_goal_loop_act_map.py test/test_goal_loop_status.py scripts/validate_goal_loop_act_map.py
- ruff format --check test/test_validate_goal_loop_act_map.py test/test_goal_loop_status.py scripts/validate_goal_loop_act_map.py

## Note
- After rebasing on current origin/main, parse and diff checks were repeated. A second focused Dune rebuild was queued behind long-running shared Dune lock holders and was stopped; the same diff had already passed focused build and executable run before the clean rebase.