### PR TITLE
fix(build): unblock main at 1230b551dc — odoc + record disambiguation + Option.bind

### DIFF
--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -125,7 +125,7 @@ let flag ~target_kind ~target_id ~reporter ~reason =
   (* Reject duplicate unresolved flags for the same target *)
   let duplicate =
     Hashtbl.fold
-      (fun _k e acc ->
+      (fun _k (e : queue_entry) acc ->
          acc ||
          (e.target_id = target_id && e.target_kind = target_kind && not e.resolved))
       s.queue false
@@ -155,7 +155,7 @@ let get_queue ?resolved () =
   let filtered =
     match resolved with
     | None       -> entries
-    | Some want  -> List.filter (fun e -> e.resolved = want) entries
+    | Some want  -> List.filter (fun (e : queue_entry) -> e.resolved = want) entries
   in
   List.sort (fun a b -> Float.compare b.flagged_at a.flagged_at) filtered
 
@@ -193,7 +193,7 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
   } in
   (* Resolve any open queue entry for this target *)
   Hashtbl.iter
-    (fun _k qe ->
+    (fun _k (qe : queue_entry) ->
        if qe.target_id = target_id && qe.target_kind = target_kind && not qe.resolved then
          Hashtbl.replace s.queue qe.entry_id { qe with resolved = true })
     s.queue;

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -462,8 +462,9 @@ let add_delete_action_routes router =
                          {|{"ok":false,"error":"invalid request: requires {\"target_id\":\"...\"}"}|} reqd
                    | Some target_id ->
                        let reason =
-                         Safe_ops.json_string_opt "reason" json
-                         |> Option.bind Board_moderation.flag_reason_of_string
+                         Option.bind
+                           (Safe_ops.json_string_opt "reason" json)
+                           Board_moderation.flag_reason_of_string
                        in
                        let note = Safe_ops.json_string_opt "note" json in
                        let actor =

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -42,7 +42,7 @@ val dispatch :
       [target_id], [delta], [ts], and [ts_iso].  Query params:
       [agent] (filter by recipient, case-sensitive),
       [limit] (clamped to [1..5000], default 500).  Response also
-      includes a [scoring_rule] field ([\"up=+1,down=0\"]) and a
+      includes a [scoring_rule] field (["up=+1,down=0"]) and a
       [totals] summary identical to [GET /api/v1/karma].
 
     {2 Static assets}


### PR DESCRIPTION
## Summary

`dune build bin/main_eio.exe` 가 `origin/main` (3a81cad4cc, 1230b551dc 이후) 에서 깨져 있어 3개 독립 회귀를 fix.

#13363 (Copilot WIP, 0 commits) 를 supersede.

## 진단된 에러

| 위치 | 종류 | 원인 |
|------|------|------|
| `lib/server/server_h2_gateway_routes_extra.mli:45` | unterminated string in odoc comment | `\"...\"` 의 `\"` 가 OCaml 코멘트 lexer 안에서 escape 로 해석되어 string 미종료, 전체 `(** ... *)` 미종료 |
| `lib/board_moderation.ml:130, 158, 197` | record disambiguation | `queue_entry` 와 `audit_entry` 가 `target_id`/`target_kind`/`reason` 공유. 후정의된 `audit_entry` 우선되어 `e.resolved` 거부 |
| `lib/server/server_dashboard_http_delete_actions.ml:466` | `Option.bind` 인자 순서 | `\|> Option.bind fn` 형태로 reversed. stdlib `Option.bind` 는 option-first |

## Fix

| 파일 | 변경 |
|------|------|
| `server_h2_gateway_routes_extra.mli` | 코멘트 line 45: `[\"up=+1,down=0\"]` → `["up=+1,down=0"]` (escape 제거 → quotes balance) |
| `board_moderation.ml` | lambda 3 곳에 `(e : queue_entry)` / `(qe : queue_entry)` 명시 (line 128, 158, 196) |
| `server_dashboard_http_delete_actions.ml` | `Option.bind` 호출을 explicit `Option.bind opt fn` 형태로 정정 |

## Verification

격리된 build dir + lock 으로 검증:

```bash
env DUNE_BUILD_DIR=/private/tmp/masc-fix-13363-build \\
    DUNE_LOCAL_LOCK=/tmp/masc-fix-13363.lock \\
    DUNE_LOCAL_JOBS=4 \\
    scripts/dune-local.sh build bin/main_eio.exe
# → 1차: 2개 fix 후 line 197 에서 동일 disambiguation 추가 확인
# → 2차: 모든 fix 적용 후 39초 incremental build, exit 0
```

## Test plan

- [x] `bin/main_eio.exe` 빌드 통과
- [ ] 전체 `dune build` 통과 (CI 검증)
- [ ] 기존 `test_board_moderation`/`test_dashboard_http_delete_actions` 통과 (CI 검증)

## 회귀 메모

`Option.bind` 인자 순서 버그는 #13267 에서 같은 파일 패턴에 fix 된 적 있음. 이번 인스턴스는 **다른 파일**(`server_dashboard_http_delete_actions.ml`)에서 재발 — 코드베이스 어디선가 OCaml stdlib 가 아닌 Haskell 스타일 (`bind fn opt`) 인자 순서를 따르는 헷갈림이 반복적으로 발생. 추후 lint 또는 helper 함수 도입 검토 가치 있음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)