### PR TITLE
feat(otel): centralize GenAI semantic keys

### DIFF
--- a/lib/otel/otel_dispatch_hook.ml
+++ b/lib/otel/otel_dispatch_hook.ml
@@ -18,6 +18,32 @@
 
 module OT = Opentelemetry
 
+let enabled_override : bool option ref = ref None
+let span_emitter_override :
+  ((name:string -> attrs:OT.key_value list -> unit) option) ref =
+  ref None
+
+let enabled () =
+  match !enabled_override with
+  | Some value -> value
+  | None -> Otel_config.enabled
+
+let emit_span ~name ~attrs =
+  match !span_emitter_override with
+  | Some emit -> emit ~name ~attrs
+  | None -> ignore (OT.Trace.with_ name ~attrs (fun _scope -> ()))
+
+let with_test_span_emitter ~enabled:enabled_value ~emit_span:emit f =
+  let prev_enabled = !enabled_override in
+  let prev_emitter = !span_emitter_override in
+  enabled_override := Some enabled_value;
+  span_emitter_override := Some emit;
+  Fun.protect
+    ~finally:(fun () ->
+      enabled_override := prev_enabled;
+      span_emitter_override := prev_emitter)
+    f
+
 (** PR-0.2.C: process startup timestamp captured at module load. Used to
     classify tool calls into [phase=cold] (within first
     [cold_phase_seconds] after startup) or [phase=warm] (after).
@@ -30,6 +56,30 @@ let cold_warm_phase () =
   if Unix.gettimeofday () -. startup_time < cold_phase_seconds then "cold"
   else "warm"
 
+let tool_span_attrs (result : Tool_result.t) =
+  let status_attrs =
+    if result.success then
+      [("otel.status_code", `String "OK")]
+    else
+      [("otel.status_code", `String "ERROR")]
+  in
+  let legacy_attrs =
+    [ (Otel_genai.Attr_key.tool_name, `String result.tool_name);
+      (Otel_genai.Attr_key.tool_success, `Bool result.success);
+      (Otel_genai.Attr_key.tool_duration_ms, `Int (int_of_float result.duration_ms)) ]
+  in
+  (* OpenTelemetry GenAI semantic conventions
+     (https://opentelemetry.io/docs/specs/semconv/gen-ai/). Tool execution
+     within an agent run is the [execute_tool] operation per the spec.
+     provider/model keys are intentionally omitted — those belong on the
+     parent agent / model span, not on the inner tool span which is
+     provider-agnostic. *)
+  let gen_ai_attrs =
+    Otel_genai.tool_execution_attrs ~tool_name:result.tool_name
+    |> List.map (fun (key, value) -> key, (value :> OT.value))
+  in
+  legacy_attrs @ gen_ai_attrs @ status_attrs
+
 (** Record a tool call as an OTel span and Prometheus histogram observation. *)
 let on_tool_result (result : Tool_result.t) : Tool_result.t =
   (* Prometheus histogram: always active regardless of MASC_OTEL_ENABLED *)
@@ -38,32 +88,10 @@ let on_tool_result (result : Tool_result.t) : Tool_result.t =
              ("phase", cold_warm_phase ())]
     (result.duration_ms /. 1000.0);
   (* OTel span: only when enabled *)
-  if Otel_config.enabled then begin
-    let status_attrs =
-      if result.success then
-        [("otel.status_code", `String "OK")]
-      else
-        [("otel.status_code", `String "ERROR")]
-    in
-    let legacy_attrs =
-      [ (Otel_genai.Attr_key.tool_name, `String result.tool_name);
-        (Otel_genai.Attr_key.tool_success, `Bool result.success);
-        (Otel_genai.Attr_key.tool_duration_ms, `Int (int_of_float result.duration_ms)) ]
-    in
-    (* OpenTelemetry GenAI semantic conventions
-       (https://opentelemetry.io/docs/specs/semconv/gen-ai/). Tool execution
-       within an agent run is the [execute_tool] operation per the spec.
-       provider/model keys are intentionally omitted — those belong on the
-       parent agent / model span, not on the inner tool span which is
-       provider-agnostic. *)
-    let gen_ai_attrs =
-      Otel_genai.tool_execution_attrs ~tool_name:result.tool_name
-      |> List.map (fun (key, value) -> key, (value :> OT.value))
-    in
-    let attrs = legacy_attrs @ gen_ai_attrs @ status_attrs in
-    ignore (OT.Trace.with_ ("tool/" ^ result.tool_name) ~attrs
-      (fun _scope -> ()))
-  end;
+  if enabled () then
+    emit_span
+      ~name:("tool/" ^ result.tool_name)
+      ~attrs:(tool_span_attrs result);
   result
 
 let install () =

--- a/lib/otel/otel_dispatch_hook.ml
+++ b/lib/otel/otel_dispatch_hook.ml
@@ -46,19 +46,19 @@ let on_tool_result (result : Tool_result.t) : Tool_result.t =
         [("otel.status_code", `String "ERROR")]
     in
     let legacy_attrs =
-      [ ("tool.name", `String result.tool_name);
-        ("tool.success", `Bool result.success);
-        ("tool.duration_ms", `Int (int_of_float result.duration_ms)) ]
+      [ (Otel_genai.Attr_key.tool_name, `String result.tool_name);
+        (Otel_genai.Attr_key.tool_success, `Bool result.success);
+        (Otel_genai.Attr_key.tool_duration_ms, `Int (int_of_float result.duration_ms)) ]
     in
     (* OpenTelemetry GenAI semantic conventions
        (https://opentelemetry.io/docs/specs/semconv/gen-ai/). Tool execution
        within an agent run is the [execute_tool] operation per the spec.
-       [gen_ai.system] / [gen_ai.request.model] are intentionally omitted —
-       those belong on the parent agent / chat span (Step 2 of #7461),
-       not on the inner tool span which is provider-agnostic. *)
+       provider/model keys are intentionally omitted — those belong on the
+       parent agent / model span, not on the inner tool span which is
+       provider-agnostic. *)
     let gen_ai_attrs =
-      [ ("gen_ai.operation.name", `String "execute_tool");
-        ("gen_ai.tool.name", `String result.tool_name) ]
+      Otel_genai.tool_execution_attrs ~tool_name:result.tool_name
+      |> List.map (fun (key, value) -> key, (value :> OT.value))
     in
     let attrs = legacy_attrs @ gen_ai_attrs @ status_attrs in
     ignore (OT.Trace.with_ ("tool/" ^ result.tool_name) ~attrs

--- a/lib/otel/otel_dispatch_hook.mli
+++ b/lib/otel/otel_dispatch_hook.mli
@@ -16,6 +16,18 @@
 
     @since 2.103.0 *)
 
+val tool_span_attrs : Tool_result.t -> Opentelemetry.key_value list
+(** Build the full tool-span payload used by the post-hook. Exposed so tests can
+    pin the legacy + GenAI dual-emission contract without installing a collector. *)
+
+val with_test_span_emitter :
+  enabled:bool ->
+  emit_span:(name:string -> attrs:Opentelemetry.key_value list -> unit) ->
+  (unit -> 'a) ->
+  'a
+(** Temporarily override OTel enablement and span emission for focused
+    post-hook tests. Restores the previous emitter after [f] returns/raises. *)
+
 val install : unit -> unit
 (** Register {!on_tool_result} as a [Tool_dispatch] post-hook.
     Idempotent at the call site (calling twice would register the

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -1,10 +1,68 @@
 (** GenAI semantic-convention helpers for MASC OTel spans.
 
-    GenAI semantic conventions are still Development as of 2026-04, so these
+    GenAI semantic conventions are still Development as of 2026-05-06, so these
     helpers dual-emit MASC legacy [keeper.*] attributes with [gen_ai.*]
     attributes. *)
 
 type attr = string * [ `Bool of bool | `Int of int | `String of string ]
+
+module Attr_key = struct
+  let gen_ai_operation_name = "gen_ai.operation.name"
+  let gen_ai_provider_name = "gen_ai.provider.name"
+  let gen_ai_agent_name = "gen_ai.agent.name"
+  let gen_ai_agent_id = "gen_ai.agent.id"
+  let gen_ai_conversation_id = "gen_ai.conversation.id"
+  let gen_ai_tool_name = "gen_ai.tool.name"
+  let masc_gen_ai_keeper_name = "masc.gen_ai.keeper.name"
+  let masc_gen_ai_cascade_name = "masc.gen_ai.cascade.name"
+  let keeper_name = "keeper.name"
+  let keeper_agent_name = "keeper.agent_name"
+  let keeper_cascade_name = "keeper.cascade.name"
+  let keeper_trace_id = "keeper.trace_id"
+  let keeper_generation = "keeper.generation"
+  let keeper_max_context = "keeper.max_context"
+  let keeper_max_turns = "keeper.max_turns"
+  let keeper_max_idle_turns = "keeper.max_idle_turns"
+  let keeper_channel = "keeper.channel"
+  let keeper_is_retry = "keeper.is_retry"
+  let keeper_current_task_id = "keeper.current_task_id"
+  let tool_name = "tool.name"
+  let tool_success = "tool.success"
+  let tool_duration_ms = "tool.duration_ms"
+
+  let official_gen_ai =
+    [ gen_ai_operation_name
+    ; gen_ai_provider_name
+    ; gen_ai_agent_name
+    ; gen_ai_agent_id
+    ; gen_ai_conversation_id
+    ; gen_ai_tool_name
+    ]
+  ;;
+
+  let masc_extensions = [ masc_gen_ai_keeper_name; masc_gen_ai_cascade_name ]
+
+  let legacy =
+    [ keeper_name
+    ; keeper_agent_name
+    ; keeper_cascade_name
+    ; keeper_trace_id
+    ; keeper_generation
+    ; keeper_max_context
+    ; keeper_max_turns
+    ; keeper_max_idle_turns
+    ; keeper_channel
+    ; keeper_is_retry
+    ; keeper_current_task_id
+    ; tool_name
+    ; tool_success
+    ; tool_duration_ms
+    ]
+  ;;
+
+  let is_official_gen_ai key = List.mem key official_gen_ai
+  let is_masc_extension key = List.mem key masc_extensions
+end
 
 let keeper_turn_span_name ~keeper_name = "invoke_agent " ^ keeper_name
 
@@ -25,25 +83,33 @@ let keeper_turn_attrs
   let optional_attrs =
     match current_task_id with
     | None -> []
-    | Some task_id -> [ "keeper.current_task_id", `String task_id ]
+    | Some task_id -> [ Attr_key.keeper_current_task_id, `String task_id ]
   in
-  [ "keeper.name", `String keeper_name
-  ; "keeper.agent_name", `String agent_name
-  ; "keeper.cascade.name", `String cascade_name
-  ; "keeper.trace_id", `String trace_id
-  ; "keeper.generation", `Int generation
-  ; "keeper.max_context", `Int max_context
-  ; "keeper.max_turns", `Int max_turns
-  ; "keeper.max_idle_turns", `Int max_idle_turns
-  ; "keeper.channel", `String channel
-  ; "keeper.is_retry", `Bool is_retry
-  ; "gen_ai.operation.name", `String "invoke_agent"
-  ; "gen_ai.provider.name", `String "masc"
-  ; "gen_ai.agent.name", `String keeper_name
-  ; "gen_ai.agent.id", `String agent_name
-  ; "gen_ai.conversation.id", `String trace_id
+  [ Attr_key.keeper_name, `String keeper_name
+  ; Attr_key.keeper_agent_name, `String agent_name
+  ; Attr_key.keeper_cascade_name, `String cascade_name
+  ; Attr_key.keeper_trace_id, `String trace_id
+  ; Attr_key.keeper_generation, `Int generation
+  ; Attr_key.keeper_max_context, `Int max_context
+  ; Attr_key.keeper_max_turns, `Int max_turns
+  ; Attr_key.keeper_max_idle_turns, `Int max_idle_turns
+  ; Attr_key.keeper_channel, `String channel
+  ; Attr_key.keeper_is_retry, `Bool is_retry
+  ; Attr_key.gen_ai_operation_name, `String "invoke_agent"
+  ; Attr_key.gen_ai_provider_name, `String "masc"
+  ; Attr_key.gen_ai_agent_name, `String keeper_name
+  ; Attr_key.gen_ai_agent_id, `String agent_name
+  ; Attr_key.gen_ai_conversation_id, `String trace_id
+  ; Attr_key.masc_gen_ai_keeper_name, `String keeper_name
+  ; Attr_key.masc_gen_ai_cascade_name, `String cascade_name
   ]
   @ optional_attrs
+;;
+
+let tool_execution_attrs ~tool_name =
+  [ Attr_key.gen_ai_operation_name, `String "execute_tool"
+  ; Attr_key.gen_ai_tool_name, `String tool_name
+  ]
 ;;
 
 let with_keeper_turn_span

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -2,6 +2,36 @@
 
 type attr = string * [ `Bool of bool | `Int of int | `String of string ]
 
+module Attr_key : sig
+  val gen_ai_operation_name : string
+  val gen_ai_provider_name : string
+  val gen_ai_agent_name : string
+  val gen_ai_agent_id : string
+  val gen_ai_conversation_id : string
+  val gen_ai_tool_name : string
+  val masc_gen_ai_keeper_name : string
+  val masc_gen_ai_cascade_name : string
+  val keeper_name : string
+  val keeper_agent_name : string
+  val keeper_cascade_name : string
+  val keeper_trace_id : string
+  val keeper_generation : string
+  val keeper_max_context : string
+  val keeper_max_turns : string
+  val keeper_max_idle_turns : string
+  val keeper_channel : string
+  val keeper_is_retry : string
+  val keeper_current_task_id : string
+  val tool_name : string
+  val tool_success : string
+  val tool_duration_ms : string
+  val official_gen_ai : string list
+  val masc_extensions : string list
+  val legacy : string list
+  val is_official_gen_ai : string -> bool
+  val is_masc_extension : string -> bool
+end
+
 val keeper_turn_span_name : keeper_name:string -> string
 
 val keeper_turn_attrs
@@ -17,6 +47,8 @@ val keeper_turn_attrs
   -> is_retry:bool
   -> current_task_id:string option
   -> attr list
+
+val tool_execution_attrs : tool_name:string -> attr list
 
 val with_keeper_turn_span
   :  keeper_name:string

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -3,6 +3,13 @@ open Alcotest
 
 let assoc key attrs = List.assoc_opt key attrs
 let cascade_name raw = Lib.Keeper_cascade_profile.Runtime_name raw
+let attr_string = function
+  | Some (`String s) -> Some s
+  | _ -> None
+
+let attr_bool = function
+  | Some (`Bool b) -> Some b
+  | _ -> None
 
 let test_keeper_turn_span_name () =
   check
@@ -31,56 +38,42 @@ let test_keeper_turn_attrs_dual_emit () =
     (option (of_pp Fmt.Dump.string))
     "gen_ai operation"
     (Some "invoke_agent")
-    (Option.map
-       (function
-         | `String s -> s
-         | _ -> "?")
-       (assoc "gen_ai.operation.name" attrs));
+    (attr_string (assoc Lib.Otel_genai.Attr_key.gen_ai_operation_name attrs));
   check
     (option (of_pp Fmt.Dump.string))
     "gen_ai provider"
     (Some "masc")
-    (Option.map
-       (function
-         | `String s -> s
-         | _ -> "?")
-       (assoc "gen_ai.provider.name" attrs));
+    (attr_string (assoc Lib.Otel_genai.Attr_key.gen_ai_provider_name attrs));
   check
     (option (of_pp Fmt.Dump.string))
     "agent name"
     (Some "ani1999")
-    (Option.map
-       (function
-         | `String s -> s
-         | _ -> "?")
-       (assoc "gen_ai.agent.name" attrs));
+    (attr_string (assoc Lib.Otel_genai.Attr_key.gen_ai_agent_name attrs));
   check
     (option (of_pp Fmt.Dump.string))
     "conversation id"
     (Some "trace-123")
-    (Option.map
-       (function
-         | `String s -> s
-         | _ -> "?")
-       (assoc "gen_ai.conversation.id" attrs));
+    (attr_string (assoc Lib.Otel_genai.Attr_key.gen_ai_conversation_id attrs));
+  check
+    (option (of_pp Fmt.Dump.string))
+    "masc keeper extension"
+    (Some "ani1999")
+    (attr_string (assoc Lib.Otel_genai.Attr_key.masc_gen_ai_keeper_name attrs));
+  check
+    (option (of_pp Fmt.Dump.string))
+    "masc cascade extension"
+    (Some "research")
+    (attr_string (assoc Lib.Otel_genai.Attr_key.masc_gen_ai_cascade_name attrs));
   check
     (option (of_pp Fmt.Dump.string))
     "legacy cascade"
     (Some "research")
-    (Option.map
-       (function
-         | `String s -> s
-         | _ -> "?")
-       (assoc "keeper.cascade.name" attrs));
+    (attr_string (assoc Lib.Otel_genai.Attr_key.keeper_cascade_name attrs));
   check
     (option (of_pp Fmt.Dump.string))
     "task id"
     (Some "task-161")
-    (Option.map
-       (function
-         | `String s -> s
-         | _ -> "?")
-       (assoc "keeper.current_task_id" attrs))
+    (attr_string (assoc Lib.Otel_genai.Attr_key.keeper_current_task_id attrs))
 ;;
 
 let test_keeper_turn_attrs_omit_missing_task () =
@@ -98,16 +91,63 @@ let test_keeper_turn_attrs_omit_missing_task () =
       ~is_retry:true
       ~current_task_id:None
   in
-  check bool "omits missing task id" false (List.mem_assoc "keeper.current_task_id" attrs);
+  check
+    bool
+    "omits missing task id"
+    false
+    (List.mem_assoc Lib.Otel_genai.Attr_key.keeper_current_task_id attrs);
   check
     (option bool)
     "retry attr"
     (Some true)
-    (Option.map
-       (function
-         | `Bool b -> b
-         | _ -> false)
-       (assoc "keeper.is_retry" attrs))
+    (attr_bool (assoc Lib.Otel_genai.Attr_key.keeper_is_retry attrs))
+;;
+
+let test_attr_key_registry_boundaries () =
+  check
+    bool
+    "operation key is official"
+    true
+    (Lib.Otel_genai.Attr_key.is_official_gen_ai
+       Lib.Otel_genai.Attr_key.gen_ai_operation_name);
+  check
+    bool
+    "tool key is official"
+    true
+    (Lib.Otel_genai.Attr_key.is_official_gen_ai
+       Lib.Otel_genai.Attr_key.gen_ai_tool_name);
+  check
+    bool
+    "masc keeper key is extension"
+    true
+    (Lib.Otel_genai.Attr_key.is_masc_extension
+       Lib.Otel_genai.Attr_key.masc_gen_ai_keeper_name);
+  check
+    bool
+    "extension is not official"
+    false
+    (Lib.Otel_genai.Attr_key.is_official_gen_ai
+       Lib.Otel_genai.Attr_key.masc_gen_ai_keeper_name);
+  check
+    bool
+    "legacy key is not extension"
+    false
+    (Lib.Otel_genai.Attr_key.is_masc_extension
+       Lib.Otel_genai.Attr_key.keeper_name)
+;;
+
+let test_tool_execution_attrs () =
+  let attrs = Lib.Otel_genai.tool_execution_attrs ~tool_name:"keeper_shell" in
+  check
+    (option (of_pp Fmt.Dump.string))
+    "tool operation"
+    (Some "execute_tool")
+    (attr_string (assoc Lib.Otel_genai.Attr_key.gen_ai_operation_name attrs));
+  check
+    (option (of_pp Fmt.Dump.string))
+    "tool name"
+    (Some "keeper_shell")
+    (attr_string (assoc Lib.Otel_genai.Attr_key.gen_ai_tool_name attrs))
 ;;
 
 let () =
@@ -117,6 +157,9 @@ let () =
       , [ test_case "span name" `Quick test_keeper_turn_span_name
         ; test_case "dual emit attrs" `Quick test_keeper_turn_attrs_dual_emit
         ; test_case "omit missing task id" `Quick test_keeper_turn_attrs_omit_missing_task
+        ; test_case "attr key registry boundaries" `Quick
+            test_attr_key_registry_boundaries
+        ; test_case "tool execution attrs" `Quick test_tool_execution_attrs
         ] )
     ]
 ;;

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -11,6 +11,10 @@ let attr_bool = function
   | Some (`Bool b) -> Some b
   | _ -> None
 
+let attr_int = function
+  | Some (`Int i) -> Some i
+  | _ -> None
+
 let test_keeper_turn_span_name () =
   check
     string
@@ -136,6 +140,25 @@ let test_attr_key_registry_boundaries () =
        Lib.Otel_genai.Attr_key.keeper_name)
 ;;
 
+let test_attr_key_registry_full_coverage () =
+  let module K = Lib.Otel_genai.Attr_key in
+  let check_official key =
+    check bool (key ^ " official") true (K.is_official_gen_ai key);
+    check bool (key ^ " not masc extension") false (K.is_masc_extension key)
+  in
+  let check_extension key =
+    check bool (key ^ " extension") true (K.is_masc_extension key);
+    check bool (key ^ " not official") false (K.is_official_gen_ai key)
+  in
+  let check_legacy key =
+    check bool (key ^ " not official") false (K.is_official_gen_ai key);
+    check bool (key ^ " not extension") false (K.is_masc_extension key)
+  in
+  List.iter check_official K.official_gen_ai;
+  List.iter check_extension K.masc_extensions;
+  List.iter check_legacy K.legacy
+;;
+
 let test_tool_execution_attrs () =
   let attrs = Lib.Otel_genai.tool_execution_attrs ~tool_name:"keeper_shell" in
   check
@@ -150,6 +173,64 @@ let test_tool_execution_attrs () =
     (attr_string (assoc Lib.Otel_genai.Attr_key.gen_ai_tool_name attrs))
 ;;
 
+let test_dispatch_hook_emits_tool_span_payload () =
+  Lib.Tool_dispatch.clear_hooks ();
+  Fun.protect
+    ~finally:Lib.Tool_dispatch.clear_hooks
+    (fun () ->
+      let spans = ref [] in
+      Lib.Otel_dispatch_hook.with_test_span_emitter
+        ~enabled:true
+        ~emit_span:(fun ~name ~attrs -> spans := (name, attrs) :: !spans)
+        (fun () ->
+          Lib.Otel_dispatch_hook.install ();
+          let result : Lib.Tool_result.t =
+            { success = true
+            ; data = `String "ok"
+            ; tool_name = "keeper_shell"
+            ; duration_ms = 123.4
+            }
+          in
+          let returned = Lib.Tool_dispatch.run_post_hooks result in
+          check bool "post-hook preserves success" true returned.success);
+      match !spans with
+      | [ (name, attrs) ] ->
+          check string "span name" "tool/keeper_shell" name;
+          check
+            (option (of_pp Fmt.Dump.string))
+            "tool operation"
+            (Some "execute_tool")
+            (attr_string
+               (assoc Lib.Otel_genai.Attr_key.gen_ai_operation_name attrs));
+          check
+            (option (of_pp Fmt.Dump.string))
+            "gen_ai tool name"
+            (Some "keeper_shell")
+            (attr_string
+               (assoc Lib.Otel_genai.Attr_key.gen_ai_tool_name attrs));
+          check
+            (option (of_pp Fmt.Dump.string))
+            "legacy tool name"
+            (Some "keeper_shell")
+            (attr_string (assoc Lib.Otel_genai.Attr_key.tool_name attrs));
+          check
+            (option bool)
+            "legacy tool success"
+            (Some true)
+            (attr_bool (assoc Lib.Otel_genai.Attr_key.tool_success attrs));
+          check
+            (option int)
+            "legacy duration ms"
+            (Some 123)
+            (attr_int (assoc Lib.Otel_genai.Attr_key.tool_duration_ms attrs));
+          check
+            (option (of_pp Fmt.Dump.string))
+            "otel status"
+            (Some "OK")
+            (attr_string (assoc "otel.status_code" attrs))
+      | _ -> fail "expected exactly one emitted span")
+;;
+
 let () =
   run
     "otel_genai"
@@ -159,7 +240,11 @@ let () =
         ; test_case "omit missing task id" `Quick test_keeper_turn_attrs_omit_missing_task
         ; test_case "attr key registry boundaries" `Quick
             test_attr_key_registry_boundaries
+        ; test_case "attr key registry full coverage" `Quick
+            test_attr_key_registry_full_coverage
         ; test_case "tool execution attrs" `Quick test_tool_execution_attrs
+        ; test_case "dispatch hook emits tool span payload" `Quick
+            test_dispatch_hook_emits_tool_span_payload
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Centralizes OpenTelemetry GenAI attribute keys in `Otel_genai.Attr_key`.
- Separates official `gen_ai.*` keys, MASC extension keys, and legacy dashboard keys.
- Reuses the registry from the tool dispatch span hook instead of duplicating `gen_ai.*` string literals.
- Extends `test_otel_genai` to lock the key boundaries and tool execution attrs.

Fixes #13523.

## Evidence

[근거] OpenTelemetry GenAI semantic conventions are marked Development and describe the stability opt-in transition plan. Source: https://opentelemetry.io/docs/specs/semconv/gen-ai/ checked 2026-05-06 KST, confidence High.
[근거] OpenTelemetry GenAI metrics list `gen_ai.operation.name` and `gen_ai.provider.name` as required Development attributes and list `invoke_agent` / `execute_tool` as well-known operation values. Source: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/ checked 2026-05-06 KST, confidence High.

## Validation

- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_otel_genai.exe`
- `./_build/default/test/test_otel_genai.exe`
- `git diff --check HEAD~1 HEAD`