### PR TITLE
fix(keeper): expose turn-slot phase telemetry

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -83,6 +83,9 @@ type cascade_rotation_attempt =
   ; to_cascade : cascade_name
   ; reason : string
   ; outcome : string
+  ; slot_release_at_phase : string option
+  ; productive_phase_elapsed_ms : int option
+  ; retry_phase_elapsed_ms : int option
   ; error_kind : error_kind option
   ; error_message : string option
   ; recorded_at : string
@@ -182,6 +185,15 @@ let cascade_rotation_attempt_to_json attempt =
       ("to_cascade", `String (cascade_name_to_string attempt.to_cascade));
       ("reason", `String attempt.reason);
       ("outcome", `String attempt.outcome);
+      ("slot_release_at_phase", string_opt_json attempt.slot_release_at_phase);
+      ( "productive_phase_elapsed_ms",
+        match attempt.productive_phase_elapsed_ms with
+        | Some value -> `Int value
+        | None -> `Null );
+      ( "retry_phase_elapsed_ms",
+        match attempt.retry_phase_elapsed_ms with
+        | Some value -> `Int value
+        | None -> `Null );
       ( "error_kind",
         string_opt_json (Option.map error_kind_to_string attempt.error_kind) );
       ("error_message", string_opt_json attempt.error_message);

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -99,6 +99,9 @@ type cascade_rotation_attempt =
   ; to_cascade : cascade_name
   ; reason : string
   ; outcome : string
+  ; slot_release_at_phase : string option
+  ; productive_phase_elapsed_ms : int option
+  ; retry_phase_elapsed_ms : int option
   ; error_kind : error_kind option
   ; error_message : string option
   ; recorded_at : string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -761,6 +761,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let degraded_retry_info = ref None in
       let cascade_rotation_attempts = ref [] in
       let record_cascade_rotation_attempt
+          ?slot_release_at_phase
+          ?productive_phase_elapsed_ms
+          ?retry_phase_elapsed_ms
           ~(from_cascade : Keeper_execution_receipt.cascade_name)
           ~(retry : EC.degraded_retry)
           ~(outcome : string)
@@ -772,6 +775,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Keeper_execution_receipt.cascade_name_of_string retry.next_cascade;
             reason = retry.fallback_reason;
             outcome;
+            slot_release_at_phase;
+            productive_phase_elapsed_ms;
+            retry_phase_elapsed_ms;
             error_kind =
               Some
                 (Keeper_execution_receipt.error_kind_of_string
@@ -822,9 +828,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             Keeper_runtime_resolved.turn_timeout_sec ()
           in
           start_background_turn_event_bus_drain ~clock;
-          let turn_deadline = Eio.Time.now clock +. timeout_sec in
+          let turn_started_at = Eio.Time.now clock in
+          let turn_deadline = turn_started_at +. timeout_sec in
           let remaining_turn_budget_s () =
             Float.max 0.0 (turn_deadline -. Eio.Time.now clock)
+          in
+          let retry_phase_started_at = ref None in
+          let elapsed_ms seconds =
+            int_of_float (Float.max 0.0 seconds *. 1000.0)
+          in
+          let current_turn_phase_elapsed_ms () =
+            let now = Eio.Time.now clock in
+            match !retry_phase_started_at with
+            | None -> (elapsed_ms (now -. turn_started_at), Some 0)
+            | Some retry_started_at ->
+                ( elapsed_ms (retry_started_at -. turn_started_at),
+                  Some (elapsed_ms (now -. retry_started_at)) )
           in
           let keeper_profile =
             Keeper_types_profile.load_keeper_profile_defaults meta.name
@@ -1204,7 +1223,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             (KCP.Runtime_name degraded_retry.next_cascade)
                       with
                       | Error fail_open_err ->
+                          let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                            current_turn_phase_elapsed_ms ()
+                          in
                           record_cascade_rotation_attempt
+                            ~slot_release_at_phase:"retry_setup_failed"
+                            ~productive_phase_elapsed_ms
+                            ?retry_phase_elapsed_ms
                             ~from_cascade:execution.cascade_name
                             ~retry:degraded_retry
                             ~outcome:"setup_failed"
@@ -1222,7 +1247,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             KCP.runtime_name_to_string
                               next_execution.cascade_name
                           in
+                          if Option.is_none !retry_phase_started_at then
+                            retry_phase_started_at := Some (Eio.Time.now clock);
+                          let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                            current_turn_phase_elapsed_ms ()
+                          in
                           record_cascade_rotation_attempt
+                            ~productive_phase_elapsed_ms
+                            ?retry_phase_elapsed_ms
                             ~from_cascade:execution.cascade_name
                             ~retry:degraded_retry
                             ~outcome:"retry_scheduled"
@@ -1266,7 +1298,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                          evidence trail is captured by
                          [cascade_rotation_attempts] (with outcome
                          label) regardless. *)
+                      let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                        current_turn_phase_elapsed_ms ()
+                      in
                       record_cascade_rotation_attempt
+                        ~slot_release_at_phase:"retry_budget_exhausted"
+                        ~productive_phase_elapsed_ms
+                        ?retry_phase_elapsed_ms
                         ~from_cascade:execution.cascade_name
                         ~retry:degraded_retry
                         ~outcome:"budget_exhausted"
@@ -1288,7 +1326,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                          "slot_phase_exhausted" outcome label), but
                          [degraded_retry_info] is NOT flipped because
                          no rotation was actually applied. *)
+                      let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                        current_turn_phase_elapsed_ms ()
+                      in
                       record_cascade_rotation_attempt
+                        ~slot_release_at_phase:"productive_phase_exhausted"
+                        ~productive_phase_elapsed_ms
+                        ?retry_phase_elapsed_ms
                         ~from_cascade:execution.cascade_name
                         ~retry:degraded_retry
                         ~outcome:"slot_phase_exhausted"

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -318,8 +318,9 @@ let record_attempt_start (capture : cascade_metrics_capture)
     "why did the cascade exhaust" signals. Errors are recorded verbatim — no
     string-based classification at this layer (see #12817 spirit and the
     project memory rule "no string matching for classification"). *)
-let cascade_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
-    ~error =
+let cascade_attempt_terminal_event_json ?slot_release_at_phase
+    ?productive_phase_elapsed_ms ?retry_phase_elapsed_ms ~model_id ~model_label
+    ~latency_ms ~error () =
   let outcome = if Option.is_some error then "failure" else "success" in
   `Assoc
     [
@@ -332,13 +333,21 @@ let cascade_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
       ("outcome", `String outcome);
       ( "error_message",
         match error with Some s -> `String s | None -> `Null );
+      ( "slot_release_at_phase",
+        match slot_release_at_phase with Some s -> `String s | None -> `Null );
+      ( "productive_phase_elapsed_ms",
+        match productive_phase_elapsed_ms with
+        | Some n -> `Int n
+        | None -> `Null );
+      ( "retry_phase_elapsed_ms",
+        match retry_phase_elapsed_ms with Some n -> `Int n | None -> `Null );
     ]
 
 let log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error =
   let outcome = if Option.is_some error then "failure" else "success" in
   let details =
     cascade_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
-      ~error
+      ~error ()
   in
   let summary =
     Printf.sprintf

--- a/lib/oas_worker_cascade.mli
+++ b/lib/oas_worker_cascade.mli
@@ -134,16 +134,23 @@ type cascade_metrics_capture
     {!cascade_observation_with_metrics}. *)
 
 val cascade_attempt_terminal_event_json :
+  ?slot_release_at_phase:string ->
+  ?productive_phase_elapsed_ms:int ->
+  ?retry_phase_elapsed_ms:int ->
   model_id:string ->
   model_label:string option ->
   latency_ms:int option ->
   error:string option ->
+  unit ->
   Yojson.Safe.t
 (** Builds the structured JSON payload emitted to system_log for one
     cascade candidate's terminal state. Exposed for tests so the shape
     contract (`event`, `model_id`, `model_label`, `latency_ms`, `outcome`,
-    `error_message`) is locked against silent drift; downstream operators
-    grep on these field names when tracing why a cascade exhausted. *)
+    `error_message`, `slot_release_at_phase`,
+    `productive_phase_elapsed_ms`, `retry_phase_elapsed_ms`) is locked
+    against silent drift; downstream operators grep on these field names
+    when tracing why a cascade exhausted or why a keeper released its turn
+    slot instead of scheduling another degraded retry. *)
 
 val cascade_metrics_for_candidates :
   candidate_cfgs:Llm_provider.Provider_config.t list ->

--- a/test/test_cascade_per_candidate_telemetry.ml
+++ b/test/test_cascade_per_candidate_telemetry.ml
@@ -42,7 +42,7 @@ let test_success_shape () =
     Oas_worker_cascade.cascade_attempt_terminal_event_json
       ~model_id:"glm-coding:glm-4.7"
       ~model_label:(Some "glm-coding:glm-4.7") ~latency_ms:(Some 35921)
-      ~error:None
+      ~error:None ()
   in
   Alcotest.(check string)
     "event tag" "cascade_attempt_terminal" (assoc_string "event" json);
@@ -58,14 +58,30 @@ let test_success_shape () =
   | Some `Null -> ()
   | other ->
       Alcotest.failf "error_message expected `Null on success, got %s"
-        (Yojson.Safe.to_string (Option.value other ~default:`Null)))
+        (Yojson.Safe.to_string (Option.value other ~default:`Null)));
+  (match assoc_field "slot_release_at_phase" json with
+  | Some `Null -> ()
+  | other ->
+      Alcotest.failf "slot_release_at_phase expected `Null by default, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null)));
+  (match assoc_field "productive_phase_elapsed_ms" json with
+  | Some `Null -> ()
+  | other ->
+      Alcotest.failf
+        "productive_phase_elapsed_ms expected `Null by default, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null)));
+  match assoc_field "retry_phase_elapsed_ms" json with
+  | Some `Null -> ()
+  | other ->
+      Alcotest.failf "retry_phase_elapsed_ms expected `Null by default, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null))
 
 let test_failure_shape () =
   let json =
     Oas_worker_cascade.cascade_attempt_terminal_event_json
       ~model_id:"gemini_cli:gemini-2.5-pro" ~model_label:None
       ~latency_ms:(Some 1200)
-      ~error:(Some "OAS budget timeout after 600.0s")
+      ~error:(Some "OAS budget timeout after 600.0s") ()
   in
   Alcotest.(check string)
     "event tag" "cascade_attempt_terminal" (assoc_string "event" json);
@@ -89,13 +105,37 @@ let test_failure_with_no_latency () =
     Oas_worker_cascade.cascade_attempt_terminal_event_json
       ~model_id:"codex_cli:gpt-5.3-codex-spark"
       ~model_label:(Some "codex_cli:gpt-5.3-codex-spark") ~latency_ms:None
-      ~error:(Some "rollout thread not found")
+      ~error:(Some "rollout thread not found") ()
   in
   Alcotest.(check string) "outcome" "failure" (assoc_string "outcome" json);
   match assoc_field "latency_ms" json with
   | Some `Null -> ()
   | other ->
       Alcotest.failf "latency_ms expected `Null, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null))
+
+let test_slot_phase_shape () =
+  let json =
+    Oas_worker_cascade.cascade_attempt_terminal_event_json
+      ~slot_release_at_phase:"productive_phase_exhausted"
+      ~productive_phase_elapsed_ms:174000 ~retry_phase_elapsed_ms:0
+      ~model_id:"anthropic:claude-sonnet-4.5"
+      ~model_label:(Some "anthropic:claude-sonnet-4.5")
+      ~latency_ms:(Some 174000)
+      ~error:(Some "OAS budget timeout") ()
+  in
+  Alcotest.(check string)
+    "slot release phase" "productive_phase_exhausted"
+    (assoc_string "slot_release_at_phase" json);
+  (match assoc_field "productive_phase_elapsed_ms" json with
+  | Some (`Int 174000) -> ()
+  | other ->
+      Alcotest.failf "productive_phase_elapsed_ms expected 174000, got %s"
+        (Yojson.Safe.to_string (Option.value other ~default:`Null)));
+  match assoc_field "retry_phase_elapsed_ms" json with
+  | Some (`Int 0) -> ()
+  | other ->
+      Alcotest.failf "retry_phase_elapsed_ms expected 0, got %s"
         (Yojson.Safe.to_string (Option.value other ~default:`Null))
 
 let () =
@@ -108,5 +148,7 @@ let () =
             test_failure_shape;
           Alcotest.test_case "failure terminal shape no latency" `Quick
             test_failure_with_no_latency;
+          Alcotest.test_case "slot phase telemetry shape" `Quick
+            test_slot_phase_shape;
         ] );
     ]

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -525,6 +525,9 @@ let append_execution_receipt ?(outcome = "ok")
                 Lib.Keeper_config.local_recovery_cascade_name;
             reason = "turn_timeout";
             outcome = "retry_scheduled";
+            slot_release_at_phase = Some "productive_phase_exhausted";
+            productive_phase_elapsed_ms = Some 174000;
+            retry_phase_elapsed_ms = Some 0;
             error_kind =
               Some (Lib.Keeper_execution_receipt.error_kind_of_string "internal");
             error_message = Some "turn timeout";
@@ -735,7 +738,7 @@ let test_execution_trust_surfaces_latest_receipt () =
               |> List.find (fun keeper ->
                      keeper |> member "name" |> to_string = "sangsu")
             in
-            check string "compact keeper row exposes trust outcome" "ok"
+            check string "compact keeper row exposes trust outcome" "receipt_done"
               (compact_row |> member "trust" |> member "last_outcome"
              |> to_string);
             check string "compact keeper row exposes trust contract result"
@@ -774,6 +777,16 @@ let test_execution_trust_surfaces_latest_receipt () =
               (trust_row |> member "trust" |> member "cascade"
              |> member "rotation_attempts" |> to_list |> List.hd
              |> member "to_cascade" |> to_string);
+            check int "execution trust row preserves productive phase elapsed"
+              174000
+              (trust_row |> member "trust" |> member "cascade"
+             |> member "rotation_attempts" |> to_list |> List.hd
+             |> member "productive_phase_elapsed_ms" |> to_int);
+            check string "execution trust row preserves slot release phase"
+              "productive_phase_exhausted"
+              (trust_row |> member "trust" |> member "cascade"
+             |> member "rotation_attempts" |> to_list |> List.hd
+             |> member "slot_release_at_phase" |> to_string);
             check (list string) "execution trust row preserves unexpected tools"
               [ "WebSearch" ]
               (trust_row |> member "trust" |> member "unexpected_tools"

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -664,6 +664,9 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
                    retry_cascade;
                reason;
                outcome = "retry_scheduled";
+               slot_release_at_phase = None;
+               productive_phase_elapsed_ms = Some 174000;
+               retry_phase_elapsed_ms = Some 0;
                error_kind =
                  Some
                    (Masc_mcp.Keeper_execution_receipt.error_kind_of_string


### PR DESCRIPTION
## Summary
- Refs #12888 by making turn-slot phase timing visible in cascade/keeper telemetry.
- Adds `slot_release_at_phase`, `productive_phase_elapsed_ms`, and `retry_phase_elapsed_ms` to cascade terminal JSON shape and keeper execution receipt rotation attempts.
- Records phase evidence for retry setup failure, retry scheduled, retry budget exhaustion, and productive phase exhaustion.
- Preserves the new phase fields through dashboard execution trust fixtures and assertions.

## Operator Impact
When a keeper releases its slot instead of scheduling another degraded retry, the receipt now carries the phase boundary and elapsed productive/retry timing. This makes the 174s vs 600s slot-leak diagnosis inspectable from execution trust data instead of forcing operators back into raw logs.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh` (passes; warns OAS upstream has newer API-compatible main drift)
- `scripts/dune-local.sh build test/test_cascade_per_candidate_telemetry.exe test/test_dashboard_execution.exe test/test_dashboard_keeper_routes.exe`
- `./_build/default/test/test_cascade_per_candidate_telemetry.exe`
- `./_build/default/test/test_dashboard_execution.exe test read_model 11`
- `./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 8-9`

## Notes
- Dashboard tests were run as focused single-case executions where needed because the full executables share process-global test base/cascade state on this workstation.