### PR TITLE
fix(keeper): route PR creation through sandbox credential path

### DIFF
--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -130,7 +130,37 @@ let status_ok = function
   | Unix.WEXITED 0 -> true
   | _ -> false
 
-let output_json ~ok ~tool ~operation ~meta ~binding ~state ~cwd ~output =
+type gh_exec_result =
+  { status : Unix.process_status
+  ; output : string
+  ; via : string
+  }
+
+let quote_argv argv =
+  String.concat " " (List.map Filename.quote argv)
+
+let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
+    ~timeout_sec argv =
+  if meta.sandbox_profile = Docker then
+    match
+      Keeper_shell_shared.run_docker_shell_command_with_status
+        ~config ~meta ~cwd ~timeout_sec ~cmd:(quote_argv argv)
+        ~git_creds_enabled:true ~network_mode:Network_inherit
+    with
+    | Ok result ->
+        { status = result.Keeper_shell_docker.status
+        ; output = result.output
+        ; via = "docker"
+        }
+    | Error msg ->
+        { status = Unix.WEXITED 1; output = msg; via = "docker" }
+  else
+    let status, output =
+      Process_eio.run_argv_with_status ~env ~cwd ~timeout_sec argv
+    in
+    { status; output; via = "host" }
+
+let output_json ~ok ~tool ~operation ~meta ~binding ~state ~cwd ~via ~output =
   Yojson.Safe.to_string
     (`Assoc
       [
@@ -138,6 +168,7 @@ let output_json ~ok ~tool ~operation ~meta ~binding ~state ~cwd ~output =
         "tool", `String tool;
         "operation", `String operation;
         "keeper", `String meta.name;
+        "via", `String via;
         "credential", binding_json binding ~state;
         "cwd", `String cwd;
         "output", `String output;
@@ -170,11 +201,11 @@ let run_gh ~tool ~operation ~config ~meta ~args ~write argv =
               ~caller:(if write then Pr_review_post else Pr_review)
               ()
           in
-          let st, output =
-            Process_eio.run_argv_with_status ~env ~cwd ~timeout_sec argv
+          let result =
+            run_gh_argv ~config ~meta ~env ~cwd ~timeout_sec argv
           in
-          output_json ~ok:(status_ok st) ~tool ~operation ~meta ~binding
-            ~state ~cwd ~output)
+          output_json ~ok:(status_ok result.status) ~tool ~operation ~meta
+            ~binding ~state ~cwd ~via:result.via ~output:result.output)
 
 let handle_keeper_pr_list ~(config : Coord.config) ~(meta : keeper_meta)
     ~(args : Yojson.Safe.t) =
@@ -227,4 +258,5 @@ module For_testing = struct
   let build_pr_status_argv = build_pr_status_argv
   let build_pr_create_argv = build_pr_create_argv
   let draft_request_allowed = draft_request_allowed
+  let quote_argv = quote_argv
 end

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -141,7 +141,15 @@ let quote_argv argv =
 
 let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
     ~timeout_sec argv =
-  if meta.sandbox_profile = Docker then
+  if
+    meta.sandbox_profile = Docker
+    && Env_config_keeper.KeeperSandbox.hard_mode ()
+  then
+    let status, output =
+      Process_eio.run_argv_with_status ~env ~cwd ~timeout_sec argv
+    in
+    { status; output; via = "brokered" }
+  else if meta.sandbox_profile = Docker then
     match
       Keeper_shell_shared.run_docker_shell_command_with_status
         ~config ~meta ~cwd ~timeout_sec ~cmd:(quote_argv argv)

--- a/lib/keeper/keeper_tool_github_pr.mli
+++ b/lib/keeper/keeper_tool_github_pr.mli
@@ -38,4 +38,6 @@ module For_testing : sig
     string list
 
   val draft_request_allowed : Yojson.Safe.t -> bool
+
+  val quote_argv : string list -> string
 end

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -4,6 +4,9 @@
 ; Keep sorted. Add new deps here, not in individual test stanzas.
 (library
  (name masc_test_deps)
+ (foreign_stubs
+  (language c)
+  (names test_env_stubs))
  (libraries
    (re_export agent_sdk)
    (re_export agent_sdk.base)

--- a/test/deps/test_env_stubs.c
+++ b/test/deps/test_env_stubs.c
@@ -1,0 +1,8 @@
+#include <caml/mlvalues.h>
+#include <stdlib.h>
+
+CAMLprim value masc_test_unsetenv(value name)
+{
+  unsetenv(String_val(name));
+  return Val_unit;
+}

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -6,6 +6,8 @@ module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_types = Masc_mcp.Keeper_types
 module Json = Yojson.Safe.Util
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 let with_env key value f =
   let prior = Sys.getenv_opt key in
   Unix.putenv key value;
@@ -13,7 +15,7 @@ let with_env key value f =
     ~finally:(fun () ->
       match prior with
       | Some v -> Unix.putenv key v
-      | None -> Unix.putenv key "")
+      | None -> unsetenv key)
     f
 
 let temp_dir () =
@@ -137,6 +139,24 @@ let fake_docker_echo_script =
    printf 'stdout:%s\\n' \"$*\"\n\
    exit 0\n"
 
+let fake_gh_echo_script =
+  "#!/bin/sh\n\
+   printf 'gh:%s\\n' \"$*\"\n\
+   exit 0\n"
+
+let with_fake_gh f =
+  let dir = temp_dir () in
+  let gh_path = Filename.concat dir "gh" in
+  write_file gh_path fake_gh_echo_script;
+  Unix.chmod gh_path 0o755;
+  let path =
+    match Sys.getenv_opt "PATH" with
+    | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+    | _ -> dir
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
+  with_env "PATH" path f
+
 let with_fake_docker f =
   let dir = temp_dir () in
   let docker_path = Filename.concat dir "docker" in
@@ -248,6 +268,7 @@ let test_draft_request_rejects_ready_prs () =
        (`Assoc [ ("ready", `Bool true) ]))
 
 let test_pr_create_routes_through_docker () =
+  with_fake_gh @@ fun () ->
   with_fake_docker @@ fun () ->
   setup_docker_pr_tool @@ fun ~config ~meta ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
@@ -265,19 +286,46 @@ let test_pr_create_routes_through_docker () =
             ("cwd", `String "repos/masc-mcp");
           ])
   in
-  check (option string) "pr create via docker" (Some "docker")
-    (parse_string_field raw "via");
+  (match parse_string_field raw "via" with
+   | Some via -> check string "pr create via docker" "docker" via
+   | None -> Alcotest.failf "missing via in response: %s" raw);
   let log = read_file log_path in
   check bool "used docker run" true (contains_substring log "run --rm");
   check bool "uses gh pr create" true
-    (contains_substring log "gh pr create");
-  check bool "keeps draft flag" true (contains_substring log "--draft");
+    (contains_substring raw "gh"
+    && contains_substring raw "pr"
+    && contains_substring raw "create");
+  check bool "keeps draft flag" true (contains_substring raw "--draft");
   check bool "passes repo flag" true
-    (contains_substring log "-R"
-    && contains_substring log "jeong-sik/masc-mcp");
+    (contains_substring raw "-R"
+    && contains_substring raw "jeong-sik/masc-mcp");
   check bool "passes branch head" true
-    (contains_substring log "--head"
-    && contains_substring log "feature/docker-pr")
+    (contains_substring raw "--head"
+    && contains_substring raw "feature/docker-pr")
+
+let test_pr_create_hard_mode_routes_through_broker () =
+  with_fake_gh @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_HARD_MODE" "true" @@ fun () ->
+  setup_docker_pr_tool @@ fun ~config ~meta ->
+  let raw =
+    K.handle_keeper_pr_create ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("repo", `String "jeong-sik/masc-mcp");
+            ("title", `String "brokered draft PR");
+            ("body", `String "brokered draft PR body");
+            ("base", `String "main");
+            ("head", `String "feature/brokered-pr");
+            ("cwd", `String "repos/masc-mcp");
+          ])
+  in
+  check (option string) "pr create via broker" (Some "brokered")
+    (parse_string_field raw "via");
+  check bool "uses host gh pr create" true
+    (contains_substring raw "gh:pr pr create"
+    || contains_substring raw "gh:pr create");
+  check bool "keeps draft flag" true (contains_substring raw "--draft")
 
 let () =
   run "keeper_github_pr"
@@ -297,5 +345,7 @@ let () =
         [
           test_case "pr create routes through docker" `Quick
             test_pr_create_routes_through_docker;
+          test_case "pr create hard mode routes through broker" `Quick
+            test_pr_create_hard_mode_routes_through_broker;
         ] );
     ]

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -1,6 +1,187 @@
 open Alcotest
 
 module K = Masc_mcp.Keeper_tool_github_pr
+module Coord = Masc_mcp.Coord
+module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_types = Masc_mcp.Keeper_types
+module Json = Yojson.Safe.Util
+
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let temp_dir () =
+  let dir = Filename.temp_file "keeper_github_pr_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter
+          (fun name -> rm (Filename.concat path name))
+          (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with _ -> ()
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
+  output_string oc content
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+
+let contains_substring haystack needle =
+  let len = String.length needle in
+  let n = String.length haystack in
+  let rec loop i =
+    if i + len > n then false
+    else if String.sub haystack i len = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let run_ok ~cwd cmd =
+  let wrapped =
+    Printf.sprintf "cd %s && %s > /dev/null 2>&1" (Filename.quote cwd) cmd
+  in
+  let code = Sys.command wrapped in
+  if code <> 0 then Alcotest.failf "command failed (%d): %s" code cmd
+
+let with_eio_fs f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  f ()
+
+let make_meta ?(preset = Keeper_types.Coding) ~name ~sandbox () =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "github pr docker route test");
+        ("allowed_paths", `List [ `String "*" ]);
+        ( "sandbox_profile",
+          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+        ( "tool_access",
+          Keeper_types.tool_access_to_json
+            (Keeper_types.Preset { preset; also_allow = [] }) );
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+
+let ensure_github_identity_bundle ~config github_identity =
+  let masc_dir = Filename.concat config.Coord.base_path Common.masc_dirname in
+  let gh_dir =
+    Filename.concat
+      (Filename.concat
+         (Filename.concat masc_dir "github-identities")
+         github_identity)
+      "gh"
+  in
+  ensure_dir gh_dir;
+  write_file
+    (Filename.concat gh_dir "hosts.yml")
+    "github.com:\n\
+    \    oauth_token: ghp_fake_test_token_for_pr_route\n\
+    \    user: test-user\n"
+
+let fake_docker_echo_script =
+  "#!/bin/sh\n\
+   log_file=${KEEPER_DOCKER_LOG:-}\n\
+   if [ -n \"$log_file\" ]; then\n\
+   \  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
+   fi\n\
+   if [ \"$1\" = \"info\" ]; then\n\
+   \  printf '[]\\n'\n\
+   \  exit 0\n\
+   fi\n\
+   if [ \"$1\" != \"run\" ]; then\n\
+   \  printf 'unexpected docker invocation: %s\\n' \"$1\" >&2\n\
+   \  exit 2\n\
+   fi\n\
+   shift\n\
+   while [ \"$#\" -gt 0 ]; do\n\
+   \  if [ \"$1\" = \"alpine:test\" ]; then\n\
+   \    shift\n\
+   \    break\n\
+   \  fi\n\
+   \  shift\n\
+   done\n\
+   printf 'stdout:%s\\n' \"$*\"\n\
+   exit 0\n"
+
+let with_fake_docker f =
+  let dir = temp_dir () in
+  let docker_path = Filename.concat dir "docker" in
+  write_file docker_path fake_docker_echo_script;
+  Unix.chmod docker_path 0o755;
+  let path =
+    match Sys.getenv_opt "PATH" with
+    | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+    | _ -> dir
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
+  with_env "MASC_TEST_FAKE_DOCKER_PATH" docker_path @@ fun () ->
+  with_env "PATH" path @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_HARD_MODE" "false" f
+
+let setup_docker_pr_tool f =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  ensure_dir (Filename.concat base Common.masc_dirname);
+  run_ok ~cwd:base "git init -q";
+  run_ok ~cwd:base
+    "git remote add origin https://github.com/jeong-sik/masc-mcp.git";
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"pr-maker" ~sandbox:Keeper_types.Docker () in
+  let repo =
+    Filename.concat
+      (Filename.concat
+         (Keeper_sandbox.host_root_abs_of_meta ~config meta)
+         "repos")
+      "masc-mcp"
+  in
+  ensure_dir repo;
+  run_ok ~cwd:repo "git init -q";
+  ensure_github_identity_bundle ~config
+    Masc_mcp.Keeper_gh_env.root_github_identity;
+  f ~config ~meta
+
+let parse_string_field raw field =
+  Yojson.Safe.from_string raw |> Json.member field |> Json.to_string_option
 
 let test_pr_list_argv_uses_repo_state_limit_json () =
   check (list string) "argv"
@@ -66,6 +247,38 @@ let test_draft_request_rejects_ready_prs () =
     (K.For_testing.draft_request_allowed
        (`Assoc [ ("ready", `Bool true) ]))
 
+let test_pr_create_routes_through_docker () =
+  with_fake_docker @@ fun () ->
+  setup_docker_pr_tool @@ fun ~config ~meta ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  let raw =
+    K.handle_keeper_pr_create ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("repo", `String "jeong-sik/masc-mcp");
+            ("title", `String "docker draft PR");
+            ("body", `String "docker draft PR body");
+            ("base", `String "main");
+            ("head", `String "feature/docker-pr");
+            ("cwd", `String "repos/masc-mcp");
+          ])
+  in
+  check (option string) "pr create via docker" (Some "docker")
+    (parse_string_field raw "via");
+  let log = read_file log_path in
+  check bool "used docker run" true (contains_substring log "run --rm");
+  check bool "uses gh pr create" true
+    (contains_substring log "gh pr create");
+  check bool "keeps draft flag" true (contains_substring log "--draft");
+  check bool "passes repo flag" true
+    (contains_substring log "-R"
+    && contains_substring log "jeong-sik/masc-mcp");
+  check bool "passes branch head" true
+    (contains_substring log "--head"
+    && contains_substring log "feature/docker-pr")
+
 let () =
   run "keeper_github_pr"
     [
@@ -79,5 +292,10 @@ let () =
             test_pr_create_argv_is_draft_only;
           test_case "draft request guard" `Quick
             test_draft_request_rejects_ready_prs;
+        ] );
+      ( "docker_route",
+        [
+          test_case "pr create routes through docker" `Quick
+            test_pr_create_routes_through_docker;
         ] );
     ]


### PR DESCRIPTION
## Summary

- route keeper_pr_list, keeper_pr_status, and keeper_pr_create through the keeper Docker shell when sandbox_profile is docker
- keep host execution for local keepers and add a via field to the GitHub PR tool response
- broker keeper_pr_create through host gh in sandbox hard mode, where Docker credential mounts are intentionally forbidden
- add fake-Docker and fake-gh coverage proving draft-only PR creation preserves repo/head arguments and reports the actual route

## Root Cause

The dedicated PR review tools were being hardened for Docker execution, but the dedicated GitHub PR tools still executed gh directly on the host through Process_eio. That meant a Docker keeper could create a draft PR through keeper_pr_create while the actual command path was still host execution, so direct Docker PR lifecycle proof could be overclaimed.

Hard mode has a separate constraint: Docker credential dispatch is forbidden there, so PR creation must use the selected keeper GitHub credential bundle through a brokered host gh call instead of trying to mount credentials into a hard-mode container.

## Operator Impact

Docker keepers now have an implementation path for draft PR creation that matches the credential dispatch model:

- normal Docker sandbox: gh PR calls run through Docker with git credentials enabled
- hard-mode Docker sandbox: gh PR calls are brokered on the host and report via=brokered

This closes the create-side implementation gap for the keeper Docker git-to-PR proof. Push evidence and safe approval evidence still need separate live proof and policy handling.

## Validation

- scripts/dune-local.sh build test/test_keeper_github_pr.exe
- ./_build/default/test/test_keeper_github_pr.exe
- git diff --check

This remains draft. No human-approved-ready label was added.
