### PR TITLE
fix(board): split board write tool timeout

### DIFF
--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -86,6 +86,7 @@ logs. Candidates:
 
 | Site | Current cap | Owning issue |
 |------|-------------|--------------|
+| MCP `tools/call` default | 60 s via `MASC_TOOL_TIMEOUT_DEFAULT_SEC`; board write tools use 90 s via `MASC_TOOL_TIMEOUT_BOARD_SEC` | #10569 |
 | `keeper_llm_bridge` | 300 s default inside 600 s keeper turn | #9639, #9662 |
 | Governance `compute_judgments` | 60 s | #9629 |
 | `Process_eio` `git status --porcelain` | 15 s | #9632 |

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 412 unique knobs across 8 modules.
+**Total**: 414 unique knobs across 8 modules.
 
 ## Env_config_core (31 knobs)
 
@@ -231,43 +231,43 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | 125 | #9629: Each caller may also honour a legacy env var name from before the SSOT migration.  When present, the legacy na... |
 | `MASC_OPERATOR_JUDGE_TIMEOUT_SEC` | string_literal | 121 | #9629: Each caller may also honour a legacy env var name from before the SSOT migration.  When present, the legacy na... |
 
-## Env_config_runtime (113 knobs)
+## Env_config_runtime (115 knobs)
 
 | Env var | Kind | Line | Doc |
 |---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | 564 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | 561 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_RATE_BURST` | typed:int | 577 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | 574 | Per-agent requests per second. Default: 20. |
 | `MASC_AGENT_TRANSPORT` | string_literal | 329 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
 | `MASC_APPROVAL_JANITOR_ENABLED` | typed:bool | 424 | Enable the periodic approval_janitor sweep fiber.  Default: true. Set MASC_APPROVAL_JANITOR_ENABLED=false to disable ... |
 | `MASC_APPROVAL_JANITOR_INTERVAL_SEC` | typed:float | 432 | Sweep interval in seconds.  Default: 60s (every minute). Operators tolerate up to a minute of "approval still pending... |
 | `MASC_BOARD_BACKEND` | string_literal | 469 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
 | `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | 465 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | 791 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | 804 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | 74 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | 70 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | 803 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
+| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | 816 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
 | `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | typed:float | 193 | Token cleanup max age (seconds) |
 | `MASC_CDAL_ENABLED` | feature_flag | 355 | Enable contract-driven proof capture. Default: true. |
 | `MASC_CDAL_GATE_ENABLED` | feature_flag | 359 | Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. |
 | `MASC_CDAL_VERDICT_LOOKUP_LIMIT` | typed:int | 366 | Max verdicts to scan when looking up the latest verdict by task_id. Beyond this limit, older entries are silently ski... |
 | `MASC_CLAIM_TTL_SECONDS` | typed:float | 83 | Maximum time a task can stay Claimed/InProgress without agent heartbeat before being auto-released back to Todo (seco... |
 | `MASC_CLI_AGENT` | typed:string | 118 | {1 CLI Configuration} |
-| `MASC_COORD_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | 916 |  |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | 668 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | 664 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | 666 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | 707 |  |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | 721 |  |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | 659 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | 731 |  |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | 764 |  |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | 751 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | 696 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | 691 |  |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | 740 |  |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | 655 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | 651 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | 647 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_COORD_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | 929 |  |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | 681 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | 677 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | 679 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | 720 |  |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | 734 |  |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | 672 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | 744 |  |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | 777 |  |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | 764 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | 709 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | 704 |  |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | 753 |  |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | 668 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | 664 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | 660 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_DECISION_TTL_SEC` | typed:float | 62 | Default TTL for pending decisions (seconds, default 1 hour) |
 | `MASC_DISPATCH_V2` | feature_flag | 496 | Dispatch v2 feature flag. Default: true (since v2.102). |
 | `MASC_FULL_SURFACE` | feature_flag | 501 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
@@ -277,24 +277,24 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_GRPC_PORT` | string_literal | 300 | gRPC server port. Default: 8936. |
 | `MASC_GRPC_TARGET` | string_literal | 308 | gRPC client target address. Derived from grpc_port when unset. |
 | `MASC_HTTP_AUTH_STRICT` | feature_flag | 337 | Whether OpenAI-compatible endpoint is enabled. Default: false. |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | 819 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | 795 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | 832 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | 808 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
 | `MASC_KEEPER_ZOMBIE_THRESHOLD_SEC` | typed:float | 10 | Threshold for keeper agents (longer grace period, default 1 hour) |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | 783 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | 787 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | 796 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | 800 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
 | `MASC_LIST_PAGE_SIZE` | typed:int | 506 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
 | `MASC_LLAMA_MAX_TOKENS` | typed:int | 158 |  |
 | `MASC_LOCAL_MAX_TOKENS` | typed:int | 156 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | 595 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | 591 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | 601 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | 598 | Local worker max tokens per request. Default: 1024. |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | 608 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | 604 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | 614 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | 611 | Local worker max tokens per request. Default: 1024. |
 | `MASC_LOCK_EXPIRY_WARNING_SEC` | typed:float | 26 | Lock expiry warning threshold (seconds before expiry) |
 | `MASC_LOCK_TIMEOUT_SEC` | typed:float | 22 | Default lock timeout (seconds) |
-| `MASC_MEMORY_OAS_DEFAULT_IMPORTANCE` | typed:int | 617 | Default importance for OAS-stored memories, clamped to [1, 10]. Default: 5. |
+| `MASC_MEMORY_OAS_DEFAULT_IMPORTANCE` | typed:int | 630 | Default importance for OAS-stored memories, clamped to [1, 10]. Default: 5. |
 | `MASC_MESSAGE_MAX_COUNT` | typed:int | 246 | Maximum number of message files to retain per room (default 200). Oldest messages (by filename sort) are deleted when... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | 775 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | 609 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | 788 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | 622 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_OPENAI_COMPAT` | feature_flag | 334 | Whether OpenAI-compatible endpoint is enabled. Default: false. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | 95 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | 91 | Orchestrator check interval (seconds) |
@@ -302,48 +302,50 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_ORCHESTRATOR_TIMEOUT` | typed:int | 101 |  |
 | `MASC_PROC_MIN_CONFIDENCE` | typed:float | 482 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
 | `MASC_PROC_MIN_EVIDENCE` | typed:int | 478 | Minimum evidence count for crystallization. Default: 3. |
-| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | 807 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | 523 | Extra public tools (comma-separated names). |
+| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | 820 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | 536 | Extra public tools (comma-separated names). |
 | `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | 489 | Max consecutive consumer failures before recovery. Default: 3. |
-| `MASC_RATE_BURST` | typed:int | 558 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | 555 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | 833 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_RATE_BURST` | typed:int | 571 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | 568 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | 846 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
 | `MASC_RELAY_TARGET_AGENT` | typed:string | 111 | {1 Relay Configuration} |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | 825 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
-| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | 779 | Team session live turn window (seconds). Default: 300 (5 min). |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | 838 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | 792 | Team session live turn window (seconds). Default: 300 (5 min). |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | 34 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | 38 | Rate limit window (seconds) |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | 859 |  |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | 847 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | 875 |  |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | 872 |  |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | 860 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | 888 |  |
 | `MASC_SLOT_YIELD_ENABLED` | feature_flag | 441 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
-| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | 625 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
-| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | 630 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
-| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | 635 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
+| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | 638 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
+| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | 643 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
+| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | 648 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
 | `MASC_SPAWN_CODING_TIMEOUT_SEC` | typed:float | 132 | Extended timeout for coding mode (seconds). Default 2 hours. |
 | `MASC_SPAWN_GRACE_PERIOD_SEC` | typed:float | 136 | Grace period before timeout — sends SIGTERM for checkpoint opportunity (seconds). |
 | `MASC_SPAWN_TIMEOUT_SEC` | typed:float | 128 | Default spawn timeout for agent processes (seconds). Used by spawn.ml, spawn_eio.ml, and tool_relay.ml. Higher value ... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | 799 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | 811 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | 812 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | 824 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
 | `MASC_STARTUP_WATCHDOG_SEC` | typed:float | 348 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | 54 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | 50 | Maximum polling interval (seconds) - for idle tempo |
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | 46 | Minimum polling interval (seconds) - for urgent tempo |
 | `MASC_TIMEOUT_GCLOUD_AUTH_SEC` | typed:float | 237 | gcloud auth token fetch (used by a2a_tools, model_client, keeper_alerting) |
-| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | 511 | Tool description budget (max chars). None = unlimited. |
-| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | 519 | Read-only tool retry limit. Default: 2. |
+| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | 524 | Tool description budget (max chars). None = unlimited. |
+| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | 532 | Read-only tool retry limit. Default: 2. |
+| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | 519 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). |
+| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | 513 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
 | `MASC_USE_H2` | string_literal | 323 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
 | `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | 372 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
 | `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | 382 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
 | `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | 377 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
 | `MASC_WEBRTC_ENABLED` | feature_flag | 319 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | 539 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | 532 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | 526 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | 529 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | 547 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | 543 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | 535 |  |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | 552 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | 545 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | 539 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | 542 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | 560 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | 556 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | 548 |  |
 | `MASC_WS_ENABLED` | feature_flag | 315 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | 311 | WebSocket server port. Default: 8937. |
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | 14 | Cleanup loop interval (seconds) |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -506,6 +506,19 @@ module Tools = struct
     let v = get_int ~default:512 "MASC_LIST_PAGE_SIZE" in
     max 10 (min 1024 v)
 
+  (** Default outer MCP tool-call timeout, clamped to [5, 300] seconds.
+      Board writes have a separate timeout below so operators can tune
+      persistence stalls without raising every tool. *)
+  let timeout_default_sec () =
+    let v = get_int ~default:60 "MASC_TOOL_TIMEOUT_DEFAULT_SEC" in
+    float_of_int (max 5 (min 300 v))
+
+  (** Board write outer MCP tool-call timeout, clamped to [5, 300] seconds.
+      Default: 90 seconds (#10569). *)
+  let board_write_timeout_sec () =
+    let v = get_int ~default:90 "MASC_TOOL_TIMEOUT_BOARD_SEC" in
+    float_of_int (max 5 (min 300 v))
+
   (** Tool description budget (max chars). None = unlimited. *)
   let description_budget_opt () =
     match Sys.getenv_opt "MASC_TOOL_DESCRIPTION_BUDGET" |> trim_opt with

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -508,13 +508,17 @@ module Tools = struct
 
   (** Default outer MCP tool-call timeout, clamped to [5, 300] seconds.
       Board writes have a separate timeout below so operators can tune
-      persistence stalls without raising every tool. *)
+      persistence stalls without raising every tool.
+      @category Timeouts
+      @ops_class operator *)
   let timeout_default_sec () =
     let v = get_int ~default:60 "MASC_TOOL_TIMEOUT_DEFAULT_SEC" in
     float_of_int (max 5 (min 300 v))
 
   (** Board write outer MCP tool-call timeout, clamped to [5, 300] seconds.
-      Default: 90 seconds (#10569). *)
+      Default: 90 seconds (#10569).
+      @category Timeouts
+      @ops_class operator *)
   let board_write_timeout_sec () =
     let v = get_int ~default:90 "MASC_TOOL_TIMEOUT_BOARD_SEC" in
     float_of_int (max 5 (min 300 v))

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -240,6 +240,8 @@ module Tools : sig
   val dispatch_v2_enabled : bool
   val full_surface_enabled : unit -> bool
   val list_page_size : unit -> int
+  val timeout_default_sec : unit -> float
+  val board_write_timeout_sec : unit -> float
   val description_budget_opt : unit -> int option
   val readonly_retry_limit : int
   val public_tools_extra_opt : unit -> string option

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -18,16 +18,6 @@ let log_mcp_exn ~label exn =
   in
   Log.Mcp.info "%s%s: %s" tag label (Printexc.to_string exn)
 
-(** Parse bounded int from environment variable. *)
-let int_of_env_default name ~default ~min_v ~max_v =
-  match Sys.getenv_opt name with
-  | None -> default
-  | Some raw ->
-      let parsed =
-        Option.value ~default:default (int_of_string_opt (String.trim raw))
-      in
-      max min_v (min max_v parsed)
-
 (* Substring containment, ASCII case-insensitive.  Delegates to
    [String_util.contains_substring_ci] (which scans byte-wise without
    allocating) and preserves the local "empty needle matches all"
@@ -543,6 +533,32 @@ let coerce_tool_timeout_sec (raw_timeout_sec : float option) : float option =
       let raw_sec = int_of_float (Float.ceil raw) in
       Some (float_of_int (max 5 (min 300 raw_sec)))
 
+let tool_timeout_default_env = "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
+let tool_timeout_board_env = "MASC_TOOL_TIMEOUT_BOARD_SEC"
+
+let default_tool_timeout_sec () =
+  Env_config_runtime.Tools.timeout_default_sec ()
+
+let board_write_tool_timeout_sec () =
+  Env_config_runtime.Tools.board_write_timeout_sec ()
+
+let is_board_write_tool_name = function
+  | "keeper_board_post"
+  | "keeper_board_comment"
+  | "keeper_board_vote"
+  | "keeper_board_comment_vote"
+  | "masc_board_post"
+  | "masc_board_comment"
+  | "masc_board_vote"
+  | "masc_board_comment_vote" -> true
+  | _ -> false
+
+let tool_timeout_source ~(tool_name : string) =
+  match tool_name with
+  | "masc_persona_generate" -> "internal:masc_persona_generate_outer_budget"
+  | _ when is_board_write_tool_name tool_name -> tool_timeout_board_env
+  | _ -> tool_timeout_default_env
+
 (** Optional per-tool timeout to prevent long calls from starving the request loop. *)
 let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : float option =
   match tool_name with
@@ -562,16 +578,15 @@ let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : f
          the outer MCP tools/call timeout above that budget so callers see the
          generation result or the OAS error instead of a premature MCP timeout. *)
       Some 150.0
+  | _ when is_board_write_tool_name tool_name ->
+      (* #10569: board writes have a dedicated outer budget. They now expose
+         persist lock acquire/held histograms, but a transient disk stall can
+         still exceed the generic 60s MCP default before the board path's own
+         diagnostics are useful. Keep this separate from the global default so
+         operators can tune board writes without raising every tool. *)
+      Some (board_write_tool_timeout_sec ())
   | _ ->
-      let global_default_sec =
-        float_of_int
-          (int_of_env_default
-             "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
-             ~default:60
-             ~min_v:5
-             ~max_v:300)
-      in
-      Some global_default_sec
+      Some (default_tool_timeout_sec ())
 
 (** Resolve managed agent tool call to canonical operation *)
 let resolve_managed_agent_call ?mcp_session_id params =
@@ -638,9 +653,10 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
                (false,
                 Printf.sprintf
-                  "Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_DEFAULT_SEC)"
+                  "Tool timed out after %.0fs: %s (env: %s)"
                   timeout_sec
-                  name))
+                  name
+                  (tool_timeout_source ~tool_name:name)))
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        (* Never let a tool exception crash the MCP server. *)
        let err = Printexc.to_string exn in

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -542,15 +542,25 @@ let default_tool_timeout_sec () =
 let board_write_tool_timeout_sec () =
   Env_config_runtime.Tools.board_write_timeout_sec ()
 
+(* SSOT for which board tools mutate state lives in [Tool_board]'s
+   [tool_required_permission]: CanBroadcast (post/comment/vote/comment_vote/reaction)
+   and CanAdmin (delete/cleanup) are all writes. Reads (list/get/stats/search/
+   profile/hearths/curation_read) keep the global default timeout. Keep this
+   list in sync when new mutating board tools are added. *)
 let is_board_write_tool_name = function
   | "keeper_board_post"
   | "keeper_board_comment"
   | "keeper_board_vote"
   | "keeper_board_comment_vote"
+  | "keeper_board_delete"
+  | "keeper_board_cleanup"
   | "masc_board_post"
   | "masc_board_comment"
   | "masc_board_vote"
-  | "masc_board_comment_vote" -> true
+  | "masc_board_comment_vote"
+  | "masc_board_reaction"
+  | "masc_board_delete"
+  | "masc_board_cleanup" -> true
   | _ -> false
 
 let tool_timeout_source ~(tool_name : string) =

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -68,7 +68,11 @@ val tool_timeout_sec_opt :
 (** Returns the timeout (seconds) the dispatcher should
     apply to the call, [None] for tools that opt out
     (e.g. [masc_keeper_msg], which gates on its own
-    [max_turns] / [max_cost_usd]).  Board write tools use
+    [max_turns] / [max_cost_usd]).  Every mutating board tool
+    (post/comment/vote/comment_vote/reaction plus admin
+    delete/cleanup, both [keeper_board_*] and [masc_board_*]
+    aliases — same set as [Tool_board.tool_required_permission]'s
+    [CanBroadcast]/[CanAdmin] classifications) uses
     [MASC_TOOL_TIMEOUT_BOARD_SEC] (default 90s) instead of
     [MASC_TOOL_TIMEOUT_DEFAULT_SEC] (default 60s) so operators can
     tune board persistence separately from every other tool.

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -68,9 +68,12 @@ val tool_timeout_sec_opt :
 (** Returns the timeout (seconds) the dispatcher should
     apply to the call, [None] for tools that opt out
     (e.g. [masc_keeper_msg], which gates on its own
-    [max_turns] / [max_cost_usd]).  [_arguments] is
-    accepted for parity with future per-arg overrides but
-    currently unused. *)
+    [max_turns] / [max_cost_usd]).  Board write tools use
+    [MASC_TOOL_TIMEOUT_BOARD_SEC] (default 90s) instead of
+    [MASC_TOOL_TIMEOUT_DEFAULT_SEC] (default 60s) so operators can
+    tune board persistence separately from every other tool.
+    [_arguments] is accepted for parity with future per-arg
+    overrides but currently unused. *)
 
 (** {1 Runtime-MCP keeper trace context} *)
 

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -23,6 +23,16 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = [])
     ?tool_access name =
   let agent_name =
@@ -155,6 +165,28 @@ let test_regular_tool_uses_default_timeout () =
   with
   | Some timeout_sec -> check bool "default timeout remains enabled" true (timeout_sec >= 5.)
   | None -> fail "expected masc_status to keep fixed timeout"
+
+let test_board_write_tool_uses_board_timeout_default () =
+  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" "" (fun () ->
+    match
+      Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
+        ~tool_name:"keeper_board_post"
+        ~_arguments:(`Assoc [])
+    with
+    | Some timeout_sec ->
+        check (float 0.001) "board write default timeout" 90.0 timeout_sec
+    | None -> fail "expected keeper_board_post to keep fixed timeout")
+
+let test_board_write_tool_timeout_override () =
+  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" "123" (fun () ->
+    match
+      Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
+        ~tool_name:"masc_board_vote"
+        ~_arguments:(`Assoc [])
+    with
+    | Some timeout_sec ->
+        check (float 0.001) "board write timeout override" 123.0 timeout_sec
+    | None -> fail "expected masc_board_vote to keep fixed timeout")
 
 let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
   let base_path = temp_dir () in
@@ -435,6 +467,10 @@ let () =
           test_case "persona generate timeout exceeds OAS budget" `Quick
             test_persona_generate_timeout_exceeds_oas_budget;
           test_case "regular tool keeps default timeout" `Quick test_regular_tool_uses_default_timeout;
+          test_case "board write keeps board timeout default" `Quick
+            test_board_write_tool_uses_board_timeout_default;
+          test_case "board write timeout override" `Quick
+            test_board_write_tool_timeout_override;
           test_case "runtime MCP log context uses keeper trace/current turn" `Quick
             test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn;
           test_case "runtime MCP log context loads current task contract" `Quick


### PR DESCRIPTION
## Summary

- Adds `MASC_TOOL_TIMEOUT_BOARD_SEC` as a board-write-specific MCP `tools/call` timeout.
- Defaults board post/comment/vote/delete/cleanup/reaction write tools to 90s while preserving the 60s global default for other tools.
- Centralizes both timeout knobs in `Env_config_runtime.Tools`, regenerates `docs/runtime-tunables.md`, and documents the split in `docs/TIMEOUT-MATRIX.md`.
- Classifies both typed timeout getters for the env-knob CI guard.

## Why

`masc-mcp#10569` identified a fleet-wide board write timeout cluster where board writes inherited the generic 60s tool budget. The board persistence path now has acquire/held latency histograms, but operators still need to tune board write calls independently from unrelated tools. This patch implements the issue's per-board timeout option without raising the global timeout.

## Validation

- `python3 scripts/ci/check-env-knob-classification.py --base origin/main --head HEAD`
- `ocamlc -stop-after parsing lib/config/env_config_runtime.ml lib/config/env_config_runtime.mli lib/mcp_server_eio_call_tool.ml lib/mcp_server_eio_call_tool.mli test/test_mcp_server_eio_call_tool.ml`
- `git diff --check origin/main...HEAD`

## Local Verification Caveat

Focused Dune was not rerun in this repair pass because `/tmp/me-opam-switch.lock` is currently held by another focused build. This PR remains draft; CI is the authoritative compile surface until the shared switch is free.

Refs jeong-sik/masc-mcp#10569
