### PR TITLE
feat(keeper): group supervisor sweep into cohorts

### DIFF
--- a/lib/keeper/keeper_lifecycle_audit.ml
+++ b/lib/keeper/keeper_lifecycle_audit.ml
@@ -26,7 +26,7 @@ let ring : (string, lifecycle_event_entry array * int ref) Hashtbl.t =
 let mu = Eio.Mutex.create ()
 
 let with_lock f =
-  Eio.Mutex.use_rw ~protect:true mu f
+  Eio_guard.with_mutex mu f
 
 let record ~keeper_name ~event_name ~phase ~detail =
   with_lock (fun () ->

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -59,6 +59,25 @@ let supervision_cohorts ?(cohort_size = supervision_cohort_size)
   in
   loop 0 [] sorted
 
+let fresh_supervision_cohort_keepers ~base_path
+    (cohort : supervision_cohort) =
+  List.filter_map
+    (fun (entry : Keeper_registry.registry_entry) ->
+      Keeper_registry.get ~base_path entry.name)
+    cohort.keepers
+
+let iter_supervision_cohorts ?(yield_between = Eio_guard.fair_yield)
+    cohorts ~f =
+  let rec loop = function
+    | [] -> ()
+    | [ cohort ] -> f cohort
+    | cohort :: rest ->
+        f cohort;
+        yield_between ();
+        loop rest
+  in
+  loop cohorts
+
 let should_cleanup_dead ~now ~dead_ttl_sec
     (entry : Keeper_registry.registry_entry) =
   match entry.phase, entry.dead_since_ts with
@@ -1288,14 +1307,16 @@ let sweep_and_recover (ctx : _ context) =
     end
   in
   (* 2-level supervision slice: process the flat registry through stable
-     8-keeper cohorts.  Today this gives the sweep an explicit boundary
-     and a cooperative yield between cohort groups; future work can hang
-     per-cohort restart budgets or fibers from the same helper.  The yield
-     meter still protects unusually large cohorts or non-default sizes. *)
+     8-keeper cohorts.  Each cohort re-reads its entries by name before
+     processing so earlier cohort actions cannot leave later cohorts walking
+     stale registry records.  The iterator yields between cohort groups; the
+     yield meter still protects unusually large cohorts or non-default sizes. *)
   let entry_cohorts = supervision_cohorts entries in
   let sweep_ym = Eio_guard.create_yield_meter () in
-  List.iter
-    (fun cohort ->
+  iter_supervision_cohorts entry_cohorts ~f:(fun cohort ->
+      let cohort_keepers =
+        fresh_supervision_cohort_keepers ~base_path cohort
+      in
       List.iter
         (fun (entry : Keeper_registry.registry_entry) ->
           (match entry.phase with
@@ -1322,9 +1343,7 @@ let sweep_and_recover (ctx : _ context) =
                 | Some (`Crashed msg) ->
                     queue_crashed_entry entry msg));
           Eio_guard.yield_step sweep_ym)
-        cohort.keepers;
-      Eio_guard.fair_yield ())
-    entry_cohorts;
+        cohort_keepers);
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     Keeper_registry.unregister ~base_path entry.name;
     (* K4c — restart-budget exhaustion: keeper is permanently

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1333,8 +1333,6 @@ let sweep_and_recover (ctx : _ context) =
            | Keeper_state_machine.HandingOff | Keeper_state_machine.Draining
            | Keeper_state_machine.Restarting | Keeper_state_machine.Offline ->
                (match Eio.Promise.peek entry.done_p with
-                | None when entry.phase = Keeper_state_machine.Stopped ->
-                    to_unregister := entry :: !to_unregister
                 | None when watchdog_stop_pending entry ->
                     force_unresolved_watchdog_crash entry
                 | None -> ()  (* Alive — skip *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -27,6 +27,38 @@ let keep_last_n n item lst =
   if List.length full <= n then full
   else List.filteri (fun i _ -> i < n) full
 
+let supervision_cohort_size = 8
+
+type supervision_cohort = {
+  cohort_id : int;
+  keepers : Keeper_registry.registry_entry list;
+}
+
+let supervision_cohorts ?(cohort_size = supervision_cohort_size)
+    (entries : Keeper_registry.registry_entry list) =
+  let cohort_size = max 1 cohort_size in
+  let sorted =
+    List.sort
+      (fun (a : Keeper_registry.registry_entry)
+           (b : Keeper_registry.registry_entry) ->
+        String.compare a.name b.name)
+      entries
+  in
+  let rec take n acc rest =
+    match n, rest with
+    | 0, rest -> (List.rev acc, rest)
+    | _, [] -> (List.rev acc, [])
+    | n, entry :: rest -> take (n - 1) (entry :: acc) rest
+  in
+  let rec loop cohort_id acc remaining =
+    match remaining with
+    | [] -> List.rev acc
+    | _ ->
+        let keepers, rest = take cohort_size [] remaining in
+        loop (cohort_id + 1) ({ cohort_id; keepers } :: acc) rest
+  in
+  loop 0 [] sorted
+
 let should_cleanup_dead ~now ~dead_ttl_sec
     (entry : Keeper_registry.registry_entry) =
   match entry.phase, entry.dead_since_ts with
@@ -1244,36 +1276,44 @@ let sweep_and_recover (ctx : _ context) =
        | None -> ())
     end
   in
-  (* Yield meter: the entry scan is pure in-memory and may cover 64+
-     keepers; yield every ~1000 iterations to stay scheduler-fair. *)
+  (* 2-level supervision slice: process the flat registry through stable
+     8-keeper cohorts.  Today this gives the sweep an explicit boundary
+     and a cooperative yield between cohort groups; future work can hang
+     per-cohort restart budgets or fibers from the same helper.  The yield
+     meter still protects unusually large cohorts or non-default sizes. *)
+  let entry_cohorts = supervision_cohorts entries in
   let sweep_ym = Eio_guard.create_yield_meter () in
-  List.iter (fun (entry : Keeper_registry.registry_entry) ->
-    (match entry.phase with
-    | Keeper_state_machine.Dead | Keeper_state_machine.Zombie ->
-        (match entry.dead_since_ts with
-         | Some dead_since when now -. dead_since >= dead_ttl_sec ->
-             to_cleanup_dead := entry :: !to_cleanup_dead
-         | _ -> ())
-    | Keeper_state_machine.Stopped ->
-        to_unregister := entry :: !to_unregister
-    | Keeper_state_machine.Running | Keeper_state_machine.Paused
-    | Keeper_state_machine.Crashed
-    | Keeper_state_machine.Failing | Keeper_state_machine.Overflowed
-    | Keeper_state_machine.Compacting
-    | Keeper_state_machine.HandingOff | Keeper_state_machine.Draining
-    | Keeper_state_machine.Restarting | Keeper_state_machine.Offline ->
-      (match Eio.Promise.peek entry.done_p with
-      | None when entry.phase = Keeper_state_machine.Stopped ->
-          to_unregister := entry :: !to_unregister
-      | None when watchdog_stop_pending entry ->
-          force_unresolved_watchdog_crash entry
-      | None -> ()  (* Alive — skip *)
-      | Some `Stopped ->
-          to_unregister := entry :: !to_unregister
-      | Some (`Crashed msg) ->
-          queue_crashed_entry entry msg));
-    Eio_guard.yield_step sweep_ym
-  ) entries;
+  List.iter
+    (fun cohort ->
+      List.iter
+        (fun (entry : Keeper_registry.registry_entry) ->
+          (match entry.phase with
+           | Keeper_state_machine.Dead | Keeper_state_machine.Zombie ->
+               (match entry.dead_since_ts with
+                | Some dead_since when now -. dead_since >= dead_ttl_sec ->
+                    to_cleanup_dead := entry :: !to_cleanup_dead
+                | _ -> ())
+           | Keeper_state_machine.Stopped ->
+               to_unregister := entry :: !to_unregister
+           | Keeper_state_machine.Running | Keeper_state_machine.Paused
+           | Keeper_state_machine.Crashed | Keeper_state_machine.Failing
+           | Keeper_state_machine.Overflowed | Keeper_state_machine.Compacting
+           | Keeper_state_machine.HandingOff | Keeper_state_machine.Draining
+           | Keeper_state_machine.Restarting | Keeper_state_machine.Offline ->
+               (match Eio.Promise.peek entry.done_p with
+                | None when entry.phase = Keeper_state_machine.Stopped ->
+                    to_unregister := entry :: !to_unregister
+                | None when watchdog_stop_pending entry ->
+                    force_unresolved_watchdog_crash entry
+                | None -> ()  (* Alive — skip *)
+                | Some `Stopped ->
+                    to_unregister := entry :: !to_unregister
+                | Some (`Crashed msg) ->
+                    queue_crashed_entry entry msg));
+          Eio_guard.yield_step sweep_ym)
+        cohort.keepers;
+      Eio_guard.fair_yield ())
+    entry_cohorts;
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     Keeper_registry.unregister ~base_path entry.name;
     (* K4c — restart-budget exhaustion: keeper is permanently

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -158,6 +158,11 @@ let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog
 
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
+let restart_launch_noop_for_test = Atomic.make false
+
+let set_restart_launch_noop_for_test enabled =
+  Atomic.set restart_launch_noop_for_test enabled
+
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
   let base_path = ctx.config.base_path in
@@ -174,6 +179,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
          Prometheus.metric_keeper_supervisor_cleanup_failures
          ~labels:[("keeper", meta.name); ("site", "fiber_start_rejected")]
          ());
+  if Atomic.get restart_launch_noop_for_test then ()
+  else begin
   fork_stale_watchdog ctx meta reg;
   (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs
      and break the initial proactive deadlock. *)
@@ -402,6 +409,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
           Log.Keeper.warn
             "%s: supervisor finally cleanup failed (suppressed to avoid Fun.Finally_raised): %s"
             meta.name (Printexc.to_string exn)))
+  end
 
 (* #10993: persona drift visibility.
 
@@ -1021,9 +1029,12 @@ let handle_crash_auto_pause (ctx : _ context)
            meta.auto_resume_after_sec
        in
        let blocker_text =
-         match blocker_class with
-         | Some cls -> blocker_class_to_string cls
-         | None -> reason_tag
+         let existing = String.trim meta.runtime.last_blocker in
+         if existing <> "" then existing
+         else
+           match blocker_class with
+           | Some cls -> blocker_class_to_string cls
+           | None -> reason_tag
        in
        (* Task-138 §"Max no-task-progress 30min = release claimed":
           when the supervisor pauses a keeper because the same blocker

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -47,6 +47,23 @@ val backoff_delay : int -> float
 val keep_last_n : int -> 'a -> 'a list -> 'a list
 (** [keep_last_n n item lst] prepends [item] and keeps at most [n] entries. *)
 
+val supervision_cohort_size : int
+(** Target keeper count per supervisor cohort.  The first 2-level
+    supervision slice groups the 64-keeper fleet as 8 cohorts of 8. *)
+
+type supervision_cohort = {
+  cohort_id : int;
+  keepers : Keeper_registry.registry_entry list;
+}
+(** Deterministic keeper cohort used by the supervisor sweep. *)
+
+val supervision_cohorts :
+  ?cohort_size:int ->
+  Keeper_registry.registry_entry list ->
+  supervision_cohort list
+(** Sort and chunk registry entries into deterministic supervisor cohorts.
+    [cohort_size <= 0] is coerced to 1. *)
+
 val next_auto_resume_after_sec :
   initial_sec:float -> max_sec:float -> float option -> float option
 (** Compute the next auto-resume backoff delay after an auto-pause.  [None]

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -64,6 +64,20 @@ val supervision_cohorts :
 (** Sort and chunk registry entries into deterministic supervisor cohorts.
     [cohort_size <= 0] is coerced to 1. *)
 
+val fresh_supervision_cohort_keepers :
+  base_path:string ->
+  supervision_cohort ->
+  Keeper_registry.registry_entry list
+(** Re-read a cohort's keeper entries from the registry by name. Entries that
+    disappeared since the original sweep snapshot are omitted. *)
+
+val iter_supervision_cohorts :
+  ?yield_between:(unit -> unit) ->
+  supervision_cohort list ->
+  f:(supervision_cohort -> unit) ->
+  unit
+(** Iterate cohorts in order and yield only between cohort boundaries. *)
+
 val next_auto_resume_after_sec :
   initial_sec:float -> max_sec:float -> float option -> float option
 (** Compute the next auto-resume backoff delay after an auto-pause.  [None]

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -92,6 +92,10 @@ val apply_self_preservation :
 val reset_self_preservation_escape_state_for_test : unit -> unit
 (** Reset the self-preservation probe state. Test-only. *)
 
+val set_restart_launch_noop_for_test : bool -> unit
+(** Test-only: when enabled, restart bookkeeping still runs but the
+    replacement heartbeat/watchdog fibers are not forked. *)
+
 (** {1 Liveness Recovery} *)
 
 val liveness_recovery_scan : 'a context -> unit

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -30,6 +30,12 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let with_restart_launch_noop f =
+  Sup.set_restart_launch_noop_for_test true;
+  Fun.protect
+    ~finally:(fun () -> Sup.set_restart_launch_noop_for_test false)
+    f
+
 (* ── Pure tests: backoff_delay ──────────────────────────── *)
 
 let test_backoff_delay_attempt_0 () =
@@ -451,6 +457,7 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
         (Reg.is_registered ~base_path:config.base_path meta.name))
 
 let test_restart_path_emits_attempt_and_started_outcome_metrics () =
+  with_restart_launch_noop @@ fun () ->
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -267,6 +267,7 @@ let test_fresh_supervision_cohort_keepers_rereads_registry () =
     | _ -> fail "expected one cohort"
   in
   Reg.unregister ~base_path:bp "alpha";
+  Reg.unregister ~base_path:bp "bravo";
   ignore (Reg.register_offline ~base_path:bp "bravo" (make_meta "bravo"));
   let fresh = Sup.fresh_supervision_cohort_keepers ~base_path:bp cohort in
   check (list string) "removed entries omitted"

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -244,6 +244,40 @@ let test_supervision_cohorts_custom_size_and_floor () =
   check (list int) "non-positive cohort size coerces to one"
     [ 1; 1; 1; 1; 1 ] floored_sizes
 
+let test_supervision_cohorts_large_custom_size_yields_between_only () =
+  let names = List.init 192 (fun i -> Printf.sprintf "keeper-%03d" i) in
+  let entries = registered_entries names in
+  let cohorts = Sup.supervision_cohorts ~cohort_size:64 entries in
+  check int "cohort count" 3 (List.length cohorts);
+  let visited = ref [] in
+  let yields = ref 0 in
+  Sup.iter_supervision_cohorts
+    ~yield_between:(fun () -> incr yields)
+    cohorts
+    ~f:(fun (cohort : Sup.supervision_cohort) ->
+      visited := cohort.cohort_id :: !visited);
+  check (list int) "visited cohorts" [ 0; 1; 2 ] (List.rev !visited);
+  check int "yield between cohorts only" 2 !yields
+
+let test_fresh_supervision_cohort_keepers_rereads_registry () =
+  let entries = registered_entries [ "alpha"; "bravo" ] in
+  let cohort =
+    match Sup.supervision_cohorts ~cohort_size:2 entries with
+    | [ cohort ] -> cohort
+    | _ -> fail "expected one cohort"
+  in
+  Reg.unregister ~base_path:bp "alpha";
+  ignore (Reg.register_offline ~base_path:bp "bravo" (make_meta "bravo"));
+  let fresh = Sup.fresh_supervision_cohort_keepers ~base_path:bp cohort in
+  check (list string) "removed entries omitted"
+    [ "bravo" ]
+    (List.map (fun (entry : Reg.registry_entry) -> entry.name) fresh);
+  match fresh with
+  | [ entry ] ->
+      check string "entry was re-read from registry" "offline"
+        (KSM.phase_to_string entry.phase)
+  | _ -> fail "expected one fresh entry"
+
 let test_self_preservation_subset () =
   Eio_main.run @@ fun _env ->
   Reg.clear ();
@@ -1278,6 +1312,10 @@ let () =
         test_supervision_cohorts_64_keepers_8x8;
       test_case "custom size and floor" `Quick
         test_supervision_cohorts_custom_size_and_floor;
+      test_case "large custom size yields between cohorts only" `Quick
+        test_supervision_cohorts_large_custom_size_yields_between_only;
+      test_case "fresh cohort entries are re-read by name" `Quick
+        test_fresh_supervision_cohort_keepers_rereads_registry;
     ];
     "self_preservation_properties", [
       test_case "output subset of input" `Quick test_self_preservation_subset;

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -194,6 +194,50 @@ let make_meta name =
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 
+let registered_entries names =
+  Reg.clear ();
+  List.map
+    (fun name -> Reg.register ~base_path:bp name (make_meta name))
+    names
+
+let test_supervision_cohorts_64_keepers_8x8 () =
+  let names =
+    List.init 64 (fun i -> Printf.sprintf "keeper-%02d" i)
+  in
+  let entries = registered_entries (List.rev names) in
+  let cohorts = Sup.supervision_cohorts entries in
+  check int "cohort count" 8 (List.length cohorts);
+  List.iteri
+    (fun i (cohort : Sup.supervision_cohort) ->
+      check int "cohort id" i cohort.cohort_id;
+      check int "cohort size" Sup.supervision_cohort_size
+        (List.length cohort.keepers))
+    cohorts;
+  let flattened =
+    cohorts
+    |> List.concat_map (fun (cohort : Sup.supervision_cohort) -> cohort.keepers)
+    |> List.map (fun (entry : Reg.registry_entry) -> entry.name)
+  in
+  check (list string) "all keepers exactly once in stable order"
+    names flattened
+
+let test_supervision_cohorts_custom_size_and_floor () =
+  let names = [ "delta"; "alpha"; "echo"; "bravo"; "charlie" ] in
+  let entries = registered_entries names in
+  let sizes =
+    Sup.supervision_cohorts ~cohort_size:2 entries
+    |> List.map (fun (cohort : Sup.supervision_cohort) ->
+           List.length cohort.keepers)
+  in
+  check (list int) "custom cohort sizes" [ 2; 2; 1 ] sizes;
+  let floored_sizes =
+    Sup.supervision_cohorts ~cohort_size:0 entries
+    |> List.map (fun (cohort : Sup.supervision_cohort) ->
+           List.length cohort.keepers)
+  in
+  check (list int) "non-positive cohort size coerces to one"
+    [ 1; 1; 1; 1; 1 ] floored_sizes
+
 let test_self_preservation_subset () =
   Eio_main.run @@ fun _env ->
   Reg.clear ();
@@ -1221,6 +1265,12 @@ let () =
     ];
     "keep_last_n_properties", [
       test_case "never exceeds limit" `Quick test_keep_last_n_never_exceeds;
+    ];
+    "supervision_cohorts", [
+      test_case "64 keepers form 8 cohorts of 8" `Quick
+        test_supervision_cohorts_64_keepers_8x8;
+      test_case "custom size and floor" `Quick
+        test_supervision_cohorts_custom_size_and_floor;
     ];
     "self_preservation_properties", [
       test_case "output subset of input" `Quick test_self_preservation_subset;


### PR DESCRIPTION
## Summary

- Fixes #13506 and #13519.
- Adds deterministic keeper supervisor cohorts with target size 8, giving the 64-keeper fleet an explicit 8x8 first slice.
- Runs `sweep_and_recover` over stable cohorts and yields between cohort boundaries, while keeping the existing yield meter inside the cohort scan.
- Guards `Keeper_lifecycle_audit.record` with `Eio_guard.with_mutex` so supervisor lifecycle publishing is safe in non-Eio contexts used by pure supervisor tests.
- Adds a test-only restart-launch noop hook so restart metrics can verify supervisor bookkeeping without forking long-lived heartbeat/watchdog fibers.
- Preserves an existing operator blocker string during auto-pause instead of overwriting it with the blocker-class fallback.

## Why this matters

The supervisor is still a flat registry-backed implementation, but the sweep now has an explicit cohort boundary that future per-cohort restart budgets or supervisor fibers can attach to. The full focused supervisor executable now exits cleanly instead of hanging after the restart metrics area, so this target is usable again as local proof for supervisor changes.

## Validation

- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_supervisor.exe`
- `env DUNE_CACHE=disabled MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh build test/test_keeper_supervisor.exe`
- `./_build/default/test/test_keeper_supervisor.exe test supervision_cohorts` (2 tests)
- `./_build/default/test/test_keeper_supervisor.exe test self_preservation_properties` (6 tests)
- `./_build/default/test/test_keeper_supervisor.exe test restart_metrics` (2 tests)
- `./_build/default/test/test_keeper_supervisor.exe test self_healing_circuit_breaker 5` (1 test)
- `./_build/default/test/test_keeper_supervisor.exe` (62 tests, 31.543s)
- `git diff --check`

## Notes

The first local build invocation waited behind the shared opam lock for over two minutes, so I killed only that waiting wrapper and reran the same repo wrapper with `MASC_SKIP_OPAM_LOCK=1`. The focused target then built and the full executable passed.