### PR TITLE
fix(keeper): return docker-visible worktree cwd

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -566,6 +566,47 @@ let repos_dir_of_keeper config agent_name =
   in
   Filename.concat config.base_path repos_rel
 
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+
+let suffix_under ~prefix path =
+  let prefix = strip_trailing_slashes prefix in
+  let path = strip_trailing_slashes path in
+  if String.equal path prefix then Some ""
+  else
+    let prefix_with_sep = prefix ^ "/" in
+    if String.starts_with ~prefix:prefix_with_sep path then
+      Some
+        (String.sub path (String.length prefix_with_sep)
+           (String.length path - String.length prefix_with_sep))
+    else None
+
+let keeper_visible_worktree_path ~config ~agent_name ~host_path =
+  if not (keeper_uses_docker_sandbox ~config ~agent_name) then host_path
+  else
+    let safe_name = Playground_paths.sanitize_keeper_name agent_name in
+    let container_repos_dir =
+      Filename.concat
+        (Filename.concat
+           Env_config_keeper.DockerPlayground.container_playground_root
+           safe_name)
+        "repos"
+    in
+    match suffix_under ~prefix:(repos_dir_of_keeper config agent_name) host_path with
+    | Some "" -> container_repos_dir
+    | Some suffix -> Filename.concat container_repos_dir suffix
+    | None -> host_path
+
+let worktree_next_step keeper_path =
+  Printf.sprintf
+    "Next: keeper_bash cwd=%S cmd=\"git status -sb\"; after edits, git \
+     add/commit/push, then keeper_shell op=gh cmd=\"pr create --draft ...\"."
+    keeper_path
+
 type repo_candidate = {
   name : string;
   path : string;
@@ -996,8 +1037,11 @@ let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
                      ( clone_path,
                        Some
                          (Printf.sprintf
-                            "Sandbox clone auto-provisioned from origin %s (discovered via workspace repo %s)."
-                            origin_url source_root) )))
+                            "Sandbox clone auto-provisioned from %s."
+                            (match extract_github_org_repo origin_url with
+                             | Some org_repo ->
+                                 "https://github.com/" ^ org_repo ^ ".git"
+                             | None -> "a validated local workspace origin")) )))
   | matches ->
       Error
         (workspace_repo_ambiguous_error ~repo_name ~search_root ~matches)
@@ -1129,6 +1173,10 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
 
           let existing_worktree_ok ?(created_concurrently=false) () =
             update_agent_current_task ();
+            let keeper_path =
+              keeper_visible_worktree_path ~config ~agent_name
+                ~host_path:worktree_path
+            in
             let race_note =
               if created_concurrently then
                 "\n  Note: Worktree was created concurrently by another worker."
@@ -1138,9 +1186,9 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             Ok
               (Printf.sprintf
                  "Worktree already exists:\n  Path: %s\n  Branch: %s\n  \
-                  Repo: %s%s%s\n\nNext: cd %s"
-                 worktree_path branch_name repo_name race_note link_note
-                 worktree_path)
+                  Repo: %s%s%s\n\n%s"
+                 keeper_path branch_name repo_name race_note link_note
+                 (worktree_next_step keeper_path))
           in
 
           (* Create .worktrees directory if not exists *)
@@ -1215,6 +1263,10 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                 if exit_code = Unix.WEXITED 0 then begin
                   (* Update agent's current_worktree in state *)
                   update_agent_current_task ();
+                  let keeper_path =
+                    keeper_visible_worktree_path ~config ~agent_name
+                      ~host_path:worktree_path
+                  in
 
                   (* Link to task *)
                   let link_note = maybe_link_task () in
@@ -1225,9 +1277,10 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                     agent_name branch_name worktree_path repo_name task_id (now_iso ()) in
                   log_event config (Yojson.Safe.from_string event);
 
-                  Ok (Printf.sprintf "Worktree created:\n  Path: %s\n  Branch: %s\n  Repo: %s%s%s\n\nNext: cd %s && work && gh pr create --draft"
-                      worktree_path branch_name repo_name note
-                      (provision_note ^ link_note) worktree_path)
+                  Ok (Printf.sprintf "Worktree created:\n  Path: %s\n  Branch: %s\n  Repo: %s%s%s\n\n%s"
+                      keeper_path branch_name repo_name note
+                      (provision_note ^ link_note)
+                      (worktree_next_step keeper_path))
                 end
                 else if is_usable_git_worktree worktree_path then
                   existing_worktree_ok ~created_concurrently:true ()

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -13,7 +13,8 @@ sole clone when exactly one clone exists. If repo_name matches a \
 workspace git repo under your base_path, MASC auto-provisions the \
 sandbox clone on demand; otherwise clone the target repo first with \
 keeper_shell op=git_clone. Ambiguous multi-repo tasks fail instead of \
-picking a clone arbitrarily. After work, create \
+picking a clone arbitrarily. The success response returns a keeper-visible \
+Path; pass it as keeper_bash cwd instead of constructing cd commands. After work, create \
 a PR then call \
 masc_worktree_remove.";
     input_schema = `Assoc [

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -491,6 +491,18 @@ let test_dispatch_worktree_create_and_remove_use_docker_keeper_lane () =
       (Filename.concat ".worktrees"
          (Playground_paths.worktree_dir_name "sangsu" task_id))
   in
+  let docker_visible_worktree =
+    Filename.concat
+      (Filename.concat
+         (Filename.concat
+            (Filename.concat
+               Env_config_keeper.DockerPlayground.container_playground_root
+               "sangsu")
+            "repos")
+         "masc-mcp")
+      (Filename.concat ".worktrees"
+         (Playground_paths.worktree_dir_name "sangsu" task_id))
+  in
   let legacy_worktree =
     Filename.concat base_path
       (Filename.concat ".masc/playground/sangsu/repos/masc-mcp/.worktrees"
@@ -506,6 +518,12 @@ let test_dispatch_worktree_create_and_remove_use_docker_keeper_lane () =
   | Some (true, msg) ->
       check bool "message mentions auto-provision" true
         (contains "auto-provisioned" msg);
+      check bool "message contains docker-visible worktree path" true
+        (contains docker_visible_worktree msg);
+      check bool "message hides host docker worktree path" false
+        (contains docker_worktree msg);
+      check bool "message tells keeper to pass cwd to keeper_bash" true
+        (contains "keeper_bash cwd=" msg);
       check bool "docker sandbox clone created" true
         (Sys.file_exists docker_clone);
       check bool "docker worktree created" true


### PR DESCRIPTION
## Summary
- Return the keeper-visible worktree path from `masc_worktree_create` for Docker keepers instead of the host sandbox path.
- Replace the old `cd <path> && work && gh pr create --draft` hint with an explicit `keeper_bash cwd=...` next step.
- Add Docker-lane coverage that checks the response contains the container-visible worktree path and hides the host worktree path.

## Why
Live `/Users/dancer/me/.masc` logs showed keepers reaching worktree creation but later failing with `cwd_not_directory` and no PR. The GitHub credential bundle is valid, so this patch targets the bad handoff between worktree creation and the keeper shell.

## Validation
- PASS: `git diff --check`
- BLOCKED locally: `scripts/dune-local.sh build test/test_tool_worktree_coverage.exe` first failed in shared Dune cache cleanup (`rmdir ... Directory not empty`), then the retry with `DUNE_CACHE=disabled` stayed queued behind other `/tmp/me-dune-local.lock` holders and was stopped. Use PR CI as the remaining validation surface.

## Follow-up
- #13343 tracks approval-required visibility for `masc_worktree_create` before PR tasks stall.
- #13344 tracks routing PR-producing keeper turns away from providers that omit keeper-bound tools.