### PR TITLE
chore(dashboard): remove orphan exports — batch 2 (knip-driven)

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -311,11 +311,6 @@ async function errorResponseInfoFromResponse(res: Response): Promise<ErrorRespon
   return { detail: rawText }
 }
 
-export async function errorDetailFromResponse(res: Response): Promise<string | undefined> {
-  const info = await errorResponseInfoFromResponse(res)
-  return info.detail
-}
-
 export async function apiRequestErrorFromResponse(
   method: string,
   path: string,
@@ -655,26 +650,6 @@ export async function patch<T>(
     throw await apiRequestErrorFromResponse('PATCH', path, res)
   }
   return parseJsonResponse<T>('PATCH', path, res)
-}
-
-export async function postRaw(
-  path: string,
-  body: unknown,
-  extraHeaders?: Record<string, string>,
-  timeoutMs = DEFAULT_POST_TIMEOUT_MS,
-): Promise<string> {
-  const res = await fetchWithTimeout(path, {
-    method: 'POST',
-    headers: {
-      ...jsonHeaders(),
-      ...(extraHeaders ?? {}),
-    },
-    body: JSON.stringify(body),
-  }, timeoutMs)
-  if (!res.ok) {
-    throw await apiRequestErrorFromResponse('POST', path, res)
-  }
-  return res.text()
 }
 
 // --- Operator ---

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -314,7 +314,7 @@ function parseMcpListResponse(raw: string): McpListResponse {
   return parseMcpJsonText(payload) as McpListResponse
 }
 
-export async function listMcpTools(cursor?: string): Promise<McpToolsListResult> {
+async function listMcpTools(cursor?: string): Promise<McpToolsListResult> {
   await ensureSession()
   const text = await mcpPost({
     jsonrpc: '2.0',

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -596,7 +596,7 @@ export async function bindConnector(connectorId: string, keeperName: string, cha
   }
 }
 
-export async function unbindConnector(connectorId: string, channelId: string) {
+async function unbindConnector(connectorId: string, channelId: string) {
   const channel = channelId.trim()
   if (!channel) return
 

--- a/dashboard/src/utils/fps-adaptive.ts
+++ b/dashboard/src/utils/fps-adaptive.ts
@@ -33,10 +33,6 @@ function stop() {
   }
 }
 
-export function getFps(): number {
-  return currentFps
-}
-
 /** Subscribe to FPS updates. Returns an unsubscribe function. */
 export function onFpsChange(cb: (fps: number) => void): () => void {
   listeners.add(cb)

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -96,7 +96,7 @@ function initialContext(): DashboardWorkflowContext | null {
   return null
 }
 
-export const dashboardWorkflowContext = signal<DashboardWorkflowContext | null>(initialContext())
+const dashboardWorkflowContext = signal<DashboardWorkflowContext | null>(initialContext())
 
 export function extractActionPayload(
   action?: OperatorRecommendedAction | null,


### PR DESCRIPTION
## Why

Knip 5.x 후속 sweep (#13313 batch 1 머지 후). 6 export 가 dashboard 어디에서도 외부 import 되지 않는 dead public surface 로 확인되어 정리합니다.

## What

| File | Change | Reason |
|------|--------|--------|
| `dashboard/src/api/core.ts` | `errorDetailFromResponse` 삭제 | 0 caller. `apiRequestErrorFromResponse` 가 동일 helper (`errorResponseInfoFromResponse`) 를 사용하는 상위 함수로 대체 |
| `dashboard/src/api/core.ts` | `postRaw` 삭제 | 0 caller. 모든 사용처는 `post` / `postJson` 으로 routed |
| `dashboard/src/utils/fps-adaptive.ts` | `getFps` 삭제 | 0 caller. 소비자들은 `onFpsChange` subscription 사용 |
| `dashboard/src/api/mcp.ts` | `listMcpTools` 의 `export` 제거 (privatize) | 같은 파일의 `listAllMcpTools` (recursive pagination) 만 호출 |
| `dashboard/src/components/connector-status.ts` | `unbindConnector` 의 `export` 제거 | 같은 파일의 두 onClick 핸들러만 호출 |
| `dashboard/src/workflow-context.ts` | `dashboardWorkflowContext` 의 `export` 제거 | 같은 파일의 `loadWorkflowContext` / `setWorkflowContext` 만 read |

## Verification

- [x] `pnpm tsc --noEmit` — 0 error
- [x] `pnpm lint --quiet` — 0 warning
- [x] `pnpm vitest run` — 4 affected files / 130 tests pass

## Surface change

순수 -29 LOC (3 deletions + 3 unexports), 동작 변화 없음.

## Followups

knip 잔여 unused exports ~55개 + unused exported types 138개. 다음 batch 계속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)