### PR TITLE
fix(board): batch reaction summary embedding

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -862,35 +862,40 @@ let ensure_reaction_target_unlocked store ~target_type ~target_id =
            if Hashtbl.mem store.comments (Comment_id.to_string cid) then Ok ()
            else Error (Comment_not_found target_id))
 
-let reaction_summaries_unlocked store ~target_type ~target_id ?user_id () =
-  let counts = Hashtbl.create 8 in
-  let reacted = Hashtbl.create 8 in
-  let recent_users = Hashtbl.create 8 in
-  Hashtbl.iter
-    (fun _ (reaction : reaction) ->
-       if (=) reaction.target_type target_type
-          && String.equal reaction.target_id target_id
-       then begin
-         let reaction_user_id = Agent_id.to_string reaction.user_id in
-         let current =
-           Hashtbl.find_opt counts reaction.emoji |> Option.value ~default:0
-         in
-         Hashtbl.replace counts reaction.emoji (current + 1);
-         let users =
-           Hashtbl.find_opt recent_users reaction.emoji
-           |> Option.value ~default:[]
-         in
-         Hashtbl.replace recent_users reaction.emoji
-           ((reaction_user_id, reaction.created_at) :: users);
-         match user_id with
-         | Some user when String.equal reaction_user_id user ->
-             Hashtbl.replace reacted reaction.emoji true
-         | Some _ | None -> ()
-       end)
-    store.reactions;
+type reaction_summary_bucket = {
+  counts : (string, int) Hashtbl.t;
+  reacted : (string, bool) Hashtbl.t;
+  recent_users : (string, (string * float) list) Hashtbl.t;
+}
+
+let create_reaction_summary_bucket () =
+  {
+    counts = Hashtbl.create 8;
+    reacted = Hashtbl.create 8;
+    recent_users = Hashtbl.create 8;
+  }
+
+let add_reaction_to_summary_bucket bucket ?user_id (reaction : reaction) =
+  let reaction_user_id = Agent_id.to_string reaction.user_id in
+  let current =
+    Hashtbl.find_opt bucket.counts reaction.emoji |> Option.value ~default:0
+  in
+  Hashtbl.replace bucket.counts reaction.emoji (current + 1);
+  let users =
+    Hashtbl.find_opt bucket.recent_users reaction.emoji
+    |> Option.value ~default:[]
+  in
+  Hashtbl.replace bucket.recent_users reaction.emoji
+    ((reaction_user_id, reaction.created_at) :: users);
+  match user_id with
+  | Some user when String.equal reaction_user_id user ->
+      Hashtbl.replace bucket.reacted reaction.emoji true
+  | Some _ | None -> ()
+
+let reaction_summaries_of_bucket bucket =
   List.filter_map
     (fun emoji ->
-       let count = Hashtbl.find_opt counts emoji |> Option.value ~default:0 in
+       let count = Hashtbl.find_opt bucket.counts emoji |> Option.value ~default:0 in
        if count = 0 then None
        else
          Some
@@ -898,9 +903,9 @@ let reaction_summaries_unlocked store ~target_type ~target_id ?user_id () =
              emoji;
              count;
              reacted =
-               Hashtbl.find_opt reacted emoji |> Option.value ~default:false;
+               Hashtbl.find_opt bucket.reacted emoji |> Option.value ~default:false;
              recent_user_ids =
-               Hashtbl.find_opt recent_users emoji
+               Hashtbl.find_opt bucket.recent_users emoji
                |> Option.value ~default:[]
                |> List.sort (fun (_, a_ts) (_, b_ts) ->
                       Stdlib.Float.compare b_ts a_ts)
@@ -909,14 +914,46 @@ let reaction_summaries_unlocked store ~target_type ~target_id ?user_id () =
            })
     board_reaction_emojis
 
+let reaction_summaries_unlocked store ~target_type ~target_id ?user_id () =
+  let bucket = create_reaction_summary_bucket () in
+  Hashtbl.iter
+    (fun _ (reaction : reaction) ->
+       if (=) reaction.target_type target_type
+          && String.equal reaction.target_id target_id
+       then add_reaction_to_summary_bucket bucket ?user_id reaction)
+    store.reactions;
+  reaction_summaries_of_bucket bucket
+
+let reaction_summaries_batch_unlocked store ~targets ?user_id () =
+  let target_buckets = Hashtbl.create (List.length targets) in
+  List.iter
+    (fun target ->
+       Hashtbl.replace target_buckets target
+         (create_reaction_summary_bucket ()))
+    targets;
+  Hashtbl.iter
+    (fun _ (reaction : reaction) ->
+       match
+         Hashtbl.find_opt target_buckets
+           (reaction.target_type, reaction.target_id)
+       with
+       | None -> ()
+       | Some bucket ->
+           add_reaction_to_summary_bucket bucket ?user_id reaction)
+    store.reactions;
+  Hashtbl.fold
+    (fun target bucket acc ->
+       (target, reaction_summaries_of_bucket bucket) :: acc)
+    target_buckets []
+
+let normalize_reaction_user_id = function
+  | Some user when not (String.equal (String.trim user) "") ->
+      Some (String.trim user)
+  | Some _ | None -> None
+
 let list_reactions store ~target_type ~target_id ?user_id () =
   maybe_sweep store;
-  let user_id =
-    match user_id with
-    | Some user when not (String.equal (String.trim user) "") ->
-        Some (String.trim user)
-    | Some _ | None -> None
-  in
+  let user_id = normalize_reaction_user_id user_id in
   with_lock store (fun () ->
       match ensure_reaction_target_unlocked store ~target_type ~target_id with
       | Error e -> Error e
@@ -924,6 +961,12 @@ let list_reactions store ~target_type ~target_id ?user_id () =
           Ok
             (reaction_summaries_unlocked store ~target_type ~target_id ?user_id
                ()))
+
+let list_reactions_batch store ~targets ?user_id () =
+  maybe_sweep store;
+  let user_id = normalize_reaction_user_id user_id in
+  with_lock store (fun () ->
+      reaction_summaries_batch_unlocked store ~targets ?user_id ())
 
 let toggle_reaction store ~target_type ~target_id ~user_id ~emoji :
     (reaction_toggle_result, board_error) Result.t =

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -301,6 +301,16 @@ val list_reactions :
   unit ->
   (reaction_summary list, board_error) Result.t
 
+val list_reactions_batch :
+  store ->
+  targets:(reaction_target_type * string) list ->
+  ?user_id:string ->
+  unit ->
+  ((reaction_target_type * string) * reaction_summary list) list
+(** Returns reaction summaries for all requested [targets] after one
+    scan of the reaction table. Intended for callers that already hold
+    valid post/comment ids from the board store. *)
+
 val toggle_reaction :
   store ->
   target_type:reaction_target_type ->

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -551,6 +551,10 @@ let list_reactions ~target_type ~target_id ?user_id () =
   match backend () with
   | Jsonl store -> Board.list_reactions store ~target_type ~target_id ?user_id ()
 
+let list_reactions_batch ~targets ?user_id () =
+  match backend () with
+  | Jsonl store -> Board.list_reactions_batch store ~targets ?user_id ()
+
 let stats () =
   match backend () with
   | Jsonl store -> Board.stats store

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -233,6 +233,12 @@ val list_reactions :
   unit ->
   (Board.reaction_summary list, Board.board_error) Result.t
 
+val list_reactions_batch :
+  targets:(Board.reaction_target_type * string) list ->
+  ?user_id:string ->
+  unit ->
+  ((Board.reaction_target_type * string) * Board.reaction_summary list) list
+
 (** {1 Karma} *)
 
 val karma_score_for_direction : Board.vote_direction -> int

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -45,11 +45,21 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
         Option.value ~default:0 (List.assoc_opt author karma_map)
       in
       let paged = posts |> drop offset |> take limit in
+      let reaction_rows =
+        board_reactions_batch
+          ~targets:
+            (List.map
+               (fun (p : Board.post) ->
+                  (Board.Reaction_post, Board.Post_id.to_string p.id))
+               paged)
+          ~voter
+      in
+      let reactions_for = board_reactions_lookup reaction_rows in
       let posts_json = List.map (fun (p : Board.post) ->
         let author = Board.Agent_id.to_string p.author in
         let post_id = Board.Post_id.to_string p.id in
         let current_vote = board_current_vote_for_post ~voter ~post_id in
-        let reactions = board_reactions_for_post ~voter ~post_id in
+        let reactions = reactions_for (Board.Reaction_post, post_id) in
         board_post_dashboard_json ?current_vote ~reactions
           ~author_karma:(get_karma author) p
       ) paged in

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -65,9 +65,9 @@ val dispatch :
     {2 Failure modes}
 
     - Path-traversal attempts on the dashboard assets route return
-      [404 Not Found] (NOT [400 Bad Request] — the spec is to not
+      [404 Not Found] (NOT [400 Bad Request]).  The spec does not
       reveal whether the path traversal was rejected vs the
-      filename was missing).  Pinned at the contract seam.
+      filename was missing.  Pinned at the contract seam.
     - Missing static asset files return [404 Not Found] with the
       literal body [404 Not Found] (operator runbooks grep on this
       exact string).

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -223,13 +223,23 @@ let add_routes ~sw ~clock router =
            List.assoc_opt author karma_map |> Option.value ~default:0
          in
          let paged = posts |> drop offset |> take limit in
+         let reaction_rows =
+           board_reactions_batch
+             ~targets:
+               (List.map
+                  (fun (p : Board.post) ->
+                     (Board.Reaction_post, Board.Post_id.to_string p.id))
+                  paged)
+             ~voter
+         in
+         let reactions_for = board_reactions_lookup reaction_rows in
          let posts_json =
            List.map
              (fun (p : Board.post) ->
                let author = Board.Agent_id.to_string p.author in
                let post_id = Board.Post_id.to_string p.id in
                let current_vote = board_current_vote_for_post ~voter ~post_id in
-               let reactions = board_reactions_for_post ~voter ~post_id in
+               let reactions = reactions_for (Board.Reaction_post, post_id) in
                board_post_dashboard_json ?current_vote
                  ~reactions
                  ~author_karma:(get_karma author) p)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -294,13 +294,22 @@ let board_post_detail_json ~voter ~response_format ~post_id =
             []
       in
       let current_vote = board_current_vote_for_post ~voter ~post_id in
-      let reactions = board_reactions_for_post ~voter ~post_id in
+      let reaction_targets =
+        (Board.Reaction_post, post_id)
+        :: List.map
+             (fun (comment : Board.comment) ->
+                (Board.Reaction_comment, Board.Comment_id.to_string comment.id))
+             comments
+      in
+      let reaction_rows = board_reactions_batch ~targets:reaction_targets ~voter in
+      let reactions_for = board_reactions_lookup reaction_rows in
+      let reactions = reactions_for (Board.Reaction_post, post_id) in
       let post_json = board_post_dashboard_json ?current_vote ~reactions ~author_karma post in
       let comments_json =
         `List (List.map (fun (comment : Board.comment) ->
           let comment_id = Board.Comment_id.to_string comment.id in
           let current_vote = board_current_vote_for_comment ~voter ~comment_id in
-          let reactions = board_reactions_for_comment ~voter ~comment_id in
+          let reactions = reactions_for (Board.Reaction_comment, comment_id) in
           board_comment_dashboard_json ?current_vote ~reactions comment
         ) comments)
       in

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -171,6 +171,18 @@ let board_reactions_for_comment ~voter ~comment_id =
         comment_id (Board_types.show_board_error err);
       []
 
+let board_reactions_batch ~targets ~voter =
+  match targets with
+  | [] -> []
+  | _ -> Board_dispatch.list_reactions_batch ~targets ?user_id:voter ()
+
+let board_reactions_lookup rows =
+  let table = Hashtbl.create (List.length rows) in
+  List.iter
+    (fun (target, summaries) -> Hashtbl.replace table target summaries)
+    rows;
+  fun target -> Hashtbl.find_opt table target |> Option.value ~default:[]
+
 let board_reaction_fields = function
   | None -> []
   | Some summaries ->

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -159,6 +159,18 @@ val board_reactions_for_post :
 val board_reactions_for_comment :
   voter:string option -> comment_id:string -> Board.reaction_summary list
 
+val board_reactions_batch :
+  targets:(Board.reaction_target_type * string) list ->
+  voter:string option ->
+  ((Board.reaction_target_type * string) * Board.reaction_summary list) list
+(** [board_reactions_batch ~targets ~voter] returns dashboard reaction
+    summaries for a request's target set using one board-store scan. *)
+
+val board_reactions_lookup :
+  ((Board.reaction_target_type * string) * Board.reaction_summary list) list ->
+  Board.reaction_target_type * string ->
+  Board.reaction_summary list
+
 (** {1 Dashboard helpers} *)
 
 val board_comment_dashboard_json :

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -688,6 +688,60 @@ let test_reaction_summary_recent_user_ids () =
                 [ "reactor-a"; "reactor-b"; "reactor-c" ]
           | [] -> Alcotest.fail "expected reaction summary"
 
+let test_reaction_summary_batch () =
+  match
+    Board_dispatch.create_post ~author:"reaction-author"
+      ~content:"batch reactors parent" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let post_id = Board.Post_id.to_string post.id in
+      let comment_id =
+        match
+          Board_dispatch.add_comment ~post_id ~author:"commenter"
+            ~content:"batch reaction child" ()
+        with
+        | Error e -> Alcotest.fail (Board.show_board_error e)
+        | Ok comment -> Board.Comment_id.to_string comment.id
+      in
+      List.iter
+        (fun (target_type, target_id, user_id, emoji) ->
+           match
+             Board_dispatch.toggle_reaction ~target_type ~target_id ~user_id
+               ~emoji
+           with
+           | Ok _ -> ()
+           | Error e -> Alcotest.fail (Board.show_board_error e))
+        [
+          (Board.Reaction_post, post_id, "reactor-a", "👍");
+          (Board.Reaction_post, post_id, "reactor-b", "👍");
+          (Board.Reaction_comment, comment_id, "reactor-b", "👏");
+        ];
+      let rows =
+        Board_dispatch.list_reactions_batch
+          ~targets:
+            [
+              (Board.Reaction_post, post_id);
+              (Board.Reaction_comment, comment_id);
+            ]
+          ~user_id:"reactor-b" ()
+      in
+      let summaries_for target =
+        List.assoc_opt target rows |> Option.value ~default:[]
+      in
+      (match summaries_for (Board.Reaction_post, post_id) with
+       | summary :: _ ->
+           Alcotest.(check string) "post emoji" "👍" summary.emoji;
+           Alcotest.(check int) "post count" 2 summary.count;
+           Alcotest.(check bool) "post reacted" true summary.reacted
+       | [] -> Alcotest.fail "expected post reaction summary");
+      (match summaries_for (Board.Reaction_comment, comment_id) with
+       | summary :: _ ->
+           Alcotest.(check string) "comment emoji" "👏" summary.emoji;
+           Alcotest.(check int) "comment count" 1 summary.count;
+           Alcotest.(check bool) "comment reacted" true summary.reacted
+       | [] -> Alcotest.fail "expected comment reaction summary")
+
 let test_board_sse_reaction_changed () =
   let post_id =
     match
@@ -937,6 +991,8 @@ let () =
         (with_eio test_comment_reaction_survives_restart);
       Alcotest.test_case "summary recent user ids" `Quick
         (with_eio test_reaction_summary_recent_user_ids);
+      Alcotest.test_case "summary batch" `Quick
+        (with_eio test_reaction_summary_batch);
       Alcotest.test_case "SSE reaction_changed" `Quick
         (with_eio test_board_sse_reaction_changed);
       Alcotest.test_case "unsupported emoji rejected" `Quick


### PR DESCRIPTION
## Summary
- add a single-pass board reaction summary batch API
- use batched reaction lookup for board list and post-detail embedding paths
- keep H2 route docs compatible with ocamldoc while preserving the new sub-board route notes from main

## Verification
- git diff --check origin/main..HEAD
- env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build bin/main_eio.exe test/test_board_dispatch.exe
- ./_build/default/test/test_board_dispatch.exe (46 tests)

## Latest head
- 66f86210cb after rebase onto current origin/main