### PR TITLE
refactor(dashboard): privatize 8 internal-only types (knip batch 3)

### DIFF
--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -141,7 +141,7 @@ export function deriveTimelineRows(
   return rows
 }
 
-export interface HandoffArc {
+interface HandoffArc {
   fromIdx: number
   toIdx: number
   xPct: number

--- a/dashboard/src/components/keeper-bdi-panel.ts
+++ b/dashboard/src/components/keeper-bdi-panel.ts
@@ -26,7 +26,7 @@ function GoalHorizonRow({
   `
 }
 
-export interface KeeperBDIPanelProps {
+interface KeeperBDIPanelProps {
   will?: string | null
   needs?: string | null
   desires?: string | null

--- a/dashboard/src/components/lifeline-bar.ts
+++ b/dashboard/src/components/lifeline-bar.ts
@@ -49,7 +49,7 @@ export function heartbeatPoints(
   return points.join(' ')
 }
 
-export interface HeartbeatProps {
+interface HeartbeatProps {
   /** 0..1 — animates the trace. Caller drives via setInterval / signal. */
   phase?: number
   width?: number
@@ -121,7 +121,7 @@ const captionStyle = {
   fontWeight: 500,
 }
 
-export interface LifelineBarProps {
+interface LifelineBarProps {
   /** Short slug rendered on the left, e.g. "LIFELINE". */
   label?: string
   /** 0..1 — driven by the caller. */

--- a/dashboard/src/lib/dashboard-auth-access.ts
+++ b/dashboard/src/lib/dashboard-auth-access.ts
@@ -2,7 +2,7 @@ import type { DashboardShellAuthSummary } from '../types'
 
 export type DashboardAuthRole = 'reader' | 'worker' | 'admin'
 
-export interface DashboardAuthAccess {
+interface DashboardAuthAccess {
   allowed: boolean
   required_role: DashboardAuthRole
   effective_role: DashboardAuthRole | null

--- a/dashboard/src/lib/performance-monitor.ts
+++ b/dashboard/src/lib/performance-monitor.ts
@@ -28,7 +28,7 @@ export interface LoAFEntry extends PerformanceEntry {
   readonly scripts: readonly LoAFScript[]
 }
 
-export interface PerformanceMonitorOptions {
+interface PerformanceMonitorOptions {
   /** Maximum number of frames retained in the ring buffer. */
   maxBufferSize?: number
   /** Duration threshold (ms) above which a frame is considered "slow". */

--- a/dashboard/src/refresh-scope.ts
+++ b/dashboard/src/refresh-scope.ts
@@ -1,6 +1,6 @@
 import type { RouteState } from './types'
 
-export type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity'
+type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity'
 
 export function routeWantsRefreshTarget(
   routeState: Pick<RouteState, 'tab' | 'params'>,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -62,7 +62,7 @@ import {
 
 // --- Shell counts (lightweight fallback from /dashboard/shell) ---
 
-export interface ShellCounts {
+interface ShellCounts {
   agents: number
   tasks: number
   keepers: number


### PR DESCRIPTION
## What

Continuation of #13313 / #13342. Knip flagged 138 unused exported types after batch 2; this PR privatizes 8 of them whose only reference is inside the same file.

| Type | File | Why safe to privatize |
|---|---|---|
| \`HandoffArc\` | \`handoff-timeline.ts\` | return type of \`deriveHandoffArcs\` (same file) |
| \`KeeperBDIPanelProps\` | \`keeper-bdi-panel.ts\` | function param destructure |
| \`HeartbeatProps\` / \`LifelineBarProps\` | \`lifeline-bar.ts\` | both are local component props |
| \`DashboardAuthAccess\` | \`lib/dashboard-auth-access.ts\` | return type of exported function (callers destructure values, not the type) |
| \`PerformanceMonitorOptions\` | \`lib/performance-monitor.ts\` | constructor param |
| \`RouteRefreshTarget\` | \`refresh-scope.ts\` | param of \`routeWantsRefreshTarget\` |
| \`ShellCounts\` | \`store.ts\` | generic on \`shellCounts\` signal |

## Verification

- \`tsc --noEmit\`: 0 errors
- ESLint on 7 changed files: 0 warnings
- vitest: 5 test files / 69 tests pass (handoff-timeline, lifeline-bar, performance-monitor, refresh-scope, store)
- \`rg "<TypeName>" -g '*.ts' -g '*.tsx' src\` for each: 0 cross-file refs

## Race check

- \`gh pr list --state open --search "handoff-timeline OR lifeline-bar OR …"\`: 0 matches
- \`git log origin/main --since=1h -- <files>\`: 0 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)