### PR TITLE
refactor(dashboard): privatize 8 internal-only types (knip batch 4)

### DIFF
--- a/dashboard/src/components/activity-heatmap-draw.ts
+++ b/dashboard/src/components/activity-heatmap-draw.ts
@@ -38,7 +38,7 @@ export function canvasHeight(): number {
   return TOP_PAD + 7 * (CELL + GAP) - GAP + LEGEND_HEIGHT
 }
 
-export interface HeatmapCell {
+interface HeatmapCell {
   day: number
   hour: number
   count: number

--- a/dashboard/src/components/band.ts
+++ b/dashboard/src/components/band.ts
@@ -39,7 +39,7 @@ export type BandKind =
   | 'err'
   | 'stalled'
 
-export interface BandProps {
+interface BandProps {
   /** State tone. `undefined` ≡ `default` (idle, border-strong color). */
   kind?: BandKind
   /** Forwarded to data-testid. */

--- a/dashboard/src/components/btn.ts
+++ b/dashboard/src/components/btn.ts
@@ -38,7 +38,7 @@ export type BtnSize = 'xs' | 'sm' | 'default' | 'lg'
 
 type ResolvedVariant = 'default' | BtnVariant
 
-export interface BtnProps {
+interface BtnProps {
   children?: ComponentChildren
   /** Semantic tone. `undefined` ≡ default (warm-bordered base). */
   variant?: BtnVariant

--- a/dashboard/src/components/common/pagination.ts
+++ b/dashboard/src/components/common/pagination.ts
@@ -26,7 +26,7 @@ interface PaginationProps {
   testId?: string
 }
 
-export interface CursorPaginationProps {
+interface CursorPaginationProps {
   cursor?: string
   hasPrevious?: boolean
   hasNext?: boolean

--- a/dashboard/src/components/common/roving-tabindex.ts
+++ b/dashboard/src/components/common/roving-tabindex.ts
@@ -5,7 +5,7 @@
 
 import { useState } from 'preact/hooks'
 
-export interface RovingTabIndexResult {
+interface RovingTabIndexResult {
   activeIndex: number
   handleKeyDown: (e: KeyboardEvent) => void
   getTabIndex: (index: number) => number

--- a/dashboard/src/components/common/skeleton.ts
+++ b/dashboard/src/components/common/skeleton.ts
@@ -20,7 +20,7 @@ import { html } from 'htm/preact'
 
 const SKELETON_BASE = 'animate-pulse bg-[var(--color-bg-elevated)] rounded-[var(--r-1)]'
 
-export interface SkeletonProps {
+interface SkeletonProps {
   /** Tailwind width class or arbitrary value via class. Default w-full. */
   width?: string
   /** Tailwind height class. Default h-4 (~16px, matches body text line). */

--- a/dashboard/src/components/common/table.ts
+++ b/dashboard/src/components/common/table.ts
@@ -14,7 +14,7 @@ export interface TableColumn<T> {
   render?: (row: T) => ComponentChild
 }
 
-export interface TableProps<T> {
+interface TableProps<T> {
   columns: TableColumn<T>[]
   rows: T[]
   getRowId: (row: T) => string

--- a/dashboard/src/components/common/theme-sync.ts
+++ b/dashboard/src/components/common/theme-sync.ts
@@ -29,7 +29,7 @@ export function parseThemeFromSearch(search: string): ThemeId | null {
   return null
 }
 
-export interface ThemeSyncListeners {
+interface ThemeSyncListeners {
   onStorageChange?: (theme: ThemeId) => void
   onSearchChange?: (theme: ThemeId) => void
 }


### PR DESCRIPTION
## What

Continuation of #13313 / #13342 / #13395. Knip flagged 132 unused exported types after batch 3; this PR privatizes 8 with single internal use.

| Type | File | Why safe |
|---|---|---|
| \`BandProps\` | \`components/band.ts\` | function param of \`Band\` |
| \`BtnProps\` | \`components/btn.ts\` | function param of \`Btn\` |
| \`HeatmapCell\` | \`components/activity-heatmap-draw.ts\` | return type of \`hitTest\` |
| \`CursorPaginationProps\` | \`components/common/pagination.ts\` | function param destructure |
| \`RovingTabIndexResult\` | \`components/common/roving-tabindex.ts\` | return type of \`useRovingTabIndex\` |
| \`SkeletonProps\` | \`components/common/skeleton.ts\` | function param destructure |
| \`TableProps<T>\` | \`components/common/table.ts\` | generic function param |
| \`ThemeSyncListeners\` | \`components/common/theme-sync.ts\` | optional param of \`syncThemeAcrossSurfaces\` |

## Verification

- \`tsc --noEmit\`: 0 errors
- ESLint on 8 changed files: 0 warnings
- vitest: 8 test files / 105 tests pass

## Race check

- \`gh pr list --state open --search "band.ts OR btn.ts OR …"\`: 0 matches
- \`git log origin/main --since=1h -- <files>\`: 0 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)