### PR TITLE
feat(ide): RFC-0027 PR-γ — drag reorder for multi-keeper pins

### DIFF
--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { activeKeeperName } from '../../keeper-state'
-import { InspectorMultiKeeperBDI } from './inspector-multi-keeper-bdi'
+import {
+  InspectorMultiKeeperBDI,
+  KEEPER_DRAG_MIME,
+  buildDragHandlers,
+} from './inspector-multi-keeper-bdi'
 import {
   PIN_CAP,
   clearPins,
@@ -358,5 +362,189 @@ describe('InspectorMultiKeeperBDI — error handling', () => {
 
     const scholarPanel = container.querySelector('[data-keeper="scholar"]')
     expect(scholarPanel?.textContent).not.toContain('snapshot unavailable')
+  })
+})
+
+describe('InspectorMultiKeeperBDI — drag reorder wiring (RFC-0027 PR-γ §4)', () => {
+  // Component-level smoke: verify the drag scaffolding is on the rendered DOM.
+  // Behavior of the handlers themselves is unit-tested in the
+  // `buildDragHandlers` block below — Preact event dispatch on synthetic
+  // `Event` objects is unreliable in jsdom, so we keep the integration test
+  // surface narrow.
+  it('panels in compact-fold have draggable=true and consecutive data-drop-idx', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(SCHOLAR_SNAPSHOT))))
+    pinKeeper('scholar', 1)
+    pinKeeper('moth', 2)
+
+    const container = createContainer()
+    render(html`<${InspectorMultiKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(container.querySelectorAll('article[role="listitem"]').length).toBe(2)
+    })
+
+    const panels = Array.from(container.querySelectorAll('article[role="listitem"]'))
+    expect(panels.every(p => p.getAttribute('draggable') === 'true')).toBe(true)
+    expect(panels.map(p => p.getAttribute('data-drop-idx'))).toEqual(['0', '1'])
+  })
+
+  it('focus-mode focused panel has drop-idx 0 and chips have drop-idx 1..3', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(SCHOLAR_SNAPSHOT))))
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+    pinKeeper('c', 3)
+    pinKeeper('d', 4)
+    expect(pinnedKeepers.value.entries.length).toBe(PIN_CAP)
+
+    const container = createContainer()
+    render(html`<${InspectorMultiKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-layout="focus-mode"]')).not.toBeNull()
+    })
+
+    const focusedPanel = container.querySelector('article[data-drop-idx="0"]')
+    expect(focusedPanel?.getAttribute('data-keeper')).toBe('d')
+
+    const chips = Array.from(container.querySelectorAll('span[role="listitem"]'))
+    expect(chips.every(c => c.getAttribute('draggable') === 'true')).toBe(true)
+    expect(chips.map(c => c.getAttribute('data-drop-idx'))).toEqual(['1', '2', '3'])
+  })
+})
+
+describe('buildDragHandlers — RFC-0027 PR-γ §4 unit', () => {
+  interface SimulatedDataTransfer {
+    _data: Map<string, string>
+    _types: string[]
+    effectAllowed: string
+    dropEffect: string
+    setData: (format: string, data: string) => void
+    getData: (format: string) => string
+    readonly types: ReadonlyArray<string>
+  }
+
+  function makeDataTransfer(initial?: { mime: string; data?: string }): SimulatedDataTransfer {
+    const dt: SimulatedDataTransfer = {
+      _data: new Map(),
+      _types: initial?.mime ? [initial.mime] : [],
+      effectAllowed: '',
+      dropEffect: '',
+      setData(format: string, data: string) {
+        this._data.set(format, data)
+        if (!this._types.includes(format)) this._types.push(format)
+      },
+      getData(format: string) {
+        return this._data.get(format) ?? ''
+      },
+      get types() {
+        return this._types
+      },
+    }
+    if (initial?.mime && initial.data !== undefined) {
+      dt._data.set(initial.mime, initial.data)
+    }
+    return dt
+  }
+
+  function makeEvent(dt: SimulatedDataTransfer | null): DragEvent {
+    let prevented = false
+    return {
+      dataTransfer: dt,
+      preventDefault() {
+        prevented = true
+      },
+      get defaultPrevented() {
+        return prevented
+      },
+    } as unknown as DragEvent
+  }
+
+  beforeEach(() => {
+    clearPins()
+  })
+
+  afterEach(() => {
+    clearPins()
+  })
+
+  it('onDragStart writes the source name to the keeper MIME and sets effectAllowed=move', () => {
+    const handlers = buildDragHandlers('scholar', 0)
+    const dt = makeDataTransfer()
+    handlers.onDragStart(makeEvent(dt))
+    expect(dt.getData(KEEPER_DRAG_MIME)).toBe('scholar')
+    expect(dt.effectAllowed).toBe('move')
+  })
+
+  it('onDragStart is a no-op when dataTransfer is null', () => {
+    const handlers = buildDragHandlers('scholar', 0)
+    expect(() => handlers.onDragStart(makeEvent(null))).not.toThrow()
+  })
+
+  it('onDragOver with keeper MIME calls preventDefault and sets dropEffect=move', () => {
+    const handlers = buildDragHandlers('scholar', 0)
+    const dt = makeDataTransfer({ mime: KEEPER_DRAG_MIME })
+    const event = makeEvent(dt)
+    handlers.onDragOver(event)
+    expect(event.defaultPrevented).toBe(true)
+    expect(dt.dropEffect).toBe('move')
+  })
+
+  it('onDragOver with non-keeper MIME does NOT preventDefault', () => {
+    const handlers = buildDragHandlers('scholar', 0)
+    const dt = makeDataTransfer({ mime: 'text/plain' })
+    const event = makeEvent(dt)
+    handlers.onDragOver(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('onDrop with keeper MIME and a different source calls reorderPins', () => {
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+    pinKeeper('c', 3)
+    // Head order: ['c','b','a']
+
+    // Drop 'a' onto target 'c' (drop-idx 0).
+    const handlers = buildDragHandlers('c', 0)
+    const dt = makeDataTransfer({ mime: KEEPER_DRAG_MIME, data: 'a' })
+    const event = makeEvent(dt)
+    handlers.onDrop(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('onDrop on the same keeper (self-drop) is a no-op', () => {
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+
+    const stateBefore = pinnedKeepers.value
+    const handlers = buildDragHandlers('b', 0)
+    const dt = makeDataTransfer({ mime: KEEPER_DRAG_MIME, data: 'b' })
+    handlers.onDrop(makeEvent(dt))
+    expect(pinnedKeepers.value).toBe(stateBefore)
+  })
+
+  it('onDrop with empty source name is a no-op', () => {
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+
+    const stateBefore = pinnedKeepers.value
+    const handlers = buildDragHandlers('a', 1)
+    const dt = makeDataTransfer({ mime: KEEPER_DRAG_MIME, data: '' })
+    handlers.onDrop(makeEvent(dt))
+    expect(pinnedKeepers.value).toBe(stateBefore)
+  })
+
+  it('onDrop on a chip target reorders the source into that chip slot', () => {
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+    pinKeeper('c', 3)
+    pinKeeper('d', 4)
+    // Head order: ['d','c','b','a']
+
+    // Drag 'd' onto chip at drop-idx 3 ('a').
+    const handlers = buildDragHandlers('a', 3)
+    const dt = makeDataTransfer({ mime: KEEPER_DRAG_MIME, data: 'd' })
+    handlers.onDrop(makeEvent(dt))
+
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['c', 'b', 'a', 'd'])
   })
 })

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
@@ -10,8 +10,50 @@ import {
   pinnedKeepers,
   PIN_CAP,
   PinnedKeeperEntry,
+  reorderPins,
   unpinKeeper,
 } from './multi-keeper-pin-store'
+
+/**
+ * RFC-0027 PR-γ drag reorder MIME. Custom token (not text/plain) so
+ * accidental browser drag of plain text from a keeper name does not match.
+ * Exported for tests; consumers should use `buildDragHandlers` rather than
+ * reading the MIME directly.
+ */
+export const KEEPER_DRAG_MIME = 'application/x-keeper-name'
+
+interface DragHandlers {
+  readonly draggable: true
+  readonly onDragStart: (event: DragEvent) => void
+  readonly onDragOver: (event: DragEvent) => void
+  readonly onDrop: (event: DragEvent) => void
+}
+
+export function buildDragHandlers(entryName: string, dropIdx: number): DragHandlers {
+  return {
+    draggable: true,
+    onDragStart: (event: DragEvent) => {
+      if (!event.dataTransfer) return
+      event.dataTransfer.setData(KEEPER_DRAG_MIME, entryName)
+      event.dataTransfer.effectAllowed = 'move'
+    },
+    onDragOver: (event: DragEvent) => {
+      const types = event.dataTransfer?.types
+      if (!types) return
+      // `types` is DOMStringList in browsers, ReadonlyArray in jsdom.
+      const containsKeeperMime = Array.from(types).includes(KEEPER_DRAG_MIME)
+      if (!containsKeeperMime) return
+      event.preventDefault()
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'move'
+    },
+    onDrop: (event: DragEvent) => {
+      event.preventDefault()
+      const fromName = event.dataTransfer?.getData(KEEPER_DRAG_MIME) ?? ''
+      if (!fromName || fromName === entryName) return
+      reorderPins(fromName, dropIdx)
+    },
+  }
+}
 
 /**
  * RFC-0027 PR-β: multi-keeper BDI inspector with three layouts.
@@ -192,13 +234,15 @@ interface KeeperPanelProps {
   readonly slot: KeeperBdiSlot
   readonly compact: boolean
   readonly focused: boolean
+  readonly dropIdx: number
   readonly onUnpin: (keeperName: string) => void
 }
 
-function KeeperPanel({ entry, slot, compact, focused, onUnpin }: KeeperPanelProps) {
+function KeeperPanel({ entry, slot, compact, focused, dropIdx, onUnpin }: KeeperPanelProps) {
   const snapshot = slot.snapshot
   const error = slot.error
   const lastTool = snapshot?.last_tool_call ?? null
+  const dragHandlers = buildDragHandlers(entry.keeperName, dropIdx)
 
   return html`
     <article
@@ -206,6 +250,11 @@ function KeeperPanel({ entry, slot, compact, focused, onUnpin }: KeeperPanelProp
       aria-current=${focused ? 'true' : 'false'}
       data-keeper=${entry.keeperName}
       data-compact=${compact ? 'true' : 'false'}
+      data-drop-idx=${dropIdx}
+      draggable=${dragHandlers.draggable}
+      onDragStart=${dragHandlers.onDragStart}
+      onDragOver=${dragHandlers.onDragOver}
+      onDrop=${dragHandlers.onDrop}
       style=${focused ? PANEL_STYLE_FOCUSED : PANEL_STYLE_COMPACT}
     >
       <header style=${{ display: 'flex', alignItems: 'baseline', gap: 'var(--sp-2)' }}>
@@ -257,14 +306,25 @@ function KeeperPanel({ entry, slot, compact, focused, onUnpin }: KeeperPanelProp
 interface KeeperChipProps {
   readonly entry: PinnedKeeperEntry
   readonly slot: KeeperBdiSlot
+  readonly dropIdx: number
   readonly onFocus: (entry: PinnedKeeperEntry) => void
   readonly onUnpin: (keeperName: string) => void
 }
 
-function KeeperChip({ entry, slot, onFocus, onUnpin }: KeeperChipProps) {
+function KeeperChip({ entry, slot, dropIdx, onFocus, onUnpin }: KeeperChipProps) {
   const tokens = slot.snapshot?.recent_token_spend?.[0]?.total_tokens ?? null
+  const dragHandlers = buildDragHandlers(entry.keeperName, dropIdx)
   return html`
-    <span role="listitem" data-keeper=${entry.keeperName} style=${{ display: 'inline-flex', gap: '2px' }}>
+    <span
+      role="listitem"
+      data-keeper=${entry.keeperName}
+      data-drop-idx=${dropIdx}
+      draggable=${dragHandlers.draggable}
+      onDragStart=${dragHandlers.onDragStart}
+      onDragOver=${dragHandlers.onDragOver}
+      onDrop=${dragHandlers.onDrop}
+      style=${{ display: 'inline-flex', gap: '2px' }}
+    >
       <button
         type="button"
         onClick=${() => onFocus(entry)}
@@ -329,6 +389,7 @@ export function InspectorMultiKeeperBDI({ pollMs = 5000 }: { readonly pollMs?: n
             slot=${activeSlots[idx] ?? EMPTY_SLOT}
             compact=${idx > 0}
             focused=${idx === 0}
+            dropIdx=${idx}
             onUnpin=${unpinKeeper}
           />
         `)}
@@ -355,6 +416,7 @@ export function InspectorMultiKeeperBDI({ pollMs = 5000 }: { readonly pollMs?: n
         slot=${activeSlots[0] ?? EMPTY_SLOT}
         compact=${false}
         focused=${true}
+        dropIdx=${0}
         onUnpin=${unpinKeeper}
       />
       <div role="group" aria-label="other pinned keepers" style=${CHIP_GROUP_STYLE}>
@@ -363,6 +425,7 @@ export function InspectorMultiKeeperBDI({ pollMs = 5000 }: { readonly pollMs?: n
             key=${entry.keeperName}
             entry=${entry}
             slot=${activeSlots[idx + 1] ?? EMPTY_SLOT}
+            dropIdx=${idx + 1}
             onFocus=${focusEntry}
             onUnpin=${unpinKeeper}
           />

--- a/dashboard/src/components/ide/multi-keeper-pin-store.test.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.test.ts
@@ -5,6 +5,7 @@ import {
   headPinnedKeeper,
   pinKeeper,
   pinnedKeepers,
+  reorderPins,
   unpinKeeper,
 } from './multi-keeper-pin-store'
 
@@ -136,5 +137,83 @@ describe('multi-keeper-pin-store', () => {
   it('preserves source line as null when not provided', () => {
     pinKeeper('a')
     expect(pinnedKeepers.value.entries[0]?.line).toBeNull()
+  })
+})
+
+describe('multi-keeper-pin-store — reorderPins (RFC-0027 PR-γ §4)', () => {
+  function seed4(): void {
+    pinKeeper('a', 1)
+    pinKeeper('b', 2)
+    pinKeeper('c', 3)
+    pinKeeper('d', 4)
+    // After 4 inserts, head-promote ordering yields: ['d','c','b','a']
+  }
+
+  it('moves a middle entry to the head', () => {
+    seed4()
+    reorderPins('b', 0)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['b', 'd', 'c', 'a'])
+  })
+
+  it('moves the head to the tail', () => {
+    seed4()
+    reorderPins('d', 3)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['c', 'b', 'a', 'd'])
+  })
+
+  it('preserves pinnedAtMs and line on the moved entry (NOT a fresh pin)', () => {
+    pinKeeper('a', 11)
+    vi.advanceTimersByTime(5_000)
+    pinKeeper('b', 22)
+    const aBefore = pinnedKeepers.value.entries.find(e => e.keeperName === 'a')!
+    reorderPins('a', 0)
+    const aAfter = pinnedKeepers.value.entries[0]!
+    expect(aAfter.keeperName).toBe('a')
+    expect(aAfter.pinnedAtMs).toBe(aBefore.pinnedAtMs) // timestamp unchanged
+    expect(aAfter.line).toBe(11)                         // line unchanged
+  })
+
+  it('is a no-op when fromName is not pinned', () => {
+    seed4()
+    const before = pinnedKeepers.value
+    reorderPins('not-here', 0)
+    expect(pinnedKeepers.value).toBe(before) // identity-preserved (no allocation)
+  })
+
+  it('is a no-op when fromIdx === clampedTo', () => {
+    seed4()
+    const before = pinnedKeepers.value
+    // 'd' is at idx 0; reorder to 0 → no-op.
+    reorderPins('d', 0)
+    expect(pinnedKeepers.value).toBe(before)
+  })
+
+  it('clamps toIdx to the upper bound (entries.length - 1)', () => {
+    seed4()
+    reorderPins('d', 999)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['c', 'b', 'a', 'd'])
+  })
+
+  it('clamps toIdx to 0 when negative', () => {
+    seed4()
+    reorderPins('a', -3)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['a', 'd', 'c', 'b'])
+  })
+
+  it('rejects empty / whitespace fromName', () => {
+    seed4()
+    const before = pinnedKeepers.value
+    reorderPins('', 0)
+    reorderPins('   ', 1)
+    expect(pinnedKeepers.value).toBe(before)
+  })
+
+  it('preserves the cap (does not change entries.length)', () => {
+    seed4()
+    expect(pinnedKeepers.value.entries.length).toBe(PIN_CAP)
+    reorderPins('a', 0)
+    expect(pinnedKeepers.value.entries.length).toBe(PIN_CAP)
+    reorderPins('c', 3)
+    expect(pinnedKeepers.value.entries.length).toBe(PIN_CAP)
   })
 })

--- a/dashboard/src/components/ide/multi-keeper-pin-store.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.ts
@@ -84,6 +84,34 @@ export function clearPins(): void {
 }
 
 /**
+ * Move a pinned keeper to a specific index (RFC-0027 §4 drag reorder).
+ *
+ *  - `fromName` is matched against the trimmed `keeperName`. Whitespace or
+ *    unknown name is a no-op (no allocation).
+ *  - `toIdx` is clamped to `[0, entries.length - 1]`.
+ *  - Same-position move is a no-op (no allocation).
+ *
+ * The moved entry preserves its `pinnedAtMs` and `line`. Drag reorder is a
+ * *position* change, not a fresh pin — refreshing the timestamp would
+ * conflate explicit reorder with implicit recency and break LRU semantics
+ * for the next eviction.
+ */
+export function reorderPins(fromName: string, toIdx: number): void {
+  const trimmed = fromName.trim()
+  if (!trimmed) return
+  const prev = pinnedKeepers.value
+  const fromIdx = prev.entries.findIndex(e => e.keeperName === trimmed)
+  if (fromIdx < 0) return
+  const clampedTo = Math.max(0, Math.min(toIdx, prev.entries.length - 1))
+  if (fromIdx === clampedTo) return
+  const next = prev.entries.slice()
+  const moved = next.splice(fromIdx, 1)[0]
+  if (!moved) return
+  next.splice(clampedTo, 0, moved)
+  pinnedKeepers.value = { ...prev, entries: next }
+}
+
+/**
  * Head entry projection for legacy single-pin callers. Returns `null` when no
  * keeper is pinned.
  */


### PR DESCRIPTION
## 목적

RFC-0027 (#13289 Draft) 의 third impl. **Drag reorder 만**, RFC-0012 키보드 단축키는 PR-γ-2 로 분리. PR-α (#13296, store) + PR-β (#13306, 3 layout) main 머지 완료 위에 drag-and-drop 위임.

## Why this scope (drag only, keyboard deferred)

RFC-0027 follow-up 로 "drag reorder + RFC-0012 키보드 단축키" 두 부분 promised. 단, RFC-0012 KeyboardShortcutManager 가 **dashboard app-root 에 wire-in 안 됨** (`createKeyboardShortcutManager` caller 0 in `dashboard/src/`). RFC-0012 §8 migration path 가 "Consumer migrations: separate PRs" 강제. 따라서:

- **PR-γ (본 PR)**: drag reorder — store 확장 + drag handlers + 컴포넌트 wire-in
- **PR-γ-2** (follow-up): RFC-0012 manager 가 dashboard 에 wire-in 된 후 별도 PR 로 5 shortcut 등록 (Cmd+1..4 promote, Cmd+Shift+W unpin)

PR-γ 단독으로 user-facing 가치 — 사용자가 chip/panel 을 drag 해서 즉시 순서 변경.

## Diff stat

- +362 lines / -4 lines (4 files modified, 0 신규)
- store: `multi-keeper-pin-store.ts` (+28 line — `reorderPins` 추가)
- store test: `multi-keeper-pin-store.test.ts` (+79 line — 9 신규 reorder cases)
- component: `inspector-multi-keeper-bdi.ts` (+69/-1 line — `KEEPER_DRAG_MIME`, `buildDragHandlers`, drag handlers attached to KeeperPanel + KeeperChip, `dropIdx` prop drilled)
- component test: `inspector-multi-keeper-bdi.test.ts` (+186/-3 line — 2 component smoke + 8 buildDragHandlers unit cases)

## Public API extension

```ts
// multi-keeper-pin-store.ts
export function reorderPins(fromName: string, toIdx: number): void
// position-only move; preserves pinnedAtMs + line; clamps toIdx to entries bounds.

// inspector-multi-keeper-bdi.ts
export const KEEPER_DRAG_MIME = 'application/x-keeper-name'
export function buildDragHandlers(entryName: string, dropIdx: number): DragHandlers
```

## Three invariants on `reorderPins`

1. **Position-only mutation**: moved entry preserves `pinnedAtMs` and `line` — drag reorder is *explicit position change*, NOT a fresh pin. Refreshing timestamp would conflate manual reorder with implicit recency, breaking LRU eviction semantics for the next pin.
2. **Identity preservation on no-op**: same fromIdx === clampedTo / unknown name / empty name → returns same `pinnedKeepers.value` reference. Subscribers don't re-render unnecessarily.
3. **Cap preservation**: `entries.length` does not change.

## Drag-and-drop wiring

| 이벤트 | 핸들러 | 동작 |
|------|------|------|
| `onDragStart` | `dataTransfer.setData(MIME, keeperName)` + `effectAllowed='move'` | 드래그 시작 시 keeperName 을 custom MIME 으로 직렬화 |
| `onDragOver` | `types.includes(MIME)` 검사 → `preventDefault` + `dropEffect='move'` | drop 허용 시그널 — non-keeper drag (text 등) 는 무시 |
| `onDrop` | `getData(MIME)` → `reorderPins(fromName, dropIdx)` | self-drop / empty / 매치 안 됨 모두 no-op |

### 적용 위치

| 컴포넌트 | dropIdx |
|---------|---------|
| `KeeperPanel` (compact-fold N panels) | `idx` (0..N-1) |
| `KeeperPanel` (focus-mode focused) | `0` |
| `KeeperChip` (focus-mode 3 chips) | `idx + 1` (1, 2, 3) |

## Custom MIME 의 의의

`text/plain` 으로 drag 하면 keeper name 이 평범한 텍스트로 다른 곳에 drop 가능 (브라우저 기본 동작). custom `application/x-keeper-name` 사용 → inspector rail 안에서만 reorder 가능, 외부 drag-source 는 type guard 로 차단.

## Test results

```
Test Files  3 passed (3)
     Tests  48 passed (48)
```

| 파일 | total | new (PR-γ) |
|------|------|------|
| `multi-keeper-pin-store.test.ts` | 22 | +9 (reorder cases) |
| `inspector-multi-keeper-bdi.test.ts` | 22 | +10 (2 smoke + 8 buildDragHandlers unit) |
| `inspector-keeper-bdi.test.ts` | 4 | 0 (회귀 0) |

### Test 분리 전략

Preact event dispatch + jsdom 의 synthetic `Event` 호환성 이슈 (handler 가 `dispatchEvent` 로 안 fire) 발견. 통합 test 4건 제거 후 `buildDragHandlers` export → unit test 로 치환:

- 컴포넌트 smoke (2 cases): rendered DOM 에 `draggable=true` + `data-drop-idx` 정확히 부착됐는지 — Preact wiring 검증
- handler unit (8 cases): `buildDragHandlers` 직접 호출 + simulated DataTransfer 로 동작 검증 — Preact 의존성 0

이 분리가 더 robust — Preact event normalization 이 미래 변경되어도 unit test 는 동일하게 통과.

## Pre-flight verify (memory line 22-25 강화 protocol)

- `gh pr list --search "drag reorder OR keyboard shortcut OR pin-shortcut" --state open` → 본 PR 외 #13289 (RFC doc-only)
- `gh pr list --search "drag reorder OR keyboard shortcut OR RFC-0012" --state merged --limit 5` → RFC-0012 #11969/#12000 (manager + adapter, 04-29 merged) — 본 PR 가 referenced
- `git fetch origin && git log origin/main --since=1h --oneline -- 'dashboard/src/components/ide/'` → #13313 (orphan exports cleanup), #13306 (PR-β), #13296 (PR-α) 등 — 본 PR-γ scope 충돌 0
- `rg "reorderPins|KEEPER_DRAG_MIME|buildDragHandlers" dashboard/src/` → 본 PR 변경 영역만
- worktree 절대 경로 (`/.worktrees/rfc-0027-impl-pr-gamma`) — nested 회피 룰 적용

## Local validation

- `tsc --noEmit` → 본 PR 변경 파일 0 error
- `vitest run` (3 files) → 48/48 pass
- `eslint` (4 files) → 0 finding

## Rollback plan

4-file revert. `reorderPins` export 사라지지만 caller 0 (본 PR 자체가 introduce). `KEEPER_DRAG_MIME` / `buildDragHandlers` export 사라지지만 caller 0. `dropIdx` prop 사라지지만 컴포넌트 internal — visual 영향 0 (drag 가 단순히 동작 안 함).

## RFC-0012 키보드 단축키 deferral 근거

| 사실 | 영향 |
|------|------|
| RFC-0012 manager (#12000) merged 04-29 | API stable |
| `createKeyboardShortcutManager` caller 0 in `dashboard/src/` | manager 가 app 에 mount 안 됨 |
| `useKeyboardShortcutHost` 호출 없음 | document keydown listener 없음 |
| RFC-0012 §8 "Consumer migrations: separate PRs" | discipline |

PR-γ 가 `useKeyboardShortcut` 만 호출하면 dispatch 안 됨 (host 없음). PR-γ 가 자체 manager + host 만들면 RFC-0012 §5 precedence policy (single global registry) 위반. 따라서 dashboard root 의 manager wire-in 이 prerequisite — 별도 PR.

## RFC waiver

agent_delegation 영역 변경 없음.

`RFC-WAIVED: doc-only RFC dependency (#13289 Draft); behavior-additive (drag handlers attached to existing components, no main wiring change). RFC-0012 keyboard shortcut deferred to PR-γ-2 pending app-root manager wiring.`

## Related

- #13289 (RFC-0027 spec Draft) — 본 PR-γ 가 implements §4 drag reorder
- #13296 (RFC-0027 PR-α merged) — 본 PR-γ 가 store 확장 (`reorderPins` 추가)
- #13306 (RFC-0027 PR-β merged) — 본 PR-γ 가 component drag handlers 부착
- #11969 / #12000 (RFC-0012 manager + Preact adapter) — PR-γ-2 dependency

## Follow-up

- **PR-γ-2**: RFC-0012 manager 의 dashboard root wire-in 후 → 5 shortcut 등록 (`pin.promote.1..4` Cmd+1..4 with `scope: { within: () => inspectorRailRef }`, `pin.unpin.focused` Cmd+Shift+W)
- **PR-wire-in** (별도 axis): `InspectorKeeperBDI` 자리를 `InspectorMultiKeeperBDI` 로 교체 (high-stakes runtime, user 결정 영역)
- **a11y reorder** (RFC-0027 amend): 키보드만으로 reorder (Space + ArrowUp/Down) — 현재 drag-only 는 마우스 사용자만

🤖 Generated with [Claude Code](https://claude.com/claude-code)
