### PR TITLE
fix(keeper): align state output guard

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -42,6 +42,9 @@ let critical_prompt_recovery_block =
       "Recovery guard: act from the configured base path and active runtime tool schema; do not invent paths, repos, PRs, tasks, or tools.";
       "</world>" ]
 
+let state_block_output_guard_text =
+  "Output guard: this turn uses runtime-managed continuity. Do not output raw [STATE] or [/STATE] blocks in visible text; the runtime will synthesize and persist state metadata when needed."
+
 let ensure_critical_prompt_anchors prompt =
   match missing_critical_prompt_anchors prompt with
   | [] -> prompt

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -11,6 +11,11 @@ val ensure_critical_prompt_anchors : string -> string
     lost critical continuity/world/policy anchors. Normal prompts are returned
     unchanged. *)
 
+val state_block_output_guard_text : string
+(** Turn-level output guard for runtime-managed continuity. The runtime may
+    synthesize and persist STATE metadata, so direct/no-state turns should not
+    ask the model to emit raw STATE markers in visible text. *)
+
 val build_keeper_system_prompt :
   goal:string ->
   short_goal:string ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -380,7 +380,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   (effective_no_skill_route,
                    "Output guard: NEVER output lines starting with SKILL: or SKILL_REASON:.");
                   (effective_no_state_block,
-                   "Output guard: NEVER output [STATE] or [/STATE] blocks in this turn.");
+                   Keeper_prompt.state_block_output_guard_text);
                 ] in
                 let policy_lines =
                   List.filter_map

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -77,6 +77,13 @@ let line_block label value =
   if value = "" then ""
   else Printf.sprintf "%s: %s\n" label value
 
+let state_block_instruction_text =
+  "For non-direct keeper turns, end every response with a [STATE]...[/STATE] block unless a more specific turn-level output guard says continuity is runtime-managed:\n\
+   DONE: what you accomplished this cycle\n\
+   NEXT: what the next cycle should do\n\
+   Goal: current active goal\n\
+   Decisions: key decisions (semicolon-separated)"
+
 let autonomous_trigger_lines
     ~(decision : Keeper_world_observation.keeper_cycle_decision)
     ~(observation : Keeper_world_observation.world_observation) : string list =
@@ -230,13 +237,8 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
          CLAIM_SUBJECT: short concrete subject or task title\n\
          CLAIM_TASK_ID: task-123 (if applicable)\n\
          EVIDENCE_REFS: task:task-123, tool:keeper_task_done\n\
-         Only emit them for concrete claims you expect the system to audit.\n\
-         \n\
-         End every response with a [STATE]...[/STATE] block:\n\
-         DONE: what you accomplished this cycle\n\
-         NEXT: what the next cycle should do\n\
-         Goal: current active goal\n\
-         Decisions: key decisions (semicolon-separated)";
+         Only emit them for concrete claims you expect the system to audit.\n";
+        state_block_instruction_text;
       ]
   in
   let system_prompt =

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -7,6 +7,10 @@
 
     @since Unified Keeper Loop *)
 
+val state_block_instruction_text : string
+(** Generic STATE formatting instruction for normal keeper turns. Turn-level
+    output guards can override this when continuity is runtime-managed. *)
+
 (** Build unified system prompt and user message from keeper state.
 
     Returns [(system_prompt, user_message)] where:

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -11,6 +11,7 @@ open Alcotest
 module KAR = Masc_mcp.Keeper_agent_run
 module KSR = Masc_mcp.Keeper_skill_routing
 module KP = Masc_mcp.Keeper_prompt
+module KUP = Masc_mcp.Keeper_unified_prompt
 
 (* CJK-aware token estimator from OAS *)
 let estimate_tokens s =
@@ -20,6 +21,26 @@ let estimate_tokens s =
 let has_in s needle =
   try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
   with Not_found -> false
+
+let has_prompt_root path =
+  Sys.file_exists (Filename.concat path "config/prompts/keeper.world.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+      let rec ascend path =
+        if has_prompt_root path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then Sys.getcwd () else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
+let () =
+  let prompts_dir = Filename.concat (repo_root ()) "config/prompts" in
+  Prompt_registry.set_markdown_dir prompts_dir;
+  Masc_mcp.Prompt_defaults.init ()
 
 (* ── Fixture: realistic keeper prompt components ──────── *)
 
@@ -69,8 +90,7 @@ let build_separated () : KAR.turn_prompt =
   let prompt =
     KP.append_direct_reply_mode_prompt ~base_prompt:base_system_prompt
   in
-  let prompt = prompt ^ "\n\n" ^
-    "Output guard: NEVER output [STATE] or [/STATE] blocks in this turn." in
+  let prompt = prompt ^ "\n\n" ^ KP.state_block_output_guard_text in
   { system_prompt = prompt; dynamic_context }
 
 (* Simulate the pre-split combined prompt (everything in system_prompt) *)
@@ -80,7 +100,7 @@ let build_combined () : string =
   in
   let parts = [
     prompt;
-    "Output guard: NEVER output [STATE] or [/STATE] blocks in this turn.";
+    KP.state_block_output_guard_text;
     skill_route_text;
     continuity_snapshot_text;
     worktree_text;
@@ -220,6 +240,30 @@ let test_prompt_recovery_guard_restores_missing_anchors () =
   check bool "recovery state template present" true
     (has_in prompt "State block template");
   check bool "recovery world anchor present" true (has_in prompt "<world>")
+
+let test_state_block_guard_is_runtime_managed_not_absolute_never () =
+  let guard = KP.state_block_output_guard_text in
+  check bool "guard mentions runtime-managed continuity" true
+    (has_in guard "runtime-managed continuity");
+  check bool "guard avoids absolute NEVER state wording" false
+    (has_in guard ("NEVER output " ^ "[STATE]"));
+  check bool "guard names raw state markers" true
+    (has_in guard "raw [STATE]");
+  check bool "guard mentions runtime persistence" true
+    (has_in guard "persist state metadata")
+
+let test_unified_state_instruction_respects_turn_level_guard () =
+  let text = KUP.state_block_instruction_text in
+  check bool "instruction is scoped to non-direct turns" true
+    (has_in text "For non-direct keeper turns");
+  check bool "instruction names turn-level override" true
+    (has_in text "turn-level output guard");
+  check bool "instruction mentions runtime-managed continuity" true
+    (has_in text "runtime-managed");
+  check bool "instruction avoids old unconditional wording" false
+    (has_in text
+       ("End every response with a "
+        ^ "[STATE]...[/STATE] block:"))
 
 let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
   let prompt =
@@ -363,6 +407,10 @@ let () =
             test_keeper_prompt_preserves_snapshot_delta_anchors;
           test_case "prompt recovery guard restores missing anchors" `Quick
             test_prompt_recovery_guard_restores_missing_anchors;
+          test_case "state block guard is runtime-managed" `Quick
+            test_state_block_guard_is_runtime_managed_not_absolute_never;
+          test_case "unified state instruction respects turn-level guard" `Quick
+            test_unified_state_instruction_respects_turn_level_guard;
           test_case "prompt mentions runtime operator approval for risky actions" `Quick
             test_prompt_mentions_runtime_operator_approval_for_risky_actions;
         ] );


### PR DESCRIPTION
## What changed

- Replaced the direct/no-state turn guard's absolute `NEVER output [STATE]` wording with a runtime-managed continuity guard.
- Scoped the unified keeper prompt's STATE block instruction to non-direct keeper turns and made turn-level guards explicit.
- Bootstrapped prompt markdown loading in `test_keeper_prompt_metrics` so prompt-policy assertions do not fall back to missing runtime prompts locally.
- Added regressions that prevent the old unconditional STATE wording from returning.

## Why

`live_snapshot_delta_analysis.md` flagged a prompt contradiction where one prompt path said not to emit `[STATE]` while another required every response to end with a `[STATE]` block. The runtime already synthesizes and persists state metadata for no-state/direct turns, so the model-facing instructions should describe that boundary instead of issuing conflicting absolute directives.

## Impact

Keeper direct/no-state turns no longer see contradictory continuity instructions. Normal non-direct keeper turns still retain the visible STATE template, while runtime-managed turns rely on server-side state synthesis.

## Validation

- `git diff --check`
- `DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_prompt_metrics.exe`
- `./_build/default/test/test_keeper_prompt_metrics.exe`