### PR TITLE
fix(dashboard): add cockpit focus mode

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -40,6 +40,7 @@ import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DashboardStatusTray } from './components/status-tray'
+import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus-mode-toggle'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
 import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
@@ -225,14 +226,17 @@ export function App() {
   const currentSection = currentSectionForRoute(route.value)
   const isCodeSurface = currentTab === 'code'
   const widgetSoloMode = isWidgetSoloRoute(route.value)
+  const focusMode = dashboardFocusMode.value
+  const compactChromeMode = widgetSoloMode || focusMode
 
   return html`
     <div
       class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
       data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
+      data-focus-mode=${focusMode ? 'true' : 'false'}
     >
       <${SkipLink} />
-      <header class=${widgetSoloMode ? 'hidden' : 'relative z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5 backdrop-blur-xl'}>
+      <header class="${compactChromeMode ? 'hidden' : 'relative'} z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5 backdrop-blur-xl">
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--accent-15)] to-transparent"></div>
         <div class="flex w-full items-center justify-between gap-3 max-[1080px]:flex-col max-[1080px]:items-stretch">
           <div class="flex min-w-0 flex-1 items-center gap-3 max-[860px]:flex-wrap">
@@ -298,12 +302,14 @@ export function App() {
           </div>
         `
         : null}
-      <${Suspense} fallback=${null}>
-        <${LazyRemoteWarningBanner} />
-      <//>
+      ${focusMode ? null : html`
+        <${Suspense} fallback=${null}>
+          <${LazyRemoteWarningBanner} />
+        <//>
+      `}
 
-      <div class=${widgetSoloMode ? 'flex flex-1 overflow-hidden p-0' : 'flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col'}>
-        ${widgetSoloMode
+      <div class=${compactChromeMode ? 'flex flex-1 overflow-hidden p-0' : 'flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col'}>
+        ${compactChromeMode
           ? null
           : html`
             <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-y-auto overflow-x-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:w-full max-[1100px]:max-h-75 ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
@@ -311,8 +317,8 @@ export function App() {
             </aside>
           `}
 
-        <main id="main-content" tabindex=${-1} class=${widgetSoloMode ? 'min-w-0 flex-1 overflow-hidden bg-[var(--shell-main-bg)] backdrop-blur-lg' : 'min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0'}>
-          <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : 'h-full overflow-y-auto p-4'}>
+        <main id="main-content" tabindex=${-1} class=${compactChromeMode ? 'min-w-0 flex-1 overflow-hidden bg-[var(--shell-main-bg)] backdrop-blur-lg' : 'min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0'}>
+          <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : focusMode ? 'h-full overflow-y-auto p-3 max-[520px]:p-2' : 'h-full overflow-y-auto p-4'}>
             <${DashboardMain} />
           </div>
         </main>
@@ -325,6 +331,7 @@ export function App() {
         ? html`<${Suspense} fallback=${null}><${LazyTaskDetailOverlay} /><//>`
         : null}
       <${DashboardStatusTray} sideRailCollapsed=${sidebarCollapsed.value} />
+      <${DashboardFocusModeToggle} />
       <${ToastContainer} />
       <${ConfirmDialogOverlay} />
       <${Suspense} fallback=${null}>

--- a/dashboard/src/components/focus-mode-toggle.test.ts
+++ b/dashboard/src/components/focus-mode-toggle.test.ts
@@ -1,0 +1,71 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { useKeyboardShortcutHost } from '../../design-system/headless-preact/use-keyboard-shortcut'
+import { globalShortcutManager } from '../lib/global-shortcut-manager'
+import { DashboardFocusModeToggle, dashboardFocusMode } from './focus-mode-toggle'
+
+function FocusModeShortcutHarness() {
+  useKeyboardShortcutHost(globalShortcutManager)
+  return h(DashboardFocusModeToggle, {})
+}
+
+describe('DashboardFocusModeToggle', () => {
+  beforeEach(() => {
+    dashboardFocusMode.value = false
+    globalShortcutManager.unregisterAll('dashboard.focus-mode.')
+  })
+
+  afterEach(() => {
+    cleanup()
+    dashboardFocusMode.value = false
+    globalShortcutManager.unregisterAll('dashboard.focus-mode.')
+    vi.clearAllMocks()
+  })
+
+  it('toggles focus mode from the button', () => {
+    render(h(DashboardFocusModeToggle, {}))
+
+    const button = screen.getByTestId('dashboard-focus-mode-toggle')
+    expect(button).toHaveTextContent('Focus')
+    expect(button).toHaveAttribute('aria-pressed', 'false')
+    expect(button.getAttribute('title')).toContain('F11')
+    expect(button.getAttribute('title')).toContain('\\')
+    expect(button.getAttribute('aria-keyshortcuts')).toContain('F11')
+
+    fireEvent.click(button)
+
+    expect(dashboardFocusMode.value).toBe(true)
+    expect(button).toHaveTextContent('Exit')
+    expect(button).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('registers focus shortcuts on the global shortcut manager', () => {
+    render(h(DashboardFocusModeToggle, {}))
+
+    expect(globalShortcutManager.getById('dashboard.focus-mode.f11')).not.toBeUndefined()
+    expect(globalShortcutManager.getById('dashboard.focus-mode.mod-backslash')).not.toBeUndefined()
+  })
+
+  it('toggles focus mode through the global shortcut host and ignores editable targets', () => {
+    render(h(FocusModeShortcutHarness, {}))
+
+    fireEvent.keyDown(document, { key: 'F11' })
+    expect(dashboardFocusMode.value).toBe(true)
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    fireEvent.keyDown(input, { key: 'F11' })
+    expect(dashboardFocusMode.value).toBe(true)
+    input.remove()
+  })
+
+  it('toggles focus mode with the modifier-backslash chord', () => {
+    render(h(FocusModeShortcutHarness, {}))
+
+    fireEvent.keyDown(document, { key: '\\', metaKey: true, ctrlKey: true })
+
+    expect(dashboardFocusMode.value).toBe(true)
+  })
+})

--- a/dashboard/src/components/focus-mode-toggle.ts
+++ b/dashboard/src/components/focus-mode-toggle.ts
@@ -1,0 +1,60 @@
+import { html } from 'htm/preact'
+import { Maximize2, Minimize2 } from 'lucide-preact'
+import { useKeyboardShortcut } from '../../design-system/headless-preact/use-keyboard-shortcut'
+import { globalShortcutManager } from '../lib/global-shortcut-manager'
+import { persistentSignal } from '../lib/persistent-signal'
+import { ringFocusClasses } from './common/ring'
+
+export const dashboardFocusMode = persistentSignal<boolean>({
+  key: 'dashboard:focus-mode',
+  defaultValue: false,
+})
+
+function toggleFocusMode(): void {
+  dashboardFocusMode.value = !dashboardFocusMode.value
+}
+
+export function DashboardFocusModeToggle() {
+  const focusMode = dashboardFocusMode.value
+  const Icon = focusMode ? Minimize2 : Maximize2
+  const f11Shortcut = useKeyboardShortcut(
+    globalShortcutManager,
+    {
+      chord: { key: 'F11', modifiers: [] },
+      description: 'Toggle dashboard focus mode',
+      scope: 'global',
+      preserveInInputs: false,
+      action: toggleFocusMode,
+    },
+    'dashboard.focus-mode.f11',
+  )
+  const modBackslashShortcut = useKeyboardShortcut(
+    globalShortcutManager,
+    {
+      chord: { key: '\\', modifiers: ['Mod'] },
+      description: 'Toggle dashboard focus mode',
+      scope: 'global',
+      preserveInInputs: false,
+      action: toggleFocusMode,
+    },
+    'dashboard.focus-mode.mod-backslash',
+  )
+  const shortcutHint = `${f11Shortcut.display} or ${modBackslashShortcut.display}`
+  const ariaShortcutHint = `${f11Shortcut.aria} ${modBackslashShortcut.aria}`
+
+  return html`
+    <button
+      type="button"
+      class=${`fixed bottom-4 right-4 z-50 inline-flex h-9 items-center gap-2 rounded-[var(--r-1)] border border-solid px-3 text-xs font-semibold shadow-[var(--shadow-panel)] backdrop-blur-xl transition-colors max-[520px]:bottom-3 max-[520px]:right-3 ${focusMode ? 'border-[var(--brass-3)] bg-[var(--accent-22)] text-[var(--brass-1)]' : 'border-[var(--color-border-default)] bg-[var(--shell-header-bg)] text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]'} ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
+      title=${`Toggle focus mode (${shortcutHint})`}
+      aria-label=${`${focusMode ? 'Exit' : 'Enter'} dashboard focus mode (${shortcutHint})`}
+      aria-keyshortcuts=${ariaShortcutHint}
+      aria-pressed=${focusMode}
+      data-testid="dashboard-focus-mode-toggle"
+      onClick=${toggleFocusMode}
+    >
+      <${Icon} size=${15} aria-hidden="true" />
+      <span class="font-mono text-3xs uppercase leading-none tracking-[var(--track-caps)]">${focusMode ? 'Exit' : 'Focus'}</span>
+    </button>
+  `
+}


### PR DESCRIPTION
## Summary
- Adds a persistent dashboard focus-mode toggle inspired by the cockpit-kit FocusMode control.
- Collapses header, remote banner, and side rail so the active dashboard surface gets the viewport.
- Keeps an always-visible fixed Exit/Focus control and supports the F11 / Mod+\\ shortcut while ignoring editable targets.

## Validation
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/focus-mode-toggle.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint` (passes with existing 3 unused-disable warnings)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic-import/chunk-size warnings)

## Browser Proof
- Desktop 1440x1000: `/tmp/masc-focus-mode-0506.png`; focus mode hides header/side rail, no horizontal overflow.
- Mobile 390x844: `/tmp/masc-focus-mode-mobile-0506.png`; focus mode fills the viewport, no horizontal overflow, exit control remains visible.