### PR TITLE
test(board): pin phase1 contracts

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -433,6 +433,61 @@ describe('normalizeGovernanceJudgeSummary', () => {
 // ================================================================
 
 describe('fetchBoard', () => {
+  it('pins the Phase 1 list contract for votes and embedded reaction previews', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        posts: [
+          {
+            id: 'post-1',
+            author: 'analyst',
+            title: 'Status',
+            body: 'Working',
+            created_at: 1_713_000_000,
+            updated_at: 1_713_000_000,
+            votes: 2,
+            current_vote: 'up',
+            has_voted: true,
+            comment_count: 4,
+            reactions: [
+              {
+                emoji: '🚀',
+                count: 2,
+                reacted: true,
+                recent_user_ids: ['dashboard-reviewer'],
+              },
+            ],
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoard()
+
+    expect(result.posts).toHaveLength(1)
+    expect(result.posts[0]).toMatchObject({
+      id: 'post-1',
+      votes: 2,
+      current_vote: 'up',
+      has_voted: true,
+      comment_count: 4,
+      reactions: [{
+        emoji: '🚀',
+        count: 2,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['dashboard-reviewer'],
+      }],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/v1/board?')
+    expect(url).toContain('voter=')
+  })
+
   it('preserves board actor identity provenance from the server', async () => {
     const rawResponse = {
       posts: [
@@ -568,6 +623,75 @@ describe('fetchBoardHearths', () => {
 })
 
 describe('fetchBoardPost', () => {
+  it('pins the Phase 1 detail contract for post and comment reaction summaries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        post: {
+          id: 'post-1',
+          author: 'analyst',
+          title: 'Status',
+          body: 'Working',
+          created_at: 1_713_000_000,
+          updated_at: 1_713_000_000,
+          reactions: [{
+            emoji: '👍',
+            count: 1,
+            has_reacted: false,
+            recent_user_ids: ['agent-a'],
+          }],
+        },
+        comments: [
+          {
+            id: 'comment-1',
+            post_id: 'post-1',
+            parent_id: null,
+            author: 'reviewer',
+            content: 'Useful',
+            created_at: 1_713_000_100,
+            current_vote: 'down',
+            has_voted: true,
+            reactions: [{
+              emoji: '👏',
+              count: 3,
+              has_reacted: true,
+              recent_user_ids: ['dashboard-reviewer'],
+            }],
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoardPost('post-1')
+
+    expect(result.reactions).toEqual([{
+      emoji: '👍',
+      count: 1,
+      reacted: false,
+      has_reacted: false,
+      recent_user_ids: ['agent-a'],
+    }])
+    expect(result.comments[0]).toMatchObject({
+      id: 'comment-1',
+      parent_id: null,
+      current_vote: 'down',
+      has_voted: true,
+      reactions: [{
+        emoji: '👏',
+        count: 3,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['dashboard-reviewer'],
+      }],
+    })
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('format=flat')
+    expect(url).toContain('voter=')
+  })
+
   it('normalizes comment vote fields from the server detail payload', async () => {
     const rawResponse = {
       post: {

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -272,6 +272,38 @@ describe('CommentThread', () => {
     expect(screen.getByRole('button', { name: '댓글 비추천' })).toHaveAttribute('aria-pressed', 'false')
   })
 
+  it('announces nested reply collapse state with aria-expanded', () => {
+    const comments = [
+      {
+        id: 'c1',
+        post_id: 'post-1',
+        parent_id: null,
+        author: 'agent',
+        content: 'root',
+        created_at: '2026-04-02T00:00:00Z',
+      },
+      {
+        id: 'c2',
+        post_id: 'post-1',
+        parent_id: 'c1',
+        author: 'agent',
+        content: 'child',
+        created_at: '2026-04-02T00:01:00Z',
+      },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    const toggle = screen.getByRole('button', { name: '답글 1개 접기' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(toggle)
+
+    const collapsedToggle = screen.getByRole('button', { name: '답글 1개 펼치기' })
+    expect(collapsedToggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByText('답글 1개 접힘')).toBeInTheDocument()
+  })
+
   it('toggles a comment reaction from the thread', async () => {
     const comments = [
       {

--- a/dashboard/src/components/board/reaction-bar.test.ts
+++ b/dashboard/src/components/board/reaction-bar.test.ts
@@ -8,7 +8,11 @@ vi.mock('../../api/board', () => ({
   toggleReaction: vi.fn(),
 }))
 
-import { fetchBoardReactions } from '../../api/board'
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+import { fetchBoardReactions, toggleReaction } from '../../api/board'
 import { lastEvent } from '../../sse'
 import { ReactionBar } from './reaction-bar'
 
@@ -22,9 +26,62 @@ describe('ReactionBar', () => {
   it('renders the eight standard board reactions', () => {
     render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
 
+    expect(screen.getByRole('group', { name: '리액션' })).toBeInTheDocument()
     for (const emoji of ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥']) {
       expect(screen.getByRole('button', { name: `${emoji} 리액션 0개` })).toBeInTheDocument()
     }
+  })
+
+  it('marks the current actor reaction as pressed and announces the count', async () => {
+    vi.mocked(fetchBoardReactions).mockResolvedValueOnce([{
+      emoji: '🚀',
+      count: 2,
+      reacted: true,
+      has_reacted: true,
+      recent_user_ids: ['dashboard-reviewer', 'agent-a'],
+    }])
+
+    render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
+
+    const button = await screen.findByRole('button', { name: '🚀 리액션 2개' })
+    expect(button).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('disables reaction buttons while a toggle is in flight', async () => {
+    let resolveToggle!: (value: {
+      target_type: 'post'
+      target_id: string
+      user_id: string
+      emoji: string
+      reacted: boolean
+      summary: []
+    }) => void
+    vi.mocked(toggleReaction).mockReturnValueOnce(new Promise(resolve => {
+      resolveToggle = resolve
+    }))
+
+    render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
+
+    const target = screen.getByRole('button', { name: '🔥 리액션 0개' })
+    target.click()
+
+    await waitFor(() => {
+      expect(target).toBeDisabled()
+      expect(screen.getByRole('button', { name: '👍 리액션 0개' })).toBeDisabled()
+    })
+
+    resolveToggle({
+      target_type: 'post',
+      target_id: 'post-1',
+      user_id: 'dashboard-reviewer',
+      emoji: '🔥',
+      reacted: true,
+      summary: [],
+    })
+
+    await waitFor(() => {
+      expect(target).not.toBeDisabled()
+    })
   })
 
   it('refreshes summaries only when a matching reaction_changed event arrives', async () => {

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -114,6 +114,7 @@ describe('SSEMessageSchema', () => {
   it('accepts typed board reaction metadata at the SSE boundary', () => {
     const r = SSEMessageSchema.safeParse({
       type: 'reaction_changed',
+      event_type: 'reaction.changed',
       target_type: 'comment',
       target_id: 'comment-1',
       user_id: 'dashboard-reviewer',
@@ -121,6 +122,20 @@ describe('SSEMessageSchema', () => {
       reacted: true,
     })
     expect(r.success).toBe(true)
+  })
+
+  it('accepts Phase 1 board SSE legacy types with canonical event_type aliases', () => {
+    for (const event of [
+      { type: 'post_created', event_type: 'post.created', post_id: 'post-1', author: 'writer' },
+      { type: 'comment_added', event_type: 'comment.created', post_id: 'post-1', comment_id: 'comment-1' },
+      { type: 'post_voted', event_type: 'vote.changed', target_type: 'post', post_id: 'post-1', voter: 'reader', direction: 'up' },
+      { type: 'comment_voted', event_type: 'vote.changed', target_type: 'comment', comment_id: 'comment-1', voter: 'reader', direction: 'down' },
+      { type: 'reaction_changed', event_type: 'reaction.changed', target_type: 'post', target_id: 'post-1', user_id: 'reader', emoji: '🔥', reacted: true },
+    ]) {
+      const result = SSEMessageSchema.safeParse(event)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.event_type).toBe(event.event_type)
+    }
   })
 
   it('rejects malformed board reaction metadata at the SSE boundary', () => {

--- a/test/test_board_sse_canonical_event_type.ml
+++ b/test/test_board_sse_canonical_event_type.ml
@@ -50,15 +50,30 @@ let test_vote_changed_aliases () =
     (string_field "target_type" comment_vote)
 
 let test_reaction_changed_alias () =
-  check_event_type "reaction_changed" "reaction.changed"
-    (Board_dispatch.Reaction_changed
-       {
-         target_type = Board.Reaction_post;
-         target_id = "post-1";
-         user_id = "reader";
-         emoji = "👍";
-         reacted = true;
-       })
+  let json =
+    Boot.board_sse_event_params
+      (Board_dispatch.Reaction_changed
+         {
+           target_type = Board.Reaction_post;
+           target_id = "post-1";
+           user_id = "reader";
+           emoji = "👍";
+           reacted = true;
+         })
+  in
+  Alcotest.(check string) "reaction_changed legacy type is preserved"
+    "reaction_changed" (string_field "type" json);
+  Alcotest.(check string) "reaction.changed canonical event_type"
+    "reaction.changed" (string_field "event_type" json);
+  Alcotest.(check string) "reaction target_type" "post"
+    (string_field "target_type" json);
+  Alcotest.(check string) "reaction target_id" "post-1"
+    (string_field "target_id" json);
+  Alcotest.(check string) "reaction user_id" "reader"
+    (string_field "user_id" json);
+  Alcotest.(check string) "reaction emoji" "👍" (string_field "emoji" json);
+  Alcotest.(check bool) "reaction reacted" true
+    (json |> U.member "reacted" |> U.to_bool)
 
 let () =
   Alcotest.run "board_sse_canonical_event_type"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -266,6 +266,71 @@ let test_board_dashboard_json_embeds_reaction_summaries () =
   Alcotest.(check bool) "comment reaction selected" true
     (json_member_bool comment_summary "has_reacted")
 
+let test_board_detail_route_embeds_reaction_summaries () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post =
+    match
+      Board_dispatch.create_post ~author:"reaction-author"
+        ~content:"detail route reactable post" ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+       ~target_id:post_id ~user_id:"reactor" ~emoji:"🚀"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id ~author:"commenter"
+        ~content:"detail route reactable comment" ()
+    with
+    | Ok comment -> comment
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let comment_id = Board.Comment_id.to_string comment.id in
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_comment
+       ~target_id:comment_id ~user_id:"reactor" ~emoji:"👏"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let status, body =
+    Server_routes_http_runtime.board_post_detail_json
+      ~voter:(Some "reactor") ~response_format:"flat" ~post_id
+  in
+  Alcotest.(check string) "detail status" "ok"
+    (match status with `OK -> "ok" | _ -> "other");
+  let json = Yojson.Safe.from_string body in
+  let post_summary =
+    match json_member_list json "reactions" with
+    | summary :: _ -> summary
+    | [] -> Alcotest.fail "expected flat post reaction summary"
+  in
+  Alcotest.(check string) "flat post reaction emoji" "🚀"
+    (json_member_string post_summary "emoji");
+  Alcotest.(check bool) "flat post reaction selected" true
+    (json_member_bool post_summary "has_reacted");
+  let comment_json =
+    match json_member_list json "comments" with
+    | comment :: _ -> comment
+    | [] -> Alcotest.fail "expected flat detail comment"
+  in
+  let comment_summary =
+    match json_member_list comment_json "reactions" with
+    | summary :: _ -> summary
+    | [] -> Alcotest.fail "expected flat comment reaction summary"
+  in
+  Alcotest.(check string) "flat comment reaction emoji" "👏"
+    (json_member_string comment_summary "emoji");
+  Alcotest.(check bool) "flat comment reaction selected" true
+    (json_member_bool comment_summary "has_reacted")
+
 let test_inline_board_post_author_rewrites_caller_claim () =
   let args =
     make_args
@@ -917,6 +982,8 @@ let () =
             `Quick test_board_actor_identity_keeps_non_keeper_agent;
           Alcotest.test_case "board dashboard json embeds reaction summaries"
             `Quick test_board_dashboard_json_embeds_reaction_summaries;
+          Alcotest.test_case "board detail route embeds reaction summaries"
+            `Quick test_board_detail_route_embeds_reaction_summaries;
           Alcotest.test_case "inline board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "inline board post author accepts matching alias"


### PR DESCRIPTION
## Summary

Stacked on #13324 for the artifact's Phase 1A `board-phase1-contracts` slice.

- Pin board SSE legacy `type` values with canonical dotted `event_type` aliases at the dashboard schema boundary.
- Strengthen `ReactionBar` accessibility contracts: group label, active `aria-pressed`, and disabled state while a toggle is in flight.
- Add comment-thread collapse `aria-expanded` coverage.
- Add board list/detail API contract tests for vote state and embedded reaction summaries.
- Add backend route-level detail contract coverage proving flat post detail embeds post/comment reaction summaries for the current voter.
- Expand the OCaml SSE contract test to assert `reaction_changed` metadata fields, not just the alias.

## Why stacked

This relies on #13324's embedded `BoardPost.reactions` / `BoardComment.reactions` contract. Keeping this PR based on `feat/board-reaction-preview-0506` makes the review diff contract-only.

## Validation

- `pnpm install --offline --frozen-lockfile` in `dashboard/` to hydrate cached dependencies in the fresh worktree.
- `pnpm exec vitest run src/api/board.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts src/components/board/reaction-bar.test.ts src/schemas/sse.test.ts src/sse-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1` — 157 tests passed.
- `pnpm exec tsc --noEmit --pretty false` — passed.
- `env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_board_sse_canonical_event_type.exe test/test_tool_board_coverage.exe` — passed.
- `./_build/default/test/test_board_sse_canonical_event_type.exe` — 4 tests passed.
- `./_build/default/test/test_tool_board_coverage.exe` — 63 tests passed.
- `git diff --check` — passed.

Note: direct targeted ESLint returned warnings because the current ESLint config does not include `src/api/board.test.ts` or `src/schemas/sse.test.ts`; no lint errors were emitted.