### PR TITLE
fix(dashboard): add IDE find overlay

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -57,4 +57,18 @@ describe('cockpit entrypoint registry', () => {
       params: { section: 'runtime', view: 'heuristics', focus: 'log' },
     })
   })
+
+  it('routes the covered IDE search entrypoint directly to the find panel', () => {
+    const entrypoint = COCKPIT_ENTRYPOINTS.find(entry => entry.aliases.includes('find'))
+
+    expect(entrypoint?.coverage).toBe('covered')
+    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'search' })).toEqual({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', find: 'open' },
+    })
+    expect(cockpitTargetForParams({ mode: 'CODE', tab: 'find' })).toEqual({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', find: 'open' },
+    })
+  })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -93,7 +93,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'ide', aliases: ['review', 'pr-thread'], target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } }, coverage: 'partial' },
   { mode: 'ide', aliases: ['merge', 'split', 'split-diff'], target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } }, coverage: 'partial' },
   { mode: 'ide', aliases: ['graph', 'git-graph'], target: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } }, coverage: 'partial' },
-  { mode: 'ide', aliases: ['search', 'find'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source', focus: 'search' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['search', 'find'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source', find: 'open' } }, coverage: 'covered' },
 ]
 
 const ENTRYPOINT_TARGETS = new Map<string, CockpitRouteTarget>()

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { waitFor } from '@testing-library/preact'
-import { IdeEditor } from './ide-editor'
+import { fireEvent, waitFor } from '@testing-library/preact'
+import { currentFileFindMatches, IdeEditor } from './ide-editor'
 import { createCodeDocumentStore } from './code-document-store'
 import { createKeeperLineOwnershipStore } from './keeper-line-ownership-store'
 
@@ -49,6 +49,85 @@ describe('IdeEditor', () => {
     await waitFor(() => {
       expect(container.textContent).toContain('3 lines')
       expect(container.querySelector('.cm-content')?.textContent).toContain('masc-mcp')
+    })
+  })
+
+  it('finds current-file matches with case and whole-word options', () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\nconst RuntimeValue = runtime + 1\n',
+    })
+
+    expect(
+      currentFileFindMatches(
+        documentStore.lines(),
+        'runtime',
+        { caseSensitive: false, wholeWord: false },
+      ).map(match => match.line),
+    ).toEqual([1, 2])
+
+    expect(
+      currentFileFindMatches(
+        documentStore.lines(),
+        'runtime',
+        { caseSensitive: true, wholeWord: false },
+      ).map(match => match.line),
+    ).toEqual([1, 2])
+
+    expect(
+      currentFileFindMatches(
+        documentStore.lines(),
+        'Runtime',
+        { caseSensitive: true, wholeWord: false },
+      ).map(match => match.line),
+    ).toEqual([2])
+
+    expect(
+      currentFileFindMatches(
+        documentStore.lines(),
+        'runtime',
+        { caseSensitive: false, wholeWord: true },
+      ).map(match => match.line),
+    ).toEqual([1, 2])
+  })
+
+  it('renders the current-file find panel and cycles matches', async () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\nconst other = 2\nreturn runtime\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [],
+        findOpen: true,
+      }),
+      container,
+    )
+
+    const input = container.querySelector<HTMLInputElement>('[aria-label="Find query"]')
+    expect(input).not.toBeNull()
+    fireEvent.input(input!, { target: { value: 'runtime' } })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="ide-find-status"]')?.textContent)
+        .toContain('1 of 2 matches')
+    })
+    expect(container.querySelector('[data-testid="ide-find-results"]')?.textContent)
+      .toContain('return runtime')
+
+    const next = container.querySelector<HTMLButtonElement>('[aria-label="Next match"]')
+    expect(next).not.toBeNull()
+    fireEvent.click(next!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="ide-find-status"]')?.textContent)
+        .toContain('2 of 2 matches')
     })
   })
 })

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -1,9 +1,10 @@
 import { html } from 'htm/preact'
-import { useRef, useEffect, useState } from 'preact/hooks'
+import { useRef, useEffect, useMemo, useState } from 'preact/hooks'
 import { EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import type {
   CodeDocumentStore,
+  CodeDocumentLine,
 } from './code-document-store'
 import {
   type KeeperLineOwnershipStore,
@@ -37,7 +38,23 @@ interface IdeEditorProps {
   readonly documentStore: CodeDocumentStore
   readonly ownershipStore: KeeperLineOwnershipStore
   readonly diffRows: () => ReadonlyArray<UnifiedDiffRow>
+  readonly findOpen?: boolean
+  readonly onFindOpen?: () => void
+  readonly onFindClose?: () => void
   readonly onKeeperLineSelect?: (keeperId: string, line: number) => void
+}
+
+export interface FindOptions {
+  readonly caseSensitive: boolean
+  readonly wholeWord: boolean
+}
+
+export interface FindMatch {
+  readonly line: number
+  readonly text: string
+  readonly before: string
+  readonly match: string
+  readonly after: string
 }
 
 const EMPTY_ACTIVE_LAYERS: ReadonlySet<string> = new Set()
@@ -57,6 +74,9 @@ export function IdeEditor({
   documentStore,
   ownershipStore,
   diffRows,
+  findOpen = false,
+  onFindOpen,
+  onFindClose,
   onKeeperLineSelect,
 }: IdeEditorProps) {
   const [, forceRender] = useState(0)
@@ -70,6 +90,7 @@ export function IdeEditor({
   const keepers = ownershipStore.knownKeepers()
   const activeLayerKinds = activeLayersInDisplayOrder(activeLayers)
   const currentDiffRows = diffRows()
+  const gridTemplateRows = editorGridRows(activeLayerKinds.length > 0, findOpen)
 
   return html`
     <div
@@ -77,7 +98,7 @@ export function IdeEditor({
       aria-label="에디터 (code document store + RFC 0019 ownership)"
       style=${{
         display: 'grid',
-        gridTemplateRows: activeLayerKinds.length > 0 ? 'auto auto 1fr' : 'auto 1fr',
+        gridTemplateRows,
         background: 'var(--color-bg-page)',
         minHeight: 0,
       }}
@@ -99,9 +120,34 @@ export function IdeEditor({
         <span style=${{ marginLeft: 'auto' }}>
           ${lines.length} lines · ownership · ${keepers.length} keepers · ${activeLayerKinds.length} layers
         </span>
+        ${onFindOpen || onFindClose ? html`
+          <button
+            type="button"
+            aria-label=${findOpen ? 'Close find panel' : 'Open find panel'}
+            aria-pressed=${findOpen ? 'true' : 'false'}
+            onClick=${() => findOpen ? onFindClose?.() : onFindOpen?.()}
+            style=${{
+              height: '24px',
+              padding: '0 var(--sp-2)',
+              color: findOpen ? 'var(--color-accent-fg)' : 'var(--color-fg-muted)',
+              background: findOpen ? 'var(--color-bg-elevated)' : 'transparent',
+              border: '1px solid var(--color-border-default)',
+              borderRadius: 'var(--r-1)',
+              font: 'var(--type-eyebrow)',
+              cursor: 'pointer',
+            }}
+          >Find</button>
+        ` : null}
       </div>
       ${activeLayerKinds.length > 0
         ? LayerOverlaySummary(activeLayerKinds, ownership, keepers)
+        : null}
+      ${findOpen
+        ? html`<${IdeFindPanel}
+            lines=${lines}
+            filePath=${document.file_path}
+            onClose=${onFindClose}
+          />`
         : null}
       ${activeView === 'split-diff'
         ? SplitDiffView(currentDiffRows)
@@ -117,6 +163,274 @@ export function IdeEditor({
       }
     </div>
   `
+}
+
+// ── Find overlay ─────────────────────────────────────────────────
+
+function IdeFindPanel({
+  lines,
+  filePath,
+  onClose,
+}: {
+  readonly lines: ReadonlyArray<CodeDocumentLine>
+  readonly filePath: string
+  readonly onClose?: () => void
+}) {
+  const [query, setQuery] = useState('')
+  const [caseSensitive, setCaseSensitive] = useState(false)
+  const [wholeWord, setWholeWord] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const matches = useMemo(
+    () => currentFileFindMatches(lines, query, { caseSensitive, wholeWord }),
+    [caseSensitive, lines, query, wholeWord],
+  )
+
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [caseSensitive, filePath, query, wholeWord])
+
+  useEffect(() => {
+    if (activeIndex < matches.length || matches.length === 0) return
+    setActiveIndex(matches.length - 1)
+  }, [activeIndex, matches.length])
+
+  const activeOrdinal = matches.length > 0 ? activeIndex + 1 : 0
+  const canMove = matches.length > 1
+  const move = (delta: number): void => {
+    if (matches.length === 0) return
+    setActiveIndex(index => (index + delta + matches.length) % matches.length)
+  }
+
+  return html`
+    <div
+      role="search"
+      aria-label="Find in current file"
+      data-testid="ide-find-panel"
+      style=${{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr)',
+        alignItems: 'center',
+        gap: 'var(--sp-2)',
+        boxSizing: 'border-box',
+        width: '100%',
+        maxWidth: 'calc(100vw - 20px)',
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        background: 'var(--color-bg-surface)',
+        color: 'var(--color-fg-muted)',
+        font: 'var(--type-body)',
+        fontSize: 'var(--fs-11)',
+      }}
+    >
+      <div
+        style=${{
+          gridColumn: '1 / -1',
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 'var(--sp-1)',
+          minWidth: 0,
+        }}
+      >
+        <input
+          type="search"
+          aria-label="Find query"
+          placeholder="Find in current file"
+          value=${query}
+          onInput=${(event: Event) => setQuery((event.target as HTMLInputElement).value)}
+          style=${{
+            flex: '1 1 100px',
+            minWidth: 0,
+            maxWidth: '280px',
+            height: '28px',
+            font: 'var(--type-body)',
+            fontSize: 'var(--fs-11)',
+            color: 'var(--color-fg-primary)',
+            background: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-border-default)',
+            borderRadius: 'var(--r-1)',
+            padding: '0 var(--sp-2)',
+            outline: 'none',
+          }}
+        />
+        <${ToggleButton}
+          label="Aa"
+          pressed=${caseSensitive}
+          onClick=${() => setCaseSensitive(value => !value)}
+        />
+        <${ToggleButton}
+          label="Word"
+          pressed=${wholeWord}
+          onClick=${() => setWholeWord(value => !value)}
+        />
+        <button
+          type="button"
+          aria-label="Previous match"
+          disabled=${!canMove}
+          onClick=${() => move(-1)}
+          style=${findButtonStyle(!canMove)}
+        >Prev</button>
+        <button
+          type="button"
+          aria-label="Next match"
+          disabled=${!canMove}
+          onClick=${() => move(1)}
+          style=${findButtonStyle(!canMove)}
+        >Next</button>
+        ${onClose ? html`
+          <button
+            type="button"
+            aria-label="Close find panel"
+            onClick=${onClose}
+            style=${findButtonStyle(false)}
+          >Close</button>
+        ` : null}
+      </div>
+      <div
+        role="status"
+        data-testid="ide-find-status"
+        style=${{
+          gridColumn: '1 / -1',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 'var(--sp-2)',
+          color: 'var(--color-fg-muted)',
+          minWidth: 0,
+        }}
+      >
+        <span>${activeOrdinal} of ${matches.length} matches</span>
+        <span
+          style=${{
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >${filePath}</span>
+      </div>
+      ${query.trim() !== '' && matches.length > 0
+        ? html`
+            <ol
+              role="list"
+              aria-label="Find matches"
+              data-testid="ide-find-results"
+              style=${{
+                gridColumn: '1 / -1',
+                display: 'grid',
+                gap: '2px',
+                maxHeight: '112px',
+                overflow: 'auto',
+                margin: 0,
+                padding: 0,
+                listStyle: 'none',
+              }}
+            >
+              ${matches.map((item, index) => html`
+                <li
+                  role="listitem"
+                  aria-current=${index === activeIndex ? 'true' : undefined}
+                  style=${{
+                    display: 'grid',
+                    gridTemplateColumns: '48px minmax(0, 1fr)',
+                    gap: 'var(--sp-2)',
+                    alignItems: 'baseline',
+                    padding: '2px var(--sp-2)',
+                    color: index === activeIndex ? 'var(--color-fg-primary)' : 'var(--color-fg-secondary)',
+                    background: index === activeIndex ? 'var(--color-bg-elevated)' : 'transparent',
+                    borderRadius: 'var(--r-1)',
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                >
+                  <span style=${{ color: 'var(--color-fg-muted)' }}>${item.line}</span>
+                  <code style=${{ minWidth: 0, overflowWrap: 'anywhere', whiteSpace: 'pre-wrap' }}>
+                    ${item.before}<mark>${item.match}</mark>${item.after}
+                  </code>
+                </li>
+              `)}
+            </ol>
+          `
+        : null}
+    </div>
+  `
+}
+
+function ToggleButton({
+  label,
+  pressed,
+  onClick,
+}: {
+  readonly label: string
+  readonly pressed: boolean
+  readonly onClick: () => void
+}) {
+  return html`
+    <button
+      type="button"
+      aria-pressed=${pressed ? 'true' : 'false'}
+      onClick=${onClick}
+      style=${{
+        height: '28px',
+        padding: '0 var(--sp-2)',
+        color: pressed ? 'var(--color-accent-fg)' : 'var(--color-fg-muted)',
+        background: pressed ? 'var(--color-bg-elevated)' : 'transparent',
+        border: '1px solid var(--color-border-default)',
+        borderRadius: 'var(--r-1)',
+        font: 'var(--type-eyebrow)',
+        cursor: 'pointer',
+      }}
+    >${label}</button>
+  `
+}
+
+function findButtonStyle(disabled: boolean): Record<string, string | number> {
+  return {
+    height: '28px',
+    padding: '0 var(--sp-2)',
+    color: disabled ? 'var(--color-fg-disabled)' : 'var(--color-fg-muted)',
+    background: 'transparent',
+    border: '1px solid var(--color-border-default)',
+    borderRadius: 'var(--r-1)',
+    font: 'var(--type-eyebrow)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+  }
+}
+
+export function currentFileFindMatches(
+  lines: ReadonlyArray<CodeDocumentLine>,
+  query: string,
+  options: FindOptions,
+): ReadonlyArray<FindMatch> {
+  const needle = query.trim()
+  if (needle === '') return []
+
+  const flags = options.caseSensitive ? '' : 'i'
+  const pattern = options.wholeWord
+    ? `\\b${escapeRegExp(needle)}\\b`
+    : escapeRegExp(needle)
+  const regex = new RegExp(pattern, flags)
+  const matches: FindMatch[] = []
+
+  for (const line of lines) {
+    const match = regex.exec(line.text)
+    if (!match) continue
+    matches.push({
+      line: line.num,
+      text: line.text,
+      before: line.text.slice(0, match.index),
+      match: match[0],
+      after: line.text.slice(match.index + match[0].length),
+    })
+    if (matches.length >= 50) break
+  }
+
+  return matches
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 // ── CM6 read-only editor ──────────────────────────────────────────
@@ -315,6 +629,14 @@ function LayerOverlaySummary(
 }
 
 // ── Helpers ───────────────────────────────────────────────────────
+
+function editorGridRows(hasLayerSummary: boolean, findOpen: boolean): string {
+  const rows = ['auto']
+  if (hasLayerSummary) rows.push('auto')
+  if (findOpen) rows.push('auto')
+  rows.push('1fr')
+  return rows.join(' ')
+}
 
 function activeLayersInDisplayOrder(activeLayers: ReadonlySet<string>): ReadonlyArray<IdeLayerKind> {
   return IDE_LAYER_ORDER.filter(kind => activeLayers.has(kind))

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -165,6 +165,24 @@ describe('IdeShell', () => {
     expect(route.value.params.terminal).toBe('open')
   })
 
+  it('opens the current-file find panel from the IDE command bar', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    const input = ideCommandInput(container)
+    input.value = 'find'
+    fireEvent.input(input)
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull())
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(route.value.params.find).toBe('open')
+    expect(container.querySelector('[data-testid="ide-find-panel"]')).not.toBeNull()
+  })
+
   it('renders the Cascade layer button and toggles it via URL', () => {
     route.value = {
       tab: 'code',

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -75,6 +75,7 @@ export function IdeShell() {
   const terminalOpen =
     route.value.params.terminal === 'open'
     || Boolean(route.value.params.keeper?.trim())
+  const findOpen = route.value.params.find === 'open'
   const terminalKeeper = keeperFromRoute()
 
   useEffect(() => {
@@ -99,6 +100,25 @@ export function IdeShell() {
       terminal: 'open',
     }
     if (terminalKeeper) nextParams.keeper = terminalKeeper
+    navigate('code', nextParams)
+  }
+
+  const handleFindOpen = () => {
+    navigate('code', {
+      ...route.value.params,
+      section: 'ide-shell',
+      view: activeView,
+      find: 'open',
+    })
+  }
+
+  const handleFindClose = () => {
+    const nextParams: Record<string, string> = {
+      ...route.value.params,
+      section: 'ide-shell',
+      view: activeView,
+    }
+    delete nextParams.find
     navigate('code', nextParams)
   }
 
@@ -127,6 +147,7 @@ export function IdeShell() {
         onViewChange=${handleViewChange}
         onLayersChange=${handleLayersChange}
         onTerminalOpen=${handleTerminalOpen}
+        onFindOpen=${handleFindOpen}
       />
       <div
         class="ide-plane-grid"
@@ -153,6 +174,9 @@ export function IdeShell() {
             documentStore=${coordinator.documentStore}
             ownershipStore=${coordinator.ownershipStore}
             diffRows=${coordinator.diffRows}
+            findOpen=${findOpen}
+            onFindOpen=${handleFindOpen}
+            onFindClose=${handleFindClose}
             onKeeperLineSelect=${pinInspectorKeeper}
           />
           <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -45,6 +45,7 @@ interface IdeToolbarProps {
   readonly onViewChange: (id: ViewTab) => void
   readonly onLayersChange: (active: ReadonlySet<string>) => void
   readonly onTerminalOpen?: () => void
+  readonly onFindOpen?: () => void
 }
 
 export function IdeToolbar({
@@ -53,6 +54,7 @@ export function IdeToolbar({
   onViewChange,
   onLayersChange,
   onTerminalOpen,
+  onFindOpen,
 }: IdeToolbarProps) {
   const controller = useMemo(() => {
     const next = createLayeredOverlay(IDE_LAYERS)
@@ -89,6 +91,14 @@ export function IdeToolbar({
           title: 'Open Keeper Terminal',
           keywords: 'terminal shell keeper output',
           handler: onTerminalOpen,
+        }]
+      : []),
+    ...(onFindOpen
+      ? [{
+          id: 'find-open',
+          title: 'Find in Current File',
+          keywords: 'find search current file editor match',
+          handler: onFindOpen,
         }]
       : []),
   ]


### PR DESCRIPTION

## Summary

- Adds a route-backed current-file find panel to the Code IDE editor surface (`find=open`).
- Wires the IDE command bar command `Find in Current File` and the editor header `Find` button to the same route state.
- Routes the cockpit IDE `search` / `find` entrypoint directly to the implemented `find=open` panel and marks that E5 slice covered.
- Adds current-file matching helpers with case-sensitive and whole-word toggles, result snippets, active match cycling, and focused regression tests.

## Artifact Context

- E5 artifact references include `IxSearch` / `IxFindReplace` in `MASC Cockpit (3)/design-system/preview/cb-group-k.jsx`.
- The IDE plane artifact includes a `search` mode in `MASC Cockpit (3)/cockpit-kit/Planes.jsx`.
- This PR implements the current-file find overlay slice. Replace is intentionally not included because the current CodeMirror editor surface is read-only.

## Validation

- `pnpm --dir dashboard exec eslint src/components/ide/ide-toolbar.ts src/components/ide/ide-shell.ts src/components/ide/ide-shell.test.ts src/components/ide/ide-editor.ts src/components/ide/ide-editor.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/ide/ide-editor.test.ts src/components/ide/ide-shell.test.ts src/cockpit-entrypoints.test.ts`
- `pnpm --dir dashboard run lint` (passes with existing unrelated warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes with existing dynamic-import / large-chunk warnings)
- `git diff --check`
- Browser verification via `agent-browser` at `http://127.0.0.1:5180/dashboard/#code?section=ide-shell&view=source&find=open`
  - command bar opens the panel and adds `find=open`
  - match query `question` returns `1 of 6 matches`
  - `Next match` advances to `2 of 6 matches`
  - close removes `find=open`
  - desktop screenshot: `/tmp/masc-ide-find-overlay-final.png`
  - mobile screenshot: `/tmp/masc-ide-find-overlay-mobile-fixed2.png`
- Browser verification via `agent-browser` at `http://localhost:5174/dashboard/#code?section=ide-shell&view=source&find=open`
  - cockpit search/find target route opens the IDE with the find panel mounted
  - screenshot: `/tmp/masc-ide-find-entrypoint-0506.png`

Note: Vitest still emits existing localhost:3000 `ECONNREFUSED` / socket noise from dashboard test setup, but the focused test command exits 0.
