### PR TITLE
feat(dashboard): track board latency metrics

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -20,9 +20,12 @@ import {
   normalizeGovernanceJudgeSummary,
   normalizeSubBoard,
 } from './board'
+import { boardLatencyMetrics, resetBoardLatencyMetrics } from '../board-metrics'
 
 afterEach(() => {
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
+  resetBoardLatencyMetrics()
 })
 
 // ================================================================
@@ -810,6 +813,9 @@ describe('voteComment', () => {
 describe('board reactions', () => {
   it('fetches reaction summaries with the dashboard voter', async () => {
     window.history.replaceState({}, '', '/?agent=dashboard-reviewer')
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(18)
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         reactions: [{
@@ -839,10 +845,18 @@ describe('board reactions', () => {
     expect(url).toContain('target_type=post')
     expect(url).toContain('target_id=post-1')
     expect(url).toContain('user_id=dashboard-reviewer')
+    expect(boardLatencyMetrics.value.reaction_summary).toMatchObject({
+      last_latency_ms: 18,
+      last_ok: true,
+      sample_count: 1,
+    })
   })
 
   it('toggles a reaction through the board reaction endpoint', async () => {
     window.history.replaceState({}, '', '/?agent=dashboard-reviewer')
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(31)
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         target_type: 'comment',
@@ -879,6 +893,11 @@ describe('board reactions', () => {
       target_id: 'comment-1',
       user_id: 'dashboard-reviewer',
       emoji: '🚀',
+    })
+    expect(boardLatencyMetrics.value.reaction_toggle).toMatchObject({
+      last_latency_ms: 21,
+      last_ok: true,
+      sample_count: 1,
     })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,5 +1,6 @@
 import { currentDashboardActor, get, post, withRetries, defaultBoardVoter } from './core'
 import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
+import { timeBoardRequest } from '../board-metrics'
 import type {
   BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
   BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
@@ -588,7 +589,7 @@ export async function fetchBoard(
   sortBy?: BoardSortMode,
   options?: { excludeSystem?: boolean; excludeAutomation?: boolean; author?: string; hearth?: string },
 ): Promise<{ posts: BoardPost[] }> {
-  return withRetries('fetchBoard', async () => {
+  return timeBoardRequest('list', () => withRetries('fetchBoard', async () => {
     const params = new URLSearchParams()
     if (sortBy) params.set('sort_by', sortBy)
     if (options?.excludeSystem) params.set('exclude_system', 'true')
@@ -603,7 +604,7 @@ export async function fetchBoard(
       ? raw.posts.map(normalizeBoardPost).filter((row): row is BoardPost => row !== null)
       : []
     return { posts }
-  })
+  }))
 }
 
 export async function fetchBoardHearths(): Promise<BoardHearth[]> {
@@ -626,7 +627,7 @@ export async function fetchBoardReactions(
   targetType: BoardReactionTargetType,
   targetId: string,
 ): Promise<BoardReactionSummary[]> {
-  return withRetries('fetchBoardReactions', async () => {
+  return timeBoardRequest('reaction_summary', () => withRetries('fetchBoardReactions', async () => {
     const params = new URLSearchParams({
       target_type: targetType,
       target_id: targetId,
@@ -636,11 +637,11 @@ export async function fetchBoardReactions(
     return Array.isArray(raw.reactions)
       ? raw.reactions.map(normalizeBoardReactionSummary).filter((row): row is BoardReactionSummary => row !== null)
       : []
-  })
+  }))
 }
 
 export async function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
-  return withRetries('fetchBoardPost', async () => {
+  return timeBoardRequest('detail', () => withRetries('fetchBoardPost', async () => {
     const params = new URLSearchParams({
       format: 'flat',
       voter: currentDashboardActor(),
@@ -670,7 +671,7 @@ export async function fetchBoardPost(postId: string): Promise<BoardPost & { comm
       .map(normalizeBoardComment)
       .filter((row): row is BoardComment => row !== null)
     return { ...post, comments }
-  })
+  }))
 }
 
 export function votePost(postId: string, direction: 'up' | 'down'): Promise<unknown> {
@@ -696,17 +697,19 @@ export async function toggleReaction(
   targetId: string,
   emoji: string,
 ): Promise<BoardReactionToggleResult> {
-  const raw = await post<unknown>('/api/v1/board/reactions', {
-    target_type: targetType,
-    target_id: targetId,
-    user_id: defaultBoardVoter(),
-    emoji,
+  return timeBoardRequest('reaction_toggle', async () => {
+    const raw = await post<unknown>('/api/v1/board/reactions', {
+      target_type: targetType,
+      target_id: targetId,
+      user_id: defaultBoardVoter(),
+      emoji,
+    })
+    const normalized = normalizeBoardReactionToggleResult(raw)
+    if (!normalized) {
+      throw new Error('Malformed board reaction response')
+    }
+    return normalized
   })
-  const normalized = normalizeBoardReactionToggleResult(raw)
-  if (!normalized) {
-    throw new Error('Malformed board reaction response')
-  }
-  return normalized
 }
 
 export function createPost(

--- a/dashboard/src/board-metrics.test.ts
+++ b/dashboard/src/board-metrics.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  boardLatencyMetrics,
+  recordBoardLatency,
+  resetBoardLatencyMetrics,
+  timeBoardRequest,
+} from './board-metrics'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetBoardLatencyMetrics()
+})
+
+describe('board latency metrics', () => {
+  it('records successful request latency by operation', () => {
+    vi.spyOn(performance, 'now').mockReturnValue(37.4)
+
+    recordBoardLatency('list', 10, true)
+
+    expect(boardLatencyMetrics.value.list).toMatchObject({
+      last_latency_ms: 27,
+      last_ok: true,
+      sample_count: 1,
+      failure_count: 0,
+      last_error: null,
+    })
+  })
+
+  it('records failures without erasing other operation buckets', async () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(145)
+
+    await expect(timeBoardRequest('reaction_toggle', async () => {
+      throw new Error('network down')
+    })).rejects.toThrow('network down')
+
+    expect(boardLatencyMetrics.value.reaction_toggle).toMatchObject({
+      last_latency_ms: 45,
+      last_ok: false,
+      sample_count: 1,
+      failure_count: 1,
+      last_error: 'network down',
+    })
+    expect(boardLatencyMetrics.value.list.sample_count).toBe(0)
+  })
+})

--- a/dashboard/src/board-metrics.ts
+++ b/dashboard/src/board-metrics.ts
@@ -1,0 +1,92 @@
+import { signal } from '@preact/signals'
+
+export type BoardLatencyOperation =
+  | 'list'
+  | 'list_more'
+  | 'detail'
+  | 'reaction_summary'
+  | 'reaction_toggle'
+
+export interface BoardLatencyMetric {
+  last_latency_ms: number | null
+  last_ok: boolean | null
+  sample_count: number
+  failure_count: number
+  last_error: string | null
+}
+
+export type BoardLatencyMetrics = Record<BoardLatencyOperation, BoardLatencyMetric>
+
+const OPERATIONS: BoardLatencyOperation[] = [
+  'list',
+  'list_more',
+  'detail',
+  'reaction_summary',
+  'reaction_toggle',
+]
+
+function emptyMetric(): BoardLatencyMetric {
+  return {
+    last_latency_ms: null,
+    last_ok: null,
+    sample_count: 0,
+    failure_count: 0,
+    last_error: null,
+  }
+}
+
+function emptyMetrics(): BoardLatencyMetrics {
+  return Object.fromEntries(OPERATIONS.map((op) => [op, emptyMetric()])) as BoardLatencyMetrics
+}
+
+export const boardLatencyMetrics = signal<BoardLatencyMetrics>(emptyMetrics())
+
+export function resetBoardLatencyMetrics(): void {
+  boardLatencyMetrics.value = emptyMetrics()
+}
+
+export function boardMetricNow(): number {
+  const now = globalThis.performance?.now?.()
+  return typeof now === 'number' && Number.isFinite(now) ? now : Date.now()
+}
+
+function errorMessage(error: unknown): string | null {
+  if (error instanceof Error) return error.message || error.name
+  if (typeof error === 'string') return error
+  return error == null ? null : String(error)
+}
+
+export function recordBoardLatency(
+  operation: BoardLatencyOperation,
+  startedAt: number,
+  ok: boolean,
+  error?: unknown,
+): void {
+  const elapsedMs = Math.max(0, Math.round(boardMetricNow() - startedAt))
+  const current = boardLatencyMetrics.value[operation] ?? emptyMetric()
+  boardLatencyMetrics.value = {
+    ...boardLatencyMetrics.value,
+    [operation]: {
+      last_latency_ms: elapsedMs,
+      last_ok: ok,
+      sample_count: current.sample_count + 1,
+      failure_count: current.failure_count + (ok ? 0 : 1),
+      last_error: ok ? null : errorMessage(error),
+    },
+  }
+}
+
+export async function timeBoardRequest<T>(
+  operation: BoardLatencyOperation,
+  request: () => Promise<T>,
+): Promise<T> {
+  const startedAt = boardMetricNow()
+  try {
+    const result = await request()
+    recordBoardLatency(operation, startedAt, true)
+    return result
+  } catch (err) {
+    recordBoardLatency(operation, startedAt, false, err)
+    throw err
+  }
+}

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -5,6 +5,7 @@ import { BoardSurface } from './board-surface'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore, messages, shellAuthSummary } from '../../store'
 import { route } from '../../router'
 import { PAGE_SIZE, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, newPostHearth, newPostSubmitting, showNewPostForm } from './board-state'
+import { boardLatencyMetrics, resetBoardLatencyMetrics } from '../../board-metrics'
 import type { BoardPost } from '../../types'
 
 import '@testing-library/jest-dom'
@@ -133,6 +134,7 @@ describe('BoardSurface Component', () => {
     await vi.dynamicImportSettled()
     await Promise.resolve()
     vi.unstubAllGlobals()
+    resetBoardLatencyMetrics()
   })
 
   beforeEach(() => {
@@ -159,6 +161,7 @@ describe('BoardSurface Component', () => {
     boardHearthFilter.value = ''
     boardHearths.value = [{ name: 'ops', count: 0 }]
     boardHearthsError.value = false
+    resetBoardLatencyMetrics()
     showNewPostForm.value = false
     newPostHearth.value = ''
     newPostSubmitting.value = false
@@ -262,6 +265,39 @@ describe('BoardSurface Component', () => {
 
     expect(screen.getByRole('heading', { name: 'State-block messages' })).toBeInTheDocument()
     expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
+  })
+
+  it('renders compact board latency metrics when samples exist', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-1',
+        title: 'Latency sample',
+        body: 'content',
+        author: 'keeper',
+      }),
+    ]
+    boardLatencyMetrics.value = {
+      ...boardLatencyMetrics.value,
+      list: {
+        last_latency_ms: 42,
+        last_ok: true,
+        sample_count: 1,
+        failure_count: 0,
+        last_error: null,
+      },
+      reaction_toggle: {
+        last_latency_ms: 17,
+        last_ok: false,
+        sample_count: 1,
+        failure_count: 1,
+        last_error: 'network down',
+      },
+    }
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByLabelText('목록 지연 42밀리초')).toHaveTextContent('목록 42ms')
+    expect(screen.getByLabelText('리액션 지연 17밀리초 실패')).toHaveTextContent('리액션 17ms 실패')
   })
 
   it('hides system posts by default', () => {

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -297,7 +297,12 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(screen.getByLabelText('목록 지연 42밀리초')).toHaveTextContent('목록 42ms')
-    expect(screen.getByLabelText('리액션 지연 17밀리초 실패')).toHaveTextContent('리액션 17ms 실패')
+    const failedChip = screen.getByLabelText('리액션 지연 17밀리초 실패')
+    expect(failedChip).toHaveTextContent('리액션 17ms 실패')
+    expect(failedChip.className).toContain('text-[var(--color-status-err)]')
+    expect(failedChip.className).toContain('border-[var(--bad-30)]')
+    expect(failedChip.className).not.toContain('color-status-bad')
+    expect(failedChip.className).not.toContain('bad-25')
   })
 
   it('hides system posts by default', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -509,7 +509,7 @@ function renderLatencyChip(label: string, metric: BoardLatencyMetric) {
     <span
       class=${`text-2xs tabular-nums px-1.5 py-0.5 rounded-[var(--r-0)] border ${
         failed
-          ? 'text-[var(--color-status-bad)] border-[var(--bad-25)] bg-[var(--bad-10)]'
+          ? 'text-[var(--color-status-err)] border-[var(--bad-30)] bg-[var(--bad-10)]'
           : 'text-[var(--color-fg-muted)] border-[var(--color-border-divider)] bg-[var(--color-bg-hover)]'
       }`}
       title=${failed && metric.last_error ? metric.last_error : `${label} latency`}

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -16,6 +16,7 @@ import { CursorPagination } from '../common/pagination'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate, navigateToPost, route } from '../../router'
 import { registerBoardHearthsRefresh } from '../../sse-store'
+import { boardLatencyMetrics, type BoardLatencyMetric } from '../../board-metrics'
 import { MessageRoomTimeline } from './message-room-timeline'
 import { MentionInbox } from './mention-inbox'
 import { PostDetail } from './post-detail'
@@ -501,9 +502,28 @@ function SortBar() {
 }
 
 // ── Board summary stats (compact inline) ─────────────────────────
+function renderLatencyChip(label: string, metric: BoardLatencyMetric) {
+  if (metric.last_latency_ms === null) return null
+  const failed = metric.last_ok === false
+  return html`
+    <span
+      class=${`text-2xs tabular-nums px-1.5 py-0.5 rounded-[var(--r-0)] border ${
+        failed
+          ? 'text-[var(--color-status-bad)] border-[var(--bad-25)] bg-[var(--bad-10)]'
+          : 'text-[var(--color-fg-muted)] border-[var(--color-border-divider)] bg-[var(--color-bg-hover)]'
+      }`}
+      title=${failed && metric.last_error ? metric.last_error : `${label} latency`}
+      aria-label=${failed ? `${label} 지연 ${metric.last_latency_ms}밀리초 실패` : `${label} 지연 ${metric.last_latency_ms}밀리초`}
+    >
+      ${label} ${metric.last_latency_ms}ms${failed ? ' 실패' : ''}
+    </span>
+  `
+}
+
 function BoardSummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
   const visibleCount = grouped.groups.reduce((sum, g) => sum + g.posts.length, 0)
+  const metrics = boardLatencyMetrics.value
   return html`
     <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-xs text-[var(--color-fg-muted)]">
       <span class="font-semibold text-[var(--color-fg-secondary)] tabular-nums text-md">${visibleCount}</span>
@@ -515,6 +535,8 @@ function BoardSummary() {
           <span>${meta?.icon ?? ''} ${g.posts.length}</span>
         `
       })}
+      ${renderLatencyChip('목록', metrics.list)}
+      ${renderLatencyChip('리액션', metrics.reaction_toggle)}
       ${lastBoardRefreshAt.value ? html`
         <span class="ml-auto text-2xs">갱신 <${TimeAgo} timestamp=${lastBoardRefreshAt.value} /></span>
       ` : null}

--- a/dashboard/src/store-board-metrics.test.ts
+++ b/dashboard/src/store-board-metrics.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchDashboardMemory: vi.fn(),
+}))
+
+const toastMocks = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}))
+
+vi.mock('./api/dashboard', () => ({
+  fetchDashboardMemory: apiMocks.fetchDashboardMemory,
+}))
+
+vi.mock('./api/dashboard-hot', () => ({
+  fetchDashboardShell: vi.fn(),
+}))
+
+vi.mock('./sse', () => ({
+  journal: {
+    log: vi.fn(),
+  },
+}))
+
+vi.mock('./components/common/toast', () => ({
+  showToast: toastMocks.showToast,
+}))
+
+import {
+  boardHasMore,
+  boardLoading,
+  boardLoadingMore,
+  boardOffset,
+  boardPosts,
+  boardSortMode,
+  loadMoreBoardPosts,
+  refreshBoard,
+} from './store'
+import { boardLatencyMetrics, resetBoardLatencyMetrics } from './board-metrics'
+
+beforeEach(() => {
+  resetBoardLatencyMetrics()
+  boardPosts.value = []
+  boardOffset.value = 0
+  boardHasMore.value = true
+  boardLoading.value = false
+  boardLoadingMore.value = false
+  boardSortMode.value = 'recent'
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetBoardLatencyMetrics()
+})
+
+describe('board list latency metrics', () => {
+  it('records refreshBoard list latency on success', async () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(42)
+    apiMocks.fetchDashboardMemory.mockResolvedValue({
+      posts: [],
+      has_more: false,
+      total: 0,
+      generated_at: '2026-05-06T00:00:00Z',
+    })
+
+    await refreshBoard()
+
+    expect(boardLatencyMetrics.value.list).toMatchObject({
+      last_latency_ms: 42,
+      last_ok: true,
+      sample_count: 1,
+      failure_count: 0,
+      last_error: null,
+    })
+  })
+
+  it('records load-more failures without throwing through the UI path', async () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(35)
+    boardHasMore.value = true
+    apiMocks.fetchDashboardMemory.mockRejectedValue(new Error('page timeout'))
+
+    await loadMoreBoardPosts()
+
+    expect(boardLatencyMetrics.value.list_more).toMatchObject({
+      last_latency_ms: 25,
+      last_ok: false,
+      sample_count: 1,
+      failure_count: 1,
+      last_error: 'page timeout',
+    })
+    expect(toastMocks.showToast).toHaveBeenCalledWith('다음 페이지를 불러오지 못했습니다', 'error')
+  })
+})

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -48,6 +48,7 @@ import { setArrayByKeyIfChanged } from './signal-utils'
 import { FetchScheduler } from './lib/fetch-scheduler'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
+import { boardMetricNow, recordBoardLatency } from './board-metrics'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
   normalizeExecutionQueueItem,
@@ -874,6 +875,9 @@ function boardPageSize(): number {
 }
 
 export async function refreshBoard(): Promise<void> {
+  const startedAt = boardMetricNow()
+  let ok = false
+  let failure: unknown = null
   boardLoading.value = true
   try {
     const { fetchDashboardMemory } = await import('./api/dashboard')
@@ -894,10 +898,13 @@ export async function refreshBoard(): Promise<void> {
       : next.length >= limit
     boardTotal.value = typeof data.total === 'number' ? data.total : null
     lastBoardRefreshAt.value = new Date().toISOString()
+    ok = true
   } catch (err) {
+    failure = err
     console.warn('[Board] fetch error:', err)
     showToast('게시판을 불러오지 못했습니다', 'error')
   } finally {
+    recordBoardLatency('list', startedAt, ok, failure)
     boardLoading.value = false
   }
 }
@@ -920,6 +927,9 @@ export function hydrateBoardSnapshot(data: DashboardMemoryResponse): void {
 export async function loadMoreBoardPosts(): Promise<void> {
   if (boardLoadingMore.value || boardLoading.value) return
   if (!boardHasMore.value) return
+  const startedAt = boardMetricNow()
+  let ok = false
+  let failure: unknown = null
   boardLoadingMore.value = true
   try {
     const { fetchDashboardMemory } = await import('./api/dashboard')
@@ -941,10 +951,13 @@ export async function loadMoreBoardPosts(): Promise<void> {
       ? data.has_more
       : incoming.length >= limit
     boardTotal.value = typeof data.total === 'number' ? data.total : null
+    ok = true
   } catch (err) {
+    failure = err
     console.warn('[Board] loadMore error:', err)
     showToast('다음 페이지를 불러오지 못했습니다', 'error')
   } finally {
+    recordBoardLatency('list_more', startedAt, ok, failure)
     boardLoadingMore.value = false
   }
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -48,7 +48,7 @@ import { setArrayByKeyIfChanged } from './signal-utils'
 import { FetchScheduler } from './lib/fetch-scheduler'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
-import { boardMetricNow, recordBoardLatency } from './board-metrics'
+import { timeBoardRequest } from './board-metrics'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
   normalizeExecutionQueueItem,
@@ -875,21 +875,18 @@ function boardPageSize(): number {
 }
 
 export async function refreshBoard(): Promise<void> {
-  const startedAt = boardMetricNow()
-  let ok = false
-  let failure: unknown = null
   boardLoading.value = true
   try {
     const { fetchDashboardMemory } = await import('./api/dashboard')
     const limit = boardPageSize()
-    const data = await fetchDashboardMemory(boardSortMode.value, {
+    const data = await timeBoardRequest('list', () => fetchDashboardMemory(boardSortMode.value, {
       excludeSystem: boardExcludeSystem.value,
       excludeAutomation: boardExcludeAutomation.value,
       author: boardAuthorFilter.value || undefined,
       hearth: boardHearthFilter.value || undefined,
       limit,
       offset: 0,
-    })
+    }))
     const next = data.posts ?? []
     boardPosts.value = reconcileBoardPosts(boardPosts.value, next)
     boardOffset.value = next.length
@@ -898,13 +895,10 @@ export async function refreshBoard(): Promise<void> {
       : next.length >= limit
     boardTotal.value = typeof data.total === 'number' ? data.total : null
     lastBoardRefreshAt.value = new Date().toISOString()
-    ok = true
   } catch (err) {
-    failure = err
     console.warn('[Board] fetch error:', err)
     showToast('게시판을 불러오지 못했습니다', 'error')
   } finally {
-    recordBoardLatency('list', startedAt, ok, failure)
     boardLoading.value = false
   }
 }
@@ -927,22 +921,19 @@ export function hydrateBoardSnapshot(data: DashboardMemoryResponse): void {
 export async function loadMoreBoardPosts(): Promise<void> {
   if (boardLoadingMore.value || boardLoading.value) return
   if (!boardHasMore.value) return
-  const startedAt = boardMetricNow()
-  let ok = false
-  let failure: unknown = null
   boardLoadingMore.value = true
   try {
     const { fetchDashboardMemory } = await import('./api/dashboard')
     const limit = boardPageSize()
     const offset = boardOffset.value
-    const data = await fetchDashboardMemory(boardSortMode.value, {
+    const data = await timeBoardRequest('list_more', () => fetchDashboardMemory(boardSortMode.value, {
       excludeSystem: boardExcludeSystem.value,
       excludeAutomation: boardExcludeAutomation.value,
       author: boardAuthorFilter.value || undefined,
       hearth: boardHearthFilter.value || undefined,
       limit,
       offset,
-    })
+    }))
     const incoming = data.posts ?? []
     const merged = appendBoardPosts(boardPosts.value, incoming)
     boardPosts.value = merged
@@ -951,13 +942,10 @@ export async function loadMoreBoardPosts(): Promise<void> {
       ? data.has_more
       : incoming.length >= limit
     boardTotal.value = typeof data.total === 'number' ? data.total : null
-    ok = true
   } catch (err) {
-    failure = err
     console.warn('[Board] loadMore error:', err)
     showToast('다음 페이지를 불러오지 못했습니다', 'error')
   } finally {
-    recordBoardLatency('list_more', startedAt, ok, failure)
     boardLoadingMore.value = false
   }
 }


### PR DESCRIPTION
## Summary
- Add board latency metrics for list, detail, reaction summary, and reaction toggle operations.
- Record dashboard board refresh/load-more latency, including failure samples.
- Surface compact list/reaction latency chips in the board summary.

## Validation
- pnpm --dir dashboard exec vitest run src/board-metrics.test.ts src/store-board-metrics.test.ts src/api/board.test.ts src/components/board/board-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- git diff --check

## Why
This advances the SNS Phase 1B operate slice for reaction/list latency metrics without changing server contracts or board persistence.