### PR TITLE
[codex] Persist keeper message cursors before turns

### DIFF
--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -62,6 +62,14 @@ let active_task_assignee = function
       Some assignee
   | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
+let assigned_task_ids ~matches_you tasks =
+  List.filter_map
+    (fun (task : Masc_domain.task) ->
+      match active_task_assignee task.task_status with
+      | Some assignee when matches_you assignee -> Some task.id
+      | Some _ | None -> None)
+    tasks
+
 let add_unique table key value =
   let values = Option.value (Hashtbl.find_opt table key) ~default:[] in
   if List.exists (String.equal value) values then ()

--- a/lib/dune
+++ b/lib/dune
@@ -234,6 +234,7 @@
    cohttp
    cohttp-eio
    agent_sdk
+   agent_sdk.base
    agent_sdk.llm_provider
    masc_mcp.oas_compat
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -376,6 +376,40 @@ let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
   | Some (Oas_worker_named.Oas_timeout_budget _) -> true
   | _ -> false
 
+let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
+  let updated = Keeper_world_observation.apply_message_cursor_updates meta updates in
+  if updates = [] then updated
+  else
+    let merge ~latest ~caller:_ =
+      Keeper_world_observation.apply_message_cursor_updates latest updates
+    in
+    match write_meta_with_merge ~merge config updated with
+    | Ok () -> (
+        match read_meta config updated.name with
+        | Ok (Some latest) -> latest
+        | Ok None ->
+            Prometheus.inc_counter Prometheus.metric_keeper_meta_read_failures
+              ~labels:[("keeper", updated.name); ("site", "cursor_update_none_after_write")]
+              ();
+            Log.Keeper.warn
+              "read_meta returned None after message cursor update write for %s"
+              updated.name;
+            { updated with meta_version = updated.meta_version + 1 }
+        | Error e ->
+            Prometheus.inc_counter Prometheus.metric_keeper_meta_read_failures
+              ~labels:[("keeper", updated.name); ("site", "cursor_update_read_after_write")]
+              ();
+            Log.Keeper.warn
+              "read_meta failed after message cursor update write for %s: %s"
+              updated.name e;
+            { updated with meta_version = updated.meta_version + 1 })
+    | Error e ->
+        Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
+          ~labels:[("keeper", updated.name); ("phase", "cursor_update")]
+          ();
+        Log.Keeper.warn "write_meta failed (message cursor update): %s" e;
+        updated
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -483,9 +517,6 @@ let run_keepalive_unified_turn
           ~config:ctx.config
           ~meta:meta_after_triage
       in
-      let has_message_signal =
-        obs.pending_mentions <> [] || obs.pending_scope_messages <> []
-      in
       let turn_decision =
         Keeper_world_observation.keeper_cycle_decision
           ~meta:meta_after_triage
@@ -499,9 +530,8 @@ let run_keepalive_unified_turn
         (not (Atomic.get stop))
         && turn_decision.should_run
       in
-      let meta_after_observe =
-        Keeper_world_observation.apply_message_cursor_updates
-          meta_after_triage
+      let meta_after_cursor_persist =
+        persist_message_cursor_updates ~config:ctx.config meta_after_triage
           obs.message_cursor_updates
       in
       let format_opt_int = function
@@ -598,18 +628,8 @@ let run_keepalive_unified_turn
           ~base_path:ctx.config.base_path
           ~keeper_name:meta_after_triage.name
       end;
-      if (not should_run_turn)
-         && (not has_message_signal)
-         && obs.message_cursor_updates <> []
-      then (
-        match write_meta ctx.config meta_after_observe with
-        | Ok () -> ()
-        | Error e ->
-            Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
-              ~labels:[("keeper", meta_after_observe.name); ("phase", "cursor_update")] ();
-            Log.Keeper.warn "write_meta failed (message cursor update): %s" e);
       if Atomic.get stop
-      then meta_after_triage
+      then meta_after_cursor_persist
       else if should_run_turn
       then (
         (* Admission wait happens before [mark_turn_started], so the stale
@@ -644,13 +664,13 @@ let run_keepalive_unified_turn
           Keeper_turn_slot.with_keeper_turn_slot_control ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
             match
-              with_in_turn_liveness_pulse ~ctx ~meta:meta_after_observe ~stop
+              with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop
                 (fun () ->
                   Keeper_unified_turn.run_keeper_cycle
                     ~config:ctx.config
-                    ~meta:meta_after_observe
+                    ~meta:meta_after_cursor_persist
                     ~observation:obs
-                    ~generation:meta_after_observe.runtime.generation
+                    ~generation:meta_after_cursor_persist.runtime.generation
                     ~channel:turn_decision.channel
                     ~semaphore_wait_ms:semaphore_wait_ms
                     ~turn_slot_control:slot_control
@@ -666,19 +686,19 @@ let run_keepalive_unified_turn
                  readers; escalate to ERROR only on the fatal-environment
                  branch, which is the real signal this layer owns. *)
               Log.Keeper.debug "%s: keeper cycle failed: %s"
-                meta_after_observe.name e_str;
+                meta_after_cursor_persist.name e_str;
               if String_util.contains_substring e_str "Eio switch not available"
                  || String_util.contains_substring e_str "Eio net not available"
               then begin
                 Log.Keeper.error
                   "%s: fatal environment error — promoting to Keeper_fiber_crash: %s"
-                  meta_after_observe.name e_str;
+                  meta_after_cursor_persist.name e_str;
                 Prometheus.inc_counter
                   Prometheus.metric_keeper_heartbeat_failures
-                  ~labels:[("keeper", meta_after_observe.name); ("phase", "fatal_environment")]
+                  ~labels:[("keeper", meta_after_cursor_persist.name); ("phase", "fatal_environment")]
                   ();
                 Keeper_registry.set_failure_reason
-                  ~base_path:ctx.config.base_path meta_after_observe.name
+                  ~base_path:ctx.config.base_path meta_after_cursor_persist.name
                   (Some (Keeper_registry.Exception
                     (Printf.sprintf "fatal environment error: %s" e_str)));
                 raise Keeper_registry.Keeper_fiber_crash
@@ -693,7 +713,7 @@ let run_keepalive_unified_turn
                  [sweep_and_recover] can clear it. *)
               if is_oas_timeout_budget_error err
               then begin
-                let keeper_name = meta_after_observe.name in
+                let keeper_name = meta_after_cursor_persist.name in
                 let prior_strikes =
                   prior_oas_timeout_budget_strikes
                     ~base_path:ctx.config.base_path
@@ -738,32 +758,32 @@ let run_keepalive_unified_turn
                     ] ()
                 end
               end;
-              (match read_meta ctx.config meta_after_observe.name with
+              (match read_meta ctx.config meta_after_cursor_persist.name with
                | Ok (Some latest) -> latest
                | Ok None ->
                  Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"
-                   meta_after_observe.name;
+                   meta_after_cursor_persist.name;
                  Prometheus.inc_counter
                    Prometheus.metric_keeper_meta_read_failures
-                   ~labels:[("keeper", meta_after_observe.name); ("site", "none_after_failure")]
+                   ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "none_after_failure")]
                    ();
-                 meta_after_observe
+                 meta_after_cursor_persist
                | Error e ->
                  Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"
-                   meta_after_observe.name e;
+                   meta_after_cursor_persist.name e;
                  Prometheus.inc_counter
                    Prometheus.metric_keeper_meta_read_failures
-                   ~labels:[("keeper", meta_after_observe.name); ("site", "error_after_failure")]
+                   ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "error_after_failure")]
                    ();
-                 meta_after_observe)
+                 meta_after_cursor_persist)
             | Ok updated ->
               (* PR-M: success clears the strike counter so a single
                  transient budget exhaustion does not trickle into the
                  next 4h-window's strike limit. *)
-              Keeper_turn_slot.reset_budget_exhaustion ~keeper_name:meta_after_observe.name;
+              Keeper_turn_slot.reset_budget_exhaustion ~keeper_name:meta_after_cursor_persist.name;
               clear_oas_timeout_budget_failure_reason
                 ~base_path:ctx.config.base_path
-                ~keeper_name:meta_after_observe.name;
+                ~keeper_name:meta_after_cursor_persist.name;
               updated)
         with
         | Ok meta -> meta
@@ -851,8 +871,8 @@ let run_keepalive_unified_turn
                 last_blocker_class = Some blocker_class;
               })
             meta_after_triage)
-      else if (not has_message_signal) && obs.message_cursor_updates <> [] then
-        meta_after_observe
+      else if obs.message_cursor_updates <> [] then
+        meta_after_cursor_persist
       else
         meta_after_triage
     with

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -74,6 +74,12 @@ val oas_timeout_budget_observation_reasons : string list
 val record_oas_timeout_budget_observation :
   base_path:string -> keeper_name:string -> unit
 
+val persist_message_cursor_updates :
+  config:Coord.config -> keeper_meta -> (string * int) list -> keeper_meta
+(** Persist room-message cursor updates immediately after observation.
+    This is intentionally exposed for the regression that proves a failed
+    turn cannot replay the same scoped messages forever. *)
+
 val run_keepalive_unified_turn :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -19,6 +19,22 @@ let format_mentions (mentions : (string * string) list) : string =
            (Keeper_types.short_preview ~max_len:200 content))
        mentions)
 
+let scope_message_prompt_limit = 12
+let scope_message_preview_len = 120
+
+let take_last_with_omitted limit items =
+  let len = List.length items in
+  if len <= limit then (items, 0)
+  else
+    let rec drop n xs =
+      if n <= 0 then xs
+      else
+        match xs with
+        | [] -> []
+        | _ :: rest -> drop (n - 1) rest
+    in
+    (drop (len - limit) items, len - limit)
+
 (** Format active goals into a prompt section. *)
 let format_goals (goal_ids : string list) : string =
   String.concat "\n"
@@ -26,13 +42,26 @@ let format_goals (goal_ids : string list) : string =
 
 let format_scope_messages
     (messages : (string * string) list) : string =
+  let shown_messages, omitted =
+    take_last_with_omitted scope_message_prompt_limit messages
+  in
+  let omitted_line =
+    if omitted <= 0 then []
+    else
+      [
+        Printf.sprintf
+          "- [omitted %d older scope messages; cursor still advances past the full batch]"
+          omitted;
+      ]
+  in
   String.concat "\n"
-    (List.map
-       (fun (from_agent, content) ->
-         Printf.sprintf "- %s: %s"
-           from_agent
-           (Keeper_types.short_preview ~max_len:200 content))
-       messages)
+    (omitted_line
+     @ List.map
+         (fun (from_agent, content) ->
+           Printf.sprintf "- %s: %s"
+             from_agent
+             (Keeper_types.short_preview ~max_len:scope_message_preview_len content))
+         shown_messages)
 
 let format_board_events
     (events : Keeper_world_observation.pending_board_event list) : string =

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -421,12 +421,7 @@ let status_summary_string (ctx : context) =
     String.equal assignee ctx.agent_name || String.equal assignee actual_name
   in
   let assigned_task_ids =
-    List.filter_map
-      (fun (task : Masc_domain.task) ->
-        match Coord_status_rendering.active_task_assignee task.task_status with
-        | Some assignee when matches_you assignee -> Some task.id
-        | Some _ | None -> None)
-      active_tasks
+    Coord_status_rendering.assigned_task_ids ~matches_you active_tasks
   in
   let binding =
     resolve_current_binding ~assigned_task_ids ~planning_current:current_task

--- a/test/test_keeper_meta_heartbeat_retain_9733.ml
+++ b/test/test_keeper_meta_heartbeat_retain_9733.ml
@@ -57,6 +57,18 @@ let make_meta ~name =
   | Ok m -> m
   | Error e -> fail ("meta_of_json failed: " ^ e)
 
+let read_meta_exn config name =
+  match Keeper_types.read_meta config name with
+  | Ok (Some meta) -> meta
+  | Ok None -> fail ("read_meta returned None for " ^ name)
+  | Error err -> fail ("read_meta failed: " ^ err)
+
+let room_cursor meta room_id =
+  meta.Keeper_types.last_seen_seq_by_room
+  |> List.find_map (fun (rid, seq) ->
+       if String.equal rid room_id then Some seq else None)
+  |> Option.value ~default:0
+
 (* The race we model:
 
    - cycle fiber reads meta at version N (joined_room_ids=[r1])
@@ -145,6 +157,79 @@ let test_no_race_writes_first_attempt () =
     in
     check string "goal landed" "test keeper" on_disk.goal)
 
+let test_message_cursor_updates_persist_before_turn () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let name = "cursor-preturn" in
+    let seed =
+      let m = make_meta ~name in
+      {
+        m with
+        joined_room_ids = [ "default" ];
+        last_seen_seq_by_room = [ ("default", 0) ];
+      }
+    in
+    (match Keeper_types.write_meta ~force:true config seed with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let before = read_meta_exn config name in
+    let returned =
+      Keeper_heartbeat_loop.persist_message_cursor_updates
+        ~config before [ ("default", 42) ]
+    in
+    let final = read_meta_exn config name in
+    check int "returned cursor advanced" 42 (room_cursor returned "default");
+    check int "disk cursor advanced before turn" 42 (room_cursor final "default");
+    check int "returned version follows disk" final.meta_version returned.meta_version;
+    check bool "version bumped" true (final.meta_version > before.meta_version))
+
+let test_message_cursor_updates_merge_after_cas_race () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let name = "cursor-cas-race" in
+    let seed =
+      let m = make_meta ~name in
+      {
+        m with
+        joined_room_ids = [ "default" ];
+        last_seen_seq_by_room = [ ("default", 0) ];
+        goal = "seed";
+      }
+    in
+    (match Keeper_types.write_meta ~force:true config seed with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let observer_view = read_meta_exn config name in
+    let racing_payload =
+      { observer_view with goal = "concurrent writer wins other fields" }
+    in
+    (match Keeper_types.write_meta config racing_payload with
+     | Ok () -> ()
+     | Error e -> fail ("racing write failed: " ^ e));
+    let returned =
+      Keeper_heartbeat_loop.persist_message_cursor_updates
+        ~config observer_view [ ("default", 99) ]
+    in
+    let final = read_meta_exn config name in
+    check string "concurrent field retained"
+      "concurrent writer wins other fields" final.goal;
+    check int "disk cursor advanced after CAS retry" 99
+      (room_cursor final "default");
+    check int "returned cursor advanced after CAS retry" 99
+      (room_cursor returned "default");
+    check bool "version moved past racing write" true
+      (final.meta_version > racing_payload.meta_version))
+
 let () =
   run "Keeper meta heartbeat-retain merge (#9733)"
     [
@@ -154,5 +239,9 @@ let () =
             test_caller_wins_cycle_disk_wins_heartbeat;
           test_case "no race: first attempt succeeds" `Quick
             test_no_race_writes_first_attempt;
+          test_case "message cursor persists before turn" `Quick
+            test_message_cursor_updates_persist_before_turn;
+          test_case "message cursor merge survives CAS race" `Quick
+            test_message_cursor_updates_merge_after_cas_race;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6498,6 +6498,27 @@ let test_tool_query_text_of_user_message_keeps_counted_headers () =
   check bool "keeps counted board activity header" true
     (contains_substring query "### Board Activity (1 new)")
 
+let test_scope_messages_prompt_caps_payload_not_count () =
+  let pending_scope_messages =
+    List.init 15 (fun i ->
+      ( Printf.sprintf "agent-%02d" i,
+        Printf.sprintf "message-%02d %s" i (String.make 220 'x') ))
+  in
+  let obs = { base_observation with pending_scope_messages } in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check bool "header keeps real scope message count" true
+    (contains_substring user "### Scope Messages (15 recent)");
+  check bool "older scope messages are summarized" true
+    (contains_substring user "omitted 3 older scope messages");
+  check bool "oldest omitted message absent" false
+    (contains_substring user "message-00");
+  check bool "newest retained message present" true
+    (contains_substring user "message-14");
+  check bool "long scope message preview capped" false
+    (contains_substring user (String.make 180 'x'))
+
 let test_social_model_silences_skip_only_turn () =
   let result =
     make_run_result
@@ -7869,6 +7890,8 @@ let () =
             test_tool_query_text_of_user_message_strips_continuity_noise;
           test_case "tool query keeps counted headers" `Quick
             test_tool_query_text_of_user_message_keeps_counted_headers;
+          test_case "scope messages cap prompt payload not count" `Quick
+            test_scope_messages_prompt_caps_payload_not_count;
           test_case "social model registry round trip" `Quick
             test_social_model_registry_round_trip;
           test_case "social model silences skip-only turn" `Quick


### PR DESCRIPTION
## Summary
- Persist keeper room-message cursor updates immediately after observation with a CAS merge, so early turn failures cannot replay the same scoped messages forever.
- Compact scope-message prompt payloads to the latest 12 previews while preserving the true trigger count and advancing the cursor across the full batch.
- Restore fresh-build compatibility by declaring agent_sdk.base explicitly and implementing Coord_status_rendering.assigned_task_ids.

## Why It Matters
Taskmaster was still burning turns on repeated broad scope-message batches after cursor observation. This makes cursor progress durable before turn admission and keeps the prompt bounded enough for cascade retry/local degraded paths to keep moving.

## Verification
- git diff --check origin/main...HEAD
- MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_BUILD_DIR=$PWD/_build_cursor_verify5 scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_meta_heartbeat_retain_9733.exe
- ./_build_cursor_verify5/default/test/test_keeper_unified.exe (336 tests)
- ./_build_cursor_verify5/default/test/test_keeper_meta_heartbeat_retain_9733.exe (4 tests)

## Gate Status
Draft PR. Expected policy gate remains human-approved-ready before merge.