### PR TITLE
fix(keeper): report live playground repo metadata

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -269,6 +269,62 @@ let repo_name_of_json = function
       | _ -> None)
   | _ -> None
 
+let upsert_assoc key value fields =
+  (key, value) :: List.remove_assoc key fields
+
+let git_metadata_timeout_sec = 2.0
+
+let git_string_opt repo_path args =
+  try
+    let status, out =
+      Process_eio.run_argv_with_status ~timeout_sec:git_metadata_timeout_sec
+        ("git" :: "-C" :: repo_path :: args)
+    in
+    match status with
+    | Unix.WEXITED 0 ->
+        let trimmed = String.trim out in
+        if String.equal trimmed "" then None else Some trimmed
+    | _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
+
+let enrich_playground_repo_from_git
+      ~(source : string) ~(repo_name : string) ~(repo_path : string)
+      (repo_json : Yojson.Safe.t) =
+  let fields =
+    match repo_json with
+    | `Assoc fields -> fields
+    | _ -> [ ("name", `String repo_name) ]
+  in
+  let fields =
+    fields
+    |> upsert_assoc "name" (`String repo_name)
+    |> upsert_assoc "path" (`String (Filename.concat "repos" repo_name))
+    |> upsert_assoc "source" (`String source)
+    |> upsert_assoc "observed_at"
+         (`String (Printf.sprintf "%.0f" (Unix.gettimeofday ())))
+  in
+  let fields =
+    match git_string_opt repo_path [ "rev-parse"; "--abbrev-ref"; "HEAD" ] with
+    | Some branch -> upsert_assoc "branch" (`String branch) fields
+    | None -> fields
+  in
+  let fields =
+    match git_string_opt repo_path [ "log"; "--oneline"; "-1" ] with
+    | Some commit -> upsert_assoc "latest_commit" (`String commit) fields
+    | None -> fields
+  in
+  let fields =
+    match git_string_opt repo_path [ "rev-parse"; "--is-shallow-repository" ] with
+    | Some raw ->
+        upsert_assoc "shallow"
+          (`Bool (String.equal (String.lowercase_ascii raw) "true"))
+          fields
+    | None -> fields
+  in
+  `Assoc fields
+
 let cached_playground_repo_entries playground_abs =
   let cache_path = Filename.concat playground_abs ".playground_state.json" in
   try
@@ -301,18 +357,29 @@ let playground_repos_json ~(config : Coord.config) ~(meta : keeper_meta) =
     Keeper_sandbox.host_root_abs_of_meta ~config meta
     |> normalize_path
   in
-  let cached = cached_playground_repo_entries playground_abs in
+  let repos_dir = Filename.concat playground_abs "repos" in
+  let cached =
+    cached_playground_repo_entries playground_abs
+    |> List.map (fun repo ->
+      match repo_name_of_json repo with
+      | Some name ->
+          let repo_path = Filename.concat repos_dir name in
+          if safe_is_dir repo_path
+             && safe_file_exists (Filename.concat repo_path ".git")
+          then
+            enrich_playground_repo_from_git ~source:"git" ~repo_name:name
+              ~repo_path repo
+          else repo
+      | None -> repo)
+  in
   let cached_names = List.filter_map repo_name_of_json cached in
   let fs_entries =
     filesystem_playground_repo_names playground_abs
     |> List.filter (fun name -> not (List.mem name cached_names))
     |> List.map (fun name ->
-      `Assoc
-        [
-          ("name", `String name);
-          ("path", `String (Filename.concat "repos" name));
-          ("source", `String "filesystem");
-        ])
+      let repo_path = Filename.concat repos_dir name in
+      enrich_playground_repo_from_git ~source:"filesystem" ~repo_name:name
+        ~repo_path (`Assoc []))
   in
   `List (cached @ fs_entries)
 

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -265,7 +265,17 @@ let safe_is_dir path =
 let repo_name_of_json = function
   | `Assoc fields -> (
       match List.assoc_opt "name" fields with
-      | Some (`String name) when String.trim name <> "" -> Some name
+      | Some (`String raw_name) ->
+          let name = String.trim raw_name in
+          if
+            name <> ""
+            && name <> "."
+            && name <> ".."
+            && not (String.contains name '/')
+            && not (String.contains name '\\')
+            && String.equal (Filename.basename name) name
+          then Some name
+          else None
       | _ -> None)
   | _ -> None
 
@@ -273,6 +283,7 @@ let upsert_assoc key value fields =
   (key, value) :: List.remove_assoc key fields
 
 let git_metadata_timeout_sec = 2.0
+let max_live_git_enrichment_repos = 20
 
 let git_string_opt repo_path args =
   try
@@ -292,6 +303,7 @@ let git_string_opt repo_path args =
 let enrich_playground_repo_from_git
       ~(source : string) ~(repo_name : string) ~(repo_path : string)
       (repo_json : Yojson.Safe.t) =
+  let observed_at_unix = Time_compat.now () in
   let fields =
     match repo_json with
     | `Assoc fields -> fields
@@ -303,7 +315,8 @@ let enrich_playground_repo_from_git
     |> upsert_assoc "path" (`String (Filename.concat "repos" repo_name))
     |> upsert_assoc "source" (`String source)
     |> upsert_assoc "observed_at"
-         (`String (Printf.sprintf "%.0f" (Unix.gettimeofday ())))
+         (`String (Masc_domain.iso8601_of_unix_seconds observed_at_unix))
+    |> upsert_assoc "observed_at_unix" (`Float observed_at_unix)
   in
   let fields =
     match git_string_opt repo_path [ "rev-parse"; "--abbrev-ref"; "HEAD" ] with
@@ -324,6 +337,23 @@ let enrich_playground_repo_from_git
     | None -> fields
   in
   `Assoc fields
+
+let playground_repo_entry_json ~(source : string) ~(repo_name : string)
+    (repo_json : Yojson.Safe.t) =
+  let observed_at_unix = Time_compat.now () in
+  let fields =
+    match repo_json with
+    | `Assoc fields -> fields
+    | _ -> [ ("name", `String repo_name) ]
+  in
+  fields
+  |> upsert_assoc "name" (`String repo_name)
+  |> upsert_assoc "path" (`String (Filename.concat "repos" repo_name))
+  |> upsert_assoc "source" (`String source)
+  |> upsert_assoc "observed_at"
+       (`String (Masc_domain.iso8601_of_unix_seconds observed_at_unix))
+  |> upsert_assoc "observed_at_unix" (`Float observed_at_unix)
+  |> fun fields -> `Assoc fields
 
 let cached_playground_repo_entries playground_abs =
   let cache_path = Filename.concat playground_abs ".playground_state.json" in
@@ -358,6 +388,7 @@ let playground_repos_json ~(config : Coord.config) ~(meta : keeper_meta) =
     |> normalize_path
   in
   let repos_dir = Filename.concat playground_abs "repos" in
+  let live_enriched_count = ref 0 in
   let cached =
     cached_playground_repo_entries playground_abs
     |> List.map (fun repo ->
@@ -366,10 +397,12 @@ let playground_repos_json ~(config : Coord.config) ~(meta : keeper_meta) =
           let repo_path = Filename.concat repos_dir name in
           if safe_is_dir repo_path
              && safe_file_exists (Filename.concat repo_path ".git")
+             && !live_enriched_count < max_live_git_enrichment_repos
           then
+            (incr live_enriched_count;
             enrich_playground_repo_from_git ~source:"git" ~repo_name:name
-              ~repo_path repo
-          else repo
+              ~repo_path repo)
+          else playground_repo_entry_json ~source:"cache" ~repo_name:name repo
       | None -> repo)
   in
   let cached_names = List.filter_map repo_name_of_json cached in
@@ -377,9 +410,8 @@ let playground_repos_json ~(config : Coord.config) ~(meta : keeper_meta) =
     filesystem_playground_repo_names playground_abs
     |> List.filter (fun name -> not (List.mem name cached_names))
     |> List.map (fun name ->
-      let repo_path = Filename.concat repos_dir name in
-      enrich_playground_repo_from_git ~source:"filesystem" ~repo_name:name
-        ~repo_path (`Assoc []))
+      playground_repo_entry_json ~source:"filesystem" ~repo_name:name
+        (`Assoc []))
   in
   `List (cached @ fs_entries)
 

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -193,6 +193,10 @@ let () =
             Test_operator_control_keeper
             .test_keeper_sandbox_status_clarifies_visible_container_gap;
           Alcotest.test_case
+            "keeper sandbox repo status refreshes cached git metadata" `Quick
+            Test_operator_control_keeper
+            .test_playground_repo_status_refreshes_cached_git_metadata;
+          Alcotest.test_case
             "keeper sandbox fleet includes persisted keeper" `Quick
             Test_operator_control_keeper
             .test_keeper_sandbox_status_fleet_includes_persisted_keeper;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -43,6 +43,21 @@ let read_file path =
   Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
   really_input_string ic (in_channel_length ic)
 
+let process_status_to_string = function
+  | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+  | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+  | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
+
+let run_git_exn repo args =
+  match
+    Process_eio.run_argv_with_status ~timeout_sec:5.0
+      ("git" :: "-C" :: repo :: args)
+  with
+  | Unix.WEXITED 0, out -> String.trim out
+  | status, out ->
+      Alcotest.failf "git -C %s %s failed (%s): %s" repo
+        (String.concat " " args) (process_status_to_string status) out
+
 let count_log_lines_with_prefix log prefix =
   log
   |> String.split_on_char '\n'
@@ -452,6 +467,106 @@ let test_keeper_sandbox_status_clarifies_visible_container_gap () =
            "only when you need a visible prewarmed container");
       Alcotest.(check bool) "recommendation mentions repo readiness" true
         (contains_substring recommendation "playground_repos"))
+
+let test_playground_repo_status_refreshes_cached_git_metadata () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "sandbox-git-status" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Inspect live git metadata");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let meta = read_keeper_meta_exn config keeper_name in
+      let playground_abs =
+        Keeper_sandbox.host_root_abs_of_meta ~config meta
+      in
+      let repo_name = "live-repo" in
+      let repo_path =
+        Filename.concat playground_abs (Filename.concat "repos" repo_name)
+      in
+      ensure_dir repo_path;
+      ignore (run_git_exn repo_path [ "init"; "-q" ] : string);
+      ignore
+        (run_git_exn repo_path
+           [ "config"; "user.email"; "keeper-test@example.invalid" ]
+          : string);
+      ignore
+        (run_git_exn repo_path
+           [ "config"; "user.name"; "Keeper Status Test" ]
+          : string);
+      write_file (Filename.concat repo_path "README.md") "initial\n";
+      ignore (run_git_exn repo_path [ "add"; "README.md" ] : string);
+      ignore (run_git_exn repo_path [ "commit"; "-q"; "-m"; "initial" ] : string);
+      let live_branch =
+        run_git_exn repo_path [ "rev-parse"; "--abbrev-ref"; "HEAD" ]
+      in
+      let live_commit = run_git_exn repo_path [ "log"; "--oneline"; "-1" ] in
+      write_file
+        (Filename.concat playground_abs ".playground_state.json")
+        (Printf.sprintf
+           {|{"repos":[{"name":%S,"branch":"stale-branch","latest_commit":"stale-commit","shallow":true,"last_action":"clone"}],"last_updated":"1"}|}
+           repo_name);
+      let open Yojson.Safe.Util in
+      let status_repos =
+        Keeper_sandbox_control.playground_repos_json ~config ~meta
+        |> to_list
+      in
+      let repo =
+        match
+          List.find_opt
+            (fun repo ->
+              String.equal
+                (repo |> member "name" |> to_string)
+                repo_name)
+            status_repos
+        with
+        | Some repo -> repo
+        | None -> Alcotest.fail "live repo missing from playground status"
+      in
+      Alcotest.(check string) "repo path" "repos/live-repo"
+        (repo |> member "path" |> to_string);
+      Alcotest.(check string) "repo source" "git"
+        (repo |> member "source" |> to_string);
+      Alcotest.(check string) "branch refreshed from git" live_branch
+        (repo |> member "branch" |> to_string);
+      Alcotest.(check string) "commit refreshed from git" live_commit
+        (repo |> member "latest_commit" |> to_string);
+      Alcotest.(check bool) "shallow refreshed from git" false
+        (repo |> member "shallow" |> to_bool);
+      Alcotest.(check string) "cache context preserved" "clone"
+        (repo |> member "last_action" |> to_string);
+      Alcotest.(check bool) "status is observed live" true
+        (repo |> member "observed_at" |> to_string |> String.length > 0))
 
 let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -534,7 +534,7 @@ let test_playground_repo_status_refreshes_cached_git_metadata () =
       write_file
         (Filename.concat playground_abs ".playground_state.json")
         (Printf.sprintf
-           {|{"repos":[{"name":%S,"branch":"stale-branch","latest_commit":"stale-commit","shallow":true,"last_action":"clone"}],"last_updated":"1"}|}
+           {|{"repos":[{"name":%S,"branch":"stale-branch","latest_commit":"stale-commit","shallow":true,"last_action":"clone"},{"name":"../outside","branch":"bad-cache"}],"last_updated":"1"}|}
            repo_name);
       let open Yojson.Safe.Util in
       let status_repos =
@@ -566,7 +566,24 @@ let test_playground_repo_status_refreshes_cached_git_metadata () =
       Alcotest.(check string) "cache context preserved" "clone"
         (repo |> member "last_action" |> to_string);
       Alcotest.(check bool) "status is observed live" true
-        (repo |> member "observed_at" |> to_string |> String.length > 0))
+        (repo |> member "observed_at" |> to_string |> contains_substring "T");
+      Alcotest.(check bool) "unix observation timestamp is numeric" true
+        (match repo |> member "observed_at_unix" with
+         | `Float _ | `Int _ -> true
+         | _ -> false);
+      let invalid_repo =
+        List.find_opt
+          (fun repo ->
+            String.equal (repo |> member "name" |> to_string) "../outside")
+          status_repos
+      in
+      match invalid_repo with
+      | Some repo ->
+          let source = repo |> member "source" in
+          let path = repo |> member "path" in
+          Alcotest.(check bool) "invalid cached repo not git-enriched" true
+            (source = `Null && path = `Null)
+      | None -> ())
 
 let test_keeper_sandbox_status_fleet_includes_persisted_keeper () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- Refresh playground repo status from the actual local git checkout when a cached repo entry still exists.
- Preserve cache context such as `last_action`, while overlaying live `branch`, `latest_commit`, `shallow`, `path`, `source`, and `observed_at`.
- Add a regression test where `.playground_state.json` is stale but the real playground repo has newer git metadata.

## Why this matters
Live `masc_keeper_sandbox_status` showed keeper playground repos under `/Users/dancer/me/.masc/playground` with old cached commits. Operators need the status surface to expose what the checkout actually is, not trust stale `.playground_state.json` as the source of truth. This PR is intentionally status-only: it does not auto-pull or mutate dirty keeper clones.

## Verification
- `git diff --check origin/main...HEAD`
- `env DUNE_CACHE=disabled MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_operator_control.exe`
- `./_build/default/test/test_operator_control.exe test --color=never operator 46`

## Notes
The first post-pin local build hit stale `agent_sdk`-dependent Dune artifacts. I repaired the opam pin with `scripts/opam-pin-external-deps.sh --install`, cleaned this worktree build, disabled the Dune cache for verification, and reran the focused target successfully.