### PR TITLE
fix(build): unblock main after Phase-2 board moderation + SubBoard merges

### DIFF
--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -125,7 +125,7 @@ let flag ~target_kind ~target_id ~reporter ~reason =
   (* Reject duplicate unresolved flags for the same target *)
   let duplicate =
     Hashtbl.fold
-      (fun _k e acc ->
+      (fun _k (e : queue_entry) acc ->
          acc ||
          (e.target_id = target_id && e.target_kind = target_kind && not e.resolved))
       s.queue false
@@ -193,7 +193,7 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
   } in
   (* Resolve any open queue entry for this target *)
   Hashtbl.iter
-    (fun _k qe ->
+    (fun _k (qe : queue_entry) ->
        if qe.target_id = target_id && qe.target_kind = target_kind && not qe.resolved then
          Hashtbl.replace s.queue qe.entry_id { qe with resolved = true })
     s.queue;

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -462,8 +462,9 @@ let add_delete_action_routes router =
                          {|{"ok":false,"error":"invalid request: requires {\"target_id\":\"...\"}"}|} reqd
                    | Some target_id ->
                        let reason =
-                         Safe_ops.json_string_opt "reason" json
-                         |> Option.bind Board_moderation.flag_reason_of_string
+                         Option.bind
+                           (Safe_ops.json_string_opt "reason" json)
+                           Board_moderation.flag_reason_of_string
                        in
                        let note = Safe_ops.json_string_opt "note" json in
                        let actor =

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -46,7 +46,7 @@ val dispatch :
       [target_id], [delta], [ts], and [ts_iso].  Query params:
       [agent] (filter by recipient, case-sensitive),
       [limit] (clamped to [1..5000], default 500).  Response also
-      includes a [scoring_rule] field ([\"up=+1,down=0\"]) and a
+      includes a [scoring_rule] field (["up=+1,down=0"]) and a
       [totals] summary identical to [GET /api/v1/karma].
 
     {2 Static assets}

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -829,7 +829,8 @@ let test_sub_board_create_and_get () =
   | Ok sb ->
       Alcotest.(check string) "slug matches" "alpha-board" sb.Board.slug;
       Alcotest.(check string) "name matches" "Alpha" sb.name;
-      Alcotest.(check string) "owner matches" "agent-1" sb.owner;
+      Alcotest.(check string) "owner matches" "agent-1"
+        (Board_core_classify.Agent_id.to_string sb.owner);
       let id = Board.Sub_board_id.to_string sb.id in
       (match Board_dispatch.get_sub_board ~sub_board_id:id with
        | Error e -> Alcotest.fail (Board.show_board_error e)


### PR DESCRIPTION
## What

Four breakages on \`origin/main\` HEAD \`e402f265a7\` (after #13332 / #13333 merges).

| File | Symptom | Fix |
|---|---|---|
| \`lib/server/server_h2_gateway_routes_extra.mli\` | docstring \`\\\"up=+1,down=0\\\"\` opens unbalanced string literal in OCaml comment lexer (line 17 cascade) | Replace \`\\\"…\\\"\` with plain \`\"…\"\` (paired) |
| \`lib/board_moderation.ml\` (line 130, 197) | \`audit_entry\` (defined after \`queue_entry\`) wins type-directed disambiguation on shared fields, fails on \`resolved\` | Annotate closure param \`(qe : queue_entry)\` |
| \`lib/server/server_dashboard_http_delete_actions.ml:466\` | \`… \\|> Option.bind flag_reason_of_string\` passes function as \`Option.bind\`'s first arg | Direct call: \`Option.bind (json_string_opt …) flag_reason_of_string\` |
| \`test/test_board_dispatch.ml:832\` | \`sb.owner\` is \`Agent_id.t\` after #13333, compared with \`string\` | Wrap in \`Board_core_classify.Agent_id.to_string\` |

## Verification

- \`dune build\` passes (clean)
- 8 inserts / 6 deletes across 4 files

## Race check (memory rule)

- \`gh pr list --state open --search "board_moderation OR …"\`: 0 conflicts (#13334 is unrelated readonly surface)
- \`git log origin/main --since=1h -- <files>\`: latest is \`e402f265a7\` (#13333) which I'm fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)