### PR TITLE
fix(resilience): classify hard quota as resource exhaustion

### DIFF
--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -256,23 +256,31 @@ let transient_phrases =
 
 let resource_phrases =
   [ ("token", `Tokens);
+    ("context overflow", `Tokens);
+    ("context window", `Tokens);
+    ("context length", `Tokens);
     ("memory", `Memory);
     ("disk", `Disk);
+    ("quota", `Cost);
+    ("credit", `Cost);
+    ("resource exhausted", `Cost);
     ("budget", `Cost);
+    ("cost", `Cost);
   ]
 
 let classify_string (s : string) : error_mode =
-  if List.exists (fun p -> lowercased_contains s p) transient_phrases then
-    transient ~detail:s ~max_retries:3 ~backoff_ms:250 ()
-  else
-    match
-      List.find_opt
-        (fun (p, _) -> lowercased_contains s p)
-        resource_phrases
-    with
-    | Some (_, resource) ->
-        resource_exhausted_unknown ~resource ~detail:s
-    | None -> permanent ~detail:s ~fallback:(HumanHandoff s)
+  match
+    List.find_opt
+      (fun (p, _) -> lowercased_contains s p)
+      resource_phrases
+  with
+  | Some (_, resource) ->
+      resource_exhausted_unknown ~resource ~detail:s
+  | None ->
+      if List.exists (fun p -> lowercased_contains s p) transient_phrases then
+        transient ~detail:s ~max_retries:3 ~backoff_ms:250 ()
+      else
+        permanent ~detail:s ~fallback:(HumanHandoff s)
 
 (* ── Default strategy selection ───────────────────────────────── *)
 

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -141,11 +141,11 @@ val all_strategy_tla_symbols : string list
 
 val classify_string : string -> error_mode
 (** Best-effort classification of a free-form exception or error
-    string. Returns [TransientError] for known retryable phrases
-    (timeout, rate limit, connection reset, temporary),
-    [ResourceExhausted] with unknown measurement for resource phrases, and
-    [PermanentError { fallback_strategy = HumanHandoff _ }]
-    otherwise. *)
+    string. Returns [ResourceExhausted] with unknown measurement for
+    resource phrases, including hard-quota/resource wording that may also
+    mention rate limits. Otherwise returns [TransientError] for known
+    retryable phrases (timeout, rate limit, connection reset, temporary),
+    and [PermanentError { fallback_strategy = HumanHandoff _ }] otherwise. *)
 
 (** {1 Default strategy selection} *)
 

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -198,13 +198,13 @@ let test_pipeline_classifies_permanent_handoff () =
 let test_pipeline_classifies_resource_token () =
   let outcome =
     KB.apply_post_turn_resilience witness ~now:4.0 ~working_context:None
-      ~maybe_error:(Some "token budget exhausted") ()
+      ~maybe_error:(Some "429 rate limit: token budget exhausted") ()
   in
   match outcome.resilience_meta with
   | Some (`Assoc kv) ->
       let kind = List.assoc "classified_kind" kv in
-      (* "token" matches resource phrase, "budget" might also; first
-         resource phrase wins per Recovery.classify_string ordering. *)
+      (* Resource exhaustion must win over generic transient/rate-limit
+         wording so hard quota failures do not enter the retry strategy. *)
       assert (kind = `String "ResourceExhausted");
       let strat = List.assoc "default_strategy_class" kv in
       assert (strat = `String "Abort")

--- a/test/resilience/test_recovery.ml
+++ b/test/resilience/test_recovery.ml
@@ -104,6 +104,23 @@ let test_classify_resource_token () =
       assert (detail = Some "token budget exhausted")
   | _ -> assert false
 
+let test_classify_resource_wins_over_transient_rate_limit () =
+  match R.classify_string "429 rate limit: token budget exhausted" with
+  | R.ResourceExhausted { resource; consumed; limit; detail } ->
+      assert (resource = `Tokens);
+      assert (consumed = None);
+      assert (limit = None);
+      assert (detail = Some "429 rate limit: token budget exhausted")
+  | _ -> assert false
+
+let test_classify_hard_quota_resource_exhausted () =
+  match R.classify_string "rate limit: resource exhausted, top up credits" with
+  | R.ResourceExhausted { resource; consumed; limit; _ } ->
+      assert (resource = `Cost);
+      assert (consumed = None);
+      assert (limit = None)
+  | _ -> assert false
+
 let test_classify_permanent_fallback () =
   match R.classify_string "Some generic error" with
   | R.PermanentError { fallback_strategy = R.HumanHandoff _; _ } -> ()
@@ -332,6 +349,8 @@ let () =
   test_classify_transient_timeout ();
   test_classify_transient_rate_limit ();
   test_classify_resource_token ();
+  test_classify_resource_wins_over_transient_rate_limit ();
+  test_classify_hard_quota_resource_exhausted ();
   test_classify_permanent_fallback ();
   test_strategy_for_transient_is_retry ();
   test_strategy_for_permanent_default_string ();


### PR DESCRIPTION
## Summary

Makes the resilience free-form error classifier fail closed for resource exhaustion signals before generic retryable wording. Messages such as `429 rate limit: token budget exhausted` now classify as `ResourceExhausted` and use the abort strategy instead of entering the retry path.

## Why

The post-turn resilience wire-in still receives stringified errors at this seam. The old classifier checked transient phrases first, so hard-quota messages that also contained `rate limit` were treated as retryable. That risks retrying failures that require quota/capacity recovery out of band.

## Changes

- Prioritize resource-exhaustion phrases before transient phrases in `Recovery.classify_string`.
- Add hard-quota/resource wording for quota, credit, resource exhausted, context overflow/window/length, and cost.
- Update the public classifier documentation.
- Add regression coverage for both the pure recovery classifier and the keeper bridge metadata path.

## Validation

- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `ocamlc -stop-after parsing lib/resilience/recovery.ml`
- `ocamlc -stop-after parsing lib/resilience/recovery.mli`
- `ocamlc -stop-after parsing test/resilience/test_recovery.ml`
- `ocamlc -stop-after parsing test/resilience/test_keeper_bridge.ml`

Attempted focused Dune verification with `scripts/dune-local.sh build test/resilience/test_recovery.exe test/resilience/test_keeper_bridge.exe`, but it remained queued behind the shared `/tmp/me-dune-local.lock` for several minutes. I stopped only my queued waiter and did not bypass the host throttle.