### PR TITLE
[P0] Classify stale keeper broadcasts by root cause

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -733,6 +733,14 @@ let stale_broadcast_kill_class = function
       Some (stale_kill_class_label cls)
   | _ -> None
 
+let stale_turn_bucket stale_seconds =
+  if stale_seconds < 30.0 then "stale_turn_lt_30s"
+  else if stale_seconds < 60.0 then "stale_turn_30s_to_60s"
+  else if stale_seconds < 300.0 then "stale_turn_1m_to_5m"
+  else if stale_seconds < 600.0 then "stale_turn_5m_to_10m"
+  else if stale_seconds < 1_800.0 then "stale_turn_10m_to_30m"
+  else "stale_turn_ge_30m"
+
 let stale_broadcast_payload
     ~keeper_name ~agent_name ~cascade_name ~trace_id ~generation
     ~failure_reason
@@ -755,7 +763,7 @@ let stale_broadcast_payload
     ; "failure_reason", string_opt_json failure_reason_text
     ; "failure_reason_cohort", `String failure_reason_cohort
     ; "stale_kill_class", string_opt_json (stale_broadcast_kill_class failure_reason)
-    ; "stale_turn_bucket", `String (Printf.sprintf "stale_turn_%.0fs" stale_seconds)
+    ; "stale_turn_bucket", `String (stale_turn_bucket stale_seconds)
     ; "stale_seconds", `Float stale_seconds
     ; "last_turn_ts", `Float last_turn_ts
     ; "source", `String "watchdog"

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -703,25 +703,72 @@ let append (config : Coord.config) (receipt : t) =
    longer than the stale threshold. This is the path that catches the
    "KSM=Running but no live turn" failure mode where the heartbeat fiber is
    blocked on a long call and would otherwise never produce a receipt. *)
-let emit_stale_keeper_broadcast config
+let stale_kill_class_label = function
+  | Keeper_registry.Idle_turn _ -> "idle_turn"
+  | Keeper_registry.In_turn_hung _ -> "in_turn_hung"
+  | Keeper_registry.Noop_failure_loop _ -> "noop_failure_loop"
+
+let stale_terminal_reason_code = function
+  | Some (Keeper_registry.Provider_runtime_error { code; _ }) -> code
+  | Some (Keeper_registry.Tool_required_unsatisfied { code; _ }) -> code
+  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> "oas_timeout_budget"
+  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
+  | Some (Keeper_registry.Stale_termination_storm _) ->
+      "stale_termination_storm"
+  | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
+      "heartbeat_failures"
+  | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
+  | Some (Keeper_registry.Ambiguous_partial_commit _) ->
+      "ambiguous_partial_commit"
+  | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
+  | Some (Keeper_registry.Exception _) -> "exception"
+  | None -> "stale_turn_timeout"
+
+let stale_broadcast_failure_cohort = function
+  | Some _ as reason -> Keeper_registry.failure_reason_cohort_key reason
+  | None -> "stale_turn_timeout"
+
+let stale_broadcast_kill_class = function
+  | Some (Keeper_registry.Stale_turn_timeout cls) ->
+      Some (stale_kill_class_label cls)
+  | _ -> None
+
+let stale_broadcast_payload
     ~keeper_name ~agent_name ~cascade_name ~trace_id ~generation
+    ~failure_reason
     ~stale_seconds ~last_turn_ts =
   let cascade_name_string = cascade_name_to_string cascade_name in
+  let failure_reason_text =
+    Option.map Keeper_registry.failure_reason_to_string failure_reason
+  in
+  let failure_reason_cohort = stale_broadcast_failure_cohort failure_reason in
+  `Assoc
+    [ "schema", `String "keeper.operator_broadcast_required.v1"
+    ; "keeper_name", `String keeper_name
+    ; "agent_name", `String agent_name
+    ; "cascade_name", `String cascade_name_string
+    ; "trace_id", `String trace_id
+    ; "generation", `Int generation
+    ; "disposition", `String "stalled"
+    ; "disposition_reason", `String failure_reason_cohort
+    ; "terminal_reason_code", `String (stale_terminal_reason_code failure_reason)
+    ; "failure_reason", string_opt_json failure_reason_text
+    ; "failure_reason_cohort", `String failure_reason_cohort
+    ; "stale_kill_class", string_opt_json (stale_broadcast_kill_class failure_reason)
+    ; "stale_turn_bucket", `String (Printf.sprintf "stale_turn_%.0fs" stale_seconds)
+    ; "stale_seconds", `Float stale_seconds
+    ; "last_turn_ts", `Float last_turn_ts
+    ; "source", `String "watchdog"
+    ]
+
+let emit_stale_keeper_broadcast config
+    ~keeper_name ~agent_name ~cascade_name ~trace_id ~generation
+    ~failure_reason ~stale_seconds ~last_turn_ts =
+  let cascade_name_string = cascade_name_to_string cascade_name in
   let payload =
-    `Assoc
-      [ "schema", `String "keeper.operator_broadcast_required.v1"
-      ; "keeper_name", `String keeper_name
-      ; "agent_name", `String agent_name
-      ; "cascade_name", `String cascade_name_string
-      ; "trace_id", `String trace_id
-      ; "generation", `Int generation
-      ; "disposition", `String "stalled"
-      ; "disposition_reason"
-      , `String (Printf.sprintf "stale_turn_%.0fs" stale_seconds)
-      ; "stale_seconds", `Float stale_seconds
-      ; "last_turn_ts", `Float last_turn_ts
-      ; "source", `String "watchdog"
-      ]
+    stale_broadcast_payload ~keeper_name ~agent_name
+      ~cascade_name ~trace_id ~generation ~stale_seconds ~last_turn_ts
+      ~failure_reason
   in
   let event =
     Activity_graph.emit config

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -166,6 +166,20 @@ val operator_broadcast_payload :
     Exposed so tests can pin the diagnostic fields operators need when a
     keeper turn pauses or stalls silently. *)
 
+val stale_broadcast_payload :
+  keeper_name:string ->
+  agent_name:string ->
+  cascade_name:cascade_name ->
+  trace_id:string ->
+  generation:int ->
+  failure_reason:Keeper_registry.failure_reason option ->
+  stale_seconds:float ->
+  last_turn_ts:float ->
+  Yojson.Safe.t
+(** Structured watchdog payload. Keeps the exact [stale_seconds] while
+    exposing low-cardinality failure/cohort fields for dashboards and issue
+    aggregation. *)
+
 val append : Coord.config -> t -> unit
 val latest_json : Coord.config -> string -> Yojson.Safe.t option
 val latest_json_by_keeper :
@@ -183,6 +197,7 @@ val emit_stale_keeper_broadcast :
   cascade_name:cascade_name ->
   trace_id:string ->
   generation:int ->
+  failure_reason:Keeper_registry.failure_reason option ->
   stale_seconds:float ->
   last_turn_ts:float ->
   unit

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -329,11 +329,42 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                || now -. !last_broadcast_ts > threshold
              in
              if stale && cooldown_ok then begin
+               let emit_watchdog_broadcast ~failure_reason ~stall_seconds =
+                 try
+                   Keeper_execution_receipt.emit_stale_keeper_broadcast
+                     ctx.config
+                     ~keeper_name:meta.name
+                     ~agent_name:meta.agent_name
+                     ~cascade_name:
+                       (Keeper_execution_receipt.cascade_name_of_string
+                          meta.cascade_name)
+                     ~trace_id:
+                       (Keeper_id.Trace_id.to_string
+                          entry.meta.runtime.trace_id)
+                     ~generation:entry.meta.runtime.generation
+                     ~failure_reason
+                     ~stale_seconds:stall_seconds
+                     ~last_turn_ts:last_turn;
+                   last_broadcast_ts := now
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                   Prometheus.inc_counter
+                     Prometheus.metric_keeper_stale_broadcast_emit_failures
+                     ~labels:[("keeper", meta.name)]
+                     ();
+                   Log.Keeper.warn
+                     "%s: stale broadcast emit failed (restart still triggered): %s"
+                     meta.name (Printexc.to_string exn)
+               in
                match pending_oas_timeout_budget_count entry with
                | Some count when idle_stale ->
                  let stall_seconds = now -. last_turn in
+                 let failure_reason =
+                   Keeper_registry.Oas_timeout_budget_loop { count }
+                 in
                  Keeper_registry.set_failure_reason ~base_path meta.name
-                   (Some (Keeper_registry.Oas_timeout_budget_loop { count }));
+                   (Some failure_reason);
                  (* tla-lint: allow-mutation: fiber signal — stop the keeper
                     through the provider-timeout path, preserving the typed
                     root cause for supervisor auto-pause. *)
@@ -344,7 +375,9 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    ();
                  Log.Keeper.error
                    "%s: watchdog terminating fiber (oas_timeout_budget unresolved after idle %.0fs; count=%d; preserving provider timeout root cause) [cascade=%s]"
-                   meta.name stall_seconds count meta.cascade_name
+                   meta.name stall_seconds count meta.cascade_name;
+                 emit_watchdog_broadcast ~failure_reason:(Some failure_reason)
+                   ~stall_seconds
                | _ ->
                (* #10940 follow-up: surface the most recent skip reasons
                   alongside [idle %.0fs] so operators can tell whether
@@ -402,9 +435,12 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  if in_turn_stale then in_turn_age else now -. last_turn
                in
                let prior_failure_reason = entry.last_failure_reason in
+               let failure_reason =
+                 Keeper_registry.stale_watchdog_failure_reason
+                   ~prior:prior_failure_reason ~kill_class
+               in
                Keeper_registry.set_failure_reason ~base_path meta.name
-                 (Keeper_registry.stale_watchdog_failure_reason
-                    ~prior:prior_failure_reason ~kill_class);
+                 failure_reason;
                let force_released_slots =
                  if in_turn_stale || Option.is_some active_slot_holder_age then
                    Keeper_turn_slot.force_release_stale_holder
@@ -517,31 +553,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    (List.length batch) batch_window_sec
                    (String.concat ", " batch)
                end;
-               (try
-                  Keeper_execution_receipt.emit_stale_keeper_broadcast
-                    ctx.config
-                    ~keeper_name:meta.name
-                    ~agent_name:meta.agent_name
-                    ~cascade_name:
-                      (Keeper_execution_receipt.cascade_name_of_string
-                         meta.cascade_name)
-                    ~trace_id:
-                      (Keeper_id.Trace_id.to_string
-                         entry.meta.runtime.trace_id)
-                    ~generation:entry.meta.runtime.generation
-                    ~stale_seconds:stall_seconds
-                    ~last_turn_ts:last_turn;
-                  last_broadcast_ts := now
-                with
-                | Eio.Cancel.Cancelled _ as e -> raise e
-                | exn ->
-                  Prometheus.inc_counter
-                    Prometheus.metric_keeper_stale_broadcast_emit_failures
-                    ~labels:[("keeper", meta.name)]
-                    ();
-                  Log.Keeper.warn
-                    "%s: stale broadcast emit failed (restart still triggered): %s"
-                    meta.name (Printexc.to_string exn))
+               emit_watchdog_broadcast ~failure_reason ~stall_seconds
              end
            | None ->
              Log.Keeper.warn "%s: watchdog: registry entry NOT FOUND" meta.name

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -287,6 +287,59 @@ let test_broadcast_payload_carries_turn_diagnostics () =
   check string "stop reason" "completed"
     (payload |> U.member "stop_reason" |> U.to_string)
 
+let test_stale_broadcast_payload_uses_low_cardinality_stale_reason () =
+  let payload =
+    R.stale_broadcast_payload
+      ~keeper_name:"executor"
+      ~agent_name:"executor-agent"
+      ~cascade_name:(R.cascade_name_of_string "tier_fast")
+      ~trace_id:"trace-stale"
+      ~generation:7
+      ~failure_reason:None
+      ~stale_seconds:629.0
+      ~last_turn_ts:1777990000.0
+  in
+  check string "disposition reason" "stale_turn_timeout"
+    (payload |> U.member "disposition_reason" |> U.to_string);
+  check string "terminal reason" "stale_turn_timeout"
+    (payload |> U.member "terminal_reason_code" |> U.to_string);
+  check string "failure cohort" "stale_turn_timeout"
+    (payload |> U.member "failure_reason_cohort" |> U.to_string);
+  check string "stale bucket" "stale_turn_629s"
+    (payload |> U.member "stale_turn_bucket" |> U.to_string);
+  check bool "failure reason null" true
+    (match payload |> U.member "failure_reason" with
+     | `Null -> true
+     | _ -> false)
+
+let test_stale_broadcast_payload_preserves_provider_failure_reason () =
+  let failure_reason =
+    Masc_mcp.Keeper_registry.Provider_runtime_error
+      { code = "api_error_timeout"; detail = "Timeout after 300.0s" }
+  in
+  let payload =
+    R.stale_broadcast_payload
+      ~keeper_name:"executor"
+      ~agent_name:"executor-agent"
+      ~cascade_name:(R.cascade_name_of_string "tier_fast")
+      ~trace_id:"trace-stale"
+      ~generation:7
+      ~failure_reason:(Some failure_reason)
+      ~stale_seconds:630.0
+      ~last_turn_ts:1777990000.0
+  in
+  check string "disposition reason" "provider_runtime_error"
+    (payload |> U.member "disposition_reason" |> U.to_string);
+  check string "terminal reason" "api_error_timeout"
+    (payload |> U.member "terminal_reason_code" |> U.to_string);
+  check string "failure cohort" "provider_runtime_error"
+    (payload |> U.member "failure_reason_cohort" |> U.to_string);
+  check string "failure reason detail"
+    "provider_runtime_error(api_error_timeout:Timeout after 300.0s)"
+    (payload |> U.member "failure_reason" |> U.to_string);
+  check string "stale bucket" "stale_turn_630s"
+    (payload |> U.member "stale_turn_bucket" |> U.to_string)
+
 let () =
   run "keeper_pause_broadcast"
     [
@@ -325,5 +378,9 @@ let () =
             test_each_broadcast_disp_is_reachable;
           test_case "broadcast payload carries turn diagnostics" `Quick
             test_broadcast_payload_carries_turn_diagnostics;
+          test_case "stale payload uses low-cardinality reason" `Quick
+            test_stale_broadcast_payload_uses_low_cardinality_stale_reason;
+          test_case "stale payload preserves provider failure reason" `Quick
+            test_stale_broadcast_payload_preserves_provider_failure_reason;
         ] );
     ]

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -305,7 +305,7 @@ let test_stale_broadcast_payload_uses_low_cardinality_stale_reason () =
     (payload |> U.member "terminal_reason_code" |> U.to_string);
   check string "failure cohort" "stale_turn_timeout"
     (payload |> U.member "failure_reason_cohort" |> U.to_string);
-  check string "stale bucket" "stale_turn_629s"
+  check string "stale bucket" "stale_turn_10m_to_30m"
     (payload |> U.member "stale_turn_bucket" |> U.to_string);
   check bool "failure reason null" true
     (match payload |> U.member "failure_reason" with
@@ -337,7 +337,61 @@ let test_stale_broadcast_payload_preserves_provider_failure_reason () =
   check string "failure reason detail"
     "provider_runtime_error(api_error_timeout:Timeout after 300.0s)"
     (payload |> U.member "failure_reason" |> U.to_string);
-  check string "stale bucket" "stale_turn_630s"
+  check string "stale bucket" "stale_turn_10m_to_30m"
+    (payload |> U.member "stale_turn_bucket" |> U.to_string)
+
+let test_stale_broadcast_payload_preserves_required_tool_failure_reason () =
+  let failure_reason =
+    Masc_mcp.Keeper_registry.Tool_required_unsatisfied
+      { code = "missing_required_tool_use"; detail = "keeper_shell missing" }
+  in
+  let payload =
+    R.stale_broadcast_payload
+      ~keeper_name:"executor"
+      ~agent_name:"executor-agent"
+      ~cascade_name:(R.cascade_name_of_string "tier_fast")
+      ~trace_id:"trace-stale"
+      ~generation:7
+      ~failure_reason:(Some failure_reason)
+      ~stale_seconds:75.0
+      ~last_turn_ts:1777990000.0
+  in
+  check string "disposition reason" "tool_required_unsatisfied"
+    (payload |> U.member "disposition_reason" |> U.to_string);
+  check string "terminal reason" "missing_required_tool_use"
+    (payload |> U.member "terminal_reason_code" |> U.to_string);
+  check string "failure cohort" "tool_required_unsatisfied"
+    (payload |> U.member "failure_reason_cohort" |> U.to_string);
+  check string "failure reason detail"
+    "tool_required_unsatisfied(missing_required_tool_use:keeper_shell missing)"
+    (payload |> U.member "failure_reason" |> U.to_string);
+  check string "stale bucket" "stale_turn_1m_to_5m"
+    (payload |> U.member "stale_turn_bucket" |> U.to_string)
+
+let test_stale_broadcast_payload_preserves_timeout_budget_failure_reason () =
+  let failure_reason =
+    Masc_mcp.Keeper_registry.Oas_timeout_budget_loop { count = 4 }
+  in
+  let payload =
+    R.stale_broadcast_payload
+      ~keeper_name:"executor"
+      ~agent_name:"executor-agent"
+      ~cascade_name:(R.cascade_name_of_string "tier_fast")
+      ~trace_id:"trace-stale"
+      ~generation:7
+      ~failure_reason:(Some failure_reason)
+      ~stale_seconds:1_900.0
+      ~last_turn_ts:1777990000.0
+  in
+  check string "disposition reason" "oas_timeout_budget_loop"
+    (payload |> U.member "disposition_reason" |> U.to_string);
+  check string "terminal reason" "oas_timeout_budget"
+    (payload |> U.member "terminal_reason_code" |> U.to_string);
+  check string "failure cohort" "oas_timeout_budget_loop"
+    (payload |> U.member "failure_reason_cohort" |> U.to_string);
+  check string "failure reason detail" "oas_timeout_budget_loop(count=4)"
+    (payload |> U.member "failure_reason" |> U.to_string);
+  check string "stale bucket" "stale_turn_ge_30m"
     (payload |> U.member "stale_turn_bucket" |> U.to_string)
 
 let () =
@@ -382,5 +436,9 @@ let () =
             test_stale_broadcast_payload_uses_low_cardinality_stale_reason;
           test_case "stale payload preserves provider failure reason" `Quick
             test_stale_broadcast_payload_preserves_provider_failure_reason;
+          test_case "stale payload preserves required-tool failure reason" `Quick
+            test_stale_broadcast_payload_preserves_required_tool_failure_reason;
+          test_case "stale payload preserves timeout-budget failure reason" `Quick
+            test_stale_broadcast_payload_preserves_timeout_budget_failure_reason;
         ] );
     ]


### PR DESCRIPTION
## Summary
- preserve typed root-cause fields on stale keeper watchdog broadcasts
- keep low-cardinality stale disposition buckets while carrying terminal/provider/tool failure detail
- add regression coverage for stale payload root-cause preservation

## Review Follow-up
- Addressed stale_turn_bucket cardinality by replacing per-second bucket labels with bounded ranges: lt_30s, 30s_to_60s, 1m_to_5m, 5m_to_10m, 10m_to_30m, ge_30m.
- Added stale-broadcast regression coverage for Tool_required_unsatisfied and Oas_timeout_budget_loop so terminal_reason_code, failure_reason, and cohort stay typed.

## Why it matters
Live `~/me/.masc` evidence for #13632 showed stale-turn broadcasts collapsing timeout, provider-runtime, and required-tool failures into generic stale buckets. Operators need the broadcast payload to show both the stale-turn class and the underlying failure reason so dashboard/runtime-trust triage does not stop at "stale".

## Validation
- `git diff --check`
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13675_review2 scripts/dune-local.sh build test/test_keeper_pause_broadcast.exe`
- `./_build_codex_13675_review2/default/test/test_keeper_pause_broadcast.exe` -> 18 tests

Note: first build attempt in `_build_codex_13675_review` hit an external OCaml artefact consistency error (`Agent_sdk__Agent` cmx assumptions). Re-running in a fresh build dir passed.

Fixes #13632