### PR TITLE
fix(keeper): release turn slot before degraded retry

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -641,8 +641,8 @@ let run_keepalive_unified_turn
             ~keeper_id:meta_after_triage.name
         in
         match
-          Keeper_turn_slot.with_keeper_turn_slot ~keeper_name:meta_after_triage.name
-            ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
+          Keeper_turn_slot.with_keeper_turn_slot_control ~keeper_name:meta_after_triage.name
+            ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
             match
               with_in_turn_liveness_pulse ~ctx ~meta:meta_after_observe ~stop
                 (fun () ->
@@ -653,6 +653,7 @@ let run_keepalive_unified_turn
                     ~generation:meta_after_observe.runtime.generation
                     ~channel:turn_decision.channel
                     ~semaphore_wait_ms:semaphore_wait_ms
+                    ~turn_slot_control:slot_control
                     ~shared_context
                     ())
             with

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -211,6 +211,22 @@ val set_budget_exhaustion_for_test :
 (** Test-only: pre-load strike count.  [strikes <= 0] is equivalent
     to [reset_budget_exhaustion]. *)
 
+type keeper_turn_slot_control = Keeper_turn_slot.keeper_turn_slot_control = {
+  release_for_retry : unit -> unit;
+  reacquire_after_retry :
+    unit ->
+    (int, [ `Semaphore_wait_timeout of Keeper_turn_slot.semaphore_wait_timeout ])
+      result;
+}
+
+(** Test-only wrapper around the keeper turn slot acquisition path with
+    explicit in-turn release/reacquire controls. *)
+val with_keeper_turn_slot_control_for_test :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
   keeper_name:string ->

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -473,6 +473,30 @@ type keeper_turn_slot_state = {
   autonomous_ticket : int option ref;
 }
 
+type keeper_turn_slot_control = {
+  release_for_retry : unit -> unit;
+  reacquire_after_retry :
+    unit ->
+    (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result;
+}
+
+let make_keeper_turn_slot_state () =
+  {
+    acquired_autonomous = ref false;
+    acquired_reactive = ref false;
+    acquired_turn = ref false;
+    autonomous_acquisition_id = ref None;
+    reactive_acquisition_id = ref None;
+    turn_acquisition_id = ref None;
+    autonomous_ticket = ref None;
+  }
+
+let keeper_turn_slot_is_held state =
+  !(state.acquired_autonomous)
+  || !(state.acquired_reactive)
+  || !(state.acquired_turn)
+  || Option.is_some !(state.autonomous_ticket)
+
 let after_acquire_flag_hook_for_test :
   (label:string -> keeper_name:string -> unit) option ref =
   ref None
@@ -534,18 +558,24 @@ let release_recorded_holder
       Eio.Semaphore.release sem
     end
 
-let release_keeper_turn_slot ~keeper_name state =
+let release_keeper_turn_slot_impl
+    ~keeper_name
+    ~(stamp_autonomous_completion : bool)
+    state =
   safe_bookkeeping ~op:"drop_autonomous_waiter" (fun () ->
     Option.iter
       (fun ticket -> drop_autonomous_waiter ~ticket)
       !(state.autonomous_ticket));
+  state.autonomous_ticket := None;
   (* Release exactly what we acquired. The turn, autonomous, and reactive
      semaphores account for separate quotas, so release order does not affect
      permit ownership. *)
   if !(state.acquired_turn) then begin
     release_recorded_holder ~keeper_name ~label:"turn"
       ~acquisition_id:!(state.turn_acquisition_id)
-      turn_semaphore
+      turn_semaphore;
+    state.acquired_turn := false;
+    state.turn_acquisition_id := None
   end;
   if !(state.acquired_autonomous) then begin
     release_recorded_holder ~keeper_name ~label:"autonomous"
@@ -555,15 +585,28 @@ let release_keeper_turn_slot ~keeper_name state =
            the semaphore so that [maybe_yield_for_fairness] can measure the
            correct interval when this keeper's heartbeat loops back
            immediately. *)
-        safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
-          record_autonomous_completion ~keeper_name))
-      autonomous_turn_semaphore
+        if stamp_autonomous_completion then
+          safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
+            record_autonomous_completion ~keeper_name))
+      autonomous_turn_semaphore;
+    state.acquired_autonomous := false;
+    state.autonomous_acquisition_id := None
   end;
   if !(state.acquired_reactive) then begin
     release_recorded_holder ~keeper_name ~label:"reactive"
       ~acquisition_id:!(state.reactive_acquisition_id)
-      reactive_turn_semaphore
+      reactive_turn_semaphore;
+    state.acquired_reactive := false;
+    state.reactive_acquisition_id := None
   end
+
+let release_keeper_turn_slot ~keeper_name state =
+  release_keeper_turn_slot_impl
+    ~keeper_name ~stamp_autonomous_completion:true state
+
+let release_keeper_turn_slot_for_retry ~keeper_name state =
+  release_keeper_turn_slot_impl
+    ~keeper_name ~stamp_autonomous_completion:false state
 
 (** Force-release every slot recorded for [keeper_name] in [holder_table].
     Called by the supervisor when a keeper has been declared crashed but
@@ -816,7 +859,7 @@ let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
            Eio.Fiber.yield ());
       wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at)
 
-let with_keeper_turn_slot ~keeper_name ~channel f =
+let with_keeper_turn_slot_control ~keeper_name ~channel f =
   let is_autonomous =
     match channel with
     | Keeper_world_observation.Scheduled_autonomous -> true
@@ -831,33 +874,12 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
      log lines from every other surface that uses the SSOT helper —
      operators grepping for one form silently missed the other. *)
   let channel_label = Keeper_world_observation.channel_to_string channel in
-  let t0 = Time_compat.now () in
-  let queue_depth = List.length (autonomous_waiter_snapshot_for_test ()) in
-  Log.Keeper.routine "semaphore_acquire: keeper=%s channel=%s autonomous_available=%d turn_available=%d queue_depth=%d"
-    keeper_name
-    channel_label
-    (Eio.Semaphore.get_value autonomous_turn_semaphore)
-    (Eio.Semaphore.get_value turn_semaphore)
-    queue_depth;
-  Prometheus.set_gauge Prometheus.metric_keeper_turn_queue_depth
-    ~labels:[("keeper", keeper_name); ("channel", channel_label)]
-    (float_of_int queue_depth);
   (* Track acquisitions in mutable flags so the outer Fun.protect can
      release exactly the slots we hold — regardless of which result or
      exception path fires (Eio.Cancel.Cancelled or any other). This
      keeps resource cleanup independent of Eio.Semaphore's internal
      cancel-race handling. *)
-  let slot_state =
-    {
-      acquired_autonomous = ref false;
-      acquired_reactive = ref false;
-      acquired_turn = ref false;
-      autonomous_acquisition_id = ref None;
-      reactive_acquisition_id = ref None;
-      turn_acquisition_id = ref None;
-      autonomous_ticket = ref None;
-    }
-  in
+  let slot_state = make_keeper_turn_slot_state () in
   let acquire_bounded ~label ~phase sem =
     match Eio_context.get_clock_opt () with
     | Some clock ->
@@ -914,9 +936,22 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
          record_holder is the caller's responsibility, after flag set. *)
       Ok ()
   in
-  Fun.protect
-    ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
-    (fun () ->
+  let log_acquire_attempt () =
+    let queue_depth = List.length (autonomous_waiter_snapshot_for_test ()) in
+    Log.Keeper.routine
+      "semaphore_acquire: keeper=%s channel=%s autonomous_available=%d turn_available=%d queue_depth=%d"
+      keeper_name
+      channel_label
+      (Eio.Semaphore.get_value autonomous_turn_semaphore)
+      (Eio.Semaphore.get_value turn_semaphore)
+      queue_depth;
+    Prometheus.set_gauge Prometheus.metric_keeper_turn_queue_depth
+      ~labels:[("keeper", keeper_name); ("channel", channel_label)]
+      (float_of_int queue_depth)
+  in
+  let acquire_all () =
+    let t0 = Time_compat.now () in
+    log_acquire_attempt ();
       let autonomous_result =
         if is_autonomous
         then begin
@@ -1010,10 +1045,48 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
             record_holder ~label:"turn" ~keeper_name
               ~acquired_at:(Time_compat.now ())
           in
-          slot_state.turn_acquisition_id := Some acquisition_id;
-          let semaphore_wait_ms =
-            int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
-          Ok (f ~semaphore_wait_ms))
+              slot_state.turn_acquisition_id := Some acquisition_id;
+              let semaphore_wait_ms =
+                int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
+              Ok semaphore_wait_ms
+  in
+  let slot_control =
+    {
+      release_for_retry =
+        (fun () ->
+          if keeper_turn_slot_is_held slot_state then begin
+            Log.Keeper.info
+              "%s: releasing keeper turn slot before degraded retry"
+              keeper_name;
+            release_keeper_turn_slot_for_retry ~keeper_name slot_state
+          end);
+      reacquire_after_retry =
+        (fun () ->
+          if keeper_turn_slot_is_held slot_state then begin
+            Log.Keeper.warn
+              "%s: retry slot reacquire requested while a slot is still held; releasing first"
+              keeper_name;
+            release_keeper_turn_slot_for_retry ~keeper_name slot_state
+          end;
+          acquire_all ());
+    }
+  in
+  Fun.protect
+    ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
+    (fun () ->
+      match acquire_all () with
+      | Error _ as e -> e
+      | Ok semaphore_wait_ms ->
+          Ok (f ~semaphore_wait_ms ~slot_control))
+;;
+
+let with_keeper_turn_slot ~keeper_name ~channel f =
+  with_keeper_turn_slot_control ~keeper_name ~channel
+    (fun ~semaphore_wait_ms ~slot_control:_ -> f ~semaphore_wait_ms)
+;;
+
+let with_keeper_turn_slot_control_for_test ~keeper_name ~channel f =
+  with_keeper_turn_slot_control ~keeper_name ~channel f
 ;;
 
 let with_keeper_turn_slot_for_test ~keeper_name ~channel f =

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -169,10 +169,31 @@ val set_budget_exhaustion_for_test : keeper_name:string -> strikes:int -> unit
 
 type keeper_turn_slot_state
 
+type keeper_turn_slot_control = {
+  release_for_retry : unit -> unit;
+  reacquire_after_retry :
+    unit ->
+    (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result;
+}
+
+val with_keeper_turn_slot_control :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
 val with_keeper_turn_slot :
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
+(** Test-only wrapper around the keeper turn slot acquisition path with
+    explicit in-turn release/reacquire controls. *)
+val with_keeper_turn_slot_control_for_test :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 (** Test-only wrapper around the keeper turn slot acquisition path. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -74,11 +74,34 @@ let record_streaming_cancelled_observation
     ~prev:Keeper_turn_fsm.Streaming
     (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop)
 
+let sdk_error_of_retry_slot_reacquire_timeout
+    ~(keeper_name : string)
+    (timeout : Keeper_turn_slot.semaphore_wait_timeout) =
+  let phase =
+    Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase
+  in
+  let holder_summary =
+    Keeper_turn_slot.format_slot_holders timeout.timeout_holders
+  in
+  Agent_sdk.Error.Api
+    (Agent_sdk.Retry.Timeout
+       {
+         message =
+           Printf.sprintf
+             "keeper turn slot reacquire timed out after degraded retry \
+              (keeper=%s phase=%s wait=%.0fs holders=%s)"
+             keeper_name
+             phase
+             timeout.timeout_wait_sec
+             holder_summary;
+       })
+
 let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(generation : int)
     ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
     ?(semaphore_wait_ms = 0)
+    ?turn_slot_control
     ?shared_context
     () : (keeper_meta, Agent_sdk.Error.sdk_error) result =
   (* Spec navigation (OCaml -> TLA+) — plan §19 Cycle 28 anchor for
@@ -1252,7 +1275,15 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                           let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
                             current_turn_phase_elapsed_ms ()
                           in
+                          let slot_release_at_phase =
+                            match turn_slot_control with
+                            | Some slot_control ->
+                                slot_control.Keeper_turn_slot.release_for_retry ();
+                                Some "retry_scheduled"
+                            | None -> None
+                          in
                           record_cascade_rotation_attempt
+                            ?slot_release_at_phase
                             ~productive_phase_elapsed_ms
                             ?retry_phase_elapsed_ms
                             ~from_cascade:execution.cascade_name
@@ -1271,17 +1302,45 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             (match
                                next_execution.max_context_resolution.requested_override
                              with
-                             | Some requested -> string_of_int requested
-                             | None -> "none")
+                            | Some requested -> string_of_int requested
+                            | None -> "none")
                             (short_preview (Agent_sdk.Error.to_string err));
                           Eio.Fiber.yield ();
-                          retry_loop ~run_meta ~execution:next_execution
-                            ~run_generation
-                            ~attempt:1
-                            ~is_retry:true
-                            ~overflow_retry_used
-                            ~attempted_cascades:
-                              (next_execution_cascade_name :: attempted_cascades))
+                          let run_retry_after_reacquire () =
+                            retry_loop ~run_meta ~execution:next_execution
+                              ~run_generation
+                              ~attempt:1
+                              ~is_retry:true
+                              ~overflow_retry_used
+                              ~attempted_cascades:
+                                (next_execution_cascade_name :: attempted_cascades)
+                          in
+                          match turn_slot_control with
+                          | None -> run_retry_after_reacquire ()
+                          | Some slot_control -> (
+                              match
+                                slot_control.Keeper_turn_slot.reacquire_after_retry ()
+                              with
+                              | Ok retry_semaphore_wait_ms ->
+                                  Log.Keeper.info
+                                    "%s: reacquired keeper turn slot for degraded retry on cascade=%s wait_ms=%d"
+                                    meta.name
+                                    next_execution_cascade_name
+                                    retry_semaphore_wait_ms;
+                                  run_retry_after_reacquire ()
+                              | Error (`Semaphore_wait_timeout timeout) ->
+                                  let slot_err =
+                                    sdk_error_of_retry_slot_reacquire_timeout
+                                      ~keeper_name:meta.name timeout
+                                  in
+                                  Log.Keeper.warn
+                                    "%s: degraded retry to %s skipped because turn slot reacquire timed out: %s"
+                                    meta.name
+                                    next_execution_cascade_name
+                                    (short_preview
+                                       (Agent_sdk.Error.to_string slot_err));
+                                  mark_terminal_error slot_err;
+                                  Error slot_err))
                   | Degraded_retry_budget_exhausted degraded_retry ->
                       (* #13120 review (P1, threads 2 & 4): record the
                          rejection in [cascade_rotation_attempts] so

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -240,6 +240,7 @@ val run_keeper_cycle :
   generation:int ->
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
+  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   ?shared_context:Agent_sdk.Context.t ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
@@ -251,6 +252,7 @@ val run_unified_turn :
   generation:int ->
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
+  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   ?shared_context:Agent_sdk.Context.t ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -390,6 +390,126 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
          "force-released autonomous holder stamped normal completion: delay=%.3f"
          delay)
 
+let test_retry_control_releases_and_reacquires_reactive_slot () =
+  let keeper_name = "diag-retry-reactive" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let reactive_before = KK.reactive_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_control_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ~slot_control ->
+         assert_eq ~msg:"turn acquired before retry release"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive acquired before retry release"
+           ~expected:(reactive_before - 1)
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+         slot_control.release_for_retry ();
+         assert_eq ~msg:"turn restored during retry release"
+           ~expected:turn_before
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive restored during retry release"
+           ~expected:reactive_before
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+         let names =
+           List.map fst (KK.reactive_slot_holders ~now:(Time_compat.now ()))
+         in
+         if List.mem keeper_name names then
+           failwith "reactive holder remained after retry release";
+         let nested =
+           KK.with_keeper_turn_slot_for_test
+             ~keeper_name:"diag-retry-reactive-peer"
+             ~channel:Masc_mcp.Keeper_world_observation.Reactive
+             (fun ~semaphore_wait_ms:_ -> ())
+         in
+         (match nested with
+          | Ok () -> ()
+          | Error (`Semaphore_wait_timeout _) ->
+              failwith "nested keeper could not acquire released slot");
+         (match slot_control.reacquire_after_retry () with
+          | Error (`Semaphore_wait_timeout _) ->
+              failwith "retry reacquire unexpectedly timed out"
+          | Ok retry_wait_ms when retry_wait_ms < 0 ->
+              failwith "retry reacquire returned negative wait"
+          | Ok _ -> ());
+         assert_eq ~msg:"turn reacquired after retry release"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive reacquired after retry release"
+           ~expected:(reactive_before - 1)
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn baseline after retry control finalizer"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"reactive baseline after retry control finalizer"
+    ~expected:reactive_before
+    ~actual:(KK.reactive_turn_semaphore_value_for_test ())
+
+let test_retry_control_autonomous_release_skips_completion_stamp () =
+  let keeper_name = "diag-retry-autonomous" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let autonomous_before = KK.autonomous_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_control_for_test
+      ~keeper_name
+      ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
+      (fun ~semaphore_wait_ms:_ ~slot_control ->
+         assert_eq ~msg:"turn acquired before autonomous retry release"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous acquired before retry release"
+           ~expected:(autonomous_before - 1)
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
+         slot_control.release_for_retry ();
+         assert_eq ~msg:"turn restored by autonomous retry release"
+           ~expected:turn_before
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous restored by retry release"
+           ~expected:autonomous_before
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
+         let delay =
+           let ticket =
+             KK.enqueue_autonomous_waiter_for_test "diag-retry-waiting-peer"
+           in
+           Fun.protect
+             ~finally:(fun () -> KK.drop_autonomous_waiter_for_test ticket)
+             (fun () ->
+                KK.fairness_delay_sec_at
+                  ~keeper_name ~now:(Time_compat.now ()))
+         in
+         if delay <> 0.0 then
+           failwith
+             (Printf.sprintf
+                "retry release stamped normal autonomous completion: delay=%.3f"
+                delay);
+         (match slot_control.reacquire_after_retry () with
+          | Error (`Semaphore_wait_timeout _) ->
+              failwith "autonomous retry reacquire unexpectedly timed out"
+          | Ok _ -> ());
+         assert_eq ~msg:"turn reacquired after autonomous retry release"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous reacquired after retry release"
+           ~expected:(autonomous_before - 1)
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn baseline after autonomous retry control"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"autonomous baseline after retry control"
+    ~expected:autonomous_before
+    ~actual:(KK.autonomous_turn_semaphore_value_for_test ())
+
 let test_force_release_marker_ttl_bounds_unfinalized_fibers () =
   KK.clear_force_released_markers_for_test ();
   let marked_at = 1_000.0 in
@@ -432,6 +552,10 @@ let () =
         test_force_release_marker_does_not_leak_to_replacement;
       "force released autonomous holder skips completion stamp",
         test_force_released_autonomous_holder_does_not_stamp_completion;
+      "retry control releases and reacquires reactive slot",
+        test_retry_control_releases_and_reacquires_reactive_slot;
+      "retry control autonomous release skips completion stamp",
+        test_retry_control_autonomous_release_skips_completion_stamp;
       "force release marker ttl bounds unfinalized fibers",
         test_force_release_marker_ttl_bounds_unfinalized_fibers;
     ]


### PR DESCRIPTION
## Summary
- Add a `Keeper_turn_slot` control object that can release and reacquire the current keeper turn slot inside a live turn.
- Wire the heartbeat path to pass that control into `run_keeper_cycle`, so degraded cascade retry releases the productive slot before yielding and reacquires it before retry execution.
- Stamp `slot_release_at_phase="retry_scheduled"` when the runtime actually releases the slot, and add regression coverage for reactive and autonomous slot release/reacquire behavior.

## Why
#12888 still had the runtime retry loop recursing under the same outer turn slot. The TLA model in #13288 pinned the invariant; this patch moves the runtime toward that contract so degraded retries do not starve other keepers while waiting for fallback work.

## Validation
- `dune build --root . -j 1 test/test_keeper_turn_slot_holders.exe`
- `./_build/default/test/test_keeper_turn_slot_holders.exe`
- `dune build --root . -j 1 test/test_cascade_per_candidate_telemetry.exe`
- `./_build/default/test/test_cascade_per_candidate_telemetry.exe`
- `scripts/check-oas-pin.sh` (API fingerprint OK; existing upstream drift warning remains)
- `git diff --check`

Note: `scripts/dune-local.sh build test/test_keeper_turn_slot_holders.exe` was attempted first, but this host had a long `/tmp/me-dune-local.lock` queue from other sessions. I used the same focused targets through direct `dune -j 1` rather than running a full suite.