### PR TITLE
fix(oas): preserve close cancellation

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -564,8 +564,11 @@ let run
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     let bt = Printexc.get_backtrace () in
-    (try Agent_sdk.Agent.close agent with close_exn ->
-      Log.Misc.warn "agent close failed during cleanup: %s" (Printexc.to_string close_exn));
+    (try Agent_sdk.Agent.close agent with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | close_exn ->
+       Log.Misc.warn "agent close failed during cleanup: %s"
+         (Printexc.to_string close_exn));
     let detail =
       Printf.sprintf "execution exception: %s" (Printexc.to_string exn)
     in

--- a/test/dune
+++ b/test/dune
@@ -1181,6 +1181,7 @@
 (include stanzas/test_oas_bridge_timeout_ssot_10094.inc)
 (include stanzas/test_oas_timeout_budget_strike.inc)
 (include stanzas/test_oas_worker.inc)
+(include stanzas/test_oas_worker_exec_close_cancel_source.inc)
 (include stanzas/test_oas_worker_exec_checkpoint.inc)
 (include stanzas/test_openapi_api_e2e.inc)
 (include stanzas/test_operator_control.inc)

--- a/test/stanzas/test_oas_worker_exec_close_cancel_source.inc
+++ b/test/stanzas/test_oas_worker_exec_close_cancel_source.inc
@@ -1,0 +1,7 @@
+; #11929/#10395 OAS worker cleanup must re-raise cancellation.
+; Pure source-text inspection; no MASC_BASE_PATH, no project libs.
+
+(test
+ (name test_oas_worker_exec_close_cancel_source)
+ (modules test_oas_worker_exec_close_cancel_source)
+ (deps ../lib/oas_worker_exec.ml))

--- a/test/test_oas_worker_exec_close_cancel_source.ml
+++ b/test/test_oas_worker_exec_close_cancel_source.ml
@@ -1,0 +1,74 @@
+(* Regression guard for #11929/#10395: OAS worker cleanup must not
+   swallow Eio cancellation if Agent.close raises while handling another
+   execution exception. *)
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let contains haystack needle =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec scan i =
+    if i + n > h then false
+    else if String.sub haystack i n = needle then true
+    else scan (i + 1)
+  in
+  scan 0
+
+let assert_contains ~label haystack needle =
+  if not (contains haystack needle) then
+    failwith
+      (Printf.sprintf "[%s] expected source to contain %S" label needle)
+
+let assert_order ~label haystack first second =
+  let position needle =
+    let n = String.length needle in
+    let h = String.length haystack in
+    let rec scan i =
+      if i + n > h then None
+      else if String.sub haystack i n = needle then Some i
+      else scan (i + 1)
+    in
+    scan 0
+  in
+  match position first, position second with
+  | Some a, Some b when a < b -> ()
+  | _ ->
+      failwith
+        (Printf.sprintf
+           "[%s] expected %S to appear before %S in oas_worker_exec.ml"
+           label first second)
+
+let () =
+  let parent p = Filename.dirname p in
+  let exe = Sys.executable_name in
+  let project_root = parent (parent (parent (parent exe))) in
+  let candidates =
+    [
+      Filename.concat project_root "lib/oas_worker_exec.ml";
+      "lib/oas_worker_exec.ml";
+      "../lib/oas_worker_exec.ml";
+    ]
+  in
+  let src =
+    match List.find_opt Sys.file_exists candidates with
+    | Some path -> read_file path
+    | None ->
+        failwith
+          (Printf.sprintf "no oas_worker_exec.ml source path resolved (cwd=%s, exe=%s)"
+             (Sys.getcwd ()) exe)
+  in
+  let cancel_guard = "Eio.Cancel.Cancelled _ as e -> raise e" in
+  let close_warning = "agent close failed during cleanup" in
+  assert_contains ~label:"close cleanup cancel guard block" src
+    "try Agent_sdk.Agent.close agent with\n\
+     \     | Eio.Cancel.Cancelled _ as e -> raise e\n\
+     \     | close_exn ->";
+  assert_contains ~label:"cleanup cancel guard" src cancel_guard;
+  assert_contains ~label:"cleanup warning anchor" src close_warning;
+  assert_order ~label:"cancel guard before cleanup warning" src cancel_guard
+    close_warning;
+  print_endline "test_oas_worker_exec_close_cancel_source: OK"


### PR DESCRIPTION
## What changed

- Re-raise `Eio.Cancel.Cancelled` if `Agent_sdk.Agent.close` raises cancellation while `Oas_worker_exec.run` is cleaning up after another execution exception.
- Added a source regression test that anchors the cleanup cancel guard in `lib/oas_worker_exec.ml`.

## Why

#11929/#10395 track OAS/keeper cancellation loss from broad cleanup catches. This hot path already re-raised cancellation around the main agent run, but the secondary close-failure handler still caught every exception as a warning. If cancellation arrived during `Agent.close`, the worker could convert a structured-cancel signal into ordinary cleanup noise.

## Impact

OAS worker cleanup now preserves Eio structured cancellation semantics instead of swallowing a close-time cancellation. Non-cancellation close failures still log the existing warning and the original execution exception path remains unchanged.

## Validation

- `git diff --check`
- `DUNE_JOBS=1 scripts/dune-local.sh build test/test_oas_worker_exec_close_cancel_source.exe`
- `./_build/default/test/test_oas_worker_exec_close_cancel_source.exe`
- `DUNE_JOBS=1 scripts/dune-local.sh build test/test_oas_worker.exe`

Direct `./_build/default/test/test_oas_worker.exe` execution was also attempted. Without explicit isolation it failed 40/150 in the current local environment. With `MASC_TEST_ALLOW_HOME_BASE_PATH=1`, `MASC_BASE_PATH=/tmp/masc-oas-worker-ZFewvQ`, and `MASC_CONFIG_DIR=/tmp/masc-oas-worker-ZFewvQ/.masc/config`, it reduced to 2/150 with the first remaining failure at `last provider succeeds without timeout`. I filed #13441 for that unrelated direct-run harness/runtime-state sensitivity.