### PR TITLE
fix(board): complete curation snapshot contract

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -17,14 +17,14 @@ tools = ["keeper_time_now", "keeper_context_status", "keeper_memory_search", "ke
 
 # Board tools split: core (frequent) vs extended (discoverable via tool_search).
 [groups.board_core]
-tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list"]
+tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list", "keeper_board_curation_read", "keeper_board_curation_submit"]
 
 [groups.board_extended]
 tools = ["keeper_board_stats", "keeper_board_search"]
 
 # Full board group: backward compat alias.
 [groups.board]
-tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list", "keeper_board_stats", "keeper_board_search"]
+tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list", "keeper_board_curation_read", "keeper_board_curation_submit", "keeper_board_stats", "keeper_board_search"]
 
 # Coordination split: core (task lifecycle) vs extended (audit, force ops).
 [groups.coordination_core]
@@ -70,7 +70,7 @@ tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_she
 # Tools allowed on the keeper's last turn (safety constraint).
 # On last turn, visible tools are intersected with this set.
 [groups.last_turn_safe]
-tools = ["keeper_board_post", "keeper_board_comment", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_tool_search", "keeper_broadcast", "keeper_task_done", "masc_web_search"]
+tools = ["keeper_board_post", "keeper_board_comment", "keeper_board_curation_submit", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_tool_search", "keeper_broadcast", "keeper_task_done", "masc_web_search"]
 
 # Optional tools that require explicit opt-in via also_allow.
 # Excluded from all presets by default; a keeper must list them in also_allow.

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -4,6 +4,7 @@ import {
   createSubBoard,
   createPost,
   fetchBoard,
+  fetchBoardCuration,
   fetchBoardHearths,
   fetchBoardPost,
   fetchBoardReactions,
@@ -540,6 +541,87 @@ describe('fetchBoardHearths', () => {
       { name: 'research', count: 0 },
     ])
     expect(fetchMock).toHaveBeenCalledWith('/api/v1/board/hearths', expect.any(Object))
+  })
+})
+
+describe('fetchBoardCuration', () => {
+  it('normalizes summary, tags, answer matches, and health score from the curation snapshot', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        snapshot: {
+          id: 'cu-1',
+          generated_at: 1_748_779_200,
+          submitted_by: 'keeper-curator',
+          model: 'gpt-5',
+          summary: 'Two active incidents need review.',
+          ordering: ['post-a', 'post-b'],
+          highlights: ['post-a'],
+          tag_suggestions: [
+            { post_id: 'post-a', tags: ['incident', 'ops'], rationale: 'Incident thread' },
+            { post_id: ' ', tags: ['ignored'], rationale: 'missing post id' },
+          ],
+          answer_matches: [
+            {
+              question_post_id: 'post-question',
+              answer_post_id: 'post-answer',
+              score: 0.86,
+              rationale: 'Same stack trace',
+            },
+          ],
+          health_score: 0.74,
+          health_components: [
+            { name: 'answer_rate', score: 0.8, weight: 0.25, rationale: 'Most questions have replies' },
+          ],
+          rationale: 'Prioritize incidents before planning threads.',
+          provenance: { run_id: 'curation-run-1' },
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoardCuration()
+
+    expect(result).toMatchObject({
+      id: 'cu-1',
+      submitted_by: 'keeper-curator',
+      model: 'gpt-5',
+      summary: 'Two active incidents need review.',
+      ordering: ['post-a', 'post-b'],
+      highlights: ['post-a'],
+      tag_suggestions: [
+        { post_id: 'post-a', tags: ['incident', 'ops'], rationale: 'Incident thread' },
+      ],
+      answer_matches: [
+        {
+          question_post_id: 'post-question',
+          answer_post_id: 'post-answer',
+          score: 0.86,
+          rationale: 'Same stack trace',
+        },
+      ],
+      health_score: 0.74,
+      health_components: [
+        { name: 'answer_rate', score: 0.8, weight: 0.25, rationale: 'Most questions have replies' },
+      ],
+      rationale: 'Prioritize incidents before planning threads.',
+      provenance: { run_id: 'curation-run-1' },
+    })
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/board/curation', expect.any(Object))
+  })
+
+  it('returns null when no curation snapshot exists', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ snapshot: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchBoardCuration()).resolves.toBeNull()
   })
 })
 

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -554,8 +554,8 @@ describe('fetchBoardCuration', () => {
           submitted_by: 'keeper-curator',
           model: 'gpt-5',
           summary: 'Two active incidents need review.',
-          ordering: ['post-a', 'post-b'],
-          highlights: ['post-a'],
+          ordering: ['post-a', { id: 'not-coerced' }, 'post-b', 7, ' '],
+          highlights: ['post-a', { name: 'not-coerced' }, null],
           tag_suggestions: [
             { post_id: 'post-a', tags: ['incident', 'ops'], rationale: 'Incident thread' },
             { post_id: ' ', tags: ['ignored'], rationale: 'missing post id' },

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -557,7 +557,7 @@ describe('fetchBoardCuration', () => {
           ordering: ['post-a', { id: 'not-coerced' }, 'post-b', 7, ' '],
           highlights: ['post-a', { name: 'not-coerced' }, null],
           tag_suggestions: [
-            { post_id: 'post-a', tags: ['incident', 'ops'], rationale: 'Incident thread' },
+            { post_id: 'post-a', tags: ['incident', { name: 'not-coerced' }, ' ops ', ' '], rationale: 'Incident thread' },
             { post_id: ' ', tags: ['ignored'], rationale: 'missing post id' },
           ],
           answer_matches: [

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -462,14 +462,22 @@ function normalizeBoardHearth(raw: unknown): BoardHearth | null {
   }
 }
 
+function asStrictStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
 function normalizeBoardCurationSnapshot(raw: unknown): BoardCurationSnapshot | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id, '').trim()
   const generated_at = asNullableIsoTimestamp(raw.generated_at)
   const submitted_by = asString(raw.submitted_by, '').trim()
   if (!id || !generated_at || !submitted_by) return null
-  const ordering = Array.isArray(raw.ordering) ? raw.ordering.map(v => String(v)) : []
-  const highlights = Array.isArray(raw.highlights) ? raw.highlights.map(v => String(v)) : []
+  const ordering = asStrictStringArray(raw.ordering)
+  const highlights = asStrictStringArray(raw.highlights)
   const rationale = asString(raw.rationale, '')
   const model = asNullableString(raw.model)
   const healthScore = asNumber(raw.health_score)

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -472,7 +472,67 @@ function normalizeBoardCurationSnapshot(raw: unknown): BoardCurationSnapshot | n
   const highlights = Array.isArray(raw.highlights) ? raw.highlights.map(v => String(v)) : []
   const rationale = asString(raw.rationale, '')
   const model = asNullableString(raw.model)
-  return { id, generated_at, submitted_by, model, ordering, highlights, rationale, provenance: raw.provenance }
+  const healthScore = asNumber(raw.health_score)
+  return {
+    id,
+    generated_at,
+    submitted_by,
+    model,
+    summary: asNullableString(raw.summary),
+    ordering,
+    highlights,
+    tag_suggestions: normalizeBoardCurationTagSuggestions(raw.tag_suggestions),
+    answer_matches: normalizeBoardCurationAnswerMatches(raw.answer_matches),
+    health_score: healthScore ?? null,
+    health_components: normalizeBoardCurationHealthComponents(raw.health_components),
+    rationale,
+    provenance: raw.provenance,
+  }
+}
+
+function normalizeBoardCurationTagSuggestions(raw: unknown): BoardCurationSnapshot['tag_suggestions'] {
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((item) => {
+    if (!isRecord(item)) return []
+    const post_id = asString(item.post_id, '').trim()
+    if (!post_id) return []
+    return [{
+      post_id,
+      tags: asStringList(item.tags),
+      rationale: asString(item.rationale, ''),
+    }]
+  })
+}
+
+function normalizeBoardCurationAnswerMatches(raw: unknown): BoardCurationSnapshot['answer_matches'] {
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((item) => {
+    if (!isRecord(item)) return []
+    const question_post_id = asString(item.question_post_id, '').trim()
+    const answer_post_id = asString(item.answer_post_id, '').trim()
+    if (!question_post_id || !answer_post_id) return []
+    return [{
+      question_post_id,
+      answer_post_id,
+      score: asNumber(item.score, 0),
+      rationale: asString(item.rationale, ''),
+    }]
+  })
+}
+
+function normalizeBoardCurationHealthComponents(raw: unknown): BoardCurationSnapshot['health_components'] {
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((item) => {
+    if (!isRecord(item)) return []
+    const name = asString(item.name, '').trim()
+    if (!name) return []
+    return [{
+      name,
+      score: asNumber(item.score, 0),
+      weight: asNumber(item.weight, 0),
+      rationale: asString(item.rationale, ''),
+    }]
+  })
 }
 
 function normalizeBoardReactionSummary(raw: unknown): BoardReactionSummary | null {

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -506,7 +506,7 @@ function normalizeBoardCurationTagSuggestions(raw: unknown): BoardCurationSnapsh
     if (!post_id) return []
     return [{
       post_id,
-      tags: asStringList(item.tags),
+      tags: asStrictStringArray(item.tags),
       rationale: asString(item.rationale, ''),
     }]
   })

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -195,10 +195,35 @@ export interface BoardCurationSnapshot {
   generated_at: string
   submitted_by: string
   model?: string | null
+  summary?: string | null
   ordering: string[]
   highlights: string[]
+  tag_suggestions: BoardCurationTagSuggestion[]
+  answer_matches: BoardCurationAnswerMatch[]
+  health_score?: number | null
+  health_components: BoardCurationHealthComponent[]
   rationale: string
   provenance?: unknown
+}
+
+export interface BoardCurationTagSuggestion {
+  post_id: string
+  tags: string[]
+  rationale: string
+}
+
+export interface BoardCurationAnswerMatch {
+  question_post_id: string
+  answer_post_id: string
+  score: number
+  rationale: string
+}
+
+export interface BoardCurationHealthComponent {
+  name: string
+  score: number
+  weight: number
+  rationale: string
 }
 
 // --- SubBoard ---

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -347,6 +347,7 @@ never modified by the replay path.
 | `masc_board_search` | 전문 검색 |
 | `masc_board_stats` | 통계 (post/comment count, backend) |
 | `masc_board_hearths` | 활성 hearth 목록 |
+| `masc_board_curation_read` | 최신 AI curation snapshot 조회 (read-only) |
 | `masc_board_delete` | 게시물 삭제 (연관 댓글/투표 포함) |
 
 ### 10.2 Vote 도구 (Tool_vote)
@@ -434,6 +435,32 @@ slug 중복 생성 시 `Already_exists` 에러.
 - `SubBoard` / `SubBoardAccess` 타입: `dashboard/src/types/core.ts`
 - API 함수: `fetchSubBoards()`, `fetchSubBoard(id)`, `createSubBoard(slug, name, description, access?, members?)` in `dashboard/src/api/board.ts`
 - 네비게이션: workspace 섹션에 `sub-boards` 항목 추가 (`dashboard/src/config/navigation.ts`)
+
+---
+
+## 11a. AI Curation Readonly Snapshot
+
+AI curation은 Phase 3 기능이지만, mutation은 금지하고 read-only snapshot 계약부터 고정한다. Keeper/agent는 최신 board window를 읽고 다음 projection을 제출할 수 있으며, board post/comment/vote state는 변경하지 않는다.
+
+### 11a.1 Snapshot Fields
+
+| Field | 의미 |
+|-------|------|
+| `summary` | 현재 board window의 TL;DR |
+| `ordering` | 추천 읽기 순서의 post id 목록 |
+| `highlights` | 특히 중요하게 표시할 post id 목록 |
+| `tag_suggestions` | post별 추천 태그와 근거 |
+| `answer_matches` | 질문 post와 후보 답변 post의 매칭, score, 근거 |
+| `health_score` | 0.0-1.0 정규화 커뮤니티 건강도 점수 |
+| `health_components` | 건강도 하위 지표별 score/weight/rationale |
+| `provenance` | model, prompt/run id, source window 등 감사 가능한 메타데이터 |
+
+### 11a.2 Invariants
+
+1. Curation read path는 board content mutation을 수행하지 않는다.
+2. Empty snapshot은 JSON `null`로 반환한다.
+3. Snapshot은 operator-auditable provenance를 포함할 수 있어야 한다.
+4. Summary/tag/match/health fields는 missing 시 empty/null로 안전하게 normalize한다.
 
 ---
 

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -347,7 +347,8 @@ never modified by the replay path.
 | `masc_board_search` | 전문 검색 |
 | `masc_board_stats` | 통계 (post/comment count, backend) |
 | `masc_board_hearths` | 활성 hearth 목록 |
-| `masc_board_curation_read` | 최신 AI curation snapshot 조회 (read-only) |
+| `masc_board_curation_read` | 최신 AI curation snapshot 조회 |
+| `masc_board_curation_submit` | AI curation snapshot 제출: summary/order/highlights/tag suggestions/answer matches/health/provenance 기록. 게시글/댓글/투표는 수정하지 않음 |
 | `masc_board_delete` | 게시물 삭제 (연관 댓글/투표 포함) |
 
 ### 10.2 Vote 도구 (Tool_vote)
@@ -438,9 +439,9 @@ slug 중복 생성 시 `Already_exists` 에러.
 
 ---
 
-## 11a. AI Curation Readonly Snapshot
+## 11a. AI Curation Snapshot
 
-AI curation은 Phase 3 기능이지만, mutation은 금지하고 read-only snapshot 계약부터 고정한다. Keeper/agent는 최신 board window를 읽고 다음 projection을 제출할 수 있으며, board post/comment/vote state는 변경하지 않는다.
+AI curation은 board post/comment/vote mutation과 분리된 projection 계약이다. Keeper/agent는 최신 board window를 읽고 다음 projection snapshot을 제출할 수 있으며, board post/comment/vote state는 변경하지 않는다.
 
 ### 11a.1 Snapshot Fields
 

--- a/lib/board_curation.ml
+++ b/lib/board_curation.ml
@@ -15,7 +15,7 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-(** Board_curation — AI curation readonly surface for the board.
+(** Board_curation — AI curation projection surface for the board.
 
     See board_curation.mli for the full contract. *)
 

--- a/lib/board_curation.ml
+++ b/lib/board_curation.ml
@@ -26,10 +26,35 @@ type curation_snapshot = {
   generated_at : float;
   submitted_by : string;
   model : string option;
+  summary : string option;
   ordering : string list;
   highlights : string list;
+  tag_suggestions : curation_tag_suggestion list;
+  answer_matches : curation_answer_match list;
+  health_score : float option;
+  health_components : curation_health_component list;
   rationale : string;
   provenance : Yojson.Safe.t;
+}
+
+and curation_tag_suggestion = {
+  post_id : string;
+  tags : string list;
+  rationale : string;
+}
+
+and curation_answer_match = {
+  question_post_id : string;
+  answer_post_id : string;
+  score : float;
+  rationale : string;
+}
+
+and curation_health_component = {
+  name : string;
+  score : float;
+  weight : float;
+  rationale : string;
 }
 
 (** {1 ID generation} *)
@@ -43,13 +68,41 @@ let generate_id () =
 (** {1 JSON serialisation} *)
 
 let snapshot_to_yojson (s : curation_snapshot) : Yojson.Safe.t =
+  let tag_suggestion_to_yojson (t : curation_tag_suggestion) =
+    `Assoc [
+      ("post_id", `String t.post_id);
+      ("tags", `List (List.map (fun tag -> `String tag) t.tags));
+      ("rationale", `String t.rationale);
+    ]
+  in
+  let answer_match_to_yojson (m : curation_answer_match) =
+    `Assoc [
+      ("question_post_id", `String m.question_post_id);
+      ("answer_post_id", `String m.answer_post_id);
+      ("score", `Float m.score);
+      ("rationale", `String m.rationale);
+    ]
+  in
+  let health_component_to_yojson (c : curation_health_component) =
+    `Assoc [
+      ("name", `String c.name);
+      ("score", `Float c.score);
+      ("weight", `Float c.weight);
+      ("rationale", `String c.rationale);
+    ]
+  in
   `Assoc [
     ("id", `String s.id);
     ("generated_at", `Float s.generated_at);
     ("submitted_by", `String s.submitted_by);
     ("model", match s.model with Some m -> `String m | None -> `Null);
+    ("summary", match s.summary with Some v -> `String v | None -> `Null);
     ("ordering", `List (List.map (fun id -> `String id) s.ordering));
     ("highlights", `List (List.map (fun id -> `String id) s.highlights));
+    ("tag_suggestions", `List (List.map tag_suggestion_to_yojson s.tag_suggestions));
+    ("answer_matches", `List (List.map answer_match_to_yojson s.answer_matches));
+    ("health_score", match s.health_score with Some score -> `Float score | None -> `Null);
+    ("health_components", `List (List.map health_component_to_yojson s.health_components));
     ("rationale", `String s.rationale);
     ("provenance", s.provenance);
   ]

--- a/lib/board_curation.mli
+++ b/lib/board_curation.mli
@@ -1,7 +1,7 @@
-(** Board_curation — AI curation readonly surface for the board.
+(** Board_curation — AI curation projection surface for the board.
 
     Implements the board AI curation contract described in the
-    board-ai-curation-readonly PR split.  Provides:
+    board AI curation PR split.  Provides:
 
     - A typed curation snapshot: AI-produced summary, ordering,
       highlighted post IDs, tag suggestions, question/answer matches,
@@ -12,7 +12,8 @@
     - Test-only [reset_for_test] for isolation.
 
     Design properties:
-    - Read-only surface: no board posts are mutated.
+    - Projection-only surface: snapshots may be submitted, but board posts,
+      comments, and votes are not mutated.
     - Operator-auditable: [provenance] is a free-form JSON blob that
       callers populate with model name, parameters, run metadata etc.
     - Crypto IDs: snapshot IDs carry a ["cu-"] prefix and are
@@ -21,7 +22,7 @@
       in-process.  Callers that need durable history should persist
       the JSON blob returned by {!snapshot_to_yojson}.
 
-    @since board-ai-curation-readonly *)
+    @since board-ai-curation *)
 
 (** {1 Types} *)
 

--- a/lib/board_curation.mli
+++ b/lib/board_curation.mli
@@ -3,8 +3,9 @@
     Implements the board AI curation contract described in the
     board-ai-curation-readonly PR split.  Provides:
 
-    - A typed curation snapshot: AI-produced ordering, highlighted
-      post IDs, overall rationale, and operator-auditable provenance.
+    - A typed curation snapshot: AI-produced summary, ordering,
+      highlighted post IDs, tag suggestions, question/answer matches,
+      health score, overall rationale, and operator-auditable provenance.
     - In-memory singleton store of the latest snapshot (single-writer;
       callers must serialise [submit_snapshot] if needed).
     - JSON projection used by the HTTP read endpoint.
@@ -33,15 +34,45 @@ type curation_snapshot = {
   (** Agent or keeper name that submitted the snapshot. *)
   model : string option;
   (** AI model used to produce the curation, if known. *)
+  summary : string option;
+  (** Optional TL;DR summary of the current board window. *)
   ordering : string list;
   (** Post IDs in AI-suggested reading order (most relevant first). *)
   highlights : string list;
   (** Subset of [ordering] marked as especially noteworthy. *)
+  tag_suggestions : curation_tag_suggestion list;
+  (** Suggested tags by post. *)
+  answer_matches : curation_answer_match list;
+  (** Candidate question/answer matches. *)
+  health_score : float option;
+  (** Optional normalized community health score in the range [0.0, 1.0]. *)
+  health_components : curation_health_component list;
+  (** Auditable health-score component breakdown. *)
   rationale : string;
   (** Human-readable explanation of the curation decisions. *)
   provenance : Yojson.Safe.t;
   (** Operator-auditable provenance blob (model params, run metadata,
       etc.).  Opaque to this module; callers control the schema. *)
+}
+
+and curation_tag_suggestion = {
+  post_id : string;
+  tags : string list;
+  rationale : string;
+}
+
+and curation_answer_match = {
+  question_post_id : string;
+  answer_post_id : string;
+  score : float;
+  rationale : string;
+}
+
+and curation_health_component = {
+  name : string;
+  score : float;
+  weight : float;
+  rationale : string;
 }
 
 (** {1 ID generation} *)

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -636,9 +636,19 @@ let backend_name () =
 
 (* AI curation delegate — thin wrappers around Board_curation *)
 
+let validate_curation_health_score = function
+  | None -> None
+  | Some score
+    when Float.is_finite score && score >= 0.0 && score <= 1.0 ->
+    Some score
+  | Some score ->
+    invalid_arg
+      (Printf.sprintf "health_score must be in [0.0, 1.0], got %g" score)
+
 let submit_curation_snapshot ~submitted_by ?model ?summary ~ordering ~highlights
     ?(tag_suggestions = []) ?(answer_matches = []) ?health_score
     ?(health_components = []) ~rationale ?(provenance = `Assoc []) () =
+  let health_score = validate_curation_health_score health_score in
   let snap : Board_curation.curation_snapshot = {
     id = Board_curation.generate_id ();
     generated_at = Time_compat.now ();

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -636,15 +636,21 @@ let backend_name () =
 
 (* AI curation delegate — thin wrappers around Board_curation *)
 
-let submit_curation_snapshot ~submitted_by ?model ~ordering ~highlights
-    ~rationale ?(provenance = `Assoc []) () =
+let submit_curation_snapshot ~submitted_by ?model ?summary ~ordering ~highlights
+    ?(tag_suggestions = []) ?(answer_matches = []) ?health_score
+    ?(health_components = []) ~rationale ?(provenance = `Assoc []) () =
   let snap : Board_curation.curation_snapshot = {
     id = Board_curation.generate_id ();
     generated_at = Time_compat.now ();
     submitted_by;
     model;
+    summary;
     ordering;
     highlights;
+    tag_suggestions;
+    answer_matches;
+    health_score;
+    health_components;
     rationale;
     provenance;
   } in

--- a/lib/board_dispatch.mli
+++ b/lib/board_dispatch.mli
@@ -286,8 +286,13 @@ val flush : unit -> unit
 val submit_curation_snapshot :
   submitted_by:string ->
   ?model:string ->
+  ?summary:string ->
   ordering:string list ->
   highlights:string list ->
+  ?tag_suggestions:Board_curation.curation_tag_suggestion list ->
+  ?answer_matches:Board_curation.curation_answer_match list ->
+  ?health_score:float ->
+  ?health_components:Board_curation.curation_health_component list ->
   rationale:string ->
   ?provenance:Yojson.Safe.t ->
   unit ->

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -269,6 +269,7 @@ let tool_search_alias_entries =
   ; "keeper_board_delete", "게시판 삭제 제거 글삭제"
   ; "keeper_board_stats", "게시판 통계 활동 참여 게시글수"
   ; "keeper_board_curation_read", "게시판 AI 큐레이션 추천순서 하이라이트"
+  ; "keeper_board_curation_submit", "게시판 AI 큐레이션 요약 태그 답변매칭 건강도 제출"
   ; "keeper_stay_silent", "침묵 대기 아무것도 안함 넘어가기"
   ; "keeper_tool_search", "도구 검색 발견 찾기 어떤도구"
   ; "keeper_voice_listen", "음성 듣기 마이크 녹음 입력"

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -77,6 +77,7 @@ type computed_tool_surface =
   }
 
 type turn_affordance =
+  | Board_curation
   | Board_post_or_comment
   | Message_sweep
   | Reply_in_room
@@ -87,6 +88,7 @@ type turn_affordance =
   | Inspect_worktree_delta
 
 let turn_affordance_of_string = function
+  | "board_curation" -> Some Board_curation
   | "board_post_or_comment" -> Some Board_post_or_comment
   | "message_sweep" -> Some Message_sweep
   | "reply_in_room" -> Some Reply_in_room
@@ -98,6 +100,7 @@ let turn_affordance_of_string = function
   | _ -> None
 
 let should_tool_gate_affordance = function
+  | Board_curation
   | Board_post_or_comment
   | Message_sweep
   | Reply_in_room
@@ -120,6 +123,7 @@ let turn_affordances_require_tool_gate turn_affordances =
    contract for that affordance and must be allowed to respond with
    text instead. *)
 let tools_for_gated_affordance = function
+  | Board_curation -> [ "keeper_board_curation_submit" ]
   | Board_post_or_comment ->
     [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast" ]
   | Message_sweep -> [ "masc_messages"; "masc_keeper_msg" ]
@@ -141,6 +145,21 @@ let tools_for_gated_affordance = function
   | Inspect_worktree_delta ->
     [ "keeper_shell"; "keeper_bash"; "masc_code_git";
       "keeper_fs_read" ]
+
+let preferred_tool_names_for_turn_affordances turn_affordances =
+  turn_affordances
+  |> List.filter_map turn_affordance_of_string
+  |> List.concat_map (function
+       | Board_curation -> [ "keeper_board_curation_submit" ]
+       | Board_post_or_comment
+       | Message_sweep
+       | Reply_in_room
+       | Task_claim
+       | Task_audit
+       | Task_verify
+       | Work_discovery
+       | Inspect_worktree_delta -> [])
+  |> Keeper_types.dedupe_keep_order
 
 (* Filtered variant of [turn_affordances_require_tool_gate]:  a gated
    affordance only counts when the keeper actually has a tool that can
@@ -183,7 +202,10 @@ let has_task_claim_affordance = has_turn_affordance Task_claim
 
 let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
-  if (not has_current_task)
+  if has_turn_affordance Board_curation turn_affordances
+     && List.mem "keeper_board_curation_submit" allowed_tool_names
+  then Agent_sdk.Types.Tool "keeper_board_curation_submit"
+  else if (not has_current_task)
      && has_task_claim_affordance turn_affordances
      && List.mem "keeper_task_claim" allowed_tool_names
   then Agent_sdk.Types.Tool "keeper_task_claim"

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -67,6 +67,7 @@ type computed_tool_surface =
 
 (** Affordances that influence per-turn tool gating. *)
 type turn_affordance =
+  | Board_curation
   | Board_post_or_comment
   | Message_sweep
   | Reply_in_room
@@ -87,6 +88,10 @@ val turn_affordances_require_tool_gate : string list -> bool
 (** Tools that satisfy a gated affordance (used by
     [turn_affordances_require_tool_gate_with_allowed]). *)
 val tools_for_gated_affordance : turn_affordance -> string list
+
+(** Specific tools that should be force-included/preferred for an
+    affordance, when the keeper policy exposes them. *)
+val preferred_tool_names_for_turn_affordances : string list -> string list
 
 (** Like [turn_affordances_require_tool_gate] but only fires when at
     least one of the gating affordance's tools is in

--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -109,6 +109,10 @@ let handle_keeper_board_tool
     dispatch_board Tool_name.Masc.Board_search args
   | Some Tool_name.Keeper.Board_curation_read ->
     dispatch_board Tool_name.Masc.Board_curation_read args
+  | Some Tool_name.Keeper.Board_curation_submit ->
+    dispatch_board
+      Tool_name.Masc.Board_curation_submit
+      (assoc_override_string "submitted_by" meta.name args)
   | Some Tool_name.Keeper.Board_delete ->
     dispatch_board Tool_name.Masc.Board_delete args
   | Some Tool_name.Keeper.Board_cleanup ->

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -446,6 +446,8 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Board_cleanup
     | Tool_name.Keeper.Board_comment
     | Tool_name.Keeper.Board_comment_vote
+    | Tool_name.Keeper.Board_curation_read
+    | Tool_name.Keeper.Board_curation_submit
     | Tool_name.Keeper.Board_delete
     | Tool_name.Keeper.Board_get
     | Tool_name.Keeper.Board_list

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -687,8 +687,14 @@ let prepare_agent_setup
       |> validate_allow_list ~turn
       |> Keeper_types.dedupe_keep_order
     in
+    let visible_affordance_tool_names =
+      preferred_tool_names_for_turn_affordances turn_affordances
+      |> validate_allow_list ~turn
+      |> Keeper_types.dedupe_keep_order
+    in
     let merged =
-      Keeper_types.dedupe_keep_order (merged @ visible_required_tool_names)
+      Keeper_types.dedupe_keep_order
+        (merged @ visible_required_tool_names @ visible_affordance_tool_names)
     in
     let selection_mode =
       if llm_rerank_enabled
@@ -752,9 +758,14 @@ let prepare_agent_setup
           max_tools;
         let required_turn_essential_tool_names =
           if required_tool_names <> [] then visible_required_tool_names
-          else if tool_gate_requested
-             && has_task_claim_affordance turn_affordances
-          then [ "keeper_task_claim" ]
+          else if tool_gate_requested then
+            let claim_tools =
+              if has_task_claim_affordance turn_affordances
+              then [ "keeper_task_claim" ]
+              else []
+            in
+            Keeper_types.dedupe_keep_order
+              (visible_affordance_tool_names @ claim_tools)
           else []
         in
         let essential_names =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -268,6 +268,7 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
   let has_keeper_board_wrapper name =
     let eq v = String.equal name (Tool_name.Masc.to_string v) in
     eq Tool_name.Masc.Board_comment
+    || eq Tool_name.Masc.Board_curation_submit
     || eq Tool_name.Masc.Board_post
     || eq Tool_name.Masc.Board_vote
     || eq Tool_name.Masc.Board_delete

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -69,6 +69,7 @@ let core_discovery_tools =
       (* Board: core interaction *)
       Keeper Board_get; Keeper Board_post;
       Keeper Board_comment; Keeper Board_vote; Keeper Board_list;
+      Keeper Board_curation_read; Keeper Board_curation_submit;
       (* Shell + VCS *)
       Keeper Shell;
       Keeper Bash;
@@ -319,10 +320,12 @@ let reconcile_safe_tools =
     Tool_name.[
       Keeper Board_post; Keeper Board_comment;
       Keeper Board_vote; Keeper Board_comment_vote;
+      Keeper Board_curation_submit;
       Keeper Broadcast;
       Keeper Task_done;
       Masc Board_post; Masc Board_comment;
       Masc Board_vote; Masc Board_comment_vote;
+      Masc Board_curation_submit;
       Masc Broadcast;
     ]
 

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -454,6 +454,7 @@ let observed_affordances_of_observation
   let add affordance = affordances := affordance :: !affordances in
   if observation.pending_mentions <> [] then add "reply_in_room";
   if observation.pending_board_events <> [] then add "board_post_or_comment";
+  if List.length observation.pending_board_events >= 2 then add "board_curation";
   if observation.pending_scope_messages <> [] then add "message_sweep";
   if observation.claimable_task_count > 0 then add "task_claim";
   if observation.failed_task_count > 0 then add "task_audit";

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -192,6 +192,12 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     else
       ""
   in
+  let board_curation_guidance =
+    if tool_allowed "keeper_board_curation_submit" then
+      "- See enough board activity to summarize or route? Call keeper_board_curation_submit with a concise snapshot.\n"
+    else
+      ""
+  in
   let broadcast_guidance =
     if tool_allowed "keeper_broadcast" then
       "- Need to share broadly? Call keeper_broadcast.\n"
@@ -221,6 +227,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
             gh repo context is derived from your active task worktree/current_task_id.\n"
          else "");
         board_post_guidance;
+        board_curation_guidance;
         broadcast_guidance;
         "- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior \
          \"stay silent\", \"wait for new work\", or stale repo/blocker claims without re-checking the live \

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -375,6 +375,12 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       (Printf.sprintf "### Board Activity (%d new)\n"
          (List.length observation.pending_board_events));
     Buffer.add_string ubuf (format_board_events observation.pending_board_events);
+    if
+      tool_allowed "keeper_board_curation_submit"
+      && List.length observation.pending_board_events >= 2
+    then
+      Buffer.add_string ubuf
+        "\n- Curation due: after reading enough context, call keeper_board_curation_submit with a concise snapshot for this board window.";
     Buffer.add_string ubuf "\n\n");
   (* 10. Live worktree delta — actionable change signal *)
   (match observation.worktree_change_summary with

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -880,6 +880,10 @@ let float_field fields key default =
   match assoc_field fields key with
   | Some (`Float value) when Float.is_finite value -> value
   | Some (`Int value) -> float_of_int value
+  | Some (`String value) ->
+    (match Float.of_string_opt (String.trim value) with
+     | Some parsed when Float.is_finite parsed -> parsed
+     | _ -> default)
   | _ -> default
 
 let string_list_field fields key =
@@ -1341,7 +1345,7 @@ let tool_board_curation_submit : Masc_domain.tool_schema = {
       ("highlights", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Important post ids to highlight")]);
       ("tag_suggestions", `Assoc [("type", `String "array"); ("description", `String "Objects with post_id, tags[], rationale")]);
       ("answer_matches", `Assoc [("type", `String "array"); ("description", `String "Objects with question_post_id, answer_post_id, score, rationale")]);
-      ("health_score", `Assoc [("type", `String "number"); ("description", `String "Optional normalized health score")]);
+      ("health_score", `Assoc [("type", `String "number"); ("minimum", `Float 0.0); ("maximum", `Float 1.0); ("description", `String "Optional normalized health score in [0.0, 1.0]")]);
       ("health_components", `Assoc [("type", `String "array"); ("description", `String "Objects with name, score, weight, rationale")]);
       ("rationale", `Assoc [("type", `String "string"); ("description", `String "Required explanation for the curation decision")]);
       ("provenance", `Assoc [("type", `String "object"); ("description", `String "Audit metadata such as source window, prompt/run id, and model params")]);

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -1197,7 +1197,7 @@ Safety: never deletes posts with comments or votes unless filters are overridden
 (** All board tools *)
 let tool_board_curation_read : Masc_domain.tool_schema = {
   name = "masc_board_curation_read";
-  description = "Read the latest AI curation snapshot for the board: AI-produced post ordering, highlights, rationale, and operator-auditable provenance. Returns null when no snapshot has been submitted yet.";
+  description = "Read the latest AI curation snapshot for the board: TL;DR summary, post ordering, highlights, tag suggestions, answer matches, health score, rationale, and operator-auditable provenance. Returns null when no snapshot has been submitted yet.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc []);

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -869,6 +869,114 @@ let handle_board_curation_read _args =
     let json = Board_curation.snapshot_to_yojson snap in
     (true, Yojson.Safe.to_string json)
 
+let assoc_field fields key = List.assoc_opt key fields
+
+let string_field fields key default =
+  match assoc_field fields key with
+  | Some (`String value) -> String.trim value
+  | _ -> default
+
+let float_field fields key default =
+  match assoc_field fields key with
+  | Some (`Float value) when Float.is_finite value -> value
+  | Some (`Int value) -> float_of_int value
+  | _ -> default
+
+let string_list_field fields key =
+  match assoc_field fields key with
+  | Some (`List values) ->
+    values
+    |> List.filter_map (function
+      | `String value ->
+        let trimmed = String.trim value in
+        if String.equal trimmed "" then None else Some trimmed
+      | _ -> None)
+  | _ -> []
+
+let object_list_arg args key =
+  match args with
+  | `Assoc fields ->
+    (match assoc_field fields key with
+     | Some (`List values) ->
+       values
+       |> List.filter_map (function
+         | `Assoc fields -> Some fields
+         | _ -> None)
+     | _ -> [])
+  | _ -> []
+
+let provenance_arg args =
+  match args with
+  | `Assoc fields ->
+    (match assoc_field fields "provenance" with
+     | Some ((`Assoc _ | `List _ | `String _ | `Float _ | `Int _ | `Bool _ | `Null) as json) -> json
+     | _ -> `Assoc [])
+  | _ -> `Assoc []
+
+let curation_tag_suggestions_arg args =
+  object_list_arg args "tag_suggestions"
+  |> List.filter_map (fun fields ->
+    let post_id = string_field fields "post_id" "" in
+    if String.equal post_id "" then None
+    else
+      Some {
+        Board_curation.post_id = post_id;
+        tags = string_list_field fields "tags";
+        rationale = string_field fields "rationale" "";
+      })
+
+let curation_answer_matches_arg args =
+  object_list_arg args "answer_matches"
+  |> List.filter_map (fun fields ->
+    let question_post_id = string_field fields "question_post_id" "" in
+    let answer_post_id = string_field fields "answer_post_id" "" in
+    if String.equal question_post_id "" || String.equal answer_post_id "" then None
+    else
+      Some {
+        Board_curation.question_post_id = question_post_id;
+        answer_post_id;
+        score = float_field fields "score" 0.0;
+        rationale = string_field fields "rationale" "";
+      })
+
+let curation_health_components_arg args =
+  object_list_arg args "health_components"
+  |> List.filter_map (fun fields ->
+    let name = string_field fields "name" "" in
+    if String.equal name "" then None
+    else
+      Some {
+        Board_curation.name = name;
+        score = float_field fields "score" 0.0;
+        weight = float_field fields "weight" 0.0;
+        rationale = string_field fields "rationale" "";
+      })
+
+let handle_board_curation_submit args =
+  let submitted_by = get_string args "submitted_by" "" |> String.trim in
+  let rationale = get_string args "rationale" "" |> String.trim in
+  if String.equal submitted_by "" then
+    (false, "submitted_by required")
+  else if String.equal rationale "" then
+    (false, "rationale required")
+  else
+    let model = get_string_opt args "model" in
+    let summary = get_string_opt args "summary" in
+    let ordering = get_string_list args "ordering" in
+    let highlights = get_string_list args "highlights" in
+    let tag_suggestions = curation_tag_suggestions_arg args in
+    let answer_matches = curation_answer_matches_arg args in
+    let health_score = get_float_opt args "health_score" in
+    let health_components = curation_health_components_arg args in
+    let provenance = provenance_arg args in
+    let snap =
+      Board_dispatch.submit_curation_snapshot
+        ~submitted_by ?model ?summary ~ordering ~highlights
+        ~tag_suggestions ~answer_matches ?health_score ~health_components
+        ~rationale ~provenance ()
+    in
+    (true, Yojson.Safe.to_string (Board_curation.snapshot_to_yojson snap))
+
 (** {1 Tool Definitions} *)
 
 let tool_post_create : Masc_domain.tool_schema = {
@@ -1204,6 +1312,28 @@ let tool_board_curation_read : Masc_domain.tool_schema = {
   ];
 }
 
+let tool_board_curation_submit : Masc_domain.tool_schema = {
+  name = "masc_board_curation_submit";
+  description = "Submit an AI curation snapshot for the board. This records summary, recommended ordering, highlights, tag suggestions, answer matches, health score, rationale, and provenance without mutating board posts/comments/votes. Keeper wrappers auto-fill submitted_by.";
+  input_schema = `Assoc [
+    ("type", `String "object");
+    ("properties", `Assoc [
+      ("submitted_by", `Assoc [("type", `String "string"); ("description", `String "Submitting agent; keeper wrapper auto-fills this")]);
+      ("model", `Assoc [("type", `String "string"); ("description", `String "Model or provider label used for the curation")]);
+      ("summary", `Assoc [("type", `String "string"); ("description", `String "Short TL;DR summary of the current board window")]);
+      ("ordering", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Recommended post id reading order")]);
+      ("highlights", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Important post ids to highlight")]);
+      ("tag_suggestions", `Assoc [("type", `String "array"); ("description", `String "Objects with post_id, tags[], rationale")]);
+      ("answer_matches", `Assoc [("type", `String "array"); ("description", `String "Objects with question_post_id, answer_post_id, score, rationale")]);
+      ("health_score", `Assoc [("type", `String "number"); ("description", `String "Optional normalized health score")]);
+      ("health_components", `Assoc [("type", `String "array"); ("description", `String "Objects with name, score, weight, rationale")]);
+      ("rationale", `Assoc [("type", `String "string"); ("description", `String "Required explanation for the curation decision")]);
+      ("provenance", `Assoc [("type", `String "object"); ("description", `String "Audit metadata such as source window, prompt/run id, and model params")]);
+    ]);
+    ("required", `List [`String "submitted_by"; `String "rationale"]);
+  ];
+}
+
 let tools = [
   tool_post_create;
   tool_post_list;
@@ -1217,6 +1347,7 @@ let tools = [
   tool_profile;
   tool_hearth_list;
   tool_board_curation_read;
+  tool_board_curation_submit;
   tool_delete;
 ]
 
@@ -1254,6 +1385,7 @@ let handle_tool name args =
     | "masc_board_profile" -> handle_profile args
     | "masc_board_hearths" -> handle_hearth_list args
     | "masc_board_curation_read" -> handle_board_curation_read args
+    | "masc_board_curation_submit" -> handle_board_curation_submit args
     | "masc_board_delete" ->
       let result = handle_delete args in
       invalidate_board_list_cache ();
@@ -1289,7 +1421,8 @@ let register () =
     | "masc_board_curation_read" ->
         Some Masc_domain.CanReadState
     | "masc_board_post" | "masc_board_comment" | "masc_board_vote"
-    | "masc_board_comment_vote" | "masc_board_reaction" ->
+    | "masc_board_comment_vote" | "masc_board_reaction"
+    | "masc_board_curation_submit" ->
         Some Masc_domain.CanBroadcast
     | "masc_board_delete" | "masc_board_cleanup" ->
         Some Masc_domain.CanAdmin

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -969,13 +969,16 @@ let handle_board_curation_submit args =
     let health_score = get_float_opt args "health_score" in
     let health_components = curation_health_components_arg args in
     let provenance = provenance_arg args in
-    let snap =
-      Board_dispatch.submit_curation_snapshot
-        ~submitted_by ?model ?summary ~ordering ~highlights
-        ~tag_suggestions ~answer_matches ?health_score ~health_components
-        ~rationale ~provenance ()
-    in
-    (true, Yojson.Safe.to_string (Board_curation.snapshot_to_yojson snap))
+    try
+      let snap =
+        Board_dispatch.submit_curation_snapshot
+          ~submitted_by ?model ?summary ~ordering ~highlights
+          ~tag_suggestions ~answer_matches ?health_score ~health_components
+          ~rationale ~provenance ()
+      in
+      (true, Yojson.Safe.to_string (Board_curation.snapshot_to_yojson snap))
+    with
+    | Invalid_argument msg -> (false, msg)
 
 (** {1 Tool Definitions} *)
 

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -893,6 +893,16 @@ let string_list_field fields key =
       | _ -> None)
   | _ -> []
 
+let trim_nonempty_string value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+
+let string_opt_arg args key =
+  Option.bind (get_string_opt args key) trim_nonempty_string
+
+let string_list_arg args key =
+  get_string_list args key |> List.filter_map trim_nonempty_string
+
 let object_list_arg args key =
   match args with
   | `Assoc fields ->
@@ -909,9 +919,10 @@ let provenance_arg args =
   match args with
   | `Assoc fields ->
     (match assoc_field fields "provenance" with
-     | Some ((`Assoc _ | `List _ | `String _ | `Float _ | `Int _ | `Bool _ | `Null) as json) -> json
-     | _ -> `Assoc [])
-  | _ -> `Assoc []
+     | Some ((`Assoc _) as json) -> Ok json
+     | Some _ -> Error "provenance must be an object"
+     | _ -> Ok (`Assoc []))
+  | _ -> Ok (`Assoc [])
 
 let curation_tag_suggestions_arg args =
   object_list_arg args "tag_suggestions"
@@ -960,25 +971,27 @@ let handle_board_curation_submit args =
   else if String.equal rationale "" then
     (false, "rationale required")
   else
-    let model = get_string_opt args "model" in
-    let summary = get_string_opt args "summary" in
-    let ordering = get_string_list args "ordering" in
-    let highlights = get_string_list args "highlights" in
+    let model = string_opt_arg args "model" in
+    let summary = string_opt_arg args "summary" in
+    let ordering = string_list_arg args "ordering" in
+    let highlights = string_list_arg args "highlights" in
     let tag_suggestions = curation_tag_suggestions_arg args in
     let answer_matches = curation_answer_matches_arg args in
     let health_score = get_float_opt args "health_score" in
     let health_components = curation_health_components_arg args in
-    let provenance = provenance_arg args in
-    try
-      let snap =
-        Board_dispatch.submit_curation_snapshot
-          ~submitted_by ?model ?summary ~ordering ~highlights
-          ~tag_suggestions ~answer_matches ?health_score ~health_components
-          ~rationale ~provenance ()
-      in
-      (true, Yojson.Safe.to_string (Board_curation.snapshot_to_yojson snap))
-    with
-    | Invalid_argument msg -> (false, msg)
+    match provenance_arg args with
+    | Error msg -> (false, msg)
+    | Ok provenance ->
+      try
+        let snap =
+          Board_dispatch.submit_curation_snapshot
+            ~submitted_by ?model ?summary ~ordering ~highlights
+            ~tag_suggestions ~answer_matches ?health_score ~health_components
+            ~rationale ~provenance ()
+        in
+        (true, Yojson.Safe.to_string (Board_curation.snapshot_to_yojson snap))
+      with
+      | Invalid_argument msg -> (false, msg)
 
 (** {1 Tool Definitions} *)
 

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -213,6 +213,8 @@ let explicit_metadata : (string * metadata) list =
     ("masc_board_get", readonly_tool);
     ( "masc_board_curation_read",
       { readonly_tool with required_permission = Some Masc_domain.CanReadState } );
+    ( "masc_board_curation_submit",
+      { actor_bound_masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
     ("masc_tool_help", readonly_tool);
     ("masc_keeper_list", readonly_tool);
     ("masc_keeper_status", readonly_tool);
@@ -449,6 +451,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Keeper TK.Board_cleanup
   | TN.Keeper TK.Board_comment
   | TN.Keeper TK.Board_comment_vote
+  | TN.Keeper TK.Board_curation_submit
   | TN.Keeper TK.Board_delete
   | TN.Keeper TK.Board_post
   | TN.Keeper TK.Board_vote
@@ -537,6 +540,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Board_cleanup
   | TN.Masc TM.Board_comment
   | TN.Masc TM.Board_comment_vote
+  | TN.Masc TM.Board_curation_submit
   | TN.Masc TM.Board_delete
   | TN.Masc TM.Board_post
   | TN.Masc TM.Board_reaction
@@ -602,6 +606,7 @@ let tool_group_of_typed_tool_name = function
       | TK.Board_comment
       | TK.Board_comment_vote
       | TK.Board_curation_read
+      | TK.Board_curation_submit
       | TK.Board_delete
       | TK.Board_get
       | TK.Board_list
@@ -654,6 +659,7 @@ let tool_group_of_typed_tool_name = function
       | TM.Board_comment
       | TM.Board_comment_vote
       | TM.Board_curation_read
+      | TM.Board_curation_submit
       | TM.Board_delete
       | TM.Board_get
       | TM.Board_hearths

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -61,6 +61,8 @@ let keeper_internal_tools =
     "keeper_board_vote";
     "keeper_board_stats";
     "keeper_board_search";
+    "keeper_board_curation_read";
+    "keeper_board_curation_submit";
     (* keeper_board_delete removed from default shard in #4309.
        Dispatch still accepts it for backward compat. *)
     "keeper_shell";
@@ -96,6 +98,8 @@ let keeper_internal_replacement = function
   | "keeper_board_vote" -> Some "masc_board_vote"
   | "keeper_board_stats" -> Some "masc_board_stats"
   | "keeper_board_search" -> Some "masc_board_search"
+  | "keeper_board_curation_read" -> Some "masc_board_curation_read"
+  | "keeper_board_curation_submit" -> Some "masc_board_curation_submit"
   | "keeper_voice_speak"
   | "keeper_voice_agent"
   | "keeper_voice_sessions"
@@ -157,6 +161,7 @@ let public_mcp_surface_tools =
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote";
+    "masc_board_curation_read"; "masc_board_curation_submit";
     (* Agent discovery *)
     "masc_agents"; "masc_agent_card"; "masc_dashboard";
     (* Utility *)
@@ -180,6 +185,7 @@ let spawned_agent_surface_tools =
     "masc_worktree_create"; "masc_worktree_remove"; "masc_worktree_list";
     "masc_board_list"; "masc_board_post"; "masc_board_comment";
     "masc_board_vote"; "masc_board_get";
+    "masc_board_curation_read"; "masc_board_curation_submit";
     "masc_tool_help"; "masc_web_search";
     "masc_spawn";
     (* Phase 2: surface SSOT *)
@@ -199,6 +205,7 @@ let local_worker_surface_tools =
     "masc_goal_transition"; "masc_goal_verify"; "masc_coordination_fsm_snapshot";
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote"; "masc_board_search";
+    "masc_board_curation_read"; "masc_board_curation_submit";
     "masc_code_search"; "masc_code_symbols"; "masc_code_read";
     "masc_worktree_create"; "masc_worktree_remove"; "masc_worktree_list";
     "masc_run_init"; "masc_run_plan"; "masc_run_log";

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -255,6 +255,7 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Board_comment
     | Board_comment_vote
     | Board_curation_read
+    | Board_curation_submit
     | Board_delete
     | Board_get
     | Board_hearths

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -452,7 +452,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   | "masc_board_list" | "masc_board_get"
   | "masc_board_stats"
   | "masc_board_search" | "masc_board_profile"
-  | "masc_board_hearths" ->
+  | "masc_board_hearths"
+  | "masc_board_curation_read"
+  | "masc_board_curation_submit" ->
       Some (tuple_of_tool_result (Tool_board.handle_tool name arguments))
 
   | _ -> None

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -28,6 +28,7 @@ module Keeper = struct
     | Board_comment
     | Board_comment_vote
     | Board_curation_read
+    | Board_curation_submit
     | Board_delete
     | Board_get
     | Board_list
@@ -77,6 +78,7 @@ module Keeper = struct
     | Board_comment -> "keeper_board_comment"
     | Board_comment_vote -> "keeper_board_comment_vote"
     | Board_curation_read -> "keeper_board_curation_read"
+    | Board_curation_submit -> "keeper_board_curation_submit"
     | Board_delete -> "keeper_board_delete"
     | Board_get -> "keeper_board_get"
     | Board_list -> "keeper_board_list"
@@ -126,6 +128,7 @@ module Keeper = struct
     | "keeper_board_comment" -> Some Board_comment
     | "keeper_board_comment_vote" -> Some Board_comment_vote
     | "keeper_board_curation_read" -> Some Board_curation_read
+    | "keeper_board_curation_submit" -> Some Board_curation_submit
     | "keeper_board_delete" -> Some Board_delete
     | "keeper_board_get" -> Some Board_get
     | "keeper_board_list" -> Some Board_list
@@ -169,7 +172,7 @@ module Keeper = struct
     | "keeper_write" -> Some Write
     | _ -> None
 
-  let board_write_tools = [ Board_post; Board_comment; Board_vote ]
+  let board_write_tools = [ Board_post; Board_comment; Board_vote; Board_curation_submit ]
 
   let board_write_tool_names = List.map to_string board_write_tools
 
@@ -178,6 +181,7 @@ module Keeper = struct
     | Board_comment
     | Board_comment_vote
     | Board_curation_read
+    | Board_curation_submit
     | Board_delete
     | Board_get
     | Board_list
@@ -188,13 +192,14 @@ module Keeper = struct
     | _ -> false
 
   let is_board_write = function
-    | Board_post | Board_comment | Board_vote -> true
+    | Board_post | Board_comment | Board_vote | Board_curation_submit -> true
     | _ -> false
 
   let board_write_action_kind = function
     | Board_post -> Some "post"
     | Board_comment -> Some "comment"
     | Board_vote -> Some "vote"
+    | Board_curation_submit -> Some "curation"
     | _ -> None
 
   let pp fmt t = Format.pp_print_string fmt (to_string t)
@@ -219,6 +224,7 @@ module Masc = struct
     | Board_comment
     | Board_comment_vote
     | Board_curation_read
+    | Board_curation_submit
     | Board_delete
     | Board_get
     | Board_hearths
@@ -319,6 +325,7 @@ module Masc = struct
     | Board_comment -> "masc_board_comment"
     | Board_comment_vote -> "masc_board_comment_vote"
     | Board_curation_read -> "masc_board_curation_read"
+    | Board_curation_submit -> "masc_board_curation_submit"
     | Board_delete -> "masc_board_delete"
     | Board_get -> "masc_board_get"
     | Board_hearths -> "masc_board_hearths"
@@ -426,6 +433,7 @@ module Masc = struct
     | "masc_board_comment" -> Some Board_comment
     | "masc_board_comment_vote" -> Some Board_comment_vote
     | "masc_board_curation_read" -> Some Board_curation_read
+    | "masc_board_curation_submit" -> Some Board_curation_submit
     | "masc_board_delete" -> Some Board_delete
     | "masc_board_get" -> Some Board_get
     | "masc_board_hearths" -> Some Board_hearths
@@ -528,6 +536,7 @@ module Masc = struct
     | Board_comment
     | Board_comment_vote
     | Board_curation_read
+    | Board_curation_submit
     | Board_delete
     | Board_get
     | Board_hearths

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -13,6 +13,7 @@ module Keeper : sig
     | Board_comment
     | Board_comment_vote
     | Board_curation_read
+    | Board_curation_submit
     | Board_delete
     | Board_get
     | Board_list
@@ -84,6 +85,7 @@ module Masc : sig
     | Board_comment
     | Board_comment_vote
     | Board_curation_read
+    | Board_curation_submit
     | Board_delete
     | Board_get
     | Board_hearths

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -313,7 +313,7 @@ submitted_by is filled from your keeper identity.";
         ("highlights", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Important post ids to highlight")]);
         ("tag_suggestions", `Assoc [("type", `String "array"); ("description", `String "Objects with post_id, tags[], rationale")]);
         ("answer_matches", `Assoc [("type", `String "array"); ("description", `String "Objects with question_post_id, answer_post_id, score, rationale")]);
-        ("health_score", `Assoc [("type", `String "number"); ("description", `String "Optional normalized health score")]);
+        ("health_score", `Assoc [("type", `String "number"); ("minimum", `Float 0.0); ("maximum", `Float 1.0); ("description", `String "Optional normalized health score in [0.0, 1.0]")]);
         ("health_components", `Assoc [("type", `String "array"); ("description", `String "Objects with name, score, weight, rationale")]);
         ("rationale", `Assoc [("type", `String "string"); ("description", `String "Why this curation snapshot is useful now")]);
         ("provenance", `Assoc [("type", `String "object"); ("description", `String "Audit metadata such as source window, prompt/run id, and model params")]);

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -289,6 +289,39 @@ Use when looking for specific topics, past discussions, or related prior work.";
     ];
   };
   {
+    name = "keeper_board_curation_read";
+    description = "Read the latest AI curation snapshot for the board, including summary, \
+recommended ordering, highlights, tag suggestions, answer matches, health score, rationale, \
+and provenance. Returns null when no snapshot has been submitted yet.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+  {
+    name = "keeper_board_curation_submit";
+    description = "Submit an AI curation snapshot for the current board window. Use after reading \
+recent board activity to publish a summary, recommended reading order, highlights, tag suggestions, \
+answer matches, health score, and rationale. This does not edit board posts/comments/votes; \
+submitted_by is filled from your keeper identity.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("model", `Assoc [("type", `String "string"); ("description", `String "Model or provider label used for the curation")]);
+        ("summary", `Assoc [("type", `String "string"); ("description", `String "Short TL;DR summary of the current board window")]);
+        ("ordering", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Recommended post id reading order")]);
+        ("highlights", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Important post ids to highlight")]);
+        ("tag_suggestions", `Assoc [("type", `String "array"); ("description", `String "Objects with post_id, tags[], rationale")]);
+        ("answer_matches", `Assoc [("type", `String "array"); ("description", `String "Objects with question_post_id, answer_post_id, score, rationale")]);
+        ("health_score", `Assoc [("type", `String "number"); ("description", `String "Optional normalized health score")]);
+        ("health_components", `Assoc [("type", `String "array"); ("description", `String "Objects with name, score, weight, rationale")]);
+        ("rationale", `Assoc [("type", `String "string"); ("description", `String "Why this curation snapshot is useful now")]);
+        ("provenance", `Assoc [("type", `String "object"); ("description", `String "Audit metadata such as source window, prompt/run id, and model params")]);
+      ]);
+      ("required", `List [`String "rationale"]);
+    ];
+  };
+  {
     name = "keeper_board_delete";
     description = "Delete a board post by post_id. Use only for generated garbage, \
 expired automation, or other explicitly-approved cleanup cases.";
@@ -894,6 +927,7 @@ let shard_board : shard = {
   read_only_tools = [
     "keeper_board_get"; "keeper_board_list";
     "keeper_board_stats"; "keeper_board_search";
+    "keeper_board_curation_read";
   ];
   removable = true;
   description = "MASC Board: post, list, comment";

--- a/test/test_board_curation.ml
+++ b/test/test_board_curation.ml
@@ -18,8 +18,13 @@ let test_submit_and_retrieve () =
     generated_at = 1_735_689_600.0;
     submitted_by = "agent-test";
     model        = Some "gpt-4o";
+    summary      = None;
     ordering     = [ "p-aaa"; "p-bbb" ];
     highlights   = [ "p-aaa" ];
+    tag_suggestions = [];
+    answer_matches = [];
+    health_score = None;
+    health_components = [];
     rationale    = "Test rationale";
     provenance   = `Assoc [];
   } in
@@ -40,8 +45,13 @@ let test_reset_clears () =
     generated_at = 1_735_689_600.0;
     submitted_by = "agent-test";
     model        = None;
+    summary      = None;
     ordering     = [];
     highlights   = [];
+    tag_suggestions = [];
+    answer_matches = [];
+    health_score = None;
+    health_components = [];
     rationale    = "x";
     provenance   = `Assoc [];
   } in
@@ -55,7 +65,9 @@ let test_submit_replaces () =
   Board_curation.reset_for_test ();
   let make id rationale : Board_curation.curation_snapshot = {
     id; generated_at = 1_735_689_600.0; submitted_by = "a";
-    model = None; ordering = []; highlights = []; rationale; provenance = `Assoc [];
+    model = None; summary = None; ordering = []; highlights = [];
+    tag_suggestions = []; answer_matches = []; health_score = None;
+    health_components = []; rationale; provenance = `Assoc [];
   } in
   Board_curation.submit_snapshot (make "cu-first"  "first");
   Board_curation.submit_snapshot (make "cu-second" "second");
@@ -72,8 +84,19 @@ let test_to_yojson_round_trip () =
     generated_at = 1_748_779_200.0;
     submitted_by = "model-agent";
     model        = Some "claude-3";
+    summary      = Some "Two active questions need routing.";
     ordering     = [ "p-1"; "p-2"; "p-3" ];
     highlights   = [ "p-2" ];
+    tag_suggestions = [
+      { post_id = "p-2"; tags = [ "incident"; "ops" ]; rationale = "Incident-like thread" };
+    ];
+    answer_matches = [
+      { question_post_id = "p-1"; answer_post_id = "p-3"; score = 0.82; rationale = "Same failure signature" };
+    ];
+    health_score = Some 0.74;
+    health_components = [
+      { name = "answer_rate"; score = 0.8; weight = 0.25; rationale = "Most questions have replies" };
+    ];
     rationale    = "Highlight active discussions first";
     provenance   = `Assoc [ ("source", `String "daily-batch") ];
   } in
@@ -83,8 +106,16 @@ let test_to_yojson_round_trip () =
      let get k = List.assoc_opt k kvs in
      Alcotest.(check (option pass)) "id present"    (Some (`String "cu-json-01"))    (get "id");
      Alcotest.(check (option pass)) "model present" (Some (`String "claude-3"))      (get "model");
+     Alcotest.(check (option pass)) "summary present"
+       (Some (`String "Two active questions need routing.")) (get "summary");
      Alcotest.(check bool) "ordering is list"
        true (match get "ordering" with Some (`List _) -> true | _ -> false);
+     Alcotest.(check bool) "tag suggestions is list"
+       true (match get "tag_suggestions" with Some (`List [ _ ]) -> true | _ -> false);
+     Alcotest.(check bool) "answer matches is list"
+       true (match get "answer_matches" with Some (`List [ _ ]) -> true | _ -> false);
+     Alcotest.(check (option pass)) "health score present"
+       (Some (`Float 0.74)) (get "health_score");
    | _ -> Alcotest.fail "expected assoc")
 
 let () =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4948,6 +4948,28 @@ let test_prompt_includes_board_activity_section () =
        with Not_found -> false
      in found)
 
+let test_prompt_marks_board_curation_due_for_multi_event_window () =
+  let second_board_event =
+    {
+      sample_board_event with
+      post_id = "board-post-2";
+      title = "Answer candidate";
+      preview = "This may answer the earlier thread.";
+    }
+  in
+  let obs =
+    { base_observation with
+      pending_board_events = [ sample_board_event; second_board_event ]
+    }
+  in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check bool "marks curation due" true
+    (contains_substring user "Curation due");
+  check bool "names curation submit tool" true
+    (contains_substring user "keeper_board_curation_submit")
+
 let test_prompt_prefers_silence_guidance () =
   let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
   check bool "mentions speech act header" true
@@ -7355,6 +7377,8 @@ let () =
           test_case "includes mentions" `Quick test_prompt_includes_mentions_section;
           test_case "includes board activity" `Quick
             test_prompt_includes_board_activity_section;
+          test_case "marks board curation due" `Quick
+            test_prompt_marks_board_curation_due_for_multi_event_window;
           test_case "includes goals" `Quick test_prompt_includes_goals_section;
           test_case "includes context ratio" `Quick test_prompt_includes_context_ratio;
           test_case "includes idle" `Quick test_prompt_includes_idle;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6900,6 +6900,9 @@ let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
   check bool "two-turn board action can require initial tools" true
     (KAR.should_require_tools_for_initial_turn ~max_turns:2
        ~turn_affordances:[ "board_post_or_comment" ]);
+  check bool "two-turn board curation can require initial tools" true
+    (KAR.should_require_tools_for_initial_turn ~max_turns:2
+       ~turn_affordances:[ "board_curation" ]);
   check bool "three-turn call can require initial tools" true
     (KAR.should_require_tools_for_initial_turn ~max_turns:3 ~turn_affordances:affordances);
   check bool "pending verification requires an action tool" true
@@ -6921,6 +6924,8 @@ let test_should_require_tools_for_initial_turn_covers_actionable_affordances () 
   in
   check bool "reply requires tool gate" true (require "reply_in_room");
   check bool "verification requires tool gate" true (require "task_verify");
+  check bool "board curation requires tool gate" true
+    (require "board_curation");
   check bool "worktree inspection requires tool gate" true
     (require "inspect_worktree_delta")
 
@@ -6947,6 +6952,13 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
     "board_post_or_comment without any post tool -> gate suppressed" false
     (gate ~tools:[ "keeper_task_claim"; "keeper_tasks_list" ]
        [ "board_post_or_comment" ]);
+  check bool
+    "board_curation with submit tool -> gate fires" true
+    (gate ~tools:[ "keeper_board_curation_submit" ] [ "board_curation" ]);
+  check bool
+    "board_curation without submit tool -> gate suppressed" false
+    (gate ~tools:[ "keeper_board_post"; "keeper_board_comment" ]
+       [ "board_curation" ]);
   check bool
     "any matching affordance is enough" true
     (gate
@@ -6984,6 +6996,7 @@ let test_tools_for_gated_affordance_covers_each_variant () =
       (Printf.sprintf "tools_for_gated_affordance known tools for %s" label)
       [] (List.filter (fun name -> not (known_tool_name name)) tools)
   in
+  nonempty "Board_curation" Surface.Board_curation;
   nonempty "Board_post_or_comment" Surface.Board_post_or_comment;
   nonempty "Message_sweep" Surface.Message_sweep;
   nonempty "Reply_in_room" Surface.Reply_in_room;
@@ -6991,7 +7004,17 @@ let test_tools_for_gated_affordance_covers_each_variant () =
   nonempty "Task_audit" Surface.Task_audit;
   nonempty "Task_verify" Surface.Task_verify;
   nonempty "Work_discovery" Surface.Work_discovery;
-  nonempty "Inspect_worktree_delta" Surface.Inspect_worktree_delta
+  nonempty "Inspect_worktree_delta" Surface.Inspect_worktree_delta;
+  check (list string)
+    "board_curation force-includes submit tool"
+    [ "keeper_board_curation_submit" ]
+    (Surface.preferred_tool_names_for_turn_affordances
+       [ "board_curation"; "task_claim"; "board_curation" ]);
+  check (list string)
+    "generic board affordance has no forced specific tool"
+    []
+    (Surface.preferred_tool_names_for_turn_affordances
+       [ "board_post_or_comment" ])
 
 let test_preferred_tool_choice_for_required_turn_claims_first () =
   let choose ?(has_current_task = false) ?(turn_affordances = [ "task_claim" ])
@@ -7014,6 +7037,40 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        fail
          (Printf.sprintf
             "expected Any when already owning work, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
+  (* Board curation is the most specific action for a due curation
+     window, so prefer the submit tool over generic board/task tools. *)
+  (match
+     choose
+       ~turn_affordances:[ "board_curation"; "task_claim" ]
+       ~allowed_tool_names:
+         [
+           "keeper_board_curation_submit";
+           "keeper_task_claim";
+           "keeper_board_post";
+         ]
+       ()
+   with
+   | Agent_sdk.Types.Tool name ->
+       check string "board curation prefers submit tool"
+         "keeper_board_curation_submit" name
+   | other ->
+       fail
+         (Printf.sprintf
+            "expected Tool keeper_board_curation_submit, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~turn_affordances:[ "board_curation" ]
+       ~allowed_tool_names:[ "keeper_board_post" ]
+       ()
+   with
+   | Agent_sdk.Types.Auto -> ()
+   | other ->
+       fail
+         (Printf.sprintf
+            "expected Auto when curation submit is unavailable and keeper is idle, \
+             got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (* #10008: when no specific tool is applicable for the current
      affordance, fall back to [Auto] so the model can respond with
@@ -7992,6 +8049,42 @@ let () =
               in
               check bool "work_discovery present" true
                 (List.mem "work_discovery" affordances));
+          test_case "affordance: board curation requires multi-event window"
+            `Quick
+            (fun () ->
+              let second_board_event =
+                {
+                  sample_board_event with
+                  post_id = "board-post-2";
+                  title = "Follow-up";
+                  preview = "Another board item needs routing.";
+                }
+              in
+              let obs =
+                {
+                  base_observation with
+                  pending_board_events =
+                    [ sample_board_event; second_board_event ];
+                }
+              in
+              let affordances =
+                UM.observed_affordances_of_observation obs
+              in
+              check bool "board_curation present" true
+                (List.mem "board_curation" affordances));
+          test_case "affordance: single board event skips curation gate" `Quick
+            (fun () ->
+              let obs =
+                {
+                  base_observation with
+                  pending_board_events = [ sample_board_event ];
+                }
+              in
+              let affordances =
+                UM.observed_affordances_of_observation obs
+              in
+              check bool "board_curation absent" false
+                (List.mem "board_curation" affordances));
           test_case "affordance: task claim requires matched backlog" `Quick
             (fun () ->
               let obs =

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -527,7 +527,62 @@ let test_keeper_board_dispatch_uses_typed_tool_names () =
   in
   Alcotest.(check string) "typed curation read reaches board handler" "null" curation;
   Alcotest.(check bool) "typed curation read is not unknown" false
-    (contains_substring curation "unknown_board_tool")
+    (contains_substring curation "unknown_board_tool");
+  let curation_submit =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_curation_submit"
+      ~args:
+        (make_args
+           [
+             ("summary", `String "Two active threads need routing.");
+             ("ordering", `List [ `String "p-1"; `String "p-2" ]);
+             ("highlights", `List [ `String "p-1" ]);
+             ("tag_suggestions",
+              `List
+                [
+                  `Assoc
+                    [
+                      ("post_id", `String "p-1");
+                      ("tags", `List [ `String "ops" ]);
+                      ("rationale", `String "Operational thread");
+                    ];
+                ]);
+             ("answer_matches",
+              `List
+                [
+                  `Assoc
+                    [
+                      ("question_post_id", `String "p-1");
+                      ("answer_post_id", `String "p-2");
+                      ("score", `Float 0.8);
+                      ("rationale", `String "Same issue");
+                    ];
+                ]);
+             ("health_score", `Float 0.7);
+             ("health_components",
+              `List
+                [
+                  `Assoc
+                    [
+                      ("name", `String "answer_rate");
+                      ("score", `Float 0.7);
+                      ("weight", `Float 0.25);
+                      ("rationale", `String "Some answers present");
+                    ];
+                ]);
+             ("rationale", `String "Summarize active board activity");
+             ("provenance", `Assoc [ ("source", `String "test") ]);
+           ])
+  in
+  Alcotest.(check bool) "typed curation submit is not unknown" false
+    (contains_substring curation_submit "unknown_board_tool");
+  let submit_json = Yojson.Safe.from_string curation_submit in
+  Alcotest.(check string) "keeper source injected for curation" "typed-keeper"
+    Yojson.Safe.Util.(submit_json |> member "submitted_by" |> to_string);
+  Alcotest.(check string) "curation summary persisted"
+    "Two active threads need routing."
+    Yojson.Safe.Util.(submit_json |> member "summary" |> to_string)
 
 let test_board_curation_read_empty_returns_json_null () =
   Eio_main.run @@ fun env ->
@@ -536,6 +591,82 @@ let test_board_curation_read_empty_returns_json_null () =
   let ok, body = dispatch "masc_board_curation_read" (make_args []) in
   Alcotest.(check bool) "curation read ok" true ok;
   Alcotest.(check string) "empty curation snapshot is JSON null" "null" body
+
+let test_board_curation_submit_roundtrips_to_read () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let missing_ok, missing_body =
+    dispatch "masc_board_curation_submit"
+      (make_args [ ("rationale", `String "missing submitted_by") ])
+  in
+  Alcotest.(check bool) "raw submit requires submitted_by" false missing_ok;
+  Alcotest.(check string) "missing submitted_by error" "submitted_by required"
+    missing_body;
+  let ok, body =
+    dispatch "masc_board_curation_submit"
+      (make_args
+         [
+           ("submitted_by", `String "curator");
+           ("model", `String "test-model");
+           ("summary", `String "Board has one high-priority routing item.");
+           ("ordering", `List [ `String "p-7" ]);
+           ("highlights", `List [ `String "p-7" ]);
+           ("tag_suggestions",
+            `List
+              [
+                `Assoc
+                  [
+                    ("post_id", `String "p-7");
+                    ("tags", `List [ `String "routing"; `String "ops" ]);
+                    ("rationale", `String "Needs owner routing");
+                  ];
+              ]);
+           ("answer_matches",
+            `List
+              [
+                `Assoc
+                  [
+                    ("question_post_id", `String "p-7");
+                    ("answer_post_id", `String "p-8");
+                    ("score", `Float 0.9);
+                    ("rationale", `String "Direct answer candidate");
+                  ];
+              ]);
+           ("health_score", `Float 0.65);
+           ("health_components",
+            `List
+              [
+                `Assoc
+                  [
+                    ("name", `String "routing_latency");
+                    ("score", `Float 0.65);
+                    ("weight", `Float 0.5);
+                    ("rationale", `String "Some delay visible");
+                  ];
+              ]);
+           ("rationale", `String "Useful routing snapshot");
+           ("provenance", `Assoc [ ("source", `String "unit-test") ]);
+         ])
+  in
+  Alcotest.(check bool) "curation submit ok" true ok;
+  let submitted = Yojson.Safe.from_string body in
+  Alcotest.(check string) "submitted_by persisted" "curator"
+    Yojson.Safe.Util.(submitted |> member "submitted_by" |> to_string);
+  Alcotest.(check string) "summary persisted"
+    "Board has one high-priority routing item."
+    Yojson.Safe.Util.(submitted |> member "summary" |> to_string);
+  Alcotest.(check (float 0.0001)) "health score persisted" 0.65
+    Yojson.Safe.Util.(submitted |> member "health_score" |> to_float);
+  let read_ok, read_body = dispatch "masc_board_curation_read" (make_args []) in
+  Alcotest.(check bool) "curation read after submit ok" true read_ok;
+  let read_json = Yojson.Safe.from_string read_body in
+  Alcotest.(check string) "read returns latest id"
+    Yojson.Safe.Util.(submitted |> member "id" |> to_string)
+    Yojson.Safe.Util.(read_json |> member "id" |> to_string);
+  Alcotest.(check string) "read returns latest summary"
+    "Board has one high-priority routing item."
+    Yojson.Safe.Util.(read_json |> member "summary" |> to_string)
 
 let test_post_create_accepts_automation_rejects_system () =
   Eio_main.run @@ fun env ->
@@ -920,7 +1051,7 @@ let test_tools_count () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check int) "13 tool schemas" 13 (List.length Tool_board.tools)
+  Alcotest.(check int) "14 tool schemas" 14 (List.length Tool_board.tools)
 
 let test_tools_names_unique () =
   Eio_main.run @@ fun env ->
@@ -984,6 +1115,8 @@ let () =
             test_keeper_board_dispatch_uses_typed_tool_names;
           Alcotest.test_case "curation read empty returns JSON null" `Quick
             test_board_curation_read_empty_returns_json_null;
+          Alcotest.test_case "curation submit roundtrips to read" `Quick
+            test_board_curation_submit_roundtrips_to_read;
           Alcotest.test_case "accept automation reject system" `Quick
             test_post_create_accepts_automation_rejects_system;
           Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -603,6 +603,19 @@ let test_board_curation_submit_roundtrips_to_read () =
   Alcotest.(check bool) "raw submit requires submitted_by" false missing_ok;
   Alcotest.(check string) "missing submitted_by error" "submitted_by required"
     missing_body;
+  let invalid_score_ok, invalid_score_body =
+    dispatch "masc_board_curation_submit"
+      (make_args
+         [
+           ("submitted_by", `String "curator");
+           ("rationale", `String "score out of range");
+           ("health_score", `Float 1.5);
+         ])
+  in
+  Alcotest.(check bool) "raw submit rejects out-of-range health score" false
+    invalid_score_ok;
+  Alcotest.(check bool) "invalid score error mentions health_score" true
+    (contains_substring invalid_score_body "health_score");
   let ok, body =
     dispatch "masc_board_curation_submit"
       (make_args

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -712,6 +712,49 @@ let test_board_curation_submit_roundtrips_to_read () =
     "Board has one high-priority routing item."
     Yojson.Safe.Util.(read_json |> member "summary" |> to_string)
 
+let inline_board_dispatch ~sw ~clock name args =
+  let state = Mcp_server.create_state ~base_path:_test_base_path in
+  Tool_inline_dispatch_extra.dispatch ~config:state.Mcp_server.room_config
+    ~agent_name:"inline-curator" ~arguments:args ~state ~sw ~clock ~name
+
+let require_inline_result ~sw ~clock name args =
+  match inline_board_dispatch ~sw ~clock name args with
+  | Some result -> result
+  | None -> Alcotest.failf "%s not routed by inline board dispatch" name
+
+let test_board_curation_inline_dispatch_routes_read_and_submit () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  Eio.Switch.run @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let read_ok, read_body =
+    require_inline_result ~sw ~clock "masc_board_curation_read" (make_args [])
+  in
+  Alcotest.(check bool) "inline curation read ok" true read_ok;
+  Alcotest.(check string) "inline curation read empty" "null" read_body;
+  let submit_ok, submit_body =
+    require_inline_result ~sw ~clock "masc_board_curation_submit"
+      (make_args
+         [
+           ("submitted_by", `String "inline-curator");
+           ("summary", `String "Inline MCP curation route works.");
+           ("rationale", `String "Pin schema-to-dispatch curation routing");
+         ])
+  in
+  Alcotest.(check bool) "inline curation submit ok" true submit_ok;
+  let submitted = Yojson.Safe.from_string submit_body in
+  Alcotest.(check string) "inline submitted_by persisted" "inline-curator"
+    Yojson.Safe.Util.(submitted |> member "submitted_by" |> to_string);
+  let read2_ok, read2_body =
+    require_inline_result ~sw ~clock "masc_board_curation_read" (make_args [])
+  in
+  Alcotest.(check bool) "inline curation read after submit ok" true read2_ok;
+  Alcotest.(check string) "inline curation read after submit summary"
+    "Inline MCP curation route works."
+    Yojson.Safe.Util.(
+      Yojson.Safe.from_string read2_body |> member "summary" |> to_string)
+
 let test_post_create_accepts_automation_rejects_system () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1190,6 +1233,8 @@ let () =
             test_board_curation_read_empty_returns_json_null;
           Alcotest.test_case "curation submit roundtrips to read" `Quick
             test_board_curation_submit_roundtrips_to_read;
+          Alcotest.test_case "curation inline dispatch routes read and submit" `Quick
+            test_board_curation_inline_dispatch_routes_read_and_submit;
           Alcotest.test_case "accept automation reject system" `Quick
             test_post_create_accepts_automation_rejects_system;
           Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -616,15 +616,28 @@ let test_board_curation_submit_roundtrips_to_read () =
     invalid_score_ok;
   Alcotest.(check bool) "invalid score error mentions health_score" true
     (contains_substring invalid_score_body "health_score");
+  let invalid_provenance_ok, invalid_provenance_body =
+    dispatch "masc_board_curation_submit"
+      (make_args
+         [
+           ("submitted_by", `String "curator");
+           ("rationale", `String "provenance shape");
+           ("provenance", `String "not-an-object");
+         ])
+  in
+  Alcotest.(check bool) "raw submit rejects non-object provenance" false
+    invalid_provenance_ok;
+  Alcotest.(check bool) "invalid provenance error mentions object" true
+    (contains_substring invalid_provenance_body "object");
   let ok, body =
     dispatch "masc_board_curation_submit"
       (make_args
          [
            ("submitted_by", `String "curator");
-           ("model", `String "test-model");
-           ("summary", `String "Board has one high-priority routing item.");
-           ("ordering", `List [ `String "p-7" ]);
-           ("highlights", `List [ `String "p-7" ]);
+           ("model", `String " test-model ");
+           ("summary", `String " Board has one high-priority routing item. ");
+           ("ordering", `List [ `String " p-7 "; `String " "; `String "" ]);
+           ("highlights", `List [ `String " p-7 "; `String " " ]);
            ("tag_suggestions",
             `List
               [
@@ -666,9 +679,15 @@ let test_board_curation_submit_roundtrips_to_read () =
   let submitted = Yojson.Safe.from_string body in
   Alcotest.(check string) "submitted_by persisted" "curator"
     Yojson.Safe.Util.(submitted |> member "submitted_by" |> to_string);
+  Alcotest.(check string) "model trimmed" "test-model"
+    Yojson.Safe.Util.(submitted |> member "model" |> to_string);
   Alcotest.(check string) "summary persisted"
     "Board has one high-priority routing item."
     Yojson.Safe.Util.(submitted |> member "summary" |> to_string);
+  Alcotest.(check (list string)) "ordering trims and drops blanks" [ "p-7" ]
+    Yojson.Safe.Util.(submitted |> member "ordering" |> to_list |> List.map to_string);
+  Alcotest.(check (list string)) "highlights trim and drop blanks" [ "p-7" ]
+    Yojson.Safe.Util.(submitted |> member "highlights" |> to_list |> List.map to_string);
   Alcotest.(check (float 0.0001)) "health score persisted" 0.65
     Yojson.Safe.Util.(submitted |> member "health_score" |> to_float);
   let read_ok, read_body = dispatch "masc_board_curation_read" (make_args []) in

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -655,7 +655,7 @@ let test_board_curation_submit_roundtrips_to_read () =
                   [
                     ("question_post_id", `String "p-7");
                     ("answer_post_id", `String "p-8");
-                    ("score", `Float 0.9);
+                    ("score", `String " 0.9 ");
                     ("rationale", `String "Direct answer candidate");
                   ];
               ]);
@@ -666,8 +666,8 @@ let test_board_curation_submit_roundtrips_to_read () =
                 `Assoc
                   [
                     ("name", `String "routing_latency");
-                    ("score", `Float 0.65);
-                    ("weight", `Float 0.5);
+                    ("score", `String "0.65");
+                    ("weight", `String " 0.5 ");
                     ("rationale", `String "Some delay visible");
                   ];
               ]);
@@ -690,6 +690,18 @@ let test_board_curation_submit_roundtrips_to_read () =
     Yojson.Safe.Util.(submitted |> member "highlights" |> to_list |> List.map to_string);
   Alcotest.(check (float 0.0001)) "health score persisted" 0.65
     Yojson.Safe.Util.(submitted |> member "health_score" |> to_float);
+  let answer_match =
+    Yojson.Safe.Util.(submitted |> member "answer_matches" |> to_list |> List.hd)
+  in
+  Alcotest.(check (float 0.0001)) "string answer score parsed" 0.9
+    Yojson.Safe.Util.(answer_match |> member "score" |> to_float);
+  let health_component =
+    Yojson.Safe.Util.(submitted |> member "health_components" |> to_list |> List.hd)
+  in
+  Alcotest.(check (float 0.0001)) "string health component score parsed" 0.65
+    Yojson.Safe.Util.(health_component |> member "score" |> to_float);
+  Alcotest.(check (float 0.0001)) "string health component weight parsed" 0.5
+    Yojson.Safe.Util.(health_component |> member "weight" |> to_float);
   let read_ok, read_body = dispatch "masc_board_curation_read" (make_args []) in
   Alcotest.(check bool) "curation read after submit ok" true read_ok;
   let read_json = Yojson.Safe.from_string read_body in
@@ -1102,6 +1114,35 @@ let test_tools_all_have_descriptions () =
       (String.length t.description > 0)
   ) Tool_board.tools
 
+let health_score_schema (tool : Masc_domain.tool_schema) =
+  match tool.input_schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | Some (`Assoc properties) ->
+       (match List.assoc_opt "health_score" properties with
+        | Some (`Assoc schema) -> schema
+        | _ -> Alcotest.failf "%s missing health_score schema" tool.name)
+     | _ -> Alcotest.failf "%s missing properties schema" tool.name)
+  | _ -> Alcotest.failf "%s input_schema is not an object" tool.name
+
+let find_tool name tools =
+  match List.find_opt (fun (tool : Masc_domain.tool_schema) -> String.equal tool.name name) tools with
+  | Some tool -> tool
+  | None -> Alcotest.failf "missing tool schema %s" name
+
+let test_curation_health_score_schema_bounds () =
+  let check_bounds label tool =
+    let schema = health_score_schema tool in
+    Alcotest.(check (float 0.0001)) (label ^ " minimum") 0.0
+      Yojson.Safe.Util.(List.assoc "minimum" schema |> to_float);
+    Alcotest.(check (float 0.0001)) (label ^ " maximum") 1.0
+      Yojson.Safe.Util.(List.assoc "maximum" schema |> to_float)
+  in
+  check_bounds "raw curation submit"
+    (find_tool "masc_board_curation_submit" Tool_board.tools);
+  check_bounds "keeper curation submit"
+    (find_tool "keeper_board_curation_submit" Tool_shard.shard_board.tools)
+
 (** {1 Test Runner} *)
 
 let () =
@@ -1205,6 +1246,8 @@ let () =
           Alcotest.test_case "tools count" `Quick test_tools_count;
           Alcotest.test_case "unique names" `Quick test_tools_names_unique;
           Alcotest.test_case "all have descriptions" `Quick test_tools_all_have_descriptions;
+          Alcotest.test_case "curation health score schema bounds" `Quick
+            test_curation_health_score_schema_bounds;
         ] );
       ( "post_kind_registry",
         [

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -5,7 +5,8 @@ module Types = Masc_domain
 open Masc_mcp
 
 let all_keeper : Tool_name.Keeper.t list =
-  [ Bash; Bash_kill; Bash_output; Board_cleanup; Board_comment; Board_comment_vote; Board_delete
+  [ Bash; Bash_kill; Bash_output; Board_cleanup; Board_comment; Board_comment_vote
+  ; Board_curation_read; Board_curation_submit; Board_delete
   ; Board_get; Board_list; Board_post; Board_search; Board_stats; Board_vote
   ; Broadcast; Code_read; Context_status; Discovery; Fs_edit; Fs_read
   ; Handoff; Library_read; Library_search; Memory_search
@@ -23,6 +24,7 @@ let all_masc : Tool_name.Masc.t list =
   ; Autoresearch_record_finding; Autoresearch_search_findings
   ; Autoresearch_status; Autoresearch_stop
   ; Batch_add_tasks; Board_cleanup; Board_comment; Board_comment_vote
+  ; Board_curation_read; Board_curation_submit
   ; Board_delete; Board_get; Board_hearths; Board_list; Board_post
   ; Board_profile; Board_search
   ; Board_stats; Board_vote; Broadcast; Cancel_task; Check; Claim_next
@@ -146,8 +148,9 @@ let test_keeper_board_write_helpers () =
          (Printf.sprintf "%s is board" (to_string tool))
          true
          (is_board tool))
-    [ Board_cleanup; Board_comment; Board_comment_vote; Board_delete; Board_get
-    ; Board_list; Board_post; Board_search; Board_stats; Board_vote ];
+    [ Board_cleanup; Board_comment; Board_comment_vote; Board_curation_read
+    ; Board_curation_submit; Board_delete; Board_get; Board_list; Board_post
+    ; Board_search; Board_stats; Board_vote ];
   List.iter
     (fun tool ->
        Alcotest.(check bool)
@@ -156,7 +159,7 @@ let test_keeper_board_write_helpers () =
          (is_board tool))
     [ Broadcast; Task_done; Write ];
   Alcotest.(check (list string)) "canonical board write names"
-    [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
+    [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote"; "keeper_board_curation_submit" ]
     board_write_tool_names;
   List.iter
     (fun tool ->
@@ -171,13 +174,15 @@ let test_keeper_board_write_helpers () =
          (Printf.sprintf "%s is not board write" (to_string tool))
          false
          (is_board_write tool))
-    [ Board_list; Board_get; Board_comment_vote; Task_done; Write ];
+    [ Board_list; Board_get; Board_curation_read; Board_comment_vote; Task_done; Write ];
   Alcotest.(check (option string)) "post action kind"
     (Some "post") (board_write_action_kind Board_post);
   Alcotest.(check (option string)) "comment action kind"
     (Some "comment") (board_write_action_kind Board_comment);
   Alcotest.(check (option string)) "vote action kind"
     (Some "vote") (board_write_action_kind Board_vote);
+  Alcotest.(check (option string)) "curation action kind"
+    (Some "curation") (board_write_action_kind Board_curation_submit);
   Alcotest.(check (option string)) "non-board action kind"
     None (board_write_action_kind Board_list)
 


### PR DESCRIPTION
## Summary
- Extend board curation snapshots so keepers can submit auditable AI curation projections through `keeper_board_curation_submit`.
- Add raw `masc_board_curation_read` / `masc_board_curation_submit`, keeper identity injection for `submitted_by`, tool policy/surface/catalog registration, and dashboard normalization coverage.
- Fix the MCP inline dispatch gap: curation tools advertised by `tools/list` now route through `tools/call` instead of returning unknown tool.
- Make autonomous Keeper curation deterministic: multi-event board windows now emit a `board_curation` affordance, force-include `keeper_board_curation_submit` in the keeper tool surface when policy allows it, and prefer that exact tool choice for required-tool turns.
- Preserve the invariant that curation snapshots only publish projection metadata; they do not mutate board posts, comments, or votes.

## Why This Matters
Current `main` can advertise curation read while failing at call time, and keepers only receive a prompt hint instead of a deterministic curation action path. This PR closes both gaps: the MCP tool is callable, and autonomous keeper turns have a specific tool-gated route to submit the curation snapshot when a board window is due.

## Review Focus
- `lib/tool_inline_dispatch_extra.ml`: curation read/submit must route to `Tool_board.handle_tool`.
- `lib/keeper/keeper_agent_tool_surface.ml` and `lib/keeper/keeper_run_tools.ml`: `board_curation` should force-include and prefer `keeper_board_curation_submit` without forcing unavailable tools.
- `lib/keeper/keeper_unified_metrics.ml`: multiple pending board events should emit `board_curation` in addition to generic board activity.
- `lib/tool_board.ml` and `lib/tool_shard.ml`: submit parsing, object-only provenance, finite numeric-string score support, and health-score `[0.0, 1.0]` schema bounds.
- `dashboard/src/api/board.ts`: strict string-array normalization for curation ordering/highlights/tags.

## Evidence
- Live audit on current `main`: authenticated `/mcp tools/list include_hidden=true` advertised `masc_board_curation_read`, but `tools/call` returned `Unknown tool: masc_board_curation_read (registry inconsistency)`.
- Branch server proof on `08f690bb1f`: `tools/list` returned `masc_board_curation_read,masc_board_curation_submit`; read returned `null`; submit returned `isError=false`; read-after-submit returned the submitted summary.
- `git diff --check`
- `ocamlc -stop-after parsing` on touched keeper/board/test files
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test tool_classification --show-errors --compact`
- `./_build/default/test/test_keeper_unified.exe test verification_surface --show-errors --compact`
- `./_build/default/test/test_keeper_unified.exe --show-errors --compact`
- `./_build/default/test/test_tool_board_coverage.exe --show-errors --compact`
- Earlier dashboard evidence still applies: `pnpm exec tsc --noEmit --pretty false` and `pnpm exec vitest run --config vitest.config.ts src/api/board.test.ts --no-file-parallelism --maxWorkers=1`.

## Known Residual
- `./_build/default/test/test_tool_surface_ssot.exe` still fails on pre-existing orphaned tool schemas unrelated to curation; tracked separately as #13559. The failure list does not include the new curation read/submit tools.
- Live runtime cannot prove actual autonomous keeper submission until this PR is merged and the runtime is restarted; current `main` lacks `keeper_board_curation_submit`.

## Gate
Draft only. This is merge-prep for review, not ready-for-review or merge.