### PR TITLE
Fix keeper goal lifecycle preset allowlist

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -110,7 +110,6 @@ tools = [
   "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task",
   "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
   "masc_agent_card", "masc_tool_help",
-  "masc_goal_list", "masc_coordination_fsm_snapshot",
   "masc_task_history", "masc_plan_get", "masc_plan_get_task",
   "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
   "masc_messages", "masc_broadcast",
@@ -138,11 +137,19 @@ tools = [
   "masc_keeper_msg_result",
   "masc_keeper_list",
   "masc_keeper_status",
+  "masc_goal_review",
+]
+
+# Goal lifecycle: Goal Store + FSM proof surface.
+# `masc_goal_review` stays in dispatch as a legacy compatibility wrapper;
+# keepers that need feature-proof Goal work should use this group instead.
+[masc.goal]
+tools = [
   "masc_goal_list",
   "masc_goal_upsert",
-  "masc_goal_review",
   "masc_goal_transition",
   "masc_goal_verify",
+  "masc_coordination_fsm_snapshot",
 ]
 
 [masc.code_observe]
@@ -225,12 +232,11 @@ masc_groups = ["essential", "coordination"]
 
 [presets.dispatch]
 groups = ["base", "board_core", "filesystem", "library", "shell"]
-masc_groups = ["essential", "dispatch", "code_observe", "coordination"]
+masc_groups = ["essential", "dispatch", "goal", "code_observe", "coordination"]
 
 [presets.coding]
 groups = ["base", "board_core", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding", "github", "github_review"]
-masc_groups = ["essential", "coding"]
-masc_tools = ["masc_goal_list", "masc_coordination_fsm_snapshot"]
+masc_groups = ["essential", "goal", "coding"]
 
 # Step 9 (bloodflow restoration plan): the research preset is granted
 # delivery-oriented capabilities so analyst/scholar/verifier-tier keepers
@@ -240,13 +246,13 @@ masc_tools = ["masc_goal_list", "masc_coordination_fsm_snapshot"]
 # [keeper_routine_allowlist.ml].
 [presets.research]
 groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review"]
-masc_groups = ["essential", "coordination", "coding"]
+masc_groups = ["essential", "goal", "coordination", "coding"]
 
 # Delivery preset: research + coding for keepers that need to produce code changes.
 # Use for keepers whose goal involves PRs, issues, or code fixes.
 [presets.delivery]
 groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review", "voice"]
-masc_groups = ["essential", "coordination", "coding"]
+masc_groups = ["essential", "goal", "coordination", "coding"]
 
 [presets.full]
 all_candidates = true

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -98,6 +98,10 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 테스트 실행 | `masc_code_shell` (worktree `cwd` required) |
 | GitHub PR / 이슈 작업 | `keeper_preflight_check`, `keeper_pr_list`, `keeper_pr_status`, `keeper_pr_create` (draft-only), plus `keeper_shell op=gh` when repo context is bound |
 
+The goal lifecycle surface is configured as the `masc.goal` policy group and is
+routed to `dispatch`, `coding`, `research`, and `delivery` presets. Social and
+messaging keepers keep board/task coordination without goal mutation access.
+
 ## Research Profile Additions
 
 When the `autoresearch` shard is allocated, these tools are added (any policy mode):

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -323,9 +323,11 @@ let test_coding_preset_has_coordination_tools () =
     (has_tool "masc_task_history" tools);
   check bool "does not grant masc_plan_get_task" false
     (has_tool "masc_plan_get_task" tools);
-  check bool "does not grant masc_goal_upsert" false
+  check bool "has masc_goal_upsert" true
     (has_tool "masc_goal_upsert" tools);
-  check bool "does not grant masc_goal_verify" false
+  check bool "has masc_goal_transition" true
+    (has_tool "masc_goal_transition" tools);
+  check bool "has masc_goal_verify" true
     (has_tool "masc_goal_verify" tools);
   check bool "has keeper_broadcast" true
     (has_tool "keeper_broadcast" tools)

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -127,6 +127,29 @@ let test_delivery_satisfies_coding () =
   check bool "delivery satisfies coding" true
     (KTPC.preset_can_satisfy cfg ~agent_preset:"delivery" ~required_preset:"coding")
 
+let test_goal_lifecycle_group_routes_to_goal_capable_presets () =
+  let cfg = load_config () in
+  let required =
+    [
+      "masc_goal_list";
+      "masc_goal_upsert";
+      "masc_goal_transition";
+      "masc_goal_verify";
+      "masc_coordination_fsm_snapshot";
+    ]
+  in
+  List.iter
+    (fun preset ->
+      match KTPC.resolve_preset cfg preset () with
+      | Some (KTPC.Subset tools) ->
+          List.iter
+            (fun tool ->
+              check bool (preset ^ " includes " ^ tool) true (List.mem tool tools))
+            required
+      | Some KTPC.All_candidates -> ()
+      | None -> fail ("missing preset " ^ preset))
+    [ "dispatch"; "coding"; "research"; "delivery" ]
+
 let test_full_satisfies_anything () =
   let cfg = load_config () in
   check bool "full satisfies delivery" true
@@ -165,6 +188,8 @@ let () =
           test_case "same preset satisfies" `Quick test_same_preset_satisfies;
           test_case "social cannot satisfy delivery" `Quick test_social_cannot_satisfy_delivery;
           test_case "delivery satisfies coding" `Quick test_delivery_satisfies_coding;
+          test_case "goal lifecycle routes to goal-capable presets" `Quick
+            test_goal_lifecycle_group_routes_to_goal_capable_presets;
           test_case "full satisfies anything" `Quick test_full_satisfies_anything;
           test_case "minimal cannot satisfy social" `Quick test_minimal_cannot_satisfy_social;
           test_case "unknown preset returns false" `Quick test_unknown_preset_returns_false;

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -633,6 +633,12 @@ let test_dispatch_preset_routes_pm_tools () =
     (List.mem "masc_plan_get_task" allowed);
   check bool "dispatch includes goal upsert" true
     (List.mem "masc_goal_upsert" allowed);
+  check bool "dispatch includes goal transition" true
+    (List.mem "masc_goal_transition" allowed);
+  check bool "dispatch includes goal verify" true
+    (List.mem "masc_goal_verify" allowed);
+  check bool "dispatch includes FSM snapshot" true
+    (List.mem "masc_coordination_fsm_snapshot" allowed);
   check bool "dispatch includes keeper list" true
     (List.mem "masc_keeper_list" allowed);
   check bool "dispatch includes keeper status" true
@@ -666,9 +672,11 @@ let test_coding_preset_routes_coordination_read_models () =
     (List.mem "masc_goal_list" allowed);
   check bool "coding includes FSM snapshot read model" true
     (List.mem "masc_coordination_fsm_snapshot" allowed);
-  check bool "coding does not include goal upsert" false
+  check bool "coding includes goal upsert" true
     (List.mem "masc_goal_upsert" allowed);
-  check bool "coding does not include goal verify" false
+  check bool "coding includes goal transition" true
+    (List.mem "masc_goal_transition" allowed);
+  check bool "coding includes goal verify" true
     (List.mem "masc_goal_verify" allowed)
 
 let test_coordination_presets_route_plan_history_reads () =


### PR DESCRIPTION
Summary:
- add a dedicated MASC goal lifecycle policy group for goal list, upsert, transition, verify, and FSM snapshot
- route that group to dispatch, coding, research, and delivery presets while leaving social and messaging without goal mutation access
- update keeper policy and exposure tests plus the capability matrix note

Verification:
- scripts/dune-local.sh build test/test_tool_access_policy.exe test/test_keeper_tool_policy_config.exe test/test_keeper_tool_exposure.exe
- ./_build/default/test/test_tool_access_policy.exe
- ./_build/default/test/test_keeper_tool_policy_config.exe
- ./_build/default/test/test_keeper_tool_exposure.exe
- git diff --check

Note:
- test/test_dashboard_keeper_feature_proof.exe was not run because the extra build remained queued on the shared opam switch lock; no source change was made in that feature-proof test path.