### PR TITLE
fix(dashboard): surface backlog pressure by priority

### DIFF
--- a/dashboard/src/components/goals/kanban-components.test.ts
+++ b/dashboard/src/components/goals/kanban-components.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/preact'
 import '@testing-library/jest-dom'
-import { TaskBacklog, resetTaskBacklogState } from './kanban-components'
+import { TaskBacklog, buildBacklogPressureRows, resetTaskBacklogState } from './kanban-components'
 import { executionError, executionLoaded, executionLoading, tasks } from '../../store'
 import { resetTaskSearch } from './goal-helpers'
 import type { Task } from '../../types'
@@ -38,12 +38,73 @@ describe('TaskBacklog', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     tasks.value = []
     executionLoaded.value = false
     executionLoading.value = false
     executionError.value = null
     resetTaskSearch()
     resetTaskBacklogState()
+  })
+
+  it('summarizes unclaimed priority pressure by oldest task age', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-06T12:00:00Z'))
+    const criticalTodo: Task = {
+      id: 'task-critical',
+      title: 'Critical task',
+      status: 'todo',
+      priority: 1,
+      description: 'Needs prompt claim.',
+      created_at: '2026-05-06T10:00:00Z',
+    }
+    const newerCriticalTodo: Task = {
+      id: 'task-critical-newer',
+      title: 'Newer critical task',
+      status: 'todo',
+      priority: 1,
+      created_at: '2026-05-06T11:30:00Z',
+    }
+    const claimedCritical: Task = {
+      id: 'task-claimed',
+      title: 'Claimed critical task',
+      status: 'claimed',
+      priority: 1,
+      created_at: '2026-05-06T08:00:00Z',
+    }
+    tasks.value = [criticalTodo, newerCriticalTodo, claimedCritical]
+
+    render(h(TaskBacklog, {}))
+
+    const pressure = screen.getByLabelText('Backlog pressure')
+    const p1 = within(pressure).getByRole('button', { name: 'P1 backlog pressure: 2 unclaimed' })
+    expect(p1).toHaveTextContent('2h')
+    expect(p1).toHaveTextContent('breached 1h')
+    expect(within(pressure).getByRole('button', { name: 'P2 backlog pressure: 0 unclaimed' })).toBeDisabled()
+  })
+
+  it('builds pressure rows without counting claimed tasks', () => {
+    const rows = buildBacklogPressureRows([
+      {
+        id: 'todo-p2',
+        title: 'Todo P2',
+        status: 'todo',
+        priority: 2,
+        created_at: '2026-05-06T00:00:00Z',
+      },
+      {
+        id: 'claimed-p2',
+        title: 'Claimed P2',
+        status: 'claimed',
+        priority: 2,
+        created_at: '2026-05-05T00:00:00Z',
+      },
+    ], Date.parse('2026-05-06T07:00:00Z'))
+
+    const p2 = rows.find(row => row.priority === 2)
+    expect(p2?.count).toBe(1)
+    expect(p2?.tone).toBe('warn')
+    expect(p2?.oldestTask?.id).toBe('todo-p2')
   })
 
   it('preserves expanded done pagination after clearing search', async () => {

--- a/dashboard/src/components/goals/kanban-components.test.ts
+++ b/dashboard/src/components/goals/kanban-components.test.ts
@@ -93,18 +93,50 @@ describe('TaskBacklog', () => {
         created_at: '2026-05-06T00:00:00Z',
       },
       {
-        id: 'claimed-p2',
-        title: 'Claimed P2',
-        status: 'claimed',
+        id: 'assigned-todo-p2',
+        title: 'Assigned todo P2',
+        status: 'todo',
         priority: 2,
+        assignee: 'keeper-alpha',
         created_at: '2026-05-05T00:00:00Z',
+      },
+      {
+        id: 'blank-assignee-p2',
+        title: 'Blank assignee P2',
+        status: 'todo',
+        priority: 2,
+        assignee: ' ',
+        created_at: '2026-05-06T01:00:00Z',
       },
     ], Date.parse('2026-05-06T07:00:00Z'))
 
     const p2 = rows.find(row => row.priority === 2)
-    expect(p2?.count).toBe(1)
+    expect(p2?.count).toBe(2)
     expect(p2?.tone).toBe('warn')
     expect(p2?.oldestTask?.id).toBe('todo-p2')
+  })
+
+  it('normalizes out-of-range priorities into P4 pressure', () => {
+    const rows = buildBacklogPressureRows([
+      {
+        id: 'todo-p0',
+        title: 'Todo P0',
+        status: 'todo',
+        priority: 0,
+        created_at: '2026-05-06T00:00:00Z',
+      },
+      {
+        id: 'todo-p5',
+        title: 'Todo P5',
+        status: 'todo',
+        priority: 5,
+        created_at: '2026-05-06T01:00:00Z',
+      },
+    ], Date.parse('2026-05-06T07:00:00Z'))
+
+    const p4 = rows.find(row => row.priority === 4)
+    expect(p4?.count).toBe(2)
+    expect(p4?.oldestTask?.id).toBe('todo-p0')
   })
 
   it('preserves expanded done pagination after clearing search', async () => {

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -37,6 +37,20 @@ const DECK_PANEL = 'overflow-hidden rounded-[var(--r-0)] border border-[var(--co
 const DECK_HEAD = 'border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2'
 const DECK_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
 const META_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 font-mono text-3xs'
+const BACKLOG_PRESSURE_PRIORITIES = [1, 2, 3, 4] as const
+const BACKLOG_STALE_THRESHOLD_HOURS: Record<number, number | undefined> = {
+  1: 1,
+  2: 6,
+}
+
+export type BacklogPressureRow = {
+  priority: number
+  count: number
+  oldestAgeMs: number | null
+  oldestTask: Task | null
+  staleThresholdHours: number | null
+  tone: 'bad' | 'warn' | 'ok' | 'idle'
+}
 
 export function resetTaskBacklogState() {
   doneVisibleCount.value = DONE_PAGE_SIZE
@@ -50,6 +64,72 @@ function priorityToneClass(priority: number): string {
     case 3: return 'border-[var(--color-info-border)] bg-[var(--color-info-soft)] text-[var(--color-info-fg)]'
     default: return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
   }
+}
+
+function pressureToneClass(row: BacklogPressureRow): string {
+  switch (row.tone) {
+    case 'bad': return 'border-[var(--color-err-border)] bg-[var(--color-err-soft)] text-[var(--color-err-fg)]'
+    case 'warn': return 'border-[var(--color-warn-border)] bg-[var(--color-warn-soft)] text-[var(--color-warn-fg)]'
+    case 'ok': return 'border-[var(--color-info-border)] bg-[var(--color-info-soft)] text-[var(--color-info-fg)]'
+    default: return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]'
+  }
+}
+
+function taskCreatedAtMs(task: Task): number | null {
+  if (!task.created_at) return null
+  const ts = Date.parse(task.created_at)
+  return Number.isFinite(ts) ? ts : null
+}
+
+function formatAgeMs(ageMs: number | null): string {
+  if (ageMs == null) return 'unknown'
+  const minutes = Math.max(0, Math.floor(ageMs / 60_000))
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 48) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  return `${days}d`
+}
+
+export function buildBacklogPressureRows(tasks: Task[], nowMs = Date.now()): BacklogPressureRow[] {
+  const todoTasks = tasks.filter(task => task.status === 'todo')
+  return BACKLOG_PRESSURE_PRIORITIES.map(priority => {
+    const matching = todoTasks.filter(task => (task.priority ?? 4) === priority)
+    const withAge = matching
+      .map(task => {
+        const createdAt = taskCreatedAtMs(task)
+        return {
+          task,
+          ageMs: createdAt == null ? null : Math.max(0, nowMs - createdAt),
+        }
+      })
+      .sort((a, b) => {
+        if (a.ageMs == null && b.ageMs == null) return a.task.id.localeCompare(b.task.id)
+        if (a.ageMs == null) return 1
+        if (b.ageMs == null) return -1
+        return b.ageMs - a.ageMs
+      })
+    const oldest = withAge[0] ?? null
+    const staleThresholdHours = BACKLOG_STALE_THRESHOLD_HOURS[priority] ?? null
+    const stale =
+      staleThresholdHours != null
+      && oldest?.ageMs != null
+      && oldest.ageMs >= staleThresholdHours * 60 * 60 * 1000
+    const tone =
+      matching.length === 0
+        ? 'idle'
+        : stale
+          ? priority === 1 ? 'bad' : 'warn'
+          : 'ok'
+    return {
+      priority,
+      count: matching.length,
+      oldestAgeMs: oldest?.ageMs ?? null,
+      oldestTask: oldest?.task ?? null,
+      staleThresholdHours,
+      tone,
+    }
+  })
 }
 
 function taskScope(task: Task): string | null {
@@ -212,6 +292,56 @@ function TaskColumn({
   `
 }
 
+function BacklogPressure({ todoTasks }: { todoTasks: Task[] }) {
+  const rows = buildBacklogPressureRows(todoTasks)
+  const total = rows.reduce((sum, row) => sum + row.count, 0)
+  const staleRows = rows.filter(row => row.tone === 'bad' || row.tone === 'warn')
+  if (total === 0) return null
+
+  return html`
+    <section class="mb-3 ${DECK_PANEL}" aria-label="Backlog pressure">
+      <div class="${DECK_HEAD} flex items-start justify-between gap-3">
+        <div>
+          <h3 class="font-mono text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-primary)]">Backlog Pressure</h3>
+          <p class="mt-1 text-3xs leading-relaxed text-[var(--color-fg-muted)]">Unclaimed tasks grouped by priority and oldest age.</p>
+        </div>
+        <span class=${`rounded-[var(--r-0)] border px-1.5 py-0.5 font-mono text-3xs font-semibold ${
+          staleRows.length > 0
+            ? 'border-[var(--color-err-border)] bg-[var(--color-err-soft)] text-[var(--color-err-fg)]'
+            : 'border-[var(--color-info-border)] bg-[var(--color-info-soft)] text-[var(--color-info-fg)]'
+        }`}>${total} todo</span>
+      </div>
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-2 p-2.5">
+        ${rows.map(row => html`
+          <button
+            key=${row.priority}
+            type="button"
+            disabled=${!row.oldestTask}
+            onClick=${() => row.oldestTask ? openTaskDetail(row.oldestTask) : undefined}
+            class=${`min-h-22 rounded-[var(--r-0)] border p-2 text-left transition-colors ${pressureToneClass(row)} ${row.oldestTask ? 'hover:border-[var(--color-border-strong)]' : 'opacity-60'}`}
+            aria-label=${`${priorityLabel(row.priority)} backlog pressure: ${row.count} unclaimed`}
+          >
+            <div class="flex items-center justify-between gap-2">
+              <span class="font-mono text-2xs font-semibold">${priorityLabel(row.priority)}</span>
+              <span class="font-mono text-2xs font-semibold">${row.count}</span>
+            </div>
+            <div class="mt-2 font-mono text-3xs uppercase">oldest ${formatAgeMs(row.oldestAgeMs)}</div>
+            <div class="mt-1 truncate text-3xs">
+              ${row.count === 0
+                ? 'clear'
+                : row.staleThresholdHours == null
+                  ? 'watch'
+                  : row.tone === 'bad' || row.tone === 'warn'
+                    ? `breached ${row.staleThresholdHours}h`
+                    : `within ${row.staleThresholdHours}h`}
+            </div>
+          </button>
+        `)}
+      </div>
+    </section>
+  `
+}
+
 export function TaskBacklog() {
   const { todo, inProgress, awaitingVerification, done } = tasksByStatus.value
   const totalTasks = todo.length + inProgress.length + awaitingVerification.length + done.length
@@ -304,6 +434,7 @@ export function TaskBacklog() {
           <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${filteredTotal}/${totalTasks}</span>
         ` : null}
       </div>
+      <${BacklogPressure} todoTasks=${todo} />
       <div class="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-3 items-start">
         <${TaskColumn}
           title="할 일"

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -91,10 +91,16 @@ function formatAgeMs(ageMs: number | null): string {
   return `${days}d`
 }
 
+function normalizePriority(priority: number | undefined): 1 | 2 | 3 | 4 {
+  return priority === 1 || priority === 2 || priority === 3 ? priority : 4
+}
+
 export function buildBacklogPressureRows(tasks: Task[], nowMs = Date.now()): BacklogPressureRow[] {
-  const todoTasks = tasks.filter(task => task.status === 'todo')
+  const todoTasks = tasks.filter(
+    task => task.status === 'todo' && String(task.assignee ?? '').trim() === '',
+  )
   return BACKLOG_PRESSURE_PRIORITIES.map(priority => {
-    const matching = todoTasks.filter(task => (task.priority ?? 4) === priority)
+    const matching = todoTasks.filter(task => normalizePriority(task.priority) === priority)
     const withAge = matching
       .map(task => {
         const createdAt = taskCreatedAtMs(task)


### PR DESCRIPTION
## Summary
- add a Backlog Pressure strip to Task Backlog that groups unclaimed todo work by priority
- show oldest unclaimed age with P1/P2 threshold states so stale high-priority work is visible without log inspection
- cover the pressure summary with component and helper tests

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec vitest run src/components/goals/kanban-components.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src/components/goals/kanban-components.ts src/components/goals/kanban-components.test.ts
- git diff --check

Closes #13390