### PR TITLE
docs(goal-loop): record workspace corpus search

### DIFF
--- a/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
+++ b/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
@@ -145,7 +145,7 @@
   completion report that keeps #13265 open because the corpus is not
   replayable. A design research note with aggregate 206/STILL_PRESENT claims
   and a single `R-FATAL-1` example was also checked and does not contain the
-  missing row corpus. The closest GOAL-loop export archive was checked as
+  missing row corpus. The closest GOAL LOOP export archive was checked as
   well; it contains the same prompt documents and research notes, with no
   `source_catalog_id`, strict-row schema, or 206 itemized rows. A later
   workspace/tmp sweep checked 16 generated JSON artifacts mentioning the

--- a/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
+++ b/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
@@ -147,7 +147,10 @@
   and a single `R-FATAL-1` example was also checked and does not contain the
   missing row corpus. The closest GOAL-loop export archive was checked as
   well; it contains the same prompt documents and research notes, with no
-  `source_catalog_id`, strict-row schema, or 206 itemized rows.
+  `source_catalog_id`, strict-row schema, or 206 itemized rows. A later
+  workspace/tmp sweep checked 16 generated JSON artifacts mentioning the
+  catalog id; those were Orient/status/catalog snapshots with 18 or 19 rows,
+  not a complete strict 206-row corpus.
 - [근거] `python3 test/test_goal_loop_completion_audit.py` checked at
   2026-05-06T09:59:29+09:00, confidence High: the completion audit now accepts
   an optional `--strict-row-corpus` artifact and validates it against the

--- a/test/fixtures/goal_loop/row-corpus-discovery.external-claim.json
+++ b/test/fixtures/goal_loop/row-corpus-discovery.external-claim.json
@@ -119,6 +119,22 @@
       "sha256": "c41ad0b7e719e27f557e5b93e422048a64ccf993ba3ebdcc04e296452497ff28",
       "contents_summary": "46 markdown files including the 12 prompt documents and research notes",
       "note": "Archive search finds aggregate 206 claims, top finding examples, and ACT-title placeholders, but no source_catalog_id, strict-row schema, or 206 itemized finding rows."
+    },
+    {
+      "artifact_name": "workspace_tmp_goal_loop_catalog_mentions",
+      "artifact_kind": "runtime_search_report",
+      "result": "NOT_ROW_CORPUS",
+      "observed_files_checked": 16,
+      "observed_file_classes": [
+        "orient_snapshot",
+        "status_snapshot",
+        "pretty_printed_audit_catalog"
+      ],
+      "observed_candidate_row_counts": [
+        18,
+        19
+      ],
+      "note": "Workspace and temporary JSON artifacts mentioning goal-loop-206-audit-external-claim-2026-05-05 were checked. They were generated Orient/status/catalog snapshots, not a COMPLETE strict row corpus with 206 findings and a corpus_id."
     }
   ],
   "broader_structured_id_triage": {

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -395,7 +395,7 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
             "FULL_ROW_CORPUS_NOT_FOUND",
         )
         self.assertEqual(discovery_evidence["prompt_sources_checked"], 12)
-        self.assertEqual(discovery_evidence["candidate_artifacts_checked"], 8)
+        self.assertEqual(discovery_evidence["candidate_artifacts_checked"], 9)
         self.assertFalse(discovery_evidence["local_path_leaks"])
         self.assertTrue(discovery_evidence["source_catalog_id_matches"])
 


### PR DESCRIPTION
## Summary

- Adds the workspace/tmp catalog-mention sweep to the GOAL LOOP row-corpus discovery manifest without recording local absolute paths.
- Records that 16 small JSON artifacts mentioning the GOAL LOOP catalog id were generated Orient/status/catalog snapshots, not a complete 206-row strict corpus.
- Keeps #13265 open: this is negative search evidence only, and the strict row corpus is still the required input.

## Verification

- python3 -m json.tool test/fixtures/goal_loop/row-corpus-discovery.external-claim.json
- ruff check scripts/goal_loop_completion_audit.py test/test_goal_loop_completion_audit.py
- ruff format --check scripts/goal_loop_completion_audit.py test/test_goal_loop_completion_audit.py
- python3 -m py_compile scripts/goal_loop_completion_audit.py test/test_goal_loop_completion_audit.py
- python3 test/test_goal_loop_completion_audit.py
- git diff --check
- python3 scripts/goal_loop_completion_audit.py /private/tmp/goal-loop-status-live-post-act-cf01.json --structured-id-triage test/fixtures/goal_loop/structured-id-triage.external-claim.json --row-corpus-discovery test/fixtures/goal_loop/row-corpus-discovery.external-claim.json --require-complete --format text exits non-zero by design with only strict_row_level_catalog_complete.

Refs #13265