### PR TITLE
fix(dashboard): wire IDE command bar

### DIFF
--- a/dashboard/src/components/common/command-bar.test.ts
+++ b/dashboard/src/components/common/command-bar.test.ts
@@ -110,4 +110,16 @@ describe('CommandBar', () => {
     render(h(CommandBar, { actions, testId: 'cmd-1' }), container)
     expect(container.querySelector('[data-testid="cmd-1"]')).not.toBeNull()
   })
+
+  it('keeps aria-controls stable across rerenders', () => {
+    const container = document.createElement('div')
+    render(h(CommandBar, { actions }), container)
+    const first = container.querySelector('input')?.getAttribute('aria-controls')
+
+    render(h(CommandBar, { actions, placeholder: 'Next command...' }), container)
+    const second = container.querySelector('input')?.getAttribute('aria-controls')
+
+    expect(first).toBeTruthy()
+    expect(second).toBe(first)
+  })
 })

--- a/dashboard/src/components/common/command-bar.ts
+++ b/dashboard/src/components/common/command-bar.ts
@@ -6,8 +6,9 @@
 
 import { html } from 'htm/preact'
 import { useMemo, useRef, useState } from 'preact/hooks'
+import { useId } from '../../../design-system/headless-preact/use-id'
 
-interface CommandBarAction {
+export interface CommandBarAction {
   id: string
   title: string
   keywords?: string
@@ -16,6 +17,8 @@ interface CommandBarAction {
 
 interface CommandBarProps {
   actions: CommandBarAction[]
+  className?: string
+  inputClassName?: string
   placeholder?: string
   onSelect?: (action: CommandBarAction) => void
   testId?: string
@@ -50,6 +53,8 @@ function filterActions(actions: CommandBarAction[], query: string): CommandBarAc
 
 export function CommandBar({
   actions,
+  className,
+  inputClassName = 'w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-fg-primary)] outline-none transition-colors focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]',
   placeholder = '명령어 검색...',
   onSelect,
   testId,
@@ -58,7 +63,7 @@ export function CommandBar({
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
-  const listId = useMemo(() => `cmdbar-list-${Math.random().toString(36).slice(2, 8)}`, [])
+  const listId = `${useId()}-cmdbar-list`
 
   const filtered = useMemo(() => filterActions(actions, query), [actions, query])
 
@@ -120,11 +125,11 @@ export function CommandBar({
   }
 
   return html`
-    <div class="relative w-full" data-command-bar data-testid=${testId}>
+    <div class=${`relative w-full ${className ?? ''}`} data-command-bar data-testid=${testId}>
       <input
         ref=${inputRef}
         type="text"
-        class="w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-fg-primary)] outline-none transition-colors focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]"
+        class=${inputClassName}
         placeholder=${placeholder}
         value=${query}
         onInput=${handleInput}

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -54,6 +54,14 @@ function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
   return button
 }
 
+function ideCommandInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector('[data-testid="ide-command-bar"] input')
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error('missing IDE command bar input')
+  }
+  return input
+}
+
 describe('IdeShell', () => {
   let container: HTMLDivElement
 
@@ -102,6 +110,57 @@ describe('IdeShell', () => {
 
     fireEvent.click(buttonByText(container, 'EXPLODE'))
     expect(route.value.params.layers).toBe('explode')
+  })
+
+  it('runs view commands from the IDE command bar', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    const input = ideCommandInput(container)
+    input.value = 'unified'
+    fireEvent.input(input)
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull())
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(route.value.params.view).toBe('unified')
+  })
+
+  it('runs layer commands from the IDE command bar', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    const input = ideCommandInput(container)
+    input.value = 'cascade'
+    fireEvent.input(input)
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull())
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(route.value.params.layers).toBe('cascade')
+  })
+
+  it('opens the terminal route from the IDE command bar', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    const input = ideCommandInput(container)
+    input.value = 'terminal'
+    fireEvent.input(input)
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull())
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(route.value.params.terminal).toBe('open')
   })
 
   it('renders the Cascade layer button and toggles it via URL', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -90,6 +90,17 @@ export function IdeShell() {
     navigate('code', paramsWithLayers(route.value.params, activeView, nextLayers))
   }
 
+  const handleTerminalOpen = () => {
+    const nextParams: Record<string, string> = {
+      ...route.value.params,
+      section: 'ide-shell',
+      view: activeView,
+      terminal: 'open',
+    }
+    if (terminalKeeper) nextParams.keeper = terminalKeeper
+    navigate('code', nextParams)
+  }
+
   return html`
     <section
       class="ide-plane-shell"
@@ -114,6 +125,7 @@ export function IdeShell() {
         activeLayers=${activeLayers}
         onViewChange=${handleViewChange}
         onLayersChange=${handleLayersChange}
+        onTerminalOpen=${handleTerminalOpen}
       />
       <div
         class="ide-plane-grid"

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -5,6 +5,7 @@ import {
   type OverlayLayer,
 } from '../../../design-system/headless-core/layered-overlay'
 import { useLayeredOverlay } from '../../../design-system/headless-preact/use-layered-overlay'
+import { CommandBar, type CommandBarAction } from '../common/command-bar'
 
 // Phase 1 PR-3: IDE editor toolbar — view tabs + LAYERS toggle.
 // View tabs (SOURCE / SPLIT DIFF / UNIFIED / BLAME) are local UI state
@@ -43,9 +44,16 @@ interface IdeToolbarProps {
   readonly activeLayers: ReadonlySet<string>
   readonly onViewChange: (id: ViewTab) => void
   readonly onLayersChange: (active: ReadonlySet<string>) => void
+  readonly onTerminalOpen?: () => void
 }
 
-export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersChange }: IdeToolbarProps) {
+export function IdeToolbar({
+  activeView,
+  activeLayers,
+  onViewChange,
+  onLayersChange,
+  onTerminalOpen,
+}: IdeToolbarProps) {
   const controller = useMemo(() => {
     const next = createLayeredOverlay(IDE_LAYERS)
     next.setActive(activeLayers)
@@ -62,6 +70,29 @@ export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersCha
     onLayersChange(controller.active())
   }
 
+  const commandActions: CommandBarAction[] = [
+    ...VIEW_TABS.map(tab => ({
+      id: `view-${tab.id}`,
+      title: `View: ${tab.label}`,
+      keywords: `${tab.id} ${tab.label} editor mode`,
+      handler: () => onViewChange(tab.id),
+    })),
+    ...IDE_LAYERS.map(layer => ({
+      id: `layer-${layer.kind}`,
+      title: `${isActive(layer.kind) ? 'Hide' : 'Show'} ${layer.label} layer`,
+      keywords: `toggle ${layer.kind} ${layer.description}`,
+      handler: () => handleLayerToggle(layer.kind),
+    })),
+    ...(onTerminalOpen
+      ? [{
+          id: 'terminal-open',
+          title: 'Open Keeper Terminal',
+          keywords: 'terminal shell keeper output',
+          handler: onTerminalOpen,
+        }]
+      : []),
+  ]
+
   return html`
     <div
       class="ide-toolbar"
@@ -69,6 +100,7 @@ export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersCha
       aria-label="IDE editor toolbar"
       style=${{
         display: 'grid',
+        gridTemplateColumns: 'auto minmax(180px, 320px) 1fr auto',
         alignItems: 'center',
         gap: 'var(--sp-3)',
         padding: 'var(--sp-2) var(--sp-3)',
@@ -96,6 +128,13 @@ export function IdeToolbar({ activeView, activeLayers, onViewChange, onLayersCha
           >${tab.label}</button>
         `)}
       </div>
+      <${CommandBar}
+        actions=${commandActions}
+        placeholder="Run IDE command..."
+        testId="ide-command-bar"
+        className="min-w-0"
+        inputClassName="h-7 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] outline-none transition-colors placeholder:text-[var(--color-fg-disabled)] focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]"
+      />
       <span class="ide-toolbar-spacer" aria-hidden="true" />
       <div
         class="ide-toolbar-layers"


### PR DESCRIPTION
## Summary
- Reuse the existing `CommandBar` molecule inside the Code IDE toolbar.
- Add command actions for IDE view switching, overlay layer toggles, and opening the keeper terminal drawer.
- Replace the command bar's random listbox id with the design-system `useId` helper so ARIA wiring stays stable across rerenders.

## Why It Matters
The imported Kimi/MASC cockpit artifacts call out a command-palette/terminal IDE surface, but the live Code IDE toolbar only exposed direct tabs and layer buttons. This makes the existing command bar molecule part of the actual IDE workflow instead of leaving it as an isolated component.

## Validation
- `pnpm --dir dashboard exec eslint src/components/common/command-bar.ts src/components/common/command-bar.test.ts src/components/common/command-bar.a11y.test.ts src/components/ide/ide-toolbar.ts src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/common/command-bar.test.ts src/components/common/command-bar.a11y.test.ts src/components/ide/ide-shell.test.ts`
- Browser proof: `http://127.0.0.1:5180/dashboard/#code?section=ide-shell&view=source` with command bar visible, `unified` command updating `view=unified`, `cascade` command setting `layers=cascade`, and `terminal` command setting `terminal=open`. Screenshot: `/tmp/masc-ide-commandbar.png`.

Known local test noise: the focused Vitest run still prints existing localhost:3000 ECONNREFUSED/socket hang-up noise, but the selected test files pass.