### PR TITLE
fix(dashboard): expose agent trust summary state

### DIFF
--- a/dashboard/src/components/common/agent-trust.test.ts
+++ b/dashboard/src/components/common/agent-trust.test.ts
@@ -1,9 +1,72 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentTrust } from './agent-trust'
+import {
+  AgentTrust,
+  clampTrustScore,
+  summarizeAgentTrust,
+  trustScoreBand,
+  trustToneConfig,
+} from './agent-trust'
 
 const baseMetrics = { score: 85, approvals: 10, rejections: 2, overrides: 1 }
+
+describe('clampTrustScore', () => {
+  it('rounds and clamps score values', () => {
+    expect(clampTrustScore(84.6)).toBe(85)
+    expect(clampTrustScore(150)).toBe(100)
+    expect(clampTrustScore(-10)).toBe(0)
+  })
+})
+
+describe('trustScoreBand', () => {
+  it('maps score thresholds to high, medium, and low bands', () => {
+    expect(trustScoreBand(80)).toBe('high')
+    expect(trustScoreBand(79)).toBe('medium')
+    expect(trustScoreBand(50)).toBe('medium')
+    expect(trustScoreBand(49)).toBe('low')
+  })
+})
+
+describe('trustToneConfig', () => {
+  it('uses semantic status tokens for each band', () => {
+    expect(trustToneConfig('high').scoreClass).toContain('var(--color-status-ok)')
+    expect(trustToneConfig('medium').barClass).toContain('var(--color-status-warn)')
+    expect(trustToneConfig('low').barTrackClass).toContain('var(--color-status-err)')
+  })
+})
+
+describe('summarizeAgentTrust', () => {
+  it('summarizes clamped score, totals, band, and approval rate label', () => {
+    expect(summarizeAgentTrust(baseMetrics)).toEqual({
+      rawScore: 85,
+      score: 85,
+      band: 'high',
+      approvals: 10,
+      rejections: 2,
+      overrides: 1,
+      total: 13,
+      approvalRate: (10 / 13) * 100,
+      approvalRateLabel: '76.9',
+      hasEvaluations: true,
+    })
+  })
+
+  it('summarizes empty evaluation state', () => {
+    expect(summarizeAgentTrust({ score: 50, approvals: 0, rejections: 0, overrides: 0 })).toEqual({
+      rawScore: 50,
+      score: 50,
+      band: 'medium',
+      approvals: 0,
+      rejections: 0,
+      overrides: 0,
+      total: 0,
+      approvalRate: 0,
+      approvalRateLabel: '0.0',
+      hasEvaluations: false,
+    })
+  })
+})
 
 describe('AgentTrust', () => {
   it('renders container', () => {
@@ -16,6 +79,21 @@ describe('AgentTrust', () => {
     const container = document.createElement('div')
     render(h(AgentTrust, { metrics: baseMetrics }), container)
     expect(container.textContent).toContain('85')
+  })
+
+  it('exposes summary metadata on the root', () => {
+    const container = document.createElement('div')
+    render(h(AgentTrust, { metrics: baseMetrics }), container)
+    const el = container.querySelector('[data-agent-trust]') as HTMLElement
+    expect(el.dataset.trustRawScore).toBe('85')
+    expect(el.dataset.trustScore).toBe('85')
+    expect(el.dataset.trustBand).toBe('high')
+    expect(el.dataset.trustApprovals).toBe('10')
+    expect(el.dataset.trustRejections).toBe('2')
+    expect(el.dataset.trustOverrides).toBe('1')
+    expect(el.dataset.trustTotal).toBe('13')
+    expect(el.dataset.trustApprovalRate).toBe('76.9')
+    expect(el.dataset.trustHasEvaluations).toBe('true')
   })
 
   it('clamps score to 100', () => {
@@ -59,6 +137,8 @@ describe('AgentTrust', () => {
     const container = document.createElement('div')
     render(h(AgentTrust, { metrics: { score: 50, approvals: 0, rejections: 0, overrides: 0 } }), container)
     expect(container.textContent).toContain('0.0')
+    const el = container.querySelector('[data-agent-trust]') as HTMLElement
+    expect(el.dataset.trustHasEvaluations).toBe('false')
   })
 
   it('renders role meter', () => {

--- a/dashboard/src/components/common/agent-trust.ts
+++ b/dashboard/src/components/common/agent-trust.ts
@@ -12,88 +12,146 @@ export interface TrustMetrics {
   overrides: number
 }
 
+export type TrustScoreBand = 'high' | 'medium' | 'low'
+
+export interface TrustToneConfig {
+  scoreClass: string
+  barClass: string
+  barTrackClass: string
+}
+
+export interface AgentTrustSummary {
+  readonly rawScore: number
+  readonly score: number
+  readonly band: TrustScoreBand
+  readonly approvals: number
+  readonly rejections: number
+  readonly overrides: number
+  readonly total: number
+  readonly approvalRate: number
+  readonly approvalRateLabel: string
+  readonly hasEvaluations: boolean
+}
+
 interface AgentTrustProps {
   metrics: TrustMetrics
   testId?: string
 }
 
-function scoreColorClass(score: number): string {
-  if (score >= 80) return 'text-[var(--ok-10)]'
-  if (score >= 50) return 'text-[var(--warn-10)]'
-  return 'text-[var(--error-10)]'
+export function clampTrustScore(score: number): number {
+  return Math.max(0, Math.min(100, Math.round(score)))
 }
 
-function scoreBarBg(score: number): string {
-  if (score >= 80) return 'bg-[var(--ok-10)]'
-  if (score >= 50) return 'bg-[var(--warn-10)]'
-  return 'bg-[var(--error-10)]'
+export function trustScoreBand(score: number): TrustScoreBand {
+  if (score >= 80) return 'high'
+  if (score >= 50) return 'medium'
+  return 'low'
 }
 
-function scoreBarBgMuted(score: number): string {
-  if (score >= 80) return 'bg-[var(--ok-3)]'
-  if (score >= 50) return 'bg-[var(--warn-3)]'
-  return 'bg-[var(--error-3)]'
+const TRUST_TONE_CONFIG: Record<TrustScoreBand, TrustToneConfig> = {
+  high: {
+    scoreClass: 'text-[var(--color-status-ok)]',
+    barClass: 'bg-[var(--color-status-ok)]',
+    barTrackClass: 'bg-[var(--color-status-ok)]/15',
+  },
+  medium: {
+    scoreClass: 'text-[var(--color-status-warn)]',
+    barClass: 'bg-[var(--color-status-warn)]',
+    barTrackClass: 'bg-[var(--color-status-warn)]/15',
+  },
+  low: {
+    scoreClass: 'text-[var(--color-status-err)]',
+    barClass: 'bg-[var(--color-status-err)]',
+    barTrackClass: 'bg-[var(--color-status-err)]/15',
+  },
 }
 
-export function AgentTrust({ metrics, testId }: AgentTrustProps) {
-  const clampedScore = Math.max(0, Math.min(100, Math.round(metrics.score)))
+export function trustToneConfig(band: TrustScoreBand): TrustToneConfig {
+  return TRUST_TONE_CONFIG[band]
+}
+
+export function summarizeAgentTrust(metrics: TrustMetrics): AgentTrustSummary {
+  const score = clampTrustScore(metrics.score)
   const total = metrics.approvals + metrics.rejections + metrics.overrides
   const approvalRate = total > 0 ? (metrics.approvals / total) * 100 : 0
 
-  const scoreClass = scoreColorClass(clampedScore)
-  const barClass = scoreBarBg(clampedScore)
-  const barTrackClass = scoreBarBgMuted(clampedScore)
+  return {
+    rawScore: metrics.score,
+    score,
+    band: trustScoreBand(score),
+    approvals: metrics.approvals,
+    rejections: metrics.rejections,
+    overrides: metrics.overrides,
+    total,
+    approvalRate,
+    approvalRateLabel: approvalRate.toFixed(1),
+    hasEvaluations: total > 0,
+  }
+}
+
+export function AgentTrust({ metrics, testId }: AgentTrustProps) {
+  const summary = summarizeAgentTrust(metrics)
+  const tone = trustToneConfig(summary.band)
 
   return html`
     <div
       class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
       data-agent-trust
+      data-trust-raw-score=${summary.rawScore}
+      data-trust-score=${summary.score}
+      data-trust-band=${summary.band}
+      data-trust-approvals=${summary.approvals}
+      data-trust-rejections=${summary.rejections}
+      data-trust-overrides=${summary.overrides}
+      data-trust-total=${summary.total}
+      data-trust-approval-rate=${summary.approvalRateLabel}
+      data-trust-has-evaluations=${summary.hasEvaluations}
       data-testid=${testId}
     >
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-[var(--color-fg-primary)]">신뢰도 점수</span>
-        <span class="text-lg font-bold ${scoreClass}" aria-label="신뢰도 ${clampedScore}점">
-          ${clampedScore}
+        <span class="text-lg font-bold ${tone.scoreClass}" aria-label="신뢰도 ${summary.score}점">
+          ${summary.score}
         </span>
       </div>
 
       <div
-        class="mb-3 h-2 w-full rounded-full ${barTrackClass}"
+        class="mb-3 h-2 w-full rounded-full ${tone.barTrackClass}"
         role="meter"
         aria-label="신뢰도 점수"
         aria-valuemin="0"
         aria-valuemax="100"
-        aria-valuenow=${clampedScore}
+        aria-valuenow=${summary.score}
       >
         <div
-          class="h-full rounded-full ${barClass} transition-[width] duration-[var(--t-xslow)]"
-          style=${{ width: `${clampedScore}%` }}
+          class="h-full rounded-full ${tone.barClass} transition-[width] duration-[var(--t-xslow)]"
+          style=${{ width: `${summary.score}%` }}
         ></div>
       </div>
 
       <div class="mb-2 grid grid-cols-3 gap-2 text-center">
-        <div class="rounded-[var(--r-1)] bg-[var(--ok-1)] p-1">
-          <div class="text-lg text-[var(--ok-10)]" aria-label="승인 ${metrics.approvals}회">
-            ${metrics.approvals}
+        <div class="min-w-0 rounded-[var(--r-1)] bg-[var(--color-status-ok)]/12 p-1">
+          <div class="text-lg text-[var(--color-status-ok)]" aria-label="승인 ${summary.approvals}회">
+            ${summary.approvals}
           </div>
           <div class="text-3xs text-[var(--color-fg-secondary)]">승인</div>
         </div>
-        <div class="rounded-[var(--r-1)] bg-[var(--error-1)] p-1">
-          <div class="text-lg text-[var(--error-10)]" aria-label="거부 ${metrics.rejections}회">
-            ${metrics.rejections}
+        <div class="min-w-0 rounded-[var(--r-1)] bg-[var(--color-status-err)]/12 p-1">
+          <div class="text-lg text-[var(--color-status-err)]" aria-label="거부 ${summary.rejections}회">
+            ${summary.rejections}
           </div>
           <div class="text-3xs text-[var(--color-fg-secondary)]">거부</div>
         </div>
-        <div class="rounded-[var(--r-1)] bg-[var(--warn-1)] p-1">
-          <div class="text-lg text-[var(--warn-10)]" aria-label="수정 ${metrics.overrides}회">
-            ${metrics.overrides}
+        <div class="min-w-0 rounded-[var(--r-1)] bg-[var(--color-status-warn)]/12 p-1">
+          <div class="text-lg text-[var(--color-status-warn)]" aria-label="수정 ${summary.overrides}회">
+            ${summary.overrides}
           </div>
           <div class="text-3xs text-[var(--color-fg-secondary)]">수정</div>
         </div>
       </div>
 
       <div class="text-3xs text-[var(--color-fg-secondary)]">
-        승인률: ${approvalRate.toFixed(1)}% (${total}회 평가)
+        승인률: ${summary.approvalRateLabel}% (${summary.total}회 평가)
       </div>
     </div>
   `


### PR DESCRIPTION
## Summary

- Export AgentTrust summary helpers for score clamping, trust band selection, tone config, totals, and approval-rate metadata.
- Replace legacy `ok/warn/error` token classes with semantic status tokens for score text, meter fill/track, and approval/rejection/override cells.
- Expose root `data-trust-*` attributes for raw score, clamped score, band, counts, total, approval rate, and empty-evaluation state.

## Why it matters

This continues the Kimi/dashboard design-system cleanup across common agent components. AgentTrust now has the same inspectable summary metadata pattern as adjacent components while keeping the visible compact trust card unchanged for operators.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/agent-trust.test.ts src/components/common/agent-trust.a11y.test.ts` — 25 tests passed
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` (passes with existing warnings in `copy-id-button.test.ts`, `virtual-list.ts`, and `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes with existing Vite dynamic/static import and chunk-size warnings)
- Browser QA via Vite on port 5216 with desktop screenshot `/tmp/masc-agent-trust-summary-0506.png` and mobile screenshot `/tmp/masc-agent-trust-summary-0506-mobile.png`

## Browser QA notes

- Verified five states: high, medium, low, empty, and clamped score.
- DOM proof covered raw/clamped score, trust band, counts, total, approval rate, meter aria value, fill width, semantic computed colors, and no desktop/mobile overflow.
- Browser errors were empty; only Vite connection debug logs were present.
- Temporary QA page and temporary `dashboard/node_modules` symlink were removed before publish; the Vite server on port 5216 was stopped and the port was clear before commit.