### PR TITLE
fix(telemetry): observe admission rejections

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -152,9 +152,11 @@ let format_fd_growth_hint ~keeper_name ~fd_count ~now =
           " [Δ%+d fd in %.0fs = %+.1f fd/min, %s; previous fd=%d at %.0fs ago]"
           dfd dt rate_per_min trend prev_fd dt)
 
-let check_host_resources ~keeper_name =
-  let fd_count = Prometheus.approximate_open_fd_count () in
-  let threshold = Prometheus.fd_warn_threshold in
+let observe_rejection ~surface ~reason =
+  Safe_ops.protect ~default:() (fun () ->
+      Admission_queue_metrics.on_reject ~surface ~reason)
+
+let check_host_resources_with ~surface ~keeper_name ~fd_count ~threshold =
   if fd_count >= threshold * 9 / 10 then begin
     (* #10745: include fd-growth rate inline so the leak signal does
        not require log scrubbing.  Monotonic positive trend across
@@ -170,12 +172,20 @@ let check_host_resources ~keeper_name =
         fd_count threshold hint
     in
     Log.Misc.warn "admission rejected for %s: %s" keeper_name msg;
+    observe_rejection ~surface ~reason:Admission_queue_metrics.Host_resource_saturated;
     Error (`Host_resource_saturated msg)
   end else
     Ok ()
 
+let check_host_resources ~surface ~keeper_name =
+  let fd_count = Prometheus.approximate_open_fd_count () in
+  let threshold = Prometheus.fd_warn_threshold in
+  check_host_resources_with ~surface ~keeper_name ~fd_count ~threshold
+
 let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
-  match check_host_resources ~keeper_name with
+  match
+    check_host_resources ~surface:Admission_queue_metrics.With_permit ~keeper_name
+  with
   | Error _ as e -> e
   | Ok () ->
       (* Passthrough: provider-level throttling belongs in OAS (cascade),
@@ -189,7 +199,11 @@ let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
       Ok (with_inflight_observation ~keeper_name ~cascade_name f)
 
 let try_with_permit ~priority:_ ~keeper_name ~cascade_name f =
-  match check_host_resources ~keeper_name with
+  match
+    check_host_resources
+      ~surface:Admission_queue_metrics.Try_with_permit
+      ~keeper_name
+  with
   | Error _ -> None
   | Ok () ->
       Some (with_inflight_observation ~keeper_name ~cascade_name f)
@@ -239,3 +253,8 @@ let reset_for_test ~max_slots =
     global.active <- 0;
     global.waiters <- []);
   Admission_queue_metrics.set_max_concurrent max_slots
+
+module For_testing = struct
+  let check_host_resources ~surface ~keeper_name ~fd_count ~threshold =
+    check_host_resources_with ~surface ~keeper_name ~fd_count ~threshold
+end

--- a/lib/admission_queue.mli
+++ b/lib/admission_queue.mli
@@ -74,3 +74,16 @@ val max_concurrent : unit -> int
 
 val reset_for_test : max_slots:int -> unit
 (** Reset queue state for testing. Not for production use. *)
+
+module For_testing : sig
+  (** Test-only hooks. These are exposed for deterministic unit coverage and are
+      not part of the production API contract. *)
+
+  val check_host_resources :
+    surface:Admission_queue_metrics.rejection_surface ->
+    keeper_name:string ->
+    fd_count:int ->
+    threshold:int ->
+    (unit, [> `Host_resource_saturated of string ]) result
+  (** Deterministic host-resource check for threshold tests. *)
+end

--- a/lib/admission_queue_metrics.ml
+++ b/lib/admission_queue_metrics.ml
@@ -2,6 +2,16 @@
 
     @since 3.0.0 *)
 
+type rejection_surface = With_permit | Try_with_permit
+type rejection_reason = Host_resource_saturated
+
+let rejection_surface_label = function
+  | With_permit -> "with_permit"
+  | Try_with_permit -> "try_with_permit"
+
+let rejection_reason_label = function
+  | Host_resource_saturated -> "host_resource_saturated"
+
 let on_acquire ~keeper_name:_ ~cascade_name:_ ~wait_ms =
   Prometheus.inc_gauge Prometheus.metric_inference_queue_inflight ();
   Prometheus.inc_counter Prometheus.metric_inference_queue_acquired ();
@@ -10,6 +20,15 @@ let on_acquire ~keeper_name:_ ~cascade_name:_ ~wait_ms =
 
 let on_release ~keeper_name:_ ~cascade_name:_ =
   Prometheus.dec_gauge Prometheus.metric_inference_queue_inflight ()
+
+let on_reject ~surface ~reason =
+  Prometheus.inc_counter Prometheus.metric_inference_queue_rejected
+    ~labels:
+      [
+        ("surface", rejection_surface_label surface);
+        ("reason", rejection_reason_label reason);
+      ]
+    ()
 
 let set_max_concurrent value =
   Prometheus.set_gauge Prometheus.metric_inference_queue_max_concurrent

--- a/lib/admission_queue_metrics.mli
+++ b/lib/admission_queue_metrics.mli
@@ -5,6 +5,18 @@
 
     @since 3.0.0 *)
 
+type rejection_surface = With_permit | Try_with_permit
+(** Bounded [surface] label vocabulary for rejected admission requests. *)
+
+type rejection_reason = Host_resource_saturated
+(** Bounded [reason] label vocabulary for rejected admission requests. *)
+
+val rejection_surface_label : rejection_surface -> string
+(** Prometheus label value for a rejection surface. *)
+
+val rejection_reason_label : rejection_reason -> string
+(** Prometheus label value for a rejection reason. *)
+
 val on_acquire :
   keeper_name:string ->
   cascade_name:Keeper_cascade_profile.runtime_name ->
@@ -16,6 +28,11 @@ val on_acquire :
 val on_release :
   keeper_name:string -> cascade_name:Keeper_cascade_profile.runtime_name -> unit
 (** Called on release. Decrements inflight gauge. *)
+
+val on_reject : surface:rejection_surface -> reason:rejection_reason -> unit
+(** Called when admission rejects before running the callback.
+    Emits [surface=with_permit|try_with_permit] and
+    [reason=host_resource_saturated]. *)
 
 val set_max_concurrent : int -> unit
 (** Syncs the configured admission queue capacity into Prometheus. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -853,6 +853,7 @@ let metric_inference_queue_inflight = "masc_inference_queue_inflight"
 let metric_inference_queue_acquired = "masc_inference_queue_acquired_total"
 let metric_inference_queue_wait = "masc_inference_queue_wait_seconds"
 let metric_inference_queue_cancelled = "masc_inference_queue_cancelled_total"
+let metric_inference_queue_rejected = "masc_inference_queue_rejected_total"
 let metric_inference_queue_max_concurrent = "masc_inference_queue_max_concurrent"
 
 (* Agent health metrics — used in transport_metrics.ml. *)
@@ -1493,6 +1494,10 @@ let init () =
     "Total admission permits acquired" Counter;
   add metric_inference_queue_cancelled
     "Total admission waits cancelled by fiber cancellation" Counter;
+  add metric_inference_queue_rejected
+    "Total admission requests rejected before execution. Labels: \
+     surface=with_permit|try_with_permit, reason=host_resource_saturated"
+    Counter;
   register_histogram ~name:metric_inference_queue_wait
     ~help:"Time waiting in admission queue before exchanging for permit" ();
   (* LLM provider HTTP response counter — emitted by Llm_metric_bridge

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -920,6 +920,10 @@ val metric_inference_queue_inflight : string
 val metric_inference_queue_acquired : string
 val metric_inference_queue_wait : string
 val metric_inference_queue_cancelled : string
+val metric_inference_queue_rejected : string
+(** Total admission requests rejected before execution. Labels:
+    [surface=with_permit|try_with_permit] and
+    [reason=host_resource_saturated]. *)
 val metric_inference_queue_max_concurrent : string
 
 (** {1 Agent health metrics} *)

--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -264,6 +264,51 @@ let test_try_with_permit_releases_inflight_gauge () =
     in
     check (float 0.1) "try_with_permit balanced" before after)
 
+let rejected_metric ~surface =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_inference_queue_rejected
+    ~labels:
+      [
+        ( "surface",
+          Masc_mcp.Admission_queue_metrics.rejection_surface_label surface );
+        ( "reason",
+          Masc_mcp.Admission_queue_metrics.rejection_reason_label
+            Masc_mcp.Admission_queue_metrics.Host_resource_saturated );
+      ]
+    ()
+
+let test_host_resource_rejection_increments_counter () =
+  Eio_main.run (fun _env ->
+    let surface = Masc_mcp.Admission_queue_metrics.With_permit in
+    let before = rejected_metric ~surface in
+    match
+      AQ.For_testing.check_host_resources
+        ~surface
+        ~keeper_name:"fd-saturated-test"
+        ~fd_count:90
+        ~threshold:100
+    with
+    | Ok () -> fail "expected host resource rejection"
+    | Error (`Host_resource_saturated _) ->
+        check (float 0.1) "rejection counter increments" (before +. 1.0)
+          (rejected_metric ~surface))
+
+let test_host_resource_ok_does_not_increment_counter () =
+  Eio_main.run (fun _env ->
+    let surface = Masc_mcp.Admission_queue_metrics.Try_with_permit in
+    let before = rejected_metric ~surface in
+    match
+      AQ.For_testing.check_host_resources
+        ~surface
+        ~keeper_name:"fd-ok-test"
+        ~fd_count:89
+        ~threshold:100
+    with
+    | Error _ -> fail "unexpected host resource rejection"
+    | Ok () ->
+        check (float 0.1) "rejection counter unchanged" before
+          (rejected_metric ~surface))
+
 (* ============================================================
    Runner
    ============================================================ *)
@@ -303,5 +348,9 @@ let () =
         test_with_permit_increments_acquired_counter;
       test_case "try_with_permit balances inflight gauge" `Quick
         test_try_with_permit_releases_inflight_gauge;
+      test_case "host resource rejection increments counter" `Quick
+        test_host_resource_rejection_increments_counter;
+      test_case "host resource ok does not increment counter" `Quick
+        test_host_resource_ok_does_not_increment_counter;
     ];
   ]

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -278,6 +278,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_telemetry_unified_source_read_failures;
   check_registered Prometheus.metric_tool_assignment_telemetry_failures;
   check_registered Prometheus.metric_keeper_oas_hook_output_parse_failures;
+  check_registered Prometheus.metric_inference_queue_rejected;
   check_registered Prometheus.metric_coord_telemetry_drop;
   check_registered Prometheus.metric_coord_claim_post_provision_failures;
   check_registered Prometheus.metric_keeper_lifecycle_callback_failures;


### PR DESCRIPTION
## Summary
- add masc_inference_queue_rejected_total{surface,reason} for admission queue host-resource rejections
- thread explicit rejection surfaces through with_permit and try_with_permit
- add deterministic coverage for rejection and non-rejection paths plus Prometheus registration

## Why this matters
Admission queue saturation currently rejects work with only log/context symptoms. This makes the rejection path visible as a stable Prometheus counter split by caller surface and rejection reason.

## Verification
- ocamlc -stop-after parsing lib/admission_queue.ml lib/admission_queue.mli lib/admission_queue_metrics.ml lib/admission_queue_metrics.mli lib/prometheus.ml lib/prometheus.mli test/test_admission_queue_coverage.ml test/test_prometheus_coverage.ml
- git diff --check origin/main...HEAD

Not run in this rebase pass: scripts/dune-local.sh build test/test_admission_queue_coverage.exe test/test_prometheus_coverage.exe, because the shared opam lock is currently held by another worktree build. CI is the full verification surface for the rebased head.

## Review focus
Please check the metric label cardinality and that the deterministic For_testing.check_host_resources hook does not weaken the production admission guard.