### PR TITLE
fix(board): exclude self votes from karma

### DIFF
--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -269,8 +269,11 @@ val karma_score_for_direction : vote_direction -> int
 (* Up → +1,  Down → 0 *)
 ```
 
-Downvotes do **not** subtract karma.  All replay and rebuild operations
-must call `karma_score_for_direction` — never inline the rule.
+Downvotes do **not** subtract karma. Self-upvotes can affect the visible
+content score, but they do **not** emit karma events and do **not** mint
+`Earn_upvote` economy credit; karma is peer recognition only. All replay
+and rebuild operations must call `karma_score_for_direction` — never
+inline the rule.
 
 ### 9a.2 Karma Event Type
 
@@ -289,15 +292,16 @@ type karma_event = {
 
 ```ocaml
 val build_karma_ledger : store -> karma_event list
-(* Reads vote_log; returns Up-only events sorted by ts ascending. *)
+(* Reads vote_log; returns peer Up-only events sorted by ts ascending. *)
 
 val totals_of_karma_ledger : karma_event list -> (string * int) list
 (* Aggregates (recipient, total) pairs sorted descending by total. *)
 ```
 
 **Invariant:** `totals_of_karma_ledger (build_karma_ledger store)` must
-equal `get_all_karma store` for every recipient in the store (modulo
-quarantined fixture votes).
+equal `get_all_karma store` for every recipient in the store. Deleted
+targets, quarantined fixture votes, and self-upvotes are excluded by the
+ledger projection before totals are computed.
 
 ### 9a.4 HTTP API
 

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -107,9 +107,9 @@ let rewrite_vote_log store =
 
 (* [vote_outcome] carries the information needed to run the post-lock
    [Agent_economy.earn] call.  [earn_upvote_for] is [Some author] only
-   on the fresh-upvote path — a vote flip does not earn credits
-   (prevents down/up alternation abuse), and a downvote does not earn
-   at all. *)
+   on the fresh peer-upvote path — a self-upvote is not reputation, a
+   vote flip does not earn credits (prevents down/up alternation abuse),
+   and a downvote does not earn at all. *)
 type vote_outcome = {
   delta : int;
   earn_upvote_for : string option;
@@ -200,7 +200,9 @@ let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
                   invalidate_post_caches store;
                   let author_name = Agent_id.to_string post.author in
                   let earn =
-                    if (=) direction Up then Some author_name else None
+                    if (=) direction Up && not (String.equal voter author_name)
+                    then Some author_name
+                    else None
                   in
                   Ok { delta = updated.votes_up - updated.votes_down;
                        earn_upvote_for = earn;
@@ -902,6 +904,10 @@ let build_karma_ledger store =
                in
                (match recipient_opt with
                 | None -> acc
+                | Some recipient when String.equal recipient voter ->
+                    (* Content score still records the vote, but karma is
+                       peer recognition; self-upvotes do not mint reputation. *)
+                    acc
                 | Some recipient ->
                     { recipient; voter; target_kind = kind;
                       target_id; delta; ts } :: acc))
@@ -951,42 +957,20 @@ let karma_event_to_yojson (e : karma_event) : Yojson.Safe.t =
     ("ts_iso",      `String ts_iso);
   ]
 
-(** Calculate karma (total upvotes) for an agent *)
-let get_agent_karma store ~agent_name =
-  let all_posts = list_posts store () in
-  let post_karma =
-    List.fold_left (fun acc (p : post) ->
-      if String.equal (Agent_id.to_string p.author) agent_name then acc + p.votes_up
-      else acc
-    ) 0 all_posts
-  in
-  let comment_karma =
-    Hashtbl.fold (fun _ (c : comment) acc ->
-      if String.equal (Agent_id.to_string c.author) agent_name then acc + c.votes_up
-      else acc
-    ) store.comments 0
-  in
-  post_karma + comment_karma
-
 (** Get karma for all agents (cached) *)
 let get_all_karma store =
   match store.karma_cache with
   | Some cached -> cached
   | None ->
-      let karma_map = Hashtbl.create 64 in
-      Hashtbl.iter (fun _ (p : post) ->
-        let author = Agent_id.to_string p.author in
-        let current = Hashtbl.find_opt karma_map author |> Option.value ~default:0 in
-        Hashtbl.replace karma_map author (current + p.votes_up)
-      ) store.posts;
-      Hashtbl.iter (fun _ (c : comment) ->
-        let author = Agent_id.to_string c.author in
-        let current = Hashtbl.find_opt karma_map author |> Option.value ~default:0 in
-        Hashtbl.replace karma_map author (current + c.votes_up)
-      ) store.comments;
-      let result = Hashtbl.fold (fun k v acc -> (k, v) :: acc) karma_map [] in
+      let result = build_karma_ledger store |> totals_of_karma_ledger in
       store.karma_cache <- Some result;
       result
+
+(** Calculate karma (total peer upvotes) for an agent *)
+let get_agent_karma store ~agent_name =
+  get_all_karma store
+  |> List.assoc_opt agent_name
+  |> Option.value ~default:0
 
 (** Available flairs *)
 let available_flairs = [

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -152,7 +152,8 @@ let current_vote_for_post store ~voter ~post_id
 let vote store ~voter ~post_id ~direction : (int, board_error) Result.t =
   match Agent_id.of_string voter with
   | Error e -> Error e
-  | Ok _ ->
+  | Ok agent ->
+  let voter = Agent_id.to_string agent in
   match Post_id.of_string post_id with
   | Error e -> Error e
   | Ok pid ->
@@ -254,7 +255,8 @@ let current_vote_for_comment store ~voter ~comment_id
 let vote_comment store ~voter ~comment_id ~direction : (int, board_error) Result.t =
   match Agent_id.of_string voter with
   | Error e -> Error e
-  | Ok _ ->
+  | Ok agent ->
+  let voter = Agent_id.to_string agent in
   match Comment_id.of_string comment_id with
   | Error e -> Error e
   | Ok cid ->
@@ -867,6 +869,40 @@ let parse_vote_key key =
           if kind = "" || target_id = "" || voter = "" then None
           else Some (kind, target_id, voter))
 
+let canonical_vote_voter voter =
+  match Agent_id.of_string voter with
+  | Ok agent -> Agent_id.to_string agent
+  | Error _ -> String.trim voter
+
+let karma_event_of_vote store key (direction, ts) =
+  let delta = karma_score_for_direction direction in
+  if delta = 0 then None
+  else
+    match parse_vote_key key with
+    | None -> None
+    | Some (kind, target_id, voter_raw) ->
+        let recipient_opt =
+          match kind with
+          | "post" ->
+              (match Hashtbl.find_opt store.posts target_id with
+               | Some (p : post) -> Some (Agent_id.to_string p.author)
+               | None -> None)
+          | "comment" ->
+              (match Hashtbl.find_opt store.comments target_id with
+               | Some (c : comment) -> Some (Agent_id.to_string c.author)
+               | None -> None)
+          | _ -> None
+        in
+        let voter = canonical_vote_voter voter_raw in
+        match recipient_opt with
+        | None -> None
+        | Some recipient when String.equal recipient voter ->
+            (* Content score still records the vote, but karma is
+               peer recognition; self-upvotes do not mint reputation. *)
+            None
+        | Some recipient ->
+            Some { recipient; voter; target_kind = kind; target_id; delta; ts }
+
 (** Rebuild the karma ledger from the in-memory vote log and
     post/comment author tables.
 
@@ -884,33 +920,9 @@ let build_karma_ledger store =
   with_lock store (fun () ->
     Hashtbl.fold
       (fun key (direction, ts) acc ->
-         let delta = karma_score_for_direction direction in
-         if delta = 0 then acc
-         else
-           match parse_vote_key key with
-           | None -> acc
-           | Some (kind, target_id, voter) ->
-               let recipient_opt =
-                 match kind with
-                 | "post" ->
-                     (match Hashtbl.find_opt store.posts target_id with
-                      | Some (p : post) -> Some (Agent_id.to_string p.author)
-                      | None -> None)
-                 | "comment" ->
-                     (match Hashtbl.find_opt store.comments target_id with
-                      | Some (c : comment) -> Some (Agent_id.to_string c.author)
-                      | None -> None)
-                 | _ -> None
-               in
-               (match recipient_opt with
-                | None -> acc
-                | Some recipient when String.equal recipient voter ->
-                    (* Content score still records the vote, but karma is
-                       peer recognition; self-upvotes do not mint reputation. *)
-                    acc
-                | Some recipient ->
-                    { recipient; voter; target_kind = kind;
-                      target_id; delta; ts } :: acc))
+         match karma_event_of_vote store key (direction, ts) with
+         | None -> acc
+         | Some event -> event :: acc)
       store.vote_log [])
   |> List.sort (fun a b -> Float.compare a.ts b.ts)
 
@@ -962,7 +974,23 @@ let get_all_karma store =
   match store.karma_cache with
   | Some cached -> cached
   | None ->
-      let result = build_karma_ledger store |> totals_of_karma_ledger in
+      let result =
+        with_lock store (fun () ->
+          let tbl = Hashtbl.create 64 in
+          Hashtbl.iter
+            (fun key vote ->
+               match karma_event_of_vote store key vote with
+               | None -> ()
+               | Some (e : karma_event) ->
+                   let prev =
+                     Hashtbl.find_opt tbl e.recipient
+                     |> Option.value ~default:0
+                   in
+                   Hashtbl.replace tbl e.recipient (prev + e.delta))
+            store.vote_log;
+          Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl [])
+        |> List.sort (fun (_, a) (_, b) -> Int.compare b a)
+      in
       store.karma_cache <- Some result;
       result
 

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -22,7 +22,7 @@
     - {b Vote log persistence}: [append_vote_log],
       [rewrite_vote_log].
     - {b Internal vote outcome}: the [vote_outcome] record
-      carries the score delta, optional fresh-upvote economy
+      carries the score delta, optional fresh peer-upvote economy
       credit, and post-lock vote log / feedback side effects.
     - {b Persistence loaders}: [load_persisted_posts],
       [load_persisted_comments], [load_persisted_votes],
@@ -94,7 +94,7 @@ val vote :
 
     Vote flips swap up↔down without re-counting (and
     {b without} earning credits, to prevent down/up
-    alternation abuse).  Fresh upvotes earn the post
+    alternation abuse).  Fresh peer upvotes earn the post
     author a credit via [Agent_economy.earn] {b outside}
     the lock so the ledger write does not block other
     readers.  Every vote is broadcast to
@@ -201,7 +201,8 @@ val karma_score_for_direction : vote_direction -> int
 val build_karma_ledger : store -> karma_event list
 (** Rebuild the full karma ledger from the in-memory vote log and
     author tables.  One {!karma_event} is emitted per [Up] vote
-    whose target post/comment still exists in the store.
+    whose target post/comment still exists in the store and whose
+    voter differs from the content author.
 
     The function:
     - Holds the store lock for the duration of the snapshot.
@@ -209,10 +210,11 @@ val build_karma_ledger : store -> karma_event list
       callers can replay them in chronological order.
     - Silently drops votes whose target has since been deleted
       (content gone, vote orphan — not an error).
+    - Excludes self-upvotes from karma. The board score can still
+      record a self-vote, but reputation is peer recognition only.
 
     Replay contract: [totals_of_karma_ledger (build_karma_ledger s)]
-    must equal the output of [get_all_karma s] when no votes have
-    been quarantined or dropped. *)
+    must equal the output of [get_all_karma s]. *)
 
 val totals_of_karma_ledger : karma_event list -> (string * int) list
 (** Aggregate [(recipient, total_karma)] pairs from a ledger.
@@ -225,13 +227,14 @@ val karma_event_to_yojson : karma_event -> Yojson.Safe.t
     [ts_iso] is RFC-3339 UTC (["YYYY-MM-DDTHH:MM:SSZ"]). *)
 
 val get_agent_karma : store -> agent_name:string -> int
-(** Sums [votes_up] across every post + comment authored
-    by [agent_name].  Lock-free read of the in-memory
-    [posts] / [comments] tables. *)
+(** Returns the karma projection for [agent_name] from the same
+    ledger-backed totals used by {!get_all_karma}.  Self-upvotes are
+    excluded. *)
 
 val get_all_karma : store -> (string * int) list
-(** Returns [(agent_name, total_upvotes)] for every author
-    in the store.  Memoised in [store.karma_cache] —
+(** Returns [(agent_name, total_peer_upvotes)] for every author in
+    the store by replaying the karma ledger.  Memoised in
+    [store.karma_cache] —
     {!invalidate_post_caches} and
     {!invalidate_comment_caches} clear the entry on every
     relevant mutation. *)

--- a/test/test_board_karma_ledger.ml
+++ b/test/test_board_karma_ledger.ml
@@ -104,7 +104,7 @@ let test_downvote_no_event () =
 let test_self_post_upvote_no_karma () =
   let post = create_post_exn ~author:"alice" ~content:"self vote" in
   let pid = Board.Post_id.to_string post.id in
-  vote_exn ~voter:"alice" ~post_id:pid ~direction:Board.Up;
+  vote_exn ~voter:" alice " ~post_id:pid ~direction:Board.Up;
   let events = Board_dispatch.get_karma_ledger () in
   Alcotest.(check int) "self post upvote → no karma event" 0 (List.length events);
   Alcotest.(check int) "self post upvote excluded from agent karma" 0
@@ -125,7 +125,7 @@ let test_self_post_upvote_no_economy_credit () =
     let before =
       Agent_economy.get_balance ~base_path ~agent_name:"alice"
     in
-    vote_exn ~voter:"alice" ~post_id:pid ~direction:Board.Up;
+    vote_exn ~voter:" alice " ~post_id:pid ~direction:Board.Up;
     let after_self_vote =
       Agent_economy.get_balance ~base_path ~agent_name:"alice"
     in
@@ -168,7 +168,7 @@ let test_self_comment_upvote_no_karma () =
     | Error e -> Alcotest.fail (Board.show_board_error e)
   in
   let cid = Board.Comment_id.to_string comment.id in
-  vote_comment_exn ~voter:"charlie" ~comment_id:cid ~direction:Board.Up;
+  vote_comment_exn ~voter:" charlie " ~comment_id:cid ~direction:Board.Up;
   let events = Board_dispatch.get_karma_ledger () in
   Alcotest.(check int) "self comment upvote → no karma event" 0 (List.length events);
   Alcotest.(check int) "self comment upvote excluded from agent karma" 0

--- a/test/test_board_karma_ledger.ml
+++ b/test/test_board_karma_ledger.ml
@@ -19,6 +19,16 @@ let fresh_test_base_path () =
   Unix.putenv "MASC_BASE_PATH" dir;
   dir
 
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
 (** Run [f] inside an Eio runtime with an isolated JSONL board *)
 let with_eio f () =
   Eio_main.run @@ fun env ->
@@ -89,6 +99,39 @@ let test_downvote_no_event () =
   let events = Board_dispatch.get_karma_ledger () in
   Alcotest.(check int) "downvote → no karma event" 0 (List.length events)
 
+(** {1 Self-upvotes do NOT produce karma} *)
+
+let test_self_post_upvote_no_karma () =
+  let post = create_post_exn ~author:"alice" ~content:"self vote" in
+  let pid = Board.Post_id.to_string post.id in
+  vote_exn ~voter:"alice" ~post_id:pid ~direction:Board.Up;
+  let events = Board_dispatch.get_karma_ledger () in
+  Alcotest.(check int) "self post upvote → no karma event" 0 (List.length events);
+  Alcotest.(check int) "self post upvote excluded from agent karma" 0
+    (Board_dispatch.get_agent_karma ~agent_name:"alice");
+  Alcotest.(check (list (pair string int))) "self post upvote excluded from all karma"
+    [] (Board_dispatch.get_all_karma ());
+  match Board_dispatch.get_post ~post_id:pid with
+  | Ok updated ->
+      Alcotest.(check int) "self vote still affects board score" 1 updated.votes_up
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+
+let test_self_post_upvote_no_economy_credit () =
+  with_env "MASC_ECONOMY_ENABLED" "true" (fun () ->
+    Agent_economy.reset_cache ();
+    let base_path = Sys.getenv "MASC_BASE_PATH" in
+    let post = create_post_exn ~author:"alice" ~content:"economy self vote" in
+    let pid = Board.Post_id.to_string post.id in
+    let before =
+      Agent_economy.get_balance ~base_path ~agent_name:"alice"
+    in
+    vote_exn ~voter:"alice" ~post_id:pid ~direction:Board.Up;
+    let after_self_vote =
+      Agent_economy.get_balance ~base_path ~agent_name:"alice"
+    in
+    Alcotest.(check (float 0.0001)) "self upvote does not earn economy credit"
+      before after_self_vote)
+
 (** {1 Comment upvote produces an event} *)
 
 let test_comment_upvote_produces_event () =
@@ -110,6 +153,26 @@ let test_comment_upvote_produces_event () =
   Alcotest.(check string) "recipient is comment author" "charlie" ev.recipient;
   Alcotest.(check string) "target_kind is comment" "comment" ev.target_kind;
   Alcotest.(check string) "target_id matches comment" cid ev.target_id
+
+(** {1 Comment self-upvotes do NOT produce karma} *)
+
+let test_self_comment_upvote_no_karma () =
+  let post = create_post_exn ~author:"alice" ~content:"parent post" in
+  let pid = Board.Post_id.to_string post.id in
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id:pid ~author:"charlie"
+        ~content:"self-voted comment" ()
+    with
+    | Ok c -> c
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let cid = Board.Comment_id.to_string comment.id in
+  vote_comment_exn ~voter:"charlie" ~comment_id:cid ~direction:Board.Up;
+  let events = Board_dispatch.get_karma_ledger () in
+  Alcotest.(check int) "self comment upvote → no karma event" 0 (List.length events);
+  Alcotest.(check int) "self comment upvote excluded from agent karma" 0
+    (Board_dispatch.get_agent_karma ~agent_name:"charlie")
 
 (** {1 Multiple voters each produce distinct events} *)
 
@@ -240,8 +303,14 @@ let () =
         (with_eio test_upvote_produces_one_event);
       Alcotest.test_case "downvote no event" `Quick
         (with_eio test_downvote_no_event);
+      Alcotest.test_case "self post upvote no karma" `Quick
+        (with_eio test_self_post_upvote_no_karma);
+      Alcotest.test_case "self post upvote no economy credit" `Quick
+        (with_eio test_self_post_upvote_no_economy_credit);
       Alcotest.test_case "comment upvote event" `Quick
         (with_eio test_comment_upvote_produces_event);
+      Alcotest.test_case "self comment upvote no karma" `Quick
+        (with_eio test_self_comment_upvote_no_karma);
       Alcotest.test_case "multiple voters" `Quick
         (with_eio test_multiple_voters);
       Alcotest.test_case "events sorted oldest first" `Quick


### PR DESCRIPTION
## Summary
- exclude self-upvotes from rebuilt karma ledger events and cached karma totals
- keep visible board score behavior unchanged, but block self-upvotes from minting Earn_upvote economy credit
- document the peer-recognition rule in the Board spec

## Verification
- scripts/opam-pin-external-deps.sh --install
- scripts/dune-local.sh build test/test_board_karma_ledger.exe
- ./_build/default/test/test_board_karma_ledger.exe
- git diff --check
