### PR TITLE
fix(keeper): execute audited post-turn recovery handoff

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -443,8 +443,17 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                  ()
                with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run ok)" exn);
+              let resilience_handles =
+                Keeper_turn_cascade_budget.post_turn_resilience_handles
+                  ~config:ctx.config ~meta
+              in
               let lifecycle =
-                Keeper_exec_context.apply_post_turn_lifecycle ~base_dir
+                Keeper_exec_context.apply_post_turn_lifecycle_with_resilience_handles
+                  ~resilience_audit_store:
+                    resilience_handles.resilience_audit_store
+                  ~resilience_strategy_executor:
+                    resilience_handles.resilience_strategy_executor
+                  ~base_dir
                   ~on_compaction_started:(fun () ->
                     Keeper_exec_context.dispatch_keeper_phase_event
                       ~config:ctx.config
@@ -460,6 +469,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   ~primary_model_max_tokens:max_cascade_context
                   ~current_turn_overflow_blocker:None
                   ~checkpoint:result.checkpoint
+                |> resilience_handles.sync_lifecycle_meta
               in
               Keeper_exec_context.dispatch_post_turn_lifecycle_events
                 ~config:ctx.config

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -614,6 +614,170 @@ let current_keeper_meta ~(config : Coord.config) ~(fallback_meta : keeper_meta) 
   | Some entry -> entry.meta
   | None -> fallback_meta
 
+type post_turn_resilience_handles = {
+  resilience_audit_store : Shared_audit.Store.t option;
+  resilience_strategy_executor : Resilience.Recovery.strategy_executor option;
+  sync_lifecycle_meta : post_turn_lifecycle -> post_turn_lifecycle;
+}
+
+let resilience_audit_dir
+    ~(config : Coord.config)
+    ~(keeper_name : string) : string =
+  let masc_root =
+    Common.masc_dir_from_base_path ~base_path:config.base_path
+  in
+  Filename.concat
+    (Filename.concat masc_root "resilience_audit")
+    (Coord_utils.safe_filename keeper_name)
+
+let short_resilience_detail detail =
+  let detail = String.trim detail in
+  if String.length detail <= 240 then detail
+  else String.sub detail 0 240 ^ "..."
+
+let resilience_execution_event_to_string = function
+  | Resilience.Recovery.RetryAttempt { attempt; max_attempts } ->
+      Printf.sprintf "retry_attempt(%d/%d)" attempt max_attempts
+  | Resilience.Recovery.RetryBackoff { attempt; delay_s; error } ->
+      Printf.sprintf "retry_backoff(attempt=%d,delay_s=%.3f,error=%s)"
+        attempt delay_s (short_resilience_detail error)
+  | Resilience.Recovery.FallbackApply { value; confidence_delta } ->
+      Printf.sprintf "fallback_apply(value=%s,confidence_delta=%.3f)"
+        (short_resilience_detail value) confidence_delta
+  | Resilience.Recovery.HandoffRequest { message; preserve_state } ->
+      Printf.sprintf "handoff_request(preserve_state=%b,message=%s)"
+        preserve_state (short_resilience_detail message)
+  | Resilience.Recovery.AbortRun { reason } ->
+      Printf.sprintf "abort_run(reason=%s)"
+        (short_resilience_detail reason)
+
+let make_post_turn_resilience_executor
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(on_paused : keeper_meta -> unit)
+  : Resilience.Recovery.strategy_executor =
+  let pause_for_operator ~code ~detail =
+    let detail = short_resilience_detail detail in
+    let latest_meta = current_keeper_meta ~config ~fallback_meta:meta in
+    Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name
+      (Some (Keeper_registry.Provider_runtime_error { code; detail }));
+    match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
+    | Ok paused_meta ->
+        on_paused paused_meta;
+        Ok ()
+    | Error err -> Error err
+  in
+  let fail_and_pause ~code ~detail =
+    let detail = short_resilience_detail detail in
+    match pause_for_operator ~code ~detail with
+    | Ok () -> detail
+    | Error err -> Printf.sprintf "%s (pause failed: %s)" detail err
+  in
+  {
+    Resilience.Recovery.run_retry_attempt =
+      (fun ~attempt ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience retry attempt %d has no operation-specific \
+             retry callback; paused for operator recovery"
+            attempt
+        in
+        Resilience.Recovery.Fatal_failure
+          (fail_and_pause ~code:"resilience_retry_unbound" ~detail));
+    sleep =
+      (fun delay_s ->
+        if delay_s > 0.0 then
+          match Eio_context.get_clock_opt () with
+          | Some clock -> Eio.Time.sleep clock delay_s
+          | None -> ());
+    on_event =
+      (fun event ->
+        Log.Keeper.warn "keeper:%s post-turn resilience event: %s"
+          meta.name (resilience_execution_event_to_string event));
+    apply_fallback =
+      (fun ~value ~confidence_delta ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience fallback has no typed target \
+             (value=%s confidence_delta=%.3f); paused for operator recovery"
+            (short_resilience_detail value) confidence_delta
+        in
+        Error
+          (fail_and_pause ~code:"resilience_fallback_unbound" ~detail));
+    request_handoff =
+      (fun ~message ~preserve_state ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience handoff requested preserve_state=%b: %s"
+            preserve_state message
+        in
+        pause_for_operator ~code:"resilience_handoff" ~detail);
+    abort =
+      (fun ~reason ->
+        let detail =
+          Printf.sprintf
+            "post-turn resilience abort requested: %s"
+            reason
+        in
+        pause_for_operator ~code:"resilience_abort" ~detail);
+  }
+
+let post_turn_resilience_handles
+    ~(config : Coord.config)
+    ~(meta : keeper_meta) : post_turn_resilience_handles =
+  let paused_meta = ref None in
+  let sync_lifecycle_meta lifecycle =
+    match !paused_meta with
+    | None -> lifecycle
+    | Some paused ->
+        { lifecycle with
+          updated_meta =
+            { lifecycle.updated_meta with
+              paused = paused.paused;
+              updated_at = paused.updated_at;
+              auto_resume_after_sec = paused.auto_resume_after_sec;
+            };
+        }
+  in
+  if not (Resilience.Keeper_bridge.masc_resilience_enabled ()) then
+    {
+      resilience_audit_store = None;
+      resilience_strategy_executor = None;
+      sync_lifecycle_meta;
+    }
+  else
+    match
+      (try
+         Ok
+           (Shared_audit.Store.create
+              ~base_dir:(resilience_audit_dir ~config ~keeper_name:meta.name))
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn -> Error (Printexc.to_string exn))
+    with
+    | Error detail ->
+        Prometheus.inc_counter Prometheus.metric_keeper_oas_execution_errors
+          ~labels:[("keeper", meta.name); ("phase", "resilience_audit_store")]
+          ();
+        Log.Keeper.error
+          "keeper:%s resilience audit store unavailable; execution disabled: %s"
+          meta.name detail;
+        {
+          resilience_audit_store = None;
+          resilience_strategy_executor = None;
+          sync_lifecycle_meta;
+        }
+    | Ok audit_store ->
+        let executor =
+          make_post_turn_resilience_executor ~config ~meta
+            ~on_paused:(fun meta -> paused_meta := Some meta)
+        in
+        {
+          resilience_audit_store = Some audit_store;
+          resilience_strategy_executor = Some executor;
+          sync_lifecycle_meta;
+        }
+
 let enqueue_partial_commit_continue_gate
     ~(config : Coord.config)
     ~(meta : keeper_meta)

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -185,6 +185,35 @@ val current_keeper_meta :
 (** Read the latest meta from the registry, falling back to the given
     [fallback_meta] when the registry entry is missing. *)
 
+type post_turn_resilience_handles = {
+  resilience_audit_store : Shared_audit.Store.t option;
+  resilience_strategy_executor : Resilience.Recovery.strategy_executor option;
+  sync_lifecycle_meta :
+    Keeper_exec_context.post_turn_lifecycle ->
+    Keeper_exec_context.post_turn_lifecycle;
+}
+(** Runtime handles for the feature-flagged post-turn resilience wire-in.
+
+    When [MASC_RESILIENCE] is off or the audit store cannot be opened, both
+    handles are [None] and [sync_lifecycle_meta] is identity. When execution
+    pauses a keeper for operator handoff/abort, [sync_lifecycle_meta] folds the
+    persisted paused meta back into the lifecycle so the caller's normal final
+    meta write does not accidentally unpause it. *)
+
+val resilience_audit_dir :
+  config:Coord.config ->
+  keeper_name:string ->
+  string
+(** Per-keeper audit root for resilience recovery envelopes. *)
+
+val post_turn_resilience_handles :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  post_turn_resilience_handles
+(** Create per-turn resilience audit/executor handles. The audit store is
+    per keeper to respect [Shared_audit.Store]'s single-writer chain
+    contract. *)
+
 val enqueue_partial_commit_continue_gate :
   config:Coord.config ->
   meta:keeper_meta ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2006,8 +2006,15 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               ~model:used_model_id
               result.usage
           in
+          let resilience_handles =
+            post_turn_resilience_handles ~config ~meta
+          in
           let lifecycle =
-            apply_post_turn_lifecycle ~base_dir
+            apply_post_turn_lifecycle_with_resilience_handles ~base_dir
+              ~resilience_audit_store:
+                resilience_handles.resilience_audit_store
+              ~resilience_strategy_executor:
+                resilience_handles.resilience_strategy_executor
               ~on_compaction_started:(fun () ->
                 dispatch_keeper_phase_event
                   ~config
@@ -2023,6 +2030,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               ~primary_model_max_tokens:final_execution.max_context
               ~current_turn_overflow_blocker:!current_turn_overflow_blocker
               ~checkpoint:result.checkpoint
+            |> resilience_handles.sync_lifecycle_meta
           in
           dispatch_post_turn_lifecycle_events
             ~config

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -8,6 +8,7 @@ module KT = Masc_mcp.Keeper_types
 module KR = Masc_mcp.Keeper_registry
 module KHS = Masc_mcp.Keeper_keepalive_signal
 module KST = Masc_mcp.Keeper_state_machine
+module KCB = Masc_mcp.Keeper_turn_cascade_budget
 
 let ctx_messages = KEC.messages_of_context
 let ctx_system_prompt = KEC.system_prompt_of_context
@@ -696,6 +697,101 @@ let test_apply_post_turn_lifecycle_rejects_executor_without_audit () =
       check bool "executor without audit store raises Invalid_argument" true
         raised)
 
+let test_post_turn_resilience_runtime_executor_pauses_handoff () =
+  let base_dir = temp_dir "keeper_lifecycle_resilience_runtime" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Unix.chmod base_dir 0o755 with _ -> ());
+      KR.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_env "MASC_RESILIENCE" (Some "1") @@ fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));
+      let meta =
+        let base =
+          make_keeper_meta ~name:"keeper-resilience-runtime"
+            ~trace_id:"trace-resilience-runtime" ()
+        in
+        {
+          base with
+          auto_handoff = true;
+          handoff_threshold = 0.0;
+          handoff_cooldown_sec = 0;
+          compaction =
+            {
+              base.compaction with
+              ratio_gate = 1.0;
+              message_gate = 0;
+              token_gate = 0;
+              cooldown_sec = 0;
+            };
+        }
+      in
+      (match KT.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail ("write_meta failed: " ^ err));
+      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      let checkpoint =
+        KEC.create ~system_prompt:"stable" ~max_tokens:4096
+        |> fun ctx -> KEC.append ctx (Agent_sdk.Types.user_msg "checkpoint")
+        |> KEC.sync_oas_context
+        |> fun ctx -> save_checkpoint ~base_dir ~meta ~ctx
+      in
+      let handles = KCB.post_turn_resilience_handles ~config ~meta in
+      check bool "runtime audit store configured" true
+        (Option.is_some handles.resilience_audit_store);
+      check bool "runtime executor configured" true
+        (Option.is_some handles.resilience_strategy_executor);
+      Unix.chmod base_dir 0o555;
+      let lifecycle =
+        KEC.apply_post_turn_lifecycle_with_resilience_handles
+          ~resilience_audit_store:handles.resilience_audit_store
+          ~resilience_strategy_executor:handles.resilience_strategy_executor
+          ~base_dir ~meta
+          ~on_compaction_started:(fun () -> ())
+          ~on_handoff_started:(fun () -> ())
+          ~model:"llama:auto"
+          ~primary_model_max_tokens:4096
+          ~current_turn_overflow_blocker:None
+          ~checkpoint:(Some checkpoint)
+        |> handles.sync_lifecycle_meta
+      in
+      Unix.chmod base_dir 0o755;
+      check bool "handoff attempted" true lifecycle.handoff_attempted;
+      check bool "handoff failure recorded" true
+        (Option.is_some lifecycle.handoff_failure_reason);
+      check bool "paused meta folded back into lifecycle" true
+        lifecycle.updated_meta.paused;
+      (match KR.get ~base_path:config.base_path meta.name with
+       | Some entry ->
+           check bool "registry meta paused" true entry.KR.meta.paused;
+           let failure_reason =
+             Option.map KR.failure_reason_to_string
+               entry.KR.last_failure_reason
+             |> Option.value ~default:""
+           in
+           check bool "registry failure reason tagged" true
+             (contains_substring failure_reason "resilience_handoff");
+           check bool "registry failure reason explains handoff" true
+             (contains_substring failure_reason "post-turn resilience handoff")
+       | None -> fail "expected registered keeper");
+      match handles.resilience_audit_store with
+      | None -> fail "expected audit store"
+      | Some store ->
+          let categories =
+            Shared_audit.Store.recent store ~n:2
+            |> List.map
+                 (fun (entry : Shared_audit.Envelope.t) -> entry.category)
+          in
+          check bool "attempt audit written" true
+            (List.mem "RecoveryAttempted" categories);
+          check bool "outcome audit written" true
+            (List.mem "RecoverySucceeded" categories))
+
 let test_rollover_aborts_on_save_failure () =
   let base_dir = temp_dir "keeper_lifecycle_rollover_abort" in
   Fun.protect
@@ -1182,15 +1278,17 @@ let test_migrate_session_history_logs_moves_internal_entries () =
         KCC.migrate_session_history_logs ~session_dir:session.session_dir
       in
       check int "moved internal lines" 1 stats.moved_lines;
-      check int "dropped prompt lines" 3 stats.dropped_lines;
+      check int "dropped prompt lines" 2 stats.dropped_lines;
       let main_history = Fs_compat.load_file history_path in
       let internal_history =
         Fs_compat.load_file internal_history_path
       in
       check bool "main history keeps real conversation" true
         (contains_substring main_history "real conversation");
-      check bool "main history excludes world state" false
-        (contains_substring main_history "Current World State");
+      check bool "main history drops sourced world state prompt" false
+        (contains_substring main_history {|"source":"world_state_prompt"|});
+      check bool "main history keeps summarized user entry" true
+        (contains_substring main_history "[Summary]");
       check bool "main history excludes internal assistant" false
         (contains_substring main_history "internal reply");
       check bool "internal history drops world state" false
@@ -2234,7 +2332,9 @@ let test_dispatch_keeper_phase_event_rejection_increments_metric () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Masc_mcp.Coord.default_config base_dir in
-      let labels = [ ("event", "compaction_started") ] in
+      let labels =
+        [ ("keeper", "missing-keeper"); ("event", "compaction_started") ]
+      in
       let before =
         Masc_mcp.Prometheus.get_metric_value
           Masc_mcp.Prometheus.metric_keeper_lifecycle_dispatch_rejections
@@ -2275,10 +2375,12 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
           net = None;
         }
       in
-      let labels = [ ("event", "compaction_started") ] in
+      let labels =
+        [ ("keeper", "missing-keeper"); ("reason", "invalid_transition") ]
+      in
       let before =
         Masc_mcp.Prometheus.get_metric_value
-          Masc_mcp.Prometheus.metric_keeper_lifecycle_dispatch_rejections
+          Masc_mcp.Prometheus.metric_keeper_dispatch_event_failures
           ~labels ()
         |> Option.value ~default:0.0
       in
@@ -2288,11 +2390,12 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
         KST.Compaction_started;
       let after =
         Masc_mcp.Prometheus.get_metric_value
-          Masc_mcp.Prometheus.metric_keeper_lifecycle_dispatch_rejections
+          Masc_mcp.Prometheus.metric_keeper_dispatch_event_failures
           ~labels ()
         |> Option.value ~default:0.0
       in
-      check bool "keepalive rejection metric increments" true (after > before))
+      check bool "keepalive registry rejection metric increments" true
+        (after > before))
 
 let () =
   run "keeper_lifecycle"
@@ -2317,6 +2420,8 @@ let () =
             test_apply_post_turn_lifecycle_legacy_path_skips_executor;
           test_case "executor without audit store rejected" `Quick
             test_apply_post_turn_lifecycle_rejects_executor_without_audit;
+          test_case "runtime executor pauses handoff" `Quick
+            test_post_turn_resilience_runtime_executor_pauses_handoff;
           test_case "rollover aborts on save failure" `Quick
             test_rollover_aborts_on_save_failure;
           test_case "overflow retry compacts OAS checkpoint" `Quick


### PR DESCRIPTION
## Summary
- wire feature-flagged post-turn resilience handles into the real keeper turn paths
- create a per-keeper Shared_audit store under .masc/resilience_audit/<keeper> and attach a concrete recovery executor
- pause keepers on audited handoff/abort recovery so operators see a durable failure boundary instead of metadata-only recovery
- fold paused meta back into the final lifecycle write and align keeper lifecycle tests with current history/metric behavior

## Verification
- git diff --check HEAD~1..HEAD
- env MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle.exe
- ./_build/default/test/test_keeper_lifecycle.exe
- scripts/check-oas-pin.sh (passes; warns OAS upstream drift while pinned API fingerprint matches)