### PR TITLE
fix(dashboard): expose breadcrumb history summary state

### DIFF
--- a/dashboard/src/components/common/breadcrumb-history.test.ts
+++ b/dashboard/src/components/common/breadcrumb-history.test.ts
@@ -11,7 +11,9 @@ describe('BreadcrumbHistory', () => {
   it('formats breadcrumb timestamps', () => {
     const timestamp = new Date('2024-01-15T09:30:00').getTime()
     expect(formatBreadcrumbTime(timestamp)).not.toBe('')
+    expect(formatBreadcrumbTime(0)).not.toBe('')
     expect(formatBreadcrumbTime()).toBe('')
+    expect(formatBreadcrumbTime(Number.NaN)).toBe('')
   })
 
   it('summarizes empty history', () => {
@@ -59,6 +61,16 @@ describe('BreadcrumbHistory', () => {
     })
   })
 
+  it('treats epoch zero as a valid breadcrumb timestamp', () => {
+    const summary = summarizeBreadcrumbHistory([{ id: 'epoch', label: 'Epoch', timestamp: 0 }])
+    expect(summary.hasTimestamps).toBe(true)
+    expect(summary.items[0]).toMatchObject({
+      timestamp: 0,
+      hasTimestamp: true,
+    })
+    expect(summary.items[0]?.timeLabel).not.toBe('')
+  })
+
   it('renders empty message when no items', () => {
     const container = document.createElement('div')
     render(h(BreadcrumbHistory, { items: [] }), container)
@@ -66,6 +78,7 @@ describe('BreadcrumbHistory', () => {
     const nav = container.querySelector('[data-breadcrumb-history]') as HTMLElement
     expect(nav.dataset.breadcrumbCount).toBe('0')
     expect(nav.dataset.breadcrumbEmpty).toBe('true')
+    expect(nav.dataset.breadcrumbNavigable).toBe('false')
   })
 
   it('renders breadcrumb items', () => {
@@ -80,6 +93,9 @@ describe('BreadcrumbHistory', () => {
     const nav = container.querySelector('[data-breadcrumb-history]') as HTMLElement
     expect(nav.dataset.breadcrumbCount).toBe('2')
     expect(nav.dataset.breadcrumbEmpty).toBe('false')
+    expect(nav.dataset.breadcrumbHasActive).toBe('false')
+    expect(nav.dataset.breadcrumbHasTimestamps).toBe('false')
+    expect(nav.dataset.breadcrumbNavigable).toBe('false')
   })
 
   it('renders separators between items', () => {
@@ -133,6 +149,10 @@ describe('BreadcrumbHistory', () => {
     const item = container.querySelector('[data-breadcrumb-item-id="a"]') as HTMLElement
     expect(item.dataset.breadcrumbItemActive).toBe('true')
     expect(item.dataset.breadcrumbItemFirst).toBe('true')
+    const inactiveItem = container.querySelector('[data-breadcrumb-item-id="b"]') as HTMLElement
+    expect(inactiveItem.dataset.breadcrumbItemActive).toBe('false')
+    expect(inactiveItem.dataset.breadcrumbItemFirst).toBe('false')
+    expect(inactiveItem.dataset.breadcrumbItemLast).toBe('true')
   })
 
   it('renders timestamp when provided', () => {

--- a/dashboard/src/components/common/breadcrumb-history.test.ts
+++ b/dashboard/src/components/common/breadcrumb-history.test.ts
@@ -1,13 +1,71 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { BreadcrumbHistory } from './breadcrumb-history'
+import {
+  BreadcrumbHistory,
+  formatBreadcrumbTime,
+  summarizeBreadcrumbHistory,
+} from './breadcrumb-history'
 
 describe('BreadcrumbHistory', () => {
+  it('formats breadcrumb timestamps', () => {
+    const timestamp = new Date('2024-01-15T09:30:00').getTime()
+    expect(formatBreadcrumbTime(timestamp)).not.toBe('')
+    expect(formatBreadcrumbTime()).toBe('')
+  })
+
+  it('summarizes empty history', () => {
+    expect(summarizeBreadcrumbHistory([])).toEqual({
+      count: 0,
+      empty: true,
+      activeId: '',
+      activeIndex: -1,
+      hasActive: false,
+      hasTimestamps: false,
+      items: [],
+    })
+  })
+
+  it('summarizes active and timestamp metadata', () => {
+    const timestamp = new Date('2024-01-15T09:30:00').getTime()
+    const summary = summarizeBreadcrumbHistory([
+      { id: 'a', label: 'Step A', timestamp },
+      { id: 'b', label: 'Step B', active: true },
+    ])
+    expect(summary.count).toBe(2)
+    expect(summary.activeId).toBe('b')
+    expect(summary.activeIndex).toBe(1)
+    expect(summary.hasActive).toBe(true)
+    expect(summary.hasTimestamps).toBe(true)
+    expect(summary.items[0]).toMatchObject({
+      id: 'a',
+      index: 0,
+      active: false,
+      first: true,
+      last: false,
+      timestamp,
+      timeLabel: formatBreadcrumbTime(timestamp),
+      hasTimestamp: true,
+    })
+    expect(summary.items[1]).toMatchObject({
+      id: 'b',
+      index: 1,
+      active: true,
+      first: false,
+      last: true,
+      timestamp: null,
+      timeLabel: '',
+      hasTimestamp: false,
+    })
+  })
+
   it('renders empty message when no items', () => {
     const container = document.createElement('div')
     render(h(BreadcrumbHistory, { items: [] }), container)
     expect(container.textContent).toContain('히스토리가 없습니다')
+    const nav = container.querySelector('[data-breadcrumb-history]') as HTMLElement
+    expect(nav.dataset.breadcrumbCount).toBe('0')
+    expect(nav.dataset.breadcrumbEmpty).toBe('true')
   })
 
   it('renders breadcrumb items', () => {
@@ -19,6 +77,9 @@ describe('BreadcrumbHistory', () => {
     render(h(BreadcrumbHistory, { items }), container)
     expect(container.textContent).toContain('Step A')
     expect(container.textContent).toContain('Step B')
+    const nav = container.querySelector('[data-breadcrumb-history]') as HTMLElement
+    expect(nav.dataset.breadcrumbCount).toBe('2')
+    expect(nav.dataset.breadcrumbEmpty).toBe('false')
   })
 
   it('renders separators between items', () => {
@@ -51,8 +112,8 @@ describe('BreadcrumbHistory', () => {
     ]
     render(h(BreadcrumbHistory, { items }), container)
     const buttons = container.querySelectorAll('button')
-    expect(buttons[0]?.className).toContain('text-[var(--color-accent)]')
-    expect(buttons[1]?.className).not.toContain('text-[var(--color-accent)]')
+    expect(buttons[0]?.className).toContain('text-[var(--color-accent-fg)]')
+    expect(buttons[1]?.className).not.toContain('text-[var(--color-accent-fg)]')
   })
 
   it('applies aria-current to active item', () => {
@@ -65,13 +126,25 @@ describe('BreadcrumbHistory', () => {
     const buttons = container.querySelectorAll('button')
     expect(buttons[0]?.getAttribute('aria-current')).toBe('page')
     expect(buttons[1]?.getAttribute('aria-current')).toBeNull()
+    const nav = container.querySelector('[data-breadcrumb-history]') as HTMLElement
+    expect(nav.dataset.breadcrumbActiveId).toBe('a')
+    expect(nav.dataset.breadcrumbActiveIndex).toBe('0')
+    expect(nav.dataset.breadcrumbHasActive).toBe('true')
+    const item = container.querySelector('[data-breadcrumb-item-id="a"]') as HTMLElement
+    expect(item.dataset.breadcrumbItemActive).toBe('true')
+    expect(item.dataset.breadcrumbItemFirst).toBe('true')
   })
 
   it('renders timestamp when provided', () => {
     const container = document.createElement('div')
     const items = [{ id: 'a', label: 'Step A', timestamp: new Date('2024-01-15T09:30:00').getTime() }]
     render(h(BreadcrumbHistory, { items }), container)
-    expect(container.querySelector('time')).not.toBeNull()
+    const time = container.querySelector('time')
+    expect(time).not.toBeNull()
+    expect(time?.getAttribute('datetime')).not.toBeNull()
+    const item = container.querySelector('[data-breadcrumb-item-id="a"]') as HTMLElement
+    expect(item.dataset.breadcrumbItemHasTimestamp).toBe('true')
+    expect(item.dataset.breadcrumbItemTimeLabel).not.toBe('')
   })
 
   it('applies testId', () => {

--- a/dashboard/src/components/common/breadcrumb-history.ts
+++ b/dashboard/src/components/common/breadcrumb-history.ts
@@ -11,22 +11,83 @@ export interface BreadcrumbItem {
   active?: boolean
 }
 
+export interface BreadcrumbItemSummary {
+  readonly id: string
+  readonly label: string
+  readonly index: number
+  readonly active: boolean
+  readonly first: boolean
+  readonly last: boolean
+  readonly timestamp: number | null
+  readonly timeLabel: string
+  readonly hasTimestamp: boolean
+}
+
+export interface BreadcrumbHistorySummary {
+  readonly count: number
+  readonly empty: boolean
+  readonly activeId: string
+  readonly activeIndex: number
+  readonly hasActive: boolean
+  readonly hasTimestamps: boolean
+  readonly items: BreadcrumbItemSummary[]
+}
+
 interface BreadcrumbHistoryProps {
   items: BreadcrumbItem[]
   onNavigate?: (id: string) => void
   testId?: string
 }
 
-function formatTime(ts?: number): string {
+export function formatBreadcrumbTime(ts?: number): string {
   if (!ts) return ''
   const d = new Date(ts)
   return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
 }
 
+export function summarizeBreadcrumbHistory(items: BreadcrumbItem[]): BreadcrumbHistorySummary {
+  const activeIndex = items.findIndex((item) => item.active === true)
+  const summaryItems = items.map((item, index) => {
+    const timeLabel = formatBreadcrumbTime(item.timestamp)
+    return {
+      id: item.id,
+      label: item.label,
+      index,
+      active: item.active === true,
+      first: index === 0,
+      last: index === items.length - 1,
+      timestamp: item.timestamp ?? null,
+      timeLabel,
+      hasTimestamp: timeLabel.length > 0,
+    }
+  })
+
+  return {
+    count: items.length,
+    empty: items.length === 0,
+    activeId: activeIndex >= 0 ? items[activeIndex]!.id : '',
+    activeIndex,
+    hasActive: activeIndex >= 0,
+    hasTimestamps: summaryItems.some((item) => item.hasTimestamp),
+    items: summaryItems,
+  }
+}
+
 export function BreadcrumbHistory({ items, onNavigate, testId }: BreadcrumbHistoryProps) {
-  if (items.length === 0) {
+  const summary = summarizeBreadcrumbHistory(items)
+  const navigable = onNavigate != null
+
+  if (summary.empty) {
     return html`
       <nav
+        data-breadcrumb-history
+        data-breadcrumb-count="0"
+        data-breadcrumb-empty="true"
+        data-breadcrumb-active-id=""
+        data-breadcrumb-active-index="-1"
+        data-breadcrumb-has-active="false"
+        data-breadcrumb-has-timestamps="false"
+        data-breadcrumb-navigable=${navigable}
         data-testid=${testId}
         class="text-xs text-[var(--color-fg-muted)]"
         aria-label="작업 히스토리"
@@ -37,28 +98,55 @@ export function BreadcrumbHistory({ items, onNavigate, testId }: BreadcrumbHisto
   }
 
   return html`
-    <nav data-testid=${testId} aria-label="작업 히스토리">
-      <ol class="flex items-center gap-1 text-sm overflow-auto"
+    <nav
+      data-breadcrumb-history
+      data-breadcrumb-count=${summary.count}
+      data-breadcrumb-empty="false"
+      data-breadcrumb-active-id=${summary.activeId}
+      data-breadcrumb-active-index=${summary.activeIndex}
+      data-breadcrumb-has-active=${summary.hasActive}
+      data-breadcrumb-has-timestamps=${summary.hasTimestamps}
+      data-breadcrumb-navigable=${navigable}
+      data-testid=${testId}
+      aria-label="작업 히스토리"
+    >
+      <ol class="flex max-w-full items-center gap-1 overflow-x-auto overflow-y-hidden text-sm"
         role="list"
       >
-        ${items.map((item, idx) => {
+        ${summary.items.map((item) => {
           const activeCls = item.active
-            ? 'text-[var(--color-accent)] font-medium'
+            ? 'text-[var(--color-accent-fg)] font-medium'
             : 'text-[var(--color-fg-secondary)] hover:text-[var(--color-fg-primary)]'
           return html`
-            <li class="flex items-center gap-1 shrink-0" role="listitem">
-              ${idx > 0
+            <li
+              class="flex min-w-0 shrink-0 items-center gap-1"
+              role="listitem"
+              data-breadcrumb-item
+              data-breadcrumb-item-id=${item.id}
+              data-breadcrumb-item-index=${item.index}
+              data-breadcrumb-item-active=${item.active}
+              data-breadcrumb-item-first=${item.first}
+              data-breadcrumb-item-last=${item.last}
+              data-breadcrumb-item-has-timestamp=${item.hasTimestamp}
+              data-breadcrumb-item-time-label=${item.timeLabel}
+            >
+              ${item.index > 0
                 ? html`<span class="text-[var(--color-fg-muted)] mx-0.5" aria-hidden="true">/</span>`
                 : null}
               <button
-                class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-[var(--r-1)] hover:bg-[var(--color-bg-surface)] ${activeCls}"
+                class="inline-flex max-w-[14rem] items-center gap-1 rounded-[var(--r-1)] px-1.5 py-0.5 hover:bg-[var(--color-bg-surface)] ${activeCls}"
                 onClick=${() => onNavigate?.(item.id)}
                 aria-current=${item.active ? 'page' : undefined}
-                disabled=${!onNavigate}
+                disabled=${!navigable}
               >
-                <span>${item.label}</span>
-                ${item.timestamp
-                  ? html`<time class="text-3xs text-[var(--color-fg-muted)]">${formatTime(item.timestamp)}</time>`
+                <span class="min-w-0 truncate">${item.label}</span>
+                ${item.hasTimestamp
+                  ? html`<time
+                      class="shrink-0 text-3xs text-[var(--color-fg-muted)]"
+                      datetime=${new Date(item.timestamp!).toISOString()}
+                      title=${item.timeLabel}
+                      >${item.timeLabel}</time
+                    >`
                   : null}
               </button>
             </li>

--- a/dashboard/src/components/common/breadcrumb-history.ts
+++ b/dashboard/src/components/common/breadcrumb-history.ts
@@ -39,8 +39,15 @@ interface BreadcrumbHistoryProps {
   testId?: string
 }
 
+const dataBool = (value: boolean): 'true' | 'false' => (value ? 'true' : 'false')
+
+function normalizeBreadcrumbTimestamp(ts: number | undefined): number | null {
+  if (ts == null || !Number.isFinite(ts)) return null
+  return ts
+}
+
 export function formatBreadcrumbTime(ts?: number): string {
-  if (!ts) return ''
+  if (ts == null || !Number.isFinite(ts)) return ''
   const d = new Date(ts)
   return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
 }
@@ -48,7 +55,8 @@ export function formatBreadcrumbTime(ts?: number): string {
 export function summarizeBreadcrumbHistory(items: BreadcrumbItem[]): BreadcrumbHistorySummary {
   const activeIndex = items.findIndex((item) => item.active === true)
   const summaryItems = items.map((item, index) => {
-    const timeLabel = formatBreadcrumbTime(item.timestamp)
+    const timestamp = normalizeBreadcrumbTimestamp(item.timestamp)
+    const timeLabel = timestamp == null ? '' : formatBreadcrumbTime(timestamp)
     return {
       id: item.id,
       label: item.label,
@@ -56,7 +64,7 @@ export function summarizeBreadcrumbHistory(items: BreadcrumbItem[]): BreadcrumbH
       active: item.active === true,
       first: index === 0,
       last: index === items.length - 1,
-      timestamp: item.timestamp ?? null,
+      timestamp,
       timeLabel,
       hasTimestamp: timeLabel.length > 0,
     }
@@ -87,7 +95,7 @@ export function BreadcrumbHistory({ items, onNavigate, testId }: BreadcrumbHisto
         data-breadcrumb-active-index="-1"
         data-breadcrumb-has-active="false"
         data-breadcrumb-has-timestamps="false"
-        data-breadcrumb-navigable=${navigable}
+        data-breadcrumb-navigable=${dataBool(navigable)}
         data-testid=${testId}
         class="text-xs text-[var(--color-fg-muted)]"
         aria-label="작업 히스토리"
@@ -104,9 +112,9 @@ export function BreadcrumbHistory({ items, onNavigate, testId }: BreadcrumbHisto
       data-breadcrumb-empty="false"
       data-breadcrumb-active-id=${summary.activeId}
       data-breadcrumb-active-index=${summary.activeIndex}
-      data-breadcrumb-has-active=${summary.hasActive}
-      data-breadcrumb-has-timestamps=${summary.hasTimestamps}
-      data-breadcrumb-navigable=${navigable}
+      data-breadcrumb-has-active=${dataBool(summary.hasActive)}
+      data-breadcrumb-has-timestamps=${dataBool(summary.hasTimestamps)}
+      data-breadcrumb-navigable=${dataBool(navigable)}
       data-testid=${testId}
       aria-label="작업 히스토리"
     >
@@ -124,10 +132,10 @@ export function BreadcrumbHistory({ items, onNavigate, testId }: BreadcrumbHisto
               data-breadcrumb-item
               data-breadcrumb-item-id=${item.id}
               data-breadcrumb-item-index=${item.index}
-              data-breadcrumb-item-active=${item.active}
-              data-breadcrumb-item-first=${item.first}
-              data-breadcrumb-item-last=${item.last}
-              data-breadcrumb-item-has-timestamp=${item.hasTimestamp}
+              data-breadcrumb-item-active=${dataBool(item.active)}
+              data-breadcrumb-item-first=${dataBool(item.first)}
+              data-breadcrumb-item-last=${dataBool(item.last)}
+              data-breadcrumb-item-has-timestamp=${dataBool(item.hasTimestamp)}
               data-breadcrumb-item-time-label=${item.timeLabel}
             >
               ${item.index > 0


### PR DESCRIPTION
## Summary
- Export BreadcrumbHistory summary and timestamp helpers for deterministic state inspection.
- Add root `data-breadcrumb-*` and item-level metadata for active item, indexes, timestamps, and navigation availability.
- Move the active breadcrumb color to the semantic `--color-accent-fg` token and constrain long labels inside a horizontally scrollable list.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/breadcrumb-history.test.ts src/components/common/breadcrumb-history.a11y.test.ts` (17 tests)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` (passes with existing warnings in copy-id-button, virtual-list, fsm-hub)
- `pnpm --dir dashboard run build` (passes with existing Vite warnings)
- Browser QA: `/tmp/masc-breadcrumb-history-summary-0506.png`, `/tmp/masc-breadcrumb-history-summary-0506-mobile.png`

## Browser QA Notes
- Verified populated and empty states expose expected root metadata.
- Verified active item and timestamp metadata, semantic active color, and navigation callback (`keeper`).
- Verified mobile list scrolls horizontally without page overflow.
- Removed temporary QA page and `dashboard/node_modules` symlink; stopped QA port `5218`.