### PR TITLE
[P0-CRIT] unblock main build — record-iter holder lookup + SDK 0.190.11 alignment

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -946,7 +946,7 @@ let append_memory_notes_from_tool_results
         when String.trim artifact_id <> ""
              && not (Hashtbl.mem seen_artifacts artifact_id) ->
           Hashtbl.add seen_artifacts artifact_id ();
-          let kind = Artifact.kind_tag_to_string kind_tag in
+          let kind = Multimodal.Artifact.kind_tag_to_string kind_tag in
           let payload_preview = tool_result_payload_preview result in
           let text =
             tool_result_memory_text ~kind ~artifact_id ~payload_preview

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -598,28 +598,34 @@ let force_release_holder_for ~keeper_name : (string * float) list =
   let now = Time_compat.now () in
   let released_with_age = ref [] in
   let try_release ~label ~sem =
-    let snapshot =
+    let snapshots =
       with_holder_lock (fun () ->
-        match Hashtbl.find_opt holder_table (label, keeper_name) with
-        | None -> None
-        | Some acquired_at ->
-          Hashtbl.remove holder_table (label, keeper_name);
-          Some acquired_at)
+        let collected = ref [] in
+        Hashtbl.iter
+          (fun key acquired_at ->
+            if String.equal key.holder_label label
+               && String.equal key.holder_keeper_name keeper_name
+            then collected := (key, acquired_at) :: !collected)
+          holder_table;
+        List.iter
+          (fun (key, _) -> Hashtbl.remove holder_table key)
+          !collected;
+        !collected)
     in
-    match snapshot with
-    | None -> ()
-    | Some acquired_at ->
-      let age = now -. acquired_at in
-      Eio.Semaphore.release sem;
-      released_with_age := (label, age) :: !released_with_age;
-      Prometheus.inc_counter
-        Prometheus.metric_keeper_slot_force_released
-        ~labels:[("keeper", keeper_name); ("label", label)]
-        ();
-      Log.Keeper.error
-        "%s: force-released %s slot held for %.0fs (zombie fiber, \
-         likely stuck in LLM subprocess)"
-        keeper_name label age
+    List.iter
+      (fun (_key, acquired_at) ->
+        let age = now -. acquired_at in
+        Eio.Semaphore.release sem;
+        released_with_age := (label, age) :: !released_with_age;
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_slot_force_released
+          ~labels:[("keeper", keeper_name); ("label", label)]
+          ();
+        Log.Keeper.error
+          "%s: force-released %s slot held for %.0fs (zombie fiber, \
+           likely stuck in LLM subprocess)"
+          keeper_name label age)
+      snapshots
   in
   try_release ~label:"reactive" ~sem:reactive_turn_semaphore;
   try_release ~label:"autonomous" ~sem:autonomous_turn_semaphore;

--- a/test/test_keeper_turn_slot_force_release.ml
+++ b/test/test_keeper_turn_slot_force_release.ml
@@ -72,7 +72,7 @@ let test_force_release_drops_reactive_holder () =
 
         (* Post-condition: holder table no longer mentions us. *)
         let now2 = Time_compat.now () in
-        let post = List.map fst (KK.reactive_slot_holders ~now2) in
+        let post = List.map fst (KK.reactive_slot_holders ~now:now2) in
         if List.mem "zombie-reactive" post then
           failwith
             (Printf.sprintf "force-release left holder behind: [%s]"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3865,6 +3865,7 @@ let test_pre_tool_gate_records_durable_attempt_telemetry () =
         ();
       let hooks =
         HK.make_hooks
+          ~config
           ~meta_ref
           ~generation:9
           ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ ->


### PR DESCRIPTION
## Problem

`dune build` (worktree-fresh, agent_sdk 0.190.11) 가 4종 root cause 로 실패. main blocker — 모든 신규 PR 차단.

```
File "lib/keeper/keeper_turn_slot.ml", line 603, characters 44-64:
603 |         match Hashtbl.find_opt holder_table (label, keeper_name) with
                                                  ^^^^^^^^^^^^^^^^^^^^
Error: This expression has type 'a * 'b
       but an expression was expected of type holder_key

File "test/test_keeper_turn_slot_force_release.ml", line 75:
Error: The function applied to this argument has type
         now:float -> (string * float) list
       This argument cannot be applied with label ~now2

File "test/test_keeper_unified.ml", line 3885:
Error: This expression has type config:Coord_utils_backend_setup.config ->
                                Agent_sdk_base.Hooks.hooks
       which is not a record type.

File "lib/keeper/keeper_memory_bank.ml", line 949:
Error: Unbound module Artifact
```

## Root cause

### Bug 1 — `force_release_holder_for` record/tuple mismatch (runtime impact)

PR #13219 이 `holder_key` 를 `{ holder_label; holder_keeper_name; holder_acquisition_id }` record 로 도입 (generation 격리). PR #13246 이 supervisor crash path 에서 호출되는 `force_release_holder_for ~keeper_name` 함수를 추가했는데, line 603/606 의 `Hashtbl.find_opt holder_table (label, keeper_name)` 가 record migration 을 누락.

`~keeper_name` caller 는 acquisition_id 를 모르므로 record key 직접 lookup 불가능. **record-iter 패턴이 정합** — `holder_label = label && holder_keeper_name = keeper_name` 매치하는 모든 entry 를 수집 + release. 같은 keeper 의 여러 generation entry 도 한 번에 풀어줌 (zombie fiber 처리 의도와 일치).

### Bug 2 — caller short-label vs callee `~now`

`reactive_slot_holders : now:float -> ...` 에 `~now2` short-form 으로 호출. label mismatch — `~now:now2` 로 명시적 매핑 필요.

### Bug 3 — `make_hooks` 시그니처에 `~config` 추가

`Keeper_hooks_oas.make_hooks` 가 0.190.11 alignment PR 에서 첫 named arg `~config:Coord.config` 가 추가됨. `test_keeper_unified.ml:3866` test caller 누락 → partial application → return type 이 `config:... -> hooks` 함수가 되어 record field access 실패.

### Bug 4 — `Artifact` unqualified

`lib/keeper/keeper_memory_bank.ml:949` 에서 `Artifact.kind_tag_to_string` 직접 사용. 같은 파일 line 942-943 은 `Multimodal.Tool_emission.*` 처럼 fully-qualified. line 949 만 누락. `Multimodal.Artifact` prefix.

### opam pin/install trap (process)

사용자 환경 agent_sdk 가 0.190.10 installed 상태로 pin 만 0.190.11 갱신 → `inconsistent assumptions over interface Agent_sdk__Log` 다수. PR #13251 머지 후 `opam install agent_sdk` 또는 `opam reinstall agent_sdk` 가 누락된 footgun. `opam-pin-external-deps.sh` post-mortem 코멘트가 정확히 경고하는 케이스. 본 PR 자체는 binary install 단계를 코드로 강제하지 않음 — 별도 hook 또는 `pre_tool_use` script 검토는 follow-up.

## Fix

### Bug 1 — record-iter

```diff
 let try_release ~label ~sem =
-  let snapshot =
+  let snapshots =
     with_holder_lock (fun () ->
-      match Hashtbl.find_opt holder_table (label, keeper_name) with
-      | None -> None
-      | Some acquired_at ->
-        Hashtbl.remove holder_table (label, keeper_name);
-        Some acquired_at)
+      let collected = ref [] in
+      Hashtbl.iter
+        (fun key acquired_at ->
+          if String.equal key.holder_label label
+             && String.equal key.holder_keeper_name keeper_name
+          then collected := (key, acquired_at) :: !collected)
+        holder_table;
+      List.iter
+        (fun (key, _) -> Hashtbl.remove holder_table key)
+        !collected;
+      !collected)
   in
-  match snapshot with
-  | None -> ()
-  | Some acquired_at ->
+  List.iter
+    (fun (_key, acquired_at) ->
       let age = now -. acquired_at in
       Eio.Semaphore.release sem;
-      ...
+      ...)
+    snapshots
```

### Bug 2 — `~now:now2`
### Bug 3 — `~config` 추가
### Bug 4 — `Multimodal.Artifact` prefix

각 한두 글자 단위 수정.

## Test plan

- [x] `dune build --root .` green (worktree fresh build)
- [ ] CI `dune runtest` 회귀 0
- [ ] `force_release_holder_for` 의 동일 (label, keeper_name) 다중 generation entry 처리 — `test_keeper_turn_slot_force_release` 가 single generation 만 검증. multi-gen 회귀 테스트는 PR #13219/#13246 follow-up 으로 별도 이슈 등록 권장.

## Rollback plan

4-file revert. Bug 1 revert 시 supervisor crash path 의 force-release 가 다시 dead (현재 상태와 동일). Bug 2-4 revert 시 build 다시 깨짐. 단순 revert 가능.

## Behavior change

- **Bug 1**: `force_release_holder_for` 가 이제 같은 keeper 의 모든 acquisition generation entry 를 release. 이전 코드는 type 불일치로 dead 였으므로 0→정상. semaphore release 횟수가 entry 수만큼 (이전: 0 또는 1, 이후: N). over-release 는 Eio counting semaphore 가 안전하게 처리 (line 580-585 의 PR #13219 코멘트 참조).
- **Bug 2-4**: behavior 변경 없음 — type/syntax/qualifier 만 fix.

## RFC waiver

`agent_delegation` 영역 (`credential_*`, `keeper_gh_*`, `host_config_*`, `lib/repo_manager/*`, `lib/operator/operator_control*`, dashboard credential, `.claude/hooks/`, `instructions/workflow*`) 변경 없음. `lib/keeper/keeper_turn_slot.ml` + `keeper_memory_bank.ml` 은 turn slot/memory bank 로 credential/identity 영역이 아님.

`RFC-WAIVED: main build blocker hotfix; runtime fix (Bug 1) is PR #13246 follow-up patch within existing record holder_key abstraction (PR #13219), no new design surface.`

## Related

- #13219 (record `holder_key` 도입) — Bug 1 의 record 정의 출처
- #13246 (`force_release_holder_for` 추가) — Bug 1 의 누락된 caller migration
- #13251 (agent_sdk 0.190.11 pin bump) — Bug 3/4 의 SDK 정렬 트리거
- #13252 (test goal-loop fixture refresh) — Bug 2 가 같은 batch 에서 도입됐을 가능성 (확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
