### PR TITLE
test(otel): guard GenAI attr registry completeness

### DIFF
--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -60,6 +60,8 @@ module Attr_key = struct
     ]
   ;;
 
+  let all_known = official_gen_ai @ masc_extensions @ legacy
+
   let is_official_gen_ai key = List.mem key official_gen_ai
   let is_masc_extension key = List.mem key masc_extensions
 end

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -30,37 +30,47 @@ module Attr_key = struct
   let tool_success = "tool.success"
   let tool_duration_ms = "tool.duration_ms"
 
-  let official_gen_ai =
-    [ gen_ai_operation_name
-    ; gen_ai_provider_name
-    ; gen_ai_agent_name
-    ; gen_ai_agent_id
-    ; gen_ai_conversation_id
-    ; gen_ai_tool_name
+  type boundary =
+    | Official_gen_ai
+    | Masc_extension
+    | Legacy
+
+  let registry =
+    [ gen_ai_operation_name, Official_gen_ai
+    ; gen_ai_provider_name, Official_gen_ai
+    ; gen_ai_agent_name, Official_gen_ai
+    ; gen_ai_agent_id, Official_gen_ai
+    ; gen_ai_conversation_id, Official_gen_ai
+    ; gen_ai_tool_name, Official_gen_ai
+    ; masc_gen_ai_keeper_name, Masc_extension
+    ; masc_gen_ai_cascade_name, Masc_extension
+    ; keeper_name, Legacy
+    ; keeper_agent_name, Legacy
+    ; keeper_cascade_name, Legacy
+    ; keeper_trace_id, Legacy
+    ; keeper_generation, Legacy
+    ; keeper_max_context, Legacy
+    ; keeper_max_turns, Legacy
+    ; keeper_max_idle_turns, Legacy
+    ; keeper_channel, Legacy
+    ; keeper_is_retry, Legacy
+    ; keeper_current_task_id, Legacy
+    ; tool_name, Legacy
+    ; tool_success, Legacy
+    ; tool_duration_ms, Legacy
     ]
   ;;
 
-  let masc_extensions = [ masc_gen_ai_keeper_name; masc_gen_ai_cascade_name ]
-
-  let legacy =
-    [ keeper_name
-    ; keeper_agent_name
-    ; keeper_cascade_name
-    ; keeper_trace_id
-    ; keeper_generation
-    ; keeper_max_context
-    ; keeper_max_turns
-    ; keeper_max_idle_turns
-    ; keeper_channel
-    ; keeper_is_retry
-    ; keeper_current_task_id
-    ; tool_name
-    ; tool_success
-    ; tool_duration_ms
-    ]
+  let keys_for boundary =
+    registry
+    |> List.filter_map (fun (key, registered_boundary) ->
+      if registered_boundary = boundary then Some key else None)
   ;;
 
-  let all_known = official_gen_ai @ masc_extensions @ legacy
+  let all_known = List.map fst registry
+  let official_gen_ai = keys_for Official_gen_ai
+  let masc_extensions = keys_for Masc_extension
+  let legacy = keys_for Legacy
 
   let is_official_gen_ai key = List.mem key official_gen_ai
   let is_masc_extension key = List.mem key masc_extensions

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -7,59 +7,56 @@
 type attr = string * [ `Bool of bool | `Int of int | `String of string ]
 
 module Attr_key = struct
-  let gen_ai_operation_name = "gen_ai.operation.name"
-  let gen_ai_provider_name = "gen_ai.provider.name"
-  let gen_ai_agent_name = "gen_ai.agent.name"
-  let gen_ai_agent_id = "gen_ai.agent.id"
-  let gen_ai_conversation_id = "gen_ai.conversation.id"
-  let gen_ai_tool_name = "gen_ai.tool.name"
-  let masc_gen_ai_keeper_name = "masc.gen_ai.keeper.name"
-  let masc_gen_ai_cascade_name = "masc.gen_ai.cascade.name"
-  let keeper_name = "keeper.name"
-  let keeper_agent_name = "keeper.agent_name"
-  let keeper_cascade_name = "keeper.cascade.name"
-  let keeper_trace_id = "keeper.trace_id"
-  let keeper_generation = "keeper.generation"
-  let keeper_max_context = "keeper.max_context"
-  let keeper_max_turns = "keeper.max_turns"
-  let keeper_max_idle_turns = "keeper.max_idle_turns"
-  let keeper_channel = "keeper.channel"
-  let keeper_is_retry = "keeper.is_retry"
-  let keeper_current_task_id = "keeper.current_task_id"
-  let tool_name = "tool.name"
-  let tool_success = "tool.success"
-  let tool_duration_ms = "tool.duration_ms"
-
   type boundary =
     | Official_gen_ai
     | Masc_extension
     | Legacy
 
-  let registry =
-    [ gen_ai_operation_name, Official_gen_ai
-    ; gen_ai_provider_name, Official_gen_ai
-    ; gen_ai_agent_name, Official_gen_ai
-    ; gen_ai_agent_id, Official_gen_ai
-    ; gen_ai_conversation_id, Official_gen_ai
-    ; gen_ai_tool_name, Official_gen_ai
-    ; masc_gen_ai_keeper_name, Masc_extension
-    ; masc_gen_ai_cascade_name, Masc_extension
-    ; keeper_name, Legacy
-    ; keeper_agent_name, Legacy
-    ; keeper_cascade_name, Legacy
-    ; keeper_trace_id, Legacy
-    ; keeper_generation, Legacy
-    ; keeper_max_context, Legacy
-    ; keeper_max_turns, Legacy
-    ; keeper_max_idle_turns, Legacy
-    ; keeper_channel, Legacy
-    ; keeper_is_retry, Legacy
-    ; keeper_current_task_id, Legacy
-    ; tool_name, Legacy
-    ; tool_success, Legacy
-    ; tool_duration_ms, Legacy
-    ]
+  let registry_ref = ref []
+
+  let register boundary key =
+    registry_ref := (key, boundary) :: !registry_ref;
+    key
   ;;
+
+  let gen_ai_operation_name =
+    register Official_gen_ai "gen_ai.operation.name"
+  ;;
+
+  let gen_ai_provider_name = register Official_gen_ai "gen_ai.provider.name"
+  let gen_ai_agent_name = register Official_gen_ai "gen_ai.agent.name"
+  let gen_ai_agent_id = register Official_gen_ai "gen_ai.agent.id"
+
+  let gen_ai_conversation_id =
+    register Official_gen_ai "gen_ai.conversation.id"
+  ;;
+
+  let gen_ai_tool_name = register Official_gen_ai "gen_ai.tool.name"
+
+  let masc_gen_ai_keeper_name =
+    register Masc_extension "masc.gen_ai.keeper.name"
+  ;;
+
+  let masc_gen_ai_cascade_name =
+    register Masc_extension "masc.gen_ai.cascade.name"
+  ;;
+
+  let keeper_name = register Legacy "keeper.name"
+  let keeper_agent_name = register Legacy "keeper.agent_name"
+  let keeper_cascade_name = register Legacy "keeper.cascade.name"
+  let keeper_trace_id = register Legacy "keeper.trace_id"
+  let keeper_generation = register Legacy "keeper.generation"
+  let keeper_max_context = register Legacy "keeper.max_context"
+  let keeper_max_turns = register Legacy "keeper.max_turns"
+  let keeper_max_idle_turns = register Legacy "keeper.max_idle_turns"
+  let keeper_channel = register Legacy "keeper.channel"
+  let keeper_is_retry = register Legacy "keeper.is_retry"
+  let keeper_current_task_id = register Legacy "keeper.current_task_id"
+  let tool_name = register Legacy "tool.name"
+  let tool_success = register Legacy "tool.success"
+  let tool_duration_ms = register Legacy "tool.duration_ms"
+
+  let registry = List.rev !registry_ref
 
   let keys_for boundary =
     registry

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -26,11 +26,11 @@ module Attr_key : sig
   val tool_success : string
   val tool_duration_ms : string
 
-  (** Every Attr_key constant exported by this module.
+  (** Every registered Attr_key exported by this module.
 
-      Derived from the same internal registry that drives the boundary lists
-      below. Tests assert that the boundary lists form a disjoint partition of
-      this registry. *)
+      Exported constants are created through the internal registration helper,
+      and this list is derived from that registry. Tests assert that the
+      boundary lists form a disjoint partition of the registry. *)
   val all_known : string list
 
   val official_gen_ai : string list

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -28,8 +28,9 @@ module Attr_key : sig
 
   (** Every Attr_key constant exported by this module.
 
-      Keep this list in sync with the classification lists below. Tests assert
-      that each known key appears in exactly one registry boundary. *)
+      Derived from the same internal registry that drives the boundary lists
+      below. Tests assert that the boundary lists form a disjoint partition of
+      this registry. *)
   val all_known : string list
 
   val official_gen_ai : string list

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -26,11 +26,12 @@ module Attr_key : sig
   val tool_success : string
   val tool_duration_ms : string
 
-  (** Every registered Attr_key exported by this module.
+  (** Every registered Attr_key constant exported by this module.
 
       Exported constants are created through the internal registration helper,
-      and this list is derived from that registry. Tests assert that the
-      boundary lists form a disjoint partition of the registry. *)
+      and this list is derived from that registry. Tests assert that exported
+      string constants are registered and that the boundary lists form a
+      disjoint partition of the registry. *)
   val all_known : string list
 
   val official_gen_ai : string list

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -25,6 +25,13 @@ module Attr_key : sig
   val tool_name : string
   val tool_success : string
   val tool_duration_ms : string
+
+  (** Every Attr_key constant exported by this module.
+
+      Keep this list in sync with the classification lists below. Tests assert
+      that each known key appears in exactly one registry boundary. *)
+  val all_known : string list
+
   val official_gen_ai : string list
   val masc_extensions : string list
   val legacy : string list

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -159,6 +159,36 @@ let test_attr_key_registry_full_coverage () =
   List.iter check_legacy K.legacy
 ;;
 
+let sorted_unique values =
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | x :: y :: rest when String.equal x y -> loop acc (y :: rest)
+    | x :: rest -> loop (x :: acc) rest
+  in
+  values |> List.sort String.compare |> loop []
+;;
+
+let duplicate_keys values =
+  let sorted = List.sort String.compare values in
+  let rec loop acc = function
+    | x :: y :: rest when String.equal x y -> loop (x :: acc) (y :: rest)
+    | _ :: rest -> loop acc rest
+    | [] -> List.rev acc
+  in
+  loop [] sorted |> sorted_unique
+;;
+
+let test_attr_key_registry_has_no_orphans () =
+  let module K = Lib.Otel_genai.Attr_key in
+  let classified = K.official_gen_ai @ K.masc_extensions @ K.legacy in
+  check
+    (list string)
+    "classified keys match all known keys"
+    (sorted_unique K.all_known)
+    (sorted_unique classified);
+  check (list string) "no duplicate key classifications" [] (duplicate_keys classified)
+;;
+
 let test_tool_execution_attrs () =
   let attrs = Lib.Otel_genai.tool_execution_attrs ~tool_name:"keeper_shell" in
   check
@@ -187,6 +217,7 @@ let test_dispatch_hook_emits_tool_span_payload () =
           let result : Lib.Tool_result.t =
             { success = true
             ; data = `String "ok"
+            ; legacy_message = "ok"
             ; tool_name = "keeper_shell"
             ; duration_ms = 123.4
             }
@@ -242,6 +273,8 @@ let () =
             test_attr_key_registry_boundaries
         ; test_case "attr key registry full coverage" `Quick
             test_attr_key_registry_full_coverage
+        ; test_case "attr key registry has no orphans" `Quick
+            test_attr_key_registry_has_no_orphans
         ; test_case "tool execution attrs" `Quick test_tool_execution_attrs
         ; test_case "dispatch hook emits tool span payload" `Quick
             test_dispatch_hook_emits_tool_span_payload

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -178,6 +178,121 @@ let duplicate_keys values =
   loop [] sorted |> sorted_unique
 ;;
 
+let string_starts_with ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.equal (String.sub value 0 prefix_len) prefix
+;;
+
+let string_ends_with ~suffix value =
+  let value_len = String.length value in
+  let suffix_len = String.length suffix in
+  value_len >= suffix_len
+  && String.equal (String.sub value (value_len - suffix_len) suffix_len) suffix
+;;
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+;;
+
+let repo_root () =
+  let has_otel_source path =
+    Sys.file_exists (Filename.concat path "lib/otel/otel_genai.ml")
+  in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_otel_source root -> root
+  | _ ->
+      let rec ascend path =
+        if has_otel_source path
+        then path
+        else (
+          let parent = Filename.dirname path in
+          if String.equal parent path then path else ascend parent)
+      in
+      ascend (Sys.getcwd ())
+;;
+
+let source_path relative = Filename.concat (repo_root ()) relative
+
+let attr_key_mli_string_constant_names () =
+  read_file (source_path "lib/otel/otel_genai.mli")
+  |> String.split_on_char '\n'
+  |> List.filter_map (fun line ->
+    let line = String.trim line in
+    if string_starts_with ~prefix:"val " line
+       && string_ends_with ~suffix:" : string" line
+    then (
+      let rest = String.sub line 4 (String.length line - 4) in
+      match String.index_opt rest ' ' with
+      | Some idx -> Some (String.sub rest 0 idx)
+      | None -> None)
+    else None)
+  |> sorted_unique
+;;
+
+let let_binding_name_and_rhs line =
+  if string_starts_with ~prefix:"let " line
+  then (
+    let rest = String.sub line 4 (String.length line - 4) in
+    match String.index_opt rest '=' with
+    | Some idx ->
+        let name = String.sub rest 0 idx |> String.trim in
+        let rhs =
+          String.sub rest (idx + 1) (String.length rest - idx - 1) |> String.trim
+        in
+        Some (name, rhs)
+    | None -> None)
+  else None
+;;
+
+let rec next_nonempty_line = function
+  | [] -> ""
+  | line :: rest ->
+      let line = String.trim line in
+      if String.equal line "" then next_nonempty_line rest else line
+;;
+
+let registered_attr_key_constant_names () =
+  let lines =
+    read_file (source_path "lib/otel/otel_genai.ml") |> String.split_on_char '\n'
+  in
+  let rec loop acc = function
+    | [] -> sorted_unique acc
+    | line :: rest ->
+        let line = String.trim line in
+        (match let_binding_name_and_rhs line with
+         | Some (name, rhs)
+           when string_starts_with ~prefix:"register " rhs
+                || string_starts_with ~prefix:"register " (next_nonempty_line rest)
+           -> loop (name :: acc) rest
+         | _ -> loop acc rest)
+  in
+  loop [] lines
+;;
+
+let test_attr_key_exported_constants_are_registered () =
+  let module K = Lib.Otel_genai.Attr_key in
+  let exported_names = attr_key_mli_string_constant_names () in
+  let registered_exported_names =
+    registered_attr_key_constant_names ()
+    |> List.filter (fun name -> List.mem name exported_names)
+    |> sorted_unique
+  in
+  check
+    (list string)
+    "exported string constants use register helper"
+    exported_names
+    registered_exported_names;
+  check
+    int
+    "registered key count matches exported constants"
+    (List.length exported_names)
+    (List.length K.all_known)
+;;
+
 let test_attr_key_registry_has_no_orphans () =
   let module K = Lib.Otel_genai.Attr_key in
   let classified = K.official_gen_ai @ K.masc_extensions @ K.legacy in
@@ -273,6 +388,8 @@ let () =
             test_attr_key_registry_boundaries
         ; test_case "attr key registry full coverage" `Quick
             test_attr_key_registry_full_coverage
+        ; test_case "attr key exported constants are registered" `Quick
+            test_attr_key_exported_constants_are_registered
         ; test_case "attr key registry has no orphans" `Quick
             test_attr_key_registry_has_no_orphans
         ; test_case "tool execution attrs" `Quick test_tool_execution_attrs


### PR DESCRIPTION
## Summary
- add `Attr_key.all_known` as the explicit OTel GenAI attribute registry
- assert classified keys match `all_known` and are not duplicated across boundaries
- keep the existing per-boundary classification checks

Closes #13644

## Verification
- `git diff --check`
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13644 scripts/dune-local.sh exec ./test/test_otel_genai.exe` (8/8)

## Review focus
- Registry boundary correctness after post-merge review on #13525
- Whether `all_known` should remain public on `Otel_genai.Attr_key` for downstream telemetry audits
