### PR TITLE
fix(telemetry): count observed swallow failures

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -737,6 +737,11 @@ let metric_telemetry_unified_source_read_failures =
 let metric_tool_assignment_telemetry_failures =
   "masc_tool_assignment_telemetry_failures_total"
 
+(* Phase 0 exception visibility for [Telemetry_observe]: every swallowed
+   non-cancel exception logs and increments this bounded-by-callsite counter. *)
+let metric_telemetry_observe_failures =
+  "masc_telemetry_observe_failures_total"
+
 (* #10358 (c1): observability for the silent [Effect.Unhandled] catch-all
    in [lib/coord.ml] [observe_agent_lifecycle] / [observe_task_transition_event] /
    [Keeper_accountability.record_task_transition].  Those three try/with
@@ -2216,6 +2221,11 @@ let init () =
      site=read_recent_decode|read_recent_exception|warm_up_decode|\
      warm_up_exception. Any positive rate means tool assignment lifecycle \
      rows were dropped from the reconstructed read model."
+    Counter;
+  add metric_telemetry_observe_failures
+    "Total Telemetry_observe wrapper failures that were caught and returned \
+     as Error/default instead of silently disappearing. Labels: kind=<bounded \
+     call-site vocabulary>. Eio.Cancel.Cancelled is re-raised and not counted."
     Counter;
   add metric_coord_telemetry_drop
     "Total times a Coord lifecycle/transition hook dropped its Audit_log \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -406,6 +406,11 @@ val metric_tool_assignment_telemetry_failures : string
 (** Total tool-assignment telemetry decode/read failures. Labels:
     [site] is a bounded read/warm-up call-site vocabulary. *)
 
+val metric_telemetry_observe_failures : string
+(** Total {!Telemetry_observe} wrapper failures caught and returned as
+    [Error]/default. Labels: [kind] is the wrapper call-site vocabulary.
+    [Eio.Cancel.Cancelled] is re-raised and not counted. *)
+
 val metric_coord_telemetry_drop : string
 (** #10358 (c1): total times [lib/coord.ml]'s lifecycle hook caught
     [Stdlib.Effect.Unhandled] and dropped its Audit_log + Telemetry

--- a/lib/telemetry_observe.ml
+++ b/lib/telemetry_observe.ml
@@ -4,6 +4,8 @@ let observe_or_fail ~kind ?keeper_name f =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       let msg = Printexc.to_string exn in
+      Prometheus.inc_counter Prometheus.metric_telemetry_observe_failures
+        ~labels:[("kind", kind)] ();
       Log.Backend.warn ?keeper_name
         "[telemetry_observe] kind=%s caught exception: %s"
         kind msg;

--- a/lib/telemetry_observe.mli
+++ b/lib/telemetry_observe.mli
@@ -18,8 +18,9 @@ val observe_or_fail :
   ('a, string) result
 (** [observe_or_fail ~kind f] runs [f ()] and returns its [Ok]
     result.  On any exception other than [Eio.Cancel.Cancelled],
-    emits a structured warn log tagged with [kind] (and
-    [keeper_name] if supplied) and returns [Error msg].
+    increments [masc_telemetry_observe_failures_total{kind}], emits
+    a structured warn log tagged with [kind] (and [keeper_name] if
+    supplied), and returns [Error msg].
 
     [Cancelled] is re-raised so cooperative-cancel semantics are
     preserved — Step 5 (Cancelled swallow removal) depends on this. *)
@@ -44,6 +45,6 @@ val observe_or_default :
   'a
 (** [observe_or_default ~kind ~default f] runs [f ()] and returns
     its result, or [default] on exception while emitting a
-    structured log.  For call sites that genuinely need a
-    value-returning silent fall-back but want the failure surfaced
-    in observability. *)
+    structured log and incrementing the failure counter.  For call
+    sites that genuinely need a value-returning silent fall-back but
+    want the failure surfaced in observability. *)

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -279,6 +279,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_tool_assignment_telemetry_failures;
   check_registered Prometheus.metric_keeper_oas_hook_output_parse_failures;
   check_registered Prometheus.metric_inference_queue_rejected;
+  check_registered Prometheus.metric_telemetry_observe_failures;
   check_registered Prometheus.metric_coord_telemetry_drop;
   check_registered Prometheus.metric_coord_claim_post_provision_failures;
   check_registered Prometheus.metric_keeper_lifecycle_callback_failures;

--- a/test/test_telemetry_observe.ml
+++ b/test/test_telemetry_observe.ml
@@ -20,6 +20,10 @@
 
 open Masc_mcp
 
+let failure_metric_value kind =
+  Prometheus.metric_value_or_zero Prometheus.metric_telemetry_observe_failures
+    ~labels:[("kind", kind)] ()
+
 let test_observe_or_fail_returns_ok () =
   let result =
     Telemetry_observe.observe_or_fail ~kind:"test_ok" (fun () -> 42)
@@ -42,6 +46,29 @@ let test_observe_or_fail_returns_error () =
            true
          with Not_found -> false)
 
+let test_observe_or_fail_counts_exception () =
+  let kind = "test_observe_or_fail_counts_exception" in
+  let before = failure_metric_value kind in
+  let result =
+    Telemetry_observe.observe_or_fail ~kind (fun () ->
+        raise (Failure "synthetic-metric-failure"))
+  in
+  (match result with
+  | Ok _ -> Alcotest.fail "expected Error, got Ok"
+  | Error _ -> ());
+  let after = failure_metric_value kind in
+  Alcotest.(check (float 0.0001))
+    "failure counter increments once" (before +. 1.0) after
+
+let test_observe_or_fail_success_does_not_count () =
+  let kind = "test_observe_or_fail_success_does_not_count" in
+  let before = failure_metric_value kind in
+  let result = Telemetry_observe.observe_or_fail ~kind (fun () -> 11) in
+  Alcotest.(check (result int string)) "Ok 11" (Ok 11) result;
+  let after = failure_metric_value kind in
+  Alcotest.(check (float 0.0001))
+    "success leaves failure counter unchanged" before after
+
 let test_observe_or_fail_reraises_cancelled () =
   let raised = ref false in
   (try
@@ -55,6 +82,21 @@ let test_observe_or_fail_reraises_cancelled () =
   Alcotest.(check bool)
     "Eio.Cancel.Cancelled was re-raised, not swallowed"
     true !raised
+
+let test_observe_or_fail_cancelled_does_not_count () =
+  let kind = "test_observe_or_fail_cancelled_does_not_count" in
+  let before = failure_metric_value kind in
+  (try
+     let _ =
+       Telemetry_observe.observe_or_fail ~kind (fun () ->
+           raise (Eio.Cancel.Cancelled (Failure "synthetic-cancel")))
+     in
+     ()
+   with
+  | Eio.Cancel.Cancelled _ -> ());
+  let after = failure_metric_value kind in
+  Alcotest.(check (float 0.0001))
+    "Cancelled leaves failure counter unchanged" before after
 
 let test_observe_or_default_returns_value () =
   let v =
@@ -110,8 +152,14 @@ let () =
             test_observe_or_fail_returns_ok;
           Alcotest.test_case "returns Error on exception" `Quick
             test_observe_or_fail_returns_error;
+          Alcotest.test_case "counts exception" `Quick
+            test_observe_or_fail_counts_exception;
+          Alcotest.test_case "success does not count" `Quick
+            test_observe_or_fail_success_does_not_count;
           Alcotest.test_case "re-raises Eio.Cancel.Cancelled" `Quick
             test_observe_or_fail_reraises_cancelled;
+          Alcotest.test_case "Cancelled does not count" `Quick
+            test_observe_or_fail_cancelled_does_not_count;
         ] );
       ( "observe_or_default",
         [


### PR DESCRIPTION
## Summary
- add masc_telemetry_observe_failures_total{kind} for Telemetry_observe caught non-cancel exceptions
- keep Eio.Cancel.Cancelled re-raised and uncounted
- cover metric registration plus failure/success/cancel behavior in focused tests

## Verification
- ocamlc -stop-after parsing lib/prometheus.ml lib/prometheus.mli lib/telemetry_observe.ml lib/telemetry_observe.mli test/test_prometheus_coverage.ml test/test_telemetry_observe.ml
- git diff --check origin/main...HEAD

Not run in this rebase pass: scripts/dune-local.sh build test/test_telemetry_observe.exe test/test_prometheus_coverage.exe, because the shared opam lock is currently held by another worktree build. CI is the full verification surface for the rebased head.

## Review Focus
- label cardinality stays bounded to kind only
- cancellation is still propagated rather than counted as a swallowed failure