### PR TITLE
fix(coord): observe claim provision failures

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -352,6 +352,16 @@ let () =
   Atomic.set Coord_hooks.distributed_lock_acquire_failed_fn
     record_distributed_lock_acquire_failed
 
+let record_claim_post_provision_failed ~site ~agent_name ~task_id:_ ~error:_ =
+  Prometheus.inc_counter
+    Prometheus.metric_coord_claim_post_provision_failures
+    ~labels:[ ("site", site); ("agent_name", agent_name) ]
+    ()
+
+let () =
+  Atomic.set Coord_hooks.claim_post_provision_failed_fn
+    record_claim_post_provision_failed
+
 (* Activity graph emit — wraps Activity_graph for room sub-modules *)
 let () = Atomic.set Coord_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     (try

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -262,3 +262,24 @@ let task_auto_release_observed_fn
 let claim_post_provision_fn
   : (Coord_utils_backend_setup.config -> agent_name:string -> task_id:string -> unit) Atomic.t
   = Atomic.make (fun _ ~agent_name:_ ~task_id:_ -> ())
+
+let claim_post_provision_failed_fn
+  : (site:string ->
+     agent_name:string ->
+     task_id:string ->
+     error:string ->
+     unit) Atomic.t
+  = Atomic.make
+      (fun ~site:_ ~agent_name:_ ~task_id:_ ~error:_ -> ())
+
+let observe_claim_post_provision_failure ~site ~agent_name ~task_id exn =
+  let error = Printexc.to_string exn in
+  (try
+     (Atomic.get claim_post_provision_failed_fn)
+       ~site ~agent_name ~task_id ~error
+   with _ -> ());
+  (try
+     Log.RoomTask.warn
+       "claim_post_provision failed site=%s agent=%s task=%s err=%s"
+       site agent_name task_id error
+   with _ -> ())

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -69,3 +69,11 @@ val claim_post_provision_fn : (Coord_utils_backend_setup.config ->
             agent_name:string ->
             task_id:string -> unit)
            Atomic.t
+val claim_post_provision_failed_fn :
+  (site:string ->
+   agent_name:string ->
+   task_id:string ->
+   error:string ->
+   unit) Atomic.t
+val observe_claim_post_provision_failure :
+  site:string -> agent_name:string -> task_id:string -> exn -> unit

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -312,9 +312,8 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
                   ());
            (* task-103: best-effort auto-provision a sandbox worktree for
               docker keepers. The hook itself decides whether to act based
-              on keeper sandbox_profile; failures inside the hook are
-              logged by the hook implementation and must not block the
-              claim. *)
+              on keeper sandbox_profile; failures are observed centrally and
+              must not block the claim. *)
            (try
               (Atomic.get Coord_hooks.claim_post_provision_fn) config ~agent_name ~task_id
             with

--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -319,7 +319,9 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
               (Atomic.get Coord_hooks.claim_post_provision_fn) config ~agent_name ~task_id
             with
             | Eio.Cancel.Cancelled _ as e -> raise e
-            | _ -> ());
+            | exn ->
+                Coord_hooks.observe_claim_post_provision_failure
+                  ~site:"claim_task" ~agent_name ~task_id exn);
            Ok (Printf.sprintf "%s claimed %s" agent_name task_id)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -717,7 +717,9 @@ let claim_next_r
                ~task_id:task.id
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
-           | _ -> ());
+           | exn ->
+               Coord_hooks.observe_claim_post_provision_failure
+                 ~site:"claim_next" ~agent_name ~task_id:task.id exn);
 
           let message = match released_task_id with
             | Some rid ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -743,6 +743,8 @@ let metric_telemetry_unified_source_read_failures =
    most 19 (3 + 8 + 8). *)
 let metric_coord_telemetry_drop =
   "masc_coord_telemetry_drop_total"
+let metric_coord_claim_post_provision_failures =
+  "masc_coord_claim_post_provision_failures_total"
 
 (* #10094: per-caller counter for [Masc_oas_bridge.run_safe]
    timeouts.  The [caller] string supplied at the run_safe entry
@@ -2133,6 +2135,11 @@ let init () =
      series (3 + 8 + 8). Non-zero rate means a production path is \
      firing the lifecycle outside an Eio context; before this counter \
      the drop was silent (#10358 attrition root cause)."
+    Counter;
+  add metric_coord_claim_post_provision_failures
+    "Total best-effort claim post-provision hook failures. Labels: site \
+     (claim_task | claim_next) and agent_name. Task IDs are logged but \
+     not labeled to keep series cardinality bounded."
     Counter;
   add metric_auth_credential_ambiguous_lookup
     "Total runtime credential lookups where N>=2 credentials share the \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -397,6 +397,9 @@ val metric_coord_telemetry_drop : string
     outside an Eio fiber and the corresponding audit/telemetry rows
     are missing — the silent root cause behind the [#10358] 5-tag → 2-tag
     durable-ledger attrition. *)
+val metric_coord_claim_post_provision_failures : string
+(** Total best-effort claim post-provision hook failures. Labels: [site]
+    and [agent_name]. *)
 
 val metric_oas_bridge_timeout : string
 (** #10094: labelled [caller, timeout_s] so operators can

--- a/test/test_claim_post_provision_hook.ml
+++ b/test/test_claim_post_provision_hook.ml
@@ -11,6 +11,12 @@ open Alcotest
 open Masc_mcp
 module CH = Coord_hooks
 
+let failure_metric_value ~site ~agent_name =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_coord_claim_post_provision_failures
+    ~labels:[ ("site", site); ("agent_name", agent_name) ]
+    ()
+
 let with_test_env f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -52,6 +58,7 @@ let test_hook_invoked_on_successful_claim () =
 
 let test_hook_failure_does_not_block_claim () =
   with_test_env @@ fun config ->
+  let before = failure_metric_value ~site:"claim_task" ~agent_name:"claude" in
   Atomic.set CH.claim_post_provision_fn (fun _ ~agent_name:_ ~task_id:_ ->
       raise (Failure "synthetic worktree provisioning failure"));
   let _ = Coord.add_task config ~title:"task-103 t2" ~priority:1 ~description:"" in
@@ -60,10 +67,33 @@ let test_hook_failure_does_not_block_claim () =
   with
   | Ok msg ->
     check bool "claim succeeded despite hook failure" true
-      (Astring.String.is_infix ~affix:"claimed" msg)
+      (Astring.String.is_infix ~affix:"claimed" msg);
+    check (float 0.001) "claim failure metric incremented"
+      (before +. 1.0)
+      (failure_metric_value ~site:"claim_task" ~agent_name:"claude")
   | Error e ->
     failf "claim must succeed even if hook raises; got: %s"
       (Masc_domain.show_masc_error e)
+
+let test_claim_next_hook_failure_is_observed () =
+  with_test_env @@ fun config ->
+  let before = failure_metric_value ~site:"claim_next" ~agent_name:"claude" in
+  Atomic.set CH.claim_post_provision_fn (fun _ ~agent_name:_ ~task_id:_ ->
+      raise (Failure "synthetic claim_next provisioning failure"));
+  let _ = Coord.add_task config ~title:"task-103 t-next" ~priority:1 ~description:"" in
+  match Coord.claim_next_r config ~agent_name:"claude" () with
+  | Coord.Claim_next_claimed { task_id; _ } ->
+    check string "claimed task" "task-001" task_id;
+    check (float 0.001) "claim_next failure metric incremented"
+      (before +. 1.0)
+      (failure_metric_value ~site:"claim_next" ~agent_name:"claude")
+  | Coord.Claim_next_no_unclaimed ->
+    fail "claim_next unexpectedly found no unclaimed task"
+  | Coord.Claim_next_no_eligible { excluded_count } ->
+    failf "claim_next unexpectedly found no eligible task; excluded=%d"
+      excluded_count
+  | Coord.Claim_next_error msg ->
+    failf "claim_next unexpectedly failed: %s" msg
 
 let test_hook_not_invoked_on_already_claimed () =
   with_test_env @@ fun config ->
@@ -89,6 +119,8 @@ let () =
             test_hook_invoked_on_successful_claim;
           test_case "does not block claim on hook failure" `Quick
             test_hook_failure_does_not_block_claim;
+          test_case "observes claim_next hook failure" `Quick
+            test_claim_next_hook_failure_is_observed;
           test_case "skips already-claimed repeat" `Quick
             test_hook_not_invoked_on_already_claimed;
         ] );

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -276,7 +276,8 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_auth_credential_token_rotated;
   check_registered Prometheus.metric_telemetry_coverage_gap;
   check_registered Prometheus.metric_telemetry_unified_source_read_failures;
-  check_registered Prometheus.metric_coord_telemetry_drop
+  check_registered Prometheus.metric_coord_telemetry_drop;
+  check_registered Prometheus.metric_coord_claim_post_provision_failures
 
 let test_distributed_lock_metric_registered () =
   let text = Prometheus.to_prometheus_text () in


### PR DESCRIPTION
## Summary
- add a coord hook-failure observer for best-effort `claim_post_provision_fn` failures
- replace the direct `claim_task` and `claim_next` wildcard swallows with a non-blocking helper that logs the failing task and increments `masc_coord_claim_post_provision_failures_total`
- cover both direct claim and claim-next failure paths, plus Prometheus metric registration

## Why
The post-provision hook is intentionally best-effort, but a failed sandbox/worktree provision should not disappear. Claims still succeed, cancellation still propagates, and operators get a bounded metric split by `site` and `agent_name` while task IDs stay in logs only.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_claim_post_provision_hook.exe test/test_prometheus_coverage.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-claim-provision-observe-0506c MASC_BASE_PATH_INPUT=/private/tmp/masc-claim-provision-observe-0506c ./_build/default/test/test_claim_post_provision_hook.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-claim-provision-observe-0506c-prom MASC_BASE_PATH_INPUT=/private/tmp/masc-claim-provision-observe-0506c-prom ./_build/default/test/test_prometheus_coverage.exe`