### PR TITLE
fix(dashboard): surface Bonsai multimodal fetch staleness

### DIFF
--- a/dashboard_bonsai/src/multimodal_fetch.ml
+++ b/dashboard_bonsai/src/multimodal_fetch.ml
@@ -1,19 +1,45 @@
 (** Single-shot fetch of [/api/v1/multimodal/list] + 5 s polling.
 
-    Mirrors [Overview_fetch] / [Logs_fetch] pattern. Failed fetches
-    leave the previously-stored response in [Multimodal_var]. *)
+    Mirrors [Logs_fetch] / [Keepers_fetch] pattern. Failed fetches leave the
+    previously-stored response in [Multimodal_var] but stamp it stale so old
+    artifact data is not presented as current. *)
 
 open! Core
 open Brr_io
 
 let endpoint = "/api/v1/multimodal/list"
 
+let consecutive_failures = ref 0
+let last_response = ref Multimodal_types.empty_response
+
+let store_success (response : Multimodal_types.response) : unit =
+  consecutive_failures := 0;
+  let response =
+    { response with fetch_status = Multimodal_types.Fetch_fresh }
+  in
+  last_response := response;
+  Bonsai.Expert.Var.set Multimodal_var.var response
+;;
+
+let store_failure (reason : string) : unit =
+  consecutive_failures := !consecutive_failures + 1;
+  let response =
+    { !last_response with
+      fetch_status =
+        Multimodal_types.Fetch_stale
+          { reason; consecutive_failures = !consecutive_failures }
+    }
+  in
+  Bonsai.Expert.Var.set Multimodal_var.var response
+;;
+
 let parse_and_store (text : Jstr.t) : unit =
   match Yojson.Safe.from_string (Jstr.to_string text) with
   | json ->
     let response = Multimodal_types.response_of_yojson json in
-    Bonsai.Expert.Var.set Multimodal_var.var response
-  | exception _ -> ()
+    store_success response
+  | exception exn ->
+    store_failure ("parse failed: " ^ Exn.to_string exn)
 ;;
 
 let run () : unit =
@@ -24,7 +50,7 @@ let run () : unit =
   in
   Fut.await work (function
     | Ok text -> parse_and_store text
-    | Error _ -> ())
+    | Error _ -> store_failure "fetch failed")
 ;;
 
 let start_polling () : unit =

--- a/dashboard_bonsai/src/multimodal_types.ml
+++ b/dashboard_bonsai/src/multimodal_types.ml
@@ -18,12 +18,22 @@ type artifact =
   ; created_by : string  (* from provenance.created_by, "" if absent *)
   }
 
+type fetch_status =
+  | Fetch_pending
+  | Fetch_fresh
+  | Fetch_stale of
+      { reason : string
+      ; consecutive_failures : int
+      }
+
 type response =
   { count : int
   ; artifacts : artifact list
+  ; fetch_status : fetch_status
   }
 
-let empty_response : response = { count = 0; artifacts = [] }
+let empty_response : response =
+  { count = 0; artifacts = []; fetch_status = Fetch_pending }
 
 let string_field json name : string =
   match Yojson.Safe.Util.member name json with
@@ -62,5 +72,12 @@ let response_of_yojson (json : Yojson.Safe.t) : response =
     | `List xs -> List.map xs ~f:artifact_of_yojson
     | _ -> []
   in
-  { count; artifacts }
+  { count; artifacts; fetch_status = Fetch_fresh }
+;;
+
+let fetch_status_label = function
+  | Fetch_pending -> "fetch pending"
+  | Fetch_fresh -> "fetch ok"
+  | Fetch_stale { consecutive_failures; _ } ->
+    Printf.sprintf "stale %dx" consecutive_failures
 ;;

--- a/dashboard_bonsai/src/multimodal_view.ml
+++ b/dashboard_bonsai/src/multimodal_view.ml
@@ -47,6 +47,7 @@ stylesheet
     font-size: 0.85rem;
     color: var(--color-fg-muted);
   }
+  .count_stale { color: var(--accent-blood); }
   .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -155,6 +156,12 @@ let empty_state : Node.t =
     ]
 ;;
 
+let count_attrs (status : Multimodal_types.fetch_status) =
+  match status with
+  | Fetch_stale _ -> [ Style.count; Style.count_stale ]
+  | Fetch_pending | Fetch_fresh -> [ Style.count ]
+;;
+
 let view_of_response
     ~(detail_panel : Node.t)
     ~(kind_filter : string option)
@@ -181,8 +188,13 @@ let view_of_response
         ~attrs:[ Style.header ]
         [ Node.h1 ~attrs:[ Style.title ] [ Node.text "Multimodal · gallery" ]
         ; Node.span
-            ~attrs:[ Style.count ]
-            [ Node.text (Printf.sprintf "%d artifacts" r.count) ]
+            ~attrs:(count_attrs r.fetch_status)
+            [ Node.text
+                (Printf.sprintf
+                   "%d artifacts · %s"
+                   r.count
+                   (Multimodal_types.fetch_status_label r.fetch_status))
+            ]
         ]
     ; (if List.is_empty r.artifacts then Node.none else filter_bar)
     ; (if List.is_empty r.artifacts then empty_state

--- a/dashboard_bonsai/src/multimodal_view.ml
+++ b/dashboard_bonsai/src/multimodal_view.ml
@@ -158,8 +158,9 @@ let empty_state : Node.t =
 
 let count_attrs (status : Multimodal_types.fetch_status) =
   match status with
-  | Fetch_stale _ -> [ Style.count; Style.count_stale ]
-  | Fetch_pending | Fetch_fresh -> [ Style.count ]
+  | Multimodal_types.Fetch_stale _ -> [ Style.count; Style.count_stale ]
+  | Multimodal_types.Fetch_pending | Multimodal_types.Fetch_fresh ->
+    [ Style.count ]
 ;;
 
 let view_of_response


### PR DESCRIPTION
## Summary
- add fetch status to Bonsai multimodal responses
- stamp multimodal fetch success as fresh and parse/fetch failures as stale while preserving the last good artifact list
- render fetch status in the gallery header so stale multimodal artifacts are visible to operators
- qualify multimodal fetch-status constructors in the gallery view so the new stale state compiles under the Bonsai module boundary

Fixes #13452

## Validation
- `git diff --check`
- `ocamlc -stop-after parsing dashboard_bonsai/src/multimodal_types.ml dashboard_bonsai/src/multimodal_fetch.ml`

## Validation note
- `dashboard_bonsai/src/multimodal_view.ml` uses Bonsai local syntax, so direct `ocamlc -stop-after parsing` is not valid for that file without the project PPX pipeline.
- `dune build --root dashboard_bonsai @all` could not complete in this local switch because `ppx_jane`, `bonsai_web`, and `brr` are not installed; `dashboard_bonsai` is also excluded from the root dune workspace.