### PR TITLE
fix(dashboard): expose count badge metadata

### DIFF
--- a/dashboard/src/components/common/badge.a11y.test.ts
+++ b/dashboard/src/components/common/badge.a11y.test.ts
@@ -23,11 +23,15 @@ describe('CountBadge a11y', () => {
 
   it('default tone renders accessibly', async () => {
     render(html`<${CountBadge}>12<//>`, container)
+    const badge = container.querySelector('[data-count-badge]')!
+    expect(badge.getAttribute('data-count-badge-tone')).toBe('default')
+    expect(badge.getAttribute('data-count-badge-has-custom-class')).toBe('false')
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('warn tone renders accessibly', async () => {
     render(html`<${CountBadge} tone="warn">3<//>`, container)
+    expect(container.querySelector('[data-count-badge]')!.getAttribute('data-count-badge-tone')).toBe('warn')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -43,6 +47,7 @@ describe('CountBadge a11y', () => {
 
   it('accent tone renders accessibly', async () => {
     render(html`<${CountBadge} tone="accent">21<//>`, container)
+    expect(container.querySelector('[data-count-badge]')!.getAttribute('data-count-badge-tone')).toBe('accent')
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/common/badge.test.ts
+++ b/dashboard/src/components/common/badge.test.ts
@@ -1,44 +1,86 @@
-// @ts-nocheck
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { CountBadge } from './badge'
+import {
+  CountBadge,
+  countBadgeClasses,
+  summarizeCountBadge,
+  type CountBadgeProps,
+} from './badge'
+
+function renderCountBadge(props: Partial<CountBadgeProps> | null, value: string) {
+  const container = document.createElement('div')
+  render(h(CountBadge, props, value), container)
+  return container
+}
+
+describe('countBadgeClasses (pure)', () => {
+  it('combines base, tone, and custom classes without trailing whitespace', () => {
+    const cls = countBadgeClasses('warn', 'ml-2')
+    expect(cls).toContain('inline-flex')
+    expect(cls).toContain('bg-[var(--warn-12)]')
+    expect(cls).toContain('text-[var(--color-status-warn)]')
+    expect(cls).toContain('ml-2')
+    expect(countBadgeClasses('default')).not.toMatch(/\s$/)
+  })
+})
+
+describe('summarizeCountBadge (pure)', () => {
+  it('summarizes the default badge metadata without reading the DOM', () => {
+    expect(summarizeCountBadge({})).toEqual({
+      tone: 'default',
+      hasCustomClass: false,
+      classNameLength: 0,
+    })
+  })
+
+  it('summarizes custom class metadata', () => {
+    const className = 'ml-2 ring-1'
+    expect(summarizeCountBadge({ tone: 'accent', className })).toEqual({
+      tone: 'accent',
+      hasCustomClass: true,
+      classNameLength: className.length,
+    })
+  })
+})
 
 describe('CountBadge', () => {
   it('renders children', () => {
-    const container = document.createElement('div')
-    render(h(CountBadge, null, '42'), container)
+    const container = renderCountBadge(null, '42')
     expect(container.textContent).toBe('42')
   })
 
   it('applies default tone classes', () => {
-    const container = document.createElement('div')
-    render(h(CountBadge, null, '1'), container)
-    const el = container.querySelector('span')
+    const container = renderCountBadge(null, '1')
+    const el = container.querySelector('[data-count-badge]')
     expect(el).not.toBeNull()
     expect(el?.classList.contains('bg-[var(--color-bg-hover)]')).toBe(true)
     expect(el?.classList.contains('text-[var(--color-fg-muted)]')).toBe(true)
+    expect(el?.getAttribute('data-count-badge-tone')).toBe('default')
+    expect(el?.getAttribute('data-count-badge-has-custom-class')).toBe('false')
+    expect(el?.getAttribute('data-count-badge-class-length')).toBe('0')
   })
 
   it('applies warn tone', () => {
-    const container = document.createElement('div')
-    render(h(CountBadge, { tone: 'warn' }, '!'), container)
-    const el = container.querySelector('span')
+    const container = renderCountBadge({ tone: 'warn' }, '!')
+    const el = container.querySelector('[data-count-badge]')
     expect(el?.classList.contains('bg-[var(--warn-12)]')).toBe(true)
     expect(el?.classList.contains('text-[var(--color-status-warn)]')).toBe(true)
+    expect(el?.getAttribute('data-count-badge-tone')).toBe('warn')
   })
 
   it('applies ok tone', () => {
-    const container = document.createElement('div')
-    render(h(CountBadge, { tone: 'ok' }, 'OK'), container)
+    const container = renderCountBadge({ tone: 'ok' }, 'OK')
     const el = container.querySelector('span')
     expect(el?.classList.contains('bg-[var(--ok-10)]')).toBe(true)
   })
 
   it('applies custom class', () => {
-    const container = document.createElement('div')
-    render(h(CountBadge, { class: 'ml-2' }, '3'), container)
+    const className = 'ml-2'
+    const container = renderCountBadge({ class: className }, '3')
     const el = container.querySelector('span')
-    expect(el?.classList.contains('ml-2')).toBe(true)
+    expect(el?.classList.contains(className)).toBe(true)
+    expect(el?.getAttribute('data-count-badge-has-custom-class')).toBe('true')
+    expect(el?.getAttribute('data-count-badge-class-length')).toBe(String(className.length))
   })
 })

--- a/dashboard/src/components/common/badge.test.ts
+++ b/dashboard/src/components/common/badge.test.ts
@@ -30,17 +30,22 @@ describe('summarizeCountBadge (pure)', () => {
     expect(summarizeCountBadge({})).toEqual({
       tone: 'default',
       hasCustomClass: false,
-      classNameLength: 0,
+      customClassLength: 0,
     })
   })
 
-  it('summarizes custom class metadata', () => {
+  it('summarizes custom class metadata from CountBadgeProps', () => {
     const className = 'ml-2 ring-1'
-    expect(summarizeCountBadge({ tone: 'accent', className })).toEqual({
+    expect(summarizeCountBadge({ tone: 'accent', class: className })).toEqual({
       tone: 'accent',
       hasCustomClass: true,
-      classNameLength: className.length,
+      customClassLength: className.length,
     })
+  })
+
+  it('keeps className as a fallback alias but lets class win', () => {
+    expect(summarizeCountBadge({ className: 'ml-2' }).customClassLength).toBe(4)
+    expect(summarizeCountBadge({ class: 'ring-1', className: 'ml-2' }).customClassLength).toBe(6)
   })
 })
 
@@ -58,7 +63,7 @@ describe('CountBadge', () => {
     expect(el?.classList.contains('text-[var(--color-fg-muted)]')).toBe(true)
     expect(el?.getAttribute('data-count-badge-tone')).toBe('default')
     expect(el?.getAttribute('data-count-badge-has-custom-class')).toBe('false')
-    expect(el?.getAttribute('data-count-badge-class-length')).toBe('0')
+    expect(el?.getAttribute('data-count-badge-custom-class-length')).toBe('0')
   })
 
   it('applies warn tone', () => {
@@ -81,6 +86,6 @@ describe('CountBadge', () => {
     const el = container.querySelector('span')
     expect(el?.classList.contains(className)).toBe(true)
     expect(el?.getAttribute('data-count-badge-has-custom-class')).toBe('true')
-    expect(el?.getAttribute('data-count-badge-class-length')).toBe(String(className.length))
+    expect(el?.getAttribute('data-count-badge-custom-class-length')).toBe(String(className.length))
   })
 })

--- a/dashboard/src/components/common/badge.ts
+++ b/dashboard/src/components/common/badge.ts
@@ -9,7 +9,18 @@ export type BadgeTone = 'default' | 'warn' | 'ok' | 'bad' | 'accent'
 export interface CountBadgeSummary {
   readonly tone: BadgeTone
   readonly hasCustomClass: boolean
-  readonly classNameLength: number
+  readonly customClassLength: number
+}
+
+export interface CountBadgeProps {
+  tone?: BadgeTone
+  class?: string
+  children?: ComponentChildren
+}
+
+type CountBadgeSummaryInput = Pick<CountBadgeProps, 'tone' | 'class'> & {
+  /** Back-compat alias for older pure callers. `class` wins when both exist. */
+  className?: string
 }
 
 const TONE_CLASSES: Record<BadgeTone, string> = {
@@ -28,33 +39,26 @@ export function countBadgeClasses(tone: BadgeTone = 'default', extra?: string): 
 
 export function summarizeCountBadge({
   tone = 'default',
+  class: classProp,
   className,
-}: {
-  tone?: BadgeTone
-  className?: string
-}): CountBadgeSummary {
+}: CountBadgeSummaryInput): CountBadgeSummary {
+  const customClass = classProp ?? className
   return {
     tone,
-    hasCustomClass: className !== undefined && className !== '',
-    classNameLength: className?.length ?? 0,
+    hasCustomClass: customClass !== undefined && customClass !== '',
+    customClassLength: customClass?.length ?? 0,
   }
-}
-
-export interface CountBadgeProps {
-  tone?: BadgeTone
-  class?: string
-  children?: ComponentChildren
 }
 
 /** Compact count pill — e.g. task counts, filter chips */
 export function CountBadge({ tone = 'default', class: cx, children }: CountBadgeProps) {
-  const summary = summarizeCountBadge({ tone, className: cx })
+  const summary = summarizeCountBadge({ tone, class: cx })
   const cls = countBadgeClasses(tone, cx)
   return html`<span
     class=${cls}
     data-count-badge
     data-count-badge-tone=${summary.tone}
     data-count-badge-has-custom-class=${summary.hasCustomClass}
-    data-count-badge-class-length=${summary.classNameLength}
+    data-count-badge-custom-class-length=${summary.customClassLength}
   >${children}</span>`
 }

--- a/dashboard/src/components/common/badge.ts
+++ b/dashboard/src/components/common/badge.ts
@@ -4,7 +4,13 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-type BadgeTone = 'default' | 'warn' | 'ok' | 'bad' | 'accent'
+export type BadgeTone = 'default' | 'warn' | 'ok' | 'bad' | 'accent'
+
+export interface CountBadgeSummary {
+  readonly tone: BadgeTone
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+}
 
 const TONE_CLASSES: Record<BadgeTone, string> = {
   default: 'bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)]',
@@ -16,14 +22,39 @@ const TONE_CLASSES: Record<BadgeTone, string> = {
 
 const BASE = 'inline-flex items-center text-3xs px-1.5 py-px rounded-[var(--r-1)] tabular-nums font-medium'
 
-interface CountBadgeProps {
+export function countBadgeClasses(tone: BadgeTone = 'default', extra?: string): string {
+  return [BASE, TONE_CLASSES[tone], extra].filter(Boolean).join(' ')
+}
+
+export function summarizeCountBadge({
+  tone = 'default',
+  className,
+}: {
+  tone?: BadgeTone
+  className?: string
+}): CountBadgeSummary {
+  return {
+    tone,
+    hasCustomClass: className !== undefined && className !== '',
+    classNameLength: className?.length ?? 0,
+  }
+}
+
+export interface CountBadgeProps {
   tone?: BadgeTone
   class?: string
-  children: ComponentChildren
+  children?: ComponentChildren
 }
 
 /** Compact count pill — e.g. task counts, filter chips */
 export function CountBadge({ tone = 'default', class: cx, children }: CountBadgeProps) {
-  const cls = [BASE, TONE_CLASSES[tone], cx].filter(Boolean).join(' ')
-  return html`<span class=${cls}>${children}</span>`
+  const summary = summarizeCountBadge({ tone, className: cx })
+  const cls = countBadgeClasses(tone, cx)
+  return html`<span
+    class=${cls}
+    data-count-badge
+    data-count-badge-tone=${summary.tone}
+    data-count-badge-has-custom-class=${summary.hasCustomClass}
+    data-count-badge-class-length=${summary.classNameLength}
+  >${children}</span>`
 }


### PR DESCRIPTION
## Summary
- export BadgeTone, CountBadgeProps, CountBadgeSummary, countBadgeClasses, and summarizeCountBadge for pure badge state inspection
- add data-count-badge-* metadata for tone, custom class presence, and class length
- remove the old @ts-nocheck from badge tests while preserving existing tone palette and radius behavior
- extend unit and axe coverage for the new metadata hooks

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/badge.test.ts src/components/common/badge.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- browser QA via Vite port 5226: desktop /tmp/masc-count-badge-summary-0506.png, mobile /tmp/masc-count-badge-summary-0506-mobile.png
- pnpm --dir dashboard run lint: pass with existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts
- pnpm --dir dashboard run build: pass with existing Vite dynamic/static import and chunk-size warnings

## Notes
- This keeps CountBadge display-only and does not change the existing five-tone palette or compact pill sizing.