### PR TITLE
fix(dashboard): split oversized mermaid chunks

### DIFF
--- a/dashboard/src/components/common/markdown-renderer.ts
+++ b/dashboard/src/components/common/markdown-renderer.ts
@@ -9,28 +9,20 @@ import { useRef, useEffect, useMemo } from 'preact/hooks'
 import { Marked } from 'marked'
 import DOMPurify from 'dompurify'
 
-import type MermaidDefault from 'mermaid'
 import { highlightCodeHtml } from './shiki-highlighter'
+import { loadMermaid, type MermaidApi } from './mermaid-loader'
 
 // ── Lazy mermaid loader ──────────────────────────────────────
-type MermaidApi = typeof MermaidDefault
-
-function importMermaid(): Promise<MermaidApi> {
-  return import('mermaid').then(module => module.default)
-}
-let mermaidPromise: Promise<MermaidApi> | null = null
 let mermaidConfigured = false
 let mermaidRenderCount = 0
 
 function getMermaid(): Promise<MermaidApi> {
-  const promise = mermaidPromise ?? (mermaidPromise = importMermaid())
-  return promise.then(mermaid => {
+  return loadMermaid().then(mermaid => {
     if (mermaidConfigured) return mermaid
     mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict', suppressErrorRendering: true })
     mermaidConfigured = true
     return mermaid
   }).catch((err) => {
-    mermaidPromise = null
     mermaidConfigured = false
     throw err
   })

--- a/dashboard/src/components/common/mermaid-graph.test.ts
+++ b/dashboard/src/components/common/mermaid-graph.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { MermaidGraph } from './mermaid-graph'
 
 const mockRender = vi.fn()
 const mockInitialize = vi.fn()
+const containers: HTMLDivElement[] = []
+
+function createContainer(): HTMLDivElement {
+  const container = document.createElement('div')
+  containers.push(container)
+  return container
+}
 
 vi.mock('mermaid', () => ({
   default: {
@@ -21,11 +29,15 @@ describe('MermaidGraph', () => {
   })
 
   afterEach(() => {
+    for (const container of containers) {
+      render(null, container)
+    }
+    containers.length = 0
     vi.clearAllMocks()
   })
 
-  it('applies class and minHeightClass', () => {
-    const container = document.createElement('div')
+  it('applies class and minHeightClass', async () => {
+    const container = createContainer()
     render(
       h(MermaidGraph, {
         source: 'graph TD; A-->B',
@@ -37,59 +49,69 @@ describe('MermaidGraph', () => {
     const outer = container.firstElementChild as HTMLElement
     expect(outer?.classList.contains('my-class')).toBe(true)
     expect(outer?.classList.contains('min-h-20')).toBe(true)
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull()
+    })
   })
 
   it('calls mermaid render on mount', async () => {
-    const container = document.createElement('div')
+    const container = createContainer()
     render(h(MermaidGraph, { source: 'graph TD; A-->B' }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(mockInitialize).toHaveBeenCalled()
-    expect(mockRender).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockRender).toHaveBeenCalled()
+    })
     const [, source] = mockRender.mock.calls[0] as [string, string]
     expect(source).toBe('graph TD; A-->B')
   })
 
   it('shows error when render throws', async () => {
     mockRender.mockRejectedValueOnce(new Error('mermaid fail'))
-    const container = document.createElement('div')
+    const container = createContainer()
     render(h(MermaidGraph, { source: 'bad' }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(container.textContent).toContain('mermaid fail')
+    await waitFor(() => {
+      expect(container.textContent).toContain('mermaid fail')
+    })
   })
 
   it('shows fallbackText on error', async () => {
     mockRender.mockRejectedValueOnce(new Error('fail'))
-    const container = document.createElement('div')
+    const container = createContainer()
     render(h(MermaidGraph, { source: 'bad', fallbackText: 'fallback info' }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(container.textContent).toContain('fallback info')
+    await waitFor(() => {
+      expect(container.textContent).toContain('fallback info')
+    })
   })
 
   it('renders host with role and aria-label', async () => {
-    const container = document.createElement('div')
+    const container = createContainer()
     render(h(MermaidGraph, { source: 'graph TD; A-->B', fallbackText: 'my diagram' }), container)
-    await new Promise((r) => setTimeout(r, 10))
     const host = container.querySelector('[role="img"]') as HTMLElement
     expect(host).not.toBeNull()
     expect(host?.getAttribute('aria-label')).toBe('my diagram')
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull()
+    })
   })
 
   it('applies diagramClass to host', async () => {
-    const container = document.createElement('div')
+    const container = createContainer()
     render(
       h(MermaidGraph, { source: 'graph TD; A-->B', diagramClass: 'diag-special' }),
       container,
     )
-    await new Promise((r) => setTimeout(r, 10))
     const host = container.querySelector('[role="img"]') as HTMLElement
     expect(host?.classList.contains('diag-special')).toBe(true)
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull()
+    })
   })
 
   it('shows SVG parse error as fallback', async () => {
     mockRender.mockResolvedValueOnce({ svg: '<not-svg>bad</not-svg>' })
-    const container = document.createElement('div')
+    const container = createContainer()
     render(h(MermaidGraph, { source: 'x' }), container)
-    await new Promise((r) => setTimeout(r, 10))
-    expect(container.textContent).toContain('SVG parse failed')
+    await waitFor(() => {
+      expect(container.textContent).toContain('SVG parse failed')
+    })
   })
 })

--- a/dashboard/src/components/common/mermaid-graph.ts
+++ b/dashboard/src/components/common/mermaid-graph.ts
@@ -1,18 +1,13 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { EmptyState } from './empty-state'
+import { loadMermaid, type MermaidApi } from './mermaid-loader'
 
-type MermaidApi = typeof import('mermaid')['default']
-
-let mermaidPromise: Promise<MermaidApi> | null = null
 let mermaidConfigured = false
 let mermaidRenderCount = 0
 
 async function getMermaid(): Promise<MermaidApi> {
-  if (!mermaidPromise) {
-    mermaidPromise = import('mermaid').then(module => module.default)
-  }
-  const mermaid = await mermaidPromise
+  const mermaid = await loadMermaid()
   if (mermaidConfigured) return mermaid
   mermaid.initialize({
     startOnLoad: false,

--- a/dashboard/src/components/common/mermaid-loader.ts
+++ b/dashboard/src/components/common/mermaid-loader.ts
@@ -1,6 +1,6 @@
-import type MermaidDefault from 'mermaid'
+import type { Mermaid } from 'mermaid'
 
-export type MermaidApi = typeof MermaidDefault
+export type MermaidApi = Mermaid
 
 let mermaidPromise: Promise<MermaidApi> | null = null
 

--- a/dashboard/src/components/common/mermaid-loader.ts
+++ b/dashboard/src/components/common/mermaid-loader.ts
@@ -1,0 +1,17 @@
+import type MermaidDefault from 'mermaid'
+
+export type MermaidApi = typeof MermaidDefault
+
+let mermaidPromise: Promise<MermaidApi> | null = null
+
+export function loadMermaid(): Promise<MermaidApi> {
+  if (!mermaidPromise) {
+    mermaidPromise = import('mermaid')
+      .then(module => module.default)
+      .catch(err => {
+        mermaidPromise = null
+        throw err
+      })
+  }
+  return mermaidPromise
+}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -4,6 +4,47 @@ import solid from 'vite-plugin-solid'
 import tailwindcss from '@tailwindcss/vite'
 import { visualizer } from 'rollup-plugin-visualizer'
 
+function normalizeModuleId(id: string): string {
+  return id.replace(/\\/g, '/')
+}
+
+function chunkByPackage(id: string, packageNames: string[]): boolean {
+  return packageNames.some(packageName =>
+    id.includes(`/node_modules/${packageName}/`),
+  )
+}
+
+const heavyMermaidDependencyChunks: Array<{ packages: string[]; chunk: string }> = [
+  {
+    packages: ['cytoscape'],
+    chunk: 'cytoscape',
+  },
+  {
+    packages: ['cytoscape-cose-bilkent', 'cose-base', 'layout-base'],
+    chunk: 'mermaid-cose-layout',
+  },
+  {
+    packages: ['@mermaid-js/parser'],
+    chunk: 'mermaid-parser',
+  },
+  {
+    packages: ['langium'],
+    chunk: 'mermaid-parser-langium',
+  },
+  {
+    packages: ['chevrotain', 'chevrotain-allstar', '@chevrotain/regexp-to-ast'],
+    chunk: 'mermaid-parser-chevrotain',
+  },
+  {
+    packages: [
+      'vscode-jsonrpc',
+      'vscode-languageserver-protocol',
+      'vscode-languageserver-types',
+    ],
+    chunk: 'mermaid-parser-vscode-lsp',
+  },
+]
+
 export default defineConfig(({ command }) => {
   const proxyTarget = process.env.MASC_DASHBOARD_PROXY_TARGET
   if (command === 'serve' && !proxyTarget) {
@@ -53,9 +94,27 @@ export default defineConfig(({ command }) => {
       sourcemap: 'hidden',
       rollupOptions: {
         output: {
-          manualChunks: {
-            vendor: ['preact', 'preact/hooks', 'htm', '@preact/signals'],
-            solid: ['solid-js', 'solid-js/store', 'solid-js/web'],
+          manualChunks(id) {
+            const normalizedId = normalizeModuleId(id)
+            for (const { packages, chunk } of heavyMermaidDependencyChunks) {
+              if (chunkByPackage(normalizedId, packages)) return chunk
+            }
+            if (normalizedId.includes('/node_modules/mermaid/dist/chunks/mermaid.core/')) {
+              const filename = normalizedId
+                .slice(normalizedId.lastIndexOf('/') + 1)
+                .replace(/\.mjs$/, '')
+              return `mermaid-${filename}`
+            }
+            if (normalizedId.includes('/node_modules/mermaid/dist/mermaid.core.mjs')) {
+              return 'mermaid-core'
+            }
+            if (chunkByPackage(normalizedId, ['preact', 'htm', '@preact/signals'])) {
+              return 'vendor'
+            }
+            if (chunkByPackage(normalizedId, ['solid-js'])) {
+              return 'solid'
+            }
+            return undefined
           },
         },
       },


### PR DESCRIPTION
## Summary

- Split Mermaid's dashboard runtime loading through a shared `mermaid-loader`.
- Preserve Mermaid's package-level core/diagram chunk boundaries in Vite output.
- Split heavy optional Mermaid dependencies such as Cytoscape/cose layout and parser/LSP packages so they no longer collapse into oversized diagram chunks.
- Make MermaidGraph async tests wait for DOM outcomes and unmount test containers to avoid leaking render work between cases.

## Review follow-up

- Addressed the type-only import review: `MermaidApi` now aliases Mermaid's exported `Mermaid` interface directly, while the runtime dynamic import path remains unchanged.

## Product impact

The dashboard production build no longer ships JavaScript chunks above Vite's 500 kB warning threshold for the Mermaid graph path. Operators still keep Mermaid diagram support, but rare diagram/parser dependencies load as smaller chunks instead of one oversized `mermaid.core` bundle.

## Evidence

- Baseline before patch: `pnpm --dir dashboard build` warned on `mermaid.core-D4j7gaBo.js` at 577.09 kB minified.
- After patch: `pnpm --dir dashboard build` completed with no `Some chunks are larger than 500 kB` warning.
- After patch generated asset scan: `[]` for JS chunks above 500 KiB.
- Largest generated JS chunks after patch: `activity-swimlane-Dmplh1Fe.js` 482.09 KiB, `cytoscape-CQT7hIPL.js` 431.45 KiB, `vis-network-DnFwc5Y2.js` 403.26 KiB.

## Review evidence

- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/common/mermaid-graph.test.ts src/components/common/mermaid-graph.a11y.test.ts src/components/common/markdown.test.ts src/components/common/markdown-renderer.test.ts --no-file-parallelism --maxWorkers=1` - 51 tests passed before this type-only fix.
- `pnpm --dir dashboard build`
- `git diff --check origin/main...HEAD`

## Linked issue

Fixes #9898
