### PR TITLE
fix(approval): preserve room base path for pending audits

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -420,6 +420,7 @@ let to_oas_approval_callback
                   ~keeper_name
                   ~tool_name
                   ~input
+                  ?base_path
                   ?turn_id
                   ?task_id
                   ?goal_id

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -69,6 +69,7 @@ type pending_approval = {
   selected_model : string option;
   disposition : string option;
   disposition_reason : string option;
+  audit_base_path : string option;
   resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option;
   on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option;
 }
@@ -626,7 +627,7 @@ let input_preview_of_json (json : Yojson.Safe.t) =
 
 let create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
     ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
-    ?selected_model ?disposition ?disposition_reason
+    ?selected_model ?disposition ?disposition_reason ?audit_base_path
     ~resolver ~on_resolution () =
   let action_key = action_key_of_input ~tool_name ~input in
   let input_hash = normalized_input_hash input in
@@ -649,6 +650,7 @@ let create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
     selected_model;
     disposition;
     disposition_reason;
+    audit_base_path;
     resolver;
     on_resolution;
   }
@@ -716,7 +718,8 @@ let record_pending (entry : pending_approval) =
     "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s risk=%s"
     entry.id entry.keeper_name entry.tool_name
     (risk_level_to_string entry.risk_level);
-  audit_approval_event ~event_type:"pending" ~id:entry.id
+  audit_approval_event ?base_path:entry.audit_base_path ~event_type:"pending"
+    ~id:entry.id
     ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
     ~risk_level:entry.risk_level ?turn_id:entry.turn_id ?task_id:entry.task_id
     ?goal_id:entry.goal_id ~goal_ids:entry.goal_ids
@@ -821,7 +824,7 @@ let sort_entries_by_requested_at entries =
     the operator-response distribution — premature shortening turns
     every distracted operator into an [Approval_expired] event. *)
 let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
-    ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
+    ?base_path ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
     ?selected_model ?disposition ?disposition_reason
     ?clock ?(timeout_s = 600.0)
     ()
@@ -832,6 +835,7 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
     create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
       ?turn_id ?task_id ?goal_id ~goal_ids ?runtime_contract
       ?selected_model ?disposition ?disposition_reason
+      ?audit_base_path:base_path
       ~resolver:(Some resolver) ~on_resolution:None ()
   in
   atomic_update pending (fun map -> SMap.add id entry map);
@@ -863,6 +867,7 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
            Printf.sprintf "approval timeout after %.0fs" timeout_s
          in
          audit_approval_event
+           ?base_path:entry.audit_base_path
            ~event_type:"approval_timeout"
            ~id
            ~keeper_name
@@ -889,7 +894,7 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
         atomic_update pending (fun map -> SMap.remove id map)))
 
 let submit_pending ~keeper_name ~tool_name ~input ~risk_level
-    ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
+    ?base_path ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
     ?selected_model ?disposition ?disposition_reason
     ~on_resolution
     ()
@@ -910,6 +915,7 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level
         create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
           ?turn_id ?task_id ?goal_id ~goal_ids ?runtime_contract
           ?selected_model ?disposition ?disposition_reason
+          ?audit_base_path:base_path
           ~resolver:None ~on_resolution:(Some on_resolution) ()
       in
       let updated = SMap.add id entry map in
@@ -1086,7 +1092,8 @@ let expire_stale ~max_wait_s =
       ();
     Log.Keeper.warn "HITL_APPROVAL_EXPIRED: id=%s keeper=%s tool=%s"
       id entry.keeper_name entry.tool_name;
-    audit_approval_event ~event_type:"expired" ~id
+    audit_approval_event ?base_path:entry.audit_base_path ~event_type:"expired"
+      ~id
       ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
       ~risk_level:entry.risk_level ?turn_id:entry.turn_id
       ?task_id:entry.task_id ?goal_id:entry.goal_id

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -41,6 +41,7 @@ type pending_approval =
   ; selected_model : string option
   ; disposition : string option
   ; disposition_reason : string option
+  ; audit_base_path : string option
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   }
@@ -183,6 +184,7 @@ val submit_and_await :
   tool_name:string ->
   input:Yojson.Safe.t ->
   risk_level:risk_level ->
+  ?base_path:string ->
   ?turn_id:int ->
   ?task_id:string ->
   ?goal_id:string ->
@@ -205,6 +207,7 @@ val submit_pending :
   tool_name:string ->
   input:Yojson.Safe.t ->
   risk_level:risk_level ->
+  ?base_path:string ->
   ?turn_id:int ->
   ?task_id:string ->
   ?goal_id:string ->

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -578,6 +578,7 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
       ~tool_name:"keeper_continue_after_reconcile"
       ~input
       ~risk_level:Keeper_approval_queue.Critical
+      ~base_path:ctx.config.base_path
       ~on_resolution:(fun decision ->
         match decision with
         | Agent_sdk.Hooks.Approve

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -799,6 +799,7 @@ let enqueue_partial_commit_continue_gate
     ~tool_name:"keeper_continue_after_partial_commit"
     ~input
     ~risk_level:Keeper_approval_queue.Critical
+    ~base_path:config.base_path
     ~on_resolution:(fun decision ->
       let latest_meta = current_keeper_meta ~config ~fallback_meta:meta in
       match decision with

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -71,6 +71,11 @@ let pending_id_for_keeper ~keeper_name =
       entries
   | _ -> None
 
+let audit_event_names ~base_path ~keeper_name =
+  AQ.read_recent_audit ~base_path ~keeper_name ~n:10 ()
+  |> List.map (fun json ->
+         Yojson.Safe.Util.(json |> member "event" |> to_string))
+
 let execute_approval_get args =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -761,6 +766,7 @@ let test_dashboard_resolve_and_delete_rules_use_room_base_path () =
           ~tool_name:"masc_claim_task"
           ~input:(`Assoc [ ("task_id", `String "task-room") ])
           ~risk_level:AQ.Medium
+          ~base_path:room_base
           ~on_resolution:(fun _ -> ())
           ()
       in
@@ -801,6 +807,46 @@ let test_dashboard_resolve_and_delete_rules_use_room_base_path () =
         (List.length (AQ.list_rules ~base_path:room_base ()));
       Alcotest.(check int) "env fallback still empty" 0
         (List.length (AQ.list_rules ~base_path:env_base ())))
+
+let test_submit_pending_audit_uses_room_base_path () =
+  let env_base = temp_dir () in
+  let room_base = temp_dir () in
+  let old_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  let old_base_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
+  let keeper_name = "approval-room-audit-keeper" in
+  AQ.For_testing.reset_audit_store ();
+  Unix.putenv "MASC_BASE_PATH" env_base;
+  Unix.putenv "MASC_BASE_PATH_INPUT" env_base;
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      (match old_base with
+       | Some value -> Unix.putenv "MASC_BASE_PATH" value
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      (match old_base_input with
+       | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
+       | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
+      cleanup_dir env_base;
+      cleanup_dir room_base)
+    (fun () ->
+      ignore
+        (AQ.submit_pending
+           ~keeper_name
+           ~tool_name:"masc_claim_task"
+           ~input:(`Assoc [ ("task_id", `String "task-room-audit") ])
+           ~risk_level:AQ.High
+           ~base_path:room_base
+           ~on_resolution:(fun _ -> ())
+           ());
+      AQ.expire_stale ~max_wait_s:(-1.0);
+      let room_events = audit_event_names ~base_path:room_base ~keeper_name in
+      let env_events = audit_event_names ~base_path:env_base ~keeper_name in
+      Alcotest.(check bool) "room audit has pending" true
+        (List.exists (String.equal "pending") room_events);
+      Alcotest.(check bool) "room audit has expired" true
+        (List.exists (String.equal "expired") room_events);
+      Alcotest.(check (list string)) "env fallback has no room audit" []
+        env_events)
 
 let test_approval_get_dispatch_missing_id () =
   let ok, msg = execute_approval_get (`Assoc [("id", `String "")]) in
@@ -1152,6 +1198,8 @@ let () =
         test_resolve_with_policy_does_not_remember_high_allow;
       Alcotest.test_case "dashboard approve-always rules use room base_path" `Quick
         test_dashboard_resolve_and_delete_rules_use_room_base_path;
+      Alcotest.test_case "submit_pending audit uses room base_path" `Quick
+        test_submit_pending_audit_uses_room_base_path;
       Alcotest.test_case "read_recent_audit scans before keeper filter" `Quick
         test_read_recent_audit_filters_after_wide_scan;
     ]);


### PR DESCRIPTION
## Summary

- Capture the approval queue room `base_path` on each pending approval entry.
- Use that captured path for `pending`, `approval_timeout`, and janitor `expired` audit events.
- Thread the resolved room base path through governance callbacks and keeper continue-gate submissions.
- Add a regression test proving room-scoped pending/expired audit rows stay out of the env fallback ledger.

## Why

`resolve_entry` already accepted a room `base_path`, but `record_pending` and timeout/expiry paths fell back to `Env_config_core.base_path ()`. That split a single approval lifecycle across different ledgers when dashboard or room-scoped keepers were operating under a non-default base path.

## Operator Impact

Approval audit timelines now stay room-scoped from enqueue through timeout/expiry. Runtime-trust and dashboard audit readers no longer have to infer across the production fallback ledger for pending approval history.

## Validation

- `git diff --check HEAD~1..HEAD`
- `ocamlc -stop-after parsing lib/keeper/keeper_approval_queue.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_approval_queue.mli`
- `ocamlc -stop-after parsing lib/governance_pipeline.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_supervisor.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_turn_cascade_budget.ml`
- `ocamlc -stop-after parsing test/test_hitl_approval.ml`

Focused `scripts/dune-local.sh build test/test_hitl_approval.exe` was started but remained queued behind `/tmp/me-dune-local.lock` through multiple unrelated holders, so I stopped only my waiter. PR CI is the full type/build gate.