### PR TITLE
feat(board): paginate sibling replies

### DIFF
--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -133,6 +133,31 @@ describe('CommentThread', () => {
     expect(screen.getByText('child reply')).toBeInTheDocument()
   })
 
+  it('paginates sibling replies inside a busy branch', () => {
+    const comments = [
+      { id: 'c1', post_id: 'post-1', parent_id: null, author: 'root-agent', content: 'root comment', created_at: '2026-04-02T00:00:00Z' },
+      ...Array.from({ length: 7 }, (_, index) => ({
+        id: `c${index + 2}`,
+        post_id: 'post-1',
+        parent_id: 'c1',
+        author: 'child-agent',
+        content: `sibling reply ${index + 1}`,
+        created_at: `2026-04-02T00:0${index + 1}:00Z`,
+      })),
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    expect(screen.getByText('sibling reply 1')).toBeInTheDocument()
+    expect(screen.getByText('sibling reply 5')).toBeInTheDocument()
+    expect(screen.queryByText('sibling reply 6')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '답글 2개 더 보기' }))
+
+    expect(screen.getByText('sibling reply 6')).toBeInTheDocument()
+    expect(screen.getByText('sibling reply 7')).toBeInTheDocument()
+  })
+
   it('keeps replies past depth five behind an explicit continue control', () => {
     const comments = [
       { id: 'c1', post_id: 'post-1', parent_id: null, author: 'agent', content: 'level 0', created_at: '2026-04-02T00:00:00Z' },

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -41,6 +41,7 @@ import {
 import type { BoardComment, BoardPost } from './board-state'
 
 const MAX_INLINE_COMMENT_DEPTH = 5
+const INITIAL_CHILD_REPLY_LIMIT = 5
 
 // ── Expiry chip (returns html, kept in UI layer) ───────────────────
 function expiryChip(post: BoardPost) {
@@ -183,6 +184,7 @@ function CommentItem({
   const [expanded, setExpanded] = useState(false)
   const [collapsed, setCollapsed] = useState(false)
   const [deepExpanded, setDeepExpanded] = useState(false)
+  const [visibleReplyLimit, setVisibleReplyLimit] = useState(INITIAL_CHILD_REPLY_LIMIT)
   const displayText = needsTruncation && !expanded
     ? `${contentChars.slice(0, 297).join('')}...`
     : comment.content
@@ -197,6 +199,11 @@ function CommentItem({
   const childForceExpanded = forceThreadExpanded || deepExpanded
   const repliesExpanded = !collapsedByUser
   const canToggleReplies = replies.length > 0 && !cappedByDepth && !suppressCollapseToggle && !forceThreadExpanded
+  const visibleReplies = forceThreadExpanded
+    ? replies
+    : replies.slice(0, visibleReplyLimit)
+  const hiddenSiblingReplyCount = Math.max(0, replies.length - visibleReplies.length)
+  const canLoadMoreSiblingReplies = showReplies && !forceThreadExpanded && hiddenSiblingReplyCount > 0
   const score = comment.vote_balance ?? comment.votes ?? ((comment.votes_up ?? 0) - (comment.votes_down ?? 0))
   const authorLabel = boardActorDisplayName(comment.author, comment.author_identity)
   const authorAvatarKey = boardActorAvatarKey(comment.author, comment.author_identity)
@@ -301,7 +308,14 @@ function CommentItem({
       </div>
       ${showReplies ? html`
         <div class="flex flex-col gap-1.5 mt-1.5">
-          ${replies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${childForceExpanded} suppressCollapseToggle=${suppressCollapseToggle} />`)}
+          ${visibleReplies.map(reply => html`<${CommentItem} key=${reply.id} comment=${reply} postId=${postId} depth=${depth + 1} childrenMap=${childrenMap} descendantCounts=${descendantCounts} forceThreadExpanded=${childForceExpanded} suppressCollapseToggle=${suppressCollapseToggle} />`)}
+          ${canLoadMoreSiblingReplies ? html`
+            <button
+              type="button"
+              class="ml-4 mt-1 rounded-[var(--r-1)] border border-dashed border-[var(--color-border-divider)] bg-transparent px-2 py-1 text-left text-2xs text-[var(--color-accent-fg)] hover:bg-[var(--accent-10)]"
+              onClick=${() => setVisibleReplyLimit(visibleReplyLimit + INITIAL_CHILD_REPLY_LIMIT)}
+            >답글 ${hiddenSiblingReplyCount}개 더 보기</button>
+          ` : null}
         </div>
       ` : null}
     </div>


### PR DESCRIPTION
## Summary
- add per-branch sibling reply pagination to the board comment thread
- keep depth cap / continue-thread behavior intact while avoiding rendering every reply sibling at once
- add component coverage for loading hidden sibling replies

## Artifact Coverage
- Advances masc_sns.agent.final Phase 1 / 4.1.2: nested comments with depth-5 visual nesting, collapse/expand, Continue this thread, and Load more sibling comments.

## Verification
- pnpm install --offline
- pnpm exec vitest run src/components/board/post-detail.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check origin/main...HEAD