### PR TITLE
fix(keeper): preserve positive timed durations

### DIFF
--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -42,10 +42,16 @@ let usage_of_response (resp : Oas_response.api_response) : Agent_sdk.Types.api_u
 
 (** Measure wall-clock latency of a thunk in milliseconds.
     Use at call sites that need per-call timing (keeper tool loops, etc.). *)
+let elapsed_duration_ms elapsed_s =
+  let elapsed_ms = elapsed_s *. 1000.0 in
+  if (not (Float.is_finite elapsed_ms)) || Float.compare elapsed_ms 0.0 <= 0
+  then 0
+  else max 1 (int_of_float elapsed_ms)
+
 let timed (f : unit -> 'a) : 'a * int =
   let t0 = Time_compat.now () in
   let result = f () in
-  let ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
+  let ms = elapsed_duration_ms (Time_compat.now () -. t0) in
   (result, ms)
 
 (* ================================================================ *)

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -40,14 +40,14 @@ let zero_usage : Agent_sdk.Types.api_usage =
 let usage_of_response (resp : Oas_response.api_response) : Agent_sdk.Types.api_usage =
   match resp.usage with Some u -> u | None -> zero_usage
 
-(** Measure wall-clock latency of a thunk in milliseconds.
-    Use at call sites that need per-call timing (keeper tool loops, etc.). *)
+(** Convert elapsed seconds to integer milliseconds for telemetry. *)
 let elapsed_duration_ms elapsed_s =
   let elapsed_ms = elapsed_s *. 1000.0 in
   if (not (Float.is_finite elapsed_ms)) || Float.compare elapsed_ms 0.0 <= 0
   then 0
   else max 1 (int_of_float elapsed_ms)
 
+(** Measure wall-clock latency of a thunk in milliseconds. *)
 let timed (f : unit -> 'a) : 'a * int =
   let t0 = Time_compat.now () in
   let result = f () in

--- a/lib/inference_utils.mli
+++ b/lib/inference_utils.mli
@@ -20,6 +20,11 @@ val zero_usage : Agent_sdk.Types.api_usage
 (** Extract usage from an api_response, defaulting to {!zero_usage}. *)
 val usage_of_response : Oas_response.api_response -> Agent_sdk.Types.api_usage
 
+(** Convert elapsed seconds to integer milliseconds for telemetry. Positive
+    sub-1ms intervals are rounded up to 1; non-positive or non-finite
+    intervals return 0. *)
+val elapsed_duration_ms : float -> int
+
 (** Measure wall-clock latency of a thunk in milliseconds. *)
 val timed : (unit -> 'a) -> 'a * int
 

--- a/test/dune
+++ b/test/dune
@@ -70,6 +70,7 @@
         test_gc_sampler
         test_process_timeout_counter
         test_git_fetch_timeout_9587
+        test_inference_utils
         test_auth_ambiguous_lookup_9786
         test_auth_load_credential_of
         test_keeper_wake_telemetry
@@ -282,6 +283,7 @@
           test_gc_sampler
           test_process_timeout_counter
           test_git_fetch_timeout_9587
+          test_inference_utils
           test_auth_ambiguous_lookup_9786
           test_auth_load_credential_of
           test_keeper_wake_telemetry

--- a/test/test_inference_utils.ml
+++ b/test/test_inference_utils.ml
@@ -1,0 +1,33 @@
+open Alcotest
+open Masc_mcp
+
+let test_elapsed_duration_ms_rounds_positive_sub_ms_to_one () =
+  check int "positive sub-ms" 1 (Inference_utils.elapsed_duration_ms 0.0004)
+
+let test_elapsed_duration_ms_preserves_integer_floor () =
+  check int "floor larger interval" 12
+    (Inference_utils.elapsed_duration_ms 0.0129)
+
+let test_elapsed_duration_ms_keeps_non_positive_zero () =
+  check int "zero" 0 (Inference_utils.elapsed_duration_ms 0.0);
+  check int "negative" 0 (Inference_utils.elapsed_duration_ms (-0.001))
+
+let test_elapsed_duration_ms_rejects_non_finite () =
+  check int "nan" 0 (Inference_utils.elapsed_duration_ms nan);
+  check int "infinity" 0 (Inference_utils.elapsed_duration_ms infinity)
+
+let () =
+  Alcotest.run "Inference_utils"
+    [
+      ( "timing",
+        [
+          test_case "positive sub-ms intervals round up" `Quick
+            test_elapsed_duration_ms_rounds_positive_sub_ms_to_one;
+          test_case "larger intervals use integer floor" `Quick
+            test_elapsed_duration_ms_preserves_integer_floor;
+          test_case "non-positive intervals stay zero" `Quick
+            test_elapsed_duration_ms_keeps_non_positive_zero;
+          test_case "non-finite intervals stay zero" `Quick
+            test_elapsed_duration_ms_rejects_non_finite;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add a pure `Inference_utils.elapsed_duration_ms` conversion
- make `Inference_utils.timed` round positive sub-ms elapsed work up to `1ms`
- add focused regression coverage for sub-ms, normal, non-positive, and non-finite elapsed intervals

## Why
`Keeper_exec_context.timed` delegates to `Inference_utils.timed`, so unified/direct keeper turns and keeper tool loops could record real positive work as `0ms` when the elapsed interval was below 1ms. That weakens the Phase 0 duration telemetry gate by making completed work look like missing timing.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_inference_utils.exe`
- `./_build/default/test/test_inference_utils.exe`