### PR TITLE
fix(dashboard): add widget solo route

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -44,6 +44,7 @@ import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
 import { useKeeperPinShortcuts } from './components/ide/use-keeper-pin-shortcuts'
+import { isWidgetSoloRoute } from './components/widget-solo'
 
 // Sidebar collapsed state persists across reloads — a user who picks
 // the dense layout keeps it. Namespaced key avoids clashing with any
@@ -222,11 +223,15 @@ export function App() {
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
   const isCodeSurface = currentTab === 'code'
+  const widgetSoloMode = isWidgetSoloRoute(route.value)
 
   return html`
-    <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]">
+    <div
+      class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
+      data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
+    >
       <${SkipLink} />
-      <header class="relative z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5 backdrop-blur-xl">
+      <header class=${widgetSoloMode ? 'hidden' : 'relative z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5 backdrop-blur-xl'}>
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--accent-15)] to-transparent"></div>
         <div class="flex w-full items-center justify-between gap-3 max-[1080px]:flex-col max-[1080px]:items-stretch">
           <div class="flex min-w-0 flex-1 items-center gap-3 max-[860px]:flex-wrap">
@@ -277,17 +282,25 @@ export function App() {
         </div>
       </header>
 
-      <${Suspense} fallback=${null}>
-        <${LazyRemoteWarningBanner} />
-      <//>
+      ${widgetSoloMode
+        ? null
+        : html`
+          <${Suspense} fallback=${null}>
+            <${LazyRemoteWarningBanner} />
+          <//>
+        `}
 
-      <div class="flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col">
-        <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-y-auto overflow-x-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:w-full max-[1100px]:max-h-75 ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
-          <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
-        </aside>
+      <div class=${widgetSoloMode ? 'flex flex-1 overflow-hidden p-0' : 'flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col'}>
+        ${widgetSoloMode
+          ? null
+          : html`
+            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-y-auto overflow-x-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:w-full max-[1100px]:max-h-75 ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+              <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
+            </aside>
+          `}
 
-        <main id="main-content" tabindex=${-1} class="min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0">
-          <div class=${isCodeSurface ? 'h-full overflow-hidden p-0' : 'h-full overflow-y-auto p-4'}>
+        <main id="main-content" tabindex=${-1} class=${widgetSoloMode ? 'min-w-0 flex-1 overflow-hidden bg-[var(--shell-main-bg)] backdrop-blur-lg' : 'min-w-0 flex-1 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-main-bg)] backdrop-blur-lg max-[1100px]:min-h-0'}>
+          <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : 'h-full overflow-y-auto p-4'}>
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -283,12 +283,23 @@ export function App() {
       </header>
 
       ${widgetSoloMode
-        ? null
-        : html`
-          <${Suspense} fallback=${null}>
-            <${LazyRemoteWarningBanner} />
-          <//>
-        `}
+        ? html`
+          <div
+            class="flex shrink-0 flex-wrap items-center justify-end gap-2 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5"
+            data-testid="dashboard-widget-solo-auth-strip"
+            aria-label="Solo view auth and runtime status"
+          >
+            <${Suspense} fallback=${authStatusFallback()}>
+              <${LazyAuthStatus} />
+            <//>
+            <${ConnectionStatus} />
+            <${ErrorCounterBadge} />
+          </div>
+        `
+        : null}
+      <${Suspense} fallback=${null}>
+        <${LazyRemoteWarningBanner} />
+      <//>
 
       <div class=${widgetSoloMode ? 'flex flex-1 overflow-hidden p-0' : 'flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col'}>
         ${widgetSoloMode

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h, render } from 'preact'
+import { waitFor } from '@testing-library/preact'
+import { DashboardMain } from './dashboard-shell'
+import { route } from '../router'
+import { connected } from '../sse'
+import { dashboardLoading } from '../store'
+import { namespaceTruthInitializing } from '../namespace-truth-store'
+
+describe('DashboardMain solo mode', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    dashboardLoading.value = false
+    connected.value = true
+    namespaceTruthInitializing.value = false
+    document.title = 'MASC Dashboard'
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('keeps document title and active observability filters visible in solo mode', async () => {
+    route.value = {
+      tab: 'monitoring',
+      params: {
+        section: 'runtime',
+        view: 'cost',
+        solo: '1',
+        keeper: 'keeper-alpha',
+        range: '1h',
+      },
+      postId: null,
+    }
+
+    render(h(DashboardMain, {}), container)
+
+    await waitFor(() => expect(document.title).toBe('MASC · Cascade'))
+    expect(container.querySelector('[data-testid="dashboard-widget-solo-bar"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Active observability filters"]')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -21,6 +21,7 @@ import {
 } from '../config/navigation'
 import { ObservatoryFilterBar } from './common/observatory-filter-bar'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
+import { ExternalLink } from 'lucide-preact'
 import { ScrollToTopButton } from './common/scroll-to-top'
 import { CopyIdButton } from './common/copy-id-button'
 import { formatElapsedCompact } from '../lib/format-time'
@@ -31,6 +32,11 @@ import { ringFocusClasses } from './common/ring'
 import { SurfaceIcon } from './surface-icon'
 import { Breadcrumb, type BreadcrumbItem } from './common/breadcrumb'
 import { RouteLink } from './common/route-link'
+import {
+  isWidgetSoloRoute,
+  WidgetSoloBar,
+  widgetSoloUrlForRoute,
+} from './widget-solo'
 
 const buildIdentityOpen = signal(false)
 
@@ -673,6 +679,7 @@ function SurfaceLead() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
+  const soloUrl = widgetSoloUrlForRoute(route.value)
 
   const description = currentSection?.description ?? currentView?.description ?? null
   const title = currentSection?.label ?? currentView?.label ?? 'Home'
@@ -713,6 +720,17 @@ function SurfaceLead() {
               size=${14}
             />`
           : null}
+        <a
+          href=${soloUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class=${`inline-flex size-7 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
+          title="Open this surface in a solo view"
+          aria-label="Open this surface in a solo view"
+          data-testid="dashboard-widget-solo-link"
+        >
+          <${ExternalLink} size=${14} aria-hidden="true" />
+        </a>
       </div>
       ${description ? html`<p class="m-0 max-w-[72rem] text-xs leading-[var(--lh-body)] text-[var(--color-fg-muted)]">${description}</p>` : null}
     </div>
@@ -725,6 +743,7 @@ export function DashboardMain() {
   }
 
   const routeLabel = dashboardRouteBoundaryKey(route.value)
+  const soloMode = isWidgetSoloRoute(route.value)
   const immersiveSurface = route.value.tab === 'code'
   const warmingBanner = namespaceTruthInitializing.value ? html`
     <div class=${immersiveSurface
@@ -733,6 +752,26 @@ export function DashboardMain() {
       Server data warming; this view will refresh automatically.
     </div>
   ` : null
+
+  if (soloMode) {
+    const soloBodyClass = route.value.tab === 'code'
+      ? 'min-h-0 flex-1 overflow-hidden'
+      : 'min-h-0 flex-1 overflow-y-auto p-3 max-[520px]:p-2'
+
+    return html`
+      <div class="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] bg-[var(--color-bg-page)]">
+        <${WidgetSoloBar} routeState=${route.value} />
+        <div class=${soloBodyClass}>
+          ${warmingBanner}
+          <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
+            <div class=${route.value.tab === 'code' ? 'h-full min-h-0 overflow-hidden' : 'animate-in fade-in slide-in-from-bottom-2 duration-[var(--t-slow)] fill-mode-both'}>
+              <${TabContent} />
+            </div>
+          <//>
+        </div>
+      </div>
+    `
+  }
 
   if (immersiveSurface) {
     return html`

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -674,6 +674,15 @@ function composeDocumentTitle(
   return `MASC · ${leaf}`
 }
 
+function useSurfaceDocumentTitle(): void {
+  const currentTab = route.value.tab
+  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
+  const currentSection = currentSectionForRoute(route.value)
+
+  useEffect(() => {
+    document.title = composeDocumentTitle(currentView?.label ?? null, currentSection?.label ?? null)
+  }, [currentView?.label, currentSection?.label])
+}
 
 function SurfaceLead() {
   const currentTab = route.value.tab
@@ -690,13 +699,6 @@ function SurfaceLead() {
   const trail = currentSection !== null
     ? deriveBreadcrumbTrail(currentView?.label ?? null, currentSection.label, currentTab)
     : []
-
-  // Sync document.title — syncing to an external system (the browser
-  // tab title) is a legitimate useEffect. Keyed on the two labels so
-  // the effect only re-runs on actual navigation, not every render.
-  useEffect(() => {
-    document.title = composeDocumentTitle(currentView?.label ?? null, currentSection?.label ?? null)
-  }, [currentView?.label, currentSection?.label])
 
   return html`
     <div class="mb-3 flex flex-col gap-1.5">
@@ -738,6 +740,8 @@ function SurfaceLead() {
 }
 
 export function DashboardMain() {
+  useSurfaceDocumentTitle()
+
   if (dashboardLoading.value && !connected.value && !namespaceTruthInitializing.value) {
     return html`<${LoadingState}>Loading dashboard...<//>`
   }
@@ -759,8 +763,9 @@ export function DashboardMain() {
       : 'min-h-0 flex-1 overflow-y-auto p-3 max-[520px]:p-2'
 
     return html`
-      <div class="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] bg-[var(--color-bg-page)]">
+      <div class="grid h-full min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] bg-[var(--color-bg-page)]">
         <${WidgetSoloBar} routeState=${route.value} />
+        <${ObservatoryFilterBar} />
         <div class=${soloBodyClass}>
           ${warmingBanner}
           <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>

--- a/dashboard/src/components/widget-solo.test.ts
+++ b/dashboard/src/components/widget-solo.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { h, render } from 'preact'
+import type { RouteState } from '../types'
+import {
+  isWidgetSoloRoute,
+  WidgetSoloBar,
+  widgetSoloExitHashForRoute,
+  widgetSoloHashForRoute,
+  widgetSoloLabelForRoute,
+  widgetSoloUrlForRoute,
+  withWidgetSoloParam,
+  withoutWidgetSoloParam,
+} from './widget-solo'
+
+function routeState(params: Record<string, string> = {}): RouteState {
+  return {
+    tab: 'monitoring',
+    params,
+    postId: null,
+  }
+}
+
+describe('widget solo routing', () => {
+  it('sets and detects the solo route param without dropping existing params', () => {
+    const params = withWidgetSoloParam({ section: 'runtime', view: 'cost' })
+
+    expect(params).toEqual({ section: 'runtime', view: 'cost', solo: '1' })
+    expect(isWidgetSoloRoute(routeState(params))).toBe(true)
+  })
+
+  it('removes only the solo route param for the exit link', () => {
+    const params = withoutWidgetSoloParam({ section: 'runtime', view: 'cost', solo: '1' })
+
+    expect(params).toEqual({ section: 'runtime', view: 'cost' })
+    expect(isWidgetSoloRoute(routeState(params))).toBe(false)
+  })
+
+  it('builds solo and exit hashes for the current dashboard surface', () => {
+    const route = routeState({ section: 'runtime', view: 'cost' })
+
+    expect(widgetSoloHashForRoute(route)).toBe('#monitoring?section=runtime&view=cost&solo=1')
+    expect(widgetSoloExitHashForRoute({ ...route, params: { ...route.params, solo: '1' } }))
+      .toBe('#monitoring?section=runtime&view=cost')
+  })
+
+  it('preserves the current dashboard pathname and query when building a popout url', () => {
+    const route = routeState({ section: 'runtime', view: 'cost' })
+
+    expect(widgetSoloUrlForRoute(route, { pathname: '/dashboard/', search: '?theme=paper' }))
+      .toBe('/dashboard/?theme=paper#monitoring?section=runtime&view=cost&solo=1')
+  })
+
+  it('labels the solo surface from the active section and view', () => {
+    expect(widgetSoloLabelForRoute(routeState({ section: 'runtime', view: 'cost' }))).toEqual({
+      title: 'Cascade',
+      id: 'monitoring:runtime:cost',
+    })
+  })
+
+  it('renders a compact solo bar with an exit route back to the full dashboard', () => {
+    const container = document.createElement('div')
+    render(h(WidgetSoloBar, {
+      routeState: routeState({ section: 'runtime', view: 'cost', solo: '1' }),
+    }), container)
+
+    const bar = container.querySelector('[data-testid="dashboard-widget-solo-bar"]')
+    const exit = container.querySelector('a[aria-label="Return to full dashboard"]')
+
+    expect(bar?.textContent).toContain('Cascade')
+    expect(bar?.textContent).toContain('monitoring:runtime:cost')
+    expect(exit?.getAttribute('href')).toBe('#monitoring?section=runtime&view=cost')
+  })
+})

--- a/dashboard/src/components/widget-solo.ts
+++ b/dashboard/src/components/widget-solo.ts
@@ -1,0 +1,78 @@
+import { html } from 'htm/preact'
+import type { RouteState } from '../types'
+import { hashForRoute } from '../router'
+import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from '../config/navigation'
+import { RouteLink } from './common/route-link'
+import { ringFocusClasses } from './common/ring'
+
+export const WIDGET_SOLO_PARAM = 'solo'
+
+interface LocationLike {
+  pathname: string
+  search: string
+}
+
+export function isWidgetSoloRoute(routeState: Pick<RouteState, 'params'>): boolean {
+  return routeState.params[WIDGET_SOLO_PARAM] === '1'
+}
+
+export function withWidgetSoloParam(params: Record<string, string>): Record<string, string> {
+  return { ...params, [WIDGET_SOLO_PARAM]: '1' }
+}
+
+export function withoutWidgetSoloParam(params: Record<string, string>): Record<string, string> {
+  const next = { ...params }
+  delete next[WIDGET_SOLO_PARAM]
+  return next
+}
+
+export function widgetSoloHashForRoute(routeState: RouteState): string {
+  return hashForRoute(routeState.tab, withWidgetSoloParam(routeState.params))
+}
+
+export function widgetSoloExitHashForRoute(routeState: RouteState): string {
+  return hashForRoute(routeState.tab, withoutWidgetSoloParam(routeState.params))
+}
+
+export function widgetSoloUrlForRoute(
+  routeState: RouteState,
+  locationLike: LocationLike = window.location,
+): string {
+  return `${locationLike.pathname}${locationLike.search}${widgetSoloHashForRoute(routeState)}`
+}
+
+export function widgetSoloLabelForRoute(routeState: RouteState): { title: string; id: string } {
+  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === routeState.tab)
+  const currentSection = currentSectionForRoute(routeState)
+  const title = currentSection?.label ?? currentView?.label ?? routeState.tab
+  const idParts = [
+    routeState.tab,
+    currentSection?.id,
+    routeState.params.view,
+  ].filter(Boolean)
+  return { title, id: idParts.join(':') }
+}
+
+export function WidgetSoloBar({ routeState }: { routeState: RouteState }) {
+  const label = widgetSoloLabelForRoute(routeState)
+
+  return html`
+    <div
+      class="flex h-9 shrink-0 items-center gap-3 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 font-mono text-xs text-[var(--color-fg-muted)]"
+      data-testid="dashboard-widget-solo-bar"
+    >
+      <span class="size-2 shrink-0 rounded-full bg-[var(--brass-1)] shadow-[0_0_8px_rgb(var(--accent-glow)/0.5)]" aria-hidden="true"></span>
+      <span class="min-w-0 truncate font-semibold text-[var(--color-fg-secondary)]">${label.title}</span>
+      <span class="shrink-0 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-3xs uppercase text-[var(--color-fg-muted)] max-[520px]:hidden">${label.id}</span>
+      <span class="flex-1"></span>
+      <${RouteLink}
+        tab=${routeState.tab}
+        params=${withoutWidgetSoloParam(routeState.params)}
+        class=${`inline-flex h-6 shrink-0 items-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 text-3xs uppercase text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
+        aria-label="Return to full dashboard"
+      >
+        Full dashboard
+      <//>
+    </div>
+  `
+}


### PR DESCRIPTION
## Summary
- add a `solo=1` dashboard route mode that removes global shell chrome and renders the current surface as a focused widget view
- add a surface popout link next to the copy-link action so operators can open the current surface in a new solo tab
- add route helper coverage for solo URL/hash generation, exit hashes, labels, and the solo bar render path

## Why it matters
This ports the cockpit-kit `WidgetSolo` affordance into the live dashboard: any cockpit surface can be isolated for a wallboard, split-screen, or browser popout without carrying the full dashboard header and rail.

## Validation
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/widget-solo.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint` (passes with existing 3 unused-disable warnings)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic-import/chunk-size warnings)

## Browser proof
- Desktop 1440x1000: `/tmp/masc-widget-solo-0506.png`
- Mobile 390x844: `/tmp/masc-widget-solo-mobile-0506.png`
- Verified normal `#overview` exposes the popout link, direct `#overview?solo=1` sets `data-widget-solo="true"`, hides the header, removes `#dashboard-side-rail`, keeps the solo bar visible, has no horizontal overflow, and exits back to `#overview`.