### PR TITLE
fix(dashboard): classify agent output announcements

### DIFF
--- a/dashboard/src/components/common/agent-output-announcer.a11y.test.ts
+++ b/dashboard/src/components/common/agent-output-announcer.a11y.test.ts
@@ -4,7 +4,12 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { html } from 'htm/preact'
 import { axe } from 'jest-axe'
-import { AgentOutputAnnouncer, announceAgentOutput } from './agent-output-announcer'
+import {
+  AgentOutputAnnouncer,
+  announceAgentOutput,
+  resolveAgentOutputPriority,
+  summarizeAgentOutput,
+} from './agent-output-announcer'
 
 describe('AgentOutputAnnouncer a11y', () => {
   let container: HTMLElement
@@ -42,6 +47,7 @@ describe('AgentOutputAnnouncer a11y', () => {
     const region = container.querySelector('[aria-live="polite"]')
     expect(region).not.toBeNull()
     expect(region?.getAttribute('aria-atomic')).toBe('false')
+    expect(region?.getAttribute('aria-relevant')).toBe('additions text')
     expect(region?.getAttribute('aria-label')).toBe('에이전트 출력 알림')
   })
 
@@ -57,6 +63,44 @@ describe('AgentOutputAnnouncer a11y', () => {
     const region = container.querySelector('[aria-live="assertive"]')
     expect(region).not.toBeNull()
     expect(region?.getAttribute('aria-atomic')).toBe('true')
+  })
+
+  it('uses auto priority to promote errors to assertive announcements', async () => {
+    renderInAct(
+      html`<${AgentOutputAnnouncer}
+          outputs=${[{ id: 'error-1', type: 'error', content: 'Failed' }]}
+          priority=${'auto'}
+        />
+      `,
+      container,
+    )
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    const region = container.querySelector('[aria-live="assertive"]')
+    expect(region).not.toBeNull()
+    expect(region?.getAttribute('data-agent-output-announcer-output-id')).toBe('error-1')
+    expect(region?.getAttribute('data-agent-output-announcer-output-type')).toBe('error')
+  })
+
+  it('keeps auto priority polite for non-error announcements', () => {
+    expect(resolveAgentOutputPriority(
+      { id: 'text-1', type: 'text', content: 'ok' },
+      'auto',
+    )).toBe('polite')
+  })
+
+  it('returns structured announcement metadata', () => {
+    expect(summarizeAgentOutput(
+      { id: 'code-1', type: 'code', content: 'let x = 1', metadata: { language: 'ocaml', lineCount: 1 } },
+      'auto',
+    )).toEqual({
+      id: 'code-1',
+      type: 'code',
+      message: '코드 출력, ocaml 언어, 1 줄',
+      priority: 'polite',
+      contentLength: 9,
+    })
   })
 
   it('announces text output', () => {
@@ -137,6 +181,7 @@ describe('AgentOutputAnnouncer a11y', () => {
     })
     const region = container.querySelector('[aria-live]') as HTMLDivElement
     expect(region?.textContent).toBe('텍스트 출력: First')
+    expect(region?.getAttribute('data-agent-output-announcer-output-id')).toBe('1')
 
     const next = [
       ...outputs,
@@ -147,6 +192,30 @@ describe('AgentOutputAnnouncer a11y', () => {
       await new Promise((r) => setTimeout(r, 0))
     })
     expect(region?.textContent).toBe('오류 발생: Failed')
+    expect(region?.getAttribute('data-agent-output-announcer-output-id')).toBe('2')
+  })
+
+  it('updates live region when the latest output id changes at the same count', async () => {
+    const { rerender } = renderInAct(
+      html`<${AgentOutputAnnouncer}
+          outputs=${[{ id: '1', type: 'text', content: 'First' }]}
+        />`,
+      container,
+    )
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    const region = container.querySelector('[aria-live]') as HTMLDivElement
+    expect(region?.textContent).toBe('텍스트 출력: First')
+
+    rerender(html`<${AgentOutputAnnouncer}
+        outputs=${[{ id: '2', type: 'text', content: 'Second' }]}
+      />`)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(region?.textContent).toBe('텍스트 출력: Second')
+    expect(region?.getAttribute('data-agent-output-announcer-output-id')).toBe('2')
   })
 })
 

--- a/dashboard/src/components/common/agent-output-announcer.test.ts
+++ b/dashboard/src/components/common/agent-output-announcer.test.ts
@@ -113,12 +113,21 @@ describe('AgentOutputAnnouncer', () => {
     const outputs = [{ id: 'o-error', type: 'error' as const, content: 'disk full' }]
     render(h(AgentOutputAnnouncer, { outputs, priority: 'polite' }), container)
     await new Promise((r) => setTimeout(r, 10))
+    const el = container.querySelector('[role="log"]') as HTMLElement
+    const textMutations: string[] = []
+    const observer = new MutationObserver(() => {
+      textMutations.push(el.textContent ?? '')
+    })
+    observer.observe(el, { childList: true, characterData: true, subtree: true })
+
     render(h(AgentOutputAnnouncer, { outputs, priority: 'auto' }), container)
     await new Promise((r) => setTimeout(r, 10))
+    observer.disconnect()
 
-    const el = container.querySelector('[role="log"]') as HTMLElement
     expect(el?.getAttribute('aria-live')).toBe('assertive')
     expect(el?.getAttribute('data-agent-output-announcer-priority')).toBe('assertive')
+    expect(textMutations).toContain('')
+    expect(textMutations.at(-1)).toBe('오류 발생: disk full')
   })
 
   it('renders aria-label', () => {
@@ -165,5 +174,31 @@ describe('AgentOutputAnnouncer', () => {
     const el = container.querySelector('[role="log"]') as HTMLElement
     expect(el?.textContent).toContain('second')
     expect(el?.getAttribute('data-agent-output-announcer-output-id')).toBe('o2')
+  })
+
+  it('re-adds identical announcement text when only the output id changes', async () => {
+    const container = document.createElement('div')
+    render(h(AgentOutputAnnouncer, {
+      outputs: [{ id: 'o1', type: 'text', content: 'same message' }],
+    }), container)
+    await new Promise((r) => setTimeout(r, 10))
+
+    const el = container.querySelector('[role="log"]') as HTMLElement
+    const textMutations: string[] = []
+    const observer = new MutationObserver(() => {
+      textMutations.push(el.textContent ?? '')
+    })
+    observer.observe(el, { childList: true, characterData: true, subtree: true })
+
+    render(h(AgentOutputAnnouncer, {
+      outputs: [{ id: 'o2', type: 'text', content: 'same message' }],
+    }), container)
+    await new Promise((r) => setTimeout(r, 10))
+    observer.disconnect()
+
+    expect(el?.textContent).toBe('텍스트 출력: same message')
+    expect(el?.getAttribute('data-agent-output-announcer-output-id')).toBe('o2')
+    expect(textMutations).toContain('')
+    expect(textMutations.at(-1)).toBe('텍스트 출력: same message')
   })
 })

--- a/dashboard/src/components/common/agent-output-announcer.test.ts
+++ b/dashboard/src/components/common/agent-output-announcer.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentOutputAnnouncer, announceAgentOutput } from './agent-output-announcer'
+import {
+  AgentOutputAnnouncer,
+  announceAgentOutput,
+  resolveAgentOutputPriority,
+  summarizeAgentOutput,
+} from './agent-output-announcer'
 
 describe('announceAgentOutput', () => {
   it('announces code output', () => {
@@ -44,6 +49,26 @@ describe('announceAgentOutput', () => {
     expect(announceAgentOutput(out)).toContain('텍스트 출력')
     expect(announceAgentOutput(out)).toContain('300')
   })
+
+  it('summarizes output identity, type, priority, and content length', () => {
+    const summary = summarizeAgentOutput(
+      { id: 'o8', type: 'error', content: 'failed' },
+      'auto',
+    )
+    expect(summary).toEqual({
+      id: 'o8',
+      type: 'error',
+      message: '오류 발생: failed',
+      priority: 'assertive',
+      contentLength: 6,
+    })
+  })
+
+  it('classifies auto live-region priority by output type', () => {
+    expect(resolveAgentOutputPriority({ id: 't', type: 'text', content: 'ok' }, 'auto')).toBe('polite')
+    expect(resolveAgentOutputPriority({ id: 'e', type: 'error', content: 'bad' }, 'auto')).toBe('assertive')
+    expect(resolveAgentOutputPriority({ id: 'e', type: 'error', content: 'bad' }, 'polite')).toBe('polite')
+  })
 })
 
 describe('AgentOutputAnnouncer', () => {
@@ -67,6 +92,33 @@ describe('AgentOutputAnnouncer', () => {
     const el = container.querySelector('[role="log"]') as HTMLElement
     expect(el?.getAttribute('aria-live')).toBe('assertive')
     expect(el?.getAttribute('aria-atomic')).toBe('true')
+  })
+
+  it('auto priority renders errors as assertive after announcement', async () => {
+    const container = document.createElement('div')
+    render(h(AgentOutputAnnouncer, {
+      outputs: [{ id: 'o-error', type: 'error', content: 'disk full' }],
+      priority: 'auto',
+    }), container)
+    await new Promise((r) => setTimeout(r, 10))
+    const el = container.querySelector('[role="log"]') as HTMLElement
+    expect(el?.getAttribute('aria-live')).toBe('assertive')
+    expect(el?.getAttribute('aria-atomic')).toBe('true')
+    expect(el?.getAttribute('data-agent-output-announcer-priority')).toBe('assertive')
+    expect(el?.getAttribute('data-agent-output-announcer-output-type')).toBe('error')
+  })
+
+  it('updates announcement priority when the policy changes for the same output', async () => {
+    const container = document.createElement('div')
+    const outputs = [{ id: 'o-error', type: 'error' as const, content: 'disk full' }]
+    render(h(AgentOutputAnnouncer, { outputs, priority: 'polite' }), container)
+    await new Promise((r) => setTimeout(r, 10))
+    render(h(AgentOutputAnnouncer, { outputs, priority: 'auto' }), container)
+    await new Promise((r) => setTimeout(r, 10))
+
+    const el = container.querySelector('[role="log"]') as HTMLElement
+    expect(el?.getAttribute('aria-live')).toBe('assertive')
+    expect(el?.getAttribute('data-agent-output-announcer-priority')).toBe('assertive')
   })
 
   it('renders aria-label', () => {
@@ -95,5 +147,23 @@ describe('AgentOutputAnnouncer', () => {
     await new Promise((r) => setTimeout(r, 10))
     const el = container.querySelector('[role="log"]') as HTMLElement
     expect(el?.textContent).toContain('hello')
+    expect(el?.getAttribute('data-agent-output-announcer-output-id')).toBe('o1')
+    expect(el?.getAttribute('data-agent-output-announcer-content-length')).toBe('5')
+  })
+
+  it('announces a changed latest output id even when output count stays the same', async () => {
+    const container = document.createElement('div')
+    render(h(AgentOutputAnnouncer, {
+      outputs: [{ id: 'o1', type: 'text', content: 'first' }],
+    }), container)
+    await new Promise((r) => setTimeout(r, 10))
+    render(h(AgentOutputAnnouncer, {
+      outputs: [{ id: 'o2', type: 'text', content: 'second' }],
+    }), container)
+    await new Promise((r) => setTimeout(r, 10))
+
+    const el = container.querySelector('[role="log"]') as HTMLElement
+    expect(el?.textContent).toContain('second')
+    expect(el?.getAttribute('data-agent-output-announcer-output-id')).toBe('o2')
   })
 })

--- a/dashboard/src/components/common/agent-output-announcer.ts
+++ b/dashboard/src/components/common/agent-output-announcer.ts
@@ -4,13 +4,24 @@
 // Converts structured agent outputs into concise aria-live friendly strings.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 
-interface AgentOutput {
+export interface AgentOutput {
   id: string
   type: 'code' | 'text' | 'table' | 'error'
   content: string
   metadata?: { language?: string; lineCount?: number }
+}
+
+export type AgentOutputPriority = 'polite' | 'assertive'
+export type AgentOutputPriorityPolicy = AgentOutputPriority | 'auto'
+
+export interface AgentOutputAnnouncement {
+  readonly id: string
+  readonly type: AgentOutput['type']
+  readonly message: string
+  readonly priority: AgentOutputPriority
+  readonly contentLength: number
 }
 
 export function announceAgentOutput(output: AgentOutput): string {
@@ -28,9 +39,30 @@ export function announceAgentOutput(output: AgentOutput): string {
   }
 }
 
+export function resolveAgentOutputPriority(
+  output: AgentOutput,
+  priority: AgentOutputPriorityPolicy = 'polite',
+): AgentOutputPriority {
+  if (priority !== 'auto') return priority
+  return output.type === 'error' ? 'assertive' : 'polite'
+}
+
+export function summarizeAgentOutput(
+  output: AgentOutput,
+  priority: AgentOutputPriorityPolicy = 'polite',
+): AgentOutputAnnouncement {
+  return {
+    id: output.id,
+    type: output.type,
+    message: announceAgentOutput(output),
+    priority: resolveAgentOutputPriority(output, priority),
+    contentLength: output.content.length,
+  }
+}
+
 interface AgentOutputAnnouncerProps {
   outputs: AgentOutput[]
-  priority?: 'polite' | 'assertive'
+  priority?: AgentOutputPriorityPolicy
   testId?: string
 }
 
@@ -39,21 +71,23 @@ export function AgentOutputAnnouncer({
   priority = 'polite',
   testId,
 }: AgentOutputAnnouncerProps) {
-  const prevCountRef = useRef(0)
-  const liveRef = useRef<HTMLDivElement>(null)
+  const lastAnnouncedRef = useRef<string | null>(null)
+  const [announcement, setAnnouncement] = useState<AgentOutputAnnouncement | null>(null)
 
   useEffect(() => {
-    if (outputs.length > prevCountRef.current && liveRef.current) {
-      const latest = outputs[outputs.length - 1]
-      if (latest) {
-        liveRef.current.textContent = announceAgentOutput(latest)
-      }
-    }
-    prevCountRef.current = outputs.length
-  }, [outputs])
+    const latest = outputs[outputs.length - 1]
+    if (!latest) return
 
-  const ariaLive = priority === 'assertive' ? 'assertive' : 'polite'
-  const ariaAtomic = priority === 'assertive' ? 'true' : 'false'
+    const next = summarizeAgentOutput(latest, priority)
+    const announcementKey = `${next.id}:${next.priority}`
+    if (announcementKey === lastAnnouncedRef.current) return
+
+    lastAnnouncedRef.current = announcementKey
+    setAnnouncement(next)
+  }, [outputs, priority])
+
+  const ariaLive = announcement?.priority ?? (priority === 'assertive' ? 'assertive' : 'polite')
+  const ariaAtomic = ariaLive === 'assertive' ? 'true' : 'false'
 
   return html`
     <div
@@ -61,10 +95,14 @@ export function AgentOutputAnnouncer({
       role="log"
       aria-live=${ariaLive}
       aria-atomic=${ariaAtomic}
+      aria-relevant="additions text"
       aria-label="에이전트 출력 알림"
-      ref=${liveRef}
       data-agent-output-announcer
+      data-agent-output-announcer-priority=${ariaLive}
+      data-agent-output-announcer-output-id=${announcement?.id}
+      data-agent-output-announcer-output-type=${announcement?.type}
+      data-agent-output-announcer-content-length=${announcement?.contentLength}
       data-testid=${testId}
-    ></div>
+    >${announcement?.message ?? ''}</div>
   `
 }

--- a/dashboard/src/components/common/agent-output-announcer.ts
+++ b/dashboard/src/components/common/agent-output-announcer.ts
@@ -72,7 +72,15 @@ export function AgentOutputAnnouncer({
   testId,
 }: AgentOutputAnnouncerProps) {
   const lastAnnouncedRef = useRef<string | null>(null)
+  const renderedMessageRef = useRef('')
+  const pendingAnnouncementTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [announcement, setAnnouncement] = useState<AgentOutputAnnouncement | null>(null)
+
+  useEffect(() => () => {
+    if (pendingAnnouncementTimerRef.current !== null) {
+      clearTimeout(pendingAnnouncementTimerRef.current)
+    }
+  }, [])
 
   useEffect(() => {
     const latest = outputs[outputs.length - 1]
@@ -82,7 +90,24 @@ export function AgentOutputAnnouncer({
     const announcementKey = `${next.id}:${next.priority}`
     if (announcementKey === lastAnnouncedRef.current) return
 
+    if (pendingAnnouncementTimerRef.current !== null) {
+      clearTimeout(pendingAnnouncementTimerRef.current)
+      pendingAnnouncementTimerRef.current = null
+    }
+
     lastAnnouncedRef.current = announcementKey
+    if (renderedMessageRef.current === next.message) {
+      renderedMessageRef.current = ''
+      setAnnouncement(null)
+      pendingAnnouncementTimerRef.current = setTimeout(() => {
+        renderedMessageRef.current = next.message
+        setAnnouncement(next)
+        pendingAnnouncementTimerRef.current = null
+      }, 0)
+      return
+    }
+
+    renderedMessageRef.current = next.message
     setAnnouncement(next)
   }, [outputs, priority])
 


### PR DESCRIPTION
## Summary
- Export structured AgentOutput announcement metadata for screen-reader summaries.
- Add `priority="auto"` so error outputs announce assertively while normal output stays polite.
- Re-announce the latest output when the output id or resolved priority changes, including same-count replacements.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/agent-output-announcer.test.ts src/components/common/agent-output-announcer.a11y.test.ts` (34 passed)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard run lint` (passes with 3 pre-existing unused eslint-disable warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic-import and chunk-size warnings)
- Browser QA at `http://127.0.0.1:5196/dashboard/agent-output-announcer-qa.html`: verified `aria-live="assertive"`, `aria-atomic="true"`, `aria-relevant="additions text"`, output id `error-1`, output type `error`, priority `assertive`, message `오류 발생: disk full while applying patch`; screenshot `/tmp/masc-agent-output-announcer-0506.png`; QA page removed and Vite stopped.

## Review focus
- `dashboard/src/components/common/agent-output-announcer.ts`
- `dashboard/src/components/common/agent-output-announcer.test.ts`
- `dashboard/src/components/common/agent-output-announcer.a11y.test.ts`