### PR TITLE
Fix Docker PR credential proof detection

### DIFF
--- a/lib/dashboard/dashboard_keeper_git_pr_proof.ml
+++ b/lib/dashboard/dashboard_keeper_git_pr_proof.ml
@@ -130,6 +130,42 @@ let has_docker_evidence record text =
 
 let has_git_credentials text = contains_substring text "\"git_creds_enabled\":true"
 
+let json_of_string_opt text =
+  try Some (Yojson.Safe.from_string text) with
+  | Yojson.Json_error _ -> None
+;;
+
+let rec string_field_values field = function
+  | `Assoc fields ->
+    let direct =
+      match List.assoc_opt field fields with
+      | Some (`String value) -> [ value ]
+      | _ -> []
+    in
+    direct @ List.concat_map (fun (_, value) -> string_field_values field value) fields
+  | `List values -> List.concat_map (string_field_values field) values
+  | _ -> []
+;;
+
+let json_has_string_field json field expected =
+  string_field_values field json |> List.exists (String.equal expected)
+;;
+
+let has_keeper_identity_credentials text =
+  let structured =
+    match json_of_string_opt text with
+    | None -> false
+    | Some json ->
+      json_has_string_field json "credential_scope" "keeper_identity"
+      && (json_has_string_field json "git_identity_mode" "github_identity"
+          || json_has_string_field json "state" "materialized")
+  in
+  structured
+  || (contains_substring text "\"credential_scope\":\"keeper_identity\""
+      && (contains_substring text "\"git_identity_mode\":\"github_identity\""
+          || contains_substring text "\"credential_state\":{\"state\":\"materialized\""))
+;;
+
 let stage_ids_for_record record =
   let tool = string_field_opt record "tool" |> Option.value ~default:"" in
   let input = lower (input_text record) in
@@ -137,6 +173,7 @@ let stage_ids_for_record record =
   let text = input ^ "\n" ^ output in
   let docker = has_docker_evidence record text in
   let git_creds = has_git_credentials text in
+  let keeper_creds = git_creds || has_keeper_identity_credentials output in
   let stages = ref [] in
   if docker && git_creds && contains_substring input "git clone"
   then stages := "docker_clone" :: !stages;
@@ -147,7 +184,7 @@ let stage_ids_for_record record =
   then stages := "push" :: !stages;
   if
     docker
-    && git_creds
+    && keeper_creds
     && String.equal tool "keeper_pr_create"
   then stages := "pr_create" :: !stages;
   List.rev !stages

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -158,6 +158,23 @@ let log_docker_bash ?(keeper_name = "alpha") ?(success = true) command =
     ~network_mode:"inherit"
     ()
 
+let log_keeper_pr_create_with_identity ?(keeper_name = "alpha") () =
+  Keeper_tool_call_log.log_call
+    ~keeper_name
+    ~tool_name:"keeper_pr_create"
+    ~input:
+      (`Assoc [
+        ("title", `String "proof: Docker credential PR lifecycle");
+        ("draft", `Bool true);
+      ])
+    ~output_text:
+      {|{"ok":true,"tool":"keeper_pr_create","operation":"pr_create","sandbox_profile":"docker","via":"docker","credential":{"credential_scope":"keeper_identity","git_identity_mode":"github_identity","credential_state":{"state":"materialized"}},"url":"https://github.com/jeong-sik/masc-mcp/pull/1"}|}
+    ~success:true
+    ~duration_ms:1.0
+    ~sandbox_profile:"docker"
+    ~network_mode:"inherit"
+    ()
+
 let write_decision_lines config keeper_name rows =
   let path = KT.keeper_decision_log_path config keeper_name in
   Fs_compat.mkdir_p (Filename.dirname path);
@@ -488,6 +505,35 @@ let test_docker_git_pr_workflow_reports_partial_chain () =
     (json_string_values "observed_keepers"
        (keeper_evidence "docker_git_pr_workflow" json))
 
+let test_keeper_pr_create_identity_output_counts_as_pr_stage () =
+  with_store @@ fun config ->
+  ignore
+    (persist_keeper config ~name:"alpha" ~total_turns:3
+       ~autonomous_action_count:2 ~autonomous_tool_turn_count:2
+       ~board_reactive_turn_count:1 ~proactive_count_total:1);
+  log_docker_bash
+    "git clone https://github.com/jeong-sik/masc-mcp.git /workspace/masc-mcp";
+  log_docker_bash "git checkout -b fix/keeper-proof";
+  log_docker_bash "git commit -m 'proof: keeper lifecycle'";
+  log_docker_bash "git push origin fix/keeper-proof";
+  log_keeper_pr_create_with_identity ();
+  let json =
+    Dashboard_keeper_feature_proof.json
+      ~config
+      ~n:100
+      ~success_threshold_pct:80.0
+      ()
+  in
+  check string "complete Docker git PR workflow passes" "pass"
+    (feature_status "docker_git_pr_workflow" json);
+  let stage_passed id =
+    match keeper_evidence_stage id json with
+    | Some row -> Safe_ops.json_bool ~default:false "passed" row
+    | None -> false
+  in
+  check bool "PR creation stage passes from keeper identity credential output" true
+    (stage_passed "pr_create")
+
 let test_decision_log_counts_as_scheduled_proof () =
   with_store @@ fun config ->
   let latest_success_ts = 1_777_001_500.0 in
@@ -639,6 +685,8 @@ let () =
             test_approval_latest_success_proves_recovery;
           test_case "Docker git PR workflow reports partial chain" `Quick
             test_docker_git_pr_workflow_reports_partial_chain;
+          test_case "keeper PR identity output counts as PR stage" `Quick
+            test_keeper_pr_create_identity_output_counts_as_pr_stage;
           test_case "decision log counts as scheduled proof" `Quick
             test_decision_log_counts_as_scheduled_proof;
           test_case "scheduled proof uses enabled population" `Quick


### PR DESCRIPTION
## Summary
- Detect keeper identity credential evidence in keeper_pr_create JSON output, not only git_creds_enabled=true shell output.
- Add a regression fixture matching the live Docker PR proof record shape.

## Why
The feature proof dashboard was still warning on Docker git-to-PR proof even though live logs had a successful keeper_pr_create with credential_scope=keeper_identity, git_identity_mode=github_identity, and Docker routing evidence. The old detector required git_creds_enabled=true, which appears on bash clone and push records but not on the PR creation tool result.

## Validation
- scripts/dune-local.sh build test/test_dashboard_keeper_feature_proof.exe bin/keeper_feature_proof_report.exe
- ./_build/default/test/test_dashboard_keeper_feature_proof.exe (8 tests)
- ./_build/default/bin/keeper_feature_proof_report.exe --base-path /Users/dancer/me --n 5000 --threshold 80.0 -> docker_git_pr_workflow pass, 5/5 stages
- git diff --check