### PR TITLE
proof(sangsu): docker PR lifecycle proof pr13582-live-20260506-1735-remaining

### DIFF
--- a/docs/runtime-proof/keepers/sangsu-pr13582-live-20260506-1735-remaining.md
+++ b/docs/runtime-proof/keepers/sangsu-pr13582-live-20260506-1735-remaining.md
@@ -1,0 +1,17 @@
+# Docker PR Lifecycle Proof — sangsu
+
+- run_id: pr13582-live-20260506-1735-remaining
+- keeper: sangsu
+- sandbox_profile: docker
+- via: docker
+- network_mode: bridge
+- timestamp_utc: 2026-05-06T08:40Z
+
+## Lanes
+
+1. git push via=docker
+2. PR create (draft, base=main)
+3. PR review/comment
+4. PR approve (subject to GitHub same-identity policy)
+
+This file exists only as proof artifact. No product code touched.


### PR DESCRIPTION
Docker PR lifecycle proof artifact. run_id: pr13582-live-20260506-1735-remaining. via=docker confirmed for git push. No product code changes.