### PR TITLE
fix(dashboard): summarize memory timeline state

### DIFF
--- a/dashboard/src/components/common/memory-timeline.a11y.test.ts
+++ b/dashboard/src/components/common/memory-timeline.a11y.test.ts
@@ -39,12 +39,37 @@ describe('MemoryTimeline a11y', () => {
     const img = container.querySelector('[role="img"]')
     expect(img).not.toBeNull()
     expect(img?.getAttribute('aria-label')).toContain('메모리')
+    expect(img?.getAttribute('aria-label')).toContain('총 5회')
+    expect(img?.getAttribute('aria-label')).toContain('고유 메모리 5개')
   })
 
   it('renders 24 hour bars', () => {
     render(html`<${MemoryTimeline} entries=${makeEntries()} />`, container)
     const bars = container.querySelectorAll('[role="graphics-symbol"]')
     expect(bars.length).toBe(24)
+  })
+
+  it('labels each hour with dominant access type and unique memory count', () => {
+    const base = new Date()
+    base.setHours(8, 0, 0, 0)
+    render(html`<${MemoryTimeline}
+      entries=${[
+        { timestamp: base.getTime(), memoryId: 'm1', accessType: 'read' },
+        { timestamp: base.getTime() + 60000, memoryId: 'm2', accessType: 'write' },
+        { timestamp: base.getTime() + 120000, memoryId: 'm3', accessType: 'write' },
+      ]}
+    />`, container)
+    const bar = container.querySelector('[data-memory-timeline-hour="8"]')
+    expect(bar?.getAttribute('aria-label')).toBe('8시: 3회, 쓰기 우세, 고유 메모리 3개')
+    expect(bar?.getAttribute('data-memory-timeline-dominant-type')).toBe('write')
+  })
+
+  it('exposes timeline summary metadata', () => {
+    render(html`<${MemoryTimeline} entries=${makeEntries()} />`, container)
+    const summary = container.querySelector('[data-memory-timeline-summary]')
+    expect(summary).not.toBeNull()
+    expect(summary?.getAttribute('data-memory-timeline-total')).toBe('5')
+    expect(summary?.getAttribute('data-memory-timeline-unique')).toBe('5')
   })
 
   it('renders time labels', () => {

--- a/dashboard/src/components/common/memory-timeline.test.ts
+++ b/dashboard/src/components/common/memory-timeline.test.ts
@@ -1,9 +1,61 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { MemoryTimeline } from './memory-timeline'
+import {
+  buildMemoryTimelineHeatmap,
+  MemoryTimeline,
+  summarizeMemoryTimeline,
+} from './memory-timeline'
 
 describe('MemoryTimeline', () => {
+  it('summarizes totals, unique memories, peak hour, and access type mix', () => {
+    const base = new Date()
+    base.setHours(9, 0, 0, 0)
+
+    expect(summarizeMemoryTimeline([
+      { timestamp: base.getTime(), memoryId: 'a', accessType: 'read' },
+      { timestamp: base.getTime() + 60000, memoryId: 'b', accessType: 'write' },
+      { timestamp: base.getTime() + 120000, memoryId: 'a', accessType: 'search' },
+    ])).toEqual({
+      totalAccesses: 3,
+      uniqueMemoryCount: 2,
+      peakHour: 9,
+      peakCount: 3,
+      typeCounts: { read: 1, write: 1, search: 1 },
+    })
+  })
+
+  it('builds dominant hourly heatmap metadata', () => {
+    const base = new Date()
+    base.setHours(9, 0, 0, 0)
+    const heatmap = buildMemoryTimelineHeatmap([
+      { timestamp: base.getTime(), memoryId: 'a', accessType: 'read' },
+      { timestamp: base.getTime() + 60000, memoryId: 'b', accessType: 'write' },
+      { timestamp: base.getTime() + 120000, memoryId: 'c', accessType: 'write' },
+    ])
+
+    expect(heatmap).toHaveLength(24)
+    expect(heatmap[9]).toMatchObject({
+      hour: 9,
+      count: 3,
+      intensity: 1,
+      dominantType: 'write',
+      uniqueMemoryCount: 3,
+      typeCounts: { read: 1, write: 2, search: 0 },
+    })
+  })
+
+  it('keeps empty hours unclassified instead of marking them as read dominant', () => {
+    const heatmap = buildMemoryTimelineHeatmap([])
+    expect(heatmap[0]).toMatchObject({
+      hour: 0,
+      count: 0,
+      intensity: 0,
+      dominantType: null,
+      uniqueMemoryCount: 0,
+    })
+  })
+
   it('renders 24 bars', () => {
     const container = document.createElement('div')
     render(h(MemoryTimeline, { entries: [] }), container)
@@ -21,15 +73,35 @@ describe('MemoryTimeline', () => {
     const container = document.createElement('div')
     render(h(MemoryTimeline, { entries: [] }), container)
     const img = container.querySelector('[role="img"]')
-    expect(img?.getAttribute('aria-label')).toBe('시간대별 메모리 접근 패턴')
+    expect(img?.getAttribute('aria-label')).toBe('시간대별 메모리 접근 패턴, 접근 없음')
   })
 
   it('renders legend labels', () => {
     const container = document.createElement('div')
     render(h(MemoryTimeline, { entries: [] }), container)
-    expect(container.textContent).toContain('읽기')
-    expect(container.textContent).toContain('쓰기')
-    expect(container.textContent).toContain('검색')
+    expect(container.textContent).toContain('읽기 0')
+    expect(container.textContent).toContain('쓰기 0')
+    expect(container.textContent).toContain('검색 0')
+  })
+
+  it('renders summary chips', () => {
+    const container = document.createElement('div')
+    const now = new Date()
+    now.setHours(14, 0, 0, 0)
+    render(
+      h(MemoryTimeline, {
+        entries: [
+          { timestamp: now.getTime(), memoryId: 'a', accessType: 'read' },
+          { timestamp: now.getTime() + 60000, memoryId: 'b', accessType: 'search' },
+        ],
+      }),
+      container,
+    )
+    const summary = container.querySelector('[data-memory-timeline-summary]')
+    expect(summary?.getAttribute('data-memory-timeline-total')).toBe('2')
+    expect(summary?.getAttribute('data-memory-timeline-unique')).toBe('2')
+    expect(summary?.getAttribute('data-memory-timeline-peak-hour')).toBe('14')
+    expect(summary?.textContent).toContain('피크 14시 · 2회')
   })
 
   it('aggregates entries by hour', () => {
@@ -47,8 +119,11 @@ describe('MemoryTimeline', () => {
     )
     const bars = container.querySelectorAll('[role="graphics-symbol"]')
     const bar14 = bars[14] as HTMLElement
-    expect(bar14?.getAttribute('aria-label')).toBe('14시: 2회')
-    expect(bar14?.getAttribute('title')).toBe('14시 — 2회 접근')
+    expect(bar14?.getAttribute('aria-label')).toBe('14시: 2회, 읽기 우세, 고유 메모리 2개')
+    expect(bar14?.getAttribute('title')).toBe('14시 — 2회 접근 · 읽기 우세 · 2개 메모리')
+    expect(bar14?.getAttribute('data-memory-timeline-count')).toBe('2')
+    expect(bar14?.getAttribute('data-memory-timeline-dominant-type')).toBe('read')
+    expect(bar14?.getAttribute('data-memory-timeline-unique')).toBe('2')
   })
 
   it('uses different colors per access type', () => {
@@ -67,9 +142,20 @@ describe('MemoryTimeline', () => {
     const hour0 = new Date(t).getHours()
     const bar0 = bars[hour0] as HTMLElement
     expect(bar0?.style.background).toBe('var(--warn-10)')
+    expect(bar0?.getAttribute('data-memory-timeline-dominant-type')).toBe('write')
     const hour1 = new Date(t + 3600000).getHours()
     const bar1 = bars[hour1] as HTMLElement
     expect(bar1?.style.background).toBe('var(--color-accent)')
+    expect(bar1?.getAttribute('data-memory-timeline-dominant-type')).toBe('search')
+  })
+
+  it('labels empty hours as no access', () => {
+    const container = document.createElement('div')
+    render(h(MemoryTimeline, { entries: [] }), container)
+    const firstBar = container.querySelector('[data-memory-timeline-hour="0"]')
+    expect(firstBar?.getAttribute('aria-label')).toBe('0시: 접근 없음')
+    expect(firstBar?.getAttribute('title')).toBe('0시 — 접근 없음')
+    expect(firstBar?.getAttribute('data-memory-timeline-dominant-type')).toBe('')
   })
 
   it('shows max count in legend', () => {

--- a/dashboard/src/components/common/memory-timeline.test.ts
+++ b/dashboard/src/components/common/memory-timeline.test.ts
@@ -56,6 +56,22 @@ describe('MemoryTimeline', () => {
     })
   })
 
+  it('marks tied hourly access types as mixed', () => {
+    const base = new Date()
+    base.setHours(10, 0, 0, 0)
+    const heatmap = buildMemoryTimelineHeatmap([
+      { timestamp: base.getTime(), memoryId: 'a', accessType: 'read' },
+      { timestamp: base.getTime() + 60000, memoryId: 'b', accessType: 'write' },
+    ])
+
+    expect(heatmap[10]).toMatchObject({
+      hour: 10,
+      count: 2,
+      dominantType: 'mixed',
+      typeCounts: { read: 1, write: 1, search: 0 },
+    })
+  })
+
   it('renders 24 bars', () => {
     const container = document.createElement('div')
     render(h(MemoryTimeline, { entries: [] }), container)
@@ -152,10 +168,31 @@ describe('MemoryTimeline', () => {
   it('labels empty hours as no access', () => {
     const container = document.createElement('div')
     render(h(MemoryTimeline, { entries: [] }), container)
-    const firstBar = container.querySelector('[data-memory-timeline-hour="0"]')
+    const firstBar = container.querySelector('[data-memory-timeline-hour="0"]') as HTMLElement
     expect(firstBar?.getAttribute('aria-label')).toBe('0시: 접근 없음')
     expect(firstBar?.getAttribute('title')).toBe('0시 — 접근 없음')
     expect(firstBar?.getAttribute('data-memory-timeline-dominant-type')).toBe('')
+    expect(firstBar?.style.background).toBe('var(--color-border-default)')
+  })
+
+  it('renders tied access buckets as mixed instead of forcing a winner', () => {
+    const container = document.createElement('div')
+    const t = new Date()
+    t.setHours(11, 0, 0, 0)
+    render(
+      h(MemoryTimeline, {
+        entries: [
+          { timestamp: t.getTime(), memoryId: 'a', accessType: 'read' },
+          { timestamp: t.getTime() + 60000, memoryId: 'b', accessType: 'write' },
+        ],
+      }),
+      container,
+    )
+    const bar = container.querySelector('[data-memory-timeline-hour="11"]') as HTMLElement
+    expect(bar?.getAttribute('data-memory-timeline-dominant-type')).toBe('mixed')
+    expect(bar?.getAttribute('aria-label')).toBe('11시: 2회, 접근 유형 동등, 고유 메모리 2개')
+    expect(bar?.getAttribute('title')).toBe('11시 — 2회 접근 · 접근 유형 동등 · 2개 메모리')
+    expect(bar?.style.background).toBe('var(--color-fg-muted)')
   })
 
   it('shows max count in legend', () => {

--- a/dashboard/src/components/common/memory-timeline.ts
+++ b/dashboard/src/components/common/memory-timeline.ts
@@ -8,6 +8,7 @@ import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
 
 export type MemoryAccessType = 'read' | 'write' | 'search'
+export type DominantMemoryAccessType = MemoryAccessType | 'mixed'
 
 export interface TimelineEntry {
   timestamp: number
@@ -19,7 +20,7 @@ export interface HourlyMemoryAccess {
   readonly hour: number
   readonly count: number
   readonly intensity: number
-  readonly dominantType: MemoryAccessType | null
+  readonly dominantType: DominantMemoryAccessType | null
   readonly uniqueMemoryCount: number
   readonly typeCounts: Record<MemoryAccessType, number>
 }
@@ -44,26 +45,15 @@ const ACCESS_TYPE_LABEL: Record<MemoryAccessType, string> = {
   search: '검색',
 }
 
-const ACCESS_TYPE_PRIORITY: Record<MemoryAccessType, number> = {
-  read: 1,
-  search: 2,
-  write: 3,
-}
-
 function emptyTypeCounts(): Record<MemoryAccessType, number> {
   return { read: 0, write: 0, search: 0 }
 }
 
-function dominantAccessType(typeCounts: Record<MemoryAccessType, number>): MemoryAccessType {
-  return ACCESS_TYPES.reduce<MemoryAccessType>((best, accessType) => {
-    const bestCount = typeCounts[best]
-    const nextCount = typeCounts[accessType]
-    if (nextCount > bestCount) return accessType
-    if (nextCount === bestCount && ACCESS_TYPE_PRIORITY[accessType] > ACCESS_TYPE_PRIORITY[best]) {
-      return accessType
-    }
-    return best
-  }, 'read')
+function dominantAccessType(typeCounts: Record<MemoryAccessType, number>): DominantMemoryAccessType | null {
+  const maxCount = Math.max(...ACCESS_TYPES.map(accessType => typeCounts[accessType]))
+  if (maxCount === 0) return null
+  const winners = ACCESS_TYPES.filter(accessType => typeCounts[accessType] === maxCount)
+  return winners.length === 1 ? (winners[0] ?? null) : 'mixed'
 }
 
 export function summarizeMemoryTimeline(entries: TimelineEntry[]): MemoryTimelineSummary {
@@ -122,18 +112,21 @@ export function buildMemoryTimelineHeatmap(entries: TimelineEntry[]): HourlyMemo
       hour,
       count,
       intensity: count / max,
-      dominantType: count > 0 ? dominantAccessType(typeCounts) : null,
+      dominantType: dominantAccessType(typeCounts),
       uniqueMemoryCount: bucket?.memoryIds.size ?? 0,
       typeCounts,
     }
   })
 }
 
-function accessTypeColor(accessType: MemoryAccessType): string {
+function accessTypeColor(accessType: DominantMemoryAccessType | null): string {
+  if (accessType === null) return 'var(--color-border-default)'
   return accessType === 'write'
     ? 'var(--warn-10)'
     : accessType === 'search'
       ? 'var(--color-accent)'
+      : accessType === 'mixed'
+        ? 'var(--color-fg-muted)'
       : 'var(--ok-10)'
 }
 
@@ -143,12 +136,14 @@ function formatPeakHour(summary: MemoryTimelineSummary): string {
 
 function formatHourTitle(hour: HourlyMemoryAccess): string {
   if (hour.count === 0 || !hour.dominantType) return `${hour.hour}시 — 접근 없음`
-  return `${hour.hour}시 — ${hour.count}회 접근 · ${ACCESS_TYPE_LABEL[hour.dominantType]} 우세 · ${hour.uniqueMemoryCount}개 메모리`
+  const typeLabel = hour.dominantType === 'mixed' ? '접근 유형 동등' : `${ACCESS_TYPE_LABEL[hour.dominantType]} 우세`
+  return `${hour.hour}시 — ${hour.count}회 접근 · ${typeLabel} · ${hour.uniqueMemoryCount}개 메모리`
 }
 
 function formatHourAriaLabel(hour: HourlyMemoryAccess): string {
   if (hour.count === 0 || !hour.dominantType) return `${hour.hour}시: 접근 없음`
-  return `${hour.hour}시: ${hour.count}회, ${ACCESS_TYPE_LABEL[hour.dominantType]} 우세, 고유 메모리 ${hour.uniqueMemoryCount}개`
+  const typeLabel = hour.dominantType === 'mixed' ? '접근 유형 동등' : `${ACCESS_TYPE_LABEL[hour.dominantType]} 우세`
+  return `${hour.hour}시: ${hour.count}회, ${typeLabel}, 고유 메모리 ${hour.uniqueMemoryCount}개`
 }
 
 export function MemoryTimeline({ entries, testId }: MemoryTimelineProps) {
@@ -181,7 +176,7 @@ export function MemoryTimeline({ entries, testId }: MemoryTimelineProps) {
               style=${{
                 opacity: 0.1 + h.intensity * 0.9,
                 height: `${20 + h.intensity * 80}%`,
-                background: accessTypeColor(h.dominantType ?? 'read'),
+                background: accessTypeColor(h.dominantType),
               }}
               title=${formatHourTitle(h)}
               role="graphics-symbol"

--- a/dashboard/src/components/common/memory-timeline.ts
+++ b/dashboard/src/components/common/memory-timeline.ts
@@ -7,10 +7,29 @@
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
 
+export type MemoryAccessType = 'read' | 'write' | 'search'
+
 export interface TimelineEntry {
   timestamp: number
   memoryId: string
-  accessType: 'read' | 'write' | 'search'
+  accessType: MemoryAccessType
+}
+
+export interface HourlyMemoryAccess {
+  readonly hour: number
+  readonly count: number
+  readonly intensity: number
+  readonly dominantType: MemoryAccessType | null
+  readonly uniqueMemoryCount: number
+  readonly typeCounts: Record<MemoryAccessType, number>
+}
+
+export interface MemoryTimelineSummary {
+  readonly totalAccesses: number
+  readonly uniqueMemoryCount: number
+  readonly peakHour: number | null
+  readonly peakCount: number
+  readonly typeCounts: Record<MemoryAccessType, number>
 }
 
 interface MemoryTimelineProps {
@@ -18,7 +37,99 @@ interface MemoryTimelineProps {
   testId?: string
 }
 
-function accessTypeColor(accessType: string): string {
+const ACCESS_TYPES: readonly MemoryAccessType[] = ['read', 'write', 'search']
+const ACCESS_TYPE_LABEL: Record<MemoryAccessType, string> = {
+  read: '읽기',
+  write: '쓰기',
+  search: '검색',
+}
+
+const ACCESS_TYPE_PRIORITY: Record<MemoryAccessType, number> = {
+  read: 1,
+  search: 2,
+  write: 3,
+}
+
+function emptyTypeCounts(): Record<MemoryAccessType, number> {
+  return { read: 0, write: 0, search: 0 }
+}
+
+function dominantAccessType(typeCounts: Record<MemoryAccessType, number>): MemoryAccessType {
+  return ACCESS_TYPES.reduce<MemoryAccessType>((best, accessType) => {
+    const bestCount = typeCounts[best]
+    const nextCount = typeCounts[accessType]
+    if (nextCount > bestCount) return accessType
+    if (nextCount === bestCount && ACCESS_TYPE_PRIORITY[accessType] > ACCESS_TYPE_PRIORITY[best]) {
+      return accessType
+    }
+    return best
+  }, 'read')
+}
+
+export function summarizeMemoryTimeline(entries: TimelineEntry[]): MemoryTimelineSummary {
+  const typeCounts = emptyTypeCounts()
+  const memoryIds = new Set<string>()
+  const hourCounts: Record<number, number> = {}
+
+  entries.forEach((entry) => {
+    typeCounts[entry.accessType] += 1
+    memoryIds.add(entry.memoryId)
+    const hour = new Date(entry.timestamp).getHours()
+    hourCounts[hour] = (hourCounts[hour] ?? 0) + 1
+  })
+
+  const peak = Object.entries(hourCounts).reduce<{ hour: number | null; count: number }>(
+    (best, [hour, count]) => {
+      const hourNumber = Number(hour)
+      if (count > best.count) return { hour: hourNumber, count }
+      if (count === best.count && best.hour !== null && hourNumber < best.hour) {
+        return { hour: hourNumber, count }
+      }
+      return best
+    },
+    { hour: null, count: 0 },
+  )
+
+  return {
+    totalAccesses: entries.length,
+    uniqueMemoryCount: memoryIds.size,
+    peakHour: peak.hour,
+    peakCount: peak.count,
+    typeCounts,
+  }
+}
+
+export function buildMemoryTimelineHeatmap(entries: TimelineEntry[]): HourlyMemoryAccess[] {
+  const hours = Array.from({ length: 24 }, (_, i) => i)
+  const map: Record<number, { count: number; typeCounts: Record<MemoryAccessType, number>; memoryIds: Set<string> }> = {}
+
+  entries.forEach((entry) => {
+    const hour = new Date(entry.timestamp).getHours()
+    if (!map[hour]) {
+      map[hour] = { count: 0, typeCounts: emptyTypeCounts(), memoryIds: new Set() }
+    }
+    map[hour].count += 1
+    map[hour].typeCounts[entry.accessType] += 1
+    map[hour].memoryIds.add(entry.memoryId)
+  })
+
+  const max = Math.max(...Object.values(map).map((v) => v.count), 1)
+  return hours.map((hour) => {
+    const bucket = map[hour]
+    const typeCounts = bucket?.typeCounts ?? emptyTypeCounts()
+    const count = bucket?.count ?? 0
+    return {
+      hour,
+      count,
+      intensity: count / max,
+      dominantType: count > 0 ? dominantAccessType(typeCounts) : null,
+      uniqueMemoryCount: bucket?.memoryIds.size ?? 0,
+      typeCounts,
+    }
+  })
+}
+
+function accessTypeColor(accessType: MemoryAccessType): string {
   return accessType === 'write'
     ? 'var(--warn-10)'
     : accessType === 'search'
@@ -26,32 +137,42 @@ function accessTypeColor(accessType: string): string {
       : 'var(--ok-10)'
 }
 
+function formatPeakHour(summary: MemoryTimelineSummary): string {
+  return summary.peakHour === null ? '없음' : `${summary.peakHour}시`
+}
+
+function formatHourTitle(hour: HourlyMemoryAccess): string {
+  if (hour.count === 0 || !hour.dominantType) return `${hour.hour}시 — 접근 없음`
+  return `${hour.hour}시 — ${hour.count}회 접근 · ${ACCESS_TYPE_LABEL[hour.dominantType]} 우세 · ${hour.uniqueMemoryCount}개 메모리`
+}
+
+function formatHourAriaLabel(hour: HourlyMemoryAccess): string {
+  if (hour.count === 0 || !hour.dominantType) return `${hour.hour}시: 접근 없음`
+  return `${hour.hour}시: ${hour.count}회, ${ACCESS_TYPE_LABEL[hour.dominantType]} 우세, 고유 메모리 ${hour.uniqueMemoryCount}개`
+}
+
 export function MemoryTimeline({ entries, testId }: MemoryTimelineProps) {
-  const hours = useMemo(() => Array.from({ length: 24 }, (_, i) => i), [])
-
-  const heatmap = useMemo(() => {
-    const map: Record<number, { count: number; type: string }> = {}
-    entries.forEach(e => {
-      const hour = new Date(e.timestamp).getHours()
-      if (!map[hour]) {
-        map[hour] = { count: 0, type: e.accessType }
-      }
-      map[hour].count += 1
-    })
-    const max = Math.max(...Object.values(map).map(v => v.count), 1)
-    return hours.map(h => ({
-      hour: h,
-      count: map[h]?.count || 0,
-      intensity: (map[h]?.count || 0) / max,
-      type: map[h]?.type || 'read',
-    }))
-  }, [entries])
-
-  const maxCount = Math.max(...heatmap.map(h => h.count), 1)
+  const heatmap = useMemo(() => buildMemoryTimelineHeatmap(entries), [entries])
+  const summary = useMemo(() => summarizeMemoryTimeline(entries), [entries])
+  const chartLabel = summary.totalAccesses === 0
+    ? '시간대별 메모리 접근 패턴, 접근 없음'
+    : `시간대별 메모리 접근 패턴, 총 ${summary.totalAccesses}회, 고유 메모리 ${summary.uniqueMemoryCount}개, 최대 ${formatPeakHour(summary)} ${summary.peakCount}회`
 
   return html`
     <div class="w-full" data-memory-timeline data-testid=${testId}>
-      <div class="flex items-end gap-1 h-16" role="img" aria-label="시간대별 메모리 접근 패턴">
+      <div
+        class="mb-2 grid grid-cols-3 gap-2 text-3xs text-[var(--color-fg-secondary)]"
+        data-memory-timeline-summary
+        data-memory-timeline-total=${summary.totalAccesses}
+        data-memory-timeline-unique=${summary.uniqueMemoryCount}
+        data-memory-timeline-peak-hour=${summary.peakHour ?? ''}
+        data-memory-timeline-peak-count=${summary.peakCount}
+      >
+        <span>총 ${summary.totalAccesses}회</span>
+        <span>고유 ${summary.uniqueMemoryCount}개</span>
+        <span>피크 ${formatPeakHour(summary)} · ${summary.peakCount}회</span>
+      </div>
+      <div class="flex h-16 items-end gap-1" role="img" aria-label=${chartLabel}>
         ${heatmap.map(
           h => html`
             <div
@@ -60,11 +181,15 @@ export function MemoryTimeline({ entries, testId }: MemoryTimelineProps) {
               style=${{
                 opacity: 0.1 + h.intensity * 0.9,
                 height: `${20 + h.intensity * 80}%`,
-                background: accessTypeColor(h.type),
+                background: accessTypeColor(h.dominantType ?? 'read'),
               }}
-              title="${h.hour}시 — ${h.count}회 접근"
+              title=${formatHourTitle(h)}
               role="graphics-symbol"
-              aria-label="${h.hour}시: ${h.count}회"
+              aria-label=${formatHourAriaLabel(h)}
+              data-memory-timeline-hour=${h.hour}
+              data-memory-timeline-count=${h.count}
+              data-memory-timeline-dominant-type=${h.dominantType ?? ''}
+              data-memory-timeline-unique=${h.uniqueMemoryCount}
             ></div>
           `,
         )}
@@ -79,17 +204,17 @@ export function MemoryTimeline({ entries, testId }: MemoryTimelineProps) {
       <div class="mt-1.5 flex items-center gap-3 text-3xs text-[var(--color-fg-muted)]">
         <span class="inline-flex items-center gap-1">
           <span class="inline-block h-2 w-2 rounded-[var(--r-0)]" style=${{ background: 'var(--ok-10)' }}></span>
-          읽기
+          읽기 ${summary.typeCounts.read}
         </span>
         <span class="inline-flex items-center gap-1">
           <span class="inline-block h-2 w-2 rounded-[var(--r-0)]" style=${{ background: 'var(--warn-10)' }}></span>
-          쓰기
+          쓰기 ${summary.typeCounts.write}
         </span>
         <span class="inline-flex items-center gap-1">
           <span class="inline-block h-2 w-2 rounded-[var(--r-0)]" style=${{ background: 'var(--color-accent)' }}></span>
-          검색
+          검색 ${summary.typeCounts.search}
         </span>
-        <span class="ml-auto">최대 ${maxCount}회</span>
+        <span class="ml-auto">최대 ${summary.peakCount}회</span>
       </div>
     </div>
   `


### PR DESCRIPTION
## Summary
- Add pure MemoryTimeline summary and heatmap helpers for total accesses, unique memories, peak hour, type mix, and dominant hourly access type.
- Render a compact summary strip and per-type counts above/below the hourly heatmap.
- Add per-hour metadata and accessible labels, including explicit no-access labels for empty hours.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/memory-timeline.test.ts src/components/common/memory-timeline.a11y.test.ts` (19 passed)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard run lint` (passes with 3 pre-existing unused eslint-disable warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic-import and chunk-size warnings)
- Browser QA at `http://127.0.0.1:5197/dashboard/memory-timeline-qa.html`: verified 24 bars, total `5`, unique `4`, peak hour `8`, peak count `3`, peak dominant type `write`, empty hour label `0시: 접근 없음`, no visible overflow, only Vite debug console lines; screenshot `/tmp/masc-memory-timeline-summary-0506.png`; QA page removed and Vite stopped.

## Review focus
- `dashboard/src/components/common/memory-timeline.ts`
- `dashboard/src/components/common/memory-timeline.test.ts`
- `dashboard/src/components/common/memory-timeline.a11y.test.ts`