### PR TITLE
fix(keeper): accept progress before stay-silent

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -335,6 +335,7 @@ let actionable_tool_contract_violation_reason
     | [] ->
       Some
         "actionable keeper signal was present, but the model called no keeper tools"
+    | names when List.exists is_owned_task_progress_tool_name names -> None
     | names
       when (not claim_context_allowed)
            && not (List.exists is_owned_task_progress_tool_name names) ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6004,6 +6004,16 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
        check bool "reason mentions typed no-work proof" true
          (contains_substring reason "typed no-work proof")
    | None -> fail "expected stay_silent actionable violation");
+  check (option string) "execution plus stay_silent remains accepted" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_board_comment"; "keeper_stay_silent" ]);
+  check (option string) "owned-task progress plus stay_silent remains accepted" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:false
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_bash"; "keeper_stay_silent" ]);
   check (option string) "non-actionable stay_silent remains allowed" None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true


### PR DESCRIPTION
## Summary
- Treat actionable keeper turns as satisfied when they include real progress before a later `keeper_stay_silent`.
- Keep rejecting no-tools, passive-only, claim-only after ownership, and `keeper_stay_silent` without proof when no real progress happened.
- Add regression coverage for execution+stay_silent and owned-task-progress+stay_silent.

## Why
Live audit of the `/Users/dancer/me` runtime showed keepers were active, but some successful action runs were still recorded as cycle failures because one later `keeper_stay_silent` appeared. Example: executor used `keeper_board_comment`, `keeper_board_get`, `keeper_task_claim`, `keeper_board_list`, then `keeper_stay_silent`, and the cycle was marked `Completion contract [require_tool_use] violated`. That is not "잠만잠"; it is progress being misclassified as failure.

## Validation
- `env DUNE_BUILD_DIR=/private/tmp/masc-stay-contract-build DUNE_LOCAL_LOCK=/tmp/masc-stay-contract.lock DUNE_LOCAL_JOBS=2 scripts/dune-local.sh exec ./test/test_keeper_unified.exe -- test --show-errors --compact metrics_observation 47-50`
- `ocamlformat --check lib/keeper/keeper_tool_disclosure.ml test/test_keeper_unified.ml` currently exits 1 because these files are not ocamlformat-stable as a whole; applying formatter would churn unrelated existing formatting.