### PR TITLE
fix(keeper): add research evidence board sources

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -62,6 +62,13 @@ Decide what to do based on the current world state below.
 - Act before reporting: if available, call `keeper_task_claim`, `keeper_board_comment`, or `keeper_board_post` instead of just describing what you would do.
 - A turn with zero tool calls is acceptable only when `SPEECH_ACT: stay_silent`.
 
+### Research evidence
+- Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
+- Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
+- Use web evidence for external or current claims: call `masc_web_search` when it is available. If a separate page-read or fetch tool is actually present in your current tool schema, read the selected source before citing it.
+- If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
+- When posting research-backed findings to the board, include a `sources` array on `keeper_board_post`/`masc_board_post` with `{url, quote}` entries. The board will persist those sources in metadata and append a Sources footer.
+
 ### Continuity across turns
 You run in a heartbeat loop. Each turn is one Agent.run() call. Your context resets every turn.
 Your checkpoint, decision records, and board posts survive across turns and restarts.

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -294,6 +294,74 @@ let normalize_board_post_meta args =
   in
   if Stdlib.List.length base_fields = 0 then None else Some (`Assoc base_fields)
 
+let normalize_source_string s =
+  s
+  |> String.trim
+  |> String.split_on_char '\n'
+  |> List.map String.trim
+  |> List.filter (fun part -> not (String.equal part ""))
+  |> String.concat " "
+
+let source_entries_arg args =
+  let source_entry = function
+    | `Assoc fields -> (
+        match List.assoc_opt "url" fields with
+        | Some (`String raw_url) ->
+            let url = String.trim raw_url in
+            if String.equal url "" then None
+            else
+              let quote =
+                match List.assoc_opt "quote" fields with
+                | Some (`String value) ->
+                    let normalized = normalize_source_string value in
+                    if String.equal normalized "" then None else Some normalized
+                | _ -> None
+              in
+              Some
+                (`Assoc
+                   (("url", `String url)
+                    :: (match quote with
+                        | Some value -> [ ("quote", `String value) ]
+                        | None -> [])))
+        | _ -> None)
+    | _ -> None
+  in
+  match Yojson.Safe.Util.member "sources" args with
+  | `List values -> (
+      match List.filter_map source_entry values with
+      | [] -> None
+      | entries -> Some entries)
+  | _ -> None
+
+let merge_sources_into_meta meta_json sources =
+  let fields =
+    match meta_json with
+    | Some (`Assoc fields) -> fields
+    | _ -> []
+  in
+  let fields = assoc_replace "sources" (`List sources) fields in
+  let fields = assoc_replace "has_external_sources" (`Bool true) fields in
+  Some (`Assoc fields)
+
+let sources_footer sources =
+  let line_of_source = function
+    | `Assoc fields -> (
+        match List.assoc_opt "url" fields with
+        | Some (`String url) ->
+            let quote =
+              match List.assoc_opt "quote" fields with
+              | Some (`String value) when not (String.equal value "") ->
+                  " - \"" ^ value ^ "\""
+              | _ -> ""
+            in
+            Some ("- <" ^ url ^ ">" ^ quote)
+        | _ -> None)
+    | _ -> None
+  in
+  match List.filter_map line_of_source sources with
+  | [] -> ""
+  | lines -> "\n\n---\n## Sources\n" ^ String.concat "\n" lines
+
 (** Detect markdown that was cut mid-write by an LLM max_tokens limit.
 
     The detector walks the string once with a small state machine that is
@@ -409,30 +477,38 @@ let handle_post_create args =
   | Some t when String.equal (String.trim t) "" ->
       (false, "Title must not be empty or whitespace-only")
   | _ ->
-  let body = get_string_opt args "body" |> Option.map strip_state_blocks_text in
-  let raw_content = match body with Some value -> value | None -> get_string args "content" "" in
+  let body_arg = get_string_opt args "body" |> Option.map strip_state_blocks_text in
+  let raw_content = match body_arg with Some value -> value | None -> get_string args "content" "" in
+  let sources = source_entries_arg args in
   let content =
     let stripped = strip_state_blocks_text raw_content in
-    match detect_truncated_markdown_with_reason stripped with
-    | Some reason ->
-      let author_label =
-        match get_string_opt args "author" |> Option.map String.trim with
-        | Some a when not (String.equal a "") -> a
-        | _ -> "unknown"
-      in
-      Prometheus.inc_counter Prometheus.metric_board_truncated_posts
-        ~labels:[("author", author_label)] ();
-      (* #9777: body_len is the LLM's own output length AFTER state-block
-         stripping, not a MASC-imposed limit. The signal name explains
-         which structural pattern triggered the marker. *)
-      Log.BoardLog.warn
-        "board_post: detected truncated markdown (author=%s body_len=%d signal=%s) — appending 잘림 marker"
-        author_label (String.length stripped)
-        (truncation_signal_to_string reason);
-      stripped ^ "\n\n_…[잘림 — LLM 출력이 중간에 끊겼습니다]_"
-    | None ->
-      stripped
+    let content =
+      match detect_truncated_markdown_with_reason stripped with
+      | Some reason ->
+        let author_label =
+          match get_string_opt args "author" |> Option.map String.trim with
+          | Some a when not (String.equal a "") -> a
+          | _ -> "unknown"
+        in
+        Prometheus.inc_counter Prometheus.metric_board_truncated_posts
+          ~labels:[("author", author_label)] ();
+        (* #9777: body_len is the LLM's own output length AFTER state-block
+           stripping, not a MASC-imposed limit. The signal name explains
+           which structural pattern triggered the marker. *)
+        Log.BoardLog.warn
+          "board_post: detected truncated markdown (author=%s body_len=%d signal=%s) — appending 잘림 marker"
+          author_label (String.length stripped)
+          (truncation_signal_to_string reason);
+        stripped ^ "\n\n_…[잘림 — LLM 출력이 중간에 끊겼습니다]_"
+      | None ->
+        stripped
+    in
+    match sources with
+    | Some entries when not (String.equal (String.trim content) "") ->
+        content ^ sources_footer entries
+    | _ -> content
   in
+  let body = Option.map (fun _ -> content) body_arg in
   let author = get_string_opt args "author" |> Option.map String.trim in
   let title_is_empty =
     match title with
@@ -453,7 +529,11 @@ let handle_post_create args =
   let hearth = get_string_opt args "hearth" in
   let thread_id = get_string_opt args "thread_id" in
   let raw_post_kind = get_string_opt args "post_kind" in
-  let meta_json = normalize_board_post_meta args in
+  let meta_json =
+    match sources with
+    | Some entries -> merge_sources_into_meta (normalize_board_post_meta args) entries
+    | None -> normalize_board_post_meta args
+  in
 
   let visibility = match visibility_of_string visibility_str with
     | Some v -> v
@@ -794,6 +874,17 @@ let tool_post_create : Masc_domain.tool_schema = {
       ("content", `Assoc [("type", `String "string"); ("description", `String "Post body text (alternative to `body`, max 4000 chars)")]);
       ("author", `Assoc [("type", `String "string"); ("description", `String "Author name. Auto-filled from caller's agent_name when omitted.")]);
       ("meta", `Assoc [("type", `String "object"); ("description", `String "Optional structured operational metadata")]);
+      ("sources", `Assoc [
+        ("type", `String "array");
+        ("description", `String "Optional external evidence sources appended to the post and persisted in meta.sources");
+        ("items", `Assoc [
+          ("type", `String "object");
+          ("properties", `Assoc [
+            ("url", `Assoc [("type", `String "string"); ("description", `String "Source URL")]);
+            ("quote", `Assoc [("type", `String "string"); ("description", `String "Short relevant quote or snippet")]);
+          ]);
+        ]);
+      ]);
       ("classification_reason", `Assoc [("type", `String "string"); ("description", `String "Optional explicit classification rationale; persisted into meta and surfaced by the dashboard")]);
       ("judgment", `Assoc [("type", `String "object"); ("description", `String "Optional structured LLM judgment metadata. Use summary/reason/confidence keys when you want the board to retain your classification rationale")]);
       ("visibility", `Assoc [("type", `String "string"); ("description", `String "public|unlisted|internal|direct (default: internal)")]);

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -206,6 +206,17 @@ or starting discussions that other keepers should see.";
         ("thread_id", `Assoc [("type", `String "string"); ("description", `String "Linked conversation thread ID (optional)")]);
         ("classification_reason", `Assoc [("type", `String "string"); ("description", `String "Optional explicit rationale for why this should appear as automation/direct in board views")]);
         ("judgment", `Assoc [("type", `String "object"); ("description", `String "Optional structured LLM judgment metadata. Use summary or reason to preserve why you posted/classified it this way")]);
+        ("sources", `Assoc [
+          ("type", `String "array");
+          ("description", `String "Optional external evidence sources appended to the post and persisted in meta.sources");
+          ("items", `Assoc [
+            ("type", `String "object");
+            ("properties", `Assoc [
+              ("url", `Assoc [("type", `String "string"); ("description", `String "Source URL")]);
+              ("quote", `Assoc [("type", `String "string"); ("description", `String "Short relevant quote or snippet")]);
+            ]);
+          ]);
+        ]);
       ]);
       ("required", `List [`String "content"]);
     ];

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1701,6 +1701,20 @@ let test_prompt_includes_operational_tool_guidance () =
   check bool "mentions server-managed heartbeat" true
     (contains_substring sys "Heartbeat is server-managed")
 
+let test_prompt_includes_research_evidence_contract () =
+  let sys, _user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta
+      ~observation:base_observation ()
+  in
+  check bool "mentions research evidence" true
+    (contains_substring sys "Research evidence");
+  check bool "mentions web search" true
+    (contains_substring sys "masc_web_search");
+  check bool "mentions uncited marker" true
+    (contains_substring sys "[uncited]");
+  check bool "mentions board sources metadata" true
+    (contains_substring sys "sources` array")
+
 let test_capabilities_prompt_distinguishes_sandbox_and_worktree () =
   let prompt = Prompt_registry.get_prompt "keeper.capabilities" in
   check bool "sandbox paths documented" true
@@ -7206,6 +7220,8 @@ let () =
             test_prompt_mentions_extend_turns_guidance;
           test_case "includes operational tool guidance" `Quick
             test_prompt_includes_operational_tool_guidance;
+          test_case "includes research evidence contract" `Quick
+            test_prompt_includes_research_evidence_contract;
           test_case "distinguishes sandbox and worktree" `Quick
             test_capabilities_prompt_distinguishes_sandbox_and_worktree;
           test_case "world prompt distinguishes sandbox and worktree" `Quick

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -40,11 +40,16 @@ let dispatch name args =
 let make_args pairs = `Assoc pairs
 
 let parse_create_response_json body =
-  match String.index_opt body '\n' with
-  | Some idx ->
-      Yojson.Safe.from_string
-        (String.sub body (idx + 1) (String.length body - idx - 1))
-  | None -> Yojson.Safe.from_string body
+  let trimmed = String.trim body in
+  if String.length trimmed > 0 && Char.equal trimmed.[0] '{' then
+    Yojson.Safe.from_string trimmed
+  else
+    match String.index_opt body '\n' with
+    | Some idx ->
+        Yojson.Safe.from_string
+          (String.sub body (idx + 1) (String.length body - idx - 1))
+    | None ->
+        Alcotest.failf "expected JSON payload in create response: %s" body
 
 let make_keeper_meta ?(name = "judge-keeper") () : Keeper_types.keeper_meta =
   match
@@ -421,6 +426,41 @@ let test_post_create_judgment_roundtrip () =
   Alcotest.(check string) "judgment summary kept in meta" summary
     Yojson.Safe.Util.(json |> member "meta" |> member "judgment" |> member "summary" |> to_string)
 
+let test_post_create_sources_footer_and_meta () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let ok, body =
+    dispatch "masc_board_post"
+      (make_args
+         [
+           ("content", `String "External claim: prompt contracts need evidence.");
+           ("author", `String "tester");
+           ( "sources",
+             `List
+               [
+                 `Assoc
+                   [
+                     ("url", `String "https://example.com/docs");
+                     ("quote", `String "evidence beats assertion");
+                   ];
+               ] );
+         ])
+  in
+  Alcotest.(check bool) "create ok" true ok;
+  let json = parse_create_response_json body in
+  let content = Yojson.Safe.Util.(json |> member "content" |> to_string) in
+  Alcotest.(check bool) "sources footer appended" true
+    (contains_substring content "## Sources");
+  Alcotest.(check bool) "source url rendered" true
+    (contains_substring content "<https://example.com/docs>");
+  Alcotest.(check string) "source url persisted" "https://example.com/docs"
+    Yojson.Safe.Util.(
+      json |> member "meta" |> member "sources" |> index 0 |> member "url"
+      |> to_string);
+  Alcotest.(check bool) "external source flag" true
+    Yojson.Safe.Util.(json |> member "meta" |> member "has_external_sources" |> to_bool)
+
 let test_keeper_board_post_preserves_meta_reason () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -676,11 +716,9 @@ let test_dispatch_delete_success () =
   let _ok, body = dispatch "masc_board_post"
     (make_args [("content", `String "to be deleted"); ("author", `String "tester")]) in
   let post_id =
-    try
-      parse_create_response_json body
-      |> Yojson.Safe.Util.member "id"
-      |> Yojson.Safe.Util.to_string
-    with _ -> Alcotest.fail ("Failed to parse post JSON from: " ^ body)
+    parse_create_response_json body
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string
   in
   let ok_del, msg_del = dispatch "masc_board_delete"
     (make_args [("post_id", `String post_id)]) in
@@ -715,13 +753,10 @@ let test_post_get_success () =
   let ok, body = dispatch "masc_board_post"
     (make_args [("content", `String "Get me"); ("author", `String "tester")]) in
   Alcotest.(check bool) "create ok" true ok;
-  (* Response is "✅ Post created:\n{json}" — extract JSON after first newline *)
   let post_id =
-    try
-      parse_create_response_json body
-      |> Yojson.Safe.Util.member "id"
-      |> Yojson.Safe.Util.to_string
-    with _ -> Alcotest.fail ("Failed to parse post JSON from: " ^ body)
+    parse_create_response_json body
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string
   in
   Alcotest.(check bool) "post_id not empty" true (String.length post_id > 0);
   let ok2, body2 = dispatch "masc_board_get"
@@ -923,6 +958,8 @@ let () =
             test_post_create_structured_payload;
           Alcotest.test_case "create judgment roundtrip" `Quick
             test_post_create_judgment_roundtrip;
+          Alcotest.test_case "create sources footer and meta" `Quick
+            test_post_create_sources_footer_and_meta;
           Alcotest.test_case "keeper board post preserves meta reason" `Quick
             test_keeper_board_post_preserves_meta_reason;
           Alcotest.test_case "keeper board dispatch uses typed names" `Quick

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -343,7 +343,9 @@ let test_keeper_board_post_schema_supports_judgment () =
           Alcotest.(check bool) "has classification_reason" true
             (List.mem_assoc "classification_reason" props);
           Alcotest.(check bool) "has judgment" true
-            (List.mem_assoc "judgment" props)
+            (List.mem_assoc "judgment" props);
+          Alcotest.(check bool) "has sources" true
+            (List.mem_assoc "sources" props)
       | None -> Alcotest.fail "keeper_board_post missing properties"
 
 (* ============================================================


### PR DESCRIPTION
Refs #13387.

## What changed
- Added a keeper unified prompt contract for research evidence: use code evidence for repo-local claims, `masc_web_search` for external/current claims when available, and mark unverifiable claims with `[uncited]`.
- Added optional `sources` support to `masc_board_post` and keeper-facing `keeper_board_post` schemas.
- Board posts with `sources` now append a Sources footer and persist `meta.sources` plus `meta.has_external_sources=true`.
- Updated board tests to tolerate both legacy prefixed create responses and current bare JSON responses.

## Why
#13387 showed `masc_web_search` existed but the keeper prompt and board post contract did not make external evidence auditable. PR #13412 covers tool availability; this PR covers the prompt and board evidence surface without adding a hard posting gate.

## Scope note
The unused-tool rolling telemetry proposed in #13387 remains separate follow-up scope.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_tool_board_coverage.exe test/test_tool_shard_coverage.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_tool_board_coverage.exe test post_crud`
- `./_build/default/test/test_keeper_unified.exe test unified_prompt`
- `./_build/default/test/test_tool_shard_coverage.exe`