### PR TITLE
fix(audit-response): repair recovery note CI gates

### DIFF
--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -1,7 +1,13 @@
 (* Recovery — Cycle 23 / Tier B6.
    Classification plus callback-driven strategy execution. Keeper-turn
    lifecycle integration remains outside this module; see recovery.mli for
-   the design rationale. *)
+   the design rationale.
+
+   Audit response 2026-05-05 §4: classification + audit log entry only;
+   strategy execution is deferred until the keeper-turn wire-in lands
+   (see resilience_runtime.mli §Deferred). External audits should read the
+   matrix at docs/audit-responses/2026-05-05-dashboard-heuristic.md before
+   filing claims against this module. *)
 
 type error_mode =
   | TransientError of {

--- a/test/test_fs_compat_home_guard.ml
+++ b/test/test_fs_compat_home_guard.ml
@@ -69,15 +69,23 @@ let test_tmp_write_allowed () =
 let test_escape_hatch_allows_home () =
   Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "1";
   let path = Filename.concat (home ()) ".masc/_9921_guard_probe_bypass.jsonl" in
-  (try
-    FC.append_file path "{\"bypass\":1}\n";
-    Alcotest.(check bool) "bypass write succeeded" true (Sys.file_exists path)
-  with FC.Test_isolation_breach msg ->
-    Alcotest.failf
-      "escape hatch should allow HOME write, got Test_isolation_breach: %s" msg);
-  (* clean up so we do not leave probe junk in the real ledger dir *)
-  (try Sys.remove path with Sys_error _ -> ());
-  Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" ""
+  let parent = Filename.dirname path in
+  let parent_existed = Sys.file_exists parent in
+  Fun.protect
+    ~finally:(fun () ->
+      (* clean up so we do not leave probe junk in the real ledger dir *)
+      (try Sys.remove path with Sys_error _ -> ());
+      (if not parent_existed then
+         try Unix.rmdir parent with Unix.Unix_error _ -> ());
+      Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "")
+    (fun () ->
+      FC.mkdir_p parent;
+      try
+        FC.append_file path "{\"bypass\":1}\n";
+        Alcotest.(check bool) "bypass write succeeded" true (Sys.file_exists path)
+      with FC.Test_isolation_breach msg ->
+        Alcotest.failf
+          "escape hatch should allow HOME write, got Test_isolation_breach: %s" msg)
 
 let () =
   Alcotest.run "fs_compat_home_guard" [

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -44,7 +44,7 @@ let parse_create_response_json body =
   | Some idx ->
       Yojson.Safe.from_string
         (String.sub body (idx + 1) (String.length body - idx - 1))
-  | None -> Alcotest.fail "expected JSON payload in create response"
+  | None -> Yojson.Safe.from_string body
 
 let make_keeper_meta ?(name = "judge-keeper") () : Keeper_types.keeper_meta =
   match
@@ -377,13 +377,7 @@ let test_post_create_structured_payload () =
        ])
   in
   Alcotest.(check bool) "create ok" true ok;
-  let json =
-    match String.index_opt body '\n' with
-    | Some idx ->
-        Yojson.Safe.from_string
-          (String.sub body (idx + 1) (String.length body - idx - 1))
-    | None -> Alcotest.fail "expected JSON payload in create response"
-  in
+  let json = parse_create_response_json body in
   Alcotest.(check string) "title kept" "Why"
     Yojson.Safe.Util.(json |> member "title" |> to_string);
   Alcotest.(check string) "body stripped" "Visible answer"
@@ -682,14 +676,11 @@ let test_dispatch_delete_success () =
   let _ok, body = dispatch "masc_board_post"
     (make_args [("content", `String "to be deleted"); ("author", `String "tester")]) in
   let post_id =
-    match String.index_opt body '\n' with
-    | Some idx ->
-      let json_str = String.sub body (idx + 1) (String.length body - idx - 1) in
-      (try
-        let json = Yojson.Safe.from_string json_str in
-        json |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string
-      with _ -> Alcotest.fail ("Failed to parse post JSON from: " ^ json_str))
-    | None -> Alcotest.fail ("No newline in create response: " ^ body)
+    try
+      parse_create_response_json body
+      |> Yojson.Safe.Util.member "id"
+      |> Yojson.Safe.Util.to_string
+    with _ -> Alcotest.fail ("Failed to parse post JSON from: " ^ body)
   in
   let ok_del, msg_del = dispatch "masc_board_delete"
     (make_args [("post_id", `String post_id)]) in
@@ -726,14 +717,11 @@ let test_post_get_success () =
   Alcotest.(check bool) "create ok" true ok;
   (* Response is "✅ Post created:\n{json}" — extract JSON after first newline *)
   let post_id =
-    match String.index_opt body '\n' with
-    | Some idx ->
-      let json_str = String.sub body (idx + 1) (String.length body - idx - 1) in
-      (try
-        let json = Yojson.Safe.from_string json_str in
-        json |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string
-      with _ -> Alcotest.fail ("Failed to parse post JSON from: " ^ json_str))
-    | None -> Alcotest.fail ("No newline in create response: " ^ body)
+    try
+      parse_create_response_json body
+      |> Yojson.Safe.Util.member "id"
+      |> Yojson.Safe.Util.to_string
+    with _ -> Alcotest.fail ("Failed to parse post JSON from: " ^ body)
   in
   Alcotest.(check bool) "post_id not empty" true (String.length post_id > 0);
   let ok2, body2 = dispatch "masc_board_get"
@@ -1008,8 +996,9 @@ let () =
               ("author", `String "claude-agent")
             ]) in
             Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check bool) "classified as direct" true
-              (contains_substring msg {|"post_kind": "direct"|}));
+            Alcotest.(check string) "classified as direct" "direct"
+              Yojson.Safe.Util.(
+                parse_create_response_json msg |> member "post_kind" |> to_string));
           Alcotest.test_case "with hook: agent classified as automation" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1020,8 +1009,9 @@ let () =
               ("author", `String "claude-agent")
             ]) in
             Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check bool) "classified as automation" true
-              (contains_substring msg {|"post_kind": "automation"|}));
+            Alcotest.(check string) "classified as automation" "automation"
+              Yojson.Safe.Util.(
+                parse_create_response_json msg |> member "post_kind" |> to_string));
           Alcotest.test_case "with hook: non-agent stays direct" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1032,8 +1022,9 @@ let () =
               ("author", `String "sangsu")
             ]) in
             Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check bool) "classified as direct" true
-              (contains_substring msg {|"post_kind": "direct"|}));
+            Alcotest.(check string) "classified as direct" "direct"
+              Yojson.Safe.Util.(
+                parse_create_response_json msg |> member "post_kind" |> to_string));
           Alcotest.test_case "legacy human override normalizes to direct" `Quick (fun () ->
             Eio_main.run @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1045,8 +1036,9 @@ let () =
               ("post_kind", `String "human")
             ]) in
             Alcotest.(check bool) "post created" true ok;
-            Alcotest.(check bool) "legacy override normalized to direct" true
-              (contains_substring msg {|"post_kind": "direct"|}));
+            Alcotest.(check string) "legacy override normalized to direct" "direct"
+              Yojson.Safe.Util.(
+                parse_create_response_json msg |> member "post_kind" |> to_string));
         ] );
       ( "board_list_cache",
         [


### PR DESCRIPTION
## Purpose
- Keep the `recovery.ml` deferred-execution warning explicit for audit readers.
- Fix the HOME escape-hatch guard so CI creates and cleans the runner HOME parent path deterministically.
- Finish the Tool_result call-site migration exposed by the Health `@check` job, leaving `to_legacy_compat` only as an exported compatibility helper.
- Update board tool tests to parse typed Tool_result payloads instead of depending on legacy prefixed text bodies.

## CI triage and updates
- Previous CI hit `test_fs_compat_home_guard` on a missing `$HOME/.masc` parent and a Health `legacy_tuple` alert failure in tests.
- Added parent creation/cleanup for the HOME escape-hatch test.
- Migrated remaining Tool_result callers/tests to structured `Tool_result.t` plus `Tool_result.message`.
- Rebased onto current `main` after #13237 landed; GitHub now reports the PR branch mergeable.

## Verification
- `git diff --check`
- `rg -n "to_legacy_compat" lib test -g "*.ml" -g "*.mli"` (helper/docs only)
- `env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_tool_board_coverage.exe`
- `env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_fs_compat_home_guard.exe`

CI is rerunning on head `f9801ce575`.