### PR TITLE
fix(dashboard): summarize memory search results

### DIFF
--- a/dashboard/src/components/common/memory-search.a11y.test.ts
+++ b/dashboard/src/components/common/memory-search.a11y.test.ts
@@ -57,8 +57,11 @@ describe('MemorySearch a11y', () => {
   it('has search input with aria-label', () => {
     render(html`<${MemorySearch} />`, container)
     const input = container.querySelector('input')
+    const summary = container.querySelector('[data-memory-search-summary]')
     expect(input).not.toBeNull()
+    expect(input?.getAttribute('type')).toBe('search')
     expect(input?.getAttribute('aria-label')).toBe('메모리 검색')
+    expect(input?.getAttribute('aria-describedby')).toBe(summary?.id)
   })
 
   it('renders similarity bars', () => {
@@ -71,5 +74,36 @@ describe('MemorySearch a11y', () => {
   it('has list role for results', () => {
     render(html`<${MemorySearch} results=${makeResults()} />`, container)
     expect(container.querySelector('[role="list"]')).not.toBeNull()
+  })
+
+  it('exposes result summary and cluster metadata', () => {
+    render(html`<${MemorySearch} results=${makeResults()} />`, container)
+    const root = container.querySelector('[data-memory-search]')
+    const summary = container.querySelector('[data-memory-search-summary]')
+    const clusters = container.querySelector('[data-memory-search-clusters]')
+    expect(root?.getAttribute('data-memory-search-result-count')).toBe('3')
+    expect(root?.getAttribute('data-memory-search-cluster-count')).toBe('3')
+    expect(root?.getAttribute('data-memory-search-top-similarity')).toBe('92')
+    expect(summary?.textContent).toContain('결과 3개')
+    expect(clusters?.getAttribute('aria-label')).toBe('관련 메모리 클러스터')
+    expect(container.querySelector('[data-memory-search-cluster="io"]')?.textContent).toContain('io 1 · 92%')
+  })
+
+  it('labels result rows with rank, similarity, and cluster', () => {
+    render(html`<${MemorySearch} results=${makeResults()} />`, container)
+    const row = container.querySelector('[data-memory-search-result-id="r1"]')
+    expect(row?.getAttribute('data-memory-search-result-rank')).toBe('1')
+    expect(row?.getAttribute('data-memory-search-result-cluster')).toBe('io')
+    expect(row?.getAttribute('data-memory-search-result-similarity')).toBe('92')
+    expect(row?.getAttribute('aria-label')).toBe('1위 파일 읽기 기억, 유사도 92%, 클러스터 io')
+  })
+
+  it('uses accessible progressbar semantics for similarity', () => {
+    render(html`<${MemorySearch} results=${makeResults()} />`, container)
+    const progress = container.querySelector('[role="progressbar"]')
+    expect(progress?.getAttribute('aria-valuemin')).toBe('0')
+    expect(progress?.getAttribute('aria-valuemax')).toBe('100')
+    expect(progress?.getAttribute('aria-valuenow')).toBe('92')
+    expect(progress?.getAttribute('aria-label')).toBe('파일 읽기 기억 유사도')
   })
 })

--- a/dashboard/src/components/common/memory-search.test.ts
+++ b/dashboard/src/components/common/memory-search.test.ts
@@ -1,15 +1,52 @@
-// @ts-nocheck
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { MemorySearch } from './memory-search'
+import {
+  formatSimilarityPercent,
+  MemorySearch,
+  normalizeSimilarity,
+  summarizeMemorySearchResults,
+} from './memory-search'
 
 describe('MemorySearch', () => {
+  it('normalizes similarity values for display and progress bars', () => {
+    expect(normalizeSimilarity(1.2)).toBe(1)
+    expect(normalizeSimilarity(-0.4)).toBe(0)
+    expect(normalizeSimilarity(Number.NaN)).toBe(0)
+    expect(formatSimilarityPercent(0.924)).toBe('92%')
+  })
+
+  it('summarizes result and cluster metadata', () => {
+    expect(summarizeMemorySearchResults([
+      { id: '1', content: 'memory one', similarity: 0.85, cluster: 'A' },
+      { id: '2', content: 'memory two', similarity: 0.62, cluster: 'B' },
+      { id: '3', content: 'memory three', similarity: 0.91, cluster: 'A' },
+    ])).toEqual({
+      resultCount: 3,
+      topSimilarity: 0.91,
+      averageSimilarity: (0.85 + 0.62 + 0.91) / 3,
+      clusterCount: 2,
+      clusters: [
+        { cluster: 'A', count: 2, topSimilarity: 0.91 },
+        { cluster: 'B', count: 1, topSimilarity: 0.62 },
+      ],
+    })
+  })
+
   it('renders input with query', () => {
     const container = document.createElement('div')
     render(h(MemorySearch, { query: 'hello' }), container)
     const input = container.querySelector('input') as HTMLInputElement
     expect(input?.value).toBe('hello')
+  })
+
+  it('syncs input when controlled query changes', async () => {
+    const container = document.createElement('div')
+    render(h(MemorySearch, { query: 'hello' }), container)
+    render(h(MemorySearch, { query: 'updated' }), container)
+    await new Promise((r) => setTimeout(r, 10))
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input?.value).toBe('updated')
   })
 
   it('calls onQueryChange on input', () => {
@@ -45,6 +82,62 @@ describe('MemorySearch', () => {
     expect(container.textContent).toContain('62%')
     expect(container.textContent).toContain('A')
     expect(container.textContent).toContain('B')
+    expect(container.querySelectorAll('[role="progressbar"]').length).toBe(2)
+  })
+
+  it('renders summary and cluster metadata', () => {
+    const container = document.createElement('div')
+    render(
+      h(MemorySearch, {
+        results: [
+          { id: '1', content: 'memory one', similarity: 0.85, cluster: 'A' },
+          { id: '2', content: 'memory two', similarity: 0.62, cluster: 'B' },
+          { id: '3', content: 'memory three', similarity: 0.91, cluster: 'A' },
+        ],
+      }),
+      container,
+    )
+    const root = container.querySelector('[data-memory-search]')
+    const summary = container.querySelector('[data-memory-search-summary]')
+    const cluster = container.querySelector('[data-memory-search-cluster="A"]')
+    expect(root?.getAttribute('data-memory-search-result-count')).toBe('3')
+    expect(root?.getAttribute('data-memory-search-cluster-count')).toBe('2')
+    expect(root?.getAttribute('data-memory-search-top-similarity')).toBe('91')
+    expect(summary?.textContent).toContain('결과 3개')
+    expect(summary?.textContent).toContain('최고 91%')
+    expect(summary?.textContent).toContain('클러스터 2개')
+    expect(cluster?.getAttribute('data-memory-search-cluster-count')).toBe('2')
+    expect(cluster?.textContent).toContain('A 2 · 91%')
+  })
+
+  it('clamps row progress and annotates result rank metadata', () => {
+    const container = document.createElement('div')
+    render(
+      h(MemorySearch, {
+        results: [
+          { id: '1', content: 'too high', similarity: 1.5, cluster: 'A' },
+          { id: '2', content: 'too low', similarity: -0.5, cluster: 'B' },
+        ],
+      }),
+      container,
+    )
+    const rows = container.querySelectorAll('[role="listitem"]')
+    const firstProgress = rows[0]?.querySelector('[role="progressbar"]') as HTMLElement
+    const secondProgress = rows[1]?.querySelector('[role="progressbar"]') as HTMLElement
+    expect(rows[0]?.getAttribute('data-memory-search-result-rank')).toBe('1')
+    expect(rows[0]?.getAttribute('data-memory-search-result-similarity')).toBe('100')
+    expect(rows[0]?.getAttribute('aria-label')).toContain('유사도 100%')
+    expect(firstProgress?.getAttribute('aria-valuenow')).toBe('100')
+    expect(firstProgress?.style.width).toBe('100%')
+    expect(secondProgress?.getAttribute('aria-valuenow')).toBe('0')
+    expect(secondProgress?.style.width).toBe('0%')
+  })
+
+  it('renders an empty state for non-loading searches with no results', () => {
+    const container = document.createElement('div')
+    render(h(MemorySearch, { query: 'missing', results: [] }), container)
+    expect(container.textContent).toContain('검색 결과 없음')
+    expect(container.querySelector('[role="status"]')?.textContent).toBe('검색 결과 없음')
   })
 
   it('applies testId', () => {
@@ -63,7 +156,10 @@ describe('MemorySearch', () => {
     const container = document.createElement('div')
     render(h(MemorySearch, {}), container)
     const input = container.querySelector('input') as HTMLInputElement
+    const summary = container.querySelector('[data-memory-search-summary]')
     expect(input?.getAttribute('aria-label')).toBe('메모리 검색')
+    expect(input?.getAttribute('aria-describedby')).toBe(summary?.id)
+    expect(summary?.id).toContain('memory-search-summary')
   })
 
   it('renders result listitems with role', () => {

--- a/dashboard/src/components/common/memory-search.ts
+++ b/dashboard/src/components/common/memory-search.ts
@@ -4,13 +4,28 @@
 
 import { html } from 'htm/preact'
 import type { FunctionComponent } from 'preact'
-import { useState } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useId } from '../../../design-system/headless-preact/use-id'
 
 export interface MemorySearchResult {
   id: string
   content: string
   similarity: number
   cluster: string
+}
+
+export interface MemorySearchClusterSummary {
+  readonly cluster: string
+  readonly count: number
+  readonly topSimilarity: number
+}
+
+export interface MemorySearchSummary {
+  readonly resultCount: number
+  readonly topSimilarity: number
+  readonly averageSimilarity: number
+  readonly clusterCount: number
+  readonly clusters: MemorySearchClusterSummary[]
 }
 
 interface MemorySearchProps {
@@ -21,6 +36,43 @@ interface MemorySearchProps {
   testId?: string
 }
 
+export function normalizeSimilarity(similarity: number): number {
+  return Number.isFinite(similarity) ? Math.max(0, Math.min(1, similarity)) : 0
+}
+
+export function formatSimilarityPercent(similarity: number): string {
+  return `${Math.round(normalizeSimilarity(similarity) * 100)}%`
+}
+
+export function summarizeMemorySearchResults(results: MemorySearchResult[]): MemorySearchSummary {
+  const clusters = new Map<string, { count: number; topSimilarity: number }>()
+  let totalSimilarity = 0
+  let topSimilarity = 0
+
+  results.forEach((result) => {
+    const similarity = normalizeSimilarity(result.similarity)
+    totalSimilarity += similarity
+    topSimilarity = Math.max(topSimilarity, similarity)
+
+    const cluster = clusters.get(result.cluster) ?? { count: 0, topSimilarity: 0 }
+    cluster.count += 1
+    cluster.topSimilarity = Math.max(cluster.topSimilarity, similarity)
+    clusters.set(result.cluster, cluster)
+  })
+
+  const clusterSummaries = Array.from(clusters.entries())
+    .map(([cluster, summary]) => ({ cluster, ...summary }))
+    .sort((a, b) => b.count - a.count || b.topSimilarity - a.topSimilarity || a.cluster.localeCompare(b.cluster))
+
+  return {
+    resultCount: results.length,
+    topSimilarity,
+    averageSimilarity: results.length === 0 ? 0 : totalSimilarity / results.length,
+    clusterCount: clusterSummaries.length,
+    clusters: clusterSummaries,
+  }
+}
+
 export const MemorySearch: FunctionComponent<MemorySearchProps> = ({
   query = '',
   results = [],
@@ -29,56 +81,116 @@ export const MemorySearch: FunctionComponent<MemorySearchProps> = ({
   testId,
 }) => {
   const [localQuery, setLocalQuery] = useState(query)
+  const summary = useMemo(() => summarizeMemorySearchResults(results), [results])
+  const summaryId = `${useId()}-memory-search-summary`
 
-  const handleInput = (e: InputEvent) => {
+  useEffect(() => {
+    setLocalQuery(query)
+  }, [query])
+
+  const handleInput = (e: Event) => {
     const v = (e.currentTarget as HTMLInputElement).value
     setLocalQuery(v)
     onQueryChange?.(v)
   }
 
   return html`
-    <div class="w-full" data-memory-search data-testid=${testId}>
-      <input
-        type="text"
-        value=${localQuery}
-        onInput=${handleInput}
-        class="w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-fg-primary)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
-        placeholder="기억 검색 (의미적 유사도)..."
-        aria-label="메모리 검색"
-      />
+    <div
+      class="w-full"
+      data-memory-search
+      data-memory-search-result-count=${summary.resultCount}
+      data-memory-search-cluster-count=${summary.clusterCount}
+      data-memory-search-top-similarity=${Math.round(summary.topSimilarity * 100)}
+      data-testid=${testId}
+    >
+      <div class="flex items-center gap-2">
+        <input
+          type="search"
+          value=${localQuery}
+          onInput=${handleInput}
+          class="w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-fg-primary)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+          placeholder="기억 검색 (의미적 유사도)..."
+          aria-label="메모리 검색"
+          aria-describedby=${summaryId}
+        />
+      </div>
+      <div
+        id=${summaryId}
+        class="mt-2 grid grid-cols-3 gap-2 text-3xs text-[var(--color-fg-secondary)]"
+        data-memory-search-summary
+      >
+        <span>결과 ${summary.resultCount}개</span>
+        <span>최고 ${formatSimilarityPercent(summary.topSimilarity)}</span>
+        <span>클러스터 ${summary.clusterCount}개</span>
+      </div>
       ${loading
-        ? html`<div class="mt-2 animate-pulse text-3xs text-[var(--color-fg-secondary)]">검색 중...</div>`
+        ? html`<div class="mt-2 animate-pulse text-3xs text-[var(--color-fg-secondary)]" role="status">검색 중...</div>`
+        : null}
+      ${!loading && localQuery && summary.resultCount === 0
+        ? html`<div class="mt-2 text-3xs text-[var(--color-fg-muted)]" role="status">검색 결과 없음</div>`
+        : null}
+      ${summary.clusters.length > 0
+        ? html`
+            <div class="mt-2 flex flex-wrap gap-1.5" aria-label="관련 메모리 클러스터" data-memory-search-clusters>
+              ${summary.clusters.map(
+                cluster => html`
+                  <span
+                    key=${cluster.cluster}
+                    class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2 py-1 text-3xs text-[var(--color-fg-secondary)]"
+                    data-memory-search-cluster=${cluster.cluster}
+                    data-memory-search-cluster-count=${cluster.count}
+                    data-memory-search-cluster-top=${Math.round(cluster.topSimilarity * 100)}
+                  >
+                    ${cluster.cluster} ${cluster.count} · ${formatSimilarityPercent(cluster.topSimilarity)}
+                  </span>
+                `,
+              )}
+            </div>
+          `
         : null}
       <div class="mt-2 space-y-1" role="list" aria-label="검색 결과">
         ${results.map(
-          r => html`
+          (r, index) => {
+            const similarity = normalizeSimilarity(r.similarity)
+            const percent = Math.round(similarity * 100)
+            return html`
             <div
               key=${r.id}
               class="group flex cursor-pointer items-center gap-3 rounded-[var(--r-1)] px-3 py-2 hover:bg-[var(--color-bg-hover)]"
               role="listitem"
+              aria-label="${index + 1}위 ${r.content}, 유사도 ${percent}%, 클러스터 ${r.cluster}"
+              data-memory-search-result-id=${r.id}
+              data-memory-search-result-rank=${index + 1}
+              data-memory-search-result-cluster=${r.cluster}
+              data-memory-search-result-similarity=${percent}
             >
               <div class="h-1 w-12 overflow-hidden rounded-full bg-[var(--color-bg-elevated)]">
                 <div
                   class="h-full rounded-full"
                   style=${{
-                    width: `${Math.round(r.similarity * 100)}%`,
+                    width: `${percent}%`,
                     background: 'var(--color-accent)',
                   }}
-                  aria-hidden="true"
+                  role="progressbar"
+                  aria-label="${r.content} 유사도"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  aria-valuenow=${percent}
                 ></div>
               </div>
               <span class="w-12 text-3xs text-[var(--color-fg-secondary)]"
-                >${(r.similarity * 100).toFixed(0)}%</span
+                >${formatSimilarityPercent(similarity)}</span
               >
               <span class="flex-1 truncate text-sm text-[var(--color-fg-primary)]"
                 >${r.content}</span
               >
               <span
-                class="text-3xs text-[var(--color-accent)] opacity-0 transition-opacity group-hover:opacity-100"
+                class="text-3xs text-[var(--color-accent)]"
                 >${r.cluster}</span
               >
             </div>
-          `,
+          `
+          },
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add MemorySearch summary helpers for result count, top/average similarity, and cluster aggregation.
- Render a compact semantic-search summary strip plus visible cluster chips with stable data attributes.
- Add accessible result row metadata, clamped similarity progressbars, and controlled-query sync.

## Why it matters
MemorySearch is supposed to expose semantic vector-search output, not just a flat list. This gives operators and tests a direct way to see result volume, top similarity, and related memory clusters while preserving the compact dashboard molecule.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/memory-search.test.ts src/components/common/memory-search.a11y.test.ts` (23 passed)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard run lint` (passes with 3 existing unrelated warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic-import/chunk-size warnings)
- Browser QA via `agent-browser` at 760x620: verified result/cluster/top-similarity metadata, `aria-describedby` summary linkage, clamped progressbars, row labels, no visible overflow, console only Vite debug lines. Screenshot: `/tmp/masc-memory-search-summary-0506.png`.

## Review focus
- `dashboard/src/components/common/memory-search.ts`
- `dashboard/src/components/common/memory-search.test.ts`
- `dashboard/src/components/common/memory-search.a11y.test.ts`