### PR TITLE
fix(dashboard): strengthen IDE keeper identity chrome

### DIFF
--- a/dashboard/src/components/ide/ide-activity-mock.test.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.test.ts
@@ -9,7 +9,7 @@ describe('IdeActivityMock', () => {
     render(h(IdeActivityMock, {}), container)
 
     const region = container.querySelector('[role="region"]')
-    expect(region?.getAttribute('aria-label')).toBe('ACTIVITY')
+    expect(region?.getAttribute('aria-label')).toBe('EVENT TIMELINE')
     expect(container.textContent).toContain('0 events · 0 keepers')
   })
 })

--- a/dashboard/src/components/ide/ide-activity-mock.ts
+++ b/dashboard/src/components/ide/ide-activity-mock.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
+import { KeeperBadge } from '../keeper-badge'
 import {
   createRunActivityStore,
   type RunActivityEvent,
@@ -129,7 +129,7 @@ export function IdeActivityMock() {
   return html`
     <div
       role="region"
-      aria-label="ACTIVITY"
+      aria-label="EVENT TIMELINE"
       style=${{
         display: 'flex',
         flexDirection: 'column',
@@ -149,7 +149,7 @@ export function IdeActivityMock() {
           borderBottom: '1px solid var(--color-border-divider)',
         }}
       >
-        <span>ACTIVITY</span>
+        <span>EVENT TIMELINE</span>
         <span>${events.length} events · ${keepers.length} keepers</span>
       </div>
       <ol
@@ -170,13 +170,11 @@ export function IdeActivityMock() {
 }
 
 function ActivityRow(item: RunActivityEvent) {
-  const hue = keeperHueIndex(item.keeper_id)
-  const dot = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
   return html`
     <li
       style=${{
         display: 'grid',
-        gridTemplateColumns: '52px 8px 1fr',
+        gridTemplateColumns: '52px minmax(0, 1fr)',
         gap: 'var(--sp-2)',
         alignItems: 'baseline',
         padding: '4px 6px',
@@ -185,10 +183,10 @@ function ActivityRow(item: RunActivityEvent) {
       }}
     >
       <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${formatActivityTime(item.timestamp_ms)}</span>
-      <span aria-hidden="true" style=${{ width: '6px', height: '6px', borderRadius: '50%', background: dot, alignSelf: 'center' }} />
       <div style=${{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
         <span style=${{ fontSize: 'var(--fs-11)' }}>
-          <strong style=${{ color: dot }}>${item.keeper_id}</strong> ${' '}${item.verb}${' '}<span style=${{ color: 'var(--color-fg-muted)' }}>${item.target}</span>
+          <${KeeperBadge} id=${item.keeper_id} variant="full" size="sm" />
+          ${' '}${item.verb}${' '}<span style=${{ color: 'var(--color-fg-muted)' }}>${item.target}</span>
         </span>
         ${item.detail ? html`<span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${item.detail}</span>` : null}
       </div>

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.test.ts
@@ -14,8 +14,8 @@ describe('IdeConversationRailMock', () => {
     render(h(IdeConversationRailMock, {}), container)
 
     const region = container.querySelector('[role="region"]')
-    expect(region?.getAttribute('aria-label')).toBe('CONVERSATION')
-    expect(container.textContent).toContain('CONVERSATION')
+    expect(region?.getAttribute('aria-label')).toBe('REACTION THREAD')
+    expect(container.textContent).toContain('REACTION THREAD')
     expect(container.textContent).toContain('0')
   })
 

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
+import { KeeperBadge } from '../keeper-badge'
 import {
   fetchKeeperDecisions,
   type KeeperDecision,
@@ -133,7 +134,7 @@ export function IdeConversationRailMock() {
   return html`
     <div
       role="region"
-      aria-label="CONVERSATION"
+      aria-label="REACTION THREAD"
       style=${{
         display: 'flex',
         flexDirection: 'column',
@@ -152,7 +153,7 @@ export function IdeConversationRailMock() {
           borderBottom: '1px solid var(--color-border-divider)',
         }}
       >
-        <span>CONVERSATION</span>
+        <span>REACTION THREAD</span>
         <span>
           ${visibleCounts.thread}/${posts.length} threads ·
           ${visibleCounts.decision}/${decisions.length} decisions ·
@@ -276,7 +277,7 @@ function PostCard(post: BoardPost, focused: boolean, onFocus: () => void) {
       >
         <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--sp-2)' }}>
           <span style=${{ fontSize: 'var(--fs-11)', color: kindColor, letterSpacing: '0.05em' }}>${KIND_LABEL[kind]}</span>
-          <span style=${{ fontSize: 'var(--fs-11)', color: keeperColor }}>${post.author_identity}</span>
+          <${KeeperBadge} id=${post.author_identity} variant="full" size="sm" />
           <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)', marginLeft: 'auto' }}>${formatThreadTime(createdMs)}</span>
         </div>
         ${post.hearth ? html`
@@ -320,7 +321,7 @@ function DecisionCard(item: Extract<ReplayRailItem, { source: 'decision' }>) {
       >
         <div style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)' }}>
           <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-status-info)', letterSpacing: '0.05em' }}>DECISION</span>
-          <span style=${{ fontSize: 'var(--fs-11)', color }}>${keeper}</span>
+          <${KeeperBadge} id=${keeper} variant="full" size="sm" />
           <span style=${{ marginLeft: 'auto', fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>${formatThreadTime(item.timestamp_ms)}</span>
         </div>
         <p style=${{ margin: 0, color: 'var(--color-fg-secondary)', fontSize: 'var(--fs-12)' }}>${summary || 'decision event'}</p>

--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -39,4 +39,17 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
     expect(leafItem).toBeDefined()
     expect(leafItem?.getAttribute('tabindex')).toBe('0')
   })
+
+  it('renders keeper sigils in file rows instead of color-only markers', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE)
+    render(h(IdeExplorer, { fileTreeStore: store }), container)
+
+    const keeperOwnedRow = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="treeitem"]'),
+    ).find(el => el.textContent?.includes('router.ts'))
+
+    expect(keeperOwnedRow?.textContent).toContain('NK')
+    expect(keeperOwnedRow?.textContent).toContain('router.ts')
+  })
 })

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -7,6 +7,7 @@ import { activeIdeFile } from './ide-shell'
 import type { WorkspaceSource } from '../../api/workspace-source'
 import type { Repository } from '../../api/repositories'
 import { showToast } from '../common/toast'
+import { KeeperBadge } from '../keeper-badge'
 
 interface IdeExplorerProps {
   readonly fileTreeStore: FileTreeStore
@@ -272,9 +273,6 @@ function SourceHint(source: WorkspaceSource) {
 
 function TreeRow(node: FileTreeNode, expanded: boolean, onClick: () => void) {
   const indent = node.depth * 12
-  const dotColor = node.hueIndex !== null
-    ? `var(--color-keeper-${node.hueIndex}-glow, var(--k-${node.hueIndex}))`
-    : 'transparent'
   const chevron = node.hasChildren ? (expanded ? '▾' : '▸') : ''
   const onKeyDown = (e: KeyboardEvent): void => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -303,16 +301,9 @@ function TreeRow(node: FileTreeNode, expanded: boolean, onClick: () => void) {
       }}
     >
       <span aria-hidden="true" style=${{ color: 'var(--color-fg-muted)', width: '12px', textAlign: 'center' }}>${chevron}</span>
-      <span
-        aria-hidden="true"
-        style=${{
-          width: '8px',
-          height: '8px',
-          borderRadius: '50%',
-          background: dotColor,
-          opacity: node.hueIndex !== null ? 0.85 : 0,
-        }}
-      />
+      ${node.keeperId
+        ? html`<${KeeperBadge} id=${node.keeperId} variant="sigil" size="sm" />`
+        : html`<span aria-hidden="true" style=${{ width: '14px', height: '14px' }} />`}
       <span>${node.label}</span>
       ${node.diff !== null
         ? html`<span style=${{ color: 'var(--color-fg-muted)', font: 'var(--fs-11)' }}>${node.diff}</span>`

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
+import { KeeperBadge } from '../keeper-badge'
 import {
   createKeeperPresenceStore,
   type KeeperPresenceEntry,
@@ -171,7 +171,7 @@ export function IdePresenceStrip() {
   return html`
     <div
       role="status"
-      aria-label="IDE keeper presence"
+      aria-label="Live workspace keeper presence"
       style=${{
         display: 'inline-flex',
         alignItems: 'center',
@@ -195,6 +195,7 @@ export function IdePresenceStrip() {
           margin: 0,
           padding: 0,
           minWidth: 0,
+          overflow: 'hidden',
         }}
       >
         ${entries.map(entry => html`<${PresenceChip} entry=${entry} />`)}
@@ -204,11 +205,11 @@ export function IdePresenceStrip() {
 }
 
 function PresenceChip({ entry }: { readonly entry: KeeperPresenceEntry }) {
-  const hue = keeperHueIndex(entry.keeper_id)
-  const keeperColor = `var(--color-keeper-${hue}-glow, var(--k-${hue}))`
+  const isActive = entry.status === 'active'
   return html`
     <li
       title=${`${entry.keeper_id} · ${entry.role} · ${entry.branch}`}
+      aria-label=${`${entry.keeper_id} ${entry.status} in ${entry.workspace_label}`}
       style=${{
         display: 'inline-flex',
         alignItems: 'center',
@@ -218,15 +219,18 @@ function PresenceChip({ entry }: { readonly entry: KeeperPresenceEntry }) {
         whiteSpace: 'nowrap',
       }}
     >
-      <span
-        aria-hidden="true"
-        class="size-[6px] shrink-0 rounded-full"
-        style=${{ background: keeperColor, opacity: entry.status === 'active' ? 0.95 : 0.45 }}
-      />
+      <${KeeperBadge} id=${entry.keeper_id} variant="sigil" size="sm" beat=${isActive} />
       <span style=${{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
         ${entry.keeper_id}@${entry.workspace_label}
+      </span>
+      <span
+        style=${{
+          color: isActive ? 'var(--color-status-ok)' : 'var(--color-fg-muted)',
+          fontSize: 'var(--fs-10)',
+        }}
+      >
+        ${entry.status}
       </span>
     </li>
   `
 }
-

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -98,8 +98,12 @@ export function IdeShell() {
           color: 'var(--color-fg-muted)',
         }}
       >
-        <span style=${{ color: 'var(--color-fg-secondary)' }}>코드 IDE</span>
+        <span style=${{ color: 'var(--color-fg-secondary)' }}>MASC IDE</span>
         <span>·</span>
+        <span
+          class="chip sm is-brass"
+          style=${{ flexShrink: 0 }}
+        >LIVE WORKSPACE</span>
         <${IdePresenceStrip} />
         <span style=${{ marginLeft: 'auto', color: 'var(--color-status-ok)' }}>● mcp · connected</span>
       </header>

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -58,19 +58,11 @@ export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersCha
 
   return html`
     <div
+      class="ide-toolbar"
       role="toolbar"
       aria-label="IDE editor toolbar"
-      style=${{
-        display: 'grid',
-        gridTemplateColumns: 'auto 1fr auto',
-        alignItems: 'center',
-        gap: 'var(--sp-3)',
-        padding: 'var(--sp-2) var(--sp-3)',
-        borderBottom: '1px solid var(--color-border-divider)',
-        background: 'var(--color-bg-surface)',
-      }}
     >
-      <div role="tablist" aria-label="View mode" style=${{ display: 'flex', gap: 'var(--sp-2)' }}>
+      <div class="ide-view-tabs" role="tablist" aria-label="View mode">
         ${VIEW_TABS.map(tab => html`
           <button
             type="button"
@@ -92,14 +84,8 @@ export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersCha
       </div>
       <span aria-hidden="true" />
       <div
+        class="ide-layer-picker"
         aria-label="Layers (multi-select)"
-        style=${{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--sp-2)',
-          color: 'var(--color-fg-muted)',
-          font: 'var(--type-eyebrow)',
-        }}
       >
         <span>LAYERS</span>
         ${IDE_LAYERS.map(layer => html`

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -250,6 +250,42 @@
 }
 
 /* ── IDE Plane Shell ── */
+.ide-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--color-border-divider);
+  background: var(--color-bg-surface);
+  min-width: 0;
+}
+
+.ide-view-tabs,
+.ide-layer-picker {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.ide-view-tabs {
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.ide-view-tabs::-webkit-scrollbar,
+.ide-layer-picker::-webkit-scrollbar {
+  display: none;
+}
+
+.ide-layer-picker {
+  justify-content: flex-end;
+  overflow-x: auto;
+  color: var(--color-fg-muted);
+  font: var(--type-eyebrow);
+}
+
 .ide-plane-grid {
   display: grid;
   grid-template-columns: minmax(180px, 220px) minmax(0, 1fr) minmax(280px, 320px);
@@ -279,6 +315,20 @@
   grid-column: 3;
   grid-row: 2;
   min-width: 0;
+}
+
+@media (max-width: 1180px) {
+  .ide-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ide-toolbar > [aria-hidden="true"] {
+    display: none;
+  }
+
+  .ide-layer-picker {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- replace color-only keeper marks in the IDE explorer, live workspace strip, event timeline, and reaction thread with KeeperBadge sigils/names
- rename the IDE side rails to the Kimi-derived EVENT TIMELINE / REACTION THREAD language
- move the IDE toolbar layout into responsive CSS so layer controls wrap/scroll cleanly on tablet widths

## Operator impact
Operators can now identify keeper authorship from sigils plus text instead of relying on color. The code IDE keeps the cockpit/Kimi surfaces recognizable at narrow widths without overlapping the layer controls.

## Validation
- pnpm --dir dashboard install --offline --frozen-lockfile
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-explorer.test.ts src/components/ide/ide-activity-mock.test.ts src/components/ide/ide-conversation-rail-mock.test.ts src/components/ide/ide-presence-strip.test.ts src/components/ide/ide-shell.test.ts
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-activity-mock.a11y.test.ts src/components/ide/ide-conversation-rail-mock.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec eslint src/components/ide/ide-explorer.test.ts src/components/ide/ide-activity-mock.ts src/components/ide/ide-conversation-rail-mock.ts src/components/ide/ide-explorer.ts src/components/ide/ide-presence-strip.ts src/components/ide/ide-shell.ts src/components/ide/ide-toolbar.ts
- agent-browser screenshots at 1440x900 and 760x900 against /dashboard/#code?section=ide-shell&view=source&layers=time,approve

## Review focus
- confirm the KeeperBadge usage matches the design-system two-channel keeper attribution rule
- check the tablet/mobile toolbar behavior for no overlap or hidden active layer state