### PR TITLE
fix(docker): declare runtime storage volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,13 @@ RUN chmod +x /app/masc-mcp
 # Create non-root user for runtime
 RUN groupadd --system appgroup && useradd --system --gid appgroup appuser
 
-# Create data directory for JSONL fallback
+# Runtime state lives under MASC_BASE_PATH=/app, which resolves durable JSONL
+# storage to /app/.masc. Keep it separate from the immutable config seed below.
 RUN mkdir -p /app/.masc && chown -R appuser:appgroup /app/.masc
 
 # Copy all config files. CI may generate additional JSON alongside tracked files.
+# MASC_CONFIG_DIR points here, so this is the image-baked config root, not
+# the mutable runtime storage root.
 COPY config/ /app/config/
 
 # Copy the built dashboard SPA from the build stage.  lib/web_dashboard.ml
@@ -68,6 +71,8 @@ RUN chown -R appuser:appgroup /app/assets
 ENV PORT=8080
 ENV MASC_BASE_PATH=/app
 ENV MASC_CONFIG_DIR=/app/config
+
+VOLUME ["/app/.masc"]
 
 EXPOSE 8080
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -743,6 +743,20 @@ let test_board_flusher_start_retry_contracts () =
     (file_contains_pattern "lib/board_dispatch.ml"
        "Board flusher actor startup CAS contention exhausted")
 
+let test_docker_config_storage_contracts () =
+  check bool "production image base path remains app root" true
+    (file_contains_pattern "Dockerfile" {|ENV MASC_BASE_PATH=/app|});
+  check bool "production image config dir remains image-baked config root" true
+    (file_contains_pattern "Dockerfile" {|ENV MASC_CONFIG_DIR=/app/config|});
+  check bool "production image documents config root is not runtime storage" true
+    (file_contains_pattern "Dockerfile"
+       "this is the image-baked config root, not");
+  check bool "production image declares runtime storage volume" true
+    (file_contains_pattern "Dockerfile" {|VOLUME ["/app/.masc"]|});
+  check bool "production image keeps runtime storage owned by appuser" true
+    (file_contains_pattern "Dockerfile"
+       {|chown -R appuser:appgroup /app/.masc|})
+
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
@@ -1451,6 +1465,8 @@ let () =
              test_keeper_sandbox_credential_volume_contracts;
            test_case "board flusher start retry contracts" `Quick
              test_board_flusher_start_retry_contracts;
+           test_case "docker config storage contracts" `Quick
+             test_docker_config_storage_contracts;
            test_case "dashboard warm hydration contracts" `Quick
              test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;


### PR DESCRIPTION
## Summary
- document the production Docker image split between `/app/config` as the image-baked config root and `/app/.masc` as mutable runtime storage
- declare `/app/.masc` as a Docker volume so JSONL/runtime state is not treated like immutable config
- add a source guard that pins the Docker config/storage contract

## Why
The Kimi/Docker validation follow-up found that the production image already had separate `MASC_BASE_PATH=/app` and `MASC_CONFIG_DIR=/app/config` paths, but the Dockerfile did not make the mutable runtime storage contract explicit. This keeps the operator-facing image contract aligned with the runtime path truth.

## Validation
- `git diff --check --cached`
- `env DUNE_JOBS=2 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/docker-config-storage-truth-0506 test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe` (43 tests run)

Note: `scripts/dune-local.sh build test/test_ci_hardening_source.exe` was attempted first but waited on `/tmp/me-dune-local.lock`; the same focused target was run directly with `DUNE_JOBS=2` to avoid blocking behind another worktree build.