### PR TITLE
feat(board): expose current vote state

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -443,6 +443,8 @@ describe('fetchBoard', () => {
           body: 'Working',
           created_at: 1_713_000_000,
           updated_at: 1_713_000_000,
+          current_vote: 'up',
+          has_voted: true,
           author_identity: {
             kind: 'keeper',
             id: 'analyst',
@@ -465,6 +467,10 @@ describe('fetchBoard', () => {
 
     const result = await fetchBoard()
 
+    expect(result.posts[0]).toMatchObject({
+      current_vote: 'up',
+      has_voted: true,
+    })
     expect(result.posts[0]?.author_identity).toMatchObject({
       kind: 'keeper',
       id: 'analyst',
@@ -472,6 +478,8 @@ describe('fetchBoard', () => {
       source: 'keeper_alias_contract',
       runtime_agent_name: 'keeper-analyst-agent',
     })
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('voter=')
   })
 
   it('passes hearth filters through to the board API', async () => {
@@ -526,6 +534,8 @@ describe('fetchBoardPost', () => {
         body: 'Working',
         created_at: 1_713_000_000,
         updated_at: 1_713_000_000,
+        current_vote: 'down',
+        has_voted: true,
       },
       comments: [
         {
@@ -537,6 +547,8 @@ describe('fetchBoardPost', () => {
           votes_up: 5,
           votes_down: 2,
           score: 3,
+          current_vote: 'up',
+          has_voted: true,
         },
       ],
     }
@@ -556,7 +568,13 @@ describe('fetchBoardPost', () => {
       vote_balance: 3,
       votes_up: 5,
       votes_down: 2,
+      current_vote: 'up',
+      has_voted: true,
     })
+    expect(result.current_vote).toBe('down')
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('format=flat')
+    expect(url).toContain('voter=')
   })
 })
 

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,8 +1,9 @@
-import { get, post, withRetries, defaultBoardVoter } from './core'
+import { currentDashboardActor, get, post, withRetries, defaultBoardVoter } from './core'
 import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
 import type {
   BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
   BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
+  BoardVoteDirection,
   GovernanceContextRef,
   GovernanceDecisionItem, GovernanceExecutedRoute,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
@@ -330,6 +331,11 @@ function normalizeBoardActorIdentity(
   }
 }
 
+function normalizeBoardVoteDirection(raw: unknown): BoardVoteDirection | null {
+  const direction = asString(raw, '').trim().toLowerCase()
+  return direction === 'up' || direction === 'down' ? direction : null
+}
+
 function normalizeBoardPost(raw: unknown): BoardPost | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id, '').trim()
@@ -342,6 +348,8 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
   const votesUp = asNumber(raw.votes_up, 0)
   const votesDown = asNumber(raw.votes_down, 0)
   const votes = asNumber(raw.votes, score || (votesUp - votesDown))
+  const currentVote = normalizeBoardVoteDirection(raw.current_vote)
+  const hasVoted = typeof raw.has_voted === 'boolean' ? raw.has_voted : currentVote !== null
   const commentCount = asNumber(raw.comment_count, asNumber(raw.reply_count, 0))
   const flairValue = (() => {
     const flair = raw.flair
@@ -382,6 +390,8 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     tags,
     votes,
     vote_balance: score,
+    current_vote: currentVote,
+    has_voted: hasVoted,
     comment_count: commentCount,
     created_at: createdAt ?? '',
     updated_at: updatedAt ?? '',
@@ -409,6 +419,8 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
   const votesDown = asNumber(raw.votes_down, 0)
   const score = asNumber(raw.score, votesUp - votesDown)
   const votes = asNumber(raw.votes, score)
+  const currentVote = normalizeBoardVoteDirection(raw.current_vote)
+  const hasVoted = typeof raw.has_voted === 'boolean' ? raw.has_voted : currentVote !== null
   return {
     id,
     post_id: postId,
@@ -421,6 +433,8 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     vote_balance: score,
     votes_up: votesUp,
     votes_down: votesDown,
+    current_vote: currentVote,
+    has_voted: hasVoted,
   }
 }
 
@@ -486,6 +500,7 @@ export async function fetchBoard(
     if (options?.excludeAutomation) params.set('exclude_automation', 'true')
     if (options?.author) params.set('author', options.author)
     if (options?.hearth) params.set('hearth', options.hearth)
+    params.set('voter', currentDashboardActor())
     params.set('limit', options?.excludeSystem || options?.excludeAutomation || options?.author || options?.hearth ? '150' : '100')
     const qs = params.toString()
     const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
@@ -524,7 +539,11 @@ export async function fetchBoardReactions(
 
 export async function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
   return withRetries('fetchBoardPost', async () => {
-    const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?format=flat`)
+    const params = new URLSearchParams({
+      format: 'flat',
+      voter: currentDashboardActor(),
+    })
+    const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?${params}`)
     const postRaw = isRecord(raw.post) ? raw.post : raw
     const post = normalizeBoardPost(postRaw) ?? {
       id: postId,

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -505,6 +505,8 @@ function PostCard({ post }: { post: BoardPost }) {
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)
+  const upvoteActive = post.current_vote === 'up'
+  const downvoteActive = post.current_vote === 'down'
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
     event.stopPropagation()
@@ -568,13 +570,17 @@ function PostCard({ post }: { post: BoardPost }) {
       <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-9">
         <button type="button"
           aria-label="추천"
-          class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded-[var(--r-1)] text-2xs text-[var(--color-fg-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] transition-colors cursor-pointer border-0 bg-transparent"
+          aria-pressed=${upvoteActive ? 'true' : 'false'}
+          disabled=${upvoteActive}
+          class=${`vote-btn upvote w-7 h-5 flex items-center justify-center rounded-[var(--r-1)] text-2xs transition-colors border-0 bg-transparent ${upvoteActive ? 'active text-[var(--warn-bright)] bg-[var(--warn-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] cursor-pointer'}`}
           onClick=${(event: Event) => handleVote('up', event)}
         ><span aria-hidden="true">▲</span></button>
         <span class="text-sm font-semibold tabular-nums text-[var(--color-fg-secondary)]">${post.votes ?? 0}</span>
         <button type="button"
           aria-label="비추천"
-          class="vote-btn downvote w-7 h-5 flex items-center justify-center rounded-[var(--r-1)] text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] hover:bg-[var(--accent-10)] transition-colors cursor-pointer border-0 bg-transparent"
+          aria-pressed=${downvoteActive ? 'true' : 'false'}
+          disabled=${downvoteActive}
+          class=${`vote-btn downvote w-7 h-5 flex items-center justify-center rounded-[var(--r-1)] text-2xs transition-colors border-0 bg-transparent ${downvoteActive ? 'active text-[var(--color-accent-fg)] bg-[var(--accent-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:text-[var(--color-accent-fg)] hover:bg-[var(--accent-10)] cursor-pointer'}`}
           onClick=${(event: Event) => handleVote('down', event)}
         ><span aria-hidden="true">▼</span></button>
       </div>

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -81,7 +81,7 @@ import {
   countCommentDescendants,
   filterCommentTree,
 } from './post-detail'
-import { voteComment } from './board-state'
+import { voteComment, votePost } from './board-state'
 import { toggleReaction } from '../../api/board'
 import type { BoardComment } from '../../types/core'
 
@@ -249,6 +249,29 @@ describe('CommentThread', () => {
     expect(screen.getByText('4')).toBeInTheDocument()
   })
 
+  it('marks the current comment vote as pressed', () => {
+    const comments = [
+      {
+        id: 'c1',
+        post_id: 'post-1',
+        parent_id: null,
+        author: 'agent',
+        content: 'already voted',
+        created_at: '2026-04-02T00:00:00Z',
+        vote_balance: 4,
+        current_vote: 'up',
+        has_voted: true,
+      },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    const upvote = screen.getByRole('button', { name: '댓글 추천' })
+    expect(upvote).toHaveAttribute('aria-pressed', 'true')
+    expect(upvote).toBeDisabled()
+    expect(screen.getByRole('button', { name: '댓글 비추천' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
   it('toggles a comment reaction from the thread', async () => {
     const comments = [
       {
@@ -402,5 +425,36 @@ describe('PostDetail', () => {
     expect(screen.getByText(/분류 근거:/)).toBeInTheDocument()
     expect(screen.getByText(/Direct board post without automation provenance/)).toBeInTheDocument()
     expect(screen.getByText('직접')).toBeInTheDocument()
+  })
+
+  it('marks the current post vote as pressed', async () => {
+    const post = {
+      id: 'post-1',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T00:00:00Z',
+      votes: 7,
+      vote_balance: 7,
+      current_vote: 'down',
+      has_voted: true,
+      comment_count: 0,
+      post_kind: 'direct',
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    const downvote = screen.getByRole('button', { name: '▼ 비추천' })
+    expect(downvote).toHaveAttribute('aria-pressed', 'true')
+    expect(downvote).toBeDisabled()
+    expect(screen.getByRole('button', { name: '▲ 추천' })).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(screen.getByRole('button', { name: '▲ 추천' }))
+    await waitFor(() => {
+      expect(votePost).toHaveBeenCalledWith('post-1', 'up')
+    })
   })
 })

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -208,6 +208,8 @@ function CommentItem({
   const authorLabel = boardActorDisplayName(comment.author, comment.author_identity)
   const authorAvatarKey = boardActorAvatarKey(comment.author, comment.author_identity)
   const authorTitle = boardActorTitle(comment.author, comment.author_identity)
+  const upvoteActive = comment.current_vote === 'up'
+  const downvoteActive = comment.current_vote === 'down'
 
   const handleCommentVote = async (dir: 'up' | 'down') => {
     try {
@@ -239,15 +241,19 @@ function CommentItem({
           <div class="ml-auto flex items-center gap-1">
             <button
               type="button"
-              class="h-5 w-6 rounded-[var(--r-1)] border-0 bg-transparent text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--warn-10)] hover:text-[var(--warn-bright)]"
+              class=${`h-5 w-6 rounded-[var(--r-1)] border-0 bg-transparent text-2xs ${upvoteActive ? 'active text-[var(--warn-bright)] bg-[var(--warn-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:bg-[var(--warn-10)] hover:text-[var(--warn-bright)]'}`}
               aria-label="댓글 추천"
+              aria-pressed=${upvoteActive ? 'true' : 'false'}
+              disabled=${upvoteActive}
               onClick=${() => handleCommentVote('up')}
             >▲</button>
             <span class="min-w-5 text-center text-2xs font-semibold tabular-nums text-[var(--color-fg-secondary)]">${score}</span>
             <button
               type="button"
-              class="h-5 w-6 rounded-[var(--r-1)] border-0 bg-transparent text-2xs text-[var(--color-fg-muted)] hover:bg-[var(--accent-10)] hover:text-[var(--color-accent-fg)]"
+              class=${`h-5 w-6 rounded-[var(--r-1)] border-0 bg-transparent text-2xs ${downvoteActive ? 'active text-[var(--color-accent-fg)] bg-[var(--accent-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:bg-[var(--accent-10)] hover:text-[var(--color-accent-fg)]'}`}
               aria-label="댓글 비추천"
+              aria-pressed=${downvoteActive ? 'true' : 'false'}
+              disabled=${downvoteActive}
               onClick=${() => handleCommentVote('down')}
             >▼</button>
           </div>
@@ -423,6 +429,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
   const handleVote = async (dir: 'up' | 'down') => {
     try {
       await votePost(post.id, dir)
+      await loadPostDetail(post.id)
       refreshBoard()
     } catch (err) {
       console.warn(`[board] vote failed (post=${post.id}, dir=${dir})`, err instanceof Error ? err.message : err)
@@ -432,6 +439,8 @@ export function PostDetail({ post }: { post: BoardPost }) {
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)
+  const upvoteActive = post.current_vote === 'up'
+  const downvoteActive = post.current_vote === 'down'
 
   return html`
     <div>
@@ -497,13 +506,17 @@ export function PostDetail({ post }: { post: BoardPost }) {
             <${ActionButton}
               variant="ghost"
               size="sm"
-              class="vote-btn upvote text-xs hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)]"
+              class=${`vote-btn upvote text-xs hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)] ${upvoteActive ? 'active text-[var(--warn-bright)] border-[var(--warn-30)] bg-[var(--warn-10)]' : ''}`}
+              pressed=${upvoteActive}
+              disabled=${upvoteActive}
               onClick=${() => handleVote('up')}
             >▲ 추천<//>
             <${ActionButton}
               variant="ghost"
               size="sm"
-              class="vote-btn downvote text-xs hover:text-[var(--color-accent-fg)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)]"
+              class=${`vote-btn downvote text-xs hover:text-[var(--color-accent-fg)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)] ${downvoteActive ? 'active text-[var(--color-accent-fg)] border-[var(--accent-30)] bg-[var(--accent-10)]' : ''}`}
+              pressed=${downvoteActive}
+              disabled=${downvoteActive}
               onClick=${() => handleVote('down')}
             >▼ 비추천<//>
           </div>

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -116,6 +116,8 @@ type BoardPostMeta = Record<string, unknown> & {
   judgment?: unknown
 }
 
+export type BoardVoteDirection = 'up' | 'down'
+
 export interface BoardActorIdentity {
   kind: 'keeper' | 'agent'
   id: string
@@ -139,6 +141,8 @@ export interface BoardPost {
   tags: string[]
   votes: number
   vote_balance?: number
+  current_vote?: BoardVoteDirection | null
+  has_voted?: boolean
   comment_count: number
   created_at: string
   updated_at: string
@@ -161,6 +165,8 @@ export interface BoardComment {
   vote_balance?: number
   votes_up?: number
   votes_down?: number
+  current_vote?: BoardVoteDirection | null
+  has_voted?: boolean
 }
 
 export type BoardReactionTargetType = 'post' | 'comment'

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -429,6 +429,10 @@ let add_comment ~post_id ~author ~content ?parent_id
           ok
       | Error _ as err -> err)
 
+let current_vote_for_post ~voter ~post_id =
+  match backend () with
+  | Jsonl store -> Board.current_vote_for_post store ~voter ~post_id
+
 let vote ~voter ~post_id ~direction =
   let result =
     match backend () with
@@ -443,6 +447,10 @@ let vote ~voter ~post_id ~direction =
          "board vote failed: post_id=%s voter=%s: %s"
          post_id voter (Board_types.show_board_error e));
   result
+
+let current_vote_for_comment ~voter ~comment_id =
+  match backend () with
+  | Jsonl store -> Board.current_vote_for_comment store ~voter ~comment_id
 
 let vote_comment ~voter ~comment_id ~direction =
   let result =

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -187,11 +187,21 @@ val list_comments : ?limit:int -> unit -> Board.comment list
 
 (** {1 Votes} *)
 
+val current_vote_for_post :
+  voter:string ->
+  post_id:string ->
+  (Board.vote_direction option, Board.board_error) Result.t
+
 val vote :
   voter:string ->
   post_id:string ->
   direction:Board.vote_direction ->
   (int, Board.board_error) Result.t
+
+val current_vote_for_comment :
+  voter:string ->
+  comment_id:string ->
+  (Board.vote_direction option, Board.board_error) Result.t
 
 val vote_comment :
   voter:string ->

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -134,6 +134,21 @@ let record_vote_side_effect store outcome =
     ~agent_name:outcome.vote_author_name
     ~direction:vote_dir
 
+let current_vote_for_post store ~voter ~post_id
+    : (vote_direction option, board_error) Result.t =
+  match Agent_id.of_string voter with
+  | Error e -> Error e
+  | Ok agent ->
+  match Post_id.of_string post_id with
+  | Error e -> Error e
+  | Ok pid ->
+      with_lock store (fun () ->
+        let post_key = Post_id.to_string pid in
+        if not (Hashtbl.mem store.posts post_key) then Error (Post_not_found post_id)
+        else
+          let vote_key = "post:" ^ post_key ^ ":" ^ Agent_id.to_string agent in
+          Ok (Option.map fst (Hashtbl.find_opt store.vote_log vote_key)))
+
 let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
   match Agent_id.of_string voter with
   | Error e -> Error e
@@ -214,6 +229,24 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
            record_vote_side_effect store outcome;
            Ok delta
        | Error _ as e -> e)
+
+let current_vote_for_comment store ~voter ~comment_id
+    : (vote_direction option, board_error) Result.t =
+  match Agent_id.of_string voter with
+  | Error e -> Error e
+  | Ok agent ->
+  match Comment_id.of_string comment_id with
+  | Error e -> Error e
+  | Ok cid ->
+      with_lock store (fun () ->
+        let comment_key = Comment_id.to_string cid in
+        if not (Hashtbl.mem store.comments comment_key) then
+          Error (Comment_not_found comment_id)
+        else
+          let vote_key =
+            "comment:" ^ comment_key ^ ":" ^ Agent_id.to_string agent
+          in
+          Ok (Option.map fst (Hashtbl.find_opt store.vote_log vote_key)))
 
 (** Vote on a comment *)
 let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result.t =

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -72,6 +72,14 @@ val vote_log_path : unit -> string
 
 (** {1 Voting} *)
 
+val current_vote_for_post :
+  store ->
+  voter:string ->
+  post_id:string ->
+  (vote_direction option, board_error) Result.t
+(** Returns the persisted vote direction for [voter] on [post_id],
+    if any. *)
+
 val vote :
   store ->
   voter:string ->
@@ -92,6 +100,14 @@ val vote :
     readers.  Every vote is broadcast to
     {!Thompson_sampling.record_vote} outside the state lock
     for posterior feedback. *)
+
+val current_vote_for_comment :
+  store ->
+  voter:string ->
+  comment_id:string ->
+  (vote_direction option, board_error) Result.t
+(** Returns the persisted vote direction for [voter] on [comment_id],
+    if any. *)
 
 val vote_comment :
   store ->

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -35,6 +35,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let limit = int_query_param httpun_request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
       let offset = int_query_param httpun_request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
       let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
+      let voter = board_voter_query httpun_request in
       let posts =
         Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
           ~exclude_automation ?author_filter ~limit:base_fetch ()
@@ -46,7 +47,9 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let paged = posts |> drop offset |> take limit in
       let posts_json = List.map (fun (p : Board.post) ->
         let author = Board.Agent_id.to_string p.author in
-        board_post_dashboard_json ~author_karma:(get_karma author) p
+        let post_id = Board.Post_id.to_string p.id in
+        let current_vote = board_current_vote_for_post ~voter ~post_id in
+        board_post_dashboard_json ?current_vote ~author_karma:(get_karma author) p
       ) paged in
       let json = `Assoc [
         ("posts", `List posts_json);
@@ -79,7 +82,10 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
          && String.length p > 14 ->
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param httpun_request "format") in
-      let (status, body) = board_post_detail_json ~response_format:format ~post_id in
+      let voter = board_voter_query httpun_request in
+      let (status, body) =
+        board_post_detail_json ~voter ~response_format:format ~post_id
+      in
       h2_respond_json h2_reqd body ~status ~extra_headers:cors;
       true
 

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -213,6 +213,7 @@ let add_routes ~sw ~clock router =
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
+         let voter = board_voter_query req in
          let posts =
            Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
              ~exclude_automation ?author_filter ~limit:base_fetch ()
@@ -226,7 +227,10 @@ let add_routes ~sw ~clock router =
            List.map
              (fun (p : Board.post) ->
                let author = Board.Agent_id.to_string p.author in
-               board_post_dashboard_json ~author_karma:(get_karma author) p)
+               let post_id = Board.Post_id.to_string p.id in
+               let current_vote = board_current_vote_for_post ~voter ~post_id in
+               board_post_dashboard_json ?current_vote
+                 ~author_karma:(get_karma author) p)
              paged
          in
          let json = `Assoc [
@@ -267,7 +271,10 @@ let add_routes ~sw ~clock router =
               let format =
                 query_param req "format" |> Option.value ~default:"nested"
               in
-              let (status, body) = board_post_detail_json ~response_format:format ~post_id in
+              let voter = board_voter_query req in
+              let (status, body) =
+                board_post_detail_json ~voter ~response_format:format ~post_id
+              in
               respond_json_with_cors ~status request reqd body)
        ) request reqd)
 

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -237,7 +237,7 @@ let readiness_handler _request reqd =
             ]))
       reqd
 
-let board_post_detail_json ~response_format ~post_id =
+let board_post_detail_json ~voter ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error err ->
       (`Not_found, Printf.sprintf {|{"error":"%s"}|}
@@ -253,8 +253,15 @@ let board_post_detail_json ~response_format ~post_id =
               post_id (Board_types.show_board_error err);
             []
       in
-      let post_json = board_post_dashboard_json ~author_karma post in
-      let comments_json = `List (List.map board_comment_dashboard_json comments) in
+      let current_vote = board_current_vote_for_post ~voter ~post_id in
+      let post_json = board_post_dashboard_json ?current_vote ~author_karma post in
+      let comments_json =
+        `List (List.map (fun (comment : Board.comment) ->
+          let comment_id = Board.Comment_id.to_string comment.id in
+          let current_vote = board_current_vote_for_comment ~voter ~comment_id in
+          board_comment_dashboard_json ?current_vote comment
+        ) comments)
+      in
       let json =
         if String.equal (String.lowercase_ascii (String.trim response_format)) "flat" then
           match post_json with

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -152,11 +152,14 @@ val readiness_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** {1 Board} *)
 
 val board_post_detail_json :
+  voter:string option ->
   response_format:string ->
   post_id:string ->
   [> `OK | `Not_found ] * string
-(** [board_post_detail_json ~response_format ~post_id] returns
+(** [board_post_detail_json ~voter ~response_format ~post_id] returns
     [(status, json_string)] for [GET /api/v1/board/<post_id>].
+    When [voter] is supplied, post/comment rows include vote state for
+    that voter.
 
     {2 response_format values (case-insensitive, trimmed)}
 

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -111,6 +111,28 @@ let board_actor_author_for_write raw =
   | Some (keeper_name, _, _) -> keeper_name
   | None -> String.trim raw
 
+let board_voter_query request =
+  query_param request "voter"
+  |> Option.map String.trim
+  |> Fun.flip Option.bind (fun raw ->
+       if raw = "" then None else Some (board_actor_author_for_write raw))
+
+let board_current_vote_for_post ~voter ~post_id =
+  match voter with
+  | None -> None
+  | Some voter -> (
+      match Board_dispatch.current_vote_for_post ~voter ~post_id with
+      | Ok vote -> Some vote
+      | Error _ -> Some None)
+
+let board_current_vote_for_comment ~voter ~comment_id =
+  match voter with
+  | None -> None
+  | Some voter -> (
+      match Board_dispatch.current_vote_for_comment ~voter ~comment_id with
+      | Ok vote -> Some vote
+      | Error _ -> Some None)
+
 let max_filtered_board_window = 5200
 
 let board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset =
@@ -118,14 +140,26 @@ let board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset =
   if exclude_system || exclude_automation then max base max_filtered_board_window
   else base
 
-let board_comment_dashboard_json (c : Board.comment) : Yojson.Safe.t =
+let board_vote_state_fields = function
+  | None -> []
+  | Some None -> [ ("current_vote", `Null); ("has_voted", `Bool false) ]
+  | Some (Some direction) ->
+      [
+        ("current_vote", `String (Board.vote_direction_to_string direction));
+        ("has_voted", `Bool true);
+      ]
+
+let board_comment_dashboard_json ?current_vote (c : Board.comment) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
   match Board.comment_to_yojson c with
   | `Assoc fields ->
-      `Assoc (fields @ [ ("author_identity", board_actor_identity_json author) ])
+      `Assoc
+        (fields
+         @ [ ("author_identity", board_actor_identity_json author) ]
+         @ board_vote_state_fields current_vote)
   | other -> other
 
-let board_post_dashboard_json ~author_karma (p : Board.post) : Yojson.Safe.t =
+let board_post_dashboard_json ?current_vote ~author_karma (p : Board.post) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string p.author in
   let base_fields =
     match Board_dispatch.post_to_yojson_with_karma p ~author_karma with
@@ -153,7 +187,8 @@ let board_post_dashboard_json ~author_karma (p : Board.post) : Yojson.Safe.t =
           ("updated_at_iso", `String (iso8601_of_unix p.updated_at));
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);
-        ] )
+        ]
+      @ board_vote_state_fields current_vote )
 
 let dashboard_compact_mode request =
   match query_param request "mode" with

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -142,15 +142,32 @@ val board_actor_author_for_write : string -> string
     the keeper's canonical name regardless of which alias the
     write request used. *)
 
+val board_voter_query : Httpun.Request.t -> string option
+(** Reads and canonicalizes the board [voter] query parameter. *)
+
+val board_current_vote_for_post :
+  voter:string option -> post_id:string -> Board.vote_direction option option
+(** [None] means no voter was supplied; [Some None] means a voter was
+    supplied but has not voted on this post. *)
+
+val board_current_vote_for_comment :
+  voter:string option -> comment_id:string -> Board.vote_direction option option
+
 (** {1 Dashboard helpers} *)
 
-val board_comment_dashboard_json : Board.comment -> Yojson.Safe.t
+val board_comment_dashboard_json :
+  ?current_vote:Board.vote_direction option ->
+  Board.comment ->
+  Yojson.Safe.t
 (** [board_comment_dashboard_json c] renders a comment with the
     [author_identity] field appended via
     {!board_actor_identity_json}. *)
 
 val board_post_dashboard_json :
-  author_karma:int -> Board.post -> Yojson.Safe.t
+  ?current_vote:Board.vote_direction option ->
+  author_karma:int ->
+  Board.post ->
+  Yojson.Safe.t
 (** [board_post_dashboard_json ~author_karma p] renders a post
     with explicit operator-visible fields:
 

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -434,6 +434,53 @@ let test_vote_flip () =
       | Ok score ->
           Alcotest.(check int) "score after flip" (-1) score
 
+let test_current_vote_lookup () =
+  let vote_label = Option.map Board.vote_direction_to_string in
+  match
+    Board_dispatch.create_post ~author:"state-test" ~content:"state vote"
+      ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let pid = Board.Post_id.to_string post.id in
+      (match Board_dispatch.current_vote_for_post ~voter:"reader" ~post_id:pid with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok vote ->
+           Alcotest.(check (option string)) "post vote starts empty" None
+             (vote_label vote));
+      ignore (Board_dispatch.vote ~voter:"reader" ~post_id:pid ~direction:Board.Up);
+      (match Board_dispatch.current_vote_for_post ~voter:"reader" ~post_id:pid with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok vote ->
+           Alcotest.(check (option string)) "post vote state" (Some "up")
+             (vote_label vote));
+      (match
+         Board_dispatch.add_comment ~post_id:pid ~author:"commenter"
+           ~content:"vote this comment" ()
+       with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok comment ->
+           let cid = Board.Comment_id.to_string comment.id in
+           (match
+              Board_dispatch.current_vote_for_comment ~voter:"reader"
+                ~comment_id:cid
+            with
+            | Error e -> Alcotest.fail (Board.show_board_error e)
+            | Ok vote ->
+                Alcotest.(check (option string)) "comment vote starts empty" None
+                  (vote_label vote));
+           ignore
+             (Board_dispatch.vote_comment ~voter:"reader" ~comment_id:cid
+                ~direction:Board.Down);
+           match
+             Board_dispatch.current_vote_for_comment ~voter:"reader"
+               ~comment_id:cid
+           with
+           | Error e -> Alcotest.fail (Board.show_board_error e)
+           | Ok vote ->
+               Alcotest.(check (option string)) "comment vote state"
+                 (Some "down") (vote_label vote))
+
 let test_vote_persisted_by_flusher_actor () =
   try
     Eio_main.run @@ fun env ->
@@ -779,6 +826,8 @@ let () =
       Alcotest.test_case "upvote" `Quick (with_eio test_vote_post);
       Alcotest.test_case "dedup" `Quick (with_eio test_vote_dedup);
       Alcotest.test_case "flip" `Quick (with_eio test_vote_flip);
+      Alcotest.test_case "current vote lookup" `Quick
+        (with_eio test_current_vote_lookup);
       Alcotest.test_case "vote persisted by flusher actor" `Quick
         test_vote_persisted_by_flusher_actor;
     ];


### PR DESCRIPTION
## Summary
- expose per-voter current_vote/has_voted fields on board post list and post detail JSON
- have dashboard board fetches send the current dashboard actor as voter
- render active/pressed/disabled vote buttons for posts and comments, with detail refresh after post votes

## Artifact tie-in
- Advances Phase 1 vote UI readiness from /Users/dancer/Downloads/masc_sns.agent.final by making the current user's selected vote visible in list/detail/comment surfaces.

## Validation
- pnpm exec vitest run src/api/board.test.ts src/components/board/post-detail.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- env DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_board_dispatch.exe
- ./_build/default/test/test_board_dispatch.exe
- git diff --check