### PR TITLE
fix(keeper): observe create discovery refresh

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -629,6 +629,7 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
         + (Prometheus.metric_total Prometheus.metric_keeper_turn_cleanup_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_cleanup_tracking_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_cascade_sync_failures |> int_of_float)
+        + (Prometheus.metric_total Prometheus.metric_keeper_local_discovery_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_thinking_persist_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_checkpoint_failures |> int_of_float)
         + (Prometheus.metric_total Prometheus.metric_keeper_memory_write_failures |> int_of_float)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -309,9 +309,25 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   (Keeper_cascade_profile.Runtime_name
                      Keeper_config.default_cascade_name)
               in
-              ignore
-                (Cascade_runtime.refresh_local_discovery_if_possible
-                   cascade_models);
+              (match
+                 Keeper_turn_helpers.ensure_local_discovery_ready
+                   cascade_models
+               with
+               | Ok () -> ()
+               | Error msg ->
+                   Log.Keeper.warn
+                     "create_keeper local discovery refresh incomplete for \
+                      name=%s: %s"
+                     p.name
+                     msg;
+                   Prometheus.inc_counter
+                     Prometheus.metric_keeper_cascade_sync_failures
+                     ~labels:
+                       [
+                         ("keeper", p.name);
+                         ("site", "create_local_discovery_refresh");
+                       ]
+                     ());
               let primary_max_context =
                 match p.max_context_override_opt with
                 | Some v -> v

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -321,7 +321,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                      p.name
                      msg;
                    Prometheus.inc_counter
-                     Prometheus.metric_keeper_cascade_sync_failures
+                     Prometheus.metric_keeper_local_discovery_failures
                      ~labels:
                        [
                          ("keeper", p.name);

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -673,6 +673,8 @@ let metric_keeper_turn_error_after_tools =
   "masc_keeper_turn_error_after_tools_total"
 let metric_keeper_cascade_sync_failures =
   "masc_keeper_cascade_sync_failures_total"
+let metric_keeper_local_discovery_failures =
+  "masc_keeper_local_discovery_failures_total"
 let metric_keeper_thinking_persist_failures =
   "masc_keeper_thinking_persist_failures_total"
 let metric_keeper_checkpoint_failures =
@@ -1872,6 +1874,10 @@ let init () =
   add metric_keeper_cascade_sync_failures
     "Total cascade state synchronization failures (pause/resume/auto-pause). \
      Labeled by keeper and site."
+    Counter;
+  add metric_keeper_local_discovery_failures
+    "Total local discovery readiness failures observed during create/turn \
+     paths. Labeled by keeper and site."
     Counter;
   add metric_keeper_thinking_persist_failures
     "Total thinking content persistence failures in keeper_agent_run. \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -305,6 +305,16 @@ val metric_keeper_turn_livelock_blocks : string
 val metric_keeper_turn_timeout_committed : string
 val metric_keeper_turn_error_after_tools : string
 val metric_keeper_cascade_sync_failures : string
+(** Cascade state synchronization failures: pause/resume/auto-pause paths
+    only. Local discovery refresh failures use
+    [metric_keeper_local_discovery_failures] so dashboards can attribute
+    distinct failure classes. *)
+
+val metric_keeper_local_discovery_failures : string
+(** Local discovery readiness failures observed during create/turn paths.
+    Separated from [metric_keeper_cascade_sync_failures] so dashboards do
+    not conflate cascade-state sync with discovery-refresh incompleteness. *)
+
 val metric_keeper_thinking_persist_failures : string
 val metric_keeper_checkpoint_failures : string
 val metric_keeper_memory_write_failures : string

--- a/test/test_keeper_turn_up_create_meta_retry.ml
+++ b/test/test_keeper_turn_up_create_meta_retry.ml
@@ -51,6 +51,32 @@ let write_meta_exn config meta =
   | Ok () -> ()
   | Error err -> fail ("write_meta failed: " ^ err)
 
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let load_source rel =
+  let path = Filename.concat (source_root ()) rel in
+  if not (Sys.file_exists path) then
+    failwith (Printf.sprintf "source file not found: %s" path);
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop idx =
+      idx + needle_len <= haystack_len
+      &&
+      (String.sub haystack idx needle_len = needle || loop (idx + 1))
+    in
+    loop 0
+
 let test_bootstrap_write_retries_and_preserves_heartbeat_fields () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -98,6 +124,19 @@ let test_bootstrap_write_retries_and_preserves_heartbeat_fields () =
       check bool "version advanced past heartbeat write" true
         (final.meta_version > heartbeat_write.meta_version))
 
+let test_create_keeper_observes_local_discovery_refresh_source () =
+  let src = load_source "lib/keeper/keeper_turn_up_create.ml" in
+  check bool "create path no longer discards local discovery refresh" false
+    (contains_substring
+       src
+       "ignore\n                (Cascade_runtime.refresh_local_discovery_if_possible");
+  check bool "create path uses local discovery helper" true
+    (contains_substring
+       src
+       "Keeper_turn_helpers.ensure_local_discovery_ready");
+  check bool "create path labels observable refresh failures" true
+    (contains_substring src "create_local_discovery_refresh")
+
 let () =
   run "keeper_turn_up_create bootstrap meta CAS retry"
     [
@@ -107,5 +146,12 @@ let () =
             "retries stale bootstrap write and keeps heartbeat fields"
             `Quick
             test_bootstrap_write_retries_and_preserves_heartbeat_fields;
+        ] );
+      ( "source_contracts",
+        [
+          test_case
+            "create_keeper observes local discovery refresh failures"
+            `Quick
+            test_create_keeper_observes_local_discovery_refresh_source;
         ] );
     ]

--- a/test/test_keeper_turn_up_create_meta_retry.ml
+++ b/test/test_keeper_turn_up_create_meta_retry.ml
@@ -77,6 +77,31 @@ let contains_substring haystack needle =
     in
     loop 0
 
+(* Whitespace-insensitive substring check: collapses every run of ASCII
+   whitespace in both the haystack and needle to a single space before
+   comparing. Used by source-contract assertions so OCamlformat
+   reflowing the offending pattern (e.g. moving an [ignore (...)]
+   onto one line vs. two) doesn't mask a regression. *)
+let contains_substring_ws_insensitive haystack needle =
+  let collapse s =
+    let buf = Buffer.create (String.length s) in
+    let in_ws = ref true in
+    String.iter
+      (fun c ->
+        match c with
+        | ' ' | '\t' | '\n' | '\r' ->
+            if not !in_ws then begin
+              Buffer.add_char buf ' ';
+              in_ws := true
+            end
+        | _ ->
+            Buffer.add_char buf c;
+            in_ws := false)
+      s;
+    Buffer.contents buf
+  in
+  contains_substring (collapse haystack) (collapse needle)
+
 let test_bootstrap_write_retries_and_preserves_heartbeat_fields () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -126,16 +151,21 @@ let test_bootstrap_write_retries_and_preserves_heartbeat_fields () =
 
 let test_create_keeper_observes_local_discovery_refresh_source () =
   let src = load_source "lib/keeper/keeper_turn_up_create.ml" in
+  (* Use whitespace-insensitive match so OCamlformat's choice of
+     newlines/indent for the [ignore (...)] form does not silently
+     mask a regression. *)
   check bool "create path no longer discards local discovery refresh" false
-    (contains_substring
+    (contains_substring_ws_insensitive
        src
-       "ignore\n                (Cascade_runtime.refresh_local_discovery_if_possible");
+       "ignore (Cascade_runtime.refresh_local_discovery_if_possible");
   check bool "create path uses local discovery helper" true
     (contains_substring
        src
        "Keeper_turn_helpers.ensure_local_discovery_ready");
   check bool "create path labels observable refresh failures" true
-    (contains_substring src "create_local_discovery_refresh")
+    (contains_substring src "create_local_discovery_refresh");
+  check bool "create path uses dedicated local discovery metric" true
+    (contains_substring src "metric_keeper_local_discovery_failures")
 
 let () =
   run "keeper_turn_up_create bootstrap meta CAS retry"


### PR DESCRIPTION
## Summary

- Replace the keeper creation path's discarded local-discovery refresh result with an observable best-effort branch.
- Log incomplete discovery refreshes and increment `metric_keeper_cascade_sync_failures{site=create_local_discovery_refresh}` when selected bootstrap labels require local runtime discovery but refresh cannot complete.
- Add a source-contract test to keep `create_keeper` from regressing back to ignored discovery refreshes.

## Why

`keeper_up` computes the initial checkpoint context from the default cascade labels. When those labels require local-provider discovery, silently discarding a failed refresh can leave bootstrap context sizing based on stale/static assumptions. This keeps keeper creation non-blocking while making that degraded bootstrap visible to operators.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_turn_up_create_meta_retry.exe`
- `./_build/default/test/test_keeper_turn_up_create_meta_retry.exe`
- Rebased cleanly onto current `origin/main` before push.