### PR TITLE
fix(process): observe bg task sidecar failures

### DIFF
--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -396,19 +396,28 @@ let read_pid_file path =
   try
     let ic = open_in path in
     Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-      match int_of_string_opt (String.trim (input_line ic)),
-            int_of_string_opt (String.trim (input_line ic))
-      with
+      let input_line_opt ic =
+        try Some (input_line ic) with End_of_file -> None
+      in
+      let pid_line = input_line_opt ic in
+      let pgid_line = input_line_opt ic in
+      let parse_int line =
+        line |> Option.map String.trim |> Option.bind int_of_string_opt
+      in
+      match parse_int pid_line, parse_int pgid_line with
       | Some pid, Some pgid -> Some (pid, pgid)
       | _ ->
           observe_sidecar_failure ~site:"read_parse"
-            (Failure "invalid PID sidecar");
+            (Failure (Printf.sprintf "invalid PID sidecar: %s" path));
           None)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       if Sys.file_exists path then
-        observe_sidecar_failure ~site:"read" exn;
+        observe_sidecar_failure ~site:"read"
+          (Failure
+             (Printf.sprintf "read PID sidecar %s: %s" path
+                (Printexc.to_string exn)));
       None
 
 let pid_is_live pid =

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -85,6 +85,28 @@ let bg_dir_of ~base_path ~keeper =
 let pid_file_of ~base_path ~keeper ~task_id =
   Filename.concat (bg_dir_of ~base_path ~keeper) (task_id ^ ".pid")
 
+let sidecar_failure_observer :
+    ((site:string -> exn -> unit) option) Atomic.t =
+  Atomic.make None
+
+let set_sidecar_failure_observer f =
+  Atomic.set sidecar_failure_observer (Some f)
+
+let observe_sidecar_failure ~site exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Misc.warn "bg_task PID sidecar %s failed: %s"
+        site (Printexc.to_string exn);
+      (match Atomic.get sidecar_failure_observer with
+       | None -> ()
+       | Some observe ->
+           (try observe ~site exn with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | observer_exn ->
+                Log.Misc.warn "bg_task PID sidecar observer failed: %s"
+                  (Printexc.to_string observer_exn)))
+
 let rec ensure_dir path =
   if Sys.file_exists path then ()
   else begin
@@ -95,15 +117,29 @@ let rec ensure_dir path =
   end
 
 let try_write_pid_file path ~pid ~pgid ~started_at =
-  Safe_ops.protect ~default:() (fun () ->
+  try
     ensure_dir (Filename.dirname path);
     let oc = open_out_gen [ Open_wronly; Open_creat; Open_trunc ] 0o644 path in
-    Printf.fprintf oc "%d\n%d\n%f\n" pid pgid started_at;
-    close_out_noerr oc)
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () ->
+        Printf.fprintf oc "%d\n%d\n%f\n" pid pgid started_at;
+        flush oc)
+  with exn -> observe_sidecar_failure ~site:"write" exn
+
+let delete_pid_file path =
+  try
+    Unix.unlink path;
+    true
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> false
+  | exn ->
+      observe_sidecar_failure ~site:"unlink" exn;
+      false
 
 let try_delete_pid_file = function
   | None -> ()
-  | Some path -> Safe_ops.protect ~default:() (fun () -> Unix.unlink path)
+  | Some path -> ignore (delete_pid_file path : bool)
 
 let registry : (string, state) Hashtbl.t = Hashtbl.create 16
 let registry_mu = Mutex.create ()
@@ -342,19 +378,38 @@ let list_with_started_at ~keeper =
 (* Directory walk helpers — avoid Filename.Infix / extra deps. *)
 
 let safe_readdir dir =
-  Safe_ops.protect ~default:[] (fun () -> Array.to_list (Sys.readdir dir))
+  try Array.to_list (Sys.readdir dir) with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      if Sys.file_exists dir then
+        observe_sidecar_failure ~site:"readdir" exn;
+      []
 
-let is_dir p = Safe_ops.protect ~default:false (fun () -> Sys.is_directory p)
+let is_dir p =
+  try (Unix.stat p).Unix.st_kind = Unix.S_DIR with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> false
+  | exn ->
+      observe_sidecar_failure ~site:"is_dir" exn;
+      false
 
 let read_pid_file path =
-  Safe_ops.protect ~default:None (fun () ->
+  try
     let ic = open_in path in
     Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
       match int_of_string_opt (String.trim (input_line ic)),
             int_of_string_opt (String.trim (input_line ic))
       with
       | Some pid, Some pgid -> Some (pid, pgid)
-      | _ -> None))
+      | _ ->
+          observe_sidecar_failure ~site:"read_parse"
+            (Failure "invalid PID sidecar");
+          None)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      if Sys.file_exists path then
+        observe_sidecar_failure ~site:"read" exn;
+      None
 
 let pid_is_live pid =
   try Unix.kill pid 0; true
@@ -401,8 +456,8 @@ let reap_orphans ~base_path =
                      Process_eio.tree_kill ~pgid
                        ~signal:Sys.sigterm ~grace_sec:1.0
                  | None | Some (_, _) -> ());
-                Safe_ops.protect ~default:() (fun () -> Unix.unlink path);
-                incr reaped
+                if delete_pid_file path then
+                  incr reaped
               end
             end)
             (safe_readdir bg_dir))

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -122,6 +122,12 @@ val list_with_started_at : keeper:string -> (task_id * float) list
     wall-clock elapsed time without consulting the child process or
     reading the PID file. *)
 
+val set_sidecar_failure_observer : (site:string -> exn -> unit) -> unit
+(** Install the process-local observer for PID sidecar persistence
+    failures.  The top-level Prometheus module wires this to
+    [masc_bg_task_sidecar_failures_total]; [bg_task] keeps the hook here
+    to avoid a lower-library dependency cycle. *)
+
 val reap_orphans : base_path:string -> int
 (** Startup hook: read PID files under \`.masc/keeper/*/bg/*.pid\`,
     SIGKILL any pgroup whose leader is no longer in the live task

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1051,6 +1051,8 @@ let metric_oas_bus_publish = "masc_oas_bus_publish_total"
 let metric_runtime_ollama_probe_generate_skips =
   "masc_runtime_ollama_probe_generate_skips_total"
 let metric_process_timeout = "masc_process_timeout_total"
+let metric_bg_task_sidecar_failures =
+  "masc_bg_task_sidecar_failures_total"
 let metric_distributed_lock_acquire_failed =
   "masc_distributed_lock_acquire_failed_total"
 
@@ -2044,6 +2046,14 @@ let init () =
     "Total subprocess executions that exceeded their configured timeout. \
      Labeled by program and timeout_sec."
     Counter;
+  add metric_bg_task_sidecar_failures
+    "Total background-task PID sidecar persistence failures. \
+     Labeled by site=write|read|read_parse|readdir|is_dir|unlink."
+    Counter;
+  Bg_task.set_sidecar_failure_observer (fun ~site _exn ->
+      inc_counter metric_bg_task_sidecar_failures
+        ~labels:[("site", site)]
+        ());
   add metric_distributed_lock_acquire_failed
     "Total distributed lock acquire exhaustions. Labeled by key and attempts. \
      A non-zero rate indicates lock contention exhausted the retry budget."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -695,6 +695,11 @@ val metric_runtime_ollama_probe_generate_skips : string
 val metric_process_timeout : string
 (** #9632: subprocess executions that exceeded their configured
     timeout. Labels: [program, timeout_sec]. *)
+
+val metric_bg_task_sidecar_failures : string
+(** Background-task PID sidecar persistence failures. Labels:
+    [site] = [write | read | read_parse | readdir | is_dir | unlink]. *)
+
 val metric_distributed_lock_acquire_failed : string
 (** #9645: distributed lock acquire retry-budget exhaustions.
     Labels: [key, attempts]. *)

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -6,6 +6,20 @@
 
 open Alcotest
 
+let sidecar_observer_counts : (string, float) Hashtbl.t = Hashtbl.create 8
+
+let () =
+  Bg_task.set_sidecar_failure_observer (fun ~site _exn ->
+      let current =
+        Hashtbl.find_opt sidecar_observer_counts site
+        |> Option.value ~default:0.0
+      in
+      Hashtbl.replace sidecar_observer_counts site (current +. 1.0))
+
+let bg_sidecar_failure_count site =
+  Hashtbl.find_opt sidecar_observer_counts site
+  |> Option.value ~default:0.0
+
 let wait_until ~timeout_s f =
   let deadline = Unix.gettimeofday () +. timeout_s in
   let rec loop () =
@@ -16,6 +30,32 @@ let wait_until ~timeout_s f =
   loop ()
 
 let env_of_current () = Unix.environment ()
+
+let rec mkdir_p p =
+  if Sys.file_exists p then ()
+  else begin
+    let parent = Filename.dirname p in
+    if parent <> p then mkdir_p parent;
+    try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+  end
+
+let rec rm_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Array.iter (fun e -> rm_tree (Filename.concat path e)) (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
+let with_temp_base prefix f =
+  let base = Filename.temp_file prefix "" in
+  Unix.unlink base;
+  Unix.mkdir base 0o755;
+  Fun.protect ~finally:(fun () -> try rm_tree base with _ -> ()) (fun () ->
+      f base)
+
+let bg_dir_for ~base ~keeper =
+  Filename.concat base (Printf.sprintf ".masc/keeper/%s/bg" keeper)
 
 let with_ring_line_limit raw f =
   let previous = Sys.getenv_opt "MASC_KEEPER_SHELL_RING_LINES" in
@@ -293,6 +333,66 @@ let test_reap_orphans_removes_stale_file () =
       check bool "reaped at least one" true (n >= 1);
       check bool "stale file removed" false (Sys.file_exists stale))
 
+let test_pid_file_write_failure_observed () =
+  let base_file = Filename.temp_file "bg_task_pid_write_fail" "" in
+  Fun.protect
+    ~finally:(fun () -> try Unix.unlink base_file with _ -> ())
+    (fun () ->
+      let before = bg_sidecar_failure_count "write" in
+      let tid =
+        match
+          Bg_task.spawn ~base_path:base_file ~keeper:"kp-pid-write-fail"
+            ~argv:[ "/bin/sleep"; "1" ]
+            ~cwd:"" ~envp:(env_of_current ()) ~timeout_sec:0.0 ()
+        with
+        | Ok t -> t
+        | Error _ -> failwith "spawn failed"
+      in
+      let after = bg_sidecar_failure_count "write" in
+      check (float 0.0001) "write failure counted"
+        (before +. 1.0) after;
+      ignore (Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:0.2);
+      ignore (poll_for_closed tid))
+
+let test_reap_orphans_observes_malformed_pid_file () =
+  with_temp_base "bg_task_reap_parse" (fun base ->
+      let keeper = "kp-reap-parse" in
+      let bg_dir = bg_dir_for ~base ~keeper in
+      mkdir_p bg_dir;
+      let stale = Filename.concat bg_dir "bad-pid.pid" in
+      let oc = open_out stale in
+      output_string oc "not-a-pid\nnot-a-pgid\n0.0\n";
+      close_out oc;
+      let before = bg_sidecar_failure_count "read_parse" in
+      let n = Bg_task.reap_orphans ~base_path:base in
+      let after = bg_sidecar_failure_count "read_parse" in
+      check (float 0.0001) "read parse failure counted"
+        (before +. 1.0) after;
+      check int "malformed sidecar removed" 1 n;
+      check bool "malformed pid file gone" false (Sys.file_exists stale))
+
+let test_reap_orphans_observes_unlink_failure () =
+  with_temp_base "bg_task_reap_unlink" (fun base ->
+      let keeper = "kp-reap-unlink" in
+      let bg_dir = bg_dir_for ~base ~keeper in
+      mkdir_p bg_dir;
+      let stale = Filename.concat bg_dir "stuck-pid.pid" in
+      let oc = open_out stale in
+      output_string oc "999999\n999999\n0.0\n";
+      close_out oc;
+      Fun.protect
+        ~finally:(fun () -> try Unix.chmod bg_dir 0o755 with _ -> ())
+        (fun () ->
+          Unix.chmod bg_dir 0o555;
+          let before = bg_sidecar_failure_count "unlink" in
+          let n = Bg_task.reap_orphans ~base_path:base in
+          let after = bg_sidecar_failure_count "unlink" in
+          check (float 0.0001) "unlink failure counted"
+            (before +. 1.0) after;
+          check int "failed unlink not counted as removed" 0 n;
+          check bool "pid file retained after failed unlink" true
+            (Sys.file_exists stale)))
+
 let () =
   run "bg_task"
     [
@@ -319,6 +419,12 @@ let () =
             test_pid_file_created_and_cleaned;
           test_case "reap_orphans removes stale pid file" `Quick
             test_reap_orphans_removes_stale_file;
+          test_case "pid file write failure is observed" `Quick
+            test_pid_file_write_failure_observed;
+          test_case "malformed pid sidecar is observed" `Quick
+            test_reap_orphans_observes_malformed_pid_file;
+          test_case "pid sidecar unlink failure is observed" `Quick
+            test_reap_orphans_observes_unlink_failure;
         ] );
       ( "lifecycle",
         [

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -7,18 +7,24 @@
 open Alcotest
 
 let sidecar_observer_counts : (string, float) Hashtbl.t = Hashtbl.create 8
+let sidecar_observer_messages : (string, string) Hashtbl.t = Hashtbl.create 8
 
 let () =
-  Bg_task.set_sidecar_failure_observer (fun ~site _exn ->
+  Bg_task.set_sidecar_failure_observer (fun ~site exn ->
       let current =
         Hashtbl.find_opt sidecar_observer_counts site
         |> Option.value ~default:0.0
       in
-      Hashtbl.replace sidecar_observer_counts site (current +. 1.0))
+      Hashtbl.replace sidecar_observer_counts site (current +. 1.0);
+      Hashtbl.replace sidecar_observer_messages site (Printexc.to_string exn))
 
 let bg_sidecar_failure_count site =
   Hashtbl.find_opt sidecar_observer_counts site
   |> Option.value ~default:0.0
+
+let bg_sidecar_failure_message site =
+  Hashtbl.find_opt sidecar_observer_messages site
+  |> Option.value ~default:""
 
 let wait_until ~timeout_s f =
   let deadline = Unix.gettimeofday () +. timeout_s in
@@ -55,7 +61,11 @@ let with_temp_base prefix f =
       f base)
 
 let bg_dir_for ~base ~keeper =
-  Filename.concat base (Printf.sprintf ".masc/keeper/%s/bg" keeper)
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:base)
+       (Filename.concat "keeper" keeper))
+    "bg"
 
 let with_ring_line_limit raw f =
   let previous = Sys.getenv_opt "MASC_KEEPER_SHELL_RING_LINES" in
@@ -368,8 +378,33 @@ let test_reap_orphans_observes_malformed_pid_file () =
       let after = bg_sidecar_failure_count "read_parse" in
       check (float 0.0001) "read parse failure counted"
         (before +. 1.0) after;
+      check bool "read parse message includes path" true
+        (String_util.contains_substring
+           (bg_sidecar_failure_message "read_parse")
+           stale);
       check int "malformed sidecar removed" 1 n;
       check bool "malformed pid file gone" false (Sys.file_exists stale))
+
+let test_reap_orphans_observes_truncated_pid_file_as_parse () =
+  with_temp_base "bg_task_reap_truncated" (fun base ->
+      let keeper = "kp-reap-truncated" in
+      let bg_dir = bg_dir_for ~base ~keeper in
+      mkdir_p bg_dir;
+      let stale = Filename.concat bg_dir "truncated-pid.pid" in
+      let oc = open_out stale in
+      output_string oc "999999\n";
+      close_out oc;
+      let before = bg_sidecar_failure_count "read_parse" in
+      let n = Bg_task.reap_orphans ~base_path:base in
+      let after = bg_sidecar_failure_count "read_parse" in
+      check (float 0.0001) "truncated parse failure counted"
+        (before +. 1.0) after;
+      check bool "truncated parse message includes path" true
+        (String_util.contains_substring
+           (bg_sidecar_failure_message "read_parse")
+           stale);
+      check int "truncated sidecar removed" 1 n;
+      check bool "truncated pid file gone" false (Sys.file_exists stale))
 
 let test_reap_orphans_observes_unlink_failure () =
   with_temp_base "bg_task_reap_unlink" (fun base ->
@@ -423,6 +458,8 @@ let () =
             test_pid_file_write_failure_observed;
           test_case "malformed pid sidecar is observed" `Quick
             test_reap_orphans_observes_malformed_pid_file;
+          test_case "truncated pid sidecar is a parse failure" `Quick
+            test_reap_orphans_observes_truncated_pid_file_as_parse;
           test_case "pid sidecar unlink failure is observed" `Quick
             test_reap_orphans_observes_unlink_failure;
         ] );

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -287,6 +287,15 @@ let test_distributed_lock_metric_registered () =
        ("# TYPE " ^ Prometheus.metric_distributed_lock_acquire_failed
         ^ " counter"))
 
+let test_bg_task_sidecar_metric_registered () =
+  let text = Prometheus.to_prometheus_text () in
+  check bool "has bg task sidecar HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_bg_task_sidecar_failures ^ " "));
+  check bool "has bg task sidecar TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_bg_task_sidecar_failures ^ " counter"))
+
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
   Prometheus.register_histogram ~name ~help:"export format test" ();
@@ -460,6 +469,8 @@ let () =
         test_review_blocker_metrics_registered;
       test_case "distributed lock metric registered" `Quick
         test_distributed_lock_metric_registered;
+      test_case "bg task sidecar metric registered" `Quick
+        test_bg_task_sidecar_metric_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
     ];


### PR DESCRIPTION
## Summary
- Replace silent PID sidecar `Safe_ops.protect` paths in `Bg_task` with cancel-aware observation for write, read, parse, readdir/is_dir, and unlink failures.
- Add the bounded Prometheus counter `masc_bg_task_sidecar_failures_total{site=...}` through a lower-library observer hook to avoid a `masc_process` -> `masc_mcp` dependency cycle.
- Keep background task spawn/reap best-effort behavior, while no longer counting a stale sidecar as removed when unlink fails.

## Why
PID sidecars are the restart recovery trail for background shell tasks. If writes, reads, or cleanup fail silently, orphan recovery and operator forensics can drift while the live in-memory task registry still appears normal.

## Validation
- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_bg_task_stub.exe test/test_prometheus_coverage.exe lib/exec/test/test_exec_run.exe`
- `./_build/default/test/test_bg_task_stub.exe` passed 17 tests
- `./_build/default/test/test_prometheus_coverage.exe test to_prometheus_text` passed 11 tests
- `./_build/default/lib/exec/test/test_exec_run.exe` passed 3 tests