### PR TITLE
fix(keeper): stop cross-goal claim fallback

### DIFF
--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -62,6 +62,14 @@ let active_task_assignee = function
       Some assignee
   | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
+let assigned_task_ids ~matches_you tasks =
+  List.filter_map
+    (fun (task : Masc_domain.task) ->
+      match active_task_assignee task.task_status with
+      | Some assignee when matches_you assignee -> Some task.id
+      | Some _ | None -> None)
+    tasks
+
 let add_unique table key value =
   let values = Option.value (Hashtbl.find_opt table key) ~default:[] in
   if List.exists (String.equal value) values then ()

--- a/lib/dune
+++ b/lib/dune
@@ -234,6 +234,7 @@
    cohttp
    cohttp-eio
    agent_sdk
+   agent_sdk.base
    agent_sdk.llm_provider
    masc_mcp.oas_compat
 

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -87,7 +87,7 @@ let resolve_claim_goal_scope ?agent_tool_names
         let is_auto_goal =
           active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
         in
-        if is_auto_goal || allow_empty_goal_scope_fallback then
+        if allow_empty_goal_scope_fallback then
           {
             task_filter = (fun (_task : Masc_domain.task) -> true);
             mode =

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -84,10 +84,10 @@ let resolve_claim_goal_scope ?agent_tool_names
              config
              goal_ids)
       then
-        let is_auto_goal =
-          active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
-        in
         if allow_empty_goal_scope_fallback then
+          let is_auto_goal =
+            active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
+          in
           {
             task_filter = (fun (_task : Masc_domain.task) -> true);
             mode =

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -421,12 +421,7 @@ let status_summary_string (ctx : context) =
     String.equal assignee ctx.agent_name || String.equal assignee actual_name
   in
   let assigned_task_ids =
-    List.filter_map
-      (fun (task : Masc_domain.task) ->
-        match Coord_status_rendering.active_task_assignee task.task_status with
-        | Some assignee when matches_you assignee -> Some task.id
-        | Some _ | None -> None)
-      active_tasks
+    Coord_status_rendering.assigned_task_ids ~matches_you active_tasks
   in
   let binding =
     resolve_current_binding ~assigned_task_ids ~planning_current:current_task

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -71,6 +71,16 @@ let set_task_created_at_by_title config ~title ~created_at =
   if not !seen then failwith (Printf.sprintf "task not found: %s" title);
   Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
 
+let transition_task_exn ?notes config ~agent_name ~task_id ~action () =
+  match
+    Coord.transition_task_r config ~agent_name ~task_id ~action ?notes ()
+  with
+  | Ok _ -> ()
+  | Error err ->
+      fail
+        (Printf.sprintf "transition %s failed: %s" task_id
+           (Masc_domain.masc_error_to_string err))
+
 let strict_contract ?(verify_gate_evidence = []) () : Masc_domain.task_contract =
   {
     strict = true;
@@ -616,6 +626,52 @@ let test_claim_does_not_cross_goal_when_persisted_goal_scope_empty () =
     check bool "does not claim product fallback" false
       (contains_substring message "fallback to all tasks"))
 
+let test_explicit_empty_goal_scope_fallback_override_still_claims_cross_goal () =
+  with_room (fun config ->
+    let scoped_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let product_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Product goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta = make_goal_scoped_meta [ scoped_goal.id ] in
+    let _ =
+      Coord_task.add_task ~goal_id:product_goal.id config
+        ~title:"Product fallback task" ~priority:1 ~description:"desc"
+    in
+    let scope =
+      Keeper_runtime_contract.resolve_claim_goal_scope
+        ~allow_empty_goal_scope_fallback:true ~config ~meta ()
+    in
+    check string "claim scope fallback mode"
+      "empty_goal_scope_fallback_all_tasks" scope.mode;
+    check (list string) "effective goal ids cleared" [] scope.effective_goal_ids;
+    check bool "fallback reason present" true
+      (Option.is_some scope.fallback_reason);
+    match
+      Coord.claim_next_r config ~agent_name:meta.agent_name
+        ~agent_tool_names:(Keeper_tool_policy.keeper_allowed_tool_names meta)
+        ~task_filter:scope.task_filter ()
+    with
+    | Coord.Claim_next_claimed { task_id; _ } ->
+        let task =
+          Coord.get_tasks_raw config
+          |> List.find_opt (fun (task : Masc_domain.task) ->
+               String.equal task.id task_id)
+        in
+        (match task with
+         | Some task ->
+             check string "fallback claimed product task" "Product fallback task"
+               task.title;
+             check string "fallback claimed product goal" product_goal.id
+               (Option.value task.goal_id ~default:"")
+         | None -> fail "claimed task not found")
+    | _ -> fail "expected explicit fallback override to claim product task")
+
 let test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool () =
   with_room (fun config ->
     let scoped_goal, _ =
@@ -645,6 +701,64 @@ let test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool () =
     let _ =
       Coord_task.add_task ~goal_id:product_goal.id config
         ~title:"Product fallback task" ~priority:2 ~description:"desc"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    check_no_task_claimed config meta;
+    check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
+    check bool "message keeps active scope" true
+      (contains_substring message "within active_goal_ids");
+    check bool "does not claim product fallback" false
+      (contains_substring message "fallback to all tasks"))
+
+let test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable () =
+  with_room (fun config ->
+    let scoped_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let product_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Product goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta =
+      { (make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ]) with
+        active_goal_ids = [ scoped_goal.id ];
+      }
+    in
+    let _ =
+      Coord_task.add_task ~goal_id:scoped_goal.id config
+        ~title:"Scoped already in progress" ~priority:1
+        ~description:"owned by another worker"
+    in
+    let in_progress_task = task_by_title config "Scoped already in progress" in
+    ignore
+      (Coord.claim_task config ~agent_name:"other-agent"
+         ~task_id:in_progress_task.id);
+    transition_task_exn config ~agent_name:"other-agent"
+      ~task_id:in_progress_task.id ~action:Masc_domain.Start ();
+    let _ =
+      Coord_task.add_task ~goal_id:scoped_goal.id config
+        ~title:"Scoped already done" ~priority:2 ~description:"terminal"
+    in
+    let done_task = task_by_title config "Scoped already done" in
+    ignore
+      (Coord.claim_task config ~agent_name:"other-agent" ~task_id:done_task.id);
+    transition_task_exn config ~agent_name:"other-agent"
+      ~task_id:done_task.id ~action:Masc_domain.Done_action ~notes:"done" ();
+    let _ =
+      Coord_task.add_task
+        ~contract:(contract_requiring_tools [ "keeper_bash" ])
+        ~goal_id:scoped_goal.id config
+        ~title:"Scoped task needing bash" ~priority:3
+        ~description:"requires unavailable shell access"
+    in
+    let _ =
+      Coord_task.add_task ~goal_id:product_goal.id config
+        ~title:"Product fallback task" ~priority:1 ~description:"desc"
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
@@ -1213,9 +1327,16 @@ let () =
       test_case "claim does not cross-goal when persisted goal scope is empty"
         `Quick
         test_claim_does_not_cross_goal_when_persisted_goal_scope_empty;
+      test_case
+        "explicit empty goal scope fallback override still claims cross-goal"
+        `Quick
+        test_explicit_empty_goal_scope_fallback_override_still_claims_cross_goal;
       test_case "claim does not cross-goal when scoped task requires missing tool"
         `Quick
         test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool;
+      test_case "claim does not cross-goal when all scoped tasks unavailable"
+        `Quick
+        test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable;
       test_case
         "claim does not cross-goal when scoped task is verification blocked"
         `Quick

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -189,6 +189,30 @@ let check_effective_goal_ids label scope expected =
   in
   check (list string) label expected actual
 
+let claimed_task_for_agent config agent_name =
+  Coord.get_tasks_raw config
+  |> List.find_opt (fun (task : Masc_domain.task) ->
+       Masc_domain.task_assignee_of_status task.task_status = Some agent_name)
+
+let check_no_task_claimed config meta =
+  match claimed_task_for_agent config meta.Keeper_types.agent_name with
+  | None -> ()
+  | Some task ->
+      fail
+        (Printf.sprintf
+           "expected no claimed task for scoped keeper, got %s (%s)"
+           task.id task.title)
+
+let check_active_goal_scope_no_fallback json ~goal_id =
+  let scope = Yojson.Safe.Util.member "claim_scope" json in
+  check string "claim scope mode" "active_goal_ids"
+    Yojson.Safe.Util.(scope |> member "mode" |> to_string);
+  check (list string) "effective goal ids preserved" [ goal_id ]
+    Yojson.Safe.Util.(
+      scope |> member "effective_goal_ids" |> to_list |> List.map to_string);
+  check (option string) "fallback reason absent" None
+    Yojson.Safe.Util.(scope |> member "fallback_reason" |> to_string_option)
+
 let with_registered_keeper config meta f =
   Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_types.name;
   ignore
@@ -529,7 +553,7 @@ let test_claim_respects_active_goal_ids () =
           json |> member "claimed_task" |> member "goal_id" |> to_string)
     | None -> fail "expected a claimed task")
 
-let test_claim_falls_back_from_empty_auto_goal_scope () =
+let test_claim_does_not_cross_goal_when_auto_goal_scope_empty () =
   with_room (fun config ->
     let meta = make_test_meta ~name:"executor" () in
     let auto_goal, _ =
@@ -553,29 +577,15 @@ let test_claim_falls_back_from_empty_auto_goal_scope () =
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
-    let claimed_task =
-      Coord.get_tasks_raw config
-      |> List.find_opt (fun (task : Masc_domain.task) ->
-           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
-    in
-    match claimed_task with
-    | Some task ->
-      check string "claimed product task" "Product task" task.title;
-      let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "auto_goal_fallback_all_tasks"
-        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check int "effective goal ids cleared" 0
-        Yojson.Safe.Util.(
-          scope |> member "effective_goal_ids" |> to_list |> List.length);
-      check string "claim scope matched product goal" product_goal.id
-        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string);
-      check bool "fallback reason present" true
-        Yojson.Safe.Util.(
-          scope |> member "fallback_reason" |> to_string |> fun s ->
-          String.length s > 0)
-    | None -> fail "expected fallback to claim a product task")
+    let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    check_no_task_claimed config meta;
+    check_active_goal_scope_no_fallback json ~goal_id:auto_goal.id;
+    check bool "message keeps active scope" true
+      (contains_substring message "within active_goal_ids");
+    check bool "does not claim product fallback" false
+      (contains_substring message "fallback to all tasks"))
 
-let test_claim_stops_from_empty_persisted_goal_scope () =
+let test_claim_does_not_cross_goal_when_persisted_goal_scope_empty () =
   with_room (fun config ->
     let keeper_goal, _ =
       match Goal_store.upsert_goal config ~title:"Masc improver" () with
@@ -598,36 +608,15 @@ let test_claim_stops_from_empty_persisted_goal_scope () =
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
-    let claimed_task =
-      Coord.get_tasks_raw config
-      |> List.find_opt (fun (task : Masc_domain.task) ->
-           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
-    in
-    match claimed_task with
-    | Some task ->
-      fail
-        (Printf.sprintf
-           "expected persisted active_goal_ids to stop before claiming %s"
-           task.title)
-    | None ->
-      let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "active_goal_ids"
-        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check int "effective goal ids retained" 1
-        Yojson.Safe.Util.(
-          scope |> member "effective_goal_ids" |> to_list |> List.length);
-      check_effective_goal_ids "effective goal ids" scope [ keeper_goal.id ];
-      check bool "fallback reason absent" true
-        Yojson.Safe.Util.(scope |> member "fallback_reason" |> json_is_null);
-      check bool "product goal stayed unclaimed" true
-        (Coord.get_tasks_raw config
-         |> List.exists (fun (task : Masc_domain.task) ->
-              String.equal task.title "Product task"
-              && Option.equal String.equal task.goal_id (Some product_goal.id)
-              &&
-              match task.task_status with Masc_domain.Todo -> true | _ -> false)))
+    let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    check_no_task_claimed config meta;
+    check_active_goal_scope_no_fallback json ~goal_id:keeper_goal.id;
+    check bool "message keeps active scope" true
+      (contains_substring message "within active_goal_ids");
+    check bool "does not claim product fallback" false
+      (contains_substring message "fallback to all tasks"))
 
-let test_claim_stops_when_scoped_task_requires_missing_tool () =
+let test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool () =
   with_room (fun config ->
     let scoped_goal, _ =
       match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
@@ -660,35 +649,14 @@ let test_claim_stops_when_scoped_task_requires_missing_tool () =
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
-    let claimed_task =
-      Coord.get_tasks_raw config
-      |> List.find_opt (fun (task : Masc_domain.task) ->
-           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
-    in
-    match claimed_task with
-    | Some task ->
-      fail
-        (Printf.sprintf
-           "expected scoped missing-tool task to block fallback, claimed %s"
-           task.title)
-    | None ->
-      let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "active_goal_ids"
-        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check_effective_goal_ids "effective goal ids" scope [ scoped_goal.id ];
-      check bool "message names scoped active goals" true
-        (contains_substring message "within active_goal_ids");
-      check bool "message avoids fallback" false
-        (contains_substring message "fallback");
-      check bool "product goal stayed unclaimed" true
-        (Coord.get_tasks_raw config
-         |> List.exists (fun (task : Masc_domain.task) ->
-              String.equal task.title "Product fallback task"
-              && Option.equal String.equal task.goal_id (Some product_goal.id)
-              &&
-              match task.task_status with Masc_domain.Todo -> true | _ -> false)))
+    check_no_task_claimed config meta;
+    check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
+    check bool "message keeps active scope" true
+      (contains_substring message "within active_goal_ids");
+    check bool "does not claim product fallback" false
+      (contains_substring message "fallback to all tasks"))
 
-let test_claim_stops_when_scoped_task_is_verification_blocked () =
+let test_claim_does_not_cross_goal_when_scoped_task_is_verification_blocked () =
   with_room (fun config ->
     let scoped_goal, _ =
       match Goal_store.upsert_goal config ~title:"Scoped verification goal" () with
@@ -715,35 +683,14 @@ let test_claim_stops_when_scoped_task_is_verification_blocked () =
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
-    let claimed_task =
-      Coord.get_tasks_raw config
-      |> List.find_opt (fun (task : Masc_domain.task) ->
-           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
-    in
-    match claimed_task with
-    | Some task ->
-      fail
-        (Printf.sprintf
-           "expected verification-blocked scoped task to block fallback, claimed %s"
-           task.title)
-    | None ->
-      let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "active_goal_ids"
-        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check_effective_goal_ids "effective goal ids" scope [ scoped_goal.id ];
-      check bool "message names scoped active goals" true
-        (contains_substring message "within active_goal_ids");
-      check bool "message avoids fallback" false
-        (contains_substring message "fallback");
-      check bool "product goal stayed unclaimed" true
-        (Coord.get_tasks_raw config
-         |> List.exists (fun (task : Masc_domain.task) ->
-              String.equal task.title "Product fallback task"
-              && Option.equal String.equal task.goal_id (Some product_goal.id)
-              &&
-              match task.task_status with Masc_domain.Todo -> true | _ -> false)))
+    check_no_task_claimed config meta;
+    check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
+    check bool "message keeps active scope" true
+      (contains_substring message "within active_goal_ids");
+    check bool "does not claim product fallback" false
+      (contains_substring message "fallback to all tasks"))
 
-let test_claim_no_eligible_persisted_scope_reports_scope_truth () =
+let test_claim_no_eligible_scoped_reports_scope_truth () =
   with_room (fun config ->
     let scoped_goal, _ =
       match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
@@ -781,18 +728,14 @@ let test_claim_no_eligible_persisted_scope_reports_scope_truth () =
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
-    let scope = Yojson.Safe.Util.member "claim_scope" json in
-    check string "claim scope mode" "active_goal_ids"
-      Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-    check_effective_goal_ids "effective goal ids" scope [ scoped_goal.id ];
-    check bool "message names active scope" true
-      (contains_substring message "within active_goal_ids");
+    check_no_task_claimed config meta;
+    check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
     check bool "message avoids fallback search" false
-      (contains_substring message "fallback");
+      (contains_substring message "fallback to all tasks");
     check bool "message stops task checking" true
       (contains_substring message "Stop task-checking");
-    check bool "excluded count present" true
-      Yojson.Safe.Util.(scope |> member "excluded_count" |> to_int |> fun n -> n > 0))
+    check bool "message preserves active scope" true
+      (contains_substring message "within active_goal_ids"))
 
 let test_claim_skips_required_tools_without_access () =
   with_room (fun config ->
@@ -1265,16 +1208,20 @@ let () =
         test_claim_prefers_oldest_same_priority_task;
       test_case "claim respects active_goal_ids" `Quick
         test_claim_respects_active_goal_ids;
-      test_case "claim falls back from empty auto goal scope" `Quick
-        test_claim_falls_back_from_empty_auto_goal_scope;
-      test_case "claim stops from empty persisted goal scope" `Quick
-        test_claim_stops_from_empty_persisted_goal_scope;
-      test_case "claim stops when scoped task requires missing tool" `Quick
-        test_claim_stops_when_scoped_task_requires_missing_tool;
-      test_case "claim stops when scoped task is verification blocked" `Quick
-        test_claim_stops_when_scoped_task_is_verification_blocked;
-      test_case "claim no eligible persisted scope reports scope truth" `Quick
-        test_claim_no_eligible_persisted_scope_reports_scope_truth;
+      test_case "claim does not cross-goal when auto goal scope is empty" `Quick
+        test_claim_does_not_cross_goal_when_auto_goal_scope_empty;
+      test_case "claim does not cross-goal when persisted goal scope is empty"
+        `Quick
+        test_claim_does_not_cross_goal_when_persisted_goal_scope_empty;
+      test_case "claim does not cross-goal when scoped task requires missing tool"
+        `Quick
+        test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool;
+      test_case
+        "claim does not cross-goal when scoped task is verification blocked"
+        `Quick
+        test_claim_does_not_cross_goal_when_scoped_task_is_verification_blocked;
+      test_case "claim no eligible scoped reports scope truth" `Quick
+        test_claim_no_eligible_scoped_reports_scope_truth;
       test_case "claim skips tasks requiring missing tools" `Quick
         test_claim_skips_required_tools_without_access;
       test_case "claim allows tasks requiring available tools" `Quick


### PR DESCRIPTION
## Summary
- Align `keeper_task_claim` with world observation: scoped keepers no longer clear `active_goal_ids` and claim unrelated goal tasks when their own active goal has no eligible work.
- Preserve `active_goal_ids` in claim scope and return a no-eligible result instead of product-domain fallback for auto-goal and persisted-goal paths.
- Keep the explicit `allow_empty_goal_scope_fallback` override path intact, so callers that intentionally allow empty-scope fallback can still claim cross-goal work.
- Carry fresh-build repairs needed after the main bump: `agent_sdk.base` in `lib/dune` and the shared `Coord_status_rendering.assigned_task_ids` implementation.

## Review Follow-up
- Addressed the unresolved review thread in `dafac1db0f` by moving the `is_auto_goal` read inside the `allow_empty_goal_scope_fallback` branch.
- This keeps the common no-fallback path from doing unnecessary goal-store reads.

## Live Evidence
- Latest live taskmaster turn showed `claimable_task_count=0` while scope traffic and `failed_task_count` remained high; prior board/task evidence showed cross-domain fallback claims into unrelated goal tasks.
- Code root cause: `Keeper_world_observation` already called `resolve_claim_goal_scope` with `allow_empty_goal_scope_fallback=false`, but `keeper_task_claim` used the default true path.

## Verification
- `git diff --check origin/main...HEAD`
- `MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_BUILD_DIR=$PWD/_build_claim_scope_verify4 scripts/dune-local.sh build test/test_keeper_task_dispatch.exe`
- `./_build_claim_scope_verify4/default/test/test_keeper_task_dispatch.exe` (38 tests pass)

## Guardrails
- Draft PR only.
- Do not add `human-approved-ready` unless a human explicitly approves.
