### PR TITLE
fix(keeper): allow sandbox repos listing through repo mapping

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -268,6 +268,68 @@ let normalize_path_for_prefix_check path =
     String.sub p 0 (String.length p - 1)
   else p
 
+let relative_under ~root path =
+  let root_norm = normalize_path_for_prefix_check root in
+  let path_norm = normalize_path_for_prefix_check path in
+  if String.equal path_norm root_norm then Some ""
+  else
+    let prefix = root_norm ^ "/" in
+    if String.starts_with ~prefix path_norm then
+      Some
+        (String.sub path_norm (String.length prefix)
+           (String.length path_norm - String.length prefix))
+    else None
+
+let path_segments rel =
+  String.split_on_char '/' rel
+  |> List.filter (fun segment -> not (String.equal segment ""))
+
+type playground_path =
+  | Playground_internal
+  | Playground_repos_root
+  | Playground_repo of string
+
+let playground_path_of_path ~base_path ~path =
+  let playground_root =
+    Filename.concat (Filename.concat base_path ".masc") "playground"
+  in
+  match relative_under ~root:playground_root path with
+  | None -> None
+  | Some rel -> (
+      match path_segments rel with
+      | "docker" :: _keeper :: "repos" :: repo_id :: _
+      | _keeper :: "repos" :: repo_id :: _ ->
+          Some (Playground_repo repo_id)
+      | "docker" :: _keeper :: ["repos"]
+      | _keeper :: ["repos"] ->
+          Some Playground_repos_root
+      | _ -> Some Playground_internal)
+
+let basename_of_path path =
+  normalize_path_for_prefix_check path |> Filename.basename
+
+let resolve_repository_id_segment ~base_path segment =
+  match Repo_store.load_all ~base_path with
+  | Error msg ->
+      Log.Misc.warn
+        "[KeeperRepoMapping] resolve_repository_id_segment: repo store load \
+         failed for segment %s (error: %s)"
+        segment msg;
+      segment
+  | Ok repos -> (
+      match
+        List.find_opt
+          (fun (repo : repository) ->
+            String.equal repo.id segment
+            || String.equal repo.name segment
+            || String.equal
+                 (basename_of_path (Repo_store.local_path ~base_path repo))
+                 segment)
+          repos
+      with
+      | Some repo -> repo.id
+      | None -> segment)
+
 (** [path_under_repo ~base_path repo path] returns [true] when [path]
     is equal to or strictly under [repo]'s resolved local_path. *)
 let path_under_repo ~base_path repo path =
@@ -281,6 +343,11 @@ let path_under_repo ~base_path repo path =
     registered repository whose [local_path] contains [path], or [None]
     if the path is not under any registered repository. *)
 let repository_id_of_path ~base_path ~path =
+  match playground_path_of_path ~base_path ~path with
+  | Some Playground_internal | Some Playground_repos_root -> None
+  | Some (Playground_repo repo_id) ->
+      Some (resolve_repository_id_segment ~base_path repo_id)
+  | None -> (
   match Repo_store.load_all ~base_path with
   | Error msg ->
       Log.Misc.warn
@@ -293,7 +360,7 @@ let repository_id_of_path ~base_path ~path =
         List.find_opt (fun repo -> path_under_repo ~base_path repo path) repos
       with
       | Some repo -> Some repo.id
-      | None -> None)
+      | None -> None))
 
 (** [validate_path_access ~keeper_id ~base_path ~path] checks whether
     [keeper_id] is allowed to access the repository that contains [path].

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -50,6 +50,14 @@ let with_empty_temp_base_path f =
       rm_rf dir)
     (fun () -> f dir)
 
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" || Sys.file_exists path then ()
+  else begin
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755
+  end
+
 let write_mapping ?credential_id base_path keeper_id repo_ids =
   let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
   let entries =
@@ -200,6 +208,100 @@ let test_validate_path_access_no_repo () =
       match Keeper_repo_mapping.validate_path_access ~keeper_id:"keeper-1" ~base_path ~path with
       | Ok () -> ()
       | Error e -> Alcotest.fail ("expected Ok for no-repo path, got: " ^ e))
+
+let test_validate_path_access_playground_repos_root_ignores_base_repo () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_path =
+        Filename.concat base_path "workspace/yousleepwhen/masc-mcp"
+      in
+      ensure_dir masc_path;
+      let masc_repo =
+        { (sample_repo "masc-mcp") with
+          name = "masc-mcp";
+          local_path = masc_path;
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "nick0cave" [ "masc-mcp" ];
+      let path =
+        Filename.concat base_path ".masc/playground/docker/nick0cave/repos"
+      in
+      ensure_dir path;
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
+          ~base_path ~path
+      with
+      | Ok () -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected playground repos root to bypass base repo mapping, got: "
+             ^ e))
+
+let test_validate_path_access_playground_repo_uses_registered_name () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_path =
+        Filename.concat base_path "workspace/yousleepwhen/masc-mcp"
+      in
+      ensure_dir masc_path;
+      let masc_repo =
+        { (sample_repo "repo-masc") with
+          name = "masc-mcp";
+          local_path = masc_path;
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "nick0cave" [ "repo-masc" ];
+      let path =
+        Filename.concat base_path
+          ".masc/playground/docker/nick0cave/repos/masc-mcp/lib"
+      in
+      ensure_dir path;
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
+          ~base_path ~path
+      with
+      | Ok () -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected playground repo path to resolve by registered name, got: "
+             ^ e))
+
+let test_validate_path_access_playground_unknown_repo_denied () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_path =
+        Filename.concat base_path "workspace/yousleepwhen/masc-mcp"
+      in
+      ensure_dir masc_path;
+      let masc_repo =
+        { (sample_repo "masc-mcp") with
+          name = "masc-mcp";
+          local_path = masc_path;
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "nick0cave" [ "masc-mcp" ];
+      let path =
+        Filename.concat base_path
+          ".masc/playground/docker/nick0cave/repos/unknown/lib"
+      in
+      ensure_dir path;
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
+          ~base_path ~path
+      with
+      | Ok () -> Alcotest.fail "expected unknown playground repo to be denied"
+      | Error msg ->
+          Alcotest.(check bool)
+            "mentions not allowed" true (contains_substring msg "not allowed"))
 
 let test_apply_mapping_explicit () =
   with_temp_base_path (fun base_path ->
@@ -484,6 +586,12 @@ let () =
           Alcotest.test_case "allowed" `Quick test_validate_path_access_allowed;
           Alcotest.test_case "denied" `Quick test_validate_path_access_denied;
           Alcotest.test_case "no repo" `Quick test_validate_path_access_no_repo;
+          Alcotest.test_case "playground repos root ignores base repo" `Quick
+            test_validate_path_access_playground_repos_root_ignores_base_repo;
+          Alcotest.test_case "playground repo resolves registered name" `Quick
+            test_validate_path_access_playground_repo_uses_registered_name;
+          Alcotest.test_case "playground unknown repo denied" `Quick
+            test_validate_path_access_playground_unknown_repo_denied;
         ] );
       ( "apply_mapping",
         [


### PR DESCRIPTION
## Summary
- Keep keeper repo mapping from classifying `.masc/playground/.../repos` as the broad base repo.
- Resolve sandbox `repos/<repo>` segments by registered repo id, name, or local-path basename before applying keeper mappings.
- Preserve denial for unknown sandbox repos when a keeper mapping exists.

## Why this matters
Live runtime evidence showed a keeper_shell read inside the Docker playground failing with `Keeper nick0cave is not allowed to access repository me` for `path=repos`. That path is the keeper sandbox repo lane, so the root `me` repository mapping was blocking keepers before they could inspect or work on sandbox repos.

## Tests
- `scripts/dune-local.sh build test/test_keeper_repo_mapping.exe`
- `./_build/default/test/test_keeper_repo_mapping.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-shell-repos-0505 --cache=disabled -j 1 bin/main_eio.exe`