### PR TITLE
fix(keeper): label stale batch root cause

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -121,6 +121,88 @@ let stale_kill_class_label (cls : Keeper_registry.stale_kill_class) : string =
   | In_turn_hung _ -> "in_turn_hung"
   | Noop_failure_loop _ -> "noop_failure_loop"
 
+type batch_root_cause =
+  | Cascade_unhealthy
+  | Provider_auth
+  | Fd_exhaustion
+  | Mixed
+  | Unknown
+
+let batch_root_cause_to_string = function
+  | Cascade_unhealthy -> "cascade_unhealthy"
+  | Provider_auth -> "provider_auth"
+  | Fd_exhaustion -> "fd_exhaustion"
+  | Mixed -> "mixed"
+  | Unknown -> "unknown"
+
+let contains_any_ci haystack needles =
+  List.exists
+    (fun needle -> String_util.contains_substring_ci haystack needle)
+    needles
+
+let provider_auth_failure ~code ~detail =
+  contains_any_ci code
+    [ "auth"; "unauthorized"; "permission_denied"; "permission denied" ]
+  || contains_any_ci detail
+       [
+         "auth";
+         "unauthorized";
+         "invalid api key";
+         "bad key";
+         "permission denied";
+       ]
+
+let fd_exhaustion_failure detail =
+  contains_any_ci detail
+    [
+      "too many open files";
+      "file descriptor";
+      "fd leak";
+      "os error 24";
+      "emfile";
+    ]
+
+let failure_reason_batch_root_cause
+    (reason : Keeper_registry.failure_reason) : batch_root_cause option =
+  match reason with
+  | Provider_runtime_error { code; detail }
+    when provider_auth_failure ~code ~detail ->
+      Some Provider_auth
+  | Exception detail when fd_exhaustion_failure detail ->
+      Some Fd_exhaustion
+  | Stale_turn_timeout _
+  | Stale_termination_storm _
+  | Oas_timeout_budget_loop _
+  | Provider_runtime_error _ ->
+      Some Cascade_unhealthy
+  | Heartbeat_consecutive_failures _
+  | Turn_consecutive_failures _
+  | Tool_required_unsatisfied _
+  | Ambiguous_partial_commit _
+  | Fiber_unresolved
+  | Exception _ ->
+      None
+
+let classify_batch_root_cause reasons =
+  let causes =
+    reasons
+    |> List.filter_map failure_reason_batch_root_cause
+    |> List.sort_uniq compare
+  in
+  match causes with
+  | [] -> Unknown
+  | [ cause ] -> cause
+  | _ -> Mixed
+
+let classify_batch_root_cause_for_test = classify_batch_root_cause
+
+let batch_failure_reasons ~base_path keeper_names =
+  keeper_names
+  |> List.filter_map (fun keeper_name ->
+         match Keeper_registry.get ~base_path keeper_name with
+         | Some entry -> entry.last_failure_reason
+         | None -> None)
+
 let slot_holder_age ~now keeper_name =
   let holder_age holders = List.assoc_opt keeper_name holders in
   [
@@ -188,15 +270,14 @@ let () =
    cross-keeper pattern.  Issue evidence: 8 keepers terminated
    within the same second at 12:54:13Z (analyst, executor,
    issue_king, janitor, masc-improver, nick0cave, ollama-local,
-   qa-king).  That shape is a *systemic* signal — typically cascade
-   dead (#10474), provider auth failure, or fd exhaustion (#10745) —
-   not 8 independent stuck fibers.  The supervisor will keep
-   restarting each one individually unless an operator notices.
+   qa-king).  That shape is a *systemic* signal, not 8 independent
+   stuck fibers.  The supervisor will keep restarting each one
+   individually unless an operator notices.
 
    Track recent terminations across all keepers in a small bounded
    window.  When the number of distinct keepers in the window
-   reaches the threshold we emit a fleet-tier ERROR pointing at the
-   systemic root-cause issue list, plus a Prometheus counter.  No
+   reaches the threshold we emit a fleet-tier ERROR and a Prometheus
+   counter labelled by the low-cardinality [batch_root_cause].  No
    state-machine change: the per-keeper restart still proceeds.  The
    point is to make the batch event visible at all. *)
 let batch_window_sec = Env_config_keeper.KeeperWatchdog.batch_window_sec
@@ -505,17 +586,25 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                   comment on [batch_terminations] for rationale. *)
                let batch = record_batch_termination meta.name now in
                if List.length batch >= batch_threshold then begin
+                 let root_cause =
+                   batch_failure_reasons ~base_path batch
+                   |> classify_batch_root_cause
+                 in
+                 let root_cause_label =
+                   batch_root_cause_to_string root_cause
+                 in
                  Prometheus.inc_counter
                    Prometheus.metric_keeper_stale_termination_batch
+                   ~labels:[ ("root_cause", root_cause_label) ]
                    ();
                  Log.Keeper.error
                    "FLEET BATCH TERMINATION: %d distinct keepers \
                     terminated in last %.0fs [%s] — systemic signal \
-                    (cascade dead, provider auth, fd leak).  \
+                    root_cause=%s.  \
                     Per-keeper restarts will loop without operator \
                     intervention.  See #10765, #10474, #10745."
                    (List.length batch) batch_window_sec
-                   (String.concat ", " batch)
+                   (String.concat ", " batch) root_cause_label
                end;
                (try
                   Keeper_execution_receipt.emit_stale_keeper_broadcast

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -10,6 +10,23 @@ val slot_holder_age_for_test :
     the oldest slot-holder age for [keeper_name] across turn, reactive,
     and autonomous holder tables. *)
 
+type batch_root_cause =
+  | Cascade_unhealthy
+  | Provider_auth
+  | Fd_exhaustion
+  | Mixed
+  | Unknown
+(** Low-cardinality root-cause label for fleet-wide stale termination
+    batches.  This is derived from already-latched keeper failure
+    reasons, so dashboards get a typed signal instead of parsing the
+    batch log line. *)
+
+val batch_root_cause_to_string : batch_root_cause -> string
+
+val classify_batch_root_cause_for_test :
+  Keeper_registry.failure_reason list -> batch_root_cause
+(** Test-only view of the batch root-cause classifier. *)
+
 val fork_stale_watchdog :
   'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
 (** Fork a stale-turn watchdog fiber for the given keeper.

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2209,7 +2209,7 @@ let init () =
   add metric_keeper_stale_termination_threshold_breached
     "Total stale termination threshold breaches triggering auto-pause.      Labels: keeper." Counter;
   add metric_keeper_stale_termination_batch
-    "Total fleet-wide batch termination events (multiple keepers terminated      within the batch window)." Counter;
+    "Total fleet-wide batch termination events (multiple keepers terminated      within the batch window). Labels: root_cause." Counter;
   add metric_keeper_stale_broadcast_emit_failures
     "Total failures emitting stale keeper broadcast events. Labels: keeper." Counter;
   add metric_keeper_tool_use_failure

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -10,6 +10,8 @@
 
 open Masc_mcp.Keeper_registry
 
+module SW = Masc_mcp.Keeper_stale_watchdog
+
 let r = Alcotest.(check string)
 
 let test_idle_turn_label () =
@@ -126,6 +128,50 @@ let test_stale_watchdog_uses_stale_reason_without_terminal_prior () =
         (failure_reason_to_string reason)
   | None -> Alcotest.fail "expected stale reason"
 
+let root_cause_label reasons =
+  reasons
+  |> SW.classify_batch_root_cause_for_test
+  |> SW.batch_root_cause_to_string
+
+let test_batch_root_cause_labels () =
+  r "cascade_unhealthy label" "cascade_unhealthy"
+    (SW.batch_root_cause_to_string SW.Cascade_unhealthy);
+  r "provider_auth label" "provider_auth"
+    (SW.batch_root_cause_to_string SW.Provider_auth);
+  r "fd_exhaustion label" "fd_exhaustion"
+    (SW.batch_root_cause_to_string SW.Fd_exhaustion);
+  r "mixed label" "mixed" (SW.batch_root_cause_to_string SW.Mixed);
+  r "unknown label" "unknown" (SW.batch_root_cause_to_string SW.Unknown)
+
+let test_batch_root_cause_provider_auth () =
+  r "provider auth" "provider_auth"
+    (root_cause_label
+       [
+         Provider_runtime_error
+           { code = "auth_error"; detail = "bad key rejected" };
+       ])
+
+let test_batch_root_cause_fd_exhaustion () =
+  r "fd exhaustion" "fd_exhaustion"
+    (root_cause_label [ Exception "too many open files (os error 24)" ])
+
+let test_batch_root_cause_cascade_unhealthy () =
+  r "cascade unhealthy" "cascade_unhealthy"
+    (root_cause_label [ Oas_timeout_budget_loop { count = 2 } ])
+
+let test_batch_root_cause_mixed () =
+  r "mixed" "mixed"
+    (root_cause_label
+       [
+         Provider_runtime_error
+           { code = "auth_error"; detail = "bad key rejected" };
+         Exception "too many open files";
+       ])
+
+let test_batch_root_cause_unknown () =
+  r "unknown" "unknown"
+    (root_cause_label [ Heartbeat_consecutive_failures 3 ])
+
 let () =
   Alcotest.run "stale_kill_class"
     [
@@ -167,5 +213,18 @@ let () =
             test_stale_watchdog_preserves_terminal_failure_reason;
           Alcotest.test_case "uses stale reason without terminal prior" `Quick
             test_stale_watchdog_uses_stale_reason_without_terminal_prior;
+        ] );
+      ( "batch_root_cause",
+        [
+          Alcotest.test_case "labels" `Quick test_batch_root_cause_labels;
+          Alcotest.test_case "provider auth" `Quick
+            test_batch_root_cause_provider_auth;
+          Alcotest.test_case "fd exhaustion" `Quick
+            test_batch_root_cause_fd_exhaustion;
+          Alcotest.test_case "cascade unhealthy" `Quick
+            test_batch_root_cause_cascade_unhealthy;
+          Alcotest.test_case "mixed" `Quick test_batch_root_cause_mixed;
+          Alcotest.test_case "unknown" `Quick
+            test_batch_root_cause_unknown;
         ] );
     ]


### PR DESCRIPTION
## Summary

- add a typed low-cardinality `batch_root_cause` classifier for fleet-wide stale termination batches
- label `masc_keeper_stale_termination_batch_total` with `root_cause`
- include the typed root cause in the fleet batch termination log and pin labels in the stale watchdog test

## Why

Refs #11266 Track 2b.

The batch watchdog already detected simultaneous keeper terminations, but the operator-facing root cause lived only in a hardcoded text hint: cascade dead / provider auth / fd leak. This makes the signal queryable as `root_cause={cascade_unhealthy,provider_auth,fd_exhaustion,mixed,unknown}` while keeping the existing batch counter and per-keeper restart behavior intact.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing lib/keeper/keeper_stale_watchdog.mli lib/keeper/keeper_stale_watchdog.ml test/test_stale_kill_class.ml lib/prometheus.ml`
- `scripts/dune-local.sh build test/test_stale_kill_class.exe test/test_keeper_turn_slot_holders.exe`
- `./_build/default/test/test_stale_kill_class.exe`
- `./_build/default/test/test_keeper_turn_slot_holders.exe`
