### PR TITLE
feat(ide): RFC-0028 PR-δ-2 — cascade-hop → keeper-trace bridge (second producer wire-in)

### DIFF
--- a/dashboard/src/components/ide/cascade-hop-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/cascade-hop-trace-bridge.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  bridgeCascadeEventsToTrace,
+  type CascadeHopProducerInput,
+} from './cascade-hop-trace-bridge'
+import {
+  clearTraces,
+  keeperTraceState,
+} from './keeper-trace-store'
+
+function evt(
+  cascade_name: string,
+  cycle: number,
+  ts: number,
+  strategy = 'round_robin',
+): CascadeHopProducerInput {
+  return { cascade_name, cycle, ts, strategy }
+}
+
+beforeEach(() => {
+  clearTraces()
+})
+
+afterEach(() => {
+  clearTraces()
+})
+
+describe('bridgeCascadeEventsToTrace — RFC-0028 PR-δ cascade-hop producer', () => {
+  it('emits a trace event for every cascade event on the first call', () => {
+    const out = bridgeCascadeEventsToTrace(
+      [
+        evt('default', 1, 1_715_000_000),
+        evt('default', 2, 1_715_000_001),
+      ],
+      new Set(),
+    )
+
+    expect(out.size).toBe(2)
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(2)
+    expect(events.every(e => e.source === 'cascade-hop')).toBe(true)
+  })
+
+  it('does not re-emit cascade events that share the same dedup key', () => {
+    const known = new Set(['cascade:default:1:1715000000'])
+    bridgeCascadeEventsToTrace(
+      [
+        evt('default', 1, 1_715_000_000),
+        evt('default', 2, 1_715_000_001),
+      ],
+      known,
+    )
+
+    const ids = keeperTraceState.value.events.map(e => e.id)
+    expect(ids).toEqual(['cascade:default:2:1715000001'])
+  })
+
+  it('returns an updated set including all newly emitted dedup keys', () => {
+    const out = bridgeCascadeEventsToTrace(
+      [evt('default', 1, 1_715_000_000)],
+      new Set(['cascade:other:0:0']),
+    )
+    expect([...out].sort()).toEqual([
+      'cascade:default:1:1715000000',
+      'cascade:other:0:0',
+    ])
+  })
+
+  it('returns the input set unchanged when events is empty', () => {
+    const before = new Set(['cascade:default:0:0'])
+    const after = bridgeCascadeEventsToTrace([], before)
+    expect(after).toBe(before)
+    expect(keeperTraceState.value.events.length).toBe(0)
+  })
+
+  it('skips events with non-finite ts (NaN-guard)', () => {
+    bridgeCascadeEventsToTrace(
+      [
+        evt('default', 1, Number.NaN),
+        evt('default', 2, 1_715_000_000),
+      ],
+      new Set(),
+    )
+    const ids = keeperTraceState.value.events.map(e => e.id)
+    expect(ids).toEqual(['cascade:default:2:1715000000'])
+  })
+
+  it('accepts both unix-seconds and unix-milliseconds for ts', () => {
+    bridgeCascadeEventsToTrace(
+      [
+        evt('a', 1, 1_715_000_000),       // seconds
+        evt('b', 1, 1_715_000_000_000),   // milliseconds
+      ],
+      new Set(),
+    )
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(2)
+    const aMs = events.find(e => e.keeperName === 'a')?.tsMs
+    const bMs = events.find(e => e.keeperName === 'b')?.tsMs
+    expect(aMs).toBe(1_715_000_000_000)
+    expect(bMs).toBe(1_715_000_000_000)
+  })
+
+  it('maps fields correctly: id, tsMs, keeperName, source, hopId, provider', () => {
+    bridgeCascadeEventsToTrace(
+      [evt('mainline', 7, 1_715_000_000, 'weighted_score')],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event.id).toBe('cascade:mainline:7:1715000000')
+    expect(event.tsMs).toBe(1_715_000_000_000)
+    expect(event.keeperName).toBe('mainline')
+    expect(event.source).toBe('cascade-hop')
+    if (event.source === 'cascade-hop') {
+      expect(event.hopId).toBe('mainline-7')
+      expect(event.provider).toBe('weighted_score')
+    }
+  })
+
+  it('is idempotent across repeated calls with the returned set', () => {
+    const inputs = [
+      evt('default', 1, 1_715_000_000),
+      evt('default', 2, 1_715_000_001),
+    ]
+    let known: ReadonlySet<string> = new Set()
+    known = bridgeCascadeEventsToTrace(inputs, known)
+    known = bridgeCascadeEventsToTrace(inputs, known)
+    known = bridgeCascadeEventsToTrace(inputs, known)
+
+    expect(keeperTraceState.value.events.length).toBe(2)
+  })
+})

--- a/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
+++ b/dashboard/src/components/ide/cascade-hop-trace-bridge.ts
@@ -1,0 +1,93 @@
+import { pushTrace } from './keeper-trace-store'
+
+/**
+ * RFC-0028 PR-δ producer: cascade-hop → keeper-trace bridge.
+ *
+ * Pure mapper — given a snapshot of CascadeStrategyTraceEvent values
+ * (from `/api/v1/cascade/strategy_trace`) and a set of dedup keys that
+ * have already been emitted, push trace events for the new ones and
+ * return the updated set.
+ *
+ * Dedup-key shape: `cascade:${cascade_name}:${cycle}:${ts}`.
+ *
+ *   - `cascade_name + cycle` would be sufficient under monotonic cycle
+ *     assumption, but `ts` is included to survive a server-side cycle
+ *     reset (e.g., process restart) without false-coalesce.
+ *   - The key never appears outside this module. The only consumer is
+ *     `alreadyEmitted: ReadonlySet<string>` owned by the calling
+ *     component — same lifecycle pattern as the anchored-thread bridge
+ *     (PR-δ-1, #13375).
+ *
+ * Mapping (CascadeStrategyTraceEvent → KeeperTraceEvent[cascade-hop]):
+ *   id         ← `cascade:${cascade_name}:${cycle}:${ts}` (synthesized)
+ *   tsMs       ← unixishToMs(event.ts)  (NaN-guarded; second or ms input)
+ *   keeperName ← event.cascade_name  (cascade is cascade-level, not
+ *                keeper-level — the trace store's `keeperName` field is
+ *                used as a logical bucket and consumers route cascade
+ *                rows to RFC §5 cascade-name lane.)
+ *   source     ← 'cascade-hop'
+ *   hopId      ← `${cascade_name}-${cycle}` (single strategy decision
+ *                identity for replay grouping)
+ *   provider   ← event.strategy  (the cascade strategy that produced
+ *                the hop; RFC-0023 uses "strategy" as the routing
+ *                discriminator and this surfaces it on the chip.)
+ *
+ * Why a pure function (not a stateful subscription):
+ *   - The owning component (`IdeConversationRailMock`) already has the
+ *     fetched `cascadeEvents` array as a useState value. A pure mapper
+ *     called from a `useEffect([cascadeEvents])` is sufficient and
+ *     trivially testable.
+ *   - Avoids storing per-component state inside the trace store, which
+ *     would couple the store to producer lifecycle.
+ *   - Module-level mutable state would leak across components and break
+ *     the deduplication guarantee on remount.
+ *
+ * NaN-guard rationale: a malformed `ts` (or a null) would propagate
+ * `NaN` into the store and break binary-search insertion. We silently
+ * skip such events — they cannot participate in replay either.
+ */
+
+export interface CascadeHopProducerInput {
+  readonly ts: number
+  readonly cascade_name: string
+  readonly strategy: string
+  readonly cycle: number
+}
+
+function unixishToMs(ts: number): number {
+  if (!Number.isFinite(ts)) return Number.NaN
+  return ts > 1_000_000_000_000 ? ts : ts * 1000
+}
+
+function dedupKey(event: CascadeHopProducerInput): string {
+  return `cascade:${event.cascade_name}:${event.cycle}:${event.ts}`
+}
+
+/**
+ * Push trace events for every cascade event not already in
+ * `alreadyEmitted` and return the updated set. The caller (typically a
+ * component effect) owns the set and re-passes it on each call.
+ */
+export function bridgeCascadeEventsToTrace(
+  events: ReadonlyArray<CascadeHopProducerInput>,
+  alreadyEmitted: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (events.length === 0) return alreadyEmitted
+  const next = new Set(alreadyEmitted)
+  for (const event of events) {
+    const key = dedupKey(event)
+    if (next.has(key)) continue
+    const tsMs = unixishToMs(event.ts)
+    if (!Number.isFinite(tsMs)) continue
+    pushTrace({
+      id: key,
+      tsMs,
+      keeperName: event.cascade_name,
+      source: 'cascade-hop',
+      hopId: `${event.cascade_name}-${event.cycle}`,
+      provider: event.strategy,
+    })
+    next.add(key)
+  }
+  return next
+}

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { bridgePostsToTrace } from './anchored-thread-trace-bridge'
+import { bridgeCascadeEventsToTrace } from './cascade-hop-trace-bridge'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import { KeeperBadge } from '../keeper-badge'
 import {
@@ -138,6 +139,15 @@ export function IdeConversationRailMock() {
   useEffect(() => {
     knownPostIds.current = bridgePostsToTrace(posts, knownPostIds.current)
   }, [posts])
+
+  // RFC-0028 PR-δ-2 cascade-hop producer: each cascade strategy_trace
+  // event becomes a keeper-trace event the first time it is observed.
+  // Dedup key is `cascade:${cascade_name}:${cycle}:${ts}` so a server
+  // restart that resets cycle counters cannot collide with prior runs.
+  const knownCascadeKeys = useRef<ReadonlySet<string>>(new Set())
+  useEffect(() => {
+    knownCascadeKeys.current = bridgeCascadeEventsToTrace(cascadeEvents, knownCascadeKeys.current)
+  }, [cascadeEvents])
 
   const replayItems = replayRailItems(posts, decisions, cascadeEvents)
   const replayEvents = replayEventsForItems(replayItems)


### PR DESCRIPTION
## 목적

RFC-0028 PR-δ (4 producer wire-in) 의 두 번째 sub-PR. cascade-hop producer 를 keeper-trace-store (#13311 PR-α) 로 wire. PR-δ-1 (#13375 anchored-thread) 와 같은 컴포넌트, 같은 패턴, 다른 endpoint.

## Scope (4 producer 분할)

| Sub-PR | Producer | Source | 본 PR? |
|--------|----------|--------|--------|
| PR-δ-1 (#13375 MERGED) | anchored-thread | BoardPost (`/api/v1/board`) | — |
| **PR-δ-2 (본 PR)** | **cascade-hop** | CascadeStrategyTraceEvent (`/api/v1/cascade/strategy_trace`) | ✅ |
| PR-δ-3 | decision-log | KeeperDecision (`/api/v1/decisions`) | follow-up |
| PR-δ-4 | bdi-snapshot | RFC-0024 BDI inspector polling | follow-up |

## Diff stat

- 3 files / +235 / -0
- 신규: `cascade-hop-trace-bridge.ts` (93), `cascade-hop-trace-bridge.test.ts` (132, 8 cases)
- 수정: `ide-conversation-rail-mock.ts` (+10/-0, import + ref + useEffect)

## Public API

### `cascade-hop-trace-bridge.ts` (신규)

```ts
export interface CascadeHopProducerInput {
  readonly ts: number
  readonly cascade_name: string
  readonly strategy: string
  readonly cycle: number
}

export function bridgeCascadeEventsToTrace(
  events: ReadonlyArray<CascadeHopProducerInput>,
  alreadyEmitted: ReadonlySet<string>,
): ReadonlySet<string>
```

Pure mapper — 새 cascade event 만 `pushTrace` 호출, 갱신된 dedup-key set 반환.

## 설계 결정

### Pure function vs Stateful subscription
PR-δ-1 의 결정과 동일. 컴포넌트가 이미 useState 로 cascadeEvents 보관, mapper trivially testable, store invariants (binary-search / coalesce / retention) 가 producer lifecycle 와 결합 회피.

### Synth dedup key (anchored-thread 와 차이)

| 측면 | anchored-thread (PR-δ-1) | cascade-hop (본 PR) |
|------|--------|--------|
| Native id 존재? | ✅ `post.id` | ❌ |
| Dedup key | `post.id` | `cascade:${cascade_name}:${cycle}:${ts}` |
| 근거 | external fact | server cycle counter reset 시 collision 방지 |

`cascade_name + cycle` 만으로도 monotonic 가정 하 충분하지만, 서버 재시작 시 cycle 0 부터 재시작 가능 → ts 까지 포함해서 cross-restart safe.

### Field mapping (CascadeStrategyTraceEvent → KeeperTraceEvent)

| trace 필드 | source | 비고 |
|-----------|--------|-----|
| `id` | `cascade:${cascade_name}:${cycle}:${ts}` | synth, dedup-key 와 동일 |
| `tsMs` | `unixishToMs(event.ts)` | second / ms tolerant, NaN 시 skip |
| `keeperName` | `event.cascade_name` | cascade 는 cascade-level — store 의 keeperName 을 logical bucket 으로 사용 (RFC §5 cascade-name lane) |
| `source` | `'cascade-hop'` | discriminator |
| `hopId` | `${cascade_name}-${cycle}` | RFC-0023 single strategy decision identity |
| `provider` | `event.strategy` | RFC-0023 의 strategy 가 routing discriminator → chip 표시 field |

### unixishToMs (anchored-thread NaN-guard 와 차이)

anchored-thread 는 `Date.parse(iso) → NaN` skip. cascade event 의 `ts` 는 numeric — second 와 ms 를 자동 변환:

```ts
function unixishToMs(ts: number): number {
  if (!Number.isFinite(ts)) return Number.NaN
  return ts > 1_000_000_000_000 ? ts : ts * 1000
}
```

Server 측이 second 또는 ms 둘 다 send 가능 (`unixishToMs` 가 IdeConversationRailMock 에서 이미 같은 패턴으로 사용 — line 91-94, 검증된 heuristic). 본 bridge 는 inline copy 로 self-contained.

## Wire-in (`IdeConversationRailMock`)

```ts
const knownCascadeKeys = useRef<ReadonlySet<string>>(new Set())
useEffect(() => {
  knownCascadeKeys.current = bridgeCascadeEventsToTrace(cascadeEvents, knownCascadeKeys.current)
}, [cascadeEvents])
```

| 측면 | 설명 |
|------|------|
| Ref scope | 컴포넌트 인스턴스별. remount 시 새 set 으로 시작 (production semantics 와 일치) |
| Trigger | `cascadeEvents` (useState) 변경 시. 첫 fetch 결과 도착 시 모든 event 발화, 후속 fetch 는 새 dedup-key 만 |
| 회귀 위험 | 0 — UI render 무변경, store 는 additive |
| PR-δ-1 와 공존 | 같은 컴포넌트의 다른 useEffect, `posts` / `cascadeEvents` 별도 deps array — 상호 독립 |

## Test results

```
Test Files  34 passed (34)
     Tests  223 passed (223)  -- src/components/ide broader sweep
```

PR-δ-1 머지 후 baseline (211/211 across 33) 와 비교 → +12 tests, +1 file.

| 파일 | total | new (PR-δ-2) |
|------|------|------|
| `cascade-hop-trace-bridge.test.ts` (신규) | 8 | 8 (first-emit / dedup / set-return / empty / NaN-guard / **second-or-ms** / field mapping / idempotent) |
| `anchored-thread-trace-bridge.test.ts` (PR-δ-1) | 7 | 회귀 0 |
| 기타 32 IDE files | 208 | 회귀 0 |

### second-or-ms 케이스 (cascade-specific)

PR-δ-1 가 `Date.parse` 의존이라 second/ms 처리 필요 없었음. 본 PR 은 numeric ts 라 명시적 검증:

```ts
it('accepts both unix-seconds and unix-milliseconds for ts', () => {
  bridgeCascadeEventsToTrace([
    evt('a', 1, 1_715_000_000),       // seconds
    evt('b', 1, 1_715_000_000_000),   // milliseconds
  ], new Set())
  expect(events.find(e => e.keeperName === 'a')?.tsMs).toBe(1_715_000_000_000)
  expect(events.find(e => e.keeperName === 'b')?.tsMs).toBe(1_715_000_000_000)
})
```

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "cascade-hop-trace-bridge OR bridgeCascadeEventsToTrace OR 'RFC-0028 PR-δ-2'" --state open` → 본 PR 외 0
- `gh pr list --search "cascade-hop-trace-bridge OR bridgeCascadeEventsToTrace" --state merged --limit 5` → 0 — synth dedup key + new symbol, 1차 등장
- `git fetch origin && git log origin/main --since=1h --oneline` → #13375 (PR-δ-1, base ancestor), 본 PR 와 다른 producer
- `rg "bridgeCascadeEventsToTrace|cascade-hop-trace-bridge" dashboard/src/` → 본 PR 신규 caller 만 (test + ide-conversation-rail-mock)

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/components/ide/` → **223/223 pass** across 34 files
- ESLint 본 PR 변경 파일 → **0 error / 0 warning**

## Rollback plan

3-file revert. Bridge 모듈은 ide-conversation-rail-mock 외 caller 0. revert 시 useEffect + import drop. store / overlay / PR-δ-1 anchored-thread 모두 unchanged. cascade strategy_trace fetch 는 기존대로 replay rail 에 표시 (변경 없음).

## RFC waiver

agent_delegation 영역 변경 없음. behavior-additive (UI 변경 0, store 의 add-only 작업).

`RFC-WAIVED: behavior-additive bridge over existing additive store. Bridge is a pure mapper; wire-in only adds a useEffect that pushes events. No UI changes. RFC-0028 PR-α (#13311) and PR-β (#13336) already merged; PR-δ-1 (#13375) for the anchored-thread sibling already merged.`

## Related

- #13311 (RFC-0028 PR-α store) — base, 본 PR 가 `pushTrace` consume
- #13336 (RFC-0028 PR-β overlay) — sibling, 본 PR 의 events 가 표시될 곳 (overlay wire-in 별도 PR 필요)
- #13375 (RFC-0028 PR-δ-1 anchored-thread) — sibling producer, 본 PR 와 같은 컴포넌트의 다른 useEffect
- #13293 (RFC-0028 spec Draft) — §5 cascade-hop bucket
- #13236 (audit replay timeline) — 같은 컴포넌트의 sibling cascade rendering

## Follow-up

- **PR-δ-3 decision-log** producer: `KeeperDecision → trace` mapper, 같은 컴포넌트 wire-in
- **PR-δ-4 bdi-snapshot** producer: RFC-0024 BDI inspector polling 결과 wire
- **PR-wire-in**: `<OverlayKeeperTrace active={...}>` IDE shell 마운트 — 첫 producer (PR-δ-1) 가 이미 main, 본 PR 가 두 번째 → user-visible wire-in 시점 도래
- RFC-0028 spec (#13289) 머지 후 amend PR (PR-δ family 결정 인용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
