### PR TITLE
fix(keeper): avoid passive-only required tool gates

### DIFF
--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -141,7 +141,10 @@ val preferred_tool_choice_for_required_turn :
     preset facing unclaimed tasks) aren't forced into unwinnable
     contract violations. *)
 val turn_affordances_require_tool_gate_with_allowed :
-  allowed_tool_names:string list -> string list -> bool
+     ?record_suppression_metric:bool
+  -> allowed_tool_names:string list
+  -> string list
+  -> bool
 
 (** Canonical model label for MASC status/metrics surfaces.
     Prefers the final cascade attempt label when available, then the

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -171,7 +171,9 @@ let turn_affordances_require_tool_gate_with_allowed
     ~(allowed_tool_names : string list) turn_affordances : bool =
   let has_matching_tool affordance =
     List.exists
-      (fun tool -> List.mem tool allowed_tool_names)
+      (fun tool ->
+         List.mem tool allowed_tool_names
+         && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract tool)
       (tools_for_gated_affordance affordance)
   in
   List.exists
@@ -202,19 +204,26 @@ let has_task_claim_affordance = has_turn_affordance Task_claim
 
 let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
+  let progress_tool_available name =
+    List.mem name allowed_tool_names
+    && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name
+  in
   if has_turn_affordance Board_curation turn_affordances
-     && List.mem "keeper_board_curation_submit" allowed_tool_names
+     && progress_tool_available "keeper_board_curation_submit"
   then Agent_sdk.Types.Tool "keeper_board_curation_submit"
   else if (not has_current_task)
      && has_task_claim_affordance turn_affordances
-     && List.mem "keeper_task_claim" allowed_tool_names
+     && progress_tool_available "keeper_task_claim"
   then Agent_sdk.Types.Tool "keeper_task_claim"
   else if has_turn_affordance Task_audit turn_affordances
-          && List.mem "keeper_tasks_audit" allowed_tool_names
+          && progress_tool_available "keeper_tasks_audit"
   then Agent_sdk.Types.Tool "keeper_tasks_audit"
   else if has_turn_affordance Task_verify turn_affordances
-          && List.mem "keeper_tasks_list" allowed_tool_names
-  then Agent_sdk.Types.Tool "keeper_tasks_list"
+          && progress_tool_available "keeper_task_submit_for_verification"
+  then Agent_sdk.Types.Tool "keeper_task_submit_for_verification"
+  else if has_turn_affordance Task_verify turn_affordances
+          && progress_tool_available "keeper_task_done"
+  then Agent_sdk.Types.Tool "keeper_task_done"
   else if not has_current_task then
     (* #10008: no active task and no applicable specific claim tool
        to force.  Fall back to [Auto] instead of [Any] so the model

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -99,6 +99,17 @@ let turn_affordance_of_string = function
   | "inspect_worktree_delta" -> Some Inspect_worktree_delta
   | _ -> None
 
+let turn_affordance_to_string = function
+  | Board_curation -> "board_curation"
+  | Board_post_or_comment -> "board_post_or_comment"
+  | Message_sweep -> "message_sweep"
+  | Reply_in_room -> "reply_in_room"
+  | Task_claim -> "task_claim"
+  | Task_audit -> "task_audit"
+  | Task_verify -> "task_verify"
+  | Work_discovery -> "work_discovery"
+  | Inspect_worktree_delta -> "inspect_worktree_delta"
+
 let should_tool_gate_affordance = function
   | Board_curation
   | Board_post_or_comment
@@ -168,6 +179,7 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
    them whenever the board lists unclaimed tasks, leading to repeated
    [Failure_run_error] turns the keeper cannot resolve. *)
 let turn_affordances_require_tool_gate_with_allowed
+    ?(record_suppression_metric = false)
     ~(allowed_tool_names : string list) turn_affordances : bool =
   let has_matching_tool affordance =
     List.exists
@@ -176,13 +188,22 @@ let turn_affordances_require_tool_gate_with_allowed
          && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract tool)
       (tools_for_gated_affordance affordance)
   in
-  List.exists
-    (function
-      | Some affordance ->
-        should_tool_gate_affordance affordance
-        && has_matching_tool affordance
-      | None -> false)
-    (List.map turn_affordance_of_string turn_affordances)
+  let gated_affordances =
+    turn_affordances
+    |> List.filter_map turn_affordance_of_string
+    |> List.filter should_tool_gate_affordance
+  in
+  let gate_requested = List.exists has_matching_tool gated_affordances in
+  if record_suppression_metric && not gate_requested then
+    List.iter
+      (fun affordance ->
+         if not (has_matching_tool affordance) then
+           Prometheus.inc_counter
+             Prometheus.metric_keeper_required_tool_gate_suppressed_total
+             ~labels:[ ("affordance", turn_affordance_to_string affordance) ]
+             ())
+      gated_affordances;
+  gate_requested
 
 let should_require_tools_for_initial_turn ~(max_turns : int)
     ~(turn_affordances : string list) =

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -99,7 +99,10 @@ val preferred_tool_names_for_turn_affordances : string list -> string list
     Passive read/status tools may still be visible, but they cannot be
     the sole reason to force [Require_tool_use]. *)
 val turn_affordances_require_tool_gate_with_allowed :
-  allowed_tool_names:string list -> string list -> bool
+     ?record_suppression_metric:bool
+  -> allowed_tool_names:string list
+  -> string list
+  -> bool
 
 (** Whether the very first turn of a multi-turn slot should require
     a tool call. *)

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -95,7 +95,9 @@ val preferred_tool_names_for_turn_affordances : string list -> string list
 
 (** Like [turn_affordances_require_tool_gate] but only fires when at
     least one of the gating affordance's tools is in
-    [allowed_tool_names]. *)
+    [allowed_tool_names] and can satisfy the required-tool contract.
+    Passive read/status tools may still be visible, but they cannot be
+    the sole reason to force [Require_tool_use]. *)
 val turn_affordances_require_tool_gate_with_allowed :
   allowed_tool_names:string list -> string list -> bool
 

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -560,7 +560,7 @@ let prepare_agent_setup
     && not is_last_turn
     && (caller_requires_tools
         || turn_affordances_require_tool_gate_with_allowed
-             ~allowed_tool_names turn_affordances)
+             ~record_suppression_metric:true ~allowed_tool_names turn_affordances)
   in
   let compute_tool_surface ~turn ~messages ~current_tool_choice ~decay_discovered
       : computed_tool_surface =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -764,11 +764,6 @@ let prepare_agent_setup
     let per_call_turn = turn - start_turn_count in
     let is_last_turn = per_call_turn >= max_turns in
     let is_warning_zone = per_call_turn >= max_turns - 1 in
-    let tool_gate_requested =
-      required_tool_names <> []
-      || tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn
-           ~allowed_tool_names:all_allowed
-    in
     let all_allowed, tool_surface_fallback_used =
       if all_allowed = [] then
         let fallback_allowed = fallback_tool_surface ~turn in
@@ -787,6 +782,11 @@ let prepare_agent_setup
           all_allowed
       else
         all_allowed
+    in
+    let tool_gate_requested =
+      required_tool_names <> []
+      || tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn
+           ~allowed_tool_names:all_allowed
     in
     let all_allowed =
       if List.length all_allowed > max_tools then (

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -549,7 +549,8 @@ let prepare_agent_setup
     in
     validate_allow_list ~turn (fallback_floor_tool_names @ repo_probe)
   in
-  let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn =
+  let tool_gate_requested_for_turn
+      ~current_tool_choice ~is_last_turn ~allowed_tool_names =
     let caller_requires_tools =
       match current_tool_choice with
       | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> true
@@ -557,7 +558,9 @@ let prepare_agent_setup
     in
     max_turns > 1
     && not is_last_turn
-    && (caller_requires_tools || turn_affordances_require_tool_gate turn_affordances)
+    && (caller_requires_tools
+        || turn_affordances_require_tool_gate_with_allowed
+             ~allowed_tool_names turn_affordances)
   in
   let compute_tool_surface ~turn ~messages ~current_tool_choice ~decay_discovered
       : computed_tool_surface =
@@ -764,6 +767,7 @@ let prepare_agent_setup
     let tool_gate_requested =
       required_tool_names <> []
       || tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn
+           ~allowed_tool_names:all_allowed
     in
     let all_allowed, tool_surface_fallback_used =
       if all_allowed = [] then

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1042,6 +1042,8 @@ let metric_keeper_passive_loop_detected_total =
   "masc_keeper_passive_loop_detected_total"
 let metric_keeper_required_tool_loop_detected_total =
   "masc_keeper_required_tool_loop_detected_total"
+let metric_keeper_required_tool_gate_suppressed_total =
+  "masc_keeper_required_tool_gate_suppressed_total"
 
 (* Task-138: Minimum proactive cadence — observability gauges that pair
    with the [keeper_passive_loop_detector] streak counter so operators
@@ -1725,6 +1727,11 @@ let init () =
     "#13362 Total required-tool contract loops: keeper hit N consecutive \
      actionable required-tool failures before making execution/completion \
      progress. Labeled by keeper and kind."
+    Counter;
+  add metric_keeper_required_tool_gate_suppressed_total
+    "#13653 Total Require_tool_use gate suppressions caused by actionable \
+     affordances whose visible keeper tool surface contains no \
+     contract-satisfying tool. Labeled by affordance."
     Counter;
   add metric_keeper_consecutive_idle
     "Task-138 Current consecutive-idle streak (passive-only turns) per \

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1729,7 +1729,7 @@ let init () =
      progress. Labeled by keeper and kind."
     Counter;
   add metric_keeper_required_tool_gate_suppressed_total
-    "#13653 Total Require_tool_use gate suppressions caused by actionable \
+    "#13631 Total Require_tool_use gate suppressions caused by actionable \
      affordances whose visible keeper tool surface contains no \
      contract-satisfying tool. Labeled by affordance."
     Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -347,7 +347,7 @@ val metric_keeper_required_tool_loop_detected_total : string
     progress.  Incremented once per loop episode. Labels: [keeper, kind]. *)
 
 val metric_keeper_required_tool_gate_suppressed_total : string
-(** #13653 Total Require_tool_use gate suppressions caused by actionable
+(** #13631 Total Require_tool_use gate suppressions caused by actionable
     affordances whose visible keeper tool surface contains no
     contract-satisfying tool. Labels: [affordance]. *)
 

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -346,6 +346,11 @@ val metric_keeper_required_tool_loop_detected_total : string
     actionable required-tool failures before making execution/completion
     progress.  Incremented once per loop episode. Labels: [keeper, kind]. *)
 
+val metric_keeper_required_tool_gate_suppressed_total : string
+(** #13653 Total Require_tool_use gate suppressions caused by actionable
+    affordances whose visible keeper tool surface contains no
+    contract-satisfying tool. Labels: [affordance]. *)
+
 val metric_keeper_consecutive_idle : string
 (** Task-138 Current consecutive-idle streak (passive-only turns) per
     keeper.  Resets to 0 on the next execution/completion turn.  Pairs

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7179,6 +7179,34 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
     "unknown affordance string is ignored" false
     (gate ~tools:[ "keeper_task_claim" ] [ "totally_unknown_affordance" ])
 
+let test_turn_affordance_gate_suppression_metric () =
+  let metric affordance =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_required_tool_gate_suppressed_total
+      ~labels:[ ("affordance", affordance) ]
+      ()
+  in
+  let gate ~tools affordances =
+    KAR.turn_affordances_require_tool_gate_with_allowed
+      ~record_suppression_metric:true ~allowed_tool_names:tools affordances
+  in
+  let verify_before = metric "task_verify" in
+  let unknown_before = metric "totally_unknown_affordance" in
+  check bool "passive task_verify list tool suppresses gate" false
+    (gate ~tools:[ "keeper_tasks_list" ] [ "task_verify" ]);
+  check (float 0.0) "task_verify suppression increments metric"
+    (verify_before +. 1.0)
+    (metric "task_verify");
+  check (float 0.0) "unknown affordance does not create metric label"
+    unknown_before
+    (metric "totally_unknown_affordance");
+  let claim_before = metric "task_claim" in
+  check bool "claim tool present keeps gate active" true
+    (gate ~tools:[ "keeper_task_claim" ] [ "task_claim" ]);
+  check (float 0.0) "successful gate does not increment suppression metric"
+    claim_before
+    (metric "task_claim")
+
 let test_tools_for_gated_affordance_covers_each_variant () =
   (* Compile-time exhaustiveness already ensures every variant is
      handled; this asserts the runtime mapping is non-empty so a
@@ -8232,6 +8260,8 @@ let () =
           test_case "affordance gate filters by allowed_tool_names"
             `Quick
             test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool;
+          test_case "affordance gate suppression emits metric" `Quick
+            test_turn_affordance_gate_suppression_metric;
           test_case "tools_for_gated_affordance non-empty for every variant"
             `Quick test_tools_for_gated_affordance_covers_each_variant;
         ] );

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7159,6 +7159,16 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
        ~tools:[ "masc_claim_next" ]
        [ "task_claim"; "task_audit"; "board_post_or_comment" ]);
   check bool
+    "task_audit with only passive audit/list tools -> gate suppressed" false
+    (gate ~tools:[ "keeper_tasks_audit"; "keeper_tasks_list" ]
+       [ "task_audit" ]);
+  check bool
+    "task_verify with only passive task list -> gate suppressed" false
+    (gate ~tools:[ "keeper_tasks_list" ] [ "task_verify" ]);
+  check bool
+    "task_verify with submit tool -> gate fires" true
+    (gate ~tools:[ "keeper_task_submit_for_verification" ] [ "task_verify" ]);
+  check bool
     "all gated affordances missing tools -> gate suppressed" false
     (gate
        ~tools:[ "keeper_context_status"; "keeper_time_now" ]
@@ -7276,11 +7286,11 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
        ()
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "task audit prefers audit tool" "keeper_tasks_audit" name
+   | Agent_sdk.Types.Auto -> ()
    | other ->
        fail
-         (Printf.sprintf "expected Tool keeper_tasks_audit, got %s"
+         (Printf.sprintf
+            "expected Auto for task audit with passive audit tool, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
@@ -7301,11 +7311,26 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~allowed_tool_names:[ "keeper_tasks_list"; "keeper_board_post" ]
        ()
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "task verify prefers task list" "keeper_tasks_list" name
+   | Agent_sdk.Types.Auto -> ()
    | other ->
        fail
-         (Printf.sprintf "expected Tool keeper_tasks_list, got %s"
+         (Printf.sprintf
+            "expected Auto for task verify with passive task list, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~turn_affordances:[ "task_verify" ]
+       ~allowed_tool_names:
+         [ "keeper_tasks_list"; "keeper_task_submit_for_verification" ]
+       ()
+   with
+   | Agent_sdk.Types.Tool name ->
+       check string "task verify prefers submit tool"
+         "keeper_task_submit_for_verification" name
+   | other ->
+       fail
+         (Printf.sprintf
+            "expected Tool keeper_task_submit_for_verification, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match choose ~allowed_tool_names:[ "keeper_board_post" ] () with
   | Agent_sdk.Types.Auto -> ()


### PR DESCRIPTION
## Summary
- suppress strict required-tool gating when the only visible affordance tools are passive read/status tools that cannot satisfy the completion contract
- route task verification required-tool preference to progress tools (`keeper_task_submit_for_verification`, then `keeper_task_done`) instead of passive `keeper_tasks_list`
- recompute the required-tool gate after applying the empty-surface fallback so fallback tools can satisfy actionable affordance gates
- add focused regression coverage for passive-only task audit/verify affordances and submit-tool gating

## Evidence
- Live runtime source: `/Users/dancer/me/.masc/activity-events/2026-05/06.jsonl`
- Issue: #13631 tracks 42 recent `tool_required_unsatisfied` / `completion_contract_violation:require_tool_use` broadcasts, including passive-only task affordance variants.
- This PR addresses the self-contradictory subset where MASC forced `Require_tool_use` even though the exposed tool could not satisfy `Keeper_tool_disclosure.tool_name_can_satisfy_required_contract`.

## Review follow-up
- Addressed Copilot's fallback-order finding in 55c19cc08d: `tool_gate_requested` is now computed from the post-fallback, post-last-turn visible allowlist.

## Validation
- `ocamlc -stop-after parsing lib/keeper/keeper_run_tools.ml`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_OPAM_LOCK=0 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test --show-errors --color=never tool_classification` - 6 tests passed

Refs #13631
