### PR TITLE
fix(dashboard): surface IDE persistence map

### DIFF
--- a/dashboard/src/components/common/memory-graph.ts
+++ b/dashboard/src/components/common/memory-graph.ts
@@ -22,29 +22,39 @@ interface MemoryGraphProps {
   nodes: MemoryNode[]
   edges: MemoryEdge[]
   onSelectNode?: (id: string) => void
+  width?: number
+  height?: number
+  ariaLabel?: string
   testId?: string
 }
 
-export function MemoryGraph({ nodes, edges, onSelectNode, testId }: MemoryGraphProps) {
+export function MemoryGraph({
+  nodes,
+  edges,
+  onSelectNode,
+  width = 400,
+  height = 300,
+  ariaLabel = '메모리 그래프',
+  testId,
+}: MemoryGraphProps) {
   if (nodes.length === 0) {
     return html`
       <div
         data-testid=${testId}
         class="flex h-48 items-center justify-center text-xs text-[var(--color-fg-muted)]"
         role="img"
-        aria-label="메모리 그래프"
+        aria-label=${ariaLabel}
+        style=${{ height: `${height}px` }}
       >
         노드가 없습니다.
       </div>
     `
   }
 
-  const width = 400
-  const height = 300
   const nodeMap = new Map(nodes.map((n) => [n.id, n]))
 
   return html`
-    <figure data-testid=${testId} class="w-full overflow-auto" aria-label="메모리 그래프">
+    <figure data-testid=${testId} class="w-full overflow-auto" aria-label=${ariaLabel}>
       <svg
         viewBox="0 0 ${width} ${height}"
         class="w-full h-auto"

--- a/dashboard/src/components/ide/ide-persistence-panel.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.a11y.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { cleanup, render, waitFor } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchKeeperStateDiagram,
+  type KeeperStateDiagramResponse,
+} from '../../api/keeper'
+import { activeKeeperName } from '../../keeper-state'
+import { keepers } from '../../store'
+import { IdePersistencePanel } from './ide-persistence-panel'
+
+vi.mock('../../api/keeper', async () => {
+  const actual = await vi.importActual<typeof import('../../api/keeper')>('../../api/keeper')
+  return {
+    ...actual,
+    fetchKeeperStateDiagram: vi.fn(),
+  }
+})
+
+const fetchKeeperStateDiagramMock = vi.mocked(fetchKeeperStateDiagram)
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  activeKeeperName.value = ''
+  keepers.value = []
+})
+
+describe('IdePersistencePanel a11y', () => {
+  it('has no axe violations for lifecycle and memory graph content', async () => {
+    activeKeeperName.value = 'sangsu'
+    keepers.value = [{
+      name: 'sangsu',
+      status: 'online',
+      phase: 'Running',
+      last_heartbeat: '2026-05-06T00:00:00Z',
+    }]
+    fetchKeeperStateDiagramMock.mockResolvedValue({
+      keeper: 'sangsu',
+      current_phase: 'Running',
+      mermaid: 'graph TD',
+      memory_kind_usage: [
+        { kind: 'tool_result', used: 8, cap: 10, priority: 1 },
+        { kind: 'semantic_note', used: 3, cap: 12, priority: 2 },
+      ],
+    } satisfies KeeperStateDiagramResponse)
+
+    const { container, findByTestId } = render(html`<${IdePersistencePanel} pollMs=${60_000} />`)
+    await findByTestId('ide-memory-graph')
+    await waitFor(() => expect(fetchKeeperStateDiagramMock).toHaveBeenCalled())
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/ide/ide-persistence-panel.test.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchKeeperStateDiagram,
+  type KeeperStateDiagramResponse,
+  type MemoryKindUsageEntry,
+} from '../../api/keeper'
+import { activeKeeperName } from '../../keeper-state'
+import { keepers } from '../../store'
+import {
+  buildMemoryGraphModel,
+  IdePersistencePanel,
+  lifecycleStateFromKeeperPhase,
+  persistenceStateFromKeeperPhase,
+} from './ide-persistence-panel'
+
+vi.mock('../../api/keeper', async () => {
+  const actual = await vi.importActual<typeof import('../../api/keeper')>('../../api/keeper')
+  return {
+    ...actual,
+    fetchKeeperStateDiagram: vi.fn(),
+  }
+})
+
+const fetchKeeperStateDiagramMock = vi.mocked(fetchKeeperStateDiagram)
+
+const usage: MemoryKindUsageEntry[] = [
+  { kind: 'tool_result', used: 10, cap: 10, priority: 1 },
+  { kind: 'semantic_note', used: 3, cap: 12, priority: 2 },
+  { kind: 'turn_summary', used: 7, cap: 20, priority: 3 },
+]
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  activeKeeperName.value = ''
+  keepers.value = []
+})
+
+describe('ide persistence helpers', () => {
+  it('maps keeper phases to lifecycle states', () => {
+    expect(lifecycleStateFromKeeperPhase(null)).toBe('created')
+    expect(lifecycleStateFromKeeperPhase('Running')).toBe('active')
+    expect(lifecycleStateFromKeeperPhase('Paused')).toBe('idle')
+    expect(lifecycleStateFromKeeperPhase('Crashed')).toBe('terminated')
+  })
+
+  it('maps keeper phases to persistence states', () => {
+    expect(persistenceStateFromKeeperPhase('Running')).toBe('saved')
+    expect(persistenceStateFromKeeperPhase('Compacting')).toBe('syncing')
+    expect(persistenceStateFromKeeperPhase('Overflowed')).toBe('conflict')
+    expect(persistenceStateFromKeeperPhase('Offline')).toBe('offline')
+    expect(persistenceStateFromKeeperPhase('Running', true)).toBe('offline')
+  })
+
+  it('builds a keeper-centered memory graph from memory usage rows', () => {
+    const graph = buildMemoryGraphModel('sangsu', usage)
+    expect(graph.nodes.map(node => node.id)).toEqual([
+      'keeper',
+      'memory-tool_result',
+      'memory-turn_summary',
+      'memory-semantic_note',
+    ])
+    expect(graph.edges).toHaveLength(3)
+    expect(graph.totalUsed).toBe(20)
+    expect(graph.totalCap).toBe(42)
+    expect(graph.saturatedCount).toBe(1)
+  })
+})
+
+describe('IdePersistencePanel', () => {
+  it('renders active keeper lifecycle and memory graph from the state diagram endpoint', async () => {
+    activeKeeperName.value = 'sangsu'
+    keepers.value = [{
+      name: 'sangsu',
+      status: 'online',
+      phase: 'Running',
+      last_heartbeat: '2026-05-06T00:00:00Z',
+      memory_recent_note: 'kept the workspace root on main',
+    }]
+    fetchKeeperStateDiagramMock.mockResolvedValue({
+      keeper: 'sangsu',
+      current_phase: 'Compacting',
+      mermaid: 'graph TD',
+      memory_kind_usage: usage,
+    } satisfies KeeperStateDiagramResponse)
+
+    render(html`<${IdePersistencePanel} pollMs=${60_000} />`)
+
+    await waitFor(() => expect(fetchKeeperStateDiagramMock).toHaveBeenCalledWith(
+      'sangsu',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    ))
+
+    expect(screen.getByText('PERSISTENCE MAP')).toBeTruthy()
+    expect(screen.getByText('MEMORY GRAPH')).toBeTruthy()
+    expect(screen.getByTestId('ide-persistence-lifecycle')).toBeTruthy()
+    expect(screen.getByTestId('ide-memory-graph')).toBeTruthy()
+    expect(screen.getByText(/tool_result/)).toBeTruthy()
+    expect(screen.getByText('kept the workspace root on main')).toBeTruthy()
+  })
+
+  it('falls back to the explicit keeper name when no active keeper is selected', async () => {
+    fetchKeeperStateDiagramMock.mockResolvedValue({
+      keeper: 'keeper-2',
+      current_phase: 'Running',
+      mermaid: 'graph TD',
+      memory_kind_usage: [],
+    } satisfies KeeperStateDiagramResponse)
+
+    render(html`<${IdePersistencePanel} keeperName="keeper-2" pollMs=${60_000} />`)
+
+    await waitFor(() => expect(fetchKeeperStateDiagramMock).toHaveBeenCalledWith(
+      'keeper-2',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    ))
+    expect(screen.getByText('keeper-2')).toBeTruthy()
+    expect(screen.getByText('memory bank data unavailable')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/ide/ide-persistence-panel.ts
+++ b/dashboard/src/components/ide/ide-persistence-panel.ts
@@ -1,0 +1,384 @@
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+
+import {
+  fetchKeeperStateDiagram,
+  type KeeperStateDiagramResponse,
+  type MemoryKindUsageEntry,
+} from '../../api/keeper'
+import { activeKeeperName } from '../../keeper-state'
+import { keepers } from '../../store'
+import type { Keeper } from '../../types'
+import { MemoryGraph } from '../common/memory-graph'
+import { PersistenceStatus, type PersistenceState } from '../common/persistence-status'
+
+const REFRESH_MS = 30_000
+
+type LifecycleState = 'created' | 'active' | 'idle' | 'terminated'
+
+interface GraphNode {
+  id: string
+  label: string
+  x: number
+  y: number
+  color?: string
+}
+
+interface GraphEdge {
+  source: string
+  target: string
+  label?: string
+}
+
+interface MemoryGraphModel {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  visibleUsage: MemoryKindUsageEntry[]
+  totalUsed: number
+  totalCap: number
+  saturatedCount: number
+}
+
+interface IdePersistencePanelProps {
+  keeperName?: string
+  pollMs?: number
+}
+
+const LIFECYCLE_STEPS: ReadonlyArray<{ state: LifecycleState; label: string }> = [
+  { state: 'created', label: 'CREATED' },
+  { state: 'active', label: 'ACTIVE' },
+  { state: 'idle', label: 'IDLE' },
+  { state: 'terminated', label: 'DONE' },
+]
+
+function normalizePhase(phase: string | null | undefined): string {
+  return phase?.trim().toLowerCase() ?? ''
+}
+
+export function lifecycleStateFromKeeperPhase(phase: string | null | undefined): LifecycleState {
+  switch (normalizePhase(phase)) {
+    case '':
+      return 'created'
+    case 'offline':
+    case 'stopped':
+    case 'crashed':
+    case 'dead':
+    case 'zombie':
+    case 'terminated':
+      return 'terminated'
+    case 'idle':
+    case 'paused':
+    case 'stable':
+      return 'idle'
+    default:
+      return 'active'
+  }
+}
+
+export function persistenceStateFromKeeperPhase(
+  phase: string | null | undefined,
+  hasFetchError = false,
+): PersistenceState {
+  if (hasFetchError) return 'offline'
+  switch (normalizePhase(phase)) {
+    case 'failing':
+    case 'overflowed':
+    case 'crashed':
+    case 'zombie':
+      return 'conflict'
+    case 'compacting':
+    case 'handoffing':
+    case 'handingoff':
+    case 'draining':
+    case 'restarting':
+      return 'syncing'
+    case '':
+    case 'offline':
+    case 'stopped':
+    case 'dead':
+      return 'offline'
+    default:
+      return 'saved'
+  }
+}
+
+export function buildMemoryGraphModel(
+  keeperName: string,
+  usage: readonly MemoryKindUsageEntry[],
+): MemoryGraphModel {
+  const visibleUsage = [...usage]
+    .sort((left, right) => right.used - left.used || left.kind.localeCompare(right.kind))
+    .slice(0, 3)
+  const totalUsed = usage.reduce((sum, row) => sum + row.used, 0)
+  const totalCap = usage.reduce((sum, row) => sum + row.cap, 0)
+  const saturatedCount = usage.filter(row => row.cap > 0 && row.used >= row.cap).length
+
+  if (!keeperName.trim()) {
+    return { nodes: [], edges: [], visibleUsage, totalUsed, totalCap, saturatedCount }
+  }
+
+  const positions = [
+    { x: 170, y: 12 },
+    { x: 86, y: 44 },
+    { x: 254, y: 44 },
+  ]
+
+  const nodes: GraphNode[] = [
+    {
+      id: 'keeper',
+      label: keeperName,
+      x: 170,
+      y: 36,
+      color: 'var(--color-bg-elevated)',
+    },
+    ...visibleUsage.map((row, index) => {
+      const saturated = row.cap > 0 && row.used >= row.cap
+      return {
+        id: `memory-${row.kind}`,
+        label: row.kind,
+        x: positions[index]?.x ?? 170,
+        y: positions[index]?.y ?? 92,
+        color: saturated
+          ? 'var(--color-status-warn-bg, var(--warn-20))'
+          : 'var(--color-accent-bg, var(--color-bg-surface))',
+      }
+    }),
+  ]
+  const edges = visibleUsage.map(row => ({
+    source: 'keeper',
+    target: `memory-${row.kind}`,
+    label: `${row.used}/${row.cap}`,
+  }))
+
+  return { nodes, edges, visibleUsage, totalUsed, totalCap, saturatedCount }
+}
+
+function useSignalValue<T>(signal: { value: T; subscribe: (fn: (value: T) => void) => () => void }): T {
+  const [value, setValue] = useState(signal.value)
+  useEffect(() => signal.subscribe(next => setValue(next)), [signal])
+  return value
+}
+
+function resolveKeeperName(explicit: string | undefined, active: string, rows: readonly Keeper[]): string {
+  const fromProp = explicit?.trim()
+  if (fromProp) return fromProp
+  const fromActive = active.trim()
+  if (fromActive) return fromActive
+  return rows[0]?.name?.trim() ?? ''
+}
+
+function findKeeper(rows: readonly Keeper[], name: string): Keeper | null {
+  const needle = name.trim().toLowerCase()
+  if (!needle) return null
+  return rows.find(row => row.name.trim().toLowerCase() === needle) ?? null
+}
+
+function LifecycleMini({ state, phase }: { state: LifecycleState; phase: string | null }) {
+  return html`
+    <div
+      role="region"
+      aria-label="Keeper lifecycle"
+      data-testid="ide-persistence-lifecycle"
+      style=${{
+        display: 'grid',
+        gap: 'var(--sp-2)',
+        border: '1px solid var(--color-border-default)',
+        borderRadius: 'var(--r-2)',
+        background: 'var(--color-bg-page)',
+        padding: 'var(--sp-1) var(--sp-2)',
+      }}
+    >
+      <div style=${{ display: 'flex', justifyContent: 'space-between', gap: 'var(--sp-2)', font: 'var(--type-eyebrow)', color: 'var(--color-fg-muted)' }}>
+        <span>LIFECYCLE</span>
+        <span style=${{ color: 'var(--color-fg-secondary)' }}>${phase ?? 'unknown'}</span>
+      </div>
+      <div
+        role="list"
+        aria-label="Lifecycle states"
+        style=${{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: '4px' }}
+      >
+        ${LIFECYCLE_STEPS.map(step => {
+          const current = step.state === state
+          return html`
+            <div
+              key=${step.state}
+              role="listitem"
+              aria-current=${current ? 'step' : undefined}
+              style=${{
+                display: 'grid',
+                gap: '4px',
+                justifyItems: 'center',
+                minWidth: 0,
+                color: current ? 'var(--color-accent-fg)' : 'var(--color-fg-muted)',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style=${{
+                  width: '10px',
+                  height: '10px',
+                  borderRadius: '999px',
+                  border: `1px solid ${current ? 'var(--color-accent-fg)' : 'var(--color-border-default)'}`,
+                  background: current ? 'var(--color-accent-fg)' : 'var(--color-bg-elevated)',
+                  boxShadow: current ? '0 0 0 3px color-mix(in srgb, var(--color-accent-fg) 18%, transparent)' : 'none',
+                }}
+              />
+              <span style=${{ maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 'var(--fs-10)', fontFamily: 'var(--font-mono)' }}>
+                ${step.label}
+              </span>
+            </div>
+          `
+        })}
+      </div>
+    </div>
+  `
+}
+
+export function IdePersistencePanel({
+  keeperName: explicitKeeperName,
+  pollMs = REFRESH_MS,
+}: IdePersistencePanelProps) {
+  const activeName = useSignalValue(activeKeeperName)
+  const keeperRows = useSignalValue(keepers)
+  const keeperName = resolveKeeperName(explicitKeeperName, activeName, keeperRows)
+  const keeper = findKeeper(keeperRows, keeperName)
+  const [diagram, setDiagram] = useState<KeeperStateDiagramResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const name = keeperName.trim()
+    if (!name) {
+      setDiagram(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    let timer: number | null = null
+
+    const refresh = async () => {
+      setLoading(true)
+      try {
+        const next = await fetchKeeperStateDiagram(name, { signal: controller.signal })
+        if (controller.signal.aborted) return
+        setDiagram(next)
+        setError(null)
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setDiagram(null)
+          setError(err instanceof Error ? err.message : 'state diagram unavailable')
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }
+
+    void refresh()
+    timer = window.setInterval(refresh, Math.max(5000, pollMs))
+    return () => {
+      controller.abort()
+      if (timer !== null) window.clearInterval(timer)
+    }
+  }, [keeperName, pollMs])
+
+  const phase = diagram?.current_phase ?? keeper?.phase ?? null
+  const lifecycleState = lifecycleStateFromKeeperPhase(phase)
+  const persistenceState = persistenceStateFromKeeperPhase(phase, error !== null)
+  const usage = diagram?.memory_kind_usage ?? []
+  const graph = useMemo(() => buildMemoryGraphModel(keeperName, usage), [keeperName, usage])
+  const lastSaved = keeper?.last_heartbeat ?? keeper?.updated_at ?? keeper?.created_at ?? null
+
+  return html`
+    <section
+      aria-label="PERSISTENCE MAP"
+      data-testid="ide-persistence-panel"
+      style=${{
+        display: 'grid',
+        gap: 'var(--sp-3)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        background: 'var(--color-bg-surface)',
+      }}
+    >
+      <header style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)' }}>
+        <h3 style=${{ margin: 0, font: 'var(--type-eyebrow)', color: 'var(--color-fg-primary)' }}>
+          PERSISTENCE MAP
+        </h3>
+        <span style=${{ color: 'var(--color-accent-fg)', fontSize: 'var(--fs-12)' }}>
+          ${keeperName || '—'}
+        </span>
+        <span style=${{ marginLeft: 'auto' }}>
+          <${PersistenceStatus} status=${persistenceState} lastSaved=${lastSaved} />
+        </span>
+      </header>
+
+      ${error
+        ? html`<div role="status" style=${{ color: 'var(--color-status-warn)', fontSize: 'var(--fs-12)' }}>${error}</div>`
+        : null}
+
+      ${keeperName
+        ? html`
+          <div style=${{ display: 'grid', gap: 'var(--sp-2)' }}>
+            <${LifecycleMini} state=${lifecycleState} phase=${phase} />
+
+            <div
+              style=${{
+                display: 'grid',
+                gap: 'var(--sp-2)',
+                border: '1px solid var(--color-border-default)',
+                borderRadius: 'var(--r-2)',
+                background: 'var(--color-bg-page)',
+                padding: 'var(--sp-1) var(--sp-2)',
+              }}
+            >
+              <div style=${{ display: 'flex', justifyContent: 'space-between', gap: 'var(--sp-2)', font: 'var(--type-eyebrow)', color: 'var(--color-fg-muted)' }}>
+                <span>MEMORY GRAPH</span>
+                <span>${loading && usage.length === 0 ? 'loading' : `${graph.totalUsed}/${graph.totalCap || 0} · ${graph.saturatedCount} saturated`}</span>
+              </div>
+              <${MemoryGraph}
+                nodes=${graph.nodes}
+                edges=${graph.edges}
+                width=${340}
+                height=${64}
+                ariaLabel="IDE memory graph"
+                testId="ide-memory-graph"
+              />
+              <span
+                style=${{
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  color: graph.visibleUsage.length === 0 ? 'var(--color-fg-disabled)' : 'var(--color-fg-muted)',
+                  fontSize: 'var(--fs-11)',
+                }}
+                title=${graph.visibleUsage.map(row => `${row.kind} ${row.used}/${row.cap}`).join(' · ')}
+              >
+                ${graph.visibleUsage.length === 0
+                  ? 'memory bank data unavailable'
+                  : graph.visibleUsage.map(row => row.kind).join(' · ')}
+              </span>
+              ${keeper?.memory_recent_note
+                ? html`
+                  <div
+                    style=${{
+                      color: 'var(--color-fg-muted)',
+                      fontSize: 'var(--fs-11)',
+                      lineHeight: 1.35,
+                      borderTop: '1px solid var(--color-border-divider)',
+                      paddingTop: 'var(--sp-2)',
+                    }}
+                  >
+                    ${keeper.memory_recent_note}
+                  </div>
+                `
+                : null}
+            </div>
+          </div>
+        `
+        : html`<div role="status" style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-12)' }}>keeper unavailable</div>`}
+    </section>
+  `
+}

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -40,6 +40,7 @@ describe('IdeShell', () => {
     expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')
+    expect(container.textContent).toContain('PERSISTENCE MAP')
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Time')
     expect(container.textContent).toContain('Approve')

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -11,6 +11,7 @@ import { KeeperShellDrawer } from './keeper-shell-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
 import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { InspectorKeeperBDI, pinInspectorKeeper } from './inspector-keeper-bdi'
+import { IdePersistencePanel } from './ide-persistence-panel'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
@@ -145,10 +146,12 @@ export function IdeShell() {
           class="ide-plane-conversation"
           style=${{
             display: 'grid',
-            gridTemplateRows: 'auto 1fr',
+            gridTemplateRows: 'auto auto 1fr',
             minHeight: 0,
+            overflow: 'auto',
           }}
         >
+          <${IdePersistencePanel} keeperName=${terminalKeeper} />
           <${InspectorKeeperBDI} />
           <${IdeConversationRailMock} />
         </div>

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -658,6 +658,11 @@
     overflow: hidden;
   }
 
+  .ide-plane-conversation {
+    max-height: none;
+    overflow: visible;
+  }
+
   .ide-plane-editor {
     overflow: hidden;
   }


### PR DESCRIPTION
## Summary
- Add a compact IDE persistence panel for the selected keeper in the Code IDE rail.
- Map keeper phase into lifecycle/persistence states and graph top memory-bank usage from `/state-diagram`.
- Let `MemoryGraph` accept compact sizing/aria labels and keep the mobile IDE rail from clipping the new panel.

## Why it matters
The downloaded Kimi/MASC Cockpit docs already expect IDE-grade persistence/lifecycle visibility. The repo had the primitives, but the Code IDE surface did not show the selected keeper's memory/persistence state in context. This PR wires that state into the operator workflow instead of adding another unused primitive.

## Review focus
- `dashboard/src/components/ide/ide-persistence-panel.ts`: phase-to-state mapping, `/state-diagram` fallback behavior, and compact graph model.
- `dashboard/src/components/ide/ide-shell.ts`: right-rail placement above the BDI inspector.
- `dashboard/src/components/common/memory-graph.ts`: compact sizing and aria-label API remains backward-compatible.

## Verification
- `pnpm --dir dashboard install --offline --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-persistence-panel.test.ts src/components/ide/ide-persistence-panel.a11y.test.ts src/components/ide/ide-shell.test.ts src/components/common/memory-graph.test.ts src/components/common/memory-graph.a11y.test.ts`
- `pnpm --dir dashboard exec eslint src/components/ide/ide-persistence-panel.ts src/components/ide/ide-persistence-panel.test.ts src/components/ide/ide-persistence-panel.a11y.test.ts src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts src/components/common/memory-graph.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check HEAD~1..HEAD`
- Browser/IAB screenshots on local Vite at desktop and mobile widths