### PR TITLE
feat(ide): RFC-0028 PR-δ-1 — anchored-thread → keeper-trace bridge (first producer wire-in)

### DIFF
--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  bridgePostsToTrace,
+  type AnchoredThreadProducerInput,
+} from './anchored-thread-trace-bridge'
+import {
+  clearTraces,
+  keeperTraceState,
+} from './keeper-trace-store'
+
+function post(
+  id: string,
+  ts_iso: string,
+  keeper: string,
+): AnchoredThreadProducerInput {
+  return { id, created_at_iso: ts_iso, author_identity: keeper }
+}
+
+beforeEach(() => {
+  clearTraces()
+})
+
+afterEach(() => {
+  clearTraces()
+})
+
+describe('bridgePostsToTrace — RFC-0028 PR-δ anchored-thread producer', () => {
+  it('emits a trace event for every post on the first call', () => {
+    const out = bridgePostsToTrace(
+      [
+        post('p1', '2026-05-06T01:00:00Z', 'scholar'),
+        post('p2', '2026-05-06T01:00:01Z', 'moth'),
+      ],
+      new Set(),
+    )
+
+    expect([...out].sort()).toEqual(['p1', 'p2'])
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(2)
+    expect(events.every(e => e.source === 'anchored-thread')).toBe(true)
+  })
+
+  it('does not re-emit posts that are in the alreadyEmitted set', () => {
+    const known = new Set(['p1'])
+    bridgePostsToTrace(
+      [
+        post('p1', '2026-05-06T01:00:00Z', 'scholar'),
+        post('p2', '2026-05-06T01:00:01Z', 'moth'),
+      ],
+      known,
+    )
+
+    const ids = keeperTraceState.value.events.map(e => e.id).sort()
+    expect(ids).toEqual(['p2'])
+  })
+
+  it('returns an updated set including all newly emitted ids', () => {
+    const out = bridgePostsToTrace(
+      [post('p1', '2026-05-06T01:00:00Z', 'scholar')],
+      new Set(['p0']),
+    )
+    expect([...out].sort()).toEqual(['p0', 'p1'])
+  })
+
+  it('returns the input set unchanged when posts is empty', () => {
+    const before = new Set(['p0'])
+    const after = bridgePostsToTrace([], before)
+    expect(after).toBe(before)
+    expect(keeperTraceState.value.events.length).toBe(0)
+  })
+
+  it('skips posts with malformed created_at_iso (NaN-guard)', () => {
+    bridgePostsToTrace(
+      [
+        post('bad', 'not-a-date', 'scholar'),
+        post('p1', '2026-05-06T01:00:00Z', 'moth'),
+      ],
+      new Set(),
+    )
+    const ids = keeperTraceState.value.events.map(e => e.id)
+    expect(ids).toEqual(['p1'])
+  })
+
+  it('maps fields correctly: id, tsMs, keeperName, threadId, source, line=null', () => {
+    bridgePostsToTrace(
+      [post('p1', '2026-05-06T01:00:00Z', 'scholar')],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event.id).toBe('p1')
+    expect(event.tsMs).toBe(Date.parse('2026-05-06T01:00:00Z'))
+    expect(event.keeperName).toBe('scholar')
+    expect(event.source).toBe('anchored-thread')
+    if (event.source === 'anchored-thread') {
+      expect(event.threadId).toBe('p1')
+      expect(event.line).toBeNull()
+    }
+  })
+
+  it('is idempotent across repeated calls with the returned set', () => {
+    const inputs = [
+      post('p1', '2026-05-06T01:00:00Z', 'scholar'),
+      post('p2', '2026-05-06T01:00:01Z', 'moth'),
+    ]
+    let known: ReadonlySet<string> = new Set()
+    known = bridgePostsToTrace(inputs, known)
+    known = bridgePostsToTrace(inputs, known)
+    known = bridgePostsToTrace(inputs, known)
+
+    expect(keeperTraceState.value.events.length).toBe(2)
+  })
+})

--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
@@ -1,0 +1,64 @@
+import { pushTrace } from './keeper-trace-store'
+
+/**
+ * RFC-0028 PR-δ producer: anchored-thread → keeper-trace bridge.
+ *
+ * Pure mapper — given a snapshot of anchored-thread posts and a set of
+ * post ids that have already been emitted, push trace events for the
+ * new ones and return the updated set.
+ *
+ * Why a pure function (not a stateful subscription):
+ *   - The owning component (`IdeConversationRailMock`) already has the
+ *     fetched `posts` array as a useState value. A pure mapper called
+ *     from a `useEffect([posts])` is sufficient and trivially testable.
+ *   - Avoids storing per-component state inside the trace store, which
+ *     would couple the store to producer lifecycle.
+ *   - Module-level mutable state would leak across components and break
+ *     the deduplication guarantee on remount.
+ *
+ * Mapping (BoardPost → KeeperTraceEvent):
+ *   id         ← post.id
+ *   tsMs       ← Date.parse(post.created_at_iso) (NaN-guarded)
+ *   keeperName ← post.author_identity
+ *   threadId   ← post.id (BoardPost is the thread itself for now)
+ *   line       ← null (BoardPost carries no line anchor; consumers fall
+ *                back to the keeper-level no-line bucket per RFC §5)
+ *
+ * NaN-guard rationale: a malformed `created_at_iso` would otherwise
+ * propagate `NaN` into the store and break binary-search insertion. We
+ * silently skip such posts — they cannot participate in replay either.
+ */
+
+export interface AnchoredThreadProducerInput {
+  readonly id: string
+  readonly created_at_iso: string
+  readonly author_identity: string
+}
+
+/**
+ * Push trace events for every post not already in `alreadyEmitted` and
+ * return the updated set. The caller (typically a component effect)
+ * owns the set and re-passes it on each call.
+ */
+export function bridgePostsToTrace(
+  posts: ReadonlyArray<AnchoredThreadProducerInput>,
+  alreadyEmitted: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (posts.length === 0) return alreadyEmitted
+  const next = new Set(alreadyEmitted)
+  for (const post of posts) {
+    if (next.has(post.id)) continue
+    const tsMs = Date.parse(post.created_at_iso)
+    if (!Number.isFinite(tsMs)) continue
+    pushTrace({
+      id: post.id,
+      tsMs,
+      keeperName: post.author_identity,
+      source: 'anchored-thread',
+      threadId: post.id,
+      line: null,
+    })
+    next.add(post.id)
+  }
+  return next
+}

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { bridgePostsToTrace } from './anchored-thread-trace-bridge'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import { KeeperBadge } from '../keeper-badge'
 import {
@@ -128,6 +129,15 @@ export function IdeConversationRailMock() {
   }, [])
   useEffect(() => activeIdeFile.subscribe(file => setActiveFile(file)), [])
   useEffect(() => activeKeeperName.subscribe(name => setKeeperName(name)), [])
+
+  // RFC-0028 PR-δ anchored-thread producer: each fetched post becomes a
+  // keeper-trace event the first time it is observed, deduplicated by id
+  // across renders. The ref carries the cumulative known-id set so a
+  // re-render with the same posts is a no-op.
+  const knownPostIds = useRef<ReadonlySet<string>>(new Set())
+  useEffect(() => {
+    knownPostIds.current = bridgePostsToTrace(posts, knownPostIds.current)
+  }, [posts])
 
   const replayItems = replayRailItems(posts, decisions, cascadeEvents)
   const replayEvents = replayEventsForItems(replayItems)


### PR DESCRIPTION
## 목적

RFC-0028 PR-δ (4 producer wire-in) 의 첫 sub-PR. anchored-thread producer 를 keeper-trace-store (#13311 PR-α) 로 wire. PR-β (#13336 overlay) 가 main 에 있어 wire-in 후 store 에 이벤트 흐르면 곧 user-visible chip 표시 가능 (overlay 가 IDE shell 에 mount 되는 별도 PR 후).

## Scope (4 producer 분할)

| Sub-PR | Producer | Source | 본 PR? |
|--------|----------|--------|--------|
| **PR-δ-1 (본 PR)** | **anchored-thread** | BoardPost (`/api/v1/board`) | ✅ |
| PR-δ-2 | cascade-hop | CascadeStrategyTraceEvent (`/api/v1/cascade/trace`) | follow-up |
| PR-δ-3 | decision-log | KeeperDecision (`/api/v1/decisions`) | follow-up |
| PR-δ-4 | bdi-snapshot | RFC-0024 BDI inspector polling | follow-up |

각 producer 별 PR 분리 — review 부담 분산 + 별 endpoint contract 확인 timing 분리.

## Diff stat

- 3 files / +187 / -1
- 신규: `anchored-thread-trace-bridge.ts` (64), `anchored-thread-trace-bridge.test.ts` (112, 7 cases)
- 수정: `ide-conversation-rail-mock.ts` (+11/-1, import + ref + useEffect)

## Public API

### `anchored-thread-trace-bridge.ts` (신규)

```ts
export interface AnchoredThreadProducerInput {
  readonly id: string
  readonly created_at_iso: string
  readonly author_identity: string
}

export function bridgePostsToTrace(
  posts: ReadonlyArray<AnchoredThreadProducerInput>,
  alreadyEmitted: ReadonlySet<string>,
): ReadonlySet<string>
```

Pure mapper — 새 post 만 `pushTrace` 호출, 갱신된 known-id set 반환.

## 설계 결정

### Pure function vs Stateful subscription

| 옵션 | 채택? | 근거 |
|------|------|------|
| Pure mapper + `useEffect([posts])` | ✅ | 컴포넌트가 이미 useState 로 posts 보관, mapper 가 trivially testable |
| Stateful subscription (store 가 producer state 보관) | ❌ | store invariants (binary-search / coalesce / retention) 가 producer lifecycle 와 결합 |
| Module-level mutable state | ❌ | 컴포넌트 remount 시 dedup 깨짐 |

### Field mapping (BoardPost → KeeperTraceEvent)

| trace 필드 | source | 비고 |
|-----------|--------|-----|
| `id` | `post.id` | 1:1 |
| `tsMs` | `Date.parse(post.created_at_iso)` | NaN 시 skip |
| `keeperName` | `post.author_identity` | 1:1 |
| `source` | `'anchored-thread'` | discriminator |
| `threadId` | `post.id` | BoardPost 는 thread 자체 |
| `line` | `null` | BoardPost 가 line anchor 미보유 → RFC §5 keeper-level no-line bucket |

### NaN-guard

`Date.parse('not-a-date')` 가 `NaN` 반환. NaN 이 store 의 binary-search insertion 에 들어가면 ordering invariant 깨짐 + replay 에서 표시 불가. malformed iso 는 silently skip — test 에 명시.

## Wire-in (`IdeConversationRailMock`)

```ts
const knownPostIds = useRef<ReadonlySet<string>>(new Set())
useEffect(() => {
  knownPostIds.current = bridgePostsToTrace(posts, knownPostIds.current)
}, [posts])
```

| 측면 | 설명 |
|------|------|
| Ref scope | 컴포넌트 인스턴스별. remount 시 새 set 으로 시작 (production semantics 와 일치) |
| Trigger | `posts` (useState) 변경 시. 첫 fetch 결과 도착 시 모든 post 발화, 후속 fetch 는 새 id 만 |
| 회귀 위험 | 0 — UI render 무변경, store 는 additive |

## Test results

```
Test Files  33 passed (33)
     Tests  211 passed (211)  -- src/components/ide broader sweep
```

| 파일 | total | new (PR-δ-1) |
|------|------|------|
| `anchored-thread-trace-bridge.test.ts` (신규) | 7 | 7 (first-emit / dedup / set-return / empty / NaN-guard / field mapping / idempotent) |
| 기타 32 IDE files | 204 | 회귀 0 |

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "anchored-thread-trace-bridge OR bridgePostsToTrace OR 'RFC-0028 PR-δ'" --state open` → 본 PR 외 0
- `gh pr list --search "..." --state merged --limit 5` → #13311 (PR-α store, base), #13336 (PR-β overlay, sibling), #13236 (audit replay timeline, 다른 surface)
- `git fetch origin && git log origin/main --since=1h -- dashboard/src/components/ide/keeper-trace-store.ts dashboard/src/components/ide/ide-conversation-rail-mock.ts` → empty
- `rg 'bridgePostsToTrace|anchored-thread-trace-bridge' dashboard/src/` → 본 PR 신규 caller 만

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/components/ide/` → **211/211 pass** across 33 files
- ESLint 본 PR 변경 파일 → **0 error / 0 warning** (RFC-0027 PR-γ-2 의 app.ts pre-existing warning 같은 것 없음 — 본 PR 변경 파일들이 모두 ESLint scope 안)

## Rollback plan

3-file revert. Bridge 모듈은 ide-conversation-rail-mock 외 caller 0. revert 시 useEffect + pure factory drop. store / overlay 는 unchanged.

## Why mock 컴포넌트에 wire-in 인지

`IdeConversationRailMock` 는 mock 이라는 이름이지만 actual production IDE conversation rail (ide-shell.ts 가 mount). "mock" 은 backend 가 stub 이라는 의미 — 사용자가 IDE 보면 fetch 결과가 본 PR bridge 로 trace store 에 들어감. backend ready 시점에 wire-in 패턴 동일 사용.

## RFC waiver

agent_delegation 영역 변경 없음. behavior-additive (UI 변경 0, store 의 add-only 작업).

`RFC-WAIVED: behavior-additive bridge over existing additive store. Bridge is a pure mapper; wire-in only adds a useEffect that pushes events. No UI changes. RFC-0028 PR-α (#13311) and PR-β (#13336) already merged.`

## Related

- #13311 (RFC-0028 PR-α store) — base, 본 PR 가 `pushTrace` consume
- #13336 (RFC-0028 PR-β overlay) — sibling, 본 PR 의 events 가 표시될 곳 (overlay wire-in 별도 PR 필요)
- #13293 (RFC-0028 spec Draft) — §5 anchored-thread bucket
- #13236 (audit replay timeline) — 같은 IDE conversation rail 내 sibling

## Follow-up

- **PR-δ-2 cascade-hop** producer: `CascadeStrategyTraceEvent → trace` mapper, 같은 컴포넌트 wire-in
- **PR-δ-3 decision-log** producer: `KeeperDecision → trace` mapper
- **PR-δ-4 bdi-snapshot** producer: RFC-0024 BDI inspector polling 결과 wire
- **PR-wire-in**: `<OverlayKeeperTrace active={...}>` IDE shell 마운트 — 첫 producer 머지 후 user-visible
- RFC-0028 spec (#13289) 머지 후 amend PR (PR-δ family 결정 인용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
