### PR TITLE
fix(keeper): preserve post-turn cancellation

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -146,7 +146,9 @@ let apply_autonomous_wirein
             { cp with Agent_sdk.Checkpoint.working_context = new_wc }
           in
           { lifecycle with checkpoint = Some new_cp }
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
           Log.Keeper.warn
             "keeper:%s autonomous wire-in failed: %s"
             lifecycle.updated_meta.name (Printexc.to_string exn);
@@ -205,7 +207,9 @@ let apply_resilience_wirein
             }
           in
           { lifecycle with checkpoint = Some new_cp }
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
           Log.Keeper.warn
             "keeper:%s resilience wire-in failed: %s"
             lifecycle.updated_meta.name (Printexc.to_string exn);
@@ -272,7 +276,9 @@ let apply_tool_emission_wirein
             { cp with Agent_sdk.Checkpoint.working_context = new_wc }
           in
           { lifecycle with checkpoint = Some new_cp }
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
           Log.Keeper.warn
             "keeper:%s tool emission drain failed: %s"
             lifecycle.updated_meta.name
@@ -340,7 +346,9 @@ let apply_multimodal_wirein
             { cp with Agent_sdk.Checkpoint.working_context = new_wc }
           in
           { lifecycle with checkpoint = Some new_cp }
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
           Log.Keeper.warn
             "keeper:%s multimodal wire-in failed: %s"
             lifecycle.updated_meta.name (Printexc.to_string exn);

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -584,7 +584,21 @@ let test_keeper_agent_upgrade_source_contracts () =
   check bool "keeper post-turn tail order is tool emission before multimodal" true
     (match tool_emission, multimodal with
      | Some t, Some m -> t < m
-     | _ -> false)
+     | _ -> false);
+  let guarded_wirein_catch message =
+    file_contains_pattern "lib/keeper/keeper_post_turn.ml"
+      ("with\n        | Eio.Cancel.Cancelled _ as e -> raise e\n        | exn ->\n\
+        \          Log.Keeper.warn\n            \"keeper:%s "
+       ^ message ^ " failed: %s\"")
+  in
+  check bool "autonomous post-turn wire-in re-raises cancellation" true
+    (guarded_wirein_catch "autonomous wire-in");
+  check bool "resilience post-turn wire-in re-raises cancellation" true
+    (guarded_wirein_catch "resilience wire-in");
+  check bool "tool emission post-turn wire-in re-raises cancellation" true
+    (guarded_wirein_catch "tool emission drain");
+  check bool "multimodal post-turn wire-in re-raises cancellation" true
+    (guarded_wirein_catch "multimodal wire-in")
 
 let test_contract_harness_contracts () =
   check bool "contract harness exposes extract_text helper" true


### PR DESCRIPTION
## Summary
- Re-raise `Eio.Cancel.Cancelled` from the four feature-flagged `Keeper_post_turn` wire-ins: autonomous, resilience, tool emission drain, and multimodal hydration.
- Add a source guard so those wire-in catch blocks cannot regress back to swallowing cancellation.

## Why It Matters
`Keeper_post_turn` intentionally logs and preserves the primary turn outcome when optional wire-ins fail, but cancellation is not an ordinary optional failure. Swallowing `Eio.Cancel.Cancelled` can keep a keeper tail alive after supervisor shutdown, timeout, or parent-fiber cancellation, which is the same reliability class tracked by #10395.

## Operator Impact
Cancellation now propagates through post-turn tail work instead of being converted into a warning plus unchanged lifecycle result. Non-cancel wire-in failures still remain isolated and visible through the existing warning and `keeper_post_turn_wirein_failures` metric.

## Validation
- `git diff --check`
- `MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 scripts/dune-local.sh build test/test_keeper_lifecycle.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `./_build/default/test/test_keeper_lifecycle.exe test checkpoint_patch`
- `./_build/default/test/test_keeper_lifecycle.exe test post_turn_lifecycle`
- Informational: `scripts/lint-cancel-guard.sh` still fails on 48 pre-existing wildcard catches, but no longer reports `lib/keeper/keeper_post_turn.ml`.

Refs #10395