### PR TITLE
feat(dashboard): RFC-0012 — wire useKeyboardShortcutHost into App root (empty-registry host)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -41,6 +41,8 @@ import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
 import { Menu, X } from 'lucide-preact'
+import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
+import { globalShortcutManager } from './lib/global-shortcut-manager'
 
 // Sidebar collapsed state persists across reloads — a user who picks
 // the dense layout keeps it. Namespaced key avoids clashing with any
@@ -90,6 +92,14 @@ function refreshCurrentRoute(options?: { recordVisit?: boolean }): void {
 }
 
 export function App() {
+  // RFC-0012 §3.2: bind a single document-level keydown listener once at
+  // the app root. Registry starts empty; per RFC §8 each ad-hoc keydown
+  // owner (command palette, modal Escape, IDE multi-keeper pin promote /
+  // unpin) migrates onto `globalShortcutManager` in its own PR. The
+  // manager's `dispatch` returns `false` on no-match so the host does not
+  // `preventDefault`, leaving existing element-scoped listeners working.
+  useKeyboardShortcutHost(globalShortcutManager)
+
   useEffect(() => {
     let cancelled = false
     // Resolved once per mount; runtime changes require a reload.  The

--- a/dashboard/src/lib/global-shortcut-manager.test.ts
+++ b/dashboard/src/lib/global-shortcut-manager.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { globalShortcutManager } from './global-shortcut-manager'
+
+afterEach(() => {
+  globalShortcutManager.unregisterAll()
+})
+
+describe('globalShortcutManager — RFC-0012 dashboard root host', () => {
+  it('exposes the headless-core KeyboardShortcutManager surface', () => {
+    expect(typeof globalShortcutManager.register).toBe('function')
+    expect(typeof globalShortcutManager.unregisterAll).toBe('function')
+    expect(typeof globalShortcutManager.dispatch).toBe('function')
+    expect(typeof globalShortcutManager.subscribe).toBe('function')
+    expect(typeof globalShortcutManager.formatChord).toBe('function')
+    expect(typeof globalShortcutManager.formatAria).toBe('function')
+  })
+
+  it('returns the same instance on repeated import (singleton)', async () => {
+    const reimported = (await import('./global-shortcut-manager')).globalShortcutManager
+    expect(reimported).toBe(globalShortcutManager)
+  })
+
+  it('register + dispatch fires the action and returns true on match', () => {
+    let fired = 0
+    globalShortcutManager.register({
+      id: 'test.cmd-b',
+      chord: { key: 'F1', modifiers: [] },
+      description: 'test bind',
+      scope: 'global',
+      action: () => { fired += 1 },
+    })
+
+    const matched = globalShortcutManager.dispatch({
+      key: 'F1',
+      target: null,
+      preventDefault: () => undefined,
+      stopPropagation: () => undefined,
+    })
+
+    expect(matched).toBe(true)
+    expect(fired).toBe(1)
+  })
+
+  it('dispatch returns false (fall-through) when no shortcut matches', () => {
+    // Registry is empty after afterEach unregisterAll. No registration here:
+    // the host wire-in must NOT preventDefault when there is nothing to fire,
+    // so existing ad-hoc keydown listeners keep working until their owners
+    // migrate per RFC-0012 §8.
+    const matched = globalShortcutManager.dispatch({
+      key: 'F1',
+      target: null,
+      preventDefault: () => undefined,
+      stopPropagation: () => undefined,
+    })
+    expect(matched).toBe(false)
+  })
+
+  it('unregister return cleans up so the same id can re-register', () => {
+    let firedV1 = 0
+    let firedV2 = 0
+    const dispose = globalShortcutManager.register({
+      id: 'test.cmd-b',
+      chord: { key: 'F1', modifiers: [] },
+      description: 'v1',
+      scope: 'global',
+      action: () => { firedV1 += 1 },
+    })
+    dispose()
+
+    globalShortcutManager.register({
+      id: 'test.cmd-b',
+      chord: { key: 'F1', modifiers: [] },
+      description: 'v2',
+      scope: 'global',
+      action: () => { firedV2 += 1 },
+    })
+
+    globalShortcutManager.dispatch({
+      key: 'F1',
+      target: null,
+      preventDefault: () => undefined,
+      stopPropagation: () => undefined,
+    })
+
+    expect(firedV1).toBe(0)
+    expect(firedV2).toBe(1)
+  })
+
+  it('subscribe receives the snapshot on each registry change', () => {
+    const snapshots: number[] = []
+    const unsub = globalShortcutManager.subscribe(s => snapshots.push(s.length))
+    const dispose = globalShortcutManager.register({
+      id: 'test.cmd-b',
+      chord: { key: 'F1', modifiers: [] },
+      description: '',
+      scope: 'global',
+      action: () => undefined,
+    })
+    dispose()
+    unsub()
+
+    expect(snapshots).toEqual([1, 0])
+  })
+})

--- a/dashboard/src/lib/global-shortcut-manager.ts
+++ b/dashboard/src/lib/global-shortcut-manager.ts
@@ -1,0 +1,29 @@
+/**
+ * RFC-0012 dashboard root shortcut host: single module-level
+ * KeyboardShortcutManager instance shared across the dashboard.
+ *
+ * Wire-in policy (RFC-0012 §8):
+ *   - `App` (src/app.ts) calls `useKeyboardShortcutHost(globalShortcutManager)`
+ *     once at mount, binding a single document-level keydown listener that
+ *     dispatches every event through the manager.
+ *   - Consumer modules (command palette, modal Escape, IDE editor binds,
+ *     RFC-0027 multi-keeper pin promote / unpin) migrate their ad-hoc
+ *     keydown listeners onto this manager via `useKeyboardShortcut(...)` in
+ *     **separate PRs**. The host can be wired with an empty registry
+ *     because `dispatch` returns `false` on no-match and the host does not
+ *     `preventDefault` — existing element-scoped keydown listeners keep
+ *     working until their owners migrate.
+ *
+ * Why a module-level singleton:
+ *   The manager is reactive (subscribers fire when registrations change)
+ *   and consumed from many surfaces. A module-level constant keeps the
+ *   import path stable and avoids Context plumbing across the existing
+ *   signals-based store layer. SPA mount-once means HMR-stale instances
+ *   are not a concern in production.
+ *
+ * Tests must rely on `unregisterAll()` (no `_reset` API) to keep the
+ * singleton's runtime contract identical across test and production.
+ */
+import { createKeyboardShortcutManager } from '../../design-system/headless-core/keyboard-shortcuts'
+
+export const globalShortcutManager = createKeyboardShortcutManager()


### PR DESCRIPTION
## 목적

RFC-0012 (#11969 spec / #12000 core / #12211 solid adapter, all merged) 의 dashboard root 통합. `createKeyboardShortcutManager` / `useKeyboardShortcutHost` 가 main 에 있지만 dashboard 의 `src/` 에서 caller 0 → host listener 가 binding 안 됨. 본 PR 가 처음으로 host 를 mount 한다.

## Scope

| 범위 | 본 PR | 별개 PR |
|------|------|--------|
| Module-level manager singleton + host wire-in | ✅ | — |
| 9 ad-hoc keydown owner 들의 migration | ❌ | RFC-0012 §8 강제 |
| 첫 consumer (RFC-0027 PR-γ-2 키보드 단축키 5개) | ❌ | follow-up |

RFC-0012 §8 enforces "consumer migrations as separate PRs". 본 PR scope 는 host wire-in 만.

## Diff stat

- 3 files / +143 / -0
- 신규: `dashboard/src/lib/global-shortcut-manager.ts` (29), `dashboard/src/lib/global-shortcut-manager.test.ts` (104, 6 cases)
- 수정: `dashboard/src/app.ts` (+10): import + `useKeyboardShortcutHost(globalShortcutManager)` 호출

## Public API

### `dashboard/src/lib/global-shortcut-manager.ts` (신규)

```ts
import { createKeyboardShortcutManager } from '../../design-system/headless-core/keyboard-shortcuts'

export const globalShortcutManager = createKeyboardShortcutManager()
```

Module-level singleton. Test 는 `unregisterAll()` 로 reset (별도 `_reset` API 도입 X — production runtime contract 와 동일하게 유지).

### `dashboard/src/app.ts` (수정)

```ts
export function App() {
  // RFC-0012 §3.2: bind a single document-level keydown listener once
  // at the app root. Registry starts empty; per RFC §8 each ad-hoc
  // keydown owner migrates onto `globalShortcutManager` in its own PR.
  // The manager's `dispatch` returns `false` on no-match so the host
  // does not `preventDefault`, leaving existing element-scoped
  // listeners working.
  useKeyboardShortcutHost(globalShortcutManager)

  useEffect(() => { /* existing setup */ }, [])
  // ...
}
```

`useKeyboardShortcutHost` 가 자체적으로 useEffect 를 사용 — `App` 본문에서 직접 호출.

## Why module-level singleton (vs Context Provider)

| 결정 항목 | 선택 | 근거 |
|----------|------|------|
| Singleton | module export | RFC §3 "one registry owns ... across the whole app" |
| 위치 | `src/lib/` | dashboard 의 lib/ 가 공통 유틸리티 위치 |
| Context | 사용 안 함 | dashboard 가 reactive state 를 `@preact/signals` 로 처리, Context 는 signals 와 결이 다름 |
| HMR stale | 무시 | SPA 한 번 mount, production 영향 0 |

## Why empty registry on first wire-in

| 측면 | 설명 |
|------|------|
| Backward compat | `dispatch` 가 no-match 시 false → host 가 `preventDefault` 안 함. 기존 9 element-scoped keydown listener 그대로 작동 |
| Migration timing | 각 keydown owner (palette, modal, IDE) 가 본인 PR 에서 register 호출로 옮겨감. 호스트 wire-in 과 owner migration 의 timing 분리 가능 |
| 검증 단순성 | 본 PR 의 책임 = manager singleton round-trip + host bind. 첫 consumer = RFC-0027 PR-γ-2 의 5 shortcut |

## Test results

```
Test Files  29 passed (29)
     Tests  383 passed (383)  -- src/app.ts + src/lib/ broader sweep
```

| 파일 | total | new |
|------|------|------|
| `global-shortcut-manager.test.ts` (신규) | 6 | 6 (surface / singleton / dispatch true / dispatch false fall-through / re-register / subscribe) |
| 기타 28 test files | 377 | 회귀 0 |

### Platform-agnostic chord 사용 근거

Test 에서 chord 가 `{ key: 'F1', modifiers: [] }`. jsdom 의 `navigator.platform` 이 비어있어 `detectPlatform()` 이 'linux' 반환 → `Mod` 가 `ctrlKey` 매치를 요구. 본 test 의 책임은 manager singleton round-trip 이지 platform-mapping contract 이 아님 — 후자는 `headless-core/keyboard-shortcuts.test.ts` (24 cases on main) 가 이미 검증.

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "global-shortcut-manager OR useKeyboardShortcutHost OR 'RFC-0012 dashboard'" --state open` → 본 PR 외 0건
- `gh pr list --search "..." --state merged --limit 5` → #12000 / #12211 / #11969 (RFC-0012 module PRs, already main); #13323 (RFC-0027 PR-γ, sibling axis 다른 영역)
- `git fetch origin && git log origin/main --since=1h -- 'dashboard/src/app.ts' 'dashboard/src/lib/' 'dashboard/design-system/headless-preact/use-keyboard-shortcut.ts'` → #13313 (orphan exports), #13283 (cockpit keeper runtime). overlap 0
- `rg 'createKeyboardShortcutManager|useKeyboardShortcutHost' dashboard/src/` → 본 PR 신규 caller 만 (이전 0)

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/app.ts src/lib/` → **383/383 pass** across 29 files
- ESLint 본 PR 변경 파일 → 0 error / 3 warning ("File ignored because no matching configuration") — `src/lib/`, `src/app.ts` 는 dashboard ESLint config scope 밖. RFC-0028 PR-β 의 headless-core 와 같은 pre-existing pattern. config 이슈, 코드 이슈 아님.

## Rollback plan

3-file revert. Empty registry 라 production behavior 변경 없음 — revert 가 host listener bind 만 undo.

## Wire-in 과 Consumer migration 의 의도적 분리

본 PR 가 **host listener bind 만** 수행:

| 측면 | 영향 |
|------|------|
| 9 기존 ad-hoc keydown owner | 그대로 작동 (no-match fall-through) |
| Manager registry | 빈 상태로 alive |
| 첫 consumer | RFC-0027 PR-γ-2 의 5 shortcut |
| User-facing 효과 | 본 PR 단독으로는 없음 (registry 비어있음) |

이 분리가 RFC-0012 §8 의 "consumer migrations as separate PRs" 강제 사항과 정확히 일치. 머지해도 user-facing 영향 0, review-time isolation 보장.

## RFC waiver

agent_delegation 영역 변경 없음. host listener 자체는 doc-only / behavior-additive (empty registry, fall-through 동작).

`RFC-WAIVED: doc-only / behavior-additive (host listener bind on empty registry; existing element-scoped keydown listeners unchanged via no-match fall-through). RFC-0012 (#11969 / #12000 / #12211) already merged.`

## Related

- #11969 (RFC-0012 spec) — 본 PR 가 §3.2 / §8 implements
- #12000 (RFC-0012 core + Preact adapter) — 본 PR 가 expose 한 API consume
- #12211 (RFC-0012 Solid adapter) — sibling adapter
- #13323 (RFC-0027 PR-γ drag reorder) — 다음 consumer (PR-γ-2) 의 shortcut wire-in 영역

## Follow-up

- **RFC-0027 PR-γ-2**: 5 multi-keeper pin shortcut (Cmd+1..4 promote, Cmd+Shift+W unpin) — 본 PR 머지 후 첫 consumer
- **9 ad-hoc keydown migration**: 각 owner 가 본인 PR 에서 RFC §8 따라 manager 로 이전
- **Command palette 통합**: 기존 inline keydown → manager 등록

🤖 Generated with [Claude Code](https://claude.com/claude-code)
