### PR TITLE
fix(metrics): contract keeper starvation rate

### DIFF
--- a/docs/observability/goal-loop-observe-metrics.md
+++ b/docs/observability/goal-loop-observe-metrics.md
@@ -25,6 +25,7 @@ now contract checked.
 |--------|--------|-------|
 | keeper turn success rate | `masc_keeper_turn_completed_total`, `masc_keeper_turn_scheduled_total` | `GoalLoopKeeperTurnSuccessRateCritical` |
 | keeper semaphore wait p99 | `masc_keeper_semaphore_wait_seconds_bucket` | `GoalLoopKeeperSemaphoreWaitP99Critical` |
+| starvation rate | `masc_keeper_semaphore_wait_timeout_total`, `masc_keeper_turn_scheduled_total` | `GoalLoopKeeperStarvationRateCritical` |
 | keeper alive-but-stuck | `masc_keeper_alive_but_stuck_seconds`, `masc_keeper_alive_but_stuck_threshold_seconds` | `GoalLoopKeeperAliveButStuckCritical` |
 | keeper zombie loop | `masc_keeper_zombie_loop_detected_total` | `GoalLoopKeeperZombieLoopCritical` |
 | provider health probe skipped | `masc_provider_health_probe_skipped_total` | `GoalLoopProviderHealthProbeSkippedWarning` |
@@ -56,8 +57,8 @@ Expected result:
 
 ```text
 GOAL LOOP Observe Metrics Contract: PASS
-checked_signals: 15
-passing_signals: 15
+checked_signals: 16
+passing_signals: 16
 failing_signals: 0
 ```
 

--- a/infrastructure/monitoring/goal-loop-observe-alerts.yml
+++ b/infrastructure/monitoring/goal-loop-observe-alerts.yml
@@ -21,6 +21,7 @@ groups:
           absent(masc_keeper_turn_completed_total)
           or absent(masc_keeper_turn_scheduled_total)
           or absent(masc_keeper_semaphore_wait_seconds_bucket)
+          or absent(masc_keeper_semaphore_wait_timeout_total)
           or absent(masc_keeper_alive_but_stuck_seconds)
           or absent(masc_keeper_alive_but_stuck_threshold_seconds)
           or absent(masc_keeper_zombie_loop_detected_total)
@@ -90,6 +91,25 @@ groups:
           description: |
             Bounded semaphore acquisition is no longer bounded in practice.
             Check turn slot holder state and fallback ladder activation.
+
+      - alert: GoalLoopKeeperStarvationRateCritical
+        expr: |
+          (
+            sum(increase(masc_keeper_semaphore_wait_timeout_total[5m]))
+            /
+            clamp_min(sum(increase(masc_keeper_turn_scheduled_total[5m])), 1)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Fleet keeper starvation rate > 5%"
+          description: |
+            More than 5% of scheduled keeper turns are ending in
+            semaphore-wait timeouts. This converts the Phase 0
+            starvation-rate requirement into an alertable fleet ratio.
 
       - alert: GoalLoopKeeperAliveButStuckCritical
         expr: |

--- a/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
+++ b/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
@@ -33,6 +33,24 @@
       ]
     },
     {
+      "signal_id": "starvation_rate",
+      "metric_names": [
+        "masc_keeper_semaphore_wait_timeout_total",
+        "masc_keeper_turn_scheduled_total"
+      ],
+      "alert_names": [
+        "GoalLoopKeeperStarvationRateCritical"
+      ],
+      "threshold_fragments": [
+        "[5m]",
+        "> 0.05"
+      ],
+      "dashboard_query_fragments": [
+        "masc_keeper_semaphore_wait_timeout_total",
+        "masc_keeper_turn_scheduled_total"
+      ]
+    },
+    {
       "signal_id": "keeper_alive_but_stuck",
       "metric_names": [
         "masc_keeper_alive_but_stuck_seconds",

--- a/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
+++ b/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
@@ -5,6 +5,7 @@
       "masc_keeper_turn_completed_total{keeper_name}",
       "masc_keeper_turn_scheduled_total{keeper_name}",
       "masc_keeper_semaphore_wait_seconds_bucket{keeper_name,cascade_profile}",
+      "masc_keeper_semaphore_wait_timeout_total{keeper,channel}",
       "masc_keeper_alive_but_stuck_seconds{keeper_name}",
       "masc_keeper_alive_but_stuck_threshold_seconds{keeper_name}",
       "masc_keeper_zombie_loop_detected_total{keeper_name}",
@@ -71,9 +72,14 @@
           "expr": "sum by (keeper_name) (rate(masc_keeper_turn_completed_total[5m])) / clamp_min(sum by (keeper_name) (rate(masc_keeper_turn_scheduled_total[5m])), 0.001)",
           "legendFormat": "{{keeper_name}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(increase(masc_keeper_semaphore_wait_timeout_total[5m])) / clamp_min(sum(increase(masc_keeper_turn_scheduled_total[5m])), 1)",
+          "legendFormat": "fleet starvation rate",
+          "refId": "B"
         }
       ],
-      "title": "Keeper Turn Success Rate",
+      "title": "Keeper Turn Rates",
       "type": "timeseries"
     },
     {

--- a/scripts/validate_goal_loop_observe_metrics.py
+++ b/scripts/validate_goal_loop_observe_metrics.py
@@ -57,8 +57,9 @@ def alert_exprs(alert_text: str) -> dict[str, str]:
         line = lines[index]
         alert_match = re.match(r"\s*-\s*alert:\s*([A-Za-z0-9_:.-]+)\s*$", line)
         if alert_match:
-            current_alert = alert_match.group(1)
-            exprs.setdefault(current_alert, "")
+            alert_name = alert_match.group(1)
+            current_alert = alert_name
+            exprs.setdefault(alert_name, "")
             index += 1
             continue
 

--- a/test/test_validate_goal_loop_observe_metrics.py
+++ b/test/test_validate_goal_loop_observe_metrics.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -42,7 +43,7 @@ def load_current_report(
     contract: dict[str, object] | None = None,
     alert_text: str | None = None,
     dashboard_text: str | None = None,
-) -> object:
+) -> Any:
     return validate_goal_loop_observe_metrics.validate_contract(
         contract
         if contract is not None
@@ -65,9 +66,31 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         report = load_current_report()
 
         self.assertEqual("PASS", report.status)
-        self.assertEqual(15, report.checked_signals)
-        self.assertEqual(15, report.passing_signals)
+        self.assertEqual(16, report.checked_signals)
+        self.assertEqual(16, report.passing_signals)
         self.assertEqual(0, report.failing_signals)
+
+    def test_contract_pins_starvation_rate_signal(self) -> None:
+        contract = validate_goal_loop_observe_metrics.load_json_object(
+            str(CONTRACT_PATH)
+        )
+        signals = {
+            signal["signal_id"]: signal
+            for signal in contract["required_signals"]
+        }
+
+        starvation_rate = signals["starvation_rate"]
+        self.assertEqual(
+            [
+                "masc_keeper_semaphore_wait_timeout_total",
+                "masc_keeper_turn_scheduled_total",
+            ],
+            starvation_rate["metric_names"],
+        )
+        self.assertEqual(
+            ["GoalLoopKeeperStarvationRateCritical"],
+            starvation_rate["alert_names"],
+        )
 
     def test_cli_require_complete_passes(self) -> None:
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- add the Phase 0 starvation_rate signal to the GOAL LOOP Observe metrics contract
- alert on fleet-wide semaphore wait timeouts over scheduled keeper turns
- expose the derived starvation-rate PromQL query in the Grafana Observe dashboard
- pin the new contract signal in validator tests and clean up pyright typing in that path

## Verification
- python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete --format text
- python3 test/test_validate_goal_loop_observe_metrics.py
- ruff check scripts/validate_goal_loop_observe_metrics.py test/test_validate_goal_loop_observe_metrics.py
- npx pyright --outputjson scripts/validate_goal_loop_observe_metrics.py test/test_validate_goal_loop_observe_metrics.py
- git diff --check