### PR TITLE
fix(dashboard): expose agent delegation summary state

### DIFF
--- a/dashboard/src/components/common/agent-delegation.test.ts
+++ b/dashboard/src/components/common/agent-delegation.test.ts
@@ -1,24 +1,76 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentDelegation } from './agent-delegation'
+import {
+  AgentDelegation,
+  flattenDelegationTree,
+  formatElapsed,
+  statusToPresence,
+  summarizeDelegationTree,
+} from './agent-delegation'
+import type { DelegationNode } from './agent-delegation'
 
-const rootNode = {
+const now = new Date('2026-05-06T00:00:00Z').getTime()
+const rootNode: DelegationNode = {
   agentId: 'agent-alpha-123',
   task: 'root task',
-  status: 'active' as const,
-  startedAt: Date.now(),
-  completedAt: Date.now() + 5000,
+  status: 'active',
+  startedAt: now,
+  completedAt: now + 5000,
   children: [
     {
       agentId: 'agent-beta-456',
       task: 'child task',
-      status: 'completed' as const,
-      startedAt: Date.now(),
-      completedAt: Date.now() + 3000,
+      status: 'completed',
+      startedAt: now + 1000,
+      completedAt: now + 4000,
+    },
+    {
+      agentId: 'agent-gamma-789',
+      task: 'failed child task',
+      status: 'failed',
     },
   ],
 }
+
+describe('delegation helpers', () => {
+  it('maps node status to presence state', () => {
+    expect(statusToPresence('active')).toBe('busy')
+    expect(statusToPresence('completed')).toBe('active')
+    expect(statusToPresence('failed')).toBe('inactive')
+    expect(statusToPresence('pending')).toBe('idle')
+  })
+
+  it('formats elapsed time only for valid timestamps', () => {
+    expect(formatElapsed(now, now + 2500)).toBe('2.5s')
+    expect(formatElapsed(now + 2500, now)).toBeNull()
+    expect(formatElapsed(now, undefined)).toBeNull()
+  })
+
+  it('flattens delegation tree with depth and leaf metadata', () => {
+    const flat = flattenDelegationTree(rootNode)
+    expect(flat.map((item) => [item.node.agentId, item.depth, item.leaf])).toEqual([
+      ['agent-alpha-123', 0, false],
+      ['agent-beta-456', 1, true],
+      ['agent-gamma-789', 1, true],
+    ])
+    expect(flat[0]?.childCount).toBe(2)
+  })
+
+  it('summarizes delegation tree counts and status', () => {
+    const summary = summarizeDelegationTree(rootNode)
+    expect(summary.totalCount).toBe(3)
+    expect(summary.leafCount).toBe(2)
+    expect(summary.maxDepth).toBe(1)
+    expect(summary.activeCount).toBe(1)
+    expect(summary.completedCount).toBe(1)
+    expect(summary.failedCount).toBe(1)
+    expect(summary.latestStartedAt).toBe(now + 1000)
+    expect(summary.latestCompletedAt).toBe(now + 5000)
+    expect(summary.longestElapsedMs).toBe(5000)
+    expect(summary.status).toBe('failed')
+  })
+})
 
 describe('AgentDelegation', () => {
   it('renders tree role', () => {
@@ -67,7 +119,7 @@ describe('AgentDelegation', () => {
   it('renders treeitem roles', () => {
     const container = document.createElement('div')
     render(h(AgentDelegation, { root: rootNode }), container)
-    expect(container.querySelectorAll('[role="treeitem"]').length).toBe(2)
+    expect(container.querySelectorAll('[role="treeitem"]').length).toBe(3)
   })
 
   it('applies testId', () => {
@@ -80,5 +132,34 @@ describe('AgentDelegation', () => {
     const container = document.createElement('div')
     render(h(AgentDelegation, { root: rootNode }), container)
     expect(container.querySelector('[data-agent-delegation]')).not.toBeNull()
+  })
+
+  it('exposes root summary data attributes', () => {
+    const container = document.createElement('div')
+    render(h(AgentDelegation, { root: rootNode }), container)
+    const root = container.querySelector('[data-agent-delegation]') as HTMLElement
+    expect(root.dataset.agentDelegationTotalCount).toBe('3')
+    expect(root.dataset.agentDelegationLeafCount).toBe('2')
+    expect(root.dataset.agentDelegationMaxDepth).toBe('1')
+    expect(root.dataset.agentDelegationActiveCount).toBe('1')
+    expect(root.dataset.agentDelegationCompletedCount).toBe('1')
+    expect(root.dataset.agentDelegationFailedCount).toBe('1')
+    expect(root.dataset.agentDelegationLatestStartedAt).toBe(String(now + 1000))
+    expect(root.dataset.agentDelegationLatestCompletedAt).toBe(String(now + 5000))
+    expect(root.dataset.agentDelegationLongestElapsedMs).toBe('5000')
+    expect(root.dataset.agentDelegationStatus).toBe('failed')
+  })
+
+  it('exposes node data attributes', () => {
+    const container = document.createElement('div')
+    render(h(AgentDelegation, { root: rootNode }), container)
+    const child = container.querySelector('[data-delegation-agent-id="agent-beta-456"]') as HTMLElement
+    expect(child.dataset.delegationTask).toBe('child task')
+    expect(child.dataset.delegationStatus).toBe('completed')
+    expect(child.dataset.delegationDepth).toBe('1')
+    expect(child.dataset.delegationPath).toBe('0.0')
+    expect(child.dataset.delegationChildCount).toBe('0')
+    expect(child.dataset.delegationLeaf).toBe('true')
+    expect(child.dataset.delegationElapsedMs).toBe('3000')
   })
 })

--- a/dashboard/src/components/common/agent-delegation.ts
+++ b/dashboard/src/components/common/agent-delegation.ts
@@ -166,6 +166,16 @@ interface NodeViewProps {
   path: string
 }
 
+function delegationNodeKey(node: DelegationNode): string {
+  return [
+    node.agentId,
+    node.task,
+    node.status,
+    node.startedAt ?? '',
+    node.completedAt ?? '',
+  ].join(':')
+}
+
 function NodeView({ node, depth, path }: NodeViewProps) {
   const presenceStatus = statusToPresence(node.status)
   const elapsed = formatElapsed(node.startedAt, node.completedAt)
@@ -210,7 +220,12 @@ function NodeView({ node, depth, path }: NodeViewProps) {
         ? html`
             <div role="group">
               ${node.children?.map((child, childIndex) => html`
-                <${NodeView} node=${child} depth=${depth + 1} path=${`${path}.${childIndex}`} />
+                <${NodeView}
+                  key=${delegationNodeKey(child)}
+                  node=${child}
+                  depth=${depth + 1}
+                  path=${`${path}.${childIndex}`}
+                />
               `)}
             </div>
           `

--- a/dashboard/src/components/common/agent-delegation.ts
+++ b/dashboard/src/components/common/agent-delegation.ts
@@ -7,13 +7,39 @@
 import { html } from 'htm/preact'
 import { AgentPresence } from './agent-presence'
 
-interface DelegationNode {
+export type DelegationStatus = 'pending' | 'active' | 'completed' | 'failed'
+export type DelegationTreeStatus = 'empty' | 'pending' | 'active' | 'completed' | 'failed' | 'mixed'
+
+export interface DelegationNode {
   agentId: string
   task: string
-  status: 'pending' | 'active' | 'completed' | 'failed'
+  status: DelegationStatus
   children?: DelegationNode[]
   startedAt?: number
   completedAt?: number
+}
+
+export interface DelegationNodeSummary {
+  readonly node: DelegationNode
+  readonly depth: number
+  readonly index: number
+  readonly childCount: number
+  readonly leaf: boolean
+  readonly elapsedMs: number | null
+}
+
+export interface DelegationSummary {
+  readonly totalCount: number
+  readonly leafCount: number
+  readonly maxDepth: number
+  readonly pendingCount: number
+  readonly activeCount: number
+  readonly completedCount: number
+  readonly failedCount: number
+  readonly latestStartedAt: number | null
+  readonly latestCompletedAt: number | null
+  readonly longestElapsedMs: number | null
+  readonly status: DelegationTreeStatus
 }
 
 interface AgentDelegationProps {
@@ -21,7 +47,7 @@ interface AgentDelegationProps {
   testId?: string
 }
 
-function statusToPresence(status: DelegationNode['status']): string {
+export function statusToPresence(status: DelegationStatus): string {
   switch (status) {
     case 'active':
       return 'busy'
@@ -35,40 +61,157 @@ function statusToPresence(status: DelegationNode['status']): string {
   }
 }
 
-function formatElapsed(startedAt?: number, completedAt?: number): string | null {
+export function elapsedMs(startedAt?: number, completedAt?: number): number | null {
   if (startedAt == null || completedAt == null) return null
   const ms = completedAt - startedAt
   if (ms < 0) return null
+  return ms
+}
+
+export function formatElapsed(startedAt?: number, completedAt?: number): string | null {
+  const ms = elapsedMs(startedAt, completedAt)
+  if (ms == null) return null
   return `${(ms / 1000).toFixed(1)}s`
+}
+
+export function flattenDelegationTree(root: DelegationNode): DelegationNodeSummary[] {
+  const items: DelegationNodeSummary[] = []
+  const visit = (node: DelegationNode, depth: number) => {
+    const childCount = node.children?.length ?? 0
+    items.push({
+      node,
+      depth,
+      index: items.length,
+      childCount,
+      leaf: childCount === 0,
+      elapsedMs: elapsedMs(node.startedAt, node.completedAt),
+    })
+    node.children?.forEach((child) => visit(child, depth + 1))
+  }
+  visit(root, 0)
+  return items
+}
+
+export function summarizeDelegationTree(root: DelegationNode): DelegationSummary {
+  const items = flattenDelegationTree(root)
+  let pendingCount = 0
+  let activeCount = 0
+  let completedCount = 0
+  let failedCount = 0
+  let latestStartedAt: number | null = null
+  let latestCompletedAt: number | null = null
+  let longestElapsedMs: number | null = null
+
+  items.forEach((item) => {
+    switch (item.node.status) {
+      case 'pending':
+        pendingCount += 1
+        break
+      case 'active':
+        activeCount += 1
+        break
+      case 'completed':
+        completedCount += 1
+        break
+      case 'failed':
+        failedCount += 1
+        break
+    }
+
+    if (Number.isFinite(item.node.startedAt)) {
+      latestStartedAt = latestStartedAt === null ? item.node.startedAt ?? null : Math.max(latestStartedAt, item.node.startedAt ?? 0)
+    }
+    if (Number.isFinite(item.node.completedAt)) {
+      latestCompletedAt = latestCompletedAt === null ? item.node.completedAt ?? null : Math.max(latestCompletedAt, item.node.completedAt ?? 0)
+    }
+    if (item.elapsedMs != null) {
+      longestElapsedMs = longestElapsedMs === null ? item.elapsedMs : Math.max(longestElapsedMs, item.elapsedMs)
+    }
+  })
+
+  const totalCount = items.length
+  const status: DelegationTreeStatus =
+    totalCount === 0
+      ? 'empty'
+      : failedCount > 0
+        ? 'failed'
+        : activeCount > 0
+          ? 'active'
+          : pendingCount > 0
+            ? completedCount > 0
+              ? 'mixed'
+              : 'pending'
+            : completedCount === totalCount
+              ? 'completed'
+              : 'mixed'
+
+  return {
+    totalCount,
+    leafCount: items.filter((item) => item.leaf).length,
+    maxDepth: Math.max(0, ...items.map((item) => item.depth)),
+    pendingCount,
+    activeCount,
+    completedCount,
+    failedCount,
+    latestStartedAt,
+    latestCompletedAt,
+    longestElapsedMs,
+    status,
+  }
 }
 
 interface NodeViewProps {
   node: DelegationNode
   depth: number
+  path: string
 }
 
-function NodeView({ node, depth }: NodeViewProps) {
+function NodeView({ node, depth, path }: NodeViewProps) {
   const presenceStatus = statusToPresence(node.status)
   const elapsed = formatElapsed(node.startedAt, node.completedAt)
-  const marginLeft = depth > 0 ? 'ml-6' : ''
+  const elapsedValue = elapsedMs(node.startedAt, node.completedAt)
+  const childCount = node.children?.length ?? 0
+  const indentRem = Math.min(depth * 1.25, 3.75)
   const borderLeft = depth > 0 ? 'border-l-2 border-[var(--color-border-default)] pl-3' : ''
 
   return html`
-    <div class="flex flex-col ${marginLeft}" role="treeitem" aria-expanded=${node.children && node.children.length > 0 ? 'true' : undefined}>
-      <div class="flex items-center gap-2 py-1.5 ${borderLeft}">
-        <${AgentPresence} status=${presenceStatus} size="sm" />
-        <span class="text-sm text-[var(--color-fg-primary)]">${node.task}</span>
-        <span class="font-mono text-xs text-[var(--color-fg-secondary)]">
-          ${node.agentId.slice(0, 8)}
-        </span>
-        ${elapsed
-          ? html`<span class="text-xs text-[var(--color-fg-muted)]">(${elapsed})</span>`
-          : null}
+    <div
+      class="flex min-w-0 flex-col"
+      style=${depth > 0 ? { marginLeft: `${indentRem}rem` } : undefined}
+      role="treeitem"
+      aria-level=${depth + 1}
+      aria-expanded=${childCount > 0 ? 'true' : undefined}
+      data-delegation-agent-id=${node.agentId}
+      data-delegation-task=${node.task}
+      data-delegation-status=${node.status}
+      data-delegation-depth=${depth}
+      data-delegation-path=${path}
+      data-delegation-child-count=${childCount}
+      data-delegation-leaf=${childCount === 0}
+      data-delegation-elapsed-ms=${elapsedValue ?? ''}
+    >
+      <div class="min-w-0 py-1.5 ${borderLeft}">
+        <div class="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-x-2 gap-y-1">
+          <${AgentPresence} status=${presenceStatus} size="sm" />
+          <div class="min-w-0 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-x-2">
+            <span class="block min-w-0 break-words text-sm text-[var(--color-fg-primary)]">${node.task}</span>
+            <span class="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 sm:mt-0 sm:justify-end">
+              <span class="shrink-0 font-mono text-xs text-[var(--color-fg-secondary)]">
+                ${node.agentId.slice(0, 8)}
+              </span>
+              ${elapsed
+                ? html`<span class="shrink-0 text-xs text-[var(--color-fg-muted)]">(${elapsed})</span>`
+                : null}
+            </span>
+          </div>
+        </div>
       </div>
-      ${node.children && node.children.length > 0
+      ${childCount > 0
         ? html`
             <div role="group">
-              ${node.children.map((child) => html`<${NodeView} node=${child} depth=${depth + 1} />`)}
+              ${node.children?.map((child, childIndex) => html`
+                <${NodeView} node=${child} depth=${depth + 1} path=${`${path}.${childIndex}`} />
+              `)}
             </div>
           `
         : null}
@@ -77,14 +220,27 @@ function NodeView({ node, depth }: NodeViewProps) {
 }
 
 export function AgentDelegation({ root, testId }: AgentDelegationProps) {
+  const summary = summarizeDelegationTree(root)
+
   return html`
     <div
-      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
       role="tree"
       data-agent-delegation
+      data-agent-delegation-total-count=${summary.totalCount}
+      data-agent-delegation-leaf-count=${summary.leafCount}
+      data-agent-delegation-max-depth=${summary.maxDepth}
+      data-agent-delegation-pending-count=${summary.pendingCount}
+      data-agent-delegation-active-count=${summary.activeCount}
+      data-agent-delegation-completed-count=${summary.completedCount}
+      data-agent-delegation-failed-count=${summary.failedCount}
+      data-agent-delegation-latest-started-at=${summary.latestStartedAt ?? ''}
+      data-agent-delegation-latest-completed-at=${summary.latestCompletedAt ?? ''}
+      data-agent-delegation-longest-elapsed-ms=${summary.longestElapsedMs ?? ''}
+      data-agent-delegation-status=${summary.status}
       data-testid=${testId}
     >
-      <${NodeView} node=${root} depth=${0} />
+      <${NodeView} node=${root} depth=${0} path="0" />
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- export delegation traversal, elapsed-time, presence-mapping, and summary helpers
- expose root tree summary metadata and per-node path/depth/status/elapsed data attributes
- cap nested indentation and group node metadata with task text for mobile-safe wrapping

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/agent-delegation.test.ts src/components/common/agent-delegation.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint (passes; existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts)
- pnpm --dir dashboard run build (passes; existing Vite dynamic/static import and chunk-size warnings)

## Browser QA
- Vite QA: http://127.0.0.1:5214/dashboard/agent-delegation-qa.html with MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9
- Desktop screenshot: /tmp/masc-agent-delegation-summary-0506.png
- Mobile screenshot: /tmp/masc-agent-delegation-summary-0506-mobile.png
- Verified summary metadata: total=5, leaf=2, maxDepth=3, active=2, completed=1, failed=1, longestElapsedMs=12000, status=failed
- Verified deepest node metadata: depth=3, path=0.1.0.0, status=failed, leaf=true
- Verified zero horizontal overflow on desktop/mobile and no browser console/page errors

## Notes
- Temporary QA page was removed before commit.
