### PR TITLE
fix(keeper): preflight docker lifecycle proof blockers

### DIFF
--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import sys
 import time
+from collections import Counter
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -787,6 +788,18 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         fleet_failures.append(
             f"minimum_{args.expected_keepers}_configured_keepers_got_{len(config_paths)}"
         )
+    github_identity_counts = Counter(
+        keeper.github_identity for keeper in keepers if keeper.github_identity
+    )
+    requires_docker_approve = (
+        args.require_docker_pr_approve_evidence
+        or args.require_docker_pr_lifecycle_evidence
+    )
+    if requires_docker_approve and len(github_identity_counts) < 2:
+        fleet_failures.append(
+            "docker_pr_approve_identity_pool_insufficient"
+            f"_unique_github_identities_{len(github_identity_counts)}"
+        )
     failed_keepers = [keeper for keeper in keepers if keeper.failures]
     ok = not fleet_failures and not failed_keepers
     return {
@@ -796,6 +809,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         "expected_keepers": args.expected_keepers,
         "configured_keepers": len(config_paths),
         "max_silence_hours": args.max_silence_hours,
+        "github_identity_counts": dict(sorted(github_identity_counts.items())),
         "requirements": {
             "require_board_evidence": args.require_board_evidence,
             "require_pr_surface_evidence": args.require_pr_surface_evidence,

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import time
 from collections import Counter
@@ -55,6 +56,22 @@ SHELL_TOOLS = {
     "keeper_bash",
     "keeper_shell",
 }
+PRODUCT_DOMAIN_MARKERS = {
+    "customer",
+    "goal",
+    "goals",
+    "pm",
+    "product",
+    "roadmap",
+    "strategy",
+}
+DESIGN_DOMAIN_MARKERS = {
+    "design",
+    "interface",
+    "product-design",
+    "ui",
+    "ux",
+}
 
 
 @dataclass
@@ -73,6 +90,8 @@ class KeeperAudit:
     last_turn_age_hours: float | None
     recent_action: bool
     board_action: bool
+    product_action: bool
+    design_action: bool
     pr_surface_action: bool
     pr_review_mutation: bool
     pr_create_action: bool
@@ -84,6 +103,9 @@ class KeeperAudit:
     docker_pr_approve_mutation: bool
     docker_pr_lifecycle_action: bool
     evidence_tools: list[str]
+    board_post_evidence: list[str]
+    product_evidence: list[str]
+    design_evidence: list[str]
     pr_lifecycle_evidence: list[str]
     docker_pr_lifecycle_evidence: list[str]
     failures: list[str]
@@ -526,6 +548,116 @@ def complete_lifecycle_evidence(evidence: set[str]) -> bool:
     )
 
 
+def board_post_paths(base_path: Path) -> list[Path]:
+    path = base_path / ".masc" / "board_posts.jsonl"
+    return [path] if path.exists() else []
+
+
+def domain_tokens(value: Any) -> set[str]:
+    if not isinstance(value, str):
+        return set()
+    raw = value.strip().lower()
+    if not raw:
+        return set()
+    tokens = set(re.split(r"[^a-z0-9]+", raw))
+    tokens.discard("")
+    tokens.add(raw)
+    return tokens
+
+
+def domain_marker_sources(
+    value: Any,
+    *,
+    prefix: str,
+    domain_markers: set[str],
+) -> list[str]:
+    sources: list[str] = []
+    if isinstance(value, str):
+        if domain_tokens(value) & domain_markers:
+            sources.append(f"{prefix}={value.strip().lower()}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            sources.extend(
+                domain_marker_sources(
+                    item,
+                    prefix=f"{prefix}[{index}]",
+                    domain_markers=domain_markers,
+                )
+            )
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            if isinstance(key, str):
+                sources.extend(
+                    domain_marker_sources(
+                        item,
+                        prefix=f"{prefix}.{key}",
+                        domain_markers=domain_markers,
+                    )
+                )
+    return sources
+
+
+def board_post_domain_sources(
+    row: dict[str, Any],
+    domain_markers: set[str],
+) -> list[str]:
+    sources = domain_marker_sources(
+        row.get("hearth"),
+        prefix="hearth",
+        domain_markers=domain_markers,
+    )
+    meta = row.get("meta")
+    if isinstance(meta, dict):
+        sources.extend(
+            domain_marker_sources(
+                meta,
+                prefix="meta",
+                domain_markers=domain_markers,
+            )
+        )
+    return sorted(set(sources))
+
+
+def board_post_evidence_item(kind: str, row: dict[str, Any], source: str) -> str:
+    post_id = string_field(row, "id") or "unknown"
+    source_slug = re.sub(r"[^a-z0-9_.=-]+", "_", source.lower()).strip("_")
+    return f"{kind}:board_post:{post_id}:{source_slug}"
+
+
+def scan_keeper_board_posts(
+    base_path: Path,
+    name: str,
+    *,
+    max_silence_hours: float | None = None,
+    now: float | None = None,
+) -> tuple[float | None, set[str], set[str], set[str]]:
+    latest_ts: float | None = None
+    board_post_evidence: set[str] = set()
+    product_evidence: set[str] = set()
+    design_evidence: set[str] = set()
+    min_ts: float | None = None
+    if max_silence_hours is not None:
+        min_ts = (time.time() if now is None else now) - (max_silence_hours * 3600.0)
+
+    for path in board_post_paths(base_path):
+        for row in iter_jsonl(path):
+            if string_field(row, "author") != name:
+                continue
+            ts = numeric_field(row, "updated_at") or numeric_field(row, "created_at")
+            if min_ts is not None and ts is not None and ts < min_ts:
+                continue
+            if ts is not None:
+                latest_ts = ts if latest_ts is None else max(latest_ts, ts)
+            post_id = string_field(row, "id") or "unknown"
+            board_post_evidence.add(f"board_post:{post_id}")
+            for source in board_post_domain_sources(row, PRODUCT_DOMAIN_MARKERS):
+                product_evidence.add(board_post_evidence_item("product", row, source))
+            for source in board_post_domain_sources(row, DESIGN_DOMAIN_MARKERS):
+                design_evidence.add(board_post_evidence_item("design", row, source))
+
+    return latest_ts, board_post_evidence, product_evidence, design_evidence
+
+
 def scan_keeper_evidence(
     base_path: Path,
     name: str,
@@ -581,6 +713,8 @@ def audit_keeper(
     config_path: Path,
     max_silence_hours: float,
     require_board_evidence: bool,
+    require_product_evidence: bool,
+    require_design_evidence: bool,
     require_pr_surface_evidence: bool,
     require_pr_review_evidence: bool,
     require_pr_create_evidence: bool,
@@ -589,6 +723,7 @@ def audit_keeper(
     require_docker_pr_create_evidence: bool,
     require_docker_git_push_evidence: bool,
     require_docker_pr_approve_evidence: bool,
+    forbidden_github_identities: set[str] | None = None,
 ) -> KeeperAudit:
     name = config_path.stem
     config = load_keeper_config(config_path)
@@ -623,6 +758,8 @@ def audit_keeper(
         failures.append("preset_not_pr_capable")
     if not github_identity:
         failures.append("github_identity_missing")
+    elif forbidden_github_identities and github_identity in forbidden_github_identities:
+        failures.append(f"github_identity_forbidden_{github_identity}")
     if git_identity_mode != "github_identity":
         failures.append("git_identity_mode_not_github_identity")
 
@@ -642,10 +779,22 @@ def audit_keeper(
         pr_lifecycle_evidence,
         docker_pr_lifecycle_evidence,
     ) = scan_keeper_evidence(base_path, name, max_silence_hours=max_silence_hours)
+    (
+        board_post_ts,
+        board_post_evidence,
+        product_evidence,
+        design_evidence,
+    ) = scan_keeper_board_posts(
+        base_path, name, max_silence_hours=max_silence_hours
+    )
     runtime_turn_ts = numeric_field(runtime, "last_turn_ts")
     updated_ts = iso_to_unix(string_field(runtime, "updated_at"))
     last_turn_ts = max(
-        (ts for ts in (evidence_ts, runtime_turn_ts, updated_ts) if ts is not None),
+        (
+            ts
+            for ts in (evidence_ts, board_post_ts, runtime_turn_ts, updated_ts)
+            if ts is not None
+        ),
         default=None,
     )
     last_turn_age_hours: float | None = None
@@ -658,7 +807,9 @@ def audit_keeper(
         if not recent_action:
             failures.append("silence_window_exceeded")
 
-    board_action = bool(tools & BOARD_TOOLS)
+    board_action = bool(tools & BOARD_TOOLS) or bool(board_post_evidence)
+    product_action = bool(product_evidence)
+    design_action = bool(design_evidence)
     pr_surface_action = bool(tools & PR_SURFACE_TOOLS)
     pr_review_mutation = bool(tools & PR_REVIEW_MUTATION_TOOLS)
     pr_create_action = any(
@@ -687,6 +838,10 @@ def audit_keeper(
     )
     if require_board_evidence and not board_action:
         failures.append("board_action_evidence_missing")
+    if require_product_evidence and not product_action:
+        failures.append("product_action_evidence_missing")
+    if require_design_evidence and not design_action:
+        failures.append("design_action_evidence_missing")
     if require_pr_surface_evidence and not pr_surface_action:
         failures.append("pr_surface_evidence_missing")
     elif not pr_surface_action:
@@ -723,6 +878,8 @@ def audit_keeper(
         last_turn_age_hours=last_turn_age_hours,
         recent_action=recent_action,
         board_action=board_action,
+        product_action=product_action,
+        design_action=design_action,
         pr_surface_action=pr_surface_action,
         pr_review_mutation=pr_review_mutation,
         pr_create_action=pr_create_action,
@@ -734,6 +891,9 @@ def audit_keeper(
         docker_pr_approve_mutation=docker_pr_approve_mutation,
         docker_pr_lifecycle_action=docker_pr_lifecycle_action,
         evidence_tools=sorted(tools),
+        board_post_evidence=sorted(board_post_evidence),
+        product_evidence=sorted(product_evidence),
+        design_evidence=sorted(design_evidence),
         pr_lifecycle_evidence=sorted(pr_lifecycle_evidence),
         docker_pr_lifecycle_evidence=sorted(docker_pr_lifecycle_evidence),
         failures=failures,
@@ -756,6 +916,8 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             config_path=path,
             max_silence_hours=args.max_silence_hours,
             require_board_evidence=args.require_board_evidence,
+            require_product_evidence=args.require_product_evidence,
+            require_design_evidence=args.require_design_evidence,
             require_pr_surface_evidence=args.require_pr_surface_evidence,
             require_pr_review_evidence=args.require_pr_review_evidence,
             require_pr_create_evidence=(
@@ -779,6 +941,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
                 args.require_docker_pr_approve_evidence
                 or args.require_docker_pr_lifecycle_evidence
             ),
+            forbidden_github_identities=set(args.forbid_github_identity or []),
         )
         for path in config_paths
     ]
@@ -812,6 +975,9 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         "github_identity_counts": dict(sorted(github_identity_counts.items())),
         "requirements": {
             "require_board_evidence": args.require_board_evidence,
+            "require_product_evidence": args.require_product_evidence,
+            "require_design_evidence": args.require_design_evidence,
+            "forbid_github_identity": args.forbid_github_identity or [],
             "require_pr_surface_evidence": args.require_pr_surface_evidence,
             "require_pr_review_evidence": args.require_pr_review_evidence,
             "require_pr_create_evidence": args.require_pr_create_evidence,
@@ -857,6 +1023,7 @@ def print_text(report: dict[str, Any]) -> None:
         print(
             "- {name}: {marker} preset={preset} sandbox={sandbox}/{network} "
             "gh={github} recent={recent} age={age} board={board} "
+            "product={product} design={design} "
             "pr_surface={pr_surface} pr_review={pr_review} "
             "pr_create={pr_create} git_push={git_push} "
             "pr_approve={pr_approve} docker_pr_create={docker_pr_create} "
@@ -871,6 +1038,8 @@ def print_text(report: dict[str, Any]) -> None:
                 recent=str(keeper["recent_action"]).lower(),
                 age=age_label,
                 board=str(keeper["board_action"]).lower(),
+                product=str(keeper["product_action"]).lower(),
+                design=str(keeper["design_action"]).lower(),
                 pr_surface=str(keeper["pr_surface_action"]).lower(),
                 pr_review=str(keeper["pr_review_mutation"]).lower(),
                 pr_create=str(keeper["pr_create_action"]).lower(),
@@ -902,10 +1071,36 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--max-silence-hours", type=float, default=2400.0)
     parser.add_argument(
+        "--forbid-github-identity",
+        action="append",
+        default=[],
+        metavar="IDENTITY",
+        help=(
+            "Fail keepers using this GitHub identity. Repeat for multiple "
+            "operator or unsafe identity names."
+        ),
+    )
+    parser.add_argument(
         "--no-require-board-evidence",
         action="store_false",
         dest="require_board_evidence",
         help="Do not fail when a keeper lacks board action evidence.",
+    )
+    parser.add_argument(
+        "--require-product-evidence",
+        action="store_true",
+        help=(
+            "Fail unless each keeper has recent product-domain board evidence "
+            "from explicit hearth or metadata markers."
+        ),
+    )
+    parser.add_argument(
+        "--require-design-evidence",
+        action="store_true",
+        help=(
+            "Fail unless each keeper has recent design-domain board evidence "
+            "from explicit hearth or metadata markers."
+        ),
     )
     parser.add_argument(
         "--require-pr-surface-evidence",

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -16,6 +16,8 @@ PROMPT_DIR="$RUN_DIR/prompts"
 REQUESTS_FILE="$RUN_DIR/requests.jsonl"
 RESULTS_FILE="$RUN_DIR/results.jsonl"
 POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
+REVIEW_TARGETS_FILE="$RUN_DIR/review-targets.jsonl"
+GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
 SUMMARY_FILE="$RUN_DIR/summary.json"
 AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
 AUDIT_STATUS_RESULT=0
@@ -50,8 +52,8 @@ Usage: scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh [options]
 Post-merge/live reprobe harness for Docker PR lifecycle evidence.
 
 Default mode is dry-run: discover target keepers, render per-keeper prompts,
-and run the read-only Docker lifecycle audit. It does not send keeper messages
-unless --mutate is supplied.
+render a cross-keeper approval ring, and run the read-only Docker lifecycle
+audit. It does not send keeper messages unless --mutate is supplied.
 
 Options:
   --mutate                 Send prompts to keepers via masc_keeper_msg.
@@ -137,6 +139,8 @@ while [[ $# -gt 0 ]]; do
         REQUESTS_FILE="$RUN_DIR/requests.jsonl"
         RESULTS_FILE="$RUN_DIR/results.jsonl"
         POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
+        REVIEW_TARGETS_FILE="$RUN_DIR/review-targets.jsonl"
+        GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
         SUMMARY_FILE="$RUN_DIR/summary.json"
         AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
       fi
@@ -150,6 +154,8 @@ while [[ $# -gt 0 ]]; do
       REQUESTS_FILE="$RUN_DIR/requests.jsonl"
       RESULTS_FILE="$RUN_DIR/results.jsonl"
       POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
+      REVIEW_TARGETS_FILE="$RUN_DIR/review-targets.jsonl"
+      GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
       SUMMARY_FILE="$RUN_DIR/summary.json"
       AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
       shift 2
@@ -174,6 +180,7 @@ mkdir -p "$RUN_DIR" "$RAW_DIR" "$PROMPT_DIR"
 : >"$REQUESTS_FILE"
 : >"$RESULTS_FILE"
 : >"$POLL_ERRORS_FILE"
+: >"$REVIEW_TARGETS_FILE"
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
@@ -467,8 +474,184 @@ PY
   log "target keepers: $count"
 }
 
+build_review_targets() {
+  local keeper_count
+  keeper_count="$(awk 'NF { c++ } END { print c + 0 }' "$RUN_DIR/keepers.txt")"
+  : >"$REVIEW_TARGETS_FILE"
+  if [[ "$keeper_count" -lt 2 ]]; then
+    while IFS= read -r keeper; do
+      [[ -n "$keeper" ]] || continue
+      jq -nc \
+        --arg keeper "$keeper" \
+        '{keeper:$keeper, review_target:null, mode:"insufficient_targets"}' \
+        >>"$REVIEW_TARGETS_FILE"
+    done <"$RUN_DIR/keepers.txt"
+    if [[ "$MUTATE" == "1" ]]; then
+      echo "at least two target keepers are required for cross-keeper approval proof" >&2
+      exit 1
+    fi
+    return 0
+  fi
+
+  awk 'NF { keepers[++n] = $0 }
+       END {
+         for (i = 1; i <= n; i++) {
+           target = keepers[(i % n) + 1]
+           printf "%s\t%s\n", keepers[i], target
+         }
+       }' "$RUN_DIR/keepers.txt" |
+    while IFS=$'\t' read -r keeper review_target; do
+      [[ -n "$keeper" ]] || continue
+      jq -nc \
+        --arg keeper "$keeper" \
+        --arg review_target "$review_target" \
+        '{keeper:$keeper, review_target:$review_target, mode:"ring"}' \
+        >>"$REVIEW_TARGETS_FILE"
+    done
+  log "review target ring: $REVIEW_TARGETS_FILE"
+}
+
+build_github_identity_counts() {
+  python3 - "$BASE_PATH" "$RUN_DIR/keepers.txt" "$GITHUB_IDENTITY_COUNTS_FILE" <<'PY'
+import json
+import pathlib
+import sys
+from collections import Counter
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore
+
+
+base_path = pathlib.Path(sys.argv[1]).expanduser().resolve()
+keepers_file = pathlib.Path(sys.argv[2])
+out_file = pathlib.Path(sys.argv[3])
+config_dir = base_path / ".masc" / "config" / "keepers"
+runtime_dir = base_path / ".masc" / "keepers"
+
+
+def merge_dicts(base, overlay):
+    merged = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = merge_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_keeper_config(path, seen=None):
+    seen = set() if seen is None else seen
+    resolved = path.resolve()
+    if resolved in seen:
+        return {}
+    seen.add(resolved)
+    try:
+        raw = tomllib.loads(path.read_text())
+    except Exception:
+        return {}
+    keeper = raw.get("keeper")
+    if not isinstance(keeper, dict):
+        return {}
+    base_name = keeper.get("base")
+    if isinstance(base_name, str) and base_name.strip():
+        return merge_dicts(load_keeper_config(path.parent / base_name, seen), keeper)
+    return keeper
+
+
+def string_field(data, key):
+    value = data.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+keepers = [line.strip() for line in keepers_file.read_text().splitlines() if line.strip()]
+identities = {}
+missing = []
+for keeper in keepers:
+    config = load_keeper_config(config_dir / f"{keeper}.toml")
+    runtime = {}
+    runtime_path = runtime_dir / f"{keeper}.json"
+    if runtime_path.exists():
+        try:
+            loaded = json.loads(runtime_path.read_text())
+            if isinstance(loaded, dict):
+                runtime = loaded
+        except Exception:
+            runtime = {}
+    identity = string_field(runtime, "github_identity") or string_field(
+        config, "github_identity"
+    )
+    if identity:
+        identities[keeper] = identity
+    else:
+        missing.append(keeper)
+
+counts = Counter(identities.values())
+out_file.write_text(
+    json.dumps(
+        {
+            "base_path": str(base_path),
+            "keeper_count": len(keepers),
+            "unique_count": len(counts),
+            "counts": dict(sorted(counts.items())),
+            "keepers": identities,
+            "missing": missing,
+        },
+        sort_keys=True,
+        indent=2,
+    )
+    + "\n"
+)
+PY
+}
+
+assert_github_identity_pool_for_mutate() {
+  build_github_identity_counts
+  local unique_count
+  unique_count="$(jq -r '.unique_count // 0' "$GITHUB_IDENTITY_COUNTS_FILE")"
+  if [[ "$MUTATE" == "1" && "$unique_count" -lt 2 ]]; then
+    echo "at least two unique github_identity values are required for cross-keeper approval proof" >&2
+    jq -c '{unique_count, counts, missing}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
+    exit 1
+  fi
+}
+
+review_target_for_keeper() {
+  local keeper="$1"
+  jq -r --arg keeper "$keeper" '
+    select(.keeper == $keeper) | .review_target // empty
+  ' "$REVIEW_TARGETS_FILE" | head -n 1
+}
+
 prompt_for_keeper() {
   local keeper="$1"
+  local review_target="${2:-}"
+  local review_branch=""
+  local review_target_json="null"
+  local review_branch_json="null"
+  local review_instruction=""
+  if [[ -n "$review_target" ]]; then
+    review_branch="keeper/$review_target-docker-pr-proof-$RUN_ID"
+    review_target_json="\"$review_target\""
+    review_branch_json="\"$review_branch\""
+    review_instruction="$(cat <<EOF
+Cross-keeper approval target:
+- You must review and APPROVE the draft PR whose head branch is: $review_branch
+- This target belongs to keeper: $review_target
+- Do not approve your own PR or your own branch.
+- If the target PR is not visible yet, wait/retry briefly by listing PRs for that head branch before declaring a blocker.
+- If GitHub reports the target PR has the same author identity as your current credential and rejects approval as self-approval, stop and report blocker="github_self_approve_policy" with the exact tool output.
+EOF
+)"
+  else
+    review_instruction="$(cat <<'EOF'
+Cross-keeper approval target:
+- No distinct review target was available. You can create/push/comment on your own draft PR, but this run cannot satisfy PR APPROVE evidence.
+- Stop before approval and report blocker="insufficient_review_targets".
+EOF
+)"
+  fi
   cat <<EOF
 Docker PR lifecycle proof run: $RUN_ID
 
@@ -483,13 +666,19 @@ Required proof lane:
 3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md.
 4. Commit and git push that branch. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 5. Create a draft PR for that branch with keeper_pr_create or the native PR-create tool path. Do not mark ready, do not merge, do not add human-approved-ready.
-6. Use keeper_pr_review_read and keeper_pr_review_comment for review evidence. COMMENT is allowed on your proof PR. APPROVE is allowed only when the PR is a draft agent/keeper proof PR and the tool preflight permits it.
+6. Use keeper_pr_review_read and keeper_pr_review_comment for review evidence. COMMENT is allowed on your own proof PR. APPROVE must target the cross-keeper PR below, not your own PR.
+
+$review_instruction
+
 7. Reply with one compact JSON object:
    {
      "run_id": "$RUN_ID",
      "keeper": "$keeper",
      "branch": "keeper/$keeper-docker-pr-proof-$RUN_ID",
+     "review_target_keeper": $review_target_json,
+     "review_target_branch": $review_branch_json,
      "pr_url": "...",
+     "approved_pr_url": "...",
      "docker_pr_create": true,
      "docker_git_push": true,
      "docker_pr_review": true,
@@ -513,7 +702,7 @@ EOF
 render_prompts() {
   while IFS= read -r keeper; do
     [[ -n "$keeper" ]] || continue
-    prompt_for_keeper "$keeper" >"$PROMPT_DIR/$keeper.txt"
+    prompt_for_keeper "$keeper" "$(review_target_for_keeper "$keeper")" >"$PROMPT_DIR/$keeper.txt"
   done <"$RUN_DIR/keepers.txt"
 }
 
@@ -556,7 +745,8 @@ send_prompts() {
       --arg keeper "$keeper" \
       --arg request_id "$request_id" \
       --arg prompt_file "$PROMPT_DIR/$keeper.txt" \
-      '{keeper:$keeper, request_id:$request_id, prompt_file:$prompt_file, status:"pending"}' \
+      --arg review_target "$(review_target_for_keeper "$keeper")" \
+      '{keeper:$keeper, request_id:$request_id, prompt_file:$prompt_file, review_target:$review_target, status:"pending"}' \
       >>"$REQUESTS_FILE"
   done <"$RUN_DIR/keepers.txt"
 }
@@ -655,6 +845,8 @@ write_summary() {
     --arg expected_server_commit "$EXPECTED_SERVER_COMMIT" \
     --arg server_commit "$SERVER_COMMIT_ACTUAL" \
     --arg server_health_file "$SERVER_HEALTH_CHECK_FILE" \
+    --arg review_targets_file "$REVIEW_TARGETS_FILE" \
+    --arg github_identity_counts_file "$GITHUB_IDENTITY_COUNTS_FILE" \
     --argjson mutate "$MUTATE" \
     --argjson keeper_count "$keeper_count" \
     --argjson request_count "$request_count" \
@@ -671,6 +863,8 @@ write_summary() {
       expected_server_commit:$expected_server_commit,
       server_commit:$server_commit,
       server_health_file:$server_health_file,
+      review_targets_file:$review_targets_file,
+      github_identity_counts_file:$github_identity_counts_file,
       mutate:$mutate,
       keeper_count:$keeper_count,
       request_count:$request_count,
@@ -711,6 +905,8 @@ require_cmd curl
 assert_expected_server_commit
 ensure_mcp_session_if_needed
 discover_keepers
+build_review_targets
+assert_github_identity_pool_for_mutate
 render_prompts
 
 if [[ "$MUTATE" == "1" ]]; then

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -38,6 +38,10 @@ REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_shell,keeper_bash,masc_code_git,keeper_
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_TOKEN="${MASC_MCP_TOKEN:-}"
 MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-docker-pr-lifecycle-reprobe}"
+EXPECTED_SERVER_COMMIT="${EXPECTED_SERVER_COMMIT:-}"
+SERVER_HEALTH_URL="${SERVER_HEALTH_URL:-}"
+SERVER_COMMIT_ACTUAL=""
+SERVER_HEALTH_CHECK_FILE=""
 
 usage() {
   cat <<'EOF'
@@ -58,6 +62,9 @@ Options:
   --repo OWNER/REPO        Target repository slug in the keeper prompt.
   --base-path PATH         MASC base path for audit (default: $HOME/me).
   --mcp-url URL            MCP endpoint (default: http://127.0.0.1:8935/mcp).
+  --expected-server-commit COMMIT
+                           Fail unless /health build.commit matches this commit.
+  --server-health-url URL  Health endpoint for commit verification.
   --board-post-id ID       Post a final board comment to this thread.
   --run-id ID              Stable run id for prompts and artifacts.
   --run-dir PATH           Artifact directory.
@@ -71,6 +78,7 @@ Environment:
   KEEPER_TURN_TIMEOUT_SEC  Per-keeper Agent.run timeout_sec sent to masc_keeper_msg.
   REQUIRED_TOOLS           CSV required_tools sent to masc_keeper_msg when mutating.
   RUN_AUDIT=0              Skip final audit.
+  EXPECTED_SERVER_COMMIT   Optional expected /health build.commit prefix.
 EOF
 }
 
@@ -106,6 +114,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --mcp-url)
       MCP_URL="$2"
+      shift 2
+      ;;
+    --expected-server-commit)
+      EXPECTED_SERVER_COMMIT="$2"
+      shift 2
+      ;;
+    --server-health-url)
+      SERVER_HEALTH_URL="$2"
       shift 2
       ;;
     --board-post-id)
@@ -168,6 +184,48 @@ require_cmd() {
     echo "required command not found: $1" >&2
     exit 127
   fi
+}
+
+server_health_url() {
+  if [[ -n "$SERVER_HEALTH_URL" ]]; then
+    printf '%s\n' "$SERVER_HEALTH_URL"
+    return 0
+  fi
+  local base="$MCP_URL"
+  base="${base%/mcp}"
+  if [[ "$base" == "$MCP_URL" ]]; then
+    base="${MCP_URL%/}"
+  fi
+  printf '%s/health\n' "$base"
+}
+
+assert_expected_server_commit() {
+  if [[ -z "$EXPECTED_SERVER_COMMIT" ]]; then
+    return 0
+  fi
+
+  local health_url health_file actual
+  health_url="$(server_health_url)"
+  health_file="$RAW_DIR/server-health.json"
+  if ! curl -fsS --max-time 5 "$health_url" >"$health_file"; then
+    echo "failed to fetch server health for commit check: $health_url" >&2
+    exit 1
+  fi
+
+  actual="$(jq -r '.build.commit // .build_commit // .commit // empty' "$health_file")"
+  SERVER_COMMIT_ACTUAL="$actual"
+  SERVER_HEALTH_CHECK_FILE="$health_file"
+  if [[ -z "$actual" ]]; then
+    echo "server health did not expose build.commit: $health_url" >&2
+    exit 1
+  fi
+  if [[ "$actual" != "$EXPECTED_SERVER_COMMIT" \
+      && "$actual" != "$EXPECTED_SERVER_COMMIT"* \
+      && "$EXPECTED_SERVER_COMMIT" != "$actual"* ]]; then
+    echo "server commit mismatch: expected=$EXPECTED_SERVER_COMMIT actual=$actual url=$health_url" >&2
+    exit 1
+  fi
+  log "server commit verified: expected=$EXPECTED_SERVER_COMMIT actual=$actual"
 }
 
 load_mcp_token() {
@@ -594,6 +652,9 @@ write_summary() {
     --arg run_dir "$RUN_DIR" \
     --arg repo "$REPO_SLUG" \
     --arg base_path "$BASE_PATH" \
+    --arg expected_server_commit "$EXPECTED_SERVER_COMMIT" \
+    --arg server_commit "$SERVER_COMMIT_ACTUAL" \
+    --arg server_health_file "$SERVER_HEALTH_CHECK_FILE" \
     --argjson mutate "$MUTATE" \
     --argjson keeper_count "$keeper_count" \
     --argjson request_count "$request_count" \
@@ -607,6 +668,9 @@ write_summary() {
       run_dir:$run_dir,
       repo:$repo,
       base_path:$base_path,
+      expected_server_commit:$expected_server_commit,
+      server_commit:$server_commit,
+      server_health_file:$server_health_file,
       mutate:$mutate,
       keeper_count:$keeper_count,
       request_count:$request_count,
@@ -644,6 +708,7 @@ require_cmd jq
 require_cmd python3
 require_cmd curl
 
+assert_expected_server_commit
 ensure_mcp_session_if_needed
 discover_keepers
 render_prompts

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -41,6 +41,7 @@ MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_TOKEN="${MASC_MCP_TOKEN:-}"
 MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-docker-pr-lifecycle-reprobe}"
 EXPECTED_SERVER_COMMIT="${EXPECTED_SERVER_COMMIT:-}"
+FORBID_GITHUB_IDENTITIES="${FORBID_GITHUB_IDENTITIES:-}"
 SERVER_HEALTH_URL="${SERVER_HEALTH_URL:-}"
 SERVER_COMMIT_ACTUAL=""
 SERVER_HEALTH_CHECK_FILE=""
@@ -66,6 +67,9 @@ Options:
   --mcp-url URL            MCP endpoint (default: http://127.0.0.1:8935/mcp).
   --expected-server-commit COMMIT
                            Fail unless /health build.commit matches this commit.
+  --forbid-github-identity NAME
+                           Fail --mutate preflight when a target keeper uses
+                           this GitHub identity. Repeat or pass comma-separated.
   --server-health-url URL  Health endpoint for commit verification.
   --board-post-id ID       Post a final board comment to this thread.
   --run-id ID              Stable run id for prompts and artifacts.
@@ -81,6 +85,7 @@ Environment:
   REQUIRED_TOOLS           CSV required_tools sent to masc_keeper_msg when mutating.
   RUN_AUDIT=0              Skip final audit.
   EXPECTED_SERVER_COMMIT   Optional expected /health build.commit prefix.
+  FORBID_GITHUB_IDENTITIES Optional CSV of forbidden keeper GitHub identities.
 EOF
 }
 
@@ -120,6 +125,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --expected-server-commit)
       EXPECTED_SERVER_COMMIT="$2"
+      shift 2
+      ;;
+    --forbid-github-identity)
+      if [[ -n "$FORBID_GITHUB_IDENTITIES" ]]; then
+        FORBID_GITHUB_IDENTITIES="$FORBID_GITHUB_IDENTITIES,$2"
+      else
+        FORBID_GITHUB_IDENTITIES="$2"
+      fi
       shift 2
       ;;
     --server-health-url)
@@ -541,7 +554,7 @@ PY
 }
 
 build_github_identity_counts() {
-  python3 - "$BASE_PATH" "$RUN_DIR/keepers.txt" "$GITHUB_IDENTITY_COUNTS_FILE" <<'PY'
+  python3 - "$BASE_PATH" "$RUN_DIR/keepers.txt" "$GITHUB_IDENTITY_COUNTS_FILE" "$FORBID_GITHUB_IDENTITIES" <<'PY'
 import json
 import pathlib
 import sys
@@ -556,6 +569,11 @@ except ModuleNotFoundError:
 base_path = pathlib.Path(sys.argv[1]).expanduser().resolve()
 keepers_file = pathlib.Path(sys.argv[2])
 out_file = pathlib.Path(sys.argv[3])
+forbidden = {
+    item.strip()
+    for item in sys.argv[4].split(",")
+    if item.strip()
+}
 config_dir = base_path / ".masc" / "config" / "keepers"
 runtime_dir = base_path / ".masc" / "keepers"
 
@@ -597,6 +615,7 @@ def string_field(data, key):
 keepers = [line.strip() for line in keepers_file.read_text().splitlines() if line.strip()]
 identities = {}
 missing = []
+forbidden_keepers = []
 for keeper in keepers:
     config = load_keeper_config(config_dir / f"{keeper}.toml")
     runtime = {}
@@ -613,6 +632,8 @@ for keeper in keepers:
     )
     if identity:
         identities[keeper] = identity
+        if identity in forbidden:
+            forbidden_keepers.append({"keeper": keeper, "github_identity": identity})
     else:
         missing.append(keeper)
 
@@ -626,6 +647,8 @@ out_file.write_text(
             "counts": dict(sorted(counts.items())),
             "keepers": identities,
             "missing": missing,
+            "forbidden_identities": sorted(forbidden),
+            "forbidden_keepers": forbidden_keepers,
         },
         sort_keys=True,
         indent=2,
@@ -642,6 +665,12 @@ assert_github_identity_pool_for_mutate() {
   if [[ "$MUTATE" == "1" && "$unique_count" -lt 2 ]]; then
     echo "at least two unique github_identity values are required for cross-keeper approval proof" >&2
     jq -c '{unique_count, counts, missing}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
+    exit 1
+  fi
+  if [[ "$MUTATE" == "1" ]] \
+    && jq -e '(.forbidden_keepers // []) | length > 0' "$GITHUB_IDENTITY_COUNTS_FILE" >/dev/null; then
+    echo "target keeper set includes forbidden github_identity values" >&2
+    jq -c '{forbidden_identities, forbidden_keepers}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
     exit 1
   fi
 }
@@ -846,12 +875,26 @@ run_audit() {
     return 0
   fi
   log "running Docker PR lifecycle audit"
+  local audit_args=(
+    "$REPO_ROOT/scripts/audit-keeper-fleet-readiness.py"
+    --base-path "$BASE_PATH"
+    --expected-keepers "$EXPECTED_KEEPERS"
+    --require-docker-pr-lifecycle-evidence
+    --json
+  )
+  if [[ -n "$FORBID_GITHUB_IDENTITIES" ]]; then
+    IFS=',' read -r -a forbidden_items <<<"$FORBID_GITHUB_IDENTITIES"
+    local forbidden_item
+    for forbidden_item in "${forbidden_items[@]}"; do
+      forbidden_item="${forbidden_item#"${forbidden_item%%[![:space:]]*}"}"
+      forbidden_item="${forbidden_item%"${forbidden_item##*[![:space:]]}"}"
+      if [[ -n "$forbidden_item" ]]; then
+        audit_args+=(--forbid-github-identity "$forbidden_item")
+      fi
+    done
+  fi
   set +e
-  python3 "$REPO_ROOT/scripts/audit-keeper-fleet-readiness.py" \
-    --base-path "$BASE_PATH" \
-    --expected-keepers "$EXPECTED_KEEPERS" \
-    --require-docker-pr-lifecycle-evidence \
-    --json >"$AUDIT_FILE"
+  python3 "${audit_args[@]}" >"$AUDIT_FILE"
   local audit_status=$?
   set -e
   AUDIT_STATUS_RESULT="$audit_status"
@@ -872,6 +915,7 @@ write_summary() {
     --arg repo "$REPO_SLUG" \
     --arg base_path "$BASE_PATH" \
     --arg expected_server_commit "$EXPECTED_SERVER_COMMIT" \
+    --arg forbid_github_identities "$FORBID_GITHUB_IDENTITIES" \
     --arg server_commit "$SERVER_COMMIT_ACTUAL" \
     --arg server_health_file "$SERVER_HEALTH_CHECK_FILE" \
     --arg review_targets_file "$REVIEW_TARGETS_FILE" \
@@ -890,6 +934,7 @@ write_summary() {
       repo:$repo,
       base_path:$base_path,
       expected_server_commit:$expected_server_commit,
+      forbid_github_identities:$forbid_github_identities,
       server_commit:$server_commit,
       server_health_file:$server_health_file,
       review_targets_file:$review_targets_file,

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -475,40 +475,69 @@ PY
 }
 
 build_review_targets() {
-  local keeper_count
-  keeper_count="$(awk 'NF { c++ } END { print c + 0 }' "$RUN_DIR/keepers.txt")"
-  : >"$REVIEW_TARGETS_FILE"
-  if [[ "$keeper_count" -lt 2 ]]; then
-    while IFS= read -r keeper; do
-      [[ -n "$keeper" ]] || continue
-      jq -nc \
-        --arg keeper "$keeper" \
-        '{keeper:$keeper, review_target:null, mode:"insufficient_targets"}' \
-        >>"$REVIEW_TARGETS_FILE"
-    done <"$RUN_DIR/keepers.txt"
-    if [[ "$MUTATE" == "1" ]]; then
-      echo "at least two target keepers are required for cross-keeper approval proof" >&2
-      exit 1
-    fi
-    return 0
-  fi
+  python3 - "$RUN_DIR/keepers.txt" "$GITHUB_IDENTITY_COUNTS_FILE" \
+    "$REVIEW_TARGETS_FILE" <<'PY'
+import json
+import pathlib
+import sys
 
-  awk 'NF { keepers[++n] = $0 }
-       END {
-         for (i = 1; i <= n; i++) {
-           target = keepers[(i % n) + 1]
-           printf "%s\t%s\n", keepers[i], target
-         }
-       }' "$RUN_DIR/keepers.txt" |
-    while IFS=$'\t' read -r keeper review_target; do
-      [[ -n "$keeper" ]] || continue
-      jq -nc \
-        --arg keeper "$keeper" \
-        --arg review_target "$review_target" \
-        '{keeper:$keeper, review_target:$review_target, mode:"ring"}' \
-        >>"$REVIEW_TARGETS_FILE"
-    done
-  log "review target ring: $REVIEW_TARGETS_FILE"
+keepers_file = pathlib.Path(sys.argv[1])
+identity_counts_file = pathlib.Path(sys.argv[2])
+review_targets_file = pathlib.Path(sys.argv[3])
+
+keepers = [line.strip() for line in keepers_file.read_text().splitlines() if line.strip()]
+try:
+    identity_payload = json.loads(identity_counts_file.read_text())
+except Exception:
+    identity_payload = {}
+identities = identity_payload.get("keepers")
+if not isinstance(identities, dict):
+    identities = {}
+
+
+def fallback_target(index):
+    if len(keepers) < 2:
+        return None
+    return keepers[(index + 1) % len(keepers)]
+
+
+with review_targets_file.open("w", encoding="utf-8") as handle:
+    for index, keeper in enumerate(keepers):
+        keeper_identity = identities.get(keeper)
+        review_target = None
+        mode = "insufficient_targets"
+
+        if len(keepers) >= 2 and isinstance(keeper_identity, str):
+            for candidate in keepers:
+                if candidate == keeper:
+                    continue
+                candidate_identity = identities.get(candidate)
+                if isinstance(candidate_identity, str) and candidate_identity != keeper_identity:
+                    review_target = candidate
+                    mode = "identity_aware"
+                    break
+            if review_target is None:
+                mode = "identity_pool_insufficient"
+        elif len(keepers) >= 2:
+            review_target = fallback_target(index)
+            mode = "ring_unverified_identity"
+
+        row = {
+            "keeper": keeper,
+            "keeper_identity": keeper_identity,
+            "review_target": review_target,
+            "review_target_identity": identities.get(review_target) if review_target else None,
+            "mode": mode,
+        }
+        handle.write(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n")
+PY
+  if [[ "$MUTATE" == "1" ]] \
+    && jq -e 'select(.review_target == null)' "$REVIEW_TARGETS_FILE" >/dev/null; then
+    echo "cross-keeper approval targets could not be assigned for every keeper" >&2
+    jq -c 'select(.review_target == null)' "$REVIEW_TARGETS_FILE" >&2 || true
+    exit 1
+  fi
+  log "review targets: $REVIEW_TARGETS_FILE"
 }
 
 build_github_identity_counts() {
@@ -905,8 +934,8 @@ require_cmd curl
 assert_expected_server_commit
 ensure_mcp_session_if_needed
 discover_keepers
-build_review_targets
 assert_github_identity_pool_for_mutate
+build_review_targets
 render_prompts
 
 if [[ "$MUTATE" == "1" ]]; then

--- a/scripts/harness/workload/keeper_product_design_board_reprobe.sh
+++ b/scripts/harness/workload/keeper_product_design_board_reprobe.sh
@@ -1,0 +1,575 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# shellcheck disable=SC1091
+# shellcheck source=scripts/harness/lib/mcp_jsonrpc.sh
+source "$REPO_ROOT/scripts/harness/lib/mcp_jsonrpc.sh"
+
+RUN_ID="${RUN_ID:-keeper-product-design-board-$(date +%Y%m%d_%H%M%S)}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/keeper_product_design_board/$RUN_ID}"
+RUN_DIR_EXPLICIT=0
+RAW_DIR="$RUN_DIR/raw"
+PROMPT_DIR="$RUN_DIR/prompts"
+REQUESTS_FILE="$RUN_DIR/requests.jsonl"
+RESULTS_FILE="$RUN_DIR/results.jsonl"
+POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
+SUMMARY_FILE="$RUN_DIR/summary.json"
+AUDIT_FILE="$RUN_DIR/audit-product-design.json"
+AUDIT_STATUS_RESULT=0
+
+BASE_PATH="${BASE_PATH:-${MASC_BASE_PATH:-$HOME/me}}"
+EXPECTED_KEEPERS="${EXPECTED_KEEPERS:-14}"
+KEEPER_NAMES="${KEEPER_NAMES:-}"
+MAX_KEEPERS="${MAX_KEEPERS:-0}"
+MUTATE="${MUTATE:-0}"
+RUN_AUDIT="${RUN_AUDIT:-1}"
+EXIT_ON_AUDIT_FAIL="${EXIT_ON_AUDIT_FAIL:-}"
+MSG_TIMEOUT_SEC="${MSG_TIMEOUT_SEC:-120}"
+KEEPER_TURN_TIMEOUT_SEC="${KEEPER_TURN_TIMEOUT_SEC:-600}"
+INIT_TIMEOUT_SEC="${INIT_TIMEOUT_SEC:-60}"
+POLL_TIMEOUT_SEC="${POLL_TIMEOUT_SEC:-900}"
+POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
+REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_board_post}"
+MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
+MCP_TOKEN="${MASC_MCP_TOKEN:-}"
+MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-product-design-board-reprobe}"
+BOARD_POST_ID="${BOARD_POST_ID:-}"
+FORBID_GITHUB_IDENTITIES="${FORBID_GITHUB_IDENTITIES:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/harness_keeper_product_design_board_reprobe.sh [options]
+
+Render or send keeper prompts that require explicit product/design board
+evidence, then audit the fleet with --require-product-evidence and
+--require-design-evidence.
+
+Options:
+  --mutate                 Send prompts to keepers via masc_keeper_msg.
+  --dry-run                Do not send prompts (default).
+  --keeper-names CSV       Target explicit keeper names instead of config discovery.
+  --max-keepers N          Limit targets after discovery/CSV expansion.
+  --expected-keepers N     Minimum configured keeper count for audit.
+  --base-path PATH         MASC base path for audit and config discovery.
+  --mcp-url URL            MCP endpoint (default: http://127.0.0.1:8935/mcp).
+  --board-post-id ID       Post a final board comment to this thread.
+  --run-id ID              Stable run id for prompts and artifacts.
+  --run-dir PATH           Artifact directory.
+  --forbid-github-identity NAME
+                           Pass a forbidden identity to the final audit.
+  -h, --help               Show this help.
+
+Environment:
+  MASC_MCP_TOKEN           Optional bearer token for MCP calls.
+  POLL_TIMEOUT_SEC         Overall result polling window when --mutate is used.
+  POLL_INTERVAL_SEC        Poll interval in seconds.
+  MSG_TIMEOUT_SEC          HTTP request timeout for MCP tool calls.
+  KEEPER_TURN_TIMEOUT_SEC  Per-keeper Agent.run timeout_sec sent to masc_keeper_msg.
+  REQUIRED_TOOLS           CSV required_tools sent to masc_keeper_msg.
+  RUN_AUDIT=0              Skip final audit.
+  FORBID_GITHUB_IDENTITIES Optional CSV of forbidden keeper GitHub identities.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mutate)
+      MUTATE=1
+      shift
+      ;;
+    --dry-run)
+      MUTATE=0
+      shift
+      ;;
+    --keeper-names)
+      KEEPER_NAMES="$2"
+      shift 2
+      ;;
+    --max-keepers)
+      MAX_KEEPERS="$2"
+      shift 2
+      ;;
+    --expected-keepers)
+      EXPECTED_KEEPERS="$2"
+      shift 2
+      ;;
+    --base-path)
+      BASE_PATH="$2"
+      shift 2
+      ;;
+    --mcp-url)
+      MCP_URL="$2"
+      shift 2
+      ;;
+    --board-post-id)
+      BOARD_POST_ID="$2"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="$2"
+      if [[ "$RUN_DIR_EXPLICIT" != "1" ]]; then
+        RUN_DIR="$REPO_ROOT/logs/keeper_product_design_board/$RUN_ID"
+        RAW_DIR="$RUN_DIR/raw"
+        PROMPT_DIR="$RUN_DIR/prompts"
+        REQUESTS_FILE="$RUN_DIR/requests.jsonl"
+        RESULTS_FILE="$RUN_DIR/results.jsonl"
+        POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
+        SUMMARY_FILE="$RUN_DIR/summary.json"
+        AUDIT_FILE="$RUN_DIR/audit-product-design.json"
+      fi
+      shift 2
+      ;;
+    --run-dir)
+      RUN_DIR="$2"
+      RUN_DIR_EXPLICIT=1
+      RAW_DIR="$RUN_DIR/raw"
+      PROMPT_DIR="$RUN_DIR/prompts"
+      REQUESTS_FILE="$RUN_DIR/requests.jsonl"
+      RESULTS_FILE="$RUN_DIR/results.jsonl"
+      POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
+      SUMMARY_FILE="$RUN_DIR/summary.json"
+      AUDIT_FILE="$RUN_DIR/audit-product-design.json"
+      shift 2
+      ;;
+    --forbid-github-identity)
+      if [[ -n "$FORBID_GITHUB_IDENTITIES" ]]; then
+        FORBID_GITHUB_IDENTITIES="$FORBID_GITHUB_IDENTITIES,$2"
+      else
+        FORBID_GITHUB_IDENTITIES="$2"
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$EXIT_ON_AUDIT_FAIL" ]]; then
+  EXIT_ON_AUDIT_FAIL="$MUTATE"
+fi
+
+mkdir -p "$RUN_DIR" "$RAW_DIR" "$PROMPT_DIR"
+: >"$REQUESTS_FILE"
+: >"$RESULTS_FILE"
+: >"$POLL_ERRORS_FILE"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 127
+  fi
+}
+
+load_mcp_token() {
+  if [[ -n "$MCP_TOKEN" ]]; then
+    return 0
+  fi
+  local token_file="$BASE_PATH/.masc/auth/codex-mcp-client.token"
+  if [[ -f "$token_file" ]]; then
+    MCP_TOKEN="$(tr -d '\n' <"$token_file")"
+  fi
+}
+
+init_mcp_session() {
+  if [[ -n "${MCP_SESSION_ID:-}" ]]; then
+    return 0
+  fi
+
+  local headers_file body_file init_body session_id protocol_version deadline
+  headers_file="$(mcp_mktemp_file "keeper-product-design-init" ".headers")"
+  body_file="$(mcp_mktemp_file "keeper-product-design-init" ".body")"
+  init_body="$(
+    jq -cn --arg client_name "$MCP_CLIENT_NAME" \
+      '{jsonrpc:"2.0", id:1, method:"initialize", params:{protocolVersion:"2025-11-25", clientInfo:{name:$client_name, version:"1.0"}, capabilities:{}}}'
+  )"
+
+  deadline=$(( $(date +%s) + INIT_TIMEOUT_SEC ))
+  while :; do
+    : >"$headers_file"
+    : >"$body_file"
+    local remaining_sec init_attempt_timeout
+    remaining_sec=$((deadline - $(date +%s)))
+    if [[ "$remaining_sec" -le 0 ]]; then
+      break
+    fi
+    init_attempt_timeout="$remaining_sec"
+    if [[ "$MSG_TIMEOUT_SEC" -gt 0 && "$MSG_TIMEOUT_SEC" -lt "$init_attempt_timeout" ]]; then
+      init_attempt_timeout="$MSG_TIMEOUT_SEC"
+    fi
+
+    local -a cmd=(
+      curl -sS --max-time "$init_attempt_timeout"
+      -D "$headers_file"
+      -o "$body_file"
+      -X POST "$MCP_URL"
+      -H "Content-Type: application/json"
+      -H "Accept: application/json, text/event-stream"
+    )
+    if [[ -n "$MCP_TOKEN" ]]; then
+      cmd+=( -H "Authorization: Bearer $MCP_TOKEN" )
+    fi
+    cmd+=( --data-binary "$init_body" )
+
+    if "${cmd[@]}" >/dev/null; then
+      session_id="$(awk 'tolower($0) ~ /^mcp-session-id:/ { sub(/^[^:]+:[[:space:]]*/, "", $0); sub(/\r$/, "", $0); print $0; exit }' "$headers_file")"
+      protocol_version="$(awk 'tolower($0) ~ /^mcp-protocol-version:/ { sub(/^[^:]+:[[:space:]]*/, "", $0); sub(/\r$/, "", $0); print $0; exit }' "$headers_file")"
+      if [[ -n "$session_id" ]]; then
+        break
+      fi
+      if ! jq -e '.error.code == -32002' "$body_file" >/dev/null 2>&1; then
+        break
+      fi
+    fi
+    sleep 2
+  done
+
+  if [[ -z "${session_id:-}" ]]; then
+    echo "MCP initialize did not return Mcp-Session-Id before ${INIT_TIMEOUT_SEC}s deadline" >&2
+    cat "$body_file" >&2 || true
+    rm -f "$headers_file" "$body_file"
+    exit 1
+  fi
+
+  MCP_SESSION_ID="$session_id"
+  export MCP_SESSION_ID
+  if [[ -n "${protocol_version:-}" ]]; then
+    MCP_PROTOCOL_VERSION="$protocol_version"
+    export MCP_PROTOCOL_VERSION
+  fi
+  rm -f "$headers_file" "$body_file"
+}
+
+ensure_mcp_session_if_needed() {
+  if [[ "$MUTATE" == "1" || -n "$BOARD_POST_ID" ]]; then
+    load_mcp_token
+    init_mcp_session
+  fi
+}
+
+tool_call() {
+  local id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  local timeout_sec="${4:-$MSG_TIMEOUT_SEC}"
+  local saved_timeout="${HTTP_TIMEOUT_SEC:-}"
+  HTTP_TIMEOUT_SEC="$timeout_sec"
+  local json_id payload
+  json_id="$(jq -cn --arg value "$id" '$value')"
+  payload="$(mcp_call_tool "$json_id" "$tool_name" "$args_json" "${MCP_SESSION_ID:-}" "$MCP_TOKEN" "$MCP_URL")"
+  HTTP_TIMEOUT_SEC="$saved_timeout"
+  printf '%s' "$payload"
+}
+
+tool_text_or_empty() {
+  local payload="$1"
+  printf '%s' "$payload" | mcp_extract_text
+}
+
+discover_keepers() {
+  local keeper_file="$RUN_DIR/keepers.txt"
+  if [[ -n "$KEEPER_NAMES" ]]; then
+    printf '%s\n' "$KEEPER_NAMES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | awk 'NF' >"$keeper_file"
+  else
+    local config_dir="$BASE_PATH/.masc/config/keepers"
+    if [[ ! -d "$config_dir" ]]; then
+      echo "keeper config dir not found: $config_dir" >&2
+      exit 1
+    fi
+    python3 - "$config_dir" >"$keeper_file" <<'PY'
+import pathlib
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore
+
+root = pathlib.Path(sys.argv[1])
+
+
+def merge_dicts(base, overlay):
+    merged = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = merge_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_keeper_config(path, seen=None):
+    seen = set() if seen is None else seen
+    resolved = path.resolve()
+    if resolved in seen:
+        return {}
+    seen.add(resolved)
+    try:
+        raw = tomllib.loads(path.read_text())
+    except Exception:
+        return {}
+    keeper = raw.get("keeper")
+    if not isinstance(keeper, dict):
+        return {}
+    base_name = keeper.get("base")
+    if isinstance(base_name, str) and base_name.strip():
+        return merge_dicts(load_keeper_config(path.parent / base_name, seen), keeper)
+    return keeper
+
+
+names = []
+for path in sorted(root.glob("*.toml")):
+    if path.name == "base.toml":
+        continue
+    keeper = load_keeper_config(path)
+    if keeper.get("sandbox_profile") != "docker":
+        continue
+    name = keeper.get("name") or path.stem
+    if isinstance(name, str) and name:
+        names.append(name)
+
+unique = []
+for name in names:
+    if name not in unique:
+        unique.append(name)
+if "sangsu" in unique:
+    unique.remove("sangsu")
+    unique.insert(0, "sangsu")
+for name in unique:
+    print(name)
+PY
+  fi
+
+  if [[ "$MAX_KEEPERS" =~ ^[0-9]+$ ]] && [[ "$MAX_KEEPERS" -gt 0 ]]; then
+    local limited="$RUN_DIR/keepers.limited.txt"
+    head -n "$MAX_KEEPERS" "$keeper_file" >"$limited"
+    mv "$limited" "$keeper_file"
+  fi
+
+  local count
+  count="$(awk 'NF { c++ } END { print c + 0 }' "$keeper_file")"
+  if [[ "$count" -eq 0 ]]; then
+    echo "no target keepers discovered; pass --keeper-names or check config state" >&2
+    exit 1
+  fi
+  log "target keepers: $count"
+}
+
+prompt_for_keeper() {
+  local keeper="$1"
+  cat <<EOF
+Product/design board evidence run: $RUN_ID
+
+Keeper: $keeper
+
+Goal: create explicit product and design-domain board evidence for the fleet readiness audit.
+
+Required action:
+1. Call keeper_board_post exactly once.
+2. Use hearth: product-design
+3. The post must include one concrete product decision or risk, one concrete design decision or risk, and one next action that another keeper or operator can verify.
+4. Do not edit files. Do not create a PR in this run.
+5. After the tool call, reply with one compact JSON object:
+   {"run_id":"$RUN_ID","keeper":"$keeper","hearth":"product-design","keeper_board_post":true,"product_evidence":true,"design_evidence":true,"blocker":null}
+
+This prompt is sent with masc_keeper_msg.required_tools=["keeper_board_post"].
+If keeper_board_post is unavailable or policy-blocked, stop and reply with the exact blocker instead of substituting another surface.
+EOF
+}
+
+render_prompts() {
+  while IFS= read -r keeper; do
+    [[ -n "$keeper" ]] || continue
+    prompt_for_keeper "$keeper" >"$PROMPT_DIR/$keeper.txt"
+  done <"$RUN_DIR/keepers.txt"
+}
+
+send_prompts() {
+  while IFS= read -r keeper; do
+    [[ -n "$keeper" ]] || continue
+    local prompt args payload text request_id
+    prompt="$(cat "$PROMPT_DIR/$keeper.txt")"
+    args="$(
+      jq -cn \
+        --arg name "$keeper" \
+        --arg message "$prompt" \
+        --arg required_tools_csv "$REQUIRED_TOOLS" \
+        --argjson timeout "$KEEPER_TURN_TIMEOUT_SEC" \
+        '{name:$name,message:$message,timeout_sec:$timeout,required_tools:($required_tools_csv | split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0)))}'
+    )"
+    log "sending product/design prompt to $keeper"
+    payload="$(tool_call "keeper-product-design-msg-$keeper-$RUN_ID" "masc_keeper_msg" "$args" "$MSG_TIMEOUT_SEC")"
+    printf '%s' "$payload" >"$RAW_DIR/msg-$keeper.jsonrpc.json"
+    mcp_require_tool_ok "$payload" "masc_keeper_msg:$keeper"
+    text="$(tool_text_or_empty "$payload")"
+    printf '%s' "$text" >"$RAW_DIR/msg-$keeper.text"
+    request_id="$(printf '%s' "$text" | jq -r '.request_id // .id // empty' 2>/dev/null || true)"
+    if [[ -z "$request_id" ]]; then
+      echo "masc_keeper_msg did not return request_id for $keeper" >&2
+      printf '%s\n' "$text" >&2
+      exit 1
+    fi
+    jq -nc --arg keeper "$keeper" --arg request_id "$request_id" --arg prompt_file "$PROMPT_DIR/$keeper.txt" \
+      '{keeper:$keeper, request_id:$request_id, prompt_file:$prompt_file, status:"pending"}' >>"$REQUESTS_FILE"
+  done <"$RUN_DIR/keepers.txt"
+}
+
+result_is_terminal() {
+  local text="$1"
+  printf '%s' "$text" | jq -e '(.reply? | type == "string" and length > 0) or ((.status? // "" | ascii_downcase) as $s | ($s == "done" or $s == "complete" or $s == "completed" or $s == "failed" or $s == "error" or $s == "cancelled"))' >/dev/null 2>&1
+}
+
+poll_results() {
+  local deadline pending_file
+  deadline=$(( $(date +%s) + POLL_TIMEOUT_SEC ))
+  pending_file="$RUN_DIR/pending.txt"
+  jq -r '.request_id + "\t" + .keeper' "$REQUESTS_FILE" >"$pending_file"
+
+  while [[ -s "$pending_file" && "$(date +%s)" -lt "$deadline" ]]; do
+    local next_pending="$RUN_DIR/pending.next"
+    : >"$next_pending"
+    while IFS=$'\t' read -r request_id keeper; do
+      [[ -n "$request_id" ]] || continue
+      local args payload text status
+      args="$(jq -cn --arg request_id "$request_id" '{request_id:$request_id}')"
+      payload="$(tool_call "keeper-product-design-result-$request_id" "masc_keeper_msg_result" "$args" 30)"
+      printf '%s' "$payload" >"$RAW_DIR/result-$keeper-$request_id.jsonrpc.json"
+      if ! mcp_require_tool_ok "$payload" "masc_keeper_msg_result:$keeper" >/dev/null 2>&1; then
+        jq -nc --arg keeper "$keeper" --arg request_id "$request_id" --arg status "poll_error" \
+          --arg raw_file "$RAW_DIR/result-$keeper-$request_id.jsonrpc.json" \
+          '{keeper:$keeper, request_id:$request_id, status:$status, raw_file:$raw_file}' >>"$POLL_ERRORS_FILE"
+        printf '%s\t%s\n' "$request_id" "$keeper" >>"$next_pending"
+        continue
+      fi
+      text="$(tool_text_or_empty "$payload")"
+      printf '%s' "$text" >"$RAW_DIR/result-$keeper-$request_id.text"
+      if result_is_terminal "$text"; then
+        status="$(printf '%s' "$text" | jq -r '.status // (if .reply then "completed" else "unknown" end)' 2>/dev/null || echo completed)"
+        jq -nc --arg keeper "$keeper" --arg request_id "$request_id" --arg status "$status" \
+          --arg text_file "$RAW_DIR/result-$keeper-$request_id.text" \
+          '{keeper:$keeper, request_id:$request_id, status:$status, text_file:$text_file}' >>"$RESULTS_FILE"
+      else
+        printf '%s\t%s\n' "$request_id" "$keeper" >>"$next_pending"
+      fi
+    done <"$pending_file"
+    mv "$next_pending" "$pending_file"
+    [[ -s "$pending_file" ]] || break
+    sleep "$POLL_INTERVAL_SEC"
+  done
+
+  if [[ -s "$pending_file" ]]; then
+    while IFS=$'\t' read -r request_id keeper; do
+      jq -nc --arg keeper "$keeper" --arg request_id "$request_id" \
+        '{keeper:$keeper, request_id:$request_id, status:"poll_timeout"}' >>"$RESULTS_FILE"
+    done <"$pending_file"
+  fi
+}
+
+run_audit() {
+  if [[ "$RUN_AUDIT" != "1" ]]; then
+    AUDIT_STATUS_RESULT=0
+    return 0
+  fi
+  log "running product/design fleet audit"
+  local -a audit_args=(
+    "$REPO_ROOT/scripts/audit-keeper-fleet-readiness.py"
+    --base-path "$BASE_PATH"
+    --expected-keepers "$EXPECTED_KEEPERS"
+    --require-product-evidence
+    --require-design-evidence
+    --json
+  )
+  if [[ -n "$FORBID_GITHUB_IDENTITIES" ]]; then
+    IFS=',' read -r -a forbidden_items <<<"$FORBID_GITHUB_IDENTITIES"
+    local forbidden_item
+    for forbidden_item in "${forbidden_items[@]}"; do
+      forbidden_item="${forbidden_item#"${forbidden_item%%[![:space:]]*}"}"
+      forbidden_item="${forbidden_item%"${forbidden_item##*[![:space:]]}"}"
+      if [[ -n "$forbidden_item" ]]; then
+        audit_args+=(--forbid-github-identity "$forbidden_item")
+      fi
+    done
+  fi
+  set +e
+  python3 "${audit_args[@]}" >"$AUDIT_FILE"
+  local audit_status=$?
+  set -e
+  AUDIT_STATUS_RESULT="$audit_status"
+  return 0
+}
+
+write_summary() {
+  local audit_status="$1"
+  local keeper_count request_count result_count timeout_count poll_error_count
+  keeper_count="$(awk 'NF { c++ } END { print c + 0 }' "$RUN_DIR/keepers.txt")"
+  request_count="$(awk 'NF { c++ } END { print c + 0 }' "$REQUESTS_FILE")"
+  result_count="$(awk 'NF { c++ } END { print c + 0 }' "$RESULTS_FILE")"
+  timeout_count="$(jq -s '[.[] | select(.status == "poll_timeout")] | length' "$RESULTS_FILE" 2>/dev/null || echo 0)"
+  poll_error_count="$(awk 'NF { c++ } END { print c + 0 }' "$POLL_ERRORS_FILE")"
+  jq -n \
+    --arg run_id "$RUN_ID" \
+    --arg run_dir "$RUN_DIR" \
+    --arg base_path "$BASE_PATH" \
+    --arg forbid_github_identities "$FORBID_GITHUB_IDENTITIES" \
+    --argjson mutate "$MUTATE" \
+    --argjson keeper_count "$keeper_count" \
+    --argjson request_count "$request_count" \
+    --argjson result_count "$result_count" \
+    --argjson timeout_count "$timeout_count" \
+    --argjson poll_error_count "$poll_error_count" \
+    --argjson audit_status "$audit_status" \
+    --arg audit_file "$AUDIT_FILE" \
+    '{run_id:$run_id,run_dir:$run_dir,base_path:$base_path,forbid_github_identities:$forbid_github_identities,mutate:$mutate,keeper_count:$keeper_count,request_count:$request_count,result_count:$result_count,timeout_count:$timeout_count,poll_error_count:$poll_error_count,audit_status:$audit_status,audit_file:$audit_file}' \
+    >"$SUMMARY_FILE"
+}
+
+post_board_summary() {
+  [[ -n "$BOARD_POST_ID" ]] || return 0
+  local content args payload
+  content="$(jq -r '"Product/design board reprobe " + .run_id + "\n- mutate: " + (.mutate | tostring) + "\n- keepers: " + (.keeper_count | tostring) + "\n- requests: " + (.request_count | tostring) + "\n- results: " + (.result_count | tostring) + "\n- timeouts: " + (.timeout_count | tostring) + "\n- poll_errors: " + (.poll_error_count | tostring) + "\n- audit_status: " + (.audit_status | tostring) + "\n- artifacts: " + .run_dir' "$SUMMARY_FILE")"
+  args="$(jq -cn --arg post_id "$BOARD_POST_ID" --arg content "$content" \
+    '{post_id:$post_id, author:"keeper-product-design-board-reprobe", content:$content, ttl_hours:168}')"
+  payload="$(tool_call "product-design-board-comment-$RUN_ID" "masc_board_comment" "$args" 30)"
+  printf '%s' "$payload" >"$RAW_DIR/board-comment.jsonrpc.json"
+}
+
+require_cmd jq
+require_cmd python3
+require_cmd curl
+
+ensure_mcp_session_if_needed
+discover_keepers
+render_prompts
+
+if [[ "$MUTATE" == "1" ]]; then
+  send_prompts
+  poll_results
+else
+  log "dry-run mode: prompts rendered under $PROMPT_DIR; no keeper messages sent"
+fi
+
+audit_status=0
+if [[ "$RUN_AUDIT" == "1" ]]; then
+  run_audit
+  audit_status="$AUDIT_STATUS_RESULT"
+fi
+write_summary "$audit_status"
+post_board_summary || true
+
+log "summary: $SUMMARY_FILE"
+if [[ "$audit_status" -ne 0 && "$EXIT_ON_AUDIT_FAIL" == "1" ]]; then
+  exit "$audit_status"
+fi

--- a/scripts/harness_keeper_product_design_board_reprobe.sh
+++ b/scripts/harness_keeper_product_design_board_reprobe.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/workload/keeper_product_design_board_reprobe.sh" "$@"

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -47,10 +47,12 @@ def audit_args(base_path: Path, expected_keepers: int):
     )
 
 
-def write_ready_keeper(root: Path, name: str) -> None:
+def write_ready_keeper(
+    root: Path, name: str, *, github_identity: str = "anyang-keepers"
+) -> None:
     config_dir = root / ".masc" / "config" / "keepers"
     runtime_dir = root / ".masc" / "keepers"
-    credential_dir = root / ".masc" / "github-identities" / "anyang-keepers" / "gh"
+    credential_dir = root / ".masc" / "github-identities" / github_identity / "gh"
     config_dir.mkdir(parents=True, exist_ok=True)
     runtime_dir.mkdir(parents=True, exist_ok=True)
     credential_dir.mkdir(parents=True, exist_ok=True)
@@ -61,7 +63,7 @@ def write_ready_keeper(root: Path, name: str) -> None:
                 'sandbox_profile = "docker"',
                 'network_mode = "inherit"',
                 'tool_preset = "coding"',
-                'github_identity = "anyang-keepers"',
+                f'github_identity = "{github_identity}"',
                 'git_identity_mode = "github_identity"',
                 "",
             ]
@@ -74,7 +76,7 @@ def write_ready_keeper(root: Path, name: str) -> None:
                 "sandbox_profile": "docker",
                 "network_mode": "inherit",
                 "tool_preset": "coding",
-                "github_identity": "anyang-keepers",
+                "github_identity": github_identity,
                 "git_identity_mode": "github_identity",
                 "last_turn_ts": time.time(),
             }
@@ -452,6 +454,44 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertFalse(report["ok"])
         self.assertEqual(
             report["fleet_failures"], ["minimum_2_configured_keepers_got_1"]
+        )
+
+    def test_docker_pr_approve_requirement_fails_with_single_identity_pool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            write_ready_keeper(root, "bravo")
+            args = audit_args(root, expected_keepers=2)
+            args.require_docker_pr_lifecycle_evidence = True
+
+            report = audit.build_report(args)
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["github_identity_counts"], {"anyang-keepers": 2})
+        self.assertIn(
+            "docker_pr_approve_identity_pool_insufficient"
+            "_unique_github_identities_1",
+            report["fleet_failures"],
+        )
+
+    def test_docker_pr_approve_requirement_accepts_multiple_identity_pool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha", github_identity="anyang-keepers")
+            write_ready_keeper(root, "bravo", github_identity="reviewer-keepers")
+            args = audit_args(root, expected_keepers=2)
+            args.require_docker_pr_approve_evidence = True
+
+            report = audit.build_report(args)
+
+        self.assertEqual(
+            report["github_identity_counts"],
+            {"anyang-keepers": 1, "reviewer-keepers": 1},
+        )
+        self.assertNotIn(
+            "docker_pr_approve_identity_pool_insufficient"
+            "_unique_github_identities_1",
+            report["fleet_failures"],
         )
 
 

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -34,6 +34,8 @@ def audit_args(base_path: Path, expected_keepers: int):
         expected_keepers=expected_keepers,
         max_silence_hours=2400.0,
         require_board_evidence=True,
+        require_product_evidence=False,
+        require_design_evidence=False,
         require_pr_surface_evidence=False,
         require_pr_review_evidence=False,
         require_pr_create_evidence=False,
@@ -44,6 +46,7 @@ def audit_args(base_path: Path, expected_keepers: int):
         require_docker_git_push_evidence=False,
         require_docker_pr_approve_evidence=False,
         require_docker_pr_lifecycle_evidence=False,
+        forbid_github_identity=[],
     )
 
 
@@ -95,6 +98,34 @@ def write_ready_keeper(
         + "\n",
         encoding="utf-8",
     )
+
+
+def write_board_post(
+    root: Path,
+    author: str,
+    post_id: str,
+    *,
+    hearth: str | None = None,
+    meta: dict | None = None,
+    body: str = "body",
+    ts: float | None = None,
+) -> None:
+    row = {
+        "id": post_id,
+        "author": author,
+        "body": body,
+        "content": body,
+        "created_at": time.time() if ts is None else ts,
+        "updated_at": time.time() if ts is None else ts,
+    }
+    if hearth is not None:
+        row["hearth"] = hearth
+    if meta is not None:
+        row["meta"] = meta
+    board_path = root / ".masc" / "board_posts.jsonl"
+    board_path.parent.mkdir(parents=True, exist_ok=True)
+    with board_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row) + "\n")
 
 
 class AuditKeeperFleetReadinessTest(unittest.TestCase):
@@ -432,6 +463,59 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertEqual(evidence, {"pr_create:keeper_shell"})
         self.assertEqual(docker_evidence, set())
 
+    def test_product_and_design_evidence_use_explicit_board_domains(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            write_board_post(root, "alpha", "p-product", hearth="product")
+            write_board_post(
+                root,
+                "alpha",
+                "p-design",
+                meta={"tags": ["design"], "source": "keeper_board_post"},
+            )
+            args = audit_args(root, expected_keepers=1)
+            args.require_product_evidence = True
+            args.require_design_evidence = True
+
+            report = audit.build_report(args)
+
+        self.assertTrue(report["ok"])
+        keeper = report["keepers"][0]
+        self.assertTrue(keeper["product_action"])
+        self.assertTrue(keeper["design_action"])
+        self.assertEqual(
+            keeper["product_evidence"],
+            ["product:board_post:p-product:hearth=product"],
+        )
+        self.assertEqual(
+            keeper["design_evidence"],
+            ["design:board_post:p-design:meta.tags_0_=design"],
+        )
+
+    def test_product_and_design_evidence_ignore_freeform_body_mentions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            write_board_post(
+                root,
+                "alpha",
+                "p-freeform",
+                body="This mentions product and design, but has no domain marker.",
+            )
+            args = audit_args(root, expected_keepers=1)
+            args.require_product_evidence = True
+            args.require_design_evidence = True
+
+            report = audit.build_report(args)
+
+        self.assertFalse(report["ok"])
+        keeper = report["keepers"][0]
+        self.assertFalse(keeper["product_action"])
+        self.assertFalse(keeper["design_action"])
+        self.assertIn("product_action_evidence_missing", keeper["failures"])
+        self.assertIn("design_action_evidence_missing", keeper["failures"])
+
     def test_expected_keepers_is_minimum_not_exact_count(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -454,6 +538,21 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertFalse(report["ok"])
         self.assertEqual(
             report["fleet_failures"], ["minimum_2_configured_keepers_got_1"]
+        )
+
+    def test_forbid_github_identity_fails_matching_keeper(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha", github_identity="operator")
+            args = audit_args(root, expected_keepers=1)
+            args.forbid_github_identity = ["operator"]
+
+            report = audit.build_report(args)
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(
+            report["keepers"][0]["failures"],
+            ["github_identity_forbidden_operator"],
         )
 
     def test_docker_pr_approve_requirement_fails_with_single_identity_pool(self):


### PR DESCRIPTION
## Summary

- add fleet audit preflights for Docker PR approval evidence, product/design board evidence, and forbidden GitHub identities
- expose `github_identity_counts`, product/design booleans, and board-domain evidence in the fleet readiness JSON report
- add `--expected-server-commit` / `EXPECTED_SERVER_COMMIT` to the Docker PR lifecycle reprobe harness so it fails before MCP mutation if `/health.build.commit` is not the PR head under test
- render cross-keeper approval targets by GitHub identity, not just keeper order, so approval proof cannot silently route to same-identity PRs
- make the mutate harness fail before sending keeper messages when the identity pool is insufficient, a target cannot be assigned, or a target keeper uses a forbidden identity such as the operator account
- add `scripts/harness_keeper_product_design_board_reprobe.sh` so the fleet can be prompted to create explicit `product-design` board evidence and then audited separately from Docker PR lifecycle proof
- add regression coverage for single-identity failure, multi-identity acceptance, explicit product/design board-domain evidence, and forbidden identity failure

## Why it matters

Live Docker PR lifecycle reprobe proved a keeper can create/push/review-comment from Docker, but GitHub rejects approve when the author and reviewer are the same account. A later live audit showed a different but unsafe state: `verifier` had drifted to `github_identity = "jeong-sik"`, which creates a second identity pool but uses the operator account for keeper proof. This PR makes both states fail closed before a fleet run sends keeper messages.

The goal audit also needs to distinguish ordinary board chatter from product/design work. Product and design evidence now comes from explicit board `hearth` or metadata markers, not freeform body text, so the audit can say which keepers actually posted product/design-domain work. The new product/design reprobe harness closes the action path: render/send required `keeper_board_post` prompts, poll async keeper results, then run the product/design-only audit.

Tracks #13705, #13706, and #13727.

## Validation

- `python3 test/test_audit_keeper_fleet_readiness.py` (22 tests)
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `bash -n scripts/harness/workload/keeper_product_design_board_reprobe.sh scripts/harness_keeper_product_design_board_reprobe.sh`
- `git diff --check`
- `scripts/audit-keeper-fleet-readiness.py --base-path /Users/dancer/me --expected-keepers 14 --require-docker-pr-lifecycle-evidence --require-product-evidence --require-design-evidence --forbid-github-identity jeong-sik` (expected failure; reports missing Docker lifecycle/product/design evidence and blocks `verifier` on `github_identity_forbidden_jeong-sik`)
- `RUN_AUDIT=0 scripts/harness_keeper_product_design_board_reprobe.sh --dry-run --keeper-names sangsu,verifier --run-id product-design-dryrun-0506 --run-dir /tmp/keeper-product-design-dryrun-0506`
- `scripts/harness_keeper_product_design_board_reprobe.sh --dry-run --keeper-names sangsu,verifier --run-id product-design-audit-fail-0506b --run-dir /tmp/keeper-product-design-audit-fail-0506b --forbid-github-identity jeong-sik` (expected audit failure recorded in summary)
- `RUN_AUDIT=0 scripts/harness_keeper_product_design_board_reprobe.sh --dry-run --run-id product-design-discovery-dryrun-0506 --run-dir /tmp/keeper-product-design-discovery-dryrun-0506` (discovers 17 docker keepers)
- `RUN_AUDIT=0 MSG_TIMEOUT_SEC=30 INIT_TIMEOUT_SEC=30 scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh --mutate --keeper-names sangsu,verifier --run-id forbidden-identity-mutate-preflight-0506 --run-dir /tmp/keeper-docker-pr-forbidden-identity-mutate-preflight-0506 --forbid-github-identity jeong-sik` (expected failure before keeper messages)

Earlier guard validations on this branch covered server commit mismatch, identity-aware cross-target selection, and same-identity mutate preflight failure.