### PR TITLE
[P0] Unblock main — three-track test compile failures

### DIFF
--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -13,6 +13,9 @@ module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_types = Masc_mcp.Keeper_types
 module Json = Yojson.Safe.Util
 
+(* [Unix.unsetenv] is not portably available in OCaml's stdlib Unix module,
+   so the repo convention is to clear via [Unix.putenv key ""]. See e.g.
+   [test/test_board_vote_quarantine.ml] and [test/test_provider_kind_resolution.ml]. *)
 let with_env key value f =
   let prior = Sys.getenv_opt key in
   Unix.putenv key value;
@@ -20,7 +23,7 @@ let with_env key value f =
     ~finally:(fun () ->
       match prior with
       | Some v -> Unix.putenv key v
-      | None -> Unix.unsetenv key)
+      | None -> Unix.putenv key "")
     f
 
 let temp_dir () =
@@ -222,13 +225,19 @@ let parse_nested_string_field raw outer field =
   |> Json.member field
   |> Json.to_string_option
 
-let test_with_env_restores_unset_variable () =
+(* OCaml stdlib's Unix module has no portable unsetenv, so the [with_env]
+   helper clears via [Unix.putenv NAME ""]. This test verifies the helper's
+   actual contract: the value is restored to empty after the scope (not to
+   the literal "unset" state). See repo convention notes in
+   test_board_vote_quarantine.ml and test_env_config_sandbox.ml. *)
+let test_with_env_restores_cleared_variable () =
   let key = "MASC_KEEPER_PR_REVIEW_WITH_ENV_UNSET_TEST" in
-  Unix.unsetenv key;
+  Unix.putenv key "";
   with_env key "temporary" (fun () ->
     check (option string) "env set inside scope" (Some "temporary")
       (Sys.getenv_opt key));
-  check (option string) "env unset after scope" None (Sys.getenv_opt key)
+  check (option string) "env cleared after scope" (Some "")
+    (Sys.getenv_opt key)
 
 let test_research_preset_can_mutate_pr_reviews () =
   check bool "research can comment/approve through review tool" true
@@ -415,8 +424,8 @@ let () =
         test_passes_through_unrelated_errors;
     ];
     "docker_route", [
-      test_case "with_env restores unset variables" `Quick
-        test_with_env_restores_unset_variable;
+      test_case "with_env restores cleared variables" `Quick
+        test_with_env_restores_cleared_variable;
       test_case "read routes through docker and injects repo flag" `Quick
         test_read_routes_docker_and_injects_repo_flag;
       test_case "comment and approve route through docker" `Quick

--- a/test/test_otel_genai.ml
+++ b/test/test_otel_genai.ml
@@ -187,6 +187,7 @@ let test_dispatch_hook_emits_tool_span_payload () =
           let result : Lib.Tool_result.t =
             { success = true
             ; data = `String "ok"
+            ; legacy_message = "ok"
             ; tool_name = "keeper_shell"
             ; duration_ms = 123.4
             }

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -451,10 +451,10 @@ let test_playground_repo_cache_preserves_concurrent_updates () =
   ensure_dir playground_dir;
   Eio.Fiber.both
     (fun () ->
-       Masc_mcp.Playground_repo_cache.update ~playground_dir
+       Playground_repo_cache.update ~playground_dir
          ~repo_name:"repo-a" ~repo_path ~action:"clone" ~shallow:false)
     (fun () ->
-       Masc_mcp.Playground_repo_cache.update ~playground_dir
+       Playground_repo_cache.update ~playground_dir
          ~repo_name:"repo-b" ~repo_path ~action:"fetch" ~shallow:false);
   let open Yojson.Safe.Util in
   let names =


### PR DESCRIPTION
## Summary

`origin/main` 빌드가 세 개의 독립적인 test 회귀로 동시에 깨져 있었습니다. 한 PR로 모두 unblock합니다.

| # | 파일 | 증상 | 원인 |
|---|------|------|------|
| 1 | `test/test_otel_genai.ml:188` | `Tool_result.t` record 리터럴에 `legacy_message` 필드 누락 | 업스트림 `Tool_result` 재작성이 필드를 추가했지만 이 테스트는 갱신 누락 |
| 2 | `test/test_keeper_pr_review.ml:23,230` | `Unbound value Unix.unsetenv` | OCaml stdlib `Unix`에는 portable `unsetenv`가 없음 — repo 컨벤션은 `Unix.putenv NAME ""` |
| 3 | `test/test_tool_worktree_coverage.ml:454,457` | `Unbound module Masc_mcp.Playground_repo_cache` | 모듈은 `masc_coord` 라이브러리 (`(wrapped false)`)에 있음 — production caller들은 unqualified로 참조 |

## Overlap with existing PR

**PR #13647 (`test(otel): guard GenAI attr registry completeness`)** 가 에러 #1을 동일하게 수정합니다 (record 리터럴에 `legacy_message = "ok"` 추가). 그 PR은 추가로 attr key registry boundary 테스트를 도입하므로 독립적인 가치가 있어 살려두는 게 좋습니다. 이 PR이 먼저 머지되면 #13647은 trivial한 conflict (단일 라인) 만 rebase하면 됩니다.

에러 #2, #3은 다른 open PR에서 다뤄지지 않습니다.

## Root Cause Analysis

### #2 — `Unix.unsetenv`

이미 코드베이스 4곳에서 동일 한계를 명시적 주석으로 인정 중:

- `test/test_board_vote_quarantine.ml:17`
- `test/test_channel_gate_imessage_state.ml:8`
- `test/test_worker_runtime.ml:50`
- `test/test_env_config_sandbox.ml:59`

새로 추가된 `test_with_env_restores_unset_variable` 케이스는 `Sys.getenv_opt = None` post-condition을 단언했는데, helper 자체가 portable하게 그 contract를 만족할 수 없습니다. 케이스를 `test_with_env_restores_cleared_variable`로 rename하고 assertion을 `Some ""`(현실적 post-condition)으로 조정했습니다.

### #3 — `Masc_mcp.Playground_repo_cache`

PR #13595에서 모듈 추가와 테스트가 같은 commit에 들어왔는데, 테스트가 잘못된 prefix로 호출했습니다.

- `lib/coord/dune` → `(name masc_coord) (wrapped false)`
- `test/deps/dune` → `(re_export masc_coord)`
- production 사용 (모두 unqualified):
  - `lib/coord/coord_worktree.ml:1229`
  - `lib/keeper/keeper_shell_shared.ml:377`

## Verification

```bash
# Worktree
cd ~/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-build-0506

# 1. opam reinstall agent_sdk (별개의 환경 이슈 — 로컬 stale install)
opam reinstall agent_sdk -y

# 2. 깨끗한 빌드
dune clean --root .
dune build --root .              # exit 0

# 3. 영향받은 테스트 실행
_build/default/test/test_keeper_pr_review.exe        # 11 tests OK
_build/default/test/test_otel_genai.exe              # 7 tests OK
_build/default/test/test_tool_worktree_coverage.exe  # builds clean
```

## GitHub Checks

이 PR은 Draft로 열렸습니다. `agent-pr` 라벨 + `human-approved-ready` 미부여 상태에서 `Draft Auto-Merge Guard`는 red로 남는 게 정상입니다. P0 unblock 성격이라 사람 승인 후 ready 전환을 권장합니다.

## Memory

- 메모리 `feedback_masc_mcp_agent_sdk_pin_bump_requires_dune_clean.md` 패턴 확인 — `agent_sdk` ABI mismatch는 코드 fix가 아니라 `opam reinstall agent_sdk` + `dune clean`으로 해결 (이번에도 동일 적용).
- 메모리 `feedback_check_open_prs_before_fixing_pasted_build_error.md` 적용 — 이 PR을 열기 전 open PR을 검색해 #13647 overlap을 발견.