### PR TITLE
test(goal-loop): refresh startup ACT fixture after force release

### DIFF
--- a/docs/examples/goal-loop-fixture.md
+++ b/docs/examples/goal-loop-fixture.md
@@ -25,10 +25,11 @@ python3 scripts/goal_loop_status.py \
 Expected key facts:
 
 - `overall_status` is `critical`.
-- Decide reports `act_linked_count=4` and `act_missing_count=1`.
-- Act remains critical because `D-EMERGENCY-1` is still missing a linked ACT
-  artifact.
-- Verify remains `FAIL`, so the loop must not be marked complete.
+- Decide reports `act_linked_count=5` and `act_missing_count=0`.
+- Act is no longer critical in the fixture: every startup decision has at least
+  one linked PR artifact.
+- Verify remains `FAIL` because the startup replay is pre-ACT evidence, so the
+  loop must not be marked complete until a post-ACT live verify passes.
 
 Use the JSON status form when another tool needs to consume the replay:
 

--- a/test/fixtures/goal_loop/act-map.startup.json
+++ b/test/fixtures/goal_loop/act-map.startup.json
@@ -1,13 +1,15 @@
 {
   "D-EMERGENCY-1": [
     "PR#13218 keeper credential auto-recovery",
-    "PR#13231 keeper slot forced-reclaim regression"
+    "PR#13231 keeper slot forced-reclaim regression",
+    "PR#13246 keeper slot crash-path force release"
   ],
   "D-EMERGENCY-2": [
     "PR#13124 provider health probes"
   ],
   "D-P1-1": [
-    "PR#13123 alive-stuck recovery"
+    "PR#13123 alive-stuck recovery",
+    "PR#13190 partial stale-turn recovery"
   ],
   "D-P2-1": [
     "PR#13138 keeper TOML unknown keys"

--- a/test/fixtures/goal_loop/known-prs.startup.json
+++ b/test/fixtures/goal_loop/known-prs.startup.json
@@ -2,13 +2,23 @@
   "prs": [
     {
       "number": 13231,
-      "state": "OPEN",
+      "state": "MERGED",
       "title": "test(keeper): pin slot reclaim after acquire flag"
     },
     {
       "number": 13218,
-      "state": "OPEN",
+      "state": "MERGED",
       "title": "fix(keeper): self-heal archived credentials"
+    },
+    {
+      "number": 13246,
+      "state": "MERGED",
+      "title": "fix(keeper): force-release stale turn slots from supervisor crash path"
+    },
+    {
+      "number": 13190,
+      "state": "MERGED",
+      "title": "fix(keeper): allow partial stale recovery restarts"
     },
     {
       "number": 13123,

--- a/test/fixtures/goal_loop/verify.fail.json
+++ b/test/fixtures/goal_loop/verify.fail.json
@@ -2,14 +2,14 @@
   "failing_findings": [
     {
       "finding_id": "NF-2",
-      "reason": "D-EMERGENCY-1 still has no linked ACT artifact"
+      "reason": "startup replay still contains credential starvation evidence; post-ACT live verify has not passed"
     }
   ],
   "status": "FAIL",
   "violations": [
     {
       "decision_id": "D-EMERGENCY-1",
-      "kind": "act_missing"
+      "kind": "post_act_verify_pending"
     }
   ]
 }

--- a/test/test_decide_goal_loop_findings.py
+++ b/test/test_decide_goal_loop_findings.py
@@ -108,7 +108,7 @@ class DecideGoalLoopFindingsTest(unittest.TestCase):
         self.assertIn('"act_linked_count": 1', result.stdout)
         self.assertIn('"act_missing_count": 1', result.stdout)
 
-    def test_startup_fixture_keeps_unlinked_emergency_action_visible(self) -> None:
+    def test_startup_fixture_links_all_decisions_after_emergency_acts(self) -> None:
         orient = json.loads(
             (FIXTURE_DIR / "orient.startup.json").read_text(encoding="utf-8")
         )
@@ -123,15 +123,26 @@ class DecideGoalLoopFindingsTest(unittest.TestCase):
         by_id = {decision.decision_id: decision for decision in report.decisions}
 
         self.assertEqual(report.decisions_total, 5)
-        self.assertEqual(report.act_linked_count, 4)
-        self.assertEqual(report.act_missing_count, 1)
+        self.assertEqual(report.act_linked_count, 5)
+        self.assertEqual(report.act_missing_count, 0)
         self.assertEqual(
             by_id["D-EMERGENCY-1"].act_status,
-            "ACT_MISSING",
+            "ACT_LINKED",
+        )
+        self.assertEqual(
+            by_id["D-EMERGENCY-1"].act_artifacts,
+            [
+                "PR#13218 keeper credential auto-recovery",
+                "PR#13231 keeper slot forced-reclaim regression",
+                "PR#13246 keeper slot crash-path force release",
+            ],
         )
         self.assertEqual(
             by_id["D-P1-1"].act_artifacts,
-            ["PR#13123 alive-stuck recovery"],
+            [
+                "PR#13123 alive-stuck recovery",
+                "PR#13190 partial stale-turn recovery",
+            ],
         )
 
 

--- a/test/test_validate_goal_loop_act_map.py
+++ b/test/test_validate_goal_loop_act_map.py
@@ -34,9 +34,9 @@ class ValidateGoalLoopActMapTest(unittest.TestCase):
             require_pr_ref=True,
         )
 
-        self.assertEqual(report.artifact_count, 6)
-        self.assertEqual(report.pr_ref_count, 6)
-        self.assertEqual(report.known_pr_count, 6)
+        self.assertEqual(report.artifact_count, 8)
+        self.assertEqual(report.pr_ref_count, 8)
+        self.assertEqual(report.known_pr_count, 8)
         self.assertEqual(report.missing_pr_count, 0)
         self.assertEqual(report.malformed_artifact_count, 0)
 


### PR DESCRIPTION
## Summary

- Refresh the GOAL LOOP startup ACT map now that #13190 and #13246 are merged.
- Update the known-PR fixture states for #13218/#13231 and add the new merged recovery/force-release artifacts.
- Change the fixture VERIFY failure from stale act_missing wording to post-ACT live verify pending.

## Verification

- python3 -m json.tool test/fixtures/goal_loop/act-map.startup.json
- python3 -m json.tool test/fixtures/goal_loop/known-prs.startup.json
- python3 -m json.tool test/fixtures/goal_loop/verify.fail.json
- git diff --check
- python3 test/test_decide_goal_loop_findings.py
- python3 test/test_validate_goal_loop_act_map.py
- python3 test/test_goal_loop_status.py
- python3 scripts/validate_goal_loop_act_map.py test/fixtures/goal_loop/act-map.startup.json --known-prs-json test/fixtures/goal_loop/known-prs.startup.json --require-pr-ref --fail-on any
- npx pyright --outputjson test/test_decide_goal_loop_findings.py test/test_goal_loop_status.py test/test_validate_goal_loop_act_map.py
- ruff check test/test_decide_goal_loop_findings.py test/test_goal_loop_status.py test/test_validate_goal_loop_act_map.py
- ruff format --check test/test_decide_goal_loop_findings.py test/test_goal_loop_status.py test/test_validate_goal_loop_act_map.py
- fixture replay: act_linked_count=5, act_missing_count=0, act status ok, verify still critical

## GOAL LOOP ACT Checklist

- Observe: uses existing startup replay fixture.
- Orient: no new finding classifier; fixture remains a deterministic replay.
- Decide: all startup decisions now have linked ACT artifacts.
- Act: fixture links #13190 and #13246 for the merged recovery/force-release work.
- Verify: remains FAIL until post-ACT live verification passes; no false PASS.
- Loop: next_action now stays on the highest-priority live evidence, not missing ACT drift.