### PR TITLE
Allow keeper coordination proof tools in policy

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -13,7 +13,7 @@
 # ── Tool Groups ─────────────────────────────────────────────────────
 
 [groups.base]
-tools = ["keeper_time_now", "keeper_context_status", "keeper_memory_search", "keeper_tool_search"]
+tools = ["keeper_time_now", "keeper_context_status", "keeper_memory_search", "keeper_tool_search", "keeper_tools_list"]
 
 # Board tools split: core (frequent) vs extended (discoverable via tool_search).
 [groups.board_core]
@@ -31,7 +31,16 @@ tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keepe
 tools = ["keeper_tasks_list", "keeper_task_claim", "keeper_task_done", "keeper_broadcast"]
 
 [groups.coordination]
-tools = ["keeper_tasks_list", "keeper_tasks_audit", "keeper_task_claim", "keeper_task_done", "keeper_broadcast"]
+tools = [
+  "keeper_tasks_list",
+  "keeper_tasks_audit",
+  "keeper_task_claim",
+  "keeper_task_done",
+  "keeper_task_submit_for_verification",
+  "keeper_task_force_release",
+  "keeper_task_create",
+  "keeper_broadcast",
+]
 
 [groups.shell]
 # keeper_bash: full bash with 3-layer deterministic guard
@@ -101,6 +110,8 @@ tools = [
   "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task",
   "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
   "masc_agent_card", "masc_tool_help",
+  "masc_goal_list", "masc_coordination_fsm_snapshot",
+  "masc_task_history", "masc_plan_get", "masc_plan_get_task",
   "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
   "masc_messages", "masc_broadcast",
 ]
@@ -219,6 +230,7 @@ masc_groups = ["essential", "dispatch", "code_observe", "coordination"]
 [presets.coding]
 groups = ["base", "board_core", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding", "github", "github_review"]
 masc_groups = ["essential", "coding"]
+masc_tools = ["masc_goal_list", "masc_coordination_fsm_snapshot"]
 
 # Step 9 (bloodflow restoration plan): the research preset is granted
 # delivery-oriented capabilities so analyst/scholar/verifier-tier keepers

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -98,6 +98,7 @@ let test_default_has_base_tools () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has tools" true (List.length tools > 0);
   check bool "has keeper_time_now" true (has_tool "keeper_time_now" tools);
+  check bool "has keeper_tools_list" true (has_tool "keeper_tools_list" tools);
   check bool "has keeper_context_status" true (has_tool "keeper_context_status" tools)
 
 (* Governance tool schemas are no longer registered. *)
@@ -257,6 +258,24 @@ let test_coding_preset_has_coordination_tools () =
     (has_tool "keeper_tasks_list" tools);
   check bool "has keeper_task_claim" true
     (has_tool "keeper_task_claim" tools);
+  check bool "has keeper_task_submit_for_verification" true
+    (has_tool "keeper_task_submit_for_verification" tools);
+  check bool "has keeper_task_create" true
+    (has_tool "keeper_task_create" tools);
+  check bool "has keeper_task_force_release" true
+    (has_tool "keeper_task_force_release" tools);
+  check bool "has masc_goal_list" true
+    (has_tool "masc_goal_list" tools);
+  check bool "has masc_coordination_fsm_snapshot" true
+    (has_tool "masc_coordination_fsm_snapshot" tools);
+  check bool "does not grant masc_task_history" false
+    (has_tool "masc_task_history" tools);
+  check bool "does not grant masc_plan_get_task" false
+    (has_tool "masc_plan_get_task" tools);
+  check bool "does not grant masc_goal_upsert" false
+    (has_tool "masc_goal_upsert" tools);
+  check bool "does not grant masc_goal_verify" false
+    (has_tool "masc_goal_verify" tools);
   check bool "has keeper_broadcast" true
     (has_tool "keeper_broadcast" tools)
 

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -671,6 +671,29 @@ let test_coding_preset_routes_coordination_read_models () =
   check bool "coding does not include goal verify" false
     (List.mem "masc_goal_verify" allowed)
 
+let test_coordination_presets_route_plan_history_reads () =
+  init_keeper_tool_registry ();
+  List.iter
+    (fun (label, preset) ->
+      let base = make_gate_test_meta ~name:("test-" ^ label ^ "-coordination") () in
+      let meta =
+        {
+          base with
+          tool_access = Preset { preset; also_allow = [] };
+          tool_denylist = [];
+        }
+      in
+      let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+      check bool (label ^ " includes task history") true
+        (List.mem "masc_task_history" allowed);
+      check bool (label ^ " includes plan get") true
+        (List.mem "masc_plan_get" allowed);
+      check bool (label ^ " includes plan get task") true
+        (List.mem "masc_plan_get_task" allowed);
+      check bool (label ^ " does not include goal upsert") false
+        (List.mem "masc_goal_upsert" allowed))
+    [ ("social", Social); ("messaging", Messaging) ]
+
 let test_preset_universe_superset_of_policy () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
@@ -820,6 +843,8 @@ let () =
             test_dispatch_preset_routes_pm_tools;
           test_case "coding routes coordination read models" `Quick
             test_coding_preset_routes_coordination_read_models;
+          test_case "coordination presets route plan/history reads" `Quick
+            test_coordination_presets_route_plan_history_reads;
         ] );
       ( "inter_diff_composition",
         [

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -625,6 +625,12 @@ let test_dispatch_preset_routes_pm_tools () =
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "dispatch includes goal list" true
     (List.mem "masc_goal_list" allowed);
+  check bool "dispatch includes task history" true
+    (List.mem "masc_task_history" allowed);
+  check bool "dispatch includes plan get" true
+    (List.mem "masc_plan_get" allowed);
+  check bool "dispatch includes plan get task" true
+    (List.mem "masc_plan_get_task" allowed);
   check bool "dispatch includes goal upsert" true
     (List.mem "masc_goal_upsert" allowed);
   check bool "dispatch includes keeper list" true
@@ -647,6 +653,23 @@ let test_dispatch_preset_routes_pm_tools () =
     (List.mem "masc_code_write" allowed);
   check bool "dispatch excludes code git" false
     (List.mem "masc_code_git" allowed)
+
+let test_coding_preset_routes_coordination_read_models () =
+  init_keeper_tool_registry ();
+  let base = make_gate_test_meta ~name:"test-coding-coordination-read" () in
+  let meta = { base with
+    tool_access = Preset { preset = Coding; also_allow = [] };
+    tool_denylist = [];
+  } in
+  let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "coding includes goal list read model" true
+    (List.mem "masc_goal_list" allowed);
+  check bool "coding includes FSM snapshot read model" true
+    (List.mem "masc_coordination_fsm_snapshot" allowed);
+  check bool "coding does not include goal upsert" false
+    (List.mem "masc_goal_upsert" allowed);
+  check bool "coding does not include goal verify" false
+    (List.mem "masc_goal_verify" allowed)
 
 let test_preset_universe_superset_of_policy () =
   init_keeper_tool_registry ();
@@ -795,6 +818,8 @@ let () =
         [
           test_case "dispatch routes PM tools" `Quick
             test_dispatch_preset_routes_pm_tools;
+          test_case "coding routes coordination read models" `Quick
+            test_coding_preset_routes_coordination_read_models;
         ] );
       ( "inter_diff_composition",
         [


### PR DESCRIPTION
## What
- Add the taskboard proof tools `keeper_task_submit_for_verification`, `keeper_task_force_release`, and `keeper_task_create` to the extended `coordination` policy group.
- Add `keeper_tools_list` to the base group so the policy-denial hint can actually be followed by every preset.
- Add read-only coordination proof tools `masc_goal_list`, `masc_coordination_fsm_snapshot`, `masc_task_history`, `masc_plan_get`, and `masc_plan_get_task` to MASC coordination policy.
- Keep `coordination_core` unchanged, so social/messaging presets do not get the heavier taskboard mutation surface.
- Add policy/exposure tests that prove coding keepers receive the narrow read models while broader task history/plan reads and mutating goal tools remain outside coding policy.

## Why
The live keeper feature proof and #13567 showed standard keeper proof paths failing as `not_in_allow_set`: task verification could not use `keeper_task_submit_for_verification`, coordination-state guidance pointed keepers at `masc_coordination_fsm_snapshot` even when unavailable, and the runtime told keepers to use `keeper_tools_list` while denying that same discovery tool.

This fixes allow-set mistakes for autonomous, proof-required read/discovery paths. It does not bypass governance: mutating goal operations and high-risk writes still flow through their existing risk/approval gates.

Tracks #13567.

## Validation
- `scripts/opam-pin-external-deps.sh --install`
- `scripts/dune-local.sh build test/test_keeper_tool_exposure.exe test/test_tool_access_policy.exe test/test_keeper_tool_policy_config.exe`
- `./_build/default/test/test_keeper_tool_exposure.exe`
- `./_build/default/test/test_tool_access_policy.exe`
- `./_build/default/test/test_keeper_tool_policy_config.exe`