### PR TITLE
fix(dashboard): expose kbd metadata

### DIFF
--- a/dashboard/src/components/common/kbd.a11y.test.ts
+++ b/dashboard/src/components/common/kbd.a11y.test.ts
@@ -24,6 +24,9 @@ describe('Kbd a11y', () => {
 
   it('single-key default md size passes axe', async () => {
     render(html`<p>Press <${Kbd}>?<//></p>`, container)
+    const kbd = container.querySelector('[data-kbd]')!
+    expect(kbd.getAttribute('data-kbd-size')).toBe('md')
+    expect(kbd.getAttribute('data-kbd-has-title')).toBe('false')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -32,6 +35,7 @@ describe('Kbd a11y', () => {
       html`<p>Press <${Kbd} size="sm">/<//> to focus search</p>`,
       container,
     )
+    expect(container.querySelector('[data-kbd]')!.getAttribute('data-kbd-size')).toBe('sm')
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -50,6 +54,14 @@ describe('Kbd a11y', () => {
       </button>`,
       container,
     )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('title metadata passes axe', async () => {
+    render(html`<p>Open <${Kbd} title="Open command palette">⌘K<//></p>`, container)
+    const kbd = container.querySelector('[data-kbd]')!
+    expect(kbd.getAttribute('data-kbd-has-title')).toBe('true')
+    expect(kbd.getAttribute('data-kbd-title-length')).toBe('20')
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/common/kbd.test.ts
+++ b/dashboard/src/components/common/kbd.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { Kbd, kbdClasses } from './kbd'
+import { Kbd, kbdClasses, summarizeKbd } from './kbd'
 
 describe('kbdClasses (pure)', () => {
   it('default size is md (shortcut-sheet row baseline)', () => {
@@ -62,6 +62,28 @@ describe('kbdClasses (pure)', () => {
   })
 })
 
+describe('summarizeKbd (pure)', () => {
+  it('summarizes the default keyboard pill without reading the DOM', () => {
+    expect(summarizeKbd({})).toEqual({
+      size: 'md',
+      hasTitle: false,
+      hasCustomClass: false,
+      titleLength: 0,
+      classNameLength: 0,
+    })
+  })
+
+  it('summarizes title and custom class metadata', () => {
+    expect(summarizeKbd({ size: 'sm', title: 'Search', className: 'ml-1' })).toEqual({
+      size: 'sm',
+      hasTitle: true,
+      hasCustomClass: true,
+      titleLength: 6,
+      classNameLength: 4,
+    })
+  })
+})
+
 describe('Kbd component', () => {
   let container: HTMLElement
   beforeEach(() => {
@@ -78,6 +100,10 @@ describe('Kbd component', () => {
     const el = container.querySelector('kbd[data-kbd]')!
     expect(el.tagName).toBe('KBD')
     expect(el.textContent).toBe('⌘K')
+    expect(el.getAttribute('data-kbd-has-title')).toBe('false')
+    expect(el.getAttribute('data-kbd-has-custom-class')).toBe('false')
+    expect(el.getAttribute('data-kbd-title-length')).toBe('0')
+    expect(el.getAttribute('data-kbd-class-length')).toBe('0')
   })
 
   it('data-kbd-size reflects the size prop (default md)', () => {
@@ -90,8 +116,20 @@ describe('Kbd component', () => {
   })
 
   it('title attribute propagates (hover tooltip parity with raw <kbd>)', () => {
-    render(html`<${Kbd} title="단축키 목록 (?)">?<//>`, container)
+    const title = '단축키 목록 (?)'
+    render(html`<${Kbd} title=${title}>?<//>`, container)
     expect(container.querySelector('[data-kbd]')!.getAttribute('title')).toBe('단축키 목록 (?)')
+    expect(container.querySelector('[data-kbd]')!.getAttribute('data-kbd-has-title')).toBe('true')
+    expect(container.querySelector('[data-kbd]')!.getAttribute('data-kbd-title-length')).toBe(String(title.length))
+  })
+
+  it('custom class metadata reflects caller composition', () => {
+    const className = 'ml-1'
+    render(html`<${Kbd} class=${className}>?<//>`, container)
+    const el = container.querySelector('[data-kbd]')!
+    expect(el.className).toContain(className)
+    expect(el.getAttribute('data-kbd-has-custom-class')).toBe('true')
+    expect(el.getAttribute('data-kbd-class-length')).toBe(String(className.length))
   })
 
   it('testId renders as data-testid', () => {

--- a/dashboard/src/components/common/kbd.test.ts
+++ b/dashboard/src/components/common/kbd.test.ts
@@ -73,14 +73,19 @@ describe('summarizeKbd (pure)', () => {
     })
   })
 
-  it('summarizes title and custom class metadata', () => {
-    expect(summarizeKbd({ size: 'sm', title: 'Search', className: 'ml-1' })).toEqual({
+  it('summarizes title and custom class metadata from KbdProps', () => {
+    expect(summarizeKbd({ size: 'sm', title: 'Search', class: 'ml-1' })).toEqual({
       size: 'sm',
       hasTitle: true,
       hasCustomClass: true,
       titleLength: 6,
       classNameLength: 4,
     })
+  })
+
+  it('keeps className as a fallback alias but lets class win', () => {
+    expect(summarizeKbd({ className: 'ml-1' }).classNameLength).toBe(4)
+    expect(summarizeKbd({ class: 'mr-22', className: 'ml-1' }).classNameLength).toBe(5)
   })
 })
 

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -38,6 +38,25 @@ export interface KbdSummary {
   readonly classNameLength: number
 }
 
+export interface KbdProps {
+  /** Key label — e.g. "⌘K", "?", "1", "Ctrl+P". Supports multi-char
+      strings because the primitive deliberately doesn't parse chords;
+      callers that want auto-split key chords should compose several
+      <Kbd> with a "+" separator between them (GitHub convention). */
+  children?: ComponentChildren
+  size?: KbdSize
+  class?: string
+  /** HTML title attribute — hover tooltip. Matches the existing
+      `title="단축키 목록 (?)"` usage in fsm-hub.ts verbatim. */
+  title?: string
+  testId?: string
+}
+
+type KbdSummaryInput = Pick<KbdProps, 'size' | 'class' | 'title'> & {
+  /** Back-compat alias for older pure callers. `class` wins when both exist. */
+  className?: string
+}
+
 const BASE =
   'inline-flex items-center justify-center rounded-xs border border-b-2 font-mono text-center text-3xs ' +
   'border-[var(--color-border-strong)] bg-[var(--color-bg-elevated)]'
@@ -57,34 +76,18 @@ export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
 
 export function summarizeKbd({
   size = 'md',
+  class: classProp,
   className,
   title,
-}: {
-  size?: KbdSize
-  className?: string
-  title?: string
-}): KbdSummary {
+}: KbdSummaryInput): KbdSummary {
+  const customClass = classProp ?? className
   return {
     size,
     hasTitle: title !== undefined && title !== '',
-    hasCustomClass: className !== undefined && className !== '',
+    hasCustomClass: customClass !== undefined && customClass !== '',
     titleLength: title?.length ?? 0,
-    classNameLength: className?.length ?? 0,
+    classNameLength: customClass?.length ?? 0,
   }
-}
-
-export interface KbdProps {
-  /** Key label — e.g. "⌘K", "?", "1", "Ctrl+P". Supports multi-char
-      strings because the primitive deliberately doesn't parse chords;
-      callers that want auto-split key chords should compose several
-      <Kbd> with a "+" separator between them (GitHub convention). */
-  children?: ComponentChildren
-  size?: KbdSize
-  class?: string
-  /** HTML title attribute — hover tooltip. Matches the existing
-      `title="단축키 목록 (?)"` usage in fsm-hub.ts verbatim. */
-  title?: string
-  testId?: string
 }
 
 export function Kbd({
@@ -94,7 +97,7 @@ export function Kbd({
   title,
   testId,
 }: KbdProps) {
-  const summary = summarizeKbd({ size, className: cx, title })
+  const summary = summarizeKbd({ size, class: cx, title })
   const cls = kbdClasses(size, cx)
   return html`<kbd
     class=${cls}

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -28,7 +28,15 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-type KbdSize = 'sm' | 'md'
+export type KbdSize = 'sm' | 'md'
+
+export interface KbdSummary {
+  readonly size: KbdSize
+  readonly hasTitle: boolean
+  readonly hasCustomClass: boolean
+  readonly titleLength: number
+  readonly classNameLength: number
+}
 
 const BASE =
   'inline-flex items-center justify-center rounded-xs border border-b-2 font-mono text-center text-3xs ' +
@@ -47,7 +55,25 @@ export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
     : `${BASE} ${sized} ${extra}`
 }
 
-interface KbdProps {
+export function summarizeKbd({
+  size = 'md',
+  className,
+  title,
+}: {
+  size?: KbdSize
+  className?: string
+  title?: string
+}): KbdSummary {
+  return {
+    size,
+    hasTitle: title !== undefined && title !== '',
+    hasCustomClass: className !== undefined && className !== '',
+    titleLength: title?.length ?? 0,
+    classNameLength: className?.length ?? 0,
+  }
+}
+
+export interface KbdProps {
   /** Key label — e.g. "⌘K", "?", "1", "Ctrl+P". Supports multi-char
       strings because the primitive deliberately doesn't parse chords;
       callers that want auto-split key chords should compose several
@@ -68,11 +94,16 @@ export function Kbd({
   title,
   testId,
 }: KbdProps) {
+  const summary = summarizeKbd({ size, className: cx, title })
   const cls = kbdClasses(size, cx)
   return html`<kbd
     class=${cls}
     data-kbd
-    data-kbd-size=${size}
+    data-kbd-size=${summary.size}
+    data-kbd-has-title=${summary.hasTitle}
+    data-kbd-has-custom-class=${summary.hasCustomClass}
+    data-kbd-title-length=${summary.titleLength}
+    data-kbd-class-length=${summary.classNameLength}
     title=${title}
     data-testid=${testId}
   >${children}</kbd>`


### PR DESCRIPTION
## Summary
- export KbdSize, KbdProps, KbdSummary, and summarizeKbd for pure shortcut-pill state inspection
- add data-kbd-* metadata for size, title presence/length, custom class presence, and class length
- keep the existing md/sm chiclet styling and chord rendering behavior intact
- extend unit and axe coverage for title/custom-class metadata hooks

## Validation
- pnpm --dir dashboard exec vitest run src/components/common/kbd.test.ts src/components/common/kbd.a11y.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check
- browser QA via Vite port 5227: desktop /tmp/masc-kbd-summary-0506.png, mobile /tmp/masc-kbd-summary-0506-mobile.png
- pnpm --dir dashboard run lint: pass with existing warnings in copy-id-button.test.ts, virtual-list.ts, fsm-hub.ts
- pnpm --dir dashboard run build: pass with existing Vite dynamic/static import and chunk-size warnings

## Notes
- This keeps Kbd semantic-only and does not add chord parsing; callers still compose multiple Kbd atoms when they need split chords.