### PR TITLE
[codex] Cover Docker multi-keeper isolation

### DIFF
--- a/scripts/keeper-docker-multikeeper-isolation-smoke.sh
+++ b/scripts/keeper-docker-multikeeper-isolation-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image_tag="${MASC_KEEPER_SANDBOX_DOCKER_IMAGE:-masc-keeper-sandbox:local}"
+
+if ! docker image inspect "$image_tag" >/dev/null 2>&1; then
+  "$repo_root/scripts/build-keeper-sandbox-image.sh" "$image_tag"
+fi
+
+security_options="$(docker info --format '{{json .SecurityOptions}}' 2>/dev/null || true)"
+if [[ "${MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS:-false}" == "true" ]] \
+  && ! grep -qi 'rootless' <<<"$security_options"; then
+  printf 'FAIL: Docker rootless mode required but not reported by docker info\n' >&2
+  exit 1
+fi
+if [[ "${MASC_KEEPER_SANDBOX_REQUIRE_USERNS:-false}" == "true" ]] \
+  && ! grep -qi 'userns' <<<"$security_options"; then
+  printf 'FAIL: Docker userns support required but not reported by docker info\n' >&2
+  exit 1
+fi
+if ! grep -qi 'rootless' <<<"$security_options"; then
+  printf 'WARN: Docker rootless mode not reported; continuing because it is not required\n' >&2
+fi
+if ! grep -qi 'userns' <<<"$security_options"; then
+  printf 'WARN: Docker userns support not reported; continuing because it is not required\n' >&2
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$tmpdir/playgrounds/keeper-a" "$tmpdir/playgrounds/keeper-b"
+mkdir -p "$tmpdir/creds/keeper-a/gh" "$tmpdir/creds/keeper-b/gh"
+printf 'keeper-a-playground\n' > "$tmpdir/playgrounds/keeper-a/own.txt"
+printf 'keeper-b-playground\n' > "$tmpdir/playgrounds/keeper-b/own.txt"
+printf 'keeper-a-gh\n' > "$tmpdir/creds/keeper-a/gh/identity.txt"
+printf 'keeper-b-gh\n' > "$tmpdir/creds/keeper-b/gh/identity.txt"
+printf 'keeper-a-gh-only\n' > "$tmpdir/creds/keeper-a/gh/keeper-a.txt"
+printf 'keeper-b-gh-only\n' > "$tmpdir/creds/keeper-b/gh/keeper-b.txt"
+
+run_keeper() {
+  local keeper="$1"
+  local other="$2"
+  local playground="$tmpdir/playgrounds/$keeper"
+  local gh_dir="$tmpdir/creds/$keeper/gh"
+  local expected="$keeper-gh"
+  local expected_playground="$keeper-playground"
+
+  docker run --rm -i \
+    --user "$(id -u):$(id -g)" \
+    --read-only \
+    --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+    --cap-drop=ALL \
+    --security-opt no-new-privileges \
+    --network none \
+    -v "$playground:/workspace:rw" \
+    -v "$gh_dir:/tmp/keeper-creds/.config/gh:ro" \
+    --workdir /workspace \
+    -e "EXPECTED_IDENTITY=$expected" \
+    -e "EXPECTED_PLAYGROUND=$expected_playground" \
+    -e "OTHER_KEEPER=$other" \
+    "$image_tag" \
+    bash -lc '
+      set -euo pipefail
+      test "$(cat own.txt)" = "$EXPECTED_PLAYGROUND"
+      test ! -e "/workspace/$OTHER_KEEPER"
+      test "$(cat /tmp/keeper-creds/.config/gh/identity.txt)" = "$EXPECTED_IDENTITY"
+      test -e "/tmp/keeper-creds/.config/gh/${EXPECTED_IDENTITY%-gh}.txt"
+      test ! -e "/tmp/keeper-creds/.config/gh/${OTHER_KEEPER}.txt"
+      if (printf probe >/tmp/keeper-creds/.config/gh/write-probe) 2>/dev/null; then
+        printf "credential projection is writable\n" >&2
+        exit 21
+      fi
+      printf "ok\n" > write-ok.txt
+    ' >/dev/null
+
+  test "$(cat "$playground/write-ok.txt")" = "ok"
+}
+
+run_keeper keeper-a keeper-b
+run_keeper keeper-b keeper-a
+
+printf 'keeper docker multi-keeper isolation smoke passed for %s\n' "$image_tag"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -829,6 +829,51 @@ let test_keeper_sandbox_credential_volume_contracts () =
     (file_contains_pattern "lib/keeper/host_config_provider.ml"
        {|let cred_root = "/tmp/keeper-creds"|})
 
+let test_keeper_docker_multikeeper_isolation_contracts () =
+  check bool "multi-keeper docker smoke script exists" true
+    (Sys.file_exists
+       (source_path "scripts/keeper-docker-multikeeper-isolation-smoke.sh"));
+  check bool "smoke mounts credential projection read-only" true
+    (file_contains_pattern
+       "scripts/keeper-docker-multikeeper-isolation-smoke.sh"
+       {|:/tmp/keeper-creds/.config/gh:ro|});
+  check bool "smoke probes credential projection write failure" true
+    (file_contains_pattern
+       "scripts/keeper-docker-multikeeper-isolation-smoke.sh"
+       "credential projection is writable");
+  check bool "smoke creates keeper credential sentinels" true
+    (file_contains_pattern
+       "scripts/keeper-docker-multikeeper-isolation-smoke.sh"
+       "keeper-a-gh-only"
+     && file_contains_pattern
+          "scripts/keeper-docker-multikeeper-isolation-smoke.sh"
+          "keeper-b-gh-only");
+  check bool "smoke rejects sibling credential sentinel" true
+    (file_contains_pattern
+       "scripts/keeper-docker-multikeeper-isolation-smoke.sh"
+       {|test ! -e "/tmp/keeper-creds/.config/gh/${OTHER_KEEPER}.txt"|});
+  check bool "smoke covers two keepers" true
+    (file_contains_pattern
+       "scripts/keeper-docker-multikeeper-isolation-smoke.sh"
+       "run_keeper keeper-a keeper-b"
+     && file_contains_pattern
+          "scripts/keeper-docker-multikeeper-isolation-smoke.sh"
+          "run_keeper keeper-b keeper-a");
+  check bool "unit test asserts selected keeper identity only" true
+    (file_contains_pattern "test/test_keeper_shell_docker_route.ml"
+       "test_git_creds_mounts_only_selected_keeper_identity");
+  check bool "unit test rejects sibling keeper credential mount" true
+    (file_contains_pattern "test/test_keeper_shell_docker_route.ml"
+       "sibling keeper bundle not mounted");
+  check bool "unit test rejects sibling keeper playground mount" true
+    (file_contains_pattern "test/test_keeper_shell_docker_route.ml"
+       "does not mount keeper B playground");
+  check bool "rootless and userns checks remain explicit" true
+    (file_contains_pattern "lib/keeper/keeper_sandbox_runtime.ml"
+       "sandbox runtime requires Docker rootless mode"
+     && file_contains_pattern "lib/keeper/keeper_sandbox_runtime.ml"
+          "sandbox runtime requires Docker userns support")
+
 let test_board_flusher_start_retry_contracts () =
   check bool "board flusher start has bounded CAS retry count" true
     (file_contains_pattern "lib/board_dispatch.ml"
@@ -1618,6 +1663,8 @@ let () =
              test_keeper_list_cache_atomic_contracts;
            test_case "keeper sandbox credential volume contracts" `Quick
              test_keeper_sandbox_credential_volume_contracts;
+           test_case "keeper docker multi-keeper isolation contracts" `Quick
+             test_keeper_docker_multikeeper_isolation_contracts;
            test_case "board flusher start retry contracts" `Quick
              test_board_flusher_start_retry_contracts;
            test_case "docker config storage contracts" `Quick

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -166,19 +166,22 @@ let with_fake_docker script f =
 let with_tool_policy_config f =
   let project_root = Masc_test_deps.find_project_root () in
   let config_dir = Filename.concat project_root "config" in
+  with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
+  Masc_mcp.Config_dir_resolver.reset ();
   Tool_code_write.reset_policy_config_cache ();
   Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ();
-  (match
-     Masc_mcp.Keeper_tool_policy.init_policy_config ~base_path:project_root
-   with
-   | Ok () -> ()
-   | Error e -> Alcotest.failf "init_policy_config failed: %s" e);
-  with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
   Fun.protect
     ~finally:(fun () ->
       Tool_code_write.reset_policy_config_cache ();
-      Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ())
-    f
+      Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ();
+      Masc_mcp.Config_dir_resolver.reset ())
+    (fun () ->
+      (match
+         Masc_mcp.Keeper_tool_policy.init_policy_config ~base_path:project_root
+       with
+       | Ok () -> ()
+       | Error e -> Alcotest.failf "init_policy_config failed: %s" e);
+      f ())
 
 let with_config_dir config_dir f =
   let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -126,11 +126,34 @@ let setup ~sandbox f =
   ensure_dir playground;
   f ~config ~meta ~playground
 
+let setup_two_docker_keepers f =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  ensure_dir (Filename.concat base Common.masc_dirname);
+  let config = Coord.default_config base in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta_a = make_meta ~name:"keeper-a" ~sandbox:Keeper_types.Docker in
+  let meta_b = make_meta ~name:"keeper-b" ~sandbox:Keeper_types.Docker in
+  let playground_a = Keeper_sandbox.host_root_abs_of_meta ~config meta_a in
+  let playground_b = Keeper_sandbox.host_root_abs_of_meta ~config meta_b in
+  ensure_dir playground_a;
+  ensure_dir playground_b;
+  f ~config ~meta_a ~playground_a ~meta_b ~playground_b
+
 let with_fake_docker script f =
   let dir = temp_dir () in
   let docker_path = Filename.concat dir "docker" in
+  let gh_path = Filename.concat dir "gh" in
   write_file docker_path script;
+  write_file gh_path
+    "#!/bin/sh\n\
+     if [ \"$1\" = \"auth\" ] && [ \"$2\" = \"status\" ]; then\n\
+       exit 0\n\
+     fi\n\
+     exit 0\n";
   Unix.chmod docker_path 0o755;
+  Unix.chmod gh_path 0o755;
   let path =
     match Sys.getenv_opt "PATH" with
     | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
@@ -141,12 +164,21 @@ let with_fake_docker script f =
   with_env "PATH" path f
 
 let with_tool_policy_config f =
-  let config_dir =
-    Filename.concat (Masc_test_deps.find_project_root ()) "config"
-  in
+  let project_root = Masc_test_deps.find_project_root () in
+  let config_dir = Filename.concat project_root "config" in
   Tool_code_write.reset_policy_config_cache ();
+  Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ();
+  (match
+     Masc_mcp.Keeper_tool_policy.init_policy_config ~base_path:project_root
+   with
+   | Ok () -> ()
+   | Error e -> Alcotest.failf "init_policy_config failed: %s" e);
   with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
-  Fun.protect ~finally:Tool_code_write.reset_policy_config_cache f
+  Fun.protect
+    ~finally:(fun () ->
+      Tool_code_write.reset_policy_config_cache ();
+      Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ())
+    f
 
 let with_config_dir config_dir f =
   let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
@@ -819,6 +851,85 @@ let test_git_creds_uses_github_identity_mode () =
     (contains_substring line
        "GIT_AUTHOR_EMAIL=anyang-keepers@users.noreply.github.com")
 
+let test_git_creds_mounts_only_selected_keeper_identity () =
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup_two_docker_keepers
+  @@ fun ~config ~meta_a ~playground_a ~meta_b ~playground_b ->
+  let identity_a = "keeper-a-gh" in
+  let identity_b = "keeper-b-gh" in
+  ensure_github_identity_bundle ~config
+    Masc_mcp.Keeper_gh_env.root_github_identity;
+  ensure_github_identity_bundle ~config identity_a;
+  ensure_github_identity_bundle ~config identity_b;
+  let root_gh_dir = Masc_mcp.Keeper_gh_env.root_gh_config_dir config in
+  let gh_dir id =
+    Masc_mcp.Keeper_gh_env.gh_config_dir_of_bundle
+      (Masc_mcp.Keeper_gh_env.bundle_root config ~github_identity:id)
+  in
+  let run_for ~(meta : Keeper_types.keeper_meta) ~playground ~github_identity
+      ~other_identity ~log_name =
+    with_keeper_identity_toml ~config ~keeper_name:meta.name
+      ~github_identity ~git_identity_mode:"github_identity"
+    @@ fun () ->
+    let log_path = Filename.concat config.Coord.base_path log_name in
+    let line =
+      run_git_creds_docker_shell ~config ~meta ~playground ~log_path
+    in
+    let selected_gh = gh_dir github_identity in
+    let other_gh = gh_dir other_identity in
+    let mounted_playground =
+      Keeper_alerting_path.normalize_path_for_check playground
+      |> Keeper_alerting_path.strip_trailing_slashes
+    in
+    Alcotest.(check bool)
+      (github_identity ^ " selected GH bundle mounted read-only")
+      true
+      (contains_substring line
+         (selected_gh ^ ":/tmp/keeper-creds/.config/gh:ro"));
+    Alcotest.(check bool)
+      (github_identity ^ " root fallback bundle not mounted")
+      false
+      (contains_substring line
+         (root_gh_dir ^ ":/tmp/keeper-creds/.config/gh:ro"));
+    Alcotest.(check bool)
+      (github_identity ^ " sibling keeper bundle not mounted")
+      false
+      (contains_substring line
+         (other_gh ^ ":/tmp/keeper-creds/.config/gh:ro"));
+    Alcotest.(check bool)
+      (github_identity ^ " own playground mounted")
+      true
+      (contains_substring line
+         (mounted_playground ^ ":"
+          ^ Keeper_sandbox.container_root meta.name
+          ^ ":rw"));
+    line
+  in
+  let mounted_playground_a =
+    Keeper_alerting_path.normalize_path_for_check playground_a
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let mounted_playground_b =
+    Keeper_alerting_path.normalize_path_for_check playground_b
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let line_a =
+    run_for ~meta:meta_a ~playground:playground_a
+      ~github_identity:identity_a ~other_identity:identity_b
+      ~log_name:"docker-a.log"
+  in
+  let line_b =
+    run_for ~meta:meta_b ~playground:playground_b
+      ~github_identity:identity_b ~other_identity:identity_a
+      ~log_name:"docker-b.log"
+  in
+  Alcotest.(check bool) "keeper A docker run does not mount keeper B playground"
+    false
+    (contains_substring line_a mounted_playground_b);
+  Alcotest.(check bool) "keeper B docker run does not mount keeper A playground"
+    false
+    (contains_substring line_b mounted_playground_a)
+
 let test_git_clone_repairs_existing_docker_clone_checkout () =
   with_tool_policy_config @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -970,6 +1081,9 @@ let () =
           Alcotest.test_case
             "git-creds uses GitHub author only in github_identity mode"
             `Quick test_git_creds_uses_github_identity_mode;
+          Alcotest.test_case
+            "git-creds mounts only the selected keeper identity"
+            `Quick test_git_creds_mounts_only_selected_keeper_identity;
           Alcotest.test_case "hard mode git_clone uses brokered route" `Quick
             test_hard_mode_git_clone_uses_brokered_route;
 	          Alcotest.test_case "git_clone repairs existing docker clone checkout"


### PR DESCRIPTION
## Summary
- add a Docker smoke script that runs two keepers with separate playground and GH credential projections
- add Alcotest coverage that git credential Docker runs mount only the selected keeper identity
- add source-hardening guards for the smoke script and isolation contracts
- initialize Keeper_tool_policy in docker route tests so git_clone route cases load clone_depth config explicitly

## Why
This locks down the multi-keeper Docker boundary: one keeper should not see a sibling keeper's playground or GitHub credential bundle, and the projected GH config must stay read-only inside the container.

## Validation
- `git diff --check origin/main...HEAD`
- `bash -n scripts/keeper-docker-multikeeper-isolation-smoke.sh`
- `DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh exec ./test/test_ci_hardening_source.exe -- test source_guard 16`
  - result: 1 focused source guard passed, run ID `XUZCGKC6`
- `DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh exec ./test/test_keeper_shell_docker_route.exe -- test -q`
  - result: 24 tests passed, run ID `XCBWY8KS`
- `scripts/keeper-docker-multikeeper-isolation-smoke.sh`
  - result: keeper docker multi-keeper isolation smoke passed for `masc-keeper-sandbox:local`

## Review focus
- The Docker smoke must preserve separate `/workspace` mounts per keeper.
- The GH credential projection must stay scoped to the selected keeper and mounted read-only.
- The route tests should keep git credential Docker behavior explicit without weakening legacy non-Docker cases.
