### PR TITLE
fix(keeper): preserve positive route durations

### DIFF
--- a/lib/keeper/keeper_timing.ml
+++ b/lib/keeper/keeper_timing.ml
@@ -20,4 +20,5 @@ let elapsed_duration_ms ~start_time ~end_time =
   let elapsed_ms = (end_time -. start_time) *. 1000.0 in
   if (not (Float.is_finite elapsed_ms)) || Float.compare elapsed_ms 0.0 <= 0
   then 0
+  else if Float.compare elapsed_ms (float_of_int max_int) >= 0 then max_int
   else max 1 (int_of_float elapsed_ms)

--- a/lib/keeper/keeper_timing.ml
+++ b/lib/keeper/keeper_timing.ml
@@ -11,3 +11,13 @@ let timed (f : unit -> 'a) : 'a * float =
   let result = f () in
   let elapsed_ms = (Time_compat.now () -. t0) *. 1000.0 in
   (result, elapsed_ms)
+
+(** [elapsed_duration_ms ~start_time ~end_time] converts a monotonic time
+    interval to an integer millisecond telemetry value. Positive elapsed time
+    smaller than 1ms is rounded up so completed calls are not recorded as
+    [0ms]. *)
+let elapsed_duration_ms ~start_time ~end_time =
+  let elapsed_ms = (end_time -. start_time) *. 1000.0 in
+  if (not (Float.is_finite elapsed_ms)) || Float.compare elapsed_ms 0.0 <= 0
+  then 0
+  else max 1 (int_of_float elapsed_ms)

--- a/lib/keeper/keeper_timing.mli
+++ b/lib/keeper/keeper_timing.mli
@@ -7,8 +7,8 @@ val round1 : float -> float
     Uses [Time_compat.now] as the single timing source. *)
 val timed : (unit -> 'a) -> 'a * float
 
-(** Convert elapsed wall-clock timestamps to integer milliseconds for
-    telemetry. Positive intervals below 1ms are rounded up to 1 so completed
-    calls are not recorded as [0ms]. Non-positive or non-finite intervals
-    return 0. *)
+(** Convert elapsed monotonic timestamps from the same clock, such as
+    [Eio.Time.now], to integer milliseconds for telemetry. Positive intervals
+    below 1ms are rounded up to 1 so completed calls are not recorded as [0ms].
+    Non-positive or non-finite intervals return 0. *)
 val elapsed_duration_ms : start_time:float -> end_time:float -> int

--- a/lib/keeper/keeper_timing.mli
+++ b/lib/keeper/keeper_timing.mli
@@ -6,3 +6,9 @@ val round1 : float -> float
 (** [timed f] runs [f ()], returning its result and elapsed time in ms.
     Uses [Time_compat.now] as the single timing source. *)
 val timed : (unit -> 'a) -> 'a * float
+
+(** Convert elapsed wall-clock timestamps to integer milliseconds for
+    telemetry. Positive intervals below 1ms are rounded up to 1 so completed
+    calls are not recorded as [0ms]. Non-positive or non-finite intervals
+    return 0. *)
+val elapsed_duration_ms : start_time:float -> end_time:float -> int

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -63,7 +63,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
           (false, Printf.sprintf "Internal error: %s" err))
   in
   let end_time = Eio.Time.now clock in
-  let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
+  let duration_ms = Keeper_timing.elapsed_duration_ms ~start_time ~end_time in
   let error_msg =
     if success then None
     else Some (Printf.sprintf "duration_ms=%d" duration_ms)
@@ -294,7 +294,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
           (false, Printf.sprintf "Internal error: %s" err))
   in
   let end_time = Eio.Time.now clock in
-  let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
+  let duration_ms = Keeper_timing.elapsed_duration_ms ~start_time ~end_time in
   let error_msg =
     if success then None
     else Some (Printf.sprintf "duration_ms=%d" duration_ms)

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -111,6 +111,10 @@ let record_internal_error_metric ~duration_ms body_str exn =
   with
   | Yojson.Json_error _ -> fallback ()
 
+let request_elapsed_ms request_started =
+  Keeper_timing.elapsed_duration_ms ~start_time:request_started
+    ~end_time:(Unix.gettimeofday ())
+
 let handle_gate_message ~sw ~clock state request reqd =
   Http.Request.read_body_async reqd (fun body_str ->
     let request_started = Unix.gettimeofday () in
@@ -126,9 +130,7 @@ let handle_gate_message ~sw ~clock state request reqd =
         let json = Yojson.Safe.from_string body_str in
         match Channel_gate.inbound_of_json json with
         | Error e ->
-            let duration_ms =
-              int_of_float ((Unix.gettimeofday () -. request_started) *. 1000.0)
-            in
+            let duration_ms = request_elapsed_ms request_started in
             record_validation_error_metric ~duration_ms body_str e;
             Error (Channel_gate.Validation Channel_gate.Empty_content, e)
         | Ok msg ->
@@ -138,17 +140,13 @@ let handle_gate_message ~sw ~clock state request reqd =
                 Error (gate_err, Channel_gate.gate_error_to_string gate_err))
       with
       | Yojson.Json_error _e ->
-          let duration_ms =
-            int_of_float ((Unix.gettimeofday () -. request_started) *. 1000.0)
-          in
+          let duration_ms = request_elapsed_ms request_started in
           record_validation_error_metric ~duration_ms body_str "invalid json";
           Error (Channel_gate.Validation Channel_gate.Empty_content, "invalid json")
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
           (* Log details server-side, return generic message to client *)
-          let duration_ms =
-            int_of_float ((Unix.gettimeofday () -. request_started) *. 1000.0)
-          in
+          let duration_ms = request_elapsed_ms request_started in
           record_internal_error_metric ~duration_ms body_str exn;
           Log.Misc.error "channel_gate internal error: %s" (Printexc.to_string exn);
           Error (Channel_gate.Internal "", "internal error")

--- a/test/dune
+++ b/test/dune
@@ -73,6 +73,7 @@
         test_auth_ambiguous_lookup_9786
         test_auth_load_credential_of
         test_keeper_wake_telemetry
+        test_keeper_timing
         test_keeper_memory
         test_keeper_accountability
         test_reputation_ledger_v2
@@ -285,6 +286,7 @@
           test_auth_ambiguous_lookup_9786
           test_auth_load_credential_of
           test_keeper_wake_telemetry
+          test_keeper_timing
           test_keeper_memory
           test_keeper_accountability
           test_reputation_ledger_v2

--- a/test/test_keeper_timing.ml
+++ b/test/test_keeper_timing.ml
@@ -1,0 +1,38 @@
+open Alcotest
+open Masc_mcp
+
+let test_elapsed_duration_ms_rounds_positive_sub_ms_to_one () =
+  check int "positive sub-ms interval" 1
+    (Keeper_timing.elapsed_duration_ms ~start_time:10.0 ~end_time:10.0004)
+
+let test_elapsed_duration_ms_preserves_integral_floor () =
+  check int "integer millisecond floor" 12
+    (Keeper_timing.elapsed_duration_ms ~start_time:2.0 ~end_time:2.0129)
+
+let test_elapsed_duration_ms_keeps_non_positive_zero () =
+  check int "same timestamp" 0
+    (Keeper_timing.elapsed_duration_ms ~start_time:5.0 ~end_time:5.0);
+  check int "backwards timestamp" 0
+    (Keeper_timing.elapsed_duration_ms ~start_time:5.0 ~end_time:4.999)
+
+let test_elapsed_duration_ms_rejects_non_finite () =
+  check int "infinite interval" 0
+    (Keeper_timing.elapsed_duration_ms ~start_time:0.0 ~end_time:infinity);
+  check int "nan interval" 0
+    (Keeper_timing.elapsed_duration_ms ~start_time:0.0 ~end_time:nan)
+
+let () =
+  run "Keeper_timing"
+    [
+      ( "duration_ms",
+        [
+          test_case "positive sub-ms intervals round up" `Quick
+            test_elapsed_duration_ms_rounds_positive_sub_ms_to_one;
+          test_case "larger intervals use integer floor" `Quick
+            test_elapsed_duration_ms_preserves_integral_floor;
+          test_case "non-positive intervals stay zero" `Quick
+            test_elapsed_duration_ms_keeps_non_positive_zero;
+          test_case "non-finite intervals stay zero" `Quick
+            test_elapsed_duration_ms_rejects_non_finite;
+        ] );
+    ]

--- a/test/test_keeper_timing.ml
+++ b/test/test_keeper_timing.ml
@@ -21,6 +21,11 @@ let test_elapsed_duration_ms_rejects_non_finite () =
   check int "nan interval" 0
     (Keeper_timing.elapsed_duration_ms ~start_time:0.0 ~end_time:nan)
 
+let test_elapsed_duration_ms_clamps_overflow () =
+  check int "oversized finite interval" max_int
+    (Keeper_timing.elapsed_duration_ms ~start_time:0.0
+       ~end_time:(float_of_int max_int))
+
 let () =
   run "Keeper_timing"
     [
@@ -34,5 +39,7 @@ let () =
             test_elapsed_duration_ms_keeps_non_positive_zero;
           test_case "non-finite intervals stay zero" `Quick
             test_elapsed_duration_ms_rejects_non_finite;
+          test_case "oversized intervals clamp to max_int" `Quick
+            test_elapsed_duration_ms_clamps_overflow;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add `Keeper_timing.elapsed_duration_ms` for telemetry-safe elapsed-time conversion
- use it for keeper chat stream dispatch and channel gate validation/internal-error route metrics
- add focused tests for sub-ms, normal, non-positive, and non-finite intervals

## Why
Several route-level duration paths truncated elapsed milliseconds with `int_of_float`. A completed call that took less than 1ms was emitted as `duration_ms=0`, polluting Phase 0 duration telemetry and making real work indistinguishable from missing timing.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_timing.exe`
- `./_build/default/test/test_keeper_timing.exe`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_timing.exe test/test_channel_gate_metrics.exe`
- `./_build/default/test/test_channel_gate_metrics.exe`

Note: local validation first exposed a stale switch/build-artifact mismatch; `scripts/opam-pin-external-deps.sh --install` restored the repo-pinned `agent_sdk` version before the focused build was rerun.