### PR TITLE
fix(dashboard): avoid tool-quality fleet rows

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -509,7 +509,7 @@ describe('FleetTelemetryPanel', () => {
     ])
   })
 
-  it('marks tool-quality-only fallback rows as known tool activity', async () => {
+  it('does not synthesize fleet runtime rows from tool-quality-only data', async () => {
     const { buildFleetRows } = await loadPanel({
       fetchDashboardExecution: vi.fn().mockResolvedValue(executionResponse),
       fetchToolQuality: vi.fn().mockResolvedValue(toolQualityResponse),
@@ -527,13 +527,7 @@ describe('FleetTelemetryPanel', () => {
       ],
     })
 
-    expect(rows).toHaveLength(1)
-    expect(rows[0]).toMatchObject({
-      name: 'keeper-tool-only',
-      tool_calls: 5,
-      tool_activity_known: true,
-      model: 'unknown',
-    })
+    expect(rows).toEqual([])
   })
 
   it('prefers tool-quality call counts when success data is present', async () => {
@@ -699,7 +693,7 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('glm-5.1')
   })
 
-  it('shows partial telemetry warnings while keeping degraded data visible', async () => {
+  it('shows partial telemetry warnings without treating tool quality as runtime state', async () => {
     const fetchDashboardExecution = vi.fn().mockRejectedValue(new Error('execution down'))
     const fetchToolQuality = vi.fn().mockResolvedValue({
       ...toolQualityResponse,
@@ -726,7 +720,9 @@ describe('FleetTelemetryPanel', () => {
 
     expect(container.textContent).toContain('부분 텔레메트리')
     expect(container.textContent).toContain('실행 스냅샷 사용 불가: execution down')
-    expect(container.textContent).toContain('keeper-fallback')
+    expect(container.textContent).not.toContain('keeper-fallback')
+    expect(container.textContent).toContain('Keeper 데이터 없음.')
+    expect(container.textContent).toContain('95.5%')
     expect(container.textContent).toContain('텔레메트리 저장소')
   }, 60_000)
 

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -515,6 +515,25 @@ describe('buildToolQualityMap', () => {
   })
 })
 
+describe('buildFleetRows', () => {
+  it('does not turn tool-quality-only data into runtime fleet rows', () => {
+    const rows = buildFleetRows([], {
+      total: 5,
+      success: 5,
+      failure: 0,
+      success_rate: 100,
+      by_tool: [],
+      by_keeper: [
+        { name: 'keeper-tool-only', calls: 5, success_pct: 100 },
+      ],
+      failure_categories: [],
+      hourly_trend: [],
+    })
+
+    expect(rows).toEqual([])
+  })
+})
+
 describe('buildRuntimeWarnings', () => {
   it('warns about admission queue blockage', () => {
     const rows = [makeRow({ runtime_blocker_class: 'admission_queue_wait_timeout' })]

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -460,43 +460,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
                 : 'env',
           }
         })
-      : toolQuality.by_keeper.map((keeper): FleetRow => ({
-          name: keeper.name,
-          status: 'unknown',
-          keepalive_running: false,
-          diagnostic_health_state: null,
-          diagnostic_summary: null,
-          context_ratio: 0,
-          turn_count: 0,
-          last_latency_ms: 0,
-          last_activity_ago_s: null,
-          activity_label: '최근 활동',
-          activity_source: 'none',
-          model: 'unknown',
-          cascade_label: null,
-          provider_label: null,
-          fallback_label: null,
-          tool_calls: keeper.calls,
-          tool_success_pct: keeper.success_pct,
-          tool_activity_known: keeper.calls > 0,
-          recent_tools: [],
-          runtime_blocker_class: null,
-          runtime_blocker_summary: null,
-          runtime_trust_attention: false,
-          runtime_trust_reason: null,
-          runtime_trust_next_action: null,
-          terminal_reason_code: null,
-          terminal_reason_severity: null,
-          tool_audit_at: null,
-          goal_label: null,
-          goal_linked: false,
-          active_goal_count: 0,
-          sandbox_profile: null,
-          sandbox_last_error: null,
-          effective_sandbox_image: null,
-          decision_required: false,
-          budget_source: null,
-        }))
+      : []
 
   return [...rows].sort(compareFleetRows)
 }


### PR DESCRIPTION
## Summary
- stop synthesizing fleet runtime rows from toolQuality.by_keeper when execution keepers are empty
- keep tool quality visible as aggregate telemetry without counting it as keeper runtime state
- update focused fleet telemetry tests for the separated evidence boundary

## Why it matters
The goal-driven plan flags fake dashboard data as an operator-trust problem. Tool-quality data is real evidence, but it is not a keeper runtime snapshot. This change prevents partial tool-quality evidence from appearing as unknown/offline fleet rows.

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false