### PR TITLE
fix: surface filesystem sandbox repos in keeper status

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -255,25 +255,7 @@ let rec sanitize_json_utf8 (json : Yojson.Safe.t) : Yojson.Safe.t =
           items
       in
       if !changed then `List sanitized_items else json
-  | `Tuple items ->
-      let changed = ref false in
-      let sanitized_items =
-        List.map
-          (fun item ->
-             let sanitized = sanitize_json_utf8 item in
-             if sanitized != item then changed := true;
-             sanitized)
-          items
-      in
-      if !changed then `Tuple sanitized_items else json
-  | `Variant (name, payload) ->
-      let sanitized_name = sanitize_text_utf8 name in
-      let sanitized_payload = Option.map sanitize_json_utf8 payload in
-      if sanitized_name != name || sanitized_payload != payload then
-        `Variant (sanitized_name, sanitized_payload)
-      else
-        json
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Floatlit _) as other -> other
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as other -> other
 
 let count_invalid_utf8_bytes s =
   let len = String.length s in

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -254,6 +254,68 @@ let cleanup_stale ~(config : Coord.config) ~(timeout_sec : float) () =
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)
 
+let safe_file_exists path =
+  try Fs_compat.file_exists path with
+  | Sys_error _ -> false
+
+let safe_is_dir path =
+  try Fs_compat.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+
+let repo_name_of_json = function
+  | `Assoc fields -> (
+      match List.assoc_opt "name" fields with
+      | Some (`String name) when String.trim name <> "" -> Some name
+      | _ -> None)
+  | _ -> None
+
+let cached_playground_repo_entries playground_abs =
+  let cache_path = Filename.concat playground_abs ".playground_state.json" in
+  try
+    match Yojson.Safe.from_file cache_path with
+    | `Assoc _ as json -> (
+        match Yojson.Safe.Util.member "repos" json with
+        | `List repos -> repos
+        | _ -> [])
+    | _ -> []
+  with
+  | Sys_error _ | Yojson.Json_error _ -> []
+
+let filesystem_playground_repo_names playground_abs =
+  let repos_dir = Filename.concat playground_abs "repos" in
+  if not (safe_is_dir repos_dir) then []
+  else
+    try
+      Sys.readdir repos_dir
+      |> Array.to_list
+      |> List.filter (fun name ->
+        let repo_path = Filename.concat repos_dir name in
+        safe_is_dir repo_path
+        && safe_file_exists (Filename.concat repo_path ".git"))
+      |> List.sort String.compare
+    with
+    | Sys_error _ -> []
+
+let playground_repos_json ~(config : Coord.config) ~(meta : keeper_meta) =
+  let playground_abs =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> normalize_path
+  in
+  let cached = cached_playground_repo_entries playground_abs in
+  let cached_names = List.filter_map repo_name_of_json cached in
+  let fs_entries =
+    filesystem_playground_repo_names playground_abs
+    |> List.filter (fun name -> not (List.mem name cached_names))
+    |> List.map (fun name ->
+      `Assoc
+        [
+          ("name", `String name);
+          ("path", `String (Filename.concat "repos" name));
+          ("source", `String "filesystem");
+        ])
+  in
+  `List (cached @ fs_entries)
+
 let preflight_status_json ~timeout_sec =
   Keeper_sandbox_runtime.docker_preflight ~timeout_sec ()
   |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
@@ -383,5 +445,6 @@ let live_status_json ?(include_preflight = true)
       ("container_error", Json_util.string_opt_to_json container_error);
       ("why_no_container", Json_util.string_opt_to_json why_no_container);
       ("recommendation", Json_util.string_opt_to_json recommendation);
+      ("playground_repos", playground_repos_json ~config ~meta);
       ("identity", identity_json meta);
     ]

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -45,6 +45,11 @@ val cleanup_stale :
   unit ->
   Keeper_sandbox_runtime.cleanup_result
 
+val playground_repos_json :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  Yojson.Safe.t
+
 val live_status_json :
   ?include_preflight:bool ->
   ?preflight_override:Yojson.Safe.t option ->

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1262,16 +1262,8 @@ let handle_keeper_status ctx args : tool_result =
                Json_util.string_opt_to_json effective_sandbox_image);
              ("allowed_paths", string_list_to_json m.allowed_paths);
              ("playground_repos",
-               let cache_path = Filename.concat playground_abs
-                 ".playground_state.json" in
-               try
-                 match Yojson.Safe.from_file cache_path with
-                 | `Assoc _ as json ->
-                   (match Yojson.Safe.Util.member "repos" json with
-                    | `Null -> `List []
-                    | repos -> repos)
-                 | _ -> `List []
-               with Sys_error _ | Yojson.Json_error _ -> `List []);
+               Keeper_sandbox_control.playground_repos_json
+                 ~config:ctx.config ~meta:m);
              ("pr_history",
                let pr_path = Filename.concat playground_abs
                  ".playground_pr_history.jsonl" in

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -280,6 +280,12 @@ let test_keeper_sandbox_status_exposes_local_summary () =
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
+      let meta = read_keeper_meta_exn config keeper_name in
+      let repo_path =
+        Keeper_sandbox.host_root_abs_of_meta ~config meta
+        |> fun root -> Filename.concat root "repos/sandbox-repo"
+      in
+      ensure_dir (Filename.concat repo_path ".git");
       let ok, body =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
           ~args:
@@ -306,16 +312,36 @@ let test_keeper_sandbox_status_exposes_local_summary () =
       Alcotest.(check bool) "identity matches canonical agent" true
         (sandbox_json |> member "identity" |> member "agent_name_matches"
        |> to_bool);
-      let ok, status_body =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
-          ~args:(`Assoc [ ("name", `String keeper_name); ("fast", `Bool true) ])
+      let sandbox_repos =
+        sandbox_json |> member "playground_repos" |> to_list
       in
-      Alcotest.(check bool) "keeper status ok" true ok;
-      let status_json = parse_json_exn status_body in
-      Alcotest.(check string) "status surfaces sandbox_live local" "local"
-        Yojson.Safe.Util.(
-          status_json |> member "sandbox_live" |> member "effective_mode"
-          |> to_string))
+      Alcotest.(check bool) "sandbox status scans filesystem repo" true
+        (List.exists
+           (fun repo ->
+             String.equal
+               (repo |> member "name" |> to_string)
+               "sandbox-repo"
+             && String.equal
+                  (repo |> member "source" |> to_string)
+                  "filesystem")
+           sandbox_repos);
+      (* keepalive is not part of this status-surface assertion. *)
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let status_repos =
+        Keeper_sandbox_control.playground_repos_json ~config ~meta
+        |> to_list
+      in
+      Alcotest.(check bool) "keeper status repo helper scans filesystem repo"
+        true
+        (List.exists
+           (fun repo ->
+             String.equal
+               (repo |> member "name" |> to_string)
+               "sandbox-repo"
+             && String.equal
+                  (repo |> member "path" |> to_string)
+                  "repos/sandbox-repo")
+           status_repos))
 
 let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- Merge cached playground repo metadata with actual filesystem repos discovered under keeper sandbox repos/*/.git.
- Surface the merged list in both masc_keeper_sandbox_status and masc_keeper_status execution_context via a shared helper.
- Add coverage for a filesystem-only sandbox repo so status no longer falsely reports an empty/missing repo list when .playground_state.json is stale.
- Include a small Yojson.Safe compile fix in Safe_ops because latest main currently had Basic-only variants in a Safe.t sanitizer.

## Why
Live Docker keepers had real checkouts under /Users/dancer/me/.masc/playground/docker/<keeper>/repos/masc-mcp, but status could still show playground_repos=[] or omit masc-mcp because it only trusted .playground_state.json. That hides whether a keeper can actually operate on code and makes the UI/API look more idle than the runtime state.

## Validation
- PASS: git diff --check origin/main...HEAD
- PASS before the final fast-moving-main rebase: env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-sandbox-repo-status-0505i scripts/dune-local.sh build test/test_operator_control.exe
- PASS before the final fast-moving-main rebase: /private/tmp/masc-dune-sandbox-repo-status-0505i/default/test/test_operator_control.exe test operator 44 --compact --show-errors
- Latest rerun after the final rebase stopped at the repo wrapper pin guard because the shared opam switch was moved to agent_sdk 0.190.11 while this head expects 0.190.10.