### PR TITLE
feat(dashboard): add board message focus surfaces

### DIFF
--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -48,11 +48,11 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'partial' },
   { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'partial' },
 
-  // Comms Plane: board, mention inbox, and state-block messages have production coverage; room/composer zones remain partial.
+  // Comms Plane: board and message focus surfaces have production coverage; composer zones remain partial.
   { mode: 'comms', aliases: ['bd-feed', 'board-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'workspace', params: { section: 'board', focus: 'thread' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'workspace', params: { section: 'board', focus: 'automation' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-rm', 'messages-room'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-room' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['ms-rm', 'messages-room'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-room' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'workspace', params: { section: 'board', focus: 'mention-inbox' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'workspace', params: { section: 'board', focus: 'state-block' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'partial' },

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -48,13 +48,13 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'partial' },
   { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'partial' },
 
-  // Comms Plane: board and mention inbox have production coverage; room/composer zones remain partial.
+  // Comms Plane: board, mention inbox, and state-block messages have production coverage; room/composer zones remain partial.
   { mode: 'comms', aliases: ['bd-feed', 'board-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'workspace', params: { section: 'board', focus: 'thread' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'workspace', params: { section: 'board', focus: 'automation' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-rm', 'messages-room'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-room' } }, coverage: 'partial' },
   { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'workspace', params: { section: 'board', focus: 'mention-inbox' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'workspace', params: { section: 'board', focus: 'state-block' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'workspace', params: { section: 'board', focus: 'state-block' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'partial' },
   { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'partial' },
   { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'partial' },

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -48,12 +48,12 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'partial' },
   { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'partial' },
 
-  // Comms Plane: board has production coverage; room/composer zones remain partial.
+  // Comms Plane: board and mention inbox have production coverage; room/composer zones remain partial.
   { mode: 'comms', aliases: ['bd-feed', 'board-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'workspace', params: { section: 'board', focus: 'thread' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'workspace', params: { section: 'board', focus: 'automation' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-rm', 'messages-room'], target: { tab: 'workspace', params: { section: 'board', focus: 'messages-room' } }, coverage: 'partial' },
-  { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'workspace', params: { section: 'board', focus: 'mention-inbox' } }, coverage: 'partial' },
+  { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'workspace', params: { section: 'board', focus: 'mention-inbox' } }, coverage: 'covered' },
   { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'workspace', params: { section: 'board', focus: 'state-block' } }, coverage: 'partial' },
   { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'partial' },
   { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'partial' },

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -244,6 +244,16 @@ describe('BoardSurface Component', () => {
     expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
+  it('routes the message room focus to the room timeline surface', () => {
+    route.value = { params: { focus: 'messages-room' } } as any
+    messages.value = [{ id: 'm-room', from: 'sangsu', room: 'ops', content: 'room update' }]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByRole('heading', { name: 'Room timeline' })).toBeInTheDocument()
+    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
+  })
+
   it('routes the state-block focus to the message surface', () => {
     route.value = { params: { focus: 'state-block' } } as any
     messages.value = [{ id: 'm-state', from: 'sangsu', content: '[STATE]\nGoal: keep context\n[/STATE]' }]

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -244,6 +244,16 @@ describe('BoardSurface Component', () => {
     expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
+  it('routes the state-block focus to the message surface', () => {
+    route.value = { params: { focus: 'state-block' } } as any
+    messages.value = [{ id: 'm-state', from: 'sangsu', content: '[STATE]\nGoal: keep context\n[/STATE]' }]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByRole('heading', { name: 'State-block messages' })).toBeInTheDocument()
+    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
+  })
+
   it('hides system posts by default', () => {
     boardPosts.value = [
       makePost({

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -2,7 +2,7 @@ import { h } from 'preact'
 import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { BoardSurface } from './board-surface'
-import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore } from '../../store'
+import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore, messages, shellAuthSummary } from '../../store'
 import { route } from '../../router'
 import { PAGE_SIZE, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
 import type { BoardPost } from '../../types'
@@ -168,6 +168,8 @@ describe('BoardSurface Component', () => {
       notice: PAGE_SIZE,
       system: PAGE_SIZE,
     }
+    messages.value = []
+    shellAuthSummary.value = null
     route.value = { params: {} } as any
   })
 
@@ -230,6 +232,16 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(screen.getByRole('button', { name: '🔥 리액션 2개' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('routes the mention inbox focus to the message surface', () => {
+    route.value = { params: { focus: 'mention-inbox' } } as any
+    messages.value = [{ id: 'm-1', from: 'sojin', content: '@dashboard needs review' }]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByRole('heading', { name: 'Mention inbox' })).toBeInTheDocument()
+    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
   it('hides system posts by default', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -16,6 +16,7 @@ import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
 import { registerBoardHearthsRefresh } from '../../sse-store'
+import { MessageRoomTimeline } from './message-room-timeline'
 import { MentionInbox } from './mention-inbox'
 import { PostDetail } from './post-detail'
 import { ReactionBar } from './reaction-bar'
@@ -735,6 +736,15 @@ export function BoardSurface() {
       <div>
         <${BoardSummary} />
         <${MentionInbox} />
+      </div>
+    `
+  }
+
+  if (focus === 'messages-room') {
+    return html`
+      <div>
+        <${BoardSummary} />
+        <${MessageRoomTimeline} />
       </div>
     `
   }

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -19,6 +19,7 @@ import { registerBoardHearthsRefresh } from '../../sse-store'
 import { MentionInbox } from './mention-inbox'
 import { PostDetail } from './post-detail'
 import { ReactionBar } from './reaction-bar'
+import { StateBlockMessages } from './state-block-messages'
 import {
   boardActorAvatarKey,
   boardActorDisplayName,
@@ -734,6 +735,15 @@ export function BoardSurface() {
       <div>
         <${BoardSummary} />
         <${MentionInbox} />
+      </div>
+    `
+  }
+
+  if (focus === 'state-block') {
+    return html`
+      <div>
+        <${BoardSummary} />
+        <${StateBlockMessages} />
       </div>
     `
   }

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -16,6 +16,7 @@ import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
 import { registerBoardHearthsRefresh } from '../../sse-store'
+import { MentionInbox } from './mention-inbox'
 import { PostDetail } from './post-detail'
 import { ReactionBar } from './reaction-bar'
 import {
@@ -698,6 +699,7 @@ export function BoardSurface() {
   const grouped = splitVisiblePosts(filteredPosts)
   const posts = grouped.groups.flatMap(g => g.posts)
   const hint = filterHint(grouped)
+  const focus = route.value.params.focus ?? null
   const postId = route.value.params.post ?? null
   const post = postId
     ? posts.find(row => row.id === postId) ?? (detailPostId.value === postId ? detailPost.value : null)
@@ -725,6 +727,15 @@ export function BoardSurface() {
               : html`<${EmptyState} message="글을 찾지 못했습니다" compact />`}
           </div>
         `
+  }
+
+  if (focus === 'mention-inbox') {
+    return html`
+      <div>
+        <${BoardSummary} />
+        <${MentionInbox} />
+      </div>
+    `
   }
 
   return html`

--- a/dashboard/src/components/board/mention-inbox.test.ts
+++ b/dashboard/src/components/board/mention-inbox.test.ts
@@ -1,0 +1,108 @@
+import { h } from 'preact'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { MentionInbox, buildMentionInboxModel, extractMentionTargets, mentionTargetCandidates } from './mention-inbox'
+import { messages, shellAuthSummary } from '../../store'
+import type { DashboardShellAuthSummary, Message } from '../../types'
+
+import '@testing-library/jest-dom'
+
+function auth(overrides: Partial<DashboardShellAuthSummary> = {}): DashboardShellAuthSummary {
+  return {
+    enabled: true,
+    require_token: false,
+    default_role: null,
+    token_present: true,
+    token_valid: true,
+    token_agent: 'dashboard',
+    requested_agent: null,
+    effective_agent: 'dashboard',
+    effective_role: 'admin',
+    auth_error_code: null,
+    auth_error_detail: null,
+    can_keeper_msg: true,
+    keeper_msg_error: null,
+    ...overrides,
+  }
+}
+
+function message(overrides: Partial<Message> & { content: string }): Message {
+  const { content, ...rest } = overrides
+  return {
+    from: 'keeper',
+    content,
+    timestamp: '2026-05-06T03:00:00Z',
+    ...rest,
+  }
+}
+
+describe('mention inbox helpers', () => {
+  it('extracts unique @targets without treating emails as mentions', () => {
+    expect(extractMentionTargets('ping @dashboard and @sangsu, not user@example.com, again @dashboard')).toEqual([
+      'dashboard',
+      'sangsu',
+    ])
+  })
+
+  it('builds for-me and other mention lanes from execution messages', () => {
+    const model = buildMentionInboxModel(
+      [
+        message({ id: 'plain', content: 'plain broadcast' }),
+        message({ id: 'mine', content: '@dashboard please inspect', seq: 2 }),
+        message({ id: 'other', content: '@sangsu has context', seq: 3 }),
+        message({ id: 'typed', type: 'message.mentioned', content: 'explicit event without target', seq: 4 }),
+      ],
+      ['dashboard'],
+    )
+
+    expect(model.forMe.map(row => row.message.id)).toEqual(['mine'])
+    expect(model.others.map(row => row.message.id)).toEqual(['typed', 'other'])
+  })
+
+  it('deduplicates auth and actor aliases as current mention targets', () => {
+    expect(mentionTargetCandidates(auth({ token_agent: 'DASHBOARD', effective_agent: 'dashboard' }), 'dashboard')).toEqual([
+      'dashboard',
+      'operator',
+    ])
+  })
+})
+
+describe('MentionInbox', () => {
+  afterEach(() => {
+    cleanup()
+    messages.value = []
+    shellAuthSummary.value = null
+  })
+
+  beforeEach(() => {
+    messages.value = []
+    shellAuthSummary.value = auth()
+  })
+
+  it('renders separate for-me and other mention lanes', () => {
+    messages.value = [
+      message({ id: 'm-1', from: 'sojin', content: '@dashboard review this' }),
+      message({ id: 'm-2', from: 'ani', content: '@sangsu I left notes' }),
+    ]
+
+    render(h(MentionInbox, null))
+
+    expect(screen.getByRole('heading', { name: 'Mention inbox' })).toBeInTheDocument()
+    expect(screen.getByLabelText('For me')).toHaveTextContent('@dashboard')
+    expect(screen.getByLabelText('Other mentions')).toHaveTextContent('@sangsu')
+  })
+
+  it('marks messages carrying state blocks', () => {
+    messages.value = [
+      message({
+        id: 'm-state',
+        content: '@dashboard [STATE]\nGoal: land C2 mention inbox\n[/STATE]\nready',
+      }),
+    ]
+
+    render(h(MentionInbox, null))
+
+    expect(screen.getByText('STATE')).toBeInTheDocument()
+    expect(screen.queryByText('Goal: land C2 mention inbox')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/board/mention-inbox.ts
+++ b/dashboard/src/components/board/mention-inbox.ts
@@ -1,0 +1,243 @@
+import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+import { ArrowLeft, AtSign } from 'lucide-preact'
+import { ActionButton } from '../common/button'
+import { EmptyState } from '../common/empty-state'
+import { RichContent } from '../common/rich-content'
+import { TimeAgo } from '../common/time-ago'
+import { stripStateBlocks } from '../../keeper-message'
+import { currentDashboardActorName } from '../../lib/dashboard-session-actor'
+import { navigate } from '../../router'
+import { messages, shellAuthSummary } from '../../store'
+import type { DashboardShellAuthSummary, Message } from '../../types'
+
+interface MentionInboxRow {
+  message: Message
+  mentionTargets: string[]
+  isForMe: boolean
+  index: number
+  timestampMs: number | null
+}
+
+export interface MentionInboxModel {
+  forMe: MentionInboxRow[]
+  others: MentionInboxRow[]
+}
+
+const MENTION_RE = /(^|[^A-Za-z0-9._-])@([A-Za-z0-9._-]{1,64})/g
+
+function normalizeTarget(value: string | null | undefined): string | null {
+  const normalized = value?.trim().replace(/^@+/, '').toLowerCase()
+  return normalized || null
+}
+
+export function extractMentionTargets(content: string): string[] {
+  const seen = new Set<string>()
+  const targets: string[] = []
+  for (const match of content.matchAll(MENTION_RE)) {
+    const target = match[2]
+    if (!target) continue
+    const key = normalizeTarget(target)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    targets.push(target)
+  }
+  return targets
+}
+
+export function mentionTargetCandidates(
+  auth: DashboardShellAuthSummary | null,
+  actorName: string,
+): string[] {
+  const values = [
+    auth?.effective_agent,
+    auth?.token_agent,
+    auth?.requested_agent,
+    actorName,
+    'dashboard',
+    'operator',
+  ]
+  const seen = new Set<string>()
+  const targets: string[] = []
+  for (const value of values) {
+    const key = normalizeTarget(value)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    targets.push(key)
+  }
+  return targets
+}
+
+function messageTimestampMs(message: Message): number | null {
+  if (!message.timestamp) return null
+  const parsed = Date.parse(message.timestamp)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function messageMentions(message: Message): boolean {
+  return extractMentionTargets(message.content).length > 0 || message.type?.toLowerCase().includes('mention') === true
+}
+
+export function buildMentionInboxModel(
+  messageList: readonly Message[],
+  currentTargets: readonly string[],
+): MentionInboxModel {
+  const targetSet = new Set(
+    currentTargets
+      .map(normalizeTarget)
+      .filter((target): target is string => target !== null),
+  )
+  const rows = messageList
+    .map((message, index): MentionInboxRow | null => {
+      if (!messageMentions(message)) return null
+      const mentionTargets = extractMentionTargets(message.content)
+      const isForMe = mentionTargets.some(target => {
+        const key = normalizeTarget(target)
+        return key ? targetSet.has(key) : false
+      })
+      return {
+        message,
+        mentionTargets,
+        isForMe,
+        index,
+        timestampMs: messageTimestampMs(message),
+      }
+    })
+    .filter((row): row is MentionInboxRow => row !== null)
+    .sort((left, right) => {
+      if (left.timestampMs !== null && right.timestampMs !== null && left.timestampMs !== right.timestampMs) {
+        return right.timestampMs - left.timestampMs
+      }
+      if (left.message.seq !== undefined && right.message.seq !== undefined && left.message.seq !== right.message.seq) {
+        return right.message.seq - left.message.seq
+      }
+      return right.index - left.index
+    })
+
+  return {
+    forMe: rows.filter(row => row.isForMe),
+    others: rows.filter(row => !row.isForMe),
+  }
+}
+
+function previewContent(message: Message): string {
+  return stripStateBlocks(message.content).trim() || message.content.trim() || '(empty)'
+}
+
+function rowKey(row: MentionInboxRow): string {
+  return row.message.id ?? `${row.message.seq ?? 'message'}-${row.index}`
+}
+
+function MessageRow({ row }: { row: MentionInboxRow }) {
+  const preview = previewContent(row.message)
+  const hasState = row.message.content.includes('[STATE]')
+  return html`
+    <article class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3.5 py-3">
+      <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? 'system'}</span>
+        ${row.message.timestamp
+          ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${row.message.timestamp} /></span>`
+          : null}
+        ${row.message.type
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-0.5 text-3xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${row.message.type}</span>`
+          : null}
+        ${hasState
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-accent-soft)] bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-medium text-[var(--color-accent-fg)]">STATE</span>`
+          : null}
+      </div>
+      <div class="mt-2 text-sm leading-paragraph text-[var(--color-fg-primary)]">
+        <${RichContent} text=${preview} previewLimit=${2} />
+      </div>
+      ${row.mentionTargets.length > 0
+        ? html`
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              ${row.mentionTargets.map(target => html`
+                <span class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-muted)]" key=${target}>
+                  <${AtSign} size=${11} aria-hidden="true" />
+                  @${target}
+                </span>
+              `)}
+            </div>
+          `
+        : null}
+    </article>
+  `
+}
+
+function MentionLane({
+  title,
+  rows,
+  emptyMessage,
+}: {
+  title: string
+  rows: MentionInboxRow[]
+  emptyMessage: string
+}) {
+  return html`
+    <section class="min-w-0" aria-label=${title}>
+      <div class="mb-2 flex items-center justify-between gap-2">
+        <h3 class="text-sm font-semibold text-[var(--color-fg-secondary)]">${title}</h3>
+        <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2 py-0.5 text-3xs font-medium tabular-nums text-[var(--color-fg-muted)]">${rows.length}</span>
+      </div>
+      ${rows.length === 0
+        ? html`<${EmptyState} message=${emptyMessage} compact />`
+        : html`<div class="grid gap-2.5">${rows.map(row => html`<${MessageRow} key=${rowKey(row)} row=${row} />`)}</div>`}
+    </section>
+  `
+}
+
+export function MentionInbox() {
+  const actorName = currentDashboardActorName()
+  const targetCandidates = mentionTargetCandidates(shellAuthSummary.value, actorName)
+  const targetKey = targetCandidates.join('|')
+  const model = useMemo(
+    () => buildMentionInboxModel(messages.value, targetCandidates),
+    [targetKey, messages.value],
+  )
+  const total = model.forMe.length + model.others.length
+
+  return html`
+    <section class="grid gap-4" aria-labelledby="mention-inbox-heading">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Messages</div>
+          <h2 id="mention-inbox-heading" class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">Mention inbox</h2>
+        </div>
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          class="inline-flex items-center gap-1.5"
+          onClick=${() => navigate('workspace', { section: 'board' })}
+          ariaLabel="게시판으로 돌아가기"
+        >
+          <${ArrowLeft} size=${14} aria-hidden="true" />
+          Board
+        <//>
+      </div>
+
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-2">
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">For me</div>
+          <div class="mt-1 text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${model.forMe.length}</div>
+        </div>
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Other mentions</div>
+          <div class="mt-1 text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${model.others.length}</div>
+        </div>
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Targets</div>
+          <div class="mt-1 truncate text-sm font-semibold text-[var(--color-fg-primary)]">${targetCandidates.map(target => `@${target}`).join(', ')}</div>
+        </div>
+      </div>
+
+      ${total === 0
+        ? html`<${EmptyState} message="멘션 메시지가 없습니다" compact />`
+        : html`
+            <div class="grid gap-4 xl:grid-cols-2">
+              <${MentionLane} title="For me" rows=${model.forMe} emptyMessage="현재 actor 대상 멘션이 없습니다" />
+              <${MentionLane} title="Other mentions" rows=${model.others} emptyMessage="다른 대상 멘션이 없습니다" />
+            </div>
+          `}
+    </section>
+  `
+}

--- a/dashboard/src/components/board/message-room-timeline.test.ts
+++ b/dashboard/src/components/board/message-room-timeline.test.ts
@@ -1,0 +1,69 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MessageRoomTimeline, buildMessageRoomModel } from './message-room-timeline'
+import { messages } from '../../store'
+import type { Message } from '../../types'
+
+import '@testing-library/jest-dom'
+
+function message(overrides: Partial<Message> & { content: string }): Message {
+  const { content, ...rest } = overrides
+  return {
+    from: 'keeper',
+    content,
+    timestamp: '2026-05-06T03:00:00Z',
+    ...rest,
+  }
+}
+
+describe('message room timeline helpers', () => {
+  it('groups messages by room and defaults roomless payloads to execution', () => {
+    const model = buildMessageRoomModel([
+      message({ id: 'm-1', room: 'ops', content: 'ops note', seq: 2 }),
+      message({ id: 'm-2', content: 'runtime note', seq: 1 }),
+      message({ id: 'm-3', room: '#ops', content: '@dashboard [STATE]\nGoal: ship\n[/STATE]', seq: 3 }),
+    ])
+
+    expect(model.rooms.map(room => room.room)).toEqual(['execution', 'ops'])
+    expect(model.rooms.find(room => room.room === 'ops')?.rows.map(row => row.message.id)).toEqual(['m-1', 'm-3'])
+    expect(model.totalMentions).toBe(1)
+    expect(model.totalStateBlocks).toBe(1)
+  })
+})
+
+describe('MessageRoomTimeline', () => {
+  afterEach(() => {
+    cleanup()
+    messages.value = []
+  })
+
+  it('renders room tabs and switches the visible timeline', async () => {
+    messages.value = [
+      message({ id: 'm-1', room: 'ops', from: 'sojin', content: 'ops first', seq: 1 }),
+      message({ id: 'm-2', room: 'review', from: 'ani', content: '@dashboard review needed', seq: 2 }),
+    ]
+
+    render(h(MessageRoomTimeline, null))
+
+    expect(screen.getByRole('heading', { name: 'Room timeline' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /#ops/ })).toHaveAttribute('aria-selected', 'true')
+    expect(await screen.findByText('ops first')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /#review/ }))
+
+    expect(screen.getByRole('tab', { name: /#review/ })).toHaveAttribute('aria-selected', 'true')
+    expect(await screen.findByText(/review needed/)).toBeInTheDocument()
+    expect(screen.getByText('@dashboard')).toBeInTheDocument()
+  })
+
+  it('shows state counts on timeline rows', () => {
+    messages.value = [
+      message({ id: 'm-state', room: 'ops', content: '[STATE]\nGoal: keep context\n[/STATE]', seq: 1 }),
+    ]
+
+    render(h(MessageRoomTimeline, null))
+
+    expect(screen.getByText('STATE 1')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/board/message-room-timeline.ts
+++ b/dashboard/src/components/board/message-room-timeline.ts
@@ -1,0 +1,216 @@
+import { html } from 'htm/preact'
+import { useMemo, useState } from 'preact/hooks'
+import { ArrowLeft, AtSign, Braces } from 'lucide-preact'
+import { ActionButton } from '../common/button'
+import { EmptyState } from '../common/empty-state'
+import { RichContent } from '../common/rich-content'
+import { TimeAgo } from '../common/time-ago'
+import { stripStateBlocks } from '../../keeper-message'
+import { navigate } from '../../router'
+import { messages } from '../../store'
+import type { Message } from '../../types'
+import { extractMentionTargets } from './mention-inbox'
+import { extractStateBlocks } from './state-block-messages'
+
+interface TimelineRow {
+  message: Message
+  index: number
+  timestampMs: number | null
+  mentionTargets: string[]
+  stateBlockCount: number
+}
+
+interface RoomBucket {
+  room: string
+  rows: TimelineRow[]
+}
+
+export interface MessageRoomModel {
+  rooms: RoomBucket[]
+  totalMessages: number
+  totalMentions: number
+  totalStateBlocks: number
+}
+
+function normalizeRoom(value: string | null | undefined): string {
+  const room = value?.trim().replace(/^#+/, '')
+  return room || 'execution'
+}
+
+function messageTimestampMs(message: Message): number | null {
+  if (!message.timestamp) return null
+  const parsed = Date.parse(message.timestamp)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function timelineSort(left: TimelineRow, right: TimelineRow): number {
+  if (left.timestampMs !== null && right.timestampMs !== null && left.timestampMs !== right.timestampMs) {
+    return left.timestampMs - right.timestampMs
+  }
+  if (left.message.seq !== undefined && right.message.seq !== undefined && left.message.seq !== right.message.seq) {
+    return left.message.seq - right.message.seq
+  }
+  return left.index - right.index
+}
+
+export function buildMessageRoomModel(messageList: readonly Message[]): MessageRoomModel {
+  const byRoom = new Map<string, TimelineRow[]>()
+  let totalMentions = 0
+  let totalStateBlocks = 0
+
+  messageList.forEach((message, index) => {
+    const mentionTargets = extractMentionTargets(message.content)
+    const stateBlockCount = extractStateBlocks(message.content).length
+    totalMentions += mentionTargets.length
+    totalStateBlocks += stateBlockCount
+    const room = normalizeRoom(message.room)
+    const rows = byRoom.get(room) ?? []
+    rows.push({
+      message,
+      index,
+      timestampMs: messageTimestampMs(message),
+      mentionTargets,
+      stateBlockCount,
+    })
+    byRoom.set(room, rows)
+  })
+
+  const rooms = Array.from(byRoom.entries())
+    .map(([room, rows]) => ({ room, rows: rows.sort(timelineSort) }))
+    .sort((left, right) => {
+      if (left.room === 'execution') return -1
+      if (right.room === 'execution') return 1
+      return left.room.localeCompare(right.room)
+    })
+
+  return {
+    rooms,
+    totalMessages: messageList.length,
+    totalMentions,
+    totalStateBlocks,
+  }
+}
+
+function previewContent(message: Message): string {
+  return stripStateBlocks(message.content).trim() || message.content.trim() || '(empty)'
+}
+
+function rowKey(row: TimelineRow): string {
+  return row.message.id ?? `${row.message.seq ?? 'message'}-${row.index}`
+}
+
+function TimelineMessage({ row }: { row: TimelineRow }) {
+  const preview = previewContent(row.message)
+  return html`
+    <article class="grid grid-cols-[3rem_minmax(0,1fr)] gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3.5 py-3">
+      <div class="pt-0.5 text-right text-3xs font-semibold tabular-nums uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+        ${row.message.seq !== undefined ? `#${row.message.seq}` : row.index + 1}
+      </div>
+      <div class="min-w-0">
+        <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+          <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? 'system'}</span>
+          ${row.message.timestamp
+            ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${row.message.timestamp} /></span>`
+            : null}
+          ${row.message.type
+            ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-0.5 text-3xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${row.message.type}</span>`
+            : null}
+          ${row.stateBlockCount > 0
+            ? html`
+                <span class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-accent-soft)] bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-medium text-[var(--color-accent-fg)]">
+                  <${Braces} size=${11} aria-hidden="true" />
+                  STATE ${row.stateBlockCount}
+                </span>
+              `
+            : null}
+        </div>
+        <div class="mt-2 text-sm leading-paragraph text-[var(--color-fg-primary)]">
+          <${RichContent} text=${preview} previewLimit=${2} />
+        </div>
+        ${row.mentionTargets.length > 0
+          ? html`
+              <div class="mt-2 flex flex-wrap gap-1.5">
+                ${row.mentionTargets.map(target => html`
+                  <span class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-muted)]" key=${target}>
+                    <${AtSign} size=${11} aria-hidden="true" />
+                    @${target}
+                  </span>
+                `)}
+              </div>
+            `
+          : null}
+      </div>
+    </article>
+  `
+}
+
+export function MessageRoomTimeline() {
+  const model = useMemo(() => buildMessageRoomModel(messages.value), [messages.value])
+  const [selectedRoom, setSelectedRoom] = useState<string | null>(null)
+  const activeRoom = model.rooms.some(room => room.room === selectedRoom)
+    ? selectedRoom
+    : model.rooms[0]?.room ?? null
+  const active = activeRoom ? model.rooms.find(room => room.room === activeRoom) ?? null : null
+
+  return html`
+    <section class="grid gap-4" aria-labelledby="message-room-timeline-heading">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Messages</div>
+          <h2 id="message-room-timeline-heading" class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">Room timeline</h2>
+        </div>
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          class="inline-flex items-center gap-1.5"
+          onClick=${() => navigate('workspace', { section: 'board' })}
+          ariaLabel="게시판으로 돌아가기"
+        >
+          <${ArrowLeft} size=${14} aria-hidden="true" />
+          Board
+        <//>
+      </div>
+
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-2">
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Rooms</div>
+          <div class="mt-1 text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${model.rooms.length}</div>
+        </div>
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Messages</div>
+          <div class="mt-1 text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${model.totalMessages}</div>
+        </div>
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Signals</div>
+          <div class="mt-1 text-sm font-semibold tabular-nums text-[var(--color-fg-primary)]">${model.totalMentions} mentions · ${model.totalStateBlocks} state</div>
+        </div>
+      </div>
+
+      ${model.rooms.length === 0
+        ? html`<${EmptyState} message="메시지 타임라인이 없습니다" compact />`
+        : html`
+            <div class="flex flex-wrap gap-2" role="tablist" aria-label="Message rooms">
+              ${model.rooms.map(room => html`
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected=${room.room === activeRoom}
+                  class=${`rounded-[var(--r-1)] border px-3 py-1.5 text-xs font-medium transition-colors ${
+                    room.room === activeRoom
+                      ? 'border-[var(--color-accent)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
+                      : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
+                  }`}
+                  onClick=${() => setSelectedRoom(room.room)}
+                >
+                  #${room.room}
+                  <span class="ml-2 text-3xs tabular-nums opacity-70">${room.rows.length}</span>
+                </button>
+              `)}
+            </div>
+            <section role="tabpanel" aria-label=${active ? `#${active.room} timeline` : 'Message timeline'} class="grid gap-2.5">
+              ${active?.rows.map(row => html`<${TimelineMessage} key=${rowKey(row)} row=${row} />`)}
+            </section>
+          `}
+    </section>
+  `
+}

--- a/dashboard/src/components/board/state-block-messages.test.ts
+++ b/dashboard/src/components/board/state-block-messages.test.ts
@@ -1,0 +1,84 @@
+import { h } from 'preact'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import { StateBlockMessages, buildStateBlockRows, extractStateBlocks, stateBlockFields } from './state-block-messages'
+import { messages } from '../../store'
+import type { Message } from '../../types'
+
+import '@testing-library/jest-dom'
+
+function message(overrides: Partial<Message> & { content: string }): Message {
+  const { content, ...rest } = overrides
+  return {
+    from: 'keeper',
+    content,
+    timestamp: '2026-05-06T03:00:00Z',
+    ...rest,
+  }
+}
+
+describe('state block message helpers', () => {
+  it('extracts complete state blocks from message content', () => {
+    expect(extractStateBlocks('hello [STATE]\nGoal: ship\nNext: verify\n[/STATE] bye')).toEqual([
+      'Goal: ship\nNext: verify',
+    ])
+  })
+
+  it('ignores incomplete state blocks', () => {
+    expect(extractStateBlocks('hello [STATE]\nGoal: missing end')).toEqual([])
+  })
+
+  it('parses state block fields into label/value rows', () => {
+    expect(stateBlockFields('Goal: ship\nProgress: 80%\nloose line\nNext: review')).toEqual([
+      { label: 'Goal', value: 'ship' },
+      { label: 'Progress', value: '80%' },
+      { label: 'Next', value: 'review' },
+    ])
+  })
+
+  it('builds newest-first rows and strips messages without state payloads', () => {
+    const rows = buildStateBlockRows([
+      message({ id: 'plain', content: 'plain text', seq: 1 }),
+      message({ id: 'old', content: '[STATE]\nGoal: older\n[/STATE]', seq: 2, timestamp: '2026-05-06T02:00:00Z' }),
+      message({ id: 'new', content: '[STATE]\nGoal: newer\n[/STATE]', seq: 3, timestamp: '2026-05-06T04:00:00Z' }),
+    ])
+
+    expect(rows.map(row => row.message.id)).toEqual(['new', 'old'])
+    expect(rows[0]?.fields).toEqual([{ label: 'Goal', value: 'newer' }])
+  })
+})
+
+describe('StateBlockMessages', () => {
+  afterEach(() => {
+    cleanup()
+    messages.value = []
+  })
+
+  it('renders state payloads separately from the human preview', async () => {
+    messages.value = [
+      message({
+        id: 'state-1',
+        from: 'nick0cave',
+        seq: 8,
+        content: 'status changed\n[STATE]\nGoal: restore room\nNext: notify sangsu\n[/STATE]\nready',
+      }),
+    ]
+
+    render(h(StateBlockMessages, null))
+
+    expect(screen.getByRole('heading', { name: 'State-block messages' })).toBeInTheDocument()
+    expect(await screen.findByText('status changed')).toBeInTheDocument()
+    expect(screen.getByText('Goal')).toBeInTheDocument()
+    expect(screen.getByText('restore room')).toBeInTheDocument()
+    expect(screen.getByText('Next')).toBeInTheDocument()
+    expect(screen.getByText('notify sangsu')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no messages carry state blocks', () => {
+    messages.value = [message({ id: 'plain', content: '@dashboard no state here' })]
+
+    render(h(StateBlockMessages, null))
+
+    expect(screen.getByText('state block 메시지가 없습니다')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/board/state-block-messages.ts
+++ b/dashboard/src/components/board/state-block-messages.ts
@@ -1,0 +1,177 @@
+import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+import { ArrowLeft, Braces } from 'lucide-preact'
+import { ActionButton } from '../common/button'
+import { EmptyState } from '../common/empty-state'
+import { RichContent } from '../common/rich-content'
+import { TimeAgo } from '../common/time-ago'
+import { stripStateBlocks } from '../../keeper-message'
+import { navigate } from '../../router'
+import { messages } from '../../store'
+import type { Message } from '../../types'
+
+interface StateBlockRow {
+  message: Message
+  stateBlock: string
+  fields: StateBlockField[]
+  index: number
+  timestampMs: number | null
+}
+
+interface StateBlockField {
+  label: string
+  value: string
+}
+
+const STATE_BLOCK_RE = /\[STATE\]([\s\S]*?)\[\/STATE\]/g
+
+export function extractStateBlocks(content: string): string[] {
+  const blocks: string[] = []
+  for (const match of content.matchAll(STATE_BLOCK_RE)) {
+    const block = match[1]?.trim()
+    if (block) blocks.push(block)
+  }
+  return blocks
+}
+
+export function stateBlockFields(block: string): StateBlockField[] {
+  return block
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const separator = line.indexOf(':')
+      if (separator <= 0) return null
+      const label = line.slice(0, separator).trim()
+      const value = line.slice(separator + 1).trim()
+      return label && value ? { label, value } : null
+    })
+    .filter((row): row is StateBlockField => row !== null)
+}
+
+function messageTimestampMs(message: Message): number | null {
+  if (!message.timestamp) return null
+  const parsed = Date.parse(message.timestamp)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function buildStateBlockRows(messageList: readonly Message[]): StateBlockRow[] {
+  return messageList
+    .flatMap((message, index): StateBlockRow[] => {
+      const stateBlocks = extractStateBlocks(message.content)
+      if (stateBlocks.length === 0) return []
+      return stateBlocks.map(stateBlock => ({
+        message,
+        stateBlock,
+        fields: stateBlockFields(stateBlock),
+        index,
+        timestampMs: messageTimestampMs(message),
+      }))
+    })
+    .sort((left, right) => {
+      if (left.timestampMs !== null && right.timestampMs !== null && left.timestampMs !== right.timestampMs) {
+        return right.timestampMs - left.timestampMs
+      }
+      if (left.message.seq !== undefined && right.message.seq !== undefined && left.message.seq !== right.message.seq) {
+        return right.message.seq - left.message.seq
+      }
+      return right.index - left.index
+    })
+}
+
+function previewContent(message: Message): string {
+  return stripStateBlocks(message.content).trim() || '(state-only message)'
+}
+
+function rowKey(row: StateBlockRow): string {
+  return `${row.message.id ?? row.message.seq ?? row.index}-${row.stateBlock.slice(0, 24)}`
+}
+
+function StateRow({ row }: { row: StateBlockRow }) {
+  return html`
+    <article
+      role="listitem"
+      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] border-l-[3px] border-l-[var(--warn-bright)] bg-[var(--color-bg-surface)] px-3.5 py-3"
+    >
+      <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        ${row.message.seq !== undefined
+          ? html`<span class="text-3xs font-semibold tabular-nums uppercase tracking-[var(--track-caps)] text-[var(--warn-bright)]">#${row.message.seq}</span>`
+          : null}
+        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">${row.message.from ?? 'system'}</span>
+        ${row.message.timestamp
+          ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${row.message.timestamp} /></span>`
+          : null}
+        ${row.message.type
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-0.5 text-3xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${row.message.type}</span>`
+          : null}
+      </div>
+
+      <div class="mt-2 text-sm leading-paragraph text-[var(--color-fg-primary)]">
+        <${RichContent} text=${previewContent(row.message)} previewLimit=${2} />
+      </div>
+
+      <div
+        class="mt-3 rounded-[var(--r-1)] border border-[var(--color-accent-soft)] bg-[var(--accent-10)] px-3 py-3"
+        aria-label="State block"
+      >
+        <div class="mb-2 flex items-center gap-2 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">
+          <${Braces} size=${13} aria-hidden="true" />
+          STATE
+        </div>
+        ${row.fields.length > 0
+          ? html`
+              <dl class="grid gap-2 sm:grid-cols-2">
+                ${row.fields.map(field => html`
+                  <div class="min-w-0 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2" key=${field.label}>
+                    <dt class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${field.label}</dt>
+                    <dd class="mt-1 text-xs leading-paragraph text-[var(--color-fg-secondary)]">${field.value}</dd>
+                  </div>
+                `)}
+              </dl>
+            `
+          : html`<pre class="whitespace-pre-wrap break-words text-xs leading-paragraph text-[var(--color-fg-secondary)]">${row.stateBlock}</pre>`}
+      </div>
+    </article>
+  `
+}
+
+export function StateBlockMessages() {
+  const rows = useMemo(() => buildStateBlockRows(messages.value), [messages.value])
+  const sourceCount = new Set(rows.map(row => row.message.from ?? 'system')).size
+
+  return html`
+    <section class="grid gap-4" aria-labelledby="state-block-messages-heading">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Messages</div>
+          <h2 id="state-block-messages-heading" class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">State-block messages</h2>
+        </div>
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          class="inline-flex items-center gap-1.5"
+          onClick=${() => navigate('workspace', { section: 'board' })}
+          ariaLabel="게시판으로 돌아가기"
+        >
+          <${ArrowLeft} size=${14} aria-hidden="true" />
+          Board
+        <//>
+      </div>
+
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-2">
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">State blocks</div>
+          <div class="mt-1 text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${rows.length}</div>
+        </div>
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Sources</div>
+          <div class="mt-1 text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${sourceCount}</div>
+        </div>
+      </div>
+
+      ${rows.length === 0
+        ? html`<${EmptyState} message="state block 메시지가 없습니다" compact />`
+        : html`<div role="list" aria-label=${`${rows.length} state messages`} class="grid gap-2.5">${rows.map(row => html`<${StateRow} key=${rowKey(row)} row=${row} />`)}</div>`}
+    </section>
+  `
+}

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeExecutionQueueItem, normalizeExecutionSessionBrief } from './store-normalizers'
+import { normalizeExecutionQueueItem, normalizeExecutionSessionBrief, normalizeMessage } from './store-normalizers'
 
 describe('normalizeExecutionSessionBrief', () => {
   it('promotes legacy room-only payloads to namespace while keeping the room alias', () => {
@@ -75,6 +75,22 @@ describe('normalizeExecutionQueueItem', () => {
           severity: 'bad',
         },
       },
+    })
+  })
+})
+
+describe('normalizeMessage', () => {
+  it('preserves room metadata for board message room timelines', () => {
+    expect(normalizeMessage({
+      id: 'm-1',
+      from_agent: 'sangsu',
+      content: 'handoff ready',
+      room_id: 'keeper-room',
+    })).toMatchObject({
+      id: 'm-1',
+      from: 'sangsu',
+      content: 'handoff ready',
+      room: 'keeper-room',
     })
   })
 })

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -150,6 +150,7 @@ export function normalizeMessage(raw: unknown): Message | null {
   const from = asString(raw.from) ?? asString(raw.from_agent)
   const content = asString(raw.content) ?? ''
   const timestamp = asString(raw.timestamp)
+  const room = asString(raw.room) ?? asString(raw.room_id) ?? asString(raw.channel) ?? asString(raw.channel_name)
   return {
     id: asString(raw.id),
     seq: asNumber(raw.seq),
@@ -157,6 +158,7 @@ export function normalizeMessage(raw: unknown): Message | null {
     content,
     timestamp,
     type: asString(raw.type),
+    room,
   }
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -105,6 +105,7 @@ export interface Message {
   content: string
   timestamp?: string
   type?: string
+  room?: string
 }
 
 // --- Board ---


### PR DESCRIPTION

## Summary

- add board focus surfaces for `workspace?section=board&focus=messages-room`, `focus=mention-inbox`, and `focus=state-block`
- preserve optional message room metadata during execution snapshot normalization so room timelines can group real room/channel payloads when present
- classify execution messages into for-me vs other mention lanes using existing dashboard auth/actor signals
- extract inline `[STATE]...[/STATE]` payloads into a structured state-block message view while keeping human prose previews separate
- mark the cockpit `messages-room`, `messages-mention-inbox`, and `messages-state-block` entrypoints covered now that they land on concrete surfaces

## Operator impact

- operators can jump from the C2 room, mention-inbox, and state-block cockpit aliases into focused board message views instead of falling back to the general board feed
- room metadata is no longer discarded before UI rendering, and roomless legacy payloads still fall back to an `execution` timeline
- state-block payloads are visible as structured key/value rows while noisy machine-readable blocks stay out of ordinary message previews

## Verification

- `pnpm --dir dashboard exec vitest run src/components/board/message-room-timeline.test.ts src/components/board/mention-inbox.test.ts src/components/board/state-block-messages.test.ts src/components/board/board-surface.test.ts src/cockpit-entrypoints.test.ts src/store-normalizers.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint` (existing unrelated warnings only)
- `pnpm --dir dashboard run build` (existing Vite chunk warnings)
- `gh pr checks 13459 --repo jeong-sik/masc-mcp` (CI Gate, PR Live Gate, sync, draft guard, and fundamental checks pass at `bf33ba3cb913b17448cdfd7f7e7e4d0243cdea39`)
- Browser verification via `agent-browser` at `http://127.0.0.1:5356/dashboard/#workspace?section=board&focus=messages-room`
  - route mounts `Room timeline`
  - screenshot: `/tmp/masc-mention-inbox-room-timeline-0506.png`
- Browser verification via `agent-browser` at `http://127.0.0.1:5356/dashboard/#workspace?section=board&focus=mention-inbox`
  - route mounts `Mention inbox`
  - screenshot: `/tmp/masc-mention-inbox-focused-0506.png`
- Browser verification via `agent-browser` at `http://127.0.0.1:5356/dashboard/#workspace?section=board&focus=state-block`
  - route mounts `State-block messages`
  - screenshot: `/tmp/masc-mention-inbox-state-block-0506.png`

Note: local `agent-browser errors` reports `Cannot use import statement outside a module` in this Vite dashboard session; the route snapshots render, and `agent-browser console` only shows Vite connect logs.
