### PR TITLE
fix(docker): declare keeper credential volume

### DIFF
--- a/Dockerfile.keeper-sandbox
+++ b/Dockerfile.keeper-sandbox
@@ -6,6 +6,7 @@
 #     MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS=false
 #     REQUIRE_USERNS=false
 # - The host docker socket is typically mounted for DinD operations.
+# - Keeper GitHub/SSH credential bundles are projected at /tmp/keeper-creds.
 
 FROM ubuntu:24.04
 
@@ -43,5 +44,7 @@ RUN opam init --disable-sandboxing --root "$OPAMROOT" --bare -y \
  && rm -rf "$OPAMROOT/repo" "$OPAMROOT/.opam-switch/sources"
 
 ENV PATH="/opt/opam/default/bin:${PATH}"
+
+VOLUME ["/tmp/keeper-creds"]
 
 CMD ["/bin/bash"]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -715,6 +715,20 @@ let test_keeper_list_cache_atomic_contracts () =
   check bool "keeper list cache no longer mutates expiry field in place" true
     (file_not_contains_pattern "lib/tool_keeper.ml" "_keeper_list_cache.expires_at <-")
 
+let test_keeper_sandbox_credential_volume_contracts () =
+  check bool "keeper sandbox documents credential projection path" true
+    (file_contains_pattern "Dockerfile.keeper-sandbox"
+       "credential bundles are projected at /tmp/keeper-creds");
+  check bool "keeper sandbox declares credential projection volume" true
+    (file_contains_pattern "Dockerfile.keeper-sandbox"
+       {|VOLUME ["/tmp/keeper-creds"]|});
+  check bool "host config provider exposes the same in-container root" true
+    (file_contains_pattern "lib/keeper/host_config_provider.mli"
+       {|[/tmp/keeper-creds]|});
+  check bool "host config provider implementation uses the volume root" true
+    (file_contains_pattern "lib/keeper/host_config_provider.ml"
+       {|let cred_root = "/tmp/keeper-creds"|})
+
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
@@ -1419,6 +1433,8 @@ let () =
              test_keeper_direct_reply_contracts;
            test_case "keeper list cache atomic contracts" `Quick
              test_keeper_list_cache_atomic_contracts;
+           test_case "keeper sandbox credential volume contracts" `Quick
+             test_keeper_sandbox_credential_volume_contracts;
            test_case "dashboard warm hydration contracts" `Quick
              test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;


### PR DESCRIPTION
## Summary
- declare /tmp/keeper-creds as the keeper sandbox credential projection volume
- document the Dockerfile contract beside the existing hardening notes
- add a source-contract test that keeps Dockerfile.keeper-sandbox aligned with Host_config_provider.cred_root

## Source-doc link
- Follows the Kimi Multi Keeper plan Docker credential mount standardization gap (Boundary B / credential mount contract)
- Refs #13276

## Verification
- scripts/dune-local.sh build test/test_ci_hardening_source.exe
- scripts/dune-local.sh exec test/test_ci_hardening_source.exe (passed before rebase: 41 tests, including the new credential volume contract)
- git diff --check origin/main..HEAD

## Note
- The post-rebase focused exec was started again and is queued behind another repo-local Dune lock; the branch was rebased cleanly onto current origin/main and PR CI will run on this exact head.