### PR TITLE
fix(keeper): allow first-turn task claim contract

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -208,6 +208,9 @@ let run_turn
   let keeper_has_owned_active_task () =
     Option.is_some (owned_active_task_id_for_meta ~config ~meta:acc.meta)
   in
+  (* A claim tool mutates [acc.meta.current_task_id] during this run; contract
+     gating must judge claim-context tools against ownership at turn entry. *)
+  let had_owned_active_task_at_turn_start = keeper_has_owned_active_task () in
   (* 8. Run Agent *)
   let contract =
     if Env_config.Cdal.enabled () then Keeper_cdal_contract.of_keeper_meta meta else None
@@ -655,7 +658,7 @@ let run_turn
          in
          let actionable_tool_contract_violation_reason =
            Keeper_tool_disclosure.actionable_tool_contract_violation_reason
-             ~claim_context_allowed:(not (keeper_has_owned_active_task ()))
+             ~claim_context_allowed:(not had_owned_active_task_at_turn_start)
              ~actionable_signal_context
              ~tool_names:actual_keeper_tool_names
          in
@@ -691,7 +694,7 @@ let run_turn
            else if required_tool_names <> [] && not all_required_used then
              if actual_keeper_tool_names = [] then "missing_required_tool_use"
              else if all_class Keeper_tool_disclosure.Claim_context
-                     && keeper_has_owned_active_task ()
+                     && had_owned_active_task_at_turn_start
              then "claim_only_after_owned_task"
              else if all_class Keeper_tool_disclosure.Claim_context
              then "needs_execution_progress"
@@ -699,7 +702,7 @@ let run_turn
              else "missing_required_tool_use"
            else if actual_keeper_tool_names = [] then "satisfied_completion"
            else if all_class Keeper_tool_disclosure.Claim_context
-                   && keeper_has_owned_active_task ()
+                   && had_owned_active_task_at_turn_start
            then "claim_only_after_owned_task"
            else if all_class Keeper_tool_disclosure.Claim_context
            then "needs_execution_progress"


### PR DESCRIPTION
## Summary
- Snapshot active task ownership at keeper turn entry before provider/tool execution mutates `current_task_id`.
- Use that turn-start ownership value when deciding whether claim-context tools are allowed.
- Prevent a valid first `keeper_task_claim` from being reclassified as `claim_only_after_owned_task` after the claim itself succeeds.

## Live evidence
- `qa-king` turn 66 started with `task_id=null`, executed `keeper_task_claim`, then the completion contract failed as: `owned active task ... keeper_task_claim`.
- The false positive left `qa-king` in `tool_required_unsatisfied` even though the claim was the expected autonomous first step.

## Verification
- `git diff --check origin/main...HEAD`
- Attempted `scripts/dune-local.sh build test/test_keeper_unified.exe` after repairing the agent_sdk pin. Local verification was blocked by shared Dune lock contention and a Dune shared-cache temp artifact race; CI is the verification surface for this draft.

## Notes
- This does not relax the strict gate for keepers that already had an active task at turn start; claim-only loops after ownership still classify as `claim_only_after_owned_task`.