### PR TITLE
test(keeper): audit PR creation evidence

### DIFF
--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -113,7 +113,7 @@ class KeeperAudit:
 
 
 def load_json(path: Path) -> dict[str, Any]:
-    with path.open("r", encoding="utf-8") as handle:
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
         data = json.load(handle)
     if not isinstance(data, dict):
         raise ValueError(f"{path}: expected JSON object")

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1243,6 +1243,25 @@ let test_keeper_github_pr_tool_contracts () =
     (file_contains_pattern "config/tool_policy.toml"
        {|keeper_pr_create|})
 
+let test_keeper_pr_audit_contracts () =
+  check bool "keeper fleet audit has explicit PR-create flag" true
+    (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       "--require-pr-create-evidence");
+  check bool "keeper fleet audit treats keeper_pr_create as creation evidence" true
+    (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       "PR_CREATE_TOOLS");
+  check bool "keeper fleet audit requires structured create markers" true
+    (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       "has_gh_pr_create_marker");
+  check bool "keeper fleet audit scans filesystem JSONL evidence" true
+    (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       "pr_action_metric_paths"
+     && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+          "tool_call_paths");
+  check bool "keeper fleet audit survives live invalid utf8 rows" true
+    (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       {|errors="replace"|})
+
 let test_dashboard_warm_hydration_contracts () =
   check bool "execution default route hydrates cache on first success" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
@@ -1998,6 +2017,8 @@ let () =
             test_tool_failure_classification_contracts;
           test_case "keeper github PR tool contracts" `Quick
             test_keeper_github_pr_tool_contracts;
+          test_case "keeper PR audit contracts" `Quick
+            test_keeper_pr_audit_contracts;
           test_case "dashboard warm hydration contracts" `Quick
             test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;


### PR DESCRIPTION
## Summary

- Extends `scripts/audit-keeper-fleet-readiness.py` from PR-surface usage checks to actual PR creation evidence.
- Scans filesystem JSONL evidence only: keeper decisions, playground PR history, metrics, PR-action metrics, execution receipts, and trajectories.
- Adds strict flags for `--require-pr-created-evidence` and `--require-pr-url-evidence`, with source-guard coverage so the audit does not regress.
- Hardens live JSONL reads with `errors="replace"` after the current runtime contained an invalid UTF-8 row.

## Live Evidence

Filesystem runtime, not PG/PostgreSQL:

- `/health` reported `startup.phase=ready`, `backend_mode=filesystem`, `effective_base_path=/Users/dancer/me`, `effective_masc_root=/Users/dancer/me/.masc`.
- `doctor auth --base-path /Users/dancer/me --json` confirmed the live Codex MCP token can read state from `/Users/dancer/me/.masc`.

Strict audit after this patch:

```json
{
  "ok": false,
  "pr_created_count": 3,
  "pr_url_count": 3,
  "glm": {
    "name": "glm-coding-plan",
    "pr_surface_action": true,
    "pr_created_evidence": false,
    "pr_url_evidence": false,
    "failures": [
      "pr_created_evidence_missing",
      "pr_url_evidence_missing"
    ]
  }
}
```

Live Keeper PR proof attempt:

- Sent `masc_keeper_msg` to `glm-coding-plan` asking for a docs-only worktree branch, commit, push, and draft PR.
- Poll result reached `Agent.run failed: Timeout: Timeout after 300.0s (budget=300s)`.
- Filesystem evidence then showed `keeper_shell` repo access was denied, `masc_worktree_create` succeeded, and the turn ended as `api_error_timeout`; no PR URL evidence appeared.
- GitHub live search for open PRs created on 2026-05-05/06 did not show a matching Keeper proof PR.

This PR intentionally makes that missing proof visible as an audit failure instead of accepting PR-tool-surface evidence as enough.

## Validation

- `ruff check scripts/audit-keeper-fleet-readiness.py`
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py`
- `git diff --check origin/main..HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/dune-local.sh build ./test/test_ci_hardening_source.exe` (passed before final rebase; post-rebase rerun was blocked by shared opam/Dune lock contention)
- `./_build/default/test/test_ci_hardening_source.exe test source_guard 20`
- `python3 scripts/audit-keeper-fleet-readiness.py --base-path /Users/dancer/me --expected-keepers 17 --max-silence-hours 72 --require-pr-surface-evidence --require-pr-created-evidence --require-pr-url-evidence --json`

## Notes

- `pyright --outputjson scripts/audit-keeper-fleet-readiness.py` could not be run locally because `pyright` is not installed in this shell.