### PR TITLE
fix(dashboard): correct Option.bind argument order — unblock main build

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1365,8 +1365,7 @@ let sort_by_latest_ts jsons =
     jsons
 
 let string_member_nonempty key json =
-  Safe_ops.json_string_opt key json
-  |> Option.bind nonempty_string_opt
+  Option.bind (Safe_ops.json_string_opt key json) nonempty_string_opt
 
 let int_member_fallback key json =
   let usage = Yojson.Safe.Util.member "usage" json in
@@ -1451,7 +1450,7 @@ let keeper_bdi_snapshot_json (config : Coord.config) (name : string)
                || Option.is_some (string_member_nonempty "need" json))
       in
       let metric_field key =
-        latest_social |> Option.bind (string_member_nonempty key)
+        Option.bind latest_social (string_member_nonempty key)
       in
       let belief =
         match metric_field "belief_summary" with


### PR DESCRIPTION
## 요약

`main` 빌드를 깨뜨리던 `Option.bind` 인자 순서 오류 두 곳을 수정합니다.

```
File "lib/dashboard/dashboard_http_keeper.ml", line 1369, characters 17-36:
1369 |   |> Option.bind nonempty_string_opt
                        ^^^^^^^^^^^^^^^^^^^
Error: The value nonempty_string_opt has type string -> string option
       but an expression was expected of type 'a option
```

## 원인

OCaml stdlib `Option.bind`의 시그니처는 `'a option -> ('a -> 'b option) -> 'b option` — option이 첫 인자, 함수가 두 번째. Haskell의 `>>=`나 일부 라이브러리의 flipped bind에 익숙해 함수를 첫 인자(option 자리)에 부분 적용한 패턴이 두 군데 들어가 있었습니다.

| 위치 | Before | After |
|------|--------|-------|
| `dashboard_http_keeper.ml:1369` `string_member_nonempty` | `Safe_ops.json_string_opt key json \|> Option.bind nonempty_string_opt` | `Option.bind (Safe_ops.json_string_opt key json) nonempty_string_opt` |
| `dashboard_http_keeper.ml:1453` `keeper_bdi_snapshot_json.metric_field` | `latest_social \|> Option.bind (string_member_nonempty key)` | `Option.bind latest_social (string_member_nonempty key)` |

타입 검사기가 두 곳 모두 거절하고 있었으므로 런타임 동작 변화는 없습니다 — 정상 `Option.bind opt f` 의미 그대로입니다.

## 검증

- `dune build --root .` ✅ (worktree에서 풀 빌드 통과, exit 0)
- 변경 함수의 직접 unit test 부재 (private helper) → 빌드/타입 검사를 검증으로 삼음

## 회귀 가드 후보 (별 이슈/PR 권장)

```
rg "\\|> Option\\.bind " lib/
```

OCaml stdlib `Option.bind`에서 이 패턴은 거의 항상 인자 순서 버그입니다. 같은 작성자가 같은 파일 내에서 동일 오해를 반복했으므로 lint 가드가 효과적입니다.

## 미검증 / 주의

- 이 PR 직전 머지된 `#13236 (94d4221, feat(ide): add audit replay timeline ...)`이 같은 파일을 건드렸습니다. main blocker 시점이 그 PR과 관련되어 있는지는 확인하지 않았습니다.
- agent ready_for_review가 Draft Auto-Merge Guard에 의해 close될 수 있어 Draft 유지합니다 — `human-approved-ready` 라벨 부착 후 ready 전환 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)