### PR TITLE
fix(test): isolate oas worker direct runs

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -65,6 +65,7 @@ let allow_inherited_test_config_paths () =
   Env_config_core.get_bool ~default:false
     test_config_path_override_env
 
+let initial_env_base_path = Env_config_core.base_path_raw_opt ()
 let initial_env_config_dir = Env_config_core.config_dir_opt ()
 let initial_env_personas_dir = Env_config_core.personas_dir_opt ()
 let initial_env_home = Sys.getenv_opt "HOME" |> trim_opt
@@ -79,6 +80,29 @@ let sanitize_inherited_test_env_opt ~running_under_test_executable ~allow_inheri
   else
     current
 
+let path_equal_or_under ~parent path =
+  String.equal path parent
+  || (not (String.equal parent "/")
+     && String.starts_with ~prefix:(parent ^ "/") path)
+  || (String.equal parent "/" && String.starts_with ~prefix:"/" path)
+
+let sanitize_inherited_test_base_path_opt ~running_under_test_executable
+    ~allow_inherited ~initial ~current ~home =
+  if running_under_test_executable && not allow_inherited then
+    match current, initial, home with
+    | Some current_value, Some initial_value, Some home
+      when String.equal current_value initial_value ->
+        let current_base =
+          Env_config_core.normalize_masc_base_path_input current_value
+        in
+        let home_base = Env_config_core.normalize_masc_base_path_input home in
+        if home_base <> "" && path_equal_or_under ~parent:home_base current_base
+        then None
+        else current
+    | _ -> current
+  else
+    current
+
 let current_env_config_dir_opt () =
   sanitize_inherited_test_env_opt
     ~running_under_test_executable:
@@ -86,6 +110,15 @@ let current_env_config_dir_opt () =
     ~allow_inherited:(allow_inherited_test_config_paths ())
     ~initial:initial_env_config_dir
     ~current:(Env_config_core.config_dir_opt ())
+
+let current_env_base_path_opt () =
+  sanitize_inherited_test_base_path_opt
+    ~running_under_test_executable:
+      (running_under_test_executable Sys.executable_name)
+    ~allow_inherited:(allow_inherited_test_config_paths ())
+    ~initial:initial_env_base_path
+    ~current:(Env_config_core.base_path_raw_opt ())
+    ~home:initial_env_home
 
 let current_env_personas_dir_opt () =
   sanitize_inherited_test_env_opt
@@ -324,7 +357,7 @@ let inputs_from_env () =
   {
     cwd = Sys.getcwd ();
     executable_name = Sys.executable_name;
-    env_base_path = Env_config_core.base_path_opt ();
+    env_base_path = current_env_base_path_opt ();
     env_config_dir = current_env_config_dir_opt ();
     env_personas_dir = current_env_personas_dir_opt ();
     env_home = current_env_home_opt ();
@@ -379,7 +412,13 @@ let reset () =
 
 let cascade_path_opt () =
   let resolution = resolve () in
-  if resolution.cascade.exists then Some resolution.cascade.path else None
+  match resolution.config_root.source with
+  | Env | Local_masc | Home_masc | Exe_relative | Cwd
+    when resolution.cascade.exists ->
+      Some resolution.cascade.path
+  | Env | Local_masc | Home_masc | Exe_relative | Cwd
+  | Invalid_env | Missing ->
+      None
 
 let cascade_path_candidate () =
   (resolve ()).cascade.path
@@ -388,8 +427,14 @@ let cascade_toml_path_candidate () =
   Filename.concat (resolve ()).config_root.path cascade_toml_filename
 
 let cascade_toml_path_opt () =
-  let path = cascade_toml_path_candidate () in
-  if existing_file path then Some path else None
+  let resolution = resolve () in
+  match resolution.config_root.source with
+  | Env | Local_masc | Home_masc | Exe_relative | Cwd
+    when resolution.cascade_authoring.exists ->
+      Some resolution.cascade_authoring.path
+  | Env | Local_masc | Home_masc | Exe_relative | Cwd
+  | Invalid_env | Missing ->
+      None
 
 let prompts_dir () =
   (resolve ()).prompts.path
@@ -399,7 +444,13 @@ let keepers_dir () =
 
 let personas_dir_opt () =
   let resolution = resolve () in
-  if resolution.personas.exists then Some resolution.personas.path else None
+  match resolution.config_root.source with
+  | Env | Local_masc | Home_masc | Exe_relative | Cwd
+    when resolution.personas.exists ->
+      Some resolution.personas.path
+  | Env | Local_masc | Home_masc | Exe_relative | Cwd
+  | Invalid_env | Missing ->
+      None
 
 let dedupe_paths paths =
   let rec go seen acc = function

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -462,8 +462,16 @@ let dedupe_paths paths =
   go StringSet.empty [] paths
 
 let personas_dirs_with inputs resolution =
+  (* Mirror [personas_dir_opt]'s invariant: when the resolver is Missing or
+     Invalid_env, never expose a personas path even if [resolution.personas.exists]
+     happens to be true (e.g. [default_missing_root] pointing at a repo-local
+     config/ tree). Without this gate, callers can silently load personas from
+     a fallback root the resolver explicitly disowned. *)
   let primary =
-    if resolution.personas.exists then [ resolution.personas.path ] else []
+    match resolution.config_root.source with
+    | Invalid_env | Missing -> []
+    | Env | Local_masc | Home_masc | Exe_relative | Cwd ->
+      if resolution.personas.exists then [ resolution.personas.path ] else []
   in
   let explicit_personas_dir_override = trim_opt inputs.env_personas_dir in
   (* Persona resolution is intentionally single-source:

--- a/lib/config_dir_resolver.mli
+++ b/lib/config_dir_resolver.mli
@@ -95,6 +95,7 @@ val config_signature_exists : string -> bool
     under a test executable and [MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE] is unset. *)
 
 val current_env_config_dir_opt : unit -> string option
+val current_env_base_path_opt : unit -> string option
 val current_env_personas_dir_opt : unit -> string option
 val current_env_home_opt : unit -> string option
 
@@ -106,6 +107,17 @@ val sanitize_inherited_test_env_opt :
   allow_inherited:bool ->
   initial:string option ->
   current:string option ->
+  string option
+
+(** Base-path-specific test env sanitization. Same captured test values are
+    stripped only when they resolve under the process HOME; temp roots supplied
+    at process start stay usable. *)
+val sanitize_inherited_test_base_path_opt :
+  running_under_test_executable:bool ->
+  allow_inherited:bool ->
+  initial:string option ->
+  current:string option ->
+  home:string option ->
   string option
 
 val path_from_executable : cwd:string -> string -> string option

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -108,6 +108,38 @@ let test_sanitize_inherited_test_env_opt_keeps_runtime_override () =
   check (option string) "runtime override preserved"
     (Some "/tmp/test-config-root") actual
 
+let test_sanitize_inherited_test_base_path_opt_drops_captured_home_path () =
+  let actual =
+    Lib.Config_dir_resolver.sanitize_inherited_test_base_path_opt
+      ~running_under_test_executable:true ~allow_inherited:false
+      ~initial:(Some "/Users/dancer/me")
+      ~current:(Some "/Users/dancer/me")
+      ~home:(Some "/Users/dancer/me")
+  in
+  check (option string) "same captured MASC_BASE_PATH ignored" None actual
+
+let test_sanitize_inherited_test_base_path_opt_keeps_sibling_prefix_path () =
+  let actual =
+    Lib.Config_dir_resolver.sanitize_inherited_test_base_path_opt
+      ~running_under_test_executable:true ~allow_inherited:false
+      ~initial:(Some "/Users/dancer/me2")
+      ~current:(Some "/Users/dancer/me2")
+      ~home:(Some "/Users/dancer/me")
+  in
+  check (option string) "sibling path preserved"
+    (Some "/Users/dancer/me2") actual
+
+let test_sanitize_inherited_test_base_path_opt_keeps_process_temp_path () =
+  let actual =
+    Lib.Config_dir_resolver.sanitize_inherited_test_base_path_opt
+      ~running_under_test_executable:true ~allow_inherited:false
+      ~initial:(Some "/tmp/test-oas-worker-base")
+      ~current:(Some "/tmp/test-oas-worker-base")
+      ~home:(Some "/Users/dancer/me")
+  in
+  check (option string) "process temp base preserved"
+    (Some "/tmp/test-oas-worker-base") actual
+
 let test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in () =
   let actual =
     Lib.Config_dir_resolver.sanitize_inherited_test_env_opt
@@ -387,6 +419,12 @@ let () =
             test_sanitize_inherited_test_env_opt_drops_captured_parent_shell_value;
           test_case "keeps runtime override" `Quick
             test_sanitize_inherited_test_env_opt_keeps_runtime_override;
+          test_case "drops captured parent-shell base path by default" `Quick
+            test_sanitize_inherited_test_base_path_opt_drops_captured_home_path;
+          test_case "keeps sibling prefix base path" `Quick
+            test_sanitize_inherited_test_base_path_opt_keeps_sibling_prefix_path;
+          test_case "keeps process temp base path" `Quick
+            test_sanitize_inherited_test_base_path_opt_keeps_process_temp_path;
           test_case "opt-in preserves config-path override" `Quick
             test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in;
           test_case "canonicalizes explicit base path" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -63,6 +63,29 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let test_process_base_path = ref None
+
+let configure_direct_test_environment () =
+  (* The named-cascade liveness observer defaults to streaming mode. These
+     tests use simple non-streaming OpenAI-compatible mocks, so keep liveness
+     covered by its dedicated test executable and run this suite on the
+     baseline request path. *)
+  Unix.putenv "MASC_CASCADE_ATTEMPT_LIVENESS" "off";
+  Cascade_attempt_liveness_config.reset_cache_for_test ();
+  (* Keep any async cleanup or background observer in this test process away
+     from the operator's live HOME-backed MASC root. Individual tests can still
+     install narrower fixtures with [with_temp_masc_config]. *)
+  let base = temp_dir "test_oas_worker_base" in
+  let config_dir = Filename.concat base ".masc/config" in
+  mkdir_p config_dir;
+  Unix.putenv "MASC_BASE_PATH" base;
+  Unix.putenv "MASC_BASE_PATH_INPUT" base;
+  Unix.putenv "MASC_CONFIG_DIR" config_dir;
+  Config_dir_resolver.reset ();
+  Cascade_catalog_runtime.reset_cache_for_tests ();
+  test_process_base_path := Some base;
+  at_exit (fun () -> Option.iter cleanup_dir !test_process_base_path)
+
 let _parse_json s =
   try Yojson.Safe.from_string s
   with Yojson.Json_error e -> failwith ("invalid json: " ^ e)
@@ -634,16 +657,21 @@ let test_cascade_metrics_evicts_lowest_call_key () =
 let test_cascade_audit_persists_observation () =
   let base = temp_dir "test_cascade_audit" in
   let old_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
+  let old_base_path_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
   Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
   Fun.protect
     ~finally:(fun () ->
       (match old_base_path with
        | Some value -> Unix.putenv "MASC_BASE_PATH" value
        | None -> Unix.putenv "MASC_BASE_PATH" "");
+      (match old_base_path_input with
+       | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
+       | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
       Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
       cleanup_dir base)
     (fun () ->
       Unix.putenv "MASC_BASE_PATH" base;
+      Unix.putenv "MASC_BASE_PATH_INPUT" base;
       let observation : Masc_mcp.Oas_worker_cascade.cascade_observation =
         {
           cascade_name =
@@ -4555,6 +4583,7 @@ let test_run_named_circuit_breaker_skips_open_provider () =
 (* ================================================================ *)
 
 let () =
+  configure_direct_test_environment ();
   Eio_main.run @@ fun env ->
   test_net := Some env#net;
   test_proc_mgr := Some (Eio.Stdenv.process_mgr env);


### PR DESCRIPTION
## Summary

- strip inherited HOME-backed `MASC_BASE_PATH` when resolving config from test executables unless `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` opts in
- avoid returning cascade/persona config paths from `Missing` or `Invalid_env` resolver roots, even when repo-local candidates exist
- initialize `test_oas_worker.exe` direct runs with a temp MASC base/config root and keep its non-streaming mocks off the liveness observer path
- keep the cascade audit fixture aligned across `MASC_BASE_PATH` and `MASC_BASE_PATH_INPUT`

## Root Cause

Direct local execution inherited the operator shell's live `MASC_BASE_PATH=/Users/dancer/me`, so linked module initialization could resolve live `~/.masc` config before the test body installed its own fixture. A separate missing-root accessor path could still hand out repo-local cascade files when fallback was disabled, which made the test try to materialize config under the repo. The named-cascade tests also used non-streaming OpenAI mocks while liveness observation defaulted to streaming mode.

Fixes #13441.

## Validation

- `env MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_oas_worker.exe test/test_config_dir_resolver.exe`
- `./_build/default/test/test_oas_worker.exe` (150 tests)
- `./_build/default/test/test_config_dir_resolver.exe` (21 tests)
- `git diff --check`

The direct `test_oas_worker.exe` run no longer prints the live `/Users/dancer/me/.masc/config/cascade.json` load line.
