### PR TITLE
fix(dashboard): surface stale goals fetches

### DIFF
--- a/dashboard_bonsai/src/goals_fetch.ml
+++ b/dashboard_bonsai/src/goals_fetch.ml
@@ -32,11 +32,22 @@ let store_failure (reason : string) : unit =
   Bonsai.Expert.Var.set Goals_var.var response
 ;;
 
+let invalid_response_reason json =
+  match
+    Yojson.Safe.Util.member "status" json, Yojson.Safe.Util.member "message" json
+  with
+  | `String status, `String message ->
+    Printf.sprintf "unexpected goals response: %s: %s" status message
+  | `String status, _ -> Printf.sprintf "unexpected goals response: %s" status
+  | _ -> "unexpected goals response envelope"
+;;
+
 let parse_and_store (text : Jstr.t) : unit =
   match Yojson.Safe.from_string (Jstr.to_string text) with
-  | json ->
+  | json when Goals_types.is_response_envelope json ->
     let response = Goals_types.response_of_yojson json in
     store_success response
+  | json -> store_failure (invalid_response_reason json)
   | exception exn ->
     store_failure ("parse failed: " ^ Exn.to_string exn)
 ;;

--- a/dashboard_bonsai/src/goals_types.ml
+++ b/dashboard_bonsai/src/goals_types.ml
@@ -2,7 +2,8 @@
 
     Mirrors [lib/dashboard/dashboard_goals.ml:dashboard_goals_tree_json].
     Recursive tree of goal nodes; each node carries its immediate task
-    list. *)
+    list. [fetch_status] is client-local polling state and is not emitted by
+    the server. *)
 
 open! Core
 
@@ -166,6 +167,12 @@ let summary_of_yojson json : summary =
   }
 ;;
 
+let is_response_envelope json =
+  match Yojson.Safe.Util.member "tree" json, Yojson.Safe.Util.member "summary" json with
+  | `List _, `Assoc _ -> true
+  | _ -> false
+;;
+
 let response_of_yojson json : response =
   let tree =
     match Yojson.Safe.Util.member "tree" json with
@@ -182,7 +189,13 @@ let response_of_yojson json : response =
 
 let fetch_status_label = function
   | Fetch_pending -> "fetch pending"
-  | Fetch_fresh -> "fetch ok"
+  | Fetch_fresh -> "fetch fresh"
   | Fetch_stale { consecutive_failures; _ } ->
-    Printf.sprintf "stale %dx" consecutive_failures
+    Printf.sprintf "fetch stale x%d" consecutive_failures
+;;
+
+let fetch_status_reason = function
+  | Fetch_pending -> "waiting for first goals response"
+  | Fetch_fresh -> "latest goals response parsed"
+  | Fetch_stale { reason; _ } -> reason
 ;;

--- a/dashboard_bonsai/src/goals_view.ml
+++ b/dashboard_bonsai/src/goals_view.ml
@@ -214,6 +214,12 @@ let truncate ~max_len s =
   else String.sub s ~pos:0 ~len:(max_len - 1) ^ "…"
 ;;
 
+let short_reason reason =
+  if String.length reason <= 96
+  then reason
+  else String.sub reason ~pos:0 ~len:96 ^ "..."
+;;
+
 let blocker_label source =
   match String.lowercase source with
   | "goal_phase" -> "goal phase"
@@ -384,16 +390,20 @@ let rec view_node ~(depth : int) (n : Goals_types.node) : Node.t =
 
 let view_meta_strip (r : Goals_types.response) =
   let s = r.summary in
-  let fetch_color =
+  let feed_color =
     match r.fetch_status with
-    | Goals_types.Fetch_pending -> `Brass
+    | Goals_types.Fetch_pending -> `Default
     | Goals_types.Fetch_fresh -> `Ok
-    | Goals_types.Fetch_stale _ -> `Blood
+    | Goals_types.Fetch_stale { consecutive_failures; _ } ->
+      if consecutive_failures >= 3 then `Blood else `Brass
   in
   Meta.strip
     ~label:"Goals summary"
-    [ Meta.cell ~color:fetch_color ~k:"feed"
-        ~v:(Goals_types.fetch_status_label r.fetch_status) ()
+    [ Meta.cell
+        ~color:feed_color
+        ~k:"feed"
+        ~v:(Goals_types.fetch_status_label r.fetch_status)
+        ()
     ; Meta.cell ~k:"goals" ~v:(Printf.sprintf "%d" s.total_goals) ()
     ; Meta.cell ~color:`Ok ~k:"active"
         ~v:(Printf.sprintf "%d" s.active_goals) ()
@@ -404,7 +414,34 @@ let view_meta_strip (r : Goals_types.response) =
     ]
 ;;
 
+let view_fetch_notice (r : Goals_types.response) =
+  match r.fetch_status with
+  | Goals_types.Fetch_pending | Goals_types.Fetch_fresh -> Node.none
+  | Goals_types.Fetch_stale { reason; consecutive_failures } ->
+    let reason_text = short_reason reason in
+    let label =
+      Printf.sprintf "goals feed stale x%d: %s" consecutive_failures reason_text
+    in
+    Node.div
+      ~attrs:[ Style.blocker; Attr.role "status"; Attr.create "aria-label" label ]
+      [ Node.div
+          ~attrs:[ Style.blocker_k ]
+          [ Node.text (Printf.sprintf "goals feed stale x%d" consecutive_failures) ]
+      ; Node.div ~attrs:[ Style.blocker_v ] [ Node.text reason_text ]
+      ]
+;;
+
 let render ~(shell : Overview_types.response) (r : Goals_types.response) : Node.t =
+  let quiet_text =
+    match r.fetch_status with
+    | Goals_types.Fetch_pending -> "goal tree fetch is pending."
+    | Goals_types.Fetch_fresh -> "goal tree is empty."
+    | Goals_types.Fetch_stale { reason; consecutive_failures } ->
+      Printf.sprintf
+        "goal tree feed is stale (%dx) — %s"
+        consecutive_failures
+        (short_reason reason)
+  in
   Shell_view.view
     ~shell
     ~active:Goals
@@ -419,11 +456,12 @@ let render ~(shell : Overview_types.response) (r : Goals_types.response) : Node.
         ~sub_lang:"ko"
         ()
     ; view_meta_strip r
+    ; view_fetch_notice r
     ; (match r.tree with
        | [] ->
          Node.div
-           ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No goals" ]
-           [ Node.text "goal tree is empty." ]
+           ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" quiet_text ]
+           [ Node.text quiet_text ]
        | nodes ->
          Node.div
            ~attrs:[ Style.tree; Attr.role "list"; Attr.create "aria-label" "Goal tree" ]


### PR DESCRIPTION
Refs #13445.

## What changed
- Added `fetch_status` to the Bonsai goals response model, matching the existing logs/keepers stale-feed contract.
- `Goals_fetch` now keeps the last good response, stamps parse/fetch failures as stale, and increments consecutive failure count instead of silently leaving the UI unchanged.
- Goals view now shows a feed status cell and a stale notice/empty-state reason when the goals feed fails.

## Why
The goals tab could render old goal data as current after a parse or fetch failure. Logs and keepers already had stale-status treatment; this brings the goals tab up to that same runtime-truth standard.

## Notes
While validating, I found the integrated `make bonsai-dashboard` target can miss the explicit JS build target from a clean dashboard `_build`; tracked separately as #13450.

## Validation
- `git diff --check`
- `OPAMSWITCH=bonsai-dashboard opam exec -- dune build --root . bin/main.bc.js` from `dashboard_bonsai/`
- `ocamlformat --enable-outside-detected-project --check dashboard_bonsai/src/goals_fetch.ml dashboard_bonsai/src/goals_types.ml dashboard_bonsai/src/goals_view.ml` attempted; blocked by pre-existing Bonsai local graph syntax in `goals_view.ml` (`let component (_graph @ local) =`)