### PR TITLE
fix(dashboard): surface websocket close details (#10701)

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -52,9 +52,13 @@ class MockWebSocket {
     this.sent.push(data)
   }
 
-  close(): void {
+  close(event: Partial<Pick<CloseEvent, 'code' | 'reason' | 'wasClean'>> = {}): void {
     this.readyState = MockWebSocket.CLOSED
-    this.onclose?.(new CloseEvent('close'))
+    this.onclose?.({
+      code: event.code ?? 1000,
+      reason: event.reason ?? '',
+      wasClean: event.wasClean ?? true,
+    } as CloseEvent)
   }
 
   open(): void {
@@ -449,6 +453,39 @@ describe('dashboard websocket route subscriptions', () => {
     socket.close()
 
     await expect(subscribePromise).rejects.toThrow('dashboard websocket closed')
+  })
+
+  it('surfaces close code and reason when the socket closes', async () => {
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const initialSubscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: initialSubscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+
+    const subscribePromise = subscribeDashboardRoute({
+      tab: 'workspace',
+      params: { section: 'planning' },
+    })
+    expect(parseRpc(socket, 2).method).toBe('dashboard/subscribe')
+
+    socket.close({ code: 4001, reason: 'auth rejected', wasClean: false })
+
+    const closeMessage = 'dashboard websocket closed (code=4001, reason=auth rejected, wasClean=false)'
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(dashboardWsLastError.value).toBe(closeMessage)
+    await expect(subscribePromise).rejects.toThrow(closeMessage)
   })
 
   it('rejects in-flight subscribe RPCs when the server never responds', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -204,6 +204,12 @@ function rejectPendingRpcs(err: Error): void {
   pending.clear()
 }
 
+function formatCloseEventError(event: CloseEvent): string {
+  const parts = [`code=${event.code}`, `wasClean=${event.wasClean}`]
+  if (event.reason) parts.splice(1, 0, `reason=${event.reason}`)
+  return `dashboard websocket closed (${parts.join(', ')})`
+}
+
 function scheduleReconnect(): void {
   if (!shouldReconnect) return
   if (reconnectTimer) return
@@ -526,15 +532,17 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
       dashboardWsLastError.value = 'dashboard websocket error'
     })
   }
-  ws.onclose = () => {
+  ws.onclose = (event) => {
     if (socket !== ws) return
+    const closeError = new Error(formatCloseEventError(event))
     batch(() => {
       dashboardWsConnected.value = false
       dashboardWsReady.value = false
+      dashboardWsLastError.value = closeError.message
     })
     lastSubscribeKey = ''
     socket = null
-    rejectPendingRpcs(new Error('dashboard websocket closed'))
+    rejectPendingRpcs(closeError)
     scheduleReconnect()
   }
 }


### PR DESCRIPTION
## Summary

- surface browser WebSocket close `code`, `reason`, and `wasClean` in `dashboardWsLastError`
- reject in-flight dashboard RPCs with the same close detail instead of the generic closed error
- add focused coverage for a server close carrying an auth-style reason

## Why

Issue #10701 asks for close reason/code visibility after the WS-only connect/close storm. Current `main` already downgraded per-session storm logs and added cleanup hardening, but the dashboard client still collapsed every close into `dashboard websocket closed`, which made a single-client trace blind to browser-observable close details.

This patch records the data available at the browser boundary without claiming server-side close metadata the current OCaml handlers do not expose.

Refs #10701.

## Validation

- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1` — 17 passed
- `pnpm --dir dashboard run lint` — 0 errors, 3 existing warnings outside this patch
- `git diff --check origin/main..HEAD`
