### PR TITLE
refactor(keeper): share stripped path normalization

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -30,6 +30,9 @@ let normalize_path_for_check (path : string) : string =
     let (resolved_base, suffix_parts) = collect_suffix path [] in
     List.fold_left Filename.concat resolved_base suffix_parts
 
+let normalize_path_for_check_stripped path =
+  normalize_path_for_check path |> strip_trailing_slashes
+
 let normalize_allowed_path_for_check ~(root : string) (path : string) : string option =
   let raw = String.trim path in
   if raw = "" then None

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -14,6 +14,9 @@ val strip_trailing_slashes : string -> string
     tree until an ancestor resolves, then reconstructs the suffix. *)
 val normalize_path_for_check : string -> string
 
+(** [normalize_path_for_check] with trailing slashes stripped. *)
+val normalize_path_for_check_stripped : string -> string
+
 (** Normalize an allowed-paths entry against [root], returning [None]
     when blank or unresolvable. *)
 val normalize_allowed_path_for_check :

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -277,7 +277,7 @@ let host_path_of_own_container_path ~(config : Coord.config) ~(meta : keeper_met
   else
     let strip = Keeper_alerting_path.strip_trailing_slashes in
     let normalize path =
-      Keeper_alerting_path.normalize_path_for_check path |> strip
+      Keeper_alerting_path.normalize_path_for_check_stripped path
     in
     let container_root = Keeper_sandbox.container_root meta.name |> normalize in
     let raw_norm = normalize raw in

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -1,8 +1,7 @@
 (** Keeper_sandbox_containment — see .mli for contract. *)
 
 let normalize p =
-  Keeper_alerting_path.normalize_path_for_check p
-  |> Keeper_alerting_path.strip_trailing_slashes
+  Keeper_alerting_path.normalize_path_for_check_stripped p
 
 let starts_with ~prefix s = String.starts_with ~prefix s
 

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -63,8 +63,7 @@ let keeper_private_container_root (meta : keeper_meta) =
 let docker_private_workspace_cwd ~(config : Coord.config) ~(meta : keeper_meta)
     host_cwd =
   let normalize_path_for_containment path =
-    Keeper_alerting_path.normalize_path_for_check path
-    |> Keeper_alerting_path.strip_trailing_slashes
+    Keeper_alerting_path.normalize_path_for_check_stripped path
   in
   let host_root =
     Keeper_sandbox.host_root_abs_of_meta ~config meta
@@ -91,8 +90,7 @@ let rewrite_docker_command_paths ~(config : Coord.config) ~(meta : keeper_meta)
   in
   let normalized_host_root =
     raw_host_root
-    |> Keeper_alerting_path.normalize_path_for_check
-    |> Keeper_alerting_path.strip_trailing_slashes
+    |> Keeper_alerting_path.normalize_path_for_check_stripped
   in
   let container_root = keeper_private_container_root meta in
   let rewritten =

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -16,16 +16,8 @@ type t =
     mutable state : state;
   }
 
-let strip_trailing_slashes path =
-  let rec loop i =
-    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
-  in
-  let len = loop (String.length path) in
-  if len = String.length path then path else String.sub path 0 len
-
 let normalize_path path =
-  Keeper_alerting_path.normalize_path_for_check path
-  |> strip_trailing_slashes
+  Keeper_alerting_path.normalize_path_for_check_stripped path
 
 let create ~(config : Coord.config) ~(meta : keeper_meta)
     ?(network_mode = Network_none) () =
@@ -39,7 +31,9 @@ let create ~(config : Coord.config) ~(meta : keeper_meta)
     config;
     meta;
     host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize_path;
-    container_root = Keeper_sandbox.container_root meta.name |> strip_trailing_slashes;
+    container_root =
+      Keeper_sandbox.container_root meta.name
+      |> Keeper_alerting_path.strip_trailing_slashes;
     uid = Unix.getuid ();
     gid = Unix.getgid ();
     network_mode;

--- a/test/test_keeper_alerting_path_norms.ml
+++ b/test/test_keeper_alerting_path_norms.ml
@@ -123,6 +123,16 @@ let test_raw_looks_repos_typo_rejected () =
     false
     (KAP.raw_looks_like_playground_subdir "repository/foo")
 
+(* ── normalize_path_for_check_stripped ──────────────────────── *)
+
+let test_normalize_path_for_check_stripped_removes_trailing_slash () =
+  let cwd = Sys.getcwd () in
+  let raw = cwd ^ "/" in
+  check_bool "fixture cwd is not root" true (cwd <> "/");
+  Alcotest.(check string) "normalized and stripped"
+    (KAP.normalize_path_for_check cwd)
+    (KAP.normalize_path_for_check_stripped raw)
+
 (* ── format_path_rejection: redaction guarantees ─────────────── *)
 
 let test_format_rejection_includes_raw () =
@@ -241,6 +251,11 @@ let () =
             test_raw_looks_empty_rejected;
           Alcotest.test_case "'repository/foo' sibling typo rejected"
             `Quick test_raw_looks_repos_typo_rejected;
+        ] );
+      ( "normalize_path_for_check_stripped",
+        [
+          Alcotest.test_case "removes trailing slash" `Quick
+            test_normalize_path_for_check_stripped_removes_trailing_slash;
         ] );
       ( "format_path_rejection",
         [

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -145,13 +145,16 @@ let with_fake_docker script f =
   let dir = temp_dir () in
   let docker_path = Filename.concat dir "docker" in
   let gh_path = Filename.concat dir "gh" in
-  write_file docker_path script;
-  write_file gh_path
+  let fake_gh_auth_status_ok =
     "#!/bin/sh\n\
      if [ \"$1\" = \"auth\" ] && [ \"$2\" = \"status\" ]; then\n\
-       exit 0\n\
+     \  exit 0\n\
      fi\n\
-     exit 0\n";
+     printf 'unexpected gh invocation: %s\\n' \"$*\" >&2\n\
+     exit 2\n"
+  in
+  write_file docker_path script;
+  write_file gh_path fake_gh_auth_status_ok;
   Unix.chmod docker_path 0o755;
   Unix.chmod gh_path 0o755;
   let path =
@@ -166,22 +169,18 @@ let with_fake_docker script f =
 let with_tool_policy_config f =
   let project_root = Masc_test_deps.find_project_root () in
   let config_dir = Filename.concat project_root "config" in
+  let reset () =
+    Masc_mcp.Config_dir_resolver.reset ();
+    Tool_code_write.reset_policy_config_cache ();
+    Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ()
+  in
+  reset ();
   with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
-  Masc_mcp.Config_dir_resolver.reset ();
-  Tool_code_write.reset_policy_config_cache ();
-  Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ();
-  Fun.protect
-    ~finally:(fun () ->
-      Tool_code_write.reset_policy_config_cache ();
-      Masc_mcp.Keeper_tool_policy.reset_policy_config_for_test ();
-      Masc_mcp.Config_dir_resolver.reset ())
-    (fun () ->
-      (match
-         Masc_mcp.Keeper_tool_policy.init_policy_config ~base_path:project_root
-       with
-       | Ok () -> ()
-       | Error e -> Alcotest.failf "init_policy_config failed: %s" e);
-      f ())
+  reset ();
+  Fun.protect ~finally:reset @@ fun () ->
+  match Masc_mcp.Keeper_tool_policy.init_policy_config ~base_path:project_root with
+  | Ok () -> f ()
+  | Error msg -> Alcotest.failf "init_policy_config failed: %s" msg
 
 let with_config_dir config_dir f =
   let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in


### PR DESCRIPTION
## Summary

- add `normalize_path_for_check_stripped` as the shared helper for normalized, trailing-slash-free path comparisons
- switch keeper sandbox containment, turn runtime, docker shell path rewrite, and exec path mapping to the shared helper
- harden `test_keeper_shell_docker_route` fixtures so fake Docker tests do not depend on ambient `gh` auth or a preloaded keeper tool policy cache

## Why

Keeper playground and docker boundary checks repeatedly open-coded `normalize_path_for_check |> strip_trailing_slashes`. Centralizing that pattern keeps `/base/.masc/playground/...` comparisons consistent across containment, runtime, and docker git dispatch paths, reducing drift in the code that decides whether a keeper is working inside its own sandbox.

## Validation

- `git diff --check origin/main...HEAD`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_alerting_path_norms.exe test/test_keeper_sandbox_containment.exe test/test_keeper_shell_docker_route.exe test/test_keeper_shell_docker_cwd_response.exe`
- `./_build/default/test/test_keeper_alerting_path_norms.exe --color=never`
- `./_build/default/test/test_keeper_sandbox_containment.exe --color=never`
- `./_build/default/test/test_keeper_shell_docker_route.exe --color=never`
- `./_build/default/test/test_keeper_shell_docker_cwd_response.exe --color=never`
