### PR TITLE
fix(keeper): persist route evidence for keeper tool calls

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -8,7 +8,23 @@ type tool_call_detail =
   ; provider : string
   ; outcome : string
   ; latency_ms : float
+  ; route_evidence : Yojson.Safe.t option
   }
+
+let tool_call_detail_to_json (detail : tool_call_detail) =
+  let route_evidence_field =
+    match detail.route_evidence with
+    | Some evidence -> [ ("route_evidence", evidence) ]
+    | None -> []
+  in
+  `Assoc
+    ([
+       ("tool_name", `String detail.tool_name);
+       ("provider", `String detail.provider);
+       ("outcome", `String detail.outcome);
+       ("latency_ms", `Float detail.latency_ms);
+     ]
+     @ route_evidence_field)
 
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -5,7 +5,10 @@ type tool_call_detail =
   ; provider : string
   ; outcome : string
   ; latency_ms : float
+  ; route_evidence : Yojson.Safe.t option
   }
+
+val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
 
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -69,7 +69,10 @@ type tool_call_detail =
   ; provider : string
   ; outcome : string
   ; latency_ms : float
+  ; route_evidence : Yojson.Safe.t option
   }
+
+val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
 
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -984,11 +984,17 @@ let prepare_agent_setup
       ?trajectory_acc
       ~on_tool_executed:(fun
           ~tool_name
-          ~input:_
-          ~output_text:_
+          ~input
+          ~output_text
           ~success
           ~duration_ms
           ~provider ->
+        let route_evidence =
+          Keeper_tool_call_log.route_evidence_json_of_tool_io
+            ~tool_name
+            ~input
+            ~output_text
+        in
         (match Keeper_registry.get ~base_path:config.base_path meta.name with
          | Some entry ->
            acc.meta <- entry.meta;
@@ -999,6 +1005,7 @@ let prepare_agent_setup
           ; provider
           ; outcome = if success then "ok" else "error"
           ; latency_ms = duration_ms
+          ; route_evidence
           }
           :: acc.tool_calls)
       ~discover_work_nudge

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -604,12 +604,24 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   | Some c -> `Float c
                   | None -> `Null
                 in
+                let tool_call_evidence =
+                  result.tool_calls
+                  |> List.filter_map (fun detail ->
+                         match detail.Keeper_agent_run.route_evidence with
+                         | Some _ ->
+                             Some
+                               (Keeper_agent_run.tool_call_detail_to_json
+                                  detail)
+                         | None -> None)
+                in
                 `Assoc [
                   ("reply", `String result.response_text);
                   ("model", `String surface_model_used);
                   ("model_used_raw", `String result.model_used);
                   ("turns", `Int result.turn_count);
                   ("tool_calls", `Int result.tool_calls_made);
+                  ( "tool_call_evidence",
+                    `List tool_call_evidence );
                   ("usage", `Assoc [
                     ("input_tokens", `Int u.input_tokens);
                     ("output_tokens", `Int u.output_tokens);

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -488,12 +488,7 @@ let decision_id ~(meta : keeper_meta) ~(ts : float) ~(suffix_seed : string) : st
 let tool_call_detail_to_json
     (detail : Keeper_agent_run.tool_call_detail)
   : Yojson.Safe.t =
-  `Assoc
-    [ ("tool_name", `String detail.tool_name)
-    ; ("provider", `String detail.provider)
-    ; ("outcome", `String detail.outcome)
-    ; ("latency_ms", `Float detail.latency_ms)
-    ]
+  Keeper_agent_run.tool_call_detail_to_json detail
 
 let provider_context_json ~(meta : keeper_meta)
     (result : Keeper_agent_run.run_result option) =

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -264,11 +264,17 @@ let route_safe_input_string value =
     (Observability_redact.redact_preview ~max_len:max_output_len)
     value
 
+let route_text_for_evidence output_text =
+  match Tool_output.decode_from_oas output_text with
+  | Tool_output.Stored { preview; _ } -> preview
+  | Tool_output.Inline value -> value
+
 let route_evidence_json_of_tool_io ~tool_name ~input ~output_text =
+  let route_text = route_text_for_evidence output_text in
   let parsed_output =
     match Safe_ops.parse_json_safe
             ~context:"Keeper_tool_call_log.route_evidence"
-            output_text
+            route_text
     with
     | Ok json -> Some json
     | Error _ -> None
@@ -301,9 +307,11 @@ let route_evidence_json_of_tool_io ~tool_name ~input ~output_text =
   let output_json = Option.value ~default:(`Assoc []) route_json in
   let pr_url =
     match parsed_output with
-    | Some json -> route_output_url json output_text
-    | None -> github_pull_url_of_text output_text
+    | Some json -> route_output_url json route_text
+    | None -> github_pull_url_of_text route_text
   in
+  if Option.is_none route_json && Option.is_none pr_url then None
+  else
   let fields =
     []
     |> add_string "pr_url" pr_url

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -179,6 +179,155 @@ let action_radius_json_for_call ~keeper_name ~tool_name ~input ~success
     ?sandbox_target:ctx.sandbox_profile
     ()
 
+let assoc_opt = function
+  | `Assoc fields -> Some fields
+  | _ -> None
+
+let assoc_member_opt name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let assoc_string_opt name json =
+  match assoc_member_opt name json with
+  | Some (`String value) when String.trim value <> "" -> Some value
+  | _ -> None
+
+let assoc_bool_opt name json =
+  match assoc_member_opt name json with
+  | Some (`Bool value) -> Some value
+  | _ -> None
+
+let route_candidate_has_fields json =
+  match assoc_opt json with
+  | None -> false
+  | Some fields ->
+      List.exists
+        (fun (name, _) ->
+           List.mem name
+             [
+               "via";
+               "sandbox_profile";
+               "git_creds_enabled";
+               "network_mode";
+               "status";
+               "effective_sandbox_image";
+             ])
+        fields
+
+let route_candidate_of_output json =
+  if route_candidate_has_fields json then Some json
+  else
+    match assoc_member_opt "result" json with
+    | Some result when route_candidate_has_fields result -> Some result
+    | _ -> (
+        match assoc_member_opt "detail" json with
+        | Some detail when route_candidate_has_fields detail -> Some detail
+        | _ -> None)
+
+let find_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 then Some 0
+  else
+    let rec loop idx =
+      if idx + needle_len > haystack_len then None
+      else if String.sub haystack idx needle_len = needle then Some idx
+      else loop (idx + 1)
+    in
+    loop 0
+
+let github_pull_url_of_text text =
+  match find_substring ~needle:"https://github.com/" text with
+  | None -> None
+  | Some start ->
+      let len = String.length text in
+      let rec stop idx =
+        if idx >= len then idx
+        else
+          match text.[idx] with
+          | ' ' | '\n' | '\r' | '\t' | '"' | '\'' | ')' | ']' -> idx
+          | _ -> stop (idx + 1)
+      in
+      let finish = stop start in
+      let url = String.sub text start (finish - start) in
+      if find_substring ~needle:"/pull/" url |> Option.is_some then Some url
+      else None
+
+let route_output_url output_json output_text =
+  match assoc_string_opt "url" output_json with
+  | Some url when find_substring ~needle:"/pull/" url |> Option.is_some ->
+      Some url
+  | _ -> github_pull_url_of_text output_text
+
+let route_safe_input_string value =
+  Option.map
+    (Observability_redact.redact_preview ~max_len:max_output_len)
+    value
+
+let route_evidence_json_of_tool_io ~tool_name ~input ~output_text =
+  let parsed_output =
+    match Safe_ops.parse_json_safe
+            ~context:"Keeper_tool_call_log.route_evidence"
+            output_text
+    with
+    | Ok json -> Some json
+    | Error _ -> None
+  in
+  let route_json =
+    match parsed_output with
+    | Some json -> route_candidate_of_output json
+    | None -> None
+  in
+  let command =
+    match assoc_string_opt "cmd" input with
+    | Some cmd -> Some cmd
+    | None -> assoc_string_opt "op" input
+  in
+  let add_string name value fields =
+    match value with
+    | Some value -> (name, `String value) :: fields
+    | None -> fields
+  in
+  let add_bool name value fields =
+    match value with
+    | Some value -> (name, `Bool value) :: fields
+    | None -> fields
+  in
+  let add_json name value fields =
+    match value with
+    | Some value -> (name, value) :: fields
+    | None -> fields
+  in
+  let output_json = Option.value ~default:(`Assoc []) route_json in
+  let pr_url =
+    match parsed_output with
+    | Some json -> route_output_url json output_text
+    | None -> github_pull_url_of_text output_text
+  in
+  let fields =
+    []
+    |> add_string "pr_url" pr_url
+    |> add_json "status"
+         (Option.map
+            (Observability_redact.preview_json_strings ~max_len:max_output_len)
+            (assoc_member_opt "status" output_json))
+    |> add_string "effective_sandbox_image"
+         (assoc_string_opt "effective_sandbox_image" output_json)
+    |> add_string "network_mode" (assoc_string_opt "network_mode" output_json)
+    |> add_bool "git_creds_enabled"
+         (assoc_bool_opt "git_creds_enabled" output_json)
+    |> add_string "sandbox_profile"
+         (assoc_string_opt "sandbox_profile" output_json)
+    |> add_string "via" (assoc_string_opt "via" output_json)
+    |> add_string "path" (route_safe_input_string (assoc_string_opt "path" input))
+    |> add_string "cwd" (route_safe_input_string (assoc_string_opt "cwd" input))
+    |> add_string "command" (route_safe_input_string command)
+    |> add_string "tool_name" (Some tool_name)
+  in
+  match fields with
+  | [ ("tool_name", _) ] -> None
+  | _ -> Some (`Assoc (List.rev fields))
+
 let store_ref : Dated_jsonl.t option ref = ref None
 let configured_store_ref : (string * string) option ref = ref None
 
@@ -563,6 +712,16 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
           ?sandbox_target:sandbox_profile
           ()
       in
+      let route_evidence_field =
+        match
+          route_evidence_json_of_tool_io
+            ~tool_name
+            ~input:safe_input
+            ~output_text
+        with
+        | Some evidence -> [ ("route_evidence", evidence) ]
+        | None -> []
+      in
       let json =
         `Assoc
           ([ ("ts", `Float (Time_compat.now ()))
@@ -577,6 +736,7 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
            ; ("runtime_contract", runtime_contract)
            ; ("action_radius", action_radius)
            ]
+           @ route_evidence_field
            @ model_field @ lane_field @ tool_choice_field
            @ thinking_enabled_field @ thinking_budget_field
            @ prompt_fingerprint_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -85,6 +85,16 @@ val action_radius_json_for_call :
 (** [action_radius_json_for_call ...] derives the canonical action radius
     from a keeper tool call and its current sandbox context. *)
 
+val route_evidence_json_of_tool_io :
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  output_text:string ->
+  Yojson.Safe.t option
+(** [route_evidence_json_of_tool_io] extracts first-class route proof from
+    keeper git/gh tool I/O. The evidence includes redacted command/cwd/path
+    from the input plus route/status fields such as [via], [sandbox_profile],
+    [git_creds_enabled], [network_mode], [status], and PR URL when present. *)
+
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
 (** [init ?cluster_name ~base_path ()] creates the cluster-aware Dated_jsonl
     store. Call once at startup. *)

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -408,6 +408,73 @@ let test_route_evidence_extracts_pr_url_from_gh_output () =
        | None -> Alcotest.fail "expected command evidence")
     | _ -> Alcotest.fail "expected exactly one entry")
 
+let test_route_evidence_stored_for_blob_backed_git_push () =
+  with_tmp_log (fun () ->
+    let sentinel =
+      Tool_output.encode_for_oas
+        (Tool_output.Stored {
+          sha256 = String.make 64 'b';
+          bytes = 8192;
+          mime = "application/json";
+          preview =
+            {|{"ok":true,"via":"docker","sandbox_profile":"docker","git_creds_enabled":true,"network_mode":"bridge","effective_sandbox_image":"masc-keeper-sandbox:local","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|};
+        })
+    in
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"executor"
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+           [
+             ("cmd", `String "git push -u origin keeper/large-route-proof");
+             ("cwd", `String "repos/masc-mcp-keeper-direct-proof");
+           ])
+      ~output_text:sentinel
+      ~success:true
+      ~duration_ms:42.0
+      ();
+    let entries = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "entry persisted" 1 (List.length entries);
+    match entries with
+    | [ entry ] ->
+      let evidence = Yojson.Safe.Util.member "route_evidence" entry in
+      Alcotest.(check (option string)) "via captured from blob preview"
+        (Some "docker")
+        (Safe_ops.json_string_opt "via" evidence);
+      Alcotest.(check (option string)) "network mode captured"
+        (Some "bridge")
+        (Safe_ops.json_string_opt "network_mode" evidence);
+      Alcotest.(check bool) "git creds captured" true
+        (Safe_ops.json_bool ~default:false "git_creds_enabled" evidence);
+      let status = Yojson.Safe.Util.member "status" evidence in
+      Alcotest.(check (option string)) "status label captured"
+        (Some "success")
+        (Safe_ops.json_string_opt "label" status);
+      Alcotest.(check (option string)) "command captured"
+        (Some "git push -u origin [REDACTED]")
+        (Safe_ops.json_string_opt "command" evidence)
+    | _ -> Alcotest.fail "expected exactly one entry")
+
+let test_route_evidence_skips_unproven_filesystem_calls () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"executor"
+      ~tool_name:"keeper_fs_read"
+      ~input:(`Assoc [ ("path", `String "README.md") ])
+      ~output_text:"file contents"
+      ~success:true
+      ~duration_ms:4.0
+      ();
+    let entries = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "entry persisted" 1 (List.length entries);
+    match entries with
+    | [ entry ] ->
+      Alcotest.(check bool) "route evidence absent without proof" true
+        (match Yojson.Safe.Util.member "route_evidence" entry with
+         | `Null -> true
+         | _ -> false)
+    | _ -> Alcotest.fail "expected exactly one entry")
+
 let find_bucket name json =
   json
   |> Yojson.Safe.Util.to_list
@@ -743,6 +810,10 @@ let () =
             test_route_evidence_stored_for_git_push
         ; eio_test "route evidence extracts PR URL"
             test_route_evidence_extracts_pr_url_from_gh_output
+        ; eio_test "route evidence reads blob-backed git push preview"
+            test_route_evidence_stored_for_blob_backed_git_push
+        ; eio_test "route evidence skips unproven filesystem calls"
+            test_route_evidence_skips_unproven_filesystem_calls
         ; eio_test "dashboard aggregate groups runtime fields"
             test_dashboard_aggregate_groups_runtime_fields
         ; eio_test "dashboard hourly trend buckets numeric ts"

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -322,6 +322,92 @@ let test_turn_context_fields_absent_without_context () =
        | `Null -> true
        | _ -> false))
 
+let test_route_evidence_stored_for_git_push () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"executor"
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+           [
+             ( "cmd",
+               `String
+                 "git push -u origin keeper/executor-direct-clone-pr-proof-20260506-1039"
+             );
+             ( "cwd",
+               `String "repos/masc-mcp-keeper-direct-proof-20260506-1039" );
+           ])
+      ~output_text:
+        {|{"ok":true,"via":"docker","cwd":"repos/masc-mcp-keeper-direct-proof-20260506-1039","sandbox_profile":"docker","git_creds_enabled":true,"network_mode":"bridge","effective_sandbox_image":"masc-keeper-sandbox:local","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|}
+      ~success:true
+      ~duration_ms:42.0
+      ();
+    let entries = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "entry persisted" 1 (List.length entries);
+    match entries with
+    | [ entry ] ->
+      let evidence = Yojson.Safe.Util.member "route_evidence" entry in
+      Alcotest.(check (option string)) "tool name"
+        (Some "keeper_bash")
+        (Safe_ops.json_string_opt "tool_name" evidence);
+      Alcotest.(check (option string)) "command captured"
+        (Some "git push -u origin [REDACTED]")
+        (Safe_ops.json_string_opt "command" evidence);
+      Alcotest.(check (option string)) "cwd captured"
+        (Some "[REDACTED]")
+        (Safe_ops.json_string_opt "cwd" evidence);
+      Alcotest.(check (option string)) "via captured"
+        (Some "docker")
+        (Safe_ops.json_string_opt "via" evidence);
+      Alcotest.(check (option string)) "sandbox profile captured"
+        (Some "docker")
+        (Safe_ops.json_string_opt "sandbox_profile" evidence);
+      Alcotest.(check bool) "git creds captured" true
+        (Safe_ops.json_bool ~default:false "git_creds_enabled" evidence);
+      Alcotest.(check (option string)) "network mode captured"
+        (Some "bridge")
+        (Safe_ops.json_string_opt "network_mode" evidence);
+      let status = Yojson.Safe.Util.member "status" evidence in
+      Alcotest.(check (option string)) "status label"
+        (Some "success")
+        (Safe_ops.json_string_opt "label" status)
+    | _ -> Alcotest.fail "expected exactly one entry")
+
+let test_route_evidence_extracts_pr_url_from_gh_output () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"executor"
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+           [
+             ( "cmd",
+               `String
+                 "gh pr create --draft --title proof --body proof --base main"
+             );
+             ( "cwd",
+               `String "repos/masc-mcp-keeper-direct-proof-20260506-1039" );
+           ])
+      ~output_text:
+        "https://github.com/jeong-sik/masc-mcp/pull/13550\n"
+      ~success:true
+      ~duration_ms:10.0
+      ();
+    let entries = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "entry persisted" 1 (List.length entries);
+    match entries with
+    | [ entry ] ->
+      let evidence = Yojson.Safe.Util.member "route_evidence" entry in
+      Alcotest.(check (option string)) "pr url captured"
+        (Some "https://github.com/jeong-sik/masc-mcp/pull/13550")
+        (Safe_ops.json_string_opt "pr_url" evidence);
+      (match Safe_ops.json_string_opt "command" evidence with
+       | Some command ->
+         Alcotest.(check bool) "command captured" true
+           (String.starts_with ~prefix:"gh pr create" command)
+       | None -> Alcotest.fail "expected command evidence")
+    | _ -> Alcotest.fail "expected exactly one entry")
+
 let find_bucket name json =
   json
   |> Yojson.Safe.Util.to_list
@@ -653,6 +739,10 @@ let () =
         ; eio_test "turn context fields stored" test_turn_context_fields_stored
         ; eio_test "turn context fields absent without context"
             test_turn_context_fields_absent_without_context
+        ; eio_test "route evidence stored for git push"
+            test_route_evidence_stored_for_git_push
+        ; eio_test "route evidence extracts PR URL"
+            test_route_evidence_extracts_pr_url_from_gh_output
         ; eio_test "dashboard aggregate groups runtime fields"
             test_dashboard_aggregate_groups_runtime_fields
         ; eio_test "dashboard hourly trend buckets numeric ts"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3447,11 +3447,24 @@ let test_append_decision_record_persists_tool_calls () =
           ; provider = "codex_cli"
           ; outcome = "ok"
           ; latency_ms = 12.5
+          ; route_evidence =
+              Some
+                (`Assoc
+                   [
+                     ("tool_name", `String "keeper_shell");
+                     ("command", `String "git_status");
+                     ("cwd", `String "repos/masc-mcp");
+                     ("via", `String "docker");
+                     ("sandbox_profile", `String "docker");
+                     ("git_creds_enabled", `Bool true);
+                     ("network_mode", `String "bridge");
+                   ])
           }
         ; { tool_name = "keeper_board_post"
           ; provider = "codex_cli"
           ; outcome = "error"
           ; latency_ms = 3.0
+          ; route_evidence = None
           }
         ]
       in
@@ -3539,8 +3552,23 @@ let test_append_decision_record_persists_tool_calls () =
         Yojson.Safe.Util.(List.nth recorded_tool_calls 0 |> member "tool_name" |> to_string);
       check string "first provider" "codex_cli"
         Yojson.Safe.Util.(List.nth recorded_tool_calls 0 |> member "provider" |> to_string);
+      check string "first route via" "docker"
+        Yojson.Safe.Util.(
+          List.nth recorded_tool_calls 0 |> member "route_evidence"
+          |> member "via" |> to_string);
+      check bool "first route git creds" true
+        Yojson.Safe.Util.(
+          List.nth recorded_tool_calls 0 |> member "route_evidence"
+          |> member "git_creds_enabled" |> to_bool);
 	      check string "second outcome" "error"
 	        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "outcome" |> to_string);
+      check bool "second route evidence absent" true
+        (match
+           Yojson.Safe.Util.(
+             List.nth recorded_tool_calls 1 |> member "route_evidence")
+         with
+         | `Null -> true
+         | _ -> false);
 	      check (float 0.001) "second latency" 3.0
 	        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "latency_ms" |> to_float);
 	      check string "terminal reason success" "success"


### PR DESCRIPTION
## Summary

- persist first-class route_evidence on keeper tool-call JSONL rows for git/gh proof turns
- carry route evidence through keeper run tool_call_detail, decision metrics, and masc_keeper_msg_result tool_call_evidence
- extract Docker route fields and PR URLs while keeping input command/cwd/path under observability redaction rules

## Why

Issue #13536 showed that a successful keeper git/gh proof could be verified from live logs only with extra context. Operators need the keeper_msg result, decision log, and .masc/tool_calls JSONL to preserve the route proof directly: via, sandbox_profile, git_creds_enabled, network_mode, status, effective_sandbox_image, and PR URL when present.

This complements the direct proof PR #13550 by making future proof turns self-describing in the observability artifacts instead of requiring manual reconstruction.

Fixes #13536
Refs #13550

## Validation

- git diff --check
- env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build --cache=disabled test/test_keeper_tool_call_log.exe test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_tool_call_log.exe: 20 tests passed
- ./_build/default/test/test_keeper_unified.exe: 320 tests passed

## Notes

- Input command/cwd/path are still redacted by the existing observability preview rules.
- PR URL and route/status fields are extracted before output preview truncation so the proof link survives redaction of the regular output field.