### PR TITLE
fix(keeper): resolve playground repos by URL basename

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -308,6 +308,15 @@ let playground_path_of_path ~base_path ~path =
 let basename_of_path path =
   normalize_path_for_prefix_check path |> Filename.basename
 
+let repository_url_basename url =
+  let stripped = normalize_path_for_prefix_check url in
+  if stripped = "" then ""
+  else
+    let base = Filename.basename stripped in
+    if Filename.check_suffix base ".git" then
+      String.sub base 0 (String.length base - 4)
+    else base
+
 let resolve_repository_id_segment ~base_path segment =
   match Repo_store.load_all ~base_path with
   | Error msg ->
@@ -322,6 +331,7 @@ let resolve_repository_id_segment ~base_path segment =
           (fun (repo : repository) ->
             String.equal repo.id segment
             || String.equal repo.name segment
+            || String.equal (repository_url_basename repo.url) segment
             || String.equal
                  (basename_of_path (Repo_store.local_path ~base_path repo))
                  segment)

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -272,6 +272,39 @@ let test_validate_path_access_playground_repo_uses_registered_name () =
             ("expected playground repo path to resolve by registered name, got: "
              ^ e))
 
+let test_validate_path_access_playground_repo_uses_url_basename () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_path =
+        Filename.concat base_path "workspace/yousleepwhen/masc-mcp"
+      in
+      ensure_dir masc_path;
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let path =
+        Filename.concat base_path
+          ".masc/playground/docker/executor/repos/masc-mcp/lib"
+      in
+      ensure_dir path;
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected playground repo path to resolve by repository URL basename, got: "
+             ^ e))
+
 let test_validate_path_access_playground_unknown_repo_denied () =
   with_temp_base_path (fun base_path ->
       let root_repo =
@@ -590,6 +623,8 @@ let () =
             test_validate_path_access_playground_repos_root_ignores_base_repo;
           Alcotest.test_case "playground repo resolves registered name" `Quick
             test_validate_path_access_playground_repo_uses_registered_name;
+          Alcotest.test_case "playground repo resolves repository URL basename" `Quick
+            test_validate_path_access_playground_repo_uses_url_basename;
           Alcotest.test_case "playground unknown repo denied" `Quick
             test_validate_path_access_playground_unknown_repo_denied;
         ] );


### PR DESCRIPTION
## Summary

- Allow keeper playground repo paths like `repos/masc-mcp` to resolve through the registered repository URL basename when the repo id/name is `masc`.
- Add a regression for docker playground paths where mappings allow `masc` but the sandbox clone directory is `masc-mcp`.
- Remove the stale OAS pin bump from the branch; this PR now only changes the repo mapping path resolver and its test.

## Why

Live Keeper PR proof failed before draft PR creation because `glm-coding-plan` hit:

```text
Keeper glm-coding-plan is not allowed to access repository masc-mcp
```

The live mapping allows repository id `masc`, while the actual sandbox clone path is `.masc/playground/docker/glm-coding-plan/repos/masc-mcp`. URL-basename resolution keeps the stable repo id (`masc`) while accepting the real clone directory name (`masc-mcp`).

## Validation

- `git diff --check origin/main..HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `ocamlc -stop-after parsing lib/repo_manager/keeper_repo_mapping.ml test/test_keeper_repo_mapping.ml`

## Blocked Local Validation

- `scripts/dune-local.sh build test/test_keeper_repo_mapping.exe` was queued but blocked by the shared opam lock held by another worktree (`fix-13441-oas-worker-test-isolation`). The PR remains draft and CI is the build gate.

## Review Focus

- `repository_url_basename` matching in `lib/repo_manager/keeper_repo_mapping.ml`
- The new playground-path regression in `test/test_keeper_repo_mapping.ml`