### PR TITLE
fix(keeper): make FSM guard violations fail closed

### DIFF
--- a/docs/audit/TLA-PPX-ADOPTION-AUDIT-2026-04.md
+++ b/docs/audit/TLA-PPX-ADOPTION-AUDIT-2026-04.md
@@ -28,7 +28,7 @@ The repo has **two TLA-related PPX systems**, with separate purposes and adoptio
 | Implementation | `ppx_tla/ppx_tla.ml` + `lib/keeper/keeper_fsm_guard_runtime.{ml,mli}` (33 + 36 LOC) |
 | Behaviour | Identity helper wrapping any value with `try assert(<expr>); v with Assert_failure -> incr counter; v` |
 | Metric | `metric_fsm_guard_violation` (`lib/prometheus.mli:293`) |
-| Runtime gate | `MASC_FSM_GUARD_ASSERT=0` disables re-raise (assert mode is default — production fails fast) |
+| Runtime gate | fail-closed: `Assert_failure` always re-raises after the violation counter increments |
 
 This is the canonical "spec-action as runtime invariant" hook documented in CLAUDE.md (`feedback_fsm_guard_identity_helper_counter_wrap_pattern`).
 

--- a/docs/observability/keeper-turn-fsm-metrics.md
+++ b/docs/observability/keeper-turn-fsm-metrics.md
@@ -101,8 +101,8 @@ The line text is stable and pinned by the `test_keeper_turn_fsm_emit` sentinel â
 `emit_transition` also classifies every `(prev, next)` pair against the
 runtime image of `KeeperTurnFSM.tla` `Next`. An edge outside the contract
 increments `masc_fsm_guard_violation_total{action="KeeperTurnFSM.Next", ...}`
-and logs `[fsm:transition:violation]`; with `MASC_FSM_GUARD_ASSERT=1` the same
-violation raises during tests/CI.
+and re-raises `Assert_failure`. `MASC_FSM_GUARD_ASSERT=0` no longer enables
+counter-only mode.
 
 ## Pulling a single turn back out
 

--- a/lib/keeper/keeper_fsm_guard_runtime.ml
+++ b/lib/keeper/keeper_fsm_guard_runtime.ml
@@ -2,24 +2,8 @@
 
    See keeper_fsm_guard_runtime.mli for the contract. *)
 
-let policy_assert_mode = ref None
-
-let read_assert_env () =
-  match Sys.getenv_opt "MASC_FSM_GUARD_ASSERT" with
-  | Some "0" | Some "false" | Some "FALSE" -> false
-  | _ -> true
-
-let assert_mode () =
-  match !policy_assert_mode with
-  | Some v -> v
-  | None ->
-      let v = read_assert_env () in
-      policy_assert_mode := Some v;
-      v
-
-(* tla-lint: allow-mutation: test hook — reset env-cached policy between tests *)
-let refresh_policy_for_test () = policy_assert_mode := None
-let assert_mode_for_test () = assert_mode ()
+let refresh_policy_for_test () = ()
+let assert_mode_for_test () = true
 
 let bump_counter ~action ~stage =
   Prometheus.inc_counter Prometheus.metric_fsm_guard_violation
@@ -27,8 +11,7 @@ let bump_counter ~action ~stage =
     ()
 
 let wrap_unit ~action ~stage thunk =
-  let hard = assert_mode () in
   try thunk ()
   with Assert_failure _ as exn ->
     bump_counter ~action ~stage;
-    if hard then raise exn else ()
+    raise exn

--- a/lib/keeper/keeper_fsm_guard_runtime.mli
+++ b/lib/keeper/keeper_fsm_guard_runtime.mli
@@ -3,18 +3,14 @@
     Cycle 43 / Tier I3 follow-up to the smoke test at
     [keeper_turn_fsm.ml:118] (PR #11377 era). The PPX
     [@@fsm_guard "<bool-expr>"] injects [assert (<bool-expr>);] into
-    the function body. On the heartbeat / task-acquisition hot paths
-    that fire every cycle, raising [Assert_failure] would crash the
-    keeper on a transient drift — undesirable in production but
-    desirable in tests.
+    the function body.
 
     [wrap_unit] runs a [unit -> unit] thunk under that contract:
     catches [Assert_failure], bumps the
     [Prometheus.metric_fsm_guard_violation] counter labelled with
-    [action] / [stage], and either re-raises (default, "assert mode")
-    or swallows the failure ([MASC_FSM_GUARD_ASSERT=0], "counter
-    mode" — for production soak periods where transient drift should
-    not crash the fleet).
+    [action] / [stage], and re-raises.  FSM contract violations are
+    fail-closed in production and tests; [MASC_FSM_GUARD_ASSERT] is no
+    longer a runtime soft-mode escape hatch.
 
     The thunk is expected to call an identity helper of return type
     [unit] (a function whose only purpose is to carry the
@@ -28,10 +24,10 @@ val wrap_unit :
   (unit -> unit) ->
   unit
 
-(** Force a re-read of [MASC_FSM_GUARD_ASSERT] for tests that need to
-    flip the policy mid-run. Production code never calls this. *)
+(** Compatibility no-op retained for older tests.  The guard policy no
+    longer reads [MASC_FSM_GUARD_ASSERT]. *)
 val refresh_policy_for_test : unit -> unit
 
-(** Inspect the cached policy. [true] iff [MASC_FSM_GUARD_ASSERT=1] at
-    module init or after [refresh_policy_for_test]. *)
+(** Always [true]: guard violations always re-raise after incrementing
+    the violation counter. *)
 val assert_mode_for_test : unit -> bool

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -33,9 +33,8 @@ let format_since_last_scheduled_autonomous = function
    honest actions of [specs/keeper-state-machine/KeeperHeartbeat.tla].
    Each helper is wrapped at the call site by
    [Keeper_fsm_guard_runtime.wrap_unit], so an [Assert_failure] from a
-   PPX-injected guard becomes a Prometheus counter increment by default
-   (counter mode) and a re-raise when [MASC_FSM_GUARD_ASSERT=1]
-   (assert mode for tests / CI). The bug-action [MissedWakeup] is
+   PPX-injected guard increments the Prometheus violation counter and
+   re-raises. The bug-action [MissedWakeup] is
    intentionally NOT instrumented — it is the failure mode these guards
    are designed to detect, not to enforce. *)
 

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -136,15 +136,13 @@ let record_execution_receipt_gap
    honest actions of [specs/keeper-state-machine/KeeperTaskAcquisition.tla].
    Each helper is wrapped at the call site by
    [Keeper_fsm_guard_runtime.wrap_unit] so an [Assert_failure] from a
-   PPX-injected guard becomes a Prometheus counter increment by default
-   (counter mode) and a re-raise when [MASC_FSM_GUARD_ASSERT=1]
-   (assert mode for tests / CI). Bug-action [TaskRejected] is NOT
+   PPX-injected guard increments the Prometheus violation counter and
+   re-raises. Bug-action [TaskRejected] is NOT
    instrumented -- it is the failure mode these guards are designed to
    detect.
 
    This pattern follows PR #11696 (Cycle 43, KeeperHeartbeat closeout)
-   which introduced [Keeper_fsm_guard_runtime] and the counter-default
-   policy. *)
+   which introduced [Keeper_fsm_guard_runtime]. *)
 
 (* AssignTask: the channel decision picks "turn" when at least one of
    [pending_mentions], [pending_board_events], or

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -556,10 +556,10 @@ val metric_keeper_lifecycle_transitions : string
 
 (** Cycle 43 (Tier I3 follow-up to fsm_guard smoke at
     [keeper_turn_fsm.ml:118]): runtime [@@fsm_guard] assert violations
-    that the [Keeper_fsm_guard_runtime.wrap_unit] caught and recovered
-    from. Bumped by the wrap helper before swallowing
-    [Assert_failure] in counter mode (default), and also bumped before
-    re-raising in assert mode ([MASC_FSM_GUARD_ASSERT=1]).
+    observed by [Keeper_fsm_guard_runtime.wrap_unit]. Bumped by the
+    wrap helper before re-raising [Assert_failure]. FSM guard
+    violations are fail-closed; [MASC_FSM_GUARD_ASSERT=0] no longer
+    enables counter-only mode.
 
     Labels: [action, stage]. [action] is the spec-action name
     ([WakeupSignal], [HeartbeatTick], [TurnComplete],

--- a/test/test_keeper_fsm_guard_actions.ml
+++ b/test/test_keeper_fsm_guard_actions.ml
@@ -10,11 +10,8 @@
     2. An honest thunk (no assert raised) leaves the counter alone.
     3. A buggy thunk (raises [Assert_failure], simulating a PPX-injected
        guard that observed a spec violation) bumps the counter by one
-       and re-raises by default (assert mode is now the default — see
-       commit "invert MASC_FSM_GUARD_ASSERT default to assert mode").
-    4. With [MASC_FSM_GUARD_ASSERT=0], the same buggy thunk is swallowed
-       after bumping the counter (counter mode opts out of re-raise so
-       hot paths like keeper heartbeats degrade gracefully).
+       and re-raises.
+    4. [MASC_FSM_GUARD_ASSERT=0] no longer enables counter-only mode.
     5. Non-[Assert_failure] exceptions propagate unchanged — only the
        spec-violation channel is intercepted. *)
 
@@ -35,8 +32,6 @@ let test_counter_constant_is_stable () =
     counter_name
 
 let test_honest_thunk_leaves_counter_alone () =
-  Unix.putenv "MASC_FSM_GUARD_ASSERT" "0";
-  G.refresh_policy_for_test ();
   let action = "TestAction" in
   let stage = "honest" in
   let before = read_count ~action ~stage in
@@ -46,25 +41,31 @@ let test_honest_thunk_leaves_counter_alone () =
     "honest thunk does not bump the counter"
     before after
 
-let test_buggy_thunk_in_counter_mode_swallows_and_bumps () =
+let test_env_zero_still_reraises_and_bumps () =
   Unix.putenv "MASC_FSM_GUARD_ASSERT" "0";
   G.refresh_policy_for_test ();
+  Alcotest.(check bool)
+    "env zero no longer disables assert mode"
+    true (G.assert_mode_for_test ());
   let action = "TestAction" in
-  let stage = "buggy_counter" in
+  let stage = "env_zero_assert" in
   let before = read_count ~action ~stage in
-  (* Should not raise — the wrapper catches Assert_failure. *)
-  G.wrap_unit ~action ~stage (fun () -> assert false);
+  let raised =
+    try
+      G.wrap_unit ~action ~stage (fun () -> assert false);
+      false
+    with Assert_failure _ -> true
+  in
   let after = read_count ~action ~stage in
+  Alcotest.(check bool)
+    "Assert_failure propagates even with env zero"
+    true raised;
   Alcotest.(check (float 0.0001))
-    "Assert_failure is caught and counter bumped by one"
+    "Assert_failure counter bumped by one before re-raise"
     (before +. 1.0) after
 
-(* Pin the contract change from commit eb6fc718b7 ("invert
-   MASC_FSM_GUARD_ASSERT default to assert mode"): when the env var is
-   unset / cleared, the policy must default to assert mode.  The
-   codebase uses [Unix.putenv NAME ""] as the unset approximation
-   (matched in [test_board_vote_quarantine.ml:17] and several siblings;
-   see the convention note there). *)
+(* [Unix.putenv NAME ""] is the repo convention for clearing env in tests
+   (matched in [test_board_vote_quarantine.ml:17] and siblings). *)
 let test_default_is_assert_mode_when_env_cleared () =
   Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
   G.refresh_policy_for_test ();
@@ -88,16 +89,15 @@ let test_default_is_assert_mode_when_env_cleared () =
     "counter is bumped before re-raise under default mode"
     (before +. 1.0) after
 
-let test_buggy_thunk_in_assert_mode_reraises () =
+let test_buggy_thunk_reraises () =
   Unix.putenv "MASC_FSM_GUARD_ASSERT" "1";
   G.refresh_policy_for_test ();
   Alcotest.(check bool)
-    "policy is now assert mode"
+    "policy remains assert mode"
     true (G.assert_mode_for_test ());
   let action = "TestAction" in
   let stage = "buggy_assert" in
   let before = read_count ~action ~stage in
-  (* Should raise — assert mode bumps then re-raises. *)
   let raised =
     try
       G.wrap_unit ~action ~stage (fun () -> assert false);
@@ -116,8 +116,6 @@ let test_buggy_thunk_in_assert_mode_reraises () =
   G.refresh_policy_for_test ()
 
 let test_non_assert_exception_propagates_unchanged () =
-  Unix.putenv "MASC_FSM_GUARD_ASSERT" "0";
-  G.refresh_policy_for_test ();
   let action = "TestAction" in
   let stage = "non_assert" in
   let before = read_count ~action ~stage in
@@ -136,16 +134,22 @@ let test_non_assert_exception_propagates_unchanged () =
     before after
 
 let test_distinct_action_label_isolation () =
-  Unix.putenv "MASC_FSM_GUARD_ASSERT" "0";
-  G.refresh_policy_for_test ();
   let stage = "iso" in
   let action_a = "ActionA" in
   let action_b = "ActionB" in
   let a_before = read_count ~action:action_a ~stage in
   let b_before = read_count ~action:action_b ~stage in
-  G.wrap_unit ~action:action_a ~stage (fun () -> assert false);
+  let raised =
+    try
+      G.wrap_unit ~action:action_a ~stage (fun () -> assert false);
+      false
+    with Assert_failure _ -> true
+  in
   let a_after = read_count ~action:action_a ~stage in
   let b_after = read_count ~action:action_b ~stage in
+  Alcotest.(check bool)
+    "action A violation re-raises"
+    true raised;
   Alcotest.(check (float 0.0001))
     "action A counter bumped"
     (a_before +. 1.0) a_after;
@@ -160,20 +164,20 @@ let () =
       test_case "name matches documented series" `Quick
         test_counter_constant_is_stable;
     ];
-    "counter mode (MASC_FSM_GUARD_ASSERT=0)", [
+    "fail closed", [
       test_case "honest thunk does not bump" `Quick
         test_honest_thunk_leaves_counter_alone;
-      test_case "buggy thunk swallows + bumps" `Quick
-        test_buggy_thunk_in_counter_mode_swallows_and_bumps;
+      test_case "env zero still re-raises + bumps" `Quick
+        test_env_zero_still_reraises_and_bumps;
       test_case "non-assert exception propagates" `Quick
         test_non_assert_exception_propagates_unchanged;
       test_case "action label isolation" `Quick
         test_distinct_action_label_isolation;
     ];
-    "assert mode (default + MASC_FSM_GUARD_ASSERT=1)", [
+    "assert mode", [
       test_case "default with cleared env is assert mode" `Quick
         test_default_is_assert_mode_when_env_cleared;
       test_case "buggy thunk re-raises after bumping" `Quick
-        test_buggy_thunk_in_assert_mode_reraises;
+        test_buggy_thunk_reraises;
     ];
   ]

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -15,6 +15,7 @@
 
 open Masc_mcp
 module F = Keeper_turn_fsm
+module P = Prometheus
 
 (* ── Compile-time signature anchor ─────────────────────────── *)
 
@@ -136,6 +137,35 @@ let test_invalid_transition_rejected () =
     Alcotest.failf
       "Idle -> Done unexpectedly classified as %s"
       (F.transition_action_label action)
+;;
+
+let read_fsm_guard_count ~stage =
+  P.metric_value_or_zero P.metric_fsm_guard_violation
+    ~labels:[ "action", "KeeperTurnFSM.Next"; "stage", stage ]
+    ()
+
+let test_invalid_emit_transition_fails_closed_and_bumps_counter () =
+  let stage = "idle->done" in
+  let before = read_fsm_guard_count ~stage in
+  let raised =
+    try
+      F.emit_transition
+        ~keeper_name:"alice"
+        ~turn_id:13457
+        ~prev:F.Idle
+        F.Done;
+      false
+    with Assert_failure _ -> true
+  in
+  let after = read_fsm_guard_count ~stage in
+  Alcotest.(check bool)
+    "invalid emit_transition re-raises"
+    true
+    raised;
+  Alcotest.(check (float 0.0001))
+    "invalid emit_transition bumps fsm guard counter"
+    (before +. 1.0)
+    after
 ;;
 
 let test_stop_signaled_blocks_forward_transitions () =
@@ -323,6 +353,10 @@ let () =
             "invalid transition rejected"
             `Quick
             test_invalid_transition_rejected
+        ; Alcotest.test_case
+            "invalid emit_transition fails closed and bumps counter"
+            `Quick
+            test_invalid_emit_transition_fails_closed_and_bumps_counter
         ; Alcotest.test_case
             "stop_signaled blocks forward transitions"
             `Quick


### PR DESCRIPTION
Summary:
- remove MASC_FSM_GUARD_ASSERT=0 counter-mode behavior from the FSM guard runtime
- keep the guard violation counter but always re-raise Assert_failure
- update tests, docs, and call-site comments to the fail-closed contract
- add a real KeeperTurnFSM.emit_transition invalid-edge regression that proves the guard counter bumps before fail-closed re-raise

Fixes #13457

Validation:
- git diff --check
- ocamlc -stop-after parsing lib/keeper/keeper_fsm_guard_runtime.ml lib/keeper/keeper_fsm_guard_runtime.mli lib/keeper/keeper_turn_helpers.ml lib/keeper/keeper_keepalive_signal.ml test/test_keeper_fsm_guard_actions.ml test/test_keeper_turn_fsm_emit.ml
- scripts/dune-local.sh build test/test_keeper_fsm_guard_actions.exe test/test_keeper_turn_fsm_emit.exe
- ./_build/default/test/test_keeper_fsm_guard_actions.exe
- ./_build/default/test/test_keeper_turn_fsm_emit.exe