### PR TITLE
feat(ide): RFC-0028 PR-β — overlay-keeper-trace component + IDE_LAYERS conflictsWith

### DIFF
--- a/dashboard/design-system/headless-core/layered-overlay.test.ts
+++ b/dashboard/design-system/headless-core/layered-overlay.test.ts
@@ -145,6 +145,63 @@ describe('createLayeredOverlay', () => {
   })
 })
 
+describe('createLayeredOverlay — conflictsWith (RFC-0028 §3 / §10)', () => {
+  const CONFLICT_LAYERS: ReadonlyArray<OverlayLayer> = [
+    { kind: 'time', label: 'Time', description: '' },
+    { kind: 'cascade', label: 'Cascade', description: '' },
+    {
+      kind: 'keeper-trace',
+      label: 'Keeper Trace',
+      description: '',
+      conflictsWith: ['cascade'],
+    },
+  ]
+
+  it('activating a layer with conflictsWith drops every active conflicting layer', () => {
+    const c = createLayeredOverlay(CONFLICT_LAYERS)
+    c.toggle('cascade')
+    c.toggle('keeper-trace')
+    expect([...c.active()]).toEqual(['keeper-trace'])
+  })
+
+  it('activating the conflicted-with layer drops the layer that declared the conflict', () => {
+    const c = createLayeredOverlay(CONFLICT_LAYERS)
+    c.toggle('keeper-trace')
+    c.toggle('cascade')
+    // Symmetric: cascade activating drops keeper-trace because keeper-trace
+    // declared cascade in its conflictsWith.
+    expect([...c.active()]).toEqual(['cascade'])
+  })
+
+  it('preserves a non-conflicting layer alongside the new one', () => {
+    const c = createLayeredOverlay(CONFLICT_LAYERS)
+    c.toggle('time')
+    c.toggle('cascade')
+    c.toggle('keeper-trace')
+    // 'time' is not in any conflictsWith → stays. 'cascade' goes.
+    expect([...c.active()].sort()).toEqual(['keeper-trace', 'time'])
+  })
+
+  it('setActive resolves multi-layer conflicts deterministically (registration order)', () => {
+    const c = createLayeredOverlay(CONFLICT_LAYERS)
+    c.setActive(new Set(['cascade', 'keeper-trace', 'time']))
+    // 'cascade' is registered first → wins; 'keeper-trace' (later) loses.
+    expect([...c.active()].sort()).toEqual(['cascade', 'time'])
+  })
+
+  it('self-conflict declarations are ignored (kindA === kindB never conflicts)', () => {
+    const SELF_CONFLICT_LAYERS: ReadonlyArray<OverlayLayer> = [
+      { kind: 'a', label: 'A', description: '', conflictsWith: ['a'] },
+      { kind: 'b', label: 'B', description: '' },
+    ]
+    const c = createLayeredOverlay(SELF_CONFLICT_LAYERS)
+    c.toggle('a')
+    expect(c.isActive('a')).toBe(true)
+    c.toggle('b')
+    expect([...c.active()].sort()).toEqual(['a', 'b'])
+  })
+})
+
 describe('serializeActive / parseActive', () => {
   const KNOWN = new Set(LAYERS.map(l => l.kind))
 

--- a/dashboard/design-system/headless-core/layered-overlay.ts
+++ b/dashboard/design-system/headless-core/layered-overlay.ts
@@ -28,6 +28,14 @@ export interface OverlayLayer {
   readonly label: string
   readonly description: string
   readonly mutuallyExclusive?: boolean
+  /**
+   * RFC-0028 §3 / §10: layers whose visual surfaces collide with this one.
+   * Activating this layer drops every active layer in `conflictsWith`, and
+   * activating any layer that lists this one in *its* `conflictsWith` drops
+   * this one — i.e. the relationship is treated as symmetric at runtime
+   * even when declared on only one side.
+   */
+  readonly conflictsWith?: ReadonlyArray<string>
 }
 
 export interface LayeredOverlayController {
@@ -61,6 +69,23 @@ export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): Layer
 
   const isExclusive = (kind: string): boolean => layerByKind.get(kind)?.mutuallyExclusive === true
 
+  // Symmetric: kindA and kindB conflict if either declares the other in its
+  // `conflictsWith`. Self-pairs are never conflicts.
+  const isConflicting = (kindA: string, kindB: string): boolean => {
+    if (kindA === kindB) return false
+    const a = layerByKind.get(kindA)
+    const b = layerByKind.get(kindB)
+    if (a?.conflictsWith?.includes(kindB)) return true
+    if (b?.conflictsWith?.includes(kindA)) return true
+    return false
+  }
+
+  const dropConflicts = (target: Set<string>, kind: string): void => {
+    for (const active of [...target]) {
+      if (isConflicting(kind, active)) target.delete(active)
+    }
+  }
+
   const sameActive = (left: ReadonlySet<string>, right: ReadonlySet<string>): boolean => {
     if (left.size !== right.size) return false
     for (const kind of left) {
@@ -76,6 +101,18 @@ export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): Layer
     const next = new Set<string>()
     for (const layer of layers) {
       if (requested.has(layer.kind)) next.add(layer.kind)
+    }
+    // Drop conflicting pairs in registration order: first declared wins. This
+    // is a deterministic resolution for batched setActive() calls where
+    // multiple conflicting layers arrive together.
+    for (const layer of layers) {
+      if (next.has(layer.kind)) {
+        for (const other of [...next]) {
+          if (other !== layer.kind && isConflicting(layer.kind, other)) {
+            next.delete(other)
+          }
+        }
+      }
     }
     return next
   }
@@ -99,9 +136,11 @@ export function createLayeredOverlay(layers: ReadonlyArray<OverlayLayer>): Layer
       next.add(kind)
     } else {
       // Activating any non-exclusive layer drops any active exclusive
-      // layer first, then adds the new layer.
+      // layer first, drops any active layer that conflicts with this kind,
+      // then adds the new layer.
       const exclusive = hasExclusiveActive()
       if (exclusive !== null) next.delete(exclusive)
+      dropConflicts(next, kind)
       next.add(kind)
     }
 

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -29,6 +29,12 @@ export const IDE_LAYERS: ReadonlyArray<OverlayLayer> = [
   { kind: 'approve', label: 'Approve', description: 'APPROVE thread 마커' },
   { kind: 'notes', label: 'Notes', description: 'NOTE/SUGGEST 마커' },
   { kind: 'cascade', label: 'Cascade', description: 'provider/model/cost/latency gutter chip' },
+  {
+    kind: 'keeper-trace',
+    label: 'Trace',
+    description: '4-source stitched gutter chip (anchored-thread / cascade-hop / bdi-snapshot / decision-log)',
+    conflictsWith: ['cascade'],
+  },
   { kind: 'explode', label: 'EXPLODE', description: 'per-keeper ghost copies', mutuallyExclusive: true },
 ]
 

--- a/dashboard/src/components/ide/overlay-keeper-trace.test.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  OverlayKeeperTrace,
+  TRACE_CHIP_CAP,
+  bucketTraceEvents,
+} from './overlay-keeper-trace'
+import {
+  clearTraces,
+  keeperTraceState,
+  pushTrace,
+} from './keeper-trace-store'
+
+const mountedContainers: HTMLElement[] = []
+
+function createContainer(): HTMLElement {
+  const container = document.createElement('div')
+  mountedContainers.push(container)
+  return container
+}
+
+function pushAnchored(id: string, keeperName: string, line: number | null, tsMs: number, threadId = 'th'): void {
+  pushTrace({
+    id,
+    tsMs,
+    keeperName,
+    source: 'anchored-thread',
+    threadId,
+    line,
+  })
+}
+
+function pushBdi(id: string, keeperName: string, tsMs: number, intention: string | null = 'inspect'): void {
+  pushTrace({
+    id,
+    tsMs,
+    keeperName,
+    source: 'bdi-snapshot',
+    intention,
+  })
+}
+
+function pushDecision(id: string, keeperName: string, tsMs: number): void {
+  pushTrace({
+    id,
+    tsMs,
+    keeperName,
+    source: 'decision-log',
+    decisionId: `dec-${id}`,
+    semanticOutcome: 'success',
+  })
+}
+
+beforeEach(() => {
+  clearTraces()
+})
+
+afterEach(() => {
+  for (const container of mountedContainers.splice(0)) {
+    render(null, container)
+  }
+  clearTraces()
+})
+
+describe('bucketTraceEvents — RFC-0028 §5 grouping', () => {
+  it('groups events by (keeperName, line)', () => {
+    pushAnchored('a', 'scholar', 12, 1000)
+    pushAnchored('b', 'scholar', 12, 1100) // same keeper, same line -> same bucket
+    pushAnchored('c', 'scholar', 99, 1200) // same keeper, different line -> separate
+    pushAnchored('d', 'moth', 12, 1300) // different keeper -> separate
+
+    const buckets = bucketTraceEvents(keeperTraceState.value.events)
+    const keys = buckets.map(b => `${b.keeperName}@${b.line}`).sort()
+    expect(keys).toEqual(['moth@12', 'scholar@12', 'scholar@99'])
+  })
+
+  it('non-anchored sources fall into the keeper-level no-line bucket', () => {
+    pushBdi('a', 'scholar', 1000)
+    pushDecision('b', 'scholar', 1100)
+    pushAnchored('c', 'scholar', 12, 1200)
+
+    const buckets = bucketTraceEvents(keeperTraceState.value.events)
+    const noLineBucket = buckets.find(b => b.line === null)
+    expect(noLineBucket).toBeDefined()
+    expect(noLineBucket?.events.length).toBe(2)
+    expect(noLineBucket?.events.map(e => e.source).sort()).toEqual(['bdi-snapshot', 'decision-log'])
+  })
+
+  it('sorts events newest-first within each bucket', () => {
+    pushAnchored('a', 'scholar', 12, 1000)
+    pushAnchored('b', 'scholar', 12, 3000)
+    pushAnchored('c', 'scholar', 12, 2000)
+
+    const buckets = bucketTraceEvents(keeperTraceState.value.events)
+    expect(buckets[0]?.events.map(e => e.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('orders buckets by most-recent head event first', () => {
+    pushAnchored('old-h', 'scholar', 12, 1000)
+    pushAnchored('mid-h', 'moth', 30, 5000)
+    pushAnchored('new-h', 'luna', 50, 9000)
+
+    const buckets = bucketTraceEvents(keeperTraceState.value.events)
+    expect(buckets.map(b => b.keeperName)).toEqual(['luna', 'moth', 'scholar'])
+  })
+})
+
+describe('OverlayKeeperTrace — render gating', () => {
+  it('returns null when active=false', () => {
+    pushAnchored('a', 'scholar', 12, 1000)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${false} />`, container)
+    expect(container.querySelector('[data-overlay="keeper-trace"]')).toBeNull()
+  })
+
+  it('returns null when active=true but no events', () => {
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+    expect(container.querySelector('[data-overlay="keeper-trace"]')).toBeNull()
+  })
+
+  it('renders the overlay region when active and events exist', () => {
+    pushAnchored('a', 'scholar', 12, 1000)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+    const region = container.querySelector('[role="region"][aria-label="Keeper trace overlay"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('data-overlay')).toBe('keeper-trace')
+  })
+})
+
+describe('OverlayKeeperTrace — bucket render (RFC-0028 §5)', () => {
+  it('renders one bucket per (keeperName, line) tuple with the keeper + line label', () => {
+    pushAnchored('a', 'scholar', 12, 1000)
+    pushAnchored('b', 'moth', 30, 1100)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+    const buckets = container.querySelectorAll('[data-overlay="keeper-trace"] [role="group"][data-keeper]')
+    expect(buckets.length).toBe(2)
+    const lineLabels = Array.from(buckets).map(b => b.textContent ?? '')
+    expect(lineLabels.some(t => t.includes('L12'))).toBe(true)
+    expect(lineLabels.some(t => t.includes('L30'))).toBe(true)
+  })
+
+  it('caps visible chips to TRACE_CHIP_CAP and renders +N overflow', () => {
+    // Push 5 events, all anchored at scholar L12 within retention.
+    // None coalesce because each tsMs is > COALESCE_WINDOW_MS apart.
+    for (let i = 0; i < 5; i += 1) {
+      pushAnchored(`e${i}`, 'scholar', 12, 1000 + i * 100, 'th')
+    }
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+
+    const bucket = container.querySelector('[role="group"][data-keeper="scholar"][data-line="12"]')
+    const chips = bucket?.querySelectorAll('li[role="img"]')
+    expect(chips?.length).toBe(TRACE_CHIP_CAP)
+
+    const overflow = bucket?.querySelector('[data-overflow]')
+    expect(overflow?.textContent).toBe(`+${5 - TRACE_CHIP_CAP}`)
+    expect(overflow?.getAttribute('data-overflow')).toBe(String(5 - TRACE_CHIP_CAP))
+  })
+
+  it('does not render overflow chip when bucket size <= TRACE_CHIP_CAP', () => {
+    pushAnchored('e0', 'scholar', 12, 1000, 'th')
+    pushAnchored('e1', 'scholar', 12, 1100, 'th')
+    pushAnchored('e2', 'scholar', 12, 1200, 'th')
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+    const bucket = container.querySelector('[role="group"][data-keeper="scholar"]')
+    const chips = bucket?.querySelectorAll('li[role="img"]')
+    expect(chips?.length).toBe(3)
+    expect(bucket?.querySelector('[data-overflow]')).toBeNull()
+  })
+
+  it('chips carry data-source attribute matching the event source', () => {
+    pushAnchored('a', 'scholar', null, 1000) // no line → no-line bucket
+    pushBdi('b', 'scholar', 1100)
+    pushDecision('c', 'scholar', 1200)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+    const bucket = container.querySelector('[role="group"][data-keeper="scholar"]')
+    const chips = Array.from(bucket?.querySelectorAll('li[role="img"]') ?? [])
+    const sources = chips.map(c => c.getAttribute('data-source'))
+    expect(sources).toEqual(expect.arrayContaining(['anchored-thread', 'bdi-snapshot', 'decision-log']))
+  })
+
+  it('chip aria-label includes source + line + count', () => {
+    pushAnchored('a', 'scholar', 42, 1000)
+    pushAnchored('b', 'scholar', 42, 1010, 'th-2') // coalesces with 'a' (within COALESCE_WINDOW_MS)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} />`, container)
+    const chip = container.querySelector('li[role="img"]')
+    // The single coalesced chip should have count 2.
+    expect(chip?.getAttribute('aria-label')).toContain('thread')
+    expect(chip?.getAttribute('aria-label')).toContain('L42')
+    expect(chip?.getAttribute('aria-label')).toContain('×2')
+  })
+})
+
+describe('OverlayKeeperTrace — keeperFilter', () => {
+  it('renders only the named keeper\'s buckets when keeperFilter is set', () => {
+    pushAnchored('a', 'scholar', 12, 1000)
+    pushAnchored('b', 'moth', 30, 1100)
+    pushAnchored('c', 'luna', 50, 1200)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} keeperFilter=${'moth'} />`, container)
+    const buckets = container.querySelectorAll('[role="group"][data-keeper]')
+    expect(buckets.length).toBe(1)
+    expect(buckets[0]?.getAttribute('data-keeper')).toBe('moth')
+  })
+
+  it('returns null when the named keeper has no events', () => {
+    pushAnchored('a', 'scholar', 12, 1000)
+
+    const container = createContainer()
+    render(html`<${OverlayKeeperTrace} active=${true} keeperFilter=${'nobody'} />`, container)
+    expect(container.querySelector('[data-overlay="keeper-trace"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -1,0 +1,210 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import {
+  KeeperTraceEvent,
+  KeeperTraceSource,
+  keeperTraceState,
+} from './keeper-trace-store'
+
+/**
+ * RFC-0028 PR-β: keeper-trace gutter chip overlay.
+ *
+ * Reads `keeperTraceState` (the 4-source stitched store from PR-α) and
+ * renders a stacked gutter chip per RFC §5: cap=3 visible chips per
+ * (keeperName, line) bucket plus a `+N` overflow indicator. Each chip is
+ * colored by source (anchored-thread / cascade-hop / bdi-snapshot /
+ * decision-log) and exposes a hover tooltip with the underlying event
+ * details.
+ *
+ * Bucket key (RFC §5 + §11 #3):
+ *   `${keeperName}@${line ?? 'no-line'}`
+ *
+ * Events without a line (bdi-snapshot, decision-log without anchor) are
+ * grouped under the keeper-level bucket, so a sidebar overlay can render
+ * them next to the keeper avatar rather than at a specific line. PR-β
+ * keeps the bucket-by-line shape; consumers (editor gutter, sidebar
+ * keeper rail) decide where to mount the chips.
+ *
+ * Conflict avoidance (RFC §10): the `keeper-trace` IDE_LAYERS entry
+ * declares `conflictsWith: ['cascade']` so activating either layer drops
+ * the other automatically — see `layered-overlay.ts`. PR-β does not
+ * coordinate with cascade-overlay directly; the layer registry handles it.
+ */
+
+export const TRACE_CHIP_CAP = 3
+
+/** Source → chip background color (semantic, not literal). */
+const SOURCE_COLORS: Record<KeeperTraceSource, string> = {
+  'anchored-thread': 'var(--color-status-info, #4a90e2)',
+  'cascade-hop': 'var(--color-accent-fg, #8b5cf6)',
+  'bdi-snapshot': 'var(--color-status-ok, #2dba4e)',
+  'decision-log': 'var(--color-status-warn, #d97706)',
+}
+
+/** Source → label glyph for tooltip + ARIA. */
+const SOURCE_LABELS: Record<KeeperTraceSource, string> = {
+  'anchored-thread': 'thread',
+  'cascade-hop': 'cascade',
+  'bdi-snapshot': 'BDI',
+  'decision-log': 'decision',
+}
+
+interface TraceBucket {
+  readonly keeperName: string
+  readonly line: number | null
+  readonly events: ReadonlyArray<KeeperTraceEvent>
+}
+
+/**
+ * Group events by (keeperName, line). Each bucket sorts events newest-first
+ * (descending tsMs) so the head chip surfaces the most recent burst.
+ */
+export function bucketTraceEvents(
+  events: ReadonlyArray<KeeperTraceEvent>,
+): ReadonlyArray<TraceBucket> {
+  const map = new Map<string, KeeperTraceEvent[]>()
+  for (const event of events) {
+    const lineKey = lineOf(event) ?? 'no-line'
+    const key = `${event.keeperName}@${lineKey}`
+    let group = map.get(key)
+    if (!group) {
+      group = []
+      map.set(key, group)
+    }
+    group.push(event)
+  }
+  const buckets: TraceBucket[] = []
+  for (const [, group] of map) {
+    group.sort((a, b) => b.tsMs - a.tsMs)
+    const head = group[0]!
+    buckets.push({
+      keeperName: head.keeperName,
+      line: lineOf(head),
+      events: group,
+    })
+  }
+  // Stable bucket order: most recent head event first.
+  buckets.sort((a, b) => (b.events[0]?.tsMs ?? 0) - (a.events[0]?.tsMs ?? 0))
+  return buckets
+}
+
+function lineOf(event: KeeperTraceEvent): number | null {
+  return event.source === 'anchored-thread' ? event.line : null
+}
+
+interface OverlayKeeperTraceProps {
+  /**
+   * When `false`, the overlay renders nothing (the IDE_LAYERS toggle is
+   * off). The component still subscribes to the store so toggling on is
+   * cheap, but the active=false path short-circuits before any DOM work.
+   */
+  readonly active: boolean
+  /**
+   * Optional filter. When provided, only the named keeper's buckets render.
+   * Used by inspector-side mounts (a single-keeper rail) to scope the
+   * overlay; editor-side mounts pass `undefined`.
+   */
+  readonly keeperFilter?: string
+}
+
+function useTraceEvents(): ReadonlyArray<KeeperTraceEvent> {
+  const [snapshot, setSnapshot] = useState(keeperTraceState.value)
+  useEffect(() => keeperTraceState.subscribe(value => setSnapshot(value)), [])
+  return snapshot.events
+}
+
+const OVERLAY_CONTAINER_STYLE = {
+  display: 'grid',
+  gap: 'var(--sp-1)',
+  fontSize: 'var(--fs-11)',
+} as const
+
+const STACK_STYLE = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '2px',
+} as const
+
+const CHIP_STYLE = {
+  display: 'inline-block',
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+  border: '1px solid var(--color-bg-surface)',
+} as const
+
+const OVERFLOW_STYLE = {
+  marginLeft: '4px',
+  color: 'var(--color-fg-muted)',
+  fontSize: 'var(--fs-11)',
+} as const
+
+function formatTooltip(event: KeeperTraceEvent): string {
+  const sourceLabel = SOURCE_LABELS[event.source]
+  const lineSuffix = event.source === 'anchored-thread' && event.line !== null
+    ? ` L${event.line}`
+    : ''
+  const countSuffix = event.count > 1 ? ` ×${event.count}` : ''
+  return `${sourceLabel}${lineSuffix}${countSuffix}`
+}
+
+export function OverlayKeeperTrace({ active, keeperFilter }: OverlayKeeperTraceProps) {
+  const events = useTraceEvents()
+  if (!active) return null
+
+  const filtered = keeperFilter
+    ? events.filter(e => e.keeperName === keeperFilter)
+    : events
+  if (filtered.length === 0) return null
+
+  const buckets = bucketTraceEvents(filtered)
+  if (buckets.length === 0) return null
+
+  return html`
+    <div
+      role="region"
+      aria-label="Keeper trace overlay"
+      data-overlay="keeper-trace"
+      style=${OVERLAY_CONTAINER_STYLE}
+    >
+      ${buckets.map(bucket => html`
+        <${BucketRow} key=${`${bucket.keeperName}@${bucket.line ?? 'no-line'}`} bucket=${bucket} />
+      `)}
+    </div>
+  `
+}
+
+function BucketRow({ bucket }: { readonly bucket: TraceBucket }) {
+  const visible = bucket.events.slice(0, TRACE_CHIP_CAP)
+  const overflow = bucket.events.length - visible.length
+  const lineLabel = bucket.line !== null ? `L${bucket.line}` : '—'
+
+  return html`
+    <div
+      role="group"
+      data-keeper=${bucket.keeperName}
+      data-line=${bucket.line ?? 'no-line'}
+      style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-1)' }}
+    >
+      <span style=${{ color: 'var(--color-accent-fg)', font: 'var(--type-eyebrow)' }}>
+        ${bucket.keeperName}
+      </span>
+      <span style=${{ color: 'var(--color-fg-muted)' }}>${lineLabel}</span>
+      <ul role="list" aria-label=${`${bucket.keeperName} trace events`} style=${STACK_STYLE}>
+        ${visible.map(event => html`
+          <li
+            role="img"
+            data-source=${event.source}
+            data-count=${event.count}
+            aria-label=${formatTooltip(event)}
+            title=${formatTooltip(event)}
+            style=${{ ...CHIP_STYLE, background: SOURCE_COLORS[event.source] }}
+          />
+        `)}
+      </ul>
+      ${overflow > 0
+        ? html`<span aria-label=${`${overflow} more`} data-overflow=${overflow} style=${OVERFLOW_STYLE}>+${overflow}</span>`
+        : null}
+    </div>
+  `
+}


### PR DESCRIPTION
## 목적

RFC-0028 (#13293 Draft) 의 second impl. **Gutter chip overlay 컴포넌트 + IDE_LAYERS entry + conflictsWith 지원**, store consumer 가 첫 등장. PR-α (#13311) main 머지로 store stable 한 시점에 합류.

## Scope

- **PR-α (merged #13311)**: store + ingestion API + retention + coalesce
- **PR-β (본 PR)**: overlay component + IDE_LAYERS entry + conflictsWith 메커니즘
- **PR-γ** (follow-up): scrubber bidirectional sync (chip click → ReplayWindow jump)
- **PR-δ** (follow-up): 4-producer wire-in (각 polling client / SSE / decision log emit 시 `pushTrace`)
- **PR-ε** (follow-up): perf harness (100k event PR-bound replay scrub < 50ms / scrub)

## Diff stat

- 5 files / +388 / -1 line
- 신규: `overlay-keeper-trace.ts` (210), `overlay-keeper-trace.test.ts` (218)
- 수정: `layered-overlay.ts` (+41), `layered-overlay.test.ts` (+57), `ide-toolbar.ts` (+6/-1)

## Public API

### `overlay-keeper-trace.ts` (신규)
```ts
export const TRACE_CHIP_CAP = 3

export function bucketTraceEvents(
  events: ReadonlyArray<KeeperTraceEvent>,
): ReadonlyArray<TraceBucket>

export function OverlayKeeperTrace({
  active: boolean,
  keeperFilter?: string,
})
```

### `layered-overlay.ts` (확장 — `OverlayLayer` shape)
```ts
export interface OverlayLayer {
  // ...
  readonly conflictsWith?: ReadonlyArray<string> // RFC-0028 §3 / §10
}
```

### `ide-toolbar.ts` (IDE_LAYERS 확장)
```ts
{
  kind: 'keeper-trace',
  label: 'Trace',
  description: '4-source stitched gutter chip ...',
  conflictsWith: ['cascade'],
}
```

## conflictsWith 의미론 (RFC-0028 §10 backward-compat)

**Symmetric runtime semantics from one-sided declaration**:

```ts
// keeper-trace declares cascade in its conflictsWith.
// Activating either drops the other automatically.

// User toggles cascade ON, then keeper-trace ON
//   → cascade dropped, only keeper-trace active

// User toggles keeper-trace ON, then cascade ON  
//   → keeper-trace dropped, only cascade active
```

`isConflicting(A, B)` returns true if **either** `A.conflictsWith.includes(B)` or `B.conflictsWith.includes(A)` — relationship is bidirectional at runtime even when declared on one side. Self-pairs (`A.conflictsWith.includes(A)`) ignored.

`setActive` (URL persistence path) resolves multi-conflict batches in **registration order** — first-declared wins, deterministic across renders.

## Bucket grouping (RFC-0028 §5)

`bucketTraceEvents`:
- key = `${keeperName}@${line ?? 'no-line'}`
- 같은 (keeperName, line) 의 events 는 한 bucket
- anchored-thread 만 line 가짐 — bdi-snapshot / decision-log / cascade-hop 은 keeper-level no-line bucket
- bucket 내부 events: `tsMs` desc 정렬 (newest first)
- buckets 간: head event tsMs desc (most recent bucket first)

## Render gating

| 조건 | 결과 |
|------|------|
| `active=false` | `null` 반환 (DOM work 0) |
| `events.length === 0` | `null` |
| `keeperFilter` 일치 0 | `null` |
| 그 외 | `<region role="region" aria-label="Keeper trace overlay">` |

`active=false` short-circuits *before* DOM work — IDE_LAYERS toggle 가 off 인 동안 component 가 mounted 되어 있어도 cost 거의 0.

## Cap=3 + `+N` overflow (RFC-0028 §5)

```html
<ul role="list" aria-label="scholar trace events">
  <li role="img" data-source="anchored-thread" data-count="2" aria-label="thread L42 ×2" />
  <li role="img" data-source="cascade-hop" data-count="1" aria-label="cascade" />
  <li role="img" data-source="bdi-snapshot" data-count="1" aria-label="BDI" />
</ul>
<span data-overflow="2" aria-label="2 more">+2</span>
```

`TRACE_CHIP_CAP = 3` 은 RFC §5 spec. Overflow chip 은 `data-overflow=N` (count) + `aria-label="N more"`.

## Source → color mapping (RFC §5)

| source | color token | semantic |
|--------|-------------|----------|
| `anchored-thread` | `var(--color-status-info)` | 파랑 — thread anchor |
| `cascade-hop` | `var(--color-accent-fg)` | 보라 — cascade hop |
| `bdi-snapshot` | `var(--color-status-ok)` | 초록 — BDI poll |
| `decision-log` | `var(--color-status-warn)` | 주황 — decision |

## Test results

```
Test Files  27 passed (27)
     Tests  150 passed (150)  -- broader IDE sweep (no regression)
```

| 파일 | total | new (PR-β) |
|------|------|------|
| `overlay-keeper-trace.test.ts` (신규) | 14 | 14 (4 bucket unit + 3 gate + 5 bucket render + 2 keeperFilter) |
| `layered-overlay.test.ts` | 24 | +5 (conflictsWith cases) |
| 기타 25 IDE test files | — | 회귀 0 |

## Pre-flight verify (memory line 22-25 강화 protocol)

- `gh pr list --search "overlay-keeper-trace OR keeper-trace overlay OR conflictsWith" --state open` → 본 PR 외 #13293 (doc-only RFC)
- `gh pr list --search "..." --state merged --limit 5` → store dependency #13311 (PR-α) merged
- `git fetch origin && git log origin/main --since=1h --oneline -- 'dashboard/src/components/ide/' 'dashboard/design-system/headless-core/'` → #13323 (PR-γ, sibling axis), #13322 (persistence), #13311 (PR-α) — overlap 0
- `rg "OverlayKeeperTrace|TRACE_CHIP_CAP|bucketTraceEvents" dashboard/src/` → 본 PR 신규 파일만
- worktree 절대 경로 (`/.worktrees/rfc-0028-impl-pr-beta-overlay`) — nested 회피 룰 적용

## Local validation

- `tsc --noEmit` → 본 PR 변경 파일 0 error
- `vitest run src/components/ide/` (broader) → **150/150 pass** across 27 files
- `eslint` 본 PR 변경 파일 → 0 error (2 warning = headless-core 가 기존 ESLint scope 밖, pre-existing)

## Rollback plan

5-file revert. `OverlayKeeperTrace` import caller 0 (component 가 아직 IDE shell 에 mount 안 됨; toolbar 의 IDE_LAYERS toggle 에만 등장). `conflictsWith` field 없어져도 기존 layer 들은 무관 (optional). PR-α store 는 그대로 남음.

## Wire-in 의 의도적 deferral

본 PR-β 가 `OverlayKeeperTrace` 를 dashboard root render 에 mount 하지 않음:

| reason | 영향 |
|------|------|
| RFC-0028 §6 ARIA / §7 replay sync 가 PR-γ 에 분리 | wire-in 시점에 ReplayOverlayStore 통합 필요 |
| User-facing rollout 은 4 producer wire-in (PR-δ) 후에 의미 | producer 없으면 events.length === 0 → null 반환 |
| Two-phase rollout 의 review-time isolation | 머지해도 user-facing 영향 0 |

## RFC waiver

agent_delegation 영역 변경 없음.

`RFC-WAIVED: doc-only RFC dependency (#13293 Draft); behavior-additive (new layer added to IDE_LAYERS, opt-in toggle, no main render wire-in). conflictsWith mechanism is symmetric runtime semantics, declared one-sided.`

## Related

- #13293 (RFC-0028 spec Draft) — 본 PR-β 가 implements §3 / §5 / §10
- #13311 (RFC-0028 PR-α merged) — 본 PR-β 가 store consume
- #13215 (RFC-0023 P0-B Cascade overlay) — 본 PR-β 가 conflictsWith 로 visual collision 회피
- #11616 (RFC-0020 LAYERS umbrella) — 본 PR 가 OverlayLayer 확장

## Follow-up

- **PR-γ** (RFC-0028 §7): scrubber bidirectional sync — chip click → `ReplayWindow.jump(tsMs)`, scrubber drag → 해당 시간대 chip highlight
- **PR-δ**: 4-producer wire-in (RFC-0021 anchored-thread polling client / RFC-0023 cascade SSE / RFC-0024 BDI snapshot polling / RFC-0026 decision log emit)
- **PR-wire-in**: dashboard IDE shell 의 LAYERS toggle 활성 시 `<OverlayKeeperTrace active=${...} />` 렌더 — editor gutter 또는 keeper rail
- **PR-ε**: perf harness — 100k event 시나리오 < 50ms / scrub
- **RFC-0028 amend PR**: §3 KeeperTraceEvent shape align with actual code (after #13293 main merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
