### PR TITLE
fix(build): unblock main from board moderation merge fallout

### DIFF
--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -125,7 +125,7 @@ let flag ~target_kind ~target_id ~reporter ~reason =
   (* Reject duplicate unresolved flags for the same target *)
   let duplicate =
     Hashtbl.fold
-      (fun _k e acc ->
+      (fun _k (e : queue_entry) acc ->
          acc ||
          (e.target_id = target_id && e.target_kind = target_kind && not e.resolved))
       s.queue false
@@ -193,7 +193,7 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
   } in
   (* Resolve any open queue entry for this target *)
   Hashtbl.iter
-    (fun _k qe ->
+    (fun _k (qe : queue_entry) ->
        if qe.target_id = target_id && qe.target_kind = target_kind && not qe.resolved then
          Hashtbl.replace s.queue qe.entry_id { qe with resolved = true })
     s.queue;

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -462,8 +462,9 @@ let add_delete_action_routes router =
                          {|{"ok":false,"error":"invalid request: requires {\"target_id\":\"...\"}"}|} reqd
                    | Some target_id ->
                        let reason =
-                         Safe_ops.json_string_opt "reason" json
-                         |> Option.bind Board_moderation.flag_reason_of_string
+                         Option.bind
+                           (Safe_ops.json_string_opt "reason" json)
+                           Board_moderation.flag_reason_of_string
                        in
                        let note = Safe_ops.json_string_opt "note" json in
                        let actor =

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -32,7 +32,7 @@ val dispatch :
     - [GET /api/v1/board/hearths] — hearth name+count list.
     - [GET /api/v1/board/flairs] — available flair list.
     - [GET /api/v1/board/<post_id>] — single post with
-      configurable [format] query param (defaults to ["nested"]).
+      configurable [format] query param (defaults to [nested]).
     - [GET /api/v1/board/sub-boards] — sub-board list.
     - [POST /api/v1/board/sub-boards] — create sub-board (auth required).
       Body: [{ slug, name, description, access? }].
@@ -46,7 +46,7 @@ val dispatch :
       [target_id], [delta], [ts], and [ts_iso].  Query params:
       [agent] (filter by recipient, case-sensitive),
       [limit] (clamped to [1..5000], default 500).  Response also
-      includes a [scoring_rule] field ([\"up=+1,down=0\"]) and a
+      includes a [scoring_rule] field ([up=+1,down=0]) and a
       [totals] summary identical to [GET /api/v1/karma].
 
     {2 Static assets}
@@ -65,12 +65,12 @@ val dispatch :
     {2 Failure modes}
 
     - Path-traversal attempts on the dashboard assets route return
-      [404 Not Found] (NOT [400 Bad Request] — the spec is "do not
+      [404 Not Found] (NOT [400 Bad Request] — the spec is to not
       reveal whether the path traversal was rejected vs the
-      filename was missing").  Pinned at the contract seam.
+      filename was missing).  Pinned at the contract seam.
     - Missing static asset files return [404 Not Found] with the
-      literal body [["404 Not Found"]].  Operator runbooks grep on
-      this exact string.
+      literal body [404 Not Found] (operator runbooks grep on this
+      exact string).
 
     Returns [false] for any route the dispatcher does not
     recognise — the parent gateway falls through to its catch-all


### PR DESCRIPTION
## Why

`dune build` on `main` was failing after #13332 (board moderation safety) merged. Three orthogonal compile errors:

1. **`lib/board_moderation.ml:130,197`** — record disambiguation. `queue_entry` and `audit_entry` both define `target_id` / `target_kind`; the newer `audit_entry` (later in file) wins type inference, so `e.resolved` fails to typecheck. Annotated `Hashtbl` iter args as `queue_entry`.

2. **`lib/server/server_dashboard_http_delete_actions.ml:466`** — `Option.bind` argument order. stdlib signature is `(option, fn)`, but the `|>` pipeline applied `flag_reason_of_string` as the option arg. Rewritten as direct call.

3. **`lib/server/server_h2_gateway_routes_extra.mli`** — ocamldoc treats raw double-quotes as the start of a string literal, and multiple un-escapable quotes in the route documentation (especially `[["404 Not Found"]]` and `["nested"]`) made the `(** *)` block unterminated. Replaced with bare bracket-quoted code spans without inner quotes.

## Verification

```bash
MASC_SKIP_PIN_CHECK=1 dune build --root .  # clean
```

Full repo build green.

## Out of scope

Behavior unchanged — pure compile fix. The semantic intent of `record_action` resolving open queue entries and `flag_reason_of_string` parsing reason strings is preserved.

## Reviewer notes

- Record disambiguation pattern in `board_moderation.ml`: long-term, splitting `queue_entry` and `audit_entry` into separate modules avoids inference fragility.
- Other ocamldoc files with raw double-quotes (`grep -rn '"' lib/**/*.mli`) may have the same latent hazard — out of scope here, but worth a sweep.

This PR is intentionally Draft per `feedback_masc_mcp_draft_guard_blocks_agent_ready`. Add `human-approved-ready` label to enable Ready transition.