### PR TITLE
fix(memory): surface search audit append failures

### DIFF
--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -318,7 +318,17 @@ let keeper_memory_search_json
          | Some s -> [ "top_score", `Float s ]
          | None -> [])) in
     append_jsonl_line (keeper_decision_log_path config meta.name) log_entry
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_decision_audit_flush_failures
+      ~labels:[("keeper", meta.name)]
+      ();
+    Log.Keeper.warn
+      "keeper:%s memory_search decision-log append failed: %s"
+      meta.name
+      (Printexc.to_string exn));
   Yojson.Safe.to_string result
 ;;
 

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1037,6 +1037,31 @@ let test_memory_search_bank_empty () =
     let match_count = Yojson.Safe.Util.(json |> member "match_count" |> to_int) in
     check int "match_count is 0" 0 match_count)
 
+let test_memory_search_decision_log_failure_is_observable () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
+    let config = make_test_room_config dir in
+    let keeper_name = "memory-search-log-failure" in
+    let meta = keeper_meta ~name:keeper_name ~mention_targets:[keeper_name] () in
+    Keeper_types.mkdir_p (Keeper_types.keeper_decision_log_path config keeper_name);
+    let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
+    let before =
+      Masc_mcp.Prometheus.metric_total
+        Masc_mcp.Prometheus.metric_keeper_decision_audit_flush_failures
+    in
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
+      ~name:"keeper_memory_search"
+      ~input:(`Assoc [ ("query", `String "anything") ])
+      () in
+    let after =
+      Masc_mcp.Prometheus.metric_total
+        Masc_mcp.Prometheus.metric_keeper_decision_audit_flush_failures
+    in
+    let json = Yojson.Safe.from_string result in
+    let no_match = Yojson.Safe.Util.(json |> member "no_match" |> to_bool) in
+    check bool "memory search still returns result" true no_match;
+    check bool "decision-log append failure increments counter" true (after > before))
+
 (** Test: query with no matching text returns no_match: true *)
 let test_memory_search_bank_no_match () =
   let dir = test_tmpdir () in
@@ -1488,6 +1513,8 @@ let () =
             test_memory_search_bank_prefers_long_term_over_stale_short_term;
           test_case "empty bank returns no_match" `Quick
             test_memory_search_bank_empty;
+          test_case "decision log append failure is observable" `Quick
+            test_memory_search_decision_log_failure_is_observable;
           test_case "no matching query returns no_match" `Quick
             test_memory_search_bank_no_match;
           test_case "source=history uses legacy search" `Quick

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1046,16 +1046,20 @@ let test_memory_search_decision_log_failure_is_observable () =
     Keeper_types.mkdir_p (Keeper_types.keeper_decision_log_path config keeper_name);
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let before =
-      Masc_mcp.Prometheus.metric_total
+      Masc_mcp.Prometheus.metric_value_or_zero
         Masc_mcp.Prometheus.metric_keeper_decision_audit_flush_failures
+        ~labels:[("keeper", keeper_name)]
+        ()
     in
     let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "anything") ])
       () in
     let after =
-      Masc_mcp.Prometheus.metric_total
+      Masc_mcp.Prometheus.metric_value_or_zero
         Masc_mcp.Prometheus.metric_keeper_decision_audit_flush_failures
+        ~labels:[("keeper", keeper_name)]
+        ()
     in
     let json = Yojson.Safe.from_string result in
     let no_match = Yojson.Safe.Util.(json |> member "no_match" |> to_bool) in


### PR DESCRIPTION
## Summary
- Replace the silent keeper_memory_search decision-log append catch-all with log + metric visibility.
- Reuse masc_keeper_decision_audit_flush_failures_total{keeper} for the existing decision-audit loss surface.
- Add a regression case that makes the decision log path a directory, verifies keeper_memory_search still returns a result, and verifies the failure counter increments.

## Verification
- scripts/dune-local.sh build test/test_keeper_memory.exe
- ./_build/default/test/test_keeper_memory.exe test memory_bank_search 5

Note: running the full test_keeper_memory.exe executed the new case successfully, then failed later in pre-existing memory_cap_telemetry / compaction records consolidation with ASSERT compaction ran. The focused case above isolates this patch.