### PR TITLE
[P2] Cap cockpit KPI strip and add suggest nudges

### DIFF
--- a/dashboard/cockpit-kit/Chrome.jsx
+++ b/dashboard/cockpit-kit/Chrome.jsx
@@ -281,13 +281,13 @@ function kpiCollect(D) {
     note: stalledKeepers.length ? kpiList(stalledKeepers, keeperStallNote, "stalled") : "clear",
   };
 
-  let spot = { label: "Tokens/sec", value: tps.value, unit: tps.unit, tone: "brass", note: tps.note, urgent: false };
+  let spot = { key: "tps", label: "Tokens/sec", value: tps.value, unit: tps.unit, tone: "brass", note: tps.note, urgent: false };
   if (failureCount > 0) {
-    spot = { label: "Fails", value: failureValue, unit: failureUnit, tone: "err", note: failureNote, urgent: true };
+    spot = { key: "fails", label: "Fails", value: failureValue, unit: failureUnit, tone: "err", note: failureNote, urgent: true };
   } else if (stalledKeepers.length > 0) {
-    spot = { label: "Stalled", value: stalledKeepers.length, unit: "", tone: "stalled", note: stalledMetric.note, urgent: true };
+    spot = { key: "stalled", label: "Stalled", value: stalledKeepers.length, unit: "", tone: "stalled", note: stalledMetric.note, urgent: true };
   } else if (cascade.count > 0) {
-    spot = { label: "Cascade Hits", value: cascade.count, unit: "", tone: "info", note: cascade.note, urgent: true };
+    spot = { key: "cascade", label: "Cascade Hits", value: cascade.count, unit: "", tone: "info", note: cascade.note, urgent: true };
   }
 
   return {
@@ -300,19 +300,45 @@ function kpiCollect(D) {
     active: activeMetric,
     stalled: stalledMetric,
     goals: goalMetric,
-    metricCount: 8,
   };
 }
 
 // ============== KPI Strip ==============
+const VISIBLE_KPI_LIMIT = 5;
+
 function KpiStrip() {
   const [col, toggle] = (window.useCollapsed ? window.useCollapsed("kpi") : [false, () => {}]);
   const stats = kpiCollect(window.MASC_DATA || {});
   const spot = stats.spot;
+  const metricCells = [
+    { key: "tps", label: "Tokens/sec", metric: stats.tps, tone: "brass", className: stats.tps.live ? " live" : "" },
+    { key: "passRate", label: "Pass Rate", metric: stats.passRate, tone: "ok" },
+    { key: "fails", label: "Fails", metric: stats.fails, tone: "err" },
+    { key: "cascade", label: "Cascade Hits", metric: { value: stats.cascade.count, unit: "", note: stats.cascade.note }, tone: "info" },
+    { key: "active", label: "Active Keepers", metric: stats.active },
+    { key: "stalled", label: "Stalled", metric: stats.stalled, valueStyle: { color: "var(--stalled-fg)" } },
+    { key: "goals", label: "Goal Progress", metric: stats.goals },
+    { key: "prs", label: "Open PRs", metric: stats.prs },
+  ];
+  const visibleCells =
+    metricCells
+      .filter(cell => cell.key !== spot.key)
+      .slice(0, VISIBLE_KPI_LIMIT);
+  const visibleMetricCount = 1 + visibleCells.length;
+  const totalMetricCount = 1 + metricCells.length;
+  const renderMetricCell = (cell) => (
+    <div key={cell.key} className={"kpi-cell" + (cell.className || "")}>
+      <span className="kpi-l">{cell.label}</span>
+      <span className={"kpi-v" + (cell.tone ? " " + cell.tone : "")} style={cell.valueStyle || null}>
+        {cell.metric.value}{cell.metric.unit && <span className="u">{cell.metric.unit}</span>}
+      </span>
+      <span className="kpi-d">{cell.metric.note}</span>
+    </div>
+  );
   return (
     <div className={"kpi" + (col ? " wx-collapsed" : "")}>
       <div className="kpi-collapse-tab" onClick={toggle} title={col ? "expand KPI" : "collapse KPI"}>
-        {col ? "▸ KPI · " + (spot.urgent ? "⚠ " + spot.label : stats.metricCount + " metrics") : "▾"}
+        {col ? "▸ KPI · " + (spot.urgent ? "⚠ " + spot.label : visibleMetricCount + "/" + totalMetricCount) : "▾"}
         {!col && (
           <a className="wx-popout"
              href="?widget=kpi"
@@ -327,46 +353,7 @@ function KpiStrip() {
         <span className={"kpi-v " + spot.tone}>{spot.value}{spot.unit && <span className="u">{spot.unit}</span>}</span>
         <span className="kpi-d">{spot.note}</span>
       </div>
-      <div className={"kpi-cell" + (stats.tps.live ? " live" : "")}>
-        <span className="kpi-l">Tokens/sec</span>
-        <span className="kpi-v brass">{stats.tps.value}{stats.tps.unit && <span className="u">{stats.tps.unit}</span>}</span>
-        <span className="kpi-d">{stats.tps.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Pass Rate</span>
-        <span className="kpi-v ok">{stats.passRate.value}{stats.passRate.unit && <span className="u">{stats.passRate.unit}</span>}</span>
-        <span className="kpi-d">{stats.passRate.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Fails</span>
-        <span className="kpi-v err">{stats.fails.value}{stats.fails.unit && <span className="u">{stats.fails.unit}</span>}</span>
-        <span className="kpi-d">{stats.fails.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Cascade Hits</span>
-        <span className="kpi-v info">{stats.cascade.count}</span>
-        <span className="kpi-d">{stats.cascade.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Open PRs</span>
-        <span className="kpi-v">{stats.prs.value}</span>
-        <span className="kpi-d">{stats.prs.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Active Keepers</span>
-        <span className="kpi-v">{stats.active.value}{stats.active.unit && <span className="u">{stats.active.unit}</span>}</span>
-        <span className="kpi-d">{stats.active.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Stalled</span>
-        <span className="kpi-v" style={{color:"var(--stalled-fg)"}}>{stats.stalled.value}</span>
-        <span className="kpi-d">{stats.stalled.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Goal Progress</span>
-        <span className="kpi-v">{stats.goals.value}{stats.goals.unit && <span className="u">{stats.goals.unit}</span>}</span>
-        <span className="kpi-d">{stats.goals.note}</span>
-      </div>
+      {visibleCells.map(renderMetricCell)}
     </div>
   );
 }

--- a/dashboard/cockpit-kit/Chrome.jsx
+++ b/dashboard/cockpit-kit/Chrome.jsx
@@ -325,7 +325,7 @@ function KpiStrip() {
       .filter(cell => cell.key !== spot.key)
       .slice(0, VISIBLE_KPI_LIMIT);
   const visibleMetricCount = 1 + visibleCells.length;
-  const totalMetricCount = 1 + metricCells.length;
+  const totalMetricCount = metricCells.length;
   const renderMetricCell = (cell) => (
     <div key={cell.key} className={"kpi-cell" + (cell.className || "")}>
       <span className="kpi-l">{cell.label}</span>

--- a/dashboard/cockpit-kit/cockpit.css
+++ b/dashboard/cockpit-kit/cockpit.css
@@ -708,6 +708,7 @@ button { font: inherit; }
   text-transform: uppercase; letter-spacing: .06em; white-space: nowrap;
 }
 .rail-nudge .ch.hint     { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.rail-nudge .ch.suggest  { color: var(--warn-fg); border-color: var(--warn-border); }
 .rail-nudge .ch.approve  { color: var(--ok-fg); border-color: var(--ok-border); }
 .rail-nudge .ch.reject   { color: var(--err-fg); border-color: var(--err-border); }
 .rail-nudge .ch.redirect { color: var(--info-fg, var(--info)); border-color: var(--info); }

--- a/dashboard/cockpit-kit/data-p2.js
+++ b/dashboard/cockpit-kit/data-p2.js
@@ -19,7 +19,7 @@ window.MASC_P2 = (function () {
   // Each nudge: WHO (op), WHEN, WHAT (channel), and WHO got pinged.
   const nudges = [
     { id:"n-014", at:"16:28:11Z", channel:"hint",     to:["sangsu"],          body:"L187 drift, 한 번만 확인 부탁",                            ack:false },
-    { id:"n-013b",at:"16:20:36Z", channel:"suggest",  to:["qa-king"],         body:"flake 재현 로그를 붙이고 retry window 고정",               ack:false },
+    { id:"n-013b", at:"16:20:36Z", channel:"suggest",  to:["qa-king"],         body:"flake 재현 로그를 붙이고 retry window 고정",               ack:false },
     { id:"n-013", at:"16:14:02Z", channel:"approve",  to:["nick0cave"],       body:"PR #9712 backport approve",                                ack:true  },
     { id:"n-012", at:"15:51:27Z", channel:"reject",   to:["qa-king"],         body:"flake re-run 거부 — 실 실패로 처리",                       ack:true  },
     { id:"n-011", at:"15:32:00Z", channel:"redirect", to:["rama","scholar"],  body:"cascade regression 보지 말고 ar-93ff2489 우선",            ack:true  },

--- a/dashboard/cockpit-kit/data-p2.js
+++ b/dashboard/cockpit-kit/data-p2.js
@@ -19,6 +19,7 @@ window.MASC_P2 = (function () {
   // Each nudge: WHO (op), WHEN, WHAT (channel), and WHO got pinged.
   const nudges = [
     { id:"n-014", at:"16:28:11Z", channel:"hint",     to:["sangsu"],          body:"L187 drift, 한 번만 확인 부탁",                            ack:false },
+    { id:"n-013b",at:"16:20:36Z", channel:"suggest",  to:["qa-king"],         body:"flake 재현 로그를 붙이고 retry window 고정",               ack:false },
     { id:"n-013", at:"16:14:02Z", channel:"approve",  to:["nick0cave"],       body:"PR #9712 backport approve",                                ack:true  },
     { id:"n-012", at:"15:51:27Z", channel:"reject",   to:["qa-king"],         body:"flake re-run 거부 — 실 실패로 처리",                       ack:true  },
     { id:"n-011", at:"15:32:00Z", channel:"redirect", to:["rama","scholar"],  body:"cascade regression 보지 말고 ar-93ff2489 우선",            ack:true  },

--- a/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
@@ -281,13 +281,13 @@ function kpiCollect(D) {
     note: stalledKeepers.length ? kpiList(stalledKeepers, keeperStallNote, "stalled") : "clear",
   };
 
-  let spot = { label: "Tokens/sec", value: tps.value, unit: tps.unit, tone: "brass", note: tps.note, urgent: false };
+  let spot = { key: "tps", label: "Tokens/sec", value: tps.value, unit: tps.unit, tone: "brass", note: tps.note, urgent: false };
   if (failureCount > 0) {
-    spot = { label: "Fails", value: failureValue, unit: failureUnit, tone: "err", note: failureNote, urgent: true };
+    spot = { key: "fails", label: "Fails", value: failureValue, unit: failureUnit, tone: "err", note: failureNote, urgent: true };
   } else if (stalledKeepers.length > 0) {
-    spot = { label: "Stalled", value: stalledKeepers.length, unit: "", tone: "stalled", note: stalledMetric.note, urgent: true };
+    spot = { key: "stalled", label: "Stalled", value: stalledKeepers.length, unit: "", tone: "stalled", note: stalledMetric.note, urgent: true };
   } else if (cascade.count > 0) {
-    spot = { label: "Cascade Hits", value: cascade.count, unit: "", tone: "info", note: cascade.note, urgent: true };
+    spot = { key: "cascade", label: "Cascade Hits", value: cascade.count, unit: "", tone: "info", note: cascade.note, urgent: true };
   }
 
   return {
@@ -300,15 +300,41 @@ function kpiCollect(D) {
     active: activeMetric,
     stalled: stalledMetric,
     goals: goalMetric,
-    metricCount: 8,
   };
 }
 
 // ============== KPI Strip ==============
+const VISIBLE_KPI_LIMIT = 5;
+
 function KpiStrip() {
   const [col, toggle] = (window.useCollapsed ? window.useCollapsed("kpi") : [false, () => {}]);
   const stats = kpiCollect(window.MASC_DATA || {});
   const spot = stats.spot;
+  const metricCells = [
+    { key: "tps", label: "Tokens/sec", metric: stats.tps, tone: "brass", className: stats.tps.live ? " live" : "" },
+    { key: "passRate", label: "Pass Rate", metric: stats.passRate, tone: "ok" },
+    { key: "fails", label: "Fails", metric: stats.fails, tone: "err" },
+    { key: "cascade", label: "Cascade Hits", metric: { value: stats.cascade.count, unit: "", note: stats.cascade.note }, tone: "info" },
+    { key: "active", label: "Active Keepers", metric: stats.active },
+    { key: "stalled", label: "Stalled", metric: stats.stalled, valueStyle: { color: "var(--stalled-fg)" } },
+    { key: "goals", label: "Goal Progress", metric: stats.goals },
+    { key: "prs", label: "Open PRs", metric: stats.prs },
+  ];
+  const visibleCells =
+    metricCells
+      .filter(cell => cell.key !== spot.key)
+      .slice(0, VISIBLE_KPI_LIMIT);
+  const visibleMetricCount = 1 + visibleCells.length;
+  const totalMetricCount = 1 + metricCells.length;
+  const renderMetricCell = (cell) => (
+    <div key={cell.key} className={"kpi-cell" + (cell.className || "")}>
+      <span className="kpi-l">{cell.label}</span>
+      <span className={"kpi-v" + (cell.tone ? " " + cell.tone : "")} style={cell.valueStyle || null}>
+        {cell.metric.value}{cell.metric.unit && <span className="u">{cell.metric.unit}</span>}
+      </span>
+      <span className="kpi-d">{cell.metric.note}</span>
+    </div>
+  );
   return (
     <div className={"kpi" + (col ? " wx-collapsed" : "")}>
       <div
@@ -329,7 +355,7 @@ function KpiStrip() {
         role="button"
         tabIndex={0}
         aria-expanded={!col}>
-        {col ? "▸ KPI · " + (spot.urgent ? "⚠ " + spot.label : stats.metricCount + " metrics") : "▾"}
+        {col ? "▸ KPI · " + (spot.urgent ? "⚠ " + spot.label : visibleMetricCount + "/" + totalMetricCount) : "▾"}
         {!col && (
           <a className="wx-popout"
              href="?widget=kpi"
@@ -344,46 +370,7 @@ function KpiStrip() {
         <span className={"kpi-v " + spot.tone}>{spot.value}{spot.unit && <span className="u">{spot.unit}</span>}</span>
         <span className="kpi-d">{spot.note}</span>
       </div>
-      <div className={"kpi-cell" + (stats.tps.live ? " live" : "")}>
-        <span className="kpi-l">Tokens/sec</span>
-        <span className="kpi-v brass">{stats.tps.value}{stats.tps.unit && <span className="u">{stats.tps.unit}</span>}</span>
-        <span className="kpi-d">{stats.tps.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Pass Rate</span>
-        <span className="kpi-v ok">{stats.passRate.value}{stats.passRate.unit && <span className="u">{stats.passRate.unit}</span>}</span>
-        <span className="kpi-d">{stats.passRate.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Fails</span>
-        <span className="kpi-v err">{stats.fails.value}{stats.fails.unit && <span className="u">{stats.fails.unit}</span>}</span>
-        <span className="kpi-d">{stats.fails.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Cascade Hits</span>
-        <span className="kpi-v info">{stats.cascade.count}</span>
-        <span className="kpi-d">{stats.cascade.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Open PRs</span>
-        <span className="kpi-v">{stats.prs.value}</span>
-        <span className="kpi-d">{stats.prs.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Active Keepers</span>
-        <span className="kpi-v">{stats.active.value}{stats.active.unit && <span className="u">{stats.active.unit}</span>}</span>
-        <span className="kpi-d">{stats.active.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Stalled</span>
-        <span className="kpi-v" style={{color:"var(--stalled-fg)"}}>{stats.stalled.value}</span>
-        <span className="kpi-d">{stats.stalled.note}</span>
-      </div>
-      <div className="kpi-cell">
-        <span className="kpi-l">Goal Progress</span>
-        <span className="kpi-v">{stats.goals.value}{stats.goals.unit && <span className="u">{stats.goals.unit}</span>}</span>
-        <span className="kpi-d">{stats.goals.note}</span>
-      </div>
+      {visibleCells.map(renderMetricCell)}
     </div>
   );
 }

--- a/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
@@ -325,7 +325,7 @@ function KpiStrip() {
       .filter(cell => cell.key !== spot.key)
       .slice(0, VISIBLE_KPI_LIMIT);
   const visibleMetricCount = 1 + visibleCells.length;
-  const totalMetricCount = 1 + metricCells.length;
+  const totalMetricCount = metricCells.length;
   const renderMetricCell = (cell) => (
     <div key={cell.key} className={"kpi-cell" + (cell.className || "")}>
       <span className="kpi-l">{cell.label}</span>

--- a/dashboard/design-system/ui_kits/cockpit/cockpit.css
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit.css
@@ -708,6 +708,7 @@ button { font: inherit; }
   text-transform: uppercase; letter-spacing: .06em; white-space: nowrap;
 }
 .rail-nudge .ch.hint     { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.rail-nudge .ch.suggest  { color: var(--warn-fg); border-color: var(--warn-border); }
 .rail-nudge .ch.approve  { color: var(--ok-fg); border-color: var(--ok-border); }
 .rail-nudge .ch.reject   { color: var(--err-fg); border-color: var(--err-border); }
 .rail-nudge .ch.redirect { color: var(--info-fg, var(--info)); border-color: var(--info); }

--- a/dashboard/design-system/ui_kits/cockpit/data-p2.js
+++ b/dashboard/design-system/ui_kits/cockpit/data-p2.js
@@ -19,7 +19,7 @@ window.MASC_P2 = (function () {
   // Each nudge: WHO (op), WHEN, WHAT (channel), and WHO got pinged.
   const nudges = [
     { id:"n-014", at:"16:28:11Z", channel:"hint",     to:["sangsu"],          body:"L187 drift, 한 번만 확인 부탁",                            ack:false },
-    { id:"n-013b",at:"16:20:36Z", channel:"suggest",  to:["qa-king"],         body:"flake 재현 로그를 붙이고 retry window 고정",               ack:false },
+    { id:"n-013b", at:"16:20:36Z", channel:"suggest",  to:["qa-king"],         body:"flake 재현 로그를 붙이고 retry window 고정",               ack:false },
     { id:"n-013", at:"16:14:02Z", channel:"approve",  to:["nick0cave"],       body:"PR #9712 backport approve",                                ack:true  },
     { id:"n-012", at:"15:51:27Z", channel:"reject",   to:["qa-king"],         body:"flake re-run 거부 — 실 실패로 처리",                       ack:true  },
     { id:"n-011", at:"15:32:00Z", channel:"redirect", to:["rama","scholar"],  body:"cascade regression 보지 말고 ar-93ff2489 우선",            ack:true  },

--- a/dashboard/design-system/ui_kits/cockpit/data-p2.js
+++ b/dashboard/design-system/ui_kits/cockpit/data-p2.js
@@ -19,6 +19,7 @@ window.MASC_P2 = (function () {
   // Each nudge: WHO (op), WHEN, WHAT (channel), and WHO got pinged.
   const nudges = [
     { id:"n-014", at:"16:28:11Z", channel:"hint",     to:["sangsu"],          body:"L187 drift, 한 번만 확인 부탁",                            ack:false },
+    { id:"n-013b",at:"16:20:36Z", channel:"suggest",  to:["qa-king"],         body:"flake 재현 로그를 붙이고 retry window 고정",               ack:false },
     { id:"n-013", at:"16:14:02Z", channel:"approve",  to:["nick0cave"],       body:"PR #9712 backport approve",                                ack:true  },
     { id:"n-012", at:"15:51:27Z", channel:"reject",   to:["qa-king"],         body:"flake re-run 거부 — 실 실패로 처리",                       ack:true  },
     { id:"n-011", at:"15:32:00Z", channel:"redirect", to:["rama","scholar"],  body:"cascade regression 보지 말고 ar-93ff2489 우선",            ack:true  },


### PR DESCRIPTION
## Summary
- cap the cockpit KPI strip to spotlight + five ranked support KPIs, with the spotlight metric deduplicated from the support cells
- preserve the existing cockpit visual system while reducing first-viewport KPI load from nine cells to six
- add the missing `suggest` operator-nudge layer to both live cockpit kit data and the design-system kit mirror

## Why it matters
The reliability roadmap asks for progressive disclosure: operators should see the current critical signal and a small set of supporting KPIs, not every available metric at once. This keeps failures, stalled keepers, and cascade hits visible without duplicating the same metric in the strip.

## Verification
- `git diff --check`
- Browser static check from `dashboard` root at `http://127.0.0.1:9876/cockpit-kit/index.html`
- Browser DOM check: `.kpi > .kpi-cell` count = `6`
- Browser DOM check: nudge channels = `hint>suggest>approve>reject>redirect`
- Browser request/error check after reload: no page errors

Screenshot captured during verification: `/tmp/masc-cockpit-13548-root.png`

Closes #13548