### PR TITLE
fix(dashboard): expose section header metadata

### DIFF
--- a/dashboard/src/components/common/section-header.test.ts
+++ b/dashboard/src/components/common/section-header.test.ts
@@ -1,56 +1,96 @@
-// @ts-nocheck
 import { describe, expect, it } from 'vitest'
-import { h } from 'preact'
+import { h, type ComponentChildren } from 'preact'
 import { render } from 'preact'
-import { SectionHeader } from './section-header'
+import {
+  SectionHeader,
+  type SectionHeaderProps,
+  sectionHeaderClasses,
+  sectionHeaderHeadingClasses,
+  summarizeSectionHeader,
+} from './section-header'
+
+function renderHeader(props: SectionHeaderProps = {}, children: ComponentChildren = 'A') {
+  const container = document.createElement('div')
+  render(h(SectionHeader, props, children), container)
+  return container
+}
 
 describe('SectionHeader', () => {
   it('renders children', () => {
-    const container = document.createElement('div')
-    render(h(SectionHeader, null, 'Overview'), container)
+    const container = renderHeader({}, 'Overview')
     expect(container.textContent).toContain('Overview')
   })
 
   it('renders right slot', () => {
-    const container = document.createElement('div')
-    render(h(SectionHeader, { right: h('span', null, '12') }, 'Items'), container)
+    const container = renderHeader({ right: h('span', null, '12') }, 'Items')
     expect(container.textContent).toContain('Items')
     expect(container.textContent).toContain('12')
   })
 
   it('applies xs size class', () => {
-    const container = document.createElement('div')
-    render(h(SectionHeader, { size: 'xs' }, 'A'), container)
+    const container = renderHeader({ size: 'xs' })
     const heading = container.querySelector('h4')
     expect(heading?.classList.contains('text-3xs')).toBe(true)
   })
 
   it('applies sm size class by default', () => {
-    const container = document.createElement('div')
-    render(h(SectionHeader, null, 'A'), container)
+    const container = renderHeader()
     const heading = container.querySelector('h4')
     expect(heading?.classList.contains('text-2xs')).toBe(true)
   })
 
   it('applies md size class', () => {
-    const container = document.createElement('div')
-    render(h(SectionHeader, { size: 'md' }, 'A'), container)
+    const container = renderHeader({ size: 'md' })
     const heading = container.querySelector('h4')
     expect(heading?.classList.contains('text-sm')).toBe(true)
   })
 
   it('applies custom class', () => {
-    const container = document.createElement('div')
-    render(h(SectionHeader, { class: 'my-header' }, 'A'), container)
-    const el = container.querySelector('div')
+    const container = renderHeader({ class: 'my-header' })
+    const el = container.querySelector('[data-section-header]')
     expect(el?.classList.contains('my-header')).toBe(true)
   })
 
   it('renders as uppercase tracked heading', () => {
-    const container = document.createElement('div')
-    render(h(SectionHeader, null, 'A'), container)
+    const container = renderHeader()
     const heading = container.querySelector('h4')
     expect(heading?.classList.contains('uppercase')).toBe(true)
     expect(heading?.classList.contains('tracking-[var(--track-sub)]')).toBe(true)
+  })
+
+  it('exposes section header summary metadata', () => {
+    const container = renderHeader({
+      size: 'md',
+      class: 'mt-2',
+      right: h('button', { type: 'button' }, 'Open'),
+    }, 'Logs')
+    const el = container.querySelector('[data-section-header]')
+
+    expect(el?.getAttribute('data-section-header-size')).toBe('md')
+    expect(el?.getAttribute('data-section-header-has-right')).toBe('true')
+    expect(el?.getAttribute('data-section-header-has-custom-class')).toBe('true')
+    expect(el?.getAttribute('data-section-header-class-length')).toBe('4')
+  })
+
+  it('summarizes default section header state', () => {
+    expect(summarizeSectionHeader({})).toEqual({
+      size: 'sm',
+      hasRight: false,
+      hasCustomClass: false,
+      classNameLength: 0,
+    })
+  })
+
+  it('treats null and false right slots as absent', () => {
+    expect(summarizeSectionHeader({ right: null }).hasRight).toBe(false)
+    expect(summarizeSectionHeader({ right: false }).hasRight).toBe(false)
+  })
+
+  it('exports stable class helpers', () => {
+    expect(sectionHeaderClasses()).toBe('flex items-center justify-between gap-2')
+    expect(sectionHeaderClasses('mt-2')).toBe('flex items-center justify-between gap-2 mt-2')
+    expect(sectionHeaderHeadingClasses('xs')).toContain('text-3xs')
+    expect(sectionHeaderHeadingClasses('sm')).toContain('text-2xs')
+    expect(sectionHeaderHeadingClasses('md')).toContain('text-sm')
   })
 })

--- a/dashboard/src/components/common/section-header.ts
+++ b/dashboard/src/components/common/section-header.ts
@@ -4,7 +4,14 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-type HeaderSize = 'xs' | 'sm' | 'md'
+export type HeaderSize = 'xs' | 'sm' | 'md'
+
+export interface SectionHeaderSummary {
+  readonly size: HeaderSize
+  readonly hasRight: boolean
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+}
 
 const SIZE_CLASSES: Record<HeaderSize, string> = {
   xs: 'text-3xs font-semibold tracking-wider',
@@ -12,12 +19,37 @@ const SIZE_CLASSES: Record<HeaderSize, string> = {
   md: 'text-sm font-medium tracking-[var(--track-sub)]',
 }
 
-interface SectionHeaderProps {
+export function sectionHeaderClasses(extra?: string): string {
+  return ['flex items-center justify-between gap-2', extra].filter(Boolean).join(' ')
+}
+
+export function sectionHeaderHeadingClasses(size: HeaderSize = 'sm'): string {
+  return `m-0 ${SIZE_CLASSES[size]} uppercase tracking-[var(--track-sub)] text-[var(--color-fg-muted)]`
+}
+
+export function summarizeSectionHeader({
+  size = 'sm',
+  className,
+  right,
+}: {
+  size?: HeaderSize
+  className?: string
+  right?: ComponentChildren
+}): SectionHeaderSummary {
+  return {
+    size,
+    hasRight: right !== undefined && right !== null && right !== false,
+    hasCustomClass: className !== undefined && className !== '',
+    classNameLength: className?.length ?? 0,
+  }
+}
+
+export interface SectionHeaderProps {
   size?: HeaderSize
   class?: string
   /** Right-side slot (counts, actions) */
   right?: ComponentChildren
-  children: ComponentChildren
+  children?: ComponentChildren
 }
 
 /** Uppercase tracked section label — the dashboard's standard heading pattern */
@@ -27,9 +59,17 @@ export function SectionHeader({
   right,
   children,
 }: SectionHeaderProps) {
+  const summary = summarizeSectionHeader({ size, className: cx, right })
   return html`
-    <div class="flex items-center justify-between gap-2 ${cx ?? ''}">
-      <h4 class="m-0 ${SIZE_CLASSES[size]} uppercase tracking-[var(--track-sub)] text-[var(--color-fg-muted)]">${children}</h4>
+    <div
+      class=${sectionHeaderClasses(cx)}
+      data-section-header
+      data-section-header-size=${summary.size}
+      data-section-header-has-right=${summary.hasRight}
+      data-section-header-has-custom-class=${summary.hasCustomClass}
+      data-section-header-class-length=${summary.classNameLength}
+    >
+      <h4 class=${sectionHeaderHeadingClasses(size)}>${children}</h4>
       ${right ?? null}
     </div>
   `


### PR DESCRIPTION
## Summary
- Export `HeaderSize`, `SectionHeaderProps`, and `SectionHeaderSummary` for dashboard metadata consumers.
- Add `summarizeSectionHeader`, `sectionHeaderClasses`, and `sectionHeaderHeadingClasses` helpers while preserving the existing heading markup/classes.
- Stamp `SectionHeader` with `data-section-header-*` metadata for size, right-slot presence, custom class presence, and class length; remove the stale unit-test `@ts-nocheck`.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/section-header.test.ts src/components/common/section-header.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- Browser QA via Vite port 5228 temporary fixture:
  - desktop screenshot: `/tmp/masc-section-header-summary-0506.png`
  - mobile screenshot: `/tmp/masc-section-header-summary-0506-mobile.png`
  - verified 3 rendered section headers, expected `data-section-header-*` metadata, no desktop/mobile overflow, and console limited to Vite connect logs.
- `pnpm --dir dashboard run lint` (passes; existing warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes; existing Vite dynamic/static import and chunk-size warnings)