### PR TITLE
fix(opam): guard agent_sdk pin downgrades

### DIFF
--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -118,8 +118,6 @@ installed_agent_sdk_version() {
 
 guard_agent_sdk_downgrade() {
   [[ "${MASC_ALLOW_OAS_PIN_DOWNGRADE:-0}" != "1" ]] || return 0
-  # Explicit overrides are operator-directed; do not second-guess them here.
-  [[ -z "${AGENT_SDK_PIN_URL:-}" ]] || return 0
 
   local recorded_floor
   if [[ -r "${agent_sdk_floor_path}" ]]; then

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -110,7 +110,7 @@ installed_agent_sdk_version() {
   command -v opam >/dev/null 2>&1 || return 1
 
   local installed_packages agent_sdk_row installed_version show_version
-  if ! installed_packages="$(OPAMCOLOR=never opam list --installed --columns=name,version --short 2>&1)"; then
+  if ! installed_packages="$(OPAMCOLOR=never opam list --installed --columns=name,version 2>&1)"; then
     echo "[opam-pin] ERROR: failed to inspect installed agent_sdk via opam list" >&2
     echo "[opam-pin] opam list output: ${installed_packages:-<empty>}" >&2
     return 2
@@ -141,7 +141,8 @@ installed_agent_sdk_version() {
     return 0
   fi
 
-  return 1
+  echo "[opam-pin] ERROR: could not determine installed agent_sdk version from opam list or opam show" >&2
+  return 2
 }
 
 guard_agent_sdk_downgrade() {

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -35,6 +35,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 opam_lock_path="${MASC_OPAM_LOCK_PATH:-/tmp/me-opam-switch.lock}"
+agent_sdk_floor_path="${MASC_AGENT_SDK_FLOOR_PATH:-/tmp/me-agent-sdk-floor}"
 
 if [[ "${MASC_OPAM_LOCK:-1}" != "0" \
       && "${MASC_SKIP_OPAM_LOCK:-0}" != "1" \
@@ -78,6 +79,105 @@ for arg in "$@"; do
   esac
 done
 
+normalize_version_triplet() {
+  local value
+  value="$(printf '%s' "$1" | sed -E $'s/\x1B\\[[0-9;]*[[:alpha:]]//g')"
+  if [[ "${value}" =~ ([0-9]+(\.[0-9]+){0,2}) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
+}
+
+# Returns true when $1 > $2 for three-part semver-ish versions.
+version_gt() {
+  local lhs rhs
+  lhs="$(normalize_version_triplet "$1")"
+  rhs="$(normalize_version_triplet "$2")"
+  [[ -n "${lhs}" && -n "${rhs}" ]] || return 1
+
+  local IFS='.'
+  # shellcheck disable=SC2206
+  local a=(${lhs}) b=(${rhs})
+  local i
+  for i in 0 1 2; do
+    local va=${a[$i]:-0} vb=${b[$i]:-0}
+    if (( va > vb )); then return 0; fi
+    if (( va < vb )); then return 1; fi
+  done
+  return 1
+}
+
+installed_agent_sdk_version() {
+  command -v opam >/dev/null 2>&1 || return 1
+
+  local installed_packages installed_version
+  installed_packages="$(OPAMCOLOR=never opam list --installed --columns=name,version --short 2>/dev/null)" || return 1
+  installed_version="$(awk '$1 == "agent_sdk" { print $2 }' <<<"${installed_packages}")"
+  [[ -n "${installed_version}" ]] || return 1
+  printf '%s' "${installed_version}"
+}
+
+guard_agent_sdk_downgrade() {
+  [[ "${MASC_ALLOW_OAS_PIN_DOWNGRADE:-0}" != "1" ]] || return 0
+  # Explicit overrides are operator-directed; do not second-guess them here.
+  [[ -z "${AGENT_SDK_PIN_URL:-}" ]] || return 0
+
+  local recorded_floor
+  if [[ -r "${agent_sdk_floor_path}" ]]; then
+    recorded_floor="$(head -n 1 "${agent_sdk_floor_path}" 2>/dev/null || true)"
+    if [[ -n "${recorded_floor}" ]] && version_gt "${recorded_floor}" "${OAS_AGENT_SDK_MIN_VERSION}"; then
+      echo "[opam-pin] ERROR: refusing to downgrade agent_sdk below recorded floor ${recorded_floor}; branch floor is ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+      echo "[opam-pin] recorded floor: ${agent_sdk_floor_path}" >&2
+      echo "[opam-pin] branch pin source: ${agent_sdk_pin_source}" >&2
+      echo "[opam-pin] script path: ${SCRIPT_DIR}/opam-pin-external-deps.sh" >&2
+      echo "[opam-pin] likely cause: a stale worktree is trying to repin the shared opam switch to an older OAS SDK" >&2
+      echo "[opam-pin] repair: rebase/update this worktree to the current OAS pin, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1 for an intentional rollback" >&2
+      exit 1
+    fi
+  fi
+
+  local installed_version
+  installed_version="$(installed_agent_sdk_version 2>/dev/null || true)"
+  [[ -n "${installed_version}" ]] || return 0
+
+  if version_gt "${installed_version}" "${OAS_AGENT_SDK_MIN_VERSION}"; then
+    echo "[opam-pin] ERROR: refusing to downgrade installed agent_sdk ${installed_version} to branch floor ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+    echo "[opam-pin] branch pin source: ${agent_sdk_pin_source}" >&2
+    echo "[opam-pin] script path: ${SCRIPT_DIR}/opam-pin-external-deps.sh" >&2
+    echo "[opam-pin] likely cause: a stale worktree is trying to repin the shared opam switch to an older OAS SDK" >&2
+    echo "[opam-pin] repair: rebase/update this worktree to the current OAS pin, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1 for an intentional rollback" >&2
+    exit 1
+  fi
+}
+
+record_agent_sdk_floor() {
+  # Explicit local/rollback use should not ratchet the shared default floor down.
+  [[ -z "${AGENT_SDK_PIN_URL:-}" ]] || return 0
+
+  local recorded_floor
+  if [[ -r "${agent_sdk_floor_path}" ]]; then
+    recorded_floor="$(head -n 1 "${agent_sdk_floor_path}" 2>/dev/null || true)"
+    if [[ -n "${recorded_floor}" ]] && version_gt "${recorded_floor}" "${OAS_AGENT_SDK_MIN_VERSION}"; then
+      return 0
+    fi
+  fi
+
+  local floor_dir tmp_path
+  floor_dir="$(dirname "${agent_sdk_floor_path}")"
+  mkdir -p "${floor_dir}" 2>/dev/null || {
+    echo "[opam-pin] WARN: could not create agent_sdk floor dir: ${floor_dir}" >&2
+    return 0
+  }
+  tmp_path="${agent_sdk_floor_path}.tmp.$$"
+  if printf '%s\n' "${OAS_AGENT_SDK_MIN_VERSION}" > "${tmp_path}" \
+    && mv "${tmp_path}" "${agent_sdk_floor_path}"; then
+    return 0
+  fi
+  rm -f "${tmp_path}" 2>/dev/null || true
+  echo "[opam-pin] WARN: could not record agent_sdk floor: ${agent_sdk_floor_path}" >&2
+}
+
+guard_agent_sdk_downgrade
+
 # Accumulate the package names we pin so a follow-up `opam install` in
 # --install mode can rebuild exactly the set that changed, nothing more.
 pinned_pkgs=()
@@ -119,6 +219,7 @@ fi
 opam_pin_add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.3.0 -n -y
 pinned_pkgs+=("mcp_protocol")
 opam_pin_add agent_sdk "${agent_sdk_pin_source}" -n -y
+record_agent_sdk_floor
 pinned_pkgs+=("agent_sdk")
 opam_pin_add ocaml-webrtc "https://github.com/jeong-sik/ocaml-webrtc.git#${WEBRTC_SHA}" -n -y
 pinned_pkgs+=("ocaml-webrtc")

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -109,11 +109,39 @@ version_gt() {
 installed_agent_sdk_version() {
   command -v opam >/dev/null 2>&1 || return 1
 
-  local installed_packages installed_version
-  installed_packages="$(OPAMCOLOR=never opam list --installed --columns=name,version --short 2>/dev/null)" || return 1
-  installed_version="$(awk '$1 == "agent_sdk" { print $2 }' <<<"${installed_packages}")"
-  [[ -n "${installed_version}" ]] || return 1
-  printf '%s' "${installed_version}"
+  local installed_packages agent_sdk_row installed_version show_version
+  if ! installed_packages="$(OPAMCOLOR=never opam list --installed --columns=name,version --short 2>&1)"; then
+    echo "[opam-pin] ERROR: failed to inspect installed agent_sdk via opam list" >&2
+    echo "[opam-pin] opam list output: ${installed_packages:-<empty>}" >&2
+    return 2
+  fi
+
+  agent_sdk_row="$(awk '$1 == "agent_sdk" { print; exit }' <<<"${installed_packages}")"
+  if [[ -n "${agent_sdk_row}" ]]; then
+    installed_version="$(awk '{ print $2 }' <<<"${agent_sdk_row}")"
+    if [[ -z "$(normalize_version_triplet "${installed_version}")" ]]; then
+      echo "[opam-pin] ERROR: could not parse installed agent_sdk version from opam list row: ${agent_sdk_row}" >&2
+      return 2
+    fi
+    printf '%s' "${installed_version}"
+    return 0
+  fi
+
+  # Fallback: opam show reads package metadata directly from the switch.  This
+  # covers cases where opam list output is incomplete but the switch still knows
+  # the package version.
+  show_version="$(OPAMCOLOR=never opam show agent_sdk --field=version 2>/dev/null || true)"
+  if [[ -n "${show_version}" ]]; then
+    installed_version="$(normalize_version_triplet "${show_version}")"
+    if [[ -z "${installed_version}" ]]; then
+      echo "[opam-pin] ERROR: could not parse installed agent_sdk version from opam show output: ${show_version}" >&2
+      return 2
+    fi
+    printf '%s' "${installed_version}"
+    return 0
+  fi
+
+  return 1
 }
 
 guard_agent_sdk_downgrade() {
@@ -134,8 +162,22 @@ guard_agent_sdk_downgrade() {
   fi
 
   local installed_version
-  installed_version="$(installed_agent_sdk_version 2>/dev/null || true)"
-  [[ -n "${installed_version}" ]] || return 0
+  if installed_version="$(installed_agent_sdk_version)"; then
+    :
+  else
+    case "$?" in
+      1)
+        return 0
+        ;;
+      *)
+        echo "[opam-pin] ERROR: refusing to mutate agent_sdk pin because installed version could not be determined" >&2
+        echo "[opam-pin] branch pin source: ${agent_sdk_pin_source}" >&2
+        echo "[opam-pin] script path: ${SCRIPT_DIR}/opam-pin-external-deps.sh" >&2
+        echo "[opam-pin] repair: fix opam switch inspection, or set MASC_ALLOW_OAS_PIN_DOWNGRADE=1 for an intentional rollback" >&2
+        exit 1
+        ;;
+    esac
+  fi
 
   if version_gt "${installed_version}" "${OAS_AGENT_SDK_MIN_VERSION}"; then
     echo "[opam-pin] ERROR: refusing to downgrade installed agent_sdk ${installed_version} to branch floor ${OAS_AGENT_SDK_MIN_VERSION}" >&2

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -25,6 +25,12 @@ set -euo pipefail
 
 case "$1" in
   list)
+    for arg in "$@"; do
+      if [[ "${arg}" == "--short" ]]; then
+        echo "fake opam list rejects --short with explicit columns" >&2
+        exit 44
+      fi
+    done
     if [[ "${FAKE_OPAM_LIST_FAIL:-0}" == "1" ]]; then
       echo "fake opam list failure" >&2
       exit 42
@@ -193,5 +199,20 @@ assert_contains "${TMP}/case8.err" "refusing to downgrade installed agent_sdk 99
 assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
 echo "ok case 8 - opam show fallback preserves installed-version protection"
 
+case9_err="${TMP}/case9.err"
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+if run_pin_script \
+  FAKE_AGENT_SDK_LIST_OUTPUT=$'other_pkg 1.0.0\n' \
+  FAKE_OPAM_SHOW_FAIL=1 \
+  bash "${PIN_SCRIPT}" >"${TMP}/case9.out" 2>"${case9_err}"; then
+  echo "FAIL case 9: missing agent_sdk list row plus failed opam show should fail closed" >&2
+  exit 1
+fi
+assert_contains "${case9_err}" "could not determine installed agent_sdk version"
+assert_contains "${case9_err}" "refusing to mutate agent_sdk pin because installed version could not be determined"
+assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
+echo "ok case 9 - unavailable installed version fails closed when opam is present"
+
 echo ""
-echo "[opam-pin-downgrade-guard test] PASS - 8/8 cases"
+echo "[opam-pin-downgrade-guard test] PASS - 9/9 cases"

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Regression test for scripts/opam-pin-external-deps.sh downgrade guard.
+#
+# Run: bash test/test_opam_pin_downgrade_guard.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PIN_SCRIPT="${REPO_ROOT}/scripts/opam-pin-external-deps.sh"
+
+source "${REPO_ROOT}/scripts/oas-agent-sdk-pin.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAKE_BIN="${TMP}/bin"
+CALLS_FILE="${TMP}/opam.calls"
+FLOOR_FILE="${TMP}/agent_sdk.floor"
+mkdir -p "${FAKE_BIN}"
+
+cat > "${FAKE_BIN}/opam" <<'FAKE_OPAM'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+  list)
+    printf 'agent_sdk %s\n' "${FAKE_AGENT_SDK_VERSION:-0.0.0}"
+    ;;
+  pin)
+    shift
+    if [[ "${1:-}" == "add" ]]; then
+      printf 'pin add %s %s\n' "${2:-}" "${3:-}" >> "${OPAM_FAKE_CALLS:?}"
+      exit 0
+    fi
+    echo "unexpected fake opam pin command: $*" >&2
+    exit 2
+    ;;
+  install)
+    printf 'install %s\n' "$*" >> "${OPAM_FAKE_CALLS:?}"
+    ;;
+  *)
+    echo "unexpected fake opam command: $*" >&2
+    exit 2
+    ;;
+esac
+FAKE_OPAM
+chmod +x "${FAKE_BIN}/opam"
+
+run_pin_script() {
+  env \
+    PATH="${FAKE_BIN}:${PATH}" \
+    OPAM_FAKE_CALLS="${CALLS_FILE}" \
+    MASC_AGENT_SDK_FLOOR_PATH="${FLOOR_FILE}" \
+    MASC_SKIP_OPAM_LOCK=1 \
+    "$@"
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${file}"; then
+    echo "FAIL: expected ${file} to contain: ${needle}" >&2
+    echo "--- ${file} ---" >&2
+    cat "${file}" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "${needle}" "${file}"; then
+    echo "FAIL: expected ${file} not to contain: ${needle}" >&2
+    echo "--- ${file} ---" >&2
+    cat "${file}" >&2
+    exit 1
+  fi
+}
+
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+if run_pin_script FAKE_AGENT_SDK_VERSION=999.999.999 bash "${PIN_SCRIPT}" >"${TMP}/case1.out" 2>"${TMP}/case1.err"; then
+  echo "FAIL case 1: stale branch downgrade should be rejected" >&2
+  exit 1
+fi
+assert_contains "${TMP}/case1.err" "refusing to downgrade installed agent_sdk 999.999.999"
+assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
+echo "ok case 1 - newer installed agent_sdk is not downgraded"
+
+: > "${CALLS_FILE}"
+printf '999.999.999\n' > "${FLOOR_FILE}"
+if run_pin_script FAKE_AGENT_SDK_VERSION="${OAS_AGENT_SDK_MIN_VERSION}" bash "${PIN_SCRIPT}" >"${TMP}/case2.out" 2>"${TMP}/case2.err"; then
+  echo "FAIL case 2: recorded floor downgrade should be rejected" >&2
+  exit 1
+fi
+assert_contains "${TMP}/case2.err" "refusing to downgrade agent_sdk below recorded floor 999.999.999"
+assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
+echo "ok case 2 - recorded floor blocks stale worktree downgrade"
+
+: > "${CALLS_FILE}"
+printf '999.999.999\n' > "${FLOOR_FILE}"
+run_pin_script FAKE_AGENT_SDK_VERSION=999.999.999 MASC_ALLOW_OAS_PIN_DOWNGRADE=1 bash "${PIN_SCRIPT}" >"${TMP}/case3.out" 2>"${TMP}/case3.err"
+assert_contains "${CALLS_FILE}" "pin add agent_sdk"
+if [[ "$(cat "${FLOOR_FILE}")" != "999.999.999" ]]; then
+  echo "FAIL case 3: rollback override should not lower the recorded floor" >&2
+  exit 1
+fi
+echo "ok case 3 - explicit rollback override permits the pin without lowering the floor"
+
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+run_pin_script FAKE_AGENT_SDK_VERSION="${OAS_AGENT_SDK_MIN_VERSION}" bash "${PIN_SCRIPT}" >"${TMP}/case4.out" 2>"${TMP}/case4.err"
+assert_contains "${CALLS_FILE}" "pin add agent_sdk"
+if [[ "$(cat "${FLOOR_FILE}")" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
+  echo "FAIL case 4: expected recorded floor ${OAS_AGENT_SDK_MIN_VERSION}, got $(cat "${FLOOR_FILE}" 2>/dev/null || true)" >&2
+  exit 1
+fi
+echo "ok case 4 - equal installed version permits normal pinning and records the floor"
+
+echo ""
+echo "[opam-pin-downgrade-guard test] PASS - 4/4 cases"

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -118,5 +118,33 @@ if [[ "$(cat "${FLOOR_FILE}")" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
 fi
 echo "ok case 4 - equal installed version permits normal pinning and records the floor"
 
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+if run_pin_script \
+  FAKE_AGENT_SDK_VERSION=999.999.999 \
+  AGENT_SDK_PIN_URL=git@local:agent-sdk-old.git \
+  bash "${PIN_SCRIPT}" >"${TMP}/case5.out" 2>"${TMP}/case5.err"; then
+  echo "FAIL case 5: AGENT_SDK_PIN_URL downgrade should still be rejected" >&2
+  exit 1
+fi
+assert_contains "${TMP}/case5.err" "refusing to downgrade installed agent_sdk 999.999.999"
+assert_contains "${TMP}/case5.err" "branch pin source: git@local:agent-sdk-old.git"
+assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
+echo "ok case 5 - AGENT_SDK_PIN_URL does not bypass downgrade protection"
+
+: > "${CALLS_FILE}"
+printf '999.999.999\n' > "${FLOOR_FILE}"
+run_pin_script \
+  FAKE_AGENT_SDK_VERSION=999.999.999 \
+  AGENT_SDK_PIN_URL=git@local:agent-sdk-old.git \
+  MASC_ALLOW_OAS_PIN_DOWNGRADE=1 \
+  bash "${PIN_SCRIPT}" >"${TMP}/case6.out" 2>"${TMP}/case6.err"
+assert_contains "${CALLS_FILE}" "pin add agent_sdk git@local:agent-sdk-old.git"
+if [[ "$(cat "${FLOOR_FILE}")" != "999.999.999" ]]; then
+  echo "FAIL case 6: AGENT_SDK_PIN_URL rollback override should not lower the recorded floor" >&2
+  exit 1
+fi
+echo "ok case 6 - explicit rollback override permits AGENT_SDK_PIN_URL without lowering the floor"
+
 echo ""
-echo "[opam-pin-downgrade-guard test] PASS - 4/4 cases"
+echo "[opam-pin-downgrade-guard test] PASS - 6/6 cases"

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -25,7 +25,25 @@ set -euo pipefail
 
 case "$1" in
   list)
-    printf 'agent_sdk %s\n' "${FAKE_AGENT_SDK_VERSION:-0.0.0}"
+    if [[ "${FAKE_OPAM_LIST_FAIL:-0}" == "1" ]]; then
+      echo "fake opam list failure" >&2
+      exit 42
+    fi
+    if [[ -n "${FAKE_AGENT_SDK_LIST_OUTPUT+x}" ]]; then
+      printf '%b' "${FAKE_AGENT_SDK_LIST_OUTPUT}"
+    else
+      printf 'agent_sdk %s\n' "${FAKE_AGENT_SDK_VERSION:-0.0.0}"
+    fi
+    ;;
+  show)
+    shift
+    if [[ "${1:-}" == "agent_sdk" && "${2:-}" == "--field=version" ]]; then
+      [[ "${FAKE_OPAM_SHOW_FAIL:-0}" == "1" ]] && exit 43
+      printf '%s\n' "${FAKE_OPAM_SHOW_VERSION:-${FAKE_AGENT_SDK_VERSION:-0.0.0}}"
+      exit 0
+    fi
+    echo "unexpected fake opam show command: $*" >&2
+    exit 2
     ;;
   pin)
     shift
@@ -37,6 +55,7 @@ case "$1" in
     exit 2
     ;;
   install)
+    shift
     printf 'install %s\n' "$*" >> "${OPAM_FAKE_CALLS:?}"
     ;;
   *)
@@ -146,5 +165,33 @@ if [[ "$(cat "${FLOOR_FILE}")" != "999.999.999" ]]; then
 fi
 echo "ok case 6 - explicit rollback override permits AGENT_SDK_PIN_URL without lowering the floor"
 
+case7_err="${TMP}/case7.err"
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+if run_pin_script \
+  FAKE_OPAM_LIST_FAIL=1 \
+  FAKE_OPAM_SHOW_VERSION=999.999.999 \
+  bash "${PIN_SCRIPT}" >"${TMP}/case7.out" 2>"${case7_err}"; then
+  echo "FAIL case 7: opam list inspection failure should fail closed" >&2
+  exit 1
+fi
+assert_contains "${case7_err}" "failed to inspect installed agent_sdk via opam list"
+assert_contains "${case7_err}" "refusing to mutate agent_sdk pin because installed version could not be determined"
+assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
+echo "ok case 7 - opam inspection failure fails closed"
+
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+if run_pin_script \
+  FAKE_AGENT_SDK_LIST_OUTPUT=$'other_pkg 1.0.0\n' \
+  FAKE_OPAM_SHOW_VERSION=999.999.999 \
+  bash "${PIN_SCRIPT}" >"${TMP}/case8.out" 2>"${TMP}/case8.err"; then
+  echo "FAIL case 8: opam show fallback should still block a newer installed version" >&2
+  exit 1
+fi
+assert_contains "${TMP}/case8.err" "refusing to downgrade installed agent_sdk 999.999.999"
+assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
+echo "ok case 8 - opam show fallback preserves installed-version protection"
+
 echo ""
-echo "[opam-pin-downgrade-guard test] PASS - 6/6 cases"
+echo "[opam-pin-downgrade-guard test] PASS - 8/8 cases"


### PR DESCRIPTION
## Summary

- Adds a downgrade guard to `scripts/opam-pin-external-deps.sh` for the shared `agent_sdk` opam pin.
- Refuses branch-local pin scripts that would lower `agent_sdk` below either the currently installed version or a host-local recorded floor.
- Keeps downgrade checks active even when `AGENT_SDK_PIN_URL` is supplied, so local source overrides cannot bypass the shared-switch floor.
- Fails closed when opam is available but the installed `agent_sdk` version cannot be determined, while using an `opam show` fallback when `opam list` output is incomplete.
- Adds `MASC_ALLOW_OAS_PIN_DOWNGRADE=1` as the explicit rollback escape hatch.
- Adds a fake-opam regression test covering installed-version protection, recorded-floor protection, rollback override behavior, normal equal-version pinning, `AGENT_SDK_PIN_URL` allow/deny behavior, opam-inspection failure, and `opam show` fallback behavior.

## Why

During #13463 validation, stale worktrees with old OAS pin metadata repeatedly repinned the shared opam switch from `agent_sdk 0.190.25` back to `0.190.12`. The existing lock serialized mutations but did not prevent an old branch-local script from downgrading shared host state.

Refs #13479.

## Operator Impact

After a newer branch records its accepted `agent_sdk` floor, later guarded stale worktrees fail before `opam pin add` instead of silently downgrading the shared switch. Intentional rollback remains possible, but it has to be explicit with `MASC_ALLOW_OAS_PIN_DOWNGRADE=1`.

Already-running old worktrees that do not contain this guard still need to finish, be stopped, or be rebased; this PR prevents the same class from recurring once the guarded script is present.

## Validation

[근거]
- `bash -n scripts/opam-pin-external-deps.sh test/test_opam_pin_downgrade_guard.sh` passed on 2026-05-06 Asia/Seoul.
- `bash test/test_opam_pin_downgrade_guard.sh` passed 8/8 cases on 2026-05-06 Asia/Seoul.
- `git diff --check` passed on 2026-05-06 Asia/Seoul.
- GitHub checks pass/skipped at head `1be7294e088aba4bbf560fff1b41100e157ba4af`.
- All four Copilot review threads are resolved.
- Live #13463 repin was repaired earlier, but a later stale worktree downgraded the shared switch again to `agent_sdk 0.190.12`; see #13479 evidence comment https://github.com/jeong-sik/masc-mcp/issues/13479#issuecomment-4385420299.

신뢰도: High for shell guard behavior; Medium for live host stability because external old worktrees may still mutate the shared switch until they stop, rebase, or this guard lands.