### PR TITLE
fix(keeper): preserve cascade retries before turn timeout

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -291,6 +291,21 @@ let reclassify_oas_timeout_for_attempt
            })
   | _ -> err
 
+let attempt_watchdog_timeout_sec
+    ~(remaining_turn_budget_s : float)
+    (timeout_budget : oas_timeout_budget_resolution) : float =
+  let desired =
+    timeout_budget.effective_timeout_sec +. oas_timeout_guard_sec
+  in
+  let outer_margin_sec = 1.0 in
+  let cap_before_outer_timeout =
+    Float.max 0.001 (remaining_turn_budget_s -. outer_margin_sec)
+  in
+  let floor =
+    Float.min min_oas_timeout_budget_sec cap_before_outer_timeout
+  in
+  Float.max floor (Float.min desired cap_before_outer_timeout)
+
 type degraded_retry_budget_decision =
   | No_degraded_retry
   | Degraded_retry_slot_phase_exhausted of EC.degraded_retry

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -291,15 +291,17 @@ let reclassify_oas_timeout_for_attempt
            })
   | _ -> err
 
+let attempt_watchdog_outer_turn_reserve_sec = 1.0
+
 let attempt_watchdog_timeout_sec
     ~(remaining_turn_budget_s : float)
     (timeout_budget : oas_timeout_budget_resolution) : float =
   let desired =
     timeout_budget.effective_timeout_sec +. oas_timeout_guard_sec
   in
-  let outer_margin_sec = 1.0 in
   let cap_before_outer_timeout =
-    Float.max 0.001 (remaining_turn_budget_s -. outer_margin_sec)
+    Float.max 0.001
+      (remaining_turn_budget_s -. attempt_watchdog_outer_turn_reserve_sec)
   in
   let floor =
     Float.min min_oas_timeout_budget_sec cap_before_outer_timeout

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -104,6 +104,18 @@ val reclassify_oas_timeout_for_attempt :
   Agent_sdk.Error.sdk_error ->
   Agent_sdk.Error.sdk_error
 
+val attempt_watchdog_timeout_sec :
+  remaining_turn_budget_s:float ->
+  oas_timeout_budget_resolution ->
+  float
+(** Wall-clock watchdog for a single cascade attempt.
+
+    The watchdog fires after the OAS per-attempt budget plus the normal
+    finalization guard, but no later than one second before the enclosing
+    keeper turn wall-clock timeout. This keeps a hung provider attempt on the
+    structured [oas_timeout_budget] path, where degraded cascade rotation can
+    still run, instead of falling through to terminal [turn_timeout]. *)
+
 type degraded_retry_budget_decision =
   | No_degraded_retry
   | Degraded_retry_slot_phase_exhausted of EC.degraded_retry

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -111,10 +111,11 @@ val attempt_watchdog_timeout_sec :
 (** Wall-clock watchdog for a single cascade attempt.
 
     The watchdog fires after the OAS per-attempt budget plus the normal
-    finalization guard, but no later than one second before the enclosing
-    keeper turn wall-clock timeout. This keeps a hung provider attempt on the
-    structured [oas_timeout_budget] path, where degraded cascade rotation can
-    still run, instead of falling through to terminal [turn_timeout]. *)
+    finalization guard, while reserving a small outer-turn margin before the
+    enclosing keeper turn wall-clock timeout. This keeps a hung provider
+    attempt on the structured [oas_timeout_budget] path, where degraded cascade
+    rotation can still run, instead of falling through to terminal
+    [turn_timeout]. *)
 
 type degraded_retry_budget_decision =
   | No_degraded_retry

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -899,7 +899,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             else Keeper_agent_tool_surface.Optional
           in
           let do_run ~(execution : cascade_execution) ~run_meta ~run_generation ~is_retry
-              ~oas_timeout_s =
+              ~oas_timeout_s ~attempt_watchdog_s =
             last_execution := execution;
             Otel_genai.with_keeper_turn_span
               ~keeper_name:run_meta.name
@@ -921,37 +921,39 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ~prev:Keeper_turn_fsm.Awaiting_provider
                   Keeper_turn_fsm.Streaming;
                 try
-                  Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
-                    ~max_context:execution.max_context ~build_turn_prompt
-                    ~user_message ~cascade_name:execution.cascade_name
-                    ~world_observation:observation
-                    ~turn_affordances
-                    ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
-                    ~generation:run_generation
-                    ~max_turns
-                    ~max_idle_turns
-                    ~history_user_source:"world_state_prompt"
-                    ~history_assistant_source:"internal_assistant"
-                    ~degraded_retry_applied:(Option.is_some !degraded_retry_info)
-                    ?degraded_retry_cascade:
-                      (Option.map
-                         (fun (retry : EC.degraded_retry) -> retry.next_cascade)
-                         !degraded_retry_info)
-                    ?fallback_reason:
-                      (Option.map
-                         (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
-                         !degraded_retry_info)
-                    ~cascade_rotation_attempts:
-                      (List.rev !cascade_rotation_attempts)
-                    ~temperature:execution.temperature
-                    ~max_tokens:execution.max_tokens
-                    ~oas_timeout_s
-                    ?max_cost_usd
-                    ~trajectory_acc
-                    ~is_retry
-                    ?shared_context
-                    ?event_bus:(Keeper_event_bus.get ())
-                    ()
+                  Eio.Time.with_timeout_exn clock attempt_watchdog_s (fun () ->
+                      Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
+                        ~max_context:execution.max_context ~build_turn_prompt
+                        ~user_message ~cascade_name:execution.cascade_name
+                        ~world_observation:observation
+                        ~turn_affordances
+                        ?provider_filter:
+                          (Env_config_keeper.KeeperCascade.provider_allowlist ())
+                        ~generation:run_generation
+                        ~max_turns
+                        ~max_idle_turns
+                        ~history_user_source:"world_state_prompt"
+                        ~history_assistant_source:"internal_assistant"
+                        ~degraded_retry_applied:(Option.is_some !degraded_retry_info)
+                        ?degraded_retry_cascade:
+                          (Option.map
+                             (fun (retry : EC.degraded_retry) -> retry.next_cascade)
+                             !degraded_retry_info)
+                        ?fallback_reason:
+                          (Option.map
+                             (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
+                             !degraded_retry_info)
+                        ~cascade_rotation_attempts:
+                          (List.rev !cascade_rotation_attempts)
+                        ~temperature:execution.temperature
+                        ~max_tokens:execution.max_tokens
+                        ~oas_timeout_s
+                        ?max_cost_usd
+                        ~trajectory_acc
+                        ~is_retry
+                        ?shared_context
+                        ?event_bus:(Keeper_event_bus.get ())
+                        ())
                 with Eio.Cancel.Cancelled _ as e ->
                   (* Cycle 1b-iv: external cancellation that escapes the
                      in-band receipt builder in [Keeper_agent_run.run_turn].
@@ -978,7 +980,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     ~cascade_name:execution.cascade_name
                     ~keeper_turn_id
                     ();
-                  raise e)
+                  raise e
+                | Eio.Time.Timeout ->
+                  Error
+                    (Agent_sdk.Error.Api
+                       (Timeout
+                          {
+                            message =
+                              Printf.sprintf
+                                "Turn wall-clock budget exhausted during cascade attempt \
+                                 (budget=%.1fs, watchdog=%.1fs)"
+                                oas_timeout_s attempt_watchdog_s;
+                          })))
           in
           let fail_open_rotation_cascades =
             active_fail_open_rotation_cascades ()
@@ -1080,8 +1093,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_registry.set_turn_cascade_state
                     ~base_path:config.base_path meta.name
                     Keeper_registry.Cascade_trying;
+                  let attempt_watchdog_s =
+                    attempt_watchdog_timeout_sec
+                      ~remaining_turn_budget_s:(remaining_turn_budget_s ())
+                      timeout_budget
+                  in
                   do_run ~execution ~run_meta ~run_generation ~is_retry
                     ~oas_timeout_s:timeout_budget.effective_timeout_sec
+                    ~attempt_watchdog_s
             in
             match attempt_result with
             | Ok result ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -57,6 +57,12 @@ val resolve_bounded_oas_timeout_budget_with_turn_budget :
   remaining_turn_budget_s:float ->
   oas_timeout_budget_resolution option
 
+(** Per-attempt watchdog used around the OAS call. It fires before the
+    enclosing keeper-turn wall-clock timeout so recoverable provider stalls can
+    still rotate through the degraded cascade path. *)
+val attempt_watchdog_timeout_sec :
+  remaining_turn_budget_s:float -> oas_timeout_budget_resolution -> float
+
 val oas_retry_budget_available_for_turn :
   is_retry:bool ->
   estimated_input_tokens:int ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5525,6 +5525,41 @@ let test_bounded_oas_timeout_reserves_degraded_retry_budget () =
         budget.source
   | None -> fail "expected bounded timeout"
 
+let test_attempt_watchdog_preserves_degraded_retry_reserve () =
+  match
+    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~is_retry:false ~reserve_degraded_retry_budget:true
+      ~estimated_input_tokens:2_000 ~max_turns:4
+      ~remaining_turn_budget_s:500.0
+  with
+  | Some budget ->
+      check (float 0.01)
+        "attempt watchdog includes OAS timeout plus finalization guard"
+        257.5
+        (UT.attempt_watchdog_timeout_sec
+           ~remaining_turn_budget_s:500.0
+           budget)
+  | None -> fail "expected bounded timeout"
+
+let test_attempt_watchdog_fires_before_outer_turn_timeout () =
+  let budget =
+    {
+      UT.effective_timeout_sec = 293.0;
+      adaptive_timeout_sec = 600.0;
+      keeper_turn_timeout_sec = 600.0;
+      remaining_turn_budget_sec = 293.0;
+      estimated_input_tokens = 2_000;
+      max_turns = 4;
+      source = "adaptive_per_attempt_retry";
+    }
+  in
+  check (float 0.01)
+    "retry watchdog is capped just before the enclosing turn timeout"
+    292.0
+    (UT.attempt_watchdog_timeout_sec
+       ~remaining_turn_budget_s:293.0
+       budget)
+
 let test_bounded_oas_timeout_refuses_too_little_budget () =
   check (option (float 0.01)) "insufficient budget returns none" None
     (UT.bounded_oas_timeout_for_turn_budget
@@ -7723,6 +7758,10 @@ let () =
             test_bounded_oas_timeout_uses_channel_turn_budget_override;
           test_case "bounded OAS timeout reserves degraded retry budget" `Quick
             test_bounded_oas_timeout_reserves_degraded_retry_budget;
+          test_case "attempt watchdog preserves degraded retry reserve" `Quick
+            test_attempt_watchdog_preserves_degraded_retry_reserve;
+          test_case "attempt watchdog fires before outer turn timeout" `Quick
+            test_attempt_watchdog_fires_before_outer_turn_timeout;
           test_case "bounded OAS timeout refuses too little remaining budget" `Quick
             test_bounded_oas_timeout_refuses_too_little_budget;
           test_case "OAS timeout classification uses current attempt budget" `Quick


### PR DESCRIPTION
## Summary

Live keeper runtime state showed many keepers ending turns with `last_blocker=turn_timeout` even though the cascade catalog already has degraded/local fallback paths. This patch adds a per-attempt watchdog around `Keeper_agent_run.run_turn` so a hung provider attempt fails on the structured `oas_timeout_budget` path before the enclosing keeper-turn wall clock expires.

Changes:
- add `attempt_watchdog_timeout_sec` to compute an attempt-local wall clock cap from the OAS attempt budget plus guard time
- wrap each OAS cascade attempt with the watchdog and reclassify watchdog expiry as the existing structural OAS timeout shape
- keep the watchdog capped one second before the outer turn timeout so degraded cascade rotation still has budget to run
- add regression coverage for the degraded retry reserve and the outer-timeout cap

## Product impact

Keepers should no longer burn the entire turn budget on one stalled provider call and skip the existing degraded/local recovery path. Operator-visible `turn_timeout` blockers should move toward structured cascade retry/fallback evidence when the provider hangs.

## Evidence

- Live runtime symptom checked from `/Users/dancer/me/.masc/keepers/*.json`: most active keepers reported `last_blocker=turn_timeout`.
- Live cascade config already contains fallback paths such as `tier_fast -> keeper_bound_safe -> local_recovery` and `big_three -> local_recovery`.
- Root cause in code: `run_keeper_cycle` had an outer turn timeout around the full retry loop, but no per-attempt wall-clock watchdog around `Keeper_agent_run.run_turn`.

## Review evidence

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe` passed: 327 tests
- Local `agent_sdk` opam pin was updated from `0.190.12` to repo-required `0.190.25` via `scripts/opam-pin-external-deps.sh --install` before rerunning the focused build.

## Linked issue

None yet. This PR is from live runtime triage of keeper `turn_timeout` blockers.
