### PR TITLE
fix(board): add board write tool timeout

### DIFF
--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -11,6 +11,7 @@ is effectively advisory.
 | Layer | Role | Typical cap | Source of truth |
 |-------|------|-------------|-----------------|
 | `Tool` | per-tool HTTP / shell invocation | 10–60 s | `Env_config_runtime.*`, `lib/tool_local_runtime_http.ml` |
+| `MCP tools/call` | outer per-tool dispatcher cap | 60 s default; board writes 90 s default | `MASC_TOOL_TIMEOUT_DEFAULT_SEC`, `MASC_TOOL_TIMEOUT_BOARD_SEC`, `Mcp_server_eio_call_tool.tool_timeout_sec_opt` |
 | `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 300 s default; provider attempt caps may be lower | `Env_config_keeper.oas_timeout_sec*`, `Oas_worker_named.effective_provider_attempt_timeout_s` |
 | `Keeper_turn` | one keeper turn (may issue many OAS calls) | 600 s default/hard ceiling | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
 | `Keeper_cycle` | full keeper lifecycle | N×turn | cycle supervisor |

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -568,9 +568,7 @@ let is_board_write_tool_name = function
   | "masc_board_delete"
   | "masc_board_cleanup"
   | "masc_board_reaction"
-  | "masc_board_curation_submit"
-  | "masc_board_delete"
-  | "masc_board_cleanup" -> true
+  | "masc_board_curation_submit" -> true
   | _ -> false
 
 let tool_timeout ~(tool_name : string) ~(_arguments : Yojson.Safe.t) :

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -540,6 +540,8 @@ type resolved_tool_timeout = {
 
 let tool_timeout_default_env = "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
 let tool_timeout_board_env = "MASC_TOOL_TIMEOUT_BOARD_SEC"
+let tool_timeout_persona_generate_source =
+  "internal:masc_persona_generate_oas_budget"
 
 let default_tool_timeout_sec () =
   Env_config_runtime.Tools.timeout_default_sec ()
@@ -589,7 +591,11 @@ let tool_timeout ~(tool_name : string) ~(_arguments : Yojson.Safe.t) :
       (* Persona generation runs an OAS worker with its own 120s budget. Keep
          the outer MCP tools/call timeout above that budget so callers see the
          generation result or the OAS error instead of a premature MCP timeout. *)
-      Some { timeout_sec = 150.0; source_env = None }
+      Some
+        {
+          timeout_sec = 150.0;
+          source_env = Some tool_timeout_persona_generate_source;
+        }
   | name when is_board_write_tool_name name ->
       (* #10569: board writes can queue behind the JSONL persist mutex. Keep
          them bounded, but avoid forcing them through the generic 60s budget
@@ -677,7 +683,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                (false,
                 let source =
                   match source_env with
-                  | Some env -> Printf.sprintf " (env: %s)" env
+                  | Some source -> Printf.sprintf " (timeout source: %s)" source
                   | None -> ""
                 in
                 Printf.sprintf "Tool timed out after %.0fs: %s%s"

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -565,6 +565,8 @@ let is_board_write_tool_name = function
   | "masc_board_comment"
   | "masc_board_vote"
   | "masc_board_comment_vote"
+  | "masc_board_delete"
+  | "masc_board_cleanup"
   | "masc_board_reaction"
   | "masc_board_curation_submit"
   | "masc_board_delete"

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -533,6 +533,11 @@ let coerce_tool_timeout_sec (raw_timeout_sec : float option) : float option =
       let raw_sec = int_of_float (Float.ceil raw) in
       Some (float_of_int (max 5 (min 300 raw_sec)))
 
+type resolved_tool_timeout = {
+  timeout_sec : float;
+  source_env : string option;
+}
+
 let tool_timeout_default_env = "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
 let tool_timeout_board_env = "MASC_TOOL_TIMEOUT_BOARD_SEC"
 
@@ -543,15 +548,17 @@ let board_write_tool_timeout_sec () =
   Env_config_runtime.Tools.board_write_timeout_sec ()
 
 (* SSOT for which board tools mutate state lives in [Tool_board]'s
-   [tool_required_permission]: CanBroadcast (post/comment/vote/comment_vote/reaction)
-   and CanAdmin (delete/cleanup) are all writes. Reads (list/get/stats/search/
-   profile/hearths/curation_read) keep the global default timeout. Keep this
-   list in sync when new mutating board tools are added. *)
+   [tool_required_permission]: CanBroadcast (post/comment/vote/comment_vote/
+   reaction/curation_submit) and CanAdmin (delete/cleanup) are all writes.
+   Reads (list/get/stats/search/profile/hearths/curation_read) keep the global
+   default timeout. Keep this list in sync when new mutating board tools are
+   added. *)
 let is_board_write_tool_name = function
   | "keeper_board_post"
   | "keeper_board_comment"
   | "keeper_board_vote"
   | "keeper_board_comment_vote"
+  | "keeper_board_curation_submit"
   | "keeper_board_delete"
   | "keeper_board_cleanup"
   | "masc_board_post"
@@ -559,18 +566,13 @@ let is_board_write_tool_name = function
   | "masc_board_vote"
   | "masc_board_comment_vote"
   | "masc_board_reaction"
+  | "masc_board_curation_submit"
   | "masc_board_delete"
   | "masc_board_cleanup" -> true
   | _ -> false
 
-let tool_timeout_source ~(tool_name : string) =
-  match tool_name with
-  | "masc_persona_generate" -> "internal:masc_persona_generate_outer_budget"
-  | _ when is_board_write_tool_name tool_name -> tool_timeout_board_env
-  | _ -> tool_timeout_default_env
-
-(** Optional per-tool timeout to prevent long calls from starving the request loop. *)
-let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : float option =
+let tool_timeout ~(tool_name : string) ~(_arguments : Yojson.Safe.t) :
+    resolved_tool_timeout option =
   match tool_name with
   | "masc_keeper_msg" ->
       (* No fixed timeout for keeper_msg. Keeper has its own internal limits
@@ -587,16 +589,27 @@ let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : f
       (* Persona generation runs an OAS worker with its own 120s budget. Keep
          the outer MCP tools/call timeout above that budget so callers see the
          generation result or the OAS error instead of a premature MCP timeout. *)
-      Some 150.0
-  | _ when is_board_write_tool_name tool_name ->
-      (* #10569: board writes have a dedicated outer budget. They now expose
-         persist lock acquire/held histograms, but a transient disk stall can
-         still exceed the generic 60s MCP default before the board path's own
-         diagnostics are useful. Keep this separate from the global default so
-         operators can tune board writes without raising every tool. *)
-      Some (board_write_tool_timeout_sec ())
+      Some { timeout_sec = 150.0; source_env = None }
+  | name when is_board_write_tool_name name ->
+      (* #10569: board writes can queue behind the JSONL persist mutex. Keep
+         them bounded, but avoid forcing them through the generic 60s budget
+         while persist-lock histograms identify queueing vs disk stall. *)
+      Some
+        {
+          timeout_sec = board_write_tool_timeout_sec ();
+          source_env = Some tool_timeout_board_env;
+        }
   | _ ->
-      Some (default_tool_timeout_sec ())
+      Some
+        {
+          timeout_sec = default_tool_timeout_sec ();
+          source_env = Some tool_timeout_default_env;
+        }
+
+(** Optional per-tool timeout to prevent long calls from starving the request loop. *)
+let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : float option =
+  tool_timeout ~tool_name ~_arguments
+  |> Option.map (fun timeout -> timeout.timeout_sec)
 
 (** Resolve managed agent tool call to canonical operation *)
 let resolve_managed_agent_call ?mcp_session_id params =
@@ -637,12 +650,12 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     let local_timeout_hit = ref false in
     let result =
       try
-        match tool_timeout_sec_opt ~tool_name:name ~_arguments:arguments with
+        match tool_timeout ~tool_name:name ~_arguments:arguments with
         | None ->
             execute_tool_eio ~sw ~clock ?profile:(Some profile) ?mcp_session_id ?auth_token
               ?internal_keeper_runtime:(Some internal_keeper_runtime)
               state ~name ~arguments
-        | Some timeout_sec ->
+        | Some { timeout_sec; source_env } ->
             (try
                Eio.Time.with_timeout_exn
                  clock
@@ -662,11 +675,13 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                local_timeout_hit := true;
                Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
                (false,
-                Printf.sprintf
-                  "Tool timed out after %.0fs: %s (env: %s)"
-                  timeout_sec
-                  name
-                  (tool_timeout_source ~tool_name:name)))
+                let source =
+                  match source_env with
+                  | Some env -> Printf.sprintf " (env: %s)" env
+                  | None -> ""
+                in
+                Printf.sprintf "Tool timed out after %.0fs: %s%s"
+                  timeout_sec name source))
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        (* Never let a tool exception crash the MCP server. *)
        let err = Printexc.to_string exn in

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -72,7 +72,8 @@ val tool_timeout_sec_opt :
     [MASC_TOOL_TIMEOUT_BOARD_SEC] (default 90s, clamped
     5s..300s). This includes keeper/masc board post/comment/vote,
     comment_vote, delete, cleanup, curation_submit, and
-    [masc_board_reaction]. Other bounded tools use
+    [masc_board_reaction]. [masc_persona_generate] uses a fixed
+    outer timeout above its internal OAS worker budget. Other bounded tools use
     [MASC_TOOL_TIMEOUT_DEFAULT_SEC] (default 60s, same
     clamp). [_arguments] is accepted for parity with future
     per-arg overrides but currently unused. *)

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -68,14 +68,14 @@ val tool_timeout_sec_opt :
 (** Returns the timeout (seconds) the dispatcher should
     apply to the call, [None] for tools that opt out
     (e.g. [masc_keeper_msg], which gates on its own
-    [max_turns] / [max_cost_usd]). Every mutating board tool
-    (post/comment/vote/comment_vote/reaction/curation_submit plus
-    admin delete/cleanup, across [keeper_board_*] and [masc_board_*]
-    aliases where present) uses [MASC_TOOL_TIMEOUT_BOARD_SEC]
-    (default 90s, clamped 5s..300s); other bounded tools use
-    [MASC_TOOL_TIMEOUT_DEFAULT_SEC] (default 60s, same clamp).
-    [_arguments] is accepted for parity with future per-arg overrides
-    but currently unused. *)
+    [max_turns] / [max_cost_usd]). Board write tools use
+    [MASC_TOOL_TIMEOUT_BOARD_SEC] (default 90s, clamped
+    5s..300s). This includes keeper/masc board post/comment/vote,
+    comment_vote, delete, cleanup, curation_submit, and
+    [masc_board_reaction]. Other bounded tools use
+    [MASC_TOOL_TIMEOUT_DEFAULT_SEC] (default 60s, same
+    clamp). [_arguments] is accepted for parity with future
+    per-arg overrides but currently unused. *)
 
 (** {1 Runtime-MCP keeper trace context} *)
 

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -68,16 +68,14 @@ val tool_timeout_sec_opt :
 (** Returns the timeout (seconds) the dispatcher should
     apply to the call, [None] for tools that opt out
     (e.g. [masc_keeper_msg], which gates on its own
-    [max_turns] / [max_cost_usd]).  Every mutating board tool
-    (post/comment/vote/comment_vote/reaction plus admin
-    delete/cleanup, both [keeper_board_*] and [masc_board_*]
-    aliases — same set as [Tool_board.tool_required_permission]'s
-    [CanBroadcast]/[CanAdmin] classifications) uses
-    [MASC_TOOL_TIMEOUT_BOARD_SEC] (default 90s) instead of
-    [MASC_TOOL_TIMEOUT_DEFAULT_SEC] (default 60s) so operators can
-    tune board persistence separately from every other tool.
-    [_arguments] is accepted for parity with future per-arg
-    overrides but currently unused. *)
+    [max_turns] / [max_cost_usd]). Every mutating board tool
+    (post/comment/vote/comment_vote/reaction/curation_submit plus
+    admin delete/cleanup, across [keeper_board_*] and [masc_board_*]
+    aliases where present) uses [MASC_TOOL_TIMEOUT_BOARD_SEC]
+    (default 90s, clamped 5s..300s); other bounded tools use
+    [MASC_TOOL_TIMEOUT_DEFAULT_SEC] (default 60s, same clamp).
+    [_arguments] is accepted for parity with future per-arg overrides
+    but currently unused. *)
 
 (** {1 Runtime-MCP keeper trace context} *)
 

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -197,8 +197,6 @@ let test_board_write_tools_use_board_timeout_default () =
       "masc_board_cleanup";
       "masc_board_reaction";
       "masc_board_curation_submit";
-      "masc_board_delete";
-      "masc_board_cleanup";
     ];
   check (float 0.0001) "regular tool keeps generic default" 60.0
     (timeout_for_tool "masc_status")

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -23,14 +23,14 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
-let with_env name value f =
-  let previous = Sys.getenv_opt name in
-  Unix.putenv name value;
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Unix.putenv key (Option.value ~default:"" value);
   Fun.protect
     ~finally:(fun () ->
       match previous with
-      | Some v -> Unix.putenv name v
-      | None -> Unix.putenv name "")
+      | Some raw -> Unix.putenv key raw
+      | None -> Unix.putenv key "")
     f
 
 let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = [])
@@ -166,27 +166,54 @@ let test_regular_tool_uses_default_timeout () =
   | Some timeout_sec -> check bool "default timeout remains enabled" true (timeout_sec >= 5.)
   | None -> fail "expected masc_status to keep fixed timeout"
 
-let test_board_write_tool_uses_board_timeout_default () =
-  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" "" (fun () ->
-    match
-      Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
-        ~tool_name:"keeper_board_post"
-        ~_arguments:(`Assoc [])
-    with
-    | Some timeout_sec ->
-        check (float 0.001) "board write default timeout" 90.0 timeout_sec
-    | None -> fail "expected keeper_board_post to keep fixed timeout")
+let timeout_for_tool name =
+  match
+    Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
+      ~tool_name:name
+      ~_arguments:(`Assoc [])
+  with
+  | Some timeout_sec -> timeout_sec
+  | None -> fail ("expected bounded timeout for " ^ name)
 
-let test_board_write_tool_timeout_override () =
-  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" "123" (fun () ->
-    match
-      Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
-        ~tool_name:"masc_board_vote"
-        ~_arguments:(`Assoc [])
-    with
-    | Some timeout_sec ->
-        check (float 0.001) "board write timeout override" 123.0 timeout_sec
-    | None -> fail "expected masc_board_vote to keep fixed timeout")
+let test_board_write_tools_use_board_timeout_default () =
+  with_env "MASC_TOOL_TIMEOUT_DEFAULT_SEC" (Some "60") @@ fun () ->
+  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" None @@ fun () ->
+  List.iter
+    (fun name ->
+       check (float 0.0001) (name ^ " timeout") 90.0 (timeout_for_tool name))
+    [
+      "keeper_board_post";
+      "keeper_board_comment";
+      "keeper_board_vote";
+      "keeper_board_comment_vote";
+      "keeper_board_curation_submit";
+      "keeper_board_delete";
+      "keeper_board_cleanup";
+      "masc_board_post";
+      "masc_board_comment";
+      "masc_board_vote";
+      "masc_board_comment_vote";
+      "masc_board_reaction";
+      "masc_board_curation_submit";
+      "masc_board_delete";
+      "masc_board_cleanup";
+    ];
+  check (float 0.0001) "regular tool keeps generic default" 60.0
+    (timeout_for_tool "masc_status")
+
+let test_board_write_timeout_can_override_and_clamps () =
+  with_env "MASC_TOOL_TIMEOUT_DEFAULT_SEC" (Some "60") @@ fun () ->
+  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" (Some "120") @@ fun () ->
+  check (float 0.0001) "board override" 120.0
+    (timeout_for_tool "keeper_board_post");
+  check (float 0.0001) "regular unaffected" 60.0
+    (timeout_for_tool "masc_status");
+  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" (Some "1") @@ fun () ->
+  check (float 0.0001) "board min clamp" 5.0
+    (timeout_for_tool "keeper_board_post");
+  with_env "MASC_TOOL_TIMEOUT_BOARD_SEC" (Some "999") @@ fun () ->
+  check (float 0.0001) "board max clamp" 300.0
+    (timeout_for_tool "keeper_board_post")
 
 let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
   let base_path = temp_dir () in
@@ -467,10 +494,10 @@ let () =
           test_case "persona generate timeout exceeds OAS budget" `Quick
             test_persona_generate_timeout_exceeds_oas_budget;
           test_case "regular tool keeps default timeout" `Quick test_regular_tool_uses_default_timeout;
-          test_case "board write keeps board timeout default" `Quick
-            test_board_write_tool_uses_board_timeout_default;
-          test_case "board write timeout override" `Quick
-            test_board_write_tool_timeout_override;
+          test_case "board write tools use board timeout default" `Quick
+            test_board_write_tools_use_board_timeout_default;
+          test_case "board write timeout override clamps" `Quick
+            test_board_write_timeout_can_override_and_clamps;
           test_case "runtime MCP log context uses keeper trace/current turn" `Quick
             test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn;
           test_case "runtime MCP log context loads current task contract" `Quick

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -193,6 +193,8 @@ let test_board_write_tools_use_board_timeout_default () =
       "masc_board_comment";
       "masc_board_vote";
       "masc_board_comment_vote";
+      "masc_board_delete";
+      "masc_board_cleanup";
       "masc_board_reaction";
       "masc_board_curation_submit";
       "masc_board_delete";


### PR DESCRIPTION
## Summary

- add `MASC_TOOL_TIMEOUT_BOARD_SEC` for board write MCP tools, defaulting to 90s and clamped to 5s..300s
- keep regular bounded MCP tools on `MASC_TOOL_TIMEOUT_DEFAULT_SEC` with the existing 60s default
- document the tools/call timeout layer and add focused tests for board default, override, and clamp behavior

## Review Follow-up

- Expanded the board write timeout predicate to include board admin mutations: `keeper_board_delete`, `keeper_board_cleanup`, `masc_board_delete`, and `masc_board_cleanup`.
- Updated the interface comment so operators can see that post/comment/vote/comment_vote/curation_submit/delete/cleanup and `masc_board_reaction` use the board timeout bucket.
- Extended the timeout test matrix so admin board mutations are covered by the board-specific timeout default.

## Why

#10569 showed board write RPCs (`keeper_board_post`, comments, votes) all hitting the generic 60s tools/call cap while board persistence can queue behind the JSONL persist mutex. #13038 already added persist-lock histograms; this PR adds a bounded board-specific override so operators can mitigate queue pressure without changing synchronous durability semantics.

This is a mitigation, not the full async board-writer redesign.

## Validation

- `git diff --check origin/main..HEAD`
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13678_review scripts/dune-local.sh exec ./test/test_mcp_server_eio_call_tool.exe -- test timeout` was attempted but the Alcotest filter matched no tests.
- `./_build_codex_13678_review/default/test/test_mcp_server_eio_call_tool.exe` -> 12 tests

Refs #10569
