### PR TITLE
fix(telemetry): floor provider request latency

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -131,6 +131,10 @@ let emit_fallback_triggered ~kind ~detail =
     observability so a broken hook does not blank out the dashboard. *)
 let request_latency_metric = Prometheus.metric_llm_provider_request_latency
 
+let request_latency_seconds ~latency_ms =
+  let latency_ms = Stdlib.max 1 latency_ms in
+  Float.of_int latency_ms /. 1000.0
+
 (** Emit a single latency observation to the Prometheus histogram.
 
     Exposed so that per-call metrics sinks (e.g. the cascade-observation
@@ -138,7 +142,7 @@ let request_latency_metric = Prometheus.metric_llm_provider_request_latency
     same histogram without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_request_latency ~model_id ~latency_ms =
-  let seconds = Float.of_int latency_ms /. 1000.0 in
+  let seconds = request_latency_seconds ~latency_ms in
   Prometheus.observe_histogram request_latency_metric
     ~labels:[("model", model_id)] seconds
 

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -130,10 +130,17 @@ let emit_fallback_triggered ~kind ~detail =
     the AfterTurn hook later runs.  Provides redundant latency
     observability so a broken hook does not blank out the dashboard. *)
 let request_latency_metric = Prometheus.metric_llm_provider_request_latency
+let request_latency_clamped_metric =
+  Prometheus.metric_llm_provider_request_latency_clamped
 
 let request_latency_seconds ~latency_ms =
   let latency_ms = Stdlib.max 1 latency_ms in
   Float.of_int latency_ms /. 1000.0
+
+let emit_request_latency_clamped ~model_id ~reason =
+  Prometheus.inc_counter request_latency_clamped_metric
+    ~labels:[("model", model_id); ("reason", reason)]
+    ()
 
 (** Emit a single latency observation to the Prometheus histogram.
 
@@ -142,6 +149,8 @@ let request_latency_seconds ~latency_ms =
     same histogram without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_request_latency ~model_id ~latency_ms =
+  if latency_ms <= 0 then
+    emit_request_latency_clamped ~model_id ~reason:"non_positive_latency_ms";
   let seconds = request_latency_seconds ~latency_ms in
   Prometheus.observe_histogram request_latency_metric
     ~labels:[("model", model_id)] seconds

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -23,7 +23,9 @@ val emit_http_status :
 
 (** Emit a single latency observation to the Prometheus histogram.  Values
     below 1ms are recorded as 1ms so fast calls still produce a non-zero
-    histogram sum.
+    histogram sum; non-positive inputs also increment
+    [masc_llm_provider_request_latency_clamped_total] so sentinel or missing
+    durations remain visible.
 
     Called by both the global sink built in {!make_sink} and any
     per-call OAS [Metrics.t] literal that wants to forward

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -21,7 +21,10 @@ val http_status_metric : string
 val emit_http_status :
   provider:string -> model_id:string -> status:int -> unit
 
-(** Emit a single latency observation to the Prometheus histogram.
+(** Emit a single latency observation to the Prometheus histogram.  Values
+    below 1ms are recorded as 1ms so fast calls still produce a non-zero
+    histogram sum.
+
     Called by both the global sink built in {!make_sink} and any
     per-call OAS [Metrics.t] literal that wants to forward
     [on_request_end] (e.g. cascade observation captures).  Single

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -901,6 +901,8 @@ let metric_tool_call_duration = "masc_tool_call_duration_seconds"
 let metric_llm_provider_http_status = "masc_llm_provider_http_status_total"
 let metric_llm_provider_request_latency =
   "masc_llm_provider_request_latency_seconds"
+let metric_llm_provider_request_latency_clamped =
+  "masc_llm_provider_request_latency_clamped_total"
 let metric_llm_provider_capability_drops =
   "masc_llm_provider_capability_drops_total"
 let metric_llm_provider_cache_hits = "masc_llm_provider_cache_hits_total"
@@ -1492,6 +1494,10 @@ let init () =
     Counter;
   add metric_llm_provider_errors
     "Total OAS LLM request errors, labeled by model"
+    Counter;
+  add metric_llm_provider_request_latency_clamped
+    "Total OAS LLM request latency observations clamped before histogram \
+     emission, labeled by model and reason"
     Counter;
   add metric_llm_provider_retries
     "Total OAS LLM retries, labeled by provider, model, and attempt"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -452,6 +452,7 @@ val metric_tool_call : string
 val metric_tool_call_duration : string
 val metric_llm_provider_http_status : string
 val metric_llm_provider_request_latency : string
+val metric_llm_provider_request_latency_clamped : string
 val metric_llm_provider_capability_drops : string
 val metric_llm_provider_cache_hits : string
 val metric_llm_provider_cache_misses : string

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -91,6 +91,25 @@ let test_sink_records_oas_callbacks () =
     Prom.metric_llm_provider_output_tokens
     ~labels:provider_model_labels ~before:before_output ~delta:23.0
 
+let test_request_latency_clamps_zero_ms () =
+  let model_id =
+    Printf.sprintf "bridge-latency-zero-%d" (Unix.getpid ())
+  in
+  let labels = [ ("model", model_id) ] in
+  let before_sum =
+    metric Prom.metric_llm_provider_request_latency ~labels
+  in
+  let before_count =
+    metric (Prom.metric_llm_provider_request_latency ^ "_count") ~labels
+  in
+  Bridge.emit_request_latency ~model_id ~latency_ms:0;
+  check_metric_delta "latency sum floors to 1ms"
+    Prom.metric_llm_provider_request_latency
+    ~labels ~before:before_sum ~delta:0.001;
+  check_metric_delta "latency count +1"
+    (Prom.metric_llm_provider_request_latency ^ "_count")
+    ~labels ~before:before_count ~delta:1.0
+
 let () =
   Alcotest.run "llm_metric_bridge"
     [
@@ -100,5 +119,7 @@ let () =
             test_metric_names_stable;
           Alcotest.test_case "sink records OAS callbacks" `Quick
             test_sink_records_oas_callbacks;
+          Alcotest.test_case "request latency floors zero ms" `Quick
+            test_request_latency_clamps_zero_ms;
         ] );
     ]

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -38,7 +38,11 @@ let test_metric_names_stable () =
   Alcotest.(check string)
     "output tokens metric"
     "masc_llm_provider_output_tokens_total"
-    Prom.metric_llm_provider_output_tokens
+    Prom.metric_llm_provider_output_tokens;
+  Alcotest.(check string)
+    "request latency clamped metric"
+    "masc_llm_provider_request_latency_clamped_total"
+    Prom.metric_llm_provider_request_latency_clamped
 
 let test_sink_records_oas_callbacks () =
   let sink : Llm_provider.Metrics.t = Bridge.make_sink () in
@@ -102,13 +106,38 @@ let test_request_latency_clamps_zero_ms () =
   let before_count =
     metric (Prom.metric_llm_provider_request_latency ^ "_count") ~labels
   in
+  let clamped_labels =
+    [ ("model", model_id); ("reason", "non_positive_latency_ms") ]
+  in
+  let before_clamped =
+    metric Prom.metric_llm_provider_request_latency_clamped
+      ~labels:clamped_labels
+  in
   Bridge.emit_request_latency ~model_id ~latency_ms:0;
   check_metric_delta "latency sum floors to 1ms"
     Prom.metric_llm_provider_request_latency
     ~labels ~before:before_sum ~delta:0.001;
   check_metric_delta "latency count +1"
     (Prom.metric_llm_provider_request_latency ^ "_count")
-    ~labels ~before:before_count ~delta:1.0
+    ~labels ~before:before_count ~delta:1.0;
+  check_metric_delta "latency clamp +1"
+    Prom.metric_llm_provider_request_latency_clamped
+    ~labels:clamped_labels ~before:before_clamped ~delta:1.0
+
+let test_request_latency_positive_ms_does_not_clamp () =
+  let model_id =
+    Printf.sprintf "bridge-latency-positive-%d" (Unix.getpid ())
+  in
+  let labels =
+    [ ("model", model_id); ("reason", "non_positive_latency_ms") ]
+  in
+  let before =
+    metric Prom.metric_llm_provider_request_latency_clamped ~labels
+  in
+  Bridge.emit_request_latency ~model_id ~latency_ms:42;
+  check_metric_delta "positive latency avoids clamp counter"
+    Prom.metric_llm_provider_request_latency_clamped
+    ~labels ~before ~delta:0.0
 
 let () =
   Alcotest.run "llm_metric_bridge"
@@ -121,5 +150,7 @@ let () =
             test_sink_records_oas_callbacks;
           Alcotest.test_case "request latency floors zero ms" `Quick
             test_request_latency_clamps_zero_ms;
+          Alcotest.test_case "positive request latency does not clamp" `Quick
+            test_request_latency_positive_ms_does_not_clamp;
         ] );
     ]


### PR DESCRIPTION
## Summary
- floor provider request latency observations below 1ms to 1ms before writing the Prometheus histogram
- emit `masc_llm_provider_request_latency_clamped_total` when non-positive latency is clamped, with bounded labels `model` and `reason=non_positive_latency_ms`
- document the floor/counter on the bridge interface
- add regressions for zero-latency clamp accounting and positive-latency non-clamp behavior

## Why this matters
Fast provider callbacks can otherwise create histogram samples with count but zero sum, while `latency_ms = 0` can also mean unknown/not measured on error paths. The histogram keeps a non-zero floor, and the clamp counter lets operators detect coverage gaps instead of confusing missing duration with genuinely fast calls.

## Verification
- `git diff --check`
- `MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=_build_codex_13681_review scripts/dune-local.sh exec ./test/test_llm_metric_bridge.exe` -> 4 tests

## Review focus
Please check that the 1ms floor plus explicit clamp counter is acceptable for the Prometheus request-latency histogram and that label shape remains bounded.
