### PR TITLE
feat(goal-loop): add verify pipeline gates

### DIFF
--- a/docs/observability/goal-loop-verify-pipeline.md
+++ b/docs/observability/goal-loop-verify-pipeline.md
@@ -11,6 +11,12 @@ entry per required check. `PASS` is only emitted when every gate passes.
 Missing production evidence is represented as `BLOCKED`; mapped but unrun
 commands are represented as `SKIPPED`.
 
+Metric gates read snapshot keys from the JSON passed via `--metrics-json`; the
+gate evidence records those snapshot keys separately from any underlying
+`masc_*` Prometheus series used to derive them. The rendered command examples
+therefore query `GOAL_LOOP_METRICS_JSON` with `jq` instead of naming a
+non-repo `prometheus` CLI.
+
 Covered gate groups:
 
 - `unit_tests`: `dune runtest test/`
@@ -32,3 +38,6 @@ TLA assets.
 the pipeline result. A partial pipeline adds the `verify_pipeline_complete`
 blocker, so a generic Verify `PASS` cannot close the GOAL LOOP while metric,
 TLA, log, or Orient gates are blocked.
+For schema version 1, completion also validates the reported gate counts and the
+full required gate-id set, so a minimal all-PASS fixture cannot stand in for the
+repo-owned Verify contract.

--- a/docs/observability/goal-loop-verify-pipeline.md
+++ b/docs/observability/goal-loop-verify-pipeline.md
@@ -1,0 +1,34 @@
+# GOAL LOOP Verify Pipeline
+
+`scripts/goal_loop_verify_pipeline.py` is the repo-owned contract for the
+prompt-level Verify phase. It turns partial evidence into explicit gate records
+instead of letting a narrow post-ACT log check stand in for full completion.
+
+## Gate Contract
+
+The output JSON has `schema_version: 1`, a top-level `status`, and one `gates`
+entry per required check. `PASS` is only emitted when every gate passes.
+Missing production evidence is represented as `BLOCKED`; mapped but unrun
+commands are represented as `SKIPPED`.
+
+Covered gate groups:
+
+- `unit_tests`: `dune runtest test/`
+- `regression_metric`: semaphore skip, pricing miss, UTF-8 repair, recovery
+  execution, and admission backpressure
+- `metric_verification`: keeper turn success rate and dashboard snapshot latency
+- `tla_check`: prompt specs `TierRouting.tla`, `Validation.tla`, `Liveness.tla`
+- `log_verification`: required and forbidden post-ACT production log patterns
+- `orient_recheck`: still-present and new-finding counts from the Orient recheck
+
+The current prompt TLA spec names are intentionally checked by exact filename.
+If those specs are absent, the gate is `BLOCKED` with
+`reason: prompt_tla_spec_missing`; it is not silently satisfied by adjacent
+TLA assets.
+
+## Completion Audit
+
+`scripts/goal_loop_completion_audit.py --verify-pipeline <result.json>` consumes
+the pipeline result. A partial pipeline adds the `verify_pipeline_complete`
+blocker, so a generic Verify `PASS` cannot close the GOAL LOOP while metric,
+TLA, log, or Orient gates are blocked.

--- a/scripts/goal_loop_completion_audit.py
+++ b/scripts/goal_loop_completion_audit.py
@@ -1063,6 +1063,41 @@ def prompt_closeout_checklist_evidence(
     }
 
 
+def verify_pipeline_evidence(
+    verify_summary: dict[str, Any],
+    verify_pipeline: dict[str, Any] | None,
+) -> tuple[bool, dict[str, Any]]:
+    raw_pipeline = verify_pipeline
+    if raw_pipeline is None:
+        embedded = verify_summary.get("verify_pipeline")
+        raw_pipeline = embedded if isinstance(embedded, dict) else None
+    if raw_pipeline is None:
+        return True, {"pipeline_status": "NOT_PROVIDED", "provided": False}
+
+    raw_gates = raw_pipeline.get("gates", [])
+    gates = raw_gates if isinstance(raw_gates, list) else []
+    non_pass_gate_ids = [
+        gate.get("gate_id")
+        for gate in gates
+        if isinstance(gate, dict) and gate.get("status") != "PASS"
+    ]
+    non_pass_gate_ids = [
+        gate_id for gate_id in non_pass_gate_ids if isinstance(gate_id, str)
+    ]
+    status = raw_pipeline.get("status")
+    passed = status == "PASS" and bool(gates) and not non_pass_gate_ids
+    return passed, {
+        "pipeline_status": status,
+        "provided": True,
+        "gates_total": as_int(raw_pipeline.get("gates_total")),
+        "gates_passed": as_int(raw_pipeline.get("gates_passed")),
+        "gates_failed": as_int(raw_pipeline.get("gates_failed")),
+        "gates_blocked": as_int(raw_pipeline.get("gates_blocked")),
+        "gates_skipped": as_int(raw_pipeline.get("gates_skipped")),
+        "non_pass_gate_ids": non_pass_gate_ids,
+    }
+
+
 def build_completion_audit(
     status: dict[str, Any],
     *,
@@ -1071,6 +1106,7 @@ def build_completion_audit(
     strict_row_corpus: dict[str, Any] | None = None,
     prompt_closeout_checklist: dict[str, Any] | None = None,
     source_row_candidate_inventory: dict[str, Any] | None = None,
+    verify_pipeline: dict[str, Any] | None = None,
 ) -> CompletionAudit:
     audit_catalog = nested_dict(status, "phases", "orient", "summary", "audit_catalog")
     verify_summary = nested_dict(status, "phases", "verify", "summary")
@@ -1288,6 +1324,10 @@ def build_completion_audit(
         and verify_evidence["evidence_window_end"] is not None
         and verify_evidence["checked_at"] is not None
     )
+    pipeline_passed, pipeline_evidence = verify_pipeline_evidence(
+        verify_summary,
+        verify_pipeline,
+    )
 
     criteria = [
         criterion(
@@ -1414,6 +1454,15 @@ def build_completion_audit(
                 },
             )
         )
+    if pipeline_evidence["provided"]:
+        criteria.append(
+            criterion(
+                "verify_pipeline_complete",
+                pipeline_passed,
+                "Full Verify pipeline gates are present and all required gates pass.",
+                pipeline_evidence,
+            )
+        )
     blockers = [item.criterion_id for item in criteria if item.status == "FAIL"]
     status_text = "COMPLETE" if not blockers else "BLOCKED"
     return CompletionAudit(
@@ -1472,6 +1521,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Optional explicit source-row candidate inventory manifest.",
     )
     parser.add_argument(
+        "--verify-pipeline",
+        help="Optional GOAL LOOP Verify pipeline result JSON to require for closeout.",
+    )
+    parser.add_argument(
         "--require-complete",
         action="store_true",
         help="Exit non-zero unless every completion criterion passes.",
@@ -1492,6 +1545,7 @@ def main(argv: list[str] | None = None) -> int:
         source_row_candidate_inventory=load_optional_json_file(
             args.source_row_candidate_inventory
         ),
+        verify_pipeline=load_optional_json_file(args.verify_pipeline),
     )
     if args.format == "json":
         print(audit_to_json(audit))

--- a/scripts/goal_loop_completion_audit.py
+++ b/scripts/goal_loop_completion_audit.py
@@ -42,6 +42,24 @@ PROMPT_CHECKLIST_PR_REF_RE = re.compile(
 )
 PROMPT_SOURCE_PATH_PREFIX = "prompt_corpus/GOAL_LOOP/"
 REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_VERIFY_GATE_IDS = frozenset(
+    {
+        "unit_tests",
+        "keeper_turn_success_rate_healthy",
+        "no_semaphore_skip",
+        "no_pricing_miss",
+        "no_utf8_repair",
+        "recovery_executed",
+        "admission_backpressure_observed",
+        "dashboard_snapshot_latency_p99",
+        "orient_recheck_no_still_present",
+        "orient_recheck_no_new_finding",
+        "tla_prompt_spec_tierrouting",
+        "tla_prompt_spec_validation",
+        "tla_prompt_spec_liveness",
+        "post_act_log_contract",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -1076,6 +1094,17 @@ def verify_pipeline_evidence(
 
     raw_gates = raw_pipeline.get("gates", [])
     gates = raw_gates if isinstance(raw_gates, list) else []
+    gate_ids = [
+        gate.get("gate_id")
+        for gate in gates
+        if isinstance(gate, dict) and isinstance(gate.get("gate_id"), str)
+    ]
+    gate_id_set = set(gate_ids)
+    missing_gate_ids = sorted(REQUIRED_VERIFY_GATE_IDS - gate_id_set)
+    unexpected_gate_ids = sorted(gate_id_set - REQUIRED_VERIFY_GATE_IDS)
+    duplicate_gate_ids = sorted(
+        {gate_id for gate_id in gate_ids if gate_ids.count(gate_id) > 1}
+    )
     non_pass_gate_ids = [
         gate.get("gate_id")
         for gate in gates
@@ -1084,16 +1113,48 @@ def verify_pipeline_evidence(
     non_pass_gate_ids = [
         gate_id for gate_id in non_pass_gate_ids if isinstance(gate_id, str)
     ]
+    status_counts = {
+        status: sum(
+            1
+            for gate in gates
+            if isinstance(gate, dict) and gate.get("status") == status
+        )
+        for status in ("PASS", "FAIL", "BLOCKED", "SKIPPED")
+    }
+    reported_total = as_int(raw_pipeline.get("gates_total"))
+    counts_match = (
+        reported_total == len(gates)
+        and as_int(raw_pipeline.get("gates_passed")) == status_counts["PASS"]
+        and as_int(raw_pipeline.get("gates_failed")) == status_counts["FAIL"]
+        and as_int(raw_pipeline.get("gates_blocked")) == status_counts["BLOCKED"]
+        and as_int(raw_pipeline.get("gates_skipped")) == status_counts["SKIPPED"]
+    )
+    schema_version = as_int(raw_pipeline.get("schema_version"))
     status = raw_pipeline.get("status")
-    passed = status == "PASS" and bool(gates) and not non_pass_gate_ids
+    passed = (
+        schema_version == 1
+        and status == "PASS"
+        and bool(gates)
+        and counts_match
+        and not missing_gate_ids
+        and not unexpected_gate_ids
+        and not duplicate_gate_ids
+        and len(gate_ids) == len(REQUIRED_VERIFY_GATE_IDS)
+        and not non_pass_gate_ids
+    )
     return passed, {
+        "schema_version": schema_version,
         "pipeline_status": status,
         "provided": True,
-        "gates_total": as_int(raw_pipeline.get("gates_total")),
+        "gates_total": reported_total,
         "gates_passed": as_int(raw_pipeline.get("gates_passed")),
         "gates_failed": as_int(raw_pipeline.get("gates_failed")),
         "gates_blocked": as_int(raw_pipeline.get("gates_blocked")),
         "gates_skipped": as_int(raw_pipeline.get("gates_skipped")),
+        "counts_match": counts_match,
+        "missing_gate_ids": missing_gate_ids,
+        "unexpected_gate_ids": unexpected_gate_ids,
+        "duplicate_gate_ids": duplicate_gate_ids,
         "non_pass_gate_ids": non_pass_gate_ids,
     }
 

--- a/scripts/goal_loop_verify_pipeline.py
+++ b/scripts/goal_loop_verify_pipeline.py
@@ -42,6 +42,10 @@ PROMETHEUS_METRIC_SOURCES = {
     "keeper_turn_success_rate": ["masc_keeper_turns_total"],
     "keeper_skipping_turn_rate_5m": ["masc_keeper_semaphore_wait_timeout_total"],
     "pricing_catalog_miss_total": ["masc_pricing_catalog_miss_total"],
+    "persistence_utf8_repair_total": ["masc_persistence_utf8_repair_total"],
+    "dashboard_snapshot_latency_p99": [
+        "masc_dashboard_snapshot_latency_seconds_bucket"
+    ],
     "admission_queue_depth": ["masc_inference_queue_depth"],
     "admission_queue_wait_ms": ["masc_inference_queue_wait_seconds"],
 }
@@ -495,6 +499,38 @@ def build_unit_gate(unit_tests_passed: bool, unit_tests_failed: bool) -> VerifyG
     )
 
 
+def _assert_emitted_gate_ids_match_required(gates: list[VerifyGate]) -> None:
+    """Refuse to build a pipeline report whose gate IDs drift from the
+    declared contract in ``REQUIRED_VERIFY_GATE_IDS``.
+
+    Without this check, a future edit to gate construction (renaming,
+    accidental duplication, dropped gate) could silently change the
+    pipeline contract: callers that key off specific gate_ids would
+    fail downstream instead of at the script boundary. Raising here
+    surfaces the drift at the producing site.
+    """
+    emitted = [gate.gate_id for gate in gates]
+    counts: dict[str, int] = {}
+    for gate_id in emitted:
+        counts[gate_id] = counts.get(gate_id, 0) + 1
+    duplicates = sorted(gate_id for gate_id, freq in counts.items() if freq > 1)
+    required = set(REQUIRED_VERIFY_GATE_IDS)
+    emitted_set = set(emitted)
+    missing = sorted(required - emitted_set)
+    extra = sorted(emitted_set - required)
+    problems: list[str] = []
+    if missing:
+        problems.append(f"missing={missing}")
+    if extra:
+        problems.append(f"extra={extra}")
+    if duplicates:
+        problems.append(f"duplicates={duplicates}")
+    if problems:
+        raise AssertionError(
+            "Verify pipeline gate-id contract drift: " + "; ".join(problems)
+        )
+
+
 def build_pipeline_report(
     *,
     repo_root: Path,
@@ -510,6 +546,7 @@ def build_pipeline_report(
         *build_tla_gates(repo_root=repo_root, tla_results=tla_results),
         build_log_gate(log_paths),
     ]
+    _assert_emitted_gate_ids_match_required(gates)
     counts = {
         status: sum(1 for item in gates if item.status == status)
         for status in (

--- a/scripts/goal_loop_verify_pipeline.py
+++ b/scripts/goal_loop_verify_pipeline.py
@@ -22,6 +22,29 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution path
 
 
 PROMPT_TLA_SPECS = ("TierRouting.tla", "Validation.tla", "Liveness.tla")
+REQUIRED_VERIFY_GATE_IDS = (
+    "unit_tests",
+    "keeper_turn_success_rate_healthy",
+    "no_semaphore_skip",
+    "no_pricing_miss",
+    "no_utf8_repair",
+    "recovery_executed",
+    "admission_backpressure_observed",
+    "dashboard_snapshot_latency_p99",
+    "orient_recheck_no_still_present",
+    "orient_recheck_no_new_finding",
+    "tla_prompt_spec_tierrouting",
+    "tla_prompt_spec_validation",
+    "tla_prompt_spec_liveness",
+    "post_act_log_contract",
+)
+PROMETHEUS_METRIC_SOURCES = {
+    "keeper_turn_success_rate": ["masc_keeper_turns_total"],
+    "keeper_skipping_turn_rate_5m": ["masc_keeper_semaphore_wait_timeout_total"],
+    "pricing_catalog_miss_total": ["masc_pricing_catalog_miss_total"],
+    "admission_queue_depth": ["masc_inference_queue_depth"],
+    "admission_queue_wait_ms": ["masc_inference_queue_wait_seconds"],
+}
 
 DEFAULT_MUST_CONTAIN = (
     "recovery_strategy_executed",
@@ -124,6 +147,9 @@ def metric_gate(
     value = metric_value(metrics, metric_name)
     evidence = {
         "metric_name": metric_name,
+        "metric_snapshot_key": metric_name,
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "prometheus_sources": PROMETHEUS_METRIC_SOURCES.get(metric_name, []),
         "value": value,
         "predicate": predicate,
     }
@@ -165,18 +191,39 @@ def metric_gate(
     )
 
 
+def metric_snapshot_command(metric_name: str) -> list[str]:
+    return [
+        "sh",
+        "-c",
+        (
+            f"jq '(.metrics // .).{metric_name}' "
+            '"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}"'
+        ),
+    ]
+
+
 def admission_backpressure_gate(metrics: dict[str, Any] | None) -> VerifyGate:
     queue_depth = metric_value(metrics, "admission_queue_depth")
     wait_ms = metric_value(metrics, "admission_queue_wait_ms")
     evidence = {
         "admission_queue_depth": queue_depth,
         "admission_queue_wait_ms": wait_ms,
+        "metric_source": "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+        "prometheus_sources": {
+            "admission_queue_depth": PROMETHEUS_METRIC_SOURCES["admission_queue_depth"],
+            "admission_queue_wait_ms": PROMETHEUS_METRIC_SOURCES[
+                "admission_queue_wait_ms"
+            ],
+        },
         "predicate": "admission_queue_depth > 0 || admission_queue_wait_ms > 0",
     }
     command = [
-        "prometheus",
-        "query",
-        "admission_queue_depth || admission_queue_wait_ms",
+        "sh",
+        "-c",
+        (
+            "jq '(.metrics // .) | {admission_queue_depth, admission_queue_wait_ms}' "
+            '"${GOAL_LOOP_METRICS_JSON:?set GOAL_LOOP_METRICS_JSON to production metric snapshot JSON}"'
+        ),
     ]
     if metrics is None:
         return gate(
@@ -219,7 +266,7 @@ def build_metric_gates(metrics_json: dict[str, Any] | None) -> list[VerifyGate]:
             metric_name="keeper_turn_success_rate",
             category="metric_verification",
             predicate="> 0.95",
-            command=["prometheus", "query", "keeper_turn_success_rate"],
+            command=metric_snapshot_command("keeper_turn_success_rate"),
         ),
         metric_gate(
             metrics,
@@ -227,7 +274,7 @@ def build_metric_gates(metrics_json: dict[str, Any] | None) -> list[VerifyGate]:
             metric_name="keeper_skipping_turn_rate_5m",
             category="regression_metric",
             predicate="== 0",
-            command=["prometheus", "query", "keeper_skipping_turn_rate[5m]"],
+            command=metric_snapshot_command("keeper_skipping_turn_rate_5m"),
         ),
         metric_gate(
             metrics,
@@ -235,7 +282,7 @@ def build_metric_gates(metrics_json: dict[str, Any] | None) -> list[VerifyGate]:
             metric_name="pricing_catalog_miss_total",
             category="regression_metric",
             predicate="== 0",
-            command=["prometheus", "query", "pricing_catalog_miss_total"],
+            command=metric_snapshot_command("pricing_catalog_miss_total"),
         ),
         metric_gate(
             metrics,
@@ -243,7 +290,7 @@ def build_metric_gates(metrics_json: dict[str, Any] | None) -> list[VerifyGate]:
             metric_name="persistence_utf8_repair_total",
             category="regression_metric",
             predicate="== 0",
-            command=["prometheus", "query", "persistence_utf8_repair_total"],
+            command=metric_snapshot_command("persistence_utf8_repair_total"),
         ),
         metric_gate(
             metrics,
@@ -251,7 +298,7 @@ def build_metric_gates(metrics_json: dict[str, Any] | None) -> list[VerifyGate]:
             metric_name="recovery_strategy_executed_total_1h",
             category="regression_metric",
             predicate="> 0",
-            command=["prometheus", "query", "recovery_strategy_executed_total[1h]"],
+            command=metric_snapshot_command("recovery_strategy_executed_total_1h"),
         ),
         admission_backpressure_gate(metrics),
         metric_gate(
@@ -260,7 +307,7 @@ def build_metric_gates(metrics_json: dict[str, Any] | None) -> list[VerifyGate]:
             metric_name="dashboard_snapshot_latency_p99",
             category="metric_verification",
             predicate="< 5.0",
-            command=["prometheus", "query", "dashboard_snapshot_latency_p99"],
+            command=metric_snapshot_command("dashboard_snapshot_latency_p99"),
         ),
         metric_gate(
             metrics,
@@ -290,6 +337,11 @@ def find_tla_spec(repo_root: Path, spec_name: str) -> str | None:
 def tla_result_for(tla_results: dict[str, Any] | None, spec_name: str) -> str | None:
     if tla_results is None:
         return None
+    raw = tla_results.get(spec_name)
+    if isinstance(raw, dict):
+        raw = raw.get("status")
+    if isinstance(raw, str):
+        return raw
     specs = tla_results.get("specs")
     if isinstance(specs, dict):
         raw = specs.get(spec_name)
@@ -506,11 +558,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--metrics-json",
-        help="Production metric snapshot JSON. Accepts top-level metrics or {'metrics': {...}}.",
+        help=(
+            "Production metric snapshot JSON using the gate metric_name fields. "
+            "Accepts top-level metrics or {'metrics': {...}}."
+        ),
     )
     parser.add_argument(
         "--tla-results-json",
-        help="Optional TLC result JSON keyed by prompt spec name.",
+        help=(
+            "Optional TLC result JSON. Accepts top-level spec keys "
+            "or {'specs': {...}} / {'specs': [{'spec'|'name', 'status'}]}."
+        ),
     )
     parser.add_argument(
         "--log",

--- a/scripts/goal_loop_verify_pipeline.py
+++ b/scripts/goal_loop_verify_pipeline.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Build the strict GOAL LOOP Verify pipeline result.
+
+This maps the prompt-level ``verify.yml`` gates into a repo-owned JSON contract.
+It does not claim that missing production evidence is green: absent metric,
+TLA, log, or orient inputs become explicit BLOCKED/SKIPPED gate records.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.verify_goal_loop_logs import verify_log_contract
+except ModuleNotFoundError:  # pragma: no cover - direct script execution path
+    from verify_goal_loop_logs import verify_log_contract
+
+
+PROMPT_TLA_SPECS = ("TierRouting.tla", "Validation.tla", "Liveness.tla")
+
+DEFAULT_MUST_CONTAIN = (
+    "recovery_strategy_executed",
+    "provider_health_probe_completed",
+    "fallback_ladder_activated",
+)
+DEFAULT_MUST_NOT_CONTAIN = (
+    "skipping turn.*semaphore wait",
+    "pricing_catalog_miss",
+    "persistence UTF-8 repaired",
+    "alive-but-stuck detected",
+    "Lenient_json fallback hit",
+    "archived credential.*starvation",
+)
+
+
+@dataclass(frozen=True)
+class VerifyGate:
+    gate_id: str
+    category: str
+    status: str
+    summary: str
+    command: list[str] | None
+    reason: str | None
+    evidence: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class VerifyPipelineReport:
+    schema_version: int
+    status: str
+    gates_total: int
+    gates_passed: int
+    gates_failed: int
+    gates_blocked: int
+    gates_skipped: int
+    gates: list[VerifyGate]
+
+
+def load_json_file(path: str | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def gate(
+    gate_id: str,
+    category: str,
+    status: str,
+    summary: str,
+    *,
+    command: list[str] | None = None,
+    reason: str | None = None,
+    evidence: dict[str, Any] | None = None,
+) -> VerifyGate:
+    return VerifyGate(
+        gate_id=gate_id,
+        category=category,
+        status=status,
+        summary=summary,
+        command=command,
+        reason=reason,
+        evidence=evidence or {},
+    )
+
+
+def metrics_root(metrics_json: dict[str, Any] | None) -> dict[str, Any] | None:
+    if metrics_json is None:
+        return None
+    nested = metrics_json.get("metrics")
+    return nested if isinstance(nested, dict) else metrics_json
+
+
+def metric_value(metrics: dict[str, Any] | None, key: str) -> float | None:
+    if metrics is None or key not in metrics:
+        return None
+    raw = metrics[key]
+    if isinstance(raw, dict):
+        raw = raw.get("value")
+    if isinstance(raw, bool):
+        return 1.0 if raw else 0.0
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    return None
+
+
+def metric_gate(
+    metrics: dict[str, Any] | None,
+    *,
+    gate_id: str,
+    metric_name: str,
+    category: str,
+    predicate: str,
+    command: list[str],
+) -> VerifyGate:
+    value = metric_value(metrics, metric_name)
+    evidence = {
+        "metric_name": metric_name,
+        "value": value,
+        "predicate": predicate,
+    }
+    if metrics is None:
+        return gate(
+            gate_id,
+            category,
+            "BLOCKED",
+            f"{metric_name} cannot be evaluated without a production metric snapshot.",
+            command=command,
+            reason="missing_metric_snapshot",
+            evidence=evidence,
+        )
+    if value is None:
+        return gate(
+            gate_id,
+            category,
+            "BLOCKED",
+            f"{metric_name} is absent from the production metric snapshot.",
+            command=command,
+            reason="missing_metric",
+            evidence=evidence,
+        )
+
+    passed = {
+        "== 0": value == 0.0,
+        "> 0": value > 0.0,
+        "> 0.95": value > 0.95,
+        "< 5.0": value < 5.0,
+    }[predicate]
+    return gate(
+        gate_id,
+        category,
+        "PASS" if passed else "FAIL",
+        f"{metric_name} {predicate}",
+        command=command,
+        reason=None if passed else "predicate_failed",
+        evidence=evidence,
+    )
+
+
+def admission_backpressure_gate(metrics: dict[str, Any] | None) -> VerifyGate:
+    queue_depth = metric_value(metrics, "admission_queue_depth")
+    wait_ms = metric_value(metrics, "admission_queue_wait_ms")
+    evidence = {
+        "admission_queue_depth": queue_depth,
+        "admission_queue_wait_ms": wait_ms,
+        "predicate": "admission_queue_depth > 0 || admission_queue_wait_ms > 0",
+    }
+    command = [
+        "prometheus",
+        "query",
+        "admission_queue_depth || admission_queue_wait_ms",
+    ]
+    if metrics is None:
+        return gate(
+            "admission_backpressure_observed",
+            "regression_metric",
+            "BLOCKED",
+            "Admission backpressure cannot be evaluated without a metric snapshot.",
+            command=command,
+            reason="missing_metric_snapshot",
+            evidence=evidence,
+        )
+    if queue_depth is None and wait_ms is None:
+        return gate(
+            "admission_backpressure_observed",
+            "regression_metric",
+            "BLOCKED",
+            "Admission backpressure metrics are absent from the snapshot.",
+            command=command,
+            reason="missing_metric",
+            evidence=evidence,
+        )
+    passed = (queue_depth or 0.0) > 0.0 or (wait_ms or 0.0) > 0.0
+    return gate(
+        "admission_backpressure_observed",
+        "regression_metric",
+        "PASS" if passed else "FAIL",
+        "Admission queue must show real backpressure instead of 100% passthrough.",
+        command=command,
+        reason=None if passed else "predicate_failed",
+        evidence=evidence,
+    )
+
+
+def build_metric_gates(metrics_json: dict[str, Any] | None) -> list[VerifyGate]:
+    metrics = metrics_root(metrics_json)
+    return [
+        metric_gate(
+            metrics,
+            gate_id="keeper_turn_success_rate_healthy",
+            metric_name="keeper_turn_success_rate",
+            category="metric_verification",
+            predicate="> 0.95",
+            command=["prometheus", "query", "keeper_turn_success_rate"],
+        ),
+        metric_gate(
+            metrics,
+            gate_id="no_semaphore_skip",
+            metric_name="keeper_skipping_turn_rate_5m",
+            category="regression_metric",
+            predicate="== 0",
+            command=["prometheus", "query", "keeper_skipping_turn_rate[5m]"],
+        ),
+        metric_gate(
+            metrics,
+            gate_id="no_pricing_miss",
+            metric_name="pricing_catalog_miss_total",
+            category="regression_metric",
+            predicate="== 0",
+            command=["prometheus", "query", "pricing_catalog_miss_total"],
+        ),
+        metric_gate(
+            metrics,
+            gate_id="no_utf8_repair",
+            metric_name="persistence_utf8_repair_total",
+            category="regression_metric",
+            predicate="== 0",
+            command=["prometheus", "query", "persistence_utf8_repair_total"],
+        ),
+        metric_gate(
+            metrics,
+            gate_id="recovery_executed",
+            metric_name="recovery_strategy_executed_total_1h",
+            category="regression_metric",
+            predicate="> 0",
+            command=["prometheus", "query", "recovery_strategy_executed_total[1h]"],
+        ),
+        admission_backpressure_gate(metrics),
+        metric_gate(
+            metrics,
+            gate_id="dashboard_snapshot_latency_p99",
+            metric_name="dashboard_snapshot_latency_p99",
+            category="metric_verification",
+            predicate="< 5.0",
+            command=["prometheus", "query", "dashboard_snapshot_latency_p99"],
+        ),
+        metric_gate(
+            metrics,
+            gate_id="orient_recheck_no_still_present",
+            metric_name="orient_recheck_still_present",
+            category="orient_recheck",
+            predicate="== 0",
+            command=["dune", "exec", "orient.exe", "--", "--check-all"],
+        ),
+        metric_gate(
+            metrics,
+            gate_id="orient_recheck_no_new_finding",
+            metric_name="orient_recheck_new_finding",
+            category="orient_recheck",
+            predicate="== 0",
+            command=["dune", "exec", "orient.exe", "--", "--check-all"],
+        ),
+    ]
+
+
+def find_tla_spec(repo_root: Path, spec_name: str) -> str | None:
+    for path in repo_root.joinpath("specs").rglob(spec_name):
+        return path.relative_to(repo_root).as_posix()
+    return None
+
+
+def tla_result_for(tla_results: dict[str, Any] | None, spec_name: str) -> str | None:
+    if tla_results is None:
+        return None
+    specs = tla_results.get("specs")
+    if isinstance(specs, dict):
+        raw = specs.get(spec_name)
+        if isinstance(raw, dict):
+            raw = raw.get("status")
+        return raw if isinstance(raw, str) else None
+    if isinstance(specs, list):
+        for entry in specs:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("spec") == spec_name or entry.get("name") == spec_name:
+                status = entry.get("status")
+                return status if isinstance(status, str) else None
+    return None
+
+
+def build_tla_gates(
+    *,
+    repo_root: Path,
+    tla_results: dict[str, Any] | None,
+) -> list[VerifyGate]:
+    gates: list[VerifyGate] = []
+    for spec_name in PROMPT_TLA_SPECS:
+        found_path = find_tla_spec(repo_root, spec_name)
+        result = tla_result_for(tla_results, spec_name)
+        evidence = {
+            "prompt_spec": spec_name,
+            "resolved_path": found_path,
+            "result_status": result,
+        }
+        if found_path is None:
+            gates.append(
+                gate(
+                    f"tla_prompt_spec_{spec_name.removesuffix('.tla').lower()}",
+                    "tla_check",
+                    "BLOCKED",
+                    f"Prompt TLA spec {spec_name} is not present in specs/.",
+                    command=["scripts/tla-check.sh"],
+                    reason="prompt_tla_spec_missing",
+                    evidence=evidence,
+                )
+            )
+            continue
+        if result is None:
+            gates.append(
+                gate(
+                    f"tla_prompt_spec_{spec_name.removesuffix('.tla').lower()}",
+                    "tla_check",
+                    "SKIPPED",
+                    f"Prompt TLA spec {spec_name} exists but no TLC result was supplied.",
+                    command=["scripts/tla-check.sh"],
+                    reason="tla_result_not_supplied",
+                    evidence=evidence,
+                )
+            )
+            continue
+        passed = result.upper() == "PASS"
+        gates.append(
+            gate(
+                f"tla_prompt_spec_{spec_name.removesuffix('.tla').lower()}",
+                "tla_check",
+                "PASS" if passed else "FAIL",
+                f"Prompt TLA spec {spec_name} TLC result is {result}.",
+                command=["scripts/tla-check.sh"],
+                reason=None if passed else "tla_check_failed",
+                evidence=evidence,
+            )
+        )
+    return gates
+
+
+def build_log_gate(log_paths: list[str]) -> VerifyGate:
+    command = [
+        "scripts/verify_goal_loop_logs.py",
+        "--mode",
+        "log-contract",
+        "--must-contain",
+        "...",
+        "--must-not-contain",
+        "...",
+    ]
+    if not log_paths:
+        return gate(
+            "post_act_log_contract",
+            "log_verification",
+            "BLOCKED",
+            "Post-ACT production log contract was not evaluated.",
+            command=command,
+            reason="missing_post_act_logs",
+            evidence={
+                "must_contain": list(DEFAULT_MUST_CONTAIN),
+                "must_not_contain": list(DEFAULT_MUST_NOT_CONTAIN),
+            },
+        )
+
+    report = verify_log_contract(
+        log_paths,
+        must_contain=list(DEFAULT_MUST_CONTAIN),
+        must_not_contain=list(DEFAULT_MUST_NOT_CONTAIN),
+        max_samples=3,
+    )
+    return gate(
+        "post_act_log_contract",
+        "log_verification",
+        report.status,
+        "Post-ACT production logs satisfy the required/forbidden pattern contract.",
+        command=command,
+        reason=None if report.status == "PASS" else "log_contract_failed",
+        evidence=asdict(report),
+    )
+
+
+def build_unit_gate(unit_tests_passed: bool, unit_tests_failed: bool) -> VerifyGate:
+    command = ["dune", "runtest", "test/"]
+    if unit_tests_passed and unit_tests_failed:
+        return gate(
+            "unit_tests",
+            "unit_tests",
+            "FAIL",
+            "Unit test gate received conflicting pass/fail evidence.",
+            command=command,
+            reason="conflicting_unit_test_evidence",
+        )
+    if unit_tests_passed:
+        return gate(
+            "unit_tests",
+            "unit_tests",
+            "PASS",
+            "Unit tests were reported as passing.",
+            command=command,
+            evidence={"reported": "passed"},
+        )
+    if unit_tests_failed:
+        return gate(
+            "unit_tests",
+            "unit_tests",
+            "FAIL",
+            "Unit tests were reported as failing.",
+            command=command,
+            reason="unit_tests_failed",
+            evidence={"reported": "failed"},
+        )
+    return gate(
+        "unit_tests",
+        "unit_tests",
+        "SKIPPED",
+        "Unit test command is mapped but no run evidence was supplied.",
+        command=command,
+        reason="unit_tests_not_run",
+        evidence={"reported": "not_supplied"},
+    )
+
+
+def build_pipeline_report(
+    *,
+    repo_root: Path,
+    metrics_json: dict[str, Any] | None,
+    tla_results: dict[str, Any] | None,
+    log_paths: list[str],
+    unit_tests_passed: bool,
+    unit_tests_failed: bool,
+) -> VerifyPipelineReport:
+    gates = [
+        build_unit_gate(unit_tests_passed, unit_tests_failed),
+        *build_metric_gates(metrics_json),
+        *build_tla_gates(repo_root=repo_root, tla_results=tla_results),
+        build_log_gate(log_paths),
+    ]
+    counts = {
+        status: sum(1 for item in gates if item.status == status)
+        for status in (
+            "PASS",
+            "FAIL",
+            "BLOCKED",
+            "SKIPPED",
+        )
+    }
+    if counts["FAIL"] > 0:
+        status = "FAIL"
+    elif counts["BLOCKED"] > 0 or counts["SKIPPED"] > 0:
+        status = "BLOCKED"
+    else:
+        status = "PASS"
+    return VerifyPipelineReport(
+        schema_version=1,
+        status=status,
+        gates_total=len(gates),
+        gates_passed=counts["PASS"],
+        gates_failed=counts["FAIL"],
+        gates_blocked=counts["BLOCKED"],
+        gates_skipped=counts["SKIPPED"],
+        gates=gates,
+    )
+
+
+def report_to_json(report: VerifyPipelineReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: VerifyPipelineReport) -> str:
+    lines = [f"GOAL LOOP Verify Pipeline: {report.status}"]
+    lines.append(
+        "gates: "
+        f"pass={report.gates_passed} fail={report.gates_failed} "
+        f"blocked={report.gates_blocked} skipped={report.gates_skipped}"
+    )
+    for item in report.gates:
+        suffix = f" ({item.reason})" if item.reason else ""
+        lines.append(f"- {item.gate_id}: {item.status}{suffix}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--metrics-json",
+        help="Production metric snapshot JSON. Accepts top-level metrics or {'metrics': {...}}.",
+    )
+    parser.add_argument(
+        "--tla-results-json",
+        help="Optional TLC result JSON keyed by prompt spec name.",
+    )
+    parser.add_argument(
+        "--log",
+        action="append",
+        default=[],
+        help="Post-ACT production log path. Repeat for multiple files.",
+    )
+    parser.add_argument(
+        "--unit-tests-passed",
+        action="store_true",
+        help="Record the unit test gate as PASS.",
+    )
+    parser.add_argument(
+        "--unit-tests-failed",
+        action="store_true",
+        help="Record the unit test gate as FAIL.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--require-pass",
+        action="store_true",
+        help="Exit non-zero unless every gate passes.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    report = build_pipeline_report(
+        repo_root=repo_root,
+        metrics_json=load_json_file(args.metrics_json),
+        tla_results=load_json_file(args.tla_results_json),
+        log_paths=list(args.log),
+        unit_tests_passed=args.unit_tests_passed,
+        unit_tests_failed=args.unit_tests_failed,
+    )
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    if args.require_pass and report.status != "PASS":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -247,6 +247,61 @@ def synthetic_strict_row_corpus(row_count: int = 206) -> dict[str, object]:
     }
 
 
+def blocked_verify_pipeline() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "status": "BLOCKED",
+        "gates_total": 3,
+        "gates_passed": 1,
+        "gates_failed": 0,
+        "gates_blocked": 1,
+        "gates_skipped": 1,
+        "gates": [
+            {
+                "gate_id": "unit_tests",
+                "category": "unit_tests",
+                "status": "PASS",
+            },
+            {
+                "gate_id": "tla_prompt_spec_tierrouting",
+                "category": "tla_check",
+                "status": "BLOCKED",
+                "reason": "prompt_tla_spec_missing",
+            },
+            {
+                "gate_id": "post_act_log_contract",
+                "category": "log_verification",
+                "status": "SKIPPED",
+                "reason": "missing_post_act_logs",
+            },
+        ],
+    }
+
+
+def passing_verify_pipeline() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "status": "PASS",
+        "gates_total": 2,
+        "gates_passed": 2,
+        "gates_failed": 0,
+        "gates_blocked": 0,
+        "gates_skipped": 0,
+        "gates": [
+            {
+                "gate_id": "unit_tests",
+                "category": "unit_tests",
+                "status": "PASS",
+            },
+            {
+                "gate_id": "keeper_turn_success_rate_healthy",
+                "category": "metric_verification",
+                "status": "PASS",
+            },
+        ],
+    }
+
+
 class GoalLoopCompletionAuditTest(unittest.TestCase):
     def test_string_list_strips_and_rejects_empty_entries(self) -> None:
         self.assertEqual(
@@ -384,6 +439,43 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
             by_id["post_act_verify_complete"].evidence["evidence_kind"],
             "fixture",
         )
+
+    def test_completion_audit_blocks_partial_verify_pipeline(self) -> None:
+        audit = goal_loop_completion_audit.build_completion_audit(
+            complete_status(),
+            verify_pipeline=blocked_verify_pipeline(),
+        )
+
+        self.assertEqual(audit.status, "BLOCKED")
+        self.assertIn("verify_pipeline_complete", audit.blockers)
+        by_id = {item.criterion_id: item for item in audit.criteria}
+        evidence = by_id["verify_pipeline_complete"].evidence
+        self.assertEqual(evidence["pipeline_status"], "BLOCKED")
+        self.assertEqual(
+            evidence["non_pass_gate_ids"],
+            ["tla_prompt_spec_tierrouting", "post_act_log_contract"],
+        )
+
+    def test_completion_audit_accepts_passing_verify_pipeline(self) -> None:
+        audit = goal_loop_completion_audit.build_completion_audit(
+            complete_status(),
+            verify_pipeline=passing_verify_pipeline(),
+        )
+
+        self.assertEqual(audit.status, "COMPLETE")
+        self.assertNotIn("verify_pipeline_complete", audit.blockers)
+        by_id = {item.criterion_id: item for item in audit.criteria}
+        self.assertEqual(by_id["verify_pipeline_complete"].status, "PASS")
+
+    def test_completion_audit_consumes_embedded_verify_pipeline(self) -> None:
+        status = complete_status()
+        verify_summary = status["phases"]["verify"]["summary"]
+        verify_summary["verify_pipeline"] = blocked_verify_pipeline()
+
+        audit = goal_loop_completion_audit.build_completion_audit(status)
+
+        self.assertEqual(audit.status, "BLOCKED")
+        self.assertIn("verify_pipeline_complete", audit.blockers)
 
     def test_completion_audit_accepts_structured_id_triage_manifest(self) -> None:
         triage = json.loads(TRIAGE_FIXTURE.read_text(encoding="utf-8"))
@@ -1375,9 +1467,14 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as raw_dir:
             status_path = Path(raw_dir) / "status.json"
             corpus_path = Path(raw_dir) / "strict-row-corpus.json"
+            pipeline_path = Path(raw_dir) / "verify-pipeline.json"
             status_path.write_text(json.dumps(blocked_status()), encoding="utf-8")
             corpus_path.write_text(
                 json.dumps(synthetic_strict_row_corpus()),
+                encoding="utf-8",
+            )
+            pipeline_path.write_text(
+                json.dumps(blocked_verify_pipeline()),
                 encoding="utf-8",
             )
             result = subprocess.run(
@@ -1395,6 +1492,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
                     str(PROMPT_CHECKLIST_FIXTURE),
                     "--source-row-candidate-inventory",
                     str(SOURCE_ROW_CANDIDATE_INVENTORY_FIXTURE),
+                    "--verify-pipeline",
+                    str(pipeline_path),
                     "--require-complete",
                 ],
                 text=True,

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -254,8 +254,8 @@ def blocked_verify_pipeline() -> dict[str, object]:
         "gates_total": 3,
         "gates_passed": 1,
         "gates_failed": 0,
-        "gates_blocked": 1,
-        "gates_skipped": 1,
+        "gates_blocked": 2,
+        "gates_skipped": 0,
         "gates": [
             {
                 "gate_id": "unit_tests",
@@ -271,7 +271,7 @@ def blocked_verify_pipeline() -> dict[str, object]:
             {
                 "gate_id": "post_act_log_contract",
                 "category": "log_verification",
-                "status": "SKIPPED",
+                "status": "BLOCKED",
                 "reason": "missing_post_act_logs",
             },
         ],
@@ -279,26 +279,23 @@ def blocked_verify_pipeline() -> dict[str, object]:
 
 
 def passing_verify_pipeline() -> dict[str, object]:
+    gates = [
+        {
+            "gate_id": gate_id,
+            "category": "verify_pipeline",
+            "status": "PASS",
+        }
+        for gate_id in sorted(goal_loop_completion_audit.REQUIRED_VERIFY_GATE_IDS)
+    ]
     return {
         "schema_version": 1,
         "status": "PASS",
-        "gates_total": 2,
-        "gates_passed": 2,
+        "gates_total": len(gates),
+        "gates_passed": len(gates),
         "gates_failed": 0,
         "gates_blocked": 0,
         "gates_skipped": 0,
-        "gates": [
-            {
-                "gate_id": "unit_tests",
-                "category": "unit_tests",
-                "status": "PASS",
-            },
-            {
-                "gate_id": "keeper_turn_success_rate_healthy",
-                "category": "metric_verification",
-                "status": "PASS",
-            },
-        ],
+        "gates": gates,
     }
 
 
@@ -466,6 +463,33 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         self.assertNotIn("verify_pipeline_complete", audit.blockers)
         by_id = {item.criterion_id: item for item in audit.criteria}
         self.assertEqual(by_id["verify_pipeline_complete"].status, "PASS")
+
+    def test_completion_audit_rejects_partial_passing_verify_pipeline(self) -> None:
+        partial = {
+            "schema_version": 1,
+            "status": "PASS",
+            "gates_total": 1,
+            "gates_passed": 1,
+            "gates_failed": 0,
+            "gates_blocked": 0,
+            "gates_skipped": 0,
+            "gates": [
+                {
+                    "gate_id": "unit_tests",
+                    "category": "unit_tests",
+                    "status": "PASS",
+                }
+            ],
+        }
+        audit = goal_loop_completion_audit.build_completion_audit(
+            complete_status(),
+            verify_pipeline=partial,
+        )
+
+        self.assertEqual(audit.status, "BLOCKED")
+        by_id = {item.criterion_id: item for item in audit.criteria}
+        evidence = by_id["verify_pipeline_complete"].evidence
+        self.assertIn("post_act_log_contract", evidence["missing_gate_ids"])
 
     def test_completion_audit_consumes_embedded_verify_pipeline(self) -> None:
         status = complete_status()

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -491,6 +491,20 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         evidence = by_id["verify_pipeline_complete"].evidence
         self.assertIn("post_act_log_contract", evidence["missing_gate_ids"])
 
+    def test_completion_audit_rejects_verify_pipeline_count_mismatch(self) -> None:
+        pipeline = passing_verify_pipeline()
+        pipeline["gates_total"] = 1
+
+        audit = goal_loop_completion_audit.build_completion_audit(
+            complete_status(),
+            verify_pipeline=pipeline,
+        )
+
+        self.assertEqual(audit.status, "BLOCKED")
+        by_id = {item.criterion_id: item for item in audit.criteria}
+        evidence = by_id["verify_pipeline_complete"].evidence
+        self.assertFalse(evidence["counts_match"])
+
     def test_completion_audit_consumes_embedded_verify_pipeline(self) -> None:
         status = complete_status()
         verify_summary = status["phases"]["verify"]["summary"]

--- a/test/test_goal_loop_verify_pipeline.py
+++ b/test/test_goal_loop_verify_pipeline.py
@@ -40,14 +40,17 @@ def passing_metrics() -> dict[str, object]:
 
 class GoalLoopVerifyPipelineTest(unittest.TestCase):
     def test_missing_evidence_blocks_every_prompt_level_gate(self) -> None:
-        report = goal_loop_verify_pipeline.build_pipeline_report(
-            repo_root=REPO_ROOT,
-            metrics_json=None,
-            tla_results=None,
-            log_paths=[],
-            unit_tests_passed=False,
-            unit_tests_failed=False,
-        )
+        with tempfile.TemporaryDirectory() as raw_dir:
+            repo_root = Path(raw_dir)
+            repo_root.joinpath("specs").mkdir()
+            report = goal_loop_verify_pipeline.build_pipeline_report(
+                repo_root=repo_root,
+                metrics_json=None,
+                tla_results=None,
+                log_paths=[],
+                unit_tests_passed=False,
+                unit_tests_failed=False,
+            )
 
         self.assertEqual(report.status, "BLOCKED")
         by_id = {item.gate_id: item for item in report.gates}
@@ -71,6 +74,35 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
         self.assertEqual(by_id["post_act_log_contract"].reason, "missing_post_act_logs")
 
     def test_metric_snapshot_covers_required_production_gates(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            repo_root = Path(raw_dir)
+            repo_root.joinpath("specs").mkdir()
+            report = goal_loop_verify_pipeline.build_pipeline_report(
+                repo_root=repo_root,
+                metrics_json=passing_metrics(),
+                tla_results=None,
+                log_paths=[],
+                unit_tests_passed=True,
+                unit_tests_failed=False,
+            )
+
+        by_id = {item.gate_id: item for item in report.gates}
+        for gate_id in (
+            "keeper_turn_success_rate_healthy",
+            "no_semaphore_skip",
+            "no_pricing_miss",
+            "no_utf8_repair",
+            "recovery_executed",
+            "admission_backpressure_observed",
+            "dashboard_snapshot_latency_p99",
+            "orient_recheck_no_still_present",
+            "orient_recheck_no_new_finding",
+        ):
+            self.assertEqual(by_id[gate_id].status, "PASS", gate_id)
+        self.assertEqual(report.status, "BLOCKED")
+        self.assertEqual(by_id["tla_prompt_spec_tierrouting"].status, "BLOCKED")
+
+    def test_metric_gate_commands_reference_snapshot_metric_keys(self) -> None:
         report = goal_loop_verify_pipeline.build_pipeline_report(
             repo_root=REPO_ROOT,
             metrics_json=passing_metrics(),
@@ -83,17 +115,29 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
         by_id = {item.gate_id: item for item in report.gates}
         for gate_id in (
             "keeper_turn_success_rate_healthy",
+            "no_semaphore_skip",
             "no_pricing_miss",
             "no_utf8_repair",
             "recovery_executed",
-            "admission_backpressure_observed",
             "dashboard_snapshot_latency_p99",
-            "orient_recheck_no_still_present",
-            "orient_recheck_no_new_finding",
         ):
-            self.assertEqual(by_id[gate_id].status, "PASS", gate_id)
-        self.assertEqual(report.status, "BLOCKED")
-        self.assertEqual(by_id["tla_prompt_spec_tierrouting"].status, "BLOCKED")
+            metric_name = by_id[gate_id].evidence["metric_name"]
+            command = " ".join(by_id[gate_id].command or [])
+            self.assertIn(metric_name, command)
+            self.assertNotIn("prometheus query", command)
+            self.assertEqual(
+                by_id[gate_id].evidence["metric_source"],
+                "GOAL_LOOP_METRICS_JSON (--metrics-json)",
+            )
+
+    def test_tla_results_accept_top_level_spec_keys(self) -> None:
+        self.assertEqual(
+            goal_loop_verify_pipeline.tla_result_for(
+                {"TierRouting.tla": "PASS"},
+                "TierRouting.tla",
+            ),
+            "PASS",
+        )
 
     def test_log_contract_fails_on_forbidden_pattern(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:

--- a/test/test_goal_loop_verify_pipeline.py
+++ b/test/test_goal_loop_verify_pipeline.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "goal_loop_verify_pipeline.py"
+
+spec = importlib.util.spec_from_file_location("goal_loop_verify_pipeline", SCRIPT_PATH)
+assert spec is not None
+goal_loop_verify_pipeline = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = goal_loop_verify_pipeline
+spec.loader.exec_module(goal_loop_verify_pipeline)
+
+
+def passing_metrics() -> dict[str, object]:
+    return {
+        "metrics": {
+            "keeper_turn_success_rate": 0.99,
+            "keeper_skipping_turn_rate_5m": 0,
+            "pricing_catalog_miss_total": 0,
+            "persistence_utf8_repair_total": 0,
+            "recovery_strategy_executed_total_1h": 1,
+            "admission_queue_depth": 2,
+            "admission_queue_wait_ms": 0,
+            "dashboard_snapshot_latency_p99": 1.5,
+            "orient_recheck_still_present": 0,
+            "orient_recheck_new_finding": 0,
+        }
+    }
+
+
+class GoalLoopVerifyPipelineTest(unittest.TestCase):
+    def test_missing_evidence_blocks_every_prompt_level_gate(self) -> None:
+        report = goal_loop_verify_pipeline.build_pipeline_report(
+            repo_root=REPO_ROOT,
+            metrics_json=None,
+            tla_results=None,
+            log_paths=[],
+            unit_tests_passed=False,
+            unit_tests_failed=False,
+        )
+
+        self.assertEqual(report.status, "BLOCKED")
+        by_id = {item.gate_id: item for item in report.gates}
+        self.assertEqual(by_id["unit_tests"].status, "SKIPPED")
+        self.assertEqual(
+            by_id["keeper_turn_success_rate_healthy"].reason,
+            "missing_metric_snapshot",
+        )
+        self.assertEqual(
+            by_id["tla_prompt_spec_tierrouting"].reason,
+            "prompt_tla_spec_missing",
+        )
+        self.assertEqual(
+            by_id["tla_prompt_spec_validation"].reason,
+            "prompt_tla_spec_missing",
+        )
+        self.assertEqual(
+            by_id["tla_prompt_spec_liveness"].reason,
+            "prompt_tla_spec_missing",
+        )
+        self.assertEqual(by_id["post_act_log_contract"].reason, "missing_post_act_logs")
+
+    def test_metric_snapshot_covers_required_production_gates(self) -> None:
+        report = goal_loop_verify_pipeline.build_pipeline_report(
+            repo_root=REPO_ROOT,
+            metrics_json=passing_metrics(),
+            tla_results=None,
+            log_paths=[],
+            unit_tests_passed=True,
+            unit_tests_failed=False,
+        )
+
+        by_id = {item.gate_id: item for item in report.gates}
+        for gate_id in (
+            "keeper_turn_success_rate_healthy",
+            "no_pricing_miss",
+            "no_utf8_repair",
+            "recovery_executed",
+            "admission_backpressure_observed",
+            "dashboard_snapshot_latency_p99",
+            "orient_recheck_no_still_present",
+            "orient_recheck_no_new_finding",
+        ):
+            self.assertEqual(by_id[gate_id].status, "PASS", gate_id)
+        self.assertEqual(report.status, "BLOCKED")
+        self.assertEqual(by_id["tla_prompt_spec_tierrouting"].status, "BLOCKED")
+
+    def test_log_contract_fails_on_forbidden_pattern(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            path = Path(raw_dir) / "post-act.log"
+            path.write_text(
+                "\n".join(
+                    [
+                        "recovery_strategy_executed keeper=executor",
+                        "provider_health_probe_completed provider=ollama",
+                        "fallback_ladder_activated keeper=executor",
+                        "[WARN] pricing_catalog_miss model=bad",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            report = goal_loop_verify_pipeline.build_pipeline_report(
+                repo_root=REPO_ROOT,
+                metrics_json=passing_metrics(),
+                tla_results=None,
+                log_paths=[str(path)],
+                unit_tests_passed=True,
+                unit_tests_failed=False,
+            )
+
+        by_id = {item.gate_id: item for item in report.gates}
+        self.assertEqual(by_id["post_act_log_contract"].status, "FAIL")
+        self.assertEqual(by_id["post_act_log_contract"].reason, "log_contract_failed")
+
+    def test_cli_require_pass_returns_nonzero_for_blocked_tla_specs(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            metrics_path = Path(raw_dir) / "metrics.json"
+            metrics_path.write_text(json.dumps(passing_metrics()), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--metrics-json",
+                    str(metrics_path),
+                    "--unit-tests-passed",
+                    "--require-pass",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "BLOCKED")
+        self.assertGreater(payload["gates_blocked"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_goal_loop_verify_pipeline.py
+++ b/test/test_goal_loop_verify_pipeline.py
@@ -130,6 +130,32 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
                 "GOAL_LOOP_METRICS_JSON (--metrics-json)",
             )
 
+    def test_required_gate_id_contract_is_exact(self) -> None:
+        report = goal_loop_verify_pipeline.build_pipeline_report(
+            repo_root=REPO_ROOT,
+            metrics_json=passing_metrics(),
+            tla_results=None,
+            log_paths=[],
+            unit_tests_passed=True,
+            unit_tests_failed=False,
+        )
+
+        self.assertEqual(
+            [item.gate_id for item in report.gates],
+            list(goal_loop_verify_pipeline.REQUIRED_VERIFY_GATE_IDS),
+        )
+
+    def test_prometheus_sources_cover_metric_backed_snapshot_keys(self) -> None:
+        sources = goal_loop_verify_pipeline.PROMETHEUS_METRIC_SOURCES
+        self.assertEqual(
+            sources["persistence_utf8_repair_total"],
+            ["masc_persistence_utf8_repair_total"],
+        )
+        self.assertEqual(
+            sources["dashboard_snapshot_latency_p99"],
+            ["masc_dashboard_snapshot_latency_seconds_bucket"],
+        )
+
     def test_tla_results_accept_top_level_spec_keys(self) -> None:
         self.assertEqual(
             goal_loop_verify_pipeline.tla_result_for(
@@ -190,6 +216,46 @@ class GoalLoopVerifyPipelineTest(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["status"], "BLOCKED")
         self.assertGreater(payload["gates_blocked"], 0)
+
+    def test_emitted_gate_ids_match_required_contract(self) -> None:
+        # Real build path emits exactly the REQUIRED_VERIFY_GATE_IDS set
+        # — no missing, extra, or duplicate gate IDs.
+        with tempfile.TemporaryDirectory() as raw_dir:
+            repo_root = Path(raw_dir)
+            repo_root.joinpath("specs").mkdir()
+            report = goal_loop_verify_pipeline.build_pipeline_report(
+                repo_root=repo_root,
+                metrics_json=None,
+                tla_results=None,
+                log_paths=[],
+                unit_tests_passed=False,
+                unit_tests_failed=False,
+            )
+        emitted = sorted(item.gate_id for item in report.gates)
+        required = sorted(goal_loop_verify_pipeline.REQUIRED_VERIFY_GATE_IDS)
+        self.assertEqual(emitted, required)
+
+    def test_gate_id_contract_assertion_catches_drift(self) -> None:
+        # Contract assertion raises when emitted gate IDs drift from
+        # REQUIRED_VERIFY_GATE_IDS, so future edits cannot silently
+        # rename/drop/duplicate a gate without surfacing it here.
+        VerifyGate = goal_loop_verify_pipeline.VerifyGate
+        bogus = [
+            VerifyGate(
+                gate_id="not_a_required_id",
+                category="x",
+                status="PASS",
+                summary="",
+                command=None,
+                reason=None,
+                evidence={},
+            )
+        ]
+        with self.assertRaises(AssertionError) as ctx:
+            goal_loop_verify_pipeline._assert_emitted_gate_ids_match_required(bogus)
+        message = str(ctx.exception)
+        self.assertIn("missing=", message)
+        self.assertIn("extra=", message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #13610

## Summary

- Add `scripts/goal_loop_verify_pipeline.py`, a strict JSON contract for the prompt-level Verify phase.
- Map unit tests, regression metrics, production metric checks, TLA prompt specs, log verification, and Orient re-check into explicit gate records.
- Treat missing production metrics/logs and missing prompt TLA specs (`TierRouting.tla`, `Validation.tla`, `Liveness.tla`) as `BLOCKED` instead of green.
- Teach `scripts/goal_loop_completion_audit.py` to consume `--verify-pipeline` or embedded `verify_summary.verify_pipeline`, adding `verify_pipeline_complete` as a closeout blocker when any gate is not `PASS`.
- Document the contract in `docs/observability/goal-loop-verify-pipeline.md`.

## Operator Impact

- A generic post-ACT Verify `PASS` can no longer close the GOAL LOOP when the production metric, TLA, log, or Orient re-check gates are partial.
- The current missing prompt TLA assets and production snapshots are visible as blocked gates, preserving the “do not guess” policy.

## Verification

- `ruff format --check scripts/goal_loop_completion_audit.py scripts/goal_loop_verify_pipeline.py test/test_goal_loop_completion_audit.py test/test_goal_loop_verify_pipeline.py`
- `ruff check scripts/goal_loop_completion_audit.py scripts/goal_loop_verify_pipeline.py test/test_goal_loop_completion_audit.py test/test_goal_loop_verify_pipeline.py`
- `python3 -m py_compile scripts/goal_loop_completion_audit.py scripts/goal_loop_verify_pipeline.py test/test_goal_loop_completion_audit.py test/test_goal_loop_verify_pipeline.py`
- `python3 test/test_goal_loop_verify_pipeline.py`
- `python3 test/test_goal_loop_completion_audit.py`
- `python3 scripts/goal_loop_verify_pipeline.py --format text`
- `git diff --check origin/main...HEAD`

Known gap: `pyright` is not installed in this worktree environment.
