### PR TITLE
feat(scripts): verify_audit_claim.sh — deterministic count check + 0.19.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## [0.19.11] - 2026-05-06
+
+### Added
+- `scripts/verify_audit_claim.sh`: deterministic verifier for audit count claims (`<expected> <pattern> <path...>`). Forces measurement against the working tree before count claims are acted on. Origin: 2026-05-06 hallucinated audit cascade where a "16 silent-empty antipatterns" claim cross-cited by 4 keepers measured as 2 against actual code (8x overstated). Exit 0 on match, 1 on mismatch with overstatement ratio.
+
 ## [0.19.10] - 2026-05-05
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.19.10)
+(version 0.19.11)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)

--- a/scripts/verify_audit_claim.sh
+++ b/scripts/verify_audit_claim.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# verify_audit_claim.sh — deterministic verifier for audit count claims.
+#
+# Purpose
+#   Audits posted by keepers / external reports often state quantitative
+#   claims like "16 silent-empty antipatterns in lib/keeper/keeper_tool_policy.ml"
+#   or "3 sites in lib/relay.ml".  Without independent measurement those
+#   numbers cascade through cross-citation.  Real measurements observed
+#   2026-05-06: claimed 16 → actual 2 (8x drift); claimed 3 → actual 1.
+#
+# This script forces measurement against the working tree before the
+# claim is acted on (sprint planning, PR scoping, RFC drafting).
+#
+# Usage
+#   verify_audit_claim.sh <expected_count> <pattern> <path...>
+#
+# Example
+#   verify_audit_claim.sh 16 'match !policy_config with' lib/keeper/keeper_tool_policy.ml
+#   verify_audit_claim.sh 3  'match !'                    lib/relay.ml
+#
+# Exit code 0 = match, 1 = mismatch, 2 = invocation error.
+# stdout: actual count + commit hash + per-file breakdown.
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 <expected_count> <pattern> <path...>" >&2
+  exit 2
+fi
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ERROR: ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+EXPECTED="$1"; shift
+PATTERN="$1"; shift
+PATHS=("$@")
+
+# Force measurement against committed working tree, not stale assumption.
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DIRTY=$(git status --porcelain 2>/dev/null | head -1)
+
+ACTUAL=0
+echo "=== verify_audit_claim ==="
+echo "  commit:    $COMMIT$([ -n "$DIRTY" ] && echo " (dirty)" || true)"
+echo "  pattern:   $PATTERN"
+echo "  expected:  $EXPECTED"
+echo "  per-path:"
+for p in "${PATHS[@]}"; do
+  if [ ! -e "$p" ]; then
+    echo "    $p: <missing>"
+    continue
+  fi
+  N=$(rg -c -- "$PATTERN" "$p" 2>/dev/null | awk -F: '{s+=$NF} END{print s+0}')
+  ACTUAL=$((ACTUAL + N))
+  echo "    $p: $N"
+done
+echo "  actual:    $ACTUAL"
+
+if [ "$ACTUAL" = "$EXPECTED" ]; then
+  echo "  result:    OK"
+  exit 0
+fi
+
+if [ "$ACTUAL" -lt "$EXPECTED" ]; then
+  RATIO=$(awk -v a="$ACTUAL" -v e="$EXPECTED" 'BEGIN{ if(a==0) print "inf"; else printf "%.1fx\n", e/a }')
+  echo "  result:    MISMATCH — claim overstated by $RATIO"
+else
+  echo "  result:    MISMATCH — actual exceeds claim (under-counted audit)"
+fi
+exit 1


### PR DESCRIPTION
## Summary

Adds `scripts/verify_audit_claim.sh` — a deterministic verifier for audit count claims (file pattern + expected count). Bumps `0.19.10 → 0.19.11`.

## Origin

2026-05-06 the keeper fleet emitted a task-186 → board_post → cross-check cascade ending in a recommendation to clean "16 silent-empty antipatterns in `lib/keeper/keeper_tool_policy.ml`" plus "3 occurrences in `lib/relay.ml`". Direct measurement at this commit:

| claim | actual |
|-------|--------|
| `match !policy_config with` × 16 in `lib/keeper/keeper_tool_policy.ml` | **2** (lines 88, 96) |
| `match !` × 3 in `lib/relay.ml` | **1** (line 356) |
| 13 specific line numbers (94/99/104/109/114/119/126/131/136/141/146/153/160) cited as evidence | none of those lines hold the pattern |

The two `policy_config` sites are the canonical helpers introduced by #13129 / #13185 (`with_policy_config_or` and `require_policy_config`); the proposed cleanup would have undone working code. The `relay.ml:356` site is an Option-returning latest-checkpoint accessor (`None` is meaningful, not a silent fallback).

## What this PR does

A 72-line bash script. Self-tested against the cascade above:

```
$ scripts/verify_audit_claim.sh 16 'match !policy_config with' lib/keeper/keeper_tool_policy.ml
... actual: 2 / result: MISMATCH — claim overstated by 8.0x   exit 1

$ scripts/verify_audit_claim.sh 3  'match !' lib/relay.ml
... actual: 1 / result: MISMATCH — claim overstated by 3.0x   exit 1

$ scripts/verify_audit_claim.sh 2 'match !policy_config with' lib/keeper/keeper_tool_policy.ml
... actual: 2 / result: OK                                    exit 0
```

Output prints commit hash + per-path counts so cited results are reproducible by reviewers.

## Why bash, not OCaml

Single-purpose shell tool, depends only on `rg` + `git`. No build dependency, no opam churn.

## Scope

- `scripts/verify_audit_claim.sh` (new, +72)
- `CHANGELOG.md` (+5)
- `dune-project` version bump

No code in `lib/`, `dashboard/`, or `test/` is modified. No RFC-gated subsystem touched.

## Test plan

- [x] Self-test against the originating cascade (3 cases above) — pass
- [x] `bash -n scripts/verify_audit_claim.sh` syntax check
- [ ] Reviewer: pick any past audit count claim and run it through the script

## Related

- Memory note `feedback_keeper_hallucinated_audit_cascade.md` documents the cascade chain.
- Issue #13362 (silent-defer / contract violations) — same root failure mode (`bdi_speech_v1.ml:140-142` Defer/Silent stamp), different surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
