### PR TITLE
feat(keeper): add scoped PR workflow tools

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -49,10 +49,9 @@ tools = ["keeper_fs_edit"]
 tools = ["keeper_library_search", "keeper_library_read"]
 
 [groups.github]
-# PR submit helpers are no longer exposed. The canonical path is
-# masc_worktree_create → masc_code_edit/masc_code_write → masc_code_git
-# → keeper_shell op=gh for `gh pr create`.
-tools = ["keeper_preflight_check"]
+# Dedicated PR helpers run keeper-scoped credential preflight before gh.
+# keeper_pr_create is draft-only; ready/merge flows remain gated elsewhere.
+tools = ["keeper_preflight_check", "keeper_pr_list", "keeper_pr_status", "keeper_pr_create"]
 
 [groups.github_review]
 tools = ["keeper_pr_review_read", "keeper_pr_review_comment", "keeper_pr_review_reply"]

--- a/lib/dune
+++ b/lib/dune
@@ -73,6 +73,7 @@
    host_config_provider
    in_container_login_provider
    keeper_gh_shared
+   keeper_tool_github_pr
    keeper_tool_pr_review
    keeper_exec_preflight
    keeper_exec_task

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -280,6 +280,15 @@ let execute_keeper_tool_call_with_outcome
     | "keeper_preflight_check" ->
       make_executed_tool_result
         (Keeper_exec_preflight.handle_keeper_preflight_check ~config ~meta ~args)
+    | "keeper_pr_list" ->
+      make_executed_tool_result
+        (Keeper_tool_github_pr.handle_keeper_pr_list ~config ~meta ~args)
+    | "keeper_pr_status" ->
+      make_executed_tool_result
+        (Keeper_tool_github_pr.handle_keeper_pr_status ~config ~meta ~args)
+    | "keeper_pr_create" ->
+      make_executed_tool_result
+        (Keeper_tool_github_pr.handle_keeper_pr_create ~config ~meta ~args)
     | "keeper_pr_review_read" ->
       make_executed_tool_result
         (Keeper_tool_pr_review.handle_keeper_pr_review_read ~config ~meta ~args)

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -1,0 +1,230 @@
+(** Dedicated GitHub PR keeper tools. *)
+
+open Keeper_types
+open Keeper_exec_shared
+
+let pr_json_fields =
+  "number,title,state,isDraft,headRefName,baseRefName,mergeable,reviewDecision,url,updatedAt"
+
+let credential_state_json = function
+  | Repo_manager_types.Unmaterialized ->
+      `Assoc [ "state", `String "unmaterialized" ]
+  | Repo_manager_types.Materialized { last_verified_at } ->
+      `Assoc
+        [
+          "state", `String "materialized";
+          "last_verified_at", `Intlit (Int64.to_string last_verified_at);
+        ]
+  | Repo_manager_types.Stale { reason } ->
+      `Assoc [ "state", `String "stale"; "reason", `String reason ]
+
+let binding_json (binding : Keeper_gh_env.keeper_binding) ~state =
+  `Assoc
+    [
+      "effective_github_identity", `String binding.effective_github_identity;
+      ( "credential_scope",
+        `String
+          (Keeper_gh_env.credential_scope_to_string binding.credential_scope) );
+      "git_identity_mode", `String binding.git_identity_mode;
+      "credential_state", credential_state_json state;
+    ]
+
+let with_repo_arg repo argv =
+  let repo = String.trim repo in
+  if repo = "" then argv else argv @ [ "-R"; repo ]
+
+let opt_flag flag = function
+  | None -> []
+  | Some value ->
+      let value = String.trim value in
+      if value = "" then [] else [ flag; value ]
+
+let clamp_limit n =
+  Int.max 1 (Int.min 100 n)
+
+let normalize_state raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "open" -> Ok "open"
+  | "closed" -> Ok "closed"
+  | "merged" -> Ok "merged"
+  | "all" -> Ok "all"
+  | other ->
+      Error
+        (Printf.sprintf
+           "state must be one of open, closed, merged, all; got %S" other)
+
+let build_pr_list_argv ~repo ~state ~limit =
+  [ "gh"; "pr"; "list" ]
+  |> with_repo_arg repo
+  |> fun argv ->
+  argv
+  @ [
+      "--state";
+      state;
+      "--limit";
+      string_of_int (clamp_limit limit);
+      "--json";
+      pr_json_fields;
+    ]
+
+let build_pr_status_argv ~repo ~pr_number =
+  [ "gh"; "pr"; "view"; string_of_int pr_number ]
+  |> with_repo_arg repo
+  |> fun argv -> argv @ [ "--json"; pr_json_fields ^ ",body,files,reviews,comments" ]
+
+let build_pr_create_argv ~repo ~title ~body ~base ~head =
+  [ "gh"; "pr"; "create" ]
+  |> with_repo_arg repo
+  |> fun argv ->
+  argv
+  @ [ "--draft"; "--title"; title; "--body"; body ]
+  @ opt_flag "--base" base
+  @ opt_flag "--head" head
+
+let draft_request_allowed args =
+  match Safe_ops.json_bool_opt "draft" args with
+  | Some false -> false
+  | Some true | None -> (
+      match Safe_ops.json_bool_opt "ready" args with
+      | Some true -> false
+      | Some false | None -> true)
+
+let mutation_preset_ok = function
+  | Some (Delivery | Coding | Full) -> true
+  | _ -> false
+
+let scoped_credential_or_error ~config ~meta =
+  match Keeper_gh_env.keeper_binding config ~keeper_name:meta.name with
+  | Error reason ->
+      Error
+        (`Assoc
+          [
+            "ok", `Bool false;
+            "error", `String "credential_binding_failed";
+            "reason", `String reason;
+            "keeper", `String meta.name;
+          ])
+  | Ok binding -> (
+      let state =
+        Credential_materializer.verify_state
+          ~gh_config_dir:binding.gh_config_dir
+      in
+      match state with
+      | Repo_manager_types.Materialized _ ->
+          let env =
+            Keeper_gh_env.compose_base_with_gh_config
+              ~dir:binding.gh_config_dir
+          in
+          Ok (binding, state, env)
+      | Repo_manager_types.Unmaterialized | Repo_manager_types.Stale _ ->
+          Error
+            (`Assoc
+              [
+                "ok", `Bool false;
+                "error", `String "credential_preflight_failed";
+                "keeper", `String meta.name;
+                "credential", binding_json binding ~state;
+              ]))
+
+let status_ok = function
+  | Unix.WEXITED 0 -> true
+  | _ -> false
+
+let output_json ~ok ~tool ~operation ~meta ~binding ~state ~cwd ~output =
+  Yojson.Safe.to_string
+    (`Assoc
+      [
+        "ok", `Bool ok;
+        "tool", `String tool;
+        "operation", `String operation;
+        "keeper", `String meta.name;
+        "credential", binding_json binding ~state;
+        "cwd", `String cwd;
+        "output", `String output;
+      ])
+
+let run_gh ~tool ~operation ~config ~meta ~args ~write argv =
+  match scoped_credential_or_error ~config ~meta with
+  | Error json -> Yojson.Safe.to_string json
+  | Ok (binding, state, env) -> (
+      let cwd_result =
+        if write then
+          Keeper_shell_shared.resolve_keeper_shell_write_cwd ~config ~meta ~args
+        else
+          Keeper_shell_shared.resolve_keeper_shell_read_cwd ~config ~meta ~args
+      in
+      match cwd_result with
+      | Error reason ->
+          Yojson.Safe.to_string
+            (`Assoc
+              [
+                "ok", `Bool false;
+                "tool", `String tool;
+                "error", `String "cwd_resolution_failed";
+                "reason", `String reason;
+                "keeper", `String meta.name;
+              ])
+      | Ok cwd ->
+          let timeout_sec =
+            Env_config_exec_timeout.timeout_sec
+              ~caller:(if write then Pr_review_post else Pr_review)
+              ()
+          in
+          let st, output =
+            Process_eio.run_argv_with_status ~env ~cwd ~timeout_sec argv
+          in
+          output_json ~ok:(status_ok st) ~tool ~operation ~meta ~binding
+            ~state ~cwd ~output)
+
+let handle_keeper_pr_list ~(config : Coord.config) ~(meta : keeper_meta)
+    ~(args : Yojson.Safe.t) =
+  let repo = Safe_ops.json_string ~default:"" "repo" args in
+  let limit = Safe_ops.json_int ~default:20 "limit" args |> clamp_limit in
+  match Safe_ops.json_string ~default:"open" "state" args |> normalize_state with
+  | Error reason -> error_json reason
+  | Ok state ->
+      run_gh ~tool:"keeper_pr_list" ~operation:"pr_list" ~config ~meta
+        ~args ~write:false (build_pr_list_argv ~repo ~state ~limit)
+
+let handle_keeper_pr_status ~(config : Coord.config) ~(meta : keeper_meta)
+    ~(args : Yojson.Safe.t) =
+  let repo = Safe_ops.json_string ~default:"" "repo" args in
+  let pr_number = Keeper_tool_pr_review.pr_number_of_args args in
+  if pr_number = 0 then
+    error_json "pr_number is required. Good: pr_number=123."
+  else
+    run_gh ~tool:"keeper_pr_status" ~operation:"pr_status" ~config ~meta
+      ~args ~write:false (build_pr_status_argv ~repo ~pr_number)
+
+let handle_keeper_pr_create ~(config : Coord.config) ~(meta : keeper_meta)
+    ~(args : Yojson.Safe.t) =
+  let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
+  let body = Safe_ops.json_string ~default:"" "body" args |> String.trim in
+  let repo = Safe_ops.json_string ~default:"" "repo" args in
+  let base = Safe_ops.json_string_opt "base" args in
+  let head = Safe_ops.json_string_opt "head" args in
+  if not (draft_request_allowed args) then
+    error_json "keeper_pr_create is draft-only; omit draft or set draft=true."
+  else if title = "" then
+    error_json "title is required."
+  else if body = "" then
+    error_json "body is required."
+  else if not (mutation_preset_ok (Keeper_types.tool_access_preset meta.tool_access)) then
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          "ok", `Bool false;
+          "error", `String "preset_insufficient";
+          "reason", `String "keeper_pr_create requires delivery, coding, or full preset";
+        ])
+  else
+    run_gh ~tool:"keeper_pr_create" ~operation:"pr_create" ~config ~meta
+      ~args ~write:true
+      (build_pr_create_argv ~repo ~title ~body ~base ~head)
+
+module For_testing = struct
+  let build_pr_list_argv = build_pr_list_argv
+  let build_pr_status_argv = build_pr_status_argv
+  let build_pr_create_argv = build_pr_create_argv
+  let draft_request_allowed = draft_request_allowed
+end

--- a/lib/keeper/keeper_tool_github_pr.mli
+++ b/lib/keeper/keeper_tool_github_pr.mli
@@ -1,0 +1,41 @@
+(** Dedicated GitHub PR keeper tools.
+
+    These are intentionally narrower than [keeper_shell op=gh]: they run
+    scoped [gh] argv commands after verifying the keeper/root GitHub
+    credential bundle and keep PR creation draft-only. *)
+
+val handle_keeper_pr_list :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+
+val handle_keeper_pr_status :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+
+val handle_keeper_pr_create :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+
+module For_testing : sig
+  val build_pr_list_argv :
+    repo:string -> state:string -> limit:int -> string list
+
+  val build_pr_status_argv :
+    repo:string -> pr_number:int -> string list
+
+  val build_pr_create_argv :
+    repo:string ->
+    title:string ->
+    body:string ->
+    base:string option ->
+    head:string option ->
+    string list
+
+  val draft_request_allowed : Yojson.Safe.t -> bool
+end

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -559,6 +559,7 @@ let all_keeper_schemas ~(masc_schemas_fn : keeper_meta -> Masc_domain.tool_schem
   @ Tool_shard.coding_tools
   @ Tool_code_write.schemas
   @ Tool_shard.keeper_preflight_tools
+  @ Tool_shard.keeper_github_pr_tools
   @ Tool_shard.keeper_pr_review_tools
   @ (masc_schemas_fn meta)
 

--- a/lib/keeper/keeper_tool_pr_review.mli
+++ b/lib/keeper/keeper_tool_pr_review.mli
@@ -13,6 +13,10 @@ val all_pr_review_events : pr_review_event list
 val valid_pr_review_event_strings : string list
 val pr_review_mutation_preset_ok : Keeper_types.tool_preset option -> bool
 
+(** Both ["pr_number"] and ["number"] are accepted for schema-drift
+    compatibility across keeper PR tools. *)
+val pr_number_of_args : Yojson.Safe.t -> int
+
 (** Detect "PR not found" markers in [gh] CLI output (REST 404 + GraphQL
     "could not resolve"). Exposed for unit testing the parser; keepers
     consume the structured JSON returned by [handle_keeper_pr_review_read]. *)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -484,6 +484,56 @@ Returns structured JSON with all check results. Read-only, no side effects.";
   };
 ]
 
+(** Dedicated GitHub PR workflow tools. *)
+let keeper_github_pr_tools : Masc_domain.tool_schema list = [
+  {
+    name = "keeper_pr_list";
+    description = "List GitHub pull requests with keeper-scoped credentials. \
+Runs credential preflight before gh, accepts repo owner/name or cwd, and returns gh JSON. Read-only.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name). Optional when cwd is a git repo.")]);
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional keeper sandbox repo/worktree cwd.")]);
+        ("state", `Assoc [("type", `String "string"); ("enum", `List [`String "open"; `String "closed"; `String "merged"; `String "all"]); ("description", `String "PR state filter. Default open.")]);
+        ("limit", `Assoc [("type", `String "integer"); ("description", `String "Max PRs to return, 1-100. Default 20.")]);
+      ]);
+    ];
+  };
+  {
+    name = "keeper_pr_status";
+    description = "Read one GitHub PR status/details with keeper-scoped credentials. \
+Runs credential preflight before gh. Pass pr_number (preferred) or number.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name). Optional when cwd is a git repo.")]);
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional keeper sandbox repo/worktree cwd.")]);
+        ("pr_number", `Assoc [("type", `String "integer"); ("description", `String "PR number (preferred field name)")]);
+        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number (legacy alias for pr_number)")]);
+      ]);
+    ];
+  };
+  {
+    name = "keeper_pr_create";
+    description = "Create a draft GitHub pull request with keeper-scoped credentials. \
+Draft-only by policy: omit draft or set draft=true. Requires delivery, coding, or full preset.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name). Optional when cwd is a git repo.")]);
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Keeper sandbox repo/worktree cwd. Required when repo cannot infer the branch context.")]);
+        ("title", `Assoc [("type", `String "string"); ("description", `String "PR title")]);
+        ("body", `Assoc [("type", `String "string"); ("description", `String "PR body")]);
+        ("base", `Assoc [("type", `String "string"); ("description", `String "Optional base branch")]);
+        ("head", `Assoc [("type", `String "string"); ("description", `String "Optional head branch")]);
+        ("draft", `Assoc [("type", `String "boolean"); ("description", `String "Must be true if provided; ready PR creation is rejected.")]);
+      ]);
+      ("required", `List [`String "title"; `String "body"]);
+    ];
+  };
+]
+
 (** PR review tools — read diffs, leave comments, approve/request changes. *)
 let keeper_pr_review_tools : Masc_domain.tool_schema list = [
   {
@@ -968,7 +1018,7 @@ let all_read_only_keeper_tools () : string list =
    Built from [all_shards] (every shard category flows through
    automatically — no future fix will regress the registry when
    a new shard is added) plus the two non-shard tool lists
-   [keeper_preflight_tools] and [keeper_pr_review_tools] that
+   [keeper_preflight_tools], [keeper_github_pr_tools], and [keeper_pr_review_tools] that
    live in this module but are not owned by any shard definition.
 
    Callers must still run [Config.dedupe_schemas] because a
@@ -981,7 +1031,8 @@ let all_keeper_tool_schemas : Masc_domain.tool_schema list =
       (fun _name (shard : shard) acc -> shard.tools @ acc)
       all_shards []
   in
-  shard_schemas @ keeper_preflight_tools @ keeper_pr_review_tools
+  shard_schemas @ keeper_preflight_tools @ keeper_github_pr_tools
+  @ keeper_pr_review_tools
 
 let recovery_minimum_shard_names () : string list =
   StringMap.fold (fun name shard acc ->

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -153,11 +153,15 @@ val coding_tools : Masc_domain.tool_schema list
 val keeper_preflight_tools : Masc_domain.tool_schema list
 (** Pre-flight validation tool schema. *)
 
+val keeper_github_pr_tools : Masc_domain.tool_schema list
+(** Dedicated GitHub PR workflow tools (list, status, draft create). *)
+
 val all_keeper_tool_schemas : Masc_domain.tool_schema list
 (** #10101: every keeper-facing tool schema exposed by this
     module, built from [all_shards] (so new shard categories
     flow through automatically) plus the non-shard lists
-    [keeper_preflight_tools] and [keeper_pr_review_tools].
+    [keeper_preflight_tools], [keeper_github_pr_tools], and
+    [keeper_pr_review_tools].
     Feeds [Config.raw_all_tool_schemas] so
     [Tool_help_registry.find_entry] can resolve every shard
     tool.  Duplicates are possible; dedupe at consumer. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -231,8 +231,8 @@ let command_blocked_hint name =
     | "curl" | "wget" -> " Use masc_web_search for content fetching."
     | "gh" ->
       " 'gh' is NOT available in the keeper sandbox. For pull-request \
-       work use keeper_pr_list / keeper_pr_view / keeper_pr_comment / \
-       keeper_pr_review_read. For issues use masc_board_list / \
+       work use keeper_pr_list / keeper_pr_status / keeper_pr_create / \
+       keeper_pr_review_read / keeper_pr_review_comment. For issues use masc_board_list / \
        masc_board_post / masc_board_comment. For commits or branches \
        just use 'git' directly — it is on the allowlist."
     | "docker" | "podman" | "kubectl" | "systemctl" | "brew" | "apt"

--- a/test/dune
+++ b/test/dune
@@ -102,6 +102,7 @@
         test_keeper_tool_surface_guard
         test_keeper_benchmark_canary
         test_keeper_pr_review
+        test_keeper_github_pr
         test_playground_paths
         test_keeper_llama_only
         test_keeper_meta_cwd_resilience
@@ -313,6 +314,7 @@
           test_keeper_tool_surface_guard
           test_keeper_benchmark_canary
           test_keeper_pr_review
+          test_keeper_github_pr
           test_playground_paths
           test_keeper_llama_only
           test_keeper_meta_cwd_resilience

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -859,6 +859,28 @@ let test_tool_failure_classification_contracts () =
     (file_contains_pattern "lib/mcp_server_eio_call_tool.ml"
        "let failure_class = classify_tool_failure_class error_detail")
 
+let test_keeper_github_pr_tool_contracts () =
+  check bool "dedicated keeper PR list tool exists" true
+    (file_contains_pattern "lib/tool_shard.ml" {|name = "keeper_pr_list"|});
+  check bool "dedicated keeper PR status tool exists" true
+    (file_contains_pattern "lib/tool_shard.ml" {|name = "keeper_pr_status"|});
+  check bool "dedicated keeper PR create tool exists" true
+    (file_contains_pattern "lib/tool_shard.ml" {|name = "keeper_pr_create"|});
+  check bool "PR create is draft-only" true
+    (file_contains_pattern "lib/keeper/keeper_tool_github_pr.ml"
+       {|[ "gh"; "pr"; "create" ]|}
+     && file_contains_pattern "lib/keeper/keeper_tool_github_pr.ml"
+          {|@ [ "--draft"; "--title"; title; "--body"; body ]|});
+  check bool "keeper PR tools use scoped GH env" true
+    (file_contains_pattern "lib/keeper/keeper_tool_github_pr.ml"
+       "Keeper_gh_env.compose_base_with_gh_config");
+  check bool "keeper PR tools verify credential materialization" true
+    (file_contains_pattern "lib/keeper/keeper_tool_github_pr.ml"
+       "Credential_materializer.verify_state");
+  check bool "keeper PR create is exposed by github group" true
+    (file_contains_pattern "config/tool_policy.toml"
+       {|keeper_pr_create|})
+
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
@@ -1573,10 +1595,12 @@ let () =
              test_board_flusher_start_retry_contracts;
            test_case "docker config storage contracts" `Quick
              test_docker_config_storage_contracts;
-           test_case "tool failure classification contracts" `Quick
-             test_tool_failure_classification_contracts;
-           test_case "dashboard warm hydration contracts" `Quick
-             test_dashboard_warm_hydration_contracts;
+          test_case "tool failure classification contracts" `Quick
+            test_tool_failure_classification_contracts;
+          test_case "keeper github PR tool contracts" `Quick
+            test_keeper_github_pr_tool_contracts;
+          test_case "dashboard warm hydration contracts" `Quick
+            test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;
            test_case "operator surface route contracts" `Quick
              test_operator_surface_route_contracts;

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -1,0 +1,83 @@
+open Alcotest
+
+module K = Masc_mcp.Keeper_tool_github_pr
+
+let test_pr_list_argv_uses_repo_state_limit_json () =
+  check (list string) "argv"
+    [
+      "gh";
+      "pr";
+      "list";
+      "-R";
+      "owner/repo";
+      "--state";
+      "open";
+      "--limit";
+      "20";
+      "--json";
+      "number,title,state,isDraft,headRefName,baseRefName,mergeable,reviewDecision,url,updatedAt";
+    ]
+    (K.For_testing.build_pr_list_argv ~repo:"owner/repo" ~state:"open" ~limit:20)
+
+let test_pr_status_argv_accepts_number () =
+  let argv =
+    K.For_testing.build_pr_status_argv ~repo:"owner/repo" ~pr_number:42
+  in
+  check bool "uses gh pr view" true
+    (List.exists (String.equal "view") argv);
+  check bool "contains number" true
+    (List.exists (String.equal "42") argv);
+  check bool "contains json fields" true
+    (List.exists
+       (fun s -> String.starts_with ~prefix:"number,title,state" s)
+       argv)
+
+let test_pr_create_argv_is_draft_only () =
+  check (list string) "argv"
+    [
+      "gh";
+      "pr";
+      "create";
+      "-R";
+      "owner/repo";
+      "--draft";
+      "--title";
+      "Title";
+      "--body";
+      "Body";
+      "--base";
+      "main";
+      "--head";
+      "feature";
+    ]
+    (K.For_testing.build_pr_create_argv ~repo:"owner/repo" ~title:"Title"
+       ~body:"Body" ~base:(Some "main") ~head:(Some "feature"))
+
+let test_draft_request_rejects_ready_prs () =
+  check bool "omitted draft accepted" true
+    (K.For_testing.draft_request_allowed (`Assoc []));
+  check bool "draft true accepted" true
+    (K.For_testing.draft_request_allowed
+       (`Assoc [ ("draft", `Bool true) ]));
+  check bool "draft false rejected" false
+    (K.For_testing.draft_request_allowed
+       (`Assoc [ ("draft", `Bool false) ]));
+  check bool "ready true rejected" false
+    (K.For_testing.draft_request_allowed
+       (`Assoc [ ("ready", `Bool true) ]))
+
+let () =
+  run "keeper_github_pr"
+    [
+      ( "argv",
+        [
+          test_case "pr list argv" `Quick
+            test_pr_list_argv_uses_repo_state_limit_json;
+          test_case "pr status argv" `Quick
+            test_pr_status_argv_accepts_number;
+          test_case "pr create argv is draft" `Quick
+            test_pr_create_argv_is_draft_only;
+          test_case "draft request guard" `Quick
+            test_draft_request_rejects_ready_prs;
+        ] );
+    ]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -67,6 +67,9 @@ let github_guard_fragments =
     "tool call failed";
     "gh_auth: failed";
     "could not determine repository";
+    "state must be one of open, closed, merged, all";
+    "pr_number is required";
+    "keeper_pr_create is draft-only";
   ]
 
 let voice_guard_fragments =
@@ -337,6 +340,18 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
           ("reply", `String "tool matrix reply");
           ("repo", `String "owner/tool-matrix");
         ]
+  | "keeper_pr_list" ->
+      `Assoc [ ("repo", `String "owner/tool-matrix"); ("state", `String "invalid") ]
+  | "keeper_pr_status" ->
+      `Assoc [ ("repo", `String "owner/tool-matrix"); ("pr_number", `Int 0) ]
+  | "keeper_pr_create" ->
+      `Assoc
+        [
+          ("repo", `String "owner/tool-matrix");
+          ("title", `String "tool matrix draft PR");
+          ("body", `String "tool matrix draft PR body");
+          ("draft", `Bool false);
+        ]
   | "keeper_preflight_check" -> `Assoc []
   | "keeper_stay_silent" ->
       `Assoc [ ("reason", `String "tool matrix silence") ]
@@ -360,6 +375,9 @@ let keeper_expectation_for_name name =
   | "keeper_pr_review_read"
   | "keeper_pr_review_comment"
   | "keeper_pr_review_reply"
+  | "keeper_pr_list"
+  | "keeper_pr_status"
+  | "keeper_pr_create"
   | "keeper_preflight_check" ->
       Expect_success_or_guard github_guard_fragments
   | "keeper_task_done" ->


### PR DESCRIPTION
## Summary
- add dedicated keeper_pr_list, keeper_pr_status, and draft-only keeper_pr_create tools
- run GitHub PR helpers through keeper-scoped GH_CONFIG_DIR after credential preflight
- expose the tools through keeper schemas, policy groups, dispatch, and matrix/source guards

Closes #13273.

## Verification
- PASS: env DUNE_JOBS=1 dune build --root . --cache=disabled --display=short test/test_keeper_github_pr.exe test/test_ci_hardening_source.exe (before final rebase)
- PASS: ./_build/default/test/test_keeper_github_pr.exe (4 tests, before final rebase)
- PASS: ./_build/default/test/test_ci_hardening_source.exe (45 tests, before final rebase)
- PASS: git diff --check
- BLOCKED after rebasing onto current origin/main: focused Dune build fails in existing current-main files not touched by this PR:
  - lib/board_moderation.ml: audit_entry has no resolved field
  - lib/server/server_dashboard_http_delete_actions.ml: Option.bind call shape for Board_moderation.flag_reason_of_string
  - lib/server/server_h2_gateway_routes_extra.mli: odoc comment contains nested string literal syntax