### PR TITLE
fix(keeper): auto-pause stale fleet batches

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -863,8 +863,8 @@ describe('fetchKeeperConfig', () => {
         fiber_health: 'healthy',
         presence_keepalive: 'true',
         presence_keepalive_sec: '30',
-        runtime_blocker_class: 'stale_termination_storm',
-        runtime_blocker_summary: 'Stale watchdog terminated 3 keeper cycles.',
+        runtime_blocker_class: 'stale_fleet_batch',
+        runtime_blocker_summary: 'Fleet batch paused after stale termination storm.',
         runtime_blocker_continue_gate: 'false',
       },
       runtime_trust: {
@@ -963,8 +963,8 @@ describe('fetchKeeperConfig', () => {
     expect(result.sources.cascade_runtime_json_editable).toBe(false)
     expect(result.metrics.total_cost_usd).toBe(0.12)
     expect(result.runtime.presence_keepalive_sec).toBe(30)
-    expect(result.runtime.runtime_blocker_class).toBe('stale_termination_storm')
-    expect(result.runtime.runtime_blocker_summary).toBe('Stale watchdog terminated 3 keeper cycles.')
+    expect(result.runtime.runtime_blocker_class).toBe('stale_fleet_batch')
+    expect(result.runtime.runtime_blocker_summary).toBe('Fleet batch paused after stale termination storm.')
     expect(result.active_goal_ids).toEqual(['goal-runtime'])
     expect(result.coordination.active_goal_ids).toEqual(['goal-runtime'])
     expect(result.coordination.active_goals[0]?.title).toBe('Ship runtime clarity')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1985,6 +1985,7 @@ function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['
     case 'heartbeat_failures':
     case 'turn_failures':
     case 'exception':
+    case 'stale_fleet_batch':
       return blockerClass
     default:
       return null

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -101,6 +101,7 @@ describe('mission keeper runtime helpers', () => {
     expect(keeperRuntimeBlockerLabel('provider_runtime_error')).toBe('Provider 런타임 오류')
     expect(keeperRuntimeBlockerLabel('tool_required_unsatisfied')).toBe('필수 도구 미충족')
     expect(keeperRuntimeBlockerLabel('exception')).toBe('런타임 예외')
+    expect(keeperRuntimeBlockerLabel('stale_fleet_batch')).toBe('Fleet stale 배치')
   })
 
   it('turns raw backend blocker codes into operator-readable hints', () => {
@@ -127,6 +128,19 @@ describe('mission keeper runtime helpers', () => {
 
     expect(keeperRuntimeHint(keeper)).toBe(
       'Stale watchdog terminated 8 keeper cycle(s) in the storm window; operator investigation is required before restart.',
+    )
+  })
+
+  it('turns stale fleet batch blockers into operator-readable hints', () => {
+    const keeper = {
+      name: 'batch-paused',
+      status: 'paused',
+      runtime_blocker_class: 'stale_fleet_batch',
+      runtime_blocker_summary: 'stale_fleet_batch',
+    } as Keeper
+
+    expect(keeperRuntimeHint(keeper)).toBe(
+      '여러 keeper가 같은 watchdog 창에서 stale로 종료되어 supervisor pause/backoff 상태 확인이 필요합니다.',
     )
   })
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -246,6 +246,7 @@ const runtimeBlockerLabels = {
   heartbeat_failures: '하트비트 실패',
   turn_failures: '턴 실패 반복',
   exception: '런타임 예외',
+  stale_fleet_batch: 'Fleet stale 배치',
 } satisfies Record<KeeperRuntimeBlockerClass, string>
 
 export function keeperRuntimeBlockerLabel(
@@ -314,6 +315,9 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'exception') {
     return 'Keeper 런타임 예외가 기록되어 로그와 최근 turn 상태 확인이 필요합니다.'
+  }
+  if (blockerClass === 'stale_fleet_batch') {
+    return '여러 keeper가 같은 watchdog 창에서 stale로 종료되어 supervisor pause/backoff 상태 확인이 필요합니다.'
   }
   return null
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -346,6 +346,7 @@ export type KeeperRuntimeBlockerClass =
   | 'heartbeat_failures'
   | 'turn_failures'
   | 'exception'
+  | 'stale_fleet_batch'
 
 export interface KeeperTrustLatestEvent {
   kind: string

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -665,6 +665,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         | Some { Keeper_registry.last_failure_reason =
                    Some ((Keeper_registry.Stale_turn_timeout _
                          | Keeper_registry.Stale_termination_storm _
+                         | Keeper_registry.Stale_fleet_batch _
                          | Keeper_registry.Oas_timeout_budget_loop _) as reason);
                  _ } ->
           record_crash reason

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -113,6 +113,11 @@ type blocker_class =
         per-keeper meta read [last_blocker_class = null] for the
         majority cohort during a fleet stall (observed: 6/14 keepers
         in cohort=stale_turn_timeout, every meta showing null). *)
+  | Stale_fleet_batch
+    (** Multiple keepers were stale-watchdog terminated inside the fleet
+        batch window. This mirrors [Keeper_registry.Stale_fleet_batch] so
+        keeper_meta and dashboard status can report the systemic blocker
+        instead of collapsing it to a generic turn timeout. *)
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
@@ -127,6 +132,7 @@ let blocker_class_to_string = function
   | No_tool_capable_provider -> "no_tool_capable_provider"
   | Fiber_unresolved -> "fiber_unresolved"
   | Stale_turn_timeout -> "stale_turn_timeout"
+  | Stale_fleet_batch -> "stale_fleet_batch"
 ;;
 
 let blocker_class_of_serialized_string = function
@@ -142,6 +148,7 @@ let blocker_class_of_serialized_string = function
   | "no_tool_capable_provider" -> Some No_tool_capable_provider
   | "fiber_unresolved" -> Some Fiber_unresolved
   | "stale_turn_timeout" -> Some Stale_turn_timeout
+  | "stale_fleet_batch" -> Some Stale_fleet_batch
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -146,6 +146,7 @@ type blocker_class =
   | No_tool_capable_provider
   | Fiber_unresolved
   | Stale_turn_timeout
+  | Stale_fleet_batch
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -62,6 +62,12 @@ type failure_reason =
           persisting [meta.paused = true] instead so an operator must
           investigate the underlying cascade/provider/fd issue before
           resuming the keeper. *)
+  | Stale_fleet_batch of { distinct_count : int }
+      (** Latched when the stale watchdog observes several distinct keepers
+          terminating inside the fleet batch window. This is a systemic
+          cascade/provider/runtime signal, so the supervisor pauses affected
+          keepers with auto-resume backoff instead of restarting each keeper
+          independently into the same failure mode. *)
   | Oas_timeout_budget_loop of { count : int }
       (** Latched when the same keeper exhausts the OAS turn budget on
           consecutive cycles. This is a provider/cascade/runtime throughput
@@ -87,6 +93,8 @@ let failure_reason_to_string = function
         (stale_kill_class_to_string cls)
   | Stale_termination_storm { count } ->
       Printf.sprintf "stale_termination_storm(count=%d)" count
+  | Stale_fleet_batch { distinct_count } ->
+      Printf.sprintf "stale_fleet_batch(distinct_count=%d)" distinct_count
   | Oas_timeout_budget_loop { count } ->
       Printf.sprintf "oas_timeout_budget_loop(count=%d)" count
   | Provider_runtime_error { code; detail } ->
@@ -114,6 +122,7 @@ let failure_reason_cohort_key = function
   | Some (Turn_consecutive_failures _) -> "turn_failures"
   | Some (Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Stale_termination_storm _) -> "stale_termination_storm"
+  | Some (Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Oas_timeout_budget_loop _) -> "oas_timeout_budget_loop"
   | Some (Provider_runtime_error _) -> "provider_runtime_error"
   | Some (Tool_required_unsatisfied _) -> "tool_required_unsatisfied"
@@ -133,7 +142,12 @@ let stale_watchdog_failure_reason ~prior ~kill_class =
       | Heartbeat_consecutive_failures _
       | Exception _ ) ->
       prior
-  | Some (Stale_termination_storm _ | Stale_turn_timeout _ | Fiber_unresolved)
+  | Some
+      ( Stale_termination_storm _
+      | Stale_fleet_batch _
+      | Stale_turn_timeout _
+      | Fiber_unresolved ) as prior ->
+      prior
   | None ->
       Some (Stale_turn_timeout kill_class)
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -62,6 +62,12 @@ type failure_reason =
           persisting [meta.paused = true] instead so an operator must
           investigate the underlying cascade/provider/fd issue before
           resuming the keeper. *)
+  | Stale_fleet_batch of { distinct_count : int }
+      (** Latched when the stale watchdog observes several distinct keepers
+          terminating inside the fleet batch window. This is a systemic
+          cascade/provider/runtime signal, so the supervisor pauses affected
+          keepers with auto-resume backoff instead of restarting each keeper
+          independently into the same failure mode. *)
   | Oas_timeout_budget_loop of { count : int }
       (** Latched when the same keeper exhausts the OAS turn budget on
           consecutive cycles. This is a provider/cascade/runtime throughput

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -276,10 +276,11 @@ let () =
 
    Track recent terminations across all keepers in a small bounded
    window.  When the number of distinct keepers in the window
-   reaches the threshold we emit a fleet-tier ERROR and a Prometheus
-   counter labelled by the low-cardinality [batch_root_cause].  No
-   state-machine change: the per-keeper restart still proceeds.  The
-   point is to make the batch event visible at all. *)
+   reaches the threshold we emit a fleet-tier ERROR, a Prometheus
+   counter labelled by the low-cardinality [batch_root_cause], and
+   latch the affected keepers into [Stale_fleet_batch].  The supervisor
+   then pauses/backs off those keepers instead of restarting each one
+   into the same systemic failure mode. *)
 let batch_window_sec = Env_config_keeper.KeeperWatchdog.batch_window_sec
 let batch_threshold = Env_config_keeper.KeeperWatchdog.batch_threshold
 let batch_terminations : (string * float) list Atomic.t = Atomic.make []
@@ -297,6 +298,43 @@ let record_batch_termination keeper_name now : string list =
   in
   let entries = atomic_update () in
   List.sort_uniq compare (List.map fst entries)
+
+let reset_batch_terminations_for_test () =
+  Atomic.set batch_terminations []
+
+let record_batch_termination_for_test = record_batch_termination
+
+let latch_stale_fleet_batch_reasons ~base_path ~distinct_count keeper_names =
+  List.iter
+    (fun keeper_name ->
+       match Keeper_registry.get ~base_path keeper_name with
+       | None -> ()
+       | Some entry ->
+           (match entry.last_failure_reason with
+            | Some
+                ( Keeper_registry.Oas_timeout_budget_loop _
+                | Keeper_registry.Provider_runtime_error _
+                | Keeper_registry.Tool_required_unsatisfied _
+                | Keeper_registry.Ambiguous_partial_commit _
+                | Keeper_registry.Turn_consecutive_failures _
+                | Keeper_registry.Heartbeat_consecutive_failures _
+                | Keeper_registry.Stale_termination_storm _
+                | Keeper_registry.Exception _ ) ->
+                ()
+            | Some (Keeper_registry.Stale_fleet_batch { distinct_count = n })
+              when n >= distinct_count ->
+                ()
+            | Some (Keeper_registry.Stale_turn_timeout _)
+            | Some (Keeper_registry.Stale_fleet_batch _)
+            | Some Keeper_registry.Fiber_unresolved
+            | None ->
+                Keeper_registry.set_failure_reason ~base_path keeper_name
+                  (Some
+                     (Keeper_registry.Stale_fleet_batch { distinct_count }))))
+    keeper_names
+
+let latch_stale_fleet_batch_reasons_for_test =
+  latch_stale_fleet_batch_reasons
 
 let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
@@ -593,6 +631,9 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  let root_cause_label =
                    batch_root_cause_to_string root_cause
                  in
+                 let distinct_count = List.length batch in
+                 latch_stale_fleet_batch_reasons ~base_path ~distinct_count
+                   batch;
                  Prometheus.inc_counter
                    Prometheus.metric_keeper_stale_termination_batch
                    ~labels:[ ("root_cause", root_cause_label) ]
@@ -601,9 +642,10 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    "FLEET BATCH TERMINATION: %d distinct keepers \
                     terminated in last %.0fs [%s] — systemic signal \
                     root_cause=%s.  \
-                    Per-keeper restarts will loop without operator \
-                    intervention.  See #10765, #10474, #10745."
-                   (List.length batch) batch_window_sec
+                    Affected keepers are latched for auto-pause/backoff \
+                    instead of independent restart.  See #10765, #10474, \
+                    #10745."
+                   distinct_count batch_window_sec
                    (String.concat ", " batch) root_cause_label
                end;
                (try

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -172,6 +172,7 @@ let failure_reason_batch_root_cause
       Some Fd_exhaustion
   | Stale_turn_timeout _
   | Stale_termination_storm _
+  | Stale_fleet_batch _
   | Oas_timeout_budget_loop _
   | Provider_runtime_error _ ->
       Some Cascade_unhealthy
@@ -304,30 +305,59 @@ let reset_batch_terminations_for_test () =
 
 let record_batch_termination_for_test = record_batch_termination
 
-let latch_stale_fleet_batch_reasons ~base_path ~distinct_count keeper_names =
+let stamp_stale_fleet_batch_meta ~config ~keeper_name ~distinct_count
+    ~root_reason =
+  let base_path = config.Coord.base_path in
+  match Keeper_registry.get ~base_path keeper_name with
+  | None -> ()
+  | Some entry ->
+    let root_text =
+      root_reason
+      |> Option.map Keeper_registry.failure_reason_to_string
+      |> Option.value ~default:"none"
+    in
+    let blocker =
+      Printf.sprintf "stale_fleet_batch(distinct_count=%d root_cause=%s)"
+        distinct_count root_text
+    in
+    let meta =
+      { entry.meta with
+        runtime =
+          { entry.meta.runtime with
+            last_blocker = blocker;
+            last_blocker_class = Some Stale_fleet_batch;
+          };
+      }
+    in
+    (match
+       write_meta_with_merge
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+         config meta
+     with
+     | Ok () -> ()
+     | Error err ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_write_meta_failures
+         ~labels:[("keeper", keeper_name); ("phase", "stale_fleet_batch_stamp")]
+         ();
+       Log.Keeper.warn
+         "%s: stale_fleet_batch meta stamp failed: %s"
+         keeper_name err)
+
+let latch_stale_fleet_batch_reasons ~config ~distinct_count keeper_names =
+  let base_path = config.Coord.base_path in
   List.iter
     (fun keeper_name ->
        match Keeper_registry.get ~base_path keeper_name with
        | None -> ()
        | Some entry ->
            (match entry.last_failure_reason with
-            | Some
-                ( Keeper_registry.Oas_timeout_budget_loop _
-                | Keeper_registry.Provider_runtime_error _
-                | Keeper_registry.Tool_required_unsatisfied _
-                | Keeper_registry.Ambiguous_partial_commit _
-                | Keeper_registry.Turn_consecutive_failures _
-                | Keeper_registry.Heartbeat_consecutive_failures _
-                | Keeper_registry.Stale_termination_storm _
-                | Keeper_registry.Exception _ ) ->
-                ()
             | Some (Keeper_registry.Stale_fleet_batch { distinct_count = n })
               when n >= distinct_count ->
                 ()
-            | Some (Keeper_registry.Stale_turn_timeout _)
-            | Some (Keeper_registry.Stale_fleet_batch _)
-            | Some Keeper_registry.Fiber_unresolved
-            | None ->
+            | root_reason ->
+                stamp_stale_fleet_batch_meta ~config ~keeper_name
+                  ~distinct_count ~root_reason;
                 Keeper_registry.set_failure_reason ~base_path keeper_name
                   (Some
                      (Keeper_registry.Stale_fleet_batch { distinct_count }))))
@@ -632,7 +662,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    batch_root_cause_to_string root_cause
                  in
                  let distinct_count = List.length batch in
-                 latch_stale_fleet_batch_reasons ~base_path ~distinct_count
+                 latch_stale_fleet_batch_reasons ~config:ctx.config ~distinct_count
                    batch;
                  Prometheus.inc_counter
                    Prometheus.metric_keeper_stale_termination_batch

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -27,6 +27,16 @@ val classify_batch_root_cause_for_test :
   Keeper_registry.failure_reason list -> batch_root_cause
 (** Test-only view of the batch root-cause classifier. *)
 
+val reset_batch_terminations_for_test : unit -> unit
+(** Test-only reset for fleet batch termination history. *)
+
+val record_batch_termination_for_test : string -> float -> string list
+(** Test-only wrapper around the fleet batch termination window. *)
+
+val latch_stale_fleet_batch_reasons_for_test :
+  base_path:string -> distinct_count:int -> string list -> unit
+(** Test-only wrapper for the batch failure-reason latch. *)
+
 val fork_stale_watchdog :
   'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
 (** Fork a stale-turn watchdog fiber for the given keeper.
@@ -49,5 +59,6 @@ val fork_stale_watchdog :
     per-class root-cause attribution.
 
     On detection, sets [fiber_stop] and emits a stale broadcast. The
-    supervisor's [sweep_and_recover] picks up the stopped fiber and
-    restarts with exponential backoff. *)
+    supervisor's [sweep_and_recover] picks up the stopped fiber and restarts
+    with exponential backoff, unless a per-keeper stale storm or fleet batch
+    latch routes the keeper to auto-pause/backoff first. *)

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -34,7 +34,7 @@ val record_batch_termination_for_test : string -> float -> string list
 (** Test-only wrapper around the fleet batch termination window. *)
 
 val latch_stale_fleet_batch_reasons_for_test :
-  base_path:string -> distinct_count:int -> string list -> unit
+  config:Coord.config -> distinct_count:int -> string list -> unit
 (** Test-only wrapper for the batch failure-reason latch. *)
 
 val fork_stale_watchdog :

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -339,6 +339,14 @@ let runtime_blocker_surface_of_failure_reason
                 "OAS budget timeout repeated %d consecutive cycle(s); keeper was auto-paused before restart loop."
                 count)
            Oas_timeout_budget)
+  | Keeper_registry.Stale_fleet_batch { distinct_count } ->
+      Some
+        (runtime_blocker_surface_of_typed_class
+           ~summary:
+             (Printf.sprintf
+                "Stale watchdog terminated %d distinct keeper(s) inside the fleet batch window; keeper was auto-paused before restart loop."
+                distinct_count)
+           Stale_fleet_batch)
   | Keeper_registry.Provider_runtime_error { code; detail } ->
       Some
         {

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -226,16 +226,18 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               watchdog sets fiber_stop + Stale_turn_timeout, the heartbeat
               loop exits normally but the supervisor must treat this as a
               crash so sweep_and_recover restarts the keeper.
-              #10765 Phase 2: [Stale_termination_storm] also funnels through
-              the crash path, but [sweep_and_recover]'s [`Crashed] branch
-              detects this variant and routes to auto-pause instead of
-              [to_restart], breaking the restart-loop-back-to-stale cycle. *)
+              #10765 Phase 2: [Stale_termination_storm] and
+              [Stale_fleet_batch] also funnel through the crash path, but
+              [sweep_and_recover]'s [`Crashed] branch detects these variants
+              and routes to auto-pause instead of [to_restart], breaking the
+              restart-loop-back-to-stale cycle. *)
            let watchdog_triggered =
              match Keeper_registry.get ~base_path meta.name with
              | Some e -> (
                  match e.last_failure_reason with
                  | Some (Keeper_registry.Stale_turn_timeout _)
                  | Some (Keeper_registry.Stale_termination_storm _)
+                 | Some (Keeper_registry.Stale_fleet_batch _)
                  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> true
                  | _ -> false)
              | None -> false
@@ -1137,6 +1139,23 @@ let handle_stale_storm_pause (ctx : _ context)
           See issue #10765."
          count)
 
+let handle_stale_fleet_batch_pause (ctx : _ context)
+    (entry : Keeper_registry.registry_entry) ~distinct_count =
+  handle_crash_auto_pause ctx entry
+    ~reason_tag:"stale_fleet_batch"
+    ~metric_name:Prometheus.metric_keeper_stale_fleet_batch_paused
+    ~lifecycle_detail:
+      (Printf.sprintf "stale_fleet_batch distinct_count=%d" distinct_count)
+    ~blocker_class:(Some Stale_fleet_batch)
+    ~log_message:
+      (Printf.sprintf
+         "STALE FLEET BATCH AUTO-PAUSED (distinct_keepers=%d in batch \
+          window). Supervisor will attempt self-healing auto-resume with \
+          exponential back-off instead of restarting each keeper into the \
+          same systemic failure mode (cascade dead, provider auth, fd leak, \
+          etc.). See #10765 / #10474 / #10745."
+         distinct_count)
+
 let handle_oas_timeout_budget_pause (ctx : _ context)
     (entry : Keeper_registry.registry_entry) ~count =
   handle_crash_auto_pause ctx entry
@@ -1181,6 +1200,12 @@ let sweep_and_recover (ctx : _ context) =
            once per storm, not once per sweep tick). *)
         handle_stale_storm_pause ctx entry ~count;
         to_unregister := entry :: !to_unregister
+    | Some (Keeper_registry.Stale_fleet_batch { distinct_count }) ->
+        (* Fleet batch detection means multiple keepers crossed the stale
+           watchdog together. Treating those as independent keeper crashes
+           immediately replays the batch. Pause/backoff instead. *)
+        handle_stale_fleet_batch_pause ctx entry ~distinct_count;
+        to_unregister := entry :: !to_unregister
     | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
         (* Repeated OAS budget exhaustion means the active
            cascade/model is not producing within the turn budget.
@@ -1203,6 +1228,7 @@ let sweep_and_recover (ctx : _ context) =
     match entry.last_failure_reason with
     | Some (Keeper_registry.Stale_turn_timeout _)
     | Some (Keeper_registry.Stale_termination_storm _)
+    | Some (Keeper_registry.Stale_fleet_batch _)
     | Some (Keeper_registry.Oas_timeout_budget_loop _) -> true
     | _ -> false
   in
@@ -1220,11 +1246,11 @@ let sweep_and_recover (ctx : _ context) =
        finally branch; this branch — [force_unresolved_watchdog_crash]
        — was the other silent path where the stamp was missing.
        Mapping covers all three watchdog cohorts handled by
-       [watchdog_stop_pending]; only [Stale_turn_timeout] currently
-       has a dedicated [blocker_class] variant, the other two map to
-       it as a best-effort signal until they get their own variants. *)
+       [watchdog_stop_pending]. *)
     let stamp_cohort =
       match entry.last_failure_reason with
+      | Some (Keeper_registry.Stale_fleet_batch _) ->
+        Some Stale_fleet_batch
       | Some (Keeper_registry.Stale_turn_timeout _)
       | Some (Keeper_registry.Stale_termination_storm _)
       | Some (Keeper_registry.Oas_timeout_budget_loop _) ->
@@ -1921,7 +1947,7 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
      like [Turn_consecutive_failures] / [Exception] / etc.  Those
      reasons are not in the [watchdog_stop_pending] restart set
      ([Stale_turn_timeout | Stale_termination_storm |
-     Oas_timeout_budget_loop]), so preserving them would set
+     Stale_fleet_batch | Oas_timeout_budget_loop]), so preserving them would set
      [fiber_stop = true] and then the supervisor's next sweep would
      skip [force_unresolved_watchdog_crash] — the fiber goes dormant
      instead of being restarted, defeating the entire recovery.
@@ -1933,7 +1959,7 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
 
      Idempotent: if the keeper is already in a watchdog cohort
      ([Stale_turn_timeout] / [Stale_termination_storm] /
-     [Oas_timeout_budget_loop]), preserve it so we don't churn the
+     [Stale_fleet_batch] / [Oas_timeout_budget_loop]), preserve it so we don't churn the
      [stall_seconds] field on every poll. *)
   let prior_str =
     Option.map Keeper_registry.failure_reason_to_string
@@ -1945,6 +1971,7 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
     | Some
         ( Keeper_registry.Stale_turn_timeout _
         | Keeper_registry.Stale_termination_storm _
+        | Keeper_registry.Stale_fleet_batch _
         | Keeper_registry.Oas_timeout_budget_loop _ ) as kept ->
         kept
     | _ -> Some (Keeper_registry.Stale_turn_timeout kill_class)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1251,9 +1251,10 @@ let sweep_and_recover (ctx : _ context) =
       match entry.last_failure_reason with
       | Some (Keeper_registry.Stale_fleet_batch _) ->
         Some Stale_fleet_batch
-      | Some (Keeper_registry.Stale_turn_timeout _)
-      | Some (Keeper_registry.Stale_termination_storm _)
       | Some (Keeper_registry.Oas_timeout_budget_loop _) ->
+        Some Oas_timeout_budget
+      | Some (Keeper_registry.Stale_turn_timeout _)
+      | Some (Keeper_registry.Stale_termination_storm _) ->
         Some Stale_turn_timeout
       | _ -> None
     in

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -170,6 +170,7 @@ type blocker_class =
   | No_tool_capable_provider
   | Fiber_unresolved
   | Stale_turn_timeout
+  | Stale_fleet_batch
 
 val blocker_class_to_string : blocker_class -> string
 val cascade_exhaustion_summary : cascade_exhaustion_reason -> string

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -643,6 +643,8 @@ let metric_keeper_self_preservation_universal =
   "masc_keeper_self_preservation_universal_total"
 let metric_keeper_stale_storm_paused =
   "masc_keeper_stale_storm_paused_total"
+let metric_keeper_stale_fleet_batch_paused =
+  "masc_keeper_stale_fleet_batch_paused_total"
 let metric_keeper_oas_timeout_budget_loop_paused =
   "masc_keeper_oas_timeout_budget_loop_paused_total"
 let metric_keeper_cycle_exceptions =
@@ -1852,6 +1854,10 @@ let init () =
   add metric_keeper_stale_storm_paused
     "Total keepers auto-paused due to stale termination storms. \
      Labeled by keeper."
+    Counter;
+  add metric_keeper_stale_fleet_batch_paused
+    "Total keepers auto-paused due to fleet-wide stale termination \
+     batches. Labeled by keeper."
     Counter;
   add metric_keeper_oas_timeout_budget_loop_paused
     "Total keepers auto-paused due to repeated OAS timeout budget \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -290,6 +290,7 @@ val metric_keeper_room_init_failures : string
 val metric_keeper_presence_sync_failures : string
 val metric_keeper_self_preservation_universal : string
 val metric_keeper_stale_storm_paused : string
+val metric_keeper_stale_fleet_batch_paused : string
 val metric_keeper_oas_timeout_budget_loop_paused : string
 val metric_keeper_cycle_exceptions : string
 val metric_keeper_snapshot_write_failures : string

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -32,10 +32,21 @@ let test_oas_timeout_budget_blocker_class_roundtrip () =
   | Some _ -> ()
   | None -> fail "Oas_timeout_budget label did not parse back"
 
+let test_stale_fleet_batch_blocker_class_roundtrip () =
+  let cls = KT.Stale_fleet_batch in
+  let label = KT.blocker_class_to_string cls in
+  check string "label" "stale_fleet_batch" label;
+  match MC.blocker_class_of_serialized_string label with
+  | Some MC.Stale_fleet_batch -> ()
+  | Some _ -> fail "Stale_fleet_batch label parsed as wrong class"
+  | None -> fail "Stale_fleet_batch label did not parse back"
+
 let test_blocker_class_labels_are_distinct () =
   let tt = KT.blocker_class_to_string KT.Turn_timeout in
   let ot = KT.blocker_class_to_string KT.Oas_timeout_budget in
-  check bool "Turn_timeout <> Oas_timeout_budget" true (tt <> ot)
+  let fb = KT.blocker_class_to_string KT.Stale_fleet_batch in
+  check bool "Turn_timeout <> Oas_timeout_budget" true (tt <> ot);
+  check bool "Stale_fleet_batch distinct" true (fb <> tt && fb <> ot)
 
 let test_meta_json_roundtrip_with_auto_pause_blocker () =
   let base_json = `Assoc [
@@ -113,6 +124,8 @@ let () =
             test_turn_timeout_blocker_class_roundtrip;
           test_case "Oas_timeout_budget roundtrip" `Quick
             test_oas_timeout_budget_blocker_class_roundtrip;
+          test_case "Stale_fleet_batch roundtrip" `Quick
+            test_stale_fleet_batch_blocker_class_roundtrip;
           test_case "labels are distinct" `Quick
             test_blocker_class_labels_are_distinct;
         ] );

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -31,6 +31,16 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop index =
+    if index + needle_len > haystack_len then false
+    else if String.sub haystack index needle_len = needle then true
+    else loop (index + 1)
+  in
+  needle_len = 0 || loop 0
+
 let with_restart_launch_noop f =
   Sup.set_restart_launch_noop_for_test true;
   Fun.protect
@@ -867,12 +877,19 @@ let test_stale_fleet_batch_latch_marks_batch_members () =
       (match reason "batch-a", reason "batch-b", reason "batch-provider" with
        | Some (Reg.Stale_fleet_batch { distinct_count = a }),
          Some (Reg.Stale_fleet_batch { distinct_count = b }),
-         Some (Reg.Provider_runtime_error { code; detail }) ->
+         Some (Reg.Stale_fleet_batch { distinct_count = c }) ->
            check int "batch-a distinct_count" 3 a;
            check int "batch-b distinct_count" 3 b;
-           check string "provider reason preserved code" "auth" code;
-           check string "provider reason preserved detail" "401" detail
-       | _ -> fail "unexpected batch latch failure reasons"))
+           check int "batch-provider distinct_count" 3 c
+       | _ -> fail "unexpected batch latch failure reasons");
+      (match KT.read_meta config "batch-provider" with
+       | Ok (Some m) ->
+           check bool "provider root cause remains in blocker text" true
+             (contains_substring m.runtime.last_blocker "provider_runtime_error");
+           check bool "provider blocker class is fleet batch" true
+             (m.runtime.last_blocker_class = Some KT.Stale_fleet_batch)
+       | Ok None -> fail "batch-provider meta missing"
+       | Error err -> fail ("read_meta failed: " ^ err)))
 
 let test_oas_timeout_budget_loop_pause_skips_restart () =
   Eio_main.run @@ fun env ->
@@ -976,7 +993,9 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
       (match KT.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = true after unresolved watchdog stop"
-             true m.paused
+             true m.paused;
+           check bool "budget loop blocker class preserved"
+             true (m.runtime.last_blocker_class = Some KT.Oas_timeout_budget)
        | Ok None -> fail "meta missing after unresolved watchdog stop"
        | Error err -> fail ("read_meta failed: " ^ err));
       check bool "unresolved watchdog-stopped entry reaped"

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -868,7 +868,7 @@ let test_stale_fleet_batch_latch_marks_batch_members () =
       Reg.set_failure_reason ~base_path:config.base_path "batch-provider"
         (Some (Reg.Provider_runtime_error { code = "auth"; detail = "401" }));
       Watchdog.latch_stale_fleet_batch_reasons_for_test
-        ~base_path:config.base_path ~distinct_count:3 names;
+        ~config ~distinct_count:3 names;
       let reason name =
         match Reg.get ~base_path:config.base_path name with
         | Some entry -> entry.Reg.last_failure_reason

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -5,6 +5,7 @@
 open Alcotest
 module Sup = Masc_mcp.Keeper_supervisor
 module Reg = Masc_mcp.Keeper_registry
+module Watchdog = Masc_mcp.Keeper_stale_watchdog
 module KT = Masc_mcp.Keeper_types
 module AQ = Masc_mcp.Keeper_approval_queue
 module KSM = Masc_mcp.Keeper_state_machine
@@ -762,6 +763,117 @@ let test_stale_storm_pause_skips_restart () =
       check bool "registry entry unregistered after storm pause"
         false (Reg.is_registered ~base_path:config.base_path name))
 
+let test_stale_fleet_batch_pause_skips_restart () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let name = "stale-fleet-batch-keeper" in
+      let meta = make_meta name in
+      (match KT.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      Eio.Promise.resolve reg.done_r (`Crashed "synthetic stale fleet batch");
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+      Reg.set_failure_reason ~base_path:config.base_path name
+        (Some (Reg.Stale_fleet_batch { distinct_count = 3 }));
+      let baseline_pause =
+        Masc_mcp.Prometheus.metric_total
+          "masc_keeper_stale_fleet_batch_paused_total"
+      in
+      let baseline_dead =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Prometheus.metric_keeper_dead_total
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      let after_pause =
+        Masc_mcp.Prometheus.metric_total
+          "masc_keeper_stale_fleet_batch_paused_total"
+      in
+      let after_dead =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Prometheus.metric_keeper_dead_total
+      in
+      check (float 0.001) "stale_fleet_batch_paused counter incremented by 1"
+        (baseline_pause +. 1.0) after_pause;
+      check (float 0.001) "dead counter NOT incremented (batch is not death)"
+        baseline_dead after_dead;
+      (match KT.read_meta config name with
+       | Ok (Some m) ->
+           check bool "meta.paused = true after fleet batch pause"
+             true m.paused;
+           check string "last_blocker records fleet batch"
+             "stale_fleet_batch" m.runtime.last_blocker
+       | Ok None -> fail "meta missing after fleet batch pause"
+       | Error err -> fail ("read_meta failed: " ^ err));
+      check bool "registry entry unregistered after fleet batch pause"
+        false (Reg.is_registered ~base_path:config.base_path name))
+
+let test_stale_fleet_batch_latch_marks_batch_members () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      Watchdog.reset_batch_terminations_for_test ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let names = [ "batch-a"; "batch-b"; "batch-provider" ] in
+      List.iter
+        (fun name ->
+           let meta = make_meta name in
+           (match KT.write_meta config meta with
+            | Ok () -> ()
+            | Error err -> fail err);
+           ignore (Reg.register ~base_path:config.base_path name meta))
+        names;
+      Reg.set_failure_reason ~base_path:config.base_path "batch-a"
+        (Some (Reg.Stale_turn_timeout (Reg.Idle_turn { stall_seconds = 305.0 })));
+      Reg.set_failure_reason ~base_path:config.base_path "batch-b"
+        (Some Reg.Fiber_unresolved);
+      Reg.set_failure_reason ~base_path:config.base_path "batch-provider"
+        (Some (Reg.Provider_runtime_error { code = "auth"; detail = "401" }));
+      Watchdog.latch_stale_fleet_batch_reasons_for_test
+        ~base_path:config.base_path ~distinct_count:3 names;
+      let reason name =
+        match Reg.get ~base_path:config.base_path name with
+        | Some entry -> entry.Reg.last_failure_reason
+        | None -> fail ("missing registry entry " ^ name)
+      in
+      (match reason "batch-a", reason "batch-b", reason "batch-provider" with
+       | Some (Reg.Stale_fleet_batch { distinct_count = a }),
+         Some (Reg.Stale_fleet_batch { distinct_count = b }),
+         Some (Reg.Provider_runtime_error { code; detail }) ->
+           check int "batch-a distinct_count" 3 a;
+           check int "batch-b distinct_count" 3 b;
+           check string "provider reason preserved code" "auth" code;
+           check string "provider reason preserved detail" "401" detail
+       | _ -> fail "unexpected batch latch failure reasons"))
+
 let test_oas_timeout_budget_loop_pause_skips_restart () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1351,6 +1463,10 @@ let () =
     "stale_storm_phase2", [
       test_case "Stale_termination_storm skips restart, persists paused, increments counter" `Quick
         test_stale_storm_pause_skips_restart;
+      test_case "Stale_fleet_batch skips restart, persists paused, increments counter" `Quick
+        test_stale_fleet_batch_pause_skips_restart;
+      test_case "watchdog fleet batch latch marks batch members" `Quick
+        test_stale_fleet_batch_latch_marks_batch_members;
       test_case "Oas_timeout_budget_loop skips restart, persists paused, increments counter" `Quick
         test_oas_timeout_budget_loop_pause_skips_restart;
       test_case "unresolved watchdog-stopped budget loop is reaped" `Quick
@@ -1830,7 +1946,7 @@ let () =
            [Turn_consecutive_failures] / [Exception] / etc., and
            [watchdog_stop_pending] only restarts on
            [Stale_turn_timeout | Stale_termination_storm |
-           Oas_timeout_budget_loop].  Recovery would set
+           Stale_fleet_batch | Oas_timeout_budget_loop].  Recovery would set
            [fiber_stop=true] but the supervisor would never convert
            it into a crash/restart.  Pin the post-recovery cohort to
            [stale_turn_timeout] so this regression is caught. *)

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -56,6 +56,11 @@ let test_failure_reason_to_string_oas_timeout_budget_loop () =
     "oas_timeout_budget_loop(count=3)"
     (failure_reason_to_string (Oas_timeout_budget_loop { count = 3 }))
 
+let test_failure_reason_to_string_stale_fleet_batch () =
+  r "Stale_fleet_batch includes distinct count"
+    "stale_fleet_batch(distinct_count=3)"
+    (failure_reason_to_string (Stale_fleet_batch { distinct_count = 3 }))
+
 let test_failure_reason_to_string_provider_runtime_error () =
   r "Provider_runtime_error includes terminal code"
     "provider_runtime_error(provider_error:kimi unicode crash)"
@@ -94,6 +99,11 @@ let test_oas_timeout_budget_loop_cohort_key () =
   r "Oas_timeout_budget_loop cohort_key" "oas_timeout_budget_loop"
     (failure_reason_cohort_key
        (Some (Oas_timeout_budget_loop { count = 3 })))
+
+let test_stale_fleet_batch_cohort_key () =
+  r "Stale_fleet_batch cohort_key" "stale_fleet_batch"
+    (failure_reason_cohort_key
+       (Some (Stale_fleet_batch { distinct_count = 3 })))
 
 let test_terminal_failure_cohort_keys () =
   r "Provider_runtime_error cohort_key" "provider_runtime_error"
@@ -193,6 +203,8 @@ let () =
             `Quick test_failure_reason_to_string_noop;
           Alcotest.test_case "Oas_timeout_budget_loop wraps" `Quick
             test_failure_reason_to_string_oas_timeout_budget_loop;
+          Alcotest.test_case "Stale_fleet_batch wraps" `Quick
+            test_failure_reason_to_string_stale_fleet_batch;
           Alcotest.test_case "Provider_runtime_error wraps" `Quick
             test_failure_reason_to_string_provider_runtime_error;
           Alcotest.test_case "Tool_required_unsatisfied wraps" `Quick
@@ -204,6 +216,8 @@ let () =
             `Quick test_cohort_key_collapses_subclasses;
           Alcotest.test_case "Oas_timeout_budget_loop cohort" `Quick
             test_oas_timeout_budget_loop_cohort_key;
+          Alcotest.test_case "Stale_fleet_batch cohort" `Quick
+            test_stale_fleet_batch_cohort_key;
           Alcotest.test_case "terminal failure cohorts" `Quick
             test_terminal_failure_cohort_keys;
         ] );


### PR DESCRIPTION
## Summary
- add a typed stale_fleet_batch keeper failure/blocker class for fleet-wide stale watchdog cascades
- latch all affected batch members when the watchdog sees the batch threshold, while preserving more specific provider/tool/OAS reasons
- route stale_fleet_batch crashes through supervisor auto-pause/backoff instead of independent per-keeper restart loops

## Why it matters
The fleet log already classified 3+ stale watchdog terminations in 30s as systemic, but the old path only logged that fact and still let each keeper restart independently. This makes the log truthful: a batch now becomes durable keeper status, Prometheus pause telemetry, and an auto-resume backoff boundary.

## Validation
- git diff --check
- env DUNE_CACHE=disabled dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-fleet-batch-stale-autopause-0506 test/test_stale_kill_class.exe test/test_keeper_supervisor.exe test/test_keeper_auto_pause_blocker_persist_12683.exe
- ./_build/default/test/test_stale_kill_class.exe --color=never
- ./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe --color=never
- ./_build/default/test/test_keeper_supervisor.exe test stale_storm_phase2 1,2 --color=never

Note: the repo wrapper was initially blocked by unrelated stale global opam/dune lock holders from another worktree, so the final compile/test pass used direct Dune after the agent_sdk pin check had passed.