### PR TITLE
fix: classify current Codex cost catalog gaps

### DIFF
--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -62,6 +62,14 @@ let active_task_assignee = function
       Some assignee
   | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
+let assigned_task_ids ~matches_you tasks =
+  List.filter_map
+    (fun (task : Masc_domain.task) ->
+      match active_task_assignee task.task_status with
+      | Some assignee when matches_you assignee -> Some task.id
+      | Some _ | None -> None)
+    tasks
+
 let add_unique table key value =
   let values = Option.value (Hashtbl.find_opt table key) ~default:[] in
   if List.exists (String.equal value) values then ()

--- a/lib/dune
+++ b/lib/dune
@@ -234,6 +234,7 @@
    cohttp
    cohttp-eio
    agent_sdk
+   agent_sdk.base
    agent_sdk.llm_provider
    masc_mcp.oas_compat
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -376,6 +376,40 @@ let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
   | Some (Oas_worker_named.Oas_timeout_budget _) -> true
   | _ -> false
 
+let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
+  let updated = Keeper_world_observation.apply_message_cursor_updates meta updates in
+  if updates = [] then updated
+  else
+    let merge ~latest ~caller:_ =
+      Keeper_world_observation.apply_message_cursor_updates latest updates
+    in
+    match write_meta_with_merge ~merge config updated with
+    | Ok () -> (
+        match read_meta config updated.name with
+        | Ok (Some latest) -> latest
+        | Ok None ->
+            Prometheus.inc_counter Prometheus.metric_keeper_meta_read_failures
+              ~labels:[("keeper", updated.name); ("site", "cursor_update_none_after_write")]
+              ();
+            Log.Keeper.warn
+              "read_meta returned None after message cursor update write for %s"
+              updated.name;
+            { updated with meta_version = updated.meta_version + 1 }
+        | Error e ->
+            Prometheus.inc_counter Prometheus.metric_keeper_meta_read_failures
+              ~labels:[("keeper", updated.name); ("site", "cursor_update_read_after_write")]
+              ();
+            Log.Keeper.warn
+              "read_meta failed after message cursor update write for %s: %s"
+              updated.name e;
+            { updated with meta_version = updated.meta_version + 1 })
+    | Error e ->
+        Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
+          ~labels:[("keeper", updated.name); ("phase", "cursor_update")]
+          ();
+        Log.Keeper.warn "write_meta failed (message cursor update): %s" e;
+        updated
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -483,9 +517,6 @@ let run_keepalive_unified_turn
           ~config:ctx.config
           ~meta:meta_after_triage
       in
-      let has_message_signal =
-        obs.pending_mentions <> [] || obs.pending_scope_messages <> []
-      in
       let turn_decision =
         Keeper_world_observation.keeper_cycle_decision
           ~meta:meta_after_triage
@@ -499,9 +530,8 @@ let run_keepalive_unified_turn
         (not (Atomic.get stop))
         && turn_decision.should_run
       in
-      let meta_after_observe =
-        Keeper_world_observation.apply_message_cursor_updates
-          meta_after_triage
+      let meta_after_cursor_persist =
+        persist_message_cursor_updates ~config:ctx.config meta_after_triage
           obs.message_cursor_updates
       in
       let format_opt_int = function
@@ -598,18 +628,8 @@ let run_keepalive_unified_turn
           ~base_path:ctx.config.base_path
           ~keeper_name:meta_after_triage.name
       end;
-      if (not should_run_turn)
-         && (not has_message_signal)
-         && obs.message_cursor_updates <> []
-      then (
-        match write_meta ctx.config meta_after_observe with
-        | Ok () -> ()
-        | Error e ->
-            Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
-              ~labels:[("keeper", meta_after_observe.name); ("phase", "cursor_update")] ();
-            Log.Keeper.warn "write_meta failed (message cursor update): %s" e);
       if Atomic.get stop
-      then meta_after_triage
+      then meta_after_cursor_persist
       else if should_run_turn
       then (
         (* Admission wait happens before [mark_turn_started], so the stale
@@ -644,13 +664,13 @@ let run_keepalive_unified_turn
           Keeper_turn_slot.with_keeper_turn_slot_control ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
             match
-              with_in_turn_liveness_pulse ~ctx ~meta:meta_after_observe ~stop
+              with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop
                 (fun () ->
                   Keeper_unified_turn.run_keeper_cycle
                     ~config:ctx.config
-                    ~meta:meta_after_observe
+                    ~meta:meta_after_cursor_persist
                     ~observation:obs
-                    ~generation:meta_after_observe.runtime.generation
+                    ~generation:meta_after_cursor_persist.runtime.generation
                     ~channel:turn_decision.channel
                     ~semaphore_wait_ms:semaphore_wait_ms
                     ~turn_slot_control:slot_control
@@ -666,19 +686,19 @@ let run_keepalive_unified_turn
                  readers; escalate to ERROR only on the fatal-environment
                  branch, which is the real signal this layer owns. *)
               Log.Keeper.debug "%s: keeper cycle failed: %s"
-                meta_after_observe.name e_str;
+                meta_after_cursor_persist.name e_str;
               if String_util.contains_substring e_str "Eio switch not available"
                  || String_util.contains_substring e_str "Eio net not available"
               then begin
                 Log.Keeper.error
                   "%s: fatal environment error — promoting to Keeper_fiber_crash: %s"
-                  meta_after_observe.name e_str;
+                  meta_after_cursor_persist.name e_str;
                 Prometheus.inc_counter
                   Prometheus.metric_keeper_heartbeat_failures
-                  ~labels:[("keeper", meta_after_observe.name); ("phase", "fatal_environment")]
+                  ~labels:[("keeper", meta_after_cursor_persist.name); ("phase", "fatal_environment")]
                   ();
                 Keeper_registry.set_failure_reason
-                  ~base_path:ctx.config.base_path meta_after_observe.name
+                  ~base_path:ctx.config.base_path meta_after_cursor_persist.name
                   (Some (Keeper_registry.Exception
                     (Printf.sprintf "fatal environment error: %s" e_str)));
                 raise Keeper_registry.Keeper_fiber_crash
@@ -693,7 +713,7 @@ let run_keepalive_unified_turn
                  [sweep_and_recover] can clear it. *)
               if is_oas_timeout_budget_error err
               then begin
-                let keeper_name = meta_after_observe.name in
+                let keeper_name = meta_after_cursor_persist.name in
                 let prior_strikes =
                   prior_oas_timeout_budget_strikes
                     ~base_path:ctx.config.base_path
@@ -738,32 +758,32 @@ let run_keepalive_unified_turn
                     ] ()
                 end
               end;
-              (match read_meta ctx.config meta_after_observe.name with
+              (match read_meta ctx.config meta_after_cursor_persist.name with
                | Ok (Some latest) -> latest
                | Ok None ->
                  Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"
-                   meta_after_observe.name;
+                   meta_after_cursor_persist.name;
                  Prometheus.inc_counter
                    Prometheus.metric_keeper_meta_read_failures
-                   ~labels:[("keeper", meta_after_observe.name); ("site", "none_after_failure")]
+                   ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "none_after_failure")]
                    ();
-                 meta_after_observe
+                 meta_after_cursor_persist
                | Error e ->
                  Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"
-                   meta_after_observe.name e;
+                   meta_after_cursor_persist.name e;
                  Prometheus.inc_counter
                    Prometheus.metric_keeper_meta_read_failures
-                   ~labels:[("keeper", meta_after_observe.name); ("site", "error_after_failure")]
+                   ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "error_after_failure")]
                    ();
-                 meta_after_observe)
+                 meta_after_cursor_persist)
             | Ok updated ->
               (* PR-M: success clears the strike counter so a single
                  transient budget exhaustion does not trickle into the
                  next 4h-window's strike limit. *)
-              Keeper_turn_slot.reset_budget_exhaustion ~keeper_name:meta_after_observe.name;
+              Keeper_turn_slot.reset_budget_exhaustion ~keeper_name:meta_after_cursor_persist.name;
               clear_oas_timeout_budget_failure_reason
                 ~base_path:ctx.config.base_path
-                ~keeper_name:meta_after_observe.name;
+                ~keeper_name:meta_after_cursor_persist.name;
               updated)
         with
         | Ok meta -> meta
@@ -851,8 +871,8 @@ let run_keepalive_unified_turn
                 last_blocker_class = Some blocker_class;
               })
             meta_after_triage)
-      else if (not has_message_signal) && obs.message_cursor_updates <> [] then
-        meta_after_observe
+      else if obs.message_cursor_updates <> [] then
+        meta_after_cursor_persist
       else
         meta_after_triage
     with

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -74,6 +74,12 @@ val oas_timeout_budget_observation_reasons : string list
 val record_oas_timeout_budget_observation :
   base_path:string -> keeper_name:string -> unit
 
+val persist_message_cursor_updates :
+  config:Coord.config -> keeper_meta -> (string * int) list -> keeper_meta
+(** Persist room-message cursor updates immediately after observation.
+    This is intentionally exposed for the regression that proves a failed
+    turn cannot replay the same scoped messages forever. *)
+
 val run_keepalive_unified_turn :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -435,30 +435,48 @@ let estimate_usage_cost_usd ~(model : string) (usage : Agent_sdk.Types.api_usage
 type cost_status =
   | Cost_reported_or_estimated
   | Cost_known_free
+  | Cost_known_unpriced_model
   | Cost_no_tokens
   | Cost_usage_missing
   | Cost_usage_untrusted
   | Cost_provider_unknown
+  | Cost_unresolved_model_alias
   | Cost_unpriced_model
 
 let cost_status_to_string = function
   | Cost_reported_or_estimated -> "priced"
   | Cost_known_free -> "known_free"
+  | Cost_known_unpriced_model -> "known_unpriced_model"
   | Cost_no_tokens -> "no_tokens"
   | Cost_usage_missing -> "usage_missing"
   | Cost_usage_untrusted -> "usage_untrusted"
   | Cost_provider_unknown -> "provider_unknown"
+  | Cost_unresolved_model_alias -> "unresolved_model_alias"
   | Cost_unpriced_model -> "unpriced_model"
 
 let cost_status_reason = function
   | Cost_reported_or_estimated ->
       "provider_reported_or_pricing_catalog_estimate"
   | Cost_known_free -> "known_structurally_unmetered_or_zero_price"
+  | Cost_known_unpriced_model -> "known_non_catalog_model"
   | Cost_no_tokens -> "no_billable_tokens"
   | Cost_usage_missing -> "usage_missing"
   | Cost_usage_untrusted -> "usage_untrusted"
   | Cost_provider_unknown -> "provider_unknown"
+  | Cost_unresolved_model_alias -> "model_alias_unresolved"
   | Cost_unpriced_model -> "pricing_catalog_miss"
+
+let pricing_model_leaf model =
+  let trimmed = String.trim model in
+  match String.rindex_opt trimmed ':' with
+  | None -> trimmed
+  | Some idx ->
+      String.sub trimmed (idx + 1) (String.length trimmed - idx - 1)
+
+let is_known_non_catalog_pricing_model model =
+  match pricing_model_leaf model with
+  | "gpt-5.3-codex-spark" -> true
+  | _ -> false
 
 let pricing_model_for_ledger ~model ~telemetry =
   match canonical_model_id_opt telemetry with
@@ -478,7 +496,8 @@ let model_resolution_source_for_ledger ~model ~pricing_model =
   else "raw"
 
 let pricing_catalog_status ~pricing_model =
-  if is_unresolved_pricing_label pricing_model then "miss"
+  if is_unresolved_pricing_label pricing_model then "alias_unresolved"
+  else if is_known_non_catalog_pricing_model pricing_model then "known_unpriced"
   else match Llm_provider.Pricing.pricing_for_model_opt pricing_model with
   | Some pricing
     when pricing.input_per_million = 0.0
@@ -501,7 +520,10 @@ let cost_status_for_event
   else if input_tokens <= 0 && output_tokens <= 0 then Cost_no_tokens
   else if structurally_unmetered_provider provider then Cost_known_free
   else if String.equal provider "unknown" then Cost_provider_unknown
-  else if is_unresolved_pricing_label pricing_model then Cost_unpriced_model
+  else if is_unresolved_pricing_label pricing_model then
+    Cost_unresolved_model_alias
+  else if is_known_non_catalog_pricing_model pricing_model then
+    Cost_known_unpriced_model
   else
     match Llm_provider.Pricing.pricing_for_model_opt pricing_model with
     | Some pricing
@@ -646,11 +668,11 @@ let () =
       "Total cost.jsonl emits where cost_usd ended up as 0.0 due to a \
        known classification path (vs an actually-zero call).  Labels: \
        source ∈ {missing_usage, untrusted_usage, unmetered_provider, \
-       pricing_catalog_miss, zero_token_call}.  A high \
-       [pricing_catalog_miss] rate is the hint to add upstream OAS \
-       pricing entries; a high [untrusted_usage] rate points at the \
-       trust classifier; a high [missing_usage] rate points at the \
-       provider adapter not surfacing usage.  See #10318."
+       unresolved_model_alias, known_unpriced_model, pricing_catalog_miss, \
+       zero_token_call}.  A high [pricing_catalog_miss] rate is the hint \
+       to add upstream OAS pricing entries; a high [untrusted_usage] rate \
+       points at the trust classifier; a high [missing_usage] rate points \
+       at the provider adapter not surfacing usage.  See #10318 and #13698."
     ()
 
 let classify_cost_usd_source ~usage_missing ~usage_trusted ~provider
@@ -659,7 +681,8 @@ let classify_cost_usd_source ~usage_missing ~usage_trusted ~provider
   else if not usage_trusted then "untrusted_usage"
   else if structurally_unmetered_provider provider then "unmetered_provider"
   else if cost_usd > 0.0 then "computed"
-  else if is_unresolved_pricing_label model then "pricing_catalog_miss"
+  else if is_unresolved_pricing_label model then "unresolved_model_alias"
+  else if is_known_non_catalog_pricing_model model then "known_unpriced_model"
   else
     match Llm_provider.Pricing.pricing_for_model_opt model with
     | None -> "pricing_catalog_miss"
@@ -744,7 +767,10 @@ let assemble_cost_event_payload
     | Cost_reported_or_estimated -> cost_usd
     | Cost_known_free | Cost_no_tokens -> 0.0
     | Cost_usage_missing | Cost_usage_untrusted -> 0.0
-    | Cost_provider_unknown | Cost_unpriced_model -> 0.0
+    | Cost_provider_unknown
+    | Cost_unresolved_model_alias
+    | Cost_known_unpriced_model
+    | Cost_unpriced_model -> 0.0
   in
   let cost_status_label = cost_status_to_string cost_status in
   let cost_status_reason_label = cost_status_reason cost_status in

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -154,10 +154,14 @@ type cost_status =
       (** Cost trusted: either reported by the provider or estimated from
           tokens against the pricing catalogue. *)
   | Cost_known_free       (** Provider runs locally / structurally unmetered. *)
+  | Cost_known_unpriced_model
+      (** Model is known but intentionally outside the pricing catalogue. *)
   | Cost_no_tokens        (** Usage carried zero tokens and no positive cost. *)
   | Cost_usage_missing    (** Provider returned no usage record. *)
   | Cost_usage_untrusted  (** Usage failed [classify_usage_trust]. *)
   | Cost_provider_unknown (** Provider could not be classified. *)
+  | Cost_unresolved_model_alias
+      (** Model label is an unresolved selector alias such as [auto]. *)
   | Cost_unpriced_model   (** Model has no entry in the pricing catalogue. *)
 (** Per-event cost-ledger verdict. *)
 
@@ -180,9 +184,9 @@ val model_resolution_source_for_ledger :
 
 val pricing_catalog_status : pricing_model:string -> string
 (** Catalogue lookup status for the resolved pricing model
-    (["hit_paid"] / ["hit_free"] / ["miss"]).  Unresolved aliases
-    such as ["auto"] remain misses so missing canonical telemetry is
-    visible in the ledger. *)
+    (["hit_paid"] / ["hit_free"] / ["known_unpriced"] / ["alias_unresolved"] /
+    ["miss"]).  Unresolved aliases such as ["auto"] remain visible in the
+    ledger without being conflated with genuine catalogue misses. *)
 
 val cost_status_for_event :
   provider:string ->

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -19,6 +19,22 @@ let format_mentions (mentions : (string * string) list) : string =
            (Keeper_types.short_preview ~max_len:200 content))
        mentions)
 
+let scope_message_prompt_limit = 12
+let scope_message_preview_len = 120
+
+let take_last_with_omitted limit items =
+  let len = List.length items in
+  if len <= limit then (items, 0)
+  else
+    let rec drop n xs =
+      if n <= 0 then xs
+      else
+        match xs with
+        | [] -> []
+        | _ :: rest -> drop (n - 1) rest
+    in
+    (drop (len - limit) items, len - limit)
+
 (** Format active goals into a prompt section. *)
 let format_goals (goal_ids : string list) : string =
   String.concat "\n"
@@ -26,13 +42,26 @@ let format_goals (goal_ids : string list) : string =
 
 let format_scope_messages
     (messages : (string * string) list) : string =
+  let shown_messages, omitted =
+    take_last_with_omitted scope_message_prompt_limit messages
+  in
+  let omitted_line =
+    if omitted <= 0 then []
+    else
+      [
+        Printf.sprintf
+          "- [omitted %d older scope messages; cursor still advances past the full batch]"
+          omitted;
+      ]
+  in
   String.concat "\n"
-    (List.map
-       (fun (from_agent, content) ->
-         Printf.sprintf "- %s: %s"
-           from_agent
-           (Keeper_types.short_preview ~max_len:200 content))
-       messages)
+    (omitted_line
+     @ List.map
+         (fun (from_agent, content) ->
+           Printf.sprintf "- %s: %s"
+             from_agent
+             (Keeper_types.short_preview ~max_len:scope_message_preview_len content))
+         shown_messages)
 
 let format_board_events
     (events : Keeper_world_observation.pending_board_event list) : string =

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -421,12 +421,7 @@ let status_summary_string (ctx : context) =
     String.equal assignee ctx.agent_name || String.equal assignee actual_name
   in
   let assigned_task_ids =
-    List.filter_map
-      (fun (task : Masc_domain.task) ->
-        match Coord_status_rendering.active_task_assignee task.task_status with
-        | Some assignee when matches_you assignee -> Some task.id
-        | Some _ | None -> None)
-      active_tasks
+    Coord_status_rendering.assigned_task_ids ~matches_you active_tasks
   in
   let binding =
     resolve_current_binding ~assigned_task_ids ~planning_current:current_task

--- a/test/test_cost_ledger_pricing_model_10318.ml
+++ b/test/test_cost_ledger_pricing_model_10318.ml
@@ -154,12 +154,19 @@ let test_catalog_status_miss () =
                  ~pricing_model:"catalog-probe-unknown-model-10318" in
   check string "unknown model → miss" "miss" status
 
-let test_catalog_status_miss_for_auto_alias () =
+let test_catalog_status_unresolved_for_auto_alias () =
   (* "auto" is not in the pricing catalog; once the pricing_model is
-     "auto" (because telemetry was missing), the status must be "miss"
-     so the operator knows to fix telemetry propagation. *)
+     "auto" (because telemetry was missing), the status must stay distinct
+     from real catalog misses so the operator knows to fix telemetry
+     propagation. *)
   let status = H.pricing_catalog_status ~pricing_model:"auto" in
-  check string "auto alias → miss" "miss" status
+  check string "auto alias → alias_unresolved" "alias_unresolved" status
+
+let test_catalog_status_known_unpriced_codex_spark () =
+  let status =
+    H.pricing_catalog_status ~pricing_model:"gpt-5.3-codex-spark"
+  in
+  check string "codex spark preview → known_unpriced" "known_unpriced" status
 
 (* ------------------------------------------------------------------ *)
 (* cost_status_for_event                                               *)
@@ -246,14 +253,23 @@ let test_status_unpriced_model () =
     ~cost_usd:0.0
     "unpriced_model"
 
-let test_status_auto_alias_unpriced_model () =
+let test_status_auto_alias_unresolved_model () =
   check_status
-    ~msg:"known provider + auto alias → unpriced_model"
+    ~msg:"known provider + auto alias → unresolved_model_alias"
     ~provider:"openai" ~pricing_model:"auto"
     ~usage_missing:false ~usage_trusted:true
     ~input_tokens:500 ~output_tokens:200
     ~cost_usd:0.0
-    "unpriced_model"
+    "unresolved_model_alias"
+
+let test_status_known_unpriced_codex_spark () =
+  check_status
+    ~msg:"known provider + codex spark preview → known_unpriced_model"
+    ~provider:"openai" ~pricing_model:"gpt-5.3-codex-spark"
+    ~usage_missing:false ~usage_trusted:true
+    ~input_tokens:500 ~output_tokens:200
+    ~cost_usd:0.0
+    "known_unpriced_model"
 
 (* Trusted + known-paid provider + model in catalog + zero cost (despite
    tokens) → priced status because the catalog hit means we estimated
@@ -293,10 +309,12 @@ let test_status_strings_non_empty () =
   let variants =
     [ H.Cost_reported_or_estimated
     ; H.Cost_known_free
+    ; H.Cost_known_unpriced_model
     ; H.Cost_no_tokens
     ; H.Cost_usage_missing
     ; H.Cost_usage_untrusted
     ; H.Cost_provider_unknown
+    ; H.Cost_unresolved_model_alias
     ; H.Cost_unpriced_model
     ]
   in
@@ -334,7 +352,8 @@ let () =
         [ test_case "known paid → hit_paid"        `Quick test_catalog_status_hit_paid
         ; test_case "known free (ollama) → hit_free" `Quick test_catalog_status_hit_free
         ; test_case "unknown model → miss"         `Quick test_catalog_status_miss
-        ; test_case "auto alias → miss"            `Quick test_catalog_status_miss_for_auto_alias
+        ; test_case "auto alias → alias_unresolved" `Quick test_catalog_status_unresolved_for_auto_alias
+        ; test_case "codex spark preview → known_unpriced" `Quick test_catalog_status_known_unpriced_codex_spark
         ] )
     ; ( "cost_status_for_event",
         [ test_case "usage_missing wins"           `Quick test_status_usage_missing_wins
@@ -344,7 +363,8 @@ let () =
         ; test_case "known_free unmetered"         `Quick test_status_known_free_for_unmetered
         ; test_case "provider_unknown"             `Quick test_status_provider_unknown
         ; test_case "unpriced_model"               `Quick test_status_unpriced_model
-        ; test_case "auto alias unpriced_model"    `Quick test_status_auto_alias_unpriced_model
+        ; test_case "auto alias unresolved"        `Quick test_status_auto_alias_unresolved_model
+        ; test_case "codex spark known unpriced"   `Quick test_status_known_unpriced_codex_spark
         ; test_case "priced real model"            `Quick test_status_priced_path_with_real_model
         ; test_case "known_free via catalog"       `Quick test_status_known_free_via_catalog
         ] )

--- a/test/test_cost_usd_source_attribution_10318.ml
+++ b/test/test_cost_usd_source_attribution_10318.ml
@@ -94,17 +94,26 @@ let test_pricing_catalog_miss_for_unknown_model () =
     ~cost_usd:0.0
     "pricing_catalog_miss"
 
-let test_pricing_catalog_miss_for_auto_alias () =
+let test_unresolved_model_alias_for_auto_alias () =
   (* The OAS catalog may carry zero-price fallback entries for selector
      aliases, but "auto" is not a billable model id. Treating it as
-     free would hide missing canonical telemetry. *)
+     free or a real catalog miss would hide missing canonical telemetry. *)
   check_source
-    ~msg:"auto alias on paid provider => pricing_catalog_miss"
+    ~msg:"auto alias on paid provider => unresolved_model_alias"
     ~usage_missing:false ~usage_trusted:true
     ~provider:"openai"
     ~model:"auto"
     ~cost_usd:0.0
-    "pricing_catalog_miss"
+    "unresolved_model_alias"
+
+let test_known_unpriced_model_for_codex_spark () =
+  check_source
+    ~msg:"codex spark preview => known_unpriced_model"
+    ~usage_missing:false ~usage_trusted:true
+    ~provider:"openai"
+    ~model:"gpt-5.3-codex-spark"
+    ~cost_usd:0.0
+    "known_unpriced_model"
 
 (* --- counter wiring (only non-computed sources tick) ------------- *)
 
@@ -159,8 +168,10 @@ let () =
             test_computed_when_trusted_and_positive;
           test_case "pricing_catalog_miss for unknown model" `Quick
             test_pricing_catalog_miss_for_unknown_model;
-          test_case "pricing_catalog_miss for auto alias" `Quick
-            test_pricing_catalog_miss_for_auto_alias;
+          test_case "unresolved_model_alias for auto alias" `Quick
+            test_unresolved_model_alias_for_auto_alias;
+          test_case "known_unpriced_model for codex spark" `Quick
+            test_known_unpriced_model_for_codex_spark;
         ] );
       ( "counter",
         [

--- a/test/test_keeper_meta_heartbeat_retain_9733.ml
+++ b/test/test_keeper_meta_heartbeat_retain_9733.ml
@@ -57,6 +57,18 @@ let make_meta ~name =
   | Ok m -> m
   | Error e -> fail ("meta_of_json failed: " ^ e)
 
+let read_meta_exn config name =
+  match Keeper_types.read_meta config name with
+  | Ok (Some meta) -> meta
+  | Ok None -> fail ("read_meta returned None for " ^ name)
+  | Error err -> fail ("read_meta failed: " ^ err)
+
+let room_cursor meta room_id =
+  meta.Keeper_types.last_seen_seq_by_room
+  |> List.find_map (fun (rid, seq) ->
+       if String.equal rid room_id then Some seq else None)
+  |> Option.value ~default:0
+
 (* The race we model:
 
    - cycle fiber reads meta at version N (joined_room_ids=[r1])
@@ -145,6 +157,79 @@ let test_no_race_writes_first_attempt () =
     in
     check string "goal landed" "test keeper" on_disk.goal)
 
+let test_message_cursor_updates_persist_before_turn () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let name = "cursor-preturn" in
+    let seed =
+      let m = make_meta ~name in
+      {
+        m with
+        joined_room_ids = [ "default" ];
+        last_seen_seq_by_room = [ ("default", 0) ];
+      }
+    in
+    (match Keeper_types.write_meta ~force:true config seed with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let before = read_meta_exn config name in
+    let returned =
+      Keeper_heartbeat_loop.persist_message_cursor_updates
+        ~config before [ ("default", 42) ]
+    in
+    let final = read_meta_exn config name in
+    check int "returned cursor advanced" 42 (room_cursor returned "default");
+    check int "disk cursor advanced before turn" 42 (room_cursor final "default");
+    check int "returned version follows disk" final.meta_version returned.meta_version;
+    check bool "version bumped" true (final.meta_version > before.meta_version))
+
+let test_message_cursor_updates_merge_after_cas_race () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let name = "cursor-cas-race" in
+    let seed =
+      let m = make_meta ~name in
+      {
+        m with
+        joined_room_ids = [ "default" ];
+        last_seen_seq_by_room = [ ("default", 0) ];
+        goal = "seed";
+      }
+    in
+    (match Keeper_types.write_meta ~force:true config seed with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let observer_view = read_meta_exn config name in
+    let racing_payload =
+      { observer_view with goal = "concurrent writer wins other fields" }
+    in
+    (match Keeper_types.write_meta config racing_payload with
+     | Ok () -> ()
+     | Error e -> fail ("racing write failed: " ^ e));
+    let returned =
+      Keeper_heartbeat_loop.persist_message_cursor_updates
+        ~config observer_view [ ("default", 99) ]
+    in
+    let final = read_meta_exn config name in
+    check string "concurrent field retained"
+      "concurrent writer wins other fields" final.goal;
+    check int "disk cursor advanced after CAS retry" 99
+      (room_cursor final "default");
+    check int "returned cursor advanced after CAS retry" 99
+      (room_cursor returned "default");
+    check bool "version moved past racing write" true
+      (final.meta_version > racing_payload.meta_version))
+
 let () =
   run "Keeper meta heartbeat-retain merge (#9733)"
     [
@@ -154,5 +239,9 @@ let () =
             test_caller_wins_cycle_disk_wins_heartbeat;
           test_case "no race: first attempt succeeds" `Quick
             test_no_race_writes_first_attempt;
+          test_case "message cursor persists before turn" `Quick
+            test_message_cursor_updates_persist_before_turn;
+          test_case "message cursor merge survives CAS race" `Quick
+            test_message_cursor_updates_merge_after_cas_race;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6498,6 +6498,27 @@ let test_tool_query_text_of_user_message_keeps_counted_headers () =
   check bool "keeps counted board activity header" true
     (contains_substring query "### Board Activity (1 new)")
 
+let test_scope_messages_prompt_caps_payload_not_count () =
+  let pending_scope_messages =
+    List.init 15 (fun i ->
+      ( Printf.sprintf "agent-%02d" i,
+        Printf.sprintf "message-%02d %s" i (String.make 220 'x') ))
+  in
+  let obs = { base_observation with pending_scope_messages } in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check bool "header keeps real scope message count" true
+    (contains_substring user "### Scope Messages (15 recent)");
+  check bool "older scope messages are summarized" true
+    (contains_substring user "omitted 3 older scope messages");
+  check bool "oldest omitted message absent" false
+    (contains_substring user "message-00");
+  check bool "newest retained message present" true
+    (contains_substring user "message-14");
+  check bool "long scope message preview capped" false
+    (contains_substring user (String.make 180 'x'))
+
 let test_social_model_silences_skip_only_turn () =
   let result =
     make_run_result
@@ -7869,6 +7890,8 @@ let () =
             test_tool_query_text_of_user_message_strips_continuity_noise;
           test_case "tool query keeps counted headers" `Quick
             test_tool_query_text_of_user_message_keeps_counted_headers;
+          test_case "scope messages cap prompt payload not count" `Quick
+            test_scope_messages_prompt_caps_payload_not_count;
           test_case "social model registry round trip" `Quick
             test_social_model_registry_round_trip;
           test_case "social model silences skip-only turn" `Quick


### PR DESCRIPTION
## Why

Live `/Users/dancer/me/.masc/costs.jsonl` sampling in #13698 showed `gpt-5.3-codex-spark` and `auto` as current top zero-cost `pricing_catalog_miss` rows. Those are different operator actions: `auto` means canonical model telemetry was not resolved, while `gpt-5.3-codex-spark` is a known Codex Spark preview/current model that should not be reported as an ordinary upstream catalog miss.

[근거] OpenAI API pricing page, checked 2026-05-06 Asia/Seoul, confidence High: pricing is published for `gpt-5.3-codex`, but not for `gpt-5.3-codex-spark`. https://developers.openai.com/api/docs/pricing

[근거] OpenAI Codex Spark launch note, checked 2026-05-06 Asia/Seoul, confidence High: Spark is described as a research-preview / limited API path, so this patch classifies it as known non-catalog instead of inventing a token price. https://openai.com/index/introducing-gpt-5-3-codex-spark/

## Changes

- Split unresolved selector aliases into `alias_unresolved` / `unresolved_model_alias`.
- Split current known non-catalog Codex Spark rows into `known_unpriced` / `known_unpriced_model`.
- Preserve unknown concrete model IDs as `miss` / `pricing_catalog_miss` so genuine catalog gaps remain visible.
- Extend #10318 cost-ledger tests for `auto`, `gpt-5.3-codex-spark`, and unknown concrete model behavior.

## Dependency

Stacked on #13711 (`fix/message-cursor-preturn-0506`) because current main validation was blocked by the keeper cursor / coord-status build unblocker. Retarget this PR to `main` after #13711 lands.

Addresses #13698.

## Validation

- `git diff --check origin/fix/message-cursor-preturn-0506...HEAD`
- `ocamlc -stop-after parsing -impl lib/keeper/keeper_hooks_oas.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_hooks_oas.mli`
- `ocamlc -stop-after parsing -impl test/test_cost_ledger_pricing_model_10318.ml`
- `ocamlc -stop-after parsing -impl test/test_cost_usd_source_attribution_10318.ml`
- `scripts/dune-local.sh build test/test_cost_ledger_pricing_model_10318.exe test/test_cost_usd_source_attribution_10318.exe`
- `./_build/default/test/test_cost_ledger_pricing_model_10318.exe` - 28 tests passed
- `./_build/default/test/test_cost_usd_source_attribution_10318.exe` - 10 tests passed
