### PR TITLE
fix(cdal): keep proof-store read truth in OAS

### DIFF
--- a/docs/design/cdal-contract-kernel-and-advisory-split.md
+++ b/docs/design/cdal-contract-kernel-and-advisory-split.md
@@ -150,16 +150,16 @@ Any kernel that reconstructs missing facts from traces by filename, timestamp pr
 That is acceptable for transport.
 It is not acceptable as part of a deterministic contract kernel unless the participating subset is typed and fail-closed.
 
-### 3.4 Proof Integrity and Loading Are Weak
+### 3.4 Proof Integrity and Loading Boundaries
 
-`proof-store://` is currently a write-side naming convention, not a full read-side public API.
+`proof-store://` is an OAS-owned read/write scheme. OAS exposes the public
+read surface through `Agent_sdk.Proof_store`; MASC uses
+`lib/proof_artifact_reader.ml` as a narrow adapter and must not mirror the
+directory layout.
 
-Current gaps:
+Remaining deterministic-kernel gap:
 
-- no public dereference surface
-- no typed artifact readers
-- no artifact digest in the manifest
-- no strict fail-closed handling for unsupported schema versions
+- raw evidence artifacts are not all digest-bound in the manifest
 
 ## 4. Proposed Architecture
 
@@ -714,22 +714,29 @@ Cdal_advice
   advisory_input -> advice option
 ```
 
-### 11.2 Long-Term OAS Reader API
+### 11.2 OAS Reader API Status
 
-Long-term, OAS should own the read side for the `proof-store://` scheme.
+OAS owns the read side for the `proof-store://` scheme. MASC readers should
+delegate to `Agent_sdk.Proof_store` through the local adapter, preserving OAS as
+the authority for scheme parsing, traversal rejection, and filesystem layout.
 
-Required public APIs:
+Current public APIs:
 
 - `Proof_store.resolve_ref`
 - `Proof_store.read_json`
 - `Proof_store.read_jsonl`
+- `Proof_store.load_manifest`
 - `Proof_store.load_contract`
 
-This keeps the proof-store scheme and layout authoritative in OAS rather than MASC.
+This keeps the proof-store scheme and layout authoritative in OAS rather than
+MASC.
 
-## 12. Rollout Plan
+## 12. Regression Checklist
 
-### Phase 1A: Single-Run Deterministic Audit in MASC
+The phase-1 deterministic audit lane is implemented in MASC, but future reader
+or judge changes must preserve the boundaries above.
+
+### Single-Run Deterministic Audit in MASC
 
 Preconditions:
 

--- a/docs/design/cross-run-loader-and-window-spec.md
+++ b/docs/design/cross-run-loader-and-window-spec.md
@@ -165,11 +165,24 @@ Runs may use different proof manifest schema versions. The loader must handle ve
 
 Since the current schema remains at version 1 (with optional fields added via `[@yojson.default]`), normalization is handled by the existing `Cdal_proof.of_json` decoder. A separate `normalize_manifest` function is not needed at this time. If a future schema v2 introduces breaking field changes, an explicit normalizer should be added.
 
-## 11. Proof_store Read-Side API (OAS)
+## 11. Proof_store Read-Side API (OAS, Implemented)
 
-The current `Proof_store.list_runs` returns `string list` (unordered directory listing). Cross-run windows require a richer API.
+OAS now owns the `proof-store://` read side through `Agent_sdk.Proof_store`.
+MASC must consume that public surface through `lib/proof_artifact_reader.ml`
+instead of reconstructing proof-store paths.
 
-Proposed additions to `proof_store.mli`:
+Current public read surface in OAS `proof_store.mli`:
+
+- `resolve_ref`
+- `read_json`
+- `read_jsonl`
+- `load_manifest`
+- `load_contract`
+- `list_runs`
+- `list_runs_ordered`
+- `load_window`
+
+The cross-run window APIs use the following public types:
 
 ```ocaml
 (** Run metadata for ordering and filtering. *)
@@ -205,11 +218,13 @@ val load_window :
   ((Cdal_proof.t * Yojson.Safe.t) list * string list, string) result
 ```
 
-These signatures keep the existing `list_runs` unchanged (backward compatible) and add structured alternatives. Implemented in OAS `proof_store.ml`.
+These signatures keep the existing `list_runs` backward compatible and add
+structured alternatives for deterministic window queries. Implementation and
+layout validation stay in OAS `proof_store.ml`; MASC adapters only delegate.
 
-## 12. Exit Criteria
+## 12. Regression Checklist
 
-Cross-run windows may ship when:
+Future cross-run reader changes must preserve:
 
 - `list_runs_ordered` is implemented with stable ordering
 - scope and ordering rules are explicit

--- a/lib/proof_artifact_reader.ml
+++ b/lib/proof_artifact_reader.ml
@@ -16,3 +16,5 @@ let run_artifact_path (config : Agent_sdk.Proof_store.config)
   resolve_path config ref_
 
 let read_json = Agent_sdk.Proof_store.read_json
+
+let read_jsonl = Agent_sdk.Proof_store.read_jsonl

--- a/lib/proof_artifact_reader.mli
+++ b/lib/proof_artifact_reader.mli
@@ -1,7 +1,8 @@
-(** Proof_artifact_reader — Dereference proof-store:// artifact refs.
+(** Proof_artifact_reader — Dereference proof-store:// artifact refs via OAS.
 
-    Resolves [proof-store://{run_id}/{subpath}] references to filesystem
-    paths under [{config.root}/proofs/] and reads their JSON content.
+    This module is MASC's narrow adapter over [Agent_sdk.Proof_store].
+    OAS owns the canonical proof-store scheme, layout validation, and JSON
+    readers; MASC callers should avoid reconstructing those details here.
 
     @since CDAL eval content-based redesign *)
 
@@ -26,3 +27,10 @@ val read_json :
   Agent_sdk.Proof_store.config ->
   Agent_sdk.Cdal_proof.artifact_ref ->
   (Yojson.Safe.t, string) result
+
+(** Read and parse a JSONL artifact from the proof store.
+    Returns [Error] if the file does not exist or contains invalid JSONL. *)
+val read_jsonl :
+  Agent_sdk.Proof_store.config ->
+  Agent_sdk.Cdal_proof.artifact_ref ->
+  (Yojson.Safe.t list, string) result

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -97,6 +97,9 @@ let make_ref ~run_id =
 let make_effects_ref ~run_id =
   Printf.sprintf "proof-store://%s/evidence/effects.json" run_id
 
+let make_events_ref ~run_id =
+  Printf.sprintf "proof-store://%s/evidence/events.jsonl" run_id
+
 let make_effect ?source_path ?source_line () : Yojson.Safe.t =
   let opt name f = function
     | Some value -> [ name, f value ]
@@ -465,6 +468,36 @@ let test_path_traversal_rejected () =
   | Ok path ->
     Alcotest.fail (Printf.sprintf "should reject, got Ok: %s" path)
 
+let test_read_jsonl_delegates_to_oas_reader () =
+  let store, _dir = setup_store () in
+  let run_id = "jsonl-reader-001" in
+  let path =
+    match
+      Masc_mcp.Proof_artifact_reader.run_artifact_path store ~run_id
+        ~relative_path:"evidence/events.jsonl"
+    with
+    | Ok path -> path
+    | Error msg -> Alcotest.fail msg
+  in
+  mkdirp (Filename.dirname path);
+  let oc = open_out path in
+  output_string oc {|{"event":"one"}|};
+  output_char oc '\n';
+  output_string oc {|{"event":"two"}|};
+  output_char oc '\n';
+  close_out oc;
+  match
+    Masc_mcp.Proof_artifact_reader.read_jsonl store (make_events_ref ~run_id)
+  with
+  | Ok [`Assoc [("event", `String "one")]; `Assoc [("event", `String "two")]] ->
+      ()
+  | Ok rows ->
+      Alcotest.fail
+        (Printf.sprintf "unexpected JSONL rows: %s"
+           (Yojson.Safe.to_string (`List rows)))
+  | Error msg ->
+      Alcotest.fail (Printf.sprintf "expected JSONL rows, got error: %s" msg)
+
 (* ================================================================ *)
 (* Cross-run window tests                                            *)
 (* ================================================================ *)
@@ -670,6 +703,8 @@ let () =
          test_effect_source_path_satisfies_gap;
        Alcotest.test_case "path traversal rejected" `Quick
          test_path_traversal_rejected;
+       Alcotest.test_case "jsonl reader delegates to OAS" `Quick
+         test_read_jsonl_delegates_to_oas_reader;
      ]);
     ("cross_run", [
        Alcotest.test_case "single run via project_window" `Quick

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -504,6 +504,79 @@ let test_doc_truth_guard_contracts () =
     (file_contains_pattern "scripts/check-doc-truth.sh"
        "command-plane.ts         -- Command plane types")
 
+let test_proof_store_reader_truth_contracts () =
+  check bool "proof artifact reader delegates ref resolution to OAS" true
+    (file_contains_pattern "lib/proof_artifact_reader.ml"
+       "Agent_sdk.Proof_store.resolve_ref");
+  check bool "proof artifact reader delegates JSON reads to OAS" true
+    (file_contains_pattern "lib/proof_artifact_reader.ml"
+       "Agent_sdk.Proof_store.read_json");
+  check bool "proof artifact reader delegates JSONL reads to OAS" true
+    (file_contains_pattern "lib/proof_artifact_reader.ml"
+       "Agent_sdk.Proof_store.read_jsonl");
+  check bool "proof artifact reader interface names OAS ownership" true
+    (file_contains_pattern "lib/proof_artifact_reader.mli"
+       "Agent_sdk.Proof_store");
+  check bool "proof artifact reader interface no longer documents local layout ownership" true
+    (file_not_contains_pattern "lib/proof_artifact_reader.mli"
+       "paths under [{config.root}/proofs/]");
+  check bool "cross-run design marks OAS read side implemented" true
+    (file_contains_pattern "docs/design/cross-run-loader-and-window-spec.md"
+       "Proof_store Read-Side API (OAS, Implemented)");
+  check bool "cross-run design no longer calls list_runs unordered current truth" true
+    (file_not_contains_pattern "docs/design/cross-run-loader-and-window-spec.md"
+       "The current `Proof_store.list_runs` returns `string list`");
+  check bool "cdal design no longer calls proof-store write-side only" true
+    (file_not_contains_pattern "docs/design/cdal-contract-kernel-and-advisory-split.md"
+       "write-side naming convention");
+  check bool "cdal design no longer defers OAS reader ownership" true
+    (file_not_contains_pattern "docs/design/cdal-contract-kernel-and-advisory-split.md"
+       "Long-term, OAS should own the read side");
+  check bool "cdal design no longer claims unsupported schemas lack fail-closed handling" true
+    (file_not_contains_pattern "docs/design/cdal-contract-kernel-and-advisory-split.md"
+       "no strict fail-closed handling for unsupported schema versions");
+  check bool "cdal design preserves OAS reader authority" true
+    (file_contains_pattern "docs/design/cdal-contract-kernel-and-advisory-split.md"
+       "OAS owns the read side for the `proof-store://` scheme")
+
+let test_keeper_agent_upgrade_source_contracts () =
+  check bool "shared types substrate exists" true
+    (Sys.file_exists (source_path "lib/shared_types/resilience_outcome.mli"));
+  check bool "shared audit substrate exists" true
+    (Sys.file_exists (source_path "lib/shared_audit/store.mli"));
+  check bool "multimodal hydrator is separate from keeper artifact plumbing" true
+    (Sys.file_exists (source_path "lib/multimodal/multimodal_hydrator.mli"));
+  check bool "resilience recovery strategy GADT exists" true
+    (file_contains_pattern "lib/resilience/recovery.ml" "type _ strategy =");
+  let autonomous =
+    file_pattern_position "lib/keeper/keeper_post_turn.ml"
+      "let body = apply_autonomous_wirein ~now:now_ts body"
+  in
+  let resilience =
+    file_pattern_position "lib/keeper/keeper_post_turn.ml"
+      "let body =\n    apply_resilience_wirein"
+  in
+  let tool_emission =
+    file_pattern_position "lib/keeper/keeper_post_turn.ml"
+      "let body = apply_tool_emission_wirein ~now:now_ts body"
+  in
+  let multimodal =
+    file_pattern_position "lib/keeper/keeper_post_turn.ml"
+      "apply_multimodal_wirein ~now:now_ts body"
+  in
+  check bool "keeper post-turn tail order is autonomous before resilience" true
+    (match autonomous, resilience with
+     | Some a, Some r -> a < r
+     | _ -> false);
+  check bool "keeper post-turn tail order is resilience before tool emission" true
+    (match resilience, tool_emission with
+     | Some r, Some t -> r < t
+     | _ -> false);
+  check bool "keeper post-turn tail order is tool emission before multimodal" true
+    (match tool_emission, multimodal with
+     | Some t, Some m -> t < m
+     | _ -> false)
+
 let test_contract_harness_contracts () =
   check bool "contract harness exposes extract_text helper" true
     (file_contains_pattern "scripts/harness/lib/test_framework.sh"
@@ -1473,6 +1546,10 @@ let () =
            test_case "release truth contracts" `Quick test_release_truth_contracts;
            test_case "oas pin source contracts" `Quick test_oas_pin_source_contracts;
            test_case "doc truth guard contracts" `Quick test_doc_truth_guard_contracts;
+           test_case "proof store reader truth contracts" `Quick
+             test_proof_store_reader_truth_contracts;
+           test_case "keeper agent upgrade source contracts" `Quick
+             test_keeper_agent_upgrade_source_contracts;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
            test_case "http write auth contracts" `Quick test_http_write_auth_contracts;
            test_case "tool admin snapshot auth contracts" `Quick


### PR DESCRIPTION
## Summary
- mark the OAS proof-store read API as implemented in MASC design docs instead of future/missing
- expose Proof_artifact_reader.read_jsonl as a narrow delegation to Agent_sdk.Proof_store
- add source guards for proof-store ownership and keeper-agent upgrade surfaces from the Kimi audit bundles

## Why it matters
The Kimi MASC-OAS audit bundle correctly identified an old risk: MASC had been mirroring proof-store layout assumptions. Current code has already moved ownership to OAS, but two design docs still described that read side as missing/future. This PR keeps operator/reviewer guidance aligned with the actual boundary and pins it in tests.

## Verification
- env DUNE_JOBS=2 DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-kimi-proofstore-doc-truth-0506/_build-kimi-check dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-kimi-proofstore-doc-truth-0506 ./test/test_cdal_friction_projection.exe
- env DUNE_JOBS=2 DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-kimi-proofstore-doc-truth-0506/_build-kimi-check dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-kimi-proofstore-doc-truth-0506 ./test/test_ci_hardening_source.exe
- scripts/check-boundary-guard.sh