### PR TITLE
fix(fiber): add fair-yield scheduling guard

### DIFF
--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -56,12 +56,16 @@ let yield_if_ready () =
   if Atomic.get ready then
     Safe_ops.protect ~default:() (fun () -> Eio.Fiber.yield ())
 
+let fair_yield = yield_if_ready
+
+let default_fair_yield_interval = 1000
+
 type yield_meter = {
   interval : int;
   steps : int Atomic.t;
 }
 
-let create_yield_meter ?(interval = 1000) () =
+let create_yield_meter ?(interval = default_fair_yield_interval) () =
   { interval = max 1 interval; steps = Atomic.make 0 }
 
 let yield_step meter =

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -31,13 +31,20 @@ val yield_if_ready : unit -> unit
     No-op before {!enable} or when called from a context where Eio cannot
     currently yield. *)
 
+val fair_yield : unit -> unit
+(** Named cooperative yield for scheduler-fair keeper/cascade boundaries.
+    Equivalent to {!yield_if_ready}. *)
+
+val default_fair_yield_interval : int
+(** Default step interval for CPU-heavy loops.  P0 fair-yield contract: 1000. *)
+
 type yield_meter
 (** Counter for periodic cooperative yields in CPU-heavy loops. Safe to share
     across fibers or domains. *)
 
 val create_yield_meter : ?interval:int -> unit -> yield_meter
 (** Create a meter that yields every [interval] steps.  Non-positive
-    intervals are coerced to 1.  Default: 1000. *)
+    intervals are coerced to 1.  Default: {!default_fair_yield_interval}. *)
 
 val yield_step : yield_meter -> unit
 (** Count one CPU work unit and call {!yield_if_ready} whenever the

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1244,7 +1244,7 @@ let run_heartbeat_loop
       (* Yield before each heartbeat cycle to prevent N keeper fibers
                from monopolizing the Eio scheduler during CPU-bound phases
                (tool filtering, snapshot construction, prompt building). *)
-      Eio.Fiber.yield ();
+      Eio_guard.fair_yield ();
       (* Phase 0: timing markers *)
       let t_presence_start = Time_compat.now () in
       let disk_meta_opt, new_meta_mtime =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -585,7 +585,7 @@ let run_named
       Error
         terminal_error
     | (provider_cfg : Llm_provider.Provider_config.t) :: rest ->
-      Eio.Fiber.yield (); (* Task 4-3: Prevent starvation during fast-fail cascades *)
+      Eio_guard.fair_yield (); (* P0: keep fast-fail cascades scheduler-fair. *)
       match Cascade_health_tracker.check_circuit_breaker Cascade_health_tracker.global ~provider_key:provider_cfg.model_id with
       | Error msg ->
           Log.Misc.debug "cascade %s: skipping %s (provider cooldown: %s)" cascade_name provider_cfg.model_id msg;

--- a/test/dune
+++ b/test/dune
@@ -669,6 +669,7 @@
         test_goal_verification
         test_string_util
         test_board_core_payload
+        test_board_moderation
         test_voice_config)
  (modules
         test_runtime_params

--- a/test/test_eio_guard_yield_meter.ml
+++ b/test/test_eio_guard_yield_meter.ml
@@ -30,6 +30,12 @@ let test_no_op_outside_eio () =
     EG.yield_step m
   done
 
+let test_default_interval_contract () =
+  check int "P0 fair-yield interval" 1000 EG.default_fair_yield_interval
+
+let test_fair_yield_no_op_outside_eio () =
+  EG.fair_yield ()
+
 let test_custom_interval_outside_eio () =
   let m = EG.create_yield_meter ~interval:7 () in
   for _ = 1 to 21 do     (* 3 full batches of 7 *)
@@ -111,6 +117,10 @@ let () =
     [ ( "no-op",
         [ test_case "safe outside Eio runtime (default interval)" `Quick
             test_no_op_outside_eio
+        ; test_case "default interval is 1000" `Quick
+            test_default_interval_contract
+        ; test_case "fair_yield is safe outside Eio runtime" `Quick
+            test_fair_yield_no_op_outside_eio
         ; test_case "safe outside Eio runtime (custom interval)" `Quick
             test_custom_interval_outside_eio ] )
     ; ( "eio-runtime",

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1645,7 +1645,9 @@ let test_run_model_with_masc_tools_rejects_invalid_explicit_label () =
       ~model_label:"not-a-model-label"
       ~goal:"test goal"
       ~masc_tools:[]
-      ~dispatch:(fun ~name:_ ~args:_ -> (true, "ok"))
+      ~dispatch:(fun ~name ~args:_ ->
+        Tool_result.wrap ~tool_name:name ~start_time:(Time_compat.now ())
+          (true, "ok"))
       ()
   with
   | Ok _ ->


### PR DESCRIPTION
## Summary
- Name the P0 scheduler fairness contract as `Eio_guard.fair_yield` with a documented 1000-instruction default interval.
- Route fast-fail cascade and keeper heartbeat cycle yields through the shared guard helper.
- Restore the board moderation executable target and update the OAS worker mock dispatch to the structured tool result contract found during validation.

Fixes #13345
Fixes #13386
Related to #13369

## Validation
- `dune build --root . -j 1 test/test_eio_guard_yield_meter.exe test/test_keeper_mutex_coverage.exe test/test_oas_worker.exe test/test_board_moderation.exe`
- `./_build/default/test/test_eio_guard_yield_meter.exe`
- `./_build/default/test/test_keeper_mutex_coverage.exe`
- `./_build/default/test/test_board_moderation.exe`
- `./_build/default/test/test_oas_worker.exe test cascade_config 41`
- `git diff --check`

## Review Focus
- Confirm the shared fair-yield helper is the right boundary for scheduler fairness instrumentation.
- Confirm `default_fair_yield_interval = 1000` is explicit enough for future Keeper loop adoption.