### PR TITLE
fix(build): restore main_eio server build

### DIFF
--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -125,7 +125,7 @@ let flag ~target_kind ~target_id ~reporter ~reason =
   (* Reject duplicate unresolved flags for the same target *)
   let duplicate =
     Hashtbl.fold
-      (fun _k e acc ->
+      (fun _k (e : queue_entry) acc ->
          acc ||
          (e.target_id = target_id && e.target_kind = target_kind && not e.resolved))
       s.queue false
@@ -193,7 +193,7 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
   } in
   (* Resolve any open queue entry for this target *)
   Hashtbl.iter
-    (fun _k qe ->
+    (fun _k (qe : queue_entry) ->
        if qe.target_id = target_id && qe.target_kind = target_kind && not qe.resolved then
          Hashtbl.replace s.queue qe.entry_id { qe with resolved = true })
     s.queue;

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -462,8 +462,9 @@ let add_delete_action_routes router =
                          {|{"ok":false,"error":"invalid request: requires {\"target_id\":\"...\"}"}|} reqd
                    | Some target_id ->
                        let reason =
-                         Safe_ops.json_string_opt "reason" json
-                         |> Option.bind Board_moderation.flag_reason_of_string
+                         Option.bind
+                           (Safe_ops.json_string_opt "reason" json)
+                           Board_moderation.flag_reason_of_string
                        in
                        let note = Safe_ops.json_string_opt "note" json in
                        let actor =

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -32,7 +32,7 @@ val dispatch :
     - [GET /api/v1/board/hearths] — hearth name+count list.
     - [GET /api/v1/board/flairs] — available flair list.
     - [GET /api/v1/board/<post_id>] — single post with
-      configurable [format] query param (defaults to ["nested"]).
+      configurable [format] query param (defaults to [nested]).
     - [GET /api/v1/board/sub-boards] — sub-board list.
     - [POST /api/v1/board/sub-boards] — create sub-board (auth required).
       Body: [{ slug, name, description, access? }].
@@ -46,7 +46,7 @@ val dispatch :
       [target_id], [delta], [ts], and [ts_iso].  Query params:
       [agent] (filter by recipient, case-sensitive),
       [limit] (clamped to [1..5000], default 500).  Response also
-      includes a [scoring_rule] field ([\"up=+1,down=0\"]) and a
+      includes a [scoring_rule] field ([up=+1,down=0]) and a
       [totals] summary identical to [GET /api/v1/karma].
 
     {2 Static assets}
@@ -65,12 +65,12 @@ val dispatch :
     {2 Failure modes}
 
     - Path-traversal attempts on the dashboard assets route return
-      [404 Not Found] (NOT [400 Bad Request] — the spec is "do not
+      [404 Not Found] (NOT [400 Bad Request] — the spec is to not
       reveal whether the path traversal was rejected vs the
-      filename was missing").  Pinned at the contract seam.
+      filename was missing).  Pinned at the contract seam.
     - Missing static asset files return [404 Not Found] with the
-      literal body [["404 Not Found"]].  Operator runbooks grep on
-      this exact string.
+      literal body [404 Not Found] (operator runbooks grep on this
+      exact string).
 
     Returns [false] for any route the dispatcher does not
     recognise — the parent gateway falls through to its catch-all


### PR DESCRIPTION
## Summary
- Remove ocamldoc string literals from the H2 extra-routes interface comment so the `.mli` parses again.
- Add explicit `queue_entry` annotations in board moderation folds to avoid `audit_entry` field inference.
- Use `Option.bind` in the non-pipeline form expected by this OCaml version.

## Why
Latest `main` could not build the server/test targets after the board moderation/dashboard route changes. This blocked clean runtime rebuilds and also blocked focused keeper PR-tool verification after #13365.

Closes #13361.
Closes #13366.

## Validation
- `env DUNE_JOBS=1 dune build --root . --cache=disabled --display=short test/test_keeper_github_pr.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_keeper_github_pr.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `git diff --check`