### PR TITLE
feat(chronicle): inject git epochs into memory

### DIFF
--- a/lib/chronicle_memory.ml
+++ b/lib/chronicle_memory.ml
@@ -1,0 +1,107 @@
+(** Chronicle_memory -- inject git chronicle candidates into episodic memory. *)
+
+let take n xs =
+  let rec loop remaining acc = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | x :: rest -> loop (remaining - 1) (x :: acc) rest
+  in
+  loop n [] xs
+
+let sanitize_id raw =
+  let buf = Buffer.create (String.length raw) in
+  String.iter
+    (function
+      | 'a' .. 'z' as c -> Buffer.add_char buf c
+      | 'A' .. 'Z' as c -> Buffer.add_char buf c
+      | '0' .. '9' as c -> Buffer.add_char buf c
+      | '-' -> Buffer.add_char buf '-'
+      | '_' -> Buffer.add_char buf '_'
+      | '#' -> Buffer.add_string buf "issue-"
+      | _ -> Buffer.add_char buf '-')
+    raw;
+  let value = Buffer.contents buf |> String.trim in
+  if String.equal value "" then "unknown" else value
+
+let short_sha sha =
+  let len = min 12 (String.length sha) in
+  String.sub sha 0 len
+
+let episode_id (epoch : Chronicle_ingest.candidate_epoch) =
+  Printf.sprintf "git-chronicle-%s-%s"
+    (sanitize_id epoch.id)
+    (short_sha epoch.end_commit)
+
+let csv values = String.concat "," values
+
+let commit_label count =
+  if count = 1 then "1 commit" else Printf.sprintf "%d commits" count
+
+let summary_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
+  let file_preview =
+    match take 5 epoch.file_paths with
+    | [] -> ""
+    | files -> Printf.sprintf "; files: %s" (String.concat ", " files)
+  in
+  Printf.sprintf "Git chronicle %s: %s (%s%s)"
+    epoch.id epoch.label (commit_label epoch.commit_count) file_preview
+
+let learnings_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
+  [ "git_chronicle_epoch: " ^ epoch.id
+  ; "commit_count: " ^ string_of_int epoch.commit_count
+  ; Printf.sprintf "commit_range: %s..%s"
+      (short_sha epoch.start_commit)
+      (short_sha epoch.end_commit)
+  ]
+  @ List.map (fun goal_id -> "goal_id: " ^ goal_id) epoch.goal_ids
+
+let salience_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
+  let commit_signal =
+    min 0.2 (float_of_int epoch.commit_count *. 0.02)
+  in
+  let goal_signal =
+    min 0.15 (float_of_int (List.length epoch.goal_ids) *. 0.05)
+  in
+  min 0.95 (0.55 +. commit_signal +. goal_signal)
+
+let episode_of_candidate ?timestamp ~keeper_name
+    (epoch : Chronicle_ingest.candidate_epoch) : Agent_sdk.Memory.episode =
+  let summary = summary_of_candidate epoch in
+  let learnings = learnings_of_candidate epoch in
+  let context =
+    [ "source", `String "git_chronicle"
+    ; "epoch_id", `String epoch.id
+    ; "start_commit", `String epoch.start_commit
+    ; "end_commit", `String epoch.end_commit
+    ; "start_date", `String epoch.start_date
+    ; "end_date", `String epoch.end_date
+    ; "commit_count", `String (string_of_int epoch.commit_count)
+    ; "goal_ids", `String (csv epoch.goal_ids)
+    ; "file_paths", `String (csv epoch.file_paths)
+    ]
+  in
+  { id = episode_id epoch
+  ; timestamp = Option.value timestamp ~default:(Time_compat.now ())
+  ; participants = [ keeper_name ]
+  ; action = summary
+  ; outcome = Agent_sdk.Memory.Neutral
+  ; salience = salience_of_candidate epoch
+  ; metadata =
+      [ "event_type", `String "git_chronicle"
+      ; "institution_summary", `String summary
+      ; "institution_outcome", `String "partial"
+      ; "learnings", `List (List.map (fun item -> `String item) learnings)
+      ; "context", `Assoc context
+      ; "source", `String "git_chronicle"
+      ; "goal_ids", `List (List.map (fun item -> `String item) epoch.goal_ids)
+      ; "file_paths", `List (List.map (fun item -> `String item) epoch.file_paths)
+      ]
+  }
+
+let store_candidate_epoch ~memory ~keeper_name epoch =
+  Agent_sdk.Memory.store_episode memory
+    (episode_of_candidate ~keeper_name epoch)
+
+let store_candidate_epochs ~memory ~keeper_name epochs =
+  List.iter (store_candidate_epoch ~memory ~keeper_name) epochs;
+  List.length epochs

--- a/lib/chronicle_memory.mli
+++ b/lib/chronicle_memory.mli
@@ -1,0 +1,25 @@
+(** Chronicle_memory -- inject git chronicle candidates into episodic memory. *)
+
+val episode_id : Chronicle_ingest.candidate_epoch -> string
+(** Deterministic episode id for a chronicle candidate epoch. *)
+
+val episode_of_candidate :
+  ?timestamp:float ->
+  keeper_name:string ->
+  Chronicle_ingest.candidate_epoch ->
+  Agent_sdk.Memory.episode
+(** Convert a chronicle candidate epoch into an OAS episodic memory entry. *)
+
+val store_candidate_epoch :
+  memory:Agent_sdk.Memory.t ->
+  keeper_name:string ->
+  Chronicle_ingest.candidate_epoch ->
+  unit
+(** Store one candidate epoch in [memory]. *)
+
+val store_candidate_epochs :
+  memory:Agent_sdk.Memory.t ->
+  keeper_name:string ->
+  Chronicle_ingest.candidate_epoch list ->
+  int
+(** Store candidate epochs in [memory]. Returns the number of stored entries. *)

--- a/test/test_chronicle_ingest.ml
+++ b/test/test_chronicle_ingest.ml
@@ -5,6 +5,7 @@
 open Alcotest
 
 module CI = Masc_mcp.Chronicle_ingest
+module CM = Masc_mcp.Chronicle_memory
 
 (* --- parse_git_log tests --- *)
 
@@ -191,6 +192,81 @@ let test_candidate_epoch_no_goal_uses_sha () =
   check bool "id starts with year" (String.length ep.CI.id > 4) true;
   check bool "id contains cluster" (String.contains ep.CI.id '-') true
 
+(* --- chronicle memory injection tests --- *)
+
+let sample_epoch : CI.candidate_epoch =
+  { id = "PK-999"
+  ; label = "ship chronicle memory adapter"
+  ; start_commit = "abcdef1234560000"
+  ; end_commit = "abcdef1234569999"
+  ; start_date = "2026-05-01"
+  ; end_date = "2026-05-02"
+  ; goal_ids = [ "PK-999"; "task-123" ]
+  ; file_paths = [ "lib/chronicle_memory.ml"; "test/test_chronicle_ingest.ml" ]
+  ; commit_count = 2
+  }
+
+let metadata_string key metadata =
+  match List.assoc_opt key metadata with
+  | Some (`String value) -> Some value
+  | _ -> None
+
+let metadata_list key metadata =
+  match List.assoc_opt key metadata with
+  | Some (`List values) ->
+      values
+      |> List.filter_map (function
+           | `String value -> Some value
+           | _ -> None)
+  | _ -> []
+
+let metadata_context_string key metadata =
+  match List.assoc_opt "context" metadata with
+  | Some (`Assoc fields) ->
+      (match List.assoc_opt key fields with
+       | Some (`String value) -> Some value
+       | _ -> None)
+  | _ -> None
+
+let test_chronicle_memory_episode_shape () =
+  let episode =
+    CM.episode_of_candidate ~timestamp:42.0 ~keeper_name:"sangsu" sample_epoch
+  in
+  check string "deterministic id"
+    "git-chronicle-PK-999-abcdef123456" episode.id;
+  check (float 0.001) "timestamp" 42.0 episode.timestamp;
+  check string "participant" "sangsu" (List.hd episode.participants);
+  check string "event type" "git_chronicle"
+    (Option.value ~default:""
+       (metadata_string "event_type" episode.metadata));
+  check string "source context" "git_chronicle"
+    (Option.value ~default:""
+       (metadata_context_string "source" episode.metadata));
+  check string "epoch id context" "PK-999"
+    (Option.value ~default:""
+       (metadata_context_string "epoch_id" episode.metadata));
+  check bool "goal ids metadata"
+    true
+    (List.mem "task-123" (metadata_list "goal_ids" episode.metadata));
+  check bool "summary mentions commit count"
+    true
+    (String.contains episode.action '2')
+
+let test_chronicle_memory_store_recall () =
+  let memory = Agent_sdk.Memory.create () in
+  let stored =
+    CM.store_candidate_epochs ~memory ~keeper_name:"sangsu" [ sample_epoch ]
+  in
+  check int "stored count" 1 stored;
+  let recalled = Agent_sdk.Memory.recall_episodes memory ~limit:10 () in
+  check int "recalled count" 1 (List.length recalled);
+  let episode = List.hd recalled in
+  check string "recalled id"
+    "git-chronicle-PK-999-abcdef123456" episode.id;
+  check string "recalled event type" "git_chronicle"
+    (Option.value ~default:""
+       (metadata_string "event_type" episode.metadata))
+
 let () =
   run "Chronicle_ingest" [
     ("parse_git_log", [
@@ -220,5 +296,9 @@ let () =
     ("candidate_epoch", [
       test_case "fields" `Quick test_candidate_epoch_fields;
       test_case "no-goal uses sha" `Quick test_candidate_epoch_no_goal_uses_sha;
+    ]);
+    ("chronicle_memory", [
+      test_case "episode shape" `Quick test_chronicle_memory_episode_shape;
+      test_case "store recall" `Quick test_chronicle_memory_store_recall;
     ]);
   ]

--- a/test/test_chronicle_ingest.ml
+++ b/test/test_chronicle_ingest.ml
@@ -248,9 +248,12 @@ let test_chronicle_memory_episode_shape () =
   check bool "goal ids metadata"
     true
     (List.mem "task-123" (metadata_list "goal_ids" episode.metadata));
-  check bool "summary mentions commit count"
-    true
-    (String.contains episode.action '2')
+  let expected_summary =
+    "Git chronicle PK-999: ship chronicle memory adapter (2 commits; files: \
+     lib/chronicle_memory.ml, test/test_chronicle_ingest.ml)"
+  in
+  check string "summary includes structured commit count" expected_summary
+    episode.action
 
 let test_chronicle_memory_store_recall () =
   let memory = Agent_sdk.Memory.create () in


### PR DESCRIPTION
## Summary

- Adds `Chronicle_memory`, a deterministic adapter from `Chronicle_ingest.candidate_epoch` to `Agent_sdk.Memory.episode`.
- Preserves epoch id, commit range, dates, goal ids, changed files, source, and learnings in episode metadata/context.
- Adds store helpers for one or more candidate epochs.
- Extends `test_chronicle_ingest` with episode-shape and store/recall coverage.

Fixes #13527.

## Validation

- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_chronicle_ingest.exe`
- `./_build/default/test/test_chronicle_ingest.exe`
- `git diff --check HEAD~1 HEAD`