### PR TITLE
fix(board): rate limit moderation flags

### DIFF
--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -421,6 +421,14 @@ slug 중복 생성 시 `Already_exists` 에러.
 - API 함수: `fetchSubBoards()`, `fetchSubBoard(id)`, `createSubBoard(slug, name, description, access?, members?)` in `dashboard/src/api/board.ts`
 - 네비게이션: workspace 섹션에 `sub-boards` 항목 추가 (`dashboard/src/config/navigation.ts`)
 
+### 11.6 Moderation Safety
+
+`Board_moderation.flag` enforces a per-reporter burst guard before adding
+new moderation queue rows. `MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC`
+defaults to `1.0`; set it to `0` to disable the guard for fixtures or bulk
+imports. Duplicate unresolved flags for the same target are still rejected
+independently of the rate-limit window.
+
 ---
 
 ## 11a. AI Curation Snapshot
@@ -459,6 +467,7 @@ AI curation은 board post/comment/vote mutation과 분리된 projection 계약�
 6. **댓글 삭제 cascade:** JSONL에서는 delete_post 시 comments/votes를 수동 정리한다.
 7. **JSONL rotation:** 10MB 초과 시 자동 rotation. 2세대 백업 유지.
 8. **Write path consistency:** 투표 연산(조회 + INSERT/UPDATE + 카운터 변경)은 Board store lock 안에서 일관되게 처리한다.
+9. **Moderation burst guard:** 동일 reporter의 연속 flag는 `MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC` 창 안에서 거부된다.
 
 ---
 

--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -99,6 +99,11 @@ let max_note_length = 500
 
 let global_store : store option ref = ref None
 
+let flag_rate_limit_sec () =
+  Env_config_core.get_float ~default:1.0
+    "MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC"
+  |> Float.max 0.0
+
 let make_store () : store =
   { queue = Hashtbl.create 64; audit = ref [] }
 
@@ -122,6 +127,7 @@ let reset_for_test () : unit =
 
 let flag ~target_kind ~target_id ~reporter ~reason =
   let s = store () in
+  let now = Time_compat.now () in
   (* Reject duplicate unresolved flags for the same target *)
   let duplicate =
     Hashtbl.fold
@@ -132,20 +138,39 @@ let flag ~target_kind ~target_id ~reporter ~reason =
   in
   if duplicate then
     Error (Printf.sprintf "target %s is already flagged and pending review" target_id)
-  else begin
-    let entry_id = Random_id.prefixed ~prefix:"mq-" ~bytes:16 in
-    let entry = {
-      entry_id;
-      target_kind;
-      target_id;
-      reporter;
-      reason;
-      flagged_at = Time_compat.now ();
-      resolved   = false;
-    } in
-    Hashtbl.replace s.queue entry_id entry;
-    Ok entry
-  end
+  else
+    let window_sec = flag_rate_limit_sec () in
+    let retry_after =
+      if Float.compare window_sec 0.0 <= 0 then None
+      else
+        Hashtbl.fold
+          (fun _k (e : queue_entry) acc ->
+             if not (String.equal e.reporter reporter) then acc
+             else
+               let remaining = window_sec -. (now -. e.flagged_at) in
+               if Float.compare remaining 0.0 <= 0 then acc
+               else Some (Float.max remaining (Option.value acc ~default:0.0)))
+          s.queue None
+    in
+    match retry_after with
+    | Some remaining ->
+        Error
+          (Printf.sprintf
+             "reporter %s is rate limited; retry after %.3fs"
+             reporter remaining)
+    | None ->
+        let entry_id = Random_id.prefixed ~prefix:"mq-" ~bytes:16 in
+        let entry = {
+          entry_id;
+          target_kind;
+          target_id;
+          reporter;
+          reason;
+          flagged_at = now;
+          resolved   = false;
+        } in
+        Hashtbl.replace s.queue entry_id entry;
+        Ok entry
 
 let get_queue ?resolved () =
   let s = store () in

--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -99,10 +99,16 @@ let max_note_length = 500
 
 let global_store : store option ref = ref None
 
+let default_flag_rate_limit_sec = 1.0
+
+let sanitize_flag_rate_limit_sec value =
+  if Float.is_finite value then Float.max 0.0 value
+  else default_flag_rate_limit_sec
+
 let flag_rate_limit_sec () =
-  Env_config_core.get_float ~default:1.0
+  Env_config_core.get_float ~default:default_flag_rate_limit_sec
     "MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC"
-  |> Float.max 0.0
+  |> sanitize_flag_rate_limit_sec
 
 let make_store () : store =
   { queue = Hashtbl.create 64; audit = ref [] }

--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -91,8 +91,10 @@ type audit_entry = {
 (** {1 In-memory store} *)
 
 type store = {
-  queue  : (string, queue_entry) Hashtbl.t;  (* entry_id → entry *)
-  audit  : audit_entry list ref;
+  queue : (string, queue_entry) Hashtbl.t;  (* entry_id -> entry *)
+  audit : audit_entry list ref;
+  unresolved_by_target : (target_kind * string, string) Hashtbl.t;
+  last_flag_by_reporter : (string, float) Hashtbl.t;
 }
 
 let max_note_length = 500
@@ -111,7 +113,32 @@ let flag_rate_limit_sec () =
   |> sanitize_flag_rate_limit_sec
 
 let make_store () : store =
-  { queue = Hashtbl.create 64; audit = ref [] }
+  {
+    queue = Hashtbl.create 64;
+    audit = ref [];
+    unresolved_by_target = Hashtbl.create 64;
+    last_flag_by_reporter = Hashtbl.create 64;
+  }
+
+let target_key target_kind target_id = (target_kind, target_id)
+
+let retry_after_for_reporter s ~reporter ~now ~window_sec =
+  if Float.compare window_sec 0.0 <= 0 then None
+  else
+    match Hashtbl.find_opt s.last_flag_by_reporter reporter with
+    | None -> None
+    | Some flagged_at ->
+        let flagged_at =
+          if Float.compare now flagged_at < 0 then (
+            Hashtbl.replace s.last_flag_by_reporter reporter now;
+            now)
+          else
+            flagged_at
+        in
+        let elapsed = Float.max 0.0 (now -. flagged_at) in
+        let remaining = window_sec -. elapsed in
+        if Float.compare remaining 0.0 <= 0 then None
+        else Some remaining
 
 let store () : store =
   match !global_store with
@@ -134,30 +161,12 @@ let reset_for_test () : unit =
 let flag ~target_kind ~target_id ~reporter ~reason =
   let s = store () in
   let now = Time_compat.now () in
-  (* Reject duplicate unresolved flags for the same target *)
-  let duplicate =
-    Hashtbl.fold
-      (fun _k (e : queue_entry) acc ->
-         acc ||
-         (e.target_id = target_id && e.target_kind = target_kind && not e.resolved))
-      s.queue false
-  in
-  if duplicate then
+  let target_key = target_key target_kind target_id in
+  if Hashtbl.mem s.unresolved_by_target target_key then
     Error (Printf.sprintf "target %s is already flagged and pending review" target_id)
   else
     let window_sec = flag_rate_limit_sec () in
-    let retry_after =
-      if Float.compare window_sec 0.0 <= 0 then None
-      else
-        Hashtbl.fold
-          (fun _k (e : queue_entry) acc ->
-             if not (String.equal e.reporter reporter) then acc
-             else
-               let remaining = window_sec -. (now -. e.flagged_at) in
-               if Float.compare remaining 0.0 <= 0 then acc
-               else Some (Float.max remaining (Option.value acc ~default:0.0)))
-          s.queue None
-    in
+    let retry_after = retry_after_for_reporter s ~reporter ~now ~window_sec in
     match retry_after with
     | Some remaining ->
         Error
@@ -176,6 +185,8 @@ let flag ~target_kind ~target_id ~reporter ~reason =
           resolved   = false;
         } in
         Hashtbl.replace s.queue entry_id entry;
+        Hashtbl.replace s.unresolved_by_target target_key entry_id;
+        Hashtbl.replace s.last_flag_by_reporter reporter now;
         Ok entry
 
 let get_queue ?resolved () =
@@ -195,6 +206,8 @@ let resolve_entry ~entry_id =
   match Hashtbl.find_opt s.queue entry_id with
   | None -> Error (Printf.sprintf "moderation queue entry not found: %s" entry_id)
   | Some e ->
+      if not e.resolved then
+        Hashtbl.remove s.unresolved_by_target (target_key e.target_kind e.target_id);
       Hashtbl.replace s.queue entry_id { e with resolved = true };
       Ok ()
 
@@ -222,12 +235,15 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
     note = note_trimmed;
     acted_at = Time_compat.now ();
   } in
-  (* Resolve any open queue entry for this target *)
-  Hashtbl.iter
-    (fun _k (qe : queue_entry) ->
-       if qe.target_id = target_id && qe.target_kind = target_kind && not qe.resolved then
-         Hashtbl.replace s.queue qe.entry_id { qe with resolved = true })
-    s.queue;
+  let target_key = target_key target_kind target_id in
+  (match Hashtbl.find_opt s.unresolved_by_target target_key with
+   | None -> ()
+   | Some entry_id ->
+       Hashtbl.remove s.unresolved_by_target target_key;
+       (match Hashtbl.find_opt s.queue entry_id with
+        | Some qe when not qe.resolved ->
+            Hashtbl.replace s.queue entry_id { qe with resolved = true }
+        | _ -> ()));
   s.audit := entry :: !(s.audit);
   Ok entry
 

--- a/lib/board_moderation.mli
+++ b/lib/board_moderation.mli
@@ -113,7 +113,10 @@ val flag :
   reason:flag_reason ->
   (queue_entry, string) result
 (** Flag [target_id] for operator review.  Returns an error if the same
-    [target_id] was already flagged and is still unresolved. *)
+    [target_id] was already flagged and is still unresolved, or if the
+    same [reporter] flags again inside
+    [MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC] (default 1s, set to 0 to
+    disable). *)
 
 val get_queue : ?resolved:bool -> unit -> queue_entry list
 (** Return queue entries sorted by [flagged_at] descending.

--- a/test/test_board_moderation.ml
+++ b/test/test_board_moderation.ml
@@ -14,6 +14,8 @@ open Alcotest
 open Masc_mcp
 module BM = Board_moderation
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 (* Initialise Mirage crypto RNG — required for Random_id.prefixed *)
 let () = Mirage_crypto_rng_unix.use_default ()
 
@@ -28,11 +30,20 @@ let with_env key value f =
     ~finally:(fun () ->
       match prev with
       | Some v -> Unix.putenv key v
-      | None -> Unix.putenv key "")
+      | None -> unsetenv key)
     f
 
 let with_flag_rate_limit value f =
   with_env "MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC" value f
+
+let test_with_env_restores_unset () =
+  let key = "MASC_BOARD_MODERATION_TEST_UNSET" in
+  unsetenv key;
+  check (option string) "starts unset" None (Sys.getenv_opt key);
+  with_env key "set-for-test" (fun () ->
+    check (option string) "set inside scope" (Some "set-for-test")
+      (Sys.getenv_opt key));
+  check (option string) "restored unset" None (Sys.getenv_opt key)
 
 (* ── flag_reason roundtrips ───────────────────────────────────────── *)
 
@@ -186,6 +197,26 @@ let test_flag_rate_limit_non_finite_falls_back () =
   check_non_finite "nan" "rl-nan-1" "rl-nan-2";
   check_non_finite "+inf" "rl-inf-1" "rl-inf-2"
 
+let test_flag_rate_limit_survives_resolved_entries () =
+  reset ();
+  with_flag_rate_limit "60" (fun () ->
+    let first_entry =
+      match BM.flag ~target_kind:BM.Target_post ~target_id:"rl-resolved-1"
+              ~reporter:"agent-resolved" ~reason:BM.Spam with
+      | Ok entry -> entry
+      | Error m -> fail ("first flag failed: " ^ m)
+    in
+    (match BM.resolve_entry ~entry_id:first_entry.BM.entry_id with
+     | Ok () -> ()
+     | Error m -> fail ("resolve failed: " ^ m));
+    match BM.flag ~target_kind:BM.Target_comment ~target_id:"rl-resolved-2"
+            ~reporter:"agent-resolved" ~reason:BM.Off_topic with
+    | Error m ->
+        check bool "resolved entry still rate-limits reporter" true
+          (String.starts_with
+             ~prefix:"reporter agent-resolved is rate limited" m)
+    | Ok _ -> fail "resolved entries should still enforce reporter burst window")
+
 (* ── get_queue filtering ─────────────────────────────────────────── *)
 
 let test_get_queue_unresolved () =
@@ -265,6 +296,22 @@ let test_record_action_auto_resolves_queue () =
               (List.length (BM.get_queue ~resolved:false ()))));
   (* resolved entry should exist *)
   check int "one resolved" 1 (List.length (BM.get_queue ~resolved:true ()))
+
+let test_record_action_allows_target_to_be_reflagged () =
+  reset ();
+  with_flag_rate_limit "0" (fun () ->
+    (match BM.flag ~target_kind:BM.Target_post ~target_id:"p13"
+             ~reporter:"r1" ~reason:BM.Spam with
+     | Ok _ -> ()
+     | Error m -> fail ("flag failed: " ^ m));
+    (match BM.record_action ~target_kind:BM.Target_post ~target_id:"p13"
+             ~actor:"op" ~action:BM.Remove () with
+     | Ok _ -> ()
+     | Error m -> fail ("action failed: " ^ m));
+    match BM.flag ~target_kind:BM.Target_post ~target_id:"p13"
+            ~reporter:"r2" ~reason:BM.Harassment with
+    | Ok _ -> ()
+    | Error m -> fail ("resolved target should be flaggable again: " ^ m))
 
 (* ── get_audit_trail ─────────────────────────────────────────────── *)
 
@@ -363,7 +410,10 @@ let test_audit_entry_no_optional_fields_when_absent () =
 
 let () =
   run "Board_moderation"
-    [ ( "flag_reason",
+    [ ( "env",
+        [ test_case "with_env restores unset" `Quick
+            test_with_env_restores_unset ] );
+      ( "flag_reason",
         [ test_case "spam roundtrip"       `Quick test_flag_reason_spam;
           test_case "harassment roundtrip" `Quick test_flag_reason_harassment;
           test_case "off_topic roundtrip"  `Quick test_flag_reason_off_topic;
@@ -382,7 +432,9 @@ let () =
           test_case "different reporters bypass rate limit" `Quick
             test_flag_rate_limit_allows_different_reporters;
           test_case "non-finite rate limit falls back" `Quick
-            test_flag_rate_limit_non_finite_falls_back ] );
+            test_flag_rate_limit_non_finite_falls_back;
+          test_case "resolved entries still rate-limit reporter" `Quick
+            test_flag_rate_limit_survives_resolved_entries ] );
       ( "get_queue",
         [ test_case "unresolved filter"      `Quick test_get_queue_unresolved;
           test_case "all entries"            `Quick test_get_queue_all;
@@ -392,7 +444,10 @@ let () =
       ( "record_action",
         [ test_case "happy path"             `Quick test_record_action_happy_path;
           test_case "note capped at 500"     `Quick test_record_action_note_capped;
-          test_case "auto-resolves queue"    `Quick test_record_action_auto_resolves_queue ] );
+          test_case "auto-resolves queue"    `Quick
+            test_record_action_auto_resolves_queue;
+          test_case "allows target to be reflagged" `Quick
+            test_record_action_allows_target_to_be_reflagged ] );
       ( "get_audit_trail",
         [ test_case "actor filter"           `Quick test_audit_trail_actor_filter;
           test_case "target filter"          `Quick test_audit_trail_target_filter;

--- a/test/test_board_moderation.ml
+++ b/test/test_board_moderation.ml
@@ -167,6 +167,25 @@ let test_flag_rate_limit_allows_different_reporters () =
     | Ok _, Ok _ -> ()
     | _ -> fail "different reporters should not rate-limit each other")
 
+let test_flag_rate_limit_non_finite_falls_back () =
+  let check_non_finite value target_a target_b =
+    reset ();
+    with_flag_rate_limit value (fun () ->
+      (match BM.flag ~target_kind:BM.Target_post ~target_id:target_a
+               ~reporter:"agent-nonfinite" ~reason:BM.Spam with
+       | Ok _ -> ()
+       | Error m -> fail ("first flag failed: " ^ m));
+      match BM.flag ~target_kind:BM.Target_comment ~target_id:target_b
+              ~reporter:"agent-nonfinite" ~reason:BM.Off_topic with
+      | Error m ->
+          check bool ("fallback rate-limit " ^ value) true
+            (String.starts_with
+               ~prefix:"reporter agent-nonfinite is rate limited" m)
+      | Ok _ -> fail ("non-finite rate limit should fall back: " ^ value))
+  in
+  check_non_finite "nan" "rl-nan-1" "rl-nan-2";
+  check_non_finite "+inf" "rl-inf-1" "rl-inf-2"
+
 (* ── get_queue filtering ─────────────────────────────────────────── *)
 
 let test_get_queue_unresolved () =
@@ -361,7 +380,9 @@ let () =
           test_case "same reporter rate limited" `Quick
             test_flag_rate_limited_same_reporter;
           test_case "different reporters bypass rate limit" `Quick
-            test_flag_rate_limit_allows_different_reporters ] );
+            test_flag_rate_limit_allows_different_reporters;
+          test_case "non-finite rate limit falls back" `Quick
+            test_flag_rate_limit_non_finite_falls_back ] );
       ( "get_queue",
         [ test_case "unresolved filter"      `Quick test_get_queue_unresolved;
           test_case "all entries"            `Quick test_get_queue_all;

--- a/test/test_board_moderation.ml
+++ b/test/test_board_moderation.ml
@@ -21,6 +21,19 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 let reset () = BM.reset_for_test ()
 
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let with_flag_rate_limit value f =
+  with_env "MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC" value f
+
 (* ── flag_reason roundtrips ───────────────────────────────────────── *)
 
 let test_flag_reason_spam () =
@@ -118,14 +131,41 @@ let test_flag_duplicate_rejected () =
 
 let test_flag_different_targets () =
   reset ();
-  let r1 = BM.flag ~target_kind:BM.Target_post ~target_id:"p3"
-             ~reporter:"agent-c" ~reason:BM.Spam in
-  let r2 = BM.flag ~target_kind:BM.Target_comment ~target_id:"c1"
-             ~reporter:"agent-c" ~reason:BM.Off_topic in
-  (match r1, r2 with
-   | Ok e1, Ok e2 ->
-       check bool "different ids" true (e1.BM.entry_id <> e2.BM.entry_id)
-   | _ -> fail "both flags should succeed")
+  with_flag_rate_limit "0" (fun () ->
+    let r1 = BM.flag ~target_kind:BM.Target_post ~target_id:"p3"
+               ~reporter:"agent-c" ~reason:BM.Spam in
+    let r2 = BM.flag ~target_kind:BM.Target_comment ~target_id:"c1"
+               ~reporter:"agent-c" ~reason:BM.Off_topic in
+    match r1, r2 with
+    | Ok e1, Ok e2 ->
+        check bool "different ids" true (e1.BM.entry_id <> e2.BM.entry_id)
+    | _ -> fail "both flags should succeed")
+
+let test_flag_rate_limited_same_reporter () =
+  reset ();
+  with_flag_rate_limit "60" (fun () ->
+    (match BM.flag ~target_kind:BM.Target_post ~target_id:"rl1"
+             ~reporter:"agent-rl" ~reason:BM.Spam with
+     | Ok _ -> ()
+     | Error m -> fail ("first flag failed: " ^ m));
+    match BM.flag ~target_kind:BM.Target_comment ~target_id:"rl2"
+            ~reporter:"agent-rl" ~reason:BM.Off_topic with
+    | Error m ->
+        check bool "rate-limit message" true
+          (String.starts_with
+             ~prefix:"reporter agent-rl is rate limited" m)
+    | Ok _ -> fail "second flag by same reporter should be rate limited")
+
+let test_flag_rate_limit_allows_different_reporters () =
+  reset ();
+  with_flag_rate_limit "60" (fun () ->
+    let r1 = BM.flag ~target_kind:BM.Target_post ~target_id:"rl3"
+               ~reporter:"agent-rl-a" ~reason:BM.Spam in
+    let r2 = BM.flag ~target_kind:BM.Target_comment ~target_id:"rl4"
+               ~reporter:"agent-rl-b" ~reason:BM.Off_topic in
+    match r1, r2 with
+    | Ok _, Ok _ -> ()
+    | _ -> fail "different reporters should not rate-limit each other")
 
 (* ── get_queue filtering ─────────────────────────────────────────── *)
 
@@ -140,9 +180,9 @@ let test_get_queue_unresolved () =
 let test_get_queue_all () =
   reset ();
   let _ = BM.flag ~target_kind:BM.Target_post ~target_id:"q2"
-            ~reporter:"r" ~reason:BM.Spam in
+            ~reporter:"r1" ~reason:BM.Spam in
   let _ = BM.flag ~target_kind:BM.Target_comment ~target_id:"c2"
-            ~reporter:"r" ~reason:BM.Harassment in
+            ~reporter:"r2" ~reason:BM.Harassment in
   let q = BM.get_queue () in
   check int "two entries total" 2 (List.length q)
 
@@ -317,7 +357,11 @@ let () =
       ( "flag",
         [ test_case "happy path"             `Quick test_flag_happy_path;
           test_case "duplicate rejected"     `Quick test_flag_duplicate_rejected;
-          test_case "different targets ok"   `Quick test_flag_different_targets ] );
+          test_case "different targets ok"   `Quick test_flag_different_targets;
+          test_case "same reporter rate limited" `Quick
+            test_flag_rate_limited_same_reporter;
+          test_case "different reporters bypass rate limit" `Quick
+            test_flag_rate_limit_allows_different_reporters ] );
       ( "get_queue",
         [ test_case "unresolved filter"      `Quick test_get_queue_unresolved;
           test_case "all entries"            `Quick test_get_queue_all;


### PR DESCRIPTION
## Summary
- add a per-reporter moderation flag burst guard controlled by `MASC_BOARD_MODERATION_FLAG_RATE_LIMIT_SEC`
- keep duplicate unresolved target rejection independent from the reporter rate window
- document the moderation burst guard in the Board spec

## Verification
- scripts/dune-local.sh build test/test_board_moderation.exe
- ./_build/default/test/test_board_moderation.exe
- git diff --check
