### PR TITLE
fix(keeper): resume paused keepers on up

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -47,15 +47,12 @@ let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
 let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
   meta.paused
   && (match meta.runtime.last_blocker_class with
-      | Some Ambiguous_post_commit_timeout | Some Ambiguous_post_commit_failure ->
-          true
+      | Some cls -> blocker_class_continue_gate cls
       | None ->
           (match Keeper_status_bridge.blocker_class_of_string
                   meta.runtime.last_blocker with
-           | Some Ambiguous_post_commit_timeout
-           | Some Ambiguous_post_commit_failure -> true
-           | _ -> false)
-      | _ -> false)
+           | Some cls -> blocker_class_continue_gate cls
+           | None -> false))
 
 let committed_tools_of_ambiguous_blocker (blocker : string) =
   let trimmed = String.trim blocker in

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -29,6 +29,18 @@ let resolve_active_goal_ids config p old_ids =
           (Printf.sprintf "unknown active_goal_ids: %s"
              (String.concat ", " missing))
 
+let blocker_requires_continue_gate (old : keeper_meta) =
+  match old.runtime.last_blocker_class with
+  | Some cls -> blocker_class_continue_gate cls
+  | None -> (
+      match Keeper_status_bridge.blocker_class_of_string old.runtime.last_blocker with
+      | Some cls -> blocker_class_continue_gate cls
+      | None -> false)
+
+let paused_state_requires_approval (old : keeper_meta) =
+  Keeper_approval_queue.has_pending_for_keeper ~keeper_name:old.name
+  || blocker_requires_continue_gate old
+
 let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result =
   match p.tool_access_opt, old.tool_access, p.tool_preset_opt, p.tool_also_allow_opt with
   | None, Custom _, None, Some _ ->
@@ -195,6 +207,28 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
   warn_personality_cap "will" old.will new_will;
   warn_personality_cap "needs" old.needs new_needs;
   warn_personality_cap "desires" old.desires new_desires;
+  let resume_paused_keeper =
+    old.paused && not (paused_state_requires_approval old)
+  in
+  if resume_paused_keeper then (
+    let blocker_class =
+      old.runtime.last_blocker_class
+      |> Option.map blocker_class_to_string
+      |> Option.value ~default:"none"
+    in
+    let auto_resume_after_sec =
+      old.auto_resume_after_sec
+      |> Option.map (Printf.sprintf "%.0f")
+      |> Option.value ~default:"none"
+    in
+    Log.Keeper.warn
+      "update_keeper resumed paused keeper %s; clearing \
+       auto_resume_after_sec=%s last_blocker_class=%s last_blocker=%S"
+      old.name auto_resume_after_sec blocker_class old.runtime.last_blocker);
+  if old.paused && not resume_paused_keeper then
+    Log.Keeper.warn
+      "update_keeper kept %s paused because an approval/reconcile gate is pending"
+      old.name;
   let updated = { old with
     goal;
     short_goal;
@@ -235,6 +269,17 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     tool_preset_source = p.profile_defaults.tool_preset_source;
     autoboot_enabled;
     active_goal_ids;
+    paused = if resume_paused_keeper then false else old.paused;
+    auto_resume_after_sec =
+      if resume_paused_keeper then None else old.auto_resume_after_sec;
+    runtime =
+      (if resume_paused_keeper then
+         {
+           old.runtime with
+           last_blocker = "";
+           last_blocker_class = None;
+         }
+       else old.runtime);
     voice_enabled =
       Option.value ~default:old.voice_enabled p.voice_enabled_opt;
     voice_channel =

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -122,6 +122,16 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_keeper_up_ignores_non_public_social_model_arg;
+          Alcotest.test_case "keeper up resumes auto-paused keeper" `Quick
+            Test_operator_control_keeper.test_keeper_up_resumes_auto_paused_keeper;
+          Alcotest.test_case
+            "keeper up keeps paused keeper behind continue gate" `Quick
+            Test_operator_control_keeper
+            .test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker;
+          Alcotest.test_case
+            "keeper up keeps paused keeper behind pending approval" `Quick
+            Test_operator_control_keeper
+            .test_keeper_up_keeps_paused_keeper_with_pending_approval;
           Alcotest.test_case "keeper status accepts agent alias" `Quick
             Test_operator_control_keeper
             .test_keeper_status_accepts_agent_name_alias;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -55,6 +55,30 @@ let read_keeper_meta_exn config keeper_name =
   | Ok None -> Alcotest.fail ("keeper meta missing: " ^ keeper_name)
   | Error err -> Alcotest.fail ("keeper meta read failed: " ^ err)
 
+let seed_keeper_meta_exn config keeper_name ~goal =
+  let trace_id = "trace-" ^ keeper_name in
+  let meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String (Keeper_types.keeper_agent_name keeper_name));
+            ("trace_id", `String trace_id);
+            ("goal", `String goal);
+            ("cascade_name", `String Keeper_config.default_cascade_name);
+            ("sandbox_profile", `String "local");
+            ("network_mode", `String "inherit");
+          ])
+    with
+    | Ok meta -> meta
+    | Error err -> Alcotest.fail ("keeper meta fixture failed: " ^ err)
+  in
+  (match Keeper_types.write_meta config meta with
+   | Ok () -> ()
+   | Error err -> Alcotest.fail ("keeper meta seed failed: " ^ err));
+  read_keeper_meta_exn config keeper_name
+
 let with_fake_docker script f =
   let dir = temp_dir () in
   let docker_path = Filename.concat dir "docker" in
@@ -1108,20 +1132,9 @@ let test_keeper_up_resumes_auto_paused_keeper () =
           net = None;
         }
       in
-      let ok, _ =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
-          ~args:
-            (`Assoc
-              [
-                ("name", `String keeper_name);
-                ("goal", `String "Resume a paused keeper");
-                ("proactive_enabled", `Bool false);
-                ("autoboot_enabled", `Bool false);
-              ])
+      let meta =
+        seed_keeper_meta_exn config keeper_name ~goal:"Resume a paused keeper"
       in
-      Alcotest.(check bool) "initial keeper up ok" true ok;
-      Keeper_keepalive.stop_keepalive keeper_name;
-      let meta = read_keeper_meta_exn config keeper_name in
       let blocker_text =
         Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout
       in
@@ -1189,20 +1202,10 @@ let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
           net = None;
         }
       in
-      let ok, _ =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
-          ~args:
-            (`Assoc
-              [
-                ("name", `String keeper_name);
-                ("goal", `String "Stay paused behind a continue gate");
-                ("proactive_enabled", `Bool false);
-                ("autoboot_enabled", `Bool false);
-              ])
+      let meta =
+        seed_keeper_meta_exn config keeper_name
+          ~goal:"Stay paused behind a continue gate"
       in
-      Alcotest.(check bool) "initial keeper up ok" true ok;
-      Keeper_keepalive.stop_keepalive keeper_name;
-      let meta = read_keeper_meta_exn config keeper_name in
       let blocker_text =
         "turn outcome ambiguous after committed mutating tool call(s): \
          [keeper_board_cleanup]; turn wall-clock timeout"
@@ -1276,20 +1279,9 @@ let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
           net = None;
         }
       in
-      let ok, _ =
-        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
-          ~args:
-            (`Assoc
-              [
-                ("name", `String keeper_name);
-                ("goal", `String "Stay paused behind approval");
-                ("proactive_enabled", `Bool false);
-                ("autoboot_enabled", `Bool false);
-              ])
+      let meta =
+        seed_keeper_meta_exn config keeper_name ~goal:"Stay paused behind approval"
       in
-      Alcotest.(check bool) "initial keeper up ok" true ok;
-      Keeper_keepalive.stop_keepalive keeper_name;
-      let meta = read_keeper_meta_exn config keeper_name in
       let blocker_text =
         Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout
       in

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1120,6 +1120,7 @@ let test_keeper_up_resumes_auto_paused_keeper () =
               ])
       in
       Alcotest.(check bool) "initial keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
       let meta = read_keeper_meta_exn config keeper_name in
       let blocker_text =
         Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout
@@ -1200,6 +1201,7 @@ let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
               ])
       in
       Alcotest.(check bool) "initial keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
       let meta = read_keeper_meta_exn config keeper_name in
       let blocker_text =
         "turn outcome ambiguous after committed mutating tool call(s): \
@@ -1286,6 +1288,7 @@ let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
               ])
       in
       Alcotest.(check bool) "initial keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
       let meta = read_keeper_meta_exn config keeper_name in
       let blocker_text =
         Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1083,6 +1083,262 @@ let test_keeper_up_ignores_non_public_social_model_arg () =
       Alcotest.(check string) "ignores arg social_model" "bdi_speech_v1"
         Yojson.Safe.Util.(json |> member "social_model" |> to_string))
 
+let test_keeper_up_resumes_auto_paused_keeper () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "resume-paused-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Resume a paused keeper");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "initial keeper up ok" true ok;
+      let meta = read_keeper_meta_exn config keeper_name in
+      let blocker_text =
+        Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout
+      in
+      let paused_meta =
+        {
+          meta with
+          paused = true;
+          auto_resume_after_sec = Some 3600.0;
+          runtime =
+            {
+              meta.runtime with
+              last_blocker = blocker_text;
+              last_blocker_class = Some Keeper_types.Turn_timeout;
+            };
+        }
+      in
+      (match Keeper_types.write_meta config paused_meta with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail ("paused meta write failed: " ^ err));
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "resume keeper up ok" true ok;
+      let json = parse_json_exn body in
+      Alcotest.(check bool) "response paused false" false
+        Yojson.Safe.Util.(json |> member "paused" |> to_bool);
+      let resumed = read_keeper_meta_exn config keeper_name in
+      Alcotest.(check bool) "meta paused false" false resumed.paused;
+      Alcotest.(check bool) "auto resume delay cleared" true
+        (Option.is_none resumed.auto_resume_after_sec);
+      Alcotest.(check string) "runtime blocker cleared" ""
+        resumed.runtime.last_blocker;
+      Alcotest.(check bool) "runtime blocker class cleared" true
+        (Option.is_none resumed.runtime.last_blocker_class))
+
+let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "resume-continue-gated-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Stay paused behind a continue gate");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "initial keeper up ok" true ok;
+      let meta = read_keeper_meta_exn config keeper_name in
+      let blocker_text =
+        "turn outcome ambiguous after committed mutating tool call(s): \
+         [keeper_board_cleanup]; turn wall-clock timeout"
+      in
+      let paused_meta =
+        {
+          meta with
+          paused = true;
+          auto_resume_after_sec = Some 3600.0;
+          runtime =
+            {
+              meta.runtime with
+              last_blocker = blocker_text;
+              last_blocker_class = None;
+            };
+        }
+      in
+      (match Keeper_types.write_meta config paused_meta with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail ("paused meta write failed: " ^ err));
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up accepted" true ok;
+      let json = parse_json_exn body in
+      Alcotest.(check bool) "response stays paused" true
+        Yojson.Safe.Util.(json |> member "paused" |> to_bool);
+      let still_paused = read_keeper_meta_exn config keeper_name in
+      Alcotest.(check bool) "meta remains paused" true still_paused.paused;
+      Alcotest.(check bool) "auto resume delay preserved" true
+        (Option.is_some still_paused.auto_resume_after_sec);
+      Alcotest.(check string) "runtime blocker preserved" blocker_text
+        still_paused.runtime.last_blocker)
+
+let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "resume-approval-gated-keeper" in
+  let pending_id = ref None in
+  Fun.protect
+    ~finally:(fun () ->
+      Option.iter
+        (fun id ->
+          ignore
+            (Keeper_approval_queue.resolve ~id
+               ~decision:(Agent_sdk.Hooks.Reject "test cleanup")))
+        !pending_id;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Stay paused behind approval");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "initial keeper up ok" true ok;
+      let meta = read_keeper_meta_exn config keeper_name in
+      let blocker_text =
+        Keeper_types.blocker_class_to_string Keeper_types.Turn_timeout
+      in
+      let paused_meta =
+        {
+          meta with
+          paused = true;
+          auto_resume_after_sec = Some 3600.0;
+          runtime =
+            {
+              meta.runtime with
+              last_blocker = blocker_text;
+              last_blocker_class = Some Keeper_types.Turn_timeout;
+            };
+        }
+      in
+      (match Keeper_types.write_meta config paused_meta with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail ("paused meta write failed: " ^ err));
+      pending_id :=
+        Some
+          (Keeper_approval_queue.submit_pending
+             ~keeper_name
+             ~tool_name:"keeper_continue_after_partial_commit"
+             ~input:(`Assoc [("kind", `String "continue_gate_required")])
+             ~risk_level:Keeper_approval_queue.Critical
+             ~base_path:base_dir
+             ~on_resolution:(fun _ -> ())
+             ());
+      Alcotest.(check bool) "keeper has pending approval" true
+        (Keeper_approval_queue.has_pending_for_keeper ~keeper_name);
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up accepted" true ok;
+      let json = parse_json_exn body in
+      Alcotest.(check bool) "response stays paused" true
+        Yojson.Safe.Util.(json |> member "paused" |> to_bool);
+      let still_paused = read_keeper_meta_exn config keeper_name in
+      Alcotest.(check bool) "meta remains paused" true still_paused.paused;
+      Alcotest.(check bool) "auto resume delay preserved" true
+        (Option.is_some still_paused.auto_resume_after_sec);
+      Alcotest.(check string) "runtime blocker preserved" blocker_text
+        still_paused.runtime.last_blocker)
+
 let test_keeper_status_defaults_name_to_caller () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## What changed
- `masc_keeper_up` now clears persisted `paused` state for existing keepers when there is no pending approval or ambiguous post-commit blocker.
- Resume also clears `auto_resume_after_sec` and the runtime blocker fields so `start_keepalive` can actually schedule turns.
- Added a regression test covering an auto-paused keeper being resumed through `masc_keeper_up`.

## Why
Live runtime had 17 keeper metadata records but only 13 keeper fibers. The missing keepers were persisted with `paused=true`; calling `masc_keeper_up` re-registered the fiber but left `paused=true`, so keepalive skipped turns with `keeper_paused`.

## Safety
`masc_keeper_up` does not clear paused state when a keeper has a pending approval or an ambiguous post-commit blocker, so continue-gate/reconcile flows are not bypassed.

## Validation
- `ocamlc -stop-after parsing lib/keeper/keeper_turn_up_update.ml test/test_operator_control_keeper.ml test/test_operator_control.ml`
- `git diff --check`
- Focused Dune target attempted: `scripts/dune-local.sh build test/test_operator_control.exe`, but local opam/Dune locks were held by other sessions, so it was stopped without killing those sessions.