### PR TITLE
fix(chronicle): derive deterministic memory timestamps

### DIFF
--- a/lib/chronicle_memory.ml
+++ b/lib/chronicle_memory.ml
@@ -64,6 +64,44 @@ let salience_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
   in
   min 0.95 (0.55 +. commit_signal +. goal_signal)
 
+let unix_seconds_of_yyyy_mm_dd raw =
+  let raw = String.trim raw in
+  if String.length raw < 10 then None
+  else
+    match
+      ( int_of_string_opt (String.sub raw 0 4)
+      , int_of_string_opt (String.sub raw 5 2)
+      , int_of_string_opt (String.sub raw 8 2) )
+    with
+    | Some year, Some month, Some day ->
+        (try
+           let tm =
+             { Unix.tm_sec = 0
+             ; tm_min = 0
+             ; tm_hour = 0
+             ; tm_mday = day
+             ; tm_mon = month - 1
+             ; tm_year = year - 1900
+             ; tm_wday = 0
+             ; tm_yday = 0
+             ; tm_isdst = false
+             }
+           in
+           let local_epoch, _ = Unix.mktime tm in
+           let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
+           let tz_offset = local_epoch -. utc_as_local in
+           Some (local_epoch +. tz_offset)
+         with _ -> None)
+    | _ -> None
+
+let default_timestamp_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
+  match unix_seconds_of_yyyy_mm_dd epoch.end_date with
+  | Some ts -> ts
+  | None ->
+      (match unix_seconds_of_yyyy_mm_dd epoch.start_date with
+       | Some ts -> ts
+       | None -> 0.0)
+
 let episode_of_candidate ?timestamp ~keeper_name
     (epoch : Chronicle_ingest.candidate_epoch) : Agent_sdk.Memory.episode =
   let summary = summary_of_candidate epoch in
@@ -81,7 +119,8 @@ let episode_of_candidate ?timestamp ~keeper_name
     ]
   in
   { id = episode_id epoch
-  ; timestamp = Option.value timestamp ~default:(Time_compat.now ())
+  ; timestamp =
+      Option.value timestamp ~default:(default_timestamp_of_candidate epoch)
   ; participants = [ keeper_name ]
   ; action = summary
   ; outcome = Agent_sdk.Memory.Neutral
@@ -98,10 +137,10 @@ let episode_of_candidate ?timestamp ~keeper_name
       ]
   }
 
-let store_candidate_epoch ~memory ~keeper_name epoch =
+let store_candidate_epoch ?timestamp ~memory ~keeper_name epoch =
   Agent_sdk.Memory.store_episode memory
-    (episode_of_candidate ~keeper_name epoch)
+    (episode_of_candidate ?timestamp ~keeper_name epoch)
 
-let store_candidate_epochs ~memory ~keeper_name epochs =
-  List.iter (store_candidate_epoch ~memory ~keeper_name) epochs;
+let store_candidate_epochs ?timestamp ~memory ~keeper_name epochs =
+  List.iter (store_candidate_epoch ?timestamp ~memory ~keeper_name) epochs;
   List.length epochs

--- a/lib/chronicle_memory.ml
+++ b/lib/chronicle_memory.ml
@@ -67,32 +67,7 @@ let salience_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
 let unix_seconds_of_yyyy_mm_dd raw =
   let raw = String.trim raw in
   if String.length raw < 10 then None
-  else
-    match
-      ( int_of_string_opt (String.sub raw 0 4)
-      , int_of_string_opt (String.sub raw 5 2)
-      , int_of_string_opt (String.sub raw 8 2) )
-    with
-    | Some year, Some month, Some day ->
-        (try
-           let tm =
-             { Unix.tm_sec = 0
-             ; tm_min = 0
-             ; tm_hour = 0
-             ; tm_mday = day
-             ; tm_mon = month - 1
-             ; tm_year = year - 1900
-             ; tm_wday = 0
-             ; tm_yday = 0
-             ; tm_isdst = false
-             }
-           in
-           let local_epoch, _ = Unix.mktime tm in
-           let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
-           let tz_offset = local_epoch -. utc_as_local in
-           Some (local_epoch +. tz_offset)
-         with _ -> None)
-    | _ -> None
+  else Masc_domain.parse_iso8601_opt (String.sub raw 0 10 ^ "T00:00:00Z")
 
 let default_timestamp_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
   match unix_seconds_of_yyyy_mm_dd epoch.end_date with

--- a/lib/chronicle_memory.mli
+++ b/lib/chronicle_memory.mli
@@ -3,6 +3,12 @@
 val episode_id : Chronicle_ingest.candidate_epoch -> string
 (** Deterministic episode id for a chronicle candidate epoch. *)
 
+val default_timestamp_of_candidate : Chronicle_ingest.candidate_epoch -> float
+(** Deterministic timestamp for a candidate epoch.
+
+    Uses [end_date] at 00:00:00 UTC, then [start_date], then [0.0] if neither
+    date is parseable. *)
+
 val episode_of_candidate :
   ?timestamp:float ->
   keeper_name:string ->
@@ -11,6 +17,7 @@ val episode_of_candidate :
 (** Convert a chronicle candidate epoch into an OAS episodic memory entry. *)
 
 val store_candidate_epoch :
+  ?timestamp:float ->
   memory:Agent_sdk.Memory.t ->
   keeper_name:string ->
   Chronicle_ingest.candidate_epoch ->
@@ -18,6 +25,7 @@ val store_candidate_epoch :
 (** Store one candidate epoch in [memory]. *)
 
 val store_candidate_epochs :
+  ?timestamp:float ->
   memory:Agent_sdk.Memory.t ->
   keeper_name:string ->
   Chronicle_ingest.candidate_epoch list ->

--- a/test/test_chronicle_ingest.ml
+++ b/test/test_chronicle_ingest.ml
@@ -255,20 +255,42 @@ let test_chronicle_memory_episode_shape () =
   check string "summary includes structured commit count" expected_summary
     episode.action
 
+let test_chronicle_memory_default_timestamp_uses_epoch_end_date () =
+  let episode = CM.episode_of_candidate ~keeper_name:"sangsu" sample_epoch in
+  check (float 0.001) "end date midnight UTC" 1777680000.0 episode.timestamp
+
 let test_chronicle_memory_store_recall () =
   let memory = Agent_sdk.Memory.create () in
   let stored =
     CM.store_candidate_epochs ~memory ~keeper_name:"sangsu" [ sample_epoch ]
   in
   check int "stored count" 1 stored;
-  let recalled = Agent_sdk.Memory.recall_episodes memory ~limit:10 () in
+  let recalled =
+    Agent_sdk.Memory.recall_episodes memory ~now:1777680000.0 ~limit:10 ()
+  in
   check int "recalled count" 1 (List.length recalled);
   let episode = List.hd recalled in
   check string "recalled id"
     "git-chronicle-PK-999-abcdef123456" episode.id;
   check string "recalled event type" "git_chronicle"
     (Option.value ~default:""
-       (metadata_string "event_type" episode.metadata))
+       (metadata_string "event_type" episode.metadata));
+  check (float 0.001) "stored timestamp" 1777680000.0 episode.timestamp
+
+let test_chronicle_memory_store_accepts_explicit_timestamp () =
+  let memory = Agent_sdk.Memory.create () in
+  let stored =
+    CM.store_candidate_epochs
+      ~timestamp:99.0
+      ~memory
+      ~keeper_name:"sangsu"
+      [ sample_epoch ]
+  in
+  check int "stored count" 1 stored;
+  let recalled = Agent_sdk.Memory.recall_episodes memory ~now:99.0 ~limit:10 () in
+  match recalled with
+  | [ episode ] -> check (float 0.001) "explicit timestamp" 99.0 episode.timestamp
+  | _ -> fail "expected one recalled episode"
 
 let () =
   run "Chronicle_ingest" [
@@ -302,6 +324,10 @@ let () =
     ]);
     ("chronicle_memory", [
       test_case "episode shape" `Quick test_chronicle_memory_episode_shape;
+      test_case "default timestamp uses epoch end date" `Quick
+        test_chronicle_memory_default_timestamp_uses_epoch_end_date;
       test_case "store recall" `Quick test_chronicle_memory_store_recall;
+      test_case "store accepts explicit timestamp" `Quick
+        test_chronicle_memory_store_accepts_explicit_timestamp;
     ]);
   ]

--- a/test/test_chronicle_ingest.ml
+++ b/test/test_chronicle_ingest.ml
@@ -259,6 +259,18 @@ let test_chronicle_memory_default_timestamp_uses_epoch_end_date () =
   let episode = CM.episode_of_candidate ~keeper_name:"sangsu" sample_epoch in
   check (float 0.001) "end date midnight UTC" 1777680000.0 episode.timestamp
 
+let test_chronicle_memory_default_timestamp_falls_back_to_start_date () =
+  let epoch = { sample_epoch with end_date = "not-a-date" } in
+  let episode = CM.episode_of_candidate ~keeper_name:"sangsu" epoch in
+  check (float 0.001) "start date midnight UTC" 1777593600.0 episode.timestamp
+
+let test_chronicle_memory_default_timestamp_falls_back_to_zero () =
+  let epoch =
+    { sample_epoch with start_date = "not-a-date"; end_date = "not-a-date" }
+  in
+  let episode = CM.episode_of_candidate ~keeper_name:"sangsu" epoch in
+  check (float 0.001) "missing date fallback" 0.0 episode.timestamp
+
 let test_chronicle_memory_store_recall () =
   let memory = Agent_sdk.Memory.create () in
   let stored =
@@ -326,6 +338,10 @@ let () =
       test_case "episode shape" `Quick test_chronicle_memory_episode_shape;
       test_case "default timestamp uses epoch end date" `Quick
         test_chronicle_memory_default_timestamp_uses_epoch_end_date;
+      test_case "default timestamp falls back to start date" `Quick
+        test_chronicle_memory_default_timestamp_falls_back_to_start_date;
+      test_case "default timestamp falls back to zero" `Quick
+        test_chronicle_memory_default_timestamp_falls_back_to_zero;
       test_case "store recall" `Quick test_chronicle_memory_store_recall;
       test_case "store accepts explicit timestamp" `Quick
         test_chronicle_memory_store_accepts_explicit_timestamp;


### PR DESCRIPTION
## Summary
- derive default chronicle memory timestamps from candidate epoch dates instead of wall-clock time
- expose `default_timestamp_of_candidate` and optional `~timestamp` on store helpers
- add regressions for default end-date timestamping and explicit store timestamps

Closes #13643

## Verification
- `git diff --check`
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13643 scripts/dune-local.sh exec ./test/test_chronicle_ingest.exe` (22/22)

## Review focus
- UTC date parsing fallback behavior: end_date, then start_date, then epoch 0.0
- Whether callers need a per-epoch timestamp callback beyond the explicit `~timestamp` override
