### PR TITLE
feat(keeper): promote tagged tool results to memory

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -999,6 +999,27 @@ let run_turn
                   ~reply:response_text
                   ()
               in
+              let tool_result_notes_written =
+                if Keeper_tool_emission_hook.masc_tool_emission_enabled ()
+                then
+                  let tool_results =
+                    Keeper_tool_emission_hook.(
+                      snapshot (accumulator_for_keeper meta.name))
+                  in
+                  Keeper_memory_bank.append_memory_notes_from_tool_results
+                    config meta ~turn:result.turns
+                    ~results:tool_results
+                else 0
+              in
+              let notes_written =
+                notes_written + tool_result_notes_written
+              in
+              let kinds_written =
+                if tool_result_notes_written > 0
+                   && not (List.mem "long_term" kinds_written)
+                then kinds_written @ [ "long_term" ]
+                else kinds_written
+              in
               if notes_written > 0
               then
                 Keeper_turn_telemetry.log_keeper_memory_write

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -891,6 +891,97 @@ let append_memory_notes_from_reply
       notes;
     (List.length notes, List.rev !kinds_acc)
 
+let strip_tool_result_reserved_keys (result : Yojson.Safe.t) : Yojson.Safe.t =
+  match result with
+  | `Assoc kv ->
+      let reserved =
+        [ Multimodal.Tool_emission.multimodal_kind_key
+        ; Multimodal.Tool_emission.multimodal_id_key
+        ; Multimodal.Tool_emission.multimodal_metadata_key
+        ]
+      in
+      `Assoc (List.filter (fun (key, _) -> not (List.mem key reserved)) kv)
+  | other -> other
+
+let tool_result_metadata (result : Yojson.Safe.t) : Yojson.Safe.t =
+  match result with
+  | `Assoc kv -> (
+      match
+        List.assoc_opt
+          Multimodal.Tool_emission.multimodal_metadata_key
+          kv
+      with
+      | Some (`Assoc _ as metadata) -> metadata
+      | _ -> `Assoc [])
+  | _ -> `Assoc []
+
+let tool_result_payload_preview (result : Yojson.Safe.t) : string =
+  result
+  |> strip_tool_result_reserved_keys
+  |> Yojson.Safe.to_string
+  |> String_util.utf8_safe ~max_bytes:1200 ~suffix:"..."
+  |> String_util.to_string
+
+let tool_result_memory_text ~kind ~artifact_id ~payload_preview : string =
+  Printf.sprintf
+    "ToolResult %s artifact %s: %s"
+    kind artifact_id payload_preview
+
+let append_memory_notes_from_tool_results
+    (config : Coord.config)
+    (meta : keeper_meta)
+    ~(turn : int)
+    ~(results : Yojson.Safe.t list) : int =
+  let now_ts = Time_compat.now () in
+  let path = keeper_memory_bank_path config meta.name in
+  let seen_artifacts : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  let written = ref 0 in
+  List.iter
+    (fun result ->
+      match
+        ( Multimodal.Tool_emission.extract_kind_from_result result,
+          Multimodal.Tool_emission.extract_id_from_result result )
+      with
+      | Some kind_tag, Some artifact_id
+        when String.trim artifact_id <> ""
+             && not (Hashtbl.mem seen_artifacts artifact_id) ->
+          Hashtbl.add seen_artifacts artifact_id ();
+          let kind = Artifact.kind_tag_to_string kind_tag in
+          let payload_preview = tool_result_payload_preview result in
+          let text =
+            tool_result_memory_text ~kind ~artifact_id ~payload_preview
+          in
+          if is_meaningful_memory_text text then begin
+            append_jsonl_line path
+              (`Assoc
+                [ ("ts", `String (now_iso ()))
+                ; ("ts_unix", `Float now_ts)
+                ; ("name", `String meta.name)
+                ; ( "trace_id",
+                    `String
+                      (Keeper_id.Trace_id.to_string meta.runtime.trace_id) )
+                ; ("generation", `Int meta.runtime.generation)
+                ; ("turn", `Int turn)
+                ; ("kind", `String "long_term")
+                ; ("horizon", `String long_term_horizon)
+                ; ("source", `String "tool_result")
+                ; ("schema_version", `Int keeper_memory_schema_version)
+                ; ( "priority",
+                    `Int
+                      (tuned_priority_for_candidate
+                         ~kind:"long_term" ~text) )
+                ; ("text", `String text)
+                ; ("artifact_id", `String artifact_id)
+                ; ("artifact_kind", `String kind)
+                ; ("payload_preview", `String payload_preview)
+                ; ("metadata", tool_result_metadata result)
+                ]);
+            incr written
+          end
+      | _ -> ())
+    results;
+  !written
+
 let summarize_memory_bank_lines
     (lines : string list)
     ~(recent_limit : int) : keeper_memory_summary =

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -346,6 +346,16 @@ val append_memory_notes_from_reply :
 (** Persist new memory rows derived from a turn's [reply] (and
     optional [snapshot]); returns [(rows_written, drop_reasons)]. *)
 
+(** Promote explicitly tagged tool results into durable [long_term]
+    memory-bank rows. Only results carrying the existing
+    [Multimodal.Tool_emission] reserved kind/id tags are eligible. *)
+val append_memory_notes_from_tool_results :
+  Coord.config ->
+  Keeper_types.keeper_meta ->
+  turn:int ->
+  results:Yojson.Safe.t list ->
+  int
+
 (** {1 Summary} *)
 
 val summarize_memory_bank_lines :

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -51,6 +51,12 @@ let drain acc : Yojson.Safe.t list =
   Stdlib.Mutex.unlock acc.mutex;
   items
 
+let snapshot acc : Yojson.Safe.t list =
+  Stdlib.Mutex.lock acc.mutex;
+  let items = List.rev acc.items in
+  Stdlib.Mutex.unlock acc.mutex;
+  items
+
 let accumulator_size acc =
   Stdlib.Mutex.lock acc.mutex;
   let n = List.length acc.items in

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -87,6 +87,10 @@ val drain_into_working_context :
   working_context:Yojson.Safe.t option ->
   Yojson.Safe.t option
 
+(** Snapshot currently captured tool-result JSONs without draining them.
+    The returned list preserves capture order. *)
+val snapshot : accumulator -> Yojson.Safe.t list
+
 (** Number of items currently held in the accumulator. Useful for
     tests and metrics. *)
 val accumulator_size : accumulator -> int

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -532,6 +532,61 @@ let test_memory_write_persists_horizon_and_source () =
         check int "schema version persisted" 2
           Yojson.Safe.Util.(json |> member "schema_version" |> to_int))
 
+let test_tool_result_promotes_to_long_term_memory () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let config = make_test_room_config dir in
+    let meta =
+      keeper_meta ~name:"tool-result-keeper"
+        ~mention_targets:["tool-result-keeper"] ()
+    in
+    let tagged_result =
+      `Assoc
+        [
+          ("__multimodal_kind", `String "doc");
+          ( "__multimodal_id",
+            `String "01900000-0000-7000-8000-0000000000aa" );
+          ( "__multimodal_metadata",
+            `Assoc [ ("source_tool", `String "keeper_doc_probe") ] );
+          ( "body",
+            `String "durable tool result evidence for the next turn" );
+        ]
+    in
+    let untagged_result =
+      `Assoc
+        [
+          ( "body",
+            `String
+              "ordinary tool result should stay out of long term memory" );
+        ]
+    in
+    let written =
+      Keeper_memory_bank.append_memory_notes_from_tool_results
+        config meta ~turn:3 ~results:[ tagged_result; untagged_result ]
+    in
+    check int "only tagged tool result written" 1 written;
+    let entries =
+      read_memory_bank_entries config "tool-result-keeper"
+    in
+    check int "one memory row" 1 (List.length entries);
+    match entries with
+    | [ json ] ->
+        check string "kind is long_term" "long_term"
+          Yojson.Safe.Util.(json |> member "kind" |> to_string);
+        check string "horizon is long_term" "long_term"
+          Yojson.Safe.Util.(json |> member "horizon" |> to_string);
+        check string "source is tool_result" "tool_result"
+          Yojson.Safe.Util.(json |> member "source" |> to_string);
+        check string "artifact kind persisted" "doc"
+          Yojson.Safe.Util.(json |> member "artifact_kind" |> to_string);
+        let text =
+          Yojson.Safe.Util.(json |> member "text" |> to_string)
+        in
+        check bool "text carries payload evidence" true
+          (Astring.String.is_infix
+             ~affix:"durable tool result evidence" text)
+    | _ -> fail "expected a single tool-result memory row")
+
 let test_memory_candidates_capture_next_summary () =
   let snapshot =
     {
@@ -1392,6 +1447,8 @@ let () =
             test_memory_write_then_recall_meta_fallback;
           test_case "memory note persists horizon + source" `Quick
             test_memory_write_persists_horizon_and_source;
+          test_case "tagged tool result promotes to long_term" `Quick
+            test_tool_result_promotes_to_long_term_memory;
           test_case "next summary is preserved as memory" `Quick
             test_memory_candidates_capture_next_summary;
           test_case "long_term priority matches durable tier" `Quick

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -176,6 +176,22 @@ let test_drain_empties_accumulator () =
         (H.accumulator_size acc));
   print_endline "  drain_empties_accumulator: OK"
 
+let test_snapshot_preserves_accumulator () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let _ : THooks.hook_decision =
+        hook
+          (make_post_tool_use
+             ~content:
+               {|{"__multimodal_kind":"doc","__multimodal_id":"01900000-0000-7000-8000-0000000000f1","body":"snapshot me"}|})
+      in
+      let captured = H.snapshot acc in
+      assert_eq_int ~label:"snapshot_count" 1 (List.length captured);
+      assert_eq_int ~label:"snapshot_does_not_drain" 1
+        (H.accumulator_size acc));
+  print_endline "  snapshot_preserves_accumulator: OK"
+
 let test_drain_skips_untagged () =
   with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
       let acc = H.create_accumulator () in
@@ -341,6 +357,7 @@ let () =
   test_non_json_content_ignored ();
   test_other_events_ignored ();
   test_drain_empties_accumulator ();
+  test_snapshot_preserves_accumulator ();
   test_drain_skips_untagged ();
   test_install_chain_preserves_decision ();
   test_install_no_existing_hook ();
@@ -349,4 +366,4 @@ let () =
   test_registry_registered_names_sorted ();
   test_registry_drop_keeper_unknown_name_ok ();
   test_registry_drop_then_recreate_yields_fresh_accumulator ();
-  print_endline "=== Keeper_tool_emission_hook: 14/14 OK ==="
+  print_endline "=== Keeper_tool_emission_hook: 15/15 OK ==="


### PR DESCRIPTION
## What changed
- Adds a non-draining snapshot API for keeper tool-emission accumulators.
- Promotes explicitly tagged ToolResult JSONs into keeper `memory_bank.jsonl` as `long_term` rows with `source = "tool_result"`.
- Wires successful keeper turns to persist those tagged ToolResult rows before the existing multimodal post-turn drain consumes the accumulator.
- Adds regression coverage for accumulator snapshot semantics and tagged-only long-term memory promotion.

## Why it matters
ToolResult capture previously fed the working-context/multimodal path, but it did not create a durable keeper memory-bank row. This keeps the promotion deterministic by requiring the existing `__multimodal_kind` and `__multimodal_id` opt-in tags instead of inferring durable memory from arbitrary tool output.

## Validation
- `git diff --check origin/main..HEAD` passed.
- `scripts/dune-local.sh build test/test_keeper_memory.exe test/test_keeper_tool_emission_hook.exe` was attempted twice.
- Local focused Dune validation is blocked by current-main/shared-env issues before this slice can be fully typechecked:
  - `lib/core/safe_ops.ml` matches `Yojson.Safe.t` on unsupported `Tuple`/`Variant` constructors; tracked as #13247.
  - Shared `Agent_sdk`/`Llm_provider` switch/cache drift also appeared in the first run; related existing draft PR: #13237.
  - The second run reached the shared Dune lock behind another long-running `dune build bin/main_eio.exe`; my queued validation process was killed without touching the lock holder.

## Review focus
- Confirm that tagged ToolResult rows belong in keeper `long_term` memory rather than OAS session-scoped long-term storage.
- Confirm that the promotion should remain limited to explicit multimodal tags and should not infer from untagged tool output.