### PR TITLE
fix(core): keep safe json scrubber within Yojson.Safe

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -255,25 +255,7 @@ let rec sanitize_json_utf8 (json : Yojson.Safe.t) : Yojson.Safe.t =
           items
       in
       if !changed then `List sanitized_items else json
-  | `Tuple items ->
-      let changed = ref false in
-      let sanitized_items =
-        List.map
-          (fun item ->
-             let sanitized = sanitize_json_utf8 item in
-             if sanitized != item then changed := true;
-             sanitized)
-          items
-      in
-      if !changed then `Tuple sanitized_items else json
-  | `Variant (name, payload) ->
-      let sanitized_name = sanitize_text_utf8 name in
-      let sanitized_payload = Option.map sanitize_json_utf8 payload in
-      if sanitized_name != name || sanitized_payload != payload then
-        `Variant (sanitized_name, sanitized_payload)
-      else
-        json
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Floatlit _) as other -> other
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as other -> other
 
 let count_invalid_utf8_bytes s =
   let len = String.length s in

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -80,35 +80,6 @@ let test_parse_json_safe_rate_limits_repeated_utf8_repair_logs () =
   check int "both repairs counted" 2 stats.repaired_reads;
   check int "duplicate repair warning suppressed" 1 (List.length logs)
 
-let test_sanitize_json_utf8_covers_extended_safe_constructors () =
-  let open Safe_ops in
-  let replacement = "\xEF\xBF\xBD" in
-  let sanitized =
-    sanitize_json_utf8
-      (`Variant
-        ( "bad\xffvariant",
-          Some
-            (`Tuple
-              [
-                `String "bad\xfftuple";
-                `Floatlit "nan";
-                `Assoc [ ("bad\xffkey", `String "bad\xffvalue") ];
-              ]) ))
-  in
-  match sanitized with
-  | `Variant (name, Some (`Tuple [ `String tuple_value; `Floatlit "nan"; `Assoc fields ])) ->
-      check string "variant name repaired" ("bad" ^ replacement ^ "variant") name;
-      check string "tuple string repaired" ("bad" ^ replacement ^ "tuple") tuple_value;
-      let key, value =
-        match fields with
-        | [ field ] -> field
-        | _ -> fail "expected one assoc field"
-      in
-      check string "assoc key repaired" ("bad" ^ replacement ^ "key") key;
-      check string "assoc value repaired" ("bad" ^ replacement ^ "value")
-        (Yojson.Safe.Util.to_string value)
-  | _ -> fail "unexpected sanitized JSON shape"
-
 let test_utf8_repair_log_rate_limit_table_is_bounded () =
   let open Safe_ops in
   reset_persistence_utf8_repair_stats_for_tests ();
@@ -471,8 +442,6 @@ let () =
         test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair;
       test_case "rate limits repeated utf8 repair logs" `Quick
         test_parse_json_safe_rate_limits_repeated_utf8_repair_logs;
-      test_case "sanitizes extended safe constructors" `Quick
-        test_sanitize_json_utf8_covers_extended_safe_constructors;
       test_case "bounds utf8 repair log rate-limit table" `Quick
         test_utf8_repair_log_rate_limit_table_is_bounded;
       test_case "long invalid" `Quick test_parse_json_safe_long_invalid;


### PR DESCRIPTION
## Summary
- remove Yojson.Basic-only Tuple/Variant/Floatlit patterns from sanitize_json_utf8
- keep the sanitizer within the declared Yojson.Safe.t surface so current OAS/Yojson types compile

## Validation
- git diff --check
- scripts/check-oas-pin.sh --local-only attempted, but local shared opam switch was concurrently repinned to 5dac00e while main expects 5da4a2d; leaving exact Dune validation to PR CI