### PR TITLE
fix(telemetry): observe keeper hook output parse drops

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1029,15 +1029,15 @@ let first_some a b =
   | Some _ -> a
   | None -> b
 
-let observe_output_parse_failure ~surface ~error =
+let observe_output_parse_failure ~surface ~output_bytes =
   Safe_ops.protect ~default:() (fun () ->
       Prometheus.inc_counter
         Prometheus.metric_keeper_oas_hook_output_parse_failures
         ~labels:[ ("surface", surface) ] ());
   Safe_ops.protect ~default:() (fun () ->
       Log.Keeper.warn
-        "keeper_hooks_oas output JSON parse failed: surface=%s error=%s"
-        surface error)
+        "keeper_hooks_oas output JSON parse failed: surface=%s output_bytes=%d"
+        surface output_bytes)
 
 let output_json_opt ~surface output_text =
   match
@@ -1046,8 +1046,9 @@ let output_json_opt ~surface output_text =
       output_text
   with
   | Ok json -> Some json
-  | Error error ->
-      observe_output_parse_failure ~surface ~error;
+  | Error _ ->
+      observe_output_parse_failure ~surface
+        ~output_bytes:(String.length output_text);
       None
 
 let normalized_route_via raw =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1029,14 +1029,26 @@ let first_some a b =
   | Some _ -> a
   | None -> b
 
-let output_json_opt output_text =
+let observe_output_parse_failure ~surface ~error =
+  Safe_ops.protect ~default:() (fun () ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_oas_hook_output_parse_failures
+        ~labels:[ ("surface", surface) ] ());
+  Safe_ops.protect ~default:() (fun () ->
+      Log.Keeper.warn
+        "keeper_hooks_oas output JSON parse failed: surface=%s error=%s"
+        surface error)
+
+let output_json_opt ~surface output_text =
   match
     Safe_ops.parse_json_safe
-      ~context:"Keeper_hooks_oas.pr_review_action_metric.output"
+      ~context:("Keeper_hooks_oas." ^ surface ^ ".output")
       output_text
   with
   | Ok json -> Some json
-  | Error _ -> None
+  | Error error ->
+      observe_output_parse_failure ~surface ~error;
+      None
 
 let normalized_route_via raw =
   let value = String.trim raw |> String.lowercase_ascii in
@@ -1095,7 +1107,7 @@ let pr_review_action_metric_event_of_tool_io
     ~(transport_success : bool) =
   match tool_name with
   | "keeper_pr_review_comment" ->
-      let output_json = output_json_opt output_text in
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
       let route_via = Option.bind output_json route_via_of_json in
       let action =
         match output_json with
@@ -1128,7 +1140,7 @@ let pr_review_action_metric_event_of_tool_io
            })
         (Option.bind action normalize_pr_review_action)
   | "keeper_pr_review_reply" ->
-      let output_json = output_json_opt output_text in
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
       let route_via = Option.bind output_json route_via_of_json in
       let success =
         output_success ~transport_success output_json
@@ -1257,7 +1269,7 @@ let pr_work_action_metric_events_of_tool_io
     ~(input : Yojson.Safe.t)
     ~(output_text : string)
     ~(transport_success : bool) =
-  let output_json = output_json_opt output_text in
+  let output_json = output_json_opt ~surface:"pr_work_action" output_text in
   let route_via = Option.bind output_json route_via_of_json in
   let success = output_success ~transport_success output_json in
   match tool_name with

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -541,6 +541,8 @@ let metric_keeper_meta_json_failures =
   "masc_keeper_meta_json_failures_total"
 let metric_keeper_tools_oas_failures =
   "masc_keeper_tools_oas_failures_total"
+let metric_keeper_oas_hook_output_parse_failures =
+  "masc_keeper_oas_hook_output_parse_failures_total"
 let metric_keeper_turn_up_update_failures =
   "masc_keeper_turn_up_update_failures_total"
 let metric_keeper_exec_tools_failures =
@@ -1577,6 +1579,9 @@ let init () =
     Counter;
   add metric_keeper_tools_oas_failures
     "Total keeper OAS tool failures (blocked/error result/deadlock), labeled by tool and site"
+    Counter;
+  add metric_keeper_oas_hook_output_parse_failures
+    "Total keeper OAS hook tool-output JSON parse failures, labeled by surface"
     Counter;
   add metric_keeper_turn_up_update_failures
     "Total keeper turn-up update failures (prompt cap/sandbox validation/preflight), labeled by keeper and site"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -260,6 +260,9 @@ val metric_keeper_board_signal_no_wake_total : string
 
 val metric_keeper_meta_json_failures : string
 val metric_keeper_tools_oas_failures : string
+val metric_keeper_oas_hook_output_parse_failures : string
+(** Total keeper OAS hook tool-output JSON parse failures. Labels:
+    [surface] is [pr_review_action] or [pr_work_action]. *)
 val metric_keeper_turn_up_update_failures : string
 val metric_keeper_exec_tools_failures : string
 val metric_keeper_circuit_breaker_trips : string

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -618,6 +618,12 @@ let require_pr_review_event label = function
   | Some event -> event
   | None -> failf "expected PR review action event for %s" label
 
+let hook_output_parse_failures surface =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_keeper_oas_hook_output_parse_failures
+    ~labels:[ ("surface", surface) ]
+    ()
+
 let test_pr_review_action_metric_extracts_approve () =
   let event =
     pr_review_event
@@ -657,6 +663,20 @@ let test_pr_review_action_metric_extracts_reply () =
   check (option int) "comment id" (Some 1234) event.comment_id;
   check (option string) "reply route via" (Some "host") event.route_via
 
+let test_pr_review_action_metric_observes_invalid_output_json () =
+  let before = hook_output_parse_failures "pr_review_action" in
+  let event =
+    pr_review_event
+      ~tool_name:"keeper_pr_review_comment"
+      ~input:(`Assoc [ ("number", `Int 7); ("event", `String "comment") ])
+      ~output_text:"{not-json"
+    |> require_pr_review_event "invalid output json"
+  in
+  check string "action fallback from input" "COMMENT" event.action;
+  check (option int) "number fallback" (Some 7) event.pr_number;
+  check (float 0.001) "parse failure counted" (before +. 1.0)
+    (hook_output_parse_failures "pr_review_action")
+
 let pr_work_events ~tool_name ~input ~output_text =
   Hooks.For_testing.pr_work_action_metric_events_of_tool_io
     ~tool_name ~input ~output_text ~transport_success:true
@@ -679,6 +699,19 @@ let test_pr_work_action_metric_extracts_masc_code_git_push () =
   check string "source" "masc_code_git" event.work_source;
   check bool "success" true event.success;
   check (option string) "route via" (Some "docker") event.route_via
+
+let test_pr_work_action_metric_observes_invalid_output_json () =
+  let before = hook_output_parse_failures "pr_work_action" in
+  let events =
+    pr_work_events
+      ~tool_name:"masc_code_git"
+      ~input:(`Assoc [ ("action", `String "push") ])
+      ~output_text:"{not-json"
+  in
+  check (list string) "actions fallback from input" [ "GIT_PUSH" ]
+    (work_actions events);
+  check (float 0.001) "parse failure counted" (before +. 1.0)
+    (hook_output_parse_failures "pr_work_action")
 
 let test_pr_work_action_metric_extracts_gh_pr_create () =
   let events =
@@ -849,10 +882,14 @@ let () =
             test_pr_review_action_metric_marks_structured_failure
         ; test_case "extracts reply action" `Quick
             test_pr_review_action_metric_extracts_reply
+        ; test_case "observes invalid output JSON" `Quick
+            test_pr_review_action_metric_observes_invalid_output_json
         ] )
     ; ( "pr_work_action",
         [ test_case "extracts masc_code_git push" `Quick
             test_pr_work_action_metric_extracts_masc_code_git_push
+        ; test_case "observes invalid output JSON" `Quick
+            test_pr_work_action_metric_observes_invalid_output_json
         ; test_case "extracts keeper_shell gh pr create" `Quick
             test_pr_work_action_metric_extracts_gh_pr_create
         ; test_case "extracts keeper_pr_create" `Quick

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -277,6 +277,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_telemetry_coverage_gap;
   check_registered Prometheus.metric_telemetry_unified_source_read_failures;
   check_registered Prometheus.metric_tool_assignment_telemetry_failures;
+  check_registered Prometheus.metric_keeper_oas_hook_output_parse_failures;
   check_registered Prometheus.metric_coord_telemetry_drop;
   check_registered Prometheus.metric_coord_claim_post_provision_failures
 


### PR DESCRIPTION
## Summary
- add masc_keeper_oas_hook_output_parse_failures_total{surface} for keeper OAS hook tool-output parse failures
- warn and count invalid PR review / PR work metric output JSON while preserving existing fallback behavior
- add regression coverage for invalid output JSON on pr_review_action and pr_work_action surfaces

## Verification
- scripts/check-oas-pin.sh --local-only
- env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe test/test_prometheus_coverage.exe
- ./_build/default/test/test_keeper_hooks_oas_telemetry.exe
- ./_build/default/test/test_prometheus_coverage.exe
- git diff --check origin/main..HEAD

## Operator Impact
Malformed hook output can no longer disappear into a normal transport-success fallback. Operators get a bounded two-value surface label while the existing telemetry event extraction remains tolerant.