### PR TITLE
fix(test): repair keeper compile after hook and slot API changes

### DIFF
--- a/test/test_keeper_turn_slot_force_release.ml
+++ b/test/test_keeper_turn_slot_force_release.ml
@@ -72,7 +72,7 @@ let test_force_release_drops_reactive_holder () =
 
         (* Post-condition: holder table no longer mentions us. *)
         let now2 = Time_compat.now () in
-        let post = List.map fst (KK.reactive_slot_holders ~now2) in
+        let post = List.map fst (KK.reactive_slot_holders ~now:now2) in
         if List.mem "zombie-reactive" post then
           failwith
             (Printf.sprintf "force-release left holder behind: [%s]"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3865,6 +3865,7 @@ let test_pre_tool_gate_records_durable_attempt_telemetry () =
         ();
       let hooks =
         HK.make_hooks
+          ~config
           ~meta_ref
           ~generation:9
           ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ ->


### PR DESCRIPTION
## Summary
- use the correct labelled `~now:now2` call for `reactive_slot_holders`
- pass the new required `~config` argument to `Keeper_hooks_oas.make_hooks` in the durable pre-tool gate test

## Why
Current `main` still fails CI after #13260 because these two tests compile against older APIs. This keeps downstream PRs such as #13237 blocked on unrelated keeper test compile errors.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_turn_slot_force_release.exe test/test_keeper_unified.exe` is queued behind the local Dune lock; GitHub CI is the authoritative merge gate.
