### PR TITLE
feat(ide): RFC-0027 PR-α — multi-keeper-pin-store + backward-compat shim

### DIFF
--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeKeeperBdiSnapshot,
   pinInspectorKeeper,
 } from './inspector-keeper-bdi'
+import { clearPins } from './multi-keeper-pin-store'
 
 const snapshot = {
   keeper: 'scholar',
@@ -51,7 +52,8 @@ afterEach(() => {
   }
   vi.unstubAllGlobals()
   activeKeeperName.value = ''
-  inspectorKeeperPin.value = null
+  clearPins()
+  void inspectorKeeperPin.value
 })
 
 describe('normalizeKeeperBdiSnapshot', () => {

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -1,8 +1,9 @@
-import { signal } from '@preact/signals'
+import { computed } from '@preact/signals'
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { activeKeeperName } from '../../keeper-state'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
+import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
 
 export interface KeeperBdiTokenSpend {
   readonly ts_unix: number | null
@@ -43,11 +44,24 @@ interface InspectorKeeperPin {
   readonly line: number | null
 }
 
-export const inspectorKeeperPin = signal<InspectorKeeperPin | null>(null)
+/**
+ * RFC-0027 PR-α backward-compat: legacy single-pin signal is now a derived
+ * projection over the head of `pinnedKeepers` (max-4 LRU store). Reads stay
+ * identical; mutators move to `pinKeeper` / `clearPins` from
+ * `multi-keeper-pin-store.ts`.
+ */
+export const inspectorKeeperPin = computed<InspectorKeeperPin | null>(() => {
+  const head = headPinnedKeeper.value
+  return head ? { keeperName: head.keeperName, line: head.line } : null
+})
 
 export function pinInspectorKeeper(keeperName: string, line: number | null): void {
   const trimmed = keeperName.trim()
-  inspectorKeeperPin.value = trimmed ? { keeperName: trimmed, line } : null
+  if (trimmed) {
+    pinKeeper(trimmed, line)
+  } else {
+    clearPins()
+  }
 }
 
 function normalizeTokenSpend(raw: unknown): KeeperBdiTokenSpend | null {

--- a/dashboard/src/components/ide/multi-keeper-pin-store.test.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PIN_CAP,
+  clearPins,
+  headPinnedKeeper,
+  pinKeeper,
+  pinnedKeepers,
+  unpinKeeper,
+} from './multi-keeper-pin-store'
+
+beforeEach(() => {
+  clearPins()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-05-06T00:00:00Z'))
+})
+
+afterEach(() => {
+  clearPins()
+  vi.useRealTimers()
+})
+
+describe('multi-keeper-pin-store', () => {
+  it('starts empty with the configured cap', () => {
+    expect(pinnedKeepers.value.entries).toHaveLength(0)
+    expect(pinnedKeepers.value.cap).toBe(PIN_CAP)
+    expect(headPinnedKeeper.value).toBeNull()
+  })
+
+  it('adds a single pin to the head', () => {
+    pinKeeper('scholar', 42)
+    expect(pinnedKeepers.value.entries).toHaveLength(1)
+    expect(pinnedKeepers.value.entries[0]).toEqual({
+      keeperName: 'scholar',
+      pinnedAtMs: Date.now(),
+      line: 42,
+    })
+    expect(headPinnedKeeper.value?.keeperName).toBe('scholar')
+  })
+
+  it('rejects empty / whitespace-only keeper names', () => {
+    pinKeeper('')
+    pinKeeper('   ')
+    expect(pinnedKeepers.value.entries).toHaveLength(0)
+  })
+
+  it('trims keeper name on insertion', () => {
+    pinKeeper('  brass-owl  ', 7)
+    expect(pinnedKeepers.value.entries[0]?.keeperName).toBe('brass-owl')
+  })
+
+  it('inserts new pins at the head, preserving order otherwise', () => {
+    pinKeeper('scholar', 1)
+    vi.advanceTimersByTime(1000)
+    pinKeeper('moth', 2)
+    vi.advanceTimersByTime(1000)
+    pinKeeper('luna', 3)
+
+    const names = pinnedKeepers.value.entries.map(e => e.keeperName)
+    expect(names).toEqual(['luna', 'moth', 'scholar'])
+  })
+
+  it('moves an existing pin to the head and refreshes timestamp + line', () => {
+    pinKeeper('scholar', 1)
+    vi.advanceTimersByTime(5_000)
+    pinKeeper('moth', 2)
+    vi.advanceTimersByTime(5_000)
+
+    const before = pinnedKeepers.value.entries.find(e => e.keeperName === 'scholar')
+    pinKeeper('scholar', 99)
+    const after = pinnedKeepers.value.entries[0]
+
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['scholar', 'moth'])
+    expect(after?.line).toBe(99)
+    expect(after?.pinnedAtMs).toBeGreaterThan(before?.pinnedAtMs ?? 0)
+    // No duplicates introduced.
+    const occurrences = pinnedKeepers.value.entries.filter(e => e.keeperName === 'scholar').length
+    expect(occurrences).toBe(1)
+  })
+
+  it('drops the LRU (oldest) entry when the cap would be exceeded', () => {
+    const names = ['a', 'b', 'c', 'd', 'e']
+    names.forEach((name, idx) => {
+      vi.setSystemTime(new Date(`2026-05-06T00:00:${String(idx).padStart(2, '0')}Z`))
+      pinKeeper(name, idx)
+    })
+
+    expect(pinnedKeepers.value.entries).toHaveLength(PIN_CAP)
+    // Oldest 'a' evicted; head is the most recently pinned 'e'.
+    const remaining = pinnedKeepers.value.entries.map(e => e.keeperName)
+    expect(remaining).toEqual(['e', 'd', 'c', 'b'])
+    expect(remaining).not.toContain('a')
+  })
+
+  it('unpins a keeper without disturbing the others', () => {
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+    pinKeeper('c', 3)
+
+    unpinKeeper('b')
+
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['c', 'a'])
+  })
+
+  it('unpinKeeper is a no-op for unknown name and does not allocate a new state', () => {
+    pinKeeper('a', 1)
+    const stateBefore = pinnedKeepers.value
+    unpinKeeper('does-not-exist')
+    expect(pinnedKeepers.value).toBe(stateBefore)
+  })
+
+  it('clearPins drops every entry', () => {
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+    clearPins()
+    expect(pinnedKeepers.value.entries).toHaveLength(0)
+    expect(headPinnedKeeper.value).toBeNull()
+  })
+
+  it('clearPins is idempotent on an already-empty store', () => {
+    const stateBefore = pinnedKeepers.value
+    clearPins()
+    expect(pinnedKeepers.value).toBe(stateBefore)
+  })
+
+  it('headPinnedKeeper tracks the latest pin reactively', () => {
+    pinKeeper('a', 1)
+    expect(headPinnedKeeper.value?.keeperName).toBe('a')
+    pinKeeper('b', 2)
+    expect(headPinnedKeeper.value?.keeperName).toBe('b')
+    unpinKeeper('b')
+    expect(headPinnedKeeper.value?.keeperName).toBe('a')
+    clearPins()
+    expect(headPinnedKeeper.value).toBeNull()
+  })
+
+  it('preserves source line as null when not provided', () => {
+    pinKeeper('a')
+    expect(pinnedKeepers.value.entries[0]?.line).toBeNull()
+  })
+})

--- a/dashboard/src/components/ide/multi-keeper-pin-store.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.ts
@@ -1,0 +1,92 @@
+import { computed, signal } from '@preact/signals'
+
+/**
+ * RFC-0027 PR-α: multi-keeper pin store.
+ *
+ * Replaces the single `inspectorKeeperPin` signal in `inspector-keeper-bdi.ts`
+ * with a bounded LRU collection (max 4) while preserving the legacy single-pin
+ * API for callers that have not yet migrated. Layout decisions about how many
+ * pins to render concurrently belong to the consumer (`InspectorMultiKeeperBDI`),
+ * not the store.
+ *
+ * Backward-compat (RFC-0027 §10):
+ *   - `pinInspectorKeeper(name, line)` re-exported from `inspector-keeper-bdi.ts`
+ *     forwards into `pinKeeper(name, line)`. Callers see no shape change.
+ *   - `inspectorKeeperPin` re-exported from `inspector-keeper-bdi.ts` is a
+ *     `computed` projection of the head entry (`entries[0]`). Read-only access
+ *     remains identical; tests that previously did
+ *     `inspectorKeeperPin.value = null` must move to `clearPins()`.
+ *
+ * Cap = 4 ties to RFC-0027 §11 #1 (320px inspector rail + compact-fold). The
+ * cap is a constant in the store rather than a runtime parameter so test
+ * surface is small.
+ */
+
+export const PIN_CAP = 4
+
+export interface PinnedKeeperEntry {
+  readonly keeperName: string
+  readonly pinnedAtMs: number
+  readonly line: number | null
+}
+
+export interface PinnedKeepers {
+  readonly entries: ReadonlyArray<PinnedKeeperEntry>
+  readonly cap: number
+}
+
+const initialState: PinnedKeepers = { entries: [], cap: PIN_CAP }
+
+export const pinnedKeepers = signal<PinnedKeepers>(initialState)
+
+/**
+ * Pin a keeper, moving it to the head of `entries`. If already present the
+ * existing entry is removed first, so timestamp + line are refreshed and the
+ * relative order does not drift. When `entries.length` would exceed `cap`,
+ * the oldest entry by `pinnedAtMs` is dropped (LRU eviction).
+ *
+ * Empty/whitespace `keeperName` is a no-op.
+ */
+export function pinKeeper(keeperName: string, line: number | null = null): void {
+  const trimmed = keeperName.trim()
+  if (!trimmed) return
+  const now = Date.now()
+  const prev = pinnedKeepers.value
+  const newEntry: PinnedKeeperEntry = {
+    keeperName: trimmed,
+    pinnedAtMs: now,
+    line,
+  }
+  const filtered = prev.entries.filter(entry => entry.keeperName !== trimmed)
+  const next = [newEntry, ...filtered].slice(0, prev.cap)
+  pinnedKeepers.value = { ...prev, entries: next }
+}
+
+/**
+ * Remove a single pin by keeper name. No-op if not pinned.
+ */
+export function unpinKeeper(keeperName: string): void {
+  const trimmed = keeperName.trim()
+  if (!trimmed) return
+  const prev = pinnedKeepers.value
+  const next = prev.entries.filter(entry => entry.keeperName !== trimmed)
+  if (next.length === prev.entries.length) return
+  pinnedKeepers.value = { ...prev, entries: next }
+}
+
+/**
+ * Drop every pin. Used by tests that previously set
+ * `inspectorKeeperPin.value = null`.
+ */
+export function clearPins(): void {
+  if (pinnedKeepers.value.entries.length === 0) return
+  pinnedKeepers.value = { ...pinnedKeepers.value, entries: [] }
+}
+
+/**
+ * Head entry projection for legacy single-pin callers. Returns `null` when no
+ * keeper is pinned.
+ */
+export const headPinnedKeeper = computed<PinnedKeeperEntry | null>(
+  () => pinnedKeepers.value.entries[0] ?? null,
+)


### PR DESCRIPTION
## 목적

RFC-0027 (#13289 Draft) 의 first impl. **Store + backward-compat shim 만**, multi-renderer component 는 PR-β 로 분리. v1.1 axis 의 **첫 번째 진짜 구현**.

## Why this scope (minimum viable)

3 layout 까지 한 번에 가면 ~400-500 line + 시각 검증 + reduced-motion + a11y. PR review 무게 분산 위해:

- **PR-α (본 PR)**: store 도입 + backward-compat shim ~ 250 line (server 변경 0, behavior 변경 0)
- **PR-β** (follow-up): `inspector-multi-keeper-bdi.ts` (3 layout) + cross-keeper rollup chip ~ 250 line
- **PR-γ** (follow-up): drag reorder + RFC-0012 keyboard shortcut binding ~ 100 line

PR-α 가 먼저 머지되면 PR-β/γ 의 store API 가 stable — 시각 변경에만 집중 review 가능.

## Diff stat

- +252 lines / -4 lines (4 files)
- 신규: `multi-keeper-pin-store.ts` (95 lines), `multi-keeper-pin-store.test.ts` (140 lines)
- 수정: `inspector-keeper-bdi.ts` (+15, -3 — single signal → computed shim), `inspector-keeper-bdi.test.ts` (+2, -1 — clearPins migration)

## Backward-compat (RFC-0027 §10)

기존 3 export 모두 그대로 유지:

| export | 변경 전 | 변경 후 | break? |
|--------|---------|---------|--------|
| `inspectorKeeperPin` | `signal<InspectorKeeperPin \| null>` | `computed<InspectorKeeperPin \| null>` (over `headPinnedKeeper`) | **read-only mutation 에서 break** — 본 PR 의 test fix 가 유일 caller |
| `pinInspectorKeeper(name, line)` | `inspectorKeeperPin.value = ...` | `pinKeeper(name, line)` 또는 `clearPins()` | **no break** |
| `InspectorKeeperBDI` | unchanged | unchanged | **no break** |

직접 `inspectorKeeperPin.value = ...` mutation 하는 caller 검색: `rg "inspectorKeeperPin\.value\s*=" dashboard/src/` → test 1 location 만. 본 PR 에 함께 migrate.

## Public API (multi-keeper-pin-store.ts)

```ts
export const PIN_CAP = 4

export interface PinnedKeeperEntry {
  readonly keeperName: string         // align with actual InspectorKeeperPin (camelCase)
  readonly pinnedAtMs: number
  readonly line: number | null
}

export interface PinnedKeepers {
  readonly entries: ReadonlyArray<PinnedKeeperEntry>
  readonly cap: number
}

export const pinnedKeepers: Signal<PinnedKeepers>
export function pinKeeper(keeperName: string, line: number | null = null): void
export function unpinKeeper(keeperName: string): void
export function clearPins(): void
export const headPinnedKeeper: ReadonlySignal<PinnedKeeperEntry | null>
```

## RFC-0027 amend 필요 (별도 PR)

Spec 작성 시 caller-context 부족으로 actual code 와 차이:

| RFC 가정 | Actual code | 본 PR 결정 |
|----------|-------------|------------|
| `tsx` component file | `.ts` + `htm/preact` template literal | actual style 따름 |
| `keeper_id` (snake_case) | `keeperName` (camelCase) | actual style 따름 |
| `display_label` field | 없음 | PR-β 에서 도입 (AgentPresence label fallback) |
| `source_line: { file_path, line_number }` | `line: number \| null` | PR-α 는 actual 유지, file_path 는 v1.2 후보 |

위 4개 amend 는 RFC-0027 PR #13289 가 main 머지된 후 별도 amend PR (이름: `docs(rfc): align RFC-0027 spec with actual Preact+htm patterns`).

근거: memory `feedback_rfc_section_1_4_caller_context_unverified` — RFC §3 example code grep verification 누락.

## Test plan

- [x] Unit tests (vitest): 13 cases for store (empty/single/whitespace/trim/head-insert/reorder/LRU-evict/unpin/clear/idempotent/headProjection/null-line)
- [x] Existing `inspector-keeper-bdi.test.ts` 갱신 — afterEach 의 mutation 만 변경 (rendering 동작 0 변경)
- [ ] CI vitest run (Ready 전환 시 trigger — Draft 상태에서 SKIPPED 정상 by `pr-live-gate.run_heavy=false`)
- [ ] e2e Playwright: PR-β 에서 multi component 렌더링 검증

## Pre-flight verify (memory line 22-25 강화 protocol)

- `gh pr list --search "multi-keeper-pin OR multi-keeper-bdi OR multi-pin" --state {open,merged}` → 본 PR 외 0건
- `git fetch origin && git log origin/main --since=1h --oneline -- dashboard/src/components/ide/inspector*` → #13234 (P1-A 본체) only
- `rg "inspectorKeeperPin\.value\s*=" dashboard/src/` → test 1 location
- worktree 절대 경로 (`/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/rfc-0027-impl-pr-alpha`) — nested 회피 룰 적용

## Rollback plan

4-file revert. `inspectorKeeperPin` computed → signal 복귀 + `pinInspectorKeeper` 직접 mutation 복원 + multi-keeper-pin-store 제거. 기존 e2e 그대로 통과.

## RFC waiver

Behavior 변경 0 (single-pin caller path 정합 유지). agent_delegation 영역 (`credential_*`, `keeper_gh_*`, `host_config_*`, `lib/repo_manager/*`, `lib/operator/operator_control*`, dashboard credential, `.claude/hooks/`, `instructions/workflow*`) 변경 없음.

`RFC-WAIVED: doc-only RFC dependency (#13289 Draft) — impl scope is store + shim, behavior unchanged for single-pin caller path; multi-renderer in PR-β.`

## Related

- #13289 (RFC-0027 Draft) — 본 PR-α 가 implements 첫 단계
- #13234 (P1-A BDI inspector slot impl) — 본 PR 가 backward-compat 으로 보존
- RFC-0024 §10 — backward-compat 정의 출처

## Follow-up

- **PR-β**: `inspector-multi-keeper-bdi.ts` (stacked / compact-fold / focus-mode 3 layout) + `display_label` field + cross-keeper rollup chip (RFC §7)
- **PR-γ**: drag reorder + RFC-0012 키보드 단축키 binding
- **RFC-0027 amend PR**: §3.1 PinnedKeeperEntry shape + §3.3 framework (htm/preact) 갱신 (RFC-0027 main 머지 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
