### PR TITLE
fix(dashboard): surface Bonsai shell fetch staleness

### DIFF
--- a/dashboard_bonsai/src/overview_fetch.ml
+++ b/dashboard_bonsai/src/overview_fetch.ml
@@ -1,16 +1,43 @@
-(** Single-shot fetch of [/api/v1/dashboard/shell] + 5 s polling. *)
+(** Single-shot fetch of [/api/v1/dashboard/shell] + 5 s polling.
+
+    Failed fetches keep the last shell snapshot but stamp it stale so the
+    shared shell HUD can show freshness instead of presenting old chrome data
+    as current. *)
 
 open! Core
 open Brr_io
 
 let endpoint = "/api/v1/dashboard/shell"
 
+let consecutive_failures = ref 0
+let last_response = ref Overview_types.fixture
+
+let store_success (response : Overview_types.response) : unit =
+  consecutive_failures := 0;
+  let response = { response with fetch_status = Overview_types.Fetch_fresh } in
+  last_response := response;
+  Bonsai.Expert.Var.set Overview_var.var response
+;;
+
+let store_failure (reason : string) : unit =
+  consecutive_failures := !consecutive_failures + 1;
+  let response =
+    { !last_response with
+      fetch_status =
+        Overview_types.Fetch_stale
+          { reason; consecutive_failures = !consecutive_failures }
+    }
+  in
+  Bonsai.Expert.Var.set Overview_var.var response
+;;
+
 let parse_and_store (text : Jstr.t) : unit =
   match Yojson.Safe.from_string (Jstr.to_string text) with
   | json ->
     let response = Overview_types.response_of_yojson json in
-    Bonsai.Expert.Var.set Overview_var.var response
-  | exception _ -> ()
+    store_success response
+  | exception exn ->
+    store_failure ("parse failed: " ^ Exn.to_string exn)
 ;;
 
 let run () : unit =
@@ -21,7 +48,7 @@ let run () : unit =
   in
   Fut.await work (function
     | Ok text -> parse_and_store text
-    | Error _ -> ())
+    | Error _ -> store_failure "fetch failed")
 ;;
 
 let start_polling () : unit =

--- a/dashboard_bonsai/src/overview_types.ml
+++ b/dashboard_bonsai/src/overview_types.ml
@@ -42,6 +42,14 @@ type meta_cognition =
   ; dominant_belief : belief option
   }
 
+type fetch_status =
+  | Fetch_pending
+  | Fetch_fresh
+  | Fetch_stale of
+      { reason : string
+      ; consecutive_failures : int
+      }
+
 type response =
   { generated_at : string
   ; status : status
@@ -49,6 +57,7 @@ type response =
   ; configured_keepers : int
   ; meta_cognition : meta_cognition
   ; base_path : string
+  ; fetch_status : fetch_status
   }
 
 let fixture_build : build =
@@ -82,6 +91,7 @@ let fixture : response =
   ; configured_keepers = 0
   ; meta_cognition = fixture_meta
   ; base_path = ""
+  ; fetch_status = Fetch_pending
   }
 ;;
 
@@ -175,5 +185,13 @@ let response_of_yojson json : response =
       meta_cognition_of_yojson
         (Yojson.Safe.Util.member "meta_cognition" json)
   ; base_path
+  ; fetch_status = Fetch_fresh
   }
+;;
+
+let fetch_status_label = function
+  | Fetch_pending -> "fetch pending"
+  | Fetch_fresh -> "fetch ok"
+  | Fetch_stale { consecutive_failures; _ } ->
+    Printf.sprintf "stale %dx" consecutive_failures
 ;;

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -780,9 +780,20 @@ let hud_cell ?(tone : tone = `Neutral) ~k ~v () =
     ]
 ;;
 
-let default_hud ~(active : Route.t) =
+let shell_fetch_tone (status : Overview_types.fetch_status) : tone =
+  match status with
+  | Overview_types.Fetch_pending -> `Warn
+  | Overview_types.Fetch_fresh -> `Ok
+  | Overview_types.Fetch_stale _ -> `Bad
+;;
+
+let default_hud ~(shell : Overview_types.response) ~(active : Route.t) =
   [ hud_cell ~k:"Runtime" ~v:"local" ()
-  ; hud_cell ~tone:`Ok ~k:"Snapshot" ~v:"running" ()
+  ; hud_cell
+      ~tone:(shell_fetch_tone shell.fetch_status)
+      ~k:"Shell"
+      ~v:(Overview_types.fetch_status_label shell.fetch_status)
+      ()
   ; hud_cell ~k:"Surface" ~v:"bonsai" ()
   ; hud_cell ~tone:`Warn ~k:"Route" ~v:(label active) ()
   ; hud_cell ~k:"Base" ~v:"/dashboard/b" ()
@@ -1001,7 +1012,7 @@ let view ?(shell = Overview_types.fixture) ?hud ?aside ~(active : Route.t) (chil
   let hud_nodes =
     match hud with
     | Some nodes -> nodes
-    | None -> default_hud ~active
+    | None -> default_hud ~shell ~active
   in
   let aside_node =
     match aside with


### PR DESCRIPTION
## Summary
- add fetch status to the Bonsai shell response model
- stamp shell fetch success as fresh, and parse/fetch failures as stale while preserving the last shell snapshot
- replace the static shell HUD `Snapshot running` cell with real shell fetch freshness

Fixes #13455

## Validation
- `git diff --check`
- `ocamlc -stop-after parsing dashboard_bonsai/src/overview_types.ml dashboard_bonsai/src/overview_fetch.ml dashboard_bonsai/src/shell_view.ml`

## Validation note
- `dune build --root dashboard_bonsai @all` could not complete in this local switch because `ppx_jane`, `bonsai_web`, and `brr` are not installed; `dashboard_bonsai` is also excluded from the root dune workspace.