### PR TITLE
fix(dashboard): expose agent presence summary state

### DIFF
--- a/dashboard/src/components/common/agent-presence.test.ts
+++ b/dashboard/src/components/common/agent-presence.test.ts
@@ -98,16 +98,17 @@ describe('AgentPresence', () => {
     expect(el.dataset.presencePulse).toBe('true')
     expect(el.dataset.presenceSize).toBe('md')
     expect(el.dataset.presenceDetailPresent).toBe('true')
-    expect(el.dataset.presenceDetail).toBe('task-123')
+    expect(el.hasAttribute('data-presence-detail')).toBe(false)
   })
 
-  it('exposes empty detail metadata', () => {
+  it('omits false boolean and detail-copy metadata', () => {
     const container = document.createElement('div')
     render(h(AgentPresence, { status: null }), container)
     const el = container.querySelector('[data-agent-presence]') as HTMLElement
     expect(el.dataset.presenceRawStatus).toBe('')
-    expect(el.dataset.presenceDetailPresent).toBe('false')
-    expect(el.dataset.presenceDetail).toBe('')
+    expect(el.hasAttribute('data-presence-pulse')).toBe(false)
+    expect(el.hasAttribute('data-presence-detail-present')).toBe(false)
+    expect(el.hasAttribute('data-presence-detail')).toBe(false)
   })
 
   it('renders label text', () => {

--- a/dashboard/src/components/common/agent-presence.test.ts
+++ b/dashboard/src/components/common/agent-presence.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentPresence, agentStatusToPresence, presenceConfig } from './agent-presence'
+import {
+  AgentPresence,
+  agentStatusToPresence,
+  presenceConfig,
+  summarizeAgentPresence,
+} from './agent-presence'
 
 describe('agentStatusToPresence', () => {
   it('maps active to online', () => {
@@ -40,9 +45,38 @@ describe('agentStatusToPresence', () => {
 describe('presenceConfig', () => {
   it('returns config for each state', () => {
     expect(presenceConfig('online').label).toBe('온라인')
+    expect(presenceConfig('online').colorClass).toContain('var(--color-status-ok)')
     expect(presenceConfig('working').pulse).toBe(true)
+    expect(presenceConfig('working').colorClass).toContain('var(--color-accent-fg)')
     expect(presenceConfig('idle').label).toBe('대기')
+    expect(presenceConfig('idle').colorClass).toContain('var(--color-status-warn)')
     expect(presenceConfig('offline').label).toBe('오프라인')
+  })
+})
+
+describe('summarizeAgentPresence', () => {
+  it('summarizes mapped status, label, size, and detail', () => {
+    expect(summarizeAgentPresence('busy', 'compacting', 'md')).toEqual({
+      rawStatus: 'busy',
+      state: 'working',
+      label: '작업 중',
+      pulse: true,
+      size: 'md',
+      detail: 'compacting',
+      detailPresent: true,
+    })
+  })
+
+  it('normalizes null status and detail', () => {
+    expect(summarizeAgentPresence(null, null, 'sm')).toEqual({
+      rawStatus: '',
+      state: 'offline',
+      label: '오프라인',
+      pulse: false,
+      size: 'sm',
+      detail: '',
+      detailPresent: false,
+    })
   })
 })
 
@@ -52,6 +86,28 @@ describe('AgentPresence', () => {
     render(h(AgentPresence, { status: 'active' }), container)
     const el = container.querySelector('[data-presence-state]')
     expect(el?.getAttribute('data-presence-state')).toBe('online')
+  })
+
+  it('exposes summary data attributes', () => {
+    const container = document.createElement('div')
+    render(h(AgentPresence, { status: 'busy', detail: 'task-123', size: 'md' }), container)
+    const el = container.querySelector('[data-agent-presence]') as HTMLElement
+    expect(el.dataset.presenceRawStatus).toBe('busy')
+    expect(el.dataset.presenceState).toBe('working')
+    expect(el.dataset.presenceLabel).toBe('작업 중')
+    expect(el.dataset.presencePulse).toBe('true')
+    expect(el.dataset.presenceSize).toBe('md')
+    expect(el.dataset.presenceDetailPresent).toBe('true')
+    expect(el.dataset.presenceDetail).toBe('task-123')
+  })
+
+  it('exposes empty detail metadata', () => {
+    const container = document.createElement('div')
+    render(h(AgentPresence, { status: null }), container)
+    const el = container.querySelector('[data-agent-presence]') as HTMLElement
+    expect(el.dataset.presenceRawStatus).toBe('')
+    expect(el.dataset.presenceDetailPresent).toBe('false')
+    expect(el.dataset.presenceDetail).toBe('')
   })
 
   it('renders label text', () => {
@@ -64,6 +120,7 @@ describe('AgentPresence', () => {
     const container = document.createElement('div')
     render(h(AgentPresence, { status: 'active', detail: 'task-123' }), container)
     expect(container.textContent).toContain('task-123')
+    expect(container.querySelector('[title="task-123"]')).not.toBeNull()
   })
 
   it('uses sm size by default', () => {

--- a/dashboard/src/components/common/agent-presence.ts
+++ b/dashboard/src/components/common/agent-presence.ts
@@ -133,10 +133,9 @@ export function AgentPresence({
       data-presence-raw-status=${summary.rawStatus}
       data-presence-state=${summary.state}
       data-presence-label=${summary.label}
-      data-presence-pulse=${summary.pulse}
+      data-presence-pulse=${summary.pulse ? 'true' : undefined}
       data-presence-size=${summary.size}
-      data-presence-detail-present=${summary.detailPresent}
-      data-presence-detail=${summary.detail}
+      data-presence-detail-present=${summary.detailPresent ? 'true' : undefined}
       data-testid=${testId}
     >
       <span class="relative inline-flex ${dotSize}">

--- a/dashboard/src/components/common/agent-presence.ts
+++ b/dashboard/src/components/common/agent-presence.ts
@@ -11,27 +11,38 @@
 
 import { html } from 'htm/preact'
 
-type PresenceVisualState = 'online' | 'working' | 'idle' | 'offline'
+export type PresenceVisualState = 'online' | 'working' | 'idle' | 'offline'
+export type AgentPresenceSize = 'sm' | 'md'
 
-interface PresenceConfig {
+export interface PresenceConfig {
   colorClass: string
   pulse: boolean
   label: string
 }
 
+export interface AgentPresenceSummary {
+  readonly rawStatus: string
+  readonly state: PresenceVisualState
+  readonly label: string
+  readonly pulse: boolean
+  readonly size: AgentPresenceSize
+  readonly detail: string
+  readonly detailPresent: boolean
+}
+
 const PRESENCE_CONFIG: Record<PresenceVisualState, PresenceConfig> = {
   online: {
-    colorClass: 'bg-[var(--ok-10)]',
+    colorClass: 'bg-[var(--color-status-ok)]',
     pulse: false,
     label: '온라인',
   },
   working: {
-    colorClass: 'bg-[var(--color-accent)]',
+    colorClass: 'bg-[var(--color-accent-fg)]',
     pulse: true,
     label: '작업 중',
   },
   idle: {
-    colorClass: 'bg-[var(--warn-10)]',
+    colorClass: 'bg-[var(--color-status-warn)]',
     pulse: false,
     label: '대기',
   },
@@ -68,10 +79,29 @@ export function presenceConfig(state: PresenceVisualState): PresenceConfig {
   return PRESENCE_CONFIG[state]
 }
 
+export function summarizeAgentPresence(
+  status: string | null | undefined,
+  detail: string | null | undefined,
+  size: AgentPresenceSize,
+): AgentPresenceSummary {
+  const state = agentStatusToPresence(status)
+  const config = presenceConfig(state)
+  const normalizedDetail = detail ?? ''
+  return {
+    rawStatus: status ?? '',
+    state,
+    label: config.label,
+    pulse: config.pulse,
+    size,
+    detail: normalizedDetail,
+    detailPresent: normalizedDetail.length > 0,
+  }
+}
+
 interface AgentPresenceProps {
   status: string | null | undefined
   detail?: string | null
-  size?: 'sm' | 'md'
+  size?: AgentPresenceSize
   testId?: string
 }
 
@@ -86,8 +116,8 @@ export function AgentPresence({
   size = 'sm',
   testId,
 }: AgentPresenceProps) {
-  const state = agentStatusToPresence(status)
-  const config = PRESENCE_CONFIG[state]
+  const summary = summarizeAgentPresence(status, detail, size)
+  const config = PRESENCE_CONFIG[summary.state]
   const dotSize = SIZE_CLASSES[size]
   const pulseRing = config.pulse
     ? html`<span
@@ -97,7 +127,18 @@ export function AgentPresence({
     : null
 
   return html`
-    <div class="inline-flex items-center gap-2" data-agent-presence data-presence-state=${state} data-testid=${testId}>
+    <div
+      class="inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1"
+      data-agent-presence
+      data-presence-raw-status=${summary.rawStatus}
+      data-presence-state=${summary.state}
+      data-presence-label=${summary.label}
+      data-presence-pulse=${summary.pulse}
+      data-presence-size=${summary.size}
+      data-presence-detail-present=${summary.detailPresent}
+      data-presence-detail=${summary.detail}
+      data-testid=${testId}
+    >
       <span class="relative inline-flex ${dotSize}">
         ${pulseRing}
         <span
@@ -107,7 +148,13 @@ export function AgentPresence({
         ></span>
       </span>
       <span class="text-xs text-[var(--color-fg-secondary)]">${config.label}</span>
-      ${detail ? html`<span class="max-w-[120px] truncate text-xs text-[var(--color-fg-muted)]">${detail}</span>` : null}
+      ${summary.detailPresent
+        ? html`<span
+            class="min-w-0 max-w-[12rem] truncate text-xs text-[var(--color-fg-muted)]"
+            title=${summary.detail}
+            >${summary.detail}</span
+          >`
+        : null}
     </div>
   `
 }


### PR DESCRIPTION
## Summary

- Export AgentPresence summary types/helpers so dashboard tests and future parent surfaces can read the normalized presence state without scraping rendered text.
- Move presence dots to semantic design-system tokens and expose root `data-presence-*` metadata for raw status, mapped state, label, pulse, size, and detail presence.
- Make presence detail wrapping mobile-safe with max-width truncation and a preserved `title` value for long detail text.

## Why it matters

This is another Kimi/dashboard design-system cleanup slice: AgentPresence now reports the same inspectable summary metadata pattern as the surrounding dashboard components, while keeping the visual badge compact across desktop and mobile states.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/agent-presence.test.ts src/components/common/agent-presence.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` (passes with existing warnings in `copy-id-button.test.ts`, `virtual-list.ts`, and `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic/static import and chunk-size warnings)
- Browser QA via Vite on port 5215 with desktop screenshot `/tmp/masc-agent-presence-summary-0506.png` and mobile screenshot `/tmp/masc-agent-presence-summary-0506-mobile.png`

## Browser QA notes

- Verified five states: online active/detail, working busy/long detail/md, idle, offline, and null/offline.
- DOM proof covered raw status, mapped state, pulse metadata, size metadata, detail presence, semantic token colors, and no desktop/mobile overflow.
- Temporary QA page was removed after inspection; the Vite server on port 5215 was stopped and the port was clear before publish.