### PR TITLE
Fix dashboard cockpit and keeper runtime bootstrap gaps

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -197,6 +197,7 @@ export function App() {
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
   const topbarNavItems = DASHBOARD_NAV_ITEMS.filter(item => item.id !== 'code')
+  const isCodeSurface = currentTab === 'code'
 
   return html`
     <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]">
@@ -284,7 +285,7 @@ export function App() {
         </aside>
 
         <main id="main-content" tabindex=${-1} class="min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0">
-          <div class="h-full overflow-y-auto p-4">
+          <div class=${isCodeSurface ? 'h-full overflow-hidden p-0' : 'h-full overflow-y-auto p-4'}>
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -711,11 +711,30 @@ export function DashboardMain() {
   }
 
   const routeLabel = dashboardRouteBoundaryKey(route.value)
+  const immersiveSurface = route.value.tab === 'code'
+  const warmingBanner = namespaceTruthInitializing.value ? html`
+    <div class=${immersiveSurface
+      ? 'shrink-0 border-b border-solid border-[var(--warn-20)] bg-[var(--warn-10)] px-4 py-1.5 text-center text-xs text-[var(--color-status-warn)]'
+      : 'mb-3 shrink-0 rounded-[var(--r-2)] border border-solid border-[var(--warn-20)] bg-[var(--warn-10)] px-4 py-1.5 text-center text-xs text-[var(--color-status-warn)]'}>
+      Server data warming; this view will refresh automatically.
+    </div>
+  ` : null
+
+  if (immersiveSurface) {
+    return html`
+      <div class=${`animate-in fade-in slide-in-from-bottom-2 duration-[var(--t-slow)] fill-mode-both h-full min-h-0 overflow-hidden ${namespaceTruthInitializing.value ? 'grid grid-rows-[auto_minmax(0,1fr)]' : ''}`}>
+        ${warmingBanner}
+        <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
+          <div class="h-full min-h-0 overflow-hidden">
+            <${TabContent} />
+          </div>
+        <//>
+      </div>
+    `
+  }
 
   return html`
-    ${namespaceTruthInitializing.value ? html`
-      <div class="mb-3 shrink-0 rounded-[var(--r-2)] border border-solid border-[var(--warn-20)] bg-[var(--warn-10)] px-4 py-1.5 text-center text-xs text-[var(--color-status-warn)]">Server data warming; this view will refresh automatically.</div>
-    ` : null}
+    ${warmingBanner}
     <${SurfaceLead} />
     <${ObservatoryFilterBar} />
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
+import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import { KeeperBadge } from '../keeper-badge'
 import {
   createRunActivityStore,
@@ -128,61 +129,39 @@ export function IdeActivityMock() {
 
   return html`
     <div
+      class="ide-rail-panel ide-activity-panel"
       role="region"
       aria-label="EVENT TIMELINE"
-      style=${{
-        display: 'flex',
-        flexDirection: 'column',
-        background: 'var(--color-bg-surface)',
-        borderLeft: '1px solid var(--color-border-default)',
-        borderTop: '1px solid var(--color-border-divider)',
-        minHeight: 0,
-      }}
     >
       <div
-        style=${{
-          display: 'flex',
-          justifyContent: 'space-between',
-          padding: 'var(--sp-2) var(--sp-3)',
-          color: 'var(--color-fg-muted)',
-          font: 'var(--type-eyebrow)',
-          borderBottom: '1px solid var(--color-border-divider)',
-        }}
+        class="ide-rail-head"
       >
         <span>EVENT TIMELINE</span>
         <span>${events.length} events · ${keepers.length} keepers</span>
       </div>
       <ol
-        style=${{
-          listStyle: 'none',
-          padding: 'var(--sp-2)',
-          margin: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--sp-1)',
-          overflow: 'auto',
-        }}
+        class="ide-rail-list ide-activity-list"
       >
-        ${events.map(item => ActivityRow(item))}
+        ${events.length === 0
+          ? html`<li class="ide-rail-empty">no recent activity</li>`
+          : events.map(item => ActivityRow(item))}
       </ol>
     </div>
   `
 }
 
 function ActivityRow(item: RunActivityEvent) {
+  const hue = keeperHueIndex(item.keeper_id)
+  const dot = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
   return html`
     <li
+      class="ide-activity-row"
       style=${{
-        display: 'grid',
-        gridTemplateColumns: '52px minmax(0, 1fr)',
-        gap: 'var(--sp-2)',
-        alignItems: 'baseline',
-        padding: '4px 6px',
-        font: 'var(--type-body)',
-        color: 'var(--color-fg-secondary)',
+        '--ide-activity-dot': dot,
       }}
     >
-      <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${formatActivityTime(item.timestamp_ms)}</span>
+      <span class="ide-activity-time">${formatActivityTime(item.timestamp_ms)}</span>
+      <span class="ide-activity-dot" aria-hidden="true" />
       <div style=${{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
         <span style=${{ fontSize: 'var(--fs-11)' }}>
           <${KeeperBadge} id=${item.keeper_id} variant="full" size="sm" />

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -15,8 +15,12 @@ describe('IdeConversationRailMock', () => {
 
     const region = container.querySelector('[role="region"]')
     expect(region?.getAttribute('aria-label')).toBe('REACTION THREAD')
+    expect(region?.classList.contains('ide-conversation-panel')).toBe(true)
+    expect(container.querySelector('.ide-rail-scope')?.getAttribute('aria-label')).toBe('Keeper workspace scope')
+    expect(container.querySelector('.ide-rail-list')).not.toBeNull()
     expect(container.textContent).toContain('REACTION THREAD')
     expect(container.textContent).toContain('0')
+    expect(container.textContent).toContain('no conversation activity')
   })
 
   it('orders thread, decision, and cascade replay items on one timeline', () => {

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -16,6 +16,8 @@ import {
   filterReplayEvents,
   type AuditReplayEvent,
 } from './audit-replay-slider'
+import { activeIdeFile } from './ide-shell'
+import { activeKeeperName } from '../../keeper-state'
 
 interface BoardPost {
   readonly id: string
@@ -107,6 +109,8 @@ export function IdeConversationRailMock() {
   const [cascadeEvents, setCascadeEvents] = useState<ReadonlyArray<CascadeStrategyTraceEvent>>(EMPTY_CASCADE)
   const [focusedId, setFocusedId] = useState<string | null>(null)
   const [replayUntilMs, setReplayUntilMs] = useState<number | null>(null)
+  const [activeFile, setActiveFile] = useState(activeIdeFile.value)
+  const [keeperName, setKeeperName] = useState(activeKeeperName.value)
 
   useEffect(() => {
     let cancelled = false
@@ -122,6 +126,8 @@ export function IdeConversationRailMock() {
     })
     return () => { cancelled = true }
   }, [])
+  useEffect(() => activeIdeFile.subscribe(file => setActiveFile(file)), [])
+  useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
 
   const replayItems = replayRailItems(posts, decisions, cascadeEvents)
   const replayEvents = replayEventsForItems(replayItems)
@@ -133,25 +139,12 @@ export function IdeConversationRailMock() {
 
   return html`
     <div
+      class="ide-rail-panel ide-conversation-panel"
       role="region"
       aria-label="REACTION THREAD"
-      style=${{
-        display: 'flex',
-        flexDirection: 'column',
-        background: 'var(--color-bg-surface)',
-        borderLeft: '1px solid var(--color-border-default)',
-        minHeight: 0,
-      }}
     >
       <div
-        style=${{
-          display: 'flex',
-          justifyContent: 'space-between',
-          padding: 'var(--sp-2) var(--sp-3)',
-          color: 'var(--color-fg-muted)',
-          font: 'var(--type-eyebrow)',
-          borderBottom: '1px solid var(--color-border-divider)',
-        }}
+        class="ide-rail-head"
       >
         <span>REACTION THREAD</span>
         <span>
@@ -160,27 +153,25 @@ export function IdeConversationRailMock() {
           ${visibleCounts.cascade}/${cascadeEvents.length} cascade
         </span>
       </div>
+      <div class="ide-rail-scope" aria-label="Keeper workspace scope">
+        <span>${keeperName ? `@${keeperName}` : 'all keepers'}</span>
+        <span title=${activeFile}>${activeFile}</span>
+      </div>
       <${AuditReplaySlider}
         events=${replayEvents}
         value=${replayUntilMs}
         onChange=${setReplayUntilMs}
       />
       <ol
-        style=${{
-          listStyle: 'none',
-          padding: 'var(--sp-2)',
-          margin: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--sp-2)',
-          overflow: 'auto',
-        }}
+        class="ide-rail-list"
       >
-        ${visibleItems.map(item => ReplayRailCard(
-          item,
-          focusedId,
-          nextFocusedId => setFocusedId(focusedId === nextFocusedId ? null : nextFocusedId),
-        ))}
+        ${visibleItems.length === 0
+          ? html`<li class="ide-rail-empty">no conversation activity</li>`
+          : visibleItems.map(item => ReplayRailCard(
+              item,
+              focusedId,
+              nextFocusedId => setFocusedId(focusedId === nextFocusedId ? null : nextFocusedId),
+            ))}
       </ol>
     </div>
   `
@@ -255,27 +246,18 @@ function PostCard(post: BoardPost, focused: boolean, onFocus: () => void) {
   const bodyText = post.body || post.title || ''
 
   return html`
-    <li style=${{ display: 'block' }}>
+    <li class="ide-rail-item">
       <button
+        class="ide-conversation-card"
         type="button"
         aria-current=${focused ? 'true' : undefined}
         onClick=${onFocus}
         style=${{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--sp-1)',
-          width: '100%',
-          padding: 'var(--sp-2)',
-          background: focused ? 'var(--color-bg-muted)' : 'var(--color-bg-elevated)',
-          border: '1px solid var(--color-border-default)',
+          '--ide-conversation-bg': focused ? 'var(--color-bg-muted)' : 'var(--color-bg-elevated)',
           borderLeft: `2px solid ${keeperColor}`,
-          borderRadius: 'var(--r-2)',
-          color: 'inherit',
-          textAlign: 'left',
-          cursor: 'pointer',
         }}
       >
-        <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--sp-2)' }}>
+        <div class="ide-conversation-meta">
           <span style=${{ fontSize: 'var(--fs-11)', color: kindColor, letterSpacing: '0.05em' }}>${KIND_LABEL[kind]}</span>
           <${KeeperBadge} id=${post.author_identity} variant="full" size="sm" />
           <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${formatThreadTime(createdMs)}</span>
@@ -285,7 +267,7 @@ function PostCard(post: BoardPost, focused: boolean, onFocus: () => void) {
             ${post.hearth}
           </div>
         ` : null}
-        <p style=${{ font: 'var(--type-body)', color: 'var(--color-fg-secondary)', margin: 0 }}>${bodyText}</p>
+        <p class="ide-conversation-body">${bodyText}</p>
         <div style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
           ${post.comment_count > 0 ? `${post.comment_count} replies · ` : ''}${post.votes > 0 ? `${post.votes} votes` : ''}
         </div>

--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -1,20 +1,22 @@
 import { describe, it, expect } from 'vitest'
-import { EditorState } from '@codemirror/state'
+import { EditorState, type Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import {
   readOnlyExt,
   themeExt,
   languageExt,
+  lineNumberExt,
+  syntaxHighlightExt,
   blameExtensions,
   pushOwnership,
   setOwnership,
 } from './ide-editor-extensions'
 import type { LineOwnership } from './keeper-line-ownership-store'
 
-function createTestView(extensions: ReturnType<typeof readOnlyExt>[]) {
+function createTestView(extensions: Extension[], doc = 'hello\nworld\n') {
   const container = document.createElement('div')
   document.body.appendChild(container)
-  const state = EditorState.create({ doc: 'hello\nworld\n', extensions })
+  const state = EditorState.create({ doc, extensions })
   const view = new EditorView({ state, parent: container })
   return { view, container }
 }
@@ -35,6 +37,25 @@ describe('themeExt', () => {
     expect(ext).toBeDefined()
     const { view, container } = createTestView([ext])
     expect(view.dom).toBeInstanceOf(HTMLElement)
+    view.destroy()
+    container.remove()
+  })
+})
+
+describe('lineNumberExt + syntaxHighlightExt', () => {
+  it('renders line numbers and syntax highlight spans', async () => {
+    const lang = await languageExt('index.ts')
+    const { view, container } = createTestView([
+      themeExt(),
+      lineNumberExt(),
+      syntaxHighlightExt(),
+      lang,
+    ], 'const answer = 42\n')
+
+    expect(container.querySelector('.cm-lineNumbers')).not.toBeNull()
+    expect(container.querySelectorAll('.cm-lineNumbers .cm-gutterElement').length).toBeGreaterThan(0)
+    expect(container.querySelector('.cm-line span')).not.toBeNull()
+
     view.destroy()
     container.remove()
   })
@@ -76,8 +97,8 @@ describe('pushOwnership + setOwnership effect', () => {
     const { view, container } = createTestView(exts)
 
     const ownership = new Map([
-      [1, { keeper_id: 'alpha', hue_index: 0, last_edit_kind: 'write', last_edit_ms: Date.now() }],
-      [2, { keeper_id: 'beta', hue_index: 1, last_edit_kind: 'edit', last_edit_ms: Date.now() }],
+      [1, { keeper_id: 'alpha', hue_index: 1, last_edit_kind: 'edit', last_edit_ms: Date.now() }],
+      [2, { keeper_id: 'beta', hue_index: 2, last_edit_kind: 'create', last_edit_ms: Date.now() }],
     ]) as ReadonlyMap<number, LineOwnership>
 
     expect(() => pushOwnership(view, ownership)).not.toThrow()
@@ -87,10 +108,28 @@ describe('pushOwnership + setOwnership effect', () => {
     container.remove()
   })
 
+  it('renders keeper sigil and name markers in the blame gutter', () => {
+    const exts = [themeExt(), readOnlyExt(), ...blameExtensions()]
+    const { view, container } = createTestView(exts)
+
+    const ownership = new Map([
+      [1, { keeper_id: 'alpha-keeper', hue_index: 3, last_edit_kind: 'edit', last_edit_ms: 1000 }],
+    ]) as ReadonlyMap<number, LineOwnership>
+
+    pushOwnership(view, ownership)
+
+    expect(container.querySelector('.cm-blame-marker')).not.toBeNull()
+    expect(container.querySelector('.cm-blame-sigil')?.textContent).toBe('AK')
+    expect(container.querySelector('.cm-blame-name')?.textContent).toBe('alpha-keeper')
+
+    view.destroy()
+    container.remove()
+  })
+
   it('setOwnership effect carries the ownership map', () => {
     const ownership = new Map([
-      [1, { keeper_id: 'gamma', hue_index: 2, last_edit_kind: 'write', last_edit_ms: 1000 }],
-    ]) as unknown as ReadonlyMap<number, LineOwnership>
+      [1, { keeper_id: 'gamma', hue_index: 2, last_edit_kind: 'edit', last_edit_ms: 1000 }],
+    ]) as ReadonlyMap<number, LineOwnership>
     const effect = (setOwnership as any).of(ownership)
     expect((effect as any).is(setOwnership)).toBe(true)
     expect((effect as any).value).toBe(ownership)

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -1,6 +1,8 @@
-import { EditorView, GutterMarker, gutter } from '@codemirror/view'
+import { EditorView, GutterMarker, gutter, lineNumbers, type ViewUpdate } from '@codemirror/view'
 import { Annotation, EditorState, Extension, StateField, StateEffect } from '@codemirror/state'
+import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import type { LineOwnership } from './keeper-line-ownership-store'
+import { kSigil } from '../keeper-badge'
 
 // ── Read-only lock ────────────────────────────────────────────────
 // Prevents all user input. CM6 6.x uses EditorState.changeFilter.
@@ -25,10 +27,16 @@ export function themeExt(): Extension {
       fontFamily: 'var(--font-mono)',
       fontSize: 'var(--fs-13)',
       lineHeight: '1.6',
+      height: '100%',
+    },
+    '.cm-scroller': {
+      overflow: 'auto',
+      minHeight: '0',
     },
     '.cm-content': {
       caretColor: 'transparent',
       padding: 'var(--sp-2) 0',
+      minHeight: '100%',
     },
     '.cm-line': {
       padding: '0 var(--sp-3)',
@@ -38,11 +46,55 @@ export function themeExt(): Extension {
       color: 'var(--color-fg-disabled)',
       border: 'none',
       fontSize: 'var(--fs-11)',
-      minWidth: '40px',
+      minWidth: '44px',
+      position: 'sticky',
+      left: '0',
+      zIndex: '2',
     },
     '.cm-gutterElement': {
       textAlign: 'right',
       paddingRight: 'var(--sp-2)',
+    },
+    '.cm-lineNumbers': {
+      borderRight: '1px solid var(--color-border-default)',
+    },
+    '.cm-blame-gutter': {
+      minWidth: '78px',
+      borderRight: '1px solid var(--color-border-default)',
+      background: 'var(--color-bg-surface)',
+    },
+    '.cm-blame-gutter .cm-gutterElement': {
+      padding: '0 var(--sp-2)',
+      textAlign: 'left',
+    },
+    '.cm-blame-marker': {
+      display: 'inline-grid',
+      gridTemplateColumns: '18px minmax(0, 1fr)',
+      alignItems: 'center',
+      gap: 'var(--sp-1)',
+      width: '68px',
+      minWidth: '0',
+      color: 'var(--cm-blame-color)',
+      fontSize: 'var(--fs-10)',
+      lineHeight: '1.4',
+    },
+    '.cm-blame-sigil': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '16px',
+      height: '14px',
+      borderRadius: 'var(--r-0)',
+      color: 'var(--color-bg-page)',
+      background: 'var(--cm-blame-color)',
+      fontSize: 'var(--fs-9)',
+      fontWeight: '700',
+      letterSpacing: '0',
+    },
+    '.cm-blame-name': {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
     },
     '&.cm-focused': {
       outline: 'none',
@@ -54,6 +106,10 @@ export function themeExt(): Extension {
       background: 'transparent !important',
     },
   })
+}
+
+export function syntaxHighlightExt(): Extension {
+  return syntaxHighlighting(defaultHighlightStyle, { fallback: true })
 }
 
 // ── Blame gutter ──────────────────────────────────────────────────
@@ -79,15 +135,19 @@ class BlameMarker extends GutterMarker {
       el.style.fontSize = 'var(--fs-11)'
       return el
     }
-    const color = `var(--color-keeper-${this.info.hueIndex}-glow, var(--k-${this.info.hueIndex}))`
-    el.textContent = this.info.keeperId
+    const slot = Math.min(12, Math.max(1, this.info.hueIndex || 1))
+    const color = `var(--color-keeper-${slot}, var(--k-${slot}))`
+    el.className = 'cm-blame-marker'
+    el.style.setProperty('--cm-blame-color', color)
     el.title = `${this.info.keeperId} · ${this.info.editKind}`
-    el.style.color = color
-    el.style.fontSize = 'var(--fs-11)'
-    el.style.maxWidth = '80px'
-    el.style.overflow = 'hidden'
-    el.style.textOverflow = 'ellipsis'
-    el.style.whiteSpace = 'nowrap'
+    const sigil = document.createElement('span')
+    sigil.className = 'cm-blame-sigil'
+    sigil.textContent = kSigil(this.info.keeperId)
+    sigil.setAttribute('aria-hidden', 'true')
+    const name = document.createElement('span')
+    name.className = 'cm-blame-name'
+    name.textContent = this.info.keeperId
+    el.append(sigil, name)
     return el
   }
 
@@ -136,6 +196,9 @@ function blameGutterExt(): Extension {
     blameMarkerField,
     gutter({
       class: 'cm-blame-gutter',
+      lineMarkerChange(update: ViewUpdate) {
+        return update.startState.field(blameMarkerField, false) !== update.state.field(blameMarkerField, false)
+      },
       lineMarker(view, block) {
         const line = view.state.doc.lineAt(block.from)
         const field = view.state.field(blameMarkerField, false)
@@ -204,7 +267,7 @@ export async function languageExt(filePath: string): Promise<Extension> {
 // ── Line number gutter ────────────────────────────────────────────
 
 export function lineNumberExt(): Extension {
-  return []
+  return lineNumbers()
 }
 
 // ── Blame mode extensions bundle ──────────────────────────────────

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -37,6 +37,7 @@ describe('IdeEditor', () => {
     await waitFor(() => {
       expect(container.querySelector('.cm-content')).not.toBeNull()
     })
+    expect(container.querySelector('.cm-lineNumbers')).not.toBeNull()
     expect(container.querySelector('.cm-content')?.textContent).toBe('')
 
     documentStore.load({

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -14,12 +14,15 @@ import {
   readOnlyExt,
   themeExt,
   languageExt,
+  lineNumberExt,
   blameExtensions,
   keeperLineSelectExt,
   pushOwnership,
   internalDocumentSync,
+  syntaxHighlightExt,
 } from './ide-editor-extensions'
 import { SplitDiffView, UnifiedDiffView } from './ide-diff-view'
+import { KeeperBadge } from '../keeper-badge'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -157,6 +160,8 @@ function CodeMirrorEditor({
         extensions: [
           readOnlyExt(),
           themeExt(),
+          lineNumberExt(),
+          syntaxHighlightExt(),
           lang,
           ...(onKeeperLineSelect
             ? [keeperLineSelectExt(() => ownershipStore.ownership(), onKeeperLineSelect)]
@@ -214,9 +219,9 @@ function CodeMirrorEditor({
   useEffect(() => ownershipStore.subscribe(() => forceRender(n => n + 1)), [ownershipStore])
 
   return html`
-    <div style=${{ display: 'grid', gridTemplateRows: showBlame ? 'auto 1fr' : '1fr', minHeight: 0 }}>
+    <div class="ide-codemirror-shell" data-view=${showBlame ? 'blame' : 'source'}>
       ${showBlame ? BlameTimeline(ownership, keepers) : null}
-      <div ref=${containerRef} style=${{ overflow: 'auto', minHeight: 0 }} />
+      <div ref=${containerRef} class="ide-codemirror-host" />
     </div>
   `
 }
@@ -238,26 +243,26 @@ function BlameTimeline(
   keepers: ReadonlyArray<string>,
 ) {
   const latestEdit = latestEditMs(ownership)
+  const stats = keeperOwnershipStats(ownership, keepers)
   return html`
     <div
+      class="ide-blame-timeline"
       role="status"
       aria-label="Blame timeline"
-      style=${{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 'var(--sp-2)',
-        padding: 'var(--sp-2) var(--sp-3)',
-        borderBottom: '1px solid var(--color-border-divider)',
-        color: 'var(--color-fg-muted)',
-        background: 'var(--color-bg-surface)',
-        fontSize: 'var(--fs-11)',
-      }}
     >
-      <span style=${{ font: 'var(--type-eyebrow)', color: 'var(--color-fg-primary)' }}>Blame timeline</span>
-      <span>${keepers.join(' / ')}</span>
-      <span style=${{ marginLeft: 'auto', color: 'var(--color-fg-secondary)' }}>
-        latest ${latestEdit === null ? 'no edits' : formatTime(latestEdit)}
+      <span class="ide-blame-title">BLAME</span>
+      <span class="ide-blame-summary">${ownership.size} owned lines</span>
+      <span class="ide-blame-keepers">
+        ${stats.length > 0
+          ? stats.map(stat => html`
+              <span class="ide-blame-keeper" title=${`${stat.keeper}: ${stat.lines} lines`}>
+                <${KeeperBadge} id=${stat.keeper} variant="sigil" size="sm" />
+                <span>${stat.lines}</span>
+              </span>
+            `)
+          : html`<span class="ide-blame-empty">no keeper edits</span>`}
       </span>
+      <span class="ide-blame-latest">latest ${latestEdit === null ? 'no edits' : formatTime(latestEdit)}</span>
     </div>
   `
 }
@@ -321,6 +326,22 @@ function latestEditMs(ownership: ReadonlyMap<number, LineOwnership>): number | n
     if (latest === null || owner.last_edit_ms > latest) latest = owner.last_edit_ms
   }
   return latest
+}
+
+function keeperOwnershipStats(
+  ownership: ReadonlyMap<number, LineOwnership>,
+  keepers: ReadonlyArray<string>,
+): ReadonlyArray<{ keeper: string; lines: number }> {
+  const counts = new Map<string, number>()
+  for (const owner of ownership.values()) {
+    counts.set(owner.keeper_id, (counts.get(owner.keeper_id) ?? 0) + 1)
+  }
+  for (const keeper of keepers) {
+    if (!counts.has(keeper)) counts.set(keeper, 0)
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([keeper, lines]) => ({ keeper, lines }))
 }
 
 function formatTime(ms: number): string {

--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -38,11 +38,11 @@ export function IdeInterjectMock() {
 
   return html`
     <div
+      class="ide-interject-bar"
       role="region"
       aria-label="INTERJECT (interject store active keeper wiring)"
       style=${{
         display: 'grid',
-        gridTemplateColumns: 'auto 1fr auto',
         gap: 'var(--sp-2)',
         padding: 'var(--sp-2) var(--sp-3)',
         background: 'var(--color-bg-elevated)',
@@ -66,6 +66,7 @@ export function IdeInterjectMock() {
         </span>
       </div>
       <input
+        class="ide-interject-input"
         type="text"
         placeholder="Send message to active keeper..."
         aria-label="Interject input"
@@ -83,7 +84,7 @@ export function IdeInterjectMock() {
           font: 'var(--type-body)',
         }}
       />
-      <div style=${{ display: 'flex', gap: 'var(--sp-1)' }}>
+      <div class="ide-interject-actions" style=${{ display: 'flex', gap: 'var(--sp-1)' }}>
         ${actions.map(action => InterjectButton(action, () => {
           void interjectStore.submit(action.kind)
         }))}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,6 +1,5 @@
-import { signal } from '@preact/signals'
-export const activeIdeFile = signal<string>('package.json')
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { createIdeDataCoordinator } from './ide-data-coordinator'
 import { IdeExplorer } from './ide-explorer'
@@ -12,7 +11,6 @@ import { KeeperShellDrawer } from './keeper-shell-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
 import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { InspectorKeeperBDI, pinInspectorKeeper } from './inspector-keeper-bdi'
-import { WorldVisualizer } from '../world-visualizer'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
@@ -20,6 +18,8 @@ import {
   parseActive,
   serializeActive,
 } from '../../../design-system/headless-core/layered-overlay'
+
+export const activeIdeFile = signal<string>('package.json')
 
 type ViewTab = IdeEditorView
 const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
@@ -93,36 +93,19 @@ export function IdeShell() {
       class="ide-plane-shell"
       role="region"
       aria-label="Code IDE shell"
-      style=${{
-        display: 'grid',
-        gridTemplateRows: terminalOpen
-          ? 'auto auto auto minmax(0, 1fr) auto auto'
-          : 'auto auto auto minmax(0, 1fr) auto',
-        background: 'var(--color-bg-page)',
-        color: 'var(--color-fg-primary)',
-        minHeight: 'calc(100vh - var(--h-topbar) - var(--h-kpi))',
-      }}
+      data-terminal-open=${terminalOpen ? 'true' : 'false'}
     >
       <header
-        style=${{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--sp-3)',
-          padding: 'var(--sp-2) var(--sp-3)',
-          background: 'var(--color-bg-surface)',
-          borderBottom: '1px solid var(--color-border-default)',
-          font: 'var(--type-eyebrow)',
-          color: 'var(--color-fg-muted)',
-        }}
+        class="ide-plane-statusbar"
       >
-        <span style=${{ color: 'var(--color-fg-secondary)' }}>MASC IDE</span>
+        <span class="ide-plane-statusbar-title">MASC IDE</span>
         <span>·</span>
         <span
           class="chip sm is-brass"
           style=${{ flexShrink: 0 }}
         >LIVE WORKSPACE</span>
         <${IdePresenceStrip} />
-        <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok)' }}>● mcp · connected</span>
+        <span class="ide-plane-connection">● mcp · connected</span>
       </header>
       <${IdeToolbar}
         activeView=${activeView}
@@ -130,15 +113,9 @@ export function IdeShell() {
         onViewChange=${handleViewChange}
         onLayersChange=${handleLayersChange}
       />
-      <div class="border-b border-solid border-[var(--color-border-divider)]">
-        <${WorldVisualizer} />
-      </div>
       <div
         class="ide-plane-grid"
         role="presentation"
-        style=${{
-          minHeight: 0,
-        }}
       >
         <div class="ide-plane-tree">
           <${IdeExplorer}
@@ -154,11 +131,6 @@ export function IdeShell() {
         </div>
         <div
           class="ide-plane-editor"
-          style=${{
-            display: 'grid',
-            gridTemplateRows: 'minmax(280px, 1fr) minmax(260px, 38vh)',
-            minHeight: 0,
-          }}
         >
           <${IdeEditor}
             activeView=${activeView}

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -61,8 +61,16 @@ export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersCha
       class="ide-toolbar"
       role="toolbar"
       aria-label="IDE editor toolbar"
+      style=${{
+        display: 'grid',
+        alignItems: 'center',
+        gap: 'var(--sp-3)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        background: 'var(--color-bg-surface)',
+      }}
     >
-      <div class="ide-view-tabs" role="tablist" aria-label="View mode">
+      <div class="ide-toolbar-tabs" role="tablist" aria-label="View mode" style=${{ display: 'flex', gap: 'var(--sp-2)' }}>
         ${VIEW_TABS.map(tab => html`
           <button
             type="button"
@@ -82,10 +90,17 @@ export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersCha
           >${tab.label}</button>
         `)}
       </div>
-      <span aria-hidden="true" />
+      <span class="ide-toolbar-spacer" aria-hidden="true" />
       <div
-        class="ide-layer-picker"
+        class="ide-toolbar-layers"
         aria-label="Layers (multi-select)"
+        style=${{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--sp-2)',
+          color: 'var(--color-fg-muted)',
+          font: 'var(--type-eyebrow)',
+        }}
       >
         <span>LAYERS</span>
         ${IDE_LAYERS.map(layer => html`

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -89,12 +89,14 @@ describe('ConfigResolutionPanel', () => {
         }}
         runtimeResolution=${{
           status: 'warn',
-          warnings: ['Runtime build commit (deadbee) differs from workspace HEAD (cafef00d).'],
+          warnings: ['Runtime build commit (deadbee) differs from server repo HEAD (feedbee).'],
           base_path: { path: '/tmp/runtime-input', exists: true, source: 'input' },
           workspace_path: { path: '/tmp/workspace', exists: true, source: 'workspace' },
           resolved_base_path: { path: '/tmp/workspace', exists: true, source: 'resolved_base' },
           data_root: { path: '/tmp/workspace/.masc', exists: true, source: 'runtime_data' },
           prompt_markdown_dir: { path: '/tmp/shared/prompts', exists: true, source: 'prompt_registry' },
+          server_repo_path: { path: '/tmp/masc-mcp', exists: true, source: 'server_binary' },
+          server_repo_git_commit: 'feedbee',
           workspace_git_commit: 'cafef00d',
           resolved_base_git_commit: 'cafef00d',
           source_mismatch: true,
@@ -145,9 +147,12 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('invalid env')
     expect(container.textContent).toContain('/tmp/workspace/.masc')
     expect(container.textContent).toContain('/tmp/shared/prompts')
+    expect(container.textContent).toContain('/tmp/masc-mcp')
+    expect(container.textContent).toContain('server repo head')
+    expect(container.textContent).toContain('feedbee')
     expect(container.textContent).toContain('source mismatch')
     expect(container.textContent).toContain('SIGTERM')
-    expect(container.textContent).toContain('Runtime build commit (deadbee) differs from workspace HEAD (cafef00d).')
+    expect(container.textContent).toContain('Runtime build commit (deadbee) differs from server repo HEAD (feedbee).')
     expect(container.textContent).toContain('ollama warm / kv probe')
     expect(container.textContent).toContain('kv likely reused')
     expect(container.textContent).toContain('qwen3.5:35b-a3b-coding-nvfp4')

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -609,9 +609,13 @@ export function ConfigResolutionPanel({
                 <${ConfigRow} label="resolved base path" item=${runtimeResolution.resolved_base_path} />
                 <${ConfigRow} label="data root" item=${runtimeResolution.data_root} />
                 <${ConfigRow} label="prompt markdown dir" item=${runtimeResolution.prompt_markdown_dir} />
+                ${runtimeResolution.server_repo_path
+                  ? html`<${ConfigRow} label="server repo" item=${runtimeResolution.server_repo_path} />`
+                  : null}
               </div>
 
               <div class="mt-4 grid gap-3 md:grid-cols-2">
+                <${RuntimeMetaRow} label="server repo head" value=${runtimeResolution.server_repo_git_commit ?? '--'} />
                 <${RuntimeMetaRow} label="workspace head" value=${runtimeResolution.workspace_git_commit ?? '--'} />
                 <${RuntimeMetaRow} label="resolved base head" value=${runtimeResolution.resolved_base_git_commit ?? '--'} />
                 <${RuntimeMetaRow} label="runtime build" value=${runtimeResolution.build.commit ?? runtimeResolution.build.release_version} />

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -564,6 +564,8 @@ export function normalizeDashboardRuntimeResolution(
     resolved_base_path: resolvedBasePath,
     data_root: dataRoot,
     prompt_markdown_dir: promptMarkdownDir,
+    server_repo_path: normalizeDashboardConfigResolutionItem(raw.server_repo_path),
+    server_repo_git_commit: asString(raw.server_repo_git_commit) ?? null,
     workspace_git_commit: asString(raw.workspace_git_commit) ?? null,
     resolved_base_git_commit: asString(raw.resolved_base_git_commit) ?? null,
     source_mismatch: asBoolean(raw.source_mismatch) ?? false,

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -250,15 +250,72 @@
 }
 
 /* ── IDE Plane Shell ── */
+.ide-plane-shell {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
+}
+
+.ide-plane-shell[data-terminal-open="true"] {
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+}
+
+.ide-plane-statusbar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  min-width: 0;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-default);
+  color: var(--color-fg-muted);
+  font: var(--type-eyebrow);
+}
+
+.ide-plane-statusbar-title {
+  color: var(--color-fg-secondary);
+}
+
+.ide-plane-connection {
+  margin-left: auto;
+  color: var(--color-status-ok);
+  white-space: nowrap;
+}
+
 .ide-toolbar {
   display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+  grid-template-columns: max-content minmax(1rem, 1fr) max-content;
   align-items: center;
   gap: var(--sp-3);
   padding: var(--sp-2) var(--sp-3);
   border-bottom: 1px solid var(--color-border-divider);
   background: var(--color-bg-surface);
   min-width: 0;
+  overflow: hidden;
+}
+
+.ide-toolbar-tabs,
+.ide-toolbar-layers {
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-default) transparent;
+  white-space: nowrap;
+}
+
+.ide-toolbar-tabs {
+  min-height: 2.25rem;
+}
+
+.ide-toolbar-layers {
+  justify-content: flex-end;
+  min-height: 2.25rem;
 }
 
 .ide-view-tabs,
@@ -286,35 +343,279 @@
   font: var(--type-eyebrow);
 }
 
+
 .ide-plane-grid {
   display: grid;
-  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr) minmax(280px, 320px);
-  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(200px, 248px) minmax(420px, 1fr) minmax(320px, 380px);
+  grid-template-rows: minmax(0, 1fr) minmax(180px, 32%);
+  height: 100%;
+  min-height: 0;
   min-width: 0;
+  overflow: hidden;
 }
 
 .ide-plane-tree {
   grid-column: 1;
   grid-row: 1 / span 2;
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .ide-plane-editor {
   grid-column: 2;
   grid-row: 1 / span 2;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-right: 1px solid var(--color-border-default);
 }
 
 .ide-plane-conversation {
   grid-column: 3;
   grid-row: 1;
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .ide-plane-activity {
   grid-column: 3;
   grid-row: 2;
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-top: 1px solid var(--color-border-divider);
+}
+
+.ide-rail-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  background: var(--color-bg-surface);
+}
+
+.ide-rail-head {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--color-fg-muted);
+  font: var(--type-eyebrow);
+  border-bottom: 1px solid var(--color-border-divider);
+  background: color-mix(in srgb, var(--color-bg-surface) 96%, black);
+}
+
+.ide-rail-scope {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--color-border-default);
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
+.ide-rail-scope > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-rail-list {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  list-style: none;
+  margin: 0;
+  padding: var(--sp-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-default) transparent;
+}
+
+.ide-rail-item,
+.ide-activity-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 72px;
+}
+
+.ide-rail-empty {
+  min-height: 7rem;
+  display: grid;
+  place-items: center;
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--r-1);
+  color: var(--color-fg-muted);
+  font: var(--type-eyebrow);
+}
+
+.ide-conversation-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  width: 100%;
+  padding: var(--sp-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--ide-conversation-bg, var(--color-bg-elevated));
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ide-conversation-card:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-border-strong);
+}
+
+.ide-conversation-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.ide-conversation-body {
+  margin: 0;
+  color: var(--color-fg-secondary);
+  font: var(--type-body);
+  line-height: var(--lh-body);
+  overflow-wrap: anywhere;
+}
+
+.ide-activity-list {
+  gap: var(--sp-1);
+}
+
+.ide-activity-row {
+  display: grid;
+  grid-template-columns: 52px 8px minmax(0, 1fr);
+  gap: var(--sp-2);
+  align-items: baseline;
+  padding: 4px 6px;
+  color: var(--color-fg-secondary);
+  font: var(--type-body);
+}
+
+.ide-activity-time {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-11);
+}
+
+.ide-activity-dot {
+  width: 6px;
+  height: 6px;
+  align-self: center;
+  border-radius: 50%;
+  background: var(--ide-activity-dot);
+}
+
+.ide-codemirror-shell {
+  display: grid;
+  grid-template-rows: 1fr;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ide-codemirror-shell[data-view="blame"] {
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.ide-codemirror-host {
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ide-codemirror-host .cm-editor {
+  height: 100%;
+}
+
+.ide-blame-timeline {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--color-border-divider);
+  color: var(--color-fg-muted);
+  background: color-mix(in srgb, var(--color-bg-surface) 96%, black);
+  font-size: var(--fs-11);
+}
+
+.ide-blame-title {
+  color: var(--color-fg-primary);
+  font: var(--type-eyebrow);
+}
+
+.ide-blame-summary,
+.ide-blame-latest {
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+}
+
+.ide-blame-keepers {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ide-blame-keeper {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 4px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-elevated);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
+.ide-blame-empty {
+  color: var(--color-fg-muted);
+}
+
+.ide-blame-latest {
+  margin-left: auto;
+}
+
+.ide-interject-bar {
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
+  min-width: 0;
+}
+
+.ide-interject-input {
+  min-width: 0;
+}
+
+.ide-interject-actions {
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-default) transparent;
 }
 
 @media (max-width: 1180px) {
@@ -331,7 +632,7 @@
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
   .ide-plane-shell {
     min-width: 0;
     overflow: hidden;
@@ -339,7 +640,8 @@
 
   .ide-plane-grid {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto auto auto auto;
+    grid-template-rows: minmax(10rem, 18rem) minmax(26rem, 1fr) minmax(12rem, 18rem) minmax(10rem, 16rem);
+    overflow: auto;
   }
 
   .ide-plane-tree,
@@ -353,11 +655,43 @@
   .ide-plane-tree,
   .ide-plane-conversation,
   .ide-plane-activity {
-    max-height: 22rem;
-    overflow: auto;
+    overflow: hidden;
   }
 
   .ide-plane-editor {
-    overflow-x: auto;
+    overflow: hidden;
+  }
+}
+
+@media (max-width: 640px) {
+  .ide-plane-statusbar {
+    flex-wrap: wrap;
+  }
+
+  .ide-plane-connection {
+    margin-left: 0;
+  }
+
+  .ide-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--sp-2);
+    overflow: hidden;
+  }
+
+  .ide-toolbar-spacer {
+    display: none;
+  }
+
+  .ide-toolbar-layers {
+    justify-content: flex-start;
+  }
+
+  .ide-interject-bar {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+
+  .ide-interject-actions {
+    width: 100%;
   }
 }

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -107,6 +107,8 @@ export interface DashboardRuntimeResolution {
   resolved_base_path: DashboardConfigResolutionItem
   data_root: DashboardConfigResolutionItem
   prompt_markdown_dir: DashboardConfigResolutionItem
+  server_repo_path?: DashboardConfigResolutionItem | null
+  server_repo_git_commit?: string | null
   workspace_git_commit: string | null
   resolved_base_git_commit: string | null
   source_mismatch: boolean

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -139,7 +139,6 @@ persona_name = "analyst"
 | `name` | Optional | Override keeper handle | Usually redundant because filename is already the keeper name. |
 | `sandbox_profile` | Optional | Process/filesystem sandbox profile | `local` runs on the host with fs scoped to the keeper playground. `docker` runs in a hardened ephemeral container; the basic-mode git/gh dispatcher can upgrade network+credential mounts per-command. Hard mode requires `docker`. |
 | `network_mode` | Optional | Sandbox network policy | `docker` defaults to `none` (basic-mode git/gh dispatcher can promote to `inherit`); `local` defaults to `inherit`. Hard mode requires `none`. |
-| `shared_memory_scope` | Optional | Typed shared-memory lane | `room` enables keeper-authorized `masc_team_memory_*` exchange on the flattened `default` namespace. |
 | `cascade_name` | Optional | Deployment-specific cascade override | Only when not using the default cascade. |
 | `tool_preset` | Optional | Deployment-specific policy override | Only when intentionally overriding persona default. |
 | `github_identity` | Optional | Bound GitHub CLI identity bundle | Resolves to `.masc/github-identities/<identity>/gh` for keeper-scoped `gh` auth. Required when `MASC_KEEPER_SANDBOX_HARD_MODE=true`. |
@@ -180,27 +179,23 @@ Enumerated fields only accept the values below. The loader rejects invalid input
 | --- | --- |
 | `sandbox_profile` | `local`, `docker` |
 | `network_mode` | `none`, `inherit` |
-| `shared_memory_scope` | `disabled`, `room` |
 | `git_identity_mode` | `keeper_alias`, `github_identity` |
 | `tool_preset` | `minimal`, `social`, `messaging`, `coding`, `research`, `delivery`, `full` |
 | `social_model` | `bdi_speech_v1`, `magentic_ledger_v1` (non-public: rejected when passed via tool args; TOML-only) |
 | `cascade_name` | any `<name>` such that `<name>_models` exists in `cascade.json` (e.g. `keeper_unified`, `nick0cave`) |
 
-### Sandbox + Shared Memory Example
+### Sandbox Example
 
 ```toml
 [keeper]
 persona_name = "analyst"
 sandbox_profile = "docker"
 network_mode = "none"
-shared_memory_scope = "room"
-tool_also_allow = ["masc_team_memory_read", "masc_team_memory_write", "masc_team_memory_search"]
 ```
 
 Operational intent:
 
 - private writable lane: the keeper sandbox. The current local/docker storage path is `.masc/playground/<keeper>/...`, but keeper tools should use sandbox-relative paths such as `repos/<repo>` and `mind/<file>`.
-- shared lane: `masc_team_memory_read/write/search` only, on flattened `room="default"`
 - no arbitrary shared writable shell directory
 - `sandbox_profile=docker`는 `allowed_paths=["*"]`를 거부하고, private sandbox root 밖 경로도 허용하지 않는다
 - `github_identity`가 설정된 keeper는 `.masc/github-identities/<identity>/gh`만 사용하고, bundle이 없으면 fail-closed 된다. operator 개인 `gh` config, ambient `GH_TOKEN`/`GITHUB_TOKEN`, SSH agent로는 fallback 하지 않는다.

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -279,7 +279,6 @@ spawn 시 인자로 직접 설정하는 필드.
 | `verify` | bool | `false` | 저비용 모델로 action 검증 | `masc_keeper_up`의 `verify` 인자 |
 | `sandbox_profile` | string | `local` | 실행 샌드박스 프로필 (`local`, `docker`). 기본 모드의 `docker` 프로필은 git/gh 명령에 대해서만 런타임에 network+credential 마운트를 올릴 수 있다. hard mode에서는 `docker`만 허용된다. | `masc_keeper_up`의 `sandbox_profile` 인자 |
 | `network_mode` | string | `inherit` 또는 `none` | 샌드박스 네트워크 정책. `docker`는 기본 `none` (기본 모드의 git/gh dispatch만 `inherit`으로 승격). hard mode에서는 `none`만 허용된다. | `masc_keeper_up`의 `network_mode` 인자 |
-| `shared_memory_scope` | string | `disabled` | typed shared-memory lane. `room`이면 keeper-authorized `masc_team_memory_*`를 flattened `default` namespace에서 사용 가능 | `masc_keeper_up`의 `shared_memory_scope` 인자 |
 | `github_identity` | string | 없음 | keeper에 바인딩된 GitHub CLI identity 이름. `.masc/github-identities/<identity>/gh` bundle을 사용한다. | `keeper.toml` 선언 |
 | `git_identity_mode` | string | `keeper_alias` | git author를 keeper alias로 유지할지, GitHub identity 기반 author로 결합할지 결정 | `keeper.toml` 선언 |
 | `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task를 우선 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 전체 claimable task로 fallback | `keeper.toml` 선언 |
@@ -294,8 +293,7 @@ spawn 시 인자로 직접 설정하는 필드.
   "goal": "Review incoming issues and prepare safe changes",
   "sandbox_profile": "docker",
   "network_mode": "none",
-  "shared_memory_scope": "room",
-  "tool_access": { "kind": "preset", "preset": "coding", "also_allow": ["masc_team_memory_read", "masc_team_memory_write", "masc_team_memory_search"] }
+  "tool_access": { "kind": "preset", "preset": "coding" }
 }
 ```
 
@@ -309,9 +307,6 @@ spawn 시 인자로 직접 설정하는 필드.
 - hard mode runtime preflight는 Docker `SecurityOptions`에서 `rootless`와 `userns`를 모두 요구한다. 현재 Docker Desktop/rootful daemon처럼 둘 중 하나라도 없으면 `doctor`와 keeper startup에서 fail-closed 된다.
 - 기본 sandbox 이미지는 `masc-keeper-sandbox:local`이다. Docker keeper를 올리기 전에 `scripts/build-keeper-sandbox-image.sh`를 실행해 이미지를 만들고, smoke 검증은 `scripts/keeper-sandbox-smoke.sh`를 사용한다.
 - keeper Docker 컨테이너에는 `masc.mcp.component=keeper-sandbox`와 base path hash 라벨이 붙는다. 새 컨테이너 시작 전 같은 base path 범위의 오래된 MASC keeper 컨테이너만 best-effort로 정리한다. 조정값은 `MASC_KEEPER_SANDBOX_CLEANUP_ENABLED`, `MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC`, `MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC`이다.
-- `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.
-- team memory 도구는 keeper tool surface에도 노출되어야 하므로 preset에 없다면 `tool_also_allow` 또는 `tool_access.also_allow`로 명시해야 한다.
-
 ### 3.1.2 GitHub identity 운영 절차
 
 `github_identity`는 현재 대시보드의 일반 설정 화면에서 수정하는 필드가 아니라 active config root의 `keeper.toml` overlay가 SSOT다. 대시보드에서 찾지 못하면 먼저 active config root를 확인하고 파일을 수정한다.
@@ -362,8 +357,6 @@ sandbox_profile = "docker"
 network_mode = "none"
 github_identity = "anyang-keepers"
 git_identity_mode = "github_identity"
-shared_memory_scope = "room"
-tool_also_allow = ["masc_team_memory_read", "masc_team_memory_write", "masc_team_memory_search"]
 ```
 
 ```bash
@@ -375,19 +368,9 @@ masc-mcp doctor config
 
 References: https://docs.docker.com/engine/security/rootless/ , https://docs.docker.com/engine/security/userns-remap/ , https://cli.github.com/manual/gh_help_environment , https://gvisor.dev/docs/
 
-typed team memory 사용 예시:
-
-```text
-masc_team_memory_write(room="default", key="handoff/summary.md", content="현재 상황 요약...")
-masc_team_memory_read(room="default", key="handoff/summary.md")
-masc_team_memory_search(room="default", query="요약")
-```
-
 guardrail:
 
 - path traversal / symlink escape는 차단된다.
-- secret-like payload는 team memory write에서 차단된다.
-- team memory는 keeper context에서만 허용되고, `room`은 항상 `default`여야 한다.
 - `sandbox_profile=local`은 `network_mode=none`을 허용하지 않는다. `none`은 `sandbox_profile=docker`와 함께 써야 한다.
 
 ### 3.1.2 Legendary Bash 도구 표면
@@ -911,8 +894,8 @@ materialize될 수 있지만, 정식 edit surface는 `profile.json`과 `keeper.t
 [`docs/KEEPER-FILE-MODEL.md` §2 Keeper Declaration](./KEEPER-FILE-MODEL.md#2-keeper-declaration)을 참조한다. 요약:
 
 - **Canonical minimal**: `[keeper]` 테이블에 `persona_name`만. 나머지는 persona 기본값에서 해석.
-- **Overlay fields**: `goal`, `tool_preset`, `tool_also_allow`, `cascade_name`, `sandbox_profile`, `network_mode`, `shared_memory_scope`, `github_identity`, `git_identity_mode`, `active_goal_ids` 등 배치별 override 전용.
-- **Allowed value sets**: `tool_preset ∈ {minimal, social, messaging, coding, research, delivery, full}`, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `shared_memory_scope ∈ {disabled, room}`, `git_identity_mode ∈ {keeper_alias, github_identity}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `cascade_name`은 `cascade.json`에 `<name>_models` 키로 존재해야 함.
+- **Overlay fields**: `goal`, `tool_preset`, `tool_also_allow`, `cascade_name`, `sandbox_profile`, `network_mode`, `github_identity`, `git_identity_mode`, `active_goal_ids` 등 배치별 override 전용.
+- **Allowed value sets**: `tool_preset ∈ {minimal, social, messaging, coding, research, delivery, full}`, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `git_identity_mode ∈ {keeper_alias, github_identity}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `cascade_name`은 `cascade.json`에 `<name>_models` 키로 존재해야 함.
 - **Removed / hard-rejected**: `also_allow` (top-level TOML alias), `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
 - **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `legacy_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
 

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -122,6 +122,7 @@ let select_public_local_worker_schemas () =
     (Tool_board.tools
     @ Tool_schemas_coord_core.schemas
     @ Tool_schemas_coord_extra.schemas
+    @ Tool_schemas_agent.schemas
     @ local_worker_code_schemas
     @ local_worker_worktree_schemas
     @ local_worker_run_schemas

--- a/lib/agent_tool_surfaces.mli
+++ b/lib/agent_tool_surfaces.mli
@@ -114,7 +114,7 @@ val local_worker_spawn_schemas : Masc_domain.tool_schema list
 val select_public_local_worker_schemas :
   unit -> Masc_domain.tool_schema list
 (** [select_public_local_worker_schemas ()] returns the union of
-    board / coord-core / coord-extra / code / worktree / run /
+    board / coord-core / coord-extra / agent / code / worktree / run /
     spawn schemas, deduped, intersected with
     {!local_worker_public_tool_names}.  This is the public local-
     worker surface as the dashboard sees it. *)

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -91,6 +91,12 @@ let probe_git_commit () =
          | Some root -> git_probe_from_root root
          | None -> None)
 
+let probe_repo_root () =
+  pick_repo_candidates
+    ~exe_dir:(executable_dir ())
+    ~cwd:(Sys.getcwd ())
+  |> List.find_map find_git_root
+
 (** Probe the unix timestamp of [commit] from the same git repo we
     resolved [commit] against.  Best-effort: returns [None] if [commit]
     is [None], the repo cannot be located, or git fails / output is
@@ -149,6 +155,10 @@ let commit =
   resolve_commit
     ~env_value:(Env_config_core.build_git_commit_opt ())
     ~probe:probe_git_commit
+
+let resolved_repo_root = probe_repo_root ()
+
+let repo_root () = resolved_repo_root
 
 let commit_unix_ts = probe_commit_unix_ts commit
 

--- a/lib/build_identity.mli
+++ b/lib/build_identity.mli
@@ -32,6 +32,11 @@ val of_yojson : Yojson.Safe.t -> (t, string) result
 val current : unit -> t
 (** Snapshot of the running build identity with current uptime. *)
 
+val repo_root : unit -> string option
+(** Git root used for the running server binary, preferring the executable
+    directory over the process cwd.  This is separate from the MASC base path,
+    which may intentionally point at a different workspace such as [~/me]. *)
+
 val resolve_commit :
   env_value:string option -> probe:(unit -> string option) -> string option
 (** Resolve commit hash from env var or probe function.

--- a/lib/keeper/keeper_admission_policy.ml
+++ b/lib/keeper/keeper_admission_policy.ml
@@ -41,12 +41,13 @@ let tier_compare a b =
   in
   Stdlib.compare (rank a) (rank b)
 
-let has_duplicate_provider candidates =
+let has_duplicate_candidate candidates =
   let rec aux seen = function
     | [] -> None
     | c :: rest ->
-        if List.mem c.provider seen then Some c.provider
-        else aux (c.provider :: seen) rest
+        let key = (c.provider, c.model) in
+        if List.mem key seen then Some c.provider
+        else aux (key :: seen) rest
   in
   aux [] candidates
 
@@ -60,7 +61,7 @@ let of_fields ~keeper_id ~candidates ~weight ~min_tier =
         if tier_compare min_tier head_candidate.tier < 0 then
           Error Min_tier_above_preferred
         else
-          match has_duplicate_provider candidates with
+          match has_duplicate_candidate candidates with
           | Some p -> Error (Duplicate_provider p)
           | None -> Ok { keeper_id; candidates; weight; min_tier }
 

--- a/lib/keeper/keeper_admission_policy.mli
+++ b/lib/keeper/keeper_admission_policy.mli
@@ -74,7 +74,9 @@ val of_fields :
     - [candidates <> []]
     - [min_tier] is not strictly above [Preferred] (i.e. [min_tier] is
       not "better than the most preferred candidate")
-    - all [candidate.provider] strings are distinct
+    - all [(candidate.provider, candidate.model)] pairs are distinct.
+      A policy may list the same provider more than once for explicit
+      model fallback within that provider.
     - [weight >= 1] (default 1; persona-level priority for WFQ) *)
 
 val parse_admission_json :

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1743,12 +1743,13 @@ let liveness_recovery_scan (ctx : _ context) =
 
     Reference timestamp: the newer of [proactive_rt.last_ts] and
     [entry.started_at] when proactive has ever fired ([> 0.0]),
-    otherwise [entry.started_at].  This preserves detection for
-    long-running frozen keepers while giving freshly restarted keepers
-    the normal boot grace even when their persisted proactive timestamp
-    is old.  The [entry.started_at] fallback also catches the
-    "never_started" case (e.g. [glm-coding-plan] in the production
-    sample) without a separate code path.
+    otherwise [entry.started_at].  Persisted proactive timestamps can
+    predate the current server lifecycle; [started_at] is the lower
+    bound for the current fiber, so a restart must not immediately mark
+    old-but-freshly-booted keepers stuck, while long-running frozen
+    keepers still trip the detector.  The [entry.started_at] fallback
+    also catches the "never_started" case (e.g. [glm-coding-plan] in the
+    production sample) without a separate code path.
 
     Returns [None] when not stuck.  Pure: no I/O, no global state. *)
 let detect_alive_but_stuck ~now ~stall_multiplier ~stall_floor_sec
@@ -1846,6 +1847,9 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
   let kill_class =
     Keeper_registry.Idle_turn { stall_seconds = elapsed }
   in
+  let current_entry =
+    Keeper_registry.get ~base_path entry.name |> Option.value ~default:entry
+  in
   (* PR #13106 review: must NOT route through
      [stale_watchdog_failure_reason], which preserves prior reasons
      like [Turn_consecutive_failures] / [Exception] / etc.  Those
@@ -1865,17 +1869,13 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
      ([Stale_turn_timeout] / [Stale_termination_storm] /
      [Oas_timeout_budget_loop]), preserve it so we don't churn the
      [stall_seconds] field on every poll. *)
-  let current_failure_reason =
-    match Keeper_registry.get ~base_path entry.name with
-    | Some current -> current.last_failure_reason
-    | None -> entry.last_failure_reason
-  in
   let prior_str =
-    Option.map Keeper_registry.failure_reason_to_string current_failure_reason
+    Option.map Keeper_registry.failure_reason_to_string
+      current_entry.last_failure_reason
     |> Option.value ~default:"none"
   in
   let reason =
-    match current_failure_reason with
+    match current_entry.last_failure_reason with
     | Some
         ( Keeper_registry.Stale_turn_timeout _
         | Keeper_registry.Stale_termination_storm _

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -112,13 +112,6 @@ let all_network_modes = [ Network_none; Network_inherit ]
 let valid_network_mode_strings =
   List.map network_mode_to_string all_network_modes
 
-let shared_memory_scope_of_string raw =
-  match String.lowercase_ascii (String.trim raw) with
-  | "disabled" | "room" as scope -> Some scope
-  | _ -> None
-
-let valid_shared_memory_scope_strings = [ "disabled"; "room" ]
-
 let default_sandbox_profile = Local
 
 let default_network_mode_for_profile = function
@@ -286,7 +279,6 @@ type keeper_profile_defaults = {
   sandbox_profile : sandbox_profile option;
   sandbox_image : string option;
   network_mode : network_mode option;
-  shared_memory_scope : string option;
   github_identity : string option;
   git_identity_mode : string option;
   tool_preset : string option;
@@ -461,7 +453,6 @@ let empty_keeper_profile_defaults = {
   sandbox_profile = None;
   sandbox_image = None;
   network_mode = None;
-  shared_memory_scope = None;
   github_identity = None;
   git_identity_mode = None;
   tool_preset = None;
@@ -773,20 +764,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   in
   let result =
     Result.bind result (fun () ->
-        match str "shared_memory_scope" with
-        | Some raw -> (
-            match shared_memory_scope_of_string raw with
-            | Some _ -> Ok ()
-            | None ->
-                Error
-                  (Printf.sprintf
-                     "invalid shared_memory_scope '%s' (allowed: %s)"
-                     raw
-                     (String.concat ", " valid_shared_memory_scope_strings)))
-        | None -> Ok ())
-  in
-  let result =
-    Result.bind result (fun () ->
         match str "cascade_name" with
         | None -> Ok ()
         | Some raw ->
@@ -906,8 +883,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         sandbox_image = str "sandbox_image";
         network_mode =
           Option.bind (str "network_mode") network_mode_of_string;
-        shared_memory_scope =
-          Option.bind (str "shared_memory_scope") shared_memory_scope_of_string;
         github_identity = str "github_identity";
         git_identity_mode =
           normalize_git_identity_mode_opt (str "git_identity_mode");
@@ -968,7 +943,6 @@ let parsed_field_key_names =
   ; "sandbox_profile"
   ; "sandbox_image"
   ; "network_mode"
-  ; "shared_memory_scope"
   ; "github_identity"
   ; "git_identity_mode"
   ; "tool_access.kind"
@@ -1023,7 +997,6 @@ let canonical_keeper_toml_key_names =
   ; "sandbox_profile"
   ; "sandbox_image"
   ; "network_mode"
-  ; "shared_memory_scope"
   ; "github_identity"
   ; "git_identity_mode"
   ; "tool_access.kind"
@@ -1171,8 +1144,6 @@ let merge_keeper_profile_defaults
     sandbox_profile = prefer overlay.sandbox_profile base.sandbox_profile;
     sandbox_image = prefer overlay.sandbox_image base.sandbox_image;
     network_mode = prefer overlay.network_mode base.network_mode;
-    shared_memory_scope =
-      prefer overlay.shared_memory_scope base.shared_memory_scope;
     github_identity = prefer overlay.github_identity base.github_identity;
     git_identity_mode =
       prefer overlay.git_identity_mode base.git_identity_mode;
@@ -1383,7 +1354,6 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 sandbox_profile = None;
                 sandbox_image = None;
                 network_mode = None;
-                shared_memory_scope = None;
                 github_identity = None;
                 git_identity_mode = None;
                 tool_preset = None;

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -42,9 +42,8 @@ let contains_casefold haystack needle =
    at [Log.Error], including normal policy/workflow rejections like
    [awaiting_approval] (governance critical-risk pending),
    [Join required] (keeper called masc_transition before masc_join),
-   [egress_blocked] (network policy denial), [path_outside_sandbox]
-   (sandbox boundary), and [team memory is disabled] (config-disabled
-   scope).  Single 24h window: 41 such events at ERROR, polluting
+   [egress_blocked] (network policy denial), and [path_outside_sandbox]
+   (sandbox boundary).  Single 24h window: 41 such events at ERROR, polluting
    alert ROC, supervisor escape-valve heuristics (#10887 SP cohort
    detection counts ERROR rate), and the dashboard red counter that
    operators use to triage genuine system errors.
@@ -58,7 +57,6 @@ let classify_tool_failure_severity error_detail : Log.level =
      || contains_casefold detail "join required"
      || contains_casefold detail "egress_blocked"
      || contains_casefold detail "path_outside_sandbox"
-     || contains_casefold detail "team memory is disabled"
   then Log.Warn
   else Log.Error
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -23,9 +23,10 @@ let provider_effective_max_turns kind requested =
   | Gemini_cli | Kimi_cli | Codex_cli ->
       requested
 
-(* #10097: codex_cli omits keeper-bound runtime MCP tools that require
-   request-scoped auth headers.  That omission is a structural provider
-   limitation, not a per-call incident:
+(* #10097: codex_cli can only expose keeper-bound runtime MCP tools when the
+   keeper has a raw bearer token that OAS can route through bearer_token_env_var.
+   Missing-token omissions are still a structural lane/auth setup issue, not a
+   per-call incident:
 
      - [WARN] emits only when an agent first sees an omitted-tool
        fingerprint, or when that agent's omitted tool set changes.
@@ -92,8 +93,8 @@ let record_codex_cli_omission_for_agent
       Log.warn ~ctx:"oas_worker_exec"
         "codex_cli omitting keeper-bound runtime MCP tool(s) that \
          require request-scoped auth headers: %s \
-         (structural provider limitation for %s; subsequent omissions \
-         of this same set are counted in \
+         (no per-keeper bearer-token lane available for %s; subsequent \
+         omissions of this same set are counted in \
          masc_codex_cli_mcp_tool_omission_total and not re-logged)"
         (String.concat ", " (List.sort String.compare tools))
         agent_name_key
@@ -629,12 +630,20 @@ let resolve_tool_lane_for_oas_tools
         |> dedupe_preserve_order
     | _ -> []
   in
-  let codex_keeper_bound_actor_tools =
+  let codex_can_auth_keeper_bound_actor_tools =
     match provider_cfg.kind, requested_agent_name with
     | Llm_provider.Provider_config.Codex_cli, Some agent_name
       when Option.is_some (keeper_name_of_agent_name agent_name) ->
+        Option.is_some (per_keeper_authorization_header ~agent_name)
+    | _ -> false
+  in
+  let codex_keeper_bound_actor_tools =
+    match provider_cfg.kind, requested_agent_name with
+    | Llm_provider.Provider_config.Codex_cli, Some agent_name
+      when Option.is_some (keeper_name_of_agent_name agent_name)
+           && not codex_can_auth_keeper_bound_actor_tools ->
         List.filter runtime_mcp_tool_requires_bound_actor
-          (public_tool_names @ keeper_internal_tool_names)
+        (public_tool_names @ keeper_internal_tool_names)
     | _ -> []
   in
   (* #10097: WARN once per distinct fingerprint + always-emit

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -193,7 +193,9 @@ val provider_label : Llm_provider.Provider_config.t -> string
       provider).
     - [Error sdk_error] — provider supports neither lane.
 
-    Codex_cli + keeper-bound actor tools trigger the [#10097] omission
+    Codex_cli + keeper-bound actor tools use the per-keeper raw bearer
+    token when it is available, routed through OAS [bearer_token_env_var].
+    When no per-keeper token exists, they trigger the [#10097] omission
     counter/log path. Required turns reject because the omitted tools cannot
     satisfy the tool contract; optional turns keep the prior degraded
     discovery path and exclude those tools from the resulting policy. *)

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -109,8 +109,11 @@ let codex_cli_cannot_carry_keeper_bound_runtime_mcp
   | Llm_provider.Provider_config.Codex_cli, Some agent_name, Some policy
     when Option.is_some (Keeper_identity.keeper_name_from_agent_name agent_name)
     ->
-      List.exists Oas_worker_exec.runtime_mcp_tool_requires_bound_actor
-        policy.allowed_tool_names
+      (not
+         (Oas_worker_exec.codex_cli_can_auth_keeper_bound_runtime_mcp
+            ~agent_name policy))
+      && List.exists Oas_worker_exec.runtime_mcp_tool_requires_bound_actor
+           policy.allowed_tool_names
   | _ -> false
 
 (* #10681: per-provider rejection reason produced by the cascade filter.

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -369,6 +369,8 @@ let dashboard_runtime_probe_http_json ?(force = false) () =
 let runtime_resolution_json (config : Coord.config) =
   let build = Build_identity.current () in
   let runtime_commit = build.commit in
+  let server_repo_path = Build_identity.repo_root () in
+  let server_repo_commit = Option.bind server_repo_path git_rev_parse_short in
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
@@ -384,8 +386,10 @@ let runtime_resolution_json (config : Coord.config) =
     && not (String.equal prompt_markdown_dir expected_prompt_dir)
   in
   let source_mismatch =
-    match runtime_commit, workspace_commit with
-    | Some runtime, Some workspace -> not (String.equal runtime workspace)
+    match runtime_commit, server_repo_commit, workspace_commit with
+    | Some runtime, Some server_repo, _ ->
+        not (String.equal runtime server_repo)
+    | Some runtime, None, Some workspace -> not (String.equal runtime workspace)
     | _ -> false
   in
   let diagnostics, signal_count, repair_count, agent_issue_count =
@@ -396,10 +400,15 @@ let runtime_resolution_json (config : Coord.config) =
     |> fun acc ->
     if source_mismatch then
       let runtime = Option.value ~default:"unknown" runtime_commit in
-      let workspace = Option.value ~default:"unknown" workspace_commit in
-      (Printf.sprintf
-         "Runtime build commit (%s) differs from workspace HEAD (%s). Rebuild/restart from the intended worktree."
-         runtime workspace)
+      let source_label, source_commit =
+        match server_repo_commit with
+        | Some commit -> ("server repo HEAD", commit)
+        | None ->
+            ("workspace HEAD", Option.value ~default:"unknown" workspace_commit)
+      in
+      Printf.sprintf
+        "Runtime build commit (%s) differs from %s (%s). Rebuild/restart from the intended server worktree."
+        runtime source_label source_commit
       :: acc
     else acc
     |> fun acc ->
@@ -442,6 +451,21 @@ let runtime_resolution_json (config : Coord.config) =
       ("resolved_base_path", path_item_json ~source:"resolved_base" config.base_path);
       ("data_root", path_item_json ~source:"runtime_data" (Coord.masc_root_dir config));
       ("prompt_markdown_dir", path_item_json ~source:"prompt_registry" prompt_markdown_dir);
+      ( "server_repo_path",
+        match server_repo_path with
+        | Some path -> path_item_json ~source:"server_binary" path
+        | None ->
+            `Assoc
+              [
+                ("path", `Null);
+                ("exists", `Bool false);
+                ("source", `String "server_binary");
+              ] );
+      ( "server_repo_git_commit",
+        Option.fold
+          ~none:`Null
+          ~some:(fun value -> `String value)
+          server_repo_commit );
       ( "workspace_git_commit",
         Option.fold ~none:`Null ~some:(fun value -> `String value) workspace_commit
       );

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -236,6 +236,12 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json ~status h2_reqd body ~extra_headers:cors
 
+      | `GET, ("/.well-known/agent.json" | "/.well-known/agent-card.json") ->
+          h2_respond_json h2_reqd
+            (Server_routes_http_runtime.agent_card_json httpun_request
+             |> Yojson.Safe.to_string)
+            ~extra_headers:cors
+
       | `GET, "/ws" ->
           let body =
             Server_routes_http_runtime.websocket_discovery_json httpun_request

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -84,6 +84,18 @@ let add_routes ~port ~host router =
   |> Http.Router.get "/health" health_handler
   |> Http.Router.get Server_health_paths.liveness liveness_handler
   |> Http.Router.get Server_health_paths.readiness readiness_handler
+  |> Http.Router.get "/.well-known/agent.json" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         Http.Response.json
+           (Yojson.Safe.to_string (Runtime.agent_card_json req))
+           reqd)
+         request reqd)
+  |> Http.Router.get "/.well-known/agent-card.json" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         Http.Response.json
+           (Yojson.Safe.to_string (Runtime.agent_card_json req))
+           reqd)
+         request reqd)
   |> Http.Router.get "/ws" websocket_discovery_handler
   |> Http.Router.get "/metrics" (fun request reqd ->
        with_read_auth (fun _state _req reqd ->

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -80,6 +80,46 @@ let transport_json request =
   in
   Transport_read_model.transport_status_json ctx
 
+let agent_card_json request =
+  let (host, port) = advertised_host_port request in
+  let base_url = Printf.sprintf "http://%s:%d" host port in
+  let build = Build_identity.current () in
+  `Assoc
+    [
+      ("schema", `String "masc.agent_card.v1");
+      ("name", `String "MASC-MCP");
+      ("description", `String "MASC multi-agent coordination MCP server");
+      ("url", `String base_url);
+      ("version", `String build.release_version);
+      ( "build",
+        `Assoc
+          [
+            ( "commit",
+              Option.fold ~none:`Null ~some:(fun value -> `String value)
+                build.commit );
+            ("started_at", `String build.started_at);
+            ("uptime_seconds", `Int build.uptime_seconds);
+          ] );
+      ( "endpoints",
+        `Assoc
+          [
+            ("mcp", `String (base_url ^ "/mcp"));
+            ("health", `String (base_url ^ "/health"));
+            ("dashboard", `String (base_url ^ "/dashboard/"));
+            ("websocket", `String (base_url ^ "/ws"));
+          ] );
+      ("transport", Transport_bridge.agent_card_transports_json ~host ~port);
+      ( "capabilities",
+        `Assoc
+          [
+            ("coordination", `Bool true);
+            ("task_backlog", `Bool true);
+            ("keeper_runtime", `Bool true);
+            ("dashboard", `Bool true);
+            ("graphql_readonly", `Bool true);
+          ] );
+    ]
+
 let health_path_diagnostics () =
   match current_server_state_opt () with
   | Some state ->

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -90,6 +90,11 @@ val transport_json : Httpun.Request.t -> Yojson.Safe.t
     JSON (HTTP + WS + protocol set).  Sub-projection used by
     {!make_health_json}'s [transport] field. *)
 
+val agent_card_json : Httpun.Request.t -> Yojson.Safe.t
+(** [agent_card_json request] returns the public well-known MASC server
+    card served from [/.well-known/agent.json].  This route is public
+    discovery metadata; mutable operations still require normal tool auth. *)
+
 (** {1 Health endpoints} *)
 
 val health_path_diagnostics :

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -35,6 +35,25 @@ let result_to_response = function
    [tool_schemas_agent.ml] mirrors the SSOT (cycle-aware, sync test).
    The previous code used a string match with a wildcard `_ -> Get`
    branch which silently routed any unknown action to Get. *)
+type agent_card_action =
+  | Agent_card_get
+  | Agent_card_refresh
+
+let agent_card_action_to_string = function
+  | Agent_card_get -> "get"
+  | Agent_card_refresh -> "refresh"
+
+let valid_agent_card_action_strings =
+  [ Agent_card_get; Agent_card_refresh ] |> List.map agent_card_action_to_string
+
+let agent_card_action_of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "get" -> Some Agent_card_get
+  | "refresh" -> Some Agent_card_refresh
+  | _ -> None
+
+let valid_collaboration_format_strings = [ "text"; "json" ]
+
 (** Handle masc_agents *)
 let handle_agents ctx args =
   let limit = get_int args "limit" 20 |> max 1 |> min 50 in
@@ -253,6 +272,60 @@ let handle_agent_fitness ctx args =
 
 (** Handle masc_collaboration_graph *)
 (** Handle masc_agent_card *)
+let handle_agent_card ctx args =
+  let action_raw = get_string args "action" "get" in
+  match agent_card_action_of_string action_raw with
+  | None ->
+      error_result_typed ~code:Validation_error
+        (Printf.sprintf "invalid action %S; expected one of: %s" action_raw
+           (String.concat ", " valid_agent_card_action_strings))
+  | Some action ->
+      let agents = Coord.get_agents_raw ctx.config in
+      let target = get_string_opt args "agent_name" in
+      let target_agent =
+        Option.bind target (fun name ->
+          List.find_opt
+            (fun (agent : Masc_domain.agent) -> String.equal agent.name name)
+            agents)
+      in
+      let json =
+        `Assoc [
+          ("schema", `String "masc.agent_card.v1");
+          ("name", `String "MASC-MCP");
+          ("description", `String "MASC multi-agent coordination MCP server");
+          ("action", `String (agent_card_action_to_string action));
+          ("requested_by", `String ctx.agent_name);
+          ("base_path", `String ctx.config.base_path);
+          ("workspace_path", `String ctx.config.workspace_path);
+          ("agent_count", `Int (List.length agents));
+          ( "agent",
+            match target_agent with
+            | Some agent -> Masc_domain.agent_to_yojson agent
+            | None -> `Null );
+          ( "capabilities",
+            `Assoc [
+              ("coordination", `Bool true);
+              ("task_backlog", `Bool true);
+              ("keeper_runtime", `Bool true);
+              ("dashboard", `Bool true);
+            ] );
+          ( "tools",
+            `List
+              (List.map
+                 (fun name -> `String name)
+                 [
+                   "masc_status";
+                   "masc_agents";
+                   "masc_tasks";
+                   "masc_claim_next";
+                   "masc_transition";
+                   "masc_dashboard";
+                   "masc_tool_help";
+                 ]) );
+        ]
+      in
+      (true, Yojson.Safe.to_string json)
+
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 let dispatch ctx ~name ~args =
   match name with
@@ -261,7 +334,8 @@ let dispatch ctx ~name ~args =
   | "masc_agent_update" -> Some (handle_agent_update ctx args)
   | "masc_get_metrics" -> Some (handle_get_metrics ctx args)
   | "masc_agent_fitness" -> Some (handle_agent_fitness ctx args)
-      | _ -> None
+  | "masc_agent_card" -> Some (handle_agent_card ctx args)
+  | _ -> None
 
 let schemas = Tool_schemas_agent.schemas
 
@@ -270,11 +344,11 @@ let schemas = Tool_schemas_agent.schemas
 (* ================================================================ *)
 
 let _tool_spec_read_only =
-  [ "masc_agents";  ]
+  [ "masc_agents"; "masc_agent_card" ]
 let _tool_spec_requires_join = [ "masc_register_capabilities" ]
 
 let tool_required_permission = function
-  | "masc_agents" | "masc_agent_fitness"
+  | "masc_agents" | "masc_agent_fitness" | "masc_agent_card"
   | "masc_get_metrics" ->
       Some Masc_domain.CanReadState
   | "masc_register_capabilities" | "masc_agent_update" ->

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -9,9 +9,16 @@ type context = {
 (** Issue #8501: Variant SSOT for masc_agent_card.action.  Mirror in
     [Tool_schemas_agent.agent_card_action_enum_strings] (cycle-aware,
     sync regression test catches drift). *)
+type agent_card_action =
+  | Agent_card_get
+  | Agent_card_refresh
+
+val agent_card_action_to_string : agent_card_action -> string
+val valid_agent_card_action_strings : string list
 
 (** Issue #8501: Variant SSOT for masc_collaboration_graph.format.
     Mirror in [Tool_schemas_agent.collaboration_format_enum_strings]. *)
+val valid_collaboration_format_strings : string list
 
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
@@ -36,3 +43,4 @@ val handle_agent_fitness : context -> Yojson.Safe.t -> bool * string
 (** Handle masc_collaboration_graph *)
 
 (** Handle masc_agent_card *)
+val handle_agent_card : context -> Yojson.Safe.t -> bool * string

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -206,8 +206,9 @@ let explicit_metadata : (string * metadata) list =
     ("masc_messages", readonly_tool);
     ("masc_who", readonly_tool);
     ("masc_agents", readonly_tool);
+    ( "masc_agent_card",
+      { readonly_tool with required_permission = Some Masc_domain.CanReadState } );
     ("masc_dashboard", readonly_tool);
-    ("masc_agent_card", readonly_tool);
     ("masc_board_list", readonly_tool);
     ("masc_board_get", readonly_tool);
     ("masc_tool_help", readonly_tool);
@@ -474,6 +475,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Start ->
       Some Main_worktree_write
   | TN.Masc TM.Agent_fitness
+  | TN.Masc TM.Agent_card
   | TN.Masc TM.Agents
   | TN.Masc TM.Autoresearch_search_findings
   | TN.Masc TM.Autoresearch_status
@@ -687,7 +689,7 @@ let tool_group_of_typed_tool_name = function
       | TM.Autoresearch_status
       | TM.Autoresearch_stop ) ->
       Some Masc_autoresearch
-  | TN.Masc (TM.Agent_fitness | TM.Agent_update | TM.Agents) ->
+  | TN.Masc (TM.Agent_fitness | TM.Agent_update | TM.Agent_card | TM.Agents) ->
       Some Masc_agent
   | TN.Masc
       ( TM.Add_task

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -158,7 +158,7 @@ let public_mcp_surface_tools =
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote";
     (* Agent discovery *)
-    "masc_agents"; "masc_dashboard";
+    "masc_agents"; "masc_agent_card"; "masc_dashboard";
     (* Utility *)
     "masc_tool_help"; "masc_web_search"; "masc_check";
     (* HITL approval queue *)
@@ -194,7 +194,7 @@ let spawned_agent_surface_tools =
 let local_worker_surface_tools =
   [
     "masc_status"; "masc_tasks"; "masc_claim_next"; "masc_transition";
-    "masc_add_task"; "masc_heartbeat";
+    "masc_add_task"; "masc_heartbeat"; "masc_agents"; "masc_agent_card";
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
     "masc_goal_transition"; "masc_goal_verify"; "masc_coordination_fsm_snapshot";
     "masc_board_post"; "masc_board_list"; "masc_board_get";

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -244,6 +244,7 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Transition
     | Update_priority -> Some Mod_task
     | Agent_fitness
+    | Agent_card
     | Agent_update
     | Agents
     | Get_metrics

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -201,6 +201,7 @@ module Masc = struct
     | Add_task
     | Agent_fitness
     | Agent_update
+    | Agent_card
     | Agents
     | Autoresearch_cycle
     | Autoresearch_inject
@@ -306,6 +307,7 @@ module Masc = struct
     | Add_task -> "masc_add_task"
     | Agent_fitness -> "masc_agent_fitness"
     | Agent_update -> "masc_agent_update"
+    | Agent_card -> "masc_agent_card"
     | Agents -> "masc_agents"
     | Batch_add_tasks -> "masc_batch_add_tasks"
     | Board_cleanup -> "masc_board_cleanup"
@@ -411,6 +413,7 @@ module Masc = struct
     | "masc_add_task" -> Some Add_task
     | "masc_agent_fitness" -> Some Agent_fitness
     | "masc_agent_update" -> Some Agent_update
+    | "masc_agent_card" -> Some Agent_card
     | "masc_agents" -> Some Agents
     | "masc_batch_add_tasks" -> Some Batch_add_tasks
     | "masc_board_cleanup" -> Some Board_cleanup

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -69,6 +69,7 @@ module Masc : sig
     | Add_task
     | Agent_fitness
     | Agent_update
+    | Agent_card
     | Agents
     | Autoresearch_cycle
     | Autoresearch_inject

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -34,6 +34,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_tasks", CanReadState);
     ("masc_messages", CanReadState);
     ("masc_agents", CanReadState);
+    ("masc_agent_card", CanReadState);
     ("masc_worktree_list", CanReadState);
     ("masc_task_history", CanReadState);
     ("masc_operator_snapshot", CanReadState);

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -8,6 +8,9 @@ open Masc_domain
     drift. Same shape as #8467/#8480/#8484/#8490/#8493 mirror+sync
     pattern. *)
 
+let agent_card_action_enum_strings = [ "get"; "refresh" ]
+let collaboration_format_enum_strings = [ "text"; "json" ]
+
 let schemas : tool_schema list = [
   {
     name = "masc_agents";
@@ -109,6 +112,27 @@ let schemas : tool_schema list = [
         ]);
       ]);
       ("required", `List [`String "agent_name"]);
+      ("additionalProperties", `Bool false);
+    ];
+  };
+
+  {
+    name = "masc_agent_card";
+    description = "Return the MASC server agent card and optional live agent summary.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("action", `Assoc [
+          ("type", `String "string");
+          ("enum", `List (List.map (fun s -> `String s) agent_card_action_enum_strings));
+          ("description", `String "Card action: get or refresh.");
+          ("default", `String "get");
+        ]);
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional live agent name to include in the card.");
+        ]);
+      ]);
       ("additionalProperties", `Bool false);
     ];
   };

--- a/lib/tool_schemas/tool_schemas_agent.mli
+++ b/lib/tool_schemas/tool_schemas_agent.mli
@@ -9,14 +9,16 @@
     Issues: #8501 (mirror pattern), #8372 (agent_status enum derivation),
     #8467/#8480/#8484/#8490/#8493 (related mirror+sync pattern). *)
 
-(** Allowed values for [masc_agent_card] [action]: ["get" | "refresh"].
-    Mirror of [Tool_agent.valid_agent_card_action_strings]. *)
+(** Allowed values for [masc_agent_card] [action].  Mirror of
+    [Tool_agent.valid_agent_card_action_strings]. *)
+val agent_card_action_enum_strings : string list
 
 (** Allowed values for [masc_collaboration_graph] [format]:
     ["text" | "json"]. Mirror of
     [Tool_agent.valid_collaboration_format_strings]. *)
+val collaboration_format_enum_strings : string list
 
 (** Tool schemas: [masc_agents], [masc_agent_update],
     [masc_agent_fitness], [masc_register_capabilities],
-    [masc_get_metrics]. *)
+    [masc_get_metrics], [masc_agent_card]. *)
 val schemas : Masc_domain.tool_schema list

--- a/lib/transport_bridge.mli
+++ b/lib/transport_bridge.mli
@@ -66,3 +66,5 @@ val enabled_protocols : unit -> Transport.protocol list
 
 (** Transport section for A2A Agent Card / MCP discovery.
     Includes enabled protocols, endpoints, session counts. *)
+val agent_card_transports_json :
+  host:string -> port:int -> Yojson.Safe.t

--- a/test/test_keeper_admission_policy.ml
+++ b/test/test_keeper_admission_policy.ml
@@ -94,7 +94,7 @@ let test_of_fields_min_tier_above_preferred () =
 let test_of_fields_duplicate_provider () =
   let cands =
     [ candidate ~p:"anthropic" ~m:"claude-sonnet-4-6" ~t:KAP.Preferred
-    ; candidate ~p:"anthropic" ~m:"claude-haiku-4-5" ~t:KAP.Acceptable
+    ; candidate ~p:"anthropic" ~m:"claude-sonnet-4-6" ~t:KAP.Acceptable
     ]
   in
   let got =
@@ -104,6 +104,24 @@ let test_of_fields_duplicate_provider () =
   match got with
   | Error (KAP.Duplicate_provider "anthropic") -> ()
   | _ -> Alcotest.fail "expected Duplicate_provider \"anthropic\""
+
+let test_of_fields_same_provider_different_models_allowed () =
+  let cands =
+    [ candidate ~p:"anthropic" ~m:"claude-sonnet-4-6" ~t:KAP.Preferred
+    ; candidate ~p:"anthropic" ~m:"claude-haiku-4-5" ~t:KAP.Acceptable
+    ]
+  in
+  match
+    KAP.of_fields ~keeper_id:"analyst" ~candidates:cands ~weight:1
+      ~min_tier:KAP.Acceptable
+  with
+  | Ok t ->
+      Alcotest.(check int)
+        "same provider can appear for distinct model fallbacks"
+        2 (List.length (KAP.candidates t))
+  | Error _ ->
+      Alcotest.fail
+        "same provider with distinct models should be accepted"
 
 (* ------------------------------------------------------------------ *)
 (* candidates_above_min_tier filtering                                *)
@@ -257,6 +275,8 @@ let () =
             test_of_fields_min_tier_above_preferred
         ; Alcotest.test_case "duplicate provider" `Quick
             test_of_fields_duplicate_provider
+        ; Alcotest.test_case "same provider different models allowed"
+            `Quick test_of_fields_same_provider_different_models_allowed
         ] )
     ; ( "filtering"
       , [ Alcotest.test_case "candidates_above_min_tier filters Survival"

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -207,7 +207,6 @@ let test_sandbox_policy_resync () =
 goal = "test"
 sandbox_profile = "docker"
 network_mode = "none"
-shared_memory_scope = "room"
 |};
   let config = Coord.default_config room_dir in
   let initial_meta =
@@ -220,7 +219,6 @@ shared_memory_scope = "room"
             ("trace_id", `String "trace-sandbox-policy-resync");
             ("sandbox_profile", `String "local");
             ("network_mode", `String "inherit");
-            ("shared_memory_scope", `String "disabled");
           ])
     with
     | Ok meta -> meta
@@ -251,7 +249,6 @@ let test_keeper_up_create_uses_profile_default_sandbox_policy () =
 goal = "test"
 sandbox_profile = "docker"
 network_mode = "inherit"
-shared_memory_scope = "room"
 |};
   let config = Coord.default_config room_dir in
   ignore (Coord.init config ~agent_name:(Some "operator"));

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1542,38 +1542,6 @@ legacy_scope = "removed"
     check (list string) "base include is a loader key"
       ["keeper.legacy_scope"] unknown
 
-let test_shared_memory_scope_is_canonical_toml () =
-  let input = {|
-[keeper]
-goal = "g"
-shared_memory_scope = "room"
-|} in
-  match TL.parse_toml input with
-  | Error e -> fail e
-  | Ok doc ->
-    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
-    check (list string) "shared_memory_scope is canonical" [] unknown;
-    match KTP.profile_defaults_of_toml doc with
-    | Error e -> fail e
-    | Ok d ->
-      check (option string) "shared_memory_scope parsed"
-        (Some "room") d.KTP.shared_memory_scope
-
-let test_shared_memory_scope_rejects_invalid_value () =
-  let input = {|
-[keeper]
-goal = "g"
-shared_memory_scope = "global"
-|} in
-  match TL.parse_toml input with
-  | Error e -> fail e
-  | Ok doc ->
-    match KTP.profile_defaults_of_toml doc with
-    | Ok _ -> fail "expected invalid shared_memory_scope to be rejected"
-    | Error e ->
-      check bool "mentions shared_memory_scope" true
-        (contains_substring e "shared_memory_scope")
-
 let test_oas_env_parses_allowed_keys () =
   let input = {|
 [keeper]
@@ -1962,10 +1930,6 @@ let () =
             test_detect_unknown_keys_accepts_tool_access_table;
           test_case "accepts loader base include" `Quick
             test_detect_unknown_keys_accepts_loader_base;
-          test_case "accepts shared_memory_scope" `Quick
-            test_shared_memory_scope_is_canonical_toml;
-          test_case "rejects invalid shared_memory_scope" `Quick
-            test_shared_memory_scope_rejects_invalid_value;
           test_case "also_allow alias flagged" `Quick
             test_detect_unknown_keys_flags_also_allow_alias;
           test_case "oas_env keys not flagged as unknown" `Quick

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -245,9 +245,6 @@ let test_turn_context_fields_stored () =
     Alcotest.(check (option string)) "network_mode field"
       (Some "inherit")
       (Safe_ops.json_string_opt "network_mode" entry);
-    Alcotest.(check (option string)) "shared_memory_scope field"
-      (Some "team")
-      (Safe_ops.json_string_opt "shared_memory_scope" entry);
     Alcotest.(check (option string)) "approval_mode field"
       (Some "manual")
       (Safe_ops.json_string_opt "approval_mode" entry);

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -388,10 +388,6 @@ let extra_guard_fragments_for_name = function
       [ "agent_name must match the authenticated agent";
         "no credential found" ]
   | "masc_auth_revoke" -> [ "no credential found" ]
-  | "masc_team_memory_read"
-  | "masc_team_memory_search"
-  | "masc_team_memory_write" ->
-      [ "keeper-only"; "not a keeper agent" ]
   | "masc_autoresearch_cycle"
   | "masc_autoresearch_inject"
   | "masc_autoresearch_status"

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -109,12 +109,17 @@ let with_env name value f =
 let with_temp_masc_base_path prefix f =
   let base = temp_dir prefix in
   let previous = Sys.getenv_opt "MASC_BASE_PATH" in
+  let previous_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
   Unix.putenv "MASC_BASE_PATH" base;
+  Unix.putenv "MASC_BASE_PATH_INPUT" base;
   Fun.protect
     ~finally:(fun () ->
       (match previous with
        | Some value -> Unix.putenv "MASC_BASE_PATH" value
        | None -> Unix.putenv "MASC_BASE_PATH" "");
+      (match previous_input with
+       | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
+       | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
       cleanup_dir base)
     f
 
@@ -1874,6 +1879,8 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_keeps_iden
 let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_omits_bound_tools () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-bound-no-token" @@ fun _base_path ->
   let tools =
     [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_claim_next" ]
   in
@@ -1908,6 +1915,49 @@ let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_omits_bound_t
   | Ok (_, None) ->
       Alcotest.fail
         "expected codex_cli keeper-bound public MCP tools to keep safe runtime lane"
+  | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
+
+let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_with_per_keeper_token_keeps_bound_tools
+    () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-bound-token" @@ fun () ->
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  seed_raw_token base_path "keeper-sangsu-agent" "keeper-bearer-xyz";
+  let tools =
+    [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_claim_next" ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~agent_name:"keeper-sangsu-agent"
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools ()
+  with
+  | Ok (effective_tools, Some policy) ->
+      let masc_headers =
+        List.find_map
+          (function
+            | Llm_provider.Llm_transport.Http_server server
+              when String.equal server.name "masc" -> Some server.headers
+            | _ -> None)
+          policy.servers
+      in
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "keeper-bound tool preserved for codex_cli"
+        [ "masc_status"; "masc_claim_next" ] policy.allowed_tool_names;
+      Alcotest.(check (option string)) "codex_cli uses per-keeper bearer"
+        (Some "Bearer keeper-bearer-xyz")
+        (Option.bind masc_headers (List.assoc_opt "Authorization"));
+      Alcotest.(check (option string)) "codex_cli preserves agent identity header"
+        (Some "keeper-sangsu-agent")
+        (Option.bind masc_headers (List.assoc_opt "x-masc-agent-name"));
+      Alcotest.(check (option string)) "codex_cli strips internal token" None
+        (Option.bind masc_headers (List.assoc_opt "x-masc-internal-token"))
+  | Ok (_, None) ->
+      Alcotest.fail
+        "expected codex_cli keeper-bound public MCP tools to use runtime MCP lane"
   | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
 
 let test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy () =
@@ -2078,6 +2128,8 @@ let test_resolve_tool_lane_for_codex_cli_internal_tools_rejects () =
 let test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_rejects () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-internal-no-token" @@ fun _base_path ->
   match
     Oas_worker_exec.resolve_tool_lane_for_oas_tools
       ~agent_name:"keeper-sangsu-agent"
@@ -2091,26 +2143,41 @@ let test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_reject
       Alcotest.(check string) "field" "tool_support" field
   | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
 
-let test_resolve_tool_lane_for_codex_cli_keeper_task_claim_with_agent_rejects () =
+let test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_and_per_keeper_token_uses_runtime_mcp
+    () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
-  with_temp_masc_base_path "codex-keeper-claim" @@ fun () ->
+  with_temp_masc_base_path "codex-internal-token" @@ fun () ->
   let base_path = Sys.getenv "MASC_BASE_PATH" in
-  seed_raw_token base_path "keeper-sangsu-agent" "keeper-raw-token";
+  seed_raw_token base_path "keeper-sangsu-agent" "keeper-bearer-abc";
   match
     Oas_worker_exec.resolve_tool_lane_for_oas_tools
       ~agent_name:"keeper-sangsu-agent"
       ~provider_cfg:(make_codex_cli_provider_cfg ())
-      ~tools:[ make_named_noop_tool "keeper_task_claim" ] ()
+      ~tools:[ make_named_noop_tool "keeper_bash" ] ()
   with
-  | Ok _ ->
+  | Ok (effective_tools, Some policy) ->
+      let masc_headers =
+        List.find_map
+          (function
+            | Llm_provider.Llm_transport.Http_server server
+              when String.equal server.name "masc" -> Some server.headers
+            | _ -> None)
+          policy.servers
+      in
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "keeper internal tool preserved"
+        [ "keeper_bash" ] policy.allowed_tool_names;
+      Alcotest.(check (option string)) "codex_cli uses per-keeper bearer"
+        (Some "Bearer keeper-bearer-abc")
+        (Option.bind masc_headers (List.assoc_opt "Authorization"));
+      Alcotest.(check (option string)) "codex_cli strips internal token" None
+        (Option.bind masc_headers (List.assoc_opt "x-masc-internal-token"))
+  | Ok (_, None) ->
       Alcotest.fail
-        "expected codex_cli to reject required keeper_task_claim despite per-keeper token auth"
-  | Error (Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })) ->
-      Alcotest.(check string) "field" "tool_support" field;
-      Alcotest.(check bool) "detail mentions keeper_task_claim" true
-        (contains_substring ~needle:"keeper_task_claim" detail)
+        "expected codex_cli keeper-internal tools with per-keeper token to use runtime MCP lane"
   | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
 
 let test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects () =
@@ -2166,6 +2233,8 @@ let test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_boun
     () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-filter-no-token" @@ fun _base_path ->
   let runtime_mcp_policy =
     Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
       ~agent_name:"keeper-sangsu-agent" [ "masc_status"; "masc_claim_next" ]
@@ -2230,7 +2299,7 @@ let test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_boun
       Alcotest.failf "expected only kimi_cli provider to remain, got %d"
         (List.length filtered)
 
-let test_filter_candidate_providers_for_tool_support_drops_codex_with_per_keeper_token
+let test_filter_candidate_providers_for_tool_support_keeps_codex_with_per_keeper_token
     () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
@@ -2251,14 +2320,16 @@ let test_filter_candidate_providers_for_tool_support_drops_codex_with_per_keeper
       [ make_codex_cli_provider_cfg (); make_kimi_cli_provider_cfg () ]
   in
   Alcotest.(check (list string))
-    "codex remains rejected even when bearer auth can be sourced"
-    [ "kimi_cli:kimi-for-coding" ]
+    "codex remains when bearer auth can be sourced"
+    [ "codex_cli:codex"; "kimi_cli:kimi-for-coding" ]
     (List.map Provider_tool_support.provider_debug_label filtered)
 
 let test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_for_keeper_internal_tools
     () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-header-capable-no-token" @@ fun _base_path ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
     Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
@@ -2286,6 +2357,7 @@ let test_filter_candidate_providers_for_tool_support_secondary_preserves_priorit
     () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_temp_masc_base_path "codex-secondary-priority" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
     Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
@@ -2316,6 +2388,7 @@ let test_filter_candidate_providers_for_tool_support_secondary_uses_candidate_in
     () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_temp_masc_base_path "codex-secondary-index" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
     Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
@@ -2360,6 +2433,7 @@ let count_swap_metric ~detail =
 let test_dual_track_swap_emits_secondary_kind_label_on_success () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_temp_masc_base_path "codex-secondary-metric-success" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
     Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
@@ -2389,6 +2463,7 @@ let test_dual_track_swap_emits_secondary_kind_label_on_success () =
 let test_dual_track_swap_emits_secondary_kind_label_on_rejection () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_temp_masc_base_path "codex-secondary-metric-rejection" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
     Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
@@ -2427,6 +2502,8 @@ let test_dual_track_swap_emits_secondary_kind_label_on_rejection () =
 let test_classify_filter_rejection_codex_keeper_bound_actor () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-classify-no-token" @@ fun _base_path ->
   let runtime_mcp_policy =
     Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
       ~agent_name:"keeper-sangsu-agent" [ "masc_status"; "masc_claim_next" ]
@@ -2449,6 +2526,34 @@ let test_classify_filter_rejection_codex_keeper_bound_actor () =
   Alcotest.(check (option string))
     "codex_cli with bound-actor policy classified as keeper_bound_actor"
     (Some "codex_keeper_bound_actor_required")
+    (Option.map
+       Masc_mcp.Oas_worker_named.filter_rejection_reason_label reason)
+
+let test_classify_filter_rejection_codex_keeper_bound_actor_passes_with_per_keeper_token
+    () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_temp_masc_base_path "codex-classify-token" @@ fun () ->
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  seed_raw_token base_path "keeper-sangsu-agent" "keeper-bearer-xyz";
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  let runtime_mcp_policy =
+    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+      ~keeper_name:"sangsu" tools
+  in
+  let reason =
+    Masc_mcp.Oas_worker_named.classify_filter_rejection
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      (make_codex_cli_provider_cfg ())
+  in
+  Alcotest.(check (option string))
+    "codex_cli passes keeper-bound policy when per-keeper bearer exists"
+    None
     (Option.map
        Masc_mcp.Oas_worker_named.filter_rejection_reason_label reason)
 
@@ -4372,6 +4477,10 @@ let () =
         "keeper-bound public MCP tools on codex_cli omit request-scoped tools"
         `Quick
         test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_omits_bound_tools;
+      Alcotest.test_case
+        "keeper-bound public MCP tools on codex_cli use per-keeper bearer"
+        `Quick
+        test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_with_per_keeper_token_keeps_bound_tools;
       Alcotest.test_case "public MCP tools on kimi_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy;
       Alcotest.test_case
@@ -4397,9 +4506,9 @@ let () =
         `Quick
         test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_rejects;
       Alcotest.test_case
-        "keeper_task_claim on codex_cli with keeper actor is rejected"
+        "keeper-internal tools on codex_cli with per-keeper bearer use runtime MCP"
         `Quick
-        test_resolve_tool_lane_for_codex_cli_keeper_task_claim_with_agent_rejects;
+        test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_and_per_keeper_token_uses_runtime_mcp;
       Alcotest.test_case "keeper-internal tools on kimi_cli are rejected" `Quick
         test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects;
       Alcotest.test_case "optional keeper-internal tools on codex_cli drop to text" `Quick
@@ -4411,9 +4520,9 @@ let () =
         `Quick
         test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_bound_actor_tools;
       Alcotest.test_case
-        "provider-normalized filter drops codex bound actor despite per-keeper token"
+        "provider-normalized filter keeps codex bound actor with per-keeper token"
         `Quick
-        test_filter_candidate_providers_for_tool_support_drops_codex_with_per_keeper_token;
+        test_filter_candidate_providers_for_tool_support_keeps_codex_with_per_keeper_token;
       Alcotest.test_case
         "provider-normalized filter keeps header-capable keeper-internal lanes"
         `Quick
@@ -4437,6 +4546,10 @@ let () =
       Alcotest.test_case
         "classify_filter_rejection: codex bound-actor policy → keeper_bound_actor"
         `Quick test_classify_filter_rejection_codex_keeper_bound_actor;
+      Alcotest.test_case
+        "classify_filter_rejection: codex bound-actor policy passes with per-keeper bearer"
+        `Quick
+        test_classify_filter_rejection_codex_keeper_bound_actor_passes_with_per_keeper_token;
       Alcotest.test_case
         "classify_filter_rejection: returns None when provider passes"
         `Quick test_classify_filter_rejection_passes_when_provider_supported;

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -150,9 +150,6 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_agent_card", Masc_domain.CanReadState);
       ("masc_heartbeat", Masc_domain.CanBroadcast);
       ("masc_config", Masc_domain.CanReadState);
-      ("masc_team_memory_read", Masc_domain.CanReadState);
-      ("masc_team_memory_search", Masc_domain.CanReadState);
-      ("masc_team_memory_write", Masc_domain.CanBroadcast);
       ("masc_tool_list", Masc_domain.CanReadState);
       ("masc_tool_admin_snapshot", Masc_domain.CanAdmin);
       ("masc_runtime_verify", Masc_domain.CanReadState);

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -139,6 +139,12 @@ let test_dispatch_agent_update () =
   Alcotest.(check bool) "agent_update dispatches" true (result <> None);
   )
 
+let test_dispatch_agent_card () =
+  with_ctx (fun ctx ->
+  let result = Tool_agent.dispatch ctx ~name:"masc_agent_card" ~args:(`Assoc []) in
+  Alcotest.(check bool) "agent_card dispatches" true (result <> None);
+  )
+
 
 (* ============================================================
    Handler tests — masc_agents
@@ -149,6 +155,28 @@ let test_handle_agents () =
   let (ok, msg) = Tool_agent.handle_agents ctx (`Assoc []) in
   Alcotest.(check bool) "agents succeeds" true ok;
   Alcotest.(check bool) "has response" true (String.length msg > 0);
+  )
+
+let test_handle_agent_card () =
+  with_ctx (fun ctx ->
+  let (ok, msg) = Tool_agent.handle_agent_card ctx (`Assoc []) in
+  Alcotest.(check bool) "agent card succeeds" true ok;
+  let json = Yojson.Safe.from_string msg in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "card name" "MASC-MCP"
+    (json |> member "name" |> to_string);
+  Alcotest.(check string) "card schema" "masc.agent_card.v1"
+    (json |> member "schema" |> to_string);
+  )
+
+let test_handle_agent_card_rejects_unknown_action () =
+  with_ctx (fun ctx ->
+  let (ok, msg) =
+    Tool_agent.handle_agent_card ctx (`Assoc [("action", `String "bogus")])
+  in
+  Alcotest.(check bool) "agent card rejects" false ok;
+  Alcotest.(check bool) "mentions invalid action" true
+    (String.contains msg 'b');
   )
 
 (* ============================================================
@@ -385,9 +413,13 @@ let () =
       Alcotest.test_case "agents dispatches" `Quick test_dispatch_agents;
       Alcotest.test_case "register_capabilities dispatches" `Quick test_dispatch_register_capabilities;
       Alcotest.test_case "agent_update dispatches" `Quick test_dispatch_agent_update;
+      Alcotest.test_case "agent_card dispatches" `Quick test_dispatch_agent_card;
     ]);
     ("agents", [
       Alcotest.test_case "handle_agents" `Quick test_handle_agents;
+      Alcotest.test_case "handle_agent_card" `Quick test_handle_agent_card;
+      Alcotest.test_case "handle_agent_card rejects unknown action" `Quick
+        test_handle_agent_card_rejects_unknown_action;
     ]);
     ("register_capabilities", [
       Alcotest.test_case "with capabilities" `Quick test_register_capabilities;

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -70,27 +70,6 @@ let make_test_ctx () =
   let _ = Coord.init config ~agent_name:(Some "test-agent") in
   { Tool_misc.config; agent_name = "test-agent" }
 
-let write_team_memory_keeper_meta ~config ~name ~shared_memory_scope =
-  let agent_name = Printf.sprintf "keeper-%s-agent" name in
-  let meta_json =
-    `Assoc
-      [
-        ("name", `String name);
-        ("agent_name", `String agent_name);
-        ("trace_id", `String ("trace-" ^ name));
-        ("goal", `String "team memory fixture");
-        ("shared_memory_scope", `String shared_memory_scope);
-      ]
-  in
-  let meta =
-    match Masc_test_deps.meta_of_json_fixture meta_json with
-    | Ok meta -> meta
-    | Error err -> failwith ("meta_of_json failed: " ^ err)
-  in
-  match Keeper_types.write_meta ~force:true config meta with
-  | Ok () -> agent_name
-  | Error err -> failwith ("write_meta failed: " ^ err)
-
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -146,53 +125,6 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
-)
-
-let () = test "dispatch_team_memory_write_and_read" (fun () ->
-  let ctx = make_test_ctx () in
-  let agent_name =
-    write_team_memory_keeper_meta ~config:ctx.config ~name:"room-alpha"
-      ~shared_memory_scope:"room"
-  in
-  let keeper_ctx : Tool_misc.context =
-    { config = ctx.config; agent_name }
-  in
-  let write_body =
-    match
-      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_write"
-        ~args:
-          (`Assoc
-            [
-              ("room", `String "default");
-              ("key", `String "handoff/summary.md");
-              ("content", `String "shared summary");
-            ])
-    with
-    | Some (true, body) -> body
-    | Some (false, err) -> failwith err
-    | None -> failwith "dispatch returned None"
-  in
-  let write_json = parse_json write_body in
-  let open Yojson.Safe.Util in
-  Alcotest.(check string) "write key" "handoff/summary.md"
-    (write_json |> member "key" |> to_string);
-  let read_body =
-    match
-      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_read"
-        ~args:
-          (`Assoc
-            [
-              ("room", `String "default");
-              ("key", `String "handoff/summary.md");
-            ])
-    with
-    | Some (true, body) -> body
-    | Some (false, err) -> failwith err
-    | None -> failwith "dispatch returned None"
-  in
-  let read_json = parse_json read_body in
-  Alcotest.(check string) "read content" "shared summary"
-    (read_json |> member "content" |> to_string)
 )
 
 let () = test "dispatch_dashboard_invalid_scope" (fun () ->

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -18,7 +18,7 @@ let all_keeper : Tool_name.Keeper.t list =
   ; Voice_sessions; Voice_speak; Write ]
 
 let all_masc : Tool_name.Masc.t list =
-  [ Add_task; Agent_fitness; Agent_update; Agents
+  [ Add_task; Agent_fitness; Agent_update; Agent_card; Agents
   ; Autoresearch_cycle; Autoresearch_inject; Autoresearch_start
   ; Autoresearch_record_finding; Autoresearch_search_findings
   ; Autoresearch_status; Autoresearch_stop

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -696,44 +696,6 @@ let test_masc_tool_admin_update_schema () =
           Alcotest.(check bool) "has policy" true (List.mem_assoc "policy" props)
       | None -> Alcotest.fail "masc_tool_admin_update missing properties"
 
-let test_masc_team_memory_read_schema () =
-  match find_tool "masc_team_memory_read" with
-  | None -> Alcotest.fail "masc_team_memory_read not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has room" true
-            (List.mem_assoc "room" props);
-          Alcotest.(check bool) "has key" true
-            (List.mem_assoc "key" props)
-      | None -> Alcotest.fail "masc_team_memory_read missing properties"
-
-let test_masc_team_memory_write_schema () =
-  match find_tool "masc_team_memory_write" with
-  | None -> Alcotest.fail "masc_team_memory_write not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has room" true
-            (List.mem_assoc "room" props);
-          Alcotest.(check bool) "has key" true
-            (List.mem_assoc "key" props);
-          Alcotest.(check bool) "has content" true
-            (List.mem_assoc "content" props)
-      | None -> Alcotest.fail "masc_team_memory_write missing properties"
-
-let test_masc_team_memory_search_schema () =
-  match find_tool "masc_team_memory_search" with
-  | None -> Alcotest.fail "masc_team_memory_search not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has room" true
-            (List.mem_assoc "room" props);
-          Alcotest.(check bool) "has query" true
-            (List.mem_assoc "query" props)
-      | None -> Alcotest.fail "masc_team_memory_search missing properties"
-
 (* ============================================================ *)
 (* 14. Handover Tool Tests                                       *)
 (* ============================================================ *)
@@ -812,6 +774,18 @@ let test_masc_get_metrics_schema () =
   match find_tool "masc_get_metrics" with
   | None -> Alcotest.fail "masc_get_metrics not found"
   | Some _ -> ()
+
+let test_masc_agent_card_schema () =
+  match find_tool "masc_agent_card" with
+  | None -> Alcotest.fail "masc_agent_card not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has action" true
+            (List.mem_assoc "action" props);
+          Alcotest.(check bool) "has agent_name" true
+            (List.mem_assoc "agent_name" props)
+      | None -> Alcotest.fail "masc_agent_card missing properties"
 
 let test_masc_webrtc_offer_schema () =
   match find_tool "masc_webrtc_offer" with
@@ -966,14 +940,6 @@ let () =
       Alcotest.test_case "tool-admin-update" `Quick
         test_masc_tool_admin_update_schema;
     ];
-    "team_memory_tools", [
-      Alcotest.test_case "team-memory-read" `Quick
-        test_masc_team_memory_read_schema;
-      Alcotest.test_case "team-memory-write" `Quick
-        test_masc_team_memory_write_schema;
-      Alcotest.test_case "team-memory-search" `Quick
-        test_masc_team_memory_search_schema;
-    ];
     (* runtime_verify_tools removed: masc_runtime_verify pruned *)
     "legacy_swarm_removed", [
       Alcotest.test_case "removed_from_public_schemas" `Quick
@@ -987,6 +953,7 @@ let () =
       Alcotest.test_case "dashboard" `Quick test_masc_dashboard_schema;
       Alcotest.test_case "agent_fitness" `Quick test_masc_agent_fitness_schema;
       Alcotest.test_case "get_metrics" `Quick test_masc_get_metrics_schema;
+      Alcotest.test_case "agent_card" `Quick test_masc_agent_card_schema;
     ];
     "transport_tools", [
       Alcotest.test_case "webrtc_offer" `Quick test_masc_webrtc_offer_schema;


### PR DESCRIPTION
## Summary
- makes `/code` use the full dashboard viewport and upgrades the IDE mock shell with CodeMirror line numbers, syntax highlighting, blame gutter, conversation/activity polish, and responsive toolbar/interject layout
- exposes server-repo runtime truth in dashboard config resolution so a running binary can be compared against the active workspace/base path
- implements real `masc_agent_card` support across schema, catalog, permission, dispatch, MCP tool call, and `/.well-known/agent*.json` routes
- fixes keeper admission duplicate detection for same-provider/different-model cascades, Codex CLI keeper-bound MCP bearer propagation, stale shared-memory ghost config, and restart-time alive-but-stuck false positives
- repairs the live local `.masc` config symptoms from the pasted boot log: stale tool_policy entries, missing/stale docker egress files, and retired `shared_memory_scope` keys

## Operator impact
The boot log should stop showing the key local-runtime false alarms this patch targets: unknown `keeper_fs_write/delete`, missing docker egress audits, `masc_agents` schema resolution failure, sangsu admission parse failure, immediate stale-turn keeper crashes after restart, and Codex keeper-bound MCP tools being omitted despite bearer tokens being available. The dashboard also now shows which repo commit the server binary actually came from, which matters when root checkout and worktree binaries are both running.

## Verification
- `git diff --check`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/components/ide/ide-editor-extensions.test.ts src/components/ide/ide-editor.test.ts src/components/ide/ide-conversation-rail-mock.test.ts src/components/tools/config-resolution-panel.test.ts --reporter=verbose`
- focused OCaml temp-build tests passed for keeper admission, Codex resume config, tool-name/tool coverage, agent-card dispatch path, and alive-but-stuck detection
- live smoke on alternate port 8995 with patched binary: `/health` ready with zero keeper config unknown/parse errors, `/.well-known/agent.json` 200, `/.well-known/agent-card.json` 200, `/mcp` `masc_agent_card` call `status=ok`, dashboard runtime resolution reports `server_repo_path` from this worktree

## Known follow-up
Unrelated local verification blockers discovered during this pass are tracked in #13278.