### PR TITLE
feat(board): embed reaction previews

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -445,6 +445,14 @@ describe('fetchBoard', () => {
           updated_at: 1_713_000_000,
           current_vote: 'up',
           has_voted: true,
+          reactions: [
+            {
+              emoji: '🔥',
+              count: 2,
+              reacted: true,
+              recent_user_ids: ['analyst', 'reviewer'],
+            },
+          ],
           author_identity: {
             kind: 'keeper',
             id: 'analyst',
@@ -470,6 +478,15 @@ describe('fetchBoard', () => {
     expect(result.posts[0]).toMatchObject({
       current_vote: 'up',
       has_voted: true,
+      reactions: [
+        {
+          emoji: '🔥',
+          count: 2,
+          reacted: true,
+          has_reacted: true,
+          recent_user_ids: ['analyst', 'reviewer'],
+        },
+      ],
     })
     expect(result.posts[0]?.author_identity).toMatchObject({
       kind: 'keeper',
@@ -536,6 +553,14 @@ describe('fetchBoardPost', () => {
         updated_at: 1_713_000_000,
         current_vote: 'down',
         has_voted: true,
+        reactions: [
+          {
+            emoji: '👍',
+            count: 1,
+            has_reacted: false,
+            recent_user_ids: ['reader-a'],
+          },
+        ],
       },
       comments: [
         {
@@ -549,6 +574,14 @@ describe('fetchBoardPost', () => {
           score: 3,
           current_vote: 'up',
           has_voted: true,
+          reactions: [
+            {
+              emoji: '🚀',
+              count: 4,
+              reacted: true,
+              recent_user_ids: ['reviewer'],
+            },
+          ],
         },
       ],
     }
@@ -570,8 +603,26 @@ describe('fetchBoardPost', () => {
       votes_down: 2,
       current_vote: 'up',
       has_voted: true,
+      reactions: [
+        {
+          emoji: '🚀',
+          count: 4,
+          reacted: true,
+          has_reacted: true,
+          recent_user_ids: ['reviewer'],
+        },
+      ],
     })
     expect(result.current_vote).toBe('down')
+    expect(result.reactions).toEqual([
+      {
+        emoji: '👍',
+        count: 1,
+        reacted: false,
+        has_reacted: false,
+        recent_user_ids: ['reader-a'],
+      },
+    ])
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('format=flat')
     expect(url).toContain('voter=')

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -371,6 +371,11 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
   const tags = Array.isArray(raw.tags)
     ? raw.tags.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
     : []
+  const reactions = Array.isArray(raw.reactions)
+    ? raw.reactions
+        .map(normalizeBoardReactionSummary)
+        .filter((row): row is BoardReactionSummary => row !== null)
+    : undefined
 
   return {
     id,
@@ -405,6 +410,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
         : '')
       || null,
     hearth_count: asNumber(raw.hearth_count, 0),
+    ...(reactions !== undefined ? { reactions } : {}),
   }
 }
 
@@ -421,6 +427,11 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
   const votes = asNumber(raw.votes, score)
   const currentVote = normalizeBoardVoteDirection(raw.current_vote)
   const hasVoted = typeof raw.has_voted === 'boolean' ? raw.has_voted : currentVote !== null
+  const reactions = Array.isArray(raw.reactions)
+    ? raw.reactions
+        .map(normalizeBoardReactionSummary)
+        .filter((row): row is BoardReactionSummary => row !== null)
+    : undefined
   return {
     id,
     post_id: postId,
@@ -435,6 +446,7 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     votes_down: votesDown,
     current_vote: currentVote,
     has_voted: hasVoted,
+    ...(reactions !== undefined ? { reactions } : {}),
   }
 }
 

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -198,6 +198,28 @@ describe('BoardSurface Component', () => {
     expect(screen.getByRole('link', { name: 'ani1999' })).toHaveAttribute('href')
   })
 
+  it('renders embedded reaction summaries on post cards', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-reacted',
+        title: 'Reaction preview',
+        body: 'content',
+        author: 'ani1999',
+        reactions: [{
+          emoji: '🔥',
+          count: 2,
+          reacted: true,
+          has_reacted: true,
+          recent_user_ids: ['ani1999'],
+        }],
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByRole('button', { name: '🔥 리액션 2개' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
   it('hides system posts by default', () => {
     boardPosts.value = [
       makePost({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -16,6 +16,7 @@ import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
 import { registerBoardHearthsRefresh } from '../../sse-store'
 import { PostDetail } from './post-detail'
+import { ReactionBar } from './reaction-bar'
 import {
   boardActorAvatarKey,
   boardActorDisplayName,
@@ -507,6 +508,7 @@ function PostCard({ post }: { post: BoardPost }) {
   const authorTitle = boardActorTitle(post.author, post.author_identity)
   const upvoteActive = post.current_vote === 'up'
   const downvoteActive = post.current_vote === 'down'
+  const reactionPreview = post.reactions?.some(summary => summary.count > 0 || summary.reacted || summary.has_reacted)
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
     event.stopPropagation()
@@ -636,6 +638,20 @@ function PostCard({ post }: { post: BoardPost }) {
             ${isDeleting ? '삭제 중...' : '삭제'}
           <//>
         </div>
+        ${reactionPreview ? html`
+          <div
+            class="mt-2"
+            onClick=${(event: Event) => event.stopPropagation()}
+            onKeyDown=${(event: KeyboardEvent) => event.stopPropagation()}
+          >
+            <${ReactionBar}
+              targetType="post"
+              targetId=${post.id}
+              compact
+              initialSummaries=${post.reactions}
+            />
+          </div>
+        ` : null}
       </div>
     </article>
   `

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -274,7 +274,7 @@ function CommentItem({
           >${expanded ? '접기' : '더 보기...'}<//>
         ` : null}
         <div class="mt-2">
-          <${ReactionBar} targetType="comment" targetId=${comment.id} compact />
+          <${ReactionBar} targetType="comment" targetId=${comment.id} compact initialSummaries=${comment.reactions} />
         </div>
         ${isReplying ? html`
           <div class="mt-2">
@@ -521,7 +521,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
             >▼ 비추천<//>
           </div>
 
-          <${ReactionBar} targetType="post" targetId=${post.id} />
+          <${ReactionBar} targetType="post" targetId=${post.id} initialSummaries=${post.reactions} />
         </div>
       <//>
 

--- a/dashboard/src/components/board/reaction-bar.test.ts
+++ b/dashboard/src/components/board/reaction-bar.test.ts
@@ -27,6 +27,24 @@ describe('ReactionBar', () => {
     }
   })
 
+  it('uses embedded initial summaries without an initial fetch', async () => {
+    render(h(ReactionBar, {
+      targetType: 'post',
+      targetId: 'post-1',
+      initialSummaries: [{
+        emoji: '👏',
+        count: 5,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['agent-a'],
+      }],
+    }))
+
+    expect(screen.getByRole('button', { name: '👏 리액션 5개' })).toHaveAttribute('aria-pressed', 'true')
+    await Promise.resolve()
+    expect(fetchBoardReactions).not.toHaveBeenCalled()
+  })
+
   it('refreshes summaries only when a matching reaction_changed event arrives', async () => {
     vi.mocked(fetchBoardReactions)
       .mockResolvedValueOnce([])

--- a/dashboard/src/components/board/reaction-bar.ts
+++ b/dashboard/src/components/board/reaction-bar.ts
@@ -11,13 +11,20 @@ export function ReactionBar({
   targetType,
   targetId,
   compact = false,
+  initialSummaries,
 }: {
   targetType: BoardReactionTargetType
   targetId: string
   compact?: boolean
+  initialSummaries?: BoardReactionSummary[]
 }) {
-  const [summaries, setSummaries] = useState<BoardReactionSummary[]>([])
+  const hasInitialSummaries = initialSummaries !== undefined
+  const [summaries, setSummaries] = useState<BoardReactionSummary[]>(() => initialSummaries ?? [])
   const [busyEmoji, setBusyEmoji] = useState<string | null>(null)
+
+  useEffect(() => {
+    setSummaries(initialSummaries ?? [])
+  }, [targetType, targetId, initialSummaries])
 
   useEffect(() => {
     let cancelled = false
@@ -32,7 +39,7 @@ export function ReactionBar({
           }
         })
     }
-    refresh()
+    if (!hasInitialSummaries) refresh()
     const unsubscribe = lastEvent.subscribe(event => {
       if (event?.type !== 'reaction_changed') return
       if (event.target_type === targetType && event.target_id === targetId) {
@@ -43,7 +50,7 @@ export function ReactionBar({
       cancelled = true
       unsubscribe()
     }
-  }, [targetType, targetId])
+  }, [targetType, targetId, hasInitialSummaries])
 
   const summaryByEmoji = useMemo(() => {
     const map = new Map<string, BoardReactionSummary>()

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -151,6 +151,7 @@ export interface BoardPost {
   visibility?: string
   expires_at?: string | null
   hearth_count?: number
+  reactions?: BoardReactionSummary[]
 }
 
 export interface BoardComment {
@@ -167,6 +168,7 @@ export interface BoardComment {
   votes_down?: number
   current_vote?: BoardVoteDirection | null
   has_voted?: boolean
+  reactions?: BoardReactionSummary[]
 }
 
 export type BoardReactionTargetType = 'post' | 'comment'

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -49,7 +49,9 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
         let author = Board.Agent_id.to_string p.author in
         let post_id = Board.Post_id.to_string p.id in
         let current_vote = board_current_vote_for_post ~voter ~post_id in
-        board_post_dashboard_json ?current_vote ~author_karma:(get_karma author) p
+        let reactions = board_reactions_for_post ~voter ~post_id in
+        board_post_dashboard_json ?current_vote ~reactions
+          ~author_karma:(get_karma author) p
       ) paged in
       let json = `Assoc [
         ("posts", `List posts_json);

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -229,7 +229,9 @@ let add_routes ~sw ~clock router =
                let author = Board.Agent_id.to_string p.author in
                let post_id = Board.Post_id.to_string p.id in
                let current_vote = board_current_vote_for_post ~voter ~post_id in
+               let reactions = board_reactions_for_post ~voter ~post_id in
                board_post_dashboard_json ?current_vote
+                 ~reactions
                  ~author_karma:(get_karma author) p)
              paged
          in

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -294,12 +294,14 @@ let board_post_detail_json ~voter ~response_format ~post_id =
             []
       in
       let current_vote = board_current_vote_for_post ~voter ~post_id in
-      let post_json = board_post_dashboard_json ?current_vote ~author_karma post in
+      let reactions = board_reactions_for_post ~voter ~post_id in
+      let post_json = board_post_dashboard_json ?current_vote ~reactions ~author_karma post in
       let comments_json =
         `List (List.map (fun (comment : Board.comment) ->
           let comment_id = Board.Comment_id.to_string comment.id in
           let current_vote = board_current_vote_for_comment ~voter ~comment_id in
-          board_comment_dashboard_json ?current_vote comment
+          let reactions = board_reactions_for_comment ~voter ~comment_id in
+          board_comment_dashboard_json ?current_vote ~reactions comment
         ) comments)
       in
       let json =

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -149,17 +149,45 @@ let board_vote_state_fields = function
         ("has_voted", `Bool true);
       ]
 
-let board_comment_dashboard_json ?current_vote (c : Board.comment) : Yojson.Safe.t =
+let board_reactions_for_post ~voter ~post_id =
+  match
+    Board_dispatch.list_reactions ~target_type:Board.Reaction_post
+      ~target_id:post_id ?user_id:voter ()
+  with
+  | Ok summaries -> summaries
+  | Error err ->
+      Log.Server.warn "board reactions: post %s summary failed: %s" post_id
+        (Board_types.show_board_error err);
+      []
+
+let board_reactions_for_comment ~voter ~comment_id =
+  match
+    Board_dispatch.list_reactions ~target_type:Board.Reaction_comment
+      ~target_id:comment_id ?user_id:voter ()
+  with
+  | Ok summaries -> summaries
+  | Error err ->
+      Log.Server.warn "board reactions: comment %s summary failed: %s"
+        comment_id (Board_types.show_board_error err);
+      []
+
+let board_reaction_fields = function
+  | None -> []
+  | Some summaries ->
+      [ ("reactions", `List (List.map Board.reaction_summary_to_yojson summaries)) ]
+
+let board_comment_dashboard_json ?current_vote ?reactions (c : Board.comment) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
   match Board.comment_to_yojson c with
   | `Assoc fields ->
       `Assoc
         (fields
          @ [ ("author_identity", board_actor_identity_json author) ]
-         @ board_vote_state_fields current_vote)
+         @ board_vote_state_fields current_vote
+         @ board_reaction_fields reactions)
   | other -> other
 
-let board_post_dashboard_json ?current_vote ~author_karma (p : Board.post) : Yojson.Safe.t =
+let board_post_dashboard_json ?current_vote ?reactions ~author_karma (p : Board.post) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string p.author in
   let base_fields =
     match Board_dispatch.post_to_yojson_with_karma p ~author_karma with
@@ -188,7 +216,8 @@ let board_post_dashboard_json ?current_vote ~author_karma (p : Board.post) : Yoj
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);
         ]
-      @ board_vote_state_fields current_vote )
+      @ board_vote_state_fields current_vote
+      @ board_reaction_fields reactions )
 
 let dashboard_compact_mode request =
   match query_param request "mode" with

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -153,10 +153,17 @@ val board_current_vote_for_post :
 val board_current_vote_for_comment :
   voter:string option -> comment_id:string -> Board.vote_direction option option
 
+val board_reactions_for_post :
+  voter:string option -> post_id:string -> Board.reaction_summary list
+
+val board_reactions_for_comment :
+  voter:string option -> comment_id:string -> Board.reaction_summary list
+
 (** {1 Dashboard helpers} *)
 
 val board_comment_dashboard_json :
   ?current_vote:Board.vote_direction option ->
+  ?reactions:Board.reaction_summary list ->
   Board.comment ->
   Yojson.Safe.t
 (** [board_comment_dashboard_json c] renders a comment with the
@@ -165,6 +172,7 @@ val board_comment_dashboard_json :
 
 val board_post_dashboard_json :
   ?current_vote:Board.vote_direction option ->
+  ?reactions:Board.reaction_summary list ->
   author_karma:int ->
   Board.post ->
   Yojson.Safe.t


### PR DESCRIPTION
## Summary

- Implements the Phase 1A `board-reaction-preview` gap from `/Users/dancer/Downloads/masc_sns.agent.final/masc_sns.agent.final.md`.
- Adds optional embedded `reactions` previews to `BoardPost` and `BoardComment` dashboard payloads while keeping the target summary API as the source of truth.
- Seeds `ReactionBar` from embedded summaries so list/detail views can render without an initial target-summary fetch, then still refreshes through `reaction_changed` SSE.
- Shows a compact reaction preview on board post cards and keeps card navigation isolated from reaction controls.

## Scope Notes

- This intentionally does not fold Phase 2/3 roadmap work into Phase 1A. SubBoard, karma ledger, moderation safety, and AI curation remain separate model/API slices per the artifact PR split.
- Follow-up tracking:
  - #13325 SubBoard model/API slice
  - #13327 Karma ledger contract
  - #13326 Moderation safety contract
  - #13328 AI curation readonly surface

## Verification

- `git diff --check origin/main...HEAD`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/api/board.test.ts src/components/board/reaction-bar.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1` (4 files, 110 tests)
- `scripts/dune-local.sh build bin/main_eio.exe test/test_board_dispatch.exe`
- `./_build/default/test/test_board_dispatch.exe` (38 tests)
