### PR TITLE
test(memory): make compaction telemetry trigger deterministic

### DIFF
--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1288,6 +1288,7 @@ let memory_bank_test_row ~kind ~trace_id ~text ~priority ~idx =
 let test_compaction_records_consolidation_metrics () =
   with_env "MASC_KEEPER_MEMORY_MAX_NOTES" "40" @@ fun () ->
   with_env "MASC_KEEPER_MEMORY_MAX_LENGTH" "4096" @@ fun () ->
+  with_env "MASC_KEEPER_MEMORY_COMPACT_TRIGGER_BYTES" "60000" @@ fun () ->
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir_recursive dir) (fun () ->
     let keeper = "metric-memory-keeper" in
@@ -1365,7 +1366,11 @@ let test_compaction_records_consolidation_metrics () =
     let compaction =
       Keeper_memory_bank.compact_memory_bank_if_needed config meta
     in
-    check bool "compaction ran" true compaction.performed;
+    let compaction_reason =
+      Option.value ~default:"none" compaction.reason
+    in
+    check bool (Printf.sprintf "compaction ran (%s)" compaction_reason)
+      true compaction.performed;
     check (float 0.001) "progress consolidation generated"
       (generated_progress_before +. 1.0)
       (memory_metric_value


### PR DESCRIPTION
## Summary
- Pin `MASC_KEEPER_MEMORY_COMPACT_TRIGGER_BYTES=60000` inside the memory compaction telemetry regression so the seeded test data always crosses the compaction threshold.
- Include the compaction reason in the assertion label so future threshold failures report the actual skip reason.

## Root cause
The current-main focused test `test_keeper_memory.exe test memory_cap_telemetry 2` can seed 80 rows and still stay below the default 120KB compaction trigger, causing `compact_memory_bank_if_needed` to return `under_trigger_bytes` and skip the metric assertions.

## Validation
- Reproduced on current `main`: `./_build/default/test/test_keeper_memory.exe test memory_cap_telemetry 2` failed with `ASSERT compaction ran`.
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_memory.exe`
- `./_build/default/test/test_keeper_memory.exe test memory_cap_telemetry 2`
- `./_build/default/test/test_keeper_memory.exe`

Notes: one focused build attempt hit a shared Dune cache cleanup race, and the local opam `agent_sdk` pin drift was repaired with `scripts/opam-pin-external-deps.sh --install` before rerunning the successful checks.