### PR TITLE
fix(dashboard): observe worktree status sse writes

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -76,10 +76,16 @@ let oas_telemetry_limit_param req =
 let oas_telemetry_provider_param req = trimmed_query_param req "provider"
 
 let observe_worktree_status_sse_write writer event =
-  Telemetry_observe.observe_or_default
-    ~kind:"dashboard_worktree_status_sse_write"
-    ~default:() (fun () ->
+  Telemetry_observe.observe_or_fail
+    ~kind:"dashboard_worktree_status_sse_write" (fun () ->
       Httpun.Body.Writer.write_string writer event)
+
+let rec observe_worktree_status_sse_write_all writer = function
+  | [] -> Ok ()
+  | event :: rest ->
+      (match observe_worktree_status_sse_write writer event with
+       | Ok () -> observe_worktree_status_sse_write_all writer rest
+       | Error _ as err -> err)
 
 let observe_worktree_status_sse_close writer =
   Telemetry_observe.observe_or_default
@@ -787,7 +793,7 @@ let rec add_routes ~sw ~clock router =
          let response = Httpun.Response.create ~headers `OK in
          let writer = Httpun.Reqd.respond_with_streaming inner_reqd response in
          let events = Dashboard_worktree_status.sse_events ~base_path in
-         List.iter (observe_worktree_status_sse_write writer) events;
+         ignore (observe_worktree_status_sse_write_all writer events);
          observe_worktree_status_sse_close writer
        ) request reqd)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -75,6 +75,18 @@ let oas_telemetry_limit_param req =
 
 let oas_telemetry_provider_param req = trimmed_query_param req "provider"
 
+let observe_worktree_status_sse_write writer event =
+  Telemetry_observe.observe_or_default
+    ~kind:"dashboard_worktree_status_sse_write"
+    ~default:() (fun () ->
+      Httpun.Body.Writer.write_string writer event)
+
+let observe_worktree_status_sse_close writer =
+  Telemetry_observe.observe_or_default
+    ~kind:"dashboard_worktree_status_sse_close"
+    ~default:() (fun () ->
+      Httpun.Body.Writer.close writer)
+
 let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
     ~(cascade_name : string) : (bool, string) result =
   let updated_at = Keeper_types.now_iso () in
@@ -775,12 +787,8 @@ let rec add_routes ~sw ~clock router =
          let response = Httpun.Response.create ~headers `OK in
          let writer = Httpun.Reqd.respond_with_streaming inner_reqd response in
          let events = Dashboard_worktree_status.sse_events ~base_path in
-         List.iter
-           (fun event ->
-             try Httpun.Body.Writer.write_string writer event
-             with _ -> ())
-           events;
-         (try Httpun.Body.Writer.close writer with _ -> ())
+         List.iter (observe_worktree_status_sse_write writer) events;
+         observe_worktree_status_sse_close writer
        ) request reqd)
 
   (* ── Eval feed (RFC-MASC-005 Phase 2) ── *)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1271,10 +1271,24 @@ let test_worktree_list_contracts () =
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        "dashboard_worktree_status_sse_write"
     && file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
-         "Telemetry_observe.observe_or_default");
+         "Telemetry_observe.observe_or_fail");
   check bool "dashboard worktree-status SSE close is observed" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        "dashboard_worktree_status_sse_close");
+  check bool "dashboard worktree-status SSE route uses observed write/close helpers" true
+    (file_contains_nearby_line_with_patterns
+       "lib/server/server_routes_http_routes_dashboard.ml"
+       ~anchor:{|/api/dashboard/worktree-status|}
+       ~patterns:[ "observe_worktree_status_sse_write_all" ]
+       ~max_lines:24
+     && file_contains_nearby_line_with_patterns
+          "lib/server/server_routes_http_routes_dashboard.ml"
+          ~anchor:{|/api/dashboard/worktree-status|}
+          ~patterns:[ "observe_worktree_status_sse_close" ]
+          ~max_lines:24);
+  check bool "dashboard worktree-status SSE writes fail fast" true
+    (file_not_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       "List.iter (observe_worktree_status_sse_write writer) events");
   check bool "dashboard worktree-status SSE has no raw writer swallow" true
     (file_not_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        "try Httpun.Body.Writer.write_string writer event"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1267,6 +1267,19 @@ let test_worktree_list_contracts () =
   check bool "worktree list stays read-only" true
     (file_contains_pattern "lib/tool_worktree.ml"
        {|let _tool_spec_read_only = [ "masc_worktree_list" ]|});
+  check bool "dashboard worktree-status SSE writes are observed" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       "dashboard_worktree_status_sse_write"
+    && file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+         "Telemetry_observe.observe_or_default");
+  check bool "dashboard worktree-status SSE close is observed" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       "dashboard_worktree_status_sse_close");
+  check bool "dashboard worktree-status SSE has no raw writer swallow" true
+    (file_not_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       "try Httpun.Body.Writer.write_string writer event"
+    && file_not_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+         "try Httpun.Body.Writer.close writer with _ -> ()");
   check bool "worker oas no longer reads global net directly" true
     (file_not_contains_pattern "lib/worker_oas.ml"
        "Eio_context.get_net_opt ()");


### PR DESCRIPTION
## Summary
- Replace raw `try ... with _ -> ()` wrappers in the dashboard worktree-status SSE route with named `Telemetry_observe.observe_or_default` helpers.
- Observe both per-event writes and the final writer close path, while preserving `Eio.Cancel.Cancelled` behavior from the shared wrapper.
- Add a source guard so the route does not regress to raw writer swallows.

## Root cause
`/api/dashboard/worktree-status` swallowed `Httpun.Body.Writer.write_string` and `close` exceptions directly. That hid dashboard delivery failures and could also hide cancellation if the writer raised `Eio.Cancel.Cancelled` through that path.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe`

Note: the shared opam switch drifted to `agent_sdk.0.190.25`; repaired with `scripts/opam-pin-external-deps.sh --install` before the successful focused build.