### PR TITLE
fix(coord): mark stale agent task labels in status

### DIFF
--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -57,13 +57,45 @@ let active_task_assignee = function
       Some assignee
   | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
-let assigned_task_ids ~matches_you tasks =
-  List.filter_map
+let add_unique table key value =
+  let values = Option.value (Hashtbl.find_opt table key) ~default:[] in
+  if List.exists (String.equal value) values then ()
+  else Hashtbl.replace table key (value :: values)
+
+let active_assigned_task_ids_lookup
+    ~(actual_name : string)
+    ~(ctx_agent_name : string)
+    ~(agents_with_state : (Masc_domain.agent * bool) list)
+    ~(active_tasks : Masc_domain.task list) =
+  let assignee_to_agents = Hashtbl.create (List.length agents_with_state * 2) in
+  List.iter
+    (fun ((agent : Masc_domain.agent), _) ->
+      add_unique assignee_to_agents agent.name agent.name;
+      if String.equal agent.name actual_name then
+        add_unique assignee_to_agents ctx_agent_name agent.name)
+    agents_with_state;
+  let task_ids_by_agent = Hashtbl.create (List.length agents_with_state) in
+  List.iter
     (fun (task : Masc_domain.task) ->
       match active_task_assignee task.task_status with
-      | Some assignee when matches_you assignee -> Some task.id
-      | Some _ | None -> None)
-    tasks
+      | None -> ()
+      | Some assignee ->
+          let agents =
+            Option.value (Hashtbl.find_opt assignee_to_agents assignee)
+              ~default:[]
+          in
+          List.iter
+            (fun agent_name ->
+              let task_ids =
+                Option.value (Hashtbl.find_opt task_ids_by_agent agent_name)
+                  ~default:[]
+              in
+              Hashtbl.replace task_ids_by_agent agent_name (task.id :: task_ids))
+            agents)
+    active_tasks;
+  fun agent_name ->
+    Option.value (Hashtbl.find_opt task_ids_by_agent agent_name) ~default:[]
+    |> List.rev
 
 let agent_status_icon ~is_zombie = function
   | _ when is_zombie -> "💀"
@@ -205,17 +237,19 @@ let status_summary_string
   | [] ->
       Buffer.add_string buf "  (no agents)\n"
   | _ ->
+      let active_assigned_task_ids_for_agent =
+        active_assigned_task_ids_lookup
+          ~actual_name
+          ~ctx_agent_name:ctx.agent_name
+          ~agents_with_state:shown_agents
+          ~active_tasks
+      in
       List.iter
         (fun ((agent : Masc_domain.agent), is_zombie) ->
           Coord_query.safe_yield ();
           let icon = agent_status_icon ~is_zombie agent.status in
-          let matches_agent assignee =
-            String.equal assignee agent.name
-            || (String.equal agent.name actual_name
-               && String.equal assignee ctx.agent_name)
-          in
           let active_assigned_task_ids =
-            assigned_task_ids ~matches_you:matches_agent active_tasks
+            active_assigned_task_ids_for_agent agent.name
           in
           let you_marker =
             if String.equal agent.name actual_name then " (you)" else ""

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -26,6 +26,11 @@ let option_or_dash = function
   | Some value when not (String.equal (String.trim value) "") -> value
   | _ -> "-"
 
+let first_line text =
+  match String.index_opt text '\n' with
+  | Some i -> String.sub text 0 i
+  | None -> text
+
 let take_items limit items =
   let rec loop remaining acc = function
     | _ when remaining <= 0 -> List.rev acc
@@ -113,20 +118,19 @@ let agent_focus_label ~is_zombie ~active_assigned_task_ids
     | task :: rest -> Printf.sprintf "%s (+%d)" task (List.length rest)
     | [] -> (
         match agent.current_task with
-        | Some task when not (String.equal (String.trim task) "") ->
-            Printf.sprintf "%s (stale:%s)"
-              (Masc_domain.agent_status_to_string agent.status)
-              task
+        | Some raw_task ->
+            let task = raw_task |> String.trim |> first_line in
+            if String.equal task "" then
+              Masc_domain.agent_status_to_string agent.status
+            else
+              Printf.sprintf "%s (stale:%s)"
+                (Masc_domain.agent_status_to_string agent.status)
+                task
         | _ -> Masc_domain.agent_status_to_string agent.status)
 
 let task_id_list_label = function
   | [] -> "[]"
   | ids -> "[" ^ String.concat "," ids ^ "]"
-
-let first_line text =
-  match String.index_opt text '\n' with
-  | Some i -> String.sub text 0 i
-  | None -> text
 
 let deliverable_claims_completion ~task_id deliverable =
   let normalized =

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -72,11 +72,20 @@ let agent_status_icon ~is_zombie = function
   | Masc_domain.Listening -> "🎧"
   | Masc_domain.Inactive -> "⚫"
 
-let agent_focus_label ~is_zombie (agent : Masc_domain.agent) =
+let agent_focus_label ~is_zombie ~active_assigned_task_ids
+    (agent : Masc_domain.agent) =
   if is_zombie then "stale"
-  else option_or_dash agent.current_task |> function
-    | "-" -> Masc_domain.agent_status_to_string agent.status
-    | task -> task
+  else
+    match active_assigned_task_ids with
+    | task :: [] -> task
+    | task :: rest -> Printf.sprintf "%s (+%d)" task (List.length rest)
+    | [] -> (
+        match agent.current_task with
+        | Some task when not (String.equal (String.trim task) "") ->
+            Printf.sprintf "%s (stale:%s)"
+              (Masc_domain.agent_status_to_string agent.status)
+              task
+        | _ -> Masc_domain.agent_status_to_string agent.status)
 
 let task_id_list_label = function
   | [] -> "[]"
@@ -200,12 +209,20 @@ let status_summary_string
         (fun ((agent : Masc_domain.agent), is_zombie) ->
           Coord_query.safe_yield ();
           let icon = agent_status_icon ~is_zombie agent.status in
+          let matches_agent assignee =
+            String.equal assignee agent.name
+            || (String.equal agent.name actual_name
+               && String.equal assignee ctx.agent_name)
+          in
+          let active_assigned_task_ids =
+            assigned_task_ids ~matches_you:matches_agent active_tasks
+          in
           let you_marker =
             if String.equal agent.name actual_name then " (you)" else ""
           in
           Buffer.add_string buf
             (Printf.sprintf "  %s %s%s -> %s\n" icon agent.name you_marker
-               (agent_focus_label ~is_zombie agent)))
+               (agent_focus_label ~is_zombie ~active_assigned_task_ids agent)))
         shown_agents;
       if agent_count > max_agents_display then
         Buffer.add_string buf

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -93,11 +93,27 @@ let write_agent ctx agent =
     (Types.agent_to_yojson agent)
 
 let seed_stale_current_task ctx =
-  let old_last_seen = "2000-01-01T00:00:00Z" in
+  let old_last_seen =
+    Masc_domain.iso8601_of_unix_seconds (Time_compat.now () -. 10.0)
+  in
   let agent = read_agent ctx in
   write_agent ctx
     { agent with status = Busy; current_task = Some "task-missing"; last_seen = old_last_seen };
   old_last_seen
+
+let write_agent_state config agent_name f =
+  let agent_file =
+    Filename.concat (Coord.agents_dir config)
+      (Coord.safe_filename agent_name ^ ".json")
+  in
+  let agent =
+    match Coord.read_json config agent_file |> Masc_domain.agent_of_yojson with
+    | Ok agent -> agent
+    | Error msg -> failwith ("agent parse failed: " ^ msg)
+  in
+  Coord.write_json config agent_file (Masc_domain.agent_to_yojson (f agent))
+
+let actual_test_agent_name config = Coord.resolve_agent_name config "test-agent"
 
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
@@ -253,6 +269,47 @@ let () = test "dispatch_status_hides_awaiting_verification_current_task" (fun ()
         assert (agent_after.current_task = Some "task-001");
         assert (agent_after.status = Masc_domain.Busy)
     | None -> failwith "dispatch returned None"))
+
+let () = test "dispatch_status_marks_stale_agent_current_task_label" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  let _ = Coord.add_task ctx.config ~title:"Completed elsewhere" ~priority:2 ~description:"" in
+  ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
+  (match
+     Coord.transition_task_r ctx.config ~agent_name:"test-agent"
+       ~task_id:"task-001" ~action:Masc_domain.Done_action ~notes:"ok" ()
+   with
+  | Ok _ -> ()
+  | Error err -> failwith (Masc_domain.masc_error_to_string err));
+  let actual_name = actual_test_agent_name ctx.config in
+  write_agent_state ctx.config actual_name (fun agent ->
+      { agent with status = Masc_domain.Busy; current_task = Some "task-001" });
+  match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some { success; message = result } ->
+      assert success;
+      assert_not_contains result (actual_name ^ " (you) -> task-001");
+      assert_contains result (actual_name ^ " (you) -> busy (stale:task-001)");
+      assert_contains result "Summary: active=0, done=1, cancelled=0, total=1"
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_status_players_prefer_live_board_assignment" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  ignore (Coord.add_task ctx.config ~title:"Live assignment" ~priority:2 ~description:"");
+  ignore (Coord.add_task ctx.config ~title:"Old registry focus" ~priority:2 ~description:"");
+  ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
+  let actual_name = actual_test_agent_name ctx.config in
+  write_agent_state ctx.config actual_name (fun agent ->
+      { agent with status = Masc_domain.Busy; current_task = Some "task-002" });
+  match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some { success; message = result } ->
+      assert success;
+      assert_contains result (actual_name ^ " (you) -> task-001");
+      assert_not_contains result (actual_name ^ " (you) -> task-002");
+      assert_not_contains result (actual_name ^ " (you) -> busy (stale:task-002)")
+  | None -> failwith "dispatch returned None"
+)
 
 (* Test dispatch reset without confirm *)
 let () = test "dispatch_reset_no_confirm" (fun () ->

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -93,9 +93,7 @@ let write_agent ctx agent =
     (Types.agent_to_yojson agent)
 
 let seed_stale_current_task ctx =
-  let old_last_seen =
-    Masc_domain.iso8601_of_unix_seconds (Time_compat.now () -. 10.0)
-  in
+  let old_last_seen = Masc_domain.now_iso () in
   let agent = read_agent ctx in
   write_agent ctx
     { agent with status = Busy; current_task = Some "task-missing"; last_seen = old_last_seen };
@@ -283,12 +281,16 @@ let () = test "dispatch_status_marks_stale_agent_current_task_label" (fun () ->
   | Error err -> failwith (Masc_domain.masc_error_to_string err));
   let actual_name = actual_test_agent_name ctx.config in
   write_agent_state ctx.config actual_name (fun agent ->
-      { agent with status = Masc_domain.Busy; current_task = Some "task-001" });
+      { agent with
+        status = Masc_domain.Busy;
+        current_task = Some " task-001\nignored-line "
+      });
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
   | Some { success; message = result } ->
       assert success;
       assert_not_contains result (actual_name ^ " (you) -> task-001");
       assert_contains result (actual_name ^ " (you) -> busy (stale:task-001)");
+      assert_not_contains result "ignored-line";
       assert_contains result "Summary: active=0, done=1, cancelled=0, total=1"
   | None -> failwith "dispatch returned None"
 )


### PR DESCRIPTION
## Summary
- Render Players labels from live active task assignments instead of trusting agent.current_task blindly.
- Show stale registry focus as status (stale:task-id) when no active board task is assigned.
- Add coord status coverage for stale registry focus and alias-resolved live board assignment.

## Validation
- git diff --check origin/main...HEAD
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_tool_coord_coverage.exe
- ./_build/default/test/test_tool_coord_coverage.exe --color=never