### PR TITLE
fix(keeper): observe transition audit append failures

### DIFF
--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -273,11 +273,11 @@ let get_or_create_completed_turn_ring name =
 (* Optional file sink — best-effort jsonl append                    *)
 (* ================================================================ *)
 
-(** Path of the persistent transition log, configured via the
-    [MASC_KEEPER_TRANSITION_LOG] env var. When unset or empty the sink is disabled
-    and only the in-memory ring is updated. Reading the env on each call
-    keeps the surface tiny — one keeper transition per second is the
-    upper bound, so the cost is negligible. *)
+(** Path of the explicit transition log sink, configured via the
+    [MASC_KEEPER_TRANSITION_LOG] env var. When unset or empty, records still
+    fall back to the default dated-jsonl transition-audit store. Reading the
+    env on each call keeps the surface tiny — one keeper transition per
+    second is the upper bound, so the cost is negligible. *)
 let sink_path () =
   match Sys.getenv_opt "MASC_KEEPER_TRANSITION_LOG" with
   | Some path when String.trim path <> "" -> Some path
@@ -312,7 +312,9 @@ let get_default_store () =
 
 let observe_append_failure ~site exn =
   match exn with
-  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Eio.Cancel.Cancelled _ as e ->
+      let bt = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace e bt
   | exn ->
       Prometheus.inc_counter
         Prometheus.metric_keeper_transition_audit_failures

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -274,11 +274,14 @@ let get_or_create_completed_turn_ring name =
 (* ================================================================ *)
 
 (** Path of the persistent transition log, configured via the
-    [MASC_KEEPER_TRANSITION_LOG] env var. When unset the sink is disabled
+    [MASC_KEEPER_TRANSITION_LOG] env var. When unset or empty the sink is disabled
     and only the in-memory ring is updated. Reading the env on each call
     keeps the surface tiny — one keeper transition per second is the
     upper bound, so the cost is negligible. *)
-let sink_path () = Sys.getenv_opt "MASC_KEEPER_TRANSITION_LOG"
+let sink_path () =
+  match Sys.getenv_opt "MASC_KEEPER_TRANSITION_LOG" with
+  | Some path when String.trim path <> "" -> Some path
+  | _ -> None
 
 let default_store_ref : Dated_jsonl.t option ref = ref None
 
@@ -307,30 +310,42 @@ let get_default_store () =
              (Printexc.to_string exn);
            None)
 
+let observe_append_failure ~site exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_transition_audit_failures
+        ~labels:[("site", site)]
+        ();
+      Log.Keeper.warn "transition_audit %s failed: %s"
+        site (Printexc.to_string exn)
+
 (** Append a single jsonl line for the given transition. Wraps the record
     json with the keeper name so a single sink file can mux multiple
-    keepers. Any IO error is swallowed: the in-memory ring is the
-    authoritative trail for live dashboards, the sink is for restart
+    keepers. Any IO error is observed and suppressed: the in-memory ring is
+    the authoritative trail for live dashboards, the sink is for restart
     forensics only. *)
 let append_to_sink ~keeper_name (rec_ : transition_record) =
   match sink_path () with
   | None -> ()
   | Some path ->
-    Safe_ops.protect ~default:() (fun () ->
-       let line =
-         Yojson.Safe.to_string
-           (`Assoc [
-              "keeper", `String keeper_name;
-              "record", to_json rec_;
-            ])
-       in
-       let oc =
-         open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path
-       in
-       Fun.protect
-         ~finally:(fun () ->
-           close_out_noerr oc)
-         (fun () -> output_string oc (line ^ "\n")))
+      try
+        let line =
+          Yojson.Safe.to_string
+            (`Assoc [
+               "keeper", `String keeper_name;
+               "record", to_json rec_;
+             ])
+        in
+        let oc =
+          open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path
+        in
+        Fun.protect
+          ~finally:(fun () ->
+            close_out_noerr oc)
+          (fun () -> output_string oc (line ^ "\n"))
+      with exn -> observe_append_failure ~site:"sink_append" exn
 
 let append_to_default_store ~keeper_name (rec_ : transition_record) =
   match get_default_store () with
@@ -343,8 +358,8 @@ let append_to_default_store ~keeper_name (rec_ : transition_record) =
             "record", to_json rec_;
           ]
       in
-      Safe_ops.protect ~default:() (fun () ->
-          Dated_jsonl.append store json)
+      try Dated_jsonl.append store json
+      with exn -> observe_append_failure ~site:"default_transition_append" exn
 
 let append_completed_turn_to_default_store ~keeper_name
     (rec_ : completed_turn_record) =
@@ -358,8 +373,8 @@ let append_completed_turn_to_default_store ~keeper_name
             "completed_turn", completed_turn_to_json rec_;
           ]
       in
-      Safe_ops.protect ~default:() (fun () ->
-          Dated_jsonl.append store json)
+      try Dated_jsonl.append store json
+      with exn -> observe_append_failure ~site:"default_completed_append" exn
 
 let record_transition ~keeper_name (rec_ : transition_record) =
   let ring = get_or_create_ring keeper_name in
@@ -413,22 +428,23 @@ let record_completed_turn ~keeper_name (rec_ : completed_turn_record) =
   match sink_path () with
   | None -> append_completed_turn_to_default_store ~keeper_name rec_
   | Some path ->
-      Safe_ops.protect ~default:() (fun () ->
-          let line =
-            Yojson.Safe.to_string
-              (`Assoc
-                [
-                  "keeper", `String keeper_name;
-                  "completed_turn", completed_turn_to_json rec_;
-                ])
-          in
-          let oc =
-            open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path
-          in
-          Fun.protect
-            ~finally:(fun () ->
-              close_out_noerr oc)
-            (fun () -> output_string oc (line ^ "\n")))
+      try
+        let line =
+          Yojson.Safe.to_string
+            (`Assoc
+              [
+                "keeper", `String keeper_name;
+                "completed_turn", completed_turn_to_json rec_;
+              ])
+        in
+        let oc =
+          open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path
+        in
+        Fun.protect
+          ~finally:(fun () ->
+            close_out_noerr oc)
+          (fun () -> output_string oc (line ^ "\n"))
+      with exn -> observe_append_failure ~site:"sink_completed_append" exn
 
 let recent_completed_turns_from_store ~keeper_name ~limit =
   match sink_path (), get_default_store () with
@@ -473,4 +489,6 @@ module For_testing = struct
 
   let clear_completed_turn_ring ~keeper_name =
     Hashtbl.remove completed_turn_rings keeper_name
+
+  let observe_append_failure = observe_append_failure
 end

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -57,4 +57,5 @@ val recent_completed_turns :
 module For_testing : sig
   val reset_state : unit -> unit
   val clear_completed_turn_ring : keeper_name:string -> unit
+  val observe_append_failure : site:string -> exn -> unit
 end

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -5,6 +5,7 @@ open Alcotest
 
 module Audit = Masc_mcp.Keeper_transition_audit
 module KSM = Masc_mcp.Keeper_state_machine
+module P = Masc_mcp.Prometheus
 
 let fail = Alcotest.fail
 
@@ -61,6 +62,25 @@ let transition ?(prev_phase = KSM.Running) ?(new_phase = KSM.Paused)
     transition_outcome = "applied";
     wall_clock_at_decision = 1_712_000_000.5;
   }
+
+let transition_audit_failure_count site =
+  P.metric_value_or_zero P.metric_keeper_transition_audit_failures
+    ~labels:[("site", site)]
+    ()
+
+let with_invalid_default_store f =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let base_file = Filename.concat base_dir "not-a-dir" in
+      let oc = open_out base_file in
+      close_out oc;
+      with_env "MASC_KEEPER_TRANSITION_LOG" "" (fun () ->
+          with_env "MASC_BASE_PATH" base_file (fun () ->
+              with_env "MASC_BASE_PATH_INPUT" base_file f)))
 
 (* ── Helpers to exercise the JSON round-trip via store ─────────── *)
 
@@ -192,6 +212,106 @@ let test_runtime_trust_timeline_carries_transition_operator_signal () =
           check string "transition severity" "warn"
             (event |> member "severity" |> to_string)))
 
+let test_default_transition_append_failure_is_observed_and_ring_retained () =
+  Audit.For_testing.reset_state ();
+  with_invalid_default_store (fun () ->
+      let keeper_name = "default-transition-failure-keeper" in
+      let before =
+        transition_audit_failure_count "default_transition_append"
+      in
+      Audit.record_transition ~keeper_name (transition ());
+      let after =
+        transition_audit_failure_count "default_transition_append"
+      in
+      check (float 0.0001) "default transition append failure counted"
+        (before +. 1.0) after;
+      check int "ring still records transition" 1
+        (List.length (Audit.recent_transitions ~keeper_name ~limit:5)))
+
+let test_default_completed_append_failure_is_observed_and_ring_retained () =
+  Audit.For_testing.reset_state ();
+  with_invalid_default_store (fun () ->
+      let keeper_name = "default-completed-failure-keeper" in
+      let before =
+        transition_audit_failure_count "default_completed_append"
+      in
+      Audit.record_completed_turn ~keeper_name
+        {
+          Audit.turn_id = 1;
+          started_at = 1.0;
+          ended_at = 2.0;
+          outcome = Audit.Turn_failed;
+        };
+      let after =
+        transition_audit_failure_count "default_completed_append"
+      in
+      check (float 0.0001) "default completed append failure counted"
+        (before +. 1.0) after;
+      check int "completed turn ring still records turn" 1
+        (List.length
+           (Audit.recent_completed_turns ~keeper_name ~limit:5)))
+
+let test_sink_append_failure_is_observed_and_ring_retained () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let missing_parent = Filename.concat base_dir "missing-parent" in
+      let sink = Filename.concat missing_parent "transition-audit.jsonl" in
+      with_env "MASC_KEEPER_TRANSITION_LOG" sink (fun () ->
+          let keeper_name = "sink-failure-keeper" in
+          let before = transition_audit_failure_count "sink_append" in
+          Audit.record_transition ~keeper_name (transition ());
+          let after = transition_audit_failure_count "sink_append" in
+          check (float 0.0001) "sink append failure counted"
+            (before +. 1.0) after;
+          check int "ring still records transition" 1
+            (List.length
+               (Audit.recent_transitions ~keeper_name ~limit:5))))
+
+let test_completed_turn_sink_failure_is_observed_and_ring_retained () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let missing_parent = Filename.concat base_dir "missing-parent" in
+      let sink = Filename.concat missing_parent "transition-audit.jsonl" in
+      with_env "MASC_KEEPER_TRANSITION_LOG" sink (fun () ->
+          let keeper_name = "completed-sink-failure-keeper" in
+          let before =
+            transition_audit_failure_count "sink_completed_append"
+          in
+          Audit.record_completed_turn ~keeper_name
+            {
+              Audit.turn_id = 1;
+              started_at = 1.0;
+              ended_at = 2.0;
+              outcome = Audit.Turn_failed;
+            };
+          let after =
+            transition_audit_failure_count "sink_completed_append"
+          in
+          check (float 0.0001) "completed sink append failure counted"
+            (before +. 1.0) after;
+          check int "completed turn ring still records turn" 1
+            (List.length
+               (Audit.recent_completed_turns ~keeper_name ~limit:5))))
+
+let test_append_failure_observer_reraises_cancelled () =
+  let raised = ref false in
+  (try
+     Audit.For_testing.observe_append_failure
+       ~site:"unit_cancel"
+       (Eio.Cancel.Cancelled (Failure "synthetic cancel"))
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  check bool "cancel is re-raised" true !raised
+
 (* ── Run ───────────────────────────────────────────────────────── *)
 
 let () =
@@ -213,5 +333,18 @@ let () =
             test_compact_retry_exhausted_signal_is_alerting;
           test_case "runtime trust timeline carries signal" `Quick
             test_runtime_trust_timeline_carries_transition_operator_signal;
+        ] );
+      ( "append_failures",
+        [
+          test_case "default transition append failure observed and ring retained" `Quick
+            test_default_transition_append_failure_is_observed_and_ring_retained;
+          test_case "default completed append failure observed and ring retained" `Quick
+            test_default_completed_append_failure_is_observed_and_ring_retained;
+          test_case "sink append failure observed and ring retained" `Quick
+            test_sink_append_failure_is_observed_and_ring_retained;
+          test_case "completed sink append failure observed and ring retained" `Quick
+            test_completed_turn_sink_failure_is_observed_and_ring_retained;
+          test_case "observer re-raises cancellation" `Quick
+            test_append_failure_observer_reraises_cancelled;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Route transition-audit append failures through a cancel-aware observer instead of silent `Safe_ops.protect` suppression.
- Increment `masc_keeper_transition_audit_failures_total{site=...}` for default transition, default completed-turn, sink transition, and sink completed-turn append failures.
- Preserve the live in-memory rings, re-raise cancellation, and treat an empty `MASC_KEEPER_TRANSITION_LOG` as disabled.

## Why
Durable transition-audit writes are restart-forensics data. When they fail silently, the dashboard can still look healthy from the in-memory ring while restart evidence is incomplete.

## Validation
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only` attempted; blocked by local opam switch `agent_sdk 0.190.12`, expected `>= 0.190.25`
- `env MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_transition_audit.exe`
- `env MASC_TEST_ALLOW_HOME_BASE_PATH=1 MASC_BASE_PATH=/private/tmp/masc-transition-audit-0506-rebased MASC_BASE_PATH_INPUT=/private/tmp/masc-transition-audit-0506-rebased ./_build/default/test/test_keeper_transition_audit.exe test append_failures` passed 5 cases
- Full `test_keeper_transition_audit.exe` attempted; the new append cases passed, then existing `transition_operator_signal 2` failed outside Eio context with `Stdlib.Effect.Unhandled(Eio__core__Cancel.Get_context)` in `Keeper_approval_queue.policy_summary_json`