### PR TITLE
fix(dashboard): expose feedback state metadata

### DIFF
--- a/dashboard/src/components/common/feedback-state.a11y.test.ts
+++ b/dashboard/src/components/common/feedback-state.a11y.test.ts
@@ -112,7 +112,7 @@ describe('ErrorFatal a11y', () => {
     document.body.removeChild(container)
   })
 
-  it('with retry+reload callbacks passes axe', async () => {
+  it('with reload callback passes axe', async () => {
     render(
       html`<${ErrorFatal}
         title="Session expired"

--- a/dashboard/src/components/common/feedback-state.a11y.test.ts
+++ b/dashboard/src/components/common/feedback-state.a11y.test.ts
@@ -92,7 +92,7 @@ describe('ErrorRecoverable a11y', () => {
   it('with retry callback passes axe', async () => {
     render(
       html`<${ErrorRecoverable}
-        message="Sync failed"
+        title="Sync failed"
         onRetry=${() => {}}
       />`,
       container,
@@ -115,8 +115,7 @@ describe('ErrorFatal a11y', () => {
   it('with retry+reload callbacks passes axe', async () => {
     render(
       html`<${ErrorFatal}
-        message="Session expired"
-        onRetry=${() => {}}
+        title="Session expired"
         onReload=${() => {}}
       />`,
       container,

--- a/dashboard/src/components/common/feedback-state.test.ts
+++ b/dashboard/src/components/common/feedback-state.test.ts
@@ -2,7 +2,77 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { ErrorRecoverable, ErrorFatal } from './feedback-state'
+import {
+  EmptyState,
+  ErrorFatal,
+  ErrorRecoverable,
+  ErrorState,
+  LoadingState,
+  summarizeFeedbackState,
+} from './feedback-state'
+
+describe('summarizeFeedbackState', () => {
+  it('normalizes boolean state flags', () => {
+    expect(
+      summarizeFeedbackState('empty', {
+        compact: true,
+        icon: 'IN',
+        action: html`<button>act</button>`,
+      }),
+    ).toEqual({
+      kind: 'empty',
+      compact: true,
+      hasIcon: true,
+      hasAction: true,
+      hasDetail: false,
+    })
+  })
+})
+
+describe('FeedbackState base primitives', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('publishes empty-state metadata', () => {
+    render(
+      html`<${EmptyState}
+        icon="IN"
+        message="No items"
+        compact=${true}
+        action=${html`<button>act</button>`}
+      />`,
+      container,
+    )
+    const state = container.querySelector('[data-feedback-state]')
+    expect(state?.getAttribute('data-feedback-kind')).toBe('empty')
+    expect(state?.getAttribute('data-feedback-compact')).toBe('true')
+    expect(state?.getAttribute('data-feedback-has-icon')).toBe('true')
+    expect(state?.getAttribute('data-feedback-has-action')).toBe('true')
+  })
+
+  it('publishes loading metadata and mono glyph', () => {
+    render(html`<${LoadingState}>Loading<//>`, container)
+    const state = container.querySelector('[data-feedback-state]')
+    expect(state?.getAttribute('data-feedback-kind')).toBe('loading')
+    expect(state?.getAttribute('data-feedback-has-icon')).toBe('true')
+    expect(container.querySelector('[data-feedback-icon]')?.textContent).toContain('LD')
+  })
+
+  it('publishes error metadata and mono glyph', () => {
+    render(html`<${ErrorState} message="bad" />`, container)
+    const state = container.querySelector('[data-feedback-state]')
+    expect(state?.getAttribute('data-feedback-kind')).toBe('error')
+    expect(state?.getAttribute('data-feedback-has-icon')).toBe('true')
+    expect(container.querySelector('[data-feedback-icon]')?.textContent).toContain('ER')
+  })
+})
 
 describe('ErrorRecoverable', () => {
   let container: HTMLElement
@@ -22,6 +92,8 @@ describe('ErrorRecoverable', () => {
     expect(section.getAttribute('role')).toBe('alert')
     expect(section.textContent).toContain('Cascade fallback exhausted')
     expect(section.textContent).toContain('복구 가능')
+    expect(section.getAttribute('data-feedback-kind')).toBe('recoverable')
+    expect(section.getAttribute('data-feedback-has-action')).toBe('false')
   })
 
   it('renders detail line when provided', () => {
@@ -33,6 +105,11 @@ describe('ErrorRecoverable', () => {
       container,
     )
     expect(container.textContent).toContain('2 fallback hops, timed out at 12.4s')
+    expect(
+      container
+        .querySelector('[data-feedback-state]')
+        ?.getAttribute('data-feedback-has-detail'),
+    ).toBe('true')
   })
 
   it('omits the retry button when onRetry is not supplied', () => {
@@ -46,6 +123,11 @@ describe('ErrorRecoverable', () => {
     const btn = container.querySelector('button')!
     expect(btn).toBeTruthy()
     expect(btn.textContent).toContain('다시 시도')
+    expect(
+      container
+        .querySelector('[data-feedback-state]')
+        ?.getAttribute('data-feedback-has-action'),
+    ).toBe('true')
     btn.click()
     expect(onRetry).toHaveBeenCalledTimes(1)
   })
@@ -80,6 +162,8 @@ describe('ErrorFatal', () => {
     expect(section.getAttribute('role')).toBe('alert')
     expect(section.textContent).toContain('Cockpit lost connection')
     expect(section.textContent).toContain('치명적')
+    expect(section.getAttribute('data-feedback-kind')).toBe('fatal')
+    expect(section.getAttribute('data-feedback-has-action')).toBe('false')
   })
 
   it('renders detail line when provided', () => {
@@ -91,6 +175,11 @@ describe('ErrorFatal', () => {
       container,
     )
     expect(container.textContent).toContain('Reconnect attempts: 3/3 exhausted')
+    expect(
+      container
+        .querySelector('[data-feedback-state]')
+        ?.getAttribute('data-feedback-has-detail'),
+    ).toBe('true')
   })
 
   it('omits the reload button when onReload is not supplied', () => {
@@ -104,6 +193,11 @@ describe('ErrorFatal', () => {
     const btn = container.querySelector('button')!
     expect(btn).toBeTruthy()
     expect(btn.textContent).toContain('다시 불러오기')
+    expect(
+      container
+        .querySelector('[data-feedback-state]')
+        ?.getAttribute('data-feedback-has-action'),
+    ).toBe('true')
     btn.click()
     expect(onReload).toHaveBeenCalledTimes(1)
   })

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -40,6 +40,17 @@ export function summarizeFeedbackState(
   }
 }
 
+function feedbackStateAttrs(summary: FeedbackStateSummary) {
+  return {
+    'data-feedback-state': '',
+    'data-feedback-kind': summary.kind,
+    'data-feedback-compact': summary.compact,
+    'data-feedback-has-icon': summary.hasIcon,
+    'data-feedback-has-action': summary.hasAction,
+    'data-feedback-has-detail': summary.hasDetail,
+  }
+}
+
 interface EmptyStateProps {
   message?: string
   icon?: string
@@ -64,12 +75,7 @@ export function EmptyState({
     <div
       class="flex flex-col items-center justify-center gap-2 text-center ${compact ? 'py-4' : 'py-8'} text-sm text-[var(--color-fg-muted)] ${cx ?? ''}"
       role="status"
-      data-feedback-state
-      data-feedback-kind=${summary.kind}
-      data-feedback-compact=${summary.compact}
-      data-feedback-has-icon=${summary.hasIcon}
-      data-feedback-has-action=${summary.hasAction}
-      data-feedback-has-detail=${summary.hasDetail}
+      ...${feedbackStateAttrs(summary)}
     >
       ${icon
         ? html`
@@ -93,7 +99,7 @@ interface LoadingStateProps {
   children?: ComponentChildren
 }
 
-/** Loading indicator with spin animation */
+/** Loading indicator with a pulsing mono glyph. */
 export function LoadingState({ class: cx, children }: LoadingStateProps) {
   const summary = summarizeFeedbackState('loading', { icon: true })
   return html`
@@ -101,12 +107,7 @@ export function LoadingState({ class: cx, children }: LoadingStateProps) {
       class="loading-state flex flex-col items-center py-8 text-sm ${cx ?? ''}"
       role="status"
       aria-live="polite"
-      data-feedback-state
-      data-feedback-kind=${summary.kind}
-      data-feedback-compact=${summary.compact}
-      data-feedback-has-icon=${summary.hasIcon}
-      data-feedback-has-action=${summary.hasAction}
-      data-feedback-has-detail=${summary.hasDetail}
+      ...${feedbackStateAttrs(summary)}
     >
       <span
         class="mb-3 inline-flex h-6 min-w-6 animate-pulse items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-1 font-mono text-[10px] text-[var(--color-fg-accent)] opacity-70"
@@ -131,12 +132,7 @@ export function ErrorState({ message, class: cx }: ErrorStateProps) {
     <div
       class="flex items-start gap-2 rounded-[var(--r-0)] border border-[var(--bad-30)] bg-[var(--bad-12)] px-4 py-3 text-sm text-[var(--bad-light)] ${cx ?? ''}"
       role="alert"
-      data-feedback-state
-      data-feedback-kind=${summary.kind}
-      data-feedback-compact=${summary.compact}
-      data-feedback-has-icon=${summary.hasIcon}
-      data-feedback-has-action=${summary.hasAction}
-      data-feedback-has-detail=${summary.hasDetail}
+      ...${feedbackStateAttrs(summary)}
     >
       <span class="mt-0.5 inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--bad-30)] px-1 font-mono text-[10px]" aria-hidden="true" data-feedback-icon>
         ER
@@ -179,12 +175,7 @@ export function ErrorRecoverable({
     <section
       role="alert"
       class="flex flex-col gap-2 rounded-[var(--r-0)] border border-[var(--warn-20)] border-l-[3px] border-l-[var(--color-status-warn)] bg-[var(--warn-soft)] px-4 py-3 ${cx ?? ''}"
-      data-feedback-state
-      data-feedback-kind=${summary.kind}
-      data-feedback-compact=${summary.compact}
-      data-feedback-has-icon=${summary.hasIcon}
-      data-feedback-has-action=${summary.hasAction}
-      data-feedback-has-detail=${summary.hasDetail}
+      ...${feedbackStateAttrs(summary)}
     >
       <div class="flex items-center gap-2">
         <span class="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--warn-20)] px-1 font-mono text-[10px] text-[var(--warn-bright)]" aria-hidden="true" data-feedback-icon>
@@ -241,12 +232,7 @@ export function ErrorFatal({
     <section
       role="alert"
       class="flex flex-col gap-2 rounded-[var(--r-0)] border border-[var(--bad-20)] border-l-[3px] border-l-[var(--color-status-err)] bg-[var(--bad-soft)] px-4 py-3 ${cx ?? ''}"
-      data-feedback-state
-      data-feedback-kind=${summary.kind}
-      data-feedback-compact=${summary.compact}
-      data-feedback-has-icon=${summary.hasIcon}
-      data-feedback-has-action=${summary.hasAction}
-      data-feedback-has-detail=${summary.hasDetail}
+      ...${feedbackStateAttrs(summary)}
     >
       <div class="flex items-center gap-2">
         <span class="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--bad-20)] px-1 font-mono text-[10px] text-[var(--bad-light)]" aria-hidden="true" data-feedback-icon>

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -10,8 +10,35 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
-import { AlertTriangle, AlertOctagon, Loader2, RefreshCw } from 'lucide-preact'
 import { ActionButton } from './button'
+
+export type FeedbackStateKind = 'empty' | 'loading' | 'error' | 'recoverable' | 'fatal'
+
+export interface FeedbackStateSummary {
+  kind: FeedbackStateKind
+  compact: boolean
+  hasIcon: boolean
+  hasAction: boolean
+  hasDetail: boolean
+}
+
+export function summarizeFeedbackState(
+  kind: FeedbackStateKind,
+  options: {
+    compact?: boolean
+    icon?: unknown
+    action?: unknown
+    detail?: unknown
+  } = {},
+): FeedbackStateSummary {
+  return {
+    kind,
+    compact: Boolean(options.compact),
+    hasIcon: Boolean(options.icon),
+    hasAction: Boolean(options.action),
+    hasDetail: Boolean(options.detail),
+  }
+}
 
 interface EmptyStateProps {
   message?: string
@@ -31,10 +58,30 @@ export function EmptyState({
   children,
 }: EmptyStateProps) {
   const content = children ?? message
+  const summary = summarizeFeedbackState('empty', { compact, icon, action })
 
   return html`
-    <div class="flex flex-col items-center justify-center gap-2 text-center ${compact ? 'py-4' : 'py-8'} text-sm text-[var(--color-fg-muted)] ${cx ?? ''}" role="status">
-      ${icon ? html`<span class="text-2xl opacity-40" aria-hidden="true">${icon}</span>` : null}
+    <div
+      class="flex flex-col items-center justify-center gap-2 text-center ${compact ? 'py-4' : 'py-8'} text-sm text-[var(--color-fg-muted)] ${cx ?? ''}"
+      role="status"
+      data-feedback-state
+      data-feedback-kind=${summary.kind}
+      data-feedback-compact=${summary.compact}
+      data-feedback-has-icon=${summary.hasIcon}
+      data-feedback-has-action=${summary.hasAction}
+      data-feedback-has-detail=${summary.hasDetail}
+    >
+      ${icon
+        ? html`
+            <span
+              class="inline-flex h-6 min-w-6 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-1 font-mono text-[10px] opacity-60"
+              aria-hidden="true"
+              data-feedback-icon
+            >
+              ${icon}
+            </span>
+          `
+        : null}
       ${content ? html`<span class="leading-relaxed">${content}</span>` : null}
       ${action ?? null}
     </div>
@@ -48,9 +95,26 @@ interface LoadingStateProps {
 
 /** Loading indicator with spin animation */
 export function LoadingState({ class: cx, children }: LoadingStateProps) {
+  const summary = summarizeFeedbackState('loading', { icon: true })
   return html`
-    <div class="loading-state flex flex-col items-center py-8 text-sm ${cx ?? ''}" role="status" aria-live="polite">
-      <${Loader2} size=${24} class="animate-spin mb-3 opacity-60 text-accent-fg" aria-hidden="true" />
+    <div
+      class="loading-state flex flex-col items-center py-8 text-sm ${cx ?? ''}"
+      role="status"
+      aria-live="polite"
+      data-feedback-state
+      data-feedback-kind=${summary.kind}
+      data-feedback-compact=${summary.compact}
+      data-feedback-has-icon=${summary.hasIcon}
+      data-feedback-has-action=${summary.hasAction}
+      data-feedback-has-detail=${summary.hasDetail}
+    >
+      <span
+        class="mb-3 inline-flex h-6 min-w-6 animate-pulse items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-1 font-mono text-[10px] text-[var(--color-fg-accent)] opacity-70"
+        aria-hidden="true"
+        data-feedback-icon
+      >
+        LD
+      </span>
       <span>${children ?? '불러오는 중...'}</span>
     </div>
   `
@@ -62,9 +126,21 @@ interface ErrorStateProps {
 }
 
 export function ErrorState({ message, class: cx }: ErrorStateProps) {
+  const summary = summarizeFeedbackState('error', { icon: true })
   return html`
-    <div class="flex items-start gap-2 rounded-[var(--r-1)] border border-[var(--bad-30)] bg-[var(--bad-12)] px-4 py-3 text-sm text-[var(--bad-light)] ${cx ?? ''}" role="alert">
-      <${AlertTriangle} size=${16} class="mt-0.5 shrink-0" aria-hidden="true" />
+    <div
+      class="flex items-start gap-2 rounded-[var(--r-0)] border border-[var(--bad-30)] bg-[var(--bad-12)] px-4 py-3 text-sm text-[var(--bad-light)] ${cx ?? ''}"
+      role="alert"
+      data-feedback-state
+      data-feedback-kind=${summary.kind}
+      data-feedback-compact=${summary.compact}
+      data-feedback-has-icon=${summary.hasIcon}
+      data-feedback-has-action=${summary.hasAction}
+      data-feedback-has-detail=${summary.hasDetail}
+    >
+      <span class="mt-0.5 inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--bad-30)] px-1 font-mono text-[10px]" aria-hidden="true" data-feedback-icon>
+        ER
+      </span>
       <span>${message}</span>
     </div>
   `
@@ -94,23 +170,33 @@ export function ErrorRecoverable({
   retryLabel = '다시 시도',
   class: cx,
 }: ErrorRecoverableProps) {
+  const summary = summarizeFeedbackState('recoverable', {
+    icon: true,
+    action: onRetry,
+    detail,
+  })
   return html`
     <section
       role="alert"
-      class="flex flex-col gap-2 rounded-[var(--r-1)] border border-[var(--warn-20)] border-l-[3px] border-l-[var(--color-status-warn)] bg-[var(--warn-soft)] px-4 py-3 ${cx ?? ''}"
+      class="flex flex-col gap-2 rounded-[var(--r-0)] border border-[var(--warn-20)] border-l-[3px] border-l-[var(--color-status-warn)] bg-[var(--warn-soft)] px-4 py-3 ${cx ?? ''}"
+      data-feedback-state
+      data-feedback-kind=${summary.kind}
+      data-feedback-compact=${summary.compact}
+      data-feedback-has-icon=${summary.hasIcon}
+      data-feedback-has-action=${summary.hasAction}
+      data-feedback-has-detail=${summary.hasDetail}
     >
       <div class="flex items-center gap-2">
-        <${AlertTriangle} size=${16} class="shrink-0 text-[var(--warn-bright)]" aria-hidden="true" />
+        <span class="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--warn-20)] px-1 font-mono text-[10px] text-[var(--warn-bright)]" aria-hidden="true" data-feedback-icon>
+          RT
+        </span>
         <span class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--warn-bright)]">
           복구 가능
         </span>
         ${onRetry ? html`
           <span class="ml-auto">
             <${ActionButton} variant="ghost" size="sm" onClick=${onRetry}>
-              <span class="inline-flex items-center gap-1">
-                <${RefreshCw} size=${12} aria-hidden="true" />
-                ${retryLabel}
-              </span>
+              ${retryLabel}
             <//>
           </span>
         ` : null}
@@ -146,13 +232,26 @@ export function ErrorFatal({
   reloadLabel = '다시 불러오기',
   class: cx,
 }: ErrorFatalProps) {
+  const summary = summarizeFeedbackState('fatal', {
+    icon: true,
+    action: onReload,
+    detail,
+  })
   return html`
     <section
       role="alert"
-      class="flex flex-col gap-2 rounded-[var(--r-1)] border border-[var(--bad-20)] border-l-[3px] border-l-[var(--color-status-err)] bg-[var(--bad-soft)] px-4 py-3 ${cx ?? ''}"
+      class="flex flex-col gap-2 rounded-[var(--r-0)] border border-[var(--bad-20)] border-l-[3px] border-l-[var(--color-status-err)] bg-[var(--bad-soft)] px-4 py-3 ${cx ?? ''}"
+      data-feedback-state
+      data-feedback-kind=${summary.kind}
+      data-feedback-compact=${summary.compact}
+      data-feedback-has-icon=${summary.hasIcon}
+      data-feedback-has-action=${summary.hasAction}
+      data-feedback-has-detail=${summary.hasDetail}
     >
       <div class="flex items-center gap-2">
-        <${AlertOctagon} size=${16} class="shrink-0 text-[var(--bad-light)]" aria-hidden="true" />
+        <span class="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--bad-20)] px-1 font-mono text-[10px] text-[var(--bad-light)]" aria-hidden="true" data-feedback-icon>
+          FT
+        </span>
         <span class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--bad-light)]">
           치명적
         </span>


### PR DESCRIPTION
## Summary
- Export FeedbackState summary metadata for empty/loading/error/recoverable/fatal variants.
- Add data-feedback-* hooks and compact mono glyph markers so cockpit screens can inspect state without visual scraping.
- Fix FeedbackState a11y tests to use the current title/onReload props.

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/feedback-state.test.ts src/components/common/feedback-state.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- Browser QA via Vite desktop/mobile: /tmp/masc-feedback-state-summary-0506.png, /tmp/masc-feedback-state-summary-0506-mobile-full.png

## Notes
- Lint warnings are existing copy-id-button/virtual-list/fsm-hub warnings.
- Build warnings are existing Vite dynamic/static import and chunk-size warnings.