### PR TITLE
fix(keeper): reject codex for required bound tools

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -641,86 +641,96 @@ let resolve_tool_lane_for_oas_tools
      per-tool counter.  See [record_codex_cli_omission] docs. *)
   record_codex_cli_omission_for_agent ~agent_name:requested_agent_name
     ~tools:codex_keeper_bound_actor_tools;
-  let public_tool_names =
-    if codex_keeper_bound_actor_tools = [] then
-      public_tool_names
-    else
-      List.filter
-        (fun tool_name -> not (public_mcp_tool_requires_bound_actor tool_name))
+  if tool_requirement = `Required && codex_keeper_bound_actor_tools <> [] then
+    let detail =
+      Printf.sprintf
+        "%s cannot satisfy required keeper-bound runtime MCP tools omitted by \
+         codex_cli: %s"
+        (provider_label provider_cfg)
+        (String.concat ", "
+           (List.sort String.compare codex_keeper_bound_actor_tools))
+    in
+    Error (invalid_runtime_config "tool_support" detail)
+  else
+    let public_tool_names =
+      if codex_keeper_bound_actor_tools = [] then
         public_tool_names
-  in
-  let keeper_internal_tool_names =
-    if codex_keeper_bound_actor_tools = [] then
-      keeper_internal_tool_names
-    else
-      List.filter
-        (fun tool_name ->
-          not (runtime_mcp_tool_requires_bound_actor tool_name))
+      else
+        List.filter
+          (fun tool_name -> not (public_mcp_tool_requires_bound_actor tool_name))
+          public_tool_names
+    in
+    let keeper_internal_tool_names =
+      if codex_keeper_bound_actor_tools = [] then
         keeper_internal_tool_names
-  in
-  let runtime_tool_names =
-    dedupe_preserve_order (public_tool_names @ keeper_internal_tool_names)
-  in
-  (* #12676: When all tools were bound-actor and got stripped for codex_cli,
-     runtime_tool_names is empty. The keeper still needs an MCP connection so
-     it can discover and call non-bound tools dynamically. Build a minimal
-     connect-only policy with the server URL and auth but no allowed_tool_names
-     — codex_cli will see the MCP server without per-tool approval overrides. *)
-  let runtime_mcp_policy =
-    if runtime_tool_names = [] && codex_keeper_bound_actor_tools <> [] then
-      (* Minimal connect-only policy: server + auth, empty allowed_tool_names.
-         Codex_cli will connect to MCP but have no pre-approved tools. *)
-      let env_token = first_nonempty_env [ "MASC_MCP_TOKEN" ] in
-      let per_keeper_token =
-        match env_token, requested_agent_name with
-        | None, Some name ->
-            let base_path = Env_config_core.base_path () in
-            Auth.load_raw_token base_path ~agent_name:name
-        | _ -> None
-      in
-      let auth_headers =
-        match env_token, per_keeper_token with
-        | Some raw, _ -> [ ("Authorization", "Bearer " ^ raw) ]
-        | None, Some raw -> [ ("Authorization", "Bearer " ^ raw) ]
-        | None, None -> []
-      in
-      Some
-        { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
-          servers =
-            [
-              Llm_provider.Llm_transport.Http_server
-                { name = "masc";
-                  url = Env_config_runtime.Local_runtime.mcp_url ();
-                  headers = auth_headers;
-                };
-            ];
-          allowed_server_names = [ "masc" ];
-          allowed_tool_names = [];
-          strict = false;
-          disable_builtin_tools = false;
-        }
-      |> runtime_mcp_policy_for_provider ~provider_cfg
-           ~agent_name:(Option.value ~default:"" requested_agent_name)
-    else
-      runtime_mcp_policy_of_tool_names
-        ?agent_name:requested_agent_name
-        ~allow_keeper_internal:(keeper_internal_tool_names <> [])
-        runtime_tool_names
-      |> runtime_mcp_policy_for_provider ~provider_cfg
-           ~agent_name:(Option.value ~default:"" requested_agent_name)
-  in
-  match runtime_mcp_policy with
-  | Some runtime_mcp_policy
-    when Provider_tool_support.provider_supports_runtime_mcp_policy
-           provider_cfg runtime_mcp_policy ->
-      Ok ([], Some runtime_mcp_policy)
-  | _ when tools = [] ->
-      Ok (tools, None)
-  | _ when provider_supports_inline_tools provider_cfg ->
-      Ok (tools, None)
-  | _ when tool_requirement = `Optional ->
-      Ok ([], None)
-  | _ ->
+      else
+        List.filter
+          (fun tool_name ->
+            not (runtime_mcp_tool_requires_bound_actor tool_name))
+          keeper_internal_tool_names
+    in
+    let runtime_tool_names =
+      dedupe_preserve_order (public_tool_names @ keeper_internal_tool_names)
+    in
+    (* #12676: When all tools were bound-actor and got stripped for codex_cli
+       on an optional turn, runtime_tool_names is empty. The keeper may still
+       use an MCP connection for discovery, so build a minimal connect-only
+       policy with the server URL and auth but no allowed_tool_names. Required
+       turns reject above because a zero-tool policy cannot satisfy the tool
+       contract. *)
+    let runtime_mcp_policy =
+      if runtime_tool_names = [] && codex_keeper_bound_actor_tools <> [] then
+        let env_token = first_nonempty_env [ "MASC_MCP_TOKEN" ] in
+        let per_keeper_token =
+          match env_token, requested_agent_name with
+          | None, Some name ->
+              let base_path = Env_config_core.base_path () in
+              Auth.load_raw_token base_path ~agent_name:name
+          | _ -> None
+        in
+        let auth_headers =
+          match env_token, per_keeper_token with
+          | Some raw, _ -> [ ("Authorization", "Bearer " ^ raw) ]
+          | None, Some raw -> [ ("Authorization", "Bearer " ^ raw) ]
+          | None, None -> []
+        in
+        Some
+          { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+            servers =
+              [
+                Llm_provider.Llm_transport.Http_server
+                  { name = "masc";
+                    url = Env_config_runtime.Local_runtime.mcp_url ();
+                    headers = auth_headers;
+                  };
+              ];
+            allowed_server_names = [ "masc" ];
+            allowed_tool_names = [];
+            strict = false;
+            disable_builtin_tools = false;
+          }
+        |> runtime_mcp_policy_for_provider ~provider_cfg
+             ~agent_name:(Option.value ~default:"" requested_agent_name)
+      else
+        runtime_mcp_policy_of_tool_names
+          ?agent_name:requested_agent_name
+          ~allow_keeper_internal:(keeper_internal_tool_names <> [])
+          runtime_tool_names
+        |> runtime_mcp_policy_for_provider ~provider_cfg
+             ~agent_name:(Option.value ~default:"" requested_agent_name)
+    in
+    match runtime_mcp_policy with
+    | Some runtime_mcp_policy
+      when Provider_tool_support.provider_supports_runtime_mcp_policy
+             provider_cfg runtime_mcp_policy ->
+        Ok ([], Some runtime_mcp_policy)
+    | _ when tools = [] ->
+        Ok (tools, None)
+    | _ when provider_supports_inline_tools provider_cfg ->
+        Ok (tools, None)
+    | _ when tool_requirement = `Optional ->
+        Ok ([], None)
+    | _ ->
       let detail =
         let runtime_mcp_requires_http_headers =
           match runtime_mcp_policy with

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -194,7 +194,9 @@ val provider_label : Llm_provider.Provider_config.t -> string
     - [Error sdk_error] — provider supports neither lane.
 
     Codex_cli + keeper-bound actor tools trigger the [#10097] omission
-    counter/log path; the resulting policy excludes those tools. *)
+    counter/log path. Required turns reject because the omitted tools cannot
+    satisfy the tool contract; optional turns keep the prior degraded
+    discovery path and exclude those tools from the resulting policy. *)
 val resolve_tool_lane_for_oas_tools :
   ?agent_name:string ->
   ?tool_requirement:[ `Required | `Optional ] ->

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -111,9 +111,6 @@ let codex_cli_cannot_carry_keeper_bound_runtime_mcp
     ->
       List.exists Oas_worker_exec.runtime_mcp_tool_requires_bound_actor
         policy.allowed_tool_names
-      && not
-           (Oas_worker_exec.codex_cli_can_auth_keeper_bound_runtime_mcp
-              ~agent_name policy)
   | _ -> false
 
 (* #10681: per-provider rejection reason produced by the cascade filter.

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -118,6 +118,11 @@ let with_temp_masc_base_path prefix f =
       cleanup_dir base)
     f
 
+let seed_raw_token base_path agent_name raw =
+  let auth_dir = Auth.auth_dir base_path in
+  mkdir_p auth_dir;
+  Auth.save_private_text_file (Filename.concat auth_dir (agent_name ^ ".token")) raw
+
 let with_temp_masc_config cascade_json f =
   let base = temp_dir "test_masc_config" in
   let config_dir = Filename.concat base ".masc/config" in
@@ -1874,6 +1879,7 @@ let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_omits_bound_t
   in
   match
     Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~tool_requirement:`Optional
       ~agent_name:"keeper-sangsu-agent"
       ~provider_cfg:(make_codex_cli_provider_cfg ())
       ~tools ()
@@ -2085,6 +2091,28 @@ let test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_reject
       Alcotest.(check string) "field" "tool_support" field
   | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
 
+let test_resolve_tool_lane_for_codex_cli_keeper_task_claim_with_agent_rejects () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-keeper-claim" @@ fun () ->
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  seed_raw_token base_path "keeper-sangsu-agent" "keeper-raw-token";
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~agent_name:"keeper-sangsu-agent"
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools:[ make_named_noop_tool "keeper_task_claim" ] ()
+  with
+  | Ok _ ->
+      Alcotest.fail
+        "expected codex_cli to reject required keeper_task_claim despite per-keeper token auth"
+  | Error (Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })) ->
+      Alcotest.(check string) "field" "tool_support" field;
+      Alcotest.(check bool) "detail mentions keeper_task_claim" true
+        (contains_substring ~needle:"keeper_task_claim" detail)
+  | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
+
 let test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   match
@@ -2201,6 +2229,31 @@ let test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_boun
   | _ ->
       Alcotest.failf "expected only kimi_cli provider to remain, got %d"
         (List.length filtered)
+
+let test_filter_candidate_providers_for_tool_support_drops_codex_with_per_keeper_token
+    () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-bound-token" @@ fun () ->
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  seed_raw_token base_path "keeper-sangsu-agent" "keeper-raw-token";
+  let runtime_mcp_policy =
+    Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
+      ~agent_name:"keeper-sangsu-agent" [ "masc_status"; "masc_claim_next" ]
+  in
+  let filtered =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~label:"tool_use_strict"
+      [ make_codex_cli_provider_cfg (); make_kimi_cli_provider_cfg () ]
+  in
+  Alcotest.(check (list string))
+    "codex remains rejected even when bearer auth can be sourced"
+    [ "kimi_cli:kimi-for-coding" ]
+    (List.map Provider_tool_support.provider_debug_label filtered)
 
 let test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_for_keeper_internal_tools
     () =
@@ -4329,6 +4382,10 @@ let () =
         "keeper-internal tools on codex_cli with keeper actor are rejected"
         `Quick
         test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_rejects;
+      Alcotest.test_case
+        "keeper_task_claim on codex_cli with keeper actor is rejected"
+        `Quick
+        test_resolve_tool_lane_for_codex_cli_keeper_task_claim_with_agent_rejects;
       Alcotest.test_case "keeper-internal tools on kimi_cli are rejected" `Quick
         test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects;
       Alcotest.test_case "optional keeper-internal tools on codex_cli drop to text" `Quick
@@ -4339,6 +4396,10 @@ let () =
         "provider-normalized filter drops codex keeper-bound actor tools"
         `Quick
         test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_bound_actor_tools;
+      Alcotest.test_case
+        "provider-normalized filter drops codex bound actor despite per-keeper token"
+        `Quick
+        test_filter_candidate_providers_for_tool_support_drops_codex_with_per_keeper_token;
       Alcotest.test_case
         "provider-normalized filter keeps header-capable keeper-internal lanes"
         `Quick


### PR DESCRIPTION
## Summary

Required keeper tool turns can no longer route through `codex_cli` when the runtime MCP policy includes keeper-bound actor tools.

## Root Cause

The previous gate treated Codex bearer availability as enough to satisfy keeper-bound runtime MCP tools. In live `masc-improver` proof, Codex still stripped the bound tool surface and the model attempted `keeper_task_claim` as a shell command, yielding zero actual keeper tool calls while the turn was classified as satisfied.

## Changes

- Reject `codex_cli` during provider filtering whenever required tool use includes bound-actor runtime MCP tools, even if a per-keeper raw bearer token exists.
- Reject direct Codex tool-lane resolution for required bound keeper tools before it can create a zero-tool connect-only MCP policy.
- Preserve the degraded Codex connect-only path for optional turns.
- Add regressions for `keeper_task_claim` and for the per-keeper-token case that previously let Codex survive filtering.

## Validation

- `git diff --check HEAD~1..HEAD`
- `scripts/check-oas-pin.sh --local-only` passed once with `agent_sdk` at `oas#56e2fa32d9888b319b9a26abf0b1b9eab756ee6b`.
- Focused `scripts/dune-local.sh build test/test_oas_worker.exe` started after the pin was clean and caught the new test callback bug; that bug is fixed in this PR.
- A later `scripts/check-oas-pin.sh --local-only` failed because the shared opam switch drifted again to `oas#5da4a2d148260de722bee950fff8a14bb40f267a`; tracked separately in #13230.
- The same focused Dune run also surfaced unrelated current-main compile blockers in `lib/core/safe_ops.ml`, `lib/keeper/keeper_runtime_contract.ml`, and `lib/tool_keeper.ml`.

## Review Focus

Please focus on whether required keeper-bound tool turns should categorically skip Codex, while optional Codex runtime-MCP discovery remains available.
