### PR TITLE
fix(metrics): register keeper callback counters

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1676,6 +1676,15 @@ let init () =
      phase changes. Labeled by keeper, from_phase, and to_phase; deliberately \
      omits event/reason payloads to keep cardinality bounded."
     Counter;
+  add metric_keeper_lifecycle_callback_failures
+    "Total keeper callback failures that would otherwise hide lifecycle, SSE, \
+     tool-call-log, or action-metric gaps. Labels: callback plus optional \
+     keeper at per-keeper hook sites."
+    Counter;
+  add metric_keeper_event_bus_drain
+    "Total per-turn OAS event-bus drain helper runs. Labels: site and \
+     outcome=drained|empty."
+    Counter;
   add metric_keeper_restart_attempts
     "Total supervisor restart attempts for crashed keepers. Labeled by keeper."
     Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -593,14 +593,27 @@ val metric_keeper_lifecycle_transitions : string
     ≤ 224 series; fleet-bounded. *)
 val metric_fsm_guard_violation : string
 
-(** PR-J: post-turn lifecycle callbacks raised exceptions that were
-    silently swallowed before this counter existed. Labels: [callback]
-    with values:
+(** Keeper callback failures that would otherwise look like missing
+    lifecycle, SSE, tool-call-log, or action-metric rows. Labels:
+    [callback] plus optional [keeper] at per-keeper OAS hook sites.
+
+    Lifecycle-only labels:
     - [on_compaction_started] — fired from
       [Keeper_post_turn.apply_post_turn_lifecycle]
     - [on_handoff_started] — fired from
       [Keeper_rollover.maybe_rollover_oas_handoff]
-    Cardinality: ≤ 2 series, fleet-independent. *)
+
+    Per-keeper hook labels:
+    - [gate_tool_call_log]
+    - [after_turn_sse_broadcast]
+    - [post_tool_log_write]
+    - [pr_review_action_metrics_append]
+    - [pr_work_action_metrics_append]
+    - [on_tool_executed]
+    - [on_error]
+    - [on_tool_error]
+
+    Cardinality is bounded by fleet size times this callback vocabulary. *)
 val metric_keeper_lifecycle_callback_failures : string
 val metric_keeper_supervisor_cleanup_failures : string
 val metric_keeper_slot_force_released : string

--- a/test/test_keeper_callback_hardening.ml
+++ b/test/test_keeper_callback_hardening.ml
@@ -1,10 +1,10 @@
 (** test_keeper_callback_hardening — verify PR-J counter semantics.
 
     Two new counters were added in PR-J:
-    1. [masc_keeper_lifecycle_callback_failures_total{callback}] —
-       bumped when a post-turn lifecycle callback raises. The two
-       wrappers ([Keeper_post_turn] and [Keeper_rollover]) each call
-       [Prometheus.inc_counter] in their except branch.
+    1. [masc_keeper_lifecycle_callback_failures_total{callback,...}] —
+       bumped when post-turn lifecycle callbacks or per-keeper OAS hook
+       side effects raise. Lifecycle wrappers emit [callback] only;
+       per-keeper hook sites also include [keeper].
     2. [masc_keeper_event_bus_drain_total{site,outcome}] — bumped on
        every drain, with [outcome=drained] when at least one event
        was pulled and [outcome=empty] otherwise.
@@ -40,6 +40,11 @@ let read_lifecycle_failure ~callback =
     P.metric_keeper_lifecycle_callback_failures
     ~labels:[("callback", callback)] ()
 
+let read_keeper_hook_failure ~keeper ~callback =
+  P.metric_value_or_zero
+    P.metric_keeper_lifecycle_callback_failures
+    ~labels:[("keeper", keeper); ("callback", callback)] ()
+
 let test_lifecycle_callback_label_isolation () =
   let cb_a = "on_compaction_started" in
   let cb_b = "on_handoff_started" in
@@ -55,6 +60,22 @@ let test_lifecycle_callback_label_isolation () =
   Alcotest.(check (float 0.0001))
     "callback B counter unchanged when only A bumped"
     b_before b_after
+
+let test_keeper_hook_label_shape_is_isolated () =
+  let keeper = "schema-test-keeper" in
+  let callback = "post_tool_log_write" in
+  let keeper_before = read_keeper_hook_failure ~keeper ~callback in
+  let lifecycle_before = read_lifecycle_failure ~callback in
+  P.inc_counter P.metric_keeper_lifecycle_callback_failures
+    ~labels:[("keeper", keeper); ("callback", callback)] ();
+  let keeper_after = read_keeper_hook_failure ~keeper ~callback in
+  let lifecycle_after = read_lifecycle_failure ~callback in
+  Alcotest.(check (float 0.0001))
+    "keeper hook label shape incremented"
+    (keeper_before +. 1.0) keeper_after;
+  Alcotest.(check (float 0.0001))
+    "callback-only lifecycle shape unchanged"
+    lifecycle_before lifecycle_after
 
 let read_drain ~site ~outcome =
   P.metric_value_or_zero
@@ -94,13 +115,26 @@ let test_drain_outcome_label_distinction () =
     empty_before empty_after
 
 (* ── Documented label vocabulary check ──────────────────────
-   The wrappers in keeper_post_turn.ml and keeper_rollover.ml use
-   exactly the two callback labels documented in prometheus.mli.
-   This test pins the contract so a future refactor that renames a
-   label without updating the docs is caught.  *)
+   The wrappers in keeper_post_turn.ml / keeper_rollover.ml and the
+   per-keeper hook sites in keeper_hooks_oas.ml must stay aligned with
+   prometheus.mli. This test pins the callback vocabulary so a future
+   refactor that renames a label without updating the docs is caught. *)
 
 let test_documented_callback_label_vocabulary () =
-  let documented_labels = ["on_compaction_started"; "on_handoff_started"] in
+  let documented_labels =
+    [
+      "on_compaction_started";
+      "on_handoff_started";
+      "gate_tool_call_log";
+      "after_turn_sse_broadcast";
+      "post_tool_log_write";
+      "pr_review_action_metrics_append";
+      "pr_work_action_metrics_append";
+      "on_tool_executed";
+      "on_error";
+      "on_tool_error";
+    ]
+  in
   List.iter (fun label ->
     P.inc_counter P.metric_keeper_lifecycle_callback_failures
       ~labels:[("callback", label)] ();
@@ -136,6 +170,8 @@ let () =
     "label isolation", [
       test_case "callback labels are isolated" `Quick
         test_lifecycle_callback_label_isolation;
+      test_case "keeper hook label shape is isolated" `Quick
+        test_keeper_hook_label_shape_is_isolated;
       test_case "drain site labels are isolated" `Quick
         test_drain_site_label_isolation;
       test_case "drain outcome labels are distinct" `Quick

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -277,7 +277,9 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_telemetry_coverage_gap;
   check_registered Prometheus.metric_telemetry_unified_source_read_failures;
   check_registered Prometheus.metric_coord_telemetry_drop;
-  check_registered Prometheus.metric_coord_claim_post_provision_failures
+  check_registered Prometheus.metric_coord_claim_post_provision_failures;
+  check_registered Prometheus.metric_keeper_lifecycle_callback_failures;
+  check_registered Prometheus.metric_keeper_event_bus_drain
 
 let test_distributed_lock_metric_registered () =
   let text = Prometheus.to_prometheus_text () in


### PR DESCRIPTION
## Summary
- explicitly register keeper callback failure and event-bus drain counters in Prometheus init
- update callback metric docs to match the existing callback-only and keeper+callback label shapes
- extend tests to pin registration plus keeper hook label isolation

## Verification
- git diff --check
- env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_prometheus_coverage.exe test/test_keeper_callback_hardening.exe
- ./_build/default/test/test_prometheus_coverage.exe
- ./_build/default/test/test_keeper_callback_hardening.exe

## Review Focus
- Prometheus HELP/TYPE is present before the first failure event
- callback vocabulary remains bounded and reflects current emitter sites
- existing metric names are preserved for dashboard continuity