### PR TITLE
feat(keeper): meter memory consolidation flow

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -536,6 +536,77 @@ let write_memory_bank_rows
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "failed to rewrite memory bank: %s" (Printexc.to_string exn))
 
+let drop_memory_rows n rows =
+  let rec go remaining rest =
+    if remaining <= 0 then rest
+    else
+      match rest with
+      | [] -> []
+      | _ :: tl -> go (remaining - 1) tl
+  in
+  go n rows
+
+let consolidation_metric_source source =
+  match source with
+  | "progress_consolidation" | "cross_trace_recurrence" -> source
+  | _ -> "other"
+
+let memory_row_identity (row : keeper_memory_row_raw) =
+  Yojson.Safe.to_string row.json
+
+let count_rows_by_consolidation_source rows =
+  rows
+  |> List.fold_left
+       (fun acc (row : keeper_memory_row_raw) ->
+         let source = consolidation_metric_source row.source in
+         let cur = Option.value ~default:0 (List.assoc_opt source acc) in
+         (source, cur + 1) :: List.remove_assoc source acc)
+       []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
+let record_memory_consolidation_metrics ~keeper_name ~outcome rows =
+  count_rows_by_consolidation_source rows
+  |> List.iter (fun (source, count) ->
+       if count > 0 then
+         Prometheus.inc_counter
+           Prometheus.metric_keeper_memory_consolidations
+           ~labels:
+             [
+               ("keeper", keeper_name);
+               ("source", source);
+               ("outcome", outcome);
+             ]
+           ~delta:(float_of_int count)
+           ())
+
+let retained_generated_rows ~generated selected =
+  let ids : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (fun (row : keeper_memory_row_raw) ->
+      Hashtbl.replace ids (memory_row_identity row) ())
+    generated;
+  List.filter
+    (fun (row : keeper_memory_row_raw) ->
+      Hashtbl.mem ids (memory_row_identity row))
+    selected
+
+let evicted_generated_rows ~generated ~retained =
+  let retained_ids : (string, int) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (fun (row : keeper_memory_row_raw) ->
+      let id = memory_row_identity row in
+      let cur = Option.value ~default:0 (Hashtbl.find_opt retained_ids id) in
+      Hashtbl.replace retained_ids id (cur + 1))
+    retained;
+  generated
+  |> List.filter (fun (row : keeper_memory_row_raw) ->
+       let id = memory_row_identity row in
+       match Hashtbl.find_opt retained_ids id with
+       | Some n when n > 0 ->
+           Hashtbl.replace retained_ids id (n - 1);
+           false
+       | _ -> true)
+
 let compact_memory_bank_if_needed
     (config : Coord.config)
     (meta : keeper_meta) : memory_bank_compaction =
@@ -591,7 +662,14 @@ let compact_memory_bank_if_needed
             let (consolidated_parsed, consolidated_count) =
               consolidate_memory_notes parsed
             in
-            let _ = consolidated_count in
+            let generated_consolidated =
+              drop_memory_rows before_notes consolidated_parsed
+            in
+            if consolidated_count > 0 then
+              record_memory_consolidation_metrics
+                ~keeper_name:meta.name
+                ~outcome:"generated"
+                generated_consolidated;
             let current_generation = meta.runtime.generation in
             let by_recency =
               List.sort
@@ -699,6 +777,10 @@ let compact_memory_bank_if_needed
               else
                 match write_memory_bank_rows path selected with
                 | Error _ ->
+                    record_memory_consolidation_metrics
+                      ~keeper_name:meta.name
+                      ~outcome:"write_failed"
+                      generated_consolidated;
                     { no_memory_bank_compaction with
                       target_notes;
                       before_notes;
@@ -708,6 +790,24 @@ let compact_memory_bank_if_needed
                       reason = Some "write_failed";
                     }
                 | Ok () ->
+                    let retained =
+                      retained_generated_rows
+                        ~generated:generated_consolidated
+                        selected
+                    in
+                    let evicted =
+                      evicted_generated_rows
+                        ~generated:generated_consolidated
+                        ~retained
+                    in
+                    record_memory_consolidation_metrics
+                      ~keeper_name:meta.name
+                      ~outcome:"persisted"
+                      retained;
+                    record_memory_consolidation_metrics
+                      ~keeper_name:meta.name
+                      ~outcome:"evicted"
+                      evicted;
                     {
                       performed = true;
                       reason = Some "compacted";

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -679,6 +679,8 @@ let metric_keeper_checkpoint_failures =
   "masc_keeper_checkpoint_failures_total"
 let metric_keeper_memory_write_failures =
   "masc_keeper_memory_write_failures_total"
+let metric_keeper_memory_consolidations =
+  "masc_keeper_memory_consolidations_total"
 let metric_keeper_write_meta_cycle_failures =
   "masc_keeper_write_meta_cycle_failures_total"
 let metric_keeper_alert_persist_failures =
@@ -1859,6 +1861,11 @@ let init () =
   add metric_keeper_memory_write_failures
     "Total memory write failures (notes/kinds) in keeper_agent_run. \
      Labeled by keeper."
+    Counter;
+  add metric_keeper_memory_consolidations
+    "Total keeper memory-bank consolidation rows. \
+     Labels: keeper, source=progress_consolidation|cross_trace_recurrence|other, \
+     outcome=generated|persisted|evicted|write_failed."
     Counter;
   add metric_keeper_write_meta_cycle_failures
     "Total write_meta failures after turn/cycle in keeper_unified_turn. \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -308,6 +308,7 @@ val metric_keeper_cascade_sync_failures : string
 val metric_keeper_thinking_persist_failures : string
 val metric_keeper_checkpoint_failures : string
 val metric_keeper_memory_write_failures : string
+val metric_keeper_memory_consolidations : string
 val metric_keeper_write_meta_cycle_failures : string
 val metric_keeper_alert_persist_failures : string
 val metric_keeper_metrics_sse_failures : string

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1207,6 +1207,135 @@ let test_cap_dropped_by_total () =
   let dropped = result.dropped_by_total_cap in
   check int "total drops 8" 8 dropped
 
+let memory_metric_value ~keeper ~source ~outcome =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_keeper_memory_consolidations
+    ~labels:[("keeper", keeper); ("source", source); ("outcome", outcome)]
+    ()
+
+let memory_bank_test_row ~kind ~trace_id ~text ~priority ~idx =
+  Yojson.Safe.to_string
+    (`Assoc
+       [
+         ("schema_version", `Int Keeper_memory_bank.keeper_memory_schema_version);
+         ("kind", `String kind);
+         ("horizon", `String (Keeper_memory_bank.memory_horizon_of_kind kind));
+         ("source", `String "test_seed");
+         ("text", `String text);
+         ("priority", `Int priority);
+         ("generation", `Int 1);
+         ("trace_id", `String trace_id);
+         ("turn", `Int idx);
+         ("ts_unix", `Float (1000.0 +. float_of_int idx));
+         ("ts", `String "2026-01-01T00:00:00Z");
+       ])
+
+let test_compaction_records_consolidation_metrics () =
+  with_env "MASC_KEEPER_MEMORY_MAX_NOTES" "40" @@ fun () ->
+  with_env "MASC_KEEPER_MEMORY_MAX_LENGTH" "4096" @@ fun () ->
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir_recursive dir) (fun () ->
+    let keeper = "metric-memory-keeper" in
+    let config = make_test_room_config dir in
+    let meta = keeper_meta ~name:keeper ~mention_targets:[keeper] () in
+    let bank_path = Keeper_types.keeper_memory_bank_path config keeper in
+    Keeper_types.mkdir_p (Filename.dirname bank_path);
+    let progress_rows =
+      List.init 3 (fun i ->
+        memory_bank_test_row
+          ~kind:"progress"
+          ~trace_id:"trace-progress"
+          ~text:
+            (Printf.sprintf
+               "progress cluster item %d retains enough semantic detail %s"
+               i (String.make 700 'p'))
+          ~priority:80
+          ~idx:i)
+    in
+    let recurring_text =
+      "shared durable finding survives recurrence telemetry "
+      ^ String.make 700 'r'
+    in
+    let recurring_rows =
+      List.init 3 (fun i ->
+        memory_bank_test_row
+          ~kind:"decision"
+          ~trace_id:(Printf.sprintf "trace-recurring-%d" i)
+          ~text:recurring_text
+          ~priority:85
+          ~idx:(10 + i))
+    in
+    let filler_rows =
+      List.init 74 (fun i ->
+        memory_bank_test_row
+          ~kind:"goal"
+          ~trace_id:(Printf.sprintf "trace-fill-%d" i)
+          ~text:
+            (Printf.sprintf
+               "filler note %03d pushes memory bank over compaction trigger %s"
+               i (String.make 700 'f'))
+          ~priority:10
+          ~idx:(100 + i))
+    in
+    let content =
+      String.concat "\n" (progress_rows @ recurring_rows @ filler_rows) ^ "\n"
+    in
+    (match Fs_compat.save_file_atomic bank_path content with
+     | Ok () -> ()
+     | Error err -> fail ("failed to seed memory bank: " ^ err));
+    let generated_progress_before =
+      memory_metric_value
+        ~keeper
+        ~source:"progress_consolidation"
+        ~outcome:"generated"
+    in
+    let generated_recurrence_before =
+      memory_metric_value
+        ~keeper
+        ~source:"cross_trace_recurrence"
+        ~outcome:"generated"
+    in
+    let persisted_progress_before =
+      memory_metric_value
+        ~keeper
+        ~source:"progress_consolidation"
+        ~outcome:"persisted"
+    in
+    let persisted_recurrence_before =
+      memory_metric_value
+        ~keeper
+        ~source:"cross_trace_recurrence"
+        ~outcome:"persisted"
+    in
+    let compaction =
+      Keeper_memory_bank.compact_memory_bank_if_needed config meta
+    in
+    check bool "compaction ran" true compaction.performed;
+    check (float 0.001) "progress consolidation generated"
+      (generated_progress_before +. 1.0)
+      (memory_metric_value
+         ~keeper
+         ~source:"progress_consolidation"
+         ~outcome:"generated");
+    check (float 0.001) "recurrence consolidation generated"
+      (generated_recurrence_before +. 1.0)
+      (memory_metric_value
+         ~keeper
+         ~source:"cross_trace_recurrence"
+         ~outcome:"generated");
+    check (float 0.001) "progress consolidation persisted"
+      (persisted_progress_before +. 1.0)
+      (memory_metric_value
+         ~keeper
+         ~source:"progress_consolidation"
+         ~outcome:"persisted");
+    check (float 0.001) "recurrence consolidation persisted"
+      (persisted_recurrence_before +. 1.0)
+      (memory_metric_value
+         ~keeper
+         ~source:"cross_trace_recurrence"
+         ~outcome:"persisted"))
+
 let () =
   run "Keeper_memory"
     [
@@ -1343,5 +1472,7 @@ let () =
         [
           test_case "cap enforcement reports dropped_by_kind" `Quick test_cap_dropped_by_kind;
           test_case "total cap reports dropped_by_total_cap" `Quick test_cap_dropped_by_total;
+          test_case "compaction records consolidation metrics" `Quick
+            test_compaction_records_consolidation_metrics;
         ] );
     ]


### PR DESCRIPTION
## What

- Add `masc_keeper_memory_consolidations_total` for memory-bank consolidation flow.
- Emit bounded labels for keeper, consolidation source, and outcome:
  `generated`, `persisted`, `evicted`, `write_failed`.
- Add a keeper-memory regression that forces compaction and verifies both progress consolidation and cross-trace recurrence metrics.

## Why

`memory_tier_summary` shows the current tier counts after the fact, but operators could not tell whether long-term rows were being generated by compaction and then retained, evicted, or lost on write failure. This makes the memory pipeline observable without scraping JSONL internals.

## Validation

- `git diff --check origin/main..HEAD`
- Attempted `scripts/dune-local.sh build test/test_keeper_memory.exe`; first run reached Dune but failed on a Dune cache temp cleanup error:
  `rmdir(.../.cache/dune/db/temp/dune_4d3252_artifacts): Directory not empty`
- Retried with `DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_memory.exe`, then stopped only my queued retry because the shared `/tmp/me-dune-local.lock` queue refilled behind other active worktrees.
