### PR TITLE
fix(keeper): expose web search to keeper tool surface

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -70,7 +70,7 @@ tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_she
 # Tools allowed on the keeper's last turn (safety constraint).
 # On last turn, visible tools are intersected with this set.
 [groups.last_turn_safe]
-tools = ["keeper_board_post", "keeper_board_comment", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_broadcast", "keeper_task_done"]
+tools = ["keeper_board_post", "keeper_board_comment", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_tool_search", "keeper_broadcast", "keeper_task_done", "masc_web_search"]
 
 # Optional tools that require explicit opt-in via also_allow.
 # Excluded from all presets by default; a keeper must list them in also_allow.
@@ -197,7 +197,8 @@ email_pattern = "{name}@masc.local"
 
 [presets.minimal]
 groups = ["base"]
-masc_tools = ["masc_status", "masc_tool_help"]
+masc_groups = ["essential"]
+masc_tools = ["masc_tool_help"]
 
 # Social: persona keepers that live on the board + web search.
 # ~15 tools. Optimal for 9B tool selection accuracy.

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -90,11 +90,12 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | Workflow | Primary tools |
 |----------|---------------|
 | 의견 내기 / 토론 참여 | `keeper_board_post`, `keeper_board_comment` |
+| 최신 정보 / 외부 자료 확인 | `masc_web_search` (also exposed to model clients as `WebSearch`) |
 | 찬성 / 반대 신호 | `keeper_board_vote`, `masc_case_brief_submit` (`stance = support|oppose|neutral`) |
 | 거버넌스 의견 제출 | `masc_petition_submit`, `masc_case_brief_submit`, `masc_case_status`, `masc_governance_feed` |
 | 코드 작성 / 수정 | `masc_worktree_create` -> `masc_code_write` / `masc_code_edit` / `masc_code_git` |
 | 테스트 실행 | `masc_code_shell` (worktree `cwd` required) |
-| GitHub 이슈 작성 | `keeper_github` with `gh issue create ...` |
+| GitHub PR / 이슈 작업 | `keeper_preflight_check`, `keeper_pr_list`, `keeper_pr_status`, `keeper_pr_create` (draft-only), plus `keeper_shell op=gh` when repo context is bound |
 
 ## Research Profile Additions
 

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -734,6 +734,7 @@ let prepare_agent_setup
     in
     let safe_last_turn_tools =
       Keeper_tool_policy.last_turn_safe_tool_names ()
+      |> Keeper_tool_alias.expand_universe
     in
     let all_allowed =
       if is_last_turn && required_tool_names = [] then

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -19,6 +19,7 @@ let aliases : (string * string) list =
     "Grep", "keeper_shell";   (* op=rg routed at dispatch layer, Phase A.4 *)
     "Read", "keeper_fs_read";
     "Shell", "keeper_bash";   (* LLM occasionally hallucinates "Shell" for bash *)
+    "WebSearch", "masc_web_search";
     "Write", "keeper_fs_edit"; (* create-vs-update collapsed at dispatch layer *)
   ]
 
@@ -26,13 +27,15 @@ let aliases : (string * string) list =
    (#8963 follow-up) added Edit/Write/Grep once their input adapters
    landed: Edit goes through the new keeper_fs_edit mode=patch path,
    Write maps cleanly to mode=overwrite, Grep synthesizes
-   keeper_shell op=rg. *)
+   keeper_shell op=rg. WebSearch is a read-only alias over the existing
+   masc_web_search schema. *)
 let oas_dual_register : (string * string) list =
   [
     "Bash", "keeper_bash";
     "Edit", "keeper_fs_edit";
     "Grep", "keeper_shell";
     "Read", "keeper_fs_read";
+    "WebSearch", "masc_web_search";
     "Write", "keeper_fs_edit";
   ]
 
@@ -40,7 +43,7 @@ let oas_dual_register : (string * string) list =
    check should not nuke a turn solely because these appeared — instead a
    teaching tool_result tells the LLM what surface to use. RFC-0006 §3.1. *)
 let hallucinated_builtins =
-  [ "Agent"; "Skill"; "WebSearch"; "WebFetch"; "TodoWrite"; "NotebookEdit" ]
+  [ "Agent"; "Skill"; "WebFetch"; "TodoWrite"; "NotebookEdit" ]
 
 let public_to_internal_tbl =
   let t = Hashtbl.create (List.length aliases) in
@@ -256,11 +259,23 @@ let grep_public_schema =
          schema parity.";
     ]
 
+(* Anthropic Code "WebSearch" schema. Maps directly to masc_web_search;
+   the payload already uses query/limit. *)
+let web_search_public_schema =
+  object_schema ~required:[ "query" ]
+    [
+      property "query" "string"
+        "Search query text for current public web information.";
+      property "limit" "integer"
+        "Maximum number of results to return (default 5, max 10).";
+    ]
+
 let public_input_schema = function
   | "Bash" -> Some bash_public_schema
   | "Edit" -> Some edit_public_schema
   | "Grep" -> Some grep_public_schema
   | "Read" -> Some read_public_schema
+  | "WebSearch" -> Some web_search_public_schema
   | "Write" -> Some write_public_schema
   | _ -> None
 
@@ -378,6 +393,7 @@ let translate_input ~public input =
   | "Edit" -> translate_edit_input input
   | "Grep" -> translate_grep_input input
   | "Read" -> translate_read_input input
+  | "WebSearch" -> input
   | "Write" -> translate_write_input input
   | _ -> input
 

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -10,11 +10,13 @@
     [public_name] is a known alias. Returns [None] otherwise.
 
     Examples: [to_internal "Bash" = Some "keeper_bash"],
+    [to_internal "WebSearch" = Some "masc_web_search"],
     [to_internal "Skill" = None] (no cognate). *)
 val to_internal : string -> string option
 
 (** [to_public internal_name] returns the LLM-facing alias for an
-    internal [keeper_*] tool. Falls back to [internal_name] verbatim
+    internal [keeper_*] or keeper-visible [masc_*] tool. Falls back
+    to [internal_name] verbatim
     when the tool has no Anthropic Code cognate (board/task/etc.) or
     when only part of the internal tool has a public alias, such as
     [Grep] for [keeper_shell op=rg]. *)
@@ -34,7 +36,7 @@ val canonicalize_observed_with_telemetry : string list -> string list
 
 (** [hallucinated_builtins] lists the public names from the Anthropic
     Code surface that have **no** cognate in the keeper surface
-    (e.g. [Skill], [Agent], [WebSearch]). These should be flagged with
+    (e.g. [Skill], [Agent], [WebFetch]). These should be flagged with
     a teaching message rather than nuking the turn. *)
 val hallucinated_builtins : string list
 
@@ -59,7 +61,8 @@ val all_aliases : unit -> (string * string) list
 
     Phase A.2: [Bash], [Read].
     Phase A.4: [Edit] (via new keeper_fs_edit mode=patch), [Write]
-    (via mode=overwrite), [Grep] (synthesized as keeper_shell op=rg). *)
+    (via mode=overwrite), [Grep] (synthesized as keeper_shell op=rg).
+    WebSearch maps directly to [masc_web_search]. *)
 val oas_dual_register_aliases : unit -> (string * string) list
 
 (** [public_input_schema public_name] returns the LLM-facing JSON schema

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -54,6 +54,10 @@ let hints =
     ; call = "`keeper_bash` { cmd: \"<single shell command>\" }"
     ; description = "run one shell command in the keeper workspace"
     }
+  ; { name = "masc_web_search"
+    ; call = "`masc_web_search` { query: \"<current-info query>\", limit: 5 }"
+    ; description = "look up current public context before time-sensitive claims"
+    }
   ; { name = "masc_worktree_create"
     ; call = "`masc_worktree_create` { task_id: \"<task-id>\", repo_name: \"masc-mcp\" }"
     ; description = "create a repo worktree before code edits"

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -339,7 +339,9 @@ let last_turn_safe_tool_names () =
   resolve_policy_group
     ~fallback:[ "keeper_board_post"; "keeper_board_comment";
                 "keeper_context_status"; "extend_turns";
-                "keeper_time_now"; "keeper_broadcast" ]
+                "keeper_time_now"; "keeper_tool_search";
+                "keeper_broadcast"; "keeper_task_done";
+                "masc_web_search" ]
     "last_turn_safe"
 
 let explicit_optional_candidate_tool_names (meta : keeper_meta) =

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -17,7 +17,9 @@ let test_known_aliases_resolve () =
   Alcotest.(check (option string)) "Write -> keeper_fs_edit"
     (Some "keeper_fs_edit") (Alias.to_internal "Write");
   Alcotest.(check (option string)) "Grep -> keeper_shell"
-    (Some "keeper_shell") (Alias.to_internal "Grep")
+    (Some "keeper_shell") (Alias.to_internal "Grep");
+  Alcotest.(check (option string)) "WebSearch -> masc_web_search"
+    (Some "masc_web_search") (Alias.to_internal "WebSearch")
 
 let test_unknown_returns_none () =
   Alcotest.(check (option string)) "Skill has no cognate"
@@ -36,6 +38,8 @@ let test_to_public_round_trip () =
     "Read" (Alias.to_public "keeper_fs_read");
   Alcotest.(check string) "keeper_shell stays internal"
     "keeper_shell" (Alias.to_public "keeper_shell");
+  Alcotest.(check string) "masc_web_search -> WebSearch"
+    "WebSearch" (Alias.to_public "masc_web_search");
   (* Edit/Write collapse: first occurrence wins for stability *)
   Alcotest.(check string) "keeper_fs_edit -> Edit (first wins)"
     "Edit" (Alias.to_public "keeper_fs_edit")
@@ -49,7 +53,15 @@ let test_to_public_pass_through () =
 
 let test_canonicalize_observed () =
   let input =
-    [ "Bash"; "keeper_board_post"; "masc_board_post"; "Read"; "Skill"; "Write" ]
+    [
+      "Bash";
+      "keeper_board_post";
+      "masc_board_post";
+      "Read";
+      "Skill";
+      "WebSearch";
+      "Write";
+    ]
   in
   let expected =
     [
@@ -58,6 +70,7 @@ let test_canonicalize_observed () =
       "keeper_board_post";
       "keeper_fs_read";
       "Skill";
+      "masc_web_search";
       "keeper_fs_edit";
     ]
   in
@@ -95,8 +108,10 @@ let test_hallucinated_builtins () =
     true (Alias.is_hallucinated_builtin "Skill");
   Alcotest.(check bool) "Agent is hallucinated"
     true (Alias.is_hallucinated_builtin "Agent");
-  Alcotest.(check bool) "WebSearch is hallucinated"
-    true (Alias.is_hallucinated_builtin "WebSearch");
+  Alcotest.(check bool) "WebSearch is NOT hallucinated (has cognate)"
+    false (Alias.is_hallucinated_builtin "WebSearch");
+  Alcotest.(check bool) "WebFetch is hallucinated"
+    true (Alias.is_hallucinated_builtin "WebFetch");
   Alcotest.(check bool) "Bash is NOT hallucinated (has cognate)"
     false (Alias.is_hallucinated_builtin "Bash");
   Alcotest.(check bool) "keeper_bash is NOT hallucinated"
@@ -113,7 +128,7 @@ let test_no_overlap_alias_and_hallucinated () =
 
 let test_alias_table_is_stable () =
   let pairs = Alias.all_aliases () in
-  Alcotest.(check int) "six canonical aliases" 6 (List.length pairs);
+  Alcotest.(check int) "seven canonical aliases" 7 (List.length pairs);
   (* Round-trip: every alias should round-trip via to_internal then to_public,
      except where collapse happens (Write -> keeper_fs_edit -> Edit). *)
   List.iter
@@ -127,11 +142,11 @@ let test_alias_table_is_stable () =
 
 (** Mirrors the call sequence in [keeper_agent_run.ml:1875] after
     canonicalization is applied. Pins the contract: a turn whose only
-    tool calls are Anthropic Code aliases (Bash/Read/Edit/Grep/Write)
+    tool calls are Anthropic Code aliases (Bash/Read/Edit/Grep/WebSearch/Write)
     must NOT produce any unexpected names. *)
 let allowed_keeper_surface =
   [ "keeper_bash"; "keeper_fs_read"; "keeper_fs_edit"; "keeper_shell";
-    "keeper_board_post"; "extend_turns" ]
+    "keeper_board_post"; "masc_web_search"; "extend_turns" ]
 
 let test_pure_alias_turn_no_longer_unexpected () =
   let observed = [ "Bash" ] in
@@ -146,7 +161,7 @@ let test_pure_alias_turn_no_longer_unexpected () =
     [] unexpected
 
 let test_mixed_alias_and_internal_no_unexpected () =
-  let observed = [ "Read"; "keeper_board_post"; "Edit" ] in
+  let observed = [ "Read"; "keeper_board_post"; "Edit"; "WebSearch" ] in
   let canonical = Alias.canonicalize_observed observed in
   let unexpected =
     Disclosure.unexpected_tool_names
@@ -194,8 +209,8 @@ let yojson_field name j =
 let test_oas_dual_register_subset () =
   let pairs = Alias.oas_dual_register_aliases () in
   let names = List.map fst pairs in
-  Alcotest.(check (list string)) "Phase A.4 dual-reg covers Bash/Edit/Grep/Read/Write"
-    [ "Bash"; "Edit"; "Grep"; "Read"; "Write" ] names;
+  Alcotest.(check (list string)) "dual-reg covers shell/fs/search aliases"
+    [ "Bash"; "Edit"; "Grep"; "Read"; "WebSearch"; "Write" ] names;
   (* Every entry must also appear in the full alias table. *)
   let full = List.map fst (Alias.all_aliases ()) in
   List.iter
@@ -211,7 +226,7 @@ let test_public_input_schema_present () =
       Alcotest.(check bool)
         (Printf.sprintf "%s has tailored schema" name)
         true (Option.is_some (Alias.public_input_schema name)))
-    [ "Bash"; "Edit"; "Grep"; "Read"; "Write" ];
+    [ "Bash"; "Edit"; "Grep"; "Read"; "WebSearch"; "Write" ];
   Alcotest.(check bool) "unknown public name has no schema"
     true (Option.is_none (Alias.public_input_schema "Nope"))
 
@@ -313,6 +328,23 @@ let test_grep_schema_uses_anthropic_fields () =
     true (Option.is_some (yojson_field "pattern" props));
   Alcotest.(check bool) "Grep schema does not expose internal 'op' to LLM"
     true (Option.is_none (yojson_field "op" props))
+
+let test_web_search_schema_uses_public_fields () =
+  let schema = Option.get (Alias.public_input_schema "WebSearch") in
+  let props = Option.get (yojson_field "properties" schema) in
+  Alcotest.(check bool) "WebSearch schema exposes 'query'"
+    true (Option.is_some (yojson_field "query" props));
+  Alcotest.(check bool) "WebSearch schema exposes 'limit'"
+    true (Option.is_some (yojson_field "limit" props));
+  let required =
+    match yojson_field "required" schema with
+    | Some (`List items) ->
+        List.filter_map
+          (function `String s -> Some s | _ -> None) items
+    | _ -> []
+  in
+  Alcotest.(check (list string)) "WebSearch requires 'query'"
+    [ "query" ] required
 
 let test_translate_edit_input () =
   let input =
@@ -417,6 +449,15 @@ let test_translate_grep_input () =
   Alcotest.(check bool) "-n shim dropped" true
     (Option.is_none (yojson_field "-n" translated))
 
+let test_translate_web_search_input_is_identity () =
+  let input =
+    `Assoc
+      [ ("query", `String "OpenAI API release notes"); ("limit", `Int 5) ]
+  in
+  let translated = Alias.translate_input ~public:"WebSearch" input in
+  Alcotest.(check string) "WebSearch payload already matches masc_web_search"
+    (Yojson.Safe.to_string input) (Yojson.Safe.to_string translated)
+
 let test_translate_unknown_is_identity () =
   let input = `Assoc [ ("foo", `String "bar") ] in
   let translated = Alias.translate_input ~public:"NoSuchTool" input in
@@ -430,12 +471,16 @@ let test_translate_malformed_input_is_identity () =
     (Yojson.Safe.to_string input) (Yojson.Safe.to_string translated)
 
 let test_expand_universe_adds_aliases () =
-  let internal = [ "keeper_bash"; "keeper_fs_read"; "keeper_board_post" ] in
+  let internal =
+    [ "keeper_bash"; "keeper_fs_read"; "masc_web_search"; "keeper_board_post" ]
+  in
   let expanded = Alias.expand_universe internal in
   Alcotest.(check bool) "Bash appears after expansion"
     true (List.mem "Bash" expanded);
   Alcotest.(check bool) "Read appears after expansion"
     true (List.mem "Read" expanded);
+  Alcotest.(check bool) "WebSearch appears after expansion"
+    true (List.mem "WebSearch" expanded);
   Alcotest.(check bool) "internal names preserved"
     true (List.for_all (fun n -> List.mem n expanded) internal);
   Alcotest.(check bool) "no duplicate Bash entries"
@@ -449,6 +494,8 @@ let test_expand_universe_skips_when_internal_absent () =
     true (not (List.mem "Bash" expanded));
   Alcotest.(check bool) "Read NOT added when keeper_fs_read absent"
     true (not (List.mem "Read" expanded));
+  Alcotest.(check bool) "WebSearch NOT added when masc_web_search absent"
+    true (not (List.mem "WebSearch" expanded));
   Alcotest.(check int) "expanded length unchanged"
     (List.length internal) (List.length expanded)
 
@@ -490,19 +537,21 @@ let () =
         ] );
       ( "oas-dual-register",
         [
-          Alcotest.test_case "subset is Bash + Read only" `Quick test_oas_dual_register_subset;
+          Alcotest.test_case "dual registration subset is stable" `Quick test_oas_dual_register_subset;
           Alcotest.test_case "tailored input schema present" `Quick test_public_input_schema_present;
           Alcotest.test_case "Bash schema uses 'command' field" `Quick test_bash_schema_uses_command_field;
           Alcotest.test_case "Read schema uses 'file_path' field" `Quick test_read_schema_uses_file_path;
           Alcotest.test_case "Edit schema uses Anthropic field names" `Quick test_edit_schema_uses_anthropic_fields;
           Alcotest.test_case "Write schema uses Anthropic field names" `Quick test_write_schema_uses_anthropic_fields;
           Alcotest.test_case "Grep schema uses Anthropic field names" `Quick test_grep_schema_uses_anthropic_fields;
+          Alcotest.test_case "WebSearch schema uses public field names" `Quick test_web_search_schema_uses_public_fields;
           Alcotest.test_case "translate Bash input shape" `Quick test_translate_bash_input;
           Alcotest.test_case "translate Read input shape" `Quick test_translate_read_input;
           Alcotest.test_case "translate Edit input shape" `Quick test_translate_edit_input;
           Alcotest.test_case "translate Edit drops caller mode" `Quick test_translate_edit_drops_caller_supplied_mode;
           Alcotest.test_case "translate Write input shape" `Quick test_translate_write_input;
           Alcotest.test_case "translate Grep input shape" `Quick test_translate_grep_input;
+          Alcotest.test_case "translate WebSearch input shape" `Quick test_translate_web_search_input_is_identity;
           Alcotest.test_case "translate unknown is identity" `Quick test_translate_unknown_is_identity;
           Alcotest.test_case "translate malformed is identity" `Quick test_translate_malformed_input_is_identity;
           Alcotest.test_case "expand_universe adds aliases" `Quick test_expand_universe_adds_aliases;

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -173,10 +173,10 @@ let test_coding_preset_includes_keeper_fs_edit () =
   check bool "has keeper_fs_edit" true
     (has_tool "keeper_fs_edit" tools)
 
-let test_research_preset_excludes_keeper_fs_edit () =
+let test_research_preset_includes_keeper_fs_edit () =
   let meta = make_meta ~preset:Keeper_types.Research () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "no keeper_fs_edit" false
+  check bool "has keeper_fs_edit" true
     (has_tool "keeper_fs_edit" tools)
 
 let test_minimal_preset_excludes_keeper_fs_edit () =
@@ -184,6 +184,12 @@ let test_minimal_preset_excludes_keeper_fs_edit () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "no keeper_fs_edit" false
     (has_tool "keeper_fs_edit" tools)
+
+let test_minimal_preset_has_web_search () =
+  let meta = make_meta ~preset:Keeper_types.Minimal () in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "has masc_web_search" true
+    (has_tool "masc_web_search" tools)
 
 let test_coding_preset_has_keeper_bash () =
   let meta = make_meta ~preset:Keeper_types.Coding () in
@@ -233,6 +239,16 @@ let test_research_preset_has_read_tools () =
   check bool "has keeper_fs_read" true (has_tool "keeper_fs_read" tools);
   check bool "has keeper_library_search" true (has_tool "keeper_library_search" tools);
   check bool "has masc_web_search" true (has_tool "masc_web_search" tools)
+
+let test_last_turn_safe_keeps_discovery_and_web_search () =
+  let tools = Keeper_tool_policy.last_turn_safe_tool_names () in
+  let alias_expanded = Keeper_tool_alias.expand_universe tools in
+  check bool "last turn allows keeper_tool_search" true
+    (has_tool "keeper_tool_search" tools);
+  check bool "last turn allows masc_web_search" true
+    (has_tool "masc_web_search" tools);
+  check bool "last turn allows WebSearch alias" true
+    (has_tool "WebSearch" alias_expanded)
 
 let test_coding_preset_has_coordination_tools () =
   let meta = make_meta ~preset:Keeper_types.Coding () in
@@ -760,10 +776,12 @@ let () =
         test_full_preset_includes_keeper_fs_edit;
       test_case "coding preset includes keeper_fs_edit" `Quick
         test_coding_preset_includes_keeper_fs_edit;
-      test_case "research preset excludes keeper_fs_edit" `Quick
-        test_research_preset_excludes_keeper_fs_edit;
+      test_case "research preset includes keeper_fs_edit" `Quick
+        test_research_preset_includes_keeper_fs_edit;
       test_case "minimal preset excludes keeper_fs_edit" `Quick
         test_minimal_preset_excludes_keeper_fs_edit;
+      test_case "minimal preset has web search" `Quick
+        test_minimal_preset_has_web_search;
       test_case "coding preset has keeper_bash and keeper_shell" `Quick
         test_coding_preset_has_keeper_bash;
     ]);
@@ -774,6 +792,8 @@ let () =
       test_case "presets have different tool count" `Quick test_presets_have_different_tool_count;
       test_case "messaging has board tools" `Quick test_messaging_preset_has_board_tools;
       test_case "research has read tools" `Quick test_research_preset_has_read_tools;
+      test_case "last turn keeps discovery and web search" `Quick
+        test_last_turn_safe_keeps_discovery_and_web_search;
       test_case "coding has coordination tools" `Quick test_coding_preset_has_coordination_tools;
       test_case "messaging legacy governance tools removed" `Quick test_messaging_preset_has_no_legacy_governance_tools;
       test_case "sufficient tool count" `Quick test_sufficient_tool_count;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2140,12 +2140,16 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     (contains_substring social_guidance "`keeper_task_claim` {}");
   check bool "social guidance includes board post when allowed" true
     (contains_substring social_guidance "`keeper_board_post` { content:");
+  check bool "social guidance includes web search when allowed" true
+    (contains_substring social_guidance "`masc_web_search` { query:");
   check bool "social guidance omits bash outside preset" false
     (contains_substring social_guidance "`keeper_bash` { cmd:");
   check bool "social guidance omits worktree outside preset" false
     (contains_substring social_guidance "`masc_worktree_create` { task_id:");
   check bool "coding guidance includes bash schema" true
     (contains_substring coding_guidance "`keeper_bash` { cmd:");
+  check bool "coding guidance includes web search schema" true
+    (contains_substring coding_guidance "`masc_web_search` { query:");
   check bool "coding guidance includes worktree schema" true
     (contains_substring coding_guidance "`masc_worktree_create` { task_id:");
   check bool "legacy worktree branch_name schema removed" false


### PR DESCRIPTION
## Summary
- Expose `masc_web_search` through the minimal preset and last-turn-safe policy, keeping `keeper_tool_search` available for discovery on last turn.
- Add a `WebSearch` model-facing alias for `masc_web_search`, including OAS dual registration, schema coverage, and alias expansion on last-turn surfaces.
- Add preferred-tool guidance and keeper capability docs for current-information lookup.
- Update keeper tool exposure tests for the current research preset, which already includes `keeper_fs_edit` via `filesystem_write`.

## Why
Keepers had `masc_web_search` in most non-minimal presets, but minimal/last-turn paths and Anthropic-style `WebSearch` calls still left real search unavailable or classified as hallucinated. This made long-running keepers brittle when they needed current external context.

## Validation
- `scripts/dune-local.sh build test/test_keeper_tool_alias.exe test/test_keeper_tool_exposure.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_tool_alias.exe` passed: 33 tests.
- `./_build/default/test/test_keeper_tool_exposure.exe` passed: 61 tests.
- `./_build/default/test/test_keeper_unified.exe test --show-errors unified_prompt 27` passed.