### PR TITLE
fix(dashboard): expose copyable code metadata

### DIFF
--- a/dashboard/src/components/common/copyable-code.a11y.test.ts
+++ b/dashboard/src/components/common/copyable-code.a11y.test.ts
@@ -3,7 +3,7 @@
 // jest-axe coverage for CopyableCode — single-line shell snippet with
 // a copy button. The button is icon-only by default, so tests guard
 // the accessible-name fallback chain (ariaLabel || `${label} 복사` ||
-// '복사' — same pattern as CopyIdButton).
+// '명령 복사' — same pattern as CopyIdButton).
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
@@ -23,6 +23,9 @@ describe('CopyableCode a11y', () => {
 
   it('default (secondary) variant renders accessibly', async () => {
     render(html`<${CopyableCode} command="npm install" />`, container)
+    const root = container.querySelector('[data-copyable-code]')!
+    expect(root.getAttribute('data-copyable-state')).toBe('idle')
+    expect(root.getAttribute('data-copyable-command-length')).toBe('11')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -31,6 +34,7 @@ describe('CopyableCode a11y', () => {
       html`<${CopyableCode} command="masc deploy" variant="primary" />`,
       container,
     )
+    expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copyable-variant')).toBe('primary')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -39,6 +43,7 @@ describe('CopyableCode a11y', () => {
       html`<${CopyableCode} command="masc start" label="Start command" />`,
       container,
     )
+    expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copyable-has-label')).toBe('true')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -50,6 +55,7 @@ describe('CopyableCode a11y', () => {
       />`,
       container,
     )
+    expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copyable-has-explicit-aria-label')).toBe('true')
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/common/copyable-code.a11y.test.ts
+++ b/dashboard/src/components/common/copyable-code.a11y.test.ts
@@ -3,7 +3,7 @@
 // jest-axe coverage for CopyableCode — single-line shell snippet with
 // a copy button. The button is icon-only by default, so tests guard
 // the accessible-name fallback chain (ariaLabel || `${label} 복사` ||
-// '명령 복사' — same pattern as CopyIdButton).
+// '명령 복사').
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/copyable-code.test.ts
+++ b/dashboard/src/components/common/copyable-code.test.ts
@@ -2,14 +2,41 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { CopyableCode } from './copyable-code'
+import {
+  CopyableCode,
+  copyableCodeAriaLabel,
+  summarizeCopyableCode,
+} from './copyable-code'
+import { _testResetToasts } from './toast'
 
 const flushUi = async () => {
   for (let i = 0; i < 5; i++) await Promise.resolve()
 }
 
+type ExecCommandFn = (cmd: string) => boolean
+type HappyDomDocument = { execCommand?: ExecCommandFn }
+const doc = document as unknown as HappyDomDocument
+
 describe('CopyableCode', () => {
   let container: HTMLElement
+  const realClipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
+  const realExec: ExecCommandFn | undefined = doc.execCommand
+
+  function setClipboard(value: { writeText: (t: string) => Promise<void> } | undefined): void {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value,
+    })
+  }
+
+  function setExec(fn: ExecCommandFn | undefined): void {
+    if (fn === undefined) {
+      delete doc.execCommand
+    } else {
+      doc.execCommand = fn
+    }
+  }
+
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -17,7 +44,35 @@ describe('CopyableCode', () => {
   afterEach(() => {
     render(null, container)
     document.body.removeChild(container)
+    setClipboard(realClipboard as unknown as { writeText: (t: string) => Promise<void> } | undefined)
+    setExec(realExec)
+    _testResetToasts()
     vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('derives copy button labels through the shared fallback chain', () => {
+    expect(copyableCodeAriaLabel()).toBe('명령 복사')
+    expect(copyableCodeAriaLabel('start')).toBe('start 복사')
+    expect(copyableCodeAriaLabel('start', 'Copy start command')).toBe('Copy start command')
+  })
+
+  it('summarizes copyable command metadata without reading the DOM', () => {
+    expect(
+      summarizeCopyableCode({
+        command: 'pnpm test',
+        label: 'test',
+        variant: 'primary',
+        copied: true,
+      }),
+    ).toEqual({
+      variant: 'primary',
+      state: 'copied',
+      hasLabel: true,
+      hasExplicitAriaLabel: false,
+      commandLength: 9,
+      ariaLabel: 'test 복사',
+    })
   })
 
   it('renders the command text inside a <code> element', () => {
@@ -49,16 +104,17 @@ describe('CopyableCode', () => {
 
   it('root carries data-copied="false" before any click', () => {
     render(html`<${CopyableCode} command="x" />`, container)
-    expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copied')).toBe('false')
+    const root = container.querySelector('[data-copyable-code]')!
+    expect(root.getAttribute('data-copied')).toBe('false')
+    expect(root.getAttribute('data-copyable-state')).toBe('idle')
+    expect(root.getAttribute('data-copyable-command-length')).toBe('1')
+    expect(root.getAttribute('data-copyable-has-label')).toBe('false')
     expect(container.querySelector('[data-copied-badge]')).toBeNull()
   })
 
   it('clicking the copy button calls navigator.clipboard.writeText with the command', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(globalThis.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
+    setClipboard({ writeText })
     render(html`<${CopyableCode} command="echo hello" />`, container)
     const btn = container.querySelector('[data-copy-button]') as HTMLButtonElement
     btn.click()
@@ -69,10 +125,7 @@ describe('CopyableCode', () => {
 
   it('after successful copy: data-copied=true, badge rendered, icon swapped', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(globalThis.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
+    setClipboard({ writeText })
     render(html`<${CopyableCode} command="echo hi" label="greet" />`, container)
     const btn = container.querySelector('[data-copy-button]') as HTMLButtonElement
     btn.click()
@@ -80,6 +133,8 @@ describe('CopyableCode', () => {
 
     const root = container.querySelector('[data-copyable-code]')!
     expect(root.getAttribute('data-copied')).toBe('true')
+    expect(root.getAttribute('data-copyable-state')).toBe('copied')
+    expect(root.getAttribute('data-copyable-has-label')).toBe('true')
     const badge = container.querySelector('[data-copied-badge]')
     expect(badge).toBeTruthy()
     expect(badge!.textContent).toContain('Copied')
@@ -89,33 +144,25 @@ describe('CopyableCode', () => {
 
   it('falls back to execCommand when navigator.clipboard.writeText rejects', async () => {
     const writeText = vi.fn().mockRejectedValue(new Error('permission denied'))
-    Object.defineProperty(globalThis.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-    // happy-dom doesn't define execCommand as an own property; install
-    // a stub first so vi.spyOn can see it.
-    ;(document as any).execCommand = () => true
-    const execSpy = vi.spyOn(document, 'execCommand').mockReturnValue(true)
+    setClipboard({ writeText })
+    const execFn = vi.fn<ExecCommandFn>(() => true)
+    setExec(execFn)
 
     render(html`<${CopyableCode} command="fallback" />`, container)
     ;(container.querySelector('[data-copy-button]') as HTMLButtonElement).click()
     await flushUi()
 
     expect(writeText).toHaveBeenCalledWith('fallback')
-    expect(execSpy).toHaveBeenCalledWith('copy')
+    expect(execFn).toHaveBeenCalledWith('copy')
     // Fallback still counts as success → data-copied flips to true
     expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copied')).toBe('true')
   })
 
   it('leaves data-copied="false" when both clipboard paths fail', async () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'))
-    Object.defineProperty(globalThis.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
-    ;(document as any).execCommand = () => false
-    vi.spyOn(document, 'execCommand').mockReturnValue(false)
+    setClipboard({ writeText })
+    const execFn = vi.fn<ExecCommandFn>(() => false)
+    setExec(execFn)
 
     render(html`<${CopyableCode} command="x" />`, container)
     ;(container.querySelector('[data-copy-button]') as HTMLButtonElement).click()
@@ -130,6 +177,7 @@ describe('CopyableCode', () => {
     const wrap = container.querySelector('[data-copyable-code]')!
     expect(wrap.getAttribute('data-copyable-variant')).toBe('secondary')
     expect(wrap.className).toContain('border-[var(--color-border-default)]')
+    expect(wrap.className).toContain('rounded-[var(--r-0)]')
     expect(wrap.className).not.toContain('border-[var(--accent-30)]')
   })
 

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -7,9 +7,20 @@ import { Copy, Check } from 'lucide-preact'
 import { useState } from 'preact/hooks'
 import { showToast } from './toast'
 
-type CopyableVariant = 'primary' | 'secondary'
+export type CopyableVariant = 'primary' | 'secondary'
 
-interface CopyableCodeProps {
+export type CopyableCodeState = 'idle' | 'copied'
+
+export interface CopyableCodeSummary {
+  variant: CopyableVariant
+  state: CopyableCodeState
+  hasLabel: boolean
+  hasExplicitAriaLabel: boolean
+  commandLength: number
+  ariaLabel: string
+}
+
+export interface CopyableCodeProps {
   command: string
   label?: string
   ariaLabel?: string
@@ -20,6 +31,33 @@ interface CopyableCodeProps {
       primary. Inspired by Vercel "Deploy your project" and Railway
       deploy-log next-steps hierarchy. */
   variant?: CopyableVariant
+}
+
+export function copyableCodeAriaLabel(label?: string, ariaLabel?: string): string {
+  return ariaLabel || (label ? `${label} 복사` : '명령 복사')
+}
+
+export function summarizeCopyableCode({
+  command,
+  label,
+  ariaLabel,
+  variant,
+  copied,
+}: {
+  command: string
+  label?: string
+  ariaLabel?: string
+  variant: CopyableVariant
+  copied: boolean
+}): CopyableCodeSummary {
+  return {
+    variant,
+    state: copied ? 'copied' : 'idle',
+    hasLabel: label !== undefined && label !== '',
+    hasExplicitAriaLabel: ariaLabel !== undefined && ariaLabel !== '',
+    commandLength: command.length,
+    ariaLabel: copyableCodeAriaLabel(label, ariaLabel),
+  }
 }
 
 export async function copyToClipboard(text: string): Promise<boolean> {
@@ -80,6 +118,7 @@ export function CopyableCode({
   variant = 'secondary',
 }: CopyableCodeProps) {
   const [justCopied, setJustCopied] = useState(false)
+  const summary = summarizeCopyableCode({ command, label, ariaLabel, variant, copied: justCopied })
   const onCopy = async () => {
     const ok = await copyToClipboard(command)
     if (ok) {
@@ -100,26 +139,33 @@ export function CopyableCode({
   const labelTone = copyableLabelClasses(variant)
   return html`
     <div
-      class=${`group flex items-center gap-2 rounded-[var(--r-1)] border transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] ${wrapperTone}`}
+      class=${`group flex items-center gap-2 rounded-[var(--r-0)] border transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] ${wrapperTone}`}
       data-copyable-code
-      data-copyable-variant=${variant}
+      data-copyable-variant=${summary.variant}
+      data-copyable-state=${summary.state}
+      data-copyable-has-label=${summary.hasLabel}
+      data-copyable-has-explicit-aria-label=${summary.hasExplicitAriaLabel}
+      data-copyable-command-length=${summary.commandLength}
       data-copied=${justCopied ? 'true' : 'false'}
     >
       ${label
-        ? html`<span class=${labelTone}>${label}</span>`
+        ? html`<span class=${labelTone} data-copyable-label>${label}</span>`
         : null}
-      <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-2xs text-[var(--color-fg-primary)]">${command}</code>
+      <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-2xs text-[var(--color-fg-primary)]" data-copyable-command>${command}</code>
       ${justCopied
         ? html`<span class="shrink-0 text-3xs font-semibold text-[var(--color-status-ok)]" data-copied-badge aria-live="polite">✓ Copied</span>`
         : null}
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded-[var(--r-1)] border border-transparent p-1 text-[var(--color-fg-disabled)] opacity-60 transition-opacity hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] focus-visible:opacity-100 group-hover:opacity-100"
-        aria-label=${ariaLabel || (label ? `${label} 복사` : '명령 복사')}
+        class="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-[var(--r-0)] border border-transparent text-[var(--color-fg-muted)] opacity-75 transition-[background-color,border-color,color,opacity] hover:border-[var(--color-border-subtle)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] hover:opacity-100 focus-visible:opacity-100 group-hover:opacity-100"
+        aria-label=${summary.ariaLabel}
         data-copy-button
+        data-copyable-button
         onClick=${onCopy}
       >
-        ${justCopied ? html`<${Check} size=${14} />` : html`<${Copy} size=${14} />`}
+        ${justCopied
+          ? html`<${Check} size=${14} strokeWidth=${2.25} aria-hidden="true" data-copyable-icon />`
+          : html`<${Copy} size=${14} strokeWidth=${2.25} aria-hidden="true" data-copyable-icon />`}
       </button>
     </div>
   `


### PR DESCRIPTION
## Summary
- export CopyableCode state, summary, props, aria-label helper, and summarizer for component consumers and tests
- add data-copyable-* metadata for state, label presence, explicit aria-label, command length, command text, button, and icon hooks
- tighten the primitive chrome to r-0 radius and a stable 24px copy button while preserving primary/secondary hierarchy
- replace test execCommand any-casts with typed helpers and cover clipboard state metadata

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/copyable-code.test.ts src/components/common/copyable-code.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- browser QA via Vite port 5224: desktop /tmp/masc-copyable-code-summary-0506.png, mobile /tmp/masc-copyable-code-summary-0506-mobile.png
- pnpm --dir dashboard run lint: pass with existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts
- pnpm --dir dashboard run build: pass with existing Vite import/chunk-size warnings

## Notes
- The copy-id-button lint warning is fixed in draft PR #13659 but remains visible on this branch until that PR lands on main.