### PR TITLE
fix(dashboard): add composer modes to quick intervention

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -87,4 +87,21 @@ describe('cockpit entrypoint registry', () => {
       params: { section: 'ide-shell', view: 'source', find: 'open' },
     })
   })
+
+  it('routes covered C3 composer variants to focused quick intervention modes', () => {
+    const variants = [
+      ['cm-bc', 'broadcast'],
+      ['cm-mn', 'mention'],
+      ['cm-st', 'state'],
+    ] as const
+
+    for (const [alias, focus] of variants) {
+      const entrypoint = COCKPIT_ENTRYPOINTS.find(entry => entry.aliases.includes(alias))
+      expect(entrypoint?.coverage).toBe('covered')
+      expect(cockpitTargetForParams({ mode: 'Comms', tab: alias })).toEqual({
+        tab: 'command',
+        params: { section: 'operations', view: 'ops', focus },
+      })
+    }
+  })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -48,16 +48,16 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'partial' },
   { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'partial' },
 
-  // Comms Plane: board and message focus surfaces have production coverage; composer zones remain partial.
+  // Comms Plane: board, message focus, and composer surfaces have production coverage.
   { mode: 'comms', aliases: ['bd-feed', 'board-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'workspace', params: { section: 'board', focus: 'thread' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'workspace', params: { section: 'board', focus: 'automation' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-rm', 'messages-room'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-room' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'workspace', params: { section: 'board', focus: 'mention-inbox' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'workspace', params: { section: 'board', focus: 'state-block' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'partial' },
-  { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'partial' },
-  { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'covered' },
+  { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'covered' },
 
   // Observe Plane: split prototype tabs across the consolidated production surfaces.
   { mode: 'observe', aliases: ['cs-list', 'cascade-list'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cascade' } }, coverage: 'covered' },

--- a/dashboard/src/components/common/input.test.ts
+++ b/dashboard/src/components/common/input.test.ts
@@ -168,6 +168,15 @@ describe('TextArea', () => {
     expect(spy).toHaveBeenCalledOnce()
   })
 
+  it('onKeyDown fires on key events', async () => {
+    const spy = vi.fn()
+    render(html`<${TextArea} onKeyDown=${spy} />`, container)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
   it('inputRef.current points to the inner <textarea> after mount', () => {
     const ref: { current: HTMLTextAreaElement | null } = { current: null }
     render(html`<${TextArea} inputRef=${ref} />`, container)

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -98,6 +98,11 @@ interface TextAreaProps {
   class?: string
   name?: string
   ariaLabel?: string
+  ariaAutocomplete?: string
+  ariaControls?: string
+  ariaExpanded?: boolean | string
+  ariaActiveDescendant?: string
+  role?: string
   disabled?: boolean
   required?: boolean
   /** Forwards a Preact ref to the inner <textarea>. Mirrors TextInput —
@@ -116,6 +121,11 @@ export function TextArea({
   class: cx,
   name,
   ariaLabel,
+  ariaAutocomplete,
+  ariaControls,
+  ariaExpanded,
+  ariaActiveDescendant,
+  role,
   disabled,
   required,
   inputRef,
@@ -130,7 +140,12 @@ export function TextArea({
       placeholder=${placeholder}
       rows=${rows}
       name=${name}
+      role=${role}
       aria-label=${ariaLabel}
+      aria-autocomplete=${ariaAutocomplete}
+      aria-controls=${ariaControls}
+      aria-expanded=${ariaExpanded}
+      aria-activedescendant=${ariaActiveDescendant}
       disabled=${disabled}
       required=${required}
       value=${value}

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -105,6 +105,7 @@ interface TextAreaProps {
       focus, dialog `initialFocusRef`, etc.). */
   inputRef?: { current: HTMLTextAreaElement | null }
   onInput?: (e: Event) => void
+  onKeyDown?: (e: KeyboardEvent) => void
 }
 
 export function TextArea({
@@ -119,6 +120,7 @@ export function TextArea({
   required,
   inputRef,
   onInput,
+  onKeyDown,
 }: TextAreaProps) {
   return html`
     <textarea
@@ -133,6 +135,7 @@ export function TextArea({
       required=${required}
       value=${value}
       onInput=${onInput}
+      onKeyDown=${onKeyDown}
     ></textarea>
   `
 }

--- a/dashboard/src/components/ops/ops-state.test.ts
+++ b/dashboard/src/components/ops/ops-state.test.ts
@@ -92,6 +92,11 @@ describe('ops-state', () => {
     expect(hasStateBlock('Goal: ship')).toBe(false)
   })
 
+  it('rejects state labels the backend parser does not understand', () => {
+    const message = '[STATE]\nGoal : ship\nOpen Questions: risk?\nOpenQuestions: accepted\n[/STATE]'
+    expect(stateBlockKeys(message)).toEqual(['OpenQuestions'])
+  })
+
   it('appends the state template without duplicating an existing block', () => {
     expect(ensureStateBlockDraft('')).toBe(STATE_BLOCK_TEMPLATE)
     expect(ensureStateBlockDraft('Heads up')).toBe(`Heads up\n\n${STATE_BLOCK_TEMPLATE}`)

--- a/dashboard/src/components/ops/ops-state.test.ts
+++ b/dashboard/src/components/ops/ops-state.test.ts
@@ -84,9 +84,11 @@ describe('ops-state', () => {
   })
 
   it('extracts structured state block keys', () => {
-    const message = '[STATE]\nGoal: ship\nPhase: review\nNext: watch CI\nBlocker: none\n[/STATE]'
-    expect(stateBlockKeys(message)).toEqual(['Goal', 'Phase', 'Next', 'Blocker'])
+    const message = '[STATE]\nGoal: ship\nPhase: review\nNEXT: watch CI\nBlocker: none\nOpenQuestions: risk?\nConstraints: no downtime\n[/STATE]'
+    expect(stateBlockKeys(message)).toEqual(['Goal', 'NEXT', 'OpenQuestions', 'Constraints'])
     expect(hasStateBlock(message)).toBe(true)
+    expect(hasStateBlock(STATE_BLOCK_TEMPLATE)).toBe(false)
+    expect(hasStateBlock('[STATE]\nPhase: review\nBlocker: none\n[/STATE]')).toBe(false)
     expect(hasStateBlock('Goal: ship')).toBe(false)
   })
 

--- a/dashboard/src/components/ops/ops-state.test.ts
+++ b/dashboard/src/components/ops/ops-state.test.ts
@@ -102,4 +102,11 @@ describe('ops-state', () => {
     expect(ensureStateBlockDraft('Heads up')).toBe(`Heads up\n\n${STATE_BLOCK_TEMPLATE}`)
     expect(ensureStateBlockDraft(STATE_BLOCK_TEMPLATE)).toBe(STATE_BLOCK_TEMPLATE)
   })
+
+  it('requires canonical uppercase state block tags', () => {
+    const lower = '[state]\nGoal: ship\n[/state]'
+    expect(stateBlockKeys(lower)).toEqual([])
+    expect(hasStateBlock(lower)).toBe(false)
+    expect(ensureStateBlockDraft(lower)).toBe(`${lower}\n\n${STATE_BLOCK_TEMPLATE}`)
+  })
 })

--- a/dashboard/src/components/ops/ops-state.test.ts
+++ b/dashboard/src/components/ops/ops-state.test.ts
@@ -22,7 +22,13 @@ import {
   hydratedWorkflowId,
   quickTarget,
   quickMessage,
+  quickComposerMode,
+  composerModeForFocus,
+  ensureStateBlockDraft,
+  hasStateBlock,
   persistActorName,
+  stateBlockKeys,
+  STATE_BLOCK_TEMPLATE,
 } from './ops-state'
 
 describe('ops-state', () => {
@@ -36,6 +42,7 @@ describe('ops-state', () => {
     hydratedWorkflowId.value = null
     quickTarget.value = 'namespace'
     quickMessage.value = ''
+    quickComposerMode.value = 'broadcast'
     mockPersistDashboardActorName.mockClear()
     mockResolveDashboardActorName.mockClear()
   })
@@ -57,6 +64,7 @@ describe('ops-state', () => {
     expect(taskPriority.value).toBe('2')
     expect(quickTarget.value).toBe('namespace')
     expect(quickMessage.value).toBe('')
+    expect(quickComposerMode.value).toBe('broadcast')
     expect(hydratedWorkflowId.value).toBeNull()
   })
 
@@ -65,5 +73,26 @@ describe('ops-state', () => {
     persistActorName('new-actor')
     expect(mockPersistDashboardActorName).toHaveBeenCalledWith('new-actor')
     expect(actorName.value).toBe('persisted-actor')
+  })
+
+  it('maps command focus aliases to composer modes', () => {
+    expect(composerModeForFocus('broadcast')).toBe('broadcast')
+    expect(composerModeForFocus('mention')).toBe('dm')
+    expect(composerModeForFocus('dm')).toBe('dm')
+    expect(composerModeForFocus('state')).toBe('state')
+    expect(composerModeForFocus('unknown')).toBeNull()
+  })
+
+  it('extracts structured state block keys', () => {
+    const message = '[STATE]\nGoal: ship\nPhase: review\nNext: watch CI\nBlocker: none\n[/STATE]'
+    expect(stateBlockKeys(message)).toEqual(['Goal', 'Phase', 'Next', 'Blocker'])
+    expect(hasStateBlock(message)).toBe(true)
+    expect(hasStateBlock('Goal: ship')).toBe(false)
+  })
+
+  it('appends the state template without duplicating an existing block', () => {
+    expect(ensureStateBlockDraft('')).toBe(STATE_BLOCK_TEMPLATE)
+    expect(ensureStateBlockDraft('Heads up')).toBe(`Heads up\n\n${STATE_BLOCK_TEMPLATE}`)
+    expect(ensureStateBlockDraft(STATE_BLOCK_TEMPLATE)).toBe(STATE_BLOCK_TEMPLATE)
   })
 })

--- a/dashboard/src/components/ops/ops-state.ts
+++ b/dashboard/src/components/ops/ops-state.ts
@@ -22,11 +22,30 @@ export const hydratedWorkflowId = signal<string | null>(null)
 // 'namespace' = broadcast, 'keeper:{name}' = keeper_message
 export type QuickComposerMode = 'broadcast' | 'dm' | 'state'
 
-export const STATE_BLOCK_TEMPLATE = '[STATE]\nGoal: \nPhase: \nNext: \nBlocker: \n[/STATE]'
+export const STATE_BLOCK_TEMPLATE = [
+  '[STATE]',
+  'Goal: ',
+  'DONE: ',
+  'NEXT: ',
+  'Decisions: ',
+  'OpenQuestions: ',
+  'Constraints: ',
+  '[/STATE]',
+].join('\n')
 
 export const quickTarget = signal('namespace')
 export const quickMessage = signal('')
 export const quickComposerMode = signal<QuickComposerMode>('broadcast')
+
+const STATE_BLOCK_KEYS: Record<string, string> = {
+  constraints: 'Constraints',
+  decisions: 'Decisions',
+  done: 'DONE',
+  goal: 'Goal',
+  next: 'NEXT',
+  openquestions: 'OpenQuestions',
+  progress: 'Progress',
+}
 
 export function composerModeForFocus(focus?: string | null): QuickComposerMode | null {
   switch (focus?.trim().toLowerCase()) {
@@ -54,9 +73,12 @@ export function stateBlockKeys(message: string): string[] {
   const seen = new Set<string>()
   const keys: string[] = []
   for (const line of body.split(/\r?\n/)) {
-    const match = line.match(/^\s*([A-Za-z][A-Za-z0-9 _-]{0,31})\s*:/)
-    const key = match?.[1]?.trim()
-    if (!key || seen.has(key)) continue
+    const match = line.match(/^\s*([A-Za-z][A-Za-z0-9 _-]{0,31})\s*:\s*(.*)$/)
+    const rawKey = match?.[1]?.trim()
+    const value = match?.[2]?.trim()
+    const normalized = rawKey?.replace(/\s+/g, '').toLowerCase()
+    const key = normalized ? STATE_BLOCK_KEYS[normalized] : null
+    if (!key || !value || seen.has(key)) continue
     seen.add(key)
     keys.push(key)
   }

--- a/dashboard/src/components/ops/ops-state.ts
+++ b/dashboard/src/components/ops/ops-state.ts
@@ -20,8 +20,58 @@ export const hydratedWorkflowId = signal<string | null>(null)
 
 // QuickIntervene: unified message target
 // 'namespace' = broadcast, 'keeper:{name}' = keeper_message
+export type QuickComposerMode = 'broadcast' | 'dm' | 'state'
+
+export const STATE_BLOCK_TEMPLATE = '[STATE]\nGoal: \nPhase: \nNext: \nBlocker: \n[/STATE]'
+
 export const quickTarget = signal('namespace')
 export const quickMessage = signal('')
+export const quickComposerMode = signal<QuickComposerMode>('broadcast')
+
+export function composerModeForFocus(focus?: string | null): QuickComposerMode | null {
+  switch (focus?.trim().toLowerCase()) {
+    case 'broadcast':
+      return 'broadcast'
+    case 'mention':
+    case 'dm':
+      return 'dm'
+    case 'state':
+      return 'state'
+    default:
+      return null
+  }
+}
+
+function stateBlockBody(message: string): string | null {
+  const match = message.match(/\[STATE\]([\s\S]*?)\[\/STATE\]/i)
+  return match?.[1] ?? null
+}
+
+export function stateBlockKeys(message: string): string[] {
+  const body = stateBlockBody(message)
+  if (!body) return []
+
+  const seen = new Set<string>()
+  const keys: string[] = []
+  for (const line of body.split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z][A-Za-z0-9 _-]{0,31})\s*:/)
+    const key = match?.[1]?.trim()
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    keys.push(key)
+  }
+  return keys
+}
+
+export function hasStateBlock(message: string): boolean {
+  return stateBlockKeys(message).length > 0
+}
+
+export function ensureStateBlockDraft(draft: string): string {
+  if (/\[STATE\][\s\S]*?\[\/STATE\]/i.test(draft)) return draft
+  const trimmed = draft.trimEnd()
+  return trimmed ? `${trimmed}\n\n${STATE_BLOCK_TEMPLATE}` : STATE_BLOCK_TEMPLATE
+}
 
 export function persistActorName(value: string): void {
   actorName.value = persistDashboardActorName(value)

--- a/dashboard/src/components/ops/ops-state.ts
+++ b/dashboard/src/components/ops/ops-state.ts
@@ -73,11 +73,10 @@ export function stateBlockKeys(message: string): string[] {
   const seen = new Set<string>()
   const keys: string[] = []
   for (const line of body.split(/\r?\n/)) {
-    const match = line.match(/^\s*([A-Za-z][A-Za-z0-9 _-]{0,31})\s*:\s*(.*)$/)
-    const rawKey = match?.[1]?.trim()
+    const match = line.match(/^\s*([A-Za-z][A-Za-z0-9]{0,31}):\s*(.*)$/)
+    const rawKey = match?.[1]?.toLowerCase()
     const value = match?.[2]?.trim()
-    const normalized = rawKey?.replace(/\s+/g, '').toLowerCase()
-    const key = normalized ? STATE_BLOCK_KEYS[normalized] : null
+    const key = rawKey ? STATE_BLOCK_KEYS[rawKey] : null
     if (!key || !value || seen.has(key)) continue
     seen.add(key)
     keys.push(key)

--- a/dashboard/src/components/ops/ops-state.ts
+++ b/dashboard/src/components/ops/ops-state.ts
@@ -62,7 +62,7 @@ export function composerModeForFocus(focus?: string | null): QuickComposerMode |
 }
 
 function stateBlockBody(message: string): string | null {
-  const match = message.match(/\[STATE\]([\s\S]*?)\[\/STATE\]/i)
+  const match = message.match(/\[STATE\]([\s\S]*?)\[\/STATE\]/)
   return match?.[1] ?? null
 }
 
@@ -89,7 +89,7 @@ export function hasStateBlock(message: string): boolean {
 }
 
 export function ensureStateBlockDraft(draft: string): string {
-  if (/\[STATE\][\s\S]*?\[\/STATE\]/i.test(draft)) return draft
+  if (/\[STATE\][\s\S]*?\[\/STATE\]/.test(draft)) return draft
   const trimmed = draft.trimEnd()
   return trimmed ? `${trimmed}\n\n${STATE_BLOCK_TEMPLATE}` : STATE_BLOCK_TEMPLATE
 }

--- a/dashboard/src/components/ops/quick-intervene.test.ts
+++ b/dashboard/src/components/ops/quick-intervene.test.ts
@@ -150,8 +150,14 @@ describe('QuickIntervene', () => {
 
     expect(stateButton?.getAttribute('aria-pressed')).toBe('true')
     expect(editor?.value).toContain('[STATE]')
-    expect(container.textContent).toContain('Goal')
-    expect(container.textContent).toContain('Blocker')
+    expect(editor?.value).toContain('Goal:')
+    expect(editor?.value).toContain('DONE:')
+    expect(editor?.value).toContain('NEXT:')
+    expect(editor?.value).not.toContain('Blocker:')
+
+    const send = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Send') as HTMLButtonElement | undefined
+    expect(send?.disabled).toBe(true)
   }, 15000)
 
   it('uses mention focus as keeper DM and sends to the first online keeper', async () => {
@@ -257,6 +263,109 @@ describe('QuickIntervene', () => {
     expect(container.querySelector('div[aria-label="Will mention: @nick0cave"]')).not.toBeNull()
   }, 15000)
 
+  it('sends to a typed exact keeper mention without requiring an autocomplete click', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = 'Please verify @nick0cave'
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [
+        { name: 'keeper-a', status: 'online' },
+        { name: 'nick0cave', status: 'busy' },
+      ],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const target = container.querySelector('select[aria-label="Keeper message target"]') as HTMLSelectElement | null
+    const send = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Send') as HTMLButtonElement | undefined
+
+    expect(target?.value).toBe('keeper:keeper-a')
+    expect(send?.disabled).toBe(false)
+
+    await act(async () => { send?.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    await flushUi()
+
+    expect(dispatchOperatorActionMock).toHaveBeenCalledWith({
+      actor: 'dashboard',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'nick0cave',
+      payload: { message: 'Please verify @nick0cave' },
+    })
+  }, 15000)
+
+  it('does not reapply command focus when the keeper roster refreshes', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = ''
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [{ name: 'keeper-a', status: 'online' }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const broadcastButton = container.querySelector('button[aria-label="Broadcast mode"]') as HTMLButtonElement | null
+    await act(async () => { broadcastButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    quickMessage.value = 'manual broadcast'
+    await flushUi()
+
+    await act(async () => {
+      operatorSnapshot.value = {
+        root: { paused: false, namespace: 'default' },
+        sessions: [],
+        keepers: [
+          { name: 'keeper-a', status: 'online' },
+          { name: 'keeper-b', status: 'online' },
+        ],
+        recent_messages: [],
+        pending_confirms: [],
+        available_actions: [],
+      } as unknown as OperatorSnapshot
+    })
+    await flushUi()
+
+    expect(quickComposerMode.value).toBe('broadcast')
+    expect(quickMessage.value).toBe('manual broadcast')
+    expect(broadcastButton?.getAttribute('aria-pressed')).toBe('true')
+  }, 15000)
+
   it('disables keeper DM send when no keepers are online', async () => {
     const {
       QuickIntervene,
@@ -290,6 +399,42 @@ describe('QuickIntervene', () => {
       .find(button => button.textContent?.trim() === 'Send') as HTMLButtonElement | undefined
 
     expect(target?.disabled).toBe(true)
+    expect(send?.disabled).toBe(true)
+    expect(dispatchOperatorActionMock).not.toHaveBeenCalled()
+  }, 15000)
+
+  it('disables state sends when the block has no supported values', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'state'
+    quickMessage.value = '[STATE]\nPhase: review\nBlocker: none\n[/STATE]'
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [{ name: 'keeper-a', status: 'online' }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const send = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Send') as HTMLButtonElement | undefined
+
+    expect(container.textContent).toContain('State block required')
     expect(send?.disabled).toBe(true)
     expect(dispatchOperatorActionMock).not.toHaveBeenCalled()
   }, 15000)

--- a/dashboard/src/components/ops/quick-intervene.test.ts
+++ b/dashboard/src/components/ops/quick-intervene.test.ts
@@ -1,12 +1,24 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OperatorSnapshot } from '../../types'
 
 void vi
 
+const dispatchOperatorActionMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../operator-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../operator-store')>()
+  return {
+    ...actual,
+    dispatchOperatorAction: dispatchOperatorActionMock,
+  }
+})
+
 async function flushUi(): Promise<void> {
   await Promise.resolve()
+  await new Promise(resolve => setTimeout(resolve, 0))
   await Promise.resolve()
 }
 
@@ -19,13 +31,16 @@ async function loadQuickIntervene() {
   const mod = await import('./quick-intervene')
   const operatorStore = await import('../../operator-store')
   const opsState = await import('./ops-state')
+  const router = await import('../../router')
   return {
     QuickIntervene: mod.QuickIntervene,
     actorName: opsState.actorName,
     operatorActionBusy: operatorStore.operatorActionBusy,
     operatorSnapshot: operatorStore.operatorSnapshot,
+    quickComposerMode: opsState.quickComposerMode,
     quickMessage: opsState.quickMessage,
     quickTarget: opsState.quickTarget,
+    route: router.route,
   }
 }
 
@@ -36,6 +51,12 @@ describe('QuickIntervene', () => {
     clearActorStorage()
     container = document.createElement('div')
     document.body.appendChild(container)
+    dispatchOperatorActionMock.mockReset()
+    dispatchOperatorActionMock.mockResolvedValue({
+      status: 'ok',
+      confirm_required: false,
+      result: 'sent',
+    })
   })
 
   afterEach(() => {
@@ -52,14 +73,18 @@ describe('QuickIntervene', () => {
       actorName,
       operatorActionBusy,
       operatorSnapshot,
+      quickComposerMode,
       quickMessage,
       quickTarget,
+      route,
     } = await loadQuickIntervene()
 
     actorName.value = 'dashboard-eager-manta'
     operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
     quickMessage.value = ''
     quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops' }, postId: null }
     operatorSnapshot.value = {
       root: { paused: false, namespace: 'default' },
       sessions: [{ session_id: 'session-a', status: 'active' }],
@@ -69,11 +94,11 @@ describe('QuickIntervene', () => {
       available_actions: [],
     } as unknown as OperatorSnapshot
 
-    render(html`<${QuickIntervene} />`, container)
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
     await flushUi()
 
     expect(container.textContent).toContain('Quick Intervention')
-    expect((container.querySelector('select[aria-label="Intervention target"]') as HTMLSelectElement | null)?.value).toBe('namespace')
+    expect(container.querySelector('div[aria-label="Composer mode"]')).not.toBeNull()
     expect(container.querySelector('input[name="quick_intervene_actor"]')).toBeNull()
 
     const toggle = Array.from(container.querySelectorAll('button'))
@@ -90,5 +115,130 @@ describe('QuickIntervene', () => {
     await flushUi()
 
     expect(actorName.value).toBe('dashboard-quiet-owl')
+  }, 15000)
+
+  it('preselects state mode from command focus and inserts a state template', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = ''
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [{ name: 'keeper-a', status: 'online' }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const stateButton = container.querySelector('button[aria-label="State mode"]') as HTMLButtonElement | null
+    const editor = container.querySelector('textarea[name="quick_intervene_message"]') as HTMLTextAreaElement | null
+
+    expect(stateButton?.getAttribute('aria-pressed')).toBe('true')
+    expect(editor?.value).toContain('[STATE]')
+    expect(container.textContent).toContain('Goal')
+    expect(container.textContent).toContain('Blocker')
+  }, 15000)
+
+  it('uses mention focus as keeper DM and sends to the first online keeper', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = 'ping keeper'
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [
+        { name: 'keeper-a', status: 'online' },
+        { name: 'keeper-b', status: 'busy' },
+      ],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const dmButton = container.querySelector('button[aria-label="DM mode"]') as HTMLButtonElement | null
+    const target = container.querySelector('select[aria-label="Keeper message target"]') as HTMLSelectElement | null
+    const send = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Send')
+
+    expect(dmButton?.getAttribute('aria-pressed')).toBe('true')
+    expect(target?.value).toBe('keeper:keeper-a')
+
+    await act(async () => { send?.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    await flushUi()
+
+    expect(dispatchOperatorActionMock).toHaveBeenCalledWith({
+      actor: 'dashboard',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'keeper-a',
+      payload: { message: 'ping keeper' },
+    })
+  }, 15000)
+
+  it('disables keeper DM send when no keepers are online', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = 'ping keeper'
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [{ name: 'keeper-a', status: 'offline' }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const target = container.querySelector('select[aria-label="Keeper message target"]') as HTMLSelectElement | null
+    const send = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Send') as HTMLButtonElement | undefined
+
+    expect(target?.disabled).toBe(true)
+    expect(send?.disabled).toBe(true)
+    expect(dispatchOperatorActionMock).not.toHaveBeenCalled()
   }, 15000)
 })

--- a/dashboard/src/components/ops/quick-intervene.test.ts
+++ b/dashboard/src/components/ops/quick-intervene.test.ts
@@ -211,6 +211,61 @@ describe('QuickIntervene', () => {
     })
   }, 15000)
 
+  it('fills the mention focus DM target after keepers load', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = 'late keeper ping'
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    expect(quickComposerMode.value).toBe('dm')
+    expect(quickTarget.value).toBe('')
+
+    await act(async () => {
+      operatorSnapshot.value = {
+        root: { paused: false, namespace: 'default' },
+        sessions: [],
+        keepers: [
+          { name: 'keeper-a', status: 'online' },
+          { name: 'keeper-b', status: 'busy' },
+        ],
+        recent_messages: [],
+        pending_confirms: [],
+        available_actions: [],
+      } as unknown as OperatorSnapshot
+    })
+    await flushUi()
+
+    const target = container.querySelector('select[aria-label="Keeper message target"]') as HTMLSelectElement | null
+    const send = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Send') as HTMLButtonElement | undefined
+
+    expect(target?.value).toBe('keeper:keeper-a')
+    expect(quickTarget.value).toBe('keeper:keeper-a')
+    expect(send?.disabled).toBe(false)
+  }, 15000)
+
   it('filters mention autocomplete from @draft text and applies the selected keeper', async () => {
     const {
       QuickIntervene,
@@ -310,6 +365,70 @@ describe('QuickIntervene', () => {
       target_type: 'keeper',
       target_id: 'nick0cave',
       payload: { message: 'Please verify @nick0cave' },
+    })
+    expect(quickTarget.value).toBe('keeper:nick0cave')
+    expect(quickMessage.value).toBe('')
+  }, 15000)
+
+  it('submits broadcast and DM drafts on plain Enter', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = 'broadcast ping'
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [{ name: 'keeper-a', status: 'online' }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    let editor = container.querySelector('textarea[name="quick_intervene_message"]') as HTMLTextAreaElement | null
+    await act(async () => {
+      editor?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    await flushUi()
+
+    expect(dispatchOperatorActionMock).toHaveBeenLastCalledWith({
+      actor: 'dashboard',
+      action_type: 'broadcast',
+      target_type: 'root',
+      target_id: undefined,
+      payload: { message: 'broadcast ping' },
+    })
+
+    quickComposerMode.value = 'dm'
+    quickTarget.value = 'keeper:keeper-a'
+    quickMessage.value = 'keeper ping'
+    await flushUi()
+
+    editor = container.querySelector('textarea[name="quick_intervene_message"]') as HTMLTextAreaElement | null
+    await act(async () => {
+      editor?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    await flushUi()
+
+    expect(dispatchOperatorActionMock).toHaveBeenLastCalledWith({
+      actor: 'dashboard',
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: 'keeper-a',
+      payload: { message: 'keeper ping' },
     })
   }, 15000)
 

--- a/dashboard/src/components/ops/quick-intervene.test.ts
+++ b/dashboard/src/components/ops/quick-intervene.test.ts
@@ -299,12 +299,18 @@ describe('QuickIntervene', () => {
     await flushUi()
 
     const listbox = container.querySelector('div[role="listbox"]')
+    const combobox = container.querySelector('textarea[name="quick_intervene_message"]') as HTMLTextAreaElement | null
     const nickOption = Array.from(listbox?.querySelectorAll('button[role="option"]') ?? [])
       .find(button => button.textContent?.includes('@nick0cave')) as HTMLButtonElement | undefined
     const runtimeOption = Array.from(listbox?.querySelectorAll('button[role="option"]') ?? [])
       .find(button => button.textContent?.includes('@runtime'))
 
     expect(listbox?.getAttribute('aria-label')).toBe('Mention autocomplete (1 matches)')
+    expect(listbox?.getAttribute('id')).toBe('quick-intervene-mention-listbox')
+    expect(combobox?.getAttribute('role')).toBe('combobox')
+    expect(combobox?.getAttribute('aria-autocomplete')).toBe('list')
+    expect(combobox?.getAttribute('aria-controls')).toBe('quick-intervene-mention-listbox')
+    expect(combobox?.getAttribute('aria-expanded')).toBe('true')
     expect(nickOption).not.toBeUndefined()
     expect(runtimeOption).toBeUndefined()
 
@@ -316,6 +322,52 @@ describe('QuickIntervene', () => {
     expect(editor?.value).toContain('@nick0cave')
     expect(quickMessage.value).toContain('@nick0cave')
     expect(container.querySelector('div[aria-label="Will mention: @nick0cave"]')).not.toBeNull()
+  }, 15000)
+
+  it('supports keyboard selection in mention autocomplete', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'dm'
+    quickMessage.value = 'Please verify @'
+    quickTarget.value = 'keeper:improver'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [
+        { name: 'improver', status: 'online' },
+        { name: 'nick0cave', status: 'busy' },
+        { name: 'runtime', status: 'online' },
+      ],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const editor = container.querySelector('textarea[name="quick_intervene_message"]') as HTMLTextAreaElement
+    expect(editor.getAttribute('aria-activedescendant')).toBe('quick-intervene-mention-listbox-option-0')
+
+    await act(async () => { editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })) })
+    await flushUi()
+    expect(editor.getAttribute('aria-activedescendant')).toBe('quick-intervene-mention-listbox-option-1')
+
+    await act(async () => { editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })) })
+    await flushUi()
+
+    expect(quickTarget.value).toBe('keeper:nick0cave')
+    expect(quickMessage.value).toContain('@nick0cave')
   }, 15000)
 
   it('sends to a typed exact keeper mention without requiring an autocomplete click', async () => {

--- a/dashboard/src/components/ops/quick-intervene.test.ts
+++ b/dashboard/src/components/ops/quick-intervene.test.ts
@@ -205,6 +205,58 @@ describe('QuickIntervene', () => {
     })
   }, 15000)
 
+  it('filters mention autocomplete from @draft text and applies the selected keeper', async () => {
+    const {
+      QuickIntervene,
+      operatorActionBusy,
+      operatorSnapshot,
+      quickComposerMode,
+      quickMessage,
+      quickTarget,
+      route,
+    } = await loadQuickIntervene()
+
+    operatorActionBusy.value = false
+    quickComposerMode.value = 'broadcast'
+    quickMessage.value = 'Please verify @nick'
+    quickTarget.value = 'namespace'
+    route.value = { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' }, postId: null }
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [
+        { name: 'improver', status: 'online' },
+        { name: 'nick0cave', status: 'busy' },
+        { name: 'runtime', status: 'online' },
+      ],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+
+    await act(async () => { render(html`<${QuickIntervene} />`, container) })
+    await flushUi()
+
+    const listbox = container.querySelector('div[role="listbox"]')
+    const nickOption = Array.from(listbox?.querySelectorAll('button[role="option"]') ?? [])
+      .find(button => button.textContent?.includes('@nick0cave')) as HTMLButtonElement | undefined
+    const runtimeOption = Array.from(listbox?.querySelectorAll('button[role="option"]') ?? [])
+      .find(button => button.textContent?.includes('@runtime'))
+
+    expect(listbox?.getAttribute('aria-label')).toBe('Mention autocomplete (1 matches)')
+    expect(nickOption).not.toBeUndefined()
+    expect(runtimeOption).toBeUndefined()
+
+    await act(async () => { nickOption?.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    await flushUi()
+
+    const editor = container.querySelector('textarea[name="quick_intervene_message"]') as HTMLTextAreaElement | null
+    expect(quickTarget.value).toBe('keeper:nick0cave')
+    expect(editor?.value).toContain('@nick0cave')
+    expect(quickMessage.value).toContain('@nick0cave')
+    expect(container.querySelector('div[aria-label="Will mention: @nick0cave"]')).not.toBeNull()
+  }, 15000)
+
   it('disables keeper DM send when no keepers are online', async () => {
     const {
       QuickIntervene,

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -1,37 +1,84 @@
-// QuickIntervene — unified message input. Pick a target, type, send.
-// Target selection determines action_type automatically:
-//   'namespace' → broadcast, 'session:{id}' → team_note, 'keeper:{name}' → keeper_message
+// QuickIntervene: operational composer for broadcast, keeper DM, and state blocks.
 
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
-import { TextInput } from '../common/input'
+import { TextArea, TextInput } from '../common/input'
 import { Select } from '../common/select'
 import {
   operatorActionBusy,
   operatorSnapshot,
 } from '../../operator-store'
-import { actorName, persistActorName, quickTarget, quickMessage } from './ops-state'
+import { route } from '../../router'
+import {
+  actorName,
+  composerModeForFocus,
+  ensureStateBlockDraft,
+  hasStateBlock,
+  persistActorName,
+  quickComposerMode,
+  quickTarget,
+  quickMessage,
+  stateBlockKeys,
+  STATE_BLOCK_TEMPLATE,
+  type QuickComposerMode,
+} from './ops-state'
 import { executeAction, normalizeStatus } from './helpers'
 
-function parseTarget(value: string): {
+interface ComposerTarget {
   action_type: 'broadcast' | 'keeper_message'
   target_type: 'root' | 'keeper'
   target_id?: string
   label: string
-} {
-  if (value.startsWith('keeper:')) {
-    const name = value.slice('keeper:'.length)
-    return { action_type: 'keeper_message', target_type: 'keeper', target_id: name, label: name }
+}
+
+const MODE_OPTIONS: Array<{ value: QuickComposerMode, label: string, description: string }> = [
+  { value: 'broadcast', label: 'Broadcast', description: 'All keepers' },
+  { value: 'dm', label: 'DM', description: 'One keeper' },
+  { value: 'state', label: 'State', description: 'Structured' },
+]
+
+function keeperNameFromTarget(value: string): string | null {
+  if (!value.startsWith('keeper:')) return null
+  const name = value.slice('keeper:'.length).trim()
+  return name || null
+}
+
+function selectComposerMode(mode: QuickComposerMode, onlineKeepers: Array<{ name: string }>): void {
+  quickComposerMode.value = mode
+  if (mode === 'dm') {
+    const selected = keeperNameFromTarget(quickTarget.value)
+    const selectedOnline = selected && onlineKeepers.some(k => k.name === selected)
+    if (!selectedOnline) {
+      const firstKeeper = onlineKeepers[0]?.name
+      quickTarget.value = firstKeeper ? `keeper:${firstKeeper}` : ''
+    }
+    return
   }
-  return { action_type: 'broadcast', target_type: 'root', label: 'All' }
+
+  quickTarget.value = 'namespace'
+  if (mode === 'state') quickMessage.value = ensureStateBlockDraft(quickMessage.value)
+}
+
+function parseComposerTarget(mode: QuickComposerMode): ComposerTarget | null {
+  if (mode === 'dm') {
+    const name = keeperNameFromTarget(quickTarget.value)
+    return name
+      ? { action_type: 'keeper_message', target_type: 'keeper', target_id: name, label: name }
+      : null
+  }
+  return { action_type: 'broadcast', target_type: 'root', label: mode === 'state' ? 'State block' : 'All' }
 }
 
 async function submitQuickMessage() {
   const message = quickMessage.value.trim()
   if (!message) return
-  const target = parseTarget(quickTarget.value)
+  const mode = quickComposerMode.value
+  if (mode === 'state' && !hasStateBlock(message)) return
+  const target = parseComposerTarget(mode)
+  if (!target) return
+
   const result = await executeAction({
     action_type: target.action_type,
     target_type: target.target_type,
@@ -47,15 +94,30 @@ export function QuickIntervene() {
   const snapshot = operatorSnapshot.value
   const keepers = snapshot?.keepers ?? []
   const busy = operatorActionBusy.value
+  const currentRoute = route.value
 
   const onlineKeepers = keepers.filter(k => normalizeStatus(k.status) !== 'offline')
+  const onlineKeeperKey = onlineKeepers.map(k => k.name).join('\u0000')
+  const mode = quickComposerMode.value
+  const stateKeys = mode === 'state' ? stateBlockKeys(quickMessage.value) : []
+  const selectedKeeper = keeperNameFromTarget(quickTarget.value)
+  const selectedKeeperOnline = !!selectedKeeper && onlineKeepers.some(k => k.name === selectedKeeper)
+  const sendDisabled = busy
+    || quickMessage.value.trim() === ''
+    || (mode === 'dm' && !selectedKeeperOnline)
+    || (mode === 'state' && !hasStateBlock(quickMessage.value))
+
+  useEffect(() => {
+    const nextMode = composerModeForFocus(currentRoute.params.focus)
+    if (nextMode) selectComposerMode(nextMode, onlineKeepers)
+  }, [currentRoute, onlineKeeperKey])
 
   return html`
     <section class="${CARD_STANDARD} flex flex-col gap-3" aria-label="Quick intervention">
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
           <h3 class="text-sm font-semibold text-[var(--color-fg-secondary)]">Quick Intervention</h3>
-          <p class="mt-1 text-xs leading-[1.45] text-[var(--color-fg-muted)]">Send a short note to the namespace or a keeper.</p>
+          <p class="mt-1 text-xs leading-[1.45] text-[var(--color-fg-muted)]">Send a broadcast, keeper DM, or structured state block.</p>
         </div>
         <${ActionButton}
           variant="subtle"
@@ -67,32 +129,88 @@ export function QuickIntervene() {
         <//>
       </div>
 
-      <div class="flex gap-2 items-stretch flex-wrap">
-        <${Select}
-          class="shrink-0 px-3 py-2 text-sm min-w-30"
-          value=${quickTarget.value}
-          ariaLabel="Intervention target"
-          options=${[
-            { value: 'namespace', label: 'All' },
-            ...onlineKeepers.map(k => ({ value: `keeper:${k.name}`, label: k.name })),
-          ]}
-          onInput=${(v: string) => { quickTarget.value = v }}
-          disabled=${busy}
-        />
-        <${TextInput}
-          class="min-w-50 flex-1 border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
-          placeholder="Message"
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="inline-flex rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-0.5" role="group" aria-label="Composer mode">
+          ${MODE_OPTIONS.map(option => {
+            const selected = mode === option.value
+            return html`
+              <${ActionButton}
+                variant="ghost"
+                size="sm"
+                pressed=${selected}
+                ariaLabel=${`${option.label} mode`}
+                title=${option.description}
+                onClick=${() => { selectComposerMode(option.value, onlineKeepers) }}
+                disabled=${busy}
+              >
+                ${option.label}
+              <//>
+            `
+          })}
+        </div>
+        <div class="text-2xs text-[var(--color-fg-muted)]" aria-live="polite">
+          ${quickMessage.value.length} chars / ${onlineKeepers.length} keepers online
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        ${mode === 'dm'
+          ? html`
+              <${Select}
+                class="max-w-70"
+                value=${selectedKeeperOnline ? quickTarget.value : ''}
+                placeholder="Keeper"
+                ariaLabel="Keeper message target"
+                options=${onlineKeepers.map(k => ({ value: `keeper:${k.name}`, label: k.name }))}
+                onInput=${(v: string) => { quickTarget.value = v }}
+                disabled=${busy || onlineKeepers.length === 0}
+              />
+            `
+          : html`
+              <div class="inline-flex w-fit items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-2xs text-[var(--color-fg-muted)]">
+                Target: ${mode === 'state' ? 'Namespace state stream' : 'All keepers'}
+              </div>
+            `}
+
+        <${TextArea}
+          class="min-h-26 border-[var(--color-border-default)] bg-[var(--color-bg-surface)] font-mono text-xs leading-[1.55]"
+          rows=${mode === 'state' ? 6 : 4}
+          placeholder=${mode === 'state' ? STATE_BLOCK_TEMPLATE : 'Message'}
           value=${quickMessage.value}
           name="quick_intervene_message"
-          ariaLabel="Quick intervention message"
-          autoComplete="off"
-          onInput=${(e: Event) => { quickMessage.value = (e.target as HTMLInputElement).value }}
-          onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') void submitQuickMessage() }}
+          ariaLabel=${mode === 'state' ? 'Structured state block message' : 'Quick intervention message'}
+          onInput=${(e: Event) => { quickMessage.value = (e.target as HTMLTextAreaElement).value }}
+          onKeyDown=${(e: KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void submitQuickMessage()
+          }}
           disabled=${busy}
         />
-        <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitQuickMessage() }} disabled=${busy || quickMessage.value.trim() === ''}>
-          Send
-        <//>
+
+        ${mode === 'state'
+          ? html`
+              <div class="flex flex-wrap items-center gap-2" aria-live="polite">
+                ${stateKeys.length > 0
+                  ? stateKeys.map(key => html`
+                      <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-2xs font-medium text-[var(--color-fg-secondary)]">${key}</span>
+                    `)
+                  : html`<span class="text-2xs text-[var(--color-status-warn)]">State block required</span>`}
+                <${ActionButton}
+                  variant="subtle"
+                  size="sm"
+                  onClick=${() => { quickMessage.value = ensureStateBlockDraft(quickMessage.value) }}
+                  disabled=${busy}
+                >
+                  Insert state block
+                <//>
+              </div>
+            `
+          : null}
+
+        <div class="flex justify-end">
+          <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitQuickMessage() }} disabled=${sendDisabled}>
+            Send
+          <//>
+        </div>
       </div>
 
       ${showAdvanced

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -1,7 +1,7 @@
 // QuickIntervene: operational composer for broadcast, keeper DM, and state blocks.
 
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
 import { TextArea, TextInput } from '../common/input'
@@ -61,6 +61,17 @@ function mentionQueryFromMessage(message: string): string | null {
   return match?.[1] ?? null
 }
 
+function trailingMentionNameFromMessage(message: string): string | null {
+  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]+)\s*$/)
+  return match?.[1] ?? null
+}
+
+function onlineKeeperNameForMention(onlineKeepers: OnlineKeeper[], mentionName: string | null): string | null {
+  if (!mentionName) return null
+  const normalized = mentionName.toLowerCase()
+  return onlineKeepers.find(keeper => keeper.name.toLowerCase() === normalized)?.name ?? null
+}
+
 function mentionCandidates(onlineKeepers: OnlineKeeper[], query: string | null, selectedKeeper: string | null): MentionCandidate[] {
   const normalizedQuery = query?.toLowerCase() ?? ''
   return onlineKeepers
@@ -103,9 +114,12 @@ function selectComposerMode(mode: QuickComposerMode, onlineKeepers: OnlineKeeper
   if (mode === 'state') quickMessage.value = ensureStateBlockDraft(quickMessage.value)
 }
 
-function parseComposerTarget(mode: QuickComposerMode): ComposerTarget | null {
+function parseComposerTarget(mode: QuickComposerMode, onlineKeepers: OnlineKeeper[]): ComposerTarget | null {
   if (mode === 'dm') {
-    const name = keeperNameFromTarget(quickTarget.value)
+    const typedMention = trailingMentionNameFromMessage(quickMessage.value)
+    const typedMentionTarget = onlineKeeperNameForMention(onlineKeepers, typedMention)
+    if (typedMention && !typedMentionTarget) return null
+    const name = typedMentionTarget ?? keeperNameFromTarget(quickTarget.value)
     return name
       ? { action_type: 'keeper_message', target_type: 'keeper', target_id: name, label: name }
       : null
@@ -113,12 +127,12 @@ function parseComposerTarget(mode: QuickComposerMode): ComposerTarget | null {
   return { action_type: 'broadcast', target_type: 'root', label: mode === 'state' ? 'State block' : 'All' }
 }
 
-async function submitQuickMessage() {
+async function submitQuickMessage(onlineKeepers: OnlineKeeper[]) {
   const message = quickMessage.value.trim()
   if (!message) return
   const mode = quickComposerMode.value
   if (mode === 'state' && !hasStateBlock(message)) return
-  const target = parseComposerTarget(mode)
+  const target = parseComposerTarget(mode, onlineKeepers)
   if (!target) return
 
   const result = await executeAction({
@@ -133,28 +147,36 @@ async function submitQuickMessage() {
 
 export function QuickIntervene() {
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const appliedRouteFocus = useRef<string | null>(null)
   const snapshot = operatorSnapshot.value
   const keepers = snapshot?.keepers ?? []
   const busy = operatorActionBusy.value
   const currentRoute = route.value
 
   const onlineKeepers = keepers.filter(k => normalizeStatus(k.status) !== 'offline')
-  const onlineKeeperKey = onlineKeepers.map(k => k.name).join('\u0000')
   const mode = quickComposerMode.value
   const stateKeys = mode === 'state' ? stateBlockKeys(quickMessage.value) : []
   const selectedKeeper = keeperNameFromTarget(quickTarget.value)
   const selectedKeeperOnline = !!selectedKeeper && onlineKeepers.some(k => k.name === selectedKeeper)
   const mentionQuery = mode === 'dm' ? mentionQueryFromMessage(quickMessage.value) : null
-  const mentionMatches = mode === 'dm' ? mentionCandidates(onlineKeepers, mentionQuery, selectedKeeper) : []
+  const trailingMention = mode === 'dm' ? trailingMentionNameFromMessage(quickMessage.value) : null
+  const trailingMentionTarget = mode === 'dm' ? onlineKeeperNameForMention(onlineKeepers, trailingMention) : null
+  const unresolvedTrailingMention = mode === 'dm' && !!trailingMention && !trailingMentionTarget
+  const effectiveKeeper = trailingMentionTarget ?? selectedKeeper
+  const effectiveKeeperOnline = !!trailingMentionTarget || selectedKeeperOnline
+  const mentionMatches = mode === 'dm' ? mentionCandidates(onlineKeepers, mentionQuery, effectiveKeeper) : []
   const sendDisabled = busy
     || quickMessage.value.trim() === ''
-    || (mode === 'dm' && !selectedKeeperOnline)
+    || (mode === 'dm' && (!effectiveKeeperOnline || unresolvedTrailingMention))
     || (mode === 'state' && !hasStateBlock(quickMessage.value))
 
   useEffect(() => {
-    const nextMode = composerModeForFocus(currentRoute.params.focus)
+    const focus = currentRoute.params.focus ?? null
+    if (focus === appliedRouteFocus.current) return
+    appliedRouteFocus.current = focus
+    const nextMode = composerModeForFocus(focus)
     if (nextMode) selectComposerMode(nextMode, onlineKeepers)
-  }, [currentRoute, onlineKeeperKey])
+  }, [currentRoute.params.focus])
 
   return html`
     <section class="${CARD_STANDARD} flex flex-col gap-3" aria-label="Quick intervention">
@@ -232,17 +254,17 @@ export function QuickIntervene() {
                         : html`<div class="px-2 py-2 text-xs text-[var(--color-fg-muted)]">No online keeper matches @${mentionQuery}</div>`}
                     </div>
                   `
-                : selectedKeeperOnline
+                  : effectiveKeeperOnline
                   ? html`
-                      <div class="flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-2xs text-[var(--color-fg-muted)]" aria-label=${`Will mention: @${selectedKeeper}`}>
+                      <div class="flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-2xs text-[var(--color-fg-muted)]" aria-label=${`Will mention: @${effectiveKeeper}`}>
                         <span>Will mention:</span>
                         <button
                           type="button"
                           class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 font-mono text-[var(--color-accent-fg)]"
-                          onClick=${() => { chooseMentionTarget(selectedKeeper) }}
+                          onClick=${() => { if (effectiveKeeper) chooseMentionTarget(effectiveKeeper) }}
                           disabled=${busy}
                         >
-                          @${selectedKeeper}
+                          @${effectiveKeeper}
                         </button>
                         <span class="ml-auto text-[var(--color-fg-muted)]">type @ to filter targets</span>
                       </div>
@@ -264,7 +286,7 @@ export function QuickIntervene() {
           ariaLabel=${mode === 'state' ? 'Structured state block message' : 'Quick intervention message'}
           onInput=${(e: Event) => { quickMessage.value = (e.target as HTMLTextAreaElement).value }}
           onKeyDown=${(e: KeyboardEvent) => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void submitQuickMessage()
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void submitQuickMessage(onlineKeepers)
           }}
           disabled=${busy}
         />
@@ -290,7 +312,7 @@ export function QuickIntervene() {
           : null}
 
         <div class="flex justify-end">
-          <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitQuickMessage() }} disabled=${sendDisabled}>
+          <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitQuickMessage(onlineKeepers) }} disabled=${sendDisabled}>
             Send
           <//>
         </div>

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -33,6 +33,17 @@ interface ComposerTarget {
   label: string
 }
 
+interface OnlineKeeper {
+  name: string
+  status?: string
+}
+
+interface MentionCandidate {
+  name: string
+  status?: string
+  selected: boolean
+}
+
 const MODE_OPTIONS: Array<{ value: QuickComposerMode, label: string, description: string }> = [
   { value: 'broadcast', label: 'Broadcast', description: 'All keepers' },
   { value: 'dm', label: 'DM', description: 'One keeper' },
@@ -45,7 +56,38 @@ function keeperNameFromTarget(value: string): string | null {
   return name || null
 }
 
-function selectComposerMode(mode: QuickComposerMode, onlineKeepers: Array<{ name: string }>): void {
+function mentionQueryFromMessage(message: string): string | null {
+  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]*)$/)
+  return match?.[1] ?? null
+}
+
+function mentionCandidates(onlineKeepers: OnlineKeeper[], query: string | null, selectedKeeper: string | null): MentionCandidate[] {
+  const normalizedQuery = query?.toLowerCase() ?? ''
+  return onlineKeepers
+    .filter(keeper => normalizedQuery === '' || keeper.name.toLowerCase().includes(normalizedQuery))
+    .map(keeper => ({
+      name: keeper.name,
+      status: keeper.status,
+      selected: keeper.name === selectedKeeper,
+    }))
+    .sort((a, b) => Number(b.selected) - Number(a.selected) || a.name.localeCompare(b.name))
+    .slice(0, 5)
+}
+
+function replaceTrailingMentionDraft(message: string, keeperName: string): string {
+  if (/(?:^|\s)@[A-Za-z0-9_.-]*$/.test(message)) {
+    return message.replace(/(^|\s)@[A-Za-z0-9_.-]*$/, `$1@${keeperName} `)
+  }
+  const spacer = message.trimEnd().length > 0 ? ' ' : ''
+  return `${message.trimEnd()}${spacer}@${keeperName} `
+}
+
+function chooseMentionTarget(keeperName: string): void {
+  quickTarget.value = `keeper:${keeperName}`
+  quickMessage.value = replaceTrailingMentionDraft(quickMessage.value, keeperName)
+}
+
+function selectComposerMode(mode: QuickComposerMode, onlineKeepers: OnlineKeeper[]): void {
   quickComposerMode.value = mode
   if (mode === 'dm') {
     const selected = keeperNameFromTarget(quickTarget.value)
@@ -102,6 +144,8 @@ export function QuickIntervene() {
   const stateKeys = mode === 'state' ? stateBlockKeys(quickMessage.value) : []
   const selectedKeeper = keeperNameFromTarget(quickTarget.value)
   const selectedKeeperOnline = !!selectedKeeper && onlineKeepers.some(k => k.name === selectedKeeper)
+  const mentionQuery = mode === 'dm' ? mentionQueryFromMessage(quickMessage.value) : null
+  const mentionMatches = mode === 'dm' ? mentionCandidates(onlineKeepers, mentionQuery, selectedKeeper) : []
   const sendDisabled = busy
     || quickMessage.value.trim() === ''
     || (mode === 'dm' && !selectedKeeperOnline)
@@ -165,6 +209,45 @@ export function QuickIntervene() {
                 onInput=${(v: string) => { quickTarget.value = v }}
                 disabled=${busy || onlineKeepers.length === 0}
               />
+              ${mentionQuery !== null
+                ? html`
+                    <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" role="listbox" aria-label=${`Mention autocomplete (${mentionMatches.length} matches)`}>
+                      <div class="border-b border-[var(--color-border-default)] px-2 py-1 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+                        Match @${mentionQuery}
+                      </div>
+                      ${mentionMatches.length > 0
+                        ? mentionMatches.map(candidate => html`
+                            <button
+                              type="button"
+                              class="flex w-full items-center gap-2 border-0 border-l-2 border-solid ${candidate.selected ? 'border-l-[var(--color-accent-fg)] bg-[var(--color-bg-elevated)]' : 'border-l-transparent bg-transparent'} px-2 py-1.5 text-left text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--button-ghost-bg-hover)]"
+                              role="option"
+                              aria-selected=${candidate.selected ? 'true' : 'false'}
+                              onClick=${() => { chooseMentionTarget(candidate.name) }}
+                              disabled=${busy}
+                            >
+                              <span class="font-mono text-[var(--color-accent-fg)]">@${candidate.name}</span>
+                              <span class="ml-auto text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${candidate.status ?? 'online'}</span>
+                            </button>
+                          `)
+                        : html`<div class="px-2 py-2 text-xs text-[var(--color-fg-muted)]">No online keeper matches @${mentionQuery}</div>`}
+                    </div>
+                  `
+                : selectedKeeperOnline
+                  ? html`
+                      <div class="flex flex-wrap items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-2xs text-[var(--color-fg-muted)]" aria-label=${`Will mention: @${selectedKeeper}`}>
+                        <span>Will mention:</span>
+                        <button
+                          type="button"
+                          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 font-mono text-[var(--color-accent-fg)]"
+                          onClick=${() => { chooseMentionTarget(selectedKeeper) }}
+                          disabled=${busy}
+                        >
+                          @${selectedKeeper}
+                        </button>
+                        <span class="ml-auto text-[var(--color-fg-muted)]">type @ to filter targets</span>
+                      </div>
+                    `
+                  : null}
             `
           : html`
               <div class="inline-flex w-fit items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-2xs text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -142,7 +142,12 @@ async function submitQuickMessage(onlineKeepers: OnlineKeeper[]) {
     payload: { message },
     successMessage: `Message sent to ${target.label}`,
   })
-  if (result) quickMessage.value = ''
+  if (result) {
+    if (target.target_type === 'keeper' && target.target_id) {
+      quickTarget.value = `keeper:${target.target_id}`
+    }
+    quickMessage.value = ''
+  }
 }
 
 export function QuickIntervene() {
@@ -154,6 +159,7 @@ export function QuickIntervene() {
   const currentRoute = route.value
 
   const onlineKeepers = keepers.filter(k => normalizeStatus(k.status) !== 'offline')
+  const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
   const mode = quickComposerMode.value
   const stateKeys = mode === 'state' ? stateBlockKeys(quickMessage.value) : []
   const selectedKeeper = keeperNameFromTarget(quickTarget.value)
@@ -172,11 +178,20 @@ export function QuickIntervene() {
 
   useEffect(() => {
     const focus = currentRoute.params.focus ?? null
-    if (focus === appliedRouteFocus.current) return
-    appliedRouteFocus.current = focus
     const nextMode = composerModeForFocus(focus)
+    if (!nextMode) {
+      appliedRouteFocus.current = focus
+      return
+    }
+    const focusChanged = focus !== appliedRouteFocus.current
+    const needsLoadedDmTarget = nextMode === 'dm'
+      && mode === 'dm'
+      && onlineKeepers.length > 0
+      && !selectedKeeperOnline
+    if (!focusChanged && !needsLoadedDmTarget) return
+    appliedRouteFocus.current = focus
     if (nextMode) selectComposerMode(nextMode, onlineKeepers)
-  }, [currentRoute.params.focus])
+  }, [currentRoute.params.focus, mode, onlineKeeperNames, selectedKeeperOnline])
 
   return html`
     <section class="${CARD_STANDARD} flex flex-col gap-3" aria-label="Quick intervention">
@@ -286,7 +301,11 @@ export function QuickIntervene() {
           ariaLabel=${mode === 'state' ? 'Structured state block message' : 'Quick intervention message'}
           onInput=${(e: Event) => { quickMessage.value = (e.target as HTMLTextAreaElement).value }}
           onKeyDown=${(e: KeyboardEvent) => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void submitQuickMessage(onlineKeepers)
+            const shouldSubmit = e.key === 'Enter'
+              && ((e.metaKey || e.ctrlKey) || (mode !== 'state' && !e.shiftKey && !e.altKey))
+            if (!shouldSubmit) return
+            e.preventDefault()
+            void submitQuickMessage(onlineKeepers)
           }}
           disabled=${busy}
         />

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -15,7 +15,6 @@ import {
   actorName,
   composerModeForFocus,
   ensureStateBlockDraft,
-  hasStateBlock,
   persistActorName,
   quickComposerMode,
   quickTarget,
@@ -49,6 +48,8 @@ const MODE_OPTIONS: Array<{ value: QuickComposerMode, label: string, description
   { value: 'dm', label: 'DM', description: 'One keeper' },
   { value: 'state', label: 'State', description: 'Structured' },
 ]
+
+const MENTION_LISTBOX_ID = 'quick-intervene-mention-listbox'
 
 function keeperNameFromTarget(value: string): string | null {
   if (!value.startsWith('keeper:')) return null
@@ -131,7 +132,8 @@ async function submitQuickMessage(onlineKeepers: OnlineKeeper[]) {
   const message = quickMessage.value.trim()
   if (!message) return
   const mode = quickComposerMode.value
-  if (mode === 'state' && !hasStateBlock(message)) return
+  const submitStateKeys = mode === 'state' ? stateBlockKeys(message) : []
+  if (mode === 'state' && submitStateKeys.length === 0) return
   const target = parseComposerTarget(mode, onlineKeepers)
   if (!target) return
 
@@ -152,6 +154,8 @@ async function submitQuickMessage(onlineKeepers: OnlineKeeper[]) {
 
 export function QuickIntervene() {
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const [activeMentionIndex, setActiveMentionIndex] = useState(0)
+  const [dismissedMentionQuery, setDismissedMentionQuery] = useState<string | null>(null)
   const appliedRouteFocus = useRef<string | null>(null)
   const snapshot = operatorSnapshot.value
   const keepers = snapshot?.keepers ?? []
@@ -171,10 +175,20 @@ export function QuickIntervene() {
   const effectiveKeeper = trailingMentionTarget ?? selectedKeeper
   const effectiveKeeperOnline = !!trailingMentionTarget || selectedKeeperOnline
   const mentionMatches = mode === 'dm' ? mentionCandidates(onlineKeepers, mentionQuery, effectiveKeeper) : []
+  const mentionListOpen = mentionQuery !== null && dismissedMentionQuery !== mentionQuery
+  const activeMention = mentionListOpen ? mentionMatches[activeMentionIndex] ?? mentionMatches[0] : null
+  const activeMentionOptionId = activeMention
+    ? `${MENTION_LISTBOX_ID}-option-${Math.max(mentionMatches.indexOf(activeMention), 0)}`
+    : undefined
   const sendDisabled = busy
     || quickMessage.value.trim() === ''
     || (mode === 'dm' && (!effectiveKeeperOnline || unresolvedTrailingMention))
-    || (mode === 'state' && !hasStateBlock(quickMessage.value))
+    || (mode === 'state' && stateKeys.length === 0)
+
+  useEffect(() => {
+    setActiveMentionIndex(0)
+    setDismissedMentionQuery(null)
+  }, [mentionQuery, onlineKeeperNames])
 
   useEffect(() => {
     const focus = currentRoute.params.focus ?? null
@@ -246,19 +260,25 @@ export function QuickIntervene() {
                 onInput=${(v: string) => { quickTarget.value = v }}
                 disabled=${busy || onlineKeepers.length === 0}
               />
-              ${mentionQuery !== null
+              ${mentionListOpen
                 ? html`
-                    <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" role="listbox" aria-label=${`Mention autocomplete (${mentionMatches.length} matches)`}>
+                    <div
+                      id=${MENTION_LISTBOX_ID}
+                      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+                      role="listbox"
+                      aria-label=${`Mention autocomplete (${mentionMatches.length} matches)`}
+                    >
                       <div class="border-b border-[var(--color-border-default)] px-2 py-1 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
                         Match @${mentionQuery}
                       </div>
                       ${mentionMatches.length > 0
-                        ? mentionMatches.map(candidate => html`
+                        ? mentionMatches.map((candidate, index) => html`
                             <button
+                              id=${`${MENTION_LISTBOX_ID}-option-${index}`}
                               type="button"
-                              class="flex w-full items-center gap-2 border-0 border-l-2 border-solid ${candidate.selected ? 'border-l-[var(--color-accent-fg)] bg-[var(--color-bg-elevated)]' : 'border-l-transparent bg-transparent'} px-2 py-1.5 text-left text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--button-ghost-bg-hover)]"
+                              class="flex w-full items-center gap-2 border-0 border-l-2 border-solid ${candidate.selected || index === activeMentionIndex ? 'border-l-[var(--color-accent-fg)] bg-[var(--color-bg-elevated)]' : 'border-l-transparent bg-transparent'} px-2 py-1.5 text-left text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--button-ghost-bg-hover)]"
                               role="option"
-                              aria-selected=${candidate.selected ? 'true' : 'false'}
+                              aria-selected=${candidate.selected || index === activeMentionIndex ? 'true' : 'false'}
                               onClick=${() => { chooseMentionTarget(candidate.name) }}
                               disabled=${busy}
                             >
@@ -298,9 +318,39 @@ export function QuickIntervene() {
           placeholder=${mode === 'state' ? STATE_BLOCK_TEMPLATE : 'Message'}
           value=${quickMessage.value}
           name="quick_intervene_message"
+          role=${mode === 'dm' ? 'combobox' : undefined}
+          ariaAutocomplete=${mode === 'dm' ? 'list' : undefined}
+          ariaControls=${mentionListOpen ? MENTION_LISTBOX_ID : undefined}
+          ariaExpanded=${mode === 'dm' ? String(mentionListOpen) : undefined}
+          ariaActiveDescendant=${activeMentionOptionId}
           ariaLabel=${mode === 'state' ? 'Structured state block message' : 'Quick intervention message'}
-          onInput=${(e: Event) => { quickMessage.value = (e.target as HTMLTextAreaElement).value }}
+          onInput=${(e: Event) => {
+            if (dismissedMentionQuery !== null) setDismissedMentionQuery(null)
+            quickMessage.value = (e.target as HTMLTextAreaElement).value
+          }}
           onKeyDown=${(e: KeyboardEvent) => {
+            if (mode === 'dm' && mentionListOpen && mentionMatches.length > 0) {
+              if (e.key === 'ArrowDown') {
+                e.preventDefault()
+                setActiveMentionIndex(index => (index + 1) % mentionMatches.length)
+                return
+              }
+              if (e.key === 'ArrowUp') {
+                e.preventDefault()
+                setActiveMentionIndex(index => (index - 1 + mentionMatches.length) % mentionMatches.length)
+                return
+              }
+              if (e.key === 'Enter' && !(e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)) {
+                e.preventDefault()
+                chooseMentionTarget(mentionMatches[activeMentionIndex]?.name ?? mentionMatches[0]!.name)
+                return
+              }
+            }
+            if (mode === 'dm' && mentionListOpen && e.key === 'Escape') {
+              e.preventDefault()
+              setDismissedMentionQuery(mentionQuery ?? '')
+              return
+            }
             const shouldSubmit = e.key === 'Enter'
               && ((e.metaKey || e.ctrlKey) || (mode !== 'state' && !e.shiftKey && !e.altKey))
             if (!shouldSubmit) return


### PR DESCRIPTION
## Summary
- Add Broadcast / DM / State composer modes to the existing Quick Intervention surface.
- Add mention autocomplete for the DM composer from trailing @draft text, sync the selected keeper target, and expose a will-mention pill for the selected keeper.
- Wire command focus aliases to preselect composer modes, including repeated route-object updates.
- Add structured `[STATE]` template helpers, parsed key chips, and disabled-state handling for keeper DM when no online target exists.
- Mark the C3 `composer-broadcast`, `composer-mention`, and `composer-state` cockpit entrypoints covered now that they route to concrete focused composer modes.

## Verification
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/ops/ops-state.test.ts src/components/ops/quick-intervene.test.ts src/cockpit-entrypoints.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint` (passes with existing unrelated warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes with existing dynamic-import / large-chunk warnings)
- Browser via `agent-browser` at `http://localhost:5174/dashboard/#command?section=operations&view=ops&focus=broadcast`: Broadcast mode selected.
- Browser via `agent-browser` at `http://localhost:5174/dashboard/#command?section=operations&view=ops&focus=mention`: DM mode selected, typing `Please verify @nick` shows one autocomplete match for `@nick0cave`, clicking it selects `keeper:nick0cave` and rewrites the draft to `@nick0cave`.
- Browser via `agent-browser` at `http://localhost:5174/dashboard/#command?section=operations&view=ops&focus=state`: State mode selected, state template and parsed key chips visible.
- Browser note: `agent-browser errors` reports `Cannot use import statement outside a module` in this local Vite session, while `agent-browser console` only shows Vite connect logs and the verified routes render.

## Screenshots
- `/tmp/masc-composer-v2-mention-autocomplete-0506.png`
- `/tmp/masc-composer-v2-state-clean-0506.png`
- `/tmp/masc-composer-v2-mention-mobile-0506.png`
