### PR TITLE
fix(dashboard): label terminal keeper blockers

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -10,6 +10,7 @@ import {
   fetchTlcResults,
   fetchToolQuality,
 } from './dashboard'
+import { keeperRuntimeBlockerLabel } from '../lib/keeper-runtime-display'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -928,6 +929,40 @@ describe('fetchKeeperConfig', () => {
     expect(result.coordination.active_goal_ids).toEqual(['goal-runtime'])
     expect(result.coordination.active_goals[0]?.title).toBe('Ship runtime clarity')
     expect(result.runtime_trust?.disposition).toBe('Pass')
+  })
+
+  it('preserves terminal runtime blocker classes through config fetch and display labeling', async () => {
+    const cases = [
+      ['no_tool_capable_provider', '도구 실행 Provider 없음'],
+      ['provider_runtime_error', 'Provider 런타임 오류'],
+      ['tool_required_unsatisfied', '필수 도구 미충족'],
+      ['fiber_unresolved', 'Fiber 미해결'],
+      ['stale_turn_timeout', '오래된 턴 만료'],
+    ] as const
+
+    for (const [blockerClass, label] of cases) {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            name: 'keeper-sangsu',
+            runtime: {
+              runtime_blocker_class: blockerClass,
+              runtime_blocker_summary: blockerClass,
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchKeeperConfig('keeper-sangsu')
+
+      expect(result.runtime.runtime_blocker_class).toBe(blockerClass)
+      expect(keeperRuntimeBlockerLabel(result.runtime.runtime_blocker_class)).toBe(label)
+    }
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1976,6 +1976,11 @@ function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['
     case 'turn_timeout':
     case 'completion_contract_violation':
     case 'cascade_exhausted':
+    case 'no_tool_capable_provider':
+    case 'provider_runtime_error':
+    case 'tool_required_unsatisfied':
+    case 'fiber_unresolved':
+    case 'stale_turn_timeout':
       return blockerClass
     default:
       return null

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -4,6 +4,8 @@ import {
   keeperActivityDisplay,
   keeperDisplayModel,
   keeperDisplayStatus,
+  keeperRuntimeBlockerHint,
+  keeperRuntimeBlockerLabel,
 } from './keeper-runtime-display'
 
 /** Minimal Keeper stub with only the fields relevant to status classification. */
@@ -149,6 +151,37 @@ describe('keeperDisplayModel', () => {
         ],
       }),
     ).toEqual({ label: '최근 모델', value: 'anthropic:claude-sonnet-4-6' })
+  })
+})
+
+describe('keeperRuntimeBlockerLabel', () => {
+  it('labels backend-emitted terminal keeper failure classes', () => {
+    expect(keeperRuntimeBlockerLabel('provider_runtime_error')).toBe(
+      'Provider 런타임 오류',
+    )
+    expect(keeperRuntimeBlockerLabel('tool_required_unsatisfied')).toBe(
+      '필수 도구 미충족',
+    )
+  })
+})
+
+describe('keeperRuntimeBlockerHint', () => {
+  it('explains provider runtime terminal failures when no summary is available', () => {
+    expect(
+      keeperRuntimeBlockerHint(makeKeeper({
+        runtime_blocker_class: 'provider_runtime_error',
+        runtime_blocker_summary: 'provider_runtime_error',
+      })),
+    ).toBe('Provider, adapter, or cascade가 keeper 진행 전에 실패했습니다.')
+  })
+
+  it('explains unsatisfied required tool terminal failures when no summary is available', () => {
+    expect(
+      keeperRuntimeBlockerHint(makeKeeper({
+        runtime_blocker_class: 'tool_required_unsatisfied',
+        runtime_blocker_summary: 'tool_required_unsatisfied',
+      })),
+    ).toBe('액션 가능한 신호에 필요한 keeper 도구 호출이 충족되지 않았습니다.')
   })
 })
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -1,4 +1,4 @@
-import type { Keeper } from '../types'
+import type { Keeper, KeeperRuntimeBlockerClass } from '../types'
 import { relativeTime } from './format-time'
 
 /** Max seconds since last heartbeat to consider the keeper process alive. */
@@ -238,9 +238,11 @@ const runtimeBlockerLabels = {
   completion_contract_violation: '완료 계약 위반',
   cascade_exhausted: '캐스케이드 소진',
   no_tool_capable_provider: '도구 실행 Provider 없음',
+  provider_runtime_error: 'Provider 런타임 오류',
+  tool_required_unsatisfied: '필수 도구 미충족',
   fiber_unresolved: 'Fiber 미해결',
   stale_turn_timeout: '오래된 턴 만료',
-} satisfies Record<NonNullable<Keeper['runtime_blocker_class']>, string>
+} satisfies Record<KeeperRuntimeBlockerClass, string>
 
 export function keeperRuntimeBlockerLabel(
   blockerClass: Keeper['runtime_blocker_class'] | null | undefined,
@@ -284,6 +286,12 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'no_tool_capable_provider') {
     return '요구 도구를 실행할 수 있는 provider가 없어 라우팅 또는 tool surface 확인이 필요합니다.'
+  }
+  if (blockerClass === 'provider_runtime_error') {
+    return 'Provider, adapter, or cascade가 keeper 진행 전에 실패했습니다.'
+  }
+  if (blockerClass === 'tool_required_unsatisfied') {
+    return '액션 가능한 신호에 필요한 keeper 도구 호출이 충족되지 않았습니다.'
   }
   if (blockerClass === 'fiber_unresolved') {
     return 'Keeper fiber가 종료 상태를 확정하지 못해 supervisor 확인이 필요합니다.'

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -300,6 +300,22 @@ export interface KeeperMetricPoint {
   fallback_reason: string | null
 }
 
+export type KeeperRuntimeBlockerClass =
+  | 'ambiguous_post_commit_timeout'
+  | 'ambiguous_post_commit_failure'
+  | 'autonomous_slot_wait_timeout'
+  | 'admission_queue_wait_timeout'
+  | 'turn_timeout_after_queue_wait'
+  | 'oas_timeout_budget'
+  | 'turn_timeout'
+  | 'completion_contract_violation'
+  | 'cascade_exhausted'
+  | 'no_tool_capable_provider'
+  | 'provider_runtime_error'
+  | 'tool_required_unsatisfied'
+  | 'fiber_unresolved'
+  | 'stale_turn_timeout'
+
 export interface KeeperTrustLatestEvent {
   kind: string
   ts: string
@@ -750,20 +766,7 @@ export interface Keeper {
   proactive_enabled?: boolean
   proactive_idle_sec?: number
   proactive_cooldown_sec?: number
-  runtime_blocker_class?:
-    | 'ambiguous_post_commit_timeout'
-    | 'ambiguous_post_commit_failure'
-    | 'autonomous_slot_wait_timeout'
-    | 'admission_queue_wait_timeout'
-    | 'turn_timeout_after_queue_wait'
-    | 'oas_timeout_budget'
-    | 'turn_timeout'
-    | 'completion_contract_violation'
-    | 'cascade_exhausted'
-    | 'no_tool_capable_provider'
-    | 'fiber_unresolved'
-    | 'stale_turn_timeout'
-    | null
+  runtime_blocker_class?: KeeperRuntimeBlockerClass | null
   runtime_blocker_summary?: string | null
   runtime_blocker_continue_gate?: boolean | null
   needs_attention?: boolean | null
@@ -1089,17 +1092,7 @@ interface KeeperConfigRuntime {
   fiber_health: string
   presence_keepalive: boolean
   presence_keepalive_sec: number
-  runtime_blocker_class?:
-    | 'ambiguous_post_commit_timeout'
-    | 'ambiguous_post_commit_failure'
-    | 'autonomous_slot_wait_timeout'
-    | 'admission_queue_wait_timeout'
-    | 'turn_timeout_after_queue_wait'
-    | 'oas_timeout_budget'
-    | 'turn_timeout'
-    | 'completion_contract_violation'
-    | 'cascade_exhausted'
-    | null
+  runtime_blocker_class?: KeeperRuntimeBlockerClass | null
   active_model_label?: string | null
   last_model_used_label?: string | null
   runtime_blocker_summary?: string | null


### PR DESCRIPTION
## Summary

- add a shared `KeeperRuntimeBlockerClass` type instead of duplicating runtime blocker unions
- include backend-emitted `provider_runtime_error` and `tool_required_unsatisfied` classes in the dashboard type surface
- add labels, fallback hints, and focused tests for those terminal keeper blockers

## Why

Refs #10512.

The backend can emit `provider_runtime_error` and `tool_required_unsatisfied` from typed keeper failure reasons, but the dashboard type/display layer did not model those classes. That left terminal keeper blockers less structured than the runtime already made them, especially when summaries collapse to the raw class string.

## Validation

- `pnpm install --offline --ignore-scripts`
- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec vitest run --config vitest.config.ts src/lib/keeper-runtime-display.test.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check`
