### PR TITLE
fix: derive keeper FSM TLA symbol surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # masc-mcp
 
 [![OCaml](https://img.shields.io/badge/OCaml-5.4+-orange.svg)](https://ocaml.org/)
-[![OAS](https://img.shields.io/badge/agent__sdk-%E2%89%A50.187.6-blue.svg)](https://github.com/jeong-sik/oas)
+[![OAS](https://img.shields.io/badge/agent__sdk-%E2%89%A50.190.12-blue.svg)](https://github.com/jeong-sik/oas)
 
 > Personal project. No production SLA, no external support, no compatibility guarantees. The API surface, schema, and dashboard change on the author's schedule.
 >
@@ -75,7 +75,7 @@ All protocols run concurrently from a single Eio fiber pool:
 ### Tech Stack
 
 - **OCaml 5.4+** with Eio structured concurrency (no Lwt)
-- **agent_sdk** >= 0.187.6 (OAS agent runtime; pinned floor in `dune-project`)
+- **agent_sdk** >= 0.190.12 (OAS agent runtime; pinned floor in `dune-project`)
 - **mcp_protocol** >= 1.3.0 (MCP JSON-RPC contract)
 - **h2-eio** (HTTP/2), **grpc-direct** (gRPC), **ocaml-webrtc** (WebRTC)
 - **caqti** + PostgreSQL (optional), **sqlite3** (fallback), **neo4j_bolt** (optional graph)

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -34,47 +34,43 @@ type _ turn_state =
   | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
   | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
 
-let to_tla_symbol : type a. a turn_state -> string = function
-  | Idle -> "idle"
-  | Phase_gating -> "phase_gating"
-  | Cascade_routing -> "cascade_routing"
-  | Awaiting_provider -> "awaiting_provider"
-  | Streaming -> "streaming"
-  | Awaiting_tool_result -> "awaiting_tool"
-  | Completing -> "completing"
-  | Done -> "done"
-  | Failed _ -> "failed"
-  | Cancelled _ -> "cancelled"
+module Tla_symbol = struct
+  type t =
+    | Idle [@tla.idle]
+    | Phase_gating [@tla.active]
+    | Cascade_routing [@tla.active]
+    | Awaiting_provider [@tla.active]
+    | Streaming [@tla.active]
+    | Awaiting_tool_result [@tla.symbol "awaiting_tool"] [@tla.active]
+    | Completing [@tla.active]
+    | Done [@tla.terminal]
+    | Failed of failure_reason [@tla.terminal]
+    | Cancelled of cancel_reason [@tla.terminal]
+  [@@deriving tla]
+end
 
-let all_symbols = [
-  "idle"; "phase_gating"; "cascade_routing"; "awaiting_provider";
-  "streaming"; "awaiting_tool"; "completing"; "done"; "failed"; "cancelled"
-]
+let tla_symbol_variant : type a. a turn_state -> Tla_symbol.t = function
+  | Idle -> Tla_symbol.Idle
+  | Phase_gating -> Tla_symbol.Phase_gating
+  | Cascade_routing -> Tla_symbol.Cascade_routing
+  | Awaiting_provider -> Tla_symbol.Awaiting_provider
+  | Streaming -> Tla_symbol.Streaming
+  | Awaiting_tool_result -> Tla_symbol.Awaiting_tool_result
+  | Completing -> Tla_symbol.Completing
+  | Done -> Tla_symbol.Done
+  | Failed reason -> Tla_symbol.Failed reason
+  | Cancelled reason -> Tla_symbol.Cancelled reason
 
-let active_symbols = [
-  "phase_gating"; "cascade_routing"; "awaiting_provider";
-  "streaming"; "awaiting_tool"; "completing"
-]
+let to_tla_symbol state = Tla_symbol.to_tla_symbol (tla_symbol_variant state)
 
-let terminal_symbols = [
-  "done"; "failed"; "cancelled"
-]
+let all_symbols = Tla_symbol.all_symbols
+let active_symbols = Tla_symbol.active_symbols
+let terminal_symbols = Tla_symbol.terminal_symbols
+let idle_symbols = Tla_symbol.idle_symbols
 
-let idle_symbols = [ "idle" ]
-
-let is_active : type a. a turn_state -> bool = function
-  | Phase_gating | Cascade_routing | Awaiting_provider | Streaming | Awaiting_tool_result | Completing -> true
-  | _ -> false
-
-let is_terminal : type a. a turn_state -> bool = function
-  | Done | Failed _ | Cancelled _ -> true
-  | _ -> false
-
-let is_idle : type a. a turn_state -> bool = function
-  | Idle -> true
-  | _ -> false
-
-
+let is_active state = Tla_symbol.is_active (tla_symbol_variant state)
+let is_terminal state = Tla_symbol.is_terminal (tla_symbol_variant state)
+let is_idle state = Tla_symbol.is_idle (tla_symbol_variant state)
 
 let cancel_reason_label = function
   | Cancelled_supervisor_stop -> "supervisor_stop"
@@ -120,8 +116,6 @@ let pp_failure_reason fmt = function
       Format.fprintf fmt "runtime_error(%s)" msg
   | Failure_unexpected_exception { exn; _ } ->
       Format.fprintf fmt "unexpected_exception(%s)" exn
-
-let to_tla_symbol = turn_state_label
 
 let pp_turn_state fmt (s : _ turn_state) =
   Format.pp_print_string fmt (turn_state_label s)

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -56,13 +56,13 @@ type _ turn_state =
   | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
   | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
 
-(** TLA+ symbol mapping derived by [ppx_tla].
+(** TLA+ symbol mapping backed by a private [ppx_tla]-derived symbol enum.
 
-    [to_tla_symbol] / [all_symbols] match [TurnStateSet], while
-    [active_symbols] / [terminal_symbols] and the generated
-    [is_active] / [is_terminal] predicates match [ActiveStateSet] and
-    [TerminalStateSet] in [specs/keeper-turn-fsm/KeeperTurnFSM.tla]
-    (verified by [test_keeper_turn_fsm_tla_parity]).
+    [to_tla_symbol] / [all_symbols] match [TurnStateSet]. The public
+    [active_symbols] / [terminal_symbols] / [is_active] / [is_terminal]
+    wrappers match [ActiveStateSet] and [TerminalStateSet] in
+    [specs/keeper-turn-fsm/KeeperTurnFSM.tla] (verified by
+    [test_keeper_turn_fsm_tla_parity]).
 
     [@tla.symbol "awaiting_tool"] on [Awaiting_tool_result] covers the
     OCaml-vs-TLA+ naming difference without renaming either side. *)


### PR DESCRIPTION
## Summary

- Back `Keeper_turn_fsm` TLA symbol/classification helpers with a private `[@@deriving tla]` enum while preserving the typed GADT turn-state API.
- Keep `to_tla_symbol` as the bare TLA symbol surface and keep payload-rich operator text on `turn_state_label`.
- Align the README `agent_sdk` floor with `dune-project` / generated opam (`0.190.12`).

## Why

The Kimi AST/PPX audit pointed at the keeper FSM contract as the load-bearing sync point between OCaml and `KeeperTurnFSM.tla`. Current `main` had a real drift risk: `to_tla_symbol` was re-bound to `turn_state_label`, so payload-bearing terminal states could render as labels such as `failed:runtime_error` instead of the TLA symbols `failed` / `cancelled`.

## Validation

- `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_keeper_turn_fsm_tla_parity.exe`
- `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_keeper_receipt_outcome_tla_parity.exe`
- `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_keeper_turn_fsm_emit.exe`
- `git diff --check`

## Review Focus

- `Tla_symbol` should remain a private derived symbol enum; runtime/operator display should continue using `turn_state_label`.
- The public `to_tla_symbol` contract should stay aligned with `TurnStateSet`, not the richer metric/log labels.
