### PR TITLE
fix(dashboard): focus cognition memory entries route

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -7,6 +7,7 @@ import {
   fetchDashboardTools,
   fetchCostLatency,
   fetchKeeperConfig,
+  fetchMemorySubsystems,
   fetchRuntimeModelMetrics,
   fetchTlcResults,
   fetchToolQuality,
@@ -67,18 +68,52 @@ describe('fetchDashboardShell', () => {
       status: { project: 'default' },
       counts: { agents: 1, tasks: 2, keepers: 3 },
     }
-    const fetchMock = vi.fn().mockResolvedValue(
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
       new Response(JSON.stringify(rawResponse), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
-    )
+    ))
     vi.stubGlobal('fetch', fetchMock)
 
     await fetchDashboardShell({ light: true })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/shell?light=true')
+  })
+})
+
+describe('fetchMemorySubsystems', () => {
+  it('adds the sensitive memory entries query only when requested', async () => {
+    const rawResponse = {
+      generated_at: '2026-05-06T00:00:00Z',
+      hebbian: { synapses: [], last_consolidation: 0 },
+      episodes: { total: 0, filtered: 0, shown: 0, limit: 100, items: [] },
+      filters: { keepers: [], outcomes: [] },
+    }
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchMemorySubsystems({ limit: 100 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    let requestUrl = new URL(fetchMock.mock.calls[0]?.[0] as string, 'http://dashboard.local')
+    expect(requestUrl.searchParams.has('include_memory_entries')).toBe(false)
+
+    fetchMock.mockClear()
+
+    await fetchMemorySubsystems({ limit: 100, includeMemoryEntries: true })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    requestUrl = new URL(fetchMock.mock.calls[0]?.[0] as string, 'http://dashboard.local')
+    expect(requestUrl.pathname).toBe('/api/v1/dashboard/memory-subsystems')
+    expect(requestUrl.searchParams.get('limit')).toBe('100')
+    expect(requestUrl.searchParams.get('include_memory_entries')).toBe('true')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2781,6 +2781,7 @@ interface MemorySubsystemsQuery {
   keeper?: string
   outcome?: string
   q?: string
+  includeMemoryEntries?: boolean
   signal?: AbortSignal
 }
 
@@ -2792,6 +2793,7 @@ export function fetchMemorySubsystems(
   if (opts?.keeper) params.set('keeper', opts.keeper)
   if (opts?.outcome) params.set('outcome', opts.outcome)
   if (opts?.q) params.set('q', opts.q)
+  if (opts?.includeMemoryEntries) params.set('include_memory_entries', 'true')
   const qs = params.toString()
   return get<MemorySubsystemsResponse>(
     `/api/v1/dashboard/memory-subsystems${qs ? `?${qs}` : ''}`,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2741,6 +2741,14 @@ export interface MemorySubsystemsEpisode {
   context: Record<string, string>
 }
 
+export interface MemorySubsystemsMemoryEntry {
+  keeper: string
+  kind: string
+  text: string
+  priority: number
+  ts_unix: number
+}
+
 export interface MemorySubsystemsResponse {
   generated_at: string
   hebbian: {
@@ -2754,9 +2762,17 @@ export interface MemorySubsystemsResponse {
     limit: number
     items: MemorySubsystemsEpisode[]
   }
+  memory_entries?: {
+    total: number
+    filtered: number
+    shown: number
+    limit: number
+    items: MemorySubsystemsMemoryEntry[]
+  }
   filters: {
     keepers: string[]
     outcomes: string[]
+    memory_kinds?: string[]
   }
 }
 

--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -52,6 +52,10 @@ describe('cockpit entrypoint registry', () => {
       tab: 'monitoring',
       params: { section: 'cognition', view: 'keeper', focus: 'tool-access' },
     })
+    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-mem' })).toEqual({
+      tab: 'monitoring',
+      params: { section: 'cognition', view: 'memory', focus: 'entries' },
+    })
     expect(cockpitTargetForParams({ mode: 'Observe', tab: 'sa-dash' })).toEqual({
       tab: 'command',
       params: { section: 'operations', view: 'safety' },

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -81,7 +81,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'keeper', focus: 'tool-access' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'token-stats' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'decisions' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'memory' } }, coverage: 'partial' },
+  { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'memory', focus: 'entries' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ep-card', 'episodes-cards'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ep-lrn', 'episodes-learnings'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'episodes' } }, coverage: 'covered' },
   { mode: 'cognition', aliases: ['ar-lst', 'ar-loops'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch' } }, coverage: 'covered' },

--- a/dashboard/src/components/cognition-plane.test.ts
+++ b/dashboard/src/components/cognition-plane.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 void vi
 
 const route = { value: { tab: 'monitoring' as string, params: {} as Record<string, string> } }
+const navigateMock = vi.fn()
 
 async function flushUi(): Promise<void> {
   await Promise.resolve()
@@ -14,7 +15,7 @@ async function flushUi(): Promise<void> {
 
 async function loadPlane() {
   vi.resetModules()
-  vi.doMock('../router', () => ({ route, navigate: vi.fn() }))
+  vi.doMock('../router', () => ({ route, navigate: navigateMock }))
   vi.doMock('./agents-unified', () => ({
     AgentsUnified: () => html`<div data-testid="agents-unified">AgentsUnified</div>`,
   }))
@@ -44,6 +45,7 @@ describe('CognitionPlane', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     route.value = { tab: 'monitoring', params: { section: 'cognition' } }
+    navigateMock.mockClear()
   })
 
   afterEach(() => {
@@ -91,6 +93,23 @@ describe('CognitionPlane', () => {
     await flushUi()
 
     expect(container.querySelector('[data-testid="memory-subsystems"]')?.getAttribute('data-focus')).toBe('entries')
+  })
+
+  it('keeps entries focus when re-clicking the active memory view chip', async () => {
+    route.value.params = { section: 'cognition', view: 'memory', focus: 'entries' }
+    const { CognitionPlane } = await loadPlane()
+
+    render(html`<${CognitionPlane} />`, container)
+    await flushUi()
+
+    const memoryChip = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Memory')
+    expect(memoryChip).not.toBeUndefined()
+
+    memoryChip?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(navigateMock).not.toHaveBeenCalled()
+    expect(route.value.params.focus).toBe('entries')
   })
 
   it('uses the episodes focus for the episodes view', async () => {

--- a/dashboard/src/components/cognition-plane.test.ts
+++ b/dashboard/src/components/cognition-plane.test.ts
@@ -31,7 +31,8 @@ async function loadPlane() {
     KeeperTokenStats: () => html`<div data-testid="keeper-token-stats">KeeperTokenStats</div>`,
   }))
   vi.doMock('./memory-subsystems', () => ({
-    MemorySubsystems: () => html`<div data-testid="memory-subsystems">MemorySubsystems</div>`,
+    MemorySubsystems: ({ focus }: { focus?: string }) =>
+      html`<div data-testid="memory-subsystems" data-focus=${focus ?? ''}>MemorySubsystems</div>`,
   }))
   return import('./cognition-plane')
 }
@@ -80,5 +81,25 @@ describe('CognitionPlane', () => {
 
     expect(container.querySelector('[data-testid="keeper-decisions-stream"]')).not.toBeNull()
     expect(container.textContent).not.toContain('backend-blocked')
+  })
+
+  it('routes memory focus into the memory subsystem entries surface', async () => {
+    route.value.params = { section: 'cognition', view: 'memory', focus: 'entries' }
+    const { CognitionPlane } = await loadPlane()
+
+    render(html`<${CognitionPlane} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="memory-subsystems"]')?.getAttribute('data-focus')).toBe('entries')
+  })
+
+  it('uses the episodes focus for the episodes view', async () => {
+    route.value.params = { section: 'cognition', view: 'episodes' }
+    const { CognitionPlane } = await loadPlane()
+
+    render(html`<${CognitionPlane} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="memory-subsystems"]')?.getAttribute('data-focus')).toBe('episodes')
   })
 })

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -38,6 +38,7 @@ function currentView(): CognitionView {
 }
 
 function updateViewParam(view: CognitionView): void {
+  if (view === currentView()) return
   const next: Record<string, string> = { ...route.value.params, section: 'cognition' }
   delete next.focus
   if (view === 'overview') {

--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -6,7 +6,7 @@ import { FilterChips } from './common/filter-chips'
 import { KeeperDecisionsStream } from './keeper-decisions-stream'
 import { KeeperCognitionInspector } from './keeper-cognition-inspector'
 import { KeeperTokenStats } from './keeper-token-stats'
-import { MemorySubsystems } from './memory-subsystems'
+import { MemorySubsystems, type MemorySubsystemsFocus } from './memory-subsystems'
 
 type CognitionView = 'overview' | 'keeper' | 'token-stats' | 'decisions' | 'memory' | 'episodes' | 'autoresearch'
 
@@ -39,6 +39,7 @@ function currentView(): CognitionView {
 
 function updateViewParam(view: CognitionView): void {
   const next: Record<string, string> = { ...route.value.params, section: 'cognition' }
+  delete next.focus
   if (view === 'overview') {
     delete next.view
   } else {
@@ -47,8 +48,14 @@ function updateViewParam(view: CognitionView): void {
   navigate('monitoring', next)
 }
 
+function currentMemoryFocus(view: CognitionView): MemorySubsystemsFocus {
+  if (view === 'episodes') return 'episodes'
+  return route.value.params.focus === 'entries' ? 'entries' : 'overview'
+}
+
 export function CognitionPlane() {
   const view = currentView()
+  const memoryFocus = currentMemoryFocus(view)
 
   return html`
     <div class="flex flex-col gap-5">
@@ -67,7 +74,7 @@ export function CognitionPlane() {
       ` : view === 'decisions' ? html`
         <${KeeperDecisionsStream} />
       ` : view === 'memory' || view === 'episodes' ? html`
-        <${MemorySubsystems} />
+        <${MemorySubsystems} focus=${memoryFocus} />
       ` : view === 'autoresearch' ? html`
         <${Autoresearch} />
       ` : html`

--- a/dashboard/src/components/memory-subsystems.test.ts
+++ b/dashboard/src/components/memory-subsystems.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { MemorySubsystemsSynapse } from '../api/dashboard'
-import { ARCHITECTURE_FLOW, filterSynapses } from './memory-subsystems'
+import type { MemorySubsystemsMemoryEntry, MemorySubsystemsSynapse } from '../api/dashboard'
+import { ARCHITECTURE_FLOW, filterMemoryEntries, filterSynapses } from './memory-subsystems'
 
 function makeSynapse(
   overrides: Partial<MemorySubsystemsSynapse> = {},
@@ -81,6 +81,28 @@ describe('filterSynapses', () => {
     expect(result).toHaveLength(2)
     expect(result.map(r => r.from_agent)).toContain('router-delta')
     expect(result.map(r => r.to_agent)).toContain('router-delta')
+  })
+})
+
+describe('filterMemoryEntries', () => {
+  const entries: MemorySubsystemsMemoryEntry[] = [
+    { keeper: 'sangsu', kind: 'verified', text: 'PR verified', priority: 90, ts_unix: 1 },
+    { keeper: 'issue_king', kind: 'learned', text: 'task duplicate', priority: 70, ts_unix: 2 },
+    { keeper: 'qa-king', kind: 'verified', text: 'release target checked', priority: 85, ts_unix: 3 },
+  ]
+
+  it('returns the input reference for all entries', () => {
+    expect(filterMemoryEntries(entries, 'all')).toBe(entries)
+    expect(filterMemoryEntries(entries, '')).toBe(entries)
+  })
+
+  it('keeps entries with the selected memory kind', () => {
+    const result = filterMemoryEntries(entries, 'verified')
+    expect(result.map(entry => entry.keeper)).toEqual(['sangsu', 'qa-king'])
+  })
+
+  it('returns empty when the kind is absent', () => {
+    expect(filterMemoryEntries(entries, 'plan')).toEqual([])
   })
 })
 

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -573,6 +573,7 @@ function MemoryEntriesPanel({
 
 export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: MemorySubsystemsFocus }) {
   const resource = useManagedAsyncResource<MemorySubsystemsResponse>(null)
+  const includeMemoryEntries = focus === 'entries'
 
   const keeperFilter = useSignal<string>('')
   const outcomeFilter = useSignal<string>('')
@@ -591,6 +592,7 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
           keeper: keeperFilter.value || undefined,
           outcome: outcomeFilter.value || undefined,
           q: searchQuery.value || undefined,
+          includeMemoryEntries,
           signal,
         }),
       )
@@ -601,7 +603,7 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
       resource.cancel()
       cleanup()
     }
-  }, [keeperFilter.value, outcomeFilter.value, searchQuery.value, resource])
+  }, [keeperFilter.value, outcomeFilter.value, searchQuery.value, includeMemoryEntries, resource])
 
   const { loading, error, data } = resource.state.value
   if (loading && !data) return html`<${LoadingState} label="기억 서브시스템 로드 중..." />`
@@ -661,6 +663,7 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
 
   const showArch = useSignal(false)
   const focusEntries = focus === 'entries'
+  const showMemoryEntries = focusEntries || memoryEntries.length > 0
 
   return html`
     <div class="space-y-6">
@@ -670,16 +673,18 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
         keeper checkpoint/history/memory bank는 Keeper Detail에서 확인합니다.
       </div>
 
-      <${MemoryEntriesPanel}
-        entries=${memoryEntries}
-        visibleEntries=${visibleMemoryEntries}
-        total=${memoryEntryTotal}
-        filtered=${memoryEntryFiltered}
-        knownKinds=${knownMemoryKinds}
-        activeKind=${memoryKindFilter.value}
-        onKindChange=${(kind: string) => { memoryKindFilter.value = kind }}
-        focused=${focusEntries}
-      />
+      ${showMemoryEntries ? html`
+        <${MemoryEntriesPanel}
+          entries=${memoryEntries}
+          visibleEntries=${visibleMemoryEntries}
+          total=${memoryEntryTotal}
+          filtered=${memoryEntryFiltered}
+          knownKinds=${knownMemoryKinds}
+          activeKind=${memoryKindFilter.value}
+          onKindChange=${(kind: string) => { memoryKindFilter.value = kind }}
+          focused=${focusEntries}
+        />
+      ` : null}
 
       ${focusEntries ? null : html`
 

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { signal, useSignal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
 import { LoadingState } from './common/feedback-state'
+import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { MermaidGraph } from './common/mermaid-graph'
 import { Select } from './common/select'
@@ -11,6 +12,7 @@ import {
   type MemorySubsystemsResponse,
   type MemorySubsystemsSynapse,
   type MemorySubsystemsEpisode,
+  type MemorySubsystemsMemoryEntry,
   type KeeperDecision,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
@@ -21,6 +23,8 @@ import { openAgentDetail } from './agent-detail-state'
 import { ringFocusClasses } from './common/ring'
 
 const REFRESH_MS = 30_000
+
+export type MemorySubsystemsFocus = 'overview' | 'entries' | 'episodes'
 
 export const ARCHITECTURE_FLOW = `graph LR
     subgraph Keeper["키퍼 턴"]
@@ -161,6 +165,14 @@ export function filterSynapses(
     if (s.to_agent.toLowerCase().includes(needle)) return true
     return false
   })
+}
+
+export function filterMemoryEntries(
+  entries: readonly MemorySubsystemsMemoryEntry[],
+  kind: string,
+): readonly MemorySubsystemsMemoryEntry[] {
+  if (kind === '' || kind === 'all') return entries
+  return entries.filter(entry => entry.kind === kind)
 }
 
 function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
@@ -464,12 +476,108 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
   `
 }
 
-export function MemorySubsystems() {
+function MemoryEntryRow({ entry }: { readonly entry: MemorySubsystemsMemoryEntry }) {
+  return html`
+    <div
+      class="grid grid-cols-[5.5rem_8rem_6rem_minmax(0,1fr)_3rem] items-start gap-2 border-b border-[var(--color-border-default)] px-2 py-2 text-xs last:border-b-0 max-md:grid-cols-[4.5rem_minmax(0,1fr)]"
+      role="listitem"
+      aria-label=${`${entry.keeper} · ${entry.kind} · priority ${entry.priority} · ${entry.text}`}
+    >
+      <span class="font-mono text-[var(--color-fg-disabled)] tabular-nums">
+        ${formatTimeAgo(entry.ts_unix * 1000)}
+      </span>
+      <span class="truncate font-mono text-[var(--color-fg-muted)]" title=${entry.keeper}>
+        ${entry.keeper}
+      </span>
+      <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-center font-mono text-[var(--color-accent-fg)]">
+        ${entry.kind}
+      </span>
+      <span class="min-w-0 text-[var(--color-fg-primary)] max-md:col-span-2">
+        ${entry.text}
+      </span>
+      <span class="text-right font-mono text-[var(--color-fg-disabled)] max-md:hidden">
+        p${entry.priority}
+      </span>
+    </div>
+  `
+}
+
+function MemoryEntriesPanel({
+  entries,
+  visibleEntries,
+  total,
+  filtered,
+  knownKinds,
+  activeKind,
+  onKindChange,
+  focused,
+}: {
+  readonly entries: readonly MemorySubsystemsMemoryEntry[]
+  readonly visibleEntries: readonly MemorySubsystemsMemoryEntry[]
+  readonly total: number
+  readonly filtered: number
+  readonly knownKinds: readonly string[]
+  readonly activeKind: string
+  readonly onKindChange: (kind: string) => void
+  readonly focused: boolean
+}) {
+  const chips = [
+    { key: 'all', label: 'all', count: entries.length },
+    ...knownKinds.map(kind => ({
+      key: kind,
+      label: kind,
+      count: entries.filter(entry => entry.kind === kind).length,
+    })),
+  ]
+
+  return html`
+    <section
+      data-testid="memory-entries"
+      aria-label=${`Memory entries · ${visibleEntries.length} rows`}
+      class=${`flex flex-col gap-2 ${focused ? 'rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3' : ''}`}
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <h3 class="text-base font-semibold text-[var(--color-fg-muted)]">Memory entries</h3>
+        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">
+          memory.jsonl
+        </span>
+        <span class="ml-auto text-xs text-[var(--color-fg-muted)]">
+          total ${total} · filtered ${filtered} · shown ${visibleEntries.length}
+        </span>
+      </div>
+      <${FilterChips}
+        chips=${chips}
+        value=${activeKind}
+        onChange=${onKindChange}
+        size="sm"
+        tone="accent"
+      />
+      ${
+        visibleEntries.length === 0
+          ? html`<div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-center text-sm text-[var(--color-fg-muted)]">
+              memory entries 없음
+            </div>`
+          : html`
+              <div
+                class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]"
+                role="list"
+                aria-label=${`${visibleEntries.length} memory entries`}
+              >
+                ${visibleEntries.map(entry => html`<${MemoryEntryRow} entry=${entry} />`)}
+              </div>
+            `
+      }
+    </section>
+  `
+}
+
+export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: MemorySubsystemsFocus }) {
   const resource = useManagedAsyncResource<MemorySubsystemsResponse>(null)
 
   const keeperFilter = useSignal<string>('')
   const outcomeFilter = useSignal<string>('')
   const searchQuery = useSignal<string>('')
+  const memoryKindFilter = useSignal<string>('all')
   // Client-side substring filter for the Hebbian synapses table. Independent
   // from the episodes filter bar above — the synapses table is N² in fleet
   // size and needs its own needle.
@@ -511,8 +619,16 @@ export function MemorySubsystems() {
   const episodes = data?.episodes?.items ?? []
   const totalEpisodes = data?.episodes?.total ?? 0
   const filteredTotal = data?.episodes?.filtered ?? episodes.length
+  const memoryEntries = data?.memory_entries?.items ?? []
+  const memoryEntryTotal = data?.memory_entries?.total ?? memoryEntries.length
+  const memoryEntryFiltered = data?.memory_entries?.filtered ?? memoryEntries.length
   const knownKeepers = data?.filters?.keepers ?? []
   const knownOutcomes = data?.filters?.outcomes ?? ['success', 'partial', 'failure']
+  const knownMemoryKinds = data?.filters?.memory_kinds ?? Array.from(new Set(memoryEntries.map(entry => entry.kind))).sort()
+  const visibleMemoryEntries = useMemo(
+    () => filterMemoryEntries(memoryEntries, memoryKindFilter.value),
+    [memoryEntries, memoryKindFilter.value],
+  )
 
   const onSearchInput = (e: Event) => {
     const v = (e.target as HTMLInputElement).value
@@ -524,6 +640,7 @@ export function MemorySubsystems() {
     outcomeFilter.value = ''
     searchQuery.value = ''
     synapsePairFilter.value = null
+    memoryKindFilter.value = 'all'
   }
 
   const pairFilter = synapsePairFilter.value
@@ -543,6 +660,7 @@ export function MemorySubsystems() {
     : episodes
 
   const showArch = useSignal(false)
+  const focusEntries = focus === 'entries'
 
   return html`
     <div class="space-y-6">
@@ -551,6 +669,19 @@ export function MemorySubsystems() {
         institution episodes와 Hebbian graph는 여기서 보고,
         keeper checkpoint/history/memory bank는 Keeper Detail에서 확인합니다.
       </div>
+
+      <${MemoryEntriesPanel}
+        entries=${memoryEntries}
+        visibleEntries=${visibleMemoryEntries}
+        total=${memoryEntryTotal}
+        filtered=${memoryEntryFiltered}
+        knownKinds=${knownMemoryKinds}
+        activeKind=${memoryKindFilter.value}
+        onKindChange=${(kind: string) => { memoryKindFilter.value = kind }}
+        focused=${focusEntries}
+      />
+
+      ${focusEntries ? null : html`
 
       <!-- Architecture Flow (collapsible) -->
       <section aria-label="아키텍처 데이터 흐름도">
@@ -742,6 +873,7 @@ export function MemorySubsystems() {
       </section>
 
       <${DecisionsStream} />
+      `}
 
       ${
         error

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -144,6 +144,67 @@ let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
     String.length needle = 0
     || String_util.contains_substring_ci haystack needle
   in
+  let memory_entry_to_json
+      (keeper : string)
+      (row : Keeper_memory_policy.keeper_memory_line) : Yojson.Safe.t =
+    `Assoc
+      [
+        ("keeper", `String keeper);
+        ("kind", `String row.kind);
+        ("text", `String row.text);
+        ("priority", `Int row.priority);
+        ("ts_unix", `Float row.ts_unix);
+      ]
+  in
+  let all_memory_entries =
+    try
+      Keeper_types.keeper_names config
+      |> List.concat_map (fun keeper ->
+             try
+               let summary =
+                 Keeper_memory_recall.read_keeper_memory_summary config
+                   ~name:keeper ~max_bytes:120000 ~max_lines:180
+                   ~recent_limit:30
+               in
+               List.map
+                 (fun (row : Keeper_memory_policy.keeper_memory_line) ->
+                   (keeper, row))
+                 summary.recent_notes
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | _ -> [])
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> []
+  in
+  let memory_total = List.length all_memory_entries in
+  let memory_filtered =
+    all_memory_entries
+    |> List.filter (fun (keeper, (row : Keeper_memory_policy.keeper_memory_line)) ->
+           let keeper_ok =
+             match keeper_filter with
+             | None -> true
+             | Some k -> String.equal keeper k
+           in
+           let search_ok =
+             match search with
+             | None -> true
+             | Some q ->
+               contains_ci keeper q || contains_ci row.kind q
+               || contains_ci row.text q
+           in
+           keeper_ok && search_ok)
+  in
+  let memory_filtered_total = List.length memory_filtered in
+  let memory_entries =
+    memory_filtered
+    |> List.sort
+         (fun
+           (_, (a : Keeper_memory_policy.keeper_memory_line))
+           (_, (b : Keeper_memory_policy.keeper_memory_line)) ->
+           compare b.ts_unix a.ts_unix)
+    |> take limit
+  in
   let filtered =
     all_episodes
     |> List.filter (fun (e : Institution_eio.episode) ->
@@ -182,8 +243,18 @@ let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
     else drop (filtered_total - limit) filtered
   in
   let known_keepers =
-    all_episodes
-    |> List.concat_map (fun (e : Institution_eio.episode) -> e.participants)
+    let episode_keepers =
+      all_episodes
+      |> List.concat_map (fun (e : Institution_eio.episode) -> e.participants)
+    in
+    let memory_keepers = List.map fst all_memory_entries in
+    episode_keepers @ memory_keepers
+    |> List.sort_uniq String.compare
+  in
+  let known_memory_kinds =
+    all_memory_entries
+    |> List.map (fun (_, (row : Keeper_memory_policy.keeper_memory_line)) ->
+           row.kind)
     |> List.sort_uniq String.compare
   in
   `Assoc
@@ -201,12 +272,27 @@ let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
               `List
                 (List.map Institution_eio.episode_to_json episodes) );
           ] );
+      ( "memory_entries",
+        `Assoc
+          [
+            ("total", `Int memory_total);
+            ("filtered", `Int memory_filtered_total);
+            ("shown", `Int (List.length memory_entries));
+            ("limit", `Int limit);
+            ( "items",
+              `List
+                (List.map
+                   (fun (keeper, row) -> memory_entry_to_json keeper row)
+                   memory_entries) );
+          ] );
       ( "filters",
         `Assoc
           [
             ( "keepers",
               `List (List.map (fun k -> `String k) known_keepers) );
             ("outcomes", `List [ `String "success"; `String "partial"; `String "failure" ]);
+            ( "memory_kinds",
+              `List (List.map (fun k -> `String k) known_memory_kinds) );
           ] );
     ]
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -103,8 +103,61 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   dashboard_board_json ?hearth ?author_filter ~sort_by ~exclude_system
     ~exclude_automation ~limit ~offset ()
 
-let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
+let memory_subsystems_entry_cache_ttl_sec = 30.0
+
+let memory_subsystems_entry_cache :
+    (string * float * (string * Keeper_memory_policy.keeper_memory_line) list)
+    option ref =
+  ref None
+
+let dashboard_memory_subsystems_include_entries request =
+  bool_query_param request "include_memory_entries" ~default:false
+  ||
+  match query_param request "focus" |> Option.map String.trim with
+  | Some "entries" -> true
+  | _ -> false
+
+let load_memory_subsystems_entries ~(config : Coord_utils.config) =
+  let now = Unix.gettimeofday () in
+  match !memory_subsystems_entry_cache with
+  | Some (base_path, cached_at, rows)
+    when String.equal base_path config.base_path
+         && now -. cached_at < memory_subsystems_entry_cache_ttl_sec ->
+      rows
+  | _ ->
+      let rows =
+        try
+          Keeper_types.keeper_names config
+          |> List.concat_map (fun keeper ->
+                 try
+                   let summary =
+                     Keeper_memory_recall.read_keeper_memory_summary config
+                       ~name:keeper ~max_bytes:120000 ~max_lines:180
+                       ~recent_limit:30
+                   in
+                   List.map
+                     (fun
+                       (row : Keeper_memory_policy.keeper_memory_line) ->
+                       (keeper, row))
+                     summary.recent_notes
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | _ -> [])
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> []
+      in
+      memory_subsystems_entry_cache :=
+        Some (config.base_path, now, rows);
+      rows
+
+let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config)
+    ?include_memory_entries request
     : Yojson.Safe.t =
+  let include_memory_entries =
+    Option.value include_memory_entries
+      ~default:(dashboard_memory_subsystems_include_entries request)
+  in
   let limit =
     int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:500
   in
@@ -157,25 +210,8 @@ let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
       ]
   in
   let all_memory_entries =
-    try
-      Keeper_types.keeper_names config
-      |> List.concat_map (fun keeper ->
-             try
-               let summary =
-                 Keeper_memory_recall.read_keeper_memory_summary config
-                   ~name:keeper ~max_bytes:120000 ~max_lines:180
-                   ~recent_limit:30
-               in
-               List.map
-                 (fun (row : Keeper_memory_policy.keeper_memory_line) ->
-                   (keeper, row))
-                 summary.recent_notes
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | _ -> [])
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> []
+    if include_memory_entries then load_memory_subsystems_entries ~config
+    else []
   in
   let memory_total = List.length all_memory_entries in
   let memory_filtered =

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -60,8 +60,14 @@ val dashboard_board_json :
 val dashboard_memory_http_json :
   Httpun.Request.t -> Yojson.Safe.t
 
+val dashboard_memory_subsystems_include_entries :
+  Httpun.Request.t -> bool
+
 val dashboard_memory_subsystems_http_json :
-  config:Coord_utils.config -> Httpun.Request.t -> Yojson.Safe.t
+  config:Coord_utils.config ->
+  ?include_memory_entries:bool ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
 
 val dashboard_governance_http_json :
   Httpun.Request.t -> base_path:string -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -483,11 +483,23 @@ let rec add_routes ~sw ~clock router =
              handle_dashboard_link_previews state req reqd body_str))
          request reqd)
   |> Http.Router.get "/api/v1/dashboard/memory-subsystems" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       let include_memory_entries =
+         dashboard_memory_subsystems_include_entries request
+       in
+       let handler state req reqd =
          let config = state.Mcp_server.room_config in
-         let json = dashboard_memory_subsystems_http_json ~config req in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
-       ) request reqd)
+         let json =
+           dashboard_memory_subsystems_http_json ~config
+             ~include_memory_entries req
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       in
+       if include_memory_entries then
+         with_token_permission_auth ~permission:Masc_domain.CanReadState
+           (fun state _agent_name req reqd -> handler state req reqd)
+           request reqd
+       else with_public_read handler request reqd)
   |> Http.Router.get "/api/v1/dashboard/doctor" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let self_bin = Sys.argv.(0) in


### PR DESCRIPTION
## Summary
- add `memory_entries` to `/api/v1/dashboard/memory-subsystems` from recent keeper memory-bank rows
- route `dc-mem` / `memory-entries` to `section=cognition&view=memory&focus=entries` and mark the cockpit entrypoint covered
- render a focused `memory.jsonl` entries panel with kind chips, while tolerating older backend responses without `memory_entries`

## Validation
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/memory-subsystems.test.ts src/components/cognition-plane.test.ts src/cockpit-entrypoints.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint` (0 errors; existing unrelated unused-disable warnings)
- `pnpm --dir dashboard run build`
- `scripts/dune-local.sh build lib/masc_mcp.a`

## Browser Proof
- alias `#mode=cognition&tab=dc-mem` canonicalized to `#monitoring?mode=cognition&section=cognition&view=memory&focus=entries`
- direct `#monitoring?section=cognition&view=memory&focus=entries` rendered `[data-testid="memory-entries"]`
- desktop `1440x1000`: `scrollWidth == clientWidth == 1440`
- mobile `390x844`: `scrollWidth == clientWidth == 390`
- screenshots: `/tmp/masc-memory-entries-focus-0506.png`, `/tmp/masc-memory-entries-focus-mobile-0506.png`