### PR TITLE
[P0] Fix main OCaml structure ratchet

### DIFF
--- a/lib/dashboard/dashboard_keeper_feature_catalog.mli
+++ b/lib/dashboard/dashboard_keeper_feature_catalog.mli
@@ -1,0 +1,10 @@
+(** Keeper feature catalog used by the dashboard feature-proof read model. *)
+
+type feature_spec = {
+  id : string;
+  label : string;
+  required_tools : string list;
+  next_action : string;
+}
+
+val tool_features : feature_spec list

--- a/lib/dashboard/dashboard_keeper_git_pr_proof.mli
+++ b/lib/dashboard/dashboard_keeper_git_pr_proof.mli
@@ -1,0 +1,8 @@
+(** Docker-backed keeper git-to-PR workflow proof read model. *)
+
+val json :
+  ?window_hours:float ->
+  n:int ->
+  keeper_names:string list ->
+  unit ->
+  Yojson.Safe.t

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
@@ -4,6 +4,9 @@ type failure_class = {
   sample : string option;
 }
 
+type failure_table =
+  (string, (string, int ref * string option ref) Hashtbl.t) Hashtbl.t
+
 type tool_keeper_stat = {
   name : string;
   calls : int;

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
@@ -4,8 +4,14 @@ type failure_class = {
   sample : string option;
 }
 
-type failure_table =
-  (string, (string, int ref * string option ref) Hashtbl.t) Hashtbl.t
+type failure_category_accumulator = {
+  mutable count : int;
+  mutable sample : string option;
+}
+
+type failure_categories = (string, failure_category_accumulator) Hashtbl.t
+
+type failure_table = (string, failure_categories) Hashtbl.t
 
 type tool_keeper_stat = {
   name : string;
@@ -231,17 +237,17 @@ let add_failure table tool category sample =
       Hashtbl.replace table tool categories;
       categories
   in
-  let count, saved_sample =
+  let accumulator =
     match Hashtbl.find_opt by_category key with
-    | Some values -> values
+    | Some accumulator -> accumulator
     | None ->
-      let values = (ref 0, ref None) in
-      Hashtbl.replace by_category key values;
-      values
+      let accumulator = { count = 0; sample = None } in
+      Hashtbl.replace by_category key accumulator;
+      accumulator
   in
-  incr count;
-  if !saved_sample = None && String.trim sample <> "" then
-    saved_sample := Some sample
+  accumulator.count <- accumulator.count + 1;
+  if accumulator.sample = None && String.trim sample <> "" then
+    accumulator.sample <- Some sample
 
 let keeper_record_filter keeper_names =
   let known_keepers = known_keeper_table keeper_names in
@@ -299,10 +305,11 @@ let classes_for table tool =
   | None -> []
   | Some categories ->
     Hashtbl.fold
-      (fun category (count, sample) acc ->
-         { category; count = !count; sample = !sample } :: acc)
+      (fun category accumulator acc ->
+         { category; count = accumulator.count; sample = accumulator.sample }
+         :: acc)
       categories []
-    |> List.sort (fun a b ->
+    |> List.sort (fun (a : failure_class) (b : failure_class) ->
       match Int.compare b.count a.count with
       | 0 -> String.compare a.category b.category
       | n -> n)

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.mli
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.mli
@@ -1,0 +1,45 @@
+(** Keeper tool-call failure and recovery proof helpers for dashboard read models. *)
+
+type tool_keeper_stat = {
+  name : string;
+  calls : int;
+  successes : int;
+  success_pct : float;
+  keepers : string list;
+  successful_keepers : string list;
+  failed_keepers : string list;
+  sandbox_profiles : string list;
+  network_modes : string list;
+  task_ids : string list;
+  goal_ids : string list;
+  latest_ts : float option;
+  latest_success_ts : float option;
+  latest_failure_ts : float option;
+}
+
+type failure_table
+
+val tool_success_of_record : Yojson.Safe.t -> bool
+
+val output_text : Yojson.Safe.t -> string
+
+val read_records :
+  ?window_hours:float ->
+  n:int ->
+  unit ->
+  Yojson.Safe.t list
+
+val keeper_stats_and_failures_by_tool :
+  ?window_hours:float ->
+  n:int ->
+  keeper_names:string list ->
+  unit ->
+  (string, tool_keeper_stat) Hashtbl.t * failure_table
+
+val classes_json : failure_table -> string -> Yojson.Safe.t
+
+val keeper_evidence_json :
+  (string, tool_keeper_stat) Hashtbl.t ->
+  keeper_names:string list ->
+  required_tools:string list ->
+  Yojson.Safe.t


### PR DESCRIPTION
## Summary

- Add curated interfaces for the three dashboard keeper proof modules that raised `lib_other_mli_missing`.
- Keep `Dashboard_keeper_tool_failure_proof.failure_table` abstract so callers use JSON/materialized helpers instead of depending on its nested hashtable shape.
- Leave the existing `lib/types/types_core.ml` baseline item untouched; that is already tracked by #13128.

## Review Follow-up

- Addressed the review thread in d217140086 by replacing the nested `(int ref * string option ref)` failure accumulator tuple with named accumulator types.
- `failure_table` remains abstract in the `.mli`; this only makes the internal representation self-describing.

## Why It Matters

Latest `main` CI failed in `OCaml Structure Ratchet` before the remaining heavy checks could complete:

```text
FAIL lib_other_mli_missing: 4 > baseline 1
```

This PR fixes the regression by adding the missing `.mli` files instead of raising the baseline.

## Verification

```bash
git diff --check
scripts/ocaml-structure-ratchet.sh
env MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13674_review scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_tool_exposure.exe
./_build_codex_13674_review/default/test/test_keeper_tool_exposure.exe
```

Results:

- `OCaml structure ratchet: OK`
- `test_keeper_tool_exposure.exe`: 64 tests passed.

## GitHub Checks

- `PR Live Gate`, `PR Sync Check`, `Godfile size`, `Workflow YAML syntax`, `Hardcoded model prefix`, and `Math.random in components` passed before the review follow-up push.
- Changed-surface workflow skipped the heavy PR jobs for this draft; local focused OCaml verification is listed above.
- `CI Gate` and `Draft Auto-Merge Guard` are expected to stay red while this draft has `agent-pr` and lacks the required human approval label `human-approved-ready`.

Closes #13670.
