### PR TITLE
fix(keeper): close supervision late review nits

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -175,9 +175,32 @@ let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
 let restart_launch_noop_for_test = Atomic.make false
+let restart_launch_noop_scope_mu = Stdlib.Mutex.create ()
+let restart_launch_noop_scope_depth = ref 0
+let restart_launch_noop_scope_previous = ref false
 
 let set_restart_launch_noop_for_test enabled =
   Atomic.set restart_launch_noop_for_test enabled
+
+let restart_launch_noop_enabled_for_test () =
+  Atomic.get restart_launch_noop_for_test
+
+let with_restart_launch_noop_for_test f =
+  Stdlib.Mutex.lock restart_launch_noop_scope_mu;
+  if !restart_launch_noop_scope_depth = 0 then begin
+    restart_launch_noop_scope_previous := restart_launch_noop_enabled_for_test ();
+    set_restart_launch_noop_for_test true
+  end;
+  incr restart_launch_noop_scope_depth;
+  Stdlib.Mutex.unlock restart_launch_noop_scope_mu;
+  Fun.protect
+    ~finally:(fun () ->
+      Stdlib.Mutex.lock restart_launch_noop_scope_mu;
+      decr restart_launch_noop_scope_depth;
+      if !restart_launch_noop_scope_depth = 0 then
+        set_restart_launch_noop_for_test !restart_launch_noop_scope_previous;
+      Stdlib.Mutex.unlock restart_launch_noop_scope_mu)
+    f
 
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
     (reg : Keeper_registry.registry_entry) =
@@ -862,6 +885,13 @@ let reset_self_preservation_escape_state_for_test () =
   sp_escape_state.last_dominant_cohort <- "";
   sp_escape_state.consecutive_suppressions <- 0
 
+let active_supervision_keeper_count entries =
+  List_util.count_if
+    (fun (e : Keeper_registry.registry_entry) ->
+      e.phase = Keeper_state_machine.Running
+      || e.phase = Keeper_state_machine.Crashed)
+    entries
+
 (** Self-preservation gate. Suppresses restarts when a dominant failure
     cohort exceeds ratio threshold AND minimum candidate count.
     Bounded minority [stale_turn_timeout] cohorts are allowed through so
@@ -1385,9 +1415,9 @@ let sweep_and_recover (ctx : _ context) =
   ) !to_mark_dead;
   List.iter (cleanup_dead_tombstone ctx) !to_cleanup_dead;
   let active_count =
-    List_util.count_if (fun (e : Keeper_registry.registry_entry) ->
-      e.phase = Keeper_state_machine.Running || e.phase = Keeper_state_machine.Crashed
-    ) entries in
+    Keeper_registry.all ~base_path ()
+    |> active_supervision_keeper_count
+  in
   let restart_list =
     let keepers_dir =
       Filename.concat (Coord.masc_root_dir ctx.config) "keepers" in

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -174,32 +174,54 @@ let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog
 
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
-let restart_launch_noop_for_test = Atomic.make false
-let restart_launch_noop_scope_mu = Stdlib.Mutex.create ()
-let restart_launch_noop_scope_depth = ref 0
-let restart_launch_noop_scope_previous = ref false
+type restart_launch_noop_state = {
+  enabled : bool;
+  scope_depth : int;
+  scope_previous : bool;
+}
+
+let restart_launch_noop_for_test =
+  Atomic.make { enabled = false; scope_depth = 0; scope_previous = false }
+
+let update_restart_launch_noop_state f =
+  let rec loop () =
+    let current = Atomic.get restart_launch_noop_for_test in
+    let next = f current in
+    if not (Atomic.compare_and_set restart_launch_noop_for_test current next) then
+      loop ()
+  in
+  loop ()
 
 let set_restart_launch_noop_for_test enabled =
-  Atomic.set restart_launch_noop_for_test enabled
+  update_restart_launch_noop_state (fun state -> { state with enabled })
 
 let restart_launch_noop_enabled_for_test () =
-  Atomic.get restart_launch_noop_for_test
+  (Atomic.get restart_launch_noop_for_test).enabled
 
 let with_restart_launch_noop_for_test f =
-  Stdlib.Mutex.lock restart_launch_noop_scope_mu;
-  if !restart_launch_noop_scope_depth = 0 then begin
-    restart_launch_noop_scope_previous := restart_launch_noop_enabled_for_test ();
-    set_restart_launch_noop_for_test true
-  end;
-  incr restart_launch_noop_scope_depth;
-  Stdlib.Mutex.unlock restart_launch_noop_scope_mu;
+  let enter () =
+    update_restart_launch_noop_state (fun state ->
+        if state.scope_depth = 0 then
+          {
+            enabled = true;
+            scope_depth = 1;
+            scope_previous = state.enabled;
+          }
+        else { state with enabled = true; scope_depth = state.scope_depth + 1 })
+  in
+  let leave () =
+    update_restart_launch_noop_state (fun state ->
+        if state.scope_depth <= 1 then
+          {
+            enabled = state.scope_previous;
+            scope_depth = 0;
+            scope_previous = false;
+          }
+        else { state with scope_depth = state.scope_depth - 1 })
+  in
+  enter ();
   Fun.protect
-    ~finally:(fun () ->
-      Stdlib.Mutex.lock restart_launch_noop_scope_mu;
-      decr restart_launch_noop_scope_depth;
-      if !restart_launch_noop_scope_depth = 0 then
-        set_restart_launch_noop_for_test !restart_launch_noop_scope_previous;
-      Stdlib.Mutex.unlock restart_launch_noop_scope_mu)
+    ~finally:leave
     f
 
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
@@ -218,7 +240,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
          Prometheus.metric_keeper_supervisor_cleanup_failures
          ~labels:[("keeper", meta.name); ("site", "fiber_start_rejected")]
          ());
-  if Atomic.get restart_launch_noop_for_test then ()
+  if restart_launch_noop_enabled_for_test () then ()
   else begin
   fork_stale_watchdog ctx meta reg;
   (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -106,9 +106,20 @@ val apply_self_preservation :
 val reset_self_preservation_escape_state_for_test : unit -> unit
 (** Reset the self-preservation probe state. Test-only. *)
 
+val active_supervision_keeper_count :
+  Keeper_registry.registry_entry list -> int
+(** Count currently active keepers for self-preservation denominators. *)
+
 val set_restart_launch_noop_for_test : bool -> unit
 (** Test-only: when enabled, restart bookkeeping still runs but the
     replacement heartbeat/watchdog fibers are not forked. *)
+
+val restart_launch_noop_enabled_for_test : unit -> bool
+(** Test-only: inspect the restart-launch noop flag. *)
+
+val with_restart_launch_noop_for_test : (unit -> 'a) -> 'a
+(** Test-only: scoped restart-launch noop override. Nested and overlapping
+    scopes restore the prior flag only after the outer scope exits. *)
 
 (** {1 Liveness Recovery} *)
 

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -277,19 +277,27 @@ let test_fresh_supervision_cohort_keepers_rereads_registry () =
   | _ -> fail "expected one fresh entry"
 
 let test_restart_launch_noop_scope_restores_nested_state () =
-  Sup.set_restart_launch_noop_for_test false;
-  Sup.with_restart_launch_noop_for_test (fun () ->
-      check bool "outer enables noop" true (Sup.restart_launch_noop_enabled_for_test ());
+  let previous = Sup.restart_launch_noop_enabled_for_test () in
+  Fun.protect
+    ~finally:(fun () -> Sup.set_restart_launch_noop_for_test previous)
+    (fun () ->
+      Sup.set_restart_launch_noop_for_test false;
       Sup.with_restart_launch_noop_for_test (fun () ->
-          check bool "inner keeps noop" true (Sup.restart_launch_noop_enabled_for_test ()));
-      check bool "outer remains enabled" true (Sup.restart_launch_noop_enabled_for_test ()));
-  check bool "restored false" false (Sup.restart_launch_noop_enabled_for_test ());
-  Sup.set_restart_launch_noop_for_test true;
-  Sup.with_restart_launch_noop_for_test (fun () ->
-      check bool "preserves prior true in scope" true
-        (Sup.restart_launch_noop_enabled_for_test ()));
-  check bool "restored prior true" true (Sup.restart_launch_noop_enabled_for_test ());
-  Sup.set_restart_launch_noop_for_test false
+          check bool "outer enables noop" true
+            (Sup.restart_launch_noop_enabled_for_test ());
+          Sup.with_restart_launch_noop_for_test (fun () ->
+              check bool "inner keeps noop" true
+                (Sup.restart_launch_noop_enabled_for_test ()));
+          check bool "outer remains enabled" true
+            (Sup.restart_launch_noop_enabled_for_test ()));
+      check bool "restored false" false
+        (Sup.restart_launch_noop_enabled_for_test ());
+      Sup.set_restart_launch_noop_for_test true;
+      Sup.with_restart_launch_noop_for_test (fun () ->
+          check bool "preserves prior true in scope" true
+            (Sup.restart_launch_noop_enabled_for_test ()));
+      check bool "restored prior true" true
+        (Sup.restart_launch_noop_enabled_for_test ()))
 
 let test_active_supervision_keeper_count_uses_current_entries () =
   let entries = registered_entries [ "alpha"; "bravo" ] in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -31,10 +31,7 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let with_restart_launch_noop f =
-  Sup.set_restart_launch_noop_for_test true;
-  Fun.protect
-    ~finally:(fun () -> Sup.set_restart_launch_noop_for_test false)
-    f
+  Sup.with_restart_launch_noop_for_test f
 
 (* ── Pure tests: backoff_delay ──────────────────────────── *)
 
@@ -278,6 +275,31 @@ let test_fresh_supervision_cohort_keepers_rereads_registry () =
       check string "entry was re-read from registry" "offline"
         (KSM.phase_to_string entry.phase)
   | _ -> fail "expected one fresh entry"
+
+let test_restart_launch_noop_scope_restores_nested_state () =
+  Sup.set_restart_launch_noop_for_test false;
+  Sup.with_restart_launch_noop_for_test (fun () ->
+      check bool "outer enables noop" true (Sup.restart_launch_noop_enabled_for_test ());
+      Sup.with_restart_launch_noop_for_test (fun () ->
+          check bool "inner keeps noop" true (Sup.restart_launch_noop_enabled_for_test ()));
+      check bool "outer remains enabled" true (Sup.restart_launch_noop_enabled_for_test ()));
+  check bool "restored false" false (Sup.restart_launch_noop_enabled_for_test ());
+  Sup.set_restart_launch_noop_for_test true;
+  Sup.with_restart_launch_noop_for_test (fun () ->
+      check bool "preserves prior true in scope" true
+        (Sup.restart_launch_noop_enabled_for_test ()));
+  check bool "restored prior true" true (Sup.restart_launch_noop_enabled_for_test ());
+  Sup.set_restart_launch_noop_for_test false
+
+let test_active_supervision_keeper_count_uses_current_entries () =
+  let entries = registered_entries [ "alpha"; "bravo" ] in
+  check int "initial active count" 2
+    (Sup.active_supervision_keeper_count entries);
+  Reg.unregister ~base_path:bp "bravo";
+  ignore (Reg.register_offline ~base_path:bp "bravo" (make_meta "bravo"));
+  let fresh_entries = Reg.all ~base_path:bp () in
+  check int "fresh active count excludes offline" 1
+    (Sup.active_supervision_keeper_count fresh_entries)
 
 let test_self_preservation_subset () =
   Eio_main.run @@ fun _env ->
@@ -1317,6 +1339,10 @@ let () =
         test_supervision_cohorts_large_custom_size_yields_between_only;
       test_case "fresh cohort entries are re-read by name" `Quick
         test_fresh_supervision_cohort_keepers_rereads_registry;
+      test_case "restart launch noop scoped restore" `Quick
+        test_restart_launch_noop_scope_restores_nested_state;
+      test_case "active count uses current entries" `Quick
+        test_active_supervision_keeper_count_uses_current_entries;
     ];
     "self_preservation_properties", [
       test_case "output subset of input" `Quick test_self_preservation_subset;


### PR DESCRIPTION
## Summary
- Add scoped, nest-safe `with_restart_launch_noop_for_test` support so keeper supervisor tests restore the previous restart-launch flag instead of forcing it to `false`.
- Recompute self-preservation `active_count` from a fresh registry snapshot after cohort yields, avoiding stale initial-entry counts.
- Address review feedback by replacing the scoped test flag's `Stdlib.Mutex`/refs with a lock-free `Atomic` state record and CAS loop.
- Add focused regression tests for nested restart-launch noop scoping, failure-safe test cleanup, and current-entry active supervision counting.

## Why It Matters
This closes the two late review nits on merged #13521. The previous helper could leak incorrect global test state across nested or parallel uses, and self-preservation could make a restart decision using an old keeper registry snapshot.

Closes #13654.

## Base
This branch is rebased directly on `origin/main` after #13666 merged the shared OCaml compile-blocker fixes.

## Verification
- `git diff --check`
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13672_review scripts/dune-local.sh exec ./test/test_keeper_supervisor.exe -- test supervision_cohorts`

Result: focused `supervision_cohorts` slice passed, 6 tests run.
