### PR TITLE
feat(board): add canonical SSE event aliases

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -39,8 +39,62 @@ let autoboot_proactive_warmup_sec ~base_warmup ~stagger_window_sec ~keeper_name 
     base_warmup
     + (stable_keeper_name_hash keeper_name mod (stagger_window_sec + 1))
 
+let board_sse_event_params event =
+  match event with
+  | Board_dispatch.Post_created { post_id; author; title; content; post_kind; hearth } ->
+      let preview =
+        if String.length content > 200 then String.sub content 0 200
+        else content
+      in
+      let base = [("type", `String "post_created");
+                  ("event_type", `String "post.created");
+                  ("post_id", `String post_id);
+                  ("author", `String author);
+                  ("author_identity", Server_utils.board_actor_identity_json author);
+                  ("title", `String title);
+                  ("content", `String preview);
+                  ("post_kind", `String (Board.post_kind_to_string post_kind))] in
+      `Assoc (match hearth with
+              | Some h -> ("hearth", `String h) :: base
+              | None -> base)
+  | Board_dispatch.Comment_added { post_id; comment_id; author } ->
+      `Assoc [("type", `String "comment_added");
+              ("event_type", `String "comment.created");
+              ("post_id", `String post_id);
+              ("comment_id", `String comment_id);
+              ("author", `String author);
+              ("author_identity", Server_utils.board_actor_identity_json author)]
+  | Board_dispatch.Post_voted { post_id; voter; direction } ->
+      let dir = Board_votes.vote_direction_to_string direction in
+      `Assoc [("type", `String "post_voted");
+              ("event_type", `String "vote.changed");
+              ("target_type", `String "post");
+              ("post_id", `String post_id);
+              ("voter", `String voter);
+              ("voter_identity", Server_utils.board_actor_identity_json voter);
+              ("direction", `String dir)]
+  | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
+      let dir = Board_votes.vote_direction_to_string direction in
+      `Assoc [("type", `String "comment_voted");
+              ("event_type", `String "vote.changed");
+              ("target_type", `String "comment");
+              ("comment_id", `String comment_id);
+              ("voter", `String voter);
+              ("voter_identity", Server_utils.board_actor_identity_json voter);
+              ("direction", `String dir)]
+  | Board_dispatch.Reaction_changed { target_type; target_id; user_id; emoji; reacted } ->
+      `Assoc [("type", `String "reaction_changed");
+              ("event_type", `String "reaction.changed");
+              ("target_type", `String (Board.reaction_target_type_to_string target_type));
+              ("target_id", `String target_id);
+              ("user_id", `String user_id);
+              ("user_identity", Server_utils.board_actor_identity_json user_id);
+              ("emoji", `String emoji);
+              ("reacted", `Bool reacted)]
+
 module For_testing = struct
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
+  let board_sse_event_params = board_sse_event_params
 end
 
 let filteri_with_fair_yield f xs =
@@ -341,51 +395,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       ~config:state.room_config
       signal);
   Board_dispatch.set_board_sse_hook (fun event ->
-    let params = match event with
-      | Board_dispatch.Post_created { post_id; author; title; content; post_kind; hearth } ->
-          let preview =
-            if String.length content > 200 then String.sub content 0 200
-            else content
-          in
-          let base = [("type", `String "post_created");
-                      ("post_id", `String post_id);
-                      ("author", `String author);
-                      ("author_identity", Server_utils.board_actor_identity_json author);
-                      ("title", `String title);
-                      ("content", `String preview);
-                      ("post_kind", `String (Board.post_kind_to_string post_kind))] in
-          `Assoc (match hearth with
-                  | Some h -> ("hearth", `String h) :: base
-                  | None -> base)
-      | Board_dispatch.Comment_added { post_id; comment_id; author } ->
-          `Assoc [("type", `String "comment_added");
-                  ("post_id", `String post_id);
-                  ("comment_id", `String comment_id);
-                  ("author", `String author);
-                  ("author_identity", Server_utils.board_actor_identity_json author)]
-      | Board_dispatch.Post_voted { post_id; voter; direction } ->
-          let dir = Board_votes.vote_direction_to_string direction in
-          `Assoc [("type", `String "post_voted");
-                  ("post_id", `String post_id);
-                  ("voter", `String voter);
-                  ("voter_identity", Server_utils.board_actor_identity_json voter);
-                  ("direction", `String dir)]
-      | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
-          let dir = Board_votes.vote_direction_to_string direction in
-          `Assoc [("type", `String "comment_voted");
-                  ("comment_id", `String comment_id);
-                  ("voter", `String voter);
-                  ("voter_identity", Server_utils.board_actor_identity_json voter);
-                  ("direction", `String dir)]
-      | Board_dispatch.Reaction_changed { target_type; target_id; user_id; emoji; reacted } ->
-          `Assoc [("type", `String "reaction_changed");
-                  ("target_type", `String (Board.reaction_target_type_to_string target_type));
-                  ("target_id", `String target_id);
-                  ("user_id", `String user_id);
-                  ("user_identity", Server_utils.board_actor_identity_json user_id);
-                  ("emoji", `String emoji);
-                  ("reacted", `Bool reacted)]
-    in
+    let params = board_sse_event_params event in
     Sse.broadcast (`Assoc [
       ("jsonrpc", `String "2.0");
       ("method", `String "notifications/board");

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -27,6 +27,8 @@ val start_keeper_loops :
 module For_testing : sig
   val autoboot_proactive_warmup_sec :
     base_warmup:int -> stagger_window_sec:int -> keeper_name:string -> int
+
+  val board_sse_event_params : Board_dispatch.board_sse_event -> Yojson.Safe.t
 end
 
 val start_background_maintenance :

--- a/test/dune
+++ b/test/dune
@@ -1028,6 +1028,7 @@
 (include stanzas/test_auth_token_uniqueness_audit.inc)
 (include stanzas/test_base_path_prod_guard.inc)
 (include stanzas/test_board_api_e2e.inc)
+(include stanzas/test_board_sse_canonical_event_type.inc)
 (include stanzas/test_briefing_compactors.inc)
 (include stanzas/test_briefing_gaps.inc)
 (include stanzas/test_briefing_json_helpers.inc)

--- a/test/stanzas/test_board_sse_canonical_event_type.inc
+++ b/test/stanzas/test_board_sse_canonical_event_type.inc
@@ -1,0 +1,6 @@
+; Board SSE canonical dotted event aliases
+
+(test
+ (name test_board_sse_canonical_event_type)
+ (modules test_board_sse_canonical_event_type)
+ (libraries masc_test_deps))

--- a/test/test_board_sse_canonical_event_type.ml
+++ b/test/test_board_sse_canonical_event_type.ml
@@ -1,0 +1,73 @@
+open Masc_mcp
+
+module Boot = Server_bootstrap_loops.For_testing
+module U = Yojson.Safe.Util
+
+let string_field name json = json |> U.member name |> U.to_string
+
+let check_event_type label expected event =
+  let json = Boot.board_sse_event_params event in
+  Alcotest.(check string) (label ^ " legacy type is preserved") label
+    (string_field "type" json);
+  Alcotest.(check string) (label ^ " canonical event_type") expected
+    (string_field "event_type" json)
+
+let test_post_created_alias () =
+  check_event_type "post_created" "post.created"
+    (Board_dispatch.Post_created
+       {
+         post_id = "post-1";
+         author = "writer";
+         title = "Title";
+         content = "Body";
+         post_kind = Board.Human_post;
+         hearth = None;
+       })
+
+let test_comment_created_alias () =
+  check_event_type "comment_added" "comment.created"
+    (Board_dispatch.Comment_added
+       { post_id = "post-1"; comment_id = "comment-1"; author = "reader" })
+
+let test_vote_changed_aliases () =
+  let post_vote =
+    Boot.board_sse_event_params
+      (Board_dispatch.Post_voted
+         { post_id = "post-1"; voter = "reader"; direction = Board.Up })
+  in
+  Alcotest.(check string) "post vote canonical event_type" "vote.changed"
+    (string_field "event_type" post_vote);
+  Alcotest.(check string) "post vote target_type" "post"
+    (string_field "target_type" post_vote);
+  let comment_vote =
+    Boot.board_sse_event_params
+      (Board_dispatch.Comment_voted
+         { comment_id = "comment-1"; voter = "reader"; direction = Board.Down })
+  in
+  Alcotest.(check string) "comment vote canonical event_type" "vote.changed"
+    (string_field "event_type" comment_vote);
+  Alcotest.(check string) "comment vote target_type" "comment"
+    (string_field "target_type" comment_vote)
+
+let test_reaction_changed_alias () =
+  check_event_type "reaction_changed" "reaction.changed"
+    (Board_dispatch.Reaction_changed
+       {
+         target_type = Board.Reaction_post;
+         target_id = "post-1";
+         user_id = "reader";
+         emoji = "👍";
+         reacted = true;
+       })
+
+let () =
+  Alcotest.run "board_sse_canonical_event_type"
+    [
+      ( "canonical aliases",
+        [
+          Alcotest.test_case "post.created" `Quick test_post_created_alias;
+          Alcotest.test_case "comment.created" `Quick test_comment_created_alias;
+          Alcotest.test_case "vote.changed" `Quick test_vote_changed_aliases;
+          Alcotest.test_case "reaction.changed" `Quick test_reaction_changed_alias;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add canonical dotted board event_type values to board SSE payloads while preserving legacy underscore type values
- cover post.created, comment.created, vote.changed, and reaction.changed aliases
- expose the payload formatter through For_testing and pin the wire shape with a focused OCaml test

## Artifact tie-in
- Advances Phase 1 realtime event naming from /Users/dancer/Downloads/masc_sns.agent.final without breaking existing dashboard refresh routing.

## Validation
- env DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_board_sse_canonical_event_type.exe
- ./_build/default/test/test_board_sse_canonical_event_type.exe
- git diff --check