### PR TITLE
fix(dashboard): expose agent memory summary state

### DIFF
--- a/dashboard/src/components/common/agent-memory.a11y.test.ts
+++ b/dashboard/src/components/common/agent-memory.a11y.test.ts
@@ -90,7 +90,10 @@ describe('AgentMemory a11y', () => {
   it('has list roles for memory sections', () => {
     render(html`<${AgentMemory} entries=${makeEntries()} />`, container)
     const lists = container.querySelectorAll('[role="list"]')
+    const root = container.querySelector('[data-agent-memory]') as HTMLElement
     expect(lists.length).toBe(2)
+    expect(root.dataset.agentMemoryStatus).toBe('mixed')
+    expect(root.getAttribute('aria-label')).toContain('에이전트 메모리')
   })
 
   it('renders short-term content in recency order', () => {
@@ -103,5 +106,19 @@ describe('AgentMemory a11y', () => {
     render(html`<${AgentMemory} entries=${makeEntries()} />`, container)
     expect(container.textContent).toContain('preferences')
     expect(container.textContent).toContain('schema')
+    const clusters = container.querySelectorAll('[data-memory-cluster]')
+    expect(clusters.length).toBe(2)
+    expect((clusters[0] as HTMLElement).dataset.memoryClusterCount).toBe('1')
+  })
+
+  it('exposes entry timestamps and empty section text', () => {
+    render(html`<${AgentMemory} entries=${[]} />`, container)
+    expect(container.textContent).toContain('단기 기억 없음')
+    expect(container.textContent).toContain('장기 기억 없음')
+
+    render(html`<${AgentMemory} entries=${makeEntries()} />`, container)
+    const firstShort = container.querySelector('[data-memory-entry-type="short_term"]') as HTMLElement
+    expect(firstShort.dataset.memoryEntryTimestamp).toBeTruthy()
+    expect(firstShort.querySelector('time')?.getAttribute('datetime')).toBeTruthy()
   })
 })

--- a/dashboard/src/components/common/agent-memory.test.ts
+++ b/dashboard/src/components/common/agent-memory.test.ts
@@ -135,4 +135,14 @@ describe('AgentMemory', () => {
     expect(groupByCluster(entries.slice(2)).A?.length).toBe(2)
     expect(getVisibleShortTermMemory(entries).map(entry => entry.id)).toEqual(['e1', 'e2'])
   })
+
+  it('ignores invalid timestamps when summarizing latest memory', () => {
+    const summary = summarizeAgentMemory([
+      { id: 'bad', content: 'bad', type: 'long_term', timestamp: Number.NaN },
+      { id: 'ok', content: 'ok', type: 'short_term', timestamp: 42 },
+      { id: 'infinite', content: 'infinite', type: 'short_term', timestamp: Infinity },
+    ])
+
+    expect(summary.latestTimestamp).toBe(42)
+  })
 })

--- a/dashboard/src/components/common/agent-memory.test.ts
+++ b/dashboard/src/components/common/agent-memory.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentMemory } from './agent-memory'
+import {
+  AgentMemory,
+  getVisibleShortTermMemory,
+  groupByCluster,
+  summarizeAgentMemory,
+} from './agent-memory'
 
 const entries = [
   { id: 'e1', content: 'recent', type: 'short_term' as const, timestamp: Date.now() },
@@ -14,7 +19,10 @@ describe('AgentMemory', () => {
   it('renders container', () => {
     const container = document.createElement('div')
     render(h(AgentMemory, { entries: [] }), container)
-    expect(container.querySelector('[data-agent-memory]')).not.toBeNull()
+    const root = container.querySelector('[data-agent-memory]') as HTMLElement
+    expect(root).not.toBeNull()
+    expect(root.dataset.agentMemoryStatus).toBe('empty')
+    expect(root.dataset.agentMemoryTotalCount).toBe('0')
   })
 
   it('renders short term section', () => {
@@ -27,6 +35,7 @@ describe('AgentMemory', () => {
     const container = document.createElement('div')
     render(h(AgentMemory, { entries }), container)
     expect(container.textContent).toContain('장기 기억')
+    expect(container.textContent).toContain('1개 클러스터')
   })
 
   it('renders short term entries', () => {
@@ -42,6 +51,8 @@ describe('AgentMemory', () => {
     const list = container.querySelector('[aria-label="단기 기억 목록"]')
     const items = list?.querySelectorAll('[role="listitem"]')
     expect(items?.length).toBe(2)
+    expect((items?.[0] as HTMLElement).dataset.memoryEntryId).toBe('e1')
+    expect((items?.[0] as HTMLElement).dataset.memoryEntryRecencyIndex).toBe('0')
   })
 
   it('renders long term clusters', () => {
@@ -55,6 +66,8 @@ describe('AgentMemory', () => {
     const unc = [{ id: 'e5', content: 'x', type: 'long_term' as const, timestamp: Date.now() }]
     render(h(AgentMemory, { entries: unc }), container)
     expect(container.textContent).toContain('미분류')
+    const root = container.querySelector('[data-agent-memory]') as HTMLElement
+    expect(root.dataset.agentMemoryUnclusteredCount).toBe('1')
   })
 
   it('renders similarity title when provided', () => {
@@ -63,6 +76,7 @@ describe('AgentMemory', () => {
     render(h(AgentMemory, { entries: sim }), container)
     const span = container.querySelector('span[title]') as HTMLElement
     expect(span?.getAttribute('title')).toContain('85.0')
+    expect(span.dataset.memoryEntrySimilarity).toBe('0.85')
   })
 
   it('applies testId', () => {
@@ -82,5 +96,43 @@ describe('AgentMemory', () => {
     render(h(AgentMemory, { entries: many }), container)
     const list = container.querySelector('[aria-label="단기 기억 목록"]')
     expect(list?.querySelectorAll('[role="listitem"]').length).toBe(10)
+    const root = container.querySelector('[data-agent-memory]') as HTMLElement
+    expect(root.dataset.agentMemoryShortTermCount).toBe('15')
+    expect(root.dataset.agentMemoryVisibleShortTermCount).toBe('10')
+    expect(root.dataset.agentMemoryHiddenShortTermCount).toBe('5')
+  })
+
+  it('exposes memory summary metadata', () => {
+    const container = document.createElement('div')
+    render(h(AgentMemory, { entries }), container)
+    const root = container.querySelector('[data-agent-memory]') as HTMLElement
+    const shortList = container.querySelector('[data-memory-section="short_term"]') as HTMLElement
+    const longList = container.querySelector('[data-memory-section="long_term"]') as HTMLElement
+
+    expect(root.dataset.agentMemoryStatus).toBe('mixed')
+    expect(root.dataset.agentMemoryTotalCount).toBe('4')
+    expect(root.dataset.agentMemoryShortTermCount).toBe('2')
+    expect(root.dataset.agentMemoryLongTermCount).toBe('2')
+    expect(root.dataset.agentMemoryClusterCount).toBe('1')
+    expect(shortList.dataset.memorySectionVisibleCount).toBe('2')
+    expect(longList.dataset.memorySectionClusterCount).toBe('1')
+  })
+
+  it('summarizes memory statuses and clusters', () => {
+    expect(summarizeAgentMemory([])).toMatchObject({
+      totalCount: 0,
+      status: 'empty',
+    })
+    expect(summarizeAgentMemory(entries.slice(0, 2))).toMatchObject({
+      shortTermCount: 2,
+      status: 'short_only',
+    })
+    expect(summarizeAgentMemory(entries.slice(2))).toMatchObject({
+      longTermCount: 2,
+      clusterCount: 1,
+      status: 'long_only',
+    })
+    expect(groupByCluster(entries.slice(2)).A?.length).toBe(2)
+    expect(getVisibleShortTermMemory(entries).map(entry => entry.id)).toEqual(['e1', 'e2'])
   })
 })

--- a/dashboard/src/components/common/agent-memory.ts
+++ b/dashboard/src/components/common/agent-memory.ts
@@ -16,17 +16,48 @@ export interface MemoryEntry {
   cluster?: string
 }
 
+export type AgentMemoryStatus = 'empty' | 'short_only' | 'long_only' | 'mixed'
+
+export interface AgentMemorySummary {
+  totalCount: number
+  shortTermCount: number
+  visibleShortTermCount: number
+  hiddenShortTermCount: number
+  longTermCount: number
+  clusterCount: number
+  unclusteredCount: number
+  maxSimilarity: number | null
+  latestTimestamp: number | null
+  status: AgentMemoryStatus
+}
+
 interface AgentMemoryProps {
   entries: MemoryEntry[]
   testId?: string
 }
 
+const SHORT_TERM_LIMIT = 10
+
 function formatTime(ts: number): string {
   const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return '--:--'
   return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
 }
 
-function groupByCluster(entries: MemoryEntry[]): Record<string, MemoryEntry[]> {
+function formatDateTime(ts: number): string | undefined {
+  const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return undefined
+  return d.toISOString()
+}
+
+export function getVisibleShortTermMemory(entries: MemoryEntry[]): MemoryEntry[] {
+  return entries
+    .filter(e => e.type === 'short_term')
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, SHORT_TERM_LIMIT)
+}
+
+export function groupByCluster(entries: MemoryEntry[]): Record<string, MemoryEntry[]> {
   const groups: Record<string, MemoryEntry[]> = {}
   for (const e of entries) {
     const key = e.cluster || '미분류'
@@ -36,73 +67,168 @@ function groupByCluster(entries: MemoryEntry[]): Record<string, MemoryEntry[]> {
   return groups
 }
 
+export function summarizeAgentMemory(entries: MemoryEntry[]): AgentMemorySummary {
+  const shortTermCount = entries.filter(e => e.type === 'short_term').length
+  const visibleShortTermCount = getVisibleShortTermMemory(entries).length
+  const longTerm = entries.filter(e => e.type === 'long_term')
+  const clusters = groupByCluster(longTerm)
+  const similarities = longTerm
+    .map(e => e.similarity)
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+  const status: AgentMemoryStatus =
+    entries.length === 0
+      ? 'empty'
+      : shortTermCount > 0 && longTerm.length > 0
+        ? 'mixed'
+        : shortTermCount > 0
+          ? 'short_only'
+          : 'long_only'
+
+  return {
+    totalCount: entries.length,
+    shortTermCount,
+    visibleShortTermCount,
+    hiddenShortTermCount: Math.max(0, shortTermCount - visibleShortTermCount),
+    longTermCount: longTerm.length,
+    clusterCount: Object.keys(clusters).length,
+    unclusteredCount: clusters['미분류']?.length ?? 0,
+    maxSimilarity: similarities.length > 0 ? Math.max(...similarities) : null,
+    latestTimestamp: entries.reduce<number | null>(
+      (latest, entry) => latest == null || entry.timestamp > latest ? entry.timestamp : latest,
+      null,
+    ),
+    status,
+  }
+}
+
 export function AgentMemory({ entries, testId }: AgentMemoryProps) {
-  const shortTerm = useMemo(
-    () =>
-      entries
-        .filter(e => e.type === 'short_term')
-        .sort((a, b) => b.timestamp - a.timestamp)
-        .slice(0, 10),
-    [entries],
-  )
+  const summary = useMemo(() => summarizeAgentMemory(entries), [entries])
+  const shortTerm = useMemo(() => getVisibleShortTermMemory(entries), [entries])
   const longTerm = useMemo(() => entries.filter(e => e.type === 'long_term'), [entries])
   const clusters = useMemo(() => groupByCluster(longTerm), [longTerm])
 
   return html`
     <div
-      class="flex gap-3 h-64"
+      class="flex min-h-64 flex-col gap-2 md:h-64"
       data-agent-memory
+      data-agent-memory-total-count=${summary.totalCount}
+      data-agent-memory-short-term-count=${summary.shortTermCount}
+      data-agent-memory-visible-short-term-count=${summary.visibleShortTermCount}
+      data-agent-memory-hidden-short-term-count=${summary.hiddenShortTermCount}
+      data-agent-memory-long-term-count=${summary.longTermCount}
+      data-agent-memory-cluster-count=${summary.clusterCount}
+      data-agent-memory-unclustered-count=${summary.unclusteredCount}
+      data-agent-memory-max-similarity=${summary.maxSimilarity ?? ''}
+      data-agent-memory-latest-timestamp=${summary.latestTimestamp ?? ''}
+      data-agent-memory-status=${summary.status}
       data-testid=${testId}
+      aria-label="에이전트 메모리, 전체 ${summary.totalCount}개, 클러스터 ${summary.clusterCount}개"
     >
-      <div class="flex-1 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2">
-        <h4 class="mb-2 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">
-          단기 기억 (최근 ${shortTerm.length}개)
-        </h4>
-        <div role="list" aria-label="단기 기억 목록">
-          ${shortTerm.map(
-            (e, i) => html`
-              <div
-                key=${e.id}
-                class="flex items-center gap-2 py-1 text-sm"
-                style=${{ opacity: `${Math.max(0.3, 1 - i * 0.08)}` }}
-                role="listitem"
-              >
-                <span class="text-[var(--color-accent)]" aria-hidden="true">◆</span>
-                <span class="flex-1 truncate text-[var(--color-fg-primary)]">${e.content}</span>
-                <span class="text-3xs text-[var(--color-fg-secondary)]">${formatTime(e.timestamp)}</span>
-              </div>
-            `,
-          )}
+      <div
+        class="grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
+        aria-label="에이전트 메모리 요약"
+      >
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">전체</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.totalCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">단기</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">
+            ${summary.visibleShortTermCount}/${summary.shortTermCount}
+          </div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">클러스터</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.clusterCount}</div>
         </div>
       </div>
 
-      <div class="flex-1 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2">
-        <h4 class="mb-2 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">
-          장기 기억 (${longTerm.length}개 클러스터)
-        </h4>
-        <div role="list" aria-label="장기 기억 클러스터 목록">
-          ${Object.entries(clusters).map(
-            ([cluster, items]) => html`
-              <div key=${cluster} class="mb-2" role="listitem">
-                <span class="text-3xs font-medium text-[var(--color-accent)]">${cluster}</span>
-                <div class="mt-1 flex flex-wrap gap-1">
-                  ${items.map(
-                    item => html`
-                      <span
-                        key=${item.id}
-                        class="inline-block rounded-full bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-secondary)]"
-                        title=${item.similarity != null
-                          ? `유사도: ${formatPct1(item.similarity)}`
-                          : undefined}
+      <div class="grid min-h-0 flex-1 grid-cols-1 gap-3 md:grid-cols-2">
+        <div class="min-h-0 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2">
+          <h4 class="mb-2 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">
+            단기 기억 (최근 ${shortTerm.length}개)
+          </h4>
+          <div
+            role="list"
+            aria-label="단기 기억 목록"
+            data-memory-section="short_term"
+            data-memory-section-count=${summary.shortTermCount}
+            data-memory-section-visible-count=${summary.visibleShortTermCount}
+          >
+            ${shortTerm.length === 0
+              ? html`<div class="py-2 text-3xs text-[var(--color-fg-muted)]" role="listitem">단기 기억 없음</div>`
+              : shortTerm.map(
+                  (e, i) => html`
+                    <div
+                      key=${e.id}
+                      class="flex min-w-0 items-center gap-2 py-1 text-sm"
+                      style=${{ opacity: `${Math.max(0.3, 1 - i * 0.08)}` }}
+                      role="listitem"
+                      data-memory-entry-id=${e.id}
+                      data-memory-entry-type=${e.type}
+                      data-memory-entry-timestamp=${e.timestamp}
+                      data-memory-entry-recency-index=${i}
+                    >
+                      <span class="text-[var(--color-accent-fg)]" aria-hidden="true">◆</span>
+                      <span class="min-w-0 flex-1 truncate text-[var(--color-fg-primary)]">${e.content}</span>
+                      <time
+                        class="shrink-0 text-3xs text-[var(--color-fg-secondary)]"
+                        datetime=${formatDateTime(e.timestamp)}
+                        >${formatTime(e.timestamp)}</time
                       >
-                        ${item.content.slice(0, 20)}
-                      </span>
-                    `,
-                  )}
-                </div>
-              </div>
-            `,
-          )}
+                    </div>
+                  `,
+                )}
+          </div>
+        </div>
+
+        <div class="min-h-0 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2">
+          <h4 class="mb-2 text-3xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">
+            장기 기억 (${summary.clusterCount}개 클러스터)
+          </h4>
+          <div
+            role="list"
+            aria-label="장기 기억 클러스터 목록"
+            data-memory-section="long_term"
+            data-memory-section-count=${summary.longTermCount}
+            data-memory-section-cluster-count=${summary.clusterCount}
+          >
+            ${Object.keys(clusters).length === 0
+              ? html`<div class="py-2 text-3xs text-[var(--color-fg-muted)]" role="listitem">장기 기억 없음</div>`
+              : Object.entries(clusters).map(
+                  ([cluster, items]) => html`
+                    <div
+                      key=${cluster}
+                      class="mb-2"
+                      role="listitem"
+                      data-memory-cluster=${cluster}
+                      data-memory-cluster-count=${items.length}
+                    >
+                      <span class="text-3xs font-medium text-[var(--color-accent-fg)]">${cluster}</span>
+                      <div class="mt-1 flex flex-wrap gap-1">
+                        ${items.map(
+                          item => html`
+                            <span
+                              key=${item.id}
+                              class="inline-block max-w-full truncate rounded-full bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-secondary)]"
+                              title=${item.similarity != null
+                                ? `유사도: ${formatPct1(item.similarity)}`
+                                : undefined}
+                              data-memory-entry-id=${item.id}
+                              data-memory-entry-type=${item.type}
+                              data-memory-entry-cluster=${cluster}
+                              data-memory-entry-similarity=${item.similarity ?? ''}
+                            >
+                              ${item.content.slice(0, 20)}
+                            </span>
+                          `,
+                        )}
+                      </div>
+                    </div>
+                  `,
+                )}
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/src/components/common/agent-memory.ts
+++ b/dashboard/src/components/common/agent-memory.ts
@@ -67,9 +67,12 @@ export function groupByCluster(entries: MemoryEntry[]): Record<string, MemoryEnt
   return groups
 }
 
-export function summarizeAgentMemory(entries: MemoryEntry[]): AgentMemorySummary {
+export function summarizeAgentMemory(
+  entries: MemoryEntry[],
+  visibleShortTerm = getVisibleShortTermMemory(entries),
+): AgentMemorySummary {
   const shortTermCount = entries.filter(e => e.type === 'short_term').length
-  const visibleShortTermCount = getVisibleShortTermMemory(entries).length
+  const visibleShortTermCount = visibleShortTerm.length
   const longTerm = entries.filter(e => e.type === 'long_term')
   const clusters = groupByCluster(longTerm)
   const similarities = longTerm
@@ -93,17 +96,18 @@ export function summarizeAgentMemory(entries: MemoryEntry[]): AgentMemorySummary
     clusterCount: Object.keys(clusters).length,
     unclusteredCount: clusters['미분류']?.length ?? 0,
     maxSimilarity: similarities.length > 0 ? Math.max(...similarities) : null,
-    latestTimestamp: entries.reduce<number | null>(
-      (latest, entry) => latest == null || entry.timestamp > latest ? entry.timestamp : latest,
-      null,
-    ),
+    latestTimestamp: entries.reduce<number | null>((latest, entry) => {
+      const timestamp = Number(entry.timestamp)
+      if (!Number.isFinite(timestamp)) return latest
+      return latest == null || timestamp > latest ? timestamp : latest
+    }, null),
     status,
   }
 }
 
 export function AgentMemory({ entries, testId }: AgentMemoryProps) {
-  const summary = useMemo(() => summarizeAgentMemory(entries), [entries])
   const shortTerm = useMemo(() => getVisibleShortTermMemory(entries), [entries])
+  const summary = useMemo(() => summarizeAgentMemory(entries, shortTerm), [entries, shortTerm])
   const longTerm = useMemo(() => entries.filter(e => e.type === 'long_term'), [entries])
   const clusters = useMemo(() => groupByCluster(longTerm), [longTerm])
 


### PR DESCRIPTION
## Summary
- export AgentMemory summary helpers for short/long memory counts, visible short-term window, cluster totals, unclustered count, max similarity, and status
- expose root, section, cluster, and entry metadata for dashboard QA
- correct the long-term heading to show cluster count, replace likely undefined accent token usage, add empty list rows, and stack panels on mobile

## Why it matters
AgentMemory encoded memory state only in text and layout, and the long-term heading reported entry count as cluster count. This makes mixed, short-only, long-only, and empty states inspectable while keeping the component readable at narrow widths.

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/agent-memory.test.ts src/components/common/agent-memory.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint (passes with 3 existing warnings outside this component)
- pnpm --dir dashboard run build (passes with existing Vite dynamic/static import and chunk-size warnings)
- Browser QA via Vite on 5211: desktop 820x760 and mobile 390x640; no horizontal overflow; mixed/short-only/empty metadata checked; cluster count and similarity titles checked; semantic accent color computed; no page errors

## Review focus
- Summary semantics for visible short-term memory vs total short-term memory
- Correct cluster count and unclustered handling
- Responsive stacking and metadata attribute names for dashboard QA