### PR TITLE
Improve Code IDE cockpit runtime surface

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -119,10 +119,20 @@ export function App() {
     // Initialize hash router and compatible deep links
     initRouter()
 
-    // Prime the lightweight shell status first so build/version metadata lands
-    // while the project snapshot warms heavier execution/command projections.
-    void refreshShell({ light: true })
-    requestNamespaceTruthNow()
+    const ensureLoopbackAuth = () => ensureDevToken()
+      .catch(err => {
+        console.warn('[app] dashboard dev-token bootstrap failed', err instanceof Error ? err.message : err)
+      })
+
+    // Loopback dashboards can self-provision a dev bearer token. Do that before
+    // the first authenticated projections so the header auth badge and runtime
+    // stores do not briefly settle on an unauthenticated shell snapshot.
+    void ensureLoopbackAuth()
+      .finally(() => {
+        if (cancelled) return
+        void refreshShell({ light: true })
+        requestNamespaceTruthNow()
+      })
 
     // Fetch runtime thresholds so health-strip and lifecycle state use
     // server-side config instead of compiled fallback defaults (P-DASH-07).
@@ -148,10 +158,7 @@ export function App() {
       })
       .finally(() => {
         if (cancelled) return
-        void ensureDevToken()
-          .catch(err => {
-            console.warn('[app] dashboard dev-token bootstrap failed', err instanceof Error ? err.message : err)
-          })
+        void ensureLoopbackAuth()
           .finally(() => {
             if (cancelled) return
             void connectDashboardWS(route.value)

--- a/dashboard/src/components/common/shiki-highlighter.ts
+++ b/dashboard/src/components/common/shiki-highlighter.ts
@@ -21,6 +21,8 @@ const SHIKI_LANG_ALIASES: Record<string, string> = {
   zsh: 'bash',
   yml: 'yaml',
   md: 'markdown',
+  ml: 'ocaml',
+  mli: 'ocaml',
 }
 const SHIKI_LANG_LOADERS: Record<string, ShikiLanguageLoader> = {
   bash: () => import('shiki/langs/bash.mjs'),

--- a/dashboard/src/components/ide/ide-editor-extensions.test.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.test.ts
@@ -5,6 +5,7 @@ import {
   readOnlyExt,
   themeExt,
   languageExt,
+  languageIdForFilePath,
   lineNumberExt,
   syntaxHighlightExt,
   blameExtensions,
@@ -80,6 +81,26 @@ describe('languageExt', () => {
   it('returns a language extension for .json files', async () => {
     const ext = await languageExt('package.json')
     expect(ext).toBeDefined()
+  })
+
+  it('maps OCaml source and interface files to the OCaml language', async () => {
+    expect(languageIdForFilePath('lib/server.ml')).toBe('ocaml')
+    expect(languageIdForFilePath('lib/server.mli')).toBe('ocaml')
+    expect(languageIdForFilePath('scratch.ocaml')).toBe('ocaml')
+
+    const lang = await languageExt('lib/server.ml')
+    const { view, container } = createTestView([
+      themeExt(),
+      lineNumberExt(),
+      syntaxHighlightExt(),
+      lang,
+    ], 'module type S = sig\n  val run : unit -> int\nend\n')
+
+    expect(container.querySelector('.cm-line span')).not.toBeNull()
+    expect(view.state.languageDataAt('name', 0)).toContain('ocaml')
+
+    view.destroy()
+    container.remove()
   })
 })
 

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -1,6 +1,12 @@
 import { EditorView, GutterMarker, gutter, lineNumbers, type ViewUpdate } from '@codemirror/view'
 import { Annotation, EditorState, Extension, StateField, StateEffect } from '@codemirror/state'
-import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
+import {
+  defaultHighlightStyle,
+  StreamLanguage,
+  syntaxHighlighting,
+  type StringStream,
+  type StreamParser,
+} from '@codemirror/language'
 import type { LineOwnership } from './keeper-line-ownership-store'
 import { kSigil } from '../keeper-badge'
 
@@ -235,27 +241,204 @@ export function keeperLineSelectExt(
 
 type LanguageModule = () => Promise<{ extension: Extension }>
 
-const LANGUAGE_MAP: Readonly<Record<string, LanguageModule>> = {
-  '.ts': () => import('@codemirror/lang-javascript').then(m => m.javascript({ typescript: true })),
-  '.tsx': () => import('@codemirror/lang-javascript').then(m => m.javascript({ typescript: true, jsx: true })),
-  '.js': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
-  '.jsx': () => import('@codemirror/lang-javascript').then(m => m.javascript({ jsx: true })),
-  '.py': () => import('@codemirror/lang-python').then(m => m.python()),
-  '.html': () => import('@codemirror/lang-html').then(m => m.html()),
-  '.css': () => import('@codemirror/lang-css').then(m => m.css()),
-  '.json': () => import('@codemirror/lang-json').then(m => m.json()),
-  '.md': () => import('@codemirror/lang-markdown').then(m => m.markdown()),
-  '.ocaml': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
-  '.ml': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
-  '.mli': () => import('@codemirror/lang-javascript').then(m => m.javascript()),
-  '.toml': () => import('@codemirror/lang-json').then(m => m.json()),
-  '.yaml': () => import('@codemirror/lang-json').then(m => m.json()),
-  '.yml': () => import('@codemirror/lang-json').then(m => m.json()),
+interface LanguageEntry {
+  readonly id: string
+  readonly load: LanguageModule
+}
+
+interface OcamlStreamState {
+  commentDepth: number
+  stringQuote: '"' | null
+}
+
+const OCAML_KEYWORDS = new Set([
+  'and',
+  'as',
+  'assert',
+  'begin',
+  'class',
+  'constraint',
+  'do',
+  'done',
+  'downto',
+  'else',
+  'end',
+  'exception',
+  'external',
+  'for',
+  'fun',
+  'function',
+  'functor',
+  'if',
+  'in',
+  'include',
+  'inherit',
+  'initializer',
+  'lazy',
+  'let',
+  'match',
+  'method',
+  'module',
+  'mutable',
+  'new',
+  'nonrec',
+  'object',
+  'of',
+  'open',
+  'private',
+  'rec',
+  'sig',
+  'struct',
+  'then',
+  'to',
+  'try',
+  'type',
+  'val',
+  'virtual',
+  'when',
+  'while',
+  'with',
+])
+
+const OCAML_ATOMS = new Set(['false', 'true', 'None', 'Some', 'Ok', 'Error'])
+
+const OCAML_BUILTINS = new Set([
+  'bool',
+  'char',
+  'exn',
+  'float',
+  'int',
+  'list',
+  'option',
+  'result',
+  'string',
+  'unit',
+])
+
+const ocamlStreamParser: StreamParser<OcamlStreamState> = {
+  name: 'ocaml',
+  startState: () => ({ commentDepth: 0, stringQuote: null }),
+  copyState: state => ({ ...state }),
+  languageData: {
+    name: 'ocaml',
+    commentTokens: { block: { open: '(*', close: '*)' } },
+  },
+  token(stream, state) {
+    if (state.commentDepth > 0) return readOcamlComment(stream, state)
+    if (state.stringQuote !== null) return readOcamlString(stream, state)
+    if (stream.eatSpace()) return null
+
+    if (stream.match('(*')) {
+      state.commentDepth = 1
+      return readOcamlComment(stream, state)
+    }
+
+    const ch = stream.next()
+    if (ch === undefined) return null
+
+    if (ch === '"') {
+      state.stringQuote = '"'
+      return readOcamlString(stream, state)
+    }
+
+    if (ch === '\'') {
+      if (stream.match(/^\\?.'/)) return 'string'
+      stream.eatWhile(/[A-Za-z0-9_']/)
+      return 'typeName'
+    }
+
+    if (/[0-9]/.test(ch)) {
+      stream.eatWhile(/[A-Za-z0-9_'.]/)
+      return 'number'
+    }
+
+    if (/[A-Z]/.test(ch)) {
+      stream.eatWhile(/[A-Za-z0-9_']/)
+      const ident = stream.current()
+      return OCAML_ATOMS.has(ident) ? 'atom' : 'typeName'
+    }
+
+    if (/[a-z_]/.test(ch)) {
+      stream.eatWhile(/[A-Za-z0-9_']/)
+      const ident = stream.current()
+      if (OCAML_KEYWORDS.has(ident)) return 'keyword'
+      if (OCAML_ATOMS.has(ident)) return 'atom'
+      if (OCAML_BUILTINS.has(ident)) return 'standard variableName'
+      return 'variableName'
+    }
+
+    if (/[-+*/=<>@^|&$%!?~:.;,#]/.test(ch)) {
+      stream.eatWhile(/[-+*/=<>@^|&$%!?~:.;,#]/)
+      return 'operator'
+    }
+
+    return null
+  },
+}
+
+const ocamlLanguage = StreamLanguage.define(ocamlStreamParser)
+
+function readOcamlComment(stream: StringStream, state: OcamlStreamState): string {
+  while (!stream.eol()) {
+    if (stream.match('(*')) {
+      state.commentDepth += 1
+      continue
+    }
+    if (stream.match('*)')) {
+      state.commentDepth -= 1
+      if (state.commentDepth <= 0) {
+        state.commentDepth = 0
+        break
+      }
+      continue
+    }
+    stream.next()
+  }
+  return 'comment'
+}
+
+function readOcamlString(stream: StringStream, state: OcamlStreamState): string {
+  let escaped = false
+  while (!stream.eol()) {
+    const ch = stream.next()
+    if (escaped) {
+      escaped = false
+    } else if (ch === '\\') {
+      escaped = true
+    } else if (ch === state.stringQuote) {
+      state.stringQuote = null
+      break
+    }
+  }
+  return 'string'
+}
+
+const LANGUAGE_MAP: Readonly<Record<string, LanguageEntry>> = {
+  '.ts': { id: 'typescript', load: () => import('@codemirror/lang-javascript').then(m => m.javascript({ typescript: true })) },
+  '.tsx': { id: 'typescript', load: () => import('@codemirror/lang-javascript').then(m => m.javascript({ typescript: true, jsx: true })) },
+  '.js': { id: 'javascript', load: () => import('@codemirror/lang-javascript').then(m => m.javascript()) },
+  '.jsx': { id: 'javascript', load: () => import('@codemirror/lang-javascript').then(m => m.javascript({ jsx: true })) },
+  '.py': { id: 'python', load: () => import('@codemirror/lang-python').then(m => m.python()) },
+  '.html': { id: 'html', load: () => import('@codemirror/lang-html').then(m => m.html()) },
+  '.css': { id: 'css', load: () => import('@codemirror/lang-css').then(m => m.css()) },
+  '.json': { id: 'json', load: () => import('@codemirror/lang-json').then(m => m.json()) },
+  '.md': { id: 'markdown', load: () => import('@codemirror/lang-markdown').then(m => m.markdown()) },
+  '.ocaml': { id: 'ocaml', load: () => Promise.resolve(ocamlLanguage) },
+  '.ml': { id: 'ocaml', load: () => Promise.resolve(ocamlLanguage) },
+  '.mli': { id: 'ocaml', load: () => Promise.resolve(ocamlLanguage) },
+  '.toml': { id: 'json', load: () => import('@codemirror/lang-json').then(m => m.json()) },
+  '.yaml': { id: 'json', load: () => import('@codemirror/lang-json').then(m => m.json()) },
+  '.yml': { id: 'json', load: () => import('@codemirror/lang-json').then(m => m.json()) },
+}
+
+export function languageIdForFilePath(filePath: string): string | null {
+  const ext = filePath.slice(filePath.lastIndexOf('.'))
+  return LANGUAGE_MAP[ext]?.id ?? null
 }
 
 export async function languageExt(filePath: string): Promise<Extension> {
   const ext = filePath.slice(filePath.lastIndexOf('.'))
-  const loader = LANGUAGE_MAP[ext]
+  const loader = LANGUAGE_MAP[ext]?.load
   if (!loader) return []
   try {
     return await loader()

--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -91,7 +91,6 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
     expect(keeperOwnedRow?.textContent).toContain('NK')
     expect(keeperOwnedRow?.textContent).toContain('router.ts')
   })
-
   it('renders repository source in the explorer header', () => {
     const store = createFileTreeStore()
     store.seed(SAMPLE)
@@ -103,5 +102,22 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
 
     expect(container.textContent).toContain('EXPLORER · masc-mcp')
     expect(container.textContent).not.toContain('EXPLORER · project')
+  })
+
+  it('keeps header controls outside the scrollable tree body', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE)
+    render(h(IdeExplorer, { fileTreeStore: store }), container)
+
+    const explorer = container.querySelector<HTMLElement>('.ide-explorer')
+    const scroller = container.querySelector<HTMLElement>('.ide-explorer-scroll')
+    const tree = container.querySelector<HTMLElement>('.ide-explorer-tree')
+
+    expect(explorer).not.toBeNull()
+    expect(scroller).not.toBeNull()
+    expect(tree).not.toBeNull()
+    expect(scroller?.contains(tree)).toBe(true)
+    expect(scroller?.contains(container.querySelector('header'))).toBe(false)
+    expect(scroller?.contains(container.querySelector('input[type="search"]'))).toBe(false)
   })
 })

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -108,6 +108,8 @@ export function IdeExplorer({
 
   const [filter, setFilter] = useState('')
   const [isScanningRepositories, setIsScanningRepositories] = useState(false)
+  const [activeFile, setActiveFile] = useState(activeIdeFile.value)
+  useEffect(() => activeIdeFile.subscribe(file => setActiveFile(file)), [])
 
   const handleRepositoryScan = async (): Promise<void> => {
     if (!onRepositoryScan || isScanningRepositories) return
@@ -142,18 +144,9 @@ export function IdeExplorer({
 
   return html`
     <div
+      class="ide-explorer"
       role="region"
       aria-label="EXPLORER"
-      style=${{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--sp-2)',
-        padding: 'var(--sp-3)',
-        background: 'var(--color-bg-surface)',
-        borderRight: '1px solid var(--color-border-default)',
-        minHeight: 0,
-        overflow: 'auto',
-      }}
     >
       <header
         style=${{
@@ -278,16 +271,23 @@ export function IdeExplorer({
           padding: 'var(--sp-1) var(--sp-2)',
         }}
       />
-      <ul
-        role="tree"
-        aria-label="File tree"
-        style=${{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '2px' }}
-      >
-        ${filtered.map(node => TreeRow(node, store.isExpanded(node.path), () => {
-          if (node.hasChildren) store.toggle(node.path)
-          else activeIdeFile.value = node.path
-        }))}
-      </ul>
+      <div class="ide-explorer-scroll" role="presentation">
+        <ul
+          class="ide-explorer-tree"
+          role="tree"
+          aria-label="File tree"
+        >
+          ${filtered.map(node => TreeRow(
+            node,
+            store.isExpanded(node.path),
+            node.path === activeFile,
+            () => {
+              if (node.hasChildren) store.toggle(node.path)
+              else activeIdeFile.value = node.path
+            },
+          ))}
+        </ul>
+      </div>
     </div>
   `
 }
@@ -317,7 +317,7 @@ function SourceHint(source: WorkspaceSource) {
   `
 }
 
-function TreeRow(node: FileTreeNode, expanded: boolean, onClick: () => void) {
+function TreeRow(node: FileTreeNode, expanded: boolean, selected: boolean, onClick: () => void) {
   const indent = node.depth * 12
   const chevron = node.hasChildren ? (expanded ? '▾' : '▸') : ''
   const onKeyDown = (e: KeyboardEvent): void => {
@@ -328,29 +328,22 @@ function TreeRow(node: FileTreeNode, expanded: boolean, onClick: () => void) {
   }
   return html`
     <li
+      class="ide-explorer-row"
       role="treeitem"
       aria-expanded=${node.hasChildren ? (expanded ? 'true' : 'false') : undefined}
+      aria-selected=${selected ? 'true' : undefined}
       tabIndex=${0}
       onClick=${onClick}
       onKeyDown=${onKeyDown}
       style=${{
-        display: 'grid',
-        gridTemplateColumns: 'auto auto 1fr auto',
-        alignItems: 'center',
-        gap: 'var(--sp-2)',
-        padding: '2px 4px',
         paddingLeft: `${4 + indent}px`,
-        font: 'var(--type-body)',
-        color: 'var(--color-fg-secondary)',
-        cursor: 'pointer',
-        userSelect: 'none',
       }}
     >
       <span aria-hidden="true" style=${{ color: 'var(--color-fg-muted)', width: '12px', textAlign: 'center' }}>${chevron}</span>
       ${node.keeperId
         ? html`<${KeeperBadge} id=${node.keeperId} variant="sigil" size="sm" />`
         : html`<span aria-hidden="true" style=${{ width: '14px', height: '14px' }} />`}
-      <span>${node.label}</span>
+      <span class="ide-explorer-row-label">${node.label}</span>
       ${node.diff !== null
         ? html`<span style=${{ color: 'var(--color-fg-muted)', font: 'var(--fs-11)' }}>${node.diff}</span>`
         : null}

--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h, render } from 'preact'
+import { IdeKeeperWorkPanel, keeperWorkSummary } from './ide-keeper-work-panel'
+import { keepers, tasks } from '../../store'
+import type { Keeper, Task } from '../../types'
+
+describe('IdeKeeperWorkPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+  })
+
+  afterEach(() => {
+    render(null, container)
+    keepers.value = []
+    tasks.value = []
+  })
+
+  it('summarizes the selected keeper current task and terminal reason', () => {
+    keepers.value = [keeperFixture()]
+    tasks.value = [taskFixture()]
+
+    render(h(IdeKeeperWorkPanel, { keeperName: 'sangsu' }), container)
+
+    expect(container.textContent).toContain('KEEPER WORK')
+    expect(container.textContent).toContain('task-151')
+    expect(container.textContent).toContain('Fix codex cascade config')
+    expect(container.textContent).toContain('tool_required_unsatisfied')
+    expect(container.textContent).toContain('inspect_provider_tool_contract')
+    expect(container.textContent).toContain('masc_claim_next')
+  })
+
+  it('matches keeper-agent task assignees to the canonical keeper name', () => {
+    const summary = keeperWorkSummary(
+      'sangsu',
+      [keeperFixture()],
+      [taskFixture({ assignee: 'keeper-sangsu-agent' })],
+    )
+
+    expect(summary.currentTaskId).toBe('task-151')
+    expect(summary.currentTask?.title).toBe('Fix codex cascade config')
+    expect(summary.activeTasks).toHaveLength(1)
+    expect(summary.activeTaskCount).toBe(1)
+  })
+
+  it('keeps runtime current_task visible when the task row is absent', () => {
+    const summary = keeperWorkSummary('sangsu', [keeperFixture()], [])
+
+    expect(summary.currentTaskId).toBe('task-151')
+    expect(summary.currentTask).toBeNull()
+    expect(summary.activeTaskCount).toBe(1)
+
+    keepers.value = [keeperFixture()]
+    tasks.value = []
+
+    render(h(IdeKeeperWorkPanel, { keeperName: 'sangsu' }), container)
+
+    expect(container.textContent).toContain('task-151')
+    expect(container.textContent).toContain('keeper runtime current task')
+    expect(container.textContent).not.toContain('no active keeper task')
+  })
+})
+
+function keeperFixture(): Keeper {
+  return {
+    name: 'sangsu',
+    keeper_id: 'keeper-id-sangsu',
+    agent_name: 'keeper-sangsu-agent',
+    status: 'running',
+    phase: 'Failing',
+    needs_attention: true,
+    agent: {
+      name: 'keeper-sangsu-agent',
+      current_task: 'task-151',
+    },
+    trust: {
+      needs_attention: true,
+      latest_terminal_reason: {
+        code: 'tool_required_unsatisfied',
+        summary: 'actionable keeper signal was present, but no keeper tools were called',
+        next_action: 'inspect_provider_tool_contract',
+      },
+    },
+    recent_output_preview: 'required tool contract violated',
+    recent_tool_names: ['masc_claim_next', 'masc_board_list'],
+  } as Keeper
+}
+
+function taskFixture(partial: Partial<Task> = {}): Task {
+  return {
+    id: 'task-151',
+    title: 'Fix codex cascade config',
+    status: 'claimed',
+    assignee: 'sangsu',
+    worktree: {
+      branch: 'fix/cascade',
+      path: '/workspace/.worktrees/fix-cascade',
+      git_root: '/workspace',
+      repo_name: 'masc-mcp',
+    },
+    ...partial,
+  }
+}

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -1,0 +1,228 @@
+import { html } from 'htm/preact'
+import type { Keeper, Task } from '../../types'
+import { keepers, tasks } from '../../store'
+import { KeeperBadge } from '../keeper-badge'
+import {
+  canonicalKeeperName,
+  keeperIdentityKeys,
+} from '../common/keeper-identity'
+
+interface IdeKeeperWorkPanelProps {
+  readonly keeperName: string
+}
+
+interface KeeperWorkSummary {
+  readonly displayName: string
+  readonly keeper: Keeper | null
+  readonly currentTaskId: string | null
+  readonly currentTask: Task | null
+  readonly activeTasks: ReadonlyArray<Task>
+  readonly activeTaskCount: number
+  readonly terminalCode: string | null
+  readonly terminalSummary: string | null
+  readonly nextAction: string | null
+  readonly recentOutput: string | null
+  readonly recentTools: ReadonlyArray<string>
+  readonly runtimeBlocker: string | null
+}
+
+const EMPTY_TOOLS: ReadonlyArray<string> = []
+
+export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
+  const summary = keeperWorkSummary(keeperName, keepers.value, tasks.value)
+  const keeper = summary.keeper
+  const currentTask = summary.currentTask
+  const attention = Boolean(
+    keeper?.needs_attention
+    || keeper?.trust?.needs_attention
+    || summary.terminalCode
+    || summary.runtimeBlocker,
+  )
+
+  return html`
+    <section
+      class="ide-keeper-work"
+      role="region"
+      aria-label="KEEPER WORK"
+      data-attention=${attention ? 'true' : 'false'}
+    >
+      <div class="ide-keeper-work-head">
+        <span>KEEPER WORK</span>
+        <span>
+          ${summary.displayName
+            ? html`<${KeeperBadge} id=${summary.displayName} variant="full" size="sm" />`
+            : 'all keepers'}
+        </span>
+      </div>
+      <div class="ide-keeper-work-body">
+        <div class="ide-keeper-work-strip">
+          ${WorkMetric('phase', keeper?.phase ?? keeper?.status ?? 'unknown')}
+          ${WorkMetric('task', summary.currentTaskId ?? 'none')}
+          ${WorkMetric('active', String(summary.activeTaskCount))}
+        </div>
+        ${currentTask
+          ? html`
+            <div class="ide-keeper-work-card">
+              <div class="ide-keeper-work-card-top">
+                <span>${currentTask.id}</span>
+                <span>${currentTask.status ?? 'unknown'}</span>
+              </div>
+              <strong title=${currentTask.title}>${currentTask.title}</strong>
+              ${currentTask.worktree
+                ? html`<span title=${currentTask.worktree.path}>${currentTask.worktree.branch} · ${currentTask.worktree.repo_name}</span>`
+                : null}
+            </div>
+          `
+          : summary.currentTaskId
+            ? html`
+              <div class="ide-keeper-work-card">
+                <div class="ide-keeper-work-card-top">
+                  <span>${summary.currentTaskId}</span>
+                  <span>runtime</span>
+                </div>
+                <strong>keeper runtime current task</strong>
+                <span>task row not present in execution projection</span>
+              </div>
+            `
+          : html`<div class="ide-keeper-work-empty">no active keeper task in dashboard state</div>`}
+        ${RuntimeBlock(summary)}
+        ${summary.recentOutput
+          ? html`<p class="ide-keeper-work-output">${summary.recentOutput}</p>`
+          : null}
+        ${summary.recentTools.length > 0
+          ? html`
+            <div class="ide-keeper-work-tools" aria-label="Recent keeper tools">
+              ${summary.recentTools.slice(0, 5).map(tool => html`<span>${tool}</span>`)}
+            </div>
+          `
+          : null}
+      </div>
+    </section>
+  `
+}
+
+function WorkMetric(label: string, value: string) {
+  return html`
+    <span class="ide-keeper-work-metric">
+      <span>${label}</span>
+      <strong title=${value}>${value}</strong>
+    </span>
+  `
+}
+
+function RuntimeBlock(summary: KeeperWorkSummary) {
+  const headline = summary.terminalSummary ?? summary.runtimeBlocker
+  const action = summary.nextAction
+  if (!headline && !action) return null
+  return html`
+    <div class="ide-keeper-work-runtime" role="status">
+      <div>
+        <span>${summary.terminalCode ?? 'runtime'}</span>
+        <strong>${headline ?? action}</strong>
+      </div>
+      ${action ? html`<span>${action}</span>` : null}
+    </div>
+  `
+}
+
+export function keeperWorkSummary(
+  keeperName: string,
+  keeperList: ReadonlyArray<Keeper>,
+  taskList: ReadonlyArray<Task>,
+): KeeperWorkSummary {
+  const displayName = normalizedKeeperName(keeperName)
+  const keeper = findKeeper(displayName, keeperList)
+  const explicitCurrentTaskId = firstNonEmpty(keeper?.agent?.current_task)
+  const assigneeTasks = taskList
+    .filter(task => taskMatchesKeeper(task, displayName, keeper))
+    .filter(task => task.status !== 'done' && task.status !== 'cancelled')
+  const currentTaskById = explicitCurrentTaskId
+    ? taskList.find(task => task.id === explicitCurrentTaskId) ?? null
+    : null
+  const activeTasks = uniqTasks(currentTaskById ? [currentTaskById, ...assigneeTasks] : assigneeTasks)
+  const currentTaskId = firstNonEmpty(
+    explicitCurrentTaskId,
+    activeTasks[0]?.id,
+  )
+  const currentTask = currentTaskId
+    ? activeTasks.find(task => task.id === currentTaskId) ?? null
+    : activeTasks[0] ?? null
+  const trust = keeper?.trust ?? null
+  const latestTerminal = trust?.latest_terminal_reason ?? null
+  return {
+    displayName,
+    keeper,
+    currentTaskId,
+    currentTask,
+    activeTasks,
+    activeTaskCount: currentTaskId && activeTasks.length === 0 ? 1 : activeTasks.length,
+    terminalCode: firstNonEmpty(latestTerminal?.code, keeper?.runtime_blocker_class),
+    terminalSummary: firstNonEmpty(
+      latestTerminal?.summary,
+      keeper?.runtime_blocker_summary,
+      trust?.attention_reason,
+      keeper?.attention_reason,
+    ),
+    nextAction: firstNonEmpty(
+      latestTerminal?.next_action,
+      trust?.latest_next_action,
+      trust?.next_human_action,
+      keeper?.next_human_action,
+    ),
+    recentOutput: firstNonEmpty(keeper?.recent_output_preview, keeper?.recent_input_preview),
+    recentTools: keeper?.recent_tool_names ?? keeper?.latest_tool_names ?? EMPTY_TOOLS,
+    runtimeBlocker: firstNonEmpty(keeper?.runtime_blocker_summary, keeper?.last_blocker),
+  }
+}
+
+function findKeeper(name: string, keeperList: ReadonlyArray<Keeper>): Keeper | null {
+  const target = name.toLowerCase()
+  if (!target) return keeperList[0] ?? null
+  return keeperList.find(keeper => {
+    const keys = keeperIdentityKeys(keeper.keeper_id, keeper.name, keeper.agent_name)
+    return keys.includes(target) || keys.includes(`keeper:${target}`)
+  }) ?? null
+}
+
+function taskMatchesKeeper(task: Task, keeperName: string, keeper: Keeper | null): boolean {
+  if (!task.assignee) return false
+  const taskKeys = assigneeKeys(task.assignee)
+  const keeperKeys = new Set([
+    ...keeperIdentityKeys(keeper?.keeper_id, keeper?.name ?? keeperName, keeper?.agent_name),
+    ...assigneeKeys(keeperName),
+  ])
+  return taskKeys.some(key => keeperKeys.has(key))
+}
+
+function assigneeKeys(value: string): string[] {
+  const raw = value.trim().toLowerCase()
+  const canonical = canonicalKeeperName(value)?.toLowerCase() ?? null
+  return [
+    raw,
+    canonical,
+    canonical ? `keeper:${canonical}` : null,
+  ].filter((item): item is string => Boolean(item))
+}
+
+function uniqTasks(taskList: ReadonlyArray<Task>): Task[] {
+  const seen = new Set<string>()
+  const result: Task[] = []
+  for (const task of taskList) {
+    if (task.status === 'done' || task.status === 'cancelled' || seen.has(task.id)) continue
+    seen.add(task.id)
+    result.push(task)
+  }
+  return result
+}
+
+function normalizedKeeperName(value: string): string {
+  return canonicalKeeperName(value) ?? value.trim()
+}
+
+function firstNonEmpty(...values: ReadonlyArray<string | null | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+  return null
+}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -6,6 +6,7 @@ import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
 import { IdeConversationRailMock } from './ide-conversation-rail-mock'
 import { IdeActivityMock } from './ide-activity-mock'
+import { IdeKeeperWorkPanel } from './ide-keeper-work-panel'
 import { IdeInterjectMock } from './ide-interject-mock'
 import { KeeperShellDrawer } from './keeper-shell-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
@@ -159,7 +160,7 @@ export function IdeShell() {
           class="ide-plane-conversation"
           style=${{
             display: 'grid',
-            gridTemplateRows: 'auto auto auto 1fr',
+            gridTemplateRows: 'auto auto auto auto 1fr',
             minHeight: 0,
             overflow: 'auto',
           }}
@@ -168,6 +169,7 @@ export function IdeShell() {
             activeRepositoryId=${coordinator.activeRepositoryId}
             subscribeActiveRepositoryId=${coordinator.subscribeActiveRepositoryId}
           />
+          <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
           <${IdePersistencePanel} keeperName=${terminalKeeper} />
           <${InspectorKeeperBDI} />
           <${IdeConversationRailMock} />

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -362,6 +362,71 @@
   overflow: hidden;
 }
 
+.ide-explorer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  padding: var(--sp-3);
+  border-right: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+}
+
+.ide-explorer-scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-default) transparent;
+}
+
+.ide-explorer-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ide-explorer-row {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+  padding: 2px 4px;
+  border-left: 2px solid transparent;
+  border-radius: var(--r-1);
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  font: var(--type-body);
+  user-select: none;
+}
+
+.ide-explorer-row:hover {
+  background: var(--color-bg-muted);
+}
+
+.ide-explorer-row[aria-selected="true"] {
+  border-left-color: var(--color-accent-fg);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-primary);
+}
+
+.ide-explorer-row-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .ide-plane-editor {
   grid-column: 2;
   grid-row: 1 / span 2;
@@ -400,6 +465,135 @@
   padding: var(--sp-2) var(--sp-3);
   border-bottom: 1px solid var(--color-border-divider);
   background: color-mix(in srgb, var(--color-bg-surface) 94%, black);
+}
+
+.ide-keeper-work {
+  display: grid;
+  grid-template-rows: auto minmax(0, auto);
+  gap: var(--sp-2);
+  min-width: 0;
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--color-border-divider);
+  background: var(--color-bg-surface);
+}
+
+.ide-keeper-work[data-attention="true"] {
+  background: color-mix(in srgb, var(--color-bg-surface) 88%, var(--color-status-warn));
+}
+
+.ide-keeper-work-head,
+.ide-keeper-work-card-top,
+.ide-keeper-work-strip,
+.ide-keeper-work-tools {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.ide-keeper-work-head {
+  justify-content: space-between;
+  color: var(--color-fg-muted);
+  font: var(--type-eyebrow);
+}
+
+.ide-keeper-work-body,
+.ide-keeper-work-card,
+.ide-keeper-work-runtime {
+  display: grid;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.ide-keeper-work-strip {
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.ide-keeper-work-strip::-webkit-scrollbar {
+  display: none;
+}
+
+.ide-keeper-work-metric {
+  display: inline-grid;
+  grid-template-columns: auto;
+  gap: 1px;
+  min-width: 4.75rem;
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: var(--color-bg-elevated);
+}
+
+.ide-keeper-work-metric span,
+.ide-keeper-work-card-top,
+.ide-keeper-work-card > span,
+.ide-keeper-work-runtime span,
+.ide-keeper-work-empty,
+.ide-keeper-work-output {
+  color: var(--color-fg-muted);
+  font-size: var(--fs-11);
+}
+
+.ide-keeper-work-metric strong,
+.ide-keeper-work-card strong,
+.ide-keeper-work-runtime strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-fg-primary);
+  font-size: var(--fs-12);
+  font-weight: 600;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-keeper-work-card {
+  padding: var(--sp-2);
+  border: 1px solid var(--color-border-default);
+  border-left: 2px solid var(--color-accent-fg);
+  border-radius: var(--r-2);
+  background: var(--color-bg-elevated);
+}
+
+.ide-keeper-work-card-top {
+  justify-content: space-between;
+  font: var(--type-eyebrow);
+}
+
+.ide-keeper-work-runtime {
+  padding: var(--sp-2);
+  border: 1px solid color-mix(in srgb, var(--color-status-warn) 45%, var(--color-border-default));
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-status-warn));
+}
+
+.ide-keeper-work-runtime > div {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.ide-keeper-work-output {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.ide-keeper-work-tools {
+  flex-wrap: wrap;
+}
+
+.ide-keeper-work-tools span {
+  padding: 1px var(--sp-1);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-10);
 }
 
 .ide-branch-context-head,
@@ -856,6 +1050,50 @@
 }
 
 @media (max-width: 640px) {
+  .ide-plane-shell,
+  .ide-plane-shell[data-terminal-open="true"] {
+    grid-template-rows: auto auto auto auto auto;
+    height: auto;
+    min-height: 100%;
+    overflow: visible;
+  }
+
+  .ide-plane-grid {
+    grid-template-rows:
+      24rem
+      36rem
+      34rem
+      20rem;
+    height: auto;
+    overflow: visible;
+  }
+
+  .ide-plane-tree {
+    height: 24rem;
+    min-height: 24rem;
+  }
+
+  .ide-plane-editor {
+    height: 36rem;
+    min-height: 36rem;
+  }
+
+  .ide-plane-conversation {
+    height: 34rem;
+    min-height: 34rem;
+    overflow: auto;
+  }
+
+  .ide-plane-activity {
+    height: 20rem;
+    min-height: 20rem;
+    overflow: auto;
+  }
+
+  .ide-explorer-scroll {
+    min-height: 0;
+  }
+
   .ide-plane-statusbar {
     flex-wrap: wrap;
   }

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -130,6 +130,13 @@ describe('refreshPlanForRoute', () => {
     })).toEqual([])
   })
 
+  it('hydrates the Code IDE route from live execution state', () => {
+    expect(refreshPlanForRoute({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+    })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot'])
+  })
+
   it('refreshes the inspector shell through server config once (Phase 6: view param)', async () => {
     refreshForRoute({
       tab: 'command',
@@ -178,6 +185,15 @@ describe('refreshPlanForRoute', () => {
     refreshForRoute({
       tab: 'monitoring',
       params: { section: 'journey' },
+    })
+
+    expect(refreshExecution).toHaveBeenCalledWith()
+  })
+
+  it('uses the scheduler-backed execution refresh path on Code IDE navigation', () => {
+    refreshForRoute({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
     })
 
     expect(refreshExecution).toHaveBeenCalledWith()

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -126,6 +126,8 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
         return ['harness']
       }
       return []
+    case 'code':
+      return ['namespaceTruth', 'execution', 'missionSnapshot']
     case 'logs':
     default:
       return []


### PR DESCRIPTION
## Summary
- make the Code IDE explorer use a dedicated scroll body with selected-file state
- add native OCaml CodeMirror highlighting plus Shiki aliases for .ml/.mli
- hydrate Code IDE route execution state and add a keeper work panel showing current task, runtime blocker, next action, output preview, and recent tools
- bootstrap loopback dashboard auth before first shell/runtime projections to avoid unauthenticated initial dashboard state
- add mobile Code IDE layout constraints to avoid horizontal overflow and collapsed panels

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/ide/ide-editor-extensions.test.ts src/components/ide/ide-explorer.test.ts src/components/ide/ide-keeper-work-panel.test.ts src/tab-refresh.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty
- pnpm run build
- Browser: desktop Code IDE shows scrollable tree, debug.ml OCaml highlighting, and keeper work task/runtime state
- Browser: mobile 390x844 has no horizontal overflow; explorer remains internally scrollable