### PR TITLE
fix(keeper): observe approval queue drops

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -535,16 +535,16 @@ let audit_approval_event ?base_path ~event_type ~id ~keeper_name ~tool_name
          | Some value -> [ ("auto_approved", `Bool value) ]
          | None -> []))
     in
-    (try
-       Eio.Mutex.use_rw ~protect:true audit_io_mu (fun () ->
-         Fs_compat.append_jsonl
-           (audit_today_path (Dated_jsonl.base_dir store))
-           json)
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-         record_queue_failure ~keeper_name ~site:"audit_append" ~id
-           ~event_type exn)
+    Eio.Mutex.use_rw ~protect:true audit_io_mu (fun () ->
+      try
+        Fs_compat.append_jsonl
+          (audit_today_path (Dated_jsonl.base_dir store))
+          json
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          record_queue_failure ~keeper_name ~site:"audit_append" ~id
+            ~event_type exn)
 
 let audit_rule_event ?base_path ~event_type (rule : approval_rule) =
   audit_approval_event ?base_path ~event_type ~id:rule.id
@@ -584,9 +584,6 @@ module For_testing = struct
   let reset_audit_store () =
     Eio.Mutex.use_rw ~protect:true audit_stores_mu (fun () ->
       Hashtbl.clear audit_stores)
-
-  let record_failure ~keeper_name ~site exn =
-    record_queue_failure ~keeper_name ~site exn
 end
 
 let generate_id () =

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -129,6 +129,15 @@ let approval_decision_to_string = function
   | Agent_sdk.Hooks.Reject reason -> "reject:" ^ reason
   | Agent_sdk.Hooks.Edit _ -> "edit"
 
+let record_queue_failure ~keeper_name ~site ?(id = "-") ?(event_type = "-") exn =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_approval_queue_failures
+    ~labels:[ ("keeper", keeper_name); ("site", site) ]
+    ();
+  Log.Keeper.warn
+    "approval_queue: %s failed keeper=%s id=%s event=%s err=%s"
+    site keeper_name id event_type (Printexc.to_string exn)
+
 let approval_audit_decision_to_string = function
   | Approval_resolved decision -> approval_decision_to_string decision
   | Approval_expired reason -> "reject:" ^ reason
@@ -526,11 +535,16 @@ let audit_approval_event ?base_path ~event_type ~id ~keeper_name ~tool_name
          | Some value -> [ ("auto_approved", `Bool value) ]
          | None -> []))
     in
-    Safe_ops.protect ~default:() (fun () ->
-      Eio.Mutex.use_rw ~protect:true audit_io_mu (fun () ->
-        Fs_compat.append_jsonl
-          (audit_today_path (Dated_jsonl.base_dir store))
-          json))
+    (try
+       Eio.Mutex.use_rw ~protect:true audit_io_mu (fun () ->
+         Fs_compat.append_jsonl
+           (audit_today_path (Dated_jsonl.base_dir store))
+           json)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+         record_queue_failure ~keeper_name ~site:"audit_append" ~id
+           ~event_type exn)
 
 let audit_rule_event ?base_path ~event_type (rule : approval_rule) =
   audit_approval_event ?base_path ~event_type ~id:rule.id
@@ -570,6 +584,9 @@ module For_testing = struct
   let reset_audit_store () =
     Eio.Mutex.use_rw ~protect:true audit_stores_mu (fun () ->
       Hashtbl.clear audit_stores)
+
+  let record_failure ~keeper_name ~site exn =
+    record_queue_failure ~keeper_name ~site exn
 end
 
 let generate_id () =
@@ -711,7 +728,9 @@ let broadcast_pending entry =
        ])
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> ()
+  | exn ->
+      record_queue_failure ~keeper_name:entry.keeper_name
+        ~site:"broadcast_pending" ~id:entry.id ~event_type:"pending" exn
 
 let record_pending (entry : pending_approval) =
   Log.Keeper.info
@@ -774,7 +793,9 @@ let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
        ])
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> ()
+  | exn ->
+      record_queue_failure ~keeper_name:entry.keeper_name
+        ~site:"broadcast_resolved" ~id:entry.id ~event_type:"resolved" exn
 
 let pending_entry_matches (entry : pending_approval)
     ~keeper_name ~tool_name ~action_key ~input_hash

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -172,7 +172,6 @@ val read_recent_audit :
 
 module For_testing : sig
   val reset_audit_store : unit -> unit
-  val record_failure : keeper_name:string -> site:string -> exn -> unit
 end
 
 (** {1 Submit & await} *)

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -172,6 +172,7 @@ val read_recent_audit :
 
 module For_testing : sig
   val reset_audit_store : unit -> unit
+  val record_failure : keeper_name:string -> site:string -> exn -> unit
 end
 
 (** {1 Submit & await} *)

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -77,24 +77,46 @@ let audit_event_names ~base_path ~keeper_name =
          Yojson.Safe.Util.(json |> member "event" |> to_string))
 
 let test_approval_queue_failure_metric_labels_site () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let keeper_name = "approval-failure-observe-test" in
   let site = "audit_append" in
   let labels = [ ("keeper", keeper_name); ("site", site) ] in
+  let base_path = temp_dir () in
+  let audit_dir =
+    Filename.concat
+      (Filename.concat base_path ".masc")
+      "audit-approvals"
+  in
   let before =
     Masc_mcp.Prometheus.metric_value_or_zero
       Masc_mcp.Prometheus.metric_keeper_approval_queue_failures
       ~labels
       ()
   in
-  AQ.For_testing.record_failure ~keeper_name ~site (Failure "boom");
-  let after =
-    Masc_mcp.Prometheus.metric_value_or_zero
-      Masc_mcp.Prometheus.metric_keeper_approval_queue_failures
-      ~labels
-      ()
-  in
-  Alcotest.(check (float 0.0001)) "failure counter delta" 1.0
-    (after -. before)
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      cleanup_dir base_path)
+    (fun () ->
+      AQ.For_testing.reset_audit_store ();
+      AQ.audit_approval_event ~base_path ~event_type:"warmup"
+        ~id:"audit-failure-warmup" ~keeper_name:(keeper_name ^ "-warmup")
+        ~tool_name:"keeper_shell" ~risk_level:AQ.Medium ();
+      cleanup_dir audit_dir;
+      let oc = open_out_bin audit_dir in
+      close_out oc;
+      AQ.audit_approval_event ~base_path ~event_type:"pending"
+        ~id:"audit-failure-path-test" ~keeper_name ~tool_name:"keeper_shell"
+        ~risk_level:AQ.Medium ();
+      let after =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_approval_queue_failures
+          ~labels
+          ()
+      in
+      Alcotest.(check (float 0.0001)) "failure counter delta" 1.0
+        (after -. before))
 
 let execute_approval_get args =
   Eio_main.run @@ fun env ->

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -76,6 +76,26 @@ let audit_event_names ~base_path ~keeper_name =
   |> List.map (fun json ->
          Yojson.Safe.Util.(json |> member "event" |> to_string))
 
+let test_approval_queue_failure_metric_labels_site () =
+  let keeper_name = "approval-failure-observe-test" in
+  let site = "audit_append" in
+  let labels = [ ("keeper", keeper_name); ("site", site) ] in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_approval_queue_failures
+      ~labels
+      ()
+  in
+  AQ.For_testing.record_failure ~keeper_name ~site (Failure "boom");
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_approval_queue_failures
+      ~labels
+      ()
+  in
+  Alcotest.(check (float 0.0001)) "failure counter delta" 1.0
+    (after -. before)
+
 let execute_approval_get args =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1176,6 +1196,8 @@ let () =
         test_submit_and_await_clock_returns_manual_decision;
       Alcotest.test_case "resolve nonexistent" `Quick test_approval_resolve_nonexistent;
       Alcotest.test_case "cancel cleans up" `Quick test_approval_queue_cancel_cleans_up;
+      Alcotest.test_case "failure observation labels site" `Quick
+        test_approval_queue_failure_metric_labels_site;
       Alcotest.test_case "background pending callback" `Quick
         test_background_pending_callback_and_keeper_lookup;
       Alcotest.test_case "background pending reuses existing entry" `Quick


### PR DESCRIPTION
## Summary
- turn approval audit append failures into explicit keeper warnings and `keeper_approval_queue_failures` metric increments
- observe pending/resolved approval SSE broadcast failures with `site` labels while preserving cancellation semantics
- add a focused regression test for the new metric labels

## Why
Approval queue audit and broadcast failures were previously swallowed, which made dropped approval evidence hard to distinguish from normal non-blocking behavior. The queue still remains non-blocking for these paths, but operators now get a warning and a labeled counter for the failing site.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_hitl_approval.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-hitl-approval-test-0506-case-rebased MASC_BASE_PATH_INPUT=/private/tmp/masc-hitl-approval-test-0506-case-rebased ./_build/default/test/test_hitl_approval.exe test approval_queue 8`

Note: direct full executable runs still need controlled HITL test base-path/config isolation; the focused regression case passed on the rebased branch.