### PR TITLE
fix(metrics): preserve missing latency as null

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -5,6 +5,7 @@ import {
   fetchDashboardGoalDetail,
   fetchDashboardGoalsTree,
   fetchDashboardTools,
+  fetchCostLatency,
   fetchKeeperConfig,
   fetchRuntimeModelMetrics,
   fetchTlcResults,
@@ -1024,5 +1025,49 @@ describe('fetchRuntimeModelMetrics', () => {
     expect(metric.recent_entries?.[0]?.coverage_stage).toBe('oas')
     expect(metric.buckets?.[0]?.p95_latency_ms).toBeNull()
     expect(metric.buckets?.[0]?.cache_hit_ratio).toBeNull()
+  })
+})
+
+describe('fetchCostLatency', () => {
+  it('preserves missing latency percentiles as null instead of zero', async () => {
+    const rawResponse = {
+      perAgent: [
+        {
+          agent: 'unlatenced-model',
+          in_tok: 100,
+          out_tok: 50,
+          cost: 0.01,
+          p50_ms: null,
+          p95_ms: null,
+        },
+      ],
+      matrix: {
+        providers: ['local'],
+        models: ['unlatenced-model'],
+        grid: [[0.01]],
+      },
+      latencyBuckets: [],
+      p50: null,
+      p95: null,
+      total_cost_usd: 0.01,
+      window_minutes: 60,
+      generated_at: 1,
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchCostLatency(60)
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/cost-latency?window=60')
+    expect(result.p50).toBeNull()
+    expect(result.p95).toBeNull()
+    expect(result.perAgent[0]?.p50_ms).toBeNull()
+    expect(result.perAgent[0]?.p95_ms).toBeNull()
   })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2985,8 +2985,8 @@ export interface CostPerAgentRow {
   in_tok: number
   out_tok: number
   cost: number
-  p50_ms: number
-  p95_ms: number
+  p50_ms: number | null
+  p95_ms: number | null
 }
 
 export interface CostMatrix {
@@ -3005,8 +3005,8 @@ export interface CostLatencyResponse {
   perAgent: CostPerAgentRow[]
   matrix: CostMatrix
   latencyBuckets: CostLatencyBucket[]
-  p50: number
-  p95: number
+  p50: number | null
+  p95: number | null
   total_cost_usd: number
   window_minutes: number
   generated_at: number
@@ -3021,8 +3021,8 @@ function decodeCostPerAgentRow(raw: unknown): CostPerAgentRow | null {
     in_tok: asNumber(raw.in_tok) ?? 0,
     out_tok: asNumber(raw.out_tok) ?? 0,
     cost: asNumber(raw.cost) ?? 0,
-    p50_ms: asNumber(raw.p50_ms) ?? 0,
-    p95_ms: asNumber(raw.p95_ms) ?? 0,
+    p50_ms: asNumber(raw.p50_ms) ?? null,
+    p95_ms: asNumber(raw.p95_ms) ?? null,
   }
 }
 
@@ -3058,8 +3058,8 @@ function decodeCostLatencyResponse(raw: unknown): CostLatencyResponse | null {
             n: asNumber(b.n) ?? 0,
           }))
       : [],
-    p50: asNumber(raw.p50) ?? 0,
-    p95: asNumber(raw.p95) ?? 0,
+    p50: asNumber(raw.p50) ?? null,
+    p95: asNumber(raw.p95) ?? null,
     total_cost_usd: asNumber(raw.total_cost_usd) ?? 0,
     window_minutes: asNumber(raw.window_minutes) ?? 1440,
     generated_at: asNumber(raw.generated_at) ?? 0,

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -1431,6 +1431,7 @@ let provider_stats_to_json (s : provider_stats) : Yojson.Safe.t =
    derived from that single pass. *)
 
 let compute_cost_latency_json ~base_path ~window_minutes : Yojson.Safe.t =
+  let opt_float = function Some f -> `Float f | None -> `Null in
   let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
   let entries = read_all_entries ~base_path ~since_unix in
   let model_stats_list = aggregate_by_model entries in
@@ -1452,8 +1453,8 @@ let compute_cost_latency_json ~base_path ~window_minutes : Yojson.Safe.t =
            ; ("in_tok", `Int (Option.value ~default:0 m.total_input_tokens))
            ; ("out_tok", `Int (Option.value ~default:0 m.total_output_tokens))
            ; ("cost", `Float (Option.value ~default:0.0 m.total_cost_usd))
-           ; ("p50_ms", `Float (Option.value ~default:0.0 m.p50_latency_ms))
-           ; ("p95_ms", `Float (Option.value ~default:0.0 m.p95_latency_ms))
+           ; ("p50_ms", opt_float m.p50_latency_ms)
+           ; ("p95_ms", opt_float m.p95_latency_ms)
            ])
   in
 
@@ -1500,12 +1501,12 @@ let compute_cost_latency_json ~base_path ~window_minutes : Yojson.Safe.t =
   in
   Array.sort Float.compare all_latencies;
   let global_p50 =
-    if Array.length all_latencies = 0 then 0.0
-    else percentile all_latencies 50.0
+    if Array.length all_latencies = 0 then None
+    else Some (percentile all_latencies 50.0)
   in
   let global_p95 =
-    if Array.length all_latencies = 0 then 0.0
-    else percentile all_latencies 95.0
+    if Array.length all_latencies = 0 then None
+    else Some (percentile all_latencies 95.0)
   in
 
   (* total cost across all models *)
@@ -1534,8 +1535,8 @@ let compute_cost_latency_json ~base_path ~window_minutes : Yojson.Safe.t =
           ; ("grid", `List grid)
           ] )
     ; ("latencyBuckets", `List (List.map latency_bucket_to_json latency_buckets))
-    ; ("p50", `Float global_p50)
-    ; ("p95", `Float global_p95)
+    ; ("p50", opt_float global_p50)
+    ; ("p95", opt_float global_p95)
     ; ("total_cost_usd", `Float total_cost_usd)
     ; ("window_minutes", `Int window_minutes)
     ; ("generated_at", `Float (Time_compat.now ()))

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -235,8 +235,8 @@ val compute_cost_latency_json :
         "perAgent":      [ { "agent", "in_tok", "out_tok", "cost", "p50_ms", "p95_ms" } ],
         "matrix":        { "providers": [...], "models": [...], "grid": [[...]] },
         "latencyBuckets": [ { "lo", "hi", "n" } ],
-        "p50":           number,
-        "p95":           number,
+        "p50":           number | null,
+        "p95":           number | null,
         "total_cost_usd": number,
         "window_minutes": number,
         "generated_at":  unix_seconds
@@ -246,8 +246,10 @@ val compute_cost_latency_json :
     [perAgent] rows are sorted by cost descending and omit models with
     no cost/token signal.  [p50]/[p95] are exact global percentiles
     computed from all raw latency samples in the window (not an average
-    of per-model estimates).  [matrix.grid] is a [providers × models]
-    2-D array of cost values in the same order as the [providers] /
-    [models] index arrays.
+    of per-model estimates), or [null] when no latency sample
+    contributed. Per-agent [p50_ms]/[p95_ms] follow the same null
+    semantics. [matrix.grid] is a [providers × models] 2-D array of
+    cost values in the same order as the [providers] / [models] index
+    arrays.
 
     @since 2.300.0 *)

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -674,6 +674,39 @@ let test_cost_latency_json_composes_axes_and_percentiles () =
     check int "1s-4s bucket count" 1
       (List.nth buckets 1 |> member "n" |> to_int))
 
+let test_cost_latency_json_preserves_missing_latency_as_null () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "cost_latency_missing" in
+    let ts = now_unix () in
+    write_decisions path [
+      `Assoc [
+        ("ts_unix", `Float (ts -. 10.0));
+        ("tool_call_count", `Int 0);
+        ("tools_used", `List []);
+        ("telemetry", `Assoc [
+          ("model_used", `String "unlatenced-model");
+          ("provider", `String "local");
+          ("input_tokens", `Int 100);
+          ("output_tokens", `Int 50);
+          ("cost_usd", `Float 0.01);
+        ]);
+      ];
+    ];
+    let json = M.compute_cost_latency_json ~base_path:base ~window_minutes:60 in
+    let open Yojson.Safe.Util in
+    let per_agent = json |> member "perAgent" |> to_list in
+    check int "perAgent row count" 1 (List.length per_agent);
+    let row = List.hd per_agent in
+    check bool "per-agent p50 missing is null" true
+      (match row |> member "p50_ms" with `Null -> true | _ -> false);
+    check bool "per-agent p95 missing is null" true
+      (match row |> member "p95_ms" with `Null -> true | _ -> false);
+    check bool "global p50 missing is null" true
+      (match json |> member "p50" with `Null -> true | _ -> false);
+    check bool "global p95 missing is null" true
+      (match json |> member "p95" with `Null -> true | _ -> false))
+
 (* ── thinking_fraction tests ─────────────────────── *)
 
 let success_entry_with_thinking ~model ~ts ~thinking_enabled () =
@@ -1038,6 +1071,7 @@ let () =
       test_case "costs.jsonl backfills wall tok/sec" `Quick test_costs_jsonl_backfills_wall_tok_per_sec;
       test_case "costs.jsonl dedupes matching decision sample" `Quick test_costs_jsonl_dedupes_matching_decision_sample;
       test_case "cost latency json composes axes and percentiles" `Quick test_cost_latency_json_composes_axes_and_percentiles;
+      test_case "cost latency json preserves missing latency nulls" `Quick test_cost_latency_json_preserves_missing_latency_as_null;
       test_case "json roundtrip" `Quick test_json_roundtrip;
     ];
     "thinking_fraction", [


### PR DESCRIPTION
## Summary
- emit null, not 0.0, when cost-latency global latency percentiles have no contributing samples
- emit null for per-agent p50_ms and p95_ms when that model has token/cost signal but no latency sample
- update dashboard API decoding so null latency percentiles stay null instead of being coerced to zero

## Why it matters
The goal-driven plan calls out the 0ms root cause as a measurement falsehood: missing telemetry was indistinguishable from true zero-latency execution. This keeps real zero as zero while making absence explicit at the cost-latency API boundary.

## Verification
- scripts/dune-local.sh build test/test_model_inference_metrics.exe
- ./_build/default/test/test_model_inference_metrics.exe
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false