### PR TITLE
fix(keeper): pause required-tool contract loops

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -35,6 +35,14 @@ let registry_failure_reason_of_terminal_reason
            { code = terminal_reason.code; detail })
   | _ -> None
 
+let should_auto_pause_required_tool_contract_violation
+    ~(paused : bool)
+    ~(consecutive_failures : int)
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  EC.is_required_tool_contract_violation err
+  && consecutive_failures >= Keeper_behavioral_regime.turn_fail_streak_threshold
+  && not paused
+
 let record_streaming_cancelled_observation
     ~(config : Coord.config)
     ~(run_meta : keeper_meta)
@@ -1935,31 +1943,72 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             && count >= Keeper_behavioral_regime.turn_fail_streak_threshold
             && not updated_meta.paused
           in
-          if cascade_auto_paused then begin
-            match
-              sync_keeper_paused_state ~config ~meta:updated_meta ~paused:true
-            with
-            | Ok _ ->
-                Keeper_registry.set_failure_reason ~base_path:config.base_path
-                  meta.name
-                  (Some (Keeper_registry.Turn_consecutive_failures count));
-                Log.Keeper.warn
-                  "%s: auto-paused after %d cascade_exhausted failures \
-                   (pause_threshold=%d, crash_threshold=%d); operator must \
-                   resume after cascade fix"
-                  meta.name count
-                  Keeper_behavioral_regime.turn_fail_streak_threshold
-                  threshold
-            | Error sync_err ->
-                Log.Keeper.error
-                  "%s: cascade auto-pause sync failed: %s \
-                   (falling through to crash path)" meta.name sync_err;
-                Prometheus.inc_counter
-                  Prometheus.metric_keeper_cascade_sync_failures
-                  ~labels:[("keeper", meta.name); ("site", "auto_pause")]
-                  ();
-          end;
-          if count >= threshold && not cascade_auto_paused then begin
+          let tool_contract_auto_paused =
+            should_auto_pause_required_tool_contract_violation
+              ~paused:updated_meta.paused
+              ~consecutive_failures:count err
+          in
+          let auto_pause_succeeded =
+            if cascade_auto_paused || tool_contract_auto_paused then begin
+              let released_task_id =
+                if tool_contract_auto_paused then
+                  Option.map Keeper_id.Task_id.to_string
+                    updated_meta.current_task_id
+                else None
+              in
+              let pause_meta =
+                if tool_contract_auto_paused then
+                  { updated_meta with current_task_id = None }
+                else
+                  updated_meta
+              in
+              match
+                sync_keeper_paused_state ~config ~meta:pause_meta ~paused:true
+              with
+              | Ok _ ->
+                  if cascade_auto_paused then begin
+                    Keeper_registry.set_failure_reason ~base_path:config.base_path
+                      meta.name
+                      (Some (Keeper_registry.Turn_consecutive_failures count));
+                    Log.Keeper.warn
+                      "%s: auto-paused after %d cascade_exhausted failures \
+                       (pause_threshold=%d, crash_threshold=%d); operator must \
+                       resume after cascade fix"
+                      meta.name count
+                      Keeper_behavioral_regime.turn_fail_streak_threshold
+                      threshold
+                  end else
+                    Log.Keeper.warn
+                      "%s: auto-paused after %d required-tool contract \
+                       failures (pause_threshold=%d, crash_threshold=%d, \
+                       released_task=%s); operator must inspect provider tool \
+                       contract before resuming"
+                      meta.name count
+                      Keeper_behavioral_regime.turn_fail_streak_threshold
+                      threshold
+                      (Option.value ~default:"none" released_task_id);
+                  true
+              | Error sync_err ->
+                  let auto_pause_kind =
+                    if cascade_auto_paused then "cascade" else "tool_contract"
+                  in
+                  Log.Keeper.error
+                    "%s: %s auto-pause sync failed: %s \
+                     (persistent failure remains on the crash path)"
+                    meta.name auto_pause_kind sync_err;
+                  Prometheus.inc_counter
+                    Prometheus.metric_keeper_cascade_sync_failures
+                    ~labels:
+                      [ ("keeper", meta.name);
+                        ( "site",
+                          if cascade_auto_paused then "auto_pause"
+                          else "tool_contract_auto_pause" ) ]
+                    ();
+                  false
+            end else
+              false
+          in
+          if count >= threshold && not auto_pause_succeeded then begin
             Prometheus.inc_counter
               Prometheus.metric_keeper_oas_execution_errors
               ~labels:[("keeper", meta.name); ("phase", "persistent_escalation")]

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -142,6 +142,16 @@ val sync_keeper_paused_state :
   paused:bool ->
   (Keeper_types.keeper_meta, string) result
 
+(** Required-tool contract failures are persistent keeper/provider contract
+    failures, not transient provider blips. Repeated occurrences should pause
+    the keeper before the generic supervisor crash/restart loop re-enters the
+    same prompt and model family. Exposed for regression tests. *)
+val should_auto_pause_required_tool_contract_violation :
+  paused:bool ->
+  consecutive_failures:int ->
+  Agent_sdk.Error.sdk_error ->
+  bool
+
 (** Ensure local-provider discovery is refreshed before a turn when the
     selected labels depend on runtime discovery. Exposed for targeted tests. *)
 val ensure_local_discovery_ready :

--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -29,6 +29,7 @@ module EC = Masc_mcp.Keeper_error_classify
 module Owne = Masc_mcp.Oas_worker_named
 module KT = Masc_mcp.Keeper_types
 module Regime = Masc_mcp.Keeper_behavioral_regime
+module UT = Masc_mcp.Keeper_unified_turn
 
 let cascade_name raw = Owne.cascade_name_of_string raw
 
@@ -88,6 +89,15 @@ let mk_admission_queue_timeout () =
          cascade_name = cascade_name "test";
          wait_sec = 5.0 })
 
+let mk_required_tool_contract_violation () =
+  Agent_sdk.Error.Agent
+    (Agent_sdk.Error.CompletionContractViolation
+       {
+         contract = Agent_sdk.Completion_contract_id.Require_tool_use;
+         reason =
+           "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+       })
+
 let test_pause_does_not_fire_on_transient () =
   check bool "Oas_timeout_budget -> no pause" false
     (EC.is_cascade_exhausted_error (mk_oas_timeout_budget ()));
@@ -126,6 +136,29 @@ let test_regime_flips_to_thrashing_at_threshold () =
   check string "rule_id -> turn_fail_streak"
     "turn_fail_streak" snapshot.reason.rule_id
 
+let test_required_tool_contract_pause_guard () =
+  let violation = mk_required_tool_contract_violation () in
+  check bool "below threshold -> no pause" false
+    (UT.should_auto_pause_required_tool_contract_violation
+       ~paused:false
+       ~consecutive_failures:(Regime.turn_fail_streak_threshold - 1)
+       violation);
+  check bool "threshold -> pause" true
+    (UT.should_auto_pause_required_tool_contract_violation
+       ~paused:false
+       ~consecutive_failures:Regime.turn_fail_streak_threshold
+       violation);
+  check bool "already paused -> no duplicate pause" false
+    (UT.should_auto_pause_required_tool_contract_violation
+       ~paused:true
+       ~consecutive_failures:Regime.turn_fail_streak_threshold
+       violation);
+  check bool "non contract error -> no pause" false
+    (UT.should_auto_pause_required_tool_contract_violation
+       ~paused:false
+       ~consecutive_failures:Regime.turn_fail_streak_threshold
+       (mk_oas_timeout_budget ()))
+
 let () =
   run "keeper_cascade_auto_pause_task074"
     [
@@ -141,5 +174,10 @@ let () =
           test_case "pause threshold < crash default" `Quick test_threshold_pin;
           test_case "regime flip at threshold" `Quick
             test_regime_flips_to_thrashing_at_threshold;
+        ] );
+      ( "required-tool contract pause",
+        [
+          test_case "required contract loops pause before crash" `Quick
+            test_required_tool_contract_pause_guard;
         ] );
     ]


### PR DESCRIPTION
## Summary

Repeated required-tool contract failures now take the same operator-visible pause path as cascade exhaustion instead of falling through to the generic supervisor crash/restart loop.

- Adds a pure predicate for required-tool contract auto-pause at the existing turn failure streak threshold.
- Pauses the keeper when the predicate trips and clears `current_task_id` so a claimed task is not stranded behind a paused keeper.
- Preserves the existing strict contract: a no-tool/passive actionable turn still fails; this only changes repeated failure handling.
- Extends `test_keeper_cascade_auto_pause_task074` to pin the new required-tool pause guard.

Refs #13362.

## Operator Impact

A keeper that repeatedly returns no useful required tool progress for actionable work should stop burning cycles in the same prompt/model loop. Operators will see a paused keeper with the existing tool-required/contract blocker surfaces and can inspect provider/tool contract health before resuming.

## Verification

- `MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 scripts/dune-local.sh build test/test_keeper_cascade_auto_pause_task074.exe`
- `./_build/default/test/test_keeper_cascade_auto_pause_task074.exe`

Notes: the focused build still emits pre-existing `Tool_result.to_legacy_compat` migration alerts from unrelated modules; the target exits successfully.