### PR TITLE
fix(dashboard): focus cognition keeper inspector routes

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -44,6 +44,14 @@ describe('cockpit entrypoint registry', () => {
       tab: 'monitoring',
       params: { section: 'cognition', view: 'decisions' },
     })
+    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'ki-bdi' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'keeper', focus: 'bdi' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'keeper-tool-access' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'keeper', focus: 'tool-access' },
+    })
     expect(cockpitTargetForParams({ mode: 'Observe', tab: 'sa-dash' })).toEqual({
       tab: 'command',
       params: { section: 'operations', view: 'safety' },

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -77,8 +77,8 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'observe', aliases: ['hr-mod', 'heuristic-by-module'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'heuristics', focus: 'module' } }, coverage: 'covered' },
 
   // Cognition Plane: production view tabs show available data and blocked backend gaps.
-  { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper' } }, coverage: 'partial' },
-  { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'partial' },
+  { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'bdi' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'token-stats' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'decisions' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'memory' } }, coverage: 'partial' },

--- a/dashboard/src/components/cognition-plane.test.ts
+++ b/dashboard/src/components/cognition-plane.test.ts
@@ -24,6 +24,9 @@ async function loadPlane() {
   vi.doMock('./keeper-decisions-stream', () => ({
     KeeperDecisionsStream: () => html`<div data-testid="keeper-decisions-stream">KeeperDecisionsStream</div>`,
   }))
+  vi.doMock('./keeper-cognition-inspector', () => ({
+    KeeperCognitionInspector: () => html`<div data-testid="keeper-cognition-inspector">KeeperCognitionInspector</div>`,
+  }))
   vi.doMock('./keeper-token-stats', () => ({
     KeeperTokenStats: () => html`<div data-testid="keeper-token-stats">KeeperTokenStats</div>`,
   }))
@@ -52,8 +55,20 @@ describe('CognitionPlane', () => {
     vi.doUnmock('./agents-unified')
     vi.doUnmock('./autoresearch')
     vi.doUnmock('./keeper-decisions-stream')
+    vi.doUnmock('./keeper-cognition-inspector')
     vi.doUnmock('./keeper-token-stats')
     vi.doUnmock('./memory-subsystems')
+  })
+
+  it('renders the keeper cognition inspector for the keeper view', async () => {
+    route.value.params = { section: 'cognition', view: 'keeper', focus: 'bdi' }
+    const { CognitionPlane } = await loadPlane()
+
+    render(html`<${CognitionPlane} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="keeper-cognition-inspector"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="agents-unified"]')).toBeNull()
   })
 
   it('renders the live decisions stream for the decisions view', async () => {

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -4,6 +4,7 @@ import { AgentsUnified } from './agents-unified'
 import { Autoresearch } from './autoresearch'
 import { FilterChips } from './common/filter-chips'
 import { KeeperDecisionsStream } from './keeper-decisions-stream'
+import { KeeperCognitionInspector } from './keeper-cognition-inspector'
 import { KeeperTokenStats } from './keeper-token-stats'
 import { MemorySubsystems } from './memory-subsystems'
 
@@ -60,7 +61,7 @@ export function CognitionPlane() {
       />
 
       ${view === 'keeper' ? html`
-        <${AgentsUnified} />
+        <${KeeperCognitionInspector} />
       ` : view === 'token-stats' ? html`
         <${KeeperTokenStats} />
       ` : view === 'decisions' ? html`

--- a/dashboard/src/components/keeper-cognition-inspector.test.ts
+++ b/dashboard/src/components/keeper-cognition-inspector.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Keeper } from '../types'
+import { route } from '../router'
+import { keepers } from '../store'
+import {
+  KeeperCognitionInspector,
+  selectKeeperForInspector,
+  toolAccessRowsForKeeper,
+} from './keeper-cognition-inspector'
+
+function keeper(overrides: Partial<Keeper>): Keeper {
+  return {
+    name: 'alpha',
+    status: 'idle',
+    ...overrides,
+  } as Keeper
+}
+
+describe('KeeperCognitionInspector', () => {
+  afterEach(() => {
+    keepers.value = []
+    route.value = { tab: 'overview', params: {}, postId: null }
+  })
+
+  it('selects a requested keeper by name, keeper id, or agent name', () => {
+    const list = [
+      keeper({ name: 'alpha', keeper_id: 'kid-alpha', agent_name: 'agent-alpha' }),
+      keeper({ name: 'beta', keeper_id: 'kid-beta', agent_name: 'agent-beta' }),
+    ]
+
+    expect(selectKeeperForInspector(list, 'beta')?.name).toBe('beta')
+    expect(selectKeeperForInspector(list, 'kid-beta')?.name).toBe('beta')
+    expect(selectKeeperForInspector(list, 'agent-beta')?.name).toBe('beta')
+  })
+
+  it('falls back to a keeper with BDI data before a blank first row', () => {
+    const list = [
+      keeper({ name: 'alpha' }),
+      keeper({ name: 'beta', will: 'ship the cockpit' }),
+    ]
+
+    expect(selectKeeperForInspector(list, null)?.name).toBe('beta')
+  })
+
+  it('formats live tool access rows from keeper runtime fields', () => {
+    const rows = toolAccessRowsForKeeper(keeper({
+      cascade_name: 'primary',
+      sandbox_profile: 'docker',
+      proactive_enabled: false,
+      proactive_idle_sec: 120,
+      mention_reactive_turn_count: 4,
+      recent_tool_names: ['keeper_shell', 'web_search'],
+      approval_policy_effective: { allow_rules: 3, deny_rules: 1, persisted_rules: 2 },
+      configured_social_model: 'reactive',
+    }))
+
+    expect(rows.map(row => row.label)).toContain('cascade')
+    expect(rows.find(row => row.label === 'cascade')?.value).toBe('primary')
+    expect(rows.find(row => row.label === 'sandbox')?.value).toBe('docker')
+    expect(rows.find(row => row.label === 'proactive idle')?.value).toContain('off')
+    expect(rows.find(row => row.label === 'observed tools')?.value).toContain('keeper_shell')
+    expect(rows.find(row => row.label === 'approval policy')?.value).toBe('3 allow · 1 deny · 2 persisted')
+  })
+
+  it('renders the tool access focus surface from the cognition keeper route', () => {
+    const container = document.createElement('div')
+    keepers.value = [
+      keeper({
+        name: 'beta',
+        status: 'active',
+        cascade_name: 'primary',
+        latest_tool_names: ['keeper_task_done'],
+      }),
+    ]
+    route.value = {
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'keeper', focus: 'tool-access' },
+      postId: null,
+    }
+
+    render(html`<${KeeperCognitionInspector} />`, container)
+
+    expect(container.querySelector('[data-testid="keeper-cognition-inspector"]')).not.toBeNull()
+    expect(container.textContent).toContain('Tool Access Snapshot')
+    expect(container.textContent).toContain('keeper_task_done')
+    render(null, container)
+  })
+})

--- a/dashboard/src/components/keeper-cognition-inspector.ts
+++ b/dashboard/src/components/keeper-cognition-inspector.ts
@@ -1,0 +1,267 @@
+import { html } from 'htm/preact'
+import type { Keeper } from '../types'
+import { navigate, route } from '../router'
+import { keepers } from '../store'
+import { EmptyState } from './common/empty-state'
+import { FilterChips } from './common/filter-chips'
+import { PanelCard } from './common/panel-card'
+import { KeeperBadge } from './keeper-badge'
+import { KeeperBDIPanel } from './keeper-bdi-panel'
+import { formatDuration } from './mission-utils'
+
+type KeeperInspectorFocus = 'bdi' | 'tool-access'
+
+interface ToolAccessRow {
+  label: string
+  value: string
+}
+
+const FOCUS_CHIPS: Array<{ key: KeeperInspectorFocus; label: string; title: string }> = [
+  { key: 'bdi', label: 'BDI', title: 'Will, needs, desires, and goal horizons' },
+  { key: 'tool-access', label: 'Tool Access', title: 'Runtime tool and execution access snapshot' },
+]
+
+function keeperKeys(keeper: Keeper): string[] {
+  return [
+    keeper.name,
+    keeper.keeper_id ?? '',
+    keeper.agent_name ?? '',
+  ].map(key => key.trim()).filter(Boolean)
+}
+
+export function selectKeeperForInspector(
+  keeperList: readonly Keeper[],
+  requestedName: string | null | undefined,
+): Keeper | null {
+  if (keeperList.length === 0) return null
+  const requested = requestedName?.trim()
+  if (requested) {
+    const exact = keeperList.find(keeper => keeperKeys(keeper).includes(requested))
+    if (exact) return exact
+  }
+  const withBdi = keeperList.find(hasBdiSnapshot)
+  return withBdi ?? keeperList[0] ?? null
+}
+
+export function hasBdiSnapshot(keeper: Keeper): boolean {
+  return Boolean(
+    keeper.will
+    || keeper.needs
+    || keeper.desires
+    || keeper.short_goal
+    || keeper.mid_goal
+    || keeper.long_goal
+    || keeper.goal_horizons?.short
+    || keeper.goal_horizons?.mid
+    || keeper.goal_horizons?.long,
+  )
+}
+
+function displayValue(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined || value === '') return '-'
+  return String(value)
+}
+
+function secondsLabel(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined || !Number.isFinite(seconds)) return '-'
+  return formatDuration(seconds)
+}
+
+function listLabel(values: readonly string[] | null | undefined): string {
+  const clean = (values ?? []).map(value => value.trim()).filter(Boolean)
+  return clean.length === 0 ? '-' : clean.join(' · ')
+}
+
+export function toolAccessRowsForKeeper(keeper: Keeper): ToolAccessRow[] {
+  const policy = keeper.approval_policy_effective
+  const recentTools = keeper.recent_tool_names?.length
+    ? keeper.recent_tool_names
+    : keeper.latest_tool_names
+  return [
+    {
+      label: 'cascade',
+      value: displayValue(keeper.cascade_name ?? keeper.cascade_canonical ?? keeper.selected_cascade_canonical),
+    },
+    {
+      label: 'sandbox',
+      value: displayValue(keeper.sandbox_target ?? keeper.sandbox_profile),
+    },
+    {
+      label: 'proactive idle',
+      value: keeper.proactive_enabled === false
+        ? `off · ${secondsLabel(keeper.proactive_idle_sec)}`
+        : secondsLabel(keeper.proactive_idle_sec),
+    },
+    {
+      label: 'mention turns',
+      value: displayValue(keeper.mention_reactive_turn_count),
+    },
+    {
+      label: 'observed tools',
+      value: listLabel(recentTools),
+    },
+    {
+      label: 'approval policy',
+      value: policy
+        ? `${policy.allow_rules ?? 0} allow · ${policy.deny_rules ?? 0} deny · ${policy.persisted_rules ?? 0} persisted`
+        : '-',
+    },
+    {
+      label: 'social model',
+      value: displayValue(keeper.configured_social_model ?? keeper.social_model ?? keeper.social_model_fallback),
+    },
+  ]
+}
+
+function currentFocus(): KeeperInspectorFocus {
+  return route.value.params.focus === 'tool-access' ? 'tool-access' : 'bdi'
+}
+
+function navigateFocus(focus: KeeperInspectorFocus): void {
+  navigate('monitoring', {
+    ...route.value.params,
+    section: 'cognition',
+    view: 'keeper',
+    focus,
+  })
+}
+
+function navigateKeeper(keeper: Keeper): void {
+  navigate('monitoring', {
+    ...route.value.params,
+    section: 'cognition',
+    view: 'keeper',
+    keeper: keeper.name,
+  })
+}
+
+function openKeeperDetail(keeper: Keeper): void {
+  navigate('monitoring', {
+    section: 'agents',
+    view: 'keepers',
+    keeper: keeper.name,
+  })
+}
+
+function KeeperPicker({
+  keeperList,
+  selected,
+}: {
+  keeperList: readonly Keeper[]
+  selected: Keeper
+}) {
+  return html`
+    <div class="flex flex-wrap gap-1.5" role="list" aria-label="Keeper inspector targets">
+      ${keeperList.map(keeper => {
+        const active = keeper.name === selected.name
+        return html`
+          <div role="listitem">
+            <button
+              type="button"
+              class="${active
+                ? 'border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--color-fg-primary)]'
+                : 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'} inline-flex items-center gap-2 rounded-[var(--r-1)] border px-2 py-1 text-2xs transition-colors"
+              aria-label=${keeper.name}
+              aria-pressed=${active}
+              onClick=${() => navigateKeeper(keeper)}
+            >
+              <${KeeperBadge} id=${keeper.name} variant="sigil" size="sm" />
+              <span class="font-mono">${keeper.name}</span>
+            </button>
+          </div>
+        `
+      })}
+    </div>
+  `
+}
+
+function ToolAccessSnapshot({ keeper }: { keeper: Keeper }) {
+  const rows = toolAccessRowsForKeeper(keeper)
+  return html`
+    <${PanelCard} title="Tool Access Snapshot">
+      <dl class="grid grid-cols-1 gap-x-6 md:grid-cols-2">
+        ${rows.map(row => html`
+          <div class="grid grid-cols-[112px_1fr] items-baseline gap-3 border-b border-[var(--color-border-divider)] py-2 last:border-b-0">
+            <dt class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${row.label}</dt>
+            <dd class="font-mono text-xs text-[var(--color-fg-secondary)]">${row.value}</dd>
+          </div>
+        `)}
+      </dl>
+    <//>
+  `
+}
+
+function BdiSnapshot({ keeper }: { keeper: Keeper }) {
+  if (hasBdiSnapshot(keeper)) {
+    return html`
+      <${KeeperBDIPanel}
+        will=${keeper.will}
+        needs=${keeper.needs}
+        desires=${keeper.desires}
+        short_goal=${keeper.short_goal}
+        mid_goal=${keeper.mid_goal}
+        long_goal=${keeper.long_goal}
+        goal_horizons=${keeper.goal_horizons}
+      />
+    `
+  }
+  return html`
+    <${PanelCard} title="BDI & Horizons">
+      <${EmptyState} compact=${true} message="No BDI snapshot is available for this keeper." />
+    <//>
+  `
+}
+
+export function KeeperCognitionInspector() {
+  const keeperList = keepers.value
+  const selected = selectKeeperForInspector(
+    keeperList,
+    route.value.params.keeper ?? route.value.params.agent,
+  )
+  const focus = currentFocus()
+
+  if (!selected) {
+    return html`
+      <${EmptyState}
+        message="No keeper runtime snapshots are loaded."
+        compact=${true}
+      />
+    `
+  }
+
+  return html`
+    <section class="grid gap-4" aria-label="Keeper cognition inspector" data-testid="keeper-cognition-inspector">
+      <div class="monitor-muted-panel flex flex-col gap-3 px-4 py-3">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="flex items-center gap-2">
+            <${KeeperBadge} id=${selected.name} variant="full" size="md" />
+            <span class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+              ${displayValue(selected.status)}
+            </span>
+          </div>
+          <button
+            type="button"
+            class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-1.5 text-2xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+            onClick=${() => openKeeperDetail(selected)}
+          >
+            Open detail
+          </button>
+        </div>
+
+        <${KeeperPicker} keeperList=${keeperList} selected=${selected} />
+
+        <${FilterChips}
+          chips=${FOCUS_CHIPS}
+          value=${focus}
+          onChange=${navigateFocus}
+          size="sm"
+          tone="accent"
+        />
+      </div>
+
+      ${focus === 'tool-access'
+        ? html`<${ToolAccessSnapshot} keeper=${selected} />`
+        : html`<${BdiSnapshot} keeper=${selected} />`}
+    </section>
+  `
+}


### PR DESCRIPTION
## Summary
- add a dedicated cognition keeper inspector for K1 BDI and tool-access entrypoints
- route Cognition view=keeper to the inspector instead of the broad agents fallback
- mark ki-bdi and ki-acc cockpit aliases covered with explicit focus params

## Validation
- git diff --check
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/cognition-plane.test.ts src/components/keeper-cognition-inspector.test.ts src/cockpit-entrypoints.test.ts src/components/keeper-bdi-panel.test.ts src/components/keeper-tool-access.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard run lint (0 errors; 3 existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- pnpm --dir dashboard run build (passes; existing Vite mixed dynamic/static import and chunk-size warnings)
- browser: http://localhost:5174/dashboard/#monitoring?section=cognition&view=keeper&focus=bdi renders Keeper cognition inspector and BDI panel; screenshot /tmp/masc-cognition-keeper-bdi-0506.png
- browser: http://localhost:5174/dashboard/#monitoring?section=cognition&view=keeper&focus=tool-access renders Tool Access Snapshot; screenshot /tmp/masc-cognition-keeper-tool-access-0506.png
- browser: #mode=Cognition&tab=ki-bdi canonicalizes to #monitoring?mode=Cognition&section=cognition&view=keeper&focus=bdi and renders the inspector
- browser errors after final clear: none; console only Vite debug/HMR logs

## Review Focus
- Inspector selection/fallback behavior for keeper name, keeper_id, and agent_name.
- Whether K1 BDI/tool access should remain covered now that they land on live keeper runtime data.
