### PR TITLE
fix(keeper): map completion_contract_violation:* to pause_human (#11651 regression)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -309,6 +309,19 @@ let operator_disposition (receipt : t) =
   else if provider_runtime_failure then
     ("pause_human", "provider_runtime_error")
   else if
+    String.starts_with ~prefix:"completion_contract_violation:" terminal_reason
+  then
+    (* The downstream completion-contract layer has already decided the turn
+       violated [require_tool_use] (or another contract sub-clause) and emits
+       [terminal_reason="completion_contract_violation:<sub_clause>"]. The
+       earlier-layer [tool_contract_result] can show [satisfied_completion]
+       from a separate classifier that judged the same turn locally OK; the
+       two-layer disagreement was the unmapped fall-through that #11651
+       regression counter is meant to flag. Treat terminal_reason as
+       authoritative — the disposition is the same as the explicit
+       [tool_required_unsatisfied] branch below. *)
+    ("pause_human", "tool_required_unsatisfied")
+  else if
     receipt.tool_surface.tool_requirement = Required
     && (List.mem tool_contract_result
           [

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -120,6 +120,35 @@ let test_pause_human_when_no_tools_used () =
   let r = mk_receipt ~tools_used:[] () in
   check_disp "tools_used=[]" r "pause_human" "tool_required_unsatisfied"
 
+(* Regression: the completion-contract layer can report
+   [terminal_reason="completion_contract_violation:require_tool_use"] while
+   the earlier tool_contract classifier reports
+   [tool_contract_result="satisfied_completion"]. Before this branch the
+   two-layer disagreement fell through to ("unknown","unmapped_cascade_state")
+   and tripped the #11651 regression counter. The terminal_reason is
+   authoritative — pause_human/tool_required_unsatisfied. *)
+let test_pause_human_for_completion_contract_violation_with_satisfied_inner () =
+  let r =
+    mk_receipt
+      ~terminal_reason_code:"completion_contract_violation:require_tool_use"
+      ~tool_contract_result:"satisfied_completion"
+      ~error_kind:(Some (R.error_kind_of_string "agent"))
+      ~tools_used:[ "keeper_board_list"; "keeper_stay_silent" ]
+      ()
+  in
+  check_disp "completion_contract_violation overrides satisfied inner" r
+    "pause_human" "tool_required_unsatisfied"
+
+let test_pause_human_for_completion_contract_violation_other_subclause () =
+  let r =
+    mk_receipt
+      ~terminal_reason_code:"completion_contract_violation:other_subclause"
+      ~tool_contract_result:"satisfied"
+      ~tools_used:[ "Read" ] ()
+  in
+  check_disp "completion_contract_violation:other_subclause" r "pause_human"
+    "tool_required_unsatisfied"
+
 let test_provider_failure_not_reported_as_tool_unsatisfied () =
   let r =
     mk_receipt ~tools_used:[] ~terminal_reason_code:"api_error_invalid_request"
@@ -267,6 +296,15 @@ let () =
             test_pause_human_for_each_violation;
           test_case "tools_used=[] -> pause_human" `Quick
             test_pause_human_when_no_tools_used;
+          test_case
+            "completion_contract_violation:* with satisfied_completion inner \
+             -> pause_human (#11651 regression)"
+            `Quick
+            test_pause_human_for_completion_contract_violation_with_satisfied_inner;
+          test_case
+            "completion_contract_violation:other_subclause -> pause_human"
+            `Quick
+            test_pause_human_for_completion_contract_violation_other_subclause;
           test_case "provider failure before tool use -> provider_runtime_error" `Quick
             test_provider_failure_not_reported_as_tool_unsatisfied;
           test_case "config failure before tool use -> preflight_config_error" `Quick


### PR DESCRIPTION
## Summary

- add a branch in \`keeper_execution_receipt.operator_disposition\` that maps any \`terminal_reason\` starting with \`completion_contract_violation:\` to \`("pause_human", "tool_required_unsatisfied")\`
- two regression tests cover the originally observed \`require_tool_use\` sub-clause and a generic \`other_subclause\`

## Root Cause

Live boot log on \`./start-masc-mcp.sh --base-path ~/me\` showed the inline-flagged regression of #11651:

\`\`\`
[WARN] [Keeper] operator_disposition: unmapped (
  outcome=error
  cascade_outcome=completed
  terminal_reason=completion_contract_violation:require_tool_use
  tool_contract_result=satisfied_completion
  error_kind=agent
) — investigate regression of #11651 silent-path fix
\`\`\`

Tracing \`operator_disposition\` against this tuple:

- \`cascade_exhausted\` — false (terminal_reason has different prefix)
- \`preflight_config_failure\` — false (\`error_kind=agent\` is neither config nor auth)
- \`provider_runtime_failure\` — false (\`error_kind=agent\` is not in \`[api;mcp;io;orchestration;serialization]\`, terminal_reason does not start with \`api_error_\` or equal \`provider_error\`)
- \`tool_required_unsatisfied\` — false: \`tool_contract_result="satisfied_completion"\` is not in the violated/unknown/passive_only/missing_required_tool_use list, and \`tools_used\` is non-empty
- final \`outcome_kind\` match — \`outcome="error"\` is neither \`Cancelled\`, \`Skipped\`, nor \`Ok+completed\` → falls into \`_\` and emits \`("unknown", "unmapped_cascade_state")\`

The two-layer disagreement is real: \`keeper_agent_run.ml:700/708\` emits \`tool_contract_result="satisfied_completion"\` when the local tool-call classifier is happy, while \`keeper_agent_error.ml:80\` formats \`terminal_reason="completion_contract_violation:%s"\` when the downstream completion-contract layer later rejects the same turn. The \`tool_contract_result\` reflects an earlier classifier; the \`terminal_reason\` reflects the final decision.

## Fix

Treat \`terminal_reason\` as authoritative for the \`completion_contract_violation:*\` family. The disposition is the same as the existing \`tool_required_unsatisfied\` branch — operationally the keeper is in the same state.

The new branch sits before the existing \`tool_required_unsatisfied\` branch so both disagreement-shapes (terminal_reason-only and tool_contract_result-only) yield the same \`(pause_human, tool_required_unsatisfied)\` pair, and dashboard / Prometheus labels stay backward-compatible.

## Why this branch and not OR-extension

The pre-existing \`tool_required_unsatisfied\` branch is gated on \`tool_surface.tool_requirement = Required\`. The new \`completion_contract_violation:\` case is independent of that gate — by the time the downstream layer emitted \`completion_contract_violation:require_tool_use\`, it has already decided the contract was effectively required for this turn, regardless of what the tool surface struct currently shows. Keeping the branch separate keeps the gate semantics localized.

## Validation

- \`scripts/dune-local.sh build test/test_keeper_pause_broadcast.exe\`
- \`./_build/default/test/test_keeper_pause_broadcast.exe\` → 14/14 pass, including the 2 new regression tests; the existing \`unmapped -> unknown\` test still passes (proving unrelated unmapped tuples still fall through to the regression counter)
- Adjacent suite \`test_keeper_terminal_reason.exe\` → 32/32 pass
- Adjacent suite \`test_keeper_contract_classifier_pure.exe\` → 19/20 pass; the single \`contract_status_label.000 — Tool_surface_*\` failure is **pre-existing on \`origin/main\`** (verified by running same binary on \`c3ec13dec9\`) and is unrelated to this change

## Notes

- File \`lib/keeper/keeper_execution_receipt.ml\` is **not** in PR #13283's 50+ file list, so no merge conflict expected.
- This PR addresses item P0-2 from the diagnosis report at \`~/me/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-oas-merry-waffle.md\`.
- Stays Draft per the agent-authored convention (Draft Auto-Merge guard); please add \`human-approved-ready\` label when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)