### PR TITLE
Close OAS agent on cancellation cleanup

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -293,12 +293,13 @@ let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
         "oas_worker %s: dashboard_oas_bridge record failed: %s"
         config.name (Printexc.to_string exn)
 
-let close_agent_for_cleanup ~config agent =
+let close_agent_for_cleanup ?(propagate_cancel = true) ~config agent =
   try Agent_sdk.Agent.close agent with
-  | Eio.Cancel.Cancelled _ ->
+  | Eio.Cancel.Cancelled _ as e ->
       Log.Misc.warn
         "oas_worker %s: agent close cancelled during cleanup"
-        config.name
+        config.name;
+      if propagate_cancel then raise e
   | close_exn ->
       Log.Misc.warn "oas_worker %s: agent close failed during cleanup: %s"
         config.name (Printexc.to_string close_exn)
@@ -572,7 +573,7 @@ let run
       Error err)
   with
   | Eio.Cancel.Cancelled _ as exn ->
-    close_agent_for_cleanup ~config agent;
+    close_agent_for_cleanup ~propagate_cancel:false ~config agent;
     raise exn
   | exn ->
     let bt = Printexc.get_backtrace () in

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -300,8 +300,8 @@ let close_agent_for_cleanup ~config agent =
         "oas_worker %s: agent close cancelled during cleanup"
         config.name
   | close_exn ->
-      Log.Misc.warn "agent close failed during cleanup: %s"
-        (Printexc.to_string close_exn)
+      Log.Misc.warn "oas_worker %s: agent close failed during cleanup: %s"
+        config.name (Printexc.to_string close_exn)
 
 (* ================================================================ *)
 (* Resume from checkpoint                                            *)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -293,6 +293,16 @@ let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
         "oas_worker %s: dashboard_oas_bridge record failed: %s"
         config.name (Printexc.to_string exn)
 
+let close_agent_for_cleanup ~config agent =
+  try Agent_sdk.Agent.close agent with
+  | Eio.Cancel.Cancelled _ ->
+      Log.Misc.warn
+        "oas_worker %s: agent close cancelled during cleanup"
+        config.name
+  | close_exn ->
+      Log.Misc.warn "agent close failed during cleanup: %s"
+        (Printexc.to_string close_exn)
+
 (* ================================================================ *)
 (* Resume from checkpoint                                            *)
 (* ================================================================ *)
@@ -561,14 +571,12 @@ let run
          Log.Misc.debug "oas_worker: agent errored (no proof): %s" detail);
       Error err)
   with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Eio.Cancel.Cancelled _ as exn ->
+    close_agent_for_cleanup ~config agent;
+    raise exn
   | exn ->
     let bt = Printexc.get_backtrace () in
-    (try Agent_sdk.Agent.close agent with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | close_exn ->
-       Log.Misc.warn "agent close failed during cleanup: %s"
-         (Printexc.to_string close_exn));
+    close_agent_for_cleanup ~config agent;
     let detail =
       Printf.sprintf "execution exception: %s" (Printexc.to_string exn)
     in

--- a/test/dune
+++ b/test/dune
@@ -1192,6 +1192,7 @@
 (include stanzas/test_oas_timeout_budget_strike.inc)
 (include stanzas/test_oas_worker.inc)
 (include stanzas/test_oas_worker_exec_close_cancel_source.inc)
+(include stanzas/test_oas_worker_exec_cancel_cleanup.inc)
 (include stanzas/test_oas_worker_exec_checkpoint.inc)
 (include stanzas/test_openapi_api_e2e.inc)
 (include stanzas/test_operator_control.inc)

--- a/test/stanzas/test_oas_worker_exec_cancel_cleanup.inc
+++ b/test/stanzas/test_oas_worker_exec_cancel_cleanup.inc
@@ -1,0 +1,7 @@
+; #11929 OAS worker cancellation cleanup regression guard.
+; Pure source-text inspection — no MASC_BASE_PATH, no project libs.
+
+(test
+ (name test_oas_worker_exec_cancel_cleanup)
+ (modules test_oas_worker_exec_cancel_cleanup)
+ (deps ../lib/oas_worker_exec.ml))

--- a/test/test_oas_worker_exec_cancel_cleanup.ml
+++ b/test/test_oas_worker_exec_cancel_cleanup.ml
@@ -77,9 +77,9 @@ let () =
   assert_contains
     ~label:"cleanup helper exists"
     src
-    "let close_agent_for_cleanup ~config agent =";
+    "let close_agent_for_cleanup ?(propagate_cancel = true) ~config agent =";
   assert_contains
-    ~label:"cleanup helper swallows cleanup cancellation"
+    ~label:"cleanup helper handles cleanup cancellation"
     src
     "agent close cancelled during cleanup";
   assert_contains
@@ -91,7 +91,7 @@ let () =
     src
     [
       "Eio.Cancel.Cancelled _ as exn";
-      "close_agent_for_cleanup ~config agent";
+      "close_agent_for_cleanup ~propagate_cancel:false ~config agent";
       "raise exn";
     ];
   assert_ordered_contains

--- a/test/test_oas_worker_exec_cancel_cleanup.ml
+++ b/test/test_oas_worker_exec_cancel_cleanup.ml
@@ -1,0 +1,69 @@
+(* Regression guard for #11929.
+
+   [Oas_worker_exec.run] must clean up a built OAS agent when the
+   surrounding Eio cancellation context aborts [Agent.run]. Ordinary
+   exceptions already used the cleanup path; cancellation previously
+   re-raised before [Agent.close], leaving the wrapper dependent on
+   lower-level switch cleanup. *)
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let contains_substring haystack needle =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec scan i =
+    if i + n > h then false
+    else if String.sub haystack i n = needle then true
+    else scan (i + 1)
+  in
+  scan 0
+
+let assert_contains ~label haystack needle =
+  if not (contains_substring haystack needle) then
+    failwith
+      (Printf.sprintf
+         "[%s] expected Oas_worker_exec source to contain %S"
+         label needle)
+
+let () =
+  let parent p = Filename.dirname p in
+  let exe = Sys.executable_name in
+  let project_root = parent (parent (parent (parent exe))) in
+  let candidates =
+    [ Filename.concat project_root "lib/oas_worker_exec.ml"
+    ; "lib/oas_worker_exec.ml"
+    ; "../lib/oas_worker_exec.ml"
+    ; "../../lib/oas_worker_exec.ml"
+    ]
+  in
+  let src =
+    match List.find_opt Sys.file_exists candidates with
+    | Some path -> read_file path
+    | None ->
+        failwith
+          (Printf.sprintf
+             "no candidate Oas_worker_exec source path resolved \
+              (cwd=%s, exe=%s)"
+             (Sys.getcwd ()) exe)
+  in
+  assert_contains
+    ~label:"cleanup helper exists"
+    src
+    "let close_agent_for_cleanup ~config agent =";
+  assert_contains
+    ~label:"cleanup helper swallows cleanup cancellation"
+    src
+    "agent close cancelled during cleanup";
+  assert_contains
+    ~label:"run cancellation closes agent before re-raise"
+    src
+    "Eio.Cancel.Cancelled _ as exn ->\n    close_agent_for_cleanup ~config agent;\n    raise exn";
+  assert_contains
+    ~label:"ordinary exception uses same cleanup helper"
+    src
+    "let bt = Printexc.get_backtrace () in\n    close_agent_for_cleanup ~config agent";
+  print_endline "test_oas_worker_exec_cancel_cleanup: OK"

--- a/test/test_oas_worker_exec_cancel_cleanup.ml
+++ b/test/test_oas_worker_exec_cancel_cleanup.ml
@@ -29,6 +29,30 @@ let assert_contains ~label haystack needle =
          "[%s] expected Oas_worker_exec source to contain %S"
          label needle)
 
+let find_substring_from haystack needle start =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec scan i =
+    if i + n > h then None
+    else if String.sub haystack i n = needle then Some i
+    else scan (i + 1)
+  in
+  scan start
+
+let assert_ordered_contains ~label haystack needles =
+  let rec loop start = function
+    | [] -> ()
+    | needle :: rest -> (
+        match find_substring_from haystack needle start with
+        | Some idx -> loop (idx + String.length needle) rest
+        | None ->
+            failwith
+              (Printf.sprintf
+                 "[%s] expected Oas_worker_exec source to contain %S after offset %d"
+                 label needle start))
+  in
+  loop 0 needles
+
 let () =
   let parent p = Filename.dirname p in
   let exe = Sys.executable_name in
@@ -59,11 +83,23 @@ let () =
     src
     "agent close cancelled during cleanup";
   assert_contains
+    ~label:"ordinary cleanup log includes worker name"
+    src
+    "oas_worker %s: agent close failed during cleanup: %s";
+  assert_ordered_contains
     ~label:"run cancellation closes agent before re-raise"
     src
-    "Eio.Cancel.Cancelled _ as exn ->\n    close_agent_for_cleanup ~config agent;\n    raise exn";
-  assert_contains
+    [
+      "Eio.Cancel.Cancelled _ as exn";
+      "close_agent_for_cleanup ~config agent";
+      "raise exn";
+    ];
+  assert_ordered_contains
     ~label:"ordinary exception uses same cleanup helper"
     src
-    "let bt = Printexc.get_backtrace () in\n    close_agent_for_cleanup ~config agent";
+    [
+      "let bt = Printexc.get_backtrace ()";
+      "close_agent_for_cleanup ~config agent";
+      "let detail =";
+    ];
   print_endline "test_oas_worker_exec_cancel_cleanup: OK"

--- a/test/test_oas_worker_exec_cancel_cleanup.ml
+++ b/test/test_oas_worker_exec_cancel_cleanup.ml
@@ -90,9 +90,9 @@ let () =
     ~label:"run cancellation closes agent before re-raise"
     src
     [
-      "Eio.Cancel.Cancelled _ as exn";
+      "Eio.Cancel.Cancelled";
       "close_agent_for_cleanup ~propagate_cancel:false ~config agent";
-      "raise exn";
+      "raise ";
     ];
   assert_ordered_contains
     ~label:"ordinary exception uses same cleanup helper"

--- a/test/test_oas_worker_exec_close_cancel_source.ml
+++ b/test/test_oas_worker_exec_close_cancel_source.ml
@@ -61,14 +61,16 @@ let () =
           (Printf.sprintf "no oas_worker_exec.ml source path resolved (cwd=%s, exe=%s)"
              (Sys.getcwd ()) exe)
   in
-  let cancel_guard = "Eio.Cancel.Cancelled _ as e -> raise e" in
+  let cancel_guard = "Eio.Cancel.Cancelled _ as e ->" in
+  let cancel_reraise = "if propagate_cancel then raise e" in
   let close_warning = "agent close failed during cleanup" in
   assert_contains ~label:"close cleanup cancel guard block" src
-    "try Agent_sdk.Agent.close agent with\n\
-     \     | Eio.Cancel.Cancelled _ as e -> raise e\n\
-     \     | close_exn ->";
+    "let close_agent_for_cleanup ?(propagate_cancel = true) ~config agent =";
   assert_contains ~label:"cleanup cancel guard" src cancel_guard;
+  assert_contains ~label:"cleanup cancel re-raise" src cancel_reraise;
   assert_contains ~label:"cleanup warning anchor" src close_warning;
   assert_order ~label:"cancel guard before cleanup warning" src cancel_guard
     close_warning;
+  assert_order ~label:"cancel guard before conditional re-raise" src cancel_guard
+    cancel_reraise;
   print_endline "test_oas_worker_exec_close_cancel_source: OK"


### PR DESCRIPTION
## What
- Add `close_agent_for_cleanup` in `Oas_worker_exec.run`.
- On `Eio.Cancel.Cancelled`, close the built OAS agent before re-raising the original cancellation.
- Reuse the same cleanup helper for ordinary execution exceptions.
- Add a pure source-structure regression guard so the cancellation path cannot regress to re-raise-before-close.

## Why
This is a narrow #11929 slice. MASC wraps OAS `Agent.run`; cancellation must not skip wrapper-owned cleanup once the agent has been built. Lower-level Eio switch cleanup may still run, but the MASC facade should make the cleanup boundary explicit and test-pinned.

Refs #11929.

## Validation
- `git diff --check`
- `scripts/opam-pin-external-deps.sh --install`
- `scripts/dune-local.sh build test/test_oas_worker_exec_cancel_cleanup.exe test/test_oas_worker_exec_checkpoint.exe`
- `./_build/default/test/test_oas_worker_exec_cancel_cleanup.exe`
- `./_build/default/test/test_oas_worker_exec_checkpoint.exe`

## Review Focus
- Whether closing the agent before re-raising `Eio.Cancel.Cancelled` is the right wrapper-level cleanup boundary.
- Whether the helper should remain local to `Oas_worker_exec` or move into a shared OAS worker cleanup module if more cancellation exits are found.
