### PR TITLE
feat(cascade): outer wall respects RFC-0022 attempt budget (Ollama unblock)

### DIFF
--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -61,3 +61,17 @@ let budget_for_label (label : string) : Cascade_attempt_liveness.budget =
   | "local_70b" | "local_70b_plus" | "ollama_70b" ->
       Cascade_attempt_liveness.local_70b_plus
   | _ -> Cascade_attempt_liveness.cloud_fast
+
+(* RFC-0022 §1 — see .mli for contract. *)
+let outer_wall_for_attempt
+    ~mode ~observer_attached ~per_provider_timeout_s ~provider_label =
+  match mode, observer_attached with
+  | Enforce, true -> None
+  | _, true ->
+      let budget_wall =
+        (budget_for_label provider_label).Cascade_attempt_liveness.attempt_wall_max
+      in
+      Option.map
+        (fun t -> Float.max t budget_wall)
+        per_provider_timeout_s
+  | _, false -> per_provider_timeout_s

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -44,3 +44,30 @@ val reset_cache_for_test : unit -> unit
 (** Test-only: reset the cached flag read so a new value of
     [MASC_CASCADE_ATTEMPT_LIVENESS] takes effect. Production callers
     must not invoke this. *)
+
+val outer_wall_for_attempt
+  :  mode:mode
+  -> observer_attached:bool
+  -> per_provider_timeout_s:float option
+  -> provider_label:string
+  -> float option
+(** RFC-0022 §1 — backstop wall for the legacy [per_provider_timeout_s]
+    knob.
+
+    Decides what (if anything) {!Eio.Time.with_timeout_exn} should
+    enforce around an attempt, given the active liveness mode and
+    whether an observer is attached.
+
+    - [Enforce] + observer attached: returns [None]. The observer is
+      the authority and drives [Switch.fail] on TTFT, inter-chunk, or
+      attempt wall budget breach. The legacy outer wall must not
+      pre-empt it.
+    - [Off] / [Observe], or no observer: returns
+      [Some (max t (budget_for_label provider_label).attempt_wall_max)]
+      when [per_provider_timeout_s = Some t]. Slow-but-legitimate
+      streams (local Ollama 27B / 70B+) get the profile's attempt wall
+      so the legacy 120s knob cannot prematurely fall back the cascade.
+    - No legacy timeout configured ([per_provider_timeout_s = None]):
+      returns [None] (no outer wall).
+
+    @since 0.20.0 *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -428,8 +428,21 @@ let run_named
                 ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
                 ?contract goal
             in
+            (* RFC-0022 §1 (in-attempt liveness layer): see
+               [Cascade_attempt_liveness_config.outer_wall_for_attempt]
+               for the rule. The legacy [per_provider_timeout_s] is
+               clipped to the profile's wall budget so slow-but-honest
+               streams (local Ollama 27B / 70B+) are not pre-empted
+               before the observer would consider them stalled. *)
+            let outer_wall_for_provider =
+              Cascade_attempt_liveness_config.outer_wall_for_attempt
+                ~mode:liveness_mode
+                ~observer_attached:(Option.is_some liveness_observer_opt)
+                ~per_provider_timeout_s
+                ~provider_label:provider_cfg.model_id
+            in
             let result =
-              match per_provider_timeout_s with
+              match outer_wall_for_provider with
               | None -> run_fn ()
               | Some t ->
                   let clock_opt =

--- a/test/dune
+++ b/test/dune
@@ -1037,6 +1037,7 @@
 (include stanzas/test_cascade_attempt_liveness_counters.inc)
 (include stanzas/test_cascade_attempt_liveness_observer.inc)
 (include stanzas/test_cascade_attempt_liveness_runtime.inc)
+(include stanzas/test_cascade_attempt_outer_wall.inc)
 (include stanzas/test_oas_worker_named_liveness_integration.inc)
 (include stanzas/test_cascade_capability_gate.inc)
 (include stanzas/test_cascade_catalog_runtime.inc)

--- a/test/stanzas/test_cascade_attempt_outer_wall.inc
+++ b/test/stanzas/test_cascade_attempt_outer_wall.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_attempt_outer_wall)
+ (modules test_cascade_attempt_outer_wall)
+ (libraries masc_test_deps))

--- a/test/test_cascade_attempt_outer_wall.ml
+++ b/test/test_cascade_attempt_outer_wall.ml
@@ -1,0 +1,226 @@
+(** RFC-0022 §1 — outer-wall backstop respects the per-profile budget.
+
+    The legacy [per_provider_timeout_s] knob (default 120s) used to be
+    enforced as a raw [Eio.Time.with_timeout_exn]. That pre-empted
+    attempts before the per-profile attempt-wall ([cloud_fast 180s],
+    [cloud_thinking 300s], [local_27b 900s], [local_70b_plus 1800s])
+    could fire — making slow local LLMs (Ollama) impossible to use.
+
+    This module verifies the new contract enforced by
+    {!Cascade_attempt_liveness_config.outer_wall_for_attempt}.
+
+    The Ollama scenario (slow streaming past 120s) is exercised at the
+    rule level: with [Enforce + observer] the outer wall returns
+    [None], and the observer drives cancellation. With [Observe /
+    Off + observer] the outer wall is raised to the profile's wall so
+    the legacy 120s knob cannot kill a healthy slow stream. *)
+
+open Masc_mcp
+module Cfg = Cascade_attempt_liveness_config
+module L = Cascade_attempt_liveness
+
+let f = Alcotest.float 1e-6
+let opt_f = Alcotest.option f
+
+(* ─── Enforce mode + observer attached: outer wall is suppressed ─── *)
+
+let test_enforce_with_observer_returns_none () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Enforce
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"codex_cli"
+  in
+  Alcotest.(check opt_f) "Enforce + observer → None" None actual
+
+let test_enforce_with_observer_ollama_returns_none () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Enforce
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"ollama_only"
+  in
+  Alcotest.(check opt_f)
+    "Enforce + observer + ollama → None (observer is authority)"
+    None actual
+
+(* ─── Observe / Off + observer: clip outer wall to profile budget ─── *)
+
+let test_observe_ollama_clips_to_local_27b_wall () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Observe
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"ollama_only"
+  in
+  Alcotest.(check opt_f)
+    "Observe + ollama → local_27b wall 900s (not 120s)"
+    (Some L.local_27b.attempt_wall_max)
+    actual
+
+let test_off_ollama_clips_to_local_27b_wall () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Off
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"llama-server"
+  in
+  Alcotest.(check opt_f)
+    "Off + llama-server → local_27b wall 900s"
+    (Some L.local_27b.attempt_wall_max)
+    actual
+
+let test_observe_ollama_70b_clips_to_local_70b_plus_wall () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Observe
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"ollama_70b"
+  in
+  Alcotest.(check opt_f)
+    "Observe + ollama_70b → local_70b_plus wall 1800s"
+    (Some L.local_70b_plus.attempt_wall_max)
+    actual
+
+let test_observe_cloud_fast_keeps_user_t_when_larger () =
+  (* User explicitly set a larger budget than the profile default —
+     respect it. The clip rule is [max user_t profile_wall]. *)
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Observe
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 600.0)
+      ~provider_label:"codex_cli"
+  in
+  Alcotest.(check opt_f)
+    "Observe + codex_cli + user 600s → 600s (>cloud_fast 180s)"
+    (Some 600.0) actual
+
+let test_observe_cloud_fast_clips_when_user_smaller () =
+  (* The legacy 120s knob is below cloud_fast 180s — clip up. *)
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Observe
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"codex_cli"
+  in
+  Alcotest.(check opt_f)
+    "Observe + codex_cli + user 120s → cloud_fast 180s"
+    (Some L.cloud_fast.attempt_wall_max)
+    actual
+
+(* ─── No observer: pass-through (legacy behaviour preserved) ─── *)
+
+let test_no_observer_passes_through_user_value () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Off
+      ~observer_attached:false
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"ollama_only"
+  in
+  Alcotest.(check opt_f)
+    "Off + no observer → unchanged 120s (legacy)"
+    (Some 120.0) actual
+
+let test_enforce_without_observer_passes_through () =
+  (* Defensive: Enforce was set but observer wasn't constructed
+     (e.g. liveness module disabled at compile-time or no clock).
+     We must not silently drop the legacy wall. *)
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Enforce
+      ~observer_attached:false
+      ~per_provider_timeout_s:(Some 120.0)
+      ~provider_label:"codex_cli"
+  in
+  Alcotest.(check opt_f)
+    "Enforce + no observer → unchanged 120s (no silent drop)"
+    (Some 120.0) actual
+
+(* ─── No legacy timeout configured: returns None in all modes ─── *)
+
+let test_none_input_stays_none_observe_with_observer () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Observe
+      ~observer_attached:true
+      ~per_provider_timeout_s:None
+      ~provider_label:"ollama_only"
+  in
+  Alcotest.(check opt_f) "None input → None output" None actual
+
+let test_none_input_stays_none_off_no_observer () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Off
+      ~observer_attached:false
+      ~per_provider_timeout_s:None
+      ~provider_label:"codex_cli"
+  in
+  Alcotest.(check opt_f) "None + no observer → None" None actual
+
+(* ─── Unknown labels fall back to cloud_fast ─── *)
+
+let test_unknown_label_falls_back_to_cloud_fast () =
+  let actual =
+    Cfg.outer_wall_for_attempt
+      ~mode:Cfg.Observe
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 60.0)
+      ~provider_label:"some-future-provider"
+  in
+  Alcotest.(check opt_f)
+    "Observe + unknown → cloud_fast 180s"
+    (Some L.cloud_fast.attempt_wall_max)
+    actual
+
+let () =
+  Alcotest.run "cascade-attempt-outer-wall"
+    [
+      ( "enforce-suppresses-outer-wall",
+        [
+          Alcotest.test_case "codex_cli" `Quick
+            test_enforce_with_observer_returns_none;
+          Alcotest.test_case "ollama_only" `Quick
+            test_enforce_with_observer_ollama_returns_none;
+        ] );
+      ( "observe-clips-to-budget",
+        [
+          Alcotest.test_case "ollama_only → local_27b wall" `Quick
+            test_observe_ollama_clips_to_local_27b_wall;
+          Alcotest.test_case "llama-server (Off) → local_27b wall" `Quick
+            test_off_ollama_clips_to_local_27b_wall;
+          Alcotest.test_case "ollama_70b → local_70b_plus wall" `Quick
+            test_observe_ollama_70b_clips_to_local_70b_plus_wall;
+          Alcotest.test_case "user 600s > cloud_fast 180s preserved" `Quick
+            test_observe_cloud_fast_keeps_user_t_when_larger;
+          Alcotest.test_case "user 120s < cloud_fast 180s clipped" `Quick
+            test_observe_cloud_fast_clips_when_user_smaller;
+        ] );
+      ( "no-observer-pass-through",
+        [
+          Alcotest.test_case "Off + no observer" `Quick
+            test_no_observer_passes_through_user_value;
+          Alcotest.test_case "Enforce + no observer (defensive)" `Quick
+            test_enforce_without_observer_passes_through;
+        ] );
+      ( "none-input",
+        [
+          Alcotest.test_case "Observe + observer + None" `Quick
+            test_none_input_stays_none_observe_with_observer;
+          Alcotest.test_case "Off + no observer + None" `Quick
+            test_none_input_stays_none_off_no_observer;
+        ] );
+      ( "fallback",
+        [
+          Alcotest.test_case "unknown label → cloud_fast" `Quick
+            test_unknown_label_falls_back_to_cloud_fast;
+        ] );
+    ]


### PR DESCRIPTION
## Why

진단 (2026-05-05): production keeper freeze 17/17. Server `commit=cce828db04`, base_path=`~/me`. Symptom mapping:
- 3 keepers (`analyst`, `masc-improver`, `nick0cave`): `cascade_exhausted{cascade_name=tier_fast}`, blocker text `"Per-provider timeout after 120.0s"`.
- 4 keepers (`glm-coding-plan`, `sangsu`, `scholar`, `verifier`): `completion_contract_violation`.
- 2 keepers (`qa-king`, `ramarama`): `stale_turn_timeout(idle_turn(1816s))` — force_release path (#13246) 정상 작동.
- 8 keepers: blocker_class 미스탬프 (`keeper_status_bridge::blocker_class_of_sdk_error` SDK variant 매핑 누락 — 별도 PR 예정).

근본 원인은 `lib/oas_worker_named.ml:432-451`의 outer `Eio.Time.with_timeout_exn clock t run_fn`. `t`는 wall-clock deadline이라 streaming 진행 여부와 무관하게 무조건 cancel. 같은 값이 line 320에서 `stream_idle_timeout_s`로도 동시 사용되지만 outer wall이 항상 먼저 발동.

RFC-0022는 정확히 이 layer (in-attempt liveness)를 정의하고 per-profile 예산을 둔다:

| Profile | TTFT | Inter-chunk | Wall |
|---------|------|-------------|------|
| `cloud_fast` (codex_cli, claude, gemini) | 30s | 20s | 180s |
| `cloud_thinking` (glm-coding, kimi) | 60s | 30s | 300s |
| `local_27b` (ollama_only, llama-server) | 120s | 60s | **900s** |
| `local_70b_plus` (ollama_70b) | 240s | 90s | **1800s** |

PR-1/2/4는 머지됐지만 PR-3 (#12999, SSE adapter)는 split-brain 충돌로 closed → observer가 chunk 이벤트를 받지 못해 hollow 상태. 그러나 PR-3 미완성과 무관하게 line 432-451의 legacy outer wall 120s가 항상 먼저 발동하므로, observer per-profile budget이 실효성 0.

## What

`Cascade_attempt_liveness_config.outer_wall_for_attempt` 순수 helper 추출:

| Mode | Observer | Outer wall |
|------|----------|------------|
| `Enforce` | attached | `None` (observer authority) |
| `Observe`/`Off` | attached | `Some (max user_t profile.attempt_wall_max)` |
| any | none | `per_provider_timeout_s` (legacy unchanged) |
| any | any | `None` if `per_provider_timeout_s = None` |

`Oas_worker_named.try_provider`는 inline 분기 대신 helper 호출로 단순화.

## Effect

- Ollama 27B reasoning 5분 generation (현재 120s에 죽음) → 900s wall이 적용되어 정상 완주.
- Cloud `codex_cli` 등도 user-supplied 120s가 cloud_fast 180s로 자동 raise (downside: 60s 추가 대기 가능, but observer가 Enforce 모드에서는 inter-chunk 20s로 더 빨리 끊을 수 있음).
- `Off` 모드 + observer attached: 여전히 budget으로 raise (방어적). `Off` + no observer: legacy 그대로.
- `Enforce` 진입 권장: `MASC_CASCADE_ATTEMPT_LIVENESS=enforce` (서버 재기동 필요).

## Tests

12 cases in `test_cascade_attempt_outer_wall`:

1. `Enforce + observer + codex_cli` → `None`
2. `Enforce + observer + ollama_only` → `None`
3. `Observe + ollama_only + 120s` → `Some 900.0`
4. `Off + llama-server + 120s` → `Some 900.0`
5. `Observe + ollama_70b + 120s` → `Some 1800.0`
6. `Observe + codex_cli + user 600s` → `Some 600.0` (user > profile)
7. `Observe + codex_cli + user 120s` → `Some 180.0` (clipped up)
8. `Off + no observer + 120s` → `Some 120.0` (legacy)
9. `Enforce + no observer + 120s` → `Some 120.0` (defensive — no silent drop)
10-11. `None` input → `None` output (Observe + Off)
12. unknown label → `cloud_fast`

```
Test Successful in 0.002s. 12 tests run.
```

`dune build` (full) 통과.

## Layer separation (RFC-0022 §1)

- Pre-attempt (RFC-0009): unchanged.
- **In-attempt (this RFC) — wall budget enforcement**: 본 PR이 legacy knob의 sabotage를 차단.
- Cross-attempt (RFC-0012): unchanged.

Invariant L2 (no double kill)는 그대로: outer wall이 더 큰 budget으로만 clip되므로, `Enforce` mode에서 observer가 budget 도달 시 Switch.fail로 turn-cap 전에 항상 먼저 advance.

## Out of scope (follow-up issues)

- `keeper_status_bridge::blocker_class_of_sdk_error` SDK variant 매핑 (8 keeper stamp gap) — 별도 PR.
- RFC-0022 PR-3 SSE adapter 재시도 (chunk → observer feed) — 본 PR과 독립.
- `MASC_CASCADE_ATTEMPT_LIVENESS=enforce` 기본값 변경 검토 — config-level, 별도 RFC waiver 필요.

## Refs

- RFC: `docs/rfc/RFC-0022-cascade-attempt-liveness.md` §1, §4.1, §9
- Past PRs: #12433 (RFC), #12968 (PR-1 FSM), #12981 (PR-2 runtime), #13008 (PR-2 observer), #12994 (PR-4 TLA+), #12999 (PR-3 closed)
- Related: #13246 (force_release_holder_for, complementary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)