### PR TITLE
fix(coord): demote worktree-not-found drift to INFO via typed variant

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -635,6 +635,17 @@ let transition_task_r
                  | Ok msg ->
                    Log.RoomTask.info
                      "%s worktree auto-cleanup: %s" reason_label msg
+                 | Error
+                     (Masc_domain.System
+                        (Masc_domain.System_error.WorktreeNotFound
+                           { worktree; searched_in })) ->
+                   (* #13302 P2-1: metadata-vs-disk drift is the desired
+                      end state for best-effort cleanup. Demote to INFO
+                      so it doesn't drown legitimate failures. *)
+                   Log.RoomTask.info
+                     "%s worktree auto-cleanup: skipped (already absent: \
+                      worktree=%s searched_in=%s)"
+                     reason_label worktree searched_in
                  | Error e ->
                    Log.RoomTask.warn
                      "%s worktree auto-cleanup failed \

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -1283,11 +1283,14 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
       match find_matching_clone repos_dir with
       | Some root -> Ok root
       | None ->
+        (* #13302 P2-1: distinguish metadata-vs-disk drift from generic
+           IO failure. Best-effort cleanup callers (release/cancel
+           transitions) demote this to INFO since "already absent" is
+           the desired end state; explicit-deletion callers still see
+           a typed error. *)
         Error
-          (System (System_error.IoError
-             (Printf.sprintf
-                "Worktree %s not found under sandbox repo clones in %s"
-                worktree_name repos_dir)))
+          (System (System_error.WorktreeNotFound
+             { worktree = worktree_name; searched_in = repos_dir }))
     in
     match resolve_existing_worktree_root () with
     | Error e -> Error e

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -179,6 +179,7 @@ module System_error = struct
     | InvalidFilePath of string
     | StorageError of string
     | ValidationError of string
+    | WorktreeNotFound of { worktree : string; searched_in : string }
 
   let to_string = function
     | NotInitialized -> "[SystemError] MASC not initialized. Use masc_init first."
@@ -188,6 +189,10 @@ module System_error = struct
     | InvalidFilePath reason -> Printf.sprintf "[SystemError] Invalid file path: %s" reason
     | StorageError msg -> Printf.sprintf "[SystemError] Storage error: %s" msg
     | ValidationError msg -> Printf.sprintf "[SystemError] Validation error: %s" msg
+    | WorktreeNotFound { worktree; searched_in } ->
+        Printf.sprintf
+          "[SystemError] Worktree %s not found under sandbox repo clones in %s"
+          worktree searched_in
 end
 
 type t =
@@ -243,7 +248,8 @@ let is_retryable = function
   | System (System_error.IoError _ | System_error.StorageError _) -> true
   | System (System_error.NotInitialized | System_error.AlreadyInitialized
            | System_error.InvalidJson _ | System_error.InvalidFilePath _
-           | System_error.ValidationError _) -> false
+           | System_error.ValidationError _
+           | System_error.WorktreeNotFound _) -> false
   | RateLimitExceeded _ -> true
   | CacheError (CacheReadFailed _ | CacheWriteFailed _ | CacheExpired _) -> true
   | CacheError (CacheCorrupted _) -> false

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -62,6 +62,15 @@ module System_error : sig
     | InvalidFilePath of string
     | StorageError of string
     | ValidationError of string
+    | WorktreeNotFound of { worktree : string; searched_in : string }
+        (** Distinguishes the metadata-vs-disk drift case
+            ([task.worktree = Some _] but no matching git worktree exists
+            under the sandbox repo clones) from generic IO failures. Lets
+            best-effort cleanup callers (release / cancel) demote the
+            condition to INFO instead of WARN, while explicit-deletion
+            callers (MCP [worktree_remove] tool) still surface "already
+            absent" as actionable feedback. See umbrella issue #13302
+            P2-1 audit. *)
   val to_string : t -> string
 end
 


### PR DESCRIPTION
## Summary

Fixes umbrella issue #13302 **P2-1**: best-effort worktree cleanup on `task_release`/`task_cancel` was emitting WARN for the `task.worktree = Some _` but disk-absent case (metadata-vs-disk drift), drowning legitimate IO failures.

Boot log noise:
```
[WARN] [RoomTask] task_release worktree auto-cleanup failed (best-effort, suppressed):
       IO error: Worktree keeper-issue_king-agent-task-150 not found under
       sandbox repo clones in /Users/dancer/me/.masc/playground/docker/issue_king/repos/
```

Reproduced for `issue_king`, `jobsian_purist`, `taskmaster` keepers within 60 seconds of server start.

## Approach

`cleanup_worktree_for_transition` (`coord_task.ml:628`) already silent-handles `task.worktree = None`. The WARN fires only when metadata points to a worktree name but `find_matching_clone` returns `None`. For best-effort cleanup that absence **is** the desired end state.

Distinguish the case from generic IO failure via a typed variant rather than fragile string-prefix match:

- `System_error.WorktreeNotFound { worktree; searched_in }` added to `lib/types/masc_error.{ml,mli}`.
- `coord_worktree.worktree_remove_r` returns the new variant on the `None` branch instead of a string-formatted `IoError`.
- `cleanup_worktree_for_transition` pattern-matches and logs INFO with structured fields.
- Explicit-deletion callers (`tool_worktree.ml` MCP tool, `task_sandbox.ml` sandbox cleanup) keep the typed error and surface it; only `coord_task`'s best-effort transition cleanup demotes.

`is_retryable`: `WorktreeNotFound` is non-retryable (deterministic absence; replay returns the same).

## Diff stat

```
lib/coord/coord_task.ml     | 11 +++++++++++
lib/coord/coord_worktree.ml | 11 +++++++----
lib/types/masc_error.ml     |  8 +++++++-
lib/types/masc_error.mli    |  9 +++++++++
4 files changed, 34 insertions(+), 5 deletions(-)
```

## Test plan

- [x] `test_tool_worktree_coverage.exe` 26/26 pass with new variant in error path
- [x] `@check` passes (full type-check)
- [ ] Boot smoke: `task_release worktree auto-cleanup failed` WARN should reduce to 0 in fresh start; INFO `auto-cleanup: skipped (already absent: ...)` in its place when drift occurs

## Caveats

- This addresses the **noise**, not the underlying drift. Audit comment in #13302 P2-1 lists three drift sources (duplicate cleanup, phantom metadata, manual deletion); resolving them is a separate workstream.
- `tool_worktree.ml` and `task_sandbox.ml` callers were inspected and intentionally left to surface `WorktreeNotFound` directly — explicit user/MCP requests benefit from "already absent" being actionable feedback.

## Related

- Umbrella issue: #13302 (P2-1 audit comment: https://github.com/jeong-sik/masc-mcp/issues/13302#issuecomment-4380863360)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
