### PR TITLE
fix(ide): prefer workspace repository by default

### DIFF
--- a/dashboard/src/components/ide/ide-data-coordinator.test.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.test.ts
@@ -42,6 +42,24 @@ describe('selectPreferredIdeRepositoryId', () => {
     expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('masc-mcp')
   })
 
+  it('prefers a masc-mcp workspace when a same-name mirror appears first', () => {
+    const repositories = [
+      repo('mirror-masc', '.masc/repos/mirror-masc', 'masc-mcp'),
+      repo('workspace-masc', '/Users/dancer/me/workspace/yousleepwhen/masc-mcp', 'masc-mcp'),
+    ]
+
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('workspace-masc')
+  })
+
+  it('does not treat absolute .masc/repos mirrors as workspace checkouts', () => {
+    const repositories = [
+      repo('mirror-masc', '/Users/dancer/me/.masc/repos/mirror-masc', 'masc-mcp'),
+      repo('workspace-oas', '/Users/dancer/me/workspace/yousleepwhen/oas', 'oas'),
+    ]
+
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('workspace-oas')
+  })
+
   it('falls back to the first visible absolute workspace repository', () => {
     const repositories = [
       repo('masc', '.masc/repos/masc'),

--- a/dashboard/src/components/ide/ide-data-coordinator.test.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { selectPreferredIdeRepositoryId } from './ide-data-coordinator'
+import type { Repository } from '../../api/repositories'
+
+function repo(
+  id: string,
+  localPath: string,
+  name = id,
+): Repository {
+  return {
+    id,
+    name,
+    url: '',
+    local_path: localPath,
+    default_branch: 'main',
+    status: 'active',
+    auto_sync: false,
+    sync_interval: 300,
+    credential_id: null,
+    created_at: null,
+    updated_at: null,
+  }
+}
+
+describe('selectPreferredIdeRepositoryId', () => {
+  it('keeps the current repository when it is still present', () => {
+    const repositories = [
+      repo('masc-mcp', '/Users/dancer/me/workspace/yousleepwhen/masc-mcp'),
+      repo('oas', '.masc/repos/oas'),
+    ]
+
+    expect(selectPreferredIdeRepositoryId(repositories, 'oas')).toBe('oas')
+  })
+
+  it('prefers the actual masc-mcp workspace over managed mirrors', () => {
+    const repositories = [
+      repo('masc', '.masc/repos/masc'),
+      repo('oas', '.masc/repos/oas'),
+      repo('masc-mcp', '/Users/dancer/me/workspace/yousleepwhen/masc-mcp'),
+    ]
+
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('masc-mcp')
+  })
+
+  it('falls back to the first visible absolute workspace repository', () => {
+    const repositories = [
+      repo('masc', '.masc/repos/masc'),
+      repo('kidsnote-shop', '/Users/dancer/me/workspace/kidsnote/kidsnote-shop'),
+    ]
+
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('kidsnote-shop')
+  })
+
+  it('falls back to the first repository when only mirrors exist', () => {
+    const repositories = [
+      repo('masc', '.masc/repos/masc'),
+      repo('oas', '.masc/repos/oas'),
+    ]
+
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('masc')
+  })
+})

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -49,6 +49,32 @@ function firstFilePath(nodes: ReadonlyArray<{ readonly path: string; readonly ha
   return firstFile?.path ?? null
 }
 
+function isManagedMirrorRepository(repository: Repository): boolean {
+  return repository.local_path === `.masc/repos/${repository.id}`
+    || repository.local_path.startsWith('.masc/repos/')
+}
+
+function isWorkspaceRepository(repository: Repository): boolean {
+  return repository.local_path.startsWith('/')
+    && !repository.local_path.includes('/.masc/')
+}
+
+export function selectPreferredIdeRepositoryId(
+  repositories: ReadonlyArray<Repository>,
+  current: string | null,
+): string | null {
+  if (current && repositories.some(repository => repository.id === current)) {
+    return current
+  }
+
+  return repositories.find(repository => repository.id === 'masc-mcp')?.id
+    ?? repositories.find(repository => repository.name === 'masc-mcp')?.id
+    ?? repositories.find(isWorkspaceRepository)?.id
+    ?? repositories.find(repository => !isManagedMirrorRepository(repository))?.id
+    ?? repositories[0]?.id
+    ?? null
+}
+
 export function createIdeDataCoordinator(): IdeDataCoordinator {
   const documentStore = createCodeDocumentStore({
     file_path: activeIdeFile.value,
@@ -67,10 +93,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
 
   const applyRepositories = (repositories: ReadonlyArray<Repository>): void => {
     const current = activeRepositoryIdSignal.value
-    const nextActive = current && repositories.some(repository => repository.id === current)
-      ? current
-      : repositories[0]?.id ?? null
-    activeRepositoryIdSignal.value = nextActive
+    activeRepositoryIdSignal.value = selectPreferredIdeRepositoryId(repositories, current)
     repositoriesSignal.value = repositories
   }
 

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -56,10 +56,19 @@ function isManagedMirrorRepository(repository: Repository): boolean {
     || localPath.includes('/.masc/repos/')
 }
 
+// Reviewer #13232: detect Windows drive-letter absolute paths
+// (e.g. "C:/Users/.../repo" or "D:\\projects\\repo") after
+// backslash normalization so workspace repos on Windows are not
+// classified as managed mirrors and dropped from IDE default
+// selection.  Posix absolute paths still match via the
+// leading-slash branch.
+const WINDOWS_DRIVE_LETTER_PREFIX = /^[A-Za-z]:\//
 function isWorkspaceRepository(repository: Repository): boolean {
   const localPath = repository.local_path.replace(/\\/g, '/')
-  return localPath.startsWith('/')
-    && !localPath.includes('/.masc/')
+  const isAbsolute =
+    localPath.startsWith('/') ||
+    WINDOWS_DRIVE_LETTER_PREFIX.test(localPath)
+  return isAbsolute && !localPath.includes('/.masc/')
 }
 
 function isMascMcpRepository(repository: Repository): boolean {

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -50,13 +50,20 @@ function firstFilePath(nodes: ReadonlyArray<{ readonly path: string; readonly ha
 }
 
 function isManagedMirrorRepository(repository: Repository): boolean {
-  return repository.local_path === `.masc/repos/${repository.id}`
-    || repository.local_path.startsWith('.masc/repos/')
+  const localPath = repository.local_path.replace(/\\/g, '/')
+  return localPath === `.masc/repos/${repository.id}`
+    || localPath.startsWith('.masc/repos/')
+    || localPath.includes('/.masc/repos/')
 }
 
 function isWorkspaceRepository(repository: Repository): boolean {
-  return repository.local_path.startsWith('/')
-    && !repository.local_path.includes('/.masc/')
+  const localPath = repository.local_path.replace(/\\/g, '/')
+  return localPath.startsWith('/')
+    && !localPath.includes('/.masc/')
+}
+
+function isMascMcpRepository(repository: Repository): boolean {
+  return repository.id === 'masc-mcp' || repository.name === 'masc-mcp'
 }
 
 export function selectPreferredIdeRepositoryId(
@@ -67,9 +74,9 @@ export function selectPreferredIdeRepositoryId(
     return current
   }
 
-  return repositories.find(repository => repository.id === 'masc-mcp')?.id
-    ?? repositories.find(repository => repository.name === 'masc-mcp')?.id
+  return repositories.find(repository => isMascMcpRepository(repository) && isWorkspaceRepository(repository))?.id
     ?? repositories.find(isWorkspaceRepository)?.id
+    ?? repositories.find(isMascMcpRepository)?.id
     ?? repositories.find(repository => !isManagedMirrorRepository(repository))?.id
     ?? repositories[0]?.id
     ?? null

--- a/dashboard/src/components/ide/ide-presence-strip.test.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.test.ts
@@ -57,8 +57,8 @@ describe('parseWorktreeSSE', () => {
 
     const result = parseWorktreeSSE(body)
     expect(result).toHaveLength(2)
-    expect(result[0].branch).toBe('nick0cave/wt-run-47')
-    expect(result[1].branch).toBe('improver/p0a-worktree-status-sse')
+    expect(result[0]?.branch).toBe('nick0cave/wt-run-47')
+    expect(result[1]?.branch).toBe('improver/p0a-worktree-status-sse')
   })
 
   it('skips empty data payload and non-data lines', () => {
@@ -76,7 +76,7 @@ describe('parseWorktreeSSE', () => {
     const body = 'data: {not valid json}\ndata: ' + JSON.stringify(sampleWorktrees[0])
     const result = parseWorktreeSSE(body)
     expect(result).toHaveLength(1)
-    expect(result[0].branch).toBe('nick0cave/wt-run-47')
+    expect(result[0]?.branch).toBe('nick0cave/wt-run-47')
   })
 
   it('workspace_label is populated from workspaceLabelForAgent using parsed SSE', () => {


### PR DESCRIPTION
## Summary

- Prefer the actual `masc-mcp` workspace repository when the Code IDE has no current repository selection.
- Fall back to visible absolute workspace repositories before managed `.masc/repos/*` mirrors, while preserving an existing valid selection.
- Add focused coverage for IDE repository default selection and keep the existing presence-strip test compatible with strict indexed access.

## Product impact

The Keeper IDE no longer opens against the managed `masc` mirror by default after repository discovery. On the live `~/me` runtime, the Code IDE now lands on the real `masc-mcp` checkout under `/Users/dancer/me/workspace/yousleepwhen/masc-mcp`, so the explorer and editor show the workspace users expect instead of a basepath mirror.

## Evidence

- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-data-coordinator.test.ts src/components/ide/ide-presence-strip.test.ts src/api/repositories.test.ts src/components/repo-sidebar.test.ts src/api/workspace.test.ts`
  - 5 files passed, 40 tests passed.
- `git diff --check`
- Live dashboard screenshot: `/tmp/masc-code-ide-default-repo-0505.png`
  - Shows repository selector defaulting to `masc-mcp · /Users/dancer/me/...` with populated explorer/editor.
- `curl -fsS http://127.0.0.1:8935/health`
  - `status=ok`, `version=0.19.10`, `commit=4fc454e76`, `effective_base_path=/Users/dancer/me`, `effective_masc_root=/Users/dancer/me/.masc`.

## Review evidence

- Scope is limited to dashboard IDE repository selection plus tests.
- Existing valid active repository IDs are preserved, so manual repository changes are not overridden on refresh.
- Managed mirrors remain a last-resort fallback for runtimes that only have `.masc/repos/*` entries.

## Linked issue

- None.
