### PR TITLE
fix(dashboard): reuse terminal molecule in keeper shell

### DIFF
--- a/dashboard/src/components/common/terminal.test.ts
+++ b/dashboard/src/components/common/terminal.test.ts
@@ -42,10 +42,31 @@ describe('Terminal', () => {
     expect(el?.getAttribute('aria-label')).toBe('에이전트 터미널')
   })
 
+  it('applies custom chrome props', () => {
+    const container = document.createElement('div')
+    render(h(Terminal, {
+      lines: [],
+      ariaLabel: 'Keeper shell terminal',
+      className: 'custom-terminal-shell',
+      emptyText: 'waiting for keeper shell output',
+    }), container)
+    const el = container.querySelector('[role="log"]')
+    expect(el?.getAttribute('aria-label')).toBe('Keeper shell terminal')
+    expect(el?.className).toBe('custom-terminal-shell')
+    expect(container.textContent).toContain('waiting for keeper shell output')
+  })
+
   it('applies testId', () => {
     const container = document.createElement('div')
     render(h(Terminal, { lines: [], testId: 'term-1' }), container)
     expect(container.querySelector('[data-testid="term-1"]')).not.toBeNull()
+  })
+
+  it('renders stream tone classes', () => {
+    const container = document.createElement('div')
+    render(h(Terminal, { lines: [{ text: 'stderr line', tone: 'err' }] }), container)
+    const line = container.querySelector('.term-line.is-err')
+    expect(line?.textContent).toContain('stderr line')
   })
 
   it('parses ANSI color codes', () => {

--- a/dashboard/src/components/common/terminal.ts
+++ b/dashboard/src/components/common/terminal.ts
@@ -4,15 +4,23 @@
 // Fallback div renderer (no xterm.js) for zero-dependency bundles.
 
 import { html } from 'htm/preact'
+import type { Ref } from 'preact'
+
+export type TerminalTone = 'cmd' | 'err' | 'meta' | 'ok' | 'out' | 'warn'
 
 export interface TerminalLine {
   text: string
+  tone?: TerminalTone
 }
 
 interface TerminalProps {
   lines: TerminalLine[]
+  ariaLabel?: string
+  className?: string
+  emptyText?: string
   prompt?: string
   testId?: string
+  viewportRef?: Ref<HTMLDivElement>
 }
 
 interface Segment {
@@ -93,10 +101,14 @@ function parseAnsi(input: string): Segment[] {
   return segments
 }
 
+const DEFAULT_TERMINAL_CLASS =
+  'h-64 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2 font-mono'
+
 function renderLine(line: TerminalLine): ReturnType<typeof html> {
   const segments = parseAnsi(line.text)
+  const toneClass = line.tone ? `term-line is-${line.tone}` : 'text-[var(--color-fg-primary)]'
   return html`
-    <div class="min-h-[1.25em] text-xs font-mono leading-relaxed text-[var(--color-fg-primary)]">
+    <div class=${`min-h-[1.25em] text-xs font-mono leading-relaxed ${toneClass}`}>
       ${segments.map(
         (s, idx) => html`
           <span
@@ -113,19 +125,28 @@ function renderLine(line: TerminalLine): ReturnType<typeof html> {
   `
 }
 
-export function Terminal({ lines, prompt = 'agent:$ ', testId }: TerminalProps) {
+export function Terminal({
+  lines,
+  ariaLabel = '에이전트 터미널',
+  className = DEFAULT_TERMINAL_CLASS,
+  emptyText = '출력 없음',
+  prompt = 'agent:$ ',
+  testId,
+  viewportRef,
+}: TerminalProps) {
   return html`
     <div
-      class="h-64 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2 font-mono"
+      class=${className}
       data-terminal
       data-testid=${testId}
+      ref=${viewportRef}
       role="log"
       aria-live="polite"
       aria-atomic="false"
-      aria-label="에이전트 터미널"
+      aria-label=${ariaLabel}
     >
       ${lines.length === 0
-        ? html`<div class="text-3xs text-[var(--color-fg-muted)]">출력 없음</div>`
+        ? html`<div class="text-3xs text-[var(--color-fg-muted)]">${emptyText}</div>`
         : html`<div class="space-y-0.5">${lines.map((l, i) => html`<div key=${i}>${renderLine(l)}</div>`)}</div>`}
       ${prompt
         ? html`

--- a/dashboard/src/components/ide/keeper-shell-drawer.test.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.test.ts
@@ -39,6 +39,16 @@ describe('KeeperShellDrawer event mapping', () => {
     expect(lines[0]).toEqual({ text: 'dropped 15 older bytes', stream: 'meta' })
   })
 
+  it('renders shell output through the shared terminal molecule', async () => {
+    mounted = document.createElement('div')
+    render(h(KeeperShellDrawer, { keeperName: '' }), mounted)
+
+    await waitFor(() => expect(mounted?.textContent).toContain('no keeper selected'))
+    const terminal = mounted.querySelector('[data-terminal][data-testid="keeper-shell-terminal"]')
+    expect(terminal?.getAttribute('aria-label')).toBe('Keeper shell terminal')
+    expect(terminal?.querySelector('.term-line.is-meta')?.textContent).toContain('no keeper selected')
+  })
+
   it('does not auto-scroll when reduced motion is preferred', async () => {
     let resolveFetch: (value: Response) => void = () => undefined
     const fetchPromise = new Promise<Response>(resolve => {

--- a/dashboard/src/components/ide/keeper-shell-drawer.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.ts
@@ -4,6 +4,7 @@ import {
   streamKeeperShell,
   type KeeperShellStreamEvent,
 } from '../../api/keeper-shell'
+import { Terminal, type TerminalLine } from '../common/terminal'
 
 const MAX_TERMINAL_LINES = 5000
 
@@ -55,14 +56,14 @@ function appendLines(current: ShellLine[], next: ShellLine[]): ShellLine[] {
   return [...current, ...next].slice(-MAX_TERMINAL_LINES)
 }
 
-function lineClass(stream: ShellLine['stream']): string {
-  switch (stream) {
+function toTerminalLine(line: ShellLine): TerminalLine {
+  switch (line.stream) {
     case 'stderr':
-      return 'term-line is-err'
+      return { text: line.text, tone: 'err' }
     case 'meta':
-      return 'term-line is-meta'
+      return { text: line.text, tone: 'meta' }
     default:
-      return 'term-line is-out'
+      return { text: line.text, tone: 'out' }
   }
 }
 
@@ -72,6 +73,7 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
   const [status, setStatus] = useState<'idle' | 'streaming' | 'closed' | 'error'>('idle')
   const [taskId, setTaskId] = useState<string | null>(null)
   const viewportRef = useRef<HTMLDivElement | null>(null)
+  const terminalLines = useMemo(() => lines.map(toTerminalLine), [lines])
 
   const prefersReducedMotion = useMemo(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -138,21 +140,15 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
           : null}
         <span class="ml-auto text-[var(--color-fg-muted)]">${status}</span>
       </div>
-      <div
-        ref=${viewportRef}
-        class="h-[260px] overflow-auto bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs leading-relaxed"
-        role="log"
-        aria-live="polite"
-        aria-atomic="false"
-      >
-        ${lines.length === 0
-          ? html`<div class="term-line is-meta">waiting for keeper shell output</div>`
-          : lines.map(
-              (line, index) => html`
-                <div key=${index} class=${lineClass(line.stream)}>${line.text}</div>
-              `,
-            )}
-      </div>
+      <${Terminal}
+        lines=${terminalLines}
+        prompt=${status === 'streaming' ? `${keeper || 'keeper'}:$ ` : ''}
+        testId="keeper-shell-terminal"
+        ariaLabel="Keeper shell terminal"
+        emptyText="waiting for keeper shell output"
+        className="h-[260px] overflow-auto bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs leading-relaxed"
+        viewportRef=${viewportRef}
+      />
     </aside>
   `
 }


### PR DESCRIPTION
Summary:
- Extend the shared Terminal molecule with configurable aria label, empty text, class, viewport ref, and stream tone classes while preserving its defaults.
- Render the Code IDE keeper shell drawer through Terminal instead of its local hand-rolled log DOM.
- Keep the existing keeper shell SSE mapping contract and add coverage that the drawer uses the shared terminal surface.

Verification:
- pnpm --dir dashboard exec eslint src/components/common/terminal.ts src/components/common/terminal.test.ts src/components/common/terminal.a11y.test.ts src/components/ide/keeper-shell-drawer.ts src/components/ide/keeper-shell-drawer.test.ts src/components/ide/ide-shell.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/common/terminal.test.ts src/components/common/terminal.a11y.test.ts src/components/ide/keeper-shell-drawer.test.ts src/components/ide/ide-shell.test.ts
- git diff --check

Browser proof:
- Vite: http://127.0.0.1:5180/dashboard/#code?section=ide-shell&view=source&terminal=open&keeper=sangsu
- Confirmed [data-testid=keeper-shell-terminal][data-terminal], role=log, aria-label=Keeper shell terminal, and live meta line term-line is-meta.
- Screenshot: /tmp/masc-terminal-molecule-drawer.png