### PR TITLE
feat(goal-loop): add observe metrics contract

### DIFF
--- a/docs/observability/goal-loop-observe-metrics.md
+++ b/docs/observability/goal-loop-observe-metrics.md
@@ -1,0 +1,89 @@
+# GOAL LOOP Observe Metrics
+
+Status: exporter contract
+Last verified: 2026-05-06
+
+This document pins the GOAL LOOP Observe phase to repo-owned telemetry
+artefacts. The runtime may expose these metrics directly or bridge them
+from parsed logs, but the names, thresholds, and dashboard coverage are
+now contract checked.
+
+## Artefacts
+
+- `infrastructure/monitoring/goal-loop-observe-metrics.contract.json`
+  is the machine-readable source of required Observe signals.
+- `infrastructure/monitoring/goal-loop-observe-alerts.yml` is the
+  Prometheus alert rule file.
+- `infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json`
+  is the Grafana dashboard.
+- `scripts/validate_goal_loop_observe_metrics.py` verifies that every
+  required signal appears in alerts and dashboard queries.
+
+## Required Signals
+
+| Signal | Metric | Alert |
+|--------|--------|-------|
+| keeper turn success rate | `masc_keeper_turn_completed_total`, `masc_keeper_turn_scheduled_total` | `GoalLoopKeeperTurnSuccessRateCritical` |
+| keeper semaphore wait p99 | `masc_keeper_semaphore_wait_seconds_bucket` | `GoalLoopKeeperSemaphoreWaitP99Critical` |
+| keeper alive-but-stuck | `masc_keeper_alive_but_stuck_seconds`, `masc_keeper_alive_but_stuck_threshold_seconds` | `GoalLoopKeeperAliveButStuckCritical` |
+| keeper zombie loop | `masc_keeper_zombie_loop_detected_total` | `GoalLoopKeeperZombieLoopCritical` |
+| provider health probe skipped | `masc_provider_health_probe_skipped_total` | `GoalLoopProviderHealthProbeSkippedWarning` |
+| provider actual health status | `masc_provider_actual_health_status` | `GoalLoopProviderActualHealthUnhealthyCritical` |
+| pricing catalog miss | `masc_pricing_catalog_miss_total` | `GoalLoopPricingCatalogMissCritical` |
+| dashboard all-zero metrics | `masc_dashboard_metric_all_zeros` | `GoalLoopDashboardMetricAllZerosWarning` |
+| dashboard snapshot latency | `masc_dashboard_snapshot_latency_seconds_bucket` | `GoalLoopDashboardSnapshotLatencyP99Warning` |
+| config unknown keys ignored | `masc_config_unknown_keys_ignored_total` | `GoalLoopConfigUnknownKeysIgnoredWarning` |
+| credential archived by starvation | `masc_config_credential_archived_starvation_total` | `GoalLoopCredentialArchivedStarvationCritical` |
+| governance judge unparseable | `masc_governance_judge_unparseable_total` | `GoalLoopGovernanceJudgeUnparseableWarning` |
+| governance lenient JSON fallback | `masc_governance_lenient_json_fallback_hit_total` | `GoalLoopGovernanceLenientJsonFallbackWarning` |
+| persistence UTF-8 repair | `masc_persistence_utf8_repair_total` | `GoalLoopPersistenceUtf8RepairCritical` |
+| write_meta CAS retry | `masc_write_meta_cas_retry_total` | `GoalLoopWriteMetaCasRetryWarning` |
+
+## Validation
+
+Run the contract validator from the repo root:
+
+```sh
+python3 scripts/validate_goal_loop_observe_metrics.py \
+  infrastructure/monitoring/goal-loop-observe-metrics.contract.json \
+  --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml \
+  --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json \
+  --require-complete \
+  --format text
+```
+
+Expected result:
+
+```text
+GOAL LOOP Observe Metrics Contract: PASS
+checked_signals: 15
+passing_signals: 15
+failing_signals: 0
+```
+
+The script is intentionally stdlib-only. CI can run it without installing
+YAML tooling because it checks explicit alert names, metric names, and
+threshold fragments from the contract.
+
+## Apply
+
+Prometheus deployments should include
+`infrastructure/monitoring/goal-loop-observe-alerts.yml` in their
+`rule_files` glob. Grafana imports
+`infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json`
+through the normal dashboard provisioning path or File -> Import.
+
+## Exporter Contract
+
+The contract uses bounded labels from the prompt:
+
+- `keeper_name`
+- `cascade_profile`
+- `provider_name`
+- `profile_name`
+- `model_id`
+- `file_path`
+
+Counters should increment on the exact failure event. Gauges should hold
+the current runtime state. Histograms must expose Prometheus `_bucket`
+series so the p99 rules can use `histogram_quantile`.

--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -9,13 +9,26 @@ Prometheus / Grafana files that live alongside the masc-mcp source so deployment
 | `cascade-alerts.yml` | cascade | alerts | `docs/observability/cascade-metrics.md` |
 | `cascade-slo.yml` | cascade | recording rules + SLO alerts | `docs/observability/cascade-metrics.md` |
 | `grafana-cascade-dashboard.json` | cascade | Grafana dashboard | `docs/observability/cascade-metrics.md` |
+| `grafana-goal-loop-observe-dashboard.json` | GOAL LOOP Observe | Grafana dashboard | `docs/observability/goal-loop-observe-metrics.md` |
 | `grafana-keeper-turn-fsm-dashboard.json` | keeper turn FSM | Grafana dashboard | `docs/observability/keeper-turn-fsm-metrics.md` |
+| `goal-loop-observe-alerts.yml` | GOAL LOOP Observe | alerts | `docs/observability/goal-loop-observe-metrics.md` |
+| `goal-loop-observe-metrics.contract.json` | GOAL LOOP Observe | exporter contract | `docs/observability/goal-loop-observe-metrics.md` |
 | `keeper-turn-fsm-alerts.yml` | keeper turn FSM | alerts | `docs/observability/keeper-turn-fsm-metrics.md` |
 | `keeper-turn-fsm-slo.yml` | keeper turn FSM | recording rules | `docs/observability/keeper-turn-fsm-metrics.md` |
 
 ## Domains
 
 The two domains are **deliberately separate**.
+
+### GOAL LOOP Observe
+
+Tracks the Observe phase signals from the GOAL LOOP design: keeper
+liveness, semaphore wait, provider health skips, pricing misses,
+dashboard all-zero diagnostics, config drift, governance fallback, UTF-8
+repair, and CAS retries. The exporter contract is
+`goal-loop-observe-metrics.contract.json`; `scripts/validate_goal_loop_observe_metrics.py`
+checks that the alert rules and Grafana dashboard cover every required
+signal.
 
 ### Cascade
 

--- a/infrastructure/monitoring/goal-loop-observe-alerts.yml
+++ b/infrastructure/monitoring/goal-loop-observe-alerts.yml
@@ -1,0 +1,279 @@
+# Prometheus alerting rules for GOAL LOOP Observe.
+#
+# Companion contract:
+#   - infrastructure/monitoring/goal-loop-observe-metrics.contract.json
+# Companion dashboard:
+#   - infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
+# Companion doc:
+#   - docs/observability/goal-loop-observe-metrics.md
+#
+# These rules intentionally encode the prompt's Observe phase as a
+# machine-readable exporter contract. A deployment can expose the
+# listed metrics directly or bridge them from logs, but missing or
+# zero-only instrumentation must be visible to operators.
+
+groups:
+  - name: masc_goal_loop_observe_keeper
+    interval: 30s
+    rules:
+      - alert: GoalLoopKeeperTurnSuccessRateCritical
+        expr: |
+          (
+            sum by (keeper_name) (rate(masc_keeper_turn_completed_total[5m]))
+            /
+            clamp_min(
+              sum by (keeper_name) (rate(masc_keeper_turn_scheduled_total[5m])),
+              0.001
+            )
+          ) < 0.5
+        for: 5m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Keeper {{ $labels.keeper_name }} turn success rate < 50%"
+          description: |
+            Keeper scheduled turns are not becoming completed turns. This
+            catches semaphore starvation, keepalive-only loops, and stuck
+            bootstrap paths before the Orient phase classifies the finding.
+
+      - alert: GoalLoopKeeperSemaphoreWaitP99Critical
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum by (le, keeper_name, cascade_profile) (
+              rate(masc_keeper_semaphore_wait_seconds_bucket[5m])
+            )
+          ) > 180
+        for: 5m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Keeper {{ $labels.keeper_name }} semaphore wait p99 > 180s"
+          description: |
+            Bounded semaphore acquisition is no longer bounded in practice.
+            Check turn slot holder state and fallback ladder activation.
+
+      - alert: GoalLoopKeeperAliveButStuckCritical
+        expr: |
+          (
+            masc_keeper_alive_but_stuck_seconds
+            /
+            clamp_min(masc_keeper_alive_but_stuck_threshold_seconds, 1)
+          ) > 2
+        for: 5m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Keeper {{ $labels.keeper_name }} stuck for > 2x threshold"
+          description: |
+            Supervisor-visible liveness has exceeded the configured
+            stuck threshold by more than 2x and must enter recovery.
+
+      - alert: GoalLoopKeeperZombieLoopCritical
+        expr: |
+          sum by (keeper_name) (
+            increase(masc_keeper_zombie_loop_detected_total[5m])
+          ) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Keeper {{ $labels.keeper_name }} zombie loop detected"
+          description: |
+            A loop made progress-signalling noise without real task progress.
+            This is a direct Observe-phase re-entry trigger.
+
+  - name: masc_goal_loop_observe_provider
+    interval: 30s
+    rules:
+      - alert: GoalLoopProviderHealthProbeSkippedWarning
+        expr: |
+          sum by (provider_name, profile_name) (
+            increase(masc_provider_health_probe_skipped_total[5m])
+          ) > 0
+        for: 0m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Provider health probe skipped for {{ $labels.provider_name }}"
+          description: |
+            Bootstrap skipped a live probe and treated provider health as
+            advisory. The provider must not be counted healthy until a
+            completed probe writes actual health status.
+
+      - alert: GoalLoopProviderActualHealthUnhealthyCritical
+        expr: |
+          masc_provider_actual_health_status >= 3
+        for: 5m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Provider {{ $labels.provider_name }} is unhealthy"
+          description: |
+            Provider actual health status is unhealthy. Values are:
+            0 unknown, 1 healthy, 2 degraded, 3 unhealthy.
+
+      - alert: GoalLoopPricingCatalogMissCritical
+        expr: |
+          sum by (model_id) (
+            increase(masc_pricing_catalog_miss_total[5m])
+          ) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Pricing catalog miss for {{ $labels.model_id }}"
+          description: |
+            A cost path missed the pricing catalog. Treating cost as 0.0
+            is not a true zero and must fail Verify until reconciled.
+
+  - name: masc_goal_loop_observe_dashboard
+    interval: 30s
+    rules:
+      - alert: GoalLoopDashboardMetricAllZerosWarning
+        expr: |
+          masc_dashboard_metric_all_zeros == 1
+        for: 5m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Dashboard sub-operation metrics are all zero"
+          description: |
+            Dashboard rows show ka/audit/profile/phase/activity as 0ms.
+            This usually means the metric bridge is a no-op or sampling is
+            not connected to the runtime path.
+
+      - alert: GoalLoopDashboardSnapshotLatencyP99Warning
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum by (le) (
+              rate(masc_dashboard_snapshot_latency_seconds_bucket[5m])
+            )
+          ) > 5
+        for: 10m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Dashboard snapshot latency p99 > 5s"
+          description: |
+            Observe dashboards are stale enough that Orient decisions may
+            run against delayed state.
+
+  - name: masc_goal_loop_observe_config
+    interval: 30s
+    rules:
+      - alert: GoalLoopConfigUnknownKeysIgnoredWarning
+        expr: |
+          sum by (file_path) (
+            increase(masc_config_unknown_keys_ignored_total[5m])
+          ) > 0
+        for: 0m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Unknown config keys ignored in {{ $labels.file_path }}"
+          description: |
+            Config parsing accepted unknown keys. Runtime config drift must
+            be visible instead of silently ignored.
+
+      - alert: GoalLoopCredentialArchivedStarvationCritical
+        expr: |
+          sum by (keeper_name) (
+            increase(masc_config_credential_archived_starvation_total[5m])
+          ) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Keeper {{ $labels.keeper_name }} credential archived by starvation"
+          description: |
+            A keeper credential was archived because the starvation path
+            invalidated it. Recovery must either refresh credentials or
+            release the blocking slot.
+
+  - name: masc_goal_loop_observe_governance
+    interval: 30s
+    rules:
+      - alert: GoalLoopGovernanceJudgeUnparseableWarning
+        expr: |
+          increase(masc_governance_judge_unparseable_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Governance judge returned an unparseable response"
+          description: |
+            Governance status cannot be trusted until the raw judge output
+            is repaired or rejected as invalid.
+
+      - alert: GoalLoopGovernanceLenientJsonFallbackWarning
+        expr: |
+          increase(masc_governance_lenient_json_fallback_hit_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Governance lenient JSON fallback hit"
+          description: |
+            Lenient parsing may distort guardrail state. Treat this as a
+            warning and preserve raw output for audit.
+
+  - name: masc_goal_loop_observe_integrity
+    interval: 30s
+    rules:
+      - alert: GoalLoopPersistenceUtf8RepairCritical
+        expr: |
+          increase(masc_persistence_utf8_repair_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Persistence UTF-8 repair occurred"
+          description: |
+            Runtime storage repaired invalid UTF-8. This is data
+            corruption, not a normal cleanup path.
+
+      - alert: GoalLoopWriteMetaCasRetryWarning
+        expr: |
+          sum by (keeper_name) (
+            increase(masc_write_meta_cas_retry_total[5m])
+          ) > 0
+        for: 0m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Keeper {{ $labels.keeper_name }} write_meta CAS retry"
+          description: |
+            Metadata writes are contending. A small retry count is
+            tolerable, but retries must be visible for liveness analysis.

--- a/infrastructure/monitoring/goal-loop-observe-alerts.yml
+++ b/infrastructure/monitoring/goal-loop-observe-alerts.yml
@@ -13,6 +13,40 @@
 # zero-only instrumentation must be visible to operators.
 
 groups:
+  - name: masc_goal_loop_observe_contract
+    interval: 30s
+    rules:
+      - alert: GoalLoopObserveMetricAbsentCritical
+        expr: |
+          absent(masc_keeper_turn_completed_total)
+          or absent(masc_keeper_turn_scheduled_total)
+          or absent(masc_keeper_semaphore_wait_seconds_bucket)
+          or absent(masc_keeper_alive_but_stuck_seconds)
+          or absent(masc_keeper_alive_but_stuck_threshold_seconds)
+          or absent(masc_keeper_zombie_loop_detected_total)
+          or absent(masc_provider_health_probe_skipped_total)
+          or absent(masc_provider_actual_health_status)
+          or absent(masc_pricing_catalog_miss_total)
+          or absent(masc_dashboard_metric_all_zeros)
+          or absent(masc_dashboard_snapshot_latency_seconds_bucket)
+          or absent(masc_config_unknown_keys_ignored_total)
+          or absent(masc_config_credential_archived_starvation_total)
+          or absent(masc_governance_judge_unparseable_total)
+          or absent(masc_governance_lenient_json_fallback_hit_total)
+          or absent(masc_persistence_utf8_repair_total)
+          or absent(masc_write_meta_cas_retry_total)
+        for: 5m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "GOAL LOOP Observe contract metric is absent"
+          description: |
+            At least one metric required by the Observe exporter contract is
+            absent from Prometheus, so downstream alert expressions may be
+            silent even though instrumentation is missing.
+
   - name: masc_goal_loop_observe_keeper
     interval: 30s
     rules:

--- a/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
+++ b/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
@@ -1,0 +1,212 @@
+{
+  "schema_version": 1,
+  "contract_id": "masc-goal-loop-observe-metrics-v1",
+  "status": "exporter-contract",
+  "last_verified": "2026-05-06",
+  "description": "Machine-readable GOAL LOOP Observe metric coverage contract. Every required signal must be represented in Prometheus alerts and the Grafana Observe dashboard before the Observe phase is considered shipped.",
+  "required_signals": [
+    {
+      "signal_id": "keeper_turn_success_rate",
+      "metric_names": [
+        "masc_keeper_turn_completed_total",
+        "masc_keeper_turn_scheduled_total"
+      ],
+      "alert_names": [
+        "GoalLoopKeeperTurnSuccessRateCritical"
+      ],
+      "threshold_fragments": [
+        "[5m]",
+        "< 0.5"
+      ]
+    },
+    {
+      "signal_id": "keeper_semaphore_wait_p99",
+      "metric_names": [
+        "masc_keeper_semaphore_wait_seconds_bucket"
+      ],
+      "alert_names": [
+        "GoalLoopKeeperSemaphoreWaitP99Critical"
+      ],
+      "threshold_fragments": [
+        "histogram_quantile(",
+        "> 180"
+      ]
+    },
+    {
+      "signal_id": "keeper_alive_but_stuck",
+      "metric_names": [
+        "masc_keeper_alive_but_stuck_seconds",
+        "masc_keeper_alive_but_stuck_threshold_seconds"
+      ],
+      "alert_names": [
+        "GoalLoopKeeperAliveButStuckCritical"
+      ],
+      "threshold_fragments": [
+        "> 2"
+      ]
+    },
+    {
+      "signal_id": "keeper_zombie_loop",
+      "metric_names": [
+        "masc_keeper_zombie_loop_detected_total"
+      ],
+      "alert_names": [
+        "GoalLoopKeeperZombieLoopCritical"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "provider_health_probe_skipped",
+      "metric_names": [
+        "masc_provider_health_probe_skipped_total"
+      ],
+      "alert_names": [
+        "GoalLoopProviderHealthProbeSkippedWarning"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "provider_actual_health_status",
+      "metric_names": [
+        "masc_provider_actual_health_status"
+      ],
+      "alert_names": [
+        "GoalLoopProviderActualHealthUnhealthyCritical"
+      ],
+      "threshold_fragments": [
+        ">= 3"
+      ]
+    },
+    {
+      "signal_id": "pricing_catalog_miss",
+      "metric_names": [
+        "masc_pricing_catalog_miss_total"
+      ],
+      "alert_names": [
+        "GoalLoopPricingCatalogMissCritical"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "dashboard_metric_all_zeros",
+      "metric_names": [
+        "masc_dashboard_metric_all_zeros"
+      ],
+      "alert_names": [
+        "GoalLoopDashboardMetricAllZerosWarning"
+      ],
+      "threshold_fragments": [
+        "== 1"
+      ]
+    },
+    {
+      "signal_id": "dashboard_snapshot_latency_p99",
+      "metric_names": [
+        "masc_dashboard_snapshot_latency_seconds_bucket"
+      ],
+      "alert_names": [
+        "GoalLoopDashboardSnapshotLatencyP99Warning"
+      ],
+      "threshold_fragments": [
+        "histogram_quantile(",
+        "> 5"
+      ]
+    },
+    {
+      "signal_id": "config_unknown_keys_ignored",
+      "metric_names": [
+        "masc_config_unknown_keys_ignored_total"
+      ],
+      "alert_names": [
+        "GoalLoopConfigUnknownKeysIgnoredWarning"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "credential_archived_starvation",
+      "metric_names": [
+        "masc_config_credential_archived_starvation_total"
+      ],
+      "alert_names": [
+        "GoalLoopCredentialArchivedStarvationCritical"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "governance_judge_unparseable",
+      "metric_names": [
+        "masc_governance_judge_unparseable_total"
+      ],
+      "alert_names": [
+        "GoalLoopGovernanceJudgeUnparseableWarning"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "governance_lenient_json_fallback",
+      "metric_names": [
+        "masc_governance_lenient_json_fallback_hit_total"
+      ],
+      "alert_names": [
+        "GoalLoopGovernanceLenientJsonFallbackWarning"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "persistence_utf8_repair",
+      "metric_names": [
+        "masc_persistence_utf8_repair_total"
+      ],
+      "alert_names": [
+        "GoalLoopPersistenceUtf8RepairCritical"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    },
+    {
+      "signal_id": "write_meta_cas_retry",
+      "metric_names": [
+        "masc_write_meta_cas_retry_total"
+      ],
+      "alert_names": [
+        "GoalLoopWriteMetaCasRetryWarning"
+      ],
+      "threshold_fragments": [
+        "increase(",
+        "[5m]",
+        "> 0"
+      ]
+    }
+  ]
+}

--- a/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
+++ b/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
@@ -1,4 +1,29 @@
 {
+  "__meta": {
+    "purpose": "MASC GOAL LOOP Observe contract dashboard - imports into Grafana 10+ via File -> Import.",
+    "metrics": [
+      "masc_keeper_turn_completed_total{keeper_name}",
+      "masc_keeper_turn_scheduled_total{keeper_name}",
+      "masc_keeper_semaphore_wait_seconds_bucket{keeper_name,cascade_profile}",
+      "masc_keeper_alive_but_stuck_seconds{keeper_name}",
+      "masc_keeper_alive_but_stuck_threshold_seconds{keeper_name}",
+      "masc_keeper_zombie_loop_detected_total{keeper_name}",
+      "masc_provider_health_probe_skipped_total{provider_name,profile_name}",
+      "masc_provider_actual_health_status{provider_name}",
+      "masc_pricing_catalog_miss_total{model_id}",
+      "masc_dashboard_metric_all_zeros{keeper_name}",
+      "masc_dashboard_snapshot_latency_seconds_bucket",
+      "masc_config_unknown_keys_ignored_total{file_path}",
+      "masc_config_credential_archived_starvation_total{keeper_name}",
+      "masc_governance_judge_unparseable_total",
+      "masc_governance_lenient_json_fallback_hit_total",
+      "masc_persistence_utf8_repair_total",
+      "masc_write_meta_cas_retry_total{keeper_name}"
+    ],
+    "companion_alerts": "infrastructure/monitoring/goal-loop-observe-alerts.yml",
+    "companion_contract": "infrastructure/monitoring/goal-loop-observe-metrics.contract.json",
+    "companion_doc": "docs/observability/goal-loop-observe-metrics.md"
+  },
   "annotations": {
     "list": [
       {
@@ -61,7 +86,32 @@
           "custom": {},
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".* stuck ratio"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".* zombie loops"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -97,7 +147,8 @@
       },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "unit": "short"
         },
         "overrides": []
       },
@@ -135,9 +186,23 @@
       },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "snapshot p99"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,

--- a/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
+++ b/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
@@ -1,0 +1,281 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "sum by (keeper_name) (rate(masc_keeper_turn_completed_total[5m])) / clamp_min(sum by (keeper_name) (rate(masc_keeper_turn_scheduled_total[5m])), 0.001)",
+          "legendFormat": "{{keeper_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Keeper Turn Success Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, keeper_name, cascade_profile) (rate(masc_keeper_semaphore_wait_seconds_bucket[5m])))",
+          "legendFormat": "{{keeper_name}} {{cascade_profile}}",
+          "refId": "A"
+        },
+        {
+          "expr": "masc_keeper_alive_but_stuck_seconds / clamp_min(masc_keeper_alive_but_stuck_threshold_seconds, 1)",
+          "legendFormat": "{{keeper_name}} stuck ratio",
+          "refId": "B"
+        },
+        {
+          "expr": "increase(masc_keeper_zombie_loop_detected_total[5m])",
+          "legendFormat": "{{keeper_name}} zombie loops",
+          "refId": "C"
+        }
+      ],
+      "title": "Keeper Stuck Signals",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "increase(masc_provider_health_probe_skipped_total[5m])",
+          "legendFormat": "{{provider_name}} {{profile_name}} skipped",
+          "refId": "A"
+        },
+        {
+          "expr": "masc_provider_actual_health_status",
+          "legendFormat": "{{provider_name}} health",
+          "refId": "B"
+        },
+        {
+          "expr": "increase(masc_pricing_catalog_miss_total[5m])",
+          "legendFormat": "{{model_id}} pricing miss",
+          "refId": "C"
+        }
+      ],
+      "title": "Provider Health And Pricing",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "masc_dashboard_metric_all_zeros",
+          "legendFormat": "{{keeper_name}} all-zero",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(masc_dashboard_snapshot_latency_seconds_bucket[5m])))",
+          "legendFormat": "snapshot p99",
+          "refId": "B"
+        }
+      ],
+      "title": "Dashboard Metric Integrity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "increase(masc_config_unknown_keys_ignored_total[5m])",
+          "legendFormat": "{{file_path}} unknown keys",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(masc_config_credential_archived_starvation_total[5m])",
+          "legendFormat": "{{keeper_name}} credential starvation",
+          "refId": "B"
+        }
+      ],
+      "title": "Config And Credential Drift",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "increase(masc_governance_judge_unparseable_total[5m])",
+          "legendFormat": "judge unparseable",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(masc_governance_lenient_json_fallback_hit_total[5m])",
+          "legendFormat": "lenient fallback",
+          "refId": "B"
+        },
+        {
+          "expr": "increase(masc_persistence_utf8_repair_total[5m])",
+          "legendFormat": "utf8 repair",
+          "refId": "C"
+        },
+        {
+          "expr": "increase(masc_write_meta_cas_retry_total[5m])",
+          "legendFormat": "{{keeper_name}} CAS retry",
+          "refId": "D"
+        }
+      ],
+      "title": "Governance And Data Integrity",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "masc",
+    "goal-loop",
+    "observe"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "MASC GOAL LOOP Observe",
+  "uid": "masc-goal-loop-observe",
+  "version": 1,
+  "weekStart": ""
+}

--- a/scripts/validate_goal_loop_observe_metrics.py
+++ b/scripts/validate_goal_loop_observe_metrics.py
@@ -45,12 +45,97 @@ def read_text(path: str) -> str:
 
 
 def alert_names(alert_text: str) -> set[str]:
-    names: set[str] = set()
-    for line in alert_text.splitlines():
-        match = re.match(r"\s*-\s*alert:\s*([A-Za-z0-9_:.-]+)\s*$", line)
-        if match:
-            names.add(match.group(1))
-    return names
+    return set(alert_exprs(alert_text))
+
+
+def alert_exprs(alert_text: str) -> dict[str, str]:
+    exprs: dict[str, str] = {}
+    current_alert: str | None = None
+    lines = alert_text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        alert_match = re.match(r"\s*-\s*alert:\s*([A-Za-z0-9_:.-]+)\s*$", line)
+        if alert_match:
+            current_alert = alert_match.group(1)
+            exprs.setdefault(current_alert, "")
+            index += 1
+            continue
+
+        expr_match = re.match(r"^(\s*)expr:\s*(.*)\s*$", line)
+        if current_alert and expr_match:
+            expr_indent = len(expr_match.group(1))
+            expr_value = expr_match.group(2).strip()
+            if expr_value and expr_value != "|":
+                exprs[current_alert] = expr_value
+                index += 1
+                continue
+
+            block: list[str] = []
+            index += 1
+            while index < len(lines):
+                block_line = lines[index]
+                block_indent = len(block_line) - len(block_line.lstrip())
+                if block_line.strip() and block_indent <= expr_indent:
+                    break
+                block.append(block_line.strip())
+                index += 1
+            exprs[current_alert] = "\n".join(block)
+            continue
+
+        index += 1
+    return exprs
+
+
+def dashboard_exprs(dashboard_text: str) -> list[str]:
+    data = json.loads(dashboard_text)
+    if not isinstance(data, dict):
+        raise ValueError("dashboard JSON must be an object")
+    exprs: list[str] = []
+
+    def collect(value: Any) -> None:
+        if isinstance(value, dict):
+            expr = value.get("expr")
+            if isinstance(expr, str) and expr.strip():
+                exprs.append(expr)
+            for child in value.values():
+                collect(child)
+        elif isinstance(value, list):
+            for child in value:
+                collect(child)
+
+    collect(data)
+    return exprs
+
+
+def contains_expr_token(expr: str, token: str) -> bool:
+    if not token.strip():
+        return False
+    if re.fullmatch(r"[A-Za-z_:][A-Za-z0-9_:]*", token):
+        return (
+            re.search(rf"(?<![A-Za-z0-9_:]){re.escape(token)}(?![A-Za-z0-9_:])", expr)
+            is not None
+        )
+    return token in expr
+
+
+def any_expr_contains(exprs: list[str], token: str) -> bool:
+    return any(contains_expr_token(expr, token) for expr in exprs)
+
+
+def contract_schema_version(contract: dict[str, Any]) -> int:
+    version = contract.get("schema_version")
+    if not isinstance(version, int):
+        raise ValueError("contract.schema_version must be an integer")
+    if version != 1:
+        raise ValueError(f"unsupported contract.schema_version: {version}")
+    return version
+
+
+def required_alert_exprs(
+    required_alerts: list[str], alert_expr_map: dict[str, str]
+) -> list[str]:
+    return [alert_expr_map[name] for name in required_alerts if name in alert_expr_map]
 
 
 def as_string_list(value: Any) -> list[str]:
@@ -63,15 +148,21 @@ def required_signals(contract: dict[str, Any]) -> list[dict[str, Any]]:
     raw = contract.get("required_signals", [])
     if not isinstance(raw, list):
         raise ValueError("contract.required_signals must be a list")
-    return [item for item in raw if isinstance(item, dict)]
+    if not raw:
+        raise ValueError("contract.required_signals must not be empty")
+    signals: list[dict[str, Any]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"contract.required_signals[{index}] must be an object")
+        signals.append(item)
+    return signals
 
 
 def validate_signal(
     signal: dict[str, Any],
     *,
-    alerts: set[str],
-    alert_text: str,
-    dashboard_text: str,
+    alert_expr_map: dict[str, str],
+    dashboard_query_exprs: list[str],
 ) -> SignalCheck:
     signal_id = str(signal.get("signal_id", "unknown"))
     metric_names = as_string_list(signal.get("metric_names"))
@@ -80,13 +171,20 @@ def validate_signal(
     dashboard_fragments = as_string_list(
         signal.get("dashboard_query_fragments", metric_names)
     )
-    missing_alerts = [name for name in required_alerts if name not in alerts]
-    missing_alert_metrics = [name for name in metric_names if name not in alert_text]
+    required_exprs = required_alert_exprs(required_alerts, alert_expr_map)
+    missing_alerts = [name for name in required_alerts if name not in alert_expr_map]
+    missing_alert_metrics = [
+        name for name in metric_names if not any_expr_contains(required_exprs, name)
+    ]
     missing_dashboard_metrics = [
-        fragment for fragment in dashboard_fragments if fragment not in dashboard_text
+        fragment
+        for fragment in dashboard_fragments
+        if not any_expr_contains(dashboard_query_exprs, fragment)
     ]
     missing_threshold_fragments = [
-        fragment for fragment in threshold_fragments if fragment not in alert_text
+        fragment
+        for fragment in threshold_fragments
+        if not any_expr_contains(required_exprs, fragment)
     ]
     status = (
         "PASS"
@@ -112,20 +210,21 @@ def validate_contract(
     alert_text: str,
     dashboard_text: str,
 ) -> ValidationReport:
-    alerts = alert_names(alert_text)
+    schema_version = contract_schema_version(contract)
+    alert_expr_map = alert_exprs(alert_text)
+    dashboard_query_exprs = dashboard_exprs(dashboard_text)
     checks = [
         validate_signal(
             signal,
-            alerts=alerts,
-            alert_text=alert_text,
-            dashboard_text=dashboard_text,
+            alert_expr_map=alert_expr_map,
+            dashboard_query_exprs=dashboard_query_exprs,
         )
         for signal in required_signals(contract)
     ]
     passing = sum(1 for check in checks if check.status == "PASS")
     failing = len(checks) - passing
     return ValidationReport(
-        schema_version=1,
+        schema_version=schema_version,
         status="PASS" if failing == 0 else "FAIL",
         checked_signals=len(checks),
         passing_signals=passing,
@@ -179,11 +278,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
-    report = validate_contract(
-        load_json_object(args.contract_json),
-        alert_text=read_text(args.alerts_yml),
-        dashboard_text=read_text(args.dashboard_json),
-    )
+    try:
+        report = validate_contract(
+            load_json_object(args.contract_json),
+            alert_text=read_text(args.alerts_yml),
+            dashboard_text=read_text(args.dashboard_json),
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     if args.format == "json":
         print(report_to_json(report))
     else:

--- a/scripts/validate_goal_loop_observe_metrics.py
+++ b/scripts/validate_goal_loop_observe_metrics.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate GOAL LOOP Observe metric alert and dashboard coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class SignalCheck:
+    signal_id: str
+    status: str
+    missing_alerts: list[str]
+    missing_alert_metrics: list[str]
+    missing_dashboard_metrics: list[str]
+    missing_threshold_fragments: list[str]
+
+
+@dataclass
+class ValidationReport:
+    schema_version: int
+    status: str
+    checked_signals: int
+    passing_signals: int
+    failing_signals: int
+    signal_checks: list[SignalCheck]
+
+
+def load_json_object(path: str) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def read_text(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def alert_names(alert_text: str) -> set[str]:
+    names: set[str] = set()
+    for line in alert_text.splitlines():
+        match = re.match(r"\s*-\s*alert:\s*([A-Za-z0-9_:.-]+)\s*$", line)
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+def as_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]
+
+
+def required_signals(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = contract.get("required_signals", [])
+    if not isinstance(raw, list):
+        raise ValueError("contract.required_signals must be a list")
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def validate_signal(
+    signal: dict[str, Any],
+    *,
+    alerts: set[str],
+    alert_text: str,
+    dashboard_text: str,
+) -> SignalCheck:
+    signal_id = str(signal.get("signal_id", "unknown"))
+    metric_names = as_string_list(signal.get("metric_names"))
+    required_alerts = as_string_list(signal.get("alert_names"))
+    threshold_fragments = as_string_list(signal.get("threshold_fragments"))
+    dashboard_fragments = as_string_list(
+        signal.get("dashboard_query_fragments", metric_names)
+    )
+    missing_alerts = [name for name in required_alerts if name not in alerts]
+    missing_alert_metrics = [name for name in metric_names if name not in alert_text]
+    missing_dashboard_metrics = [
+        fragment for fragment in dashboard_fragments if fragment not in dashboard_text
+    ]
+    missing_threshold_fragments = [
+        fragment for fragment in threshold_fragments if fragment not in alert_text
+    ]
+    status = (
+        "PASS"
+        if not missing_alerts
+        and not missing_alert_metrics
+        and not missing_dashboard_metrics
+        and not missing_threshold_fragments
+        else "FAIL"
+    )
+    return SignalCheck(
+        signal_id=signal_id,
+        status=status,
+        missing_alerts=missing_alerts,
+        missing_alert_metrics=missing_alert_metrics,
+        missing_dashboard_metrics=missing_dashboard_metrics,
+        missing_threshold_fragments=missing_threshold_fragments,
+    )
+
+
+def validate_contract(
+    contract: dict[str, Any],
+    *,
+    alert_text: str,
+    dashboard_text: str,
+) -> ValidationReport:
+    alerts = alert_names(alert_text)
+    checks = [
+        validate_signal(
+            signal,
+            alerts=alerts,
+            alert_text=alert_text,
+            dashboard_text=dashboard_text,
+        )
+        for signal in required_signals(contract)
+    ]
+    passing = sum(1 for check in checks if check.status == "PASS")
+    failing = len(checks) - passing
+    return ValidationReport(
+        schema_version=1,
+        status="PASS" if failing == 0 else "FAIL",
+        checked_signals=len(checks),
+        passing_signals=passing,
+        failing_signals=failing,
+        signal_checks=checks,
+    )
+
+
+def report_to_json(report: ValidationReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: ValidationReport) -> str:
+    lines = [
+        f"GOAL LOOP Observe Metrics Contract: {report.status}",
+        f"checked_signals: {report.checked_signals}",
+        f"passing_signals: {report.passing_signals}",
+        f"failing_signals: {report.failing_signals}",
+    ]
+    for check in report.signal_checks:
+        lines.append(f"- {check.signal_id}: {check.status}")
+        if check.status == "FAIL":
+            if check.missing_alerts:
+                lines.append(f"  missing_alerts={','.join(check.missing_alerts)}")
+            if check.missing_alert_metrics:
+                lines.append(
+                    f"  missing_alert_metrics={','.join(check.missing_alert_metrics)}"
+                )
+            if check.missing_dashboard_metrics:
+                lines.append(
+                    "  missing_dashboard_metrics="
+                    + ",".join(check.missing_dashboard_metrics)
+                )
+            if check.missing_threshold_fragments:
+                lines.append(
+                    "  missing_threshold_fragments="
+                    + ",".join(check.missing_threshold_fragments)
+                )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("contract_json")
+    parser.add_argument("--alerts-yml", required=True)
+    parser.add_argument("--dashboard-json", required=True)
+    parser.add_argument("--format", choices=("json", "text"), default="json")
+    parser.add_argument("--require-complete", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    report = validate_contract(
+        load_json_object(args.contract_json),
+        alert_text=read_text(args.alerts_yml),
+        dashboard_text=read_text(args.dashboard_json),
+    )
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    return 1 if args.require_complete and report.status != "PASS" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_validate_goal_loop_observe_metrics.py
+++ b/test/test_validate_goal_loop_observe_metrics.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_goal_loop_observe_metrics.py"
+CONTRACT_PATH = (
+    REPO_ROOT
+    / "infrastructure"
+    / "monitoring"
+    / "goal-loop-observe-metrics.contract.json"
+)
+ALERTS_PATH = (
+    REPO_ROOT / "infrastructure" / "monitoring" / "goal-loop-observe-alerts.yml"
+)
+DASHBOARD_PATH = (
+    REPO_ROOT
+    / "infrastructure"
+    / "monitoring"
+    / "grafana-goal-loop-observe-dashboard.json"
+)
+
+spec = importlib.util.spec_from_file_location(
+    "validate_goal_loop_observe_metrics", SCRIPT_PATH
+)
+assert spec is not None
+validate_goal_loop_observe_metrics = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = validate_goal_loop_observe_metrics
+spec.loader.exec_module(validate_goal_loop_observe_metrics)
+
+
+def load_current_report(
+    *,
+    alert_text: str | None = None,
+    dashboard_text: str | None = None,
+) -> object:
+    return validate_goal_loop_observe_metrics.validate_contract(
+        validate_goal_loop_observe_metrics.load_json_object(str(CONTRACT_PATH)),
+        alert_text=alert_text if alert_text is not None else ALERTS_PATH.read_text(),
+        dashboard_text=(
+            dashboard_text if dashboard_text is not None else DASHBOARD_PATH.read_text()
+        ),
+    )
+
+
+class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
+    def test_contract_passes_current_alerts_and_dashboard(self) -> None:
+        report = load_current_report()
+
+        self.assertEqual("PASS", report.status)
+        self.assertEqual(15, report.checked_signals)
+        self.assertEqual(15, report.passing_signals)
+        self.assertEqual(0, report.failing_signals)
+
+    def test_cli_require_complete_passes(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                str(CONTRACT_PATH),
+                "--alerts-yml",
+                str(ALERTS_PATH),
+                "--dashboard-json",
+                str(DASHBOARD_PATH),
+                "--require-complete",
+                "--format",
+                "text",
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertIn("GOAL LOOP Observe Metrics Contract: PASS", result.stdout)
+
+    def test_missing_alert_name_fails(self) -> None:
+        alert_text = ALERTS_PATH.read_text().replace(
+            "GoalLoopProviderHealthProbeSkippedWarning",
+            "GoalLoopProviderHealthProbeSkippedMissing",
+        )
+
+        report = load_current_report(alert_text=alert_text)
+
+        self.assertEqual("FAIL", report.status)
+        failed = {
+            check.signal_id: check
+            for check in report.signal_checks
+            if check.status == "FAIL"
+        }
+        self.assertIn("provider_health_probe_skipped", failed)
+        self.assertEqual(
+            ["GoalLoopProviderHealthProbeSkippedWarning"],
+            failed["provider_health_probe_skipped"].missing_alerts,
+        )
+
+    def test_missing_alert_metric_fails(self) -> None:
+        alert_text = ALERTS_PATH.read_text().replace(
+            "masc_pricing_catalog_miss_total",
+            "masc_pricing_catalog_missing_total",
+        )
+
+        report = load_current_report(alert_text=alert_text)
+
+        self.assertEqual("FAIL", report.status)
+        failed = {
+            check.signal_id: check
+            for check in report.signal_checks
+            if check.status == "FAIL"
+        }
+        self.assertIn("pricing_catalog_miss", failed)
+        self.assertEqual(
+            ["masc_pricing_catalog_miss_total"],
+            failed["pricing_catalog_miss"].missing_alert_metrics,
+        )
+
+    def test_missing_dashboard_metric_fails(self) -> None:
+        dashboard_text = DASHBOARD_PATH.read_text().replace(
+            "masc_write_meta_cas_retry_total",
+            "masc_write_meta_cas_missing_total",
+        )
+
+        report = load_current_report(dashboard_text=dashboard_text)
+
+        self.assertEqual("FAIL", report.status)
+        failed = {
+            check.signal_id: check
+            for check in report.signal_checks
+            if check.status == "FAIL"
+        }
+        self.assertIn("write_meta_cas_retry", failed)
+        self.assertEqual(
+            ["masc_write_meta_cas_retry_total"],
+            failed["write_meta_cas_retry"].missing_dashboard_metrics,
+        )
+
+    def test_cli_require_complete_fails_when_contract_broken(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            broken_alerts = Path(tmpdir) / "alerts.yml"
+            broken_alerts.write_text(
+                ALERTS_PATH.read_text().replace(
+                    "masc_dashboard_metric_all_zeros",
+                    "masc_dashboard_metric_missing",
+                )
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(CONTRACT_PATH),
+                    "--alerts-yml",
+                    str(broken_alerts),
+                    "--dashboard-json",
+                    str(DASHBOARD_PATH),
+                    "--require-complete",
+                    "--format",
+                    "json",
+                ],
+                check=False,
+                cwd=REPO_ROOT,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn('"status": "FAIL"', result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_validate_goal_loop_observe_metrics.py
+++ b/test/test_validate_goal_loop_observe_metrics.py
@@ -39,14 +39,23 @@ spec.loader.exec_module(validate_goal_loop_observe_metrics)
 
 def load_current_report(
     *,
+    contract: dict[str, object] | None = None,
     alert_text: str | None = None,
     dashboard_text: str | None = None,
 ) -> object:
     return validate_goal_loop_observe_metrics.validate_contract(
-        validate_goal_loop_observe_metrics.load_json_object(str(CONTRACT_PATH)),
-        alert_text=alert_text if alert_text is not None else ALERTS_PATH.read_text(),
+        contract
+        if contract is not None
+        else validate_goal_loop_observe_metrics.load_json_object(str(CONTRACT_PATH)),
+        alert_text=(
+            alert_text
+            if alert_text is not None
+            else ALERTS_PATH.read_text(encoding="utf-8")
+        ),
         dashboard_text=(
-            dashboard_text if dashboard_text is not None else DASHBOARD_PATH.read_text()
+            dashboard_text
+            if dashboard_text is not None
+            else DASHBOARD_PATH.read_text(encoding="utf-8")
         ),
     )
 
@@ -84,7 +93,7 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         self.assertIn("GOAL LOOP Observe Metrics Contract: PASS", result.stdout)
 
     def test_missing_alert_name_fails(self) -> None:
-        alert_text = ALERTS_PATH.read_text().replace(
+        alert_text = ALERTS_PATH.read_text(encoding="utf-8").replace(
             "GoalLoopProviderHealthProbeSkippedWarning",
             "GoalLoopProviderHealthProbeSkippedMissing",
         )
@@ -104,7 +113,7 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         )
 
     def test_missing_alert_metric_fails(self) -> None:
-        alert_text = ALERTS_PATH.read_text().replace(
+        alert_text = ALERTS_PATH.read_text(encoding="utf-8").replace(
             "masc_pricing_catalog_miss_total",
             "masc_pricing_catalog_missing_total",
         )
@@ -124,7 +133,7 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         )
 
     def test_missing_dashboard_metric_fails(self) -> None:
-        dashboard_text = DASHBOARD_PATH.read_text().replace(
+        dashboard_text = DASHBOARD_PATH.read_text(encoding="utf-8").replace(
             "masc_write_meta_cas_retry_total",
             "masc_write_meta_cas_missing_total",
         )
@@ -147,10 +156,11 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             broken_alerts = Path(tmpdir) / "alerts.yml"
             broken_alerts.write_text(
-                ALERTS_PATH.read_text().replace(
+                ALERTS_PATH.read_text(encoding="utf-8").replace(
                     "masc_dashboard_metric_all_zeros",
                     "masc_dashboard_metric_missing",
-                )
+                ),
+                encoding="utf-8",
             )
 
             result = subprocess.run(
@@ -175,6 +185,135 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
 
         self.assertEqual(1, result.returncode)
         self.assertIn('"status": "FAIL"', result.stdout)
+
+    def test_rejects_empty_required_signals(self) -> None:
+        contract = {
+            "schema_version": 1,
+            "required_signals": [],
+        }
+
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            load_current_report(contract=contract)
+
+    def test_rejects_non_object_required_signal(self) -> None:
+        contract = {
+            "schema_version": 1,
+            "required_signals": ["pricing_catalog_miss"],
+        }
+
+        with self.assertRaisesRegex(ValueError, r"required_signals\[0\]"):
+            load_current_report(contract=contract)
+
+    def test_report_reflects_contract_schema_version(self) -> None:
+        report = load_current_report()
+
+        self.assertEqual(1, report.schema_version)
+
+    def test_rejects_unsupported_schema_version(self) -> None:
+        contract = {
+            "schema_version": 2,
+            "required_signals": [
+                {
+                    "signal_id": "pricing_catalog_miss",
+                    "metric_names": ["masc_pricing_catalog_miss_total"],
+                    "alert_names": ["GoalLoopPricingCatalogMissCritical"],
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "unsupported"):
+            load_current_report(contract=contract)
+
+    def test_alert_metrics_are_checked_within_required_alert_exprs(self) -> None:
+        contract = {
+            "schema_version": 1,
+            "required_signals": [
+                {
+                    "signal_id": "pricing_catalog_miss",
+                    "metric_names": ["masc_pricing_catalog_miss_total"],
+                    "alert_names": ["GoalLoopPricingCatalogMissCritical"],
+                    "threshold_fragments": ["> 0"],
+                }
+            ],
+        }
+        alert_text = """
+groups:
+  - name: test
+    rules:
+      - alert: GoalLoopPricingCatalogMissCritical
+        expr: |
+          increase(masc_pricing_catalog_miss_total_shadow[5m]) > 0
+      - alert: OtherAlert
+        expr: |
+          increase(masc_pricing_catalog_miss_total[5m]) > 0
+"""
+        dashboard_text = """
+{
+  "panels": [
+    {
+      "targets": [
+        {"expr": "increase(masc_pricing_catalog_miss_total[5m])"}
+      ]
+    }
+  ]
+}
+"""
+
+        report = load_current_report(
+            contract=contract,
+            alert_text=alert_text,
+            dashboard_text=dashboard_text,
+        )
+
+        self.assertEqual("FAIL", report.status)
+        self.assertEqual(
+            ["masc_pricing_catalog_miss_total"],
+            report.signal_checks[0].missing_alert_metrics,
+        )
+
+    def test_dashboard_metrics_are_checked_from_target_exprs(self) -> None:
+        contract = {
+            "schema_version": 1,
+            "required_signals": [
+                {
+                    "signal_id": "pricing_catalog_miss",
+                    "metric_names": ["masc_pricing_catalog_miss_total"],
+                    "alert_names": ["GoalLoopPricingCatalogMissCritical"],
+                }
+            ],
+        }
+        alert_text = """
+groups:
+  - name: test
+    rules:
+      - alert: GoalLoopPricingCatalogMissCritical
+        expr: |
+          increase(masc_pricing_catalog_miss_total[5m]) > 0
+"""
+        dashboard_text = """
+{
+  "panels": [
+    {
+      "title": "masc_pricing_catalog_miss_total",
+      "targets": [
+        {"expr": "increase(masc_pricing_catalog_miss_total_shadow[5m])"}
+      ]
+    }
+  ]
+}
+"""
+
+        report = load_current_report(
+            contract=contract,
+            alert_text=alert_text,
+            dashboard_text=dashboard_text,
+        )
+
+        self.assertEqual("FAIL", report.status)
+        self.assertEqual(
+            ["masc_pricing_catalog_miss_total"],
+            report.signal_checks[0].missing_dashboard_metrics,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #13608

## Summary
- Add GOAL LOOP Observe exporter contract with 15 required metric signals.
- Add Prometheus alert rules and Grafana dashboard covering keeper, provider, dashboard, config, governance, and data integrity signals.
- Add a stdlib validator plus regression tests that fail when alert names, metric names, thresholds, or dashboard queries drift.

## Verification
- ruff check scripts/validate_goal_loop_observe_metrics.py test/test_validate_goal_loop_observe_metrics.py
- ruff format --check scripts/validate_goal_loop_observe_metrics.py test/test_validate_goal_loop_observe_metrics.py
- python3 -m py_compile scripts/validate_goal_loop_observe_metrics.py test/test_validate_goal_loop_observe_metrics.py
- python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete --format text
- python3 test/test_validate_goal_loop_observe_metrics.py
- git diff --check HEAD~1 HEAD

## Local gap
- pyright was not run because python3 -m pyright reports that the module is not installed in this environment.