### PR TITLE
fix(dashboard): add IDE diff summary chrome

### DIFF
--- a/dashboard/src/components/ide/ide-diff-view.test.ts
+++ b/dashboard/src/components/ide/ide-diff-view.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'vitest'
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
 import type { UnifiedDiffRow } from '../../api/workspace'
-import { buildSplitDiff } from './ide-diff-view'
+import {
+  buildSplitDiff,
+  formatDiffLineRange,
+  formatDiffSummaryAria,
+  SplitDiffView,
+  summarizeDiffRows,
+  UnifiedDiffView,
+} from './ide-diff-view'
 
 const row = (
   kind: 'context' | 'add' | 'delete',
@@ -73,5 +82,81 @@ describe('buildSplitDiff', () => {
     expect(result[0]!.after?.text).toBe('added')
     expect(result[1]!.before).toBeNull()
     expect(result[1]!.after?.text).toBe('more')
+  })
+})
+
+describe('summarizeDiffRows', () => {
+  it('counts diff tones and derives visible old/new line windows', () => {
+    const summary = summarizeDiffRows([
+      row('context', 10, 10, 'keep'),
+      row('delete', 11, null, 'remove'),
+      row('add', null, 11, 'add'),
+      row('add', null, 12, 'also add'),
+      row('context', 12, 13, 'keep again'),
+    ])
+    expect(summary).toEqual({
+      total: 5,
+      additions: 2,
+      deletions: 1,
+      context: 2,
+      changed: 3,
+      oldRange: { start: 10, end: 12 },
+      newRange: { start: 10, end: 13 },
+    })
+  })
+
+  it('returns empty ranges for empty rows', () => {
+    const summary = summarizeDiffRows([])
+    expect(summary.total).toBe(0)
+    expect(summary.changed).toBe(0)
+    expect(formatDiffLineRange(summary.oldRange)).toBe('n/a')
+    expect(formatDiffLineRange(summary.newRange)).toBe('n/a')
+  })
+})
+
+describe('formatDiffSummaryAria', () => {
+  it('produces a screen-reader summary with pluralized counts', () => {
+    const summary = summarizeDiffRows([
+      row('delete', 4, null, 'old'),
+      row('add', null, 4, 'new'),
+      row('context', 5, 5, 'same'),
+    ])
+    expect(formatDiffSummaryAria(summary, 'Unified')).toBe(
+      'Unified diff summary: 1 addition, 1 deletion, 1 context row, old lines 4-5, new lines 4-5',
+    )
+  })
+})
+
+describe('diff preview chrome', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders unified summary chips before diff rows', () => {
+    render(UnifiedDiffView([
+      row('delete', 4, null, 'old value'),
+      row('add', null, 4, 'new value'),
+      row('context', 5, 5, 'same value'),
+    ]), container)
+
+    expect(container.querySelector('[role="status"]')?.getAttribute('aria-label')).toContain('Unified diff summary')
+    expect(container.querySelector('[data-status-chip-tone="ok"]')?.textContent).toBe('+1')
+    expect(container.querySelector('[data-status-chip-tone="bad"]')?.textContent).toBe('-1')
+    expect(container.querySelector('[data-status-chip-tone="info"]')?.textContent).toBe('old 4-5 -> new 4-5')
+    expect(container.querySelector('[aria-label="Unified diff rows"]')?.textContent).toContain('new value')
+  })
+
+  it('renders split empty state instead of a blank pane', () => {
+    render(SplitDiffView([]), container)
+    expect(container.querySelector('[role="status"]')?.getAttribute('aria-label')).toContain('Split diff summary')
+    expect(container.querySelector('[role="note"]')?.textContent).toContain('No split diff rows')
   })
 })

--- a/dashboard/src/components/ide/ide-diff-view.ts
+++ b/dashboard/src/components/ide/ide-diff-view.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import type { UnifiedDiffRow } from '../../api/workspace'
+import { StatusChip } from '../common/status-chip'
 
 // ── Shared diff types ─────────────────────────────────────────────
 
@@ -16,54 +17,32 @@ export interface SplitDiffRow {
   readonly after: SplitDiffCell | null
 }
 
+export interface DiffLineRange {
+  readonly start: number | null
+  readonly end: number | null
+}
+
+export interface DiffSummary {
+  readonly total: number
+  readonly additions: number
+  readonly deletions: number
+  readonly context: number
+  readonly changed: number
+  readonly oldRange: DiffLineRange
+  readonly newRange: DiffLineRange
+}
+
 // ── Unified diff view ─────────────────────────────────────────────
 
 export function UnifiedDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
-  return html`
-    <ol
-      aria-label="Unified diff preview"
-      style=${{
-        listStyle: 'none',
-        padding: 'var(--sp-2) 0',
-        margin: 0,
-        overflow: 'auto',
-        fontFamily: 'var(--font-mono)',
-        fontSize: 'var(--fs-13)',
-        lineHeight: 1.6,
-      }}
-    >
-      ${rows.map(row => html`
-        <li
-          style=${{
-            display: 'grid',
-            gridTemplateColumns: '32px 40px 40px minmax(0, 1fr)',
-            gap: 'var(--sp-2)',
-            alignItems: 'center',
-            padding: '0 var(--sp-3)',
-            background: diffBackground(row.kind),
-            color: row.kind === 'delete' ? 'var(--color-status-danger, var(--color-fg-secondary))' : 'var(--color-fg-secondary)',
-          }}
-        >
-          <span style=${{ color: diffMarkerColor(row.kind), textAlign: 'center' }}>${diffMarker(row.kind)}</span>
-          <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${row.oldLine ?? ''}</span>
-          <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${row.newLine ?? ''}</span>
-          <span style=${{ whiteSpace: 'pre', minWidth: 0 }}>${row.text}</span>
-        </li>
-      `)}
-    </ol>
-  `
-}
-
-// ── Split diff view ───────────────────────────────────────────────
-
-export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
-  const splitRows: SplitDiffRow[] = buildSplitDiff(rows)
+  const summary = summarizeDiffRows(rows)
   return html`
     <div
-      aria-label="Split diff preview"
+      role="region"
+      aria-label="Unified diff preview"
       style=${{
         display: 'grid',
-        gridTemplateRows: 'auto 1fr',
+        gridTemplateRows: 'auto minmax(0, 1fr)',
         minHeight: 0,
         overflow: 'hidden',
         fontFamily: 'var(--font-mono)',
@@ -71,6 +50,129 @@ export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
         lineHeight: 1.6,
       }}
     >
+      <${DiffSummaryStrip} summary=${summary} mode="Unified" />
+      ${summary.total === 0
+        ? DiffEmptyState('No diff rows for the selected file.')
+        : html`
+          <ol
+            aria-label="Unified diff rows"
+            style=${{
+              listStyle: 'none',
+              padding: 'var(--sp-2) 0',
+              margin: 0,
+              overflow: 'auto',
+            }}
+          >
+            ${rows.map(row => html`
+              <li
+                style=${{
+                  display: 'grid',
+                  gridTemplateColumns: '32px 40px 40px minmax(0, 1fr)',
+                  gap: 'var(--sp-2)',
+                  alignItems: 'start',
+                  padding: '0 var(--sp-3)',
+                  background: diffBackground(row.kind),
+                  color: row.kind === 'delete' ? 'var(--color-status-danger, var(--color-fg-secondary))' : 'var(--color-fg-secondary)',
+                }}
+              >
+                <span style=${{ color: diffMarkerColor(row.kind), textAlign: 'center' }}>${diffMarker(row.kind)}</span>
+                <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${row.oldLine ?? ''}</span>
+                <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${row.newLine ?? ''}</span>
+                <span style=${{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', minWidth: 0 }}>${row.text}</span>
+              </li>
+            `)}
+          </ol>
+        `}
+    </div>
+  `
+}
+
+// ── Diff summary strip ────────────────────────────────────────────
+
+function DiffSummaryStrip({
+  summary,
+  mode,
+}: {
+  readonly summary: DiffSummary
+  readonly mode: 'Unified' | 'Split'
+}) {
+  return html`
+    <div
+      role="status"
+      aria-label=${formatDiffSummaryAria(summary, mode)}
+      style=${{
+        display: 'flex',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: 'var(--sp-2)',
+        minWidth: 0,
+        padding: 'var(--sp-2) var(--sp-3)',
+        borderBottom: '1px solid var(--color-border-divider)',
+        background: 'var(--color-bg-surface)',
+        color: 'var(--color-fg-muted)',
+        font: 'var(--type-eyebrow)',
+      }}
+    >
+      <span style=${{ color: 'var(--color-fg-secondary)' }}>${mode} diff</span>
+      <span style=${{ color: 'var(--color-fg-disabled)' }}>${summary.changed} changed rows</span>
+      <span
+        style=${{
+          display: 'inline-flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 'var(--sp-1)',
+          minWidth: 0,
+        }}
+      >
+        <${StatusChip} tone="ok" uppercase=${false}>+${summary.additions}</${StatusChip}>
+        <${StatusChip} tone="bad" uppercase=${false}>-${summary.deletions}</${StatusChip}>
+        <${StatusChip} tone="neutral" uppercase=${false}>${summary.context} context</${StatusChip}>
+        <${StatusChip} tone="info" uppercase=${false}>old ${formatDiffLineRange(summary.oldRange)} -> new ${formatDiffLineRange(summary.newRange)}</${StatusChip}>
+      </span>
+    </div>
+  `
+}
+
+function DiffEmptyState(label: string) {
+  return html`
+    <div
+      role="note"
+      style=${{
+        display: 'grid',
+        placeItems: 'center',
+        minHeight: '120px',
+        padding: 'var(--sp-4)',
+        color: 'var(--color-fg-muted)',
+        background: 'var(--color-bg-page)',
+        font: 'var(--type-body)',
+        fontSize: 'var(--fs-12)',
+        textAlign: 'center',
+      }}
+    >
+      ${label}
+    </div>
+  `
+}
+
+// ── Split diff view ───────────────────────────────────────────────
+
+export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
+  const summary = summarizeDiffRows(rows)
+  const splitRows: SplitDiffRow[] = buildSplitDiff(rows)
+  return html`
+    <div
+      aria-label="Split diff preview"
+      style=${{
+        display: 'grid',
+        gridTemplateRows: 'auto auto minmax(0, 1fr)',
+        minHeight: 0,
+        overflow: 'hidden',
+        fontFamily: 'var(--font-mono)',
+        fontSize: 'var(--fs-13)',
+        lineHeight: 1.6,
+      }}
+    >
+      <${DiffSummaryStrip} summary=${summary} mode="Split" />
       <div
         style=${{
           display: 'grid',
@@ -85,17 +187,19 @@ export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
         <span style=${{ padding: 'var(--sp-2) var(--sp-3)', borderLeft: '1px solid var(--color-border-divider)' }}>AFTER</span>
       </div>
       <div style=${{ overflow: 'auto' }}>
-        ${splitRows.map(row => html`
-          <div
-            style=${{
-              display: 'grid',
-              gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
-            }}
-          >
-            <${SplitDiffCellView} cell=${row.before} />
-            <${SplitDiffCellView} cell=${row.after} framed=${true} />
-          </div>
-        `)}
+        ${splitRows.length === 0
+          ? DiffEmptyState('No split diff rows for the selected file.')
+          : splitRows.map(row => html`
+            <div
+              style=${{
+                display: 'grid',
+                gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+              }}
+            >
+              <${SplitDiffCellView} cell=${row.before} />
+              <${SplitDiffCellView} cell=${row.after} framed=${true} />
+            </div>
+          `)}
       </div>
     </div>
   `
@@ -115,7 +219,7 @@ function SplitDiffCellView({
         display: 'grid',
         gridTemplateColumns: '40px 24px minmax(0, 1fr)',
         gap: 'var(--sp-2)',
-        alignItems: 'center',
+        alignItems: 'start',
         minHeight: '24px',
         padding: '0 var(--sp-3)',
         borderLeft: framed ? '1px solid var(--color-border-divider)' : undefined,
@@ -125,7 +229,7 @@ function SplitDiffCellView({
     >
       <span style=${{ color: 'var(--color-fg-disabled)', fontSize: 'var(--fs-11)', textAlign: 'right' }}>${cell?.line ?? ''}</span>
       <span style=${{ color: diffMarkerColor(kind), textAlign: 'center' }}>${cell ? diffMarker(kind) : ''}</span>
-      <span style=${{ whiteSpace: 'pre', minWidth: 0 }}>${cell?.text ?? ''}</span>
+      <span style=${{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', minWidth: 0 }}>${cell?.text ?? ''}</span>
     </div>
   `
 }
@@ -148,6 +252,60 @@ function diffMarkerColor(kind: string): string {
   if (kind === 'add') return 'var(--color-status-ok, var(--ok))'
   if (kind === 'delete') return 'var(--color-status-danger, var(--danger))'
   return 'var(--color-fg-disabled)'
+}
+
+// ── Summary helpers ───────────────────────────────────────────────
+
+export function summarizeDiffRows(rows: ReadonlyArray<UnifiedDiffRow>): DiffSummary {
+  let additions = 0
+  let deletions = 0
+  let context = 0
+  let oldStart: number | null = null
+  let oldEnd: number | null = null
+  let newStart: number | null = null
+  let newEnd: number | null = null
+
+  for (const row of rows) {
+    if (row.kind === 'add') {
+      additions += 1
+    } else if (row.kind === 'delete') {
+      deletions += 1
+    } else {
+      context += 1
+    }
+    if (row.oldLine != null) {
+      oldStart = oldStart == null ? row.oldLine : Math.min(oldStart, row.oldLine)
+      oldEnd = oldEnd == null ? row.oldLine : Math.max(oldEnd, row.oldLine)
+    }
+    if (row.newLine != null) {
+      newStart = newStart == null ? row.newLine : Math.min(newStart, row.newLine)
+      newEnd = newEnd == null ? row.newLine : Math.max(newEnd, row.newLine)
+    }
+  }
+
+  return {
+    total: rows.length,
+    additions,
+    deletions,
+    context,
+    changed: additions + deletions,
+    oldRange: { start: oldStart, end: oldEnd },
+    newRange: { start: newStart, end: newEnd },
+  }
+}
+
+export function formatDiffLineRange(range: DiffLineRange): string {
+  if (range.start == null || range.end == null) return 'n/a'
+  if (range.start === range.end) return `${range.start}`
+  return `${range.start}-${range.end}`
+}
+
+export function formatDiffSummaryAria(summary: DiffSummary, mode: 'Unified' | 'Split'): string {
+  return `${mode} diff summary: ${summary.additions} ${pluralize('addition', summary.additions)}, ${summary.deletions} ${pluralize('deletion', summary.deletions)}, ${summary.context} context ${pluralize('row', summary.context)}, old lines ${formatDiffLineRange(summary.oldRange)}, new lines ${formatDiffLineRange(summary.newRange)}`
+}
+
+function pluralize(noun: string, count: number): string {
+  return count === 1 ? noun : `${noun}s`
 }
 
 // ── Split diff builder ────────────────────────────────────────────

--- a/dashboard/src/components/ide/ide-diff-view.ts
+++ b/dashboard/src/components/ide/ide-diff-view.ts
@@ -96,6 +96,13 @@ function DiffSummaryStrip({
   readonly summary: DiffSummary
   readonly mode: 'Unified' | 'Split'
 }) {
+  // In Split mode buildSplitDiff visually pairs each delete with its add on
+  // the same row, so additions+deletions over-counts the visible "changed
+  // rows". Use max(additions,deletions) — that matches one logical row per
+  // pair plus any unpaired add/delete. Unified mode keeps the linear count.
+  const changedRows = mode === 'Split'
+    ? Math.max(summary.additions, summary.deletions)
+    : summary.changed
   return html`
     <div
       role="status"
@@ -114,7 +121,7 @@ function DiffSummaryStrip({
       }}
     >
       <span style=${{ color: 'var(--color-fg-secondary)' }}>${mode} diff</span>
-      <span style=${{ color: 'var(--color-fg-disabled)' }}>${summary.changed} changed rows</span>
+      <span style=${{ color: 'var(--color-fg-disabled)' }}>${changedRows} changed rows</span>
       <span
         style=${{
           display: 'inline-flex',
@@ -161,6 +168,7 @@ export function SplitDiffView(rows: ReadonlyArray<UnifiedDiffRow>) {
   const splitRows: SplitDiffRow[] = buildSplitDiff(rows)
   return html`
     <div
+      role="region"
       aria-label="Split diff preview"
       style=${{
         display: 'grid',


### PR DESCRIPTION
## Summary

- Add a reusable IDE diff summary model for additions, deletions, context rows, and old/new line windows.
- Render summary chips ahead of both unified and split diff rows.
- Add zero-row empty states and wrap long diff text so narrow panes do not force horizontal page overflow.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/ide/ide-diff-view.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard run lint` (passes with 3 existing warnings outside this slice)
- `pnpm --dir dashboard run build` (passes with existing Vite chunk/import warnings)
- Browser proof with Vite dev server plus a small localhost mock API:
  - split diff desktop: `/tmp/masc-ide-diff-summary-desktop-0506.png`
  - split diff mobile: `/tmp/masc-ide-diff-summary-mobile-0506.png`
  - unified diff mobile: `/tmp/masc-ide-diff-summary-unified-mobile-0506.png`
  - mobile `bodyScrollWidth` stayed equal to viewport width while the long diff row was present

## Review Focus

- `dashboard/src/components/ide/ide-diff-view.ts`
- `dashboard/src/components/ide/ide-diff-view.test.ts`
