### PR TITLE
fix(keeper): reconcile heartbeat task id

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -205,7 +205,9 @@ let process_directive ~agent_name directive =
 (* ── gRPC heartbeat stream ── *)
 
 let reconcile_current_task_id_for_heartbeat ~config ~agent_name =
-  try Keeper_current_task_reconcile.sync_current_task_id_for_agent_name ~config ~agent_name
+  try
+    Keeper_current_task_reconcile.sync_current_task_id_for_agent_name ~config ~agent_name;
+    true
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -216,14 +218,26 @@ let reconcile_current_task_id_for_heartbeat ~config ~agent_name =
     Log.Keeper.warn
       "gRPC heartbeat: failed to reconcile current_task_id for %s: %s"
       agent_name
-      (Printexc.to_string exn)
+      (Printexc.to_string exn);
+    false
+;;
+
+let registry_current_task_id agent_name =
+  match Keeper_registry.find_by_agent_name agent_name with
+  | Some e -> e.meta.current_task_id
+  | None -> None
 ;;
 
 let current_task_id_for_agent ~config agent_name =
-  reconcile_current_task_id_for_heartbeat ~config ~agent_name;
-  match Keeper_registry.find_by_agent_name agent_name with
-  | Some e -> (match e.meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "")
+  match registry_current_task_id agent_name with
   | None -> ""
+  | Some _ ->
+    if reconcile_current_task_id_for_heartbeat ~config ~agent_name then
+      match registry_current_task_id agent_name with
+      | Some task_id -> Keeper_id.Task_id.to_string task_id
+      | None -> ""
+    else
+      ""
 ;;
 
 let make_grpc_heartbeat_ping ~config ~agent_name ~session_id =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -204,18 +204,34 @@ let process_directive ~agent_name directive =
 
 (* ── gRPC heartbeat stream ── *)
 
-let current_task_id_for_agent agent_name =
+let reconcile_current_task_id_for_heartbeat ~config ~agent_name =
+  try Keeper_current_task_reconcile.sync_current_task_id_for_agent_name ~config ~agent_name
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_reconcile_failures
+      ~labels:[("keeper", agent_name); ("phase", "grpc_heartbeat")]
+      ();
+    Log.Keeper.warn
+      "gRPC heartbeat: failed to reconcile current_task_id for %s: %s"
+      agent_name
+      (Printexc.to_string exn)
+;;
+
+let current_task_id_for_agent ~config agent_name =
+  reconcile_current_task_id_for_heartbeat ~config ~agent_name;
   match Keeper_registry.find_by_agent_name agent_name with
   | Some e -> (match e.meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "")
   | None -> ""
 ;;
 
-let make_grpc_heartbeat_ping ~agent_name ~session_id =
+let make_grpc_heartbeat_ping ~config ~agent_name ~session_id =
   Masc_grpc_types.HeartbeatPing.
     { agent_name
     ; session_id
     ; timestamp_ms = Int64.of_float (Time_compat.now () *. 1000.0)
-    ; current_task_id = current_task_id_for_agent agent_name
+    ; current_task_id = current_task_id_for_agent ~config agent_name
     }
 ;;
 
@@ -234,6 +250,7 @@ let run_grpc_heartbeat_stream
       ~close_ref
       ~clock
       ~interval_sec
+      ~config
       ~agent_name
       ~session_id
       send
@@ -244,7 +261,7 @@ let run_grpc_heartbeat_stream
     then ()
     else (
       (try
-         send (make_grpc_heartbeat_ping ~agent_name ~session_id);
+         send (make_grpc_heartbeat_ping ~config ~agent_name ~session_id);
          match recv () with
          | Ok ack -> handle_grpc_heartbeat_ack ~agent_name ack
          | Error err ->
@@ -308,6 +325,7 @@ let run_grpc_heartbeat_fiber
       ~sw
       ~stop
       ~(grpc_client : Masc_grpc_client.t)
+      ~(config : Coord.config)
       ~(agent_name : string)
       ~(session_id : string)
       ~(interval_sec : float)
@@ -347,6 +365,7 @@ let run_grpc_heartbeat_fiber
                ~close_ref
                ~clock
                ~interval_sec
+               ~config
                ~agent_name
                ~session_id
                send
@@ -390,6 +409,7 @@ let start_keeper_grpc_heartbeat
       ~sw:ctx.sw
       ~stop
       ~grpc_client:client
+      ~config:ctx.config
       ~agent_name:m.agent_name
       ~session_id
       ~interval_sec:interval

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -16,7 +16,9 @@ val set_grpc_client : ?env:Eio_unix.Stdenv.base -> Masc_grpc_client.t -> unit
     Supported: "pause", "resume", "wakeup", "claim:<task_id>". *)
 val process_directive : agent_name:string -> string -> unit
 
-(** Test-visible helper for the [current_task_id] sent in gRPC heartbeats. *)
+(** Test-visible helper for the [current_task_id] sent in gRPC heartbeats.
+    This may reconcile registry state against the task backlog before reading
+    the value, and returns an empty string when reconciliation cannot be trusted. *)
 val current_task_id_for_agent : config:Coord.config -> string -> string
 
 (** Wake up a specific keeper immediately. Used by broadcast notification

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -16,6 +16,9 @@ val set_grpc_client : ?env:Eio_unix.Stdenv.base -> Masc_grpc_client.t -> unit
     Supported: "pause", "resume", "wakeup", "claim:<task_id>". *)
 val process_directive : agent_name:string -> string -> unit
 
+(** Test-visible helper for the [current_task_id] sent in gRPC heartbeats. *)
+val current_task_id_for_agent : config:Coord.config -> string -> string
+
 (** Wake up a specific keeper immediately. Used by broadcast notification
     when a @mention targets a running keeper.
 

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -299,6 +299,38 @@ let test_stale_current_task_id_is_cleared_from_backlog () =
       check (option string) "stale current_task_id cleared" None
         (current_task_id_string synced)))
 
+let test_heartbeat_current_task_id_reconciles_terminal_backlog () =
+  with_room (fun config ->
+    let meta = make_test_meta ~name:"heartbeat-keeper" () in
+    with_registered_keeper config meta (fun () ->
+      let _ =
+        Coord.add_task config ~title:"Heartbeat stale task" ~priority:1
+          ~description:"desc"
+      in
+      let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+      let json = parse_json result in
+      let task_id =
+        Yojson.Safe.Util.(
+          json |> member "claimed_task" |> member "task_id" |> to_string)
+      in
+      (match
+         Coord.force_done_task_r config ~agent_name:meta.agent_name ~task_id
+           ~notes:"terminal in backlog" ()
+       with
+       | Ok _ -> ()
+       | Error msg -> fail (Masc_domain.masc_error_to_string msg));
+      let current_task_id =
+        Keeper_keepalive.current_task_id_for_agent ~config meta.agent_name
+      in
+      check string "heartbeat task id cleared" "" current_task_id;
+      let registry_meta =
+        match Keeper_registry.get ~base_path:config.Coord.base_path meta.name with
+        | Some entry -> entry.meta
+        | None -> fail "expected keeper registry entry"
+      in
+      check (option string) "registry current_task_id cleared" None
+        (current_task_id_string registry_meta)))
+
 let test_claim_empty_room () =
   with_room (fun config ->
     let meta = make_test_meta () in
@@ -990,6 +1022,8 @@ let () =
         test_release_clears_keeper_current_task_id;
       test_case "stale current_task_id clears from backlog" `Quick
         test_stale_current_task_id_is_cleared_from_backlog;
+      test_case "heartbeat current_task_id reconciles terminal backlog" `Quick
+        test_heartbeat_current_task_id_reconciles_terminal_backlog;
       test_case "claim empty room" `Quick test_claim_empty_room;
       test_case "claim respects active_goal_ids" `Quick
         test_claim_respects_active_goal_ids;


### PR DESCRIPTION
Refs #13460.

## Why
#13460 showed stale task state escaping into keeper-facing broadcasts after the backlog had already moved terminal. The existing Keeper_current_task_reconcile helper was used by run context assembly, but the gRPC heartbeat ping path read registry meta directly before emitting current_task_id.

## What changed
- Reconcile keeper current_task_id against backlog before building gRPC heartbeat pings.
- Treat reconciliation failure as observable via metric_keeper_reconcile_failures{phase="grpc_heartbeat"} while preserving heartbeat liveness.
- Add regression: claim task -> force terminal in backlog -> heartbeat lookup clears registry current_task_id and emits an empty task id.

## Scope note
This is the heartbeat slice for #13460. It does not yet cover namespace mention tracker emitters or every task-state cache named in the issue; those remain follow-up PRs.

## Validation
- ocamlc -stop-after parsing lib/keeper/keeper_keepalive.mli lib/keeper/keeper_keepalive.ml test/test_keeper_task_dispatch.ml
- scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe test claim
- git diff --check