### PR TITLE
fix(dashboard): expose agent lifecycle summary state

### DIFF
--- a/dashboard/src/components/common/agent-lifecycle.test.ts
+++ b/dashboard/src/components/common/agent-lifecycle.test.ts
@@ -1,13 +1,66 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentLifecycle } from './agent-lifecycle'
+import {
+  AgentLifecycle,
+  formatLifecycleTransitionTime,
+  lifecycleTransitionKey,
+  summarizeAgentLifecycle,
+} from './agent-lifecycle'
 
 describe('AgentLifecycle', () => {
+  it('formats lifecycle transition timestamps', () => {
+    const timestamp = new Date('2024-01-15T09:30:00').getTime()
+    expect(formatLifecycleTransitionTime(timestamp)).not.toBe('')
+    expect(formatLifecycleTransitionTime()).toBe('')
+  })
+
+  it('builds stable transition keys', () => {
+    expect(lifecycleTransitionKey('created', 'active')).toBe('created→active')
+  })
+
+  it('summarizes known current state', () => {
+    const timestamp = new Date('2024-01-15T09:30:00').getTime()
+    const summary = summarizeAgentLifecycle(
+      'active',
+      { from: 'created', to: 'active', timestamp },
+      lifecycleTransitionKey('created', 'active'),
+    )
+
+    expect(summary.currentLabel).toBe('활성')
+    expect(summary.currentKnown).toBe(true)
+    expect(summary.stateCount).toBe(4)
+    expect(summary.transitionCount).toBe(5)
+    expect(summary.hasLastTransition).toBe(true)
+    expect(summary.lastTransitionFromLabel).toBe('생성됨')
+    expect(summary.lastTransitionToLabel).toBe('활성')
+    expect(summary.lastTransitionAt).toBe(timestamp)
+    expect(summary.lastTransitionTimeLabel).not.toBe('')
+    expect(summary.states.find((state) => state.key === 'active')?.current).toBe(true)
+    expect(summary.transitions.find((transition) => transition.key === 'created→active')?.flashing).toBe(true)
+    const pause = summary.transitions.find((transition) => transition.key === 'active→idle')
+    const resume = summary.transitions.find((transition) => transition.key === 'idle→active')
+    const timeout = summary.transitions.find((transition) => transition.key === 'idle→terminated')
+    expect(Math.abs((pause?.labelX ?? 0) - (resume?.labelX ?? 0))).toBeGreaterThan(60)
+    expect(pause?.labelY).toBeGreaterThan(100)
+    expect(resume?.labelY).toBeGreaterThan(100)
+    expect(timeout?.labelY).toBeGreaterThan((resume?.labelY ?? 0) + 20)
+  })
+
+  it('summarizes unknown current state fallback', () => {
+    const summary = summarizeAgentLifecycle('unknown')
+    expect(summary.currentLabel).toBe('unknown')
+    expect(summary.currentKnown).toBe(false)
+    expect(summary.hasLastTransition).toBe(false)
+    expect(summary.lastTransitionFrom).toBe('')
+    expect(summary.flashEdge).toBe('')
+  })
+
   it('renders container', () => {
     const container = document.createElement('div')
     render(h(AgentLifecycle, { currentState: 'active' }), container)
     expect(container.querySelector('[role="region"]')).not.toBeNull()
+    expect(container.querySelector('[data-agent-lifecycle]')).not.toBeNull()
   })
 
   it('renders current state label', () => {
@@ -20,6 +73,8 @@ describe('AgentLifecycle', () => {
     const container = document.createElement('div')
     render(h(AgentLifecycle, { currentState: 'unknown' }), container)
     expect(container.textContent).toContain('unknown')
+    const root = container.querySelector('[data-agent-lifecycle]') as HTMLElement
+    expect(root.dataset.lifecycleCurrentKnown).toBe('false')
   })
 
   it('renders svg diagram', () => {
@@ -41,6 +96,13 @@ describe('AgentLifecycle', () => {
     expect(container.textContent).toContain('마지막 전환')
     expect(container.textContent).toContain('생성됨')
     expect(container.textContent).toContain('활성')
+    const root = container.querySelector('[data-agent-lifecycle]') as HTMLElement
+    expect(root.dataset.lifecycleHasLastTransition).toBe('true')
+    expect(root.dataset.lifecycleLastTransitionFrom).toBe('created')
+    expect(root.dataset.lifecycleLastTransitionTo).toBe('active')
+    expect(root.dataset.lifecycleFlashEdge).toBe('created→active')
+    const transition = container.querySelector('[data-lifecycle-transition-key="created→active"]') as HTMLElement
+    expect(transition.dataset.lifecycleTransitionFlashing).toBe('true')
   })
 
   it('applies testId', () => {
@@ -54,5 +116,33 @@ describe('AgentLifecycle', () => {
     render(h(AgentLifecycle, { currentState: 'terminated' }), container)
     const el = container.querySelector('[aria-label^="현재 상태"]')
     expect(el).not.toBeNull()
+  })
+
+  it('exposes state and transition metadata', () => {
+    const container = document.createElement('div')
+    render(h(AgentLifecycle, { currentState: 'active' }), container)
+
+    const root = container.querySelector('[data-agent-lifecycle]') as HTMLElement
+    expect(root.dataset.lifecycleCurrentState).toBe('active')
+    expect(root.dataset.lifecycleCurrentLabel).toBe('활성')
+    expect(root.dataset.lifecycleStateCount).toBe('4')
+    expect(root.dataset.lifecycleTransitionCount).toBe('5')
+
+    const current = container.querySelector('[data-lifecycle-state-key="active"]') as HTMLElement
+    expect(current.dataset.lifecycleStateCurrent).toBe('true')
+    const transition = container.querySelector('[data-lifecycle-transition-key="created→active"]') as HTMLElement
+    expect(transition.dataset.lifecycleTransitionLabel).toBe('activate')
+  })
+
+  it('uses semantic lifecycle tokens for active state', () => {
+    const container = document.createElement('div')
+    render(h(AgentLifecycle, { currentState: 'active' }), container)
+    const badge = container.querySelector('[aria-label="현재 상태: 활성"]')
+    expect(badge?.className).toContain('text-[var(--color-accent-fg)]')
+    const current = container.querySelector('[data-lifecycle-state-key="active"]')
+    const circle = current?.querySelector('circle:not([opacity])')
+    const label = current?.querySelector('text')
+    expect(circle?.getAttribute('class')).toContain('stroke-[var(--color-accent-fg)]')
+    expect(label?.getAttribute('class')).toContain('fill-[var(--color-accent-fg)]')
   })
 })

--- a/dashboard/src/components/common/agent-lifecycle.test.ts
+++ b/dashboard/src/components/common/agent-lifecycle.test.ts
@@ -12,6 +12,7 @@ describe('AgentLifecycle', () => {
   it('formats lifecycle transition timestamps', () => {
     const timestamp = new Date('2024-01-15T09:30:00').getTime()
     expect(formatLifecycleTransitionTime(timestamp)).not.toBe('')
+    expect(formatLifecycleTransitionTime(0)).not.toBe('')
     expect(formatLifecycleTransitionTime()).toBe('')
   })
 

--- a/dashboard/src/components/common/agent-lifecycle.ts
+++ b/dashboard/src/components/common/agent-lifecycle.ts
@@ -108,7 +108,7 @@ export function lifecycleTransitionKey(from: string, to: string): string {
 }
 
 export function formatLifecycleTransitionTime(timestamp?: number | null): string {
-  if (!timestamp) return ''
+  if (timestamp == null) return ''
   return new Date(timestamp).toLocaleTimeString()
 }
 
@@ -264,7 +264,7 @@ export function AgentLifecycle({
         ${summary.transitions.map((transition) => {
           return html`
             <g
-              key=${transition.label}
+              key=${transition.key}
               data-lifecycle-transition
               data-lifecycle-transition-key=${transition.key}
               data-lifecycle-transition-from=${transition.from}

--- a/dashboard/src/components/common/agent-lifecycle.ts
+++ b/dashboard/src/components/common/agent-lifecycle.ts
@@ -6,10 +6,52 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 
-interface LifecycleTransition {
+export interface LifecycleTransition {
   from: string
   to: string
   label: string
+  labelOffsetX?: number
+  labelOffsetY?: number
+}
+
+export interface LifecycleStateSummary {
+  readonly key: string
+  readonly label: string
+  readonly index: number
+  readonly current: boolean
+  readonly x: number
+  readonly y: number
+}
+
+export interface LifecycleTransitionSummary {
+  readonly key: string
+  readonly from: string
+  readonly to: string
+  readonly label: string
+  readonly fromLabel: string
+  readonly toLabel: string
+  readonly flashing: boolean
+  readonly path: string
+  readonly labelX: number
+  readonly labelY: number
+}
+
+export interface AgentLifecycleSummary {
+  readonly currentState: string
+  readonly currentLabel: string
+  readonly currentKnown: boolean
+  readonly stateCount: number
+  readonly transitionCount: number
+  readonly hasLastTransition: boolean
+  readonly lastTransitionFrom: string
+  readonly lastTransitionTo: string
+  readonly lastTransitionFromLabel: string
+  readonly lastTransitionToLabel: string
+  readonly lastTransitionAt: number | null
+  readonly lastTransitionTimeLabel: string
+  readonly flashEdge: string
+  readonly states: LifecycleStateSummary[]
+  readonly transitions: LifecycleTransitionSummary[]
 }
 
 interface AgentLifecycleProps {
@@ -27,27 +69,27 @@ const STATES: Record<string, { x: number; y: number; label: string }> = {
 
 const TRANSITIONS: LifecycleTransition[] = [
   { from: 'created', to: 'active', label: 'activate' },
-  { from: 'active', to: 'idle', label: 'pause' },
-  { from: 'idle', to: 'active', label: 'resume' },
+  { from: 'active', to: 'idle', label: 'pause', labelOffsetX: -36, labelOffsetY: 16 },
+  { from: 'idle', to: 'active', label: 'resume', labelOffsetX: 40, labelOffsetY: 16 },
   { from: 'active', to: 'terminated', label: 'kill' },
-  { from: 'idle', to: 'terminated', label: 'timeout' },
+  { from: 'idle', to: 'terminated', label: 'timeout', labelOffsetX: 28, labelOffsetY: 22 },
 ]
 
 function nodeClass(isCurrent: boolean): string {
   const base =
     'transition-[background-color,border-color,box-shadow,opacity] duration-[var(--t-slow)]'
   if (isCurrent) {
-    return `${base} r-6 stroke-[var(--accent-9)] stroke-2 fill-[var(--accent-3)]`
+    return `${base} r-6 stroke-[var(--color-accent-fg)] stroke-2 fill-[var(--color-bg-hover)]`
   }
-  return `${base} r-4 stroke-[var(--gray-8)] stroke-1 fill-[var(--gray-3)]`
+  return `${base} r-4 stroke-[var(--color-border-strong)] stroke-1 fill-[var(--color-bg-elevated)]`
 }
 
 function nodeLabelClass(isCurrent: boolean): string {
   const base = 'text-xs font-medium select-none'
   if (isCurrent) {
-    return `${base} fill-[var(--accent-11)]`
+    return `${base} fill-[var(--color-accent-fg)]`
   }
-  return `${base} fill-[var(--gray-11)]`
+  return `${base} fill-[var(--color-fg-secondary)]`
 }
 
 function edgePath(from: { x: number; y: number }, to: { x: number; y: number }): string {
@@ -61,17 +103,85 @@ function edgePath(from: { x: number; y: number }, to: { x: number; y: number }):
   return `M ${from.x} ${from.y} Q ${ctrlX} ${ctrlY} ${to.x} ${to.y}`
 }
 
+export function lifecycleTransitionKey(from: string, to: string): string {
+  return `${from}→${to}`
+}
+
+export function formatLifecycleTransitionTime(timestamp?: number | null): string {
+  if (!timestamp) return ''
+  return new Date(timestamp).toLocaleTimeString()
+}
+
+export function summarizeAgentLifecycle(
+  currentState: string,
+  lastTransition?: { from: string; to: string; timestamp: number },
+  flashEdge: string | null = null,
+): AgentLifecycleSummary {
+  const stateEntries = Object.entries(STATES)
+  const currentDefinition = STATES[currentState]
+  const states = stateEntries.map(([key, state], index) => ({
+    key,
+    label: state.label,
+    index,
+    current: key === currentState,
+    x: state.x,
+    y: state.y,
+  }))
+  const transitions = TRANSITIONS.map((transition) => {
+    const from = STATES[transition.from]!
+    const to = STATES[transition.to]!
+    const key = lifecycleTransitionKey(transition.from, transition.to)
+    const reverseKey = lifecycleTransitionKey(transition.to, transition.from)
+    return {
+      key,
+      from: transition.from,
+      to: transition.to,
+      label: transition.label,
+      fromLabel: from.label,
+      toLabel: to.label,
+      flashing: flashEdge === key || flashEdge === reverseKey,
+      path: edgePath(from, to),
+      labelX: (from.x + to.x) / 2 + (transition.labelOffsetX ?? 0),
+      labelY: (from.y + to.y) / 2 - 8 + (transition.labelOffsetY ?? 0),
+    }
+  })
+
+  return {
+    currentState,
+    currentLabel: currentDefinition?.label ?? currentState,
+    currentKnown: currentDefinition != null,
+    stateCount: states.length,
+    transitionCount: transitions.length,
+    hasLastTransition: lastTransition != null,
+    lastTransitionFrom: lastTransition?.from ?? '',
+    lastTransitionTo: lastTransition?.to ?? '',
+    lastTransitionFromLabel: lastTransition
+      ? STATES[lastTransition.from]?.label ?? lastTransition.from
+      : '',
+    lastTransitionToLabel: lastTransition
+      ? STATES[lastTransition.to]?.label ?? lastTransition.to
+      : '',
+    lastTransitionAt: lastTransition?.timestamp ?? null,
+    lastTransitionTimeLabel: formatLifecycleTransitionTime(lastTransition?.timestamp),
+    flashEdge: flashEdge ?? '',
+    states,
+    transitions,
+  }
+}
+
 export function AgentLifecycle({
   currentState,
   lastTransition,
   testId,
 }: AgentLifecycleProps) {
-  const [flashEdge, setFlashEdge] = useState<string | null>(null)
+  const [flashEdge, setFlashEdge] = useState<string | null>(() =>
+    lastTransition ? lifecycleTransitionKey(lastTransition.from, lastTransition.to) : null,
+  )
   const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (lastTransition) {
-      const key = `${lastTransition.from}→${lastTransition.to}`
+      const key = lifecycleTransitionKey(lastTransition.from, lastTransition.to)
       setFlashEdge(key)
       if (flashTimeoutRef.current) {
         clearTimeout(flashTimeoutRef.current)
@@ -90,31 +200,43 @@ export function AgentLifecycle({
   const svgWidth = 420
   const svgHeight = 210
 
-  const stateList = Object.entries(STATES)
+  const summary = summarizeAgentLifecycle(currentState, lastTransition, flashEdge)
 
   return html`
     <div
-      class="rounded-[var(--r-3)] border border-[var(--gray-6)] bg-[var(--gray-1)] p-4"
+      class="max-w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4"
       role="region"
       aria-label="에이전트 생명주기"
+      data-agent-lifecycle
+      data-lifecycle-current-state=${summary.currentState}
+      data-lifecycle-current-label=${summary.currentLabel}
+      data-lifecycle-current-known=${summary.currentKnown}
+      data-lifecycle-state-count=${summary.stateCount}
+      data-lifecycle-transition-count=${summary.transitionCount}
+      data-lifecycle-has-last-transition=${summary.hasLastTransition}
+      data-lifecycle-last-transition-from=${summary.lastTransitionFrom}
+      data-lifecycle-last-transition-to=${summary.lastTransitionTo}
+      data-lifecycle-last-transition-time-label=${summary.lastTransitionTimeLabel}
+      data-lifecycle-flash-edge=${summary.flashEdge}
       data-testid=${testId}
     >
-      <div class="mb-3 flex items-center gap-2">
-        <span class="text-sm font-medium text-[var(--gray-12)]">생명주기 상태</span>
+      <div class="mb-3 flex min-w-0 flex-wrap items-center gap-2">
+        <span class="text-sm font-medium text-[var(--color-fg-primary)]">생명주기 상태</span>
         <span
-          class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-[var(--accent-3)] text-[var(--accent-11)]"
-          aria-label="현재 상태: ${STATES[currentState]?.label ?? currentState}"
+          class="inline-flex max-w-full items-center rounded-full bg-[var(--color-accent-fg)]/12 px-2 py-0.5 text-xs font-medium text-[var(--color-accent-fg)]"
+          aria-label="현재 상태: ${summary.currentLabel}"
         >
-          ${STATES[currentState]?.label ?? currentState}
+          <span class="min-w-0 truncate">${summary.currentLabel}</span>
         </span>
       </div>
 
       <svg
         role="img"
-        aria-label="에이전트 상태 다이어그램. 상태: ${stateList.map(([,s]) => s.label).join(', ')}"
+        aria-label="에이전트 상태 다이어그램. 상태: ${summary.states.map((s) => s.label).join(', ')}"
         viewBox="0 0 ${svgWidth} ${svgHeight}"
-        class="w-full"
+        class="block w-full max-w-full"
         style="max-width:420px;"
+        data-lifecycle-svg
       >
         <defs>
           <marker
@@ -125,7 +247,7 @@ export function AgentLifecycle({
             refY="3.5"
             orient="auto"
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="var(--gray-8)" />
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-border-strong)" />
           </marker>
           <marker
             id="arrowhead-flash"
@@ -135,53 +257,59 @@ export function AgentLifecycle({
             refY="3.5"
             orient="auto"
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="var(--accent-9)" />
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-accent-fg)" />
           </marker>
         </defs>
 
-        ${TRANSITIONS.map((t) => {
-          const from = STATES[t.from]
-          const to = STATES[t.to]
-          if (!from || !to) return null
-          const isFlashing =
-            flashEdge === `${t.from}→${t.to}` ||
-            flashEdge === `${t.to}→${t.from}`
-          const pathD = edgePath(from, to)
-
+        ${summary.transitions.map((transition) => {
           return html`
-            <g key=${t.label}>
+            <g
+              key=${transition.label}
+              data-lifecycle-transition
+              data-lifecycle-transition-key=${transition.key}
+              data-lifecycle-transition-from=${transition.from}
+              data-lifecycle-transition-to=${transition.to}
+              data-lifecycle-transition-label=${transition.label}
+              data-lifecycle-transition-flashing=${transition.flashing}
+            >
               <path
-                d=${pathD}
+                d=${transition.path}
                 fill="none"
-                stroke=${isFlashing ? 'var(--accent-9)' : 'var(--gray-8)'}
-                stroke-width=${isFlashing ? '2.5' : '1.5'}
-                marker-end=${isFlashing ? 'url(#arrowhead-flash)' : 'url(#arrowhead)'}
-                class=${isFlashing ? 'transition-colors duration-[var(--t-slow)]' : ''}
+                stroke=${transition.flashing ? 'var(--color-accent-fg)' : 'var(--color-border-strong)'}
+                stroke-width=${transition.flashing ? '2.5' : '1.5'}
+                marker-end=${transition.flashing ? 'url(#arrowhead-flash)' : 'url(#arrowhead)'}
+                class=${transition.flashing ? 'transition-colors duration-[var(--t-slow)]' : ''}
               />
               <text
-                x=${(from.x + to.x) / 2}
-                y=${(from.y + to.y) / 2 - 8}
+                x=${transition.labelX}
+                y=${transition.labelY}
                 text-anchor="middle"
-                class="text-2xs fill-[var(--gray-10)] select-none"
+                class="select-none text-2xs fill-[var(--color-fg-muted)]"
               >
-                ${t.label}
+                ${transition.label}
               </text>
             </g>
           `
         })}
 
-        ${stateList.map(([key, state]) => {
-          const isCurrent = key === currentState
+        ${summary.states.map((state) => {
           return html`
-            <g key=${key}>
-              ${isCurrent
+            <g
+              key=${state.key}
+              data-lifecycle-state
+              data-lifecycle-state-key=${state.key}
+              data-lifecycle-state-label=${state.label}
+              data-lifecycle-state-index=${state.index}
+              data-lifecycle-state-current=${state.current}
+            >
+              ${state.current
                 ? html`
                     <circle
                       cx=${state.x}
                       cy=${state.y}
                       r="10"
                       fill="none"
-                      stroke="var(--accent-7)"
+                      stroke="var(--color-accent-fg)"
                       stroke-width="1"
                       opacity="0.5"
                     >
@@ -203,13 +331,13 @@ export function AgentLifecycle({
               <circle
                 cx=${state.x}
                 cy=${state.y}
-                class=${nodeClass(isCurrent)}
+                class=${nodeClass(state.current)}
               />
               <text
                 x=${state.x}
                 y=${state.y + 20}
                 text-anchor="middle"
-                class=${nodeLabelClass(isCurrent)}
+                class=${nodeLabelClass(state.current)}
               >
                 ${state.label}
               </text>
@@ -220,10 +348,10 @@ export function AgentLifecycle({
 
       ${lastTransition
         ? html`
-            <div class="mt-2 text-xs text-[var(--gray-10)]">
-              마지막 전환: ${STATES[lastTransition.from]?.label ?? lastTransition.from}
-              → ${STATES[lastTransition.to]?.label ?? lastTransition.to}
-              (${new Date(lastTransition.timestamp).toLocaleTimeString()})
+            <div class="mt-2 break-words text-xs text-[var(--color-fg-muted)]">
+              마지막 전환: ${summary.lastTransitionFromLabel}
+              → ${summary.lastTransitionToLabel}
+              (${summary.lastTransitionTimeLabel})
             </div>
           `
         : null}


### PR DESCRIPTION
## Summary
- Export lifecycle transition/time/summary helpers for deterministic AgentLifecycle state inspection.
- Add root `data-lifecycle-*`, state-node metadata, and transition metadata including flash state.
- Move the lifecycle diagram from legacy gray/accent tokens to semantic dashboard tokens.
- Seed the initial transition flash state from `lastTransition` and separate SVG transition labels to avoid overlap on desktop and mobile.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/agent-lifecycle.test.ts src/components/common/agent-lifecycle.a11y.test.ts` (23 tests)
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` (passes with existing warnings in copy-id-button, virtual-list, fsm-hub)
- `pnpm --dir dashboard run build` (passes with existing Vite warnings)
- Browser QA: `/tmp/masc-agent-lifecycle-summary-0506.png`, `/tmp/masc-agent-lifecycle-summary-0506-mobile.png`

## Browser QA Notes
- Verified known and unknown current-state metadata, state counts, transition counts, active state metadata, and semantic active token classes.
- Verified initial `created→active` flash metadata is present before the one-second expiry.
- Verified long unknown state labels truncate on mobile, SVG scales to viewport, and page/component overflow stays false.
- Verified transition labels do not overlap after placement offsets.
- Removed temporary QA page and `dashboard/node_modules` symlink; stopped QA port `5219`.