### PR TITLE
fix(dashboard): announce board reaction failures

### DIFF
--- a/dashboard/src/components/board/reaction-bar.a11y.test.ts
+++ b/dashboard/src/components/board/reaction-bar.a11y.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'jest-axe'
+import '@testing-library/jest-dom'
+
+vi.mock('../../api/board', () => ({
+  fetchBoardReactions: vi.fn().mockResolvedValue([]),
+  toggleReaction: vi.fn(),
+}))
+
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+import { toggleReaction } from '../../api/board'
+import { ReactionBar } from './reaction-bar'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ReactionBar a11y', () => {
+  it('renders embedded summaries without axe violations', async () => {
+    const { container } = render(h(ReactionBar, {
+      targetType: 'post',
+      targetId: 'post-1',
+      initialSummaries: [{
+        emoji: '🔥',
+        count: 2,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['agent-a'],
+      }],
+    }))
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('keeps the failed-toggle live status axe clean', async () => {
+    vi.mocked(toggleReaction).mockRejectedValueOnce(new Error('network down'))
+
+    const { container } = render(h(ReactionBar, {
+      targetType: 'post',
+      targetId: 'post-1',
+      initialSummaries: [],
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: '👍 리액션 0개' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('리액션 반영에 실패했습니다')
+    })
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/board/reaction-bar.test.ts
+++ b/dashboard/src/components/board/reaction-bar.test.ts
@@ -30,6 +30,7 @@ describe('ReactionBar', () => {
     for (const emoji of ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥']) {
       expect(screen.getByRole('button', { name: `${emoji} 리액션 0개` })).toBeInTheDocument()
     }
+    expect(screen.getByRole('status')).toHaveTextContent('')
   })
 
   it('uses embedded initial summaries without an initial fetch', async () => {
@@ -91,6 +92,36 @@ describe('ReactionBar', () => {
       expect(fetchBoardReactions).toHaveBeenCalledTimes(2)
       expect(screen.getByRole('button', { name: '🔥 리액션 3개' })).toBeInTheDocument()
     })
+  })
+
+  it('clears the live status before retrying reaction summary refreshes', async () => {
+    vi.mocked(fetchBoardReactions).mockRejectedValueOnce(new Error('offline'))
+
+    render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('리액션 요약을 불러오지 못했습니다')
+    })
+
+    let resolveRefresh: (value: []) => void = () => {}
+    vi.mocked(fetchBoardReactions).mockImplementationOnce(() => new Promise(resolve => {
+      resolveRefresh = resolve
+    }))
+
+    lastEvent.value = {
+      type: 'reaction_changed',
+      target_type: 'post',
+      target_id: 'post-1',
+      user_id: 'agent-a',
+      emoji: '🔥',
+      reacted: true,
+    }
+
+    await waitFor(() => {
+      expect(fetchBoardReactions).toHaveBeenCalledTimes(2)
+      expect(screen.getByRole('status')).toHaveTextContent('')
+    })
+    resolveRefresh([])
   })
 
   it('announces and toasts failed reaction toggles', async () => {

--- a/dashboard/src/components/board/reaction-bar.test.ts
+++ b/dashboard/src/components/board/reaction-bar.test.ts
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
@@ -8,8 +8,13 @@ vi.mock('../../api/board', () => ({
   toggleReaction: vi.fn(),
 }))
 
-import { fetchBoardReactions } from '../../api/board'
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+import { fetchBoardReactions, toggleReaction } from '../../api/board'
 import { lastEvent } from '../../sse'
+import { showToast } from '../common/toast'
 import { ReactionBar } from './reaction-bar'
 
 afterEach(() => {
@@ -86,5 +91,21 @@ describe('ReactionBar', () => {
       expect(fetchBoardReactions).toHaveBeenCalledTimes(2)
       expect(screen.getByRole('button', { name: '🔥 리액션 3개' })).toBeInTheDocument()
     })
+  })
+
+  it('announces and toasts failed reaction toggles', async () => {
+    vi.mocked(toggleReaction).mockRejectedValueOnce(new Error('network down'))
+
+    render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
+
+    const reaction = screen.getByRole('button', { name: '👍 리액션 0개' })
+    fireEvent.click(reaction)
+
+    await waitFor(() => {
+      expect(toggleReaction).toHaveBeenCalledWith('post', 'post-1', '👍')
+      expect(showToast).toHaveBeenCalledWith('리액션 반영에 실패했습니다', 'error')
+    })
+    expect(screen.getByRole('status')).toHaveTextContent('리액션 반영에 실패했습니다')
+    expect(reaction).not.toBeDisabled()
   })
 })

--- a/dashboard/src/components/board/reaction-bar.ts
+++ b/dashboard/src/components/board/reaction-bar.ts
@@ -21,9 +21,11 @@ export function ReactionBar({
   const hasInitialSummaries = initialSummaries !== undefined
   const [summaries, setSummaries] = useState<BoardReactionSummary[]>(() => initialSummaries ?? [])
   const [busyEmoji, setBusyEmoji] = useState<string | null>(null)
+  const [statusMessage, setStatusMessage] = useState('')
 
   useEffect(() => {
     setSummaries(initialSummaries ?? [])
+    setStatusMessage('')
   }, [targetType, targetId, initialSummaries])
 
   useEffect(() => {
@@ -31,11 +33,15 @@ export function ReactionBar({
     const refresh = () => {
       void fetchBoardReactions(targetType, targetId)
         .then(next => {
-          if (!cancelled) setSummaries(next)
+          if (!cancelled) {
+            setSummaries(next)
+            setStatusMessage('')
+          }
         })
         .catch(err => {
           if (!cancelled) {
             console.warn('[board] reaction summary failed', err instanceof Error ? err.message : err)
+            setStatusMessage('리액션 요약을 불러오지 못했습니다')
           }
         })
     }
@@ -61,12 +67,15 @@ export function ReactionBar({
   const handleToggle = async (emoji: string) => {
     if (busyEmoji) return
     setBusyEmoji(emoji)
+    setStatusMessage('')
     try {
       const result = await toggleReaction(targetType, targetId, emoji)
       setSummaries(result.summary)
     } catch (err) {
       console.warn('[board] reaction toggle failed', err instanceof Error ? err.message : err)
-      showToast('리액션 반영에 실패했습니다', 'error')
+      const message = '리액션 반영에 실패했습니다'
+      setStatusMessage(message)
+      showToast(message, 'error')
     } finally {
       setBusyEmoji(null)
     }
@@ -97,6 +106,9 @@ export function ReactionBar({
           </button>
         `
       })}
+      ${statusMessage
+        ? html`<span class="sr-only" role="status" aria-live="polite" aria-atomic="true">${statusMessage}</span>`
+        : null}
     </div>
   `
 }

--- a/dashboard/src/components/board/reaction-bar.ts
+++ b/dashboard/src/components/board/reaction-bar.ts
@@ -31,6 +31,7 @@ export function ReactionBar({
   useEffect(() => {
     let cancelled = false
     const refresh = () => {
+      setStatusMessage('')
       void fetchBoardReactions(targetType, targetId)
         .then(next => {
           if (!cancelled) {
@@ -106,9 +107,7 @@ export function ReactionBar({
           </button>
         `
       })}
-      ${statusMessage
-        ? html`<span class="sr-only" role="status" aria-live="polite" aria-atomic="true">${statusMessage}</span>`
-        : null}
+      <span class="sr-only" role="status" aria-live="polite" aria-atomic="true">${statusMessage}</span>
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- Add a local screen-reader live status for board reaction summary/toggle failures.
- Keep failed user toggles on the existing global error toast path.
- Add unit and jest-axe coverage for embedded summaries and failed-toggle status.

## Validation
- pnpm --dir dashboard exec vitest run src/components/board/reaction-bar.test.ts src/components/board/reaction-bar.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- git diff --check

## Why
This closes the Phase 1B board SNS gap for failed reaction toast/a11y audit without changing the reaction API source of truth.