### PR TITLE
fix(keeper): persist timeout budget strikes in process

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -184,9 +184,10 @@ val set_after_acquire_flag_hook_for_test :
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
     per keeper. Promoted to [Keeper_fiber_crash] at
     [oas_timeout_budget_strike_limit]; reset on any successful turn.
-    Counter survives within a server lifetime. After restart, callers
-    may hydrate the first bump from persisted [Oas_timeout_budget_loop]
-    state so multi-process loops still reach the supervisor gate. *)
+    The in-process CAS map survives within a server lifetime. After
+    restart, callers may hydrate the first bump from persisted
+    [Oas_timeout_budget_loop] state so multi-process loops still reach
+    the supervisor gate. *)
 val oas_timeout_budget_strike_limit : int
 
 val bump_budget_exhaustion_seeded :

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -667,20 +667,46 @@ let reset_autonomous_completion_for_test () : unit =
    partially observed loop. *)
 let oas_timeout_budget_strike_limit = 3
 
-let bump_budget_exhaustion_seeded ~keeper_name:_ ~prior_strikes : int =
-  max 0 prior_strikes + 1
+module Budget_strike_map = Map.Make (String)
 
-let bump_budget_exhaustion ~keeper_name:_ : int =
-  1
+let budget_exhaustions : int Budget_strike_map.t Atomic.t =
+  Atomic.make Budget_strike_map.empty
 
-let reset_budget_exhaustion ~keeper_name:_ : unit =
-  ()
+let update_budget_exhaustions f =
+  let rec loop () =
+    let current = Atomic.get budget_exhaustions in
+    let next, result = f current in
+    if Atomic.compare_and_set budget_exhaustions current next then result
+    else loop ()
+  in
+  loop ()
 
-let peek_budget_exhaustion_for_test ~keeper_name:_ : int =
-  0
+let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes : int =
+  let prior_strikes = max 0 prior_strikes in
+  update_budget_exhaustions (fun current ->
+    let current_strikes =
+      Budget_strike_map.find_opt keeper_name current
+      |> Option.value ~default:prior_strikes
+    in
+    let next_strikes = max current_strikes prior_strikes + 1 in
+    (Budget_strike_map.add keeper_name next_strikes current, next_strikes))
 
-let set_budget_exhaustion_for_test ~keeper_name:_ ~strikes:_ : unit =
-  ()
+let bump_budget_exhaustion ~keeper_name : int =
+  bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes:0
+
+let reset_budget_exhaustion ~keeper_name : unit =
+  update_budget_exhaustions (fun current ->
+    (Budget_strike_map.remove keeper_name current, ()))
+
+let peek_budget_exhaustion_for_test ~keeper_name : int =
+  Budget_strike_map.find_opt keeper_name (Atomic.get budget_exhaustions)
+  |> Option.value ~default:0
+
+let set_budget_exhaustion_for_test ~keeper_name ~strikes : unit =
+  if strikes <= 0 then reset_budget_exhaustion ~keeper_name
+  else
+    update_budget_exhaustions (fun current ->
+      (Budget_strike_map.add keeper_name strikes current, ()))
 
 (** Test-only: stamp a completion time directly without going through
     [Time_compat.now].  Allows deterministic fairness-cooldown scenarios. *)

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -153,7 +153,11 @@ val set_after_acquire_flag_hook_for_test :
   (label:string -> keeper_name:string -> unit) option -> unit
 
 (** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
-    per keeper. Promoted to [Keeper_fiber_crash] at this limit. *)
+    per keeper. Promoted to [Keeper_fiber_crash] at this limit.
+
+    Counts are stored in an in-process CAS map and can be seeded from the
+    persisted [Oas_timeout_budget_loop] failure reason on the first bump after
+    restart or another process update. *)
 val oas_timeout_budget_strike_limit : int
 
 val bump_budget_exhaustion_seeded :

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -1,18 +1,58 @@
-(* Test rewritten for stateless budget exhaustion *)
 open Masc_mcp
 
 module KK = Keeper_keepalive
 
-let test_bump_increments () =
-  let strikes = KK.bump_budget_exhaustion_seeded ~keeper_name:"k" ~prior_strikes:2 in
-  Alcotest.(check int) "bump increments from 2 to 3" 3 strikes
+let with_reset keeper f =
+  KK.reset_budget_exhaustion ~keeper_name:keeper;
+  Fun.protect
+    ~finally:(fun () -> KK.reset_budget_exhaustion ~keeper_name:keeper)
+    f
+
+let test_seeded_bump_increments_from_prior () =
+  with_reset "seeded" (fun () ->
+    let strikes =
+      KK.bump_budget_exhaustion_seeded
+        ~keeper_name:"seeded"
+        ~prior_strikes:2
+    in
+    Alcotest.(check int) "bump increments from 2 to 3" 3 strikes;
+    Alcotest.(check int) "peek sees persisted in-process count" 3
+      (KK.peek_budget_exhaustion_for_test ~keeper_name:"seeded"))
+
+let test_in_process_bump_accumulates () =
+  with_reset "in-process" (fun () ->
+    Alcotest.(check int) "first" 1
+      (KK.bump_budget_exhaustion ~keeper_name:"in-process");
+    Alcotest.(check int) "second" 2
+      (KK.bump_budget_exhaustion ~keeper_name:"in-process"))
+
+let test_seeded_bump_uses_higher_persisted_count () =
+  with_reset "seed-max" (fun () ->
+    KK.set_budget_exhaustion_for_test ~keeper_name:"seed-max" ~strikes:1;
+    let strikes =
+      KK.bump_budget_exhaustion_seeded
+        ~keeper_name:"seed-max"
+        ~prior_strikes:4
+    in
+    Alcotest.(check int) "seed catches up to persisted count" 5 strikes)
 
 let test_reset_clears () =
-  KK.reset_budget_exhaustion ~keeper_name:"k";
-  Alcotest.(check pass) "reset is a no-op" () ()
+  KK.set_budget_exhaustion_for_test ~keeper_name:"reset" ~strikes:2;
+  KK.reset_budget_exhaustion ~keeper_name:"reset";
+  Alcotest.(check int) "reset clears" 0
+    (KK.peek_budget_exhaustion_for_test ~keeper_name:"reset")
 
-let tests =
+let () =
+  Alcotest.run "oas_timeout_budget_strike"
   [
-    ("bump increments", `Quick, test_bump_increments);
-    ("reset clears", `Quick, test_reset_clears);
+    ( "strike ledger",
+      [
+        Alcotest.test_case "seeded bump increments" `Quick
+          test_seeded_bump_increments_from_prior;
+        Alcotest.test_case "in-process bump accumulates" `Quick
+          test_in_process_bump_accumulates;
+        Alcotest.test_case "seeded bump uses higher persisted count" `Quick
+          test_seeded_bump_uses_higher_persisted_count;
+        Alcotest.test_case "reset clears" `Quick test_reset_clears;
+      ] );
   ]


### PR DESCRIPTION
## Summary

- replace the stateless `oas_timeout_budget` strike helpers with an in-process CAS-backed per-keeper ledger
- keep seeded bump behavior so persisted `Oas_timeout_budget_loop` counts can hydrate the first bump after restart or another process update
- make `test_oas_timeout_budget_strike` run as a real Alcotest executable and cover seed, in-process accumulation, catch-up, and reset behavior

## Why

The audit follow-up identified `consecutive_budget_exhaustions` as still-live but requiring a narrower framing: restart/multi-process cases should derive from persisted turn failure state, while same-process retries still need a real per-keeper strike ledger. The interface already described that behavior, but the implementation had been rewritten to stateless/no-op helpers and the test file did not call `Alcotest.run`.

This keeps the existing supervisor flow intact: callers seed from `Oas_timeout_budget_loop`, the local ledger accumulates repeated failures within the process, and successful turns reset the in-process count plus clear the persisted failure reason.

## Validation

- `git diff --check HEAD~1..HEAD`
- `scripts/check-oas-pin.sh`
- `env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe`
- `./_build/default/test/test_oas_timeout_budget_strike.exe` (4 tests)
