### PR TITLE
fix(oas): scrub codex cli argv prompts

### DIFF
--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -73,6 +73,21 @@ let rec sanitize_content_blocks_utf8
         | Agent_sdk.Types.Text s ->
             let sanitized = sanitize_text_utf8 s in
             if sanitized == s then block else Agent_sdk.Types.Text sanitized
+        | Agent_sdk.Types.ToolUse { id; name; input } ->
+            let sanitized_id = sanitize_text_utf8 id in
+            let sanitized_name = sanitize_text_utf8 name in
+            let sanitized_input = sanitize_json_utf8 input in
+            if sanitized_id == id
+               && sanitized_name == name
+               && sanitized_input == input
+            then block
+            else
+              Agent_sdk.Types.ToolUse
+                {
+                  id = sanitized_id;
+                  name = sanitized_name;
+                  input = sanitized_input;
+                }
         | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; json } ->
             let sanitized_tool_use_id = sanitize_text_utf8 tool_use_id in
             let sanitized_content = sanitize_text_utf8 content in

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1340,6 +1340,72 @@ let make_per_call_switch_transport
             transport.complete_stream ~on_event req));
   }
 
+let sanitize_runtime_mcp_server_for_cli =
+  let sanitize = Inference_utils.sanitize_text_utf8 in
+  function
+  | Llm_provider.Llm_transport.Stdio_server { name; command; args; env } ->
+      Llm_provider.Llm_transport.Stdio_server
+        {
+          name = sanitize name;
+          command = sanitize command;
+          args = List.map sanitize args;
+          env =
+            List.map
+              (fun (key, value) -> (sanitize key, sanitize value))
+              env;
+        }
+  | Llm_provider.Llm_transport.Http_server { name; url; headers } ->
+      Llm_provider.Llm_transport.Http_server
+        {
+          name = sanitize name;
+          url = sanitize url;
+          headers =
+            List.map
+              (fun (key, value) -> (sanitize key, sanitize value))
+              headers;
+        }
+
+let sanitize_runtime_mcp_policy_for_cli
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  let sanitize = Inference_utils.sanitize_text_utf8 in
+  {
+    policy with
+    servers = List.map sanitize_runtime_mcp_server_for_cli policy.servers;
+    allowed_server_names = List.map sanitize policy.allowed_server_names;
+    allowed_tool_names = List.map sanitize policy.allowed_tool_names;
+    permission_mode = Option.map sanitize policy.permission_mode;
+    approval_mode = Option.map sanitize policy.approval_mode;
+  }
+
+let sanitize_cli_completion_request_for_argv
+    (req : Llm_provider.Llm_transport.completion_request) =
+  {
+    req with
+    config =
+      {
+        req.config with
+        system_prompt =
+          Option.map Inference_utils.sanitize_text_utf8
+            req.config.system_prompt;
+      };
+    messages = Inference_utils.sanitize_messages_utf8 req.messages;
+    runtime_mcp_policy =
+      Option.map sanitize_runtime_mcp_policy_for_cli
+        req.runtime_mcp_policy;
+  }
+
+let make_cli_argv_sanitizing_transport
+    (transport : Llm_provider.Llm_transport.t) =
+  {
+    Llm_provider.Llm_transport.complete_sync =
+      (fun req ->
+        transport.complete_sync (sanitize_cli_completion_request_for_argv req));
+    complete_stream =
+      (fun ~on_event req ->
+        transport.complete_stream ~on_event
+          (sanitize_cli_completion_request_for_argv req));
+  }
+
 let non_http_transport_of_provider
     ~(sw : Eio.Switch.t)
     ~(provider_cfg : Llm_provider.Provider_config.t)
@@ -1458,12 +1524,13 @@ let non_http_transport_of_provider
           in
           Ok
             (Some
-               (make_per_call_switch_transport (fun ~sw ->
-                    Llm_provider.Transport_codex_cli.create ~sw ~mgr
-                      ~config:
-                        {
-                          Llm_provider.Transport_codex_cli.default_config with
-                          cwd;
-                        }))))
+               (make_cli_argv_sanitizing_transport
+                  (make_per_call_switch_transport (fun ~sw ->
+                       Llm_provider.Transport_codex_cli.create ~sw ~mgr
+                         ~config:
+                           {
+                             Llm_provider.Transport_codex_cli.default_config with
+                             cwd;
+                           })))))
   | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
       Ok None

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -25,6 +25,15 @@ val claude_code_max_turns_hard_cap : int
 val provider_effective_max_turns :
   Llm_provider.Provider_config.provider_kind -> int -> int
 
+val sanitize_cli_completion_request_for_argv :
+  Llm_provider.Llm_transport.completion_request ->
+  Llm_provider.Llm_transport.completion_request
+(** Scrub request text that CLI transports may flatten into argv.
+
+    Codex CLI passes sub-threshold prompts as a positional argument, so any
+    invalid UTF-8 in history, system prompt, or request-scoped MCP overrides
+    can make the subprocess fail before the cascade reaches provider logic. *)
+
 (** Sorted, comma-joined fingerprint of a tool list.  Used as the dedup key
     by the [#10097] omission machinery — identical sets fingerprint to the
     same string regardless of input order. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5221,13 +5221,52 @@ let test_sanitize_messages_utf8_cleans_history_path () =
       metadata = [];
       }
   in
+  let assistant_msg =
+    Agent_sdk.Types.
+      {
+        role = Assistant;
+        content =
+          [
+            ToolUse
+              {
+                id = "call\001id";
+                name = "keeper\127shell";
+                input =
+                  `Assoc
+                    [
+                      ("pattern\000", `String "bad\127bytes");
+                      ("nested", `List [`String "x\001y"]);
+                    ];
+              };
+          ];
+        name = None;
+        tool_call_id = None;
+        metadata = [];
+      }
+  in
   let sanitized =
-    Masc_mcp.Inference_utils.sanitize_messages_utf8 [ user_msg; tool_msg ]
+    Masc_mcp.Inference_utils.sanitize_messages_utf8
+      [ user_msg; assistant_msg; tool_msg ]
   in
   match sanitized with
-  | [ user_msg; tool_msg ] ->
+  | [ user_msg; assistant_msg; tool_msg ] ->
       check string "user history content sanitized" "hist ory entry"
         (Agent_sdk.Types.text_of_message user_msg);
+      (match assistant_msg.Agent_sdk.Types.content with
+       | [ Agent_sdk.Types.ToolUse { id; name; input } ] ->
+           check string "tool use id sanitized" "call id" id;
+           check string "tool use name sanitized" "keeper shell" name;
+           (match input with
+            | `Assoc
+                [
+                  (key, `String value);
+                  ("nested", `List [`String nested_value]);
+                ] ->
+                check string "tool use json key sanitized" "pattern " key;
+                check string "tool use json value sanitized" "bad bytes" value;
+                check string "tool use nested json sanitized" "x y" nested_value
+            | _ -> fail "expected sanitized tool use json")
+       | _ -> fail "expected sanitized tool use");
       (match tool_msg.Agent_sdk.Types.content with
        | [ Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ] ->
            check string "tool id sanitized" "tool id" tool_use_id;
@@ -5238,7 +5277,7 @@ let test_sanitize_messages_utf8_cleans_history_path () =
                 check string "tool json value sanitized" "value " value
             | _ -> fail "expected sanitized tool result json")
        | _ -> fail "expected sanitized tool result")
-  | _ -> fail "expected two sanitized messages"
+  | _ -> fail "expected three sanitized messages"
 
 let test_sanitize_messages_utf8_reuses_clean_history_list () =
   let msgs =

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -3372,6 +3372,107 @@ let test_codex_cli_prompt_preflight_scales_retry_limit_for_argv_only_overflow ()
         (preflight.retry_limit_tokens < preflight.context_window_tokens)
   | None -> Alcotest.fail "expected argv-only codex preflight overflow"
 
+let test_sanitize_cli_completion_request_for_argv_scrubs_codex_request () =
+  let provider_cfg = make_codex_cli_provider_cfg () in
+  let policy =
+    {
+      Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      servers =
+        [
+          Llm_provider.Llm_transport.Http_server
+            {
+              name = "masc\001http";
+              url = "http://127.0.0.1:8935/mcp\127";
+              headers = [ ("X-MASC\000Agent", "keeper\127one") ];
+            };
+        ];
+      allowed_server_names = [ "masc\001http" ];
+      allowed_tool_names = [ "keeper\127shell" ];
+      permission_mode = Some "approve\001all";
+      approval_mode = Some "manual\127gate";
+    }
+  in
+  let req =
+    {
+      Llm_provider.Llm_transport.config =
+        { provider_cfg with system_prompt = Some "sys\001prompt" };
+      messages =
+        [
+          Agent_sdk.Types.user_msg "go\127now";
+          Agent_sdk.Types.
+            {
+              role = Assistant;
+              content =
+                [
+                  ToolUse
+                    {
+                      id = "call\001id";
+                      name = "keeper\127shell";
+                      input = `Assoc [ ("cmd\000", `String "pwd\127") ];
+                    };
+                ];
+              name = None;
+              tool_call_id = None;
+              metadata = [];
+            };
+        ];
+      tools = [];
+      runtime_mcp_policy = Some policy;
+    }
+  in
+  let sanitized =
+    Oas_worker_exec_transport.sanitize_cli_completion_request_for_argv req
+  in
+  Alcotest.(check (option string))
+    "system prompt sanitized" (Some "sys prompt")
+    sanitized.config.system_prompt;
+  (match sanitized.messages with
+   | user_msg :: assistant_msg :: _ ->
+       Alcotest.(check string)
+         "message text sanitized" "go now"
+         (Agent_sdk.Types.text_of_message user_msg);
+       (match assistant_msg.Agent_sdk.Types.content with
+        | [ Agent_sdk.Types.ToolUse { id; name; input } ] ->
+            Alcotest.(check string) "tool id sanitized" "call id" id;
+            Alcotest.(check string) "tool name sanitized" "keeper shell" name;
+            (match input with
+             | `Assoc [ (key, `String value) ] ->
+                 Alcotest.(check string) "tool input key sanitized" "cmd " key;
+                 Alcotest.(check string) "tool input value sanitized" "pwd " value
+             | _ -> Alcotest.fail "expected sanitized tool input")
+        | _ -> Alcotest.fail "expected sanitized ToolUse")
+   | _ -> Alcotest.fail "expected sanitized messages");
+  (match sanitized.runtime_mcp_policy with
+   | Some
+       {
+         Llm_provider.Llm_transport.servers =
+           [
+             Llm_provider.Llm_transport.Http_server
+               { name; url; headers = [ (header_key, header_value) ] };
+           ];
+         allowed_server_names;
+         allowed_tool_names;
+         permission_mode;
+         approval_mode;
+         _;
+       } ->
+       Alcotest.(check string) "server name sanitized" "masc http" name;
+       Alcotest.(check string) "server url sanitized"
+         "http://127.0.0.1:8935/mcp " url;
+       Alcotest.(check string) "header key sanitized" "X-MASC Agent"
+         header_key;
+       Alcotest.(check string) "header value sanitized" "keeper one"
+         header_value;
+       Alcotest.(check (list string)) "allowed servers sanitized"
+         [ "masc http" ] allowed_server_names;
+       Alcotest.(check (list string)) "allowed tools sanitized"
+         [ "keeper shell" ] allowed_tool_names;
+       Alcotest.(check (option string)) "permission mode sanitized"
+         (Some "approve all") permission_mode;
+       Alcotest.(check (option string)) "approval mode sanitized"
+         (Some "manual gate") approval_mode
+   | _ -> Alcotest.fail "expected sanitized runtime MCP policy")
+
 let test_worker_build_agent_uses_default_internal_retry_policy () =
   with_raw_trace "worker_build_agent_retry" @@ fun raw_trace ->
   let meta = make_worker_meta () in
@@ -4744,6 +4845,8 @@ let () =
         test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback;
       Alcotest.test_case "codex preflight scales retry limit for argv overflow" `Quick
         test_codex_cli_prompt_preflight_scales_retry_limit_for_argv_only_overflow;
+      Alcotest.test_case "codex argv scrubber cleans request text" `Quick
+        test_sanitize_cli_completion_request_for_argv_scrubs_codex_request;
       Alcotest.test_case "public MCP tools on codex_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy;
       Alcotest.test_case


### PR DESCRIPTION
## Summary
- scrub Codex CLI completion requests before SDK transport flattens prompts into argv
- extend history sanitization to ToolUse id/name/input JSON
- cover system prompt, message, and runtime MCP override scrub paths

## Live root cause
The running keeper fleet showed Codex CLI failures like: invalid UTF-8 was detected in one or more arguments. Codex CLI passes smaller prompts as a positional argv entry, so invalid bytes in history or runtime MCP text can kill the subprocess before normal cascade/provider handling.

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_oas_worker.exe test/test_keeper_unified.exe
- ./_build/default/test/test_oas_worker.exe test --color=never --show-errors resume_config 20-22
- ./_build/default/test/test_keeper_unified.exe test --color=never --show-errors unified_prompt 31-34