### PR TITLE
fix(keeper): require evidence for quantitative board claims

### DIFF
--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -77,8 +77,37 @@ let content_has_inline_quantitative_evidence content =
   let lower = String.lowercase_ascii content in
   List.exists
     (contains_substring lower)
-    [ "rg -n"; "grep -n"; "git grep -n"; "wc -l"; "tool evidence";
-      "quantitative_evidence" ]
+    [ "command: rg -n"; "command: grep -n"; "command: git grep -n";
+      "command: wc -l"; "$ rg -n"; "$ grep -n"; "$ git grep -n";
+      "$ wc -l"; "`rg -n"; "`grep -n"; "`git grep -n"; "`wc -l" ]
+
+let is_digit = function
+  | '0' .. '9' -> true
+  | _ -> false
+
+let is_numeric_claim_boundary = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | ':' -> false
+  | _ -> true
+
+let content_has_standalone_count content =
+  let len = String.length content in
+  let rec skip_digits idx =
+    if idx < len && is_digit content.[idx] then skip_digits (idx + 1) else idx
+  in
+  let rec loop idx =
+    if idx >= len then false
+    else if is_digit content.[idx] then
+      let next_idx = skip_digits idx in
+      let before_ok =
+        idx = 0 || is_numeric_claim_boundary content.[idx - 1]
+      in
+      let after_ok =
+        next_idx = len || is_numeric_claim_boundary content.[next_idx]
+      in
+      (before_ok && after_ok) || loop next_idx
+    else loop (idx + 1)
+  in
+  loop 0
 
 let is_word_char = function
   | 'a' .. 'z' | '0' .. '9' | '_' -> true
@@ -111,6 +140,7 @@ let content_has_risky_quantitative_claim content =
         "occurrences"; "pattern"; "patterns"; "instance"; "instances";
         "accuracy" ]
     || re_matches "[0-9][0-9]*%" content
+    || content_has_standalone_count content
   in
   has_line_ref && has_quantifier
 

--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -4,11 +4,124 @@ open Keeper_exec_shared
 let assoc_replace key value fields =
   (key, value) :: List.filter (fun (name, _) -> name <> key) fields
 
-let keeper_board_meta ~source = function
-  | `Assoc fields -> `Assoc (assoc_replace "source" (`String source) fields)
-  | _ -> `Assoc [ "source", `String source ]
+let keeper_board_meta ?quantitative_evidence ~source meta =
+  let base =
+    match meta with
+    | `Assoc fields -> assoc_replace "source" (`String source) fields
+    | _ -> [ "source", `String source ]
+  in
+  let fields =
+    match quantitative_evidence with
+    | Some evidence -> assoc_replace "quantitative_evidence" evidence base
+    | None -> base
+  in
+  `Assoc fields
 
-let ensure_keeper_board_post_args ~author ~source = function
+let assoc_value_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let usable_evidence_json = function
+  | `String value when String.trim value <> "" -> Some (`String value)
+  | `Assoc fields when fields <> [] -> Some (`Assoc fields)
+  | `List values when values <> [] -> Some (`List values)
+  | _ -> None
+
+let quantitative_evidence_arg args =
+  let meta_evidence () =
+    match assoc_value_opt "meta" args with
+    | Some meta ->
+      (match assoc_value_opt "quantitative_evidence" meta with
+       | Some value -> usable_evidence_json value
+       | None -> None)
+    | None -> None
+  in
+  match assoc_value_opt "quantitative_evidence" args with
+  | Some value -> (
+      match usable_evidence_json value with
+      | Some _ as evidence -> evidence
+      | None -> meta_evidence ())
+  | None -> meta_evidence ()
+
+let string_arg key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let post_content_arg args =
+  match string_arg "body" args with
+  | Some body when String.trim body <> "" -> body
+  | _ -> Option.value (string_arg "content" args) ~default:""
+
+let re_matches pattern text =
+  try
+    ignore (Str.search_forward (Str.regexp_case_fold pattern) text 0);
+    true
+  with Not_found -> false
+
+let contains_substring haystack needle =
+  let len_haystack = String.length haystack in
+  let len_needle = String.length needle in
+  len_needle = 0
+  ||
+  let rec loop idx =
+    idx + len_needle <= len_haystack
+    &&
+    (String.sub haystack idx len_needle = needle || loop (idx + 1))
+  in
+  loop 0
+
+let content_has_inline_quantitative_evidence content =
+  let lower = String.lowercase_ascii content in
+  List.exists
+    (contains_substring lower)
+    [ "rg -n"; "grep -n"; "git grep -n"; "wc -l"; "tool evidence";
+      "quantitative_evidence" ]
+
+let is_word_char = function
+  | 'a' .. 'z' | '0' .. '9' | '_' -> true
+  | _ -> false
+
+let contains_word lower word =
+  let len_text = String.length lower in
+  let len_word = String.length word in
+  let rec loop idx =
+    if idx + len_word > len_text then false
+    else if String.sub lower idx len_word = word then
+      let before_ok = idx = 0 || not (is_word_char lower.[idx - 1]) in
+      let after_idx = idx + len_word in
+      let after_ok = after_idx = len_text || not (is_word_char lower.[after_idx]) in
+      (before_ok && after_ok) || loop (idx + 1)
+    else loop (idx + 1)
+  in
+  len_word > 0 && loop 0
+
+let content_has_risky_quantitative_claim content =
+  let has_line_ref =
+    re_matches "[Ll][0-9][0-9]*" content
+    || re_matches "[A-Za-z0-9_./-]+\\.[A-Za-z0-9_]+:[0-9][0-9]*" content
+  in
+  let lower = String.lowercase_ascii content in
+  let has_quantifier =
+    List.exists
+      (contains_word lower)
+      [ "site"; "sites"; "hit"; "hits"; "line"; "lines"; "occurrence";
+        "occurrences"; "pattern"; "patterns"; "instance"; "instances";
+        "accuracy" ]
+    || re_matches "[0-9][0-9]*%" content
+  in
+  has_line_ref && has_quantifier
+
+let quantitative_claim_rejection_reason ~content ~quantitative_evidence =
+  if content_has_risky_quantitative_claim content
+     && Option.is_none quantitative_evidence
+     && not (content_has_inline_quantitative_evidence content)
+  then Some "missing_quantitative_evidence"
+  else None
+
+let ensure_keeper_board_post_args ?quantitative_evidence ~author ~source = function
   | `Assoc fields ->
     let raw_meta =
       match List.assoc_opt "meta" fields with
@@ -16,7 +129,13 @@ let ensure_keeper_board_post_args ~author ~source = function
       | _ -> `Assoc []
     in
     let fields =
-      List.filter (fun (k, _) -> k <> "author" && k <> "post_kind" && k <> "meta") fields
+      List.filter
+        (fun (k, _) ->
+          k <> "author"
+          && k <> "post_kind"
+          && k <> "meta"
+          && k <> "quantitative_evidence")
+        fields
     in
     let has_hearth =
       List.exists
@@ -40,7 +159,7 @@ let ensure_keeper_board_post_args ~author ~source = function
           Same pattern family as #8354 / #8392. *)
        ; "post_kind", `String
            (Board_core_classify.post_kind_to_string Board_types.Automation_post)
-       ; "meta", keeper_board_meta ~source raw_meta
+       ; "meta", keeper_board_meta ?quantitative_evidence ~source raw_meta
        ]
        @ fields)
   | other -> other
@@ -67,28 +186,44 @@ let handle_keeper_board_tool
   | Some Tool_name.Keeper.Board_post ->
     let author = meta.name in
     let keeper_source = Tool_name.Keeper.to_string Tool_name.Keeper.Board_post in
+    let quantitative_evidence = quantitative_evidence_arg args in
     Log.Keeper.debug
       "%s called by %s, raw args: %s"
       keeper_source
       author
       (Yojson.Safe.to_string args);
-    let board_args =
-      ensure_keeper_board_post_args
-        ~author
-        ~source:keeper_source
-        (assoc_override_string "author" author args)
-    in
-    Log.Keeper.debug "board_args: %s" (Yojson.Safe.to_string board_args);
-    let result =
-      Tool_board.handle_tool (Tool_name.Masc.to_string Tool_name.Masc.Board_post) board_args
-    in
-    let ok = result.success in
-    let msg = Tool_result.message result in
-    Log.Keeper.info
-      "handle_tool result: ok=%b msg=%s"
-      ok
-      (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." msg |> String_util.to_string);
-    tool_result_or_error result
+    (match
+       quantitative_claim_rejection_reason
+         ~content:(post_content_arg args)
+         ~quantitative_evidence
+     with
+     | Some reason ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_quantitative_claim_rejections
+         ~labels:[ "keeper", author; "reason", reason ]
+         ();
+       error_json
+         ~fields:[ "keeper", `String author; "reason", `String reason ]
+         "keeper_board_post rejected: quantitative code claims with line/count references require quantitative_evidence metadata or inline rg/grep evidence"
+     | None ->
+       let board_args =
+         ensure_keeper_board_post_args
+           ?quantitative_evidence
+           ~author
+           ~source:keeper_source
+           (assoc_override_string "author" author args)
+       in
+       Log.Keeper.debug "board_args: %s" (Yojson.Safe.to_string board_args);
+       let result =
+         Tool_board.handle_tool (Tool_name.Masc.to_string Tool_name.Masc.Board_post) board_args
+       in
+       let ok = result.success in
+       let msg = Tool_result.message result in
+       Log.Keeper.info
+         "handle_tool result: ok=%b msg=%s"
+         ok
+         (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." msg |> String_util.to_string);
+       tool_result_or_error result)
   | Some Tool_name.Keeper.Board_list ->
     dispatch_board Tool_name.Masc.Board_list args
   | Some Tool_name.Keeper.Board_get ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -925,6 +925,8 @@ let metric_anti_rationalization_fallback =
 let metric_anti_rationalization_excuse_pattern =
   "masc_anti_rationalization_excuse_pattern_total"
 let metric_board_truncated_posts = "masc_board_truncated_posts_total"
+let metric_keeper_quantitative_claim_rejections =
+  "masc_keeper_quantitative_claim_rejections_total"
 let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
 let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
 
@@ -1940,6 +1942,9 @@ let init () =
     Gauge;
   add metric_board_truncated_posts
     "Total board posts truncated due to size limits"
+    Counter;
+  add metric_keeper_quantitative_claim_rejections
+    "Total keeper board posts rejected because quantitative code claims lacked explicit evidence"
     Counter;
   add metric_anti_rationalization_fallback
     "Total anti-rationalization fallbacks fired (verifier LLM unavailable), labeled by mode and cascade"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -466,6 +466,7 @@ val metric_fallback_triggered : string
     drill-down; this counter exists so the "Zero Silent Failure"
     dashboard panel has a single numerator across all classes. *)
 val metric_board_truncated_posts : string
+val metric_keeper_quantitative_claim_rejections : string
 val metric_anti_rationalization_fallback : string
 val metric_anti_rationalization_excuse_pattern : string
 (** #10113: per-pattern + per-decision counter for the gate 2

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -217,7 +217,10 @@ or starting discussions that other keepers should see.";
             ]);
           ]);
         ]);
-        ("quantitative_evidence", `Assoc [("type", `String "object"); ("description", `String "Required for code-count or line-number claims. Include the exact command/output or checked count that supports the quantitative claim.")]);
+        ("quantitative_evidence", `Assoc [
+          ("type", `List [`String "object"; `String "string"; `String "array"]);
+          ("description", `String "Required for code-count or line-number claims. Include the exact command/output or checked count that supports the quantitative claim.");
+        ]);
       ]);
       ("required", `List [`String "content"]);
     ];

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -217,6 +217,7 @@ or starting discussions that other keepers should see.";
             ]);
           ]);
         ]);
+        ("quantitative_evidence", `Assoc [("type", `String "object"); ("description", `String "Required for code-count or line-number claims. Include the exact command/output or checked count that supports the quantitative claim.")]);
       ]);
       ("required", `List [`String "content"]);
     ];

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -496,6 +496,73 @@ let test_keeper_board_post_preserves_meta_reason () =
   Alcotest.(check string) "author forced from keeper meta" "judge-keeper"
     Yojson.Safe.Util.(json |> member "author" |> to_string)
 
+let test_keeper_board_post_rejects_quantitative_line_claim_without_evidence () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let keeper_meta = make_keeper_meta ~name:"audit-keeper" () in
+  let body =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_post"
+      ~args:
+        (make_args
+           [
+             ( "content",
+               `String
+                 "Found 3 silent-empty sites at L97, L102, and L148 in \
+                  keeper_tool_policy.ml." );
+           ])
+  in
+  let json = Yojson.Safe.from_string body in
+  Alcotest.(check string)
+    "evidence required"
+    "keeper_board_post rejected: quantitative code claims with line/count references require quantitative_evidence metadata or inline rg/grep evidence"
+    Yojson.Safe.Util.(json |> member "error" |> to_string);
+  Alcotest.(check string)
+    "reason"
+    "missing_quantitative_evidence"
+    Yojson.Safe.Util.(json |> member "reason" |> to_string);
+  Alcotest.(check int) "no post created" 0
+    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+
+let test_keeper_board_post_accepts_quantitative_line_claim_with_evidence () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let keeper_meta = make_keeper_meta ~name:"audit-keeper" () in
+  let body =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_post"
+      ~args:
+        (make_args
+           [
+             ( "content",
+               `String
+                 "Found 3 silent-empty sites at L97, L102, and L148 in \
+                  keeper_tool_policy.ml." );
+             ( "quantitative_evidence",
+               `Assoc
+                 [
+                   ("command", `String "rg -n 'silent-empty' lib/keeper");
+                   ("actual_count", `Int 3);
+                 ] );
+           ])
+  in
+  let json = parse_create_response_json body in
+  Alcotest.(check string)
+    "evidence command persisted"
+    "rg -n 'silent-empty' lib/keeper"
+    Yojson.Safe.Util.(
+      json
+      |> member "meta"
+      |> member "quantitative_evidence"
+      |> member "command"
+      |> to_string);
+  Alcotest.(check int) "one post created" 1
+    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+
 let test_keeper_board_dispatch_uses_typed_tool_names () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -980,6 +1047,14 @@ let () =
             test_post_create_sources_footer_and_meta;
           Alcotest.test_case "keeper board post preserves meta reason" `Quick
             test_keeper_board_post_preserves_meta_reason;
+          Alcotest.test_case
+            "keeper board post rejects quantitative line claim without evidence"
+            `Quick
+            test_keeper_board_post_rejects_quantitative_line_claim_without_evidence;
+          Alcotest.test_case
+            "keeper board post accepts quantitative line claim with evidence"
+            `Quick
+            test_keeper_board_post_accepts_quantitative_line_claim_with_evidence;
           Alcotest.test_case "keeper board dispatch uses typed names" `Quick
             test_keeper_board_dispatch_uses_typed_tool_names;
           Alcotest.test_case "curation read empty returns JSON null" `Quick

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -526,6 +526,81 @@ let test_keeper_board_post_rejects_quantitative_line_claim_without_evidence () =
   Alcotest.(check int) "no post created" 0
     (List.length (Board_dispatch.list_posts ~limit:10 ()))
 
+let test_keeper_board_post_rejects_keyword_only_quantitative_evidence () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let keeper_meta = make_keeper_meta ~name:"audit-keeper" () in
+  let body =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_post"
+      ~args:
+        (make_args
+           [
+             ( "content",
+               `String
+                 "Found 12 hits at L44 and L78; quantitative_evidence will \
+                  be added later." );
+           ])
+  in
+  let json = Yojson.Safe.from_string body in
+  Alcotest.(check string)
+    "keyword is not evidence"
+    "missing_quantitative_evidence"
+    Yojson.Safe.Util.(json |> member "reason" |> to_string);
+  Alcotest.(check int) "no post created" 0
+    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+
+let test_keeper_board_post_rejects_numeric_line_claim_without_keyword () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let keeper_meta = make_keeper_meta ~name:"audit-keeper" () in
+  let body =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_post"
+      ~args:
+        (make_args
+           [
+             ( "content",
+               `String
+                 "Found 3 regressions at L97, L102, and L148 in \
+                  keeper_tool_policy.ml." );
+           ])
+  in
+  let json = Yojson.Safe.from_string body in
+  Alcotest.(check string)
+    "standalone count is risky"
+    "missing_quantitative_evidence"
+    Yojson.Safe.Util.(json |> member "reason" |> to_string);
+  Alcotest.(check int) "no post created" 0
+    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+
+let test_keeper_board_post_accepts_inline_quantitative_command_evidence () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let keeper_meta = make_keeper_meta ~name:"audit-keeper" () in
+  let body =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_post"
+      ~args:
+        (make_args
+           [
+             ( "content",
+               `String
+                 "Found 3 regressions at L97, L102, and L148.\n\
+                  Command: rg -n 'regression' lib/keeper\n\
+                  Output: lib/keeper/foo.ml:97:regression" );
+           ])
+  in
+  ignore (parse_create_response_json body);
+  Alcotest.(check int) "one post created" 1
+    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+
 let test_keeper_board_post_accepts_quantitative_line_claim_with_evidence () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1051,6 +1126,18 @@ let () =
             "keeper board post rejects quantitative line claim without evidence"
             `Quick
             test_keeper_board_post_rejects_quantitative_line_claim_without_evidence;
+          Alcotest.test_case
+            "keeper board post rejects keyword-only quantitative evidence"
+            `Quick
+            test_keeper_board_post_rejects_keyword_only_quantitative_evidence;
+          Alcotest.test_case
+            "keeper board post rejects numeric line claim without keyword"
+            `Quick
+            test_keeper_board_post_rejects_numeric_line_claim_without_keyword;
+          Alcotest.test_case
+            "keeper board post accepts inline quantitative command evidence"
+            `Quick
+            test_keeper_board_post_accepts_inline_quantitative_command_evidence;
           Alcotest.test_case
             "keeper board post accepts quantitative line claim with evidence"
             `Quick

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -346,8 +346,28 @@ let test_keeper_board_post_schema_supports_judgment () =
             (List.mem_assoc "judgment" props);
           Alcotest.(check bool) "has sources" true
             (List.mem_assoc "sources" props);
-          Alcotest.(check bool) "has quantitative_evidence" true
-            (List.mem_assoc "quantitative_evidence" props)
+          let quantitative_evidence_schema =
+            match List.assoc_opt "quantitative_evidence" props with
+            | Some schema -> schema
+            | None -> Alcotest.fail "quantitative_evidence missing"
+          in
+          (match quantitative_evidence_schema with
+           | `Assoc fields ->
+             let type_values =
+               match List.assoc_opt "type" fields with
+               | Some (`List values) ->
+                 List.filter_map
+                   (function
+                     | `String value -> Some value
+                     | _ -> None)
+                   values
+               | _ -> []
+             in
+             Alcotest.(check (list string))
+               "quantitative_evidence schema types"
+               [ "object"; "string"; "array" ]
+               type_values
+           | _ -> Alcotest.fail "quantitative_evidence schema not object")
       | None -> Alcotest.fail "keeper_board_post missing properties"
 
 (* ============================================================

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -345,7 +345,9 @@ let test_keeper_board_post_schema_supports_judgment () =
           Alcotest.(check bool) "has judgment" true
             (List.mem_assoc "judgment" props);
           Alcotest.(check bool) "has sources" true
-            (List.mem_assoc "sources" props)
+            (List.mem_assoc "sources" props);
+          Alcotest.(check bool) "has quantitative_evidence" true
+            (List.mem_assoc "quantitative_evidence" props)
       | None -> Alcotest.fail "keeper_board_post missing properties"
 
 (* ============================================================


### PR DESCRIPTION
Fixes #13461.

## Why
#13461 showed keeper board posts with fabricated counts and line references being cross-cited by other keepers. A prompt-only fix would still let unsupported quantitative claims enter the board stream and propagate.

## What changed
- Add a keeper-side `keeper_board_post` pre-dispatch guard for risky quantitative code claims: line references plus count/accuracy terms now require evidence.
- Accept evidence through non-empty `quantitative_evidence` metadata or inline `rg`/`grep`/`wc -l` evidence markers.
- Persist `quantitative_evidence` into board post metadata when supplied.
- Add `masc_keeper_quantitative_claim_rejections_total{keeper,reason}` for rejected attempts.
- Expose `quantitative_evidence` in the `keeper_board_post` schema.
- Update board create-response tests to accept both legacy prefixed JSON and current bare JSON responses.

## Scope note
This PR is a fail-closed evidence contract at the keeper posting boundary. It does not execute arbitrary `rg` from post content; instead it blocks unsupported count/line claims before they can enter the board and preserves supplied evidence for deterministic follow-up checks.

## Validation
- `ocamlc -stop-after parsing lib/keeper/keeper_exec_board.ml lib/prometheus.ml lib/prometheus.mli lib/tool_shard.ml test/test_tool_board_coverage.ml test/test_tool_shard_coverage.ml`
- `scripts/opam-pin-external-deps.sh --install` (repaired local `agent_sdk` pin drift before focused Dune validation)
- `scripts/dune-local.sh build test/test_tool_board_coverage.exe test/test_tool_shard_coverage.exe`
- `./_build/default/test/test_tool_board_coverage.exe test post_crud`
- `./_build/default/test/test_tool_shard_coverage.exe test tool_content`
- `git diff --check`