### PR TITLE
fix(keeper): clarify claim scope truth

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -85,6 +85,36 @@ let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
   `Assoc fields
 ;;
 
+let claim_scope_context_suffix ~(meta : keeper_meta) claim_goal_scope =
+  match claim_goal_scope.Keeper_runtime_contract.mode with
+  | "active_goal_ids" ->
+    (match meta.active_goal_ids with
+     | [] -> " in active goal scope"
+     | goal_ids ->
+       Printf.sprintf
+         " within active_goal_ids=[%s]"
+         (String.concat ", " goal_ids))
+  | "all_tasks" -> " across all tasks"
+  | "auto_goal_fallback_all_tasks" -> " after auto-goal fallback to all tasks"
+  | "empty_goal_scope_fallback_all_tasks" ->
+    " after active-goal fallback to all tasks"
+  | mode -> Printf.sprintf " in claim_scope.mode=%s" mode
+;;
+
+let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
+  match claim_goal_scope.Keeper_runtime_contract.fallback_reason with
+  | Some _ ->
+    Printf.sprintf
+      "ACTION: Stop scope-lock diagnosis; claim_scope.mode=%s already searched all \
+       tasks; resolve blockers/excluded=%d."
+      claim_goal_scope.Keeper_runtime_contract.mode
+      excluded_count
+  | None ->
+    Printf.sprintf
+      "ACTION: Stop task-checking — blocked/excluded=%d."
+      excluded_count
+;;
+
 let find_task_goal_id config task_id =
   Coord.get_tasks_raw config
   |> List.find_map (fun (task : Masc_domain.task) ->
@@ -284,17 +314,10 @@ let handle_keeper_task_tool
           else message
       | Coord.Claim_next_no_unclaimed -> "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
       | Coord.Claim_next_no_eligible { excluded_count; _ } ->
-        let scope_suffix =
-          match meta.active_goal_ids with
-          | [] -> ""
-          | goal_ids ->
-              Printf.sprintf
-                " within active_goal_ids=[%s]"
-                (String.concat ", " goal_ids)
-        in
         Printf.sprintf
-          "No eligible tasks%s. ACTION: Stop task-checking — blocked/excluded=%d."
-          scope_suffix excluded_count
+          "No eligible tasks%s. %s"
+          (claim_scope_context_suffix ~meta claim_goal_scope)
+          (no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count)
       | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
     in
     let claim_scope, claimed_task_fields =

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -64,7 +64,8 @@ let active_goal_ids_have_eligible_claim_task
             latest_verification_status
             task)
 
-let resolve_claim_goal_scope ?agent_tool_names ~(config : Coord.config)
+let resolve_claim_goal_scope ?agent_tool_names
+    ?(allow_empty_goal_scope_fallback = true) ~(config : Coord.config)
     ~(meta : keeper_meta) () =
   match meta.active_goal_ids with
   | [] ->
@@ -86,19 +87,27 @@ let resolve_claim_goal_scope ?agent_tool_names ~(config : Coord.config)
         let is_auto_goal =
           active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
         in
-        {
-          task_filter = (fun (_task : Masc_domain.task) -> true);
-          mode =
-            (if is_auto_goal then "auto_goal_fallback_all_tasks"
-             else "empty_goal_scope_fallback_all_tasks");
-          effective_goal_ids = [];
-          fallback_reason =
-            Some
-              (if is_auto_goal then
-                 "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks"
-               else
-                 "active goal scope has no claimable linked tasks; falling back to all claimable tasks");
-        }
+        if is_auto_goal || allow_empty_goal_scope_fallback then
+          {
+            task_filter = (fun (_task : Masc_domain.task) -> true);
+            mode =
+              (if is_auto_goal then "auto_goal_fallback_all_tasks"
+               else "empty_goal_scope_fallback_all_tasks");
+            effective_goal_ids = [];
+            fallback_reason =
+              Some
+                (if is_auto_goal then
+                   "auto keeper goal has no claimable linked tasks; falling back to all claimable tasks"
+                 else
+                   "active goal scope has no claimable linked tasks; falling back to all claimable tasks");
+          }
+        else
+          {
+            task_filter = scoped_filter;
+            mode = "active_goal_ids";
+            effective_goal_ids = goal_ids;
+            fallback_reason = None;
+          }
       else
         {
           task_filter = scoped_filter;

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -13,6 +13,7 @@ type claim_goal_scope = {
 
 val resolve_claim_goal_scope :
   ?agent_tool_names:string list ->
+  ?allow_empty_goal_scope_fallback:bool ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   unit ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -248,6 +248,7 @@ let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
   let scope =
     Keeper_runtime_contract.resolve_claim_goal_scope
       ?agent_tool_names
+      ~allow_empty_goal_scope_fallback:false
       ~config
       ~meta
       ()

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -532,6 +532,54 @@ let test_claim_falls_back_when_scoped_task_is_verification_blocked () =
         Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string)
     | None -> fail "expected fallback to claim product task")
 
+let test_claim_no_eligible_after_fallback_reports_scope_truth () =
+  with_room (fun config ->
+    let scoped_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let product_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Product goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta =
+      { (make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ]) with
+        active_goal_ids = [ scoped_goal.id ];
+      }
+    in
+    let _ =
+      Coord_task.add_task
+        ~contract:(contract_requiring_tools [ "keeper_bash" ])
+        ~goal_id:scoped_goal.id
+        config
+        ~title:"Scoped task needing bash"
+        ~priority:1
+        ~description:"requires shell execution"
+    in
+    let _ =
+      Coord_task.add_task
+        ~contract:(contract_requiring_tools [ "keeper_fs_edit" ])
+        ~goal_id:product_goal.id
+        config
+        ~title:"Fallback task also missing tools"
+        ~priority:2
+        ~description:"also requires unavailable write access"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    let scope = Yojson.Safe.Util.member "claim_scope" json in
+    check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+      Yojson.Safe.Util.(scope |> member "mode" |> to_string);
+    check bool "message names fallback search" true
+      (contains_substring message "fallback to all tasks");
+    check bool "message stops scope-lock diagnosis" true
+      (contains_substring message "Stop scope-lock diagnosis");
+    check bool "message avoids stale active scope" false
+      (contains_substring message "within active_goal_ids"))
+
 let test_claim_skips_required_tools_without_access () =
   with_room (fun config ->
     let meta = make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ] in
@@ -1001,6 +1049,8 @@ let () =
         test_claim_falls_back_when_scoped_task_requires_missing_tool;
       test_case "claim falls back when scoped task is verification blocked" `Quick
         test_claim_falls_back_when_scoped_task_is_verification_blocked;
+      test_case "claim no eligible after fallback reports scope truth" `Quick
+        test_claim_no_eligible_after_fallback_reports_scope_truth;
       test_case "claim skips tasks requiring missing tools" `Quick
         test_claim_skips_required_tools_without_access;
       test_case "claim allows tasks requiring available tools" `Quick


### PR DESCRIPTION
## What changed

- Updated `keeper_task_claim` no-eligible messaging to describe the effective claim scope instead of always echoing `active_goal_ids`.
- Kept explicit claim-tool fallback reporting precise when the scheduler searches all tasks.
- Made world-observation claimable backlog counting strict for non-auto active goals, so out-of-scope tasks do not wake keepers or become actionable signal.
- Preserved auto-goal fallback behavior for generated keeper goals.
- Added/kept focused regressions for claim-scope messaging and verified the existing `world_observation 6` regression now passes.

## Why

Live board/task evidence showed keepers repeatedly reporting a scope-lock even when the explicit claim path had already fallen back to all tasks. At the same time, issue #13425 showed the observation path had become too broad: a keeper scoped to one active goal saw a task linked only to another goal as claimable backlog.

This patch separates the two contracts:

- `keeper_task_claim` can still report explicit scheduler fallback truth.
- passive world observation stays strict unless the active goal is the generated auto keeper goal.

That keeps keepers from waking on out-of-scope backlog while preserving clear diagnostics when a claim command is actually invoked.

Fixes #13425.
Refs #13432: the failing `world_observation 6` signal is fixed here by separating passive observation from explicit claim fallback, not by broadening passive observation.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing lib/keeper/keeper_runtime_contract.ml lib/keeper/keeper_runtime_contract.mli lib/keeper/keeper_world_observation.ml`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_task_dispatch.exe`
- `./_build/default/test/test_keeper_unified.exe test world_observation 6`
- `./_build/default/test/test_keeper_task_dispatch.exe` (31 tests)
