### PR TITLE
fix(dashboard): label IDE repository source truthfully

### DIFF
--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -1,13 +1,52 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
-import { IdeExplorer } from './ide-explorer'
+import { explorerScopeLabel, IdeExplorer } from './ide-explorer'
 import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
+import type { Repository } from '../../api/repositories'
 
 const SAMPLE: ReadonlyArray<FileTreeNode> = [
   { path: 'runtime', label: 'runtime', depth: 0, parent: null, hasChildren: true, diff: null, keeperId: null, hueIndex: null },
   { path: 'runtime/router.ts', label: 'router.ts', depth: 1, parent: 'runtime', hasChildren: false, diff: '+14', keeperId: 'nick0cave', hueIndex: 1 },
   { path: 'package.json', label: 'package.json', depth: 0, parent: null, hasChildren: false, diff: null, keeperId: null, hueIndex: null },
 ]
+
+function repo(id: string, name = id): Repository {
+  return {
+    id,
+    name,
+    url: '',
+    local_path: `/workspace/${id}`,
+    default_branch: 'main',
+    status: 'active',
+    auto_sync: false,
+    sync_interval: 0,
+    credential_id: null,
+    created_at: null,
+    updated_at: null,
+  }
+}
+
+describe('explorerScopeLabel', () => {
+  it('labels repository-backed IDE trees with the repository name', () => {
+    expect(
+      explorerScopeLabel(
+        { kind: 'repository', repoId: 'masc-mcp' },
+        '',
+        [repo('masc-mcp', 'masc-mcp')],
+      ),
+    ).toEqual({ label: 'masc-mcp', tone: 'accent' })
+  })
+
+  it('keeps repository fallback states visibly distinct from project root', () => {
+    expect(
+      explorerScopeLabel(
+        { kind: 'repository_unknown', repoId: 'missing-repo' },
+        '',
+        [],
+      ),
+    ).toEqual({ label: 'missing-repo fallback', tone: 'muted' })
+  })
+})
 
 describe('IdeExplorer tree row keyboard accessibility', () => {
   let container: HTMLDivElement
@@ -51,5 +90,18 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
 
     expect(keeperOwnedRow?.textContent).toContain('NK')
     expect(keeperOwnedRow?.textContent).toContain('router.ts')
+  })
+
+  it('renders repository source in the explorer header', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE)
+    render(h(IdeExplorer, {
+      fileTreeStore: store,
+      workspaceSource: () => ({ kind: 'repository', repoId: 'masc-mcp' } as const),
+      repositories: () => [repo('masc-mcp', 'masc-mcp')],
+    }), container)
+
+    expect(container.textContent).toContain('EXPLORER · masc-mcp')
+    expect(container.textContent).not.toContain('EXPLORER · project')
   })
 })

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -26,6 +26,45 @@ interface IdeExplorerProps {
   readonly subscribeRepositories?: (listener: () => void) => () => void
 }
 
+type ExplorerScopeTone = 'accent' | 'muted'
+
+interface ExplorerScopeLabel {
+  readonly label: string
+  readonly tone: ExplorerScopeTone
+}
+
+function repositoryLabel(
+  repositories: ReadonlyArray<Repository>,
+  repoId: string,
+): string {
+  const repository = repositories.find(candidate => candidate.id === repoId)
+  return repository?.name.trim() || repoId
+}
+
+export function explorerScopeLabel(
+  source: WorkspaceSource,
+  keeperName: string,
+  repositories: ReadonlyArray<Repository> = [],
+): ExplorerScopeLabel {
+  const keeper = keeperName.trim()
+  if (keeper) return { label: `@${keeper}`, tone: 'accent' }
+
+  switch (source.kind) {
+    case 'repository':
+      return { label: repositoryLabel(repositories, source.repoId), tone: 'accent' }
+    case 'repository_missing':
+    case 'repository_unknown':
+      return { label: `${repositoryLabel(repositories, source.repoId)} fallback`, tone: 'muted' }
+    case 'playground':
+      return { label: `@${source.keeper}`, tone: 'accent' }
+    case 'playground_missing':
+    case 'keeper_unknown':
+      return { label: `@${source.keeper} fallback`, tone: 'muted' }
+    case 'project':
+      return { label: 'project', tone: 'muted' }
+  }
+}
+
 export function IdeExplorer({
   fileTreeStore: store,
   workspaceSource,
@@ -99,6 +138,7 @@ export function IdeExplorer({
     return visible.filter(n => n.label.toLowerCase().includes(needle))
   }, [visible, filter])
   const fileCount = filtered.filter(n => !n.hasChildren).length
+  const scopeLabel = explorerScopeLabel(source, keeperName, repoList)
 
   return html`
     <div
@@ -125,7 +165,13 @@ export function IdeExplorer({
           borderBottom: '1px solid var(--color-border-divider)',
         }}
       >
-        <span>EXPLORER ${keeperName ? html`· <span style=${{ color: 'var(--color-accent-fg)' }}>@${keeperName}</span>` : '· project'}</span>
+        <span>EXPLORER · <span
+            style=${{
+              color: scopeLabel.tone === 'accent'
+                ? 'var(--color-accent-fg)'
+                : 'var(--color-fg-muted)',
+            }}
+          >${scopeLabel.label}</span></span>
         <span>${fileCount} FILES</span>
       </header>
       ${repoList.length > 0 || onRepositoryScan ? html`


### PR DESCRIPTION
## Summary
- show the active repository name in the Code IDE explorer header when the tree comes from `/api/v1/workspace/tree?repo_id=...`
- keep fallback cases visibly distinct as `<repo> fallback` instead of collapsing them into `project`
- cover the source-label behavior with focused IDE explorer tests

## Why
The live runtime is already serving repository-backed IDE data from the configured base path, but the explorer header still said `EXPLORER · project`. That made a healthy `repo_id=masc-mcp` view look like a basepath-only fallback and made operator diagnosis harder.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/ide/ide-explorer.test.ts`
- `pnpm --dir dashboard exec eslint src/components/ide/ide-explorer.ts src/components/ide/ide-explorer.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- Playwright screenshot against local Vite proxy waited for `EXPLORER · masc-mcp` and confirmed the repository tree renders with 647 files.