### PR TITLE
fix(keeper): detect required-tool contract loops

### DIFF
--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -1,4 +1,4 @@
-(** Keeper_passive_loop_detector — detect keepers stuck in passive-read loops.
+(** Keeper_passive_loop_detector — detect keepers stuck in no-progress loops.
 
     A "passive loop" is N consecutive turns where the LLM only called
     read-only / status tools ([Passive_status] class in
@@ -15,6 +15,10 @@
 let default_threshold = 5
 (** Number of consecutive passive turns before declaring a loop. *)
 
+let required_tool_failure_threshold = 3
+(** Number of consecutive required-tool contract failures before declaring
+    a no-tool/no-progress loop (#13362). *)
+
 let threshold () =
   max 2
     (match Sys.getenv_opt "MASC_KEEPER_PASSIVE_LOOP_THRESHOLD" with
@@ -24,9 +28,20 @@ let threshold () =
          | Some n when n > 0 -> n
          | _ -> default_threshold)
 
+let required_tool_no_call_progress_class = "required_tool_no_call"
+let required_tool_unsatisfied_progress_class = "required_tool_unsatisfied"
+
+let progress_class_of_terminal_reason_code = function
+  | "required_tool_use_no_tool_call" ->
+      Some required_tool_no_call_progress_class
+  | "required_tool_use_unsatisfied" ->
+      Some required_tool_unsatisfied_progress_class
+  | _ -> None
+
 type keeper_state = {
   mutable streak : int;
   mutable detected_latched : bool;
+  mutable last_progress_class : string option;
   (* Task-138: Unix timestamp of the most recent productive turn
      (execution/completion class). 0.0 until the keeper has produced
      anything in this process. *)
@@ -45,7 +60,7 @@ let get_or_create keeper_name =
   | Some s -> s
   | None ->
       let s = { streak = 0; detected_latched = false;
-                last_productive_ts = 0.0 } in
+                last_progress_class = None; last_productive_ts = 0.0 } in
       Hashtbl.replace state keeper_name s;
       s
 
@@ -67,6 +82,53 @@ let update_last_productive_gauge keeper_name ts =
     ~labels:[("keeper", keeper_name)]
     ts
 
+let is_required_tool_progress_class = function
+  | "required_tool_no_call" | "required_tool_unsatisfied" -> true
+  | _ -> false
+
+let increments_streak = function
+  | "passive_status" | "claim_context"
+  | "required_tool_no_call" | "required_tool_unsatisfied" -> true
+  | _ -> false
+
+let same_streak_family a b =
+  (is_required_tool_progress_class a && is_required_tool_progress_class b)
+  || ((not (is_required_tool_progress_class a))
+      && not (is_required_tool_progress_class b))
+
+let threshold_for_progress_class progress_class =
+  if is_required_tool_progress_class progress_class
+  then required_tool_failure_threshold
+  else threshold ()
+
+let detect_counter_for_progress_class progress_class =
+  if is_required_tool_progress_class progress_class
+  then Prometheus.metric_keeper_required_tool_loop_detected_total
+  else Prometheus.metric_keeper_passive_loop_detected_total
+
+let detect_labels_for_progress_class keeper_name progress_class =
+  if is_required_tool_progress_class progress_class
+  then [("keeper", keeper_name); ("kind", progress_class)]
+  else [("keeper", keeper_name)]
+
+let log_detected_loop keeper_name progress_class streak threshold =
+  if is_required_tool_progress_class progress_class then
+    Log.Keeper.warn
+      "REQUIRED_TOOL_LOOP: keeper=%s streak=%d threshold=%d kind=%s \
+       — actionable turns are failing the required-tool contract before any \
+       execution/completion progress. The next turn will receive a \
+       tool-required nudge; inspect provider tool support and active-goal \
+       ownership if this repeats."
+      keeper_name streak threshold progress_class
+  else
+    Log.Keeper.warn
+      "PASSIVE_LOOP: keeper=%s streak=%d threshold=%d \
+       — keeper is completing turns with only read-only/status tools. \
+       Check task assignment, persona contract, or cascade proactive \
+       setting.  Counter latched; will not re-fire until an \
+       execution/completion turn resets the streak."
+      keeper_name streak threshold
+
 (** [record_turn ~keeper_name ~progress_class] updates the passive streak
     counter for [keeper_name] based on the [tool_progress_class] of the
     turn that just completed.  Pass the string representation
@@ -74,37 +136,40 @@ let update_last_productive_gauge keeper_name ts =
 let record_turn ~keeper_name ~progress_class =
   with_lock (fun () ->
     let s = get_or_create keeper_name in
-    match progress_class with
-    | "passive_status" | "claim_context" ->
-        s.streak <- s.streak + 1;
+    if increments_streak progress_class then begin
+        s.streak <-
+          (match s.last_progress_class with
+          | Some last when same_streak_family last progress_class -> s.streak + 1
+          | _ ->
+              s.detected_latched <- false;
+              1);
+        s.last_progress_class <- Some progress_class;
         update_streak_gauge keeper_name s.streak;
-        let t = threshold () in
+        let t = threshold_for_progress_class progress_class in
         if s.streak >= t && not s.detected_latched then begin
           s.detected_latched <- true;
           Prometheus.inc_counter
-            Prometheus.metric_keeper_passive_loop_detected_total
-            ~labels:[("keeper", keeper_name)] ();
-          Log.Keeper.warn
-            "PASSIVE_LOOP: keeper=%s streak=%d threshold=%d \
-             — keeper is completing turns with only read-only/status tools. \
-             Check task assignment, persona contract, or cascade proactive \
-             setting.  Counter latched; will not re-fire until an \
-             execution/completion turn resets the streak."
-            keeper_name s.streak t
+            (detect_counter_for_progress_class progress_class)
+            ~labels:(detect_labels_for_progress_class keeper_name progress_class)
+            ();
+          log_detected_loop keeper_name progress_class s.streak t
         end
-    | _ ->
+      end
+    else begin
         (* Execution or Completion: reset streak *)
         if s.streak > 0 then
           update_streak_gauge keeper_name 0;
         s.streak <- 0;
         s.detected_latched <- false;
+        s.last_progress_class <- Some progress_class;
         (* Task-138: record productive turn timestamp + gauge.
            Both internal field and external metric stay in sync so a
            later [last_productive_ts] read returns the same value the
            dashboard sees. *)
         let now = Unix.time () in
         s.last_productive_ts <- now;
-        update_last_productive_gauge keeper_name now)
+        update_last_productive_gauge keeper_name now
+      end)
 
 let current_streak ~keeper_name =
   with_lock (fun () ->
@@ -112,22 +177,38 @@ let current_streak ~keeper_name =
     | Some s -> s.streak
     | None -> 0)
 
-let nudge_message_text ~streak =
-  Printf.sprintf
-    ("ACTION REQUIRED — PASSIVE LOOP DETECTED: You have completed %d"
-     ^^ " consecutive turns using only read-only or status tools without any"
-     ^^ " execution or completion action. This violates the keeper turn"
-     ^^ " contract. You MUST call an execution or completion tool this turn"
-     ^^ " (e.g. keeper_task_done, keeper_task_claim, keeper_shell,"
-     ^^ " keeper_board_post with a concrete update, or another write tool)."
-     ^^ " Do not call read-only tools again without first taking an action.")
-    streak
+let nudge_message_text ~streak ~progress_class =
+  if is_required_tool_progress_class progress_class then
+    Printf.sprintf
+      ("ACTION REQUIRED — REQUIRED TOOL LOOP DETECTED: You have failed %d"
+       ^^ " consecutive actionable turns without satisfying the required"
+       ^^ " keeper-tool contract (%s). This turn MUST emit a real keeper"
+       ^^ " tool call that advances the active goal/task, such as"
+       ^^ " keeper_shell, keeper_fs_read, keeper_board_post,"
+       ^^ " keeper_board_comment, keeper_task_claim, or keeper_task_done."
+       ^^ " If no action is actually possible, call keeper_stay_silent only"
+       ^^ " with a typed no-work proof instead of returning plain text or"
+       ^^ " an empty response.")
+      streak progress_class
+  else
+    Printf.sprintf
+      ("ACTION REQUIRED — PASSIVE LOOP DETECTED: You have completed %d"
+       ^^ " consecutive turns using only read-only or status tools without any"
+       ^^ " execution or completion action. This violates the keeper turn"
+       ^^ " contract. You MUST call an execution or completion tool this turn"
+       ^^ " (e.g. keeper_task_done, keeper_task_claim, keeper_shell,"
+       ^^ " keeper_board_post with a concrete update, or another write tool)."
+       ^^ " Do not call read-only tools again without first taking an action.")
+      streak
 
 let nudge_message ~keeper_name =
   with_lock (fun () ->
     match Hashtbl.find_opt state keeper_name with
     | Some s when s.detected_latched ->
-        Some (nudge_message_text ~streak:s.streak)
+        let progress_class =
+          Option.value ~default:"passive_status" s.last_progress_class
+        in
+        Some (nudge_message_text ~streak:s.streak ~progress_class)
     | _ -> None)
 
 let reset ~keeper_name =

--- a/lib/keeper/keeper_passive_loop_detector.mli
+++ b/lib/keeper/keeper_passive_loop_detector.mli
@@ -1,4 +1,4 @@
-(** Keeper_passive_loop_detector — detect keepers stuck in passive-read loops.
+(** Keeper_passive_loop_detector — detect keepers stuck in no-progress loops.
 
     A "passive loop" occurs when a keeper completes N consecutive turns
     using only read-only / status tools without any execution or completion
@@ -7,7 +7,17 @@
     calls but they are all passive reads that cannot satisfy an owned task
     contract.
 
+    The same detector also tracks repeated required-tool contract failures
+    where an actionable turn returns no keeper tool call. Those failed turns
+    never reach the normal post-success progress classifier, so the keeper
+    failure path records them explicitly here.
+
     @since #12799 *)
+
+val progress_class_of_terminal_reason_code : string -> string option
+(** Map typed terminal-reason codes into detector progress classes. Returns
+    [Some _] only for required-tool failures that should count toward an
+    inter-turn no-progress loop. *)
 
 val record_turn :
   keeper_name:string ->
@@ -20,6 +30,8 @@ val record_turn :
     [Keeper_tool_disclosure.tool_progress_class] for the turn's dominant
     tool usage:
     - ["passive_status"] or ["claim_context"] increments the streak.
+    - ["required_tool_no_call"] or ["required_tool_unsatisfied"] increments
+      the required-tool failure streak.
     - Any other value (["execution"] / ["completion"]) resets the streak
       and clears the detection latch.
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1802,6 +1802,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   (Some failure_reason)
             | None -> ()
           end;
+          (match
+             Keeper_passive_loop_detector.progress_class_of_terminal_reason_code
+               terminal_reason.code
+           with
+           | Some progress_class ->
+               Keeper_passive_loop_detector.record_turn
+                 ~keeper_name:updated_meta.name ~progress_class
+           | None -> ());
           Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~semaphore_wait_ms
             ~outcome:(if is_ambiguous_partial then "partial" else "error")

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1026,6 +1026,8 @@ let metric_provider_actual_health_status =
    calls for N consecutive turns.  Labels: keeper. *)
 let metric_keeper_passive_loop_detected_total =
   "masc_keeper_passive_loop_detected_total"
+let metric_keeper_required_tool_loop_detected_total =
+  "masc_keeper_required_tool_loop_detected_total"
 
 (* Task-138: Minimum proactive cadence — observability gauges that pair
    with the [keeper_passive_loop_detector] streak counter so operators
@@ -1702,6 +1704,11 @@ let init () =
   add metric_keeper_passive_loop_detected_total
     "#12799 Total passive-loop detections: keeper issued only read-only tool \
      calls for N consecutive turns. Labeled by keeper."
+    Counter;
+  add metric_keeper_required_tool_loop_detected_total
+    "#13362 Total required-tool contract loops: keeper hit N consecutive \
+     actionable required-tool failures before making execution/completion \
+     progress. Labeled by keeper and kind."
     Counter;
   add metric_keeper_consecutive_idle
     "Task-138 Current consecutive-idle streak (passive-only turns) per \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -339,6 +339,11 @@ val metric_keeper_passive_loop_detected_total : string
     Incremented once per loop episode (streak resets on any execution-progress
     turn). Labels: [keeper]. *)
 
+val metric_keeper_required_tool_loop_detected_total : string
+(** #13362 Total required-tool contract loops: keeper hit N consecutive
+    actionable required-tool failures before making execution/completion
+    progress.  Incremented once per loop episode. Labels: [keeper, kind]. *)
+
 val metric_keeper_consecutive_idle : string
 (** Task-138 Current consecutive-idle streak (passive-only turns) per
     keeper.  Resets to 0 on the next execution/completion turn.  Pairs

--- a/test/test_keeper_passive_loop_detector.ml
+++ b/test/test_keeper_passive_loop_detector.ml
@@ -15,6 +15,7 @@ let setup () = PLD.reset_all_for_test ()
 (* ── Tests ──────────────────────────────────────────────────────────── *)
 
 let test_initial_streak_zero () =
+  Eio_main.run @@ fun _env ->
   setup ();
   check int "no-state keeper streak = 0" 0
     (PLD.current_streak ~keeper_name:"k1")
@@ -33,6 +34,77 @@ let test_claim_context_increments_streak () =
   PLD.record_turn ~keeper_name:"k1" ~progress_class:"claim_context";
   check int "claim_context increments" 1
     (PLD.current_streak ~keeper_name:"k1")
+
+let test_terminal_reason_maps_required_tool_failures () =
+  check (option string) "no tool call maps to detector class"
+    (Some "required_tool_no_call")
+    (PLD.progress_class_of_terminal_reason_code
+       "required_tool_use_no_tool_call");
+  check (option string) "unsatisfied maps to detector class"
+    (Some "required_tool_unsatisfied")
+    (PLD.progress_class_of_terminal_reason_code
+       "required_tool_use_unsatisfied");
+  check (option string) "provider errors do not count"
+    None
+    (PLD.progress_class_of_terminal_reason_code "provider_error")
+
+let test_required_tool_no_call_fires_metric_at_three () =
+  Eio_main.run @@ fun _env ->
+  setup ();
+  let labels =
+    [ ("keeper", "k-required-no-call"); ("kind", "required_tool_no_call") ]
+  in
+  let before =
+    P.metric_value_or_zero
+      P.metric_keeper_required_tool_loop_detected_total
+      ~labels ()
+  in
+  PLD.record_turn ~keeper_name:"k-required-no-call"
+    ~progress_class:"required_tool_no_call";
+  PLD.record_turn ~keeper_name:"k-required-no-call"
+    ~progress_class:"required_tool_no_call";
+  check int "below required-tool threshold" 2
+    (PLD.current_streak ~keeper_name:"k-required-no-call");
+  check (float 0.001) "no metric before threshold" before
+    (P.metric_value_or_zero
+       P.metric_keeper_required_tool_loop_detected_total
+       ~labels ());
+  PLD.record_turn ~keeper_name:"k-required-no-call"
+    ~progress_class:"required_tool_no_call";
+  check int "at required-tool threshold" 3
+    (PLD.current_streak ~keeper_name:"k-required-no-call");
+  check (float 0.001) "required-tool metric increments once"
+    (before +. 1.0)
+    (P.metric_value_or_zero
+       P.metric_keeper_required_tool_loop_detected_total
+       ~labels ())
+
+let test_required_tool_streak_does_not_inherit_passive_streak () =
+  Eio_main.run @@ fun _env ->
+  setup ();
+  PLD.record_turn ~keeper_name:"k-family" ~progress_class:"passive_status";
+  PLD.record_turn ~keeper_name:"k-family" ~progress_class:"passive_status";
+  check int "passive streak starts" 2
+    (PLD.current_streak ~keeper_name:"k-family");
+  PLD.record_turn ~keeper_name:"k-family"
+    ~progress_class:"required_tool_no_call";
+  check int "required-tool family starts its own streak" 1
+    (PLD.current_streak ~keeper_name:"k-family")
+
+let test_required_tool_nudge_mentions_real_tool_call () =
+  Eio_main.run @@ fun _env ->
+  setup ();
+  for _ = 1 to 3 do
+    PLD.record_turn ~keeper_name:"k-required-nudge"
+      ~progress_class:"required_tool_no_call"
+  done;
+  match PLD.nudge_message ~keeper_name:"k-required-nudge" with
+  | None -> fail "expected required-tool nudge at threshold"
+  | Some msg ->
+      check bool "nudge names required tool loop" true
+        (Re.execp (Re.compile (Re.str "REQUIRED TOOL LOOP")) msg);
+      check bool "nudge requires real keeper tool" true
+        (Re.execp (Re.compile (Re.str "real keeper tool call")) msg)
 
 let test_execution_resets_streak () =
   Eio_main.run @@ fun _env ->
@@ -185,6 +257,14 @@ let () =
         test_passive_increments_streak;
       test_case "claim_context increments streak" `Quick
         test_claim_context_increments_streak;
+      test_case "terminal reason maps required-tool failures" `Quick
+        test_terminal_reason_maps_required_tool_failures;
+      test_case "required-tool no-call fires at 3" `Quick
+        test_required_tool_no_call_fires_metric_at_three;
+      test_case "required-tool streak is separate from passive streak" `Quick
+        test_required_tool_streak_does_not_inherit_passive_streak;
+      test_case "required-tool nudge asks for real tool" `Quick
+        test_required_tool_nudge_mentions_real_tool_call;
       test_case "execution resets streak" `Quick
         test_execution_resets_streak;
       test_case "completion resets streak" `Quick


### PR DESCRIPTION
Fixes #13362

## Summary
- record required-tool terminal-reason failures in the existing keeper no-progress detector
- latch a new required-tool loop metric after 3 consecutive actionable contract failures
- inject a before-turn nudge that requires a real keeper tool call or typed no-work proof
- keep passive-read streaks separate from required-tool contract failure streaks

## Why This Matters
Issue #13362 is an alive-but-stuck keeper failure: actionable turns can repeatedly fail the required-tool contract and then return to the next cycle with no inter-turn pressure. The existing passive-loop detector only saw successful passive turns, so these failed turns stayed invisible to the nudge path.

This keeps provider/contract classification in the existing OAS-facing terminal reason surface, while MASC owns the keeper scheduling recovery: repeated typed contract failures now become an observable MASC keeper loop with a targeted nudge.

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_keeper_passive_loop_detector.exe
- ./_build/default/test/test_keeper_passive_loop_detector.exe
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test metrics_observation 42-52
- ./_build/default/test/test_keeper_unified.exe test phase_gate 27,35-42

## Review Focus
- required-tool terminal reason mapping into detector progress classes
- no cross-contamination between passive-read loops and required-tool loops
- failure-path recording in keeper_unified_turn before decision records are appended