### PR TITLE
fix(keeper): preserve bash execution durations

### DIFF
--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -67,6 +67,10 @@ val handle_keeper_bash :
   unit ->
   string
 
+module For_testing : sig
+  val elapsed_duration_ms : start_time:float -> end_time:float -> int
+end
+
 val handle_keeper_bash_output :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1,6 +1,18 @@
 open Keeper_types
 open Keeper_exec_shared
 
+let elapsed_duration_ms ~start_time ~end_time =
+  let elapsed_ms = (end_time -. start_time) *. 1000. in
+  match classify_float elapsed_ms with
+  | FP_nan | FP_infinite -> 0
+  | _ when elapsed_ms <= 0. -> 0
+  | _ when elapsed_ms < 1. -> 1
+  | _ -> int_of_float elapsed_ms
+
+module For_testing = struct
+  let elapsed_duration_ms = elapsed_duration_ms
+end
+
 let handle_keeper_bash
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(turn_sandbox_factory_git : Keeper_sandbox_factory.t option)
@@ -524,7 +536,8 @@ let handle_keeper_bash
                              ~cwd ~timeout_sec argv_merged
                          in
                          let elapsed_ms =
-                           int_of_float ((Unix.gettimeofday () -. t0) *. 1000.)
+                           elapsed_duration_ms
+                             ~start_time:t0 ~end_time:(Unix.gettimeofday ())
                          in
                          if not (Keeper_shell_shared.process_status_is_timeout st) then begin
                            let exit_code = match st with
@@ -571,7 +584,8 @@ let handle_keeper_bash
                        ~cwd ~timeout_sec argv_merged
                    in
                    let elapsed_ms =
-                     int_of_float ((Unix.gettimeofday () -. t0) *. 1000.)
+                     elapsed_duration_ms
+                       ~start_time:t0 ~end_time:(Unix.gettimeofday ())
                    in
                    (if auto_bg_observe_enabled then begin
                       let budget_ms =
@@ -620,7 +634,8 @@ let handle_keeper_bash
                    (match outcome with
                     | Masc_exec.Exec_run.Completed r ->
                       let elapsed_ms =
-                        int_of_float ((Unix.gettimeofday () -. t0_bg) *. 1000.)
+                        elapsed_duration_ms
+                          ~start_time:t0_bg ~end_time:(Unix.gettimeofday ())
                       in
                       (* P21: store in exec cache if not a timeout *)
                       if not (Keeper_shell_shared.process_status_is_timeout r.status) then
@@ -649,7 +664,8 @@ let handle_keeper_bash
                            ())
                     | Masc_exec.Exec_run.Promoted p ->
                       let elapsed_ms =
-                        int_of_float ((Unix.gettimeofday () -. t0_bg) *. 1000.)
+                        elapsed_duration_ms
+                          ~start_time:t0_bg ~end_time:(Unix.gettimeofday ())
                       in
                       Log.Keeper.info
                         "BG_PROMOTE: keeper=%s task_id=%s budget_ms=%d cmd=%s"

--- a/lib/keeper/keeper_shell_bash.mli
+++ b/lib/keeper/keeper_shell_bash.mli
@@ -12,3 +12,7 @@ val handle_keeper_bash :
   args:Yojson.Safe.t ->
   unit ->
   string
+
+module For_testing : sig
+  val elapsed_duration_ms : start_time:float -> end_time:float -> int
+end

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -312,6 +312,17 @@ let parse_error_field raw =
   |> Json.member "error"
   |> Json.to_string_option
 
+let test_keeper_bash_elapsed_duration_preserves_positive_sub_ms () =
+  let elapsed = Keeper_exec_shell.For_testing.elapsed_duration_ms in
+  Alcotest.(check int) "sub-ms positive duration rounds up to 1" 1
+    (elapsed ~start_time:10.0 ~end_time:10.0004);
+  Alcotest.(check int) "one ms duration stays one" 1
+    (elapsed ~start_time:10.0 ~end_time:10.001);
+  Alcotest.(check int) "negative clock drift is zero" 0
+    (elapsed ~start_time:10.0 ~end_time:9.999);
+  Alcotest.(check int) "nan duration is zero" 0
+    (elapsed ~start_time:Float.nan ~end_time:10.0)
+
 let test_docker_blocks_nested_docker_command () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -665,6 +676,8 @@ let () =
       Alcotest.test_case "git write classification" `Quick test_git_write_classification;
     ]);
     ("edge", [
+      Alcotest.test_case "elapsed duration preserves positive sub-ms" `Quick
+        test_keeper_bash_elapsed_duration_preserves_positive_sub_ms;
       Alcotest.test_case "empty command blocked" `Quick test_empty_command;
       Alcotest.test_case "docker blocks nested docker command" `Quick
         test_docker_blocks_nested_docker_command;


### PR DESCRIPTION
## Summary

- Add a shared bash-shell elapsed duration helper that preserves positive sub-millisecond timings as `1` ms.
- Apply it to the real keeper bash execution paths, including cached/non-cached local runs and auto-background completion/promotion.
- Cover the helper with a focused bash safety regression test.

## Why

Actual shell executions could report `execution_time_ms = 0` when they completed in less than 1 ms because the previous `int_of_float` conversion truncated positive fractional milliseconds. That collapses real work into the same telemetry bucket as intentionally unexecuted blocked/validation responses.

## Validation

- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_bash_safety.exe`
- `MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-keeper-shell-bash-duration-0506 MASC_BASE_PATH_INPUT=/private/tmp/masc-keeper-shell-bash-duration-0506 ./_build/default/test/test_keeper_bash_safety.exe test edge 0`

Note: the local opam switch was still pinned to `agent_sdk 0.190.12` while current `main` expects `>= 0.190.25`; the shared opam repair lane was blocked by another local Dune job, so the focused build used `MASC_SKIP_PIN_CHECK=1`. CI should validate against the current repo pin.