### PR TITLE
fix(bounded): stop retrying hard quota failures

### DIFF
--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -191,9 +191,36 @@ let retryable_error_re =
   ] in
   Re.(compile (no_case (alt (List.map str patterns))))
 
+(** Hard quota/capacity exhaustion is not retryable inside this
+    same-agent bounded loop.  Cross-provider fallback and long
+    cooldown decisions are owned by keeper/cascade classifiers. *)
+let hard_quota_error_indicators = [
+  "hard_quota";
+  "terminalquotaerror";
+  "quota_exhausted";
+  "quota exceeded";
+  "insufficient_quota";
+  "you exceeded your current quota";
+  "exhausted your capacity on this model";
+  "quota will reset after";
+  "you've hit your limit";
+  "monthly usage limit";
+  "org's monthly usage limit";
+  "reached your specified api usage limits";
+  "you will regain access on";
+]
+
+let message_looks_like_hard_quota_error msg =
+  let contains needle = String_util.contains_substring_ci msg needle in
+  List.exists contains hard_quota_error_indicators
+  || (contains "claude exited with code 1"
+      && contains "\"api_error_status\":429"
+      && contains "you've hit your limit")
+
 (** Check if error is retryable (transient failures) *)
 let is_retryable_error msg =
-  Re.execp retryable_error_re msg
+  (not (message_looks_like_hard_quota_error msg))
+  && Re.execp retryable_error_re msg
 
 (** Create new bounded state *)
 let create_state constraints =

--- a/lib/bounded.mli
+++ b/lib/bounded.mli
@@ -162,13 +162,17 @@ val calc_backoff_delay : retry_config -> int -> int
     [jitter_range = capped * jitter_factor]. *)
 
 val is_retryable_error : string -> bool
-(** [is_retryable_error msg] is [true] when [msg] matches any of
-    the 14 hoisted patterns: [timeout], [timed out],
-    [connection refused], [connection reset], [network],
-    [ECONNREFUSED], [ETIMEDOUT], [rate limit], [429], [503], [502],
-    [504], [overloaded], [temporarily unavailable].  Case-insensitive
-    via pre-compiled DFAs (rebuilding 14 [Re.t] per call would be
-    wasted on the hot retry path). *)
+(** [is_retryable_error msg] is [true] when [msg] describes a
+    transient local retry condition and [false] for hard-quota /
+    capacity-exhaustion text.  The transient detector matches the 14
+    hoisted patterns [timeout], [timed out], [connection refused],
+    [connection reset], [network], [ECONNREFUSED], [ETIMEDOUT],
+    [rate limit], [429], [503], [502], [504], [overloaded],
+    [temporarily unavailable] via pre-compiled case-insensitive
+    DFAs.  Hard quota/capacity exhaustion short-circuits to [false]
+    even when the message also contains [429], because same-agent
+    retry cannot repair an exhausted account; cascade/keeper
+    classifiers own cross-provider fallback and cooldown. *)
 
 val check_goal : Yojson.Safe.t -> goal -> bool
 (** [check_goal result goal] resolves [goal.path] under [result]

--- a/test/test_bounded.ml
+++ b/test/test_bounded.ml
@@ -267,6 +267,13 @@ let test_is_retryable_error () =
   check bool "rate limit is retryable" true (Bounded.is_retryable_error "Rate limit exceeded 429");
   check bool "503 is retryable" true (Bounded.is_retryable_error "Service unavailable 503");
   check bool "connection refused is retryable" true (Bounded.is_retryable_error "ECONNREFUSED");
+  (* Hard quotas may include 429 but should not burn bounded same-agent retries. *)
+  check bool "cli-wrapped hard quota is not retryable" false
+    (Bounded.is_retryable_error
+       "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit resets Apr 24 at 4am (Asia/Seoul)\"}");
+  check bool "monthly usage cap is not retryable" false
+    (Bounded.is_retryable_error
+       "You have reached your specified API usage limits. You will regain access on 2026-05-07 at 10:00 UTC.");
   (* Non-retryable errors *)
   check bool "generic error not retryable" false (Bounded.is_retryable_error "Invalid JSON");
   check bool "auth error not retryable" false (Bounded.is_retryable_error "Unauthorized 401")

--- a/test/test_bounded_coverage.ml
+++ b/test/test_bounded_coverage.ml
@@ -120,6 +120,15 @@ let test_retryable_rate_limit () =
 let test_retryable_429 () =
   check bool "429" true (Bounded.is_retryable_error "HTTP 429 Too Many Requests")
 
+let test_not_retryable_hard_quota_429 () =
+  check bool "hard quota 429" false
+    (Bounded.is_retryable_error
+       "claude exited with code 1: {\"api_error_status\":429,\"result\":\"You've hit your limit resets Apr 24 at 4am\"}")
+
+let test_not_retryable_quota_exhausted () =
+  check bool "quota exhausted" false
+    (Bounded.is_retryable_error "provider returned quota_exhausted for this account")
+
 let test_retryable_502 () =
   check bool "502" true (Bounded.is_retryable_error "Error 502 Bad Gateway")
 
@@ -243,6 +252,8 @@ let () =
       test_case "ETIMEDOUT" `Quick test_retryable_etimedout;
       test_case "rate limit" `Quick test_retryable_rate_limit;
       test_case "429" `Quick test_retryable_429;
+      test_case "not hard quota 429" `Quick test_not_retryable_hard_quota_429;
+      test_case "not quota exhausted" `Quick test_not_retryable_quota_exhausted;
       test_case "502" `Quick test_retryable_502;
       test_case "503" `Quick test_retryable_503;
       test_case "504" `Quick test_retryable_504;


### PR DESCRIPTION
## Summary

- Prevent `Bounded.is_retryable_error` from treating hard-quota/capacity-exhaustion text as retryable, even when a CLI wrapper also includes `429`.
- Keep soft transient retry behavior for timeout/network/rate-limit/5xx messages.
- Add regression coverage for CLI-wrapped hard-quota 429s, monthly usage caps, and `quota_exhausted` text.

## Why

The bounded loop retries the same agent. A hard quota cannot be repaired by same-agent retry, so retrying burns bounded retry budget and delays the keeper/cascade layer that owns cross-provider fallback and cooldown.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing lib/bounded.ml`
- `ocamlc -stop-after parsing lib/bounded.mli`
- `ocamlc -stop-after parsing test/test_bounded.ml`
- `ocamlc -stop-after parsing test/test_bounded_coverage.ml`
- Attempted `scripts/dune-local.sh build test/test_bounded.exe test/test_bounded_coverage.exe`; stopped my queued build because the shared `/tmp/me-dune-local.lock` queue was saturated behind another long-running focused Dune build.