### PR TITLE
fix(keeper): surface required-tool failures

### DIFF
--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -161,6 +161,6 @@ let extract_accountability_claim (result : Keeper_agent_run.run_result) =
 
 let apply_to_result = Keeper_social_model_registry.apply_to_result
 let derive_failure_state ~meta ~observation ~previous_state
-    ~is_auto_recoverable ~reason =
+    ~is_auto_recoverable ~sdk_error ~reason =
   Keeper_social_model_registry.derive_failure_state ~meta ~observation
-    ~previous_state ~is_auto_recoverable ~reason
+    ~previous_state ~is_auto_recoverable ~sdk_error ~reason

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -83,6 +83,7 @@ val derive_failure_state :
   observation:Keeper_world_observation.world_observation ->
   previous_state:social_state option ->
   is_auto_recoverable:bool ->
+  sdk_error:Agent_sdk.Error.sdk_error option ->
   reason:string ->
   social_state * transition_reason
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1702,7 +1702,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let social_state, social_transition_reason =
             Social.derive_failure_state ~meta ~observation
               ~previous_state:previous_social_state
-              ~is_auto_recoverable ~reason:e_str
+              ~is_auto_recoverable ~sdk_error:(Some err) ~reason:e_str
           in
           let failure_meta_base =
             match !paused_meta_override with

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -431,10 +431,20 @@ let apply_to_result ~(meta : keeper_meta)
   in
   (result, social_state, transition_reason)
 
+let is_required_tool_use_contract_error = function
+  | Some
+      (Agent_sdk.Error.Agent
+         (Agent_sdk.Error.CompletionContractViolation
+            { contract = Agent_sdk.Completion_contract_id.Require_tool_use; _ }))
+    ->
+      true
+  | _ -> false
+
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
     ~(is_auto_recoverable : bool)
+    ~(sdk_error : Agent_sdk.Error.sdk_error option)
     ~(reason : string) =
   let previous_state = Option.map state_of_social_state previous_state in
   let blocker =
@@ -442,8 +452,18 @@ let derive_failure_state ~(meta : keeper_meta)
     | "" -> None
     | value -> Some (short_preview value)
   in
+  let required_tool_use_failed =
+    is_required_tool_use_contract_error sdk_error
+  in
   let state =
-    if is_auto_recoverable && observation.claimable_task_count > 0 then
+    if required_tool_use_failed then
+      make_state ~meta ~observation ?previous_state
+        ~active_desire:"recover_tool_route"
+        ~current_intention:"surface_required_tool_blocker"
+        ?blocker
+        ~need:"operator_guidance_or_tool_capable_route"
+        ()
+    else if is_auto_recoverable && observation.claimable_task_count > 0 then
       make_state ~meta ~observation ?previous_state
         ~active_desire:"recover_tool_route"
         ~current_intention:"retry_claim_after_recovery"
@@ -454,6 +474,9 @@ let derive_failure_state ~(meta : keeper_meta)
       make_state ~meta ~observation ?previous_state ?blocker ()
   in
   let output =
-    { speech_act = Types.Defer; delivery_surface = Types.Silent }
+    if required_tool_use_failed then
+      { speech_act = Types.Request_help; delivery_surface = Types.Board_post }
+    else
+      { speech_act = Types.Defer; delivery_surface = Types.Silent }
   in
   (to_social_state state output, Types.Failure_run_error)

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
@@ -41,6 +41,7 @@ val derive_failure_state :
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
   is_auto_recoverable:bool ->
+  sdk_error:Agent_sdk.Error.sdk_error option ->
   reason:string ->
   Keeper_social_model_types.social_state
   * Keeper_social_model_types.transition_reason

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -205,10 +205,11 @@ let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
     ~(is_auto_recoverable : bool)
+    ~(sdk_error : Agent_sdk.Error.sdk_error option)
     ~(reason : string) =
   let base_state, transition_reason =
     Bdi.derive_failure_state ~meta ~observation ~previous_state
-      ~is_auto_recoverable ~reason
+      ~is_auto_recoverable ~sdk_error ~reason
   in
   let previous_snapshot =
     Option.bind previous_state Fsm.snapshot_of_social_state

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
@@ -14,6 +14,7 @@ val derive_failure_state :
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
   is_auto_recoverable:bool ->
+  sdk_error:Agent_sdk.Error.sdk_error option ->
   reason:string ->
   Keeper_social_model_types.social_state
   * Keeper_social_model_types.transition_reason

--- a/lib/keeper/social_model/keeper_social_model_registry.ml
+++ b/lib/keeper/social_model/keeper_social_model_registry.ml
@@ -23,11 +23,12 @@ let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
     ~(is_auto_recoverable : bool)
+    ~(sdk_error : Agent_sdk.Error.sdk_error option)
     ~(reason : string) =
   match active_model_of_meta meta with
   | Types.Bdi_speech_v1 ->
       Keeper_social_model_bdi_speech_v1.derive_failure_state ~meta
-        ~observation ~previous_state ~is_auto_recoverable ~reason
+        ~observation ~previous_state ~is_auto_recoverable ~sdk_error ~reason
   | Types.Magentic_ledger_v1 ->
       Keeper_social_model_magentic_ledger_v1.derive_failure_state ~meta
-        ~observation ~previous_state ~is_auto_recoverable ~reason
+        ~observation ~previous_state ~is_auto_recoverable ~sdk_error ~reason

--- a/lib/keeper/social_model/keeper_social_model_registry.mli
+++ b/lib/keeper/social_model/keeper_social_model_registry.mli
@@ -14,6 +14,7 @@ val derive_failure_state :
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
   is_auto_recoverable:bool ->
+  sdk_error:Agent_sdk.Error.sdk_error option ->
   reason:string ->
   Keeper_social_model_types.social_state
   * Keeper_social_model_types.transition_reason

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6655,6 +6655,7 @@ let test_social_model_bdi_failure_state_rewrites_claim_retry_loop () =
   let state, transition_reason =
     KSM.derive_failure_state ~meta:minimal_meta ~observation ~previous_state
       ~is_auto_recoverable:true
+      ~sdk_error:None
       ~reason:
         "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"tool_use_strict\"}"
   in
@@ -6673,6 +6674,32 @@ let test_social_model_bdi_failure_state_rewrites_claim_retry_loop () =
   check bool "blocker keeps failure detail" true
     (match state.blocker with
     | Some blocker -> contains_substring blocker "cascade_exhausted"
+    | None -> false)
+
+let test_social_model_required_tool_failure_requests_help () =
+  let state, transition_reason =
+    KSM.derive_failure_state ~meta:minimal_meta ~observation:base_observation
+      ~previous_state:None ~is_auto_recoverable:false
+      ~sdk_error:(Some (required_tool_contract_violation_error ()))
+      ~reason:
+        "Completion contract [require_tool_use] violated: actionable keeper \
+         signal was present, but the model called no keeper tools"
+  in
+  check string "transition reason" "failure:run_error"
+    (KSM.transition_reason_to_string transition_reason);
+  check string "speech act requests help" "request_help"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface is operator-visible board post" "board_post"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check (option string) "active desire recovers route"
+    (Some "recover_tool_route") state.active_desire;
+  check (option string) "intention surfaces blocker"
+    (Some "surface_required_tool_blocker") state.current_intention;
+  check (option string) "need names route recovery"
+    (Some "operator_guidance_or_tool_capable_route") state.need;
+  check bool "blocker keeps contract detail" true
+    (match state.blocker with
+    | Some blocker -> contains_substring blocker "require_tool_use"
     | None -> false)
 
 let test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context
@@ -6694,6 +6721,7 @@ let test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_conte
   let state, _ =
     KSM.derive_failure_state ~meta:minimal_meta ~observation:base_observation
       ~previous_state ~is_auto_recoverable:false
+      ~sdk_error:None
       ~reason:"local config error"
   in
   check (option string) "active desire still carries on ordinary failure"
@@ -7447,6 +7475,8 @@ let () =
             test_social_model_previous_state_of_meta_falls_back_for_unknown_model;
           test_case "bdi failure rewrites stale claim retry loop" `Quick
             test_social_model_bdi_failure_state_rewrites_claim_retry_loop;
+          test_case "bdi required-tool failure requests help" `Quick
+            test_social_model_required_tool_failure_requests_help;
           test_case "bdi failure keeps ordinary carry state" `Quick
             test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context;
           test_case "magentic ledger stalled state carries until delta" `Quick


### PR DESCRIPTION
## Summary

- thread `sdk_error` into keeper social-model failure derivation
- classify `Require_tool_use` completion-contract failures as `request_help` / `board_post` social state instead of leaving the keeper in `defer` / `silent`
- preserve existing silent/defer behavior for ordinary provider/config failures

## Why

#13362 shows a separate post-#13341 failure class: actionable keeper turns can still emit no keeper tools. #13418 stops repeated contract failures from cycling indefinitely by pausing after the failure streak threshold. This follow-up makes the immediate failure social state operator-visible, so dashboards and summaries do not describe a required-tool blocker as silent deferral.

## Operator Impact

Required-tool contract failures now carry `last_speech_act=request_help`, `delivery_surface=board_post`, `active_desire=recover_tool_route`, and an explicit route-recovery need. The strict tool contract still fails as before; this only changes the social/runtime explanation attached to the failed turn.

## Validation

- `git diff --check`
- `MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 80-82`

Known unrelated local failure recorded separately as #13425: `./_build/default/test/test_keeper_unified.exe test world_observation 6` also fails on the root `main` checkout with `scoped claimable backlog` expected `0`, received `1`. This PR does not change that world-observation path.

Refs #13362
Refs #13425