### PR TITLE
fix(keeper): observe tool OAS side effects

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -284,6 +284,60 @@ let tool_exec_result_markers ~(input : Yojson.Safe.t) ~(output : string)
   in
   List.rev markers
 
+let keeper_tool_call_event_json ~keeper_name ~tool_name ~duration_ms ~success
+    ?error_text ?(extra_fields = []) ~ts () =
+  let fields =
+    [
+      ("type", `String "keeper_tool_call");
+      ("name", `String keeper_name);
+      ("tool_name", `String tool_name);
+      ("duration_ms", `Int duration_ms);
+      ("success", `Bool success);
+      ("ts_unix", `Float ts);
+    ]
+  in
+  let fields =
+    match error_text with
+    | Some error_text -> fields @ [ ("error_text", `String error_text) ]
+    | None -> fields
+  in
+  `Assoc (fields @ extra_fields)
+;;
+
+let broadcast_keeper_tool_call_event ~keeper_name ~tool_name ~duration_ms
+    ~success ?error_text ?(extra_fields = []) ~site ~ts () =
+  try
+    Sse.broadcast
+      (keeper_tool_call_event_json ~keeper_name ~tool_name ~duration_ms
+         ~success ?error_text ~extra_fields ~ts ())
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_sse_broadcast_failures
+        ~labels:[("keeper", keeper_name)]
+        ();
+      Log.Keeper.warn
+        "keeper tool-call SSE broadcast failed: keeper=%s tool=%s site=%s err=%s"
+        keeper_name tool_name site (Printexc.to_string exn)
+;;
+
+let append_tool_exec_decision_log ~config ~keeper_name ~site entry =
+  try
+    Keeper_types_support.append_jsonl_line
+      (Keeper_types_support.keeper_decision_log_path config keeper_name)
+      entry
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_decision_audit_flush_failures
+        ~labels:[("keeper", keeper_name)]
+        ();
+      Log.Keeper.warn
+        "keeper tool execution decision-log append failed: keeper=%s site=%s err=%s"
+        keeper_name site (Printexc.to_string exn)
+
 (** RFC-0006 Phase A.2: build the per-tool handler closure.
 
     Extracted from the original anonymous closure inside [make_tools] so
@@ -372,17 +426,9 @@ let make_keeper_tool_handler
             String_util.utf8_safe ~max_bytes:(sse_error_preview_max_chars + 3) ~suffix:"..." s |> String_util.to_string
           in
           let ts = Time_compat.now () in
-          (try Sse.broadcast
-            (`Assoc [
-              ("type", `String "keeper_tool_call");
-              ("name", `String meta.name);
-              ("tool_name", `String name);
-              ("duration_ms", `Int duration_ms);
-              ("success", `Bool false);
-              ("error_text", `String detail);
-              ("ts_unix", `Float ts);
-            ])
-           with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          broadcast_keeper_tool_call_event
+            ~keeper_name:meta.name ~tool_name:name ~duration_ms
+            ~success:false ~error_text:detail ~site:"error_result" ~ts ();
           Prometheus.inc_counter
             Prometheus.metric_keeper_tools_oas_failures
             ~labels:[("tool", name); ("site", "error_result")]
@@ -393,20 +439,18 @@ let make_keeper_tool_handler
           let normalized_error =
             normalize_tool_result ~success:false raw_result
           in
-          (try
-            Keeper_types_support.append_jsonl_line
-              (Keeper_types_support.keeper_decision_log_path config meta.name)
-              (`Assoc [
-                "ts_unix", `Float ts;
-                "event", `String "tool_exec";
-                "keeper_name", `String meta.name;
-                "tool", `String name;
-                "duration_ms", `Int duration_ms;
-                "result_bytes", `Int (String.length normalized_error);
-                "ok", `Bool false;
-                "error_preview", `String detail;
-              ])
-          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          append_tool_exec_decision_log ~config ~keeper_name:meta.name
+            ~site:"error_result"
+            (`Assoc [
+              "ts_unix", `Float ts;
+              "event", `String "tool_exec";
+              "keeper_name", `String meta.name;
+              "tool", `String name;
+              "duration_ms", `Int duration_ms;
+              "result_bytes", `Int (String.length normalized_error);
+              "ok", `Bool false;
+              "error_preview", `String detail;
+            ]);
           Keeper_tool_call_log.set_truncation_info
             ~keeper_name:meta.name
             ~original_bytes:(String.length normalized_error) ();
@@ -421,16 +465,9 @@ let make_keeper_tool_handler
               legacy_message = raw_result } in
            ignore (Tool_dispatch.run_post_hooks tr));
           let ts = Time_compat.now () in
-          (try Sse.broadcast
-            (`Assoc [
-              ("type", `String "keeper_tool_call");
-              ("name", `String meta.name);
-              ("tool_name", `String name);
-              ("duration_ms", `Int duration_ms);
-              ("success", `Bool true);
-              ("ts_unix", `Float ts);
-            ])
-           with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          broadcast_keeper_tool_call_event
+            ~keeper_name:meta.name ~tool_name:name ~duration_ms
+            ~success:true ~site:"success" ~ts ();
           (* Notify session callback (e.g., mark_used for discovered tools) *)
           (match on_tool_called with Some f -> f name | None -> ());
           (* PR#814 Gap 1: Capture git status delta after successful tool execution.
@@ -481,21 +518,19 @@ let make_keeper_tool_handler
           if was_truncated then
             Log.Keeper.info "tool %s output truncated: %d -> %d chars"
               name original_len (String.length truncated_result);
-          (try
-            Keeper_types_support.append_jsonl_line
-              (Keeper_types_support.keeper_decision_log_path config meta.name)
-              (`Assoc ([
-                "ts_unix", `Float ts;
-                "event", `String "tool_exec";
-                "keeper_name", `String meta.name;
-                "tool", `String name;
-                "duration_ms", `Int duration_ms;
-                "result_bytes", `Int original_len;
-                "ok", `Bool true;
-              ] @ result_marker_fields @ (if was_truncated then
-                ["truncated_to", `Int (String.length truncated_result)]
-              else [])))
-          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          append_tool_exec_decision_log ~config ~keeper_name:meta.name
+            ~site:"success"
+            (`Assoc ([
+              "ts_unix", `Float ts;
+              "event", `String "tool_exec";
+              "keeper_name", `String meta.name;
+              "tool", `String name;
+              "duration_ms", `Int duration_ms;
+              "result_bytes", `Int original_len;
+              "ok", `Bool true;
+            ] @ result_marker_fields @ (if was_truncated then
+              ["truncated_to", `Int (String.length truncated_result)]
+            else [])));
           (* Publish truncation info for OAS hook's tool_call_log *)
           Keeper_tool_call_log.set_truncation_info
             ~keeper_name:meta.name
@@ -542,25 +577,18 @@ let make_keeper_tool_handler
         Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
         !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
         (* Tool-call observability via OAS Event_bus. See above. *)
-        (try Sse.broadcast
-          (`Assoc ([
-            ("type", `String "keeper_tool_call");
-            ("name", `String meta.name);
-            ("tool_name", `String name);
-            ("duration_ms", `Int duration_ms);
-            ("success", `Bool false);
-            ("error_text", `String error_text);
-            ("ts_unix", `Float ts);
-          ]
-          @
-          if is_edeadlk then
-            [
-              ( "error_class",
-                `String transient_mutex_contention_error_class );
-              ("recoverable", `Bool true);
-            ]
-          else []))
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        broadcast_keeper_tool_call_event
+          ~keeper_name:meta.name ~tool_name:name ~duration_ms
+          ~success:false ~error_text
+          ~extra_fields:
+            (if is_edeadlk then
+               [
+                 ( "error_class",
+                   `String transient_mutex_contention_error_class );
+                 ("recoverable", `Bool true);
+               ]
+             else [])
+          ~site:"exception" ~ts ();
         let msg =
           if is_edeadlk then
             Printf.sprintf
@@ -589,28 +617,26 @@ let make_keeper_tool_handler
           else
             normalize_tool_result ~success:false msg
         in
-        (try
-          Keeper_types_support.append_jsonl_line
-            (Keeper_types_support.keeper_decision_log_path config meta.name)
-            (`Assoc ([
-              "ts_unix", `Float ts;
-              "event", `String "tool_exec";
-              "keeper_name", `String meta.name;
-              "tool", `String name;
-              "duration_ms", `Int duration_ms;
-              "result_bytes", `Int (String.length normalized_exn);
-              "ok", `Bool false;
-              "error", `String error_text;
+        append_tool_exec_decision_log ~config ~keeper_name:meta.name
+          ~site:"exception"
+          (`Assoc ([
+            "ts_unix", `Float ts;
+            "event", `String "tool_exec";
+            "keeper_name", `String meta.name;
+            "tool", `String name;
+            "duration_ms", `Int duration_ms;
+            "result_bytes", `Int (String.length normalized_exn);
+            "ok", `Bool false;
+            "error", `String error_text;
+          ]
+          @
+          if is_edeadlk then
+            [
+              ( "error_class",
+                `String transient_mutex_contention_error_class );
+              ("recoverable", `Bool true);
             ]
-            @
-            if is_edeadlk then
-              [
-                ( "error_class",
-                  `String transient_mutex_contention_error_class );
-                ("recoverable", `Bool true);
-              ]
-            else []))
-        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          else []));
         Keeper_tool_call_log.set_truncation_info
           ~keeper_name:meta.name
           ~original_bytes:(String.length normalized_exn) ();

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -115,6 +115,59 @@ let string_contains ~sub text =
   in
   sub_len = 0 || loop 0
 
+let test_tool_side_effect_failures_are_observed () =
+  let meta = make_test_meta ~name:"test-keeper-side-effects" () in
+  let ctx_snapshot = make_test_ctx () in
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_side_effects_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+      let tool = find_tool "keeper_fs_read" tools in
+      let keeper_labels = [("keeper", meta.name)] in
+      let sse_before =
+        Prometheus.metric_value_or_zero
+          Prometheus.metric_keeper_sse_broadcast_failures
+          ~labels:keeper_labels ()
+      in
+      let decision_before =
+        Prometheus.metric_value_or_zero
+          Prometheus.metric_keeper_decision_audit_flush_failures
+          ~labels:keeper_labels ()
+      in
+      let original_hook = Atomic.get Sse.buffer_commit_test_hook in
+      Fun.protect
+        ~finally:(fun () ->
+          Atomic.set Sse.buffer_commit_test_hook original_hook)
+        (fun () ->
+          Atomic.set Sse.buffer_commit_test_hook
+            (Some (fun () -> failwith "forced keeper tool SSE failure"));
+          match Tool.execute tool
+                  (`Assoc [("path", `String "missing-side-effect-file.txt")])
+          with
+          | Error _ -> ()
+          | Ok _ -> fail "missing file should be surfaced as tool error");
+      check (float 0.001) "SSE failure metric incremented"
+        (sse_before +. 1.0)
+        (Prometheus.metric_value_or_zero
+           Prometheus.metric_keeper_sse_broadcast_failures
+           ~labels:keeper_labels ());
+      check (float 0.001) "decision-log failure metric incremented"
+        (decision_before +. 1.0)
+        (Prometheus.metric_value_or_zero
+           Prometheus.metric_keeper_decision_audit_flush_failures
+           ~labels:keeper_labels ()))
+
 let is_guardrail_message message =
   string_contains
     ~sub:"failed 3 times in a row with the same arguments"
@@ -701,6 +754,8 @@ let () =
       test_case "repeated errors are blocked" `Quick test_repeated_error_results_are_blocked;
       test_case "failure count resets after success" `Quick test_failure_count_resets_after_success;
       test_case "failure tracking is independent per args" `Quick test_failure_tracking_is_independent_per_args;
+      test_case "tool side-effect failures are observed" `Quick
+        test_tool_side_effect_failures_are_observed;
     ];
     "normalize_tool_result", [
       test_case "success JSON wraps under result" `Quick test_normalize_success_json;


### PR DESCRIPTION
## Summary
- replace silent keeper tool-call SSE broadcast drops with a helper that logs and increments keeper SSE failure metrics
- replace silent tool execution decision-log append drops with a helper that logs and increments decision audit failure metrics
- add a source contract in `test_keeper_tools_oas` so the cancel-safe `| _ -> ()` pattern does not return in this file

## Why
Keeper tool calls were already returning the right tool result, but producer-side observability failures could disappear: if the SSE broadcast or decision-log append raised, the keeper continued without any operator-visible signal. That weakens the Phase 0/1 goal of removing swallowed side effects around keeper runtime truth.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/dune-local.sh build test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_tools_oas.exe`