### PR TITLE
fix(dashboard): focus autoresearch cockpit routes

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -56,5 +56,13 @@ describe('cockpit entrypoint registry', () => {
       tab: 'monitoring',
       params: { section: 'runtime', view: 'heuristics', focus: 'log' },
     })
+    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'ar-fnd' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'autoresearch', focus: 'finding' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'ar-flow' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'autoresearch', focus: 'flow' },
+    })
   })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -85,8 +85,8 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'cognition', aliases: ['ep-card', 'episodes-cards'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ep-lrn', 'episodes-learnings'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ar-lst', 'ar-loops'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ar-fnd', 'ar-finding-card'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'finding' } }, coverage: 'partial' },
-  { mode: 'cognition', aliases: ['ar-flw', 'ar-flow'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'flow' } }, coverage: 'partial' },
+  { mode: 'cognition', aliases: ['ar-fnd', 'ar-finding-card'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'finding' } }, coverage: 'covered' },
+  { mode: 'cognition', aliases: ['ar-flw', 'ar-flow'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'flow' } }, coverage: 'covered' },
 
   // IDE Plane.
   { mode: 'ide', aliases: ['edit', 'source'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'partial' },

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -7,7 +7,7 @@ import type {
   AutoresearchLoopSummary,
   AutoresearchLoopsResponse,
 } from '../api/autoresearch'
-import { filterCycles } from './autoresearch'
+import { autoresearchFocusFromParam, filterCycles } from './autoresearch'
 
 void vi
 
@@ -113,6 +113,8 @@ describe('Autoresearch surface refresh', () => {
 
   afterEach(async () => {
     const { resetAutoresearchState } = await import('./autoresearch')
+    const { route } = await import('../router')
+    route.value = { tab: 'overview', params: {}, postId: null }
     resetAutoresearchState()
     render(null, container)
     container.remove()
@@ -161,6 +163,73 @@ describe('Autoresearch surface refresh', () => {
     expect(container.textContent).toContain('2 / 5')
     expect(container.textContent).toContain('사이클 이력 (2건)')
   }, 20000)
+
+  it('renders the finding card focus from the cognition autoresearch route', async () => {
+    const loop = loopSummary('loop-fnd0', {
+      queued_hypothesis: 'try focused route',
+      program_note: 'prefer current metric evidence',
+      insights: ['finding insight one'],
+      warnings: ['finding warning one'],
+    })
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
+      .mockResolvedValue({ loops: [loop], total: 1, offset: 0, limit: 100 })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
+      .mockResolvedValue(loopDetail(loop))
+
+    const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
+      fetchAutoresearchLoops: fetchLoops,
+      fetchAutoresearchLoopDetail: fetchDetail,
+    })
+    const { route } = await import('../router')
+    route.value = {
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'autoresearch', focus: 'finding' },
+      postId: null,
+    }
+
+    render(html`<${Autoresearch} />`, container)
+    await refreshAutoresearchSurface()
+    await flushUi()
+
+    expect(container.textContent).toContain('Finding Card')
+    expect(container.textContent).toContain('try focused route')
+    expect(container.textContent).toContain('finding insight one')
+    expect(container.textContent).toContain('finding warning one')
+  })
+
+  it('renders the flow snapshot focus from the cognition autoresearch route', async () => {
+    const loop = loopSummary('loop-flw0', {
+      total_keeps: 3,
+      total_discards: 1,
+      current_cycle: 4,
+      recent_cycles: [cycleRecord(0), cycleRecord(1)],
+    })
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
+      .mockResolvedValue({ loops: [loop], total: 1, offset: 0, limit: 100 })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
+      .mockResolvedValue(loopDetail(loop))
+
+    const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
+      fetchAutoresearchLoops: fetchLoops,
+      fetchAutoresearchLoopDetail: fetchDetail,
+    })
+    const { route } = await import('../router')
+    route.value = {
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'autoresearch', focus: 'flow' },
+      postId: null,
+    }
+
+    render(html`<${Autoresearch} />`, container)
+    await refreshAutoresearchSurface()
+    await flushUi()
+
+    expect(container.textContent).toContain('Flow Snapshot')
+    expect(container.textContent).toContain('Latest Cycle')
+    expect(container.textContent).toContain('#1')
+    expect(container.textContent).toContain('hypothesis-1')
+    expect(container.textContent).toContain('75.0%')
+  })
 
   it('preserves the current selection when that loop still exists after refresh', async () => {
     const loopA = loopSummary('loop-a111', { target_file: 'target-a.ml' })
@@ -521,5 +590,14 @@ describe('filterCycles', () => {
     const copy = cycles.slice()
     filterCycles(cycles, 'keep')
     expect(cycles).toEqual(copy)
+  })
+})
+
+describe('autoresearchFocusFromParam', () => {
+  it('accepts explicit focus aliases and defaults everything else to overview', () => {
+    expect(autoresearchFocusFromParam('finding')).toBe('finding')
+    expect(autoresearchFocusFromParam('flow')).toBe('flow')
+    expect(autoresearchFocusFromParam('unknown')).toBe('overview')
+    expect(autoresearchFocusFromParam(null)).toBe('overview')
   })
 })

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -9,10 +9,11 @@ import { ActionButton } from './common/button'
 import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { Eyebrow } from './common/eyebrow'
+import { FilterChips } from './common/filter-chips'
 import { InfoCard } from './common/info-card'
 import { formatElapsedCompact, formatTimestampKo, formatDelta } from '../lib/format-time'
 import { statusLabel } from '../lib/status-label'
-import { navigate } from '../router'
+import { navigate, route } from '../router'
 import type {
   AutoresearchLoopSummary,
   AutoresearchCycleRecord,
@@ -57,6 +58,46 @@ export function resetAutoresearchState(): void {
 }
 
 // --- Helpers ---
+
+type AutoresearchFocus = 'overview' | 'finding' | 'flow'
+
+const FOCUS_CHIPS: Array<{ key: AutoresearchFocus; label: string; title: string }> = [
+  { key: 'overview', label: 'Overview', title: 'Loop list and harness boundary' },
+  { key: 'finding', label: 'Finding Card', title: 'Current hypothesis, note, and insight snapshot' },
+  { key: 'flow', label: 'Flow Snapshot', title: 'Keep/discard flow and latest cycle state' },
+]
+
+export function autoresearchFocusFromParam(value: string | null | undefined): AutoresearchFocus {
+  return value === 'finding' || value === 'flow' ? value : 'overview'
+}
+
+function navigateFocus(focus: AutoresearchFocus): void {
+  const next: Record<string, string> = {
+    ...route.value.params,
+    section: 'cognition',
+    view: 'autoresearch',
+  }
+  if (focus === 'overview') {
+    delete next.focus
+  } else {
+    next.focus = focus
+  }
+  navigate('monitoring', next)
+}
+
+function AutoresearchFocusRail({ focus }: { focus: AutoresearchFocus }) {
+  return html`
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <${FilterChips}
+        chips=${FOCUS_CHIPS}
+        value=${focus}
+        onChange=${navigateFocus}
+        size="sm"
+        tone="accent"
+      />
+    </div>
+  `
+}
 
 function MonoBody({ children }: { children: unknown }) {
   return html`<div class="text-[var(--color-fg-secondary)] text-sm font-mono">${children}</div>`
@@ -439,6 +480,147 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
   `
 }
 
+function selectedCycles(
+  loop: AutoresearchLoopSummary | null,
+  detail: { history?: AutoresearchCycleRecord[] } | null,
+): AutoresearchCycleRecord[] {
+  return detail?.history ?? loop?.recent_cycles ?? []
+}
+
+function FindingFocusPanel() {
+  const loop = selectedLoop.value
+  const detail = loopDetail.value
+  const insights = detail?.insights ?? loop?.insights ?? []
+  const warnings = loop?.warnings ?? []
+
+  if (!loop) {
+    return html`
+      <${SurfaceCard} variant="compact">
+        <${EmptyState} message="Finding Card를 보려면 루프를 선택하세요." compact />
+      <//>
+    `
+  }
+
+  return html`
+    <${SurfaceCard} variant="compact">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-[1.15fr_0.85fr]">
+        <${InfoCard}>
+          <${Eyebrow}>Finding Card</${Eyebrow}>
+          <div class="mt-1 text-sm font-medium text-[var(--color-fg-primary)]">${loop.goal}</div>
+          <div class="mt-2 grid gap-2 text-xs text-[var(--color-fg-secondary)]">
+            <div>
+              <span class="text-[var(--color-fg-muted)]">current hypothesis</span>
+              <div class="mt-0.5 leading-relaxed">${loop.queued_hypothesis ?? '대기 가설 없음'}</div>
+            </div>
+            <div>
+              <span class="text-[var(--color-fg-muted)]">program note</span>
+              <div class="mt-0.5 leading-relaxed">${loop.program_note ?? 'program note 없음'}</div>
+            </div>
+          </div>
+        </${InfoCard}>
+
+        <${InfoCard}>
+          <${Eyebrow}>Evidence</${Eyebrow}>
+          <dl class="mt-2 grid grid-cols-[88px_1fr] gap-x-3 gap-y-1.5 text-xs">
+            <dt class="text-[var(--color-fg-muted)]">metric</dt>
+            <dd class="font-mono text-[var(--color-fg-secondary)]">${loop.metric_fn}</dd>
+            <dt class="text-[var(--color-fg-muted)]">target</dt>
+            <dd class="font-mono text-[var(--color-fg-secondary)]">${loop.target_file}</dd>
+            <dt class="text-[var(--color-fg-muted)]">best</dt>
+            <dd class="font-mono text-[var(--color-status-ok)]">${loop.best_score.toFixed(4)}</dd>
+            <dt class="text-[var(--color-fg-muted)]">status</dt>
+            <dd class="${statusColor(loop.status)}">${statusLabel(loop.status)}</dd>
+          </dl>
+        </${InfoCard}>
+      </div>
+
+      <div class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+        <${InfoCard}>
+          <${Eyebrow}>Insights</${Eyebrow}>
+          <div class="mt-2">
+            <${InsightsList} insights=${insights.slice(0, 3)} />
+          </div>
+        </${InfoCard}>
+        <${InfoCard}>
+          <${Eyebrow}>Warnings</${Eyebrow}>
+          <div class="mt-2">
+            ${warnings.length > 0
+              ? html`<${WarningsList} warnings=${warnings.slice(0, 3)} />`
+              : html`<${EmptyState} message="경고 없음" compact />`}
+          </div>
+        </${InfoCard}>
+      </div>
+    <//>
+  `
+}
+
+function FlowFocusPanel() {
+  const loop = selectedLoop.value
+  const cycles = selectedCycles(loop, loopDetail.value)
+  const latest = cycles[cycles.length - 1]
+
+  if (!loop) {
+    return html`
+      <${SurfaceCard} variant="compact">
+        <${EmptyState} message="Flow Snapshot을 보려면 루프를 선택하세요." compact />
+      <//>
+    `
+  }
+
+  const totalCycles = loop.total_keeps + loop.total_discards
+  const keepPct = totalCycles > 0 ? (loop.total_keeps / totalCycles) * 100 : 0
+
+  return html`
+    <${SurfaceCard} variant="compact">
+      <div class="grid grid-cols-1 gap-3 lg:grid-cols-[0.9fr_1.1fr]">
+        <${InfoCard}>
+          <${Eyebrow}>Flow Snapshot</${Eyebrow}>
+          <div class="mt-2 grid grid-cols-2 gap-3 text-xs">
+            <div>
+              <div class="text-[var(--color-fg-muted)]">kept</div>
+              <div class="mt-0.5 font-mono text-sm font-semibold text-[var(--color-status-ok)]">${loop.total_keeps}</div>
+            </div>
+            <div>
+              <div class="text-[var(--color-fg-muted)]">discarded</div>
+              <div class="mt-0.5 font-mono text-sm font-semibold text-[var(--color-status-err)]">${loop.total_discards}</div>
+            </div>
+            <div>
+              <div class="text-[var(--color-fg-muted)]">cycle</div>
+              <div class="mt-0.5 font-mono text-sm text-[var(--color-fg-primary)]">${loop.current_cycle} / ${loop.max_cycles}</div>
+            </div>
+            <div>
+              <div class="text-[var(--color-fg-muted)]">keep rate</div>
+              <div class="mt-0.5 font-mono text-sm text-[var(--color-fg-primary)]">${keepPct.toFixed(1)}%</div>
+            </div>
+          </div>
+          <div class="mt-3 h-2 overflow-hidden rounded-[var(--r-0)] bg-[var(--color-bg-hover)]">
+            <div
+              class="h-full bg-[var(--ok-48)] transition-[width] duration-[var(--t-slow)]"
+              style=${{ width: `${keepPct}%` }}
+            />
+          </div>
+        </${InfoCard}>
+
+        <${InfoCard}>
+          <${Eyebrow}>Latest Cycle</${Eyebrow}>
+          ${latest ? html`
+            <dl class="mt-2 grid grid-cols-[84px_1fr] gap-x-3 gap-y-1.5 text-xs">
+              <dt class="text-[var(--color-fg-muted)]">cycle</dt>
+              <dd class="font-mono text-[var(--color-fg-secondary)]">#${latest.cycle}</dd>
+              <dt class="text-[var(--color-fg-muted)]">hypothesis</dt>
+              <dd class="text-[var(--color-fg-secondary)]">${latest.hypothesis}</dd>
+              <dt class="text-[var(--color-fg-muted)]">delta</dt>
+              <dd class="font-mono ${latest.delta >= 0 ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}">${formatDelta(latest.delta)}</dd>
+              <dt class="text-[var(--color-fg-muted)]">decision</dt>
+              <dd class="text-[var(--color-fg-secondary)]">${decisionLabel(latest.decision)}</dd>
+            </dl>
+          ` : html`<${EmptyState} message="아직 cycle 기록이 없습니다." compact />`}
+        </${InfoCard}>
+      </div>
+    <//>
+  `
+}
+
 // --- Detail view ---
 
 function LoopDetailView() {
@@ -560,15 +742,24 @@ export function Autoresearch() {
   }
 
   const loops = isLoaded(state) ? state.data.loops : []
+  const focus = autoresearchFocusFromParam(route.value.params.focus)
 
   if (loops.length === 0) {
     return html`
       <div class="flex flex-col gap-4">
-        <${EmptyState}
-          message="실행된 오토리서치 루프가 없습니다."
-          icon="🔬"
-          action=${html`<${StartFormButton} />`}
-        />
+        <${AutoresearchFocusRail} focus=${focus} />
+        ${focus === 'finding'
+          ? html`<${FindingFocusPanel} />`
+          : focus === 'flow'
+            ? html`<${FlowFocusPanel} />`
+            : html`
+              <${EmptyState}
+                message="실행된 오토리서치 루프가 없습니다."
+                icon="🔬"
+                action=${html`<${StartFormButton} />`}
+              />
+            `}
+        ${focus !== 'overview' ? html`<div class="self-start"><${StartFormButton} /></div>` : null}
         ${showStartForm.value ? html`<${StartAutoresearchForm} />` : null}
       </div>
     `
@@ -576,7 +767,13 @@ export function Autoresearch() {
 
   return html`
     <div class="flex flex-col gap-5">
-      <${OutcomeVsHarnessCallout} loopCount=${loops.length} />
+      <${AutoresearchFocusRail} focus=${focus} />
+
+      ${focus === 'finding'
+        ? html`<${FindingFocusPanel} />`
+        : focus === 'flow'
+          ? html`<${FlowFocusPanel} />`
+          : html`<${OutcomeVsHarnessCallout} loopCount=${loops.length} />`}
 
       <div class="flex items-center justify-between">
         <${Eyebrow} class="font-medium">


### PR DESCRIPTION
## Summary
- add autoresearch focus tabs driven by `focus=finding` / `focus=flow`
- add first-screen Finding Card and Flow Snapshot panels while preserving the existing loop detail below
- keep focus-specific empty states useful when no runtime loops exist, including the existing start-loop action
- mark `ar-fnd` and `ar-flw` cockpit aliases covered

## Validation
- git diff --check
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/autoresearch.test.ts src/cockpit-entrypoints.test.ts src/components/cognition-plane.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard run lint (0 errors; 3 existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- pnpm --dir dashboard run build (passes; existing Vite mixed dynamic/static import and chunk-size warnings)
- browser: http://localhost:5174/dashboard/#monitoring?section=cognition&view=autoresearch&focus=finding renders the selected Finding Card focus tab and start-loop empty state; screenshot /tmp/masc-autoresearch-finding-0506.png
- browser: http://localhost:5174/dashboard/#monitoring?section=cognition&view=autoresearch&focus=flow renders the selected Flow Snapshot focus tab and start-loop empty state; screenshot /tmp/masc-autoresearch-flow-0506.png
- browser: #mode=Cognition&tab=ar-flow canonicalizes to #monitoring?mode=Cognition&section=cognition&view=autoresearch&focus=flow and renders the selected focus tab
- browser errors after final clear: none; console only Vite debug/HMR logs

## Review Focus
- Focus-param handling in `Autoresearch` for data-loaded and empty-runtime states.
- Whether the Finding Card / Flow Snapshot panels are sufficient to graduate the Kimi Agent autoresearch aliases from partial to covered.
