### PR TITLE
fix(keeper): preserve local recovery fallback rotation

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -285,7 +285,10 @@ let deprecated_logical_profile_names =
     "keeper_unified";
     "phase_recovery";
     "phase_buffer";
-    "local_recovery";
+    (* [local_recovery] is intentionally not listed here. Operators can
+       declare it as a concrete fallback_cascade profile, and the loader must
+       keep that profile visible so fallback chains do not collapse back into
+       routes.phase_recovery. *)
     "local_only";
     "tool_required";
     "tool_use_strict";

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -291,10 +291,10 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some "auth_error"
          | _ -> None)
 
-let normalized_cascade_name name =
+let normalized_cascade_name ~catalog_names name =
   let trimmed = String.trim name in
   let is_live_catalog_profile =
-    List.exists (String.equal trimmed) (Keeper_cascade_profile.catalog_names ())
+    List.exists (String.equal trimmed) catalog_names
   in
   (* Fallback candidates are concrete catalog profiles, not keeper-declared
      logical routes.  Preserve live profile names like [local_recovery] so a
@@ -307,8 +307,8 @@ let normalized_cascade_name name =
   then trimmed
   else Keeper_cascade_profile.normalize_declared_name trimmed
 
-let required_tool_rotation_candidate name =
-  let normalized = normalized_cascade_name name in
+let required_tool_rotation_candidate ~catalog_names name =
+  let normalized = normalized_cascade_name ~catalog_names name in
   let routed_local_only_is_distinct =
     not
       (String.equal
@@ -323,39 +323,46 @@ let required_tool_rotation_candidate name =
       && String.equal normalized Keeper_config.local_only_cascade_name))
 
 let legacy_degraded_rotation_candidates
+    ~catalog_names
     ~(base_cascade : string)
     ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement) =
-  let normalized_base = normalized_cascade_name base_cascade in
+  let normalized_base = normalized_cascade_name ~catalog_names base_cascade in
   let default_cascade =
-    normalized_cascade_name Keeper_config.default_cascade_name
+    normalized_cascade_name ~catalog_names Keeper_config.default_cascade_name
   in
   let local_recovery_cascade =
-    normalized_cascade_name Keeper_config.local_recovery_cascade_name
+    normalized_cascade_name ~catalog_names
+      Keeper_config.local_recovery_cascade_name
   in
   match tool_requirement with
   | Required -> [ normalized_base; default_cascade ]
   | Optional | No_tools ->
     [ normalized_base; default_cascade; local_recovery_cascade ]
 
-let normalize_rotation_candidates candidates =
+let normalize_rotation_candidates ~catalog_names candidates =
   candidates
   |> List.filter_map (fun candidate ->
          let trimmed = String.trim candidate in
-         if String.equal trimmed "" then None else Some (normalized_cascade_name trimmed))
+         if String.equal trimmed "" then None
+         else Some (normalized_cascade_name ~catalog_names trimmed))
   |> dedupe_keep_order
 
 let degraded_rotation_candidates
+    ~catalog_names
     ~(rotation_cascades : string list option)
     ~(fallback_hint : string option)
     ~(base_cascade : string)
     ~(effective_cascade : string)
     ~(tool_requirement : Keeper_agent_tool_surface.tool_requirement) =
-  let normalized_effective = normalized_cascade_name effective_cascade in
+  let normalized_effective =
+    normalized_cascade_name ~catalog_names effective_cascade
+  in
   let raw_candidates =
     match rotation_cascades with
     | None ->
-        legacy_degraded_rotation_candidates ~base_cascade ~tool_requirement
-    | Some catalog -> normalize_rotation_candidates catalog
+        legacy_degraded_rotation_candidates ~catalog_names ~base_cascade
+          ~tool_requirement
+    | Some catalog -> normalize_rotation_candidates ~catalog_names catalog
   in
   let candidates =
     match fallback_hint with
@@ -364,13 +371,13 @@ let degraded_rotation_candidates
         let trimmed = String.trim hint in
         if String.equal trimmed "" then raw_candidates
         else
-          normalize_rotation_candidates (trimmed :: raw_candidates)
+          normalize_rotation_candidates ~catalog_names (trimmed :: raw_candidates)
   in
   candidates
   |> List.filter (fun candidate ->
          (not (String.equal candidate normalized_effective))
          && (tool_requirement <> Required
-             || required_tool_rotation_candidate candidate))
+             || required_tool_rotation_candidate ~catalog_names candidate))
 
 let degraded_rotation_after_recoverable_error
     ?rotation_cascades
@@ -383,12 +390,14 @@ let degraded_rotation_after_recoverable_error
   match recoverable_cascade_failure_reason err with
   | None -> None
   | Some fallback_reason ->
+      let catalog_names = Keeper_cascade_profile.catalog_names () in
       let attempted =
         attempted_cascades
-        |> List.map normalized_cascade_name
+        |> List.map (normalized_cascade_name ~catalog_names)
         |> dedupe_keep_order
       in
       degraded_rotation_candidates
+        ~catalog_names
         ~rotation_cascades
         ~fallback_hint
         ~base_cascade ~effective_cascade ~tool_requirement

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -293,8 +293,15 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
 
 let normalized_cascade_name name =
   let trimmed = String.trim name in
+  let is_live_catalog_profile =
+    List.exists (String.equal trimmed) (Keeper_cascade_profile.catalog_names ())
+  in
+  (* Fallback candidates are concrete catalog profiles, not keeper-declared
+     logical routes.  Preserve live profile names like [local_recovery] so a
+     fallback_cascade does not collapse back to routes.phase_recovery. *)
   if
-    String.equal trimmed Keeper_config.local_only_cascade_name
+    is_live_catalog_profile
+    || String.equal trimmed Keeper_config.local_only_cascade_name
     || String.equal trimmed Keeper_config.local_recovery_cascade_name
     || String.equal trimmed Keeper_config.tool_use_strict_cascade_name
   then trimmed
@@ -302,19 +309,18 @@ let normalized_cascade_name name =
 
 let required_tool_rotation_candidate name =
   let normalized = normalized_cascade_name name in
-  let default_cascade = Keeper_config.default_cascade_name in
   let routed_local_only_is_distinct =
-    not (String.equal Keeper_config.local_only_cascade_name default_cascade)
-  in
-  let routed_local_recovery_is_distinct =
     not
-      (String.equal Keeper_config.local_recovery_cascade_name default_cascade)
+      (String.equal
+         Keeper_config.local_only_cascade_name
+         Keeper_config.default_cascade_name)
   in
+  (* Required-tool turns may still use [local_recovery] when the catalog
+     declares it as a tool-capable fallback profile; only the buffer/local-only
+     lane is filtered here. *)
   not
     ((routed_local_only_is_distinct
-      && String.equal normalized Keeper_config.local_only_cascade_name)
-     || (routed_local_recovery_is_distinct
-         && String.equal normalized Keeper_config.local_recovery_cascade_name))
+      && String.equal normalized Keeper_config.local_only_cascade_name))
 
 let legacy_degraded_rotation_candidates
     ~(base_cascade : string)

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -316,8 +316,9 @@ let required_tool_rotation_candidate ~catalog_names name =
          Keeper_config.default_cascade_name)
   in
   (* Required-tool turns may still use [local_recovery] when the catalog
-     declares it as a tool-capable fallback profile; only the buffer/local-only
-     lane is filtered here. *)
+     declares it as a tool-capable fallback profile.  Keep excluding the
+     local-only/buffer lane here: those routes are recovery/control lanes and
+     may not satisfy a required keeper-tool contract. *)
   not
     ((routed_local_only_is_distinct
       && String.equal normalized Keeper_config.local_only_cascade_name))
@@ -390,6 +391,9 @@ let degraded_rotation_after_recoverable_error
   match recoverable_cascade_failure_reason err with
   | None -> None
   | Some fallback_reason ->
+      (* Load the live catalog once at the degraded-rotation boundary and pass
+         the snapshot through normalization/filter helpers.  This preserves
+         concrete profile names without adding per-candidate catalog I/O. *)
       let catalog_names = Keeper_cascade_profile.catalog_names () in
       let attempted =
         attempted_cascades

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4564,6 +4564,21 @@ let test_degraded_rotation_after_recoverable_error_filters_required_catalog_dire
   expect_degraded_retry "required catalog classifier rotation"
     "big_three" "required_tool_contract_violation" degraded_retry
 
+let test_degraded_rotation_preserves_local_recovery_profile_hint_for_required_tool
+    () =
+  let degraded_retry =
+    EC.degraded_rotation_after_recoverable_error
+      ~rotation_cascades:[ "big_three"; "local_recovery" ]
+      ~fallback_hint:"local_recovery"
+      ~base_cascade:"tier_fast"
+      ~effective_cascade:"keeper_bound_safe"
+      ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
+      ~attempted_cascades:[ "tier_fast"; "keeper_bound_safe"; "big_three" ]
+      (required_tool_contract_violation_error ())
+  in
+  expect_degraded_retry "required local_recovery fallback profile"
+    "local_recovery" "required_tool_contract_violation" degraded_retry
+
 let test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly () =
   let degraded_retry =
     EC.degraded_rotation_after_recoverable_error
@@ -7879,6 +7894,10 @@ let () =
           test_case "classifier filters required-tool catalog rotation"
             `Quick
             test_degraded_rotation_after_recoverable_error_filters_required_catalog_directly;
+          test_case
+            "classifier preserves explicit local_recovery fallback profile"
+            `Quick
+            test_degraded_rotation_preserves_local_recovery_profile_hint_for_required_tool;
           test_case "classifier normalizes catalog rotation"
             `Quick
             test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly;


### PR DESCRIPTION
## Summary

- Preserve explicit `local_recovery` cascade profiles from live catalog loading instead of treating them as deprecated logical aliases.
- Keep concrete catalog fallback names intact during keeper degraded rotation, so `fallback_cascade = "local_recovery"` does not collapse back into `routes.phase_recovery`.
- Allow required-tool contract recovery to rotate into catalog-declared `local_recovery` while still excluding local-only/buffer lanes.

## Product impact

Live keepers were still blocking on completion-contract failures after the turn-timeout fix:

- `analyst`: passive status/read tool only
- `glm-coding-plan`: no keeper tools
- `velvet-hammer`: `keeper_stay_silent` without typed no-work proof
- `verifier`: no keeper tools

The live config already declares `local_recovery` as the fallback for `big_three` and `keeper_bound_safe`, but the runtime dropped or normalized that concrete profile away. This made required-tool contract failures stop after cloud/tool-safe rotations even though the operator-configured local recovery lane existed.

## Evidence

- Root cause: `Cascade_config_loader.deprecated_logical_profile_names` dropped concrete `[local_recovery]` catalog entries.
- Root cause: keeper degraded rotation normalized `local_recovery` through logical routes, turning it back into `phase_recovery` / `big_three`.
- Root cause: required-tool recovery filtered local recovery candidates too broadly.
- Fix verified by a regression that simulates attempted `tier_fast -> keeper_bound_safe -> big_three` and confirms `fallback_hint:"local_recovery"` still selects `local_recovery` for `required_tool_contract_violation`.
- Rebased after #13346 merged; the PR now only changes cascade loading, keeper error classification, and the focused regression test.

## Review evidence

- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_cascade_profile.exe test/test_cascade_toml_materialization.exe test/test_cascade_toml_section_fallback_10259.exe test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_keeper_unified.exe` passed 326 tests
- `./_build/default/test/test_keeper_cascade_profile.exe` passed 12 tests
- `env MASC_CASCADE_TOML_PATH=config/cascade.toml MASC_CASCADE_JSON_PATH=config/cascade.json ./_build/default/test/test_cascade_toml_materialization.exe` passed 22 tests
- `./_build/default/test/test_cascade_toml_section_fallback_10259.exe` passed 8 tests
- `./_build/default/test/test_keeper_toml_config_validation.exe` passed 15 tests

## Linked issue

None. Follow-up from live keeper liveness triage on 2026-05-06.
