### PR TITLE
fix(dashboard): expose agent failure summary state

### DIFF
--- a/dashboard/src/components/common/agent-failure.test.ts
+++ b/dashboard/src/components/common/agent-failure.test.ts
@@ -1,28 +1,76 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentFailure, failureConfig, failureTypeFromDiagnostic } from './agent-failure'
+import {
+  AgentFailure,
+  failureConfig,
+  failureTypeFromDiagnostic,
+  summarizeAgentFailure,
+  summarizeRetryBudget,
+} from './agent-failure'
 
 describe('failureConfig', () => {
   it('returns config for retryable', () => {
     const cfg = failureConfig('retryable')
     expect(cfg.label).toBe('재시도 가능')
     expect(cfg.action).toContain('재시도')
+    expect(cfg.colorVar).toBe('var(--color-status-warn)')
   })
 
   it('returns config for non_retryable', () => {
     const cfg = failureConfig('non_retryable')
     expect(cfg.label).toBe('재시도 불가')
+    expect(cfg.colorVar).toBe('var(--color-status-err)')
   })
 
   it('returns config for human_required', () => {
     const cfg = failureConfig('human_required')
     expect(cfg.label).toBe('승인 필요')
+    expect(cfg.colorVar).toBe('var(--color-accent-fg)')
   })
 
   it('returns config for degraded', () => {
     const cfg = failureConfig('degraded')
     expect(cfg.label).toBe('성능 저하')
+  })
+})
+
+describe('summarizeRetryBudget', () => {
+  it('summarizes retry budget', () => {
+    expect(summarizeRetryBudget(2, 5)).toEqual({
+      current: 2,
+      max: 5,
+      remaining: 3,
+      percent: 40,
+      exhausted: false,
+      visible: true,
+    })
+  })
+
+  it('hides invalid or empty retry budgets', () => {
+    expect(summarizeRetryBudget(undefined, 3).visible).toBe(false)
+    expect(summarizeRetryBudget(1, 0).visible).toBe(false)
+  })
+
+  it('detects exhausted retry budget', () => {
+    const budget = summarizeRetryBudget(7, 5)
+    expect(budget.current).toBe(7)
+    expect(budget.remaining).toBe(0)
+    expect(budget.percent).toBe(100)
+    expect(budget.exhausted).toBe(true)
+  })
+})
+
+describe('summarizeAgentFailure', () => {
+  it('reports retrying and exhausted retry statuses', () => {
+    expect(summarizeAgentFailure('retryable', 1, 3).status).toBe('retrying')
+    expect(summarizeAgentFailure('retryable', 3, 3).status).toBe('retry_exhausted')
+  })
+
+  it('reports non-retryable, human, and degraded statuses', () => {
+    expect(summarizeAgentFailure('non_retryable').status).toBe('blocked')
+    expect(summarizeAgentFailure('human_required').status).toBe('waiting_for_human')
+    expect(summarizeAgentFailure('degraded').status).toBe('degraded')
   })
 })
 
@@ -74,6 +122,35 @@ describe('AgentFailure', () => {
     render(h(AgentFailure, { type: 'human_required', message: 'x' }), container)
     const el = container.querySelector('[data-failure-type]')
     expect(el?.getAttribute('data-failure-type')).toBe('human_required')
+  })
+
+  it('exposes summary data attributes', () => {
+    const container = document.createElement('div')
+    render(h(AgentFailure, { type: 'retryable', message: 'x', retryCount: 2, maxRetries: 5 }), container)
+    const root = container.querySelector('[data-agent-failure]') as HTMLElement
+    expect(root.dataset.agentFailureStatus).toBe('retrying')
+    expect(root.dataset.agentFailureLabel).toBe('재시도 가능')
+    expect(root.dataset.agentFailureAction).toBe('자동 재시도 중...')
+    expect(root.dataset.agentFailureRetryCurrent).toBe('2')
+    expect(root.dataset.agentFailureRetryMax).toBe('5')
+    expect(root.dataset.agentFailureRetryRemaining).toBe('3')
+    expect(root.dataset.agentFailureRetryPercent).toBe('40')
+    expect(root.dataset.agentFailureRetryExhausted).toBe('false')
+    expect(root.dataset.agentFailureRetryVisible).toBe('true')
+  })
+
+  it('exposes exhausted retry status', () => {
+    const container = document.createElement('div')
+    render(h(AgentFailure, { type: 'retryable', message: 'x', retryCount: 5, maxRetries: 5 }), container)
+    const root = container.querySelector('[data-agent-failure]') as HTMLElement
+    expect(root.dataset.agentFailureStatus).toBe('retry_exhausted')
+    expect(root.dataset.agentFailureRetryExhausted).toBe('true')
+  })
+
+  it('uses semantic aria label fallback for empty message', () => {
+    const container = document.createElement('div')
+    render(h(AgentFailure, { type: 'degraded', message: '' }), container)
+    expect(container.querySelector('[role="alert"]')?.getAttribute('aria-label')).toContain('상세 메시지 없음')
   })
 
   it('applies testId', () => {

--- a/dashboard/src/components/common/agent-failure.test.ts
+++ b/dashboard/src/components/common/agent-failure.test.ts
@@ -50,6 +50,15 @@ describe('summarizeRetryBudget', () => {
   it('hides invalid or empty retry budgets', () => {
     expect(summarizeRetryBudget(undefined, 3).visible).toBe(false)
     expect(summarizeRetryBudget(1, 0).visible).toBe(false)
+    expect(summarizeRetryBudget(1, Infinity)).toEqual({
+      current: 0,
+      max: 0,
+      remaining: 0,
+      percent: 0,
+      exhausted: false,
+      visible: false,
+    })
+    expect(summarizeRetryBudget(NaN, 3).visible).toBe(false)
   })
 
   it('detects exhausted retry budget', () => {

--- a/dashboard/src/components/common/agent-failure.ts
+++ b/dashboard/src/components/common/agent-failure.ts
@@ -4,43 +4,59 @@
 // non-retryable, human-required and degraded failure types. The compact alert
 // card lets operators instantly grasp severity and required action.
 //
-// Icons are text/emoji placeholders (Kimi spec uses emoji). Production code
-// should swap the icon field for an SVG icon map when an icon library is
-// adopted.
-
 import { html } from 'htm/preact'
+import { AlertTriangle, RefreshCcw, UserRound, XCircle } from 'lucide-preact'
+import type { LucideIcon } from 'lucide-preact'
 
 export type FailureType = 'retryable' | 'non_retryable' | 'human_required' | 'degraded'
+export type AgentFailureStatus = 'retrying' | 'retry_exhausted' | 'blocked' | 'waiting_for_human' | 'degraded'
 
-interface FailureConfig {
-  icon: string
+export interface FailureConfig {
+  Icon: LucideIcon
   colorVar: string
   label: string
   action: string
 }
 
+export interface AgentFailureRetryBudget {
+  readonly current: number
+  readonly max: number
+  readonly remaining: number
+  readonly percent: number
+  readonly exhausted: boolean
+  readonly visible: boolean
+}
+
+export interface AgentFailureSummary {
+  readonly type: FailureType
+  readonly label: string
+  readonly action: string
+  readonly status: AgentFailureStatus
+  readonly retry: AgentFailureRetryBudget
+}
+
 const FAILURE_CONFIG: Record<FailureType, FailureConfig> = {
   retryable: {
-    icon: '\u{21BB}',
-    colorVar: 'var(--warn-10)',
+    Icon: RefreshCcw,
+    colorVar: 'var(--color-status-warn)',
     label: '재시도 가능',
     action: '자동 재시도 중...',
   },
   non_retryable: {
-    icon: '\u{2715}',
-    colorVar: 'var(--bad-light)',
+    Icon: XCircle,
+    colorVar: 'var(--color-status-err)',
     label: '재시도 불가',
     action: '수동 개입 필요',
   },
   human_required: {
-    icon: '\u{1F464}',
-    colorVar: 'var(--color-accent)',
+    Icon: UserRound,
+    colorVar: 'var(--color-accent-fg)',
     label: '승인 필요',
     action: 'Human-in-the-loop 대기 중',
   },
   degraded: {
-    icon: '\u{26A0}',
-    colorVar: 'var(--warn-10)',
+    Icon: AlertTriangle,
+    colorVar: 'var(--color-status-warn)',
     label: '성능 저하',
     action: '대체 모드 실행 중',
   },
@@ -49,6 +65,50 @@ const FAILURE_CONFIG: Record<FailureType, FailureConfig> = {
 /** Pure: lookup a failure type's display config. */
 export function failureConfig(type: FailureType): FailureConfig {
   return FAILURE_CONFIG[type]
+}
+
+export function summarizeRetryBudget(
+  retryCount: number | undefined,
+  maxRetries: number | undefined,
+): AgentFailureRetryBudget {
+  const visible = retryCount !== undefined && maxRetries !== undefined && maxRetries > 0
+  const current = visible && Number.isFinite(retryCount) ? Math.max(0, Math.floor(retryCount)) : 0
+  const max = visible && Number.isFinite(maxRetries) ? Math.max(1, Math.floor(maxRetries)) : 0
+  const clampedCurrent = max > 0 ? Math.min(current, max) : 0
+  return {
+    current,
+    max,
+    remaining: Math.max(0, max - clampedCurrent),
+    percent: max > 0 ? Math.round((clampedCurrent / max) * 100) : 0,
+    exhausted: max > 0 && current >= max,
+    visible,
+  }
+}
+
+export function summarizeAgentFailure(
+  type: FailureType,
+  retryCount?: number,
+  maxRetries?: number,
+): AgentFailureSummary {
+  const cfg = failureConfig(type)
+  const retry = summarizeRetryBudget(retryCount, maxRetries)
+  const status: AgentFailureStatus =
+    type === 'retryable'
+      ? retry.exhausted
+        ? 'retry_exhausted'
+        : 'retrying'
+      : type === 'human_required'
+        ? 'waiting_for_human'
+        : type === 'degraded'
+          ? 'degraded'
+          : 'blocked'
+  return {
+    type,
+    label: cfg.label,
+    action: cfg.action,
+    status,
+    retry,
+  }
 }
 
 /** Pure: map a diagnostic error + recoverable flag to a failure type.
@@ -79,17 +139,31 @@ export function AgentFailure({
   testId,
 }: AgentFailureProps) {
   const cfg = FAILURE_CONFIG[type]
+  const summary = summarizeAgentFailure(type, retryCount, maxRetries)
+  const Icon = cfg.Icon
 
   return html`
     <div
-      class="flex items-start gap-2 rounded-[var(--r-1)] border p-2"
+      class="grid grid-cols-[auto_minmax(0,1fr)] gap-2 rounded-[var(--r-1)] border p-2 sm:grid-cols-[auto_minmax(0,1fr)_auto]"
       style="border-color: ${cfg.colorVar}; background-color: color-mix(in srgb, ${cfg.colorVar} 8%, transparent);"
       role="alert"
+      aria-label="${summary.label}: ${message || '상세 메시지 없음'}"
       data-agent-failure
       data-failure-type=${type}
+      data-agent-failure-status=${summary.status}
+      data-agent-failure-label=${summary.label}
+      data-agent-failure-action=${summary.action}
+      data-agent-failure-retry-current=${summary.retry.current}
+      data-agent-failure-retry-max=${summary.retry.max}
+      data-agent-failure-retry-remaining=${summary.retry.remaining}
+      data-agent-failure-retry-percent=${summary.retry.percent}
+      data-agent-failure-retry-exhausted=${summary.retry.exhausted}
+      data-agent-failure-retry-visible=${summary.retry.visible}
       data-testid=${testId}
     >
-      <span class="text-lg leading-none" aria-hidden="true">${cfg.icon}</span>
+      <span class="mt-0.5 shrink-0 leading-none" style="color: ${cfg.colorVar};" aria-hidden="true">
+        <${Icon} size=${16} strokeWidth=${2} />
+      </span>
       <div class="min-w-0 flex-1">
         <div class="text-sm font-medium" style="color: ${cfg.colorVar};">
           ${cfg.label}
@@ -97,15 +171,15 @@ export function AgentFailure({
         <div class="break-words text-xs text-[var(--color-fg-muted)]">
           ${message}
         </div>
-        ${retryCount !== undefined && maxRetries !== undefined && maxRetries > 0
+        ${summary.retry.visible
           ? html`
               <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
-                재시도: ${retryCount}/${maxRetries}
+                재시도: ${summary.retry.current}/${summary.retry.max}
               </div>
             `
           : null}
       </div>
-      <span class="shrink-0 text-xs text-[var(--color-fg-muted)]">
+      <span class="col-start-2 text-xs text-[var(--color-fg-muted)] sm:col-start-auto sm:shrink-0 sm:text-right">
         ${cfg.action}
       </span>
     </div>

--- a/dashboard/src/components/common/agent-failure.ts
+++ b/dashboard/src/components/common/agent-failure.ts
@@ -71,9 +71,22 @@ export function summarizeRetryBudget(
   retryCount: number | undefined,
   maxRetries: number | undefined,
 ): AgentFailureRetryBudget {
-  const visible = retryCount !== undefined && maxRetries !== undefined && maxRetries > 0
-  const current = visible && Number.isFinite(retryCount) ? Math.max(0, Math.floor(retryCount)) : 0
-  const max = visible && Number.isFinite(maxRetries) ? Math.max(1, Math.floor(maxRetries)) : 0
+  const finiteRetryCount =
+    typeof retryCount === 'number' && Number.isFinite(retryCount) ? retryCount : undefined
+  const finiteMaxRetries =
+    typeof maxRetries === 'number' && Number.isFinite(maxRetries) ? maxRetries : undefined
+  if (finiteRetryCount === undefined || finiteMaxRetries === undefined || finiteMaxRetries <= 0) {
+    return {
+      current: 0,
+      max: 0,
+      remaining: 0,
+      percent: 0,
+      exhausted: false,
+      visible: false,
+    }
+  }
+  const current = Math.max(0, Math.floor(finiteRetryCount))
+  const max = Math.max(1, Math.floor(finiteMaxRetries))
   const clampedCurrent = max > 0 ? Math.min(current, max) : 0
   return {
     current,
@@ -81,7 +94,7 @@ export function summarizeRetryBudget(
     remaining: Math.max(0, max - clampedCurrent),
     percent: max > 0 ? Math.round((clampedCurrent / max) * 100) : 0,
     exhausted: max > 0 && current >= max,
-    visible,
+    visible: true,
   }
 }
 


### PR DESCRIPTION
## Summary
- replace AgentFailure placeholder glyphs and legacy color tokens with lucide icons and semantic status/accent tokens
- export retry-budget and failure-summary helpers for deterministic status derivation
- expose root status, label/action, and retry metadata data attributes for dashboard/runtime proof surfaces
- switch the alert card to a responsive grid so action text wraps under content on mobile

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/agent-failure.test.ts src/components/common/agent-failure.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint (passes; existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- pnpm --dir dashboard run build (passes; existing Vite dynamic/static import and chunk-size warnings)

## Browser QA
- Vite QA: http://127.0.0.1:5213/dashboard/agent-failure-qa.html with MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9
- Desktop screenshot: /tmp/masc-agent-failure-summary-0506.png
- Mobile screenshot: /tmp/masc-agent-failure-summary-0506-mobile.png
- Verified retrying metadata: current=2, max=5, remaining=3, percent=40, exhausted=false, status=retrying
- Verified retry_exhausted, blocked, waiting_for_human, and degraded statuses, semantic border colors, and zero horizontal overflow on desktop/mobile

## Notes
- Temporary QA page was removed before commit.
