### PR TITLE
refactor(dashboard): privatize 6 internal-only types (knip batch 5)

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -203,7 +203,7 @@ export class ApiRequestError extends Error {
   }
 }
 
-export interface ApiErrorSummary {
+interface ApiErrorSummary {
   message: string
   status: number | null
   path: string | null

--- a/dashboard/src/components/chip.ts
+++ b/dashboard/src/components/chip.ts
@@ -28,7 +28,7 @@ import { html } from 'htm/preact'
 import type { ComponentChildren, VNode } from 'preact'
 import { MONO_STACK } from './common/font-stacks'
 
-export type ChipKind =
+type ChipKind =
   | 'neutral'
   | 'brass'
   | 'ok'
@@ -38,9 +38,9 @@ export type ChipKind =
   | 'stalled'
   | 'ghost'
 
-export type ChipSize = 'sm' | 'default' | 'lg'
+type ChipSize = 'sm' | 'default' | 'lg'
 
-export interface ChipProps {
+interface ChipProps {
   children: ComponentChildren
   /** Tone. `undefined` ≡ `neutral`. `ghost` is a transparent variant. */
   kind?: ChipKind

--- a/dashboard/src/components/common/recovery-wizard.ts
+++ b/dashboard/src/components/common/recovery-wizard.ts
@@ -7,7 +7,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 
-export interface RecoveryStep {
+interface RecoveryStep {
   id: string
   label: string
   status: 'pending' | 'running' | 'completed' | 'failed'

--- a/dashboard/src/components/turn-budget-gauge.ts
+++ b/dashboard/src/components/turn-budget-gauge.ts
@@ -26,7 +26,7 @@ export const BUDGET_CRIT_RATIO = 0.8
 
 // ── Derivations ───────────────────────────────────────────────────────────
 
-export interface BudgetGaugeState {
+interface BudgetGaugeState {
   used: number
   max: number
   ratio: number

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -37,9 +37,9 @@ import {
   KEEPER_STREAM_IDLE_TIMEOUT_MS,
 } from './config/constants'
 
-export type KeeperInterjectActionKind = 'send' | 'approve' | 'pause' | 'drain'
+type KeeperInterjectActionKind = 'send' | 'approve' | 'pause' | 'drain'
 
-export interface KeeperInterjectCommand {
+interface KeeperInterjectCommand {
   readonly kind: KeeperInterjectActionKind
   readonly keeperName: string
   readonly message?: string

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -20,7 +20,7 @@ export interface KeeperActivityDisplay {
   ageSeconds: number | null
 }
 
-export interface KeeperModelDisplay {
+interface KeeperModelDisplay {
   label: string
   value: string
 }

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -28,7 +28,7 @@ export interface KeeperMonitoringSummary {
   hint: string | null
 }
 
-export interface MonitoringEvidence {
+interface MonitoringEvidence {
   phase: PhaseMeta | null
   stage: StageMeta | null
 }

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -55,7 +55,7 @@ export type PulseState = 'working' | 'idle' | 'stale'
 
 const STALE_THRESHOLD_MS = 120_000
 
-export interface AgentPulse {
+interface AgentPulse {
   name: string
   emoji: string
   koreanName: string | null

--- a/dashboard/src/pending-confirm.ts
+++ b/dashboard/src/pending-confirm.ts
@@ -78,7 +78,7 @@ interface PendingConfirmSource {
   available_actions?: OperatorActionDescriptor[] | null
 }
 
-export interface PendingConfirmState {
+interface PendingConfirmState {
   items: PendingConfirmation[]
   summary: PendingConfirmSummary
   actor_filter: string | null

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -266,8 +266,6 @@ export interface DashboardMissionBriefingResponse {
   last_error?: string | null
 }
 
-export type DashboardProofVerdict = 'proven' | 'partial' | 'insufficient' | string
-
 export interface DashboardProofWorkerRunEvidence {
   worker_run_id: string
   session_id?: string | null


### PR DESCRIPTION
## What

Continuation of #13313 / #13342 / #13395 / #13424. Privatizes 13 internal-only types + removes 1 unused alias across 10 files.

### Privatized (12 types — single internal reference)

| Type | File |
|---|---|
| \`RecoveryStep\` | \`components/common/recovery-wizard.ts\` |
| \`ChipKind\` / \`ChipSize\` / \`ChipProps\` | \`components/chip.ts\` |
| \`BudgetGaugeState\` | \`components/turn-budget-gauge.ts\` |
| \`ApiErrorSummary\` | \`api/core.ts\` |
| \`KeeperModelDisplay\` | \`lib/keeper-runtime-display.ts\` |
| \`MonitoringEvidence\` | \`lib/monitoring-runtime.ts\` |
| \`KeeperInterjectActionKind\` / \`KeeperInterjectCommand\` | \`keeper-actions.ts\` |
| \`PendingConfirmState\` | \`pending-confirm.ts\` |
| \`AgentPulse\` | \`live-store.ts\` |

### Deleted (1 alias, definition-only)

| Type | File | Note |
|---|---|---|
| \`DashboardProofVerdict\` | \`types/dashboard-mission.ts\` | \`'proven' \\| 'partial' \\| 'insufficient' \\| string\` — \`\\| string\` subsumes literals; type was structurally vacuous |

## Audit observation

Knip flagged 9 additional types (agent-conversation, agent-memory, breadcrumb-history, event-stream, file-tree, keyboard-shortcut, memory-search, memory-timeline, sync-conflict) that turn out to be referenced from \`*.a11y.test.ts\` via inline \`import('./X').Type[]\` syntax. Knip's static analysis missed this pattern — those were excluded.

## Verification

- \`tsc --noEmit\`: 0 errors
- ESLint on 10 changed files: 0 warnings
- vitest: 8 test files / 167 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)