### PR TITLE
feat(oas): expose provider error counts in dashboard bridge

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -23,6 +23,14 @@ type sample = {
   retry_count : int;
 }
 
+type provider_error_count = {
+  provider_id : string;
+  cascade_name : string;
+  kind : string;
+  capacity_scope : string;
+  count : int;
+}
+
 (* Guards [table]. Critical sections are short — queue push, fold, or clear.
    Stdlib.Mutex is chosen over Eio.Mutex because record/read may be called
    from different domains, and the section never yields to Eio. Same
@@ -32,6 +40,9 @@ let mu = Mutex.create ()
 (* Per-provider FIFO. Head = oldest, tail = newest. *)
 let table : (string, (sample * float) Queue.t) Hashtbl.t =
   Hashtbl.create 8
+
+let provider_error_table : (string * string * string * string, int) Hashtbl.t =
+  Hashtbl.create 16
 
 let with_lock f =
   Mutex.lock mu;
@@ -75,6 +86,16 @@ let sample_entry_to_yojson (s, recorded_at) =
     [
       ("sample", sample_to_yojson s);
       ("recorded_at", `Float recorded_at);
+    ]
+
+let provider_error_count_to_yojson (c : provider_error_count) =
+  `Assoc
+    [
+      ("provider_id", `String c.provider_id);
+      ("cascade_name", `String c.cascade_name);
+      ("kind", `String c.kind);
+      ("capacity_scope", `String c.capacity_scope);
+      ("count", `Int c.count);
     ]
 
 let provider_json = function
@@ -182,6 +203,61 @@ let record_response ~provider_id ~model_id ?total_duration_ms ?serialization_ms
     (sample_of_response ~provider_id ~model_id ?total_duration_ms
        ?serialization_ms ?retry_count ~status response)
 
+let provider_error_capacity_scope_label = function
+  | Provider_error.CapacityExhausted { scope; _ } ->
+      Provider_error.scope_to_string scope
+  | Provider_error.RateLimit _
+  | Provider_error.AuthError _
+  | Provider_error.ServerError _
+  | Provider_error.InvalidRequest _ ->
+      "none"
+
+let record_provider_error ~cascade_name ~provider_id error =
+  let kind = Provider_error.to_error_kind error in
+  let capacity_scope = provider_error_capacity_scope_label error in
+  let key = (provider_id, cascade_name, kind, capacity_scope) in
+  with_lock (fun () ->
+      let count =
+        match Hashtbl.find_opt provider_error_table key with
+        | Some count -> count
+        | None -> 0
+      in
+      Hashtbl.replace provider_error_table key (count + 1))
+
+let compare_provider_error_count a b =
+  match Int.compare b.count a.count with
+  | 0 -> (
+      match String.compare a.provider_id b.provider_id with
+      | 0 -> (
+          match String.compare a.cascade_name b.cascade_name with
+          | 0 -> (
+              match String.compare a.kind b.kind with
+              | 0 -> String.compare a.capacity_scope b.capacity_scope
+              | c -> c)
+          | c -> c)
+      | c -> c)
+  | c -> c
+
+let provider_error_counts ?provider () =
+  let counts =
+    with_lock (fun () ->
+        Hashtbl.fold
+          (fun (provider_id, cascade_name, kind, capacity_scope) count acc ->
+            match provider with
+            | Some provider when not (String.equal provider provider_id) -> acc
+            | _ ->
+                {
+                  provider_id;
+                  cascade_name;
+                  kind;
+                  capacity_scope;
+                  count;
+                }
+                :: acc)
+          provider_error_table [])
+  in
+  List.sort compare_provider_error_count counts
+
 let snapshot_provider provider =
   with_lock (fun () ->
       match Hashtbl.find_opt table provider with
@@ -224,9 +300,10 @@ type summary = {
   total_cost_usd : float;
   error_ratio : float;
   cancelled_count : int;
+  provider_error_counts : provider_error_count list;
 }
 
-let zero_summary =
+let zero_summary provider_error_counts =
   {
     sample_count = 0;
     ttfb_p50_ms = 0.0;
@@ -238,6 +315,7 @@ let zero_summary =
     total_cost_usd = 0.0;
     error_ratio = 0.0;
     cancelled_count = 0;
+    provider_error_counts;
   }
 
 (* Nearest-rank percentile (no interpolation) keeps the dashboard
@@ -254,8 +332,9 @@ let percentile (sorted : float array) (p : float) =
 
 let summary ?provider ?limit () =
   let xs = recent ?provider ?limit () in
+  let provider_error_counts = provider_error_counts ?provider () in
   match xs with
-  | [] -> zero_summary
+  | [] -> zero_summary provider_error_counts
   | _ ->
       let n = List.length xs in
       let ttfbs =
@@ -299,6 +378,7 @@ let summary ?provider ?limit () =
         total_cost_usd = total_cost;
         error_ratio = float_of_int errors /. float_of_int n;
         cancelled_count = cancels;
+        provider_error_counts;
       }
 
 let summary_to_yojson (s : summary) =
@@ -314,6 +394,9 @@ let summary_to_yojson (s : summary) =
       ("total_cost_usd", `Float s.total_cost_usd);
       ("error_ratio", `Float s.error_ratio);
       ("cancelled_count", `Int s.cancelled_count);
+      ( "provider_error_counts",
+        `List (List.map provider_error_count_to_yojson s.provider_error_counts)
+      )
     ]
 
 let recent_json ?provider ?limit () =
@@ -344,5 +427,17 @@ let summary_json ?provider ?limit () =
 let clear ?provider () =
   with_lock (fun () ->
       match provider with
-      | Some p -> Hashtbl.remove table p
-      | None -> Hashtbl.reset table)
+      | Some p ->
+          Hashtbl.remove table p;
+          let keys =
+            Hashtbl.fold
+              (fun (provider_id, cascade_name, kind, capacity_scope) _ acc ->
+                if String.equal provider_id p then
+                  (provider_id, cascade_name, kind, capacity_scope) :: acc
+                else acc)
+              provider_error_table []
+          in
+          List.iter (Hashtbl.remove provider_error_table) keys
+      | None ->
+          Hashtbl.reset table;
+          Hashtbl.reset provider_error_table)

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -27,8 +27,8 @@
     @since unreleased *)
 
 (** Outcome status of a single OAS call. Mirrors the variant intent of
-    {!Provider_error} (I2 #11925) but kept local to the bridge so this
-    module does not yet depend on the WIP Type Triad. *)
+    {!Provider_error} (I2 #11925) but stays local because telemetry
+    samples and provider-error event counts have different lifecycles. *)
 type status =
   | Success
   | Error of { transient : bool }
@@ -106,6 +106,26 @@ val record_response :
   unit
 (** Convert an OAS response with {!sample_of_response}, then {!record} it. *)
 
+type provider_error_count = {
+  provider_id : string;
+  cascade_name : string;
+  kind : string;
+  capacity_scope : string;
+  count : int;
+}
+(** Aggregated provider-error variant count emitted by the OAS worker
+    boundary. [kind] follows {!Provider_error.to_error_kind};
+    [capacity_scope] is ["none"] for non-capacity errors. *)
+
+val record_provider_error :
+  cascade_name:string -> provider_id:string -> Provider_error.t -> unit
+(** [record_provider_error ~cascade_name ~provider_id error] increments the
+    dashboard count for a typed provider-error event. *)
+
+val provider_error_counts : ?provider:string -> unit -> provider_error_count list
+(** Current provider-error counts, sorted by descending [count]. With
+    [provider], only matching provider rows are returned. *)
+
 val recent :
   ?provider:string -> ?limit:int -> unit -> (sample * float) list
 (** [recent ?provider ?limit ()] returns up to [limit] most recent samples,
@@ -136,6 +156,7 @@ type summary = {
   error_ratio : float;
       (** [(Error \/ Timeout) / sample_count] — Cancelled is excluded. *)
   cancelled_count : int;  (** Explicit cancellation count. *)
+  provider_error_counts : provider_error_count list;
 }
 
 val summary : ?provider:string -> ?limit:int -> unit -> summary

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -191,8 +191,9 @@ val summary_json : ?provider:string -> ?limit:int -> unit -> Yojson.Safe.t
     [GET /api/v1/dashboard/oas/telemetry/summary?provider=P&limit=N]. *)
 
 val clear : ?provider:string -> unit -> unit
-(** [clear ?provider ()] drops samples. With [provider] only that ring is
-    cleared. Without [provider] the entire table is reset.
+(** [clear ?provider ()] drops samples and provider-error counts. With
+    [provider] only that provider's ring/counts are cleared. Without
+    [provider] the entire telemetry table is reset.
 
     Intended for test fixtures and dashboard reset; do not call from
     production code. *)

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -439,6 +439,8 @@ let provider_error_capacity_scope_label = function
 let emit_provider_error_metric ~cascade_name ~provider error =
   let cascade_name = provider_label (cascade_name_to_string cascade_name) in
   let provider = provider_label provider in
+  Dashboard_oas_bridge.record_provider_error ~cascade_name ~provider_id:provider
+    error;
   Prometheus.inc_counter provider_error_total_metric
     ~labels:
       [

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -2,10 +2,12 @@
 
     Twelve-signal collector for I1 telemetry pipeline (#11924). Covers
     ring-buffer semantics (record/recent/clear), provider filter, and
-    the nearest-rank percentile in {!Dashboard_oas_bridge.summary}. *)
+    the nearest-rank percentile in {!Dashboard_oas_bridge.summary}, plus
+    provider-error count aggregation for I2 (#11925). *)
 
 module DOB = Masc_mcp.Dashboard_oas_bridge
 module Json = Yojson.Safe.Util
+module P = Provider_error
 
 let make_sample
     ?(provider = "anthropic")
@@ -212,6 +214,83 @@ let test_summary_json_contains_aggregate () =
   Alcotest.(check (float 1e-9)) "error_ratio" 0.5
     (summary |> Json.member "error_ratio" |> Json.to_float)
 
+(* --- provider-error counts --- *)
+
+let provider_error_count ~provider ~cascade ~kind ~capacity_scope counts =
+  match
+    List.find_opt
+      (fun (count : DOB.provider_error_count) ->
+        String.equal count.provider_id provider
+        && String.equal count.cascade_name cascade
+        && String.equal count.kind kind
+        && String.equal count.capacity_scope capacity_scope)
+      counts
+  with
+  | Some count -> count
+  | None ->
+      Alcotest.failf "missing provider_error_count %s/%s/%s/%s"
+        provider cascade kind capacity_scope
+
+let test_provider_error_counts_group_and_filter () =
+  setup ();
+  let rate_limit =
+    P.RateLimit { retry_after = Some 2.0; provider = "anthropic" }
+  in
+  let capacity =
+    P.CapacityExhausted { scope = `Model; affected = [ "ollama" ] }
+  in
+  DOB.record_provider_error ~cascade_name:"big_three" ~provider_id:"anthropic"
+    rate_limit;
+  DOB.record_provider_error ~cascade_name:"big_three" ~provider_id:"anthropic"
+    rate_limit;
+  DOB.record_provider_error ~cascade_name:"big_three" ~provider_id:"ollama"
+    capacity;
+  let all = DOB.provider_error_counts () in
+  Alcotest.(check int) "two groups" 2 (List.length all);
+  let anthropic =
+    provider_error_count ~provider:"anthropic" ~cascade:"big_three"
+      ~kind:"rate_limit" ~capacity_scope:"none" all
+  in
+  Alcotest.(check int) "anthropic rate_limit count" 2
+    anthropic.DOB.count;
+  let ollama =
+    provider_error_count ~provider:"ollama" ~cascade:"big_three"
+      ~kind:"capacity_exhausted" ~capacity_scope:"model" all
+  in
+  Alcotest.(check int) "ollama capacity count" 1 ollama.DOB.count;
+  let filtered = DOB.provider_error_counts ~provider:"anthropic" () in
+  Alcotest.(check int) "filtered groups" 1 (List.length filtered);
+  let filtered_anthropic =
+    provider_error_count ~provider:"anthropic" ~cascade:"big_three"
+      ~kind:"rate_limit" ~capacity_scope:"none" filtered
+  in
+  Alcotest.(check int) "filtered count" 2
+    filtered_anthropic.DOB.count
+
+let test_summary_json_contains_provider_error_counts () =
+  setup ();
+  DOB.record_provider_error ~cascade_name:"big_three" ~provider_id:"anthropic"
+    (P.AuthError { provider = "anthropic" });
+  let json = DOB.summary_json ~provider:"anthropic" ~limit:10 () in
+  let summary = json |> Json.member "summary" in
+  Alcotest.(check int) "sample_count can be zero" 0
+    (summary |> Json.member "sample_count" |> Json.to_int);
+  match summary |> Json.member "provider_error_counts" |> Json.to_list with
+  | [ count ] ->
+      Alcotest.(check string) "provider" "anthropic"
+        (count |> Json.member "provider_id" |> Json.to_string);
+      Alcotest.(check string) "cascade" "big_three"
+        (count |> Json.member "cascade_name" |> Json.to_string);
+      Alcotest.(check string) "kind" "auth_error"
+        (count |> Json.member "kind" |> Json.to_string);
+      Alcotest.(check string) "capacity scope" "none"
+        (count |> Json.member "capacity_scope" |> Json.to_string);
+      Alcotest.(check int) "count" 1
+        (count |> Json.member "count" |> Json.to_int)
+  | counts ->
+      Alcotest.failf "expected one provider_error_count, got %d"
+        (List.length counts)
+
 (* --- clear --- *)
 
 let test_clear_provider () =
@@ -223,6 +302,21 @@ let test_clear_provider () =
     (List.length (DOB.recent ~provider:"anthropic" ()));
   Alcotest.(check int) "ollama remains" 1
     (List.length (DOB.recent ~provider:"ollama" ()))
+
+let test_clear_provider_error_counts () =
+  setup ();
+  DOB.record_provider_error ~cascade_name:"big_three" ~provider_id:"anthropic"
+    (P.RateLimit { retry_after = None; provider = "anthropic" });
+  DOB.record_provider_error ~cascade_name:"big_three" ~provider_id:"ollama"
+    (P.ServerError { code = 503; transient = true });
+  DOB.clear ~provider:"anthropic" ();
+  Alcotest.(check int) "anthropic counts cleared" 0
+    (List.length (DOB.provider_error_counts ~provider:"anthropic" ()));
+  Alcotest.(check int) "ollama counts remain" 1
+    (List.length (DOB.provider_error_counts ~provider:"ollama" ()));
+  DOB.clear ();
+  Alcotest.(check int) "all counts cleared" 0
+    (List.length (DOB.provider_error_counts ()))
 
 (* --- OAS response projection --- *)
 
@@ -387,9 +481,20 @@ let () =
             test_recent_json_filters_provider;
           Alcotest.test_case "summary aggregate" `Quick
             test_summary_json_contains_aggregate;
+          Alcotest.test_case "summary provider-error counts" `Quick
+            test_summary_json_contains_provider_error_counts;
         ] );
       ( "clear",
-        [ Alcotest.test_case "clear provider" `Quick test_clear_provider ] );
+        [
+          Alcotest.test_case "clear provider" `Quick test_clear_provider;
+          Alcotest.test_case "clear provider-error counts" `Quick
+            test_clear_provider_error_counts;
+        ] );
+      ( "provider_error_counts",
+        [
+          Alcotest.test_case "group + filter" `Quick
+            test_provider_error_counts_group_and_filter;
+        ] );
       ( "oas_response",
         [
           Alcotest.test_case "usage + native telemetry" `Quick


### PR DESCRIPTION
## Summary
- Add typed provider-error aggregate counts to `Dashboard_oas_bridge` and expose them in `/api/v1/dashboard/oas/telemetry/summary`.
- Wire `Oas_worker_named_fsm.emit_provider_error_metric` to record the same typed provider-error event count beside `masc_provider_error_total`.
- Cover grouping, provider filtering, JSON serialization, and provider-scoped clear behavior in `test_dashboard_oas_bridge`.

## Why
Issue #11925 had provider_error variants reaching Prometheus, but the dashboard/OAS bridge still had no typed event-count surface. Operators could see call samples and ratios, but not which provider-error variants were accumulating by provider/cascade.

## Validation
- `git diff --check origin/main...HEAD`
- `ocamlc -stop-after parsing lib/dashboard/dashboard_oas_bridge.mli lib/dashboard/dashboard_oas_bridge.ml lib/oas_worker_named_fsm.ml test/test_dashboard_oas_bridge.ml`
- `scripts/dune-local.sh build test/test_dashboard_oas_bridge.exe test/test_provider_error.exe`
- `./_build/default/test/test_dashboard_oas_bridge.exe`
- `./_build/default/test/test_provider_error.exe`

Refs #11925