### PR TITLE
feat(goal-loop): add post-act live replay runner

### DIFF
--- a/docs/examples/goal-loop-live-replay.md
+++ b/docs/examples/goal-loop-live-replay.md
@@ -1,0 +1,42 @@
+# GOAL LOOP post-ACT live replay
+
+Use this runner after ACT PRs have landed and the active runtime has been
+restarted or otherwise re-entered the relevant code path. It captures a bounded
+log window, then writes Observe, Orient, Decide, Verify, Status, and metadata
+JSON artifacts in one directory.
+
+Example:
+
+```bash
+python3 scripts/goal_loop_live_replay.py \
+  --log /path/to/server.log \
+  --duration-seconds 60 \
+  --artifact-dir /tmp/goal-loop-live-verify-$(date -u +%Y%m%dT%H%M%SZ) \
+  --act-map test/fixtures/goal_loop/act-map.startup.json \
+  --runtime-source localhost:8935 \
+  --base-path /Users/dancer/me \
+  --loop-iteration post-act-live \
+  --fail-on verify \
+  --format text
+```
+
+Artifacts written:
+
+- `metadata.json`: source log paths, captured log paths, runtime source, base
+  path, evidence window, duration, policy, and loop label.
+- `observe.json`: raw GOAL LOOP log pattern counts and samples.
+- `orient.json`: finding-level classification from Observe evidence.
+- `decide.json`: actionable decision queue and ACT linkage.
+- `verify.json`: PASS/FAIL result plus `post_act_verify=true`,
+  `evidence_kind=live_runtime_logs`, concrete evidence source, evidence window,
+  and `checked_at`.
+- `status.json`: aggregate GOAL LOOP status and next action.
+
+Interpretation:
+
+- `verify_status=PASS` means the captured post-ACT window did not contain
+  evidence matching the configured Verify policy.
+- `verify_status=FAIL` keeps the loop red and stores concrete samples in the
+  phase artifacts.
+- A PASS is only a bounded replay result. It is not a permanent proof that the
+  failure cannot recur.

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -80,7 +80,9 @@ def artifact_log_name(index: int, source: Path) -> str:
     return f"{index:02d}-{name}"
 
 
-def source_snapshots(paths: list[Path], *, tail_only: bool) -> dict[Path, SourceSnapshot]:
+def source_snapshots(
+    paths: list[Path], *, tail_only: bool
+) -> dict[Path, SourceSnapshot]:
     snapshots: dict[Path, SourceSnapshot] = {}
     for path in paths:
         stat = path.stat()

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -55,6 +55,14 @@ class ReplaySummary:
     metadata_json: str
 
 
+@dataclass(frozen=True)
+class SourceSnapshot:
+    inode: int
+    size: int
+    mtime_ns: int
+    offset: int
+
+
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
@@ -72,11 +80,28 @@ def artifact_log_name(index: int, source: Path) -> str:
     return f"{index:02d}-{name}"
 
 
-def source_offsets(paths: list[Path], *, tail_only: bool) -> dict[Path, int]:
-    offsets: dict[Path, int] = {}
+def source_snapshots(paths: list[Path], *, tail_only: bool) -> dict[Path, SourceSnapshot]:
+    snapshots: dict[Path, SourceSnapshot] = {}
     for path in paths:
-        offsets[path] = path.stat().st_size if tail_only else 0
-    return offsets
+        stat = path.stat()
+        snapshots[path] = SourceSnapshot(
+            inode=stat.st_ino,
+            size=stat.st_size,
+            mtime_ns=stat.st_mtime_ns,
+            offset=stat.st_size if tail_only else 0,
+        )
+    return snapshots
+
+
+def capture_offset_after_window(source: Path, snapshot: SourceSnapshot) -> int:
+    current = source.stat()
+    if current.st_ino != snapshot.inode:
+        return 0
+    if current.st_size < snapshot.size:
+        return 0
+    if current.st_size == snapshot.size and current.st_mtime_ns != snapshot.mtime_ns:
+        return 0
+    return snapshot.offset
 
 
 def capture_log_window(
@@ -94,7 +119,7 @@ def capture_log_window(
 
     log_dir = artifact_dir / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    offsets = source_offsets(sources, tail_only=duration_seconds > 0)
+    snapshots = source_snapshots(sources, tail_only=duration_seconds > 0)
     if duration_seconds > 0:
         time.sleep(duration_seconds)
 
@@ -104,8 +129,9 @@ def capture_log_window(
         if duration_seconds <= 0:
             shutil.copyfile(source, target)
         else:
+            offset = capture_offset_after_window(source, snapshots[source])
             with source.open("rb") as input_handle:
-                input_handle.seek(offsets[source])
+                input_handle.seek(offset)
                 target.write_bytes(input_handle.read())
         captured.append(str(target))
     return captured
@@ -177,6 +203,7 @@ def replay_logs(
     base_path: str | None,
 ) -> ReplaySummary:
     artifact_dir.mkdir(parents=True, exist_ok=True)
+    max_samples_effective = max(max_samples, 0)
     window_start = utc_now_iso()
     captured_logs = capture_log_window(
         log_paths,
@@ -187,7 +214,7 @@ def replay_logs(
 
     observe_report = observe_goal_loop_logs.scan_logs(
         captured_logs,
-        max_samples=max(max_samples, 0),
+        max_samples=max_samples_effective,
     )
     observe_json = asdict(observe_report)
 
@@ -249,7 +276,9 @@ def replay_logs(
         "evidence_window_end": window_end,
         "act_map_path": act_map_path,
         "verify_policy": verify_policy,
-        "max_samples": max_samples,
+        "max_samples": max_samples_effective,
+        "max_samples_requested": max_samples,
+        "max_samples_effective": max_samples_effective,
     }
 
     paths = {

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Capture a bounded GOAL LOOP post-ACT log replay artifact.
+
+This runner is intentionally a thin orchestrator over the existing phase tools:
+Observe scans captured logs, Orient classifies findings, Decide maps ACT
+coverage, Verify judges the post-ACT evidence, and Status writes the aggregate
+snapshot. It does not claim a permanent fix; it only stores the replay evidence
+needed to keep the loop moving.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import decide_goal_loop_findings  # noqa: E402
+import goal_loop_status  # noqa: E402
+import observe_goal_loop_logs  # noqa: E402
+import orient_goal_loop_logs  # noqa: E402
+import verify_goal_loop_logs  # noqa: E402
+
+
+VERIFY_EVIDENCE_KEYS = (
+    "evidence_kind",
+    "evidence_source",
+    "evidence_window_start",
+    "evidence_window_end",
+    "checked_at",
+)
+
+
+@dataclass(frozen=True)
+class ReplaySummary:
+    artifact_dir: str
+    overall_status: str
+    verify_status: str
+    captured_logs: list[str]
+    observe_json: str
+    orient_json: str
+    decide_json: str
+    verify_json: str
+    status_json: str
+    metadata_json: str
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def artifact_log_name(index: int, source: Path) -> str:
+    name = source.name or f"log-{index}"
+    return f"{index:02d}-{name}"
+
+
+def source_offsets(paths: list[Path], *, tail_only: bool) -> dict[Path, int]:
+    offsets: dict[Path, int] = {}
+    for path in paths:
+        offsets[path] = path.stat().st_size if tail_only else 0
+    return offsets
+
+
+def capture_log_window(
+    log_paths: list[str],
+    *,
+    artifact_dir: Path,
+    duration_seconds: float,
+) -> list[str]:
+    if not log_paths:
+        raise ValueError("at least one --log path is required")
+    sources = [Path(raw_path) for raw_path in log_paths]
+    for source in sources:
+        if not source.is_file():
+            raise FileNotFoundError(f"log path is not a file: {source}")
+
+    log_dir = artifact_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    offsets = source_offsets(sources, tail_only=duration_seconds > 0)
+    if duration_seconds > 0:
+        time.sleep(duration_seconds)
+
+    captured: list[str] = []
+    for index, source in enumerate(sources, start=1):
+        target = log_dir / artifact_log_name(index, source)
+        if duration_seconds <= 0:
+            shutil.copyfile(source, target)
+        else:
+            with source.open("rb") as input_handle:
+                input_handle.seek(offsets[source])
+                target.write_bytes(input_handle.read())
+        captured.append(str(target))
+    return captured
+
+
+def format_evidence_source(
+    *,
+    runtime_source: str,
+    captured_logs: list[str],
+    base_path: str | None,
+) -> str:
+    parts = [f"runtime_source={runtime_source}"]
+    if base_path:
+        parts.append(f"base_path={base_path}")
+    parts.append("logs=" + ",".join(captured_logs))
+    return ";".join(parts)
+
+
+def status_summary_with_verify_metadata(
+    status_json: dict[str, Any],
+    verify_json: dict[str, Any],
+) -> dict[str, Any]:
+    phases = status_json.get("phases")
+    if not isinstance(phases, dict):
+        return status_json
+    verify_phase = phases.get("verify")
+    if not isinstance(verify_phase, dict):
+        return status_json
+    summary = verify_phase.get("summary")
+    if not isinstance(summary, dict):
+        summary = {}
+
+    post_act_verify = verify_json.get("post_act_verify")
+    if isinstance(post_act_verify, bool):
+        summary["post_act_verify"] = post_act_verify
+
+    violations = verify_json.get("violations")
+    summary["violation_kinds"] = []
+    if isinstance(violations, list):
+        summary["violation_kinds"] = sorted(
+            {
+                str(kind)
+                for violation in violations
+                if isinstance(violation, dict)
+                for kind in [violation.get("kind")]
+                if isinstance(kind, str)
+            }
+        )
+
+    for key in VERIFY_EVIDENCE_KEYS:
+        value = verify_json.get(key)
+        if isinstance(value, str) and value.strip():
+            summary[key] = value.strip()
+
+    verify_phase["summary"] = summary
+    return status_json
+
+
+def replay_logs(
+    *,
+    log_paths: list[str],
+    artifact_dir: Path,
+    duration_seconds: float,
+    act_map_path: str | None,
+    loop_iteration: str,
+    verify_policy: str,
+    max_samples: int,
+    runtime_source: str,
+    base_path: str | None,
+) -> ReplaySummary:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    window_start = utc_now_iso()
+    captured_logs = capture_log_window(
+        log_paths,
+        artifact_dir=artifact_dir,
+        duration_seconds=duration_seconds,
+    )
+    window_end = utc_now_iso()
+
+    observe_report = observe_goal_loop_logs.scan_logs(
+        captured_logs,
+        max_samples=max(max_samples, 0),
+    )
+    observe_json = asdict(observe_report)
+
+    orient_report = orient_goal_loop_logs.orient_scan(observe_json)
+    orient_json = asdict(orient_report)
+
+    act_map = (
+        decide_goal_loop_findings.load_act_map_input(act_map_path)
+        if act_map_path
+        else None
+    )
+    decide_report = decide_goal_loop_findings.decide_orient(
+        orient_json,
+        act_map=act_map,
+    )
+    decide_json = asdict(decide_report)
+
+    verify_report = verify_goal_loop_logs.verify_orient(
+        orient_json,
+        policy=verify_policy,
+    )
+    verify_json = asdict(verify_report)
+    verify_json.update(
+        {
+            "post_act_verify": True,
+            "evidence_kind": "live_runtime_logs",
+            "evidence_source": format_evidence_source(
+                runtime_source=runtime_source,
+                captured_logs=captured_logs,
+                base_path=base_path,
+            ),
+            "evidence_window_start": window_start,
+            "evidence_window_end": window_end,
+            "checked_at": utc_now_iso(),
+        }
+    )
+
+    status_report = goal_loop_status.build_status_report(
+        observe=observe_json,
+        orient=orient_json,
+        decide=decide_json,
+        verify=verify_json,
+        generated_at=verify_json["checked_at"],
+        loop_iteration=loop_iteration,
+    )
+    status_json = asdict(status_report)
+    status_json = status_summary_with_verify_metadata(status_json, verify_json)
+
+    metadata = {
+        "schema_version": 1,
+        "generated_at": verify_json["checked_at"],
+        "loop_iteration": loop_iteration,
+        "source_logs": log_paths,
+        "captured_logs": captured_logs,
+        "runtime_source": runtime_source,
+        "base_path": base_path,
+        "duration_seconds": duration_seconds,
+        "evidence_window_start": window_start,
+        "evidence_window_end": window_end,
+        "act_map_path": act_map_path,
+        "verify_policy": verify_policy,
+        "max_samples": max_samples,
+    }
+
+    paths = {
+        "metadata_json": artifact_dir / "metadata.json",
+        "observe_json": artifact_dir / "observe.json",
+        "orient_json": artifact_dir / "orient.json",
+        "decide_json": artifact_dir / "decide.json",
+        "verify_json": artifact_dir / "verify.json",
+        "status_json": artifact_dir / "status.json",
+    }
+    write_json(paths["metadata_json"], metadata)
+    write_json(paths["observe_json"], observe_json)
+    write_json(paths["orient_json"], orient_json)
+    write_json(paths["decide_json"], decide_json)
+    write_json(paths["verify_json"], verify_json)
+    write_json(paths["status_json"], status_json)
+
+    return ReplaySummary(
+        artifact_dir=str(artifact_dir),
+        overall_status=status_report.overall_status,
+        verify_status=verify_report.status,
+        captured_logs=captured_logs,
+        observe_json=str(paths["observe_json"]),
+        orient_json=str(paths["orient_json"]),
+        decide_json=str(paths["decide_json"]),
+        verify_json=str(paths["verify_json"]),
+        status_json=str(paths["status_json"]),
+        metadata_json=str(paths["metadata_json"]),
+    )
+
+
+def summary_to_text(summary: ReplaySummary) -> str:
+    lines = [
+        f"GOAL LOOP Live Replay: {summary.overall_status}",
+        f"verify_status: {summary.verify_status}",
+        f"artifact_dir: {summary.artifact_dir}",
+        f"captured_logs: {', '.join(summary.captured_logs)}",
+        f"observe_json: {summary.observe_json}",
+        f"orient_json: {summary.orient_json}",
+        f"decide_json: {summary.decide_json}",
+        f"verify_json: {summary.verify_json}",
+        f"status_json: {summary.status_json}",
+        f"metadata_json: {summary.metadata_json}",
+    ]
+    return "\n".join(lines)
+
+
+def should_fail(summary: ReplaySummary, mode: str) -> bool:
+    if mode == "none":
+        return False
+    if mode == "verify":
+        return summary.verify_status != "PASS"
+    if mode == "critical":
+        return summary.overall_status == "critical"
+    raise ValueError(f"unknown fail mode: {mode}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--log",
+        action="append",
+        required=True,
+        help="Runtime log file to replay. Repeat for multiple files.",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        required=True,
+        help="Directory where replay JSON artifacts will be written.",
+    )
+    parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=0.0,
+        help=(
+            "Capture only bytes appended during this window. "
+            "Use 0 to replay the current file contents."
+        ),
+    )
+    parser.add_argument(
+        "--act-map",
+        help="Optional decision-to-PR artifact map JSON.",
+    )
+    parser.add_argument(
+        "--runtime-source",
+        default="local_runtime",
+        help="Human-readable runtime source label stored in evidence metadata.",
+    )
+    parser.add_argument(
+        "--base-path",
+        help="Runtime base path associated with the captured logs.",
+    )
+    parser.add_argument(
+        "--loop-iteration",
+        default="post-act-live",
+        help="Loop iteration label stored in status.json.",
+    )
+    parser.add_argument(
+        "--verify-policy",
+        choices=("critical", "present"),
+        default="critical",
+        help="Post-ACT Orient verification policy.",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=3,
+        help="Maximum sample lines retained per Observe pattern.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "verify", "critical"),
+        default="verify",
+        help="Exit non-zero when replay reaches this condition.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    summary = replay_logs(
+        log_paths=list(args.log),
+        artifact_dir=Path(args.artifact_dir),
+        duration_seconds=max(args.duration_seconds, 0.0),
+        act_map_path=args.act_map,
+        loop_iteration=args.loop_iteration,
+        verify_policy=args.verify_policy,
+        max_samples=args.max_samples,
+        runtime_source=args.runtime_source,
+        base_path=args.base_path,
+    )
+    if args.format == "json":
+        print(json.dumps(asdict(summary), ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(summary_to_text(summary))
+    return 1 if should_fail(summary, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_goal_loop_live_replay.py
+++ b/test/test_goal_loop_live_replay.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -75,6 +76,61 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
             self.assertIsInstance(verify["evidence_window_start"], str)
             self.assertIsInstance(verify["evidence_window_end"], str)
             self.assertIsInstance(verify["checked_at"], str)
+            metadata = read_json(artifact_dir / "metadata.json")
+            self.assertEqual(metadata["max_samples"], 2)
+            self.assertEqual(metadata["max_samples_requested"], 2)
+            self.assertEqual(metadata["max_samples_effective"], 2)
+
+    def test_replay_metadata_records_requested_and_effective_max_samples(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            log_path.write_text(
+                "[INFO] provider_health_probe_completed provider=ollama\n",
+                encoding="utf-8",
+            )
+
+            goal_loop_live_replay.replay_logs(
+                log_paths=[str(log_path)],
+                artifact_dir=artifact_dir,
+                duration_seconds=0,
+                act_map_path=None,
+                loop_iteration="test-negative-max-samples",
+                verify_policy="critical",
+                max_samples=-7,
+                runtime_source="unit-test",
+                base_path=None,
+            )
+
+            metadata = read_json(artifact_dir / "metadata.json")
+            self.assertEqual(metadata["max_samples_requested"], -7)
+            self.assertEqual(metadata["max_samples_effective"], 0)
+            self.assertEqual(metadata["max_samples"], 0)
+
+    def test_capture_window_reads_from_start_after_truncation(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            log_path.write_text("old line before capture\n", encoding="utf-8")
+
+            def truncate_during_sleep(_duration: float) -> None:
+                log_path.write_text("new\n", encoding="utf-8")
+
+            with mock.patch.object(
+                goal_loop_live_replay.time,
+                "sleep",
+                side_effect=truncate_during_sleep,
+            ):
+                captured = goal_loop_live_replay.capture_log_window(
+                    [str(log_path)],
+                    artifact_dir=artifact_dir,
+                    duration_seconds=1.0,
+                )
+
+            captured_text = Path(captured[0]).read_text(encoding="utf-8")
+            self.assertEqual(captured_text, "new\n")
 
     def test_replay_keeps_loop_red_when_critical_signature_remains(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:

--- a/test/test_goal_loop_live_replay.py
+++ b/test/test_goal_loop_live_replay.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "goal_loop_live_replay.py"
+FIXTURE_DIR = REPO_ROOT / "test" / "fixtures" / "goal_loop"
+
+spec = importlib.util.spec_from_file_location("goal_loop_live_replay", SCRIPT_PATH)
+assert spec is not None
+goal_loop_live_replay = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = goal_loop_live_replay
+spec.loader.exec_module(goal_loop_live_replay)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+class GoalLoopLiveReplayTest(unittest.TestCase):
+    def test_replay_writes_pass_artifacts_for_clean_log(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            log_path.write_text(
+                "[INFO] provider_health_probe_completed provider=ollama\n",
+                encoding="utf-8",
+            )
+
+            summary = goal_loop_live_replay.replay_logs(
+                log_paths=[str(log_path)],
+                artifact_dir=artifact_dir,
+                duration_seconds=0,
+                act_map_path=None,
+                loop_iteration="test-clean",
+                verify_policy="critical",
+                max_samples=2,
+                runtime_source="unit-test",
+                base_path="/tmp/masc",
+            )
+
+            self.assertEqual(summary.verify_status, "PASS")
+            self.assertEqual(summary.overall_status, "ok")
+            self.assertTrue((artifact_dir / "metadata.json").is_file())
+            self.assertTrue((artifact_dir / "observe.json").is_file())
+            status = read_json(artifact_dir / "status.json")
+            self.assertEqual(status["loop_iteration"], "test-clean")
+            self.assertEqual(status["overall_status"], "ok")
+            verify_summary = status["phases"]["verify"]["summary"]
+            self.assertIs(verify_summary["post_act_verify"], True)
+            self.assertEqual(verify_summary["evidence_kind"], "live_runtime_logs")
+            self.assertIn("runtime_source=unit-test", verify_summary["evidence_source"])
+            self.assertIn("base_path=/tmp/masc", verify_summary["evidence_source"])
+            self.assertIsInstance(verify_summary["evidence_window_start"], str)
+            self.assertIsInstance(verify_summary["evidence_window_end"], str)
+            self.assertIsInstance(verify_summary["checked_at"], str)
+            self.assertEqual(verify_summary["violation_kinds"], [])
+            verify = read_json(artifact_dir / "verify.json")
+            self.assertIs(verify["post_act_verify"], True)
+            self.assertEqual(verify["evidence_kind"], "live_runtime_logs")
+            self.assertIn("runtime_source=unit-test", verify["evidence_source"])
+            self.assertIn("base_path=/tmp/masc", verify["evidence_source"])
+            self.assertIsInstance(verify["evidence_window_start"], str)
+            self.assertIsInstance(verify["evidence_window_end"], str)
+            self.assertIsInstance(verify["checked_at"], str)
+
+    def test_replay_keeps_loop_red_when_critical_signature_remains(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            log_path.write_text(
+                "[WARN] [Auth] archived credential sangsu.json "
+                "(reason: bare-form keeper credential is dead after "
+                "PR-3b1 starvation)\n",
+                encoding="utf-8",
+            )
+
+            summary = goal_loop_live_replay.replay_logs(
+                log_paths=[str(log_path)],
+                artifact_dir=artifact_dir,
+                duration_seconds=0,
+                act_map_path=str(FIXTURE_DIR / "act-map.startup.json"),
+                loop_iteration="test-fail",
+                verify_policy="critical",
+                max_samples=2,
+                runtime_source="unit-test",
+                base_path=None,
+            )
+
+            self.assertEqual(summary.verify_status, "FAIL")
+            self.assertEqual(summary.overall_status, "critical")
+            decide = read_json(artifact_dir / "decide.json")
+            self.assertEqual(decide["act_missing_count"], 0)
+            self.assertEqual(decide["act_linked_count"], 1)
+            verify = read_json(artifact_dir / "verify.json")
+            self.assertEqual(verify["failing_findings"][0]["finding_id"], "NF-2")
+            self.assertIs(verify["post_act_verify"], True)
+
+    def test_cli_fails_on_verify_and_writes_status_json(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            log_path.write_text(
+                "[WARN] [Keeper] executor: alive-but-stuck detected\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--log",
+                    str(log_path),
+                    "--artifact-dir",
+                    str(artifact_dir),
+                    "--act-map",
+                    str(FIXTURE_DIR / "act-map.startup.json"),
+                    "--loop-iteration",
+                    "cli-fail",
+                    "--runtime-source",
+                    "cli-test",
+                    "--base-path",
+                    "/tmp/masc",
+                    "--fail-on",
+                    "verify",
+                    "--format",
+                    "text",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("GOAL LOOP Live Replay: critical", result.stdout)
+            status = read_json(artifact_dir / "status.json")
+            self.assertEqual(status["loop_iteration"], "cli-fail")
+            self.assertEqual(status["overall_status"], "critical")
+            verify_summary = status["phases"]["verify"]["summary"]
+            self.assertIs(verify_summary["post_act_verify"], True)
+            self.assertIn("runtime_source=cli-test", verify_summary["evidence_source"])
+            self.assertIn("base_path=/tmp/masc", verify_summary["evidence_source"])
+            verify = read_json(artifact_dir / "verify.json")
+            self.assertIn("runtime_source=cli-test", verify["evidence_source"])
+            self.assertIn("base_path=/tmp/masc", verify["evidence_source"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/goal_loop_live_replay.py`, a bounded post-ACT replay runner that writes `metadata.json`, `observe.json`, `orient.json`, `decide.json`, `verify.json`, and `status.json`.
- Stamp `verify.json` and the generated `status.json` verify summary with closeout metadata: `post_act_verify=true`, `evidence_kind=live_runtime_logs`, concrete `evidence_source`, evidence window start/end, `checked_at`, and `violation_kinds`.
- Keep the PR self-contained and disjoint from strict corpus/status ingestion.
- Add focused tests for clean PASS artifacts, still-red critical evidence, CLI fail-on-verify behavior, and runtime/base-path metadata.
- Document the operator command in `docs/examples/goal-loop-live-replay.md`.

Closes #13505.

## Why This Matters

The GOAL LOOP can collect bounded post-ACT runtime evidence without hand-stitching the phase scripts. A PASS is explicitly limited to the captured log window; remaining forbidden evidence keeps the loop red with concrete samples and metadata for the completion audit path.

This PR provides the runner and artifact contract. It does not itself prove production post-ACT recovery, and it does not close the strict 206-row corpus blocker.

## Verification

- `ruff format --check scripts/goal_loop_live_replay.py test/test_goal_loop_live_replay.py`
- `ruff check scripts/goal_loop_live_replay.py test/test_goal_loop_live_replay.py`
- `python3 -m py_compile scripts/goal_loop_live_replay.py test/test_goal_loop_live_replay.py`
- `python3 test/test_goal_loop_live_replay.py`
- `git diff --check origin/main...HEAD`
- Self-contained clean-log smoke:
  `python3 scripts/goal_loop_live_replay.py --log /private/tmp/goal-loop-live-replay-clean.log --artifact-dir /private/tmp/goal-loop-live-replay-status-rebased-artifacts --act-map test/fixtures/goal_loop/act-map.startup.json --runtime-source localhost:8935 --base-path /Users/dancer/me --loop-iteration post-act-live-rebased-smoke --fail-on verify --format text`
- Smoke generated `status.json` verify summary with `verify_status=PASS`, `post_act_verify=true`, `evidence_kind=live_runtime_logs`, concrete `evidence_source`, evidence window start/end, `checked_at`, and `violation_kinds=[]`.

Known gap: `pyright` is not installed in this worktree environment.
