### PR TITLE
fix(dashboard): expose persistence status metadata

### DIFF
--- a/dashboard/src/components/common/persistence-status.a11y.test.ts
+++ b/dashboard/src/components/common/persistence-status.a11y.test.ts
@@ -49,6 +49,7 @@ describe('PersistenceStatus a11y', () => {
     const el = container.querySelector('[data-testid="ps"]') as HTMLElement
     expect(el.getAttribute('role')).toBe('status')
     expect(el.getAttribute('aria-live')).toBe('polite')
+    expect(el.getAttribute('aria-busy')).toBe('true')
   })
 
   it('contains the correct label text for each state', () => {
@@ -64,5 +65,36 @@ describe('PersistenceStatus a11y', () => {
       render(html`<${PersistenceStatus} status=${status} />`, container)
       expect(container.textContent).toContain(label)
     }
+  })
+
+  it('exposes state, freshness, and action metadata', () => {
+    render(
+      html`<${PersistenceStatus}
+        status="conflict"
+        lastSaved="2026-05-05T22:00:00Z"
+        now="2026-05-06T00:00:00Z"
+      />`,
+      container,
+    )
+    const el = container.querySelector('[data-persistence-status]')
+    expect(el?.getAttribute('data-persistence-state')).toBe('conflict')
+    expect(el?.getAttribute('data-persistence-severity')).toBe('attention')
+    expect(el?.getAttribute('data-persistence-freshness')).toBe('stale')
+    expect(el?.getAttribute('data-persistence-action-required')).toBe('true')
+    expect(el?.getAttribute('aria-label')).toContain('오래됨')
+  })
+
+  it('renders machine-readable time metadata when lastSaved is valid', () => {
+    render(
+      html`<${PersistenceStatus}
+        status="saved"
+        lastSaved="2026-05-05T23:58:00Z"
+        now="2026-05-06T00:00:00Z"
+      />`,
+      container,
+    )
+    const time = container.querySelector('time[data-persistence-time]')
+    expect(time?.getAttribute('datetime')).toBe('2026-05-05T23:58:00.000Z')
+    expect(container.querySelector('[data-persistence-freshness-label]')?.textContent).toBe('최신')
   })
 })

--- a/dashboard/src/components/common/persistence-status.test.ts
+++ b/dashboard/src/components/common/persistence-status.test.ts
@@ -1,9 +1,41 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { PersistenceStatus } from './persistence-status'
+import {
+  classifyPersistenceFreshness,
+  getPersistenceStatusConfig,
+  PersistenceStatus,
+  summarizePersistenceStatus,
+} from './persistence-status'
 
 describe('PersistenceStatus', () => {
+  it('maps states to operator severity metadata', () => {
+    expect(getPersistenceStatusConfig('saved').severity).toBe('ok')
+    expect(getPersistenceStatusConfig('syncing').severity).toBe('busy')
+    expect(getPersistenceStatusConfig('conflict').severity).toBe('attention')
+    expect(getPersistenceStatusConfig('offline').severity).toBe('offline')
+  })
+
+  it('classifies timestamp freshness deterministically', () => {
+    const now = '2026-05-06T00:00:00Z'
+    expect(classifyPersistenceFreshness('2026-05-05T23:58:00Z', now)).toMatchObject({
+      freshness: 'fresh',
+      ageMs: 120000,
+      lastSavedIso: '2026-05-05T23:58:00.000Z',
+    })
+    expect(classifyPersistenceFreshness('2026-05-05T23:30:00Z', now).freshness).toBe('recent')
+    expect(classifyPersistenceFreshness('2026-05-05T22:30:00Z', now).freshness).toBe('stale')
+    expect(classifyPersistenceFreshness(null, now).freshness).toBe('unknown')
+    expect(classifyPersistenceFreshness('not-a-date', now).lastSavedIso).toBeNull()
+  })
+
+  it('summarizes action-required states', () => {
+    expect(summarizePersistenceStatus('saved').actionRequired).toBe(false)
+    expect(summarizePersistenceStatus('syncing').actionRequired).toBe(false)
+    expect(summarizePersistenceStatus('conflict').actionRequired).toBe(true)
+    expect(summarizePersistenceStatus('offline').actionRequired).toBe(true)
+  })
+
   it('renders role status', () => {
     const container = document.createElement('div')
     render(h(PersistenceStatus, { status: 'saved' }), container)
@@ -39,6 +71,7 @@ describe('PersistenceStatus', () => {
     render(h(PersistenceStatus, { status: 'saved' }), container)
     const el = container.querySelector('[role="status"]')
     expect(el?.getAttribute('aria-label')).toContain('저장됨')
+    expect(el?.getAttribute('aria-label')).toContain('시간 정보 없음')
   })
 
   it('applies testId', () => {
@@ -52,5 +85,50 @@ describe('PersistenceStatus', () => {
     const ts = new Date(Date.now() - 60000).toISOString()
     render(h(PersistenceStatus, { status: 'saved', lastSaved: ts }), container)
     expect(container.textContent).toContain('전')
+  })
+
+  it('exposes machine-readable persistence metadata', () => {
+    const container = document.createElement('div')
+    render(h(PersistenceStatus, {
+      status: 'saved',
+      lastSaved: '2026-05-05T23:58:00Z',
+      now: '2026-05-06T00:00:00Z',
+    }), container)
+    const el = container.querySelector('[data-persistence-status]')
+    expect(el?.getAttribute('data-persistence-state')).toBe('saved')
+    expect(el?.getAttribute('data-persistence-severity')).toBe('ok')
+    expect(el?.getAttribute('data-persistence-freshness')).toBe('fresh')
+    expect(el?.getAttribute('data-persistence-action-required')).toBe('false')
+    expect(el?.getAttribute('data-persistence-last-saved')).toBe('2026-05-05T23:58:00.000Z')
+    expect(el?.getAttribute('data-persistence-age-ms')).toBe('120000')
+    expect(container.querySelector('[data-persistence-freshness-label]')?.textContent).toBe('최신')
+  })
+
+  it('renders lastSaved as a time element with datetime', () => {
+    const container = document.createElement('div')
+    render(h(PersistenceStatus, {
+      status: 'saved',
+      lastSaved: '2026-05-05T23:58:00Z',
+      now: '2026-05-06T00:00:00Z',
+    }), container)
+    const time = container.querySelector('time[data-persistence-time]')
+    expect(time?.getAttribute('datetime')).toBe('2026-05-05T23:58:00.000Z')
+  })
+
+  it('marks syncing as busy for assistive tech', () => {
+    const container = document.createElement('div')
+    render(h(PersistenceStatus, { status: 'syncing' }), container)
+    const el = container.querySelector('[role="status"]')
+    expect(el?.getAttribute('aria-busy')).toBe('true')
+    expect(el?.getAttribute('data-persistence-severity')).toBe('busy')
+  })
+
+  it('marks conflict and offline as action-required', () => {
+    const container = document.createElement('div')
+    render(h(PersistenceStatus, { status: 'conflict' }), container)
+    expect(container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-action-required')).toBe('true')
+
+    render(h(PersistenceStatus, { status: 'offline' }), container)
+    expect(container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-action-required')).toBe('true')
   })
 })

--- a/dashboard/src/components/common/persistence-status.test.ts
+++ b/dashboard/src/components/common/persistence-status.test.ts
@@ -23,6 +23,11 @@ describe('PersistenceStatus', () => {
       ageMs: 120000,
       lastSavedIso: '2026-05-05T23:58:00.000Z',
     })
+    expect(classifyPersistenceFreshness('2026-05-05T23:58:00Z', 1778025600)).toMatchObject({
+      freshness: 'fresh',
+      ageMs: 120000,
+      lastSavedIso: '2026-05-05T23:58:00.000Z',
+    })
     expect(classifyPersistenceFreshness('2026-05-05T23:30:00Z', now).freshness).toBe('recent')
     expect(classifyPersistenceFreshness('2026-05-05T22:30:00Z', now).freshness).toBe('stale')
     expect(classifyPersistenceFreshness(null, now).freshness).toBe('unknown')
@@ -113,6 +118,29 @@ describe('PersistenceStatus', () => {
     }), container)
     const time = container.querySelector('time[data-persistence-time]')
     expect(time?.getAttribute('datetime')).toBe('2026-05-05T23:58:00.000Z')
+  })
+
+  it('keeps rendered relative time aligned with provided now', () => {
+    const container = document.createElement('div')
+    render(h(PersistenceStatus, {
+      status: 'saved',
+      lastSaved: '2026-05-05T23:58:00Z',
+      now: '2026-05-06T00:00:00Z',
+    }), container)
+    expect(container.querySelector('[data-persistence-time]')?.textContent).toBe('2분 전')
+    expect(container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-age-ms')).toBe('120000')
+  })
+
+  it('does not render raw invalid timestamps as time elements', () => {
+    const container = document.createElement('div')
+    render(h(PersistenceStatus, {
+      status: 'saved',
+      lastSaved: 'not-a-date',
+      now: '2026-05-06T00:00:00Z',
+    }), container)
+    expect(container.querySelector('time[data-persistence-time]')).toBeNull()
+    expect(container.textContent).not.toContain('not-a-date')
+    expect(container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-last-saved')).toBeNull()
   })
 
   it('marks syncing as busy for assistive tech', () => {

--- a/dashboard/src/components/common/persistence-status.test.ts
+++ b/dashboard/src/components/common/persistence-status.test.ts
@@ -23,7 +23,9 @@ describe('PersistenceStatus', () => {
       ageMs: 120000,
       lastSavedIso: '2026-05-05T23:58:00.000Z',
     })
-    expect(classifyPersistenceFreshness('2026-05-05T23:58:00Z', 1778025600)).toMatchObject({
+    expect(
+      classifyPersistenceFreshness('2026-05-05T23:58:00Z', 1778025600),
+    ).toMatchObject({
       freshness: 'fresh',
       ageMs: 120000,
       lastSavedIso: '2026-05-05T23:58:00.000Z',
@@ -122,25 +124,35 @@ describe('PersistenceStatus', () => {
 
   it('keeps rendered relative time aligned with provided now', () => {
     const container = document.createElement('div')
-    render(h(PersistenceStatus, {
-      status: 'saved',
-      lastSaved: '2026-05-05T23:58:00Z',
-      now: '2026-05-06T00:00:00Z',
-    }), container)
+    render(
+      h(PersistenceStatus, {
+        status: 'saved',
+        lastSaved: '2026-05-05T23:58:00Z',
+        now: '2026-05-06T00:00:00Z',
+      }),
+      container,
+    )
     expect(container.querySelector('[data-persistence-time]')?.textContent).toBe('2분 전')
-    expect(container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-age-ms')).toBe('120000')
+    expect(
+      container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-age-ms'),
+    ).toBe('120000')
   })
 
   it('does not render raw invalid timestamps as time elements', () => {
     const container = document.createElement('div')
-    render(h(PersistenceStatus, {
-      status: 'saved',
-      lastSaved: 'not-a-date',
-      now: '2026-05-06T00:00:00Z',
-    }), container)
+    render(
+      h(PersistenceStatus, {
+        status: 'saved',
+        lastSaved: 'not-a-date',
+        now: '2026-05-06T00:00:00Z',
+      }),
+      container,
+    )
     expect(container.querySelector('time[data-persistence-time]')).toBeNull()
     expect(container.textContent).not.toContain('not-a-date')
-    expect(container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-last-saved')).toBeNull()
+    expect(
+      container.querySelector('[data-persistence-status]')?.getAttribute('data-persistence-last-saved'),
+    ).toBeNull()
   })
 
   it('marks syncing as busy for assistive tech', () => {

--- a/dashboard/src/components/common/persistence-status.ts
+++ b/dashboard/src/components/common/persistence-status.ts
@@ -140,9 +140,10 @@ export function PersistenceStatus({
 }: PersistenceStatusProps) {
   const cfg = getPersistenceStatusConfig(status)
   const summary = summarizePersistenceStatus(status, lastSaved, now)
-  const timeText = summary.lastSavedIso && summary.ageMs !== null
-    ? relativeTimeFromAgeMs(summary.ageMs)
-    : null
+  const timeText =
+    summary.lastSavedIso && summary.ageMs !== null
+      ? relativeTimeFromAgeMs(summary.ageMs)
+      : null
   const freshnessLabel = FRESHNESS_LABEL[summary.freshness]
 
   return html`

--- a/dashboard/src/components/common/persistence-status.ts
+++ b/dashboard/src/components/common/persistence-status.ts
@@ -5,6 +5,7 @@
 // of the dashboard.
 
 import { html } from 'htm/preact'
+import { formatRelativeAgeMs, normalizeTimestampMs } from '../../lib/format-time'
 import { StatusDot } from './status-dot'
 
 export type PersistenceState = 'saved' | 'syncing' | 'conflict' | 'offline'
@@ -27,8 +28,6 @@ const CONFIG: Record<PersistenceState, PersistenceStateConfig> = {
 
 const FRESH_MS = 5 * 60 * 1000
 const RECENT_MS = 60 * 60 * 1000
-const UNIX_MS_THRESHOLD = 1_000_000_000_000
-const relativeFormatter = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' })
 
 const FRESHNESS_LABEL: Record<PersistenceFreshness, string> = {
   fresh: '최신',
@@ -73,7 +72,7 @@ function timestampMs(value?: string | null): number | null {
 
 function normalizeUnixMs(value: number): number {
   if (!Number.isFinite(value)) return Date.now()
-  return value < UNIX_MS_THRESHOLD ? value * 1000 : value
+  return normalizeTimestampMs(value)
 }
 
 function nowMs(value: string | number | Date | undefined): number {
@@ -84,14 +83,6 @@ function nowMs(value: string | number | Date | undefined): number {
     return Number.isNaN(parsed) ? Date.now() : parsed
   }
   return Date.now()
-}
-
-function relativeTimeFromAgeMs(ageMs: number): string {
-  const deltaSec = Math.max(0, Math.round(ageMs / 1000))
-  if (deltaSec < 60) return relativeFormatter.format(-deltaSec, 'second')
-  if (deltaSec < 3600) return relativeFormatter.format(-Math.round(deltaSec / 60), 'minute')
-  if (deltaSec < 86400) return relativeFormatter.format(-Math.round(deltaSec / 3600), 'hour')
-  return relativeFormatter.format(-Math.round(deltaSec / 86400), 'day')
 }
 
 export function classifyPersistenceFreshness(
@@ -142,7 +133,7 @@ export function PersistenceStatus({
   const summary = summarizePersistenceStatus(status, lastSaved, now)
   const timeText =
     summary.lastSavedIso && summary.ageMs !== null
-      ? relativeTimeFromAgeMs(summary.ageMs)
+      ? formatRelativeAgeMs(summary.ageMs)
       : null
   const freshnessLabel = FRESHNESS_LABEL[summary.freshness]
 

--- a/dashboard/src/components/common/persistence-status.ts
+++ b/dashboard/src/components/common/persistence-status.ts
@@ -6,7 +6,6 @@
 
 import { html } from 'htm/preact'
 import { StatusDot } from './status-dot'
-import { relativeTime } from '../../lib/format-time'
 
 export type PersistenceState = 'saved' | 'syncing' | 'conflict' | 'offline'
 export type PersistenceFreshness = 'fresh' | 'recent' | 'stale' | 'unknown'
@@ -28,6 +27,8 @@ const CONFIG: Record<PersistenceState, PersistenceStateConfig> = {
 
 const FRESH_MS = 5 * 60 * 1000
 const RECENT_MS = 60 * 60 * 1000
+const UNIX_MS_THRESHOLD = 1_000_000_000_000
+const relativeFormatter = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' })
 
 const FRESHNESS_LABEL: Record<PersistenceFreshness, string> = {
   fresh: '최신',
@@ -70,14 +71,27 @@ function timestampMs(value?: string | null): number | null {
   return Number.isNaN(parsed) ? null : parsed
 }
 
+function normalizeUnixMs(value: number): number {
+  if (!Number.isFinite(value)) return Date.now()
+  return value < UNIX_MS_THRESHOLD ? value * 1000 : value
+}
+
 function nowMs(value: string | number | Date | undefined): number {
   if (value instanceof Date) return value.getTime()
-  if (typeof value === 'number') return value
+  if (typeof value === 'number') return normalizeUnixMs(value)
   if (typeof value === 'string') {
     const parsed = Date.parse(value)
     return Number.isNaN(parsed) ? Date.now() : parsed
   }
   return Date.now()
+}
+
+function relativeTimeFromAgeMs(ageMs: number): string {
+  const deltaSec = Math.max(0, Math.round(ageMs / 1000))
+  if (deltaSec < 60) return relativeFormatter.format(-deltaSec, 'second')
+  if (deltaSec < 3600) return relativeFormatter.format(-Math.round(deltaSec / 60), 'minute')
+  if (deltaSec < 86400) return relativeFormatter.format(-Math.round(deltaSec / 3600), 'hour')
+  return relativeFormatter.format(-Math.round(deltaSec / 86400), 'day')
 }
 
 export function classifyPersistenceFreshness(
@@ -126,7 +140,9 @@ export function PersistenceStatus({
 }: PersistenceStatusProps) {
   const cfg = getPersistenceStatusConfig(status)
   const summary = summarizePersistenceStatus(status, lastSaved, now)
-  const timeText = lastSaved ? relativeTime(lastSaved) : null
+  const timeText = summary.lastSavedIso && summary.ageMs !== null
+    ? relativeTimeFromAgeMs(summary.ageMs)
+    : null
   const freshnessLabel = FRESHNESS_LABEL[summary.freshness]
 
   return html`

--- a/dashboard/src/components/common/persistence-status.ts
+++ b/dashboard/src/components/common/persistence-status.ts
@@ -9,52 +9,161 @@ import { StatusDot } from './status-dot'
 import { relativeTime } from '../../lib/format-time'
 
 export type PersistenceState = 'saved' | 'syncing' | 'conflict' | 'offline'
+export type PersistenceFreshness = 'fresh' | 'recent' | 'stale' | 'unknown'
+export type PersistenceSeverity = 'ok' | 'busy' | 'attention' | 'offline'
 
-interface StateConfig {
+export interface PersistenceStateConfig {
   toneClass: string
   icon: string
   label: string
+  severity: PersistenceSeverity
 }
 
-const CONFIG: Record<PersistenceState, StateConfig> = {
-  saved:   { toneClass: 'bg-[var(--ok-20)]', icon: '✓', label: '저장됨' },
-  syncing: { toneClass: 'bg-[var(--warn-20)]', icon: '↻', label: '동기화 중' },
-  conflict:{ toneClass: 'bg-[var(--bad-20)]', icon: '!', label: '충돌' },
-  offline: { toneClass: 'bg-[var(--accent-30)]', icon: '○', label: '오프라인' },
+const CONFIG: Record<PersistenceState, PersistenceStateConfig> = {
+  saved:   { toneClass: 'bg-[var(--ok-20)]', icon: '✓', label: '저장됨', severity: 'ok' },
+  syncing: { toneClass: 'bg-[var(--warn-20)]', icon: '↻', label: '동기화 중', severity: 'busy' },
+  conflict:{ toneClass: 'bg-[var(--bad-20)]', icon: '!', label: '충돌', severity: 'attention' },
+  offline: { toneClass: 'bg-[var(--accent-30)]', icon: '○', label: '오프라인', severity: 'offline' },
+}
+
+const FRESH_MS = 5 * 60 * 1000
+const RECENT_MS = 60 * 60 * 1000
+
+const FRESHNESS_LABEL: Record<PersistenceFreshness, string> = {
+  fresh: '최신',
+  recent: '최근',
+  stale: '오래됨',
+  unknown: '시간 정보 없음',
+}
+
+const FRESHNESS_CLASS: Record<PersistenceFreshness, string> = {
+  fresh: 'text-[var(--color-status-ok)]',
+  recent: 'text-[var(--color-fg-muted)]',
+  stale: 'text-[var(--color-status-warn)]',
+  unknown: 'text-[var(--color-fg-disabled)]',
+}
+
+export interface PersistenceStatusSummary {
+  readonly status: PersistenceState
+  readonly label: string
+  readonly severity: PersistenceSeverity
+  readonly freshness: PersistenceFreshness
+  readonly actionRequired: boolean
+  readonly lastSavedIso: string | null
+  readonly ageMs: number | null
 }
 
 interface PersistenceStatusProps {
   status: PersistenceState
   lastSaved?: string | null
+  now?: string | number | Date
   testId?: string
+}
+
+export function getPersistenceStatusConfig(status: PersistenceState): PersistenceStateConfig {
+  return CONFIG[status]
+}
+
+function timestampMs(value?: string | null): number | null {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function nowMs(value: string | number | Date | undefined): number {
+  if (value instanceof Date) return value.getTime()
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value)
+    return Number.isNaN(parsed) ? Date.now() : parsed
+  }
+  return Date.now()
+}
+
+export function classifyPersistenceFreshness(
+  lastSaved?: string | null,
+  now?: string | number | Date,
+): { freshness: PersistenceFreshness; ageMs: number | null; lastSavedIso: string | null } {
+  const savedMs = timestampMs(lastSaved)
+  if (savedMs === null) {
+    return { freshness: 'unknown', ageMs: null, lastSavedIso: null }
+  }
+
+  const ageMs = Math.max(0, nowMs(now) - savedMs)
+  if (ageMs <= FRESH_MS) {
+    return { freshness: 'fresh', ageMs, lastSavedIso: new Date(savedMs).toISOString() }
+  }
+  if (ageMs <= RECENT_MS) {
+    return { freshness: 'recent', ageMs, lastSavedIso: new Date(savedMs).toISOString() }
+  }
+  return { freshness: 'stale', ageMs, lastSavedIso: new Date(savedMs).toISOString() }
+}
+
+export function summarizePersistenceStatus(
+  status: PersistenceState,
+  lastSaved?: string | null,
+  now?: string | number | Date,
+): PersistenceStatusSummary {
+  const cfg = getPersistenceStatusConfig(status)
+  const freshness = classifyPersistenceFreshness(lastSaved, now)
+
+  return {
+    status,
+    label: cfg.label,
+    severity: cfg.severity,
+    freshness: freshness.freshness,
+    actionRequired: status === 'conflict' || status === 'offline',
+    lastSavedIso: freshness.lastSavedIso,
+    ageMs: freshness.ageMs,
+  }
 }
 
 export function PersistenceStatus({
   status,
   lastSaved,
+  now,
   testId,
 }: PersistenceStatusProps) {
-  const cfg = CONFIG[status]
+  const cfg = getPersistenceStatusConfig(status)
+  const summary = summarizePersistenceStatus(status, lastSaved, now)
   const timeText = lastSaved ? relativeTime(lastSaved) : null
+  const freshnessLabel = FRESHNESS_LABEL[summary.freshness]
 
   return html`
     <div
       class="inline-flex items-center gap-1.5 text-xs"
+      data-persistence-status
+      data-persistence-state=${summary.status}
+      data-persistence-severity=${summary.severity}
+      data-persistence-freshness=${summary.freshness}
+      data-persistence-action-required=${summary.actionRequired ? 'true' : 'false'}
+      data-persistence-last-saved=${summary.lastSavedIso ?? undefined}
+      data-persistence-age-ms=${summary.ageMs === null ? undefined : Math.round(summary.ageMs)}
       data-testid=${testId}
       role="status"
       aria-live="polite"
-      aria-label="${cfg.label}${timeText ? ' · ' + timeText : ''}"
+      aria-busy=${status === 'syncing' ? 'true' : undefined}
+      aria-label="${cfg.label}${timeText ? ' · ' + timeText : ''} · ${freshnessLabel}"
     >
       <${StatusDot}
         size="sm"
         class=${cfg.toneClass}
-        ariaLabel=${cfg.label}
       />
-      <span class="text-[var(--color-fg-muted)]">${cfg.icon}</span>
+      <span class="text-[var(--color-fg-muted)]" aria-hidden="true">${cfg.icon}</span>
       <span class="text-[var(--color-fg-muted)]">${cfg.label}</span>
       ${timeText
-        ? html`<span class="text-[var(--color-fg-muted)] ml-1">${timeText}</span>`
+        ? html`<time
+            class="ml-1 text-[var(--color-fg-muted)]"
+            datetime=${summary.lastSavedIso ?? undefined}
+            data-persistence-time
+          >${timeText}</time>`
         : null}
+      ${summary.freshness === 'unknown'
+        ? null
+        : html`<span
+            class=${`text-3xs ${FRESHNESS_CLASS[summary.freshness]}`}
+            data-persistence-freshness-label
+          >${freshnessLabel}</span>`}
     </div>
   `
 }

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -1,12 +1,21 @@
 // Unified time formatting utilities.
 
 const rtf = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' })
+const UNIX_MS_THRESHOLD = 1_000_000_000_000
 
-function formatRelativeSec(deltaSec: number): string {
+export function formatRelativeSec(deltaSec: number): string {
   if (deltaSec < 60) return rtf.format(-deltaSec, 'second')
   if (deltaSec < 3600) return rtf.format(-Math.round(deltaSec / 60), 'minute')
   if (deltaSec < 86400) return rtf.format(-Math.round(deltaSec / 3600), 'hour')
   return rtf.format(-Math.round(deltaSec / 86400), 'day')
+}
+
+export function normalizeTimestampMs(ts: number): number {
+  return ts < UNIX_MS_THRESHOLD ? ts * 1000 : ts
+}
+
+export function formatRelativeAgeMs(ageMs: number): string {
+  return formatRelativeSec(Math.max(0, Math.round(ageMs / 1000)))
 }
 
 /** Relative time from ISO string — "3분 전", "2시간 전" etc. Uses Intl.RelativeTimeFormat. */
@@ -14,7 +23,7 @@ export function relativeTime(iso?: string | null, fallback = '정보 없음'): s
   if (!iso) return fallback
   const ts = Date.parse(iso)
   if (Number.isNaN(ts)) return iso
-  return formatRelativeSec(Math.max(0, Math.round((Date.now() - ts) / 1000)))
+  return formatRelativeAgeMs(Date.now() - ts)
 }
 
 /** Format elapsed seconds — "3초", "5분", "2시간". Returns '정보 없음' for invalid. */
@@ -65,7 +74,7 @@ export function formatTimeAgo(ts: string | number): string {
   const now = Date.now()
   const then =
     typeof ts === 'number'
-      ? (ts < 1_000_000_000_000 ? ts * 1000 : ts)
+      ? normalizeTimestampMs(ts)
       : new Date(ts).getTime()
   return formatRelativeSec(Math.max(0, Math.floor((now - then) / 1000)))
 }


### PR DESCRIPTION
## Summary
- Add pure PersistenceStatus helpers for state severity, freshness, action-required, timestamp, and age metadata.
- Render machine-readable `data-persistence-*` attributes plus `<time datetime>` for valid `lastSaved` values.
- Surface freshness labels for valid timestamps and mark syncing rows with `aria-busy` while keeping the dot decorative under the status label.

## Why it matters
The v2 persistence UI plan calls for persistence state to be an operator-readable atom, not only an icon and label. This gives dashboard callers and tests a stable way to distinguish fresh/recent/stale/unknown state, conflict/offline action requirements, and sync-in-progress semantics.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/persistence-status.test.ts src/components/common/persistence-status.a11y.test.ts` (24 passed)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check origin/main..HEAD`
- `pnpm --dir dashboard run lint` (passes with 3 existing unrelated warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic-import/chunk-size warnings)
- Browser QA via `agent-browser` at 720x520: verified saved/syncing/conflict/offline metadata, `aria-busy` only on syncing, visible freshness labels, `<time datetime>`, no visible overflow, console only Vite debug lines. Screenshot: `/tmp/masc-persistence-status-summary-0506.png`.

## Review focus
- `dashboard/src/components/common/persistence-status.ts`
- `dashboard/src/components/common/persistence-status.test.ts`
- `dashboard/src/components/common/persistence-status.a11y.test.ts`