### PR TITLE
fix(keeper): clarify sandbox container visibility

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -354,10 +354,10 @@ let why_no_container (meta : keeper_meta) ~preflight containers =
         match meta.network_mode with
         | Network_inherit ->
             Some
-              "network_mode=inherit uses one-shot Docker containers unless a managed sandbox is explicitly started"
+              "no visible managed sandbox container; network_mode=inherit uses one-shot Docker containers on sandboxed tool calls, and those containers still mount the keeper playground"
         | Network_none ->
             Some
-              "no active turn or managed sandbox container; Docker containers start on sandboxed tool calls or via masc_keeper_sandbox_start")
+              "no active turn or visible managed sandbox container; Docker containers start on sandboxed tool calls or via masc_keeper_sandbox_start, with the keeper playground mounted")
 
 let recommendation (meta : keeper_meta) ~preflight containers =
   if meta.sandbox_profile = Local then
@@ -372,7 +372,7 @@ let recommendation (meta : keeper_meta) ~preflight containers =
     | _ ->
         Some
           (Printf.sprintf
-             "Run masc_keeper_sandbox_start with name=%S to prewarm a visible managed container."
+             "Run masc_keeper_sandbox_start with name=%S only when you need a visible prewarmed container; repo access also requires playground_repos to include the target repo."
              meta.name)
 
 let identity_json (meta : keeper_meta) =

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -179,6 +179,10 @@ let () =
             Test_operator_control_keeper
             .test_keeper_sandbox_status_exposes_local_summary;
           Alcotest.test_case
+            "keeper sandbox status clarifies visible container gap" `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_status_clarifies_visible_container_gap;
+          Alcotest.test_case
             "keeper sandbox fleet includes persisted keeper" `Quick
             Test_operator_control_keeper
             .test_keeper_sandbox_status_fleet_includes_persisted_keeper;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -343,6 +343,92 @@ let test_keeper_sandbox_status_exposes_local_summary () =
                   "repos/sandbox-repo")
            status_repos))
 
+let test_keeper_sandbox_status_clarifies_visible_container_gap () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "sandbox-docker-visible-gap" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Inspect visible Docker container gap");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      update_keeper_sandbox_mode config keeper_name
+        ~sandbox_profile:Keeper_types.Docker
+        ~network_mode:Keeper_types.Network_inherit;
+      Keeper_status_detail.invalidate_status_cache_for keeper_name;
+      let state_dir = Filename.concat base_dir "fake-docker" in
+      let state_file = Filename.concat state_dir "containers.tsv" in
+      let log_path = Filename.concat state_dir "docker.log" in
+      ensure_dir state_dir;
+      with_fake_docker fake_docker_managed_sandbox_script @@ fun () ->
+      with_env "KEEPER_DOCKER_STATE_FILE" state_file @@ fun () ->
+      with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("include_preflight", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "sandbox status ok" true ok;
+      let open Yojson.Safe.Util in
+      let sandbox_json =
+        parse_json_exn body |> Yojson.Safe.Util.member "sandbox"
+      in
+      Alcotest.(check string) "effective mode"
+        "oneshot_or_managed_inherit"
+        (sandbox_json |> member "effective_mode" |> to_string);
+      Alcotest.(check int) "no visible containers" 0
+        (sandbox_json |> member "container_count" |> to_int);
+      let why_no_container =
+        sandbox_json |> member "why_no_container" |> to_string
+      in
+      Alcotest.(check bool) "reason says visible managed container" true
+        (contains_substring why_no_container
+           "no visible managed sandbox container");
+      Alcotest.(check bool) "reason says one-shot still mounts playground" true
+        (contains_substring why_no_container
+           "still mount the keeper playground");
+      let recommendation =
+        sandbox_json |> member "recommendation" |> to_string
+      in
+      Alcotest.(check bool) "recommendation scopes prewarm" true
+        (contains_substring recommendation
+           "only when you need a visible prewarmed container");
+      Alcotest.(check bool) "recommendation mentions repo readiness" true
+        (contains_substring recommendation "playground_repos"))
+
 let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
Summary:
- clarify keeper sandbox status when no visible managed container is running
- distinguish visible/prewarmed managed containers from one-shot Docker tool calls that still mount the keeper playground
- add an operator-control regression for Docker/inherit status guidance

Why it matters:
- live keeper board/runtime diagnosis treated container_count=0 as missing repo mounts
- code and live Docker proof show one-shot/managed containers mount the keeper playground; repo access failures should check playground_repos/repo readiness instead of assuming mount absence

Validation:
- git diff --check origin/main...HEAD
- MASC_SKIP_OPAM_LOCK=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_operator_control.exe
- MASC_SKIP_OPAM_LOCK=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh exec ./test/test_operator_control.exe -- test operator 46
- gh pr checks 13510 --watch --interval 10

Review focus:
- wording in keeper_sandbox_control.ml for why_no_container/recommendation
- regression coverage for the Docker visible-container gap