### PR TITLE
fix(review): close post-merge roadmap nits

### DIFF
--- a/lib/chronicle_memory.ml
+++ b/lib/chronicle_memory.ml
@@ -64,6 +64,34 @@ let salience_of_candidate (epoch : Chronicle_ingest.candidate_epoch) =
   in
   min 0.95 (0.55 +. commit_signal +. goal_signal)
 
+let utc_midnight_of_yyyy_mm_dd raw =
+  try
+    Scanf.sscanf raw "%04d-%02d-%02d" (fun year month day ->
+        let tm =
+          {
+            Unix.tm_sec = 0;
+            tm_min = 0;
+            tm_hour = 0;
+            tm_mday = day;
+            tm_mon = month - 1;
+            tm_year = year - 1900;
+            tm_wday = 0;
+            tm_yday = 0;
+            tm_isdst = false;
+          }
+        in
+        let local_epoch, _ = Unix.mktime tm in
+        let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
+        let tz_offset = local_epoch -. utc_as_local in
+        Some (local_epoch +. tz_offset))
+  with Scanf.Scan_failure _ | Failure _ | End_of_file | Invalid_argument _ ->
+    None
+
+let default_timestamp_of_candidate epoch =
+  Option.value
+    (utc_midnight_of_yyyy_mm_dd epoch.Chronicle_ingest.end_date)
+    ~default:(Time_compat.now ())
+
 let episode_of_candidate ?timestamp ~keeper_name
     (epoch : Chronicle_ingest.candidate_epoch) : Agent_sdk.Memory.episode =
   let summary = summary_of_candidate epoch in
@@ -81,7 +109,7 @@ let episode_of_candidate ?timestamp ~keeper_name
     ]
   in
   { id = episode_id epoch
-  ; timestamp = Option.value timestamp ~default:(Time_compat.now ())
+  ; timestamp = Option.value timestamp ~default:(default_timestamp_of_candidate epoch)
   ; participants = [ keeper_name ]
   ; action = summary
   ; outcome = Agent_sdk.Memory.Neutral
@@ -98,10 +126,10 @@ let episode_of_candidate ?timestamp ~keeper_name
       ]
   }
 
-let store_candidate_epoch ~memory ~keeper_name epoch =
+let store_candidate_epoch ?timestamp ~memory ~keeper_name epoch =
   Agent_sdk.Memory.store_episode memory
-    (episode_of_candidate ~keeper_name epoch)
+    (episode_of_candidate ?timestamp ~keeper_name epoch)
 
-let store_candidate_epochs ~memory ~keeper_name epochs =
-  List.iter (store_candidate_epoch ~memory ~keeper_name) epochs;
+let store_candidate_epochs ?timestamp ~memory ~keeper_name epochs =
+  List.iter (store_candidate_epoch ?timestamp ~memory ~keeper_name) epochs;
   List.length epochs

--- a/lib/chronicle_memory.mli
+++ b/lib/chronicle_memory.mli
@@ -11,15 +11,22 @@ val episode_of_candidate :
 (** Convert a chronicle candidate epoch into an OAS episodic memory entry. *)
 
 val store_candidate_epoch :
+  ?timestamp:float ->
   memory:Agent_sdk.Memory.t ->
   keeper_name:string ->
   Chronicle_ingest.candidate_epoch ->
   unit
-(** Store one candidate epoch in [memory]. *)
+(** Store one candidate epoch in [memory].
+
+    [?timestamp] overrides the deterministic epoch-date timestamp. *)
 
 val store_candidate_epochs :
+  ?timestamp:float ->
   memory:Agent_sdk.Memory.t ->
   keeper_name:string ->
   Chronicle_ingest.candidate_epoch list ->
   int
-(** Store candidate epochs in [memory]. Returns the number of stored entries. *)
+(** Store candidate epochs in [memory]. Returns the number of stored entries.
+
+    [?timestamp] overrides the deterministic epoch-date timestamp for every
+    stored epoch. *)

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -30,6 +30,32 @@ module Attr_key = struct
   let tool_success = "tool.success"
   let tool_duration_ms = "tool.duration_ms"
 
+  let all_known =
+    [ gen_ai_operation_name
+    ; gen_ai_provider_name
+    ; gen_ai_agent_name
+    ; gen_ai_agent_id
+    ; gen_ai_conversation_id
+    ; gen_ai_tool_name
+    ; masc_gen_ai_keeper_name
+    ; masc_gen_ai_cascade_name
+    ; keeper_name
+    ; keeper_agent_name
+    ; keeper_cascade_name
+    ; keeper_trace_id
+    ; keeper_generation
+    ; keeper_max_context
+    ; keeper_max_turns
+    ; keeper_max_idle_turns
+    ; keeper_channel
+    ; keeper_is_retry
+    ; keeper_current_task_id
+    ; tool_name
+    ; tool_success
+    ; tool_duration_ms
+    ]
+  ;;
+
   let official_gen_ai =
     [ gen_ai_operation_name
     ; gen_ai_provider_name

--- a/lib/otel/otel_genai.mli
+++ b/lib/otel/otel_genai.mli
@@ -25,6 +25,7 @@ module Attr_key : sig
   val tool_name : string
   val tool_success : string
   val tool_duration_ms : string
+  val all_known : string list
   val official_gen_ai : string list
   val masc_extensions : string list
   val legacy : string list

--- a/test/test_chronicle_ingest.ml
+++ b/test/test_chronicle_ingest.ml
@@ -255,13 +255,27 @@ let test_chronicle_memory_episode_shape () =
   check string "summary includes structured commit count" expected_summary
     episode.action
 
+let test_chronicle_memory_default_timestamp_uses_epoch_end_date () =
+  let episode = CM.episode_of_candidate ~keeper_name:"sangsu" sample_epoch in
+  let tm = Unix.gmtime episode.timestamp in
+  check int "year" 2026 (tm.Unix.tm_year + 1900);
+  check int "month" 5 (tm.Unix.tm_mon + 1);
+  check int "day" 2 tm.Unix.tm_mday;
+  check int "hour" 0 tm.Unix.tm_hour;
+  check int "minute" 0 tm.Unix.tm_min
+
 let test_chronicle_memory_store_recall () =
   let memory = Agent_sdk.Memory.create () in
+  let expected =
+    CM.episode_of_candidate ~keeper_name:"sangsu" sample_epoch
+  in
   let stored =
     CM.store_candidate_epochs ~memory ~keeper_name:"sangsu" [ sample_epoch ]
   in
   check int "stored count" 1 stored;
-  let recalled = Agent_sdk.Memory.recall_episodes memory ~limit:10 () in
+  let recalled =
+    Agent_sdk.Memory.recall_episodes memory ~now:expected.timestamp ~limit:10 ()
+  in
   check int "recalled count" 1 (List.length recalled);
   let episode = List.hd recalled in
   check string "recalled id"
@@ -269,6 +283,15 @@ let test_chronicle_memory_store_recall () =
   check string "recalled event type" "git_chronicle"
     (Option.value ~default:""
        (metadata_string "event_type" episode.metadata))
+
+let test_chronicle_memory_store_timestamp_override () =
+  let memory = Agent_sdk.Memory.create () in
+  CM.store_candidate_epoch ~timestamp:84.0 ~memory ~keeper_name:"sangsu"
+    sample_epoch;
+  let episode =
+    Agent_sdk.Memory.recall_episodes memory ~now:84.0 ~limit:10 () |> List.hd
+  in
+  check (float 0.001) "stored timestamp override" 84.0 episode.timestamp
 
 let () =
   run "Chronicle_ingest" [
@@ -302,6 +325,10 @@ let () =
     ]);
     ("chronicle_memory", [
       test_case "episode shape" `Quick test_chronicle_memory_episode_shape;
+      test_case "default timestamp uses epoch end date" `Quick
+        test_chronicle_memory_default_timestamp_uses_epoch_end_date;
       test_case "store recall" `Quick test_chronicle_memory_store_recall;
+      test_case "store timestamp override" `Quick
+        test_chronicle_memory_store_timestamp_override;
     ]);
   ]

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -142,6 +142,7 @@ let test_attr_key_registry_boundaries () =
 
 let test_attr_key_registry_full_coverage () =
   let module K = Lib.Otel_genai.Attr_key in
+  let unique keys = List.sort_uniq String.compare keys in
   let check_official key =
     check bool (key ^ " official") true (K.is_official_gen_ai key);
     check bool (key ^ " not masc extension") false (K.is_masc_extension key)
@@ -156,7 +157,17 @@ let test_attr_key_registry_full_coverage () =
   in
   List.iter check_official K.official_gen_ai;
   List.iter check_extension K.masc_extensions;
-  List.iter check_legacy K.legacy
+  List.iter check_legacy K.legacy;
+  let classified = K.official_gen_ai @ K.masc_extensions @ K.legacy in
+  check
+    (list string)
+    "all known keys are classified"
+    (unique K.all_known)
+    (unique classified);
+  check int "no duplicate classifications" (List.length classified)
+    (List.length (unique classified));
+  check int "no duplicate all_known keys" (List.length K.all_known)
+    (List.length (unique K.all_known))
 ;;
 
 let test_tool_execution_attrs () =
@@ -187,6 +198,7 @@ let test_dispatch_hook_emits_tool_span_payload () =
           let result : Lib.Tool_result.t =
             { success = true
             ; data = `String "ok"
+            ; legacy_message = "ok"
             ; tool_name = "keeper_shell"
             ; duration_ms = 123.4
             }


### PR DESCRIPTION
## Summary
- Add `Attr_key.all_known` and registry completeness assertions so GenAI key constants cannot drift outside the official/MASC/legacy partitions.
- Make chronicle memory default timestamps deterministic from candidate epoch `end_date` instead of `Time_compat.now ()`.
- Thread `?timestamp` through chronicle store helpers for explicit backfill control.
- Add a scoped restart-launch noop test helper and compute supervisor self-preservation active counts from a fresh registry snapshot.

## Review follow-ups
- Follows up merged #13521 late threads:
  - https://github.com/jeong-sik/masc-mcp/pull/13521#discussion_r3193556496
  - https://github.com/jeong-sik/masc-mcp/pull/13521#discussion_r3193556521
- Follows up merged #13525 late thread: https://github.com/jeong-sik/masc-mcp/pull/13525#discussion_r3193495127
- Follows up merged #13537 late thread: https://github.com/jeong-sik/masc-mcp/pull/13537#discussion_r3193488206

## Verification
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_followups scripts/dune-local.sh exec ./test/test_otel_genai.exe` (7 tests)
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_followups scripts/dune-local.sh exec ./test/test_chronicle_ingest.exe` (22 tests)
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_followups scripts/dune-local.sh exec ./test/test_keeper_supervisor.exe -- test supervision_cohorts` (6 selected tests)
- `git diff --check`

## Notes
- Draft only. This PR exists because the source PRs were already merged before the late review threads were handled.