### PR TITLE
fix(test): preflight missing bisect reporter

### DIFF
--- a/scripts/coverage_percent.sh
+++ b/scripts/coverage_percent.sh
@@ -5,6 +5,25 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 coverage_dir="${COVERAGE_DIR:-$root_dir/_coverage}"
 reuse_existing=false
 
+require_bisect_reporter() {
+  if ! command -v opam >/dev/null 2>&1; then
+    echo "opam is required to run coverage_percent.sh" >&2
+    exit 127
+  fi
+  if ! opam exec -- bash -lc 'command -v bisect-ppx-report >/dev/null 2>&1'; then
+    cat >&2 <<'EOF'
+bisect-ppx-report is not installed in the active opam switch.
+
+Install/pin the repo test dependencies with bisect support before measuring:
+  scripts/opam-pin-external-deps.sh --with-bisect
+  opam install . --deps-only --with-test
+
+CI does this through the setup/pin dependency actions with --with-bisect.
+EOF
+    exit 127
+  fi
+}
+
 for arg in "$@"; do
   case "$arg" in
     --reuse-existing)
@@ -16,6 +35,8 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+require_bisect_reporter
 
 if ! $reuse_existing; then
   rm -rf "$coverage_dir"


### PR DESCRIPTION
## Summary

- make `scripts/coverage_percent.sh` fail early when `opam` or `bisect-ppx-report` is unavailable
- print the repo setup commands needed to install/pin bisect-enabled test dependencies before measuring coverage

## Why it matters

The active 100% coverage objective needs a real bisect percentage, but the current local switch fails with `bash: bisect-ppx-report: command not found`. This change turns that into an actionable preflight instead of an opaque reporter failure.

Tracks #13717 and supports #13718.

## Validation

- `bash -n scripts/coverage_percent.sh`
- `scripts/coverage_percent.sh --reuse-existing` (expected failure in this local switch: missing `bisect-ppx-report`, now with actionable setup instructions)
- `git diff --check`