### PR TITLE
fix(telemetry): observe tool assignment decode drops

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -726,6 +726,9 @@ let metric_telemetry_coverage_gap =
 let metric_telemetry_unified_source_read_failures =
   "masc_telemetry_unified_source_read_failures_total"
 
+let metric_tool_assignment_telemetry_failures =
+  "masc_tool_assignment_telemetry_failures_total"
+
 (* #10358 (c1): observability for the silent [Effect.Unhandled] catch-all
    in [lib/coord.ml] [observe_agent_lifecycle] / [observe_task_transition_event] /
    [Keeper_accountability.record_task_transition].  Those three try/with
@@ -2129,6 +2132,12 @@ let init () =
      tool_usage|oas_event|execution_receipt|goal_event|tool_metric and \
      site=<bounded read/discovery call-site>. Any positive rate means the \
      dashboard fan-in returned partial data instead of a true empty source."
+    Counter;
+  add metric_tool_assignment_telemetry_failures
+    "Total tool assignment telemetry decode/read failures. Labels: \
+     site=read_recent_decode|read_recent_exception|warm_up_decode|\
+     warm_up_exception. Any positive rate means tool assignment lifecycle \
+     rows were dropped from the reconstructed read model."
     Counter;
   add metric_coord_telemetry_drop
     "Total times a Coord lifecycle/transition hook dropped its Audit_log \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -382,6 +382,10 @@ val metric_telemetry_unified_source_read_failures : string
     [source] is {!Telemetry_unified.source_to_string}; [site] is a bounded
     read/discovery call-site vocabulary. *)
 
+val metric_tool_assignment_telemetry_failures : string
+(** Total tool-assignment telemetry decode/read failures. Labels:
+    [site] is a bounded read/warm-up call-site vocabulary. *)
+
 val metric_coord_telemetry_drop : string
 (** #10358 (c1): total times [lib/coord.ml]'s lifecycle hook caught
     [Stdlib.Effect.Unhandled] and dropped its Audit_log + Telemetry

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -170,6 +170,12 @@ let rng = Random.State.make_self_init ()
 let rng_mu = Eio.Mutex.create ()
 let with_rng f = Eio.Mutex.use_ro rng_mu (fun () -> f rng)
 
+let observe_failure ~site ~error =
+  Prometheus.inc_counter Prometheus.metric_tool_assignment_telemetry_failures
+    ~labels:[ ("site", site) ] ();
+  Log.Telemetry.warn "tool_assignment_telemetry failure: site=%s error=%s"
+    site error
+
 (* ── Store lifecycle ──────────────────────────────────── *)
 
 let get_or_create_store () : Dated_jsonl.t =
@@ -290,14 +296,21 @@ let read_recent ~n : (tool_event list, string) Result.t =
     let events =
       List.filter_map
         (fun json ->
-          match event_of_json json with Ok ev -> Some ev | Error _ -> None)
+          match event_of_json json with
+          | Ok ev -> Some ev
+          | Error msg ->
+              observe_failure ~site:"read_recent_decode" ~error:msg;
+              None)
         jsons
     in
     (* Dated_jsonl returns oldest-first; API promises newest-first. *)
     Ok (List.rev events)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Stdlib.Printexc.to_string exn)
+  | exn ->
+      let error = Stdlib.Printexc.to_string exn in
+      observe_failure ~site:"read_recent_exception" ~error;
+      Error error
 
 let warm_up () : unit =
   try
@@ -310,11 +323,16 @@ let warm_up () : unit =
           match event_of_json json with
           | Ok (Assigned { assignment_id; agent_id; _ }) ->
               Hashtbl.replace agent_index agent_id assignment_id
+          | Error msg ->
+              observe_failure ~site:"warm_up_decode" ~error:msg
           | _ -> ())
         jsons)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Log.Telemetry.warn "warm_up failed: %s" (Stdlib.Printexc.to_string exn)
+  | exn ->
+      let error = Stdlib.Printexc.to_string exn in
+      observe_failure ~site:"warm_up_exception" ~error;
+      Log.Telemetry.warn "warm_up failed: %s" error
 
 let reset_for_testing () : unit =
   store_ref := None;

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -331,8 +331,7 @@ let warm_up () : unit =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       let error = Stdlib.Printexc.to_string exn in
-      observe_failure ~site:"warm_up_exception" ~error;
-      Log.Telemetry.warn "warm_up failed: %s" error
+      observe_failure ~site:"warm_up_exception" ~error
 
 let reset_for_testing () : unit =
   store_ref := None;

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -170,11 +170,37 @@ let rng = Random.State.make_self_init ()
 let rng_mu = Eio.Mutex.create ()
 let with_rng f = Eio.Mutex.use_ro rng_mu (fun () -> f rng)
 
-let observe_failure ~site ~error =
+let record_failure_metric ~site =
   Prometheus.inc_counter Prometheus.metric_tool_assignment_telemetry_failures
-    ~labels:[ ("site", site) ] ();
+    ~labels:[ ("site", site) ] ()
+
+let observe_failure ~site ~error =
+  record_failure_metric ~site;
   Log.Telemetry.warn "tool_assignment_telemetry failure: site=%s error=%s"
     site error
+
+type failure_acc =
+  { mutable count : int
+  ; mutable first_error : string option
+  }
+
+let create_failure_acc () = { count = 0; first_error = None }
+
+let add_decode_failure acc error =
+  acc.count <- acc.count + 1;
+  match acc.first_error with
+  | Some _ -> ()
+  | None -> acc.first_error <- Some error
+
+let observe_decode_failures ~site acc =
+  if acc.count > 0 then (
+    for _ = 1 to acc.count do
+      record_failure_metric ~site
+    done;
+    let first_error = Option.value ~default:"unknown" acc.first_error in
+    Log.Telemetry.warn
+      "tool_assignment_telemetry failures: site=%s count=%d first_error=%s"
+      site acc.count first_error)
 
 (* ── Store lifecycle ──────────────────────────────────── *)
 
@@ -293,16 +319,18 @@ let read_recent ~n : (tool_event list, string) Result.t =
   try
     let store = get_or_create_store () in
     let jsons = Dated_jsonl.read_recent store n in
+    let decode_failures = create_failure_acc () in
     let events =
       List.filter_map
         (fun json ->
           match event_of_json json with
           | Ok ev -> Some ev
           | Error msg ->
-              observe_failure ~site:"read_recent_decode" ~error:msg;
+              add_decode_failure decode_failures msg;
               None)
         jsons
     in
+    observe_decode_failures ~site:"read_recent_decode" decode_failures;
     (* Dated_jsonl returns oldest-first; API promises newest-first. *)
     Ok (List.rev events)
   with
@@ -316,6 +344,7 @@ let warm_up () : unit =
   try
     let store = get_or_create_store () in
     let jsons = Dated_jsonl.read_recent store 100_000 in
+    let decode_failures = create_failure_acc () in
     Eio_guard.with_mutex index_mu (fun () ->
       Hashtbl.clear agent_index;
       List.iter
@@ -323,10 +352,10 @@ let warm_up () : unit =
           match event_of_json json with
           | Ok (Assigned { assignment_id; agent_id; _ }) ->
               Hashtbl.replace agent_index agent_id assignment_id
-          | Error msg ->
-              observe_failure ~site:"warm_up_decode" ~error:msg
+          | Error msg -> add_decode_failure decode_failures msg
           | _ -> ())
-        jsons)
+        jsons);
+    observe_decode_failures ~site:"warm_up_decode" decode_failures
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -170,12 +170,12 @@ let rng = Random.State.make_self_init ()
 let rng_mu = Eio.Mutex.create ()
 let with_rng f = Eio.Mutex.use_ro rng_mu (fun () -> f rng)
 
-let record_failure_metric ~site =
+let record_failure_metric ?(delta = 1.0) ~site () =
   Prometheus.inc_counter Prometheus.metric_tool_assignment_telemetry_failures
-    ~labels:[ ("site", site) ] ()
+    ~labels:[ ("site", site) ] ~delta ()
 
 let observe_failure ~site ~error =
-  record_failure_metric ~site;
+  record_failure_metric ~site ();
   Log.Telemetry.warn "tool_assignment_telemetry failure: site=%s error=%s"
     site error
 
@@ -194,9 +194,7 @@ let add_decode_failure acc error =
 
 let observe_decode_failures ~site acc =
   if acc.count > 0 then (
-    for _ = 1 to acc.count do
-      record_failure_metric ~site
-    done;
+    record_failure_metric ~site ~delta:(float_of_int acc.count) ();
     let first_error = Option.value ~default:"unknown" acc.first_error in
     Log.Telemetry.warn
       "tool_assignment_telemetry failures: site=%s count=%d first_error=%s"

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -276,6 +276,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_auth_credential_token_rotated;
   check_registered Prometheus.metric_telemetry_coverage_gap;
   check_registered Prometheus.metric_telemetry_unified_source_read_failures;
+  check_registered Prometheus.metric_tool_assignment_telemetry_failures;
   check_registered Prometheus.metric_coord_telemetry_drop;
   check_registered Prometheus.metric_coord_claim_post_provision_failures
 

--- a/test/test_tool_assignment_telemetry.ml
+++ b/test/test_tool_assignment_telemetry.ml
@@ -39,6 +39,18 @@ let with_eio_temp_base_path f =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       f ())
 
+let failure_metric site =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_tool_assignment_telemetry_failures
+    ~labels:[ ("site", site) ]
+    ()
+
+let append_raw_tool_event json =
+  let dir = Filename.concat (Env_config.base_path ()) "data/tool-events" in
+  Fs_compat.mkdir_p dir;
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  Dated_jsonl.append store json
+
 (* --- Test 1: Assigned snapshot has all fields --- *)
 
 let test_assigned_snapshot_has_all_fields () =
@@ -213,6 +225,29 @@ let test_read_recent_newest_first () =
             check bool "older event present" true has_id1
         | _ -> fail "expected Assigned event at head"))
 
+let test_read_recent_decode_failure_is_observed () =
+  with_eio_temp_base_path (fun () ->
+    Tool_assignment_telemetry.reset_for_testing ();
+    append_raw_tool_event
+      (`Assoc [ ("event_type", `String "Bogus"); ("timestamp", `Float 1.0) ]);
+    let before = failure_metric "read_recent_decode" in
+    match Tool_assignment_telemetry.read_recent ~n:10 with
+    | Error msg -> fail ("read_recent failed: " ^ msg)
+    | Ok events ->
+        check int "malformed row dropped" 0 (List.length events);
+        check (float 0.001) "decode failure counted" (before +. 1.0)
+          (failure_metric "read_recent_decode"))
+
+let test_warm_up_decode_failure_is_observed () =
+  with_eio_temp_base_path (fun () ->
+    Tool_assignment_telemetry.reset_for_testing ();
+    append_raw_tool_event
+      (`Assoc [ ("event_type", `String "Bogus"); ("timestamp", `Float 1.0) ]);
+    let before = failure_metric "warm_up_decode" in
+    Tool_assignment_telemetry.warm_up ();
+    check (float 0.001) "warm-up decode failure counted" (before +. 1.0)
+      (failure_metric "warm_up_decode"))
+
 let () =
   run "Tool_assignment_telemetry"
     [
@@ -229,5 +264,9 @@ let () =
           test_case "config hash format" `Quick test_config_hash_format;
           test_case "read_recent newest first" `Quick
             test_read_recent_newest_first;
+          test_case "read_recent decode failure is observed" `Quick
+            test_read_recent_decode_failure_is_observed;
+          test_case "warm_up decode failure is observed" `Quick
+            test_warm_up_decode_failure_is_observed;
         ] );
     ]

--- a/test/test_tool_assignment_telemetry.ml
+++ b/test/test_tool_assignment_telemetry.ml
@@ -230,12 +230,14 @@ let test_read_recent_decode_failure_is_observed () =
     Tool_assignment_telemetry.reset_for_testing ();
     append_raw_tool_event
       (`Assoc [ ("event_type", `String "Bogus"); ("timestamp", `Float 1.0) ]);
+    append_raw_tool_event
+      (`Assoc [ ("event_type", `String "Broken"); ("timestamp", `Float 2.0) ]);
     let before = failure_metric "read_recent_decode" in
     match Tool_assignment_telemetry.read_recent ~n:10 with
     | Error msg -> fail ("read_recent failed: " ^ msg)
     | Ok events ->
         check int "malformed row dropped" 0 (List.length events);
-        check (float 0.001) "decode failure counted" (before +. 1.0)
+        check (float 0.001) "decode failures counted" (before +. 2.0)
           (failure_metric "read_recent_decode"))
 
 let test_warm_up_decode_failure_is_observed () =
@@ -243,9 +245,11 @@ let test_warm_up_decode_failure_is_observed () =
     Tool_assignment_telemetry.reset_for_testing ();
     append_raw_tool_event
       (`Assoc [ ("event_type", `String "Bogus"); ("timestamp", `Float 1.0) ]);
+    append_raw_tool_event
+      (`Assoc [ ("event_type", `String "Broken"); ("timestamp", `Float 2.0) ]);
     let before = failure_metric "warm_up_decode" in
     Tool_assignment_telemetry.warm_up ();
-    check (float 0.001) "warm-up decode failure counted" (before +. 1.0)
+    check (float 0.001) "warm-up decode failures counted" (before +. 2.0)
       (failure_metric "warm_up_decode"))
 
 let () =


### PR DESCRIPTION
## Summary
- add `masc_tool_assignment_telemetry_failures_total{site}` for tool-assignment read/warm-up failures
- count malformed/unknown tool-assignment lifecycle rows per row while aggregating decode WARN logs once per `read_recent`/`warm_up` call
- preserve existing API behavior: bad rows are still dropped and `read_recent` still returns successful decoded rows

## Review Follow-up
- Addressed Copilot log-spam review by splitting metric recording from warning emission and logging `count` + `first_error` once per decode pass.
- Extended decode-failure regressions to two malformed rows so per-row metric accounting stays covered after aggregation.
- Addressed counter overhead follow-up by using one `Prometheus.inc_counter ~delta:(float_of_int count)` call for aggregated decode failures instead of looping once per bad row.

## Verification
- `ocamlc -stop-after parsing lib/tool_assignment_telemetry.ml`
- `ocamlc -stop-after parsing lib/tool_assignment_telemetry.ml test/test_tool_assignment_telemetry.ml`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_tool_assignment_telemetry.exe test/test_prometheus_coverage.exe`
- `./_build/default/test/test_tool_assignment_telemetry.exe`
- `./_build/default/test/test_prometheus_coverage.exe test to_prometheus_text`

## Operator Impact
Malformed tool-assignment telemetry rows no longer disappear silently from the reconstructed read model, and malformed bursts no longer produce one WARN per row during recent reads or 100k-row warm-up scans. Operators can alert on a bounded site label vocabulary while the runtime keeps its current tolerant fallback behavior.
