### PR TITLE
Resolve keeper sandbox repos by git remote

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -331,11 +331,50 @@ let read_file_opt path =
   try Some (In_channel.with_open_bin path In_channel.input_all)
   with Sys_error _ -> None
 
+let safe_file_exists path =
+  try Sys.file_exists path with Sys_error _ -> false
+
+let safe_is_directory path =
+  try Sys.is_directory path with Sys_error _ -> false
+
+let normalize_lexical_path path =
+  let absolute = String.starts_with ~prefix:"/" path in
+  let segments =
+    String.split_on_char '/' path
+    |> List.filter (fun segment ->
+         not (String.equal segment "" || String.equal segment "."))
+  in
+  let normalized =
+    List.fold_left
+      (fun acc segment ->
+        if String.equal segment ".." then
+          match acc with
+          | [] -> []
+          | _ :: rest -> rest
+        else
+          segment :: acc)
+      [] segments
+    |> List.rev
+  in
+  let body = String.concat "/" normalized in
+  if absolute then "/" ^ body else body
+
+let gitdir_config_path ~repo_root gitdir =
+  let gitdir =
+    if Filename.is_relative gitdir then Filename.concat repo_root gitdir
+    else gitdir
+  in
+  let repo_lane = Filename.dirname repo_root |> normalize_lexical_path in
+  let gitdir = normalize_lexical_path gitdir in
+  match relative_under ~root:repo_lane gitdir with
+  | None -> None
+  | Some _ -> Some (Filename.concat gitdir "config")
+
 let git_config_path_of_repo_root repo_root =
   let dot_git = Filename.concat repo_root ".git" in
-  if Sys.file_exists dot_git && Sys.is_directory dot_git then
+  if safe_file_exists dot_git && safe_is_directory dot_git then
     Some (Filename.concat dot_git "config")
-  else if Sys.file_exists dot_git then
+  else if safe_file_exists dot_git then
     match read_file_opt dot_git with
     | None -> None
     | Some content ->
@@ -348,12 +387,7 @@ let git_config_path_of_repo_root repo_root =
                  String.sub line 7 (String.length line - 7)
                  |> String.trim
                in
-               let gitdir =
-                 if Filename.is_relative gitdir then
-                   Filename.concat repo_root gitdir
-                 else gitdir
-               in
-               Some (Filename.concat gitdir "config")
+               gitdir_config_path ~repo_root gitdir
              else None)
   else
     None

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -287,7 +287,7 @@ let path_segments rel =
 type playground_path =
   | Playground_internal
   | Playground_repos_root
-  | Playground_repo of string
+  | Playground_repo of { segment : string; repo_root : string }
 
 let playground_path_of_path ~base_path ~path =
   let playground_root =
@@ -297,9 +297,19 @@ let playground_path_of_path ~base_path ~path =
   | None -> None
   | Some rel -> (
       match path_segments rel with
-      | "docker" :: _keeper :: "repos" :: repo_id :: _
-      | _keeper :: "repos" :: repo_id :: _ ->
-          Some (Playground_repo repo_id)
+      | "docker" :: keeper :: "repos" :: repo_id :: _ ->
+          let repo_root =
+            Filename.concat playground_root
+              (Filename.concat "docker"
+                 (Filename.concat keeper (Filename.concat "repos" repo_id)))
+          in
+          Some (Playground_repo { segment = repo_id; repo_root })
+      | keeper :: "repos" :: repo_id :: _ ->
+          let repo_root =
+            Filename.concat playground_root
+              (Filename.concat keeper (Filename.concat "repos" repo_id))
+          in
+          Some (Playground_repo { segment = repo_id; repo_root })
       | "docker" :: _keeper :: ["repos"]
       | _keeper :: ["repos"] ->
           Some Playground_repos_root
@@ -317,7 +327,83 @@ let repository_url_basename url =
       String.sub base 0 (String.length base - 4)
     else base
 
-let resolve_repository_id_segment ~base_path segment =
+let read_file_opt path =
+  try Some (In_channel.with_open_bin path In_channel.input_all)
+  with Sys_error _ -> None
+
+let git_config_path_of_repo_root repo_root =
+  let dot_git = Filename.concat repo_root ".git" in
+  if Sys.file_exists dot_git && Sys.is_directory dot_git then
+    Some (Filename.concat dot_git "config")
+  else if Sys.file_exists dot_git then
+    match read_file_opt dot_git with
+    | None -> None
+    | Some content ->
+        content
+        |> String.split_on_char '\n'
+        |> List.find_map (fun line ->
+             let line = String.trim line in
+             if String.starts_with ~prefix:"gitdir:" line then
+               let gitdir =
+                 String.sub line 7 (String.length line - 7)
+                 |> String.trim
+               in
+               let gitdir =
+                 if Filename.is_relative gitdir then
+                   Filename.concat repo_root gitdir
+                 else gitdir
+               in
+               Some (Filename.concat gitdir "config")
+             else None)
+  else
+    None
+
+let remote_origin_url_of_repo_root repo_root =
+  match git_config_path_of_repo_root repo_root with
+  | None -> None
+  | Some config_path -> (
+      match read_file_opt config_path with
+      | None -> None
+      | Some content ->
+          let rec loop in_origin = function
+            | [] -> None
+            | line :: rest ->
+                let line = String.trim line in
+                if String.starts_with ~prefix:"[" line then
+                  loop (String.equal line {|[remote "origin"]|}) rest
+                else if in_origin && String.starts_with ~prefix:"url" line then
+                  (match String.index_opt line '=' with
+                   | None -> loop in_origin rest
+                   | Some idx ->
+                       let value =
+                         String.sub line (idx + 1)
+                           (String.length line - idx - 1)
+                         |> String.trim
+                       in
+                       if value = "" then loop in_origin rest else Some value)
+                else
+                  loop in_origin rest
+          in
+          loop false (String.split_on_char '\n' content))
+
+let repository_matches_token ~base_path token (repo : repository) =
+  String.equal repo.id token
+  || String.equal repo.name token
+  || String.equal (repository_url_basename repo.url) token
+  || String.equal
+       (basename_of_path (Repo_store.local_path ~base_path repo))
+       token
+
+let repository_matches_remote_url ~remote_url (repo : repository) =
+  let remote_basename = repository_url_basename remote_url in
+  remote_url <> ""
+  && (String.equal repo.url remote_url
+      || (remote_basename <> ""
+          && (String.equal repo.id remote_basename
+              || String.equal repo.name remote_basename
+              || String.equal (repository_url_basename repo.url) remote_basename)))
+
+let resolve_repository_id_segment ~base_path ?repo_root segment =
   match Repo_store.load_all ~base_path with
   | Error msg ->
       Log.Misc.warn
@@ -328,17 +414,17 @@ let resolve_repository_id_segment ~base_path segment =
   | Ok repos -> (
       match
         List.find_opt
-          (fun (repo : repository) ->
-            String.equal repo.id segment
-            || String.equal repo.name segment
-            || String.equal (repository_url_basename repo.url) segment
-            || String.equal
-                 (basename_of_path (Repo_store.local_path ~base_path repo))
-                 segment)
+          (repository_matches_token ~base_path segment)
           repos
       with
       | Some repo -> repo.id
-      | None -> segment)
+      | None -> (
+          match Option.bind repo_root remote_origin_url_of_repo_root with
+          | None -> segment
+          | Some remote_url -> (
+              match List.find_opt (repository_matches_remote_url ~remote_url) repos with
+              | Some repo -> repo.id
+              | None -> segment)))
 
 (** [path_under_repo ~base_path repo path] returns [true] when [path]
     is equal to or strictly under [repo]'s resolved local_path. *)
@@ -355,8 +441,8 @@ let path_under_repo ~base_path repo path =
 let repository_id_of_path ~base_path ~path =
   match playground_path_of_path ~base_path ~path with
   | Some Playground_internal | Some Playground_repos_root -> None
-  | Some (Playground_repo repo_id) ->
-      Some (resolve_repository_id_segment ~base_path repo_id)
+  | Some (Playground_repo { segment; repo_root }) ->
+      Some (resolve_repository_id_segment ~base_path ~repo_root segment)
   | None -> (
   match Repo_store.load_all ~base_path with
   | Error msg ->

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -103,6 +103,18 @@ let write_repositories base_path repos =
   let oc = open_out path in
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
 
+let write_git_origin repo_root url =
+  let git_dir = Filename.concat repo_root ".git" in
+  ensure_dir git_dir;
+  let config_path = Filename.concat git_dir "config" in
+  let content =
+    Printf.sprintf "[remote \"origin\"]\n\turl = %s\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n" url
+  in
+  let oc = open_out config_path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
 let repo_under_base base_path id =
   let local_path = Filename.concat base_path ("repo-" ^ id) in
   Unix.mkdir local_path 0o755;
@@ -303,6 +315,37 @@ let test_validate_path_access_playground_repo_uses_url_basename () =
       | Error e ->
           Alcotest.fail
             ("expected playground repo path to resolve by repository URL basename, got: "
+             ^ e))
+
+let test_validate_path_access_playground_unique_clone_uses_git_remote () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repo_root =
+        Filename.concat base_path
+          ".masc/playground/docker/executor/repos/keeper-direct-clone-proof-0506"
+      in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      write_git_origin repo_root "https://github.com/jeong-sik/masc-mcp.git";
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected unique playground clone to resolve by git remote, got: "
              ^ e))
 
 let test_validate_path_access_playground_unknown_repo_denied () =
@@ -625,6 +668,8 @@ let () =
             test_validate_path_access_playground_repo_uses_registered_name;
           Alcotest.test_case "playground repo resolves repository URL basename" `Quick
             test_validate_path_access_playground_repo_uses_url_basename;
+          Alcotest.test_case "playground unique clone resolves git remote" `Quick
+            test_validate_path_access_playground_unique_clone_uses_git_remote;
           Alcotest.test_case "playground unknown repo denied" `Quick
             test_validate_path_access_playground_unknown_repo_denied;
         ] );

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -58,6 +58,13 @@ let rec ensure_dir path =
     Unix.mkdir path 0o755
   end
 
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
 let write_mapping ?credential_id base_path keeper_id repo_ids =
   let path = Filename.concat base_path ".masc/config/keeper_repo_mappings.toml" in
   let entries =
@@ -110,10 +117,15 @@ let write_git_origin repo_root url =
   let content =
     Printf.sprintf "[remote \"origin\"]\n\turl = %s\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n" url
   in
-  let oc = open_out config_path in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> output_string oc content)
+  write_file config_path content
+
+let write_gitdir_origin repo_root ~gitdir_ref ~gitdir_path ~url =
+  write_file (Filename.concat repo_root ".git")
+    (Printf.sprintf "gitdir: %s\n" gitdir_ref);
+  write_file (Filename.concat gitdir_path "config")
+    (Printf.sprintf
+       "[remote \"origin\"]\n\turl = %s\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+       url)
 
 let repo_under_base base_path id =
   let local_path = Filename.concat base_path ("repo-" ^ id) in
@@ -347,6 +359,110 @@ let test_validate_path_access_playground_unique_clone_uses_git_remote () =
           Alcotest.fail
             ("expected unique playground clone to resolve by git remote, got: "
              ^ e))
+
+let test_validate_path_access_playground_gitdir_relative_uses_git_remote () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repos_root =
+        Filename.concat base_path ".masc/playground/docker/executor/repos"
+      in
+      let repo_root = Filename.concat repos_root "linked-worktree" in
+      let gitdir_path = Filename.concat repos_root "linked-worktree-gitdir" in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      write_gitdir_origin repo_root
+        ~gitdir_ref:"../linked-worktree-gitdir"
+        ~gitdir_path
+        ~url:"https://github.com/jeong-sik/masc-mcp.git";
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected relative gitdir file to resolve by git remote, got: "
+             ^ e))
+
+let test_validate_path_access_playground_gitdir_absolute_under_sandbox_uses_git_remote () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repos_root =
+        Filename.concat base_path ".masc/playground/docker/executor/repos"
+      in
+      let repo_root = Filename.concat repos_root "absolute-worktree" in
+      let gitdir_path = Filename.concat repos_root "absolute-worktree-gitdir" in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      write_gitdir_origin repo_root
+        ~gitdir_ref:gitdir_path
+        ~gitdir_path
+        ~url:"https://github.com/jeong-sik/masc-mcp.git";
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected absolute in-sandbox gitdir file to resolve by git remote, got: "
+             ^ e))
+
+let test_validate_path_access_playground_gitdir_escape_denied () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repos_root =
+        Filename.concat base_path ".masc/playground/docker/executor/repos"
+      in
+      let repo_root = Filename.concat repos_root "escaping-worktree" in
+      let outside_gitdir = Filename.concat base_path "outside-gitdir" in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      write_gitdir_origin repo_root
+        ~gitdir_ref:outside_gitdir
+        ~gitdir_path:outside_gitdir
+        ~url:"https://github.com/jeong-sik/masc-mcp.git";
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> Alcotest.fail "expected gitdir escape to be denied"
+      | Error msg ->
+          Alcotest.(check bool)
+            "mentions not allowed" true (contains_substring msg "not allowed"))
 
 let test_validate_path_access_playground_unknown_repo_denied () =
   with_temp_base_path (fun base_path ->
@@ -670,6 +786,12 @@ let () =
             test_validate_path_access_playground_repo_uses_url_basename;
           Alcotest.test_case "playground unique clone resolves git remote" `Quick
             test_validate_path_access_playground_unique_clone_uses_git_remote;
+          Alcotest.test_case "playground relative gitdir resolves git remote" `Quick
+            test_validate_path_access_playground_gitdir_relative_uses_git_remote;
+          Alcotest.test_case "playground absolute in-sandbox gitdir resolves git remote" `Quick
+            test_validate_path_access_playground_gitdir_absolute_under_sandbox_uses_git_remote;
+          Alcotest.test_case "playground escaping gitdir is denied" `Quick
+            test_validate_path_access_playground_gitdir_escape_denied;
           Alcotest.test_case "playground unknown repo denied" `Quick
             test_validate_path_access_playground_unknown_repo_denied;
         ] );


### PR DESCRIPTION
## What
- Resolve keeper playground repository paths by the sandbox clone directory name first, preserving the existing registered-name behavior.
- When the clone directory name is not registered, read its git `remote.origin.url` and map that URL back to the registered repository.
- Keep `.git` directory/file probes fail-safe and bound `gitdir:` pointers to the keeper playground repo lane so a corrupted clone cannot make access checks read arbitrary host config files.
- Add regression coverage for unique clone origin resolution, `.git` file relative/absolute in-lane pointers, and escaping gitdir denial.

## Why
#13568 live tool-call receipts showed keeper filesystem writes denied as repository access failures even though `/Users/dancer/me/.masc/config/keeper_repo_mappings.toml` already grants the keeper access to `masc-mcp`. The failing workflow clones repositories into unique proof/work directories under `repos/`, so the access check was treating that arbitrary directory segment as the repository id.

This keeps repository ACLs enforced while allowing valid sandbox clones to resolve by their actual git origin. It also keeps worktree-style `.git` files inside the sandbox boundary.

Tracks #13568.

## Validation
- ocamlc -stop-after parsing lib/repo_manager/keeper_repo_mapping.ml test/test_keeper_repo_mapping.ml
- git diff --check
- focused Dune not rerun locally because /tmp/me-opam-switch.lock and /tmp/me-dune-local.lock are held by other sessions; draft CI is the current full verification surface