### PR TITLE
fix(keeper): materialize PR review tool surface

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -188,6 +188,13 @@ let run_named
   let error_cascade_name = cascade_name_of_string cascade_name in
   let runtime_cascade_name = Keeper_cascade_profile.Runtime_name cascade_name in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
+  (* Keeper-internal tools cannot degrade to a text-only CLI palette: the
+     model would see no callable schema and emit misleading diagnostics. *)
+  let require_tool_support =
+    require_tool_support
+    || keeper_internal_tools_require_materialized_runtime_surface
+         ~keeper_name tools
+  in
   let configured_labels_result, candidate_cfgs_result, secondary_resolver =
     match model_strings with
     | Some ms when ms <> [] ->
@@ -198,6 +205,7 @@ let run_named
       ( Ok ms,
         Ok
           (resolve_providers_from_model_strings ?provider_filter
+             ?runtime_mcp_policy
              ~require_tool_choice_support ~require_tool_support ms),
         None )
     | _ ->

--- a/lib/oas_worker_named_cascade.ml
+++ b/lib/oas_worker_named_cascade.ml
@@ -91,6 +91,22 @@ let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool
   | Some policy, None -> Some policy
   | None, _ -> None
 
+let keeper_internal_tool_names_for_runtime_surface ~(keeper_name : string)
+    (tools : Agent_sdk.Tool.t list) =
+  match keeper_agent_name_opt keeper_name with
+  | None -> []
+  | Some _ ->
+      tools
+      |> List.filter (fun (tool : Agent_sdk.Tool.t) ->
+             Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
+               tool.schema.name)
+      |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
+      |> List.sort_uniq String.compare
+
+let keeper_internal_tools_require_materialized_runtime_surface
+    ~(keeper_name : string) (tools : Agent_sdk.Tool.t list) =
+  keeper_internal_tool_names_for_runtime_surface ~keeper_name tools <> []
+
 let runtime_mcp_policy_for_provider
     ~(keeper_name : string)
     ~(provider_cfg : Llm_provider.Provider_config.t)

--- a/lib/oas_worker_named_cascade.mli
+++ b/lib/oas_worker_named_cascade.mli
@@ -61,6 +61,17 @@ val runtime_mcp_policy_for_tools :
 (** Build a runtime MCP policy from the tool list, honouring public MCP tools
     and keeper-internal surface classifications. *)
 
+val keeper_internal_tool_names_for_runtime_surface :
+  keeper_name:string -> Agent_sdk.Tool.t list -> string list
+(** Keeper-internal tool names that require a keeper-bound runtime surface for
+    the given keeper. Empty when [keeper_name] does not resolve to a keeper
+    agent name. *)
+
+val keeper_internal_tools_require_materialized_runtime_surface :
+  keeper_name:string -> Agent_sdk.Tool.t list -> bool
+(** [true] when the active tool surface contains keeper-internal tools that
+    must not be silently dropped by an optional CLI/runtime-MCP lane. *)
+
 val runtime_mcp_policy_for_provider :
   keeper_name:string ->
   provider_cfg:Llm_provider.Provider_config.t ->

--- a/lib/oas_worker_named_cascade.mli
+++ b/lib/oas_worker_named_cascade.mli
@@ -64,8 +64,7 @@ val runtime_mcp_policy_for_tools :
 val keeper_internal_tool_names_for_runtime_surface :
   keeper_name:string -> Agent_sdk.Tool.t list -> string list
 (** Keeper-internal tool names that require a keeper-bound runtime surface for
-    the given keeper. Empty when [keeper_name] does not resolve to a keeper
-    agent name. *)
+    the given keeper. Empty when [keeper_name] is blank. *)
 
 val keeper_internal_tools_require_materialized_runtime_surface :
   keeper_name:string -> Agent_sdk.Tool.t list -> bool

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -78,6 +78,15 @@ let keeper_internal_tools =
     "keeper_voice_session_end";
     (* Tool discovery *)
     "keeper_tool_search";
+    (* Keeper-scoped GitHub PR tools. These are native keeper tools, not
+       public MCP tools, so CLI lanes must materialize them through the
+       keeper-bound runtime MCP surface instead of silently dropping them. *)
+    "keeper_pr_list";
+    "keeper_pr_status";
+    "keeper_pr_create";
+    "keeper_pr_review_read";
+    "keeper_pr_review_comment";
+    "keeper_pr_review_reply";
     (* keeper_deliberation_decision: Agent_sdk.Structured result schema, not
        a regular tool — does not need a keeper shard entry.
        keeper_unified: cascade name, not a tool. *)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2500,6 +2500,40 @@ let test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_fo
     [ "claude_code:auto"; "kimi_cli:kimi-for-coding" ]
     (List.map Provider_tool_support.provider_debug_label filtered)
 
+let test_keeper_internal_tools_force_materialized_runtime_surface () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_pr_review_comment" ] in
+  let require_tool_support =
+    Masc_mcp.Oas_worker_named.keeper_internal_tools_require_materialized_runtime_surface
+      ~keeper_name:"issue_king" tools
+  in
+  Alcotest.(check bool)
+    "keeper PR-review tools require a materialized runtime surface"
+    true require_tool_support;
+  let runtime_mcp_policy =
+    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+      ~keeper_name:"issue_king" tools
+  in
+  let filtered =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"issue_king"
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support:false
+      ~require_tool_support
+      ~label:"tier_fast"
+      [
+        make_gemini_cli_provider_cfg ~model_id:"gemini-3-flash-preview" ();
+        make_glm_provider_cfg ~model_id:"glm-5-turbo" ();
+      ]
+  in
+  Alcotest.(check (list string))
+    "text-only CLI path is removed before it can drop keeper PR-review tools"
+    [ "glm:glm-5-turbo" ]
+    (List.map Provider_tool_support.provider_debug_label filtered)
+
 let test_filter_candidate_providers_for_tool_support_secondary_preserves_priority_slot
     () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
@@ -4770,6 +4804,10 @@ let () =
         "provider-normalized filter keeps header-capable keeper-internal lanes"
         `Quick
         test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_for_keeper_internal_tools;
+      Alcotest.test_case
+        "keeper PR-review tools force a materialized runtime surface"
+        `Quick
+        test_keeper_internal_tools_force_materialized_runtime_surface;
       Alcotest.test_case
         "provider-normalized secondary preserves primary priority slot"
         `Quick


### PR DESCRIPTION
## Summary

- Classify keeper PR list/status/create/review tools as `Keeper_internal` so runtime MCP can materialize them for keeper-bound CLI lanes.
- Force `run_named` to require tool support whenever keeper-internal tools are on the active surface, even if the turn itself does not require a tool call.
- Pass the runtime MCP policy into direct model-string filtering so provider filtering sees the actual header/auth requirements.

## Product impact

- User-visible change: keepers on `tier_fast` no longer get a misleading text-only runtime palette for native PR-review tools; incompatible CLI providers are filtered before the model turn.
- Operator impact: `allowed_tool_names` and the active runtime schema now agree for `keeper_pr_review_*`, making PR review evidence collection reliable without temporary cascade overrides.

## Evidence

- Reproduced/root cause: `keeper_pr_review_*` existed in keeper policy but was missing from canonical `Keeper_internal` surface, so runtime MCP classification skipped it.
- `scripts/dune-local.sh build test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe test resume_config 41 --show-errors`
- `scripts/dune-local.sh build test/test_keeper_pr_review.exe`
- `./_build/default/test/test_keeper_pr_review.exe test --show-errors`
- `git diff --check`
- Accidental-test cleanup: an early regression test invoked Gemini CLI and created one unintended PR #13526 comment; that comment was deleted and the test was replaced with a pure provider-filter case.

## GOAL LOOP ACT checklist

- [x] Observe — #13561 records the live `tier_fast` failure where `allowed_tool_names` included PR-review tools but the active palette did not.
- [x] Orient — mapped to the runtime MCP surface/catalog split between `Keeper_tool_policy` and `Tool_catalog_surfaces`.
- [x] Decide — bounded fix keeps the existing PR-review handlers and only repairs provider filtering/materialization.
- [x] Act — code changed in `Tool_catalog_surfaces` and `Oas_worker_named` only, with one focused regression test.
- [x] Verify — focused Dune build and targeted Alcotest cases pass locally.
- [x] Loop — linked issue is #13561; no additional follow-up from this patch.

## Review evidence

- Local self-review: checked the diff after the accidental integration-test side effect and removed the unsafe test path.
- Focused review target: provider filtering and canonical keeper-internal surface membership.

## Linked issue

- Closes #13561

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added/removed.
- [ ] **TypeScript** — N/A: no TypeScript union change.
- [ ] **TLA+ spec** — N/A: no TLA+ domain change.
- [ ] **Event / JSON schema** — N/A: no event type or JSON schema enum change.
- [ ] **`make check-variants` passes** — N/A: no variant/schema enum change in this PR.
