### PR TITLE
fix(cascade): keep GLM tool-choice capable

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -23,8 +23,11 @@
   },
   "_comment_big_three": "Canonical keeper/workflow profile. Keep operator-chosen providers here; code must route logical usages through [routes] instead of hardcoding extra profile names.",
   "big_three_models": [
-    "codex_cli:gpt-5.3-codex-spark", "gemini_cli:auto",
-    "kimi_cli:kimi-for-coding", "glm-coding:auto", "claude_code:auto"
+    "codex_cli:gpt-5.3-codex-spark",
+    "gemini_cli:auto",
+    "kimi_cli:kimi-for-coding",
+    { "model": "glm-coding:auto", "supports_tool_choice": true },
+    "claude_code:auto"
   ],
   "big_three_temperature": 0.2,
   "big_three_max_tokens": 16384,
@@ -60,7 +63,9 @@
   "tier_medium_fallback_cascade": "big_three",
   "_comment___safe_lane": "System-only baseline cascade. Satisfies every capability profile. Used as last-resort fallback target. Not keeper-assignable.",
   "__safe_lane_models": [
-    "claude_code:auto", "glm-coding:auto", "kimi_cli:kimi-for-coding"
+    "claude_code:auto",
+    { "model": "glm-coding:auto", "supports_tool_choice": true },
+    "kimi_cli:kimi-for-coding"
   ],
   "__safe_lane_temperature": 0.2,
   "__safe_lane_max_tokens": 16384,
@@ -68,10 +73,12 @@
   "__safe_lane_required_capability_profile": "tool_strict",
   "_comment_tier_fast": "Cheap+fast tool-capable cloud models for keeper turns. Bias toward latency and cost over reasoning depth. All entries support tool calling. Falls back to big_three on exhaustion.",
   "tier_fast_models": [
-    "claude_code:claude-haiku-4-5-20251001", "codex_cli:gpt-5.3-codex-spark",
+    "claude_code:claude-haiku-4-5-20251001",
+    "codex_cli:gpt-5.3-codex-spark",
     "gemini_cli:gemini-3-flash-preview",
-    "gemini_cli:gemini-3.1-flash-lite-preview", "glm-coding:glm-5-turbo",
-    "glm-coding:glm-4.7-flashx"
+    "gemini_cli:gemini-3.1-flash-lite-preview",
+    { "model": "glm-coding:glm-5-turbo", "supports_tool_choice": true },
+    { "model": "glm-coding:glm-4.7-flashx", "supports_tool_choice": true }
   ],
   "tier_fast_temperature": 0.2,
   "tier_fast_max_tokens": 8192,

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -27,7 +27,7 @@ models = [
   "codex_cli:gpt-5.3-codex-spark",
   "gemini_cli:auto",
   "kimi_cli:kimi-for-coding",
-  "glm-coding:auto",
+  { model = "glm-coding:auto", supports_tool_choice = true },
   "claude_code:auto",
 ]
 temperature = 0.2
@@ -101,7 +101,7 @@ fallback_cascade = "big_three"
 comment = "System-only baseline cascade. Satisfies every capability profile. Used as last-resort fallback target. Not keeper-assignable."
 models = [
   "claude_code:auto",
-  "glm-coding:auto",
+  { model = "glm-coding:auto", supports_tool_choice = true },
   "kimi_cli:kimi-for-coding",
 ]
 temperature = 0.2
@@ -116,8 +116,8 @@ models = [
   "codex_cli:gpt-5.3-codex-spark",
   "gemini_cli:gemini-3-flash-preview",
   "gemini_cli:gemini-3.1-flash-lite-preview",
-  "glm-coding:glm-5-turbo",
-  "glm-coding:glm-4.7-flashx",
+  { model = "glm-coding:glm-5-turbo", supports_tool_choice = true },
+  { model = "glm-coding:glm-4.7-flashx", supports_tool_choice = true },
 ]
 temperature = 0.2
 max_tokens = 8192

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -104,6 +104,26 @@ let model_names_for_profile json profile_name =
        | `String model -> model
        | value -> value |> member "model" |> to_string)
 
+let model_entry_for_profile json profile_name model_name =
+  json
+  |> member (profile_name ^ "_models")
+  |> to_list
+  |> List.find_opt (function
+       | `String model -> String.equal model model_name
+       | value -> String.equal (value |> member "model" |> to_string) model_name)
+
+let supports_tool_choice_for_profile json profile_name model_name =
+  match model_entry_for_profile json profile_name model_name with
+  | None -> failf "%s missing from %s models" model_name profile_name
+  | Some (`String _) -> None
+  | Some value -> (
+      match value |> member "supports_tool_choice" with
+      | `Null -> None
+      | `Bool enabled -> Some enabled
+      | other ->
+          failf "unexpected supports_tool_choice value for %s/%s: %s"
+            profile_name model_name (Yojson.Safe.to_string other))
+
 let test_repo_seed_uses_two_profiles_plus_routes () =
   let rendered = render_or_fail (repo_toml_path ()) |> Yojson.Safe.from_string in
   let expect_profile_models profile_name expected =
@@ -127,6 +147,20 @@ let test_repo_seed_uses_two_profiles_plus_routes () =
       "glm-coding:auto";
       "claude_code:auto";
     ];
+  check (option bool) "big_three GLM declares tool choice support"
+    (Some true)
+    (supports_tool_choice_for_profile rendered "big_three" "glm-coding:auto");
+  check (option bool) "__safe_lane GLM declares tool choice support"
+    (Some true)
+    (supports_tool_choice_for_profile rendered "__safe_lane" "glm-coding:auto");
+  check (option bool) "tier_fast GLM 5 turbo declares tool choice support"
+    (Some true)
+    (supports_tool_choice_for_profile rendered "tier_fast"
+       "glm-coding:glm-5-turbo");
+  check (option bool) "tier_fast GLM 4.7 flashx declares tool choice support"
+    (Some true)
+    (supports_tool_choice_for_profile rendered "tier_fast"
+       "glm-coding:glm-4.7-flashx");
   check bool "default profile removed" true
     (match rendered |> member "default_models" with `Null -> true | _ -> false);
   check bool "governance profile removed" true


### PR DESCRIPTION
## Summary
- Mark GLM HTTP cascade entries as supports_tool_choice in keeper/tool-strict profiles.
- Keep the checked-in cascade.json runtime view in sync with cascade.toml.
- Add a seed materialization regression so these GLM fallbacks cannot silently lose tool-choice metadata again.

## Live evidence
- Claude hard quota exposed a fallback gap: required-tool gating could drop GLM entries from tier_fast/big_three when their seed entries lacked supports_tool_choice metadata.
- The live cascade hotfix kept GLM as the non-Claude tool-capable fallback; this PR makes that seed behavior durable.

## Validation
- git diff --check
- python3 TOML/JSON metadata check for big_three, __safe_lane, and tier_fast GLM entries
- Local Dune build attempted, but another session held the shared /tmp/me-dune-local.lock; draft PR CI is the verification surface for the OCaml test executable.