### PR TITLE
fix(dashboard): surface Bonsai goals fetch staleness

### DIFF
--- a/dashboard_bonsai/src/goals_fetch.ml
+++ b/dashboard_bonsai/src/goals_fetch.ml
@@ -1,19 +1,44 @@
 (** Single-shot fetch of [/api/v1/dashboard/goals] + 10 s polling.
 
     Goals are config-driven — they change slowly. 10 s polling keeps the
-    tab fresh without hammering the endpoint. *)
+    tab fresh without hammering the endpoint. Failed fetches keep the last
+    good response in the Var but stamp it stale, matching Logs_fetch and
+    Keepers_fetch so stale goal data is visible instead of silently current. *)
 
 open! Core
 open Brr_io
 
 let endpoint = "/api/v1/dashboard/goals"
 
+let consecutive_failures = ref 0
+let last_response = ref Goals_types.fixture
+
+let store_success (response : Goals_types.response) : unit =
+  consecutive_failures := 0;
+  let response = { response with fetch_status = Goals_types.Fetch_fresh } in
+  last_response := response;
+  Bonsai.Expert.Var.set Goals_var.var response
+;;
+
+let store_failure (reason : string) : unit =
+  consecutive_failures := !consecutive_failures + 1;
+  let response =
+    { !last_response with
+      fetch_status =
+        Goals_types.Fetch_stale
+          { reason; consecutive_failures = !consecutive_failures }
+    }
+  in
+  Bonsai.Expert.Var.set Goals_var.var response
+;;
+
 let parse_and_store (text : Jstr.t) : unit =
   match Yojson.Safe.from_string (Jstr.to_string text) with
   | json ->
     let response = Goals_types.response_of_yojson json in
-    Bonsai.Expert.Var.set Goals_var.var response
-  | exception _ -> ()
+    store_success response
+  | exception exn ->
+    store_failure ("parse failed: " ^ Exn.to_string exn)
 ;;
 
 let run () : unit =
@@ -24,7 +49,7 @@ let run () : unit =
   in
   Fut.await work (function
     | Ok text -> parse_and_store text
-    | Error _ -> ())
+    | Error _ -> store_failure "fetch failed")
 ;;
 
 let start_polling () : unit =

--- a/dashboard_bonsai/src/goals_types.ml
+++ b/dashboard_bonsai/src/goals_types.ml
@@ -46,10 +46,19 @@ type summary =
   ; overall_convergence_pct : int
   }
 
+type fetch_status =
+  | Fetch_pending
+  | Fetch_fresh
+  | Fetch_stale of
+      { reason : string
+      ; consecutive_failures : int
+      }
+
 type response =
   { generated_at : string
   ; tree : node list
   ; summary : summary
+  ; fetch_status : fetch_status
   }
 
 let fixture_summary : summary =
@@ -62,7 +71,7 @@ let fixture_summary : summary =
 ;;
 
 let fixture : response =
-  { generated_at = ""; tree = []; summary = fixture_summary }
+  { generated_at = ""; tree = []; summary = fixture_summary; fetch_status = Fetch_pending }
 ;;
 
 (* ---------- manual Yojson decoding ---------- *)
@@ -168,5 +177,12 @@ let response_of_yojson json : response =
     | `Assoc _ as s -> summary_of_yojson s
     | _ -> fixture_summary
   in
-  { generated_at = string_field json "generated_at"; tree; summary }
+  { generated_at = string_field json "generated_at"; tree; summary; fetch_status = Fetch_fresh }
+;;
+
+let fetch_status_label = function
+  | Fetch_pending -> "fetch pending"
+  | Fetch_fresh -> "fetch ok"
+  | Fetch_stale { consecutive_failures; _ } ->
+    Printf.sprintf "stale %dx" consecutive_failures
 ;;

--- a/dashboard_bonsai/src/goals_view.ml
+++ b/dashboard_bonsai/src/goals_view.ml
@@ -384,9 +384,17 @@ let rec view_node ~(depth : int) (n : Goals_types.node) : Node.t =
 
 let view_meta_strip (r : Goals_types.response) =
   let s = r.summary in
+  let fetch_color =
+    match r.fetch_status with
+    | Goals_types.Fetch_pending -> `Brass
+    | Goals_types.Fetch_fresh -> `Ok
+    | Goals_types.Fetch_stale _ -> `Blood
+  in
   Meta.strip
     ~label:"Goals summary"
-    [ Meta.cell ~k:"goals" ~v:(Printf.sprintf "%d" s.total_goals) ()
+    [ Meta.cell ~color:fetch_color ~k:"feed"
+        ~v:(Goals_types.fetch_status_label r.fetch_status) ()
+    ; Meta.cell ~k:"goals" ~v:(Printf.sprintf "%d" s.total_goals) ()
     ; Meta.cell ~color:`Ok ~k:"active"
         ~v:(Printf.sprintf "%d" s.active_goals) ()
     ; Meta.cell ~k:"tasks"


### PR DESCRIPTION
## Summary
- add fetch status to Bonsai goals responses
- stamp goals fetch success as fresh and parse/fetch failures as stale while preserving the last good tree
- render a goals summary feed cell so stale goals data is visible to operators

Fixes #13445

## Validation
- git diff --check
- git diff --cached --check
- ocamlc -stop-after parsing dashboard_bonsai/src/goals_types.ml dashboard_bonsai/src/goals_fetch.ml

## Validation note
- dashboard_bonsai full js_of_ocaml build could not run in this local switch because bonsai_web and ppx_jane are not installed locally; this package is excluded from the root dune workspace.