### PR TITLE
fix(keeper): preserve snapshot prompt anchors

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -182,27 +182,58 @@ let oas_history_snapshot_id_of_checkpoint (ckpt : Agent_sdk.Checkpoint.t) : stri
   Printf.sprintf "%s%013d-g%d%s"
     oas_history_prefix created_ms generation oas_history_suffix
 
+let prune_oas_history ~(session_dir : string) : unit =
+  let files = list_oas_history_files ~session_dir in
+  if List.length files > max_oas_history_retained then
+    files
+    |> List.filteri (fun index _ -> index >= max_oas_history_retained)
+    |> List.iter (fun filename ->
+         let path = oas_history_path ~session_dir ~snapshot_id:filename in
+         try Sys.remove path with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             Log.Keeper.warn "OAS snapshot cleanup failed for %s: %s"
+               path (Printexc.to_string exn);
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_checkpoint_failures
+               ~labels:[("site", "oas_cleanup")]
+               ())
+
+let hardlink_oas_history_from_canonical
+    ~(session_dir : string)
+    ~(session_id : string)
+    ~(snapshot_id : string) : (unit, string) result =
+  let canonical_path = oas_checkpoint_path ~session_dir ~session_id in
+  let snapshot_path = oas_history_path ~session_dir ~snapshot_id in
+  if not (Fs_compat.file_exists canonical_path) then
+    Error "canonical OAS checkpoint is missing"
+  else
+    try
+      if Fs_compat.file_exists snapshot_path then Sys.remove snapshot_path;
+      Unix.link canonical_path snapshot_path;
+      Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> Error (Printexc.to_string exn)
+
 let save_oas_history ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : unit =
   let snapshot_id = oas_history_snapshot_id_of_checkpoint ckpt in
-  match Keeper_fs.save_atomic
-    (oas_history_path ~session_dir ~snapshot_id)
-    (Agent_sdk.Checkpoint.to_string ckpt) with
+  let save_snapshot_file () =
+    Keeper_fs.save_atomic
+      (oas_history_path ~session_dir ~snapshot_id)
+      (Agent_sdk.Checkpoint.to_string ckpt)
+  in
+  let save_result =
+    match
+      hardlink_oas_history_from_canonical
+        ~session_dir ~session_id:ckpt.session_id ~snapshot_id
+    with
+    | Ok () -> Ok ()
+    | Error _ -> save_snapshot_file ()
+  in
+  match save_result with
   | Ok () ->
-    let files = list_oas_history_files ~session_dir in
-    if List.length files > max_oas_history_retained then
-      files
-      |> List.filteri (fun index _ -> index >= max_oas_history_retained)
-      |> List.iter (fun filename ->
-           let path = oas_history_path ~session_dir ~snapshot_id:filename in
-           try Sys.remove path with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-               Log.Keeper.warn "OAS snapshot cleanup failed for %s: %s"
-                 path (Printexc.to_string exn);
-               Prometheus.inc_counter
-                 Prometheus.metric_keeper_checkpoint_failures
-                 ~labels:[("site", "oas_cleanup")]
-                 ())
+    prune_oas_history ~session_dir
   | Error msg ->
     Log.Keeper.warn "save_oas_history failed for %s: %s" snapshot_id msg;
     Prometheus.inc_counter

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -18,6 +18,44 @@ let exact_direct_mention_present ~(targets : string list) (content : string) :
 let keeper_constitution () =
   Prompt_registry.get_prompt Keeper_prompt_names.constitution
 
+let critical_prompt_anchors =
+  [ ("continuity", "<continuity>");
+    ("pr_merge_rules", "PR merge rules");
+    ("state_block_template", "State block template");
+    ("world", "<world>") ]
+
+let missing_critical_prompt_anchors prompt =
+  List.filter_map
+    (fun (name, needle) ->
+      if String_util.contains_substring prompt needle then None else Some name)
+    critical_prompt_anchors
+
+let critical_prompt_recovery_block =
+  String.concat "\n"
+    [ "<continuity>";
+      "Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.";
+      "PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.";
+      "State block template: non-direct keeper turns must end with [STATE]...[/STATE] containing DONE, NEXT, Goal, and Decisions.";
+      "</continuity>";
+      "";
+      "<world>";
+      "Recovery guard: act from the configured base path and active runtime tool schema; do not invent paths, repos, PRs, tasks, or tools.";
+      "</world>" ]
+
+let ensure_critical_prompt_anchors prompt =
+  match missing_critical_prompt_anchors prompt with
+  | [] -> prompt
+  | missing ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_prompt_failures
+        ~labels:[("prompt", "critical_prompt_anchors")]
+        ();
+      Log.Keeper.warn
+        "build_keeper_system_prompt: critical prompt anchors missing (%s); \
+         appending recovery guard"
+        (String.concat "," missing);
+      prompt ^ "\n\n" ^ critical_prompt_recovery_block
+
 (** Format an *allowlist* for prompt rendering.  An empty allowlist means
     the gate is OFF (any account-accessible repo is permitted), so we
     render that intent explicitly — otherwise the LLM sees the literal
@@ -209,6 +247,7 @@ let build_keeper_system_prompt
       active_goals_block;
       "</identity>";
     ]
+  |> ensure_critical_prompt_anchors
 
 (* XML wrapping stays in code — it is structure, not prompt content. *)
 let direct_reply_mode_body () =

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -6,6 +6,11 @@ val exact_direct_mention_present : targets:string list -> string -> bool
 
 val keeper_constitution : unit -> string
 
+val ensure_critical_prompt_anchors : string -> string
+(** Append a minimal technical recovery block when the keeper system prompt
+    lost critical continuity/world/policy anchors. Normal prompts are returned
+    unchanged. *)
+
 val build_keeper_system_prompt :
   goal:string ->
   short_goal:string ->

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -17,6 +17,10 @@ let estimate_tokens s =
   if s = "" then 0
   else Agent_sdk.Context_reducer.estimate_char_tokens s
 
+let has_in s needle =
+  try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
+  with Not_found -> false
+
 (* ── Fixture: realistic keeper prompt components ──────── *)
 
 let base_system_prompt =
@@ -178,14 +182,44 @@ let test_direct_reply_prompt_matches_server_managed_heartbeat_policy () =
       ~instructions:""
       ()
   in
-  let has_in s needle =
-    try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
-    with Not_found -> false
-  in
   check bool "mentions server-managed heartbeat" true
     (has_in prompt "Heartbeat is server-managed");
   check bool "does not mention masc_heartbeat" false
     (has_in prompt "masc_heartbeat")
+
+let test_keeper_prompt_preserves_snapshot_delta_anchors () =
+  let prompt =
+    KP.build_keeper_system_prompt
+      ~goal:"Keep live snapshot continuity safe"
+      ~short_goal:"verify technical anchors"
+      ~mid_goal:"prevent persona-only prompt regression"
+      ~long_goal:"preserve operator safety through compaction"
+      ~will:"maintain coherent identity"
+      ~needs:"runtime truth and durable continuity"
+      ~desires:"observable progress"
+      ~instructions:""
+      ()
+  in
+  check bool "continuity anchor present" true (has_in prompt "<continuity>");
+  check bool "PR merge rules retained" true (has_in prompt "PR merge rules");
+  check bool "state block template retained" true
+    (has_in prompt "State block template");
+  check bool "world anchor present" true (has_in prompt "<world>")
+
+let test_prompt_recovery_guard_restores_missing_anchors () =
+  let prompt =
+    KP.ensure_critical_prompt_anchors
+      "You are imseonghan, a keeper agent.\nWill: keep going."
+  in
+  check bool "original persona text kept" true
+    (has_in prompt "You are imseonghan");
+  check bool "recovery continuity anchor present" true
+    (has_in prompt "<continuity>");
+  check bool "recovery PR merge rules present" true
+    (has_in prompt "PR merge rules");
+  check bool "recovery state template present" true
+    (has_in prompt "State block template");
+  check bool "recovery world anchor present" true (has_in prompt "<world>")
 
 let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
   let prompt =
@@ -199,10 +233,6 @@ let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
       ~desires:"safe execution"
       ~instructions:""
       ()
-  in
-  let has_in s needle =
-    try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
-    with Not_found -> false
   in
   check bool "mentions operator approval" true
     (has_in prompt "operator approval may be required by the runtime");
@@ -329,6 +359,10 @@ let () =
             test_soft_context_in_dynamic_only;
           test_case "direct reply prompt matches server-managed heartbeat policy" `Quick
             test_direct_reply_prompt_matches_server_managed_heartbeat_policy;
+          test_case "keeper prompt preserves snapshot delta anchors" `Quick
+            test_keeper_prompt_preserves_snapshot_delta_anchors;
+          test_case "prompt recovery guard restores missing anchors" `Quick
+            test_prompt_recovery_guard_restores_missing_anchors;
           test_case "prompt mentions runtime operator approval for risky actions" `Quick
             test_prompt_mentions_runtime_operator_approval_for_risky_actions;
         ] );

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -3518,6 +3518,20 @@ let test_keeper_checkpoint_store_writes_oas_history () =
         | latest :: _ -> latest
         | [] -> Alcotest.fail "expected OAS snapshot history file"
       in
+      let canonical_stat =
+        Unix.stat
+          (Keeper_checkpoint_store.oas_checkpoint_path
+             ~session_dir ~session_id:"trace-history")
+      in
+      let latest_snapshot_stat =
+        Unix.stat
+          (Keeper_checkpoint_store.oas_history_path
+             ~session_dir ~snapshot_id:latest_snapshot_id)
+      in
+      Alcotest.(check int) "latest history shares canonical device"
+        canonical_stat.st_dev latest_snapshot_stat.st_dev;
+      Alcotest.(check int) "latest history hardlinks canonical checkpoint"
+        canonical_stat.st_ino latest_snapshot_stat.st_ino;
       match
         Keeper_checkpoint_store.load_oas_history_file
           ~session_dir ~snapshot_id:latest_snapshot_id


### PR DESCRIPTION
## Summary
- Add a keeper prompt recovery guard for snapshot-delta critical anchors: <continuity>, PR merge rules, State block template, and <world>.
- Add regression coverage for persona-only prompt recovery after compaction.
- Store OAS history snapshots as hardlinks to the canonical checkpoint when possible, preserving read paths while avoiding duplicate bytes for identical trace/snapshot payloads.

## Why it matters
The live snapshot delta audit showed persona-only prompt recovery after compaction: technical continuity rules, PR merge policy, state-block guidance, and world/path anchors disappeared. It also showed the latest trace checkpoint and OAS snapshot had identical content. This PR keeps those operator-safety anchors durable and reduces duplicate checkpoint storage without changing the checkpoint load contract.

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_keeper_prompt_metrics.exe test/test_oas_worker.exe
- _build/default/test/test_keeper_prompt_metrics.exe test separation_harness 3,4 --compact --show-errors
- _build/default/test/test_oas_worker.exe test keeper_checkpoint_store 1 --compact --show-errors