### PR TITLE
fix(dashboard): expose inline spinner metadata

### DIFF
--- a/dashboard/src/components/common/inline-spinner.a11y.test.ts
+++ b/dashboard/src/components/common/inline-spinner.a11y.test.ts
@@ -65,4 +65,12 @@ describe('InlineSpinner a11y', () => {
     )
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('standalone with ariaLabel passes axe', async () => {
+    render(
+      html`<${InlineSpinner} ariaLabel="Loading task state" />`,
+      container,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
 })

--- a/dashboard/src/components/common/inline-spinner.test.ts
+++ b/dashboard/src/components/common/inline-spinner.test.ts
@@ -7,6 +7,8 @@ import {
   inlineSpinnerClasses,
   inlineSpinnerSizeClass,
   inlineSpinnerToneClass,
+  normalizeInlineSpinnerAriaLabel,
+  summarizeInlineSpinner,
 } from './inline-spinner'
 
 describe('inlineSpinnerSizeClass (pure)', () => {
@@ -73,6 +75,9 @@ describe('InlineSpinner component', () => {
     expect(el.tagName).toBe('SPAN')
     expect(el.getAttribute('data-inline-spinner-size')).toBe('sm')
     expect(el.getAttribute('data-inline-spinner-tone')).toBe('accent')
+    expect(el.getAttribute('data-inline-spinner-has-semantic-label')).toBe('false')
+    expect(el.getAttribute('data-inline-spinner-has-custom-class')).toBe('false')
+    expect(el.getAttribute('data-inline-spinner-has-test-id')).toBe('false')
   })
 
   it('size + tone reflect in data attributes', () => {
@@ -93,22 +98,64 @@ describe('InlineSpinner component', () => {
     expect(el.getAttribute('role')).toBeNull()
   })
 
+  it('blank ariaLabel stays decorative', () => {
+    render(html`<${InlineSpinner} ariaLabel="   " />`, container)
+    const el = container.querySelector('[data-inline-spinner]') as HTMLElement
+    expect(el.getAttribute('aria-hidden')).toBe('true')
+    expect(el.getAttribute('role')).toBeNull()
+    expect(el.getAttribute('aria-label')).toBeNull()
+    expect(el.getAttribute('data-inline-spinner-has-semantic-label')).toBe('false')
+  })
+
   it('ariaLabel promotes to semantic: role="status" + no aria-hidden', () => {
     render(
-      html`<${InlineSpinner} ariaLabel="Loading tool metrics" />`,
+      html`<${InlineSpinner} ariaLabel="  Loading tool metrics  " />`,
       container,
     )
     const el = container.querySelector('[data-inline-spinner]')!
     expect(el.getAttribute('role')).toBe('status')
     expect(el.getAttribute('aria-label')).toBe('Loading tool metrics')
     expect(el.getAttribute('aria-hidden')).toBeNull()
+    expect(el.getAttribute('data-inline-spinner-has-semantic-label')).toBe('true')
+    expect(el.getAttribute('data-inline-spinner-aria-label-length')).toBe('20')
   })
 
   it('testId renders as data-testid', () => {
     render(
-      html`<${InlineSpinner} testId="refresh-spinner" />`,
+      html`<${InlineSpinner} class="mr-2" testId="refresh-spinner" />`,
       container,
     )
-    expect(container.querySelector('[data-testid="refresh-spinner"]')).toBeTruthy()
+    const el = container.querySelector('[data-testid="refresh-spinner"]')!
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('data-inline-spinner-has-custom-class')).toBe('true')
+    expect(el.getAttribute('data-inline-spinner-has-test-id')).toBe('true')
+    expect(el.getAttribute('data-inline-spinner-class-length')).toBe('4')
+    expect(el.getAttribute('data-inline-spinner-test-id-length')).toBe('15')
+  })
+
+  it('normalizes aria labels for semantic use', () => {
+    expect(normalizeInlineSpinnerAriaLabel()).toBeUndefined()
+    expect(normalizeInlineSpinnerAriaLabel('')).toBeUndefined()
+    expect(normalizeInlineSpinnerAriaLabel('   ')).toBeUndefined()
+    expect(normalizeInlineSpinnerAriaLabel(' Loading ')).toBe('Loading')
+  })
+
+  it('summarizes inline spinner state', () => {
+    expect(summarizeInlineSpinner({
+      size: 'xs',
+      tone: 'muted',
+      className: 'mr-2',
+      ariaLabel: ' Loading ',
+      testId: 'sync-spinner',
+    })).toEqual({
+      size: 'xs',
+      tone: 'muted',
+      hasSemanticLabel: true,
+      hasCustomClass: true,
+      hasTestId: true,
+      ariaLabelLength: 7,
+      classNameLength: 4,
+      testIdLength: 12,
+    })
   })
 })

--- a/dashboard/src/components/common/inline-spinner.ts
+++ b/dashboard/src/components/common/inline-spinner.ts
@@ -16,8 +16,19 @@
 
 import { html } from 'htm/preact'
 
-type InlineSpinnerSize = 'xs' | 'sm' | 'md'
-type InlineSpinnerTone = 'accent' | 'muted'
+export type InlineSpinnerSize = 'xs' | 'sm' | 'md'
+export type InlineSpinnerTone = 'accent' | 'muted'
+
+export interface InlineSpinnerSummary {
+  readonly size: InlineSpinnerSize
+  readonly tone: InlineSpinnerTone
+  readonly hasSemanticLabel: boolean
+  readonly hasCustomClass: boolean
+  readonly hasTestId: boolean
+  readonly ariaLabelLength: number
+  readonly classNameLength: number
+  readonly testIdLength: number
+}
 
 /** Pure: Tailwind size tokens for each variant. Exposed so a hot-path
     render (timeline rows, log tail, iterating progress lists) can
@@ -54,11 +65,42 @@ export function inlineSpinnerClasses(
   return parts.join(' ')
 }
 
-interface InlineSpinnerProps {
+export function normalizeInlineSpinnerAriaLabel(ariaLabel?: string): string | undefined {
+  const normalized = ariaLabel?.trim()
+  return normalized === undefined || normalized === '' ? undefined : normalized
+}
+
+export function summarizeInlineSpinner({
+  size = 'sm',
+  tone = 'accent',
+  className,
+  ariaLabel,
+  testId,
+}: {
+  size?: InlineSpinnerSize
+  tone?: InlineSpinnerTone
+  className?: string
+  ariaLabel?: string
+  testId?: string
+}): InlineSpinnerSummary {
+  const normalizedAriaLabel = normalizeInlineSpinnerAriaLabel(ariaLabel)
+  return {
+    size,
+    tone,
+    hasSemanticLabel: normalizedAriaLabel !== undefined,
+    hasCustomClass: className !== undefined && className !== '',
+    hasTestId: testId !== undefined && testId !== '',
+    ariaLabelLength: normalizedAriaLabel?.length ?? 0,
+    classNameLength: className?.length ?? 0,
+    testIdLength: testId?.length ?? 0,
+  }
+}
+
+export interface InlineSpinnerProps {
   size?: InlineSpinnerSize
   tone?: InlineSpinnerTone
   class?: string
-  /** Override the decorative default. Setting this flips to role=\"status\"
+  /** Override the decorative default. Setting a non-empty label flips to role=\"status\"
       (screen-reader announces the loading state) instead of
       aria-hidden. Use when the spinner is the ONLY indication of
       progress — otherwise a nearby text label already carries it. */
@@ -73,16 +115,29 @@ export function InlineSpinner({
   ariaLabel,
   testId,
 }: InlineSpinnerProps) {
+  const summary = summarizeInlineSpinner({
+    size,
+    tone,
+    className: cx,
+    ariaLabel,
+    testId,
+  })
+  const normalizedAriaLabel = normalizeInlineSpinnerAriaLabel(ariaLabel)
   const cls = inlineSpinnerClasses(size, tone, cx)
-  const semantic = ariaLabel !== undefined
   return html`<span
     class=${cls}
-    role=${semantic ? 'status' : undefined}
-    aria-label=${ariaLabel}
-    aria-hidden=${semantic ? undefined : 'true'}
+    role=${summary.hasSemanticLabel ? 'status' : undefined}
+    aria-label=${normalizedAriaLabel}
+    aria-hidden=${summary.hasSemanticLabel ? undefined : 'true'}
     data-inline-spinner
-    data-inline-spinner-size=${size}
-    data-inline-spinner-tone=${tone}
+    data-inline-spinner-size=${summary.size}
+    data-inline-spinner-tone=${summary.tone}
+    data-inline-spinner-has-semantic-label=${summary.hasSemanticLabel}
+    data-inline-spinner-has-custom-class=${summary.hasCustomClass}
+    data-inline-spinner-has-test-id=${summary.hasTestId}
+    data-inline-spinner-aria-label-length=${summary.ariaLabelLength}
+    data-inline-spinner-class-length=${summary.classNameLength}
+    data-inline-spinner-test-id-length=${summary.testIdLength}
     data-testid=${testId}
   ></span>`
 }


### PR DESCRIPTION
## Summary
- Export `InlineSpinnerSize`, `InlineSpinnerTone`, `InlineSpinnerProps`, and `InlineSpinnerSummary` for dashboard metadata consumers.
- Add `summarizeInlineSpinner` and `normalizeInlineSpinnerAriaLabel` helpers while preserving the existing size/tone class API.
- Stamp `InlineSpinner` with `data-inline-spinner-*` metadata for size, tone, semantic-label state, custom class, test id, and emitted length fields.
- Treat blank/whitespace-only `ariaLabel` as decorative so the spinner does not create an unnamed `role=status`.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/inline-spinner.test.ts src/components/common/inline-spinner.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- Browser QA via Vite port 5230 temporary fixture:
  - desktop screenshot: `/tmp/masc-inline-spinner-summary-0506.png`
  - mobile screenshot: `/tmp/masc-inline-spinner-summary-0506-mobile.png`
  - verified 3 rendered spinners, expected `data-inline-spinner-*` metadata, decorative spinners stay `aria-hidden`, semantic spinner has `role=status`, no desktop/mobile overflow, and console limited to Vite connect logs.
- Rebased on current `origin/main`, then reran focused vitest + tsc.
- `pnpm --dir dashboard run lint` (passes; existing warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes; existing Vite dynamic/static import and chunk-size warnings)