### PR TITLE
fix(dashboard): expose agent capability summary state

### DIFF
--- a/dashboard/src/components/common/agent-capability.test.ts
+++ b/dashboard/src/components/common/agent-capability.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { AgentCapability, normalizeTools } from './agent-capability'
+import {
+  AgentCapability,
+  normalizeTools,
+  summarizeAgentCapability,
+  toolConfig,
+} from './agent-capability'
 
 describe('normalizeTools', () => {
   it('returns empty array for null input', () => {
@@ -21,11 +26,75 @@ describe('normalizeTools', () => {
   })
 })
 
+describe('toolConfig', () => {
+  it('returns mono glyph configs for known tools', () => {
+    expect(toolConfig('shell')).toMatchObject({
+      glyph: 'SH',
+      label: '터미널',
+    })
+  })
+
+  it('falls back to a generic mono glyph for unknown tools', () => {
+    expect(toolConfig('custom_tool')).toEqual({
+      glyph: 'TL',
+      label: 'custom_tool',
+      description: 'custom_tool 도구',
+    })
+  })
+})
+
+describe('summarizeAgentCapability', () => {
+  it('summarizes visible and hidden tools', () => {
+    const summary = summarizeAgentCapability(
+      ['file_read', 'shell', 'unknown_tool', 'api_call'],
+      2,
+    )
+
+    expect(summary).toMatchObject({
+      tools: ['file_read', 'shell', 'unknown_tool', 'api_call'],
+      count: 4,
+      visibleCount: 2,
+      extraCount: 2,
+      empty: false,
+      maxVisible: 2,
+      hidden: ['unknown_tool', 'api_call'],
+      hiddenLabel: 'unknown_tool, api_call',
+    })
+    expect(summary.visible).toEqual([
+      expect.objectContaining({
+        tool: 'file_read',
+        glyph: 'RD',
+        known: true,
+        index: 0,
+      }),
+      expect.objectContaining({ tool: 'shell', glyph: 'SH', known: true, index: 1 }),
+    ])
+  })
+
+  it('clamps negative maxVisible to zero', () => {
+    const summary = summarizeAgentCapability(['shell'], -1)
+    expect(summary.visible).toEqual([])
+    expect(summary.hidden).toEqual(['shell'])
+    expect(summary.extraCount).toBe(1)
+    expect(summary.maxVisible).toBe(0)
+  })
+})
+
 describe('AgentCapability', () => {
   it('renders empty state', () => {
     const container = document.createElement('div')
     render(h(AgentCapability, { tools: [] }), container)
     expect(container.textContent).toContain('도구 없음')
+    expect(
+      container
+        .querySelector('[data-agent-capability]')
+        ?.getAttribute('data-capability-empty'),
+    ).toBe('true')
+    expect(
+      container
+        .querySelector('[data-agent-capability]')
+        ?.getAttribute('data-capability-count'),
+    ).toBe('0')
   })
 
   it('renders tool badges', () => {
@@ -33,12 +102,22 @@ describe('AgentCapability', () => {
     render(h(AgentCapability, { tools: ['file_read', 'shell'] }), container)
     expect(container.textContent).toContain('파일 읽기')
     expect(container.textContent).toContain('터미널')
+    expect(container.textContent).toContain('RD')
+    expect(container.textContent).toContain('SH')
   })
 
   it('limits visible badges', () => {
     const container = document.createElement('div')
-    render(h(AgentCapability, { tools: ['a', 'b', 'c', 'd', 'e'], maxVisible: 3 }), container)
+    render(
+      h(AgentCapability, { tools: ['a', 'b', 'c', 'd', 'e'], maxVisible: 3 }),
+      container,
+    )
     expect(container.textContent).toContain('+2')
+    const root = container.querySelector('[data-agent-capability]')
+    expect(root?.getAttribute('data-capability-count')).toBe('5')
+    expect(root?.getAttribute('data-capability-visible-count')).toBe('3')
+    expect(root?.getAttribute('data-capability-extra-count')).toBe('2')
+    expect(root?.getAttribute('data-capability-hidden-label')).toBe('d, e')
   })
 
   it('applies testId', () => {
@@ -52,5 +131,18 @@ describe('AgentCapability', () => {
     render(h(AgentCapability, { tools: ['file_read', null, 'shell'] }), container)
     const badges = container.querySelectorAll('[data-tool]')
     expect(badges.length).toBe(2)
+  })
+
+  it('publishes per-tool summary metadata', () => {
+    const container = document.createElement('div')
+    render(h(AgentCapability, { tools: ['shell', 'custom_tool'] }), container)
+    const badges = container.querySelectorAll('[data-capability-tool]')
+
+    expect(badges[0]?.getAttribute('data-capability-tool-known')).toBe('true')
+    expect(badges[0]?.getAttribute('data-capability-tool-glyph')).toBe('SH')
+    expect(badges[0]?.getAttribute('data-capability-tool-label')).toBe('터미널')
+    expect(badges[1]?.getAttribute('data-capability-tool-known')).toBe('false')
+    expect(badges[1]?.getAttribute('data-capability-tool-glyph')).toBe('TL')
+    expect(badges[1]?.getAttribute('data-capability-tool-label')).toBe('custom_tool')
   })
 })

--- a/dashboard/src/components/common/agent-capability.test.ts
+++ b/dashboard/src/components/common/agent-capability.test.ts
@@ -41,6 +41,19 @@ describe('toolConfig', () => {
       description: 'custom_tool 도구',
     })
   })
+
+  it('treats prototype keys as unknown tools', () => {
+    expect(toolConfig('__proto__')).toEqual({
+      glyph: 'TL',
+      label: '__proto__',
+      description: '__proto__ 도구',
+    })
+    expect(toolConfig('constructor')).toEqual({
+      glyph: 'TL',
+      label: 'constructor',
+      description: 'constructor 도구',
+    })
+  })
 })
 
 describe('summarizeAgentCapability', () => {
@@ -77,6 +90,14 @@ describe('summarizeAgentCapability', () => {
     expect(summary.hidden).toEqual(['shell'])
     expect(summary.extraCount).toBe(1)
     expect(summary.maxVisible).toBe(0)
+  })
+
+  it('does not mark inherited object keys as known', () => {
+    const summary = summarizeAgentCapability(['__proto__', 'constructor'])
+    expect(summary.visible).toEqual([
+      expect.objectContaining({ tool: '__proto__', glyph: 'TL', known: false }),
+      expect.objectContaining({ tool: 'constructor', glyph: 'TL', known: false }),
+    ])
   })
 })
 

--- a/dashboard/src/components/common/agent-capability.ts
+++ b/dashboard/src/components/common/agent-capability.ts
@@ -4,33 +4,34 @@
 // an agent can use. The compact badge row lets operators quickly scan
 // an agent's capability envelope without opening a detail panel.
 //
-// Icons are text/emoji placeholders (Kimi spec uses emoji). Production
-// code should swap the icon field for an SVG icon map when an icon
-// library is adopted.
+// Cockpit treatment uses compact mono glyphs instead of emoji/icon-library
+// placeholders so capability affordances stay dense and operator-readable.
 
 import { html } from 'htm/preact'
 
-interface ToolConfig {
-  icon: string
+export type CapabilityGlyph = 'RD' | 'WR' | 'SH' | 'SR' | 'DB' | 'API' | 'TL'
+
+export interface ToolConfig {
+  glyph: CapabilityGlyph
   label: string
   description: string
 }
 
-const TOOL_CONFIG: Record<string, ToolConfig> = {
-  file_read: { icon: '\u{1F4C4}', label: '파일 읽기', description: '로컬 파일 시스템 읽기' },
-  file_write: { icon: '\u{270F}\u{FE0F}', label: '파일 쓰기', description: '로컬 파일 시스템 쓰기' },
-  shell: { icon: '\u{1F4BB}', label: '터미널', description: '셸 명령 실행' },
-  web_search: { icon: '\u{1F50D}', label: '웹 검색', description: '인터넷 검색' },
-  db_query: { icon: '\u{1F5C3}\u{FE0F}', label: 'DB 쿼리', description: '데이터베이스 조회' },
-  api_call: { icon: '\u{1F50C}', label: 'API 호출', description: '외부 API 호출' },
+export const TOOL_CONFIG: Record<string, ToolConfig> = {
+  file_read: { glyph: 'RD', label: '파일 읽기', description: '로컬 파일 시스템 읽기' },
+  file_write: { glyph: 'WR', label: '파일 쓰기', description: '로컬 파일 시스템 쓰기' },
+  shell: { glyph: 'SH', label: '터미널', description: '셸 명령 실행' },
+  web_search: { glyph: 'SR', label: '웹 검색', description: '인터넷 검색' },
+  db_query: { glyph: 'DB', label: 'DB 쿼리', description: '데이터베이스 조회' },
+  api_call: { glyph: 'API', label: 'API 호출', description: '외부 API 호출' },
 }
 
 /** Pure: lookup a tool's display config. Falls back to a generic
     representation for unknown tools so the UI never renders blank. */
-function toolConfig(tool: string): ToolConfig {
+export function toolConfig(tool: string): ToolConfig {
   return (
     TOOL_CONFIG[tool] ?? {
-      icon: '\u{2699}\u{FE0F}',
+      glyph: 'TL',
       label: tool,
       description: `${tool} 도구`,
     }
@@ -53,6 +54,60 @@ export function normalizeTools(
   return out
 }
 
+export interface CapabilityItemSummary {
+  tool: string
+  glyph: CapabilityGlyph
+  label: string
+  description: string
+  known: boolean
+  index: number
+}
+
+export interface AgentCapabilitySummary {
+  tools: string[]
+  visible: CapabilityItemSummary[]
+  hidden: string[]
+  count: number
+  visibleCount: number
+  extraCount: number
+  empty: boolean
+  maxVisible: number
+  hiddenLabel: string
+}
+
+export function summarizeAgentCapability(
+  tools: Array<string | null | undefined> | null | undefined,
+  maxVisible = 4,
+): AgentCapabilitySummary {
+  const normalized = normalizeTools(tools)
+  const limit = Math.max(0, Math.floor(maxVisible))
+  const visibleTools = normalized.slice(0, limit)
+  const hidden = normalized.slice(limit)
+  const visible = visibleTools.map((tool, index) => {
+    const cfg = toolConfig(tool)
+    return {
+      tool,
+      glyph: cfg.glyph,
+      label: cfg.label,
+      description: cfg.description,
+      known: Boolean(TOOL_CONFIG[tool]),
+      index,
+    }
+  })
+
+  return {
+    tools: normalized,
+    visible,
+    hidden,
+    count: normalized.length,
+    visibleCount: visible.length,
+    extraCount: hidden.length,
+    empty: normalized.length === 0,
+    maxVisible: limit,
+    hiddenLabel: hidden.join(', '),
+  }
+}
+
 interface AgentCapabilityProps {
   tools: Array<string | null | undefined> | null | undefined
   maxVisible?: number
@@ -60,53 +115,75 @@ interface AgentCapabilityProps {
 }
 
 const BASE_BADGE =
-  'inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-elevated)]'
+  'inline-flex min-w-0 max-w-full items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-elevated)]'
+
+const GLYPH_BADGE =
+  'mr-1 inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-1 font-mono text-[9px] font-semibold leading-none text-[var(--color-fg-accent)]'
 
 export function AgentCapability({
   tools,
   maxVisible = 4,
   testId,
 }: AgentCapabilityProps) {
-  const normalized = normalizeTools(tools)
-  const visible = normalized.slice(0, maxVisible)
-  const extra = Math.max(0, normalized.length - maxVisible)
+  const summary = summarizeAgentCapability(tools, maxVisible)
 
-  if (visible.length === 0 && extra === 0) {
+  if (summary.empty) {
     return html`
       <span
-        class="inline-flex items-center rounded-[var(--r-0)] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]"
+        class="inline-flex min-w-0 max-w-full items-center rounded-[var(--r-0)] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]"
         data-agent-capability
+        data-capability-count=${summary.count}
+        data-capability-visible-count=${summary.visibleCount}
+        data-capability-extra-count=${summary.extraCount}
+        data-capability-max-visible=${summary.maxVisible}
+        data-capability-empty=${summary.empty}
+        data-capability-hidden-label=${summary.hiddenLabel}
         data-testid=${testId}
       >
-        도구 없음
+        <span class=${GLYPH_BADGE} aria-hidden="true">TL</span>
+        <span class="min-w-0 truncate">도구 없음</span>
       </span>
     `
   }
 
   return html`
-    <div class="flex flex-wrap items-center gap-1.5" data-agent-capability data-testid=${testId}>
-      ${visible.map(
-        tool => {
-          const cfg = toolConfig(tool)
-          return html`
-            <span
-              class=${BASE_BADGE}
-              title=${cfg.description}
-              data-tool=${tool}
-            >
-              <span aria-hidden="true">${cfg.icon}</span>
-              <span class="ml-1">${cfg.label}</span>
-            </span>
-          `
-        },
+    <div
+      class="flex min-w-0 max-w-full flex-wrap items-center gap-1.5"
+      data-agent-capability
+      data-capability-count=${summary.count}
+      data-capability-visible-count=${summary.visibleCount}
+      data-capability-extra-count=${summary.extraCount}
+      data-capability-max-visible=${summary.maxVisible}
+      data-capability-empty=${summary.empty}
+      data-capability-hidden-label=${summary.hiddenLabel}
+      data-testid=${testId}
+    >
+      ${summary.visible.map(
+        item => html`
+          <span
+            class=${BASE_BADGE}
+            title=${item.description}
+            data-tool=${item.tool}
+            data-capability-tool=${item.tool}
+            data-capability-tool-index=${item.index}
+            data-capability-tool-known=${item.known}
+            data-capability-tool-label=${item.label}
+            data-capability-tool-glyph=${item.glyph}
+          >
+            <span class=${GLYPH_BADGE} aria-hidden="true">${item.glyph}</span>
+            <span class="min-w-0 truncate">${item.label}</span>
+          </span>
+        `,
       )}
-      ${extra > 0
+      ${summary.extraCount > 0
         ? html`
             <span
-              class="inline-flex items-center rounded-[var(--r-0)] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]"
-              title="${normalized.slice(maxVisible).join(', ')}"
+              class="inline-flex min-w-0 max-w-full items-center rounded-[var(--r-0)] border border-dashed border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 font-mono text-3xs text-[var(--color-fg-muted)]"
+              title=${summary.hiddenLabel}
+              data-capability-extra
+              data-capability-extra-count=${summary.extraCount}
             >
-              +${extra}
+              +${summary.extraCount}
             </span>
           `
         : null}

--- a/dashboard/src/components/common/agent-capability.ts
+++ b/dashboard/src/components/common/agent-capability.ts
@@ -17,25 +17,28 @@ export interface ToolConfig {
   description: string
 }
 
-export const TOOL_CONFIG: Record<string, ToolConfig> = {
+const TOOL_CONFIG = Object.freeze({
   file_read: { glyph: 'RD', label: '파일 읽기', description: '로컬 파일 시스템 읽기' },
   file_write: { glyph: 'WR', label: '파일 쓰기', description: '로컬 파일 시스템 쓰기' },
   shell: { glyph: 'SH', label: '터미널', description: '셸 명령 실행' },
   web_search: { glyph: 'SR', label: '웹 검색', description: '인터넷 검색' },
   db_query: { glyph: 'DB', label: 'DB 쿼리', description: '데이터베이스 조회' },
   api_call: { glyph: 'API', label: 'API 호출', description: '외부 API 호출' },
+} satisfies Record<string, ToolConfig>)
+
+function hasToolConfig(tool: string): tool is keyof typeof TOOL_CONFIG {
+  return Object.prototype.hasOwnProperty.call(TOOL_CONFIG, tool)
 }
 
 /** Pure: lookup a tool's display config. Falls back to a generic
     representation for unknown tools so the UI never renders blank. */
 export function toolConfig(tool: string): ToolConfig {
-  return (
-    TOOL_CONFIG[tool] ?? {
-      glyph: 'TL',
-      label: tool,
-      description: `${tool} 도구`,
-    }
-  )
+  if (hasToolConfig(tool)) return TOOL_CONFIG[tool]
+  return {
+    glyph: 'TL',
+    label: tool,
+    description: `${tool} 도구`,
+  }
 }
 
 /** Pure: filter + deduplicate tool names, preserving order. */
@@ -90,7 +93,7 @@ export function summarizeAgentCapability(
       glyph: cfg.glyph,
       label: cfg.label,
       description: cfg.description,
-      known: Boolean(TOOL_CONFIG[tool]),
+      known: hasToolConfig(tool),
       index,
     }
   })
@@ -118,7 +121,7 @@ const BASE_BADGE =
   'inline-flex min-w-0 max-w-full items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-elevated)]'
 
 const GLYPH_BADGE =
-  'mr-1 inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-1 font-mono text-[9px] font-semibold leading-none text-[var(--color-fg-accent)]'
+  'mr-1 inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-1 font-mono text-[9px] font-semibold leading-none text-[var(--color-accent-fg)]'
 
 export function AgentCapability({
   tools,


### PR DESCRIPTION
## Summary

- export `toolConfig`, `summarizeAgentCapability`, and capability summary types for the AgentCapability molecule
- replace emoji placeholders with dense Cockpit-style mono glyph badges (`RD`, `WR`, `SH`, `SR`, `DB`, `API`, `TL`)
- publish root, badge, overflow, empty, known/unknown, count, and hidden-label metadata via `data-capability-*`
- tighten badge sizing/truncation so long unknown tool names stay contained on mobile

## Why This Matters

Agent capability badges are one of the remaining small components that still had placeholder emoji semantics from the older Kimi reference. This moves the component toward the Cockpit design rules: dense operator-readable labels, no emoji/icon-library dependency, and inspectable state for tests, QA, and downstream dashboard composition.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/agent-capability.test.ts src/components/common/agent-capability.a11y.test.ts` — 20 passed
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` — existing 3 warnings only: `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`
- `pnpm --dir dashboard run build` — completed with existing Vite dynamic/static import and chunk-size warnings
- Browser QA via `agent-browser` against temporary Vite page on desktop and mobile
  - `/tmp/masc-agent-capability-summary-0506.png`
  - `/tmp/masc-agent-capability-summary-0506-mobile.png`

## Browser QA Notes

- Desktop and mobile screenshots inspected with `view_image`
- Verified visible, overflow, unknown long-tool, and empty states
- Verified `data-capability-count`, visible count, extra count, empty state, hidden labels, per-tool glyphs, and known/unknown metadata
- Verified no page-level horizontal overflow at 390px mobile viewport
- Verified no emoji glyphs in rendered capability metadata
- Browser console/errors clean apart from normal Vite debug connection logs