### PR TITLE
fix(keeper): avoid Docker word false positives

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -145,11 +145,32 @@ let sandbox_socket_markers =
     "buildkitd.sock";
   ]
 
+let rec shell_ir_uses_nested_container_runtime = function
+  | Masc_exec.Shell_ir.Simple simple ->
+      let bin =
+        Masc_exec.Bin.to_string simple.bin
+        |> Filename.basename
+        |> String.lowercase_ascii
+      in
+      List.mem bin nested_container_runtime_tokens
+  | Masc_exec.Shell_ir.Pipeline stages ->
+      List.exists shell_ir_uses_nested_container_runtime stages
+
 let command_uses_nested_container_runtime cmd =
-  let lowered_words = lowercase_shell_words cmd in
   let lowered_cmd = String.lowercase_ascii cmd in
-  List.exists (fun token -> List.mem token nested_container_runtime_tokens)
-    lowered_words
+  let runtime_bin =
+    match Masc_exec_bash_parser.Bash.parse_string cmd with
+    | Masc_exec.Parsed.Parsed ir ->
+        shell_ir_uses_nested_container_runtime ir
+    | Masc_exec.Parsed.Parse_error _
+    | Masc_exec.Parsed.Parse_aborted _
+    | Masc_exec.Parsed.Too_complex _ ->
+        let lowered_words = lowercase_shell_words cmd in
+        List.exists
+          (fun token -> List.mem token nested_container_runtime_tokens)
+          lowered_words
+  in
+  runtime_bin
   || List.exists (String_util.contains_substring lowered_cmd) sandbox_socket_markers
 
 (* ── Sandbox runtime preflight ─────────────────────────── *)

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -915,6 +915,40 @@ let test_bash_rewrites_host_path_command_for_docker () =
   Alcotest.(check bool) "command no longer leaks host playground path" false
     (response_mentions raw "output" playground)
 
+let test_nested_runtime_detector_ignores_commit_message_words () =
+  let cases =
+    [
+      "git commit --allow-empty -m 'docker sandbox proof'";
+      "git -C /tmp/repo commit -m 'podman nerdctl buildah mentioned as text'";
+      "echo 'docker podman buildah are just words'";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        ("does not block quoted/plain argument text: " ^ cmd)
+        false
+        (Keeper_shell_docker.command_uses_nested_container_runtime cmd))
+    cases
+
+let test_nested_runtime_detector_blocks_runtime_binaries () =
+  let cases =
+    [
+      "docker ps";
+      "podman run alpine true";
+      "nerdctl images";
+      "buildah bud .";
+      "cd /tmp && docker ps";
+    ]
+  in
+  List.iter
+    (fun cmd ->
+      Alcotest.(check bool)
+        ("blocks nested runtime command: " ^ cmd)
+        true
+        (Keeper_shell_docker.command_uses_nested_container_runtime cmd))
+    cases
+
 let () =
   Alcotest.run "Keeper_shell_docker_route"
     [
@@ -970,6 +1004,12 @@ let () =
           Alcotest.test_case
             "git-creds uses GitHub author only in github_identity mode"
             `Quick test_git_creds_uses_github_identity_mode;
+          Alcotest.test_case
+            "nested runtime detector ignores commit message words"
+            `Quick test_nested_runtime_detector_ignores_commit_message_words;
+          Alcotest.test_case
+            "nested runtime detector blocks runtime binaries"
+            `Quick test_nested_runtime_detector_blocks_runtime_binaries;
           Alcotest.test_case "hard mode git_clone uses brokered route" `Quick
             test_hard_mode_git_clone_uses_brokered_route;
 	          Alcotest.test_case "git_clone repairs existing docker clone checkout"


### PR DESCRIPTION
## Summary

- make nested container runtime detection prefer the parsed command binary instead of scanning every shell word
- keep blocking actual `docker`, `podman`, `nerdctl`, and `buildah` invocations, including parser-fallback complex commands
- add regressions proving `git commit -m 'docker ...'` and similar text arguments no longer trigger the nested-runtime gate

## Root Cause

`command_uses_nested_container_runtime` scanned all lowercased shell words. A harmless commit message or text argument containing `docker`/`podman`/`nerdctl`/`buildah` was classified as an attempted nested container runtime invocation, so Docker keepers could be blocked while committing evidence about Docker sandbox work.

## Operator Impact

Docker keepers can now commit PR/evidence work whose message mentions Docker without hitting the misleading `sandbox_profile=docker+git_creds blocks nested container runtimes` error. Actual nested runtime binaries remain blocked.

## Validation

- `git diff --check`
- `MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh exec ./test/test_keeper_shell_docker_route.exe -- test docker_route_contract 7,8`

Note: the full `test_keeper_shell_docker_route.exe` currently has unrelated credential-preflight fixture failures; the two new regression cases pass in isolation.