### PR TITLE
fix(keeper): unblock build after #13228 + #13227 type collision

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -247,6 +247,7 @@ let handle_keeper_task_tool
         ~agent_tool_names
         ~config
         ~meta
+        ()
     in
     let result =
       Coord.claim_next_r config ~agent_name:meta.agent_name ~agent_tool_names

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -65,7 +65,7 @@ let active_goal_ids_have_eligible_claim_task
             task)
 
 let resolve_claim_goal_scope ?agent_tool_names ~(config : Coord.config)
-    ~(meta : keeper_meta) =
+    ~(meta : keeper_meta) () =
   match meta.active_goal_ids with
   | [] ->
       {

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -15,6 +15,7 @@ val resolve_claim_goal_scope :
   ?agent_tool_names:string list ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
+  unit ->
   claim_goal_scope
 
 val runtime_contract_json :

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -244,12 +244,13 @@ let backlog_updated_since_last_scheduled_autonomous
     | None -> false
 
 let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
-    ~(meta : keeper_meta) =
+    ~(meta : keeper_meta) () =
   let scope =
     Keeper_runtime_contract.resolve_claim_goal_scope
       ?agent_tool_names
       ~config
       ~meta
+      ()
   in
   scope.task_filter
 
@@ -270,6 +271,7 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
         ?agent_tool_names:allowed_tool_names
         ~config
         ~meta
+        ()
     in
     let required_tools_allowed required_tools =
       match allowed_tool_names with

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1156,7 +1156,8 @@ let handle_keeper_sandbox_status ctx args : tool_result =
       in
       let render_item (meta : keeper_meta) =
         let preflight_override =
-          if meta.sandbox_profile = Docker then cached_preflight else None
+          if meta.sandbox_profile = Docker then Some cached_preflight
+          else None
         in
         Keeper_sandbox_control.live_status_json
           ~include_preflight ?preflight_override


### PR DESCRIPTION
## Problem

`dune build` (dev profile, warning-as-error) 실패. 두 별도 PR이 머지된 직후 발생.

```
File "lib/keeper/keeper_runtime_contract.ml", line 67, characters 30-46:
67 | let resolve_claim_goal_scope ?agent_tool_names ~(config : Coord.config)
                                   ^^^^^^^^^^^^^^^^
Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.

File "lib/tool_keeper.ml", line 1162, characters 30-48:
1162 |           ~include_preflight ?preflight_override
                                     ^^^^^^^^^^^^^^^^^^
Error: The value preflight_override has type Yojson.Safe.t option
       but an expression was expected of type Yojson.Safe.t option option
```

근원:
- #13228 (`fix(keeper): fallback when active goal claim pool is empty`) — `resolve_claim_goal_scope` + wrapper `claim_goal_scope_filter`가 마지막 인자로 `?agent_tool_names` (optional) + `~config` `~meta` (named) → 마지막 optional erase 불가.
- #13227 (`fix(keeper): include persisted sandbox fleet status`) — `live_status_json`에 `?preflight_override:Yojson.Safe.t option`을 추가했고, caller (`tool_keeper.ml:1158-1162`)가 `?preflight_override` propagation으로 forward. caller variable이 `Yojson.Safe.t option`이라 callee가 기대하는 `(Yojson.Safe.t option) option`과 한 단계 wrap이 부족.

## Root cause

### Bug A (warning 16)

OCaml의 named/optional 인자 erasure 규칙: 함수 시그니처 끝이 named/optional 만으로 끝나면 caller가 partial application과 last-argument 차이를 분간 못함 → erasable 불가능. dev profile은 warning 16을 error로 격상.

### Bug B (option option mismatch)

`?preflight_override:T` 호출 규약:
- `?label:e` forward는 `e : T option`을 요구.
- 여기 T = `Yojson.Safe.t option` 이므로 caller가 forward하려면 `e : (Yojson.Safe.t option) option`.

기존 caller는 `let preflight_override = if Docker then cached_preflight else None in`로 `Yojson.Safe.t option` 한 단계만 만들어 부족.

## Fix

### Bug A — 함수 끝에 `unit` 위치 인자 추가

`keeper_runtime_contract.mli`:
```diff
 val resolve_claim_goal_scope :
   ?agent_tool_names:string list ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
+  unit ->
   claim_goal_scope
```

`keeper_runtime_contract.ml:67`:
```diff
 let resolve_claim_goal_scope ?agent_tool_names ~(config : Coord.config)
-    ~(meta : keeper_meta) =
+    ~(meta : keeper_meta) () =
```

같은 패턴의 wrapper `keeper_world_observation.ml::claim_goal_scope_filter` (line 246) + caller 3곳 (`keeper_world_observation.ml::resolve_claim_goal_scope` 호출 line 249, wrapper caller line 268, `keeper_exec_task.ml::resolve_claim_goal_scope` 호출 line 246) 모두 `()` 추가.

### Bug B — caller value를 `Some`으로 wrap

`tool_keeper.ml:1158-1160`:
```diff
 let preflight_override =
-  if meta.sandbox_profile = Docker then cached_preflight else None
+  if meta.sandbox_profile = Docker then Some cached_preflight
+  else None
 in
```

이로써 `preflight_override : (Yojson.Safe.t option) option`. `?preflight_override` propagation type-checks.

semantic 보존:
- docker keeper → `Some cached_preflight` → callee가 cached value 사용 (의도, fleet probe 1회 재사용).
- non-docker → `None` → callee default branch → 자체 `preflight_status_json` 호출 안 함 (cache miss raw branch는 docker-only conditional).

## Test plan

- [x] `dune build` (dev profile) 통과 — warning 0.
- [ ] CI `dune runtest` regression 0 (#13228, #13227 도입 동작 보존).
- [ ] 시그니처/타입 fix만 적용 — runtime behavior 변경 없음.

## Rollback plan

4-file revert. 영향: 함수 호출 시 마지막 `()` 위치 인자 추가, `Some` wrap 한 글자. behavior 0 변경.

## RFC-WAIVED

Build-error hotfix; agent_delegation 영역 (`lib/keeper/credential_*`, `keeper_gh_*`, `host_config_*`, `lib/repo_manager/*`) 변경 없음. 시그니처 정렬과 type wrap만.

## Related

- #13228 — `?agent_tool_names` 추가 (warning 16 root)
- #13227 — `?preflight_override` 추가 (option option root)
- #13219 (P0 reactive_slot cancel race) 및 #13221 (P0 sandbox bundle visibility): 본 PR 머지 + main green 후 두 P0 PR rebase/ready 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
