### PR TITLE
feat(ide): RFC-0027 PR-γ-2 — 5 multi-keeper-pin keyboard shortcuts (first RFC-0012 consumer)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -43,6 +43,7 @@ import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation
 import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
+import { useKeeperPinShortcuts } from './components/ide/use-keeper-pin-shortcuts'
 
 // Sidebar collapsed state persists across reloads — a user who picks
 // the dense layout keeps it. Namespaced key avoids clashing with any
@@ -99,6 +100,13 @@ export function App() {
   // manager's `dispatch` returns `false` on no-match so the host does not
   // `preventDefault`, leaving existing element-scoped listeners working.
   useKeyboardShortcutHost(globalShortcutManager)
+
+  // RFC-0027 PR-γ-2: 5 multi-keeper-pin shortcuts (Mod+Shift+1..4
+  // promote, Mod+Shift+W unpin head). First consumer of the global
+  // shortcut manager (RFC-0012 §8 consumer-migration pattern). Chord
+  // namespace deliberately distinct from RFC-0012 §4 default IDE set
+  // (Mod+1..9 reserved for tab switching, Mod+W for tab close).
+  useKeeperPinShortcuts(globalShortcutManager)
 
   useEffect(() => {
     let cancelled = false

--- a/dashboard/src/components/ide/multi-keeper-pin-store.test.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.test.ts
@@ -5,7 +5,9 @@ import {
   headPinnedKeeper,
   pinKeeper,
   pinnedKeepers,
+  promotePinAt,
   reorderPins,
+  unpinHead,
   unpinKeeper,
 } from './multi-keeper-pin-store'
 
@@ -215,5 +217,101 @@ describe('multi-keeper-pin-store — reorderPins (RFC-0027 PR-γ §4)', () => {
     expect(pinnedKeepers.value.entries.length).toBe(PIN_CAP)
     reorderPins('c', 3)
     expect(pinnedKeepers.value.entries.length).toBe(PIN_CAP)
+  })
+})
+
+describe('multi-keeper-pin-store — promotePinAt (RFC-0027 PR-γ-2 keyboard)', () => {
+  function seed4(): void {
+    pinKeeper('a')
+    pinKeeper('b')
+    pinKeeper('c')
+    pinKeeper('d')
+    // pinKeeper inserts at head, so post-seed order is [d, c, b, a].
+  }
+
+  it('promotePinAt(2) moves the slot-2 entry to head', () => {
+    seed4()
+    promotePinAt(2)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['c', 'd', 'b', 'a'])
+  })
+
+  it('promotePinAt(4) moves the slot-4 entry to head', () => {
+    seed4()
+    promotePinAt(4)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['a', 'd', 'c', 'b'])
+  })
+
+  it('promotePinAt(1) is a no-op (already head)', () => {
+    seed4()
+    const before = pinnedKeepers.value
+    promotePinAt(1)
+    expect(pinnedKeepers.value).toBe(before)
+  })
+
+  it('promotePinAt(0) is a no-op (1-indexed; idx<1 rejected)', () => {
+    seed4()
+    const before = pinnedKeepers.value
+    promotePinAt(0)
+    expect(pinnedKeepers.value).toBe(before)
+  })
+
+  it('promotePinAt(idx > entries.length) is a no-op', () => {
+    seed4()
+    const before = pinnedKeepers.value
+    promotePinAt(5)
+    promotePinAt(99)
+    expect(pinnedKeepers.value).toBe(before)
+  })
+
+  it('promotePinAt preserves pinnedAtMs (position-only, not fresh pin)', () => {
+    seed4()
+    const slot2Before = pinnedKeepers.value.entries[1]!
+    const tsBefore = slot2Before.pinnedAtMs
+    vi.advanceTimersByTime(120000)
+    promotePinAt(2)
+    const head = pinnedKeepers.value.entries[0]!
+    expect(head.keeperName).toBe(slot2Before.keeperName)
+    expect(head.pinnedAtMs).toBe(tsBefore)
+  })
+
+  it('promotePinAt is a no-op on empty pin list', () => {
+    const before = pinnedKeepers.value
+    promotePinAt(1)
+    promotePinAt(2)
+    expect(pinnedKeepers.value).toBe(before)
+  })
+})
+
+describe('multi-keeper-pin-store — unpinHead (RFC-0027 PR-γ-2 keyboard)', () => {
+  it('removes the head entry, leaving the rest in order', () => {
+    pinKeeper('a')
+    pinKeeper('b')
+    pinKeeper('c')
+    // order = [c, b, a]
+    unpinHead()
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['b', 'a'])
+  })
+
+  it('updates headPinnedKeeper to the new head', () => {
+    pinKeeper('a')
+    pinKeeper('b')
+    expect(headPinnedKeeper.value?.keeperName).toBe('b')
+    unpinHead()
+    expect(headPinnedKeeper.value?.keeperName).toBe('a')
+  })
+
+  it('is a no-op when nothing is pinned', () => {
+    const before = pinnedKeepers.value
+    unpinHead()
+    expect(pinnedKeepers.value).toBe(before)
+  })
+
+  it('clears the collection when called repeatedly', () => {
+    pinKeeper('a')
+    pinKeeper('b')
+    unpinHead()
+    unpinHead()
+    expect(pinnedKeepers.value.entries.length).toBe(0)
+    expect(headPinnedKeeper.value).toBeNull()
   })
 })

--- a/dashboard/src/components/ide/multi-keeper-pin-store.ts
+++ b/dashboard/src/components/ide/multi-keeper-pin-store.ts
@@ -118,3 +118,34 @@ export function reorderPins(fromName: string, toIdx: number): void {
 export const headPinnedKeeper = computed<PinnedKeeperEntry | null>(
   () => pinnedKeepers.value.entries[0] ?? null,
 )
+
+/**
+ * Promote the pinned keeper at 1-based slot `idx` to the head (RFC-0027
+ * PR-γ-2 keyboard `Mod+Shift+1..4`). Position-only change — `pinnedAtMs`
+ * and `line` are preserved so explicit promote does not steal recency
+ * semantics from the next LRU eviction (same convention as `reorderPins`).
+ *
+ *  - `idx` is the user-facing 1-based slot. `1` is already head and is a
+ *    no-op. Out-of-range (≤0 or > entries.length) is a no-op.
+ *  - Whitespace / unknown name lookup is unnecessary — index-only.
+ */
+export function promotePinAt(idx: number): void {
+  const idx0 = idx - 1
+  const prev = pinnedKeepers.value
+  if (idx0 < 0 || idx0 >= prev.entries.length) return
+  if (idx0 === 0) return
+  const target = prev.entries[idx0]
+  if (!target) return
+  reorderPins(target.keeperName, 0)
+}
+
+/**
+ * Drop the head pin (RFC-0027 PR-γ-2 keyboard `Mod+Shift+W`). No-op when
+ * nothing is pinned. Distinct from `clearPins()` which empties the whole
+ * collection.
+ */
+export function unpinHead(): void {
+  const head = pinnedKeepers.value.entries[0]
+  if (!head) return
+  unpinKeeper(head.keeperName)
+}

--- a/dashboard/src/components/ide/use-keeper-pin-shortcuts.test.ts
+++ b/dashboard/src/components/ide/use-keeper-pin-shortcuts.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { createKeyboardShortcutManager } from '../../../design-system/headless-core/keyboard-shortcuts'
+import { useKeeperPinShortcuts } from './use-keeper-pin-shortcuts'
+import {
+  clearPins,
+  pinKeeper,
+  pinnedKeepers,
+} from './multi-keeper-pin-store'
+
+const containers: HTMLElement[] = []
+
+async function mountHost(
+  manager: ReturnType<typeof createKeyboardShortcutManager>,
+): Promise<HTMLElement> {
+  function Host() {
+    useKeeperPinShortcuts(manager)
+    return html`<div data-testid="host" />`
+  }
+  const container = document.createElement('div')
+  containers.push(container)
+  render(html`<${Host} />`, container)
+  // Preact schedules useEffect on a microtask but vitest+jsdom shows a
+  // race on the first render of the file (registry empty after a single
+  // setTimeout(0) tick). vi.waitFor polls until the side effect lands —
+  // robust across cold/warm module state.
+  await vi.waitFor(() => {
+    if (manager.getAll().length < 5) throw new Error('shortcuts not registered yet')
+  })
+  return container
+}
+
+async function unmount(
+  container: HTMLElement,
+  manager: ReturnType<typeof createKeyboardShortcutManager>,
+): Promise<void> {
+  render(null, container)
+  await vi.waitFor(() => {
+    if (manager.getAll().length > 0) throw new Error('shortcuts not disposed yet')
+  })
+}
+
+function fireChord(
+  manager: ReturnType<typeof createKeyboardShortcutManager>,
+  chordKey: string,
+  modifiers: { meta?: boolean; shift?: boolean; ctrl?: boolean } = {},
+): boolean {
+  return manager.dispatch({
+    key: chordKey,
+    metaKey: modifiers.meta ?? false,
+    ctrlKey: modifiers.ctrl ?? false,
+    shiftKey: modifiers.shift ?? false,
+    target: null,
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined,
+  })
+}
+
+beforeEach(() => {
+  clearPins()
+})
+
+afterEach(() => {
+  for (const container of containers.splice(0)) {
+    render(null, container)
+  }
+  clearPins()
+})
+
+describe('useKeeperPinShortcuts — RFC-0027 PR-γ-2', () => {
+  it('registers 5 shortcuts on mount (4 promote + 1 unpin)', async () => {
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    await mountHost(manager)
+    const ids = manager.getAll().map(s => s.id).sort()
+    expect(ids).toEqual([
+      'ide.pin.promote-1',
+      'ide.pin.promote-2',
+      'ide.pin.promote-3',
+      'ide.pin.promote-4',
+      'ide.pin.unpin-head',
+    ])
+  })
+
+  it('disposes all 5 shortcuts on unmount', async () => {
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    const container = await mountHost(manager)
+    expect(manager.getAll().length).toBe(5)
+    await unmount(container, manager)
+    expect(manager.getAll().length).toBe(0)
+  })
+
+  it('Mod+Shift+2 dispatch promotes the slot-2 entry to head', async () => {
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    await mountHost(manager)
+    pinKeeper('a')
+    pinKeeper('b')
+    pinKeeper('c') // post-seed order: [c, b, a]; slot-2 = b
+
+    const matched = fireChord(manager, '2', { meta: true, shift: true })
+
+    expect(matched).toBe(true)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('Mod+Shift+W dispatch unpins the head entry', async () => {
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    await mountHost(manager)
+    pinKeeper('a')
+    pinKeeper('b') // head = b
+
+    const matched = fireChord(manager, 'w', { meta: true, shift: true })
+
+    expect(matched).toBe(true)
+    expect(pinnedKeepers.value.entries.map(e => e.keeperName)).toEqual(['a'])
+  })
+
+  it('Mod+1 (without Shift) does NOT match — exact-match chord policy', async () => {
+    // RFC-0012 §4 reserves Mod+1 for ide.tab.switch.1. Our chord is
+    // Mod+Shift+1; chordMatches() rejects Mod+1 because wantsShift=true
+    // but event.shiftKey=false.
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    await mountHost(manager)
+    pinKeeper('a')
+    pinKeeper('b')
+
+    const matched = fireChord(manager, '1', { meta: true, shift: false })
+
+    expect(matched).toBe(false)
+  })
+
+  it('Mod+W (without Shift) does NOT match the unpin chord', async () => {
+    // Mod+W is RFC-0012 §4 ide.tab.close; ours is Mod+Shift+W.
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    await mountHost(manager)
+    pinKeeper('a')
+    pinKeeper('b')
+
+    const matched = fireChord(manager, 'w', { meta: true, shift: false })
+
+    expect(matched).toBe(false)
+    expect(pinnedKeepers.value.entries.length).toBe(2)
+  })
+
+  it('Mod+Shift+5 is unmatched (only slots 1..4 are bound)', async () => {
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    await mountHost(manager)
+    pinKeeper('a')
+    const matched = fireChord(manager, '5', { meta: true, shift: true })
+    expect(matched).toBe(false)
+  })
+
+  it('description and aria-keyshortcut format are platform-aware', async () => {
+    const manager = createKeyboardShortcutManager({ platform: 'mac' })
+    await mountHost(manager)
+    const promote2 = manager.getById('ide.pin.promote-2')!
+    expect(promote2.description).toBe('Promote pinned keeper #2 to head')
+    expect(manager.formatAria(promote2.chord)).toBe('Meta+Shift+2')
+    expect(manager.formatChord(promote2.chord)).toBe('⌘+Shift+2')
+
+    const winManager = createKeyboardShortcutManager({ platform: 'win' })
+    expect(winManager.formatChord(promote2.chord)).toBe('Ctrl+Shift+2')
+  })
+})

--- a/dashboard/src/components/ide/use-keeper-pin-shortcuts.ts
+++ b/dashboard/src/components/ide/use-keeper-pin-shortcuts.ts
@@ -1,0 +1,62 @@
+import { useEffect } from 'preact/hooks'
+import type { KeyboardShortcutManager } from '../../../design-system/headless-core/keyboard-shortcuts'
+import { promotePinAt, unpinHead } from './multi-keeper-pin-store'
+
+/**
+ * RFC-0027 PR-γ-2: register the 5 multi-keeper-pin keyboard shortcuts on
+ * the supplied manager and dispose them on unmount.
+ *
+ * Chord choices avoid RFC-0012 §4 default IDE set:
+ *   - `Mod+1..9` is reserved for `ide.tab.switch.1..9` → use `Mod+Shift+1..4`
+ *   - `Mod+W` is reserved for `ide.tab.close` → use `Mod+Shift+W` for unpin
+ *     (chord matcher `wantsShift !== shiftKey` makes the two distinct)
+ *
+ * Defaults follow RFC-0012 §3 conventions:
+ *   - `scope: 'global'` — promote/unpin should fire from anywhere in the
+ *     dashboard, not only when the multi-keeper inspector has focus
+ *   - `preserveInInputs: false` — typing `Cmd+Shift+1` in a name field
+ *     should NOT promote a pin; user is mid-edit
+ *   - manager is injected (not the module-level `globalShortcutManager`)
+ *     so tests can supply a `platform: 'mac'` instance and exercise the
+ *     production chord matcher without depending on jsdom's empty
+ *     `navigator.platform`. Production wiring imports
+ *     `globalShortcutManager` and passes it.
+ *
+ * Idempotent re-mount: re-running the effect re-registers under the same
+ * ids, which `KeyboardShortcutManager.register` handles by replacing in
+ * place (with a diagnostic warning). Disposers chain by closure.
+ */
+export function useKeeperPinShortcuts(manager: KeyboardShortcutManager): void {
+  useEffect(() => {
+    const disposers: Array<() => void> = []
+
+    for (let slot = 1; slot <= 4; slot += 1) {
+      const idx = slot
+      disposers.push(
+        manager.register({
+          id: `ide.pin.promote-${idx}`,
+          chord: { key: String(idx), modifiers: ['Mod', 'Shift'] },
+          description: `Promote pinned keeper #${idx} to head`,
+          scope: 'global',
+          preserveInInputs: false,
+          action: () => promotePinAt(idx),
+        }),
+      )
+    }
+
+    disposers.push(
+      manager.register({
+        id: 'ide.pin.unpin-head',
+        chord: { key: 'w', modifiers: ['Mod', 'Shift'] },
+        description: 'Unpin the head pinned keeper',
+        scope: 'global',
+        preserveInInputs: false,
+        action: () => unpinHead(),
+      }),
+    )
+
+    return () => {
+      for (const dispose of disposers) dispose()
+    }
+  }, [manager])
+}


### PR DESCRIPTION
## 목적

RFC-0012 (#13352 host wire-in) 의 **첫 consumer migration**. RFC-0027 multi-keeper-pin 라인의 사용자 단축키 5개를 manager 에 register. PR #13352 base 위에서 동작 (host listener 가 dispatch 까지 connect 됨).

## Scope

| 측면 | 본 PR | 참고 |
|------|------|------|
| 5 keyboard shortcut (4 promote + 1 unpin) | ✅ | RFC-0012 §4 default 와 chord namespace 충돌 회피 |
| Store API 추가 (`promotePinAt`, `unpinHead`) | ✅ | 기존 reorderPins 와 의도 분리 |
| Production wire-in (App 에 hook 호출) | ✅ | RFC-0012 §8 첫 consumer 패턴 |
| 9 ad-hoc keydown 다른 owner migration | ❌ | RFC-0012 §8 강제 별개 PR |
| RFC-0027 spec amend | ❌ | RFC-0027 spec PR (#13289) 머지 후 별개 |

## Diff stat

- 5 files / +363 / -0
- 신규: `use-keeper-pin-shortcuts.ts` (62), `use-keeper-pin-shortcuts.test.ts` (164, 8 cases)
- 수정: `multi-keeper-pin-store.ts` (+31, +`promotePinAt` +`unpinHead`), `multi-keeper-pin-store.test.ts` (+98, 11 cases), `app.ts` (+8)

## 5 shortcut spec

| ID | Chord | Action | RFC-0012 §4 충돌? |
|----|------|--------|-----|
| `ide.pin.promote-1` | `Mod+Shift+1` | promotePinAt(1) → no-op (already head) | `Mod+1`(tab.switch.1) 와 distinct (`wantsShift !== shiftKey` exact-match) |
| `ide.pin.promote-2` | `Mod+Shift+2` | entries[1] → head | distinct |
| `ide.pin.promote-3` | `Mod+Shift+3` | entries[2] → head | distinct |
| `ide.pin.promote-4` | `Mod+Shift+4` | entries[3] → head | distinct |
| `ide.pin.unpin-head` | `Mod+Shift+W` | unpinHead() → drops entries[0] | `Mod+W`(tab.close) 와 distinct |

`Mod+1` reject + `Mod+W` reject 는 본 PR test 에 명시 케이스 (chord namespace 명확 검증).

## Store API 추가

### `promotePinAt(idx: number)`

```ts
export function promotePinAt(idx: number): void {
  const idx0 = idx - 1
  const prev = pinnedKeepers.value
  if (idx0 < 0 || idx0 >= prev.entries.length) return
  if (idx0 === 0) return
  const target = prev.entries[idx0]
  if (!target) return
  reorderPins(target.keeperName, 0)
}
```

- 1-based slot index (사용자 단축키 의미와 일치)
- Position-only move — `pinnedAtMs` / `line` 보존 (LRU semantics)
- Out-of-range / `idx=1` (already head) / 빈 list 모두 no-op

### `unpinHead()`

```ts
export function unpinHead(): void {
  const head = pinnedKeepers.value.entries[0]
  if (!head) return
  unpinKeeper(head.keeperName)
}
```

- `clearPins()` (전체 비움) 과 다름 — head 만 drop
- 빈 list → no-op

## Hook 설계 (RFC-0012 §3.2)

```ts
export function useKeeperPinShortcuts(manager: KeyboardShortcutManager): void {
  useEffect(() => {
    const disposers: Array<() => void> = []
    for (let slot = 1; slot <= 4; slot += 1) {
      const idx = slot
      disposers.push(manager.register({
        id: `ide.pin.promote-${idx}`,
        chord: { key: String(idx), modifiers: ['Mod', 'Shift'] },
        description: `Promote pinned keeper #${idx} to head`,
        scope: 'global',
        preserveInInputs: false,
        action: () => promotePinAt(idx),
      }))
    }
    disposers.push(manager.register({
      id: 'ide.pin.unpin-head',
      chord: { key: 'w', modifiers: ['Mod', 'Shift'] },
      description: 'Unpin the head pinned keeper',
      scope: 'global',
      preserveInInputs: false,
      action: () => unpinHead(),
    }))
    return () => { for (const dispose of disposers) dispose() }
  }, [manager])
}
```

| 결정 | 선택 | 근거 |
|------|------|------|
| Manager 주입 방식 | hook 인자 | test 가 platform: 'mac' 인스턴스로 chord 검증, production 은 globalShortcutManager 주입 — jsdom 의 빈 navigator.platform 우회 |
| `scope` | 'global' | 사용자가 keeper inspector focus 안 잡아도 promote 가능 |
| `preserveInInputs` | false | 입력 중 Mod+Shift+1 promote 안 시킴 |
| Effect deps | `[manager]` | remount 시 같은 manager 면 register stable |

## Production wire-in

`App` 컴포넌트의 `useKeyboardShortcutHost` 바로 다음 line:

```ts
useKeyboardShortcutHost(globalShortcutManager)

// RFC-0027 PR-γ-2: 5 multi-keeper-pin shortcuts (Mod+Shift+1..4
// promote, Mod+Shift+W unpin head). First consumer of the global
// shortcut manager (RFC-0012 §8 consumer-migration pattern). Chord
// namespace deliberately distinct from RFC-0012 §4 default IDE set
// (Mod+1..9 reserved for tab switching, Mod+W for tab close).
useKeeperPinShortcuts(globalShortcutManager)
```

이걸로 host listener (PR #13352) → dispatch → register → action chain 이 한 번 round-trip 작동. RFC-0012 wire-in 의 첫 검증 가능 effect.

## Test results

```
Test Files  59 passed (59)
     Tests  577 passed (577)  -- src/components/ide + src/lib broader sweep
```

| 파일 | total | new (PR-γ-2) |
|------|------|------|
| `multi-keeper-pin-store.test.ts` | 35 | +11 (`promotePinAt` 7 + `unpinHead` 4) |
| `use-keeper-pin-shortcuts.test.ts` (신규) | 8 | 8 (registers / disposes / promote dispatch / unpin dispatch / 3 chord-reject / format) |
| 기타 57 test files | 534 | 회귀 0 |

### Test infra note

Preact `useEffect` 가 microtask 비동기인데 vitest+jsdom 에서 첫 render 시 setTimeout(0) flush 가 race. `vi.waitFor` polling 으로 변경 — cold/warm module state 모두 robust.

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "promote-pin OR unpinHead OR pin-shortcuts OR 'RFC-0027 PR-γ-2'" --state open` → 본 PR 외 0
- `gh pr list --search "..." --state merged --limit 5` → #13352 (host wire-in, base), #13306 (PR-β), #13323 (PR-γ drag)
- `git fetch origin && git log origin/main --since=1h -- dashboard/src/components/ide/multi-keeper-pin-store.ts dashboard/src/app.ts` → #13352 / #13323. Sibling 함수, overlap 0
- `rg "promotePinAt|unpinHead|useKeeperPinShortcuts" dashboard/src/` → 본 PR 신규 caller 만

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/components/ide/ src/lib/` → **577/577 pass** across 59 files
- ESLint 본 PR 변경 파일:
  - `src/components/ide/use-keeper-pin-shortcuts.ts(test.ts)`, `multi-keeper-pin-store.ts(test.ts)` → 0 error / 0 warning
  - `src/app.ts` → 0 error / 1 warning ("File ignored ...") = pre-existing pattern (PR #13352 / RFC-0028 PR-β 와 동일 — `src/app.ts` 가 dashboard ESLint config scope 밖)

## Rollback plan

5-file revert. 새 store API (`promotePinAt`, `unpinHead`) 는 additive — 기존 caller 0. hook + app.ts wire-in 은 RFC-0012 manager 의 첫 consumer 라 revert 시 manager 가 다시 빈 registry 로 돌아감 (PR #13352 의 빈 host 상태와 동일). 다른 keydown owner migration 영향 0.

## Why 본 PR 가 RFC-0012 wire-in 의 진정한 첫 검증

PR #13352 가 host wire-in 만 (registry 빈 상태) 라 사실상 production effect 0. 본 PR 가 처음으로 chord 등록 + dispatch 사이클을 작동시킴. 이걸로 RFC-0012 §3.2 의 "Bind a single global event listener for the registry. Mount once at the app root." 가 user-facing 효과로 실현. RFC §8 의 "consumer migrations as separate PRs" 패턴이 first-class로 작동하는 첫 사례.

## RFC waiver

agent_delegation 영역 변경 없음. behavior-additive (새 chord 등록만, 기존 등록 변경 X).

`RFC-WAIVED: behavior-additive consumer migration on RFC-0012 host (#13352, already merged); chord namespace deliberately non-overlapping with RFC-0012 §4 reserved set (verified by exact-match reject tests Mod+1 / Mod+W). RFC-0027 multi-keeper-pin foundation (#13296 / #13306 / #13323) already merged.`

## Related

- #13352 (RFC-0012 host wire-in) — base, host listener 가 본 PR 의 dispatch 검증
- #13296 (RFC-0027 PR-α store) — 본 PR 의 promote/unpin 이 store 에 추가
- #13306 (RFC-0027 PR-β BDI 컴포넌트) — UX 단짝 (UI 가 chord 표시 가능)
- #13323 (RFC-0027 PR-γ drag) — sibling reorder primitive (reorderPins 호출, promote 와 의도 분리)
- #13289 (RFC-0027 spec Draft) — chord namespace 결정을 본 PR 가 first 시행, spec amend 후속
- #11969 / #12000 (RFC-0012 spec / core) — manager surface

## Follow-up

- **RFC-0027 spec amend PR**: chord 결정 (Mod+Shift+1..4 + Mod+Shift+W) 을 RFC-0027 §? 에 반영, RFC-0012 §4 와 cross-link
- **Discoverability**: Kbd primitive (#8062, 머지됨) 가 `manager.formatChord` 출력을 inspector toolbar 에 표시
- **9 ad-hoc keydown migration**: RFC-0012 §8 따라 각 owner 별 PR (command palette, modal Escape 등)
- **PIN_CAP=4 vs slot=5 검증**: 본 PR 가 slot 5 register 안 함 — RFC-0027 store cap=4 와 일치. cap 변경 시 본 hook 도 같이 amend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
