### PR TITLE
fix oas attempt liveness cancellation scope

### DIFF
--- a/lib/cascade/cascade_attempt_liveness_observer.ml
+++ b/lib/cascade/cascade_attempt_liveness_observer.ml
@@ -185,12 +185,17 @@ let tick_interval_seconds (b : L.budget) : float =
   let smaller = Float.min b.ttft_max b.inter_chunk_max in
   Float.max 0.5 (smaller /. 4.0)
 
+let register_attempt_switch (t : t) ~(sw : Eio.Switch.t) : unit =
+  match t.mode with
+  | Cfg.Off -> ()
+  | Cfg.Observe | Cfg.Enforce -> t.sw_ref := Some sw
+
 let start_tick_fiber (t : t) ~(sw : Eio.Switch.t)
     ~(clock : _ Eio.Time.clock) : unit =
   match t.mode with
   | Cfg.Off -> ()
   | Cfg.Observe | Cfg.Enforce ->
-      t.sw_ref := Some sw;
+      register_attempt_switch t ~sw;
       let interval = tick_interval_seconds t.budget in
       Eio.Fiber.fork ~sw (fun () ->
           let rec loop () =

--- a/lib/cascade/cascade_attempt_liveness_observer.mli
+++ b/lib/cascade/cascade_attempt_liveness_observer.mli
@@ -71,6 +71,16 @@ val wrap_on_event :
     - [Enforce]: same as [Observe] plus may [Eio.Switch.fail] on
       [Outcome]. *)
 
+val register_attempt_switch :
+  t ->
+  sw:Eio.Switch.t ->
+  unit
+(** Register the provider-attempt switch used by enforce mode.
+
+    This is separate from {!start_tick_fiber} so callers without an
+    available Eio clock can still scope [Liveness_kill] cancellation to the
+    current provider attempt. *)
+
 val start_tick_fiber :
   t ->
   sw:Eio.Switch.t ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -433,9 +433,11 @@ let run_named
          Mode is captured once per attempt. Off short-circuits before
          observer construction so the wrapper is bit-identical to the
          baseline. Observe and Enforce wrap on_event, start a tick fiber
-         under [~sw], and finalize the per-attempt outcome counter when
-         the run returns. Enforce additionally calls [Eio.Switch.fail]
-         on the first Outcome to tear down [Oas_worker_exec.run]. *)
+         under the provider-attempt switch, and finalize the per-attempt
+         outcome counter when the run returns. Enforce additionally calls
+         [Eio.Switch.fail] on the first Outcome to tear down only the current
+         [Oas_worker_exec.run] attempt; the outer keeper/cascade switch must
+         stay alive so the FSM can fall through to the next provider. *)
       let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
       let liveness_observer_opt =
         match liveness_mode with
@@ -452,77 +454,111 @@ let run_named
                 ~provider_label:provider_cfg.model_id
                 ~started_at:(Time_compat.now ())
             in
-            (match Eio_context.get_clock_opt () with
-             | Some clock ->
-                 Cascade_attempt_liveness_observer.start_tick_fiber obs
-                   ~sw ~clock
-             | None ->
-                 (* No clock available — wrapper still emits counters
-                    via on_event but TTFT/wall checks won't fire. *)
-                 ());
             Some obs
-      in
-      let liveness_on_event =
-        match liveness_observer_opt with
-        | None -> on_event
-        | Some obs ->
-            Cascade_attempt_liveness_observer.wrap_on_event obs on_event
       in
       let finalize_liveness () =
         match liveness_observer_opt with
         | None -> ()
         | Some obs -> Cascade_attempt_liveness_observer.finalize obs
       in
+      let liveness_timeout_error failure =
+        let kind = Cascade_attempt_liveness.failure_kind_label failure in
+        Agent_sdk.Error.Api
+          (Timeout
+             {
+               message =
+                 Printf.sprintf
+                   "Cascade attempt liveness guard killed provider %s/%s: %s"
+                   cascade_name provider_cfg.model_id kind;
+             })
+      in
+      let with_liveness_attempt f =
+        let run_attempt () =
+          try
+            Eio.Switch.run (fun attempt_sw ->
+                (match liveness_observer_opt, Eio_context.get_clock_opt () with
+                 | Some obs, Some clock ->
+                     Cascade_attempt_liveness_observer.start_tick_fiber obs
+                       ~sw:attempt_sw ~clock
+                 | Some _, None ->
+                     (* No clock available — wrapper still emits counters
+                        via on_event but TTFT/wall checks won't fire. *)
+                     ()
+                 | None, _ -> ());
+                let liveness_on_event =
+                  match liveness_observer_opt with
+                  | None -> on_event
+                  | Some obs ->
+                      Cascade_attempt_liveness_observer.wrap_on_event obs
+                        on_event
+                in
+                f ~attempt_sw ~liveness_on_event)
+          with
+          | Cascade_attempt_liveness_observer.Liveness_kill failure ->
+              Error (liveness_timeout_error failure)
+          | Eio.Cancel.Cancelled _ as e -> raise e
+        in
+        match run_attempt () with
+        | result ->
+            finalize_liveness ();
+            result
+        | exception exn ->
+            let bt = Printexc.get_raw_backtrace () in
+            finalize_liveness ();
+            Printexc.raise_with_backtrace exn bt
+      in
       match
         with_codex_cli_preflight
           ~scope:(Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id)
           ~config ~goal
           (fun () ->
-            let effective_checkpoint = match resume_checkpoint with
-              | Some _ -> resume_checkpoint
-              | None -> oas_checkpoint
-            in
-            let run_fn () =
-              Oas_worker_exec.run ~sw ~net ~config
-                ?oas_checkpoint:effective_checkpoint
-                ?on_event:liveness_on_event
-                ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
-                ?contract goal
-            in
-            (* RFC-0022 §1 (in-attempt liveness layer): see
-               [Cascade_attempt_liveness_config.outer_wall_for_attempt]
-               for the rule. The legacy [per_provider_timeout_s] is
-               clipped to the profile's wall budget so slow-but-honest
-               streams (local Ollama 27B / 70B+) are not pre-empted
-               before the observer would consider them stalled. *)
-            let outer_wall_for_provider =
-              Cascade_attempt_liveness_config.outer_wall_for_attempt
-                ~mode:liveness_mode
-                ~observer_attached:(Option.is_some liveness_observer_opt)
-                ~per_provider_timeout_s
-                ~provider_label:provider_cfg.model_id
-            in
             let result =
-              match outer_wall_for_provider with
-              | None -> run_fn ()
-              | Some t ->
-                  let clock_opt =
-                    match Masc_eio_env.get_opt () with
-                    | Some env -> (
-                        match env.clock with
-                        | Some _ as clock_opt -> clock_opt
-                        | None -> Eio_context.get_clock_opt ())
-                    | None -> Eio_context.get_clock_opt ()
-                  in
-                  (match clock_opt with
-                   | Some clock ->
-                       (try Eio.Time.with_timeout_exn clock t run_fn
-                        with Eio.Time.Timeout ->
-                          Log.Misc.info
-                            "[cascade-fallback] cascade %s: provider %s per-provider timeout after %.1fs, falling back"
-                            cascade_name provider_cfg.model_id t;
-                          Error (Agent_sdk.Error.Api (Timeout { message = Printf.sprintf "Per-provider timeout after %.1fs" t })))
-                   | None -> run_fn ())
+              with_liveness_attempt
+                (fun ~attempt_sw ~liveness_on_event ->
+                   let effective_checkpoint = match resume_checkpoint with
+                     | Some _ -> resume_checkpoint
+                     | None -> oas_checkpoint
+                   in
+                   let run_fn () =
+                     Oas_worker_exec.run ~sw:attempt_sw ~net ~config
+                       ?oas_checkpoint:effective_checkpoint
+                       ?on_event:liveness_on_event
+                       ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
+                       ?contract goal
+                   in
+                   (* RFC-0022 §1 (in-attempt liveness layer): see
+                      [Cascade_attempt_liveness_config.outer_wall_for_attempt]
+                      for the rule. The legacy [per_provider_timeout_s] is
+                      clipped to the profile's wall budget so slow-but-honest
+                      streams (local Ollama 27B / 70B+) are not pre-empted
+                      before the observer would consider them stalled. *)
+                   let outer_wall_for_provider =
+                     Cascade_attempt_liveness_config.outer_wall_for_attempt
+                       ~mode:liveness_mode
+                       ~observer_attached:(Option.is_some liveness_observer_opt)
+                       ~per_provider_timeout_s
+                       ~provider_label:provider_cfg.model_id
+                   in
+                   match outer_wall_for_provider with
+                   | None -> run_fn ()
+                   | Some t ->
+                       let clock_opt =
+                         match Masc_eio_env.get_opt () with
+                         | Some env -> (
+                             match env.clock with
+                             | Some _ as clock_opt -> clock_opt
+                             | None -> Eio_context.get_clock_opt ())
+                         | None -> Eio_context.get_clock_opt ()
+                       in
+                       (match clock_opt with
+                        | Some clock ->
+                            (try Eio.Time.with_timeout_exn clock t run_fn
+                             with Eio.Time.Timeout ->
+                               Log.Misc.info
+                                 "[cascade-fallback] cascade %s: provider %s per-provider timeout after %.1fs, falling back"
+                                 cascade_name provider_cfg.model_id t;
+                               Error (Agent_sdk.Error.Api (Timeout { message = Printf.sprintf "Per-provider timeout after %.1fs" t })))
+                        | None -> run_fn ()))
             in
             Ok result)
     with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -476,6 +476,11 @@ let run_named
         let run_attempt () =
           try
             Eio.Switch.run (fun attempt_sw ->
+                (match liveness_observer_opt with
+                 | Some obs ->
+                     Cascade_attempt_liveness_observer.register_attempt_switch
+                       obs ~sw:attempt_sw
+                 | None -> ());
                 (match liveness_observer_opt, Eio_context.get_clock_opt () with
                  | Some obs, Some clock ->
                      Cascade_attempt_liveness_observer.start_tick_fiber obs

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -12,9 +12,10 @@
 
     2. The observer module is reachable through the
        [Cascade_attempt_liveness_observer.{create, wrap_on_event,
-       finalize}] surface that try_provider depends on, with the
-       expected mode contract (Off pass-through; Observe wraps; Enforce
-       wraps + raises). Same surface, exercised end-to-end.
+       register_attempt_switch, finalize}] surface that try_provider
+       depends on, with the expected mode contract (Off pass-through;
+       Observe wraps; Enforce wraps + scopes cancellation to the provider
+       attempt switch even when no clock is available).
 
     3. End-to-end finalize emits the observed_total counter with the
        outcome label that try_provider's `finalize_liveness ()` call
@@ -25,33 +26,6 @@ module Cfg = Cascade_attempt_liveness_config
 module Obs = Cascade_attempt_liveness_observer
 
 let env_var = "MASC_CASCADE_ATTEMPT_LIVENESS"
-
-let source_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root -> root
-  | None -> Sys.getcwd ()
-
-let source_path file_rel = Filename.concat (source_root ()) file_rel
-
-let string_contains haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else
-    let rec loop idx =
-      idx + needle_len <= haystack_len
-      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
-    in
-    loop 0
-
-let file_contains_pattern file_rel pattern =
-  let path = source_path file_rel in
-  if not (Sys.file_exists path) then false
-  else
-    let ic = open_in path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () -> string_contains (In_channel.input_all ic) pattern)
 
 let with_env value f =
   let prior = Sys.getenv_opt env_var in
@@ -143,27 +117,35 @@ let test_e2e_off_no_observed_total () =
       Alcotest.(check (float 1e-6))
         "Off finalize emits no observed counter" before after)
 
-let test_enforce_uses_provider_attempt_switch_contract () =
-  let file = "lib/oas_worker_named.ml" in
-  Alcotest.(check bool)
-    "liveness tick fiber runs under attempt switch"
-    true
-    (file_contains_pattern file
-       "Cascade_attempt_liveness_observer.start_tick_fiber obs\n                       ~sw:attempt_sw ~clock");
-  Alcotest.(check bool)
-    "OAS run uses attempt switch"
-    true
-    (file_contains_pattern file "Oas_worker_exec.run ~sw:attempt_sw");
-  Alcotest.(check bool)
-    "liveness kill is converted to provider error"
-    true
-    (file_contains_pattern file
-       "Cascade_attempt_liveness_observer.Liveness_kill failure");
-  Alcotest.(check bool)
-    "converted liveness kill is timeout-like"
-    true
-    (file_contains_pattern file
-       "Cascade attempt liveness guard killed provider %s/%s: %s")
+let test_enforce_registered_switch_kills_attempt_without_tick_clock () =
+  let cascade = "integ_enforce_cascade" in
+  let provider = "integ_enforce_provider" in
+  let raised = ref None in
+  with_env (Some "enforce") (fun () ->
+      Eio_main.run (fun _env ->
+          try
+            Eio.Switch.run (fun attempt_sw ->
+                let mode = Cfg.current_mode () in
+                let budget = Cfg.budget_for_label provider in
+                let obs =
+                  Obs.create ~mode ~budget ~cascade_label:cascade
+                    ~provider_label:provider ~started_at:0.0
+                in
+                Obs.register_attempt_switch obs ~sw:attempt_sw;
+                let wrapped = Obs.wrap_on_event obs None in
+                (match wrapped with
+                 | Some f -> f (Agent_sdk.Types.SSEError "wire boom")
+                 | None -> Alcotest.fail "Enforce should wrap");
+                Eio.Fiber.yield ())
+          with
+          | Obs.Liveness_kill failure ->
+              raised := Some (Cascade_attempt_liveness.failure_kind_label failure)
+          | exn ->
+              Alcotest.failf "unexpected exception: %s" (Printexc.to_string exn)));
+  Alcotest.(check (option string))
+    "registered attempt switch receives enforce kill without tick fiber"
+    (Some "provider_error")
+    !raised
 
 let () =
   Alcotest.run "oas_worker_named_liveness_integration"
@@ -185,7 +167,7 @@ let () =
       ( "source contract",
         [
           Alcotest.test_case
-            "enforce kill is scoped to provider-attempt switch" `Quick
-            test_enforce_uses_provider_attempt_switch_contract;
+            "enforce kill is scoped without clock tick fiber" `Quick
+            test_enforce_registered_switch_kills_attempt_without_tick_clock;
         ] );
     ]

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -26,6 +26,33 @@ module Obs = Cascade_attempt_liveness_observer
 
 let env_var = "MASC_CASCADE_ATTEMPT_LIVENESS"
 
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let source_path file_rel = Filename.concat (source_root ()) file_rel
+
+let string_contains haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop idx =
+      idx + needle_len <= haystack_len
+      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
+    in
+    loop 0
+
+let file_contains_pattern file_rel pattern =
+  let path = source_path file_rel in
+  if not (Sys.file_exists path) then false
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> string_contains (In_channel.input_all ic) pattern)
+
 let with_env value f =
   let prior = Sys.getenv_opt env_var in
   (match value with
@@ -116,6 +143,28 @@ let test_e2e_off_no_observed_total () =
       Alcotest.(check (float 1e-6))
         "Off finalize emits no observed counter" before after)
 
+let test_enforce_uses_provider_attempt_switch_contract () =
+  let file = "lib/oas_worker_named.ml" in
+  Alcotest.(check bool)
+    "liveness tick fiber runs under attempt switch"
+    true
+    (file_contains_pattern file
+       "Cascade_attempt_liveness_observer.start_tick_fiber obs\n                       ~sw:attempt_sw ~clock");
+  Alcotest.(check bool)
+    "OAS run uses attempt switch"
+    true
+    (file_contains_pattern file "Oas_worker_exec.run ~sw:attempt_sw");
+  Alcotest.(check bool)
+    "liveness kill is converted to provider error"
+    true
+    (file_contains_pattern file
+       "Cascade_attempt_liveness_observer.Liveness_kill failure");
+  Alcotest.(check bool)
+    "converted liveness kill is timeout-like"
+    true
+    (file_contains_pattern file
+       "Cascade attempt liveness guard killed provider %s/%s: %s")
+
 let () =
   Alcotest.run "oas_worker_named_liveness_integration"
     [
@@ -132,5 +181,11 @@ let () =
             `Quick test_e2e_observe_finalize_emits_observed_total;
           Alcotest.test_case "Off e2e emits nothing" `Quick
             test_e2e_off_no_observed_total;
+        ] );
+      ( "source contract",
+        [
+          Alcotest.test_case
+            "enforce kill is scoped to provider-attempt switch" `Quick
+            test_enforce_uses_provider_attempt_switch_contract;
         ] );
     ]


### PR DESCRIPTION
## Summary

- run each OAS cascade provider attempt inside a provider-attempt sub-switch
- start the attempt-liveness tick fiber under that sub-switch and pass the same sub-switch into Oas_worker_exec.run
- convert enforce-mode liveness kills into a timeout-like provider error so the cascade FSM can try the next provider instead of cancelling the outer keeper/cascade switch
- add a source contract test for the #11929 attempt-switch boundary

## Why

Issue #11929 is about OAS-internal cancellation guard behavior for bimodal hangs. Current main already has the RFC-0022 liveness observer, but enforce-mode kills were wired to the caller's outer switch. That can terminate the whole keeper/cascade scope, which defeats the contract that a bad provider attempt should fail fast while the turn lives and falls through to the next provider.

## Validation

- git diff --check origin/main..HEAD
- ocamlc -stop-after parsing lib/oas_worker_named.ml test/test_oas_worker_named_liveness_integration.ml
- scripts/dune-local.sh build test/test_oas_worker_named_liveness_integration.exe
- ./_build/default/test/test_oas_worker_named_liveness_integration.exe