### PR TITLE
feat(board): add reaction foundation

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -311,6 +311,84 @@ let dispatch_route ~routes ~request ~path reqd =
         ) hearths));
       ] in
       Http.Response.json (Yojson.Safe.to_string json) reqd
+  | `POST, "/api/v1/board/reactions" ->
+      Http.Request.read_body_async reqd (fun body ->
+        try
+          let args = Yojson.Safe.from_string body in
+          let target_type_raw =
+            Option.value ~default:""
+              (Safe_ops.json_string_opt "target_type" args)
+          in
+          let target_id =
+            Option.value ~default:"" (Safe_ops.json_string_opt "target_id" args)
+          in
+          let user_id =
+            Option.value ~default:"" (Safe_ops.json_string_opt "user_id" args)
+          in
+          let emoji =
+            Option.value ~default:"" (Safe_ops.json_string_opt "emoji" args)
+          in
+          match Board.reaction_target_type_of_string_opt target_type_raw with
+          | None ->
+              Http.Response.json ~status:`Bad_request
+                {|{"error":"target_type must be post or comment"}|} reqd
+          | Some target_type ->
+              (match
+                 Board_dispatch.toggle_reaction ~target_type ~target_id
+                   ~user_id ~emoji
+               with
+               | Ok result ->
+                   Http.Response.json
+                     (Yojson.Safe.to_string
+                        (Board.reaction_toggle_result_to_yojson result))
+                     reqd
+               | Error e ->
+                   Http.Response.json ~status:`Bad_request
+                     (Yojson.Safe.to_string
+                        (`Assoc
+                           [
+                             ("error", `String (Tool_board.board_error_to_string e));
+                           ]))
+                     reqd)
+        with
+        | Yojson.Json_error msg ->
+            Http.Response.json ~status:`Bad_request
+              (Yojson.Safe.to_string
+                 (`Assoc [ ("error", `String ("invalid JSON: " ^ msg)) ]))
+              reqd)
+  | `GET, "/api/v1/board/reactions" ->
+      let target_type_raw =
+        Option.value ~default:"" (query_param request "target_type")
+      in
+      let target_id =
+        Option.value ~default:"" (query_param request "target_id")
+      in
+      let user_id = query_param request "user_id" in
+      (match Board.reaction_target_type_of_string_opt target_type_raw with
+       | None ->
+           Http.Response.json ~status:`Bad_request
+             {|{"error":"target_type must be post or comment"}|} reqd
+       | Some target_type ->
+           (match
+              Board_dispatch.list_reactions ~target_type ~target_id ?user_id ()
+            with
+            | Ok summary ->
+                let json =
+                  `Assoc
+                    [
+                      ( "reactions",
+                        `List (List.map Board.reaction_summary_to_yojson summary) );
+                    ]
+                in
+                Http.Response.json (Yojson.Safe.to_string json) reqd
+            | Error e ->
+                Http.Response.json ~status:`Bad_request
+                  (Yojson.Safe.to_string
+                     (`Assoc
+                        [
+                          ("error", `String (Tool_board.board_error_to_string e));
+                        ]))
+                  reqd))
   | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param request "format") in

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -5,7 +5,9 @@ import {
   fetchBoard,
   fetchBoardHearths,
   fetchBoardPost,
+  fetchBoardReactions,
   sanitizeBoardTitle,
+  toggleReaction,
   voteComment,
   asNullableIsoTimestamp,
   normalizePendingConfirmation,
@@ -603,6 +605,58 @@ describe('voteComment', () => {
       direction: 'down',
       vote: 'down',
       voter: 'dashboard-reviewer',
+    })
+  })
+})
+
+describe('board reactions', () => {
+  it('fetches reaction summaries with the dashboard voter', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-reviewer')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ reactions: [{ emoji: '👍', count: 2, reacted: true }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoardReactions('post', 'post-1')
+
+    expect(result).toEqual([{ emoji: '👍', count: 2, reacted: true }])
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/v1/board/reactions?')
+    expect(url).toContain('target_type=post')
+    expect(url).toContain('target_id=post-1')
+    expect(url).toContain('user_id=dashboard-reviewer')
+  })
+
+  it('toggles a reaction through the board reaction endpoint', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-reviewer')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        target_type: 'comment',
+        target_id: 'comment-1',
+        user_id: 'dashboard-reviewer',
+        emoji: '🚀',
+        reacted: true,
+        summary: [{ emoji: '🚀', count: 1, reacted: true }],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await toggleReaction('comment', 'comment-1', '🚀')
+
+    expect(result.summary).toEqual([{ emoji: '🚀', count: 1, reacted: true }])
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/board/reactions')
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      target_type: 'comment',
+      target_id: 'comment-1',
+      user_id: 'dashboard-reviewer',
+      emoji: '🚀',
     })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,7 +1,8 @@
 import { get, post, withRetries, defaultBoardVoter } from './core'
 import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
 import type {
-  BoardActorIdentity, BoardPost, BoardComment, BoardSortMode,
+  BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
+  BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
   GovernanceContextRef,
   GovernanceDecisionItem, GovernanceExecutedRoute,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
@@ -433,6 +434,39 @@ function normalizeBoardHearth(raw: unknown): BoardHearth | null {
   }
 }
 
+function normalizeBoardReactionSummary(raw: unknown): BoardReactionSummary | null {
+  if (!isRecord(raw)) return null
+  const emoji = asString(raw.emoji, '').trim()
+  if (!emoji) return null
+  return {
+    emoji,
+    count: asNumber(raw.count, 0),
+    reacted: raw.reacted === true,
+  }
+}
+
+function normalizeBoardReactionToggleResult(raw: unknown): BoardReactionToggleResult | null {
+  if (!isRecord(raw)) return null
+  const targetType = asString(raw.target_type, '').trim()
+  const targetId = asString(raw.target_id, '').trim()
+  const userId = asString(raw.user_id, '').trim()
+  const emoji = asString(raw.emoji, '').trim()
+  if ((targetType !== 'post' && targetType !== 'comment') || !targetId || !userId || !emoji) {
+    return null
+  }
+  const summary = Array.isArray(raw.summary)
+    ? raw.summary.map(normalizeBoardReactionSummary).filter((row): row is BoardReactionSummary => row !== null)
+    : []
+  return {
+    target_type: targetType,
+    target_id: targetId,
+    user_id: userId,
+    emoji,
+    reacted: raw.reacted === true,
+    summary,
+  }
+}
+
 export async function fetchBoard(
   sortBy?: BoardSortMode,
   options?: { excludeSystem?: boolean; excludeAutomation?: boolean; author?: string; hearth?: string },
@@ -459,6 +493,23 @@ export async function fetchBoardHearths(): Promise<BoardHearth[]> {
     const raw = await get<{ hearths?: unknown[] }>('/api/v1/board/hearths')
     return Array.isArray(raw.hearths)
       ? raw.hearths.map(normalizeBoardHearth).filter((row): row is BoardHearth => row !== null)
+      : []
+  })
+}
+
+export async function fetchBoardReactions(
+  targetType: BoardReactionTargetType,
+  targetId: string,
+): Promise<BoardReactionSummary[]> {
+  return withRetries('fetchBoardReactions', async () => {
+    const params = new URLSearchParams({
+      target_type: targetType,
+      target_id: targetId,
+      user_id: defaultBoardVoter(),
+    })
+    const raw = await get<{ reactions?: unknown[] }>(`/api/v1/board/reactions?${params}`)
+    return Array.isArray(raw.reactions)
+      ? raw.reactions.map(normalizeBoardReactionSummary).filter((row): row is BoardReactionSummary => row !== null)
       : []
   })
 }
@@ -509,6 +560,24 @@ export function voteComment(commentId: string, direction: 'up' | 'down'): Promis
     vote: direction,
     voter: defaultBoardVoter(),
   })
+}
+
+export async function toggleReaction(
+  targetType: BoardReactionTargetType,
+  targetId: string,
+  emoji: string,
+): Promise<BoardReactionToggleResult> {
+  const raw = await post<unknown>('/api/v1/board/reactions', {
+    target_type: targetType,
+    target_id: targetId,
+    user_id: defaultBoardVoter(),
+    emoji,
+  })
+  const normalized = normalizeBoardReactionToggleResult(raw)
+  if (!normalized) {
+    throw new Error('Malformed board reaction response')
+  }
+  return normalized
 }
 
 export function createPost(

--- a/dashboard/src/components/board/index.ts
+++ b/dashboard/src/components/board/index.ts
@@ -6,3 +6,4 @@ export {
   countCommentDescendants,
   filterCommentTree,
 } from './post-detail'
+export { ReactionBar } from './reaction-bar'

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
@@ -29,6 +29,18 @@ vi.mock('../common/toast', () => ({
 
 vi.mock('../common/empty-state', () => ({
   EmptyState: ({ message }: { message: string }) => h('div', {}, message),
+}))
+
+vi.mock('../../api/board', () => ({
+  fetchBoardReactions: vi.fn().mockResolvedValue([]),
+  toggleReaction: vi.fn().mockResolvedValue({
+    target_type: 'comment',
+    target_id: 'c1',
+    user_id: 'dashboard-reviewer',
+    emoji: '🚀',
+    reacted: true,
+    summary: [{ emoji: '🚀', count: 1, reacted: true }],
+  }),
 }))
 
 vi.mock('../common/input', () => ({
@@ -64,6 +76,7 @@ import {
   filterCommentTree,
 } from './post-detail'
 import { voteComment } from './board-state'
+import { toggleReaction } from '../../api/board'
 import type { BoardComment } from '../../types/core'
 
 afterEach(() => {
@@ -203,6 +216,27 @@ describe('CommentThread', () => {
 
     expect(voteComment).toHaveBeenCalledWith('c1', 'up')
     expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
+  it('toggles a comment reaction from the thread', async () => {
+    const comments = [
+      {
+        id: 'c1',
+        post_id: 'post-1',
+        parent_id: null,
+        author: 'agent',
+        content: 'react to me',
+        created_at: '2026-04-02T00:00:00Z',
+      },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    fireEvent.click(await screen.findByRole('button', { name: '🚀 리액션 0개' }))
+
+    await waitFor(() => {
+      expect(toggleReaction).toHaveBeenCalledWith('comment', 'c1', '🚀')
+    })
   })
 })
 

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -12,6 +12,7 @@ import { RichContent } from '../common/rich-content'
 import { TextInput } from '../common/input'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate } from '../../router'
+import { ReactionBar } from './reaction-bar'
 import {
   boardActorAvatarKey,
   boardActorDisplayName,
@@ -259,6 +260,9 @@ function CommentItem({
             onClick=${() => setExpanded(!expanded)}
           >${expanded ? '접기' : '더 보기...'}<//>
         ` : null}
+        <div class="mt-2">
+          <${ReactionBar} targetType="comment" targetId=${comment.id} compact />
+        </div>
         ${isReplying ? html`
           <div class="mt-2">
             <${RichComposer}
@@ -489,6 +493,8 @@ export function PostDetail({ post }: { post: BoardPost }) {
               onClick=${() => handleVote('down')}
             >▼ 비추천<//>
           </div>
+
+          <${ReactionBar} targetType="post" targetId=${post.id} />
         </div>
       <//>
 

--- a/dashboard/src/components/board/reaction-bar.ts
+++ b/dashboard/src/components/board/reaction-bar.ts
@@ -1,0 +1,95 @@
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { fetchBoardReactions, toggleReaction } from '../../api/board'
+import { lastEvent } from '../../sse'
+import { showToast } from '../common/toast'
+import type { BoardReactionSummary, BoardReactionTargetType } from '../../types'
+
+const BOARD_REACTION_EMOJIS = ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥'] as const
+
+export function ReactionBar({
+  targetType,
+  targetId,
+  compact = false,
+}: {
+  targetType: BoardReactionTargetType
+  targetId: string
+  compact?: boolean
+}) {
+  const [summaries, setSummaries] = useState<BoardReactionSummary[]>([])
+  const [busyEmoji, setBusyEmoji] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const refresh = () => {
+      void fetchBoardReactions(targetType, targetId)
+        .then(next => {
+          if (!cancelled) setSummaries(next)
+        })
+        .catch(err => {
+          if (!cancelled) {
+            console.warn('[board] reaction summary failed', err instanceof Error ? err.message : err)
+          }
+        })
+    }
+    refresh()
+    const unsubscribe = lastEvent.subscribe(event => {
+      if (event?.type !== 'reaction_changed') return
+      if (event.target_type === targetType && event.target_id === targetId) {
+        refresh()
+      }
+    })
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [targetType, targetId])
+
+  const summaryByEmoji = useMemo(() => {
+    const map = new Map<string, BoardReactionSummary>()
+    for (const summary of summaries) map.set(summary.emoji, summary)
+    return map
+  }, [summaries])
+
+  const handleToggle = async (emoji: string) => {
+    if (busyEmoji) return
+    setBusyEmoji(emoji)
+    try {
+      const result = await toggleReaction(targetType, targetId, emoji)
+      setSummaries(result.summary)
+    } catch (err) {
+      console.warn('[board] reaction toggle failed', err instanceof Error ? err.message : err)
+      showToast('리액션 반영에 실패했습니다', 'error')
+    } finally {
+      setBusyEmoji(null)
+    }
+  }
+
+  return html`
+    <div class="flex items-center gap-1 flex-wrap" role="group" aria-label="리액션">
+      ${BOARD_REACTION_EMOJIS.map(emoji => {
+        const summary = summaryByEmoji.get(emoji)
+        const count = summary?.count ?? 0
+        const reacted = summary?.reacted ?? false
+        return html`
+          <button
+            key=${emoji}
+            type="button"
+            class=${`${compact ? 'h-6 min-w-7 px-1.5 text-2xs' : 'h-7 min-w-8 px-2 text-xs'} rounded-[var(--r-1)] border transition-colors duration-[var(--t-med)] ${
+              reacted
+                ? 'bg-[var(--accent-12)] text-[var(--color-accent-fg)] border-[var(--accent-20)]'
+                : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-divider)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
+            } disabled:opacity-60`}
+            aria-pressed=${reacted}
+            aria-label=${`${emoji} 리액션 ${count}개`}
+            disabled=${busyEmoji !== null}
+            onClick=${() => { void handleToggle(emoji) }}
+          >
+            <span aria-hidden="true">${emoji}</span>
+            ${count > 0 ? html`<span class="ml-1 tabular-nums">${count}</span>` : null}
+          </button>
+        `
+      })}
+    </div>
+  `
+}

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -24,6 +24,10 @@ describe('SSEEventTypeSchema', () => {
     expect(SSEEventTypeSchema.parse('oas:masc:audit_event')).toBe('oas:masc:audit_event')
   })
 
+  it('accepts board reaction changes', () => {
+    expect(SSEEventTypeSchema.parse('reaction_changed')).toBe('reaction_changed')
+  })
+
   it('rejects an unknown event type', () => {
     const r = SSEEventTypeSchema.safeParse('this_is_not_a_real_event')
     expect(r.success).toBe(false)
@@ -103,6 +107,28 @@ describe('SSEMessageSchema', () => {
       type: 'post_created',
       post_id: 'post-1',
       post_kind: 1,
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('accepts typed board reaction metadata at the SSE boundary', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'reaction_changed',
+      target_type: 'comment',
+      target_id: 'comment-1',
+      user_id: 'dashboard-reviewer',
+      emoji: '🚀',
+      reacted: true,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects malformed board reaction metadata at the SSE boundary', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'reaction_changed',
+      target_type: 'post',
+      target_id: 'post-1',
+      reacted: 'yes',
     })
     expect(r.success).toBe(false)
   })

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -37,6 +37,7 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'comment_added',
   'post_voted',
   'comment_voted',
+  'reaction_changed',
   'heartbeat',
   'keeper_heartbeat',
   'keeper_handoff',
@@ -87,6 +88,10 @@ const STRING_FIELDS = new Set([
   'author',
   'voter',
   'direction',
+  'target_type',
+  'target_id',
+  'user_id',
+  'emoji',
   'hearth',
   'agent_name',
   'keeper_name',
@@ -131,7 +136,7 @@ const NUMBER_FIELDS = new Set([
   'total_turns',
 ])
 
-const BOOLEAN_FIELDS = new Set(['success'])
+const BOOLEAN_FIELDS = new Set(['success', 'reacted'])
 
 function ok<T>(data: T): SafeParseSuccess<T> {
   return { success: true, data }

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -266,6 +266,24 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshBoard).toHaveBeenCalledTimes(1)
   })
 
+  it('routes board reaction changes through the board refresh budget', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'reaction_changed',
+      target_type: 'comment',
+      target_id: 'comment-1',
+      user_id: 'dashboard-reviewer',
+      emoji: '🚀',
+      reacted: true,
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps optimistic post_created hydration inside the active hearth filter', async () => {
     const { sseStore } = await loadSseStore()
     const refreshHearths = vi.fn()

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -150,6 +150,7 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   comment_added:        { target: 'board' },
   post_voted:           { target: 'board' },
   comment_voted:        { target: 'board' },
+  reaction_changed:     { target: 'board' },
   // Activity graph
   activity:             { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -163,6 +163,23 @@ export interface BoardComment {
   votes_down?: number
 }
 
+export type BoardReactionTargetType = 'post' | 'comment'
+
+export interface BoardReactionSummary {
+  emoji: string
+  count: number
+  reacted: boolean
+}
+
+export interface BoardReactionToggleResult {
+  target_type: BoardReactionTargetType
+  target_id: string
+  user_id: string
+  emoji: string
+  reacted: boolean
+  summary: BoardReactionSummary[]
+}
+
 // --- Keeper Metrics ---
 
 export interface InferenceTelemetry {

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -18,6 +18,7 @@ export type SSEEventType =
   | 'comment_added'
   | 'post_voted'
   | 'comment_voted'
+  | 'reaction_changed'
   | 'heartbeat'
   | 'keeper_heartbeat'
   | 'keeper_handoff'
@@ -141,6 +142,11 @@ export interface SSEEvent {
   voter?: string
   voter_identity?: BoardActorIdentity | null
   direction?: 'up' | 'down' | string
+  target_type?: 'post' | 'comment' | string
+  target_id?: string
+  user_id?: string
+  emoji?: string
+  reacted?: boolean
   post_kind?: BoardPost['post_kind'] | string
   hearth?: string
   agent_name?: string

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -38,6 +38,7 @@ let create_store () = {
   karma_cache = None;
   sorted_posts_cache = None;
   comments_by_post = Hashtbl.create 1024;
+  reactions = Hashtbl.create 4096;
   dirty_posts = false;
   dirty_comments = false;
   dirty_post_ids = Hashtbl.create 256;
@@ -216,6 +217,9 @@ let persist_path () =
 let comments_path () =
   Filename.concat (board_masc_dir ()) "board_comments.jsonl"
 
+let reactions_path () =
+  Filename.concat (board_masc_dir ()) "board_reactions.jsonl"
+
 let ensure_dir path =
   if String.equal path "" || String.equal path "." || String.equal path "/" then ()
   else Fs_compat.mkdir_p path
@@ -288,6 +292,71 @@ let comment_to_yojson (c : comment) : Yojson.Safe.t =
     ("score", `Int (c.votes_up - c.votes_down));
   ]
 
+let reaction_target_type_to_string = function
+  | Reaction_post -> "post"
+  | Reaction_comment -> "comment"
+
+let reaction_target_type_of_string_opt raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "post" -> Some Reaction_post
+  | "comment" -> Some Reaction_comment
+  | _ -> None
+
+let valid_reaction_target_type_strings = [ "post"; "comment" ]
+
+let board_reaction_emojis =
+  [ "👍"; "❤️"; "🎉"; "🚀"; "👀"; "😕"; "👏"; "🔥" ]
+
+let reaction_key ~target_type ~target_id ~user_id ~emoji =
+  String.concat ":"
+    [ reaction_target_type_to_string target_type; target_id; user_id; emoji ]
+
+let reaction_to_yojson (r : reaction) : Yojson.Safe.t =
+  `Assoc [
+    ("target_type", `String (reaction_target_type_to_string r.target_type));
+    ("target_id", `String r.target_id);
+    ("user_id", `String (Agent_id.to_string r.user_id));
+    ("emoji", `String r.emoji);
+    ("created_at", `Float r.created_at);
+  ]
+
+let reaction_summary_to_yojson (summary : reaction_summary) : Yojson.Safe.t =
+  `Assoc [
+    ("emoji", `String summary.emoji);
+    ("count", `Int summary.count);
+    ("reacted", `Bool summary.reacted);
+  ]
+
+let reaction_toggle_result_to_yojson (result : reaction_toggle_result) :
+    Yojson.Safe.t =
+  `Assoc [
+    ("target_type", `String (reaction_target_type_to_string result.target_type));
+    ("target_id", `String result.target_id);
+    ("user_id", `String result.user_id);
+    ("emoji", `String result.emoji);
+    ("reacted", `Bool result.reacted);
+    ("summary", `List (List.map reaction_summary_to_yojson result.summary));
+  ]
+
+let reaction_of_yojson (json : Yojson.Safe.t) : reaction option =
+  match
+    Safe_ops.json_string_opt "target_type" json,
+    Safe_ops.json_string_opt "target_id" json,
+    Safe_ops.json_string_opt "user_id" json,
+    Safe_ops.json_string_opt "emoji" json,
+    Safe_ops.json_float_opt "created_at" json
+  with
+  | Some target_type_raw, Some target_id, Some user_id_raw, Some emoji,
+    Some created_at ->
+      (match
+         reaction_target_type_of_string_opt target_type_raw,
+         Agent_id.of_string user_id_raw
+       with
+       | Some target_type, Ok user_id ->
+           Some { target_type; target_id; user_id; emoji; created_at }
+       | _ -> None)
+  | _ -> None
+
 (** {1 Rewrite Helpers} *)
 
 let rewrite_posts store =
@@ -317,6 +386,31 @@ let rewrite_comments store =
      | Ok () -> ()
      | Error msg -> record_persist_error ~where:"rewrite_comments" msg)
   with Sys_error msg -> record_persist_error ~where:"rewrite_comments" msg
+
+let reactions_jsonl_unlocked store =
+  let buf = Buffer.create 4096 in
+  Hashtbl.iter
+    (fun _ (reaction : reaction) ->
+       Buffer.add_string buf (Yojson.Safe.to_string (reaction_to_yojson reaction));
+       Buffer.add_char buf '\n')
+    store.reactions;
+  Buffer.contents buf
+
+let save_reactions_jsonl content =
+  try
+    ensure_masc_dir ();
+    let path = reactions_path () in
+    (match Fs_compat.save_file_atomic path content with
+     | Ok () -> ()
+     | Error msg -> record_persist_error ~where:"rewrite_reactions" msg)
+  with Sys_error msg -> record_persist_error ~where:"rewrite_reactions" msg
+
+let rewrite_reactions_unlocked store =
+  save_reactions_jsonl (reactions_jsonl_unlocked store)
+
+let rewrite_reactions store =
+  let content = with_lock store (fun () -> reactions_jsonl_unlocked store) in
+  with_persist_lock store (fun () -> save_reactions_jsonl content)
 
 (** {1 Append Helpers} *)
 
@@ -733,5 +827,130 @@ let list_comments store ?(limit=1000) () : comment list =
     ) all in
     List.filteri (fun i _ -> i < limit) sorted
   )
+
+(** {1 Reactions} *)
+
+let normalize_reaction_emoji raw =
+  let emoji = String.trim raw in
+  if List.exists (String.equal emoji) board_reaction_emojis then Ok emoji
+  else
+    Error
+      (Validation_error
+         (Printf.sprintf "Unsupported board reaction emoji: %s" emoji))
+
+let ensure_reaction_target_unlocked store ~target_type ~target_id =
+  match target_type with
+  | Reaction_post ->
+      (match Post_id.of_string target_id with
+       | Error e -> Error e
+       | Ok pid ->
+           if Hashtbl.mem store.posts (Post_id.to_string pid) then Ok ()
+           else Error (Post_not_found target_id))
+  | Reaction_comment ->
+      (match Comment_id.of_string target_id with
+       | Error e -> Error e
+       | Ok cid ->
+           if Hashtbl.mem store.comments (Comment_id.to_string cid) then Ok ()
+           else Error (Comment_not_found target_id))
+
+let reaction_summaries_unlocked store ~target_type ~target_id ?user_id () =
+  let counts = Hashtbl.create 8 in
+  let reacted = Hashtbl.create 8 in
+  Hashtbl.iter
+    (fun _ (reaction : reaction) ->
+       if (=) reaction.target_type target_type
+          && String.equal reaction.target_id target_id
+       then begin
+         let current =
+           Hashtbl.find_opt counts reaction.emoji |> Option.value ~default:0
+         in
+         Hashtbl.replace counts reaction.emoji (current + 1);
+         match user_id with
+         | Some user when String.equal (Agent_id.to_string reaction.user_id) user ->
+             Hashtbl.replace reacted reaction.emoji true
+         | Some _ | None -> ()
+       end)
+    store.reactions;
+  List.filter_map
+    (fun emoji ->
+       let count = Hashtbl.find_opt counts emoji |> Option.value ~default:0 in
+       if count = 0 then None
+       else
+         Some
+           {
+             emoji;
+             count;
+             reacted =
+               Hashtbl.find_opt reacted emoji |> Option.value ~default:false;
+           })
+    board_reaction_emojis
+
+let list_reactions store ~target_type ~target_id ?user_id () =
+  maybe_sweep store;
+  let user_id =
+    match user_id with
+    | Some user when not (String.equal (String.trim user) "") ->
+        Some (String.trim user)
+    | Some _ | None -> None
+  in
+  with_lock store (fun () ->
+      match ensure_reaction_target_unlocked store ~target_type ~target_id with
+      | Error e -> Error e
+      | Ok () ->
+          Ok
+            (reaction_summaries_unlocked store ~target_type ~target_id ?user_id
+               ()))
+
+let toggle_reaction store ~target_type ~target_id ~user_id ~emoji :
+    (reaction_toggle_result, board_error) Result.t =
+  maybe_sweep store;
+  match Agent_id.of_string user_id, normalize_reaction_emoji emoji with
+  | Error e, _ -> Error e
+  | _, Error e -> Error e
+  | Ok user_id, Ok emoji ->
+      let user_id_string = Agent_id.to_string user_id in
+      let result =
+        with_lock store (fun () ->
+            match ensure_reaction_target_unlocked store ~target_type ~target_id with
+            | Error e -> Error e
+            | Ok () ->
+                let key =
+                  reaction_key ~target_type ~target_id ~user_id:user_id_string
+                    ~emoji
+                in
+                let reacted =
+                  match Hashtbl.find_opt store.reactions key with
+                  | Some _ ->
+                      Hashtbl.remove store.reactions key;
+                      false
+                  | None ->
+                      Hashtbl.replace store.reactions key
+                        {
+                          target_type;
+                          target_id;
+                          user_id;
+                          emoji;
+                          created_at = Time_compat.now ();
+                        };
+                      true
+                in
+                let summary =
+                  reaction_summaries_unlocked store ~target_type ~target_id
+                    ~user_id:user_id_string ()
+                in
+                Ok
+                  {
+                    target_type;
+                    target_id;
+                    user_id = user_id_string;
+                    emoji;
+                    reacted;
+                    summary;
+                  })
+      in
+      (match result with
+       | Ok _ -> rewrite_reactions store
+       | Error _ -> ());
+      result
 
 (** {1 Voting - Deduplicated} *)

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -114,6 +114,10 @@ val comments_path : unit -> string
 (** Path to the board comments JSONL log under
     [<base>/.masc/board-comments.jsonl]. *)
 
+val reactions_path : unit -> string
+(** Path to the board reactions JSONL snapshot under
+    [<base>/.masc/board_reactions.jsonl]. *)
+
 val ensure_masc_dir : unit -> unit
 (** Idempotent [.masc] directory creation; called before
     every JSONL append. *)
@@ -145,6 +149,12 @@ val rewrite_comments : store -> unit
     [store.comments].  Same usage pattern as
     {!rewrite_posts}. *)
 
+val rewrite_reactions : store -> unit
+(** Atomically rewrites {!reactions_path} from [store.reactions]. *)
+
+val rewrite_reactions_unlocked : store -> unit
+(** Rewrites reactions assuming the caller already owns [store.mutex]. *)
+
 val mark_dirty_post : store -> string -> unit
 (** Marks one post for append-only deferred persistence.  Call with
     [store.mutex] already held. *)
@@ -157,6 +167,21 @@ val mark_dirty_comment : store -> string -> unit
 
 val post_to_yojson : post -> Yojson.Safe.t
 val comment_to_yojson : comment -> Yojson.Safe.t
+val reaction_to_yojson : reaction -> Yojson.Safe.t
+val reaction_of_yojson : Yojson.Safe.t -> reaction option
+val reaction_summary_to_yojson : reaction_summary -> Yojson.Safe.t
+val reaction_toggle_result_to_yojson : reaction_toggle_result -> Yojson.Safe.t
+
+val reaction_target_type_to_string : reaction_target_type -> string
+val reaction_target_type_of_string_opt : string -> reaction_target_type option
+val valid_reaction_target_type_strings : string list
+val board_reaction_emojis : string list
+val reaction_key :
+  target_type:reaction_target_type ->
+  target_id:string ->
+  user_id:string ->
+  emoji:string ->
+  string
 
 (** {1 Post operations} *)
 
@@ -265,3 +290,21 @@ val list_comments :
 (** Returns up to [limit] (default 1000) most recent
     comments across every post.  Used by the profile
     aggregator. *)
+
+(** {1 Reaction operations} *)
+
+val list_reactions :
+  store ->
+  target_type:reaction_target_type ->
+  target_id:string ->
+  ?user_id:string ->
+  unit ->
+  (reaction_summary list, board_error) Result.t
+
+val toggle_reaction :
+  store ->
+  target_type:reaction_target_type ->
+  target_id:string ->
+  user_id:string ->
+  emoji:string ->
+  (reaction_toggle_result, board_error) Result.t

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -100,6 +100,13 @@ type board_sse_event =
   | Comment_added of { post_id : string; comment_id : string; author : string }
   | Post_voted of { post_id : string; voter : string; direction : Board.vote_direction }
   | Comment_voted of { comment_id : string; voter : string; direction : Board.vote_direction }
+  | Reaction_changed of {
+      target_type : Board.reaction_target_type;
+      target_id : string;
+      user_id : string;
+      emoji : string;
+      reacted : bool;
+    }
 
 let backend_state : backend_state Atomic.t = Atomic.make Uninitialized
 
@@ -451,6 +458,34 @@ let vote_comment ~voter ~comment_id ~direction =
          "board vote_comment failed: comment_id=%s voter=%s: %s"
          comment_id voter (Board_types.show_board_error e));
   result
+
+let toggle_reaction ~target_type ~target_id ~user_id ~emoji =
+  let result =
+    match backend () with
+    | Jsonl store ->
+        Board.toggle_reaction store ~target_type ~target_id ~user_id ~emoji
+  in
+  (match result with
+   | Ok toggled ->
+       emit_board_sse_event
+         (Reaction_changed
+            {
+              target_type;
+              target_id;
+              user_id = toggled.user_id;
+              emoji = toggled.emoji;
+              reacted = toggled.reacted;
+            })
+   | Error e ->
+       Log.BoardLog.warn
+         "board reaction failed: target=%s:%s user=%s emoji=%s: %s"
+         (Board.reaction_target_type_to_string target_type)
+         target_id user_id emoji (Board_types.show_board_error e));
+  result
+
+let list_reactions ~target_type ~target_id ?user_id () =
+  match backend () with
+  | Jsonl store -> Board.list_reactions store ~target_type ~target_id ?user_id ()
 
 let stats () =
   match backend () with

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -70,6 +70,13 @@ type board_sse_event =
       voter : string;
       direction : Board.vote_direction;
     }
+  | Reaction_changed of {
+      target_type : Board.reaction_target_type;
+      target_id : string;
+      user_id : string;
+      emoji : string;
+      reacted : bool;
+    }
 
 val set_keeper_board_signal_hook : (keeper_board_signal -> unit) -> unit
 (** Replace the in-process hook invoked from {!create_post} and
@@ -191,6 +198,20 @@ val vote_comment :
   comment_id:string ->
   direction:Board.vote_direction ->
   (int, Board.board_error) Result.t
+
+val toggle_reaction :
+  target_type:Board.reaction_target_type ->
+  target_id:string ->
+  user_id:string ->
+  emoji:string ->
+  (Board.reaction_toggle_result, Board.board_error) Result.t
+
+val list_reactions :
+  target_type:Board.reaction_target_type ->
+  target_id:string ->
+  ?user_id:string ->
+  unit ->
+  (Board.reaction_summary list, Board.board_error) Result.t
 
 (** {1 Karma} *)
 

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -156,6 +156,33 @@ type comment = {
   votes_down: int;
 }
 
+type reaction_target_type =
+  | Reaction_post
+  | Reaction_comment
+
+type reaction = {
+  target_type: reaction_target_type;
+  target_id: string;
+  user_id: Agent_id.t;
+  emoji: string;
+  created_at: float;
+}
+
+type reaction_summary = {
+  emoji: string;
+  count: int;
+  reacted: bool;
+}
+
+type reaction_toggle_result = {
+  target_type: reaction_target_type;
+  target_id: string;
+  user_id: string;
+  emoji: string;
+  reacted: bool;
+  summary: reaction_summary list;
+}
+
 (** {1 Limits - Enforced, Not Optional} *)
 
 module Limits = struct
@@ -199,6 +226,7 @@ type store = {
   mutable karma_cache: (string * int) list option;       (** None = stale *)
   mutable sorted_posts_cache: post list option;           (** None = stale *)
   comments_by_post: (string, string list) Hashtbl.t;      (** post_id -> comment_id list *)
+  reactions: (string, reaction) Hashtbl.t;                 (** unique target/user/emoji reactions *)
   mutable dirty_posts: bool;                               (** Deferred flush flag *)
   mutable dirty_comments: bool;                            (** Deferred flush flag *)
   dirty_post_ids: (string, unit) Hashtbl.t;                 (** Deferred post snapshots *)

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -103,6 +103,33 @@ type comment = {
   votes_down : int;
 }
 
+type reaction_target_type =
+  | Reaction_post
+  | Reaction_comment
+
+type reaction = {
+  target_type : reaction_target_type;
+  target_id : string;
+  user_id : Agent_id.t;
+  emoji : string;
+  created_at : float;
+}
+
+type reaction_summary = {
+  emoji : string;
+  count : int;
+  reacted : bool;
+}
+
+type reaction_toggle_result = {
+  target_type : reaction_target_type;
+  target_id : string;
+  user_id : string;
+  emoji : string;
+  reacted : bool;
+  summary : reaction_summary list;
+}
+
 (** {1 Limits — Enforced, Not Optional}
 
     All values resolved from [MASC_BOARD_*] env vars at module init,
@@ -147,6 +174,8 @@ type store = {
   (** [None] = stale. *)
   comments_by_post : (string, string list) Hashtbl.t;
   (** post_id -> comment_id list. *)
+  reactions : (string, reaction) Hashtbl.t;
+  (** Unique reactions keyed by target type, target id, user id, and emoji. *)
   mutable dirty_posts : bool;
   mutable dirty_comments : bool;
   dirty_post_ids : (string, unit) Hashtbl.t;

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -579,6 +579,36 @@ let load_persisted_votes store =
       Log.BoardLog.error "load votes failed: %s" (Printexc.to_string e)
   end
 
+let load_persisted_reactions store =
+  let path = reactions_path () in
+  if Fs_compat.file_exists path then begin
+    try
+      let loaded = ref 0 in
+      let lines = Fs_compat.load_jsonl path in
+      List.iter
+        (fun json ->
+           match reaction_of_yojson json with
+           | Some reaction ->
+               let user_id = Agent_id.to_string reaction.user_id in
+               let key =
+                 reaction_key ~target_type:reaction.target_type
+                   ~target_id:reaction.target_id ~user_id
+                   ~emoji:reaction.emoji
+               in
+               Hashtbl.replace store.reactions key reaction;
+               Stdlib.incr loaded
+           | None -> ())
+        lines;
+      if !loaded > 0 then
+        Log.BoardLog.info "loaded %d reactions from %s" !loaded path
+      else
+        Log.BoardLog.debug "loaded 0 reactions from %s" path
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
+        Log.BoardLog.error "load reactions failed: %s" (Printexc.to_string e)
+  end
+
 (** {1 Hearth (topic) operations} *)
 
 (** List active hearths with post counts *)
@@ -640,13 +670,28 @@ let delete_post store ~post_id : (unit, board_error) Result.t =
                   else acc)
                 store.vote_log []
             in
+            let reaction_keys =
+              Hashtbl.fold
+                (fun key (reaction : reaction) acc ->
+                  if
+                    ((=) reaction.target_type Reaction_post
+                     && String.equal reaction.target_id post_key)
+                    || ((=) reaction.target_type Reaction_comment
+                        && List.exists (String.equal reaction.target_id)
+                             comment_ids)
+                  then key :: acc
+                  else acc)
+                store.reactions []
+            in
             List.iter (fun key -> Hashtbl.remove store.vote_log key) vote_keys;
+            List.iter (fun key -> Hashtbl.remove store.reactions key) reaction_keys;
             store.post_count := max 0 (!(store.post_count) - 1);
             invalidate_post_caches store;
             invalidate_comment_caches store;
             rewrite_posts store;
             rewrite_comments store;
             rewrite_vote_log store;
+            rewrite_reactions_unlocked store;
             store.dirty_posts <- false;
             store.dirty_comments <- false;
             Hashtbl.clear store.dirty_post_ids;
@@ -667,6 +712,7 @@ let global_lazy : store Eio.Lazy.t ref =
     load_persisted_comments store;
     recalculate_reply_counts store;
     load_persisted_votes store;
+    load_persisted_reactions store;
     store))
 
 let global () = Eio.Lazy.force !global_lazy
@@ -680,6 +726,7 @@ let reset_global_for_test () =
     load_persisted_comments store;
     recalculate_reply_counts store;
     load_persisted_votes store;
+    load_persisted_reactions store;
     store)
 
 (** Flush any dirty state to disk. Call on shutdown to prevent data loss. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -377,6 +377,14 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                   ("voter", `String voter);
                   ("voter_identity", Server_utils.board_actor_identity_json voter);
                   ("direction", `String dir)]
+      | Board_dispatch.Reaction_changed { target_type; target_id; user_id; emoji; reacted } ->
+          `Assoc [("type", `String "reaction_changed");
+                  ("target_type", `String (Board.reaction_target_type_to_string target_type));
+                  ("target_id", `String target_id);
+                  ("user_id", `String user_id);
+                  ("user_identity", Server_utils.board_actor_identity_json user_id);
+                  ("emoji", `String emoji);
+                  ("reacted", `Bool reacted)]
     in
     Sse.broadcast (`Assoc [
       ("jsonrpc", `String "2.0");
@@ -421,6 +429,18 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
            `Assoc [("comment_id", `String comment_id); ("voter", `String voter);
                    ("voter_identity", Server_utils.board_actor_identity_json voter);
                    ("direction", `String dir)])
+      | Board_dispatch.Reaction_changed { target_type; target_id; user_id; emoji; reacted } ->
+          (Event_kind.Board.to_string Event_kind.Board.Voted,
+           Server_utils.board_actor_entity user_id,
+           Some (Activity_graph.entity
+                   ~kind:(Board.reaction_target_type_to_string target_type)
+                   target_id),
+           `Assoc [("target_type", `String (Board.reaction_target_type_to_string target_type));
+                   ("target_id", `String target_id);
+                   ("user_id", `String user_id);
+                   ("user_identity", Server_utils.board_actor_identity_json user_id);
+                   ("emoji", `String emoji);
+                   ("reacted", `Bool reacted)])
     in
     (* P2 silent-failure fix: Activity_graph.emit failures (Discord
        webhook, audit trail writes, etc.) were previously ignored

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -730,6 +730,30 @@ let handle_comment_vote args =
         (true, Printf.sprintf "%s Already voted (idempotent)." (if String.equal direction_str "down" then "👎" else "👍"))
     | Error e -> (false, Printf.sprintf "%s" (board_error_to_string e))
 
+let handle_reaction args =
+  let target_type_raw = get_string args "target_type" "" in
+  let target_id = get_string args "target_id" "" in
+  let user_id = get_string args "user_id" (get_string args "user" "anonymous") in
+  let emoji = get_string args "emoji" "" in
+  match Board.reaction_target_type_of_string_opt target_type_raw with
+  | None -> (false, "target_type must be post or comment")
+  | Some target_type ->
+      if String.equal (String.trim target_id) "" then
+        (false, "target_id required")
+      else if String.equal (String.trim user_id) ""
+              || String.equal (String.trim user_id) "anonymous"
+      then
+        (false, "user_id required")
+      else
+        match
+          Board_dispatch.toggle_reaction ~target_type ~target_id ~user_id ~emoji
+        with
+        | Ok result ->
+            ( true,
+              Yojson.Safe.pretty_to_string
+                (Board.reaction_toggle_result_to_yojson result) )
+        | Error e -> (false, Printf.sprintf "%s" (board_error_to_string e))
+
 (** Agent profile *)
 let handle_profile args =
   let agent = get_string args "agent" "" in
@@ -898,6 +922,29 @@ let tool_comment_vote : Masc_domain.tool_schema = {
   ];
 }
 
+let tool_reaction : Masc_domain.tool_schema = {
+  name = "masc_board_reaction";
+  description = "Toggle a standard emoji reaction on a board post or comment.";
+  input_schema = `Assoc [
+    ("type", `String "object");
+    ("properties", `Assoc [
+      ("target_type", `Assoc [
+        ("type", `String "string");
+        ("enum", `List (List.map (fun s -> `String s) Board.valid_reaction_target_type_strings));
+        ("description", `String "Reaction target type: post or comment");
+      ]);
+      ("target_id", `Assoc [("type", `String "string"); ("description", `String "Post ID or comment ID")]);
+      ("user_id", `Assoc [("type", `String "string"); ("description", `String "Reacting user/agent name")]);
+      ("emoji", `Assoc [
+        ("type", `String "string");
+        ("enum", `List (List.map (fun s -> `String s) Board.board_reaction_emojis));
+        ("description", `String "Standard board reaction emoji");
+      ]);
+    ]);
+    ("required", `List [`String "target_type"; `String "target_id"; `String "user_id"; `String "emoji"]);
+  ];
+}
+
 let tool_profile : Masc_domain.tool_schema = {
   name = "masc_board_profile";
   description = "Get an agent's board profile: post count, comment count, vote activity, and engagement stats. Use to understand an agent's contribution patterns.";
@@ -1057,6 +1104,7 @@ let tools = [
   tool_stats;
   tool_search;
   tool_comment_vote;
+  tool_reaction;
   tool_profile;
   tool_hearth_list;
   tool_delete;
@@ -1085,6 +1133,10 @@ let handle_tool name args =
   | "masc_board_search" -> handle_search args
   | "masc_board_comment_vote" ->
     let result = handle_comment_vote args in
+    invalidate_board_list_cache ();
+    result
+  | "masc_board_reaction" ->
+    let result = handle_reaction args in
     invalidate_board_list_cache ();
     result
   | "masc_board_profile" -> handle_profile args
@@ -1116,7 +1168,7 @@ let register () =
     | "masc_board_search" | "masc_board_profile" | "masc_board_hearths" ->
         Some Masc_domain.CanReadState
     | "masc_board_post" | "masc_board_comment" | "masc_board_vote"
-    | "masc_board_comment_vote" ->
+    | "masc_board_comment_vote" | "masc_board_reaction" ->
         Some Masc_domain.CanBroadcast
     | "masc_board_delete" | "masc_board_cleanup" ->
         Some Masc_domain.CanAdmin

--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -10,8 +10,8 @@
       through {!handle_tool} (one entry per
       [masc_board_*] tool name),
     - the {b tools} list advertised to MCP clients
-      (10 schemas: post, list, get, comment, vote, stats,
-      search, comment_vote, profile, hearth_list, delete),
+      (12 schemas: post, list, get, comment, vote, stats,
+      search, comment_vote, reaction, profile, hearth_list, delete),
     - the {b truncated-markdown detector}
       ({!detect_truncated_markdown} +
       {!detect_truncated_markdown_with_reason}) used by
@@ -145,9 +145,9 @@ val tool_post_create : Masc_domain.tool_schema
     reached only through {!tools}). *)
 
 val tools : Masc_domain.tool_schema list
-(** All 11 board tool schemas in advertisement order:
+(** All board tool schemas in advertisement order:
     post / list / get / comment / vote / stats / search /
-    comment_vote / profile / hearth_list / delete. *)
+    comment_vote / reaction / profile / hearth_list / delete. *)
 
 (** {1 Tool dispatcher} *)
 

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -533,6 +533,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Board_comment_vote
   | TN.Masc TM.Board_delete
   | TN.Masc TM.Board_post
+  | TN.Masc TM.Board_reaction
   | TN.Masc TM.Board_vote
   | TN.Masc TM.Broadcast
   | TN.Masc TM.Cancel_task
@@ -651,6 +652,7 @@ let tool_group_of_typed_tool_name = function
       | TM.Board_list
       | TM.Board_post
       | TM.Board_profile
+      | TM.Board_reaction
       | TM.Board_search
       | TM.Board_stats
       | TM.Board_vote ) ->

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -264,6 +264,7 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Board_list
     | Board_post
     | Board_profile
+    | Board_reaction
     | Board_search
     | Board_stats
     | Board_vote

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -219,6 +219,7 @@ module Masc = struct
     | Board_list
     | Board_post
     | Board_profile
+    | Board_reaction
     | Board_search
     | Board_stats
     | Board_vote
@@ -316,6 +317,7 @@ module Masc = struct
     | Board_list -> "masc_board_list"
     | Board_post -> "masc_board_post"
     | Board_profile -> "masc_board_profile"
+    | Board_reaction -> "masc_board_reaction"
     | Board_search -> "masc_board_search"
     | Board_stats -> "masc_board_stats"
     | Board_vote -> "masc_board_vote"
@@ -420,6 +422,7 @@ module Masc = struct
     | "masc_board_list" -> Some Board_list
     | "masc_board_post" -> Some Board_post
     | "masc_board_profile" -> Some Board_profile
+    | "masc_board_reaction" -> Some Board_reaction
     | "masc_board_search" -> Some Board_search
     | "masc_board_stats" -> Some Board_stats
     | "masc_board_vote" -> Some Board_vote
@@ -520,6 +523,7 @@ module Masc = struct
     | Board_list
     | Board_post
     | Board_profile
+    | Board_reaction
     | Board_search
     | Board_stats
     | Board_vote -> true

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -87,6 +87,7 @@ module Masc : sig
     | Board_list
     | Board_post
     | Board_profile
+    | Board_reaction
     | Board_search
     | Board_stats
     | Board_vote

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -480,6 +480,135 @@ let test_vote_persisted_by_flusher_actor () =
         Eio.Switch.fail sw Exit)
   with Exit -> ()
 
+(** {1 Reaction Operations} *)
+
+let test_reaction_toggle_and_summary () =
+  match
+    Board_dispatch.create_post ~author:"reaction-author"
+      ~content:"reactable post" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let post_id = Board.Post_id.to_string post.id in
+      (match
+         Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+           ~target_id:post_id ~user_id:"reactor" ~emoji:"🚀"
+       with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok result ->
+           Alcotest.(check bool) "reacted" true result.reacted;
+           Alcotest.(check int) "summary length" 1 (List.length result.summary);
+           (match result.summary with
+            | summary :: _ ->
+                Alcotest.(check string) "summary emoji" "🚀" summary.emoji;
+                Alcotest.(check int) "summary count" 1 summary.count;
+                Alcotest.(check bool) "summary reacted" true summary.reacted
+            | [] -> Alcotest.fail "expected reaction summary"));
+      (match
+         Board_dispatch.list_reactions ~target_type:Board.Reaction_post
+           ~target_id:post_id ~user_id:"reactor" ()
+       with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok summaries ->
+           Alcotest.(check int) "listed summary length" 1
+             (List.length summaries));
+      (match
+         Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+           ~target_id:post_id ~user_id:"reactor" ~emoji:"🚀"
+       with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok result ->
+           Alcotest.(check bool) "reacted after untoggle" false
+             result.reacted;
+           Alcotest.(check int) "summary empty after untoggle" 0
+             (List.length result.summary))
+
+let test_comment_reaction_survives_restart () =
+  match
+    Board_dispatch.create_post ~author:"reaction-author"
+      ~content:"comment reaction parent" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let post_id = Board.Post_id.to_string post.id in
+      let comment_id =
+        match
+          Board_dispatch.add_comment ~post_id ~author:"commenter"
+            ~content:"reactable comment" ()
+        with
+        | Error e -> Alcotest.fail (Board.show_board_error e)
+        | Ok comment -> Board.Comment_id.to_string comment.id
+      in
+      (match
+         Board_dispatch.toggle_reaction ~target_type:Board.Reaction_comment
+           ~target_id:comment_id ~user_id:"reactor" ~emoji:"👏"
+       with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok _ -> ());
+      Board.reset_global_for_test ();
+      Board_dispatch.reset_for_test ();
+      Board_dispatch.init_jsonl ();
+      match
+        Board_dispatch.list_reactions ~target_type:Board.Reaction_comment
+          ~target_id:comment_id ~user_id:"reactor" ()
+      with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok summaries ->
+          Alcotest.(check int) "restored summary length" 1
+            (List.length summaries);
+          match summaries with
+          | summary :: _ ->
+              Alcotest.(check string) "restored emoji" "👏" summary.emoji;
+              Alcotest.(check int) "restored count" 1 summary.count;
+              Alcotest.(check bool) "restored reacted" true summary.reacted
+          | [] -> Alcotest.fail "expected restored reaction summary"
+
+let test_board_sse_reaction_changed () =
+  let post_id =
+    match
+      Board_dispatch.create_post ~author:"reaction-author"
+        ~content:"sse reaction parent" ~post_kind:Board.Human_post ()
+    with
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+    | Ok post -> Board.Post_id.to_string post.id
+  in
+  let seen = ref None in
+  Board_dispatch.set_board_sse_hook (fun event -> seen := Some event);
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+       ~target_id:post_id ~user_id:"reactor" ~emoji:"🔥"
+   with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok _ -> ());
+  match !seen with
+  | Some
+      (Board_dispatch.Reaction_changed
+         { target_type; target_id; user_id; emoji; reacted }) ->
+      Alcotest.(check string) "target type" "post"
+        (Board.reaction_target_type_to_string target_type);
+      Alcotest.(check string) "target id" post_id target_id;
+      Alcotest.(check string) "user" "reactor" user_id;
+      Alcotest.(check string) "emoji" "🔥" emoji;
+      Alcotest.(check bool) "reacted" true reacted
+  | Some _ -> Alcotest.fail "expected reaction_changed SSE event"
+  | None -> Alcotest.fail "expected board SSE event"
+
+let test_reaction_rejects_unsupported_emoji () =
+  match
+    Board_dispatch.create_post ~author:"reaction-author"
+      ~content:"unsupported reaction parent" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let post_id = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+          ~target_id:post_id ~user_id:"reactor" ~emoji:"😄"
+      with
+      | Ok _ -> Alcotest.fail "expected Validation_error"
+      | Error (Board.Validation_error _) -> ()
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+
 (** {1 Stats / Search / Hearth} *)
 
 let test_stats () =
@@ -608,6 +737,16 @@ let () =
       Alcotest.test_case "flip" `Quick (with_eio test_vote_flip);
       Alcotest.test_case "vote persisted by flusher actor" `Quick
         test_vote_persisted_by_flusher_actor;
+    ];
+    "reactions", [
+      Alcotest.test_case "toggle and summary" `Quick
+        (with_eio test_reaction_toggle_and_summary);
+      Alcotest.test_case "comment reaction survives restart" `Quick
+        (with_eio test_comment_reaction_survives_restart);
+      Alcotest.test_case "SSE reaction_changed" `Quick
+        (with_eio test_board_sse_reaction_changed);
+      Alcotest.test_case "unsupported emoji rejected" `Quick
+        (with_eio test_reaction_rejects_unsupported_emoji);
     ];
     "misc", [
       Alcotest.test_case "stats" `Quick (with_eio test_stats);


### PR DESCRIPTION
## Summary
- Add persistent post/comment board reactions with the Phase 1 emoji set and unique target/user/emoji semantics.
- Expose POST/GET /api/v1/board/reactions plus the masc_board_reaction tool path and reaction_changed SSE event.
- Add dashboard ReactionBar controls for posts/comments, API normalizers, SSE parsing/routing, and focused regression coverage.

## Verification
- PASS: pnpm exec vitest run src/api/board.test.ts src/components/board/post-detail.test.ts src/schemas/sse.test.ts src/sse-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- PASS: scripts/dune-local.sh build test/test_board_dispatch.exe, then ./_build/default/test/test_board_dispatch.exe before the final origin/main rebase
- PASS: git diff --check origin/main...HEAD
- KNOWN LOCAL BLOCKER: pnpm exec tsc --noEmit --pretty false still fails in untouched src/components/ide/ide-presence-strip.test.ts lines 60, 61, 79 (TS2532)
- KNOWN LOCAL BLOCKER: post-rebase OCaml retry hit local agent_sdk.cmi inconsistent-assumptions noise after concurrent builds; CI should verify from a clean environment

## Review Focus
- Board reaction persistence and delete cleanup semantics
- API/tool/SSE wire shape for reaction_changed
- Dashboard detail/comment reaction UX and SSE summary refresh behavior