### PR TITLE
feat(ide): RFC-0028 PR-α — keeper-trace-store (4-source join + coalescing + retention)

### DIFF
--- a/dashboard/src/components/ide/keeper-trace-store.test.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  COALESCE_WINDOW_MS,
+  RETENTION_MS,
+  clearTraces,
+  keeperTraceState,
+  pushTrace,
+  tracesByKeeper,
+  tracesBySource,
+} from './keeper-trace-store'
+
+beforeEach(() => {
+  clearTraces()
+})
+
+afterEach(() => {
+  clearTraces()
+})
+
+describe('keeper-trace-store', () => {
+  it('starts empty', () => {
+    expect(keeperTraceState.value.events).toHaveLength(0)
+  })
+
+  it('appends a single event with count=1', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-1',
+      line: 12,
+    })
+    expect(keeperTraceState.value.events).toHaveLength(1)
+    expect(keeperTraceState.value.events[0]).toMatchObject({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      count: 1,
+    })
+  })
+
+  it('coalesces two events of the same (source, keeperName) within COALESCE_WINDOW_MS', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1000 + COALESCE_WINDOW_MS,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-2',
+      provider: 'glm',
+    })
+    expect(keeperTraceState.value.events).toHaveLength(1)
+    const merged = keeperTraceState.value.events[0]!
+    expect(merged.count).toBe(2)
+    // Coalesced entry preserves the original id (first event), updates tsMs.
+    expect(merged.id).toBe('a-1')
+    expect(merged.tsMs).toBe(1000 + COALESCE_WINDOW_MS)
+  })
+
+  it('does NOT coalesce when the gap exceeds COALESCE_WINDOW_MS', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1000 + COALESCE_WINDOW_MS + 1,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-2',
+      provider: 'glm',
+    })
+    expect(keeperTraceState.value.events).toHaveLength(2)
+    expect(keeperTraceState.value.events.map(e => e.count)).toEqual([1, 1])
+  })
+
+  it('does NOT coalesce events from different sources within the window', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1010,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect',
+    })
+    expect(keeperTraceState.value.events).toHaveLength(2)
+    expect(keeperTraceState.value.events.map(e => e.source)).toEqual(['cascade-hop', 'bdi-snapshot'])
+  })
+
+  it('does NOT coalesce same-source events for different keepers within the window', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1010,
+      keeperName: 'moth',
+      source: 'cascade-hop',
+      hopId: 'h-2',
+      provider: 'glm',
+    })
+    expect(keeperTraceState.value.events).toHaveLength(2)
+    expect(keeperTraceState.value.events.map(e => e.keeperName)).toEqual(['scholar', 'moth'])
+  })
+
+  it('inserts out-of-order events into ascending tsMs position', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 5000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-1',
+      line: 1,
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 2000,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'd-1',
+      semanticOutcome: 'success',
+    })
+    pushTrace({
+      id: 'a-3',
+      tsMs: 3500,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect',
+    })
+    expect(keeperTraceState.value.events.map(e => e.tsMs)).toEqual([2000, 3500, 5000])
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual(['a-2', 'a-3', 'a-1'])
+  })
+
+  it('coalesces beyond count=2 (3+ rapid events)', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'd-1',
+      semanticOutcome: 'success',
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1010,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'd-2',
+      semanticOutcome: 'success',
+    })
+    pushTrace({
+      id: 'a-3',
+      tsMs: 1040,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'd-3',
+      semanticOutcome: 'success',
+    })
+    expect(keeperTraceState.value.events).toHaveLength(1)
+    const merged = keeperTraceState.value.events[0]!
+    expect(merged.count).toBe(3)
+    expect(merged.id).toBe('a-1') // first id preserved
+    expect(merged.tsMs).toBe(1040)
+  })
+
+  it('prunes events older than RETENTION_MS relative to the latest', () => {
+    pushTrace({
+      id: 'old-1',
+      tsMs: 0,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-old',
+      line: 1,
+    })
+    pushTrace({
+      id: 'old-2',
+      tsMs: 200,
+      keeperName: 'moth',
+      source: 'cascade-hop',
+      hopId: 'h-old',
+      provider: 'glm',
+    })
+    // Push event at RETENTION_MS + 500 → cutoff = 500, both prior events
+    // (tsMs 0 + 200) fall outside the window.
+    pushTrace({
+      id: 'fresh-1',
+      tsMs: RETENTION_MS + 500,
+      keeperName: 'luna',
+      source: 'bdi-snapshot',
+      intention: 'review',
+    })
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual(['fresh-1'])
+  })
+
+  it('keeps events that are inside RETENTION_MS but past the cutoff midpoint', () => {
+    pushTrace({
+      id: 'survivor',
+      tsMs: 5_000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    // Push event at RETENTION_MS + 10 → cutoff = 10, survivor@5000 stays
+    // because 5000 >= 10.
+    pushTrace({
+      id: 'fresh',
+      tsMs: RETENTION_MS + 10,
+      keeperName: 'luna',
+      source: 'bdi-snapshot',
+      intention: 'review',
+    })
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual(['survivor', 'fresh'])
+  })
+
+  it('keeps boundary event exactly at retention edge', () => {
+    pushTrace({
+      id: 'boundary',
+      tsMs: 0,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-1',
+      line: 1,
+    })
+    pushTrace({
+      id: 'fresh',
+      tsMs: RETENTION_MS,
+      keeperName: 'moth',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    // Latest tsMs = RETENTION_MS, cutoff = 0 → boundary at tsMs=0 is kept (>= cutoff).
+    expect(keeperTraceState.value.events.map(e => e.id)).toEqual(['boundary', 'fresh'])
+  })
+
+  it('clearTraces drops every event', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    clearTraces()
+    expect(keeperTraceState.value.events).toHaveLength(0)
+  })
+
+  it('clearTraces is idempotent on empty state', () => {
+    const stateBefore = keeperTraceState.value
+    clearTraces()
+    expect(keeperTraceState.value).toBe(stateBefore)
+  })
+
+  it('tracesByKeeper filters by keeperName and rejects whitespace', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1100,
+      keeperName: 'moth',
+      source: 'cascade-hop',
+      hopId: 'h-2',
+      provider: 'glm',
+    })
+    expect(tracesByKeeper('scholar').map(e => e.id)).toEqual(['a-1'])
+    expect(tracesByKeeper('moth').map(e => e.id)).toEqual(['a-2'])
+    expect(tracesByKeeper(' ')).toEqual([])
+  })
+
+  it('tracesBySource filters by source variant', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    pushTrace({
+      id: 'a-2',
+      tsMs: 1100,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect',
+    })
+    pushTrace({
+      id: 'a-3',
+      tsMs: 1200,
+      keeperName: 'moth',
+      source: 'bdi-snapshot',
+      intention: 'review',
+    })
+    expect(tracesBySource('cascade-hop').map(e => e.id)).toEqual(['a-1'])
+    expect(tracesBySource('bdi-snapshot').map(e => e.id)).toEqual(['a-2', 'a-3'])
+    expect(tracesBySource('decision-log')).toEqual([])
+  })
+
+  it('preserves discriminated-union narrowing for each source', () => {
+    pushTrace({
+      id: 'a-1',
+      tsMs: 1000,
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'th-1',
+      line: 12,
+    })
+    pushTrace({
+      id: 'b-1',
+      tsMs: 1100,
+      keeperName: 'scholar',
+      source: 'cascade-hop',
+      hopId: 'h-1',
+      provider: 'glm',
+    })
+    pushTrace({
+      id: 'c-1',
+      tsMs: 1200,
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect',
+    })
+    pushTrace({
+      id: 'd-1',
+      tsMs: 1300,
+      keeperName: 'scholar',
+      source: 'decision-log',
+      decisionId: 'dec-1',
+      semanticOutcome: 'success',
+    })
+
+    for (const event of keeperTraceState.value.events) {
+      // Compile-time exhaustive narrowing.
+      switch (event.source) {
+        case 'anchored-thread':
+          expect(event.threadId).toBe('th-1')
+          expect(event.line).toBe(12)
+          break
+        case 'cascade-hop':
+          expect(event.hopId).toBe('h-1')
+          expect(event.provider).toBe('glm')
+          break
+        case 'bdi-snapshot':
+          expect(event.intention).toBe('inspect')
+          break
+        case 'decision-log':
+          expect(event.decisionId).toBe('dec-1')
+          expect(event.semanticOutcome).toBe('success')
+          break
+      }
+    }
+  })
+})

--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -1,0 +1,191 @@
+import { signal } from '@preact/signals'
+
+/**
+ * RFC-0028 PR-α: keeper-trace store.
+ *
+ * Stitched read-side projection over 4 existing layer surfaces:
+ *  - anchored-thread (RFC-0021)
+ *  - cascade-hop     (RFC-0023)
+ *  - bdi-snapshot    (RFC-0024)
+ *  - decision-log    (RFC-0026)
+ *
+ * The store is *append-only* from the producer's perspective. It enforces
+ * three invariants on every `pushTrace` call:
+ *
+ *   (1) tsMs ascending order (binary insertion).
+ *   (2) Coalescing of bursts within `COALESCE_WINDOW_MS` for the same
+ *       (source, keeperName) tuple — increments `count` instead of adding a
+ *       second entry.
+ *   (3) Retention pruning of entries older than `RETENTION_MS` relative to
+ *       the most recent event.
+ *
+ * Cap-on-render (RFC-0028 §5: "stacked gutter chip cap 3 + `+N`") is the
+ * concern of `overlay-keeper-trace.tsx` (PR-β); the store is unbounded but
+ * pruned by retention so memory stays O(events-in-last-10min).
+ *
+ * No new server endpoint: PR-β will wire the 4 producers (each existing
+ * endpoint's polling client) into `pushTrace` so the store joins them
+ * client-side.
+ */
+
+export const COALESCE_WINDOW_MS = 50
+export const RETENTION_MS = 10 * 60 * 1000 // 10 minutes
+
+export type KeeperTraceSource =
+  | 'anchored-thread'
+  | 'cascade-hop'
+  | 'bdi-snapshot'
+  | 'decision-log'
+
+interface KeeperTraceBase {
+  readonly id: string
+  readonly tsMs: number
+  readonly keeperName: string
+  readonly count: number
+  readonly source: KeeperTraceSource
+}
+
+export type KeeperTraceEvent =
+  | (KeeperTraceBase & {
+      readonly source: 'anchored-thread'
+      readonly threadId: string
+      readonly line: number | null
+    })
+  | (KeeperTraceBase & {
+      readonly source: 'cascade-hop'
+      readonly hopId: string
+      readonly provider: string
+    })
+  | (KeeperTraceBase & {
+      readonly source: 'bdi-snapshot'
+      readonly intention: string | null
+    })
+  | (KeeperTraceBase & {
+      readonly source: 'decision-log'
+      readonly decisionId: string
+      readonly semanticOutcome: string | null
+    })
+
+export type KeeperTraceEventInput =
+  | Omit<Extract<KeeperTraceEvent, { source: 'anchored-thread' }>, 'count'>
+  | Omit<Extract<KeeperTraceEvent, { source: 'cascade-hop' }>, 'count'>
+  | Omit<Extract<KeeperTraceEvent, { source: 'bdi-snapshot' }>, 'count'>
+  | Omit<Extract<KeeperTraceEvent, { source: 'decision-log' }>, 'count'>
+
+export interface KeeperTraceState {
+  readonly events: ReadonlyArray<KeeperTraceEvent>
+}
+
+const INITIAL_STATE: KeeperTraceState = { events: [] }
+
+export const keeperTraceState = signal<KeeperTraceState>(INITIAL_STATE)
+
+/**
+ * Ingest a new trace event. The input omits `count` because the store either
+ * coalesces with the latest matching entry (incrementing its count) or starts
+ * a fresh entry with `count: 1`.
+ *
+ * Coalescing rule (RFC-0028 §4):
+ *   if the existing entry with the largest tsMs has the same `source` AND the
+ *   same `keeperName` AND `(input.tsMs - existing.tsMs) <= COALESCE_WINDOW_MS`,
+ *   then replace it in-array with `{ ...existing, count: existing.count + 1, tsMs: input.tsMs }`.
+ *   Otherwise insert at the binary-search position and prune retention.
+ *
+ * Out-of-order tsMs (a producer with stale clock) is supported — the entry
+ * is inserted at the correct ascending position. Coalescing only matches the
+ * latest entry by tsMs of the same (source, keeperName) tuple.
+ */
+export function pushTrace(input: KeeperTraceEventInput): void {
+  const prev = keeperTraceState.value.events
+  const incoming: KeeperTraceEvent = { ...input, count: 1 } as KeeperTraceEvent
+
+  // Find latest entry of same (source, keeperName) — needed for coalescing.
+  // Walk backwards because retention prune keeps the array bounded.
+  let coalesceIdx = -1
+  for (let i = prev.length - 1; i >= 0; i -= 1) {
+    const candidate = prev[i]!
+    if (candidate.source === incoming.source && candidate.keeperName === incoming.keeperName) {
+      coalesceIdx = i
+      break
+    }
+  }
+
+  let nextEvents: ReadonlyArray<KeeperTraceEvent>
+  if (coalesceIdx >= 0) {
+    const existing = prev[coalesceIdx]!
+    const dt = incoming.tsMs - existing.tsMs
+    if (dt >= 0 && dt <= COALESCE_WINDOW_MS) {
+      // Coalesce: bump count and refresh tsMs to the more recent timestamp.
+      const merged = { ...existing, count: existing.count + 1, tsMs: incoming.tsMs }
+      nextEvents = replaceAt(prev, coalesceIdx, merged)
+    } else {
+      nextEvents = insertSorted(prev, incoming)
+    }
+  } else {
+    nextEvents = insertSorted(prev, incoming)
+  }
+
+  // Retention prune relative to the latest event's tsMs (NOT Date.now() —
+  // tests need deterministic eviction independent of wall clock).
+  const latestTs = nextEvents[nextEvents.length - 1]?.tsMs ?? incoming.tsMs
+  const cutoff = latestTs - RETENTION_MS
+  const pruned = nextEvents.filter(e => e.tsMs >= cutoff)
+
+  keeperTraceState.value = { events: pruned }
+}
+
+export function clearTraces(): void {
+  if (keeperTraceState.value.events.length === 0) return
+  keeperTraceState.value = INITIAL_STATE
+}
+
+export function tracesByKeeper(keeperName: string): ReadonlyArray<KeeperTraceEvent> {
+  const trimmed = keeperName.trim()
+  if (!trimmed) return []
+  return keeperTraceState.value.events.filter(e => e.keeperName === trimmed)
+}
+
+export function tracesBySource(source: KeeperTraceSource): ReadonlyArray<KeeperTraceEvent> {
+  return keeperTraceState.value.events.filter(e => e.source === source)
+}
+
+function replaceAt(
+  arr: ReadonlyArray<KeeperTraceEvent>,
+  idx: number,
+  value: KeeperTraceEvent,
+): ReadonlyArray<KeeperTraceEvent> {
+  const next = arr.slice()
+  next[idx] = value
+  // Coalesce may have shifted tsMs forward; ensure the array stays sorted by
+  // walking the entry to its correct position (only forward, since tsMs only
+  // increases on coalesce).
+  let i = idx
+  while (i + 1 < next.length && next[i + 1]!.tsMs < next[i]!.tsMs) {
+    const tmp = next[i]!
+    next[i] = next[i + 1]!
+    next[i + 1] = tmp
+    i += 1
+  }
+  return next
+}
+
+function insertSorted(
+  arr: ReadonlyArray<KeeperTraceEvent>,
+  incoming: KeeperTraceEvent,
+): ReadonlyArray<KeeperTraceEvent> {
+  if (arr.length === 0) return [incoming]
+  // Binary search for insertion position (first index where arr[i].tsMs > incoming.tsMs).
+  let lo = 0
+  let hi = arr.length
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (arr[mid]!.tsMs <= incoming.tsMs) {
+      lo = mid + 1
+    } else {
+      hi = mid
+    }
+  }
+  const next = arr.slice()
+  next.splice(lo, 0, incoming)
+  return next
+}


### PR DESCRIPTION
## 목적

RFC-0028 (#13293 Draft) 의 first impl. **Store 만**, gutter chip overlay 와 IDE_LAYERS entry 는 PR-β 로 분리. v1.1 axis 의 두 번째 RFC 의 첫 단계 — 4 source 합성 ground truth 구축.

## Why this scope (minimum viable, parallel-safe)

RFC-0028 의 5 PR 분할 중 첫째:
- **PR-α (본 PR)**: `keeper-trace-store.ts` (4-source join + coalescing + retention) ~ 250 line
- **PR-β** (follow-up): `overlay-keeper-trace.tsx` + IDE_LAYERS 'keeper-trace' entry + `conflictsWith: ['cascade']` ~ 200 line
- **PR-γ** (follow-up): scrubber bidirectional sync (chip click → ReplayWindow jump) ~ 100 line
- **PR-δ** (follow-up): 4-producer wire-in (각 endpoint 의 polling client → `pushTrace` 연결) ~ 별도 PR
- **PR-ε** (follow-up): perf harness (100k event PR-bound replay scrub < 50ms / scrub) ~ 별도 PR

Store 가 먼저 main 에 머지되면 PR-β/γ 는 시각/UX 변경에 집중 review 가능 — RFC-0027 PR-α/β 와 동일 패턴.

## Diff stat

- +576 lines / -0 lines (2 신규 파일)
- 신규: `keeper-trace-store.ts` (191 lines), `keeper-trace-store.test.ts` (385 lines)
- **수정 0**: 기존 file 변경 없음, behavior 변경 0 (consumer wire-in 없음)

## Public API (RFC-0028 §3 align)

```ts
// Discriminated union over 4 sources.
export type KeeperTraceSource =
  | 'anchored-thread'  // RFC-0021
  | 'cascade-hop'      // RFC-0023
  | 'bdi-snapshot'     // RFC-0024
  | 'decision-log'     // RFC-0026

export type KeeperTraceEvent =
  | (Base & { source: 'anchored-thread'; threadId: string; line: number | null })
  | (Base & { source: 'cascade-hop'; hopId: string; provider: string })
  | (Base & { source: 'bdi-snapshot'; intention: string | null })
  | (Base & { source: 'decision-log'; decisionId: string; semanticOutcome: string | null })

export const COALESCE_WINDOW_MS = 50
export const RETENTION_MS = 10 * 60 * 1000

export const keeperTraceState: Signal<{ events: ReadonlyArray<KeeperTraceEvent> }>
export function pushTrace(input: KeeperTraceEventInput): void
export function clearTraces(): void
export function tracesByKeeper(keeperName: string): ReadonlyArray<KeeperTraceEvent>
export function tracesBySource(source: KeeperTraceSource): ReadonlyArray<KeeperTraceEvent>
```

## Three invariants on every `pushTrace`

1. **tsMs ascending order** (binary insertion, O(log n) seek + O(n) splice for immutable replace)
2. **Coalescing**: 같은 `(source, keeperName)` + (incoming.tsMs - latest.tsMs) ∈ [0, `COALESCE_WINDOW_MS`] → `count++`, tsMs refresh, **id 보존**
3. **Retention**: 매 push 시 `latest.tsMs - RETENTION_MS` cutoff 보다 오래된 events 제거

## Why `pushTrace` 만 expose 하는가 (RFC §4 alignment)

RFC §3 = "no new endpoint, 4 store join". 즉 PR-δ 가 4 source 의 polling client 에서 각각 `pushTrace` 호출 → store 가 단일 truth 합성. 본 PR-α 가 ingestion API 만 expose 하면 PR-δ 의 producer integration 이 단순.

## Test results

```
Test Files  1 passed (1)
     Tests  16 passed (16)
```

| 케이스 | 검증 |
|------|------|
| empty initial | 시작 상태 |
| single push count=1 | base ingest |
| coalesce within window (count=2) | RFC §4 #2 |
| coalesce 3+ events | count 누적 |
| no coalesce gap > window | window boundary |
| no coalesce different sources | source-bounded |
| no coalesce different keepers | keeper-bounded |
| out-of-order tsMs ascending | invariant #1 |
| retention prune (cutoff > 0) | invariant #3 |
| retention boundary (>= cutoff) | edge case |
| clearTraces drops all | reset |
| clearTraces idempotent on empty | no-allocation guard |
| tracesByKeeper filter + whitespace | helper |
| tracesBySource filter | helper |
| discriminated narrowing 4 variants | type ergonomics |

## Key design decisions

### Coalesce key = (source, keeperName, ts-window)
같은 source 라도 다른 keeper 이벤트는 합치지 않음 — cross-keeper visual blending 회피. 같은 keeper 라도 다른 source 는 합치지 않음 — semantic conflation 회피. 50ms 는 RFC §4 spec (burst 구분 임계, perceptual threshold 아님).

### Retention 기준 = latest event tsMs (NOT `Date.now()`)
- 결정론적 test (wall clock 의존 0)
- replay scrub 시 historical events 가 일관되게 남아있음
- producer 가 stale clock 으로 push 해도 retention 이 그 timeline 기준으로 동작

### `id` 보존 in coalesce (NOT 마지막 id 채택)
- React/Preact key stability — DOM diff 의 key 가 stable 해야 transition flicker 방지
- 첫 event 의 id 가 anchor — 후속 burst 는 visual augmentation (count badge)

### `count` 만 증가, `tsMs` refresh
- **timestamp**: latest 로 refresh → 후속 retention prune 가 burst 끝 기준으로 동작 (older boundary 가 first event tsMs 가 아니라 last)
- **payload**: first event 의 payload (threadId/hopId/intention/decisionId) 가 anchor — burst 변종은 count 만 표시

### Out-of-order push 지원
4 source 가 비동기로 push → producer clock skew 가능. binary search insertion 으로 항상 ascending sorted. coalesce 는 latest entry 기준이라 out-of-order arrival 시 새 entry 로 추가 (의도적 — stale data 가 fresh burst 를 오염하지 않음).

## Pre-flight verify (memory line 22-25 강화 protocol)

- `gh pr list --search "keeper-trace-store OR trace-store OR RFC-0028" --state open` → 본 PR 외 #13293 (doc-only RFC), #13270 (unrelated)
- `gh pr list --search "..." --state merged --limit 5` → #13063 (`feat(bounded): RFC-0028 — distribution-based token prediction`) — **OCaml backend, namespace 다름** (docs/rfc/0028 vs dashboard/design-system/RFC/0028). 충돌 0
- `git fetch origin && git log origin/main --since=1h --oneline -- 'dashboard/src/components/ide/'` → #13306 (PR-β, sibling axis), #13283 (cockpit), #13296 (PR-α) — 본 RFC-0028 영역 충돌 0
- `rg "keeper-trace-store|KeeperTraceEvent" dashboard/src/` → 본 PR 신규 파일만
- worktree 절대 경로 (`/.worktrees/rfc-0028-impl-pr-alpha-trace-store`) — nested 회피 룰 적용

## Local validation

- `tsc --noEmit` → 본 PR 변경 파일 0 error
- `vitest run keeper-trace-store.test.ts` → 16/16 pass
- `eslint keeper-trace-store.{ts,test.ts}` → 0 finding

## Rollback plan

2-file revert. Producer wire-in (PR-δ) 미연결 → store 가 unused. user-facing 영향 0.

## RFC waiver

Behavior 변경 0 (store 정의만, producer wire-in 없음). agent_delegation 영역 변경 없음.

`RFC-WAIVED: doc-only RFC dependency (#13293 Draft) — impl scope is store + test only, no producer wiring or consumer rendering. PR-β/γ/δ separate.`

## Related

- #13293 (RFC-0028 spec Draft) — 본 PR-α 가 implements §3 Public API + §4 composition
- #13234 (RFC-0024 P1-A BDI inspector) — PR-δ 가 BDI snapshot polling 에서 `pushTrace` 호출 예정
- #13215 (RFC-0023 Cascade overlay) — PR-δ 가 cascade hop 에서 `pushTrace` 호출 예정
- #13236 (RFC-0026 Audit replay) — PR-δ 가 audit decision log 에서 `pushTrace` 호출 예정
- RFC-0021 anchored thread (PR #13211 umbrella sub-RFC) — PR-δ 4번째 producer

## Follow-up

- **PR-β**: `overlay-keeper-trace.tsx` (gutter chip cap=3 + `+N` overflow) + IDE_LAYERS 'keeper-trace' entry + `conflictsWith: ['cascade']`
- **PR-γ**: scrubber bidirectional sync (chip click → ReplayWindow jump, drag → chip highlight)
- **PR-δ**: 4-producer wire-in (각 polling client / SSE / decision log emit 시 `pushTrace`)
- **PR-ε**: perf harness — 100k event PR-bound replay scrub < 50ms / scrub
- **RFC-0028 amend PR** (after #13293 main merge): §3 KeeperTraceEvent shape align with actual code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
