### PR TITLE
fix(dashboard): surface IDE branch context

### DIFF
--- a/dashboard/src/components/ide/ide-branch-context-panel.a11y.test.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.a11y.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { waitFor } from '@testing-library/preact'
+import { axe } from 'jest-axe'
+import type { GitGraphResponse } from '../../api/git-graph'
+import { IdeBranchContextPanel } from './ide-branch-context-panel'
+
+function graph(): GitGraphResponse {
+  return {
+    generated_at: '2026-05-06T00:00:00Z',
+    repos: [{
+      id: 'masc',
+      root: '/workspace/masc-mcp',
+      label: 'masc-mcp',
+      current_branch: 'main',
+      head: 'abc123',
+      dirty: false,
+      conflict_count: 0,
+      branch_count: 2,
+      commit_count: 8,
+      worktree_count: 1,
+    }],
+    agents: [{
+      id: 'main',
+      label: 'main',
+      branch: 'main',
+      worktree_path: '/workspace/masc-mcp',
+      color: '#d4a14a',
+    }],
+    nodes: [{
+      id: 'branch-main',
+      kind: 'branch',
+      label: 'main',
+      repo_id: 'masc',
+      agent_id: 'main',
+      color: '#d4a14a',
+      status: 'current',
+      conflict: false,
+      sha: 'abc123',
+      branch: 'main',
+      detail: 'current branch',
+    }],
+    edges: [],
+    stats: {
+      repo_count: 1,
+      agent_count: 1,
+      branch_count: 2,
+      commit_count: 8,
+      conflict_count: 0,
+      dirty_count: 0,
+    },
+    warnings: [],
+  }
+}
+
+describe('IdeBranchContextPanel a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders loaded branch context without axe violations', async () => {
+    const fetchGraph = vi.fn().mockResolvedValue(graph())
+
+    render(
+      html`<${IdeBranchContextPanel}
+        activeRepositoryId=${() => 'masc'}
+        fetchGraph=${fetchGraph}
+        refreshMs=${null}
+      />`,
+      container,
+    )
+
+    await waitFor(() => expect(container.textContent).toContain('masc-mcp'))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders error state without axe violations', async () => {
+    const fetchGraph = vi.fn().mockRejectedValue(new Error('offline'))
+
+    render(
+      html`<${IdeBranchContextPanel}
+        activeRepositoryId=${() => 'masc'}
+        fetchGraph=${fetchGraph}
+        refreshMs=${null}
+      />`,
+      container,
+    )
+
+    await waitFor(() => expect(container.textContent).toContain('git graph unavailable'))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/ide/ide-branch-context-panel.test.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { waitFor } from '@testing-library/preact'
+import type { GitGraphResponse } from '../../api/git-graph'
+import {
+  buildIdeBranchContextModel,
+  IdeBranchContextPanel,
+} from './ide-branch-context-panel'
+
+function makeGraph(overrides: Partial<GitGraphResponse> = {}): GitGraphResponse {
+  return {
+    generated_at: '2026-05-06T00:00:00Z',
+    repos: [
+      {
+        id: 'masc',
+        root: '/workspace/masc-mcp',
+        label: 'masc-mcp',
+        current_branch: 'fix/ide-branch',
+        head: 'abcdef1234567890',
+        dirty: true,
+        conflict_count: 0,
+        branch_count: 3,
+        commit_count: 24,
+        worktree_count: 2,
+      },
+    ],
+    agents: [
+      {
+        id: 'lane-1',
+        label: 'sangsu',
+        branch: 'fix/ide-branch',
+        worktree_path: '/workspace/masc-mcp/.worktrees/fix-ide-branch',
+        color: '#d4a14a',
+      },
+    ],
+    nodes: [
+      {
+        id: 'branch-current',
+        kind: 'branch',
+        label: 'fix/ide-branch',
+        repo_id: 'masc',
+        agent_id: 'lane-1',
+        color: '#d4a14a',
+        status: 'current',
+        conflict: false,
+        sha: 'abcdef1234567890',
+        branch: 'fix/ide-branch',
+        detail: 'current branch',
+      },
+      {
+        id: 'branch-main',
+        kind: 'branch',
+        label: 'main',
+        repo_id: 'masc',
+        agent_id: null,
+        color: null,
+        status: 'clean',
+        conflict: false,
+        sha: '1111111111',
+        branch: 'main',
+        detail: null,
+      },
+    ],
+    edges: [],
+    stats: {
+      repo_count: 1,
+      agent_count: 1,
+      branch_count: 3,
+      commit_count: 24,
+      conflict_count: 0,
+      dirty_count: 1,
+    },
+    warnings: [],
+    ...overrides,
+  }
+}
+
+describe('buildIdeBranchContextModel', () => {
+  it('maps graph data to compact IDE branch context', () => {
+    const model = buildIdeBranchContextModel(makeGraph(), 'masc')
+
+    expect(model?.repoLabel).toBe('masc-mcp')
+    expect(model?.currentBranch).toBe('fix/ide-branch')
+    expect(model?.head).toBe('abcdef1234')
+    expect(model?.status).toBe('dirty')
+    expect(model?.branches[0]?.tone).toBe('current')
+    expect(model?.lanes[0]?.path).toBe('.worktrees/fix-ide-branch')
+  })
+
+  it('prefers conflict status over dirty status', () => {
+    const model = buildIdeBranchContextModel(
+      makeGraph({
+        repos: [{
+          ...makeGraph().repos[0]!,
+          dirty: true,
+          conflict_count: 2,
+        }],
+      }),
+      'masc',
+    )
+
+    expect(model?.status).toBe('conflict')
+    expect(model?.stats.conflictCount).toBe(2)
+  })
+
+  it('returns null when graph has no repositories', () => {
+    expect(buildIdeBranchContextModel(makeGraph({ repos: [] }), null)).toBeNull()
+  })
+})
+
+describe('IdeBranchContextPanel', () => {
+  it('fetches active repository graph and renders compact branch context', async () => {
+    const fetchGraph = vi.fn().mockResolvedValue(makeGraph())
+    const container = document.createElement('div')
+
+    render(
+      h(IdeBranchContextPanel, {
+        activeRepositoryId: () => 'masc',
+        fetchGraph,
+        refreshMs: null,
+      }),
+      container,
+    )
+
+    await waitFor(() => expect(container.textContent).toContain('BRANCH GRAPH'))
+    await waitFor(() => expect(container.textContent).toContain('masc-mcp'))
+
+    expect(fetchGraph).toHaveBeenCalledWith(expect.objectContaining({ limit: 80, repoId: 'masc' }))
+    expect(container.textContent).toContain('fix/ide-branch')
+    expect(container.textContent).toContain('abcdef1234')
+    expect(container.querySelector('svg[aria-label="Branch graph for masc-mcp"]')).not.toBeNull()
+  })
+
+  it('waits for an active repository before fetching branch graph data', async () => {
+    const fetchGraph = vi.fn().mockResolvedValue(makeGraph())
+    const container = document.createElement('div')
+
+    render(
+      h(IdeBranchContextPanel, {
+        activeRepositoryId: () => null,
+        fetchGraph,
+        refreshMs: null,
+      }),
+      container,
+    )
+
+    await waitFor(() => expect(container.textContent).toContain('select repository'))
+    expect(fetchGraph).not.toHaveBeenCalled()
+  })
+
+  it('refreshes when active repository subscription fires', async () => {
+    let repoId: string | null = 'masc'
+    const listeners = new Set<() => void>()
+    const fetchGraph = vi.fn().mockResolvedValue(makeGraph())
+    const container = document.createElement('div')
+
+    render(
+      h(IdeBranchContextPanel, {
+        activeRepositoryId: () => repoId,
+        subscribeActiveRepositoryId: (listener) => {
+          listeners.add(listener)
+          return () => listeners.delete(listener)
+        },
+        fetchGraph,
+        refreshMs: null,
+      }),
+      container,
+    )
+
+    await waitFor(() => expect(fetchGraph).toHaveBeenCalledTimes(1))
+    await act(() => {
+      repoId = 'oas'
+      listeners.forEach(listener => listener())
+      return Promise.resolve()
+    })
+
+    await waitFor(() => expect(fetchGraph).toHaveBeenCalledWith(expect.objectContaining({ repoId: 'oas' })))
+  })
+
+  it('renders error state without throwing', async () => {
+    const fetchGraph = vi.fn().mockRejectedValue(new Error('graph down'))
+    const container = document.createElement('div')
+
+    render(
+      h(IdeBranchContextPanel, {
+        activeRepositoryId: () => 'masc',
+        fetchGraph,
+        refreshMs: null,
+      }),
+      container,
+    )
+
+    await waitFor(() => expect(container.textContent).toContain('git graph unavailable: graph down'))
+    expect(container.querySelector('[role="alert"]')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/ide/ide-branch-context-panel.ts
+++ b/dashboard/src/components/ide/ide-branch-context-panel.ts
@@ -1,0 +1,296 @@
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { fetchGitGraph, type GitGraphResponse } from '../../api/git-graph'
+
+type BranchTone = 'current' | 'dirty' | 'conflict' | 'stale'
+type PanelState = 'loading' | 'ready' | 'empty' | 'error'
+
+export interface IdeBranchChip {
+  readonly id: string
+  readonly label: string
+  readonly tone: BranchTone
+  readonly detail: string
+}
+
+export interface IdeWorktreeLane {
+  readonly id: string
+  readonly label: string
+  readonly branch: string
+  readonly path: string
+  readonly color: string
+}
+
+export interface IdeBranchContextModel {
+  readonly repoLabel: string
+  readonly repoRoot: string
+  readonly currentBranch: string
+  readonly head: string
+  readonly status: 'clean' | 'dirty' | 'conflict'
+  readonly stats: {
+    readonly branchCount: number
+    readonly commitCount: number
+    readonly worktreeCount: number
+    readonly dirtyCount: number
+    readonly conflictCount: number
+  }
+  readonly branches: ReadonlyArray<IdeBranchChip>
+  readonly lanes: ReadonlyArray<IdeWorktreeLane>
+  readonly warnings: ReadonlyArray<string>
+}
+
+interface IdeBranchContextPanelProps {
+  readonly activeRepositoryId?: () => string | null
+  readonly subscribeActiveRepositoryId?: (listener: () => void) => () => void
+  readonly fetchGraph?: typeof fetchGitGraph
+  readonly refreshMs?: number | null
+}
+
+const DEFAULT_REFRESH_MS = 15000
+
+function shortSha(raw: string | null): string {
+  if (!raw) return 'unknown'
+  return raw.length > 10 ? raw.slice(0, 10) : raw
+}
+
+function compactPath(path: string): string {
+  const normalized = path.replace(/\\/g, '/')
+  const parts = normalized.split('/').filter(Boolean)
+  if (parts.length <= 2) return normalized || 'workspace'
+  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
+}
+
+function toneForBranch(node: GitGraphResponse['nodes'][number], currentBranch: string): BranchTone {
+  if (node.conflict || node.status === 'conflict') return 'conflict'
+  if (node.status === 'dirty') return 'dirty'
+  if (node.branch && node.branch === currentBranch) return 'current'
+  if (node.status === 'current') return 'current'
+  return 'stale'
+}
+
+function branchSortKey(branch: IdeBranchChip): string {
+  const toneRank: Record<BranchTone, string> = {
+    current: '0',
+    conflict: '1',
+    dirty: '2',
+    stale: '3',
+  }
+  return `${toneRank[branch.tone]}:${branch.label}`
+}
+
+export function buildIdeBranchContextModel(
+  graph: GitGraphResponse,
+  preferredRepoId?: string | null,
+): IdeBranchContextModel | null {
+  const repo =
+    graph.repos.find(candidate => preferredRepoId && candidate.id === preferredRepoId)
+    ?? graph.repos[0]
+
+  if (!repo) return null
+
+  const currentBranch = repo.current_branch ?? 'detached'
+  const repoNodes = graph.nodes.filter(node => node.repo_id === repo.id)
+  const branches = repoNodes
+    .filter(node => node.kind === 'branch')
+    .map(node => {
+      const label = node.branch ?? node.label
+      return {
+        id: node.id,
+        label,
+        tone: toneForBranch(node, currentBranch),
+        detail: node.detail ?? node.sha ?? node.status,
+      }
+    })
+    .sort((a, b) => branchSortKey(a).localeCompare(branchSortKey(b)))
+    .slice(0, 5)
+
+  const repoAgentIds = new Set(repoNodes.map(node => node.agent_id).filter((id): id is string => Boolean(id)))
+  const lanes = graph.agents
+    .filter(agent => repoAgentIds.size === 0 || repoAgentIds.has(agent.id))
+    .map(agent => ({
+      id: agent.id,
+      label: agent.label,
+      branch: agent.branch ?? 'detached',
+      path: compactPath(agent.worktree_path),
+      color: agent.color,
+    }))
+    .slice(0, 4)
+
+  const status =
+    repo.conflict_count > 0 ? 'conflict'
+      : repo.dirty ? 'dirty'
+        : 'clean'
+
+  return {
+    repoLabel: repo.label,
+    repoRoot: repo.root,
+    currentBranch,
+    head: shortSha(repo.head),
+    status,
+    stats: {
+      branchCount: repo.branch_count,
+      commitCount: repo.commit_count,
+      worktreeCount: repo.worktree_count,
+      dirtyCount: graph.stats.dirty_count,
+      conflictCount: repo.conflict_count,
+    },
+    branches,
+    lanes,
+    warnings: graph.warnings,
+  }
+}
+
+function stateLabel(state: PanelState, model: IdeBranchContextModel | null): string {
+  if (state === 'loading') return 'syncing'
+  if (state === 'error') return 'unavailable'
+  if (!model) return 'empty'
+  if (model.status === 'conflict') return 'conflict'
+  if (model.status === 'dirty') return 'dirty'
+  return 'clean'
+}
+
+function MiniBranchGraph({ model }: { readonly model: IdeBranchContextModel }) {
+  const branches = model.branches.length > 0
+    ? model.branches
+    : [{ id: 'current', label: model.currentBranch, tone: model.status === 'conflict' ? 'conflict' : model.status === 'dirty' ? 'dirty' : 'current', detail: model.head }]
+
+  return html`
+    <svg
+      class="ide-branch-mini-graph"
+      viewBox="0 0 320 86"
+      role="img"
+      aria-label=${`Branch graph for ${model.repoLabel}`}
+    >
+      <line x1="24" y1="43" x2="296" y2="43" class="ide-branch-mini-line" />
+      ${branches.slice(0, 5).map((branch, index) => {
+        const x = 34 + index * 62
+        const y = index % 2 === 0 ? 34 : 52
+        return html`
+          <g key=${branch.id}>
+            <line x1=${x} y1="43" x2=${x} y2=${y} class="ide-branch-mini-link" />
+            <circle cx=${x} cy=${y} r="6" class=${`ide-branch-node is-${branch.tone}`} />
+            <text x=${x} y=${index % 2 === 0 ? 20 : 74} text-anchor="middle" class="ide-branch-mini-label">
+              ${branch.label.length > 10 ? `${branch.label.slice(0, 9)}...` : branch.label}
+            </text>
+          </g>
+        `
+      })}
+    </svg>
+  `
+}
+
+export function IdeBranchContextPanel({
+  activeRepositoryId = () => null,
+  subscribeActiveRepositoryId,
+  fetchGraph = fetchGitGraph,
+  refreshMs = DEFAULT_REFRESH_MS,
+}: IdeBranchContextPanelProps) {
+  const [repoId, setRepoId] = useState<string | null>(() => activeRepositoryId())
+  const [model, setModel] = useState<IdeBranchContextModel | null>(null)
+  const [state, setState] = useState<PanelState>('loading')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!subscribeActiveRepositoryId) return undefined
+    return subscribeActiveRepositoryId(() => {
+      setRepoId(activeRepositoryId())
+    })
+  }, [activeRepositoryId, subscribeActiveRepositoryId])
+
+  useEffect(() => {
+    if (!repoId) {
+      setModel(null)
+      setError(null)
+      setState('empty')
+      return undefined
+    }
+
+    let cancelled = false
+    const controller = new AbortController()
+
+    const load = () => {
+      setState(current => current === 'ready' ? current : 'loading')
+      fetchGraph({ limit: 80, repoId, signal: controller.signal })
+        .then(graph => {
+          if (cancelled) return
+          const next = buildIdeBranchContextModel(graph, repoId)
+          setModel(next)
+          setError(null)
+          setState(next ? 'ready' : 'empty')
+        })
+        .catch(err => {
+          if (cancelled || controller.signal.aborted) return
+          setError(err instanceof Error ? err.message : String(err))
+          setState('error')
+        })
+    }
+
+    load()
+    const timer = refreshMs && refreshMs > 0
+      ? window.setInterval(load, refreshMs)
+      : null
+
+    return () => {
+      cancelled = true
+      controller.abort()
+      if (timer) window.clearInterval(timer)
+    }
+  }, [fetchGraph, refreshMs, repoId])
+
+  const branchSummary = useMemo(() => {
+    if (!model) return '0 branches / 0 worktrees'
+    return `${model.stats.branchCount} branches / ${model.stats.worktreeCount} worktrees`
+  }, [model])
+
+  return html`
+    <section class="ide-branch-context" role="region" aria-label="IDE branch context">
+      <header class="ide-branch-context-head">
+        <span>BRANCH GRAPH</span>
+        <span class=${`ide-branch-state is-${model?.status ?? state}`}>
+          ${stateLabel(state, model)}
+        </span>
+      </header>
+
+      ${model ? html`
+        <div class="ide-branch-repo-row">
+          <span class="ide-branch-repo">${model.repoLabel}</span>
+          <span class="ide-branch-current">${model.currentBranch}</span>
+          <span class="ide-branch-head">${model.head}</span>
+        </div>
+        <${MiniBranchGraph} model=${model} />
+        <div class="ide-branch-stat-row" aria-label=${branchSummary}>
+          <span>${model.stats.branchCount} br</span>
+          <span>${model.stats.worktreeCount} wt</span>
+          <span>${model.stats.commitCount} commits</span>
+          <span class=${model.stats.conflictCount > 0 ? 'is-conflict' : model.stats.dirtyCount > 0 ? 'is-dirty' : ''}>
+            ${model.stats.conflictCount > 0 ? `${model.stats.conflictCount} conflicts` : `${model.stats.dirtyCount} dirty`}
+          </span>
+        </div>
+        ${model.lanes.length > 0 ? html`
+          <ol class="ide-branch-lanes" aria-label="Worktree lanes">
+            ${model.lanes.map(lane => html`
+              <li key=${lane.id}>
+                <span class="ide-branch-lane-color" style=${{ background: lane.color }} aria-hidden="true" />
+                <span class="ide-branch-lane-name">${lane.label}</span>
+                <span class="ide-branch-lane-branch">${lane.branch}</span>
+                <span class="ide-branch-lane-path">${lane.path}</span>
+              </li>
+            `)}
+          </ol>
+        ` : null}
+        ${model.warnings.length > 0 ? html`
+          <div class="ide-branch-warning" role="status">${model.warnings[0]}</div>
+        ` : null}
+      ` : html`
+        <div class="ide-branch-empty" role=${state === 'error' ? 'alert' : 'status'}>
+          ${state === 'loading'
+            ? 'branch graph syncing...'
+            : state === 'error'
+              ? `git graph unavailable: ${error ?? 'unknown error'}`
+              : repoId
+                ? 'no repository graph'
+                : 'select repository'}
+        </div>
+      `}
+    </section>
+  `
+}

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -39,6 +39,7 @@ export interface IdeDataCoordinator {
   readonly repositories: () => ReadonlyArray<Repository>
   readonly activeRepositoryId: () => string | null
   readonly setActiveRepositoryId: (repoId: string | null) => void
+  readonly subscribeActiveRepositoryId: (listener: () => void) => () => void
   readonly scanRepositories: () => Promise<ReadonlyArray<Repository>>
   readonly subscribeRepositories: (listener: () => void) => () => void
   readonly dispose: () => void
@@ -211,6 +212,8 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     setActiveRepositoryId: (repoId: string | null) => {
       activeRepositoryIdSignal.value = repoId
     },
+    subscribeActiveRepositoryId: (listener: () => void) =>
+      activeRepositoryIdSignal.subscribe(listener),
     scanRepositories,
     subscribeRepositories: (listener: () => void) =>
       repositoriesSignal.subscribe(listener),

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -2,6 +2,46 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
+
+vi.mock('../../api/git-graph', () => ({
+  fetchGitGraph: vi.fn(() => Promise.resolve({
+    generated_at: '2026-05-06T00:00:00Z',
+    repos: [{
+      id: 'masc-mcp',
+      root: '/workspace/masc-mcp',
+      label: 'masc-mcp',
+      current_branch: 'main',
+      head: 'abc123',
+      dirty: false,
+      conflict_count: 0,
+      branch_count: 2,
+      commit_count: 8,
+      worktree_count: 1,
+    }],
+    agents: [],
+    nodes: [],
+    edges: [],
+    stats: {
+      repo_count: 1,
+      agent_count: 0,
+      branch_count: 2,
+      commit_count: 8,
+      conflict_count: 0,
+      dirty_count: 0,
+    },
+    warnings: [],
+  })),
+}))
+
+vi.mock('../../api/repositories', () => ({
+  discoverRepositories: vi.fn(() => Promise.resolve([])),
+  fetchRepositoriesList: vi.fn(() => Promise.resolve([{
+    id: 'masc-mcp',
+    name: 'masc-mcp',
+    local_path: '/workspace/masc-mcp',
+  }])),
+}))
+
 import { IdeShell } from './ide-shell'
 import { navigate, route } from '../../router'
 
@@ -83,6 +123,20 @@ describe('IdeShell', () => {
     fireEvent.click(btn)
     expect(route.value.params.layers).toBeUndefined()
     expect(btn.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('renders IDE branch graph context in the review rail', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    expect(container.textContent).toContain('BRANCH GRAPH')
+    await waitFor(() => expect(container.textContent).toContain('masc-mcp'))
+    expect(container.textContent).toContain('main')
   })
 
   it('hydrates cascade layer button from the ?layers=cascade URL param', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -12,6 +12,7 @@ import { IdePresenceStrip } from './ide-presence-strip'
 import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { InspectorKeeperBDI, pinInspectorKeeper } from './inspector-keeper-bdi'
 import { IdePersistencePanel } from './ide-persistence-panel'
+import { IdeBranchContextPanel } from './ide-branch-context-panel'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
@@ -146,11 +147,15 @@ export function IdeShell() {
           class="ide-plane-conversation"
           style=${{
             display: 'grid',
-            gridTemplateRows: 'auto auto 1fr',
+            gridTemplateRows: 'auto auto auto 1fr',
             minHeight: 0,
             overflow: 'auto',
           }}
         >
+          <${IdeBranchContextPanel}
+            activeRepositoryId=${coordinator.activeRepositoryId}
+            subscribeActiveRepositoryId=${coordinator.subscribeActiveRepositoryId}
+          />
           <${IdePersistencePanel} keeperName=${terminalKeeper} />
           <${InspectorKeeperBDI} />
           <${IdeConversationRailMock} />

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -390,6 +390,193 @@
   border-top: 1px solid var(--color-border-divider);
 }
 
+.ide-branch-context {
+  display: grid;
+  grid-template-rows: auto auto auto auto;
+  gap: var(--sp-2);
+  min-width: 0;
+  max-height: 17rem;
+  overflow: hidden;
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--color-border-divider);
+  background: color-mix(in srgb, var(--color-bg-surface) 94%, black);
+}
+
+.ide-branch-context-head,
+.ide-branch-repo-row,
+.ide-branch-stat-row,
+.ide-branch-lanes li {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.ide-branch-context-head {
+  justify-content: space-between;
+  gap: var(--sp-3);
+  color: var(--color-fg-muted);
+  font: var(--type-eyebrow);
+}
+
+.ide-branch-state {
+  color: var(--color-fg-muted);
+}
+
+.ide-branch-state.is-clean {
+  color: var(--color-status-ok);
+}
+
+.ide-branch-state.is-dirty {
+  color: var(--color-status-warn);
+}
+
+.ide-branch-state.is-conflict,
+.ide-branch-state.is-error {
+  color: var(--color-status-err);
+}
+
+.ide-branch-state.is-loading {
+  color: var(--color-status-info);
+}
+
+.ide-branch-repo-row {
+  gap: var(--sp-2);
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
+.ide-branch-repo,
+.ide-branch-current,
+.ide-branch-head,
+.ide-branch-lane-name,
+.ide-branch-lane-branch,
+.ide-branch-lane-path {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-branch-repo {
+  color: var(--color-fg-secondary);
+}
+
+.ide-branch-current {
+  color: var(--color-accent-fg);
+}
+
+.ide-branch-head {
+  margin-left: auto;
+  color: var(--color-fg-disabled);
+}
+
+.ide-branch-mini-graph {
+  width: 100%;
+  height: 5.375rem;
+  overflow: visible;
+}
+
+.ide-branch-mini-line,
+.ide-branch-mini-link {
+  stroke: var(--color-border-strong);
+  stroke-width: 1;
+}
+
+.ide-branch-node {
+  fill: var(--color-bg-elevated);
+  stroke: var(--color-border-strong);
+  stroke-width: 1.5;
+}
+
+.ide-branch-node.is-current {
+  fill: var(--color-accent-fg);
+  stroke: var(--color-accent-fg);
+}
+
+.ide-branch-node.is-dirty {
+  fill: var(--color-status-warn);
+  stroke: var(--color-status-warn);
+}
+
+.ide-branch-node.is-conflict {
+  fill: var(--color-status-err);
+  stroke: var(--color-status-err);
+}
+
+.ide-branch-mini-label {
+  fill: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
+.ide-branch-stat-row {
+  gap: var(--sp-2);
+  overflow-x: auto;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+
+.ide-branch-stat-row::-webkit-scrollbar {
+  display: none;
+}
+
+.ide-branch-stat-row .is-dirty {
+  color: var(--color-status-warn);
+}
+
+.ide-branch-stat-row .is-conflict {
+  color: var(--color-status-err);
+}
+
+.ide-branch-lanes {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ide-branch-lanes li {
+  display: grid;
+  grid-template-columns: 6px minmax(4rem, 0.9fr) minmax(4rem, 1fr) minmax(4rem, 1fr);
+  gap: var(--sp-2);
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
+.ide-branch-lane-color {
+  width: 6px;
+  height: 6px;
+  align-self: center;
+  border-radius: 50%;
+}
+
+.ide-branch-lane-name {
+  color: var(--color-fg-secondary);
+}
+
+.ide-branch-lane-branch {
+  color: var(--color-accent-fg);
+}
+
+.ide-branch-lane-path {
+  color: var(--color-fg-disabled);
+}
+
+.ide-branch-warning,
+.ide-branch-empty {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--color-status-warn);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
+}
+
 .ide-rail-panel {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Add a compact Code IDE branch-context panel backed by `/api/v1/git/graph`.
- Wire the panel to the IDE active repository signal so branch/head/worktree truth follows the selected repo.
- Keep the upstream persistence map in the rail below the new branch panel.

## Why It Matters
The Code Mode reference calls out Branch Graph context, but the IDE rail did not expose the existing live git graph surface. Operators had to leave the editing/review pane to check branch and worktree truth. This keeps current branch, head, dirty/conflict status, and active worktree lanes visible in the Code IDE itself.

## Review Focus
- `IdeBranchContextPanel` model mapping, empty/error/loading states, and scoped repo fetch behavior.
- `IdeDataCoordinator.subscribeActiveRepositoryId` wiring.
- Rail layout/CSS with the existing Persistence Map, Keeper BDI, and Reaction Thread stack.

## Verification
- `pnpm --dir dashboard exec eslint src/components/ide/ide-branch-context-panel.ts src/components/ide/ide-branch-context-panel.test.ts src/components/ide/ide-branch-context-panel.a11y.test.ts src/components/ide/ide-data-coordinator.ts src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-branch-context-panel.test.ts src/components/ide/ide-branch-context-panel.a11y.test.ts src/components/ide/ide-shell.test.ts src/api/git-graph.test.ts src/api/schemas/git-graph.test.ts`
- Browser check: `http://127.0.0.1:5180/dashboard/#code?section=ide-shell&view=source` with Vite proxying to local MASC; branch panel loaded scoped repo data above Persistence Map.

Known local noise during focused Vitest/browser: existing shell tests emit `--localstorage-file` warnings and localhost:3000 ECONNREFUSED/socket-hang-up logs; browser dev server also had unrelated auth/WS/API console noise outside this panel.