### PR TITLE
fix(coord): refresh playground repo cache on worktree fetch

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -1220,7 +1220,16 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
               Error
                 (System (System_error.IoError
                    "Failed to fetch origin before worktree creation. Verify network/auth and retry so the task starts from the latest remote ref."))
-            else match Coord_git.resolve_base_branch root base_branch with
+            else begin
+              let playground_dir =
+                repos_dir_of_keeper config agent_name
+                |> strip_trailing_slashes
+                |> Filename.dirname
+              in
+              Playground_repo_cache.update ~playground_dir ~repo_name
+                ~repo_path:root ~action:"fetch"
+                ~shallow:(Playground_repo_cache.is_shallow_repo root);
+              match Coord_git.resolve_base_branch root base_branch with
             | Error e -> Error e
             | Ok (resolved_base, fallback_from) ->
                 let note = match fallback_from with
@@ -1290,6 +1299,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                   Error (System (System_error.IoError (Printf.sprintf "Failed to create worktree from origin/%s: %s"
                     resolved_base (if detail = "" then "(no output)" else detail))))
                 end
+            end
           end
   end
 

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -31,6 +31,7 @@
   coord_verification_store
   event_kind
   coord_git
+  playground_repo_cache
   coord_worktree
   mention
   coord_resilience

--- a/lib/coord/playground_repo_cache.ml
+++ b/lib/coord/playground_repo_cache.ml
@@ -1,0 +1,91 @@
+(** Best-effort playground repository state cache.
+
+    The cache is advisory runtime metadata used by keeper status surfaces.
+    Callers must not depend on cache writes succeeding for the primary
+    operation to succeed. *)
+
+let env_float name default =
+  match Sys.getenv_opt name with
+  | Some s -> (match float_of_string_opt s with Some f -> f | None -> default)
+  | None -> default
+
+(* Ceiling for lightweight git metadata commands (rev-parse, log --oneline).
+   These are local disk ops that should complete in <1s; 5s is generous
+   without masking genuine repository corruption or NFS hangs. *)
+let git_meta_timeout_sec = env_float "MASC_KEEPER_GIT_META_TIMEOUT_SEC" 5.0
+
+let git_meta repo_path args =
+  Process_eio.run_argv_with_status ~timeout_sec:git_meta_timeout_sec
+    ("git" :: "-C" :: repo_path :: args)
+
+let is_shallow_repo repo_path =
+  try
+    match git_meta repo_path [ "rev-parse"; "--is-shallow-repository" ] with
+    | Unix.WEXITED 0, output ->
+        String.equal "true" (String.trim output)
+    | _ -> false
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> false
+
+let update
+    ~(playground_dir : string)
+    ~(repo_name : string)
+    ~(repo_path : string)
+    ~(action : string)
+    ~(shallow : bool) : unit =
+  try
+    let branch =
+      match git_meta repo_path [ "rev-parse"; "--abbrev-ref"; "HEAD" ] with
+      | Unix.WEXITED 0, output -> String.trim output
+      | _ -> "unknown"
+    in
+    let commit =
+      match git_meta repo_path [ "log"; "--oneline"; "-1" ] with
+      | Unix.WEXITED 0, output -> String.trim output
+      | _ -> ""
+    in
+    let ts = Printf.sprintf "%.0f" (Unix.gettimeofday ()) in
+    let entry =
+      `Assoc
+        [
+          ("name", `String repo_name);
+          ("branch", `String branch);
+          ("latest_commit", `String commit);
+          ("shallow", `Bool shallow);
+          ("last_action", `String action);
+          ("updated_at", `String ts);
+        ]
+    in
+    let cache_path = Filename.concat playground_dir ".playground_state.json" in
+    let existing =
+      try
+        let json = Yojson.Safe.from_file cache_path in
+        match Yojson.Safe.Util.member "repos" json with
+        | `List repos -> repos
+        | _ -> []
+      with Sys_error _ | Yojson.Json_error _ -> []
+    in
+    let updated =
+      entry
+      :: List.filter
+           (fun repo ->
+             match Yojson.Safe.Util.member "name" repo with
+             | `String name -> not (String.equal name repo_name)
+             | _ -> true)
+           existing
+    in
+    let json =
+      `Assoc [ ("repos", `List updated); ("last_updated", `String ts) ]
+    in
+    match
+      Fs_compat.save_file_atomic cache_path
+        (Yojson.Safe.pretty_to_string json ^ "\n")
+    with
+    | Ok () -> ()
+    | Error e -> Log.Misc.warn "playground cache save failed: %s" e
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Misc.warn "playground cache update failed: %s"
+        (Printexc.to_string exn)

--- a/lib/coord/playground_repo_cache.ml
+++ b/lib/coord/playground_repo_cache.ml
@@ -18,6 +18,12 @@ let git_meta repo_path args =
   Process_eio.run_argv_with_status ~timeout_sec:git_meta_timeout_sec
     ("git" :: "-C" :: repo_path :: args)
 
+let cache_update_mu = Stdlib.Mutex.create ()
+
+let with_cache_update_lock f =
+  Stdlib.Mutex.lock cache_update_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock cache_update_mu) f
+
 let is_shallow_repo repo_path =
   try
     match git_meta repo_path [ "rev-parse"; "--is-shallow-repository" ] with
@@ -57,33 +63,34 @@ let update
           ("updated_at", `String ts);
         ]
     in
-    let cache_path = Filename.concat playground_dir ".playground_state.json" in
-    let existing =
-      try
-        let json = Yojson.Safe.from_file cache_path in
-        match Yojson.Safe.Util.member "repos" json with
-        | `List repos -> repos
-        | _ -> []
-      with Sys_error _ | Yojson.Json_error _ -> []
-    in
-    let updated =
-      entry
-      :: List.filter
-           (fun repo ->
-             match Yojson.Safe.Util.member "name" repo with
-             | `String name -> not (String.equal name repo_name)
-             | _ -> true)
-           existing
-    in
-    let json =
-      `Assoc [ ("repos", `List updated); ("last_updated", `String ts) ]
-    in
-    match
-      Fs_compat.save_file_atomic cache_path
-        (Yojson.Safe.pretty_to_string json ^ "\n")
-    with
-    | Ok () -> ()
-    | Error e -> Log.Misc.warn "playground cache save failed: %s" e
+    with_cache_update_lock (fun () ->
+      let cache_path = Filename.concat playground_dir ".playground_state.json" in
+      let existing =
+        try
+          let json = Yojson.Safe.from_file cache_path in
+          match Yojson.Safe.Util.member "repos" json with
+          | `List repos -> repos
+          | _ -> []
+        with Sys_error _ | Yojson.Json_error _ -> []
+      in
+      let updated =
+        entry
+        :: List.filter
+             (fun repo ->
+               match Yojson.Safe.Util.member "name" repo with
+               | `String name -> not (String.equal name repo_name)
+               | _ -> true)
+             existing
+      in
+      let json =
+        `Assoc [ ("repos", `List updated); ("last_updated", `String ts) ]
+      in
+      match
+        Fs_compat.save_file_atomic cache_path
+          (Yojson.Safe.pretty_to_string json ^ "\n")
+      with
+      | Ok () -> ()
+      | Error e -> Log.Misc.warn "playground cache save failed: %s" e)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/coord/playground_repo_cache.mli
+++ b/lib/coord/playground_repo_cache.mli
@@ -1,0 +1,19 @@
+(** Best-effort playground repository state cache. *)
+
+val is_shallow_repo : string -> bool
+(** Return true when [repo_path] is a shallow git repository.
+
+    Probe failures return false. {!Eio.Cancel.Cancelled} is re-raised. *)
+
+val update :
+  playground_dir:string ->
+  repo_name:string ->
+  repo_path:string ->
+  action:string ->
+  shallow:bool ->
+  unit
+(** Upsert [repo_name] into [<playground_dir>/.playground_state.json]
+    using live git metadata from [repo_path].
+
+    Failures are logged at warn and otherwise ignored. {!Eio.Cancel.Cancelled}
+    is re-raised. *)

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -73,9 +73,9 @@ let user_timeout_max_sec = env_float "MASC_KEEPER_USER_TIMEOUT_MAX_SEC" 180.0
    sub-network-latency timeout without masking genuine hangs. *)
 let gh_min_timeout_sec = 15.0
 
-(* Ceiling for lightweight git metadata commands (rev-parse, log --oneline).
-   These are local disk ops that should complete in <1s; 5s is generous
-   without masking genuine repository corruption or NFS hangs. *)
+(* Public shell metadata timeout used by git-status helpers. The playground
+   repo-cache writer keeps its own copy in the lower-level coord module so
+   Coord_worktree can update the same cache without depending on this file. *)
 let git_meta_timeout_sec = env_float "MASC_KEEPER_GIT_META_TIMEOUT_SEC" 5.0
 
 let clamp_shell_timeout ?(min_sec = 1.0) ~default args =
@@ -374,55 +374,8 @@ let shell_command_available name =
 let update_playground_repo_cache
       ~(playground_dir : string) ~(repo_name : string) ~(repo_path : string)
       ~(action : string) ~(shallow : bool) : unit =
-  try
-    let branch =
-      let st, s = Process_eio.run_argv_with_status ~timeout_sec:git_meta_timeout_sec
-        [ "git"; "-C"; repo_path; "rev-parse"; "--abbrev-ref"; "HEAD" ] in
-      if st = Unix.WEXITED 0 then String.trim s else "unknown"
-    in
-    let commit =
-      let st, s = Process_eio.run_argv_with_status ~timeout_sec:git_meta_timeout_sec
-        [ "git"; "-C"; repo_path; "log"; "--oneline"; "-1" ] in
-      if st = Unix.WEXITED 0 then String.trim s else ""
-    in
-    let ts = Printf.sprintf "%.0f" (Unix.gettimeofday ()) in
-    let entry = `Assoc [
-      "name", `String repo_name;
-      "branch", `String branch;
-      "latest_commit", `String commit;
-      "shallow", `Bool shallow;
-      "last_action", `String action;
-      "updated_at", `String ts;
-    ] in
-    let cache_path = Filename.concat playground_dir ".playground_state.json" in
-    let existing =
-      try
-        let json = Yojson.Safe.from_file cache_path in
-        (match Yojson.Safe.Util.member "repos" json with
-         | `List repos -> repos
-         | _ -> [])
-      with Sys_error _ | Yojson.Json_error _ -> []
-    in
-    let updated =
-      entry :: List.filter (fun r ->
-        match Yojson.Safe.Util.member "name" r with
-        | `String n -> n <> repo_name
-        | _ -> true) existing
-    in
-    let json = `Assoc [
-      "repos", `List updated;
-      "last_updated", `String ts;
-    ] in
-    (match Fs_compat.save_file_atomic cache_path
-       (Yojson.Safe.pretty_to_string json ^ "\n") with
-     | Ok () -> ()
-     | Error e ->
-         Logs.warn (fun f -> f "playground cache save failed: %s" e))
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    Logs.warn (fun f -> f "playground cache update failed: %s"
-      (Printexc.to_string exn))
+  Playground_repo_cache.update ~playground_dir ~repo_name ~repo_path ~action
+    ~shallow
 
 let resolve_keeper_shell_read_cwd
       ~(config : Coord.config)

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -434,6 +434,44 @@ let test_dispatch_worktree_create_refreshes_playground_repo_cache () =
       check bool "cache commit uses live git metadata" true
         (contains "init" latest_commit)
 
+let test_playground_repo_cache_preserves_concurrent_updates () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  let repo_path =
+    setup_nested_repo_with_remote ~base_path
+      ~repo_rel:"workspace/yousleepwhen/masc-mcp"
+  in
+  let playground_dir =
+    Filename.concat base_path ".masc/playground/test-agent"
+  in
+  ensure_dir playground_dir;
+  Eio.Fiber.both
+    (fun () ->
+       Masc_mcp.Playground_repo_cache.update ~playground_dir
+         ~repo_name:"repo-a" ~repo_path ~action:"clone" ~shallow:false)
+    (fun () ->
+       Masc_mcp.Playground_repo_cache.update ~playground_dir
+         ~repo_name:"repo-b" ~repo_path ~action:"fetch" ~shallow:false);
+  let open Yojson.Safe.Util in
+  let names =
+    Yojson.Safe.from_file
+      (Filename.concat playground_dir ".playground_state.json")
+    |> member "repos"
+    |> to_list
+    |> List.filter_map (fun repo ->
+         match member "name" repo with
+         | `String name -> Some name
+         | _ -> None)
+    |> List.sort String.compare
+  in
+  check (list string) "concurrent cache updates preserved"
+    [ "repo-a"; "repo-b" ]
+    names
+
 let test_dispatch_worktree_create_auto_provisions_after_file_storm () =
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
@@ -879,6 +917,8 @@ let () =
         test_dispatch_worktree_create_auto_provisions_workspace_repo;
       test_case "worktree create refreshes playground repo cache" `Quick
         test_dispatch_worktree_create_refreshes_playground_repo_cache;
+      test_case "playground repo cache preserves concurrent updates" `Quick
+        test_playground_repo_cache_preserves_concurrent_updates;
       test_case "workspace repo auto-provisions after file storm" `Quick
         test_dispatch_worktree_create_auto_provisions_after_file_storm;
       test_case "workspace repo wins before hidden dir storm" `Quick

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -241,6 +241,20 @@ let contains needle haystack =
 let check_contains label needle haystack =
   check bool label true (contains needle haystack)
 
+let playground_cache_repo ~base_path ~agent_name ~repo_name =
+  let cache_path =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/playground/%s/.playground_state.json" agent_name)
+  in
+  let open Yojson.Safe.Util in
+  Yojson.Safe.from_file cache_path
+  |> member "repos"
+  |> to_list
+  |> List.find (fun repo ->
+       match member "name" repo with
+       | `String name -> String.equal name repo_name
+       | _ -> false)
+
 let test_dispatch_worktree_create_spoofed_agent_blocked () =
   let ctx = make_ctx () in
   let args = `Assoc [
@@ -371,6 +385,54 @@ let test_dispatch_worktree_create_auto_provisions_workspace_repo () =
         (contains "auto-provisioned" msg);
       check bool "sandbox clone created" true (Sys.file_exists sandbox_clone);
       check bool "worktree created" true (Sys.file_exists worktree_path)
+
+let test_dispatch_worktree_create_refreshes_playground_repo_cache () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  ignore
+    (setup_nested_repo_with_remote ~base_path
+       ~repo_rel:"workspace/yousleepwhen/masc-mcp");
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let playground_dir =
+    Filename.concat base_path ".masc/playground/test-agent"
+  in
+  ensure_dir playground_dir;
+  write_file
+    (Filename.concat playground_dir ".playground_state.json")
+    {|{"repos":[{"name":"masc-mcp","branch":"main","latest_commit":"old-cache","shallow":false,"last_action":"clone","updated_at":"1"}],"last_updated":"1"}|};
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let args =
+    `Assoc
+      [
+        ("task_id", `String "task-cache-refresh");
+        ("repo_name", `String "masc-mcp");
+        ("base_branch", `String "main");
+      ]
+  in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (false, msg) ->
+      fail
+        (Printf.sprintf
+           "expected worktree create to refresh cache, got error: %s" msg)
+  | Some (true, _msg) ->
+      let repo =
+        playground_cache_repo ~base_path ~agent_name:"test-agent"
+          ~repo_name:"masc-mcp"
+      in
+      let open Yojson.Safe.Util in
+      let latest_commit = repo |> member "latest_commit" |> to_string in
+      check string "cache action" "fetch"
+        (repo |> member "last_action" |> to_string);
+      check bool "cache commit is refreshed" false
+        (contains "old-cache" latest_commit);
+      check bool "cache commit uses live git metadata" true
+        (contains "init" latest_commit)
 
 let test_dispatch_worktree_create_auto_provisions_after_file_storm () =
   let base_path = temp_dir () in
@@ -815,6 +877,8 @@ let () =
         test_dispatch_worktree_create_reports_missing_sandbox_clone;
       test_case "workspace repo auto-provisions sandbox clone" `Quick
         test_dispatch_worktree_create_auto_provisions_workspace_repo;
+      test_case "worktree create refreshes playground repo cache" `Quick
+        test_dispatch_worktree_create_refreshes_playground_repo_cache;
       test_case "workspace repo auto-provisions after file storm" `Quick
         test_dispatch_worktree_create_auto_provisions_after_file_storm;
       test_case "workspace repo wins before hidden dir storm" `Quick


### PR DESCRIPTION
## Summary

- Extract playground repo cache writes into a coord-level helper shared by keeper shell and worktree creation.
- After `masc_worktree_create` successfully fetches `origin`, refresh `.playground_state.json` from the live sandbox clone metadata.
- Add regression coverage proving a stale cached commit is replaced with live git metadata during worktree creation.

## Why it matters

Live keeper status showed playground repo entries with old cached commits even after worktree creation had already fetched `origin`. That made operators and keepers reason from stale repo readiness data. This keeps the cache aligned with the actual fetch path without adding auto-pull behavior or mutating dirty worktrees.

## Validation

- `git diff --check`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_tool_worktree_coverage.exe`
- `./_build/default/test/test_tool_worktree_coverage.exe --color=never` (27 tests)

## Notes

Local validation first hit `agent_sdk` pin drift (`0.190.12` vs required `>=0.190.25`); repaired with `scripts/opam-pin-external-deps.sh --install`, then reran the focused build successfully.