### PR TITLE
fix(keeper): honor boot grace for stuck detector

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -808,6 +808,9 @@ let started_at ~base_path name =
   | Some entry -> Some entry.started_at
   | None -> None
 
+let set_started_at_for_test ~base_path name started_at =
+  update_entry ~base_path name (fun entry -> { entry with started_at })
+
 let spawn_slots_available () =
   let max_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
   max_keepers <= 0

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -386,6 +386,10 @@ val mark_dead : base_path:string -> string -> at:float -> unit
 (** Return the started_at timestamp, or None if not registered. *)
 val started_at : base_path:string -> string -> float option
 
+(** Test-only: override [started_at] for registry fixtures that need to
+    model a long-running fiber without waiting for wall-clock time. *)
+val set_started_at_for_test : base_path:string -> string -> float -> unit
+
 (** Count keepers in Running state. *)
 val count_running : ?base_path:string -> unit -> int
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1741,8 +1741,12 @@ let liveness_recovery_scan (ctx : _ context) =
     [max(stall_floor_sec, stall_multiplier * cooldown_sec)] without a
     proactive turn.
 
-    Reference timestamp: [proactive_rt.last_ts] if that has ever
-    fired ([> 0.0]), otherwise [entry.started_at] — this catches the
+    Reference timestamp: the newer of [proactive_rt.last_ts] and
+    [entry.started_at] when proactive has ever fired ([> 0.0]),
+    otherwise [entry.started_at].  This preserves detection for
+    long-running frozen keepers while giving freshly restarted keepers
+    the normal boot grace even when their persisted proactive timestamp
+    is old.  The [entry.started_at] fallback also catches the
     "never_started" case (e.g. [glm-coding-plan] in the production
     sample) without a separate code path.
 
@@ -1763,8 +1767,10 @@ let detect_alive_but_stuck ~now ~stall_multiplier ~stall_floor_sec
     in
     let last_proactive_ts = meta.runtime.proactive_rt.last_ts in
     let reference_ts =
-      if last_proactive_ts > 0.0 then last_proactive_ts
-      else entry.started_at
+      if last_proactive_ts > 0.0 then
+        Float.max last_proactive_ts entry.started_at
+      else
+        entry.started_at
     in
     let elapsed = now -. reference_ts in
     if elapsed > stall_threshold then Some elapsed else None

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -124,9 +124,10 @@ val detect_alive_but_stuck :
     keeper has gone longer than
     [max(stall_floor_sec, stall_multiplier * proactive.cooldown_sec)]
     without a proactive turn while autonomous turns kept advancing.
-    Reference timestamp is [proactive_rt.last_ts] if set, else
-    [entry.started_at] (covers the never-started case).  Returns [None]
-    otherwise.  Exposed for tests. *)
+    Reference timestamp is the newer of [proactive_rt.last_ts] and
+    [entry.started_at] if proactive has fired, else [entry.started_at]
+    (covers the never-started case).  Returns [None] otherwise.  Exposed
+    for tests. *)
 
 val alive_but_stuck_scan : 'a context -> unit
 (** Scan all keepers in [Keeper_registry].  For each keeper detected as

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1492,6 +1492,26 @@ let () =
             | None -> fail "expected stalled keeper to be detected"
             | Some elapsed ->
               check (float 1.0) "elapsed ≈ 99000s" 99_000.0 elapsed);
+        test_case
+          "fresh fiber start suppresses stale persisted proactive_ts"
+          `Quick
+          (fun () ->
+            (* Regression for live restart on 2026-05-05: keepers booted
+               with a fresh registry [started_at] but old persisted
+               [proactive_rt.last_ts], causing the alive-but-stuck scan to
+               crash them before a recovery turn could run. *)
+            let entry = make_test_entry
+                ~name:"abs-fresh-restart"
+                ~paused:false
+                ~phase:KSM.Running
+                ~autonomous_turn_count:50
+                ~last_proactive_ts:1_000.0
+                ~cooldown_sec:60
+                ~started_at:99_500.0
+            in
+            check (option (float 0.1))
+              "fresh boot grace wins over stale persisted proactive_ts"
+              None (detect entry));
         test_case "scan queues recovery wakeup for running stalled keeper" `Quick
           (fun () ->
             Eio_main.run @@ fun env ->
@@ -1525,6 +1545,7 @@ let () =
                 ignore (Reg.register ~base_path:config.base_path name meta);
                 ignore (Reg.dispatch_event ~base_path:config.base_path name
                           KSM.Fiber_started);
+                Reg.set_started_at_for_test ~base_path:config.base_path name 1.0;
                 let ctx : _ KT.context =
                   {
                     config;
@@ -1596,6 +1617,7 @@ let () =
                 ignore (Reg.register ~base_path:config.base_path name meta);
                 ignore (Reg.dispatch_event ~base_path:config.base_path name
                           KSM.Fiber_started);
+                Reg.set_started_at_for_test ~base_path:config.base_path name 1.0;
                 let ctx : _ KT.context =
                   {
                     config;


### PR DESCRIPTION
## Summary
- make alive-but-stuck detection use the newer of persisted proactive timestamp and the current keeper fiber start time
- add a fresh-restart regression so old persisted proactive timestamps do not immediately crash newly booted keepers
- add a test-only registry started_at override for long-running scan fixtures

## Root Cause
On live restart, keeper bootstrap refreshed `last_turn_ts` but not `runtime.proactive_rt.last_ts`. The alive-but-stuck detector preferred that old proactive timestamp over the new registry `started_at`, so keepers with historical autonomous activity were immediately marked stuck and routed through crash/restart before a recovery turn could run.

## Operator Impact
Freshly restarted keepers now receive the normal boot grace even when their persisted proactive timestamp is stale. Long-running keepers that actually freeze still trip the detector once their current fiber has been stale past the configured threshold.

## Validation
- `scripts/dune-local.sh exec ./test/test_keeper_supervisor.exe -- test alive_but_stuck`
- `git diff --check`

## Notes
A full `test_keeper_supervisor.exe` run still has unrelated existing self-preservation failures from `publish_lifecycle` being invoked outside an Eio context; the changed `alive_but_stuck` group passes.