### PR TITLE
fix(coord): reconcile stale agent task state in status

### DIFF
--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -12,9 +12,10 @@ let status config =
   ensure_initialized config;
 
   let state = read_state config in
-  let backlog = read_backlog config in
-  Coord_task_schedule.reconcile_all_agent_current_tasks_with_backlog config
-    backlog;
+  let backlog =
+    Coord_task_schedule.reconcile_all_agent_current_tasks_with_fresh_backlog
+      ~touch_last_seen:false config
+  in
   let current_room = "default" in
   let max_agents_display = 40 in
   let max_active_tasks_display = 30 in

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -12,10 +12,7 @@ let status config =
   ensure_initialized config;
 
   let state = read_state config in
-  let backlog =
-    Coord_task_schedule.reconcile_all_agent_current_tasks_with_fresh_backlog
-      ~touch_last_seen:false config
-  in
+  let backlog = read_backlog config in
   let current_room = "default" in
   let max_agents_display = 40 in
   let max_active_tasks_display = 30 in
@@ -47,10 +44,26 @@ let status config =
           match agent_of_yojson json with
           | Ok agent ->
               let is_zombie = is_zombie_agent ~agent_name:agent.name agent.last_seen in
+              let stale_current_task =
+                match agent.current_task with
+                | Some task_id ->
+                    not
+                      (Coord_task_schedule.agent_current_task_matches_backlog
+                         backlog ~agent_name:agent.name task_id)
+                | None -> false
+              in
+              let display_status =
+                if stale_current_task then
+                  match agent.status with
+                  | Inactive -> Inactive
+                  | Active | Busy | Listening -> Active
+                else
+                  agent.status
+              in
               let icon =
                 if is_zombie then "💀"
                 else
-                  match agent.status with
+                  match display_status with
                   | Busy -> "🔴"
                   | Active -> "🟢"
                   | Listening -> "🎧"
@@ -58,6 +71,7 @@ let status config =
               in
               let task =
                 if is_zombie then "zombie"
+                else if stale_current_task then "idle"
                 else Option.value agent.current_task ~default:"idle"
               in
               Some (agent.name, icon, task)

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -13,6 +13,9 @@ let status config =
 
   let state = read_state config in
   let backlog = read_backlog config in
+  let active_task_assignees =
+    Coord_task_schedule.active_task_assignees_by_task_id backlog
+  in
   let current_room = "default" in
   let max_agents_display = 40 in
   let max_active_tasks_display = 30 in
@@ -48,8 +51,8 @@ let status config =
                 match agent.current_task with
                 | Some task_id ->
                     not
-                      (Coord_task_schedule.agent_current_task_matches_backlog
-                         backlog ~agent_name:agent.name task_id)
+                      (Coord_task_schedule.agent_current_task_matches_assignments
+                         active_task_assignees ~agent_name:agent.name task_id)
                 | None -> false
               in
               let display_status =

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -13,6 +13,8 @@ let status config =
 
   let state = read_state config in
   let backlog = read_backlog config in
+  Coord_task_schedule.reconcile_all_agent_current_tasks_with_backlog config
+    backlog;
   let current_room = "default" in
   let max_agents_display = 40 in
   let max_active_tasks_display = 30 in

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -276,20 +276,30 @@ let latest_receipt_blocks_required_tool_claim config ~agent_name ~required_tools
        || (tool_requirement = Some "required" && tools_used = []))
       && not required_tool_visible
 
-let agent_current_task_matches_backlog backlog ~agent_name task_id =
-  match
-    List.find_opt
-      (fun (task : Masc_domain.task) -> String.equal task.id task_id)
-      backlog.tasks
-  with
-  | Some task -> (
+let active_task_assignees_by_task_id backlog =
+  let table = Hashtbl.create (List.length backlog.tasks) in
+  List.iter
+    (fun (task : Masc_domain.task) ->
       match task.task_status with
       | Claimed { assignee; _ } | InProgress { assignee; _ } ->
-          String.equal assignee agent_name
-      | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false)
+          Hashtbl.replace table task.id assignee
+      | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ())
+    backlog.tasks;
+  table
+
+let agent_current_task_matches_assignments active_task_assignees ~agent_name
+    task_id =
+  match Hashtbl.find_opt active_task_assignees task_id with
+  | Some assignee -> String.equal assignee agent_name
   | None -> false
 
-let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
+let agent_current_task_matches_backlog backlog ~agent_name task_id =
+  let active_task_assignees = active_task_assignees_by_task_id backlog in
+  agent_current_task_matches_assignments active_task_assignees ~agent_name
+    task_id
+
+let reconcile_agent_current_task_with_assignments config ?(touch_last_seen = true)
+    ~agent_name active_task_assignees =
   let agent_file =
     Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
   in
@@ -300,7 +310,8 @@ let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
           match agent.current_task with
           | Some task_id
             when not
-                   (agent_current_task_matches_backlog backlog ~agent_name task_id)
+                   (agent_current_task_matches_assignments active_task_assignees
+                      ~agent_name task_id)
             ->
               let updated_status =
                 match agent.status with
@@ -312,7 +323,8 @@ let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
                   agent with
                   status = updated_status;
                   current_task = None;
-                  last_seen = now_iso ();
+                  last_seen =
+                    (if touch_last_seen then now_iso () else agent.last_seen);
                 }
               in
               write_json config agent_file (agent_to_yojson updated);
@@ -326,24 +338,46 @@ let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
       | Error msg ->
           Log.Misc.error "agent state reconcile failed: %s" msg)
 
-let reconcile_all_agent_current_tasks_with_backlog config backlog =
+let reconcile_agent_current_task_with_backlog config ?(touch_last_seen = true)
+    ~agent_name backlog =
+  let active_task_assignees = active_task_assignees_by_task_id backlog in
+  reconcile_agent_current_task_with_assignments config ~touch_last_seen
+    ~agent_name active_task_assignees
+
+let reconcile_all_agent_current_tasks_with_backlog config
+    ?(touch_last_seen = true) backlog =
   let agents_path = agents_dir config in
   try
-    if Sys.file_exists agents_path then
+    if Sys.file_exists agents_path then (
+      let active_task_assignees = active_task_assignees_by_task_id backlog in
       Sys.readdir agents_path
       |> Array.to_list
       |> List.filter (fun name -> Filename.check_suffix name ".json")
       |> List.iter (fun name ->
+           Coord_query.safe_yield ();
            let path = Filename.concat agents_path name in
            match read_agent_with_repair config path with
-           | Ok (agent : Masc_domain.agent) ->
-               reconcile_agent_current_task_with_backlog config
-                 ~agent_name:agent.name backlog
+           | Ok (agent : Masc_domain.agent) -> (
+               match agent.current_task with
+               | None -> ()
+               | Some _ ->
+                   reconcile_agent_current_task_with_assignments config
+                     ~touch_last_seen ~agent_name:agent.name
+                     active_task_assignees)
            | Error msg ->
-               Log.Misc.error "agent state reconcile failed for %s: %s" name msg)
+               Log.Misc.error "agent state reconcile failed for %s: %s" name msg))
   with
   | Sys_error msg ->
       Log.Misc.error "agent state reconcile scan failed: %s" msg
+
+let reconcile_all_agent_current_tasks_with_fresh_backlog
+    ?(touch_last_seen = true) config =
+  let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
+  with_file_lock config backlog_path (fun () ->
+    let backlog = read_backlog config in
+    reconcile_all_agent_current_tasks_with_backlog config ~touch_last_seen
+      backlog;
+    backlog)
 
 (** Claim next highest priority unclaimed task.
     Optional [exclude_task_ids] prevents re-claiming known bad tasks in the

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -298,6 +298,37 @@ let agent_current_task_matches_backlog backlog ~agent_name task_id =
   agent_current_task_matches_assignments active_task_assignees ~agent_name
     task_id
 
+let reconcile_agent_current_task_record config ?(touch_last_seen = true)
+    ~agent_file ~(agent : Masc_domain.agent) active_task_assignees =
+  match agent.current_task with
+  | Some task_id
+    when not
+           (agent_current_task_matches_assignments active_task_assignees
+              ~agent_name:agent.name task_id)
+    ->
+      let updated_status =
+        match agent.status with
+        | Inactive -> Inactive
+        | Active | Busy | Listening -> Active
+      in
+      let updated =
+        {
+          agent with
+          status = updated_status;
+          current_task = None;
+          last_seen =
+            (if touch_last_seen then now_iso () else agent.last_seen);
+        }
+      in
+      write_json config agent_file (agent_to_yojson updated);
+      log_event config (`Assoc [
+           ("type", `String "agent_current_task_reconciled");
+           ("agent", `String agent.name);
+           ("stale_task", `String task_id);
+           ("ts", `String (now_iso ()));
+         ])
+  | Some _ | None -> ()
+
 let reconcile_agent_current_task_with_assignments config ?(touch_last_seen = true)
     ~agent_name active_task_assignees =
   let agent_file =
@@ -306,35 +337,9 @@ let reconcile_agent_current_task_with_assignments config ?(touch_last_seen = tru
   if path_exists config agent_file then
     with_file_lock config agent_file (fun () ->
       match read_agent_with_repair config agent_file with
-      | Ok agent -> (
-          match agent.current_task with
-          | Some task_id
-            when not
-                   (agent_current_task_matches_assignments active_task_assignees
-                      ~agent_name task_id)
-            ->
-              let updated_status =
-                match agent.status with
-                | Inactive -> Inactive
-                | Active | Busy | Listening -> Active
-              in
-              let updated =
-                {
-                  agent with
-                  status = updated_status;
-                  current_task = None;
-                  last_seen =
-                    (if touch_last_seen then now_iso () else agent.last_seen);
-                }
-              in
-              write_json config agent_file (agent_to_yojson updated);
-              log_event config (`Assoc [
-                   ("type", `String "agent_current_task_reconciled");
-                   ("agent", `String agent_name);
-                   ("stale_task", `String task_id);
-                   ("ts", `String (now_iso ()));
-                 ])
-          | Some _ | None -> ())
+      | Ok agent ->
+          reconcile_agent_current_task_record config ~touch_last_seen ~agent_file
+            ~agent active_task_assignees
       | Error msg ->
           Log.Misc.error "agent state reconcile failed: %s" msg)
 
@@ -356,16 +361,14 @@ let reconcile_all_agent_current_tasks_with_backlog config
       |> List.iter (fun name ->
            Coord_query.safe_yield ();
            let path = Filename.concat agents_path name in
-           match read_agent_with_repair config path with
-           | Ok (agent : Masc_domain.agent) -> (
-               match agent.current_task with
-               | None -> ()
-               | Some _ ->
-                   reconcile_agent_current_task_with_assignments config
-                     ~touch_last_seen ~agent_name:agent.name
-                     active_task_assignees)
-           | Error msg ->
-               Log.Misc.error "agent state reconcile failed for %s: %s" name msg))
+           with_file_lock config path (fun () ->
+             match read_agent_with_repair config path with
+             | Ok (agent : Masc_domain.agent) ->
+                 reconcile_agent_current_task_record config ~touch_last_seen
+                   ~agent_file:path ~agent active_task_assignees
+             | Error msg ->
+                 Log.Misc.error "agent state reconcile failed for %s: %s" name
+                   msg)))
   with
   | Sys_error msg ->
       Log.Misc.error "agent state reconcile scan failed: %s" msg

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -284,10 +284,9 @@ let agent_current_task_matches_backlog backlog ~agent_name task_id =
   with
   | Some task -> (
       match task.task_status with
-      | Claimed { assignee; _ } | InProgress { assignee; _ }
-      | AwaitingVerification { assignee; _ } ->
+      | Claimed { assignee; _ } | InProgress { assignee; _ } ->
           String.equal assignee agent_name
-      | Todo | Done _ | Cancelled _ -> false)
+      | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false)
   | None -> false
 
 let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
@@ -326,6 +325,25 @@ let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
           | Some _ | None -> ())
       | Error msg ->
           Log.Misc.error "agent state reconcile failed: %s" msg)
+
+let reconcile_all_agent_current_tasks_with_backlog config backlog =
+  let agents_path = agents_dir config in
+  try
+    if Sys.file_exists agents_path then
+      Sys.readdir agents_path
+      |> Array.to_list
+      |> List.filter (fun name -> Filename.check_suffix name ".json")
+      |> List.iter (fun name ->
+           let path = Filename.concat agents_path name in
+           match read_agent_with_repair config path with
+           | Ok (agent : Masc_domain.agent) ->
+               reconcile_agent_current_task_with_backlog config
+                 ~agent_name:agent.name backlog
+           | Error msg ->
+               Log.Misc.error "agent state reconcile failed for %s: %s" name msg)
+  with
+  | Sys_error msg ->
+      Log.Misc.error "agent state reconcile scan failed: %s" msg
 
 (** Claim next highest priority unclaimed task.
     Optional [exclude_task_ids] prevents re-claiming known bad tasks in the

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -65,10 +65,13 @@ val agent_current_task_matches_backlog :
   Masc_domain.backlog -> agent_name:string -> string -> bool
 
 val reconcile_agent_current_task_with_backlog :
-  config -> agent_name:string -> Masc_domain.backlog -> unit
+  config -> ?touch_last_seen:bool -> agent_name:string -> Masc_domain.backlog -> unit
 
 val reconcile_all_agent_current_tasks_with_backlog :
-  config -> Masc_domain.backlog -> unit
+  config -> ?touch_last_seen:bool -> Masc_domain.backlog -> unit
+
+val reconcile_all_agent_current_tasks_with_fresh_backlog :
+  ?touch_last_seen:bool -> config -> Masc_domain.backlog
 
 val claim_next_r :
   config ->

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -67,6 +67,9 @@ val agent_current_task_matches_backlog :
 val reconcile_agent_current_task_with_backlog :
   config -> agent_name:string -> Masc_domain.backlog -> unit
 
+val reconcile_all_agent_current_tasks_with_backlog :
+  config -> Masc_domain.backlog -> unit
+
 val claim_next_r :
   config ->
   agent_name:string ->

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -61,6 +61,12 @@ val json_string_list : string -> Yojson.Safe.t -> string list
 val latest_receipt_blocks_required_tool_claim :
   config -> agent_name:string -> required_tools:string list -> bool
 
+val active_task_assignees_by_task_id :
+  Masc_domain.backlog -> (string, string) Hashtbl.t
+
+val agent_current_task_matches_assignments :
+  (string, string) Hashtbl.t -> agent_name:string -> string -> bool
+
 val agent_current_task_matches_backlog :
   Masc_domain.backlog -> agent_name:string -> string -> bool
 

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -199,11 +199,14 @@ let safe_read_backlog (ctx : context) =
   try
     Coord.read_backlog ctx.config
   with
-  | Sys_error _ | Yojson.Json_error _ -> Coord.read_backlog ctx.config
   | exn ->
       Log.Coord.warn "read_backlog failed: %s"
         (Stdlib.Printexc.to_string exn);
-      Coord.read_backlog ctx.config
+      {
+        Masc_domain.tasks = [];
+        last_updated = Coord.now_iso ();
+        version = 1;
+      }
 
 let safe_is_zombie_agent ~agent_name last_seen =
   try Coord.is_zombie_agent ~agent_name last_seen
@@ -343,13 +346,17 @@ let status_summary_string (ctx : context) =
   let current_task = safe_current_task ctx ~joined in
   let worktree_active = status_worktree_active ctx in
   let effective_cluster_name = effective_cluster_name ctx.config in
+  let active_task_assignees =
+    Coord.active_task_assignees_by_task_id backlog
+  in
   let agents =
     safe_get_agents ctx
     |> List.map (fun (agent : Masc_domain.agent) ->
            match agent.current_task with
            | Some task_id
              when not
-                    (Coord.agent_current_task_matches_backlog backlog
+                    (Coord.agent_current_task_matches_assignments
+                       active_task_assignees
                        ~agent_name:agent.name task_id) ->
                let status =
                  match agent.status with

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -195,6 +195,14 @@ let safe_get_agents (ctx : context) =
       Log.Coord.warn "get_agents_raw failed: %s" (Stdlib.Printexc.to_string exn);
       []
 
+let safe_reconcile_agent_current_tasks (ctx : context) backlog =
+  try Coord.reconcile_all_agent_current_tasks_with_backlog ctx.config backlog
+  with
+  | Sys_error _ | Yojson.Json_error _ -> ()
+  | exn ->
+      Log.Coord.warn "agent current_task reconcile failed: %s"
+        (Stdlib.Printexc.to_string exn)
+
 let safe_is_zombie_agent ~agent_name last_seen =
   try Coord.is_zombie_agent ~agent_name last_seen
   with
@@ -320,6 +328,7 @@ let status_summary_string (ctx : context) =
   Coord.ensure_initialized ctx.config;
   let state = Coord.read_state ctx.config in
   let backlog = Coord.read_backlog ctx.config in
+  safe_reconcile_agent_current_tasks ctx backlog;
   let joined =
     try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name
     with Sys_error _ | Yojson.Json_error _ -> false

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -195,13 +195,16 @@ let safe_get_agents (ctx : context) =
       Log.Coord.warn "get_agents_raw failed: %s" (Stdlib.Printexc.to_string exn);
       []
 
-let safe_reconcile_agent_current_tasks (ctx : context) backlog =
-  try Coord.reconcile_all_agent_current_tasks_with_backlog ctx.config backlog
+let safe_reconcile_agent_current_tasks (ctx : context) =
+  try
+    Coord.reconcile_all_agent_current_tasks_with_fresh_backlog
+      ~touch_last_seen:false ctx.config
   with
-  | Sys_error _ | Yojson.Json_error _ -> ()
+  | Sys_error _ | Yojson.Json_error _ -> Coord.read_backlog ctx.config
   | exn ->
       Log.Coord.warn "agent current_task reconcile failed: %s"
-        (Stdlib.Printexc.to_string exn)
+        (Stdlib.Printexc.to_string exn);
+      Coord.read_backlog ctx.config
 
 let safe_is_zombie_agent ~agent_name last_seen =
   try Coord.is_zombie_agent ~agent_name last_seen
@@ -327,8 +330,7 @@ let coordination_fsm_attention_items ctx =
 let status_summary_string (ctx : context) =
   Coord.ensure_initialized ctx.config;
   let state = Coord.read_state ctx.config in
-  let backlog = Coord.read_backlog ctx.config in
-  safe_reconcile_agent_current_tasks ctx backlog;
+  let backlog = safe_reconcile_agent_current_tasks ctx in
   let joined =
     try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name
     with Sys_error _ | Yojson.Json_error _ -> false

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -195,14 +195,13 @@ let safe_get_agents (ctx : context) =
       Log.Coord.warn "get_agents_raw failed: %s" (Stdlib.Printexc.to_string exn);
       []
 
-let safe_reconcile_agent_current_tasks (ctx : context) =
+let safe_read_backlog (ctx : context) =
   try
-    Coord.reconcile_all_agent_current_tasks_with_fresh_backlog
-      ~touch_last_seen:false ctx.config
+    Coord.read_backlog ctx.config
   with
   | Sys_error _ | Yojson.Json_error _ -> Coord.read_backlog ctx.config
   | exn ->
-      Log.Coord.warn "agent current_task reconcile failed: %s"
+      Log.Coord.warn "read_backlog failed: %s"
         (Stdlib.Printexc.to_string exn);
       Coord.read_backlog ctx.config
 
@@ -330,7 +329,7 @@ let coordination_fsm_attention_items ctx =
 let status_summary_string (ctx : context) =
   Coord.ensure_initialized ctx.config;
   let state = Coord.read_state ctx.config in
-  let backlog = safe_reconcile_agent_current_tasks ctx in
+  let backlog = safe_read_backlog ctx in
   let joined =
     try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name
     with Sys_error _ | Yojson.Json_error _ -> false
@@ -346,6 +345,20 @@ let status_summary_string (ctx : context) =
   let effective_cluster_name = effective_cluster_name ctx.config in
   let agents =
     safe_get_agents ctx
+    |> List.map (fun (agent : Masc_domain.agent) ->
+           match agent.current_task with
+           | Some task_id
+             when not
+                    (Coord.agent_current_task_matches_backlog backlog
+                       ~agent_name:agent.name task_id) ->
+               let status =
+                 match agent.status with
+                 | Masc_domain.Inactive -> Masc_domain.Inactive
+                 | Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening ->
+                     Masc_domain.Active
+               in
+               { agent with status; current_task = None }
+           | Some _ | None -> agent)
     |> List.sort (fun (a : Masc_domain.agent) (b : Masc_domain.agent) ->
            String.compare a.name b.name)
   in

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -333,7 +333,7 @@ let test_claim_next_reconciles_stale_agent_current_task () =
     | _ -> Alcotest.fail "expected no_unclaimed after stale reconcile"
   )
 
-let test_status_reconciles_stale_agent_current_task () =
+let test_status_hides_stale_agent_current_task_without_writing () =
   with_env "MASC_VERIFICATION_FSM_ENABLED" "true" (fun () ->
     with_test_env (fun config ->
       let agent_name =
@@ -363,16 +363,20 @@ let test_status_reconciles_stale_agent_current_task () =
         | Error msg -> Alcotest.fail ("agent parse failed: " ^ msg)
       in
       Coord.write_json config agent_file (Masc_domain.agent_to_yojson stale_agent);
-      ignore (Coord.status config);
+      let output = Coord.status config in
+      Alcotest.(check bool)
+        "status renders stale task as idle" true
+        (str_contains output (Printf.sprintf "%s → idle" agent_name));
       let agent_after =
         match Coord.read_json config agent_file |> Masc_domain.agent_of_yojson with
         | Ok agent -> agent
         | Error msg -> Alcotest.fail ("agent parse failed after status: " ^ msg)
       in
       Alcotest.(check (option string))
-        "stale current_task cleared on status" None agent_after.current_task;
+        "status read does not clear stale current_task" (Some "task-001")
+        agent_after.current_task;
       Alcotest.(check string)
-        "status reset to active on status" "active"
+        "status read does not reset stored status" "busy"
         (Masc_domain.agent_status_to_string agent_after.status)))
 
 (* ============================================================ *)
@@ -1492,8 +1496,8 @@ let () =
 
     (* === Status === *)
     "status", [
-      Alcotest.test_case "reconciles stale current_task on read" `Quick
-        test_status_reconciles_stale_agent_current_task;
+      Alcotest.test_case "hides stale current_task on read without writing" `Quick
+        test_status_hides_stale_agent_current_task_without_writing;
     ];
 
     (* === Claim Next === *)

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -333,6 +333,48 @@ let test_claim_next_reconciles_stale_agent_current_task () =
     | _ -> Alcotest.fail "expected no_unclaimed after stale reconcile"
   )
 
+let test_status_reconciles_stale_agent_current_task () =
+  with_env "MASC_VERIFICATION_FSM_ENABLED" "true" (fun () ->
+    with_test_env (fun config ->
+      let agent_name =
+        match Coord.get_agents_raw config with
+        | [ agent ] -> agent.Masc_domain.name
+        | _ -> Alcotest.fail "expected exactly one joined agent"
+      in
+      let _ =
+        Coord.add_task config ~title:"Awaiting verifier" ~priority:1
+          ~description:""
+      in
+      let _ = Coord.claim_task config ~agent_name ~task_id:"task-001" in
+      (match
+         Coord.transition_task_r config ~agent_name ~task_id:"task-001"
+           ~action:Masc_domain.Submit_for_verification ()
+       with
+      | Ok _ -> ()
+      | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
+      let agent_file =
+        Filename.concat (Coord.agents_dir config)
+          (Coord.safe_filename agent_name ^ ".json")
+      in
+      let stale_agent =
+        match Coord.read_json config agent_file |> Masc_domain.agent_of_yojson with
+        | Ok agent ->
+            { agent with status = Masc_domain.Busy; current_task = Some "task-001" }
+        | Error msg -> Alcotest.fail ("agent parse failed: " ^ msg)
+      in
+      Coord.write_json config agent_file (Masc_domain.agent_to_yojson stale_agent);
+      ignore (Coord.status config);
+      let agent_after =
+        match Coord.read_json config agent_file |> Masc_domain.agent_of_yojson with
+        | Ok agent -> agent
+        | Error msg -> Alcotest.fail ("agent parse failed after status: " ^ msg)
+      in
+      Alcotest.(check (option string))
+        "stale current_task cleared on status" None agent_after.current_task;
+      Alcotest.(check string)
+        "status reset to active on status" "active"
+        (Masc_domain.agent_status_to_string agent_after.status)))
+
 (* ============================================================ *)
 (* #10421: claim_next existing-task preservation                 *)
 (* ============================================================ *)
@@ -1446,6 +1488,12 @@ let () =
       Alcotest.test_case "empty list" `Quick test_batch_add_empty_list;
       Alcotest.test_case "single task" `Quick test_batch_add_single_task;
       Alcotest.test_case "preserves priorities" `Quick test_batch_add_preserves_priorities;
+    ];
+
+    (* === Status === *)
+    "status", [
+      Alcotest.test_case "reconciles stale current_task on read" `Quick
+        test_status_reconciles_stale_agent_current_task;
     ];
 
     (* === Claim Next === *)

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -78,6 +78,27 @@ let make_test_ctx () =
     { Masc_domain.default_auth_config with enabled = false; require_token = false };
   { Tool_coord.config; agent_name = "test-agent" }
 
+let agent_file ctx =
+  let agent_name = Coord.resolve_agent_name ctx.config ctx.agent_name in
+  Filename.concat (Coord.agents_dir ctx.config)
+    (Coord.safe_filename agent_name ^ ".json")
+
+let read_agent ctx =
+  match Types.agent_of_yojson (Coord.read_json ctx.config (agent_file ctx)) with
+  | Ok agent -> agent
+  | Error msg -> failwith ("agent decode failed: " ^ msg)
+
+let write_agent ctx agent =
+  Coord.write_json ctx.config (agent_file ctx)
+    (Types.agent_to_yojson agent)
+
+let seed_stale_current_task ctx =
+  let old_last_seen = "2000-01-01T00:00:00Z" in
+  let agent = read_agent ctx in
+  write_agent ctx
+    { agent with status = Busy; current_task = Some "task-missing"; last_seen = old_last_seen };
+  old_last_seen
+
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -104,6 +125,29 @@ let () = test "dispatch_status" (fun () ->
       assert (str_contains message "🧭 You:");
       assert (str_contains message "Suggested next:")
   | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_status_reconciles_current_task_without_touching_last_seen" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some ctx.agent_name) in
+  let old_last_seen = seed_stale_current_task ctx in
+  match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some { success; _ } ->
+      assert success;
+      let agent = read_agent ctx in
+      assert (agent.current_task = None);
+      assert (agent.last_seen = old_last_seen)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "coord_status_reconciles_current_task_without_touching_last_seen" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some ctx.agent_name) in
+  let old_last_seen = seed_stale_current_task ctx in
+  ignore (Coord.status ctx.config);
+  let agent = read_agent ctx in
+  assert (agent.current_task = None);
+  assert (agent.last_seen = old_last_seen)
 )
 
 (* Test dispatch coordination FSM snapshot *)

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -100,9 +100,9 @@ let () = test "dispatch_status" (fun () ->
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args with
   | Some { success; message } ->
       assert success;
-      assert (str_contains message "⚡ Snapshot:");
+      assert (str_contains message "Snapshot:");
       assert (str_contains message "🧭 You:");
-      assert (str_contains message "💡 Suggested next:")
+      assert (str_contains message "Suggested next:")
   | None -> failwith "dispatch returned None"
 )
 
@@ -135,7 +135,7 @@ let () = test "dispatch_status_summary_and_cap" (fun () ->
   | Some { success; message = result } ->
       assert success;
       assert (str_contains result "tasks active=35 todo=35 claimed=0 in_progress=0");
-      assert (str_contains result "⚠️ Attention:");
+      assert (str_contains result "Attention:");
       assert_contains result "35 unclaimed task(s) are available right now.";
       assert (str_contains result "Summary: active=35, done=0, cancelled=0, total=35");
       assert (str_contains result "and 5 more active tasks")
@@ -164,6 +164,49 @@ let () = test "dispatch_status_done_summary" (fun () ->
       assert (str_contains result "(no active tasks)")
   | None -> failwith "dispatch returned None"
 )
+
+let () = test "dispatch_status_reconciles_stale_agent_current_task" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx () in
+    let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+    let actual_name = Coord.resolve_agent_name ctx.config "test-agent" in
+    ignore
+      (Coord.add_task ctx.config ~title:"Awaiting verifier" ~priority:2
+         ~description:"");
+    ignore (Coord.claim_task ctx.config ~agent_name:actual_name ~task_id:"task-001");
+    (match
+       Coord.transition_task_r ctx.config ~agent_name:actual_name
+         ~task_id:"task-001" ~action:Masc_domain.Submit_for_verification ()
+     with
+    | Ok _ -> ()
+    | Error err -> failwith (Masc_domain.masc_error_to_string err));
+    let agent_file =
+      Filename.concat (Coord.agents_dir ctx.config)
+        (Coord.safe_filename actual_name ^ ".json")
+    in
+    let stale_agent =
+      match Coord.read_json ctx.config agent_file |> Masc_domain.agent_of_yojson with
+      | Ok agent ->
+          { agent with
+            status = Masc_domain.Busy;
+            current_task = Some "task-001";
+          }
+      | Error msg -> failwith ("agent parse failed: " ^ msg)
+    in
+    Coord.write_json ctx.config agent_file
+      (Masc_domain.agent_to_yojson stale_agent);
+    match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+    | Some { success; message = result } ->
+        assert success;
+        assert_contains result (actual_name ^ " (you) -> active");
+        let agent_after =
+          match Coord.read_json ctx.config agent_file |> Masc_domain.agent_of_yojson with
+          | Ok agent -> agent
+          | Error msg -> failwith ("agent parse failed after status: " ^ msg)
+        in
+        assert (agent_after.current_task = None);
+        assert (agent_after.status = Masc_domain.Active)
+    | None -> failwith "dispatch returned None"))
 
 (* Test dispatch reset without confirm *)
 let () = test "dispatch_reset_no_confirm" (fun () ->
@@ -319,7 +362,7 @@ let () = test "dispatch_status_surfaces_owned_current_drift" (fun () ->
       assert (str_contains result "current=task-002");
       assert_contains result
         "Do not retry generic masc_plan_init from a drifted surface";
-      assert (not (str_contains result "💡 Suggested next: masc_plan_init -> masc_status"));
+      assert (not (str_contains result "Suggested next: masc_plan_init -> masc_status"));
       assert (str_contains result "planning current_task is unset or drifted")
   | None -> failwith "dispatch returned None"
 )
@@ -336,10 +379,10 @@ let () = test "dispatch_status_suppresses_lifecycle_guidance_without_credential"
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
   | Some { success; message = result } ->
       assert success;
-      assert (str_contains result "🔐 Credential: required=yes | available=no | candidates=test-agent");
+      assert (str_contains result "Credential: required=yes | available=no | candidates=test-agent");
       assert (str_contains result "Lifecycle actions are credential-blocked for test-agent");
-      assert (not (str_contains result "💡 Suggested next: masc_status -> masc_transition"));
-      assert (not (str_contains result "💡 Suggested next: masc_claim_next"))
+      assert (not (str_contains result "Suggested next: masc_status -> masc_transition"));
+      assert (not (str_contains result "Suggested next: masc_claim_next"))
   | None -> failwith "dispatch returned None"
 )
 
@@ -358,12 +401,12 @@ let () = test "dispatch_status_treats_keeper_internal_auth_as_credential" (fun (
       assert success;
       assert (
         str_contains result
-          "🔐 Credential: required=yes | available=yes | candidates=keeper-sangsu-agent");
+          "Credential: required=yes | available=yes | candidates=keeper-sangsu-agent");
       assert (
         not
           (str_contains result
              "Lifecycle actions are credential-blocked for keeper-sangsu-agent"));
-      assert (str_contains result "💡 Suggested next:")
+      assert (str_contains result "Suggested next:")
   | None -> failwith "dispatch returned None"
 )
 
@@ -382,8 +425,8 @@ let () = test "dispatch_status_no_owned_prefers_claim_next_over_transition" (fun
       assert (str_contains result "owned=- | current=task-001");
       assert (str_contains result "drift_reason=no_owned");
       assert (str_contains result "claim_first_suppressed=no");
-      assert_contains result "💡 Suggested next: masc_claim_next -> masc_status";
-      assert_not_contains result "💡 Suggested next: masc_status -> masc_transition"
+      assert_contains result "Suggested next: masc_claim_next -> masc_status";
+      assert_not_contains result "Suggested next: masc_status -> masc_transition"
   | None -> failwith "dispatch returned None"
 )
 
@@ -400,15 +443,15 @@ let () = test "dispatch_status_surfaces_missing_planning_for_owned_task" (fun ()
   | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=task-001 | current=task-001");
-      assert (str_contains result "📝 Planning: missing=yes | task=task-001");
+      assert (str_contains result "Planning: missing=yes | task=task-001");
       assert_contains result "Owned task task-001 has no planning context.";
       assert (
         str_contains result
           "Do not retry generic masc_plan_init from a drifted surface");
       assert (str_contains result "handoff/worktree/test logs as the temporary SSOT");
-      assert (not (str_contains result "💡 Suggested next: masc_plan_init -> masc_status"));
-      assert (not (str_contains result "💡 Suggested next: masc_heartbeat"));
-      assert (not (str_contains result "💡 Suggested next: masc_status -> masc_transition"))
+      assert (not (str_contains result "Suggested next: masc_plan_init -> masc_status"));
+      assert (not (str_contains result "Suggested next: masc_heartbeat"));
+      assert (not (str_contains result "Suggested next: masc_status -> masc_transition"))
   | None -> failwith "dispatch returned None"
 )
 
@@ -428,11 +471,11 @@ let () = test "dispatch_status_surfaces_completed_deliverable_conflict_for_activ
   | Some { success; message = result } ->
       assert success;
       assert (str_contains result "owned=task-001 | current=task-001");
-      assert (str_contains result "📝 Planning: deliverable_conflict=yes | task=task-001");
+      assert (str_contains result "Planning: deliverable_conflict=yes | task=task-001");
       assert_contains result
         "Owned task task-001 already has a completed-looking deliverable";
-      assert (str_contains result "💡 Suggested next: masc_deliver -> masc_status");
-      assert (not (str_contains result "💡 Suggested next: masc_status -> masc_transition"))
+      assert (str_contains result "Suggested next: masc_deliver -> masc_status");
+      assert (not (str_contains result "Suggested next: masc_status -> masc_transition"))
   | None -> failwith "dispatch returned None"
 )
 
@@ -450,7 +493,7 @@ let () = test "dispatch_status_flags_todo_with_completed_deliverable_as_conflict
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
   | Some { success; message = result } ->
       assert success;
-      assert (str_contains result "⚠️ task-001 P2 [todo_conflict] Conflicted todo (unclaimed)");
+      assert (str_contains result "warning task-001 P2 [todo_conflict] Conflicted todo (unclaimed)");
       assert (str_contains result "📋 task-002 P2 [todo] Fresh todo (unclaimed)");
       assert_contains result
         "1 todo task(s) have completed-looking planning deliverables";

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -127,26 +127,28 @@ let () = test "dispatch_status" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
-let () = test "dispatch_status_reconciles_current_task_without_touching_last_seen" (fun () ->
+let () = test "dispatch_status_hides_stale_current_task_without_writing" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Coord.init ctx.config ~agent_name:(Some ctx.agent_name) in
   let old_last_seen = seed_stale_current_task ctx in
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-  | Some { success; _ } ->
+  | Some { success; message } ->
       assert success;
+      assert (str_contains message "test-agent (you) -> active");
       let agent = read_agent ctx in
-      assert (agent.current_task = None);
+      assert (agent.current_task = Some "task-missing");
       assert (agent.last_seen = old_last_seen)
   | None -> failwith "dispatch returned None"
 )
 
-let () = test "coord_status_reconciles_current_task_without_touching_last_seen" (fun () ->
+let () = test "coord_status_hides_stale_current_task_without_writing" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Coord.init ctx.config ~agent_name:(Some ctx.agent_name) in
   let old_last_seen = seed_stale_current_task ctx in
-  ignore (Coord.status ctx.config);
+  let output = Coord.status ctx.config in
+  assert (str_contains output "test-agent → idle");
   let agent = read_agent ctx in
-  assert (agent.current_task = None);
+  assert (agent.current_task = Some "task-missing");
   assert (agent.last_seen = old_last_seen)
 )
 
@@ -209,7 +211,7 @@ let () = test "dispatch_status_done_summary" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
-let () = test "dispatch_status_reconciles_stale_agent_current_task" (fun () ->
+let () = test "dispatch_status_hides_awaiting_verification_current_task" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx () in
     let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
@@ -248,8 +250,8 @@ let () = test "dispatch_status_reconciles_stale_agent_current_task" (fun () ->
           | Ok agent -> agent
           | Error msg -> failwith ("agent parse failed after status: " ^ msg)
         in
-        assert (agent_after.current_task = None);
-        assert (agent_after.status = Masc_domain.Active)
+        assert (agent_after.current_task = Some "task-001");
+        assert (agent_after.status = Masc_domain.Busy)
     | None -> failwith "dispatch returned None"))
 
 (* Test dispatch reset without confirm *)


### PR DESCRIPTION
## Summary

Status reads no longer mutate room-agent files while rendering stale `current_task` bindings. `Coord.status` and `masc_status` now read the backlog, build an in-memory active task assignment index, and render stale room-agent focus as idle/active without writing `current_task`, `status`, or `last_seen` back to disk.

Write-side reconciliation remains in the scheduling/claim path. The all-agent reconcile path now reuses the already-read agent record under one file lock instead of scanning once and then re-locking/re-reading each agent.

## Product impact

Operators and keepers still see stale room-agent task bindings disappear from status output, but ordinary observation stays read-only. This keeps dashboards/status polling from silently mutating runtime state while preserving the actual cleanup behavior for lifecycle paths that are expected to write.

## Evidence

- Added/updated regression coverage showing `masc_status` hides stale room-agent focus without changing stored `current_task` or `last_seen`.
- Added/updated regression coverage showing legacy `Coord.status` renders stale focus as idle without clearing the agent file.
- Optimized assignment matching by building the active task assignee table once per status render.

## Review evidence

- `ocamlc -stop-after parsing lib/coord/coord_status.ml lib/tool_coord.ml lib/coord/coord_task_schedule.ml lib/coord/coord_task_schedule.mli test/test_tool_coord_coverage.ml test/test_room_coverage.ml`
- `git diff --check`
- Focused Dune execution was attempted with `MASC_SKIP_PIN_CHECK=1`; it was blocked by the shared opam/dune locks, so the waiting process was stopped.

## Linked issue

None for this status read/write split. Related validation drift: #13606.