### PR TITLE
feat(ide): RFC-0028 PR-δ-3 — decision-log → keeper-trace bridge (third producer wire-in)

### DIFF
--- a/dashboard/src/components/ide/decision-log-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  bridgeDecisionsToTrace,
+  type DecisionLogProducerInput,
+} from './decision-log-trace-bridge'
+import {
+  clearTraces,
+  keeperTraceState,
+} from './keeper-trace-store'
+
+function dec(
+  keeper_name: string,
+  ts_unix: number | null,
+  event_type = 'turn',
+  outcome: string | null = 'ok',
+): DecisionLogProducerInput {
+  return { keeper_name, ts_unix, event_type, outcome }
+}
+
+beforeEach(() => {
+  clearTraces()
+})
+
+afterEach(() => {
+  clearTraces()
+})
+
+describe('bridgeDecisionsToTrace — RFC-0028 PR-δ decision-log producer', () => {
+  it('emits a trace event for every decision on the first call', () => {
+    const out = bridgeDecisionsToTrace(
+      [
+        dec('scholar', 1_715_000_000),
+        dec('moth', 1_715_000_001),
+      ],
+      new Set(),
+    )
+
+    expect(out.size).toBe(2)
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(2)
+    expect(events.every(e => e.source === 'decision-log')).toBe(true)
+  })
+
+  it('does not re-emit decisions that share the same dedup key', () => {
+    const known = new Set(['decision:scholar:1715000000:turn'])
+    bridgeDecisionsToTrace(
+      [
+        dec('scholar', 1_715_000_000),
+        dec('moth', 1_715_000_001),
+      ],
+      known,
+    )
+
+    const ids = keeperTraceState.value.events.map(e => e.id)
+    expect(ids).toEqual(['decision:moth:1715000001:turn'])
+  })
+
+  it('returns an updated set including all newly emitted dedup keys', () => {
+    const out = bridgeDecisionsToTrace(
+      [dec('scholar', 1_715_000_000)],
+      new Set(['decision:other:0:turn']),
+    )
+    expect([...out].sort()).toEqual([
+      'decision:other:0:turn',
+      'decision:scholar:1715000000:turn',
+    ])
+  })
+
+  it('returns the input set unchanged when decisions is empty', () => {
+    const before = new Set(['decision:scholar:0:turn'])
+    const after = bridgeDecisionsToTrace([], before)
+    expect(after).toBe(before)
+    expect(keeperTraceState.value.events.length).toBe(0)
+  })
+
+  it('skips decisions with null ts_unix', () => {
+    bridgeDecisionsToTrace(
+      [
+        dec('scholar', null),
+        dec('moth', 1_715_000_000),
+      ],
+      new Set(),
+    )
+    const ids = keeperTraceState.value.events.map(e => e.id)
+    expect(ids).toEqual(['decision:moth:1715000000:turn'])
+  })
+
+  it('skips decisions with non-finite ts_unix (NaN)', () => {
+    bridgeDecisionsToTrace(
+      [
+        dec('scholar', Number.NaN),
+        dec('moth', 1_715_000_000),
+      ],
+      new Set(),
+    )
+    const ids = keeperTraceState.value.events.map(e => e.id)
+    expect(ids).toEqual(['decision:moth:1715000000:turn'])
+  })
+
+  it('skips decisions with an empty keeper_name (would corrupt routing bucket)', () => {
+    bridgeDecisionsToTrace(
+      [
+        dec('', 1_715_000_000),
+        dec('moth', 1_715_000_001),
+      ],
+      new Set(),
+    )
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(1)
+    expect(events[0]!.keeperName).toBe('moth')
+  })
+
+  it('maps fields correctly: id, tsMs, keeperName, source, decisionId, semanticOutcome', () => {
+    bridgeDecisionsToTrace(
+      [dec('scholar', 1_715_000_000, 'tool_use', 'error_retryable')],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event.id).toBe('decision:scholar:1715000000:tool_use')
+    expect(event.tsMs).toBe(1_715_000_000_000)
+    expect(event.keeperName).toBe('scholar')
+    expect(event.source).toBe('decision-log')
+    if (event.source === 'decision-log') {
+      expect(event.decisionId).toBe('decision:scholar:1715000000:tool_use')
+      expect(event.semanticOutcome).toBe('error_retryable')
+    }
+  })
+
+  it('preserves a null semanticOutcome (in-flight decisions)', () => {
+    bridgeDecisionsToTrace(
+      [dec('scholar', 1_715_000_000, 'turn', null)],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    if (event.source === 'decision-log') {
+      expect(event.semanticOutcome).toBeNull()
+    }
+  })
+
+  it('is idempotent across repeated calls with the returned set', () => {
+    const inputs = [
+      dec('scholar', 1_715_000_000),
+      dec('moth', 1_715_000_001),
+    ]
+    let known: ReadonlySet<string> = new Set()
+    known = bridgeDecisionsToTrace(inputs, known)
+    known = bridgeDecisionsToTrace(inputs, known)
+    known = bridgeDecisionsToTrace(inputs, known)
+
+    expect(keeperTraceState.value.events.length).toBe(2)
+  })
+})

--- a/dashboard/src/components/ide/decision-log-trace-bridge.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.ts
@@ -1,0 +1,99 @@
+import { pushTrace } from './keeper-trace-store'
+
+/**
+ * RFC-0028 PR-δ producer: decision-log → keeper-trace bridge.
+ *
+ * Pure mapper — given a snapshot of KeeperDecision values
+ * (from `/api/v1/keeper/decisions`) and a set of dedup keys that have
+ * already been emitted, push trace events for the new ones and return
+ * the updated set.
+ *
+ * Dedup-key shape: `decision:${keeper_name}:${ts_unix}:${event_type}`.
+ *
+ *   - KeeperDecision has no native id field; the (keeper_name, ts_unix,
+ *     event_type) tuple is unique under the assumption that a single
+ *     keeper does not emit two events of the same type at the same
+ *     millisecond.
+ *   - The key never appears outside this module. The only consumer is
+ *     `alreadyEmitted: ReadonlySet<string>` owned by the calling
+ *     component — same lifecycle pattern as PR-δ-1 (#13375 anchored-
+ *     thread) and PR-δ-2 (cascade-hop).
+ *
+ * Mapping (KeeperDecision → KeeperTraceEvent[decision-log]):
+ *   id              ← `decision:${keeper_name}:${ts_unix}:${event_type}`
+ *   tsMs            ← unixishToMs(decision.ts_unix)  (NaN-guarded; null/
+ *                     non-finite skip)
+ *   keeperName      ← decision.keeper_name  (real keeper-level — unlike
+ *                     cascade-hop which uses cascade_name as a logical
+ *                     bucket)
+ *   source          ← 'decision-log'
+ *   decisionId      ← same as id (RFC-0026 KeeperDecision has no
+ *                     separate decision uuid — the synth tuple key
+ *                     suffices for chip identity)
+ *   semanticOutcome ← decision.outcome  (string | null; consumers can
+ *                     surface "ok"/"error_retryable"/"error_fatal"/etc.
+ *                     verbatim, or null for in-flight)
+ *
+ * Why a pure function (not a stateful subscription):
+ *   - The owning component (`IdeConversationRailMock`) already has the
+ *     fetched `decisions` array as a useState value. A pure mapper
+ *     called from a `useEffect([decisions])` is sufficient and trivially
+ *     testable.
+ *   - Avoids storing per-component state inside the trace store, which
+ *     would couple the store to producer lifecycle.
+ *   - Module-level mutable state would leak across components and break
+ *     the deduplication guarantee on remount.
+ *
+ * Skip rule for missing fields:
+ *   - ts_unix === null OR non-finite → skip (no usable tsMs, would
+ *     break binary-search insertion).
+ *   - keeper_name === '' → skip (the trace store's keeperName field is
+ *     used as a routing bucket; an empty string would coalesce
+ *     unrelated rows).
+ */
+
+export interface DecisionLogProducerInput {
+  readonly ts_unix: number | null
+  readonly keeper_name: string
+  readonly event_type: string
+  readonly outcome: string | null
+}
+
+function unixishToMs(ts: number | null): number {
+  if (ts === null || !Number.isFinite(ts)) return Number.NaN
+  return ts > 1_000_000_000_000 ? ts : ts * 1000
+}
+
+function dedupKey(decision: DecisionLogProducerInput): string {
+  return `decision:${decision.keeper_name}:${decision.ts_unix}:${decision.event_type}`
+}
+
+/**
+ * Push trace events for every decision not already in `alreadyEmitted`
+ * and return the updated set. The caller (typically a component effect)
+ * owns the set and re-passes it on each call.
+ */
+export function bridgeDecisionsToTrace(
+  decisions: ReadonlyArray<DecisionLogProducerInput>,
+  alreadyEmitted: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (decisions.length === 0) return alreadyEmitted
+  const next = new Set(alreadyEmitted)
+  for (const decision of decisions) {
+    if (decision.keeper_name === '') continue
+    const key = dedupKey(decision)
+    if (next.has(key)) continue
+    const tsMs = unixishToMs(decision.ts_unix)
+    if (!Number.isFinite(tsMs)) continue
+    pushTrace({
+      id: key,
+      tsMs,
+      keeperName: decision.keeper_name,
+      source: 'decision-log',
+      decisionId: key,
+      semanticOutcome: decision.outcome,
+    })
+    next.add(key)
+  }
+  return next
+}

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { bridgePostsToTrace } from './anchored-thread-trace-bridge'
 import { bridgeCascadeEventsToTrace } from './cascade-hop-trace-bridge'
+import { bridgeDecisionsToTrace } from './decision-log-trace-bridge'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import { KeeperBadge } from '../keeper-badge'
 import {
@@ -149,6 +150,14 @@ export function IdeConversationRailMock() {
     knownCascadeKeys.current = bridgeCascadeEventsToTrace(cascadeEvents, knownCascadeKeys.current)
   }, [cascadeEvents])
 
+  // RFC-0028 PR-δ-3 decision-log producer: each KeeperDecision becomes a
+  // keeper-trace event the first time it is observed. Dedup key is
+  // `decision:${keeper_name}:${ts_unix}:${event_type}` since the
+  // KeeperDecision payload has no native id field.
+  const knownDecisionKeys = useRef<ReadonlySet<string>>(new Set())
+  useEffect(() => {
+    knownDecisionKeys.current = bridgeDecisionsToTrace(decisions, knownDecisionKeys.current)
+  }, [decisions])
   const replayItems = replayRailItems(posts, decisions, cascadeEvents)
   const replayEvents = replayEventsForItems(replayItems)
   const visibleItemIds = new Set(filterReplayEvents(replayEvents, replayUntilMs).map(event => event.id))


### PR DESCRIPTION
## 목적

RFC-0028 PR-δ (4 producer wire-in) 의 세 번째 sub-PR. decision-log producer 를 keeper-trace-store (#13311 PR-α) 로 wire. PR-δ-1 (#13375 anchored-thread MERGED), PR-δ-2 (#13384 cascade-hop MERGED) 와 같은 컴포넌트, 같은 패턴, 다른 endpoint.

## Scope (4 producer 분할)

| Sub-PR | Producer | Source | 본 PR? |
|--------|----------|--------|--------|
| PR-δ-1 (#13375 MERGED) | anchored-thread | BoardPost (`/api/v1/board`) | — |
| PR-δ-2 (#13384 MERGED) | cascade-hop | CascadeStrategyTraceEvent (`/api/v1/cascade/strategy_trace`) | — |
| **PR-δ-3 (본 PR)** | **decision-log** | KeeperDecision (`/api/v1/keeper/decisions`) | ✅ |
| PR-δ-4 | bdi-snapshot | RFC-0024 BDI inspector polling | follow-up |

## Diff stat

- 3 files / +260 / -0
- 신규: `decision-log-trace-bridge.ts` (99), `decision-log-trace-bridge.test.ts` (152, 10 cases)
- 수정: `ide-conversation-rail-mock.ts` (+9/-0, import + ref + useEffect)

## Public API

### `decision-log-trace-bridge.ts` (신규)

```ts
export interface DecisionLogProducerInput {
  readonly ts_unix: number | null
  readonly keeper_name: string
  readonly event_type: string
  readonly outcome: string | null
}

export function bridgeDecisionsToTrace(
  decisions: ReadonlyArray<DecisionLogProducerInput>,
  alreadyEmitted: ReadonlySet<string>,
): ReadonlySet<string>
```

Pure mapper — 새 KeeperDecision 만 `pushTrace` 호출, 갱신된 dedup-key set 반환.

## 설계 결정

### Pure function vs Stateful subscription
PR-δ-1/2 결정과 동일. 컴포넌트가 이미 useState 로 decisions 보관, mapper trivially testable, store invariants (binary-search / coalesce / retention) 가 producer lifecycle 와 결합 회피.

### Synth dedup key (KeeperDecision 도 native id 없음)

`decision:${keeper_name}:${ts_unix}:${event_type}`. (keeper_name, ts_unix, event_type) tuple 이 unique 가정 — 같은 keeper 가 같은 ms 에 같은 event_type 두 번 emit 하지 않음.

### Field mapping (KeeperDecision → KeeperTraceEvent)

| trace 필드 | source | 비고 |
|-----------|--------|-----|
| `id` | dedup-key 와 동일 | KeeperDecision 에 native id 없음 |
| `tsMs` | `unixishToMs(decision.ts_unix)` | NaN-guard, null 도 skip |
| `keeperName` | `decision.keeper_name` | **real keeper-level** (cascade-hop 의 cascade_name 과 다름) |
| `source` | `'decision-log'` | discriminator |
| `decisionId` | `id` 와 동일 | RFC-0026 KeeperDecision 에 별도 uuid 없음 |
| `semanticOutcome` | `decision.outcome` | `string \| null` (in-flight 시 null 보존) |

### Skip rules (PR-δ-1/2 와 비교 시 추가)

| 조건 | Skip 이유 |
|------|----------|
| `ts_unix === null` | KeeperDecision 의 in-flight 사례 — `tsMs` 없으면 binary-search insertion 불가 |
| `ts_unix === NaN` | 동일 — store invariant 보호 |
| `keeper_name === ''` | trace store 의 `keeperName` 필드는 routing bucket — 빈 문자열은 unrelated rows 와 coalesce 위험 |

PR-δ-1 (anchored-thread) 는 `Date.parse` 의 NaN 만 skip, PR-δ-2 (cascade-hop) 는 numeric NaN 만 skip. PR-δ-3 가 처음으로 string-empty bucket guard 추가.

### unixishToMs (PR-δ-2 와 차이)

`ts_unix: number | null` 이라 PR-δ-2 의 unixishToMs 와 비교해 null 체크 추가:

```ts
function unixishToMs(ts: number | null): number {
  if (ts === null || !Number.isFinite(ts)) return Number.NaN
  return ts > 1_000_000_000_000 ? ts : ts * 1000
}
```

`IdeConversationRailMock` 의 line 91-94 와 같은 pattern (검증된 heuristic). 본 bridge 는 inline copy 로 self-contained.

## Wire-in (`IdeConversationRailMock`)

```ts
const knownDecisionKeys = useRef<ReadonlySet<string>>(new Set())
useEffect(() => {
  knownDecisionKeys.current = bridgeDecisionsToTrace(decisions, knownDecisionKeys.current)
}, [decisions])
```

| 측면 | 설명 |
|------|------|
| Ref scope | 컴포넌트 인스턴스별. remount 시 새 set 으로 시작 |
| Trigger | `decisions` (useState) 변경 시. 첫 fetch 결과 도착 시 모든 decision 발화, 후속 fetch 는 새 dedup-key 만 |
| 회귀 위험 | 0 — UI render 무변경, store 는 additive |
| PR-δ-1/2 와 공존 | 같은 컴포넌트의 다른 useEffect, 별도 deps array — 상호 독립 |

## Rebase note

PR-δ-2 (#13384) 가 PR 작성 도중 머지되었으므로 `origin/main` 에 rebase. 같은 파일 (`ide-conversation-rail-mock.ts`) 의 anchored-thread useEffect 직후 anchor 가 겹쳤으므로 manual conflict 해결 — 두 import + 두 useEffect 를 모두 보존, PR-δ-2 의 cascade-hop 직후에 PR-δ-3 의 decision-log useEffect 배치. fresh `origin/main` 위에서 통과 검증 완료.

## Test results

```
Test Files  35 passed (35)
     Tests  236 passed (236)  -- src/components/ide broader sweep
```

PR-δ-2 머지 후 baseline (223/223 across 34) 와 비교 → +13 tests (10 new + 3 main updates), +1 file.

| 파일 | total | new (PR-δ-3) |
|------|------|------|
| `decision-log-trace-bridge.test.ts` (신규) | 10 | 10 (first-emit / dedup / set-return / empty / null-ts skip / NaN-ts skip / **empty keeper_name skip** / field mapping / **null semanticOutcome preserved** / idempotent) |
| `anchored-thread-trace-bridge.test.ts` (PR-δ-1) | 7 | 회귀 0 |
| `cascade-hop-trace-bridge.test.ts` (PR-δ-2) | 8 | 회귀 0 |
| 기타 32 IDE files | 211 | 회귀 0 |

### 본 PR 의 distinctive cases

- **empty keeper_name skip**: 빈 string 이 routing bucket 을 corrupt 하므로 trace store invariant 보호
- **null semanticOutcome preserved**: in-flight decision (outcome 미정) 도 trace 에 표시되어야 — null 그대로 통과

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "decision-log-trace-bridge OR bridgeDecisionsToTrace OR 'RFC-0028 PR-δ-3'" --state open` → 본 PR 외 0
- `gh pr list --search "decision-log-trace-bridge OR bridgeDecisionsToTrace" --state merged --limit 5` → 0 — synth dedup key + new symbol, 1차 등장
- `git fetch origin && git log origin/main --since=1h --oneline` → #13375 (PR-δ-1 anc), #13384 (PR-δ-2 cas), #13385 (unrelated cmd bar). 본 PR rebased 위에 위치
- `rg "bridgeDecisionsToTrace|decision-log-trace-bridge" dashboard/src/` → 본 PR 신규 caller 만 (test + ide-conversation-rail-mock)

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/components/ide/` → **236/236 pass** across 35 files
- ESLint 본 PR 변경 파일 → **0 error / 0 warning**

## Rollback plan

3-file revert. Bridge 모듈은 ide-conversation-rail-mock 외 caller 0. revert 시 useEffect + import drop. store / overlay / PR-δ-1 anchored-thread / PR-δ-2 cascade-hop 모두 unchanged.

## RFC waiver

agent_delegation 영역 변경 없음. behavior-additive (UI 변경 0, store 의 add-only 작업).

`RFC-WAIVED: behavior-additive bridge over existing additive store. Bridge is a pure mapper; wire-in only adds a useEffect that pushes events. No UI changes. RFC-0028 PR-α (#13311) and PR-β (#13336) already merged; PR-δ-1 (#13375 anchored-thread) and PR-δ-2 (#13384 cascade-hop) already merged.`

## Related

- #13311 (RFC-0028 PR-α store) — base, 본 PR 가 `pushTrace` consume
- #13336 (RFC-0028 PR-β overlay) — sibling, 본 PR 의 events 가 표시될 곳
- #13375 (RFC-0028 PR-δ-1 anchored-thread) — sibling producer, 같은 컴포넌트
- #13384 (RFC-0028 PR-δ-2 cascade-hop) — sibling producer, 본 PR rebased on top
- #13293 (RFC-0028 spec Draft) — §5 decision-log bucket
- #13236 (audit replay timeline) — 같은 컴포넌트의 sibling decision rendering

## Follow-up

- **PR-δ-4 bdi-snapshot** producer: RFC-0024 BDI inspector polling 결과 wire (마지막 producer)
- **PR-wire-in**: `<OverlayKeeperTrace active={...}>` IDE shell 마운트 — 3 producers wired, user-visible chip 시점 도래
- RFC-0028 spec (#13289) 머지 후 amend PR (PR-δ family 결정 인용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
