### PR TITLE
fix(board): retry flusher startup CAS contention

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -109,6 +109,7 @@ type board_sse_event =
     }
 
 let backend_state : backend_state Atomic.t = Atomic.make Uninitialized
+let flusher_start_cas_retries = 3
 
 let start_flusher_actor ~sw store =
   Eio.Fiber.fork_daemon ~sw (fun () ->
@@ -131,10 +132,10 @@ let start_flusher_actor ~sw store =
   )
 
 (** CAS [Active (b, false) -> Active (b, true)] for the current [b], then
-    spawn the flusher daemon.  If the CAS loses (someone else flipped the
-    flag concurrently, or the state went back to [Uninitialized]), bail
-    out without spawning.  On daemon-spawn failure, roll the flag back so
-    a later caller can retry.
+    spawn the flusher daemon.  If the CAS loses to another fiber, retry a
+    bounded number of times while the state still needs a flusher; if
+    another fiber already flipped the flag, return.  On daemon-spawn
+    failure, roll the flag back so a later caller can retry.
 
     Pre-D-7 this was a sibling [Atomic.compare_and_set flusher_started
     false true]; the flag now lives in the variant so it cannot drift
@@ -143,26 +144,35 @@ let ensure_flusher_actor store =
   match Eio_context.get_switch_opt () with
   | None -> ()
   | Some sw ->
-      let current = Atomic.get backend_state in
-      (match current with
-       | Uninitialized -> ()
-       | Active (_, true) -> ()
-       | Active (b, false) ->
-           if Atomic.compare_and_set backend_state current (Active (b, true)) then
-             try start_flusher_actor ~sw store
-             with exn ->
-               (* Roll the flag back so a future caller can retry.  Only
-                  roll back if the state hasn't been swapped out from
-                  under us. *)
-               let _ : bool =
-                 Atomic.compare_and_set backend_state
-                   (Active (b, true)) (Active (b, false))
-               in
-               match exn with
-               | Invalid_argument msg when String.equal msg "Switch finished!" ->
-                   Log.BoardLog.warn
-                     "Skipping board flusher actor startup on finished switch"
-               | _ -> raise exn)
+      let rec loop attempts_left =
+        let current = Atomic.get backend_state in
+        match current with
+        | Uninitialized -> ()
+        | Active (_, true) -> ()
+        | Active (b, false) ->
+            if Atomic.compare_and_set backend_state current (Active (b, true)) then
+              try start_flusher_actor ~sw store
+              with exn ->
+                (* Roll the flag back so a future caller can retry.  Only
+                   roll back if the state hasn't been swapped out from
+                   under us. *)
+                let _ : bool =
+                  Atomic.compare_and_set backend_state
+                    (Active (b, true)) (Active (b, false))
+                in
+                match exn with
+                | Invalid_argument msg when String.equal msg "Switch finished!" ->
+                    Log.BoardLog.warn
+                      "Skipping board flusher actor startup on finished switch"
+                | _ -> raise exn
+            else if attempts_left > 0 then begin
+              Eio.Fiber.yield ();
+              loop (attempts_left - 1)
+            end else
+              Log.BoardLog.warn
+                "Board flusher actor startup CAS contention exhausted; retrying on next backend access"
+      in
+      loop flusher_start_cas_retries
 
 
 let keeper_board_signal_hook : (keeper_board_signal -> unit) option Atomic.t = Atomic.make None

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -729,6 +729,20 @@ let test_keeper_sandbox_credential_volume_contracts () =
     (file_contains_pattern "lib/keeper/host_config_provider.ml"
        {|let cred_root = "/tmp/keeper-creds"|})
 
+let test_board_flusher_start_retry_contracts () =
+  check bool "board flusher start has bounded CAS retry count" true
+    (file_contains_pattern "lib/board_dispatch.ml"
+       "let flusher_start_cas_retries = 3");
+  check bool "board flusher CAS contention yields before retry" true
+    (file_contains_pattern "lib/board_dispatch.ml"
+       "Eio.Fiber.yield ()");
+  check bool "board flusher retry decrements attempts" true
+    (file_contains_pattern "lib/board_dispatch.ml"
+       "loop (attempts_left - 1)");
+  check bool "board flusher exhausted retry is operator visible" true
+    (file_contains_pattern "lib/board_dispatch.ml"
+       "Board flusher actor startup CAS contention exhausted")
+
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
@@ -1435,6 +1449,8 @@ let () =
              test_keeper_list_cache_atomic_contracts;
            test_case "keeper sandbox credential volume contracts" `Quick
              test_keeper_sandbox_credential_volume_contracts;
+           test_case "board flusher start retry contracts" `Quick
+             test_board_flusher_start_retry_contracts;
            test_case "dashboard warm hydration contracts" `Quick
              test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;


### PR DESCRIPTION
## Summary
- retry board flusher startup CAS contention while the backend state still needs a flusher
- preserve the existing fast return when another fiber already starts the flusher
- add source-contract coverage for the bounded retry and exhausted-contention warning

## Source-doc link
- Follows Kimi Multi Keeper plan Phase 1 Week 2 / Boundary D board flusher CAS retry gap
- Refs #13275

## Verification
- scripts/dune-local.sh build test/test_board_dispatch.exe test/test_ci_hardening_source.exe
- ./_build/default/test/test_board_dispatch.exe (37 tests)
- ./_build/default/test/test_ci_hardening_source.exe (42 tests)
- git diff --check origin/main..HEAD

## Note
- Branch rebased cleanly onto current origin/main after local verification; PR CI will run on the rebased head.