### PR TITLE
fix(dashboard): use pagination primitive on board

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -2,9 +2,9 @@ import { h } from 'preact'
 import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
-import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter } from '../../store'
+import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore } from '../../store'
 import { route } from '../../router'
-import { boardHearths, boardHearthsError, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
+import { PAGE_SIZE, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -143,8 +143,14 @@ describe('BoardSurface Component', () => {
         headers: { 'Content-Type': 'application/json' },
       }),
     ))
+    vi.stubGlobal('IntersectionObserver', class {
+      observe = vi.fn()
+      disconnect = vi.fn()
+    })
     boardPosts.value = []
     boardLoading.value = false
+    boardHasMore.value = false
+    boardLoadingMore.value = false
     boardSortMode.value = 'recent'
     boardExcludeSystem.value = true
     boardExcludeAutomation.value = false
@@ -156,6 +162,12 @@ describe('BoardSurface Component', () => {
     showNewPostForm.value = false
     newPostHearth.value = ''
     newPostSubmitting.value = false
+    categoryVisibleLimits.value = {
+      article: PAGE_SIZE,
+      review: PAGE_SIZE,
+      notice: PAGE_SIZE,
+      system: PAGE_SIZE,
+    }
     route.value = { params: {} } as any
   })
 
@@ -290,5 +302,45 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(screen.getByRole('button', { name: '취소' })).toBeDisabled()
+  })
+
+  it('uses shared cursor pagination for category expansion', () => {
+    boardPosts.value = Array.from({ length: PAGE_SIZE + 1 }, (_, index) => makePost({
+      id: `post-${index}`,
+      title: `기술 탐색: topic ${index}`,
+      body: 'exploration content here',
+      author: 'keeper',
+      post_kind: 'direct',
+    }))
+
+    render(h(BoardSurface, null))
+
+    const nav = screen.getByRole('navigation', { name: '글/분석 게시글 페이지' })
+    expect(nav).toBeInTheDocument()
+    expect(nav.textContent).toContain('표시')
+    fireEvent.click(screen.getByRole('button', { name: /더 보기/ }))
+
+    expect(categoryVisibleLimits.value.article).toBe(PAGE_SIZE * 2)
+  })
+
+  it('lets category pagination collapse an expanded category', () => {
+    categoryVisibleLimits.value = {
+      article: PAGE_SIZE * 2,
+      review: PAGE_SIZE,
+      notice: PAGE_SIZE,
+      system: PAGE_SIZE,
+    }
+    boardPosts.value = Array.from({ length: PAGE_SIZE * 2 + 1 }, (_, index) => makePost({
+      id: `post-${index}`,
+      title: `기술 탐색: topic ${index}`,
+      body: 'exploration content here',
+      author: 'keeper',
+      post_kind: 'direct',
+    }))
+
+    render(h(BoardSurface, null))
+    fireEvent.click(screen.getByRole('button', { name: '줄이기' }))
+
+    expect(categoryVisibleLimits.value.article).toBe(PAGE_SIZE)
   })
 })

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -12,6 +12,7 @@ import { TextInput } from '../common/input'
 import { Checkbox } from '../common/checkbox'
 import { RichComposer } from '../common/rich-composer'
 import { RichContent } from '../common/rich-content'
+import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
 import { registerBoardHearthsRefresh } from '../../sse-store'
@@ -142,6 +143,15 @@ function expandCategory(
   }
 }
 
+function collapseCategory(
+  category: ContentCategory,
+  limits: Record<string, number>,
+  currentLimit: number,
+) {
+  const nextLimit = Math.max(PAGE_SIZE, currentLimit - PAGE_SIZE)
+  categoryVisibleLimits.value = { ...limits, [category]: nextLimit }
+}
+
 function renderCategorySection(
   category: ContentCategory,
   posts: BoardPost[],
@@ -163,6 +173,10 @@ function renderCategorySection(
   const remainingLabel = hasMoreLocal
     ? `${posts.length - limit}개 남음`
     : '다음 페이지 불러오기'
+  const visibleCount = Math.min(limit, posts.length)
+  const cursorLabel = hasMoreRemote && !hasMoreLocal
+    ? `${visibleCount} / ${total}+`
+    : `${visibleCount} / ${total}`
 
   if (posts.length === 0 && hidden === 0) return null
   if (posts.length === 0 && hidden > 0) {
@@ -183,16 +197,24 @@ function renderCategorySection(
           if (loadingMore) return
           expandCategory(category, limits, limit, posts.length)
         }} />
-        <div class="text-center py-3">
-          <button type="button"
-            class="px-4 py-2 rounded-[var(--r-1)] text-xs font-medium text-[var(--color-fg-muted)] bg-transparent border border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] transition-colors cursor-pointer disabled:opacity-50"
+        <div class="flex justify-center py-3">
+          <${CursorPagination}
+            cursor=${cursorLabel}
+            cursorLabel="표시"
+            hasPrevious=${limit > PAGE_SIZE}
+            hasNext=${hasMore}
+            previousLabel="줄이기"
+            nextLabel=${loadingMore ? '불러오는 중...' : `더 보기 (${remainingLabel})`}
+            ariaLabel=${`${categoryLabel(category)} 게시글 페이지`}
             disabled=${loadingMore}
-            onClick=${() => {
+            testId=${`board-category-pagination-${category}`}
+            onPrevious=${() => {
+              collapseCategory(category, limits, limit)
+            }}
+            onNext=${() => {
               expandCategory(category, limits, limit, posts.length)
             }}
-          >
-            ${loadingMore ? '불러오는 중...' : `더 보기 (${remainingLabel})`}
-          </button>
+          />
         </div>
       ` : null}
     <//>

--- a/dashboard/src/components/common/pagination.test.ts
+++ b/dashboard/src/components/common/pagination.test.ts
@@ -127,8 +127,9 @@ describe('Pagination', () => {
 describe('CursorPagination', () => {
   it('renders cursor and labels', () => {
     const container = document.createElement('div')
-    render(h(CursorPagination, { cursor: 'evt-123' }), container)
+    render(h(CursorPagination, { cursor: 'evt-123', cursorLabel: 'window' }), container)
     expect(container.textContent).toContain('evt-123')
+    expect(container.textContent).toContain('window')
     expect(container.textContent).toContain('Older')
     expect(container.textContent).toContain('Newer')
   })

--- a/dashboard/src/components/common/pagination.ts
+++ b/dashboard/src/components/common/pagination.ts
@@ -28,6 +28,7 @@ interface PaginationProps {
 
 export interface CursorPaginationProps {
   cursor?: string
+  cursorLabel?: string
   hasPrevious?: boolean
   hasNext?: boolean
   onPrevious?: () => void
@@ -238,6 +239,7 @@ export function Pagination({
 
 export function CursorPagination({
   cursor,
+  cursorLabel = 'cursor',
   hasPrevious = true,
   hasNext = true,
   onPrevious,
@@ -276,7 +278,7 @@ export function CursorPagination({
             <span
               class="min-w-0 flex-1 truncate px-2 text-center text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]"
             >
-              cursor · <span class="text-[var(--color-accent-fg)]">${cursor}</span>
+              ${cursorLabel} · <span class="text-[var(--color-accent-fg)]">${cursor}</span>
             </span>
           `
         : null}


### PR DESCRIPTION

## Summary

- Wire the shared `CursorPagination` primitive into the board category footer so G4 has a production use-site.
- Add a `cursorLabel` prop to the primitive instead of hardcoding `cursor` in every UI.
- Preserve the existing board load-more behavior while adding a previous-batch collapse control.

## Verification

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/common/pagination.test.ts src/components/common/pagination.a11y.test.ts src/components/board/board-surface.test.ts --no-file-parallelism --maxWorkers=1` (45 tests)
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint` (passes with 3 unrelated existing warnings: copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- `pnpm --dir dashboard run build` (passes with existing Vite chunk/import warnings)
- `gh pr checks 13454 --repo jeong-sik/masc-mcp` (CI Gate, PR Live Gate, sync, draft guard, and fundamental checks pass at `d792d4fe2ca75f57a303a70393cf9949f0dd1dbe`)
- Browser verification via `agent-browser` at `http://localhost:5174/dashboard/#workspace?section=board`
  - desktop viewport 1440x900 includes `줄이기`, `표시 · 20 / 169`, and `더 보기 (149개 남음)` in the board category footer
  - mobile viewport 390x844 keeps the same pagination controls present
  - desktop screenshot: `/tmp/masc-board-pagination-desktop-0506.png`
  - mobile screenshot: `/tmp/masc-board-pagination-mobile-0506.png`

Note: local `agent-browser errors` reports `Cannot use import statement outside a module` in this Vite dashboard session; the board route renders, and `agent-browser console` only shows Vite connect logs.
