### PR TITLE
fix(test): wrap sb.owner with Agent_id.to_string in test_board_dispatch

### DIFF
--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -829,7 +829,8 @@ let test_sub_board_create_and_get () =
   | Ok sb ->
       Alcotest.(check string) "slug matches" "alpha-board" sb.Board.slug;
       Alcotest.(check string) "name matches" "Alpha" sb.name;
-      Alcotest.(check string) "owner matches" "agent-1" sb.owner;
+      Alcotest.(check string) "owner matches" "agent-1"
+        (Board_core_classify.Agent_id.to_string sb.owner);
       let id = Board.Sub_board_id.to_string sb.id in
       (match Board_dispatch.get_sub_board ~sub_board_id:id with
        | Error e -> Alcotest.fail (Board.show_board_error e)


### PR DESCRIPTION
## What

Single-line companion fix to #13371. After #13333 introduced \`Board_core_classify.Agent_id.t\` as the type of \`sub_board.owner\`, the Alcotest assertion at \`test/test_board_dispatch.ml:832\` still compares it as a raw \`string\`, breaking \`dune runtest\`.

## Fix

\`\`\`ocaml
- Alcotest.(check string) "owner matches" "agent-1" sb.owner;
+ Alcotest.(check string) "owner matches" "agent-1"
+   (Board_core_classify.Agent_id.to_string sb.owner);
\`\`\`

## Verification

- \`dune build test/test_board_dispatch.exe\` clean
- 1 file changed / +2 -1 LOC

## Backstory

This was originally bundled in #13379 along with the 3 lib-side fixes already covered by #13371. #13371 took a different approach for the mli (removed quote chars entirely) so #13379 conflicted on rebase and was closed. This narrow PR re-opens just the test-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)