### PR TITLE
fix(ide): make file tree leaves keyboard-focusable

### DIFF
--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h, render } from 'preact'
+import { IdeExplorer } from './ide-explorer'
+import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
+
+const SAMPLE: ReadonlyArray<FileTreeNode> = [
+  { path: 'runtime', label: 'runtime', depth: 0, parent: null, hasChildren: true, diff: null, keeperId: null, hueIndex: null },
+  { path: 'runtime/router.ts', label: 'router.ts', depth: 1, parent: 'runtime', hasChildren: false, diff: '+14', keeperId: 'nick0cave', hueIndex: 1 },
+  { path: 'package.json', label: 'package.json', depth: 0, parent: null, hasChildren: false, diff: null, keeperId: null, hueIndex: null },
+]
+
+describe('IdeExplorer tree row keyboard accessibility', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+  })
+
+  afterEach(() => {
+    render(null, container)
+  })
+
+  it('makes every treeitem keyboard-focusable, not just directories', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE)
+    render(h(IdeExplorer, { fileTreeStore: store }), container)
+
+    const treeItems = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="treeitem"]'),
+    )
+    expect(treeItems.length).toBeGreaterThan(0)
+
+    const tabIndexes = treeItems.map(el => el.getAttribute('tabindex'))
+    for (const idx of tabIndexes) {
+      expect(idx).toBe('0')
+    }
+
+    const leafItem = treeItems.find(el => el.textContent?.includes('package.json'))
+    expect(leafItem).toBeDefined()
+    expect(leafItem?.getAttribute('tabindex')).toBe('0')
+  })
+})

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -286,7 +286,7 @@ function TreeRow(node: FileTreeNode, expanded: boolean, onClick: () => void) {
     <li
       role="treeitem"
       aria-expanded=${node.hasChildren ? (expanded ? 'true' : 'false') : undefined}
-      tabIndex=${node.hasChildren ? 0 : -1}
+      tabIndex=${0}
       onClick=${onClick}
       onKeyDown=${onKeyDown}
       style=${{
@@ -298,7 +298,7 @@ function TreeRow(node: FileTreeNode, expanded: boolean, onClick: () => void) {
         paddingLeft: `${4 + indent}px`,
         font: 'var(--type-body)',
         color: 'var(--color-fg-secondary)',
-        cursor: node.hasChildren ? 'pointer' : 'default',
+        cursor: 'pointer',
         userSelect: 'none',
       }}
     >


### PR DESCRIPTION
## Why

`dashboard/src/components/ide/ide-explorer.ts` 의 `TreeRow` 가 leaf (파일) 노드에 `tabIndex=-1` 과 `cursor:'default'` 를 주고 있어, 키보드 사용자가 Tab 으로 파일에 도달할 수 없고 이미 존재하는 `onKeyDown` (Enter/Space → 파일 열기) 핸들러가 사실상 dead code 였습니다.

`role=\"treeitem\"` 계약이 일관되지 않은 상태였습니다 — 디렉토리는 키보드로 열고, 파일은 마우스 클릭으로만 열림.

## What

- `tabIndex=${node.hasChildren ? 0 : -1}` → `tabIndex=${0}` (모든 treeitem)
- `cursor: node.hasChildren ? 'pointer' : 'default'` → `cursor: 'pointer'`
- 회귀 가드: 모든 treeitem (leaf 포함) 의 `tabindex='0'` 검증 테스트 추가

## Trade-off

이번 변경은 최소-표면 a11y fix 입니다. Tab 키 traversal 이 100+ 노드를 거치게 되는 단점이 있어, 후속 RFC 로 표준 ARIA tree 의 **roving tabindex** 패턴 (선택된 노드만 `tabindex=0`, ↑/↓ 키로 이동) 도입을 권장합니다. VS Code, GitHub 등이 사용하는 패턴.

## Verification

- [x] `pnpm tsc --noEmit` — 0 error
- [x] `pnpm lint --quiet` — 0 warning
- [x] `pnpm vitest run src/components/ide/` — 22 files / 88 tests pass
- [x] 신규 회귀 테스트 (`ide-explorer.test.ts`) pass

## Out of Scope (별도 사이클)

- IDE syntax highlighting 깜빡거림 (shiki 재계산 reset 패턴) — 분석 결과 단순 reset 제거 시 stale-content-mismatch 위험. shiki streaming 또는 debounce + diff 라는 아키텍처 변경 필요 → RFC 별도 작성 권장.
- Dashboard 디자인 시스템 (`dashboard/design-system/`) 정합성 점검 — 다음 사이클.
- File Tree 의 검색 키보드 탐색 (filter 입력 후 ↑/↓ 로 결과 탐색) — 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)