### PR TITLE
fix(cascade): skip open providers before run

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -206,6 +206,22 @@ let run_named
       ~label:cascade_name
       candidate_cfgs
   in
+  let candidate_cfgs =
+    List.filter
+      (fun (provider_cfg : Llm_provider.Provider_config.t) ->
+         match
+           Cascade_health_tracker.check_circuit_breaker
+             Cascade_health_tracker.global
+             ~provider_key:provider_cfg.model_id
+         with
+         | Ok () -> true
+         | Error msg ->
+             Log.Misc.debug
+               "cascade %s: prefilter skipped %s (provider cooldown: %s)"
+               cascade_name provider_cfg.model_id msg;
+             false)
+      candidate_cfgs
+  in
   (* Cross-cascade health-aware fallback: when the current cascade has no
      tool-capable providers after filtering, search all other cascades for
      a healthy tool-capable provider. Depth 1 only (no recursive search). *)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -137,16 +137,21 @@ let with_temp_masc_config cascade_json f =
   output_string oc cascade_json;
   close_out oc;
   let prev_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
+  let prev_base_path_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
   let prev_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
   Config_dir_resolver.reset ();
   Cascade_catalog_runtime.reset_cache_for_tests ();
   Unix.putenv "MASC_BASE_PATH" base;
+  Unix.putenv "MASC_BASE_PATH_INPUT" base;
   Unix.putenv "MASC_CONFIG_DIR" config_dir;
   Fun.protect
     ~finally:(fun () ->
       (match prev_base_path with
        | Some value -> Unix.putenv "MASC_BASE_PATH" value
        | None -> Unix.putenv "MASC_BASE_PATH" "");
+      (match prev_base_path_input with
+       | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
+       | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
       (match prev_config_dir with
        | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
        | None -> Unix.putenv "MASC_CONFIG_DIR" "");
@@ -213,6 +218,24 @@ let start_multi_mock ~sw ~net ~port (responses : string list) =
   Eio.Fiber.fork ~sw (fun () ->
       Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
   Printf.sprintf "http://127.0.0.1:%d" port
+
+let start_counting_mock ~sw ~net ~port response =
+  let calls = Atomic.make 0 in
+  let handler _conn _req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    ignore (Atomic.fetch_and_add calls 1);
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:response ()
+  in
+  let socket =
+    Eio.Net.listen net ~sw ~backlog:8 ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  ( Printf.sprintf "http://127.0.0.1:%d" port,
+    (fun () -> Atomic.get calls),
+    (fun () -> Atomic.set calls 0) )
 
 let start_delayed_mock ~sw ~net ~clock ~port ~delay_s response =
   let handler _conn _req body =
@@ -1125,6 +1148,128 @@ let test_run_named_per_provider_timeout_uses_clock_fallback_and_exempts_last_pro
         Alcotest.(check string) "last provider succeeds without timeout"
           "last provider survived timeout"
           (response_text result.response);
+        Eio.Switch.fail sw Exit
+    | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
+  with Exit -> ()
+
+let test_run_named_skips_cooldown_primary_and_falls_back () =
+  try
+    Eio.Switch.run @@ fun sw ->
+    let primary_port =
+      match find_free_port () with Some port -> port | None -> Alcotest.skip ()
+    in
+    let primary_url, primary_calls, reset_primary_calls =
+      try
+        start_counting_mock
+          ~sw
+          ~net:(require_test_net ())
+          ~port:primary_port
+          (openai_text_response "primary should be skipped")
+      with
+      | Unix.Unix_error (Unix.EPERM, "bind", _)
+      | Unix.Unix_error (Unix.EACCES, "bind", _) ->
+          Alcotest.skip ()
+    in
+    let fallback_port =
+      match find_free_port () with Some port -> port | None -> Alcotest.skip ()
+    in
+    let fallback_url, fallback_calls, reset_fallback_calls =
+      try
+        start_counting_mock
+          ~sw
+          ~net:(require_test_net ())
+          ~port:fallback_port
+          (openai_text_response "fallback survived open circuit")
+      with
+      | Unix.Unix_error (Unix.EPERM, "bind", _)
+      | Unix.Unix_error (Unix.EACCES, "bind", _) ->
+          Alcotest.skip ()
+    in
+    let primary_key = "anthropic_open_13318" in
+    let fallback_key = "moonshot_fallback_13318" in
+    with_temp_masc_config
+      (Printf.sprintf
+         {|{
+  "breaker_probe_13318_models": [
+    "custom:%s@%s",
+    "custom:%s@%s"
+  ]
+}|}
+         primary_key
+         primary_url
+         fallback_key
+         fallback_url)
+    @@ fun () ->
+    let resolved =
+      match
+        Masc_mcp.Cascade_catalog_runtime.resolve_named_providers_strict
+          ~sw
+          ~net:(require_test_net ())
+          ~cascade_name:"breaker_probe_13318"
+          ()
+      with
+      | Ok providers -> providers
+      | Error err -> Alcotest.fail err
+    in
+    (match resolved with
+     | [ primary; fallback ] ->
+         Alcotest.(check string) "primary model id"
+           primary_key primary.Llm_provider.Provider_config.model_id;
+         Alcotest.(check string) "fallback model id"
+           fallback_key fallback.model_id;
+         Alcotest.(check string) "primary base url" primary_url primary.base_url;
+         Alcotest.(check string) "fallback base url" fallback_url fallback.base_url
+     | providers ->
+         Alcotest.failf "expected 2 resolved providers, got %d"
+           (List.length providers));
+    for _ = 1 to Masc_mcp.Cascade_health_tracker.cooldown_threshold do
+      Masc_mcp.Cascade_health_tracker.record_failure
+        Masc_mcp.Cascade_health_tracker.global
+        ~provider_key:primary_key
+        ()
+    done;
+    reset_primary_calls ();
+    reset_fallback_calls ();
+    (match
+       Masc_mcp.Cascade_health_tracker.check_circuit_breaker
+         Masc_mcp.Cascade_health_tracker.global
+         ~provider_key:primary_key
+     with
+     | Ok () -> Alcotest.fail "primary provider should be OPEN before run_named"
+     | Error _ -> ());
+    Alcotest.(check int)
+      "primary has no requests before run_named"
+      0
+      (primary_calls ());
+    match
+      Oas_worker_named.run_named
+        ~cascade_name:"breaker_probe_13318"
+        ~goal:"say hello"
+        ~system_prompt:"system"
+        ~sw
+        ~net:(require_test_net ())
+        ()
+    with
+    | Ok _result ->
+        Alcotest.(check int)
+          "OPEN primary receives no request"
+          0
+          (primary_calls ());
+        Alcotest.(check bool)
+          "fallback provider receives requests"
+          true
+          (fallback_calls () > 0);
+        (match
+           Masc_mcp.Cascade_health_tracker.provider_info
+             Masc_mcp.Cascade_health_tracker.global
+             ~provider_key:fallback_key
+         with
+         | None -> Alcotest.fail "fallback provider should have health info"
+         | Some info ->
+             Alcotest.(check bool)
+               "fallback success is reflected in health tracker"
+               true
+               (info.success_rate > 0.0));
         Eio.Switch.fail sw Exit
     | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
   with Exit -> ()
@@ -4421,6 +4566,8 @@ let () =
         test_default_config_preserves_custom_local_request_path;
       Alcotest.test_case "per-provider timeout uses context clock and exempts last provider" `Quick
         test_run_named_per_provider_timeout_uses_clock_fallback_and_exempts_last_provider;
+      Alcotest.test_case "open circuit primary falls back without request" `Quick
+        test_run_named_skips_cooldown_primary_and_falls_back;
     ];
     "resume_config", [
       Alcotest.test_case "checkpoint model wins" `Quick


### PR DESCRIPTION
## What changed
- Filters providers whose circuit breaker is already OPEN immediately after tool-support filtering in `Oas_worker_named.run_named`.
- Keeps the existing in-attempt breaker guard as a second line of defense.
- Adds a `run_named` boundary regression proving an OPEN primary provider is not requested and the fallback provider is used.
- Tightens the test fixture so `with_temp_masc_config` also overrides `MASC_BASE_PATH_INPUT`; otherwise tests can still resolve the real `~/me` base path because that env var has precedence.

## Why
The lower-level health tracker and strategy tests already covered cooldown behavior, but the P0 invariant was not pinned at the MASC execution boundary. The missing boundary mattered because `run_named` prepares provider candidates before the inner `try_cascade` guard runs. OPEN providers should be removed before execution-side routing work proceeds, not only at the final attempt point.

Fixes #13318.

## Validation
- `dune build --root . -j 1 test/test_oas_worker.exe test/test_cascade_health_tracker.exe test/test_cascade_strategy.exe`
- `./_build/default/test/test_oas_worker.exe test cascade_config 41`
- `./_build/default/test/test_cascade_health_tracker.exe`
- `./_build/default/test/test_cascade_strategy.exe`
- `git diff --check`

Note: `scripts/dune-local.sh build ...` was attempted first, but it waited on `/tmp/me-dune-local.lock` behind other active sessions, so validation used focused direct `dune -j 1` commands in this isolated worktree.