### PR TITLE
fix(memory): compact bank on note pressure

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -622,13 +622,7 @@ let compact_memory_bank_if_needed
       (match Fs_compat.file_size path with Some s -> s | None -> 0)
     in
     let trigger_bytes = memory_compaction_trigger_bytes ~target_notes in
-    if size_bytes < trigger_bytes then
-      { no_memory_bank_compaction with
-        target_notes;
-        reason = Some "under_trigger_bytes";
-      }
-    else
-      match Safe_ops.read_file_safe path with
+    match Safe_ops.read_file_safe path with
       | Error _ ->
           { no_memory_bank_compaction with
             target_notes;
@@ -650,7 +644,18 @@ let compact_memory_bank_if_needed
           in
           let parsed = List.rev parsed_rev in
           let before_notes = List.length parsed in
-          if before_notes <= target_notes && invalid = 0 then
+          if
+            size_bytes < trigger_bytes
+            && before_notes <= target_notes
+            && invalid = 0
+          then
+            { no_memory_bank_compaction with
+              target_notes;
+              before_notes;
+              after_notes = before_notes;
+              reason = Some "under_trigger_bytes";
+            }
+          else if before_notes <= target_notes && invalid = 0 then
             { no_memory_bank_compaction with
               target_notes;
               before_notes;

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -334,7 +334,8 @@ val compact_memory_bank_if_needed :
   Coord.config ->
   Keeper_types.keeper_meta -> memory_bank_compaction
 (** Run a compaction pass for the keeper if the file has crossed the
-    trigger; returns [no_memory_bank_compaction] when nothing happened. *)
+    byte trigger or note-count target; returns
+    [no_memory_bank_compaction] when nothing happened. *)
 
 (** {1 Append-from-reply} *)
 

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1391,6 +1391,43 @@ let test_compaction_records_consolidation_metrics () =
          ~source:"cross_trace_recurrence"
          ~outcome:"persisted"))
 
+let test_compaction_runs_on_note_pressure_under_byte_trigger () =
+  with_env "MASC_KEEPER_MEMORY_MAX_NOTES" "40" @@ fun () ->
+  with_env "MASC_KEEPER_MEMORY_COMPACT_TRIGGER_BYTES" "60000" @@ fun () ->
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir_recursive dir) (fun () ->
+    let keeper = "note-pressure-memory-keeper" in
+    let config = make_test_room_config dir in
+    let meta = keeper_meta ~name:keeper ~mention_targets:[ keeper ] () in
+    let bank_path = Keeper_types.keeper_memory_bank_path config keeper in
+    Keeper_types.mkdir_p (Filename.dirname bank_path);
+    let target_notes = Keeper_memory_bank.memory_compaction_target_notes () in
+    let rows =
+      List.init (target_notes + 1) (fun i ->
+        memory_bank_test_row
+          ~kind:"goal"
+          ~trace_id:(Printf.sprintf "trace-short-%d" i)
+          ~text:(Printf.sprintf "short note pressure %03d" i)
+          ~priority:10
+          ~idx:i)
+    in
+    let content = String.concat "\n" rows ^ "\n" in
+    check bool "fixture is under byte trigger" true
+      (String.length content
+       < Keeper_memory_bank.memory_compaction_trigger_bytes ~target_notes);
+    (match Fs_compat.save_file_atomic bank_path content with
+     | Ok () -> ()
+     | Error err -> fail ("failed to seed memory bank: " ^ err));
+    let compaction =
+      Keeper_memory_bank.compact_memory_bank_if_needed config meta
+    in
+    check bool "compaction ran from note pressure" true compaction.performed;
+    check (option string) "compaction reason" (Some "compacted")
+      compaction.reason;
+    check int "before notes" (target_notes + 1) compaction.before_notes;
+    check int "after notes capped to target" target_notes compaction.after_notes;
+    check int "one note dropped" 1 compaction.dropped_notes)
+
 let () =
   run "Keeper_memory"
     [
@@ -1531,5 +1568,7 @@ let () =
           test_case "total cap reports dropped_by_total_cap" `Quick test_cap_dropped_by_total;
           test_case "compaction records consolidation metrics" `Quick
             test_compaction_records_consolidation_metrics;
+          test_case "note pressure triggers compaction under byte trigger" `Quick
+            test_compaction_runs_on_note_pressure_under_byte_trigger;
         ] );
     ]


### PR DESCRIPTION
## Summary

Fixes #13420.

`Keeper_memory_bank.compact_memory_bank_if_needed` no longer skips solely because the memory bank file is below the byte trigger. It now reads/parses the bank, preserves `under_trigger_bytes` for small banks, and runs the existing compaction pipeline when valid note count exceeds `memory_compaction_target_notes()` or invalid rows need cleanup.

## Review Focus

- Trigger predicate only; compaction selection, consolidation, dedup, per-kind caps, and write path are unchanged.
- Small banks below both byte and note thresholds still return `under_trigger_bytes`.
- Regression seeds `target_notes + 1` short valid rows under the byte trigger and verifies compaction caps to target.

## Validation

- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_memory.exe`
- `./_build/default/test/test_keeper_memory.exe`
- `git diff --check`

Note: local pin guard was bypassed because concurrent sessions kept mutating the opam `agent_sdk` pin source; the installed package was the repo-expected `0.190.12`. Focused build still emits pre-existing `legacy_tuple` alerts from unrelated `Tool_result.to_legacy_compat` callers.