### PR TITLE
fix(dashboard): surface Bonsai archive fetch staleness

### DIFF
--- a/dashboard_bonsai/src/archive_runs_fetch.ml
+++ b/dashboard_bonsai/src/archive_runs_fetch.ml
@@ -1,20 +1,46 @@
 (** Single-shot fetch of [/api/v1/autoresearch/loops] + 5 s polling.
 
     Archive runs are not as time-sensitive as the logs tab, so polling is
-    slower (5 s vs 3 s). Errors are silently dropped; the previous response
-    remains in [Archive_runs_var] so the UI does not flicker. *)
+    slower (5 s vs 3 s). Failed fetches keep the previous response but stamp
+    it stale, so the UI does not flicker and does not present old archive
+    rows as current. *)
 
 open! Core
 open Brr_io
 
 let endpoint = "/api/v1/autoresearch/loops?limit=200"
 
+let consecutive_failures = ref 0
+let last_response = ref Archive_runs_types.fixture
+
+let store_success (response : Archive_runs_types.response) : unit =
+  consecutive_failures := 0;
+  let response =
+    { response with fetch_status = Archive_runs_types.Fetch_fresh }
+  in
+  last_response := response;
+  Bonsai.Expert.Var.set Archive_runs_var.var response
+;;
+
+let store_failure (reason : string) : unit =
+  consecutive_failures := !consecutive_failures + 1;
+  let response =
+    { !last_response with
+      fetch_status =
+        Archive_runs_types.Fetch_stale
+          { reason; consecutive_failures = !consecutive_failures }
+    }
+  in
+  Bonsai.Expert.Var.set Archive_runs_var.var response
+;;
+
 let parse_and_store (text : Jstr.t) : unit =
   match Yojson.Safe.from_string (Jstr.to_string text) with
   | json ->
     let response = Archive_runs_types.response_of_yojson json in
-    Bonsai.Expert.Var.set Archive_runs_var.var response
-  | exception _ -> ()
+    store_success response
+  | exception exn ->
+    store_failure ("parse failed: " ^ Exn.to_string exn)
 ;;
 
 let run () : unit =
@@ -25,7 +51,7 @@ let run () : unit =
   in
   Fut.await work (function
     | Ok text -> parse_and_store text
-    | Error _ -> ())
+    | Error _ -> store_failure "fetch failed")
 ;;
 
 let start_polling () : unit =

--- a/dashboard_bonsai/src/archive_runs_types.ml
+++ b/dashboard_bonsai/src/archive_runs_types.ml
@@ -31,14 +31,24 @@ type loop =
   ; target_file : string
   }
 
+type fetch_status =
+  | Fetch_pending
+  | Fetch_fresh
+  | Fetch_stale of
+      { reason : string
+      ; consecutive_failures : int
+      }
+
 type response =
   { loops : loop list
   ; total : int
   ; offset : int
   ; limit : int
+  ; fetch_status : fetch_status
   }
 
-let fixture : response = { loops = []; total = 0; offset = 0; limit = 100 }
+let fixture : response =
+  { loops = []; total = 0; offset = 0; limit = 100; fetch_status = Fetch_pending }
 
 (* ---------- manual Yojson decoding ---------- *)
 
@@ -113,6 +123,7 @@ let response_of_yojson json : response =
   ; total = int_field json "total"
   ; offset = int_field json "offset"
   ; limit = int_field ~default:100 json "limit"
+  ; fetch_status = Fetch_fresh
   }
 ;;
 
@@ -123,4 +134,11 @@ let status_label = function
   | Failed -> "failed"
   | Completed -> "completed"
   | Unknown -> "—"
+;;
+
+let fetch_status_label = function
+  | Fetch_pending -> "fetch pending"
+  | Fetch_fresh -> "fetch ok"
+  | Fetch_stale { consecutive_failures; _ } ->
+    Printf.sprintf "stale %dx" consecutive_failures
 ;;

--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -296,9 +296,17 @@ let view_meta_strip (r : Archive_runs_types.response) =
       | Failed -> true
       | Running | Stopped | Paused | Completed | Unknown -> false)
   in
+  let fetch_color =
+    match r.fetch_status with
+    | Archive_runs_types.Fetch_pending -> `Brass
+    | Archive_runs_types.Fetch_fresh -> `Ok
+    | Archive_runs_types.Fetch_stale _ -> `Blood
+  in
   Meta.strip
     ~label:"Archive runs summary"
-    [ Meta.cell ~k:"total" ~v:(Printf.sprintf "%d" r.total) ()
+    [ Meta.cell ~color:fetch_color ~k:"feed"
+        ~v:(Archive_runs_types.fetch_status_label r.fetch_status) ()
+    ; Meta.cell ~k:"total" ~v:(Printf.sprintf "%d" r.total) ()
     ; Meta.cell ~color:`Ok ~k:"running" ~v:(Printf.sprintf "%d" running) ()
     ; Meta.cell ~k:"completed" ~v:(Printf.sprintf "%d" completed) ()
     ; Meta.cell ~color:`Blood ~k:"failed" ~v:(Printf.sprintf "%d" failed) ()


### PR DESCRIPTION
## Summary
- add fetch status to Bonsai archive runs responses
- stamp archive fetch success as fresh and parse/fetch failures as stale while preserving the last good loop list
- render an archive summary feed cell so stale autoresearch loop data is visible to operators

Fixes #13448

## Validation
- `git diff --check`
- `ocamlc -stop-after parsing dashboard_bonsai/src/archive_runs_types.ml dashboard_bonsai/src/archive_runs_fetch.ml`

## Validation note
- `dashboard_bonsai/src/archive_runs_view.ml` uses the Bonsai/PPX build surface, so direct parsing is not a substitute for the project build.
- `dune build --root dashboard_bonsai @all` could not complete in this local switch because `ppx_jane`, `bonsai_web`, and `brr` are not installed; `dashboard_bonsai` is also excluded from the root dune workspace.