### PR TITLE
fix(memory): preserve keeper hooks around memory

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1377,7 +1377,7 @@ let prepare_agent_setup
         ~episode_limit:30
         ~procedure_limit:10 ()
     in
-    Agent_sdk.Hooks.compose ~outer:mem_hooks ~inner:hooks
+    Memory_hooks.compose_with_inner ~memory_hooks:mem_hooks ~inner:hooks
   in
   (* Tier K4b/K4c: install the tool-emission PostToolUse hook so
      tagged tool results flow into this keeper's own accumulator

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -50,6 +50,42 @@ let render_memory_context
   | [] -> None
   | parts -> Some (String.concat "\n\n" parts)
 
+let before_turn_params_event_with_current_params event current_params =
+  match event with
+  | Agent_sdk.Hooks.BeforeTurnParams params ->
+      Agent_sdk.Hooks.BeforeTurnParams { params with current_params }
+  | _ -> event
+
+let compose_before_turn_params outer inner =
+  match outer, inner with
+  | None, None -> None
+  | Some _, None -> outer
+  | None, Some _ -> inner
+  | Some f_outer, Some f_inner ->
+      Some
+        (fun event ->
+          match f_outer event with
+          | Agent_sdk.Hooks.Continue -> f_inner event
+          | Agent_sdk.Hooks.AdjustParams params ->
+              let event' =
+                before_turn_params_event_with_current_params event params
+              in
+              (match f_inner event' with
+               | Agent_sdk.Hooks.Continue -> Agent_sdk.Hooks.AdjustParams params
+               | decision -> decision)
+          | decision -> decision)
+
+let compose_with_inner ~memory_hooks ~inner =
+  let composed =
+    Agent_sdk.Hooks.compose ~outer:memory_hooks ~inner
+  in
+  { composed with
+    before_turn_params =
+      compose_before_turn_params
+        memory_hooks.Agent_sdk.Hooks.before_turn_params
+        inner.Agent_sdk.Hooks.before_turn_params
+  }
+
 (** Create OAS hooks for hook-first memory injection.
 
     @param agent_name Keeper agent name (for procedure/episode lookup)
@@ -74,6 +110,7 @@ let make
     ?world_backend
     ?(episode_limit = 30)
     ?(procedure_limit = 10)
+    ?(flush_incremental = Memory_oas_bridge.flush_incremental)
     () : Agent_sdk.Hooks.hooks =
   { Agent_sdk.Hooks.empty with
 
@@ -99,13 +136,26 @@ let make
     after_turn = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.AfterTurn _ ->
-        let (ep, pr) =
-          Memory_oas_bridge.flush_incremental ~memory ~agent_name
-        in
-        if ep > 0 || pr > 0 then
-          Log.Keeper.debug
-            "memory_hooks: flush_incremental agent=%s episodes=%d procedures=%d"
-            agent_name ep pr;
+        (try
+           let (ep, pr) = flush_incremental ~memory ~agent_name in
+           if ep > 0 || pr > 0 then
+             Log.Keeper.debug
+               "memory_hooks: flush_incremental agent=%s episodes=%d procedures=%d"
+               agent_name ep pr
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_lifecycle_callback_failures
+               ~labels:
+                 [
+                   ("keeper", agent_name);
+                   ("callback", "memory_after_turn_flush");
+                 ]
+               ();
+             Log.Keeper.warn
+               "memory_hooks: flush_incremental failed agent=%s: %s"
+               agent_name (Printexc.to_string exn));
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
   }

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -8,8 +8,8 @@
     This eliminates the MASC-to-OAS lifecycle invasion where the former
     [create_memory_full] directly manipulated OAS memory state.
 
-    The hook is composed (via [Hooks.compose]) with existing keeper hooks
-    so existing safety/cost/tool-disclosure hooks remain untouched.
+    The hook is composed (via [compose_with_inner]) with existing keeper
+    hooks so existing safety/cost/tool-disclosure hooks remain untouched.
 
     Phase 1 introduced this as an opt-in path behind
     [MASC_MEMORY_HOOK_FIRST]. Phase 2 made it the only path and
@@ -93,15 +93,18 @@ let compose_with_inner ~memory_hooks ~inner =
     @param memory OAS Memory.t instance (for AfterTurn flush)
     @param episode_limit Max episodes to inject (default 30)
     @param procedure_limit Max procedures to inject (default 10)
+    @param flush_incremental Dependency-injection seam for tests; returns
+           persisted episode/procedure counts.
 
     Returns a [Hooks.hooks] record with:
     - [before_turn_params]: injects memory text via [extra_system_context]
     - [after_turn]: incrementally flushes episodes/procedures
 
-    Compose with other hooks via [Hooks.compose]:
+    Compose with other hooks via [compose_with_inner] so memory-adjusted
+    [BeforeTurnParams] are passed to the inner keeper hooks:
     {[
       let memory_hooks = Memory_hooks.make ~agent_name ~config ~memory () in
-      let hooks = Hooks.compose ~outer:memory_hooks ~inner:base_hooks
+      let hooks = Memory_hooks.compose_with_inner ~memory_hooks ~inner:base_hooks
     ]} *)
 let make
     ~(agent_name : string)
@@ -148,10 +151,7 @@ let make
              Prometheus.inc_counter
                Prometheus.metric_keeper_lifecycle_callback_failures
                ~labels:
-                 [
-                   ("keeper", agent_name);
-                   ("callback", "memory_after_turn_flush");
-                 ]
+                 [("callback", "memory_after_turn_flush")]
                ();
              Log.Keeper.warn
                "memory_hooks: flush_incremental failed agent=%s: %s"

--- a/lib/memory_hooks.mli
+++ b/lib/memory_hooks.mli
@@ -37,5 +37,16 @@ val make :
   ?world_backend:Agent_sdk.Memory.long_term_backend ->
   ?episode_limit:int ->
   ?procedure_limit:int ->
+  ?flush_incremental:
+    (memory:Agent_sdk.Memory.t -> agent_name:string -> int * int) ->
   unit ->
   Agent_sdk.Hooks.hooks
+
+val compose_with_inner :
+  memory_hooks:Agent_sdk.Hooks.hooks ->
+  inner:Agent_sdk.Hooks.hooks ->
+  Agent_sdk.Hooks.hooks
+(** Compose memory hooks with existing keeper hooks while preserving the
+    keeper [before_turn_params] slot.  When memory injects adjusted turn
+    params, the inner hook is invoked with those params instead of being
+    bypassed by generic OAS hook composition. *)

--- a/lib/memory_hooks.mli
+++ b/lib/memory_hooks.mli
@@ -15,6 +15,8 @@
     @param memory OAS Memory.t instance (for AfterTurn flush)
     @param episode_limit Max episodes to inject (default 30)
     @param procedure_limit Max procedures to inject (default 10)
+    @param flush_incremental Dependency-injection hook for tests; it returns
+           persisted episode/procedure counts.
 
     Returns a [Hooks.hooks] record with:
     - [before_turn_params]: injects memory text via [extra_system_context]

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -269,10 +269,7 @@ let test_after_turn_flush_failure_still_continues () =
   let config = make_test_config ~base_path:tmp_dir in
   let memory = Memory_oas_bridge.create_memory ~agent_name:"test_after_fail" () in
   let labels =
-    [
-      ("keeper", "test_after_fail");
-      ("callback", "memory_after_turn_flush");
-    ]
+    [("callback", "memory_after_turn_flush")]
   in
   let before =
     P.metric_value_or_zero P.metric_keeper_lifecycle_callback_failures

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -12,6 +12,7 @@ open Alcotest
 
 module Memory_oas_bridge = Masc_mcp.Memory_oas_bridge
 module Memory_hooks = Masc_mcp.Memory_hooks
+module P = Masc_mcp.Prometheus
 
 let test_base_path = Filename.temp_dir "masc_memory_hooks_base" ""
 let () = Unix.putenv "MASC_BASE_PATH" test_base_path
@@ -170,6 +171,70 @@ let test_hook_injects_world_memory () =
    | _ -> fail "unexpected hook decision");
   (try Sys.rmdir tmp_dir with _ -> ())
 
+let test_compose_preserves_inner_before_turn_params () =
+  let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
+  let config = make_test_config ~base_path:tmp_dir in
+  let memory = Agent_sdk.Memory.create () in
+  ignore
+    (Agent_sdk.Memory.store
+       memory
+       ~tier:Agent_sdk.Memory.Long_term
+       "world:compose"
+       (`Assoc [ "content", `String "Memory context must survive composition." ]));
+  let memory_hooks =
+    Memory_hooks.make
+      ~agent_name:"test_compose"
+      ~config
+      ~memory
+      ()
+  in
+  let inner_seen = ref false in
+  let inner_hooks =
+    { Agent_sdk.Hooks.empty with
+      before_turn_params =
+        Some
+          (function
+            | Agent_sdk.Hooks.BeforeTurnParams { current_params; _ } ->
+                inner_seen := true;
+                let extra =
+                  match current_params.extra_system_context with
+                  | None -> Some "[keeper params]"
+                  | Some existing -> Some (existing ^ "\n\n[keeper params]")
+                in
+                Agent_sdk.Hooks.AdjustParams
+                  { current_params with
+                    extra_system_context = extra;
+                    tool_choice = Some Agent_sdk.Types.Auto;
+                  }
+            | _ -> Agent_sdk.Hooks.Continue)
+    }
+  in
+  let hooks =
+    Memory_hooks.compose_with_inner ~memory_hooks ~inner:inner_hooks
+  in
+  let event = make_before_turn_params_event ~turn:1 () in
+  let decision =
+    match hooks.before_turn_params with
+    | Some f -> f event
+    | None -> fail "before_turn_params hook should be Some"
+  in
+  check bool "inner hook ran" true !inner_seen;
+  (match decision with
+   | Agent_sdk.Hooks.AdjustParams params ->
+     (match params.extra_system_context with
+      | Some ctx ->
+        check bool "world memory preserved" true
+          (contains_text ~needle:"world:compose" ctx);
+        check bool "inner context appended" true
+          (contains_text ~needle:"[keeper params]" ctx)
+      | None -> fail "expected composed extra_system_context");
+     check bool "inner tool choice preserved" true
+       (match params.tool_choice with
+        | Some Agent_sdk.Types.Auto -> true
+        | _ -> false)
+   | _ -> fail "expected AdjustParams from composed hooks");
+  (try Sys.rmdir tmp_dir with _ -> ())
+
 let test_after_turn_hook_returns_continue () =
   let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
   let config = make_test_config ~base_path:tmp_dir in
@@ -197,6 +262,68 @@ let test_after_turn_hook_returns_continue () =
   in
   check bool "after_turn returns Continue" true
     (match decision with Agent_sdk.Hooks.Continue -> true | _ -> false);
+  (try Sys.rmdir tmp_dir with _ -> ())
+
+let test_after_turn_flush_failure_still_continues () =
+  let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
+  let config = make_test_config ~base_path:tmp_dir in
+  let memory = Memory_oas_bridge.create_memory ~agent_name:"test_after_fail" () in
+  let labels =
+    [
+      ("keeper", "test_after_fail");
+      ("callback", "memory_after_turn_flush");
+    ]
+  in
+  let before =
+    P.metric_value_or_zero P.metric_keeper_lifecycle_callback_failures
+      ~labels ()
+  in
+  let memory_hooks =
+    Memory_hooks.make
+      ~agent_name:"test_after_fail"
+      ~config
+      ~memory
+      ~flush_incremental:(fun ~memory:_ ~agent_name:_ ->
+        raise (Failure "synthetic flush failure"))
+      ()
+  in
+  let inner_seen = ref false in
+  let inner_hooks =
+    { Agent_sdk.Hooks.empty with
+      after_turn =
+        Some
+          (fun _ ->
+             inner_seen := true;
+             Agent_sdk.Hooks.Continue)
+    }
+  in
+  let hooks =
+    Memory_hooks.compose_with_inner ~memory_hooks ~inner:inner_hooks
+  in
+  let event = Agent_sdk.Hooks.AfterTurn {
+    turn = 1;
+    response = {
+      Agent_sdk.Types.id = "r1";
+      model = "test";
+      stop_reason = Agent_sdk.Types.EndTurn;
+      content = [];
+      usage = None;
+      telemetry = None;
+    };
+  } in
+  let decision =
+    match hooks.after_turn with
+    | Some f -> f event
+    | None -> fail "after_turn hook should be Some"
+  in
+  check bool "after_turn returns Continue" true
+    (match decision with Agent_sdk.Hooks.Continue -> true | _ -> false);
+  check bool "inner after_turn still ran" true !inner_seen;
+  let after =
+    P.metric_value_or_zero P.metric_keeper_lifecycle_callback_failures
+      ~labels ()
+  in
+  check (float 0.0001) "flush failure counted" (before +. 1.0) after;
   (try Sys.rmdir tmp_dir with _ -> ())
 
 (* ── Flush idempotency test ────────────────────────────────── *)
@@ -244,7 +371,11 @@ let () =
       test_case "returns Continue when no memory" `Quick test_hook_returns_continue_when_no_memory;
       test_case "preserves existing context" `Quick test_hook_preserves_existing_context;
       test_case "injects world memory" `Quick test_hook_injects_world_memory;
+      test_case "composition preserves inner before_turn_params" `Quick
+        test_compose_preserves_inner_before_turn_params;
       test_case "after_turn returns Continue" `Quick test_after_turn_hook_returns_continue;
+      test_case "after_turn flush failure still continues" `Quick
+        test_after_turn_flush_failure_still_continues;
     ];
     "hook_structure", [
       test_case "hook slots populated correctly" `Quick test_hook_slots_populated;


### PR DESCRIPTION
## Summary
- add `Memory_hooks.compose_with_inner` so memory-injected `BeforeTurnParams` are passed into the keeper hook instead of bypassing it
- wire keeper run setup through that memory-aware composer, preserving keeper tool disclosure, turn context, decision audit, and tool filter adjustments on memory-injected turns
- guard `Memory_hooks.after_turn` flush failures with a callback-failure metric/log and return `Continue`, so keeper `after_turn` telemetry/SSE/cost hooks still run

## Why
OAS hook composition short-circuits the inner hook whenever the outer hook returns a non-`Continue` decision. Memory hooks were composed outermost; when memory existed, `before_turn_params` returned `AdjustParams`, which could skip keeper `before_turn_params` and drop tool-call context/telemetry wiring. A memory flush exception could also skip keeper `after_turn` entirely.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only` attempted; local shared opam switch reported stale `agent_sdk 0.190.12`, expected `>=0.190.25`
- `env MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_memory_hooks.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-memory-hooks-0506-a MASC_BASE_PATH_INPUT=/private/tmp/masc-memory-hooks-0506-a ./_build/default/test/test_memory_hooks.exe test hook_decisions 3`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-memory-hooks-0506-b MASC_BASE_PATH_INPUT=/private/tmp/masc-memory-hooks-0506-b ./_build/default/test/test_memory_hooks.exe test hook_decisions 5`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-memory-hooks-0506-full MASC_BASE_PATH_INPUT=/private/tmp/masc-memory-hooks-0506-full ./_build/default/test/test_memory_hooks.exe`