### PR TITLE
fix(dashboard): expose skeleton metadata

### DIFF
--- a/dashboard/src/components/common/skeleton.a11y.test.ts
+++ b/dashboard/src/components/common/skeleton.a11y.test.ts
@@ -31,6 +31,11 @@ describe('Skeleton a11y', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
+  it('blank ariaLabel Skeleton stays decorative and passes axe', async () => {
+    render(html`<${Skeleton} ariaLabel="   " />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
   it('SkeletonText 3-line passes axe', async () => {
     render(html`<${SkeletonText} lines=${3} />`, container)
     expect(await axe(container)).toHaveNoViolations()
@@ -46,6 +51,11 @@ describe('Skeleton a11y', () => {
 
   it('SkeletonCircle (avatar placeholder) passes axe', async () => {
     render(html`<${SkeletonCircle} />`, container)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('announced SkeletonCircle passes axe', async () => {
+    render(html`<${SkeletonCircle} ariaLabel="Loading avatar" />`, container)
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/dashboard/src/components/common/skeleton.test.ts
+++ b/dashboard/src/components/common/skeleton.test.ts
@@ -6,8 +6,12 @@ import {
   Skeleton,
   SkeletonText,
   SkeletonCircle,
+  normalizeSkeletonAriaLabel,
   skeletonClasses,
   skeletonTextWidths,
+  summarizeSkeleton,
+  summarizeSkeletonCircle,
+  summarizeSkeletonText,
 } from './skeleton'
 
 describe('skeletonClasses (pure)', () => {
@@ -86,19 +90,38 @@ describe('Skeleton component', () => {
     const el = container.querySelector('[data-skeleton-block]')!
     expect(el.getAttribute('aria-hidden')).toBe('true')
     expect(el.hasAttribute('role')).toBe(false)
+    expect(el.getAttribute('data-skeleton-has-semantic-label')).toBe('false')
+    expect(el.getAttribute('data-skeleton-has-custom-class')).toBe('false')
+    expect(el.getAttribute('data-skeleton-has-test-id')).toBe('false')
   })
 
   it('ariaLabel opts in to role="status" so AT announces it (inline loader use)', () => {
-    render(html`<${Skeleton} ariaLabel="Loading connector metadata" />`, container)
+    render(html`<${Skeleton} ariaLabel="  Loading connector metadata  " />`, container)
     const el = container.querySelector('[data-skeleton-block]')!
     expect(el.getAttribute('aria-label')).toBe('Loading connector metadata')
     expect(el.getAttribute('role')).toBe('status')
     expect(el.hasAttribute('aria-hidden')).toBe(false)
+    expect(el.getAttribute('data-skeleton-has-semantic-label')).toBe('true')
+    expect(el.getAttribute('data-skeleton-aria-label-length')).toBe('26')
+  })
+
+  it('blank ariaLabel stays decorative', () => {
+    render(html`<${Skeleton} ariaLabel="   " />`, container)
+    const el = container.querySelector('[data-skeleton-block]')!
+    expect(el.getAttribute('aria-hidden')).toBe('true')
+    expect(el.getAttribute('role')).toBeNull()
+    expect(el.getAttribute('aria-label')).toBeNull()
+    expect(el.getAttribute('data-skeleton-has-semantic-label')).toBe('false')
   })
 
   it('testId renders as data-testid', () => {
-    render(html`<${Skeleton} testId="connector-tile-loading" />`, container)
-    expect(container.querySelector('[data-testid="connector-tile-loading"]')).toBeTruthy()
+    render(html`<${Skeleton} class="mt-2" testId="connector-tile-loading" />`, container)
+    const el = container.querySelector('[data-testid="connector-tile-loading"]')!
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('data-skeleton-has-custom-class')).toBe('true')
+    expect(el.getAttribute('data-skeleton-has-test-id')).toBe('true')
+    expect(el.getAttribute('data-skeleton-class-length')).toBe('4')
+    expect(el.getAttribute('data-skeleton-test-id-length')).toBe('22')
   })
 
   it('width + height props override the defaults', () => {
@@ -107,6 +130,27 @@ describe('Skeleton component', () => {
     expect(el.className).toContain('w-24')
     expect(el.className).toContain('h-6')
     expect(el.className).not.toContain('w-full')
+    expect(el.getAttribute('data-skeleton-block-width')).toBe('w-24')
+    expect(el.getAttribute('data-skeleton-block-height')).toBe('h-6')
+  })
+
+  it('summarizes skeleton block state', () => {
+    expect(summarizeSkeleton({
+      width: 'w-24',
+      height: 'h-6',
+      className: 'mt-2',
+      ariaLabel: ' Loading ',
+      testId: 'block-loader',
+    })).toEqual({
+      width: 'w-24',
+      height: 'h-6',
+      hasSemanticLabel: true,
+      hasCustomClass: true,
+      hasTestId: true,
+      ariaLabelLength: 7,
+      classNameLength: 4,
+      testIdLength: 12,
+    })
   })
 })
 
@@ -125,6 +169,7 @@ describe('SkeletonText component', () => {
     render(html`<${SkeletonText} />`, container)
     const wrapper = container.querySelector('[data-skeleton-text]') as HTMLElement
     expect(wrapper.getAttribute('data-skeleton-text-lines')).toBe('3')
+    expect(wrapper.getAttribute('data-skeleton-text-rendered-lines')).toBe('3')
     expect(wrapper.children.length).toBe(3)
   })
 
@@ -146,13 +191,42 @@ describe('SkeletonText component', () => {
     render(html`<${SkeletonText} />`, container)
     const wrapper = container.querySelector('[data-skeleton-text]')!
     expect(wrapper.getAttribute('aria-hidden')).toBe('true')
+    expect(wrapper.getAttribute('data-skeleton-text-has-semantic-label')).toBe('false')
   })
 
   it('ariaLabel promotes the wrapper to role="status"', () => {
-    render(html`<${SkeletonText} ariaLabel="Loading log lines" />`, container)
+    render(html`<${SkeletonText} ariaLabel="  Loading log lines  " />`, container)
     const wrapper = container.querySelector('[data-skeleton-text]')!
     expect(wrapper.getAttribute('role')).toBe('status')
     expect(wrapper.getAttribute('aria-label')).toBe('Loading log lines')
+    expect(wrapper.getAttribute('data-skeleton-text-has-semantic-label')).toBe('true')
+    expect(wrapper.getAttribute('data-skeleton-text-aria-label-length')).toBe('17')
+  })
+
+  it('blank ariaLabel stays decorative on text skeletons', () => {
+    render(html`<${SkeletonText} ariaLabel="" />`, container)
+    const wrapper = container.querySelector('[data-skeleton-text]')!
+    expect(wrapper.getAttribute('aria-hidden')).toBe('true')
+    expect(wrapper.getAttribute('role')).toBeNull()
+    expect(wrapper.getAttribute('aria-label')).toBeNull()
+  })
+
+  it('summarizes text skeleton state', () => {
+    expect(summarizeSkeletonText({
+      lines: 4,
+      className: 'gap-3',
+      ariaLabel: ' Loading ',
+      testId: 'text-loader',
+    })).toEqual({
+      lines: 4,
+      renderedLines: 4,
+      hasSemanticLabel: true,
+      hasCustomClass: true,
+      hasTestId: true,
+      ariaLabelLength: 7,
+      classNameLength: 5,
+      testIdLength: 11,
+    })
   })
 })
 
@@ -181,10 +255,54 @@ describe('SkeletonCircle component', () => {
     expect(el.className).toContain('h-12')
     expect(el.className).toContain('w-12')
     expect(el.className).not.toContain('h-8')
+    expect(el.getAttribute('data-skeleton-circle-size')).toBe('h-12 w-12')
   })
 
   it('aria-hidden by default (decorative)', () => {
     render(html`<${SkeletonCircle} />`, container)
     expect(container.querySelector('[data-skeleton-circle]')!.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('ariaLabel promotes circle to role="status"', () => {
+    render(html`<${SkeletonCircle} ariaLabel=" Loading avatar " />`, container)
+    const el = container.querySelector('[data-skeleton-circle]')!
+    expect(el.getAttribute('role')).toBe('status')
+    expect(el.getAttribute('aria-label')).toBe('Loading avatar')
+    expect(el.getAttribute('data-skeleton-circle-has-semantic-label')).toBe('true')
+    expect(el.getAttribute('data-skeleton-circle-aria-label-length')).toBe('14')
+  })
+
+  it('blank ariaLabel stays decorative on circle skeletons', () => {
+    render(html`<${SkeletonCircle} ariaLabel=" " />`, container)
+    const el = container.querySelector('[data-skeleton-circle]')!
+    expect(el.getAttribute('aria-hidden')).toBe('true')
+    expect(el.getAttribute('role')).toBeNull()
+    expect(el.getAttribute('aria-label')).toBeNull()
+  })
+
+  it('summarizes circle skeleton state', () => {
+    expect(summarizeSkeletonCircle({
+      size: 'h-12 w-12',
+      className: 'mr-2',
+      ariaLabel: ' Loading ',
+      testId: 'avatar-loader',
+    })).toEqual({
+      size: 'h-12 w-12',
+      hasSemanticLabel: true,
+      hasCustomClass: true,
+      hasTestId: true,
+      ariaLabelLength: 7,
+      classNameLength: 4,
+      testIdLength: 13,
+    })
+  })
+})
+
+describe('normalizeSkeletonAriaLabel', () => {
+  it('normalizes labels and drops blank values', () => {
+    expect(normalizeSkeletonAriaLabel()).toBeUndefined()
+    expect(normalizeSkeletonAriaLabel('')).toBeUndefined()
+    expect(normalizeSkeletonAriaLabel('   ')).toBeUndefined()
+    expect(normalizeSkeletonAriaLabel(' Loading ')).toBe('Loading')
   })
 })

--- a/dashboard/src/components/common/skeleton.ts
+++ b/dashboard/src/components/common/skeleton.ts
@@ -20,7 +20,64 @@ import { html } from 'htm/preact'
 
 const SKELETON_BASE = 'animate-pulse bg-[var(--color-bg-elevated)] rounded-[var(--r-1)]'
 
-interface SkeletonProps {
+export interface SkeletonSummary {
+  readonly width: string
+  readonly height: string
+  readonly hasSemanticLabel: boolean
+  readonly hasCustomClass: boolean
+  readonly hasTestId: boolean
+  readonly ariaLabelLength: number
+  readonly classNameLength: number
+  readonly testIdLength: number
+}
+
+export interface SkeletonTextSummary {
+  readonly lines: number
+  readonly renderedLines: number
+  readonly hasSemanticLabel: boolean
+  readonly hasCustomClass: boolean
+  readonly hasTestId: boolean
+  readonly ariaLabelLength: number
+  readonly classNameLength: number
+  readonly testIdLength: number
+}
+
+export interface SkeletonCircleSummary {
+  readonly size: string
+  readonly hasSemanticLabel: boolean
+  readonly hasCustomClass: boolean
+  readonly hasTestId: boolean
+  readonly ariaLabelLength: number
+  readonly classNameLength: number
+  readonly testIdLength: number
+}
+
+export function normalizeSkeletonAriaLabel(ariaLabel?: string): string | undefined {
+  const normalized = ariaLabel?.trim()
+  return normalized === undefined || normalized === '' ? undefined : normalized
+}
+
+function summarizeSkeletonChrome({
+  className,
+  ariaLabel,
+  testId,
+}: {
+  className?: string
+  ariaLabel?: string
+  testId?: string
+}) {
+  const normalizedAriaLabel = normalizeSkeletonAriaLabel(ariaLabel)
+  return {
+    hasSemanticLabel: normalizedAriaLabel !== undefined,
+    hasCustomClass: className !== undefined && className !== '',
+    hasTestId: testId !== undefined && testId !== '',
+    ariaLabelLength: normalizedAriaLabel?.length ?? 0,
+    classNameLength: className?.length ?? 0,
+    testIdLength: testId?.length ?? 0,
+  }
+}
+
+export interface SkeletonProps {
   /** Tailwind width class or arbitrary value via class. Default w-full. */
   width?: string
   /** Tailwind height class. Default h-4 (~16px, matches body text line). */
@@ -47,6 +104,26 @@ export function skeletonClasses(
   return parts.join(' ')
 }
 
+export function summarizeSkeleton({
+  width,
+  height,
+  className,
+  ariaLabel,
+  testId,
+}: {
+  width?: string
+  height?: string
+  className?: string
+  ariaLabel?: string
+  testId?: string
+}): SkeletonSummary {
+  return {
+    width: width ?? 'w-full',
+    height: height ?? 'h-4',
+    ...summarizeSkeletonChrome({ className, ariaLabel, testId }),
+  }
+}
+
 export function Skeleton({
   width,
   height,
@@ -54,19 +131,28 @@ export function Skeleton({
   ariaLabel,
   testId,
 }: SkeletonProps) {
+  const summary = summarizeSkeleton({ width, height, className: cx, ariaLabel, testId })
+  const normalizedAriaLabel = normalizeSkeletonAriaLabel(ariaLabel)
   const cls = skeletonClasses(width, height, cx)
-  const ariaHidden = ariaLabel === undefined ? 'true' : undefined
   return html`<div
     class=${cls}
-    aria-hidden=${ariaHidden}
-    aria-label=${ariaLabel}
-    role=${ariaLabel !== undefined ? 'status' : undefined}
+    aria-hidden=${summary.hasSemanticLabel ? undefined : 'true'}
+    aria-label=${normalizedAriaLabel}
+    role=${summary.hasSemanticLabel ? 'status' : undefined}
     data-skeleton-block
+    data-skeleton-block-width=${summary.width}
+    data-skeleton-block-height=${summary.height}
+    data-skeleton-has-semantic-label=${summary.hasSemanticLabel}
+    data-skeleton-has-custom-class=${summary.hasCustomClass}
+    data-skeleton-has-test-id=${summary.hasTestId}
+    data-skeleton-aria-label-length=${summary.ariaLabelLength}
+    data-skeleton-class-length=${summary.classNameLength}
+    data-skeleton-test-id-length=${summary.testIdLength}
     data-testid=${testId}
   ></div>`
 }
 
-interface SkeletonTextProps {
+export interface SkeletonTextProps {
   /** Number of stacked lines. Default 3 — enough for a paragraph preview. */
   lines?: number
   class?: string
@@ -90,6 +176,24 @@ export function skeletonTextWidths(lines: number): string[] {
   return out
 }
 
+export function summarizeSkeletonText({
+  lines = 3,
+  className,
+  ariaLabel,
+  testId,
+}: {
+  lines?: number
+  className?: string
+  ariaLabel?: string
+  testId?: string
+}): SkeletonTextSummary {
+  return {
+    lines,
+    renderedLines: skeletonTextWidths(lines).length,
+    ...summarizeSkeletonChrome({ className, ariaLabel, testId }),
+  }
+}
+
 /** Stacked text-line skeleton — the "paragraph" preview used by most
     dashboards for log tails, card descriptions, etc. */
 export function SkeletonText({
@@ -98,25 +202,50 @@ export function SkeletonText({
   ariaLabel,
   testId,
 }: SkeletonTextProps) {
+  const summary = summarizeSkeletonText({ lines, className: cx, ariaLabel, testId })
+  const normalizedAriaLabel = normalizeSkeletonAriaLabel(ariaLabel)
   const widths = skeletonTextWidths(lines)
-  const ariaHidden = ariaLabel === undefined ? 'true' : undefined
   return html`<div
     class=${`flex flex-col gap-2 ${cx ?? ''}`}
-    aria-hidden=${ariaHidden}
-    aria-label=${ariaLabel}
-    role=${ariaLabel !== undefined ? 'status' : undefined}
+    aria-hidden=${summary.hasSemanticLabel ? undefined : 'true'}
+    aria-label=${normalizedAriaLabel}
+    role=${summary.hasSemanticLabel ? 'status' : undefined}
     data-skeleton-text
-    data-skeleton-text-lines=${lines}
+    data-skeleton-text-lines=${summary.lines}
+    data-skeleton-text-rendered-lines=${summary.renderedLines}
+    data-skeleton-text-has-semantic-label=${summary.hasSemanticLabel}
+    data-skeleton-text-has-custom-class=${summary.hasCustomClass}
+    data-skeleton-text-has-test-id=${summary.hasTestId}
+    data-skeleton-text-aria-label-length=${summary.ariaLabelLength}
+    data-skeleton-text-class-length=${summary.classNameLength}
+    data-skeleton-text-test-id-length=${summary.testIdLength}
     data-testid=${testId}
   >${widths.map(w => html`<div class=${`${SKELETON_BASE} ${w} h-3`} aria-hidden="true"></div>`)}</div>`
 }
 
-interface SkeletonCircleProps {
+export interface SkeletonCircleProps {
   /** Tailwind size (e.g. "h-6 w-6"). Default h-8 w-8. */
   size?: string
   class?: string
   ariaLabel?: string
   testId?: string
+}
+
+export function summarizeSkeletonCircle({
+  size,
+  className,
+  ariaLabel,
+  testId,
+}: {
+  size?: string
+  className?: string
+  ariaLabel?: string
+  testId?: string
+}): SkeletonCircleSummary {
+  return {
+    size: size ?? 'h-8 w-8',
+    ...summarizeSkeletonChrome({ className, ariaLabel, testId }),
+  }
 }
 
 /** Round skeleton for avatars / icon placeholders. */
@@ -126,14 +255,21 @@ export function SkeletonCircle({
   ariaLabel,
   testId,
 }: SkeletonCircleProps) {
-  const sizing = size ?? 'h-8 w-8'
-  const ariaHidden = ariaLabel === undefined ? 'true' : undefined
+  const summary = summarizeSkeletonCircle({ size, className: cx, ariaLabel, testId })
+  const normalizedAriaLabel = normalizeSkeletonAriaLabel(ariaLabel)
   return html`<div
-    class=${`animate-pulse rounded-full bg-[var(--color-bg-elevated)] ${sizing} ${cx ?? ''}`}
-    aria-hidden=${ariaHidden}
-    aria-label=${ariaLabel}
-    role=${ariaLabel !== undefined ? 'status' : undefined}
+    class=${`animate-pulse rounded-full bg-[var(--color-bg-elevated)] ${summary.size} ${cx ?? ''}`}
+    aria-hidden=${summary.hasSemanticLabel ? undefined : 'true'}
+    aria-label=${normalizedAriaLabel}
+    role=${summary.hasSemanticLabel ? 'status' : undefined}
     data-skeleton-circle
+    data-skeleton-circle-size=${summary.size}
+    data-skeleton-circle-has-semantic-label=${summary.hasSemanticLabel}
+    data-skeleton-circle-has-custom-class=${summary.hasCustomClass}
+    data-skeleton-circle-has-test-id=${summary.hasTestId}
+    data-skeleton-circle-aria-label-length=${summary.ariaLabelLength}
+    data-skeleton-circle-class-length=${summary.classNameLength}
+    data-skeleton-circle-test-id-length=${summary.testIdLength}
     data-testid=${testId}
   ></div>`
 }


### PR DESCRIPTION
## Summary
- Export skeleton props and summary types for block/text/circle placeholders.
- Add `normalizeSkeletonAriaLabel`, `summarizeSkeleton`, `summarizeSkeletonText`, and `summarizeSkeletonCircle`.
- Stamp block/text/circle skeletons with `data-skeleton-*` metadata for dimensions, rendered line count, semantic-label state, custom class state, test id state, and emitted length fields.
- Treat blank/whitespace-only `ariaLabel` values as decorative so skeletons do not create unnamed `role=status` regions.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/skeleton.test.ts src/components/common/skeleton.a11y.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `git diff --check`
- Browser QA via Vite port 5231 temporary fixture:
  - desktop screenshot: `/tmp/masc-skeleton-summary-0506.png`
  - mobile screenshot: `/tmp/masc-skeleton-summary-0506-mobile.png`
  - verified block/text/circle render visibly, expected `data-skeleton-*` metadata, decorative block stays `aria-hidden`, semantic text/circle have `role=status`, no desktop/mobile overflow, and post-clear console/error logs are empty.
- Rebased on current `origin/main`, then reran focused vitest + tsc.
- `pnpm --dir dashboard run lint` (passes; existing warnings in `copy-id-button.test.ts`, `virtual-list.ts`, `fsm-hub.ts`)
- `pnpm --dir dashboard run build` (passes; existing Vite dynamic/static import and chunk-size warnings)