### PR TITLE
fix(metrics): floor after-turn inference latency

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -606,6 +606,35 @@ let record_llm_tok_s_metrics
        Prometheus.metric_llm_decode_tok_per_sec ~labels v
    | _ -> ())
 
+(** Emit the after-turn wall-clock latency histogram.  A zero/negative
+    [request_latency_ms] is still a telemetry quality problem, so the
+    zero-latency counter remains the alertable signal; the histogram receives
+    a 1ms floor to avoid "hook ran but latency count stayed zero" dashboards. *)
+let record_llm_inference_latency_metric
+    ~(model : string)
+    ~(telemetry : Agent_sdk.Types.inference_telemetry option)
+  : unit =
+  let labels = [("model", model)] in
+  Prometheus.inc_counter Prometheus.metric_after_turn_hook ~labels ();
+  match telemetry with
+  | Some t ->
+    let observed_latency_ms =
+      if t.request_latency_ms > 0 then t.request_latency_ms
+      else (
+        Prometheus.inc_counter
+          Prometheus.metric_after_turn_telemetry_zero_latency
+          ~labels ();
+        1)
+    in
+    Prometheus.observe_histogram
+      Prometheus.metric_llm_inference_duration
+      ~labels
+      (Float.of_int observed_latency_ms /. 1000.0)
+  | None ->
+    Prometheus.inc_counter
+      Prometheus.metric_after_turn_telemetry_missing
+      ~labels ()
+
 let wall_tokens_per_second
     ~(usage_missing : bool)
     ~(output_tokens : int)
@@ -1504,27 +1533,11 @@ let make_hooks
                ~delta:(Float.of_int cr) ()
          | Some _ | None -> ());
         (* Inference latency histogram for /metrics endpoint.
-           Split observations into three buckets so we can tell "metric is
-           silent because no telemetry" apart from "metric is silent because
-           the hook isn't running". Without this split a histogram sum/count
-           of 0 is ambiguous between the two. *)
-        Prometheus.inc_counter
-          Prometheus.metric_after_turn_hook
-          ~labels:[("model", model)] ();
-        (match response.telemetry with
-         | Some t when t.request_latency_ms > 0 ->
-           Prometheus.observe_histogram
-             "masc_llm_inference_duration_seconds"
-             ~labels:[("model", model)]
-             (Float.of_int t.request_latency_ms /. 1000.0)
-         | Some _ ->
-           Prometheus.inc_counter
-             Prometheus.metric_after_turn_telemetry_zero_latency
-             ~labels:[("model", model)] ()
-         | None ->
-           Prometheus.inc_counter
-             Prometheus.metric_after_turn_telemetry_missing
-             ~labels:[("model", model)] ());
+           Missing telemetry stays a separate counter; zero/negative latency
+           increments the zero-latency counter and observes a 1ms floor so the
+           histogram still proves the hook ran. *)
+        record_llm_inference_latency_metric ~model
+          ~telemetry:response.telemetry;
         let fmt_tok_s = function
           | Some v -> Printf.sprintf "%.1f" v
           | None -> "-"

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -224,6 +224,14 @@ val record_llm_tok_s_metrics :
   telemetry:Agent_sdk.Types.inference_telemetry option -> unit
 (** Record provider-reported tokens-per-second when telemetry exposes it. *)
 
+val record_llm_inference_latency_metric :
+  model:string ->
+  telemetry:Agent_sdk.Types.inference_telemetry option -> unit
+(** Record after-turn inference latency. [request_latency_ms <= 0] is counted
+    by [masc_after_turn_telemetry_zero_latency_total] and floored to 1ms in
+    [masc_llm_inference_duration_seconds] so a live hook does not leave the
+    latency histogram blank. *)
+
 val wall_tokens_per_second :
   usage_missing:bool ->
   output_tokens:int ->

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -543,6 +543,93 @@ let test_record_llm_tok_s_metrics_none_telemetry_is_noop () =
   check (float 0.001) "prompt count unchanged" 0.0
     (prompt_count_after -. prompt_count_before)
 
+let inference_latency_labels model = [("model", model)]
+
+let test_record_llm_inference_latency_metric_positive_observes () =
+  let model = "latency-positive-test-model" in
+  let labels = inference_latency_labels model in
+  let telemetry = make_telemetry ~request_latency_ms:42 () in
+  let sum_before, count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration
+      ~labels
+  in
+  let hook_before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_after_turn_hook ~labels ()
+  in
+  Hooks.record_llm_inference_latency_metric ~model
+    ~telemetry:(Some telemetry);
+  let sum_after, count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration
+      ~labels
+  in
+  let hook_after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_after_turn_hook ~labels ()
+  in
+  check (float 0.0001) "latency sum +42ms" 0.042
+    (sum_after -. sum_before);
+  check (float 0.0001) "latency count +1" 1.0
+    (count_after -. count_before);
+  check (float 0.0001) "hook counter +1" 1.0
+    (hook_after -. hook_before)
+
+let test_record_llm_inference_latency_metric_zero_floors () =
+  let model = "latency-zero-test-model" in
+  let labels = inference_latency_labels model in
+  let telemetry = make_telemetry ~request_latency_ms:0 () in
+  let sum_before, count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration
+      ~labels
+  in
+  let zero_before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_after_turn_telemetry_zero_latency
+      ~labels ()
+  in
+  Hooks.record_llm_inference_latency_metric ~model
+    ~telemetry:(Some telemetry);
+  let sum_after, count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration
+      ~labels
+  in
+  let zero_after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_after_turn_telemetry_zero_latency
+      ~labels ()
+  in
+  check (float 0.0001) "zero latency counter +1" 1.0
+    (zero_after -. zero_before);
+  check (float 0.0001) "latency sum floored to 1ms" 0.001
+    (sum_after -. sum_before);
+  check (float 0.0001) "latency count +1" 1.0
+    (count_after -. count_before)
+
+let test_record_llm_inference_latency_metric_none_counts_missing () =
+  let model = "latency-missing-test-model" in
+  let labels = inference_latency_labels model in
+  let _, count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration
+      ~labels
+  in
+  let missing_before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_after_turn_telemetry_missing ~labels ()
+  in
+  Hooks.record_llm_inference_latency_metric ~model ~telemetry:None;
+  let _, count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_inference_duration
+      ~labels
+  in
+  let missing_after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_after_turn_telemetry_missing ~labels ()
+  in
+  check (float 0.0001) "missing counter +1" 1.0
+    (missing_after -. missing_before);
+  check (float 0.0001) "latency histogram unchanged" 0.0
+    (count_after -. count_before)
+
 let slot json name = json |> member "slots" |> member name
 
 let string_list_field json key =
@@ -808,6 +895,14 @@ let () =
             test_record_llm_tok_s_metrics_zero_value_is_skipped
         ; test_case "telemetry=None is a safe no-op" `Quick
             test_record_llm_tok_s_metrics_none_telemetry_is_noop
+        ] )
+    ; ( "llm_inference_latency",
+        [ test_case "positive latency observes histogram" `Quick
+            test_record_llm_inference_latency_metric_positive_observes
+        ; test_case "zero latency increments counter and floors histogram" `Quick
+            test_record_llm_inference_latency_metric_zero_floors
+        ; test_case "missing telemetry increments missing counter" `Quick
+            test_record_llm_inference_latency_metric_none_counts_missing
         ] )
     ; ( "hook_introspection",
         [ test_case "reports current runtime slots" `Quick


### PR DESCRIPTION
## Summary
- extract after-turn inference latency recording into a focused helper
- keep zero-latency telemetry counted while flooring its histogram observation to 1ms
- preserve missing-telemetry behavior as a separate counter with no histogram observation

## Verification
- git diff --check origin/main...HEAD
- env MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe
- ./_build/default/test/test_keeper_hooks_oas_telemetry.exe

## Review Focus
- zero/negative request_latency_ms still increments masc_after_turn_telemetry_zero_latency_total
- latency histogram count advances for live after-turn telemetry even when the provider reported 0ms
- telemetry=None still only increments the missing counter