### PR TITLE
fix(dashboard): focus planning accountability routes

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -127,4 +127,22 @@ describe('cockpit entrypoint registry', () => {
       target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } },
     })
   })
+
+  it('marks planning focus cockpit entries as route-covered', () => {
+    const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
+      entrypoint.aliases.map(alias => [alias, entrypoint] as const),
+    ))
+
+    expect(byAlias.get('task-st')?.coverage).toBe('covered')
+    expect(byAlias.get('acc-led')?.coverage).toBe('covered')
+    expect(byAlias.get('acc-mtx')?.coverage).toBe('covered')
+    expect(cockpitTargetForParams({ mode: 'Work', tab: 'acc-led' })).toEqual({
+      tab: 'workspace',
+      params: { section: 'planning', focus: 'accountability-ledger' },
+    })
+    expect(cockpitTargetForParams({ mode: 'Work', tab: 'acc-mtx' })).toEqual({
+      tab: 'workspace',
+      params: { section: 'planning', focus: 'accountability-matrix' },
+    })
+  })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -43,10 +43,10 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'work', aliases: ['goal-t', 'goal-tree'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['goal-d', 'goal-snapshot', 'goal-snapshot-diff'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree', focus: 'snapshot' } }, coverage: 'backend-blocked' },
   { mode: 'work', aliases: ['task-bl', 'task-backlog'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['task-st', 'task-stale'], target: { tab: 'workspace', params: { section: 'planning', view: 'default', focus: 'stale' } }, coverage: 'partial' },
+  { mode: 'work', aliases: ['task-st', 'task-stale'], target: { tab: 'workspace', params: { section: 'planning', view: 'default', focus: 'stale' } }, coverage: 'covered' },
   { mode: 'work', aliases: ['task-w', 'task-wall'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'partial' },
-  { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'partial' },
+  { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'covered' },
+  { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'covered' },
 
   // Comms Plane: board, message focus, and composer surfaces have production coverage.
   { mode: 'comms', aliases: ['bd-feed', 'board-feed'], target: { tab: 'workspace', params: { section: 'board' } }, coverage: 'covered' },

--- a/dashboard/src/components/goals/task-stale-alert.ts
+++ b/dashboard/src/components/goals/task-stale-alert.ts
@@ -17,20 +17,20 @@ import type { Task } from '../../types'
 // 30 minutes in seconds. Matches the spec's "claim_age ends in `h` or
 // > 10 minutes" rule of thumb but lifted slightly to avoid noise on
 // fast-iterating tasks. Keep this as a named constant — `feedback_no-hyperparameter-as-env-knob`.
-const STALE_THRESHOLD_SECONDS = 30 * 60
+export const STALE_THRESHOLD_SECONDS = 30 * 60
 
-interface StaleEntry {
+export interface StaleEntry {
   task: Task
   ageSeconds: number
   label: string
 }
 
-function ageSeconds(task: Task): number | null {
+function ageSeconds(task: Task, nowMs = Date.now()): number | null {
   const ref = task.updated_at ?? task.created_at
   if (!ref) return null
   const ts = Date.parse(ref)
   if (Number.isNaN(ts)) return null
-  return Math.max(0, Math.floor((Date.now() - ts) / 1000))
+  return Math.max(0, Math.floor((nowMs - ts) / 1000))
 }
 
 function ageLabel(s: number): string {
@@ -40,16 +40,20 @@ function ageLabel(s: number): string {
   return `${Math.floor(s / 86400)}d`
 }
 
-const staleEntries = computed<StaleEntry[]>(() => {
+export function deriveStaleTaskEntries(taskList: Task[], nowMs = Date.now()): StaleEntry[] {
   const acc: StaleEntry[] = []
-  for (const t of tasks.value) {
+  for (const t of taskList) {
     if (t.status !== 'claimed' && t.status !== 'in_progress') continue
-    const age = ageSeconds(t)
+    const age = ageSeconds(t, nowMs)
     if (age == null || age < STALE_THRESHOLD_SECONDS) continue
     acc.push({ task: t, ageSeconds: age, label: ageLabel(age) })
   }
   acc.sort((a, b) => b.ageSeconds - a.ageSeconds)
   return acc
+}
+
+const staleEntries = computed<StaleEntry[]>(() => {
+  return deriveStaleTaskEntries(tasks.value)
 })
 
 export function TaskStaleAlert() {

--- a/dashboard/src/components/planning-focus-panel.ts
+++ b/dashboard/src/components/planning-focus-panel.ts
@@ -54,10 +54,8 @@ const activeFocus = computed<PlanningFocus>(() => {
 
 function updateFocusParam(focus: PlanningFocus): void {
   if (focus === 'none') {
-    const view = route.value.params.view
-    replaceRoute('workspace', view && view !== 'goal-tree'
-      ? { section: 'planning', view }
-      : { section: 'planning' })
+    const { focus: _focus, ...params } = route.value.params
+    replaceRoute('workspace', { ...params, section: 'planning' })
     return
   }
 
@@ -132,6 +130,11 @@ function deriveAccountabilityRows(
     }))
     .sort((a, b) => b.stale - a.stale || b.active - a.active || b.total - a.total || a.principal.localeCompare(b.principal))
 }
+
+const staleEntriesForPlanning = computed<StaleEntry[]>(() => deriveStaleTaskEntries(tasks.value))
+const accountabilityRowsForPlanning = computed<AccountabilityRow[]>(() =>
+  deriveAccountabilityRows(tasks.value, goals.value, staleEntriesForPlanning.value),
+)
 
 function statusToneClass(status: TaskStatusBucket): string {
   switch (status) {
@@ -251,13 +254,17 @@ function LedgerFocus({ rows }: { rows: AccountabilityRow[] }) {
             <li key=${row.principal} class="rounded-[var(--r-1)] border border-card-border/60 bg-black/10 p-3">
               <div class="flex flex-wrap items-start justify-between gap-3">
                 <div class="min-w-0">
-                  <button
-                    type="button"
-                    class="font-mono text-xs font-semibold text-text-strong hover:underline"
-                    onClick=${() => row.principal !== 'unassigned' && navigate('monitoring', { section: 'agents', view: 'keepers', keeper: row.principal })}
-                  >
-                    ${row.principal}
-                  </button>
+                  ${row.principal === 'unassigned' ? html`
+                    <span class="font-mono text-xs font-semibold text-text-muted">${row.principal}</span>
+                  ` : html`
+                    <button
+                      type="button"
+                      class="font-mono text-xs font-semibold text-text-strong hover:underline"
+                      onClick=${() => navigate('monitoring', { section: 'agents', view: 'keepers', keeper: row.principal })}
+                    >
+                      ${row.principal}
+                    </button>
+                  `}
                   <div class="mt-1 text-3xs text-text-muted">
                     active ${row.active} · total ${row.total}${row.stale > 0 ? ` · stale ${row.stale}` : ''}
                   </div>
@@ -341,8 +348,8 @@ function MatrixFocus({ rows }: { rows: AccountabilityRow[] }) {
 
 export function PlanningFocusPanel() {
   const focus = activeFocus.value
-  const staleEntries = deriveStaleTaskEntries(tasks.value)
-  const rows = deriveAccountabilityRows(tasks.value, goals.value, staleEntries)
+  const staleEntries = staleEntriesForPlanning.value
+  const rows = accountabilityRowsForPlanning.value
   const chips = FOCUS_CHIPS.map(chip => ({
     ...chip,
     count: chip.key === 'stale'

--- a/dashboard/src/components/planning-focus-panel.ts
+++ b/dashboard/src/components/planning-focus-panel.ts
@@ -1,0 +1,369 @@
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { navigate, replaceRoute, route } from '../router'
+import { goals, tasks } from '../store'
+import type { Goal, Task } from '../types'
+import { FilterChips } from './common/filter-chips'
+import { deriveStaleTaskEntries, STALE_THRESHOLD_SECONDS, type StaleEntry } from './goals/task-stale-alert'
+
+type PlanningFocus = 'none' | 'stale' | 'accountability-ledger' | 'accountability-matrix'
+type TaskStatusBucket = 'todo' | 'claimed' | 'in_progress' | 'awaiting_verification' | 'done' | 'other'
+
+interface AccountabilityTask {
+  task: Task
+  status: TaskStatusBucket
+  stale: boolean
+  goalTitle: string | null
+}
+
+interface AccountabilityRow {
+  principal: string
+  total: number
+  active: number
+  stale: number
+  counts: Record<TaskStatusBucket, number>
+  tasks: AccountabilityTask[]
+}
+
+const FOCUS_CHIPS: Array<{ key: PlanningFocus; label: string; title?: string }> = [
+  { key: 'none', label: '전체' },
+  { key: 'stale', label: '점유 지연', title: 'claimed/in_progress 태스크 중 오래 갱신되지 않은 항목' },
+  { key: 'accountability-ledger', label: '책임 원장', title: 'assignee별 활성 태스크와 정체 신호' },
+  { key: 'accountability-matrix', label: '책임 매트릭스', title: 'assignee x 태스크 상태 분포' },
+]
+
+const STATUS_BUCKETS: TaskStatusBucket[] = ['todo', 'claimed', 'in_progress', 'awaiting_verification', 'done', 'other']
+
+const STATUS_LABELS: Record<TaskStatusBucket, string> = {
+  todo: 'todo',
+  claimed: 'claimed',
+  in_progress: 'progress',
+  awaiting_verification: 'verify',
+  done: 'done',
+  other: 'other',
+}
+
+function isPlanningFocus(v: string | undefined): v is Exclude<PlanningFocus, 'none'> {
+  return v === 'stale' || v === 'accountability-ledger' || v === 'accountability-matrix'
+}
+
+const activeFocus = computed<PlanningFocus>(() => {
+  const focus = route.value.params.focus
+  return isPlanningFocus(focus) ? focus : 'none'
+})
+
+function updateFocusParam(focus: PlanningFocus): void {
+  if (focus === 'none') {
+    const view = route.value.params.view
+    replaceRoute('workspace', view && view !== 'goal-tree'
+      ? { section: 'planning', view }
+      : { section: 'planning' })
+    return
+  }
+
+  replaceRoute('workspace', focus === 'stale'
+    ? { section: 'planning', view: 'default', focus }
+    : { section: 'planning', focus })
+}
+
+function statusBucket(status: Task['status']): TaskStatusBucket {
+  if (status === 'todo' || status === 'claimed' || status === 'in_progress' || status === 'awaiting_verification' || status === 'done') {
+    return status
+  }
+  return 'other'
+}
+
+function taskTimeMs(task: Task): number {
+  const ref = task.updated_at ?? task.created_at
+  if (!ref) return 0
+  const parsed = Date.parse(ref)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+function principalForTask(task: Task): string {
+  const assignee = task.assignee?.trim()
+  return assignee && assignee.length > 0 ? assignee : 'unassigned'
+}
+
+function buildGoalTitleLookup(goalList: Goal[]): Map<string, string> {
+  const lookup = new Map<string, string>()
+  for (const goal of goalList) lookup.set(goal.id, goal.title)
+  return lookup
+}
+
+function deriveAccountabilityRows(
+  taskList: Task[],
+  goalList: Goal[],
+  staleEntries: StaleEntry[],
+): AccountabilityRow[] {
+  const staleIds = new Set(staleEntries.map(entry => entry.task.id))
+  const goalTitles = buildGoalTitleLookup(goalList)
+  const rows = new Map<string, AccountabilityRow>()
+
+  for (const task of taskList) {
+    const principal = principalForTask(task)
+    const bucket = statusBucket(task.status)
+    const row = rows.get(principal) ?? {
+      principal,
+      total: 0,
+      active: 0,
+      stale: 0,
+      counts: { todo: 0, claimed: 0, in_progress: 0, awaiting_verification: 0, done: 0, other: 0 },
+      tasks: [],
+    }
+    const stale = staleIds.has(task.id)
+    row.total += 1
+    row.counts[bucket] += 1
+    if (bucket !== 'done') row.active += 1
+    if (stale) row.stale += 1
+    row.tasks.push({
+      task,
+      status: bucket,
+      stale,
+      goalTitle: task.goal_id ? goalTitles.get(task.goal_id) ?? null : null,
+    })
+    rows.set(principal, row)
+  }
+
+  return [...rows.values()]
+    .map(row => ({
+      ...row,
+      tasks: row.tasks.sort((a, b) => taskTimeMs(b.task) - taskTimeMs(a.task)),
+    }))
+    .sort((a, b) => b.stale - a.stale || b.active - a.active || b.total - a.total || a.principal.localeCompare(b.principal))
+}
+
+function statusToneClass(status: TaskStatusBucket): string {
+  switch (status) {
+    case 'claimed':
+    case 'in_progress':
+      return 'border-warn/30 bg-warn/10 text-warn'
+    case 'awaiting_verification':
+      return 'border-[var(--accent-30)] bg-[var(--accent-10)] text-accent-fg'
+    case 'done':
+      return 'border-ok/30 bg-ok/10 text-ok'
+    default:
+      return 'border-card-border/60 bg-[var(--color-bg-elevated)] text-text-muted'
+  }
+}
+
+function shortTaskId(id: string): string {
+  return id.length > 12 ? id.slice(0, 12) : id
+}
+
+function FocusFrame({
+  title,
+  meta,
+  count,
+  children,
+}: {
+  title: string
+  meta: string
+  count: string | number
+  children: unknown
+}) {
+  return html`
+    <section class="rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3" aria-label=${title}>
+      <header class="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-text-muted">planning focus</div>
+          <h3 class="mt-1 text-sm font-semibold text-text-strong">${title}</h3>
+          <p class="mt-1 text-xs leading-relaxed text-text-muted">${meta}</p>
+        </div>
+        <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-3xs text-text-body">
+          ${count}
+        </span>
+      </header>
+      <div class="mt-3">${children}</div>
+    </section>
+  `
+}
+
+function EmptyFocus({ message }: { message: string }) {
+  return html`
+    <div class="rounded-[var(--r-1)] border border-card-border/50 bg-black/10 px-3 py-4 text-xs text-text-muted">
+      ${message}
+    </div>
+  `
+}
+
+function StaleFocus({ entries }: { entries: StaleEntry[] }) {
+  return html`
+    <${FocusFrame}
+      title="오래된 태스크 점유"
+      meta=${`claimed/in_progress 상태에서 ${Math.floor(STALE_THRESHOLD_SECONDS / 60)}분 이상 갱신되지 않은 항목입니다.`}
+      count=${`${entries.length} stale`}
+    >
+      ${entries.length === 0 ? html`
+        <${EmptyFocus} message="현재 오래 점유된 태스크가 없습니다." />
+      ` : html`
+        <ul class="grid gap-2" data-testid="planning-focus-stale">
+          ${entries.slice(0, 8).map(entry => html`
+            <li key=${entry.task.id} class="grid gap-2 rounded-[var(--r-1)] border border-warn/25 bg-warn/5 px-3 py-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+              <div class="min-w-0">
+                <button
+                  type="button"
+                  class="font-mono text-2xs text-text-strong hover:underline"
+                  title=${entry.task.id}
+                  onClick=${() => navigate('workspace', { section: 'planning', view: 'default', task: entry.task.id, focus: 'stale' })}
+                >
+                  ${shortTaskId(entry.task.id)}
+                </button>
+                <div class="mt-1 truncate text-sm font-medium text-text-strong">${entry.task.title}</div>
+                <div class="mt-1 flex flex-wrap gap-1.5 text-3xs text-text-muted">
+                  ${entry.task.assignee ? html`<span>@${entry.task.assignee}</span>` : html`<span>unassigned</span>`}
+                  ${entry.task.goal_id ? html`<span>goal ${entry.task.goal_id}</span>` : null}
+                </div>
+              </div>
+              <div class="flex flex-wrap items-center gap-1.5 md:justify-end">
+                <span class="rounded-[var(--r-1)] border border-warn/40 bg-warn/10 px-2 py-1 font-mono text-3xs text-warn">${entry.label}</span>
+                ${entry.task.assignee ? html`
+                  <button
+                    type="button"
+                    class="rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-10)] px-2 py-1 font-mono text-3xs text-accent-fg hover:bg-[var(--accent-15)]"
+                    onClick=${() => entry.task.assignee && navigate('monitoring', { section: 'agents', view: 'keepers', keeper: entry.task.assignee })}
+                  >
+                    nudge
+                  </button>
+                ` : null}
+              </div>
+            </li>
+          `)}
+        </ul>
+      `}
+    <//>
+  `
+}
+
+function LedgerFocus({ rows }: { rows: AccountabilityRow[] }) {
+  const activeRows = rows.filter(row => row.active > 0 || row.stale > 0)
+  return html`
+    <${FocusFrame}
+      title="책임 원장"
+      meta="assignee별 활성 태스크, 검증 대기, 오래된 점유를 한 줄에서 확인합니다."
+      count=${`${rows.length} principals`}
+    >
+      ${rows.length === 0 ? html`
+        <${EmptyFocus} message="아직 책임자에 연결된 태스크가 없습니다." />
+      ` : html`
+        <ul class="grid gap-2" data-testid="planning-focus-ledger">
+          ${(activeRows.length > 0 ? activeRows : rows).slice(0, 8).map(row => html`
+            <li key=${row.principal} class="rounded-[var(--r-1)] border border-card-border/60 bg-black/10 p-3">
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <button
+                    type="button"
+                    class="font-mono text-xs font-semibold text-text-strong hover:underline"
+                    onClick=${() => row.principal !== 'unassigned' && navigate('monitoring', { section: 'agents', view: 'keepers', keeper: row.principal })}
+                  >
+                    ${row.principal}
+                  </button>
+                  <div class="mt-1 text-3xs text-text-muted">
+                    active ${row.active} · total ${row.total}${row.stale > 0 ? ` · stale ${row.stale}` : ''}
+                  </div>
+                </div>
+                <div class="flex flex-wrap gap-1">
+                  ${STATUS_BUCKETS.map(status => row.counts[status] > 0 ? html`
+                    <span key=${status} class="rounded-[var(--r-1)] border px-2 py-1 font-mono text-3xs ${statusToneClass(status)}">
+                      ${STATUS_LABELS[status]} ${row.counts[status]}
+                    </span>
+                  ` : null)}
+                </div>
+              </div>
+              <div class="mt-3 grid gap-1.5">
+                ${row.tasks.slice(0, 3).map(item => html`
+                  <button
+                    key=${item.task.id}
+                    type="button"
+                    class="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-[var(--r-1)] border border-card-border/40 bg-[var(--color-bg-elevated)] px-2 py-1.5 text-left hover:border-card-border/80"
+                    onClick=${() => navigate('workspace', { section: 'planning', view: 'default', task: item.task.id })}
+                  >
+                    <span class="font-mono text-3xs text-text-muted">${shortTaskId(item.task.id)}</span>
+                    <span class="min-w-0 truncate text-xs text-text-body">${item.task.title}</span>
+                    <span class="rounded-[var(--r-1)] border px-1.5 py-0.5 font-mono text-3xs ${item.stale ? 'border-warn/40 bg-warn/10 text-warn' : statusToneClass(item.status)}">
+                      ${item.stale ? 'stale' : STATUS_LABELS[item.status]}
+                    </span>
+                  </button>
+                `)}
+              </div>
+            </li>
+          `)}
+        </ul>
+      `}
+    <//>
+  `
+}
+
+function MatrixCell({ value, tone }: { value: number; tone: TaskStatusBucket }) {
+  return html`
+    <td class="border-t border-card-border/50 px-2 py-2 text-right font-mono text-2xs tabular-nums ${value > 0 ? statusToneClass(tone) : 'text-text-dim'}">
+      ${value}
+    </td>
+  `
+}
+
+function MatrixFocus({ rows }: { rows: AccountabilityRow[] }) {
+  return html`
+    <${FocusFrame}
+      title="책임 매트릭스"
+      meta="assignee x 상태 분포로 병목 구간과 검증 대기 집중도를 비교합니다."
+      count=${`${rows.length} rows`}
+    >
+      ${rows.length === 0 ? html`
+        <${EmptyFocus} message="매트릭스로 표시할 태스크가 없습니다." />
+      ` : html`
+        <div class="overflow-x-auto" data-testid="planning-focus-matrix">
+          <table class="w-full min-w-150 border-separate border-spacing-0 text-xs" aria-label="책임 매트릭스">
+            <thead>
+              <tr class="text-left font-mono text-3xs uppercase tracking-[var(--track-caps)] text-text-muted">
+                <th class="px-2 py-2">assignee</th>
+                ${STATUS_BUCKETS.map(status => html`<th key=${status} class="px-2 py-2 text-right">${STATUS_LABELS[status]}</th>`)}
+                <th class="px-2 py-2 text-right">stale</th>
+                <th class="px-2 py-2 text-right">active</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${rows.slice(0, 12).map(row => html`
+                <tr key=${row.principal}>
+                  <th class="border-t border-card-border/50 px-2 py-2 text-left font-mono text-2xs text-text-strong">${row.principal}</th>
+                  ${STATUS_BUCKETS.map(status => html`<${MatrixCell} key=${status} value=${row.counts[status]} tone=${status} />`)}
+                  <td class="border-t border-card-border/50 px-2 py-2 text-right font-mono text-2xs tabular-nums ${row.stale > 0 ? 'text-warn' : 'text-text-dim'}">${row.stale}</td>
+                  <td class="border-t border-card-border/50 px-2 py-2 text-right font-mono text-2xs tabular-nums text-text-body">${row.active}</td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+      `}
+    <//>
+  `
+}
+
+export function PlanningFocusPanel() {
+  const focus = activeFocus.value
+  const staleEntries = deriveStaleTaskEntries(tasks.value)
+  const rows = deriveAccountabilityRows(tasks.value, goals.value, staleEntries)
+  const chips = FOCUS_CHIPS.map(chip => ({
+    ...chip,
+    count: chip.key === 'stale'
+      ? staleEntries.length
+      : chip.key === 'accountability-ledger' || chip.key === 'accountability-matrix'
+        ? rows.length
+        : null,
+  }))
+
+  return html`
+    <div class="flex flex-col gap-3" aria-label="계획 포커스">
+      <${FilterChips}
+        chips=${chips}
+        value=${focus}
+        onChange=${updateFocusParam}
+        size="sm"
+        tone="accent"
+      />
+      ${focus === 'stale' ? html`<${StaleFocus} entries=${staleEntries} />` : null}
+      ${focus === 'accountability-ledger' ? html`<${LedgerFocus} rows=${rows} />` : null}
+      ${focus === 'accountability-matrix' ? html`<${MatrixFocus} rows=${rows} />` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/planning-focus-panel.ts
+++ b/dashboard/src/components/planning-focus-panel.ts
@@ -53,15 +53,16 @@ const activeFocus = computed<PlanningFocus>(() => {
 })
 
 function updateFocusParam(focus: PlanningFocus): void {
+  const params: Record<string, string> = { ...route.value.params, section: 'planning' }
   if (focus === 'none') {
-    const { focus: _focus, ...params } = route.value.params
-    replaceRoute('workspace', { ...params, section: 'planning' })
+    delete params.focus
+    replaceRoute('workspace', params)
     return
   }
 
-  replaceRoute('workspace', focus === 'stale'
-    ? { section: 'planning', view: 'default', focus }
-    : { section: 'planning', focus })
+  params.focus = focus
+  if (focus === 'stale') params.view = 'default'
+  replaceRoute('workspace', params)
 }
 
 function statusBucket(status: Task['status']): TaskStatusBucket {
@@ -69,6 +70,10 @@ function statusBucket(status: Task['status']): TaskStatusBucket {
     return status
   }
   return 'other'
+}
+
+function isActiveStatusBucket(status: TaskStatusBucket): boolean {
+  return status === 'todo' || status === 'claimed' || status === 'in_progress' || status === 'awaiting_verification'
 }
 
 function taskTimeMs(task: Task): number {
@@ -112,7 +117,7 @@ function deriveAccountabilityRows(
     const stale = staleIds.has(task.id)
     row.total += 1
     row.counts[bucket] += 1
-    if (bucket !== 'done') row.active += 1
+    if (isActiveStatusBucket(bucket)) row.active += 1
     if (stale) row.stale += 1
     row.tasks.push({
       task,
@@ -320,7 +325,7 @@ function MatrixFocus({ rows }: { rows: AccountabilityRow[] }) {
         <${EmptyFocus} message="매트릭스로 표시할 태스크가 없습니다." />
       ` : html`
         <div class="overflow-x-auto" data-testid="planning-focus-matrix">
-          <table class="w-full min-w-150 border-separate border-spacing-0 text-xs" aria-label="책임 매트릭스">
+          <table class="w-full min-w-[37.5rem] border-separate border-spacing-0 text-xs" aria-label="책임 매트릭스">
             <thead>
               <tr class="text-left font-mono text-3xs uppercase tracking-[var(--track-caps)] text-text-muted">
                 <th class="px-2 py-2">assignee</th>

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -11,15 +11,22 @@ const routeSignal = signal<{ tab: string; params: Record<string, string>; postId
 
 vi.mock('../router', () => ({
   get route() { return routeSignal },
+  navigate: vi.fn((tab: string, params?: Record<string, string>) => {
+    routeSignal.value = { tab, params: params ?? {}, postId: null }
+  }),
   replaceRoute: vi.fn((tab: string, params?: Record<string, string>) => {
     routeSignal.value = { tab, params: params ?? {}, postId: null }
   }),
 }))
 
 const coordinationSignal = signal<unknown>(null)
+const tasksSignal = signal<unknown[]>([])
+const goalsSignal = signal<unknown[]>([])
 
 vi.mock('../store', () => ({
   get coordinationFsmSnapshot() { return coordinationSignal },
+  get tasks() { return tasksSignal },
+  get goals() { return goalsSignal },
 }))
 
 vi.mock('./goals', () => ({
@@ -31,9 +38,10 @@ vi.mock('./goals/goal-tree', () => ({
 
 import { PlanningPanel } from './planning-panel'
 
-function setRoute(view?: string) {
+function setRoute(view?: string, focus?: string) {
   const params: Record<string, string> = { section: 'planning' }
   if (view) params.view = view
+  if (focus) params.focus = focus
   routeSignal.value = { tab: 'workspace', params, postId: null }
 }
 
@@ -41,6 +49,8 @@ describe('PlanningPanel', () => {
   beforeEach(() => {
     setRoute()
     coordinationSignal.value = null
+    tasksSignal.value = []
+    goalsSignal.value = []
   })
   afterEach(() => cleanup())
 
@@ -121,5 +131,76 @@ describe('PlanningPanel', () => {
     expect(screen.getAllByText('telemetry/task_completed').length).toBeGreaterThan(0)
     expect(screen.getByText('board/post')).toBeTruthy()
     expect(screen.getAllByText('task completed').length).toBeGreaterThan(0)
+  })
+
+  it('renders stale task focus from route param', () => {
+    setRoute('default', 'stale')
+    tasksSignal.value = [
+      {
+        id: 'task-stale-001',
+        title: 'Review blocked planning handoff',
+        status: 'claimed',
+        assignee: 'sangsu',
+        goal_id: 'goal-1',
+        updated_at: '2020-01-01T00:00:00Z',
+      },
+    ]
+
+    render(html`<${PlanningPanel} />`)
+
+    expect(screen.getByTestId('planning-focus-stale')).toBeTruthy()
+    expect(screen.getByText('오래된 태스크 점유')).toBeTruthy()
+    expect(screen.getByText('Review blocked planning handoff')).toBeTruthy()
+    expect(screen.getByText('@sangsu')).toBeTruthy()
+  })
+
+  it('renders accountability ledger focus from route param', () => {
+    setRoute(undefined, 'accountability-ledger')
+    tasksSignal.value = [
+      {
+        id: 'task-ledger-001',
+        title: 'Patch verifier gate',
+        status: 'awaiting_verification',
+        assignee: 'keeper-alpha',
+        goal_id: 'goal-ledger',
+        updated_at: '2026-05-06T00:00:00Z',
+      },
+    ]
+    goalsSignal.value = [
+      {
+        id: 'goal-ledger',
+        horizon: 'short',
+        title: 'Verifier readiness',
+        priority: 1,
+        status: 'active',
+        phase: 'execute',
+        created_at: '2026-05-06T00:00:00Z',
+        updated_at: '2026-05-06T00:00:00Z',
+      },
+    ]
+
+    render(html`<${PlanningPanel} />`)
+
+    expect(screen.getByTestId('planning-focus-ledger')).toBeTruthy()
+    expect(screen.getAllByText('책임 원장').length).toBeGreaterThan(0)
+    expect(screen.getByText('keeper-alpha')).toBeTruthy()
+    expect(screen.getByText('Patch verifier gate')).toBeTruthy()
+    expect(screen.getAllByText('verify').length).toBeGreaterThan(0)
+  })
+
+  it('renders accountability matrix focus from route param', () => {
+    setRoute(undefined, 'accountability-matrix')
+    tasksSignal.value = [
+      { id: 'task-matrix-1', title: 'A', status: 'todo', assignee: 'keeper-alpha', updated_at: '2026-05-06T00:00:00Z' },
+      { id: 'task-matrix-2', title: 'B', status: 'done', assignee: 'keeper-alpha', updated_at: '2026-05-06T00:00:00Z' },
+      { id: 'task-matrix-3', title: 'C', status: 'claimed', assignee: 'keeper-beta', updated_at: '2020-01-01T00:00:00Z' },
+    ]
+
+    render(html`<${PlanningPanel} />`)
+
+    expect(screen.getByTestId('planning-focus-matrix')).toBeTruthy()
+    expect(screen.getAllByText('책임 매트릭스').length).toBeGreaterThan(0)
+    expect(screen.getByText('keeper-alpha')).toBeTruthy()
+    expect(screen.getByText('keeper-beta')).toBeTruthy()
   })
 })

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { cleanup, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routeSignal = signal<{ tab: string; params: Record<string, string>; postId: string | null }>({
@@ -188,6 +188,42 @@ describe('PlanningPanel', () => {
     expect(screen.getAllByText('verify').length).toBeGreaterThan(0)
   })
 
+  it('preserves planning view params when selecting accountability focus', () => {
+    setRoute('default')
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'planning', view: 'default', task: 'task-keep' },
+      postId: null,
+    }
+
+    render(html`<${PlanningPanel} />`)
+    fireEvent.click(screen.getByRole('tab', { name: /책임 원장/ }))
+
+    expect(routeSignal.value.params).toEqual({
+      section: 'planning',
+      view: 'default',
+      task: 'task-keep',
+      focus: 'accountability-ledger',
+    })
+  })
+
+  it('does not count cancelled accountability tasks as active', () => {
+    setRoute(undefined, 'accountability-ledger')
+    tasksSignal.value = [
+      {
+        id: 'task-cancelled-001',
+        title: 'Cancelled old work',
+        status: 'cancelled',
+        assignee: 'keeper-delta',
+        updated_at: '2026-05-06T00:00:00Z',
+      },
+    ]
+
+    render(html`<${PlanningPanel} />`)
+
+    expect(screen.getByText('active 0 · total 1')).toBeTruthy()
+  })
+
   it('renders accountability matrix focus from route param', () => {
     setRoute(undefined, 'accountability-matrix')
     tasksSignal.value = [
@@ -202,5 +238,18 @@ describe('PlanningPanel', () => {
     expect(screen.getAllByText('책임 매트릭스').length).toBeGreaterThan(0)
     expect(screen.getByText('keeper-alpha')).toBeTruthy()
     expect(screen.getByText('keeper-beta')).toBeTruthy()
+  })
+
+  it('uses a concrete minimum width for the accountability matrix table', () => {
+    setRoute(undefined, 'accountability-matrix')
+    tasksSignal.value = [
+      { id: 'task-matrix-width-1', title: 'A', status: 'todo', assignee: 'keeper-alpha', updated_at: '2026-05-06T00:00:00Z' },
+    ]
+
+    render(html`<${PlanningPanel} />`)
+
+    const table = screen.getByRole('table', { name: '책임 매트릭스' })
+    expect(table.className).toContain('min-w-[37.5rem]')
+    expect(table.className).not.toContain('min-w-150')
   })
 })

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -10,6 +10,7 @@ import { coordinationFsmSnapshot } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals'
 import { GoalTree } from './goals/goal-tree'
+import { PlanningFocusPanel } from './planning-focus-panel'
 import type {
   DashboardCoordinationFsmEvidence,
   DashboardCoordinationFsmRefs,
@@ -198,6 +199,7 @@ export function PlanningPanel() {
         tone="accent"
       />
       <${CoordinationHealthPanel} />
+      <${PlanningFocusPanel} />
       ${view === 'goal-tree'
         ? html`<${GoalTree} />`
         : html`<${Planning} />`}


### PR DESCRIPTION
## Summary
- add planning focus routes for stale task claims, accountability ledger, and accountability matrix
- derive focus panels from existing task/goal store data and reuse the stale-task age derivation
- mark task-st, acc-led, and acc-mtx cockpit aliases as covered

## Verification
- git diff --check
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/planning-panel.test.ts src/cockpit-entrypoints.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard run lint (0 errors, existing 3 warnings)
- pnpm --dir dashboard run build (existing Vite chunk warnings)
- agent-browser desktop checks: /tmp/masc-planning-stale-0506.png, /tmp/masc-planning-ledger-0506.png, /tmp/masc-planning-matrix-0506.png
- agent-browser mobile matrix check: /tmp/masc-planning-matrix-mobile-0506.png; document scrollWidth == clientWidth == 390
- cockpit alias check: #mode=Work&tab=acc-led canonicalized to workspace planning focus=accountability-ledger