### PR TITLE
fix(keeper): damp broad scope keeper chatter

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -160,6 +160,9 @@ let self_identity_tokens (meta : keeper_meta) =
   |> List.flatten
   |> List.sort_uniq String.compare
 
+let keeper_authored_message author =
+  Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name author)
+
 let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
     ((string * string) list * (string * string) list * (string * int) list) =
   let targets = message_feed_targets meta in
@@ -188,7 +191,11 @@ let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
               scope_messages
               rest
         else if broad_scope then
-          if remaining <= 0 then
+          (* Broad room scope is for operator/human context; direct mentions
+             above still allow explicit keeper-to-keeper handoff. *)
+          if keeper_authored_message author then
+            consume_room_messages remaining msg.seq mentions scope_messages rest
+          else if remaining <= 0 then
             (`Saturated, remaining, last_processed, List.rev mentions, List.rev scope_messages)
           else
             consume_room_messages

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -160,7 +160,7 @@ let self_identity_tokens (meta : keeper_meta) =
   |> List.flatten
   |> List.sort_uniq String.compare
 
-let keeper_authored_message author =
+let is_keeper_authored_message author =
   Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name author)
 
 let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
@@ -193,7 +193,7 @@ let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
         else if broad_scope then
           (* Broad room scope is for operator/human context; direct mentions
              above still allow explicit keeper-to-keeper handoff. *)
-          if keeper_authored_message author then
+          if is_keeper_authored_message author then
             consume_room_messages remaining msg.seq mentions scope_messages rest
           else if remaining <= 0 then
             (`Saturated, remaining, last_processed, List.rev mentions, List.rev scope_messages)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -796,6 +796,43 @@ let test_observe_collects_scope_messages_for_room_signal_keepers () =
       check bool "scope messages collected" true
         (List.length obs.pending_scope_messages >= 1))
 
+let test_observe_damps_keeper_scope_chatter_but_keeps_direct_mentions () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      ignore
+        (Masc_mcp.Coord.broadcast config
+           ~from_agent:"keeper-ramarama-agent"
+           ~content:"general keeper room update");
+      ignore
+        (Masc_mcp.Coord.broadcast config
+           ~from_agent:"keeper-ramarama-agent"
+           ~content:"@test-keeper please inspect this");
+      ignore
+        (Masc_mcp.Coord.broadcast config ~from_agent:"operator"
+           ~content:"general operator room update");
+      let meta = { room_signal_meta with joined_room_ids = [ "default" ] } in
+      let obs =
+        WO.observe ~allowed_tool_names:None
+          ~pending_board_events:(Some [])
+          ~config ~meta
+      in
+      check int "keeper direct mention collected" 1
+        (List.length obs.pending_mentions);
+      check int "only operator scope collected" 1
+        (List.length obs.pending_scope_messages);
+      match obs.pending_scope_messages with
+      | [ (author, content) ] ->
+          check string "scope author" "operator" author;
+          check string "scope content" "general operator room update" content
+      | _ -> fail "expected one operator scope message")
+
 let test_scheduled_turn_uses_cooldown_only () =
   let meta =
     { minimal_meta with
@@ -7201,6 +7238,8 @@ let () =
             test_observe_ignores_scope_messages_without_room_signal_opt_in;
           test_case "room-signal keepers collect scope messages" `Quick
             test_observe_collects_scope_messages_for_room_signal_keepers;
+          test_case "room-signal keepers damp keeper scope chatter" `Quick
+            test_observe_damps_keeper_scope_chatter_but_keeps_direct_mentions;
           test_case "scheduled turn uses cooldown only when work exists" `Quick
             test_scheduled_turn_uses_cooldown_only;
           test_case "scheduled turn skips without structured work signal" `Quick


### PR DESCRIPTION
## Summary

- filter generic keeper-authored room messages out of broad room-signal scope
- preserve explicit direct mentions from keeper-authored messages as reactive work
- add a regression test covering keeper chatter, keeper direct mention, and operator scope messages

## Why

Live keeper logs showed `scope_message_pending` and broad room-signal wakeups being driven by keeper-authored coordination chatter. That lets one keeper reaction fan out into more keeper reactions even when no human/operator context or direct handoff was present.

The observation cursor still advances over filtered keeper chatter, so old messages do not get replayed. Direct mentions are evaluated before the broad-scope filter, so explicit keeper-to-keeper handoffs remain reactive.

## Validation

- `git diff --check origin/main...HEAD`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test --color=never world_observation 15`
- `./_build/default/test/test_keeper_unified.exe test --color=never world_observation 16`
