### PR TITLE
fix(coord): preserve active task on claim_next

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -1,7 +1,8 @@
 (** Coord_task_schedule — Scheduling: claim_next, release_stale_claims.
 
     Extracted from Coord_task to separate scheduling logic (priority queue,
-    stale detection, auto-release) from task CRUD and state transitions. *)
+    stale detection, existing-claim preservation) from task CRUD and state
+    transitions. *)
 
 open Masc_domain
 include Coord_utils
@@ -9,9 +10,9 @@ include Coord_state
 
 (** #10421: stable lowercase string label for a [task_status] suitable
     for embedding in JSONL diagnostic events.  Mirrors what the
-    [task_transition] from→to fields already use so dashboards can
-    join the new auto-release rows on identical vocabulary.  Pure;
-    exposed for tests. *)
+    [task_transition] from/to fields already use so dashboards can
+    join claim-loop diagnostics on identical vocabulary.  Pure; exposed for
+    tests. *)
 let task_status_label (status : Masc_domain.task_status) : string =
   match status with
   | Todo -> "todo"
@@ -332,7 +333,8 @@ let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
     while the backlog lock is held.
 
     Scheduling logic:
-    - Auto-releases any previous claim held by this agent (BUG-004)
+    - Preserves any active claim held by this agent; callers must explicitly
+      release or finish before claiming different work.
     - Applies starvation prevention: tasks waiting >24h get priority boost
     - Within same effective priority, prefers older tasks (FIFO) *)
 let claim_next_r
@@ -343,6 +345,7 @@ let claim_next_r
       ?(task_filter = fun _ -> true)
       ()
   =
+  let exception Existing_claim of claim_next_result in
   ensure_initialized config;
 
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
@@ -353,74 +356,59 @@ let claim_next_r
       | Ok backlog ->
       reconcile_agent_current_task_with_backlog config ~agent_name backlog;
 
-      (* BUG-004: Detect and auto-release previous claim to prevent orphaned tasks.
-         If this agent already holds a Claimed or InProgress task, release it
-         back to Todo before proceeding. AwaitingVerification is deliberately
-         excluded: releasing it would drop the verification FSM edge and reopen
-         work before a verifier approve/reject decision. *)
+      (* #10421: If this agent already holds a Claimed or InProgress task,
+         return that task instead of implicitly releasing it.  Automatic
+         release caused keeper hot-potato loops: a repeated claim_next call
+         could drop InProgress work back to Todo and let another keeper steal
+         it before the original owner had a chance to finish.  AwaitingVerification
+         is still excluded: it is no longer active implementation work for
+         the claimant. *)
       let previous_claim = List.find_opt (fun (t : Masc_domain.task) ->
         match t.task_status with
         | Claimed { assignee; _ } | InProgress { assignee; _ } ->
             String.equal assignee agent_name
         | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false
       ) backlog.tasks in
-      let observe_auto_release () =
-        match previous_claim with
-        | Some prev ->
-            Coord_task.observe_task_transition config ~agent_name ~task_id:prev.id
-              ~transition:Masc_domain.Release
-              ~details:
-                (Coord_task.task_transition_details ~from_status:prev.task_status
-                   ~to_status:Masc_domain.Todo
-                   ~reason:"auto_release_before_claim_next" ())
-        | None -> ()
+      (match previous_claim with
+       | None -> ()
+       | Some prev ->
+           let from_status = task_status_label prev.task_status in
+           log_event config (`Assoc [
+             ("type", `String "task_claim_next_existing_task");
+             ("agent", `String agent_name);
+             ("task", `String prev.id);
+             ("from_status", `String from_status);
+             ("reason", `String "existing_claim_preserved");
+             ("ts", `String (now_iso ()));
+           ]);
+           Log.RoomTask.info
+             "task_claim_next preserved existing task: agent=%s task=%s \
+              from_status=%s — finish or explicitly release before claiming \
+              different work (#10421)"
+             agent_name prev.id from_status;
+           Coord_task.update_local_agent_state config ~agent_name (fun agent ->
+             { agent with status = Busy; current_task = Some prev.id });
+           let message =
+             Printf.sprintf
+               "%s already holds [P%d] %s: %s. ACTION: Resume this task; \
+                do not call claim_next again until it is done or explicitly \
+                released."
+               agent_name prev.priority prev.id prev.title
+           in
+           raise
+             (Existing_claim
+                (Claim_next_claimed
+                   {
+                     task_id = prev.id;
+                     title = prev.title;
+                     priority = prev.priority;
+                     released_task_id = None;
+                     message;
+                   })));
+      let observe_legacy_release () =
+        ()
       in
-      let released_task_id, working_tasks = match previous_claim with
-        | None -> None, backlog.tasks
-        | Some prev ->
-            (* #10421: include [reason] and [from_status] in the JSONL
-               event so the auto-release tail (43/24 release/claim
-               ratio, 5x hot-potato on task-056) is discriminable
-               without cross-referencing observe_task_transition.
-               [from_status] separates Claimed (most cases) from
-               InProgress (rare; signals a keeper that started work
-               and then re-entered claim_next).  Same reason vocabulary
-               the structured observation already uses. *)
-            let from_status = task_status_label prev.task_status in
-            log_event config (`Assoc [
-              ("type", `String "task_claim_next_auto_release");
-              ("agent", `String agent_name);
-              ("released_task", `String prev.id);
-              ("from_status", `String from_status);
-              ("reason", `String "prev_claim_implicit_replaced");
-              ("ts", `String (now_iso ()));
-            ]);
-            (* #10421: warn-level log so dashboards see the implicit
-               release at fleet scale. [InProgress → Todo] is the
-               more concerning subset (mid-work churn) — from_status
-               surfaces that distinction in a single line. *)
-            Log.RoomTask.warn
-              "task_claim_next auto-released prev claim: agent=%s task=%s \
-               from_status=%s — keeper called claim_next without \
-               releasing/finishing the prior task (#10421)"
-              agent_name prev.id from_status;
-            (* #10421: Prometheus counter so operators can graph rate
-               and split by keeper. Hook indirection lives in
-               [coord_hooks]; emit wired in [lib/coord.ml] to avoid
-               a [masc_coord → Prometheus] dep cycle. *)
-            (try
-               (Atomic.get Coord_hooks.task_auto_release_observed_fn)
-                 ~agent_name ~from_status
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | _ -> ());
-            (* No broadcast — internal state transition, log_event suffices. *)
-            let updated = List.map (fun (t : Masc_domain.task) ->
-              if String.equal t.id prev.id then { t with task_status = Todo }
-              else t
-            ) backlog.tasks in
-            Some prev.id, updated
-      in
+      let released_task_id, working_tasks = None, backlog.tasks in
 
       (* Starvation prevention: Calculate effective priority
          Tasks waiting >24h get priority boost (-1 per 24h, min 1) *)
@@ -556,8 +544,8 @@ let claim_next_r
         | [] -> eligible_from soft_unclaimed
       in
 
-      (* Helper: clear agent current_task and reset status after auto-release
-         when no replacement task can be claimed.  Delegates to
+      (* Helper: clear agent current_task and reset status after a legacy
+         released_task_id path when no replacement task can be claimed. Delegates to
          [Coord_task.update_local_agent_state] so the agent-file write
          holds [with_file_lock] on the agent file itself, matching the
          discipline used by [Coord_task] transitions (PR #6634). *)
@@ -581,7 +569,7 @@ let claim_next_r
                  version = backlog.version + 1;
                } in
                write_backlog config new_backlog;
-               observe_auto_release ()
+               observe_legacy_release ()
            | None -> ());
           clear_agent_state_after_release ();
           Claim_next_no_unclaimed
@@ -594,7 +582,7 @@ let claim_next_r
                  version = backlog.version + 1;
                } in
                write_backlog config new_backlog;
-               observe_auto_release ()
+               observe_legacy_release ()
            | None -> ());
           clear_agent_state_after_release ();
           Claim_next_no_eligible
@@ -638,7 +626,7 @@ let claim_next_r
                Coord_task.emit_task_activity config ~agent_name ~task_id:rid
                  ~kind:(Event_kind.Task.to_string Event_kind.Task.Released)
                  ~payload:(`Assoc [ ("task_id", `String rid) ]);
-               observe_auto_release ()
+               observe_legacy_release ()
            | None -> ());
           Coord_task.emit_task_activity config ~agent_name ~task_id:task.id
             ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
@@ -668,7 +656,7 @@ let claim_next_r
 
           let message = match released_task_id with
             | Some rid ->
-                Printf.sprintf "%s auto-released %s, then claimed [P%d] %s: %s"
+                Printf.sprintf "%s released %s, then claimed [P%d] %s: %s"
                   agent_name rid task.priority task.id task.title
             | None ->
                 Printf.sprintf "%s auto-claimed [P%d] %s: %s"
@@ -682,6 +670,7 @@ let claim_next_r
             message;
           }
     with
+    | Existing_claim result -> result
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
       Claim_next_error (Printexc.to_string e)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -308,8 +308,8 @@ let is_main_worktree_boundary_exempt_with_input
 
     [keeper_broadcast]: duplicate broadcast is noise, not data loss.
     [keeper_task_done]: completing the same task twice is a no-op.
-    [keeper_task_claim] is NOT safe: claim_next_r auto-releases a
-    previous claim and selects a new task, so retries are not idempotent.
+    [keeper_task_claim] is NOT safe: it can claim new work and alter the
+    keeper/task binding, so retries are not idempotent.
 
     Read-only tools (board_list, board_get) are excluded: they never
     appear in [committed_mutating_tools] so including them here would

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -956,7 +956,7 @@ type claim_next_result =
       task_id : string;
       title : string;
       priority : int;
-      released_task_id : string option;  (** Previous task auto-released, if any *)
+      released_task_id : string option;  (** Legacy field; claim_next no longer auto-releases active work. *)
       message : string;
     }
   | Claim_next_no_unclaimed

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -334,62 +334,66 @@ let test_claim_next_reconciles_stale_agent_current_task () =
   )
 
 (* ============================================================ *)
-(* BUG-004: claim_next auto-release Tests                        *)
+(* #10421: claim_next existing-task preservation                 *)
 (* ============================================================ *)
 
-(** BUG-004: Same agent calling claim_next twice should auto-release
-    the first task, not orphan it. *)
-let test_claim_next_auto_releases_previous () =
+(** Same agent calling claim_next twice should keep the current task bound.
+    Implicit release creates keeper hot-potato loops when a model repeats the
+    claim tool before doing the work. *)
+let test_claim_next_preserves_existing_task () =
   with_test_env (fun config ->
     let _ = Coord.add_task config ~title:"First" ~priority:1 ~description:"" in
     let _ = Coord.add_task config ~title:"Second" ~priority:2 ~description:"" in
 
-    (* First claim: agent gets task-001 *)
     let r1 = Coord.claim_next config ~agent_name:"claude" in
-    Alcotest.(check bool) "first claim ok" true (contains_check r1);
     Alcotest.(check bool) "first claim has task-001" true (str_contains r1 "task-001");
 
-    (* Second claim by same agent: should auto-release task-001, claim task-002 *)
     let r2 = Coord.claim_next config ~agent_name:"claude" in
-    (* Result should contain warning about auto-release *)
-    Alcotest.(check bool) "second claim contains warning" true (contains_warning r2);
-    Alcotest.(check bool) "mentions released task" true (str_contains r2 "task-001");
-    Alcotest.(check bool) "claims new task" true (str_contains r2 "task-002");
+    Alcotest.(check bool) "second claim keeps current task" true
+      (str_contains r2 "already holds");
+    Alcotest.(check bool) "second claim mentions task-001" true
+      (str_contains r2 "task-001");
+    Alcotest.(check bool) "second claim does not move to task-002" false
+      (str_contains r2 "task-002");
 
-    (* Verify task-001 is back to Todo (not orphaned) via raw task data *)
     let tasks = Coord.get_tasks_raw config in
     let task_001 = List.find_opt (fun (t : Masc_domain.task) -> t.id = "task-001") tasks in
+    let task_002 = List.find_opt (fun (t : Masc_domain.task) -> t.id = "task-002") tasks in
     (match task_001 with
      | Some t ->
-         Alcotest.(check string) "task-001 released to todo"
+         Alcotest.(check string) "task-001 stays claimed"
+           "claimed" (Masc_domain.task_status_to_string t.task_status)
+     | None -> Alcotest.fail "task-001 not found in backlog");
+    (match task_002 with
+     | Some t ->
+         Alcotest.(check string) "task-002 stays todo"
            "todo" (Masc_domain.task_status_to_string t.task_status)
-     | None -> Alcotest.fail "task-001 not found in backlog")
+     | None -> Alcotest.fail "task-002 not found in backlog")
   )
 
-(** BUG-004: After auto-release, the released task is claimable by others. *)
-let test_claim_next_released_task_claimable_by_others () =
+(** A repeated claim by the owner must not make the current task claimable by
+    other agents. Peers should move to the next Todo task. *)
+let test_claim_next_preserved_task_not_claimable_by_others () =
   with_test_env (fun config ->
     let _ = Coord.add_task config ~title:"Task A" ~priority:1 ~description:"" in
     let _ = Coord.add_task config ~title:"Task B" ~priority:2 ~description:"" in
 
-    (* Claude claims task-001 *)
     let _ = Coord.claim_next config ~agent_name:"claude" in
-    (* Claude claims again, auto-releasing task-001 *)
     let _ = Coord.claim_next config ~agent_name:"claude" in
 
-    (* Gemini should be able to claim the released task-001 *)
     let r = Coord.claim_next config ~agent_name:"gemini" in
-    Alcotest.(check bool) "gemini can claim released task" true (contains_check r);
-    Alcotest.(check bool) "gemini gets task-001" true (str_contains r "task-001")
+    Alcotest.(check bool) "gemini does not get preserved task" false
+      (str_contains r "task-001");
+    Alcotest.(check bool) "gemini gets task-002" true (str_contains r "task-002")
   )
 
-(** BUG-004: claim_next_r returns released_task_id in structured result. *)
-let test_claim_next_r_released_task_field () =
+(** claim_next_r keeps the legacy released_task_id field but no longer sets it
+    for repeated owner calls. *)
+let test_claim_next_r_preserved_task_field () =
   with_test_env (fun config ->
     let _ = Coord.add_task config ~title:"Alpha" ~priority:1 ~description:"" in
     let _ = Coord.add_task config ~title:"Beta" ~priority:2 ~description:"" in
 
-    (* First claim: no previous task to release *)
     let r1 = Coord.claim_next_r config ~agent_name:"claude" () in
     (match r1 with
      | Coord.Claim_next_claimed { released_task_id = None; task_id; _ } ->
@@ -398,14 +402,14 @@ let test_claim_next_r_released_task_field () =
          Alcotest.fail "first claim should not release anything"
      | _ -> Alcotest.fail "first claim should succeed");
 
-    (* Second claim: should release task-001 *)
     let r2 = Coord.claim_next_r config ~agent_name:"claude" () in
     (match r2 with
-     | Coord.Claim_next_claimed { released_task_id = Some rid; task_id; _ } ->
-         Alcotest.(check string) "released task-001" "task-001" rid;
-         Alcotest.(check string) "claimed task-002" "task-002" task_id
-     | Coord.Claim_next_claimed { released_task_id = None; _ } ->
-         Alcotest.fail "second claim should report released task"
+     | Coord.Claim_next_claimed { released_task_id = None; task_id; message; _ } ->
+         Alcotest.(check string) "still task-001" "task-001" task_id;
+         Alcotest.(check bool) "message says already holds" true
+           (str_contains message "already holds")
+     | Coord.Claim_next_claimed { released_task_id = Some _; _ } ->
+         Alcotest.fail "second claim should not report a released task"
      | _ -> Alcotest.fail "second claim should succeed")
   )
 
@@ -1115,7 +1119,7 @@ let test_transition_done_from_claimed_emits_observability () =
              ("task_id", "task-001");
            ]))
 
-let test_claim_next_auto_release_emits_release_observability () =
+let test_claim_next_existing_task_does_not_emit_release_observability () =
   with_test_env (fun config ->
     let before_seq = latest_ring_seq () in
     let claude = find_agent_name_by_prefix config "claude" in
@@ -1126,13 +1130,14 @@ let test_claim_next_auto_release_emits_release_observability () =
     | Coord.Claim_next_claimed _ -> ()
     | _ -> Alcotest.fail "expected first claim_next_r to succeed");
     (match Coord.claim_next_r config ~agent_name:claude () with
-    | Coord.Claim_next_claimed { released_task_id = Some released; task_id; _ } ->
-        Alcotest.(check string) "released task id" "task-001" released;
-        Alcotest.(check string) "new task id" "task-002" task_id
-    | _ -> Alcotest.fail "expected auto-release on second claim_next_r");
+    | Coord.Claim_next_claimed { released_task_id = None; task_id; _ } ->
+        Alcotest.(check string) "keeps task id" "task-001" task_id
+    | Coord.Claim_next_claimed { released_task_id = Some _; _ } ->
+        Alcotest.fail "second claim_next_r should not auto-release"
+    | _ -> Alcotest.fail "expected existing task on second claim_next_r");
 
     let audit_entries = Audit_log.read_entries ~n:50 config in
-    Alcotest.(check bool) "audit release recorded" true
+    Alcotest.(check bool) "audit release not recorded" false
       (audit_has_entry audit_entries ~agent_id:claude
          ~action_pred:(function Audit_log.ReleaseTask -> true | _ -> false)
          ~details:
@@ -1145,7 +1150,7 @@ let test_claim_next_auto_release_emits_release_observability () =
     let ring_entries =
       Log.Ring.recent ~limit:50 ~module_filter:"Task" ~since_seq:before_seq ()
     in
-    Alcotest.(check bool) "ring release recorded" true
+    Alcotest.(check bool) "ring release not recorded" false
       (ring_has_entry ring_entries
          ~details:
            [
@@ -1456,9 +1461,12 @@ let () =
       Alcotest.test_case "consecutive" `Quick test_claim_next_consecutive;
       Alcotest.test_case "reconciles stale current_task" `Quick
         test_claim_next_reconciles_stale_agent_current_task;
-      Alcotest.test_case "BUG-004: auto-releases previous" `Quick test_claim_next_auto_releases_previous;
-      Alcotest.test_case "BUG-004: released task claimable" `Quick test_claim_next_released_task_claimable_by_others;
-      Alcotest.test_case "BUG-004: released_task_id field" `Quick test_claim_next_r_released_task_field;
+      Alcotest.test_case "#10421: preserves existing task" `Quick
+        test_claim_next_preserves_existing_task;
+      Alcotest.test_case "#10421: preserved task not claimable" `Quick
+        test_claim_next_preserved_task_not_claimable_by_others;
+      Alcotest.test_case "#10421: preserved task result field" `Quick
+        test_claim_next_r_preserved_task_field;
       Alcotest.test_case "release hard-stop blocks future claim_next" `Quick
         test_release_hard_stop_blocks_future_claim_next;
       Alcotest.test_case "release hard-stop blocks direct reclaim" `Quick
@@ -1514,8 +1522,8 @@ let () =
         test_task_transitions_emit_observability;
       Alcotest.test_case "claimed done fan-out" `Quick
         test_transition_done_from_claimed_emits_observability;
-      Alcotest.test_case "claim_next auto-release fan-out" `Quick
-        test_claim_next_auto_release_emits_release_observability;
+      Alcotest.test_case "claim_next existing task no release fan-out" `Quick
+        test_claim_next_existing_task_does_not_emit_release_observability;
     ];
 
     (* === Pause/Resume === *)


### PR DESCRIPTION
## Summary
- stop `claim_next_r` from implicitly releasing an existing Claimed/InProgress task held by the same agent
- return the existing task with a resume-now instruction instead of moving work back to Todo
- update #10421 regression coverage so repeated keeper_task_claim cannot hot-potato active work to another keeper

## Why this matters
Live keeper logs showed `task_claim_next auto-released prev claim` while a keeper already held task-185, immediately allowing another keeper to claim the same work. That makes keepers spin on claim/release reactions instead of entering the implementation loop.

## Verification
- `git diff --check`
- `scripts/dune-local.sh build test/test_room_coverage.exe`
- `./_build/default/test/test_room_coverage.exe test claim_next 8-10`
- `./_build/default/test/test_room_coverage.exe test observability 3`

Note: full `test_room_coverage.exe` still has unrelated pre-existing failures in batch/update_priority/observability/result_variants/archive cases; focused #10421 coverage is green.