### PR TITLE
feat(ide): RFC-0028 PR-δ-4 — bdi-snapshot → keeper-trace bridge (final producer wire-in)

### DIFF
--- a/dashboard/src/components/ide/bdi-snapshot-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/bdi-snapshot-trace-bridge.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  bridgeBdiSnapshotsToTrace,
+  type BdiSnapshotProducerInput,
+} from './bdi-snapshot-trace-bridge'
+import {
+  clearTraces,
+  keeperTraceState,
+} from './keeper-trace-store'
+
+function snap(
+  keeper: string,
+  generated_at: string | null,
+  intention: string | null = 'analyze diff',
+): BdiSnapshotProducerInput {
+  return { keeper, generated_at, intention }
+}
+
+beforeEach(() => {
+  clearTraces()
+})
+
+afterEach(() => {
+  clearTraces()
+})
+
+describe('bridgeBdiSnapshotsToTrace — RFC-0028 PR-δ bdi-snapshot producer', () => {
+  it('emits a trace event for every snapshot on the first call', () => {
+    const out = bridgeBdiSnapshotsToTrace(
+      [
+        snap('scholar', '2026-05-06T01:00:00Z'),
+        snap('moth', '2026-05-06T01:00:01Z'),
+      ],
+      new Set(),
+    )
+
+    expect(out.size).toBe(2)
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(2)
+    expect(events.every(e => e.source === 'bdi-snapshot')).toBe(true)
+  })
+
+  it('does not re-emit snapshots with the same dedup key (polling replay)', () => {
+    let known: ReadonlySet<string> = new Set()
+    // First poll: snapshot A
+    known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)
+    // Second poll: server has not yet published a fresh tick (same generated_at)
+    known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)
+    // Third poll: same again
+    known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)
+
+    expect(keeperTraceState.value.events.length).toBe(1)
+  })
+
+  it('emits a fresh trace event when generated_at advances', () => {
+    let known: ReadonlySet<string> = new Set()
+    known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)
+    known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:05Z')], known)
+    known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:10Z')], known)
+
+    expect(keeperTraceState.value.events.length).toBe(3)
+  })
+
+  it('returns the input set unchanged when snapshots is empty', () => {
+    const before = new Set(['bdi:scholar:2026-05-06T01:00:00Z'])
+    const after = bridgeBdiSnapshotsToTrace([], before)
+    expect(after).toBe(before)
+    expect(keeperTraceState.value.events.length).toBe(0)
+  })
+
+  it('skips snapshots with null generated_at', () => {
+    bridgeBdiSnapshotsToTrace(
+      [
+        snap('scholar', null),
+        snap('moth', '2026-05-06T01:00:00Z'),
+      ],
+      new Set(),
+    )
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(1)
+    expect(events[0]!.keeperName).toBe('moth')
+  })
+
+  it('skips snapshots with malformed generated_at (NaN-guard)', () => {
+    bridgeBdiSnapshotsToTrace(
+      [
+        snap('scholar', 'not-a-date'),
+        snap('moth', '2026-05-06T01:00:00Z'),
+      ],
+      new Set(),
+    )
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(1)
+    expect(events[0]!.keeperName).toBe('moth')
+  })
+
+  it('skips snapshots with empty keeper', () => {
+    bridgeBdiSnapshotsToTrace(
+      [
+        snap('', '2026-05-06T01:00:00Z'),
+        snap('moth', '2026-05-06T01:00:01Z'),
+      ],
+      new Set(),
+    )
+    const events = keeperTraceState.value.events
+    expect(events.length).toBe(1)
+    expect(events[0]!.keeperName).toBe('moth')
+  })
+
+  it('maps fields correctly: id, tsMs, keeperName, source, intention', () => {
+    bridgeBdiSnapshotsToTrace(
+      [snap('scholar', '2026-05-06T01:00:00Z', 'verify cascade route')],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    expect(event.id).toBe('bdi:scholar:2026-05-06T01:00:00Z')
+    expect(event.tsMs).toBe(Date.parse('2026-05-06T01:00:00Z'))
+    expect(event.keeperName).toBe('scholar')
+    expect(event.source).toBe('bdi-snapshot')
+    if (event.source === 'bdi-snapshot') {
+      expect(event.intention).toBe('verify cascade route')
+    }
+  })
+
+  it('preserves a null intention (keeper between intentions)', () => {
+    bridgeBdiSnapshotsToTrace(
+      [snap('scholar', '2026-05-06T01:00:00Z', null)],
+      new Set(),
+    )
+    const event = keeperTraceState.value.events[0]!
+    if (event.source === 'bdi-snapshot') {
+      expect(event.intention).toBeNull()
+    }
+  })
+
+  it('returns an updated set including all newly emitted dedup keys', () => {
+    const out = bridgeBdiSnapshotsToTrace(
+      [snap('scholar', '2026-05-06T01:00:00Z')],
+      new Set(['bdi:other:2026-05-06T00:59:00Z']),
+    )
+    expect([...out].sort()).toEqual([
+      'bdi:other:2026-05-06T00:59:00Z',
+      'bdi:scholar:2026-05-06T01:00:00Z',
+    ])
+  })
+})

--- a/dashboard/src/components/ide/bdi-snapshot-trace-bridge.ts
+++ b/dashboard/src/components/ide/bdi-snapshot-trace-bridge.ts
@@ -1,0 +1,90 @@
+import { pushTrace } from './keeper-trace-store'
+
+/**
+ * RFC-0028 PR-δ producer: bdi-snapshot → keeper-trace bridge.
+ *
+ * Pure mapper — given a snapshot of KeeperBdiSnapshot values
+ * (from `/api/v1/keepers/${keeper}/bdi-snapshot`, polled by
+ * `InspectorKeeperBDI`) and a set of dedup keys that have already been
+ * emitted, push trace events for the new ones and return the updated
+ * set.
+ *
+ * Dedup-key shape: `bdi:${keeper}:${generated_at}`.
+ *
+ *   - The polling endpoint replays the same `generated_at` until the
+ *     server publishes a fresh BDI tick. The dedup key naturally
+ *     collapses these duplicates and only emits a trace event when
+ *     `generated_at` advances.
+ *   - The key never appears outside this module. The only consumer is
+ *     `alreadyEmitted: ReadonlySet<string>` owned by the calling
+ *     component — same lifecycle pattern as PR-δ-1 / PR-δ-2 / PR-δ-3.
+ *
+ * Mapping (KeeperBdiSnapshot → KeeperTraceEvent[bdi-snapshot]):
+ *   id         ← `bdi:${keeper}:${generated_at}`
+ *   tsMs       ← Date.parse(generated_at)  (NaN-guarded)
+ *   keeperName ← snapshot.keeper
+ *   source     ← 'bdi-snapshot'
+ *   intention  ← snapshot.intention  (string | null; the BDI inspector
+ *                renders "—" for null today, and consumers of the trace
+ *                store can do the same.)
+ *
+ * Why a pure function (not a stateful subscription):
+ *   - The owning component (`InspectorKeeperBDI`) already holds
+ *     `snapshot` as a useState value. A pure mapper called from a
+ *     `useEffect([snapshot])` is sufficient and trivially testable.
+ *   - Avoids storing per-component state inside the trace store, which
+ *     would couple the store to producer lifecycle.
+ *   - Module-level mutable state would leak across components and break
+ *     the deduplication guarantee on remount.
+ *
+ * Skip rules for missing fields:
+ *   - generated_at === null OR malformed ISO → skip (no usable tsMs).
+ *   - keeper === '' → skip (the trace store's keeperName field is used
+ *     as a routing bucket; an empty string would coalesce unrelated
+ *     rows).
+ *
+ * The bridge accepts an array even though `InspectorKeeperBDI` only
+ * holds a single snapshot at a time — this keeps the call shape
+ * consistent with the other PR-δ producers and makes it trivial to
+ * batch from a multi-keeper polling source later.
+ */
+
+export interface BdiSnapshotProducerInput {
+  readonly keeper: string
+  readonly generated_at: string | null
+  readonly intention: string | null
+}
+
+function dedupKey(snapshot: BdiSnapshotProducerInput): string {
+  return `bdi:${snapshot.keeper}:${snapshot.generated_at ?? ''}`
+}
+
+/**
+ * Push trace events for every snapshot not already in `alreadyEmitted`
+ * and return the updated set. The caller (typically a component effect)
+ * owns the set and re-passes it on each call.
+ */
+export function bridgeBdiSnapshotsToTrace(
+  snapshots: ReadonlyArray<BdiSnapshotProducerInput>,
+  alreadyEmitted: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (snapshots.length === 0) return alreadyEmitted
+  const next = new Set(alreadyEmitted)
+  for (const snapshot of snapshots) {
+    if (snapshot.keeper === '') continue
+    if (snapshot.generated_at === null) continue
+    const key = dedupKey(snapshot)
+    if (next.has(key)) continue
+    const tsMs = Date.parse(snapshot.generated_at)
+    if (!Number.isFinite(tsMs)) continue
+    pushTrace({
+      id: key,
+      tsMs,
+      keeperName: snapshot.keeper,
+      source: 'bdi-snapshot',
+      intention: snapshot.intention,
+    })
+    next.add(key)
+  }
+  return next
+}

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -1,7 +1,8 @@
 import { computed } from '@preact/signals'
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { activeKeeperName } from '../../keeper-state'
+import { bridgeBdiSnapshotsToTrace } from './bdi-snapshot-trace-bridge'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
 import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
 
@@ -202,6 +203,17 @@ export function InspectorKeeperBDI({ pollMs = 5000 }: { readonly pollMs?: number
       if (timer !== null) window.clearInterval(timer)
     }
   }, [keeperName, pollMs])
+
+  // RFC-0028 PR-δ-4 bdi-snapshot producer: each fresh poll result becomes
+  // a keeper-trace event. Dedup key is `bdi:${keeper}:${generated_at}` so
+  // a polling tick that returns the same snapshot does not re-emit; a
+  // server publish of a fresh BDI tick advances `generated_at` and emits
+  // a new event.
+  const knownBdiKeys = useRef<ReadonlySet<string>>(new Set())
+  useEffect(() => {
+    if (snapshot === null) return
+    knownBdiKeys.current = bridgeBdiSnapshotsToTrace([snapshot], knownBdiKeys.current)
+  }, [snapshot])
 
   const tokenRows = snapshot?.recent_token_spend ?? []
   const lastTool = snapshot?.last_tool_call ?? null


### PR DESCRIPTION
## 목적

RFC-0028 PR-δ (4 producer wire-in) 의 마지막 sub-PR. bdi-snapshot producer 를 keeper-trace-store (#13311 PR-α) 로 wire. PR-δ-1/2/3 와 다르게 `IdeConversationRailMock` 가 아닌 `InspectorKeeperBDI` 컴포넌트에 wire-in (RFC-0024 BDI inspector 가 자체 polling).

이로써 RFC-0028 의 4 producer 모두 main 에 도달 — keeper-trace-store 가 4 layer surface 에서 stitched read-side projection 을 받기 시작.

## Scope (4 producer 분할 — 본 PR 로 family complete)

| Sub-PR | Producer | Source | Component | 본 PR? |
|--------|----------|--------|-----------|--------|
| PR-δ-1 (#13375 MERGED) | anchored-thread | BoardPost | IdeConversationRailMock | — |
| PR-δ-2 (#13384 MERGED) | cascade-hop | CascadeStrategyTraceEvent | IdeConversationRailMock | — |
| PR-δ-3 (#13396 MERGED) | decision-log | KeeperDecision | IdeConversationRailMock | — |
| **PR-δ-4 (본 PR)** | **bdi-snapshot** | **KeeperBdiSnapshot** | **InspectorKeeperBDI** | ✅ |

## Diff stat

- 3 files / +249 / -1
- 신규: `bdi-snapshot-trace-bridge.ts` (90), `bdi-snapshot-trace-bridge.test.ts` (146, 10 cases)
- 수정: `inspector-keeper-bdi.ts` (+13/-1, useRef import + ref + useEffect)

## Public API

### `bdi-snapshot-trace-bridge.ts` (신규)

```ts
export interface BdiSnapshotProducerInput {
  readonly keeper: string
  readonly generated_at: string | null
  readonly intention: string | null
}

export function bridgeBdiSnapshotsToTrace(
  snapshots: ReadonlyArray<BdiSnapshotProducerInput>,
  alreadyEmitted: ReadonlySet<string>,
): ReadonlySet<string>
```

Pure mapper — 새 KeeperBdiSnapshot 만 `pushTrace` 호출, 갱신된 dedup-key set 반환.

배열을 받지만 InspectorKeeperBDI 는 한 번에 1 snapshot 만 hold — 나머지 PR-δ producer 와 call-shape 일관성을 위해, 그리고 multi-keeper polling source 도입 시 batch 가능하도록 array 시그니처 유지.

## 설계 결정

### Polling-replay dedup (PR-δ-4 distinctive feature)

InspectorKeeperBDI 의 polling endpoint 는 server 에서 새 BDI tick 발행 전까지 같은 `generated_at` 반복 반환. dedup-key `bdi:${keeper}:${generated_at}` 가 자연스레 collapse → 새 snapshot (advanced generated_at) 만 trace 발화:

```ts
// 같은 snapshot 3회 polling → trace 1회만
known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)
known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)  // dedup
known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)  // dedup
expect(events.length).toBe(1)

// generated_at 진행 → 매번 발화
known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:00Z')], known)
known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:05Z')], known)
known = bridgeBdiSnapshotsToTrace([snap('scholar', '2026-05-06T01:00:10Z')], known)
expect(events.length).toBe(3)
```

테스트 두 케이스 (case 2 `does not re-emit ... polling replay`, case 3 `emits a fresh trace event when generated_at advances`) 가 명시적으로 검증.

### Field mapping (KeeperBdiSnapshot → KeeperTraceEvent)

| trace 필드 | source | 비고 |
|-----------|--------|-----|
| `id` | `bdi:${keeper}:${generated_at}` | dedup-key 와 동일 |
| `tsMs` | `Date.parse(generated_at)` | NaN-guard, malformed ISO skip |
| `keeperName` | `snapshot.keeper` | real keeper-level (cascade-hop 의 cascade_name 과 다름) |
| `source` | `'bdi-snapshot'` | discriminator |
| `intention` | `snapshot.intention` | `string \| null` (between intentions 시 null) |

KeeperBdiSnapshot 는 `belief / desire / intention / need / profile_*` 등 풍부하지만 RFC §5 가 chip 표시 field 로 `intention` 만 정의 → 본 bridge 는 1 field 만 forward (다른 field 는 InspectorKeeperBDI 가 자체 표시).

### Skip rules

| 조건 | Skip 이유 |
|------|----------|
| `generated_at === null` | 서버 BDI 업데이트 전 — 사용 가능한 tsMs 없음 |
| `Date.parse(generated_at) === NaN` | malformed ISO — binary-search insertion invariant 보호 |
| `keeper === ''` | trace store routing bucket 보호 |

## Wire-in (`InspectorKeeperBDI`)

```ts
const knownBdiKeys = useRef<ReadonlySet<string>>(new Set())
useEffect(() => {
  if (snapshot === null) return
  knownBdiKeys.current = bridgeBdiSnapshotsToTrace([snapshot], knownBdiKeys.current)
}, [snapshot])
```

| 측면 | 설명 |
|------|------|
| Ref scope | 컴포넌트 인스턴스별. remount 시 새 set 으로 시작 |
| Trigger | `snapshot` (useState) 변경 시. polling 가 `setSnapshot(next)` 호출하면 trigger |
| null guard | 첫 fetch 전 또는 abort 시 `snapshot === null` — bridge 호출 skip |
| 회귀 위험 | 0 — UI render 무변경, store 는 additive |
| PR-δ-1/2/3 와 공존 | 다른 컴포넌트 (InspectorKeeperBDI vs IdeConversationRailMock) — 상호 독립 |

`useRef` import 추가됨 (기존 `useEffect, useState` import 만 있었음).

## Rebase note

PR-δ-3 (#13396) 가 PR 작성 도중 머지되었으므로 `origin/main` 에 rebase. 본 PR 은 `InspectorKeeperBDI` 컴포넌트만 수정 — PR-δ-3 의 `IdeConversationRailMock` 변경과 orthogonal. **conflict 0**, clean rebase. (PR-δ-3 가 conflict-resolve 필요했던 것과 대비.)

## Test results

```
Test Files  36 passed (36)
     Tests  246 passed (246)  -- src/components/ide broader sweep
```

PR-δ-3 머지 후 baseline (236/236 across 35 — main + bdi 본 PR 제외) 와 비교 → +10 tests, +1 file.

| 파일 | total | new (PR-δ-4) |
|------|------|------|
| `bdi-snapshot-trace-bridge.test.ts` (신규) | 10 | 10 (first-emit / **polling replay dedup** / **generated_at advance** / empty / null-generated_at / NaN-generated_at / empty-keeper / field mapping / null-intention preserved / set-return) |
| `anchored-thread-trace-bridge.test.ts` (PR-δ-1) | 7 | 회귀 0 |
| `cascade-hop-trace-bridge.test.ts` (PR-δ-2) | 8 | 회귀 0 |
| `decision-log-trace-bridge.test.ts` (PR-δ-3) | 10 | 회귀 0 |
| 기타 32 IDE files | 211 | 회귀 0 |

### 본 PR distinctive cases

- **polling replay dedup** (case 2): 같은 snapshot 3회 호출 → 1 event
- **generated_at advance** (case 3): 다른 generated_at 3회 호출 → 3 events
- **null intention preserved**: keeper 가 between intentions 일 때 null 도 trace 에 표시 (consumer 가 "—" 등으로 render 가능)

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "bdi-snapshot-trace-bridge OR bridgeBdiSnapshotsToTrace OR 'RFC-0028 PR-δ-4'" --state open` → 본 PR 외 0
- `gh pr list --search "bdi-snapshot-trace-bridge OR bridgeBdiSnapshotsToTrace" --state merged --limit 5` → 0 — synth dedup key + new symbol, 1차 등장
- `git fetch origin && git log origin/main --since=1h --oneline` → #13375 (PR-δ-1), #13384 (PR-δ-2), #13396 (PR-δ-3 just merged), unrelated. 본 PR rebased clean
- `rg "bridgeBdiSnapshotsToTrace|bdi-snapshot-trace-bridge" dashboard/src/` → 본 PR 신규 caller 만 (test + inspector-keeper-bdi)

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/components/ide/` → **246/246 pass** across 36 files
- ESLint 본 PR 변경 파일 → **0 error / 0 warning**

## Rollback plan

3-file revert. Bridge 모듈은 inspector-keeper-bdi 외 caller 0. revert 시 useEffect + useRef import + import drop. store / overlay / PR-δ-1 anc / PR-δ-2 cas / PR-δ-3 dec 모두 unchanged.

## Why 본 PR 가 PR-δ family 의 마지막

RFC-0028 §5 가 4 source 정의 (anchored-thread / cascade-hop / decision-log / bdi-snapshot). 본 PR 으로 4 producer 모두 store 에 wire 됨 → keeper-trace-store 가 4 layer surface 에서 stitched read-side projection 받기 시작. 다음 axis 는 overlay 의 IDE shell 마운트 (`<OverlayKeeperTrace active={...}>`) — 이로써 user-visible chip 첫 등장.

## RFC waiver

agent_delegation 영역 변경 없음. behavior-additive (UI 변경 0, store 의 add-only 작업).

`RFC-WAIVED: behavior-additive bridge over existing additive store. Bridge is a pure mapper; wire-in only adds a useEffect that pushes events. No UI changes. RFC-0028 PR-α (#13311), PR-β (#13336), PR-δ-1 (#13375), PR-δ-2 (#13384), and PR-δ-3 (#13396) already merged.`

## Related

- #13311 (RFC-0028 PR-α store) — base, 본 PR 가 `pushTrace` consume
- #13336 (RFC-0028 PR-β overlay) — sibling, 본 PR 의 events 가 표시될 곳 (다음 PR 에서 IDE shell 마운트)
- #13375 (RFC-0028 PR-δ-1 anchored-thread) — sibling producer
- #13384 (RFC-0028 PR-δ-2 cascade-hop) — sibling producer
- #13396 (RFC-0028 PR-δ-3 decision-log) — sibling producer, 본 PR rebased on top
- #13293 (RFC-0028 spec Draft) — §5 bdi-snapshot bucket
- RFC-0024 (BDI inspector spec) — bdi-snapshot endpoint origin

## Follow-up

- **PR-wire-in** (다음 PR): `<OverlayKeeperTrace active={...}>` IDE shell 마운트 — 4 producers wired, user-visible chip 시점 도래
- RFC-0028 spec (#13289) 머지 후 amend PR (PR-δ family complete 인용)
- (Optional) Multi-keeper polling source for bdi-snapshot — 본 bridge 가 array 받으므로 wire-in 만 변경하면 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
