### PR TITLE
fix(dashboard): harden task wall accessibility

### DIFF
--- a/dashboard/src/components/goals/task-stale-alert.test.ts
+++ b/dashboard/src/components/goals/task-stale-alert.test.ts
@@ -1,0 +1,128 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { tasks } from '../../store'
+import type { Task } from '../../types'
+
+vi.mock('../../router', () => ({
+  navigate: vi.fn(),
+}))
+
+import { navigate } from '../../router'
+import { TaskStaleAlert } from './task-stale-alert'
+
+const mockedNavigate = vi.mocked(navigate)
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: 'task-default-001',
+    title: 'Default task',
+    status: 'claimed',
+    priority: 3,
+    created_at: '2026-05-06T00:00:00Z',
+    updated_at: '2026-05-06T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('TaskStaleAlert', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-06T01:00:00Z'))
+    tasks.value = []
+    mockedNavigate.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    tasks.value = []
+    mockedNavigate.mockClear()
+    vi.useRealTimers()
+  })
+
+  it('renders only claimed or in-progress tasks older than the stale threshold', () => {
+    tasks.value = [
+      makeTask({
+        id: 'task-stale-claimed',
+        title: 'Stale claimed work',
+        status: 'claimed',
+        assignee: 'keeper-alpha',
+        updated_at: '2026-05-06T00:20:00Z',
+      }),
+      makeTask({
+        id: 'task-stale-progress',
+        title: 'Stale in progress work',
+        status: 'in_progress',
+        assignee: 'keeper-beta',
+        updated_at: '2026-05-05T23:00:00Z',
+      }),
+      makeTask({
+        id: 'task-recent-claimed',
+        title: 'Recent claim',
+        status: 'claimed',
+        assignee: 'keeper-alpha',
+        updated_at: '2026-05-06T00:45:00Z',
+      }),
+      makeTask({
+        id: 'task-old-todo',
+        title: 'Old todo',
+        status: 'todo',
+        assignee: 'keeper-alpha',
+        updated_at: '2026-05-05T23:00:00Z',
+      }),
+    ]
+
+    render(h(TaskStaleAlert, {}))
+
+    const region = screen.getByRole('region', { name: '오래된 태스크 점유' })
+    expect(region).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByRole('heading', { name: '오래 점유 중인 태스크 (2)' })).toBeInTheDocument()
+    expect(screen.getByText('Stale claimed work')).toBeInTheDocument()
+    expect(screen.getByText('Stale in progress work')).toBeInTheDocument()
+    expect(screen.queryByText('Recent claim')).not.toBeInTheDocument()
+    expect(screen.queryByText('Old todo')).not.toBeInTheDocument()
+  })
+
+  it('routes nudge and detail actions to their owning surfaces', () => {
+    tasks.value = [
+      makeTask({
+        id: 'task-stale-claimed',
+        title: 'Stale claimed work',
+        status: 'claimed',
+        assignee: 'keeper-alpha',
+        updated_at: '2026-05-06T00:20:00Z',
+      }),
+    ]
+
+    render(h(TaskStaleAlert, {}))
+
+    fireEvent.click(screen.getByRole('button', { name: 'keeper-alpha 키퍼 상세에서 task-stale-claimed nudge' }))
+    expect(mockedNavigate).toHaveBeenCalledWith('monitoring', {
+      section: 'agents',
+      view: 'keepers',
+      keeper: 'keeper-alpha',
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '태스크 상세 패널 열기: task-stale-claimed' }))
+    expect(mockedNavigate).toHaveBeenLastCalledWith('workspace', {
+      section: 'planning',
+      task: 'task-stale-claimed',
+    })
+  })
+
+  it('does not render without stale claims', () => {
+    tasks.value = [
+      makeTask({
+        id: 'task-recent',
+        title: 'Recent task',
+        status: 'claimed',
+        updated_at: '2026-05-06T00:55:00Z',
+      }),
+    ]
+
+    render(h(TaskStaleAlert, {}))
+
+    expect(screen.queryByRole('region', { name: '오래된 태스크 점유' })).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/goals/task-stale-alert.ts
+++ b/dashboard/src/components/goals/task-stale-alert.ts
@@ -60,6 +60,7 @@ export function TaskStaleAlert() {
     <section
       class="rounded-[var(--r-1)] border border-warn/30 bg-warn/5 p-3"
       aria-label="오래된 태스크 점유"
+      aria-live="polite"
     >
       <header class="mb-2 flex items-baseline justify-between gap-2">
         <h3 class="text-xs font-semibold uppercase tracking-[var(--track-caps)] text-warn">
@@ -79,6 +80,7 @@ export function TaskStaleAlert() {
               type="button"
               class="font-mono text-text-strong hover:underline"
               title=${e.task.id}
+              aria-label=${`태스크 상세 열기: ${e.task.id} ${e.task.title}`}
               onClick=${() => navigate('workspace', { section: 'planning', task: e.task.id })}
             >
               ${e.task.id.slice(0, 12)}
@@ -96,6 +98,7 @@ export function TaskStaleAlert() {
                   type="button"
                   class="rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-10)] px-2 py-0.5 text-2xs text-accent-fg hover:bg-[var(--accent-15)]"
                   title="해당 키퍼 상세로 이동해 직접 nudge"
+                  aria-label=${`${e.task.assignee} 키퍼 상세에서 ${e.task.id} nudge`}
                   onClick=${() => e.task.assignee && navigate('monitoring', { section: 'agents', view: 'keepers', keeper: e.task.assignee })}
                 >
                   nudge
@@ -105,6 +108,7 @@ export function TaskStaleAlert() {
                 type="button"
                 class="rounded-[var(--r-1)] border border-text-muted/30 px-2 py-0.5 text-2xs text-text-muted hover:bg-[var(--color-bg-panel-alt)]"
                 title="태스크 상세 패널 열기"
+                aria-label=${`태스크 상세 패널 열기: ${e.task.id}`}
                 onClick=${() => navigate('workspace', { section: 'planning', task: e.task.id })}
               >
                 상세

--- a/dashboard/src/components/goals/task-wall.test.ts
+++ b/dashboard/src/components/goals/task-wall.test.ts
@@ -1,0 +1,133 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { tasks } from '../../store'
+import type { Task } from '../../types'
+
+vi.mock('../../router', () => ({
+  navigate: vi.fn(),
+}))
+
+import { navigate } from '../../router'
+import { TaskWall } from './task-wall'
+
+const mockedNavigate = vi.mocked(navigate)
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: 'task-default-001',
+    title: 'Default task',
+    status: 'todo',
+    priority: 3,
+    created_at: '2026-05-06T00:00:00Z',
+    updated_at: '2026-05-06T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('TaskWall', () => {
+  beforeEach(() => {
+    tasks.value = []
+    mockedNavigate.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    tasks.value = []
+    mockedNavigate.mockClear()
+  })
+
+  it('groups active tasks by keeper and hides historical tasks', () => {
+    tasks.value = [
+      makeTask({
+        id: 'task-alpha-low',
+        title: 'Alpha lower priority',
+        status: 'in_progress',
+        priority: 4,
+        assignee: 'keeper-alpha',
+      }),
+      makeTask({
+        id: 'task-alpha-high',
+        title: 'Alpha higher priority',
+        status: 'claimed',
+        priority: 1,
+        assignee: 'keeper-alpha',
+        worktree: {
+          branch: 'feature/task-wall-long-branch',
+          path: '/tmp/worktree',
+          git_root: '/tmp/repo',
+          repo_name: 'masc-mcp',
+        },
+      }),
+      makeTask({
+        id: 'task-unassigned',
+        title: 'Needs owner',
+        status: 'todo',
+        priority: 2,
+      }),
+      makeTask({
+        id: 'task-hidden-done',
+        title: 'Done should not be visible',
+        status: 'done',
+        assignee: 'keeper-beta',
+      }),
+      makeTask({
+        id: 'task-hidden-cancelled',
+        title: 'Cancelled should not be visible',
+        status: 'cancelled',
+        assignee: 'keeper-beta',
+      }),
+    ]
+
+    render(h(TaskWall, {}))
+
+    expect(screen.getByRole('region', { name: '키퍼별 태스크 월' })).toBeInTheDocument()
+    expect(screen.getByText('2 키퍼 · 진행 중 3 건')).toBeInTheDocument()
+    expect(screen.getByLabelText('keeper-alpha 태스크 2건')).toBeInTheDocument()
+    expect(screen.getByLabelText('미할당 태스크 1건')).toBeInTheDocument()
+    expect(screen.queryByText('Done should not be visible')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cancelled should not be visible')).not.toBeInTheDocument()
+
+    const alphaColumn = screen.getByLabelText('keeper-alpha 태스크 2건')
+    const alphaButtons = within(alphaColumn).getAllByRole('button')
+    expect(alphaButtons[0]).toHaveAccessibleName(
+      '태스크 task-alpha-high 열기: Alpha higher priority, branch feature/task-wall-long-branch',
+    )
+    expect(alphaButtons[1]).toHaveAccessibleName('태스크 task-alpha-low 열기: Alpha lower priority')
+  })
+
+  it('opens the selected task in planning', () => {
+    tasks.value = [
+      makeTask({
+        id: 'task-open-target',
+        title: 'Open target',
+        status: 'claimed',
+        assignee: 'keeper-alpha',
+      }),
+    ]
+
+    render(h(TaskWall, {}))
+
+    fireEvent.click(screen.getByRole('button', { name: '태스크 task-open-target 열기: Open target' }))
+
+    expect(mockedNavigate).toHaveBeenCalledWith('workspace', {
+      section: 'planning',
+      task: 'task-open-target',
+    })
+  })
+
+  it('does not render when no active task is assigned or queued', () => {
+    tasks.value = [
+      makeTask({
+        id: 'task-only-done',
+        title: 'Only done',
+        status: 'done',
+      }),
+    ]
+
+    render(h(TaskWall, {}))
+
+    expect(screen.queryByRole('region', { name: '키퍼별 태스크 월' })).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/goals/task-wall.ts
+++ b/dashboard/src/components/goals/task-wall.ts
@@ -33,6 +33,10 @@ function statusGlyph(status: Task['status']): string {
   }
 }
 
+function keeperLabel(keeper: string): string {
+  return keeper === UNASSIGNED ? '미할당' : keeper
+}
+
 const wallColumns = computed<KeeperColumn[]>(() => {
   const grouped = new Map<string, Task[]>()
   for (const t of tasks.value) {
@@ -82,10 +86,11 @@ export function TaskWall() {
           <div
             key=${col.keeper}
             class="flex flex-col gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-2"
+            aria-label=${`${keeperLabel(col.keeper)} 태스크 ${col.tasks.length}건`}
           >
             <div class="flex items-baseline justify-between gap-1 text-2xs">
               <span class="font-mono ${col.keeper === UNASSIGNED ? 'text-text-disabled' : 'text-text-strong'}">
-                ${col.keeper === UNASSIGNED ? '미할당' : col.keeper}
+                ${keeperLabel(col.keeper)}
               </span>
               <span class="text-text-muted">${col.tasks.length}</span>
             </div>
@@ -101,6 +106,9 @@ export function TaskWall() {
                     type="button"
                     class="flex w-full items-center gap-1.5 rounded-[var(--r-0)] border border-[var(--color-border-default)]/50 bg-[var(--color-bg-surface)] px-1.5 py-0.5 text-left text-2xs hover:border-[var(--accent-40)] hover:bg-[var(--accent-10)]"
                     title=${titleAttr}
+                    aria-label=${branch
+                      ? `태스크 ${t.id} 열기: ${t.title}, branch ${branch}`
+                      : `태스크 ${t.id} 열기: ${t.title}`}
                     onClick=${() => navigate('workspace', { section: 'planning', task: t.id })}
                   >
                     <span aria-hidden="true" class="text-text-muted">${statusGlyph(t.status)}</span>


### PR DESCRIPTION
## Summary
- Add explicit accessible names for repeated Task Wall and stale-claim action buttons.
- Mark the stale-claim alert as a polite live region.
- Add focused Preact tests for Task Wall grouping/filtering/navigation and stale-claim threshold/action routing.

## Why
The G2 Task Zone components already exist on `main`, but they had no focused regression coverage. Repeated visible labels like `nudge`, `상세`, and truncated task chips made the operator surface harder to verify through assistive tech and easier to regress silently.

## Validation
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/goals/task-wall.test.ts src/components/goals/task-stale-alert.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint` (passes with existing unrelated warnings)
- `pnpm --dir dashboard run build` (passes with existing chunk-size/dynamic-import warnings)
- Browser: Vite dashboard at `http://localhost:5174/dashboard/#workspace?section=planning&view=default`, live planning data rendered stale alert + task wall; console and page errors empty.