### PR TITLE
fix(dashboard): surface stale keeper fetch state

### DIFF
--- a/dashboard_bonsai/src/keepers_fetch.ml
+++ b/dashboard_bonsai/src/keepers_fetch.ml
@@ -1,21 +1,46 @@
 (** Single-shot fetch of [/dashboard/b/api/keepers/summary] + 3 s polling.
 
     Mirrors [Logs_fetch] — same Fut-based Fetch API, same interval strategy.
-    Errors are currently dropped (the previous response stays in the Var so
-    views don't flicker). Phase 1c will surface a "stale" indicator when
-    multiple fetches in a row fail. *)
+    Failed fetches keep the last good response in the Var but stamp it stale,
+    so dependent views can show freshness instead of silently rendering old
+    keeper data as current. *)
 
 open! Core
 open Brr_io
 
 let endpoint = "/dashboard/b/api/keepers/summary"
 
+let consecutive_failures = ref 0
+let last_response = ref Keepers_types.fixture
+
+let store_success (response : Keepers_types.response) : unit =
+  consecutive_failures := 0;
+  let response =
+    { response with fetch_status = Keepers_types.Fetch_fresh }
+  in
+  last_response := response;
+  Bonsai.Expert.Var.set Keepers_var.var response
+;;
+
+let store_failure (reason : string) : unit =
+  consecutive_failures := !consecutive_failures + 1;
+  let response =
+    { !last_response with
+      fetch_status =
+        Keepers_types.Fetch_stale
+          { reason; consecutive_failures = !consecutive_failures }
+    }
+  in
+  Bonsai.Expert.Var.set Keepers_var.var response
+;;
+
 let parse_and_store (text : Jstr.t) : unit =
   match Yojson.Safe.from_string (Jstr.to_string text) with
   | json ->
     let response = Keepers_types.response_of_yojson json in
-    Bonsai.Expert.Var.set Keepers_var.var response
-  | exception _ -> ()
+    store_success response
+  | exception exn ->
+    store_failure ("parse failed: " ^ Exn.to_string exn)
 ;;
 
 let run () : unit =
@@ -26,7 +51,7 @@ let run () : unit =
   in
   Fut.await work (function
     | Ok text -> parse_and_store text
-    | Error _ -> ())
+    | Error _ -> store_failure "fetch failed")
 ;;
 
 let start_polling () : unit =

--- a/dashboard_bonsai/src/keepers_types.ml
+++ b/dashboard_bonsai/src/keepers_types.ml
@@ -11,6 +11,14 @@ type keeper_status =
   | Warn
   | Dead
 
+type fetch_status =
+  | Fetch_pending
+  | Fetch_fresh
+  | Fetch_stale of
+      { reason : string
+      ; consecutive_failures : int
+      }
+
 type lane_frame =
   { kind : string              (* "llm" | "tool" | "think" | "wait" | "err" *)
   ; left : int                 (* left %, 0..100 *)
@@ -42,6 +50,7 @@ type response =
   ; cycle : int
   ; room : string option
   ; generated_at : string        (* ISO-8601 UTC *)
+  ; fetch_status : fetch_status
   }
 
 (* ---------- manual Yojson decoding ---------- *)
@@ -69,14 +78,14 @@ let status_of_string = function
   | "Live" -> Live
   | "Warn" -> Warn
   | "Dead" -> Dead
-  | _ -> Live
+  | _ -> Warn
 ;;
 
 let status_of_yojson json =
   match json with
   | `String s -> status_of_string s
   | `List [ `String s ] -> status_of_string s  (* ppx variant fallback *)
-  | _ -> Live
+  | _ -> Warn
 ;;
 
 let lane_frame_of_yojson json =
@@ -119,7 +128,21 @@ let response_of_yojson json =
   ; cycle = int_field json "cycle"
   ; room = string_opt_field json "room"
   ; generated_at = string_field json "generated_at"
+  ; fetch_status = Fetch_fresh
   }
+;;
+
+let fetch_status_label = function
+  | Fetch_pending -> "fetch · pending"
+  | Fetch_fresh -> "fetch · ok"
+  | Fetch_stale { consecutive_failures; _ } ->
+    Printf.sprintf "stale · %dx" consecutive_failures
+;;
+
+let fetch_status_reason = function
+  | Fetch_pending -> "waiting for first keeper summary"
+  | Fetch_fresh -> "latest keeper summary parsed"
+  | Fetch_stale { reason; _ } -> reason
 ;;
 
 (** Initial placeholder — empty keepers list. Views should degrade gracefully
@@ -130,5 +153,6 @@ let fixture : response =
   ; cycle = 0
   ; room = None
   ; generated_at = ""
+  ; fetch_status = Fetch_pending
   }
 ;;

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -58,10 +58,31 @@ let view_hero (rows : Keepers_directory.row list) =
     ()
 ;;
 
-let view_hud_strip ~(rows : Keepers_directory.row list) =
+let short_reason reason =
+  if String.length reason <= 96
+  then reason
+  else String.sub reason ~pos:0 ~len:96 ^ "..."
+;;
+
+let fetch_tone (status : Keepers_types.fetch_status) : Hud.v_class =
+  match status with
+  | Keepers_types.Fetch_pending -> `Neutral
+  | Keepers_types.Fetch_fresh -> `Ok
+  | Keepers_types.Fetch_stale { consecutive_failures; _ } ->
+    if consecutive_failures >= 3 then `Bad else `Warn
+;;
+
+let view_hud_strip
+      ~(keepers : Keepers_types.response)
+      ~(rows : Keepers_directory.row list) =
   let counts = Keepers_directory.counts rows in
   Hud.strip ~label:"Fleet KPIs"
-    [ Hud.cell ~k:"Fleet" ~v:(Printf.sprintf "%02d" counts.total) ()
+    [ Hud.cell
+        ~v_class:(fetch_tone keepers.fetch_status)
+        ~k:"Feed"
+        ~v:(Keepers_types.fetch_status_label keepers.fetch_status)
+        ()
+    ; Hud.cell ~k:"Fleet" ~v:(Printf.sprintf "%02d" counts.total) ()
     ; Hud.cell ~v_class:(if counts.active > 0 then `Ok else `Neutral)
         ~k:"Active"
         ~v:(Printf.sprintf "%02d" counts.active) ()
@@ -88,6 +109,18 @@ let render
   =
   let rows = Keepers_directory.build_rows ~keepers in
   let has_fleet = not (List.is_empty keepers.keepers) in
+  let quiet_text =
+    match keepers.fetch_status with
+    | Keepers_types.Fetch_pending ->
+      "keepers summary fetch is pending — directory snapshot만 먼저 올라와 있습니다."
+    | Keepers_types.Fetch_fresh ->
+      "keepers summary endpoint is quiet — directory snapshot만 먼저 올라와 있습니다."
+    | Keepers_types.Fetch_stale { reason; consecutive_failures } ->
+      Printf.sprintf
+        "keepers summary is stale (%dx) — %s"
+        consecutive_failures
+        (short_reason reason)
+  in
   let page_sections =
     [ Sec.view ~title:"directory" ~sub:"summary"
         ~right:(Printf.sprintf "%d keepers" (List.length rows))
@@ -117,9 +150,7 @@ let render
         [ Node.div
             ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No live keepers" ]
             [ Node.span ~attrs:[ Attr.create "lang" "ko" ]
-                [ Node.text
-                    "keepers summary endpoint is quiet — directory snapshot만 먼저 올라와 있습니다."
-                ]
+                [ Node.text quiet_text ]
             ]
         ]
   in
@@ -128,7 +159,7 @@ let render
     ~aside:(Keepers_directory.aside ~rows ~selected_name)
     ~active:Keepers
     [ view_hero rows
-    ; view_hud_strip ~rows
+    ; view_hud_strip ~keepers ~rows
     ; Node.div ~attrs:[] page_sections
     ]
 ;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1619,13 +1619,21 @@ let view_hud
     | "" -> "—"
     | ts -> Printf.sprintf "%s UTC" (Hud.hhmmss_of_iso ts)
   in
+  let fetch_v = Keepers_types.fetch_status_label keepers.fetch_status in
+  let fetch_cls : Hud.v_class =
+    match keepers.fetch_status with
+    | Keepers_types.Fetch_pending -> `Neutral
+    | Keepers_types.Fetch_fresh -> `Ok
+    | Keepers_types.Fetch_stale { consecutive_failures; _ } ->
+      if consecutive_failures >= 3 then `Bad else `Warn
+  in
   Hud.strip ~label:"Log controls"
     [ Hud.cell ~k:"Source" ~v:"Log.Ring" ()
     ; Hud.cell ~k:"Total" ~v:(Printf.sprintf "%d" response.total) ()
     ; Hud.cell ~k:"Level" ~v:"INFO+" ()
     ; Hud.cell ~v_class:`Ok ~k:"Refresh" ~v:"poll · 3s" ()
     ; Hud.cell ~k:"Limit" ~v:"200" ()
-    ; Hud.cell ~v_class:`Ok ~k:"Link" ~v:"fetch · ok" ()
+    ; Hud.cell ~v_class:fetch_cls ~k:"Link" ~v:fetch_v ()
     ; Hud.cell ~v_class:fleet_cls ~k:"Fleet" ~v:fleet_v ()
     ; Hud.cell ~k:"Synced" ~v:sync_v ()
     ]


### PR DESCRIPTION
## What changed

- Added keeper summary fetch freshness to the Bonsai keeper response model: pending, fresh, and stale with consecutive failure count.
- Changed `keepers_fetch.ml` so parse/fetch failures no longer silently keep stale data marked as current.
- Surfaced the freshness state in the Keepers HUD and Logs HUD.
- Changed unknown keeper status parsing from `Live` to `Warn` to avoid false-live display when the server sends an unexpected state.

## Why

The dashboard audit identified the Bonsai keepers fetch path as a silent failure: parse or network errors were dropped, leaving the previous successful response on screen with no stale indicator. That made old keeper data look current.

## Impact

Operators now see `fetch · pending`, `fetch · ok`, or `stale · Nx` instead of a permanent `fetch · ok`. If stale state repeats, the HUD tone escalates from warn to bad after 3 failures.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing dashboard_bonsai/src/keepers_types.ml`
- `ocamlc -stop-after parsing dashboard_bonsai/src/keepers_fetch.ml`
- Confirmed `keepers_fetch.ml` no longer contains the audited `exception _ -> ()` swallow path

## Local verification limitation

- `scripts/dune-local.sh build --root dashboard_bonsai @src/check` reached the nested Dune project but this local opam switch is missing dashboard Bonsai dependencies: `ppx_jane` and `brr`. No dependency install was performed in this worktree.