### PR TITLE
fix(dashboard): add git graph context strip

### DIFF
--- a/dashboard/src/components/git-graph-panel.test.ts
+++ b/dashboard/src/components/git-graph-panel.test.ts
@@ -175,6 +175,29 @@ describe('GitGraphPanel', () => {
     expect(fallbackDirtyModel.statusLabel).toBe('1 dirty worktree')
   })
 
+  it('scopes checkout dirty status to the selected repo', () => {
+    const graph = makeGraph({
+      repos: [
+        makeRepo({ id: 'repo-1', dirty: false }),
+        makeRepo({ id: 'repo-2', dirty: true }),
+      ],
+      stats: {
+        repo_count: 2,
+        agent_count: 0,
+        branch_count: 0,
+        commit_count: 0,
+        dirty_count: 1,
+        conflict_count: 0,
+      },
+    })
+
+    const model = buildGitGraphContextModel(graph, graph.repos[0]!)
+
+    expect(model.tone).toBe('clean')
+    expect(model.statusLabel).toBe('clean')
+    expect(model.dirtyCount).toBe(0)
+  })
+
   it('compacts long worktree paths for lane labels', () => {
     expect(compactGitGraphPath('/workspace/masc-mcp/.worktrees/fix-git-context')).toBe('.worktrees/fix-git-context')
     expect(compactGitGraphPath('repo')).toBe('repo')

--- a/dashboard/src/components/git-graph-panel.test.ts
+++ b/dashboard/src/components/git-graph-panel.test.ts
@@ -66,7 +66,7 @@ vi.mock('./common/time-ago', () => ({
   TimeAgo: ({ timestamp }: { timestamp?: string | null }) => h('span', null, timestamp),
 }))
 
-import { GitGraphPanel } from './git-graph-panel'
+import { buildGitGraphContextModel, compactGitGraphPath, GitGraphPanel } from './git-graph-panel'
 import { gitGraphResource, refreshGitGraph } from './git-graph-store'
 import type { GitGraphResponse } from '../api/git-graph'
 
@@ -124,6 +124,63 @@ describe('GitGraphPanel', () => {
     container.remove()
   })
 
+  it('builds compact checkout context from graph snapshot', () => {
+    const graph = makeGraph({
+      repos: [makeRepo({
+        current_branch: 'fix/git-context',
+        head: 'abcdef1234567890',
+        dirty: true,
+        branch_count: 4,
+        commit_count: 12,
+        worktree_count: 2,
+      })],
+      agents: [{
+        id: 'lane-1',
+        label: 'sangsu',
+        branch: 'fix/git-context',
+        worktree_path: '/workspace/masc-mcp/.worktrees/fix-git-context',
+        color: '#d4a14a',
+      }],
+      nodes: [{
+        id: 'branch-1',
+        kind: 'branch',
+        label: 'fix/git-context',
+        repo_id: 'repo-1',
+        agent_id: 'lane-1',
+        color: '#d4a14a',
+        status: 'current',
+        conflict: false,
+        sha: 'abcdef1234567890',
+        branch: 'fix/git-context',
+        detail: null,
+      }],
+      stats: { repo_count: 1, agent_count: 1, branch_count: 4, commit_count: 12, dirty_count: 1, conflict_count: 0 },
+    })
+
+    const model = buildGitGraphContextModel(graph, graph.repos[0]!)
+
+    expect(model.currentBranch).toBe('fix/git-context')
+    expect(model.head).toBe('abcdef1234')
+    expect(model.tone).toBe('dirty')
+    expect(model.statusLabel).toBe('1 dirty worktree')
+    expect(model.lanes[0]?.path).toBe('.worktrees/fix-git-context')
+
+    const fallbackDirtyModel = buildGitGraphContextModel(
+      makeGraph({
+        repos: [makeRepo({ dirty: true })],
+        stats: { repo_count: 1, agent_count: 0, branch_count: 0, commit_count: 0, dirty_count: 0, conflict_count: 0 },
+      }),
+      makeRepo({ dirty: true }),
+    )
+    expect(fallbackDirtyModel.statusLabel).toBe('1 dirty worktree')
+  })
+
+  it('compacts long worktree paths for lane labels', () => {
+    expect(compactGitGraphPath('/workspace/masc-mcp/.worktrees/fix-git-context')).toBe('.worktrees/fix-git-context')
+    expect(compactGitGraphPath('repo')).toBe('repo')
+    expect(compactGitGraphPath('')).toBe('workspace')
+  })
+
   it('renders loading state', () => {
     gitGraphResource.state.value = { data: null, loading: true, error: null }
     render(h(GitGraphPanel, null), container)
@@ -167,6 +224,9 @@ describe('GitGraphPanel', () => {
     expect(container.textContent).toContain('2')
     expect(container.textContent).toContain('Commits')
     expect(container.textContent).toContain('4')
+    expect(container.querySelector('[data-testid="git-graph-context-strip"]')).not.toBeNull()
+    expect(container.textContent).toContain('Current checkout')
+    expect(container.textContent).toContain('main')
   })
 
   it('renders repository selector from configured repositories', async () => {

--- a/dashboard/src/components/git-graph-panel.ts
+++ b/dashboard/src/components/git-graph-panel.ts
@@ -56,11 +56,11 @@ export function buildGitGraphContextModel(
   const repoNodes = graph.nodes.filter(node => node.repo_id === repo.id)
   const repoAgentIds = new Set(repoNodes.map(node => node.agent_id).filter((id): id is string => Boolean(id)))
   const conflictCount = repo.conflict_count
-  const dirtyCount = graph.stats.dirty_count
+  const dirtyCount = repo.dirty ? 1 : 0
   const dirtyStatusCount = dirtyCount > 0 ? dirtyCount : 1
   const tone: GitGraphContextTone =
     conflictCount > 0 ? 'conflict'
-      : repo.dirty || dirtyCount > 0 ? 'dirty'
+      : dirtyCount > 0 ? 'dirty'
         : 'clean'
 
   const statusLabel =

--- a/dashboard/src/components/git-graph-panel.ts
+++ b/dashboard/src/components/git-graph-panel.ts
@@ -7,11 +7,153 @@ import { TimeAgo } from './common/time-ago'
 import { GitGraphView } from './git-graph-view'
 import { StatTile } from './common/stat-tile'
 import { fetchRepositoriesList, type Repository } from '../api/repositories'
+import type { GitGraphResponse } from '../api/git-graph'
 import {
   cancelGitGraphRefresh,
   gitGraphResource,
   refreshGitGraph,
 } from './git-graph-store'
+
+type GitGraphContextTone = 'clean' | 'dirty' | 'conflict'
+
+export interface GitGraphContextLane {
+  readonly id: string
+  readonly label: string
+  readonly branch: string
+  readonly path: string
+  readonly color: string
+}
+
+export interface GitGraphContextModel {
+  readonly currentBranch: string
+  readonly head: string
+  readonly tone: GitGraphContextTone
+  readonly statusLabel: string
+  readonly branchCount: number
+  readonly commitCount: number
+  readonly worktreeCount: number
+  readonly dirtyCount: number
+  readonly conflictCount: number
+  readonly lanes: ReadonlyArray<GitGraphContextLane>
+}
+
+function shortRef(value: string | null): string {
+  if (!value) return 'unknown'
+  return value.length > 10 ? value.slice(0, 10) : value
+}
+
+export function compactGitGraphPath(path: string): string {
+  const normalized = path.replace(/\\/g, '/')
+  const parts = normalized.split('/').filter(Boolean)
+  if (parts.length <= 2) return normalized || 'workspace'
+  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
+}
+
+export function buildGitGraphContextModel(
+  graph: GitGraphResponse,
+  repo: GitGraphResponse['repos'][number],
+): GitGraphContextModel {
+  const repoNodes = graph.nodes.filter(node => node.repo_id === repo.id)
+  const repoAgentIds = new Set(repoNodes.map(node => node.agent_id).filter((id): id is string => Boolean(id)))
+  const conflictCount = repo.conflict_count
+  const dirtyCount = graph.stats.dirty_count
+  const dirtyStatusCount = dirtyCount > 0 ? dirtyCount : 1
+  const tone: GitGraphContextTone =
+    conflictCount > 0 ? 'conflict'
+      : repo.dirty || dirtyCount > 0 ? 'dirty'
+        : 'clean'
+
+  const statusLabel =
+    tone === 'conflict' ? `${conflictCount} conflict${conflictCount === 1 ? '' : 's'}`
+      : tone === 'dirty' ? `${dirtyStatusCount} dirty worktree${dirtyStatusCount === 1 ? '' : 's'}`
+        : 'clean'
+
+  return {
+    currentBranch: repo.current_branch ?? 'detached',
+    head: shortRef(repo.head),
+    tone,
+    statusLabel,
+    branchCount: repo.branch_count,
+    commitCount: repo.commit_count,
+    worktreeCount: repo.worktree_count,
+    dirtyCount,
+    conflictCount,
+    lanes: graph.agents
+      .filter(agent => repoAgentIds.size === 0 || repoAgentIds.has(agent.id))
+      .slice(0, 4)
+      .map(agent => ({
+        id: agent.id,
+        label: agent.label,
+        branch: agent.branch ?? 'detached',
+        path: compactGitGraphPath(agent.worktree_path),
+        color: agent.color,
+      })),
+  }
+}
+
+function toneClasses(tone: GitGraphContextTone): string {
+  if (tone === 'conflict') return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad-light)]'
+  if (tone === 'dirty') return 'border-[var(--warn-20)] bg-[var(--warn-soft)] text-[var(--warn-bright)]'
+  return 'border-[var(--ok-20)] bg-[var(--ok-soft)] text-[var(--ok-bright)]'
+}
+
+function GitGraphContextStrip({ model }: { readonly model: GitGraphContextModel }) {
+  return html`
+    <div class="grid gap-3 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]" data-testid="git-graph-context-strip">
+      <div class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="min-w-0">
+            <div class="text-2xs font-semibold uppercase tracking-[var(--track-section)] text-[var(--color-fg-muted)]">
+              Current checkout
+            </div>
+            <div class="mt-1 min-w-0 font-mono text-sm font-semibold text-[var(--color-fg-primary)] [overflow-wrap:anywhere]">
+              ${model.currentBranch}
+            </div>
+          </div>
+          <span class=${`inline-flex shrink-0 items-center rounded-full border px-2 py-1 text-2xs font-semibold uppercase tracking-[var(--track-section)] ${toneClasses(model.tone)}`}>
+            ${model.statusLabel}
+          </span>
+        </div>
+        <div class="mt-3 grid gap-2 text-2xs text-[var(--color-fg-muted)] sm:grid-cols-3">
+          <div>
+            <span class="block uppercase tracking-[var(--track-section)]">HEAD</span>
+            <span class="font-mono text-[var(--color-fg-secondary)]">${model.head}</span>
+          </div>
+          <div>
+            <span class="block uppercase tracking-[var(--track-section)]">Branches</span>
+            <span class="font-mono text-[var(--color-fg-secondary)]">${model.branchCount}</span>
+          </div>
+          <div>
+            <span class="block uppercase tracking-[var(--track-section)]">Commits</span>
+            <span class="font-mono text-[var(--color-fg-secondary)]">${model.commitCount}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+        <div class="flex items-center justify-between gap-3">
+          <div class="text-2xs font-semibold uppercase tracking-[var(--track-section)] text-[var(--color-fg-muted)]">
+            Worktree lanes
+          </div>
+          <span class="font-mono text-2xs text-[var(--color-fg-secondary)]">${model.worktreeCount}</span>
+        </div>
+        <div class="mt-2 grid gap-2">
+          ${model.lanes.length > 0 ? model.lanes.map(lane => html`
+            <div key=${lane.id} class="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-2 gap-y-1 rounded-[var(--r-0)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-2 py-1.5 text-xs sm:grid-cols-[auto_minmax(0,1fr)_minmax(0,12rem)]">
+              <span class="h-2 w-2 rounded-full" style=${{ background: lane.color }} aria-hidden="true" />
+              <span class="min-w-0 font-mono text-[var(--color-fg-primary)] [overflow-wrap:anywhere]">${lane.branch}</span>
+              <span class="col-start-2 min-w-0 text-left text-2xs text-[var(--color-fg-muted)] [overflow-wrap:anywhere] sm:col-start-auto sm:text-right">${lane.path}</span>
+            </div>
+          `) : html`
+            <div class="rounded-[var(--r-0)] border border-dashed border-[var(--color-border-subtle)] px-2 py-2 text-xs text-[var(--color-fg-muted)]">
+              No active worktree lanes in this snapshot.
+            </div>
+          `}
+        </div>
+      </div>
+    </div>
+  `
+}
 
 export function GitGraphPanel() {
   const state = gitGraphResource.state.value
@@ -70,7 +212,8 @@ export function GitGraphPanel() {
     `
   }
 
-  const repo = graph.repos[0]
+  const repo = graph.repos[0]!
+  const context = buildGitGraphContextModel(graph, repo)
 
   return html`
     <section class="grid gap-4" data-testid="git-graph-panel">
@@ -158,6 +301,8 @@ export function GitGraphPanel() {
           delta=${graph.stats.conflict_count > 0 ? { direction: 'down' as const, text: '해결 필요' } : undefined}
         />
       </div>
+
+      <${GitGraphContextStrip} model=${context} />
 
       ${graph.warnings.length > 0 ? html`
         <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-soft)] px-3 py-2 text-sm text-[var(--warn-bright)]">


### PR DESCRIPTION
## Summary

- Add a Git Graph context strip above the Cytoscape canvas with current checkout, HEAD, branch/commit counts, dirty/conflict state, and worktree lanes.
- Derive the strip from the existing git graph response instead of adding another API call.
- Cover the model builder, path compaction, dirty-label fallback, and panel rendering in the focused Git Graph panel test.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/git-graph-panel.test.ts` (11 passed)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check HEAD~1..HEAD`
- `pnpm --dir dashboard run lint` (passes with existing 3 unused-disable warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic-import/chunk-size warnings)
- Browser proof with `agent-browser` + Vite proxy mock API:
  - desktop screenshot: `/tmp/masc-git-graph-context-0506.png`
  - mobile screenshot: `/tmp/masc-git-graph-context-mobile-0506.png`
  - desktop/mobile overflow eval: `document.body.scrollWidth === document.body.clientWidth`; no overflow inside `[data-testid="git-graph-context-strip"]`

## Notes

- Opened as draft per repo workflow.
