### PR TITLE
fix(dashboard): fail fast repeated cache timeouts

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -81,6 +81,64 @@ let maybe_evict map =
 
 let now () = Time_compat.now ()
 
+type timeout_circuit = {
+  consecutive_timeouts : int;
+  opened_until : float;
+  last_timeout_at : float;
+}
+
+let timeout_circuit_threshold = 3
+let timeout_circuit_open_sec = 30.0
+let timeout_circuit_window_sec = 300.0
+let timeout_circuit_table : timeout_circuit SMap.t Atomic.t = Atomic.make SMap.empty
+
+let timeout_circuit_is_open key =
+  match SMap.find_opt key (Atomic.get timeout_circuit_table) with
+  | Some state when state.opened_until > now () -> true
+  | _ -> false
+
+let record_timeout_circuit key =
+  let ts = now () in
+  let opened =
+    atomic_update timeout_circuit_table (fun map ->
+      let previous = SMap.find_opt key map in
+      let consecutive_timeouts =
+        match previous with
+        | Some state
+          when ts -. state.last_timeout_at <= timeout_circuit_window_sec ->
+            state.consecutive_timeouts + 1
+        | _ -> 1
+      in
+      let was_open =
+        match previous with
+        | Some state when state.opened_until > ts -> true
+        | _ -> false
+      in
+      let opened_until =
+        if consecutive_timeouts >= timeout_circuit_threshold then
+          ts +. timeout_circuit_open_sec
+        else
+          0.0
+      in
+      ( consecutive_timeouts >= timeout_circuit_threshold && not was_open,
+        SMap.add key
+          { consecutive_timeouts; opened_until; last_timeout_at = ts }
+          map ))
+  in
+  if opened then
+    Log.Dashboard.warn
+      "cache: opening timeout circuit for %s after repeated no-stale timeouts"
+      key
+
+let clear_timeout_circuit key =
+  atomic_update timeout_circuit_table (fun map -> ((), SMap.remove key map))
+
+let clear_timeout_circuit_prefix prefix =
+  atomic_update timeout_circuit_table (fun map ->
+    ((), SMap.filter (fun key _ -> not (String.starts_with ~prefix key)) map))
+
+let clear_timeout_circuit_all () = Atomic.set timeout_circuit_table SMap.empty
+
 (** Default stale grace multiplier: stale data is served for [ttl * stale_factor]
     seconds after expiry while recomputation runs in the background.
     Reduced from 10x to 3x — the 10x factor was masking slow compute
@@ -394,8 +452,12 @@ let get_or_compute_simple key ~ttl compute =
        raise exn)
 
 let get_or_compute key ~ttl compute =
-  if Eio_guard.is_ready () then get_or_compute_eio key ~ttl compute
-  else get_or_compute_simple key ~ttl compute
+  let value =
+    if Eio_guard.is_ready () then get_or_compute_eio key ~ttl compute
+    else get_or_compute_simple key ~ttl compute
+  in
+  clear_timeout_circuit key;
+  value
 
 let peek key =
   let ts = now () in
@@ -405,13 +467,22 @@ let peek key =
   | Some (Computing { stale = Some stale_value; _ }) -> Some stale_value
   | _ -> None
 
-let timeout_error_json ?(waiting = false) key timeout_sec =
+let timeout_error_json ?timeout_kind ?(waiting = false) key timeout_sec =
+  let timeout_kind =
+    match timeout_kind with
+    | Some timeout_kind -> timeout_kind
+    | None -> if waiting then "waiter" else "owner"
+  in
   let message =
-    if waiting then
+    match timeout_kind with
+    | "circuit_open" ->
+      Printf.sprintf
+        "Dashboard %s is failing fast after repeated cache timeouts" key
+    | _ when waiting ->
       Printf.sprintf
         "Dashboard %s timed out after %.0fs waiting for an in-flight computation"
         key timeout_sec
-    else
+    | _ ->
       Printf.sprintf "Dashboard %s timed out after %.0fs" key timeout_sec
   in
   `Assoc
@@ -419,36 +490,44 @@ let timeout_error_json ?(waiting = false) key timeout_sec =
       ("error", `String "computation_timeout");
       ("message", `String message);
       ("generated_at", `String (Masc_domain.now_iso ()));
-      ("timeout_kind", `String (if waiting then "waiter" else "owner"));
+      ("timeout_kind", `String timeout_kind);
       ("timeout_sec", `Float timeout_sec);
       ("key", `String key);
     ]
 
 let get_or_compute_with_timeout key ~ttl ~clock ~timeout_sec compute =
-  try
-    if Eio_guard.is_ready () then
-      get_or_compute_eio ~wait_timeout_sec:timeout_sec key ~ttl (fun () ->
-        match
-          Eio.Time.with_timeout clock timeout_sec (fun () ->
-            Ok (compute ()))
-        with
-        | Ok value -> value
-        | Error `Timeout ->
-          Log.Dashboard.warn "cache compute timeout: %s (%.0fs)" key timeout_sec;
-          raise (Compute_timeout (key, false)))
-    else
-      get_or_compute_simple key ~ttl (fun () ->
-        match
-          Eio.Time.with_timeout clock timeout_sec (fun () ->
-            Ok (compute ()))
-        with
-        | Ok value -> value
-        | Error `Timeout ->
-          Log.Dashboard.warn "cache compute timeout: %s (%.0fs)" key timeout_sec;
-          raise (Compute_timeout (key, false)))
-  with
-  | Compute_timeout (key, waiting) ->
-      timeout_error_json ~waiting key timeout_sec
+  if Option.is_none (peek key) && timeout_circuit_is_open key then
+    timeout_error_json ~timeout_kind:"circuit_open" key timeout_sec
+  else
+    try
+      let value =
+        if Eio_guard.is_ready () then
+          get_or_compute_eio ~wait_timeout_sec:timeout_sec key ~ttl (fun () ->
+            match
+              Eio.Time.with_timeout clock timeout_sec (fun () ->
+                Ok (compute ()))
+            with
+            | Ok value -> value
+            | Error `Timeout ->
+              Log.Dashboard.warn "cache compute timeout: %s (%.0fs)" key timeout_sec;
+              raise (Compute_timeout (key, false)))
+        else
+          get_or_compute_simple key ~ttl (fun () ->
+            match
+              Eio.Time.with_timeout clock timeout_sec (fun () ->
+                Ok (compute ()))
+            with
+            | Ok value -> value
+            | Error `Timeout ->
+              Log.Dashboard.warn "cache compute timeout: %s (%.0fs)" key timeout_sec;
+              raise (Compute_timeout (key, false)))
+      in
+      clear_timeout_circuit key;
+      value
+    with
+    | Compute_timeout (key, waiting) ->
+        record_timeout_circuit key;
+        timeout_error_json ~waiting key timeout_sec
 
 let seed_stale_if_missing key ~stale_for value =
   let ts = now () in
@@ -458,17 +537,21 @@ let seed_stale_if_missing key ~stale_for value =
       | None ->
           ((), SMap.add key
             (Ready { value; expires_at = ts; stale_until = ts +. stale_for })
-            map))
+            map));
+  clear_timeout_circuit key
 
 let invalidate key =
-  atomic_update table (fun map -> ((), SMap.remove key map))
+  atomic_update table (fun map -> ((), SMap.remove key map));
+  clear_timeout_circuit key
 
 let invalidate_prefix prefix =
   atomic_update table (fun map ->
-    ((), SMap.filter (fun k _ -> not (String.starts_with ~prefix k)) map))
+    ((), SMap.filter (fun k _ -> not (String.starts_with ~prefix k)) map));
+  clear_timeout_circuit_prefix prefix
 
 let invalidate_all () =
-  Atomic.set table SMap.empty
+  Atomic.set table SMap.empty;
+  clear_timeout_circuit_all ()
 
 let stats () =
   let map = Atomic.get table in

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -43,7 +43,9 @@ val get_or_compute_with_timeout :
 (** Like [get_or_compute] but wraps the compute function with an Eio timeout.
     On timeout in the stale-while-revalidate path, the stale value is
     preserved (not overwritten by error JSON).  On timeout with no stale
-    data, returns a timeout-error JSON without caching it. *)
+    data, returns a timeout-error JSON without caching it.  Repeated no-stale
+    timeouts for the same key open a short fail-fast circuit; fresh or stale
+    cache entries are still served normally. *)
 
 val seed_stale_if_missing :
   string -> stale_for:float -> Yojson.Safe.t -> unit

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -12,6 +12,9 @@ let check_json msg expected actual =
     (Yojson.Safe.to_string expected)
     (Yojson.Safe.to_string actual)
 
+let timeout_kind json =
+  Yojson.Safe.Util.(member "timeout_kind" json |> to_string)
+
 (* -- 1. Nested get_or_compute must not deadlock ----------------------------- *)
 
 let test_nested_no_deadlock () =
@@ -356,7 +359,48 @@ let test_timeout_no_stale_returns_error ~clock () =
   in
   check_json "recompute after timeout" (`String "recovered") v2
 
-(* -- 12. Waiter timeout returns fast error without poisoning cache --------- *)
+(* -- 12. Repeated no-stale timeouts open a fail-fast circuit --------------- *)
+
+(** A hot dashboard key with no stale fallback should not keep spending the
+    full caller timeout on every request.  After repeated owner timeouts, the
+    key fails fast without caching timeout JSON into the normal cache table. *)
+let test_repeated_no_stale_timeout_opens_circuit ~clock () =
+  Dashboard_cache.invalidate_all ();
+  let computes = Atomic.make 0 in
+  let slow_compute () =
+    Atomic.incr computes;
+    Eio.Time.sleep clock 1.0;
+    `String "never_reached"
+  in
+  for _ = 1 to 3 do
+    let result =
+      Dashboard_cache.get_or_compute_with_timeout "circuit_timeout" ~ttl:1.0
+        ~clock ~timeout_sec:0.05 slow_compute
+    in
+    Alcotest.(check string) "owner timeout kind" "owner"
+      (timeout_kind result)
+  done;
+  let fail_fast =
+    Dashboard_cache.get_or_compute_with_timeout "circuit_timeout" ~ttl:1.0
+      ~clock ~timeout_sec:0.05 slow_compute
+  in
+  Alcotest.(check string) "circuit timeout kind" "circuit_open"
+    (timeout_kind fail_fast);
+  Alcotest.(check int) "circuit avoids fourth compute" 3
+    (Atomic.get computes);
+  Dashboard_cache.invalidate "circuit_timeout";
+  let recovered =
+    Dashboard_cache.get_or_compute_with_timeout "circuit_timeout" ~ttl:1.0
+      ~clock ~timeout_sec:0.5 (fun () ->
+        Atomic.incr computes;
+        `String "recovered")
+  in
+  check_json "invalidate clears timeout circuit" (`String "recovered")
+    recovered;
+  Alcotest.(check int) "compute allowed after invalidate" 4
+    (Atomic.get computes)
+
+(* -- 13. Waiter timeout returns fast error without poisoning cache --------- *)
 
 (** When another fiber already owns the compute slot, waiters should honor the
     caller's timeout budget instead of waiting for the global 130s eviction.
@@ -481,6 +525,8 @@ let () =
             (test_expired_stale_restored_on_timeout ~clock);
           test_case "no-stale timeout returns error, not cached" `Quick
             (test_timeout_no_stale_returns_error ~clock);
+          test_case "repeated no-stale timeout opens circuit" `Quick
+            (test_repeated_no_stale_timeout_opens_circuit ~clock);
           test_case "waiter timeout returns error, not cached" `Quick
             (test_waiter_timeout_returns_error_not_cached ~clock);
         ] );


### PR DESCRIPTION
## Summary

- Add a per-key no-stale timeout circuit to `Dashboard_cache.get_or_compute_with_timeout`.
- Keep timeout JSON out of the normal cache table while failing fast after repeated owner/waiter timeouts.
- Preserve fresh/stale cache serving and clear the circuit on successful reads or explicit invalidation.
- Add a regression test for repeated no-stale timeouts opening and clearing the circuit.
- Rebase onto current `main` and carry a small `Coord.clear_agent_current_task_cache` compile fix for the current OAS SDK/main boundary.

## Issue

- Refs #10544

## Validation

- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 DUNE_BUILD_DIR=$PWD/_build_dashboard_cache_verify scripts/dune-local.sh build test/test_dashboard_cache.exe`
- `./_build_dashboard_cache_verify/default/test/test_dashboard_cache.exe` (20 tests pass)

## Guardrails

- Draft PR only.
