### PR TITLE
fix(dashboard): label runtime blocker classes

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -8,6 +8,7 @@ import {
   keeperActivityDisplay,
   keeperDisplayModel,
   keeperDisplayStatus,
+  keeperRuntimeBlockerLabel,
   keeperRuntimeBlockerHint,
 } from '../lib/keeper-runtime-display'
 import { signal } from '@preact/signals'
@@ -347,19 +348,7 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const toneClass = keeper.paused || socialFallbackActive || runtimeBlocker || blocker || hbStale
     ? 'border-[var(--warn-24)] bg-[var(--warn-8)]'
     : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)]'
-  const runtimeBlockerLabel = runtimeBlockerClass
-    ? {
-        ambiguous_post_commit_timeout: '커밋 후 응답 없음',
-        ambiguous_post_commit_failure: '커밋 후 실패',
-        autonomous_slot_wait_timeout: '자율 슬롯 대기 만료',
-        admission_queue_wait_timeout: '대기열 진입 만료',
-        turn_timeout_after_queue_wait: '대기 후 턴 만료',
-        oas_timeout_budget: 'OAS 응답 만료',
-        turn_timeout: '턴 응답 만료',
-        completion_contract_violation: '완료 계약 위반',
-        cascade_exhausted: '캐스케이드 소진',
-      }[runtimeBlockerClass]
-    : null
+  const runtimeBlockerLabel = keeperRuntimeBlockerLabel(runtimeBlockerClass)
   const trustToneClass =
     trustDisposition === 'Alert'
       ? 'bg-[var(--bad-soft)] text-[var(--color-status-err)]'

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Keeper } from '../types'
 import {
   keeperDisplayStatus,
+  keeperRuntimeBlockerLabel,
   keeperRecentActionLabel,
   keeperRecentHeartbeatLabel,
   keeperRuntimeHint,
@@ -87,6 +88,25 @@ describe('mission keeper runtime helpers', () => {
 
     expect(keeperRuntimeHint(keeper)).toBe(
       '계속 진행 승인 대기 · Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+    )
+  })
+
+  it('labels backend runtime blocker classes used by keeper_status_bridge', () => {
+    expect(keeperRuntimeBlockerLabel('no_tool_capable_provider')).toBe('도구 실행 Provider 없음')
+    expect(keeperRuntimeBlockerLabel('fiber_unresolved')).toBe('Fiber 미해결')
+    expect(keeperRuntimeBlockerLabel('stale_turn_timeout')).toBe('오래된 턴 만료')
+  })
+
+  it('turns raw backend blocker codes into operator-readable hints', () => {
+    const keeper = {
+      name: 'tool-less',
+      status: 'idle',
+      runtime_blocker_class: 'no_tool_capable_provider',
+      runtime_blocker_summary: 'no_tool_capable_provider',
+    } as Keeper
+
+    expect(keeperRuntimeHint(keeper)).toBe(
+      '요구 도구를 실행할 수 있는 provider가 없어 라우팅 또는 tool surface 확인이 필요합니다.',
     )
   })
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -227,12 +227,34 @@ function continueGateHint(keeper: Keeper): string {
   return '계속 진행 승인 대기 · 일부 변경이 반영되었을 수 있어 운영자 확인이 필요합니다.'
 }
 
+const runtimeBlockerLabels = {
+  ambiguous_post_commit_timeout: '커밋 후 응답 없음',
+  ambiguous_post_commit_failure: '커밋 후 실패',
+  autonomous_slot_wait_timeout: '자율 슬롯 대기 만료',
+  admission_queue_wait_timeout: '대기열 진입 만료',
+  turn_timeout_after_queue_wait: '대기 후 턴 만료',
+  oas_timeout_budget: 'OAS 응답 만료',
+  turn_timeout: '턴 응답 만료',
+  completion_contract_violation: '완료 계약 위반',
+  cascade_exhausted: '캐스케이드 소진',
+  no_tool_capable_provider: '도구 실행 Provider 없음',
+  fiber_unresolved: 'Fiber 미해결',
+  stale_turn_timeout: '오래된 턴 만료',
+} satisfies Record<NonNullable<Keeper['runtime_blocker_class']>, string>
+
+export function keeperRuntimeBlockerLabel(
+  blockerClass: Keeper['runtime_blocker_class'] | null | undefined,
+): string | null {
+  if (!blockerClass) return null
+  return runtimeBlockerLabels[blockerClass] ?? null
+}
+
 export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): string | null {
   if (!keeper) return null
   if (keeper.runtime_blocker_continue_gate) return continueGateHint(keeper)
   const blockerClass = keeper.runtime_blocker_class
   const runtimeBlocker = keeper.runtime_blocker_summary?.trim()
-  if (runtimeBlocker) return runtimeBlocker
+  if (runtimeBlocker && runtimeBlocker !== blockerClass) return runtimeBlocker
   if (blockerClass === 'ambiguous_post_commit_timeout') {
     return '최근 변경 이후 응답이 끊겨 상태 확인이 필요합니다.'
   }
@@ -256,6 +278,18 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'completion_contract_violation') {
     return '완료 계약 조건을 만족하지 못해 재확인이 필요합니다.'
+  }
+  if (blockerClass === 'cascade_exhausted') {
+    return '캐스케이드 후보가 모두 소진되어 provider 상태 확인이 필요합니다.'
+  }
+  if (blockerClass === 'no_tool_capable_provider') {
+    return '요구 도구를 실행할 수 있는 provider가 없어 라우팅 또는 tool surface 확인이 필요합니다.'
+  }
+  if (blockerClass === 'fiber_unresolved') {
+    return 'Keeper fiber가 종료 상태를 확정하지 못해 supervisor 확인이 필요합니다.'
+  }
+  if (blockerClass === 'stale_turn_timeout') {
+    return '오래된 턴 제한 시간이 만료되어 최신 실행 상태 확인이 필요합니다.'
   }
   return null
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -750,6 +750,9 @@ export interface Keeper {
     | 'turn_timeout'
     | 'completion_contract_violation'
     | 'cascade_exhausted'
+    | 'no_tool_capable_provider'
+    | 'fiber_unresolved'
+    | 'stale_turn_timeout'
     | null
   runtime_blocker_summary?: string | null
   runtime_blocker_continue_gate?: boolean | null


### PR DESCRIPTION
## Summary

- Extend the dashboard `Keeper.runtime_blocker_class` union to include backend classes already emitted by `keeper_status_bridge`: `no_tool_capable_provider`, `fiber_unresolved`, and `stale_turn_timeout`.
- Centralize runtime blocker labels in `keeper-runtime-display` and reuse them from keeper detail.
- Convert raw canonical blocker summaries into operator-readable Korean hints when the backend summary is just the blocker code.
- Add regression coverage for the new label surface and raw-code hint behavior.

## Why

#10512 is still open because stuck/root-cause visibility remains incomplete. Current backend already has more structured blocker classes than the dashboard names. Without explicit labels, the keeper detail strip can fall back to generic `런타임 차단` or raw enum-like text, which weakens the operator-facing stuck reason surface.

## Operator Impact

Keeper detail now names these blocker causes directly: no provider can run the required tool, keeper fiber did not resolve, and stale turn timeout. Operators see a concrete reason instead of a generic runtime-blocked chip or raw backend code.

## Validation

- `git diff --check`
- `pnpm install --offline --frozen-lockfile` in `dashboard/` to materialize this worktree's local `node_modules` from the pnpm store
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/mission-agent-cards.test.ts` (8 tests passed)