### PR TITLE
fix(dashboard): expose status dot metadata

### DIFF
--- a/dashboard/src/components/common/status-dot.a11y.test.ts
+++ b/dashboard/src/components/common/status-dot.a11y.test.ts
@@ -16,8 +16,9 @@ describe('StatusDot a11y', () => {
     document.body.removeChild(container)
   })
 
-  it('default render passes axe (decorative dot, role=presentation expected)', async () => {
+  it('default render passes axe (decorative dot, aria-hidden expected)', async () => {
     render(html`<${StatusDot} />`, container)
+    expect(container.querySelector('[data-status-dot]')!.getAttribute('data-status-dot-mode')).toBe('decorative')
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
@@ -32,6 +33,15 @@ describe('StatusDot a11y', () => {
       </div>`,
       container,
     )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('semantic mode passes axe with an accessible name', async () => {
+    render(html`<${StatusDot} ariaLabel="job healthy" class="bg-[var(--ok-10)]" />`, container)
+    const dot = container.querySelector('[data-status-dot]')!
+    expect(dot.getAttribute('data-status-dot-mode')).toBe('semantic')
+    expect(dot.getAttribute('data-status-dot-has-aria-label')).toBe('true')
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })

--- a/dashboard/src/components/common/status-dot.a11y.test.ts
+++ b/dashboard/src/components/common/status-dot.a11y.test.ts
@@ -45,4 +45,13 @@ describe('StatusDot a11y', () => {
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
+
+  it('blank ariaLabel stays decorative instead of rendering a nameless image', async () => {
+    render(html`<${StatusDot} ariaLabel="   " />`, container)
+    const dot = container.querySelector('[data-status-dot]')!
+    expect(dot.getAttribute('data-status-dot-mode')).toBe('decorative')
+    expect(dot.getAttribute('role')).toBeNull()
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
 })

--- a/dashboard/src/components/common/status-dot.test.ts
+++ b/dashboard/src/components/common/status-dot.test.ts
@@ -4,6 +4,7 @@ import { render } from 'preact'
 import { html } from 'htm/preact'
 import {
   StatusDot,
+  summarizeStatusDot,
   statusDotClasses,
   statusDotSizeClass,
 } from './status-dot'
@@ -48,6 +49,29 @@ describe('statusDotClasses (pure)', () => {
   })
 })
 
+describe('summarizeStatusDot (pure)', () => {
+  it('summarizes the decorative default without reading the DOM', () => {
+    expect(summarizeStatusDot({})).toEqual({
+      size: 'sm',
+      mode: 'decorative',
+      hasCustomClass: false,
+      hasAriaLabel: false,
+      classNameLength: 0,
+    })
+  })
+
+  it('summarizes semantic dots with tone metadata', () => {
+    const tone = 'bg-[var(--ok-10)] ring-1'
+    expect(summarizeStatusDot({ size: 'md', className: tone, ariaLabel: 'healthy' })).toEqual({
+      size: 'md',
+      mode: 'semantic',
+      hasCustomClass: true,
+      hasAriaLabel: true,
+      classNameLength: tone.length,
+    })
+  })
+})
+
 describe('StatusDot component', () => {
   let container: HTMLElement
   beforeEach(() => {
@@ -64,11 +88,19 @@ describe('StatusDot component', () => {
     const el = container.querySelector('[data-status-dot]') as HTMLElement
     expect(el.tagName).toBe('SPAN')
     expect(el.getAttribute('data-status-dot-size')).toBe('sm')
+    expect(el.getAttribute('data-status-dot-mode')).toBe('decorative')
+    expect(el.getAttribute('data-status-dot-has-custom-class')).toBe('false')
+    expect(el.getAttribute('data-status-dot-has-aria-label')).toBe('false')
+    expect(el.getAttribute('data-status-dot-class-length')).toBe('0')
   })
 
   it('tone class (passed via `class`) ends up on the span', () => {
-    render(html`<${StatusDot} class="bg-[var(--ok-10)]" />`, container)
-    expect(container.querySelector('[data-status-dot]')!.className).toContain('bg-[var(--ok-10)]')
+    const tone = 'bg-[var(--ok-10)]'
+    render(html`<${StatusDot} class=${tone} />`, container)
+    const el = container.querySelector('[data-status-dot]')!
+    expect(el.className).toContain(tone)
+    expect(el.getAttribute('data-status-dot-has-custom-class')).toBe('true')
+    expect(el.getAttribute('data-status-dot-class-length')).toBe(String(tone.length))
   })
 
   it('default (no ariaLabel) is decorative — aria-hidden=true, no role', () => {
@@ -90,6 +122,8 @@ describe('StatusDot component', () => {
     expect(el.getAttribute('role')).toBe('img')
     expect(el.getAttribute('aria-label')).toBe('running')
     expect(el.getAttribute('aria-hidden')).toBeNull()
+    expect(el.getAttribute('data-status-dot-mode')).toBe('semantic')
+    expect(el.getAttribute('data-status-dot-has-aria-label')).toBe('true')
   })
 
   it('each size variant renders distinct Tailwind tokens', () => {

--- a/dashboard/src/components/common/status-dot.test.ts
+++ b/dashboard/src/components/common/status-dot.test.ts
@@ -4,6 +4,7 @@ import { render } from 'preact'
 import { html } from 'htm/preact'
 import {
   StatusDot,
+  normalizeStatusDotAriaLabel,
   summarizeStatusDot,
   statusDotClasses,
   statusDotSizeClass,
@@ -49,6 +50,15 @@ describe('statusDotClasses (pure)', () => {
   })
 })
 
+describe('normalizeStatusDotAriaLabel (pure)', () => {
+  it('trims usable labels and drops empty labels', () => {
+    expect(normalizeStatusDotAriaLabel(' running ')).toBe('running')
+    expect(normalizeStatusDotAriaLabel('')).toBeUndefined()
+    expect(normalizeStatusDotAriaLabel('   ')).toBeUndefined()
+    expect(normalizeStatusDotAriaLabel()).toBeUndefined()
+  })
+})
+
 describe('summarizeStatusDot (pure)', () => {
   it('summarizes the decorative default without reading the DOM', () => {
     expect(summarizeStatusDot({})).toEqual({
@@ -68,6 +78,17 @@ describe('summarizeStatusDot (pure)', () => {
       hasCustomClass: true,
       hasAriaLabel: true,
       classNameLength: tone.length,
+    })
+  })
+
+  it('keeps empty aria labels decorative to avoid nameless role=img dots', () => {
+    expect(summarizeStatusDot({ ariaLabel: '' })).toMatchObject({
+      mode: 'decorative',
+      hasAriaLabel: false,
+    })
+    expect(summarizeStatusDot({ ariaLabel: '   ' })).toMatchObject({
+      mode: 'decorative',
+      hasAriaLabel: false,
     })
   })
 })
@@ -124,6 +145,16 @@ describe('StatusDot component', () => {
     expect(el.getAttribute('aria-hidden')).toBeNull()
     expect(el.getAttribute('data-status-dot-mode')).toBe('semantic')
     expect(el.getAttribute('data-status-dot-has-aria-label')).toBe('true')
+  })
+
+  it('empty ariaLabel remains decorative and omits a blank accessible name', () => {
+    render(html`<${StatusDot} ariaLabel="   " />`, container)
+    const el = container.querySelector('[data-status-dot]') as HTMLElement
+    expect(el.getAttribute('role')).toBeNull()
+    expect(el.getAttribute('aria-hidden')).toBe('true')
+    expect(el.getAttribute('aria-label')).toBeNull()
+    expect(el.getAttribute('data-status-dot-mode')).toBe('decorative')
+    expect(el.getAttribute('data-status-dot-has-aria-label')).toBe('false')
   })
 
   it('each size variant renders distinct Tailwind tokens', () => {

--- a/dashboard/src/components/common/status-dot.ts
+++ b/dashboard/src/components/common/status-dot.ts
@@ -21,7 +21,16 @@
 
 import { html } from 'htm/preact'
 
-type StatusDotSize = 'xs' | 'sm' | 'md' | 'lg'
+export type StatusDotSize = 'xs' | 'sm' | 'md' | 'lg'
+export type StatusDotMode = 'decorative' | 'semantic'
+
+export interface StatusDotSummary {
+  readonly size: StatusDotSize
+  readonly mode: StatusDotMode
+  readonly hasCustomClass: boolean
+  readonly hasAriaLabel: boolean
+  readonly classNameLength: number
+}
 
 /** Pure: Tailwind size tokens for each named variant. Exposed so
     a caller that wraps its own <span> (legacy code in a hot render
@@ -50,7 +59,26 @@ export function statusDotClasses(
   return parts.join(' ')
 }
 
-interface StatusDotProps {
+export function summarizeStatusDot({
+  size = 'sm',
+  className,
+  ariaLabel,
+}: {
+  size?: StatusDotSize
+  className?: string
+  ariaLabel?: string
+}): StatusDotSummary {
+  const hasAriaLabel = ariaLabel !== undefined && ariaLabel !== ''
+  return {
+    size,
+    mode: ariaLabel !== undefined ? 'semantic' : 'decorative',
+    hasCustomClass: className !== undefined && className !== '',
+    hasAriaLabel,
+    classNameLength: className?.length ?? 0,
+  }
+}
+
+export interface StatusDotProps {
   size?: StatusDotSize
   /** Additional Tailwind classes for tone, margin, etc. Caller-owned
       because per-file helpers (`statusDot(status)`, `verdictTone(v)`,
@@ -70,15 +98,20 @@ export function StatusDot({
   ariaLabel,
   testId,
 }: StatusDotProps) {
+  const summary = summarizeStatusDot({ size, className: cx, ariaLabel })
   const cls = statusDotClasses(size, cx)
-  const semantic = ariaLabel !== undefined
+  const semantic = summary.mode === 'semantic'
   return html`<span
     class=${cls}
     role=${semantic ? 'img' : undefined}
     aria-label=${ariaLabel}
     aria-hidden=${semantic ? undefined : 'true'}
     data-status-dot
-    data-status-dot-size=${size}
+    data-status-dot-size=${summary.size}
+    data-status-dot-mode=${summary.mode}
+    data-status-dot-has-custom-class=${summary.hasCustomClass}
+    data-status-dot-has-aria-label=${summary.hasAriaLabel}
+    data-status-dot-class-length=${summary.classNameLength}
     data-testid=${testId}
   ></span>`
 }

--- a/dashboard/src/components/common/status-dot.ts
+++ b/dashboard/src/components/common/status-dot.ts
@@ -59,6 +59,11 @@ export function statusDotClasses(
   return parts.join(' ')
 }
 
+export function normalizeStatusDotAriaLabel(ariaLabel?: string): string | undefined {
+  const normalized = ariaLabel?.trim()
+  return normalized === '' ? undefined : normalized
+}
+
 export function summarizeStatusDot({
   size = 'sm',
   className,
@@ -68,10 +73,10 @@ export function summarizeStatusDot({
   className?: string
   ariaLabel?: string
 }): StatusDotSummary {
-  const hasAriaLabel = ariaLabel !== undefined && ariaLabel !== ''
+  const hasAriaLabel = normalizeStatusDotAriaLabel(ariaLabel) !== undefined
   return {
     size,
-    mode: ariaLabel !== undefined ? 'semantic' : 'decorative',
+    mode: hasAriaLabel ? 'semantic' : 'decorative',
     hasCustomClass: className !== undefined && className !== '',
     hasAriaLabel,
     classNameLength: className?.length ?? 0,
@@ -100,11 +105,12 @@ export function StatusDot({
 }: StatusDotProps) {
   const summary = summarizeStatusDot({ size, className: cx, ariaLabel })
   const cls = statusDotClasses(size, cx)
+  const normalizedAriaLabel = normalizeStatusDotAriaLabel(ariaLabel)
   const semantic = summary.mode === 'semantic'
   return html`<span
     class=${cls}
     role=${semantic ? 'img' : undefined}
-    aria-label=${ariaLabel}
+    aria-label=${normalizedAriaLabel}
     aria-hidden=${semantic ? undefined : 'true'}
     data-status-dot
     data-status-dot-size=${summary.size}


### PR DESCRIPTION
## Summary
- export StatusDotSize, StatusDotMode, StatusDotProps, StatusDotSummary, and summarizeStatusDot for pure state inspection
- add data-status-dot-* metadata for size, decorative/semantic mode, custom class presence, aria-label presence, and class length
- keep the existing caller-owned tone and fixed 6/8/10/12px sizing behavior intact
- extend unit and axe coverage for decorative and semantic status dots

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/status-dot.test.ts src/components/common/status-dot.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- browser QA via Vite port 5225: desktop /tmp/masc-status-dot-summary-0506.png, mobile /tmp/masc-status-dot-summary-0506-mobile.png
- pnpm --dir dashboard run lint: pass with existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts
- pnpm --dir dashboard run build: pass with existing Vite dynamic/static import and chunk-size warnings

## Notes
- The copy-id-button lint warning is fixed in draft PR #13659 but remains visible on this branch until that PR lands on main.