### PR TITLE
[P2] Expose entropic oscillation keeper wakeups

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -88,8 +88,8 @@ let turn_reason_to_string = function
   | Task_backlog _ -> "task_backlog"
   | Task_reactive_cooldown_elapsed -> "task_reactive_cooldown_elapsed"
   | Never_started -> "never_started"
-  | Min_interval_elapsed
-  | Entropic_oscillation -> "min_interval_elapsed"
+  | Min_interval_elapsed -> "min_interval_elapsed"
+  | Entropic_oscillation -> "entropic_oscillation"
 
 let skip_reason_to_string = function
   | Keeper_paused -> "keeper_paused"
@@ -1099,6 +1099,15 @@ let provider_cooldown_remaining_sec_for_cascade
           | [] -> Some 0
           | first :: rest -> Some (List.fold_left min first rest)
 
+let entropic_oscillation_interval_sec = 600
+
+let entropic_oscillation_probability_percent = 5
+
+let should_inject_entropic_oscillation
+    ~since_last_scheduled_autonomous ~draw_percent =
+  since_last_scheduled_autonomous >= entropic_oscillation_interval_sec
+  && draw_percent >= 0
+  && draw_percent < entropic_oscillation_probability_percent
 
 let keeper_cycle_decision
     ?(provider_cooldown_remaining_sec =
@@ -1229,10 +1238,10 @@ let keeper_cycle_decision
            on top defeats its purpose. Without this bypass, keepers ignore
            unclaimed work for idle_gate seconds even when the backlog signal
            is ready to fire. Ref: #7226 claim-first + idle_gate observation. *)
-        let entropic_oscillation_interval = 600 in
         let should_oscillate =
-          since_last_scheduled_autonomous >= entropic_oscillation_interval
-          && (Random.int 100 < 5)
+          should_inject_entropic_oscillation
+            ~since_last_scheduled_autonomous
+            ~draw_percent:(Random.int 100)
         in
         let should_run =
           is_bootstrap

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1239,9 +1239,10 @@ let keeper_cycle_decision
            unclaimed work for idle_gate seconds even when the backlog signal
            is ready to fire. Ref: #7226 claim-first + idle_gate observation. *)
         let should_oscillate =
-          should_inject_entropic_oscillation
-            ~since_last_scheduled_autonomous
-            ~draw_percent:(Random.int 100)
+          (not min_interval_elapsed)
+          && should_inject_entropic_oscillation
+               ~since_last_scheduled_autonomous
+               ~draw_percent:(Random.int 100)
         in
         let should_run =
           is_bootstrap

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -265,6 +265,17 @@ val effective_proactive_cooldown :
 val provider_cooldown_remaining_sec_for_cascade :
   cascade_name:Keeper_cascade_profile.runtime_name -> int option
 
+val entropic_oscillation_interval_sec : int
+(** Minimum scheduled-autonomous silence before entropy injection can wake a
+    keeper. *)
+
+val entropic_oscillation_probability_percent : int
+(** Percent chance sampled after the interval gate has elapsed. *)
+
+val should_inject_entropic_oscillation :
+  since_last_scheduled_autonomous:int -> draw_percent:int -> bool
+(** Deterministic policy predicate for the stochastic entropy wakeup. *)
+
 val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:
     (cascade_name:Keeper_cascade_profile.runtime_name -> int option) ->

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -62,6 +62,7 @@ let test_turn_reason_to_string_coverage () =
     WO.Task_reactive_cooldown_elapsed;
     WO.Never_started;
     WO.Min_interval_elapsed;
+    WO.Entropic_oscillation;
   ] in
   List.iter (fun v ->
     let s = WO.turn_reason_to_string v in
@@ -69,6 +70,32 @@ let test_turn_reason_to_string_coverage () =
       (Printf.sprintf "turn_reason_to_string(%s) is non-empty" s)
       true (String.length s > 0)
   ) variants
+
+let test_turn_reason_to_string_distinguishes_entropy () =
+  check string "min interval tag preserved"
+    "min_interval_elapsed"
+    (WO.turn_reason_to_string WO.Min_interval_elapsed);
+  check string "entropic wakeup has distinct tag"
+    "entropic_oscillation"
+    (WO.turn_reason_to_string WO.Entropic_oscillation)
+
+let test_entropic_oscillation_policy () =
+  check bool "does not inject before interval"
+    false
+    (WO.should_inject_entropic_oscillation
+       ~since_last_scheduled_autonomous:
+         (WO.entropic_oscillation_interval_sec - 1)
+       ~draw_percent:0);
+  check bool "injects at interval below probability"
+    true
+    (WO.should_inject_entropic_oscillation
+       ~since_last_scheduled_autonomous:WO.entropic_oscillation_interval_sec
+       ~draw_percent:(WO.entropic_oscillation_probability_percent - 1));
+  check bool "does not inject at probability boundary"
+    false
+    (WO.should_inject_entropic_oscillation
+       ~since_last_scheduled_autonomous:WO.entropic_oscillation_interval_sec
+       ~draw_percent:WO.entropic_oscillation_probability_percent)
 
 let test_skip_reason_to_string_coverage () =
   let variants = [
@@ -212,6 +239,8 @@ let make_obs_meta name =
     ("agent_name", `String ("agent-" ^ name));
     ("trace_id", `String ("trace-obs-" ^ name));
     ("goal", `String "observer test");
+    ("sandbox_profile", `String "local");
+    ("network_mode", `String "inherit");
   ] in
   match KTypes.meta_of_json json with
   | Ok meta -> meta
@@ -411,7 +440,11 @@ let () =
     ];
     "typed_variant_coverage", [
       test_case "turn_reason_to_string all variants" `Quick test_turn_reason_to_string_coverage;
+      test_case "turn_reason_to_string distinguishes entropy" `Quick test_turn_reason_to_string_distinguishes_entropy;
       test_case "skip_reason_to_string all variants" `Quick test_skip_reason_to_string_coverage;
+    ];
+    "entropic_oscillation", [
+      test_case "policy interval and probability boundary" `Quick test_entropic_oscillation_policy;
     ];
     "recovery_floor", [
       test_case "floor shard names non-empty" `Quick test_recovery_floor_non_empty;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1477,6 +1477,41 @@ let test_min_interval_fires_without_work_signal () =
            List.mem WO.Min_interval_elapsed (first :: rest)
        | WO.Skip _ -> false))
 
+let test_min_interval_turn_is_not_tagged_entropic () =
+  with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
+    Fun.protect ~finally:Random.self_init @@ fun () ->
+    Random.init 15;
+    let meta =
+      { minimal_meta with
+        proactive =
+          { enabled = true; idle_sec = 0; cooldown_sec = 600 };
+        runtime =
+          { minimal_meta.runtime with
+            proactive_rt =
+              { minimal_meta.runtime.proactive_rt with
+                last_ts = Time_compat.now () -. 1000.0;
+              };
+          };
+      }
+    in
+    let obs = { base_observation with idle_seconds = 0 } in
+    let decision =
+      WO.keeper_cycle_decision
+        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+        ~meta obs
+    in
+    check bool "min interval elapsed fires turn" true decision.should_run;
+    check bool "Min_interval_elapsed reason emitted" true
+      (match decision.verdict with
+       | WO.Run { reasons = (first, rest) } ->
+           List.mem WO.Min_interval_elapsed (first :: rest)
+       | WO.Skip _ -> false);
+    check bool "Min_interval_elapsed is not tagged as entropic" false
+      (match decision.verdict with
+       | WO.Run { reasons = (first, rest) } ->
+           List.mem WO.Entropic_oscillation (first :: rest)
+       | WO.Skip _ -> false))
+
 let test_min_interval_does_not_fire_before_elapsed () =
   (* With since_last = 500s and min_interval = 900s, the keeper should
      NOT get a free housekeeping turn (no work signals present either). *)
@@ -7261,6 +7296,8 @@ let () =
             test_provider_cooldown_blocks_bootstrap_turn;
           test_case "min interval: fires without work signal after interval" `Quick
             test_min_interval_fires_without_work_signal;
+          test_case "min interval: not tagged entropic" `Quick
+            test_min_interval_turn_is_not_tagged_entropic;
           test_case "min interval: does not fire before elapsed" `Quick
             test_min_interval_does_not_fire_before_elapsed;
           test_case "min interval: never fires for bootstrap turn" `Quick


### PR DESCRIPTION
## Summary
- split `Entropic_oscillation` from the `min_interval_elapsed` reason tag so prompt/runtime telemetry can identify entropy-injection wakeups
- expose the existing 600s / 5% entropic oscillation policy as a deterministic helper for tests
- update `test_decision_pipeline` fixtures to satisfy the current fail-loud sandbox policy fields

## Why it matters
Entropic oscillation is supposed to be an explicit stochastic liveness stimulus. Before this change, operator-facing reason tags collapsed it into ordinary min-interval cadence, hiding whether a keeper woke because housekeeping was due or because entropy injection fired.

This PR makes the Law 6 signal observable without changing the current policy thresholds. Operators and telemetry consumers can distinguish routine cadence from entropy-injection wakeups, which is the first bounded step before richer stochastic resonance controls.

## Verification
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_decision_pipeline.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false ./_build/default/test/test_decision_pipeline.exe`
- `git diff --check HEAD~1 HEAD`
- GitHub checks currently pass for CI Gate and Draft Auto-Merge Guard on this draft PR.

## Review focus
- Confirm `entropic_oscillation` is only used when the entropy stimulus fires, not when normal minimum-interval cadence already explains the wakeup.
- Confirm the deterministic helper preserves the current `>= 600s` / `5%` policy and exists only to make the policy testable.

Closes #13540
