### PR TITLE
fix(keeper): externalize continuity prompt contract

### DIFF
--- a/config/prompts/behavior/continuity_contract.md
+++ b/config/prompts/behavior/continuity_contract.md
@@ -1,0 +1,7 @@
+---
+description: keeper continuity and direct-reply behavior contract injected into every keeper system prompt
+category: keeper.behavior
+loader: Keeper_prompt_external
+---
+Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.
+When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE].

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -108,6 +108,10 @@ let render_world_prompt ~allowed_orgs ~denied_repos : string =
         msg;
       Prompt_registry.get_prompt Keeper_prompt_names.world
 
+let behavior_prompt_block name ~fallback =
+  Option.value (Keeper_prompt_external.get name) ~default:fallback
+  |> String.trim
+
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~will ~needs ~desires
     ~instructions ?(persona_extended = "") ?(keeper_name = "")
@@ -127,12 +131,16 @@ let build_keeper_system_prompt
      in-source string.  Subsequent C-5b PRs migrate the remaining
      blocks in this function. *)
   let profile_policy =
-    Option.value
-      (Keeper_prompt_external.get "profile_policy")
-      ~default:
+    behavior_prompt_block "profile_policy"
+      ~fallback:
         "Maintain high standard of reasoning, factual grounding, and clear communication."
   in
-  let profile_policy = String.trim profile_policy in
+  let continuity_contract =
+    behavior_prompt_block "continuity_contract"
+      ~fallback:
+        "Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.\n\
+         When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE]."
+  in
   (* Layer 2 PR-B (commit 7): three normalize_self_model_text calls
      consolidated through [Keeper_personality_io.to_prompt_form]. The
      fallback strings below are the same; only the trim+truncate path
@@ -202,9 +210,9 @@ let build_keeper_system_prompt
       profile_policy;
       "\n\
        \n\
-       <continuity>\n\
-       Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.\n\
-       When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE].\n";
+       <continuity>\n";
+      continuity_contract;
+      "\n";
       keeper_constitution ();
       "\n\
        </continuity>\n\

--- a/lib/keeper/keeper_prompt_external.mli
+++ b/lib/keeper/keeper_prompt_external.mli
@@ -4,12 +4,12 @@
     Each named block is read from
     [<Config_dir_resolver.prompts_dir ()>/behavior/<name>.md] on first
     access and cached for the remainder of the process lifetime.  The
-    cache key is the block name; file content (frontmatter and all) is
-    returned verbatim to keep the loader free of markdown semantics.
+    cache key is the block name. A leading YAML frontmatter block is
+    stripped so callers receive only prompt body text.
 
-    Missing files do not crash.  [get name] returns [None] and emits a
-    [WARN] (once per name) so callers can fall back to an in-source
-    string while operators iterate on the external file.
+    Missing files do not crash.  [get name] returns [None] and logs
+    once per name so callers can fall back to an in-source string while
+    operators iterate on the external file.
 
     This module is a thin sibling of [Prompt_registry]: that registry
     handles versioned, override-able, frontmatter-aware system prompts.

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -1,11 +1,22 @@
 (** Tier C C-5a: smoke test for the externalized behavior prompt
     loader.  Verifies that the demonstration migration
     ([profile_policy]) loads from
-    [config/prompts/behavior/profile_policy.md] (relative to the
-    repo root, which Config_dir_resolver locates via [_build/]
-    proximity) and yields a non-empty body. *)
+    [config/prompts/behavior/*.md] (relative to the repo root, which
+    Config_dir_resolver locates via [_build/] proximity) and yields
+    non-empty bodies. *)
 
 module Lib = Masc_mcp
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop i =
+      i + needle_len <= haystack_len
+      && (String.sub haystack i needle_len = needle || loop (i + 1))
+    in
+    loop 0
 
 let with_repo_root_cwd f =
   let original_cwd = Sys.getcwd () in
@@ -34,19 +45,23 @@ let with_repo_root_cwd f =
       Unix.putenv "MASC_CONFIG_DIR" config_dir;
       Sys.chdir root;
       Lib.Config_dir_resolver.reset ();
+      Prompt_registry.clear ();
+      Prompt_registry.set_markdown_dir (Filename.concat config_dir "prompts");
+      Lib.Prompt_defaults.init ();
       Fun.protect
         ~finally:(fun () ->
           Sys.chdir original_cwd;
           (match prev_config_dir with
            | Some v -> Unix.putenv "MASC_CONFIG_DIR" v
            | None -> Unix.putenv "MASC_CONFIG_DIR" "");
-          Lib.Config_dir_resolver.reset ())
+          Lib.Config_dir_resolver.reset ();
+          Prompt_registry.clear ())
         f
 
-let test_loads_profile_policy () =
+let test_loads_block name expected_substring =
   with_repo_root_cwd (fun () ->
       Lib.Keeper_prompt_external.reset_cache ();
-      match Lib.Keeper_prompt_external.get "profile_policy" with
+      match Lib.Keeper_prompt_external.get name with
       | Some content ->
           Alcotest.(check bool)
             "non-empty body" true
@@ -54,11 +69,42 @@ let test_loads_profile_policy () =
           Alcotest.(check bool)
             "frontmatter stripped" false
             (String.length content >= 3
-             && String.sub content 0 3 = "---")
+             && String.sub content 0 3 = "---");
+          Alcotest.(check bool)
+            "expected body text" true
+            (contains_substring content expected_substring)
       | None ->
           Alcotest.fail
-            "expected profile_policy.md to load from \
-             config/prompts/behavior/")
+            ("expected " ^ name
+             ^ ".md to load from config/prompts/behavior/"))
+
+let test_loads_profile_policy () =
+  test_loads_block "profile_policy" "reasoning"
+
+let test_loads_continuity_contract () =
+  test_loads_block "continuity_contract" "Continuity"
+
+let test_system_prompt_includes_continuity_contract () =
+  with_repo_root_cwd (fun () ->
+      Lib.Keeper_prompt_external.reset_cache ();
+      let prompt =
+        Lib.Keeper_prompt.build_keeper_system_prompt
+          ~goal:"verify prompt behavior externalization"
+          ~short_goal:"keep continuity contract loaded"
+          ~mid_goal:"reduce source literal behavior blocks"
+          ~long_goal:"keep prompt config operator-tunable"
+          ~will:"maintain coherent identity"
+          ~needs:"runtime truth"
+          ~desires:"observable progress"
+          ~instructions:""
+          ()
+      in
+      Alcotest.(check bool)
+        "continuity contract present" true
+        (contains_substring prompt "When <direct_reply_mode> is present");
+      Alcotest.(check bool)
+        "constitution still present" true
+        (contains_substring prompt "PR merge rules"))
 
 let test_missing_returns_none () =
   with_repo_root_cwd (fun () ->
@@ -87,6 +133,10 @@ let () =
         [
           Alcotest.test_case "loads profile_policy" `Quick
             test_loads_profile_policy;
+          Alcotest.test_case "loads continuity_contract" `Quick
+            test_loads_continuity_contract;
+          Alcotest.test_case "system prompt includes continuity_contract"
+            `Quick test_system_prompt_includes_continuity_contract;
           Alcotest.test_case "missing returns None" `Quick
             test_missing_returns_none;
           Alcotest.test_case "second lookup uses cache" `Quick


### PR DESCRIPTION
## Summary
- add config/prompts/behavior/continuity_contract.md for the keeper continuity/direct-reply behavior contract
- load the continuity contract through Keeper_prompt_external with the existing in-source fallback path
- extend the external prompt test to cover the new behavior block and final system-prompt composition

Fixes #13440

## Validation
- git diff --check
- git diff --cached --check
- ocamlc -stop-after parsing lib/keeper/keeper_prompt.ml lib/keeper/keeper_prompt_external.mli test/test_keeper_prompt_external.ml
- scripts/dune-local.sh build test/test_keeper_prompt_external.exe
- ./_build/default/test/test_keeper_prompt_external.exe