### PR TITLE
fix(dashboard): add accessible surface tabs

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -32,8 +32,8 @@ import {
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
 import { TransportBeacon } from './components/transport-beacon'
-import { SurfaceIcon } from './components/surface-icon'
-import { RouteLink } from './components/common/route-link'
+import { DashboardSurfaceTabs } from './components/dashboard-surface-tabs'
+import { SkipLink } from './components/skip-link'
 import { selectedAgentName } from './components/agent-detail-selection'
 import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
@@ -214,12 +214,11 @@ export function App() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
-  const topbarNavItems = DASHBOARD_NAV_ITEMS.filter(item => item.id !== 'code')
   const isCodeSurface = currentTab === 'code'
 
   return html`
     <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]">
-      <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-[var(--r-2)] focus:bg-[var(--color-bg-page)] focus:px-4 focus:py-2 focus:text-sm focus:text-[var(--color-fg-secondary)] focus:shadow-[var(--shadow-panel)] focus:ring-2 focus:ring-[var(--select-20)]">Skip to main content</a>
+      <${SkipLink} />
       <header class="relative z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5 backdrop-blur-xl">
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--accent-15)] to-transparent"></div>
         <div class="flex w-full items-center justify-between gap-3 max-[1080px]:flex-col max-[1080px]:items-stretch">
@@ -255,29 +254,7 @@ export function App() {
               </div>
             </div>
 
-            <nav class="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] max-[520px]:w-full" aria-label="Dashboard surfaces">
-              <div class="inline-flex min-w-max items-center gap-0.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-0.5">
-                ${topbarNavItems.map(item => {
-                  const active = item.id === currentTab
-                  return html`
-                    <${RouteLink}
-                      tab=${item.id}
-                      params=${item.defaultParams}
-                      ariaCurrent=${active ? 'page' : undefined}
-                      title=${item.description}
-                      class=${`inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-[var(--radius-sm)] border px-2 font-mono text-3xs uppercase leading-none tracking-[var(--track-caps)] transition-colors ${
-                        active
-                          ? 'border-[var(--brass-3)] bg-[var(--accent-22)] text-[var(--brass-1)] shadow-[inset_0_-1px_0_var(--brass-3)]'
-                          : 'border-transparent text-[var(--color-fg-muted)] hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-secondary)]'
-                      }`}
-                    >
-                      <${SurfaceIcon} icon=${item.icon} size=${13} />
-                      <span>${item.label}</span>
-                    <//>
-                  `
-                })}
-              </div>
-            </nav>
+            <${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab=${currentTab} />
           </div>
 
           <div class="flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">

--- a/dashboard/src/components/common/route-link.ts
+++ b/dashboard/src/components/common/route-link.ts
@@ -5,22 +5,34 @@ import type { TabId } from '../../types'
 import { ringFocusClasses } from './ring'
 
 interface RouteLinkProps {
+  id?: string
   tab: TabId
   params?: Record<string, string>
   class?: string
+  role?: string
   title?: string
+  tabIndex?: number
   'aria-label'?: string
+  ariaControls?: string
   ariaCurrent?: 'page' | 'location' | undefined
+  ariaSelected?: boolean | 'true' | 'false'
+  onKeyDown?: (event: KeyboardEvent) => void
   children: ComponentChildren
 }
 
 export function RouteLink({
+  id,
   tab,
   params,
   class: className,
+  role,
   title,
+  tabIndex,
   'aria-label': ariaLabel,
+  ariaControls,
   ariaCurrent,
+  ariaSelected,
+  onKeyDown,
   children,
 }: RouteLinkProps) {
   const href = hashForRoute(tab, params)
@@ -31,11 +43,17 @@ export function RouteLink({
 
   return html`
     <a
+      id=${id}
       href=${href}
       class=${classNameWithFocus}
+      role=${role}
       title=${title}
+      tabindex=${tabIndex}
       aria-label=${ariaLabel}
+      aria-controls=${ariaControls}
       aria-current=${ariaCurrent}
+      aria-selected=${ariaSelected}
+      onKeyDown=${onKeyDown}
       onClick=${(event: MouseEvent) => {
         if (
           event.defaultPrevented

--- a/dashboard/src/components/dashboard-surface-tabs.test.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { DASHBOARD_NAV_ITEMS } from '../config/navigation'
+import { DashboardSurfaceTabs, dashboardSurfaceTabId } from './dashboard-surface-tabs'
+
+const navigate = vi.fn()
+const hashForRoute = vi.fn((tab: string, params?: Record<string, string>) => {
+  return params ? `#${tab}?${new URLSearchParams(params)}` : `#${tab}`
+})
+
+vi.mock('../router', () => ({
+  navigate: (...args: Parameters<typeof navigate>) => navigate(...args),
+  hashForRoute: (...args: Parameters<typeof hashForRoute>) => hashForRoute(...args),
+}))
+
+describe('DashboardSurfaceTabs', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    navigate.mockClear()
+    hashForRoute.mockClear()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders top-level surfaces as an ARIA tablist', () => {
+    render(
+      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      container,
+    )
+
+    const tablist = container.querySelector('[role="tablist"]')
+    expect(tablist?.getAttribute('aria-label')).toBe('Dashboard surfaces')
+
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'))
+    expect(tabs.map(tab => tab.textContent?.trim())).toContain('Code')
+    expect(tabs).toHaveLength(DASHBOARD_NAV_ITEMS.length)
+  })
+
+  it('marks the current surface as the selected tab', () => {
+    render(
+      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="code" />`,
+      container,
+    )
+
+    const codeTab = container.querySelector(`#${dashboardSurfaceTabId('code')}`)
+    const overviewTab = container.querySelector(`#${dashboardSurfaceTabId('overview')}`)
+    expect(codeTab?.getAttribute('aria-selected')).toBe('true')
+    expect(codeTab?.getAttribute('aria-current')).toBe('page')
+    expect(codeTab?.getAttribute('tabindex')).toBe('0')
+    expect(overviewTab?.getAttribute('aria-selected')).toBe('false')
+    expect(overviewTab?.getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('moves focus and activates the next surface on ArrowRight', () => {
+    render(
+      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      container,
+    )
+
+    const overviewTab = container.querySelector(`#${dashboardSurfaceTabId('overview')}`) as HTMLElement
+    const monitorTab = container.querySelector(`#${dashboardSurfaceTabId('monitoring')}`) as HTMLElement
+    overviewTab.focus()
+    overviewTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+
+    expect(document.activeElement).toBe(monitorTab)
+    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'journey' })
+  })
+
+  it('jumps to the last surface on End', () => {
+    render(
+      html`<${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />`,
+      container,
+    )
+
+    const overviewTab = container.querySelector(`#${dashboardSurfaceTabId('overview')}`) as HTMLElement
+    const logsTab = container.querySelector(`#${dashboardSurfaceTabId('logs')}`) as HTMLElement
+    overviewTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+
+    expect(document.activeElement).toBe(logsTab)
+    expect(navigate).toHaveBeenCalledWith('logs', undefined)
+  })
+
+  it('passes axe with route tabs and the controlled main panel target', async () => {
+    render(
+      html`
+        <${DashboardSurfaceTabs} items=${DASHBOARD_NAV_ITEMS} currentTab="overview" />
+        <main id="main-content">Overview content</main>
+      `,
+      container,
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/dashboard-surface-tabs.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.ts
@@ -1,0 +1,123 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { SurfaceIcon } from './surface-icon'
+import { RouteLink } from './common/route-link'
+import type { DashboardSurfaceIcon } from '../config/navigation'
+import type { TabId } from '../types'
+
+interface DashboardSurfaceTabItem {
+  readonly id: TabId
+  readonly label: string
+  readonly icon: DashboardSurfaceIcon
+  readonly description: string
+  readonly defaultParams?: Record<string, string>
+}
+
+interface DashboardSurfaceTabsProps {
+  readonly items: ReadonlyArray<DashboardSurfaceTabItem>
+  readonly currentTab: TabId
+}
+
+export function DashboardSurfaceTabs({ items, currentTab }: DashboardSurfaceTabsProps) {
+  useEffect(() => {
+    document
+      .getElementById(dashboardSurfaceTabId(currentTab))
+      ?.scrollIntoView({ block: 'nearest', inline: 'center' })
+  }, [currentTab])
+
+  return html`
+    <nav class="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] max-[520px]:w-full" aria-label="Dashboard surfaces">
+      <div
+        role="tablist"
+        aria-label="Dashboard surfaces"
+        class="inline-flex min-w-max items-center gap-0.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-0.5"
+      >
+        ${items.map(item => {
+          const active = item.id === currentTab
+          return html`
+            <${RouteLink}
+              id=${dashboardSurfaceTabId(item.id)}
+              role="tab"
+              tab=${item.id}
+              params=${item.defaultParams}
+              tabIndex=${active ? 0 : -1}
+              ariaControls="main-content"
+              ariaCurrent=${active ? 'page' : undefined}
+              ariaSelected=${active ? 'true' : 'false'}
+              title=${item.description}
+              onKeyDown=${handleSurfaceTabKeyDown}
+              class=${`inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-[var(--radius-sm)] border px-2 font-mono text-3xs uppercase leading-none tracking-[var(--track-caps)] transition-colors ${
+                active
+                  ? 'border-[var(--brass-3)] bg-[var(--accent-22)] text-[var(--brass-1)] shadow-[inset_0_-1px_0_var(--brass-3)]'
+                  : 'border-transparent text-[var(--color-fg-muted)] hover:border-[var(--color-border-strong)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-secondary)]'
+              }`}
+            >
+              <${SurfaceIcon} icon=${item.icon} size=${13} />
+              <span>${item.label}</span>
+            <//>
+          `
+        })}
+      </div>
+    </nav>
+  `
+}
+
+export function dashboardSurfaceTabId(tab: TabId): string {
+  return `dashboard-surface-tab-${tab}`
+}
+
+function handleSurfaceTabKeyDown(event: KeyboardEvent): void {
+  const direction = surfaceTabKeyboardDirection(event.key)
+  if (direction === null) return
+
+  const current = event.currentTarget as HTMLElement | null
+  const tablist = current?.closest('[role="tablist"]')
+  if (!current || !tablist) return
+
+  const tabs = Array.from(tablist.querySelectorAll<HTMLElement>('[role="tab"]'))
+  const currentIndex = tabs.indexOf(current)
+  if (currentIndex === -1 || tabs.length === 0) return
+
+  event.preventDefault()
+  const nextIndex = nextSurfaceTabIndex(currentIndex, tabs.length, direction)
+  const next = tabs[nextIndex]
+  if (!next) return
+  next.focus()
+  next.click()
+}
+
+type SurfaceTabKeyboardDirection = 'next' | 'previous' | 'first' | 'last'
+
+function surfaceTabKeyboardDirection(key: string): SurfaceTabKeyboardDirection | null {
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      return 'next'
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      return 'previous'
+    case 'Home':
+      return 'first'
+    case 'End':
+      return 'last'
+    default:
+      return null
+  }
+}
+
+function nextSurfaceTabIndex(
+  currentIndex: number,
+  count: number,
+  direction: SurfaceTabKeyboardDirection,
+): number {
+  switch (direction) {
+    case 'next':
+      return (currentIndex + 1) % count
+    case 'previous':
+      return (currentIndex - 1 + count) % count
+    case 'first':
+      return 0
+    case 'last':
+      return count - 1
+  }
+}

--- a/dashboard/src/components/skip-link.test.ts
+++ b/dashboard/src/components/skip-link.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { SkipLink } from './skip-link'
+
+describe('SkipLink', () => {
+  it('targets main content and uses the focus-visible skip-link style', () => {
+    const container = document.createElement('div')
+    render(html`<${SkipLink} />`, container)
+
+    const link = container.querySelector('a')
+    expect(link?.getAttribute('href')).toBe('#main-content')
+    expect(link?.classList.contains('sr-only')).toBe(true)
+    expect(link?.classList.contains('skip-link')).toBe(true)
+    expect(link?.textContent).toBe('Skip to main content')
+  })
+
+  it('focuses the target without relying on hash navigation', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    render(
+      html`
+        <${SkipLink} />
+        <main id="main-content" tabindex="-1">Main</main>
+      `,
+      container,
+    )
+
+    const link = container.querySelector('a') as HTMLAnchorElement
+    const main = container.querySelector('main') as HTMLElement
+    link.click()
+
+    expect(document.activeElement).toBe(main)
+    render(null, container)
+    document.body.removeChild(container)
+  })
+})

--- a/dashboard/src/components/skip-link.ts
+++ b/dashboard/src/components/skip-link.ts
@@ -1,0 +1,24 @@
+import { html } from 'htm/preact'
+
+interface SkipLinkProps {
+  readonly targetId?: string
+  readonly label?: string
+}
+
+export function SkipLink({
+  targetId = 'main-content',
+  label = 'Skip to main content',
+}: SkipLinkProps) {
+  return html`
+    <a
+      href=${`#${targetId}`}
+      class="sr-only skip-link"
+      onClick=${(event: MouseEvent) => {
+        const target = document.getElementById(targetId)
+        if (!target) return
+        event.preventDefault()
+        target.focus()
+      }}
+    >${label}</a>
+  `
+}

--- a/dashboard/src/styles/a11y.css
+++ b/dashboard/src/styles/a11y.css
@@ -58,6 +58,7 @@
   margin: 0;
   overflow: visible;
   clip: auto;
+  clip-path: none;
   white-space: normal;
   border-width: 1px;
   background: var(--color-bg-page);


### PR DESCRIPTION
## Summary

- Replaces the dashboard top surface link strip with an ARIA `tablist` backed by route links.
- Adds roving keyboard behavior for topbar surfaces: Arrow keys cycle, Home/End jump, and activation stays route-backed.
- Includes the Code surface in the topbar tablist and scrolls the active tab into view for deep links.
- Extracts the skip-to-content link into a component and fixes the focused `.skip-link` style so Tailwind's `sr-only` `clip-path` no longer hides it.
- Keeps skip-link activation router-safe by focusing `#main-content` without changing the hash route.

## Artifact Context

- `Kimi_Agent_디자인 시스템 설계/design_system_proposal_sec00.md` identifies accessibility P0 gaps: `skip-to-content` and `Topbar tablist`.
- This PR covers those two screen-level accessibility pieces without overlapping the IDE find overlay PR.

## Validation

- `pnpm --dir dashboard exec eslint src/components/dashboard-surface-tabs.ts src/components/common/route-link.ts src/components/skip-link.ts src/components/common/route-link.test.ts src/components/common/route-link.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/dashboard-surface-tabs.test.ts src/components/skip-link.test.ts src/components/common/route-link.test.ts src/components/common/route-link.a11y.test.ts`
- `git diff --check HEAD~1..HEAD`
- Browser verification via `agent-browser`:
  - Code deep link selects the Code tab and scrolls it into view.
  - ArrowRight from Code activates Logs.
  - Focused skip link renders as a visible 169x38px control.
  - Clicking skip link focuses `main#main-content` while keeping `#overview`.
  - Mobile viewport keeps body width stable at 390px.

Screenshots:

- `/tmp/masc-topbar-code-tab-visible.png`
- `/tmp/masc-topbar-tabs-skip-link-fixed.png`
- `/tmp/masc-topbar-tabs-mobile.png`

Note: Vitest still emits the existing `--localstorage-file` warning, but the focused test command exits 0.
