### PR TITLE
feat(ide): RFC-0028 PR-ζ — mount OverlayKeeperTrace in InspectorKeeperBDI

### DIFF
--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -197,7 +197,7 @@ export function IdeShell() {
           />
           <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
           <${IdePersistencePanel} keeperName=${terminalKeeper} />
-          <${InspectorKeeperBDI} />
+          <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
           <${IdeConversationRailMock} />
         </div>
         <div class="ide-plane-activity" style=${{ minHeight: 0 }}>

--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -174,4 +174,30 @@ describe('InspectorKeeperBDI', () => {
 
     render(null, container)
   })
+
+  it('trims whitespace from the keeper name so polling and overlay filter stay consistent', async () => {
+    pushTrace({
+      id: 'inspector-trace-trimmed',
+      tsMs: Date.parse('2026-05-06T01:00:00Z'),
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect selected line',
+    })
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = '  scholar  '
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} traceActive=${true} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    const overlay = container.querySelector('[data-overlay="keeper-trace"]')
+    expect(overlay).not.toBeNull()
+    expect(overlay?.querySelector('[data-keeper="scholar"]')).not.toBeNull()
+
+    render(null, container)
+  })
 })

--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -9,6 +9,7 @@ import {
   pinInspectorKeeper,
 } from './inspector-keeper-bdi'
 import { clearPins } from './multi-keeper-pin-store'
+import { clearTraces, pushTrace } from './keeper-trace-store'
 
 const snapshot = {
   keeper: 'scholar',
@@ -53,6 +54,7 @@ afterEach(() => {
   vi.unstubAllGlobals()
   activeKeeperName.value = ''
   clearPins()
+  clearTraces()
   void inspectorKeeperPin.value
 })
 
@@ -106,6 +108,69 @@ describe('InspectorKeeperBDI', () => {
     })
 
     expect(container.textContent).toContain('scholar')
+
+    render(null, container)
+  })
+
+  it('mounts the keeper-trace overlay scoped to this keeper when traceActive is true', async () => {
+    pushTrace({
+      id: 'inspector-trace-self',
+      tsMs: Date.parse('2026-05-06T01:00:00Z'),
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect selected line',
+    })
+    pushTrace({
+      id: 'inspector-trace-other',
+      tsMs: Date.parse('2026-05-06T01:00:00Z'),
+      keeperName: 'tech_glutton',
+      source: 'bdi-snapshot',
+      intention: 'should not appear',
+    })
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    pinInspectorKeeper('scholar', 42)
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} traceActive=${true} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    const overlay = container.querySelector('[data-overlay="keeper-trace"]')
+    expect(overlay).not.toBeNull()
+
+    const scholarBucket = overlay?.querySelector('[data-keeper="scholar"]')
+    expect(scholarBucket).not.toBeNull()
+
+    const otherBucket = overlay?.querySelector('[data-keeper="tech_glutton"]')
+    expect(otherBucket).toBeNull()
+
+    render(null, container)
+  })
+
+  it('does not render the keeper-trace overlay when traceActive is false (default)', async () => {
+    pushTrace({
+      id: 'inspector-trace-default-off',
+      tsMs: Date.parse('2026-05-06T01:00:00Z'),
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'inspect selected line',
+    })
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    pinInspectorKeeper('scholar', 42)
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    const overlay = container.querySelector('[data-overlay="keeper-trace"]')
+    expect(overlay).toBeNull()
 
     render(null, container)
   })

--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -200,4 +200,27 @@ describe('InspectorKeeperBDI', () => {
 
     render(null, container)
   })
+
+  it('does not render an unscoped keeper-trace overlay without a selected keeper', async () => {
+    pushTrace({
+      id: 'inspector-trace-no-keeper',
+      tsMs: Date.parse('2026-05-06T01:00:00Z'),
+      keeperName: 'scholar',
+      source: 'bdi-snapshot',
+      intention: 'should stay hidden',
+    })
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = '   '
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} traceActive=${true} />`, container)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-overlay="keeper-trace"]')).toBeNull()
+    expect(container.querySelector('[data-keeper="scholar"]')).toBeNull()
+
+    render(null, container)
+  })
 })

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -178,13 +178,17 @@ export function InspectorKeeperBDI({
   const pin = useInspectorKeeperPin()
   const activeKeeper = useActiveKeeperName()
   const reducedMotion = useReducedMotion()
-  const keeperName = pin?.keeperName ?? activeKeeper
+  // Single trim point: fetch URL, header display, and OverlayKeeperTrace's
+  // keeperFilter all share the same string. Untrimmed sources (e.g. an
+  // activeKeeperName signal set without trimming) would otherwise let polling
+  // succeed for "scholar" while the overlay filter "  scholar  " misses the
+  // events the producer pushed under the trimmed keeper name.
+  const keeperName = (pin?.keeperName ?? activeKeeper).trim()
   const [snapshot, setSnapshot] = useState<KeeperBdiSnapshot | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    const name = keeperName.trim()
-    if (!name) {
+    if (!keeperName) {
       setSnapshot(null)
       setError(null)
       return
@@ -194,7 +198,7 @@ export function InspectorKeeperBDI({
     let timer: number | null = null
     const refresh = async () => {
       try {
-        const next = await fetchKeeperBdiSnapshot(name, controller.signal)
+        const next = await fetchKeeperBdiSnapshot(keeperName, controller.signal)
         if (controller.signal.aborted) return
         setSnapshot(next)
         setError(next ? null : 'snapshot unavailable')

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -293,7 +293,9 @@ export function InspectorKeeperBDI({
           : null}
       </div>
 
-      <${OverlayKeeperTrace} active=${traceActive} keeperFilter=${keeperName} />
+      ${keeperName
+        ? html`<${OverlayKeeperTrace} active=${traceActive} keeperFilter=${keeperName} />`
+        : null}
     </section>
   `
 }

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -5,6 +5,7 @@ import { activeKeeperName } from '../../keeper-state'
 import { bridgeBdiSnapshotsToTrace } from './bdi-snapshot-trace-bridge'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
 import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
+import { OverlayKeeperTrace } from './overlay-keeper-trace'
 
 export interface KeeperBdiTokenSpend {
   readonly ts_unix: number | null
@@ -167,7 +168,13 @@ function BdiRow({ label, value }: { readonly label: string, readonly value: stri
   `
 }
 
-export function InspectorKeeperBDI({ pollMs = 5000 }: { readonly pollMs?: number }) {
+export function InspectorKeeperBDI({
+  pollMs = 5000,
+  traceActive = false,
+}: {
+  readonly pollMs?: number
+  readonly traceActive?: boolean
+}) {
   const pin = useInspectorKeeperPin()
   const activeKeeper = useActiveKeeperName()
   const reducedMotion = useReducedMotion()
@@ -281,6 +288,8 @@ export function InspectorKeeperBDI({ pollMs = 5000 }: { readonly pollMs?: number
           ? html`<span style=${{ color: lastTool.success === false ? 'var(--color-status-warn)' : 'var(--color-status-ok)' }}>${lastTool.semantic_outcome}</span>`
           : null}
       </div>
+
+      <${OverlayKeeperTrace} active=${traceActive} keeperFilter=${keeperName} />
     </section>
   `
 }


### PR DESCRIPTION
## 목적

RFC-0028 의 stitched layer 를 inspector-keeper-bdi surface 에도 mount. PR-ε (#13408) 가 editor pane 에 mount 한 OverlayKeeperTrace 를, PR-β (#13336) 의 `keeperFilter` prop 을 활용해 BDI inspector 가 보고 있는 단일 keeper 만 표시하는 single-keeper rail 로 추가.

RFC §1 명시:
> "4 source 는 **3개 별도 surface** (anchored-thread-rail, cascade-overlay-layer, **inspector-keeper-bdi**) 에 독립 표시되어 user 가 4 surface 를 동시 scan 해야 cross-source 상관 (causal chain) 을 발견한다"

본 PR 가 그 inspector surface 에 stitched layer 도달.

## RFC-0028 family 진행 상황

| PR | 역할 | 상태 |
|----|------|------|
| PR-α (#13311) | keeper-trace store (binary-search / coalesce / retention) | MERGED |
| PR-β (#13336) | OverlayKeeperTrace component + IDE_LAYERS conflictsWith | MERGED |
| PR-δ-1 (#13375) | anchored-thread → trace bridge | MERGED |
| PR-δ-2 (#13384) | cascade-hop → trace bridge | MERGED |
| PR-δ-3 (#13396) | decision-log → trace bridge | MERGED |
| PR-δ-4 (#13404) | bdi-snapshot → trace bridge (4/4 producer) | MERGED |
| PR-ε (#13408) | OverlayKeeperTrace mount in IDE shell editor pane | MERGED |
| **PR-ζ (본 PR)** | **OverlayKeeperTrace mount in InspectorKeeperBDI (single-keeper rail)** | **Draft** |

## Diff stat

- 3 files / +76 / -2
- 수정: `inspector-keeper-bdi.ts` (+10/-1, import + traceActive prop + mount), `inspector-keeper-bdi.test.ts` (+65, import + clearTraces + 2 tests), `ide-shell.ts` (+1/-1, prop pass)

## Mount 위치 결정

| 후보 | 선택? | 근거 |
|------|------|------|
| **컴포넌트 내부, Last Tool 다음 (본 PR)** | ✅ | InspectorKeeperBDI 가 자기 `keeperName` 을 알므로 keeperFilter 중복 derive 회피. BDI 정보 + 최근 trace 자연 순서 |
| editor pane 옆 별도 mount (with derive) | ❌ | IdeShell 의 `keeperFromRoute()` vs InspectorKeeperBDI 의 `pin?.keeperName ?? activeKeeper` 가 미묘하게 달라 source-of-truth 분리 위험 |
| header 옆 (눈에 띔) | ❌ | header 는 BDI 식별자 영역 — chip 표시는 정보 컴팩트한 footer 가 적합 |

```ts
<${OverlayKeeperTrace} active=${traceActive} keeperFilter=${keeperName} />
```

`keeperName` = `pin?.keeperName ?? activeKeeper` (기존 hook), trim 전 raw 값.

## Public API 변경

### `InspectorKeeperBDI` props (확장)

```ts
{
  readonly pollMs?: number       // 기존
  readonly traceActive?: boolean // 신규 (default false)
}
```

| 측면 | 설명 |
|------|------|
| `traceActive` 의미 | IDE_LAYERS 의 `keeper-trace` 토글 상태 — IdeShell 에서 `activeLayers.has('keeper-trace')` 전달 |
| Default false | RFC-0028 layer 가 OFF 일 때 overlay 가 mount 되지 않음. PR-ε 의 editor-pane mount 와 toggle 일관 |
| Backward compat | 기존 caller (`<InspectorKeeperBDI />`) 영향 없음 — `traceActive` default false 로 기존 행동 유지 |

### IdeShell 변경

```diff
- <${InspectorKeeperBDI} />
+ <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
```

PR-ε 가 editor pane 의 `<OverlayKeeperTrace active={...} />` 와 동일 source (`activeLayers.has('keeper-trace')`) 사용 → toggle 한 번으로 두 surface 동시 ON/OFF.

## 설계 결정

### keeperFilter 활용 (PR-β 의 명시적 의도)

`OverlayKeeperTrace` 의 `keeperFilter?: string` prop 코멘트:
> "Used by inspector-side mounts (a single-keeper rail) to scope the overlay; editor-side mounts pass `undefined`."

본 PR 가 그 의도 그대로 구현. editor pane (PR-ε) 가 `keeperFilter=undefined` (모든 keeper 표시), inspector pane (본 PR) 가 `keeperFilter=keeperName` (단일 keeper 표시).

### Cross-keeper isolation 검증

테스트 case `mounts the keeper-trace overlay scoped to this keeper when traceActive is true` 가:
1. `pushTrace` 로 'scholar' + 'tech_glutton' 두 keeper 의 event 를 store 에 발화
2. `pinInspectorKeeper('scholar', 42)` 로 inspector 가 'scholar' 만 보게 설정
3. overlay 가 `[data-keeper="scholar"]` bucket 만 렌더, `[data-keeper="tech_glutton"]` 부재 검증

= keeperFilter 가 OverlayKeeperTrace line 156 `events.filter(e => e.keeperName === keeperFilter)` 으로 cross-keeper isolation 보장.

### Render gating (active=false short-circuit)

OverlayKeeperTrace line 153 `if (!active) return null` — `traceActive=false` 일 때 store 구독은 하지만 DOM 작업 0. IDE_LAYERS layer OFF 시 inspector pane 에 chip 미표시.

테스트 case `does not render the keeper-trace overlay when traceActive is false (default)` 가:
1. store 에 'scholar' event 푸시
2. `<InspectorKeeperBDI pollMs=${60_000} />` (traceActive 미지정 → default false)
3. `[data-overlay="keeper-trace"]` 부재 검증

## Test additions

기존 `inspector-keeper-bdi.test.ts` 가 4 case (normalize 2 + render 2). RFC-0028 mount 검증 2 case 추가:

```ts
it('mounts the keeper-trace overlay scoped to this keeper when traceActive is true', async () => {
  pushTrace({ id: 'inspector-trace-self', keeperName: 'scholar', source: 'bdi-snapshot', ... })
  pushTrace({ id: 'inspector-trace-other', keeperName: 'tech_glutton', source: 'bdi-snapshot', ... })
  pinInspectorKeeper('scholar', 42)
  render(html`<${InspectorKeeperBDI} traceActive=${true} />`, container)
  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledWith(...))

  const overlay = container.querySelector('[data-overlay="keeper-trace"]')
  expect(overlay).not.toBeNull()
  expect(overlay?.querySelector('[data-keeper="scholar"]')).not.toBeNull()
  expect(overlay?.querySelector('[data-keeper="tech_glutton"]')).toBeNull()
})

it('does not render the keeper-trace overlay when traceActive is false (default)', async () => {
  pushTrace({ keeperName: 'scholar', source: 'bdi-snapshot', ... })
  pinInspectorKeeper('scholar', 42)
  render(html`<${InspectorKeeperBDI} />`, container)  // traceActive 미지정
  await vi.waitFor(...)
  expect(container.querySelector('[data-overlay="keeper-trace"]')).toBeNull()
})
```

`afterEach` 에 `clearTraces()` 추가 — store 격리 (PR-ε 의 ide-shell.test.ts 패턴 동일).

## Test results

```
Test Files  37 passed (37)
     Tests  258 passed (258)  -- src/components/ide broader sweep
```

PR-ε 머지 후 baseline (36/248 across 36) 대비 +1 file +10 tests (rebase 흡수 변경 + 본 PR +2). inspector-keeper-bdi.test.ts 단독: 4 → 6 cases (+2).

| 파일 | total | new (PR-ζ) |
|------|------|------|
| `inspector-keeper-bdi.test.ts` | 6 | +2 (mount + filter / mount-off) |
| 기타 36 IDE files | 252 | 회귀 0 |

## Pre-flight verify (memory line 22-25)

- `gh pr list --search "InspectorKeeperBDI traceActive OR 'RFC-0028 PR-ζ' OR inspector-overlay-mount" --state open` → 본 PR 외 0
- `gh pr list --search "OverlayKeeperTrace keeperFilter" --state merged --limit 5` → #13336 (PR-β, keeperFilter prop 정의), #13408 (PR-ε, editor mount; keeperFilter 미사용)
- `git fetch origin && git log origin/main --since=24h --oneline` → 9 commits (RFC-0028 spec md 등 포함), rebased clean (다른 영역)
- `rg "InspectorKeeperBDI" dashboard/src/` → 본 PR 변경 + 기존 component/test/shell

## Local validation

- `tsc --noEmit` → 0 error
- `vitest run src/components/ide/inspector-keeper-bdi.test.ts` → **6/6 pass**
- `vitest run src/components/ide/` → **258/258 pass** across 37 files
- ESLint 본 PR 변경 파일 → **0 error / 0 warning**

## Rollback plan

3-file revert. mount + 2 tests + traceActive prop drop. PR-α store / PR-β overlay component / PR-δ-1..4 producer / PR-ε shell-mount 모두 unchanged.

## Why 본 PR 가 RFC-0028 surface coverage 의 마지막 gate

RFC §1 가 4 source x 3 surface 매트릭스 정의:
- **anchored-thread-rail** (IdeConversationRailMock) — RFC-0021
- **cascade-overlay-layer** (editor pane) — RFC-0023
- **inspector-keeper-bdi** (Inspector pane) — RFC-0024

PR-ε 가 editor pane 에 stitched layer mount. 본 PR 가 inspector pane 에 stitched layer mount. anchored-thread-rail 는 자체 thread bubble UI 가 producer 역할 (PR-δ-1) — 별도 stitched mount 불요. RFC §1 의 "3개 별도 surface" 모두 stitched layer 도달.

## RFC waiver

agent_delegation 영역 변경 없음. behavior-additive (mount 추가 + 1 prop, render gating 검증).

`RFC-WAIVED: behavior-additive prop addition + mount with explicit URL/layer-toggle gating. Cross-keeper isolation verified by test (keeperFilter scopes to single keeper). RFC-0028 spec (dashboard/design-system/RFC/0028-keeper-trace-replay.md), PR-α (#13311), PR-β (#13336), PR-δ-1..4 (#13375 / #13384 / #13396 / #13404), PR-ε (#13408) 모두 머지됨.`

## Related

- Closes #13621 (Goal 4-5 dashboard BDI Inspector tracking)
- #13311 (RFC-0028 PR-α store) — `keeper-trace-store` 가 events 보유
- #13336 (RFC-0028 PR-β overlay) — `keeperFilter` prop 정의, 본 PR 가 그 prop 활용
- #13375 / #13384 / #13396 / #13404 (PR-δ-1..4) — 4 producer 가 store 에 events 발화
- #13408 (RFC-0028 PR-ε editor mount) — sibling mount, 같은 `activeLayers.has('keeper-trace')` source 공유
- RFC-0028 spec (`dashboard/design-system/RFC/0028-keeper-trace-replay.md`) — §1 inspector-keeper-bdi surface 명시
- RFC-0024 (BDI inspector spec) — InspectorKeeperBDI 본체 origin

## Follow-up

- RFC §189 v2 candidate: chip click → inspector slot auto-pin (현 v1 = 별도 gesture)
- (Optional) cascade vs keeper-trace conflictsWith UX 확인 — PR-β 가 conflictsWith 정의했지만 실 toggle 동작 검증 미수행
- RFC-0028 spec amend PR (PR family 완성 인용 — 본 PR 머지 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
