### PR TITLE
feat(goal-loop): add anti-stagnation SLA state

### DIFF
--- a/docs/observability/goal-loop-anti-stagnation.md
+++ b/docs/observability/goal-loop-anti-stagnation.md
@@ -1,0 +1,53 @@
+# GOAL LOOP Anti-Stagnation SLA
+
+`scripts/goal_loop_anti_stagnation.py` evaluates per-finding lifecycle state
+against the prompt anti-stagnation rules. It produces machine-readable JSON so
+status/dashboard consumers do not need to infer escalation state from prose.
+
+## Input Shape
+
+The input JSON is a finding lifecycle snapshot:
+
+```json
+{
+  "findings": [
+    {
+      "finding_id": "NF-2",
+      "status": "STILL_PRESENT",
+      "first_seen_at": "2026-05-05T00:00:00Z",
+      "act": {
+        "ref": "PR#13050",
+        "created_at": "2026-05-05T06:00:00Z",
+        "merged_at": "2026-05-06T00:00:00Z",
+        "repair_ref": "PR#13060",
+        "rollback_ref": null
+      },
+      "verify": {
+        "status": "FAIL",
+        "checked_at": "2026-05-06T03:00:00Z",
+        "failed_at": "2026-05-06T03:00:00Z"
+      },
+      "escalation": {
+        "recorded": false
+      }
+    }
+  ]
+}
+```
+
+## Rules
+
+- `still_present_requires_act`: `STILL_PRESENT` or `PARTIALLY_FIXED` findings
+  must carry an ACT reference.
+- `act_creation_deadline_missed`: an ACT must be created within 48 hours of
+  first detection.
+- `verify_after_merge_deadline_missed`: merged ACT work must have Verify
+  evidence within 24 hours.
+- `verify_fail_repair_deadline_missed`: failed Verify needs a repair PR or
+  rollback reference within 4 hours.
+- `week_old_escalation_required`: findings still present for more than one week
+  must have an escalation record.
+
+`scripts/goal_loop_status.py --anti-stagnation-json <report.json>` exposes the
+summary under `phases.act.summary.anti_stagnation` and
+`system_health_signals.anti_stagnation`.

--- a/docs/observability/goal-loop-anti-stagnation.md
+++ b/docs/observability/goal-loop-anti-stagnation.md
@@ -20,6 +20,7 @@ The input JSON is a finding lifecycle snapshot:
         "created_at": "2026-05-05T06:00:00Z",
         "merged_at": "2026-05-06T00:00:00Z",
         "repair_ref": "PR#13060",
+        "repair_created_at": "2026-05-06T05:00:00Z",
         "rollback_ref": null
       },
       "verify": {
@@ -44,7 +45,8 @@ The input JSON is a finding lifecycle snapshot:
 - `verify_after_merge_deadline_missed`: merged ACT work must have Verify
   evidence within 24 hours.
 - `verify_fail_repair_deadline_missed`: failed Verify needs a repair PR or
-  rollback reference within 4 hours.
+  rollback reference with `repair_created_at` or `rollback_created_at` within
+  4 hours. A bare reference without a timestamp does not prove the SLA.
 - `week_old_escalation_required`: findings still present for more than one week
   must have an escalation record.
 

--- a/scripts/goal_loop_anti_stagnation.py
+++ b/scripts/goal_loop_anti_stagnation.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Evaluate GOAL LOOP anti-stagnation SLA state.
+
+The input is a machine-readable finding lifecycle snapshot. The output is a
+deterministic report that makes missing ACT references, stale ACT creation,
+missing post-merge Verify, failed Verify repair gaps, and week-old escalation
+requirements visible to status/dashboard consumers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+STILL_PRESENT_STATUSES = {"STILL_PRESENT", "PARTIALLY_FIXED"}
+ACT_CREATION_DEADLINE_HOURS = 48.0
+VERIFY_AFTER_MERGE_DEADLINE_HOURS = 24.0
+VERIFY_FAIL_REPAIR_DEADLINE_HOURS = 4.0
+WEEK_OLD_ESCALATION_HOURS = 24.0 * 7.0
+
+
+@dataclass(frozen=True)
+class StagnationViolation:
+    finding_id: str
+    rule_id: str
+    severity: str
+    message: str
+    age_hours: float | None
+    deadline_hours: float
+    evidence: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StagnationFinding:
+    finding_id: str
+    status: str
+    age_hours: float | None
+    act_ref: str | None
+    act_created_at: str | None
+    act_merged_at: str | None
+    verify_status: str | None
+    verify_checked_at: str | None
+    verify_failed_at: str | None
+    escalated: bool
+    violations: list[StagnationViolation]
+
+
+@dataclass(frozen=True)
+class StagnationReport:
+    schema_version: int
+    status: str
+    checked_at: str
+    findings_total: int
+    still_present_total: int
+    violations_total: int
+    escalations_required: int
+    findings: list[StagnationFinding]
+    violations: list[StagnationViolation]
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def iso_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def age_hours(now: datetime, timestamp: datetime | None) -> float | None:
+    if timestamp is None:
+        return None
+    return round(max((now - timestamp).total_seconds(), 0.0) / 3600.0, 3)
+
+
+def load_json(path: str) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def raw_findings(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = snapshot.get("findings")
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    raw = snapshot.get("items")
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    return []
+
+
+def string_field(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def bool_field(value: Any) -> bool:
+    return value is True
+
+
+def nested_object(raw: dict[str, Any], key: str) -> dict[str, Any]:
+    value = raw.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def finding_id(raw: dict[str, Any]) -> str:
+    for key in ("finding_id", "id"):
+        value = string_field(raw.get(key))
+        if value is not None:
+            return value
+    return "unknown"
+
+
+def finding_status(raw: dict[str, Any]) -> str:
+    value = string_field(raw.get("status"))
+    return value.upper() if value is not None else "UNKNOWN"
+
+
+def first_seen_at(raw: dict[str, Any]) -> datetime | None:
+    for key in ("first_seen_at", "detected_at", "created_at"):
+        parsed = parse_timestamp(raw.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def violation(
+    *,
+    raw: dict[str, Any],
+    rule_id: str,
+    severity: str,
+    message: str,
+    age: float | None,
+    deadline_hours: float,
+    evidence: dict[str, Any],
+) -> StagnationViolation:
+    return StagnationViolation(
+        finding_id=finding_id(raw),
+        rule_id=rule_id,
+        severity=severity,
+        message=message,
+        age_hours=age,
+        deadline_hours=deadline_hours,
+        evidence=evidence,
+    )
+
+
+def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding:
+    status = finding_status(raw)
+    first_seen = first_seen_at(raw)
+    finding_age = age_hours(now, first_seen)
+    act = nested_object(raw, "act")
+    verify = nested_object(raw, "verify")
+    escalation = nested_object(raw, "escalation")
+
+    act_ref = string_field(act.get("ref") or raw.get("act_ref"))
+    act_created = parse_timestamp(act.get("created_at") or raw.get("act_created_at"))
+    act_merged = parse_timestamp(act.get("merged_at") or raw.get("act_merged_at"))
+    repair_ref = string_field(act.get("repair_ref") or raw.get("repair_ref"))
+    rollback_ref = string_field(act.get("rollback_ref") or raw.get("rollback_ref"))
+    verify_status = string_field(verify.get("status") or raw.get("verify_status"))
+    verify_status_upper = verify_status.upper() if verify_status is not None else None
+    verify_checked = parse_timestamp(
+        verify.get("checked_at") or raw.get("verify_checked_at")
+    )
+    verify_failed = parse_timestamp(
+        verify.get("failed_at") or raw.get("verify_failed_at")
+    )
+    escalated = (
+        bool_field(raw.get("escalated"))
+        or bool_field(escalation.get("recorded"))
+        or bool_field(escalation.get("p0"))
+        or bool_field(raw.get("p0_escalated"))
+    )
+
+    violations: list[StagnationViolation] = []
+    is_still_present = status in STILL_PRESENT_STATUSES
+    if is_still_present and act_ref is None:
+        violations.append(
+            violation(
+                raw=raw,
+                rule_id="still_present_requires_act",
+                severity="critical",
+                message="STILL_PRESENT finding has no ACT reference.",
+                age=finding_age,
+                deadline_hours=0.0,
+                evidence={"status": status, "act_ref": act_ref},
+            )
+        )
+
+    if (
+        is_still_present
+        and finding_age is not None
+        and finding_age > ACT_CREATION_DEADLINE_HOURS
+        and act_created is None
+    ):
+        violations.append(
+            violation(
+                raw=raw,
+                rule_id="act_creation_deadline_missed",
+                severity="critical",
+                message="ACT was not created within 48 hours of a present finding.",
+                age=finding_age,
+                deadline_hours=ACT_CREATION_DEADLINE_HOURS,
+                evidence={
+                    "first_seen_at": raw.get("first_seen_at"),
+                    "act_ref": act_ref,
+                },
+            )
+        )
+
+    merge_age = age_hours(now, act_merged)
+    verify_after_merge_ok = (
+        verify_checked is not None
+        and act_merged is not None
+        and verify_checked >= act_merged
+    )
+    if (
+        act_merged is not None
+        and merge_age is not None
+        and merge_age > VERIFY_AFTER_MERGE_DEADLINE_HOURS
+        and not verify_after_merge_ok
+    ):
+        violations.append(
+            violation(
+                raw=raw,
+                rule_id="verify_after_merge_deadline_missed",
+                severity="critical",
+                message="Merged ACT has no Verify evidence within 24 hours.",
+                age=merge_age,
+                deadline_hours=VERIFY_AFTER_MERGE_DEADLINE_HOURS,
+                evidence={
+                    "act_merged_at": act.get("merged_at") or raw.get("act_merged_at"),
+                    "verify_checked_at": verify.get("checked_at")
+                    or raw.get("verify_checked_at"),
+                },
+            )
+        )
+
+    verify_failed_age = age_hours(now, verify_failed)
+    if (
+        verify_status_upper == "FAIL"
+        and verify_failed_age is not None
+        and verify_failed_age > VERIFY_FAIL_REPAIR_DEADLINE_HOURS
+        and repair_ref is None
+        and rollback_ref is None
+    ):
+        violations.append(
+            violation(
+                raw=raw,
+                rule_id="verify_fail_repair_deadline_missed",
+                severity="critical",
+                message="Failed Verify has no repair PR or rollback within 4 hours.",
+                age=verify_failed_age,
+                deadline_hours=VERIFY_FAIL_REPAIR_DEADLINE_HOURS,
+                evidence={
+                    "verify_failed_at": verify.get("failed_at")
+                    or raw.get("verify_failed_at"),
+                    "repair_ref": repair_ref,
+                    "rollback_ref": rollback_ref,
+                },
+            )
+        )
+
+    if (
+        is_still_present
+        and finding_age is not None
+        and finding_age > WEEK_OLD_ESCALATION_HOURS
+        and not escalated
+    ):
+        violations.append(
+            violation(
+                raw=raw,
+                rule_id="week_old_escalation_required",
+                severity="critical",
+                message="Finding is still present for more than one week without escalation.",
+                age=finding_age,
+                deadline_hours=WEEK_OLD_ESCALATION_HOURS,
+                evidence={
+                    "first_seen_at": raw.get("first_seen_at"),
+                    "escalated": escalated,
+                },
+            )
+        )
+
+    return StagnationFinding(
+        finding_id=finding_id(raw),
+        status=status,
+        age_hours=finding_age,
+        act_ref=act_ref,
+        act_created_at=iso_utc(act_created) if act_created else None,
+        act_merged_at=iso_utc(act_merged) if act_merged else None,
+        verify_status=verify_status_upper,
+        verify_checked_at=iso_utc(verify_checked) if verify_checked else None,
+        verify_failed_at=iso_utc(verify_failed) if verify_failed else None,
+        escalated=escalated,
+        violations=violations,
+    )
+
+
+def build_report(snapshot: dict[str, Any], *, now: datetime) -> StagnationReport:
+    findings = [evaluate_finding(raw, now=now) for raw in raw_findings(snapshot)]
+    violations = [violation for finding in findings for violation in finding.violations]
+    critical = any(item.severity == "critical" for item in violations)
+    warning = any(item.severity == "warning" for item in violations)
+    status = "critical" if critical else "warning" if warning else "ok"
+    return StagnationReport(
+        schema_version=1,
+        status=status,
+        checked_at=iso_utc(now),
+        findings_total=len(findings),
+        still_present_total=sum(
+            1 for item in findings if item.status in STILL_PRESENT_STATUSES
+        ),
+        violations_total=len(violations),
+        escalations_required=sum(
+            1 for item in violations if item.rule_id == "week_old_escalation_required"
+        ),
+        findings=findings,
+        violations=violations,
+    )
+
+
+def report_to_json(report: StagnationReport) -> str:
+    return json.dumps(asdict(report), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def report_to_text(report: StagnationReport) -> str:
+    lines = [
+        f"GOAL LOOP Anti-Stagnation: {report.status}",
+        f"checked_at: {report.checked_at}",
+        f"findings_total: {report.findings_total}",
+        f"still_present_total: {report.still_present_total}",
+        f"violations_total: {report.violations_total}",
+        f"escalations_required: {report.escalations_required}",
+    ]
+    for item in report.violations:
+        lines.append(
+            f"- {item.finding_id} {item.rule_id}: "
+            f"age={item.age_hours}h deadline={item.deadline_hours}h"
+        )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("state_json", help="Anti-stagnation finding lifecycle JSON.")
+    parser.add_argument(
+        "--now",
+        help="Override current time as ISO-8601 for deterministic checks.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "warning", "critical"),
+        default="none",
+        help="Exit non-zero when report status reaches this severity.",
+    )
+    return parser.parse_args(argv)
+
+
+def should_fail(report: StagnationReport, mode: str) -> bool:
+    rank = {"ok": 0, "warning": 1, "critical": 2}
+    if mode == "none":
+        return False
+    return rank[report.status] >= rank[mode]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    now = parse_timestamp(args.now) if args.now else datetime.now(timezone.utc)
+    if now is None:
+        raise ValueError(f"invalid --now timestamp: {args.now}")
+    report = build_report(load_json(args.state_json), now=now)
+    if args.format == "json":
+        print(report_to_json(report))
+    else:
+        print(report_to_text(report))
+    return 1 if should_fail(report, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/goal_loop_anti_stagnation.py
+++ b/scripts/goal_loop_anti_stagnation.py
@@ -89,6 +89,12 @@ def age_hours(now: datetime, timestamp: datetime | None) -> float | None:
     return round(max((now - timestamp).total_seconds(), 0.0) / 3600.0, 3)
 
 
+def delta_hours(later: datetime | None, earlier: datetime | None) -> float | None:
+    if later is None or earlier is None:
+        return None
+    return round((later - earlier).total_seconds() / 3600.0, 3)
+
+
 def load_json(path: str) -> dict[str, Any]:
     with Path(path).open("r", encoding="utf-8") as handle:
         data = json.load(handle)
@@ -133,12 +139,21 @@ def finding_status(raw: dict[str, Any]) -> str:
     return value.upper() if value is not None else "UNKNOWN"
 
 
-def first_seen_at(raw: dict[str, Any]) -> datetime | None:
+def first_seen_at(raw: dict[str, Any]) -> tuple[datetime | None, str | None]:
     for key in ("first_seen_at", "detected_at", "created_at"):
         parsed = parse_timestamp(raw.get(key))
         if parsed is not None:
-            return parsed
-    return None
+            return parsed, key
+    return None, None
+
+
+def first_seen_evidence(
+    first_seen: datetime | None, first_seen_source: str | None
+) -> dict[str, Any]:
+    return {
+        "first_seen_at": iso_utc(first_seen) if first_seen is not None else None,
+        "first_seen_source": first_seen_source,
+    }
 
 
 def violation(
@@ -164,7 +179,7 @@ def violation(
 
 def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding:
     status = finding_status(raw)
-    first_seen = first_seen_at(raw)
+    first_seen, first_seen_source = first_seen_at(raw)
     finding_age = age_hours(now, first_seen)
     act = nested_object(raw, "act")
     verify = nested_object(raw, "verify")
@@ -175,6 +190,12 @@ def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding
     act_merged = parse_timestamp(act.get("merged_at") or raw.get("act_merged_at"))
     repair_ref = string_field(act.get("repair_ref") or raw.get("repair_ref"))
     rollback_ref = string_field(act.get("rollback_ref") or raw.get("rollback_ref"))
+    repair_created = parse_timestamp(
+        act.get("repair_created_at") or raw.get("repair_created_at")
+    )
+    rollback_created = parse_timestamp(
+        act.get("rollback_created_at") or raw.get("rollback_created_at")
+    )
     verify_status = string_field(verify.get("status") or raw.get("verify_status"))
     verify_status_upper = verify_status.upper() if verify_status is not None else None
     verify_checked = parse_timestamp(
@@ -205,32 +226,41 @@ def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding
             )
         )
 
-    if (
-        is_still_present
-        and finding_age is not None
+    act_creation_hours = delta_hours(act_created, first_seen)
+    act_creation_missing_overdue = (
+        finding_age is not None
         and finding_age > ACT_CREATION_DEADLINE_HOURS
         and act_created is None
-    ):
+    )
+    act_creation_late = (
+        act_creation_hours is not None
+        and act_creation_hours > ACT_CREATION_DEADLINE_HOURS
+    )
+    if is_still_present and (act_creation_missing_overdue or act_creation_late):
+        evidence = first_seen_evidence(first_seen, first_seen_source)
+        evidence.update(
+            {
+                "act_ref": act_ref,
+                "act_created_at": iso_utc(act_created) if act_created else None,
+                "act_creation_hours": act_creation_hours,
+            }
+        )
         violations.append(
             violation(
                 raw=raw,
                 rule_id="act_creation_deadline_missed",
                 severity="critical",
                 message="ACT was not created within 48 hours of a present finding.",
-                age=finding_age,
+                age=act_creation_hours if act_creation_late else finding_age,
                 deadline_hours=ACT_CREATION_DEADLINE_HOURS,
-                evidence={
-                    "first_seen_at": raw.get("first_seen_at"),
-                    "act_ref": act_ref,
-                },
+                evidence=evidence,
             )
         )
 
     merge_age = age_hours(now, act_merged)
-    verify_after_merge_ok = (
-        verify_checked is not None
-        and act_merged is not None
-        and verify_checked >= act_merged
+    verify_after_merge_hours = delta_hours(verify_checked, act_merged)
+    verify_after_merge_ok = verify_after_merge_hours is not None and (
+        0.0 <= verify_after_merge_hours <= VERIFY_AFTER_MERGE_DEADLINE_HOURS
     )
     if (
         act_merged is not None
@@ -244,23 +274,38 @@ def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding
                 rule_id="verify_after_merge_deadline_missed",
                 severity="critical",
                 message="Merged ACT has no Verify evidence within 24 hours.",
-                age=merge_age,
+                age=(
+                    verify_after_merge_hours
+                    if verify_after_merge_hours is not None
+                    else merge_age
+                ),
                 deadline_hours=VERIFY_AFTER_MERGE_DEADLINE_HOURS,
                 evidence={
                     "act_merged_at": act.get("merged_at") or raw.get("act_merged_at"),
                     "verify_checked_at": verify.get("checked_at")
                     or raw.get("verify_checked_at"),
+                    "verify_after_merge_hours": verify_after_merge_hours,
                 },
             )
         )
 
     verify_failed_age = age_hours(now, verify_failed)
+    repair_after_failure_hours = delta_hours(repair_created, verify_failed)
+    rollback_after_failure_hours = delta_hours(rollback_created, verify_failed)
+    repair_in_deadline = repair_ref is not None and (
+        repair_after_failure_hours is not None
+        and 0.0 <= repair_after_failure_hours <= VERIFY_FAIL_REPAIR_DEADLINE_HOURS
+    )
+    rollback_in_deadline = rollback_ref is not None and (
+        rollback_after_failure_hours is not None
+        and 0.0 <= rollback_after_failure_hours <= VERIFY_FAIL_REPAIR_DEADLINE_HOURS
+    )
     if (
         verify_status_upper == "FAIL"
         and verify_failed_age is not None
         and verify_failed_age > VERIFY_FAIL_REPAIR_DEADLINE_HOURS
-        and repair_ref is None
-        and rollback_ref is None
+        and not repair_in_deadline
+        and not rollback_in_deadline
     ):
         violations.append(
             violation(
@@ -274,7 +319,15 @@ def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding
                     "verify_failed_at": verify.get("failed_at")
                     or raw.get("verify_failed_at"),
                     "repair_ref": repair_ref,
+                    "repair_created_at": iso_utc(repair_created)
+                    if repair_created
+                    else None,
+                    "repair_after_failure_hours": repair_after_failure_hours,
                     "rollback_ref": rollback_ref,
+                    "rollback_created_at": iso_utc(rollback_created)
+                    if rollback_created
+                    else None,
+                    "rollback_after_failure_hours": rollback_after_failure_hours,
                 },
             )
         )
@@ -285,6 +338,8 @@ def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding
         and finding_age > WEEK_OLD_ESCALATION_HOURS
         and not escalated
     ):
+        evidence = first_seen_evidence(first_seen, first_seen_source)
+        evidence["escalated"] = escalated
         violations.append(
             violation(
                 raw=raw,
@@ -293,10 +348,7 @@ def evaluate_finding(raw: dict[str, Any], *, now: datetime) -> StagnationFinding
                 message="Finding is still present for more than one week without escalation.",
                 age=finding_age,
                 deadline_hours=WEEK_OLD_ESCALATION_HOURS,
-                evidence={
-                    "first_seen_at": raw.get("first_seen_at"),
-                    "escalated": escalated,
-                },
+                evidence=evidence,
             )
         )
 

--- a/scripts/goal_loop_status.py
+++ b/scripts/goal_loop_status.py
@@ -386,9 +386,52 @@ def summarize_decide(decide: dict[str, Any] | None) -> PhaseStatus:
     return PhaseStatus(status=status, summary=summary)
 
 
-def summarize_act(decide: dict[str, Any] | None) -> PhaseStatus:
+def anti_stagnation_summary(
+    anti_stagnation: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if anti_stagnation is None:
+        return None
+    violations_raw = anti_stagnation.get("violations", [])
+    violations = violations_raw if isinstance(violations_raw, list) else []
+    return {
+        "status": anti_stagnation.get("status", "unknown"),
+        "checked_at": anti_stagnation.get("checked_at"),
+        "findings_total": as_int(anti_stagnation.get("findings_total")),
+        "still_present_total": as_int(anti_stagnation.get("still_present_total")),
+        "violations_total": as_int(anti_stagnation.get("violations_total")),
+        "escalations_required": as_int(anti_stagnation.get("escalations_required")),
+        "violations": [
+            {
+                "finding_id": violation.get("finding_id", "unknown"),
+                "rule_id": violation.get("rule_id", "unknown"),
+                "severity": violation.get("severity", "unknown"),
+                "age_hours": violation.get("age_hours"),
+                "deadline_hours": violation.get("deadline_hours"),
+            }
+            for violation in violations[:10]
+            if isinstance(violation, dict)
+        ],
+    }
+
+
+def summarize_act(
+    decide: dict[str, Any] | None,
+    anti_stagnation: dict[str, Any] | None = None,
+) -> PhaseStatus:
+    anti_summary = anti_stagnation_summary(anti_stagnation)
     if decide is None:
-        return PhaseStatus(status="unknown", summary={"reason": "decide_json_missing"})
+        summary: dict[str, Any] = {"reason": "decide_json_missing"}
+        if anti_summary is not None:
+            summary["anti_stagnation"] = anti_summary
+            status = (
+                "critical"
+                if anti_summary["violations_total"] > 0
+                else "ok"
+                if anti_summary["status"] == "ok"
+                else "unknown"
+            )
+            return PhaseStatus(status=status, summary=summary)
+        return PhaseStatus(status="unknown", summary=summary)
 
     decisions_total = as_int(decide.get("decisions_total"))
     act_missing_count = as_int(decide.get("act_missing_count"), default=-1)
@@ -401,23 +444,34 @@ def summarize_act(decide: dict[str, Any] | None) -> PhaseStatus:
             if decisions_total == 0 or act_linked_count > 0
             else "warning"
         )
-        return PhaseStatus(
-            status=status,
-            summary={
-                "decisions_total": decisions_total,
-                "act_linked_count": max(act_linked_count, 0),
-                "act_missing_count": act_missing_count,
-            },
-        )
+        summary = {
+            "decisions_total": decisions_total,
+            "act_linked_count": max(act_linked_count, 0),
+            "act_missing_count": act_missing_count,
+        }
+        if anti_summary is not None:
+            summary["anti_stagnation"] = anti_summary
+            if anti_summary["violations_total"] > 0:
+                status = "critical"
+        return PhaseStatus(status=status, summary=summary)
     if decisions_total > 0:
-        return PhaseStatus(
-            status="unknown",
-            summary={
-                "decisions_total": decisions_total,
-                "reason": "act_map_not_evaluated",
-            },
-        )
-    return PhaseStatus(status="ok", summary={"decisions_total": 0})
+        summary = {
+            "decisions_total": decisions_total,
+            "reason": "act_map_not_evaluated",
+        }
+        status = "unknown"
+        if anti_summary is not None:
+            summary["anti_stagnation"] = anti_summary
+            if anti_summary["violations_total"] > 0:
+                status = "critical"
+        return PhaseStatus(status=status, summary=summary)
+    summary = {"decisions_total": 0}
+    status = "ok"
+    if anti_summary is not None:
+        summary["anti_stagnation"] = anti_summary
+        if anti_summary["violations_total"] > 0:
+            status = "critical"
+    return PhaseStatus(status=status, summary=summary)
 
 
 def summarize_verify(verify: dict[str, Any] | None) -> PhaseStatus:
@@ -497,12 +551,26 @@ def system_health_signals(observe: dict[str, Any] | None) -> dict[str, Any]:
     return signals
 
 
+def attach_anti_stagnation_signal(
+    signals: dict[str, Any],
+    anti_stagnation: dict[str, Any] | None,
+) -> dict[str, Any]:
+    anti_summary = anti_stagnation_summary(anti_stagnation)
+    if anti_summary is None:
+        return signals
+    return {
+        **signals,
+        "anti_stagnation": anti_summary,
+    }
+
+
 def build_status_report(
     *,
     observe: dict[str, Any] | None,
     orient: dict[str, Any] | None,
     decide: dict[str, Any] | None,
     verify: dict[str, Any] | None,
+    anti_stagnation: dict[str, Any] | None = None,
     generated_at: str | None = None,
     loop_iteration: str = "unknown",
 ) -> GoalLoopStatus:
@@ -510,7 +578,7 @@ def build_status_report(
         "observe": summarize_observe(observe),
         "orient": summarize_orient(orient),
         "decide": summarize_decide(decide),
-        "act": summarize_act(decide),
+        "act": summarize_act(decide, anti_stagnation),
         "verify": summarize_verify(verify),
     }
     overall = status_max([phase.status for phase in phases.values()])
@@ -521,7 +589,10 @@ def build_status_report(
         overall_status=overall,
         phases=phases,
         next_action=decide_next_action(decide),
-        system_health_signals=system_health_signals(observe),
+        system_health_signals=attach_anti_stagnation_signal(
+            system_health_signals(observe),
+            anti_stagnation,
+        ),
     )
 
 
@@ -564,6 +635,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--orient-json", help="JSON from orient_goal_loop_logs.py")
     parser.add_argument("--decide-json", help="JSON from decide_goal_loop_findings.py")
     parser.add_argument("--verify-json", help="JSON from verify_goal_loop_logs.py")
+    parser.add_argument(
+        "--anti-stagnation-json",
+        help="JSON from goal_loop_anti_stagnation.py.",
+    )
     parser.add_argument("--loop-iteration", default="unknown")
     parser.add_argument(
         "--format",
@@ -587,6 +662,7 @@ def main(argv: list[str] | None = None) -> int:
         orient=load_json_file(args.orient_json),
         decide=load_json_file(args.decide_json),
         verify=load_json_file(args.verify_json),
+        anti_stagnation=load_json_file(args.anti_stagnation_json),
         loop_iteration=args.loop_iteration,
     )
     if args.format == "json":

--- a/test/test_goal_loop_anti_stagnation.py
+++ b/test/test_goal_loop_anti_stagnation.py
@@ -61,6 +61,32 @@ class GoalLoopAntiStagnationTest(unittest.TestCase):
         rule_ids = {violation.rule_id for violation in report.violations}
         self.assertIn("act_creation_deadline_missed", rule_ids)
 
+    def test_act_creation_deadline_flags_late_act(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "R-FATAL-2",
+                        "status": "STILL_PRESENT",
+                        "detected_at": "2026-05-05T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13053",
+                            "created_at": "2026-05-07T12:00:00Z",
+                        },
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        violation = report.violations[0]
+        self.assertEqual(violation.rule_id, "act_creation_deadline_missed")
+        self.assertEqual(violation.age_hours, 60.0)
+        self.assertEqual(
+            violation.evidence["first_seen_at"], "2026-05-05T00:00:00+00:00"
+        )
+        self.assertEqual(violation.evidence["first_seen_source"], "detected_at")
+
     def test_verify_after_merge_deadline_misses_after_24_hours(self) -> None:
         report = goal_loop_anti_stagnation.build_report(
             {
@@ -84,6 +110,34 @@ class GoalLoopAntiStagnationTest(unittest.TestCase):
         self.assertEqual(
             report.violations[0].rule_id, "verify_after_merge_deadline_missed"
         )
+
+    def test_verify_after_merge_deadline_flags_late_verify(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "CD-9",
+                        "status": "VERIFIED_FIXED",
+                        "first_seen_at": "2026-05-05T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13054",
+                            "created_at": "2026-05-05T06:00:00Z",
+                            "merged_at": "2026-05-06T00:00:00Z",
+                        },
+                        "verify": {
+                            "status": "PASS",
+                            "checked_at": "2026-05-07T06:00:00Z",
+                        },
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        violation = report.violations[0]
+        self.assertEqual(violation.rule_id, "verify_after_merge_deadline_missed")
+        self.assertEqual(violation.age_hours, 30.0)
+        self.assertEqual(violation.evidence["verify_after_merge_hours"], 30.0)
 
     def test_failed_verify_requires_repair_or_rollback_within_4_hours(self) -> None:
         report = goal_loop_anti_stagnation.build_report(
@@ -111,6 +165,60 @@ class GoalLoopAntiStagnationTest(unittest.TestCase):
             report.violations[0].rule_id,
             "verify_fail_repair_deadline_missed",
         )
+
+    def test_failed_verify_requires_timestamped_repair_within_4_hours(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "CF-2",
+                        "status": "PARTIALLY_FIXED",
+                        "first_seen_at": "2026-05-07T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13055",
+                            "created_at": "2026-05-07T01:00:00Z",
+                            "repair_ref": "PR#13056",
+                        },
+                        "verify": {
+                            "status": "FAIL",
+                            "failed_at": "2026-05-07T18:00:00Z",
+                        },
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        violation = report.violations[0]
+        self.assertEqual(violation.rule_id, "verify_fail_repair_deadline_missed")
+        self.assertEqual(violation.evidence["repair_ref"], "PR#13056")
+        self.assertIsNone(violation.evidence["repair_created_at"])
+
+    def test_timestamped_repair_within_4_hours_satisfies_failed_verify(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "CF-3",
+                        "status": "PARTIALLY_FIXED",
+                        "first_seen_at": "2026-05-07T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13057",
+                            "created_at": "2026-05-07T01:00:00Z",
+                            "repair_ref": "PR#13058",
+                            "repair_created_at": "2026-05-07T21:00:00Z",
+                        },
+                        "verify": {
+                            "status": "FAIL",
+                            "failed_at": "2026-05-07T18:00:00Z",
+                        },
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        self.assertEqual(report.violations_total, 0)
 
     def test_week_old_still_present_requires_escalation(self) -> None:
         report = goal_loop_anti_stagnation.build_report(

--- a/test/test_goal_loop_anti_stagnation.py
+++ b/test/test_goal_loop_anti_stagnation.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "goal_loop_anti_stagnation.py"
+
+spec = importlib.util.spec_from_file_location("goal_loop_anti_stagnation", SCRIPT_PATH)
+assert spec is not None
+goal_loop_anti_stagnation = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = goal_loop_anti_stagnation
+spec.loader.exec_module(goal_loop_anti_stagnation)
+
+
+NOW = datetime(2026, 5, 8, 0, 0, tzinfo=timezone.utc)
+
+
+class GoalLoopAntiStagnationTest(unittest.TestCase):
+    def test_still_present_requires_act_reference(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "NF-2",
+                        "status": "STILL_PRESENT",
+                        "first_seen_at": "2026-05-07T20:00:00Z",
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        self.assertEqual(report.status, "critical")
+        self.assertEqual(report.violations[0].rule_id, "still_present_requires_act")
+
+    def test_act_creation_deadline_misses_after_48_hours(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "R-FATAL-1",
+                        "status": "STILL_PRESENT",
+                        "first_seen_at": "2026-05-05T00:00:00Z",
+                        "act": {"ref": "planned PR#13050"},
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        rule_ids = {violation.rule_id for violation in report.violations}
+        self.assertIn("act_creation_deadline_missed", rule_ids)
+
+    def test_verify_after_merge_deadline_misses_after_24_hours(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "CD-8",
+                        "status": "PARTIALLY_FIXED",
+                        "first_seen_at": "2026-05-05T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13050",
+                            "created_at": "2026-05-05T06:00:00Z",
+                            "merged_at": "2026-05-06T00:00:00Z",
+                        },
+                        "verify": {"status": "PENDING"},
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        self.assertEqual(
+            report.violations[0].rule_id, "verify_after_merge_deadline_missed"
+        )
+
+    def test_failed_verify_requires_repair_or_rollback_within_4_hours(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "CF-1",
+                        "status": "PARTIALLY_FIXED",
+                        "first_seen_at": "2026-05-07T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13051",
+                            "created_at": "2026-05-07T01:00:00Z",
+                        },
+                        "verify": {
+                            "status": "FAIL",
+                            "failed_at": "2026-05-07T18:00:00Z",
+                        },
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        self.assertEqual(
+            report.violations[0].rule_id,
+            "verify_fail_repair_deadline_missed",
+        )
+
+    def test_week_old_still_present_requires_escalation(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "CE-1",
+                        "status": "STILL_PRESENT",
+                        "first_seen_at": "2026-04-30T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13052",
+                            "created_at": "2026-05-01T00:00:00Z",
+                        },
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        self.assertEqual(report.escalations_required, 1)
+        self.assertEqual(report.violations[0].rule_id, "week_old_escalation_required")
+
+    def test_satisfied_lifecycle_has_no_violations(self) -> None:
+        report = goal_loop_anti_stagnation.build_report(
+            {
+                "findings": [
+                    {
+                        "finding_id": "NF-1",
+                        "status": "VERIFIED_FIXED",
+                        "first_seen_at": "2026-05-05T00:00:00Z",
+                        "act": {
+                            "ref": "PR#13050",
+                            "created_at": "2026-05-05T02:00:00Z",
+                            "merged_at": "2026-05-05T04:00:00Z",
+                        },
+                        "verify": {
+                            "status": "PASS",
+                            "checked_at": "2026-05-05T06:00:00Z",
+                        },
+                    }
+                ]
+            },
+            now=NOW,
+        )
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.violations_total, 0)
+
+    def test_cli_fails_on_critical_status(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            path = Path(raw_dir) / "anti.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "finding_id": "NF-2",
+                                "status": "STILL_PRESENT",
+                                "first_seen_at": "2026-05-07T20:00:00Z",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(path),
+                    "--now",
+                    "2026-05-08T00:00:00Z",
+                    "--fail-on",
+                    "critical",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "critical")
+        self.assertEqual(payload["violations_total"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_goal_loop_status.py
+++ b/test/test_goal_loop_status.py
@@ -159,6 +159,63 @@ class GoalLoopStatusTest(unittest.TestCase):
         self.assertEqual(summary["evidence_window_end"], "2026-05-06T00:00:00Z")
         self.assertEqual(summary["checked_at"], "2026-05-06T00:00:00Z")
 
+    def test_status_exposes_anti_stagnation_violations(self) -> None:
+        report = goal_loop_status.build_status_report(
+            observe={
+                "files": ["server.log"],
+                "total_lines": 5,
+                "matched_lines": 0,
+                "patterns": {},
+            },
+            orient={
+                "summary": {
+                    "evidence_present": 0,
+                    "critical_present": 0,
+                    "findings_total": 1,
+                },
+                "findings": [],
+            },
+            decide={
+                "decisions_total": 1,
+                "p0_count": 0,
+                "act_missing_count": 0,
+                "act_linked_count": 1,
+                "decisions": [],
+            },
+            verify={"status": "PASS", "failing_findings": []},
+            anti_stagnation={
+                "status": "critical",
+                "checked_at": "2026-05-08T00:00:00+00:00",
+                "findings_total": 1,
+                "still_present_total": 1,
+                "violations_total": 1,
+                "escalations_required": 1,
+                "violations": [
+                    {
+                        "finding_id": "CE-1",
+                        "rule_id": "week_old_escalation_required",
+                        "severity": "critical",
+                        "age_hours": 192.0,
+                        "deadline_hours": 168.0,
+                    }
+                ],
+            },
+            generated_at="2026-05-08T00:00:00+00:00",
+        )
+
+        self.assertEqual(report.overall_status, "critical")
+        anti_summary = report.phases["act"].summary["anti_stagnation"]
+        self.assertEqual(anti_summary["violations_total"], 1)
+        self.assertEqual(anti_summary["escalations_required"], 1)
+        self.assertEqual(
+            anti_summary["violations"][0]["rule_id"],
+            "week_old_escalation_required",
+        )
+        self.assertEqual(
+            report.system_health_signals["anti_stagnation"]["violations_total"],
+            1,
+        )
+
     def test_orient_audit_catalog_gap_keeps_goal_warning(self) -> None:
         report = goal_loop_status.build_status_report(
             observe={
@@ -649,6 +706,76 @@ class GoalLoopStatusTest(unittest.TestCase):
                 "provider_health_skipped"
             ],
             1,
+        )
+
+    def test_cli_accepts_anti_stagnation_json(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            decide_path = root / "decide.json"
+            verify_path = root / "verify.json"
+            anti_path = root / "anti.json"
+            decide_path.write_text(
+                json.dumps(
+                    {
+                        "decisions_total": 0,
+                        "p0_count": 0,
+                        "decisions": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            verify_path.write_text(
+                json.dumps({"status": "PASS", "failing_findings": []}),
+                encoding="utf-8",
+            )
+            anti_path.write_text(
+                json.dumps(
+                    {
+                        "status": "critical",
+                        "checked_at": "2026-05-08T00:00:00+00:00",
+                        "findings_total": 1,
+                        "still_present_total": 1,
+                        "violations_total": 1,
+                        "escalations_required": 0,
+                        "violations": [
+                            {
+                                "finding_id": "NF-2",
+                                "rule_id": "still_present_requires_act",
+                                "severity": "critical",
+                                "age_hours": 4.0,
+                                "deadline_hours": 0.0,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--decide-json",
+                    str(decide_path),
+                    "--verify-json",
+                    str(verify_path),
+                    "--anti-stagnation-json",
+                    str(anti_path),
+                    "--fail-on",
+                    "critical",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["phases"]["act"]["summary"]["anti_stagnation"]["violations"][0][
+                "rule_id"
+            ],
+            "still_present_requires_act",
         )
 
     def test_report_json_is_machine_readable(self) -> None:


### PR DESCRIPTION
Closes #13611

## Summary

- Add `scripts/goal_loop_anti_stagnation.py`, a machine-readable SLA evaluator for GOAL LOOP finding lifecycle state.
- Enforce the anti-stagnation branches: `STILL_PRESENT` requires ACT, ACT creation within 48h, Verify within 24h after merge, repair/rollback within 4h after Verify FAIL, and week-old escalation.
- Wire `scripts/goal_loop_status.py --anti-stagnation-json` so status/dashboard JSON exposes the SLA summary under `phases.act.summary.anti_stagnation` and `system_health_signals.anti_stagnation`.
- Add focused branch coverage tests and operator docs in `docs/observability/goal-loop-anti-stagnation.md`.

## Operator Impact

- Stalled findings now produce explicit rule IDs and deadline evidence instead of being hidden in prose audit notes.
- The dashboard/status surface can show anti-stagnation violations and escalation requirements without re-parsing the audit document.

## Verification

- `ruff format --check scripts/goal_loop_anti_stagnation.py scripts/goal_loop_status.py test/test_goal_loop_anti_stagnation.py test/test_goal_loop_status.py`
- `ruff check scripts/goal_loop_anti_stagnation.py scripts/goal_loop_status.py test/test_goal_loop_anti_stagnation.py test/test_goal_loop_status.py`
- `python3 -m py_compile scripts/goal_loop_anti_stagnation.py scripts/goal_loop_status.py test/test_goal_loop_anti_stagnation.py test/test_goal_loop_status.py`
- `python3 test/test_goal_loop_anti_stagnation.py`
- `python3 test/test_goal_loop_status.py`
- `git diff --check origin/main...HEAD`

Known gap: `pyright` is not installed in this worktree environment.
