### PR TITLE
fix(coord): honor agent_type in zombie thresholds

### DIFF
--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -348,12 +348,18 @@ type decision =
 - 작업 중 에이전트: 100% skip
 - 5분+ idle 에이전트: 33% emission (3x interval)
 
-### 5.3 Zombie Detection (`resilience.mli`)
+### 5.3 Zombie Detection (`lib/coord/coord_resilience.mli`)
 
 ```ocaml
 module Zombie : sig
   val is_zombie : ?threshold:float -> string -> bool
-  val is_zombie_for_agent : agent_name:string -> string -> bool
+  val is_zombie_for_agent :
+    ?keeper_threshold_sec:float ->
+    ?agent_threshold_sec:float ->
+    ?agent_type:string ->
+    agent_name:string ->
+    string ->
+    bool
   val is_keeper : name:string -> agent_type:string -> bool
 end
 ```

--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -21,7 +21,12 @@ let get_agents_status config =
         let path = Filename.concat agents_path name in
         match read_agent_with_repair config path with
         | Ok agent ->
-            let is_zombie = is_zombie_agent ~agent_name:agent.name agent.last_seen in
+            let is_zombie =
+              is_zombie_agent
+                ~agent_type:agent.agent_type
+                ~agent_name:agent.name
+                agent.last_seen
+            in
             let status = if is_zombie then "zombie" else agent_status_to_string agent.status in
             agents := `Assoc [
               ("name", `String agent.name);
@@ -162,7 +167,12 @@ let find_agents_by_capability config ~capability =
       if Filename.check_suffix name ".json" then begin
         let path = Filename.concat agents_path name in
         match read_agent_with_repair config path with
-        | Ok agent when List.mem capability agent.capabilities && not (is_zombie_agent ~agent_name:agent.name agent.last_seen) ->
+        | Ok agent
+          when List.mem capability agent.capabilities
+               && not (is_zombie_agent
+                         ~agent_type:agent.agent_type
+                         ~agent_name:agent.name
+                         agent.last_seen) ->
             matching := `Assoc [
               ("name", `String agent.name);
               ("status", `String (agent_status_to_string agent.status));

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -60,12 +60,12 @@ let cleanup_zombies
           match read_agent_with_repair config path with
           | Ok agent
             when (not (List.exists (fun (n, _) -> n = agent.name) !zombie_entries)) &&
-                 (let threshold =
-                    if Coord_resilience.Zombie.is_keeper ~name:agent.name ~agent_type:agent.agent_type
-                    then keeper_threshold_sec
-                    else agent_threshold_sec
-                  in
-                  Coord_resilience.Zombie.is_zombie ~threshold agent.last_seen) ->
+                 Coord_resilience.Zombie.is_zombie_for_agent
+                   ~keeper_threshold_sec
+                   ~agent_threshold_sec
+                   ~agent_type:agent.agent_type
+                   ~agent_name:agent.name
+                   agent.last_seen ->
               zombie_entries := (agent.name, path) :: !zombie_entries
           | Ok _ -> () (* not a zombie, skip *)
           | Error err ->

--- a/lib/coord/coord_resilience.ml
+++ b/lib/coord/coord_resilience.ml
@@ -47,18 +47,24 @@ module Zombie = struct
     Time.is_stale ~threshold last_seen_iso
 
   (** Check if agent is a keeper by name pattern AND/OR agent_type field.
-      Name-only matching is insufficient: any agent named "keeper-*-agent"
-      would get the extended 7-day threshold without this check. *)
+      Name-only matching is insufficient: agents with [agent_type="keeper"]
+      but no keeper-shaped name still need the keeper threshold, while
+      legacy keeper-named agents keep the same behavior. *)
   let is_keeper ~name ~agent_type =
     is_keeper_name name
     || String.lowercase_ascii (String.trim agent_type) = "keeper"
 
   (** Check if an agent is a zombie, using keeper threshold for keeper agents *)
-  let is_zombie_for_agent ~agent_name last_seen_iso =
+  let is_zombie_for_agent
+      ?(keeper_threshold_sec = Env_config_runtime.Zombie.keeper_threshold_seconds)
+      ?(agent_threshold_sec = default_zombie_threshold)
+      ?(agent_type = "")
+      ~agent_name
+      last_seen_iso =
     let threshold =
-      if is_keeper_name agent_name
-      then Env_config_runtime.Zombie.keeper_threshold_seconds
-      else default_zombie_threshold
+      if is_keeper ~name:agent_name ~agent_type
+      then keeper_threshold_sec
+      else agent_threshold_sec
     in
     is_zombie ~threshold last_seen_iso
 end

--- a/lib/coord/coord_resilience.mli
+++ b/lib/coord/coord_resilience.mli
@@ -69,17 +69,25 @@ module Zombie : sig
       - [name] matches the keeper-name convention, OR
       - [agent_type] equals ["keeper"] (case-insensitive, trimmed)
 
-      Name-only matching is insufficient because any agent named
-      [keeper-*-agent] would otherwise get the extended 7-day
-      threshold without the type field check. *)
+      Name-only matching is insufficient because non-pattern keeper
+      agents still need the keeper threshold, while legacy
+      [keeper-*-agent] names keep the same behavior. *)
 
   val is_zombie_for_agent :
-    agent_name:string -> string -> bool
-  (** [is_zombie_for_agent ~agent_name last_seen_iso] uses
+    ?keeper_threshold_sec:float ->
+    ?agent_threshold_sec:float ->
+    ?agent_type:string ->
+    agent_name:string ->
+    string ->
+    bool
+  (** [is_zombie_for_agent ?keeper_threshold_sec ?agent_threshold_sec
+      ?agent_type ~agent_name last_seen_iso] uses
       {!Env_config_runtime.Zombie.keeper_threshold_seconds} when
-      [agent_name] matches {!is_keeper_name}, otherwise falls
-      back to {!default_zombie_threshold}.  This is the canonical
-      "should I evict this agent" predicate for the gc loop. *)
+      {!is_keeper} matches the name or type, otherwise falls back to
+      {!default_zombie_threshold}.  Callers may override both
+      thresholds for deterministic tests or one-off cleanup windows.
+      This is the canonical "should I evict this agent" predicate for
+      the gc loop. *)
 end
 
 (** {1 Zero-Zombie protocol}

--- a/lib/coord/coord_state.ml
+++ b/lib/coord/coord_state.ml
@@ -186,8 +186,11 @@ let parse_iso_time iso_str =
   | Some t -> t
   | None -> Coord_resilience.Time.now ()
 
-let is_zombie_agent ~agent_name last_seen_iso =
-  Coord_resilience.Zombie.is_zombie_for_agent ~agent_name last_seen_iso
+let is_zombie_agent ?agent_type ~agent_name last_seen_iso =
+  Coord_resilience.Zombie.is_zombie_for_agent
+    ?agent_type
+    ~agent_name
+    last_seen_iso
 
 let take n xs =
   if n <= 0 then []

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -65,5 +65,5 @@ val pause_info :
 val heartbeat_timeout_seconds : float
 val parse_iso_time_opt : string -> float option
 val parse_iso_time : string -> float
-val is_zombie_agent : agent_name:string -> string -> bool
+val is_zombie_agent : ?agent_type:string -> agent_name:string -> string -> bool
 val take : int -> 'a list -> 'a list

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -46,7 +46,12 @@ let status config =
           let json = read_json config path in
           match agent_of_yojson json with
           | Ok agent ->
-              let is_zombie = is_zombie_agent ~agent_name:agent.name agent.last_seen in
+              let is_zombie =
+                is_zombie_agent
+                  ~agent_type:agent.agent_type
+                  ~agent_name:agent.name
+                  agent.last_seen
+              in
               let stale_current_task =
                 match agent.current_task with
                 | Some task_id ->

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -152,7 +152,12 @@ let parse_agent_status (config : Coord.config) ~(agent_name : string) : Yojson.S
                 ("last_seen", `String agent.last_seen);
                 ("age_s", `Float age_s);
                 ("last_seen_ago_s", `Float last_seen_ago_s);
-                ("is_zombie", `Bool (Coord.is_zombie_agent ~agent_name:agent.name agent.last_seen));
+                ("is_zombie",
+                 `Bool
+                   (Coord.is_zombie_agent
+                      ~agent_type:agent.agent_type
+                      ~agent_name:agent.name
+                      agent.last_seen));
               ]))
 
 let json_string_opt key json =

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -208,8 +208,8 @@ let safe_read_backlog (ctx : context) =
         version = 1;
       }
 
-let safe_is_zombie_agent ~agent_name last_seen =
-  try Coord.is_zombie_agent ~agent_name last_seen
+let safe_is_zombie_agent ?agent_type ~agent_name last_seen =
+  try Coord.is_zombie_agent ?agent_type ~agent_name last_seen
   with
   | Sys_error _ | Yojson.Json_error _ -> false
   | exn ->
@@ -374,7 +374,10 @@ let status_summary_string (ctx : context) =
       (fun (agent : Masc_domain.agent) ->
         Coord_query.safe_yield ();
         let is_zombie =
-          safe_is_zombie_agent ~agent_name:agent.name agent.last_seen
+          safe_is_zombie_agent
+            ~agent_type:agent.agent_type
+            ~agent_name:agent.name
+            agent.last_seen
         in
         (agent, is_zombie))
       agents

--- a/test/test_resilience.ml
+++ b/test/test_resilience.ml
@@ -192,6 +192,15 @@ let test_zombie_for_agent_keeper_600s () =
   check bool "600s old keeper agent is not zombie" false
     (Coord_resilience.Zombie.is_zombie_for_agent ~agent_name:"keeper-eval-agent" ts)
 
+let test_zombie_for_agent_keeper_type_600s () =
+  (* Non-pattern keeper agents must also get the keeper threshold. *)
+  let ts = make_iso_seconds_ago 600.0 in
+  check bool "600s old agent_type=keeper is not zombie" false
+    (Coord_resilience.Zombie.is_zombie_for_agent
+       ~agent_type:"keeper"
+       ~agent_name:"regular-bot"
+       ts)
+
 let test_zombie_for_agent_keeper_4000s () =
   (* 4000s old keeper agent: should be zombie (exceeds keeper threshold 3600s) *)
   let ts = make_iso_seconds_ago 4000.0 in
@@ -244,6 +253,7 @@ let () =
     "Zombie.is_zombie_for_agent", [
       test_case "regular 600s" `Quick test_zombie_for_agent_regular_600s;
       test_case "keeper 600s" `Quick test_zombie_for_agent_keeper_600s;
+      test_case "keeper type 600s" `Quick test_zombie_for_agent_keeper_type_600s;
       test_case "keeper 4000s" `Quick test_zombie_for_agent_keeper_4000s;
       test_case "keeper recent" `Quick test_zombie_for_agent_keeper_recent;
     ];

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -808,15 +808,15 @@ let iso_ago seconds =
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
 (** Helper: join an agent then overwrite its last_seen to simulate staleness *)
-let make_stale_agent config ~name ~age_seconds =
+let make_stale_agent ?(agent_type = "test") config ~name ~age_seconds =
   let _ = Coord.join config ~agent_name:name ~capabilities:[] () in
   (* Overwrite the agent file with a stale last_seen *)
   let agents_path = Filename.concat (Coord.masc_dir config) "agents" in
   let path = Filename.concat agents_path (Coord.safe_filename name ^ ".json") in
   let stale_ts = iso_ago age_seconds in
   let agent_json = Printf.sprintf
-    {|{"name":"%s","agent_type":"test","status":"inactive","capabilities":[],"joined_at":"%s","last_seen":"%s"}|}
-    name stale_ts stale_ts
+    {|{"name":"%s","agent_type":"%s","status":"inactive","capabilities":[],"joined_at":"%s","last_seen":"%s"}|}
+    name agent_type stale_ts stale_ts
   in
   Coord.write_json config path (Yojson.Safe.from_string agent_json)
 
@@ -845,6 +845,19 @@ let test_cleanup_zombies_spares_recent_keeper () =
     let result = Coord.cleanup_zombies config in
     Alcotest.(check bool) "recent keeper spared"
       true (not (str_contains result "keeper-active-agent"))
+  )
+
+let test_cleanup_zombies_spares_type_keeper () =
+  with_test_env (fun config ->
+    (* Non-pattern keeper agents also use the keeper threshold. *)
+    make_stale_agent
+      ~agent_type:"keeper"
+      config
+      ~name:"regular-keeper-runtime"
+      ~age_seconds:600.0;
+    let result = Coord.cleanup_zombies config in
+    Alcotest.(check bool) "agent_type=keeper spared below keeper threshold"
+      true (not (str_contains result "regular-keeper-runtime"))
   )
 
 let test_cleanup_zombies_removes_broken_agent_file () =
@@ -1679,6 +1692,7 @@ let () =
       Alcotest.test_case "cleanup detects regular zombie" `Quick test_cleanup_zombies_detects_regular;
       Alcotest.test_case "cleanup detects keeper zombie" `Quick test_cleanup_zombies_detects_keeper;
       Alcotest.test_case "cleanup spares recent keeper" `Quick test_cleanup_zombies_spares_recent_keeper;
+      Alcotest.test_case "cleanup spares type keeper" `Quick test_cleanup_zombies_spares_type_keeper;
       Alcotest.test_case "cleanup removes broken agent file" `Quick test_cleanup_zombies_removes_broken_agent_file;
       Alcotest.test_case "cleanup preserves non-json files" `Quick test_cleanup_zombies_preserves_non_json_files;
     ];


### PR DESCRIPTION
## Summary

- extends the coord zombie predicate so keeper threshold selection can use `agent_type="keeper"` as well as legacy `keeper-*-agent` names
- routes `cleanup_zombies` and status surfaces through the shared type-aware helper
- adds regressions for non-pattern keeper agents staying below the keeper zombie threshold

## Why

`masc-mcp#11927` was largely stale on current `main`: production cleanup is already activity-based on `last_seen`. The remaining inconsistency was that the exported/canonical predicate still used name-pattern detection only, while `cleanup_zombies` had its own type-aware branch. That made non-pattern keeper runtimes look zombie on dashboard/status paths sooner than the GC path would evict them.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `ocamlc -stop-after parsing lib/coord/coord_resilience.ml lib/coord/coord_resilience.mli lib/coord/coord_gc.ml lib/coord/coord_state.ml lib/coord/coord_state.mli lib/coord/coord_agent.ml lib/coord/coord_status.ml lib/tool_coord.ml lib/keeper/keeper_exec_status.ml test/test_resilience.ml test/test_room.ml`
- `scripts/dune-local.sh build test/test_resilience.exe test/test_room.exe`
- `./_build/default/test/test_resilience.exe`
- `./_build/default/test/test_room.exe` (existing broader init/join/task failures remain; the cleanup zombie group, including the new `agent_type=keeper` regression, passed)

Refs jeong-sik/masc-mcp#11927
