### PR TITLE
fix(keeper): clear stale task worktree bindings

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -436,8 +436,11 @@ let transition_task_r
                  then (
                    let t =
                      match action with
-                     | Masc_domain.Claim -> clear_soft_do_not_reclaim_reason t
-                     | Masc_domain.Release
+                     | Masc_domain.Claim ->
+                       t
+                       |> clear_soft_do_not_reclaim_reason
+                       |> clear_stale_worktree_binding
+                     | Masc_domain.Release -> clear_stale_worktree_binding t
                      | Masc_domain.Start
                      | Masc_domain.Done_action
                      | Masc_domain.Cancel

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -67,6 +67,12 @@ let clear_soft_do_not_reclaim_reason (task : Masc_domain.task) =
   | Some _ | None -> task
 ;;
 
+let clear_stale_worktree_binding (task : Masc_domain.task) =
+  match task.worktree with
+  | None -> task
+  | Some _ -> { task with worktree = None }
+;;
+
 (** Claim task with file locking (TOCTOU prevention) *)
 let claim_task config ~agent_name ~task_id =
   ensure_initialized config;
@@ -97,7 +103,11 @@ let claim_task config ~agent_name ~task_id =
                     match task.task_status with
                     | _ when !blocked_reason <> None -> task
                     | Todo ->
-                      let task = clear_soft_do_not_reclaim_reason task in
+                      let task =
+                        task
+                        |> clear_soft_do_not_reclaim_reason
+                        |> clear_stale_worktree_binding
+                      in
                       { task with
                         task_status =
                           Claimed { assignee = agent_name; claimed_at = now_iso () }
@@ -226,7 +236,11 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
                 then (
                   match t.task_status with
                   | Todo ->
-                    let t = clear_soft_do_not_reclaim_reason t in
+                    let t =
+                      t
+                      |> clear_soft_do_not_reclaim_reason
+                      |> clear_stale_worktree_binding
+                    in
                     let t' =
                       { t with
                         task_status =

--- a/lib/coord/coord_task_claim.mli
+++ b/lib/coord/coord_task_claim.mli
@@ -20,6 +20,10 @@ val do_not_reclaim_reason_blocks_claim : string option -> string option
 val clear_soft_do_not_reclaim_reason : Masc_domain.task -> Masc_domain.task
 (** Clears soft cycle/routing reasons before a task is claimed. *)
 
+val clear_stale_worktree_binding : Masc_domain.task -> Masc_domain.task
+(** Clears per-claim worktree metadata before a new owner claims a task or a
+    released task returns to [Todo]. *)
+
 (** {1 Task claiming} *)
 
 val claim_task :

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -596,7 +596,11 @@ let claim_next_r
           (* Claim this task *)
           let new_tasks = List.map (fun (t : task) ->
             if t.id = task.id then
-              let t = Coord_task.clear_soft_do_not_reclaim_reason t in
+              let t =
+                t
+                |> Coord_task.clear_soft_do_not_reclaim_reason
+                |> Coord_task.clear_stale_worktree_binding
+              in
               {
                 t with
                 task_status =
@@ -653,6 +657,12 @@ let claim_next_r
                    (Masc_domain.Claimed
                       { assignee = agent_name; claimed_at = now_iso () })
                  ());
+          (try
+             (Atomic.get Coord_hooks.claim_post_provision_fn) config ~agent_name
+               ~task_id:task.id
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | _ -> ());
 
           let message = match released_task_id with
             | Some rid ->
@@ -721,7 +731,10 @@ let release_stale_claims config ~ttl_seconds =
                   ("age_s", age_seconds_json ts);
                   ("ts", `String now_str);
                 ]);
-                { task with task_status = Todo }
+                { task with
+                  task_status = Todo;
+                  worktree = None;
+                }
               end else task
           | InProgress { assignee; started_at } ->
               let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) started_at in
@@ -734,7 +747,10 @@ let release_stale_claims config ~ttl_seconds =
                   ("age_s", age_seconds_json ts);
                   ("ts", `String now_str);
                 ]);
-                { task with task_status = Todo }
+                { task with
+                  task_status = Todo;
+                  worktree = None;
+                }
               end else task
           | AwaitingVerification _ -> task  (* leave alone; awaiting verifier *)
         | Todo | Done _ | Cancelled _ -> task

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -177,6 +177,33 @@ let with_registered_keeper config meta f =
 let current_task_id_string (meta : Keeper_types.keeper_meta) =
   Option.map Keeper_id.Task_id.to_string meta.current_task_id
 
+let with_claim_post_provision_hook hook f =
+  let previous = Atomic.get Coord_hooks.claim_post_provision_fn in
+  Atomic.set Coord_hooks.claim_post_provision_fn hook;
+  Fun.protect
+    ~finally:(fun () -> Atomic.set Coord_hooks.claim_post_provision_fn previous)
+    f
+
+let stale_worktree_info ~agent_name ~task_id : Masc_domain.worktree_info =
+  {
+    branch = Printf.sprintf "%s/%s" agent_name task_id;
+    path = Printf.sprintf ".worktrees/%s-%s" agent_name task_id;
+    git_root = "/tmp/stale-sandbox/repos/masc-mcp";
+    repo_name = "masc-mcp";
+  }
+
+let link_stale_worktree config ~agent_name ~task_id =
+  match
+    Coord_worktree.link_worktree_to_task config ~task_id
+      ~worktree_info:(stale_worktree_info ~agent_name ~task_id)
+  with
+  | Ok () -> ()
+  | Error e ->
+    fail
+      (Printf.sprintf
+         "failed to link stale worktree: %s"
+         (Masc_domain.masc_error_to_string e))
+
 (* --- keeper_task_claim tests --- *)
 
 let test_claim_returns_result () =
@@ -279,6 +306,77 @@ let test_release_clears_keeper_current_task_id () =
       in
       check (option string) "persisted current_task_id cleared" None
         (current_task_id_string persisted_meta)))
+
+let test_claim_clears_stale_task_worktree_metadata () =
+  with_claim_post_provision_hook
+    (fun _config ~agent_name:_ ~task_id:_ -> ())
+    (fun () ->
+      with_room (fun config ->
+        let meta = make_test_meta () in
+        with_registered_keeper config meta (fun () ->
+          let _ =
+            Coord.add_task config ~title:"Stale worktree claim" ~priority:1
+              ~description:"desc"
+          in
+          let task_id = (only_task config).id in
+          link_stale_worktree config ~agent_name:"previous-agent" ~task_id;
+          check bool "stale worktree linked" true
+            (Option.is_some (only_task config).worktree);
+          let _ = call_tool config meta "keeper_task_claim" (`Assoc []) in
+          check bool "stale worktree cleared on claim" true
+            (Option.is_none (only_task config).worktree))))
+
+let test_release_clears_task_worktree_metadata () =
+  with_claim_post_provision_hook
+    (fun _config ~agent_name:_ ~task_id:_ -> ())
+    (fun () ->
+      with_room (fun config ->
+        let meta = make_test_meta () in
+        with_registered_keeper config meta (fun () ->
+          let _ =
+            Coord.add_task config ~title:"Worktree release task" ~priority:1
+              ~description:"desc"
+          in
+          let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+          let json = parse_json result in
+          let task_id =
+            Yojson.Safe.Util.(
+              json |> member "claimed_task" |> member "task_id" |> to_string)
+          in
+          link_stale_worktree config ~agent_name:meta.agent_name ~task_id;
+          check bool "worktree linked before release" true
+            (Option.is_some (only_task config).worktree);
+          let ok, message =
+            Tool_task.handle_transition
+              { Tool_task.config; agent_name = meta.agent_name; sw = None }
+              (`Assoc
+                 [
+                   ("task_id", `String task_id);
+                   ("action", `String "release");
+                   ("reason", `String "handoff to another keeper");
+                 ])
+          in
+          if not ok then fail message;
+          check bool "worktree cleared on release" true
+            (Option.is_none (only_task config).worktree))))
+
+let test_claim_next_runs_post_provision_hook () =
+  let observed = ref None in
+  with_claim_post_provision_hook
+    (fun _config ~agent_name ~task_id -> observed := Some (agent_name, task_id))
+    (fun () ->
+      with_room (fun config ->
+        let meta = make_test_meta () in
+        with_registered_keeper config meta (fun () ->
+          let _ =
+            Coord.add_task config ~title:"Provision hook task" ~priority:1
+              ~description:"desc"
+          in
+          let task_id = (only_task config).id in
+          let _ = call_tool config meta "keeper_task_claim" (`Assoc []) in
+          check (option (pair string string)) "claim-next provision hook"
+            (Some (meta.agent_name, task_id))
+            !observed)))
 
 let test_stale_current_task_id_is_cleared_from_backlog () =
   with_room (fun config ->
@@ -988,6 +1086,12 @@ let () =
         test_claim_syncs_keeper_current_task_id;
       test_case "release clears keeper current_task_id" `Quick
         test_release_clears_keeper_current_task_id;
+      test_case "claim clears stale task worktree metadata" `Quick
+        test_claim_clears_stale_task_worktree_metadata;
+      test_case "release clears task worktree metadata" `Quick
+        test_release_clears_task_worktree_metadata;
+      test_case "claim-next runs post-provision hook" `Quick
+        test_claim_next_runs_post_provision_hook;
       test_case "stale current_task_id clears from backlog" `Quick
         test_stale_current_task_id_is_cleared_from_backlog;
       test_case "claim empty room" `Quick test_claim_empty_room;


### PR DESCRIPTION
## Summary
- clear stale per-task worktree metadata when tasks are claimed, released, or stale-released
- run claim-next through the same post-provision hook used by explicit task claim
- add regression coverage for stale worktree cleanup and claim-next provisioning

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (33 tests)

## Operator impact
This removes the stale executor-owned worktree binding that can strand a todo task in another keeper sandbox after handoff, while keeping new claimants on their own provisioned worktree path.