### PR TITLE
docs(rfc): clarify RFC-0027 pin dedupe

### DIFF
--- a/dashboard/design-system/RFC/0027-multi-keeper-bdi-peek.md
+++ b/dashboard/design-system/RFC/0027-multi-keeper-bdi-peek.md
@@ -79,7 +79,7 @@ placement: RFC 0024 의 single-slot 위치 (`ide-shell.ts` 우측). single-pin c
 
 | Action | Result |
 |--------|--------|
-| line click (RFC 0019 ownership) → `setPinnedKeeper(K)` | K 가 이미 pinned 면 기존 entry 를 제거하고 새 `pinned_at_ms` 로 head 에 prepend. `candidate = [entry(K, now), ...prev.filter(e => e.keeper_id !== K)]`; cap 초과 시 array tail 이 아니라 `min(pinned_at_ms)` entry 를 drop. |
+| line click (RFC 0019 ownership) → `setPinnedKeeper(K)` | K 가 이미 pinned 면 기존 entry 를 제거하고 새 `pinned_at_ms` 로 head 에 prepend. `candidate = [entry(K, now), ...prev.filter(e => e.keeper_id !== K)]`; cap 초과 시 array tail 이 아니라 `min(pinned_at_ms)` entry 를 drop. tie 면 minima 중 current UI order 에서 가장 뒤의 entry 를 drop. |
 | command palette `Pin keeper <id>` | 같은 reorder/cap 로직 |
 | X 버튼 또는 `Esc` (RFC 0012) | 활성 pin (focus 된 entry) unpin. focus 없으면 head unpin. |
 | drag (mouse 또는 keyboard `Alt+ArrowLeft/Right`) | `reorderPins` 호출, source_line 보존 |
@@ -166,7 +166,7 @@ rollup 은 client-side 계산 (server-side aggregation 안 함 — RFC 0026 audi
 
 **State migration**: 기존 `keeper-pin-store.ts` (single keeper id 를 hold) → `multi-keeper-pin-store.ts` 로 import path 변경. v1 에 stored single pin 이 있으면 startup 에 entries=[그 keeper] 로 hydrate (localStorage 호환).
 
-**Hook entry point**: `setPinnedKeeper(K)` 시그니처 유지 (single keeper id 받음) — internally existing K 를 먼저 제거한 뒤 `candidate = [entry(K, now), ...prev.filter(e => e.keeper_id !== K)]` 를 만들고, cap 초과 시 `pinned_at_ms` 가 가장 오래된 entry 를 drop. repeated pin 은 duplicate 없이 single entry 를 head 로 promote. v1 caller 변경 없음.
+**Hook entry point**: `setPinnedKeeper(K)` 시그니처 유지 (single keeper id 받음) — internally existing K 를 먼저 제거한 뒤 `candidate = [entry(K, now), ...prev.filter(e => e.keeper_id !== K)]` 를 만들고, cap 초과 시 `pinned_at_ms` 가 가장 오래된 entry 를 drop. tie 면 minima 중 current UI order 에서 가장 뒤의 entry 를 drop. repeated pin 은 duplicate 없이 single entry 를 head 로 promote. v1 caller 변경 없음.
 
 ## 11. Open questions
 

--- a/dashboard/design-system/RFC/0027-multi-keeper-bdi-peek.md
+++ b/dashboard/design-system/RFC/0027-multi-keeper-bdi-peek.md
@@ -35,7 +35,7 @@ RFC 0024 §2 Non-Goal #3 가 "multi-keeper compare view 는 별도 RFC" 로 defe
 ```ts
 // dashboard/src/components/ide/multi-keeper-pin-store.ts
 export interface PinnedKeepers {
-  // ordered, max 4. head = most recently pinned.
+  // UI order, max 4. pinKeeper prepends; reorderPins may change order without changing pinned_at_ms.
   readonly entries: ReadonlyArray<PinnedKeeperEntry>
   // global cap; future RFC may parameterize.
   readonly cap: 4
@@ -79,7 +79,7 @@ placement: RFC 0024 의 single-slot 위치 (`ide-shell.ts` 우측). single-pin c
 
 | Action | Result |
 |--------|--------|
-| line click (RFC 0019 ownership) → `setPinnedKeeper(K)` | K 가 이미 pinned 면 head 로 reorder. 아니면 `entries = [K, ...prev].slice(0, cap)`. Cap 초과 시 LRU (가장 오래된 `pinned_at_ms`) drop. |
+| line click (RFC 0019 ownership) → `setPinnedKeeper(K)` | K 가 이미 pinned 면 기존 entry 를 제거하고 새 `pinned_at_ms` 로 head 에 prepend. `candidate = [entry(K, now), ...prev.filter(e => e.keeper_id !== K)]`; cap 초과 시 array tail 이 아니라 `min(pinned_at_ms)` entry 를 drop. |
 | command palette `Pin keeper <id>` | 같은 reorder/cap 로직 |
 | X 버튼 또는 `Esc` (RFC 0012) | 활성 pin (focus 된 entry) unpin. focus 없으면 head unpin. |
 | drag (mouse 또는 keyboard `Alt+ArrowLeft/Right`) | `reorderPins` 호출, source_line 보존 |
@@ -166,7 +166,7 @@ rollup 은 client-side 계산 (server-side aggregation 안 함 — RFC 0026 audi
 
 **State migration**: 기존 `keeper-pin-store.ts` (single keeper id 를 hold) → `multi-keeper-pin-store.ts` 로 import path 변경. v1 에 stored single pin 이 있으면 startup 에 entries=[그 keeper] 로 hydrate (localStorage 호환).
 
-**Hook entry point**: `setPinnedKeeper(K)` 시그니처 유지 (single keeper id 받음) — internally `entries = [K, ...prev].slice(0, cap)` 로 위임. v1 caller 변경 없음.
+**Hook entry point**: `setPinnedKeeper(K)` 시그니처 유지 (single keeper id 받음) — internally existing K 를 먼저 제거한 뒤 `candidate = [entry(K, now), ...prev.filter(e => e.keeper_id !== K)]` 를 만들고, cap 초과 시 `pinned_at_ms` 가 가장 오래된 entry 를 drop. repeated pin 은 duplicate 없이 single entry 를 head 로 promote. v1 caller 변경 없음.
 
 ## 11. Open questions
 


### PR DESCRIPTION
Follow-up for #13289 review threads.\n\nAddresses unresolved review feedback on RFC-0027 pin behavior:\n- dedupe existing keeper before prepending on repeated pin\n- make cap eviction use oldest pinned_at_ms rather than array tail after drag reorder\n\nValidation: doc-only change; CI dashboard/doc gates will run on PR.