### PR TITLE
fix(server): pass ~voter to board_post_detail_json in main_eio — unblock main build

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -392,7 +392,8 @@ let dispatch_route ~routes ~request ~path reqd =
   | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param request "format") in
-      let (status, body) = board_post_detail_json ~response_format:format ~post_id in
+      let voter = board_voter_query request in
+      let (status, body) = board_post_detail_json ~voter ~response_format:format ~post_id in
       Http.Response.json ~status body reqd
   | _ -> Http.Router.dispatch routes request reqd
 


### PR DESCRIPTION
## 요약

`origin/main`을 깨뜨리던 `bin/main_eio.ml:395`의 partial application 타입 오류를 수정합니다.

```
File "bin/main_eio.ml", line 395, characters 27-82:
395 |       let (status, body) = board_post_detail_json ~response_format:format ~post_id in
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type
         voter:string option -> [> `Not_found | `OK ] * string
       but an expression was expected of type 'a * 'b
Hint: This function application is partial, maybe some arguments are missing.
```

## 원인

직전 머지 `#13292 feat(board): expose current vote state` (`93c2feba17`, 2026-05-06 00:08 KST)이 `board_post_detail_json` 시그니처에 `~voter:string option`을 필수 인자로 추가하면서 두 caller는 갱신했으나 `bin/main_eio.ml`의 legacy fallback handler call site는 빠뜨렸습니다.

| 파일 | #13292에서 갱신 여부 |
|------|---------------------|
| `lib/server/server_h2_gateway_routes_extra.ml:85-87` | ✅ |
| `lib/server/server_routes_http_routes_activity.ml:274-277` | ✅ |
| `bin/main_eio.ml:395` | ❌ ← 이번 PR이 fix |

## 수정

이미 갱신된 두 caller와 동일 패턴을 적용 — `Server_utils.board_voter_query request`로 query string `?voter=...`을 추출 후 전달.

```diff
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param request "format") in
+      let voter = board_voter_query request in
-      let (status, body) = board_post_detail_json ~response_format:format ~post_id in
+      let (status, body) = board_post_detail_json ~voter ~response_format:format ~post_id in
       Http.Response.json ~status body reqd
```

`board_voter_query`는 `bin/main_eio.ml:52`의 `include Masc_mcp.Server_utils`로 이미 스코프에 있어 추가 import 불필요.

## 검증

- `dune build --root .` ✅ exit 0 (worktree에서 풀 빌드 통과, 2m48s)
- 변경 line: 1 추가 + 1 수정. 다른 caller 패턴과 1:1 일치.

## 미검증 / 주의

- legacy `bin/main_eio.ml` 코드 경로의 실제 런타임 트래픽 비중은 확인하지 않았습니다 — H2 gateway/activity routes로 대부분 라우팅된다고 추정. 이 fix는 빌드 복구만 목표로 하고 동작은 H2 gateway와 동등화.
- agent ready_for_review가 Draft Auto-Merge Guard에 의해 close될 수 있어 Draft 유지 — `human-approved-ready` 라벨 부착 후 ready 전환 부탁드립니다.
- 같은 패턴(Build job 통과 후 main blocker)이 직전에도 다수 발생 (`#13260`, `#12992`, `#12815`, `#12978`). #13292가 어떻게 main에 들어왔는지(필수 체크 fail이 admin-merge로 우회됐는지)는 별도 조사 가치 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)