### PR TITLE
fix(keeper): observe registry phase broadcast failures

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -521,6 +521,15 @@ let broadcast_composite_changed ~name ~ts_unix =
         "registry: broadcast_composite_changed name=%s failed: %s"
         name (Printexc.to_string exn)
 
+let record_phase_broadcast_failure ~name exn =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_sse_broadcast_failures
+    ~labels:[("keeper", name); ("site", "phase_changed")]
+    ();
+  Log.Keeper.warn
+    "registry: keeper_phase_changed broadcast failed name=%s err=%s"
+    name (Printexc.to_string exn)
+
 let completed_turn_outcome_of_observation
     (obs : turn_observation) : Keeper_transition_audit.completed_turn_outcome =
   (* P1 silent-failure fix: the previous wildcard `| _ -> Turn_failed`
@@ -1235,7 +1244,7 @@ let rec dispatch_event_with_audit
              ])
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
-        | _exn -> ());
+        | exn -> record_phase_broadcast_failure ~name exn);
        (* Update running count based on phase transition *)
        (match tr.prev_phase, tr.new_phase with
         | Running, phase when phase <> Running ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1828,7 +1828,8 @@ let init () =
      data loss. Labeled by keeper."
     Counter;
   add metric_keeper_sse_broadcast_failures
-    "Total in-turn heartbeat SSE broadcast failures. Labeled by keeper."
+    "Total keeper SSE broadcast failures. Labeled by keeper and site \
+     when available."
     Counter;
   add metric_keeper_room_heartbeat_failures
     "Total room heartbeat failures (consecutive, leads to crash). \

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -475,6 +475,40 @@ let test_dispatch_event_emits_lifecycle_transition_metric_only_on_phase_change (
   check (float 0.001) "phase-change transition metric incremented"
     (changed_before +. 1.0) changed_after
 
+let test_dispatch_event_observes_phase_sse_broadcast_failure () =
+  R.clear ();
+  let keeper_name = "k4-lifecycle-sse-failure" in
+  let labels = [("keeper", keeper_name); ("site", "phase_changed")] in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_sse_broadcast_failures
+      ~labels ()
+  in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Masc_mcp.Sse.buffer_commit_test_hook None)
+    (fun () ->
+      Atomic.set Masc_mcp.Sse.buffer_commit_test_hook
+        (Some (fun () -> failwith "forced phase broadcast failure"));
+      match R.dispatch_event ~base_path:bp keeper_name KSM.Operator_pause with
+      | Error err ->
+          fail
+            (KSM.transition_error_to_string err)
+      | Ok _ -> ());
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_sse_broadcast_failures
+      ~labels ()
+  in
+  check (float 0.001) "phase SSE failure metric incremented"
+    (before +. 1.0) after;
+  match R.get ~base_path:bp keeper_name with
+  | None -> fail "expected registered keeper"
+  | Some entry ->
+      check string "phase transition still applied" "paused"
+        (KSM.phase_to_string entry.phase)
+
 let test_extended_states () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k4x" (make_meta "k4x") in
@@ -1311,6 +1345,8 @@ let () =
             test_dispatch_event_emits_phase_sse;
           eio_test "dispatch event emits lifecycle metric only on phase change"
             test_dispatch_event_emits_lifecycle_transition_metric_only_on_phase_change;
+          eio_test "dispatch event observes phase SSE broadcast failure"
+            test_dispatch_event_observes_phase_sse_broadcast_failure;
           eio_test "extended states" test_extended_states;
           eio_test "stopped entry action is observability-only"
             test_stopped_entry_action_is_observability_only;

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -485,9 +485,10 @@ let test_dispatch_event_observes_phase_sse_broadcast_failure () =
       ~labels ()
   in
   ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  let original_hook = Atomic.get Masc_mcp.Sse.buffer_commit_test_hook in
   Fun.protect
     ~finally:(fun () ->
-      Atomic.set Masc_mcp.Sse.buffer_commit_test_hook None)
+      Atomic.set Masc_mcp.Sse.buffer_commit_test_hook original_hook)
     (fun () ->
       Atomic.set Masc_mcp.Sse.buffer_commit_test_hook
         (Some (fun () -> failwith "forced phase broadcast failure"));


### PR DESCRIPTION
## Summary
- replace the silent `keeper_phase_changed` SSE broadcast catch in `Keeper_registry.dispatch_event` with a warning and `keeper_sse_broadcast_failures` metric increment
- label the metric with `site=phase_changed` so phase-change broadcast failures can be separated from heartbeat/presence broadcast failures
- add a focused registry regression test that forces `Sse.broadcast` to raise and proves the phase transition still applies

## Why
Phase transitions are core runtime-truth signals for keepers. If the phase transition applies but the SSE notification path fails, operators should see that as an observability failure instead of a silent missing dashboard update.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_registry.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-keeper-registry-sse-0506 MASC_BASE_PATH_INPUT=/private/tmp/masc-keeper-registry-sse-0506 ./_build/default/test/test_keeper_registry.exe test basic 16`