### PR TITLE
fix(server): observe workspace route failures

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -872,6 +872,7 @@ let metric_after_turn_telemetry_zero_latency =
 let metric_tasks = "masc_tasks_total"
 let metric_errors = "masc_errors_total"
 let metric_error_events = "masc_error_events_total"
+let metric_workspace_route_failures = "masc_workspace_route_failures_total"
 let metric_active_agents = "masc_active_agents"
 let metric_pending_tasks = "masc_pending_tasks"
 let metric_uptime_seconds = "masc_uptime_seconds"
@@ -1287,6 +1288,9 @@ let init () =
   add metric_errors "Total errors" Counter;
   add metric_error_events
     "Error events by type (parsing, missing_config, etc.)" Counter;
+  add metric_workspace_route_failures
+    "Total workspace route filesystem/git/read exceptions, labeled by site"
+    Counter;
   add metric_active_agents "Currently active agents" Gauge;
   add metric_pending_tasks "Tasks waiting to be claimed" Gauge;
   add metric_uptime_seconds "Server uptime in seconds" Gauge;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -441,6 +441,7 @@ val metric_after_turn_telemetry_zero_latency : string
 val metric_tasks : string
 val metric_errors : string
 val metric_error_events : string
+val metric_workspace_route_failures : string
 val metric_active_agents : string
 val metric_pending_tasks : string
 val metric_uptime_seconds : string

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -6,6 +6,18 @@ module Http = Http_server_eio
 
 let base_path_of_state state = state.Mcp_server.room_config.base_path
 
+let sanitize_log_value ?(max_bytes = 240) s =
+  let without_controls =
+    String.map
+      (fun c ->
+        let code = Char.code c in
+        if code < 0x20 || code = 0x7f then '_' else c)
+      s
+  in
+  String_util.utf8_safe ~max_bytes:(max_bytes + 3) ~suffix:"..."
+    without_controls
+  |> String_util.to_string
+
 let observe_workspace_route_failure ~site ~path exn =
   match exn with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -14,7 +26,9 @@ let observe_workspace_route_failure ~site ~path exn =
         ~labels:[("site", site)]
         ();
       Log.Server.warn "workspace route %s failed path=%s err=%s"
-        site path (Printexc.to_string exn)
+        (sanitize_log_value ~max_bytes:64 site)
+        (sanitize_log_value ~max_bytes:180 path)
+        (sanitize_log_value (Printexc.to_string exn))
 
 let workspace_or_default ~site ~path ~default f =
   try f () with
@@ -24,6 +38,7 @@ let workspace_or_default ~site ~path ~default f =
       default
 
 module For_testing = struct
+  let sanitize_log_value = sanitize_log_value
   let observe_workspace_route_failure = observe_workspace_route_failure
 end
 

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -14,7 +14,7 @@ let sanitize_log_value ?(max_bytes = 240) s =
         if code < 0x20 || code = 0x7f then '_' else c)
       s
   in
-  String_util.utf8_safe ~max_bytes:(max_bytes + 3) ~suffix:"..."
+  String_util.utf8_safe ~max_bytes ~suffix:"..."
     without_controls
   |> String_util.to_string
 
@@ -22,11 +22,12 @@ let observe_workspace_route_failure ~site ~path exn =
   match exn with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
+      let site = sanitize_log_value ~max_bytes:64 site in
       Prometheus.inc_counter Prometheus.metric_workspace_route_failures
         ~labels:[("site", site)]
         ();
       Log.Server.warn "workspace route %s failed path=%s err=%s"
-        (sanitize_log_value ~max_bytes:64 site)
+        site
         (sanitize_log_value ~max_bytes:180 path)
         (sanitize_log_value (Printexc.to_string exn))
 

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -18,24 +18,28 @@ let sanitize_log_value ?(max_bytes = 240) s =
     without_controls
   |> String_util.to_string
 
-let observe_workspace_route_failure ~site ~path exn =
+let observe_workspace_route_failure ?(warn_on_failure = true) ~site ~path exn =
   match exn with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       let site = sanitize_log_value ~max_bytes:64 site in
+      let path = sanitize_log_value ~max_bytes:180 path in
+      let error = sanitize_log_value (Printexc.to_string exn) in
       Prometheus.inc_counter Prometheus.metric_workspace_route_failures
         ~labels:[("site", site)]
         ();
-      Log.Server.warn "workspace route %s failed path=%s err=%s"
-        site
-        (sanitize_log_value ~max_bytes:180 path)
-        (sanitize_log_value (Printexc.to_string exn))
+      if warn_on_failure then
+        Log.Server.warn "workspace route %s failed path=%s err=%s"
+          site path error
+      else
+        Log.Server.debug "workspace route %s failed path=%s err=%s"
+          site path error
 
-let workspace_or_default ~site ~path ~default f =
+let workspace_or_default ?(warn_on_failure = true) ~site ~path ~default f =
   try f () with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      observe_workspace_route_failure ~site ~path exn;
+      observe_workspace_route_failure ~warn_on_failure ~site ~path exn;
       default
 
 module For_testing = struct
@@ -299,6 +303,7 @@ let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
           let full = Filename.concat dir f in
           let is_dir =
             workspace_or_default
+              ~warn_on_failure:false
               ~site:"tree_is_directory"
               ~path:full
               ~default:false

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -6,6 +6,27 @@ module Http = Http_server_eio
 
 let base_path_of_state state = state.Mcp_server.room_config.base_path
 
+let observe_workspace_route_failure ~site ~path exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Prometheus.inc_counter Prometheus.metric_workspace_route_failures
+        ~labels:[("site", site)]
+        ();
+      Log.Server.warn "workspace route %s failed path=%s err=%s"
+        site path (Printexc.to_string exn)
+
+let workspace_or_default ~site ~path ~default f =
+  try f () with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      observe_workspace_route_failure ~site ~path exn;
+      default
+
+module For_testing = struct
+  let observe_workspace_route_failure = observe_workspace_route_failure
+end
+
 (* Pure classification of the [?keeper=<name>] query param into a
    workspace base directory plus a source tag.
 
@@ -246,8 +267,11 @@ let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
   if depth > max_depth || remaining <= 0 then (acc, remaining)
   else
     let entries =
-      try Sys.readdir dir |> Array.to_list
-      with _ -> []
+      workspace_or_default
+        ~site:"tree_readdir"
+        ~path:dir
+        ~default:[]
+        (fun () -> Sys.readdir dir |> Array.to_list)
     in
     let rec fold acc remaining = function
       | [] -> (acc, remaining)
@@ -257,7 +281,13 @@ let rec scan_dir_bounded ~base ~depth ~max_depth ~remaining acc dir =
         else if List.mem f excluded_dirs then fold acc remaining rest
         else
           let full = Filename.concat dir f in
-          let is_dir = try Sys.is_directory full with _ -> false in
+          let is_dir =
+            workspace_or_default
+              ~site:"tree_is_directory"
+              ~path:full
+              ~default:false
+              (fun () -> Sys.is_directory full)
+          in
           let rel = rel_under base full in
           let has_children = is_dir && depth < max_depth in
           let parent = if depth = 0 then "" else Filename.dirname rel in
@@ -296,7 +326,14 @@ let git_run ~cwd args =
     match status with
     | Unix.WEXITED 0 -> Some (String.trim out)
     | _ -> None
-  with _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      observe_workspace_route_failure
+        ~site:"git_run"
+        ~path:cwd
+        exn;
+      None
 
 let git_run_lines ~cwd args =
   match git_run ~cwd args with
@@ -489,7 +526,14 @@ let add_routes router =
                    let content = Fs_compat.load_file path in
                    let json = `Assoc [("ok", `Bool true); ("content", `String content)] in
                    json_response_with_source ~status:`OK ~source request reqd json
-                 with _ -> json_response ~status:`Internal_server_error request reqd (json_error "Failed to read file")
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                     observe_workspace_route_failure
+                       ~site:"file_read"
+                       ~path
+                       exn;
+                     json_response ~status:`Internal_server_error request reqd (json_error "Failed to read file")
                else
                  json_response ~status:`Not_found request reqd (json_error "File not found"))
          request reqd)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -77,3 +77,8 @@ val scan_dir :
     ["-"]. Used to refuse query-string values that could be parsed as
     git options (e.g. [?base_ref=-L1,9999]). Exposed for unit testing. *)
 val valid_git_ref : string -> bool
+
+module For_testing : sig
+  val observe_workspace_route_failure :
+    site:string -> path:string -> exn -> unit
+end

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -79,6 +79,11 @@ val scan_dir :
 val valid_git_ref : string -> bool
 
 module For_testing : sig
+  (** White-box helpers for route-level regression tests. Not part of the
+      stable/public workspace API. *)
+
+  val sanitize_log_value : ?max_bytes:int -> string -> string
+
   val observe_workspace_route_failure :
     site:string -> path:string -> exn -> unit
 end

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -85,5 +85,5 @@ module For_testing : sig
   val sanitize_log_value : ?max_bytes:int -> string -> string
 
   val observe_workspace_route_failure :
-    site:string -> path:string -> exn -> unit
+    ?warn_on_failure:bool -> site:string -> path:string -> exn -> unit
 end

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -298,6 +298,15 @@ let test_bg_task_sidecar_metric_registered () =
     (text_has_literal text
        ("# TYPE " ^ Prometheus.metric_bg_task_sidecar_failures ^ " counter"))
 
+let test_workspace_route_metric_registered () =
+  let text = Prometheus.to_prometheus_text () in
+  check bool "has workspace route failure HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_workspace_route_failures ^ " "));
+  check bool "has workspace route failure TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_workspace_route_failures ^ " counter"))
+
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
   Prometheus.register_histogram ~name ~help:"export format test" ();
@@ -473,6 +482,8 @@ let () =
         test_distributed_lock_metric_registered;
       test_case "bg task sidecar metric registered" `Quick
         test_bg_task_sidecar_metric_registered;
+      test_case "workspace route metric registered" `Quick
+        test_workspace_route_metric_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
     ];

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -13,6 +13,7 @@
      - [`KeeperUnknown]      — no keeper meta for the given name *)
 
 module W = Masc_mcp.Server_routes_http_routes_workspace
+module P = Masc_mcp.Prometheus
 
 let project = "/repo"
 let repository_root = "/repo/.masc/repos/masc"
@@ -356,6 +357,31 @@ let test_tree_node_limit_signed_lone_underscore_is_junk () =
     750
     (W.tree_node_limit_of_query (Some "+_"))
 
+let test_workspace_failure_observer_increments_metric () =
+  let labels = [("site", "unit_test")] in
+  let before =
+    P.metric_value_or_zero P.metric_workspace_route_failures ~labels ()
+  in
+  W.For_testing.observe_workspace_route_failure
+    ~site:"unit_test"
+    ~path:"/tmp/missing"
+    (Failure "synthetic workspace failure");
+  let after =
+    P.metric_value_or_zero P.metric_workspace_route_failures ~labels ()
+  in
+  Alcotest.(check (float 0.0001))
+    "workspace route failure counted" (before +. 1.0) after
+
+let test_workspace_failure_observer_reraises_cancelled () =
+  let raised = ref false in
+  (try
+     W.For_testing.observe_workspace_route_failure
+       ~site:"unit_test_cancel"
+       ~path:"/tmp/missing"
+       (Eio.Cancel.Cancelled (Failure "synthetic cancel"))
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  Alcotest.(check bool) "cancel is re-raised" true !raised
+
 (* ─── valid_git_ref (option-injection guard) ────────────────────── *)
 
 let test_valid_ref_main () =
@@ -456,6 +482,10 @@ let () =
         ; Alcotest.test_case "limit leading underscore is junk" `Quick test_tree_node_limit_leading_underscore_is_junk
         ; Alcotest.test_case "limit double underscore is junk" `Quick test_tree_node_limit_double_underscore_is_junk
         ; Alcotest.test_case "limit signed lone underscore is junk" `Quick test_tree_node_limit_signed_lone_underscore_is_junk
+        ; Alcotest.test_case "failure observer increments metric" `Quick
+            test_workspace_failure_observer_increments_metric
+        ; Alcotest.test_case "failure observer re-raises cancel" `Quick
+            test_workspace_failure_observer_reraises_cancelled
         ] )
     ; ( "valid_git_ref"
       , [ Alcotest.test_case "main"              `Quick test_valid_ref_main

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -26,6 +26,18 @@ let lookup_for known name = if name = known then Some playground_root else None
 let lookup_repo_for known name = if name = known then Some repository_root else None
 let exists_only path expected = path = expected
 
+let contains needle haystack =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  if nlen = 0 then true
+  else
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
 let test_no_param () =
   let (base, src) =
     W.classify_keeper_query
@@ -372,6 +384,17 @@ let test_workspace_failure_observer_increments_metric () =
   Alcotest.(check (float 0.0001))
     "workspace route failure counted" (before +. 1.0) after
 
+let test_workspace_log_value_sanitizer_bounds_controlled_text () =
+  let sanitized =
+    W.For_testing.sanitize_log_value ~max_bytes:12
+      "alpha\nbeta\radmin\ttrail-with-extra"
+  in
+  Alcotest.(check bool) "newlines removed" false (contains "\n" sanitized);
+  Alcotest.(check bool) "carriage returns removed" false
+    (contains "\r" sanitized);
+  Alcotest.(check bool) "tabs removed" false (contains "\t" sanitized);
+  Alcotest.(check bool) "bounded with suffix" true (contains "..." sanitized)
+
 let test_workspace_failure_observer_reraises_cancelled () =
   let raised = ref false in
   (try
@@ -484,6 +507,8 @@ let () =
         ; Alcotest.test_case "limit signed lone underscore is junk" `Quick test_tree_node_limit_signed_lone_underscore_is_junk
         ; Alcotest.test_case "failure observer increments metric" `Quick
             test_workspace_failure_observer_increments_metric
+        ; Alcotest.test_case "log sanitizer bounds controlled text" `Quick
+            test_workspace_log_value_sanitizer_bounds_controlled_text
         ; Alcotest.test_case "failure observer re-raises cancel" `Quick
             test_workspace_failure_observer_reraises_cancelled
         ] )

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -389,11 +389,35 @@ let test_workspace_log_value_sanitizer_bounds_controlled_text () =
     W.For_testing.sanitize_log_value ~max_bytes:12
       "alpha\nbeta\radmin\ttrail-with-extra"
   in
+  Alcotest.(check bool) "within requested byte budget" true
+    (String.length sanitized <= 12);
   Alcotest.(check bool) "newlines removed" false (contains "\n" sanitized);
   Alcotest.(check bool) "carriage returns removed" false
     (contains "\r" sanitized);
   Alcotest.(check bool) "tabs removed" false (contains "\t" sanitized);
   Alcotest.(check bool) "bounded with suffix" true (contains "..." sanitized)
+
+let test_workspace_failure_observer_bounds_site_label () =
+  let raw_site = "unit\n" ^ String.make 100 'x' in
+  let site = W.For_testing.sanitize_log_value ~max_bytes:64 raw_site in
+  let labels = [("site", site)] in
+  let before =
+    P.metric_value_or_zero P.metric_workspace_route_failures ~labels ()
+  in
+  W.For_testing.observe_workspace_route_failure
+    ~site:raw_site
+    ~path:"/tmp/missing"
+    (Failure "synthetic workspace failure");
+  let after =
+    P.metric_value_or_zero P.metric_workspace_route_failures ~labels ()
+  in
+  Alcotest.(check bool) "site label has no newline" false
+    (contains "\n" site);
+  Alcotest.(check bool) "site label is bounded" true
+    (String.length site <= 64);
+  Alcotest.(check (float 0.0001))
+    "workspace route failure counted under sanitized site"
+    (before +. 1.0) after
 
 let test_workspace_failure_observer_reraises_cancelled () =
   let raised = ref false in
@@ -509,6 +533,8 @@ let () =
             test_workspace_failure_observer_increments_metric
         ; Alcotest.test_case "log sanitizer bounds controlled text" `Quick
             test_workspace_log_value_sanitizer_bounds_controlled_text
+        ; Alcotest.test_case "failure observer bounds site label" `Quick
+            test_workspace_failure_observer_bounds_site_label
         ; Alcotest.test_case "failure observer re-raises cancel" `Quick
             test_workspace_failure_observer_reraises_cancelled
         ] )

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -384,6 +384,22 @@ let test_workspace_failure_observer_increments_metric () =
   Alcotest.(check (float 0.0001))
     "workspace route failure counted" (before +. 1.0) after
 
+let test_workspace_failure_observer_counts_when_warn_suppressed () =
+  let labels = [("site", "unit_test_debug")] in
+  let before =
+    P.metric_value_or_zero P.metric_workspace_route_failures ~labels ()
+  in
+  W.For_testing.observe_workspace_route_failure
+    ~warn_on_failure:false
+    ~site:"unit_test_debug"
+    ~path:"/tmp/racy-entry"
+    (Failure "synthetic per-entry workspace failure");
+  let after =
+    P.metric_value_or_zero P.metric_workspace_route_failures ~labels ()
+  in
+  Alcotest.(check (float 0.0001))
+    "workspace route failure counted without WARN" (before +. 1.0) after
+
 let test_workspace_log_value_sanitizer_bounds_controlled_text () =
   let sanitized =
     W.For_testing.sanitize_log_value ~max_bytes:12
@@ -531,6 +547,8 @@ let () =
         ; Alcotest.test_case "limit signed lone underscore is junk" `Quick test_tree_node_limit_signed_lone_underscore_is_junk
         ; Alcotest.test_case "failure observer increments metric" `Quick
             test_workspace_failure_observer_increments_metric
+        ; Alcotest.test_case "failure observer counts when warn suppressed" `Quick
+            test_workspace_failure_observer_counts_when_warn_suppressed
         ; Alcotest.test_case "log sanitizer bounds controlled text" `Quick
             test_workspace_log_value_sanitizer_bounds_controlled_text
         ; Alcotest.test_case "failure observer bounds site label" `Quick


### PR DESCRIPTION
## Summary
- add a workspace route failure observer that increments `masc_workspace_route_failures_total` by bounded `site` label and logs the failing path/error
- route `scan_dir` readdir/is-directory exceptions, `git_run` exceptions, and file-read exceptions through the observer while preserving existing fallback behavior (`[]`, `false`, `None`, and 500)
- expose a small `For_testing` hook and add regression coverage for metric increment, cancellation re-raise, and Prometheus registration

## Why
These workspace route paths previously swallowed filesystem/git/read exceptions silently. This keeps the user-facing fallback contracts intact while making the failure boundary visible to telemetry/logs, and it preserves cancellation semantics by re-raising `Eio.Cancel.Cancelled`.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_workspace_routes_keeper.exe test/test_prometheus_coverage.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-workspace-route-observe-0506-a MASC_BASE_PATH_INPUT=/private/tmp/masc-workspace-route-observe-0506-a ./_build/default/test/test_workspace_routes_keeper.exe test scan_dir 15`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-workspace-route-observe-0506-b MASC_BASE_PATH_INPUT=/private/tmp/masc-workspace-route-observe-0506-b ./_build/default/test/test_workspace_routes_keeper.exe test scan_dir 16`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-workspace-route-observe-0506-c MASC_BASE_PATH_INPUT=/private/tmp/masc-workspace-route-observe-0506-c ./_build/default/test/test_prometheus_coverage.exe test to_prometheus_text 9`