### PR TITLE
fix(coord): invalidate stale terminal task signals

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -318,14 +318,14 @@ let () =
 
 (* #13460: cache desync invalidation counter. Coord_broadcast emits this when
    it replaces an active-claim/release message for a terminal backlog task with
-   a cache_invalidated broadcast. *)
-let record_cache_desync_cleared ~module_name ~task_id ~status =
+   a cache_invalidated broadcast.  Keep labels fleet-bounded; the task id stays
+   in the replacement message, not the Prometheus series key. *)
+let record_cache_desync_cleared ~module_name ~task_id:_ ~status =
   Prometheus.inc_counter
     Prometheus.metric_cache_desync_cleared
     ~labels:
       [
         ("module", module_name);
-        ("task_id", task_id);
         ("status", status);
       ]
     ()

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -316,11 +316,65 @@ let () =
   Atomic.set Coord_hooks.task_auto_release_observed_fn
     record_task_auto_release
 
+let clear_agent_current_task_cache config ~task_id =
+  let agents_path = agents_dir config in
+  if path_exists config agents_path then
+    let agent_files =
+      try Sys.readdir agents_path with
+      | Sys_error msg ->
+        Log.Misc.warn "cache desync agent scan failed: %s" msg;
+        [||]
+    in
+    Array.iter
+      (fun name ->
+         if Filename.check_suffix name ".json"
+         then (
+           let path = Filename.concat agents_path name in
+           if path_exists config path
+           then
+             with_file_lock config path (fun () ->
+               match read_agent_with_repair config path with
+               | Ok agent when agent.current_task = Some task_id ->
+                 let status =
+                   match agent.status with
+                   | Inactive -> Inactive
+                   | Active | Busy | Listening -> Active
+                 in
+                 let updated =
+                   {
+                     agent with
+                     status;
+                     current_task = None;
+                     last_seen = now_iso ();
+                   }
+                 in
+                 write_json config path (agent_to_yojson updated);
+                 log_event
+                   config
+                   (`Assoc
+                      [
+                        ("type", `String "agent_current_task_cache_cleared");
+                        ("agent", `String agent.name);
+                        ("stale_task", `String task_id);
+                        ("ts", `String (now_iso ()));
+                      ])
+               | Ok _ -> ()
+               | Error msg ->
+                 Log.Misc.warn
+                   "cache desync agent read failed for %s: %s"
+                   name
+                   msg)))
+      agent_files
+
 (* #13460: cache desync invalidation counter. Coord_broadcast emits this when
    it replaces an active-claim/release message for a terminal backlog task with
-   a cache_invalidated broadcast.  Keep labels fleet-bounded; the task id stays
-   in the replacement message, not the Prometheus series key. *)
-let record_cache_desync_cleared ~module_name ~task_id:_ ~status =
+   a cache_invalidated broadcast.  Clear coord-owned current_task caches so the
+   same stale claim does not re-emit every taskmaster cycle.  Keep labels
+   fleet-bounded; the task id stays in the replacement message/event, not the
+   Prometheus series key. *)
+let record_cache_desync_cleared config ~module_name ~task_id ~status =
+  if not (String.equal status "backlog_unavailable")
+  then clear_agent_current_task_cache config ~task_id;
   Prometheus.inc_counter
     Prometheus.metric_cache_desync_cleared
     ~labels:

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -316,6 +316,24 @@ let () =
   Atomic.set Coord_hooks.task_auto_release_observed_fn
     record_task_auto_release
 
+(* #13460: cache desync invalidation counter. Coord_broadcast emits this when
+   it replaces an active-claim/release message for a terminal backlog task with
+   a cache_invalidated broadcast. *)
+let record_cache_desync_cleared ~module_name ~task_id ~status =
+  Prometheus.inc_counter
+    Prometheus.metric_cache_desync_cleared
+    ~labels:
+      [
+        ("module", module_name);
+        ("task_id", task_id);
+        ("status", status);
+      ]
+    ()
+
+let () =
+  Atomic.set Coord_hooks.cache_desync_cleared_fn
+    record_cache_desync_cleared
+
 (* #9632: Process_eio timeout observability.
    Fleet-wide rate of subprocess timeouts, broken down by program
    (argv[0] basename) and configured budget.  Lets operators answer

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -61,14 +61,17 @@ let broadcast_channel config =
 let on_broadcast_mention : (string option -> unit) ref =
   ref (fun _mention -> ())
 
-let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~content =
+let broadcast ?trace_context ?(msg_type = "broadcast")
+    ?(task_cache_invariant_checked = false) config ~from_agent ~content =
   ensure_initialized config;
   let content =
-    Coord_task_cache_invariant.rewrite_broadcast_content
-      ~config
-      ~from_agent
-      ~module_name:"coord_broadcast"
-      ~content
+    if task_cache_invariant_checked then content
+    else
+      Coord_task_cache_invariant.rewrite_broadcast_content
+        ~config
+        ~from_agent
+        ~module_name:"coord_broadcast"
+        ~content
   in
   let seq = Coord_state.next_seq config in
   let mention = Mention.extract content in

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -63,6 +63,13 @@ let on_broadcast_mention : (string option -> unit) ref =
 
 let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~content =
   ensure_initialized config;
+  let content =
+    Coord_task_cache_invariant.rewrite_broadcast_content
+      ~config
+      ~from_agent
+      ~module_name:"coord_broadcast"
+      ~content
+  in
   let seq = Coord_state.next_seq config in
   let mention = Mention.extract content in
   let safe_content = sanitize_message content in

--- a/lib/coord/coord_broadcast.mli
+++ b/lib/coord/coord_broadcast.mli
@@ -16,5 +16,6 @@ val broadcast_channel : Coord_utils_backend_setup.config -> string
 val on_broadcast_mention : (string option -> unit) ref
 val broadcast : ?trace_context:string ->
            ?msg_type:string ->
+           ?task_cache_invariant_checked:bool ->
            Coord_utils_backend_setup.config ->
            from_agent:string -> content:string -> string

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -241,6 +241,14 @@ let task_auto_release_observed_fn
   : (agent_name:string -> from_status:string -> unit) Atomic.t
   = Atomic.make (fun ~agent_name:_ ~from_status:_ -> ())
 
+(** #13460: stale task-state cache emission observability.
+    Coord sub-modules fire this when they replace a stale active-task
+    broadcast/mention with a cache invalidation message. [lib/coord.ml]
+    wires it to Prometheus to avoid a [masc_coord -> Prometheus] dependency. *)
+let cache_desync_cleared_fn
+  : (module_name:string -> task_id:string -> status:string -> unit) Atomic.t
+  = Atomic.make (fun ~module_name:_ ~task_id:_ ~status:_ -> ())
+
 (** task-103: Auto-provision a sandbox worktree on successful task claim.
 
     [Coord_task.claim_task_r] flips a task to [Claimed] but does not create

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -244,10 +244,12 @@ let task_auto_release_observed_fn
 (** #13460: stale task-state cache emission observability.
     Coord sub-modules fire this when they replace a stale active-task
     broadcast/mention with a cache invalidation message. [lib/coord.ml]
-    wires it to Prometheus to avoid a [masc_coord -> Prometheus] dependency. *)
+    clears coord-owned task caches and wires observability to Prometheus
+    to avoid a [masc_coord -> Prometheus] dependency. *)
 let cache_desync_cleared_fn
-  : (module_name:string -> task_id:string -> status:string -> unit) Atomic.t
-  = Atomic.make (fun ~module_name:_ ~task_id:_ ~status:_ -> ())
+  : (Coord_utils_backend_setup.config ->
+     module_name:string -> task_id:string -> status:string -> unit) Atomic.t
+  = Atomic.make (fun _config ~module_name:_ ~task_id:_ ~status:_ -> ())
 
 (** task-103: Auto-provision a sandbox worktree on successful task claim.
 

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -66,7 +66,8 @@ val task_completion_path_observed_fn : (path:string -> contract_state:string -> 
 val task_auto_release_observed_fn :
   (agent_name:string -> from_status:string -> unit) Atomic.t
 val cache_desync_cleared_fn :
-  (module_name:string -> task_id:string -> status:string -> unit) Atomic.t
+  (Coord_utils_backend_setup.config ->
+   module_name:string -> task_id:string -> status:string -> unit) Atomic.t
 val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
             agent_name:string ->
             task_id:string -> unit)

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -65,6 +65,8 @@ val task_completion_path_observed_fn : (path:string -> contract_state:string -> 
            Atomic.t
 val task_auto_release_observed_fn :
   (agent_name:string -> from_status:string -> unit) Atomic.t
+val cache_desync_cleared_fn :
+  (module_name:string -> task_id:string -> status:string -> unit) Atomic.t
 val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
             agent_name:string ->
             task_id:string -> unit)

--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -105,6 +105,14 @@ let record_cache_desync_cleared ~module_name stale_tasks =
     stale_tasks
 ;;
 
+let stale_active_task_signal_present ~config ~module_name ~content =
+  match terminal_task_mentions ~config ~content with
+  | [] -> false
+  | stale_tasks ->
+    record_cache_desync_cleared ~module_name stale_tasks;
+    true
+;;
+
 let rewrite_broadcast_content ~config ~from_agent ~module_name ~content =
   if string_starts_with ~prefix:"[cache_invalidated]" (String.trim content)
   then content

--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -8,7 +8,19 @@ type stale_terminal_task = {
   actor : string;
 }
 
+type cache_signal_check =
+  | No_cache_signal
+  | No_terminal_task
+  | Backlog_unavailable of {
+      task_ids : string list;
+      error : string;
+    }
+  | Terminal_tasks of stale_terminal_task list
+
 let task_ref_re = lazy (Re.Pcre.re "\\btask-[0-9]+\\b" |> Re.compile)
+let invalidation_memory_ttl_s = 3600.0
+let invalidation_memory : (string, float) Hashtbl.t = Hashtbl.create 64
+let invalidation_memory_lock = Mutex.create ()
 
 let string_contains s needle =
   let len_s = String.length s in
@@ -41,26 +53,26 @@ let active_cache_language_present content =
   List.exists
     (string_contains lower)
     [
+      "active-claim";
+      "cache desync";
       "stale claim";
       "current_task_id";
       "still claimed";
       "still lists";
-      "claimed by";
       "please release";
-      "mark done";
-      "blocking";
-      "blocked by";
+      "task-state cache";
     ]
 ;;
 
-let terminal_task_mentions ~config ~content =
+let check_cache_signal ~config ~content =
   let task_ids = extract_task_ids content in
-  if task_ids = [] || not (active_cache_language_present content) then []
+  if task_ids = [] || not (active_cache_language_present content)
+  then No_cache_signal
   else
     match Coord_state.read_backlog_r config with
     | Error msg ->
       Log.Misc.warn "task cache invariant: backlog read failed before broadcast: %s" msg;
-      []
+      Backlog_unavailable { task_ids; error = msg }
     | Ok backlog ->
       let task_by_id =
         List.filter_map
@@ -76,9 +88,12 @@ let terminal_task_mentions ~config ~content =
              else None)
           backlog.tasks
       in
-      List.sort
-        (fun left right -> String.compare left.task_id right.task_id)
-        task_by_id
+      let stale_tasks =
+        List.sort
+          (fun left right -> String.compare left.task_id right.task_id)
+          task_by_id
+      in
+      if stale_tasks = [] then No_terminal_task else Terminal_tasks stale_tasks
 ;;
 
 let invalidation_message ~from_agent stale_tasks =
@@ -95,21 +110,69 @@ let invalidation_message ~from_agent stale_tasks =
     task_summary
 ;;
 
+let backlog_unavailable_message ~from_agent task_ids =
+  Printf.sprintf
+    "[cache_invalidated] skipped unverifiable task-state broadcast from %s: \
+     backlog read failed while checking %s; original active-claim message was \
+     not emitted."
+    from_agent
+    (String.concat ", " task_ids)
+;;
+
+let remember_invalidation ~module_name ~task_id ~status =
+  let key = String.concat "\x00" [ module_name; task_id; status ] in
+  let now = Time_compat.now () in
+  Mutex.lock invalidation_memory_lock;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock invalidation_memory_lock)
+    (fun () ->
+       Hashtbl.filter_map_inplace
+         (fun _ ts ->
+            if now -. ts > invalidation_memory_ttl_s then None else Some ts)
+         invalidation_memory;
+       let first_seen = not (Hashtbl.mem invalidation_memory key) in
+       Hashtbl.replace invalidation_memory key now;
+       first_seen)
+;;
+
 let record_cache_desync_cleared ~module_name stale_tasks =
   List.iter
     (fun task ->
-       (Atomic.get Coord_hooks.cache_desync_cleared_fn)
-         ~module_name
-         ~task_id:task.task_id
-         ~status:task.status)
+       if remember_invalidation ~module_name ~task_id:task.task_id ~status:task.status
+       then
+         (Atomic.get Coord_hooks.cache_desync_cleared_fn)
+           ~module_name
+           ~task_id:task.task_id
+           ~status:task.status)
     stale_tasks
 ;;
 
+let record_backlog_unavailable ~module_name task_ids =
+  List.iter
+    (fun task_id ->
+       if
+         remember_invalidation
+           ~module_name
+           ~task_id
+           ~status:"backlog_unavailable"
+       then
+         (Atomic.get Coord_hooks.cache_desync_cleared_fn)
+           ~module_name
+           ~task_id
+           ~status:"backlog_unavailable")
+    task_ids
+;;
+
 let stale_active_task_signal_present ~config ~module_name ~content =
-  match terminal_task_mentions ~config ~content with
-  | [] -> false
+  match check_cache_signal ~config ~content with
+  | No_cache_signal | No_terminal_task -> false
   | stale_tasks ->
-    record_cache_desync_cleared ~module_name stale_tasks;
+    (match stale_tasks with
+     | Terminal_tasks stale_tasks ->
+       record_cache_desync_cleared ~module_name stale_tasks
+     | Backlog_unavailable { task_ids; _ } ->
+       record_backlog_unavailable ~module_name task_ids
+     | No_cache_signal | No_terminal_task -> ());
     true
 ;;
 
@@ -117,9 +180,12 @@ let rewrite_broadcast_content ~config ~from_agent ~module_name ~content =
   if string_starts_with ~prefix:"[cache_invalidated]" (String.trim content)
   then content
   else
-    match terminal_task_mentions ~config ~content with
-    | [] -> content
-    | stale_tasks ->
+    match check_cache_signal ~config ~content with
+    | No_cache_signal | No_terminal_task -> content
+    | Backlog_unavailable { task_ids; error = _ } ->
+      record_backlog_unavailable ~module_name task_ids;
+      backlog_unavailable_message ~from_agent task_ids
+    | Terminal_tasks stale_tasks ->
       record_cache_desync_cleared ~module_name stale_tasks;
       invalidation_message ~from_agent stale_tasks
 ;;

--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -42,6 +42,11 @@ let string_starts_with ~prefix s =
   len_s >= len_prefix && String.sub s 0 len_prefix = prefix
 ;;
 
+let trusted_cache_signal_sender from_agent =
+  String.lowercase_ascii from_agent |> fun value ->
+  string_contains value "taskmaster"
+;;
+
 let extract_task_ids content =
   Re.all (Lazy.force task_ref_re) content
   |> List.map (fun group -> Re.Group.get group 0)
@@ -105,7 +110,7 @@ let invalidation_message ~from_agent stale_tasks =
   in
   Printf.sprintf
     "[cache_invalidated] skipped stale task-state broadcast from %s: %s is \
-     terminal in backlog; original active-claim message was not emitted."
+     terminal in backlog; original cached-claim message was not emitted."
     from_agent
     task_summary
 ;;
@@ -163,8 +168,11 @@ let record_backlog_unavailable ~module_name task_ids =
     task_ids
 ;;
 
-let stale_active_task_signal_present ~config ~module_name ~content =
-  match check_cache_signal ~config ~content with
+let stale_active_task_signal_present ~config ~from_agent ~module_name ~content =
+  if string_starts_with ~prefix:"[cache_invalidated]" (String.trim content)
+     || not (trusted_cache_signal_sender from_agent)
+  then false
+  else match check_cache_signal ~config ~content with
   | No_cache_signal | No_terminal_task -> false
   | stale_tasks ->
     (match stale_tasks with
@@ -178,6 +186,7 @@ let stale_active_task_signal_present ~config ~module_name ~content =
 
 let rewrite_broadcast_content ~config ~from_agent ~module_name ~content =
   if string_starts_with ~prefix:"[cache_invalidated]" (String.trim content)
+     || not (trusted_cache_signal_sender from_agent)
   then content
   else
     match check_cache_signal ~config ~content with

--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -140,19 +140,20 @@ let remember_invalidation ~module_name ~task_id ~status =
        first_seen)
 ;;
 
-let record_cache_desync_cleared ~module_name stale_tasks =
+let record_cache_desync_cleared ~config ~module_name stale_tasks =
   List.iter
     (fun task ->
        if remember_invalidation ~module_name ~task_id:task.task_id ~status:task.status
        then
          (Atomic.get Coord_hooks.cache_desync_cleared_fn)
+           config
            ~module_name
            ~task_id:task.task_id
            ~status:task.status)
     stale_tasks
 ;;
 
-let record_backlog_unavailable ~module_name task_ids =
+let record_backlog_unavailable ~config ~module_name task_ids =
   List.iter
     (fun task_id ->
        if
@@ -162,6 +163,7 @@ let record_backlog_unavailable ~module_name task_ids =
            ~status:"backlog_unavailable"
        then
          (Atomic.get Coord_hooks.cache_desync_cleared_fn)
+           config
            ~module_name
            ~task_id
            ~status:"backlog_unavailable")
@@ -177,9 +179,9 @@ let stale_active_task_signal_present ~config ~from_agent ~module_name ~content =
   | stale_tasks ->
     (match stale_tasks with
      | Terminal_tasks stale_tasks ->
-       record_cache_desync_cleared ~module_name stale_tasks
+       record_cache_desync_cleared ~config ~module_name stale_tasks
      | Backlog_unavailable { task_ids; _ } ->
-       record_backlog_unavailable ~module_name task_ids
+       record_backlog_unavailable ~config ~module_name task_ids
      | No_cache_signal | No_terminal_task -> ());
     true
 ;;
@@ -192,9 +194,9 @@ let rewrite_broadcast_content ~config ~from_agent ~module_name ~content =
     match check_cache_signal ~config ~content with
     | No_cache_signal | No_terminal_task -> content
     | Backlog_unavailable { task_ids; error = _ } ->
-      record_backlog_unavailable ~module_name task_ids;
+      record_backlog_unavailable ~config ~module_name task_ids;
       backlog_unavailable_message ~from_agent task_ids
     | Terminal_tasks stale_tasks ->
-      record_cache_desync_cleared ~module_name stale_tasks;
+      record_cache_desync_cleared ~config ~module_name stale_tasks;
       invalidation_message ~from_agent stale_tasks
 ;;

--- a/lib/coord/coord_task_cache_invariant.ml
+++ b/lib/coord/coord_task_cache_invariant.ml
@@ -1,0 +1,117 @@
+(** Guard task-state cache emissions against terminal backlog truth. *)
+
+open Masc_domain
+
+type stale_terminal_task = {
+  task_id : string;
+  status : string;
+  actor : string;
+}
+
+let task_ref_re = lazy (Re.Pcre.re "\\btask-[0-9]+\\b" |> Re.compile)
+
+let string_contains s needle =
+  let len_s = String.length s in
+  let len_needle = String.length needle in
+  if len_needle = 0 then true
+  else if len_needle > len_s then false
+  else
+    let rec loop i =
+      if i > len_s - len_needle then false
+      else if String.sub s i len_needle = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+;;
+
+let string_starts_with ~prefix s =
+  let len_s = String.length s in
+  let len_prefix = String.length prefix in
+  len_s >= len_prefix && String.sub s 0 len_prefix = prefix
+;;
+
+let extract_task_ids content =
+  Re.all (Lazy.force task_ref_re) content
+  |> List.map (fun group -> Re.Group.get group 0)
+  |> List.sort_uniq String.compare
+;;
+
+let active_cache_language_present content =
+  let lower = String.lowercase_ascii content in
+  List.exists
+    (string_contains lower)
+    [
+      "stale claim";
+      "current_task_id";
+      "still claimed";
+      "still lists";
+      "claimed by";
+      "please release";
+      "mark done";
+      "blocking";
+      "blocked by";
+    ]
+;;
+
+let terminal_task_mentions ~config ~content =
+  let task_ids = extract_task_ids content in
+  if task_ids = [] || not (active_cache_language_present content) then []
+  else
+    match Coord_state.read_backlog_r config with
+    | Error msg ->
+      Log.Misc.warn "task cache invariant: backlog read failed before broadcast: %s" msg;
+      []
+    | Ok backlog ->
+      let task_by_id =
+        List.filter_map
+          (fun (task : task) ->
+             if List.mem task.id task_ids && task_status_is_terminal task.task_status
+             then
+               Some
+                 {
+                   task_id = task.id;
+                   status = task_status_to_string task.task_status;
+                   actor = task_display_assignee task.task_status;
+                 }
+             else None)
+          backlog.tasks
+      in
+      List.sort
+        (fun left right -> String.compare left.task_id right.task_id)
+        task_by_id
+;;
+
+let invalidation_message ~from_agent stale_tasks =
+  let task_summary =
+    stale_tasks
+    |> List.map (fun task ->
+      Printf.sprintf "%s=%s by %s" task.task_id task.status task.actor)
+    |> String.concat ", "
+  in
+  Printf.sprintf
+    "[cache_invalidated] skipped stale task-state broadcast from %s: %s is \
+     terminal in backlog; original active-claim message was not emitted."
+    from_agent
+    task_summary
+;;
+
+let record_cache_desync_cleared ~module_name stale_tasks =
+  List.iter
+    (fun task ->
+       (Atomic.get Coord_hooks.cache_desync_cleared_fn)
+         ~module_name
+         ~task_id:task.task_id
+         ~status:task.status)
+    stale_tasks
+;;
+
+let rewrite_broadcast_content ~config ~from_agent ~module_name ~content =
+  if string_starts_with ~prefix:"[cache_invalidated]" (String.trim content)
+  then content
+  else
+    match terminal_task_mentions ~config ~content with
+    | [] -> content
+    | stale_tasks ->
+      record_cache_desync_cleared ~module_name stale_tasks;
+      invalidation_message ~from_agent stale_tasks
+;;

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -24,6 +24,7 @@
   coord_status
   coord_task
   coord_task_classify
+  coord_task_cache_invariant
   coord_task_claim
   coord_task_create
   coord_task_lifecycle

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -180,6 +180,13 @@ let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
                 (identity_tokens_of_value author)
         then
           consume_room_messages remaining msg.seq mentions scope_messages rest
+        else if
+          Coord_task_cache_invariant.stale_active_task_signal_present
+            ~config
+            ~module_name:"keeper_world_observation"
+            ~content:msg.content
+        then
+          consume_room_messages remaining msg.seq mentions scope_messages rest
         else if exact_direct_mention_present ~targets msg.content then
           if remaining <= 0 then
             (`Saturated, remaining, last_processed, List.rev mentions, List.rev scope_messages)

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -183,6 +183,7 @@ let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
         else if
           Coord_task_cache_invariant.stale_active_task_signal_present
             ~config
+            ~from_agent:author
             ~module_name:"keeper_world_observation"
             ~content:msg.content
         then

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1808,7 +1808,7 @@ let init () =
     Counter;
   add metric_cache_desync_cleared
     "Total stale task-state cache emissions cleared after reloading backlog \
-     truth. Labeled by module, task_id, and status."
+     truth. Labeled by module and status."
     Counter;
   add metric_keeper_reconcile_failures
     "Total current-task reconciliation failures. \

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -619,6 +619,8 @@ let metric_tool_policy_unloaded_query =
   "masc_tool_policy_unloaded_query_total"
 let metric_tool_policy_init_failed =
   "masc_tool_policy_init_failed_total"
+let metric_cache_desync_cleared =
+  "masc_cache_desync_cleared_total"
 let metric_keeper_reconcile_failures =
   "masc_keeper_reconcile_failures_total"
 let metric_keeper_decision_audit_flush_failures =
@@ -1803,6 +1805,10 @@ let init () =
   add metric_tool_policy_init_failed
     "Total server startup tool-policy initialization failures. \
      Labeled by base_path."
+    Counter;
+  add metric_cache_desync_cleared
+    "Total stale task-state cache emissions cleared after reloading backlog \
+     truth. Labeled by module, task_id, and status."
     Counter;
   add metric_keeper_reconcile_failures
     "Total current-task reconciliation failures. \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -278,6 +278,7 @@ val metric_keeper_tool_selection_failures : string
 val metric_keeper_tool_policy_failures : string
 val metric_tool_policy_unloaded_query : string
 val metric_tool_policy_init_failed : string
+val metric_cache_desync_cleared : string
 val metric_keeper_reconcile_failures : string
 val metric_keeper_decision_audit_flush_failures : string
 val metric_keeper_oas_cancel : string

--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -50,6 +50,13 @@ let handle_broadcast (ctx : context) : tool_result option =
   if not allowed then
     Some (false, Printf.sprintf "Rate limited. %d sec remaining." wait_secs)
   else begin
+    let message =
+      Coord_task_cache_invariant.rewrite_broadcast_content
+        ~config
+        ~from_agent:agent_name
+        ~module_name:"tool_inline_dispatch_comm"
+        ~content:message
+    in
     let trace_context = Otel_trace_context.from_ambient () in
     let broadcast_result = Coord.broadcast ?trace_context config ~from_agent:agent_name ~content:message in
         let mention = Mention.extract message in

--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -58,7 +58,10 @@ let handle_broadcast (ctx : context) : tool_result option =
         ~content:message
     in
     let trace_context = Otel_trace_context.from_ambient () in
-    let broadcast_result = Coord.broadcast ?trace_context config ~from_agent:agent_name ~content:message in
+    let broadcast_result =
+      Coord.broadcast ?trace_context ~task_cache_invariant_checked:true config
+        ~from_agent:agent_name ~content:message
+    in
         let mention = Mention.extract message in
         let _ = Session.push_message registry ~from_agent:agent_name ~content:message ~mention in
         let notification_fields = [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -833,6 +833,48 @@ let test_observe_damps_keeper_scope_chatter_but_keeps_direct_mentions () =
           check string "scope content" "general operator room update" content
       | _ -> fail "expected one operator scope message")
 
+let test_observe_skips_stale_terminal_task_mentions () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      ignore
+        (Masc_mcp.Coord.add_task config ~title:"Terminal task" ~priority:1
+           ~description:"");
+      ignore
+        (Masc_mcp.Coord.claim_task config ~agent_name:"nick0cave"
+           ~task_id:"task-001");
+      ignore
+        (Masc_mcp.Coord.broadcast config ~from_agent:"taskmaster"
+           ~content:
+             "@test-keeper task-001 stale claim detected: current_task_id=null \
+              but MASC still lists task-001 as claimed by you. Please release \
+              it.");
+      (match
+         Masc_mcp.Coord.force_done_task_r config ~agent_name:"operator"
+           ~task_id:"task-001" ~notes:"terminal in backlog" ()
+       with
+       | Ok _ -> ()
+       | Error err -> fail (Masc_domain.masc_error_to_string err));
+      let meta = { minimal_meta with joined_room_ids = [ "default" ] } in
+      let obs =
+        WO.observe ~allowed_tool_names:None
+          ~pending_board_events:(Some [])
+          ~config ~meta
+      in
+      check int "stale mention skipped" 0 (List.length obs.pending_mentions);
+      check int "scope messages stay empty" 0
+        (List.length obs.pending_scope_messages);
+      check bool "cursor advanced" true
+        (List.exists
+           (fun (room_id, seq) -> String.equal room_id "default" && seq > 0)
+           obs.message_cursor_updates))
+
 let test_scheduled_turn_uses_cooldown_only () =
   let meta =
     { minimal_meta with
@@ -7580,6 +7622,8 @@ let () =
             test_observe_collects_scope_messages_for_room_signal_keepers;
           test_case "room-signal keepers damp keeper scope chatter" `Quick
             test_observe_damps_keeper_scope_chatter_but_keeps_direct_mentions;
+          test_case "stale terminal task mentions advance cursor" `Quick
+            test_observe_skips_stale_terminal_task_mentions;
           test_case "scheduled turn uses cooldown only when work exists" `Quick
             test_scheduled_turn_uses_cooldown_only;
           test_case "scheduled turn skips without structured work signal" `Quick

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -209,6 +209,17 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
    | msgs ->
      Alcotest.failf "expected one replacement message, got %d" (List.length msgs));
 
+  let normal_update =
+    "Normal update: blocked by task-001 while I wait for review context."
+  in
+  let normal_result =
+    Coord.broadcast config ~from_agent:"taskmaster-jade-heron" ~content:normal_update
+  in
+  Alcotest.(check bool)
+    "normal task mention is not invalidated"
+    false
+    (str_contains normal_result "[cache_invalidated]");
+
   let _ = Coord.reset config in
   Unix.rmdir tmp_dir
 

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -166,6 +166,12 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   Unix.mkdir tmp_dir 0o755;
 
   let config = room_config tmp_dir in
+  let current_task_for agent_name =
+    Coord.get_agents_raw config
+    |> List.find_opt (fun (agent : Masc_domain.agent) ->
+      String.equal agent.name agent_name)
+    |> Option.bind (fun agent -> agent.current_task)
+  in
   let _ = Coord.init config ~agent_name:(Some "taskmaster") in
   let _ = Coord.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in
   let _ = Coord.claim_task config ~agent_name:"nick0cave" ~task_id:"task-001" in
@@ -179,6 +185,10 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
    with
    | Ok _ -> ()
    | Error err -> Alcotest.fail (Masc_domain.masc_error_to_string err));
+  Alcotest.(check (option string))
+    "assignee has stale current_task before invariant"
+    (Some "task-001")
+    (current_task_for "nick0cave");
 
   let stale_message =
     "@nick0cave task-001 stale claim detected: current_task_id=null but \
@@ -208,6 +218,10 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
        (str_contains msg.content "task-001=done")
    | msgs ->
      Alcotest.failf "expected one replacement message, got %d" (List.length msgs));
+  Alcotest.(check (option string))
+    "stale current_task cleared"
+    None
+    (current_task_for "nick0cave");
 
   let normal_update =
     "Normal update: blocked by task-001 while I wait for review context."

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -152,6 +152,66 @@ let test_broadcast_message () =
   let _ = Coord.reset config in
   Unix.rmdir tmp_dir
 
+let test_broadcast_replaces_terminal_task_cache_desync () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let tmp_dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc_test_%d_%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.)))
+  in
+  Unix.mkdir tmp_dir 0o755;
+
+  let config = room_config tmp_dir in
+  let _ = Coord.init config ~agent_name:(Some "taskmaster") in
+  let _ = Coord.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in
+  let _ = Coord.claim_task config ~agent_name:"nick0cave" ~task_id:"task-001" in
+  (match
+     Coord.force_done_task_r
+       config
+       ~agent_name:"operator"
+       ~task_id:"task-001"
+       ~notes:"terminal in backlog"
+       ()
+   with
+   | Ok _ -> ()
+   | Error err -> Alcotest.fail (Masc_domain.masc_error_to_string err));
+
+  let stale_message =
+    "@nick0cave task-001 stale claim detected: current_task_id=null but \
+     MASC still lists task-001 as claimed by you. Please release it."
+  in
+  let since_seq =
+    Coord.get_all_messages_raw config ~since_seq:0
+    |> List.fold_left (fun acc msg -> max acc msg.Masc_domain.seq) 0
+  in
+  let result =
+    Coord.broadcast config ~from_agent:"taskmaster-jade-heron" ~content:stale_message
+  in
+  Alcotest.(check bool)
+    "broadcast reports invalidation"
+    true
+    (str_contains result "[cache_invalidated]");
+  let messages = Coord.get_all_messages_raw config ~since_seq in
+  (match messages with
+   | [ msg ] ->
+     Alcotest.(check bool)
+       "original stale text omitted"
+       false
+       (str_contains msg.content "Please release");
+     Alcotest.(check bool)
+       "replacement cites terminal task"
+       true
+       (str_contains msg.content "task-001=done")
+   | msgs ->
+     Alcotest.failf "expected one replacement message, got %d" (List.length msgs));
+
+  let _ = Coord.reset config in
+  Unix.rmdir tmp_dir
+
 let test_worktree_list_no_git () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1599,6 +1659,8 @@ let () =
       Alcotest.test_case "broadcast" `Quick test_broadcast_message;
       Alcotest.test_case "lifecycle messages are typed" `Quick
         test_lifecycle_messages_are_typed;
+      Alcotest.test_case "broadcast replaces terminal task cache desync" `Quick
+        test_broadcast_replaces_terminal_task_cache_desync;
     ];
     "worktree", [
       Alcotest.test_case "list no git" `Quick test_worktree_list_no_git;

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -219,6 +219,13 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     "normal task mention is not invalidated"
     false
     (str_contains normal_result "[cache_invalidated]");
+  let operator_result =
+    Coord.broadcast config ~from_agent:"operator" ~content:stale_message
+  in
+  Alcotest.(check bool)
+    "non-taskmaster stale-looking prose is not invalidated"
+    false
+    (str_contains operator_result "[cache_invalidated]");
 
   let _ = Coord.reset config in
   Unix.rmdir tmp_dir


### PR DESCRIPTION
Refs #13460.

## Why
#13460 captured taskmaster repeatedly broadcasting active-claim/release requests for task-037 after backlog truth had already moved the task to a terminal state. The same stale active-task text can also sit in room history and keep retriggering keeper mention observation after the task is already done.

## What changed
- Add a coord task-cache invariant helper that extracts task ids from active-claim style text and reloads backlog truth before emit or observation.
- Replace stale active-task broadcasts for terminal tasks with one cache_invalidated broadcast instead of emitting the original message.
- Apply the same rewrite in masc_broadcast tool dispatch before SSE/session/mention side effects so stale text is not re-pushed outside the message file path.
- Suppress persisted stale terminal-task messages during keeper world observation while still advancing the message cursor.
- Add masc_cache_desync_cleared_total{module,task_id,status} via Coord_hooks to avoid a coord -> Prometheus dependency.
- Add regressions for task-001 claimed -> forced done -> stale broadcast replacement and stale persisted mention suppression.

## Scope note
This covers the taskmaster broadcast and namespace/mention observation slices for #13460. Dashboard/frontend cache invalidation remains a follow-up if live browser/runtime evidence shows a separate client cache path.

## Validation
- ocamlc -stop-after parsing lib/coord/coord_hooks.mli lib/coord/coord_hooks.ml lib/coord/coord_task_cache_invariant.ml lib/coord/coord_broadcast.ml lib/tool_inline_dispatch_comm.ml lib/prometheus.ml lib/prometheus.mli test/test_room.ml
- scripts/opam-pin-external-deps.sh --install (repair local agent_sdk pin drift)
- scripts/dune-local.sh build test/test_room.exe
- ./_build/default/test/test_room.exe test messages
- ocamlc -stop-after parsing lib/coord/coord_task_cache_invariant.ml lib/keeper/keeper_world_observation.ml test/test_keeper_unified.ml
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test world_observation 16
- git diff --check

## Notes
- First focused test_room build retry hit the known shared Dune cache race: rmdir(...dune_*_artifacts): Directory not empty; rerun passed.
- test_keeper_unified build waited for the shared opam and Dune locks, then passed.