### PR TITLE
fix(keeper): surface no-tool provider blockers

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -257,6 +257,16 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
         if summary = "" then
           "OAS budget timeout fired before the keeper hard timeout."
         else summary
+    | No_tool_capable_provider -> (
+        match
+          Oas_worker_named.classify_masc_internal_error
+            (Agent_sdk.Error.Internal summary)
+        with
+        | Some err -> (
+            match Oas_worker_named.summary_of_masc_internal_error err with
+            | Some structured_summary -> structured_summary
+            | None -> if summary = "" then str else summary)
+        | None -> if summary = "" then str else summary)
     | _ -> if summary = "" then str else summary
   in
   { blocker_class = str; summary; continue_gate }

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1560,6 +1560,10 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             Printf.sprintf
               "OAS budget timeout after %.1fs (%s, estimated input %d tokens, keeper hard cap %.1fs)"
               budget_sec source estimated_input_tokens keeper_turn_timeout_sec
+        | Some (Oas_worker_named.No_tool_capable_provider _ as err) -> (
+            match Oas_worker_named.summary_of_masc_internal_error err with
+            | Some summary -> summary
+            | None -> reason)
         | _ -> reason)
     | None -> reason
   in

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -70,6 +70,36 @@ let effective_provider_attempt_timeout_s
   | None ->
       provider_default_attempt_timeout_s constraints
 
+let required_tool_names_for_no_tool_error ~runtime_mcp_policy ~tools =
+  let names =
+    match runtime_mcp_policy with
+    | Some policy
+      when policy.Llm_provider.Llm_transport.allowed_tool_names <> [] ->
+        policy.allowed_tool_names
+    | _ -> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) tools
+  in
+  List.sort_uniq String.compare names
+
+let provider_rejections_for_no_tool_error
+    ~keeper_name ?runtime_mcp_policy ~tools
+    ~require_tool_choice_support ~require_tool_support provider_cfgs =
+  provider_cfgs
+  |> List.filter_map (fun provider_cfg ->
+       match
+         classify_filter_rejection ~keeper_name ?runtime_mcp_policy ~tools
+           ~require_tool_choice_support ~require_tool_support provider_cfg
+       with
+       | None -> None
+       | Some reason ->
+           Some
+             {
+               provider_label =
+                 Provider_tool_support.provider_debug_label provider_cfg;
+               provider_kind =
+                 Provider_tool_support.provider_kind_label provider_cfg;
+               reason = filter_rejection_reason_label reason;
+             })
+
 let apply_stream_idle_timeout_default = function
   | Some _ as v -> v
   | None -> Some Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
@@ -195,6 +225,7 @@ let run_named
        Log.Misc.error "cascade %s: %s" cascade_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
    | Ok configured_labels, Ok candidate_cfgs ->
+  let original_candidate_cfgs = candidate_cfgs in
   let candidate_cfgs =
     filter_candidate_providers_for_tool_support
       ~keeper_name
@@ -271,11 +302,25 @@ let run_named
   in
   match candidate_cfgs with
   | [] ->
+      let required_tool_names =
+        required_tool_names_for_no_tool_error ~runtime_mcp_policy ~tools
+      in
+      let provider_rejections =
+        provider_rejections_for_no_tool_error
+          ~keeper_name ?runtime_mcp_policy ~tools
+          ~require_tool_choice_support ~require_tool_support
+          original_candidate_cfgs
+      in
       Error
         (sdk_error_of_masc_internal_error
            (if require_tool_choice_support then
               No_tool_capable_provider
-                { cascade_name = error_cascade_name; configured_labels }
+                {
+                  cascade_name = error_cascade_name;
+                  configured_labels;
+                  required_tool_names;
+                  provider_rejections;
+                }
             else
               Cascade_exhausted
                 {

--- a/lib/oas_worker_named_error.ml
+++ b/lib/oas_worker_named_error.ml
@@ -14,6 +14,12 @@ type cascade_name = Keeper_cascade_profile.runtime_name
 let cascade_name_of_string raw = Keeper_cascade_profile.Runtime_name raw
 let cascade_name_to_string = Keeper_cascade_profile.runtime_name_to_string
 
+type provider_rejection = {
+  provider_label : string;
+  provider_kind : string;
+  reason : string;
+}
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : cascade_name;
@@ -27,6 +33,8 @@ type masc_internal_error =
   | No_tool_capable_provider of {
       cascade_name : cascade_name;
       configured_labels : string list;
+      required_tool_names : string list;
+      provider_rejections : provider_rejection list;
     }
   | Accept_rejected of {
       scope : string;
@@ -59,6 +67,48 @@ type masc_internal_error =
 
 let masc_internal_error_prefix = "[masc_oas_error] "
 
+let string_list_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let string_list_of_assoc key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`List values) ->
+          values
+          |> List.filter_map (function
+               | `String value -> Some value
+               | _ -> None)
+      | _ -> [])
+  | _ -> []
+
+let provider_rejection_to_json r =
+  `Assoc
+    [
+      ("provider_label", `String r.provider_label);
+      ("provider_kind", `String r.provider_kind);
+      ("reason", `String r.reason);
+    ]
+
+let provider_rejection_of_json = function
+  | `Assoc fields ->
+      let field name =
+        match List.assoc_opt name fields with
+        | Some (`String value) -> Some value
+        | _ -> None
+      in
+      (match field "provider_label", field "provider_kind", field "reason" with
+       | Some provider_label, Some provider_kind, Some reason ->
+           Some { provider_label; provider_kind; reason }
+       | _ -> None)
+  | _ -> None
+
+let provider_rejections_of_assoc key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`List values) -> List.filter_map provider_rejection_of_json values
+      | _ -> [])
+  | _ -> []
+
 let string_opt_of_assoc key = function
   | `Assoc fields -> (
       match List.assoc_opt key fields with
@@ -84,14 +134,22 @@ let masc_internal_error_to_json = function
         ("detail", `String detail);
         ("exit_code", Json_util.int_opt_to_json exit_code);
       ]
-  | No_tool_capable_provider { cascade_name; configured_labels } ->
+  | No_tool_capable_provider
+      {
+        cascade_name;
+        configured_labels;
+        required_tool_names;
+        provider_rejections;
+      } ->
     let cascade_name = cascade_name_to_string cascade_name in
     `Assoc
       [
         ("kind", `String "no_tool_capable_provider");
         ("cascade_name", `String cascade_name);
-        ( "configured_labels",
-          `List (List.map (fun value -> `String value) configured_labels) );
+        ("configured_labels", string_list_json configured_labels);
+        ("required_tool_names", string_list_json required_tool_names);
+        ( "provider_rejections",
+          `List (List.map provider_rejection_to_json provider_rejections) );
       ]
   | Accept_rejected { scope; model; reason } ->
     `Assoc
@@ -143,9 +201,41 @@ let masc_internal_error_to_json = function
       [
         ("kind", `String "ambiguous_post_commit");
         ("is_timeout", `Bool is_timeout);
-        ("tools", `List (List.map (fun v -> `String v) tools));
+        ("tools", string_list_json tools);
         ("original_error", `String original_error);
       ]
+
+let summarize_list ?(empty = "none") values =
+  match values with
+  | [] -> empty
+  | _ -> String.concat ", " values
+
+let summarize_provider_rejections rejections =
+  match rejections with
+  | [] -> "none"
+  | _ ->
+      rejections
+      |> List.map (fun r ->
+           Printf.sprintf "%s:%s" r.provider_label r.reason)
+      |> String.concat "; "
+
+let summary_of_masc_internal_error = function
+  | No_tool_capable_provider
+      {
+        cascade_name;
+        configured_labels;
+        required_tool_names;
+        provider_rejections;
+      } ->
+      let cascade_name = cascade_name_to_string cascade_name in
+      Some
+        (Printf.sprintf
+           "No tool-capable provider for cascade %s; required_tools=[%s]; rejected_providers=[%s]; configured=[%s]"
+           cascade_name
+           (summarize_list required_tool_names)
+           (summarize_provider_rejections provider_rejections)
+           (summarize_list configured_labels))
+  | _ -> None
 
 (* #9933: classify emitted [masc_oas_error] payloads by kind so
    dashboards and Grafana alerts can watch the fleet-wide rate per
@@ -292,23 +382,17 @@ let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
            | Some (`String "no_tool_capable_provider") -> (
                match string_opt_of_assoc "cascade_name" json with
                | Some cascade_name ->
-                 let configured_labels =
-                   match json with
-                   | `Assoc fields -> (
-                       match List.assoc_opt "configured_labels" fields with
-                       | Some (`List values) ->
-                         values
-                         |> List.filter_map (function
-                              | `String value -> Some value
-                              | _ -> None)
-                       | _ -> [])
-                   | _ -> []
-                 in
                  Some
                    (No_tool_capable_provider
                       {
                         cascade_name = cascade_name_of_string cascade_name;
-                        configured_labels;
+                        configured_labels =
+                          string_list_of_assoc "configured_labels" json;
+                        required_tool_names =
+                          string_list_of_assoc "required_tool_names" json;
+                        provider_rejections =
+                          provider_rejections_of_assoc "provider_rejections"
+                            json;
                       })
                | None -> None)
            | Some (`String "accept_rejected") -> (

--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -15,6 +15,12 @@ type cascade_name = Keeper_cascade_profile.runtime_name
 val cascade_name_of_string : string -> cascade_name
 val cascade_name_to_string : cascade_name -> string
 
+type provider_rejection = {
+  provider_label : string;
+  provider_kind : string;
+  reason : string;
+}
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : cascade_name;
@@ -28,6 +34,8 @@ type masc_internal_error =
   | No_tool_capable_provider of {
       cascade_name : cascade_name;
       configured_labels : string list;
+      required_tool_names : string list;
+      provider_rejections : provider_rejection list;
     }
   | Accept_rejected of {
       scope : string;
@@ -59,6 +67,10 @@ type masc_internal_error =
     }
 
 val masc_internal_error_to_json : masc_internal_error -> Yojson.Safe.t
+
+val summary_of_masc_internal_error : masc_internal_error -> string option
+(** Operator-facing concise summary for structured errors where the raw JSON
+    payload is too noisy for dashboard cards. *)
 
 val sdk_error_of_masc_internal_error : masc_internal_error -> Agent_sdk.Error.sdk_error
 (** Convert a [masc_internal_error] to an SDK error, bumping the

--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -42,7 +42,12 @@ let mk_cascade_exhausted () =
 let mk_no_tool_capable () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.No_tool_capable_provider
-       { cascade_name = cascade_name "test"; configured_labels = [] })
+       {
+         cascade_name = cascade_name "test";
+         configured_labels = [];
+         required_tool_names = [];
+         provider_rejections = [];
+       })
 
 let mk_accept_rejected () =
   Owne.sdk_error_of_masc_internal_error

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -31,7 +31,12 @@ let make_cascade_exhausted reason =
 let make_no_tool_capable () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.No_tool_capable_provider
-       { cascade_name = cascade_name "test_cascade"; configured_labels = [] })
+       {
+         cascade_name = cascade_name "test_cascade";
+         configured_labels = [];
+         required_tool_names = [];
+         provider_rejections = [];
+       })
 
 let make_accept_rejected () =
   Owne.sdk_error_of_masc_internal_error

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -5,6 +5,7 @@ module KSB = Masc_mcp.Keeper_status_bridge
 module KR = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
 module Coord = Masc_mcp.Coord
+module OWN = Masc_mcp.Oas_worker_named
 
 let keeper_health_testable : KT.keeper_health Alcotest.testable =
   Alcotest.testable
@@ -42,6 +43,17 @@ let with_temp_base_path prefix f =
   Sys.remove path;
   Unix.mkdir path 0o700;
   Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+
+let has_substring haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > hay_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
 
 let iso_of_seconds_ago age_s =
   let ts = Time_compat.now () -. age_s in
@@ -345,6 +357,58 @@ let test_runtime_surface_derives_cascade_exhausted_from_meta () =
   check bool "runtime blocker continue gate stays false"
     false
     (runtime |> member "runtime_blocker_continue_gate" |> to_bool)
+
+let test_runtime_surface_names_no_tool_provider_details () =
+  KR.clear ();
+  let payload =
+    OWN.No_tool_capable_provider
+      {
+        cascade_name = OWN.cascade_name_of_string "tool_required";
+        configured_labels = [ "codex"; "kimi" ];
+        required_tool_names = [ "keeper_bash"; "masc_worktree_create" ];
+        provider_rejections =
+          [
+            {
+              OWN.provider_label = "codex_cli:codex";
+              provider_kind = "codex_cli";
+              reason = "codex_keeper_bound_actor_required";
+            };
+          ];
+      }
+  in
+  let summary =
+    match OWN.summary_of_masc_internal_error payload with
+    | Some summary -> summary
+    | None -> fail "expected no-tool provider summary"
+  in
+  let base = make_meta ~name:"runtime-no-tool-provider-test" () in
+  let meta =
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          last_blocker = summary;
+          last_blocker_class = Some KT.No_tool_capable_provider;
+        };
+    }
+  in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-no-tool-provider"
+  in
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  let surfaced_summary =
+    runtime |> member "runtime_blocker_summary" |> to_string
+  in
+  check string "runtime blocker class"
+    "no_tool_capable_provider"
+    (runtime |> member "runtime_blocker_class" |> to_string);
+  check bool "summary names required worktree tool" true
+    (has_substring surfaced_summary "masc_worktree_create");
+  check bool "summary names rejected provider and reason" true
+    (has_substring surfaced_summary
+       "codex_cli:codex:codex_keeper_bound_actor_required")
 
 let test_runtime_surface_routes_oas_timeout_to_timeout_action () =
   KR.clear ();
@@ -728,6 +792,8 @@ let () =
             test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta;
           test_case "runtime surface derives cascade exhausted blocker" `Quick
             test_runtime_surface_derives_cascade_exhausted_from_meta;
+          test_case "runtime surface names no-tool provider details" `Quick
+            test_runtime_surface_names_no_tool_provider_details;
           test_case "runtime surface routes OAS timeout to timeout action"
             `Quick
             test_runtime_surface_routes_oas_timeout_to_timeout_action;

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -103,12 +103,72 @@ let test_no_tool_capable_provider_kind () =
          {
            cascade_name = typed_cascade_name cascade_name;
            configured_labels = [ "openai"; "anthropic" ];
+           required_tool_names = [];
+           provider_rejections = [];
          })
   in
   Alcotest.(check (float 0.0001))
     "no_tool_capable_provider{cascade_name=tool_required} counter +1"
     (before +. 1.0)
     (counter_for ~cascade_name kind)
+
+let contains_substring haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > hay_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let test_no_tool_capable_provider_payload_names_tools_and_rejections () =
+  let payload =
+    OWN.No_tool_capable_provider
+      {
+        cascade_name = typed_cascade_name "tool_required";
+        configured_labels = [ "codex"; "kimi" ];
+        required_tool_names = [ "keeper_bash"; "masc_worktree_create" ];
+        provider_rejections =
+          [
+            {
+              OWN.provider_label = "codex_cli:codex";
+              provider_kind = "codex_cli";
+              reason = "codex_keeper_bound_actor_required";
+            };
+            {
+              OWN.provider_label = "kimi_cli:kimi";
+              provider_kind = "kimi_cli";
+              reason = "tool_lane_unsupported";
+            };
+          ];
+      }
+  in
+  let json = OWN.masc_internal_error_to_json payload in
+  let open Yojson.Safe.Util in
+  Alcotest.(check (list string))
+    "required tools serialized"
+    [ "keeper_bash"; "masc_worktree_create" ]
+    (json |> member "required_tool_names" |> to_list
+     |> List.map to_string);
+  Alcotest.(check string)
+    "first rejected provider serialized"
+    "codex_cli:codex"
+    (json |> member "provider_rejections" |> index 0
+     |> member "provider_label" |> to_string);
+  let err = OWN.sdk_error_of_masc_internal_error payload in
+  match OWN.classify_masc_internal_error err with
+  | Some parsed -> (
+      match OWN.summary_of_masc_internal_error parsed with
+      | Some summary ->
+          Alcotest.(check bool) "summary names missing worktree tool" true
+            (contains_substring summary "masc_worktree_create");
+          Alcotest.(check bool) "summary names rejected codex provider" true
+            (contains_substring summary
+               "codex_cli:codex:codex_keeper_bound_actor_required")
+      | None -> Alcotest.fail "expected no-tool summary")
+  | None -> Alcotest.fail "expected no-tool error round-trip"
 
 let test_accept_rejected_kind () =
   let kind = "accept_rejected" in
@@ -302,5 +362,12 @@ let () =
           Alcotest.test_case
             "non-cascade-aware variant uses unknown" `Quick
             test_non_cascade_aware_variant_uses_unknown;
+        ] );
+      ( "structured_payload_13344",
+        [
+          Alcotest.test_case
+            "no_tool_capable_provider names tools and rejected providers"
+            `Quick
+            test_no_tool_capable_provider_payload_names_tools_and_rejections;
         ] );
     ]


### PR DESCRIPTION
Fixes #13344

## Summary
- extend `no_tool_capable_provider` with requested runtime tool names and per-provider rejection reasons
- preserve the existing OAS/MASC boundary: provider capability filtering remains in the OAS worker/cascade path, while MASC records the operator-facing blocker evidence
- render structured no-tool provider details into keeper runtime blocker summaries so dashboard surfaces name the blocked tools and provider/client reasons

## Why This Matters
A PR-producing keeper can be routed onto a provider/client that cannot expose keeper-bound runtime tools. The cascade filter already blocks or reroutes those providers, but the terminal blocker previously carried only configured model labels. Operators could see that the keeper was blocked, but not which runtime tools were missing or which provider/client caused the block.

This turns the terminal state into auditable evidence instead of a generic fallback failure.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_oas_error_kind_counter.exe test/test_keeper_exec_status.exe test/test_oas_worker.exe`
- `./_build/default/test/test_oas_error_kind_counter.exe`
- `./_build/default/test/test_keeper_exec_status.exe`
- `./_build/default/test/test_oas_worker.exe test resume_config 37-47`
- `scripts/dune-local.sh build test/test_keeper_error_classify_recoverable.exe test/test_keeper_cascade_auto_pause_task074.exe`
- `./_build/default/test/test_keeper_error_classify_recoverable.exe`
- `./_build/default/test/test_keeper_cascade_auto_pause_task074.exe`

Note: local Dune emitted existing `Tool_result.to_legacy_compat` migration alerts from unrelated files while compiling the first target set.

## Review Focus
- `No_tool_capable_provider` payload compatibility with older JSON that lacks the new fields
- provider rejection detail source in `run_named`
- dashboard/runtime summary readability for `no_tool_capable_provider` blockers