### PR TITLE
fix(dashboard): expose eyebrow metadata

### DIFF
--- a/dashboard/src/components/common/eyebrow.a11y.test.ts
+++ b/dashboard/src/components/common/eyebrow.a11y.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { axe } from 'jest-axe'
+import { Eyebrow } from './eyebrow'
+
+describe('Eyebrow a11y', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('main')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('default render passes axe', async () => {
+    render(html`<${Eyebrow}>Runtime<//>`, container)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('disabled tone with custom class passes axe', async () => {
+    render(html`<${Eyebrow} tone="disabled" class="inline-block">Inactive<//>`, container)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/dashboard/src/components/common/eyebrow.test.ts
+++ b/dashboard/src/components/common/eyebrow.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { h, type ComponentChildren } from 'preact'
+import { render } from 'preact'
+import {
+  Eyebrow,
+  type EyebrowProps,
+  eyebrowClasses,
+  summarizeEyebrow,
+} from './eyebrow'
+
+function renderEyebrow(props: EyebrowProps = {}, children: ComponentChildren = 'Runtime') {
+  const container = document.createElement('div')
+  render(h(Eyebrow, props, children), container)
+  return container
+}
+
+describe('Eyebrow', () => {
+  it('renders children with the muted tone by default', () => {
+    const container = renderEyebrow({}, 'Runtime')
+    const eyebrow = container.querySelector('[data-eyebrow]')
+
+    expect(container.textContent).toContain('Runtime')
+    expect(eyebrow?.classList.contains('text-[var(--color-fg-muted)]')).toBe(true)
+  })
+
+  it('applies disabled tone classes', () => {
+    const container = renderEyebrow({ tone: 'disabled' })
+    const eyebrow = container.querySelector('[data-eyebrow]')
+
+    expect(eyebrow?.classList.contains('text-[var(--color-fg-disabled)]')).toBe(true)
+  })
+
+  it('applies custom classes', () => {
+    const container = renderEyebrow({ class: 'inline-block' })
+    const eyebrow = container.querySelector('[data-eyebrow]')
+
+    expect(eyebrow?.classList.contains('inline-block')).toBe(true)
+  })
+
+  it('exposes eyebrow summary metadata', () => {
+    const container = renderEyebrow({ tone: 'disabled', class: 'mb-1' })
+    const eyebrow = container.querySelector('[data-eyebrow]')
+
+    expect(eyebrow?.getAttribute('data-eyebrow-tone')).toBe('disabled')
+    expect(eyebrow?.getAttribute('data-eyebrow-has-custom-class')).toBe('true')
+    expect(eyebrow?.getAttribute('data-eyebrow-class-length')).toBe('4')
+  })
+
+  it('summarizes default eyebrow state', () => {
+    expect(summarizeEyebrow({})).toEqual({
+      tone: 'muted',
+      hasCustomClass: false,
+      classNameLength: 0,
+    })
+  })
+
+  it('summarizes custom eyebrow state', () => {
+    expect(summarizeEyebrow({ tone: 'disabled', className: 'mb-1' })).toEqual({
+      tone: 'disabled',
+      hasCustomClass: true,
+      classNameLength: 4,
+    })
+  })
+
+  it('exports stable class helper output', () => {
+    expect(eyebrowClasses()).toBe(
+      'text-3xs uppercase tracking-wider text-[var(--color-fg-muted)]',
+    )
+    expect(eyebrowClasses('disabled', 'mb-1')).toBe(
+      'text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1',
+    )
+  })
+})

--- a/dashboard/src/components/common/eyebrow.ts
+++ b/dashboard/src/components/common/eyebrow.ts
@@ -1,17 +1,54 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-interface EyebrowProps {
-  tone?: 'muted' | 'disabled'
+export type EyebrowTone = 'muted' | 'disabled'
+
+export interface EyebrowSummary {
+  readonly tone: EyebrowTone
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+}
+
+const BASE = 'text-3xs uppercase tracking-wider'
+
+const TONE_CLASSES: Record<EyebrowTone, string> = {
+  muted: 'text-[var(--color-fg-muted)]',
+  disabled: 'text-[var(--color-fg-disabled)]',
+}
+
+export function eyebrowClasses(tone: EyebrowTone = 'muted', extra?: string): string {
+  return [BASE, TONE_CLASSES[tone], extra].filter(Boolean).join(' ')
+}
+
+export function summarizeEyebrow({
+  tone = 'muted',
+  className,
+}: {
+  tone?: EyebrowTone
+  className?: string
+}): EyebrowSummary {
+  return {
+    tone,
+    hasCustomClass: className !== undefined && className !== '',
+    classNameLength: className?.length ?? 0,
+  }
+}
+
+export interface EyebrowProps {
+  tone?: EyebrowTone
   class?: string
-  children: ComponentChildren
+  children?: ComponentChildren
 }
 
 /** Inline eyebrow label — `text-3xs uppercase tracking-wider` used inside cards */
 export function Eyebrow({ tone = 'muted', class: cx, children }: EyebrowProps) {
-  const color =
-    tone === 'disabled'
-      ? 'text-[var(--color-fg-disabled)]'
-      : 'text-[var(--color-fg-muted)]'
-  return html`<span class="text-3xs uppercase tracking-wider ${color} ${cx ?? ''}">${children}</span>`
+  const summary = summarizeEyebrow({ tone, className: cx })
+  const cls = eyebrowClasses(tone, cx)
+  return html`<span
+    class=${cls}
+    data-eyebrow
+    data-eyebrow-tone=${summary.tone}
+    data-eyebrow-has-custom-class=${summary.hasCustomClass}
+    data-eyebrow-class-length=${summary.classNameLength}
+  >${children}</span>`
 }


### PR DESCRIPTION
## Summary
- Export `EyebrowTone`, `EyebrowProps`, and `EyebrowSummary` for dashboard metadata consumers.
- Add `summarizeEyebrow` and `eyebrowClasses` helpers while preserving the existing uppercase tracked label styling.
- Stamp `Eyebrow` with `data-eyebrow-*` metadata for tone, custom-class presence, and class length; add focused unit and a11y tests.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/eyebrow.test.ts src/components/common/eyebrow.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- Browser QA via Vite port 5229 temporary fixture:
  - desktop screenshot: `/tmp/masc-eyebrow-summary-0506.png`
  - mobile screenshot: `/tmp/masc-eyebrow-summary-0506-mobile.png`
  - verified 2 rendered eyebrow labels, expected `data-eyebrow-*` metadata, no desktop/mobile overflow, and console limited to Vite connect logs.
- Rebased on current `origin/main`, then reran focused vitest + tsc.
- `pnpm --dir dashboard run lint` (passes; existing warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes; existing Vite dynamic/static import and chunk-size warnings)