### PR TITLE
fix(dashboard): expose version history summary state

### DIFF
--- a/dashboard/src/components/common/version-history.a11y.test.ts
+++ b/dashboard/src/components/common/version-history.a11y.test.ts
@@ -80,6 +80,7 @@ describe('VersionHistory a11y', () => {
       container,
     )
     expect(container.textContent).toContain('현재')
+    expect(container.querySelector('[aria-current="step"]')?.getAttribute('data-version-snapshot-id')).toBe('snap-002-bbb')
   })
 
   it('shows rollback buttons for non-current snapshots when handler provided', () => {
@@ -103,7 +104,12 @@ describe('VersionHistory a11y', () => {
       />`,
       container,
     )
-    expect(container.querySelector('[role="list"]')).not.toBeNull()
+    const list = container.querySelector('[role="list"]')
+    const region = container.querySelector('[data-version-history]') as HTMLElement
+    expect(list).not.toBeNull()
+    expect(list?.getAttribute('aria-label')).toBe('버전 히스토리')
+    expect(region.getAttribute('aria-describedby')).toMatch(/version-history-summary/)
+    expect(region.dataset.versionHistoryStatus).toBe('current')
   })
 
   it('renders change counts', () => {
@@ -117,5 +123,33 @@ describe('VersionHistory a11y', () => {
     expect(container.textContent).toContain('+12')
     expect(container.textContent).toContain('~7')
     expect(container.textContent).toContain('-1')
+  })
+
+  it('exposes row metadata for assistive review', () => {
+    render(
+      html`<${VersionHistory}
+        snapshots=${makeSnapshots()}
+        currentId="snap-002-bbb"
+        onRollback=${() => {}}
+      />`,
+      container,
+    )
+    const first = container.querySelector('[data-version-snapshot-id="snap-001-aaa"]')
+    const current = container.querySelector('[data-version-snapshot-id="snap-002-bbb"]')
+    expect(first?.getAttribute('aria-label')).toContain('이전 버전')
+    expect(first?.getAttribute('data-version-snapshot-added')).toBe('12')
+    expect(current?.getAttribute('aria-label')).toContain('현재 버전')
+    expect(current?.getAttribute('data-version-snapshot-state')).toBe('current')
+  })
+
+  it('announces the empty state', () => {
+    render(
+      html`<${VersionHistory} snapshots=${[]} currentId="" />`,
+      container,
+    )
+    const root = container.querySelector('[data-version-history]') as HTMLElement
+    const status = container.querySelector('[role="status"]')
+    expect(root.dataset.versionHistoryStatus).toBe('empty')
+    expect(status?.textContent).toContain('스냅샷 없음')
   })
 })

--- a/dashboard/src/components/common/version-history.test.ts
+++ b/dashboard/src/components/common/version-history.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { VersionHistory } from './version-history'
+import {
+  getVersionSnapshotState,
+  shortSnapshotId,
+  summarizeVersionHistory,
+  VersionHistory,
+} from './version-history'
 
 describe('VersionHistory', () => {
   const snapshots = [
@@ -50,6 +55,38 @@ describe('VersionHistory', () => {
     expect(buttons[0]?.textContent).toContain('이 상태로 롤백')
   })
 
+  it('exposes version history summary metadata', () => {
+    const container = document.createElement('div')
+    render(h(VersionHistory, { snapshots, currentId: 'snap-a', onRollback: () => {}, testId: 'vh-1' }), container)
+    const root = container.querySelector('[data-version-history]') as HTMLElement
+
+    expect(root.dataset.versionHistoryCount).toBe('2')
+    expect(root.dataset.versionHistoryCurrentId).toBe('snap-a')
+    expect(root.dataset.versionHistoryCurrentIndex).toBe('0')
+    expect(root.dataset.versionHistoryStatus).toBe('current')
+    expect(root.dataset.versionHistoryRollbackCount).toBe('1')
+    expect(root.dataset.versionHistoryAdded).toBe('2')
+    expect(root.dataset.versionHistoryModified).toBe('4')
+    expect(root.dataset.versionHistoryDeleted).toBe('1')
+    expect(root.getAttribute('aria-describedby')).toMatch(/version-history-summary/)
+  })
+
+  it('marks snapshot rows with current state and change metadata', () => {
+    const container = document.createElement('div')
+    render(h(VersionHistory, { snapshots, currentId: 'snap-a' }), container)
+    const current = container.querySelector('[data-version-snapshot-id="snap-a"]') as HTMLElement
+    const historical = container.querySelector('[data-version-snapshot-id="snap-b"]') as HTMLElement
+
+    expect(current.dataset.versionSnapshotCurrent).toBe('true')
+    expect(current.dataset.versionSnapshotState).toBe('current')
+    expect(current.getAttribute('aria-current')).toBe('step')
+    expect(current.querySelector('time')?.getAttribute('datetime')).toBeTruthy()
+    expect(historical.dataset.versionSnapshotCurrent).toBe('false')
+    expect(historical.dataset.versionSnapshotState).toBe('historical')
+    expect(historical.getAttribute('aria-current')).toBeNull()
+    expect(historical.dataset.versionSnapshotModified).toBe('3')
+  })
+
   it('calls onRollback on click', async () => {
     const onRollback = vi.fn()
     const container = document.createElement('div')
@@ -77,9 +114,51 @@ describe('VersionHistory', () => {
     expect(list?.getAttribute('aria-label')).toBe('버전 히스토리')
   })
 
+  it('renders an empty state when there are no snapshots', () => {
+    const container = document.createElement('div')
+    render(h(VersionHistory, { snapshots: [], currentId: '' }), container)
+    const root = container.querySelector('[data-version-history]') as HTMLElement
+
+    expect(root.dataset.versionHistoryStatus).toBe('empty')
+    expect(root.dataset.versionHistoryCount).toBe('0')
+    expect(container.textContent).toContain('스냅샷 없음')
+    expect(container.querySelector('[role="status"]')).not.toBeNull()
+    expect(container.querySelector('[role="list"]')).toBeNull()
+  })
+
   it('applies testId', () => {
     const container = document.createElement('div')
     render(h(VersionHistory, { snapshots, currentId: 'snap-a', testId: 'vh-1' }), container)
     expect(container.querySelector('[data-testid="vh-1"]')).not.toBeNull()
+  })
+
+  it('summarizes version history without rendering', () => {
+    const summary = summarizeVersionHistory(snapshots, 'snap-a', true)
+
+    expect(summary.totalCount).toBe(2)
+    expect(summary.currentId).toBe('snap-a')
+    expect(summary.currentIndex).toBe(0)
+    expect(summary.currentShortId).toBe('snap-a')
+    expect(summary.status).toBe('current')
+    expect(summary.hasCurrent).toBe(true)
+    expect(summary.rollbackCount).toBe(1)
+    expect(summary.totalAdded).toBe(2)
+    expect(summary.totalModified).toBe(4)
+    expect(summary.totalDeleted).toBe(1)
+    expect(summary.newestTimestamp!).toBeGreaterThanOrEqual(summary.oldestTimestamp!)
+    expect(shortSnapshotId('abcdef12345')).toBe('abcdef1')
+    expect(shortSnapshotId('snap-001-alpha', ['snap-001-alpha', 'snap-002-beta'])).toBe('snap-001')
+    expect(getVersionSnapshotState(snapshots[0]!, 'snap-a')).toBe('current')
+    expect(getVersionSnapshotState(snapshots[1]!, 'snap-a')).toBe('historical')
+  })
+
+  it('summarizes a missing current id', () => {
+    const summary = summarizeVersionHistory(snapshots, 'missing')
+
+    expect(summary.status).toBe('missing-current')
+    expect(summary.hasCurrent).toBe(false)
+    expect(summary.currentIndex).toBe(-1)
+    expect(summary.currentShortId).toBeNull()
+    expect(summary.rollbackCount).toBe(0)
   })
 })

--- a/dashboard/src/components/common/version-history.ts
+++ b/dashboard/src/components/common/version-history.ts
@@ -3,6 +3,8 @@
 // Kimi design system sec03 reference: 3.2.3 git-log-style snapshot timeline.
 
 import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+import { useId } from '../../../design-system/headless-preact/use-id'
 
 export interface VersionSnapshot {
   id: string
@@ -19,6 +21,77 @@ interface VersionHistoryProps {
   testId?: string
 }
 
+export type VersionSnapshotState = 'current' | 'historical'
+
+export type VersionHistoryStatus = 'empty' | 'current' | 'missing-current'
+
+export interface VersionHistorySummary {
+  totalCount: number
+  currentId: string
+  currentIndex: number
+  currentShortId: string | null
+  status: VersionHistoryStatus
+  hasCurrent: boolean
+  rollbackCount: number
+  totalAdded: number
+  totalModified: number
+  totalDeleted: number
+  newestTimestamp: number | null
+  oldestTimestamp: number | null
+}
+
+export function shortSnapshotId(id: string, snapshots: Array<VersionSnapshot | string> = []): string {
+  const minLength = Math.min(7, id.length)
+  if (snapshots.length === 0) {
+    return id.slice(0, minLength)
+  }
+
+  const ids = snapshots.map(snapshot => typeof snapshot === 'string' ? snapshot : snapshot.id)
+  for (let length = minLength; length <= id.length; length += 1) {
+    const prefix = id.slice(0, length)
+    if (ids.filter(candidate => candidate.startsWith(prefix)).length === 1) {
+      return prefix
+    }
+  }
+
+  return id
+}
+
+export function getVersionSnapshotState(
+  snapshot: VersionSnapshot,
+  currentId: string,
+): VersionSnapshotState {
+  return snapshot.id === currentId ? 'current' : 'historical'
+}
+
+export function summarizeVersionHistory(
+  snapshots: VersionSnapshot[],
+  currentId: string,
+  rollbackEnabled = false,
+): VersionHistorySummary {
+  const currentIndex = snapshots.findIndex(snapshot => snapshot.id === currentId)
+  const hasCurrent = currentIndex >= 0
+  const timestamps = snapshots.map(snapshot => snapshot.timestamp)
+  const totalAdded = snapshots.reduce((sum, snapshot) => sum + snapshot.changes.added, 0)
+  const totalModified = snapshots.reduce((sum, snapshot) => sum + snapshot.changes.modified, 0)
+  const totalDeleted = snapshots.reduce((sum, snapshot) => sum + snapshot.changes.deleted, 0)
+
+  return {
+    totalCount: snapshots.length,
+    currentId,
+    currentIndex,
+    currentShortId: hasCurrent ? shortSnapshotId(currentId, snapshots) : null,
+    status: snapshots.length === 0 ? 'empty' : hasCurrent ? 'current' : 'missing-current',
+    hasCurrent,
+    rollbackCount: rollbackEnabled ? snapshots.filter(snapshot => snapshot.id !== currentId).length : 0,
+    totalAdded,
+    totalModified,
+    totalDeleted,
+    newestTimestamp: timestamps.length > 0 ? Math.max(...timestamps) : null,
+    oldestTimestamp: timestamps.length > 0 ? Math.min(...timestamps) : null,
+  }
+}
+
 function formatRelativeTime(ts: number): string {
   const diff = Date.now() - ts
   const sec = Math.floor(diff / 1000)
@@ -31,77 +104,143 @@ function formatRelativeTime(ts: number): string {
   return `${day}일 전`
 }
 
+function snapshotAriaLabel(snapshot: VersionSnapshot, state: VersionSnapshotState): string {
+  const stateLabel = state === 'current' ? '현재 버전' : '이전 버전'
+  return `${snapshot.id} ${snapshot.message}, ${stateLabel}, 변경 +${snapshot.changes.added} ~${snapshot.changes.modified} -${snapshot.changes.deleted}`
+}
+
 export function VersionHistory({
   snapshots,
   currentId,
   onRollback,
   testId,
 }: VersionHistoryProps) {
+  const summaryId = `${useId()}-version-history-summary`
+  const summary = useMemo(
+    () => summarizeVersionHistory(snapshots, currentId, Boolean(onRollback)),
+    [snapshots, currentId, onRollback],
+  )
+
   return html`
     <div
-      class="space-y-0"
+      class="space-y-3"
       data-version-history
+      data-version-history-count=${summary.totalCount}
+      data-version-history-current-id=${summary.currentId}
+      data-version-history-current-index=${summary.currentIndex}
+      data-version-history-status=${summary.status}
+      data-version-history-rollback-count=${summary.rollbackCount}
+      data-version-history-added=${summary.totalAdded}
+      data-version-history-modified=${summary.totalModified}
+      data-version-history-deleted=${summary.totalDeleted}
       data-testid=${testId}
-      role="list"
+      role="region"
       aria-label="버전 히스토리"
+      aria-describedby=${summaryId}
     >
-      ${snapshots.map(
-        snap => {
-          const isCurrent = snap.id === currentId
-          const borderColor = isCurrent ? 'var(--color-accent)' : 'var(--color-border-default)'
-          const dotColor = isCurrent ? 'var(--color-accent)' : 'var(--color-border-default)'
-          return html`
+      <div
+        id=${summaryId}
+        class="grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
+        aria-label="버전 히스토리 요약"
+      >
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">스냅샷</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.totalCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">현재</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.currentShortId ?? '없음'}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">변경</div>
+          <div class="font-mono text-sm">
+            <span class="text-[var(--ok)]">+${summary.totalAdded}</span>
+            <span class="ml-1 text-[var(--warn)]">~${summary.totalModified}</span>
+            <span class="ml-1 text-[var(--err)]">-${summary.totalDeleted}</span>
+          </div>
+        </div>
+      </div>
+      ${summary.totalCount === 0
+        ? html`
             <div
-              key=${snap.id}
-              class="relative flex items-start gap-3 border-l-2 py-2 pl-4"
-              style=${{ borderColor }}
-              role="listitem"
+              class="rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] px-3 py-2 text-sm text-[var(--color-fg-secondary)]"
+              role="status"
             >
-              <span
-                class="absolute -left-[5px] top-3 h-2 w-2 rounded-full"
-                style=${{ background: dotColor }}
-                aria-hidden="true"
-              >
-              </span>
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 flex-wrap">
-                  <span class="font-mono text-3xs text-[var(--color-fg-secondary)]"
-                    >${snap.id.slice(0, 7)}</span
-                  >
-                  <span class="text-sm text-[var(--color-fg-primary)]"
-                    >${snap.message}</span
-                  >
-                  ${isCurrent
-                    ? html`
-                        <span
-                          class="rounded-[var(--r-1)] bg-[var(--color-accent)] px-1.5 text-3xs text-white"
-                          >현재</span
-                        >
-                      `
-                    : null}
-                </div>
-                <div class="mt-0.5 text-3xs text-[var(--color-fg-secondary)]">
-                  ${snap.author} · ${formatRelativeTime(snap.timestamp)}
-                  <span class="ml-2 text-[var(--ok-10)]">+${snap.changes.added}</span>
-                  <span class="ml-1 text-[var(--warn-10)]">~${snap.changes.modified}</span>
-                  <span class="ml-1 text-[var(--error-10)]">-${snap.changes.deleted}</span>
-                </div>
-              </div>
-              ${!isCurrent && onRollback
-                ? html`
-                    <button
-                      class="text-3xs text-[var(--color-accent)] opacity-0 transition-opacity hover:underline focus:opacity-100 group-hover:opacity-100"
-                      onClick=${() => onRollback(snap.id)}
-                      aria-label="${snap.id.slice(0, 7)} 상태로 롤백"
-                    >
-                      이 상태로 롤백
-                    </button>
-                  `
-                : null}
+              스냅샷 없음
             </div>
           `
-        },
-      )}
+        : html`
+            <div class="space-y-0" role="list" aria-label="버전 히스토리">
+              ${snapshots.map((snap, index) => {
+                const state = getVersionSnapshotState(snap, currentId)
+                const isCurrent = state === 'current'
+                const borderColor = isCurrent ? 'var(--color-accent)' : 'var(--color-border-default)'
+                const dotColor = isCurrent ? 'var(--color-accent)' : 'var(--color-border-default)'
+                const timestampIso = new Date(snap.timestamp).toISOString()
+                return html`
+                  <div
+                    key=${snap.id}
+                    class="group relative flex items-start gap-3 border-l-2 py-2 pl-4"
+                    style=${{ borderColor }}
+                    role="listitem"
+                    aria-current=${isCurrent ? 'step' : undefined}
+                    aria-label=${snapshotAriaLabel(snap, state)}
+                    data-version-snapshot-id=${snap.id}
+                    data-version-snapshot-index=${index}
+                    data-version-snapshot-state=${state}
+                    data-version-snapshot-current=${String(isCurrent)}
+                    data-version-snapshot-added=${snap.changes.added}
+                    data-version-snapshot-modified=${snap.changes.modified}
+                    data-version-snapshot-deleted=${snap.changes.deleted}
+                    data-version-snapshot-timestamp=${snap.timestamp}
+                  >
+                    <span
+                      class="absolute -left-[5px] top-3 h-2 w-2 rounded-full"
+                      style=${{ background: dotColor }}
+                      aria-hidden="true"
+                    >
+                    </span>
+                    <div class="min-w-0 flex-1">
+                      <div class="flex flex-wrap items-center gap-2">
+                        <span class="font-mono text-3xs text-[var(--color-fg-secondary)]"
+                          >${shortSnapshotId(snap.id, snapshots)}</span
+                        >
+                        <span class="min-w-0 text-sm text-[var(--color-fg-primary)]"
+                          >${snap.message}</span
+                        >
+                        ${isCurrent
+                          ? html`
+                              <span
+                                class="rounded-[var(--r-1)] bg-[var(--color-accent)] px-1.5 text-3xs text-white"
+                                >현재</span
+                              >
+                            `
+                          : null}
+                      </div>
+                      <div class="mt-0.5 text-3xs text-[var(--color-fg-secondary)]">
+                        ${snap.author} ·
+                        <time datetime=${timestampIso}>${formatRelativeTime(snap.timestamp)}</time>
+                        <span class="ml-2 text-[var(--ok)]">+${snap.changes.added}</span>
+                        <span class="ml-1 text-[var(--warn)]">~${snap.changes.modified}</span>
+                        <span class="ml-1 text-[var(--err)]">-${snap.changes.deleted}</span>
+                      </div>
+                    </div>
+                    ${!isCurrent && onRollback
+                      ? html`
+                          <button
+                            class="shrink-0 rounded-[var(--r-1)] px-2 py-1 text-3xs text-[var(--color-accent)] opacity-100 transition-colors hover:bg-[var(--color-bg-hover)] hover:underline focus:bg-[var(--color-bg-hover)] sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100"
+                            onClick=${() => onRollback(snap.id)}
+                            aria-label="${snap.id} 상태로 롤백"
+                          >
+                            이 상태로 롤백
+                          </button>
+                        `
+                      : null}
+                  </div>
+                `
+              })}
+            </div>
+          `}
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- Add pure VersionHistory helpers for summary state, snapshot state, and git-style short-id display with prefix disambiguation.
- Surface root metadata for total snapshots, current index/status, rollback count, and aggregate change counts.
- Add row metadata, `aria-current="step"`, full-id assistive labels, `<time datetime>`, and a visible empty state.
- Replace alpha/undefined change-count text tokens with semantic solid tokens and make rollback actions reachable on mobile while preserving hover reveal on wider viewports.
- Expand unit and axe coverage for summary metadata, row state, empty state, helper behavior, and assistive labels.

## Why It Matters
Operators and tests can now identify whether a history panel is empty, has a current snapshot, or is missing the configured current id without parsing visible text. The snapshot rows expose enough metadata for automation and assistive review, and visible short ids now disambiguate common prefixes instead of producing repeated labels like `snap-00`.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/version-history.test.ts src/components/common/version-history.a11y.test.ts` — 2 files / 22 tests passed
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` — passed
- `git diff --check origin/main..HEAD` — passed
- `pnpm --dir dashboard run lint` — passed with 3 existing unrelated warnings in `copy-id-button.test.ts`, `virtual-list.ts`, and `fsm-hub.ts`
- `pnpm --dir dashboard run build` — passed with existing Vite dynamic-import/chunk-size warnings
- Browser QA via `agent-browser` at 800x640 and 390x640: populated, missing-current, and empty states rendered; metadata matched; rollback emitted the expected full id; no horizontal overflow; console only Vite debug/reconnect logs. Screenshot captured locally at `/tmp/masc-version-history-summary-0506.png`.

## Review Focus
- Confirm the `empty | current | missing-current` status contract is the right surface for downstream automation.
- Confirm short-id disambiguation is acceptable for non-hash snapshot ids.