### PR TITLE
fix(discovery): observe history failures

### DIFF
--- a/lib/discovery_history.ml
+++ b/lib/discovery_history.ml
@@ -84,10 +84,18 @@ let record_to_json (r : probe_record) : Yojson.Safe.t =
 
 (* ── Write ────────────────────────────────────────────────── *)
 
+let failure_site_label = function
+  | "record_probe"
+  | "read_recent"
+  | "read_range"
+  | "prune" as site -> site
+  | _ -> "unknown"
+
 let observe_failure ~site ~base_path exn =
   match exn with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
+      let site = failure_site_label site in
       Prometheus.inc_counter Prometheus.metric_discovery_history_failures
         ~labels:[("site", site)]
         ();
@@ -106,7 +114,7 @@ let record_probe ~base_path (endpoints : Llm_provider.Discovery.endpoint_status 
       let json = record_to_json r in
       Dated_jsonl.append store json
     ) endpoints
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+  with exn ->
     observe_failure ~site:"record_probe" ~base_path exn
 
 (* ── Read ─────────────────────────────────────────────────── *)
@@ -115,7 +123,7 @@ let read_recent ~base_path ~count : Yojson.Safe.t list =
   try
     let store = get_or_create_store ~base_path in
     Dated_jsonl.read_recent store count
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+  with exn ->
     observe_failure ~site:"read_recent" ~base_path exn;
     []
 
@@ -123,7 +131,7 @@ let read_range ~base_path ~since ~until : Yojson.Safe.t list =
   try
     let store = get_or_create_store ~base_path in
     Dated_jsonl.read_range store ~since ~until
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+  with exn ->
     observe_failure ~site:"read_range" ~base_path exn;
     []
 
@@ -135,5 +143,5 @@ let prune ~base_path ~days =
     let deleted = Dated_jsonl.prune store ~days in
     if deleted > 0 then
       Log.Discovery.info "discovery_history: pruned %d old day-files" deleted
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+  with exn ->
     observe_failure ~site:"prune" ~base_path exn

--- a/lib/discovery_history.ml
+++ b/lib/discovery_history.ml
@@ -84,6 +84,20 @@ let record_to_json (r : probe_record) : Yojson.Safe.t =
 
 (* ── Write ────────────────────────────────────────────────── *)
 
+let observe_failure ~site ~base_path exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Prometheus.inc_counter Prometheus.metric_discovery_history_failures
+        ~labels:[("site", site)]
+        ();
+      Log.Discovery.error "discovery_history: %s failed base_path=%s: %s"
+        site base_path (Printexc.to_string exn)
+
+module For_testing = struct
+  let observe_failure = observe_failure
+end
+
 let record_probe ~base_path (endpoints : Llm_provider.Discovery.endpoint_status list) =
   try
     let store = get_or_create_store ~base_path in
@@ -93,8 +107,7 @@ let record_probe ~base_path (endpoints : Llm_provider.Discovery.endpoint_status 
       Dated_jsonl.append store json
     ) endpoints
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Discovery.error "discovery_history: append failed: %s"
-      (Printexc.to_string exn)
+    observe_failure ~site:"record_probe" ~base_path exn
 
 (* ── Read ─────────────────────────────────────────────────── *)
 
@@ -103,8 +116,7 @@ let read_recent ~base_path ~count : Yojson.Safe.t list =
     let store = get_or_create_store ~base_path in
     Dated_jsonl.read_recent store count
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Discovery.error "discovery_history: read failed: %s"
-      (Printexc.to_string exn);
+    observe_failure ~site:"read_recent" ~base_path exn;
     []
 
 let read_range ~base_path ~since ~until : Yojson.Safe.t list =
@@ -112,8 +124,7 @@ let read_range ~base_path ~since ~until : Yojson.Safe.t list =
     let store = get_or_create_store ~base_path in
     Dated_jsonl.read_range store ~since ~until
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Discovery.error "discovery_history: read_range failed: %s"
-      (Printexc.to_string exn);
+    observe_failure ~site:"read_range" ~base_path exn;
     []
 
 (* ── Prune ────────────────────────────────────────────────── *)
@@ -125,5 +136,4 @@ let prune ~base_path ~days =
     if deleted > 0 then
       Log.Discovery.info "discovery_history: pruned %d old day-files" deleted
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Discovery.error "discovery_history: prune failed: %s"
-      (Printexc.to_string exn)
+    observe_failure ~site:"prune" ~base_path exn

--- a/lib/discovery_history.mli
+++ b/lib/discovery_history.mli
@@ -45,4 +45,6 @@ val prune :
 
 module For_testing : sig
   val observe_failure : site:string -> base_path:string -> exn -> unit
+  (** White-box helper. [site] is canonicalized before metric emission and is
+      not part of the stable public API. *)
 end

--- a/lib/discovery_history.mli
+++ b/lib/discovery_history.mli
@@ -8,7 +8,7 @@
 val record_probe :
   base_path:string -> Llm_provider.Discovery.endpoint_status list -> unit
 (** Append probe results for all endpoints to today's JSONL file.
-    Silently catches I/O failures (best-effort persistence). *)
+    Logs and counts I/O failures while preserving best-effort persistence. *)
 
 (** #10404: probe records previously stored only the head model in
     [model_id], silently discarding additional models loaded on the
@@ -42,3 +42,7 @@ val read_range :
 val prune :
   base_path:string -> days:int -> unit
 (** Delete discovery day-files older than [days] days. *)
+
+module For_testing : sig
+  val observe_failure : site:string -> base_path:string -> exn -> unit
+end

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -696,6 +696,8 @@ let metric_keeper_observation_query_failures =
   "masc_keeper_observation_query_failures_total"
 let metric_persistence_read_drops =
   "masc_persistence_read_drops_total"
+let metric_discovery_history_failures =
+  "masc_discovery_history_failures_total"
 
 (* #10097: codex_cli provider cannot carry keeper-bound runtime MCP
    tools that need request-scoped auth headers.  Every time
@@ -1928,6 +1930,10 @@ let init () =
   add metric_persistence_read_drops
     "Total persisted read-model entries dropped during filesystem scans, \
      labeled by surface and reason"
+    Counter;
+  add metric_discovery_history_failures
+    "Total discovery history JSONL persistence/read/prune failures, \
+     labeled by site"
     Counter;
   add metric_oas_sse_relay_retries
     "Total OAS SSE relay retry attempts, labeled by failed stage"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -363,6 +363,7 @@ val metric_keeper_ollama_saturation_skip : string
     by [keeper] and [cascade] so dashboards can attribute starvation
     to specific cascade profiles. *)
 val metric_persistence_read_drops : string
+val metric_discovery_history_failures : string
 val metric_codex_cli_mcp_tool_omission : string
 (** #10097: per-tool counter for codex_cli keeper-bound runtime
     MCP omissions.  Paired with a once-per-fingerprint WARN log

--- a/test/test_discovery_history_models_10404.ml
+++ b/test/test_discovery_history_models_10404.ml
@@ -6,6 +6,7 @@
 
 open Alcotest
 module DH = Masc_mcp.Discovery_history
+module P = Masc_mcp.Prometheus
 
 let make ~models : DH.probe_record = {
   ts = 1777129200.0;
@@ -62,6 +63,44 @@ let test_single_model_round_trip () =
     (Astring.String.is_infix
        ~affix:"\"model_id\":\"qwen3.6:27b-coding-nvfp4\"" s)
 
+let text_has_literal text literal =
+  Astring.String.is_infix ~affix:literal text
+
+let test_failure_observer_increments_metric () =
+  let labels = [("site", "unit_test")] in
+  let before =
+    P.metric_value_or_zero P.metric_discovery_history_failures ~labels ()
+  in
+  DH.For_testing.observe_failure
+    ~site:"unit_test"
+    ~base_path:"/tmp/masc-discovery-history"
+    (Failure "synthetic discovery history failure");
+  let after =
+    P.metric_value_or_zero P.metric_discovery_history_failures ~labels ()
+  in
+  check (float 0.0001) "discovery history failure counted"
+    (before +. 1.0)
+    after
+
+let test_failure_observer_reraises_cancelled () =
+  let raised = ref false in
+  (try
+     DH.For_testing.observe_failure
+       ~site:"unit_test_cancel"
+       ~base_path:"/tmp/masc-discovery-history"
+       (Eio.Cancel.Cancelled (Failure "synthetic cancel"))
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  check bool "cancel is re-raised" true !raised
+
+let test_failure_metric_registered () =
+  let text = P.to_prometheus_text () in
+  check bool "has discovery history failure HELP" true
+    (text_has_literal text
+       ("# HELP " ^ P.metric_discovery_history_failures ^ " "));
+  check bool "has discovery history failure TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ P.metric_discovery_history_failures ^ " counter"))
+
 let () =
   run "discovery_history_models_10404" [
     ("model_preservation", [
@@ -73,5 +112,13 @@ let () =
           test_empty_models_omits_field;
         test_case "single-model round-trip stays consistent" `Quick
           test_single_model_round_trip;
+      ]);
+    ("failure_observer", [
+        test_case "increments metric" `Quick
+          test_failure_observer_increments_metric;
+        test_case "re-raises cancellation" `Quick
+          test_failure_observer_reraises_cancelled;
+        test_case "metric registered" `Quick
+          test_failure_metric_registered;
       ]);
   ]

--- a/test/test_discovery_history_models_10404.ml
+++ b/test/test_discovery_history_models_10404.ml
@@ -67,7 +67,7 @@ let text_has_literal text literal =
   Astring.String.is_infix ~affix:literal text
 
 let test_failure_observer_increments_metric () =
-  let labels = [("site", "unit_test")] in
+  let labels = [("site", "unknown")] in
   let before =
     P.metric_value_or_zero P.metric_discovery_history_failures ~labels ()
   in
@@ -80,6 +80,22 @@ let test_failure_observer_increments_metric () =
   in
   check (float 0.0001) "discovery history failure counted"
     (before +. 1.0)
+    after
+
+let test_failure_observer_bounds_metric_site_label () =
+  let labels = [("site", "arbitrary_unbounded_test_site")] in
+  let before =
+    P.metric_value_or_zero P.metric_discovery_history_failures ~labels ()
+  in
+  DH.For_testing.observe_failure
+    ~site:"arbitrary_unbounded_test_site"
+    ~base_path:"/tmp/masc-discovery-history"
+    (Failure "synthetic discovery history failure");
+  let after =
+    P.metric_value_or_zero P.metric_discovery_history_failures ~labels ()
+  in
+  check (float 0.0001) "raw arbitrary site label not emitted"
+    before
     after
 
 let test_failure_observer_reraises_cancelled () =
@@ -116,6 +132,8 @@ let () =
     ("failure_observer", [
         test_case "increments metric" `Quick
           test_failure_observer_increments_metric;
+        test_case "bounds metric site label" `Quick
+          test_failure_observer_bounds_metric_site_label;
         test_case "re-raises cancellation" `Quick
           test_failure_observer_reraises_cancelled;
         test_case "metric registered" `Quick


### PR DESCRIPTION
## Summary
- add `masc_discovery_history_failures_total` with bounded `site` labels
- route discovery-history JSONL write/read/range/prune exceptions through one observer that logs and increments the metric
- preserve the existing best-effort contracts: write/prune do not fail the caller, read fallbacks still return `[]`, and `Eio.Cancel.Cancelled` still re-raises

## Why
`Discovery_history.record_probe` was still documented as silently catching I/O failures, and the implementation only logged append/read/prune exceptions. This makes probe-history loss visible to metrics while keeping discovery cache refreshes non-blocking.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only` attempted; local shared opam pin reported `agent_sdk` at `ff434b7388c24ba9a65cadf21e118edbd61db06b`, expected `434b72c0141886bf70214799ca03309c48cbd202`
- `env MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_discovery_history_models_10404.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-discovery-history-0506-a MASC_BASE_PATH_INPUT=/private/tmp/masc-discovery-history-0506-a ./_build/default/test/test_discovery_history_models_10404.exe test failure_observer 0`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-discovery-history-0506-b MASC_BASE_PATH_INPUT=/private/tmp/masc-discovery-history-0506-b ./_build/default/test/test_discovery_history_models_10404.exe test failure_observer 1`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-discovery-history-0506-c MASC_BASE_PATH_INPUT=/private/tmp/masc-discovery-history-0506-c ./_build/default/test/test_discovery_history_models_10404.exe test failure_observer 2`