### PR TITLE
fix(dashboard): extract surface breadcrumb primitive

### DIFF
--- a/dashboard/src/components/common/breadcrumb.a11y.test.ts
+++ b/dashboard/src/components/common/breadcrumb.a11y.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Breadcrumb } from './breadcrumb'
+
+describe('Breadcrumb a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('link trail passes axe', async () => {
+    render(
+      html`<${Breadcrumb}
+        items=${[
+          { label: 'Command', href: '#command' },
+          { label: 'Operations' },
+        ]}
+      />`,
+      container,
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('button trail passes axe', async () => {
+    render(
+      html`<${Breadcrumb}
+        items=${[
+          { label: 'Connectors', onClick: () => {} },
+          { label: 'Discord' },
+        ]}
+      />`,
+      container,
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('marks the current item for screen readers', () => {
+    render(
+      html`<${Breadcrumb}
+        items=${[
+          { label: 'Cockpit', href: '#cockpit' },
+          { label: 'Fleet' },
+        ]}
+      />`,
+      container,
+    )
+
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toBe('Fleet')
+  })
+})

--- a/dashboard/src/components/common/breadcrumb.test.ts
+++ b/dashboard/src/components/common/breadcrumb.test.ts
@@ -1,0 +1,102 @@
+// @ts-nocheck
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { Breadcrumb } from './breadcrumb'
+
+describe('Breadcrumb', () => {
+  it('renders a breadcrumb nav and ordered path', () => {
+    const container = document.createElement('div')
+    render(h(Breadcrumb, {
+      items: [
+        { label: 'Command', href: '#command' },
+        { label: 'Operations' },
+      ],
+    }), container)
+
+    const nav = container.querySelector('nav')
+    expect(nav?.getAttribute('aria-label')).toBe('Breadcrumb')
+    expect(container.querySelectorAll('ol > li').length).toBe(2)
+    expect(container.textContent).toContain('Command')
+    expect(container.textContent).toContain('Operations')
+  })
+
+  it('marks the terminal crumb as current', () => {
+    const container = document.createElement('div')
+    render(h(Breadcrumb, {
+      items: [
+        { label: 'Connectors', href: '#connectors' },
+        { label: 'Discord' },
+      ],
+    }), container)
+
+    const current = container.querySelector('[aria-current="page"]')
+    expect(current).not.toBeNull()
+    expect(current?.textContent).toBe('Discord')
+  })
+
+  it('uses an explicit current crumb when provided', () => {
+    const container = document.createElement('div')
+    render(h(Breadcrumb, {
+      items: [
+        { label: 'Workspace' },
+        { label: 'Board', current: true },
+        { label: 'Task' },
+      ],
+    }), container)
+
+    const current = container.querySelectorAll('[aria-current="page"]')
+    expect(current.length).toBe(1)
+    expect(current[0]?.textContent).toBe('Board')
+  })
+
+  it('keeps separators decorative', () => {
+    const container = document.createElement('div')
+    render(h(Breadcrumb, {
+      items: [
+        { label: 'A' },
+        { label: 'B' },
+        { label: 'C' },
+      ],
+    }), container)
+
+    const separators = container.querySelectorAll('[aria-hidden="true"]')
+    expect(separators.length).toBe(2)
+    expect(separators[0]?.textContent).toBe('›')
+  })
+
+  it('calls item onClick for interactive crumbs', () => {
+    const onClick = vi.fn()
+    const container = document.createElement('div')
+    render(h(Breadcrumb, {
+      items: [
+        { label: 'Command', href: '#command', onClick },
+        { label: 'Operations' },
+      ],
+    }), container)
+
+    ;(container.querySelector('a') as HTMLAnchorElement).click()
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies test id, custom aria label, and surface marker', () => {
+    const container = document.createElement('div')
+    render(h(Breadcrumb, {
+      items: [{ label: 'Operations' }],
+      ariaLabel: 'Page path',
+      testId: 'surface-breadcrumb',
+      dataSurfaceBreadcrumb: true,
+    }), container)
+
+    const nav = container.querySelector('[data-testid="surface-breadcrumb"]')
+    expect(nav).not.toBeNull()
+    expect(nav?.getAttribute('aria-label')).toBe('Page path')
+    expect(nav?.getAttribute('data-surface-breadcrumb')).toBe('true')
+  })
+
+  it('renders nothing when the trail is empty', () => {
+    const container = document.createElement('div')
+    render(h(Breadcrumb, { items: [] }), container)
+    expect(container.querySelector('nav')).toBeNull()
+  })
+})

--- a/dashboard/src/components/common/breadcrumb.ts
+++ b/dashboard/src/components/common/breadcrumb.ts
@@ -1,0 +1,121 @@
+// Breadcrumb — shared path navigation primitive.
+//
+// Matches the design-system G5 contract: nav[aria-label] > ol > li,
+// decorative separators, and the terminal crumb marked aria-current="page".
+
+import { html } from 'htm/preact'
+
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+  current?: boolean
+  onClick?: (event: MouseEvent) => void
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+  ariaLabel?: string
+  class?: string
+  itemClass?: string
+  currentClass?: string
+  separator?: string
+  testId?: string
+  dataSurfaceBreadcrumb?: boolean
+}
+
+const NAV_CLASS = [
+  'flex items-center gap-1 font-mono text-3xs uppercase',
+  'tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]',
+].join(' ')
+
+const LIST_CLASS = 'flex min-w-0 items-center gap-1'
+const ITEM_CLASS = 'inline-flex min-w-0 items-center gap-1'
+const CRUMB_CLASS = [
+  'min-w-0 rounded-[var(--r-1)] px-1 py-0.5',
+  'text-[var(--color-fg-disabled)]',
+].join(' ')
+const INTERACTIVE_CLASS = [
+  CRUMB_CLASS,
+  'cursor-pointer hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-primary)]',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)]',
+].join(' ')
+const CURRENT_CLASS = `${CRUMB_CLASS} text-[var(--color-fg-primary)]`
+const SEPARATOR_CLASS = 'text-[var(--color-fg-disabled)]'
+
+function itemKey(item: BreadcrumbItem, index: number): string {
+  return `${index}:${item.label}`
+}
+
+function renderCrumb(
+  item: BreadcrumbItem,
+  itemClass?: string,
+  currentClass?: string,
+) {
+  const current = item.current === true
+  if (current) {
+    return html`
+      <span
+        class=${currentClass ? `${CURRENT_CLASS} ${currentClass}` : CURRENT_CLASS}
+        aria-current="page"
+      >${item.label}</span>
+    `
+  }
+  if (item.href) {
+    return html`
+      <a
+        href=${item.href}
+        class=${itemClass ? `${INTERACTIVE_CLASS} ${itemClass}` : INTERACTIVE_CLASS}
+        onClick=${item.onClick}
+      >${item.label}</a>
+    `
+  }
+  if (item.onClick) {
+    return html`
+      <button
+        type="button"
+        class=${itemClass ? `${INTERACTIVE_CLASS} bg-transparent border-0 ${itemClass}` : `${INTERACTIVE_CLASS} bg-transparent border-0`}
+        onClick=${item.onClick}
+      >${item.label}</button>
+    `
+  }
+  return html`<span class=${itemClass ? `${CRUMB_CLASS} ${itemClass}` : CRUMB_CLASS}>${item.label}</span>`
+}
+
+export function Breadcrumb({
+  items,
+  ariaLabel = 'Breadcrumb',
+  class: cx,
+  itemClass,
+  currentClass,
+  separator = '›',
+  testId,
+  dataSurfaceBreadcrumb = false,
+}: BreadcrumbProps) {
+  if (items.length === 0) return null
+
+  const hasExplicitCurrent = items.some((item) => item.current === true)
+
+  return html`
+    <nav
+      aria-label=${ariaLabel}
+      data-testid=${testId}
+      data-surface-breadcrumb=${dataSurfaceBreadcrumb ? 'true' : undefined}
+      class=${cx ? `${NAV_CLASS} ${cx}` : NAV_CLASS}
+    >
+      <ol class=${LIST_CLASS}>
+        ${items.map((item, index) => {
+          const isLast = index === items.length - 1
+          const current = hasExplicitCurrent ? item.current === true : isLast
+          return html`
+            <li key=${itemKey(item, index)} class=${ITEM_CLASS}>
+              ${renderCrumb({ ...item, current }, itemClass, currentClass)}
+              ${!isLast
+                ? html`<span aria-hidden="true" class=${SEPARATOR_CLASS}>${separator}</span>`
+                : null}
+            </li>
+          `
+        })}
+      </ol>
+    </nav>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -2,8 +2,8 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect } from 'preact/hooks'
-import type { RouteState } from '../types'
-import { route } from '../router'
+import type { RouteState, TabId } from '../types'
+import { hashForRoute, navigate, route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import { dashboardWsConnected } from '../dashboard-ws-state'
@@ -19,7 +19,6 @@ import {
   currentSectionForRoute,
   visibleSectionItemsForTab,
 } from '../config/navigation'
-import { RouteLink } from './common/route-link'
 import { ObservatoryFilterBar } from './common/observatory-filter-bar'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
 import { ScrollToTopButton } from './common/scroll-to-top'
@@ -30,6 +29,8 @@ import { ErrorPanel } from './common/error-panel'
 import { Bell } from 'lucide-preact'
 import { ringFocusClasses } from './common/ring'
 import { SurfaceIcon } from './surface-icon'
+import { Breadcrumb, type BreadcrumbItem } from './common/breadcrumb'
+import { RouteLink } from './common/route-link'
 
 const buildIdentityOpen = signal(false)
 
@@ -596,12 +597,12 @@ function currentSectionShareUrl(): string {
     the page title for exactly this reason. */
 interface BreadcrumbCrumb {
   label: string
-  navigableTab: string | null
+  navigableTab: TabId | null
 }
 function deriveBreadcrumbTrail(
   tabLabel: string | null,
   sectionLabel: string | null,
-  tabId: string | null,
+  tabId: TabId | null,
 ): BreadcrumbCrumb[] {
   if (tabLabel === null && sectionLabel === null) return []
   if (sectionLabel === null) {
@@ -617,6 +618,35 @@ function deriveBreadcrumbTrail(
     { label: tabLabel, navigableTab: tabId },
     { label: sectionLabel, navigableTab: null },
   ]
+}
+
+function navigateCrumb(event: MouseEvent, tab: TabId): void {
+  if (
+    event.defaultPrevented
+    || event.button !== 0
+    || event.metaKey
+    || event.ctrlKey
+    || event.shiftKey
+    || event.altKey
+  ) {
+    return
+  }
+  event.preventDefault()
+  navigate(tab)
+}
+
+function breadcrumbItemsForTrail(trail: BreadcrumbCrumb[]): BreadcrumbItem[] {
+  return trail.map((crumb, index) => {
+    const current = index === trail.length - 1
+    if (crumb.navigableTab !== null && !current) {
+      return {
+        label: crumb.label,
+        href: hashForRoute(crumb.navigableTab),
+        onClick: (event: MouseEvent) => navigateCrumb(event, crumb.navigableTab!),
+      }
+    }
+    return { label: crumb.label, current }
+  })
 }
 
 
@@ -664,28 +694,12 @@ function SurfaceLead() {
   return html`
     <div class="mb-3 flex flex-col gap-1.5">
       ${trail.length > 0
-        ? html`<nav
-            class="flex items-center gap-1 font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]"
-            aria-label="Page path"
-            data-surface-breadcrumb
-          >
-            ${trail.map((crumb, i) => {
-              const isLast = i === trail.length - 1
-              const sep = i > 0
-                ? html`<span aria-hidden="true" class="text-[var(--color-fg-disabled)]">›</span>`
-                : null
-              const crumbEl = crumb.navigableTab !== null && !isLast
-                ? html`<${RouteLink}
-                    tab=${crumb.navigableTab}
-                    class="cursor-pointer rounded-[var(--r-1)] px-1 py-0.5 hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-primary)]"
-                  >${crumb.label}<//>`
-                : html`<span
-                    class="px-1 py-0.5 ${isLast ? 'text-[var(--color-fg-primary)]' : ''}"
-                    aria-current=${isLast ? 'page' : undefined}
-                  >${crumb.label}</span>`
-              return html`${sep}${crumbEl}`
-            })}
-          </nav>`
+        ? html`<${Breadcrumb}
+            items=${breadcrumbItemsForTrail(trail)}
+            ariaLabel="Breadcrumb"
+            testId="surface-breadcrumb"
+            dataSurfaceBreadcrumb=${true}
+          />`
         : null}
       <div class="flex items-center gap-2">
         <h2 class="text-lg font-semibold tracking-normal text-[var(--color-fg-secondary)] leading-tight">


### PR DESCRIPTION

## Summary

- Add a shared `Breadcrumb` primitive for dashboard page paths with `nav > ol > li`, decorative separators, and a single `aria-current="page"` crumb.
- Replace the inline `SurfaceLead` breadcrumb markup with the shared primitive while preserving the `data-surface-breadcrumb` marker and hash navigation behavior.
- Add focused render and jest-axe coverage for link, button, explicit-current, empty, and marker cases.

## Verification

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/common/breadcrumb.test.ts src/components/common/breadcrumb.a11y.test.ts --no-file-parallelism --maxWorkers=1` (10 tests)
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint` (passes with 3 unrelated existing warnings: copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- `pnpm --dir dashboard run build` (passes with existing Vite chunk/import warnings)
- `gh pr checks 13443 --repo jeong-sik/masc-mcp` (CI Gate, PR Live Gate, sync, draft guard, and fundamental checks pass at `9ee0e5d560bb08577f08207b3f15ed07ee38b47d`)
- Browser verification via `agent-browser` at `http://localhost:5174/dashboard/#command?section=operations&view=ops`
  - desktop viewport 1440x900 renders breadcrumb `COMMAND > ACTIONS`, preserves `data-surface-breadcrumb="true"`, and has one `aria-current="page"` crumb within the breadcrumb
  - mobile viewport 390x844 preserves the same breadcrumb/current-crumb state
  - desktop screenshot: `/tmp/masc-breadcrumb-desktop-0506.png`
  - mobile screenshot: `/tmp/masc-breadcrumb-mobile-0506.png`

Note: local `agent-browser errors` reports `Cannot use import statement outside a module` in this Vite dashboard session; the command route renders, and `agent-browser console` only shows Vite connect logs.
