### PR TITLE
fix(server): surface storage fallback reason

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -59,6 +59,22 @@ let () =
 let requested_backend_mode () =
   Env_config_core.storage_type ()
 
+let storage_enforcement_fallback_reason ~requested ~effective =
+  let requested = requested |> String.trim |> String.lowercase_ascii in
+  let effective = effective |> String.trim |> String.lowercase_ascii in
+  if requested = "" || String.equal requested effective then
+    None
+  else
+    Some
+      (Printf.sprintf
+         "MASC_STORAGE_TYPE=%s requested; filesystem-only bootstrap enforced as %s"
+         requested effective)
+
+let note_storage_enforcement_fallback ~requested ~effective =
+  match storage_enforcement_fallback_reason ~requested ~effective with
+  | Some reason -> Server_startup_state.note_fallback reason
+  | None -> ()
+
 let ensure_default_oas_cascade_timeout_env () =
   match Sys.getenv_opt "OAS_CASCADE_MODEL_TIMEOUT_SEC" |> Env_config_core.trim_opt with
   | Some _ -> ()
@@ -1428,10 +1444,14 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     | Env_config.Transport.Unknown_h2_mode _ -> `Auto
   in
   let socket = Server_bootstrap_http.listen_socket ~sw ~net config in
+  let requested_backend_mode_before_enforcement = requested_backend_mode () in
   force_jsonl_fallback_env ();
   let initial_backend_mode = requested_backend_mode () in
   server_state := None;
   Server_startup_state.reset ~backend_mode:initial_backend_mode ();
+  note_storage_enforcement_fallback
+    ~requested:requested_backend_mode_before_enforcement
+    ~effective:initial_backend_mode;
 
   (* 2. All init in background fiber — protected so failures don't kill HTTP *)
   Eio.Fiber.fork ~sw (fun () ->

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -8,6 +8,10 @@
 
 val force_jsonl_fallback_env : unit -> unit
 val requested_backend_mode : unit -> string
+val storage_enforcement_fallback_reason :
+  requested:string -> effective:string -> string option
+val note_storage_enforcement_fallback :
+  requested:string -> effective:string -> unit
 val ensure_default_oas_cascade_timeout_env : unit -> unit
 val config_bootstrap_mode : unit -> [> `Auto | `Empty | `Skip ]
 val bootstrap_base_path_config_root : base_path:string -> unit

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -497,6 +497,26 @@ let test_force_jsonl_fallback_env () =
   Alcotest.(check string) "storage type forced to filesystem" "filesystem"
     (Sys.getenv "MASC_STORAGE_TYPE")
 
+let test_storage_enforcement_fallback_reason () =
+  Alcotest.(check (option string))
+    "filesystem request needs no fallback reason" None
+    (Server_runtime_bootstrap.storage_enforcement_fallback_reason
+       ~requested:"filesystem" ~effective:"filesystem");
+  Alcotest.(check (option string))
+    "memory request records filesystem enforcement"
+    (Some
+       "MASC_STORAGE_TYPE=memory requested; filesystem-only bootstrap enforced as filesystem")
+    (Server_runtime_bootstrap.storage_enforcement_fallback_reason
+       ~requested:"memory" ~effective:"filesystem");
+  Server_startup_state.reset ~backend_mode:"filesystem" ();
+  Server_runtime_bootstrap.note_storage_enforcement_fallback
+    ~requested:"memory" ~effective:"filesystem";
+  let json = Server_startup_state.to_yojson () in
+  Alcotest.(check string)
+    "startup fallback reason is operator visible"
+    "MASC_STORAGE_TYPE=memory requested; filesystem-only bootstrap enforced as filesystem"
+    (Yojson.Safe.Util.(json |> member "fallback_reason" |> to_string))
+
 let test_default_oas_cascade_timeout_tracks_keeper_timeout () =
   with_env "OAS_CASCADE_MODEL_TIMEOUT_SEC" None @@ fun () ->
   with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" (Some "300") @@ fun () ->
@@ -2272,6 +2292,9 @@ let () =
         [
           Alcotest.test_case "force_jsonl_fallback_env forces filesystem" `Quick
             test_force_jsonl_fallback_env;
+          Alcotest.test_case
+            "storage enforcement fallback reason is visible"
+            `Quick test_storage_enforcement_fallback_reason;
           Alcotest.test_case
             "default OAS cascade timeout tracks keeper timeout"
             `Quick test_default_oas_cascade_timeout_tracks_keeper_timeout;


### PR DESCRIPTION
## Summary
- capture the requested storage backend before server startup forces filesystem mode
- record a startup `fallback_reason` when a non-filesystem `MASC_STORAGE_TYPE` request is overridden
- add a focused regression that proves the fallback reason is rendered in startup JSON

## Why
`force_jsonl_fallback_env()` intentionally enforces filesystem storage, but the startup state only showed the effective backend. Operators could not tell that `MASC_STORAGE_TYPE=memory` or another retired backend request had been overridden. This keeps the filesystem-only bootstrap behavior while making the fallback visible.

## Validation
- `git diff --check`
- `env DUNE_JOBS=2 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/runtime-storage-fallback-reason-0506 test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 1`

Note: `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe` was attempted first but waited on `/tmp/me-dune-local.lock`. The full `test_server_runtime_bootstrap.exe` run also reached the new case successfully, then stalled in later integration cases; the targeted Alcotest case was rerun directly and passed.