### PR TITLE
[P0] Key cascade circuit breaker by provider

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -774,6 +774,18 @@ let weighted_shuffle
       in
       selected :: sorted_remaining
 
+(** Extract the provider-level health key for a "provider:model" string.
+    Circuit-breaker state is per provider, not per model id, so
+    ["claude_code:auto"] and ["claude_code:sonnet"] share a key while
+    ["claude_code:auto"] and ["gemini_cli:auto"] remain independent. *)
+let provider_key_of_model_string s =
+  match parse_model_string s with
+  | Some cfg -> Provider_adapter.provider_health_key_of_config cfg
+  | None -> (
+      match String.split_on_char ':' s with
+      | provider :: _rest when String.trim provider <> "" -> String.trim provider
+      | _ -> s)
+
 let order_weighted_entries
     ?(rand_int = weighted_random_int)
     ?rotation_scope
@@ -789,13 +801,7 @@ let order_weighted_entries
     let health = Cascade_health_tracker.global in
     let health_adjusted = List.map
         (fun (e : Cascade_config_loader.weighted_entry) ->
-           (* Extract model_id from "provider:model_id" to match the key
-              used by the cascade runtime (cfg.model_id; see
-              cascade_runtime.ml + cascade_strategy.ml). *)
-           let provider_key = match String.split_on_char ':' e.model with
-             | _ :: rest when rest <> [] -> String.concat ":" rest
-             | _ -> e.model
-           in
+           let provider_key = provider_key_of_model_string e.model in
            let ew = Cascade_health_tracker.effective_weight health
                ~provider_key ~config_weight:e.weight in
            { e with weight = ew })
@@ -873,13 +879,6 @@ type selection_trace = {
   candidates : candidate_info list;
   source : cascade_source;
 }
-
-(** Extract the provider_key the health tracker uses for a "provider:model"
-    string. Mirrors the derivation in {!order_weighted_entries}. *)
-let provider_key_of_model_string s =
-  match String.split_on_char ':' s with
-  | _ :: rest when rest <> [] -> String.concat ":" rest
-  | _ -> s
 
 let display_model_string s =
   match split_provider_model s with

--- a/lib/cascade/cascade_inventory.ml
+++ b/lib/cascade/cascade_inventory.ml
@@ -4,7 +4,7 @@ let score_provider health ~exclude ~keeper_assignable
     (provider : Llm_provider.Provider_config.t) =
   if not keeper_assignable then 0.0
   else
-    let provider_key = provider.model_id in
+    let provider_key = Provider_adapter.provider_health_key_of_config provider in
     if List.mem provider_key exclude then 0.0
     else if Cascade_health_tracker.is_in_cooldown health ~provider_key then 0.0
     else
@@ -34,9 +34,11 @@ let best_runner_among ~health ~exclude candidates =
   let positive =
     List.filter
       (fun (sp : scored_provider) ->
+         let provider_key =
+           Provider_adapter.provider_health_key_of_config sp.provider
+         in
          sp.score > 0.0
-         && not (List.mem sp.provider.Llm_provider.Provider_config.model_id
-                   exclude))
+         && not (List.mem provider_key exclude))
       candidates
   in
   match positive with

--- a/lib/cascade/cascade_inventory.mli
+++ b/lib/cascade/cascade_inventory.mli
@@ -26,7 +26,7 @@
     [score = success_rate × latency_score × is_not_in_cooldown]
 
     - 0.0 when the provider is in cooldown.
-    - 0.0 when the provider's [model_id] appears in the [exclude] list.
+    - 0.0 when the provider's provider-health key appears in the [exclude] list.
     - 0.0 when [keeper_assignable = false] for the cascade the provider
       came from (caller must filter externally — see
       {!score_provider}'s [keeper_assignable] flag).
@@ -65,8 +65,8 @@ type scored_provider = {
     [candidates] from {!Cascade_catalog_runtime} which has its own
     enumeration order.
 
-    [exclude] is the list of [provider.model_id]s to skip — typically
-    populated with the model IDs from the cascade that just exhausted,
+    [exclude] is the list of provider-health keys to skip — typically
+    populated with the provider keys from the cascade that just exhausted,
     so cross-cascade promotion never re-elects a provider that already
     failed in the current turn. *)
 val best_runner_among :

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -312,7 +312,7 @@ val default_sticky_ttl_ms : int
 (** {1 Candidate adapter}
 
     Strategies read three pieces of information from each candidate:
-    the health-tracker key (typically [model_id]), the capacity key
+    the health-tracker key (typically provider-scoped), the capacity key
     (typically [base_url]), and the weight used by weighted_random.
     We expose an adapter so tests can drive the strategy with simple
     in-memory records, and production wires it to

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -598,7 +598,9 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                             in
                             let has_recovery_evidence
                                 (p : Llm_provider.Provider_config.t) =
-                              let provider_key = p.model_id in
+                              let provider_key =
+                                Provider_adapter.provider_health_key_of_config p
+                              in
                               match
                                 Cascade_health_tracker.provider_info
                                   Cascade_health_tracker.global

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -186,7 +186,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       |> List.filter (fun name -> name <> "")
       |> Keeper_types.dedupe_keep_order
     in
-    (match keeper_msg_timeout_override args with
+    match keeper_msg_timeout_override args with
     | Error e -> (false, e)
     | Ok keeper_msg_oas_timeout_s ->
     (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -248,16 +248,19 @@ let run_named
   let candidate_cfgs =
     List.filter
       (fun (provider_cfg : Llm_provider.Provider_config.t) ->
+         let provider_health_key =
+           Provider_adapter.provider_health_key_of_config provider_cfg
+         in
          match
            Cascade_health_tracker.check_circuit_breaker
              Cascade_health_tracker.global
-             ~provider_key:provider_cfg.model_id
+             ~provider_key:provider_health_key
          with
          | Ok () -> true
          | Error msg ->
              Log.Misc.debug
-               "cascade %s: prefilter skipped %s (provider cooldown: %s)"
-               cascade_name provider_cfg.model_id msg;
+               "cascade %s: prefilter skipped %s (provider_key=%s cooldown: %s)"
+               cascade_name provider_cfg.model_id provider_health_key msg;
              false)
       candidate_cfgs
   in
@@ -680,9 +683,12 @@ let run_named
         terminal_error
     | (provider_cfg : Llm_provider.Provider_config.t) :: rest ->
       Eio_guard.fair_yield (); (* P0: keep fast-fail cascades scheduler-fair. *)
-      match Cascade_health_tracker.check_circuit_breaker Cascade_health_tracker.global ~provider_key:provider_cfg.model_id with
+      let provider_health_key =
+        Provider_adapter.provider_health_key_of_config provider_cfg
+      in
+      match Cascade_health_tracker.check_circuit_breaker Cascade_health_tracker.global ~provider_key:provider_health_key with
       | Error msg ->
-          Log.Misc.debug "cascade %s: skipping %s (provider cooldown: %s)" cascade_name provider_cfg.model_id msg;
+          Log.Misc.debug "cascade %s: skipping %s (provider_key=%s cooldown: %s)" cascade_name provider_cfg.model_id provider_health_key msg;
           try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s rest last_err
       | Ok () ->
       let is_last = rest = [] in
@@ -720,7 +726,7 @@ let run_named
          a single number, which would mislead strategy ranking. *)
       (match result with
       | Ok result when accept result.response ->
-        Cascade_health_tracker.(record_success global ~provider_key:provider_cfg.model_id
+        Cascade_health_tracker.(record_success global ~provider_key:provider_health_key
           ~latency_ms:attempt_latency_ms ());
         (* FSM: Call_ok → Accept *)
         let observation =
@@ -734,7 +740,7 @@ let run_named
         Oas_worker_cascade.record_cascade ~keeper_name
           ~cascade_name:error_cascade_name
           ~outcome:`Success ~observation:(Some observation) ();
-        on_success ~provider_key:provider_cfg.model_id;
+        on_success ~provider_key:provider_health_key;
         Ok result
       | Ok result ->
         (* Response arrived but failed the cascade's [accept] predicate
@@ -746,7 +752,7 @@ let run_named
            weight but keeps the [Rejected] tag so the dashboard can
            distinguish it from hard errors. *)
         Cascade_health_tracker.(
-          record_rejected global ~provider_key:provider_cfg.model_id
+          record_rejected global ~provider_key:provider_health_key
             ~error_kind:(error_kind_of_string "accept_rejected") ());
         (* FSM: Accept_rejected → decide *)
         let reason = Printf.sprintf "response rejected by accept (model=%s)" result.response.model in
@@ -765,7 +771,7 @@ let run_named
            Oas_worker_cascade.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Success ~observation:(Some observation) ();
-           on_success ~provider_key:provider_cfg.model_id;
+           on_success ~provider_key:provider_health_key;
            Ok result
          | Cascade_fsm.Try_next { last_err = new_err } ->
            (* Demoted from WARN to INFO (task-239): cascade will retry the
@@ -812,7 +818,7 @@ let run_named
            Oas_worker_cascade.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Success ~observation:(Some observation) ();
-           on_success ~provider_key:provider_cfg.model_id;
+           on_success ~provider_key:provider_health_key;
            Ok result)
       | Error sdk_err ->
         let sdk_err =
@@ -837,14 +843,14 @@ let run_named
         in
         if sdk_error_is_hard_quota sdk_err then
           Cascade_health_tracker.(
-            record_hard_quota global ~provider_key:provider_cfg.model_id
+            record_hard_quota global ~provider_key:provider_health_key
               ~error_kind:(error_kind_of_string "hard_quota")
               ~error_reason:err_str ())
         else if sdk_error_is_resumable_cli_session sdk_err
                 || sdk_error_is_terminal_provider_runtime_failure sdk_err
         then
           Cascade_health_tracker.(
-            record_terminal_failure global ~provider_key:provider_cfg.model_id
+            record_terminal_failure global ~provider_key:provider_health_key
               ~error_kind:
                 (error_kind_of_string
                    (if sdk_error_is_resumable_cli_session sdk_err then
@@ -863,7 +869,7 @@ let run_named
              hard_quota; the tracker's max-clamp guards against a
              misclassified hard quota silently producing a long blackout. *)
           Cascade_health_tracker.(
-            record_soft_rate_limited global ~provider_key:provider_cfg.model_id
+            record_soft_rate_limited global ~provider_key:provider_health_key
               ?retry_after_s:retry_after_opt
               ~error_kind:(error_kind_of_string "http_429")
               ~error_reason:err_str ())
@@ -902,7 +908,7 @@ let run_named
             else "failure"
           in
           Cascade_health_tracker.(
-            record_failure global ~provider_key:provider_cfg.model_id
+            record_failure global ~provider_key:provider_health_key
               ~error_kind:(error_kind_of_string error_kind)
               ~error_reason:err_str ())));
         (* FSM: Call_err → decide.
@@ -1084,7 +1090,7 @@ let run_named
      Cascade_client_capacity.auto_register_cli_with_override
        ~capacity_keys:candidate_capacity_keys ~max_concurrent:n);
   let adapter : Llm_provider.Provider_config.t Cascade_strategy.adapter = {
-    health_key = (fun (c : Llm_provider.Provider_config.t) -> c.model_id);
+    health_key = Provider_adapter.provider_health_key_of_config;
     capacity_key = capacity_key_of;
     weight = (fun _ -> 1);
   } in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1473,6 +1473,9 @@ let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
   | Some adapter -> adapter.cascade_prefix
   | None -> provider_label_from_registry cfg
 
+let provider_health_key_of_config cfg =
+  provider_label_of_config cfg
+
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   display_provider_name (provider_label_of_config cfg)
 

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -370,6 +370,10 @@ val adapter_of_provider_config :
 val provider_label_of_config :
   Llm_provider.Provider_config.t -> string
 
+(** Stable provider-level key for cascade health and circuit-breaker state. *)
+val provider_health_key_of_config :
+  Llm_provider.Provider_config.t -> string
+
 (** User-facing provider label for a provider config. *)
 val display_provider_name_of_config :
   Llm_provider.Provider_config.t -> string

--- a/test/test_cascade_inventory.ml
+++ b/test/test_cascade_inventory.ml
@@ -20,6 +20,9 @@ let provider_of_label label =
   | Some cfg -> cfg
   | None -> fail ("expected model label to parse: " ^ label)
 
+let provider_health_key provider =
+  Masc_mcp.Provider_adapter.provider_health_key_of_config provider
+
 let mk_scored ?(cascade_name = "test") ?(score = 0.0) label =
   Inv.
     {
@@ -42,7 +45,7 @@ let test_score_excluded_zero () =
   let h = H.create () in
   let p = provider_of_label "codex_cli:gpt-5.3-codex" in
   let s = Inv.score_provider h
-            ~exclude:[p.Llm_provider.Provider_config.model_id]
+            ~exclude:[provider_health_key p]
             ~keeper_assignable:true p
   in
   check (float 0.001) "excluded provider scores 0.0" 0.0 s
@@ -51,9 +54,9 @@ let test_score_cooldown_zero () =
   let h = H.create () in
   let p = provider_of_label "codex_cli:gpt-5.3-codex" in
   (* Trigger cooldown via 3 consecutive failures (default threshold). *)
-  H.record_failure h ~provider_key:p.model_id ();
-  H.record_failure h ~provider_key:p.model_id ();
-  H.record_failure h ~provider_key:p.model_id ();
+  H.record_failure h ~provider_key:(provider_health_key p) ();
+  H.record_failure h ~provider_key:(provider_health_key p) ();
+  H.record_failure h ~provider_key:(provider_health_key p) ();
   let s = Inv.score_provider h ~exclude:[] ~keeper_assignable:true p in
   check (float 0.001) "cooled-down provider scores 0.0" 0.0 s
 
@@ -69,12 +72,27 @@ let test_score_combines_success_and_latency () =
      should produce score ≈ 0.125, not 1.0 and not 0.0. *)
   let h = H.create () in
   let p = provider_of_label "codex_cli:gpt-5.3-codex" in
-  H.record_success h ~provider_key:p.model_id ~latency_ms:8000.0 ();
-  H.record_failure h ~provider_key:p.model_id ();
+  H.record_success h ~provider_key:(provider_health_key p) ~latency_ms:8000.0 ();
+  H.record_failure h ~provider_key:(provider_health_key p) ();
   let s = Inv.score_provider h ~exclude:[] ~keeper_assignable:true p in
   check bool
     (Printf.sprintf "score=%.3f should be in (0.05, 0.20)" s)
     true (s > 0.05 && s < 0.20)
+
+let test_score_cooldown_is_provider_scoped () =
+  let h = H.create () in
+  let primary = provider_of_label "gemini_cli:auto" in
+  let same_provider_other_model =
+    provider_of_label "gemini_cli:gemini-3-flash-preview"
+  in
+  H.record_failure h ~provider_key:(provider_health_key primary) ();
+  H.record_failure h ~provider_key:(provider_health_key primary) ();
+  H.record_failure h ~provider_key:(provider_health_key primary) ();
+  let s =
+    Inv.score_provider h ~exclude:[] ~keeper_assignable:true
+      same_provider_other_model
+  in
+  check (float 0.001) "same provider other model is cooled down" 0.0 s
 
 (* ── best_runner_among ──────────────────────────────────────────── *)
 
@@ -108,14 +126,14 @@ let test_best_runner_picks_highest_score () =
 
 let test_best_runner_excludes_provider () =
   (* The exclude list takes precedence over the score — even a 1.0
-     candidate is skipped if its model_id is in [exclude]. *)
+     candidate is skipped if its provider-health key is in [exclude]. *)
   let h = H.create () in
   let high = mk_scored "codex_cli:gpt-5.3-codex" ~score:1.0 in
   let lower = mk_scored "gemini_cli:auto" ~score:0.4 in
   let candidates = [high; lower] in
   match Inv.best_runner_among
           ~health:h
-          ~exclude:[high.provider.model_id]
+          ~exclude:[provider_health_key high.provider]
           candidates
   with
   | None -> fail "lower-score provider should win after exclusion"
@@ -148,6 +166,8 @@ let () =
         test_score_keeper_unassignable_zero;
       test_case "score combines success_rate and latency" `Quick
         test_score_combines_success_and_latency;
+      test_case "cooldown is provider scoped" `Quick
+        test_score_cooldown_is_provider_scoped;
     ];
     "best_runner_among", [
       test_case "empty input returns None" `Quick

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -11,6 +11,7 @@ open Alcotest
 module R = Masc_mcp.Cascade_model_resolve
 module C = Masc_mcp.Cascade_config
 module State = Masc_mcp.Cascade_state
+module H = Masc_mcp.Cascade_health_tracker
 
 let unset_env k =
   try Unix.putenv k "" with _ -> ()
@@ -71,6 +72,7 @@ let test_glm_coding_auto_models_default_order () =
   with_clean_env (fun () ->
     check (list string) "glm-coding:auto expands to coding-plan order"
       [
+        "glm-5-code";
         "glm-5.1";
         "glm-5";
         "glm-5-turbo";
@@ -294,6 +296,32 @@ let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
       "claude_code:auto"
       (List.hd other_scope))
 
+let test_order_weighted_entries_cooldown_is_provider_scoped () =
+  with_clean_env (fun () ->
+    let entry model =
+      {
+        Masc_mcp.Cascade_config_loader.model = model;
+        weight = 100;
+        supports_tool_choice = None;
+        secondary = None;
+        secondary_supports_tool_choice = None;
+      }
+    in
+    H.record_failure H.global ~provider_key:"test-provider" ();
+    H.record_failure H.global ~provider_key:"test-provider" ();
+    H.record_failure H.global ~provider_key:"test-provider" ();
+    let ordered =
+      C.order_weighted_entries ~rand_int:(fun _ -> 0)
+        [
+          entry "test-provider:model-a";
+          entry "other-provider:model-a";
+        ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    check string "cooled provider model is skipped"
+      "other-provider:model-a" (List.hd ordered))
+
 let () =
   run "Cascade_model_resolve" [
     "gemini auto", [
@@ -328,5 +356,7 @@ let () =
       test_case "weighted ordering rotates provider order by scope"
         `Quick
         test_order_weighted_entries_rotation_scope_rotates_top_level_providers;
+      test_case "weighted ordering cooldown is provider scoped" `Quick
+        test_order_weighted_entries_cooldown_is_provider_scoped;
     ];
   ]

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -349,6 +349,24 @@ let test_provider_label_of_config_preserves_cli_vs_api_identity () =
   check string "kimi cli model label" "kimi_cli:kimi-for-coding"
     (Adapter.model_label_of_config kimi_cli_cfg)
 
+let test_provider_health_key_is_provider_scoped () =
+  let cfg label =
+    match Masc_mcp.Cascade_config.parse_model_string label with
+    | Some cfg -> cfg
+    | None -> fail ("expected model label to parse: " ^ label)
+  in
+  let claude_auto = cfg "claude_code:auto" in
+  let claude_sonnet = cfg "claude_code:claude-sonnet-4-6" in
+  let gemini_auto = cfg "gemini_cli:auto" in
+  check string "same provider shares health key" "claude_code"
+    (Adapter.provider_health_key_of_config claude_auto);
+  check string "same provider different model shares health key"
+    (Adapter.provider_health_key_of_config claude_auto)
+    (Adapter.provider_health_key_of_config claude_sonnet);
+  check bool "same model id across providers remains isolated" true
+    (Adapter.provider_health_key_of_config claude_auto
+     <> Adapter.provider_health_key_of_config gemini_auto)
+
 let test_provider_of_model_label_uses_typed_boundaries () =
   check string "explicit prefix wins over coarse kind" "glm-coding"
     (Adapter.provider_of_model_label
@@ -435,6 +453,8 @@ let () =
             test_runtime_mcp_header_support_uses_declared_policy;
           test_case "provider label keeps cli vs api identity" `Quick
             test_provider_label_of_config_preserves_cli_vs_api_identity;
+          test_case "provider health key is provider scoped" `Quick
+            test_provider_health_key_is_provider_scoped;
           test_case "provider model label uses typed boundaries" `Quick
             test_provider_of_model_label_uses_typed_boundaries;
           test_case "unmetered provider uses telemetry policy" `Quick


### PR DESCRIPTION
## Summary
- add `Provider_adapter.provider_health_key_of_config` as the stable provider-level circuit-breaker key
- route cascade prefilter, runtime health recording, strategy adapter, inventory scoring, selection-trace health lookup, stale-watchdog recovery evidence, and weighted-entry cooldown ordering through that key
- add regression coverage proving same-provider/different-model cooldown sharing and `*:auto` provider isolation
- repair the current-main `keeper_msg_timeout_override` match wrapper syntax so the rebased branch can compile
- update the `glm-coding:auto` model-list assertion for the catalog-backed `glm-5-code` entry

## Root cause
Cascade health was keyed by `Provider_config.model_id`. That split failure streaks across models for one provider and risked collisions for different providers that both expose `auto`. The P0 circuit-breaker behavior needs provider-level OPEN/fallback semantics.

## Operator impact
When a provider such as Anthropic/Claude hits repeated failures or rate limits, all models under that provider now share the cooldown state, while Moonshot/Gemini/OpenAI-style alternate providers stay independently eligible for fallback.

Closes #13691.
Fixes #13775.

## Validation
- `git diff --check`
- `env DUNE_BUILD_DIR=_build_codex_provider_health_direct dune build --root . --display short -j 1 test/test_cascade_model_resolve.exe`
- `./_build_codex_provider_health_direct/default/test/test_cascade_model_resolve.exe` - 16 tests
- `env DUNE_BUILD_DIR=_build_codex_provider_health_direct dune build --root . --display short -j 1 test/test_provider_adapter.exe test/test_cascade_inventory.exe test/test_cascade_health_tracker.exe test/test_cascade_strategy.exe`
- `./_build_codex_provider_health_direct/default/test/test_provider_adapter.exe` - 34 tests
- `./_build_codex_provider_health_direct/default/test/test_cascade_inventory.exe` - 11 tests
- `./_build_codex_provider_health_direct/default/test/test_cascade_health_tracker.exe` - 54 tests
- `./_build_codex_provider_health_direct/default/test/test_cascade_strategy.exe` - 71 tests

Note: `scripts/dune-local.sh` was first attempted with a fresh custom build dir, but Dune entered a stale no-worker wait after artifacts stopped updating; the direct single-job Dune command above produced compiler output, completed, and was used for validation.
