### PR TITLE
fix(keeper): audit Docker PR lifecycle tool calls

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1131,6 +1131,7 @@ let output_success ~transport_success = function
   | None -> transport_success
 
 let pr_review_action_metric_event_of_tool_io
+    ~route_via_fallback
     ~(tool_name : string)
     ~(input : Yojson.Safe.t)
     ~(output_text : string)
@@ -1138,7 +1139,10 @@ let pr_review_action_metric_event_of_tool_io
   match tool_name with
   | "keeper_pr_review_comment" ->
       let output_json = output_json_opt ~surface:"pr_review_action" output_text in
-      let route_via = Option.bind output_json route_via_of_json in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
       let action =
         match output_json with
         | Some json -> Safe_ops.json_string_opt "event" json
@@ -1171,7 +1175,10 @@ let pr_review_action_metric_event_of_tool_io
         (Option.bind action normalize_pr_review_action)
   | "keeper_pr_review_reply" ->
       let output_json = output_json_opt ~surface:"pr_review_action" output_text in
-      let route_via = Option.bind output_json route_via_of_json in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
       let success =
         output_success ~transport_success output_json
       in
@@ -1252,7 +1259,17 @@ let pr_work_actions_of_git_segment segment =
        | Masc_exec.Shell_ir.Lit action :: _ ->
            pr_work_action_of_git_action action |> Option.to_list
        | _ -> [])
-  | _ -> []
+  | _ ->
+      let lower = String.trim segment |> String.lowercase_ascii in
+      let starts_with_word prefix =
+        String.equal lower prefix
+        || (String.length lower > String.length prefix
+            && String.starts_with ~prefix:(prefix ^ " ") lower)
+      in
+      if starts_with_word "git push" then [ "GIT_PUSH" ]
+      else if starts_with_word "git commit" then [ "GIT_COMMIT" ]
+      else if starts_with_word "git add" then [ "GIT_ADD" ]
+      else []
 
 let pr_work_actions_of_gh_segment segment =
   match Keeper_gh_shared.parse_simple_gh_command segment with
@@ -1295,12 +1312,16 @@ let command_input_of_tool ~(tool_name : string) (input : Yojson.Safe.t) =
   | _ -> None
 
 let pr_work_action_metric_events_of_tool_io
+    ~route_via_fallback
     ~(tool_name : string)
     ~(input : Yojson.Safe.t)
     ~(output_text : string)
     ~(transport_success : bool) =
   let output_json = output_json_opt ~surface:"pr_work_action" output_text in
-  let route_via = Option.bind output_json route_via_of_json in
+  let route_via =
+    first_some (Option.bind output_json route_via_of_json)
+      route_via_fallback
+  in
   let success = output_success ~transport_success output_json in
   match tool_name with
   | "masc_code_git" ->
@@ -1361,9 +1382,15 @@ let append_pr_review_action_metric
     ~(transport_success : bool)
     ~(duration_ms : float)
     () =
+  let route_via_fallback =
+    match meta.sandbox_profile, tool_name with
+    | Docker, ("keeper_pr_review_comment" | "keeper_pr_review_reply") ->
+        Some "brokered"
+    | _ -> None
+  in
   match
     pr_review_action_metric_event_of_tool_io
-      ~tool_name ~input ~output_text ~transport_success
+      ~route_via_fallback ~tool_name ~input ~output_text ~transport_success
   with
   | None -> ()
   | Some event ->
@@ -1409,9 +1436,16 @@ let append_pr_work_action_metrics
     ~(transport_success : bool)
     ~(duration_ms : float)
     () =
+  let route_via_fallback =
+    match meta.sandbox_profile, tool_name with
+    | Docker, "keeper_pr_create" ->
+        if Env_config_keeper.KeeperSandbox.hard_mode () then Some "brokered"
+        else Some "docker"
+    | _ -> None
+  in
   let events =
     pr_work_action_metric_events_of_tool_io
-      ~tool_name ~input ~output_text ~transport_success
+      ~route_via_fallback ~tool_name ~input ~output_text ~transport_success
   in
   match events with
   | [] -> ()

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1118,6 +1118,105 @@ let route_via_of_json json =
   ]
   |> List.find_map Fun.id
 
+let command_input_of_tool ~(tool_name : string) (input : Yojson.Safe.t) =
+  match tool_name with
+  | "keeper_shell" ->
+      let op =
+        Safe_ops.json_string ~default:"" "op" input
+        |> String.trim |> String.lowercase_ascii
+      in
+      if op = "gh" then
+        Safe_ops.json_string_opt "cmd" input
+        |> Option.map (fun cmd -> "gh " ^ String.trim cmd)
+      else None
+  | "keeper_bash" ->
+      Safe_ops.json_string_opt "cmd" input
+  | "masc_code_shell" ->
+      Safe_ops.json_string_opt "command" input
+  | _ -> None
+
+let output_command_of_json = function
+  | Some json -> Safe_ops.json_string_opt "command" json
+  | None -> None
+
+let command_candidates_of_tool_io ~tool_name ~input ~output_json =
+  let add_candidate candidate acc =
+    match candidate with
+    | None -> acc
+    | Some value ->
+        let command = String.trim value in
+        if command = "" || List.mem command acc then acc else acc @ [ command ]
+  in
+  []
+  |> add_candidate (command_input_of_tool ~tool_name input)
+  |> add_candidate (output_command_of_json output_json)
+
+let shell_words_prefix ?(max_words = 8) command =
+  let len = String.length command in
+  let buf = Buffer.create 32 in
+  let push acc =
+    if Buffer.length buf = 0 then acc
+    else
+      let word = Buffer.contents buf in
+      Buffer.clear buf;
+      word :: acc
+  in
+  let rec loop acc i in_single in_double escaped =
+    if i >= len || List.length acc >= max_words then List.rev (push acc)
+    else
+      let c = command.[i] in
+      if escaped then (
+        Buffer.add_char buf c;
+        loop acc (i + 1) in_single in_double false)
+      else
+        match c with
+        | '\\' when not in_single ->
+            loop acc (i + 1) in_single in_double true
+        | '\'' when not in_double ->
+            loop acc (i + 1) (not in_single) in_double false
+        | '"' when not in_single ->
+            loop acc (i + 1) in_single (not in_double) false
+        | ' ' | '\t' | '\r' | '\n' when (not in_single) && not in_double ->
+            let acc = push acc in
+            loop acc (i + 1) in_single in_double false
+        | _ ->
+            Buffer.add_char buf c;
+            loop acc (i + 1) in_single in_double false
+  in
+  loop [] 0 false false false
+
+let gh_argv_of_segment segment =
+  match Keeper_gh_shared.parse_simple_gh_command segment with
+  | Ok cmd -> Some (Keeper_gh_shared.gh_simple_command_argv cmd)
+  | Error _ ->
+      (match shell_words_prefix segment with
+       | bin :: args when String.equal (String.lowercase_ascii bin) "gh" ->
+           Some args
+       | _ -> None)
+
+let gh_pr_review_action_of_command command =
+  match gh_argv_of_segment command with
+  | Some (subcommand :: action :: pr_number :: args)
+    when String.equal (String.lowercase_ascii subcommand) "pr"
+         && String.equal (String.lowercase_ascii action) "review" ->
+      let has_flag flag =
+        List.exists
+          (fun arg -> String.equal (String.lowercase_ascii arg) flag)
+          args
+      in
+      let action =
+        if has_flag "--approve" then Some "APPROVE"
+        else if has_flag "--request-changes" then Some "REQUEST_CHANGES"
+        else if has_flag "--comment" then Some "COMMENT"
+        else None
+      in
+      Option.map (fun action -> (action, int_of_string_opt pr_number)) action
+  | Some (subcommand :: action :: pr_number :: _)
+    when String.equal (String.lowercase_ascii subcommand) "pr"
+         && String.equal (String.lowercase_ascii action) "comment" ->
+      Some ("COMMENT", int_of_string_opt pr_number)
+  | _ -> None
+
 let output_success ~transport_success = function
   | Some json ->
       (match Safe_ops.json_bool_opt "ok" json with
@@ -1202,6 +1301,25 @@ let pr_review_action_metric_event_of_tool_io
           success;
           route_via;
         }
+  | "keeper_shell" ->
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
+      let success =
+        output_success ~transport_success output_json
+      in
+      command_candidates_of_tool_io ~tool_name ~input ~output_json
+      |> List.find_map gh_pr_review_action_of_command
+      |> Option.map (fun (action, pr_number) ->
+           {
+             action;
+             pr_number;
+             comment_id = None;
+             success;
+             route_via;
+           })
   | _ -> None
 
 let split_top_level_command_segments command =
@@ -1272,15 +1390,12 @@ let pr_work_actions_of_git_segment segment =
       else []
 
 let pr_work_actions_of_gh_segment segment =
-  match Keeper_gh_shared.parse_simple_gh_command segment with
-  | Ok cmd ->
-      (match Keeper_gh_shared.gh_simple_command_argv cmd with
-       | subcommand :: action :: _
-         when String.equal (String.lowercase_ascii subcommand) "pr"
-              && String.equal (String.lowercase_ascii action) "create" ->
-           [ "PR_CREATE" ]
-       | _ -> [])
-  | Error _ -> []
+  match gh_argv_of_segment segment with
+  | Some (subcommand :: action :: _)
+    when String.equal (String.lowercase_ascii subcommand) "pr"
+         && String.equal (String.lowercase_ascii action) "create" ->
+      [ "PR_CREATE" ]
+  | _ -> []
 
 let pr_work_actions_of_command command =
   split_top_level_command_segments command
@@ -1293,23 +1408,6 @@ let pr_work_actions_of_command command =
          match pr_work_actions_of_gh_segment segment with
          | [] -> pr_work_actions_of_git_segment segment
          | actions -> actions)
-
-let command_input_of_tool ~(tool_name : string) (input : Yojson.Safe.t) =
-  match tool_name with
-  | "keeper_shell" ->
-      let op =
-        Safe_ops.json_string ~default:"" "op" input
-        |> String.trim |> String.lowercase_ascii
-      in
-      if op = "gh" then
-        Safe_ops.json_string_opt "cmd" input
-        |> Option.map (fun cmd -> "gh " ^ String.trim cmd)
-      else None
-  | "keeper_bash" ->
-      Safe_ops.json_string_opt "cmd" input
-  | "masc_code_shell" ->
-      Safe_ops.json_string_opt "command" input
-  | _ -> None
 
 let pr_work_action_metric_events_of_tool_io
     ~route_via_fallback
@@ -1358,18 +1456,25 @@ let pr_work_action_metric_events_of_tool_io
         };
       ]
   | "keeper_shell" | "keeper_bash" | "masc_code_shell" ->
-      (match command_input_of_tool ~tool_name input with
-       | None -> []
-       | Some command ->
+      command_candidates_of_tool_io ~tool_name ~input ~output_json
+      |> List.concat_map (fun command ->
            pr_work_actions_of_command command
            |> List.map (fun work_action ->
-                {
-                  work_action;
-                  work_source = tool_name;
-                  command = Some command;
-                  success;
-                  route_via;
-                }))
+                ( command,
+                  {
+                    work_action;
+                    work_source = tool_name;
+                    command = Some command;
+                    success;
+                    route_via;
+                  } )))
+      |> List.fold_left
+           (fun (seen, events) (_command, event) ->
+              let key = event.work_action in
+              if List.mem key seen then (seen, events)
+              else (key :: seen, events @ [ event ]))
+           ([], [])
+      |> snd
   | _ -> []
 
 let append_pr_review_action_metric
@@ -1386,6 +1491,9 @@ let append_pr_review_action_metric
     match meta.sandbox_profile, tool_name with
     | Docker, ("keeper_pr_review_comment" | "keeper_pr_review_reply") ->
         Some "brokered"
+    | Docker, "keeper_shell" ->
+        if Env_config_keeper.KeeperSandbox.hard_mode () then Some "brokered"
+        else Some "docker"
     | _ -> None
   in
   match
@@ -1441,6 +1549,11 @@ let append_pr_work_action_metrics
     | Docker, "keeper_pr_create" ->
         if Env_config_keeper.KeeperSandbox.hard_mode () then Some "brokered"
         else Some "docker"
+    | Docker, "keeper_shell" ->
+        if Env_config_keeper.KeeperSandbox.hard_mode () then Some "brokered"
+        else Some "docker"
+    | Docker, ("keeper_bash" | "masc_code_shell" | "masc_code_git") ->
+        Some "docker"
     | _ -> None
   in
   let events =

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -350,6 +350,7 @@ val hook_introspection_json :
 
 module For_testing : sig
   val pr_review_action_metric_event_of_tool_io :
+    route_via_fallback:string option ->
     tool_name:string ->
     input:Yojson.Safe.t ->
     output_text:string ->
@@ -357,6 +358,7 @@ module For_testing : sig
     pr_review_action_metric_event option
 
   val pr_work_action_metric_events_of_tool_io :
+    route_via_fallback:string option ->
     tool_name:string ->
     input:Yojson.Safe.t ->
     output_text:string ->

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import sys
 import time
 from collections import Counter
@@ -254,6 +255,19 @@ def bool_field(row: dict[str, Any], key: str) -> bool:
     return value if isinstance(value, bool) else False
 
 
+def output_json(row: dict[str, Any]) -> dict[str, Any]:
+    output = row.get("output")
+    if isinstance(output, dict):
+        return output
+    if isinstance(output, str):
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
 def tool_succeeded_in_row(row: dict[str, Any], tool_name: str) -> bool:
     if row.get("tool") == tool_name:
         return row.get("ok") is True
@@ -403,6 +417,74 @@ def has_docker_execution_marker(row: dict[str, Any]) -> bool:
     )
 
 
+def has_tool_call_docker_execution_marker(row: dict[str, Any]) -> bool:
+    return has_docker_execution_marker(row) or has_docker_execution_marker(
+        output_json(row)
+    )
+
+
+def shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return []
+
+
+def tool_call_command_candidates(row: dict[str, Any]) -> list[str]:
+    candidates: list[str] = []
+
+    def add(raw: Any) -> None:
+        if isinstance(raw, str):
+            command = raw.strip()
+            if command and command not in candidates:
+                candidates.append(command)
+
+    input_json = row.get("input")
+    if isinstance(input_json, dict):
+        tool = row.get("tool")
+        if tool == "keeper_shell" and input_json.get("op") == "gh":
+            cmd = input_json.get("cmd")
+            if isinstance(cmd, str):
+                add("gh " + cmd.strip())
+        elif tool == "keeper_bash":
+            add(input_json.get("cmd"))
+        elif tool == "masc_code_shell":
+            add(input_json.get("command"))
+        elif tool == "masc_code_git":
+            add(input_json.get("action"))
+
+    add(output_json(row).get("command"))
+    return candidates
+
+
+def gh_argv(command: str) -> list[str]:
+    words = shell_words(command)
+    if words and words[0].lower() == "gh":
+        return words[1:]
+    return []
+
+
+def command_is_git_push(command: str) -> bool:
+    words = shell_words(command)
+    return len(words) >= 2 and words[0].lower() == "git" and words[1].lower() == "push"
+
+
+def command_is_gh_pr_create(command: str) -> bool:
+    argv = gh_argv(command)
+    return len(argv) >= 2 and argv[0].lower() == "pr" and argv[1].lower() == "create"
+
+
+def command_is_gh_pr_approve(command: str) -> bool:
+    argv = gh_argv(command)
+    lowered_args = [arg.lower() for arg in argv[3:]]
+    return (
+        len(argv) >= 3
+        and argv[0].lower() == "pr"
+        and argv[1].lower() == "review"
+        and "--approve" in lowered_args
+    )
+
+
 def pr_lifecycle_evidence_from_decision(
     row: dict[str, Any],
 ) -> tuple[set[str], set[str]]:
@@ -436,6 +518,38 @@ def pr_lifecycle_evidence_from_decision(
         row
     ):
         add("pr_approve:keeper_pr_review_comment")
+    return evidence, docker_evidence
+
+
+def pr_lifecycle_evidence_from_tool_call(
+    row: dict[str, Any],
+) -> tuple[set[str], set[str]]:
+    evidence: set[str] = set()
+    docker_evidence: set[str] = set()
+    tool = row.get("tool")
+    if not isinstance(tool, str) or not bool_field(row, "success"):
+        return evidence, docker_evidence
+
+    def add(item: str) -> None:
+        evidence.add(item)
+        if has_tool_call_docker_execution_marker(row):
+            docker_evidence.add(item)
+
+    if tool == "keeper_pr_create":
+        add("pr_create:keeper_pr_create")
+    elif tool == "masc_code_git":
+        for command in tool_call_command_candidates(row):
+            if command.strip().lower() == "push":
+                add("git_push:masc_code_git")
+                break
+    elif tool in SHELL_TOOLS or tool == "masc_code_shell":
+        for command in tool_call_command_candidates(row):
+            if command_is_git_push(command):
+                add(f"git_push:{tool}")
+            if command_is_gh_pr_create(command):
+                add(f"pr_create:{tool}")
+            if command_is_gh_pr_approve(command):
+                add(f"pr_approve:{tool}")
     return evidence, docker_evidence
 
 
@@ -658,6 +772,13 @@ def scan_keeper_board_posts(
     return latest_ts, board_post_evidence, product_evidence, design_evidence
 
 
+def tool_call_paths(base_path: Path) -> list[Path]:
+    calls_dir = base_path / ".masc" / "tool_calls"
+    if not calls_dir.exists():
+        return []
+    return sorted(path for path in calls_dir.rglob("*.jsonl") if path.is_file())
+
+
 def scan_keeper_evidence(
     base_path: Path,
     name: str,
@@ -704,6 +825,31 @@ def scan_keeper_evidence(
             pr_lifecycle_evidence
         ) and complete_lifecycle_evidence(docker_pr_lifecycle_evidence):
             break
+    if not (
+        complete_lifecycle_evidence(pr_lifecycle_evidence)
+        and complete_lifecycle_evidence(docker_pr_lifecycle_evidence)
+    ):
+        for calls in tool_call_paths(base_path):
+            for row in iter_jsonl(calls):
+                if row.get("keeper") != name:
+                    continue
+                ts = numeric_field(row, "ts") or numeric_field(row, "ts_unix")
+                if min_metric_ts is not None and ts is not None and ts < min_metric_ts:
+                    continue
+                if ts is not None:
+                    latest_ts = ts if latest_ts is None else max(latest_ts, ts)
+                tool = row.get("tool")
+                if isinstance(tool, str):
+                    tools.add(tool)
+                row_evidence, row_docker_evidence = (
+                    pr_lifecycle_evidence_from_tool_call(row)
+                )
+                pr_lifecycle_evidence.update(row_evidence)
+                docker_pr_lifecycle_evidence.update(row_docker_evidence)
+            if complete_lifecycle_evidence(
+                pr_lifecycle_evidence
+            ) and complete_lifecycle_evidence(docker_pr_lifecycle_evidence):
+                break
     return latest_ts, tools, pr_lifecycle_evidence, docker_pr_lifecycle_evidence
 
 

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -776,7 +776,13 @@ def tool_call_paths(base_path: Path) -> list[Path]:
     calls_dir = base_path / ".masc" / "tool_calls"
     if not calls_dir.exists():
         return []
-    return sorted(path for path in calls_dir.rglob("*.jsonl") if path.is_file())
+    candidates: list[tuple[int, str, Path]] = []
+    for path in calls_dir.rglob("*.jsonl"):
+        if not path.is_file():
+            continue
+        day_key = pr_action_metric_day_key(path)
+        candidates.append((day_key or -1, str(path), path))
+    return [path for _, _, path in sorted(candidates, reverse=True)]
 
 
 def scan_keeper_evidence(

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -292,6 +292,48 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertEqual(evidence, {"git_push:masc_code_git"})
         self.assertEqual(docker_evidence, set())
 
+    def test_tool_call_log_drives_shell_lifecycle_evidence(self):
+        row = {
+            "ts": 50.0,
+            "keeper": "alpha",
+            "tool": "keeper_shell",
+            "input": {"op": "gh", "cmd": "pr create --draft --title t"},
+            "output": json.dumps(
+                {
+                    "ok": True,
+                    "command": "gh 'pr' 'create' '--draft' '--title' 't'",
+                    "via": "docker",
+                }
+            ),
+            "success": True,
+        }
+
+        evidence, docker_evidence = audit.pr_lifecycle_evidence_from_tool_call(row)
+
+        self.assertEqual(evidence, {"pr_create:keeper_shell"})
+        self.assertEqual(docker_evidence, {"pr_create:keeper_shell"})
+
+    def test_tool_call_log_does_not_count_failed_approve(self):
+        row = {
+            "ts": 55.0,
+            "keeper": "alpha",
+            "tool": "keeper_shell",
+            "input": {"op": "gh", "cmd": "pr review 123 --approve"},
+            "output": json.dumps(
+                {
+                    "ok": False,
+                    "command": "gh 'pr' 'review' '123' '--approve'",
+                    "via": "docker",
+                }
+            ),
+            "success": False,
+        }
+
+        evidence, docker_evidence = audit.pr_lifecycle_evidence_from_tool_call(row)
+
+        self.assertEqual(evidence, set())
+        self.assertEqual(docker_evidence, set())
+
     def test_scan_keeper_evidence_reads_rotated_decision_logs(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -568,8 +610,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertFalse(report["ok"])
         self.assertEqual(report["github_identity_counts"], {"anyang-keepers": 2})
         self.assertIn(
-            "docker_pr_approve_identity_pool_insufficient"
-            "_unique_github_identities_1",
+            "docker_pr_approve_identity_pool_insufficient_unique_github_identities_1",
             report["fleet_failures"],
         )
 
@@ -588,10 +629,64 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             {"anyang-keepers": 1, "reviewer-keepers": 1},
         )
         self.assertNotIn(
-            "docker_pr_approve_identity_pool_insufficient"
-            "_unique_github_identities_1",
+            "docker_pr_approve_identity_pool_insufficient_unique_github_identities_1",
             report["fleet_failures"],
         )
+
+    def test_scan_keeper_evidence_reads_tool_calls(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls_dir = root / ".masc" / "tool_calls" / "2026-05"
+            calls_dir.mkdir(parents=True)
+            rows = [
+                {
+                    "ts": 50.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "input": {"cmd": "git push -u origin keeper/proof"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 60.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_shell",
+                    "input": {"op": "gh", "cmd": "pr review 123 --approve"},
+                    "output": json.dumps(
+                        {
+                            "ok": True,
+                            "command": "gh 'pr' 'review' '123' '--approve'",
+                            "via": "docker",
+                        }
+                    ),
+                    "success": True,
+                },
+                {
+                    "ts": 70.0,
+                    "keeper": "beta",
+                    "tool": "keeper_shell",
+                    "input": {"op": "gh", "cmd": "pr create --draft"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+            ]
+            (calls_dir / "06.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+
+            latest_ts, tools, evidence, docker_evidence = audit.scan_keeper_evidence(
+                root, "alpha"
+            )
+
+        self.assertEqual(latest_ts, 60.0)
+        self.assertEqual(tools, {"keeper_bash", "keeper_shell"})
+        self.assertEqual(
+            evidence,
+            {"git_push:keeper_bash", "pr_approve:keeper_shell"},
+        )
+        self.assertEqual(docker_evidence, evidence)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -687,6 +687,102 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         )
         self.assertEqual(docker_evidence, evidence)
 
+    def test_scan_keeper_evidence_reads_newest_tool_calls_first(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            old_calls_dir = root / ".masc" / "tool_calls" / "2026-05"
+            new_calls_dir = root / ".masc" / "tool_calls" / "2026-06"
+            old_calls_dir.mkdir(parents=True)
+            new_calls_dir.mkdir(parents=True)
+
+            old_rows = [
+                {
+                    "ts": 10.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "input": {"cmd": "git push -u origin keeper/old"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 20.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_shell",
+                    "input": {"op": "gh", "cmd": "pr create --draft"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 30.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_shell",
+                    "input": {"op": "gh", "cmd": "pr review 1 --approve"},
+                    "output": json.dumps(
+                        {
+                            "ok": True,
+                            "command": "gh pr review 1 --approve",
+                            "via": "docker",
+                        }
+                    ),
+                    "success": True,
+                },
+            ]
+            new_rows = [
+                {
+                    "ts": 70.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "input": {"cmd": "git push -u origin keeper/new"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 80.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_shell",
+                    "input": {"op": "gh", "cmd": "pr create --draft"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 90.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_shell",
+                    "input": {"op": "gh", "cmd": "pr review 2 --approve"},
+                    "output": json.dumps(
+                        {
+                            "ok": True,
+                            "command": "gh pr review 2 --approve",
+                            "via": "docker",
+                        }
+                    ),
+                    "success": True,
+                },
+            ]
+            (old_calls_dir / "31.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in old_rows),
+                encoding="utf-8",
+            )
+            (new_calls_dir / "01.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in new_rows),
+                encoding="utf-8",
+            )
+
+            latest_ts, _tools, evidence, docker_evidence = audit.scan_keeper_evidence(
+                root, "alpha"
+            )
+
+        self.assertEqual(latest_ts, 90.0)
+        self.assertEqual(
+            evidence,
+            {
+                "git_push:keeper_bash",
+                "pr_create:keeper_shell",
+                "pr_approve:keeper_shell",
+            },
+        )
+        self.assertEqual(docker_evidence, evidence)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -593,6 +593,5 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             report["fleet_failures"],
         )
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -851,6 +851,26 @@ let test_pr_review_action_metric_observes_invalid_output_json () =
   check (float 0.001) "parse failure counted" (before +. 1.0)
     (hook_output_parse_failures "pr_review_action")
 
+let test_pr_review_action_metric_extracts_keeper_shell_approve () =
+  let event =
+    pr_review_event
+      ~tool_name:"keeper_shell"
+      ~input:
+        (`Assoc
+          [
+            ("op", `String "gh");
+            ("cmd", `String "pr review 13680 --approve --body ok");
+          ])
+      ~output_text:
+        {|{"ok":true,"op":"gh","command":"gh 'pr' 'review' '13680' '--approve' '--body' 'ok'","via":"docker"}|}
+      ()
+    |> require_pr_review_event "keeper_shell approve"
+  in
+  check string "approve action" "APPROVE" event.action;
+  check (option int) "approve pr" (Some 13680) event.pr_number;
+  check bool "approve success" true event.success;
+  check (option string) "approve route via" (Some "docker") event.route_via
+
 let pr_work_events ?route_via_fallback ~tool_name ~input ~output_text () =
   Hooks.For_testing.pr_work_action_metric_events_of_tool_io
     ~route_via_fallback ~tool_name ~input ~output_text
@@ -908,6 +928,28 @@ let test_pr_work_action_metric_extracts_gh_pr_create () =
   | [ event ] ->
       check (option string) "route via nested" (Some "docker") event.route_via
   | _ -> failf "expected one pr create event"
+
+let test_pr_work_action_metric_extracts_quoted_output_gh_pr_create () =
+  let events =
+    pr_work_events
+      ~tool_name:"keeper_shell"
+      ~input:
+        (`Assoc
+          [
+            ("op", `String "gh");
+            ("cmd", `String "pr status");
+          ])
+      ~output_text:
+        {|{"ok":true,"op":"gh","command":"gh 'pr' 'create' '--draft' '--base' 'main' '--head' 'keeper/proof'","via":"docker"}|}
+      ()
+  in
+  check (list string) "quoted output pr create action" [ "PR_CREATE" ]
+    (work_actions events);
+  match events with
+  | [ event ] ->
+      check (option string) "quoted output route via" (Some "docker")
+        event.route_via
+  | _ -> failf "expected one quoted output pr create event"
 
 let test_pr_work_action_metric_extracts_keeper_pr_create () =
   let events =
@@ -1124,6 +1166,8 @@ let () =
             test_pr_review_action_metric_extracts_reply
         ; test_case "observes invalid output JSON" `Quick
             test_pr_review_action_metric_observes_invalid_output_json
+        ; test_case "extracts keeper_shell approve" `Quick
+            test_pr_review_action_metric_extracts_keeper_shell_approve
         ] )
     ; ( "pr_work_action",
         [ test_case "extracts masc_code_git push" `Quick
@@ -1132,6 +1176,8 @@ let () =
             test_pr_work_action_metric_observes_invalid_output_json
         ; test_case "extracts keeper_shell gh pr create" `Quick
             test_pr_work_action_metric_extracts_gh_pr_create
+        ; test_case "extracts quoted output gh pr create" `Quick
+            test_pr_work_action_metric_extracts_quoted_output_gh_pr_create
         ; test_case "extracts keeper_pr_create" `Quick
             test_pr_work_action_metric_extracts_keeper_pr_create
         ; test_case "uses native pr create route fallback" `Quick

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -779,9 +779,10 @@ let test_on_idle_hook_returns_runtime_nudge () =
             tool_names = [ "keeper_bash" ];
           }))
 
-let pr_review_event ~tool_name ~input ~output_text =
+let pr_review_event ?route_via_fallback ~tool_name ~input ~output_text () =
   Hooks.For_testing.pr_review_action_metric_event_of_tool_io
-    ~tool_name ~input ~output_text ~transport_success:true
+    ~route_via_fallback ~tool_name ~input ~output_text
+    ~transport_success:true
 
 let require_pr_review_event label = function
   | Some event -> event
@@ -800,6 +801,7 @@ let test_pr_review_action_metric_extracts_approve () =
       ~input:(`Assoc [ ("pr_number", `Int 13177); ("event", `String "COMMENT") ])
       ~output_text:
         {|{"ok":true,"pr_number":13177,"event":"APPROVE","keeper":"sangsu","via":"docker"}|}
+      ()
     |> require_pr_review_event "approve"
   in
   check string "action from output" "APPROVE" event.action;
@@ -813,6 +815,7 @@ let test_pr_review_action_metric_marks_structured_failure () =
       ~tool_name:"keeper_pr_review_comment"
       ~input:(`Assoc [ ("number", `Int 42); ("event", `String "approve") ])
       ~output_text:{|{"ok":false,"error":"gh_failed"}|}
+      ()
     |> require_pr_review_event "failed approve"
   in
   check string "action fallback from input" "APPROVE" event.action;
@@ -825,6 +828,7 @@ let test_pr_review_action_metric_extracts_reply () =
       ~tool_name:"keeper_pr_review_reply"
       ~input:(`Assoc [ ("pr_number", `Int 9); ("comment_id", `Int 1234) ])
       ~output_text:{|{"ok":true,"pr_number":9,"comment_id":1234,"via":"host"}|}
+      ()
     |> require_pr_review_event "reply"
   in
   check string "reply action" "REPLY" event.action;
@@ -839,6 +843,7 @@ let test_pr_review_action_metric_observes_invalid_output_json () =
       ~tool_name:"keeper_pr_review_comment"
       ~input:(`Assoc [ ("number", `Int 7); ("event", `String "comment") ])
       ~output_text:"{not-json"
+      ()
     |> require_pr_review_event "invalid output json"
   in
   check string "action fallback from input" "COMMENT" event.action;
@@ -846,9 +851,10 @@ let test_pr_review_action_metric_observes_invalid_output_json () =
   check (float 0.001) "parse failure counted" (before +. 1.0)
     (hook_output_parse_failures "pr_review_action")
 
-let pr_work_events ~tool_name ~input ~output_text =
+let pr_work_events ?route_via_fallback ~tool_name ~input ~output_text () =
   Hooks.For_testing.pr_work_action_metric_events_of_tool_io
-    ~tool_name ~input ~output_text ~transport_success:true
+    ~route_via_fallback ~tool_name ~input ~output_text
+    ~transport_success:true
 
 let work_actions events = List.map (fun e -> e.Hooks.work_action) events
 
@@ -858,6 +864,7 @@ let test_pr_work_action_metric_extracts_masc_code_git_push () =
       ~tool_name:"masc_code_git"
       ~input:(`Assoc [ ("action", `String "push") ])
       ~output_text:{|{"status":"ok","action":"push","via":"docker"}|}
+      ()
   in
   check (list string) "actions" [ "GIT_PUSH" ] (work_actions events);
   let event =
@@ -876,6 +883,7 @@ let test_pr_work_action_metric_observes_invalid_output_json () =
       ~tool_name:"masc_code_git"
       ~input:(`Assoc [ ("action", `String "push") ])
       ~output_text:"{not-json"
+      ()
   in
   check (list string) "actions fallback from input" [ "GIT_PUSH" ]
     (work_actions events);
@@ -892,6 +900,7 @@ let test_pr_work_action_metric_extracts_gh_pr_create () =
             ("cmd", `String "pr create --draft --title t") ])
       ~output_text:
         {|{"ok":true,"op":"gh","command":"gh pr create --draft","route":{"via":"docker"}}|}
+      ()
   in
   check (list string) "pr create action" [ "PR_CREATE" ]
     (work_actions events);
@@ -912,6 +921,7 @@ let test_pr_work_action_metric_extracts_keeper_pr_create () =
           ])
       ~output_text:
         {|{"ok":true,"tool":"keeper_pr_create","operation":"pr_create","via":"brokered"}|}
+      ()
   in
   check (list string) "pr create action" [ "PR_CREATE" ]
     (work_actions events);
@@ -920,6 +930,48 @@ let test_pr_work_action_metric_extracts_keeper_pr_create () =
       check string "source" "keeper_pr_create" event.work_source;
       check (option string) "route via" (Some "brokered") event.route_via
   | _ -> failf "expected one keeper_pr_create event"
+
+let test_pr_work_action_metric_uses_native_pr_create_route_fallback () =
+  let events =
+    pr_work_events ~route_via_fallback:"brokered"
+      ~tool_name:"keeper_pr_create"
+      ~input:
+        (`Assoc
+          [
+            ("title", `String "proof");
+            ("head", `String "proof/keeper-docker");
+          ])
+      ~output_text:
+        {|{"ok":true,"tool":"keeper_pr_create","operation":"pr_create"}|}
+      ()
+  in
+  check (list string) "pr create action" [ "PR_CREATE" ]
+    (work_actions events);
+  match events with
+  | [ event ] ->
+      check (option string) "route fallback" (Some "brokered")
+        event.route_via
+  | _ -> failf "expected one keeper_pr_create event"
+
+let test_pr_work_action_metric_extracts_bash_git_push_with_redirection () =
+  let events =
+    pr_work_events
+      ~tool_name:"keeper_bash"
+      ~input:
+        (`Assoc
+          [
+            ( "cmd",
+              `String "git push -u origin keeper/proof-branch 2>&1" );
+          ])
+      ~output_text:{|{"ok":true,"via":"docker"}|}
+      ()
+  in
+  check (list string) "git push with redirection" [ "GIT_PUSH" ]
+    (work_actions events);
+  match events with
+  | [ event ] ->
+      check (option string) "route via" (Some "docker") event.route_via
+  | _ -> failf "expected one git push event"
 
 let test_pr_work_action_metric_extracts_bash_git_sequence_failure () =
   let events =
@@ -931,6 +983,7 @@ let test_pr_work_action_metric_extracts_bash_git_sequence_failure () =
               `String "git add lib/foo.ml && git commit -m x && git push origin feat/x" );
           ])
       ~output_text:{|{"ok":false,"cmd":"git push origin feat/x"}|}
+      ()
   in
   check (list string) "git action sequence"
     [ "GIT_ADD" ]
@@ -951,6 +1004,7 @@ let test_pr_work_action_metric_ignores_quoted_command_words () =
             );
           ])
       ~output_text:{|{"ok":true}|}
+      ()
   in
   check (list string) "quoted command words do not add actions"
     [ "GIT_COMMIT" ] (work_actions bash_events);
@@ -964,6 +1018,7 @@ let test_pr_work_action_metric_ignores_quoted_command_words () =
             ("cmd", `String "issue comment 1 --body \"please pr create later\"");
           ])
       ~output_text:{|{"ok":true}|}
+      ()
   in
   check (list string) "quoted pr create is not a command" [] (work_actions gh_events)
 
@@ -973,6 +1028,7 @@ let test_pr_work_action_metric_skips_shell_control_flow_segments () =
       ~tool_name:"keeper_bash"
       ~input:(`Assoc [ ("cmd", `String "false && git push origin feat/x") ])
       ~output_text:{|{"ok":false}|}
+      ()
   in
   check (list string) "skipped && segment" [] (work_actions and_events);
   let or_events =
@@ -986,6 +1042,7 @@ let test_pr_work_action_metric_skips_shell_control_flow_segments () =
                 "git commit -m reviewed || gh pr create --draft --title retry" );
           ])
       ~output_text:{|{"ok":true}|}
+      ()
   in
   check (list string) "skipped || fallback segment" [ "GIT_COMMIT" ]
     (work_actions or_events)
@@ -1077,6 +1134,10 @@ let () =
             test_pr_work_action_metric_extracts_gh_pr_create
         ; test_case "extracts keeper_pr_create" `Quick
             test_pr_work_action_metric_extracts_keeper_pr_create
+        ; test_case "uses native pr create route fallback" `Quick
+            test_pr_work_action_metric_uses_native_pr_create_route_fallback
+        ; test_case "extracts bash git push with redirection" `Quick
+            test_pr_work_action_metric_extracts_bash_git_push_with_redirection
         ; test_case "extracts conservative bash git failure" `Quick
             test_pr_work_action_metric_extracts_bash_git_sequence_failure
         ; test_case "ignores quoted command words" `Quick


### PR DESCRIPTION
## Summary
- preserve Docker/brokered route evidence for native keeper PR lifecycle metrics
- audit successful keeper_shell/keeper_bash/masc_code tool_calls for git push, gh pr create, and gh pr review --approve lifecycle evidence
- surface the single GitHub identity pool as a fleet blocker when Docker PR approve evidence is required

## Validation
- python3 test/test_audit_keeper_fleet_readiness.py
- ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py
- ruff format --check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe passed before the final main rebase on the same OCaml patch; latest rerun was blocked by a concurrent /tmp/me-opam-switch.lock holder and canceled before PR publish
