### PR TITLE
fix(process): parse bg task pid sidecar ints

### DIFF
--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -402,7 +402,7 @@ let read_pid_file path =
       let pid_line = input_line_opt ic in
       let pgid_line = input_line_opt ic in
       let parse_int line =
-        line |> Option.map String.trim |> Option.bind int_of_string_opt
+        Option.bind (Option.map String.trim line) Stdlib.int_of_string_opt
       in
       match parse_int pid_line, parse_int pgid_line with
       | Some pid, Some pgid -> Some (pid, pgid)


### PR DESCRIPTION
## Summary
- Fix `Bg_task.read_pid_file` integer parsing so `Option.bind` receives the option argument first.
- Unblocks focused OCaml builds that currently fail on `lib/process/bg_task.ml:405`.

## Root Cause
The pipeline form partially applied `Option.bind` with `int_of_string_opt` as the first argument. `Option.bind` expects the option first, so the compiler rejected the call before downstream keeper tests could build.

Closes #13656.

## Verification
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_bg_task_parse_latest2 scripts/dune-local.sh build lib/process/masc_process.cmxa`
- `git diff --check HEAD~1..HEAD`

Note: `test/test_bg_task_stub.exe` build was started but stopped because this host currently has several concurrent Dune jobs; CI should be the heavier verification surface.
