### PR TITLE
fix(memory): surface activity emit failures

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -620,6 +620,7 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
         + (Prometheus.metric_total Prometheus.metric_keeper_turn_metrics_snapshot_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_oas_execution_errors |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_episode_create_failures |> int_of_float)
+        + (Prometheus.metric_total Prometheus.metric_keeper_memory_activity_emit_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_supervisor_sweep_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_toml_reconcile_sweep_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_tool_usage_flush_failures |> int_of_float)

--- a/lib/keeper/keeper_agent_memory_episode.ml
+++ b/lib/keeper/keeper_agent_memory_episode.ml
@@ -33,7 +33,19 @@ let emit_flush_activity
         ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> ()
+    | exn ->
+      let outcome_label =
+        match outcome with
+        | None -> "success"
+        | Some value -> value
+      in
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_memory_activity_emit_failures
+        ~labels:[("keeper", keeper_name); ("outcome", outcome_label)]
+        ();
+      Log.Keeper.error
+        "keeper:%s episode.flush activity emit failed outcome=%s: %s"
+        keeper_name outcome_label (Printexc.to_string exn)
 
 let record_success
     ~(config : Coord_utils.config)

--- a/lib/keeper/keeper_agent_memory_episode.mli
+++ b/lib/keeper/keeper_agent_memory_episode.mli
@@ -4,8 +4,8 @@
     preserving the keeper runner as a thin orchestration layer. *)
 
 (** Emit an [episode.flush] activity payload via [Coord_hooks.activity_emit_fn].
-    No-op if both [episodes] and [procedures] are zero. Swallows non-cancel
-    exceptions; re-raises [Eio.Cancel.Cancelled]. *)
+    No-op if both [episodes] and [procedures] are zero. Logs and counts
+    non-cancel exceptions; re-raises [Eio.Cancel.Cancelled]. *)
 val emit_flush_activity :
   config:Coord_utils.config ->
   keeper_name:string ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -659,6 +659,8 @@ let metric_keeper_oas_execution_errors =
   "masc_keeper_oas_execution_errors_total"
 let metric_keeper_episode_create_failures =
   "masc_keeper_episode_create_failures_total"
+let metric_keeper_memory_activity_emit_failures =
+  "masc_keeper_memory_activity_emit_failures_total"
 let metric_keeper_supervisor_sweep_failures =
   "masc_keeper_supervisor_sweep_failures_total"
 let metric_keeper_toml_reconcile_sweep_failures =
@@ -1838,6 +1840,10 @@ let init () =
   add metric_keeper_episode_create_failures
     "Total episode creation failures in keeper_agent_memory_episode. \
      Labeled by keeper."
+    Counter;
+  add metric_keeper_memory_activity_emit_failures
+    "Total memory flush activity emit callback failures in \
+     keeper_agent_memory_episode. Labeled by keeper and outcome."
     Counter;
   add metric_keeper_supervisor_sweep_failures
     "Total supervisor sweep failures in keeper_runtime periodic beat. \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -298,6 +298,7 @@ val metric_keeper_room_heartbeat_failures : string
 val metric_keeper_turn_metrics_snapshot_failures : string
 val metric_keeper_oas_execution_errors : string
 val metric_keeper_episode_create_failures : string
+val metric_keeper_memory_activity_emit_failures : string
 val metric_keeper_supervisor_sweep_failures : string
 val metric_keeper_toml_reconcile_sweep_failures : string
 val metric_keeper_tool_usage_flush_failures : string

--- a/test/dune
+++ b/test/dune
@@ -210,6 +210,7 @@
         test_keeper_topk_llm
         test_warn_root_causes
         test_memory_hooks
+        test_keeper_agent_memory_episode_activity
         test_agent_stress_timeout_wire_10341
         test_institution_episodes_failure_learnings_10325
         test_institution_of_string_fail_closed
@@ -425,6 +426,7 @@
           test_keeper_topk_llm
           test_warn_root_causes
           test_memory_hooks
+          test_keeper_agent_memory_episode_activity
           test_agent_stress_timeout_wire_10341
           test_institution_episodes_failure_learnings_10325
           test_institution_of_string_fail_closed

--- a/test/test_keeper_agent_memory_episode_activity.ml
+++ b/test/test_keeper_agent_memory_episode_activity.ml
@@ -1,0 +1,119 @@
+(** Tests for keeper memory episode activity visibility. *)
+
+open Alcotest
+open Masc_mcp
+
+module Episode = Keeper_agent_memory_episode
+module Hooks = Coord_hooks
+module P = Prometheus
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_memory_activity_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter
+          (fun name -> rm (Filename.concat path name))
+          (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let make_config ~base_path : Coord_utils.config =
+  let backend_config : Backend_types.config = {
+    backend_type = Backend_types.Memory;
+    base_path;
+    node_id = "test-node";
+    cluster_name = "default";
+    pubsub_max_messages = 1000;
+  } in
+  let memory_backend = Backend.Memory.create () in
+  {
+    Coord_utils.base_path;
+    workspace_path = base_path;
+    lock_expiry_minutes = 30;
+    backend_config;
+    backend = Coord_utils.Memory memory_backend;
+  }
+
+let with_config f =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () -> f (make_config ~base_path))
+
+let with_activity_emit fn f =
+  let previous = Atomic.get Hooks.activity_emit_fn in
+  Fun.protect
+    ~finally:(fun () -> Atomic.set Hooks.activity_emit_fn previous)
+    (fun () ->
+      Atomic.set Hooks.activity_emit_fn fn;
+      f ())
+
+let read_failure ~keeper ~outcome =
+  P.metric_value_or_zero
+    P.metric_keeper_memory_activity_emit_failures
+    ~labels:[("keeper", keeper); ("outcome", outcome)]
+    ()
+
+let failing_emit _config ~actor:_ ?subject ~kind:_ ~payload:_ ~tags:_ () =
+  ignore subject;
+  failwith "activity graph down"
+
+let test_activity_emit_failure_increments_success_metric () =
+  with_config (fun config ->
+    let keeper = "keeper-memory-activity-success" in
+    let before = read_failure ~keeper ~outcome:"success" in
+    with_activity_emit failing_emit (fun () ->
+      Episode.emit_flush_activity ~config ~keeper_name:keeper ~turn:7
+        ~episodes:1 ~procedures:0 ~tags:["memory"; "episode"; "flush"]
+        ();
+      let after = read_failure ~keeper ~outcome:"success" in
+      check (float 0.0001)
+        "activity emit failure increments success-outcome metric"
+        (before +. 1.0) after))
+
+let test_activity_emit_failure_increments_failure_metric () =
+  with_config (fun config ->
+    let keeper = "keeper-memory-activity-failure" in
+    let before = read_failure ~keeper ~outcome:"failure" in
+    with_activity_emit failing_emit (fun () ->
+      Episode.emit_flush_activity ~config ~keeper_name:keeper ~turn:8
+        ~episodes:0 ~procedures:1 ~outcome:"failure"
+        ~tags:["memory"; "episode"; "flush"; "failure"]
+        ();
+      let after = read_failure ~keeper ~outcome:"failure" in
+      check (float 0.0001)
+        "activity emit failure preserves failure outcome label"
+        (before +. 1.0) after))
+
+let test_zero_flush_is_noop () =
+  with_config (fun config ->
+    let called = ref false in
+    let counting_emit _config ~actor:_ ?subject ~kind:_ ~payload:_ ~tags:_ () =
+      ignore subject;
+      called := true
+    in
+    with_activity_emit counting_emit (fun () ->
+      Episode.emit_flush_activity ~config
+        ~keeper_name:"keeper-memory-activity-noop" ~turn:9
+        ~episodes:0 ~procedures:0 ~tags:["memory"]
+        ();
+      check bool "zero flush does not call activity emit" false !called))
+
+let () =
+  run "keeper_agent_memory_episode_activity" [
+    "activity emit visibility", [
+      test_case "success flush emit failure increments metric" `Quick
+        test_activity_emit_failure_increments_success_metric;
+      test_case "failure flush emit failure increments metric" `Quick
+        test_activity_emit_failure_increments_failure_metric;
+      test_case "zero flush remains a no-op" `Quick test_zero_flush_is_noop;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- count and log memory episode.flush activity emit callback failures instead of silently ignoring them
- expose the new failure counter in the compact dashboard tool-error aggregate
- add focused coverage for success/failure flush activity emit failures and zero-flush no-op behavior

## Why it matters
The goal-driven plan calls out silent failure accumulation as the first reliability hazard. Current main already surfaces compaction/handoff callback failures, but memory flush activity emit failures were still silently ignored. This preserves the keep-going runtime policy while making the failure visible to operators and metrics.

## Verification
- scripts/dune-local.sh build test/test_keeper_agent_memory_episode_activity.exe
- ./_build/default/test/test_keeper_agent_memory_episode_activity.exe
- scripts/dune-local.sh build test/test_keeper_callback_hardening.exe
- ./_build/default/test/test_keeper_callback_hardening.exe