### PR TITLE
fix(dashboard): summarize keeper terminal streams

### DIFF
--- a/dashboard/src/components/ide/keeper-shell-drawer.test.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.test.ts
@@ -69,7 +69,7 @@ describe('KeeperShellDrawer event mapping', () => {
     const terminal = mounted.querySelector('[data-terminal][data-testid="keeper-shell-terminal"]')
     expect(terminal?.getAttribute('aria-label')).toBe('Keeper shell terminal')
     expect(terminal?.querySelector('.term-line.is-meta')?.textContent).toContain('no keeper selected')
-    expect(mounted.querySelector('[data-testid="keeper-shell-summary"]')?.textContent).toContain('1 lines')
+    expect(mounted.querySelector('[data-testid="keeper-shell-summary"]')?.textContent).toContain('1 line')
     expect(mounted.querySelector('[data-status-chip-tone="neutral"]')?.textContent).toContain('idle')
   })
 
@@ -94,6 +94,7 @@ describe('KeeperShellDrawer event mapping', () => {
 
     await waitFor(() => expect(mounted?.textContent).toContain('task-123'))
     const summary = mounted.querySelector('[data-testid="keeper-shell-summary"]')
+    expect(summary?.getAttribute('role')).toBeNull()
     expect(summary?.getAttribute('aria-label')).toContain('4 lines, 2 stdout, 1 stderr, 1 meta')
     expect(summary?.getAttribute('aria-label')).toContain('15 dropped bytes')
     expect(summary?.textContent).toContain('stdout 2')

--- a/dashboard/src/components/ide/keeper-shell-drawer.test.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.test.ts
@@ -2,7 +2,11 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { KeeperShellDrawer, linesFromShellEvent } from './keeper-shell-drawer'
+import {
+  KeeperShellDrawer,
+  linesFromShellEvent,
+  summarizeShellLines,
+} from './keeper-shell-drawer'
 
 let mounted: HTMLDivElement | null = null
 
@@ -39,6 +43,24 @@ describe('KeeperShellDrawer event mapping', () => {
     expect(lines[0]).toEqual({ text: 'dropped 15 older bytes', stream: 'meta' })
   })
 
+  it('summarizes terminal streams and dropped byte evidence', () => {
+    const summary = summarizeShellLines([
+      { text: 'dropped 15 older bytes', stream: 'meta' },
+      { text: 'one', stream: 'stdout' },
+      { text: 'two', stream: 'stdout' },
+      { text: 'warn', stream: 'stderr' },
+    ])
+
+    expect(summary).toEqual({
+      total: 4,
+      stdout: 2,
+      stderr: 1,
+      meta: 1,
+      droppedBytes: 15,
+      lastStream: 'stderr',
+    })
+  })
+
   it('renders shell output through the shared terminal molecule', async () => {
     mounted = document.createElement('div')
     render(h(KeeperShellDrawer, { keeperName: '' }), mounted)
@@ -47,6 +69,38 @@ describe('KeeperShellDrawer event mapping', () => {
     const terminal = mounted.querySelector('[data-terminal][data-testid="keeper-shell-terminal"]')
     expect(terminal?.getAttribute('aria-label')).toBe('Keeper shell terminal')
     expect(terminal?.querySelector('.term-line.is-meta')?.textContent).toContain('no keeper selected')
+    expect(mounted.querySelector('[data-testid="keeper-shell-summary"]')?.textContent).toContain('1 lines')
+    expect(mounted.querySelector('[data-status-chip-tone="neutral"]')?.textContent).toContain('idle')
+  })
+
+  it('renders streaming summary chips for stdout, stderr, and dropped bytes', async () => {
+    let resolveFetch: (value: Response) => void = () => undefined
+    const fetchPromise = new Promise<Response>(resolve => {
+      resolveFetch = resolve
+    })
+    const fetchMock = vi.fn().mockReturnValue(fetchPromise)
+    vi.stubGlobal('fetch', fetchMock)
+
+    mounted = document.createElement('div')
+    render(h(KeeperShellDrawer, { keeperName: 'sangsu' }), mounted)
+
+    resolveFetch(new Response(
+      'event: shell\ndata: {"type":"snapshot","keeper":"sangsu","task_id":"task-123","stdout_since":"one\\ntwo\\n","stderr_since":"warn\\n","bytes_dropped_stdout":12,"bytes_dropped_stderr":3,"closed":false}\n\n',
+      {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      },
+    ))
+
+    await waitFor(() => expect(mounted?.textContent).toContain('task-123'))
+    const summary = mounted.querySelector('[data-testid="keeper-shell-summary"]')
+    expect(summary?.getAttribute('aria-label')).toContain('4 lines, 2 stdout, 1 stderr, 1 meta')
+    expect(summary?.getAttribute('aria-label')).toContain('15 dropped bytes')
+    expect(summary?.textContent).toContain('stdout 2')
+    expect(summary?.textContent).toContain('stderr 1')
+    expect(summary?.textContent).toContain('dropped 15B')
+    expect(mounted.querySelector('[data-status-chip-tone="info"]')?.textContent).toContain('streaming')
+    expect(mounted.querySelector('[data-status-chip-tone="bad"]')?.textContent).toContain('stderr 1')
   })
 
   it('does not auto-scroll when reduced motion is preferred', async () => {
@@ -73,7 +127,7 @@ describe('KeeperShellDrawer event mapping', () => {
     log.scrollTop = 17
 
     resolveFetch(new Response(
-      'event: shell\ndata: {"type":"snapshot","keeper":"sangsu","stdout_since":"fresh\\\\n","stderr_since":"","closed":false}\n\n',
+      'event: shell\ndata: {"type":"snapshot","keeper":"sangsu","stdout_since":"fresh\\n","stderr_since":"","closed":false}\n\n',
       {
         status: 200,
         headers: { 'Content-Type': 'text/event-stream' },

--- a/dashboard/src/components/ide/keeper-shell-drawer.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.ts
@@ -4,6 +4,7 @@ import {
   streamKeeperShell,
   type KeeperShellStreamEvent,
 } from '../../api/keeper-shell'
+import { StatusChip, type StatusChipTone } from '../common/status-chip'
 import { Terminal, type TerminalLine } from '../common/terminal'
 
 const MAX_TERMINAL_LINES = 5000
@@ -15,6 +16,17 @@ interface ShellLine {
 
 interface KeeperShellDrawerProps {
   keeperName: string
+}
+
+type KeeperShellStatus = 'idle' | 'streaming' | 'closed' | 'error'
+
+export interface KeeperShellSummary {
+  readonly total: number
+  readonly stdout: number
+  readonly stderr: number
+  readonly meta: number
+  readonly droppedBytes: number
+  readonly lastStream: ShellLine['stream'] | null
 }
 
 function splitChunkLines(chunk: string): string[] {
@@ -56,6 +68,29 @@ function appendLines(current: ShellLine[], next: ShellLine[]): ShellLine[] {
   return [...current, ...next].slice(-MAX_TERMINAL_LINES)
 }
 
+export function summarizeShellLines(lines: ReadonlyArray<ShellLine>): KeeperShellSummary {
+  let stdout = 0
+  let stderr = 0
+  let meta = 0
+  let droppedBytes = 0
+  for (const line of lines) {
+    if (line.stream === 'stdout') stdout += 1
+    else if (line.stream === 'stderr') stderr += 1
+    else meta += 1
+
+    const dropped = /^dropped\s+(\d+)\s+older bytes$/.exec(line.text)
+    if (dropped) droppedBytes += Number(dropped[1])
+  }
+  return {
+    total: lines.length,
+    stdout,
+    stderr,
+    meta,
+    droppedBytes,
+    lastStream: lines[lines.length - 1]?.stream ?? null,
+  }
+}
+
 function toTerminalLine(line: ShellLine): TerminalLine {
   switch (line.stream) {
     case 'stderr':
@@ -67,13 +102,52 @@ function toTerminalLine(line: ShellLine): TerminalLine {
   }
 }
 
+function statusTone(status: KeeperShellStatus): StatusChipTone {
+  if (status === 'streaming') return 'info'
+  if (status === 'closed') return 'neutral'
+  if (status === 'error') return 'bad'
+  return 'neutral'
+}
+
+function shellSummaryLabel(summary: KeeperShellSummary, status: KeeperShellStatus): string {
+  const last = summary.lastStream ?? 'none'
+  const dropped = summary.droppedBytes > 0 ? `, ${summary.droppedBytes} dropped bytes` : ''
+  return `Keeper shell ${status}: ${summary.total} lines, ${summary.stdout} stdout, ${summary.stderr} stderr, ${summary.meta} meta, last ${last}${dropped}`
+}
+
+function KeeperShellSummaryStrip({
+  summary,
+  status,
+}: {
+  readonly summary: KeeperShellSummary
+  readonly status: KeeperShellStatus
+}) {
+  return html`
+    <div
+      role="status"
+      aria-label=${shellSummaryLabel(summary, status)}
+      data-testid="keeper-shell-summary"
+      class="flex min-w-0 flex-wrap items-center gap-1.5 text-[var(--color-fg-muted)]"
+    >
+      <${StatusChip} tone="neutral" uppercase=${false}>${summary.total} lines</${StatusChip}>
+      <${StatusChip} tone="ok" uppercase=${false}>stdout ${summary.stdout}</${StatusChip}>
+      <${StatusChip} tone=${summary.stderr > 0 ? 'bad' : 'neutral'} uppercase=${false}>stderr ${summary.stderr}</${StatusChip}>
+      <${StatusChip} tone="neutral" uppercase=${false}>meta ${summary.meta}</${StatusChip}>
+      ${summary.droppedBytes > 0
+        ? html`<${StatusChip} tone="warn" uppercase=${false}>dropped ${summary.droppedBytes}B</${StatusChip}>`
+        : null}
+    </div>
+  `
+}
+
 export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
   const keeper = keeperName.trim()
   const [lines, setLines] = useState<ShellLine[]>([])
-  const [status, setStatus] = useState<'idle' | 'streaming' | 'closed' | 'error'>('idle')
+  const [status, setStatus] = useState<KeeperShellStatus>('idle')
   const [taskId, setTaskId] = useState<string | null>(null)
   const viewportRef = useRef<HTMLDivElement | null>(null)
   const terminalLines = useMemo(() => lines.map(toTerminalLine), [lines])
+  const summary = useMemo(() => summarizeShellLines(lines), [lines])
 
   const prefersReducedMotion = useMemo(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -131,14 +205,17 @@ export function KeeperShellDrawer({ keeperName }: KeeperShellDrawerProps) {
       aria-label="Keeper shell drawer"
     >
       <div
-        class="flex items-center gap-2 border-b border-solid border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 font-mono text-2xs"
+        class="flex min-w-0 flex-wrap items-center gap-2 border-b border-solid border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 font-mono text-2xs"
       >
         <span class="text-[var(--color-fg-secondary)]">TERMINAL</span>
         <span class="text-[var(--color-fg-muted)]">${keeper || 'none'}</span>
         ${taskId
           ? html`<span class="truncate text-[var(--color-fg-disabled)]">${taskId}</span>`
           : null}
-        <span class="ml-auto text-[var(--color-fg-muted)]">${status}</span>
+        <${StatusChip} tone=${statusTone(status)} uppercase=${false} class="font-mono">${status}</${StatusChip}>
+        <div class="ml-auto min-w-0">
+          <${KeeperShellSummaryStrip} summary=${summary} status=${status} />
+        </div>
       </div>
       <${Terminal}
         lines=${terminalLines}

--- a/dashboard/src/components/ide/keeper-shell-drawer.ts
+++ b/dashboard/src/components/ide/keeper-shell-drawer.ts
@@ -109,10 +109,14 @@ function statusTone(status: KeeperShellStatus): StatusChipTone {
   return 'neutral'
 }
 
+function lineCountLabel(count: number): string {
+  return `${count} ${count === 1 ? 'line' : 'lines'}`
+}
+
 function shellSummaryLabel(summary: KeeperShellSummary, status: KeeperShellStatus): string {
   const last = summary.lastStream ?? 'none'
   const dropped = summary.droppedBytes > 0 ? `, ${summary.droppedBytes} dropped bytes` : ''
-  return `Keeper shell ${status}: ${summary.total} lines, ${summary.stdout} stdout, ${summary.stderr} stderr, ${summary.meta} meta, last ${last}${dropped}`
+  return `Keeper shell ${status}: ${lineCountLabel(summary.total)}, ${summary.stdout} stdout, ${summary.stderr} stderr, ${summary.meta} meta, last ${last}${dropped}`
 }
 
 function KeeperShellSummaryStrip({
@@ -124,12 +128,11 @@ function KeeperShellSummaryStrip({
 }) {
   return html`
     <div
-      role="status"
       aria-label=${shellSummaryLabel(summary, status)}
       data-testid="keeper-shell-summary"
       class="flex min-w-0 flex-wrap items-center gap-1.5 text-[var(--color-fg-muted)]"
     >
-      <${StatusChip} tone="neutral" uppercase=${false}>${summary.total} lines</${StatusChip}>
+      <${StatusChip} tone="neutral" uppercase=${false}>${lineCountLabel(summary.total)}</${StatusChip}>
       <${StatusChip} tone="ok" uppercase=${false}>stdout ${summary.stdout}</${StatusChip}>
       <${StatusChip} tone=${summary.stderr > 0 ? 'bad' : 'neutral'} uppercase=${false}>stderr ${summary.stderr}</${StatusChip}>
       <${StatusChip} tone="neutral" uppercase=${false}>meta ${summary.meta}</${StatusChip}>


### PR DESCRIPTION
## Summary

- Add a StatusChip-backed keeper shell stream summary to the Terminal-in-Dashboard drawer.
- Count stdout, stderr, meta, and dropped-byte evidence from keeper shell SSE snapshots.
- Expose an aria summary while continuing to render output through the shared `Terminal` molecule.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/ide/keeper-shell-drawer.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` (passes with 3 existing warnings in unrelated files)
- `pnpm --dir dashboard run build` (passes with known Vite dynamic-import and chunk-size warnings)
- Browser proof with local mock API + Vite:
  - Desktop screenshot: `/tmp/masc-keeper-terminal-summary-desktop-0506.png`
  - Mobile screenshot: `/tmp/masc-keeper-terminal-summary-mobile-0506.png`
  - Verified summary chips: `streaming`, `4 lines`, `stdout 2`, `stderr 1`, `meta 1`, `dropped 15B`
  - Verified mobile no-overflow: body/document scroll width stayed at `390px`
  - Verified no browser page errors

## Review Focus

- `dashboard/src/components/ide/keeper-shell-drawer.ts`
- `dashboard/src/components/ide/keeper-shell-drawer.test.ts`
