### PR TITLE
fix(keeper): unblock main build (typed holder_key + Multimodal prefix)

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -946,7 +946,7 @@ let append_memory_notes_from_tool_results
         when String.trim artifact_id <> ""
              && not (Hashtbl.mem seen_artifacts artifact_id) ->
           Hashtbl.add seen_artifacts artifact_id ();
-          let kind = Artifact.kind_tag_to_string kind_tag in
+          let kind = Multimodal.Artifact.kind_tag_to_string kind_tag in
           let payload_preview = tool_result_payload_preview result in
           let text =
             tool_result_memory_text ~kind ~artifact_id ~payload_preview

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -598,28 +598,39 @@ let force_release_holder_for ~keeper_name : (string * float) list =
   let now = Time_compat.now () in
   let released_with_age = ref [] in
   let try_release ~label ~sem =
-    let snapshot =
+    let snapshots =
       with_holder_lock (fun () ->
-        match Hashtbl.find_opt holder_table (label, keeper_name) with
-        | None -> None
-        | Some acquired_at ->
-          Hashtbl.remove holder_table (label, keeper_name);
-          Some acquired_at)
+        purge_expired_force_released_holders_locked ~now;
+        let matching =
+          Hashtbl.fold
+            (fun key acquired_at acc ->
+               if String.equal key.holder_label label
+                  && String.equal key.holder_keeper_name keeper_name
+               then (key, acquired_at) :: acc
+               else acc)
+            holder_table []
+        in
+        List.iter
+          (fun (key, _) ->
+            Hashtbl.remove holder_table key;
+            Hashtbl.replace force_released_holders key now)
+          matching;
+        matching)
     in
-    match snapshot with
-    | None -> ()
-    | Some acquired_at ->
-      let age = now -. acquired_at in
-      Eio.Semaphore.release sem;
-      released_with_age := (label, age) :: !released_with_age;
-      Prometheus.inc_counter
-        Prometheus.metric_keeper_slot_force_released
-        ~labels:[("keeper", keeper_name); ("label", label)]
-        ();
-      Log.Keeper.error
-        "%s: force-released %s slot held for %.0fs (zombie fiber, \
-         likely stuck in LLM subprocess)"
-        keeper_name label age
+    List.iter
+      (fun (_key, acquired_at) ->
+        let age = now -. acquired_at in
+        Eio.Semaphore.release sem;
+        released_with_age := (label, age) :: !released_with_age;
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_slot_force_released
+          ~labels:[("keeper", keeper_name); ("label", label)]
+          ();
+        Log.Keeper.error
+          "%s: force-released %s slot held for %.0fs (zombie fiber, \
+           likely stuck in LLM subprocess)"
+          keeper_name label age)
+      snapshots
   in
   try_release ~label:"reactive" ~sem:reactive_turn_semaphore;
   try_release ~label:"autonomous" ~sem:autonomous_turn_semaphore;


### PR DESCRIPTION
## 증상

main HEAD \`cce828db04\` 에서 \`dune build bin/main_eio.exe\` 가 두 컴파일 에러로 실패. 모든 worktree 의 \`start-masc-mcp.sh\` 가 binary 를 못 만들고, 사용자/agent 가 \"빌드가 계속 뻑남\" 으로 호소.

## Root cause

두 PR 이 같은 머지 윈도우에 들어왔는데 main 의 \`Build and Test\` workflow 가 **path filter** 로 skip 되면서 두 silent regression 모두 main 에 반영됨.

1. **\`lib/keeper/keeper_turn_slot.ml:603\`** — Unbound \`Hashtbl.find_opt\` index. \`force_release_holder_for\` (PR #13246) 가 \`(label, keeper_name)\` 튜플로 \`holder_table\` 을 조회. 다른 PR 이 \`holder_table\` 키를 typed record 로 승격:
   \`\`\`ocaml
   type holder_key = {
     holder_label : string;
     holder_keeper_name : string;
     holder_acquisition_id : int;
   }
   \`\`\`
   supervisor crash hook 의 escape path 가 타입체크 실패.

2. **\`lib/keeper/keeper_memory_bank.ml:949\`** — \`Unbound module Artifact\`. 모듈은 \`lib/multimodal/artifact.ml\` 에 있어 keeper 컨텍스트에선 \`Multimodal.Artifact.kind_tag_to_string\` 으로 호출해야 함.

## Fix

| 파일 | 변경 |
|------|------|
| \`lib/keeper/keeper_turn_slot.ml\` | \`Hashtbl.fold\` 로 holder_table 순회, \`label\`+\`keeper_name\` 매칭되는 모든 키 수집 (rare multi-acquisition 대응), 각 key 를 \`holder_table\` 에서 제거 후 \`force_released_holders\` 에 표시 (late fiber 의 \`consume_force_release\` 와 정합). 그 다음 semaphore release + Prometheus + 로그. |
| \`lib/keeper/keeper_memory_bank.ml\` | \`Artifact.kind_tag_to_string\` → \`Multimodal.Artifact.kind_tag_to_string\` |

## 검증

\`\`\`
$ cd .worktrees/fix-main-build-2026-05-05
$ dune build bin/main_eio.exe --root .
$ ls -la _build/default/bin/main_eio.exe
-r-xr-xr-x dancer 47M Tue May  5 23:10:40 2026 main_eio.exe
\`\`\`

clean fresh worktree 에서 빌드 성공, 47 MB binary 생성.

## 후속 권고 (별도 PR / 별도 이슈)

- main 의 \`Build and Test\` job path filter 를 \`lib/keeper/**\` 포함하도록 확장 — 이번처럼 Build skip → silent breakage 재발 방지.
- \`bin/main_eio.exe\` 빌드는 \`start-masc-mcp.sh\` 의 \`/tmp/masc-mcp-build.lock\` mutex 경유가 canonical. 직접 \`dune build --root .\` 호출하면 다중 세션이 같은 \`_build/\` 를 동시에 건드려 정체. 가이드 문서 보강 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)