### PR TITLE
fix(dashboard): add IDE rail toggle

### DIFF
--- a/dashboard/src/components/common/command-palette.test.ts
+++ b/dashboard/src/components/common/command-palette.test.ts
@@ -8,13 +8,14 @@ const navigate = vi.fn()
 const requestConfirm = vi.fn()
 const runGarbageCollection = vi.fn().mockResolvedValue(undefined)
 const cleanupZombies = vi.fn().mockResolvedValue(undefined)
+const route = signal<any>({ tab: 'code', params: { section: 'ide-shell' }, postId: null })
 const missionSnapshot = signal<any>(null)
 const missionAgentBriefs = signal<any[]>([])
 const missionKeeperBriefs = signal<any[]>([])
 
 async function loadPalette() {
   vi.resetModules()
-  vi.doMock('../../router', () => ({ navigate }))
+  vi.doMock('../../router', () => ({ navigate, route }))
   vi.doMock('./confirm-dialog', () => ({ requestConfirm }))
   vi.doMock('../flow-control/flow-control-state', () => ({
     cleanupZombies,
@@ -37,6 +38,7 @@ describe('CommandPalette', () => {
     missionSnapshot.value = null
     missionAgentBriefs.value = []
     missionKeeperBriefs.value = []
+    route.value = { tab: 'code', params: { section: 'ide-shell' }, postId: null }
   })
 
   afterEach(() => {
@@ -74,6 +76,36 @@ describe('CommandPalette', () => {
     overview?.handler()
 
     expect(navigate).toHaveBeenCalledWith('overview')
+  })
+
+  it('registers a global IDE rails toggle command', async () => {
+    const { CommandPalette } = await loadPalette()
+
+    render(html`<${CommandPalette} />`, container)
+    await waitFor(() => {
+      const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+        data?: Array<{ id: string; title: string; handler: () => void }>
+      }) | null
+      expect(palette?.data?.some((item) => item.id === 'ide-toggle-rails')).toBe(true)
+    })
+
+    const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+      data?: Array<{ id: string; title: string; handler: () => void }>
+    }) | null
+
+    const toggle = palette?.data?.find((item) => item.id === 'ide-toggle-rails')
+    expect(toggle?.title).toContain('숨기기')
+    toggle?.handler()
+    expect(navigate).toHaveBeenCalledWith('code', { section: 'ide-shell', rails: 'hidden' })
+
+    route.value = { tab: 'code', params: { section: 'ide-shell', rails: 'hidden' }, postId: null }
+    render(html`<${CommandPalette} />`, container)
+    await waitFor(() => {
+      const updated = container.querySelector('ninja-keys') as (HTMLElement & {
+        data?: Array<{ id: string; title: string; handler: () => void }>
+      }) | null
+      expect(updated?.data?.find((item) => item.id === 'ide-toggle-rails')?.title).toContain('보이기')
+    })
   })
 
   it('runs maintenance actions only after confirmation', async () => {

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
-import { navigate } from '../../router'
+import { navigate, route } from '../../router'
 import { requestConfirm } from './confirm-dialog'
 import { runGarbageCollection, cleanupZombies } from '../flow-control/flow-control-state'
 import { missionSnapshot, missionAgentBriefs, missionKeeperBriefs } from '../../mission-signals'
@@ -105,6 +105,21 @@ export function CommandPalette() {
         handler: () => navigate('logs')
       },
       {
+        id: 'ide-toggle-rails',
+        title: route.value.params.rails === 'hidden' ? 'IDE rails 보이기' : 'IDE rails 숨기기',
+        section: 'IDE',
+        keywords: 'code ide rails layout conversation activity toggle',
+        handler: () => {
+          const next: Record<string, string> = { ...route.value.params, section: 'ide-shell' }
+          if (next.rails === 'hidden') {
+            delete next.rails
+          } else {
+            next.rails = 'hidden'
+          }
+          navigate('code', next)
+        }
+      },
+      {
         id: 'action-gc',
         title: '유지보수: GC (Garbage Collection) 실행',
         section: 'System Ops',
@@ -158,7 +173,7 @@ export function CommandPalette() {
 
     ref.current.data = [...baseActions, ...agentActions, ...keeperActions, ...sessionActions]
 
-  }, [ready, missionSnapshot.value, missionAgentBriefs.value, missionKeeperBriefs.value])
+  }, [ready, route.value, missionSnapshot.value, missionAgentBriefs.value, missionKeeperBriefs.value])
 
   if (!ready) return null
 

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -300,6 +300,24 @@ describe('IdeShell', () => {
     expect(route.value.params.layers).toBe('cascade')
   })
 
+  it('runs the rails command from the IDE command bar', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    const input = ideCommandInput(container)
+    input.value = 'rails'
+    fireEvent.input(input)
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull())
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(route.value.params.rails).toBe('hidden')
+    expect(buttonByText(container, 'Rails').getAttribute('aria-pressed')).toBe('true')
+  })
+
   it('opens the terminal route from the IDE command bar', async () => {
     route.value = {
       tab: 'code',
@@ -368,6 +386,39 @@ describe('IdeShell', () => {
     expect(container.textContent).toContain('BRANCH GRAPH')
     await waitFor(() => expect(container.textContent).toContain('masc-mcp'))
     expect(container.textContent).toContain('main')
+  })
+
+  it('hydrates collapsed IDE rails from the route', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'split-diff', rails: 'hidden' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    expect(container.querySelector('.ide-plane-shell')?.getAttribute('data-rails-collapsed')).toBe('true')
+    expect(container.querySelector('.ide-plane-conversation')).toBeNull()
+    expect(container.querySelector('.ide-plane-activity')).toBeNull()
+    expect(buttonByText(container, 'Rails').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('toggles IDE rails through the toolbar and persists the route param', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const railsButton = buttonByText(container, 'Rails')
+    expect(railsButton.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.click(railsButton)
+    expect(route.value.params.rails).toBe('hidden')
+    expect(container.querySelector('.ide-plane-shell')?.getAttribute('data-rails-collapsed')).toBe('true')
+    fireEvent.click(buttonByText(container, 'Rails'))
+    expect(route.value.params.rails).toBeUndefined()
   })
 
   it('hydrates cascade layer button from the ?layers=cascade URL param', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -82,6 +82,20 @@ function paramsWithLayers(
   return next
 }
 
+function paramsWithRails(
+  params: Record<string, string>,
+  view: ViewTab,
+  collapsed: boolean,
+): Record<string, string> {
+  const next: Record<string, string> = { ...params, section: 'ide-shell', view }
+  if (collapsed) {
+    next.rails = 'hidden'
+  } else {
+    delete next.rails
+  }
+  return next
+}
+
 export function IdeShell() {
   const coordinator = useMemo(() => createIdeDataCoordinator(), [])
 
@@ -96,6 +110,7 @@ export function IdeShell() {
     || Boolean(route.value.params.keeper?.trim())
   const findOpen = route.value.params.find === 'open'
   const terminalKeeper = keeperFromRoute()
+  const railsCollapsed = route.value.params.rails === 'hidden'
 
   useEffect(() => {
     const next = viewFromRoute(route.value.params.view)
@@ -114,6 +129,10 @@ export function IdeShell() {
 
   const handleLayersChange = (nextLayers: ReadonlySet<string>) => {
     navigate('code', paramsWithLayers(route.value.params, activeView, nextLayers))
+  }
+
+  const handleRailsToggle = () => {
+    navigate('code', paramsWithRails(route.value.params, activeView, !railsCollapsed))
   }
 
   const handleTerminalOpen = () => {
@@ -152,6 +171,7 @@ export function IdeShell() {
       role="region"
       aria-label="Code IDE shell"
       data-terminal-open=${terminalOpen ? 'true' : 'false'}
+      data-rails-collapsed=${railsCollapsed ? 'true' : 'false'}
     >
       <header
         class="ide-plane-statusbar"
@@ -170,6 +190,8 @@ export function IdeShell() {
         activeLayers=${activeLayers}
         onViewChange=${handleViewChange}
         onLayersChange=${handleLayersChange}
+        railsCollapsed=${railsCollapsed}
+        onRailsToggle=${handleRailsToggle}
         onTerminalOpen=${handleTerminalOpen}
         onFindOpen=${handleFindOpen}
       />
@@ -208,27 +230,35 @@ export function IdeShell() {
           />
           <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />
         </div>
-        <div
-          class="ide-plane-conversation"
-          style=${{
-            display: 'grid',
-            gridTemplateRows: 'auto auto auto auto 1fr',
-            minHeight: 0,
-            overflow: 'auto',
-          }}
-        >
-          <${IdeBranchContextPanel}
-            activeRepositoryId=${coordinator.activeRepositoryId}
-            subscribeActiveRepositoryId=${coordinator.subscribeActiveRepositoryId}
-          />
-          <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
-          <${IdePersistencePanel} keeperName=${terminalKeeper} />
-          <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
-          <${IdeConversationRailMock} />
-        </div>
-        <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
-          <${IdeActivityMock} />
-        </div>
+        ${railsCollapsed
+          ? null
+          : html`
+            <div
+              class="ide-plane-conversation"
+              style=${{
+                display: 'grid',
+                gridTemplateRows: 'auto auto auto auto 1fr',
+                minHeight: 0,
+                overflow: 'auto',
+              }}
+            >
+              <${IdeBranchContextPanel}
+                activeRepositoryId=${coordinator.activeRepositoryId}
+                subscribeActiveRepositoryId=${coordinator.subscribeActiveRepositoryId}
+              />
+              <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
+              <${IdePersistencePanel} keeperName=${terminalKeeper} />
+              <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
+              <${IdeConversationRailMock} />
+            </div>
+          `}
+        ${railsCollapsed
+          ? null
+          : html`
+            <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
+              <${IdeActivityMock} />
+            </div>
+          `}
       </div>
       ${terminalOpen
         ? html`<${KeeperShellDrawer} keeperName=${terminalKeeper} />`

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
+import { PanelRightClose, PanelRightOpen } from 'lucide-preact'
 import {
   createLayeredOverlay,
   type OverlayLayer,
@@ -47,6 +48,8 @@ interface IdeToolbarProps {
   readonly activeLayers: ReadonlySet<string>
   readonly onViewChange: (id: ViewTab) => void
   readonly onLayersChange: (active: ReadonlySet<string>) => void
+  readonly railsCollapsed?: boolean
+  readonly onRailsToggle?: () => void
   readonly onTerminalOpen?: () => void
   readonly onFindOpen?: () => void
 }
@@ -56,6 +59,8 @@ export function IdeToolbar({
   activeLayers,
   onViewChange,
   onLayersChange,
+  railsCollapsed = false,
+  onRailsToggle,
   onTerminalOpen,
   onFindOpen,
 }: IdeToolbarProps) {
@@ -88,6 +93,14 @@ export function IdeToolbar({
       keywords: `toggle ${layer.kind} ${layer.description}`,
       handler: () => handleLayerToggle(layer.kind),
     })),
+    ...(onRailsToggle
+      ? [{
+          id: 'rail-toggle',
+          title: railsCollapsed ? 'Show IDE rails' : 'Hide IDE rails',
+          keywords: 'rails inspector activity conversation layout wide center',
+          handler: onRailsToggle,
+        }]
+      : []),
     ...(onTerminalOpen
       ? [{
           id: 'terminal-open',
@@ -111,7 +124,8 @@ export function IdeToolbar({
       role="toolbar"
       aria-label="IDE editor toolbar"
       data-testid="ide-toolbar"
-      class="ide-toolbar grid min-w-0 grid-cols-1 items-center gap-2 border-b border-[var(--color-border-divider)] bg-[var(--color-bg-surface)] px-3 py-2 lg:grid-cols-[minmax(0,max-content)_minmax(12rem,16rem)_minmax(0,1fr)]"
+      class="ide-toolbar"
+      data-has-rails=${onRailsToggle ? 'true' : 'false'}
     >
       <div
         class="ide-toolbar-tabs flex min-w-0 gap-1.5 overflow-x-auto pb-0.5"
@@ -143,6 +157,36 @@ export function IdeToolbar({
         className="min-w-0"
         inputClassName="h-7 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] outline-none transition-colors placeholder:text-[var(--color-fg-disabled)] focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]"
       />
+      ${onRailsToggle ? html`
+        <button
+          type="button"
+          aria-pressed=${railsCollapsed ? 'true' : 'false'}
+          onClick=${onRailsToggle}
+          title=${railsCollapsed ? 'Show IDE rails' : 'Hide IDE rails'}
+          style=${{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 'var(--sp-1)',
+            minWidth: '4rem',
+            height: '26px',
+            padding: '2px 8px',
+            background: railsCollapsed ? 'var(--color-bg-elevated)' : 'transparent',
+            color: railsCollapsed ? 'var(--color-accent-fg)' : 'var(--color-fg-secondary)',
+            border: '1px solid',
+            borderColor: railsCollapsed ? 'var(--color-accent-fg)' : 'var(--color-border-default)',
+            borderRadius: 'var(--r-1)',
+            font: 'var(--type-body)',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          ${railsCollapsed
+            ? html`<${PanelRightOpen} size=${13} aria-hidden="true" />`
+            : html`<${PanelRightClose} size=${13} aria-hidden="true" />`}
+          <span>Rails</span>
+        </button>
+      ` : null}
       <div
         aria-label="Layers (multi-select)"
         data-testid="ide-toolbar-layers"

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -299,6 +299,10 @@
   overflow: hidden;
 }
 
+.ide-toolbar[data-has-rails="true"] {
+  grid-template-columns: max-content minmax(1rem, 1fr) max-content max-content;
+}
+
 .ide-toolbar-tabs,
 .ide-toolbar-layers {
   min-width: 0;
@@ -453,6 +457,21 @@
   min-height: 0;
   overflow: hidden;
   border-top: 1px solid var(--color-border-divider);
+}
+
+.ide-plane-shell[data-rails-collapsed="true"] .ide-plane-grid {
+  grid-template-columns: minmax(200px, 260px) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.ide-plane-shell[data-rails-collapsed="true"] .ide-plane-tree {
+  grid-row: 1;
+}
+
+.ide-plane-shell[data-rails-collapsed="true"] .ide-plane-editor {
+  grid-column: 2;
+  grid-row: 1;
+  border-right: 0;
 }
 
 .ide-branch-context {
@@ -1000,7 +1019,8 @@
 }
 
 @media (max-width: 1180px) {
-  .ide-toolbar {
+  .ide-toolbar,
+  .ide-toolbar[data-has-rails="true"] {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -1023,6 +1043,17 @@
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: minmax(10rem, 18rem) minmax(26rem, 1fr) minmax(12rem, 18rem) minmax(10rem, 16rem);
     overflow: auto;
+  }
+
+  .ide-plane-shell[data-rails-collapsed="true"] .ide-plane-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(10rem, 18rem) minmax(26rem, 1fr);
+  }
+
+  .ide-plane-shell[data-rails-collapsed="true"] .ide-plane-tree,
+  .ide-plane-shell[data-rails-collapsed="true"] .ide-plane-editor {
+    grid-column: 1;
+    grid-row: auto;
   }
 
   .ide-plane-tree,
@@ -1102,7 +1133,8 @@
     margin-left: 0;
   }
 
-  .ide-toolbar {
+  .ide-toolbar,
+  .ide-toolbar[data-has-rails="true"] {
     grid-template-columns: minmax(0, 1fr);
     gap: var(--sp-2);
     overflow: hidden;


### PR DESCRIPTION
## Summary
- add a persisted `rails=hidden` route state for the Code IDE shell
- add a toolbar Rails toggle and command-palette action to hide/show the conversation, BDI, persistence, and activity rails
- expand the editor into the freed space on desktop while stacking tree/editor cleanly on mobile

## Why it matters
This gives operators a wide-center IDE view for code reading and diff inspection without losing a shareable route back to that layout. Browser proof caught and fixed a toolbar hit-target overlap, then verified the mobile hidden-rails grid does not push the editor offscreen.

## Validation
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/ide/ide-shell.test.ts` (13 passed; existing localhost:3000 fetch noise from the suite)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint` (0 errors, existing 3 unused-disable warnings)
- `pnpm --dir dashboard run build` (passes; existing Vite dynamic-import/chunk-size warnings)

## Browser proof
- Desktop 1440x1000 hidden rails: no body overflow, no command/Rails overlap, editor width 916px, screenshot `/tmp/masc-ide-rails-hidden-0506.png`
- Mobile 390x844 hidden rails: one 352px grid column, editor width 352px, no body overflow, screenshot `/tmp/masc-ide-rails-hidden-mobile-0506.png`