### PR TITLE
spec(keeper): model turn-slot retry release invariant

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -142,6 +142,8 @@ ensure_trace_data() {
 # Run all keeper state machine specs
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperStateMachine.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperTurnCycle.tla"
+run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperTurnSlot.tla"
+run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperTurnSlot.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCascadeLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCascadeLifecycle.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperOASAdvanced.tla"

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-05T04:03:30Z (HEAD: a2df61c549)
+Generated: 2026-05-05T14:52:32Z (HEAD: 9f878eba7c)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 88 |
-| Manual specs | 88 |
+| Total .tla files | 89 |
+| Manual specs | 89 |
 | TTrace (auto-generated) | 0 |
 | Directories | 18 |
-| Total .cfg files | 177 |
-| Buggy .cfg (bug-model pair) | 86 |
+| Total .cfg files | 179 |
+| Buggy .cfg (bug-model pair) | 87 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -51,7 +51,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | AuditLogAppendOrder.tla | AuditLogAppendOrder | manual | 2 | 1 | clean={inv:TypeOK, inv:MutexExclusion} buggy={inv:MutexExclusion} | 5cafd04c9e66 |
 | AuditLogDurableBeforeAck.tla | AuditLogDurableBeforeAck | manual | 2 | 1 | clean={inv:TypeOK, inv:Durability} buggy={inv:Durability} | 2e72a23b081e |
 | Bounded.tla | Bounded | manual | 2 | 1 | clean={inv:TypeOK, inv:Termination, inv:TokenBudget} buggy={inv:Termination, inv:TokenBudget} | d22f3d75f262 |
-| Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | 834dcb495e5a |
+| Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | bbed415483ac |
 | CascadeKeeperRecovery.tla | CascadeKeeperRecovery | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 370581910533 |
 | CascadeResolver.tla | CascadeResolver | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:NeverRouteToDown} | e0c5a7d1d999 |
 | CascadeStrategy.tla | CascadeStrategy | manual | 2 | 1 | clean={inv:Safety} buggy={inv:BoundedCycle} | 004523df4adf |
@@ -112,7 +112,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 |------|--------|------|-----|-------|-------------------------|---------------|
 | ContractClosure.tla | ContractClosure | manual | 2 | 1 | clean={inv:TypeOK, inv:ClosureIntegrity, prop:VerdictUnblocksFsm} buggy={inv:ClosureIntegrity} | d4121bf6a81c |
 
-### specs/keeper-state-machine (28 specs)
+### specs/keeper-state-machine (29 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
@@ -142,6 +142,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperTaskAcquisition.tla | KeeperTaskAcquisition | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | dacc5ab9bbfc |
 | KeeperTraceSpec.tla | KeeperTraceSpec | manual | 1 | 0 | clean={inv:TypeOK, inv:RunningRequiresFiber, inv:OfflineRequiresLaunchPending, inv:StoppedRequiresDrain, inv:DeadRequiresNoBudget, inv:DerivePhaseAgreement, prop:RestartCountMonotonic, prop:BudgetNeverRevives, prop:TransitionMatrixAgreement} | 12ceda9758f0 |
 | KeeperTurnCycle.tla | KeeperTurnCycle | manual | 1 | 0 | clean={inv:TypeOK, inv:Safety, prop:Liveness} | 5edbfd9dcab8 |
+| KeeperTurnSlot.tla | KeeperTurnSlot | manual | 2 | 1 | clean={inv:Safety} buggy={inv:RetryPhaseRequiresReleased} | f75c324a95fe |
 | KeeperWorkPipeline.tla | KeeperWorkPipeline | manual | 1 | 0 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent, inv:NoForcePush, inv:ReviewBeforeSubmit, prop:EventualCompletion, prop:NoOrphanWorkspace} | ab03a79d78e6 |
 | OperatorPauseBroadcast.tla | OperatorPauseBroadcast | manual | 2 | 1 | clean={inv:TypeOK, inv:EmittedBeforeResolved, prop:PauseLeadsToBroadcast, prop:OperatorPauseEverHandled} buggy={inv:TypeOK, prop:PauseLeadsToBroadcast} | 2ef619cbcd73 |
 

--- a/specs/keeper-state-machine/KeeperTurnSlot-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperTurnSlot-buggy.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    ProductivePhaseBudget = 2
+    MaxRetryTicks = 2
+    MaxSteps = 6
+
+INVARIANT RetryPhaseRequiresReleased
+
+CHECK_DEADLOCK FALSE

--- a/specs/keeper-state-machine/KeeperTurnSlot.cfg
+++ b/specs/keeper-state-machine/KeeperTurnSlot.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    ProductivePhaseBudget = 2
+    MaxRetryTicks = 2
+    MaxSteps = 6
+
+INVARIANT Safety
+
+CHECK_DEADLOCK FALSE

--- a/specs/keeper-state-machine/KeeperTurnSlot.tla
+++ b/specs/keeper-state-machine/KeeperTurnSlot.tla
@@ -1,0 +1,222 @@
+---- MODULE KeeperTurnSlot ----
+\* KeeperTurnSlot -- #12888 productive-slot lifecycle contract.
+\*
+\* This is the formal target for the 174s <-> 600s slot leak class:
+\* once degraded retry routing begins, the outer turn slot must already be
+\* released. A retry may later reacquire a fresh productive slot, but it must
+\* not keep the same acquisition across the retry phase.
+\*
+\* OCaml <-> TLA+ mapping:
+\*
+\*   spec variable / action     | OCaml surface
+\*   ---------------------------+----------------------------------------------
+\*   ProductivePhaseBudget      | Env_config_keeper.KeeperRetryBackoff.
+\*                              | degraded_retry_slot_phase_budget_sec
+\*   productive_elapsed         | keeper_unified_turn.current_turn_phase_elapsed_ms
+\*   RetryScheduled             | Degraded_retry_allowed branch
+\*   ProductivePhaseExhausted   | Degraded_retry_slot_phase_exhausted branch
+\*   release_at_phase           | cascade_rotation_attempt.slot_release_at_phase
+\*
+\* The current runtime mitigation (#13120) rejects late rotation once the
+\* productive phase is exhausted; #13272 exposes the release/phase telemetry.
+\* This spec pins the stricter #12888 target invariant so future two-tier
+\* admission work has a model-level acceptance check.
+
+EXTENDS Naturals
+
+CONSTANTS
+    ProductivePhaseBudget,
+    MaxRetryTicks,
+    MaxSteps
+
+VARIABLES
+    phase,
+    slot_held,
+    slot_held_elapsed,
+    productive_elapsed,
+    retry_elapsed,
+    release_at_phase,
+    step
+
+vars ==
+    << phase, slot_held, slot_held_elapsed, productive_elapsed,
+       retry_elapsed, release_at_phase, step >>
+
+PhaseSet == {"idle", "productive", "retry", "done", "failed"}
+ReleasePhaseSet ==
+    {"none", "retry_scheduled", "productive_phase_exhausted", "finish"}
+
+TypeOK ==
+    /\ ProductivePhaseBudget \in Nat \ {0}
+    /\ MaxRetryTicks \in Nat
+    /\ MaxSteps \in Nat
+    /\ phase \in PhaseSet
+    /\ slot_held \in BOOLEAN
+    /\ slot_held_elapsed \in 0..ProductivePhaseBudget
+    /\ productive_elapsed \in 0..ProductivePhaseBudget
+    /\ retry_elapsed \in 0..MaxRetryTicks
+    /\ release_at_phase \in ReleasePhaseSet
+    /\ step \in 0..MaxSteps
+
+Init ==
+    /\ phase = "idle"
+    /\ slot_held = FALSE
+    /\ slot_held_elapsed = 0
+    /\ productive_elapsed = 0
+    /\ retry_elapsed = 0
+    /\ release_at_phase = "none"
+    /\ step = 0
+
+AcquireProductive ==
+    /\ step < MaxSteps
+    /\ phase = "idle"
+    /\ ~slot_held
+    /\ phase' = "productive"
+    /\ slot_held' = TRUE
+    /\ slot_held_elapsed' = 0
+    /\ productive_elapsed' = 0
+    /\ retry_elapsed' = 0
+    /\ release_at_phase' = "none"
+    /\ step' = step + 1
+
+ProductiveTick ==
+    /\ step < MaxSteps
+    /\ phase = "productive"
+    /\ slot_held
+    /\ productive_elapsed < ProductivePhaseBudget
+    /\ slot_held_elapsed < ProductivePhaseBudget
+    /\ productive_elapsed' = productive_elapsed + 1
+    /\ slot_held_elapsed' = slot_held_elapsed + 1
+    /\ step' = step + 1
+    /\ UNCHANGED <<phase, slot_held, retry_elapsed, release_at_phase>>
+
+\* First degraded retry decision. The slot is released before the model enters
+\* retry phase; a later retry attempt must acquire a fresh productive slot.
+RetryScheduled ==
+    /\ step < MaxSteps
+    /\ phase = "productive"
+    /\ slot_held
+    /\ productive_elapsed < ProductivePhaseBudget
+    /\ phase' = "retry"
+    /\ slot_held' = FALSE
+    /\ release_at_phase' = "retry_scheduled"
+    /\ retry_elapsed' = 0
+    /\ step' = step + 1
+    /\ UNCHANGED <<slot_held_elapsed, productive_elapsed>>
+
+\* Stop-gap behavior from #13120: if the productive phase is already exhausted,
+\* end the cycle so the outer slot is released instead of rotating in place.
+ProductivePhaseExhausted ==
+    /\ step < MaxSteps
+    /\ phase = "productive"
+    /\ slot_held
+    /\ productive_elapsed >= ProductivePhaseBudget
+    /\ phase' = "failed"
+    /\ slot_held' = FALSE
+    /\ release_at_phase' = "productive_phase_exhausted"
+    /\ step' = step + 1
+    /\ UNCHANGED <<slot_held_elapsed, productive_elapsed, retry_elapsed>>
+
+FinishProductive ==
+    /\ step < MaxSteps
+    /\ phase = "productive"
+    /\ slot_held
+    /\ phase' = "done"
+    /\ slot_held' = FALSE
+    /\ release_at_phase' = "finish"
+    /\ step' = step + 1
+    /\ UNCHANGED <<slot_held_elapsed, productive_elapsed, retry_elapsed>>
+
+RetryTick ==
+    /\ step < MaxSteps
+    /\ phase = "retry"
+    /\ ~slot_held
+    /\ retry_elapsed < MaxRetryTicks
+    /\ retry_elapsed' = retry_elapsed + 1
+    /\ step' = step + 1
+    /\ UNCHANGED <<phase, slot_held, slot_held_elapsed,
+                  productive_elapsed, release_at_phase>>
+
+RetryReacquireProductive ==
+    /\ step < MaxSteps
+    /\ phase = "retry"
+    /\ ~slot_held
+    /\ phase' = "productive"
+    /\ slot_held' = TRUE
+    /\ slot_held_elapsed' = 0
+    /\ productive_elapsed' = 0
+    /\ release_at_phase' = "none"
+    /\ step' = step + 1
+    /\ UNCHANGED retry_elapsed
+
+FinishTerminal ==
+    /\ step < MaxSteps
+    /\ phase \in {"done", "failed"}
+    /\ ~slot_held
+    /\ phase' = "idle"
+    /\ release_at_phase' = "none"
+    /\ step' = step + 1
+    /\ UNCHANGED <<slot_held, slot_held_elapsed,
+                  productive_elapsed, retry_elapsed>>
+
+Next ==
+    \/ AcquireProductive
+    \/ ProductiveTick
+    \/ RetryScheduled
+    \/ ProductivePhaseExhausted
+    \/ FinishProductive
+    \/ RetryTick
+    \/ RetryReacquireProductive
+    \/ FinishTerminal
+
+Spec == Init /\ [][Next]_vars
+
+\* Safety invariants.
+SlotHeldOnlyInProductive ==
+    slot_held => phase = "productive"
+
+SlotHeldBoundedByProductiveBudget ==
+    slot_held => slot_held_elapsed <= ProductivePhaseBudget
+
+RetryPhaseRequiresReleased ==
+    phase = "retry" => ~slot_held
+
+ProductiveExhaustionReleasesSlot ==
+    release_at_phase = "productive_phase_exhausted" =>
+        /\ phase = "failed"
+        /\ ~slot_held
+
+Safety ==
+    /\ TypeOK
+    /\ SlotHeldOnlyInProductive
+    /\ SlotHeldBoundedByProductiveBudget
+    /\ RetryPhaseRequiresReleased
+    /\ ProductiveExhaustionReleasesSlot
+
+\* Bug model: degraded retry changes the logical phase but forgets to release
+\* the slot. TLC must violate RetryPhaseRequiresReleased.
+RetryScheduledWithoutRelease ==
+    /\ step < MaxSteps
+    /\ phase = "productive"
+    /\ slot_held
+    /\ productive_elapsed < ProductivePhaseBudget
+    /\ phase' = "retry"
+    /\ slot_held' = TRUE
+    /\ release_at_phase' = "retry_scheduled"
+    /\ retry_elapsed' = 0
+    /\ step' = step + 1
+    /\ UNCHANGED <<slot_held_elapsed, productive_elapsed>>
+
+NextBuggy ==
+    \/ AcquireProductive
+    \/ ProductiveTick
+    \/ RetryScheduledWithoutRelease
+    \/ ProductivePhaseExhausted
+    \/ FinishProductive
+    \/ RetryTick
+    \/ RetryReacquireProductive
+    \/ FinishTerminal
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+====


### PR DESCRIPTION
## Summary

- add `KeeperTurnSlot.tla` for the #12888 productive-slot lifecycle contract
- add clean/buggy cfgs so TLC proves the clean model and rejects a retry phase that keeps the slot held
- wire the spec into `scripts/tla-check.sh` and refresh `specs/INDEX.md`

## Why

#12888 still has a formal acceptance gap after the runtime mitigation in #13120 and the telemetry surface in #13272. This PR pins the stricter target: retry phase must not keep the same turn-slot acquisition, and productive-phase exhaustion releases the slot instead of rotating in place.

## Validation

- PASS: `java -XX:+UseParallelGC -Xmx1g -cp /Users/dancer/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/keeper-state-machine/KeeperTurnSlot.cfg -workers 1 -deadlock specs/keeper-state-machine/KeeperTurnSlot.tla` (69 states generated, 59 distinct)
- PASS expected violation: `java -XX:+UseParallelGC -Xmx1g -cp /Users/dancer/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/keeper-state-machine/KeeperTurnSlot-buggy.cfg -workers 1 -deadlock specs/keeper-state-machine/KeeperTurnSlot.tla` (`RetryPhaseRequiresReleased` violated)
- PASS: `bash scripts/ci/check-tla-harness-coverage.sh`
- PASS: `git diff --cached --check`
- PASS: `scripts/check-oas-pin.sh` (API surface matched; warned upstream OAS drift remains)