### PR TITLE
fix(dashboard): upgrade file tree semantics

### DIFF
--- a/dashboard/src/components/common/file-tree.test.ts
+++ b/dashboard/src/components/common/file-tree.test.ts
@@ -22,6 +22,12 @@ describe('FileTree', () => {
     expect(container.querySelector('[role="tree"]')).not.toBeNull()
   })
 
+  it('applies a custom aria-label', () => {
+    const container = document.createElement('div')
+    render(h(FileTree, { nodes, 'aria-label': 'Workspace files' }), container)
+    expect(container.querySelector('[role="tree"]')?.getAttribute('aria-label')).toBe('Workspace files')
+  })
+
   it('renders treeitems when expanded', () => {
     const container = document.createElement('div')
     render(h(FileTree, { nodes, expandedIds: ['d1'] }), container)
@@ -66,15 +72,47 @@ describe('FileTree', () => {
     render(h(FileTree, { nodes, onToggle }), container)
 
     const dir = container.querySelector<HTMLElement>('[data-file-tree-row="d1"]')
-    dir?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    const rightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+    dir?.dispatchEvent(rightEvent)
     await new Promise((r) => setTimeout(r, 0))
+    expect(rightEvent.defaultPrevented).toBe(true)
     expect(onToggle).toHaveBeenCalledWith('d1')
 
     render(h(FileTree, { nodes, expandedIds: ['d1'], onToggle }), container)
     const expandedDir = container.querySelector<HTMLElement>('[data-file-tree-row="d1"]')
-    expandedDir?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+    const leftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true })
+    expandedDir?.dispatchEvent(leftEvent)
     await new Promise((r) => setTimeout(r, 0))
+    expect(leftEvent.defaultPrevented).toBe(true)
     expect(onToggle).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses roving tabindex without hard-coded aria-selected', () => {
+    const container = document.createElement('div')
+    render(h(FileTree, { nodes, expandedIds: ['d1'] }), container)
+
+    const items = Array.from(container.querySelectorAll('[role="treeitem"]'))
+
+    expect(items.map(item => item.getAttribute('tabindex'))).toEqual(['0', '-1', '-1'])
+    expect(items.every(item => !item.hasAttribute('aria-selected'))).toBe(true)
+  })
+
+  it('moves focus to the first child when right arrow hits an expanded directory', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    render(h(FileTree, { nodes, expandedIds: ['d1'] }), container)
+
+    const dir = container.querySelector<HTMLElement>('[data-file-tree-row="d1"]')
+    const child = container.querySelector<HTMLElement>('[data-file-tree-row="f1"]')
+    dir?.focus()
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+    dir?.dispatchEvent(event)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(child)
+    expect(child?.getAttribute('tabindex')).toBe('0')
+    container.remove()
   })
 
   it('calls onSelect on file click', async () => {

--- a/dashboard/src/components/common/file-tree.test.ts
+++ b/dashboard/src/components/common/file-tree.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { FileTree } from './file-tree'
+import { FileTree, visibleFileTreeRows } from './file-tree'
 
 describe('FileTree', () => {
   const nodes = [
@@ -29,6 +29,15 @@ describe('FileTree', () => {
     expect(items.length).toBe(3)
   })
 
+  it('flattens visible rows with ARIA sibling metadata', () => {
+    const rows = visibleFileTreeRows(nodes, new Set(['d1']))
+    expect(rows.map(row => [row.node.id, row.depth, row.posInSet, row.setSize])).toEqual([
+      ['d1', 0, 1, 2],
+      ['f1', 1, 1, 1],
+      ['f2', 0, 2, 2],
+    ])
+  })
+
   it('shows directory arrow when collapsed', () => {
     const container = document.createElement('div')
     render(h(FileTree, { nodes }), container)
@@ -51,6 +60,23 @@ describe('FileTree', () => {
     expect(onToggle).toHaveBeenCalledWith('d1')
   })
 
+  it('supports left and right arrow directory expansion shortcuts', async () => {
+    const onToggle = vi.fn()
+    const container = document.createElement('div')
+    render(h(FileTree, { nodes, onToggle }), container)
+
+    const dir = container.querySelector<HTMLElement>('[data-file-tree-row="d1"]')
+    dir?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onToggle).toHaveBeenCalledWith('d1')
+
+    render(h(FileTree, { nodes, expandedIds: ['d1'], onToggle }), container)
+    const expandedDir = container.querySelector<HTMLElement>('[data-file-tree-row="d1"]')
+    expandedDir?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onToggle).toHaveBeenCalledTimes(2)
+  })
+
   it('calls onSelect on file click', async () => {
     const onSelect = vi.fn()
     const container = document.createElement('div')
@@ -67,6 +93,37 @@ describe('FileTree', () => {
     const items = container.querySelectorAll('[role="treeitem"]')
     expect(items[0]?.getAttribute('aria-expanded')).toBe('true')
     expect(items[2]?.hasAttribute('aria-expanded')).toBe(false)
+  })
+
+  it('applies ARIA tree position metadata to visible rows', () => {
+    const container = document.createElement('div')
+    render(h(FileTree, { nodes, expandedIds: ['d1'] }), container)
+
+    const src = container.querySelector('[data-file-tree-row="d1"]')
+    const child = container.querySelector('[data-file-tree-row="f1"]')
+    const readme = container.querySelector('[data-file-tree-row="f2"]')
+
+    expect(src?.getAttribute('aria-level')).toBe('1')
+    expect(src?.getAttribute('aria-posinset')).toBe('1')
+    expect(src?.getAttribute('aria-setsize')).toBe('2')
+    expect(child?.getAttribute('aria-level')).toBe('2')
+    expect(child?.getAttribute('aria-posinset')).toBe('1')
+    expect(child?.getAttribute('aria-setsize')).toBe('1')
+    expect(readme?.getAttribute('aria-level')).toBe('1')
+    expect(readme?.getAttribute('aria-posinset')).toBe('2')
+  })
+
+  it('renders git status as a semantic StatusChip instead of a color-only marker', () => {
+    const container = document.createElement('div')
+    render(h(FileTree, { nodes, expandedIds: ['d1'] }), container)
+
+    const status = container.querySelector('[data-file-tree-git-status="modified"]')
+    const chip = status?.querySelector('[data-status-chip]')
+
+    expect(status?.getAttribute('aria-label')).toBe('modified git status')
+    expect(chip?.textContent?.trim()).toBe('M')
+    expect(chip?.getAttribute('data-status-chip-tone')).toBe('warn')
+    expect(chip?.getAttribute('data-status-chip-uppercase')).toBe('false')
   })
 
   it('applies testId', () => {

--- a/dashboard/src/components/common/file-tree.ts
+++ b/dashboard/src/components/common/file-tree.ts
@@ -4,6 +4,7 @@
 // with git status badges.
 
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import { StatusChip, type StatusChipTone } from './status-chip'
 
 export interface FileNode {
@@ -20,6 +21,7 @@ interface FileTreeProps {
   expandedIds?: string[]
   onToggle?: (id: string) => void
   testId?: string
+  'aria-label'?: string
 }
 
 type GitStatus = NonNullable<FileNode['gitStatus']>
@@ -73,11 +75,23 @@ function activateNode(
 
 function handleTreeRowKeyDown(
   e: KeyboardEvent,
-  node: FileNode,
+  row: FileTreeRow,
+  rowIndex: number,
+  rows: ReadonlyArray<FileTreeRow>,
   expanded: ReadonlySet<string>,
+  setActiveId: (id: string) => void,
   onSelect?: (node: FileNode) => void,
   onToggle?: (id: string) => void,
 ): void {
+  const node = row.node
+  const focusRow = (nextIndex: number) => {
+    const next = rows[nextIndex]
+    if (!next) return
+    setActiveId(next.node.id)
+    const root = (e.currentTarget as HTMLElement).closest('[data-file-tree]')
+    root?.querySelector<HTMLElement>(`[data-file-tree-index="${nextIndex}"]`)?.focus()
+  }
+
   switch (e.key) {
     case 'Enter':
     case ' ':
@@ -85,16 +99,40 @@ function handleTreeRowKeyDown(
       activateNode(node, onSelect, onToggle)
       break
     case 'ArrowRight':
-      if (node.type === 'directory' && !expanded.has(node.id)) {
-        e.preventDefault()
-        onToggle?.(node.id)
+      e.preventDefault()
+      if (node.type === 'directory') {
+        if (!expanded.has(node.id)) onToggle?.(node.id)
+        else if (rows[rowIndex + 1]?.depth === row.depth + 1) focusRow(rowIndex + 1)
       }
       break
     case 'ArrowLeft':
+      e.preventDefault()
       if (node.type === 'directory' && expanded.has(node.id)) {
-        e.preventDefault()
         onToggle?.(node.id)
+      } else {
+        const parentIndex = rows
+          .slice(0, rowIndex)
+          .map((candidate, index) => ({ candidate, index }))
+          .reverse()
+          .find(({ candidate }) => candidate.depth === row.depth - 1)?.index
+        if (parentIndex != null) focusRow(parentIndex)
       }
+      break
+    case 'ArrowDown':
+      e.preventDefault()
+      focusRow(Math.min(rowIndex + 1, rows.length - 1))
+      break
+    case 'ArrowUp':
+      e.preventDefault()
+      focusRow(Math.max(rowIndex - 1, 0))
+      break
+    case 'Home':
+      e.preventDefault()
+      focusRow(0)
+      break
+    case 'End':
+      e.preventDefault()
+      focusRow(rows.length - 1)
       break
   }
 }
@@ -117,12 +155,17 @@ function renderGitStatus(status: GitStatus) {
 
 function renderRow(
   row: FileTreeRow,
+  rowIndex: number,
+  activeId: string | null,
+  rows: ReadonlyArray<FileTreeRow>,
   expanded: ReadonlySet<string>,
+  setActiveId: (id: string) => void,
   onSelect?: (node: FileNode) => void,
   onToggle?: (id: string) => void,
 ): ReturnType<typeof html> {
   const { node, depth, posInSet, setSize } = row
   const isExpanded = expanded.has(node.id)
+  const isActive = node.id === activeId
   const paddingLeft = `${depth * 16}px`
 
   return html`
@@ -131,17 +174,18 @@ function renderRow(
       class="flex min-w-0 cursor-pointer items-center gap-1 rounded-[var(--r-1)] py-0.5 pr-2 hover:bg-[var(--color-bg-hover)]"
       style=${{ paddingLeft }}
       onClick=${() => activateNode(node, onSelect, onToggle)}
+      onFocus=${() => setActiveId(node.id)}
       role="treeitem"
       aria-expanded=${node.type === 'directory' ? isExpanded : undefined}
-      aria-selected="false"
       aria-level=${depth + 1}
       aria-posinset=${posInSet}
       aria-setsize=${setSize}
       data-file-tree-row=${node.id}
+      data-file-tree-index=${rowIndex}
       data-file-tree-depth=${depth}
-      tabindex="0"
+      tabindex=${isActive ? 0 : -1}
       onKeyDown=${(e: KeyboardEvent) =>
-        handleTreeRowKeyDown(e, node, expanded, onSelect, onToggle)}
+        handleTreeRowKeyDown(e, row, rowIndex, rows, expanded, setActiveId, onSelect, onToggle)}
     >
       <span class="inline-block w-4 shrink-0 text-center text-[var(--color-fg-secondary)]" aria-hidden="true">
         ${node.type === 'directory' ? (isExpanded ? '▼' : '▶') : ' '}
@@ -158,9 +202,14 @@ export function FileTree({
   expandedIds = [],
   onToggle,
   testId,
+  'aria-label': ariaLabel = '파일 트리',
 }: FileTreeProps) {
+  const [activeId, setActiveId] = useState<string | null>(null)
   const expanded = new Set(expandedIds)
   const rows = visibleFileTreeRows(nodes, expanded)
+  const visibleActiveId = rows.some(row => row.node.id === activeId)
+    ? activeId
+    : rows[0]?.node.id ?? null
 
   return html`
     <div
@@ -168,9 +217,10 @@ export function FileTree({
       data-file-tree
       data-testid=${testId}
       role="tree"
-      aria-label="파일 트리"
+      aria-label=${ariaLabel}
     >
-      ${rows.map(row => renderRow(row, expanded, onSelect, onToggle))}
+      ${rows.map((row, rowIndex) =>
+        renderRow(row, rowIndex, visibleActiveId, rows, expanded, setActiveId, onSelect, onToggle))}
     </div>
   `
 }

--- a/dashboard/src/components/common/file-tree.ts
+++ b/dashboard/src/components/common/file-tree.ts
@@ -4,6 +4,7 @@
 // with git status badges.
 
 import { html } from 'htm/preact'
+import { StatusChip, type StatusChipTone } from './status-chip'
 
 export interface FileNode {
   id: string
@@ -21,73 +22,134 @@ interface FileTreeProps {
   testId?: string
 }
 
-function gitStatusColor(status?: string): string {
-  switch (status) {
-    case 'modified':
-      return 'var(--warn-10)'
-    case 'added':
-      return 'var(--ok-10)'
-    case 'deleted':
-      return 'var(--error-10)'
-    default:
-      return 'var(--color-fg-muted)'
+type GitStatus = NonNullable<FileNode['gitStatus']>
+
+export interface FileTreeRow {
+  readonly node: FileNode
+  readonly depth: number
+  readonly posInSet: number
+  readonly setSize: number
+}
+
+const GIT_STATUS_META: Record<
+  GitStatus,
+  { readonly label: string; readonly shortLabel: string; readonly tone: StatusChipTone }
+> = {
+  modified: { label: 'modified', shortLabel: 'M', tone: 'warn' },
+  added: { label: 'added', shortLabel: 'A', tone: 'ok' },
+  deleted: { label: 'deleted', shortLabel: 'D', tone: 'bad' },
+  untracked: { label: 'untracked', shortLabel: 'U', tone: 'neutral' },
+}
+
+export function visibleFileTreeRows(
+  nodes: ReadonlyArray<FileNode>,
+  expanded: ReadonlySet<string>,
+  depth: number = 0,
+): FileTreeRow[] {
+  const rows: FileTreeRow[] = []
+  const setSize = nodes.length
+  nodes.forEach((node, index) => {
+    rows.push({
+      node,
+      depth,
+      posInSet: index + 1,
+      setSize,
+    })
+    if (node.type === 'directory' && node.children && expanded.has(node.id)) {
+      rows.push(...visibleFileTreeRows(node.children, expanded, depth + 1))
+    }
+  })
+  return rows
+}
+
+function activateNode(
+  node: FileNode,
+  onSelect?: (node: FileNode) => void,
+  onToggle?: (id: string) => void,
+): void {
+  if (node.type === 'directory') onToggle?.(node.id)
+  else onSelect?.(node)
+}
+
+function handleTreeRowKeyDown(
+  e: KeyboardEvent,
+  node: FileNode,
+  expanded: ReadonlySet<string>,
+  onSelect?: (node: FileNode) => void,
+  onToggle?: (id: string) => void,
+): void {
+  switch (e.key) {
+    case 'Enter':
+    case ' ':
+      e.preventDefault()
+      activateNode(node, onSelect, onToggle)
+      break
+    case 'ArrowRight':
+      if (node.type === 'directory' && !expanded.has(node.id)) {
+        e.preventDefault()
+        onToggle?.(node.id)
+      }
+      break
+    case 'ArrowLeft':
+      if (node.type === 'directory' && expanded.has(node.id)) {
+        e.preventDefault()
+        onToggle?.(node.id)
+      }
+      break
   }
 }
 
-function renderNode(
-  node: FileNode,
-  depth: number,
-  expanded: Set<string>,
+function renderGitStatus(status: GitStatus) {
+  const meta = GIT_STATUS_META[status]
+  return html`
+    <span
+      class="ml-auto shrink-0"
+      data-file-tree-git-status=${status}
+      aria-label=${`${meta.label} git status`}
+      title=${`${meta.label} git status`}
+    >
+      <${StatusChip} tone=${meta.tone} uppercase=${false} class="font-mono">
+        ${meta.shortLabel}
+      </${StatusChip}>
+    </span>
+  `
+}
+
+function renderRow(
+  row: FileTreeRow,
+  expanded: ReadonlySet<string>,
   onSelect?: (node: FileNode) => void,
   onToggle?: (id: string) => void,
-): ReturnType<typeof html>[] {
+): ReturnType<typeof html> {
+  const { node, depth, posInSet, setSize } = row
   const isExpanded = expanded.has(node.id)
   const paddingLeft = `${depth * 16}px`
 
-  const row = html`
+  return html`
     <div
       key=${node.id}
-      class="flex cursor-pointer items-center rounded-[var(--r-1)] py-0.5 pr-2 hover:bg-[var(--color-bg-hover)]"
+      class="flex min-w-0 cursor-pointer items-center gap-1 rounded-[var(--r-1)] py-0.5 pr-2 hover:bg-[var(--color-bg-hover)]"
       style=${{ paddingLeft }}
-      onClick=${() =>
-        node.type === 'directory' ? onToggle?.(node.id) : onSelect?.(node)}
+      onClick=${() => activateNode(node, onSelect, onToggle)}
       role="treeitem"
       aria-expanded=${node.type === 'directory' ? isExpanded : undefined}
       aria-selected="false"
+      aria-level=${depth + 1}
+      aria-posinset=${posInSet}
+      aria-setsize=${setSize}
+      data-file-tree-row=${node.id}
+      data-file-tree-depth=${depth}
       tabindex="0"
-      onKeyDown=${(e: KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          node.type === 'directory' ? onToggle?.(node.id) : onSelect?.(node)
-        }
-      }}
+      onKeyDown=${(e: KeyboardEvent) =>
+        handleTreeRowKeyDown(e, node, expanded, onSelect, onToggle)}
     >
-      <span class="inline-block w-4 text-center text-[var(--color-fg-secondary)]" aria-hidden="true">
+      <span class="inline-block w-4 shrink-0 text-center text-[var(--color-fg-secondary)]" aria-hidden="true">
         ${node.type === 'directory' ? (isExpanded ? '▼' : '▶') : ' '}
       </span>
-      <span class="text-sm text-[var(--color-fg-primary)]">${node.name}</span>
-      ${node.gitStatus
-        ? html`
-            <span
-              class="ml-2 inline-block h-1.5 w-1.5 rounded-full"
-              style=${{ background: gitStatusColor(node.gitStatus) }}
-              title=${node.gitStatus}
-            ></span>
-          `
-        : null}
+      <span class="min-w-0 truncate text-sm text-[var(--color-fg-primary)]">${node.name}</span>
+      ${node.gitStatus ? renderGitStatus(node.gitStatus) : null}
     </div>
   `
-
-  const children: ReturnType<typeof html>[] = []
-  children.push(row)
-
-  if (node.type === 'directory' && node.children && isExpanded) {
-    for (const child of node.children) {
-      children.push(...renderNode(child, depth + 1, expanded, onSelect, onToggle))
-    }
-  }
-
-  return children
 }
 
 export function FileTree({
@@ -98,6 +160,7 @@ export function FileTree({
   testId,
 }: FileTreeProps) {
   const expanded = new Set(expandedIds)
+  const rows = visibleFileTreeRows(nodes, expanded)
 
   return html`
     <div
@@ -107,7 +170,7 @@ export function FileTree({
       role="tree"
       aria-label="파일 트리"
     >
-      ${nodes.flatMap(n => renderNode(n, 0, expanded, onSelect, onToggle))}
+      ${rows.map(row => renderRow(row, expanded, onSelect, onToggle))}
     </div>
   `
 }


### PR DESCRIPTION
## Summary

- Upgrade the shared `FileTree` molecule toward the Kimi/FileTree and RFC-0014 tree-view contract.
- Flatten visible rows with `aria-level`, `aria-posinset`, and `aria-setsize` so screen readers receive tree position context.
- Add ArrowRight/ArrowLeft directory shortcuts and replace color-only git dots with semantic `StatusChip` badges.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/file-tree.test.ts src/components/common/file-tree.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` (passes with 3 existing warnings in unrelated files)
- `pnpm --dir dashboard run build` (passes with known Vite dynamic-import and chunk-size warnings)
- Browser proof via temporary Vite QA page:
  - Screenshot: `/tmp/masc-filetree-aria-status-0506.png`
  - Verified `role="tree"`, row ARIA position metadata, and git status chips for modified/added/deleted/untracked
  - Verified no browser page errors and no horizontal overflow at `720px`

## Review Focus

- `dashboard/src/components/common/file-tree.ts`
- `dashboard/src/components/common/file-tree.test.ts`
