### PR TITLE
[codex] Fix Code IDE trace and interject state

### DIFF
--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -130,4 +130,27 @@ describe('IdeEditor', () => {
         .toContain('2 of 2 matches')
     })
   })
+
+  it('includes keeper trace in active layer summary and count', () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [],
+        activeLayers: new Set(['time', 'keeper-trace']),
+      }),
+      container,
+    )
+
+    expect(container.textContent).toContain('2 layers')
+    expect(container.querySelector('[aria-label="Active IDE overlays"]')?.textContent)
+      .toContain('Trace')
+  })
 })

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -27,7 +27,7 @@ import { KeeperBadge } from '../keeper-badge'
 
 // ── Types ─────────────────────────────────────────────────────────
 
-const IDE_LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'cascade', 'explode'] as const
+const IDE_LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'cascade', 'keeper-trace', 'explode'] as const
 type IdeLayerKind = (typeof IDE_LAYER_ORDER)[number]
 
 export type IdeEditorView = 'source' | 'split-diff' | 'unified' | 'blame'
@@ -677,6 +677,7 @@ const LAYER_LABEL: Record<IdeLayerKind, string> = {
   approve: 'Approve',
   notes: 'Notes',
   cascade: 'Cascade',
+  'keeper-trace': 'Trace',
   explode: 'EXPLODE',
 }
 
@@ -691,6 +692,7 @@ function layerSummary(kind: IdeLayerKind, latestEdit: number | null, keepers: Re
   if (kind === 'approve') return '0 approval'
   if (kind === 'notes') return '0 note'
   if (kind === 'cascade') return '0 hits'
+  if (kind === 'keeper-trace') return 'stitched trace'
   if (kind === 'explode') return 'exclusive ghost view'
   return ''
 }

--- a/dashboard/src/components/ide/ide-interject-mock.test.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.test.ts
@@ -72,4 +72,24 @@ describe('IdeInterjectMock', () => {
 
     expect(send.disabled).toBe(false)
   })
+
+  it('preserves typed message when the route keeper changes', async () => {
+    const container = document.createElement('div')
+    await act(async () => {
+      render(h(IdeInterjectMock, { keeperName: 'keeper-alpha' }), container)
+    })
+
+    const input = container.querySelector('input') as HTMLInputElement
+    await act(async () => {
+      input.value = 'keep this draft'
+      input.dispatchEvent(new InputEvent('input', { bubbles: true }))
+    })
+
+    await act(async () => {
+      render(h(IdeInterjectMock, { keeperName: 'keeper-beta' }), container)
+    })
+
+    expect(container.textContent).toContain('keeper-beta')
+    expect((container.querySelector('input') as HTMLInputElement).value).toBe('keep this draft')
+  })
 })

--- a/dashboard/src/components/ide/ide-interject-mock.test.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.test.ts
@@ -53,4 +53,23 @@ describe('IdeInterjectMock', () => {
 
     expect(send.disabled).toBe(false)
   })
+
+  it('prefers the route keeper over the global active keeper signal', async () => {
+    activeKeeperName.value = ''
+    const container = document.createElement('div')
+    await act(async () => {
+      render(h(IdeInterjectMock, { keeperName: 'tech_glutton' }), container)
+    })
+
+    expect(container.textContent).toContain('tech_glutton')
+    const input = container.querySelector('input') as HTMLInputElement
+    const send = container.querySelector('button') as HTMLButtonElement
+
+    await act(async () => {
+      input.value = 'inspect the current IDE context'
+      input.dispatchEvent(new InputEvent('input', { bubbles: true }))
+    })
+
+    expect(send.disabled).toBe(false)
+  })
 })

--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
+import type { FunctionComponent } from 'preact'
 import { dispatchKeeperInterjectAction } from '../../keeper-actions'
 import { activeKeeperName } from '../../keeper-state'
 import {
@@ -20,18 +21,30 @@ async function dispatchInterject(request: InterjectDispatchRequest): Promise<voi
   })
 }
 
-export function IdeInterjectMock() {
+interface IdeInterjectMockProps {
+  readonly keeperName?: string | null
+}
+
+function resolveActiveKeeper(keeperName?: string | null): string {
+  const routeKeeper = keeperName?.trim()
+  return routeKeeper || activeKeeperName.value
+}
+
+export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ keeperName = null }) => {
   const interjectStore = useMemo(() =>
     createInterjectStore({
-      initialActiveKeeper: activeKeeperName.value,
+      initialActiveKeeper: resolveActiveKeeper(keeperName),
       dispatch: dispatchInterject,
-    }), [])
+    }), [keeperName])
   const [, forceRender] = useState(0)
 
   useEffect(() => interjectStore.subscribe(() => forceRender(tick => tick + 1)), [interjectStore])
   useEffect(() => activeKeeperName.subscribe(name => {
-    interjectStore.setActiveKeeper(name)
-  }), [interjectStore])
+    interjectStore.setActiveKeeper(keeperName?.trim() || name)
+  }), [interjectStore, keeperName])
+  useEffect(() => {
+    interjectStore.setActiveKeeper(resolveActiveKeeper(keeperName))
+  }, [interjectStore, keeperName])
 
   const snapshot = interjectStore.snapshot()
   const actions = interjectStore.actions()

--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import type { FunctionComponent } from 'preact'
 import { dispatchKeeperInterjectAction } from '../../keeper-actions'
 import { activeKeeperName } from '../../keeper-state'
@@ -10,8 +10,8 @@ import {
 } from './interject-store'
 
 // The input and button states flow through the same store/dispatch boundary
-// that live active-keeper wiring uses. Send remains disabled until the global
-// keeper selection signal resolves to a concrete keeper.
+// that live active-keeper wiring uses. Send remains disabled until a concrete
+// keeper resolves, preferring the route-scoped keeper over the global signal.
 
 async function dispatchInterject(request: InterjectDispatchRequest): Promise<void> {
   await dispatchKeeperInterjectAction({
@@ -31,11 +31,11 @@ function resolveActiveKeeper(keeperName?: string | null): string {
 }
 
 export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ keeperName = null }) => {
-  const interjectStore = useMemo(() =>
+  const [interjectStore] = useState(() =>
     createInterjectStore({
       initialActiveKeeper: resolveActiveKeeper(keeperName),
       dispatch: dispatchInterject,
-    }), [keeperName])
+    }))
   const [, forceRender] = useState(0)
 
   useEffect(() => interjectStore.subscribe(() => forceRender(tick => tick + 1)), [interjectStore])

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -207,7 +207,7 @@ export function IdeShell() {
       ${terminalOpen
         ? html`<${KeeperShellDrawer} keeperName=${terminalKeeper} />`
         : null}
-      <${IdeInterjectMock} />
+      <${IdeInterjectMock} keeperName=${terminalKeeper} />
     </section>
   `
 }


### PR DESCRIPTION
## Summary

- Include `keeper-trace` in the Code IDE editor overlay ordering, label, count, and summary so the Trace layer appears in the active overlay chip list instead of only in the toolbar/URL state.
- Feed the route-selected keeper into the Code IDE interject rail so `keeper=tech_glutton` can drive `INTERJECT tech_glutton` even when the global active keeper signal is empty.
- Add focused regression coverage for both the trace overlay summary and route keeper precedence.

## Why

The live IDE audit showed the Trace toolbar state and URL could be active while the editor still reported only one layer, and the bottom interject rail showed no active keeper despite the route and keeper work panel being scoped to `tech_glutton`. That made the Code IDE cockpit internally inconsistent for the exact keeper workflow it was supposed to inspect.

## Validation

- Browser audit against local Vite dashboard + live MASC backend:
  - auth badge showed `Verified @dashboard · admin`
  - keeper work panel rendered live `tech_glutton` runtime state
  - `keeper-trace,time` route rendered `2 layers` and active overlays text `Time no edits` / `Trace stitched trace`
  - bottom interject rail rendered `INTERJECT tech_glutton`
  - mobile viewport 390px reported no document horizontal overflow
- `pnpm exec eslint src/components/ide/ide-editor.ts src/components/ide/ide-editor.test.ts src/components/ide/ide-interject-mock.ts src/components/ide/ide-interject-mock.test.ts src/components/ide/ide-shell.ts`
- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec vitest run --config vitest.config.ts src/components/ide/ide-editor.test.ts src/components/ide/ide-interject-mock.test.ts src/components/ide/ide-shell.test.ts src/components/ide/ide-explorer.test.ts src/components/ide/ide-keeper-work-panel.test.ts src/tab-refresh.test.ts --no-file-parallelism --maxWorkers=1` (6 files / 44 tests passed; existing localhost/socket warning noise still appears)
- `pnpm run build` (passes; existing Vite dynamic-import and chunk-size warnings remain)
