### PR TITLE
Fix keeper goal-scoped claim fallback

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -143,7 +143,7 @@ persona_name = "analyst"
 | `tool_preset` | Optional | Deployment-specific policy override | Only when intentionally overriding persona default. |
 | `github_identity` | Optional | Bound GitHub CLI identity bundle | Resolves to `.masc/github-identities/<identity>/gh` for keeper-scoped `gh` auth. Required when `MASC_KEEPER_SANDBOX_HARD_MODE=true`. |
 | `git_identity_mode` | Optional | Commit identity policy | `keeper_alias` keeps git author separate from GitHub auth; `github_identity` is reserved for future explicit coupling. |
-| `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` prefers tasks linked to these goals, then falls back to all claimable tasks if the scoped pool has no task claimable with the keeper's current capabilities. |
+| `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` claims only tasks linked to these goals. If the scoped pool has no task claimable with the keeper's current capabilities, the claim stops; only auto-repaired keeper-purpose goals may fall back to all claimable tasks. |
 
 ### Additional supported overlay fields
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -281,7 +281,7 @@ spawn 시 인자로 직접 설정하는 필드.
 | `network_mode` | string | `inherit` 또는 `none` | 샌드박스 네트워크 정책. `docker`는 기본 `none` (기본 모드의 git/gh dispatch만 `inherit`으로 승격). hard mode에서는 `none`만 허용된다. | `masc_keeper_up`의 `network_mode` 인자 |
 | `github_identity` | string | 없음 | keeper에 바인딩된 GitHub CLI identity 이름. `.masc/github-identities/<identity>/gh` bundle을 사용한다. | `keeper.toml` 선언 |
 | `git_identity_mode` | string | `keeper_alias` | git author를 keeper alias로 유지할지, GitHub identity 기반 author로 결합할지 결정 | `keeper.toml` 선언 |
-| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task를 우선 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 전체 claimable task로 fallback | `keeper.toml` 선언 |
+| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task만 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 claim을 멈춘다. auto-repair keeper-purpose goal만 전체 claimable task fallback 허용 | `keeper.toml` 선언 |
 
 ### 3.1.1 Sandbox Core V1 사용법
 

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -65,7 +65,7 @@ let active_goal_ids_have_eligible_claim_task
             task)
 
 let resolve_claim_goal_scope ?agent_tool_names
-    ?(allow_empty_goal_scope_fallback = true) ~(config : Coord.config)
+    ?(allow_empty_goal_scope_fallback = false) ~(config : Coord.config)
     ~(meta : keeper_meta) () =
   match meta.active_goal_ids with
   | [] ->

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -13,6 +13,10 @@ type claim_goal_scope = {
 
 val resolve_claim_goal_scope :
   ?agent_tool_names:string list ->
+  (** [allow_empty_goal_scope_fallback] should stay false for normal keeper
+      task claims. Auto-repaired keeper-purpose goals may still fall back to
+      all tasks; explicit persisted [active_goal_ids] stay scoped unless this
+      flag is set. *)
   ?allow_empty_goal_scope_fallback:bool ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -832,10 +832,10 @@ Use for status updates, announcements, warnings, or coordination.";
     name = "keeper_task_claim";
     description = "Claim the next unclaimed todo task that matches your capabilities. \
 Returns claimed task details (task_id, title, description) or empty if none available. \
-If active_goal_ids are configured, goal-linked tasks are preferred; when that scoped \
-pool has no claimable task for your current capabilities, the claim stops instead of \
-crossing into unrelated goals. Auto-repaired keeper-purpose goals may still fall back \
-to all claimable tasks.";
+If active_goal_ids are configured, only tasks linked to those goals are eligible; \
+when that scoped pool has no claimable task for your current capabilities, the \
+claim stops instead of crossing into unrelated goals. Auto-repaired keeper-purpose \
+goals may still fall back to all claimable tasks.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -833,8 +833,9 @@ Use for status updates, announcements, warnings, or coordination.";
     description = "Claim the next unclaimed todo task that matches your capabilities. \
 Returns claimed task details (task_id, title, description) or empty if none available. \
 If active_goal_ids are configured, goal-linked tasks are preferred; when that scoped \
-pool has no claimable task for your current capabilities, the claim falls back to all \
-claimable tasks.";
+pool has no claimable task for your current capabilities, the claim stops instead of \
+crossing into unrelated goals. Auto-repaired keeper-purpose goals may still fall back \
+to all claimable tasks.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -168,6 +168,10 @@ let parse_json s =
   try Yojson.Safe.from_string s
   with _ -> failwith (Printf.sprintf "invalid JSON: %s" s)
 
+let json_is_null = function
+  | `Null -> true
+  | _ -> false
+
 let contains_substring s needle =
   let s_len = String.length s in
   let n_len = String.length needle in
@@ -564,7 +568,7 @@ let test_claim_falls_back_from_empty_auto_goal_scope () =
           String.length s > 0)
     | None -> fail "expected fallback to claim a product task")
 
-let test_claim_falls_back_from_empty_persisted_goal_scope () =
+let test_claim_stops_from_empty_persisted_goal_scope () =
   with_room (fun config ->
     let keeper_goal, _ =
       match Goal_store.upsert_goal config ~title:"Masc improver" () with
@@ -594,22 +598,32 @@ let test_claim_falls_back_from_empty_persisted_goal_scope () =
     in
     match claimed_task with
     | Some task ->
-      check string "claimed product task" "Product task" task.title;
+      fail
+        (Printf.sprintf
+           "expected persisted active_goal_ids to stop before claiming %s"
+           task.title)
+    | None ->
       let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+      check string "claim scope mode" "active_goal_ids"
         Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check int "effective goal ids cleared" 0
+      check int "effective goal ids retained" 1
         Yojson.Safe.Util.(
           scope |> member "effective_goal_ids" |> to_list |> List.length);
-      check string "claim scope matched product goal" product_goal.id
-        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string);
-      check bool "fallback reason present" true
+      check string "effective goal id" keeper_goal.id
         Yojson.Safe.Util.(
-          scope |> member "fallback_reason" |> to_string |> fun s ->
-          String.length s > 0)
-    | None -> fail "expected fallback to claim a product task")
+          scope |> member "effective_goal_ids" |> to_list |> List.hd
+          |> to_string);
+      check bool "fallback reason absent" true
+        Yojson.Safe.Util.(scope |> member "fallback_reason" |> json_is_null);
+      check bool "product goal stayed unclaimed" true
+        (Coord.get_tasks_raw config
+         |> List.exists (fun (task : Masc_domain.task) ->
+              String.equal task.title "Product task"
+              && Option.equal String.equal task.goal_id (Some product_goal.id)
+              &&
+              match task.task_status with Masc_domain.Todo -> true | _ -> false)))
 
-let test_claim_falls_back_when_scoped_task_requires_missing_tool () =
+let test_claim_stops_when_scoped_task_requires_missing_tool () =
   with_room (fun config ->
     let scoped_goal, _ =
       match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
@@ -641,6 +655,7 @@ let test_claim_falls_back_when_scoped_task_requires_missing_tool () =
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
+    let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     let claimed_task =
       Coord.get_tasks_raw config
       |> List.find_opt (fun (task : Masc_domain.task) ->
@@ -648,15 +663,31 @@ let test_claim_falls_back_when_scoped_task_requires_missing_tool () =
     in
     match claimed_task with
     | Some task ->
-      check string "claimed fallback task" "Product fallback task" task.title;
+      fail
+        (Printf.sprintf
+           "expected scoped missing-tool task to block fallback, claimed %s"
+           task.title)
+    | None ->
       let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+      check string "claim scope mode" "active_goal_ids"
         Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check string "claim scope matched product goal" product_goal.id
-        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string)
-    | None -> fail "expected fallback to claim product task")
+      check string "effective goal id" scoped_goal.id
+        Yojson.Safe.Util.(
+          scope |> member "effective_goal_ids" |> to_list |> List.hd
+          |> to_string);
+      check bool "message names scoped active goals" true
+        (contains_substring message "within active_goal_ids");
+      check bool "message avoids fallback" false
+        (contains_substring message "fallback");
+      check bool "product goal stayed unclaimed" true
+        (Coord.get_tasks_raw config
+         |> List.exists (fun (task : Masc_domain.task) ->
+              String.equal task.title "Product fallback task"
+              && Option.equal String.equal task.goal_id (Some product_goal.id)
+              &&
+              match task.task_status with Masc_domain.Todo -> true | _ -> false)))
 
-let test_claim_falls_back_when_scoped_task_is_verification_blocked () =
+let test_claim_stops_when_scoped_task_is_verification_blocked () =
   with_room (fun config ->
     let scoped_goal, _ =
       match Goal_store.upsert_goal config ~title:"Scoped verification goal" () with
@@ -682,6 +713,7 @@ let test_claim_falls_back_when_scoped_task_is_verification_blocked () =
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
+    let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     let claimed_task =
       Coord.get_tasks_raw config
       |> List.find_opt (fun (task : Masc_domain.task) ->
@@ -689,15 +721,31 @@ let test_claim_falls_back_when_scoped_task_is_verification_blocked () =
     in
     match claimed_task with
     | Some task ->
-      check string "claimed fallback task" "Product fallback task" task.title;
+      fail
+        (Printf.sprintf
+           "expected verification-blocked scoped task to block fallback, claimed %s"
+           task.title)
+    | None ->
       let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+      check string "claim scope mode" "active_goal_ids"
         Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check string "claim scope matched product goal" product_goal.id
-        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string)
-    | None -> fail "expected fallback to claim product task")
+      check string "effective goal id" scoped_goal.id
+        Yojson.Safe.Util.(
+          scope |> member "effective_goal_ids" |> to_list |> List.hd
+          |> to_string);
+      check bool "message names scoped active goals" true
+        (contains_substring message "within active_goal_ids");
+      check bool "message avoids fallback" false
+        (contains_substring message "fallback");
+      check bool "product goal stayed unclaimed" true
+        (Coord.get_tasks_raw config
+         |> List.exists (fun (task : Masc_domain.task) ->
+              String.equal task.title "Product fallback task"
+              && Option.equal String.equal task.goal_id (Some product_goal.id)
+              &&
+              match task.task_status with Masc_domain.Todo -> true | _ -> false)))
 
-let test_claim_no_eligible_after_fallback_reports_scope_truth () =
+let test_claim_no_eligible_persisted_scope_reports_scope_truth () =
   with_room (fun config ->
     let scoped_goal, _ =
       match Goal_store.upsert_goal config ~title:"Scoped keeper goal" () with
@@ -736,14 +784,20 @@ let test_claim_no_eligible_after_fallback_reports_scope_truth () =
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     let scope = Yojson.Safe.Util.member "claim_scope" json in
-    check string "claim scope mode" "empty_goal_scope_fallback_all_tasks"
+    check string "claim scope mode" "active_goal_ids"
       Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-    check bool "message names fallback search" true
-      (contains_substring message "fallback to all tasks");
-    check bool "message stops scope-lock diagnosis" true
-      (contains_substring message "Stop scope-lock diagnosis");
-    check bool "message avoids stale active scope" false
-      (contains_substring message "within active_goal_ids"))
+    check string "effective goal id" scoped_goal.id
+      Yojson.Safe.Util.(
+        scope |> member "effective_goal_ids" |> to_list |> List.hd
+        |> to_string);
+    check bool "message names active scope" true
+      (contains_substring message "within active_goal_ids");
+    check bool "message avoids fallback search" false
+      (contains_substring message "fallback");
+    check bool "message stops task checking" true
+      (contains_substring message "Stop task-checking");
+    check bool "excluded count present" true
+      Yojson.Safe.Util.(scope |> member "excluded_count" |> to_int |> fun n -> n > 0))
 
 let test_claim_skips_required_tools_without_access () =
   with_room (fun config ->
@@ -1218,14 +1272,14 @@ let () =
         test_claim_respects_active_goal_ids;
       test_case "claim falls back from empty auto goal scope" `Quick
         test_claim_falls_back_from_empty_auto_goal_scope;
-      test_case "claim falls back from empty persisted goal scope" `Quick
-        test_claim_falls_back_from_empty_persisted_goal_scope;
-      test_case "claim falls back when scoped task requires missing tool" `Quick
-        test_claim_falls_back_when_scoped_task_requires_missing_tool;
-      test_case "claim falls back when scoped task is verification blocked" `Quick
-        test_claim_falls_back_when_scoped_task_is_verification_blocked;
-      test_case "claim no eligible after fallback reports scope truth" `Quick
-        test_claim_no_eligible_after_fallback_reports_scope_truth;
+      test_case "claim stops from empty persisted goal scope" `Quick
+        test_claim_stops_from_empty_persisted_goal_scope;
+      test_case "claim stops when scoped task requires missing tool" `Quick
+        test_claim_stops_when_scoped_task_requires_missing_tool;
+      test_case "claim stops when scoped task is verification blocked" `Quick
+        test_claim_stops_when_scoped_task_is_verification_blocked;
+      test_case "claim no eligible persisted scope reports scope truth" `Quick
+        test_claim_no_eligible_persisted_scope_reports_scope_truth;
       test_case "claim skips tasks requiring missing tools" `Quick
         test_claim_skips_required_tools_without_access;
       test_case "claim allows tasks requiring available tools" `Quick

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -182,6 +182,13 @@ let contains_substring s needle =
   in
   if n_len = 0 then true else loop 0
 
+let check_effective_goal_ids label scope expected =
+  let actual =
+    Yojson.Safe.Util.(
+      scope |> member "effective_goal_ids" |> to_list |> List.map to_string)
+  in
+  check (list string) label expected actual
+
 let with_registered_keeper config meta f =
   Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_types.name;
   ignore
@@ -609,10 +616,7 @@ let test_claim_stops_from_empty_persisted_goal_scope () =
       check int "effective goal ids retained" 1
         Yojson.Safe.Util.(
           scope |> member "effective_goal_ids" |> to_list |> List.length);
-      check string "effective goal id" keeper_goal.id
-        Yojson.Safe.Util.(
-          scope |> member "effective_goal_ids" |> to_list |> List.hd
-          |> to_string);
+      check_effective_goal_ids "effective goal ids" scope [ keeper_goal.id ];
       check bool "fallback reason absent" true
         Yojson.Safe.Util.(scope |> member "fallback_reason" |> json_is_null);
       check bool "product goal stayed unclaimed" true
@@ -671,10 +675,7 @@ let test_claim_stops_when_scoped_task_requires_missing_tool () =
       let scope = Yojson.Safe.Util.member "claim_scope" json in
       check string "claim scope mode" "active_goal_ids"
         Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check string "effective goal id" scoped_goal.id
-        Yojson.Safe.Util.(
-          scope |> member "effective_goal_ids" |> to_list |> List.hd
-          |> to_string);
+      check_effective_goal_ids "effective goal ids" scope [ scoped_goal.id ];
       check bool "message names scoped active goals" true
         (contains_substring message "within active_goal_ids");
       check bool "message avoids fallback" false
@@ -729,10 +730,7 @@ let test_claim_stops_when_scoped_task_is_verification_blocked () =
       let scope = Yojson.Safe.Util.member "claim_scope" json in
       check string "claim scope mode" "active_goal_ids"
         Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check string "effective goal id" scoped_goal.id
-        Yojson.Safe.Util.(
-          scope |> member "effective_goal_ids" |> to_list |> List.hd
-          |> to_string);
+      check_effective_goal_ids "effective goal ids" scope [ scoped_goal.id ];
       check bool "message names scoped active goals" true
         (contains_substring message "within active_goal_ids");
       check bool "message avoids fallback" false
@@ -786,10 +784,7 @@ let test_claim_no_eligible_persisted_scope_reports_scope_truth () =
     let scope = Yojson.Safe.Util.member "claim_scope" json in
     check string "claim scope mode" "active_goal_ids"
       Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-    check string "effective goal id" scoped_goal.id
-      Yojson.Safe.Util.(
-        scope |> member "effective_goal_ids" |> to_list |> List.hd
-        |> to_string);
+    check_effective_goal_ids "effective goal ids" scope [ scoped_goal.id ];
     check bool "message names active scope" true
       (contains_substring message "within active_goal_ids");
     check bool "message avoids fallback search" false


### PR DESCRIPTION
## Summary

This tightens `keeper_task_claim` goal scoping for explicit/persisted `active_goal_ids`.

Previously, a keeper with `active_goal_ids` would fall back to all claimable tasks when its scoped pool had no currently claimable task. In the live runtime, that caused scope-lock loops where keepers with a real goal assignment claimed unrelated product/backlog tasks and then reported goal mismatch.

With this change:

- explicit persisted `active_goal_ids` stay scoped and return `No eligible tasks ... within active_goal_ids`
- auto-repaired keeper-purpose goals still keep the existing all-task fallback escape hatch
- tool docs and keeper docs describe the new boundary
- dispatch tests cover empty persisted scope, missing-tool scoped tasks, verification-blocked scoped tasks, and no-eligible scope truth

## Review Follow-up

- Clarified the `keeper_task_claim` tool description so configured `active_goal_ids` are described as strict eligibility scope, not preference.
- Replaced direct `List.hd` assertions on `claim_scope.effective_goal_ids` with `check_effective_goal_ids`, so empty or wrong lists fail as clear Alcotest assertions.

## Why This Matters

This is a direct blocker for proving Task/Board/Goal keeper autonomy. If keepers cross from their assigned goal into unrelated tasks, the runtime can show activity but not valid goal-directed work. Stopping at the scope boundary makes the blocker explicit and keeps the dashboard/task evidence auditable.

## Verification

- `git diff --check`
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13677_review scripts/dune-local.sh exec ./test/test_keeper_task_dispatch.exe -- test claim` -> 22 claim tests

## GitHub Checks

- Latest PR checks pass: CI Gate, Draft Auto-Merge Guard, PR Live Gate, PR Sync Check, Godfile size, Workflow YAML syntax, Hardcoded model prefix, and Math.random in components.
