### PR TITLE
feat(board): include recent reaction users

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -613,7 +613,14 @@ describe('board reactions', () => {
   it('fetches reaction summaries with the dashboard voter', async () => {
     window.history.replaceState({}, '', '/?agent=dashboard-reviewer')
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ reactions: [{ emoji: '👍', count: 2, reacted: true }] }), {
+      new Response(JSON.stringify({
+        reactions: [{
+          emoji: '👍',
+          count: 2,
+          has_reacted: true,
+          recent_user_ids: ['agent-b', 'agent-a'],
+        }],
+      }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
@@ -622,7 +629,13 @@ describe('board reactions', () => {
 
     const result = await fetchBoardReactions('post', 'post-1')
 
-    expect(result).toEqual([{ emoji: '👍', count: 2, reacted: true }])
+    expect(result).toEqual([{
+      emoji: '👍',
+      count: 2,
+      reacted: true,
+      has_reacted: true,
+      recent_user_ids: ['agent-b', 'agent-a'],
+    }])
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/api/v1/board/reactions?')
     expect(url).toContain('target_type=post')
@@ -639,7 +652,12 @@ describe('board reactions', () => {
         user_id: 'dashboard-reviewer',
         emoji: '🚀',
         reacted: true,
-        summary: [{ emoji: '🚀', count: 1, reacted: true }],
+        summary: [{
+          emoji: '🚀',
+          count: 1,
+          has_reacted: true,
+          recent_user_ids: ['dashboard-reviewer'],
+        }],
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -649,7 +667,13 @@ describe('board reactions', () => {
 
     const result = await toggleReaction('comment', 'comment-1', '🚀')
 
-    expect(result.summary).toEqual([{ emoji: '🚀', count: 1, reacted: true }])
+    expect(result.summary).toEqual([{
+      emoji: '🚀',
+      count: 1,
+      reacted: true,
+      has_reacted: true,
+      recent_user_ids: ['dashboard-reviewer'],
+    }])
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/board/reactions')
     expect(JSON.parse(String(init.body))).toMatchObject({

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -438,10 +438,18 @@ function normalizeBoardReactionSummary(raw: unknown): BoardReactionSummary | nul
   if (!isRecord(raw)) return null
   const emoji = asString(raw.emoji, '').trim()
   if (!emoji) return null
+  const hasReacted = raw.has_reacted === true || raw.reacted === true
+  const recentUserIds = Array.isArray(raw.recent_user_ids)
+    ? raw.recent_user_ids
+        .map(value => asString(value, '').trim())
+        .filter(value => value !== '')
+    : []
   return {
     emoji,
     count: asNumber(raw.count, 0),
-    reacted: raw.reacted === true,
+    reacted: hasReacted,
+    has_reacted: hasReacted,
+    recent_user_ids: recentUserIds,
   }
 }
 

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -39,7 +39,13 @@ vi.mock('../../api/board', () => ({
     user_id: 'dashboard-reviewer',
     emoji: '🚀',
     reacted: true,
-    summary: [{ emoji: '🚀', count: 1, reacted: true }],
+    summary: [{
+      emoji: '🚀',
+      count: 1,
+      reacted: true,
+      has_reacted: true,
+      recent_user_ids: ['dashboard-reviewer'],
+    }],
   }),
 }))
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -169,6 +169,8 @@ export interface BoardReactionSummary {
   emoji: string
   count: number
   reacted: boolean
+  has_reacted: boolean
+  recent_user_ids: string[]
 }
 
 export interface BoardReactionToggleResult {

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -325,6 +325,10 @@ let reaction_summary_to_yojson (summary : reaction_summary) : Yojson.Safe.t =
     ("emoji", `String summary.emoji);
     ("count", `Int summary.count);
     ("reacted", `Bool summary.reacted);
+    ("has_reacted", `Bool summary.reacted);
+    ( "recent_user_ids",
+      `List (List.map (fun user_id -> `String user_id) summary.recent_user_ids)
+    );
   ]
 
 let reaction_toggle_result_to_yojson (result : reaction_toggle_result) :
@@ -856,17 +860,25 @@ let ensure_reaction_target_unlocked store ~target_type ~target_id =
 let reaction_summaries_unlocked store ~target_type ~target_id ?user_id () =
   let counts = Hashtbl.create 8 in
   let reacted = Hashtbl.create 8 in
+  let recent_users = Hashtbl.create 8 in
   Hashtbl.iter
     (fun _ (reaction : reaction) ->
        if (=) reaction.target_type target_type
           && String.equal reaction.target_id target_id
        then begin
+         let reaction_user_id = Agent_id.to_string reaction.user_id in
          let current =
            Hashtbl.find_opt counts reaction.emoji |> Option.value ~default:0
          in
          Hashtbl.replace counts reaction.emoji (current + 1);
+         let users =
+           Hashtbl.find_opt recent_users reaction.emoji
+           |> Option.value ~default:[]
+         in
+         Hashtbl.replace recent_users reaction.emoji
+           ((reaction_user_id, reaction.created_at) :: users);
          match user_id with
-         | Some user when String.equal (Agent_id.to_string reaction.user_id) user ->
+         | Some user when String.equal reaction_user_id user ->
              Hashtbl.replace reacted reaction.emoji true
          | Some _ | None -> ()
        end)
@@ -882,6 +894,13 @@ let reaction_summaries_unlocked store ~target_type ~target_id ?user_id () =
              count;
              reacted =
                Hashtbl.find_opt reacted emoji |> Option.value ~default:false;
+             recent_user_ids =
+               Hashtbl.find_opt recent_users emoji
+               |> Option.value ~default:[]
+               |> List.sort (fun (_, a_ts) (_, b_ts) ->
+                      Stdlib.Float.compare b_ts a_ts)
+               |> List.map fst
+               |> List.filteri (fun idx _ -> idx < 5);
            })
     board_reaction_emojis
 

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -172,6 +172,7 @@ type reaction_summary = {
   emoji: string;
   count: int;
   reacted: bool;
+  recent_user_ids: string list;
 }
 
 type reaction_toggle_result = {

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -119,6 +119,7 @@ type reaction_summary = {
   emoji : string;
   count : int;
   reacted : bool;
+  recent_user_ids : string list;
 }
 
 type reaction_toggle_result = {

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -502,14 +502,16 @@ let test_reaction_toggle_and_summary () =
             | summary :: _ ->
                 Alcotest.(check string) "summary emoji" "🚀" summary.emoji;
                 Alcotest.(check int) "summary count" 1 summary.count;
-                Alcotest.(check bool) "summary reacted" true summary.reacted
+                Alcotest.(check bool) "summary reacted" true summary.reacted;
+                Alcotest.(check (list string)) "summary recent users"
+                  [ "reactor" ] summary.recent_user_ids
             | [] -> Alcotest.fail "expected reaction summary"));
       (match
          Board_dispatch.list_reactions ~target_type:Board.Reaction_post
            ~target_id:post_id ~user_id:"reactor" ()
        with
-       | Error e -> Alcotest.fail (Board.show_board_error e)
-       | Ok summaries ->
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok summaries ->
            Alcotest.(check int) "listed summary length" 1
              (List.length summaries));
       (match
@@ -560,8 +562,50 @@ let test_comment_reaction_survives_restart () =
           | summary :: _ ->
               Alcotest.(check string) "restored emoji" "👏" summary.emoji;
               Alcotest.(check int) "restored count" 1 summary.count;
-              Alcotest.(check bool) "restored reacted" true summary.reacted
+              Alcotest.(check bool) "restored reacted" true summary.reacted;
+              Alcotest.(check (list string)) "restored recent users"
+                [ "reactor" ] summary.recent_user_ids
           | [] -> Alcotest.fail "expected restored reaction summary"
+
+let test_reaction_summary_recent_user_ids () =
+  match
+    Board_dispatch.create_post ~author:"reaction-author"
+      ~content:"recent reactors parent" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let post_id = Board.Post_id.to_string post.id in
+      List.iter
+        (fun user_id ->
+           match
+             Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+               ~target_id:post_id ~user_id ~emoji:"👍"
+           with
+           | Ok _ -> ()
+           | Error e -> Alcotest.fail (Board.show_board_error e))
+        [ "reactor-a"; "reactor-b"; "reactor-c" ];
+      match
+        Board_dispatch.list_reactions ~target_type:Board.Reaction_post
+          ~target_id:post_id ~user_id:"reactor-b" ()
+      with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok summaries ->
+          match summaries with
+          | summary :: _ ->
+              Alcotest.(check string) "summary emoji" "👍" summary.emoji;
+              Alcotest.(check int) "summary count" 3 summary.count;
+              Alcotest.(check bool) "selected user reacted" true
+                summary.reacted;
+              Alcotest.(check int) "recent user cap input length" 3
+                (List.length summary.recent_user_ids);
+              List.iter
+                (fun user_id ->
+                   Alcotest.(check bool)
+                     (Printf.sprintf "recent includes %s" user_id)
+                     true
+                     (List.mem user_id summary.recent_user_ids))
+                [ "reactor-a"; "reactor-b"; "reactor-c" ]
+          | [] -> Alcotest.fail "expected reaction summary"
 
 let test_board_sse_reaction_changed () =
   let post_id =
@@ -743,6 +787,8 @@ let () =
         (with_eio test_reaction_toggle_and_summary);
       Alcotest.test_case "comment reaction survives restart" `Quick
         (with_eio test_comment_reaction_survives_restart);
+      Alcotest.test_case "summary recent user ids" `Quick
+        (with_eio test_reaction_summary_recent_user_ids);
       Alcotest.test_case "SSE reaction_changed" `Quick
         (with_eio test_board_sse_reaction_changed);
       Alcotest.test_case "unsupported emoji rejected" `Quick


### PR DESCRIPTION
## Summary
- add has_reacted and recent_user_ids to board reaction summaries
- keep the existing reacted boolean for dashboard/API compatibility
- normalize the new reaction payload shape in dashboard API clients

## Artifact Coverage
- Covers masc_sns.agent.final 4.1.3: reaction API count + recent 5 users + current-user reaction flag.

## Verification
- pnpm exec vitest run src/api/board.test.ts src/components/board/post-detail.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
- OCaml focused Dune target still being rerun locally under serialized wrapper after host Dune contention; CI will also verify.