### PR TITLE
fix(dashboard): expose sync conflict summary state

### DIFF
--- a/dashboard/src/components/common/sync-conflict.a11y.test.ts
+++ b/dashboard/src/components/common/sync-conflict.a11y.test.ts
@@ -66,6 +66,10 @@ describe('SyncConflict a11y', () => {
     const region = container.querySelector('[role="region"]') as HTMLElement
     expect(region).not.toBeNull()
     expect(region.getAttribute('aria-describedby')).toMatch(/sync-conflict-summary/)
+    const summary = document.getElementById(region.getAttribute('aria-describedby') ?? '')
+    expect(summary?.getAttribute('aria-label')).toBeNull()
+    expect(summary?.textContent).toContain('전체')
+    expect(summary?.textContent).toContain('남음')
     expect(region.dataset.syncConflictStatus).toBe('partial')
     expect(region.dataset.syncConflictActionRequired).toBe('true')
   })

--- a/dashboard/src/components/common/sync-conflict.a11y.test.ts
+++ b/dashboard/src/components/common/sync-conflict.a11y.test.ts
@@ -52,6 +52,7 @@ describe('SyncConflict a11y', () => {
     expect(container.textContent).toContain('config.timeout')
     expect(container.textContent).toContain('로컬')
     expect(container.textContent).toContain('원격')
+    expect(container.textContent).toContain('남음')
   })
 
   it('has region role', () => {
@@ -62,7 +63,25 @@ describe('SyncConflict a11y', () => {
       />`,
       container,
     )
-    expect(container.querySelector('[role="region"]')).not.toBeNull()
+    const region = container.querySelector('[role="region"]') as HTMLElement
+    expect(region).not.toBeNull()
+    expect(region.getAttribute('aria-describedby')).toMatch(/sync-conflict-summary/)
+    expect(region.dataset.syncConflictStatus).toBe('partial')
+    expect(region.dataset.syncConflictActionRequired).toBe('true')
+  })
+
+  it('labels row resolution state for assistive review', () => {
+    render(
+      html`<${SyncConflict}
+        conflicts=${makeConflicts()}
+        onResolve=${() => {}}
+      />`,
+      container,
+    )
+    const resolved = container.querySelector('[data-sync-conflict-field="config.timeout"]')
+    const unresolved = container.querySelector('[data-sync-conflict-field="config.retry"]')
+    expect(resolved?.getAttribute('aria-label')).toContain('해결됨')
+    expect(unresolved?.getAttribute('aria-label')).toContain('미해결')
   })
 
   it('has merge apply button', () => {
@@ -75,5 +94,16 @@ describe('SyncConflict a11y', () => {
     )
     const btn = container.querySelector('button[aria-label="병합 적용"]')
     expect(btn).not.toBeNull()
+  })
+
+  it('announces empty conflicts as a status', () => {
+    render(
+      html`<${SyncConflict} conflicts=${[]} onResolve=${() => {}} />`,
+      container,
+    )
+    const status = container.querySelector('[role="status"]')
+    const btn = container.querySelector('button[aria-label="병합 적용"]') as HTMLButtonElement
+    expect(status?.textContent).toContain('충돌 없음')
+    expect(btn.disabled).toBe(true)
   })
 })

--- a/dashboard/src/components/common/sync-conflict.test.ts
+++ b/dashboard/src/components/common/sync-conflict.test.ts
@@ -131,7 +131,15 @@ describe('SyncConflict', () => {
     expect(summary.actionRequired).toBe(false)
     expect(summary.resolvedFields).toEqual(['name', 'age'])
     expect(summary.unresolvedFields).toEqual([])
-    expect(isConflictResolved(conflicts[0]!, { name: '' })).toBe(true)
+    expect(isConflictResolved(conflicts[0]!, { name: '' })).toBe(false)
+    expect(isConflictResolved(conflicts[0]!, { name: '   ' })).toBe(false)
     expect(getConflictResolutionState(conflicts[0]!)).toBe('unresolved')
+  })
+
+  it('keeps empty merged values unresolved', () => {
+    const emptyMerged = [{ field: 'name', localValue: 'Alice', remoteValue: 'Bob', mergedValue: '' }]
+
+    expect(summarizeSyncConflicts(emptyMerged).status).toBe('open')
+    expect(isConflictResolved(emptyMerged[0]!)).toBe(false)
   })
 })

--- a/dashboard/src/components/common/sync-conflict.test.ts
+++ b/dashboard/src/components/common/sync-conflict.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { SyncConflict } from './sync-conflict'
+import {
+  getConflictResolutionState,
+  isConflictResolved,
+  summarizeSyncConflicts,
+  SyncConflict,
+} from './sync-conflict'
 
 describe('SyncConflict', () => {
   const conflicts = [
@@ -30,6 +35,35 @@ describe('SyncConflict', () => {
     const container = document.createElement('div')
     render(h(SyncConflict, { conflicts, onResolve: () => {} }), container)
     expect(container.textContent).toContain('동기화 충돌 (1/2)')
+    expect(container.textContent).toContain('전체')
+    expect(container.textContent).toContain('해결')
+    expect(container.textContent).toContain('남음')
+  })
+
+  it('exposes conflict summary metadata', () => {
+    const container = document.createElement('div')
+    render(h(SyncConflict, { conflicts, onResolve: () => {}, testId: 'sc-1' }), container)
+    const root = container.querySelector('[data-sync-conflict]') as HTMLElement
+
+    expect(root.dataset.syncConflictCount).toBe('2')
+    expect(root.dataset.syncConflictResolvedCount).toBe('1')
+    expect(root.dataset.syncConflictUnresolvedCount).toBe('1')
+    expect(root.dataset.syncConflictStatus).toBe('partial')
+    expect(root.dataset.syncConflictActionRequired).toBe('true')
+  })
+
+  it('marks each row with resolution state and diff side metadata', () => {
+    const container = document.createElement('div')
+    render(h(SyncConflict, { conflicts, onResolve: () => {} }), container)
+    const nameRow = container.querySelector('[data-sync-conflict-field="name"]') as HTMLElement
+    const ageRow = container.querySelector('[data-sync-conflict-field="age"]') as HTMLElement
+
+    expect(nameRow.dataset.syncConflictResolutionState).toBe('unresolved')
+    expect(nameRow.getAttribute('aria-label')).toContain('미해결')
+    expect(ageRow.dataset.syncConflictResolutionState).toBe('resolved')
+    expect(ageRow.getAttribute('aria-label')).toContain('해결됨')
+    expect(container.querySelectorAll('[data-sync-conflict-side="local"]').length).toBe(2)
+    expect(container.querySelectorAll('[data-sync-conflict-side="remote"]').length).toBe(2)
   })
 
   it('shows local and remote labels', () => {
@@ -55,9 +89,49 @@ describe('SyncConflict', () => {
     expect(onResolve).toHaveBeenCalledOnce()
   })
 
+  it('shows an empty state and disables apply when no conflicts exist', () => {
+    const onResolve = vi.fn()
+    const container = document.createElement('div')
+    render(h(SyncConflict, { conflicts: [], onResolve }), container)
+    const root = container.querySelector('[data-sync-conflict]') as HTMLElement
+    const btn = container.querySelector('button[aria-label="병합 적용"]') as HTMLButtonElement
+
+    expect(root.dataset.syncConflictStatus).toBe('empty')
+    expect(root.dataset.syncConflictActionRequired).toBe('false')
+    expect(container.textContent).toContain('충돌 없음')
+    expect(container.querySelector('[role="list"]')).toBeNull()
+    expect(btn.disabled).toBe(true)
+  })
+
   it('applies testId', () => {
     const container = document.createElement('div')
     render(h(SyncConflict, { conflicts, onResolve: () => {}, testId: 'sc-1' }), container)
     expect(container.querySelector('[data-testid="sc-1"]')).not.toBeNull()
+  })
+
+  it('summarizes conflicts without rendering', () => {
+    const summary = summarizeSyncConflicts(conflicts)
+
+    expect(summary).toEqual({
+      totalCount: 2,
+      resolvedCount: 1,
+      unresolvedCount: 1,
+      status: 'partial',
+      actionRequired: true,
+      fields: ['name', 'age'],
+      resolvedFields: ['age'],
+      unresolvedFields: ['name'],
+    })
+  })
+
+  it('summarizes explicit edits as resolved', () => {
+    const summary = summarizeSyncConflicts(conflicts, { name: 'Alice Bob' })
+
+    expect(summary.status).toBe('resolved')
+    expect(summary.actionRequired).toBe(false)
+    expect(summary.resolvedFields).toEqual(['name', 'age'])
+    expect(summary.unresolvedFields).toEqual([])
+    expect(isConflictResolved(conflicts[0]!, { name: '' })).toBe(true)
+    expect(getConflictResolutionState(conflicts[0]!)).toBe('unresolved')
   })
 })

--- a/dashboard/src/components/common/sync-conflict.ts
+++ b/dashboard/src/components/common/sync-conflict.ts
@@ -4,6 +4,7 @@
 
 import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
+import { useId } from '../../../design-system/headless-preact/use-id'
 import { InlineEdit } from './inline-edit'
 
 export interface ConflictEntry {
@@ -19,11 +20,81 @@ interface SyncConflictProps {
   testId?: string
 }
 
+export type ConflictResolutionState = 'resolved' | 'unresolved'
+
+export type SyncConflictStatus = 'empty' | 'open' | 'partial' | 'resolved'
+
+export interface SyncConflictSummary {
+  totalCount: number
+  resolvedCount: number
+  unresolvedCount: number
+  status: SyncConflictStatus
+  actionRequired: boolean
+  fields: string[]
+  resolvedFields: string[]
+  unresolvedFields: string[]
+}
+
+export function isConflictResolved(
+  conflict: ConflictEntry,
+  resolutions: Record<string, string> = {},
+): boolean {
+  return resolutions[conflict.field] !== undefined || conflict.mergedValue !== undefined
+}
+
+export function getConflictResolutionState(
+  conflict: ConflictEntry,
+  resolutions: Record<string, string> = {},
+): ConflictResolutionState {
+  return isConflictResolved(conflict, resolutions) ? 'resolved' : 'unresolved'
+}
+
+export function summarizeSyncConflicts(
+  conflicts: ConflictEntry[],
+  resolutions: Record<string, string> = {},
+): SyncConflictSummary {
+  const fields = conflicts.map(conflict => conflict.field)
+  const resolvedFields = conflicts
+    .filter(conflict => isConflictResolved(conflict, resolutions))
+    .map(conflict => conflict.field)
+  const unresolvedFields = conflicts
+    .filter(conflict => !isConflictResolved(conflict, resolutions))
+    .map(conflict => conflict.field)
+
+  const totalCount = conflicts.length
+  const resolvedCount = resolvedFields.length
+  const unresolvedCount = unresolvedFields.length
+  const status: SyncConflictStatus =
+    totalCount === 0
+      ? 'empty'
+      : unresolvedCount === 0
+        ? 'resolved'
+        : resolvedCount === 0
+          ? 'open'
+          : 'partial'
+
+  return {
+    totalCount,
+    resolvedCount,
+    unresolvedCount,
+    status,
+    actionRequired: unresolvedCount > 0,
+    fields,
+    resolvedFields,
+    unresolvedFields,
+  }
+}
+
+function resolutionLabel(state: ConflictResolutionState): string {
+  return state === 'resolved' ? '해결됨' : '미해결'
+}
+
 export function SyncConflict({ conflicts, onResolve, testId }: SyncConflictProps) {
   const [resolutions, setResolutions] = useState<Record<string, string>>({})
+  const summaryId = `${useId()}-sync-conflict-summary`
 
-  const resolvedCount = useMemo(
-    () => conflicts.filter(c => resolutions[c.field] !== undefined || c.mergedValue !== undefined).length,
+  const summary = useMemo(
+    () => summarizeSyncConflicts(conflicts, resolutions),
     [conflicts, resolutions],
   )
 
@@ -33,50 +104,105 @@ export function SyncConflict({ conflicts, onResolve, testId }: SyncConflictProps
 
   return html`
     <div
-      class="rounded-[var(--r-1)] border border-[var(--error-10)] bg-[var(--color-bg-surface)] p-3"
+      class="rounded-[var(--r-1)] border border-[var(--bad-20)] bg-[var(--color-bg-surface)] p-3"
       data-sync-conflict
+      data-sync-conflict-count=${summary.totalCount}
+      data-sync-conflict-resolved-count=${summary.resolvedCount}
+      data-sync-conflict-unresolved-count=${summary.unresolvedCount}
+      data-sync-conflict-status=${summary.status}
+      data-sync-conflict-action-required=${String(summary.actionRequired)}
       data-testid=${testId}
       role="region"
       aria-label="동기화 충돌"
+      aria-describedby=${summaryId}
     >
-      <h4 class="mb-2 text-sm font-medium text-[var(--error-10)]">
-        동기화 충돌 (${resolvedCount}/${conflicts.length})
+      <h4 class="mb-2 text-sm font-medium text-[var(--err)]">
+        동기화 충돌 (${summary.resolvedCount}/${summary.totalCount})
       </h4>
-      <div role="list" aria-label="충돌 항목 목록">
-        ${conflicts.map(
-          c => html`
-            <div
-              key=${c.field}
-              class="mb-3 border-b border-[var(--color-border-default)] pb-2 last:mb-0 last:border-b-0 last:pb-0"
-              role="listitem"
-            >
-              <div class="mb-1 font-mono text-3xs text-[var(--color-fg-secondary)]">${c.field}</div>
-              <div class="mb-1 grid grid-cols-2 gap-2">
-                <div class="rounded-[var(--r-1)] bg-[var(--ok-10)]/10 p-2">
-                  <div class="mb-0.5 text-3xs font-medium text-[var(--ok-10)]">로컬</div>
-                  <div class="break-all font-mono text-xs text-[var(--color-fg-primary)]">${c.localValue}</div>
-                </div>
-                <div class="rounded-[var(--r-1)] bg-[var(--error-10)]/10 p-2">
-                  <div class="mb-0.5 text-3xs font-medium text-[var(--error-10)]">원격</div>
-                  <div class="break-all font-mono text-xs text-[var(--color-fg-primary)]">${c.remoteValue}</div>
-                </div>
-              </div>
-              <div class="mt-1 flex items-center gap-2">
-                <span class="text-3xs text-[var(--color-fg-secondary)]">병합:</span>
-                <div class="flex-1">
-                  <${InlineEdit}
-                    value=${resolutions[c.field] ?? c.mergedValue ?? c.localValue}
-                    onSave=${(v: string) => setResolution(c.field, v)}
-                  />
-                </div>
-              </div>
-            </div>
-          `,
-        )}
+      <div
+        id=${summaryId}
+        class="mb-3 grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
+        aria-label="동기화 충돌 요약"
+      >
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">전체</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.totalCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">해결</div>
+          <div class="font-mono text-sm text-[var(--ok)]">${summary.resolvedCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">남음</div>
+          <div class="font-mono text-sm text-[var(--err)]">${summary.unresolvedCount}</div>
+        </div>
       </div>
+      ${summary.totalCount === 0
+        ? html`
+            <div
+              class="rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] px-3 py-2 text-sm text-[var(--color-fg-secondary)]"
+              role="status"
+            >
+              충돌 없음
+            </div>
+          `
+        : html`
+            <div role="list" aria-label="충돌 항목 목록">
+              ${conflicts.map(c => {
+                const resolutionState = getConflictResolutionState(c, resolutions)
+                return html`
+                  <div
+                    key=${c.field}
+                    class="mb-3 border-b border-[var(--color-border-default)] pb-2 last:mb-0 last:border-b-0 last:pb-0"
+                    role="listitem"
+                    aria-label=${`${c.field} 충돌, ${resolutionLabel(resolutionState)}`}
+                    data-sync-conflict-field=${c.field}
+                    data-sync-conflict-resolution-state=${resolutionState}
+                  >
+                    <div class="mb-1 flex items-center justify-between gap-2">
+                      <span class="min-w-0 truncate font-mono text-3xs text-[var(--color-fg-secondary)]">
+                        ${c.field}
+                      </span>
+                      <span
+                        class="shrink-0 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-secondary)]"
+                      >
+                        ${resolutionLabel(resolutionState)}
+                      </span>
+                    </div>
+                    <div class="mb-1 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <div
+                        class="rounded-[var(--r-1)] bg-[var(--ok-10)]/10 p-2"
+                        data-sync-conflict-side="local"
+                      >
+                        <div class="mb-0.5 text-3xs font-medium text-[var(--ok)]">로컬</div>
+                        <div class="break-all font-mono text-xs text-[var(--color-fg-primary)]">${c.localValue}</div>
+                      </div>
+                      <div
+                        class="rounded-[var(--r-1)] bg-[var(--bad-10)] p-2"
+                        data-sync-conflict-side="remote"
+                      >
+                        <div class="mb-0.5 text-3xs font-medium text-[var(--err)]">원격</div>
+                        <div class="break-all font-mono text-xs text-[var(--color-fg-primary)]">${c.remoteValue}</div>
+                      </div>
+                    </div>
+                    <div class="mt-1 flex items-center gap-2" data-sync-conflict-merge-field=${c.field}>
+                      <span class="text-3xs text-[var(--color-fg-secondary)]">병합:</span>
+                      <div class="min-w-0 flex-1">
+                        <${InlineEdit}
+                          value=${resolutions[c.field] ?? c.mergedValue ?? c.localValue}
+                          onSave=${(v: string) => setResolution(c.field, v)}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                `
+              })}
+            </div>
+          `}
       <button
-        class="mt-2 w-full rounded-[var(--r-1)] bg-[var(--color-accent)] py-1.5 text-sm text-white transition-colors hover:bg-[var(--accent-11)]"
+        class="mt-2 w-full rounded-[var(--r-1)] bg-[var(--color-accent)] py-1.5 text-sm text-white transition-colors hover:bg-[var(--accent-11)] disabled:cursor-not-allowed disabled:opacity-50"
         onClick=${() => onResolve(resolutions)}
+        disabled=${summary.totalCount === 0}
         aria-label="병합 적용"
       >
         병합 적용

--- a/dashboard/src/components/common/sync-conflict.ts
+++ b/dashboard/src/components/common/sync-conflict.ts
@@ -39,7 +39,11 @@ export function isConflictResolved(
   conflict: ConflictEntry,
   resolutions: Record<string, string> = {},
 ): boolean {
-  return resolutions[conflict.field] !== undefined || conflict.mergedValue !== undefined
+  const resolvedValue = resolutions[conflict.field]
+  return (
+    (resolvedValue !== undefined && resolvedValue.trim() !== '') ||
+    (conflict.mergedValue !== undefined && conflict.mergedValue.trim() !== '')
+  )
 }
 
 export function getConflictResolutionState(
@@ -122,7 +126,6 @@ export function SyncConflict({ conflicts, onResolve, testId }: SyncConflictProps
       <div
         id=${summaryId}
         class="mb-3 grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
-        aria-label="동기화 충돌 요약"
       >
         <div>
           <div class="text-3xs text-[var(--color-fg-secondary)]">전체</div>


### PR DESCRIPTION
## Summary
- Add pure SyncConflict summary helpers for total/resolved/unresolved counts, status, action-required state, and field buckets.
- Surface root and row data attributes for conflict counts, status, row resolution state, diff sides, and merge fields.
- Add an empty-state status, disable empty apply, wire `aria-describedby`, and replace unreadable/undefined conflict color tokens with existing semantic tokens.
- Expand unit and axe coverage for metadata, row labels, empty state, and helper behavior.

## Why It Matters
Operators and test automation can now inspect whether a conflict panel is empty, open, partial, or resolved without parsing visible copy. Assistive review also gets row-level resolved/unresolved labels, while the visual diff labels no longer depend on low-contrast alpha text tokens or the undefined `--error-10` token.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/sync-conflict.test.ts src/components/common/sync-conflict.a11y.test.ts` — 2 files / 19 tests passed
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` — passed
- `git diff --check origin/main..HEAD` — passed
- `pnpm --dir dashboard run lint` — passed with 3 existing unrelated warnings in `copy-id-button.test.ts`, `virtual-list.ts`, and `fsm-hub.ts`
- `pnpm --dir dashboard run build` — passed with existing Vite dynamic-import/chunk-size warnings
- Browser QA via `agent-browser` at 760x620 and 390x640: mixed + empty states rendered, metadata matched, inline edit updated row state and apply payload, no horizontal overflow, console only Vite debug/reconnect logs. Screenshot captured locally at `/tmp/masc-sync-conflict-summary-0506.png`.

## Review Focus
- Confirm the new helper/status contract matches the expected SyncConflict automation surface.
- Confirm disabling apply for an empty conflict list is acceptable.