### PR TITLE
fix(keeper): accept integer per-provider timeouts

### DIFF
--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -488,6 +488,7 @@ let toml_int_opt (doc : toml_doc) (key : string) : int option =
 let toml_float_opt (doc : toml_doc) (key : string) : float option =
   match List.assoc_opt key doc with
   | Some (Toml_float f) -> Some f
+  | Some (Toml_int i) -> Some (float_of_int i)
   | _ -> None
 ;;
 

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -739,6 +739,47 @@ preset = "delivery"
         (Some "toml")
         updated.tool_preset_source
 
+let test_toml_integer_per_provider_timeout_updates_runtime () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "timeout-int-toml-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+sandbox_profile = "docker"
+goal = "test"
+per_provider_timeout = 45
+|};
+  let config = Coord.default_config room_dir in
+  let initial_meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-timeout-int-toml");
+            ("per_provider_timeout_s", `Float 12.5);
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  seed_persisted_meta config initial_meta;
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check
+        (option (float 0.0001))
+        "integer TOML timeout updates runtime"
+        (Some 45.0)
+        updated.Keeper_types.per_provider_timeout_s
+
 let test_toml_invalid_per_provider_timeout_clears_stale_runtime () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
   with_config_dir @@ fun config_dir ->
@@ -1255,6 +1296,10 @@ let () =
             "persona defaults can be overlaid by keeper TOML"
             `Quick
             test_persona_overlay_resync;
+          test_case
+            "integer TOML per_provider_timeout updates runtime JSON"
+            `Quick
+            test_toml_integer_per_provider_timeout_updates_runtime;
           test_case
             "invalid TOML per_provider_timeout clears stale runtime JSON"
             `Quick


### PR DESCRIPTION
## Summary
- accept TOML integer literals in keeper float parsing for `per_provider_timeout`
- add a runtime config SSOT regression proving `per_provider_timeout = 45` overwrites stale runtime meta as `45.0`

## Root Cause
Live keeper config used `per_provider_timeout = 45`, which is valid TOML but was parsed as `Toml_int`. The keeper timeout loader only accepted `Toml_float`, so runtime reconciliation logged `keeper TOML per_provider_timeout has invalid type; ignoring` and left the safety timeout unset.

## Validation
- `scripts/dune-local.sh build test/test_keeper_runtime_config_ssot.exe`
- `./_build/default/test/test_keeper_runtime_config_ssot.exe test policy 10-13 --show-errors`

## Notes
- Full `test_keeper_runtime_config_ssot.exe` was attempted, but this live sandbox still fails existing non-target cases that require Docker API access (`policy.002`) and a cascade-default expectation under the current test environment (`discovery.001`). The focused timeout regression and neighboring timeout cases pass.