### PR TITLE
feat(board): embed reaction previews

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -433,6 +433,61 @@ describe('normalizeGovernanceJudgeSummary', () => {
 // ================================================================
 
 describe('fetchBoard', () => {
+  it('pins the Phase 1 list contract for votes and embedded reaction previews', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        posts: [
+          {
+            id: 'post-1',
+            author: 'analyst',
+            title: 'Status',
+            body: 'Working',
+            created_at: 1_713_000_000,
+            updated_at: 1_713_000_000,
+            votes: 2,
+            current_vote: 'up',
+            has_voted: true,
+            comment_count: 4,
+            reactions: [
+              {
+                emoji: '🚀',
+                count: 2,
+                reacted: true,
+                recent_user_ids: ['dashboard-reviewer'],
+              },
+            ],
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoard()
+
+    expect(result.posts).toHaveLength(1)
+    expect(result.posts[0]).toMatchObject({
+      id: 'post-1',
+      votes: 2,
+      current_vote: 'up',
+      has_voted: true,
+      comment_count: 4,
+      reactions: [{
+        emoji: '🚀',
+        count: 2,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['dashboard-reviewer'],
+      }],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/v1/board?')
+    expect(url).toContain('voter=')
+  })
+
   it('preserves board actor identity provenance from the server', async () => {
     const rawResponse = {
       posts: [
@@ -568,6 +623,75 @@ describe('fetchBoardHearths', () => {
 })
 
 describe('fetchBoardPost', () => {
+  it('pins the Phase 1 detail contract for post and comment reaction summaries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        post: {
+          id: 'post-1',
+          author: 'analyst',
+          title: 'Status',
+          body: 'Working',
+          created_at: 1_713_000_000,
+          updated_at: 1_713_000_000,
+          reactions: [{
+            emoji: '👍',
+            count: 1,
+            has_reacted: false,
+            recent_user_ids: ['agent-a'],
+          }],
+        },
+        comments: [
+          {
+            id: 'comment-1',
+            post_id: 'post-1',
+            parent_id: null,
+            author: 'reviewer',
+            content: 'Useful',
+            created_at: 1_713_000_100,
+            current_vote: 'down',
+            has_voted: true,
+            reactions: [{
+              emoji: '👏',
+              count: 3,
+              has_reacted: true,
+              recent_user_ids: ['dashboard-reviewer'],
+            }],
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoardPost('post-1')
+
+    expect(result.reactions).toEqual([{
+      emoji: '👍',
+      count: 1,
+      reacted: false,
+      has_reacted: false,
+      recent_user_ids: ['agent-a'],
+    }])
+    expect(result.comments[0]).toMatchObject({
+      id: 'comment-1',
+      parent_id: null,
+      current_vote: 'down',
+      has_voted: true,
+      reactions: [{
+        emoji: '👏',
+        count: 3,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['dashboard-reviewer'],
+      }],
+    })
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('format=flat')
+    expect(url).toContain('voter=')
+  })
+
   it('normalizes comment vote fields from the server detail payload', async () => {
     const rawResponse = {
       post: {

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -498,6 +498,49 @@ describe('fetchBoard', () => {
     expect(url).toContain('hearth=ops')
     expect(url).toContain('limit=150')
   })
+
+  it('normalizes embedded post reaction summaries from the board list payload', async () => {
+    const rawResponse = {
+      posts: [
+        {
+          id: 'post-1',
+          author: 'analyst',
+          title: 'Status',
+          body: 'Working',
+          created_at: 1_713_000_000,
+          updated_at: 1_713_000_000,
+          reactions: [
+            {
+              emoji: '🚀',
+              count: 3,
+              has_reacted: true,
+              recent_user_ids: ['agent-a', 'agent-b'],
+            },
+            { emoji: ' ', count: 99 },
+          ],
+        },
+      ],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoard()
+
+    expect(result.posts[0]?.reactions).toEqual([
+      {
+        emoji: '🚀',
+        count: 3,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['agent-a', 'agent-b'],
+      },
+    ])
+  })
 })
 
 describe('fetchBoardHearths', () => {
@@ -536,6 +579,14 @@ describe('fetchBoardPost', () => {
         updated_at: 1_713_000_000,
         current_vote: 'down',
         has_voted: true,
+        reactions: [
+          {
+            emoji: '👍',
+            count: 4,
+            has_reacted: false,
+            recent_user_ids: ['analyst'],
+          },
+        ],
       },
       comments: [
         {
@@ -549,6 +600,14 @@ describe('fetchBoardPost', () => {
           score: 3,
           current_vote: 'up',
           has_voted: true,
+          reactions: [
+            {
+              emoji: '👏',
+              count: 2,
+              reacted: true,
+              recent_user_ids: ['reviewer'],
+            },
+          ],
         },
       ],
     }
@@ -570,8 +629,22 @@ describe('fetchBoardPost', () => {
       votes_down: 2,
       current_vote: 'up',
       has_voted: true,
+      reactions: [{
+        emoji: '👏',
+        count: 2,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['reviewer'],
+      }],
     })
     expect(result.current_vote).toBe('down')
+    expect(result.reactions).toEqual([{
+      emoji: '👍',
+      count: 4,
+      reacted: false,
+      has_reacted: false,
+      recent_user_ids: ['analyst'],
+    }])
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('format=flat')
     expect(url).toContain('voter=')

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -371,6 +371,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
   const tags = Array.isArray(raw.tags)
     ? raw.tags.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
     : []
+  const reactions = normalizeBoardReactionSummaries(raw.reactions)
 
   return {
     id,
@@ -405,6 +406,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
         : '')
       || null,
     hearth_count: asNumber(raw.hearth_count, 0),
+    ...(Array.isArray(raw.reactions) ? { reactions } : {}),
   }
 }
 
@@ -421,6 +423,7 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
   const votes = asNumber(raw.votes, score)
   const currentVote = normalizeBoardVoteDirection(raw.current_vote)
   const hasVoted = typeof raw.has_voted === 'boolean' ? raw.has_voted : currentVote !== null
+  const reactions = normalizeBoardReactionSummaries(raw.reactions)
   return {
     id,
     post_id: postId,
@@ -435,6 +438,7 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     votes_down: votesDown,
     current_vote: currentVote,
     has_voted: hasVoted,
+    ...(Array.isArray(raw.reactions) ? { reactions } : {}),
   }
 }
 
@@ -465,6 +469,12 @@ function normalizeBoardReactionSummary(raw: unknown): BoardReactionSummary | nul
     has_reacted: hasReacted,
     recent_user_ids: recentUserIds,
   }
+}
+
+function normalizeBoardReactionSummaries(raw: unknown): BoardReactionSummary[] {
+  return Array.isArray(raw)
+    ? raw.map(normalizeBoardReactionSummary).filter((row): row is BoardReactionSummary => row !== null)
+    : []
 }
 
 function normalizeBoardReactionToggleResult(raw: unknown): BoardReactionToggleResult | null {

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -198,6 +198,39 @@ describe('BoardSurface Component', () => {
     expect(screen.getByRole('link', { name: 'ani1999' })).toHaveAttribute('href')
   })
 
+  it('renders compact embedded reaction summaries on list cards', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-1',
+        title: 'Reaction preview',
+        body: 'content',
+        author: 'ani1999',
+        reactions: [
+          {
+            emoji: '🚀',
+            count: 2,
+            reacted: true,
+            has_reacted: true,
+            recent_user_ids: ['ani1999'],
+          },
+          {
+            emoji: '👏',
+            count: 3,
+            reacted: false,
+            has_reacted: false,
+            recent_user_ids: ['keeper'],
+          },
+        ],
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByLabelText('리액션 요약 5개')).toBeInTheDocument()
+    expect(screen.getByText('🚀')).toBeInTheDocument()
+    expect(screen.getByText('👏')).toBeInTheDocument()
+  })
+
   it('hides system posts by default', () => {
     boardPosts.value = [
       makePost({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -77,6 +77,7 @@ import {
   refreshBoardHearths,
 } from './board-state'
 import type { BoardPost, ContentCategory } from './board-state'
+import type { BoardReactionSummary } from '../../types'
 
 /**
  * Pure filter for board posts.
@@ -200,6 +201,27 @@ function renderCategorySection(
 
 function CategorySection({ group }: { group: { category: ContentCategory; posts: BoardPost[]; total: number; hidden: number } }) {
   return renderCategorySection(group.category, group.posts, group.total, group.hidden)
+}
+
+function ReactionSummaryPreview({ summaries }: { summaries?: readonly BoardReactionSummary[] }) {
+  const visible = (summaries ?? [])
+    .filter(summary => summary.count > 0)
+    .slice(0, 3)
+  if (visible.length === 0) return null
+  const total = visible.reduce((sum, summary) => sum + summary.count, 0)
+  return html`
+    <span
+      class="inline-flex items-center gap-1 text-2xs text-[var(--color-fg-muted)]"
+      aria-label=${`리액션 요약 ${total}개`}
+    >
+      ${visible.map(summary => html`
+        <span key=${summary.emoji} class=${`inline-flex items-center gap-0.5 px-1 py-0.5 rounded-[var(--r-1)] border ${summary.has_reacted ? 'border-[var(--accent-20)] bg-[var(--color-accent-soft)] text-[var(--color-accent-fg)]' : 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]'}`}>
+          <span aria-hidden="true">${summary.emoji}</span>
+          <span class="tabular-nums">${summary.count}</span>
+        </span>
+      `)}
+    </span>
+  `
 }
 
 // ── New post form ──────────────────────────────────────────────────
@@ -617,6 +639,7 @@ function PostCard({ post }: { post: BoardPost }) {
 
           <!-- Counts -->
           <span class="text-2xs text-[var(--color-fg-muted)]">댓글 ${post.comment_count}</span>
+          <${ReactionSummaryPreview} summaries=${post.reactions} />
 
           <!-- Category badges -->
           <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -272,6 +272,38 @@ describe('CommentThread', () => {
     expect(screen.getByRole('button', { name: '댓글 비추천' })).toHaveAttribute('aria-pressed', 'false')
   })
 
+  it('announces nested reply collapse state with aria-expanded', () => {
+    const comments = [
+      {
+        id: 'c1',
+        post_id: 'post-1',
+        parent_id: null,
+        author: 'agent',
+        content: 'root',
+        created_at: '2026-04-02T00:00:00Z',
+      },
+      {
+        id: 'c2',
+        post_id: 'post-1',
+        parent_id: 'c1',
+        author: 'agent',
+        content: 'child',
+        created_at: '2026-04-02T00:01:00Z',
+      },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    const toggle = screen.getByRole('button', { name: '답글 1개 접기' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(toggle)
+
+    const collapsedToggle = screen.getByRole('button', { name: '답글 1개 펼치기' })
+    expect(collapsedToggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByText('답글 1개 접힘')).toBeInTheDocument()
+  })
+
   it('toggles a comment reaction from the thread', async () => {
     const comments = [
       {

--- a/dashboard/src/components/board/reaction-bar.test.ts
+++ b/dashboard/src/components/board/reaction-bar.test.ts
@@ -8,7 +8,11 @@ vi.mock('../../api/board', () => ({
   toggleReaction: vi.fn(),
 }))
 
-import { fetchBoardReactions } from '../../api/board'
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+import { fetchBoardReactions, toggleReaction } from '../../api/board'
 import { lastEvent } from '../../sse'
 import { ReactionBar } from './reaction-bar'
 
@@ -22,9 +26,62 @@ describe('ReactionBar', () => {
   it('renders the eight standard board reactions', () => {
     render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
 
+    expect(screen.getByRole('group', { name: '리액션' })).toBeInTheDocument()
     for (const emoji of ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥']) {
       expect(screen.getByRole('button', { name: `${emoji} 리액션 0개` })).toBeInTheDocument()
     }
+  })
+
+  it('marks the current actor reaction as pressed and announces the count', async () => {
+    vi.mocked(fetchBoardReactions).mockResolvedValueOnce([{
+      emoji: '🚀',
+      count: 2,
+      reacted: true,
+      has_reacted: true,
+      recent_user_ids: ['dashboard-reviewer', 'agent-a'],
+    }])
+
+    render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
+
+    const button = await screen.findByRole('button', { name: '🚀 리액션 2개' })
+    expect(button).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('disables reaction buttons while a toggle is in flight', async () => {
+    let resolveToggle!: (value: {
+      target_type: 'post'
+      target_id: string
+      user_id: string
+      emoji: string
+      reacted: boolean
+      summary: []
+    }) => void
+    vi.mocked(toggleReaction).mockReturnValueOnce(new Promise(resolve => {
+      resolveToggle = resolve
+    }))
+
+    render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
+
+    const target = screen.getByRole('button', { name: '🔥 리액션 0개' })
+    target.click()
+
+    await waitFor(() => {
+      expect(target).toBeDisabled()
+      expect(screen.getByRole('button', { name: '👍 리액션 0개' })).toBeDisabled()
+    })
+
+    resolveToggle({
+      target_type: 'post',
+      target_id: 'post-1',
+      user_id: 'dashboard-reviewer',
+      emoji: '🔥',
+      reacted: true,
+      summary: [],
+    })
+
+    await waitFor(() => {
+      expect(target).not.toBeDisabled()
+    })
   })
 
   it('refreshes summaries only when a matching reaction_changed event arrives', async () => {

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -114,6 +114,7 @@ describe('SSEMessageSchema', () => {
   it('accepts typed board reaction metadata at the SSE boundary', () => {
     const r = SSEMessageSchema.safeParse({
       type: 'reaction_changed',
+      event_type: 'reaction.changed',
       target_type: 'comment',
       target_id: 'comment-1',
       user_id: 'dashboard-reviewer',
@@ -121,6 +122,20 @@ describe('SSEMessageSchema', () => {
       reacted: true,
     })
     expect(r.success).toBe(true)
+  })
+
+  it('accepts Phase 1 board SSE legacy types with canonical event_type aliases', () => {
+    for (const event of [
+      { type: 'post_created', event_type: 'post.created', post_id: 'post-1', author: 'writer' },
+      { type: 'comment_added', event_type: 'comment.created', post_id: 'post-1', comment_id: 'comment-1' },
+      { type: 'post_voted', event_type: 'vote.changed', target_type: 'post', post_id: 'post-1', voter: 'reader', direction: 'up' },
+      { type: 'comment_voted', event_type: 'vote.changed', target_type: 'comment', comment_id: 'comment-1', voter: 'reader', direction: 'down' },
+      { type: 'reaction_changed', event_type: 'reaction.changed', target_type: 'post', target_id: 'post-1', user_id: 'reader', emoji: '🔥', reacted: true },
+    ]) {
+      const result = SSEMessageSchema.safeParse(event)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.event_type).toBe(event.event_type)
+    }
   })
 
   it('rejects malformed board reaction metadata at the SSE boundary', () => {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -151,6 +151,7 @@ export interface BoardPost {
   visibility?: string
   expires_at?: string | null
   hearth_count?: number
+  reactions?: BoardReactionSummary[]
 }
 
 export interface BoardComment {
@@ -167,6 +168,7 @@ export interface BoardComment {
   votes_down?: number
   current_vote?: BoardVoteDirection | null
   has_voted?: boolean
+  reactions?: BoardReactionSummary[]
 }
 
 export type BoardReactionTargetType = 'post' | 'comment'

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -49,7 +49,12 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
         let author = Board.Agent_id.to_string p.author in
         let post_id = Board.Post_id.to_string p.id in
         let current_vote = board_current_vote_for_post ~voter ~post_id in
-        board_post_dashboard_json ?current_vote ~author_karma:(get_karma author) p
+        let reactions =
+          board_reaction_summaries ~target_type:Board.Reaction_post
+            ~target_id:post_id ~user_id:voter
+        in
+        board_post_dashboard_json ?current_vote ~reactions
+          ~author_karma:(get_karma author) p
       ) paged in
       let json = `Assoc [
         ("posts", `List posts_json);

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -229,8 +229,12 @@ let add_routes ~sw ~clock router =
                let author = Board.Agent_id.to_string p.author in
                let post_id = Board.Post_id.to_string p.id in
                let current_vote = board_current_vote_for_post ~voter ~post_id in
+               let reactions =
+                 board_reaction_summaries ~target_type:Board.Reaction_post
+                   ~target_id:post_id ~user_id:voter
+               in
                board_post_dashboard_json ?current_vote
-                 ~author_karma:(get_karma author) p)
+                 ~reactions ~author_karma:(get_karma author) p)
              paged
          in
          let json = `Assoc [

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -294,12 +294,22 @@ let board_post_detail_json ~voter ~response_format ~post_id =
             []
       in
       let current_vote = board_current_vote_for_post ~voter ~post_id in
-      let post_json = board_post_dashboard_json ?current_vote ~author_karma post in
+      let reactions =
+        board_reaction_summaries ~target_type:Board.Reaction_post
+          ~target_id:post_id ~user_id:voter
+      in
+      let post_json =
+        board_post_dashboard_json ?current_vote ~reactions ~author_karma post
+      in
       let comments_json =
         `List (List.map (fun (comment : Board.comment) ->
           let comment_id = Board.Comment_id.to_string comment.id in
           let current_vote = board_current_vote_for_comment ~voter ~comment_id in
-          board_comment_dashboard_json ?current_vote comment
+          let reactions =
+            board_reaction_summaries ~target_type:Board.Reaction_comment
+              ~target_id:comment_id ~user_id:voter
+          in
+          board_comment_dashboard_json ?current_vote ~reactions comment
         ) comments)
       in
       let json =

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -133,6 +133,11 @@ let board_current_vote_for_comment ~voter ~comment_id =
       | Ok vote -> Some vote
       | Error _ -> Some None)
 
+let board_reaction_summaries ~target_type ~target_id ~user_id =
+  match Board_dispatch.list_reactions ~target_type ~target_id ?user_id () with
+  | Ok summaries -> summaries
+  | Error _ -> []
+
 let max_filtered_board_window = 5200
 
 let board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset =
@@ -149,17 +154,23 @@ let board_vote_state_fields = function
         ("has_voted", `Bool true);
       ]
 
-let board_comment_dashboard_json ?current_vote (c : Board.comment) : Yojson.Safe.t =
+let board_reaction_summary_fields = function
+  | None -> []
+  | Some summaries ->
+      [ ("reactions", `List (List.map Board.reaction_summary_to_yojson summaries)) ]
+
+let board_comment_dashboard_json ?current_vote ?reactions (c : Board.comment) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
   match Board.comment_to_yojson c with
   | `Assoc fields ->
       `Assoc
         (fields
          @ [ ("author_identity", board_actor_identity_json author) ]
+         @ board_reaction_summary_fields reactions
          @ board_vote_state_fields current_vote)
   | other -> other
 
-let board_post_dashboard_json ?current_vote ~author_karma (p : Board.post) : Yojson.Safe.t =
+let board_post_dashboard_json ?current_vote ?reactions ~author_karma (p : Board.post) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string p.author in
   let base_fields =
     match Board_dispatch.post_to_yojson_with_karma p ~author_karma with
@@ -188,6 +199,7 @@ let board_post_dashboard_json ?current_vote ~author_karma (p : Board.post) : Yoj
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);
         ]
+      @ board_reaction_summary_fields reactions
       @ board_vote_state_fields current_vote )
 
 let dashboard_compact_mode request =

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -153,10 +153,20 @@ val board_current_vote_for_post :
 val board_current_vote_for_comment :
   voter:string option -> comment_id:string -> Board.vote_direction option option
 
+val board_reaction_summaries :
+  target_type:Board.reaction_target_type ->
+  target_id:string ->
+  user_id:string option ->
+  Board.reaction_summary list
+(** [board_reaction_summaries ~target_type ~target_id ~user_id] returns
+    the current reaction summary for dashboard embedding. Lookup failures
+    degrade to [] so stale/deleted rows do not break the board list. *)
+
 (** {1 Dashboard helpers} *)
 
 val board_comment_dashboard_json :
   ?current_vote:Board.vote_direction option ->
+  ?reactions:Board.reaction_summary list ->
   Board.comment ->
   Yojson.Safe.t
 (** [board_comment_dashboard_json c] renders a comment with the
@@ -165,6 +175,7 @@ val board_comment_dashboard_json :
 
 val board_post_dashboard_json :
   ?current_vote:Board.vote_direction option ->
+  ?reactions:Board.reaction_summary list ->
   author_karma:int ->
   Board.post ->
   Yojson.Safe.t

--- a/test/test_board_sse_canonical_event_type.ml
+++ b/test/test_board_sse_canonical_event_type.ml
@@ -50,15 +50,30 @@ let test_vote_changed_aliases () =
     (string_field "target_type" comment_vote)
 
 let test_reaction_changed_alias () =
-  check_event_type "reaction_changed" "reaction.changed"
-    (Board_dispatch.Reaction_changed
-       {
-         target_type = Board.Reaction_post;
-         target_id = "post-1";
-         user_id = "reader";
-         emoji = "👍";
-         reacted = true;
-       })
+  let json =
+    Boot.board_sse_event_params
+      (Board_dispatch.Reaction_changed
+         {
+           target_type = Board.Reaction_post;
+           target_id = "post-1";
+           user_id = "reader";
+           emoji = "👍";
+           reacted = true;
+         })
+  in
+  Alcotest.(check string) "reaction_changed legacy type is preserved"
+    "reaction_changed" (string_field "type" json);
+  Alcotest.(check string) "reaction.changed canonical event_type"
+    "reaction.changed" (string_field "event_type" json);
+  Alcotest.(check string) "reaction target_type" "post"
+    (string_field "target_type" json);
+  Alcotest.(check string) "reaction target_id" "post-1"
+    (string_field "target_id" json);
+  Alcotest.(check string) "reaction user_id" "reader"
+    (string_field "user_id" json);
+  Alcotest.(check string) "reaction emoji" "👍" (string_field "emoji" json);
+  Alcotest.(check bool) "reaction reacted" true
+    (json |> U.member "reacted" |> U.to_bool)
 
 let () =
   Alcotest.run "board_sse_canonical_event_type"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -266,6 +266,71 @@ let test_board_dashboard_json_embeds_reaction_summaries () =
   Alcotest.(check bool) "comment reaction selected" true
     (json_member_bool comment_summary "has_reacted")
 
+let test_board_detail_route_embeds_reaction_summaries () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post =
+    match
+      Board_dispatch.create_post ~author:"reaction-author"
+        ~content:"detail route reactable post" ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+       ~target_id:post_id ~user_id:"reactor" ~emoji:"🚀"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id ~author:"commenter"
+        ~content:"detail route reactable comment" ()
+    with
+    | Ok comment -> comment
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let comment_id = Board.Comment_id.to_string comment.id in
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_comment
+       ~target_id:comment_id ~user_id:"reactor" ~emoji:"👏"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let status, body =
+    Server_routes_http_runtime.board_post_detail_json
+      ~voter:(Some "reactor") ~response_format:"flat" ~post_id
+  in
+  Alcotest.(check string) "detail status" "ok"
+    (match status with `OK -> "ok" | _ -> "other");
+  let json = Yojson.Safe.from_string body in
+  let post_summary =
+    match json_member_list json "reactions" with
+    | summary :: _ -> summary
+    | [] -> Alcotest.fail "expected flat post reaction summary"
+  in
+  Alcotest.(check string) "flat post reaction emoji" "🚀"
+    (json_member_string post_summary "emoji");
+  Alcotest.(check bool) "flat post reaction selected" true
+    (json_member_bool post_summary "has_reacted");
+  let comment_json =
+    match json_member_list json "comments" with
+    | comment :: _ -> comment
+    | [] -> Alcotest.fail "expected flat detail comment"
+  in
+  let comment_summary =
+    match json_member_list comment_json "reactions" with
+    | summary :: _ -> summary
+    | [] -> Alcotest.fail "expected flat comment reaction summary"
+  in
+  Alcotest.(check string) "flat comment reaction emoji" "👏"
+    (json_member_string comment_summary "emoji");
+  Alcotest.(check bool) "flat comment reaction selected" true
+    (json_member_bool comment_summary "has_reacted")
+
 let test_inline_board_post_author_rewrites_caller_claim () =
   let args =
     make_args
@@ -917,6 +982,8 @@ let () =
             `Quick test_board_actor_identity_keeps_non_keeper_agent;
           Alcotest.test_case "board dashboard json embeds reaction summaries"
             `Quick test_board_dashboard_json_embeds_reaction_summaries;
+          Alcotest.test_case "board detail route embeds reaction summaries"
+            `Quick test_board_detail_route_embeds_reaction_summaries;
           Alcotest.test_case "inline board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "inline board post author accepts matching alias"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -155,6 +155,21 @@ let json_member_string json key =
   | `String value -> value
   | _ -> Alcotest.failf "expected string field %s" key
 
+let json_member_int json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int value -> value
+  | _ -> Alcotest.failf "expected int field %s" key
+
+let json_member_bool json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool value -> value
+  | _ -> Alcotest.failf "expected bool field %s" key
+
+let json_member_list json key =
+  match Yojson.Safe.Util.member key json with
+  | `List values -> values
+  | _ -> Alcotest.failf "expected list field %s" key
+
 let test_board_actor_identity_canonicalizes_keeper_alias () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -180,6 +195,76 @@ let test_board_actor_identity_keeps_non_keeper_agent () =
   Alcotest.(check string) "key" "agent:codex" (json_member_string json "key");
   Alcotest.(check string) "source" "raw_agent"
     (json_member_string json "source")
+
+let test_board_dashboard_json_embeds_reaction_summaries () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post =
+    match
+      Board_dispatch.create_post ~author:"reaction-author"
+        ~content:"reactable post" ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+       ~target_id:post_id ~user_id:"reactor" ~emoji:"🚀"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id ~author:"commenter"
+        ~content:"reactable comment" ()
+    with
+    | Ok comment -> comment
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let comment_id = Board.Comment_id.to_string comment.id in
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_comment
+       ~target_id:comment_id ~user_id:"reactor" ~emoji:"👏"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let post_reactions =
+    Server_utils.board_reaction_summaries ~target_type:Board.Reaction_post
+      ~target_id:post_id ~user_id:(Some "reactor")
+  in
+  let post_json =
+    Server_utils.board_post_dashboard_json ~reactions:post_reactions
+      ~author_karma:0 post
+  in
+  let post_summary =
+    match json_member_list post_json "reactions" with
+    | summary :: _ -> summary
+    | [] -> Alcotest.fail "expected post reaction summary"
+  in
+  Alcotest.(check string) "post reaction emoji" "🚀"
+    (json_member_string post_summary "emoji");
+  Alcotest.(check int) "post reaction count" 1
+    (json_member_int post_summary "count");
+  Alcotest.(check bool) "post reaction selected" true
+    (json_member_bool post_summary "has_reacted");
+  let comment_reactions =
+    Server_utils.board_reaction_summaries ~target_type:Board.Reaction_comment
+      ~target_id:comment_id ~user_id:(Some "reactor")
+  in
+  let comment_json =
+    Server_utils.board_comment_dashboard_json ~reactions:comment_reactions comment
+  in
+  let comment_summary =
+    match json_member_list comment_json "reactions" with
+    | summary :: _ -> summary
+    | [] -> Alcotest.fail "expected comment reaction summary"
+  in
+  Alcotest.(check string) "comment reaction emoji" "👏"
+    (json_member_string comment_summary "emoji");
+  Alcotest.(check bool) "comment reaction selected" true
+    (json_member_bool comment_summary "has_reacted")
 
 let test_inline_board_post_author_rewrites_caller_claim () =
   let args =
@@ -795,7 +880,7 @@ let test_tools_count () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check int) "11 tool schemas" 11 (List.length Tool_board.tools)
+  Alcotest.(check int) "12 tool schemas" 12 (List.length Tool_board.tools)
 
 let test_tools_names_unique () =
   Eio_main.run @@ fun env ->
@@ -830,6 +915,8 @@ let () =
             `Quick test_board_actor_identity_canonicalizes_keeper_alias;
           Alcotest.test_case "board actor identity keeps non-keeper agent"
             `Quick test_board_actor_identity_keeps_non_keeper_agent;
+          Alcotest.test_case "board dashboard json embeds reaction summaries"
+            `Quick test_board_dashboard_json_embeds_reaction_summaries;
           Alcotest.test_case "inline board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "inline board post author accepts matching alias"


### PR DESCRIPTION
## Summary

Implements the Phase 1A `board-reaction-preview` slice from `/Users/dancer/Downloads/masc_sns.agent.final/masc_sns.agent.final.md`.

- Embed board reaction summaries on `/api/v1/board` list rows and `/api/v1/board/:post_id?format=flat` detail payloads for posts and comments.
- Add dashboard `BoardPost.reactions` / `BoardComment.reactions` normalization.
- Render compact, non-interactive reaction previews on board list cards from embedded data, avoiding per-card reaction fetches.
- Add regression coverage for backend dashboard JSON, frontend API normalization, and list-card preview rendering.
- Repair the stale `test_tool_board_coverage` schema-count assertion from 11 to the current 12 registered board tools, including `tool_reaction`.

## Operator Impact

The board list now shows reaction activity as part of the main board payload, so operators can scan social signal without opening every post or triggering an extra reaction-summary request per card.

## Validation

- `pnpm install --offline --frozen-lockfile` in `dashboard/` to hydrate cached dependencies in the fresh worktree.
- `pnpm exec vitest run src/api/board.test.ts src/components/board/board-surface.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1` — 86 tests passed.
- `pnpm exec tsc --noEmit --pretty false` — passed.
- `env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_tool_board_coverage.exe` — passed.
- `./_build/default/test/test_tool_board_coverage.exe` — 62 tests passed.
- `git diff --check` — passed.

Note: direct `pnpm exec eslint src/api/board.ts src/components/board/board-surface.ts` returned one warning because the current ESLint config does not include those touched files in its target set; no lint errors were emitted.