### PR TITLE
fix(keeper): unblock runtime tool surfaces

### DIFF
--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -62,6 +62,14 @@ let active_task_assignee = function
       Some assignee
   | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
+let assigned_task_ids ~matches_you tasks =
+  List.filter_map
+    (fun (task : Masc_domain.task) ->
+      match active_task_assignee task.task_status with
+      | Some assignee when matches_you assignee -> Some task.id
+      | Some _ | None -> None)
+    tasks
+
 let add_unique table key value =
   let values = Option.value (Hashtbl.find_opt table key) ~default:[] in
   if List.exists (String.equal value) values then ()

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -231,7 +231,12 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   in
   if has_turn_affordance Board_curation turn_affordances
      && progress_tool_available "keeper_board_curation_submit"
-  then Agent_sdk.Types.Tool "keeper_board_curation_submit"
+  then
+    (* Keep the curation submit tool visible, but do not force exact
+       tool_choice. Several keeper cascades can use runtime MCP tools while
+       lacking inline exact-tool-choice support; exact forcing turns those
+       productive lanes into spurious pause-human failures. *)
+    Agent_sdk.Types.Any
   else if (not has_current_task)
      && has_task_claim_affordance turn_affordances
      && progress_tool_available "keeper_task_claim"
@@ -239,12 +244,14 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   else if has_turn_affordance Task_audit turn_affordances
           && progress_tool_available "keeper_tasks_audit"
   then Agent_sdk.Types.Tool "keeper_tasks_audit"
-  else if has_turn_affordance Task_verify turn_affordances
+  else if has_current_task
+          && has_turn_affordance Task_verify turn_affordances
           && progress_tool_available "keeper_task_submit_for_verification"
-  then Agent_sdk.Types.Tool "keeper_task_submit_for_verification"
-  else if has_turn_affordance Task_verify turn_affordances
+  then Agent_sdk.Types.Any
+  else if has_current_task
+          && has_turn_affordance Task_verify turn_affordances
           && progress_tool_available "keeper_task_done"
-  then Agent_sdk.Types.Tool "keeper_task_done"
+  then Agent_sdk.Types.Any
   else if not has_current_task then
     (* #10008: no active task and no applicable specific claim tool
        to force.  Fall back to [Auto] instead of [Any] so the model

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -237,13 +237,42 @@ let content_blocks_to_json
 let content_blocks_of_json
     (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
   let open Yojson.Safe.Util in
-  match json |> member "content_blocks" with
+  let parse_block_list = function
+    | `List blocks ->
+        let parsed =
+          List.filter_map Agent_sdk.Api.content_block_of_json blocks
+        in
+        if List.length parsed = List.length blocks then Some parsed else None
+    | _ -> None
+  in
+  match parse_block_list (json |> member "content_blocks") with
+  | Some _ as blocks -> blocks
+  | None ->
+      (* Some OAS/OpenAI-style checkpoints use a structured [content] array
+         instead of MASC's [content_blocks] field. Treat that as the same
+         block source rather than forcing the legacy flat-string path. *)
+      parse_block_list (json |> member "content")
+
+let legacy_content_text_of_json (json : Yojson.Safe.t) : string =
+  let open Yojson.Safe.Util in
+  match json |> member "content" with
+  | `String value -> Inference_utils.sanitize_text_utf8 value
+  | `Null -> ""
   | `List blocks ->
       let parsed =
         List.filter_map Agent_sdk.Api.content_block_of_json blocks
       in
-      if List.length parsed = List.length blocks then Some parsed else None
-  | _ -> None
+      let msg : Agent_sdk.Types.message =
+        {
+          Agent_sdk.Types.role = Agent_sdk.Types.User;
+          content = parsed;
+          name = None;
+          tool_call_id = None;
+          metadata = [];
+        }
+      in
+      Inference_utils.sanitize_text_utf8 (text_of_message msg)
+  | _ -> ""
 
 let string_field_opt key value =
   match value with
@@ -289,11 +318,7 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
 let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
-  let text =
-    match json |> member "content" |> to_string_option with
-    | Some value -> Inference_utils.sanitize_text_utf8 value
-    | None -> ""
-  in
+  let text = legacy_content_text_of_json json in
   let content =
     match content_blocks_of_json json with
     | Some blocks ->
@@ -340,9 +365,7 @@ let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
       in
       Inference_utils.sanitize_text_utf8 (text_of_message msg)
   | _ ->
-      (match json |> member "content" |> to_string_option with
-       | Some value -> Inference_utils.sanitize_text_utf8 value
-       | None -> "")
+      legacy_content_text_of_json json
 
 let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
   List.filter_map

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -863,8 +863,11 @@ let run_keepalive_unified_turn
         Prometheus.metric_keeper_cycle_exceptions
         ~labels:[("keeper", meta_after_triage.name)]
         ();
-      Log.Keeper.error "%s: keeper cycle exception: %s"
-        meta_after_triage.name (Printexc.to_string exn);
+      let backtrace = Printexc.get_backtrace () in
+      Log.Keeper.error "%s: keeper cycle exception: %s%s"
+        meta_after_triage.name
+        (Printexc.to_string exn)
+        (if String.equal backtrace "" then "" else "\n" ^ backtrace);
       meta_after_triage)
 ;;
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1649,7 +1649,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             end))
         with
         | result -> cleanup (); result
-        | exception e -> cleanup (); raise e
+        | exception e ->
+            let backtrace = Printexc.get_raw_backtrace () in
+            cleanup ();
+            Printexc.raise_with_backtrace e backtrace
       in
       let turn_event_bus = drain_turn_event_bus ~site:"turn_finalize_capture" () in
       (match turn_event_bus.correlation_id with

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -150,14 +150,59 @@ let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
 
 (** {1 Schema Conversion}
 
-    Delegates to [Agent_sdk.Mcp.json_schema_to_params] — the canonical
-    JSON Schema to OAS [tool_param list] conversion.
-
-    @since 2.221.0 — delegates to OAS Mcp module (removes 40-line duplicate) *)
+    Convert MASC JSON Schemas into the narrower OAS [tool_param list]
+    representation. Keep this adapter tolerant: MASC schemas may contain
+    JSON Schema unions such as ["object"; "string"; "array"], while the
+    OAS param model has a single scalar [param_type]. *)
 
 let param_type_of_string = Agent_sdk.Mcp.json_schema_type_to_param_type
 
-let params_of_json_schema = Agent_sdk.Mcp.json_schema_to_params
+let string_of_json_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value -> Some value
+  | _ -> None
+
+let type_string_of_schema_property prop =
+  match Yojson.Safe.Util.member "type" prop with
+  | `String value -> Some value
+  | `List values ->
+      List.find_map
+        (function
+          | `String value when not (String.equal value "null") -> Some value
+          | _ -> None)
+        values
+  | _ -> None
+
+let params_of_json_schema schema =
+  let open Yojson.Safe.Util in
+  let required_list =
+    match schema |> member "required" with
+    | `List items ->
+        List.filter_map
+          (function
+            | `String value -> Some value
+            | _ -> None)
+          items
+    | _ -> []
+  in
+  match schema |> member "properties" with
+  | `Assoc pairs ->
+      List.map
+        (fun (name, prop) ->
+          let param_type =
+            prop
+            |> type_string_of_schema_property
+            |> Option.value ~default:"string"
+            |> param_type_of_string
+          in
+          let description =
+            string_of_json_member "description" prop
+            |> Option.value ~default:""
+          in
+          let required = List.mem name required_list in
+          { Agent_sdk.Types.name = name; description; param_type; required })
+        pairs
+  | _ -> []
 
 (** {1 OAS Tool.t Creation}
 

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -421,12 +421,7 @@ let status_summary_string (ctx : context) =
     String.equal assignee ctx.agent_name || String.equal assignee actual_name
   in
   let assigned_task_ids =
-    List.filter_map
-      (fun (task : Masc_domain.task) ->
-        match Coord_status_rendering.active_task_assignee task.task_status with
-        | Some assignee when matches_you assignee -> Some task.id
-        | Some _ | None -> None)
-      active_tasks
+    Coord_status_rendering.assigned_task_ids ~matches_you active_tasks
   in
   let binding =
     resolve_current_binding ~assigned_task_ids ~planning_current:current_task

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -67,6 +67,31 @@ let test_message_of_json_new_content_blocks_only () =
   | [ T.Text s ] -> Alcotest.(check string) "text" "world" s
   | _ -> Alcotest.fail "expected one Text block"
 
+let test_message_of_json_legacy_content_array () =
+  (* OAS/OpenAI-style legacy checkpoints may store structured blocks under
+     content instead of content_blocks. This must not raise Type_error. *)
+  let source : T.message =
+    {
+      T.role = T.Assistant;
+      content = [ T.Text "array payload" ];
+      name = None;
+      tool_call_id = None;
+      metadata = [];
+    }
+  in
+  let content_blocks =
+    match C.message_to_json source with
+    | `Assoc fields -> List.assoc "content_blocks" fields
+    | _ -> Alcotest.fail "expected object"
+  in
+  let legacy : Yojson.Safe.t =
+    `Assoc [ ("role", `String "assistant"); ("content", content_blocks) ]
+  in
+  let parsed = C.message_of_json legacy in
+  match parsed.content with
+  | [ T.Text s ] -> Alcotest.(check string) "text" "array payload" s
+  | _ -> Alcotest.fail "expected one Text block"
+
 (* --- text_of_history_jsonl_json --- *)
 
 let test_history_jsonl_text_uses_blocks_first () =
@@ -93,6 +118,27 @@ let test_history_jsonl_text_legacy_fallback () =
   in
   let text = C.text_of_history_jsonl_json legacy in
   Alcotest.(check string) "fallback to flat content" "legacy payload" text
+
+let test_history_jsonl_text_legacy_content_array () =
+  let source : T.message =
+    {
+      T.role = T.User;
+      content = [ T.Text "array history payload" ];
+      name = None;
+      tool_call_id = None;
+      metadata = [];
+    }
+  in
+  let content_blocks =
+    match C.message_to_json source with
+    | `Assoc fields -> List.assoc "content_blocks" fields
+    | _ -> Alcotest.fail "expected object"
+  in
+  let legacy : Yojson.Safe.t =
+    `Assoc [ ("role", `String "user"); ("content", content_blocks) ]
+  in
+  let text = C.text_of_history_jsonl_json legacy in
+  Alcotest.(check string) "text from array content" "array history payload" text
 
 let test_history_jsonl_text_empty_when_neither () =
   let empty : Yojson.Safe.t = `Assoc [ ("role", `String "user") ] in
@@ -185,6 +231,8 @@ let () =
             test_message_of_json_legacy_content_only;
           Alcotest.test_case "new content_blocks-only loads" `Quick
             test_message_of_json_new_content_blocks_only;
+          Alcotest.test_case "legacy content array loads" `Quick
+            test_message_of_json_legacy_content_array;
           Alcotest.test_case "round-trip text preserved" `Quick
             test_roundtrip_text_preserved;
         ] );
@@ -194,6 +242,8 @@ let () =
             test_history_jsonl_text_uses_blocks_first;
           Alcotest.test_case "legacy fallback" `Quick
             test_history_jsonl_text_legacy_fallback;
+          Alcotest.test_case "legacy content array fallback" `Quick
+            test_history_jsonl_text_legacy_content_array;
           Alcotest.test_case "empty when neither" `Quick
             test_history_jsonl_text_empty_when_neither;
         ] );

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7283,13 +7283,11 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
          ]
        ()
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "board curation prefers submit tool"
-         "keeper_board_curation_submit" name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_board_curation_submit, got %s"
+            "expected Any for board curation required turn, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
@@ -7352,13 +7350,25 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
          [ "keeper_tasks_list"; "keeper_task_submit_for_verification" ]
        ()
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "task verify prefers submit tool"
-         "keeper_task_submit_for_verification" name
+   | Agent_sdk.Types.Auto -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_task_submit_for_verification, got %s"
+            "expected Auto for idle task verify turn, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     choose
+       ~has_current_task:true
+       ~turn_affordances:[ "task_verify" ]
+       ~allowed_tool_names:
+         [ "keeper_tasks_list"; "keeper_task_submit_for_verification" ]
+       ()
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+       fail
+         (Printf.sprintf
+            "expected Any for active task verify turn, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match choose ~allowed_tool_names:[ "keeper_board_post" ] () with
   | Agent_sdk.Types.Auto -> ()

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -250,6 +250,43 @@ let test_empty_schema_passes () =
   | Proceed _ -> Alcotest.fail "Empty schema should Pass"
   | Reject r -> Alcotest.fail (Yojson.Safe.to_string r.data)
 
+let test_schema_union_type_does_not_raise () =
+  let schema =
+    `Assoc
+      [
+        ("type", `String "object");
+        ( "properties",
+          `Assoc
+            [
+              ( "quantitative_evidence",
+                `Assoc
+                  [
+                    ( "type",
+                      `List
+                        [ `String "object"; `String "string"; `String "array" ]
+                    );
+                    ( "description",
+                      `String
+                        "Required for code-count or line-number claims."
+                    );
+                  ] );
+            ] );
+      ]
+  in
+  match Tool_bridge.params_of_json_schema schema with
+  | [ (param : Agent_sdk.Types.tool_param) ] ->
+      Alcotest.(check string)
+        "name"
+        "quantitative_evidence"
+        param.name;
+      Alcotest.(check bool) "optional" false param.required;
+      (match param.param_type with
+       | Agent_sdk.Types.Object -> ()
+       | _ -> Alcotest.fail "expected first non-null union type to be object")
+  | params ->
+      Alcotest.failf "expected one converted parameter, got %d"
+        (List.length params)
+
 (* ================================================================ *)
 (* Test: registered pre-hook path                                    *)
 (* ================================================================ *)
@@ -421,6 +458,8 @@ let () =
       Alcotest.test_case "null args with required" `Quick test_null_args_with_required;
       Alcotest.test_case "extra fields allowed" `Quick test_extra_fields_allowed;
       Alcotest.test_case "empty schema passes" `Quick test_empty_schema_passes;
+      Alcotest.test_case "schema union type does not raise" `Quick
+        test_schema_union_type_does_not_raise;
     ]);
     ("registered_hook", [
       Alcotest.test_case "coercion flows through registered hook" `Quick


### PR DESCRIPTION
## Summary
- implement the missing `Coord_status_rendering.assigned_task_ids` helper so the live server target rebuilds from this branch
- tolerate JSON Schema union `type` arrays in `Tool_bridge.params_of_json_schema`, fixing keeper tool-bundle crashes on `keeper_board_post.quantitative_evidence`
- harden legacy structured `content` history parsing and preserve keeper-cycle backtraces across cleanup
- relax exact tool-choice forcing for board-curation/task-verification turns to `Any`, while keeping MASC substantive-tool post-run validation

## Why this matters
The live keeper runtime was failing before providers could act: MASC schemas can contain JSON Schema unions such as `["object", "string", "array"]`, but the upstream OAS adapter assumed `type` was a single string and raised `Yojson__Safe.Util.Type_error("Expected string or null, got array", _)` while building keeper tool bundles. That made keepers crash/livelock instead of reacting to board/task work.

After the schema adapter fix, keepers reached real turns again: board posts were created, board wakeups were emitted, and keeper Docker worktree prep/restoration happened under `/Users/dancer/me/.masc/playground/docker/...`. The next failure class was exact `require_specific_tool(...)` pressure on providers that can use runtime MCP tools but cannot reliably honor inline exact tool choice, so this PR keeps the required-tool contract but lets any substantive keeper tool satisfy the turn.

## Verification
- `git diff --check`
- `env DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506/_build_schema_probe opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506 -j 2 test/test_tool_input_validation.exe`
- `env DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506/_build_schema_probe opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506 -j 2 test/test_keeper_context_core_dedup.exe`
- `env DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506/_build_schema_probe opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506 -j 2 test/test_keeper_unified.exe`
- `env DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506/_build_schema_probe opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-coord-status-rendering-helper-0506 -j 2 bin/main_eio.exe`
- live `/health` on `127.0.0.1:8935` reported this branch/commit with `effective_base_path=/Users/dancer/me` before a competing local Codex session reclaimed the shared 8935 runtime
- live post-fix logs showed keeper board posts, board signal wakeups, and Docker worktree prep/restoration under `/Users/dancer/me/.masc/playground/docker/...`

## Notes
- This remains draft. CI is still the merge gate.
- A separate local Codex session (`codex resume 019df680-8bc7-70a0-8e22-7b9b6c58c859`) is supervising another `8935` server from `port-fleet-audit-pr-lifecycle-0506`, so sustained live verification of this exact head could not keep ownership of the shared base-path runtime.
