### PR TITLE
fix(dashboard): surface stale logs fetch state

### DIFF
--- a/dashboard_bonsai/src/hud.ml
+++ b/dashboard_bonsai/src/hud.ml
@@ -4,7 +4,7 @@
     optional semantic color class. Phase 1에서 logs_view.ml에 인라인이었으나
     Phase 2.A shell 추출로 공용 모듈 분리.
 
-    logs 탭은 8 cells (Source/Total/Level/Refresh/Limit/Link/Fleet/Synced)을
+    logs 탭은 8 cells (Source/Total/Level/Refresh/Logs/Keepers/Fleet/Synced)을
     쓰지만, 다른 탭은 자기 필요에 맞게 셀 리스트만 다르게 조립 — API는
     cell 렌더 primitive + strip container만 제공.
 

--- a/dashboard_bonsai/src/logs_fetch.ml
+++ b/dashboard_bonsai/src/logs_fetch.ml
@@ -1,21 +1,44 @@
-(** Single-shot fetch of [/api/v1/dashboard/logs].
+(** Single-shot fetch of [/api/v1/dashboard/logs] + 3 s polling.
 
     Uses brr's Fetch API (which returns [Fut.or_error]) and updates
-    [Logs_var.var] on success. Errors are dropped silently for now — a
-    Phase 1c iteration will surface them to the view layer. Polling is
-    also Phase 1c. *)
+    [Logs_var.var] on success. Failed fetches keep the last good
+    response in the Var but stamp it stale, so the logs HUD can show
+    freshness instead of silently rendering old rows as current. *)
 
 open! Core
 open Brr_io
 
 let endpoint = "/api/v1/dashboard/logs?limit=200&level=INFO"
 
+let consecutive_failures = ref 0
+let last_response = ref Logs_types.fixture
+
+let store_success (response : Logs_types.response) : unit =
+  consecutive_failures := 0;
+  let response = { response with fetch_status = Logs_types.Fetch_fresh } in
+  last_response := response;
+  Bonsai.Expert.Var.set Logs_var.var response
+;;
+
+let store_failure (reason : string) : unit =
+  consecutive_failures := !consecutive_failures + 1;
+  let response =
+    { !last_response with
+      fetch_status =
+        Logs_types.Fetch_stale
+          { reason; consecutive_failures = !consecutive_failures }
+    }
+  in
+  Bonsai.Expert.Var.set Logs_var.var response
+;;
+
 let parse_and_store (text : Jstr.t) : unit =
   match Yojson.Safe.from_string (Jstr.to_string text) with
   | json ->
     let response = Logs_types.response_of_yojson json in
-    Bonsai.Expert.Var.set Logs_var.var response
-  | exception _ -> ()
+    store_success response
+  | exception exn ->
+    store_failure ("parse failed: " ^ Exn.to_string exn)
 ;;
 
 let run () : unit =
@@ -26,16 +49,13 @@ let run () : unit =
   in
   Fut.await work (function
     | Ok text -> parse_and_store text
-    | Error _ -> ())
+    | Error _ -> store_failure "fetch failed")
 ;;
 
 (** Register a 3 s polling loop via [window.setInterval]. Runs forever for the
-    lifetime of the page — Phase 1c should swap this for a Bonsai
-    [Clock.every] once the Fut→Effect bridge lands, so polling cancels with
-    component unmount. The returned [timer_id] is ignored for now because the
-    page survives until full reload. *)
+    lifetime of the page. The returned [timer_id] is ignored for now because
+    the page survives until full reload. *)
 let start_polling () : unit =
   let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:3000 run in
   ()
 ;;
-

--- a/dashboard_bonsai/src/logs_types.ml
+++ b/dashboard_bonsai/src/logs_types.ml
@@ -25,7 +25,16 @@ type entry =
 type response =
   { total : int
   ; entries : entry list
+  ; fetch_status : fetch_status
   }
+
+and fetch_status =
+  | Fetch_pending
+  | Fetch_fresh
+  | Fetch_stale of
+      { reason : string
+      ; consecutive_failures : int
+      }
 
 (* ---------- manual Yojson decoding ---------- *)
 
@@ -74,10 +83,26 @@ let response_of_yojson (json : Yojson.Safe.t) : response =
     | `List lst -> List.map entry_of_yojson lst
     | _ -> []
   in
-  { total = int_field json "total"; entries }
+  { total = int_field json "total"
+  ; entries
+  ; fetch_status = Fetch_fresh
+  }
 ;;
 
 (* ---------- helpers ---------- *)
+
+let fetch_status_label = function
+  | Fetch_pending -> "fetch pending"
+  | Fetch_fresh -> "fetch fresh"
+  | Fetch_stale { consecutive_failures; _ } ->
+    Printf.sprintf "fetch stale x%d" consecutive_failures
+;;
+
+let fetch_status_reason = function
+  | Fetch_pending -> "waiting for first logs response"
+  | Fetch_fresh -> "latest logs response parsed"
+  | Fetch_stale { reason; _ } -> reason
+;;
 
 (** Level comparison — matches [Log.level_to_int] on the server. *)
 let level_order = function
@@ -91,6 +116,7 @@ let level_order = function
 (** Fixture for Phase 1a static render. Remove when fetch lands. *)
 let fixture : response =
   { total = 3
+  ; fetch_status = Fetch_pending
   ; entries =
       [ { seq = 3
         ; ts = "2026-04-19T17:12:03Z"

--- a/dashboard_bonsai/src/logs_var.ml
+++ b/dashboard_bonsai/src/logs_var.ml
@@ -7,8 +7,9 @@
     sources (here: brr's [Fut]-based Fetch API) into the incremental
     computation.
 
-    Initial value is [Logs_types.fixture]; it is replaced on the first
-    successful fetch. *)
+    Initial value is [Logs_types.fixture] with [Fetch_pending]. It is
+    replaced on the first successful fetch, and failed polls mark the
+    last good response as stale. *)
 
 let var : Logs_types.response Bonsai.Expert.Var.t =
   Bonsai.Expert.Var.create Logs_types.fixture

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1594,6 +1594,14 @@ let view_tombstrip ?(states = keeper_fsm_states) () =
 
 (* hhmmss_of_iso → Hud.hhmmss_of_iso (shell 추출 Phase 2.A) *)
 
+let logs_fetch_tone (status : Logs_types.fetch_status) : Hud.v_class =
+  match status with
+  | Logs_types.Fetch_pending -> `Neutral
+  | Logs_types.Fetch_fresh -> `Ok
+  | Logs_types.Fetch_stale { consecutive_failures; _ } ->
+    if consecutive_failures >= 3 then `Bad else `Warn
+;;
+
 let view_hud
       ?(keepers : Keepers_types.response = Keepers_types.fixture)
       (response : Logs_types.response) =
@@ -1619,8 +1627,9 @@ let view_hud
     | "" -> "—"
     | ts -> Printf.sprintf "%s UTC" (Hud.hhmmss_of_iso ts)
   in
-  let fetch_v = Keepers_types.fetch_status_label keepers.fetch_status in
-  let fetch_cls : Hud.v_class =
+  let logs_fetch_v = Logs_types.fetch_status_label response.fetch_status in
+  let keepers_fetch_v = Keepers_types.fetch_status_label keepers.fetch_status in
+  let keepers_fetch_cls : Hud.v_class =
     match keepers.fetch_status with
     | Keepers_types.Fetch_pending -> `Neutral
     | Keepers_types.Fetch_fresh -> `Ok
@@ -1632,8 +1641,12 @@ let view_hud
     ; Hud.cell ~k:"Total" ~v:(Printf.sprintf "%d" response.total) ()
     ; Hud.cell ~k:"Level" ~v:"INFO+" ()
     ; Hud.cell ~v_class:`Ok ~k:"Refresh" ~v:"poll · 3s" ()
-    ; Hud.cell ~k:"Limit" ~v:"200" ()
-    ; Hud.cell ~v_class:fetch_cls ~k:"Link" ~v:fetch_v ()
+    ; Hud.cell
+        ~v_class:(logs_fetch_tone response.fetch_status)
+        ~k:"Logs"
+        ~v:logs_fetch_v
+        ()
+    ; Hud.cell ~v_class:keepers_fetch_cls ~k:"Keepers" ~v:keepers_fetch_v ()
     ; Hud.cell ~v_class:fleet_cls ~k:"Fleet" ~v:fleet_v ()
     ; Hud.cell ~k:"Synced" ~v:sync_v ()
     ]


### PR DESCRIPTION
## Summary

- Add pending/fresh/stale fetch state to the Bonsai logs response model.
- Preserve the last good logs payload on fetch or parse failure and mark it stale instead of silently rendering old rows as current.
- Split the logs HUD freshness surface into separate `Logs` and `Keepers` cells.

## Why

The logs feed still had the old silent `exception _ -> ()` / `Error _ -> ()` behavior. That made the dashboard look current even when `/api/v1/dashboard/logs` stopped fetching or parsing. This mirrors the keeper freshness fix with a smaller logs-only scope.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing dashboard_bonsai/src/logs_types.ml`
- `ocamlc -stop-after parsing dashboard_bonsai/src/logs_fetch.ml`
- Attempted `scripts/dune-local.sh build dashboard_bonsai/src/dashboard_bonsai_lib.cma`; stopped my queued build because the shared `/tmp/me-dune-local.lock` queue stayed saturated.
- `ocamlc` cannot parse `logs_view.ml` directly because the file uses Bonsai local syntax (`(_graph @ local)`); CI/Dune owns that check.