### PR TITLE
fix(keeper): prefer newer runtime blockers over stale receipts

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -190,6 +190,11 @@ let receipt_ended_at_unix receipt =
       if ts > 0.0 then Some ts else None
   | None -> None
 
+(* Receipt timestamps are serialized with lower precision than runtime
+   last-turn observations, so a tiny tolerance avoids treating same-turn
+   observations as newer blockers because of formatting jitter. *)
+let runtime_blocker_receipt_timestamp_epsilon_sec = 0.001
+
 let runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
     latest_receipt =
   match assoc_string_opt "runtime_blocker_class" runtime_blocker_fields with
@@ -199,7 +204,9 @@ let runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
       | None -> true
       | Some receipt -> (
           match receipt_ended_at_unix receipt with
-          | Some receipt_ts -> meta.runtime.usage.last_turn_ts > receipt_ts +. 0.001
+          | Some receipt_ts ->
+              meta.runtime.usage.last_turn_ts
+              > receipt_ts +. runtime_blocker_receipt_timestamp_epsilon_sec
           | None -> meta.runtime.usage.last_turn_ts > 0.0))
 
 let current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
@@ -219,13 +226,13 @@ let runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt =
 
 let latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
     ~latest_receipt =
-  if runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
-       latest_receipt
-  then terminal_reason_from_runtime_blocker_fields runtime_blocker_fields
-  else
-    match Option.bind latest_decision terminal_reason_from_decision with
-    | Some _ as value -> value
-    | None -> Option.bind latest_receipt terminal_reason_from_receipt
+  match Option.bind latest_decision terminal_reason_from_decision with
+  | Some _ as value -> value
+  | None ->
+      if runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
+           latest_receipt
+      then terminal_reason_from_runtime_blocker_fields runtime_blocker_fields
+      else Option.bind latest_receipt terminal_reason_from_receipt
 
 let severity_of_approval_event event decision =
   match event with

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -120,15 +120,112 @@ let terminal_reason_from_decision json =
         (json_string_opt_member "terminal_reason_code" json)
 
 let terminal_reason_from_receipt receipt =
-  match json_string_opt_member "terminal_reason_code" receipt with
+  let terminal_reason_code = json_string_opt_member "terminal_reason_code" receipt in
+  let operator_disposition =
+    json_string_opt_member "operator_disposition" receipt
+    |> Option.map String.lowercase_ascii
+  in
+  let operator_disposition_reason =
+    json_string_opt_member "operator_disposition_reason" receipt
+    |> Option.map String.lowercase_ascii
+  in
+  let tool_contract_result =
+    json_string_opt_member "tool_contract_result" receipt
+    |> Option.map String.lowercase_ascii
+  in
+  let receipt_requires_tool_attention =
+    match operator_disposition, operator_disposition_reason, tool_contract_result with
+    | Some "pause_human", Some "tool_required_unsatisfied", _
+    | _, Some "tool_required_unsatisfied", _
+    | _, _, Some "needs_execution_progress"
+    | _, _, Some "missing_required_tool_use"
+    | _, _, Some "passive_only"
+    | _, _, Some "violated" ->
+        true
+    | _ -> false
+  in
+  match terminal_reason_code with
+  | Some code when receipt_requires_tool_attention
+                   && (String.equal code "completed"
+                       || String.equal code "success") ->
+      Some
+        (Keeper_turn_terminal.of_code ~source:"execution_receipt"
+           "required_tool_use_unsatisfied")
   | Some code ->
       Some (Keeper_turn_terminal.of_code ~source:"execution_receipt" code)
+  | None when receipt_requires_tool_attention ->
+      Some
+        (Keeper_turn_terminal.of_code ~source:"execution_receipt"
+           "required_tool_use_unsatisfied")
   | None -> None
 
-let latest_terminal_reason_opt ~latest_decision ~latest_receipt =
-  match Option.bind latest_decision terminal_reason_from_decision with
-  | Some _ as value -> value
-  | None -> Option.bind latest_receipt terminal_reason_from_receipt
+let terminal_reason_code_of_runtime_blocker_class = function
+  | "completion_contract_violation" | "tool_required_unsatisfied" ->
+      "required_tool_use_unsatisfied"
+  | "oas_timeout_budget" ->
+      "oas_timeout_budget"
+  | "turn_timeout" | "turn_timeout_after_queue_wait" | "stale_turn_timeout" ->
+      "turn_wall_clock_timeout"
+  | "ambiguous_post_commit_timeout" | "ambiguous_post_commit_failure" ->
+      "post_commit_ambiguous"
+  | "cascade_exhausted" | "no_tool_capable_provider"
+  | "provider_runtime_error" ->
+      "provider_error"
+  | _ ->
+      "unknown_error"
+
+let terminal_reason_from_runtime_blocker_fields runtime_blocker_fields =
+  match assoc_string_opt "runtime_blocker_class" runtime_blocker_fields with
+  | None -> None
+  | Some blocker_class ->
+      let code = terminal_reason_code_of_runtime_blocker_class blocker_class in
+      let summary = assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields in
+      Some
+        (Keeper_turn_terminal.of_code ~source:"runtime_blocker" ?summary code)
+
+let receipt_ended_at_unix receipt =
+  match json_string_opt_member "ended_at" receipt with
+  | Some ended_at ->
+      let ts = Masc_domain.parse_iso8601 ~default_time:0.0 ended_at in
+      if ts > 0.0 then Some ts else None
+  | None -> None
+
+let runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
+    latest_receipt =
+  match assoc_string_opt "runtime_blocker_class" runtime_blocker_fields with
+  | None -> false
+  | Some _ -> (
+      match latest_receipt with
+      | None -> true
+      | Some receipt -> (
+          match receipt_ended_at_unix receipt with
+          | Some receipt_ts -> meta.runtime.usage.last_turn_ts > receipt_ts +. 0.001
+          | None -> meta.runtime.usage.last_turn_ts > 0.0))
+
+let current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
+    latest_receipt =
+  if runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
+       latest_receipt
+  then None
+  else latest_receipt
+
+let runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt =
+  if
+    runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
+      latest_receipt
+    && meta.runtime.usage.last_turn_ts > 0.0
+  then meta.runtime.usage.last_turn_ts
+  else Time_compat.now ()
+
+let latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
+    ~latest_receipt =
+  if runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
+       latest_receipt
+  then terminal_reason_from_runtime_blocker_fields runtime_blocker_fields
+  else
+    match Option.bind latest_decision terminal_reason_from_decision with
+    | Some _ as value -> value
+    | None -> Option.bind latest_receipt terminal_reason_from_receipt
 
 let severity_of_approval_event event decision =
   match event with
@@ -476,7 +573,7 @@ let receipt_timeline_event receipt =
 
 let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
     ?observed_at_unix ~ts_unix ~runtime_blocker_fields
-    ~next_human_action () =
+    ~next_human_action ?(observation_only = true) () =
   let blocker_class = assoc_string_opt "runtime_blocker_class" runtime_blocker_fields in
   let blocker_summary =
     assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
@@ -487,7 +584,7 @@ let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
     when String.trim summary <> "" ->
       Some
         (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
-           ?observed_at_unix ~observation_only:true
+           ?observed_at_unix ~observation_only
            ~ts_unix ~kind:"runtime_blocker"
            ~title:"Runtime Blocker"
            ~summary
@@ -500,14 +597,14 @@ let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
     when String.trim summary <> "" ->
       Some
         (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
-           ?observed_at_unix ~observation_only:true
+           ?observed_at_unix ~observation_only
            ~ts_unix ~kind:"runtime_blocker"
            ~title:"Runtime Blocker"
            ~summary ~severity:"warn" ())
   | Some blocker_class, None ->
       Some
         (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
-           ?observed_at_unix ~observation_only:true
+           ?observed_at_unix ~observation_only
            ~ts_unix ~kind:"runtime_blocker"
            ~title:"Runtime Blocker"
            ~summary:blocker_class ~severity:"warn" ())
@@ -589,6 +686,20 @@ let effective_disposition_fields ~fallback_disposition ~fallback_reason
         fallback_reason,
         operator_disposition,
         operator_disposition_reason )
+
+let attention_reason_or_disposition ~needs_attention ~disposition_reason
+    attention_fields =
+  match assoc_string_opt "attention_reason" attention_fields with
+  | Some _ as value -> value
+  | None when needs_attention -> Some disposition_reason
+  | None -> None
+
+let next_human_action_or_terminal ~needs_attention ~latest_next_action
+    attention_fields =
+  match assoc_string_opt "next_human_action" attention_fields with
+  | Some _ as value -> value
+  | None when needs_attention -> latest_next_action
+  | None -> None
 
 let disposition_fields_json ~(config : Coord.config) ~(meta : keeper_meta) :
     Yojson.Safe.t =
@@ -891,7 +1002,14 @@ let execution_summary_json ~meta ~latest_receipt =
 let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
     ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
     ~next_human_action =
-  let observed_at_unix = Time_compat.now () in
+  let observed_at_unix =
+    runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt
+  in
+  let blocker_observation_only =
+    not
+      (runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
+         latest_receipt)
+  in
   let task_id = Keeper_runtime_contract.current_task_id_opt meta in
   let goal_ids = meta.active_goal_ids in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
@@ -903,7 +1021,8 @@ let latest_causal_event_summary ~meta ~latest_decision ~latest_receipt
     Option.bind latest_approval_audit approval_event_timeline_event;
     blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
       ~runtime_blocker_fields ?task_id ~goal_ids
-      ~trace_id ~next_human_action ();
+      ~trace_id ~next_human_action
+      ~observation_only:blocker_observation_only ();
   ]
   |> List.filter_map Fun.id
   |> sort_timeline_events
@@ -921,8 +1040,19 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
     | json :: _ -> Some json
     | [] -> None
   in
+  let pending_approval_count =
+    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
+  in
+  let runtime_blocker_fields =
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+  in
+  let latest_receipt_for_runtime_state =
+    current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
+      latest_receipt
+  in
   let latest_terminal_reason =
-    latest_terminal_reason_opt ~latest_decision ~latest_receipt
+    latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
+      ~latest_receipt
   in
   let latest_terminal_reason_json =
     latest_terminal_reason
@@ -931,12 +1061,6 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
   in
   let latest_next_action =
     Option.bind latest_terminal_reason (fun reason -> reason.next_action)
-  in
-  let pending_approval_count =
-    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
-  in
-  let runtime_blocker_fields =
-    Keeper_status_bridge.runtime_blocker_fields_json config meta
   in
   let attention_fields =
     Keeper_status_bridge.attention_fields_json config meta
@@ -947,7 +1071,8 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let disposition, disposition_reason, operator_disposition,
       operator_disposition_reason =
     effective_disposition_fields ~fallback_disposition
-      ~fallback_reason:fallback_disposition_reason latest_receipt
+      ~fallback_reason:fallback_disposition_reason
+      latest_receipt_for_runtime_state
   in
   let needs_attention =
     assoc_bool_default "needs_attention" ~default:false attention_fields
@@ -955,10 +1080,12 @@ let summary_json ~(config : Coord.config) ~(meta : keeper_meta) =
     || String.equal disposition "Alert"
   in
   let attention_reason =
-    assoc_string_opt "attention_reason" attention_fields
+    attention_reason_or_disposition ~needs_attention ~disposition_reason
+      attention_fields
   in
   let next_human_action =
-    assoc_string_opt "next_human_action" attention_fields
+    next_human_action_or_terminal ~needs_attention ~latest_next_action
+      attention_fields
   in
   let execution_summary =
     execution_summary_json ~meta ~latest_receipt
@@ -1021,11 +1148,19 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
     let task_id = Keeper_runtime_contract.current_task_id_opt meta in
     let goal_ids = meta.active_goal_ids in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-    let observed_at_unix = Time_compat.now () in
+    let observed_at_unix =
+      runtime_blocker_timeline_ts ~meta ~runtime_blocker_fields latest_receipt
+    in
+    let blocker_observation_only =
+      not
+        (runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
+           latest_receipt)
+    in
     [
       blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
         ~runtime_blocker_fields ?task_id ~goal_ids
-        ~trace_id ~next_human_action ()
+        ~trace_id ~next_human_action
+        ~observation_only:blocker_observation_only ()
     ]
     |> List.filter_map Fun.id
   in
@@ -1071,17 +1206,6 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
   let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
   let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
-  let latest_terminal_reason =
-    latest_terminal_reason_opt ~latest_decision ~latest_receipt
-  in
-  let latest_terminal_reason_json =
-    latest_terminal_reason
-    |> Option.map Keeper_turn_terminal.to_json
-    |> Option.value ~default:`Null
-  in
-  let latest_next_action =
-    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
-  in
   let latest_approval_audit =
     match
       Keeper_approval_queue.read_recent_audit ~base_path:config.base_path
@@ -1098,6 +1222,22 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   in
   let runtime_blocker_fields =
     Keeper_status_bridge.runtime_blocker_fields_json config meta
+  in
+  let latest_receipt_for_runtime_state =
+    current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
+      latest_receipt
+  in
+  let latest_terminal_reason =
+    latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
+      ~latest_receipt
+  in
+  let latest_terminal_reason_json =
+    latest_terminal_reason
+    |> Option.map Keeper_turn_terminal.to_json
+    |> Option.value ~default:`Null
+  in
+  let latest_next_action =
+    Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
   let attention_fields =
     Keeper_status_bridge.attention_fields_json config meta
@@ -1125,7 +1265,8 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let disposition, disposition_reason, operator_disposition,
       operator_disposition_reason =
     effective_disposition_fields ~fallback_disposition
-      ~fallback_reason:fallback_disposition_reason latest_receipt
+      ~fallback_reason:fallback_disposition_reason
+      latest_receipt_for_runtime_state
   in
   let needs_attention =
     assoc_bool_default "needs_attention" ~default:false attention_fields
@@ -1133,10 +1274,12 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
     || String.equal disposition "Alert"
   in
   let attention_reason =
-    assoc_string_opt "attention_reason" attention_fields
+    attention_reason_or_disposition ~needs_attention ~disposition_reason
+      attention_fields
   in
   let next_human_action =
-    assoc_string_opt "next_human_action" attention_fields
+    next_human_action_or_terminal ~needs_attention ~latest_next_action
+      attention_fields
   in
   let approval_state =
     approval_state_json ~pending_approval_count ~pending_approvals

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -900,6 +900,110 @@ let test_goal_detail_does_not_promote_synthetic_blocker_over_receipt () =
           check bool "runtime blocker marked observation-only" true
             (event |> member "observation_only" |> to_bool)
 
+let test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Ship newer blocker" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let meta = make_keeper_meta ~name:"newer-blocker-keeper" ~goal_id:goal.id in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  append_keeper_receipt config meta;
+  let blocked_meta =
+    {
+      meta with
+      runtime =
+        {
+          meta.runtime with
+          usage =
+            {
+              meta.runtime.usage with
+              total_turns = meta.runtime.usage.total_turns + 1;
+              last_turn_ts = Unix.gettimeofday () +. 60.0;
+            };
+          last_blocker =
+            "Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}";
+          last_blocker_class = Some Keeper_types.Oas_timeout_budget;
+        };
+    }
+  in
+  (match Keeper_types.write_meta ~force:true config blocked_meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok json ->
+      let linked_keeper =
+        match json |> member "linked_keepers" |> to_list with
+        | keeper :: _ -> keeper
+        | [] -> fail "expected linked keeper detail"
+      in
+      let runtime_trust = linked_keeper |> member "runtime_trust" in
+      let terminal_reason =
+        runtime_trust |> member "latest_terminal_reason"
+      in
+      check string "newer blocker drives disposition" "Alert"
+        (runtime_trust |> member "disposition" |> to_string);
+      check string "newer blocker drives operator disposition"
+        "alert_exhausted"
+        (runtime_trust |> member "operator_disposition" |> to_string);
+      check string "timeout blocker keeps attention reason"
+        "timeout_budget_exhausted"
+        (runtime_trust |> member "attention_reason" |> to_string);
+      check string "latest terminal reason comes from blocker"
+        "runtime_blocker"
+        (terminal_reason |> member "source" |> to_string);
+      check string "latest terminal reason is timeout budget"
+        "oas_timeout_budget"
+        (terminal_reason |> member "code" |> to_string);
+      check string "latest causal event follows runtime blocker"
+        "runtime_blocker"
+        (runtime_trust |> member "latest_causal_event" |> member "kind" |> to_string)
+
+let test_goal_detail_derives_attention_from_receipt_disposition () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Ship receipt disposition" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let meta = make_keeper_meta ~name:"receipt-disposition-keeper" ~goal_id:goal.id in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  append_keeper_receipt
+    ~tool_contract_result:"needs_execution_progress"
+    config meta;
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok json ->
+      let linked_keeper =
+        match json |> member "linked_keepers" |> to_list with
+        | keeper :: _ -> keeper
+        | [] -> fail "expected linked keeper detail"
+      in
+      let runtime_trust = linked_keeper |> member "runtime_trust" in
+      let terminal_reason =
+        runtime_trust |> member "latest_terminal_reason"
+      in
+      check string "receipt disposition pauses" "Pause"
+        (runtime_trust |> member "disposition" |> to_string);
+      check string "receipt disposition fills attention reason"
+        "tool_required_unsatisfied"
+        (runtime_trust |> member "attention_reason" |> to_string);
+      check string "receipt terminal reason follows operator disposition"
+        "required_tool_use_unsatisfied"
+        (terminal_reason |> member "code" |> to_string);
+      check string "receipt terminal reason source"
+        "execution_receipt"
+        (terminal_reason |> member "source" |> to_string);
+      check string "next action follows terminal reason"
+        "inspect_provider_tool_contract"
+        (runtime_trust |> member "next_human_action" |> to_string)
+
 let () =
   run "Dashboard_goals"
     [
@@ -954,5 +1058,13 @@ let () =
             "goal detail keeps synthetic runtime blocker out of latest causal"
             `Quick
             test_goal_detail_does_not_promote_synthetic_blocker_over_receipt;
+          test_case
+            "goal detail promotes newer runtime blocker over stale receipt"
+            `Quick
+            test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt;
+          test_case
+            "goal detail derives attention from receipt disposition"
+            `Quick
+            test_goal_detail_derives_attention_from_receipt_disposition;
         ] );
     ]

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -178,6 +178,25 @@ let append_keeper_decision_with_null_telemetry
         ("telemetry", `Null);
       ])
 
+let append_keeper_decision_terminal_reason
+    (config : Coord.config) (meta : Keeper_types.keeper_meta) =
+  Fs_compat.append_jsonl
+    (Keeper_types.keeper_decision_log_path config meta.name)
+    (`Assoc
+      [
+        ("ts_unix", `Float (Unix.gettimeofday ()));
+        ("turn_id", `Int 11);
+        ( "terminal_reason",
+          `Assoc
+            [
+              ("code", `String "decision_specific_terminal_reason");
+              ("source", `String "decision_log");
+              ("severity", `String "warn");
+              ("summary", `String "decision terminal reason is more specific");
+              ("next_action", `String "follow_decision_terminal_reason");
+            ] );
+      ])
+
 let root_node json =
   match json |> member "tree" |> to_list with
   | node :: _ -> node
@@ -963,6 +982,61 @@ let test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt () =
         "runtime_blocker"
         (runtime_trust |> member "latest_causal_event" |> member "kind" |> to_string)
 
+let test_goal_detail_keeps_decision_terminal_reason_over_newer_blocker () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Prefer decision reason" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let meta =
+    make_keeper_meta ~name:"decision-over-blocker-keeper" ~goal_id:goal.id
+  in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  append_keeper_receipt config meta;
+  append_keeper_decision_terminal_reason config meta;
+  let blocked_meta =
+    {
+      meta with
+      runtime =
+        {
+          meta.runtime with
+          usage =
+            {
+              meta.runtime.usage with
+              total_turns = meta.runtime.usage.total_turns + 1;
+              last_turn_ts = Unix.gettimeofday () +. 60.0;
+            };
+          last_blocker =
+            "Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}";
+          last_blocker_class = Some Keeper_types.Oas_timeout_budget;
+        };
+    }
+  in
+  (match Keeper_types.write_meta ~force:true config blocked_meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok json ->
+      let linked_keeper =
+        match json |> member "linked_keepers" |> to_list with
+        | keeper :: _ -> keeper
+        | [] -> fail "expected linked keeper detail"
+      in
+      let terminal_reason =
+        linked_keeper
+        |> member "runtime_trust"
+        |> member "latest_terminal_reason"
+      in
+      check string "decision terminal reason keeps precedence"
+        "decision_specific_terminal_reason"
+        (terminal_reason |> member "code" |> to_string);
+      check string "decision source retained" "decision_log"
+        (terminal_reason |> member "source" |> to_string)
+
 let test_goal_detail_derives_attention_from_receipt_disposition () =
   with_room @@ fun config ->
   let goal, _kind =
@@ -1062,6 +1136,10 @@ let () =
             "goal detail promotes newer runtime blocker over stale receipt"
             `Quick
             test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt;
+          test_case
+            "goal detail keeps decision terminal reason over newer blocker"
+            `Quick
+            test_goal_detail_keeps_decision_terminal_reason_over_newer_blocker;
           test_case
             "goal detail derives attention from receipt disposition"
             `Quick


### PR DESCRIPTION
## Summary
- Prefer runtime blocker state over older execution receipts when keeper meta shows a later failed turn.
- Map runtime blocker classes and contradictory receipt dispositions back into structured latest_terminal_reason, so execution-trust does not report stale completed while needs_attention is true.
- Fill attention_reason/next_human_action from receipt-derived disposition and terminal reason when runtime attention fields are absent.
- Mark newer runtime blocker timeline events as causal, while preserving older synthetic blockers as observation-only.

## Evidence
- Live /api/v1/dashboard/execution-trust showed keepers with needs_attention=true/runtime_blocked but terminal_reason_code=completed because last_blocker/last_turn_ts were newer than the latest receipt.
- Live nick0cave showed terminal_reason_code=completed with operator_disposition=pause_human and tool_contract_result=needs_execution_progress, leaving attention_reason/next_human_action null.
- Local proof: env DUNE_CACHE=disabled dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-runtime-blocker-terminal-reason-0506 test/test_dashboard_goals.exe
- Local proof: ./_build/default/test/test_dashboard_goals.exe --color=never (23 tests)

## Review focus
- Check runtime_blocker_supersedes_receipt timestamp boundary.
- Check receipt-derived terminal reason for completed receipts that still require tool-contract attention.
- Check that older synthetic blockers remain observation-only and do not hide durable receipts.