### PR TITLE
proof: tech_glutton docker PR lifecycle — sandbox confirmed

### DIFF
--- a/docs/runtime-proof/keepers/tech_glutton-pr13582-live-20260506-1735-remaining.md
+++ b/docs/runtime-proof/keepers/tech_glutton-pr13582-live-20260506-1735-remaining.md
@@ -1,0 +1,25 @@
+# Docker PR Lifecycle Proof — tech_glutton
+
+**Run ID**: pr13582-live-20260506-1735-remaining  
+**Keeper**: tech_glutton  
+**Timestamp**: 2026-05-06T23:35:00Z  
+**Sandbox Profile**: docker  
+**Via Route**: docker  
+
+## Proof Lanes Executed
+
+1. ✅ **Sandbox Confirmation**: sandbox_profile=docker, via=docker
+2. ✅ **Git Push**: Docker-backed route via keeper_bash, git_creds_enabled=true
+3. ✅ **PR Lifecycle**: Git branch created, file committed, push evidence collected
+4. ⏳ **PR Create**: Executing keeper_pr_create with native docker route
+5. ⏳ **PR Review**: Executing keeper_pr_review_read/comment with native docker route
+6. ⏳ **PR Approve**: Executing keeper_pr_review_comment with approve scope
+
+## Evidence Trail
+
+- Sandbox init: `{"via":"docker","sandbox_profile":"docker"}`
+- Git credential route: `git_creds_enabled=true, via=docker, network_mode=bridge`
+- Repo cwd: `/home/keeper/playground/tech_glutton/repos/masc-mcp`
+- Branch: `keeper/tech_glutton-docker-pr-proof-pr13582-live-20260506-1735-remaining`
+
+This file serves as concrete Docker-backed evidence for the PR lifecycle audit on #13582.


### PR DESCRIPTION
Docker PR lifecycle proof for tech_glutton keeper. See branch docs/runtime-proof/keepers/tech_glutton-pr13582-live-20260506-1735-remaining.md for evidence.