### PR TITLE
fix(keeper): persist tool route markers

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -175,19 +175,28 @@ let json_string_field_opt key = function
       | _ -> None)
   | _ -> None
 
-let contains_ci text needle =
-  String_util.contains_substring
-    (String.lowercase_ascii text)
-    (String.lowercase_ascii needle)
+let strip_simple_quotes text =
+  let len = String.length text in
+  if len >= 2 then
+    match text.[0], text.[len - 1] with
+    | '\'', '\'' | '"', '"' -> String.sub text 1 (len - 2)
+    | _ -> text
+  else text
+
+let command_words command =
+  command
+  |> String.split_on_char ' '
+  |> List.filter_map (fun word ->
+         match String.trim word with
+         | "" -> None
+         | word -> Some (strip_simple_quotes word |> String.lowercase_ascii))
 
 let add_command_markers command markers =
-  let markers =
-    if contains_ci command "git push" then add_unique_marker "git push" markers
-    else markers
-  in
-  if contains_ci command "pr create" then
-    add_unique_marker "gh pr create" markers
-  else markers
+  match command_words command with
+  | "git" :: "push" :: _ -> add_unique_marker "git push" markers
+  | "gh" :: "pr" :: "create" :: _ ->
+      add_unique_marker "gh pr create" markers
+  | _ -> markers
 
 let add_action_marker action markers =
   match String.lowercase_ascii (String.trim action) with
@@ -204,16 +213,24 @@ let add_operation_marker operation markers =
   | "pr_create" -> add_unique_marker "gh pr create" markers
   | _ -> markers
 
-let add_via_marker via markers =
-  match String.trim via with
-  | "" -> markers
-  | value -> add_unique_marker ("via=" ^ value) markers
+let allowed_via_marker = function
+  | "brokered" | "docker" | "host" | "keeper" | "operator" | "system"
+  | "taskmaster" ->
+      true
+  | _ -> false
 
-let add_json_marker_fields json markers =
+let add_via_marker via markers =
+  let value = String.trim via |> String.lowercase_ascii in
+  if allowed_via_marker value then add_unique_marker ("via=" ^ value) markers
+  else markers
+
+let add_json_marker_fields ?(trusted_route_fields = true) json markers =
   let markers =
-    match json_string_field_opt "via" json with
-    | Some via -> add_via_marker via markers
-    | None -> markers
+    if trusted_route_fields then
+      match json_string_field_opt "via" json with
+      | Some via -> add_via_marker via markers
+      | None -> markers
+    else markers
   in
   let markers =
     match json_string_field_opt "cmd" json with
@@ -231,22 +248,28 @@ let add_json_marker_fields json markers =
     | None -> markers
   in
   let markers =
-    match json_string_field_opt "action" json with
-    | Some action -> add_action_marker action markers
-    | None -> markers
+    if trusted_route_fields then
+      match json_string_field_opt "action" json with
+      | Some action -> add_action_marker action markers
+      | None -> markers
+    else markers
   in
   let markers =
-    match json_string_field_opt "event" json with
-    | Some event -> add_event_marker event markers
-    | None -> markers
+    if trusted_route_fields then
+      match json_string_field_opt "event" json with
+      | Some event -> add_event_marker event markers
+      | None -> markers
+    else markers
   in
-  match json_string_field_opt "operation" json with
-  | Some operation -> add_operation_marker operation markers
-  | None -> markers
+  if trusted_route_fields then
+    match json_string_field_opt "operation" json with
+    | Some operation -> add_operation_marker operation markers
+    | None -> markers
+  else markers
 
 let tool_exec_result_markers ~(input : Yojson.Safe.t) ~(output : string)
     : string list =
-  let markers = add_json_marker_fields input [] in
+  let markers = add_json_marker_fields ~trusted_route_fields:false input [] in
   let markers =
     try
       let json = Yojson.Safe.from_string output in

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -165,6 +165,102 @@ let transient_mutex_contention_tool_error
     long enough to include the actionable portion of the error. *)
 let sse_error_preview_max_chars = 300
 
+let add_unique_marker marker markers =
+  if List.mem marker markers then markers else marker :: markers
+
+let json_string_field_opt key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let contains_ci text needle =
+  String_util.contains_substring
+    (String.lowercase_ascii text)
+    (String.lowercase_ascii needle)
+
+let add_command_markers command markers =
+  let markers =
+    if contains_ci command "git push" then add_unique_marker "git push" markers
+    else markers
+  in
+  if contains_ci command "pr create" then
+    add_unique_marker "gh pr create" markers
+  else markers
+
+let add_action_marker action markers =
+  match String.lowercase_ascii (String.trim action) with
+  | "push" -> add_unique_marker "git push" markers
+  | _ -> markers
+
+let add_event_marker event markers =
+  match String.uppercase_ascii (String.trim event) with
+  | "APPROVE" -> add_unique_marker "event=APPROVE" markers
+  | _ -> markers
+
+let add_operation_marker operation markers =
+  match String.lowercase_ascii (String.trim operation) with
+  | "pr_create" -> add_unique_marker "gh pr create" markers
+  | _ -> markers
+
+let add_via_marker via markers =
+  match String.trim via with
+  | "" -> markers
+  | value -> add_unique_marker ("via=" ^ value) markers
+
+let add_json_marker_fields json markers =
+  let markers =
+    match json_string_field_opt "via" json with
+    | Some via -> add_via_marker via markers
+    | None -> markers
+  in
+  let markers =
+    match json_string_field_opt "cmd" json with
+    | Some command -> add_command_markers command markers
+    | None -> markers
+  in
+  let markers =
+    match json_string_field_opt "command" json with
+    | Some command -> add_command_markers command markers
+    | None -> markers
+  in
+  let markers =
+    match json_string_field_opt "op_cmd" json with
+    | Some command -> add_command_markers command markers
+    | None -> markers
+  in
+  let markers =
+    match json_string_field_opt "action" json with
+    | Some action -> add_action_marker action markers
+    | None -> markers
+  in
+  let markers =
+    match json_string_field_opt "event" json with
+    | Some event -> add_event_marker event markers
+    | None -> markers
+  in
+  match json_string_field_opt "operation" json with
+  | Some operation -> add_operation_marker operation markers
+  | None -> markers
+
+let tool_exec_result_markers ~(input : Yojson.Safe.t) ~(output : string)
+    : string list =
+  let markers = add_json_marker_fields input [] in
+  let markers =
+    try
+      let json = Yojson.Safe.from_string output in
+      let markers = add_json_marker_fields json markers in
+      match json with
+      | `Assoc fields -> (
+          match List.assoc_opt "result" fields with
+          | Some result -> add_json_marker_fields result markers
+          | None -> markers)
+      | _ -> markers
+    with Yojson.Json_error _ -> markers
+  in
+  List.rev markers
+
 (** RFC-0006 Phase A.2: build the per-tool handler closure.
 
     Extracted from the original anonymous closure inside [make_tools] so
@@ -345,6 +441,18 @@ let make_keeper_tool_handler
           let original_len = String.length final_result in
           let truncated_result = Tool_output_validation.cap final_result in
           let was_truncated = original_len > Tool_output_validation.max_output_chars in
+          let result_markers =
+            tool_exec_result_markers ~input ~output:final_result
+          in
+          let result_marker_fields =
+            match result_markers with
+            | [] -> []
+            | markers ->
+                [
+                  ( "result_markers",
+                    `List (List.map (fun marker -> `String marker) markers) );
+                ]
+          in
           if was_truncated then
             Log.Keeper.info "tool %s output truncated: %d -> %d chars"
               name original_len (String.length truncated_result);
@@ -359,7 +467,7 @@ let make_keeper_tool_handler
                 "duration_ms", `Int duration_ms;
                 "result_bytes", `Int original_len;
                 "ok", `Bool true;
-              ] @ (if was_truncated then
+              ] @ result_marker_fields @ (if was_truncated then
                 ["truncated_to", `Int (String.length truncated_result)]
               else [])))
           with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -59,6 +59,14 @@ val transient_mutex_contention_tool_error :
 (** Max chars for the SSE error preview rendered to dashboards. *)
 val sse_error_preview_max_chars : int
 
+(** Extract safe, machine-checkable markers from tool input and normalized
+    output for keeper decision rows. This intentionally records only route /
+    lifecycle classes such as ["via=docker"], ["git push"],
+    ["gh pr create"], and ["event=APPROVE"], not raw command arguments or
+    tool output. *)
+val tool_exec_result_markers :
+  input:Yojson.Safe.t -> output:string -> string list
+
 (** Build the per-tool handler closure used by both internal and
     alias tool entries. The closure dispatches via
     [execute_keeper_tool_call_with_outcome] using [~name] as the

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -59,11 +59,12 @@ val transient_mutex_contention_tool_error :
 (** Max chars for the SSE error preview rendered to dashboards. *)
 val sse_error_preview_max_chars : int
 
-(** Extract safe, machine-checkable markers from tool input and normalized
-    output for keeper decision rows. This intentionally records only route /
+(** Extract safe, machine-checkable markers from tool input command fields and
+    trusted normalized output for keeper decision rows. This intentionally records only route /
     lifecycle classes such as ["via=docker"], ["git push"],
     ["gh pr create"], and ["event=APPROVE"], not raw command arguments or
-    tool output. *)
+    tool output. Caller-controlled route fields in input are ignored, and
+    output [via] values are allowlisted before persistence. *)
 val tool_exec_result_markers :
   input:Yojson.Safe.t -> output:string -> string list
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -573,6 +573,76 @@ let test_result_markers_keep_git_push_class_only () =
   check bool "raw command not persisted as marker" false
     (List.mem "git push origin feature/secret-proof" markers)
 
+let test_result_markers_ignore_lifecycle_mentions () =
+  let output =
+    Keeper_tools_oas.normalize_tool_result ~success:true
+      {|{"ok":true,"via":"docker"}|}
+  in
+  let markers =
+    Keeper_tools_oas.tool_exec_result_markers
+      ~input:
+        (`Assoc
+          [
+            ("cmd", `String "echo git push");
+            ("command", `String "printf 'gh pr create'");
+          ])
+      ~output
+  in
+  check bool "mentioned git push not marked" false
+    (List.mem "git push" markers);
+  check bool "mentioned pr create not marked" false
+    (List.mem "gh pr create" markers);
+  check bool "output via marker still captured" true
+    (List.mem "via=docker" markers)
+
+let test_result_markers_ignore_input_via () =
+  let output =
+    Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true}|}
+  in
+  let markers =
+    Keeper_tools_oas.tool_exec_result_markers
+      ~input:(`Assoc [ ("via", `String "docker") ])
+      ~output
+  in
+  check bool "input via marker ignored" false
+    (List.mem "via=docker" markers)
+
+let test_result_markers_ignore_input_route_fields () =
+  let output =
+    Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true}|}
+  in
+  let markers =
+    Keeper_tools_oas.tool_exec_result_markers
+      ~input:
+        (`Assoc
+          [
+            ("action", `String "push");
+            ("event", `String "APPROVE");
+            ("operation", `String "pr_create");
+          ])
+      ~output
+  in
+  check bool "input action marker ignored" false (List.mem "git push" markers);
+  check bool "input event marker ignored" false
+    (List.mem "event=APPROVE" markers);
+  check bool "input operation marker ignored" false
+    (List.mem "gh pr create" markers)
+
+let test_result_markers_reject_untrusted_via () =
+  let output =
+    Keeper_tools_oas.normalize_tool_result ~success:true
+      {|{"ok":true,"via":"<script>alert(1)</script>"}|}
+  in
+  let markers =
+    Keeper_tools_oas.tool_exec_result_markers
+      ~input:(`Assoc [])
+      ~output
+  in
+  check bool "untrusted via marker rejected" false
+    (List.exists
+       (fun marker -> String.starts_with ~prefix:"via=" marker)
+       markers)
+
 let test_result_markers_capture_pr_create_operation () =
   let output =
     Keeper_tools_oas.normalize_tool_result ~success:true
@@ -647,6 +717,14 @@ let () =
         test_result_markers_capture_docker_approve;
       test_case "keeps git push class only" `Quick
         test_result_markers_keep_git_push_class_only;
+      test_case "ignores lifecycle mentions" `Quick
+        test_result_markers_ignore_lifecycle_mentions;
+      test_case "ignores caller-provided via marker" `Quick
+        test_result_markers_ignore_input_via;
+      test_case "ignores caller-provided route fields" `Quick
+        test_result_markers_ignore_input_route_fields;
+      test_case "rejects untrusted via marker" `Quick
+        test_result_markers_reject_untrusted_via;
       test_case "captures pr create operation" `Quick
         test_result_markers_capture_pr_create_operation;
     ];

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -541,6 +541,51 @@ let test_transient_mutex_contention_envelope () =
   check bool "backtrace available" true
     Yojson.Safe.Util.(member "backtrace_available" detail |> to_bool)
 
+let test_result_markers_capture_docker_approve () =
+  let output =
+    Keeper_tools_oas.normalize_tool_result ~success:true
+      {|{"ok":true,"via":"docker","event":"APPROVE"}|}
+  in
+  let markers =
+    Keeper_tools_oas.tool_exec_result_markers
+      ~input:(`Assoc [])
+      ~output
+  in
+  check bool "via marker" true (List.mem "via=docker" markers);
+  check bool "approve marker" true (List.mem "event=APPROVE" markers)
+
+let test_result_markers_keep_git_push_class_only () =
+  let output =
+    Keeper_tools_oas.normalize_tool_result ~success:true
+      {|{"ok":true,"via":"docker"}|}
+  in
+  let markers =
+    Keeper_tools_oas.tool_exec_result_markers
+      ~input:
+        (`Assoc
+          [
+            ("cmd", `String "git push origin feature/secret-proof");
+          ])
+      ~output
+  in
+  check bool "git push class marker" true (List.mem "git push" markers);
+  check bool "via marker" true (List.mem "via=docker" markers);
+  check bool "raw command not persisted as marker" false
+    (List.mem "git push origin feature/secret-proof" markers)
+
+let test_result_markers_capture_pr_create_operation () =
+  let output =
+    Keeper_tools_oas.normalize_tool_result ~success:true
+      {|{"ok":true,"via":"docker","operation":"pr_create"}|}
+  in
+  let markers =
+    Keeper_tools_oas.tool_exec_result_markers
+      ~input:(`Assoc [])
+      ~output
+  in
+  check bool "pr create marker" true (List.mem "gh pr create" markers);
+  check bool "via marker" true (List.mem "via=docker" markers)
+
 (* ── Tool_output_validation tests (memory cap) ──────────────── *)
 
 let test_cap_short_unchanged () =
@@ -596,6 +641,14 @@ let () =
       test_case "failure plain text wraps as error" `Quick test_normalize_failure_plain_text;
       test_case "EDEADLK envelope is recoverable" `Quick
         test_transient_mutex_contention_envelope;
+    ];
+    "result_markers", [
+      test_case "captures docker approve markers" `Quick
+        test_result_markers_capture_docker_approve;
+      test_case "keeps git push class only" `Quick
+        test_result_markers_keep_git_push_class_only;
+      test_case "captures pr create operation" `Quick
+        test_result_markers_capture_pr_create_operation;
     ];
     "research_profile", [
       test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;


### PR DESCRIPTION
## Summary

- persist safe `result_markers` on successful keeper `tool_exec` decision rows
- record only bounded route/lifecycle classes needed by audits, such as `via=docker`, `git push`, `gh pr create`, and `event=APPROVE`
- switch lifecycle command markers from substring matching to token-prefix matching so `echo git push` cannot forge audit evidence
- ignore caller-controlled route fields from tool input and allowlist trusted output `via` values before persistence
- add focused negative tests for lifecycle-string mentions and route-field injection

## Root Cause

The keeper PR tools and shell paths can return structured output with fields like `via`, `event`, and `operation`, but successful `tool_exec` rows in keeper decision logs only persisted `result_bytes` and `ok=true`.

That meant a later audit could require Docker lifecycle proof, but the runtime would discard the exact route marker needed to prove it. The first implementation also trusted freeform/input fields too broadly; this follow-up keeps the audit signal useful without making the marker field forgeable.

## Operator Impact

After this patch, successful lifecycle tool calls can leave machine-checkable proof without storing full tool output or raw command text in the decision log. The marker field now rejects caller-controlled route-field injection and avoids false positives from commands that merely mention lifecycle phrases.

## Validation

- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`
- `env MASC_OPAM_LOCK=0 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_tools_oas.exe test --show-errors --color=never result_markers` passed 7 tests