### PR TITLE
fix(keeper): expose decision terminal telemetry

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -243,6 +243,20 @@ let json_string_list_member key json =
          | _ -> None)
   | _ -> []
 
+let json_string_member_opt key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let terminal_reason_code_of_decision_json json =
+  match json_string_member_opt "terminal_reason_code" json with
+  | Some _ as value -> value
+  | None ->
+    (match Yojson.Safe.Util.member "terminal_reason" json with
+     | `Assoc _ as terminal_reason ->
+       json_string_member_opt "code" terminal_reason
+     | _ -> None)
+
 let keeper_trust_json ?(include_receipt = false)
     (config : Coord.config) (meta : Keeper_types.keeper_meta) =
   let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
@@ -2071,11 +2085,22 @@ let keeper_decisions_json
         | `Float f -> `Int (int_of_float f)
         | _ -> `Null
       in
+      let duration_ms =
+        match float_or_null "duration_ms" with
+        | `Null -> float_or_null "latency_ms"
+        | value -> value
+      in
+      let terminal_reason_code =
+        match terminal_reason_code_of_decision_json json with
+        | Some value -> `String value
+        | None -> `Null
+      in
       `Assoc [
         ("ts_unix", float_or_null "ts_unix");
         ("keeper_name", `String keeper_name);
         ("event_type", `String event_type);
         ("outcome", string_or_null "outcome");
+        ("terminal_reason_code", terminal_reason_code);
         ("model_used", string_or_null "model_used");
         ("latency_ms", float_or_null "latency_ms");
         ("cost_usd", float_or_null "cost_usd");
@@ -2084,7 +2109,7 @@ let keeper_decisions_json
         ("stop_reason", string_or_null "stop_reason");
         ("error_category", string_or_null "error_category");
         ("tool", string_or_null "tool");
-        ("duration_ms", float_or_null "duration_ms");
+        ("duration_ms", duration_ms);
         ("match_count", int_or_null "match_count");
       ]
     ) top
@@ -2166,6 +2191,20 @@ let keeper_decisions_log_json
                 let outcome = str "outcome" in
                 if outcome <> "" then outcome else "turn"
             in
+            let terminal_reason_code =
+              terminal_reason_code_of_decision_json json
+            in
+            let duration_ms =
+              let number key =
+                match Yojson.Safe.Util.member key json with
+                | `Float value -> Some value
+                | `Int value -> Some (float_of_int value)
+                | _ -> None
+              in
+              match number "duration_ms" with
+              | Some _ as value -> value
+              | None -> number "latency_ms"
+            in
             let belief_summary = str "belief_summary" in
             let current_intention = str "current_intention" in
             let blocker = str "blocker" in
@@ -2174,6 +2213,9 @@ let keeper_decisions_log_json
               List.filter (fun s -> s <> "")
                 [ decision_type
                 ; (if channel <> "" then "via " ^ channel else "")
+                ; (match terminal_reason_code with
+                   | Some code -> "reason: " ^ code
+                   | None -> "")
                 ; (if current_intention <> "" then "\xe2\x86\x92 " ^ current_intention else "")
                 ; (if blocker <> "" then "blocked: " ^ blocker else "")
                 ; (if belief_summary <> "" then belief_summary else "")
@@ -2195,6 +2237,14 @@ let keeper_decisions_log_json
               ("keeper", `String keeper_name);
               ("decision_type", `String decision_type);
               ("summary", `String summary);
+              ( "terminal_reason_code",
+                match terminal_reason_code with
+                | Some code -> `String code
+                | None -> `Null );
+              ( "duration_ms",
+                match duration_ms with
+                | Some value -> `Float value
+                | None -> `Null );
               ("evidence_refs", `List evidence_refs);
             ])
           with

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -114,7 +114,10 @@ let severity_of_tool_call success = if success then "ok" else "bad"
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
   | `Assoc _ as terminal_reason -> Keeper_turn_terminal.of_json terminal_reason
-  | _ -> None
+  | _ ->
+      Option.map
+        (Keeper_turn_terminal.of_code ~source:"decision_log")
+        (json_string_opt_member "terminal_reason_code" json)
 
 let terminal_reason_from_receipt receipt =
   match json_string_opt_member "terminal_reason_code" receipt with

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -678,10 +678,12 @@ let append_decision_record
         | _, Some err -> Keeper_turn_terminal.of_legacy_error_text err
         | _ -> Keeper_turn_terminal.of_code "unknown_error")
   in
+  let terminal_reason_code = terminal_reason.Keeper_turn_terminal.code in
   let json =
     `Assoc
       ([
         ("id", `String (decision_id ~meta ~ts:now_ts ~suffix_seed));
+        ("event", `String "turn");
         ("ts", `String (now_iso ()));
         ("ts_unix", `Float now_ts);
         ("audience", `String "internal_human_only");
@@ -695,6 +697,12 @@ let append_decision_record
         ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) goal_ids));
         ("runtime_contract", runtime_contract);
         ("terminal_reason", Keeper_turn_terminal.to_json terminal_reason);
+        ("terminal_reason_code", `String terminal_reason_code);
+        ( "terminal_reason_severity",
+          `String
+            (Keeper_turn_terminal.severity_to_string
+               terminal_reason.Keeper_turn_terminal.severity) );
+        ("terminal_reason_source", `String terminal_reason.source);
         ("provider_context", provider_context_json ~meta result);
         ("tool_contract", tool_contract_json ~tool_call_count ~tools_used result);
         ("pending_approval_count", `Int pending_approval_count);
@@ -707,6 +715,7 @@ let append_decision_record
         ("fallback_reason", Json_util.string_opt_to_json fallback_reason);
         ("turn_mode", Json_util.string_opt_to_json turn_mode_label);
         ("latency_ms", `Int latency_ms);
+        ("duration_ms", `Int latency_ms);
         ("semaphore_wait_ms", `Int semaphore_wait_ms);
         ("trigger_signals", `List (List.map (fun s -> `String s) trigger_signals));
         ("observed_affordances", `List (List.map (fun s -> `String s) affordances));

--- a/test/test_dashboard_k2_feeds.ml
+++ b/test/test_dashboard_k2_feeds.ml
@@ -186,6 +186,55 @@ let test_decisions_log_json_shape () =
      contains_substring ~needle:"deploy" s)
 ;;
 
+let test_decisions_json_terminal_reason_duration_fallback () =
+  with_config
+  @@ fun config ->
+  let meta = keeper_meta "k2-decision-terminal-duration" in
+  let path = Keeper_types.keeper_decision_log_path config meta.name in
+  append_jsonl
+    path
+    (`Assoc
+        [ "ts_unix", `Float 1_300.0
+        ; "keeper_name", `String meta.name
+        ; "outcome", `String "error"
+        ; "latency_ms", `Int 321
+        ; ( "terminal_reason"
+          , `Assoc
+              [ "code", `String "provider_error"
+              ; "source", `String "typed"
+              ; "severity", `String "bad"
+              ; "summary", `String "provider failed"
+              ] )
+        ]);
+  let compact =
+    Dash.keeper_decisions_json ~config ~keepers:[ meta ] ~limit:10 ()
+  in
+  let compact_event =
+    match Json.(compact |> member "events" |> to_list) with
+    | event :: _ -> event
+    | [] -> fail "expected compact decision event"
+  in
+  check string "compact terminal reason" "provider_error"
+    Json.(compact_event |> member "terminal_reason_code" |> to_string);
+  check (float 0.001) "compact duration fallback" 321.0
+    Json.(compact_event |> member "duration_ms" |> to_float);
+  let log =
+    Dash.keeper_decisions_log_json ~config ~keepers:[ meta ] ~limit:10 ()
+  in
+  let log_event =
+    match Json.(log |> member "events" |> to_list) with
+    | event :: _ -> event
+    | [] -> fail "expected decision log event"
+  in
+  check string "log terminal reason" "provider_error"
+    Json.(log_event |> member "terminal_reason_code" |> to_string);
+  check (float 0.001) "log duration fallback" 321.0
+    Json.(log_event |> member "duration_ms" |> to_float);
+  check bool "log summary includes reason" true
+    (let s = Json.(log_event |> member "summary" |> to_string) in
+     contains_substring ~needle:"reason: provider_error" s)
+;;
+
 (* --- Memory log tests --- *)
 
 let memory_row ~ts text =
@@ -269,6 +318,10 @@ let () =
         ; test_case "clamps low limit" `Quick test_decisions_log_clamps_low_limit
         ; test_case "clamps high limit" `Quick test_decisions_log_clamps_high_limit
         ; test_case "json shape matches spec" `Quick test_decisions_log_json_shape
+        ; test_case
+            "terminal reason and duration fallback"
+            `Quick
+            test_decisions_json_terminal_reason_duration_fallback
         ] )
     ; ( "memory log"
       , [ test_case

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1654,6 +1654,42 @@ let test_runtime_trust_snapshot_surfaces_terminal_reason () =
              && event |> member "next_human_action" |> to_string = "create_or_link_worktree")
            timeline))
 
+let test_runtime_trust_snapshot_reads_terminal_reason_code_alias () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      with_test_runtime_roots base_dir @@ fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let keeper_name = "runtime-trust-terminal-code-alias" in
+      let meta = { minimal_meta with name = keeper_name } in
+      let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
+      Keeper_types.mkdir_p (Filename.dirname decision_path);
+      Masc_mcp.Keeper_types_support.append_jsonl_line
+        decision_path
+        (`Assoc
+          [
+            ("ts_unix", `Float 1_712_000_010.0);
+            ("trace_id", `String "trace-terminal-code-alias");
+            ("turn_id", `Int 9);
+            ("terminal_reason_code", `String "provider_error");
+          ]);
+      let snapshot =
+        Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+      in
+      let open Yojson.Safe.Util in
+      check string "latest terminal code alias" "provider_error"
+        (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
+      let timeline = snapshot |> member "causal_timeline" |> to_list in
+      check bool "terminal reason alias event present" true
+        (List.exists
+           (fun event ->
+             event |> member "kind" |> to_string = "terminal_reason"
+             && event |> member "summary" |> to_string = "provider or cascade failed")
+           timeline))
+
 let test_prompt_contains_identity () =
   let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
   check bool "contains name" true (String.length sys > 0);
@@ -3453,6 +3489,8 @@ let test_append_decision_record_persists_tool_calls () =
         Yojson.Safe.Util.(json |> member "tool_call_count" |> to_int);
       check int "turn id persisted" 8
         Yojson.Safe.Util.(json |> member "turn_id" |> to_int);
+      check int "duration alias persisted" 42
+        Yojson.Safe.Util.(json |> member "duration_ms" |> to_int);
       check (option string) "task id persisted"
         (Some "task-runtime-trust")
         Yojson.Safe.Util.(json |> member "task_id" |> to_string_option);
@@ -3503,6 +3541,8 @@ let test_append_decision_record_persists_tool_calls () =
 	        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "latency_ms" |> to_float);
 	      check string "terminal reason success" "success"
 	        Yojson.Safe.Util.(json |> member "terminal_reason" |> member "code" |> to_string);
+	      check string "terminal reason code alias" "success"
+	        Yojson.Safe.Util.(json |> member "terminal_reason_code" |> to_string);
 	      check string "provider context selected model" "codex_cli:gpt-5.4"
 	        Yojson.Safe.Util.(json |> member "provider_context" |> member "selected_model" |> to_string);
 	      check string "tool contract requirement" "optional"
@@ -3586,8 +3626,12 @@ let test_append_decision_record_classifies_legacy_worktree_error () =
         read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
       in
       let open Yojson.Safe.Util in
+      check int "error duration alias persisted" 19
+        (json |> member "duration_ms" |> to_int);
       check string "terminal code" "gh_repo_context_missing_worktree"
         (json |> member "terminal_reason" |> member "code" |> to_string);
+      check string "terminal code alias" "gh_repo_context_missing_worktree"
+        (json |> member "terminal_reason_code" |> to_string);
       check string "next action" "create_or_link_worktree"
         (json |> member "terminal_reason" |> member "next_action" |> to_string);
       check string "tool contract unknown for error path" "unknown"
@@ -7195,6 +7239,8 @@ let () =
 	            test_runtime_trust_snapshot_tolerates_null_telemetry;
 	          test_case "runtime trust snapshot surfaces terminal reason" `Quick
 	            test_runtime_trust_snapshot_surfaces_terminal_reason;
+	          test_case "runtime trust snapshot reads terminal reason code alias" `Quick
+	            test_runtime_trust_snapshot_reads_terminal_reason_code_alias;
 	          test_case "with goals" `Quick test_observation_with_goals;
           test_case "economic modes" `Quick test_observation_economic_modes;
         ] );


### PR DESCRIPTION
## Summary

Refs #13393.

- Add flat `terminal_reason_code`, terminal reason metadata, and `duration_ms` aliases to turn-level `*.decisions.jsonl` records while preserving the existing structured `terminal_reason` and `latency_ms` fields.
- Teach dashboard decision feeds to derive `terminal_reason_code` from either the flat field or structured terminal reason, and to fall back from missing `duration_ms` to `latency_ms` for older rows.
- Teach runtime-trust snapshots to consume flat `terminal_reason_code` rows when a writer does not emit the structured object.

## Why

The #13393 fleet audit found that decision-log consumers were looking for `terminal_reason_code` and `duration_ms`, but the unified turn writer only emitted a structured `terminal_reason` object and `latency_ms`. That made real terminal explanations and turn durations look absent in dashboard/feed surfaces even when the turn writer had already computed them.

This is a narrow compatibility/observability fix. It does not attempt to reclassify the historical `outcome=error` population.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_dashboard_k2_feeds.exe`
- `./_build/default/test/test_dashboard_k2_feeds.exe`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 24-26`
- `./_build/default/test/test_keeper_unified.exe test world_observation 49-51`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 42-52`
