### PR TITLE
perf(dashboard): trim keeper runtime trust summary

### DIFF
--- a/docs/audit/2026-05-06-masc-performance-diagnosis-reality-check.md
+++ b/docs/audit/2026-05-06-masc-performance-diagnosis-reality-check.md
@@ -1,0 +1,89 @@
+# MASC Performance Diagnosis Reality Check — 2026-05-06
+
+Source under review: `/Users/dancer/Downloads/MASC_실전_성능_진단.md`
+
+This audit treats that report as a dated input, not current truth. The report
+was written against commit `58ed9c82`; the current inspection target is
+`2e04c82c60a1` on `origin/main`.
+
+## Current Truth
+
+Several quick-win recommendations in the report are already implemented or no
+longer map cleanly to the current dashboard:
+
+- The dashboard already defaults to WS-only mode. `dashboard/src/dashboard-ws-cutover.ts:11`
+  through `dashboard/src/dashboard-ws-cutover.ts:31` sets WS-only to `true`
+  unless runtime or build config opts out.
+- The app already primes the lightweight shell before heavier projections.
+  `dashboard/src/app.ts:114` through `dashboard/src/app.ts:121` calls
+  `refreshShell({ light: true })`, namespace truth refresh, and dashboard config
+  fetch without blocking the full app mount.
+- The server dashboard shell summary already requests lightweight keeper rows.
+  `lib/server/server_dashboard_http_core.ml:304` through
+  `lib/server/server_dashboard_http_core.ml:310` calls
+  `Operator_control.snapshot_json` with `~view:"summary"` and
+  `~lightweight_summary:true`.
+- WS inbound parsing already has a browser Web Worker path.
+  `dashboard/src/dashboard-ws.ts:56` through `dashboard/src/dashboard-ws.ts:83`
+  initializes the parser worker, and `dashboard/src/dashboard-ws.ts:409`
+  through `dashboard/src/dashboard-ws.ts:424` uses it when available.
+
+The user-provided live log still shows `keepers_json` rows taking roughly
+1.8s to 3.0s during startup/operator refresh. That points at the current
+server-side snapshot path, not only the stale frontend/SSE items from the
+dated report.
+
+## Implemented Slice
+
+The current compact keeper row used to call the full runtime-trust snapshot:
+
+- `lib/operator/operator_control_snapshot.ml:516` now calls
+  `Keeper_runtime_trust_snapshot.summary_json` instead of
+  `Keeper_runtime_trust_snapshot.snapshot_json`.
+- `lib/keeper/keeper_runtime_trust_snapshot.ml:824` through
+  `lib/keeper/keeper_runtime_trust_snapshot.ml:887` adds a summary builder
+  that keeps the compact dashboard fields but avoids full causal/audit timeline
+  construction.
+- The full path still exists for detailed views. It reads recent tool calls,
+  approval audit, transition audit, pending approvals, and runtime contract
+  data in `lib/keeper/keeper_runtime_trust_snapshot.ml:889` through
+  `lib/keeper/keeper_runtime_trust_snapshot.ml:1019`.
+- `lib/operator/operator_control_snapshot.ml:580` through
+  `lib/operator/operator_control_snapshot.ml:595` now logs a `trust=...ms`
+  sub-op so future live runs can prove whether this path is still material.
+
+This is intentionally surgical: compact dashboard rows still expose
+`disposition`, `needs_attention`, `next_human_action`, execution summary,
+latest terminal reason, latest next action, and latest causal event. They no
+longer pay for every detailed runtime-trust timeline read on each lightweight
+summary refresh.
+
+## Stale Or Needs Fresh Evidence
+
+- "Remove SSE duplication" is stale for the default route because WS-only mode
+  is already default.
+- "Move JSON/SSE parsing to Web Worker" is stale for browsers that support
+  Worker because the parser worker path already exists.
+- "Enable browser perMessageDeflate" is not implemented here. The current
+  browser WebSocket client does not expose a normal per-connection compression
+  option in the application code path; server/browser compression policy needs
+  current browser and server docs before changing runtime behavior.
+- gRPC-Web/protobuf, Redis caching, Saturn, io_uring, zstd wire changes, and
+  provider pricing/model claims are all time-sensitive or architecture-wide.
+  They require separate current evidence and operator impact review before code
+  changes.
+
+## Next Measurement
+
+Run a live dashboard shell refresh against the patched binary and compare:
+
+```sh
+scripts/dune-local.sh build test/test_operator_control.exe
+./_build/default/test/test_operator_control.exe
+./start-masc-mcp.sh --base-path ~/me
+```
+
+Then inspect dashboard logs for `keepers_json:* trust=...ms` and total
+`snapshot_json` time. If total time remains high while `trust` is low, the next
+slice should focus on `meta`, `profile`, and `agent` sub-ops from the same log
+line rather than revisiting stale frontend claims.

--- a/docs/evidence/2026-05-06-masc-performance-diagnosis-evidence-record.md
+++ b/docs/evidence/2026-05-06-masc-performance-diagnosis-evidence-record.md
@@ -1,0 +1,48 @@
+# Evidence Record — MASC Performance Diagnosis Reality Check
+
+## 공통 헤더
+
+- 날짜(ISO8601): `2026-05-06T01:38:19+09:00`
+- 작성자: Codex
+- 결정 ID: `masc-performance-diagnosis-reality-check-2026-05-06`
+- 적용 대상: `/Users/dancer/Downloads/MASC_실전_성능_진단.md`, `docs/audit/2026-05-06-masc-performance-diagnosis-reality-check.md`, dashboard keeper summary snapshot path
+- 결정 상태: 확정 (current-code reality check and one server-side hot-path reduction)
+
+## 근거 (Evidence)
+
+- 항목: MASC performance diagnosis report currency check and dashboard keeper-summary hot-path reduction
+- 출처: local report `/Users/dancer/Downloads/MASC_실전_성능_진단.md`, current source files listed in the evidence table, and focused build/test commands
+- 확인일시: `2026-05-06T01:38:19+09:00`
+- 신뢰도: High for current source inspection; Medium for user-pasted runtime timing before patched live replay
+- 제한조건: local macOS workspace, `masc-mcp` current main `2e04c82c60a1`, no browser live replay yet
+
+| 항목 | 출처 (파일:줄 또는 명령) | 확인일시 | 신뢰도 | 비고 |
+|---|---|---|---|---|
+| Source report is dated against older code | `/Users/dancer/Downloads/MASC_실전_성능_진단.md:11` says target commit `58ed9c82`; current worktree `git rev-parse --short=12 HEAD` returned `2e04c82c60a1` | 2026-05-06T01:38:19+09:00 | High | Direct local file + git command |
+| WS-only mode is already default | `dashboard/src/dashboard-ws-cutover.ts:11-31` | 2026-05-06T01:38:19+09:00 | High | Current source inspection |
+| Lightweight shell prime already exists | `dashboard/src/app.ts:114-121` | 2026-05-06T01:38:19+09:00 | High | Current source inspection |
+| Server summary already asks lightweight keeper rows | `lib/server/server_dashboard_http_core.ml:304-310` | 2026-05-06T01:38:19+09:00 | High | Current source inspection |
+| WS parser Worker path already exists | `dashboard/src/dashboard-ws.ts:56-83` and `dashboard/src/dashboard-ws.ts:409-424` | 2026-05-06T01:38:19+09:00 | High | Current source inspection |
+| Compact keeper row now uses runtime-trust summary | `lib/operator/operator_control_snapshot.ml:516-535` | 2026-05-06T01:38:19+09:00 | High | Patched source inspection |
+| New summary avoids full causal timeline reads | `lib/keeper/keeper_runtime_trust_snapshot.ml:824-887` versus full timeline/read path at `lib/keeper/keeper_runtime_trust_snapshot.ml:889-1019` | 2026-05-06T01:38:19+09:00 | High | Patched source inspection |
+| Future live proof can attribute trust cost | `lib/operator/operator_control_snapshot.ml:580-595` logs `trust=...ms` | 2026-05-06T01:38:19+09:00 | High | Patched source inspection |
+| User log still shows dashboard keeper summary latency | User-provided MASC startup log: `keepers_json` sub-op totals around 1.8s-3.0s and `snapshot_json total` around 2.5s-3.1s | 2026-05-06T01:38:19+09:00 | Medium | Runtime log was pasted by operator, not re-run after patch |
+
+## 검증 (Verification)
+
+- 1차: local source and report inspection with `nl -ba`, `rg`, and `git rev-parse`.
+- 2차: focused OCaml target build: `scripts/dune-local.sh build test/test_operator_control.exe`.
+- 3차: focused executable run: `./_build/default/test/test_operator_control.exe`.
+- 재현 결과: pending at record creation; final PR verification must update the command result in the PR summary if either command fails.
+
+## 불확실성 (Uncertainty)
+
+- 미확인 항목: patched binary has not yet been measured against a live browser/dashboard session.
+- 영향: if `trust=...ms` drops but total `keepers_json` remains high, the next bottleneck is likely another sub-op (`meta`, `profile`, `agent`, or filesystem contention), not this runtime-trust slice.
+- 추가 확인 필요: run the patched server, load the dashboard, and compare `keepers_json:* trust=...ms` plus total `snapshot_json` timing against the pasted log.
+
+## 적용범위 (Scope)
+
+- 영향 받는 영역: dashboard operator summary snapshot, keeper runtime-trust compact row, related focused OCaml build target.
+- 제약/배제: no browser protocol change, no gRPC-Web/protobuf migration, no Redis/Saturn/io_uring adoption, no provider pricing/catalog update.
+- 롤백 조건: if compact dashboard rows lose required operator fields or tests fail, revert `summary_json` call site to full `snapshot_json` and keep only the timing log until a safer summary contract is added.

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -885,6 +885,71 @@ let execution_summary_json ~meta ~latest_receipt =
         | None -> `Null );
     ]
 
+let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
+  let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
+  let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
+  let latest_terminal_reason =
+    latest_terminal_reason_opt ~latest_decision ~latest_receipt
+  in
+  let latest_terminal_reason_json =
+    latest_terminal_reason
+    |> Option.map Keeper_turn_terminal.to_json
+    |> Option.value ~default:`Null
+  in
+  let latest_next_action =
+    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
+  in
+  let pending_approval_count =
+    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
+  in
+  let runtime_blocker_fields =
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+  in
+  let attention_fields =
+    Keeper_status_bridge.attention_fields_json config meta
+  in
+  let fallback_disposition, fallback_disposition_reason =
+    disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields
+  in
+  let disposition, disposition_reason, operator_disposition,
+      operator_disposition_reason =
+    effective_disposition_fields ~fallback_disposition
+      ~fallback_reason:fallback_disposition_reason latest_receipt
+  in
+  let needs_attention =
+    assoc_bool_default "needs_attention" ~default:false attention_fields
+    || String.equal disposition "Pause"
+    || String.equal disposition "Alert"
+  in
+  let attention_reason =
+    assoc_string_opt "attention_reason" attention_fields
+  in
+  let next_human_action =
+    assoc_string_opt "next_human_action" attention_fields
+  in
+  let execution_summary =
+    execution_summary_json ~meta ~latest_receipt
+  in
+  let latest_causal_event =
+    match terminal_reason_timeline_event ~latest_decision ~latest_receipt with
+    | Some event -> event
+    | None -> `Null
+  in
+  `Assoc
+    [
+      ("disposition", `String disposition);
+      ("disposition_reason", `String disposition_reason);
+      ("operator_disposition", `String operator_disposition);
+      ("operator_disposition_reason", `String operator_disposition_reason);
+      ("needs_attention", `Bool needs_attention);
+      ("attention_reason", Json_util.string_opt_to_json attention_reason);
+      ("next_human_action", Json_util.string_opt_to_json next_human_action);
+      ("execution", execution_summary);
+      ("latest_terminal_reason", latest_terminal_reason_json);
+      ("latest_next_action", Json_util.string_opt_to_json latest_next_action);
+      ("latest_causal_event", latest_causal_event);
+    ]
+
 let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
     ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
     ~next_human_action =

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -885,9 +885,39 @@ let execution_summary_json ~meta ~latest_receipt =
         | None -> `Null );
     ]
 
+let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
+    ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
+    ~next_human_action =
+  let observed_at_unix = Time_compat.now () in
+  let task_id = Keeper_runtime_contract.current_task_id_opt meta in
+  let goal_ids = meta.active_goal_ids in
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  [
+    terminal_reason_timeline_event ~latest_decision ~latest_receipt;
+    Option.bind latest_decision decision_timeline_event;
+    Option.bind latest_receipt receipt_timeline_event;
+    Option.bind latest_tool_call tool_call_timeline_event;
+    Option.bind latest_approval_audit approval_event_timeline_event;
+    blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
+      ~runtime_blocker_fields ?task_id ~goal_ids
+      ~trace_id ~next_human_action ();
+  ]
+  |> List.filter_map Fun.id
+  |> sort_timeline_events
+  |> fun events -> latest_causal_from_timeline (`List events)
+
 let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
+  let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
   let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
+  let latest_approval_audit =
+    match
+      Keeper_approval_queue.read_recent_audit ~base_path:config.base_path
+        ~keeper_name:meta.name ~n:1 ()
+    with
+    | json :: _ -> Some json
+    | [] -> None
+  in
   let latest_terminal_reason =
     latest_terminal_reason_opt ~latest_decision ~latest_receipt
   in
@@ -931,9 +961,9 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
     execution_summary_json ~meta ~latest_receipt
   in
   let latest_causal_event =
-    match terminal_reason_timeline_event ~latest_decision ~latest_receipt with
-    | Some event -> event
-    | None -> `Null
+    latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
+      ~latest_tool_call ~latest_approval_audit
+      ~runtime_blocker_fields ~next_human_action
   in
   `Assoc
     [

--- a/lib/keeper/keeper_runtime_trust_snapshot.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot.mli
@@ -3,3 +3,6 @@ val disposition_fields_json :
 
 val snapshot_json :
   config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t
+
+val summary_json :
+  config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -516,7 +516,7 @@ let _keeper_sem = Eio.Semaphore.make _keeper_snapshot_max_concurrency
 let compact_keeper_runtime_trust_json ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta) =
   let runtime_trust =
-    Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+    Keeper_runtime_trust_snapshot.summary_json ~config ~meta
   in
   let member key = Yojson.Safe.Util.member key runtime_trust in
   `Assoc
@@ -575,13 +575,14 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
          let dt_audit = ref 0.0 in
          let dt_profile = ref 0.0 in
          let dt_phase = ref 0.0 in
+         let dt_trust = ref 0.0 in
          let dt_activity = ref 0.0 in
          let emit_timing_log total_work =
            if total_work > 0.3 then
              Log.Dashboard.info
                "[keepers_json:%s] sub-op: meta=%.0fms agent=%.0fms ka=%.0fms \
-                audit=%.0fms profile=%.0fms phase=%.0fms activity=%.0fms \
-                total=%.0fms"
+                audit=%.0fms profile=%.0fms phase=%.0fms trust=%.0fms \
+                activity=%.0fms total=%.0fms"
                name
                (!dt_meta *. 1000.0)
                (!dt_agent *. 1000.0)
@@ -589,6 +590,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                (!dt_audit *. 1000.0)
                (!dt_profile *. 1000.0)
                (!dt_phase *. 1000.0)
+               (!dt_trust *. 1000.0)
                (!dt_activity *. 1000.0)
                (total_work *. 1000.0)
          in
@@ -608,14 +610,19 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    in
                    dt_phase := Time_compat.now () -. t_ph;
                    let runtime_trust =
-                     try compact_keeper_runtime_trust_json ~config ~meta
-                     with
-                     | Eio.Cancel.Cancelled _ as e -> raise e
-                     | exn ->
-                         Log.Dashboard.warn
-                           "operator snapshot trust compact failed for paused keeper %s: %s"
-                           meta.name (Printexc.to_string exn);
-                         `Null
+                     let t_trust = Time_compat.now () in
+                     let result =
+                       try compact_keeper_runtime_trust_json ~config ~meta
+                       with
+                       | Eio.Cancel.Cancelled _ as e -> raise e
+                       | exn ->
+                           Log.Dashboard.warn
+                             "operator snapshot trust compact failed for paused keeper %s: %s"
+                             meta.name (Printexc.to_string exn);
+                           `Null
+                     in
+                     dt_trust := Time_compat.now () -. t_trust;
+                     result
                    in
                    emit_timing_log (Time_compat.now () -. t_work_start);
                    Some
@@ -771,14 +778,19 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    else keeper_context_snapshot_of_meta config meta
                  in
                  let runtime_trust =
-                   try compact_keeper_runtime_trust_json ~config ~meta
-                   with
-                   | Eio.Cancel.Cancelled _ as e -> raise e
-                   | exn ->
-                       Log.Dashboard.warn
-                         "operator snapshot trust compact failed for keeper %s: %s"
-                         meta.name (Printexc.to_string exn);
-                       `Null
+                   let t_trust = Time_compat.now () in
+                   let result =
+                     try compact_keeper_runtime_trust_json ~config ~meta
+                     with
+                     | Eio.Cancel.Cancelled _ as e -> raise e
+                     | exn ->
+                         Log.Dashboard.warn
+                           "operator snapshot trust compact failed for keeper %s: %s"
+                           meta.name (Printexc.to_string exn);
+                         `Null
+                   in
+                   dt_trust := Time_compat.now () -. t_trust;
+                   result
                  in
                  let row =
                    `Assoc

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -41,6 +41,10 @@ let () =
             "snapshot summary surfaces paused keeper runtime trust" `Quick
             Test_operator_control_snapshot
             .test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust;
+          Alcotest.test_case
+            "snapshot lightweight summary preserves receipt causal event" `Quick
+            Test_operator_control_snapshot
+            .test_lightweight_snapshot_preserves_receipt_latest_causal_event;
           Alcotest.test_case "snapshot sections" `Quick
             Test_operator_control_snapshot.test_snapshot_has_expected_sections;
           Alcotest.test_case "snapshot pending confirm summary tracks actor scope"

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -481,6 +481,93 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
         (trust |> member "latest_terminal_reason" |> member "code"
        |> to_string))
 
+let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "receipt-causal-lightweight" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Keep receipt causal signal in summary");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let meta =
+        match Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "expected keeper meta"
+        | Error err -> Alcotest.fail err
+      in
+      Dated_jsonl.append
+        (Keeper_types_support.keeper_execution_receipt_store config keeper_name)
+        (`Assoc
+          [
+            ("schema", `String "keeper.execution_receipt.v1");
+            ("keeper_name", `String keeper_name);
+            ("agent_name", `String meta.agent_name);
+            ("trace_id", `String "trace-receipt-causal-lightweight");
+            ("turn_count", `Int 3);
+            ("outcome", `String "ok");
+            ("operator_disposition", `String "pass");
+            ("operator_disposition_reason", `String "healthy");
+            ("tool_contract_result", `String "satisfied");
+            ("tools_used", `List [ `String "keeper_status" ]);
+            ("requested_tools", `List [ `String "keeper_status" ]);
+            ( "cascade",
+              `Assoc
+                [
+                  ("name", `String "big_three");
+                  ("selected_model", `String "kimi-for-coding");
+                  ("outcome", `String "completed");
+                ] );
+            ("ended_at", `String (Masc_domain.now_iso ()));
+          ]);
+      Operator_control.invalidate_snapshot_cache ();
+      let snapshot =
+        Operator_control.snapshot_json ~view:"summary" ~include_messages:false
+          ~include_keepers:true ~include_summary_fields:false
+          ~lightweight_summary:true
+          (operator_ctx env sw config "operator")
+      in
+      let open Yojson.Safe.Util in
+      let keeper =
+        snapshot |> member "keepers" |> member "items" |> to_list
+        |> List.find_opt (fun row -> row |> member "name" |> to_string = keeper_name)
+        |> Option.value ~default:`Null
+      in
+      Alcotest.(check bool) "keeper present" true (keeper <> `Null);
+      let trust = keeper |> member "runtime_trust" in
+      Alcotest.(check string) "receipt remains latest causal fallback"
+        "execution_receipt"
+        (trust |> member "latest_causal_event" |> member "kind" |> to_string))
+
 let test_snapshot_has_expected_sections () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary

- Adds a lightweight `Keeper_runtime_trust_snapshot.summary_json` path for dashboard keeper summary rows.
- Switches `Operator_control.keepers_json` compact runtime-trust rows from full `snapshot_json` to the new summary path.
- Adds per-keeper `trust=...ms` dashboard timing so future live runs can attribute whether runtime-trust is still a bottleneck.
- Records a current-code reality check for `/Users/dancer/Downloads/MASC_실전_성능_진단.md`, separating stale quick wins from still-actionable dashboard latency.
- Fixes three current-main OCaml build blockers encountered while compiling the focused operator-control target.

## Why

The provided startup log still shows `keepers_json` and `snapshot_json` spending seconds during dashboard refresh. The dated performance report correctly points at dashboard load pain, but several recommendations are already implemented on current `main`:

- WS-only dashboard mode is already default.
- Lightweight shell priming already exists.
- WS parser Worker support already exists.
- Server summary snapshots already request lightweight keeper rows.

The remaining actionable server hot path was that compact keeper rows still paid for the full runtime-trust snapshot, including recent tool call reads, approval audit reads, transition audit reads, pending approvals, runtime contract, and causal timeline assembly. Summary rows only need the compact operator fields.

## Operator Impact

Dashboard summary refresh should stop doing full runtime-trust timeline work for every keeper row. Operators also get a new `trust=...ms` sub-op in `[keepers_json:*]` logs, so the next live run can prove whether remaining delay is runtime trust, metadata/profile reads, agent status, or filesystem contention.

## Validation

- `bash scripts/procedural-memory/validate-evidence-record.sh --warn docs/evidence/2026-05-06-masc-performance-diagnosis-evidence-record.md` passed.
- `git diff --check HEAD~1..HEAD` passed.
- Focused OCaml build was attempted with `scripts/dune-local.sh build test/test_operator_control.exe`, but local validation was blocked by a long-held `/tmp/me-dune-local.lock` from another active worktree build. This PR is draft and should use CI as the next verification surface.

## Review Focus

- Confirm compact runtime-trust summary preserves the fields dashboard rows consume.
- Confirm it is acceptable for detailed runtime-trust views to keep using full `snapshot_json`.
- Confirm the build-blocker fixes are minimal and do not change moderation behavior.
