### PR TITLE
fix(dashboard): summarize memory graph state

### DIFF
--- a/dashboard/src/components/common/memory-graph.a11y.test.ts
+++ b/dashboard/src/components/common/memory-graph.a11y.test.ts
@@ -34,6 +34,16 @@ describe('MemoryGraph a11y', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
+  it('renders accessibly with selectable nodes', async () => {
+    const { nodes, edges } = makeData()
+    render(
+      html`<${MemoryGraph} nodes=${nodes} edges=${edges} onSelectNode=${vi.fn()} />`,
+      container,
+    )
+    expect(container.querySelector('svg')?.getAttribute('role')).toBe('group')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
   it('renders accessibly when empty', async () => {
     render(html`<${MemoryGraph} nodes=${[]} edges=${[]} />`, container)
     expect(await axe(container)).toHaveNoViolations()

--- a/dashboard/src/components/common/memory-graph.test.ts
+++ b/dashboard/src/components/common/memory-graph.test.ts
@@ -177,11 +177,14 @@ describe('MemoryGraph', () => {
       container,
     )
 
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('role')).toBe('group')
     const node = container.querySelector('[data-memory-graph-node="a"]')
     expect(node?.getAttribute('role')).toBe('button')
     expect(node?.getAttribute('tabindex')).toBe('0')
     expect(node?.getAttribute('aria-label')).toBe('Alpha, 1 connection')
     expect(node?.getAttribute('data-memory-graph-degree')).toBe('1')
+    expect(node?.getAttribute('class')).not.toContain('outline-none')
   })
 
   it('respects node colors', () => {

--- a/dashboard/src/components/common/memory-graph.test.ts
+++ b/dashboard/src/components/common/memory-graph.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { MemoryGraph } from './memory-graph'
+import { MemoryGraph, summarizeMemoryGraph } from './memory-graph'
 
 describe('MemoryGraph', () => {
   it('renders empty state when no nodes', () => {
@@ -27,6 +27,68 @@ describe('MemoryGraph', () => {
     expect(container.querySelector('svg')).not.toBeNull()
     expect(container.querySelectorAll('circle').length).toBe(2)
     expect(container.querySelectorAll('line').length).toBe(1)
+  })
+
+  it('summarizes linked, dangling, and isolated memory graph evidence', () => {
+    const summary = summarizeMemoryGraph(
+      [
+        { id: 'a', label: 'Alpha', x: 50, y: 50 },
+        { id: 'b', label: 'Beta', x: 150, y: 50 },
+        { id: 'c', label: 'Cold', x: 250, y: 50 },
+      ],
+      [
+        { source: 'a', target: 'b' },
+        { source: 'a', target: 'missing' },
+      ],
+    )
+
+    expect(summary.nodeCount).toBe(3)
+    expect(summary.edgeCount).toBe(2)
+    expect(summary.linkedEdgeCount).toBe(1)
+    expect(summary.danglingEdgeCount).toBe(1)
+    expect(summary.isolatedNodeCount).toBe(1)
+    expect(summary.degreeByNode.get('a')).toBe(1)
+    expect(summary.degreeByNode.get('c')).toBe(0)
+  })
+
+  it('renders summary chips for graph health', () => {
+    const container = document.createElement('div')
+    render(
+      h(MemoryGraph, {
+        nodes: [
+          { id: 'a', label: 'Alpha', x: 50, y: 50 },
+          { id: 'b', label: 'Beta', x: 150, y: 50 },
+          { id: 'c', label: 'Cold', x: 250, y: 50 },
+        ],
+        edges: [
+          { source: 'a', target: 'b' },
+          { source: 'a', target: 'missing' },
+        ],
+      }),
+      container,
+    )
+
+    const chips = Array.from(container.querySelectorAll('[data-status-chip]'))
+      .map(chip => [chip.textContent?.trim(), chip.getAttribute('data-status-chip-tone')])
+    expect(chips).toContainEqual(['nodes 3', 'neutral'])
+    expect(chips).toContainEqual(['edges 1', 'info'])
+    expect(chips).toContainEqual(['isolated 1', 'warn'])
+    expect(chips).toContainEqual(['dangling 1', 'bad'])
+  })
+
+  it('renders edge labels when provided', () => {
+    const container = document.createElement('div')
+    render(
+      h(MemoryGraph, {
+        nodes: [
+          { id: 'a', label: 'Alpha', x: 50, y: 50 },
+          { id: 'b', label: 'Beta', x: 150, y: 50 },
+        ],
+        edges: [{ source: 'a', target: 'b', label: 'recalls' }],
+      }),
+      container,
+    )
+    expect(container.querySelector('[data-memory-graph-edge-label="recalls"]')).not.toBeNull()
   })
 
   it('truncates labels to 3 chars', () => {
@@ -58,6 +120,24 @@ describe('MemoryGraph', () => {
     expect(onSelectNode).toHaveBeenCalledWith('a')
   })
 
+  it('calls onSelectNode from keyboard activation', () => {
+    const onSelectNode = vi.fn()
+    const container = document.createElement('div')
+    render(
+      h(MemoryGraph, {
+        nodes: [{ id: 'a', label: 'Alpha', x: 50, y: 50 }],
+        edges: [],
+        onSelectNode,
+      }),
+      container,
+    )
+    const node = container.querySelector('[data-memory-graph-node="a"]') as SVGGElement
+    node.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    node.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(onSelectNode).toHaveBeenCalledTimes(2)
+    expect(onSelectNode).toHaveBeenLastCalledWith('a')
+  })
+
   it('applies testId', () => {
     const container = document.createElement('div')
     render(
@@ -81,6 +161,27 @@ describe('MemoryGraph', () => {
       container,
     )
     expect(container.querySelectorAll('line').length).toBe(0)
+  })
+
+  it('describes selectable nodes with connection counts', () => {
+    const container = document.createElement('div')
+    render(
+      h(MemoryGraph, {
+        nodes: [
+          { id: 'a', label: 'Alpha', x: 50, y: 50 },
+          { id: 'b', label: 'Beta', x: 150, y: 50 },
+        ],
+        edges: [{ source: 'a', target: 'b' }],
+        onSelectNode: vi.fn(),
+      }),
+      container,
+    )
+
+    const node = container.querySelector('[data-memory-graph-node="a"]')
+    expect(node?.getAttribute('role')).toBe('button')
+    expect(node?.getAttribute('tabindex')).toBe('0')
+    expect(node?.getAttribute('aria-label')).toBe('Alpha, 1 connection')
+    expect(node?.getAttribute('data-memory-graph-degree')).toBe('1')
   })
 
   it('respects node colors', () => {

--- a/dashboard/src/components/common/memory-graph.ts
+++ b/dashboard/src/components/common/memory-graph.ts
@@ -3,8 +3,9 @@
 // Zero-dependency SVG fallback (no D3).
 
 import { html } from 'htm/preact'
+import { StatusChip } from './status-chip'
 
-interface MemoryNode {
+export interface MemoryNode {
   id: string
   label: string
   x: number
@@ -12,7 +13,7 @@ interface MemoryNode {
   color?: string
 }
 
-interface MemoryEdge {
+export interface MemoryEdge {
   source: string
   target: string
   label?: string
@@ -28,6 +29,71 @@ interface MemoryGraphProps {
   testId?: string
 }
 
+export interface MemoryGraphSummary {
+  readonly nodeCount: number
+  readonly edgeCount: number
+  readonly linkedEdgeCount: number
+  readonly danglingEdgeCount: number
+  readonly isolatedNodeCount: number
+  readonly degreeByNode: ReadonlyMap<string, number>
+}
+
+export function summarizeMemoryGraph(
+  nodes: ReadonlyArray<MemoryNode>,
+  edges: ReadonlyArray<MemoryEdge>,
+): MemoryGraphSummary {
+  const nodeIds = new Set(nodes.map(node => node.id))
+  const degreeByNode = new Map(nodes.map(node => [node.id, 0]))
+  let linkedEdgeCount = 0
+
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) continue
+    linkedEdgeCount += 1
+    degreeByNode.set(edge.source, (degreeByNode.get(edge.source) ?? 0) + 1)
+    degreeByNode.set(edge.target, (degreeByNode.get(edge.target) ?? 0) + 1)
+  }
+
+  let isolatedNodeCount = 0
+  for (const degree of degreeByNode.values()) {
+    if (degree === 0) isolatedNodeCount += 1
+  }
+
+  return {
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+    linkedEdgeCount,
+    danglingEdgeCount: edges.length - linkedEdgeCount,
+    isolatedNodeCount,
+    degreeByNode,
+  }
+}
+
+function graphAriaLabel(label: string, summary: MemoryGraphSummary): string {
+  const dangling =
+    summary.danglingEdgeCount > 0 ? `, ${summary.danglingEdgeCount} dangling edges ignored` : ''
+  const isolated =
+    summary.isolatedNodeCount > 0 ? `, ${summary.isolatedNodeCount} isolated nodes` : ''
+  return `${label}: ${summary.nodeCount} nodes, ${summary.linkedEdgeCount} linked edges${dangling}${isolated}`
+}
+
+function nodeAriaLabel(node: MemoryNode, degree: number): string {
+  return `${node.label}, ${degree} ${degree === 1 ? 'connection' : 'connections'}`
+}
+
+function edgeMidpoint(source: MemoryNode, target: MemoryNode): { readonly x: number; readonly y: number } {
+  return {
+    x: (source.x + target.x) / 2,
+    y: (source.y + target.y) / 2,
+  }
+}
+
+function handleNodeKeyDown(e: KeyboardEvent, nodeId: string, onSelectNode?: (id: string) => void): void {
+  if (!onSelectNode) return
+  if (e.key !== 'Enter' && e.key !== ' ') return
+  e.preventDefault()
+  onSelectNode(nodeId)
+}
+
 export function MemoryGraph({
   nodes,
   edges,
@@ -37,6 +103,8 @@ export function MemoryGraph({
   ariaLabel = '메모리 그래프',
   testId,
 }: MemoryGraphProps) {
+  const summary = summarizeMemoryGraph(nodes, edges)
+
   if (nodes.length === 0) {
     return html`
       <div
@@ -52,52 +120,96 @@ export function MemoryGraph({
   }
 
   const nodeMap = new Map(nodes.map((n) => [n.id, n]))
+  const visibleEdges = edges
+    .map((edge) => ({ edge, source: nodeMap.get(edge.source), target: nodeMap.get(edge.target) }))
+    .filter((entry): entry is { edge: MemoryEdge; source: MemoryNode; target: MemoryNode } =>
+      entry.source !== undefined && entry.target !== undefined,
+    )
 
   return html`
-    <figure data-testid=${testId} class="w-full overflow-auto" aria-label=${ariaLabel}>
+    <figure
+      data-memory-graph
+      data-testid=${testId}
+      class="w-full overflow-auto"
+      aria-label=${ariaLabel}
+    >
+      <figcaption class="mb-2 flex flex-wrap items-center gap-1.5 text-xs text-[var(--color-fg-muted)]">
+        <span class="mr-1 font-medium text-[var(--color-fg-primary)]">${ariaLabel}</span>
+        <${StatusChip} tone="neutral" uppercase=${false}>nodes ${summary.nodeCount}</${StatusChip}>
+        <${StatusChip} tone="info" uppercase=${false}>edges ${summary.linkedEdgeCount}</${StatusChip}>
+        ${summary.isolatedNodeCount > 0
+          ? html`<${StatusChip} tone="warn" uppercase=${false}>isolated ${summary.isolatedNodeCount}</${StatusChip}>`
+          : null}
+        ${summary.danglingEdgeCount > 0
+          ? html`<${StatusChip} tone="bad" uppercase=${false}>dangling ${summary.danglingEdgeCount}</${StatusChip}>`
+          : null}
+      </figcaption>
       <svg
+        role="img"
+        aria-label=${graphAriaLabel(ariaLabel, summary)}
         viewBox="0 0 ${width} ${height}"
         class="w-full h-auto"
-        aria-hidden="true"
       >
         <g aria-hidden="true">
-          ${edges.map((e) => {
-            const s = nodeMap.get(e.source)
-            const t = nodeMap.get(e.target)
-            if (!s || !t) return null
+          ${visibleEdges.map(({ edge, source, target }) => {
+            const midpoint = edgeMidpoint(source, target)
             return html`
-              <line
-                key=${`${e.source}-${e.target}`}
-                x1=${s.x} y1=${s.y} x2=${t.x} y2=${t.y}
-                stroke="var(--color-border-default)"
-                stroke-width="1"
-              />
+              <g key=${`${edge.source}-${edge.target}`}>
+                <line
+                  x1=${source.x} y1=${source.y} x2=${target.x} y2=${target.y}
+                  stroke="var(--color-border-default)"
+                  stroke-width="1"
+                />
+                ${edge.label
+                  ? html`
+                      <text
+                        x=${midpoint.x}
+                        y=${midpoint.y - 4}
+                        text-anchor="middle"
+                        class="pointer-events-none text-2xs fill-[var(--color-fg-muted)]"
+                        style="font-size: var(--fs-10);"
+                        data-memory-graph-edge-label=${edge.label}
+                      >
+                        ${edge.label}
+                      </text>
+                    `
+                  : null}
+              </g>
             `
           })}
         </g>
-        ${nodes.map((n) => html`
-          <g
-            key=${n.id}
-            transform="translate(${n.x}, ${n.y})"
-            class="cursor-pointer"
-            onClick=${() => onSelectNode?.(n.id)}
-          >
-            <circle
-              r="16"
-              fill=${n.color || 'var(--color-bg-surface)'}
-              stroke="var(--color-border-default)"
-              stroke-width="1"
-            />
-            <text
-              text-anchor="middle"
-              dy="4"
-              class="text-xs fill-[var(--color-fg-primary)] pointer-events-none"
-              style="font-size: var(--fs-10);"
+        ${nodes.map((node) => {
+          const degree = summary.degreeByNode.get(node.id) ?? 0
+          return html`
+            <g
+              key=${node.id}
+              transform="translate(${node.x}, ${node.y})"
+              class=${onSelectNode ? 'cursor-pointer outline-none' : ''}
+              onClick=${() => onSelectNode?.(node.id)}
+              onKeyDown=${(event: KeyboardEvent) => handleNodeKeyDown(event, node.id, onSelectNode)}
+              role=${onSelectNode ? 'button' : undefined}
+              tabindex=${onSelectNode ? 0 : undefined}
+              aria-label=${nodeAriaLabel(node, degree)}
+              data-memory-graph-node=${node.id}
+              data-memory-graph-degree=${degree}
             >
-              ${n.label.slice(0, 3)}
-            </text>
-          </g>
-        `)}
+              <circle
+                r="16"
+                fill=${node.color || 'var(--color-bg-surface)'}
+                stroke="var(--color-border-default)"
+                stroke-width="1"
+              />
+              <text
+                text-anchor="middle"
+                dy="4"
+                class="text-xs fill-[var(--color-fg-primary)] pointer-events-none"
+                style="font-size: var(--fs-10);"
+              >
+                ${node.label.slice(0, 3)}
+              </text>
+            </g>
+          `
+        })}
       </svg>
     </figure>
   `

--- a/dashboard/src/components/common/memory-graph.ts
+++ b/dashboard/src/components/common/memory-graph.ts
@@ -145,7 +145,7 @@ export function MemoryGraph({
           : null}
       </figcaption>
       <svg
-        role="img"
+        role=${onSelectNode ? 'group' : 'img'}
         aria-label=${graphAriaLabel(ariaLabel, summary)}
         viewBox="0 0 ${width} ${height}"
         class="w-full h-auto"
@@ -184,7 +184,7 @@ export function MemoryGraph({
             <g
               key=${node.id}
               transform="translate(${node.x}, ${node.y})"
-              class=${onSelectNode ? 'cursor-pointer outline-none' : ''}
+              class=${onSelectNode ? 'cursor-pointer' : ''}
               onClick=${() => onSelectNode?.(node.id)}
               onKeyDown=${(event: KeyboardEvent) => handleNodeKeyDown(event, node.id, onSelectNode)}
               role=${onSelectNode ? 'button' : undefined}


### PR DESCRIPTION
## Summary

- Upgrade the shared `MemoryGraph` molecule toward the Kimi persistence UI requirement.
- Add graph health summary chips for nodes, linked edges, isolated nodes, and dangling edges.
- Preserve edge labels, expose graph/node ARIA summaries, and make selectable SVG nodes keyboard-activatable.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/memory-graph.test.ts src/components/common/memory-graph.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard run lint` (passes with 3 existing warnings in unrelated files)
- `pnpm --dir dashboard run build` (passes with known Vite dynamic-import and chunk-size warnings)
- Browser proof via temporary Vite QA page:
  - Screenshot: `/tmp/masc-memorygraph-summary-0506.png`
  - Verified summary chips: `nodes 4`, `edges 2`, `isolated 1`, `dangling 1`
  - Verified edge labels and node ARIA labels/degrees
  - Verified keyboard activation selected the `beta` node
  - Verified no browser page errors and no horizontal overflow at `760px`

## Review Focus

- `dashboard/src/components/common/memory-graph.ts`
- `dashboard/src/components/common/memory-graph.test.ts`
