### PR TITLE
fix(activity): bind event path before append

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -185,8 +185,9 @@ let emit config ?actor ?subject ?(tags = []) ~kind ~payload () =
           }
           |> sanitize_event
         in
+        let path = day_path config in
         let json_line = Yojson.Safe.to_string (event_to_yojson value) in
-        append_line (day_path config) (json_line ^ "\n");
+        append_line path (json_line ^ "\n");
         (value, json_line))
   in
   let encoded = format_sse_event_data ~seq:value.seq json_line in


### PR DESCRIPTION
Follow-up to review feedback on #13216 after #13229 merged the UTF-8 writer sanitization path. Current main already serializes JSON writes through json_to_pretty_utf8 for backend and local writes, so this branch is reduced to the remaining activity_graph day_path issue: bind the path once inside emit and reuse it for append, avoiding midnight-boundary divergence between computed path and written file.\n\nEvidence:\n- git diff --check