### PR TITLE
fix(dashboard): expose agent conversation summary state

### DIFF
--- a/dashboard/src/components/common/agent-conversation.a11y.test.ts
+++ b/dashboard/src/components/common/agent-conversation.a11y.test.ts
@@ -36,7 +36,11 @@ describe('AgentConversation a11y', () => {
   it('has feed role', () => {
     render(html`<${AgentConversation} messages=${makeMessages()} />`, container)
     const feed = container.querySelector('[role="feed"]')
+    const root = container.querySelector('[data-agent-conversation]') as HTMLElement
     expect(feed).not.toBeNull()
+    expect(feed?.getAttribute('aria-label')).toContain('메시지 4개')
+    expect(root.dataset.agentConversationStatus).toBe('linear')
+    expect(root.dataset.agentConversationMessageCount).toBe('4')
   })
 
   it('renders user message with align class', () => {
@@ -65,6 +69,8 @@ describe('AgentConversation a11y', () => {
       container,
     )
     expect(container.textContent).toContain('feat/auth')
+    const article = container.querySelector('[data-message-id="b1"]') as HTMLElement
+    expect(article.dataset.messageBranchLabel).toBe('feat/auth')
   })
 
   it('calls onSelectMessage when clicked', () => {
@@ -90,5 +96,19 @@ describe('AgentConversation a11y', () => {
     )
     const article = container.querySelector('article')
     expect(article?.classList.contains('items-center')).toBe(true)
+  })
+
+  it('marks orphaned branches in metadata', () => {
+    render(
+      html`<${AgentConversation}
+        messages=${[{ id: 'o1', role: 'agent', content: 'Missing parent', timestamp: Date.now(), parentId: 'missing' }]}
+      />`,
+      container,
+    )
+    const root = container.querySelector('[data-agent-conversation]') as HTMLElement
+    const article = container.querySelector('[data-message-id="o1"]') as HTMLElement
+    expect(root.dataset.agentConversationStatus).toBe('orphaned')
+    expect(root.dataset.agentConversationOrphanCount).toBe('1')
+    expect(article.dataset.messageOrphan).toBe('true')
   })
 })

--- a/dashboard/src/components/common/agent-conversation.test.ts
+++ b/dashboard/src/components/common/agent-conversation.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentConversation } from './agent-conversation'
+import {
+  AgentConversation,
+  summarizeAgentConversation,
+} from './agent-conversation'
 
 const messages = [
   { id: 'm1', role: 'user' as const, content: 'hello', timestamp: Date.now() },
@@ -13,6 +16,9 @@ describe('AgentConversation', () => {
     const container = document.createElement('div')
     render(h(AgentConversation, { messages: [] }), container)
     expect(container.textContent).toContain('대화 내용이 없습니다')
+    expect(container.textContent).toContain('메시지')
+    expect(container.textContent).toContain('분기')
+    expect(container.textContent).toContain('도구')
   })
 
   it('renders role region when empty', () => {
@@ -26,12 +32,16 @@ describe('AgentConversation', () => {
     render(h(AgentConversation, { messages }), container)
     expect(container.textContent).toContain('hello')
     expect(container.textContent).toContain('hi there')
+    expect(container.querySelector('[data-agent-conversation]')).not.toBeNull()
   })
 
   it('renders user message with data-message-id', () => {
     const container = document.createElement('div')
     render(h(AgentConversation, { messages }), container)
-    expect(container.querySelector('[data-message-id="m1"]')).not.toBeNull()
+    const msg = container.querySelector('[data-message-id="m1"]') as HTMLElement
+    expect(msg).not.toBeNull()
+    expect(msg.dataset.messageRole).toBe('user')
+    expect(msg.dataset.messageOrphan).toBe('false')
   })
 
   it('renders agent message with data-message-id', () => {
@@ -74,7 +84,9 @@ describe('AgentConversation', () => {
   it('renders feed role when messages present', () => {
     const container = document.createElement('div')
     render(h(AgentConversation, { messages }), container)
-    expect(container.querySelector('[role="feed"]')).not.toBeNull()
+    const feed = container.querySelector('[role="feed"]')
+    expect(feed).not.toBeNull()
+    expect(feed?.getAttribute('aria-label')).toContain('메시지 2개')
   })
 
   it('applies testId', () => {
@@ -88,5 +100,51 @@ describe('AgentConversation', () => {
     const ts = new Date('2024-01-01T09:30:00').getTime()
     render(h(AgentConversation, { messages: [{ id: 'm6', role: 'user' as const, content: 'x', timestamp: ts }] }), container)
     expect(container.textContent).toContain('09:30')
+    expect(container.querySelector('time')?.getAttribute('datetime')).toBe(new Date(ts).toISOString())
+  })
+
+  it('exposes conversation summary metadata', () => {
+    const container = document.createElement('div')
+    const branchMessages = [
+      messages[0]!,
+      { id: 'm2', role: 'agent' as const, content: 'branch', timestamp: Date.now() + 1000, parentId: 'm1', branchLabel: 'v2' },
+      { id: 'm3', role: 'tool' as const, content: 'tool result', timestamp: Date.now() + 2000, parentId: 'missing' },
+    ]
+    render(h(AgentConversation, { messages: branchMessages }), container)
+    const root = container.querySelector('[data-agent-conversation]') as HTMLElement
+    const branch = container.querySelector('[data-message-id="m2"]') as HTMLElement
+    const orphan = container.querySelector('[data-message-id="m3"]') as HTMLElement
+
+    expect(root.dataset.agentConversationMessageCount).toBe('3')
+    expect(root.dataset.agentConversationUserCount).toBe('1')
+    expect(root.dataset.agentConversationAgentCount).toBe('1')
+    expect(root.dataset.agentConversationToolCount).toBe('1')
+    expect(root.dataset.agentConversationBranchCount).toBe('2')
+    expect(root.dataset.agentConversationOrphanCount).toBe('1')
+    expect(root.dataset.agentConversationStatus).toBe('orphaned')
+    expect(branch.dataset.messageParentId).toBe('m1')
+    expect(branch.dataset.messageBranchLabel).toBe('v2')
+    expect(orphan.dataset.messageOrphan).toBe('true')
+  })
+
+  it('summarizes linear, branched, and empty conversations', () => {
+    expect(summarizeAgentConversation([])).toMatchObject({
+      messageCount: 0,
+      status: 'empty',
+    })
+    expect(summarizeAgentConversation(messages)).toMatchObject({
+      messageCount: 2,
+      userCount: 1,
+      agentCount: 1,
+      status: 'linear',
+    })
+    expect(summarizeAgentConversation([
+      messages[0]!,
+      { id: 'm2', role: 'agent' as const, content: 'branch', timestamp: Date.now(), parentId: 'm1', branchLabel: 'v2' },
+    ])).toMatchObject({
+      branchCount: 1,
+      orphanCount: 0,
+      status: 'branched',
+    })
   })
 })

--- a/dashboard/src/components/common/agent-conversation.ts
+++ b/dashboard/src/components/common/agent-conversation.ts
@@ -13,6 +13,21 @@ export interface ConversationMessage {
   branchLabel?: string
 }
 
+export type AgentConversationStatus = 'empty' | 'linear' | 'branched' | 'orphaned'
+
+export interface AgentConversationSummary {
+  messageCount: number
+  userCount: number
+  agentCount: number
+  systemCount: number
+  toolCount: number
+  branchCount: number
+  orphanCount: number
+  firstTimestamp: number | null
+  latestTimestamp: number | null
+  status: AgentConversationStatus
+}
+
 interface AgentConversationProps {
   messages: ConversationMessage[]
   onSelectMessage?: (id: string) => void
@@ -21,15 +36,58 @@ interface AgentConversationProps {
 
 function formatTime(ts: number): string {
   const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return '--:--'
   return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+}
+
+function formatDateTime(ts: number): string | undefined {
+  const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return undefined
+  return d.toISOString()
+}
+
+export function summarizeAgentConversation(messages: ConversationMessage[]): AgentConversationSummary {
+  const ids = new Set(messages.map(msg => msg.id))
+  const userCount = messages.filter(msg => msg.role === 'user').length
+  const agentCount = messages.filter(msg => msg.role === 'agent').length
+  const systemCount = messages.filter(msg => msg.role === 'system').length
+  const toolCount = messages.filter(msg => msg.role === 'tool').length
+  const branchCount = messages.filter((msg, idx) => {
+    const prev = messages[idx - 1]
+    return msg.branchLabel !== undefined || (msg.parentId !== undefined && prev?.id !== msg.parentId)
+  }).length
+  const orphanCount = messages.filter(msg => msg.parentId !== undefined && !ids.has(msg.parentId)).length
+  const status: AgentConversationStatus =
+    messages.length === 0
+      ? 'empty'
+      : orphanCount > 0
+        ? 'orphaned'
+        : branchCount > 0
+          ? 'branched'
+          : 'linear'
+
+  return {
+    messageCount: messages.length,
+    userCount,
+    agentCount,
+    systemCount,
+    toolCount,
+    branchCount,
+    orphanCount,
+    firstTimestamp: messages[0]?.timestamp ?? null,
+    latestTimestamp: messages[messages.length - 1]?.timestamp ?? null,
+    status,
+  }
 }
 
 function MessageBubble({
   msg,
   onSelect,
+  isOrphan,
 }: {
   msg: ConversationMessage
   onSelect?: (id: string) => void
+  isOrphan?: boolean
 }) {
   const isUser = msg.role === 'user'
   const isSystem = msg.role === 'system'
@@ -42,7 +100,7 @@ function MessageBubble({
     : isTool
       ? 'bg-[var(--color-bg-surface)] text-[var(--color-fg-secondary)] text-xs border border-[var(--color-border-default)]'
       : isUser
-        ? 'ml-auto bg-[var(--color-accent)] text-[var(--color-fg-primary)]'
+        ? 'ml-auto border border-[var(--accent-30)] bg-[var(--accent-20)] text-[var(--color-accent-fg)]'
         : 'mr-auto bg-[var(--dialog-panel-bg)] text-[var(--color-fg-primary)] border border-[var(--dialog-panel-border)]'
 
   const alignCls = isUser ? 'items-end' : isSystem ? 'items-center' : 'items-start'
@@ -52,9 +110,14 @@ function MessageBubble({
       class="flex flex-col gap-0.5 ${alignCls}"
       aria-label="${msg.role} 메시지"
       data-message-id=${msg.id}
+      data-message-role=${msg.role}
+      data-message-parent-id=${msg.parentId ?? ''}
+      data-message-branch-label=${msg.branchLabel ?? ''}
+      data-message-orphan=${isOrphan ? 'true' : 'false'}
+      data-message-timestamp=${msg.timestamp}
     >
       ${msg.branchLabel
-        ? html`<span class="text-2xs text-[var(--color-accent)] font-mono">${msg.branchLabel}</span>`
+        ? html`<span class="text-2xs text-[var(--color-accent-fg)] font-mono">${msg.branchLabel}</span>`
         : null}
       <div
         class="${baseCls} ${roleCls}"
@@ -63,7 +126,7 @@ function MessageBubble({
       >
         ${msg.content}
       </div>
-      <time class="text-3xs text-[var(--color-fg-muted)]" datetime=${new Date(msg.timestamp).toISOString()}>
+      <time class="text-3xs text-[var(--color-fg-muted)]" datetime=${formatDateTime(msg.timestamp)}>
         ${formatTime(msg.timestamp)}
       </time>
     </article>
@@ -84,37 +147,94 @@ export function AgentConversation({
   onSelectMessage,
   testId,
 }: AgentConversationProps) {
+  const summary = summarizeAgentConversation(messages)
+
   if (messages.length === 0) {
     return html`
       <div
+        data-agent-conversation
+        data-agent-conversation-message-count=${summary.messageCount}
+        data-agent-conversation-user-count=${summary.userCount}
+        data-agent-conversation-agent-count=${summary.agentCount}
+        data-agent-conversation-system-count=${summary.systemCount}
+        data-agent-conversation-tool-count=${summary.toolCount}
+        data-agent-conversation-branch-count=${summary.branchCount}
+        data-agent-conversation-orphan-count=${summary.orphanCount}
+        data-agent-conversation-status=${summary.status}
+        data-agent-conversation-first-timestamp=${summary.firstTimestamp ?? ''}
+        data-agent-conversation-latest-timestamp=${summary.latestTimestamp ?? ''}
         data-testid=${testId}
-        class="flex h-32 items-center justify-center text-xs text-[var(--color-fg-muted)]"
+        class="space-y-2"
         role="region"
-        aria-label="에이전트 대화 기록"
+        aria-label="에이전트 대화 기록, 메시지 없음"
       >
-        대화 내용이 없습니다.
+        <${ConversationSummaryStrip} summary=${summary} />
+        <div class="flex h-32 items-center justify-center text-xs text-[var(--color-fg-muted)]">
+          대화 내용이 없습니다.
+        </div>
       </div>
     `
   }
 
+  const ids = new Set(messages.map(msg => msg.id))
+
   return html`
     <div
+      data-agent-conversation
+      data-agent-conversation-message-count=${summary.messageCount}
+      data-agent-conversation-user-count=${summary.userCount}
+      data-agent-conversation-agent-count=${summary.agentCount}
+      data-agent-conversation-system-count=${summary.systemCount}
+      data-agent-conversation-tool-count=${summary.toolCount}
+      data-agent-conversation-branch-count=${summary.branchCount}
+      data-agent-conversation-orphan-count=${summary.orphanCount}
+      data-agent-conversation-status=${summary.status}
+      data-agent-conversation-first-timestamp=${summary.firstTimestamp ?? ''}
+      data-agent-conversation-latest-timestamp=${summary.latestTimestamp ?? ''}
       data-testid=${testId}
-      class="flex flex-col gap-2 overflow-auto p-3"
-      role="feed"
-      aria-label="에이전트 대화 기록"
-      aria-busy="false"
+      class="space-y-2 overflow-auto p-3"
     >
-      ${messages.map((msg, idx) => {
-        const prev = messages[idx - 1]
-        const showConnector = msg.parentId && prev && prev.id !== msg.parentId
-        return html`
-          <div key=${msg.id}>
-            ${showConnector ? html`<${BranchConnector} parentId=${msg.parentId} />` : null}
-            <${MessageBubble} msg=${msg} onSelect=${onSelectMessage} />
-          </div>
-        `
-      })}
+      <${ConversationSummaryStrip} summary=${summary} />
+      <div
+        class="flex flex-col gap-2"
+        role="feed"
+        aria-label="에이전트 대화 기록, 메시지 ${summary.messageCount}개"
+        aria-busy="false"
+      >
+        ${messages.map((msg, idx) => {
+          const prev = messages[idx - 1]
+          const showConnector = msg.parentId && prev && prev.id !== msg.parentId
+          const isOrphan = msg.parentId !== undefined && !ids.has(msg.parentId)
+          return html`
+            <div key=${msg.id}>
+              ${showConnector ? html`<${BranchConnector} parentId=${msg.parentId} />` : null}
+              <${MessageBubble} msg=${msg} onSelect=${onSelectMessage} isOrphan=${isOrphan} />
+            </div>
+          `
+        })}
+      </div>
+    </div>
+  `
+}
+
+function ConversationSummaryStrip({ summary }: { summary: AgentConversationSummary }) {
+  return html`
+    <div
+      class="grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
+      aria-label="에이전트 대화 요약"
+    >
+      <div>
+        <div class="text-3xs text-[var(--color-fg-secondary)]">메시지</div>
+        <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.messageCount}</div>
+      </div>
+      <div>
+        <div class="text-3xs text-[var(--color-fg-secondary)]">분기</div>
+        <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.branchCount}</div>
+      </div>
+      <div>
+        <div class="text-3xs text-[var(--color-fg-secondary)]">도구</div>
+        <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.toolCount}</div>
+      </div>
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- export AgentConversation summary helpers and metadata for message role counts, branch edges, orphaned parent references, and timestamps
- render a compact conversation summary strip while preserving feed semantics on the message list
- expose row-level message metadata and replace the likely undefined user/branch accent token with semantic accent tokens

## Why it matters
AgentConversation showed useful timeline state but had no stable state surface for dashboard QA, and branch/orphan relationships were only implicit in rendered text/connector placement. This makes linear, branched, orphaned, and empty conversations directly inspectable without parsing bubbles.

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/agent-conversation.test.ts src/components/common/agent-conversation.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint (passes with 3 existing warnings outside this component)
- pnpm --dir dashboard run build (passes with existing Vite dynamic/static import and chunk-size warnings)
- Browser QA via Vite on 5210: desktop 820x760 and mobile 390x640; no horizontal overflow; linear/branched/orphaned/empty metadata checked; user bubble semantic accent color computed; click selection verified; no page errors

## Review focus
- Branch-count semantics: explicit branch label or non-previous parent edge, not every linear parentId
- Feed semantics with the summary strip outside the feed role
- Metadata attribute names for conversation and message-level dashboard QA