### PR TITLE
fix(keeper): route PR guidance through keeper_pr_create

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -92,9 +92,10 @@ Peer consultation contract:
 
 Task management:
 - View tasks: keeper_tasks_list
-- Create tasks: masc_add_task (single), masc_batch_add_tasks (multiple)
+- Create tasks: keeper_task_create when available; otherwise use masc_add_task (single) or masc_batch_add_tasks (multiple)
 - Claim next available: masc_claim_next
 - Claim specific and complete: keeper_task_claim, keeper_task_done
+- For code/PR work that needs review: keeper_task_submit_for_verification with task_id, notes, and pr_url
 
 Context:
 - Current time: keeper_time_now

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -72,7 +72,7 @@ PR workflow (Coding/Delivery/Full preset required):
 1. `masc_worktree_create task_id=<id>` — opens isolated branch
 2. `masc_code_read` → `masc_code_edit` — read first, then edit
 3. `keeper_bash cmd='git status'` → `git add <paths>` → `git commit -m ...` → `git push -u origin HEAD` — all with cwd inside the worktree
-4. `keeper_shell op=gh cmd='pr create --draft --title ... --body ... --base ...'` — open the draft PR after push
+4. `keeper_pr_create draft=true title=... body=... base=... head=...` — open the draft PR after push. Do not create PRs through `keeper_shell op=gh`.
 
 Knowledge lookup:
 - Past conversations and messages: keeper_memory_search

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -23,7 +23,7 @@ What you can do:
 - **Board**: post opinions, findings, suggestions (`keeper_board_post`). Comment on others' posts (`keeper_board_comment`). Vote (`keeper_board_vote`). The board is where keepers talk, argue, and share ideas.
 - **Tools**: call `keeper_tool_search` to discover what tools you have access to. Your tool set depends on your preset policy. If you are unsure whether a tool exists, search first.
 - **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, mark done.
-- **GitHub**: if `keeper_shell op=gh` is available, you can inspect PRs/issues and open draft PRs after pushing from a prepared worktree.
+- **GitHub**: inspect PRs/issues with `keeper_shell op=gh` when available. Create draft PRs with `keeper_pr_create draft=true` after pushing from a prepared worktree.
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
 - **Shell**: inspect files, search code, and use structured shell/GitHub ops (`keeper_fs_read`, `keeper_shell`). Use `Bash`/`keeper_bash` for command execution when your policy exposes it.
 - **Memory**: your checkpoint and decision records persist. Use `keeper_memory_search` to recall past context.

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -31,6 +31,7 @@ tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keepe
 tools = [
   "keeper_tasks_list",
   "keeper_task_claim",
+  "keeper_task_create",
   "keeper_task_done",
   "keeper_task_submit_for_verification",
   "keeper_broadcast",

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -28,7 +28,13 @@ tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keepe
 
 # Coordination split: core (task lifecycle) vs extended (audit, force ops).
 [groups.coordination_core]
-tools = ["keeper_tasks_list", "keeper_task_claim", "keeper_task_done", "keeper_broadcast"]
+tools = [
+  "keeper_tasks_list",
+  "keeper_task_claim",
+  "keeper_task_done",
+  "keeper_task_submit_for_verification",
+  "keeper_broadcast",
+]
 
 [groups.coordination]
 tools = [
@@ -79,7 +85,7 @@ tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_she
 # Tools allowed on the keeper's last turn (safety constraint).
 # On last turn, visible tools are intersected with this set.
 [groups.last_turn_safe]
-tools = ["keeper_board_post", "keeper_board_comment", "keeper_board_curation_submit", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_tool_search", "keeper_broadcast", "keeper_task_done", "masc_web_search"]
+tools = ["keeper_board_post", "keeper_board_comment", "keeper_board_curation_submit", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_tool_search", "keeper_broadcast", "keeper_task_done", "keeper_task_submit_for_verification", "masc_web_search"]
 
 # Optional tools that require explicit opt-in via also_allow.
 # Excluded from all presets by default; a keeper must list them in also_allow.

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -337,18 +337,19 @@ let clear_agent_current_task_cache config ~task_id =
                | Ok agent when agent.current_task = Some task_id ->
                  let status =
                    match agent.status with
-                   | Inactive -> Inactive
-                   | Active | Busy | Listening -> Active
+                   | Masc_domain.Inactive -> Masc_domain.Inactive
+                   | Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening ->
+                     Masc_domain.Active
                  in
                  let updated =
                    {
                      agent with
                      status;
                      current_task = None;
-                     last_seen = now_iso ();
+                     last_seen = Masc_domain.now_iso ();
                    }
                  in
-                 write_json config path (agent_to_yojson updated);
+                 write_json config path (Masc_domain.agent_to_yojson updated);
                  log_event
                    config
                    (`Assoc
@@ -356,7 +357,7 @@ let clear_agent_current_task_cache config ~task_id =
                         ("type", `String "agent_current_task_cache_cleared");
                         ("agent", `String agent.name);
                         ("stale_task", `String task_id);
-                        ("ts", `String (now_iso ()));
+                        ("ts", `String (Masc_domain.now_iso ()));
                       ])
                | Ok _ -> ()
                | Error msg ->

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -245,7 +245,7 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
               if exit_code = 0 then
                 Ok
                   (Printf.sprintf
-                     "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work && gh pr create --draft"
+                     "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work, then use keeper_pr_create draft=true"
                      worktree_path branch_name note worktree_path)
               else Error (System (System_error.IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base))))
 

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -604,7 +604,7 @@ let keeper_visible_worktree_path ~config ~agent_name ~host_path =
 let worktree_next_step keeper_path =
   Printf.sprintf
     "Next: keeper_bash cwd=%S cmd=\"git status -sb\"; after edits, git \
-     add/commit/push, then keeper_shell op=gh cmd=\"pr create --draft ...\"."
+     add/commit/push, then use keeper_pr_create draft=true."
     keeper_path
 
 type repo_candidate = {

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -151,7 +151,7 @@ let tools_for_gated_affordance = function
       "masc_transition" ]
   | Work_discovery ->
     [ "keeper_task_claim"; "masc_claim_next";
-      "keeper_board_post"; "masc_add_task";
+      "keeper_board_post"; "keeper_task_create"; "masc_add_task";
       "keeper_tasks_audit" ]
   | Inspect_worktree_delta ->
     [ "keeper_shell"; "keeper_bash"; "masc_code_git";

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -362,6 +362,7 @@ let tool_search_alias_entries =
   ; "keeper_task_submit_for_verification", "태스크 검증제출 리뷰요청 PR검토"
   ; "keeper_task_force_release", "태스크 강제해제 반환"
   ; "keeper_task_force_done", "태스크 강제완료"
+  ; "keeper_pr_create", "pr create pull request github draft 생성 풀리퀘스트 열기"
   ; "keeper_pr_review_read", "pr review pull request github diff comments reviews 읽기 검토"
   ; "keeper_pr_review_comment", "pr review pull request github comment approve request_changes 코멘트 승인 변경요청"
   ; "keeper_pr_review_reply", "pr review pull request github reply inline comment 답글 리뷰댓글"

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -20,6 +20,12 @@ let hints =
     ; call = "`keeper_tasks_list` {}"
     ; description = "inspect eligible task context"
     }
+  ; { name = "keeper_task_create"
+    ; call =
+        "`keeper_task_create` { title: \"<verb + object>\", description: \
+         \"<acceptance criteria>\" }"
+    ; description = "create a new backlog task with keeper-native evidence"
+    }
   ; { name = "keeper_board_get"
     ; call = "`keeper_board_get` { id: \"<post-id>\" }"
     ; description = "read a board post before replying"

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -109,20 +109,30 @@ let render_gh_workflow ~allowed_tool_names =
   let has_worktree = has allowed_tool_names "masc_worktree_create" in
   let has_bash = has allowed_tool_names "keeper_bash" in
   let has_verify = has allowed_tool_names "keeper_task_submit_for_verification" in
-  match has_shell, has_worktree, has_bash, has_verify with
-  | true, true, true, true ->
+  let has_pr_create = has allowed_tool_names "keeper_pr_create" in
+  match has_shell, has_worktree, has_bash, has_verify, has_pr_create with
+  | true, true, true, true, true ->
     Some
       "GitHub/code workflow: if you do not already hold a task, call `keeper_task_claim` \
        first; `keeper_shell op=gh` derives repo context from the active task \
        worktree/current_task_id. Then inspect with `keeper_shell op=gh`; if code change \
        is needed, `masc_worktree_create` -> edit -> `keeper_bash` for `git add` / `git \
-       commit` / `git push` -> `keeper_shell op=gh` with `cmd=\"pr create --draft ...\"` \
+       commit` / `git push` -> `keeper_pr_create` with `draft=true` \
        -> `keeper_task_submit_for_verification` with notes and `pr_url`."
-  | true, _, _, _ ->
+  | true, true, true, true, false ->
+    Some
+      "GitHub/code workflow: if you do not already hold a task, call `keeper_task_claim` \
+       first; inspect with `keeper_shell op=gh`; if code change is needed, \
+       `masc_worktree_create` -> edit -> `keeper_bash` for `git add` / `git commit` / \
+       `git push`. Do not create PRs through `keeper_shell op=gh`; submit verification \
+       notes with the pushed branch and request a dedicated draft-PR tool."
+  | true, _, _, _, _ ->
     Some
       "GitHub workflow: use `keeper_shell op=gh` only for commands supported by your \
        active tool policy. `keeper_shell op=gh` derives repo context from the active \
-       task worktree/current_task_id; claim a task first when repo context is required."
+       task worktree/current_task_id; claim a task first when repo context is required. \
+       Do not create PRs through `keeper_shell op=gh`; use the dedicated draft-PR tool \
+       when it is listed."
   | _ -> None
 ;;
 

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -525,7 +525,7 @@ let rec skip_git_global_options = function
     a sandboxed cwd by default, but explicit cwd overrides still need this
     guard. Redirect checkout/switch/branch mutations to an explicit worktree
     flow: create the worktree first, then use keeper_bash for git add/commit/
-    push and keeper_shell op=gh for the draft PR.
+    push and keeper_pr_create for the draft PR.
 
     Handles tab-separated tokens, global git options like [-C dir], and real
     branch mutation forms (create, rename, copy). Allows read-only listing. *)

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -329,6 +329,8 @@ let test_coding_preset_has_coordination_tools () =
     (has_tool "keeper_task_submit_for_verification" tools);
   check bool "has keeper_task_create" true
     (has_tool "keeper_task_create" tools);
+  check bool "has keeper_pr_create" true
+    (has_tool "keeper_pr_create" tools);
   check bool "has keeper_task_force_release" true
     (has_tool "keeper_task_force_release" tools);
   check bool "has masc_goal_list" true

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -299,8 +299,20 @@ let test_last_turn_safe_keeps_discovery_and_web_search () =
     (has_tool "keeper_tool_search" tools);
   check bool "last turn allows masc_web_search" true
     (has_tool "masc_web_search" tools);
+  check bool "last turn allows verification submit" true
+    (has_tool "keeper_task_submit_for_verification" tools);
   check bool "last turn allows WebSearch alias" true
     (has_tool "WebSearch" alias_expanded)
+
+let test_core_coordination_presets_can_submit_for_verification () =
+  [ "social", Keeper_types.Social; "messaging", Keeper_types.Messaging ]
+  |> List.iter (fun (label, preset) ->
+       let meta = make_meta ~preset () in
+       let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+       check bool
+         (label ^ " has keeper_task_submit_for_verification")
+         true
+         (has_tool "keeper_task_submit_for_verification" tools))
 
 let test_coding_preset_has_coordination_tools () =
   let meta = make_meta ~preset:Keeper_types.Coding () in
@@ -872,6 +884,8 @@ let () =
       test_case "research has read tools" `Quick test_research_preset_has_read_tools;
       test_case "last turn keeps discovery and web search" `Quick
         test_last_turn_safe_keeps_discovery_and_web_search;
+      test_case "core coordination presets can submit for verification" `Quick
+        test_core_coordination_presets_can_submit_for_verification;
       test_case "coding has coordination tools" `Quick test_coding_preset_has_coordination_tools;
       test_case "messaging legacy governance tools removed" `Quick test_messaging_preset_has_no_legacy_governance_tools;
       test_case "sufficient tool count" `Quick test_sufficient_tool_count;

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -304,11 +304,15 @@ let test_last_turn_safe_keeps_discovery_and_web_search () =
   check bool "last turn allows WebSearch alias" true
     (has_tool "WebSearch" alias_expanded)
 
-let test_core_coordination_presets_can_submit_for_verification () =
+let test_core_coordination_presets_have_task_lifecycle_tools () =
   [ "social", Keeper_types.Social; "messaging", Keeper_types.Messaging ]
   |> List.iter (fun (label, preset) ->
        let meta = make_meta ~preset () in
        let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+       check bool
+         (label ^ " has keeper_task_create")
+         true
+         (has_tool "keeper_task_create" tools);
        check bool
          (label ^ " has keeper_task_submit_for_verification")
          true
@@ -884,8 +888,8 @@ let () =
       test_case "research has read tools" `Quick test_research_preset_has_read_tools;
       test_case "last turn keeps discovery and web search" `Quick
         test_last_turn_safe_keeps_discovery_and_web_search;
-      test_case "core coordination presets can submit for verification" `Quick
-        test_core_coordination_presets_can_submit_for_verification;
+      test_case "core coordination presets have task lifecycle tools" `Quick
+        test_core_coordination_presets_have_task_lifecycle_tools;
       test_case "coding has coordination tools" `Quick test_coding_preset_has_coordination_tools;
       test_case "messaging legacy governance tools removed" `Quick test_messaging_preset_has_no_legacy_governance_tools;
       test_case "sufficient tool count" `Quick test_sufficient_tool_count;

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -420,6 +420,42 @@ let test_deterministic_prefilter_surfaces_pr_review_for_explicit_request () =
   Alcotest.(check bool) "pr review comment appears in final visible surface"
     true (List.mem "keeper_pr_review_comment" visible)
 
+let test_pr_create_aliases_cover_draft_pr_workflow () =
+  let aliases =
+    Keeper_agent_tool_surface.tool_search_aliases "keeper_pr_create"
+  in
+  Alcotest.(check bool) "keeper_pr_create aliases mention draft PR"
+    true (List.mem "draft" aliases);
+  Alcotest.(check bool) "keeper_pr_create aliases mention pull request"
+    true (List.mem "pull" aliases);
+  Alcotest.(check bool) "keeper_pr_create aliases include Korean create intent"
+    true (List.mem "생성" aliases)
+
+let test_deterministic_prefilter_surfaces_pr_create_for_draft_pr_request () =
+  let pr_create_tools =
+    test_tools
+    @ [
+        make_tool "keeper_pr_create"
+          "Open a draft pull request through the keeper credential broker";
+      ]
+  in
+  let selected =
+    deterministic_prefilter_for_tools
+      ~tools:pr_create_tools
+      ~query_text:
+        "branch push 완료. gh pr create 대신 draft 풀리퀘스트 생성해야 함"
+      ~selection_limit:10
+  in
+  let visible =
+    Keeper_tool_disclosure.merge_tool_selection_boundary
+      ~core:(Keeper_exec_tools.effective_core_tools ())
+      ~deterministic_prefilter:selected
+      ~llm_selected:[]
+      ~discovered:[]
+  in
+  Alcotest.(check bool) "keeper_pr_create appears in visible surface"
+    true (List.mem "keeper_pr_create" visible)
+
 let test_tool_search_partition_returns_allowed_core_hits () =
   let partition =
     Keeper_run_tools.partition_tool_search_hits
@@ -514,6 +550,10 @@ let () =
         test_deterministic_prefilter_hides_code_read_for_generic_file_read;
       Alcotest.test_case "deterministic prefilter surfaces pr review tools" `Quick
         test_deterministic_prefilter_surfaces_pr_review_for_explicit_request;
+      Alcotest.test_case "pr create aliases cover draft workflow" `Quick
+        test_pr_create_aliases_cover_draft_pr_workflow;
+      Alcotest.test_case "deterministic prefilter surfaces pr create" `Quick
+        test_deterministic_prefilter_surfaces_pr_create_for_draft_pr_request;
       Alcotest.test_case "tool_search returns allowed core hits" `Quick
         test_tool_search_partition_returns_allowed_core_hits;
       Alcotest.test_case "tool_search filters denied core hits" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1849,7 +1849,11 @@ let test_prompt_includes_operational_tool_guidance () =
   check bool "mentions worktree inspection guidance" true
     (contains_substring sys "masc_code_read");
   check bool "mentions server-managed heartbeat" true
-    (contains_substring sys "Heartbeat is server-managed")
+    (contains_substring sys "Heartbeat is server-managed");
+  check bool "mentions draft PR broker" true
+    (contains_substring sys "keeper_pr_create draft=true");
+  check bool "raw gh PR creation not documented" false
+    (contains_substring sys "open draft PRs after pushing")
 
 let test_prompt_includes_research_evidence_contract () =
   let sys, _user =
@@ -1877,7 +1881,9 @@ let test_capabilities_prompt_distinguishes_sandbox_and_worktree () =
     (contains_substring prompt "default coding workspace");
   check bool "git path documented via keeper_bash" true
     (contains_substring prompt "keeper_bash cmd='git status'");
-  check bool "gh pr create path documented" true
+  check bool "draft pr tool documented" true
+    (contains_substring prompt "keeper_pr_create");
+  check bool "gh pr create path not documented" false
     (contains_substring prompt "keeper_shell op=gh cmd='pr create --draft");
   check bool "legacy pr workflow removed from prompt" false
     (contains_substring prompt "keeper_pr_workflow")

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7354,7 +7354,10 @@ let test_tools_for_gated_affordance_covers_each_variant () =
     "generic board affordance has no forced specific tool"
     []
     (Surface.preferred_tool_names_for_turn_affordances
-       [ "board_post_or_comment" ])
+       [ "board_post_or_comment" ]);
+  check bool "work discovery includes keeper-native task creation" true
+    (List.mem "keeper_task_create"
+       (Surface.tools_for_gated_affordance Surface.Work_discovery))
 
 let test_preferred_tool_choice_for_required_turn_claims_first () =
   let module Surface = Masc_mcp.Keeper_agent_tool_surface in


### PR DESCRIPTION
## Summary

- Route keeper PR-opening guidance through `keeper_pr_create draft=true` instead of raw `keeper_shell op=gh pr create`.
- Keep `keeper_shell op=gh` guidance for PR/issue inspection, not draft PR creation.
- Add prompt regression coverage so unified/capabilities prompts continue to advertise the brokered PR tool and avoid the stale raw-gh path.
- Expose `keeper_task_submit_for_verification` through core coordination and last-turn safe policy so code/PR work can complete the verifier flow the prompt already requires.
- Expose `keeper_task_create` through core coordination and work-discovery guidance so social/messaging keepers can create taskboard evidence through the keeper-native tool instead of falling back to `masc_add_task`.
- Qualify the current-base `coord.ml` agent-status cache repair helper so this branch builds on latest `origin/main`.
- Surface `keeper_pr_create` in the keeper tool-selection aliases so draft-PR creation requests can retrieve the governed PR tool instead of drifting back to raw `gh`.

## Why this matters

Strict keeper feature proof checks the Docker/git/PR lifecycle through the dedicated audit path. The `pr_create` stage is verifier-compatible only when the tool-call log records `keeper_pr_create`; raw `gh pr create` through `keeper_shell op=gh` can create a real draft PR, but it does not satisfy the lifecycle evidence gate.

Live runtime also showed the narrower failure mode this patch closes: a keeper reached the PR-create step from a Docker-backed turn, but the visible tool guidance/surface led it through blocked raw `gh` attempts before a separate `keeper_pr_create` call succeeded. This patch makes the governed PR tool discoverable for that workflow.

The same strict audit also showed taskboard lifecycle friction: keepers were instructed to submit code/PR work for verification, but some core coordination surfaces did not expose `keeper_task_submit_for_verification`; common keeper presets also did not expose the keeper-native task creation tool.

## Operator impact

Future keepers should generate draft PR, task-creation, and task-verification evidence through governed tools, aligning prompt guidance, tool policy, tool selection, and dashboard proof logic.

## Verification

- `git diff --check HEAD~1..HEAD`
- Added regression coverage:
  - `test_keeper_topk_llm`: `keeper_pr_create` aliases cover draft PR workflow.
  - `test_keeper_topk_llm`: deterministic prefilter surfaces `keeper_pr_create` for draft PR creation requests.
  - `test_keeper_tool_exposure`: coding preset exposes `keeper_pr_create`.
- `DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_topk_llm.exe`
- `_build/default/test/test_keeper_topk_llm.exe` (`22 tests run`)
- `DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_unified.exe`
- `_build/default/test/test_keeper_unified.exe` (`337 tests run`)
- `DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_tool_exposure.exe`
- `_build/default/test/test_keeper_tool_exposure.exe` (`65 tests run`)
- Draft PR checks on pushed head pass: CI Gate, PR Live Gate, PR Sync Check, Draft Auto-Merge Guard, and Fundamental guards; draft-heavy jobs are skipped by policy.

## Strict Proof Status

Latest strict feature proof on live data is still `warn`: 8 pass / 10 warn. `docker_git_pr_workflow` is still warn because the current 24h audit has no successful `keeper_pr_create` PR-create stage evidence. This PR fixes the PR-lifecycle guidance/discovery mismatch and two taskboard policy mismatches, but it does not claim full all-feature completion.
