### PR TITLE
fix(dashboard): add overview fleet ticker

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -8,6 +8,7 @@ import {
   severityToneClass,
   deriveAgentAlerts,
   deriveTaskAlerts,
+  deriveFleetTickerEvents,
   type FunnelCounts,
 } from './overview'
 
@@ -16,7 +17,7 @@ function segPct(counts: FunnelCounts, key: 'created' | 'inProgress' | 'awaiting'
   const total = counts.created + counts.inProgress + counts.awaiting + counts.completed
   return total > 0 ? (counts[key] / total) * 100 : 0
 }
-import type { Agent, Task, Keeper } from '../../types/core'
+import type { Agent, Task, Keeper, Message, BoardPost } from '../../types/core'
 import type {
   DashboardMissionResponse,
   DashboardMissionSessionCard,
@@ -55,6 +56,26 @@ function makeTask(partial: Partial<Task>): Task {
 
 function makeKeeper(partial: Partial<Keeper>): Keeper {
   return { name: 'k', status: 'active', ...partial }
+}
+
+function makeMessage(partial: Partial<Message>): Message {
+  return { id: 'm-1', content: 'message', ...partial }
+}
+
+function makeBoardPost(partial: Partial<BoardPost>): BoardPost {
+  return {
+    id: 'p-1',
+    author: 'keeper',
+    title: 'post',
+    body: 'body',
+    content: 'content',
+    tags: [],
+    votes: 0,
+    comment_count: 0,
+    created_at: localIsoAt(1),
+    updated_at: localIsoAt(1),
+    ...partial,
+  }
 }
 
 describe('computeFunnelCounts', () => {
@@ -246,6 +267,53 @@ describe('pickActiveKeepers', () => {
       makeKeeper({ name: `k${i}`, last_heartbeat: `2026-04-18T0${i}:00:00+09:00` }),
     )
     expect(pickActiveKeepers(keepers, 2)).toHaveLength(2)
+  })
+})
+
+describe('deriveFleetTickerEvents', () => {
+  it('combines recent task, message, board, and keeper events in newest-first order', () => {
+    const events = deriveFleetTickerEvents({
+      taskList: [makeTask({ id: 'task-old', title: 'Old task', updated_at: localIsoAt(1), status: 'in_progress' })],
+      messageList: [makeMessage({ id: 'msg-new', from: 'sangsu', content: 'new message', timestamp: localIsoAt(4) })],
+      boardPostList: [makeBoardPost({ id: 'post-mid', title: 'Board post', updated_at: localIsoAt(3), created_at: localIsoAt(2) })],
+      keeperList: [makeKeeper({ name: 'keeper-mid', last_heartbeat: localIsoAt(2), status: 'active' })],
+    })
+
+    expect(events.map(event => event.id)).toEqual([
+      'message:msg-new',
+      'board:post-mid',
+      'keeper:keeper-mid',
+      'task:task-old',
+    ])
+  })
+
+  it('drops events without valid timestamps or readable text', () => {
+    const events = deriveFleetTickerEvents({
+      taskList: [makeTask({ id: 'bad-task', title: 'Bad', updated_at: 'not-a-date' })],
+      messageList: [makeMessage({ id: 'blank-message', content: '   ', timestamp: localIsoAt(4) })],
+      boardPostList: [makeBoardPost({ id: 'blank-post', title: '', body: '', content: '', updated_at: localIsoAt(3) })],
+      keeperList: [makeKeeper({ name: 'no-heartbeat' })],
+    })
+
+    expect(events).toEqual([])
+  })
+
+  it('limits output and maps operational tones', () => {
+    const events = deriveFleetTickerEvents({
+      max: 2,
+      taskList: [
+        makeTask({ id: 'done', title: 'Done task', updated_at: localIsoAt(4), status: 'done' }),
+        makeTask({ id: 'verify', title: 'Verify task', updated_at: localIsoAt(3), status: 'awaiting_verification' }),
+        makeTask({ id: 'cancelled', title: 'Cancelled task', updated_at: localIsoAt(2), status: 'cancelled' }),
+      ],
+      messageList: [],
+      boardPostList: [],
+      keeperList: [],
+    })
+
+    expect(events).toHaveLength(2)
+    expect(events.map(event => event.id)).toEqual(['task:done', 'task:verify'])
+    expect(events.map(event => event.tone)).toEqual(['ok', 'warn'])
   })
 })
 

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -298,6 +298,29 @@ describe('deriveFleetTickerEvents', () => {
     expect(events).toEqual([])
   })
 
+  it('uses trimmed board content fallback when title or author is whitespace', () => {
+    const events = deriveFleetTickerEvents({
+      taskList: [],
+      messageList: [],
+      boardPostList: [
+        makeBoardPost({
+          id: 'post-whitespace-title',
+          author: '   ',
+          title: '   ',
+          content: '  usable content  ',
+          body: 'body fallback',
+          updated_at: localIsoAt(3),
+        }),
+      ],
+      keeperList: [],
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]?.id).toBe('board:post-whitespace-title')
+    expect(events[0]?.actor).toBe('board')
+    expect(events[0]?.text).toBe('usable content')
+  })
+
   it('limits output and maps operational tones', () => {
     const events = deriveFleetTickerEvents({
       max: 2,

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -19,8 +19,8 @@ import { KpiStripIsland } from '../kpi-strip-island'
 import { LifelineBar } from '../lifeline-bar'
 import { AgentAvatar } from './agent-avatar'
 import { missionSnapshot } from '../../mission-store'
-import { agents, tasks, keepers } from '../../store'
-import type { Agent, Task, Keeper } from '../../types/core'
+import { agents, tasks, keepers, messages, boardPosts } from '../../store'
+import type { Agent, Task, Keeper, Message, BoardPost } from '../../types/core'
 import type {
   DashboardMissionResponse,
   DashboardMissionSessionCard,
@@ -90,6 +90,185 @@ export function severityToneClass(severity?: string | null): string {
     default:
       return 'text-[var(--color-fg-muted)]'
   }
+}
+
+// ─── Fleet ticker ───────────────────────────────────────────────────────────
+
+export type FleetTickerKind = 'task' | 'message' | 'board' | 'keeper'
+
+export interface FleetTickerEvent {
+  id: string
+  timestamp: string
+  timestampMs: number
+  actor: string
+  label: string
+  text: string
+  kind: FleetTickerKind
+  tone: 'ok' | 'warn' | 'err' | 'info' | 'idle'
+}
+
+function trimTickerText(text: string, max = 96): string {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= max) return normalized
+  return `${normalized.slice(0, max - 3)}...`
+}
+
+function taskTickerTone(status?: Task['status']): FleetTickerEvent['tone'] {
+  switch (status) {
+    case 'done':
+      return 'ok'
+    case 'awaiting_verification':
+      return 'warn'
+    case 'cancelled':
+      return 'err'
+    case 'claimed':
+    case 'in_progress':
+      return 'info'
+    default:
+      return 'idle'
+  }
+}
+
+function keeperTickerTone(status?: string | null): FleetTickerEvent['tone'] {
+  switch ((status ?? '').toLowerCase()) {
+    case 'active':
+    case 'live':
+      return 'ok'
+    case 'busy':
+    case 'executing':
+      return 'info'
+    case 'offline':
+    case 'dead':
+      return 'err'
+    case 'paused':
+    case 'inactive':
+      return 'warn'
+    default:
+      return 'idle'
+  }
+}
+
+function pushTickerEvent(out: FleetTickerEvent[], event: Omit<FleetTickerEvent, 'timestampMs'>) {
+  const timestampMs = parseIsoMs(event.timestamp)
+  if (timestampMs === null) return
+  const text = trimTickerText(event.text)
+  if (text === '') return
+  out.push({ ...event, timestampMs, text })
+}
+
+export function deriveFleetTickerEvents({
+  taskList,
+  messageList,
+  boardPostList,
+  keeperList,
+  max = 6,
+}: {
+  taskList: readonly Task[]
+  messageList: readonly Message[]
+  boardPostList: readonly BoardPost[]
+  keeperList: readonly Keeper[]
+  max?: number
+}): FleetTickerEvent[] {
+  const events: FleetTickerEvent[] = []
+  for (const task of taskList) {
+    const timestamp = task.updated_at ?? task.completed_at ?? task.created_at
+    if (!timestamp) continue
+    pushTickerEvent(events, {
+      id: `task:${task.id}`,
+      timestamp,
+      actor: task.assignee ?? 'unassigned',
+      label: task.status ?? 'task',
+      text: task.title,
+      kind: 'task',
+      tone: taskTickerTone(task.status),
+    })
+  }
+  for (const message of messageList) {
+    if (!message.timestamp) continue
+    pushTickerEvent(events, {
+      id: `message:${message.id ?? message.seq ?? message.timestamp}`,
+      timestamp: message.timestamp,
+      actor: message.from ?? 'system',
+      label: message.type ?? 'message',
+      text: message.content,
+      kind: 'message',
+      tone: 'info',
+    })
+  }
+  for (const post of boardPostList) {
+    pushTickerEvent(events, {
+      id: `board:${post.id}`,
+      timestamp: post.updated_at || post.created_at,
+      actor: post.author,
+      label: post.post_kind ?? 'board',
+      text: post.title || post.content || post.body,
+      kind: 'board',
+      tone: post.post_kind === 'system' ? 'warn' : 'info',
+    })
+  }
+  for (const keeper of keeperList) {
+    if (!keeper.last_heartbeat) continue
+    pushTickerEvent(events, {
+      id: `keeper:${keeper.name}`,
+      timestamp: keeper.last_heartbeat,
+      actor: keeper.koreanName && keeper.koreanName !== '' ? keeper.koreanName : keeper.name,
+      label: 'heartbeat',
+      text: keeperStatusLabel(keeper.status),
+      kind: 'keeper',
+      tone: keeperTickerTone(keeper.status),
+    })
+  }
+  return events
+    .sort((a, b) => b.timestampMs - a.timestampMs)
+    .slice(0, Math.max(0, max))
+}
+
+function tickerToneClass(tone: FleetTickerEvent['tone']): string {
+  switch (tone) {
+    case 'ok':
+      return 'text-[var(--color-status-ok)]'
+    case 'warn':
+      return 'text-[var(--color-status-warn)]'
+    case 'err':
+      return 'text-[var(--color-status-err)]'
+    case 'info':
+      return 'text-[var(--color-accent-fg)]'
+    default:
+      return 'text-[var(--color-fg-muted)]'
+  }
+}
+
+function FleetTicker({ events }: { events: FleetTickerEvent[] }) {
+  if (events.length === 0) return null
+  return html`
+    <${SectionCard}
+      title="Fleet Ticker"
+      right=${html`<span class="text-2xs text-[var(--color-fg-muted)]">latest ${events.length}</span>`}
+      data-testid="overview-fleet-ticker"
+    >
+      <div
+        role="list"
+        aria-label="Recent fleet events"
+        class="flex min-w-0 gap-2 overflow-x-auto pb-1"
+      >
+        ${events.map(event => html`
+          <div
+            key=${event.id}
+            role="listitem"
+            class="grid min-w-[15rem] max-w-[22rem] flex-[0_0_auto] gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2"
+          >
+            <div class="flex min-w-0 items-center gap-2 font-mono text-3xs uppercase tracking-wider">
+              <span class=${tickerToneClass(event.tone)}>${event.kind}</span>
+              <span class="truncate text-[var(--color-fg-muted)]">${event.actor}</span>
+              <${TimeAgo} timestamp=${event.timestamp} class="ml-auto shrink-0 text-[var(--color-fg-disabled)]" />
+            </div>
+            <div class="truncate text-xs font-semibold text-[var(--color-fg-primary)]">${event.text}</div>
+            <div class="truncate font-mono text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">${event.label}</div>
+          </div>
+        `)}
+      </div>
+    <//>
+  `
 }
 
 function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; taskAlerts: TaskAlert[] }) {
@@ -385,14 +564,21 @@ export function Overview() {
   const taskList = tasks.value
   const keeperList = keepers.value
   const agentList = agents.value
+  const messageList = messages.value
+  const boardPostList = boardPosts.value
   const nowMs = nowSecondsSignal.value * 1000
   const active = useMemo(() => pickActiveSession(snap), [snap])
   const counts = useMemo(() => computeFunnelCounts(taskList, active, nowMs), [taskList, active, nowMs])
   const agentAlerts = useMemo(() => deriveAgentAlerts(agentList), [agentList])
   const taskAlerts = useMemo(() => deriveTaskAlerts(taskList, nowMs), [taskList, nowMs])
+  const tickerEvents = useMemo(
+    () => deriveFleetTickerEvents({ taskList, messageList, boardPostList, keeperList }),
+    [taskList, messageList, boardPostList, keeperList],
+  )
   return html`
     <div class="flex flex-col gap-8">
       <${AlertPanel} agentAlerts=${agentAlerts} taskAlerts=${taskAlerts} />
+      <${FleetTicker} events=${tickerEvents} />
       <${FunnelCard} counts=${counts} />
       <${MissionPartyCard} active=${active} />
       <${KeeperStrip} keeperList=${keeperList} />

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -113,6 +113,15 @@ function trimTickerText(text: string, max = 96): string {
   return `${normalized.slice(0, max - 3)}...`
 }
 
+function firstNonEmptyTrimmed(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (trimmed !== '') return trimmed
+  }
+  return null
+}
+
 function taskTickerTone(status?: Task['status']): FleetTickerEvent['tone'] {
   switch (status) {
     case 'done':
@@ -199,9 +208,9 @@ export function deriveFleetTickerEvents({
     pushTickerEvent(events, {
       id: `board:${post.id}`,
       timestamp: post.updated_at || post.created_at,
-      actor: post.author,
+      actor: firstNonEmptyTrimmed(post.author) ?? 'board',
       label: post.post_kind ?? 'board',
-      text: post.title || post.content || post.body,
+      text: firstNonEmptyTrimmed(post.title, post.content, post.body) ?? '',
       kind: 'board',
       tone: post.post_kind === 'system' ? 'warn' : 'info',
     })


### PR DESCRIPTION
## Summary
- Add an Overview `Fleet Ticker` surface based on the cockpit ticker pattern.
- Derive the newest task, message, board, and keeper heartbeat events into a compact horizontal event row.
- Keep the ticker inside the existing Overview stack with local horizontal scrolling and no page-level overflow.

## Why this matters
The cockpit reference has an operator event tape in the top chrome. This ports the useful part into the current Overview page so recent fleet movement is visible without jumping into Monitor/Live surfaces.

## Validation
- `pnpm --dir dashboard install --offline --frozen-lockfile` (worktree dependency recovery; reused local store)
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/overview/overview.test.ts` (51 passed; existing localstorage-file warning)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint` (0 errors; existing 3 unused eslint-disable warnings)
- `pnpm --dir dashboard run build` (passed; existing Vite dynamic-import/chunk-size warnings)

## Browser proof
- Desktop 1440x1000: `/tmp/masc-overview-ticker-0506.png`
  - `bodyClientWidth=1440`, `bodyScrollWidth=1440`, `ticker=true`, `itemCount=6`, `listClientWidth=1142`, `listScrollWidth=1724`
- Mobile 390x844: `/tmp/masc-overview-ticker-mobile-0506.png`
  - `bodyClientWidth=390`, `bodyScrollWidth=390`, `ticker=true`, `itemCount=6`, `listClientWidth=318`, `listScrollWidth=1733`