### PR TITLE
fix(keeper): mirror runtime trust attention in status

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1020,6 +1020,9 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 Keeper_runtime_trust_snapshot.snapshot_json
                   ~config ~meta:m
               in
+              let attention_fields =
+                attention_fields_with_runtime_trust attention_fields runtime_trust
+              in
               let detail_fields =
                 if compact then []
                 else [

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -411,6 +411,51 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
     ("next_human_action", Json_util.string_opt_to_json next_human_action);
   ]
 
+let json_string_opt_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let attention_fields_with_runtime_trust attention_fields runtime_trust =
+  let existing_needs_attention =
+    match List.assoc_opt "needs_attention" attention_fields with
+    | Some (`Bool value) -> value
+    | _ -> false
+  in
+  let trust_needs_attention =
+    Safe_ops.json_bool_opt "needs_attention" runtime_trust
+    |> Option.value ~default:false
+  in
+  if existing_needs_attention || not trust_needs_attention then
+    attention_fields
+  else
+    let attention_reason =
+      match List.assoc_opt "attention_reason" attention_fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | _ -> (
+          match json_string_opt_member "attention_reason" runtime_trust with
+          | Some _ as value -> value
+          | None -> json_string_opt_member "disposition_reason" runtime_trust)
+    in
+    let next_human_action =
+      match List.assoc_opt "next_human_action" attention_fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | _ -> (
+          match json_string_opt_member "next_human_action" runtime_trust with
+          | Some _ as value -> value
+          | None -> (
+              match json_string_opt_member "latest_next_action" runtime_trust with
+              | Some _ as value -> value
+              | None -> Some "inspect_runtime_trust"))
+    in
+    [
+      ("needs_attention", `Bool true);
+      ("attention_reason", Json_util.string_opt_to_json attention_reason);
+      ("next_human_action", Json_util.string_opt_to_json next_human_action);
+    ]
+
 let trimmed_string_json value =
   let trimmed = String.trim value in
   if trimmed = "" then `Null else `String trimmed

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -411,12 +411,21 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
     ("next_human_action", Json_util.string_opt_to_json next_human_action);
   ]
 
-let json_string_opt_member key json =
+let json_string_opt_member json key =
   match Yojson.Safe.Util.member key json with
   | `String value ->
       let trimmed = String.trim value in
       if trimmed = "" then None else Some trimmed
   | _ -> None
+
+let assoc_upsert fields key value =
+  let rec loop acc = function
+    | [] -> List.rev ((key, value) :: acc)
+    | (existing_key, _) :: rest when String.equal existing_key key ->
+        List.rev_append acc ((key, value) :: rest)
+    | field :: rest -> loop (field :: acc) rest
+  in
+  loop [] fields
 
 let attention_fields_with_runtime_trust attention_fields runtime_trust =
   let existing_needs_attention =
@@ -435,26 +444,27 @@ let attention_fields_with_runtime_trust attention_fields runtime_trust =
       match List.assoc_opt "attention_reason" attention_fields with
       | Some (`String value) when String.trim value <> "" -> Some value
       | _ -> (
-          match json_string_opt_member "attention_reason" runtime_trust with
+          match json_string_opt_member runtime_trust "attention_reason" with
           | Some _ as value -> value
-          | None -> json_string_opt_member "disposition_reason" runtime_trust)
+          | None -> json_string_opt_member runtime_trust "disposition_reason")
     in
     let next_human_action =
       match List.assoc_opt "next_human_action" attention_fields with
       | Some (`String value) when String.trim value <> "" -> Some value
       | _ -> (
-          match json_string_opt_member "next_human_action" runtime_trust with
+          match json_string_opt_member runtime_trust "next_human_action" with
           | Some _ as value -> value
           | None -> (
-              match json_string_opt_member "latest_next_action" runtime_trust with
+              match json_string_opt_member runtime_trust "latest_next_action" with
               | Some _ as value -> value
               | None -> Some "inspect_runtime_trust"))
     in
-    [
-      ("needs_attention", `Bool true);
-      ("attention_reason", Json_util.string_opt_to_json attention_reason);
-      ("next_human_action", Json_util.string_opt_to_json next_human_action);
-    ]
+    attention_fields
+    |> assoc_upsert "needs_attention" (`Bool true)
+    |> assoc_upsert "attention_reason"
+         (Json_util.string_opt_to_json attention_reason)
+    |> assoc_upsert "next_human_action"
+         (Json_util.string_opt_to_json next_human_action)
 
 let trimmed_string_json value =
   let trimmed = String.trim value in

--- a/lib/keeper/keeper_status_bridge.mli
+++ b/lib/keeper/keeper_status_bridge.mli
@@ -57,6 +57,9 @@ val runtime_blocker_fields_json :
 val attention_fields_json :
   Coord_utils.config -> keeper_meta -> (string * Yojson.Safe.t) list
 
+val attention_fields_with_runtime_trust :
+  (string * Yojson.Safe.t) list -> Yojson.Safe.t -> (string * Yojson.Safe.t) list
+
 val social_model_resolution_fields_json :
   keeper_meta -> (string * Yojson.Safe.t) list
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -986,6 +986,9 @@ let handle_keeper_status ctx args : tool_result =
            Keeper_runtime_trust_snapshot.snapshot_json
              ~config:ctx.config ~meta:m
          in
+         let attention_fields =
+           attention_fields_with_runtime_trust attention_fields runtime_trust
+         in
          let disposition =
            json_string_opt_member runtime_trust "disposition"
          in

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -119,6 +119,57 @@ let test_keeper_status_helpers_tolerate_null_status_json () =
   check string "null surface inputs fall back offline" "offline"
     (ES.keeper_surface_status ~agent_status:`Null ~diagnostic:`Null)
 
+let assoc_member key fields =
+  match List.assoc_opt key fields with
+  | Some value -> value
+  | None -> `Null
+
+let test_attention_fields_promote_runtime_trust_attention () =
+  let fields =
+    [
+      ("needs_attention", `Bool false);
+      ("attention_reason", `Null);
+      ("next_human_action", `Null);
+    ]
+  in
+  let trust =
+    `Assoc
+      [
+        ("needs_attention", `Bool true);
+        ("attention_reason", `String "required_tool_use_unsatisfied");
+        ("next_human_action", `String "inspect_runtime_trust");
+      ]
+  in
+  let merged = KSB.attention_fields_with_runtime_trust fields trust in
+  check bool "trust attention promoted" true
+    (assoc_member "needs_attention" merged = `Bool true);
+  check string "trust reason promoted" "required_tool_use_unsatisfied"
+    (Yojson.Safe.Util.to_string (assoc_member "attention_reason" merged));
+  check string "trust action promoted" "inspect_runtime_trust"
+    (Yojson.Safe.Util.to_string (assoc_member "next_human_action" merged))
+
+let test_attention_fields_keep_existing_attention_reason () =
+  let fields =
+    [
+      ("needs_attention", `Bool true);
+      ("attention_reason", `String "approval_pending");
+      ("next_human_action", `String "resolve_approval");
+    ]
+  in
+  let trust =
+    `Assoc
+      [
+        ("needs_attention", `Bool true);
+        ("attention_reason", `String "runtime_trust_pause");
+        ("next_human_action", `String "inspect_runtime_trust");
+      ]
+  in
+  let merged = KSB.attention_fields_with_runtime_trust fields trust in
+  check string "existing reason preserved" "approval_pending"
+    (Yojson.Safe.Util.to_string (assoc_member "attention_reason" merged));
+  check string "existing action preserved" "resolve_approval"
+    (Yojson.Safe.Util.to_string (assoc_member "next_human_action" merged))
+
 (* --- keeper_health_state tests (online/offline mismatch fix) --- *)
 
 let make_agent_status ?(exists = true) ?(status = "active")
@@ -788,6 +839,10 @@ let () =
             test_keeper_surface_status_maps_dead_to_inactive;
           test_case "status helpers tolerate null status json" `Quick
             test_keeper_status_helpers_tolerate_null_status_json;
+          test_case "attention fields promote runtime trust attention" `Quick
+            test_attention_fields_promote_runtime_trust_attention;
+          test_case "attention fields keep existing attention reason" `Quick
+            test_attention_fields_keep_existing_attention_reason;
           test_case "runtime surface derives slot wait timeout blocker" `Quick
             test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta;
           test_case "runtime surface derives cascade exhausted blocker" `Quick

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -130,6 +130,7 @@ let test_attention_fields_promote_runtime_trust_attention () =
       ("needs_attention", `Bool false);
       ("attention_reason", `Null);
       ("next_human_action", `Null);
+      ("source", `String "exec_status");
     ]
   in
   let trust =
@@ -146,7 +147,9 @@ let test_attention_fields_promote_runtime_trust_attention () =
   check string "trust reason promoted" "required_tool_use_unsatisfied"
     (Yojson.Safe.Util.to_string (assoc_member "attention_reason" merged));
   check string "trust action promoted" "inspect_runtime_trust"
-    (Yojson.Safe.Util.to_string (assoc_member "next_human_action" merged))
+    (Yojson.Safe.Util.to_string (assoc_member "next_human_action" merged));
+  check string "extra field preserved" "exec_status"
+    (Yojson.Safe.Util.to_string (assoc_member "source" merged))
 
 let test_attention_fields_keep_existing_attention_reason () =
   let fields =

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -170,7 +170,12 @@ let test_keeper_status_disposition_mirrors_runtime_trust () =
     (count_occurrences
        ~needle:"(\"disposition\", Json_util.string_opt_to_json disposition)"
        src
-     >= 1)
+    >= 1);
+  check bool "top-level attention overlays runtime_trust" true
+    (count_occurrences
+       ~needle:"attention_fields_with_runtime_trust attention_fields runtime_trust"
+       src
+    >= 1)
 
 let () =
   run "keeper_pause_silent_failure_source"


### PR DESCRIPTION
## Summary

Keeper status surfaces now mirror embedded `runtime_trust.needs_attention` into the top-level `needs_attention` fields used by `masc_keeper_status` and dashboard keeper JSON.

The new bridge helper preserves stronger local reasons such as pending approvals, but promotes runtime-trust attention when the older local attention path would otherwise say the keeper is healthy.

## Product impact

Operators should no longer see a keeper reported as top-level healthy while the embedded runtime-trust block says the keeper needs attention because the latest execution receipt or terminal reason paused the runtime. This makes silent-action failures and required-tool contract pauses visible in the first status fields that humans and automation scan.

## Evidence

- Root cause: `Keeper_runtime_trust_snapshot` already derives attention from Pause/Alert disposition, but `keeper_status_detail` and dashboard keeper JSON emitted separate top-level attention fields from `attention_fields_json`.
- `attention_fields_with_runtime_trust` now promotes trust attention without overriding existing approval/runtime-blocker attention reasons.
- `keeper_status_detail` and `dashboard_http_keeper` both apply the overlay after building `runtime_trust`.

## Review evidence

- `git diff --check origin/main...HEAD`
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_exec_status.exe`
- `./_build/default/test/test_keeper_exec_status.exe --color=never` passed, 32 tests.
- `env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_pause_silent_failure_source.exe`
- `./_build/default/test/test_keeper_pause_silent_failure_source.exe --color=never` passed, 7 tests.
- `env MASC_INCLUDE_OPERATOR_CONTROL=true DUNE_CACHE=disabled scripts/dune-local.sh build test/test_operator_control.exe`
- `./_build/default/test/test_operator_control.exe test operator 8,53 --color=never` passed, 2 targeted tests.

## Linked issue

None.
