### PR TITLE
fix(dashboard): focus ide review cockpit route

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -76,6 +76,10 @@ describe('cockpit entrypoint registry', () => {
       tab: 'monitoring',
       params: { section: 'cognition', view: 'autoresearch', focus: 'flow' },
     })
+    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'pr-thread' })).toEqual({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'unified', focus: 'review' },
+    })
   })
 
   it('routes the covered IDE search entrypoint directly to the find panel', () => {
@@ -107,5 +111,20 @@ describe('cockpit entrypoint registry', () => {
         params: { section: 'operations', view: 'ops', focus },
       })
     }
+  })
+
+  it('marks IDE review entrypoints as covered review focus routes', () => {
+    const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
+      entrypoint.aliases.map(alias => [alias, entrypoint] as const)
+    ))
+
+    expect(byAlias.get('review')).toMatchObject({
+      coverage: 'covered',
+      target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } },
+    })
+    expect(byAlias.get('pr-thread')).toMatchObject({
+      coverage: 'covered',
+      target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } },
+    })
   })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -90,7 +90,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
 
   // IDE Plane.
   { mode: 'ide', aliases: ['edit', 'source'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'partial' },
-  { mode: 'ide', aliases: ['review', 'pr-thread'], target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['review', 'pr-thread'], target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } }, coverage: 'covered' },
   { mode: 'ide', aliases: ['merge', 'split', 'split-diff'], target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } }, coverage: 'partial' },
   { mode: 'ide', aliases: ['graph', 'git-graph'], target: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } }, coverage: 'partial' },
   { mode: 'ide', aliases: ['search', 'find'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source', find: 'open' } }, coverage: 'covered' },

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -42,6 +42,10 @@ vi.mock('../../api/repositories', () => ({
   }])),
 }))
 
+vi.mock('./ide-conversation-rail-mock', () => ({
+  IdeConversationRailMock: () => null,
+}))
+
 import { IdeShell } from './ide-shell'
 import { navigate, route } from '../../router'
 import { clearTraces, pushTrace } from './keeper-trace-store'
@@ -63,11 +67,44 @@ function ideCommandInput(container: HTMLElement): HTMLInputElement {
   return input
 }
 
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function dashboardFetchMock(input: RequestInfo | URL): Promise<Response> {
+  const url = String(input)
+  if (url.includes('/api/v1/workspace/tree')) return Promise.resolve(jsonResponse([]))
+  if (url.includes('/api/v1/workspace/file')) return Promise.resolve(jsonResponse({ ok: false, content: '' }))
+  if (url.includes('/api/v1/git/blame')) return Promise.resolve(jsonResponse([]))
+  if (url.includes('/api/v1/git/diff')) return Promise.resolve(jsonResponse({ unified: [] }))
+  if (url.includes('/state-diagram')) {
+    return Promise.resolve(jsonResponse({
+      keeper: 'sangsu',
+      current_phase: 'observe',
+      memory_kind_usage: [],
+    }))
+  }
+  if (url.includes('/bdi-snapshot')) {
+    return Promise.resolve(jsonResponse({
+      keeper: 'sangsu',
+      generated_at: '2026-05-06T00:00:00Z',
+      poll_interval_ms: 5000,
+      recent_token_spend: [],
+      source: 'test',
+    }))
+  }
+  return Promise.resolve(jsonResponse({}))
+}
+
 describe('IdeShell', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
     container = document.createElement('div')
+    vi.stubGlobal('fetch', vi.fn(dashboardFetchMock))
   })
 
   afterEach(() => {
@@ -137,6 +174,39 @@ describe('IdeShell', () => {
     expect(route.value.params.layers).toBe('explode')
   })
 
+  it('turns focus=review into a unified review workspace with review layers', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'unified', focus: 'review' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Unified diff preview"]')).not.toBeNull()
+    expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Cascade').getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('lets explicit review-focus layers override the default review bundle', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'unified', focus: 'review', layers: 'cascade' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
+    expect(buttonByText(container, 'Cascade').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
+  })
+
   it('runs view commands from the IDE command bar', async () => {
     route.value = {
       tab: 'code',
@@ -152,6 +222,20 @@ describe('IdeShell', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
 
     expect(route.value.params.view).toBe('unified')
+  })
+
+  it('clears review focus when switching away from unified review mode', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'unified', focus: 'review' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    fireEvent.click(buttonByText(container, 'SOURCE'))
+
+    expect(route.value.params.view).toBe('source')
+    expect(route.value.params.focus).toBeUndefined()
   })
 
   it('runs layer commands from the IDE command bar', async () => {

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -217,6 +217,40 @@ describe('IdeShell', () => {
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
   })
 
+  it('persists an explicit empty review-focus layer override', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'unified', focus: 'review' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    fireEvent.click(buttonByText(container, 'Trace'))
+    fireEvent.click(buttonByText(container, 'Approve'))
+    fireEvent.click(buttonByText(container, 'Notes'))
+
+    expect(route.value.params.layers).toBe('none')
+    expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
+    expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('does not activate review focus outside the unified view', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', focus: 'review' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    expect(container.querySelector('[data-testid="ide-review-focus"]')).toBeNull()
+    expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
+  })
+
   it('runs view commands from the IDE command bar', async () => {
     route.value = {
       tab: 'code',
@@ -237,7 +271,7 @@ describe('IdeShell', () => {
   it('clears review focus when switching away from unified review mode', () => {
     route.value = {
       tab: 'code',
-      params: { section: 'ide-shell', view: 'unified', focus: 'review' },
+      params: { section: 'ide-shell', view: 'unified', focus: ' Review ' },
       postId: null,
     }
 
@@ -246,6 +280,7 @@ describe('IdeShell', () => {
 
     expect(route.value.params.view).toBe('source')
     expect(route.value.params.focus).toBeUndefined()
+    expect(route.value.params.layers).toBeUndefined()
   })
 
   it('runs layer commands from the IDE command bar', async () => {

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -74,29 +74,33 @@ function jsonResponse(body: unknown): Response {
   })
 }
 
+const dashboardFetchHandlers: ReadonlyArray<[
+  RegExp,
+  () => Response,
+]> = [
+  [/\/api\/v1\/workspace\/tree/, () => jsonResponse([])],
+  [/\/api\/v1\/workspace\/file/, () => jsonResponse({ ok: false, content: '' })],
+  [/\/api\/v1\/git\/blame/, () => jsonResponse([])],
+  [/\/api\/v1\/git\/diff/, () => jsonResponse({ unified: [] })],
+  [/\/state-diagram/, () => jsonResponse({
+    keeper: 'sangsu',
+    current_phase: 'observe',
+    memory_kind_usage: [],
+  })],
+  [/\/bdi-snapshot/, () => jsonResponse({
+    keeper: 'sangsu',
+    generated_at: '2026-05-06T00:00:00Z',
+    poll_interval_ms: 5000,
+    recent_token_spend: [],
+    source: 'test',
+  })],
+]
+
 function dashboardFetchMock(input: RequestInfo | URL): Promise<Response> {
   const url = String(input)
-  if (url.includes('/api/v1/workspace/tree')) return Promise.resolve(jsonResponse([]))
-  if (url.includes('/api/v1/workspace/file')) return Promise.resolve(jsonResponse({ ok: false, content: '' }))
-  if (url.includes('/api/v1/git/blame')) return Promise.resolve(jsonResponse([]))
-  if (url.includes('/api/v1/git/diff')) return Promise.resolve(jsonResponse({ unified: [] }))
-  if (url.includes('/state-diagram')) {
-    return Promise.resolve(jsonResponse({
-      keeper: 'sangsu',
-      current_phase: 'observe',
-      memory_kind_usage: [],
-    }))
-  }
-  if (url.includes('/bdi-snapshot')) {
-    return Promise.resolve(jsonResponse({
-      keeper: 'sangsu',
-      generated_at: '2026-05-06T00:00:00Z',
-      poll_interval_ms: 5000,
-      recent_token_spend: [],
-      source: 'test',
-    }))
-  }
-  return Promise.resolve(jsonResponse({}))
+  const handler = dashboardFetchHandlers.find(([pattern]) => pattern.test(url))
+  if (!handler) throw new Error(`Unmocked fetch URL: ${url}`)
+  return Promise.resolve(handler[1]())
 }
 
 describe('IdeShell', () => {
@@ -113,6 +117,12 @@ describe('IdeShell', () => {
     window.location.hash = ''
     route.value = { tab: 'overview', params: {}, postId: null }
     clearTraces()
+  })
+
+  it('fails fast for unmocked dashboard fetch URLs', () => {
+    expect(() => dashboardFetchMock('/api/v1/dashboard/unexpected')).toThrow(
+      'Unmocked fetch URL: /api/v1/dashboard/unexpected',
+    )
   })
 
   it('hydrates layer buttons from the route layers param', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -32,6 +32,7 @@ const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
 const IDE_LAYER_LABELS = new Map(IDE_LAYERS.map(layer => [layer.kind, layer.label]))
 export const REVIEW_FOCUS_LAYERS = ['keeper-trace', 'approve', 'notes'] as const
 const REVIEW_FOCUS_LAYER_PARAM = REVIEW_FOCUS_LAYERS.join(',')
+const EMPTY_LAYER_PARAM = 'none'
 
 function viewFromRoute(raw: string | null | undefined): ViewTab {
   const normalized = raw
@@ -49,6 +50,7 @@ function focusFromRoute(raw: string | null | undefined): IdeFocus | null {
 }
 
 function layersFromRoute(raw: string | null | undefined, focus: IdeFocus | null): ReadonlySet<string> {
+  if (raw?.trim().toLowerCase() === EMPTY_LAYER_PARAM) return new Set()
   if (focus === 'review' && !raw?.trim()) {
     return parseActive(REVIEW_FOCUS_LAYER_PARAM, IDE_LAYER_KINDS)
   }
@@ -72,6 +74,8 @@ function paramsWithLayers(
   const serialized = serializeActive(activeLayers)
   if (serialized) {
     next.layers = serialized
+  } else if (focusFromRoute(params.focus) === 'review' && view === 'unified') {
+    next.layers = EMPTY_LAYER_PARAM
   } else {
     delete next.layers
   }
@@ -85,7 +89,8 @@ export function IdeShell() {
 
   const activeFocus = focusFromRoute(route.value.params.focus)
   const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
-  const activeLayers = layersFromRoute(route.value.params.layers, activeFocus)
+  const reviewFocusActive = activeFocus === 'review' && activeView === 'unified'
+  const activeLayers = layersFromRoute(route.value.params.layers, reviewFocusActive ? activeFocus : null)
   const terminalOpen =
     route.value.params.terminal === 'open'
     || Boolean(route.value.params.keeper?.trim())
@@ -100,7 +105,10 @@ export function IdeShell() {
   const handleViewChange = (next: ViewTab) => {
     setActiveView(next)
     const nextParams: Record<string, string> = { ...route.value.params, section: 'ide-shell', view: next }
-    if (next !== 'unified' && nextParams.focus === 'review') delete nextParams.focus
+    if (next !== 'unified' && focusFromRoute(nextParams.focus) === 'review') {
+      delete nextParams.focus
+      if (nextParams.layers?.trim().toLowerCase() === EMPTY_LAYER_PARAM) delete nextParams.layers
+    }
     navigate('code', nextParams)
   }
 
@@ -165,7 +173,7 @@ export function IdeShell() {
         onTerminalOpen=${handleTerminalOpen}
         onFindOpen=${handleFindOpen}
       />
-      ${activeFocus === 'review'
+      ${reviewFocusActive
         ? html`<${IdeReviewFocusStrip} activeLayers=${activeLayers} />`
         : null}
       <div

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -29,7 +29,9 @@ type ViewTab = IdeEditorView
 type IdeFocus = 'review'
 
 const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
-const REVIEW_FOCUS_LAYER_PARAM = 'approve,keeper-trace,notes'
+const IDE_LAYER_LABELS = new Map(IDE_LAYERS.map(layer => [layer.kind, layer.label]))
+export const REVIEW_FOCUS_LAYERS = ['keeper-trace', 'approve', 'notes'] as const
+const REVIEW_FOCUS_LAYER_PARAM = REVIEW_FOCUS_LAYERS.join(',')
 
 function viewFromRoute(raw: string | null | undefined): ViewTab {
   const normalized = raw
@@ -229,9 +231,9 @@ export function IdeShell() {
 }
 
 function IdeReviewFocusStrip({ activeLayers }: { readonly activeLayers: ReadonlySet<string> }) {
-  const layerLabels = ['keeper-trace', 'approve', 'notes']
+  const layerLabels = REVIEW_FOCUS_LAYERS
     .filter(layer => activeLayers.has(layer))
-    .map(layer => layer === 'keeper-trace' ? 'Trace' : layer[0]!.toUpperCase() + layer.slice(1))
+    .map(layer => IDE_LAYER_LABELS.get(layer) ?? layer)
 
   return html`
     <div

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -26,7 +26,10 @@ import {
 export const activeIdeFile = signal<string>('package.json')
 
 type ViewTab = IdeEditorView
+type IdeFocus = 'review'
+
 const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
+const REVIEW_FOCUS_LAYER_PARAM = 'approve,keeper-trace,notes'
 
 function viewFromRoute(raw: string | null | undefined): ViewTab {
   const normalized = raw
@@ -39,7 +42,14 @@ function viewFromRoute(raw: string | null | undefined): ViewTab {
   return 'source'
 }
 
-function layersFromRoute(raw: string | null | undefined): ReadonlySet<string> {
+function focusFromRoute(raw: string | null | undefined): IdeFocus | null {
+  return raw?.trim().toLowerCase() === 'review' ? 'review' : null
+}
+
+function layersFromRoute(raw: string | null | undefined, focus: IdeFocus | null): ReadonlySet<string> {
+  if (focus === 'review' && !raw?.trim()) {
+    return parseActive(REVIEW_FOCUS_LAYER_PARAM, IDE_LAYER_KINDS)
+  }
   return parseActive(raw ?? '', IDE_LAYER_KINDS)
 }
 
@@ -71,8 +81,9 @@ export function IdeShell() {
 
   useEffect(() => () => coordinator.dispose(), [coordinator])
 
+  const activeFocus = focusFromRoute(route.value.params.focus)
   const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
-  const activeLayers = layersFromRoute(route.value.params.layers)
+  const activeLayers = layersFromRoute(route.value.params.layers, activeFocus)
   const terminalOpen =
     route.value.params.terminal === 'open'
     || Boolean(route.value.params.keeper?.trim())
@@ -86,7 +97,9 @@ export function IdeShell() {
 
   const handleViewChange = (next: ViewTab) => {
     setActiveView(next)
-    navigate('code', { ...route.value.params, section: 'ide-shell', view: next })
+    const nextParams: Record<string, string> = { ...route.value.params, section: 'ide-shell', view: next }
+    if (next !== 'unified' && nextParams.focus === 'review') delete nextParams.focus
+    navigate('code', nextParams)
   }
 
   const handleLayersChange = (nextLayers: ReadonlySet<string>) => {
@@ -150,6 +163,9 @@ export function IdeShell() {
         onTerminalOpen=${handleTerminalOpen}
         onFindOpen=${handleFindOpen}
       />
+      ${activeFocus === 'review'
+        ? html`<${IdeReviewFocusStrip} activeLayers=${activeLayers} />`
+        : null}
       <div
         class="ide-plane-grid"
         role="presentation"
@@ -209,5 +225,24 @@ export function IdeShell() {
         : null}
       <${IdeInterjectMock} />
     </section>
+  `
+}
+
+function IdeReviewFocusStrip({ activeLayers }: { readonly activeLayers: ReadonlySet<string> }) {
+  const layerLabels = ['keeper-trace', 'approve', 'notes']
+    .filter(layer => activeLayers.has(layer))
+    .map(layer => layer === 'keeper-trace' ? 'Trace' : layer[0]!.toUpperCase() + layer.slice(1))
+
+  return html`
+    <div
+      data-testid="ide-review-focus"
+      class="flex flex-wrap items-center gap-2 border-b border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs text-[var(--color-fg-muted)]"
+    >
+      <span class="font-mono uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">review focus</span>
+      <span class="font-mono">UNIFIED</span>
+      <span class="text-[var(--color-fg-disabled)]">·</span>
+      <span class="font-mono">${layerLabels.length > 0 ? layerLabels.join(' / ') : 'custom layers'}</span>
+      <span class="ml-auto font-mono text-[var(--color-fg-disabled)]">branch graph rail</span>
+    </div>
   `
 }


### PR DESCRIPTION
## Summary
- route IDE `review` / `pr-thread` cockpit aliases into a real unified review focus state
- default review focus to Trace / Approve / Notes layers while preserving explicit `layers=` overrides
- mark the IDE review aliases covered in the cockpit entrypoint map

## Validation
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/ide/ide-shell.test.ts src/cockpit-entrypoints.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint` (0 errors; existing unused-disable warnings outside this slice)
- `pnpm --dir dashboard run build`

## Browser Proof
- alias `#mode=ide&tab=review` canonicalized to `#code?mode=ide&section=ide-shell&view=unified&focus=review`
- direct `#code?section=ide-shell&view=unified&focus=review` rendered `[data-testid="ide-review-focus"]` and unified preview
- mobile `390x844` alias route rendered without page-width overflow (`scrollWidth == clientWidth == 390`)
- screenshots: `/tmp/masc-ide-review-focus-0506.png`, `/tmp/masc-ide-review-focus-direct-0506.png`, `/tmp/masc-ide-review-focus-mobile-0506.png`