### PR TITLE
fix(dashboard): expose copy id button metadata

### DIFF
--- a/dashboard/src/components/common/copy-id-button.a11y.test.ts
+++ b/dashboard/src/components/common/copy-id-button.a11y.test.ts
@@ -25,6 +25,7 @@ describe('CopyIdButton a11y', () => {
     render(html`<${CopyIdButton} value="abc-123" />`, container)
     const btn = container.querySelector('button')!
     expect(btn.getAttribute('aria-label')).toBe('복사')
+    expect(btn.getAttribute('data-copy-id-state')).toBe('idle')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -32,6 +33,7 @@ describe('CopyIdButton a11y', () => {
     render(html`<${CopyIdButton} value="abc-123" label="Session ID" />`, container)
     const btn = container.querySelector('button')!
     expect(btn.getAttribute('aria-label')).toBe('Session ID 복사')
+    expect(btn.getAttribute('data-copy-id-has-label')).toBe('true')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -42,6 +44,7 @@ describe('CopyIdButton a11y', () => {
     )
     const btn = container.querySelector('button')!
     expect(btn.getAttribute('aria-label')).toBe('Copy session id')
+    expect(btn.getAttribute('data-copy-id-has-explicit-aria-label')).toBe('true')
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/common/copy-id-button.test.ts
+++ b/dashboard/src/components/common/copy-id-button.test.ts
@@ -19,7 +19,7 @@ const flushUi = async () => {
   for (let i = 0; i < 5; i++) await Promise.resolve()
 }
 
-describe('copyToClipboard', () => {
+describe('copy id button and clipboard helpers', () => {
   const realClipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
   const realExec: ExecCommandFn | undefined = doc.execCommand
   const mounted: HTMLElement[] = []
@@ -81,6 +81,16 @@ describe('copyToClipboard', () => {
       valueLength: 7,
       ariaLabel: 'Session ID 복사',
     })
+  })
+
+  it('summarizes copy button metadata with the component default size', () => {
+    expect(
+      summarizeCopyIdButton({
+        value: 'abc-123',
+        label: 'Session ID',
+        copied: false,
+      }).size,
+    ).toBe(13)
   })
 
   it('renders stable summary hooks on the icon-only button', () => {

--- a/dashboard/src/components/common/copy-id-button.test.ts
+++ b/dashboard/src/components/common/copy-id-button.test.ts
@@ -1,19 +1,35 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi, afterEach } from 'vitest'
+import { h, render } from 'preact'
 import { copyToClipboard } from './copyable-code'
+import {
+  CopyIdButton,
+  copyIdButtonAriaLabel,
+  summarizeCopyIdButton,
+} from './copy-id-button'
+import { _testGetToasts, _testResetToasts } from './toast'
 
 // happy-dom does not expose `document.execCommand` by default. Assign/delete
 // directly rather than spying on an undefined property.
 
 type ExecCommandFn = (cmd: string) => boolean
-// Loose-type escape hatch — `Document.execCommand` is declared non-optional
-// in lib.dom.d.ts, but happy-dom omits it, so we need to both assign and
-// delete the property through a typed-any reference.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const doc = document as any
+type HappyDomDocument = { execCommand?: ExecCommandFn }
+const doc = document as unknown as HappyDomDocument
+const flushUi = async () => {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
 
 describe('copyToClipboard', () => {
   const realClipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
   const realExec: ExecCommandFn | undefined = doc.execCommand
+  const mounted: HTMLElement[] = []
+
+  function renderCopyButton(props: Parameters<typeof CopyIdButton>[0]): HTMLElement {
+    const container = document.createElement('div')
+    mounted.push(container)
+    render(h(CopyIdButton, props), container)
+    return container
+  }
 
   function setClipboard(value: { writeText: (t: string) => Promise<void> } | undefined): void {
     Object.defineProperty(navigator, 'clipboard', {
@@ -32,9 +48,72 @@ describe('copyToClipboard', () => {
   }
 
   afterEach(() => {
+    for (const container of mounted.splice(0)) {
+      render(null, container)
+      container.remove()
+    }
     setClipboard(realClipboard as unknown as { writeText: (t: string) => Promise<void> } | undefined)
     setExec(realExec)
+    _testResetToasts()
     vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('derives accessible labels through the same fallback chain as the component', () => {
+    expect(copyIdButtonAriaLabel()).toBe('복사')
+    expect(copyIdButtonAriaLabel('Session ID')).toBe('Session ID 복사')
+    expect(copyIdButtonAriaLabel('Session ID', 'Copy session')).toBe('Copy session')
+  })
+
+  it('summarizes copy button metadata without reading the DOM', () => {
+    expect(
+      summarizeCopyIdButton({
+        value: 'abc-123',
+        label: 'Session ID',
+        size: 14,
+        copied: true,
+      }),
+    ).toEqual({
+      state: 'copied',
+      hasLabel: true,
+      hasExplicitAriaLabel: false,
+      size: 14,
+      valueLength: 7,
+      ariaLabel: 'Session ID 복사',
+    })
+  })
+
+  it('renders stable summary hooks on the icon-only button', () => {
+    const container = renderCopyButton({ value: 'abc-123', label: 'Session ID', size: 14 })
+    const button = container.querySelector('[data-copy-id-button]')!
+    expect(button.getAttribute('data-copy-id-state')).toBe('idle')
+    expect(button.getAttribute('data-copy-id-has-label')).toBe('true')
+    expect(button.getAttribute('data-copy-id-has-explicit-aria-label')).toBe('false')
+    expect(button.getAttribute('data-copy-id-size')).toBe('14')
+    expect(button.getAttribute('data-copy-id-value-length')).toBe('7')
+    expect(button.getAttribute('aria-label')).toBe('Session ID 복사')
+    expect(button.className).toContain('size-6')
+    expect(button.className).toContain('rounded-[var(--r-0)]')
+    expect(container.querySelector('[data-copy-id-icon]')).toBeTruthy()
+  })
+
+  it('flips copied metadata and emits a success toast after a successful click', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn(async () => {})
+    setClipboard({ writeText })
+    const container = renderCopyButton({ value: 'abc-123', label: 'Session ID' })
+    const button = container.querySelector('[data-copy-id-button]') as HTMLButtonElement
+
+    button.click()
+    await flushUi()
+
+    expect(writeText).toHaveBeenCalledWith('abc-123')
+    expect(button.getAttribute('data-copy-id-state')).toBe('copied')
+    expect(button.getAttribute('data-copied')).toBe('true')
+    expect(_testGetToasts()).toContainEqual(
+      expect.objectContaining({ message: '복사됨: Session ID', type: 'success' }),
+    )
+    vi.runOnlyPendingTimers()
   })
 
   it('uses navigator.clipboard.writeText when available and returns true on success', async () => {

--- a/dashboard/src/components/common/copy-id-button.ts
+++ b/dashboard/src/components/common/copy-id-button.ts
@@ -11,6 +11,8 @@ import { copyToClipboard } from './copyable-code'
 
 export type CopyIdButtonState = 'idle' | 'copied'
 
+const DEFAULT_COPY_ID_BUTTON_ICON_SIZE = 13
+
 export interface CopyIdButtonSummary {
   state: CopyIdButtonState
   hasLabel: boolean
@@ -35,15 +37,9 @@ export function summarizeCopyIdButton({
   value,
   label,
   ariaLabel,
-  size,
+  size = DEFAULT_COPY_ID_BUTTON_ICON_SIZE,
   copied,
-}: {
-  value: string
-  label?: string
-  ariaLabel?: string
-  size: number
-  copied: boolean
-}): CopyIdButtonSummary {
+}: CopyIdButtonProps & { copied: boolean }): CopyIdButtonSummary {
   return {
     state: copied ? 'copied' : 'idle',
     hasLabel: label !== undefined && label !== '',
@@ -54,7 +50,12 @@ export function summarizeCopyIdButton({
   }
 }
 
-export function CopyIdButton({ value, label, ariaLabel, size = 13 }: CopyIdButtonProps) {
+export function CopyIdButton({
+  value,
+  label,
+  ariaLabel,
+  size = DEFAULT_COPY_ID_BUTTON_ICON_SIZE,
+}: CopyIdButtonProps) {
   const [justCopied, setJustCopied] = useState(false)
   const summary = summarizeCopyIdButton({ value, label, ariaLabel, size, copied: justCopied })
 

--- a/dashboard/src/components/common/copy-id-button.ts
+++ b/dashboard/src/components/common/copy-id-button.ts
@@ -9,15 +9,54 @@ import { ringFocusClasses } from './ring'
 import { showToast } from './toast'
 import { copyToClipboard } from './copyable-code'
 
-interface CopyIdButtonProps {
+export type CopyIdButtonState = 'idle' | 'copied'
+
+export interface CopyIdButtonSummary {
+  state: CopyIdButtonState
+  hasLabel: boolean
+  hasExplicitAriaLabel: boolean
+  size: number
+  valueLength: number
+  ariaLabel: string
+}
+
+export interface CopyIdButtonProps {
   value: string
   label?: string
   ariaLabel?: string
   size?: number
 }
 
-export function CopyIdButton({ value, label, ariaLabel, size = 12 }: CopyIdButtonProps) {
+export function copyIdButtonAriaLabel(label?: string, ariaLabel?: string): string {
+  return ariaLabel || (label ? `${label} 복사` : '복사')
+}
+
+export function summarizeCopyIdButton({
+  value,
+  label,
+  ariaLabel,
+  size,
+  copied,
+}: {
+  value: string
+  label?: string
+  ariaLabel?: string
+  size: number
+  copied: boolean
+}): CopyIdButtonSummary {
+  return {
+    state: copied ? 'copied' : 'idle',
+    hasLabel: label !== undefined && label !== '',
+    hasExplicitAriaLabel: ariaLabel !== undefined && ariaLabel !== '',
+    size,
+    valueLength: value.length,
+    ariaLabel: copyIdButtonAriaLabel(label, ariaLabel),
+  }
+}
+
+export function CopyIdButton({ value, label, ariaLabel, size = 13 }: CopyIdButtonProps) {
   const [justCopied, setJustCopied] = useState(false)
+  const summary = summarizeCopyIdButton({ value, label, ariaLabel, size, copied: justCopied })
 
   const onCopy = async (e: MouseEvent) => {
     e.stopPropagation()
@@ -34,12 +73,21 @@ export function CopyIdButton({ value, label, ariaLabel, size = 12 }: CopyIdButto
   return html`
     <button
       type="button"
-      class=${`inline-flex shrink-0 cursor-pointer items-center justify-center rounded-[var(--r-1)] min-w-6 min-h-6 p-1.5 text-[var(--color-fg-disabled)] opacity-60 transition-[background-color,color,opacity] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] hover:opacity-100 focus-visible:opacity-100 ${ringFocusClasses({ tone: 'accent-subtle', width: 1 })}`}
-      aria-label=${ariaLabel || (label ? `${label} 복사` : '복사')}
-      title=${ariaLabel || (label ? `${label} 복사` : '복사')}
+      class=${`inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-[var(--r-0)] border border-transparent text-[var(--color-fg-muted)] opacity-75 transition-[background-color,border-color,color,opacity] hover:border-[var(--color-border-subtle)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] hover:opacity-100 focus-visible:opacity-100 ${ringFocusClasses({ tone: 'accent-subtle', width: 1 })}`}
+      aria-label=${summary.ariaLabel}
+      title=${summary.ariaLabel}
       onClick=${onCopy}
+      data-copy-id-button
+      data-copy-id-state=${summary.state}
+      data-copy-id-has-label=${summary.hasLabel}
+      data-copy-id-has-explicit-aria-label=${summary.hasExplicitAriaLabel}
+      data-copy-id-size=${summary.size}
+      data-copy-id-value-length=${summary.valueLength}
+      data-copied=${justCopied ? 'true' : 'false'}
     >
-      ${justCopied ? html`<${Check} size=${size} />` : html`<${Copy} size=${size} />`}
+      ${justCopied
+        ? html`<${Check} size=${size} strokeWidth=${2.25} aria-hidden="true" data-copy-id-icon />`
+        : html`<${Copy} size=${size} strokeWidth=${2.25} aria-hidden="true" data-copy-id-icon />`}
     </button>
   `
 }


### PR DESCRIPTION
## Summary
- Export CopyIdButton summary and aria-label helpers for deterministic copy-control state.
- Add data-copy-id-* hooks for idle/copied state, label/aria ownership, icon size, and value length.
- Tighten the icon-only button to a stable 24px r-0 target with stronger idle contrast and aria-hidden lucide glyphs.
- Remove the typed-any lint escape hatch in copy-id-button tests and add click-state coverage.

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/copy-id-button.test.ts src/components/common/copy-id-button.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- Browser QA via Vite desktop/mobile: /tmp/masc-copy-id-button-summary-0506.png, /tmp/masc-copy-id-button-summary-0506-mobile.png

## Notes
- Lint now reports only existing virtual-list/fsm-hub warnings; the previous copy-id-button.test typed-any warning is gone.
- Build warnings are existing Vite dynamic/static import and chunk-size warnings.