### PR TITLE
fix(keeper): attach source path to gate evidence

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -82,7 +82,21 @@ let escape_field s =
 (** Render structured skip reason for inline Override injection.
     The LLM sees this as the ToolResult content immediately within
     the same turn. *)
-let render_inline_skip_reason ~tool_name ~reason_code ~reason_text : string =
+let keeper_guards_source_path = "lib/keeper/keeper_guards.ml"
+
+let source_hint ~source_path ~source_line =
+  match source_path, source_line with
+  | None, None -> ""
+  | Some path, None ->
+    Printf.sprintf " source_path=%s" (escape_field path)
+  | None, Some line ->
+    Printf.sprintf " source_line=%d" line
+  | Some path, Some line ->
+    Printf.sprintf " source_path=%s source_line=%d"
+      (escape_field path) line
+
+let render_inline_skip_reason_impl ~source_path ~source_line
+    ~tool_name ~reason_code ~reason_text : string =
   let replacement_hint =
     match (Tool_catalog.metadata tool_name).Tool_catalog.replacement with
     | Some replacement ->
@@ -90,11 +104,29 @@ let render_inline_skip_reason ~tool_name ~reason_code ~reason_text : string =
     | None -> ""
   in
   Printf.sprintf
-    "[tool_skipped] tool=%s source=keeper_hook code=%s reason=%s%s"
+    "[tool_skipped] tool=%s source=keeper_hook code=%s reason=%s%s%s"
     (escape_field tool_name)
     (escape_field reason_code)
     (escape_field reason_text)
     replacement_hint
+    (source_hint ~source_path ~source_line)
+
+let render_inline_skip_reason ~tool_name ~reason_code ~reason_text : string =
+  render_inline_skip_reason_impl
+    ~source_path:None
+    ~source_line:None
+    ~tool_name
+    ~reason_code
+    ~reason_text
+
+let render_inline_skip_reason_with_source
+    ~source_path ~source_line ~tool_name ~reason_code ~reason_text : string =
+  render_inline_skip_reason_impl
+    ~source_path:(Some source_path)
+    ~source_line:(Some source_line)
+    ~tool_name
+    ~reason_code
+    ~reason_text
 
 (** Broadcast a tool skip event via SSE for dashboard visibility.
     Also records in [Dashboard_governance_metrics] for aggregation. *)
@@ -164,6 +196,8 @@ type gate_decision_event = {
   turn : int;
   accumulated_cost_usd : float;
   stage_latency_ms : float;
+  source_path : string option;
+  source_line : int option;
 }
 
 let ignore_gate_decision (_ : gate_decision_event) = ()
@@ -236,6 +270,7 @@ let () =
     ()
 
 let emit_gate_event
+    ~source_path ~source_line
     ~stage ~decision ~reason_code
     ~tool_name ~agent_name ~turn
     ~accumulated_cost_usd ~stage_latency_ms ~reason_text =
@@ -270,6 +305,10 @@ let emit_gate_event
       ("reason_text", `String reason_text);
       ("source", `String "hook");
       ("cascade_attempted", `Bool (not is_gate_rejection));
+      ("source_path",
+       (match source_path with Some path -> `String path | None -> `Null));
+      ("source_line",
+       (match source_line with Some line -> `Int line | None -> `Null));
     ] in
     (try
       Oas_bus_instrument.publish bus
@@ -287,15 +326,16 @@ let emit_gate_event
         stage tool_name (Printexc.to_string exn))
 
 let report_gate_decision on_gate_decision
+    ~source_path ~source_line
     ~stage ~decision ~reason_code ~reason_text
     ~tool_name ~keeper_name ~input ~turn
     ~accumulated_cost_usd ~stage_latency_ms =
-  emit_gate_event ~stage ~decision ~reason_code ~tool_name
+  emit_gate_event ~source_path ~source_line ~stage ~decision ~reason_code ~tool_name
     ~agent_name:keeper_name ~turn ~accumulated_cost_usd
     ~stage_latency_ms ~reason_text;
   notify_gate_decision on_gate_decision
     { stage; decision; reason_code; reason_text; tool_name; input; turn;
-      accumulated_cost_usd; stage_latency_ms }
+      accumulated_cost_usd; stage_latency_ms; source_path; source_line }
 
 (* -------------------------------------------------------------- *)
 (* Composition helpers                                             *)
@@ -366,13 +406,17 @@ let custom_guard
            keeper_name tool_name;
          broadcast_tool_skipped
            ~keeper_name ~tool_name ~reason_code:"pre_tool_use_guard";
+         let source_path = keeper_guards_source_path in
+         let source_line = __LINE__ in
          report_gate_decision on_gate_decision
+           ~source_path:(Some source_path) ~source_line:(Some source_line)
            ~stage:"pre_tool_use_guard" ~decision:Gate_override
            ~reason_code:"pre_tool_use_guard" ~reason_text:reason
            ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
            ~stage_latency_ms:latency_ms;
          Agent_sdk.Hooks.Override
-           (render_inline_skip_reason
+           (render_inline_skip_reason_with_source
+              ~source_path ~source_line
               ~tool_name ~reason_code:"pre_tool_use_guard"
               ~reason_text:reason)
        | None -> Agent_sdk.Hooks.Continue)
@@ -416,13 +460,17 @@ let streak_guard
           keeper_name tool_name new_count;
         broadcast_tool_skipped
           ~keeper_name ~tool_name ~reason_code:"streak_gate";
+        let source_path = keeper_guards_source_path in
+        let source_line = __LINE__ in
         report_gate_decision on_gate_decision
+          ~source_path:(Some source_path) ~source_line:(Some source_line)
           ~stage:"streak_gate" ~decision:Gate_override
           ~reason_code:"streak_gate" ~reason_text
           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
           ~stage_latency_ms:latency_ms;
         Agent_sdk.Hooks.Override
-          (render_inline_skip_reason
+          (render_inline_skip_reason_with_source
+             ~source_path ~source_line
              ~tool_name ~reason_code:"streak_gate" ~reason_text)
       end
       else Agent_sdk.Hooks.Continue
@@ -452,13 +500,17 @@ let deny_guard
           keeper_name tool_name;
         broadcast_tool_skipped
           ~keeper_name ~tool_name ~reason_code:"keeper_deny";
+        let source_path = keeper_guards_source_path in
+        let source_line = __LINE__ in
         report_gate_decision on_gate_decision
+          ~source_path:(Some source_path) ~source_line:(Some source_line)
           ~stage:"keeper_deny" ~decision:Gate_override
           ~reason_code:"keeper_deny" ~reason_text
           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
           ~stage_latency_ms:latency_ms;
         Agent_sdk.Hooks.Override
-          (render_inline_skip_reason
+          (render_inline_skip_reason_with_source
+             ~source_path ~source_line
              ~tool_name ~reason_code:"keeper_deny" ~reason_text)
       end
       else Agent_sdk.Hooks.Continue
@@ -494,13 +546,17 @@ let cost_guard
            keeper_name accumulated_cost_usd limit tool_name;
          broadcast_tool_skipped
            ~keeper_name ~tool_name ~reason_code:"cost_gate";
+         let source_path = keeper_guards_source_path in
+         let source_line = __LINE__ in
          report_gate_decision on_gate_decision
+           ~source_path:(Some source_path) ~source_line:(Some source_line)
            ~stage:"cost_gate" ~decision:Gate_override
            ~reason_code:"cost_gate" ~reason_text
            ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
            ~stage_latency_ms:latency_ms;
          Agent_sdk.Hooks.Override
-           (render_inline_skip_reason
+           (render_inline_skip_reason_with_source
+              ~source_path ~source_line
               ~tool_name ~reason_code:"cost_gate" ~reason_text)
        | _ -> Agent_sdk.Hooks.Continue)
     | _ -> Agent_sdk.Hooks.Continue)
@@ -540,13 +596,17 @@ let destructive_guard
              keeper_name tool_name pattern desc;
            broadcast_tool_skipped
              ~keeper_name ~tool_name ~reason_code:"destructive_guard";
+           let source_path = keeper_guards_source_path in
+           let source_line = __LINE__ in
            report_gate_decision on_gate_decision
+             ~source_path:(Some source_path) ~source_line:(Some source_line)
              ~stage:"destructive_guard" ~decision:Gate_override
              ~reason_code:"destructive_guard" ~reason_text
              ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
              ~stage_latency_ms:latency_ms;
            Agent_sdk.Hooks.Override
-             (render_inline_skip_reason
+             (render_inline_skip_reason_with_source
+                ~source_path ~source_line
                 ~tool_name ~reason_code:"destructive_guard"
                 ~reason_text))
     | _ -> Agent_sdk.Hooks.Continue)
@@ -576,7 +636,10 @@ let governance_approval_guard
       in
       if needs_approval then begin
         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+        let source_path = keeper_guards_source_path in
+        let source_line = __LINE__ in
         report_gate_decision on_gate_decision
+          ~source_path:(Some source_path) ~source_line:(Some source_line)
           ~stage:"governance_approval" ~decision:Gate_approval_required
           ~reason_code:"governance_approval"
           ~reason_text:"risk threshold reached; operator approval required"

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -26,6 +26,14 @@ val render_inline_skip_reason :
   reason_text:string ->
   string
 
+val render_inline_skip_reason_with_source :
+  source_path:string ->
+  source_line:int ->
+  tool_name:string ->
+  reason_code:string ->
+  reason_text:string ->
+  string
+
 (** Broadcast a tool-skip event to SSE listeners and record it in
     [Dashboard_governance_metrics]. *)
 val broadcast_tool_skipped :
@@ -61,6 +69,8 @@ type gate_decision_event =
   ; turn : int
   ; accumulated_cost_usd : float
   ; stage_latency_ms : float
+  ; source_path : string option
+  ; source_line : int option
   }
 
 (** Default gate observer — discards events. *)
@@ -75,6 +85,8 @@ val notify_gate_decision :
     when one is registered. Marks the turn as gate-rejected on
     [override] / [approval_required] decisions. *)
 val emit_gate_event :
+  source_path:string option ->
+  source_line:int option ->
   stage:string ->
   decision:gate_decision ->
   reason_code:string ->
@@ -90,6 +102,8 @@ val emit_gate_event :
     single call used by every guard. *)
 val report_gate_decision :
   (gate_decision_event -> unit) ->
+  source_path:string option ->
+  source_line:int option ->
   stage:string ->
   decision:gate_decision ->
   reason_code:string ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -64,18 +64,39 @@ let current_keeper_model meta =
   let m = meta.Keeper_types.runtime.usage.last_model_used in
   if m = "" then meta.Keeper_types.cascade_name else m
 
+let render_pre_tool_gate_source_hint
+    (event : Keeper_guards.gate_decision_event) =
+  match event.source_path, event.source_line with
+  | None, None -> ""
+  | Some path, None ->
+    Printf.sprintf " source_path=%s" (Keeper_guards.escape_field path)
+  | None, Some line -> Printf.sprintf " source_line=%d" line
+  | Some path, Some line ->
+    Printf.sprintf " source_path=%s source_line=%d"
+      (Keeper_guards.escape_field path) line
+
 let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
   if event.decision = Keeper_guards.Gate_approval_required then
     Printf.sprintf
-      "[tool_approval_required] tool=%s source=keeper_hook code=%s reason=%s"
+      "[tool_approval_required] tool=%s source=keeper_hook code=%s reason=%s%s"
       (Keeper_guards.escape_field event.tool_name)
       (Keeper_guards.escape_field event.reason_code)
       (Keeper_guards.escape_field event.reason_text)
+      (render_pre_tool_gate_source_hint event)
   else
-    Keeper_guards.render_inline_skip_reason
-      ~tool_name:event.tool_name
-      ~reason_code:event.reason_code
-      ~reason_text:event.reason_text
+    match event.source_path, event.source_line with
+    | Some source_path, Some source_line ->
+      Keeper_guards.render_inline_skip_reason_with_source
+        ~source_path
+        ~source_line
+        ~tool_name:event.tool_name
+        ~reason_code:event.reason_code
+        ~reason_text:event.reason_text
+    | _ ->
+      Keeper_guards.render_inline_skip_reason
+        ~tool_name:event.tool_name
+        ~reason_code:event.reason_code
+        ~reason_text:event.reason_text
 
 let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
   let decision = Keeper_guards.gate_decision_to_string event.decision in

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -9,6 +9,7 @@
 
 open Alcotest
 module KG = Masc_mcp.Keeper_guards
+module HK = Masc_mcp.Keeper_hooks_oas
 
 (* ----------------------------------------------------------------- *)
 (* Helpers                                                             *)
@@ -113,7 +114,47 @@ let test_render_inline_skip_reason () =
   check bool "contains code=streak_gate" true
     (contains_substring s "code=streak_gate");
   check bool "contains source=keeper_hook" true
-    (contains_substring s "source=keeper_hook")
+    (contains_substring s "source=keeper_hook");
+  let with_source = KG.render_inline_skip_reason_with_source
+    ~source_path:"lib/keeper/keeper_guards.ml"
+    ~source_line:123
+    ~tool_name:"keeper_fs_read"
+    ~reason_code:"streak_gate"
+    ~reason_text:"called 5 times"
+  in
+  check bool "contains source_path" true
+    (contains_substring with_source "source_path=lib/keeper/keeper_guards.ml");
+  check bool "contains source_line" true
+    (contains_substring with_source "source_line=123")
+
+let make_gate_event ?(decision = KG.Gate_override) () =
+  { KG.stage = "keeper_deny";
+    decision;
+    reason_code = "keeper_deny";
+    reason_text = "tool is on the keeper deny list";
+    tool_name = "dangerous_tool";
+    input = `Assoc [];
+    turn = 4;
+    accumulated_cost_usd = 0.0;
+    stage_latency_ms = 1.0;
+    source_path = Some "lib/keeper/keeper_guards.ml";
+    source_line = Some 123;
+  }
+
+let test_render_pre_tool_gate_output_preserves_source () =
+  let blocked = HK.render_pre_tool_gate_output (make_gate_event ()) in
+  check bool "override output carries source path" true
+    (contains_substring blocked "source_path=lib/keeper/keeper_guards.ml");
+  check bool "override output carries source line" true
+    (contains_substring blocked "source_line=123");
+  let approval =
+    HK.render_pre_tool_gate_output
+      (make_gate_event ~decision:KG.Gate_approval_required ())
+  in
+  check bool "approval output carries source path" true
+    (contains_substring approval "source_path=lib/keeper/keeper_guards.ml");
+  check bool "approval output carries source line" true
+    (contains_substring approval "source_line=123")
 
 let test_gate_decision_vocabulary () =
   check string "override" "override"
@@ -143,7 +184,11 @@ let test_deny_guard_blocks () =
   check string "denied tool -> Override" "Override" (decision_kind d);
   let text = override_text d in
   check bool "override mentions deny list" true
-    (contains_substring text "code=keeper_deny")
+    (contains_substring text "code=keeper_deny");
+  check bool "override carries source path" true
+    (contains_substring text "source_path=lib/keeper/keeper_guards.ml");
+  check bool "override carries source line" true
+    (contains_substring text "source_line=")
 
 let test_deny_guard_notifies_gate_observer () =
   let meta_ref = make_meta_ref "test_keeper" in
@@ -167,6 +212,13 @@ let test_deny_guard_notifies_gate_observer () =
     check string "reason_code" "keeper_deny" event.KG.reason_code;
     check string "tool_name" "dangerous_tool" event.KG.tool_name;
     check int "turn" 4 event.KG.turn;
+    check (option string) "source_path"
+      (Some "lib/keeper/keeper_guards.ml")
+      event.KG.source_path;
+    check bool "source_line present" true
+      (match event.KG.source_line with
+       | Some line -> line > 0
+       | None -> false);
     check bool "input preserved" true
       (match event.KG.input with
        | `Assoc [ ("path", `String "/tmp/secret") ] -> true
@@ -318,7 +370,14 @@ let test_governance_approval_notifies_gate_observer () =
       check string "decision" "approval_required"
         (KG.gate_decision_to_string event.KG.decision);
       check string "reason_code" "governance_approval" event.KG.reason_code;
-      check string "tool_name" "keeper_fs_edit" event.KG.tool_name
+      check string "tool_name" "keeper_fs_edit" event.KG.tool_name;
+      check (option string) "source_path"
+        (Some "lib/keeper/keeper_guards.ml")
+        event.KG.source_path;
+      check bool "source_line present" true
+        (match event.KG.source_line with
+         | Some line -> line > 0
+         | None -> false)
     | events ->
       failf "expected one observer event, got %d" (List.length events))
 
@@ -412,6 +471,8 @@ let () = run "Keeper_guards" [
   "utilities", [
     test_case "extract_command_from_input" `Quick test_extract_command_from_input;
     test_case "render_inline_skip_reason" `Quick test_render_inline_skip_reason;
+    test_case "pre-tool gate output preserves source" `Quick
+      test_render_pre_tool_gate_output_preserves_source;
     test_case "gate decision vocabulary" `Quick test_gate_decision_vocabulary;
   ];
   "deny_guard", [


### PR DESCRIPTION
## Summary

Fixes #13309.

Keeper pre-tool gate rejections now preserve the MASC call site that produced the gate decision. The gate observer payload, `masc.keeper_gate` event payload, inline override text, and `keeper_hooks_oas` pre-tool tool-call rendering now carry `source_path` / `source_line` when a guard blocks or requires approval.

## Root Cause

OAS `Mode_enforcer` source-path evidence is already present in the pinned Agent SDK, and MASC already has `Effect_evidence` consumers for `evidence/effects.json`. The MASC keeper hook gate path is parallel to that producer path: it generated `[tool_skipped] ... source=keeper_hook ...` and durable gate telemetry without attaching its own source path before handing the decision to OAS hook/log surfaces.

## Operator Impact

SafeAuto/CDAL diagnostics can now distinguish a generic `keeper_hook` rejection from the concrete guard implementation site. That makes gate-blocked keeper turns auditable without relying on lost backtraces or log-only context.

## Validation

- `dune build --root . -j 1 test/test_keeper_guards.exe`
- `./_build/default/test/test_keeper_guards.exe` (23 tests)
- `dune build --root . -j 1 test/test_effect_evidence_source_path.exe`
- `./_build/default/test/test_effect_evidence_source_path.exe` (13 tests)
- `git diff --check`

Note: `scripts/dune-local.sh build test/test_keeper_guards.exe` passed the Agent SDK pin check, then waited on `/tmp/me-dune-local.lock`; I stopped only this branch's waiting lock process and used direct focused `dune -j1` for the same target.