### PR TITLE
fix(dashboard): surface agent purge cleanup

### DIFF
--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -206,14 +206,16 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
    Use [join] directly. *)
 
 (** Leave room *)
-let leave config ~agent_name =
+let leave ?(stop_heartbeats = true) config ~agent_name =
   ensure_initialized config;
 
   (* Support both exact nickname match and agent_type prefix match *)
   let actual_name = resolve_agent_name config agent_name in
 
   (* Stop any heartbeats owned by this agent *)
-  let _stopped = Heartbeat.stop_by_agent ~agent_name:actual_name in
+  let _stopped =
+    if stop_heartbeats then Heartbeat.stop_by_agent ~agent_name:actual_name else 0
+  in
 
   let agent_file = Filename.concat (agents_dir config) (safe_filename actual_name ^ ".json") in
   let in_fs = Sys.file_exists agent_file in

--- a/lib/coord/coord_lifecycle.mli
+++ b/lib/coord/coord_lifecycle.mli
@@ -27,4 +27,7 @@ val join :
   string
 
 val leave :
-  Coord_utils_backend_setup.config -> agent_name:string -> string
+  ?stop_heartbeats:bool ->
+  Coord_utils_backend_setup.config ->
+  agent_name:string ->
+  string

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -16,6 +16,18 @@ type keeper_purge_target =
   ; toml_path : string option
   }
 
+type agent_purge_cleanup_result =
+  { cleanup_agent_name : string
+  ; pending_confirms_removed : int
+  ; heartbeats_stopped : int
+  ; coord_leave_result : string
+  }
+
+type keeper_purge_cleanup_result =
+  { keeper_pending_confirms_removed : int
+  ; agent_cleanup_results : agent_purge_cleanup_result list
+  }
+
 let dedupe_keep_order items =
   let seen = Hashtbl.create (List.length items) in
   List.filter
@@ -157,22 +169,46 @@ let resolve_plain_agent_target config requested_name =
   |> List.find_opt (plain_agent_artifacts_exist config)
 ;;
 
+let agent_purge_cleanup_result_to_json
+    { cleanup_agent_name
+    ; pending_confirms_removed
+    ; heartbeats_stopped
+    ; coord_leave_result
+    } =
+  `Assoc
+    [ ("agent_name", `String cleanup_agent_name)
+    ; ("pending_confirms_removed", `Int pending_confirms_removed)
+    ; ("heartbeats_stopped", `Int heartbeats_stopped)
+    ; ("coord_leave_result", `String coord_leave_result)
+    ]
+;;
+
 let purge_agent_filesystem_artifacts config agent_names =
   agent_names
   |> dedupe_keep_order
-  |> List.iter (fun agent_name ->
-       ignore
-         (Operator_pending_confirm.remove_pending_confirms_by_target config
-            ~target_type:"agent" ~target_id:(Some agent_name));
-       ignore (Heartbeat.stop_by_agent ~agent_name);
-       ignore (Coord.leave config ~agent_name);
+  |> List.map (fun agent_name ->
+       let pending_confirms_removed =
+         Operator_pending_confirm.remove_pending_confirms_by_target config
+           ~target_type:"agent" ~target_id:(Some agent_name)
+       in
+       let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
+       let coord_leave_result = Coord.leave config ~agent_name in
+       Log.Misc.info
+         "[agent_purge] cleanup agent=%s pending_confirms_removed=%d heartbeats_stopped=%d coord_leave=%S"
+         agent_name pending_confirms_removed heartbeats_stopped
+         coord_leave_result;
        remove_path_if_exists ~context:"agent_purge"
          (agent_file_path config agent_name);
        remove_path_if_exists ~context:"agent_purge"
          (Metrics_store_eio.agent_metrics_dir config agent_name);
        Tool_shard.remove_agent_shards agent_name;
        credential_aliases agent_name
-       |> List.iter (Auth.delete_credential config.base_path))
+       |> List.iter (Auth.delete_credential config.base_path);
+       { cleanup_agent_name = agent_name
+       ; pending_confirms_removed
+       ; heartbeats_stopped
+       ; coord_leave_result
+       })
 ;;
 
 let purge_keeper_artifacts config requested_name
@@ -187,11 +223,17 @@ let purge_keeper_artifacts config requested_name
   cleanup_names
   |> List.iter (fun name ->
        Keeper_keepalive.stop_keepalive ~base_path:config.base_path name);
-  ignore
-    (Operator_pending_confirm.remove_pending_confirms_by_target config
-       ~target_type:"keeper" ~target_id:(Some keeper_name));
+  let keeper_pending_confirms_removed =
+    Operator_pending_confirm.remove_pending_confirms_by_target config
+      ~target_type:"keeper" ~target_id:(Some keeper_name)
+  in
+  Log.Misc.info
+    "[keeper_purge] cleanup keeper=%s pending_confirms_removed=%d"
+    keeper_name keeper_pending_confirms_removed;
   Keeper_registry.unregister ~base_path:config.base_path keeper_name;
-  purge_agent_filesystem_artifacts config [ agent_name; keeper_name ];
+  let agent_cleanup_results =
+    purge_agent_filesystem_artifacts config [ agent_name; keeper_name ]
+  in
   List.iter
     (remove_path_if_exists ~context:"keeper_purge")
     [
@@ -210,7 +252,8 @@ let purge_keeper_artifacts config requested_name
        remove_path_if_exists ~context:"keeper_purge"
          (Keeper_types.keeper_session_dir config keeper_trace_id))
     trace_id;
-  Option.iter (remove_path_if_exists ~context:"keeper_purge") toml_path
+  Option.iter (remove_path_if_exists ~context:"keeper_purge") toml_path;
+  { keeper_pending_confirms_removed; agent_cleanup_results }
 ;;
 
 let add_delete_action_routes router =
@@ -310,7 +353,9 @@ let add_delete_action_routes router =
                (match resolve_keeper_purge_target config requested_name with
                 | Some keeper_target ->
                   let toml_deleted = Option.is_some keeper_target.toml_path in
-                  purge_keeper_artifacts config requested_name keeper_target;
+                  let purge_result =
+                    purge_keeper_artifacts config requested_name keeper_target
+                  in
                   Http.Response.json ~compress:true ~request:req
                     (Yojson.Safe.to_string
                        (`Assoc
@@ -320,12 +365,22 @@ let add_delete_action_routes router =
                             ("agent_name", `String keeper_target.agent_name);
                             ("keeper_name", `String keeper_target.keeper_name);
                             ("removed_keeper_toml", `Bool toml_deleted);
+                            ( "keeper_pending_confirms_removed",
+                              `Int purge_result.keeper_pending_confirms_removed
+                            );
+                            ( "cleanup_results",
+                              `List
+                                (List.map agent_purge_cleanup_result_to_json
+                                   purge_result.agent_cleanup_results) );
                           ]))
                     reqd
                 | None -> (
                   match resolve_plain_agent_target config requested_name with
                   | Some agent_name ->
-                    purge_agent_filesystem_artifacts config [ requested_name; agent_name ];
+                    let cleanup_results =
+                      purge_agent_filesystem_artifacts config
+                        [ requested_name; agent_name ]
+                    in
                     Http.Response.json ~compress:true ~request:req
                       (Yojson.Safe.to_string
                          (`Assoc
@@ -333,6 +388,10 @@ let add_delete_action_routes router =
                               ("ok", `Bool true);
                               ("target_kind", `String "agent");
                               ("agent_name", `String agent_name);
+                              ( "cleanup_results",
+                                `List
+                                  (List.map agent_purge_cleanup_result_to_json
+                                     cleanup_results) );
                             ]))
                       reqd
                   | None ->

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -17,10 +17,15 @@ type keeper_purge_target =
   }
 
 type agent_purge_cleanup_result =
-  { cleanup_agent_name : string
+  { agent_name : string
   ; pending_confirms_removed : int
   ; heartbeats_stopped : int
   ; coord_leave_result : string
+  }
+
+type agent_purge_cleanup_target =
+  { agent_name : string
+  ; aliases : string list
   }
 
 type keeper_purge_cleanup_result =
@@ -170,41 +175,83 @@ let resolve_plain_agent_target config requested_name =
 ;;
 
 let agent_purge_cleanup_result_to_json
-    { cleanup_agent_name
+    { agent_name
     ; pending_confirms_removed
     ; heartbeats_stopped
     ; coord_leave_result
     } =
   `Assoc
-    [ ("agent_name", `String cleanup_agent_name)
+    [ ("agent_name", `String agent_name)
     ; ("pending_confirms_removed", `Int pending_confirms_removed)
     ; ("heartbeats_stopped", `Int heartbeats_stopped)
     ; ("coord_leave_result", `String coord_leave_result)
     ]
 ;;
 
+let resolve_agent_purge_targets config agent_names =
+  let aliases_by_agent = Hashtbl.create (List.length agent_names) in
+  let order = ref [] in
+  let add_alias ~agent_name alias =
+    let aliases =
+      match Hashtbl.find_opt aliases_by_agent agent_name with
+      | Some existing -> existing
+      | None ->
+        order := agent_name :: !order;
+        []
+    in
+    Hashtbl.replace aliases_by_agent agent_name
+      (aliases @ [ alias; agent_name ] |> dedupe_keep_order)
+  in
+  agent_names
+  |> List.iter (fun requested_name ->
+       let alias = String.trim requested_name in
+       if alias <> ""
+       then (
+         let agent_name = Coord.resolve_agent_name config alias |> String.trim in
+         if agent_name <> "" then add_alias ~agent_name alias));
+  !order
+  |> List.rev
+  |> List.map (fun agent_name ->
+       let aliases =
+         Hashtbl.find_opt aliases_by_agent agent_name
+         |> Option.value ~default:[ agent_name ]
+         |> List.rev
+         |> dedupe_keep_order
+         |> List.rev
+       in
+       { agent_name; aliases })
+;;
+
 let purge_agent_filesystem_artifacts config agent_names =
   agent_names
-  |> dedupe_keep_order
-  |> List.map (fun agent_name ->
+  |> resolve_agent_purge_targets config
+  |> List.map (fun { agent_name; aliases } ->
        let pending_confirms_removed =
-         Operator_pending_confirm.remove_pending_confirms_by_target config
-           ~target_type:"agent" ~target_id:(Some agent_name)
+         aliases
+         |> List.map (fun alias ->
+              Operator_pending_confirm.remove_pending_confirms_by_target config
+                ~target_type:"agent" ~target_id:(Some alias))
+         |> List.fold_left ( + ) 0
        in
        let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
-       let coord_leave_result = Coord.leave config ~agent_name in
+       let coord_leave_result =
+         Coord.leave ~stop_heartbeats:false config ~agent_name
+       in
+       let aliases_label = String.concat "," aliases in
        Log.Misc.info
-         "[agent_purge] cleanup agent=%s pending_confirms_removed=%d heartbeats_stopped=%d coord_leave=%S"
-         agent_name pending_confirms_removed heartbeats_stopped
+         "[agent_purge] cleanup agent=%s aliases=%s pending_confirms_removed=%d heartbeats_stopped=%d coord_leave=%S"
+         agent_name aliases_label pending_confirms_removed heartbeats_stopped
          coord_leave_result;
-       remove_path_if_exists ~context:"agent_purge"
-         (agent_file_path config agent_name);
-       remove_path_if_exists ~context:"agent_purge"
-         (Metrics_store_eio.agent_metrics_dir config agent_name);
-       Tool_shard.remove_agent_shards agent_name;
-       credential_aliases agent_name
-       |> List.iter (Auth.delete_credential config.base_path);
-       { cleanup_agent_name = agent_name
+       aliases
+       |> List.iter (fun alias ->
+            remove_path_if_exists ~context:"agent_purge"
+              (agent_file_path config alias);
+            remove_path_if_exists ~context:"agent_purge"
+              (Metrics_store_eio.agent_metrics_dir config alias);
+            Tool_shard.remove_agent_shards alias;
+            credential_aliases alias
+            |> List.iter (Auth.delete_credential config.base_path));
+       { agent_name
        ; pending_confirms_removed
        ; heartbeats_stopped
        ; coord_leave_result

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -974,6 +974,20 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   require_status "agent purge route returns 200" 200 purge_result;
   check bool "agent purge identifies plain agent" true
     (contains_substr {|"target_kind":"agent"|} purge_result.body);
+  let open Yojson.Safe.Util in
+  let purge_json = Yojson.Safe.from_string purge_result.body in
+  let cleanup_rows = purge_json |> member "cleanup_results" |> to_list in
+  let cleanup_row =
+    cleanup_rows
+    |> List.find (fun row ->
+         row |> member "agent_name" |> to_string = agent_name)
+  in
+  check int "agent purge reports pending confirms" 0
+    (cleanup_row |> member "pending_confirms_removed" |> to_int);
+  check int "agent purge reports stopped heartbeats" 0
+    (cleanup_row |> member "heartbeats_stopped" |> to_int);
+  check string "agent purge reports coord leave" (agent_name ^ " left the namespace")
+    (cleanup_row |> member "coord_leave_result" |> to_string);
   check bool "agent file removed" false
     (Sys.file_exists
        (Filename.concat (Masc_mcp.Coord.agents_dir config)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -956,16 +956,19 @@ let test_keeper_directive_resume_updates_paused_meta () =
 let test_agent_purge_route_removes_plain_agent_artifacts () =
   with_seeded_server
   @@ fun ~port ~config ~admin_token ~keeper_name:_ ->
-  let agent_name = "worker-swift-fox" in
+  let requested_agent_name = "worker-swift-fox" in
+  let agent_name = "worker-swift-fox-001" in
   seed_agent_file ~capabilities:[ "coding" ] config agent_name;
   ignore
     (Masc_mcp.Auth.create_token config.base_path ~agent_name ~role:Masc_domain.Admin);
+  ignore
+    (Masc_mcp.Heartbeat.start ~agent_name ~interval:30 ~message:"route-test");
   let metrics_dir = Masc_mcp.Metrics_store_eio.agent_metrics_dir config agent_name in
   Fs_compat.mkdir_p metrics_dir;
   write_file (Filename.concat metrics_dir "2026-04.jsonl") "{}\n";
   let purge_result =
     run_curl_post
-      ~body:(Printf.sprintf {|{"agent_name":"%s"}|} agent_name)
+      ~body:(Printf.sprintf {|{"agent_name":"%s"}|} requested_agent_name)
       ~token:admin_token
       ~port
       ~path:"/api/v1/dashboard/agents/purge"
@@ -977,6 +980,8 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   let open Yojson.Safe.Util in
   let purge_json = Yojson.Safe.from_string purge_result.body in
   let cleanup_rows = purge_json |> member "cleanup_results" |> to_list in
+  check int "agent purge returns one normalized cleanup row" 1
+    (List.length cleanup_rows);
   let cleanup_row =
     cleanup_rows
     |> List.find (fun row ->
@@ -984,10 +989,12 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   in
   check int "agent purge reports pending confirms" 0
     (cleanup_row |> member "pending_confirms_removed" |> to_int);
-  check int "agent purge reports stopped heartbeats" 0
+  check int "agent purge reports stopped heartbeats" 1
     (cleanup_row |> member "heartbeats_stopped" |> to_int);
   check string "agent purge reports coord leave" (agent_name ^ " left the namespace")
     (cleanup_row |> member "coord_leave_result" |> to_string);
+  check int "agent purge leaves no duplicate heartbeat stop work" 0
+    (Masc_mcp.Heartbeat.stop_by_agent ~agent_name);
   check bool "agent file removed" false
     (Sys.file_exists
        (Filename.concat (Masc_mcp.Coord.agents_dir config)


### PR DESCRIPTION
## Summary
- return structured `cleanup_results` from `/api/v1/dashboard/agents/purge` for agent and keeper purges
- log pending-confirm cleanup counts, stopped heartbeat counts, and coord leave results during purge
- cover the plain-agent purge response contract in the dashboard keeper route test

## Why
Agent purge previously discarded cleanup outcomes from pending confirms, heartbeats, and coord leave. The purge still removed files, but operators had no response-level or log-level signal for what cleanup actually happened.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build bin/main_eio.exe test/test_dashboard_keeper_routes.exe`
- `./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 3`
- `./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 4`

Note: I also ran the full `test_dashboard_keeper_routes.exe`; the changed purge cases were fixed, while unrelated local cases 7/12 failed in this environment.