### PR TITLE
[codex] fix(ci): fail closed on agent draft guard

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -92,14 +92,25 @@ jobs:
               return;
             }
 
-            const prAuthorLogin = (pr.user?.login || "").toLowerCase();
-            const prAuthorType = pr.user?.type;
+            const normalizeLabelName = (label) =>
+              (typeof label === "string" ? label : label?.name || "").trim().toLowerCase();
+            const payloadLabels = (pr.labels || []).map(normalizeLabelName).filter(Boolean);
+            const labels = (currentPr.labels || []).map(normalizeLabelName).filter(Boolean);
+            if (payloadLabels.join(",") !== labels.join(",")) {
+              core.info(
+                `Using live PR labels for guard policy: ${labels.join(", ") || "(none)"}; ` +
+                  `event payload labels were: ${payloadLabels.join(", ") || "(none)"}.`
+              );
+            }
+
+            const prAuthor = currentPr.user || pr.user || {};
+            const prAuthorLogin = (prAuthor.login || "").toLowerCase();
+            const prAuthorType = prAuthor.type;
             const humanAuthored =
               prAuthorType === "User" &&
               prAuthorLogin &&
               humanActors.includes(prAuthorLogin);
 
-            const labels = (pr.labels || []).map((label) => label.name.toLowerCase());
             const ignoredBypassLabels = labels.filter((label) =>
               automationProneBypassLabels.has(label)
             );
@@ -113,8 +124,8 @@ jobs:
             }
 
             const looksAgentAuthored =
-              titlePattern.test(pr.title || "") ||
-              branchPattern.test(pr.head?.ref || "") ||
+              titlePattern.test(currentPr.title || pr.title || "") ||
+              branchPattern.test(currentPr.head?.ref || pr.head?.ref || "") ||
               labels.includes("agent-pr") ||
               labels.includes("codex");
 
@@ -229,11 +240,14 @@ jobs:
             const unsafeDraftBoundaryAction =
               action === "ready_for_review" ||
               action === "auto_merge_enabled";
+            // Keep the required Draft Auto-Merge Guard context red for
+            // agent-like PRs until a verified human approval label exists.
+            // A green draft-only check can be reused by a later ready/merge
+            // race before the boundary event has a chance to fail closed.
             const approvalRequired =
-              (!safeDraftOnlyState &&
-                (looksAgentAuthored ||
-                  unsafeDraftBoundaryAction ||
-                  hasAutoMergeRequest)) ||
+              looksAgentAuthored ||
+              unsafeDraftBoundaryAction ||
+              hasAutoMergeRequest ||
               bypassPolicyFailures.length > 0;
             const missingVerifiedApproval =
               approvalRequired &&

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -293,9 +293,18 @@ let test_pr_automation_draft_guard_contracts () =
     (match live_state_skip, draft_restore with
      | Some skip_pos, Some restore_pos -> skip_pos < restore_pos
      | _ -> false);
+  check bool "pr automation reads live labels for policy" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "const labels = (currentPr.labels || []).map(normalizeLabelName).filter(Boolean)");
+  check bool "pr automation does not use stale payload labels for policy" true
+    (file_not_contains_pattern ".github/workflows/pr-automation.yml"
+       "const labels = (pr.labels || [])");
   check bool "draft-only state does not suppress missing approval" true
     (file_not_contains_pattern ".github/workflows/pr-automation.yml"
-       "verifiedBypassLabels.length === 0 &&\n              !safeDraftOnlyState");
+       "(!safeDraftOnlyState &&");
+  check bool "agent-like PRs always require verified approval" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "const approvalRequired =\n              looksAgentAuthored ||\n              unsafeDraftBoundaryAction ||\n              hasAutoMergeRequest ||");
   check bool "pr automation has hard-stop label policy" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
        "hard-stop label present");


### PR DESCRIPTION
## Summary

Fixes the live draft/auto-merge race seen on #13355 and #13367, where agent-authored draft PRs could leave a green `Draft Auto-Merge Guard` context before a later ready/merge transition raced ahead.

Changes:
- Use live PR labels from `pulls.get` instead of stale `pull_request_target` event payload labels when applying hard-stop and bypass policy.
- Keep `Draft Auto-Merge Guard` red for agent-like PRs until a verified `human-approved-ready` label exists, even when the PR is still draft-only.
- Add source-contract checks so the guard cannot drift back to stale labels or `safeDraftOnlyState` approval suppression.

Operational note:
- I also restored live branch-protection admin enforcement on `main` (`enforce_admins=true`) after confirming it had drifted false while `CI Gate` and `Draft Auto-Merge Guard` were required. That setting drift explains why owner-token merges bypassed the required contexts.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing test/test_ci_hardening_source.ml`
- `bash scripts/lint/yaml-syntax.sh`
- Attempted `scripts/dune-local.sh build test/test_ci_hardening_source.exe`; stopped only my queued waiter after ~100s behind `/tmp/me-dune-local.lock`, without bypassing the shared throttle.

Related incident tracker: #9738