### PR TITLE
fix(dashboard): expose failure history summary state

### DIFF
--- a/dashboard/src/components/common/failure-history.a11y.test.ts
+++ b/dashboard/src/components/common/failure-history.a11y.test.ts
@@ -140,7 +140,8 @@ describe('FailureHistory a11y', () => {
 
   it('renders empty state gracefully', async () => {
     render(html`<${FailureHistory} failures=${[]} />`, container)
-    expect(container.querySelectorAll('[role="listitem"]').length).toBe(0)
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(1)
+    expect(container.querySelector('[data-failure-history-empty]')).not.toBeNull()
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/common/failure-history.test.ts
+++ b/dashboard/src/components/common/failure-history.test.ts
@@ -1,13 +1,72 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { FailureHistory } from './failure-history'
+import {
+  FailureHistory,
+  failureEntryStatus,
+  summarizeFailureHistory,
+} from './failure-history'
+import type { FailureEntry } from './failure-history'
 
-const baseFailures = [
-  { id: 'f1', agentId: 'agent-alpha-123', errorType: 'network', message: 'conn reset', timestamp: Date.now(), retryable: true, resolved: false },
-  { id: 'f2', agentId: 'agent-beta-456', errorType: 'timeout', message: 'timed out', timestamp: Date.now() - 60000, retryable: false, resolved: true },
-  { id: 'f3', agentId: 'agent-gamma-789', errorType: 'network', message: 'dns fail', timestamp: Date.now() - 120000, retryable: true, resolved: false },
+const now = new Date('2026-05-06T00:00:00Z').getTime()
+const retryableFailure: FailureEntry = {
+  id: 'f1',
+  agentId: 'agent-alpha-123',
+  errorType: 'network',
+  message: 'conn reset',
+  timestamp: now,
+  retryable: true,
+  resolved: false,
+}
+const baseFailures: FailureEntry[] = [
+  retryableFailure,
+  { id: 'f2', agentId: 'agent-beta-456', errorType: 'timeout', message: 'timed out', timestamp: now - 60000, retryable: false, resolved: true },
+  { id: 'f3', agentId: 'agent-gamma-789', errorType: 'network', message: 'dns fail', timestamp: now - 120000, retryable: true, resolved: false },
 ]
+
+describe('failureEntryStatus', () => {
+  it('reports resolved before retryability', () => {
+    expect(failureEntryStatus({ ...retryableFailure, resolved: true })).toBe('resolved')
+  })
+
+  it('reports retryable unresolved failures as retryable', () => {
+    expect(failureEntryStatus(retryableFailure)).toBe('retryable')
+  })
+
+  it('reports non-retryable unresolved failures as blocked', () => {
+    expect(failureEntryStatus({ ...retryableFailure, retryable: false })).toBe('blocked')
+  })
+})
+
+describe('summarizeFailureHistory', () => {
+  it('summarizes counts, status, latest timestamp, and top types', () => {
+    const summary = summarizeFailureHistory(baseFailures)
+    expect(summary.totalCount).toBe(3)
+    expect(summary.resolvedCount).toBe(1)
+    expect(summary.unresolvedCount).toBe(2)
+    expect(summary.retryableCount).toBe(2)
+    expect(summary.blockedCount).toBe(0)
+    expect(summary.typeCount).toBe(2)
+    expect(summary.latestTimestamp).toBe(now)
+    expect(summary.status).toBe('actionable')
+    expect(summary.topTypes[0]).toMatchObject({
+      errorType: 'network',
+      count: 2,
+      retryableCount: 2,
+    })
+  })
+
+  it('marks empty, all-resolved, and blocked-only histories', () => {
+    expect(summarizeFailureHistory([]).status).toBe('empty')
+    expect(summarizeFailureHistory(baseFailures.map((f) => ({ ...f, resolved: true }))).status).toBe('resolved')
+    expect(summarizeFailureHistory([{ ...retryableFailure, retryable: false }]).status).toBe('blocked')
+  })
+
+  it('limits top error types', () => {
+    const summary = summarizeFailureHistory(baseFailures, 1)
+    expect(summary.topTypes.map((type) => type.errorType)).toEqual(['network'])
+  })
+})
 
 describe('FailureHistory', () => {
   it('renders container', () => {
@@ -32,12 +91,40 @@ describe('FailureHistory', () => {
     const container = document.createElement('div')
     render(h(FailureHistory, { failures: baseFailures }), container)
     expect(container.textContent).toContain('1/3 해결')
+    expect(container.textContent).toContain('미해결')
+    expect(container.textContent).toContain('재시도')
+  })
+
+  it('exposes summary data attributes', () => {
+    const container = document.createElement('div')
+    render(h(FailureHistory, { failures: baseFailures }), container)
+    const root = container.querySelector('[data-failure-history]') as HTMLElement
+    expect(root.dataset.failureHistoryTotalCount).toBe('3')
+    expect(root.dataset.failureHistoryResolvedCount).toBe('1')
+    expect(root.dataset.failureHistoryUnresolvedCount).toBe('2')
+    expect(root.dataset.failureHistoryRetryableCount).toBe('2')
+    expect(root.dataset.failureHistoryBlockedCount).toBe('0')
+    expect(root.dataset.failureHistoryTypeCount).toBe('2')
+    expect(root.dataset.failureHistoryLatestTimestamp).toBe(String(now))
+    expect(root.dataset.failureHistoryTopErrorType).toBe('network')
+    expect(root.dataset.failureHistoryTopErrorCount).toBe('2')
+    expect(root.dataset.failureHistoryStatus).toBe('actionable')
   })
 
   it('renders top error types', () => {
     const container = document.createElement('div')
     render(h(FailureHistory, { failures: baseFailures }), container)
     expect(container.textContent).toContain('network')
+  })
+
+  it('exposes top error type metadata', () => {
+    const container = document.createElement('div')
+    render(h(FailureHistory, { failures: baseFailures }), container)
+    const network = container.querySelector('[data-failure-history-type="network"]') as HTMLElement
+    expect(network.dataset.failureHistoryTypeCount).toBe('2')
+    expect(network.dataset.failureHistoryTypeResolvedCount).toBe('0')
+    expect(network.dataset.failureHistoryTypeRetryableCount).toBe('2')
+    expect(network.dataset.failureHistoryTypeLatestTimestamp).toBe(String(now))
   })
 
   it('renders failure entries', () => {
@@ -57,6 +144,19 @@ describe('FailureHistory', () => {
     const container = document.createElement('div')
     render(h(FailureHistory, { failures: baseFailures }), container)
     expect(container.querySelector('[data-failure-id="f1"]')).not.toBeNull()
+  })
+
+  it('exposes row metadata', () => {
+    const container = document.createElement('div')
+    render(h(FailureHistory, { failures: baseFailures }), container)
+    const row = container.querySelector('[data-failure-id="f1"]') as HTMLElement
+    expect(row.dataset.failureAgentId).toBe('agent-alpha-123')
+    expect(row.dataset.failureErrorType).toBe('network')
+    expect(row.dataset.failureTimestamp).toBe(String(now))
+    expect(row.dataset.failureRetryable).toBe('true')
+    expect(row.dataset.failureResolved).toBe('false')
+    expect(row.dataset.failureStatus).toBe('retryable')
+    expect(row.querySelector('time')?.getAttribute('datetime')).toBe(new Date(now).toISOString())
   })
 
   it('renders resolved with line-through', () => {
@@ -108,6 +208,16 @@ describe('FailureHistory', () => {
     expect(onRetry).toHaveBeenCalledTimes(2)
     expect(onRetry).toHaveBeenCalledWith('f1')
     expect(onRetry).toHaveBeenCalledWith('f3')
+  })
+
+  it('renders an empty list row with empty summary status', () => {
+    const container = document.createElement('div')
+    render(h(FailureHistory, { failures: [] }), container)
+    const root = container.querySelector('[data-failure-history]') as HTMLElement
+    expect(root.dataset.failureHistoryStatus).toBe('empty')
+    expect(root.dataset.failureHistoryTopErrorType).toBe('')
+    expect(container.querySelector('[data-failure-history-empty]')).not.toBeNull()
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(1)
   })
 
   it('applies testId', () => {

--- a/dashboard/src/components/common/failure-history.ts
+++ b/dashboard/src/components/common/failure-history.ts
@@ -5,7 +5,7 @@
 
 import { html } from 'htm/preact'
 
-interface FailureEntry {
+export interface FailureEntry {
   id: string
   agentId: string
   errorType: string
@@ -13,6 +13,29 @@ interface FailureEntry {
   timestamp: number
   retryable: boolean
   resolved?: boolean
+}
+
+export type FailureEntryStatus = 'resolved' | 'retryable' | 'blocked'
+export type FailureHistoryStatus = 'empty' | 'resolved' | 'actionable' | 'blocked'
+
+export interface FailureTypeSummary {
+  readonly errorType: string
+  readonly count: number
+  readonly resolvedCount: number
+  readonly retryableCount: number
+  readonly latestTimestamp: number | null
+}
+
+export interface FailureHistorySummary {
+  readonly totalCount: number
+  readonly resolvedCount: number
+  readonly unresolvedCount: number
+  readonly retryableCount: number
+  readonly blockedCount: number
+  readonly typeCount: number
+  readonly latestTimestamp: number | null
+  readonly topTypes: FailureTypeSummary[]
+  readonly status: FailureHistoryStatus
 }
 
 interface FailureHistoryProps {
@@ -32,7 +55,9 @@ const ERROR_ICON: Record<string, string> = {
 }
 
 function formatTime(ts: number): string {
+  if (!Number.isFinite(ts)) return '--'
   const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return '--'
   return d.toLocaleString('ko-KR', {
     month: 'short',
     day: 'numeric',
@@ -41,24 +66,88 @@ function formatTime(ts: number): string {
   })
 }
 
+function formatDateTime(ts: number): string | undefined {
+  if (!Number.isFinite(ts)) return undefined
+  const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return undefined
+  return d.toISOString()
+}
+
+export function failureEntryStatus(failure: FailureEntry): FailureEntryStatus {
+  if (failure.resolved) return 'resolved'
+  return failure.retryable ? 'retryable' : 'blocked'
+}
+
+export function summarizeFailureHistory(failures: FailureEntry[], topTypeLimit = 3): FailureHistorySummary {
+  const typeSummaries = new Map<string, { count: number; resolvedCount: number; retryableCount: number; latestTimestamp: number | null }>()
+  let resolvedCount = 0
+  let retryableCount = 0
+  let latestTimestamp: number | null = null
+
+  failures.forEach((failure) => {
+    if (failure.resolved) {
+      resolvedCount += 1
+    } else if (failure.retryable) {
+      retryableCount += 1
+    }
+
+    if (Number.isFinite(failure.timestamp)) {
+      latestTimestamp = latestTimestamp === null ? failure.timestamp : Math.max(latestTimestamp, failure.timestamp)
+    }
+
+    const type = typeSummaries.get(failure.errorType) ?? {
+      count: 0,
+      resolvedCount: 0,
+      retryableCount: 0,
+      latestTimestamp: null,
+    }
+    type.count += 1
+    if (failure.resolved) type.resolvedCount += 1
+    if (failure.retryable && !failure.resolved) type.retryableCount += 1
+    if (Number.isFinite(failure.timestamp)) {
+      type.latestTimestamp = type.latestTimestamp === null ? failure.timestamp : Math.max(type.latestTimestamp, failure.timestamp)
+    }
+    typeSummaries.set(failure.errorType, type)
+  })
+
+  const totalCount = failures.length
+  const unresolvedCount = totalCount - resolvedCount
+  const blockedCount = unresolvedCount - retryableCount
+  const limit = Number.isFinite(topTypeLimit) ? Math.max(0, Math.floor(topTypeLimit)) : 0
+  const topTypes = Array.from(typeSummaries.entries())
+    .map(([errorType, summary]) => ({ errorType, ...summary }))
+    .sort((a, b) => b.count - a.count || (b.latestTimestamp ?? 0) - (a.latestTimestamp ?? 0) || a.errorType.localeCompare(b.errorType))
+    .slice(0, limit)
+  const status: FailureHistoryStatus =
+    totalCount === 0
+      ? 'empty'
+      : unresolvedCount === 0
+        ? 'resolved'
+        : retryableCount > 0
+          ? 'actionable'
+          : 'blocked'
+
+  return {
+    totalCount,
+    resolvedCount,
+    unresolvedCount,
+    retryableCount,
+    blockedCount,
+    typeCount: typeSummaries.size,
+    latestTimestamp,
+    topTypes,
+    status,
+  }
+}
+
 export function FailureHistory({
   failures,
   onRetry,
   onDismiss,
   testId,
 }: FailureHistoryProps) {
-  const total = failures.length
-  const resolvedCount = failures.filter((f) => f.resolved).length
-  const retryableCount = failures.filter((f) => f.retryable && !f.resolved).length
-
-  const typeCounts = failures.reduce<Record<string, number>>((acc, f) => {
-    acc[f.errorType] = (acc[f.errorType] || 0) + 1
-    return acc
-  }, {})
-
-  const topTypes = Object.entries(typeCounts)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 3)
+  const summary = summarizeFailureHistory(failures)
+  const topType = summary.topTypes[0]
 
   return html`
     <div
@@ -66,27 +155,61 @@ export function FailureHistory({
       role="region"
       aria-label="실패 이력"
       data-failure-history
+      data-failure-history-total-count=${summary.totalCount}
+      data-failure-history-resolved-count=${summary.resolvedCount}
+      data-failure-history-unresolved-count=${summary.unresolvedCount}
+      data-failure-history-retryable-count=${summary.retryableCount}
+      data-failure-history-blocked-count=${summary.blockedCount}
+      data-failure-history-type-count=${summary.typeCount}
+      data-failure-history-latest-timestamp=${summary.latestTimestamp ?? ''}
+      data-failure-history-top-error-type=${topType?.errorType ?? ''}
+      data-failure-history-top-error-count=${topType?.count ?? 0}
+      data-failure-history-status=${summary.status}
       data-testid=${testId}
     >
-      <div class="mb-3 flex items-center justify-between">
+      <div class="mb-3 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
         <h4 class="text-sm font-medium text-[var(--color-fg-primary)]">실패 이력</h4>
         <span class="text-xs text-[var(--color-fg-secondary)]">
-          ${resolvedCount}/${total} 해결
+          ${summary.resolvedCount}/${summary.totalCount} 해결
         </span>
       </div>
 
-      ${topTypes.length > 0
+      <div
+        class="mb-3 grid grid-cols-3 gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2"
+        aria-label="실패 이력 요약"
+        data-failure-history-summary
+      >
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">전체</div>
+          <div class="font-mono text-sm text-[var(--color-fg-primary)]">${summary.totalCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">미해결</div>
+          <div class="font-mono text-sm text-[var(--color-status-err)]">${summary.unresolvedCount}</div>
+        </div>
+        <div>
+          <div class="text-3xs text-[var(--color-fg-secondary)]">재시도</div>
+          <div class="font-mono text-sm text-[var(--color-status-warn)]">${summary.retryableCount}</div>
+        </div>
+      </div>
+
+      ${summary.topTypes.length > 0
         ? html`
-            <div class="mb-3 flex flex-wrap gap-2">
-              ${topTypes.map(
-                ([type, count]) => html`
+            <div class="mb-3 flex flex-wrap gap-2" aria-label="상위 실패 유형" data-failure-history-top-types>
+              ${summary.topTypes.map(
+                (type) => html`
                   <span
-                    key=${type}
+                    key=${type.errorType}
                     class="inline-flex items-center rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-xs text-[var(--color-fg-secondary)]"
+                    data-failure-history-type=${type.errorType}
+                    data-failure-history-type-count=${type.count}
+                    data-failure-history-type-resolved-count=${type.resolvedCount}
+                    data-failure-history-type-retryable-count=${type.retryableCount}
+                    data-failure-history-type-latest-timestamp=${type.latestTimestamp ?? ''}
                   >
-                    ${ERROR_ICON[type] || ERROR_ICON.default}
-                    <span class="ml-1">${type}</span>
-                    <span class="ml-1 text-[var(--color-fg-primary)]">${count}</span>
+                    ${ERROR_ICON[type.errorType] || ERROR_ICON.default}
+                    <span class="ml-1">${type.errorType}</span>
+                    <span class="ml-1 text-[var(--color-fg-primary)]">${type.count}</span>
                   </span>
                 `,
               )}
@@ -94,66 +217,91 @@ export function FailureHistory({
           `
         : null}
 
-      <div role="list" class="space-y-2">
-        ${failures.map((f) => {
+      <div role="list" class="space-y-2" aria-label="실패 목록, 총 ${summary.totalCount}건">
+        ${failures.length === 0
+          ? html`
+              <div
+                role="listitem"
+                class="rounded-[var(--r-1)] border border-dashed border-[var(--color-border-divider)] p-2 text-xs text-[var(--color-fg-muted)]"
+                data-failure-history-empty
+              >
+                기록된 실패 없음
+              </div>
+            `
+          : failures.map((f) => {
           const icon = ERROR_ICON[f.errorType] || ERROR_ICON.default
+          const status = failureEntryStatus(f)
           const statusClass = f.resolved
             ? 'text-[var(--color-fg-secondary)] line-through opacity-60'
             : 'text-[var(--color-fg-primary)]'
+          const canRetry = f.retryable && !f.resolved && onRetry
+          const canDismiss = onDismiss && !f.resolved
           return html`
             <div
               key=${f.id}
               role="listitem"
-              class="flex items-start gap-2 rounded-[var(--r-1)] border border-[var(--color-border-divider)] p-2"
+              class="grid grid-cols-[auto_minmax(0,1fr)] gap-2 rounded-[var(--r-1)] border border-[var(--color-border-divider)] p-2 sm:grid-cols-[auto_minmax(0,1fr)_auto]"
               data-failure-id=${f.id}
+              data-failure-agent-id=${f.agentId}
+              data-failure-error-type=${f.errorType}
+              data-failure-timestamp=${f.timestamp}
+              data-failure-retryable=${f.retryable}
+              data-failure-resolved=${Boolean(f.resolved)}
+              data-failure-status=${status}
             >
               <span class="mt-0.5 text-xs" aria-hidden="true">${icon}</span>
               <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-1">
+                <div class="flex flex-wrap items-center gap-x-1 gap-y-0.5">
                   <span class="text-xs font-mono text-[var(--color-fg-secondary)]">
                     ${f.agentId.slice(0, 8)}
                   </span>
                   <span class="text-xs text-[var(--color-fg-secondary)]">·</span>
-                  <span class="text-xs text-[var(--color-fg-secondary)]">${formatTime(f.timestamp)}</span>
+                  <time class="text-xs text-[var(--color-fg-secondary)]" datetime=${formatDateTime(f.timestamp)}>
+                    ${formatTime(f.timestamp)}
+                  </time>
                 </div>
-                <div class="mt-0.5 text-sm ${statusClass}">${f.message}</div>
+                <div class="mt-0.5 break-words text-sm ${statusClass}">${f.message}</div>
               </div>
-              <div class="flex items-center gap-1">
-                ${f.retryable && !f.resolved && onRetry
+              ${canRetry || canDismiss
+                ? html`
+                    <div class="col-start-2 flex flex-wrap items-center gap-1 sm:col-start-auto sm:justify-end">
+                      ${canRetry
                   ? html`
                       <button
-                        class="rounded-[var(--r-1)] px-2 py-1 text-xs text-[var(--color-accent)] hover:bg-[var(--color-bg-elevated)]"
-                        onClick=${() => onRetry(f.id)}
+                        class="rounded-[var(--r-1)] px-2 py-1 text-xs text-[var(--color-accent-fg)] hover:bg-[var(--color-bg-elevated)]"
+                        onClick=${() => onRetry?.(f.id)}
                         aria-label="${f.message} 재시도"
                       >
                         재시도
                       </button>
-                    `
+                  `
                   : null}
-                ${onDismiss && !f.resolved
+                ${canDismiss
                   ? html`
                       <button
                         class="rounded-[var(--r-1)] px-2 py-1 text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-elevated)]"
-                        onClick=${() => onDismiss(f.id)}
+                        onClick=${() => onDismiss?.(f.id)}
                         aria-label="${f.message} 해제"
                       >
                         해제
                       </button>
                     `
                   : null}
-              </div>
+                    </div>
+                  `
+                : null}
             </div>
           `
         })}
       </div>
 
-      ${retryableCount > 0 && onRetry
+      ${summary.retryableCount > 0 && onRetry
         ? html`
             <button
               class="mt-3 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] py-1.5 text-sm text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-elevated)]"
               onClick=${() => failures.filter((f) => f.retryable && !f.resolved).forEach((f) => onRetry?.(f.id))}
             >
-              미해결 ${retryableCount}건 일괄 재시도
+              미해결 ${summary.retryableCount}건 일괄 재시도
             </button>
           `
         : null}


### PR DESCRIPTION
## Summary
- export FailureHistory summary helpers and status types for deterministic failure counts
- expose root, error-type, and row-level data attributes for dashboard/runtime proof surfaces
- add a compact summary strip, semantic empty row, timestamp elements, and mobile-safe row/action wrapping

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/failure-history.test.ts src/components/common/failure-history.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint (passes; existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- pnpm --dir dashboard run build (passes; existing Vite dynamic/static import and chunk-size warnings)

## Browser QA
- Vite QA: http://127.0.0.1:5212/dashboard/failure-history-qa.html with MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9
- Desktop screenshot: /tmp/masc-failure-history-summary-0506.png
- Mobile screenshot: /tmp/masc-failure-history-summary-0506-mobile.png
- Verified mixed metadata: total=4, resolved=1, unresolved=3, retryable=2, blocked=1, typeCount=3, topType=network, status=actionable
- Verified blocked status, empty status/empty row, retry/dismiss callbacks, retry color rgb(212, 161, 74), and zero horizontal overflow on desktop/mobile

## Notes
- Temporary QA page was removed before commit.
