### PR TITLE
feat(ide): RFC-0028 PR-ε — mount OverlayKeeperTrace in IDE shell editor pane

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -44,6 +44,7 @@ vi.mock('../../api/repositories', () => ({
 
 import { IdeShell } from './ide-shell'
 import { navigate, route } from '../../router'
+import { clearTraces, pushTrace } from './keeper-trace-store'
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button'))
@@ -74,6 +75,7 @@ describe('IdeShell', () => {
     vi.unstubAllGlobals()
     window.location.hash = ''
     route.value = { tab: 'overview', params: {}, postId: null }
+    clearTraces()
   })
 
   it('hydrates layer buttons from the route layers param', () => {
@@ -210,6 +212,48 @@ describe('IdeShell', () => {
     expect(buttonByText(container, 'Cascade').getAttribute('aria-pressed')).toBe('true')
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Cascade')
+  })
+
+  it('mounts the OverlayKeeperTrace overlay when the keeper-trace layer is toggled on', () => {
+    pushTrace({
+      id: 'shell-mount-evt-1',
+      tsMs: Date.parse('2026-05-06T01:00:00Z'),
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'shell-mount-evt-1',
+      line: null,
+    })
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', layers: 'keeper-trace' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const overlay = container.querySelector('[data-overlay="keeper-trace"]')
+    expect(overlay).not.toBeNull()
+  })
+
+  it('does not render the OverlayKeeperTrace overlay when the keeper-trace layer is off', () => {
+    pushTrace({
+      id: 'shell-mount-evt-2',
+      tsMs: Date.parse('2026-05-06T01:00:00Z'),
+      keeperName: 'scholar',
+      source: 'anchored-thread',
+      threadId: 'shell-mount-evt-2',
+      line: null,
+    })
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const overlay = container.querySelector('[data-overlay="keeper-trace"]')
+    expect(overlay).toBeNull()
   })
 
   it('opens the keeper shell drawer from the terminal route param', async () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -11,6 +11,7 @@ import { KeeperShellDrawer } from './keeper-shell-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
 import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { InspectorKeeperBDI, pinInspectorKeeper } from './inspector-keeper-bdi'
+import { OverlayKeeperTrace } from './overlay-keeper-trace'
 import { IdePersistencePanel } from './ide-persistence-panel'
 import { IdeBranchContextPanel } from './ide-branch-context-panel'
 import { navigate, route } from '../../router'
@@ -154,6 +155,7 @@ export function IdeShell() {
             diffRows=${coordinator.diffRows}
             onKeeperLineSelect=${pinInspectorKeeper}
           />
+          <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />
         </div>
         <div
           class="ide-plane-conversation"


### PR DESCRIPTION
## 목적

RFC-0028 의 user-visible surface 를 완성. PR-β (#13336) 가 만든 `OverlayKeeperTrace` 컴포넌트를 IDE shell editor pane 에 mount 하고, `active` prop 을 IDE_LAYERS 의 `activeLayers` URL state 와 연결. 이걸로 `keeper-trace` 토글이 실제로 chip 을 보여주거나 숨김 — 그동안은 store 에 events 만 흐르고 DOM 에는 chip 이 한 번도 못 도달했다.

## RFC-0028 family 진행 상황

| PR | 역할 | 상태 |
|----|------|------|
| PR-α (#13311) | keeper-trace store (binary-search / coalesce / retention) | MERGED |
| PR-β (#13336) | OverlayKeeperTrace component + IDE_LAYERS conflictsWith | MERGED |
| PR-δ-1 (#13375) | anchored-thread → trace bridge | MERGED |
| PR-δ-2 (#13384) | cascade-hop → trace bridge | MERGED |
| PR-δ-3 (#13396) | decision-log → trace bridge | MERGED |
| PR-δ-4 (#13404) | bdi-snapshot → trace bridge (4/4 producer) | MERGED |
| **PR-ε (본 PR)** | **OverlayKeeperTrace shell-mount + render gating** | **Draft** |

## Diff stat

- 2 files / +46 / -0
- 수정: `ide-shell.ts` (+2: import + 1줄 mount), `ide-shell.test.ts` (+44: import + 1 afterEach line + 2 mount tests)

## Mount 위치 결정

```ts
<div class="ide-plane-editor">
  <${IdeEditor} ... />
  <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />
</div>
```

| 후보 | 선택? | 근거 |
|------|------|------|
| **editor pane (본 PR)** | ✅ | RFC §5 의 chip 이 코드 옆에 표시되는 게 1차 사용 사례. `keeperFilter` 미지정 → 모든 keeper 표시 |
| inspector pane (single-keeper) | ❌ | PR-β 의 `keeperFilter` prop 이 inspector mount 용. follow-up PR 가능 — 본 PR scope 분리 |
| both (editor + inspector) | ❌ | 한 PR 에서 두 mount 동시 도입은 review burden 증가. 단계적 검증 |

`active=${activeLayers.has('keeper-trace')}` 가 false 일 때 `OverlayKeeperTrace` 가 line 153 에서 `if (!active) return null` — 항상 mount 되지만 store subscribe 만 한다. 토글 ON 시 즉시 chip 등장 (subscribe 가 이미 활성).

## Test additions

기존 `ide-shell.test.ts` 가 layer 토글 / URL 동기화 / command bar 등을 검증. RFC-0028 mount 검증 2 케이스 추가:

```ts
it('mounts the OverlayKeeperTrace overlay when the keeper-trace layer is toggled on', () => {
  pushTrace({ id: 'shell-mount-evt-1', tsMs: ..., source: 'anchored-thread', ... })
  route.value = { ..., params: { ..., layers: 'keeper-trace' } }
  render(h(IdeShell, {}), container)
  expect(container.querySelector('[data-overlay="keeper-trace"]')).not.toBeNull()
})

it('does not render the OverlayKeeperTrace overlay when the keeper-trace layer is off', () => {
  pushTrace({ ... })
  route.value = { ..., params: { ... } }  // no layers param
  render(h(IdeShell, {}), container)
  expect(container.querySelector('[data-overlay="keeper-trace"]')).toBeNull()
})
```

`pushTrace` 미리 호출 — store 에 1 event 가 있어야 overlay 가 chip 을 render. event 없으면 overlay 가 line 158 `if (filtered.length === 0) return null` 에 의해 null 반환 (mount-positive 케이스 false negative 방지).

`afterEach` 에 `clearTraces()` 추가 — test 간 store state 격리.

## Test results

```
Test Files  36 passed (36)
     Tests  248 passed (248)  -- src/components/ide broader sweep
```

PR-δ-4 머지 후 baseline (246/246 across 36) 와 비교 → +2 tests.

| 파일 | total | new (PR-ε) |
|------|------|------|
| `ide-shell.test.ts` | 11 | +2 (mount on / mount off) |
| 기타 35 IDE files | 237 | 회귀 0 |

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "OverlayKeeperTrace OR overlay-shell-mount OR 'RFC-0028 PR-ε'" --state open` → 본 PR 외 0
- `gh pr list --search "OverlayKeeperTrace" --state merged --limit 5` → #13336 (PR-β, OverlayKeeperTrace 정의), PR-δ-1/2/3/4 (모두 producer, mount 없음)
- `git fetch origin && git log origin/main --since=1h --oneline` → PR-δ-4 (#13404) 등 — rebased clean (다른 파일)
- `rg "OverlayKeeperTrace" dashboard/src/` → 본 PR 신규 mount + 기존 component/test

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/components/ide/` → **248/248 pass** across 36 files
- ESLint 본 PR 변경 파일 → **0 error / 0 warning**

## Rollback plan

2-file revert. mount + 2 tests 만 drop. component / store / 4 producer / RFC-0027 family 모두 unchanged.

## Why 본 PR 가 RFC-0028 의 마지막 gate

지금까지 5 PR (PR-α + PR-β + PR-δ-1..4) 모두 main 에 도달했지만, OverlayKeeperTrace 가 IDE shell 어디에도 mount 되지 않아 user 가 chip 을 볼 수 없었다. store 에 events 가 흘러도 DOM 에 도달 못 함. 본 PR 가 mount 한 줄 + render gating 2 tests 로 user-visible surface 첫 등장:

1. `?layers=keeper-trace` URL 파라미터 또는 toolbar 의 "Trace" 버튼 클릭
2. → `activeLayers.has('keeper-trace') === true`
3. → `OverlayKeeperTrace.active === true`
4. → store events 가 chip 으로 render

RFC-0028 의 user surface complete.

## RFC waiver

agent_delegation 영역 변경 없음. behavior-additive (mount 추가, render gating 검증).

`RFC-WAIVED: behavior-additive mount with explicit URL/layer-toggle gating. Render gating verified by added tests. RFC-0028 PR-α (#13311), PR-β (#13336), and PR-δ-1..4 (#13375 / #13384 / #13396 / #13404) already merged.`

## Related

- #13311 (RFC-0028 PR-α store) — store 가 events 보유
- #13336 (RFC-0028 PR-β overlay) — 본 PR 가 mount 하는 component, IDE_LAYERS 의 keeper-trace toggle 정의
- #13375 / #13384 / #13396 / #13404 (PR-δ-1..4) — 4 producer 가 store 에 events 발화
- #13293 (RFC-0028 spec Draft) — §5 stitched chip surface

## Follow-up

- **(Optional) inspector-side mount**: `<OverlayKeeperTrace keeperFilter=${keeperName}>` 를 InspectorKeeperBDI 옆에 추가 — single-keeper rail, RFC-0028 PR-β 의 `keeperFilter` prop 이 그 용도
- RFC-0028 spec (#13293) 머지 후 amend PR (PR family 완성 인용)
- (Optional) `?layers=` 의 cascade vs keeper-trace conflictsWith UX 확인 — PR-β 가 conflictsWith 정의했지만 IdeToolbar 의 mutual exclusion behavior 가 의도대로 작동하는지 일반 use case 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
