### PR TITLE
fix(test): isolate oas worker direct runs

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -60,10 +60,15 @@ let running_under_test_executable executable_name =
   |> String.starts_with ~prefix:"test_"
 
 let test_config_path_override_env = "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE"
+let test_base_path_override_env = "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE"
 
 let allow_inherited_test_config_paths () =
   Env_config_core.get_bool ~default:false
     test_config_path_override_env
+
+let allow_inherited_test_base_path () =
+  Env_config_core.get_bool ~default:false
+    test_base_path_override_env
 
 let initial_env_base_path = Env_config_core.base_path_raw_opt ()
 let initial_env_config_dir = Env_config_core.config_dir_opt ()
@@ -115,7 +120,7 @@ let current_env_base_path_opt () =
   sanitize_inherited_test_base_path_opt
     ~running_under_test_executable:
       (running_under_test_executable Sys.executable_name)
-    ~allow_inherited:(allow_inherited_test_config_paths ())
+    ~allow_inherited:(allow_inherited_test_base_path ())
     ~initial:initial_env_base_path
     ~current:(Env_config_core.base_path_raw_opt ())
     ~home:initial_env_home
@@ -329,15 +334,19 @@ let config_root_resolution (inputs : inputs) =
 let child_item (root : path_item) name =
   let path = Filename.concat root.path name in
   let exists =
-    if String.equal name cascade_json_filename then existing_file path
+    root.exists
+    &&
+    if String.equal name cascade_json_filename then
+      existing_file path
       || existing_file (Filename.concat root.path cascade_toml_filename)
-    else existing_dir path
+    else
+      existing_dir path
   in
   { path; exists; source = root.source }
 
 let file_item (root : path_item) name =
   let path = Filename.concat root.path name in
-  let exists = existing_file path in
+  let exists = root.exists && existing_file path in
   { path; exists; source = root.source }
 
 let personas_item (inputs : inputs) root =

--- a/lib/config_dir_resolver.mli
+++ b/lib/config_dir_resolver.mli
@@ -92,8 +92,11 @@ val config_signature_exists : string -> bool
 (** {1 Env introspection}
 
     Sanitized env var readers that strip inherited test values when running
-    under a test executable and [MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE] is unset. *)
+    under a test executable. [MASC_BASE_PATH] uses
+    [MASC_TEST_ALLOW_BASE_PATH_OVERRIDE]; config/persona paths and [HOME]
+    use [MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE]. *)
 
+val current_env_base_path_opt : unit -> string option
 val current_env_config_dir_opt : unit -> string option
 val current_env_base_path_opt : unit -> string option
 val current_env_personas_dir_opt : unit -> string option

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -204,8 +204,21 @@ let snapshot_holders ~label ~now =
    downstream; this counter is only a coarse fairness gate between fibers.
    The previous [max_v:16] ceiling was a typo-defence boilerplate, not an
    architectural ceiling, and starved fleets >16 keepers. Removed. *)
+let turn_concurrency_env_opt name =
+  if Env_config_core.running_under_test_executable () then None
+  else Env_config_core.raw_value_opt name
+
+let turn_concurrency_int_of_env_default name ~default ~min_v ~max_v =
+  match turn_concurrency_env_opt name with
+  | None -> default
+  | Some raw ->
+      let v =
+        Option.value ~default:default (int_of_string_opt (String.trim raw))
+      in
+      max min_v (min max_v v)
+
 let autonomous_turn_limit =
-  Keeper_config.int_of_env_default
+  turn_concurrency_int_of_env_default
     "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:16 ~min_v:1 ~max_v:max_int
 ;;
 
@@ -213,12 +226,12 @@ let () =
   Log.Keeper.info "autonomous_turn_concurrency=%d (env=%s)"
     autonomous_turn_limit
     (Option.value ~default:"<unset>"
-       (Env_config_core.raw_value_opt "MASC_KEEPER_AUTONOMOUS_CONCURRENCY"))
+       (turn_concurrency_env_opt "MASC_KEEPER_AUTONOMOUS_CONCURRENCY"))
 
 let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
 
 let reactive_turn_limit =
-  Keeper_config.int_of_env_default
+  turn_concurrency_int_of_env_default
     "MASC_KEEPER_REACTIVE_CONCURRENCY" ~default:16 ~min_v:1 ~max_v:max_int
 ;;
 
@@ -226,7 +239,7 @@ let () =
   Log.Keeper.info "reactive_turn_concurrency=%d (env=%s)"
     reactive_turn_limit
     (Option.value ~default:"<unset>"
-       (Env_config_core.raw_value_opt "MASC_KEEPER_REACTIVE_CONCURRENCY"))
+       (turn_concurrency_env_opt "MASC_KEEPER_REACTIVE_CONCURRENCY"))
 
 let reactive_turn_semaphore = Eio.Semaphore.make reactive_turn_limit
 

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -217,6 +217,9 @@ let turn_concurrency_int_of_env_default name ~default ~min_v ~max_v =
       in
       max min_v (min max_v v)
 
+let turn_concurrency_int_of_env_default_for_test =
+  turn_concurrency_int_of_env_default
+
 let autonomous_turn_limit =
   turn_concurrency_int_of_env_default
     "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:16 ~min_v:1 ~max_v:max_int

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -26,6 +26,11 @@ val turn_semaphore : Eio.Semaphore.t
 val autonomous_turn_semaphore : Eio.Semaphore.t
 val reactive_turn_semaphore : Eio.Semaphore.t
 
+(** Test-only: resolve a keeper turn concurrency env var through the same
+    test-executable isolation gate used at module initialization. *)
+val turn_concurrency_int_of_env_default_for_test :
+  string -> default:int -> min_v:int -> max_v:int -> int
+
 (** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
     turn slot. Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
 val semaphore_wait_timeout_sec : float

--- a/lib/masc_eio_env.ml
+++ b/lib/masc_eio_env.ml
@@ -16,6 +16,8 @@ let env : t option Atomic.t = Atomic.make None
 
 let init ~sw ~net ?clock () = Atomic.set env (Some { sw; net; clock })
 
+let reset_for_test () = Atomic.set env None
+
 let get () =
   match Atomic.get env with
   | Some e -> e

--- a/lib/masc_eio_env.mli
+++ b/lib/masc_eio_env.mli
@@ -34,6 +34,9 @@ val init :
     startup but a re-init is permitted (used by the harness
     test suite). *)
 
+val reset_for_test : unit -> unit
+(** Clear the captured environment for direct test executable runs. *)
+
 val get : unit -> t
 (** Read the captured environment.
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -339,6 +339,21 @@ let test_health_and_ci_runner_diagnostics () =
     (file_contains_pattern "scripts/health_snapshot.sh" "\"regressions\": ${regressions_json}");
   check bool "tests scrub inherited MASC_BASE_PATH overrides" true
     (file_contains_pattern "test/dune" "(MASC_BASE_PATH \"\")");
+  check bool "test_oas_worker pins direct-run MASC env" true
+    (file_contains_pattern "test/test_oas_worker.ml"
+       "let pin_direct_run_masc_env");
+  check bool "test_oas_worker clears captured Eio env before tests" true
+    (file_contains_pattern "test/test_oas_worker.ml"
+       "Masc_eio_env.reset_for_test ()");
+  check bool "test_oas_worker isolates legacy timeout test from liveness observer" true
+    (file_contains_pattern "test/test_oas_worker.ml"
+       "with_cascade_attempt_liveness \"off\"");
+  check bool "keeper turn concurrency ignores operator env in tests" true
+    (file_contains_pattern "lib/keeper/keeper_turn_slot.ml"
+       "Env_config_core.running_under_test_executable ()");
+  check bool "config resolver sanitizes inherited test base path" true
+    (file_contains_pattern "lib/config_dir_resolver.ml"
+       "env_base_path = current_env_base_path_opt ()");
   check bool "ci runner captures log file" true
     (file_contains_pattern "scripts/ci-run-tests.sh" "TEST_LOG_FILE=");
   check bool "ci runner prints failure markers" true

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -218,6 +218,8 @@ let test_cwd_fallback_disabled_by_default () =
     (Lib.Config_dir_resolver.status_to_string resolution.status);
   check string "root source" "missing"
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check bool "cascade hidden when repo fallback disabled"
+    false resolution.cascade.exists;
   check bool "warning mentions opt-in" true
     (List.exists
        (string_contains ~needle:"MASC_ALLOW_REPO_CONFIG_FALLBACK=true")

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -150,6 +150,39 @@ let test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in () =
   check (option string) "opt-in preserves config-path override"
     (Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config") actual
 
+let test_inputs_from_env_honors_config_path_override_opt_in () =
+  with_temp_dir "config-dir-inputs-env-config" @@ fun root ->
+  let config = make_config_root root in
+  let personas = Filename.concat config "personas" in
+  with_env "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE" (Some "true") @@ fun () ->
+  with_env "MASC_CONFIG_DIR" (Some config) @@ fun () ->
+  with_env "MASC_PERSONAS_DIR" (Some personas) @@ fun () ->
+  let inputs = Lib.Config_dir_resolver.inputs_from_env () in
+  check (option string) "inputs preserve config env" (Some config)
+    inputs.env_config_dir;
+  check (option string) "inputs preserve personas env" (Some personas)
+    inputs.env_personas_dir;
+  let resolution = Lib.Config_dir_resolver.resolve_with inputs in
+  check string "root source" "env"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check bool "personas env exists" true resolution.personas.exists
+
+let test_inputs_from_env_honors_base_path_override_opt_in () =
+  with_temp_dir "config-dir-inputs-env-base" @@ fun root ->
+  let base = Filename.concat root "base" in
+  let _config = make_config_root (Filename.concat base Common.masc_dirname) in
+  with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" (Some "true") @@ fun () ->
+  with_env "MASC_CONFIG_DIR" None @@ fun () ->
+  with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+  with_env "MASC_BASE_PATH" (Some base) @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" (Some base) @@ fun () ->
+  let inputs = Lib.Config_dir_resolver.inputs_from_env () in
+  check (option string) "inputs preserve base env" (Some base)
+    inputs.env_base_path;
+  let resolution = Lib.Config_dir_resolver.resolve_with inputs in
+  check string "root source" "local_masc"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source)
+
 let test_normalize_masc_base_path_input_canonicalizes_explicit_path () =
   let actual =
     Env_config_core.normalize_masc_base_path_input
@@ -429,6 +462,10 @@ let () =
             test_sanitize_inherited_test_base_path_opt_keeps_process_temp_path;
           test_case "opt-in preserves config-path override" `Quick
             test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in;
+          test_case "inputs_from_env honors config-path override opt-in" `Quick
+            test_inputs_from_env_honors_config_path_override_opt_in;
+          test_case "inputs_from_env honors base-path override opt-in" `Quick
+            test_inputs_from_env_honors_base_path_override_opt_in;
           test_case "canonicalizes explicit base path" `Quick
             test_normalize_masc_base_path_input_canonicalizes_explicit_path;
         ] );

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -9,6 +9,7 @@
     requires an Eio fiber context (Eio.Mutex on holder_table). *)
 
 module KK = Masc_mcp.Keeper_keepalive
+module KTS = Masc_mcp.Keeper_turn_slot
 module SW = Masc_mcp.Keeper_stale_watchdog
 
 exception After_flag_injected
@@ -28,6 +29,29 @@ let assert_eq ~msg ~expected ~actual =
 let assert_string_eq ~msg ~expected ~actual =
   if expected <> actual then
     failwith (Printf.sprintf "%s: expected=%S actual=%S" msg expected actual)
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
+
+let test_turn_concurrency_env_ignored_under_test_executable () =
+  with_env "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" "1" @@ fun () ->
+  let actual =
+    KTS.turn_concurrency_int_of_env_default_for_test
+      "MASC_KEEPER_AUTONOMOUS_CONCURRENCY"
+      ~default:16
+      ~min_v:1
+      ~max_v:64
+  in
+  assert_eq ~msg:"test executable ignores keeper turn concurrency env"
+    ~expected:16
+    ~actual
 
 let test_turn_slot_holders_empty_when_no_slot_held () =
   let now = Time_compat.now () in
@@ -534,6 +558,8 @@ let () =
         test_format_slot_holders_truncates_and_rounds;
       "slot holders summary reports empty pools",
         test_slot_holders_summary_empty_pools;
+      "keeper turn concurrency env ignored in test executable",
+        test_turn_concurrency_env_ignored_under_test_executable;
       "autonomous slot holders records keeper during acquire",
         test_autonomous_slot_holders_records_during_acquire;
       "holders dropped after with_keeper_turn_slot exits",

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -8,6 +8,19 @@
 
 (* Direct binary runs bypass test/dune's env block. Pin runtime env before
    [Masc_mcp] is referenced so module init cannot load operator state. *)
+let env_truthy name =
+  match Sys.getenv_opt name with
+  | Some raw -> (
+      match String.lowercase_ascii (String.trim raw) with
+      | "1" | "true" | "yes" | "on" -> true
+      | _ -> false)
+  | None -> false
+
+let env_has_value name =
+  match Sys.getenv_opt name with
+  | Some raw -> String.trim raw <> ""
+  | None -> false
+
 let pin_direct_run_masc_env () =
   let base =
     Filename.concat (Filename.get_temp_dir_name ())
@@ -15,10 +28,20 @@ let pin_direct_run_masc_env () =
          (Random.bits ()))
   in
   if not (Sys.file_exists base) then Unix.mkdir base 0o755;
-  Unix.putenv "MASC_BASE_PATH" base;
-  Unix.putenv "MASC_BASE_PATH_INPUT" base;
-  Unix.putenv "MASC_CONFIG_DIR" "";
-  Unix.putenv "MASC_PERSONAS_DIR" "";
+  if not
+       (env_truthy "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE"
+        && (env_has_value "MASC_BASE_PATH"
+            || env_has_value "MASC_BASE_PATH_INPUT"))
+  then (
+    Unix.putenv "MASC_BASE_PATH" base;
+    Unix.putenv "MASC_BASE_PATH_INPUT" base);
+  if not
+       (env_truthy "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE"
+        && (env_has_value "MASC_CONFIG_DIR"
+            || env_has_value "MASC_PERSONAS_DIR"))
+  then (
+    Unix.putenv "MASC_CONFIG_DIR" "";
+    Unix.putenv "MASC_PERSONAS_DIR" "");
   Unix.putenv "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" "";
   Unix.putenv "MASC_KEEPER_REACTIVE_CONCURRENCY" ""
 
@@ -146,6 +169,75 @@ let with_env name value f =
       | Some v -> Unix.putenv name v
       | None -> Unix.putenv name "")
     f
+
+let with_env_snapshot names f =
+  let saved = List.map (fun name -> name, Sys.getenv_opt name) names in
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (fun (name, value) ->
+          match value with
+          | Some prior -> Unix.putenv name prior
+          | None -> Unix.putenv name "")
+        saved)
+    f
+
+let test_pin_direct_run_masc_env_honors_base_path_override () =
+  let base = temp_dir "oas_worker_allowed_base" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+      with_env_snapshot
+        [
+          "MASC_BASE_PATH";
+          "MASC_BASE_PATH_INPUT";
+          "MASC_CONFIG_DIR";
+          "MASC_PERSONAS_DIR";
+          "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE";
+        ]
+      @@ fun () ->
+      with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" "true" @@ fun () ->
+      with_env "MASC_BASE_PATH" base @@ fun () ->
+      with_env "MASC_BASE_PATH_INPUT" base @@ fun () ->
+      pin_direct_run_masc_env ();
+      Alcotest.(check string)
+        "MASC_BASE_PATH preserved"
+        base
+        (Sys.getenv "MASC_BASE_PATH");
+      Alcotest.(check string)
+        "MASC_BASE_PATH_INPUT preserved"
+        base
+        (Sys.getenv "MASC_BASE_PATH_INPUT"))
+
+let test_pin_direct_run_masc_env_honors_config_path_override () =
+  let config_dir = temp_dir "oas_worker_allowed_config" in
+  let personas_dir = temp_dir "oas_worker_allowed_personas" in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir config_dir;
+      cleanup_dir personas_dir)
+    (fun () ->
+      with_env_snapshot
+        [
+          "MASC_BASE_PATH";
+          "MASC_BASE_PATH_INPUT";
+          "MASC_CONFIG_DIR";
+          "MASC_PERSONAS_DIR";
+          "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE";
+        ]
+      @@ fun () ->
+      with_env "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE" "true" @@ fun () ->
+      with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" personas_dir @@ fun () ->
+      pin_direct_run_masc_env ();
+      Alcotest.(check string)
+        "MASC_CONFIG_DIR preserved"
+        config_dir
+        (Sys.getenv "MASC_CONFIG_DIR");
+      Alcotest.(check string)
+        "MASC_PERSONAS_DIR preserved"
+        personas_dir
+        (Sys.getenv "MASC_PERSONAS_DIR"))
 
 let with_cascade_attempt_liveness mode f =
   let env = "MASC_CASCADE_ATTEMPT_LIVENESS" in
@@ -4895,6 +4987,12 @@ let () =
   Masc_mcp.Oas_worker_cascade.start_actor_if_needed ~sw;
   Masc_mcp.Masc_eio_env.reset_for_test ();
   Alcotest.run "OAS Worker" [
+    "direct_run_env", [
+      Alcotest.test_case "honors allowed base path override" `Quick
+        test_pin_direct_run_masc_env_honors_base_path_override;
+      Alcotest.test_case "honors allowed config path override" `Quick
+        test_pin_direct_run_masc_env_honors_config_path_override;
+    ];
     "sse_event_bridge", [
       Alcotest.test_case "text delta extraction" `Quick
         test_text_delta_extraction;

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -6,6 +6,24 @@
     @since Phase 1 — MASC->OAS migration
     @since Phase A — OAS #215 streaming verification *)
 
+(* Direct binary runs bypass test/dune's env block. Pin runtime env before
+   [Masc_mcp] is referenced so module init cannot load operator state. *)
+let pin_direct_run_masc_env () =
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_oas_worker_env_%d_%06x" (Unix.getpid ())
+         (Random.bits ()))
+  in
+  if not (Sys.file_exists base) then Unix.mkdir base 0o755;
+  Unix.putenv "MASC_BASE_PATH" base;
+  Unix.putenv "MASC_BASE_PATH_INPUT" base;
+  Unix.putenv "MASC_CONFIG_DIR" "";
+  Unix.putenv "MASC_PERSONAS_DIR" "";
+  Unix.putenv "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" "";
+  Unix.putenv "MASC_KEEPER_REACTIVE_CONCURRENCY" ""
+
+let () = pin_direct_run_masc_env ()
+
 open Masc_mcp
 
 module Oas = Agent_sdk
@@ -1143,10 +1161,11 @@ let test_default_config_preserves_custom_local_request_path () =
       "custom local OpenAI-compatible provider should stay OpenAICompat"
 
 let test_run_named_per_provider_timeout_uses_clock_fallback_and_exempts_last_provider () =
-  with_cascade_attempt_liveness "off" @@ fun () ->
+  Masc_mcp.Masc_eio_env.reset_for_test ();
   Alcotest.(check bool) "test requires no global Masc_eio_env"
     true
-    (Option.is_none (Masc_eio_env.get_opt ()));
+    (Option.is_none (Masc_mcp.Masc_eio_env.get_opt ()));
+  with_cascade_attempt_liveness "off" @@ fun () ->
   try
     Eio.Switch.run @@ fun sw ->
     let clock =
@@ -4874,6 +4893,7 @@ let () =
   Eio_guard.enable ();
   Eio.Switch.run @@ fun sw ->
   Masc_mcp.Oas_worker_cascade.start_actor_if_needed ~sw;
+  Masc_mcp.Masc_eio_env.reset_for_test ();
   Alcotest.run "OAS Worker" [
     "sse_event_bridge", [
       Alcotest.test_case "text delta extraction" `Quick


### PR DESCRIPTION
Fixes #13441.

## Root Cause

Direct local test binary runs bypass `test/dune` env scrubbing. That let inherited runtime state leak into `test_oas_worker.exe` before the test runner started:

- `MASC_BASE_PATH_INPUT` and `MASC_BASE_PATH` could point at operator/runtime state.
- `Config_dir_resolver` marked child paths as existing even when the root was intentionally missing, so repo fallback disablement still exposed `config/cascade.json`.
- `Masc_eio_env` could remain captured for direct test execution.
- Default cascade-attempt liveness observation switched some non-streaming mock assertions onto the streaming path.

## Changes

- Require config children/files to respect the parent root existence bit.
- Sanitize inherited test base-path overrides unless `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` opts in.
- Add `Masc_eio_env.reset_for_test` and reset the captured Eio env for direct `test_oas_worker.exe` runs.
- Keep keeper turn concurrency from reading operator env in test executables.
- Make OAS worker direct-run tests set both `MASC_BASE_PATH` and `MASC_BASE_PATH_INPUT`, and isolate legacy non-stream mock tests from the liveness observer.
- Add source guards for the direct-run isolation invariants.

## Validation

- `ocamlc -stop-after parsing lib/config_dir_resolver.ml lib/config_dir_resolver.mli lib/masc_eio_env.ml lib/masc_eio_env.mli lib/keeper/keeper_turn_slot.ml test/test_config_dir_resolver.ml test/test_ci_hardening_source.ml test/test_oas_worker.ml`
- `git diff --check`
- `env DUNE_JOBS=1 scripts/dune-local.sh build --cache=disabled test/test_config_dir_resolver.exe test/test_ci_hardening_source.exe test/test_oas_worker.exe`
- `./_build/default/test/test_config_dir_resolver.exe test --show-errors`
- `./_build/default/test/test_ci_hardening_source.exe test --show-errors "source_guard" 4`
- `./_build/default/test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe --help` now shows keeper concurrency as `16 (env=<unset>)` and does not load `~/.masc/config/cascade.json` or repo `config/cascade.json`.
