### PR TITLE
fix(fsm): surface phase derivation drift

### DIFF
--- a/docs/observability/cascade-metrics.md
+++ b/docs/observability/cascade-metrics.md
@@ -165,11 +165,11 @@ This is the spec → code → dashboard → metric consistency contract.
 | Label       | Values                                                                             |
 | ----------- | ---------------------------------------------------------------------------------- |
 | `keeper`    | Keeper name (bounded by keepers registered on host, typically < 50)                |
-| `invariant` | `PhaseTurnAlignment`, `NoCascadeBeforeMeasurement`, `CompactionAtomicity`, `EventPriorityMonotone` |
+| `invariant` | `PhaseTurnAlignment`, `NoCascadeBeforeMeasurement`, `CompactionAtomicity`, `EventPriorityMonotone`, `PhaseDerivationAgreement` |
 
 Incremented from `Keeper_composite_observer.bump_invariant_violations`, invoked by `observe` on every snapshot. One counter tick **per violated invariant per snapshot**. A sustained rate means the FSM composition is wedged in an inconsistent cross-axis state.
 
-Label cardinality: `keepers × 4` (≤ 200 series in practice).
+Label cardinality: `keepers × 5` (≤ 250 series in practice).
 
 ### PromQL patterns
 
@@ -181,7 +181,7 @@ sum by (invariant) (increase(masc_keeper_invariant_violations_total[5m]))
 topk(5, rate(masc_keeper_invariant_violations_total
               {invariant="PhaseTurnAlignment"}[5m]))
 
-# Invariant health SLO (what fraction of snapshots satisfy all 4?)
+# Invariant health SLO (what fraction of snapshots satisfy all 5?)
 # Requires pairing with a snapshots_total counter in a follow-up; out of
 # scope for LT-13.
 ```

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -80,11 +80,13 @@ type invariant_key =
   | Invariant_no_cascade_before_measurement
   | Invariant_compaction_atomicity
   | Invariant_event_priority_monotone
+  | Invariant_phase_derivation_agreement
 
 let all_invariant_keys =
   [
     Invariant_phase_turn_alignment; Invariant_no_cascade_before_measurement;
     Invariant_compaction_atomicity; Invariant_event_priority_monotone;
+    Invariant_phase_derivation_agreement;
   ]
 
 type invariants_check = {
@@ -92,6 +94,7 @@ type invariants_check = {
   no_cascade_before_measurement : bool;
   compaction_atomicity : bool;
   event_priority_monotone : bool;
+  phase_derivation_agreement : bool;
 }
 
 type last_outcome = {
@@ -242,12 +245,14 @@ let invariant_key_to_string = function
   | Invariant_no_cascade_before_measurement -> "NoCascadeBeforeMeasurement"
   | Invariant_compaction_atomicity -> "CompactionAtomicity"
   | Invariant_event_priority_monotone -> "EventPriorityMonotone"
+  | Invariant_phase_derivation_agreement -> "PhaseDerivationAgreement"
 
 let invariant_key_of_string = function
   | "PhaseTurnAlignment" -> Some Invariant_phase_turn_alignment
   | "NoCascadeBeforeMeasurement" -> Some Invariant_no_cascade_before_measurement
   | "CompactionAtomicity" -> Some Invariant_compaction_atomicity
   | "EventPriorityMonotone" -> Some Invariant_event_priority_monotone
+  | "PhaseDerivationAgreement" -> Some Invariant_phase_derivation_agreement
   | _ -> None
 
 (* Derivation from registry entry *)
@@ -350,6 +355,11 @@ let check_event_priority_monotone
       obs.measurement_bind_count <= 1
       && not (Option.is_some obs.measurement && Option.is_some entry.pending_turn_measurement)
 
+let check_phase_derivation_agreement
+    (entry : Keeper_registry.registry_entry)
+    : bool =
+  Keeper_state_machine.derive_phase entry.conditions = entry.phase
+
 let compute_invariants
     (entry : Keeper_registry.registry_entry)
     ~(phase : ksm_phase)
@@ -366,12 +376,13 @@ let compute_invariants
         ~measurement_captured;
     compaction_atomicity = check_compaction_atomicity phase compaction_stage;
     event_priority_monotone = check_event_priority_monotone entry;
+    phase_derivation_agreement = check_phase_derivation_agreement entry;
   }
 
 (* Prometheus bump — one counter tick per violated invariant per snapshot.
    Called from [observe]. PromQL rate/increase distinguishes transient
-   from steady-state violations. Labels bounded: keeper × invariant (4)
-   ≤ ~200 series on a 50-keeper host. Mirrors the naming pattern in
+   from steady-state violations. Labels bounded: keeper × invariant (5)
+   ≤ ~250 series on a 50-keeper host. Mirrors the naming pattern in
    [Cascade_strategy_trace.bump_prometheus_counter]. *)
 let bump_invariant_violations ~(keeper_name : string) (inv : invariants_check) =
   let bump key satisfied =
@@ -386,7 +397,8 @@ let bump_invariant_violations ~(keeper_name : string) (inv : invariants_check) =
   bump Invariant_phase_turn_alignment inv.phase_turn_alignment;
   bump Invariant_no_cascade_before_measurement inv.no_cascade_before_measurement;
   bump Invariant_compaction_atomicity inv.compaction_atomicity;
-  bump Invariant_event_priority_monotone inv.event_priority_monotone
+  bump Invariant_event_priority_monotone inv.event_priority_monotone;
+  bump Invariant_phase_derivation_agreement inv.phase_derivation_agreement
 
 (* Public API *)
 
@@ -495,6 +507,7 @@ let invariants_to_json (inv : invariants_check) : Yojson.Safe.t =
     "no_cascade_before_measurement", `Bool inv.no_cascade_before_measurement;
     "compaction_atomicity", `Bool inv.compaction_atomicity;
     "event_priority_monotone", `Bool inv.event_priority_monotone;
+    "phase_derivation_agreement", `Bool inv.phase_derivation_agreement;
   ]
 
 let measurement_to_json (m : Keeper_state_machine.auto_rule_summary) : Yojson.Safe.t =

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -97,6 +97,7 @@ type invariant_key =
   | Invariant_no_cascade_before_measurement
   | Invariant_compaction_atomicity
   | Invariant_event_priority_monotone
+  | Invariant_phase_derivation_agreement
 
 val all_invariant_keys : invariant_key list
 
@@ -109,6 +110,7 @@ type invariants_check = {
   no_cascade_before_measurement : bool;
   compaction_atomicity : bool;
   event_priority_monotone : bool;
+  phase_derivation_agreement : bool;
 }
 
 (** Increment [masc_keeper_invariant_violations_total\{keeper, invariant\}]
@@ -120,10 +122,9 @@ val bump_invariant_violations :
 
 (** {2 Pure invariant predicates}
 
-    The four [check_*] functions below are the OCaml mirror of the
-    [SafetyInvariant] conjuncts in
-    [specs/keeper-state-machine/KeeperCompositeLifecycle.tla] (lines
-    354-377). They are exposed so cross-FSM joint tests
+    The [check_*] functions below mirror the composite TLA+
+    [SafetyInvariant] conjuncts and the runtime phase-derivation
+    agreement check. They are exposed so cross-FSM joint tests
     ([test/test_keeper_fsm_joints.ml]) can drive realistic state
     combinations through the same predicates that production
     [compute_invariants] uses, without having to construct a full
@@ -146,6 +147,12 @@ val check_compaction_atomicity : ksm_phase -> compaction_stage -> bool
     requires a captured measurement. *)
 val check_no_cascade_before_measurement :
   cascade_state:cascade_state -> measurement_captured:bool -> bool
+
+val check_phase_derivation_agreement :
+  Keeper_registry.registry_entry -> bool
+(** Runtime-visible mirror of
+    [Keeper_invariant_check.DerivePhaseAgreement]: the recorded registry
+    phase must equal [Keeper_state_machine.derive_phase conditions]. *)
 
 (** Project the 12-state {!Keeper_state_machine.phase} into the 7-state
     composite {!ksm_phase} per the 12->7 mapping documented in

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -24,6 +24,7 @@ let all_satisfied : Obs.invariants_check = {
   no_cascade_before_measurement = true;
   compaction_atomicity = true;
   event_priority_monotone = true;
+  phase_derivation_agreement = true;
 }
 
 let all_violated : Obs.invariants_check = {
@@ -31,6 +32,7 @@ let all_violated : Obs.invariants_check = {
   no_cascade_before_measurement = false;
   compaction_atomicity = false;
   event_priority_monotone = false;
+  phase_derivation_agreement = false;
 }
 
 let make_meta name =
@@ -86,7 +88,8 @@ let test_bump_increments_each_violated () =
   let keeper = "test-bump-all-violated" in
   let invariants =
     [ "PhaseTurnAlignment"; "NoCascadeBeforeMeasurement";
-      "CompactionAtomicity"; "EventPriorityMonotone" ]
+      "CompactionAtomicity"; "EventPriorityMonotone";
+      "PhaseDerivationAgreement" ]
   in
   let before = List.map (fun inv -> (inv, read ~keeper ~invariant:inv)) invariants in
   Obs.bump_invariant_violations ~keeper_name:keeper all_violated;
@@ -106,11 +109,13 @@ let test_bump_selective_increments () =
     no_cascade_before_measurement = true;  (* satisfied, no bump *)
     compaction_atomicity = false;
     event_priority_monotone = true;        (* satisfied, no bump *)
+    phase_derivation_agreement = false;
   } in
   let pt_before = read ~keeper ~invariant:"PhaseTurnAlignment" in
   let nc_before = read ~keeper ~invariant:"NoCascadeBeforeMeasurement" in
   let ca_before = read ~keeper ~invariant:"CompactionAtomicity" in
   let ep_before = read ~keeper ~invariant:"EventPriorityMonotone" in
+  let pd_before = read ~keeper ~invariant:"PhaseDerivationAgreement" in
   Obs.bump_invariant_violations ~keeper_name:keeper mixed;
   check (float 0.0001) "phase_turn_alignment +1"
     (pt_before +. 1.0) (read ~keeper ~invariant:"PhaseTurnAlignment");
@@ -119,7 +124,9 @@ let test_bump_selective_increments () =
   check (float 0.0001) "compaction_atomicity +1"
     (ca_before +. 1.0) (read ~keeper ~invariant:"CompactionAtomicity");
   check (float 0.0001) "event_priority_monotone unchanged"
-    ep_before (read ~keeper ~invariant:"EventPriorityMonotone")
+    ep_before (read ~keeper ~invariant:"EventPriorityMonotone");
+  check (float 0.0001) "phase_derivation_agreement +1"
+    (pd_before +. 1.0) (read ~keeper ~invariant:"PhaseDerivationAgreement")
 
 (* --- bump: per-keeper isolation ----------------------------------- *)
 
@@ -139,11 +146,31 @@ let test_all_invariant_keys_mapped () =
   let strings =
     List.map Obs.invariant_key_to_string Obs.all_invariant_keys
   in
-  check int "4 invariant keys" 4 (List.length strings);
+  check int "5 invariant keys" 5 (List.length strings);
   check (list string) "key names match alert-rule labels"
     [ "PhaseTurnAlignment"; "NoCascadeBeforeMeasurement";
-      "CompactionAtomicity"; "EventPriorityMonotone" ]
+      "CompactionAtomicity"; "EventPriorityMonotone";
+      "PhaseDerivationAgreement" ]
     strings
+
+let test_phase_derivation_agreement_detects_mismatch () =
+  with_registry (fun () ->
+    let base_path = "/tmp/keeper-composite-phase-derivation" in
+    let keeper_name = "phase-derivation-drift" in
+    let entry = Reg.register ~base_path keeper_name (make_meta keeper_name) in
+    check bool "registered entry agrees" true
+      (Obs.check_phase_derivation_agreement entry);
+    let drifted_entry = { entry with Reg.phase = Ksm.Paused } in
+    check bool "recorded phase drift is detected" false
+      (Obs.check_phase_derivation_agreement drifted_entry);
+    let before = read ~keeper:keeper_name ~invariant:"PhaseDerivationAgreement" in
+    let snapshot = Obs.observe drifted_entry |> Obs.snapshot_to_json in
+    let invariants = Json.member "invariants" snapshot in
+    check bool "snapshot exposes phase_derivation_agreement=false" false
+      (Json.member "phase_derivation_agreement" invariants |> Json.to_bool);
+    check (float 0.0001) "counter increments on phase derivation drift"
+      (before +. 1.0)
+      (read ~keeper:keeper_name ~invariant:"PhaseDerivationAgreement"))
 
 let test_snapshot_reports_collapsed_from_for_stable_phase () =
   with_registry (fun () ->
@@ -256,6 +283,8 @@ let () =
     ; test_case "active phase leaves collapsed_from null" `Quick test_snapshot_omits_collapsed_from_for_active_phase
     ; test_case "snapshot exposes keeper identity" `Quick test_snapshot_reports_keeper_identity
     ; test_case "snapshot exposes phase diagnosis" `Quick test_snapshot_reports_phase_diagnosis
+    ; test_case "phase derivation mismatch is visible" `Quick
+        test_phase_derivation_agreement_detects_mismatch
     ];
     "composite change signals",
     [ test_case "direct turn mutations emit composite tick" `Quick test_direct_turn_mutations_emit_composite_changed ];


### PR DESCRIPTION
## Summary

Fixes #13409.

This makes the runtime composite observer surface the same phase-derivation agreement that `Keeper_invariant_check.DerivePhaseAgreement` already validates in traces/PBT. A registry entry whose recorded phase diverges from `Keeper_state_machine.derive_phase conditions` now appears in snapshot JSON and increments `masc_keeper_invariant_violations_total{invariant="PhaseDerivationAgreement"}`.

## Review Focus

- Runtime-visible invariant only; no state machine transition behavior changes.
- Prometheus label/cardinality contract now lists 5 keeper invariants.
- Focused regression covers a drifted registry entry, JSON projection, and counter bump.

## Validation

- `scripts/dune-local.sh build test/test_keeper_composite_observer.exe`
- `./_build/default/test/test_keeper_composite_observer.exe`
- `git diff --check`

Note: focused build still emits pre-existing `legacy_tuple` alerts from unrelated `Tool_result.to_legacy_compat` callers.