### PR TITLE
fix(keeper): gate manual local discovery refresh

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -222,7 +222,11 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          (false, "" ^ e)
        | Ok () ->
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
-         ignore (Cascade_runtime.refresh_local_discovery_if_possible effective_models);
+         (match Keeper_turn_helpers.ensure_local_discovery_ready effective_models with
+          | Error e ->
+            Progress.stop_tracking turn_task_id;
+            (false, "" ^ e)
+          | Ok () ->
          let max_cascade_context =
            let resolution =
              Keeper_exec_context.resolve_max_context_resolution
@@ -621,4 +625,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-))))
+)))))

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3956,12 +3956,18 @@ let test_run_keeper_cycle_surfaces_side_effect_failures_source_contract () =
   check bool "local discovery refresh is not silently ignored" false
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
        "ignore (Cascade_runtime.refresh_local_discovery_if_possible model_labels)");
+  check bool "manual keeper_msg local discovery refresh is not silently ignored" false
+    (source_file_contains "lib/keeper/keeper_turn.ml"
+       "ignore (Cascade_runtime.refresh_local_discovery_if_possible effective_models)");
   check bool "activity graph emit is not silently ignored" false
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
        "ignore (Activity_graph.emit config");
   check bool "discovery helper guards keeper setup" true
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
-       "ensure_local_discovery_ready model_labels")
+       "ensure_local_discovery_ready model_labels");
+  check bool "manual keeper_msg discovery helper guards keeper setup" true
+    (source_file_contains "lib/keeper/keeper_turn.ml"
+       "ensure_local_discovery_ready effective_models")
 
 let test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry () =
   let base_dir = temp_dir () in


### PR DESCRIPTION
## Summary

- Route the manual `masc_keeper_msg` path through `Keeper_turn_helpers.ensure_local_discovery_ready` before resolving the turn context budget.
- Return an explicit tool error when selected local-provider labels require runtime discovery but refresh cannot run or fails.
- Extend the keeper source-contract test so the manual path cannot regress back to `ignore (Cascade_runtime.refresh_local_discovery_if_possible ...)`.

## Why

Unified keeper cycles already fail closed for required local discovery refreshes. The manual keeper-message path still discarded the refresh boolean, so a local-provider discovery failure could silently fall through to stale or static context assumptions.

## Validation

- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 4`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 6`