### PR TITLE
test(coord): stabilize generated agent status assertions

### DIFF
--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -93,7 +93,9 @@ let write_agent ctx agent =
     (Types.agent_to_yojson agent)
 
 let seed_stale_current_task ctx =
-  let old_last_seen = Masc_domain.now_iso () in
+  let old_last_seen =
+    Masc_domain.iso8601_of_unix_seconds (Time_compat.now () -. 10.0)
+  in
   let agent = read_agent ctx in
   write_agent ctx
     { agent with status = Busy; current_task = Some "task-missing"; last_seen = old_last_seen };

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -93,7 +93,7 @@ let write_agent ctx agent =
     (Types.agent_to_yojson agent)
 
 let seed_stale_current_task ctx =
-  let old_last_seen = "2000-01-01T00:00:00Z" in
+  let old_last_seen = Masc_domain.now_iso () in
   let agent = read_agent ctx in
   write_agent ctx
     { agent with status = Busy; current_task = Some "task-missing"; last_seen = old_last_seen };
@@ -131,10 +131,11 @@ let () = test "dispatch_status_hides_stale_current_task_without_writing" (fun ()
   let ctx = make_test_ctx () in
   let _ = Coord.init ctx.config ~agent_name:(Some ctx.agent_name) in
   let old_last_seen = seed_stale_current_task ctx in
+  let actual_name = Coord.resolve_agent_name ctx.config ctx.agent_name in
   match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
   | Some { success; message } ->
       assert success;
-      assert (str_contains message "test-agent (you) -> active");
+      assert_contains message (Printf.sprintf "%s (you) -> active" actual_name);
       let agent = read_agent ctx in
       assert (agent.current_task = Some "task-missing");
       assert (agent.last_seen = old_last_seen)
@@ -145,8 +146,9 @@ let () = test "coord_status_hides_stale_current_task_without_writing" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Coord.init ctx.config ~agent_name:(Some ctx.agent_name) in
   let old_last_seen = seed_stale_current_task ctx in
+  let actual_name = Coord.resolve_agent_name ctx.config ctx.agent_name in
   let output = Coord.status ctx.config in
-  assert (str_contains output "test-agent → idle");
+  assert_contains output (Printf.sprintf "%s → idle" actual_name);
   let agent = read_agent ctx in
   assert (agent.current_task = Some "task-missing");
   assert (agent.last_seen = old_last_seen)


### PR DESCRIPTION
## Summary
- update stale-current-task status assertions to resolve the actual generated joined agent name
- seed the test helper with a fresh last_seen timestamp so the test exercises stale current_task masking, not zombie-agent rendering

## Verification
- git diff --check origin/main..HEAD
- env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_tool_coord_coverage.exe
- ./_build/default/test/test_tool_coord_coverage.exe

## Review focus
The compile fixes originally carried here have landed on main through another repair. This PR now keeps only the remaining test stabilization for generated agent identities.