### PR TITLE
fix(dashboard): expose data flow graph summary state

### DIFF
--- a/dashboard/src/components/common/data-flow-graph.a11y.test.ts
+++ b/dashboard/src/components/common/data-flow-graph.a11y.test.ts
@@ -40,8 +40,11 @@ describe('DataFlowGraph a11y', () => {
   it('has aria-label on figure', () => {
     const { nodes, edges } = makeData()
     render(html`<${DataFlowGraph} nodes=${nodes} edges=${edges} />`, container)
-    const fig = container.querySelector('figure[aria-label="데이터 흐름 그래프"]')
-    expect(fig).not.toBeNull()
+    const graph = container.querySelector('figure[data-data-flow-graph]') as HTMLElement
+    expect(graph).not.toBeNull()
+    expect(graph.getAttribute('aria-label')).toContain('데이터 흐름 그래프')
+    expect(graph.dataset.dataFlowGraphStatus).toBe('connected')
+    expect(graph.dataset.dataFlowGraphValidEdgeCount).toBe('1')
   })
 
   it('calls onSelectNode when clicked', () => {
@@ -54,5 +57,23 @@ describe('DataFlowGraph a11y', () => {
     const node = container.querySelector('svg g[transform]') as HTMLElement
     node.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(onSelect).toHaveBeenCalledWith('a')
+  })
+
+  it('exposes node and edge metadata', () => {
+    const { nodes, edges } = makeData()
+    render(html`<${DataFlowGraph} nodes=${nodes} edges=${edges} />`, container)
+    const source = container.querySelector('[data-flow-node-id="a"]')
+    const edge = container.querySelector('[data-flow-edge]')
+    expect(source?.getAttribute('data-flow-node-label')).toBe('Agent A')
+    expect(source?.getAttribute('data-flow-node-outgoing')).toBe('10')
+    expect(edge?.getAttribute('data-flow-edge-source')).toBe('a')
+    expect(edge?.getAttribute('data-flow-edge-target')).toBe('b')
+  })
+
+  it('announces empty state with graph metadata', () => {
+    render(html`<${DataFlowGraph} nodes=${[]} edges=${[]} />`, container)
+    const graph = container.querySelector('[data-data-flow-graph]') as HTMLElement
+    expect(graph.dataset.dataFlowGraphStatus).toBe('empty')
+    expect(graph.getAttribute('aria-label')).toContain('노드 없음')
   })
 })

--- a/dashboard/src/components/common/data-flow-graph.test.ts
+++ b/dashboard/src/components/common/data-flow-graph.test.ts
@@ -1,32 +1,46 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { DataFlowGraph } from './data-flow-graph'
+import {
+  DataFlowGraph,
+  getRenderableFlowEdges,
+  summarizeDataFlowGraph,
+} from './data-flow-graph'
 
 describe('DataFlowGraph', () => {
+  const nodes = [
+    { id: 'a', label: 'A', x: 10, y: 10, width: 40, height: 30 },
+    { id: 'b', label: 'B', x: 100, y: 10, width: 40, height: 30 },
+  ]
+
   it('renders empty state when no nodes', () => {
     const container = document.createElement('div')
     render(h(DataFlowGraph, { nodes: [], edges: [] }), container)
     expect(container.textContent).toContain('노드가 없습니다')
     const el = container.querySelector('[role="img"]')
     expect(el).not.toBeNull()
+    expect((el as HTMLElement).dataset.dataFlowGraphStatus).toBe('empty')
+    expect((el as HTMLElement).dataset.dataFlowGraphNodeCount).toBe('0')
   })
 
   it('renders svg with nodes and edges', () => {
     const container = document.createElement('div')
     render(
       h(DataFlowGraph, {
-        nodes: [
-          { id: 'a', label: 'A', x: 10, y: 10, width: 40, height: 30 },
-          { id: 'b', label: 'B', x: 100, y: 10, width: 40, height: 30 },
-        ],
+        nodes,
         edges: [{ source: 'a', target: 'b', value: 5 }],
       }),
       container,
     )
+    const root = container.querySelector('[data-data-flow-graph]') as HTMLElement
     expect(container.querySelector('svg')).not.toBeNull()
     expect(container.textContent).toContain('A')
     expect(container.textContent).toContain('B')
+    expect(container.textContent).toContain('노드')
+    expect(root.dataset.dataFlowGraphStatus).toBe('connected')
+    expect(root.dataset.dataFlowGraphNodeCount).toBe('2')
+    expect(root.dataset.dataFlowGraphValidEdgeCount).toBe('1')
+    expect(root.dataset.dataFlowGraphTotalValue).toBe('5')
   })
 
   it('calls onSelectNode on node click', () => {
@@ -68,7 +82,10 @@ describe('DataFlowGraph', () => {
       container,
     )
     const paths = container.querySelectorAll('path')
+    const root = container.querySelector('[data-data-flow-graph]') as HTMLElement
     expect(paths.length).toBe(0)
+    expect(root.dataset.dataFlowGraphStatus).toBe('partial')
+    expect(root.dataset.dataFlowGraphMissingEdgeCount).toBe('1')
   })
 
   it('respects edge colors', () => {
@@ -85,5 +102,53 @@ describe('DataFlowGraph', () => {
     )
     const path = container.querySelector('path') as SVGPathElement
     expect(path?.getAttribute('stroke')).toBe('#ff0000')
+    expect(path?.getAttribute('data-flow-edge-source')).toBe('a')
+    expect(path?.getAttribute('data-flow-edge-target')).toBe('b')
+    expect(path?.getAttribute('data-flow-edge-value')).toBe('1')
+  })
+
+  it('marks nodes with incoming and outgoing totals', () => {
+    const container = document.createElement('div')
+    render(
+      h(DataFlowGraph, {
+        nodes,
+        edges: [{ source: 'a', target: 'b', value: 5 }],
+      }),
+      container,
+    )
+    const source = container.querySelector('[data-flow-node-id="a"]') as HTMLElement
+    const target = container.querySelector('[data-flow-node-id="b"]') as HTMLElement
+
+    expect(source.dataset.flowNodeOutgoing).toBe('5')
+    expect(source.dataset.flowNodeIncoming).toBe('0')
+    expect(target.dataset.flowNodeIncoming).toBe('5')
+    expect(target.dataset.flowNodeOutgoing).toBe('0')
+  })
+
+  it('summarizes renderable and missing edges', () => {
+    const edges = [
+      { source: 'a', target: 'b', value: 5 },
+      { source: 'a', target: 'missing', value: 2 },
+    ]
+    const summary = summarizeDataFlowGraph(nodes, edges)
+
+    expect(summary).toEqual({
+      nodeCount: 2,
+      edgeCount: 2,
+      validEdgeCount: 1,
+      missingEdgeCount: 1,
+      totalValue: 5,
+      maxValue: 5,
+      status: 'partial',
+    })
+    expect(getRenderableFlowEdges(nodes, edges).length).toBe(1)
+  })
+
+  it('summarizes disconnected nodes', () => {
+    const summary = summarizeDataFlowGraph(nodes, [])
+
+    expect(summary.status).toBe('disconnected')
+    expect(summary.validEdgeCount).toBe(0)
+    expect(summary.maxValue).toBe(1)
   })
 })

--- a/dashboard/src/components/common/data-flow-graph.test.ts
+++ b/dashboard/src/components/common/data-flow-graph.test.ts
@@ -102,6 +102,7 @@ describe('DataFlowGraph', () => {
     )
     const path = container.querySelector('path') as SVGPathElement
     expect(path?.getAttribute('stroke')).toBe('#ff0000')
+    expect(path?.getAttribute('style') ?? '').not.toContain('stroke')
     expect(path?.getAttribute('data-flow-edge-source')).toBe('a')
     expect(path?.getAttribute('data-flow-edge-target')).toBe('b')
     expect(path?.getAttribute('data-flow-edge-value')).toBe('1')
@@ -150,5 +151,17 @@ describe('DataFlowGraph', () => {
     expect(summary.status).toBe('disconnected')
     expect(summary.validEdgeCount).toBe(0)
     expect(summary.maxValue).toBe(1)
+  })
+
+  it('summarizes large edge sets without spreading into Math.max', () => {
+    const manyEdges = Array.from({ length: 120_000 }, (_, index) => ({
+      source: 'a',
+      target: 'b',
+      value: index + 1,
+    }))
+    const summary = summarizeDataFlowGraph(nodes, manyEdges)
+
+    expect(summary.validEdgeCount).toBe(120_000)
+    expect(summary.maxValue).toBe(120_000)
   })
 })

--- a/dashboard/src/components/common/data-flow-graph.ts
+++ b/dashboard/src/components/common/data-flow-graph.ts
@@ -68,7 +68,7 @@ export function summarizeDataFlowGraph(nodes: FlowNode[], edges: FlowEdge[]): Da
   const validEdgeCount = renderableEdges.length
   const missingEdgeCount = edges.length - validEdgeCount
   const totalValue = renderableEdges.reduce((sum, item) => sum + item.value, 0)
-  const maxValue = Math.max(...renderableEdges.map(item => item.value), 1)
+  const maxValue = renderableEdges.reduce((max, item) => Math.max(max, item.value), 1)
   const status: DataFlowGraphStatus =
     nodes.length === 0
       ? 'empty'
@@ -175,8 +175,7 @@ export function DataFlowGraph({ nodes, edges, onSelectNode, testId }: DataFlowGr
                 key=${`${e.source}-${e.target}`}
                 d="M${sx},${sy} C${cx1},${sy} ${cx2},${ty} ${tx},${ty}"
                 fill="none"
-                stroke=${e.color}
-                style=${{ stroke: e.color || 'var(--accent)' }}
+                stroke=${e.color || 'var(--accent)'}
                 stroke-width=${strokeW}
                 opacity="0.7"
                 data-flow-edge

--- a/dashboard/src/components/common/data-flow-graph.ts
+++ b/dashboard/src/components/common/data-flow-graph.ts
@@ -4,7 +4,7 @@
 
 import { html } from 'htm/preact'
 
-interface FlowNode {
+export interface FlowNode {
   id: string
   label: string
   x: number
@@ -14,7 +14,7 @@ interface FlowNode {
   color?: string
 }
 
-interface FlowEdge {
+export interface FlowEdge {
   source: string
   target: string
   value: number
@@ -28,14 +28,85 @@ interface DataFlowGraphProps {
   testId?: string
 }
 
+export type DataFlowGraphStatus = 'empty' | 'connected' | 'partial' | 'disconnected'
+
+export interface DataFlowGraphSummary {
+  nodeCount: number
+  edgeCount: number
+  validEdgeCount: number
+  missingEdgeCount: number
+  totalValue: number
+  maxValue: number
+  status: DataFlowGraphStatus
+}
+
+interface RenderableFlowEdge {
+  edge: FlowEdge
+  sourceNode: FlowNode
+  targetNode: FlowNode
+  value: number
+}
+
+function normalizedEdgeValue(edge: FlowEdge): number {
+  return Number.isFinite(edge.value) ? Math.max(0, edge.value) : 0
+}
+
+export function getRenderableFlowEdges(nodes: FlowNode[], edges: FlowEdge[]): RenderableFlowEdge[] {
+  const nodeMap = new Map(nodes.map(node => [node.id, node]))
+  return edges.flatMap(edge => {
+    const sourceNode = nodeMap.get(edge.source)
+    const targetNode = nodeMap.get(edge.target)
+    if (!sourceNode || !targetNode) {
+      return []
+    }
+    return [{ edge, sourceNode, targetNode, value: normalizedEdgeValue(edge) }]
+  })
+}
+
+export function summarizeDataFlowGraph(nodes: FlowNode[], edges: FlowEdge[]): DataFlowGraphSummary {
+  const renderableEdges = getRenderableFlowEdges(nodes, edges)
+  const validEdgeCount = renderableEdges.length
+  const missingEdgeCount = edges.length - validEdgeCount
+  const totalValue = renderableEdges.reduce((sum, item) => sum + item.value, 0)
+  const maxValue = Math.max(...renderableEdges.map(item => item.value), 1)
+  const status: DataFlowGraphStatus =
+    nodes.length === 0
+      ? 'empty'
+      : missingEdgeCount > 0
+        ? 'partial'
+        : validEdgeCount > 0
+          ? 'connected'
+          : 'disconnected'
+
+  return {
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+    validEdgeCount,
+    missingEdgeCount,
+    totalValue,
+    maxValue,
+    status,
+  }
+}
+
 export function DataFlowGraph({ nodes, edges, onSelectNode, testId }: DataFlowGraphProps) {
+  const summary = summarizeDataFlowGraph(nodes, edges)
+
   if (nodes.length === 0) {
     return html`
       <div
+        data-data-flow-graph
+        data-data-flow-graph-node-count=${summary.nodeCount}
+        data-data-flow-graph-edge-count=${summary.edgeCount}
+        data-data-flow-graph-valid-edge-count=${summary.validEdgeCount}
+        data-data-flow-graph-missing-edge-count=${summary.missingEdgeCount}
+        data-data-flow-graph-total-value=${summary.totalValue}
+        data-data-flow-graph-max-value=${summary.maxValue}
+        data-data-flow-graph-status=${summary.status}
         data-testid=${testId}
-        class="flex h-48 items-center justify-center text-xs text-[var(--color-fg-muted)]"
+        class="flex h-48 items-center justify-center rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] text-xs text-[var(--color-fg-muted)]"
         role="img"
-        aria-label="데이터 흐름 그래프"
+        aria-label="데이터 흐름 그래프, 노드 없음"
       >
         노드가 없습니다.
       </div>
@@ -44,22 +115,55 @@ export function DataFlowGraph({ nodes, edges, onSelectNode, testId }: DataFlowGr
 
   const width = 600
   const height = 320
-  const nodeMap = new Map(nodes.map((n) => [n.id, n]))
-  const maxValue = Math.max(...edges.map((e) => e.value), 1)
+  const renderableEdges = getRenderableFlowEdges(nodes, edges)
+  const nodeTotals = new Map(nodes.map(node => [node.id, { incoming: 0, outgoing: 0 }]))
+  for (const item of renderableEdges) {
+    nodeTotals.get(item.edge.source)!.outgoing += item.value
+    nodeTotals.get(item.edge.target)!.incoming += item.value
+  }
 
   return html`
-    <figure data-testid=${testId} class="w-full overflow-auto" aria-label="데이터 흐름 그래프">
+    <figure
+      data-data-flow-graph
+      data-data-flow-graph-node-count=${summary.nodeCount}
+      data-data-flow-graph-edge-count=${summary.edgeCount}
+      data-data-flow-graph-valid-edge-count=${summary.validEdgeCount}
+      data-data-flow-graph-missing-edge-count=${summary.missingEdgeCount}
+      data-data-flow-graph-total-value=${summary.totalValue}
+      data-data-flow-graph-max-value=${summary.maxValue}
+      data-data-flow-graph-status=${summary.status}
+      data-testid=${testId}
+      class="w-full overflow-auto"
+      role="img"
+      aria-label="데이터 흐름 그래프, 노드 ${summary.nodeCount}개, 연결 ${summary.validEdgeCount}개"
+    >
+      <div
+        class="mb-2 grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
+        aria-label="데이터 흐름 요약"
+      >
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">노드</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.nodeCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">연결</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">
+            ${summary.validEdgeCount}/${summary.edgeCount}
+          </div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">흐름</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.totalValue}</div>
+        </div>
+      </div>
       <svg
         viewBox="0 0 ${width} ${height}"
         class="w-full h-auto"
         aria-hidden="true"
       >
         <g aria-hidden="true">
-          ${edges.map((e) => {
-            const s = nodeMap.get(e.source)
-            const t = nodeMap.get(e.target)
-            if (!s || !t) return null
-            const strokeW = Math.max(1, (e.value / maxValue) * 12)
+          ${renderableEdges.map(({ edge: e, sourceNode: s, targetNode: t, value }) => {
+            const strokeW = Math.max(1, (value / summary.maxValue) * 12)
             const sx = s.x + s.width
             const sy = s.y + s.height / 2
             const tx = t.x
@@ -71,39 +175,51 @@ export function DataFlowGraph({ nodes, edges, onSelectNode, testId }: DataFlowGr
                 key=${`${e.source}-${e.target}`}
                 d="M${sx},${sy} C${cx1},${sy} ${cx2},${ty} ${tx},${ty}"
                 fill="none"
-                stroke=${e.color || 'var(--color-accent)'}
+                stroke=${e.color}
+                style=${{ stroke: e.color || 'var(--accent)' }}
                 stroke-width=${strokeW}
-                opacity="0.5"
+                opacity="0.7"
+                data-flow-edge
+                data-flow-edge-source=${e.source}
+                data-flow-edge-target=${e.target}
+                data-flow-edge-value=${value}
               />
             `
           })}
         </g>
-        ${nodes.map((n) => html`
-          <g
-            key=${n.id}
-            transform="translate(${n.x}, ${n.y})"
-            class="cursor-pointer"
-            onClick=${() => onSelectNode?.(n.id)}
-          >
-            <rect
-              width=${n.width}
-              height=${n.height}
-              rx="4"
-              fill=${n.color || 'var(--color-bg-surface)'}
-              stroke="var(--color-border-default)"
-              stroke-width="1"
-            />
-            <text
-              x=${n.width / 2}
-              y=${n.height / 2 + 4}
-              text-anchor="middle"
-              class="text-xs fill-[var(--color-fg-primary)] pointer-events-none"
-              style="font-size: var(--fs-10);"
+        ${nodes.map((n) => {
+          const totals = nodeTotals.get(n.id) ?? { incoming: 0, outgoing: 0 }
+          return html`
+            <g
+              key=${n.id}
+              transform="translate(${n.x}, ${n.y})"
+              class="cursor-pointer"
+              onClick=${() => onSelectNode?.(n.id)}
+              data-flow-node-id=${n.id}
+              data-flow-node-label=${n.label}
+              data-flow-node-incoming=${totals.incoming}
+              data-flow-node-outgoing=${totals.outgoing}
             >
-              ${n.label}
-            </text>
-          </g>
-        `)}
+              <rect
+                width=${n.width}
+                height=${n.height}
+                rx="4"
+                fill=${n.color || 'var(--color-bg-surface)'}
+                stroke="var(--color-border-default)"
+                stroke-width="1"
+              />
+              <text
+                x=${n.width / 2}
+                y=${n.height / 2 + 4}
+                text-anchor="middle"
+                class="text-xs fill-[var(--color-fg-primary)] pointer-events-none"
+                style="font-size: var(--fs-10);"
+              >
+                ${n.label}
+              </text>
+            </g>
+          `
+        })}
       </svg>
     </figure>
   `


### PR DESCRIPTION
## Summary
- export DataFlowGraph summary helpers and metadata for node/edge counts, status, totals, and missing edges
- render a compact summary strip plus empty-state metadata for graph QA and dashboard inspection
- expose node/edge data attributes and fix the default edge stroke to use the semantic accent token

## Why it matters
DataFlowGraph could look empty in browser QA because the default edge color referenced an undefined token path. This also gives operators and tests a stable way to distinguish connected, partial, disconnected, and empty graph states without parsing SVG geometry.

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/data-flow-graph.test.ts src/components/common/data-flow-graph.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint (passes with 3 existing warnings outside this component)
- pnpm --dir dashboard run build (passes with existing Vite dynamic/static import and chunk-size warnings)
- Browser QA via Vite on 5208: desktop 820x680 and mobile 390x640 screenshots; no horizontal overflow; connected/partial/disconnected/empty metadata checked; default edge computed stroke rgb(212, 161, 74); no page errors

## Review focus
- DataFlowGraph status semantics for missing/non-renderable edges
- SVG stroke fallback behavior for default and custom colored edges
- Metadata attribute names for downstream dashboard QA