### PR TITLE
fix(mcp): classify tool-call failures semantically

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -36,6 +36,16 @@ let contains_casefold haystack needle =
   String.length needle = 0
   || String_util.contains_substring_ci haystack needle
 
+type tool_failure_class =
+  | Workflow_rejection
+  | Policy_rejection
+  | Runtime_failure
+
+let tool_failure_class_to_string = function
+  | Workflow_rejection -> "workflow_rejection"
+  | Policy_rejection -> "policy_rejection"
+  | Runtime_failure -> "runtime_failure"
+
 (* #10975: tool-call failure severity classification.
 
    Without this, every [success=false] result downstream is logged
@@ -48,17 +58,28 @@ let contains_casefold haystack needle =
    detection counts ERROR rate), and the dashboard red counter that
    operators use to triage genuine system errors.
 
-   Demote those byte-substring-matched rejection patterns to WARN.
-   Anything else stays ERROR.  Same family pattern as #10881 / #10908
-   / #10919 (single-flag split between normal and catastrophic). *)
-let classify_tool_failure_severity error_detail : Log.level =
+   Classify the current untyped message boundary into a stable semantic
+   class first, then map class -> severity and telemetry. Anything unknown
+   stays [Runtime_failure] / ERROR. *)
+let classify_tool_failure_class error_detail =
   let detail = Option.value ~default:"" error_detail in
   if contains_casefold detail "awaiting_approval"
      || contains_casefold detail "join required"
-     || contains_casefold detail "egress_blocked"
-     || contains_casefold detail "path_outside_sandbox"
-  then Log.Warn
-  else Log.Error
+  then Workflow_rejection
+  else if
+    contains_casefold detail "egress_blocked"
+    || contains_casefold detail "path_outside_sandbox"
+  then Policy_rejection
+  else Runtime_failure
+
+let log_level_of_tool_failure_class = function
+  | Workflow_rejection | Policy_rejection -> Log.Warn
+  | Runtime_failure -> Log.Error
+
+let classify_tool_failure_severity error_detail : Log.level =
+  error_detail
+  |> classify_tool_failure_class
+  |> log_level_of_tool_failure_class
 
 let parse_status_from_message ~success ~message =
   if not success then
@@ -700,12 +721,15 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   Audit_log.log_tool_call state.Mcp_server.room_config
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg:error_detail
     ?trace_id:otel_trace_id ();
-  if not success then
-    Log.Mcp.emit (classify_tool_failure_severity error_detail)
+  if not success then (
+    let failure_class = classify_tool_failure_class error_detail in
+    Log.Mcp.emit (log_level_of_tool_failure_class failure_class)
       ~details:
         (`Assoc
           [
             ("event_family", `String "tool_call_failure");
+            ( "failure_class",
+              `String (tool_failure_class_to_string failure_class) );
             ("tool_name", `String name);
             ("phase", `String "failure");
             ("request_id", `String jsonrpc_id_str);
@@ -718,7 +742,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
             ("error_detail", `String (Option.value ~default:"" error_detail));
           ])
       (Printf.sprintf "tool call failed: %s — %s" name
-         (Option.value ~default:"(no detail)" error_detail));
+         (Option.value ~default:"(no detail)" error_detail)));
 
   (* Classify call source: Keeper_internal if the resolved agent_name matches
      a registered keeper (keeper-internal dispatch via cli_agent runtime),

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -757,6 +757,26 @@ let test_docker_config_storage_contracts () =
     (file_contains_pattern "Dockerfile"
        {|chown -R appuser:appgroup /app/.masc|})
 
+let test_tool_failure_classification_contracts () =
+  check bool "tool failure classification uses typed class" true
+    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+       "type tool_failure_class =");
+  check bool "workflow rejection class exists" true
+    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+       "| Workflow_rejection");
+  check bool "policy rejection class exists" true
+    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+       "| Policy_rejection");
+  check bool "runtime failure class exists" true
+    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+       "| Runtime_failure");
+  check bool "log details expose failure class" true
+    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+       {|"failure_class"|});
+  check bool "call path classifies once before log emit" true
+    (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
+       "let failure_class = classify_tool_failure_class error_detail")
+
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
@@ -1467,6 +1487,8 @@ let () =
              test_board_flusher_start_retry_contracts;
            test_case "docker config storage contracts" `Quick
              test_docker_config_storage_contracts;
+           test_case "tool failure classification contracts" `Quick
+             test_tool_failure_classification_contracts;
            test_case "dashboard warm hydration contracts" `Quick
              test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;


### PR DESCRIPTION
## Summary

- add a typed tool-call failure class: `workflow_rejection`, `policy_rejection`, `runtime_failure`
- emit `failure_class` in MCP `tool_call_failure` log details
- keep existing WARN/ERROR behavior, but route severity through the typed class instead of inline substring severity logic
- add a source-hardening contract so the semantic class and log field do not regress silently

## Why

The Kimi/code-hiding audit needs operator-visible separation between expected workflow/policy rejections and real runtime failures. This preserves the current demotion behavior for approval/sandbox denials while making the reason explicit in telemetry.

## Validation

- `git diff --check`
- `env DUNE_JOBS=2 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/tool-failure-classification-0506 test/test_mcp_server_eio_call_tool.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_mcp_server_eio_call_tool.exe`
- `./_build/default/test/test_ci_hardening_source.exe`