### PR TITLE
fix(keeper): harden repo git config probing

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -327,15 +327,34 @@ let repository_url_basename url =
       String.sub base 0 (String.length base - 4)
     else base
 
-let read_file_opt path =
-  try Some (In_channel.with_open_bin path In_channel.input_all)
-  with Sys_error _ -> None
+let max_git_probe_file_bytes = 64 * 1024
 
-let safe_file_exists path =
-  try Sys.file_exists path with Sys_error _ -> false
+let safe_lstat path =
+  try Some (Unix.lstat path)
+  with Unix.Unix_error _ -> None
+
+let safe_file_exists path = Option.is_some (safe_lstat path)
 
 let safe_is_directory path =
-  try Sys.is_directory path with Sys_error _ -> false
+  match safe_lstat path with
+  | Some { Unix.st_kind = Unix.S_DIR; _ } -> true
+  | _ -> false
+
+let safe_is_symlink path =
+  match safe_lstat path with
+  | Some { Unix.st_kind = Unix.S_LNK; _ } -> true
+  | _ -> false
+
+let read_file_opt path =
+  match safe_lstat path with
+  | Some { Unix.st_kind = Unix.S_REG; st_size; _ }
+    when st_size <= max_git_probe_file_bytes -> (
+      try
+        Some
+          (In_channel.with_open_bin path (fun ic ->
+               really_input_string ic st_size))
+      with Sys_error _ | End_of_file -> None)
+  | _ -> None
 
 let normalize_lexical_path path =
   let absolute = String.starts_with ~prefix:"/" path in
@@ -368,7 +387,11 @@ let gitdir_config_path ~repo_root gitdir =
   let gitdir = normalize_lexical_path gitdir in
   match relative_under ~root:repo_lane gitdir with
   | None -> None
-  | Some _ -> Some (Filename.concat gitdir "config")
+  | Some _ ->
+      if safe_is_directory gitdir && not (safe_is_symlink gitdir) then
+        Some (Filename.concat gitdir "config")
+      else
+        None
 
 let git_config_path_of_repo_root repo_root =
   let dot_git = Filename.concat repo_root ".git" in

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -345,6 +345,10 @@ let safe_is_symlink path =
   | Some { Unix.st_kind = Unix.S_LNK; _ } -> true
   | _ -> false
 
+let safe_realpath path =
+  try Some (Unix.realpath path)
+  with Unix.Unix_error _ -> None
+
 let read_file_opt path =
   match safe_lstat path with
   | Some { Unix.st_kind = Unix.S_REG; st_size; _ }
@@ -384,14 +388,18 @@ let gitdir_config_path ~repo_root gitdir =
     else gitdir
   in
   let repo_lane = Filename.dirname repo_root |> normalize_lexical_path in
-  let gitdir = normalize_lexical_path gitdir in
-  match relative_under ~root:repo_lane gitdir with
-  | None -> None
-  | Some _ ->
-      if safe_is_directory gitdir && not (safe_is_symlink gitdir) then
-        Some (Filename.concat gitdir "config")
-      else
-        None
+  let gitdir_lexical = normalize_lexical_path gitdir in
+  match (safe_realpath repo_lane, safe_realpath gitdir_lexical) with
+  | Some repo_lane_real, Some gitdir_real -> (
+      match relative_under ~root:repo_lane_real gitdir_real with
+      | None -> None
+      | Some _ ->
+          if
+            safe_is_directory gitdir_real
+            && not (safe_is_symlink gitdir_lexical)
+          then Some (Filename.concat gitdir_real "config")
+          else None)
+  | _ -> None
 
 let git_config_path_of_repo_root repo_root =
   let dot_git = Filename.concat repo_root ".git" in

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -540,6 +540,41 @@ let test_validate_path_access_playground_gitdir_symlink_denied () =
       | Ok () -> Alcotest.fail "expected gitdir symlink to be denied"
       | Error _ -> ())
 
+let test_validate_path_access_playground_gitdir_parent_symlink_escape_denied () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repos_root =
+        Filename.concat base_path ".masc/playground/docker/executor/repos"
+      in
+      let repo_root = Filename.concat repos_root "parent-symlink-worktree" in
+      let outside_parent = Filename.concat base_path "outside-parent" in
+      let outside_gitdir = Filename.concat outside_parent "gitdir" in
+      let symlink_parent = Filename.concat repos_root "escape-parent" in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      write_file (Filename.concat outside_gitdir "config")
+        "[remote \"origin\"]\n\turl = https://github.com/jeong-sik/masc-mcp.git\n";
+      Unix.symlink outside_parent symlink_parent;
+      write_file (Filename.concat repo_root ".git")
+        "gitdir: ../escape-parent/gitdir\n";
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> Alcotest.fail "expected parent symlink gitdir escape to be denied"
+      | Error _ -> ())
+
 let test_validate_path_access_playground_large_git_config_denied () =
   with_temp_base_path (fun base_path ->
       let root_repo =
@@ -905,6 +940,9 @@ let () =
             test_validate_path_access_playground_dot_git_symlink_denied;
           Alcotest.test_case "playground gitdir symlink is denied" `Quick
             test_validate_path_access_playground_gitdir_symlink_denied;
+          Alcotest.test_case
+            "playground gitdir parent symlink escape is denied" `Quick
+            test_validate_path_access_playground_gitdir_parent_symlink_escape_denied;
           Alcotest.test_case "playground large git config is denied" `Quick
             test_validate_path_access_playground_large_git_config_denied;
           Alcotest.test_case "playground unknown repo denied" `Quick

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -12,6 +12,17 @@ let contains_substring s needle =
   in
   if n_len = 0 then true else loop 0
 
+let is_directory_no_follow path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } -> true
+  | _ -> false
+  | exception Unix.Unix_error _ -> false
+
+let path_exists_no_follow path =
+  match Unix.lstat path with
+  | _ -> true
+  | exception Unix.Unix_error _ -> false
+
 let with_temp_base_path f =
   let dir = Filename.temp_file "mapping_test" "" in
   Sys.remove dir;
@@ -23,8 +34,8 @@ let with_temp_base_path f =
   Fun.protect
     ~finally:(fun () ->
       let rec rm_rf path =
-        if Sys.file_exists path then
-          if Sys.is_directory path then begin
+        if path_exists_no_follow path then
+          if is_directory_no_follow path then begin
             Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
             Unix.rmdir path
           end else
@@ -40,8 +51,8 @@ let with_empty_temp_base_path f =
   Fun.protect
     ~finally:(fun () ->
       let rec rm_rf path =
-        if Sys.file_exists path then
-          if Sys.is_directory path then begin
+        if path_exists_no_follow path then
+          if is_directory_no_follow path then begin
             Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
             Unix.rmdir path
           end else
@@ -464,6 +475,104 @@ let test_validate_path_access_playground_gitdir_escape_denied () =
           Alcotest.(check bool)
             "mentions not allowed" true (contains_substring msg "not allowed"))
 
+let test_validate_path_access_playground_dot_git_symlink_denied () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repos_root =
+        Filename.concat base_path ".masc/playground/docker/executor/repos"
+      in
+      let repo_root = Filename.concat repos_root "symlink-worktree" in
+      let outside_gitdir = Filename.concat base_path "outside-symlink-gitdir" in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      write_file (Filename.concat outside_gitdir "config")
+        "[remote \"origin\"]\n\turl = https://github.com/jeong-sik/masc-mcp.git\n";
+      Unix.symlink outside_gitdir (Filename.concat repo_root ".git");
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> Alcotest.fail "expected .git symlink to be denied"
+      | Error _ -> ())
+
+let test_validate_path_access_playground_gitdir_symlink_denied () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repos_root =
+        Filename.concat base_path ".masc/playground/docker/executor/repos"
+      in
+      let repo_root = Filename.concat repos_root "gitdir-symlink-worktree" in
+      let outside_gitdir = Filename.concat base_path "outside-gitdir-target" in
+      let symlink_gitdir = Filename.concat repos_root "gitdir-link" in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      write_file (Filename.concat outside_gitdir "config")
+        "[remote \"origin\"]\n\turl = https://github.com/jeong-sik/masc-mcp.git\n";
+      Unix.symlink outside_gitdir symlink_gitdir;
+      write_file (Filename.concat repo_root ".git")
+        (Printf.sprintf "gitdir: %s\n" symlink_gitdir);
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> Alcotest.fail "expected gitdir symlink to be denied"
+      | Error _ -> ())
+
+let test_validate_path_access_playground_large_git_config_denied () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc-mcp.git";
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      write_repositories base_path [ root_repo; masc_repo ];
+      write_mapping base_path "executor" [ "masc" ];
+      let repos_root =
+        Filename.concat base_path ".masc/playground/docker/executor/repos"
+      in
+      let repo_root = Filename.concat repos_root "large-config-worktree" in
+      let path = Filename.concat repo_root "docs/proof.md" in
+      ensure_dir (Filename.dirname path);
+      ensure_dir (Filename.concat repo_root ".git");
+      write_file (Filename.concat repo_root ".git/config")
+        (String.make (70 * 1024) 'x'
+         ^ "\n[remote \"origin\"]\n\turl = https://github.com/jeong-sik/masc-mcp.git\n");
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> Alcotest.fail "expected oversized git config to be denied"
+      | Error msg ->
+          Alcotest.(check bool)
+            "mentions not allowed" true (contains_substring msg "not allowed"))
+
 let test_validate_path_access_playground_unknown_repo_denied () =
   with_temp_base_path (fun base_path ->
       let root_repo =
@@ -792,6 +901,12 @@ let () =
             test_validate_path_access_playground_gitdir_absolute_under_sandbox_uses_git_remote;
           Alcotest.test_case "playground escaping gitdir is denied" `Quick
             test_validate_path_access_playground_gitdir_escape_denied;
+          Alcotest.test_case "playground .git symlink is denied" `Quick
+            test_validate_path_access_playground_dot_git_symlink_denied;
+          Alcotest.test_case "playground gitdir symlink is denied" `Quick
+            test_validate_path_access_playground_gitdir_symlink_denied;
+          Alcotest.test_case "playground large git config is denied" `Quick
+            test_validate_path_access_playground_large_git_config_denied;
           Alcotest.test_case "playground unknown repo denied" `Quick
             test_validate_path_access_playground_unknown_repo_denied;
         ] );


### PR DESCRIPTION
Follow-up to #13592 review hardening.

## Why
- Reject symlinked .git entries and symlinked gitdir targets before trusting playground repo config.
- Avoid unbounded git probe reads from repo-owned files.

## Changes
- Gate git probes with lstat-based regular-file/directory checks.
- Cap git probe reads at 64 KiB.
- Add regressions for .git symlink, gitdir symlink, and oversized config denial.

## Validation
- git diff --check origin/main...HEAD
- scripts/check-oas-pin.sh --local-only
- env MASC_OPAM_LOCK=0 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_repo_mapping.exe
- ./_build/default/test/test_keeper_repo_mapping.exe test --show-errors --color=never validate_path_access