### PR TITLE
fix(keeper): allow timeout-budget degraded retries

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -919,8 +919,10 @@ module KeeperRetryBackoff = struct
       degraded retry rotation is rejected (the rotation evidence is
       still recorded in [cascade_rotation_attempts] for audit).  The
       keeper releases the outer slot instead of holding it for a
-      retry that may itself stall.  Floor 5s prevents accidental
-      always-reject configs.
+      retry that may itself stall.  OAS timeout-budget failures may
+      still rotate to the next degraded cascade when retry budget remains,
+      because the first attempt already consumed its bounded provider
+      budget.  Floor 5s prevents accidental always-reject configs.
 
       Declared here (not in keeper_turn_cascade_budget.ml) so the
       env knob catalog generator at bin/env_knob_catalog.ml picks

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -266,6 +266,16 @@ let bounded_oas_timeout_for_turn_budget_with_turn_budget
        ~is_retry:false ~reserve_degraded_retry_budget:false
        ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s)
 
+let allow_wall_clock_retry_budget_for_attempt
+    ~(is_retry : bool)
+    ~(degraded_rotation_first_attempt : bool)
+    ~(attempt : int)
+    ~(attempted_cascades : string list) : bool =
+  is_retry
+  && degraded_rotation_first_attempt
+  && attempt = 1
+  && List.length attempted_cascades > 1
+
 let bounded_oas_timeout_for_turn_budget ~(estimated_input_tokens : int)
     ~(remaining_turn_budget_s : float) : float option =
   bounded_oas_timeout_for_turn_budget_with_turn_budget ~estimated_input_tokens

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -145,6 +145,7 @@ let oas_timeout_budget_resolution_to_yojson
     ]
 
 let resolve_bounded_oas_timeout_budget_with_turn_budget
+    ~(allow_wall_clock_retry_budget : bool)
     ~(is_retry : bool)
     ~(reserve_degraded_retry_budget : bool)
     ~(estimated_input_tokens : int) ~(max_turns : int)
@@ -159,19 +160,36 @@ let resolve_bounded_oas_timeout_budget_with_turn_budget
     let time_spent_in_turn = runtime.turn_timeout_sec.value -. remaining_turn_budget_s in
     let usable_retry_budget = adaptive_timeout_sec -. time_spent_in_turn in
 
-    (* Guard: cascade rotation cannot consume more than 1x per-attempt budget
-       per slot acquisition. If we've already spent more than the adaptive timeout
-       budget in this turn, do not allow further retries. This prevents a retry
-       loop from hogging the slot for the entire outer turn budget when inner
-       OAS attempts timeout early. *)
-    if remaining_turn_budget_s <= 0.0 || usable_retry_budget < min_oas_timeout_budget_sec then None
-    else begin
-      let effective_timeout_sec = usable_retry_budget
-      in
+    (* Guard: same-cascade retries cannot consume more than 1x per-attempt
+       budget per slot acquisition. Degraded cascade rotation can opt into
+       wall-clock retry budget so a first cascade that legitimately spent its
+       OAS timeout budget can still fail open inside the remaining turn time. *)
+    let wall_clock_retry_budget =
+      let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
+      if usable_budget < min_oas_timeout_budget_sec
+      then None
+      else Some (Float.min adaptive_timeout_sec usable_budget)
+    in
+    let retry_budget =
+      if remaining_turn_budget_s <= 0.0 then None
+      else if usable_retry_budget >= min_oas_timeout_budget_sec then
+        Some (usable_retry_budget, false)
+      else if allow_wall_clock_retry_budget then
+        Option.map (fun timeout -> (timeout, true)) wall_clock_retry_budget
+      else None
+    in
+    match retry_budget with
+    | None -> None
+    | Some (effective_timeout_sec, used_wall_clock_retry_budget) ->
       let source =
-        match runtime.oas_timeout_override_sec.value with
-        | Some _ -> "override_per_attempt_retry"
-        | None -> "adaptive_per_attempt_retry"
+        match
+          ( runtime.oas_timeout_override_sec.value,
+            used_wall_clock_retry_budget )
+        with
+        | Some _, true -> "override_wall_clock_retry"
+        | Some _, false -> "override_per_attempt_retry"
+        | None, true -> "adaptive_wall_clock_retry"
+        | None, false -> "adaptive_per_attempt_retry"
       in
       Some
         {
@@ -183,7 +201,6 @@ let resolve_bounded_oas_timeout_budget_with_turn_budget
           max_turns;
           source;
         }
-    end
   end else begin
     let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
     if usable_budget < min_oas_timeout_budget_sec
@@ -245,6 +262,7 @@ let bounded_oas_timeout_for_turn_budget_with_turn_budget
   Option.map
     (fun (budget : oas_timeout_budget_resolution) -> budget.effective_timeout_sec)
     (resolve_bounded_oas_timeout_budget_with_turn_budget
+       ~allow_wall_clock_retry_budget:false
        ~is_retry:false ~reserve_degraded_retry_budget:false
        ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s)
 
@@ -254,11 +272,13 @@ let bounded_oas_timeout_for_turn_budget ~(estimated_input_tokens : int)
     ~max_turns:(Keeper_runtime_resolved.reactive_max_turns_per_call ())
     ~remaining_turn_budget_s
 
-let oas_retry_budget_available_for_turn ~(is_retry : bool)
+let oas_retry_budget_available_for_turn
+    ~(allow_wall_clock_retry_budget : bool) ~(is_retry : bool)
     ~(estimated_input_tokens : int) ~(max_turns : int)
     ~(remaining_turn_budget_s : float) : bool =
   Option.is_some
     (resolve_bounded_oas_timeout_budget_with_turn_budget
+       ~allow_wall_clock_retry_budget
        ~reserve_degraded_retry_budget:false ~is_retry ~estimated_input_tokens
        ~max_turns ~remaining_turn_budget_s)
 
@@ -273,6 +293,12 @@ let degraded_retry_slot_phase_budget_sec =
 
 let degraded_retry_slot_phase_available ~(time_spent_in_turn_s : float) : bool =
   Float.max 0.0 time_spent_in_turn_s < degraded_retry_slot_phase_budget_sec
+
+let degraded_retry_bypasses_slot_phase_guard
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  match Oas_worker_named.classify_masc_internal_error err with
+  | Some (Oas_worker_named.Oas_timeout_budget _) -> true
+  | _ -> false
 
 let reclassify_oas_timeout_for_attempt
     ~(timeout_budget : oas_timeout_budget_resolution option)
@@ -338,11 +364,13 @@ let next_fail_open_cascade_for_turn_with_budget
       if
         match time_spent_in_turn_s with
         | Some time_spent_in_turn_s ->
-            not (degraded_retry_slot_phase_available ~time_spent_in_turn_s)
+            (not (degraded_retry_slot_phase_available ~time_spent_in_turn_s))
+            && not (degraded_retry_bypasses_slot_phase_guard err)
         | None -> false
       then Degraded_retry_slot_phase_exhausted retry
       else if
         oas_retry_budget_available_for_turn
+          ~allow_wall_clock_retry_budget:true
           ~is_retry:true ~estimated_input_tokens ~max_turns
           ~remaining_turn_budget_s
       then Degraded_retry_allowed retry

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -72,6 +72,13 @@ val resolve_bounded_oas_timeout_budget_with_turn_budget :
   remaining_turn_budget_s:float ->
   oas_timeout_budget_resolution option
 
+val allow_wall_clock_retry_budget_for_attempt :
+  is_retry:bool ->
+  degraded_rotation_first_attempt:bool ->
+  attempt:int ->
+  attempted_cascades:string list ->
+  bool
+
 val bounded_oas_timeout_for_turn_budget_with_turn_budget :
   estimated_input_tokens:int ->
   max_turns:int ->

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -64,6 +64,7 @@ val oas_timeout_budget_resolution_to_yojson :
   oas_timeout_budget_resolution -> Yojson.Safe.t
 
 val resolve_bounded_oas_timeout_budget_with_turn_budget :
+  allow_wall_clock_retry_budget:bool ->
   is_retry:bool ->
   reserve_degraded_retry_budget:bool ->
   estimated_input_tokens:int ->
@@ -83,6 +84,7 @@ val bounded_oas_timeout_for_turn_budget :
   float option
 
 val oas_retry_budget_available_for_turn :
+  allow_wall_clock_retry_budget:bool ->
   is_retry:bool ->
   estimated_input_tokens:int ->
   max_turns:int ->
@@ -94,7 +96,9 @@ val degraded_retry_slot_phase_budget_sec : float
     suppressed. This is a guardrail for #12888: once the productive
     phase has already consumed this much wall clock, rotation should end
     the cycle instead of holding the same slot for another provider
-    attempt. *)
+    attempt. OAS timeout-budget failures may still rotate to the next
+    degraded cascade when retry budget remains, because the failed attempt
+    already represents the budgeted provider wait. *)
 
 val degraded_retry_slot_phase_available :
   time_spent_in_turn_s:float -> bool

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1072,6 +1072,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               in
               match
                 resolve_bounded_oas_timeout_budget_with_turn_budget
+                  ~allow_wall_clock_retry_budget:
+                    (is_retry && List.length attempted_cascades > 1)
                   ~is_retry
                   ~reserve_degraded_retry_budget
                   ~max_turns

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1000,6 +1000,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let rec retry_loop ~run_meta ~(execution : cascade_execution)
               ~run_generation
               ~attempt ~is_retry
+              ~allow_degraded_wall_clock_retry_budget
               ~overflow_retry_used
               ~attempted_cascades =
             let execution_cascade_name =
@@ -1070,10 +1071,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     not (String.equal fallback_cascade execution_cascade_name)
                 | None -> false
               in
+              let allow_wall_clock_retry_budget =
+                allow_wall_clock_retry_budget_for_attempt
+                  ~is_retry
+                  ~degraded_rotation_first_attempt:allow_degraded_wall_clock_retry_budget
+                  ~attempt
+                  ~attempted_cascades
+              in
               match
                 resolve_bounded_oas_timeout_budget_with_turn_budget
-                  ~allow_wall_clock_retry_budget:
-                    (is_retry && List.length attempted_cascades > 1)
+                  ~allow_wall_clock_retry_budget
                   ~is_retry
                   ~reserve_degraded_retry_budget
                   ~max_turns
@@ -1348,6 +1355,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                               ~run_generation
                               ~attempt:1
                               ~is_retry:true
+                              ~allow_degraded_wall_clock_retry_budget:true
                               ~overflow_retry_used
                               ~attempted_cascades:
                                 (next_execution_cascade_name :: attempted_cascades)
@@ -1464,7 +1472,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                       Eio.Time.sleep clock delay;
                       retry_loop ~run_meta ~execution ~run_generation
                         ~attempt:(attempt + 1)
-                        ~is_retry:true ~overflow_retry_used
+                        ~is_retry:true
+                        ~allow_degraded_wall_clock_retry_budget:false
+                        ~overflow_retry_used
                         ~attempted_cascades
                   | No_degraded_retry when EC.is_context_overflow err ->
                   let current_turn_event_bus =
@@ -1531,6 +1541,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                           ~run_generation:retry_plan.retry_generation
                           ~attempt:1
                           ~is_retry:true
+                          ~allow_degraded_wall_clock_retry_budget:false
                           ~overflow_retry_used:true
                           ~attempted_cascades
                     | None ->
@@ -1562,7 +1573,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               (fun () ->
                 retry_loop ~run_meta:meta ~execution:initial_execution
                   ~run_generation:generation ~attempt:1
-                  ~is_retry:false ~overflow_retry_used:false
+                  ~is_retry:false
+                  ~allow_degraded_wall_clock_retry_budget:false
+                  ~overflow_retry_used:false
                   ~attempted_cascades:
                     [ KCP.runtime_name_to_string initial_execution.cascade_name ])
           with Eio.Time.Timeout ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -50,6 +50,7 @@ type oas_timeout_budget_resolution = {
 }
 
 val resolve_bounded_oas_timeout_budget_with_turn_budget :
+  allow_wall_clock_retry_budget:bool ->
   is_retry:bool ->
   reserve_degraded_retry_budget:bool ->
   estimated_input_tokens:int ->
@@ -64,6 +65,7 @@ val attempt_watchdog_timeout_sec :
   remaining_turn_budget_s:float -> oas_timeout_budget_resolution -> float
 
 val oas_retry_budget_available_for_turn :
+  allow_wall_clock_retry_budget:bool ->
   is_retry:bool ->
   estimated_input_tokens:int ->
   max_turns:int ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -64,6 +64,13 @@ val resolve_bounded_oas_timeout_budget_with_turn_budget :
 val attempt_watchdog_timeout_sec :
   remaining_turn_budget_s:float -> oas_timeout_budget_resolution -> float
 
+val allow_wall_clock_retry_budget_for_attempt :
+  is_retry:bool ->
+  degraded_rotation_first_attempt:bool ->
+  attempt:int ->
+  attempted_cascades:string list ->
+  bool
+
 val oas_retry_budget_available_for_turn :
   allow_wall_clock_retry_budget:bool ->
   is_retry:bool ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5619,6 +5619,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
 let test_bounded_oas_timeout_reserves_degraded_retry_budget () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
       ~is_retry:false ~reserve_degraded_retry_budget:true
       ~estimated_input_tokens:2_000 ~max_turns:4
       ~remaining_turn_budget_s:500.0
@@ -5681,6 +5682,7 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
   in
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
       ~is_retry:false ~reserve_degraded_retry_budget:false
       ~estimated_input_tokens:2_000 ~max_turns:4
       ~remaining_turn_budget_s:1200.0
@@ -5772,7 +5774,7 @@ let test_degraded_retry_budget_gate_blocks_exhausted_budget () =
   | UT.Degraded_retry_allowed _ -> fail "expected exhausted retry budget"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
 
-let test_degraded_retry_slot_phase_blocks_late_rotation () =
+let test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery () =
   match
     UT.next_fail_open_cascade_for_turn_with_budget
       ~base_cascade:"underdog"
@@ -5782,16 +5784,40 @@ let test_degraded_retry_slot_phase_blocks_late_rotation () =
       ~estimated_input_tokens:2_000
       ~max_turns:4
       ~time_spent_in_turn_s:(UT.degraded_retry_slot_phase_budget_sec +. 1.0)
-      ~remaining_turn_budget_s:1200.0
+      ~remaining_turn_budget_s:300.0
       (oas_timeout_budget_error ())
   with
-  | UT.Degraded_retry_slot_phase_exhausted retry ->
+  | UT.Degraded_retry_allowed retry ->
       check string "retry cascade candidate" KC.local_recovery_cascade_name
         retry.next_cascade;
       check string "fallback reason" "oas_timeout_budget"
         retry.fallback_reason
+  | UT.Degraded_retry_slot_phase_exhausted _ ->
+      fail "expected OAS timeout budget to bypass slot phase for local recovery"
+  | UT.Degraded_retry_budget_exhausted _ ->
+      fail "expected retry budget to remain"
+  | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
+
+let test_degraded_retry_slot_phase_blocks_contract_rotation () =
+  match
+    UT.next_fail_open_cascade_for_turn_with_budget
+      ~base_cascade:KC.default_cascade_name
+      ~effective_cascade:"strict_exec"
+      ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
+      ~attempted_cascades:[ "strict_exec" ]
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
+      ~time_spent_in_turn_s:(UT.degraded_retry_slot_phase_budget_sec +. 1.0)
+      ~remaining_turn_budget_s:1200.0
+      (required_tool_contract_violation_error ())
+  with
+  | UT.Degraded_retry_slot_phase_exhausted retry ->
+      check string "retry cascade candidate" KC.default_cascade_name
+        retry.next_cascade;
+      check string "fallback reason" "required_tool_contract_violation"
+        retry.fallback_reason
   | UT.Degraded_retry_allowed _ ->
-      fail "expected degraded retry blocked after productive slot phase"
+      fail "expected contract rotation blocked after productive slot phase"
   | UT.Degraded_retry_budget_exhausted _ ->
       fail "expected slot phase exhaustion before retry budget exhaustion"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
@@ -5804,6 +5830,7 @@ let test_degraded_retry_slot_phase_blocks_late_rotation () =
 let test_per_attempt_retry_budget_with_near_zero_remaining () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
       ~is_retry:true
       ~reserve_degraded_retry_budget:false
       ~estimated_input_tokens:2_000
@@ -5811,11 +5838,15 @@ let test_per_attempt_retry_budget_with_near_zero_remaining () =
       ~remaining_turn_budget_s:3.0
   with
   | None -> () (* expected: retry is aborted to release the slot cleanly *)
-  | Some _ -> fail "is_retry=true must refuse budget when outer turn time spent exceeds per-attempt cap"
+  | Some _ ->
+      fail
+        "is_retry=true must refuse budget when outer turn time spent exceeds \
+         per-attempt cap"
 
 let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
       ~is_retry:true
       ~reserve_degraded_retry_budget:false
       ~estimated_input_tokens:2_000
@@ -5827,9 +5858,41 @@ let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
       check bool "effective capped by min(adaptive, remaining)" true
         (budget.effective_timeout_sec <= 1200.0)
 
+let test_per_attempt_retry_blocks_after_adaptive_budget_spent () =
+  match
+    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
+      ~is_retry:true
+      ~reserve_degraded_retry_budget:false
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
+      ~remaining_turn_budget_s:300.0
+  with
+  | None -> ()
+  | Some _ ->
+      fail "plain retry should refuse once the adaptive budget was already spent"
+
+let test_degraded_retry_wall_clock_budget_allows_remaining_turn_time () =
+  match
+    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:true
+      ~is_retry:true
+      ~reserve_degraded_retry_budget:false
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
+      ~remaining_turn_budget_s:300.0
+  with
+  | None -> fail "degraded retry should use remaining wall-clock budget"
+  | Some budget ->
+      check string "source marks wall-clock retry"
+        "adaptive_wall_clock_retry" budget.source;
+      check (float 0.01) "wall-clock retry leaves finalization guard"
+        285.0 budget.effective_timeout_sec
+
 let test_non_retry_still_refuses_tiny_budget () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~reserve_degraded_retry_budget:false
       ~estimated_input_tokens:2_000
@@ -5845,6 +5908,7 @@ let test_per_attempt_retry_refuses_zero_remaining () =
      cancelled by the outer turn timeout — resolver must return None. *)
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
       ~is_retry:true
       ~reserve_degraded_retry_budget:false
       ~estimated_input_tokens:2_000
@@ -7942,12 +8006,18 @@ let () =
             test_degraded_retry_budget_gate_allows_remaining_budget;
           test_case "degraded retry is blocked when turn budget is exhausted" `Quick
             test_degraded_retry_budget_gate_blocks_exhausted_budget;
-          test_case "degraded retry is blocked after productive slot phase (#12888)" `Quick
-            test_degraded_retry_slot_phase_blocks_late_rotation;
+          test_case "OAS timeout budget can still rotate to local recovery after slot phase" `Quick
+            test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery;
+          test_case "contract retry is blocked after productive slot phase (#12888)" `Quick
+            test_degraded_retry_slot_phase_blocks_contract_rotation;
           test_case "per-attempt retry budget with near-zero remaining (#12675)" `Quick
             test_per_attempt_retry_budget_with_near_zero_remaining;
           test_case "per-attempt retry budget capped by healthy remaining" `Quick
             test_per_attempt_retry_budget_capped_by_remaining_when_healthy;
+          test_case "plain retry blocks after adaptive budget is spent" `Quick
+            test_per_attempt_retry_blocks_after_adaptive_budget_spent;
+          test_case "degraded retry can use remaining wall-clock budget" `Quick
+            test_degraded_retry_wall_clock_budget_allows_remaining_turn_time;
           test_case "non-retry still refuses tiny budget" `Quick
             test_non_retry_still_refuses_tiny_budget;
           test_case "per-attempt retry refuses zero remaining (#12675)" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5638,6 +5638,7 @@ let test_bounded_oas_timeout_reserves_degraded_retry_budget () =
 let test_attempt_watchdog_preserves_degraded_retry_reserve () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
       ~is_retry:false ~reserve_degraded_retry_budget:true
       ~estimated_input_tokens:2_000 ~max_turns:4
       ~remaining_turn_budget_s:500.0
@@ -5888,6 +5889,28 @@ let test_degraded_retry_wall_clock_budget_allows_remaining_turn_time () =
         "adaptive_wall_clock_retry" budget.source;
       check (float 0.01) "wall-clock retry leaves finalization guard"
         285.0 budget.effective_timeout_sec
+
+let test_degraded_retry_wall_clock_budget_gate_is_one_shot () =
+  let allowed ~degraded_rotation_first_attempt ~attempt ~attempted_cascades =
+    UT.allow_wall_clock_retry_budget_for_attempt
+      ~is_retry:true
+      ~degraded_rotation_first_attempt
+      ~attempt
+      ~attempted_cascades
+  in
+  let rotated_cascades = [ "local_recovery"; "underdog" ] in
+  check bool "first degraded rotation attempt may use wall clock" true
+    (allowed ~degraded_rotation_first_attempt:true ~attempt:1
+       ~attempted_cascades:rotated_cascades);
+  check bool "same-cascade retry after rotation uses per-attempt budget" false
+    (allowed ~degraded_rotation_first_attempt:false ~attempt:2
+       ~attempted_cascades:rotated_cascades);
+  check bool "attempt counter still blocks later retries" false
+    (allowed ~degraded_rotation_first_attempt:true ~attempt:2
+       ~attempted_cascades:rotated_cascades);
+  check bool "non-rotated retry cannot use wall clock" false
+    (allowed ~degraded_rotation_first_attempt:true ~attempt:1
+       ~attempted_cascades:[ "underdog" ])
 
 let test_non_retry_still_refuses_tiny_budget () =
   match
@@ -8018,6 +8041,8 @@ let () =
             test_per_attempt_retry_blocks_after_adaptive_budget_spent;
           test_case "degraded retry can use remaining wall-clock budget" `Quick
             test_degraded_retry_wall_clock_budget_allows_remaining_turn_time;
+          test_case "degraded retry wall-clock budget is one-shot" `Quick
+            test_degraded_retry_wall_clock_budget_gate_is_one_shot;
           test_case "non-retry still refuses tiny budget" `Quick
             test_non_retry_still_refuses_tiny_budget;
           test_case "per-attempt retry refuses zero remaining (#12675)" `Quick


### PR DESCRIPTION
## Summary
- allow OAS timeout-budget failures to rotate to the next degraded cascade even after the productive slot-phase guard has elapsed
- let degraded retry attempts use remaining wall-clock turn budget when the first cascade already consumed its adaptive OAS timeout budget
- keep plain same-cascade retries capped by the existing per-attempt guard
- fix a current bg-task PID sidecar parse compile regression hit while rebuilding this target

## Live evidence
- /Users/dancer/me/.masc/keepers/taskmaster.decisions.jsonl showed latest turn ending with terminal_reason.code=oas_timeout_budget, selected_model=null, tools_used=[], degraded_retry_applied=false
- /Users/dancer/me/.masc/keepers/executor.decisions.jsonl showed the same oas_timeout_budget terminal path with a retry-reserved source but no degraded retry applied
- These are whole-cascade budget failures before any committed tool side effect, so they should fail open to the next cascade instead of ending the keeper cycle silently

## Verification
- git diff --check
- MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe (332 tests)
- MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build lib/process/masc_process.cmxa