### PR TITLE
fix(coord): bound FSM snapshot tool output

### DIFF
--- a/lib/coordination_product_snapshot.ml
+++ b/lib/coordination_product_snapshot.ml
@@ -560,14 +560,52 @@ let read_recent_telemetry config =
     []
 ;;
 
+let tool_post_limit = 200
+let tool_telemetry_limit = 500
+let tool_product_limit = 120
+let tool_violation_limit = 120
+let tool_evidence_per_product_limit = 8
+
+let read_tool_telemetry config =
+  try
+    let since = Time_compat.now () -. Masc_time_constants.day in
+    Telemetry_eio.read_recent_events config ~limit:tool_telemetry_limit
+    |> List.filter (fun (record : Telemetry_eio.event_record) -> record.timestamp >= since)
+  with
+  | exn ->
+    Log.Coord.warn
+      "coordination product bounded telemetry evidence failed: %s"
+      (Printexc.to_string exn);
+    []
+;;
+
 let capture (config : Coord.config) =
+  let economy_enabled = Agent_economy.enabled () in
   { goals = Goal_store.list_goals config ()
   ; tasks = Coord_query.get_tasks_safe config
   ; posts = Board_dispatch.list_posts ~limit:Board.Limits.max_posts ()
-  ; transactions = Agent_economy.list_transactions ~base_path:config.base_path
+  ; transactions =
+      if economy_enabled
+      then Agent_economy.list_transactions ~base_path:config.base_path
+      else []
   ; telemetry_events = read_recent_telemetry config
   ; persist_errors = Board.persist_error_count ()
-  ; economy_enabled = Agent_economy.enabled ()
+  ; economy_enabled
+  }
+;;
+
+let capture_for_tool (config : Coord.config) =
+  let economy_enabled = Agent_economy.enabled () in
+  { goals = Goal_store.list_goals config ()
+  ; tasks = Coord_query.get_tasks_safe config
+  ; posts = Board_dispatch.list_posts ~limit:tool_post_limit ()
+  ; transactions =
+      if economy_enabled
+      then Agent_economy.list_transactions ~base_path:config.base_path
+      else []
+  ; telemetry_events = read_tool_telemetry config
+  ; persist_errors = Board.persist_error_count ()
+  ; economy_enabled
   }
 ;;
 
@@ -613,6 +651,7 @@ let project state =
 ;;
 
 let build config = config |> capture |> project
+let build_for_tool config = config |> capture_for_tool |> project
 
 let severity_counts (snapshot : Coordination_product.snapshot) =
   let count severity =
@@ -638,4 +677,61 @@ let safe_build_yojson config =
     Coordination_product.snapshot_to_yojson
       ~projection_error:message
       (Coordination_product.snapshot [])
+;;
+
+let capped_product (product : Coordination_product.product) =
+  { product with evidence = take tool_evidence_per_product_limit product.evidence }
+;;
+
+let cap_tool_snapshot (snapshot : Coordination_product.snapshot) =
+  let products = take tool_product_limit snapshot.products |> List.map capped_product in
+  let violations = take tool_violation_limit snapshot.violations in
+  ({ Coordination_product.products = products; violations } : Coordination_product.snapshot)
+;;
+
+let assoc_append key value = function
+  | `Assoc fields -> `Assoc (fields @ [ key, value ])
+  | json -> json
+;;
+
+let tool_truncation_json ~(original : Coordination_product.snapshot)
+      ~(capped : Coordination_product.snapshot) =
+  `Assoc
+    [ "products_original", `Int (List.length original.products)
+    ; "products_returned", `Int (List.length capped.products)
+    ; "violations_original", `Int (List.length original.violations)
+    ; "violations_returned", `Int (List.length capped.violations)
+    ; "product_limit", `Int tool_product_limit
+    ; "violation_limit", `Int tool_violation_limit
+    ; "evidence_per_product_limit", `Int tool_evidence_per_product_limit
+    ; "post_read_limit", `Int tool_post_limit
+    ; "telemetry_read_limit", `Int tool_telemetry_limit
+    ]
+;;
+
+let safe_build_tool_yojson config =
+  try
+    let original = build_for_tool config in
+    let capped = cap_tool_snapshot original in
+    Coordination_product.snapshot_to_yojson capped
+    |> assoc_append "truncation" (tool_truncation_json ~original ~capped)
+  with
+  | exn ->
+    let message = Printexc.to_string exn in
+    Log.Coord.warn "coordination product bounded snapshot failed: %s" message;
+    Coordination_product.snapshot_to_yojson
+      ~projection_error:message
+      (Coordination_product.snapshot [])
+    |> assoc_append "truncation"
+         (`Assoc
+            [ "products_original", `Int 0
+            ; "products_returned", `Int 0
+            ; "violations_original", `Int 0
+            ; "violations_returned", `Int 0
+            ; "product_limit", `Int tool_product_limit
+            ; "violation_limit", `Int tool_violation_limit
+            ; "evidence_per_product_limit", `Int tool_evidence_per_product_limit
+            ; "post_read_limit", `Int tool_post_limit
+            ; "telemetry_read_limit", `Int tool_telemetry_limit
+            ])
 ;;

--- a/lib/coordination_product_snapshot.mli
+++ b/lib/coordination_product_snapshot.mli
@@ -49,3 +49,10 @@ val safe_build_yojson : Coord.config -> Yojson.Safe.t
 
     On projection failure the result keeps the normal snapshot shape with empty
     products/violations and a [projection_error] field. *)
+
+val safe_build_tool_yojson : Coord.config -> Yojson.Safe.t
+(** Bounded variant for MCP/tool calls.
+
+    Keeps the advisory summary shape but caps expensive evidence reads and
+    serialized products so live diagnostics cannot monopolize the tool call
+    worker on large runtime state. *)

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -196,6 +196,19 @@ let read_all_events ?fs:_ config : event_record list =
   else
     read_all_events_from_path (telemetry_file config)
 
+let read_recent_events ?fs:_ config ~limit : event_record list =
+  if limit <= 0 then []
+  else
+    let store = get_telemetry_store config in
+    let jsons = Dated_jsonl.read_recent store limit in
+    if jsons <> [] then
+      parse_event_records jsons
+    else
+      read_all_events_from_path (telemetry_file config)
+      |> List.rev
+      |> List.filteri (fun i _ -> i < limit)
+      |> List.rev
+
 let summarize_tool_usage ?fs config : tool_usage_summary =
   let telemetry_path = telemetry_file config in
   let store = get_telemetry_store config in

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -112,6 +112,9 @@ type agent_activity = {
 
 val read_all_events : ?fs:'a -> config -> event_record list
 
+val read_recent_events :
+  ?fs:'a -> config -> limit:int -> event_record list
+
 val read_events_since :
   ?fs:'a -> config -> since:float -> event_record list
 

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -637,7 +637,7 @@ let handle_workflow_guide ctx _args =
 let handle_coordination_fsm_snapshot ctx _args =
   { success = true;
     message = Yojson.Safe.to_string
-      (Coordination_product_snapshot.safe_build_yojson ctx.config) }
+      (Coordination_product_snapshot.safe_build_tool_yojson ctx.config) }
 
 (* ── State check (assertion-based verification) ────────────────── *)
 

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -118,7 +118,8 @@ let () = test "dispatch_coordination_fsm_snapshot" (fun () ->
       let open Yojson.Safe.Util in
       assert (json |> member "mode" |> to_string = "advisory");
       assert (json |> member "summary" |> member "products" |> to_int >= 0);
-      assert (json |> member "summary" |> member "evidence" |> to_int >= 0)
+      assert (json |> member "summary" |> member "evidence" |> to_int >= 0);
+      assert (json |> member "truncation" |> member "product_limit" |> to_int > 0)
   | None -> failwith "dispatch returned None"
 )
 


### PR DESCRIPTION
## Summary
- Bound `masc_coordination_fsm_snapshot` to the recent data needed by tool callers instead of serializing the full runtime history.
- Add capped telemetry/post/product/evidence collection plus `truncation` metadata so operators can see when the tool response is intentionally bounded.
- Keep the full snapshot builder available for non-tool paths while routing the MCP tool through the bounded builder.

## Live issue
- Live `masc_status`, `masc_tasks`, and `masc_keeper_list` returned, but `masc_coordination_fsm_snapshot` timed out after 120s on the active 8935 runtime.
- This patch limits the tool response size so the coordination surface can fail closed with explicit truncation instead of hanging the caller.

## Verification
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_tool_coord_coverage.exe` (pass; existing legacy tuple alerts only)
- `./_build/default/test/test_tool_coord_coverage.exe test coverage 3`

## Notes
- Current live 8935 runtime was not restarted from this branch, so the live MCP tool can still time out until this lands and is deployed.