### PR TITLE
fix(telemetry): observe unified source read failures

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -716,6 +716,12 @@ let metric_codex_cli_mcp_tool_omission =
 let metric_telemetry_coverage_gap =
   "masc_telemetry_coverage_gap_total"
 
+(* Phase 0 telemetry fan-in: source discovery/read failures must not collapse
+   into an indistinguishable empty dashboard. Labels are bounded by the
+   Telemetry_unified.source enum and a small site vocabulary. *)
+let metric_telemetry_unified_source_read_failures =
+  "masc_telemetry_unified_source_read_failures_total"
+
 (* #10358 (c1): observability for the silent [Effect.Unhandled] catch-all
    in [lib/coord.ml] [observe_agent_lifecycle] / [observe_task_transition_event] /
    [Keeper_accountability.record_task_transition].  Those three try/with
@@ -2089,6 +2095,13 @@ let init () =
      stale_reason. Any positive rate means a telemetry lane is missing, \
      stale, or failed to append and dashboards should mark the source \
      coverage_gap."
+    Counter;
+  add metric_telemetry_unified_source_read_failures
+    "Total telemetry unified source discovery/read failures. Labels: \
+     source=keeper_metric|agent_event|tool_call_io|trajectory_tool_call|\
+     tool_usage|oas_event|execution_receipt|goal_event|tool_metric and \
+     site=<bounded read/discovery call-site>. Any positive rate means the \
+     dashboard fan-in returned partial data instead of a true empty source."
     Counter;
   add metric_coord_telemetry_drop
     "Total times a Coord lifecycle/transition hook dropped its Audit_log \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -375,6 +375,11 @@ val metric_telemetry_coverage_gap : string
     alertable pair to the durable
     [.masc/telemetry-coverage-gaps/YYYY-MM/DD.jsonl] store. *)
 
+val metric_telemetry_unified_source_read_failures : string
+(** Total telemetry unified source discovery/read failures. Labels:
+    [source] is {!Telemetry_unified.source_to_string}; [site] is a bounded
+    read/discovery call-site vocabulary. *)
+
 val metric_coord_telemetry_drop : string
 (** #10358 (c1): total times [lib/coord.ml]'s lifecycle hook caught
     [Stdlib.Effect.Unhandled] and dropped its Audit_log + Telemetry

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -64,6 +64,27 @@ let all_sources =
   ; Tool_metric
   ]
 
+let observe_source_read_failure source ~site ~error =
+  let source = source_to_string source in
+  Prometheus.inc_counter
+    Prometheus.metric_telemetry_unified_source_read_failures
+    ~labels:[ ("source", source); ("site", site) ]
+    ();
+  Log.Telemetry.warn
+    "telemetry_unified source read failure: source=%s site=%s error=%s"
+    source site error
+
+let observe_source_read_failure_exn source ~site exn =
+  observe_source_read_failure source ~site ~error:(Printexc.to_string exn)
+
+let protect_source_read source ~site ~default f =
+  match f () with
+  | value -> value
+  | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+  | exception exn ->
+    observe_source_read_failure_exn source ~site exn;
+    default
+
 type read_result = {
   entries : Yojson.Safe.t list;
   total_matching_entries : int;
@@ -132,14 +153,36 @@ let source_durable_store ~masc_root ~base_path = function
       | Some dir -> dir
       | None -> "")
 
+type store_dir_state =
+  | Store_missing
+  | Store_directory
+  | Store_invalid
+
+let classify_store_dir source ~site dir =
+  match Sys.file_exists dir with
+  | false -> Store_missing
+  | true ->
+    (match Sys.is_directory dir with
+     | true -> Store_directory
+     | false ->
+       observe_source_read_failure source ~site
+         ~error:(Printf.sprintf "%s exists but is not a directory" dir);
+       Store_invalid)
+  | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+  | exception exn ->
+    observe_source_read_failure_exn source ~site exn;
+    Store_invalid
+
 (** Discover all keeper metric directories under [masc_root/keepers/]. *)
 let discover_keeper_metric_dirs masc_root : (string * string) list =
   let keepers_dir = Filename.concat masc_root "keepers" in
-  if not (Sys.file_exists keepers_dir) then []
-  else
+  match classify_store_dir Keeper_metric ~site:"discover_keeper_metric_root"
+          keepers_dir with
+  | Store_missing | Store_invalid -> []
+  | Store_directory ->
     let entries =
-      Safe_ops.protect ~default:[] (fun () ->
-        Array.to_list (Sys.readdir keepers_dir))
+      protect_source_read Keeper_metric ~site:"discover_keeper_metric_dirs"
+        ~default:[] (fun () -> Array.to_list (Sys.readdir keepers_dir))
     in
     List.filter_map (fun name ->
       let metrics_dir = Filename.concat keepers_dir (name ^ "/metrics") in
@@ -147,31 +190,41 @@ let discover_keeper_metric_dirs masc_root : (string * string) list =
       else None
     ) entries
 
-let is_directory path =
-  Safe_ops.protect ~default:false (fun () ->
+let is_directory source ~site path =
+  protect_source_read source ~site ~default:false (fun () ->
     Sys.file_exists path && Sys.is_directory path)
 
-let is_jsonl_file path =
-  Safe_ops.protect ~default:false (fun () ->
+let is_jsonl_file source ~site path =
+  protect_source_read source ~site ~default:false (fun () ->
     Sys.file_exists path && (not (Sys.is_directory path))
     && Filename.check_suffix path ".jsonl")
 
 let discover_trajectory_keeper_dirs masc_root : (string * string) list =
   let trajectories_root = Filename.concat masc_root "trajectories" in
-  if not (is_directory trajectories_root) then []
-  else
-    Safe_ops.protect ~default:[] (fun () ->
+  match classify_store_dir Trajectory_tool_call
+          ~site:"discover_trajectory_root" trajectories_root with
+  | Store_missing | Store_invalid -> []
+  | Store_directory ->
+    protect_source_read Trajectory_tool_call
+      ~site:"discover_trajectory_keeper_dirs" ~default:[] (fun () ->
       Sys.readdir trajectories_root
       |> Array.to_list
       |> List.filter_map (fun name ->
            let dir = Filename.concat trajectories_root name in
-           if is_directory dir then Some (name, dir) else None))
+           if
+             is_directory Trajectory_tool_call
+               ~site:"discover_trajectory_keeper_dir_stat" dir
+           then Some (name, dir)
+           else None))
 
 let discover_execution_receipt_dirs masc_root : (string * string) list =
   let keepers_dir = Filename.concat masc_root "keepers" in
-  if not (is_directory keepers_dir) then []
-  else
-    Safe_ops.protect ~default:[] (fun () ->
+  match classify_store_dir Execution_receipt
+          ~site:"discover_execution_receipt_root" keepers_dir with
+  | Store_missing | Store_invalid -> []
+  | Store_directory ->
+    protect_source_read Execution_receipt
+      ~site:"discover_execution_receipt_dirs" ~default:[] (fun () ->
       Sys.readdir keepers_dir
       |> Array.to_list
       |> List.filter_map (fun name ->
@@ -179,7 +232,11 @@ let discover_execution_receipt_dirs masc_root : (string * string) list =
              Filename.concat (Filename.concat keepers_dir name)
                "execution-receipts"
            in
-           if is_directory dir then Some (name, dir) else None))
+           if
+             is_directory Execution_receipt
+               ~site:"discover_execution_receipt_dir_stat" dir
+           then Some (name, dir)
+           else None))
 
 let trajectory_tool_call_json = function
   | `Assoc fields -> (
@@ -267,15 +324,15 @@ let latest_ts_of_entries (entries : Yojson.Safe.t list) : float option =
       if ts > 0.0 then max_ts_opt acc ts else acc)
     None entries
 
-let latest_store_ts dir label : float option =
+let latest_store_ts source dir label : float option =
   if not (Sys.file_exists dir) then None
   else
     match Dated_jsonl.create ~base_dir:dir () with
     | store -> latest_ts_of_entries (Dated_jsonl.read_recent store 64)
     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
     | exception exn ->
-      Log.Telemetry.warn "latest_store_ts: %s store open failed: %s" label
-        (Printexc.to_string exn);
+      observe_source_read_failure_exn source ~site:"latest_store_ts" exn;
+      Log.Telemetry.warn "latest_store_ts: %s store open failed" label;
       None
 
 let sort_newest_first entries =
@@ -298,7 +355,7 @@ let freshness_fields ~now latest_ts =
     [ ("latest_ts_unix", `Null); ("latest_ts_iso", `Null); ("latest_age_s", `Null) ]
 
 let source_health_fields ~now ~exists ~entry_count ~latest_ts ~freshness_slo_s
-    ?(optional_when_missing = false) ?coverage_gap () =
+    ?(optional_when_missing = false) ?(read_error = false) ?coverage_gap () =
   match coverage_gap with
   | Some gap ->
     [
@@ -315,7 +372,8 @@ let source_health_fields ~now ~exists ~entry_count ~latest_ts ~freshness_slo_s
          dashboard fatigue; report a neutral [not_yet] with an explanatory
          reason instead. Real write failures still surface via [coverage_gap]
          regardless of this flag. *)
-      if not exists && optional_when_missing then ("not_yet", "no_entries_yet")
+      if read_error then ("error", "read_failed")
+      else if not exists && optional_when_missing then ("not_yet", "no_entries_yet")
       else if not exists then ("missing", "store_missing")
       else if entry_count = 0 then ("empty", "no_entries")
       else
@@ -558,8 +616,9 @@ let matches_scope ?session_id ?operation_id ?worker_run_id (json : Yojson.Safe.t
 (* ── Read from a single fixed-path source ───────────── *)
 
 let read_fixed_source dir source ~n ?since_ts ?until_ts () : Yojson.Safe.t list =
-  if not (Sys.file_exists dir) then []
-  else
+  match classify_store_dir source ~site:"read_fixed_source_dir" dir with
+  | Store_missing | Store_invalid -> []
+  | Store_directory ->
     match Dated_jsonl.create ~base_dir:dir () with
     | store ->
       let entries =
@@ -574,8 +633,9 @@ let read_fixed_source dir source ~n ?since_ts ?until_ts () : Yojson.Safe.t list 
       List.map (tag_entry source) entries
     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
     | exception exn ->
-      Log.Telemetry.warn "read_fixed_source: %s store open failed: %s"
-        (source_to_string source) (Printexc.to_string exn);
+      observe_source_read_failure_exn source ~site:"read_fixed_source" exn;
+      Log.Telemetry.warn "read_fixed_source: %s store open failed"
+        (source_to_string source);
       []
 
 (* ── Read keeper metrics (per-keeper directories) ───── *)
@@ -655,16 +715,22 @@ let read_execution_receipts ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
+        observe_source_read_failure_exn Execution_receipt
+          ~site:"read_execution_receipts" exn;
         Log.Telemetry.warn
-          "read_execution_receipts: store open failed for %s: %s"
-          dir (Printexc.to_string exn);
+          "read_execution_receipts: store open failed for %s" dir;
         [])
     dirs
 
 let read_trajectory_file path ?since_ts ?until_ts () =
-  if not (is_jsonl_file path) then []
+  if
+    not
+      (is_jsonl_file Trajectory_tool_call
+         ~site:"read_trajectory_file_stat" path)
+  then []
   else
-    try
+    protect_source_read Trajectory_tool_call ~site:"read_trajectory_file"
+      ~default:[] (fun () ->
       Fs_compat.load_file path
       |> String.split_on_char '\n'
       |> List.filter_map (fun line ->
@@ -677,8 +743,10 @@ let read_trajectory_file path ?since_ts ?until_ts () =
                   && within_requested_window ?since_ts ?until_ts json
                then Some json
                else None
-             with Yojson.Json_error _ -> None)
-    with Sys_error _ -> []
+             with Yojson.Json_error msg ->
+               observe_source_read_failure Trajectory_tool_call
+                 ~site:"read_trajectory_file_parse" ~error:msg;
+               None))
 
 let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
     : Yojson.Safe.t list =
@@ -691,7 +759,8 @@ let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
   let entries =
     List.concat_map
       (fun (_name, dir) ->
-        Safe_ops.protect ~default:[] (fun () ->
+        protect_source_read Trajectory_tool_call
+          ~site:"read_trajectory_tool_calls_readdir" ~default:[] (fun () ->
           Sys.readdir dir
           |> Array.to_list
           |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
@@ -713,7 +782,8 @@ let read_goal_events ~masc_root ?since_ts ?until_ts ~n () : Yojson.Safe.t list =
   if not (Sys.file_exists path) then []
   else
     let entries =
-      Safe_ops.protect ~default:[] (fun () ->
+      protect_source_read Goal_event ~site:"read_goal_events" ~default:[]
+        (fun () ->
         Fs_compat.load_jsonl path
         |> List.filter (within_requested_window ?since_ts ?until_ts))
     in
@@ -805,14 +875,17 @@ let count_fixed_source_entries ~masc_root ~base_path source : int =
   match fixed_store_dir ~masc_root ~base_path source with
   | None -> 0
   | Some dir ->
-    if not (Sys.file_exists dir) then 0
-    else
+    match classify_store_dir source ~site:"count_fixed_source_entries_dir" dir with
+    | Store_missing | Store_invalid -> 0
+    | Store_directory ->
       (match Dated_jsonl.create ~base_dir:dir () with
        | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
        | exception exn ->
-         Log.Telemetry.warn "count_source_entries: %s store open failed: %s"
-           (source_to_string source) (Printexc.to_string exn);
+         observe_source_read_failure_exn source
+           ~site:"count_fixed_source_entries" exn;
+         Log.Telemetry.warn "count_source_entries: %s store open failed"
+           (source_to_string source);
          0)
 
 let execution_receipt_summary_stats ~masc_root =
@@ -822,16 +895,17 @@ let execution_receipt_summary_stats ~masc_root =
          match Dated_jsonl.create ~base_dir:dir () with
          | store ->
            let count = Dated_jsonl.count_entries store in
-           let latest = latest_store_ts dir "execution_receipt" in
+           let latest = latest_store_ts Execution_receipt dir "execution_receipt" in
            ( count_acc + count,
              match latest with
              | Some ts -> max_ts_opt latest_acc ts
              | None -> latest_acc )
          | exception (Eio.Cancel.Cancelled _ as e) -> raise e
          | exception exn ->
+           observe_source_read_failure_exn Execution_receipt
+             ~site:"execution_receipt_summary_stats" exn;
            Log.Telemetry.warn
-             "execution_receipt_summary_stats: store open failed for %s: %s"
-             dir (Printexc.to_string exn);
+             "execution_receipt_summary_stats: store open failed for %s" dir;
            (count_acc, latest_acc))
        (0, None)
 
@@ -840,7 +914,9 @@ let trajectory_tool_call_summary_stats ~masc_root =
   |> List.fold_left
        (fun (count_acc, latest_acc) (_name, dir) ->
          let entries =
-           Safe_ops.protect ~default:[] (fun () ->
+           protect_source_read Trajectory_tool_call
+             ~site:"trajectory_tool_call_summary_readdir" ~default:[]
+             (fun () ->
              Sys.readdir dir
              |> Array.to_list
              |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
@@ -858,7 +934,8 @@ let goal_event_summary_stats ~masc_root =
   if not (Sys.file_exists path) then (0, None)
   else
     let entries =
-      Safe_ops.protect ~default:[] (fun () -> Fs_compat.load_jsonl path)
+      protect_source_read Goal_event ~site:"goal_event_summary_stats"
+        ~default:[] (fun () -> Fs_compat.load_jsonl path)
     in
     (List.length entries, latest_ts_of_entries entries)
 
@@ -873,15 +950,18 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
        | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
        | exception exn ->
-         Log.Telemetry.warn "summary_json: keeper %s store open failed: %s"
-           name (Printexc.to_string exn);
+         observe_source_read_failure_exn Keeper_metric
+           ~site:"summary_keeper_count" exn;
+         Log.Telemetry.warn "summary_json: keeper %s store open failed" name;
          0)
     ) 0 keeper_dirs
   in
   let keeper_latest_ts =
     List.fold_left
       (fun acc (name, dir) ->
-        match latest_store_ts dir (Printf.sprintf "keeper %s" name) with
+        match
+          latest_store_ts Keeper_metric dir (Printf.sprintf "keeper %s" name)
+        with
         | Some ts -> max_ts_opt acc ts
         | None -> acc)
       None keeper_dirs
@@ -934,9 +1014,20 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
     | Trajectory_tool_call ->
       let trajectories_root = Filename.concat masc_root "trajectories" in
       let dirs = discover_trajectory_keeper_dirs masc_root in
-      let exists = is_directory trajectories_root in
+      let dir_state =
+        classify_store_dir Trajectory_tool_call
+          ~site:"summary_trajectory_root" trajectories_root
+      in
+      let exists = match dir_state with
+        | Store_directory | Store_invalid -> true
+        | Store_missing -> false
+      in
+      let read_error = match dir_state with
+        | Store_invalid -> true
+        | Store_missing | Store_directory -> false
+      in
       let count, latest_ts =
-        if exists then trajectory_tool_call_summary_stats ~masc_root
+        if dir_state = Store_directory then trajectory_tool_call_summary_stats ~masc_root
         else (0, None)
       in
       ( `Assoc
@@ -952,14 +1043,25 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
               ~freshness_slo_s
               ~optional_when_missing:(source_optional_when_missing source)
-              ?coverage_gap ()),
+              ~read_error ?coverage_gap ()),
         count )
     | Execution_receipt ->
       let keepers_root = Filename.concat masc_root "keepers" in
       let dirs = discover_execution_receipt_dirs masc_root in
-      let exists = is_directory keepers_root in
+      let dir_state =
+        classify_store_dir Execution_receipt
+          ~site:"summary_execution_receipt_root" keepers_root
+      in
+      let exists = match dir_state with
+        | Store_directory | Store_invalid -> true
+        | Store_missing -> false
+      in
+      let read_error = match dir_state with
+        | Store_invalid -> true
+        | Store_missing | Store_directory -> false
+      in
       let count, latest_ts =
-        if exists then execution_receipt_summary_stats ~masc_root
+        if dir_state = Store_directory then execution_receipt_summary_stats ~masc_root
         else (0, None)
       in
       ( `Assoc
@@ -975,7 +1077,7 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
               ~freshness_slo_s
               ~optional_when_missing:(source_optional_when_missing source)
-              ?coverage_gap ()),
+              ~read_error ?coverage_gap ()),
         count )
     | Goal_event ->
       let path = goal_events_path ~masc_root in
@@ -1001,10 +1103,27 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
     | _ ->
       let dir = match fixed_store_dir ~masc_root ~base_path source with
         | Some d -> d | None -> "" in
-      let exists = dir <> "" && Sys.file_exists dir in
-      let count = if exists then count_fixed_source_entries ~masc_root ~base_path source else 0 in
+      let dir_state =
+        if dir = "" then Store_missing
+        else classify_store_dir source ~site:"summary_fixed_source_dir" dir
+      in
+      let exists = match dir_state with
+        | Store_directory | Store_invalid -> true
+        | Store_missing -> false
+      in
+      let read_error = match dir_state with
+        | Store_invalid -> true
+        | Store_missing | Store_directory -> false
+      in
+      let count =
+        if dir_state = Store_directory then
+          count_fixed_source_entries ~masc_root ~base_path source
+        else 0
+      in
       let latest_ts =
-        if exists then latest_store_ts dir (source_to_string source) else None
+        if dir_state = Store_directory then
+          latest_store_ts source dir (source_to_string source)
+        else None
       in
       ( `Assoc
           ([
@@ -1018,7 +1137,7 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
               ~freshness_slo_s
               ~optional_when_missing:(source_optional_when_missing source)
-              ?coverage_gap ()),
+              ~read_error ?coverage_gap ()),
         count )
   in
   let source_summaries = List.map source_json_and_count all_sources in

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -199,23 +199,25 @@ let is_jsonl_file source ~site path =
     Sys.file_exists path && (not (Sys.is_directory path))
     && Filename.check_suffix path ".jsonl")
 
+let discover_trajectory_keeper_dirs_in_root trajectories_root =
+  protect_source_read Trajectory_tool_call
+    ~site:"discover_trajectory_keeper_dirs" ~default:[] (fun () ->
+    Sys.readdir trajectories_root
+    |> Array.to_list
+    |> List.filter_map (fun name ->
+         let dir = Filename.concat trajectories_root name in
+         if
+           is_directory Trajectory_tool_call
+             ~site:"discover_trajectory_keeper_dir_stat" dir
+         then Some (name, dir)
+         else None))
+
 let discover_trajectory_keeper_dirs masc_root : (string * string) list =
   let trajectories_root = Filename.concat masc_root "trajectories" in
   match classify_store_dir Trajectory_tool_call
           ~site:"discover_trajectory_root" trajectories_root with
   | Store_missing | Store_invalid -> []
-  | Store_directory ->
-    protect_source_read Trajectory_tool_call
-      ~site:"discover_trajectory_keeper_dirs" ~default:[] (fun () ->
-      Sys.readdir trajectories_root
-      |> Array.to_list
-      |> List.filter_map (fun name ->
-           let dir = Filename.concat trajectories_root name in
-           if
-             is_directory Trajectory_tool_call
-               ~site:"discover_trajectory_keeper_dir_stat" dir
-           then Some (name, dir)
-           else None))
+  | Store_directory -> discover_trajectory_keeper_dirs_in_root trajectories_root
 
 let discover_execution_receipt_dirs masc_root : (string * string) list =
   let keepers_dir = Filename.concat masc_root "keepers" in
@@ -634,8 +636,6 @@ let read_fixed_source dir source ~n ?since_ts ?until_ts () : Yojson.Safe.t list 
     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
     | exception exn ->
       observe_source_read_failure_exn source ~site:"read_fixed_source" exn;
-      Log.Telemetry.warn "read_fixed_source: %s store open failed"
-        (source_to_string source);
       []
 
 (* ── Read keeper metrics (per-keeper directories) ───── *)
@@ -731,22 +731,31 @@ let read_trajectory_file path ?since_ts ?until_ts () =
   else
     protect_source_read Trajectory_tool_call ~site:"read_trajectory_file"
       ~default:[] (fun () ->
-      Fs_compat.load_file path
-      |> String.split_on_char '\n'
-      |> List.filter_map (fun line ->
-           let line = String.trim line in
-           if line = "" then None
-           else
-             try
-               let json = Yojson.Safe.from_string line in
-               if trajectory_tool_call_json json
-                  && within_requested_window ?since_ts ?until_ts json
-               then Some json
-               else None
-             with Yojson.Json_error msg ->
-               observe_source_read_failure Trajectory_tool_call
-                 ~site:"read_trajectory_file_parse" ~error:msg;
-               None))
+      let parse_error_count = ref 0 in
+      let entries =
+        Fs_compat.load_file path
+        |> String.split_on_char '\n'
+        |> List.filter_map (fun line ->
+             let line = String.trim line in
+             if line = "" then None
+             else
+               try
+                 let json = Yojson.Safe.from_string line in
+                 if trajectory_tool_call_json json
+                    && within_requested_window ?since_ts ?until_ts json
+                 then Some json
+                 else None
+               with Yojson.Json_error _ ->
+                 incr parse_error_count;
+                 None)
+      in
+      if !parse_error_count > 0 then
+        observe_source_read_failure Trajectory_tool_call
+          ~site:"read_trajectory_file_parse"
+          ~error:
+            (Printf.sprintf "%s has %d malformed JSONL line(s)" path
+               !parse_error_count);
+      entries)
 
 let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
     : Yojson.Safe.t list =
@@ -1013,10 +1022,15 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
         keeper_total )
     | Trajectory_tool_call ->
       let trajectories_root = Filename.concat masc_root "trajectories" in
-      let dirs = discover_trajectory_keeper_dirs masc_root in
       let dir_state =
         classify_store_dir Trajectory_tool_call
           ~site:"summary_trajectory_root" trajectories_root
+      in
+      let dirs =
+        match dir_state with
+        | Store_directory ->
+            discover_trajectory_keeper_dirs_in_root trajectories_root
+        | Store_missing | Store_invalid -> []
       in
       let exists = match dir_state with
         | Store_directory | Store_invalid -> true

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -275,6 +275,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_auth_credential_token_duplicate;
   check_registered Prometheus.metric_auth_credential_token_rotated;
   check_registered Prometheus.metric_telemetry_coverage_gap;
+  check_registered Prometheus.metric_telemetry_unified_source_read_failures;
   check_registered Prometheus.metric_coord_telemetry_drop
 
 let test_distributed_lock_metric_registered () =

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -848,7 +848,9 @@ let test_goal_event_source_and_summary () =
     (List.hd entries |> json_string_field "source");
   Alcotest.(check string) "newest event" "transition_completed"
     (List.hd entries |> json_string_field "event_type");
-  let summary = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  let summary =
+    Telemetry_unified.summary_json ~base_path:dir ~masc_root:root ()
+  in
   let goal_summary = source_summary "goal_event" summary in
   Alcotest.(check int) "goal event count" 2
     (json_int_field "entry_count" goal_summary);
@@ -945,6 +947,72 @@ let test_keeper_discovery_bad_root_is_observed () =
   Alcotest.(check (float 0.001)) "discovery failure counter increments"
     (before +. 1.0)
     (source_read_failure_metric "keeper_metric" "discover_keeper_metric_root")
+
+let test_trajectory_parse_errors_are_aggregated_per_file () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_bad_trajectory_rows" in
+  let root = masc_root dir in
+  let trajectory_dir = Filename.concat root "trajectories/alice" in
+  Fs_compat.mkdir_p trajectory_dir;
+  let path = Filename.concat trajectory_dir "trace-bad.jsonl" in
+  Fs_compat.append_file path
+    (String.concat "\n"
+       [
+         "{not-json";
+         Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("ts", `Float 2000.0);
+                ("tool_name", `String "keeper_bash");
+              ]);
+         "{still-not-json";
+         "";
+       ]);
+  let before =
+    source_read_failure_metric "trajectory_tool_call"
+      "read_trajectory_file_parse"
+  in
+  let entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:root
+      ~sources:[ Telemetry_unified.Trajectory_tool_call ] ()
+  in
+  Alcotest.(check int) "valid trajectory row still read" 1
+    (List.length entries);
+  Alcotest.(check (float 0.001)) "parse failures counted once per file"
+    (before +. 1.0)
+    (source_read_failure_metric "trajectory_tool_call"
+       "read_trajectory_file_parse")
+
+let test_summary_bad_trajectory_root_observed_once () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_bad_trajectory_root" in
+  let root = masc_root dir in
+  Fs_compat.mkdir_p root;
+  Fs_compat.append_file (Filename.concat root "trajectories")
+    "not a directory\n";
+  let before_summary =
+    source_read_failure_metric "trajectory_tool_call"
+      "summary_trajectory_root"
+  in
+  let before_discover =
+    source_read_failure_metric "trajectory_tool_call"
+      "discover_trajectory_root"
+  in
+  let summary = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  let trajectory_summary = source_summary "trajectory_tool_call" summary in
+  Alcotest.(check string) "bad trajectory root is error"
+    "error"
+    (json_string_field "health" trajectory_summary);
+  Alcotest.(check (float 0.001)) "summary root counted once"
+    (before_summary +. 1.0)
+    (source_read_failure_metric "trajectory_tool_call"
+       "summary_trajectory_root");
+  Alcotest.(check (float 0.001)) "discovery root not double-counted"
+    before_discover
+    (source_read_failure_metric "trajectory_tool_call"
+       "discover_trajectory_root")
 
 let test_summary_surfaces_coverage_gaps () =
   Eio_main.run @@ fun env ->
@@ -1102,6 +1170,9 @@ let () =
             test_fixed_source_bad_store_type_is_observed;
           Alcotest.test_case "keeper discovery bad root is observed" `Quick
             test_keeper_discovery_bad_root_is_observed;
+          Alcotest.test_case "trajectory parse failures are aggregated"
+            `Quick
+            test_trajectory_parse_errors_are_aggregated_per_file;
         ] );
       ( "summary",
         [
@@ -1120,6 +1191,8 @@ let () =
             test_goal_event_missing_reports_not_yet;
           Alcotest.test_case "tool_call_io missing stays missing" `Quick
             test_tool_call_io_missing_still_reports_missing;
+          Alcotest.test_case "bad trajectory root observed once" `Quick
+            test_summary_bad_trajectory_root_observed_once;
           Alcotest.test_case "counts all rows beyond recent cap" `Quick
             test_summary_counts_all_entries_beyond_recent_cap;
         ] );

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -79,6 +79,12 @@ let source_summary source_name = function
       | _ -> Alcotest.fail "expected sources")
   | _ -> Alcotest.fail "expected summary object"
 
+let source_read_failure_metric source site =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_telemetry_unified_source_read_failures
+    ~labels:[ ("source", source); ("site", site) ]
+    ()
+
 (* ── Source roundtrip ────────────────────────────── *)
 
 let test_source_roundtrip () =
@@ -895,6 +901,51 @@ let test_tool_call_io_missing_still_reports_missing () =
     "store_missing"
     (json_string_field "stale_reason" tool_summary)
 
+let test_fixed_source_bad_store_type_is_observed () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_bad_fixed_source" in
+  let root = masc_root dir in
+  Fs_compat.mkdir_p root;
+  let telemetry_path = Filename.concat root "telemetry" in
+  Fs_compat.append_file telemetry_path "not a directory\n";
+  let before = source_read_failure_metric "agent_event" "read_fixed_source_dir" in
+  let entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:root
+      ~sources:[ Telemetry_unified.Agent_event ] ()
+  in
+  Alcotest.(check int) "bad store reads as empty" 0 (List.length entries);
+  Alcotest.(check (float 0.001)) "read failure counter increments"
+    (before +. 1.0)
+    (source_read_failure_metric "agent_event" "read_fixed_source_dir");
+  let summary = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  let agent_summary = source_summary "agent_event" summary in
+  Alcotest.(check string) "bad store is an error, not empty"
+    "error"
+    (json_string_field "health" agent_summary);
+  Alcotest.(check string) "stale reason is read failure"
+    "read_failed"
+    (json_string_field "stale_reason" agent_summary)
+
+let test_keeper_discovery_bad_root_is_observed () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_bad_keeper_root" in
+  let root = masc_root dir in
+  Fs_compat.mkdir_p root;
+  Fs_compat.append_file (Filename.concat root "keepers") "not a directory\n";
+  let before =
+    source_read_failure_metric "keeper_metric" "discover_keeper_metric_root"
+  in
+  let entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:root
+      ~sources:[ Telemetry_unified.Keeper_metric ] ()
+  in
+  Alcotest.(check int) "bad keeper root reads as empty" 0 (List.length entries);
+  Alcotest.(check (float 0.001)) "discovery failure counter increments"
+    (before +. 1.0)
+    (source_read_failure_metric "keeper_metric" "discover_keeper_metric_root")
+
 let test_summary_surfaces_coverage_gaps () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1047,6 +1098,10 @@ let () =
             test_scope_filter_matches_runtime_contract_fields;
           Alcotest.test_case "goal events" `Quick
             test_goal_event_source_and_summary;
+          Alcotest.test_case "fixed source bad store type is observed" `Quick
+            test_fixed_source_bad_store_type_is_observed;
+          Alcotest.test_case "keeper discovery bad root is observed" `Quick
+            test_keeper_discovery_bad_root_is_observed;
         ] );
       ( "summary",
         [


### PR DESCRIPTION
## Summary
- add `masc_telemetry_unified_source_read_failures_total{source,site}` for Telemetry_unified discovery/read failures
- replace silent `Safe_ops.protect` fallbacks in telemetry fan-in paths with bounded metrics plus WARN logs while preserving empty-result fallback behavior
- mark invalid fixed-source store shape as `health: error` / `stale_reason: read_failed` in telemetry summaries

## Verification
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_telemetry_unified.exe test/test_prometheus_coverage.exe`
- `./_build/default/test/test_telemetry_unified.exe`
- `./_build/default/test/test_prometheus_coverage.exe`
- `git diff --check`