### PR TITLE
fix(dashboard): cover ide core cockpit routes

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -9,6 +9,9 @@ import {
 import { sectionItemsForTab } from './config/navigation'
 
 describe('cockpit entrypoint registry', () => {
+  const coverageForAlias = (alias: string) =>
+    COCKPIT_ENTRYPOINTS.find(entrypoint => entrypoint.aliases.includes(alias))?.coverage
+
   it('keeps every prototype plane mode mapped to a production route', () => {
     expect(Object.keys(COCKPIT_MODE_TARGETS)).toEqual([
       'dashboard',
@@ -40,6 +43,14 @@ describe('cockpit entrypoint registry', () => {
   })
 
   it('resolves prototype subtabs to explicit live route homes', () => {
+    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'edit' })).toEqual({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+    })
+    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'split-diff' })).toEqual({
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'split-diff' },
+    })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-str' })).toEqual({
       tab: 'monitoring',
       params: { section: 'cognition', view: 'decisions' },
@@ -189,7 +200,6 @@ describe('cockpit entrypoint registry', () => {
       params: { section: 'runtime', view: 'inspector', focus: 'compare' },
     })
   })
-
   it('marks audit actor and summary entrypoints as covered runtime routes', () => {
     const byAlias = new Map(COCKPIT_ENTRYPOINTS.flatMap(entrypoint =>
       entrypoint.aliases.map(alias => [alias, entrypoint] as const),
@@ -203,5 +213,11 @@ describe('cockpit entrypoint registry', () => {
       coverage: 'covered',
       target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit', focus: 'summary' } },
     })
+  })
+
+  it('marks existing IDE source, split, and graph surfaces covered', () => {
+    expect(coverageForAlias('edit')).toBe('covered')
+    expect(coverageForAlias('split-diff')).toBe('covered')
+    expect(coverageForAlias('git-graph')).toBe('covered')
   })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -89,10 +89,10 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   { mode: 'cognition', aliases: ['ar-flw', 'ar-flow'], target: { tab: 'monitoring', params: { section: 'cognition', view: 'autoresearch', focus: 'flow' } }, coverage: 'covered' },
 
   // IDE Plane.
-  { mode: 'ide', aliases: ['edit', 'source'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['edit', 'source'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'covered' },
   { mode: 'ide', aliases: ['review', 'pr-thread'], target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } }, coverage: 'covered' },
-  { mode: 'ide', aliases: ['merge', 'split', 'split-diff'], target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } }, coverage: 'partial' },
-  { mode: 'ide', aliases: ['graph', 'git-graph'], target: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } }, coverage: 'partial' },
+  { mode: 'ide', aliases: ['merge', 'split', 'split-diff'], target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } }, coverage: 'covered' },
+  { mode: 'ide', aliases: ['graph', 'git-graph'], target: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } }, coverage: 'covered' },
   { mode: 'ide', aliases: ['search', 'find'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source', find: 'open' } }, coverage: 'covered' },
 ]
 

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -108,16 +108,24 @@ export function IdeEditor({
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--sp-3)',
+          flexWrap: 'wrap',
+          minWidth: 0,
           padding: 'var(--sp-2) var(--sp-3)',
           borderBottom: '1px solid var(--color-border-divider)',
           color: 'var(--color-fg-muted)',
           font: 'var(--type-eyebrow)',
         }}
       >
-        <span>${document.file_path}</span>
-        <span style=${{ color: 'var(--color-fg-disabled)' }}>${document.language}</span>
-        <span style=${{ color: 'var(--color-accent-fg)' }}>${VIEW_LABEL[activeView]}</span>
-        <span style=${{ marginLeft: 'auto' }}>
+        <span style=${{
+          minWidth: 0,
+          flex: '1 1 12rem',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}>${document.file_path}</span>
+        <span style=${{ color: 'var(--color-fg-disabled)', flexShrink: 0 }}>${document.language}</span>
+        <span style=${{ color: 'var(--color-accent-fg)', flexShrink: 0 }}>${VIEW_LABEL[activeView]}</span>
+        <span style=${{ marginLeft: 'auto', flexShrink: 0, whiteSpace: 'nowrap' }}>
           ${lines.length} lines · ownership · ${keepers.length} keepers · ${activeLayerKinds.length} layers
         </span>
         ${onFindOpen || onFindClose ? html`

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -289,7 +289,7 @@
 
 .ide-toolbar {
   display: grid;
-  grid-template-columns: max-content minmax(1rem, 1fr) max-content;
+  grid-template-columns: auto minmax(180px, 320px) 1fr auto;
   align-items: center;
   gap: var(--sp-3);
   padding: var(--sp-2) var(--sp-3);


### PR DESCRIPTION
## Summary
- Mark the existing IDE source, split-diff, and git graph cockpit entrypoints as covered.
- Add registry tests for IDE edit/split routing plus coverage state for edit, split-diff, and git-graph aliases.
- Move the IDE toolbar grid back under responsive CSS and keep tab/layer controls from shrinking so mobile split-diff does not clip labels.

## Validation
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/cockpit-entrypoints.test.ts src/components/ide/ide-shell.test.ts src/components/git-graph-panel.test.ts --no-file-parallelism --maxWorkers=1` (25 tests passed; existing localhost:3000 ECONNREFUSED/socket-hang-up noise, exit 0)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint` (0 errors; existing unused-disable warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- `pnpm --dir dashboard run build` (passed; existing Vite chunk/dynamic import warnings)

## Browser Evidence
- Desktop source alias canonicalized to `#code?mode=ide&section=ide-shell&view=source`, source editor rendered, no page overflow: `/tmp/masc-ide-source-core-0506.png`
- Desktop split alias canonicalized to `#code?mode=ide&section=ide-shell&view=split-diff`, split diff rendered, no page overflow: `/tmp/masc-ide-split-core-0506.png`
- Desktop git graph alias canonicalized to `#workspace?mode=ide&section=repositories&view=graph`, graph panel rendered, no page overflow: `/tmp/masc-ide-graph-core-0506.png`
- Mobile split-diff rendered with responsive toolbar/editor meta and no page overflow: `/tmp/masc-ide-split-core-mobile-0506.png`