### PR TITLE
fix(metrics): report heuristic decision shapes

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1119,6 +1119,8 @@ export interface CoverageSite {
 
 export interface HeuristicCoverage {
   total_events: number
+  decision_shape_count: number
+  mixed_outcome_sites: number
   unique_decision_tuples: number
   sites: CoverageSite[]
 }
@@ -1135,9 +1137,12 @@ function decodeCoverageSite(raw: unknown): CoverageSite | null {
 
 function decodeHeuristicCoverage(raw: unknown): HeuristicCoverage | null {
   if (!isRecord(raw)) return null
+  const decisionShapeCount = asInt(raw.decision_shape_count) ?? asInt(raw.unique_decision_tuples) ?? 0
   return {
     total_events: asInt(raw.total_events) ?? 0,
-    unique_decision_tuples: asInt(raw.unique_decision_tuples) ?? 0,
+    decision_shape_count: decisionShapeCount,
+    mixed_outcome_sites: asInt(raw.mixed_outcome_sites) ?? 0,
+    unique_decision_tuples: decisionShapeCount,
     sites: asRecordArray(raw.sites)
       .map(decodeCoverageSite)
       .filter((s): s is CoverageSite => s !== null),

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -650,7 +650,7 @@ function HeuristicByModule({ coverage }: { coverage: HeuristicCoverage }) {
   return html`
     <section class="flex flex-col gap-2" aria-label="Heuristic by module">
       <div class="flex items-center justify-between rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
-        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">heuristic by module · ${coverage.total_events} events · ${coverage.unique_decision_tuples} unique tuples</span>
+        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">heuristic by module · ${coverage.total_events} events · ${coverage.decision_shape_count} decision shapes · ${coverage.mixed_outcome_sites} mixed sites</span>
       </div>
       <div class="flex flex-col gap-2">
         ${sortedModules.map(([moduleName, sites]) => {

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -37,6 +37,8 @@ type coverage_site = {
 type coverage_report = {
   total_events : int;
   sites : coverage_site list;
+  decision_shape_count : int;
+  mixed_outcome_sites : int;
   unique_decision_tuples : int;
 }
 
@@ -293,7 +295,7 @@ let coverage_report_of_events events =
   let site_counts : ((string * string), (int * int) ref) Hashtbl.t =
     Hashtbl.create 16
   in
-  let unique_tuples : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  let decision_shapes : (string, unit) Hashtbl.t = Hashtbl.create 16 in
   let json_string_field name json = Json_util.get_string json name in
   let json_float_field name json = Json_util.get_float json name in
   let json_bool_field name json = Json_util.get_bool json name in
@@ -316,17 +318,15 @@ let coverage_report_of_events events =
            let count, triggered_count = !slot in
            slot :=
              (count + 1, triggered_count + if triggered then 1 else 0);
-           let tuple_key =
-             Printf.sprintf "%s\000%s\000%.12g\000%.12g\000%b"
+           let shape_key =
+             Printf.sprintf "%s\000%s\000%.12g\000%b"
                module_name
                site
-               (Option.value ~default:Float.nan
-                  (json_float_field "raw_value" json))
                (Option.value ~default:Float.nan
                   (json_float_field "threshold" json))
                triggered
            in
-           Hashtbl.replace unique_tuples tuple_key ()
+           Hashtbl.replace decision_shapes shape_key ()
        | _ -> ())
     events;
   let sites =
@@ -340,10 +340,21 @@ let coverage_report_of_events events =
            let c = String.compare a.module_name b.module_name in
            if c <> 0 then c else String.compare a.site b.site)
   in
+  let mixed_outcome_sites =
+    List.fold_left
+      (fun acc site ->
+         if site.triggered_count > 0 && site.triggered_count < site.count then
+           acc + 1
+         else acc)
+      0 sites
+  in
+  let decision_shape_count = Hashtbl.length decision_shapes in
   {
     total_events = List.length events;
     sites;
-    unique_decision_tuples = Hashtbl.length unique_tuples;
+    decision_shape_count;
+    mixed_outcome_sites;
+    unique_decision_tuples = decision_shape_count;
   }
 
 let recent_coverage n =
@@ -362,6 +373,8 @@ let coverage_report_to_json report =
   `Assoc
     [
       ("total_events", `Int report.total_events);
+      ("decision_shape_count", `Int report.decision_shape_count);
+      ("mixed_outcome_sites", `Int report.mixed_outcome_sites);
       ("unique_decision_tuples", `Int report.unique_decision_tuples);
       ("sites", `List (List.map coverage_site_to_json report.sites));
     ]

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -42,6 +42,8 @@ type coverage_site = {
 type coverage_report = {
   total_events : int;
   sites : coverage_site list;
+  decision_shape_count : int;
+  mixed_outcome_sites : int;
   unique_decision_tuples : int;
 }
 
@@ -81,8 +83,10 @@ val recent : int -> Yojson.Safe.t list
 (** Read the N most recent events as JSON objects. *)
 
 val coverage_report_of_events : Yojson.Safe.t list -> coverage_report
-(** Summarize event coverage by module/site and count distinct
-    raw/threshold/triggered tuples. *)
+(** Summarize event coverage by module/site.  [decision_shape_count]
+    counts distinct module/site/threshold/triggered shapes; it deliberately
+    ignores [raw_value] so noisy score churn does not masquerade as coverage.
+    [unique_decision_tuples] is retained as a wire-compatible alias. *)
 
 val recent_coverage : int -> coverage_report
 (** Read recent events and summarize their coverage. *)

--- a/test/test_post_verifier.ml
+++ b/test/test_post_verifier.ml
@@ -170,6 +170,16 @@ let test_heuristic_coverage_report_groups_sites () =
         {
           module_name = "post_verifier";
           site = "relevance";
+          raw_value = 0.9;
+          threshold = 0.5;
+          triggered = true;
+          provenance = Hm.Post_verifier "relevance";
+          timestamp = 2.5;
+        };
+      Hm.event_to_json
+        {
+          module_name = "post_verifier";
+          site = "relevance";
           raw_value = 0.2;
           threshold = 0.5;
           triggered = false;
@@ -189,9 +199,12 @@ let test_heuristic_coverage_report_groups_sites () =
     ]
   in
   let report = Hm.coverage_report_of_events events in
-  check int "total events" 3 report.total_events;
+  check int "total events" 4 report.total_events;
   check int "two sites" 2 (List.length report.sites);
-  check int "three distinct tuples" 3 report.unique_decision_tuples;
+  check int "three decision shapes" 3 report.decision_shape_count;
+  check int "compat tuple count aliases decision shapes" 3
+    report.unique_decision_tuples;
+  check int "one mixed outcome site" 1 report.mixed_outcome_sites;
   let post_verifier_site =
     List.find
       (fun (site : Hm.coverage_site) ->
@@ -199,8 +212,8 @@ let test_heuristic_coverage_report_groups_sites () =
          && site.site = "relevance")
       report.sites
   in
-  check int "site count" 2 post_verifier_site.count;
-  check int "site triggered count" 1 post_verifier_site.triggered_count
+  check int "site count" 3 post_verifier_site.count;
+  check int "site triggered count" 2 post_verifier_site.triggered_count
 
 (* ================================================================ *)
 (* Runner                                                           *)

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -80,6 +80,36 @@ let test_parse_json_safe_rate_limits_repeated_utf8_repair_logs () =
   check int "both repairs counted" 2 stats.repaired_reads;
   check int "duplicate repair warning suppressed" 1 (List.length logs)
 
+let test_sanitize_json_utf8_covers_safe_constructors () =
+  let open Safe_ops in
+  let replacement = "\xEF\xBF\xBD" in
+  let sanitized =
+    sanitize_json_utf8
+      (`Assoc
+        [
+          ("bad\xffkey",
+             `List
+             [
+               `String "bad\xfflist";
+               `Float 1.25;
+               `Assoc [ ("nested\xffkey", `String "bad\xffvalue") ];
+             ]);
+        ])
+  in
+  match sanitized with
+  | `Assoc [ (key, `List [ `String list_value; `Float 1.25; `Assoc fields ]) ] ->
+      check string "assoc key repaired" ("bad" ^ replacement ^ "key") key;
+      check string "list string repaired" ("bad" ^ replacement ^ "list") list_value;
+      let key, value =
+        match fields with
+        | [ field ] -> field
+        | _ -> fail "expected one assoc field"
+      in
+      check string "nested key repaired" ("nested" ^ replacement ^ "key") key;
+      check string "assoc value repaired" ("bad" ^ replacement ^ "value")
+        (Yojson.Safe.Util.to_string value)
+  | _ -> fail "unexpected sanitized JSON shape"
+
 let test_utf8_repair_log_rate_limit_table_is_bounded () =
   let open Safe_ops in
   reset_persistence_utf8_repair_stats_for_tests ();
@@ -442,6 +472,8 @@ let () =
         test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair;
       test_case "rate limits repeated utf8 repair logs" `Quick
         test_parse_json_safe_rate_limits_repeated_utf8_repair_logs;
+      test_case "sanitizes safe constructors" `Quick
+        test_sanitize_json_utf8_covers_safe_constructors;
       test_case "bounds utf8 repair log rate-limit table" `Quick
         test_utf8_repair_log_rate_limit_table_is_bounded;
       test_case "long invalid" `Quick test_parse_json_safe_long_invalid;


### PR DESCRIPTION
## Summary

- report heuristic coverage as stable decision shapes instead of raw-value tuples
- add `decision_shape_count` and `mixed_outcome_sites` while keeping `unique_decision_tuples` as a compatibility alias
- update the dashboard heuristic coverage copy/decoder to use the stable shape count
- add a Safe JSON sanitizer regression test for real `Yojson.Safe.t` constructors on the current base

## Why

The audit noted that `heuristic_metrics.coverage_report` could inflate coverage when only `raw_value` changed. That made repeated score churn look like new decision coverage. The report now keys decision shapes by module/site/threshold/triggered and ignores raw-value churn, while still exposing the legacy tuple field with the same stable count for existing callers.

## Validation

- `git diff --check HEAD~2..HEAD`
- `pnpm --dir dashboard typecheck`
- `scripts/check-oas-pin.sh`
- `opam list --installed agent_sdk` (`0.190.12`, pinned to `ff434b7388c24ba9a65cadf21e118edbd61db06b`)
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_post_verifier.exe test/test_safe_ops.exe`
- `./_build/default/test/test_post_verifier.exe` (23 tests)
- `./_build/default/test/test_safe_ops.exe` (68 tests)
