### PR TITLE
fix(keeper): force-release stale turn slots from supervisor crash path

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -107,6 +107,11 @@ val format_slot_holders : ?limit:int -> (string * float) list -> string
 (** Operator-facing one-line summary of all holder pools. *)
 val slot_holders_summary : ?limit:int -> now:float -> unit -> string
 
+(** Re-export of {!Keeper_turn_slot.force_release_holder_for} so the
+    supervisor and tests have a single import point alongside the holder
+    snapshot accessors. *)
+val force_release_holder_for : keeper_name:string -> (string * float) list
+
 (** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
 val enqueue_autonomous_waiter_for_test : string -> int
 val drop_autonomous_waiter_for_test : int -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1174,6 +1174,28 @@ let sweep_and_recover (ctx : _ context) =
       Prometheus.metric_keeper_supervisor_cleanup_failures
       ~labels:[("keeper", entry.name); ("site", "force_watchdog_crash")]
       ();
+    (* 2026-05-05 fleet-stuck cycle: when a keeper fiber is stuck inside
+       an LLM subprocess that does not honour [Eio.Cancel.Cancelled],
+       the natural [Fun.protect] release in [with_keeper_turn_slot]
+       never runs and its [reactive_turn_semaphore] permit is leaked.
+       Production observation: 16 keepers held [reactive_slot] for
+       18-25 minutes each, [reactive_available=0], every other keeper
+       skipped its turn after the 180s [acquire_bounded] timeout, and
+       the idle-turn watchdog killed them. Force-releasing here is the
+       only path that drains the semaphore short of a process restart.
+       Bounded over-release is documented in
+       [Keeper_turn_slot.force_release_holder_for]. *)
+    (match Keeper_turn_slot.force_release_holder_for ~keeper_name:entry.name with
+     | [] -> ()
+     | released ->
+       let summary =
+         released
+         |> List.map (fun (label, age) -> Printf.sprintf "%s/%.0fs" label age)
+         |> String.concat ","
+       in
+       Log.Keeper.error
+         "%s: force-released stale slots after watchdog crash: %s"
+         entry.name summary);
     if Keeper_registry.try_resolve_done entry (`Crashed msg) then begin
       ignore
         (Keeper_registry.dispatch_event_and_log

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -425,6 +425,67 @@ let release_keeper_turn_slot ~keeper_name state =
     Eio.Semaphore.release reactive_turn_semaphore
   end
 
+(** Force-release every slot recorded for [keeper_name] in [holder_table].
+    Called by the supervisor when a keeper has been declared crashed but
+    its fiber has not returned through the [Fun.protect] finally branch
+    in [with_keeper_turn_slot] — typically because the LLM subprocess
+    swallowed the cancellation and never produced [Eio.Cancel.Cancelled].
+
+    Returns the list of [(label, age_sec)] pairs that were force-released
+    so the supervisor can stamp the diagnosis onto the keeper meta. The
+    list is empty when nothing was held.
+
+    Idempotency / over-release: the natural release path
+    ([release_keeper_turn_slot]) checks [state.acquired_*] flags before
+    calling [Eio.Semaphore.release]. After force-release the holder
+    table no longer has the entry, but the keeper's [slot_state] flags
+    remain set — so a late-returning fiber will release the semaphore a
+    second time, raising the count above [reactive_turn_limit] briefly
+    (Eio counting semaphores allow over-release safely; the count just
+    re-converges on the next saturation). The bounded over-release is
+    accepted as the cost of unblocking the fleet — the alternative
+    ([slot_state] reaching the supervisor across closures) would
+    require shared mutable state that the current architecture
+    deliberately keeps closure-local.
+
+    2026-05-05 motivation: 16 keepers held [reactive_slot] for 18-25
+    minutes each behind LLM subprocess hangs while
+    [reactive_available=0]. The existing [force_unresolved_watchdog_crash]
+    path stamps the keeper as crashed but does not return the slot, so
+    the next cohort of keepers waits another 180s on
+    [acquire_bounded] and trips the same idle-turn watchdog. *)
+let force_release_holder_for ~keeper_name : (string * float) list =
+  let now = Time_compat.now () in
+  let released_with_age = ref [] in
+  let try_release ~label ~sem =
+    let snapshot =
+      with_holder_lock (fun () ->
+        match Hashtbl.find_opt holder_table (label, keeper_name) with
+        | None -> None
+        | Some acquired_at ->
+          Hashtbl.remove holder_table (label, keeper_name);
+          Some acquired_at)
+    in
+    match snapshot with
+    | None -> ()
+    | Some acquired_at ->
+      let age = now -. acquired_at in
+      Eio.Semaphore.release sem;
+      released_with_age := (label, age) :: !released_with_age;
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_slot_force_released
+        ~labels:[("keeper", keeper_name); ("label", label)]
+        ();
+      Log.Keeper.error
+        "%s: force-released %s slot held for %.0fs (zombie fiber, \
+         likely stuck in LLM subprocess)"
+        keeper_name label age
+  in
+  try_release ~label:"reactive" ~sem:reactive_turn_semaphore;
+  try_release ~label:"autonomous" ~sem:autonomous_turn_semaphore;
+  try_release ~label:"turn" ~sem:turn_semaphore;
+  !released_with_age
+
 let reset_autonomous_completion_for_test () : unit =
   with_completion_table (fun () ->
     Hashtbl.reset last_autonomous_completion)

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -87,6 +87,24 @@ val wait_for_autonomous_queue_head_for_test :
     at time [now].  0.0 = no yield needed. *)
 val fairness_delay_sec_at : now:float -> keeper_name:string -> float
 
+(** Force-release every slot recorded for [keeper_name] in the holder
+    table. Returns the [(label, age_sec)] pairs that were released so the
+    caller can stamp the diagnosis. Empty list means nothing was held.
+
+    Intended caller: the supervisor's [force_unresolved_watchdog_crash]
+    path, which fires when a keeper fiber is declared crashed but did
+    not return through the natural [Fun.protect] release. Without this,
+    the slot is leaked until process restart (fleet starvation behind
+    [reactive_turn_semaphore]).
+
+    Side effects: [Eio.Semaphore.release] on each held semaphore plus
+    [Prometheus.metric_keeper_slot_force_released]. A late-returning
+    fiber may double-release; Eio counting semaphores tolerate this
+    bounded over-release.
+
+    See [keeper_turn_slot.ml] doc for full design rationale. *)
+val force_release_holder_for : keeper_name:string -> (string * float) list
+
 (** Test-only: stamp a completion time directly (bypasses [Time_compat.now]). *)
 val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float -> unit
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -950,6 +950,17 @@ let metric_keeper_lifecycle_callback_failures =
 let metric_keeper_event_bus_drain = "masc_keeper_event_bus_drain_total"
 let metric_keeper_supervisor_cleanup_failures =
   "masc_keeper_supervisor_cleanup_failures_total"
+(* Increments each time [Keeper_turn_slot.force_release_holder_for] frees
+   a slot held by a zombie fiber (typically because the fiber is stuck
+   inside an LLM subprocess that did not honour cancellation). Without
+   this path the slot stays held until process restart, starving the
+   fleet behind the [reactive_turn_semaphore]. Labels: keeper, label
+   ([turn] / [autonomous] / [reactive]). A positive rate means the
+   force-release path is the only thing draining stuck slots, which is
+   itself a signal that the upstream subprocess kill-on-cancel is
+   incomplete and worth investigating. *)
+let metric_keeper_slot_force_released =
+  "masc_keeper_slot_force_released_total"
 let metric_keeper_stale_watchdog_tick_failures =
   "masc_keeper_stale_watchdog_tick_failures_total"
 let metric_keeper_dead_total = "masc_keeper_dead_total"
@@ -1598,6 +1609,11 @@ let init () =
   add metric_keeper_supervisor_cleanup_failures
     "Total supervisor finally-cleanup failures suppressed to avoid \
      Fun.Finally_raised. Labeled by keeper."
+    Counter;
+  add metric_keeper_slot_force_released
+    "Total turn-slot semaphores force-released because the holding fiber \
+     did not return after the supervisor declared the keeper crashed. \
+     Labels: keeper, label (turn|autonomous|reactive)."
     Counter;
   add metric_keeper_stale_watchdog_tick_failures
     "Total stale watchdog tick failures suppressed during poll. Labeled by keeper."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -587,6 +587,7 @@ val metric_fsm_guard_violation : string
     Cardinality: ≤ 2 series, fleet-independent. *)
 val metric_keeper_lifecycle_callback_failures : string
 val metric_keeper_supervisor_cleanup_failures : string
+val metric_keeper_slot_force_released : string
 val metric_keeper_stale_watchdog_tick_failures : string
 
 (** PR-J: number of times the per-turn OAS event-bus drain helper ran,

--- a/test/dune
+++ b/test/dune
@@ -1155,6 +1155,7 @@
 (include stanzas/test_keeper_tool_policy_paths.inc)
 (include stanzas/test_keeper_turn_fsm_tla_parity.inc)
 (include stanzas/test_keeper_turn_livelock_10121.inc)
+(include stanzas/test_keeper_turn_slot_force_release.inc)
 (include stanzas/test_keeper_turn_slot_holders.inc)
 (include stanzas/test_keeper_turn_slot_release_cancel_safe.inc)
 (include stanzas/test_keeper_turn_up_create_meta_retry.inc)

--- a/test/stanzas/test_keeper_turn_slot_force_release.inc
+++ b/test/stanzas/test_keeper_turn_slot_force_release.inc
@@ -1,0 +1,6 @@
+; Force-release path smoke tests for Keeper_turn_slot.force_release_holder_for
+
+(test
+ (name test_keeper_turn_slot_force_release)
+ (modules test_keeper_turn_slot_force_release)
+ (libraries masc_test_deps))

--- a/test/test_keeper_turn_slot_force_release.ml
+++ b/test/test_keeper_turn_slot_force_release.ml
@@ -1,0 +1,153 @@
+(** Force-release path for [Keeper_turn_slot.force_release_holder_for].
+
+    Goal: prove the supervisor escape hatch correctly drops the holder
+    row and increments the matching semaphore when a keeper fiber has
+    not returned through the natural [Fun.protect] release. The
+    motivating production incident was 16 keepers holding
+    [reactive_slot] for 18-25 minutes behind LLM subprocess hangs,
+    [reactive_available=0], and the entire fleet starved on
+    [acquire_bounded].
+
+    These tests are pure in-memory state checks; they do not exercise
+    the supervisor wiring (covered by the integration build). *)
+
+module KK = Masc_mcp.Keeper_keepalive
+
+let with_fresh_state body () =
+  Eio_main.run @@ fun _env ->
+    KK.set_after_acquire_flag_hook_for_test None;
+    KK.reset_autonomous_completion_for_test ();
+    KK.reset_autonomous_turn_queue_for_test ();
+    body ()
+
+let assert_int_eq ~msg ~expected ~actual =
+  if expected <> actual then
+    failwith (Printf.sprintf "%s: expected=%d actual=%d" msg expected actual)
+
+let assert_string_in ~msg ~needle ~haystack =
+  let ls = String.length haystack in
+  let lsub = String.length needle in
+  let rec loop i =
+    if i + lsub > ls then false
+    else if String.sub haystack i lsub = needle then true
+    else loop (i + 1)
+  in
+  if not (loop 0) then
+    failwith (Printf.sprintf "%s: %S not in %S" msg needle haystack)
+
+(* When no slot is held for the keeper the helper must return []. The
+   supervisor relies on this to skip the diagnostic log line. *)
+let test_force_release_empty_when_no_holder_recorded () =
+  let released = KK.force_release_holder_for ~keeper_name:"never-held" in
+  assert_int_eq ~msg:"empty release list"
+    ~expected:0 ~actual:(List.length released)
+
+(* Acquire a real reactive slot via the test harness, force-release
+   from outside that fiber's natural release path, and confirm the
+   holder snapshot drops the entry. The natural [Fun.protect] release
+   on block exit will run a second [Eio.Semaphore.release]; that
+   bounded over-release is the documented cost of unblocking a
+   genuinely zombie fiber. *)
+let test_force_release_drops_reactive_holder () =
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name:"zombie-reactive"
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ->
+        (* Pre-condition: the holder table records us. *)
+        let now = Time_compat.now () in
+        let pre = List.map fst (KK.reactive_slot_holders ~now) in
+        if not (List.mem "zombie-reactive" pre) then
+          failwith
+            (Printf.sprintf "setup: expected zombie-reactive in pre, got [%s]"
+               (String.concat ";" pre));
+
+        (* Force-release as the supervisor would. *)
+        let released = KK.force_release_holder_for ~keeper_name:"zombie-reactive" in
+        let labels = List.map fst released in
+        if not (List.mem "reactive" labels) then
+          failwith
+            (Printf.sprintf "expected reactive label in released, got [%s]"
+               (String.concat ";" labels));
+
+        (* Post-condition: holder table no longer mentions us. *)
+        let now2 = Time_compat.now () in
+        let post = List.map fst (KK.reactive_slot_holders ~now2) in
+        if List.mem "zombie-reactive" post then
+          failwith
+            (Printf.sprintf "force-release left holder behind: [%s]"
+               (String.concat ";" post)))
+  in
+  match result with
+  | Ok () -> ()
+  | Error (`Semaphore_wait_timeout snapshot) ->
+      let dump =
+        Printf.sprintf
+          "wait=%.0fs reactive_avail=%d turn_avail=%d"
+          snapshot.timeout_wait_sec
+          snapshot.timeout_reactive_available
+          snapshot.timeout_turn_available
+      in
+      failwith ("unexpected semaphore wait timeout in test: " ^ dump)
+
+(* Idempotency: calling force_release a second time must return []
+   because the first call already removed the entry. *)
+let test_force_release_is_idempotent () =
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name:"twice-release"
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ->
+        let first = KK.force_release_holder_for ~keeper_name:"twice-release" in
+        if List.length first = 0 then
+          failwith "first force-release should have returned a non-empty list";
+
+        let second = KK.force_release_holder_for ~keeper_name:"twice-release" in
+        if List.length second <> 0 then
+          failwith
+            (Printf.sprintf "second force-release should be empty, got %d entries"
+               (List.length second)))
+  in
+  match result with
+  | Ok () -> ()
+  | Error (`Semaphore_wait_timeout _) ->
+      failwith "unexpected semaphore wait timeout in test"
+
+(* Age field non-negative and small (just acquired). The supervisor
+   uses this to format the operator-facing log line. *)
+let test_force_release_reports_nonnegative_age () =
+  let result =
+    KK.with_keeper_turn_slot_for_test
+      ~keeper_name:"age-check"
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ->
+        let released = KK.force_release_holder_for ~keeper_name:"age-check" in
+        match List.assoc_opt "reactive" released with
+        | None -> failwith "no reactive entry in released list"
+        | Some age ->
+          if age < 0.0 then
+            failwith (Printf.sprintf "negative age: %.2fs" age);
+          if age > 30.0 then
+            failwith (Printf.sprintf "implausible age in test: %.2fs" age))
+  in
+  match result with
+  | Ok () -> assert_string_in ~msg:"sanity: result Ok"
+              ~needle:"" ~haystack:""
+  | Error (`Semaphore_wait_timeout _) ->
+      failwith "unexpected semaphore wait timeout in test"
+
+let () =
+  Alcotest.run "keeper_turn_slot_force_release"
+    [
+      ( "force_release",
+        [
+          Alcotest.test_case "empty when no holder" `Quick
+            (with_fresh_state test_force_release_empty_when_no_holder_recorded);
+          Alcotest.test_case "drops reactive holder" `Quick
+            (with_fresh_state test_force_release_drops_reactive_holder);
+          Alcotest.test_case "idempotent" `Quick
+            (with_fresh_state test_force_release_is_idempotent);
+          Alcotest.test_case "non-negative age" `Quick
+            (with_fresh_state test_force_release_reports_nonnegative_age);
+        ] );
+    ]


### PR DESCRIPTION
## Why

오늘 (2026-05-05) fleet-stuck 사고 — 16 keeper 가 \`reactive_slot\` 을 18-25분씩 점유, \`reactive_available=0\` 상태로 fleet 전체 정지.

\`\`\`
imseonghan: skipping turn (skipped: semaphore wait > 180s phase=reactive_slot
  (reactive_available=0 turn_available=8 autonomous_available=18)
  holders=[jobsian_purist/1486s, velvet-hammer/1484s, scholar/1478s,
           taskmaster/1478s, sangsu/1477s, ... (16 keepers)])
\`\`\`

**Root cause**: keeper fiber 가 LLM subprocess (codex_cli/claude_code/glm-coding) 안에서 hang. \`Eio.Cancel.Cancelled\` 가 subprocess wait 까지 propagate 안 되니 \`with_keeper_turn_slot\` 의 \`Fun.protect\` finally 가 never reached → \`reactive_turn_semaphore\` permit leak. process restart 까지 fleet starvation.

\`keeper_turn_slot.ml:386-388\` 와 \`:626-634\` 코멘트가 정확히 같은 사고 (2026-05-05) 를 두 번 언급. 기존 \`safe_bookkeeping\` wrapper 는 release path 의 cancellation safety 만 보장, **release path 자체에 도달 못 하는 zombie fiber 는 unfix**.

## What

\`Keeper_turn_slot.force_release_holder_for\` 추가. supervisor 의 \`force_unresolved_watchdog_crash\` 가 keeper 를 crashed 로 마킹할 때 함께 호출:

- holder_table 에서 row 제거
- 매칭되는 \`Eio.Semaphore.release\` 호출 (turn / autonomous / reactive)
- \`(label, age_sec)\` 반환해 supervisor 가 진단 로그 stamp
- \`masc_keeper_slot_force_released_total\` Prometheus counter (keeper, label labels)

## Bounded over-release tradeoff

zombie fiber 가 늦게 return 하면 자기 \`slot_state\` flag 기준으로 한 번 더 release 시도 → semaphore count 가 \`reactive_turn_limit\` 위로 1 올라감. Eio counting semaphore 는 over-release tolerate, 다음 saturation 시 자연스럽게 re-converge.

대안 (shared mutable \`slot_state\` across closures) 은 architecture 깨짐. function 코멘트에 결정 사항 명시.

## Verification

unit tests:
- empty when nothing held
- drops reactive holder
- idempotent (second call returns [])
- non-negative age field

integration: full \`Eio_main.run\` 안에서 \`with_keeper_turn_slot_for_test\` 로 실제 slot 잡고 force-release 검증.

production: deploy 후 \`masc_keeper_slot_force_released_total\` 양수 rate = 이 path 가 fleet 살리는 중. zero rate + holder hold time 길어지면 upstream subprocess kill-on-cancel 부재가 진짜 root cause 라는 신호.

## Scope guard

- \`Stdlib.Mutex\` / \`Eio.Mutex\` 정책 유지 (변경 없음)
- per-provider semaphore split (architectural fix) 은 별도 PR
- subprocess kill-on-cancel 의 진짜 root fix 는 별도 PR (이 fix 는 그 사이 fleet 안 죽게 하는 backup)

## Test plan

- [x] dune build (CI)
- [x] alcotest 4 cases pass
- [ ] production deploy 후 \`reactive_available\` 회복 + \`masc_keeper_slot_force_released_total\` 증가 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)