### PR TITLE
fix runtime tool cleanup cancellation masking

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -119,6 +119,33 @@ let direct_call_block_message name =
       "Tool '%s' is hidden from the default tool surface and not callable directly."
       name
 
+let cleanup_internal_keeper_runtime_resource ~during_exception ~label cleanup =
+  try cleanup () with
+  | Eio.Cancel.Cancelled _ as e when not during_exception -> raise e
+  | exn ->
+      Log.Mcp.warn
+        "internal keeper runtime %s cleanup failed%s: %s"
+        label
+        (if during_exception then " while preserving primary exception" else "")
+        (Printexc.to_string exn)
+
+let run_with_cleanup_preserving_primary ~cleanup f =
+  match f () with
+  | result ->
+      cleanup ~during_exception:false ();
+      result
+  | exception exn ->
+      let bt = Printexc.get_raw_backtrace () in
+      cleanup ~during_exception:true ();
+      Printexc.raise_with_backtrace exn bt
+
+module For_testing = struct
+  let cleanup_internal_keeper_runtime_resource =
+    cleanup_internal_keeper_runtime_resource
+
+  let run_with_cleanup_preserving_primary = run_with_cleanup_preserving_primary
+end
+
 let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
     ?mcp_session_id ?auth_token ?(internal_keeper_runtime = false) state ~name
     ~arguments =
@@ -911,16 +938,9 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
             let cleanup_one ~during_exception label = function
               | None -> ()
               | Some factory ->
-                  (try Keeper_sandbox_factory.cleanup factory with
-                   | Eio.Cancel.Cancelled _ as e when not during_exception -> raise e
-                   | exn ->
-                       Log.Mcp.warn
-                         "internal keeper runtime %s cleanup failed%s: %s"
-                         label
-                         (if during_exception
-                          then " while preserving primary exception"
-                          else "")
-                         (Printexc.to_string exn))
+                  cleanup_internal_keeper_runtime_resource
+                    ~during_exception ~label
+                    (fun () -> Keeper_sandbox_factory.cleanup factory)
             in
             let cleanup ~during_exception () =
               cleanup_one ~during_exception "sandbox" turn_sandbox_factory;
@@ -928,19 +948,11 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
             in
             let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
             let result =
-              match
+              run_with_cleanup_preserving_primary ~cleanup (fun () ->
                 Keeper_exec_tools.execute_keeper_tool_call_with_outcome
                   ~config ~meta ~ctx_work ?turn_sandbox_factory
                   ?turn_sandbox_factory_git ~exec_cache ~name
-                  ~input:coerced_args ()
-              with
-              | result ->
-                  cleanup ~during_exception:false ();
-                  result
-              | exception exn ->
-                  let bt = Printexc.get_raw_backtrace () in
-                  cleanup ~during_exception:true ();
-                  Printexc.raise_with_backtrace exn bt
+                  ~input:coerced_args ())
             in
             let success =
               match result.Keeper_exec_tools.outcome with

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -908,20 +908,39 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
                      ~default_network_override:Keeper_types.Network_inherit
                      ~config ~meta ())
             in
-            let cleanup () =
-              Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory;
-              Option.iter
-                Keeper_sandbox_factory.cleanup turn_sandbox_factory_git
+            let cleanup_one ~during_exception label = function
+              | None -> ()
+              | Some factory ->
+                  (try Keeper_sandbox_factory.cleanup factory with
+                   | Eio.Cancel.Cancelled _ as e when not during_exception -> raise e
+                   | exn ->
+                       Log.Mcp.warn
+                         "internal keeper runtime %s cleanup failed%s: %s"
+                         label
+                         (if during_exception
+                          then " while preserving primary exception"
+                          else "")
+                         (Printexc.to_string exn))
+            in
+            let cleanup ~during_exception () =
+              cleanup_one ~during_exception "sandbox" turn_sandbox_factory;
+              cleanup_one ~during_exception "git sandbox" turn_sandbox_factory_git
             in
             let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
             let result =
-              Fun.protect
-                ~finally:cleanup
-                (fun () ->
-                  Keeper_exec_tools.execute_keeper_tool_call_with_outcome
-                    ~config ~meta ~ctx_work ?turn_sandbox_factory
-                    ?turn_sandbox_factory_git ~exec_cache ~name
-                    ~input:coerced_args ())
+              match
+                Keeper_exec_tools.execute_keeper_tool_call_with_outcome
+                  ~config ~meta ~ctx_work ?turn_sandbox_factory
+                  ?turn_sandbox_factory_git ~exec_cache ~name
+                  ~input:coerced_args ()
+              with
+              | result ->
+                  cleanup ~during_exception:false ();
+                  result
+              | exception exn ->
+                  let bt = Printexc.get_raw_backtrace () in
+                  cleanup ~during_exception:true ();
+                  Printexc.raise_with_backtrace exn bt
             in
             let success =
               match result.Keeper_exec_tools.outcome with

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -76,6 +76,21 @@ val caller_agent_name_from_arguments : Yojson.Safe.t -> string option
     for direct callers and old MCP clients.  Blank and ["unknown"]
     values are ignored. *)
 
+(** {1 Test hooks} *)
+
+module For_testing : sig
+  val cleanup_internal_keeper_runtime_resource :
+    during_exception:bool -> label:string -> (unit -> unit) -> unit
+  (** Runs one internal keeper runtime cleanup action.  Non-cancellation
+      cleanup failures are logged and suppressed; cancellation is propagated
+      only when cleanup is not running behind a primary exception. *)
+
+  val run_with_cleanup_preserving_primary :
+    cleanup:(during_exception:bool -> unit -> unit) -> (unit -> 'a) -> 'a
+  (** Runs [f] and then [cleanup].  If [f] raises, cleanup runs on the
+      exception path and the original exception/backtrace is re-raised. *)
+end
+
 (** {1 [tools/call] inner dispatcher} *)
 
 val execute_tool_eio :

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1147,23 +1147,6 @@ let test_keeper_oas_cleanup_contracts () =
     (file_contains_pattern "lib/tool_compact.ml"
        "OAS-backed compaction pipeline")
 
-let test_runtime_tool_cleanup_preserves_primary_exception () =
-  check bool "runtime tool cleanup no longer uses Fun.protect finally" true
-    (file_not_contains_pattern "lib/mcp_server_eio_execute.ml"
-       "~finally:cleanup");
-  check bool "runtime tool cleanup tracks exception path" true
-    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
-       "cleanup ~during_exception:true ();");
-  check bool "runtime tool cleanup re-raises primary exception" true
-    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
-       "Printexc.raise_with_backtrace exn bt");
-  check bool "runtime tool cleanup preserves cleanup-only cancellation" true
-    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
-       "Eio.Cancel.Cancelled _ as e when not during_exception -> raise e");
-  check bool "runtime tool cleanup warns on suppressed cleanup failure" true
-    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
-       "internal keeper runtime %s cleanup failed%s: %s")
-
 let test_dashboard_executor_pool_contracts () =
   check bool "dashboard runtime support defines executor pool helper" true
     (file_contains_pattern "lib/server/server_dashboard_http_runtime_support.ml"
@@ -1672,8 +1655,6 @@ let () =
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
            test_case "local review script contracts" `Quick test_local_review_script_contracts;
            test_case "keeper oas cleanup contracts" `Quick test_keeper_oas_cleanup_contracts;
-           test_case "runtime tool cleanup preserves primary exception (#10395)" `Quick
-             test_runtime_tool_cleanup_preserves_primary_exception;
            test_case "dashboard executor pool contracts" `Quick
              test_dashboard_executor_pool_contracts;
            test_case "transport route contracts" `Quick

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1147,6 +1147,23 @@ let test_keeper_oas_cleanup_contracts () =
     (file_contains_pattern "lib/tool_compact.ml"
        "OAS-backed compaction pipeline")
 
+let test_runtime_tool_cleanup_preserves_primary_exception () =
+  check bool "runtime tool cleanup no longer uses Fun.protect finally" true
+    (file_not_contains_pattern "lib/mcp_server_eio_execute.ml"
+       "~finally:cleanup");
+  check bool "runtime tool cleanup tracks exception path" true
+    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
+       "cleanup ~during_exception:true ();");
+  check bool "runtime tool cleanup re-raises primary exception" true
+    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
+       "Printexc.raise_with_backtrace exn bt");
+  check bool "runtime tool cleanup preserves cleanup-only cancellation" true
+    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
+       "Eio.Cancel.Cancelled _ as e when not during_exception -> raise e");
+  check bool "runtime tool cleanup warns on suppressed cleanup failure" true
+    (file_contains_pattern "lib/mcp_server_eio_execute.ml"
+       "internal keeper runtime %s cleanup failed%s: %s")
+
 let test_dashboard_executor_pool_contracts () =
   check bool "dashboard runtime support defines executor pool helper" true
     (file_contains_pattern "lib/server/server_dashboard_http_runtime_support.ml"
@@ -1655,6 +1672,8 @@ let () =
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
            test_case "local review script contracts" `Quick test_local_review_script_contracts;
            test_case "keeper oas cleanup contracts" `Quick test_keeper_oas_cleanup_contracts;
+           test_case "runtime tool cleanup preserves primary exception (#10395)" `Quick
+             test_runtime_tool_cleanup_preserves_primary_exception;
            test_case "dashboard executor pool contracts" `Quick
              test_dashboard_executor_pool_contracts;
            test_case "transport route contracts" `Quick

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2347,6 +2347,29 @@ let test_handle_request_tools_call_internal_keeper_runtime_allows_keeper_interna
       Alcotest.(check bool) "keeper_bash ok" true
         Yojson.Safe.Util.(structured |> member "ok" |> to_bool))
 
+let test_internal_keeper_runtime_cleanup_preserves_primary_exception () =
+  let module T = Masc_mcp.Mcp_server_eio_execute.For_testing in
+  let cleanup_called = ref false in
+  let cleanup ~during_exception () =
+    T.cleanup_internal_keeper_runtime_resource ~during_exception
+      ~label:"test sandbox" (fun () ->
+        cleanup_called := true;
+        failwith "cleanup failed")
+  in
+  let observed =
+    try
+      ignore
+        (T.run_with_cleanup_preserving_primary ~cleanup (fun () ->
+             failwith "tool failed"));
+      None
+    with
+    | Failure message -> Some message
+    | exn -> Some (Printexc.to_string exn)
+  in
+  Alcotest.(check (option string)) "primary tool exception surfaces"
+    (Some "tool failed") observed;
+  Alcotest.(check bool) "cleanup ran on exception path" true !cleanup_called
+
 let test_handle_request_batch_rejected () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -3173,6 +3196,8 @@ let eio_tests = [
     test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_internal_tools;
   "handle tools/call internal keeper runtime allows keeper tool", `Quick,
     test_handle_request_tools_call_internal_keeper_runtime_allows_keeper_internal_tool;
+  "internal keeper runtime cleanup preserves primary exception", `Quick,
+    test_internal_keeper_runtime_cleanup_preserves_primary_exception;
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   (* TRPG tool tests removed — modules archived *)


### PR DESCRIPTION
## Summary

- replace the internal keeper runtime tool cleanup Fun.protect block with explicit success/exception handling
- preserve the original tool-call exception/backtrace when sandbox cleanup also fails or is cancelled
- keep cleanup-only cancellation propagating, and warn instead of masking the primary failure when cleanup is secondary
- add a CI source guard for the #10395 cancellation-masking regression

## Why

Issue #10395 tracks Eio cancellation paths where finalizers can hide the real failure. This dispatcher path was still using a cleanup function as a Fun.protect finalizer around runtime keeper tool execution, which meant cleanup failure could replace the actual tool-call exception and produce misleading failure surfaces.

## Validation

- git diff --check origin/main..HEAD
- ocamlc -stop-after parsing lib/mcp_server_eio_execute.ml test/test_ci_hardening_source.ml
- scripts/dune-local.sh build test/test_ci_hardening_source.exe test/test_mcp_server_eio.exe
- ./_build/default/test/test_ci_hardening_source.exe

Note: a full local ./_build/default/test/test_mcp_server_eio.exe execution was interrupted after it stalled for about five minutes after early passing cases; the target build completed and compiled the changed dispatcher module.