### PR TITLE
fix(keeper): surface progress refresh failures

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -262,6 +262,15 @@ let current_utc_timestamp () =
     t.tm_sec
 ;;
 
+let is_missing_progress_file_error exn =
+  match exn with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> true
+  | _ ->
+    let message = Printexc.to_string exn in
+    String_util.contains_substring message "ENOENT"
+    || String_util.contains_substring message "No such file"
+;;
+
 let refresh_progress_updated_line config name =
   let progress_path = Keeper_types_support.keeper_progress_path config name in
   if Fs_compat.file_exists progress_path then try
@@ -278,6 +287,7 @@ let refresh_progress_updated_line config name =
     Fs_compat.save_file progress_path updated
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn when is_missing_progress_file_error exn -> ()
   | exn ->
     Prometheus.inc_counter
       Prometheus.metric_keeper_progress_updated_line_failures

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -264,7 +264,7 @@ let current_utc_timestamp () =
 
 let refresh_progress_updated_line config name =
   let progress_path = Keeper_types_support.keeper_progress_path config name in
-  try
+  if Fs_compat.file_exists progress_path then try
     let content = Fs_compat.load_file progress_path in
     let now_str = current_utc_timestamp () in
     let updated =
@@ -277,7 +277,17 @@ let refresh_progress_updated_line config name =
     in
     Fs_compat.save_file progress_path updated
   with
-  | _ -> ()
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_progress_updated_line_failures
+      ~labels:[("keeper", name)]
+      ();
+    Log.Keeper.warn
+      "keeper:%s progress Updated line refresh failed for %s: %s"
+      name
+      progress_path
+      (Printexc.to_string exn)
 ;;
 
 let persist_meta config path persisted =

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -95,7 +95,9 @@ val read_meta_if_changed :
 val current_utc_timestamp : unit -> string
 
 (** Refresh the [Updated:] line in the keeper progress markdown.
-    Best-effort — swallows all exceptions. *)
+    Best-effort: a missing progress file is a no-op; other failures
+    increment [metric_keeper_progress_updated_line_failures] and log a
+    warning. *)
 val refresh_progress_updated_line : Coord.config -> string -> unit
 
 (** Atomic write of [persisted] to [path]; runs the

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -649,6 +649,8 @@ let metric_keeper_cycle_exceptions =
   "masc_keeper_cycle_exceptions_total"
 let metric_keeper_snapshot_write_failures =
   "masc_keeper_snapshot_write_failures_total"
+let metric_keeper_progress_updated_line_failures =
+  "masc_keeper_progress_updated_line_failures_total"
 let metric_keeper_sse_broadcast_failures =
   "masc_keeper_sse_broadcast_failures_total"
 let metric_keeper_room_heartbeat_failures =
@@ -1819,6 +1821,12 @@ let init () =
   add metric_keeper_snapshot_write_failures
     "Total heartbeat snapshot persistence failures causing metric \
      data loss. Labeled by keeper."
+    Counter;
+  add metric_keeper_progress_updated_line_failures
+    "Total failures refreshing the Updated line in keeper progress.md. \
+     Missing progress files are no-ops; non-zero rates mean progress \
+     metadata refresh is failing after a successful meta write. Labeled \
+     by keeper."
     Counter;
   add metric_keeper_sse_broadcast_failures
     "Total in-turn heartbeat SSE broadcast failures. Labeled by keeper."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -293,6 +293,7 @@ val metric_keeper_stale_storm_paused : string
 val metric_keeper_oas_timeout_budget_loop_paused : string
 val metric_keeper_cycle_exceptions : string
 val metric_keeper_snapshot_write_failures : string
+val metric_keeper_progress_updated_line_failures : string
 val metric_keeper_sse_broadcast_failures : string
 val metric_keeper_room_heartbeat_failures : string
 val metric_keeper_turn_metrics_snapshot_failures : string

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -57,6 +57,36 @@ let test_counter_ticks_on_genuine_unknown_key () =
     true
     (after > before)
 
+let fresh_tmpdir () =
+  let path = Filename.temp_file "masc-progress-refresh-" ".tmp" in
+  Sys.remove path;
+  Keeper_types.mkdir_p path;
+  path
+
+let cleanup_tmpdir path =
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote path)))
+
+let test_progress_updated_line_failure_is_observable () =
+  let dir = fresh_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let config = Coord.default_config dir in
+    let keeper_name = "progress-refresh-failure" in
+    let progress_path = Keeper_types.keeper_progress_path config keeper_name in
+    Keeper_types.mkdir_p progress_path;
+    let before =
+      Prometheus.metric_total
+        Prometheus.metric_keeper_progress_updated_line_failures
+    in
+    Keeper_meta_store.refresh_progress_updated_line config keeper_name;
+    let after =
+      Prometheus.metric_total
+        Prometheus.metric_keeper_progress_updated_line_failures
+    in
+    Alcotest.(check bool)
+      "progress Updated-line refresh failure increments counter"
+      true
+      (after > before))
+
 let () =
   Alcotest.run
     "keeper_meta_unknown_keys_warn"
@@ -69,6 +99,10 @@ let () =
             "counter still ticks on genuine unknown"
             `Quick
             test_counter_ticks_on_genuine_unknown_key
+        ; Alcotest.test_case
+            "progress Updated-line refresh failure is observable"
+            `Quick
+            test_progress_updated_line_failure_is_observable
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Stop silently swallowing every progress Updated-line refresh failure.
- Keep missing progress.md as a no-op, but log and count real refresh exceptions with masc_keeper_progress_updated_line_failures_total{keeper}.
- Add regression coverage that forces progress.md to be a directory and verifies the counter increments.

## Verification
- scripts/dune-local.sh build test/test_keeper_meta_unknown_keys_warn.exe
- ./_build/default/test/test_keeper_meta_unknown_keys_warn.exe

Note: the first focused build attempt hit shared Dune cache cleanup noise: rmdir(...dune_f3b4da_artifacts): Directory not empty. Rerunning the same focused target passed.