### PR TITLE
fix(dashboard): preserve missing keeper latency

### DIFF
--- a/dashboard/src/components/keeper-detail-panels.test.ts
+++ b/dashboard/src/components/keeper-detail-panels.test.ts
@@ -165,6 +165,94 @@ describe('InferenceTelemetryPanel', () => {
     expect(container.textContent).toContain('avg 50.0')
     expect(container.textContent).toContain('avg 145.0')
   })
+
+  it('does not plot missing API latency as zero', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const metricsSeries = [
+      {
+        ts: 1,
+        context_ratio: 0.2,
+        context_tokens: 200,
+        context_max: 1000,
+        latency_ms: null,
+        generation: 1,
+        channel: 'turn',
+        is_handoff: false,
+        is_compaction: false,
+        compaction_saved_tokens: 0,
+        compaction_trigger: null,
+        model_used: 'glm-5',
+        cost_usd: 0.02,
+        handoff_to_model: null,
+        handoff_new_generation: null,
+        prompt_fingerprint: null,
+        prompt_metrics: null,
+        ctx_composition: null,
+        input_tokens: 120,
+        output_tokens: 80,
+        total_tokens: 200,
+        wall_tokens_per_second: 40,
+        inference_telemetry: {
+          system_fingerprint: null,
+          timings: null,
+          reasoning_tokens: null,
+          peak_memory_gb: null,
+          request_latency_ms: null,
+        },
+        fallback_applied: false,
+        fallback_hops: 0,
+        fallback_from: null,
+        fallback_to: null,
+        fallback_reason: null,
+        timeout_budget: null,
+      },
+      {
+        ts: 2,
+        context_ratio: 0.25,
+        context_tokens: 250,
+        context_max: 1000,
+        latency_ms: null,
+        generation: 1,
+        channel: 'turn',
+        is_handoff: false,
+        is_compaction: false,
+        compaction_saved_tokens: 0,
+        compaction_trigger: null,
+        model_used: 'glm-5',
+        cost_usd: 0.03,
+        handoff_to_model: null,
+        handoff_new_generation: null,
+        prompt_fingerprint: null,
+        prompt_metrics: null,
+        ctx_composition: null,
+        input_tokens: 90,
+        output_tokens: 60,
+        total_tokens: 150,
+        wall_tokens_per_second: 60,
+        inference_telemetry: {
+          system_fingerprint: null,
+          timings: null,
+          reasoning_tokens: null,
+          peak_memory_gb: null,
+          request_latency_ms: null,
+        },
+        fallback_applied: false,
+        fallback_hops: 0,
+        fallback_from: null,
+        fallback_to: null,
+        fallback_reason: null,
+        timeout_budget: null,
+      },
+    ] satisfies KeeperMetricPoint[]
+    const keeper = { metrics_series: metricsSeries } as Keeper
+
+    render(html`<${InferenceTelemetryPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('API latency')
+    expect(container.textContent).not.toContain('0.0s')
+    expect(container.querySelector('svg[aria-label="API 지연 시간 추이"] polyline')).toBeNull()
+  })
 })
 
 describe('RelationshipList and TraitsList primitives', () => {

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -900,17 +900,26 @@ const SPARKLINE_H = 40
 const SPARKLINE_PAD = 2
 const MODEL_NAME_MAX_LEN = 20
 
+function isFiniteMetricValue(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
 function miniSparkline(
-  data: number[],
+  data: Array<number | null | undefined>,
   maxOverride?: number,
 ): string {
   const W = SPARKLINE_W, H = SPARKLINE_H, pad = SPARKLINE_PAD
   const n = data.length
-  if (n < 2) return ''
-  const maxVal = maxOverride ?? Math.max(...data, 1)
-  return data.map((v, i) => {
-    const x = pad + (i / (n - 1)) * (W - 2 * pad)
-    const y = H - pad - (v / maxVal) * (H - 2 * pad)
+  const points = data
+    .map((value, index) => ({ value, index }))
+    .filter((point): point is { value: number; index: number } =>
+      isFiniteMetricValue(point.value),
+    )
+  if (points.length < 2) return ''
+  const maxVal = maxOverride ?? Math.max(...points.map(point => point.value), 1)
+  return points.map(({ value, index }) => {
+    const x = pad + (index / Math.max(n - 1, 1)) * (W - 2 * pad)
+    const y = H - pad - (value / maxVal) * (H - 2 * pad)
     return `${x.toFixed(1)},${y.toFixed(1)}`
   }).join(' ')
 }
@@ -928,9 +937,10 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
   const hwTokPerSec = telemetryPoints
     .map((p: KeeperMetricPoint) => p.inference_telemetry?.timings?.predicted_per_second)
     .filter((value): value is number => value != null)
-  const latencies = telemetryPoints.map(
-    (p: KeeperMetricPoint) => p.inference_telemetry?.request_latency_ms ?? 0,
+  const latencySeries = telemetryPoints.map(
+    (p: KeeperMetricPoint) => p.inference_telemetry?.request_latency_ms ?? null,
   )
+  const latencies = latencySeries.filter(isFiniteMetricValue)
   const cacheNs = telemetryPoints.map(
     (p: KeeperMetricPoint) => p.inference_telemetry?.timings?.cache_n ?? 0,
   )
@@ -955,7 +965,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
 
   const wallTpsLine = wallTokPerSec.length > 1 ? miniSparkline(wallTokPerSec) : ''
   const hwTpsLine = hwTokPerSec.length > 1 ? miniSparkline(hwTokPerSec) : ''
-  const latencyLine = miniSparkline(latencies)
+  const latencyLine = miniSparkline(latencySeries)
 
   const lastFp = telemetryPoints[telemetryPoints.length - 1]?.inference_telemetry?.system_fingerprint
 
@@ -1026,7 +1036,8 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   if (series.length < 2) return null
 
-  const latencies = series.map((p: KeeperMetricPoint) => p.latency_ms ?? 0)
+  const latencySeries = series.map((p: KeeperMetricPoint) => p.latency_ms)
+  const latencies = latencySeries.filter(isFiniteMetricValue)
   const costs = series.map((p: KeeperMetricPoint) => p.cost_usd ?? 0)
   const W = SPARKLINE_W, H = SPARKLINE_H
 
@@ -1040,7 +1051,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
     }
   }
 
-  const latencyLine = miniSparkline(latencies)
+  const latencyLine = miniSparkline(latencySeries)
   const costLine = miniSparkline(costs)
 
   // Fallback markers on latency chart

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -940,7 +940,6 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
   const latencySeries = telemetryPoints.map(
     (p: KeeperMetricPoint) => p.inference_telemetry?.request_latency_ms ?? null,
   )
-  const latencies = latencySeries.filter(isFiniteMetricValue)
   const cacheNs = telemetryPoints.map(
     (p: KeeperMetricPoint) => p.inference_telemetry?.timings?.cache_n ?? 0,
   )
@@ -959,7 +958,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
     hwTokPerSec.length > 0
       ? hwTokPerSec.reduce((a, b) => a + b, 0) / hwTokPerSec.length
       : 0
-  const lastLatency = latencies[latencies.length - 1] ?? 0
+  const lastLatency = latencySeries[latencySeries.length - 1] ?? null
   const totalCacheN = cacheNs.reduce((a, b) => a + b, 0)
   const totalReasoning = reasoningTokens.reduce((a, b) => a + b, 0)
 
@@ -1007,7 +1006,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
         <${DetailCard}>
           <${DetailRow}>
             <${Eyebrow}>API latency</${Eyebrow}>
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${isFiniteMetricValue(lastLatency) && lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </${DetailRow}>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="API 지연 시간 추이" style="background:var(--bg-deepest);">
             ${latencyLine ? html`<polyline points="${latencyLine}" fill="none" stroke="var(--sky-400)" stroke-width="1.5"/>` : null}
@@ -1037,11 +1036,10 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
   if (series.length < 2) return null
 
   const latencySeries = series.map((p: KeeperMetricPoint) => p.latency_ms)
-  const latencies = latencySeries.filter(isFiniteMetricValue)
   const costs = series.map((p: KeeperMetricPoint) => p.cost_usd ?? 0)
   const W = SPARKLINE_W, H = SPARKLINE_H
 
-  const lastLatency = latencies[latencies.length - 1] ?? 0
+  const lastLatency = latencySeries[latencySeries.length - 1] ?? null
   const totalCost = costs.reduce((a: number, b: number) => a + b, 0)
 
   const modelSwitches: { index: number; model: string }[] = []
@@ -1069,7 +1067,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
           <${Eyebrow}>지연 시간</${Eyebrow}>
           <span class="flex items-center gap-2">
             ${fallbackCount > 0 ? html`<span class="text-3xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--bad-soft)] text-[var(--color-status-err)] font-mono">FB ${fallbackCount}</span>` : null}
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${isFiniteMetricValue(lastLatency) && lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </span>
         </${DetailRow}>
         <svg aria-hidden="true" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" style="background:var(--bg-deepest);">

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -646,6 +646,42 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(metric?.inference_telemetry?.timings?.predicted_per_second).toBe(140)
   })
 
+  it('preserves missing latency as null in keeper runtime metrics', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'missing-latency',
+        status: 'active',
+        metrics_series: [
+          {
+            ts_unix: 7,
+            context_ratio: 0.3,
+            context_tokens: 300,
+            context_max: 1000,
+            generation: 2,
+            channel: 'turn',
+            model_used: 'glm-5',
+            cost_usd: 0.05,
+            usage: {
+              input_tokens: 120,
+              output_tokens: 80,
+              total_tokens: 200,
+            },
+            inference_telemetry: {
+              timings: {
+                predicted_per_second: 140,
+              },
+            },
+          },
+        ],
+      },
+    ])
+
+    const metric = keeper?.metrics_series?.[0]
+    expect(metric?.latency_ms).toBeNull()
+    expect(metric?.wall_tokens_per_second).toBeNull()
+    expect(metric?.inference_telemetry?.request_latency_ms).toBeNull()
+  })
+
   it('preserves paused runtime signals and blocker metadata for keeper UI', () => {
     const [keeper] = normalizeKeepers([
       {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -328,12 +328,12 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
           : null
       const rawTel = isRecord(item.inference_telemetry) ? item.inference_telemetry : null
       const rawTimings = rawTel && isRecord(rawTel.timings) ? rawTel.timings : null
-      const latencyMs = asNumber(item.latency_ms) ?? 0
+      const latencyMs = asNumber(item.latency_ms) ?? null
       const inputTokens = rawUsage ? (asNumber(rawUsage.input_tokens) ?? null) : null
       const outputTokens = rawUsage ? (asNumber(rawUsage.output_tokens) ?? null) : null
       const totalTokens = rawUsage ? (asNumber(rawUsage.total_tokens) ?? null) : null
       const wallTokensPerSecond =
-        outputTokens != null && latencyMs > 0
+        outputTokens != null && latencyMs != null && latencyMs > 0
           ? outputTokens / (latencyMs / 1000)
           : null
       const inference_telemetry = rawTel ? {
@@ -349,7 +349,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         } : null,
         reasoning_tokens: asNumber(rawTel.reasoning_tokens) ?? null,
         peak_memory_gb: asNumber(rawTel.peak_memory_gb) ?? null,
-        request_latency_ms: asNumber(rawTel.request_latency_ms) ?? 0,
+        request_latency_ms: asNumber(rawTel.request_latency_ms) ?? null,
       } : null
       const cascadeObj = isRecord(item.cascade) ? item.cascade : null
       const fallbackEvents = cascadeObj && Array.isArray(cascadeObj.fallback_events) ? cascadeObj.fallback_events : []

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -220,7 +220,7 @@ export interface InferenceTelemetry {
   } | null
   reasoning_tokens: number | null
   peak_memory_gb: number | null
-  request_latency_ms: number
+  request_latency_ms: number | null
 }
 
 export interface PromptSegmentTelemetry {
@@ -258,7 +258,7 @@ export interface KeeperMetricPoint {
   context_ratio: number
   context_tokens: number
   context_max: number
-  latency_ms: number
+  latency_ms: number | null
   generation: number
   channel: string
   is_handoff: boolean


### PR DESCRIPTION
## Summary
- Preserve missing keeper metric latency and request latency as null instead of coercing unknown values to 0.
- Skip unknown latency values in keeper detail sparklines while preserving timeline positions for known points.
- Add regression coverage for normalization and the API latency panel.

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/keeper-store-normalize.test.ts src/components/keeper-detail-panels.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false