### PR TITLE
fix(keeper): avoid docker word false positive in git commits

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -202,27 +202,68 @@ let shell_assignment_like word =
       in
       String.for_all ok_char (String.sub word 0 idx)
 
+let env_option_takes_arg = function
+  | "-u" | "--unset" | "-c" | "--chdir" -> true
+  | _ -> false
+
+let env_option_like word =
+  String.length word > 0 && word.[0] = '-'
+
+let env_split_string_inline_value word =
+  let prefix = "--split-string=" in
+  if String.starts_with ~prefix word then
+    Some
+      (String.sub word (String.length prefix)
+         (String.length word - String.length prefix))
+  else
+    None
+
 let command_word_mentions_nested_runtime cmd =
-  let rec scan expect_command in_env = function
+  let rec scan expect_command in_env skip_env_arg = function
     | [] -> false
-    | Guard_separator :: rest -> scan true false rest
-    | Guard_word (word, quoted) :: rest ->
-        if expect_command then
-          if (not quoted) && List.mem word nested_container_runtime_tokens then
-            true
-          else if (not quoted) && (word = "sudo" || word = "command" || word = "time")
-          then
-            scan true false rest
-          else if (not quoted) && word = "env" then
-            scan true true rest
-          else if in_env && (not quoted) && shell_assignment_like word then
-            scan true true rest
+    | Guard_separator :: rest -> scan true false false rest
+    | Guard_word (word, _) :: rest ->
+        if not expect_command then scan false false false rest
+        else if in_env then scan_env_word word skip_env_arg rest
+        else scan_command_word word rest
+  and scan_command_word word rest =
+    if List.mem word nested_container_runtime_tokens then
+      true
+    else if word = "sudo" || word = "command" || word = "time" then
+      scan true false false rest
+    else if word = "env" then
+      scan true true false rest
+    else if shell_assignment_like word then
+      scan true false false rest
+    else
+      scan false false false rest
+  and scan_env_word word skip_env_arg rest =
+    if skip_env_arg then
+      scan true true false rest
+    else if word = "--" then
+      scan true false false rest
+    else if word = "-s" || word = "--split-string" then
+      match rest with
+      | Guard_word (split_arg, _) :: tail ->
+          nested_in_split_arg split_arg || scan true true false tail
+      | _ -> false
+    else
+      match env_split_string_inline_value word with
+      | Some split_arg ->
+          nested_in_split_arg split_arg || scan true true false rest
+      | None ->
+          if shell_assignment_like word then
+            scan true true false rest
+          else if env_option_takes_arg word then
+            scan true true true rest
+          else if env_option_like word then
+            scan true true false rest
           else
-            scan false false rest
-        else
-          scan false false rest
+            scan_command_word word rest
+  and nested_in_split_arg split_arg =
+    scan true false false (shell_guard_tokens split_arg)
   in
-  scan true false (shell_guard_tokens cmd)
+  scan true false false (shell_guard_tokens cmd)
 
 let command_uses_nested_container_runtime cmd =
   let lowered_cmd = String.lowercase_ascii cmd in

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -145,11 +145,88 @@ let sandbox_socket_markers =
     "buildkitd.sock";
   ]
 
+type shell_guard_token =
+  | Guard_word of string * bool
+  | Guard_separator
+
+let shell_guard_tokens cmd =
+  let flush_word acc buf quoted =
+    if Buffer.length buf = 0 then acc
+    else begin
+      let word = Buffer.contents buf |> String.lowercase_ascii in
+      Buffer.clear buf;
+      Guard_word (word, quoted) :: acc
+    end
+  in
+  let len = String.length cmd in
+  let rec loop i quote quoted acc buf =
+    if i >= len then
+      List.rev (flush_word acc buf quoted)
+    else
+      match quote, cmd.[i] with
+      | Some q, c when c = q ->
+          loop (i + 1) None true acc buf
+      | Some _, c ->
+          Buffer.add_char buf c;
+          loop (i + 1) quote quoted acc buf
+      | None, ('\'' | '"' as q) ->
+          loop (i + 1) (Some q) true acc buf
+      | None, (' ' | '\t' | '\r' | '\n') ->
+          let acc = flush_word acc buf quoted in
+          loop (i + 1) None false acc buf
+      | None, (';' | '|') ->
+          let acc = Guard_separator :: flush_word acc buf quoted in
+          loop (i + 1) None false acc buf
+      | None, '&' ->
+          let acc =
+            if i + 1 < len && cmd.[i + 1] = '&' then
+              Guard_separator :: flush_word acc buf quoted
+            else
+              flush_word acc buf quoted
+          in
+          loop (if i + 1 < len && cmd.[i + 1] = '&' then i + 2 else i + 1)
+            None false acc buf
+      | None, c ->
+          Buffer.add_char buf c;
+          loop (i + 1) None quoted acc buf
+  in
+  loop 0 None false [] (Buffer.create 32)
+
+let shell_assignment_like word =
+  match String.index_opt word '=' with
+  | None | Some 0 -> false
+  | Some idx ->
+      let ok_char = function
+        | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
+        | _ -> false
+      in
+      String.for_all ok_char (String.sub word 0 idx)
+
+let command_word_mentions_nested_runtime cmd =
+  let rec scan expect_command in_env = function
+    | [] -> false
+    | Guard_separator :: rest -> scan true false rest
+    | Guard_word (word, quoted) :: rest ->
+        if expect_command then
+          if (not quoted) && List.mem word nested_container_runtime_tokens then
+            true
+          else if (not quoted) && (word = "sudo" || word = "command" || word = "time")
+          then
+            scan true false rest
+          else if (not quoted) && word = "env" then
+            scan true true rest
+          else if in_env && (not quoted) && shell_assignment_like word then
+            scan true true rest
+          else
+            scan false false rest
+        else
+          scan false false rest
+  in
+  scan true false (shell_guard_tokens cmd)
+
 let command_uses_nested_container_runtime cmd =
-  let lowered_words = lowercase_shell_words cmd in
   let lowered_cmd = String.lowercase_ascii cmd in
-  List.exists (fun token -> List.mem token nested_container_runtime_tokens)
-    lowered_words
+  command_word_mentions_nested_runtime cmd
   || List.exists (String_util.contains_substring lowered_cmd) sandbox_socket_markers
 
 (* ── Sandbox runtime preflight ─────────────────────────── *)

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -11,6 +11,7 @@ module Config_boot_overrides = Config_boot_overrides
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
 module Keeper_types = Masc_mcp.Keeper_types
 module Json = Yojson.Safe.Util
 
@@ -354,6 +355,23 @@ let test_docker_blocks_docker_socket_reference () =
   | None ->
       Alcotest.fail ("expected error json, got: " ^ raw)
 
+let test_nested_runtime_detector_ignores_git_commit_message () =
+  Alcotest.(check bool)
+    "quoted docker in git commit message is not a nested runtime"
+    false
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "git commit -m 'docs: Docker sandbox proof'");
+  Alcotest.(check bool)
+    "unquoted docker argument is not a nested runtime unless command-position"
+    false
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "git commit -m Docker-sandbox-proof");
+  Alcotest.(check bool)
+    "docker after command separator is still blocked"
+    true
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "git status && docker run --rm alpine true")
+
 let test_docker_missing_seccomp_profile_fails_closed () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -670,6 +688,8 @@ let () =
         test_docker_blocks_nested_docker_command;
       Alcotest.test_case "docker blocks docker socket reference" `Quick
         test_docker_blocks_docker_socket_reference;
+      Alcotest.test_case "nested runtime detector ignores commit messages" `Quick
+        test_nested_runtime_detector_ignores_git_commit_message;
       Alcotest.test_case "docker missing seccomp fails closed" `Quick
         test_docker_missing_seccomp_profile_fails_closed;
     ]);

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -370,7 +370,47 @@ let test_nested_runtime_detector_ignores_git_commit_message () =
     "docker after command separator is still blocked"
     true
     (Keeper_shell_docker.command_uses_nested_container_runtime
-       "git status && docker run --rm alpine true")
+       "git status && docker run --rm alpine true");
+  Alcotest.(check bool)
+    "quoted docker command word is still blocked"
+    true
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "\"docker\" run --rm alpine true");
+  Alcotest.(check bool)
+    "partially quoted docker command word is still blocked"
+    true
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "do\"cker\" run --rm alpine true");
+  Alcotest.(check bool)
+    "env option wrapper still exposes docker command"
+    true
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "env -i docker run --rm alpine true");
+  Alcotest.(check bool)
+    "env terminator still exposes docker command"
+    true
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "env -- docker run --rm alpine true");
+  Alcotest.(check bool)
+    "env value option does not treat its argument as command"
+    false
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "env -u docker git commit -m Docker-sandbox-proof");
+  Alcotest.(check bool)
+    "env split-string wrapper still exposes docker command"
+    true
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "env -S 'docker run --rm alpine true'");
+  Alcotest.(check bool)
+    "env inline split-string wrapper still exposes docker command"
+    true
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "env --split-string='docker run --rm alpine true'");
+  Alcotest.(check bool)
+    "env split-string assignment without runtime remains allowed"
+    false
+    (Keeper_shell_docker.command_uses_nested_container_runtime
+       "env -S 'FOO=docker git commit -m Docker-sandbox-proof'")
 
 let test_docker_missing_seccomp_profile_fails_closed () =
   with_eio_fs @@ fun () ->


### PR DESCRIPTION
## Summary
- Narrow the Docker nested-runtime guard to command-position runtime tokens instead of arbitrary argument text.
- Keep socket marker blocking intact.
- Add regression coverage for git commit messages that mention Docker while still blocking docker after a command separator.

## Live evidence
- 2026-05-06 KST filesystem/runtime retry kmsg_glm-coding-plan_5_1778028299410 resolved repo ACL but stopped at git commit.
- Keeper glm-coding-plan reported git commit failed with sandbox_profile=docker+git_creds blocks nested container runtimes and host socket references.
- The generated commit message included Docker sandbox, which matched the old broad token detector even though no nested container runtime was invoked.
- Storage path is filesystem/JSONL only; PostgreSQL is not part of this evidence path.

## Verification
- ocamlc -stop-after parsing lib/keeper/keeper_shell_docker.ml test/test_keeper_bash_safety.ml
- scripts/dune-local.sh build ./test/test_keeper_bash_safety.exe
- ./_build/default/test/test_keeper_bash_safety.exe
- scripts/check-oas-pin.sh --local-only
- git diff --check