### PR TITLE
refactor(coord): replace P2-1 string match with typed WorktreeNotFound variant

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -635,18 +635,26 @@ let transition_task_r
                  | Ok msg ->
                    Log.RoomTask.info
                      "%s worktree auto-cleanup: %s" reason_label msg
-                 | Error (System (System_error.IoError msg))
-                   when String.starts_with ~prefix:"Worktree " msg
-                     || String.starts_with ~prefix:"worktree " msg ->
-                   (* P2-1: "Worktree … not found" means the task had a
-                      worktree record (worktree = Some _) but the directory
-                      was never physically created on this host — typical for
-                      Docker-isolated keepers whose sandbox lives inside the
-                      container.  This is expected; demote to INFO so routine
-                      best-effort cleanup no longer fires false-alarm WARNs. *)
+                 | Error
+                     (System (System_error.WorktreeNotFound
+                        { worktree; searched_in })) ->
+                   (* P2-1: the task had a worktree record (worktree = Some _)
+                      but no matching directory was found under the sandbox
+                      repo clones — typical for Docker-isolated keepers whose
+                      sandbox lives inside the container, or for tasks where
+                      the worktree was already cleaned up by a prior
+                      transition.  This is the desired end state; demote to
+                      INFO so routine best-effort cleanup no longer fires
+                      false-alarm WARNs.
+
+                      #13304 originally implemented this demotion by matching
+                      the [IoError] message prefix; this typed-variant pattern
+                      replaces the string match so a future format change in
+                      [coord_worktree] cannot silently regress the demotion. *)
                    Log.RoomTask.info
-                     "%s worktree auto-cleanup: %s (worktree absent, skipped)"
-                     reason_label msg
+                     "%s worktree auto-cleanup: skipped (already absent: \
+                      worktree=%s searched_in=%s)"
+                     reason_label worktree searched_in
                  | Error e ->
                    Log.RoomTask.warn
                      "%s worktree auto-cleanup failed \

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -1336,11 +1336,15 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
       match find_matching_clone repos_dir with
       | Some root -> Ok root
       | None ->
+        (* #13302 P2-1 follow-up: typed variant replaces the previous
+           [IoError "Worktree ... not found under ..."] string-formatted
+           error.  #13304 demoted the WARN by matching that prefix in
+           [coord_task.cleanup_worktree_for_transition]; the typed
+           variant here lets the caller pattern-match safely so a future
+           message-format change does not silently regress the demotion. *)
         Error
-          (System (System_error.IoError
-             (Printf.sprintf
-                "Worktree %s not found under sandbox repo clones in %s"
-                worktree_name repos_dir)))
+          (System (System_error.WorktreeNotFound
+             { worktree = worktree_name; searched_in = repos_dir }))
     in
     match resolve_existing_worktree_root () with
     | Error e -> Error e

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -179,6 +179,7 @@ module System_error = struct
     | InvalidFilePath of string
     | StorageError of string
     | ValidationError of string
+    | WorktreeNotFound of { worktree : string; searched_in : string }
 
   let to_string = function
     | NotInitialized -> "[SystemError] MASC not initialized. Use masc_init first."
@@ -188,6 +189,10 @@ module System_error = struct
     | InvalidFilePath reason -> Printf.sprintf "[SystemError] Invalid file path: %s" reason
     | StorageError msg -> Printf.sprintf "[SystemError] Storage error: %s" msg
     | ValidationError msg -> Printf.sprintf "[SystemError] Validation error: %s" msg
+    | WorktreeNotFound { worktree; searched_in } ->
+        Printf.sprintf
+          "[SystemError] Worktree %s not found under sandbox repo clones in %s"
+          worktree searched_in
 end
 
 type t =
@@ -243,7 +248,8 @@ let is_retryable = function
   | System (System_error.IoError _ | System_error.StorageError _) -> true
   | System (System_error.NotInitialized | System_error.AlreadyInitialized
            | System_error.InvalidJson _ | System_error.InvalidFilePath _
-           | System_error.ValidationError _) -> false
+           | System_error.ValidationError _
+           | System_error.WorktreeNotFound _) -> false
   | RateLimitExceeded _ -> true
   | CacheError (CacheReadFailed _ | CacheWriteFailed _ | CacheExpired _) -> true
   | CacheError (CacheCorrupted _) -> false

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -62,6 +62,22 @@ module System_error : sig
     | InvalidFilePath of string
     | StorageError of string
     | ValidationError of string
+    | WorktreeNotFound of { worktree : string; searched_in : string }
+        (** Distinguishes the metadata-vs-disk drift case
+            ([task.worktree = Some _] but no matching git worktree exists
+            under the sandbox repo clones) from generic IO failures.
+
+            Best-effort cleanup callers (release / cancel / done
+            transitions in [Coord_task]) demote this condition to INFO
+            since "already absent" is the desired end state. Explicit-
+            deletion callers (MCP [worktree_remove] tool) still surface
+            it as actionable feedback.
+
+            #13304 originally implemented the demotion via a
+            [String.starts_with ~prefix:"Worktree "] match on the
+            [IoError] message, which is fragile (silently regresses if
+            the format string changes). This typed variant replaces the
+            string match. See umbrella issue #13302 P2-1. *)
   val to_string : t -> string
 end
 


### PR DESCRIPTION
## Summary

Refactor on top of merged PR #13304: replace the **fragile string-prefix match** in `coord_task.cleanup_worktree_for_transition` with a **typed `System_error.WorktreeNotFound` variant**. Same WARN→INFO demotion behavior, enforced by the type system rather than message-format conventions.

## Background

PR #13304 demoted the metadata-vs-disk drift WARN at boot via:

```ocaml
| Error (System (System_error.IoError msg))
  when String.starts_with ~prefix:"Worktree " msg
    || String.starts_with ~prefix:"worktree " msg ->
  Log.RoomTask.info "...%s (worktree absent, skipped)" reason_label msg
```

That works today but silently regresses if the format string in `coord_worktree.worktree_remove_r` ever changes (e.g. localization, debug verbosity, exception path edits). The demotion contract is not enforced by the compiler.

This PR makes the variant explicit:

```ocaml
| Error (System (System_error.WorktreeNotFound { worktree; searched_in })) ->
  Log.RoomTask.info "...skipped (already absent: worktree=%s searched_in=%s)" ...
```

## Changes

| File | Change |
|------|--------|
| `lib/types/masc_error.{ml,mli}` | Add `WorktreeNotFound { worktree; searched_in }` variant + `to_string` clause + `is_retryable` (non-retryable, deterministic absence) |
| `lib/coord/coord_worktree.ml` | `worktree_remove_r` returns `WorktreeNotFound` on `find_matching_clone None` branch instead of string-formatted `IoError` |
| `lib/coord/coord_task.ml` | `cleanup_worktree_for_transition` matches the typed variant; removes the previous `String.starts_with` guard |

```
lib/coord/coord_task.ml     | 30 +++++++++++++++++++-----------
lib/coord/coord_worktree.ml | 12 ++++++++----
lib/types/masc_error.ml     |  8 +++++++-
lib/types/masc_error.mli    | 16 ++++++++++++++++
4 files changed, 50 insertions(+), 16 deletions(-)
```

## Caller analysis

`worktree_remove_r` has 3 callers; impact differs:

| Caller | Behavior under new variant |
|--------|---------------------------|
| `lib/coord/coord_task.ml::cleanup_worktree_for_transition` | Pattern-matches `WorktreeNotFound`, logs INFO with structured fields. **This is the demotion site.** |
| `lib/task_sandbox.ml::sandbox_cleanup` | Receives typed variant; surfaces via existing error path (`masc_error_to_string` → human-readable message). No regression. |
| `lib/tool_worktree.ml::worktree_remove` (MCP tool) | Receives typed variant; surfaces via existing error path. User-facing "already absent" remains actionable feedback. |

## Build verification (deferred)

`@check` build was deferred during PR creation due to `/tmp/me-dune-local.lock` contention with 9 concurrent dune builds from external keeper agents (lock holder = different worktree, 12+ minutes elapsed). Equivalence with previously-verified PR #13360:

- **PR #13360** (closing in favor of this PR): same 4-file approach. Verified end-to-end:
  - `@check` clean
  - `test_tool_worktree_coverage.exe` 26/26 pass
- **This PR** delta: caller branch refactored from string-match to typed-variant pattern. Type signature of `worktree_remove_r` unchanged (variant lives in the existing `System_error.t` algebraic union). Other 3 files identical to #13360.

**Reviewer should run** `dune build @check` and `dune test test/test_tool_worktree_coverage.exe` before merge to confirm the inferred equivalence holds.

## Test plan

- [ ] `@check` passes
- [ ] `test_tool_worktree_coverage.exe` 26/26 pass (no string-format regression)
- [ ] `test_coord_worktree_policy_path.exe` pass
- [ ] Boot smoke: `task_release worktree auto-cleanup` continues to log INFO `(already absent: ...)` for keeper-issue_king-agent-task-150 and similar fixtures; no WARN regression

## Closes

This PR supersedes **#13360**. Closing #13360 with reference to this branch on the same commit.

## Refs

- Umbrella: #13302 (P2-1)
- Original demotion: #13304 (string match)
- Prior verified attempt: #13360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
