### PR TITLE
fix(chronicle): add adaptive pheromone evaporation

### DIFF
--- a/lib/chronicle_index.ml
+++ b/lib/chronicle_index.ml
@@ -23,6 +23,29 @@ type index =
 
 let current_schema_version = 1
 
+type pheromone_policy =
+  { tau_min : float
+  ; tau_max : float
+  ; base_evaporation : float
+  ; stagnation_threshold : float
+  ; stagnation_boost : float
+  }
+
+let default_pheromone_policy =
+  { tau_min = 0.05
+  ; tau_max = 1.0
+  ; base_evaporation = 0.08
+  ; stagnation_threshold = 0.65
+  ; stagnation_boost = 0.22
+  }
+
+let clamp_float ~min_v ~max_v value =
+  max min_v (min max_v value)
+
+let policy_or_default = function
+  | Some policy -> policy
+  | None -> default_pheromone_policy
+
 let empty ~repo ~now =
   { schema_version = current_schema_version
   ; repo
@@ -44,3 +67,70 @@ let add_or_replace_epoch (idx : index) (summary : epoch_summary) =
     List.filter (fun (s : epoch_summary) -> not (String.equal s.id summary.id)) idx.epochs
   in
   { idx with epochs = summary :: filtered }
+
+let bound_conductivity ?policy value =
+  let policy = policy_or_default policy in
+  clamp_float ~min_v:policy.tau_min ~max_v:policy.tau_max value
+
+let active_trail_stagnation_score epochs =
+  let active_conductivities =
+    epochs
+    |> List.filter_map (fun (s : epoch_summary) ->
+           match s.status with
+           | Chronicle_types.Active -> Some (max 0.0 s.conductivity)
+           | _ -> None)
+  in
+  match active_conductivities with
+  | [] -> 0.0
+  | [ only ] -> if only <= 0.0 then 0.0 else 1.0
+  | conductivities ->
+      let total = List.fold_left ( +. ) 0.0 conductivities in
+      if total <= 0.0 then
+        0.0
+      else
+        let max_share =
+          (List.fold_left max 0.0 conductivities) /. total
+        in
+        let balanced_share =
+          1.0 /. Float.of_int (List.length conductivities)
+        in
+        if max_share <= balanced_share then
+          0.0
+        else
+          clamp_float ~min_v:0.0 ~max_v:1.0
+            ((max_share -. balanced_share) /. (1.0 -. balanced_share))
+
+let adaptive_evaporation_rate ?policy ~stagnation_score () =
+  let policy = policy_or_default policy in
+  let stagnation_score = clamp_float ~min_v:0.0 ~max_v:1.0 stagnation_score in
+  let threshold = clamp_float ~min_v:0.0 ~max_v:1.0 policy.stagnation_threshold in
+  let denominator = max 0.000_001 (1.0 -. threshold) in
+  let boost_ratio =
+    if stagnation_score <= threshold then
+      0.0
+    else
+      (stagnation_score -. threshold) /. denominator
+  in
+  clamp_float ~min_v:0.0 ~max_v:1.0
+    (policy.base_evaporation +. (policy.stagnation_boost *. boost_ratio))
+
+let evaporate_conductivity ?policy ~stagnation_score conductivity =
+  let rate = adaptive_evaporation_rate ?policy ~stagnation_score () in
+  bound_conductivity ?policy (conductivity *. (1.0 -. rate))
+
+let evaporate_active_epochs ?policy idx =
+  let stagnation_score = active_trail_stagnation_score idx.epochs in
+  let epochs =
+    List.map
+      (fun (summary : epoch_summary) ->
+         match summary.status with
+         | Chronicle_types.Active ->
+             { summary with
+               conductivity =
+                 evaporate_conductivity ?policy ~stagnation_score
+                   summary.conductivity
+             }
+         | _ -> summary)
+      idx.epochs
+  in
+  { idx with epochs }

--- a/lib/chronicle_index.mli
+++ b/lib/chronicle_index.mli
@@ -23,6 +23,18 @@ type index =
 
 val current_schema_version : int
 
+type pheromone_policy =
+  { tau_min : float
+  ; tau_max : float
+  ; base_evaporation : float
+  ; stagnation_threshold : float
+  ; stagnation_boost : float
+  }
+
+val default_pheromone_policy : pheromone_policy
+(** Max-Min conductivity and adaptive evaporation defaults for Chronicle
+    trail pheromones. *)
+
 val empty : repo:string -> now:string -> index
 (** Create an empty index with the current schema version. *)
 
@@ -34,3 +46,23 @@ val active_epochs : index -> epoch_summary list
 
 val add_or_replace_epoch : index -> epoch_summary -> index
 (** Add or replace an epoch summary, returning a new index. *)
+
+val bound_conductivity : ?policy:pheromone_policy -> float -> float
+(** Clamp a conductivity value to the policy's Max-Min range. *)
+
+val active_trail_stagnation_score : epoch_summary list -> float
+(** Return [0, 1] concentration score for active Chronicle trails.
+    [0] means balanced or no active trail; [1] means one active trail
+    monopolizes all conductivity. *)
+
+val adaptive_evaporation_rate :
+  ?policy:pheromone_policy -> stagnation_score:float -> unit -> float
+(** Evaporation rate derived from the current stagnation score. *)
+
+val evaporate_conductivity :
+  ?policy:pheromone_policy -> stagnation_score:float -> float -> float
+(** Apply adaptive evaporation and Max-Min bounds to one conductivity. *)
+
+val evaporate_active_epochs : ?policy:pheromone_policy -> index -> index
+(** Evaporate active Chronicle epoch conductivities using the index's current
+    active trail concentration score. Non-active epochs are preserved. *)

--- a/test/test_chronicle_types.ml
+++ b/test/test_chronicle_types.ml
@@ -185,6 +185,67 @@ let test_add_or_replace_replaces () =
   | Some s -> check string "replaced status" (CT.show_epoch_status CT.Completed) (CT.show_epoch_status s.CI.status)
   | None -> fail "epoch missing after replace"
 
+let test_bound_conductivity_uses_max_min_policy () =
+  let policy =
+    { CI.default_pheromone_policy with
+      CI.tau_min = 0.20;
+      tau_max = 0.80;
+    }
+  in
+  check (float 0.0001) "min clamp" 0.20
+    (CI.bound_conductivity ~policy (-1.0));
+  check (float 0.0001) "max clamp" 0.80
+    (CI.bound_conductivity ~policy 1.5)
+
+let test_active_trail_stagnation_one_path () =
+  let active = sample_summary () in
+  check (float 0.0001) "single active trail monopolizes conductivity" 1.0
+    (CI.active_trail_stagnation_score [ active ])
+
+let test_active_trail_stagnation_balanced_paths () =
+  let a = { (sample_summary ()) with CI.id = "a"; conductivity = 0.5 } in
+  let b = { (sample_summary ()) with CI.id = "b"; conductivity = 0.5 } in
+  check (float 0.0001) "balanced trails are not stagnant" 0.0
+    (CI.active_trail_stagnation_score [ a; b ])
+
+let test_adaptive_evaporation_boosts_on_stagnation () =
+  let policy =
+    { CI.tau_min = 0.05;
+      tau_max = 1.0;
+      base_evaporation = 0.10;
+      stagnation_threshold = 0.65;
+      stagnation_boost = 0.20;
+    }
+  in
+  check (float 0.0001) "base rate below threshold" 0.10
+    (CI.adaptive_evaporation_rate ~policy ~stagnation_score:0.20 ());
+  check (float 0.0001) "boosted rate at full stagnation" 0.30
+    (CI.adaptive_evaporation_rate ~policy ~stagnation_score:1.0 ());
+  check (float 0.0001) "conductivity decays by boosted rate" 0.70
+    (CI.evaporate_conductivity ~policy ~stagnation_score:1.0 1.0)
+
+let test_evaporate_active_epochs_preserves_inactive () =
+  let active = { (sample_summary ()) with CI.id = "active"; conductivity = 1.0 } in
+  let completed =
+    { (sample_summary ()) with
+      CI.id = "completed";
+      status = CT.Completed;
+      conductivity = 0.9;
+    }
+  in
+  let idx =
+    { (CI.empty ~repo:"masc-mcp" ~now:"2026-05-01T00:00:00Z") with
+      CI.epochs = [ active; completed ];
+    }
+  in
+  let evaporated = CI.evaporate_active_epochs idx in
+  match CI.find_epoch evaporated "active", CI.find_epoch evaporated "completed" with
+  | Some active', Some completed' ->
+      check bool "active decayed" true (active'.CI.conductivity < active.CI.conductivity);
+      check (float 0.0001) "inactive preserved" completed.CI.conductivity
+        completed'.CI.conductivity
+  | _ -> fail "expected both epochs after evaporation"
+
 let test_json_roundtrip_index () =
   let idx = CI.empty ~repo:"masc-mcp" ~now:"2026-05-01T00:00:00Z" in
   let summary = sample_summary () in
@@ -223,5 +284,15 @@ let () =
       test_case "find_epoch missing" `Quick test_find_epoch_missing;
       test_case "active_epochs" `Quick test_active_epochs;
       test_case "add_or_replace replaces" `Quick test_add_or_replace_replaces;
+      test_case "bound conductivity uses Max-Min policy" `Quick
+        test_bound_conductivity_uses_max_min_policy;
+      test_case "one active trail is stagnant" `Quick
+        test_active_trail_stagnation_one_path;
+      test_case "balanced active trails are not stagnant" `Quick
+        test_active_trail_stagnation_balanced_paths;
+      test_case "adaptive evaporation boosts on stagnation" `Quick
+        test_adaptive_evaporation_boosts_on_stagnation;
+      test_case "evaporation preserves inactive epochs" `Quick
+        test_evaporate_active_epochs_preserves_inactive;
     ]);
   ]


### PR DESCRIPTION
## Summary
- Add a pure Chronicle pheromone policy for Max-Min conductivity bounds.
- Compute active-trail concentration as a stagnation score and derive adaptive evaporation from it.
- Add tests for one-path stagnation, balanced active trails, clamp behavior, boosted evaporation, and inactive epoch preservation.

Fixes #13399
Related to #12799

## Validation
- `dune build --root . -j 1 test/test_chronicle_types.exe`
- `./_build/default/test/test_chronicle_types.exe`
- `git diff --check origin/main...HEAD`

## Review Focus
- This is the first safe slice: pure policy helpers only, no runtime routing behavior change.
- Check whether the default Max-Min bounds and threshold are acceptable before wiring Chronicle conductivity into live routing.