### PR TITLE
[P2] Fix cockpit IDE rows and plane pop-outs

### DIFF
--- a/dashboard/cockpit-kit/Planes.jsx
+++ b/dashboard/cockpit-kit/Planes.jsx
@@ -6,9 +6,8 @@
 const { useState: usePlaneState } = React;
 
 // ─── shared header ───────────────────────────────────────────
-function PlaneHeader({ title, subtitle, branch, keepers }) {
+function PlaneHeader({ title, subtitle, branch, keepers, popoutId }) {
   const sk = keepers || new Set();
-  const planeId = "plane-" + (title || "").toLowerCase().trim();
   return (
     <div className="plane-hdr">
       <span className="ti">{title}</span>
@@ -17,23 +16,25 @@ function PlaneHeader({ title, subtitle, branch, keepers }) {
         <span>⎇ <span className="br">{branch || "main"}</span></span>
         <span>·</span>
         <span><span className="kp">{sk.size}</span> keepers selected</span>
-        <a className="wx-popout"
-           href={"?widget=" + planeId}
-           target="_blank" rel="noopener"
-           title="open plane in new tab"
-           style={{marginLeft:"8px"}}>↗</a>
+        {popoutId && (
+          <a className="wx-popout"
+             href={"?widget=" + popoutId}
+             target="_blank" rel="noopener"
+             title="open plane in new tab"
+             style={{marginLeft:"8px"}}>↗</a>
+        )}
       </span>
     </div>
   );
 }
 
 // ─── shared tabbed shell ─────────────────────────────────────
-function PlaneShell({ title, subtitle, branch, keepers, tabs, defaultTab }) {
+function PlaneShell({ title, subtitle, branch, keepers, tabs, defaultTab, popoutId }) {
   const [tab, setTab] = usePlaneState(defaultTab || tabs[0].id);
   const cur = tabs.find(t => t.id === tab) || tabs[0];
   return (
     <div className="plane">
-      <PlaneHeader title={title} subtitle={subtitle} branch={branch} keepers={keepers} />
+      <PlaneHeader title={title} subtitle={subtitle} branch={branch} keepers={keepers} popoutId={popoutId} />
       <div className="plane-tabs">
         {tabs.map(t => (
           <button key={t.id} className={tab === t.id ? "active" : ""} onClick={() => setTab(t.id)}>{t.label}</button>
@@ -53,6 +54,7 @@ function WorkPlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Work Plane" subtitle="Goals · Tasks · Accountability"
+      popoutId="plane-work"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"goal-h",   label:"Goal · Horizon",     render: () => <window.GoalHorizonTrack/> },
@@ -75,6 +77,7 @@ function CommsPlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Comms Plane" subtitle="Board · Messages · Composer v2"
+      popoutId="plane-comms"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"bd-feed", label:"Board · Feed",      render: () => <window.BoardFeed/> },
@@ -98,6 +101,7 @@ function ObservePlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Observability" subtitle="Cascade · Audit · Safe Autonomy · Cost · Heuristic"
+      popoutId="plane-observe"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"cs-list", label:"Cascade · List",       render: () => <window.CascadeList/> },
@@ -127,6 +131,7 @@ function CognitionPlane({ branch, keepers }) {
   return (
     <PlaneShell
       title="Cognition" subtitle="Keeper Inspector · Decisions · Memory · Episodes · Autoresearch"
+      popoutId="plane-cognition"
       branch={branch} keepers={keepers}
       tabs={[
         { id:"ki-bdi",  label:"Keeper · BDI",         render: () => <window.KeeperBDIPanel/> },
@@ -175,18 +180,13 @@ function IdePlane({ branch, keepers }) {
 
   // open shared drawer with terminal tab as a hint
   const openTerminal = () => {
-    const cur = (window.MASC_EXT && window.useCockpitState) ? null : null;
-    if (window.useCockpitState) {
-      // push a state change via the singleton helper
-      const ev = new CustomEvent("masc-drawer-set", { detail: { open: true, tab: "terminal" }});
-      window.dispatchEvent(ev);
-    }
+    window.dispatchEvent(new CustomEvent("masc-drawer-set", { detail: { open: true, tab: "terminal" } }));
   };
 
   const centerPanelId = `ide-v2-center-${mode}`;
   return (
     <div className="plane ide-v2 ide-v3" role="region" aria-label="IDE Plane">
-      <PlaneHeader title="IDE" subtitle="tree · editor · PR · graph · search" branch={branch} keepers={keepers} />
+      <PlaneHeader title="IDE" subtitle="tree · editor · PR · graph · search" branch={branch} keepers={keepers} popoutId="plane-ide" />
       <div className="ide-v2-modebar ide-v3-modebar">
         <div className="ide-v2-branch">
           <span className="lbl">branch</span>

--- a/dashboard/cockpit-kit/cockpit.css
+++ b/dashboard/cockpit-kit/cockpit.css
@@ -852,13 +852,16 @@ button { font: inherit; }
   min-height: 0;
   display: grid;
   grid-template-columns: minmax(220px, 25%) minmax(0, 1fr) minmax(260px, 28%);
-  grid-template-rows: minmax(0, 1fr) minmax(180px, 34%);
+  grid-template-rows: minmax(0, 1fr);
   gap: var(--sp-2);
   padding: 8px;
   background: var(--color-bg-page);
 }
 .ide-v2-body.wide {
   grid-template-columns: minmax(220px, 25%) minmax(0, 1fr);
+}
+.ide-v2-body.term-open {
+  grid-template-rows: minmax(0, 1fr) minmax(180px, 34%);
 }
 .ide-v2-tree,
 .ide-v2-center,
@@ -868,7 +871,8 @@ button { font: inherit; }
   min-height: 0;
   overflow: hidden;
 }
-.ide-v2-tree { grid-row: 1 / span 2; }
+.ide-v2-tree { grid-row: 1; }
+.ide-v2-body.term-open .ide-v2-tree { grid-row: 1 / span 2; }
 .ide-v2-center { grid-column: 2; grid-row: 1; }
 .ide-v2-right { grid-column: 3; grid-row: 1; }
 .ide-v2-right-stack {
@@ -879,26 +883,31 @@ button { font: inherit; }
   gap: var(--sp-2);
 }
 .ide-v2-terminal {
+  display: none;
   grid-column: 2 / span 2;
   grid-row: 2;
 }
+.ide-v2-body.term-open .ide-v2-terminal { display: block; }
 .ide-v2-body.wide .ide-v2-terminal { grid-column: 2; }
-.ide-v2-body:not(.term-open) { grid-template-rows: minmax(0, 1fr); }
 
 @media (max-width: 1200px) {
   .ide-v2-body,
   .ide-v2-body.wide {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto minmax(360px, 1fr) auto auto;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
   }
   .ide-v2-tree,
   .ide-v2-center,
   .ide-v2-right,
   .ide-v2-terminal {
-    grid-column: 1;
+    grid-column: auto;
     grid-row: auto;
+    flex: 0 0 auto;
     min-height: 240px;
   }
+  .ide-v2-center { flex-basis: 360px; }
+  .ide-v2-terminal { min-height: 180px; }
   .ide-v2-modebar {
     grid-template-columns: 1fr;
   }

--- a/dashboard/design-system/ui_kits/cockpit/cockpit.css
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit.css
@@ -852,13 +852,16 @@ button { font: inherit; }
   min-height: 0;
   display: grid;
   grid-template-columns: minmax(220px, 25%) minmax(0, 1fr) minmax(260px, 28%);
-  grid-template-rows: minmax(0, 1fr) minmax(180px, 34%);
+  grid-template-rows: minmax(0, 1fr);
   gap: 8px;
   padding: 8px;
   background: var(--color-bg-page);
 }
 .ide-v2-body.wide {
   grid-template-columns: minmax(220px, 25%) minmax(0, 1fr);
+}
+.ide-v2-body.term-open {
+  grid-template-rows: minmax(0, 1fr) minmax(180px, 34%);
 }
 .ide-v2-tree,
 .ide-v2-center,
@@ -868,7 +871,8 @@ button { font: inherit; }
   min-height: 0;
   overflow: hidden;
 }
-.ide-v2-tree { grid-row: 1 / span 2; }
+.ide-v2-tree { grid-row: 1; }
+.ide-v2-body.term-open .ide-v2-tree { grid-row: 1 / span 2; }
 .ide-v2-center { grid-column: 2; grid-row: 1; }
 .ide-v2-right { grid-column: 3; grid-row: 1; }
 .ide-v2-right-stack {
@@ -879,26 +883,31 @@ button { font: inherit; }
   gap: 8px;
 }
 .ide-v2-terminal {
+  display: none;
   grid-column: 2 / span 2;
   grid-row: 2;
 }
+.ide-v2-body.term-open .ide-v2-terminal { display: block; }
 .ide-v2-body.wide .ide-v2-terminal { grid-column: 2; }
-.ide-v2-body:not(.term-open) { grid-template-rows: minmax(0, 1fr); }
 
 @media (max-width: 1200px) {
   .ide-v2-body,
   .ide-v2-body.wide {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto minmax(360px, 1fr) auto auto;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
   }
   .ide-v2-tree,
   .ide-v2-center,
   .ide-v2-right,
   .ide-v2-terminal {
-    grid-column: 1;
+    grid-column: auto;
     grid-row: auto;
+    flex: 0 0 auto;
     min-height: 240px;
   }
+  .ide-v2-center { flex-basis: 360px; }
+  .ide-v2-terminal { min-height: 180px; }
   .ide-v2-modebar {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- align `dashboard/cockpit-kit` plane pop-out links with `WidgetSolo.jsx` registered ids: `plane-work`, `plane-comms`, `plane-observe`, `plane-cognition`, and `plane-ide`
- collapse IDE plane desktop layout to one grid row by default now that the embedded terminal moved to the shared drawer
- switch narrow IDE layout to a scrollable column stack to prevent tree/editor/rail overlap when viewport height is constrained
- mirror the IDE CSS behavior in the design-system cockpit kit

## Why it matters
This is the cockpit usability slice for Goal 4 task 4-3 and task 4-4. The previous plane pop-out links could generate ids that the solo viewer does not register, and the IDE plane still carried terminal-row layout rules after the terminal moved into the shared drawer.

The operator impact is practical: cockpit pop-outs should open the intended plane every time, and the IDE plane should stay scan-friendly at 1440px+ while degrading cleanly on narrower screens without overlapping the file tree, editor, or right rail.

## Verification
- `git diff --check`
- Browser static check: `http://127.0.0.1:8028/cockpit-kit/index.html`, IDE mode at `1440x900` -> `.ide-v2-body` display `grid`, `gridTemplateRows = 594px`, children tree/center/right aligned on one row
- Browser static check: IDE mode at `1000x820` -> `.ide-v2-body` display `flex`, children stack vertically without overlap
- Browser static check: `?widget=plane-work` and `?widget=plane-ide` render solo views without page errors
- GitHub checks currently pass for CI Gate and Draft Auto-Merge Guard on this draft PR.

## Review focus
- Confirm cockpit-kit pop-out ids match `WidgetSolo.jsx` exactly instead of title-derived strings.
- Confirm the cockpit-kit CSS and design-system mirror remain aligned for desktop grid and narrow stacked layouts.
- Confirm there is no leftover implicit terminal row in the default IDE plane layout.

Closes #13565
