### PR TITLE
fix(dashboard): expose event stream summary state

### DIFF
--- a/dashboard/src/components/common/event-stream.a11y.test.ts
+++ b/dashboard/src/components/common/event-stream.a11y.test.ts
@@ -43,8 +43,10 @@ describe('EventStream a11y', () => {
     expect(log).not.toBeNull()
     expect(log?.getAttribute('aria-live')).toBe('polite')
     expect(log?.getAttribute('aria-label')).toContain('이벤트 스트림')
-    expect(log.dataset.eventStreamStatus).toBe('error')
-    expect(log.dataset.eventStreamVisibleCount).toBe('3')
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    expect(root.dataset.eventStreamStatus).toBe('error')
+    expect(root.dataset.eventStreamVisibleCount).toBe('3')
+    expect(log.querySelector('[aria-label="이벤트 스트림 요약"]')).toBeNull()
   })
 
   it('renders event messages', () => {

--- a/dashboard/src/components/common/event-stream.a11y.test.ts
+++ b/dashboard/src/components/common/event-stream.a11y.test.ts
@@ -39,9 +39,12 @@ describe('EventStream a11y', () => {
 
   it('has log role with aria-live', () => {
     render(html`<${EventStream} events=${makeEvents()} />`, container)
-    const log = container.querySelector('[role="log"]')
+    const log = container.querySelector('[role="log"]') as HTMLElement
     expect(log).not.toBeNull()
     expect(log?.getAttribute('aria-live')).toBe('polite')
+    expect(log?.getAttribute('aria-label')).toContain('이벤트 스트림')
+    expect(log.dataset.eventStreamStatus).toBe('error')
+    expect(log.dataset.eventStreamVisibleCount).toBe('3')
   })
 
   it('renders event messages', () => {
@@ -55,5 +58,14 @@ describe('EventStream a11y', () => {
     render(html`<${EventStream} events=${makeEvents()} />`, container)
     expect(container.textContent).toContain('keeper')
     expect(container.textContent).toContain('monitor')
+  })
+
+  it('marks each visible event with level metadata', () => {
+    render(html`<${EventStream} events=${makeEvents()} maxItems=${2} />`, container)
+    const items = container.querySelectorAll('[data-stream-event-id]')
+    expect(items.length).toBe(2)
+    expect((items[0] as HTMLElement).dataset.streamEventLevel).toBe('error')
+    expect((items[1] as HTMLElement).dataset.streamEventLevel).toBe('warn')
+    expect(container.querySelector('time')?.getAttribute('datetime')).toBeTruthy()
   })
 })

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { EventStream } from './event-stream'
+import {
+  EventStream,
+  getVisibleStreamEvents,
+  summarizeEventStream,
+} from './event-stream'
 
 const baseEvents = [
   { id: 'e1', timestamp: new Date('2024-01-01T09:30:00').getTime(), level: 'info' as const, message: 'started', source: 'agent-a' },
@@ -26,7 +30,8 @@ describe('EventStream', () => {
     const container = document.createElement('div')
     render(h(EventStream, { events: [] }), container)
     const el = container.querySelector('[role="log"]') as HTMLElement
-    expect(el?.getAttribute('aria-label')).toBe('이벤트 스트림')
+    expect(el?.getAttribute('aria-label')).toContain('이벤트 스트림')
+    expect(el?.getAttribute('aria-label')).toContain('이벤트 0개')
   })
 
   it('renders empty state', () => {
@@ -41,6 +46,9 @@ describe('EventStream', () => {
     expect(container.textContent).toContain('started')
     expect(container.textContent).toContain('slow')
     expect(container.textContent).toContain('failed')
+    expect(container.textContent).toContain('전체')
+    expect(container.textContent).toContain('표시')
+    expect(container.textContent).toContain('에러')
   })
 
   it('renders source labels', () => {
@@ -81,6 +89,10 @@ describe('EventStream', () => {
     }))
     render(h(EventStream, { events: many, maxItems: 5 }), container)
     expect(container.querySelectorAll('[role="listitem"]').length).toBe(5)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    expect(root.dataset.eventStreamTotalCount).toBe('10')
+    expect(root.dataset.eventStreamVisibleCount).toBe('5')
+    expect(root.dataset.eventStreamHiddenCount).toBe('5')
   })
 
   it('applies testId', () => {
@@ -95,5 +107,69 @@ describe('EventStream', () => {
     expect(container.textContent).toContain('정보')
     expect(container.textContent).toContain('경고')
     expect(container.textContent).toContain('에러')
+  })
+
+  it('exposes stream summary metadata', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const latest = baseEvents[2]!
+
+    expect(root.dataset.eventStreamStatus).toBe('error')
+    expect(root.dataset.eventStreamTotalCount).toBe('3')
+    expect(root.dataset.eventStreamVisibleCount).toBe('3')
+    expect(root.dataset.eventStreamInfoCount).toBe('1')
+    expect(root.dataset.eventStreamWarnCount).toBe('1')
+    expect(root.dataset.eventStreamErrorCount).toBe('1')
+    expect(root.dataset.eventStreamLatestTimestamp).toBe(String(latest.timestamp))
+  })
+
+  it('exposes event row metadata and datetime', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents }), container)
+    const item = container.querySelector('[data-stream-event-id="e3"]') as HTMLElement
+    const time = item.querySelector('time') as HTMLTimeElement
+    const latest = baseEvents[2]!
+
+    expect(item.dataset.streamEventLevel).toBe('error')
+    expect(item.dataset.streamEventVisibleIndex).toBe('0')
+    expect(item.dataset.streamEventTimestamp).toBe(String(latest.timestamp))
+    expect(time.dateTime).toBe(new Date(latest.timestamp).toISOString())
+  })
+
+  it('summarizes visible event status', () => {
+    expect(summarizeEventStream([], 100)).toMatchObject({
+      totalCount: 0,
+      visibleCount: 0,
+      status: 'empty',
+    })
+    expect(summarizeEventStream(baseEvents.slice(0, 1), 100)).toMatchObject({
+      visibleCount: 1,
+      infoCount: 1,
+      status: 'ok',
+    })
+    expect(summarizeEventStream(baseEvents.slice(0, 2), 100)).toMatchObject({
+      visibleCount: 2,
+      warnCount: 1,
+      status: 'warning',
+    })
+    expect(summarizeEventStream(baseEvents, 2)).toMatchObject({
+      totalCount: 3,
+      visibleCount: 2,
+      hiddenCount: 1,
+      status: 'error',
+    })
+  })
+
+  it('treats maxItems zero as an empty visible window', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents, maxItems: 0 }), container)
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(0)
+    expect(getVisibleStreamEvents(baseEvents, 0)).toEqual([])
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    expect(root.dataset.eventStreamTotalCount).toBe('3')
+    expect(root.dataset.eventStreamVisibleCount).toBe('0')
+    expect(root.dataset.eventStreamHiddenCount).toBe('3')
+    expect(root.dataset.eventStreamStatus).toBe('empty')
   })
 })

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -14,6 +14,20 @@ export interface StreamEvent {
   source?: string
 }
 
+export type EventStreamStatus = 'empty' | 'ok' | 'warning' | 'error'
+
+export interface EventStreamSummary {
+  totalCount: number
+  visibleCount: number
+  hiddenCount: number
+  infoCount: number
+  warnCount: number
+  errorCount: number
+  latestTimestamp: number | null
+  oldestVisibleTimestamp: number | null
+  status: EventStreamStatus
+}
+
 interface EventStreamProps {
   events: StreamEvent[]
   maxItems?: number
@@ -22,10 +36,10 @@ interface EventStreamProps {
 
 function levelColor(level: string): string {
   return level === 'error'
-    ? 'var(--error-10)'
+    ? 'var(--color-status-err)'
     : level === 'warn'
-      ? 'var(--warn-10)'
-      : 'var(--ok-10)'
+      ? 'var(--color-status-warn)'
+      : 'var(--color-status-info)'
 }
 
 function levelLabel(level: string): string {
@@ -34,48 +48,127 @@ function levelLabel(level: string): string {
 
 function formatTime(ts: number): string {
   const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return '--:--:--'
   return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}`
 }
 
+function formatDateTime(ts: number): string | undefined {
+  const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return undefined
+  return d.toISOString()
+}
+
+export function getVisibleStreamEvents(events: StreamEvent[], maxItems: number): StreamEvent[] {
+  const itemLimit = Number.isFinite(maxItems) ? Math.max(0, Math.floor(maxItems)) : 0
+  if (itemLimit === 0) return []
+  return events.slice(-itemLimit).reverse()
+}
+
+export function summarizeEventStream(events: StreamEvent[], maxItems: number): EventStreamSummary {
+  const visible = getVisibleStreamEvents(events, maxItems)
+  const infoCount = visible.filter(e => e.level === 'info').length
+  const warnCount = visible.filter(e => e.level === 'warn').length
+  const errorCount = visible.filter(e => e.level === 'error').length
+  const status: EventStreamStatus =
+    visible.length === 0
+      ? 'empty'
+      : errorCount > 0
+        ? 'error'
+        : warnCount > 0
+          ? 'warning'
+          : 'ok'
+
+  return {
+    totalCount: events.length,
+    visibleCount: visible.length,
+    hiddenCount: Math.max(0, events.length - visible.length),
+    infoCount,
+    warnCount,
+    errorCount,
+    latestTimestamp: visible[0]?.timestamp ?? null,
+    oldestVisibleTimestamp: visible[visible.length - 1]?.timestamp ?? null,
+    status,
+  }
+}
+
 export function EventStream({ events, maxItems = 100, testId }: EventStreamProps) {
-  const visible = useMemo(
-    () => events.slice(-maxItems).reverse(),
-    [events, maxItems],
-  )
+  const visible = useMemo(() => getVisibleStreamEvents(events, maxItems), [events, maxItems])
+  const summary = useMemo(() => summarizeEventStream(events, maxItems), [events, maxItems])
 
   return html`
     <div
-      class="h-64 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2"
+      class="h-64 space-y-2 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2"
       data-event-stream
+      data-event-stream-total-count=${summary.totalCount}
+      data-event-stream-visible-count=${summary.visibleCount}
+      data-event-stream-hidden-count=${summary.hiddenCount}
+      data-event-stream-info-count=${summary.infoCount}
+      data-event-stream-warn-count=${summary.warnCount}
+      data-event-stream-error-count=${summary.errorCount}
+      data-event-stream-status=${summary.status}
+      data-event-stream-latest-timestamp=${summary.latestTimestamp ?? ''}
+      data-event-stream-oldest-visible-timestamp=${summary.oldestVisibleTimestamp ?? ''}
       data-testid=${testId}
       role="log"
-      aria-label="이벤트 스트림"
+      aria-label="이벤트 스트림, 이벤트 ${summary.visibleCount}개, 에러 ${summary.errorCount}개"
       aria-live="polite"
       aria-atomic="false"
     >
+      <div
+        class="grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
+        aria-label="이벤트 스트림 요약"
+      >
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">전체</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.totalCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">표시</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">
+            ${summary.visibleCount}/${summary.totalCount}
+          </div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">에러</div>
+          <div class="font-mono text-sm text-[var(--color-status-err)]">${summary.errorCount}</div>
+        </div>
+      </div>
       ${visible.length === 0
         ? html`<div class="text-3xs text-[var(--color-fg-muted)]">이벤트 없음</div>`
         : html`
             <div class="space-y-1" role="list">
               ${visible.map(
-                e => html`
+                (e, index) => html`
                   <div
                     key=${e.id}
-                    class="flex items-start gap-2 rounded-[var(--r-1)] px-2 py-1 hover:bg-[var(--color-bg-hover)]"
+                    class="flex min-w-0 items-start gap-2 rounded-[var(--r-1)] px-2 py-1 hover:bg-[var(--color-bg-hover)]"
                     role="listitem"
+                    data-stream-event-id=${e.id}
+                    data-stream-event-level=${e.level}
+                    data-stream-event-source=${e.source ?? ''}
+                    data-stream-event-timestamp=${e.timestamp}
+                    data-stream-event-visible-index=${index}
                   >
                     <span
                       class="mt-0.5 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"
                       style=${{ background: levelColor(e.level) }}
                       aria-hidden="true"
                     ></span>
-                    <span class="font-mono text-3xs text-[var(--color-fg-secondary)] tabular-nums"
-                      >${formatTime(e.timestamp)}</span
+                    <time
+                      class="shrink-0 font-mono text-3xs text-[var(--color-fg-secondary)] tabular-nums"
+                      datetime=${formatDateTime(e.timestamp)}
+                      >${formatTime(e.timestamp)}</time
                     >
                     ${e.source
-                      ? html`<span class="text-3xs text-[var(--color-fg-muted)]">[${e.source}]</span>`
+                      ? html`<span
+                          class="max-w-24 shrink-0 truncate text-3xs text-[var(--color-fg-muted)]"
+                          title=${e.source}
+                          >[${e.source}]</span
+                        >`
                       : null}
-                    <span class="flex-1 text-xs text-[var(--color-fg-primary)]">${e.message}</span>
+                    <span class="min-w-0 flex-1 break-words text-xs text-[var(--color-fg-primary)]"
+                      >${e.message}</span
+                    >
                     <span class="sr-only">${levelLabel(e.level)}</span>
                   </div>
                 `,

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -109,10 +109,6 @@ export function EventStream({ events, maxItems = 100, testId }: EventStreamProps
       data-event-stream-latest-timestamp=${summary.latestTimestamp ?? ''}
       data-event-stream-oldest-visible-timestamp=${summary.oldestVisibleTimestamp ?? ''}
       data-testid=${testId}
-      role="log"
-      aria-label="이벤트 스트림, 이벤트 ${summary.visibleCount}개, 에러 ${summary.errorCount}개"
-      aria-live="polite"
-      aria-atomic="false"
     >
       <div
         class="grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
@@ -133,9 +129,15 @@ export function EventStream({ events, maxItems = 100, testId }: EventStreamProps
           <div class="font-mono text-sm text-[var(--color-status-err)]">${summary.errorCount}</div>
         </div>
       </div>
-      ${visible.length === 0
-        ? html`<div class="text-3xs text-[var(--color-fg-muted)]">이벤트 없음</div>`
-        : html`
+      <div
+        role="log"
+        aria-label="이벤트 스트림, 이벤트 ${summary.visibleCount}개, 에러 ${summary.errorCount}개"
+        aria-live="polite"
+        aria-atomic="false"
+      >
+        ${visible.length === 0
+          ? html`<div class="text-3xs text-[var(--color-fg-muted)]">이벤트 없음</div>`
+          : html`
             <div class="space-y-1" role="list">
               ${visible.map(
                 (e, index) => html`
@@ -175,6 +177,7 @@ export function EventStream({ events, maxItems = 100, testId }: EventStreamProps
               )}
             </div>
           `}
+      </div>
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- export EventStream summary helpers and metadata for visible/hidden counts, severity counts, status, and visible timestamps
- render a compact stream summary strip and expose row-level event metadata plus machine-readable time elements
- replace the undefined error color token with semantic status tokens and tighten row wrapping for narrow viewports

## Why it matters
EventStream had live log state but no stable summary surface for dashboard QA or operators, and error dots referenced an undefined token. This makes empty, ok, warning, and error states inspectable without parsing text while keeping long sources/messages from widening the stream on mobile.

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/event-stream.test.ts src/components/common/event-stream.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint (passes with 3 existing warnings outside this component)
- pnpm --dir dashboard run build (passes with existing Vite dynamic/static import and chunk-size warnings)
- Browser QA via Vite on 5209: desktop 820x720 and mobile 390x640 screenshots; no horizontal overflow; error/warning/ok/empty/zero-window metadata checked; semantic level dot colors computed; no page errors

## Review focus
- EventStream visible-window status semantics, especially maxItems=0
- Metadata attribute names for stream and row-level dashboard QA
- Token replacement from undefined --error-10 to semantic status colors