### PR TITLE
fix(board): back off flusher startup contention

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -110,6 +110,44 @@ type board_sse_event =
 
 let backend_state : backend_state Atomic.t = Atomic.make Uninitialized
 let flusher_start_cas_retries = 3
+let flusher_start_backoff_base_s = 0.001
+let flusher_start_backoff_cap_s = 0.02
+let forced_flusher_start_cas_conflicts_for_test : int Atomic.t = Atomic.make 0
+
+let flusher_start_backoff_delay_s ~attempt =
+  let rec pow2 acc n =
+    if n <= 0 then acc else pow2 (acc *. 2.0) (n - 1)
+  in
+  Float.min flusher_start_backoff_cap_s
+    (flusher_start_backoff_base_s *. pow2 1.0 attempt)
+
+let sleep_flusher_start_backoff ~attempt =
+  let delay = flusher_start_backoff_delay_s ~attempt in
+  match Eio_context.get_clock_opt () with
+  | Some clock -> Eio.Time.sleep clock delay
+  | None -> Time_compat.sleep delay
+
+let consume_forced_flusher_start_cas_conflict_for_test () =
+  let rec loop () =
+    let remaining = Atomic.get forced_flusher_start_cas_conflicts_for_test in
+    if remaining <= 0 then false
+    else if Atomic.compare_and_set forced_flusher_start_cas_conflicts_for_test
+        remaining (remaining - 1)
+    then true
+    else loop ()
+  in
+  loop ()
+
+let force_flusher_start_cas_conflicts_for_test count =
+  Atomic.set forced_flusher_start_cas_conflicts_for_test (Int.max 0 count)
+
+let flusher_started_for_test () =
+  match Atomic.get backend_state with
+  | Active (_, true) -> true
+  | Active (_, false) | Uninitialized -> false
+
+let flusher_start_backoff_delay_for_test ~attempt =
+  flusher_start_backoff_delay_s ~attempt
 
 let start_flusher_actor ~sw store =
   Eio.Fiber.fork_daemon ~sw (fun () ->
@@ -133,9 +171,10 @@ let start_flusher_actor ~sw store =
 
 (** CAS [Active (b, false) -> Active (b, true)] for the current [b], then
     spawn the flusher daemon.  If the CAS loses to another fiber, retry a
-    bounded number of times while the state still needs a flusher; if
-    another fiber already flipped the flag, return.  On daemon-spawn
-    failure, roll the flag back so a later caller can retry.
+    bounded number of times with short exponential backoff while the state
+    still needs a flusher; if another fiber already flipped the flag,
+    return.  On daemon-spawn failure, roll the flag back so a later caller
+    can retry.
 
     Pre-D-7 this was a sibling [Atomic.compare_and_set flusher_started
     false true]; the flag now lives in the variant so it cannot drift
@@ -150,7 +189,11 @@ let ensure_flusher_actor store =
         | Uninitialized -> ()
         | Active (_, true) -> ()
         | Active (b, false) ->
-            if Atomic.compare_and_set backend_state current (Active (b, true)) then
+            let cas_won =
+              if consume_forced_flusher_start_cas_conflict_for_test () then false
+              else Atomic.compare_and_set backend_state current (Active (b, true))
+            in
+            if cas_won then
               try start_flusher_actor ~sw store
               with exn ->
                 (* Roll the flag back so a future caller can retry.  Only
@@ -167,6 +210,8 @@ let ensure_flusher_actor store =
                 | _ -> raise exn
             else if attempts_left > 0 then begin
               Eio.Fiber.yield ();
+              sleep_flusher_start_backoff
+                ~attempt:(flusher_start_cas_retries - attempts_left);
               loop (attempts_left - 1)
             end else
               Log.BoardLog.warn
@@ -223,6 +268,7 @@ let reset_for_test () =
   (* D-7: dropping [Active] also drops the flusher-started flag, since
      it now lives inside the variant. *)
   Atomic.set backend_state Uninitialized;
+  Atomic.set forced_flusher_start_cas_conflicts_for_test 0;
   Atomic.set keeper_board_signal_hook None;
   Atomic.set board_sse_hook None
 

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -109,6 +109,16 @@ val init_jsonl : unit -> unit
 val reset_for_test : unit -> unit
 (** Drop the in-memory backend. Test-only. *)
 
+val force_flusher_start_cas_conflicts_for_test : int -> unit
+(** Force the next [n] flusher-start CAS attempts to lose. Test-only. *)
+
+val flusher_started_for_test : unit -> bool
+(** [true] iff the active backend has marked its flusher daemon as started.
+    Test-only. *)
+
+val flusher_start_backoff_delay_for_test : attempt:int -> float
+(** Exponential backoff delay used after a flusher-start CAS loss. Test-only. *)
+
 val backend_name : unit -> string
 (** ["jsonl"] when initialised, ["uninitialized"] otherwise. *)
 

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -527,6 +527,40 @@ let test_vote_persisted_by_flusher_actor () =
         Eio.Switch.fail sw Exit)
   with Exit -> ()
 
+let test_flusher_start_retries_forced_cas_conflicts () =
+  try
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+    let clock = Eio.Stdenv.clock env in
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    Eio_context.with_test_env
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~mono_clock:(Eio.Stdenv.mono_clock env)
+      ~sw
+      (fun () ->
+        ignore (fresh_test_base_path ());
+        Board.reset_global_for_test ();
+        Board_dispatch.reset_for_test ();
+        Board_dispatch.force_flusher_start_cas_conflicts_for_test 2;
+        Board_dispatch.init_jsonl ();
+        Alcotest.(check bool)
+          "flusher starts after forced CAS contention" true
+          (Board_dispatch.flusher_started_for_test ());
+        Eio.Switch.fail sw Exit)
+  with Exit -> ()
+
+let test_flusher_start_backoff_delay_doubles_and_caps () =
+  Alcotest.(check (float 0.0001))
+    "attempt 0 delay" 0.001
+    (Board_dispatch.flusher_start_backoff_delay_for_test ~attempt:0);
+  Alcotest.(check (float 0.0001))
+    "attempt 1 delay doubles" 0.002
+    (Board_dispatch.flusher_start_backoff_delay_for_test ~attempt:1);
+  Alcotest.(check (float 0.0001))
+    "large attempt caps" 0.02
+    (Board_dispatch.flusher_start_backoff_delay_for_test ~attempt:10)
+
 (** {1 Reaction Operations} *)
 
 let test_reaction_toggle_and_summary () =
@@ -830,6 +864,10 @@ let () =
         (with_eio test_current_vote_lookup);
       Alcotest.test_case "vote persisted by flusher actor" `Quick
         test_vote_persisted_by_flusher_actor;
+      Alcotest.test_case "flusher start retries forced CAS conflicts" `Quick
+        test_flusher_start_retries_forced_cas_conflicts;
+      Alcotest.test_case "flusher start backoff doubles and caps" `Quick
+        test_flusher_start_backoff_delay_doubles_and_caps;
     ];
     "reactions", [
       Alcotest.test_case "toggle and summary" `Quick

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -736,9 +736,18 @@ let test_board_flusher_start_retry_contracts () =
   check bool "board flusher CAS contention yields before retry" true
     (file_contains_pattern "lib/board_dispatch.ml"
        "Eio.Fiber.yield ()");
+  check bool "board flusher CAS contention uses exponential backoff" true
+    (file_contains_pattern "lib/board_dispatch.ml"
+       "flusher_start_backoff_delay_s");
+  check bool "board flusher CAS backoff is bounded" true
+    (file_contains_pattern "lib/board_dispatch.ml"
+       "flusher_start_backoff_cap_s");
   check bool "board flusher retry decrements attempts" true
     (file_contains_pattern "lib/board_dispatch.ml"
        "loop (attempts_left - 1)");
+  check bool "board flusher retry has injected contention coverage" true
+    (file_contains_pattern "test/test_board_dispatch.ml"
+       "force_flusher_start_cas_conflicts_for_test 2");
   check bool "board flusher exhausted retry is operator visible" true
     (file_contains_pattern "lib/board_dispatch.ml"
        "Board flusher actor startup CAS contention exhausted")


### PR DESCRIPTION
## Summary
- add bounded exponential backoff after board flusher startup CAS contention instead of immediate tight retry
- add deterministic forced-CAS-conflict test hooks and coverage for retry success after contention
- extend the CI hardening source guard so future edits keep retry, backoff, cap, and injected-contention coverage

## Verification
- `env DUNE_JOBS=1 dune build --root . --cache=disabled --display=short test/test_board_dispatch.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_board_dispatch.exe` (40 tests)
- `./_build/default/test/test_ci_hardening_source.exe` (44 tests)
- `git diff --check origin/main..HEAD`

Refs #13275. Builds on #13298 by making the startup retry bounded-backoff instead of yield-only.