### PR TITLE
fix(dashboard): expose drawer summary state

### DIFF
--- a/dashboard/src/components/common/drawer.test.ts
+++ b/dashboard/src/components/common/drawer.test.ts
@@ -2,7 +2,47 @@
 import { describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { Drawer } from './drawer'
+import { Drawer, panelCls, summarizeDrawerPosition } from './drawer'
+
+describe('summarizeDrawerPosition', () => {
+  it('summarizes horizontal positions', () => {
+    expect(summarizeDrawerPosition('left')).toEqual({
+      position: 'left',
+      axis: 'horizontal',
+      edge: 'left',
+    })
+    expect(summarizeDrawerPosition('right')).toEqual({
+      position: 'right',
+      axis: 'horizontal',
+      edge: 'right',
+    })
+  })
+
+  it('summarizes vertical positions', () => {
+    expect(summarizeDrawerPosition('top')).toEqual({
+      position: 'top',
+      axis: 'vertical',
+      edge: 'top',
+    })
+    expect(summarizeDrawerPosition('bottom')).toEqual({
+      position: 'bottom',
+      axis: 'vertical',
+      edge: 'bottom',
+    })
+  })
+})
+
+describe('panelCls', () => {
+  it('bounds side drawers to the viewport width', () => {
+    expect(panelCls('right')).toContain('max-w-[calc(100vw-1rem)]')
+    expect(panelCls('left')).toContain('max-w-[calc(100vw-1rem)]')
+  })
+
+  it('bounds top and bottom drawers to the viewport height', () => {
+    expect(panelCls('top')).toContain('max-h-[calc(100vh-1rem)]')
+    expect(panelCls('bottom')).toContain('max-h-[calc(100vh-1rem)]')
+  })
+})
 
 describe('Drawer', () => {
   it('returns null when closed', () => {
@@ -22,6 +62,28 @@ describe('Drawer', () => {
     render(h(Drawer, { open: true, onClose: vi.fn(), title: 'T' }, 'Body'), container)
     const el = container.querySelector('[role="dialog"]')
     expect(el?.getAttribute('aria-modal')).toBe('true')
+  })
+
+  it('uses a stable generated title id for aria-labelledby', () => {
+    const container = document.createElement('div')
+    render(h(Drawer, { open: true, onClose: vi.fn(), title: 'T' }, 'Body'), container)
+    const dialog = container.querySelector('[role="dialog"]')
+    const title = container.querySelector('[data-drawer-title]')
+    expect(dialog?.getAttribute('aria-labelledby')).toBe(title?.getAttribute('id'))
+  })
+
+  it('does not reuse title ids across multiple drawers', () => {
+    const container = document.createElement('div')
+    render(
+      h('div', null, [
+        h(Drawer, { open: true, onClose: vi.fn(), title: 'A' }, 'A body'),
+        h(Drawer, { open: true, onClose: vi.fn(), title: 'B' }, 'B body'),
+      ]),
+      container,
+    )
+    const ids = Array.from(container.querySelectorAll('[data-drawer-title]'))
+      .map((el) => el.getAttribute('id'))
+    expect(new Set(ids).size).toBe(2)
   })
 
   it('renders title', () => {
@@ -61,6 +123,18 @@ describe('Drawer', () => {
     render(h(Drawer, { open: true, onClose: vi.fn(), title: 'T', position: 'left' }, 'Body'), container)
     const panel = container.querySelector('[role="dialog"]') as HTMLElement
     expect(panel?.classList.contains('left-0')).toBe(true)
+  })
+
+  it('publishes drawer position metadata', () => {
+    const container = document.createElement('div')
+    render(h(Drawer, { open: true, onClose: vi.fn(), title: 'T', position: 'bottom' }, 'Body'), container)
+    const root = container.querySelector('[data-drawer]')
+    const panel = container.querySelector('[data-drawer-panel]')
+    expect(root?.getAttribute('data-drawer-open')).toBe('true')
+    expect(root?.getAttribute('data-drawer-position')).toBe('bottom')
+    expect(root?.getAttribute('data-drawer-axis')).toBe('vertical')
+    expect(root?.getAttribute('data-drawer-edge')).toBe('bottom')
+    expect(panel?.getAttribute('data-drawer-panel-position')).toBe('bottom')
   })
 
   it('supports top position', () => {

--- a/dashboard/src/components/common/drawer.ts
+++ b/dashboard/src/components/common/drawer.ts
@@ -4,34 +4,52 @@
 // Click on backdrop closes. Animates in from the edge.
 
 import { html } from 'htm/preact'
-import { useEffect, useLayoutEffect, useRef } from 'preact/hooks'
+import { useEffect, useId, useLayoutEffect, useRef } from 'preact/hooks'
+
+export type DrawerPosition = 'left' | 'right' | 'top' | 'bottom'
+
+export interface DrawerPositionSummary {
+  position: DrawerPosition
+  axis: 'horizontal' | 'vertical'
+  edge: DrawerPosition
+}
 
 interface DrawerProps {
   open: boolean
   onClose: () => void
   title: string
   children: unknown
-  position?: 'left' | 'right' | 'top' | 'bottom'
+  position?: DrawerPosition
   class?: string
 }
 
 const BACKDROP_CLS =
   'fixed inset-0 bg-black/50 transition-opacity'
 
-function panelCls(position: string): string {
+export function summarizeDrawerPosition(
+  position: DrawerPosition = 'right',
+): DrawerPositionSummary {
+  return {
+    position,
+    axis: position === 'left' || position === 'right' ? 'horizontal' : 'vertical',
+    edge: position,
+  }
+}
+
+export function panelCls(position: DrawerPosition): string {
   const base =
-    'fixed bg-[var(--dialog-panel-bg)] border-[var(--dialog-panel-border)] shadow-[var(--shadow-panel)] overflow-auto '
+    'fixed bg-[var(--color-bg-surface)] border-[var(--color-border-default)] shadow-[var(--shadow-panel)] overflow-auto '
   switch (position) {
     case 'left':
-      return base + 'left-0 top-0 h-full w-80 border-r'
+      return base + 'left-0 top-0 h-full w-80 max-w-[calc(100vw-1rem)] border-r'
     case 'right':
-      return base + 'right-0 top-0 h-full w-80 border-l'
+      return base + 'right-0 top-0 h-full w-80 max-w-[calc(100vw-1rem)] border-l'
     case 'top':
-      return base + 'top-0 left-0 w-full h-64 border-b'
+      return base + 'top-0 left-0 w-full h-64 max-h-[calc(100vh-1rem)] border-b'
     case 'bottom':
-      return base + 'bottom-0 left-0 w-full h-64 border-t'
+      return base + 'bottom-0 left-0 w-full h-64 max-h-[calc(100vh-1rem)] border-t'
     default:
-      return base + 'right-0 top-0 h-full w-80 border-l'
+      return base + 'right-0 top-0 h-full w-80 max-w-[calc(100vw-1rem)] border-l'
   }
 }
 
@@ -45,6 +63,8 @@ export function Drawer({
 }: DrawerProps) {
   const panelRef = useRef<HTMLDivElement>(null)
   const closeBtnRef = useRef<HTMLButtonElement>(null)
+  const titleId = `${useId()}-drawer-title`
+  const summary = summarizeDrawerPosition(position)
 
   useLayoutEffect(() => {
     if (!open) return
@@ -70,6 +90,11 @@ export function Drawer({
     <div
       class="fixed inset-0 z-50"
       role="presentation"
+      data-drawer
+      data-drawer-open=${open}
+      data-drawer-position=${summary.position}
+      data-drawer-axis=${summary.axis}
+      data-drawer-edge=${summary.edge}
       onClick=${(e: MouseEvent) => {
         if (e.target === e.currentTarget) onClose()
       }}
@@ -79,25 +104,32 @@ export function Drawer({
         ref=${panelRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby="drawer-title"
+        aria-labelledby=${titleId}
         class=${panelCls(position) + (cx ? ` ${cx}` : '')}
+        data-drawer-panel
+        data-drawer-panel-position=${summary.position}
         onClick=${(e: MouseEvent) => e.stopPropagation()}
       >
-        <div class="flex items-center justify-between px-4 py-3 border-b border-[var(--color-border-default)]">
-          <h2 id="drawer-title" class="text-base font-medium text-[var(--color-fg-primary)]">
+        <div class="flex items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-4 py-3">
+          <h2
+            id=${titleId}
+            class="min-w-0 truncate font-mono text-sm font-semibold text-[var(--color-fg-primary)]"
+            data-drawer-title
+          >
             ${title}
           </h2>
           <button
             ref=${closeBtnRef}
             type="button"
             aria-label="Close drawer"
-            class="text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] transition-colors"
+            class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-subtle)] font-mono text-xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:text-[var(--color-fg-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent-fg)]"
+            data-drawer-close
             onClick=${onClose}
           >
             ✕
           </button>
         </div>
-        <div class="p-4">${children}</div>
+        <div class="min-w-0 p-4" data-drawer-body>${children}</div>
       </div>
     </div>
   `


### PR DESCRIPTION
## Summary

- export `DrawerPosition`, `DrawerPositionSummary`, `summarizeDrawerPosition`, and `panelCls` so drawer edge/axis behavior is testable
- add `data-drawer-*` metadata for open state, position, axis, edge, panel position, title, close control, and body
- replace the static `drawer-title` id with a generated `useId()` title id so multiple drawers do not collide
- bound side and top/bottom drawers to viewport dimensions for tighter mobile behavior
- move drawer chrome onto the warm dashboard surface/border tokens instead of the cooler dialog panel surface

## Why This Matters

The shared drawer primitive is used as operational chrome. It previously rendered with a static title id, no inspectable state, and fixed panel sizing. This brings it closer to the Cockpit component rules: dense mono title treatment, explicit state surfaces for QA, and responsive bounds that keep drawer content contained on small screens.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/drawer.test.ts src/components/common/drawer.a11y.test.ts` — 25 passed
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm --dir dashboard run lint` — existing 3 warnings only: `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`
- `pnpm --dir dashboard run build` — completed with existing Vite dynamic/static import and chunk-size warnings
- Browser QA via `agent-browser` against temporary Vite page on desktop and mobile
  - `/tmp/masc-drawer-summary-0506.png`
  - `/tmp/masc-drawer-summary-0506-mobile.png`

## Browser QA Notes

- Desktop and mobile screenshots inspected with `view_image`
- Verified drawer root metadata: open, position, axis, edge
- Verified panel metadata and generated `aria-labelledby` title id
- Verified no page-level horizontal overflow at 390px mobile viewport
- Verified long title and long code content truncate inside the drawer instead of expanding the page
- Verified close control removes the dialog
- Browser errors clean; console contained only normal Vite connection/restart logs during server restart