### PR TITLE
fix(keeper): preserve positive hook trajectory durations

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -103,6 +103,11 @@ let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
   Printf.sprintf "%s:%s: %s"
     decision event.reason_code event.reason_text
 
+let trajectory_duration_ms duration_ms =
+  if (not (Float.is_finite duration_ms)) || Float.compare duration_ms 0.0 <= 0
+  then 0
+  else max 1 (int_of_float (Float.round duration_ms))
+
 let record_pre_tool_gate_attempt
     ~(meta_ref : Keeper_types.keeper_meta ref)
     ~(tool_call_count_ref : int ref)
@@ -175,7 +180,7 @@ let record_pre_tool_gate_attempt
           args_json = Yojson.Safe.to_string safe_input;
           gate_decision = Trajectory.Reject error;
           result = Some output_text;
-          duration_ms = int_of_float (Float.round duration_ms);
+          duration_ms = trajectory_duration_ms duration_ms;
           error = Some error;
           cost_usd = 0.0;
         }
@@ -1800,7 +1805,7 @@ let make_hooks
                args_json = Yojson.Safe.to_string safe_input;
                gate_decision = Trajectory.Pass;
                result = Some safe_output;
-               duration_ms = int_of_float (Float.round duration_ms);
+               duration_ms = trajectory_duration_ms duration_ms;
                error = (if outcome = "ok" then None else Some safe_output);
                cost_usd = Trajectory.tool_cost_estimate tool_name;
              }

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -58,6 +58,11 @@ val pre_tool_gate_error :
   Keeper_guards.gate_decision_event -> string
 (** Render the gate decision as a structured error message for logs. *)
 
+val trajectory_duration_ms : float -> int
+(** Convert hook-reported millisecond durations for trajectory rows.
+    Positive sub-1ms durations are rounded up to 1 so real tool work does
+    not appear as missing/zero-duration telemetry. *)
+
 val record_pre_tool_gate_attempt :
   meta_ref:Keeper_types.keeper_meta ref ->
   tool_call_count_ref:int ref ->

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -320,6 +320,16 @@ let test_tool_execution_summary_derives_provider_and_outcome () =
   check string "outcome" "error" summary.outcome;
   check (float 0.001) "duration" 12.5 summary.duration_ms
 
+let test_trajectory_duration_ms_preserves_positive_sub_ms () =
+  check int "positive sub-ms" 1 (Hooks.trajectory_duration_ms 0.4);
+  check int "rounded positive" 13 (Hooks.trajectory_duration_ms 12.5)
+
+let test_trajectory_duration_ms_rejects_zero_and_non_finite () =
+  check int "zero" 0 (Hooks.trajectory_duration_ms 0.0);
+  check int "negative" 0 (Hooks.trajectory_duration_ms (-0.1));
+  check int "nan" 0 (Hooks.trajectory_duration_ms nan);
+  check int "infinity" 0 (Hooks.trajectory_duration_ms infinity)
+
 let test_record_keeper_tool_duration_metric_tracks_labels () =
   let summary =
     Hooks.tool_execution_summary
@@ -782,6 +792,10 @@ let () =
     ; ( "tool_telemetry",
         [ test_case "tool execution summary derives provider and outcome" `Quick
             test_tool_execution_summary_derives_provider_and_outcome
+        ; test_case "trajectory duration keeps positive sub-ms values" `Quick
+            test_trajectory_duration_ms_preserves_positive_sub_ms
+        ; test_case "trajectory duration rejects non-positive values" `Quick
+            test_trajectory_duration_ms_rejects_zero_and_non_finite
         ; test_case "keeper tool duration metric tracks labels" `Quick
             test_record_keeper_tool_duration_metric_tracks_labels
         ] )


### PR DESCRIPTION
## Summary
- add a pure `Keeper_hooks_oas.trajectory_duration_ms` conversion for trajectory rows
- use it for pre-tool gate and post-tool trajectory entries
- add regression coverage for positive sub-ms, rounded, non-positive, and non-finite durations

## Why
OAS hook durations were rounded with `int_of_float (Float.round duration_ms)`. Positive sub-ms tool/gate work could still be written as `duration_ms=0`, which weakens Phase 0 duration telemetry and makes real callback work look missing.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe`
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe`