### PR TITLE
Surface keeper registry failure blockers

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -863,6 +863,8 @@ describe('fetchKeeperConfig', () => {
         fiber_health: 'healthy',
         presence_keepalive: 'true',
         presence_keepalive_sec: '30',
+        runtime_blocker_class: 'stale_termination_storm',
+        runtime_blocker_summary: 'Stale watchdog terminated 3 keeper cycles.',
         runtime_blocker_continue_gate: 'false',
       },
       runtime_trust: {
@@ -961,6 +963,8 @@ describe('fetchKeeperConfig', () => {
     expect(result.sources.cascade_runtime_json_editable).toBe(false)
     expect(result.metrics.total_cost_usd).toBe(0.12)
     expect(result.runtime.presence_keepalive_sec).toBe(30)
+    expect(result.runtime.runtime_blocker_class).toBe('stale_termination_storm')
+    expect(result.runtime.runtime_blocker_summary).toBe('Stale watchdog terminated 3 keeper cycles.')
     expect(result.active_goal_ids).toEqual(['goal-runtime'])
     expect(result.coordination.active_goal_ids).toEqual(['goal-runtime'])
     expect(result.coordination.active_goals[0]?.title).toBe('Ship runtime clarity')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1981,6 +1981,10 @@ function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['
     case 'tool_required_unsatisfied':
     case 'fiber_unresolved':
     case 'stale_turn_timeout':
+    case 'stale_termination_storm':
+    case 'heartbeat_failures':
+    case 'turn_failures':
+    case 'exception':
       return blockerClass
     default:
       return null

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -121,11 +121,12 @@ describe('mission keeper runtime helpers', () => {
       name: 'stormed',
       status: 'idle',
       runtime_blocker_class: 'stale_termination_storm',
-      runtime_blocker_summary: 'stale_termination_storm',
+      runtime_blocker_summary:
+        'Stale watchdog terminated 8 keeper cycle(s) in the storm window; operator investigation is required before restart.',
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe(
-      'Stale watchdog 종료가 반복되어 restart 전에 원인 확인이 필요합니다.',
+      'Stale watchdog terminated 8 keeper cycle(s) in the storm window; operator investigation is required before restart.',
     )
   })
 

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -95,6 +95,12 @@ describe('mission keeper runtime helpers', () => {
     expect(keeperRuntimeBlockerLabel('no_tool_capable_provider')).toBe('도구 실행 Provider 없음')
     expect(keeperRuntimeBlockerLabel('fiber_unresolved')).toBe('Fiber 미해결')
     expect(keeperRuntimeBlockerLabel('stale_turn_timeout')).toBe('오래된 턴 만료')
+    expect(keeperRuntimeBlockerLabel('stale_termination_storm')).toBe('Stale 종료 폭주')
+    expect(keeperRuntimeBlockerLabel('heartbeat_failures')).toBe('하트비트 실패')
+    expect(keeperRuntimeBlockerLabel('turn_failures')).toBe('턴 실패 반복')
+    expect(keeperRuntimeBlockerLabel('provider_runtime_error')).toBe('Provider 런타임 오류')
+    expect(keeperRuntimeBlockerLabel('tool_required_unsatisfied')).toBe('필수 도구 미충족')
+    expect(keeperRuntimeBlockerLabel('exception')).toBe('런타임 예외')
   })
 
   it('turns raw backend blocker codes into operator-readable hints', () => {
@@ -107,6 +113,19 @@ describe('mission keeper runtime helpers', () => {
 
     expect(keeperRuntimeHint(keeper)).toBe(
       '요구 도구를 실행할 수 있는 provider가 없어 라우팅 또는 tool surface 확인이 필요합니다.',
+    )
+  })
+
+  it('turns registry failure blocker codes into operator-readable hints', () => {
+    const keeper = {
+      name: 'stormed',
+      status: 'idle',
+      runtime_blocker_class: 'stale_termination_storm',
+      runtime_blocker_summary: 'stale_termination_storm',
+    } as Keeper
+
+    expect(keeperRuntimeHint(keeper)).toBe(
+      'Stale watchdog 종료가 반복되어 restart 전에 원인 확인이 필요합니다.',
     )
   })
 

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Keeper } from '../types'
+import type { Keeper, KeeperRuntimeBlockerClass } from '../types'
 import {
   keeperActivityDisplay,
   keeperDisplayModel,
@@ -183,6 +183,37 @@ describe('keeperRuntimeBlockerHint', () => {
       })),
     ).toBe('액션 가능한 신호에 필요한 keeper 도구 호출이 충족되지 않았습니다.')
   })
+
+  const registryBlockerHintCases: Array<[KeeperRuntimeBlockerClass, string]> = [
+    [
+      'stale_termination_storm',
+      'Stale watchdog 종료가 반복되어 restart 전에 원인 확인이 필요합니다.',
+    ],
+    [
+      'heartbeat_failures',
+      '하트비트 실패가 누적되어 keeper 생존 상태 확인이 필요합니다.',
+    ],
+    [
+      'turn_failures',
+      '턴 실패가 반복되어 최근 실행 오류 확인이 필요합니다.',
+    ],
+    [
+      'exception',
+      'Keeper 런타임 예외가 기록되어 로그와 최근 turn 상태 확인이 필요합니다.',
+    ],
+  ]
+
+  it.each(registryBlockerHintCases)(
+    'explains registry-derived blocker %s when no summary is available',
+    (blockerClass, expected) => {
+      expect(
+        keeperRuntimeBlockerHint(makeKeeper({
+          runtime_blocker_class: blockerClass,
+          runtime_blocker_summary: blockerClass,
+        })),
+      ).toBe(expected)
+    },
+  )
 })
 
 describe('keeperActivityDisplay', () => {

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -242,6 +242,10 @@ const runtimeBlockerLabels = {
   tool_required_unsatisfied: '필수 도구 미충족',
   fiber_unresolved: 'Fiber 미해결',
   stale_turn_timeout: '오래된 턴 만료',
+  stale_termination_storm: 'Stale 종료 폭주',
+  heartbeat_failures: '하트비트 실패',
+  turn_failures: '턴 실패 반복',
+  exception: '런타임 예외',
 } satisfies Record<KeeperRuntimeBlockerClass, string>
 
 export function keeperRuntimeBlockerLabel(
@@ -298,6 +302,18 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'stale_turn_timeout') {
     return '오래된 턴 제한 시간이 만료되어 최신 실행 상태 확인이 필요합니다.'
+  }
+  if (blockerClass === 'stale_termination_storm') {
+    return 'Stale watchdog 종료가 반복되어 restart 전에 원인 확인이 필요합니다.'
+  }
+  if (blockerClass === 'heartbeat_failures') {
+    return '하트비트 실패가 누적되어 keeper 생존 상태 확인이 필요합니다.'
+  }
+  if (blockerClass === 'turn_failures') {
+    return '턴 실패가 반복되어 최근 실행 오류 확인이 필요합니다.'
+  }
+  if (blockerClass === 'exception') {
+    return 'Keeper 런타임 예외가 기록되어 로그와 최근 turn 상태 확인이 필요합니다.'
   }
   return null
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -342,6 +342,10 @@ export type KeeperRuntimeBlockerClass =
   | 'tool_required_unsatisfied'
   | 'fiber_unresolved'
   | 'stale_turn_timeout'
+  | 'stale_termination_storm'
+  | 'heartbeat_failures'
+  | 'turn_failures'
+  | 'exception'
 
 export interface KeeperTrustLatestEvent {
   kind: string

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -278,9 +278,59 @@ let runtime_blocker_surface_of_legacy_string reason cls =
   | _ ->
       runtime_blocker_surface_of_typed_class ~summary:reason cls
 
+let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =
+  match kill_class with
+  | Keeper_registry.Idle_turn { stall_seconds } ->
+      Printf.sprintf
+        "idle_turn: no completed turn for %.0fs; stale watchdog stopped the keeper before restart."
+        stall_seconds
+  | Keeper_registry.In_turn_hung { active_seconds; timeout_threshold } ->
+      Printf.sprintf
+        "in_turn_hung: active turn ran for %.0fs past the %.0fs timeout; stale watchdog stopped the keeper."
+        active_seconds timeout_threshold
+  | Keeper_registry.Noop_failure_loop { noop_count } ->
+      Printf.sprintf
+        "noop_failure_loop: %d consecutive turn(s) produced no tool calls; stale watchdog stopped the keeper."
+        noop_count
+
 let runtime_blocker_surface_of_failure_reason
     (reason : Keeper_registry.failure_reason) =
   match reason with
+  | Keeper_registry.Heartbeat_consecutive_failures count ->
+      Some
+        {
+          blocker_class = "heartbeat_failures";
+          summary =
+            Printf.sprintf
+              "Heartbeat failed %d consecutive cycle(s); supervisor recovery is required."
+              count;
+          continue_gate = false;
+        }
+  | Keeper_registry.Turn_consecutive_failures count ->
+      Some
+        {
+          blocker_class = "turn_failures";
+          summary =
+            Printf.sprintf
+              "Keeper turn failed %d consecutive cycle(s); inspect the last runtime error before retry."
+              count;
+          continue_gate = false;
+        }
+  | Keeper_registry.Stale_turn_timeout kill_class ->
+      Some
+        (runtime_blocker_surface_of_typed_class
+           ~summary:(stale_kill_class_summary kill_class)
+           Stale_turn_timeout)
+  | Keeper_registry.Stale_termination_storm { count } ->
+      Some
+        {
+          blocker_class = "stale_termination_storm";
+          summary =
+            Printf.sprintf
+              "Stale watchdog terminated %d keeper cycle(s) in the storm window; operator investigation is required before restart."
+              count;
+          continue_gate = false;
+        }
   | Keeper_registry.Oas_timeout_budget_loop { count } ->
       Some
         (runtime_blocker_surface_of_typed_class
@@ -317,7 +367,19 @@ let runtime_blocker_surface_of_failure_reason
           summary = detail;
           continue_gate = true;
         }
-  | _ -> None
+  | Keeper_registry.Fiber_unresolved ->
+      Some
+        (runtime_blocker_surface_of_typed_class
+           ~summary:
+             "Keeper fiber did not resolve a terminal outcome; supervisor cleanup is required."
+           Fiber_unresolved)
+  | Keeper_registry.Exception detail ->
+      Some
+        {
+          blocker_class = "exception";
+          summary = Printf.sprintf "Keeper runtime exception: %s" detail;
+          continue_gate = false;
+        }
 
 let proactive_runtime_reason_is_current (meta : keeper_meta) =
   let proactive_ts = meta.runtime.proactive_rt.last_ts in

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -748,6 +748,47 @@ let test_runtime_surface_maps_heartbeat_failure_reason () =
   check bool "summary preserves count" true
     (has_substring summary "3 consecutive")
 
+let test_runtime_surface_maps_registry_failure_reason_blockers () =
+  let cases =
+    [
+      ( "turn-failures",
+        KR.Turn_consecutive_failures 4,
+        "turn_failures",
+        "4 consecutive" );
+      ( "fiber-unresolved",
+        KR.Fiber_unresolved,
+        "fiber_unresolved",
+        "did not resolve" );
+      ( "exception",
+        KR.Exception "forced boom",
+        "exception",
+        "forced boom" );
+    ]
+  in
+  List.iter
+    (fun (suffix, reason, expected_class, expected_summary_substring) ->
+       KR.clear ();
+       let meta = make_meta ~name:("runtime-" ^ suffix ^ "-test") () in
+       let config =
+         Coord.default_config
+           ("/tmp/test-keeper-exec-status-" ^ suffix)
+       in
+       ignore (KR.register ~base_path:config.base_path meta.name meta);
+       KR.set_failure_reason ~base_path:config.base_path meta.name
+         (Some reason);
+       let runtime = KSB.runtime_surface_json config meta in
+       let open Yojson.Safe.Util in
+       check string (suffix ^ " runtime blocker class") expected_class
+         (runtime |> member "runtime_blocker_class" |> to_string);
+       let summary =
+         runtime |> member "runtime_blocker_summary" |> to_string
+       in
+       check bool (suffix ^ " summary preserves root cause") true
+         (has_substring summary expected_summary_substring);
+       check bool (suffix ^ " runtime attention needed") true
+         (runtime |> member "needs_attention" |> to_bool))
+    cases
+
 let test_runtime_surface_exposes_social_model_resolution_fields () =
   KR.clear ();
   let base = make_meta ~name:"runtime-social-model-test" () in
@@ -939,6 +980,8 @@ let () =
             test_runtime_surface_maps_stale_termination_storm_failure_reason;
           test_case "runtime surface maps heartbeat failure reason" `Quick
             test_runtime_surface_maps_heartbeat_failure_reason;
+          test_case "runtime surface maps registry failure blockers" `Quick
+            test_runtime_surface_maps_registry_failure_reason_blockers;
           test_case "runtime surface exposes social model fields" `Quick
             test_runtime_surface_exposes_social_model_resolution_fields;
           test_case "runtime surface exposes model display labels" `Quick

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -686,6 +686,68 @@ let test_runtime_surface_suppresses_stale_proactive_timeout_reason () =
   check (option string) "stale proactive blocker class suppressed" None
     (runtime |> member "runtime_blocker_class" |> json_string_opt)
 
+let test_runtime_surface_maps_stale_watchdog_failure_reason () =
+  KR.clear ();
+  let meta = make_meta ~name:"runtime-stale-watchdog-test" () in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-stale-watchdog"
+  in
+  ignore (KR.register ~base_path:config.base_path meta.name meta);
+  KR.set_failure_reason ~base_path:config.base_path meta.name
+    (Some
+       (KR.Stale_turn_timeout
+          (KR.In_turn_hung
+             { active_seconds = 720.0; timeout_threshold = 600.0 })));
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  check string "runtime blocker class" "stale_turn_timeout"
+    (runtime |> member "runtime_blocker_class" |> to_string);
+  let summary = runtime |> member "runtime_blocker_summary" |> to_string in
+  check bool "summary preserves stale kill subclass" true
+    (has_substring summary "in_turn_hung");
+  check bool "runtime attention needed" true
+    (runtime |> member "needs_attention" |> to_bool);
+  check string "runtime next action" "inspect_runtime_blocker"
+    (runtime |> member "next_human_action" |> to_string)
+
+let test_runtime_surface_maps_stale_termination_storm_failure_reason () =
+  KR.clear ();
+  let meta = make_meta ~name:"runtime-stale-storm-test" () in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-stale-storm"
+  in
+  ignore (KR.register ~base_path:config.base_path meta.name meta);
+  KR.set_failure_reason ~base_path:config.base_path meta.name
+    (Some (KR.Stale_termination_storm { count = 8 }));
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  check string "runtime blocker class" "stale_termination_storm"
+    (runtime |> member "runtime_blocker_class" |> to_string);
+  let summary = runtime |> member "runtime_blocker_summary" |> to_string in
+  check bool "summary preserves storm count" true
+    (has_substring summary "8 keeper cycle");
+  check bool "runtime attention needed" true
+    (runtime |> member "needs_attention" |> to_bool);
+  check string "runtime attention reason" "runtime_blocked"
+    (runtime |> member "attention_reason" |> to_string)
+
+let test_runtime_surface_maps_heartbeat_failure_reason () =
+  KR.clear ();
+  let meta = make_meta ~name:"runtime-heartbeat-failure-test" () in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-heartbeat-failure"
+  in
+  ignore (KR.register ~base_path:config.base_path meta.name meta);
+  KR.set_failure_reason ~base_path:config.base_path meta.name
+    (Some (KR.Heartbeat_consecutive_failures 3));
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  check string "runtime blocker class" "heartbeat_failures"
+    (runtime |> member "runtime_blocker_class" |> to_string);
+  let summary = runtime |> member "runtime_blocker_summary" |> to_string in
+  check bool "summary preserves count" true
+    (has_substring summary "3 consecutive")
+
 let test_runtime_surface_exposes_social_model_resolution_fields () =
   KR.clear ();
   let base = make_meta ~name:"runtime-social-model-test" () in
@@ -869,6 +931,14 @@ let () =
           test_case "runtime surface suppresses stale proactive timeout blocker"
             `Quick
             test_runtime_surface_suppresses_stale_proactive_timeout_reason;
+          test_case "runtime surface maps stale watchdog failure reason"
+            `Quick
+            test_runtime_surface_maps_stale_watchdog_failure_reason;
+          test_case "runtime surface maps stale termination storm failure reason"
+            `Quick
+            test_runtime_surface_maps_stale_termination_storm_failure_reason;
+          test_case "runtime surface maps heartbeat failure reason" `Quick
+            test_runtime_surface_maps_heartbeat_failure_reason;
           test_case "runtime surface exposes social model fields" `Quick
             test_runtime_surface_exposes_social_model_resolution_fields;
           test_case "runtime surface exposes model display labels" `Quick


### PR DESCRIPTION
## Why

#10512 tracks the case where stuck keepers have different root causes but the dashboard does not always get a structured reason. Current `main` already surfaces persisted `runtime.last_blocker_class`, but registry-only failure reasons could still be invisible while they lived only in `Keeper_registry.last_failure_reason`.

## What Changed

- Map registry failure reasons into `runtime_blocker_class` / `runtime_blocker_summary`:
  - `stale_turn_timeout` with the stale subclass in the summary.
  - `stale_termination_storm`.
  - `heartbeat_failures` and `turn_failures`.
  - `fiber_unresolved` and runtime `exception`.
- Extend dashboard runtime-blocker types, labels, and hints for those backend classes.
- Add regression coverage for registry-derived blocker projection and dashboard labels/hints.

## Validation

- `git diff --check`
- `pnpm --dir dashboard install --offline --ignore-scripts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/mission-agent-cards.test.ts --no-file-parallelism --maxWorkers=1`

OCaml focused verification was attempted with:

- `scripts/dune-local.sh build test/test_keeper_exec_status.exe`

It was blocked by shared switch contention: another worktree held `/tmp/me-opam-switch.lock` and `/tmp/me-dune-local.lock`, and the shared `agent_sdk` pin was flipped between `0.190.25` and a newer OAS worktree while this build waited. I ran `scripts/opam-pin-external-deps.sh --install` to restore this branch's expected `agent_sdk.0.190.25`, but the focused build was still queued behind another idle `dune exec` lock holder, so this PR remains draft and CI should be treated as the OCaml verification surface.

## Review Focus

- Whether the new registry-failure blocker classes are the right operator-facing taxonomy for #10512.
- Whether `stale_turn_timeout` summaries carry enough subclass detail (`idle_turn`, `in_turn_hung`, `noop_failure_loop`) without adding more dashboard schema.
