### PR TITLE
fix(metrics): expose runtime memory usage

### DIFF
--- a/lib/gc_sampler.ml
+++ b/lib/gc_sampler.ml
@@ -1,5 +1,7 @@
 (** GC stats sampler. Polls [Gc.quick_stat] every [interval] seconds and
-    exports six gauges via {!Prometheus}. See [.mli] for contract. *)
+    exports runtime heap gauges via {!Prometheus}. See [.mli] for contract. *)
+
+let word_size_bytes = float_of_int (Sys.word_size / 8)
 
 let sample_once () =
   let s = Gc.quick_stat () in
@@ -10,6 +12,8 @@ let sample_once () =
     (float_of_int s.heap_words);
   Prometheus.set_gauge Prometheus.metric_gc_live_words
     (float_of_int s.live_words);
+  Prometheus.set_gauge Prometheus.metric_memory_usage_bytes
+    (float_of_int s.live_words *. word_size_bytes);
   Prometheus.set_gauge Prometheus.metric_gc_compactions
     (float_of_int s.compactions)
 

--- a/lib/gc_sampler.mli
+++ b/lib/gc_sampler.mli
@@ -1,9 +1,14 @@
 (** OCaml GC stats sampler for Prometheus export.
 
-    Polls [Gc.quick_stat] once per [interval] seconds and writes the six
+    Polls [Gc.quick_stat] once per [interval] seconds and writes the seven
     {!Prometheus} GC gauge metrics ([masc_gc_minor_words],
     [masc_gc_major_words], [masc_gc_heap_words], [masc_gc_live_words],
-    [masc_gc_compactions], [masc_gc_promoted_words]).
+    [masc_gc_compactions], [masc_gc_promoted_words],
+    [masc_memory_usage_bytes]).
+
+    [masc_memory_usage_bytes] is the Phase 0.5 [memory_usage] signal for
+    runtime heap pressure. It is derived from [live_words] and [Sys.word_size],
+    so it tracks live OCaml heap bytes rather than process RSS.
 
     [Gc.quick_stat] does not walk the heap, so the call cost is bounded
     and safe to run on a 30s loop alongside the request path.
@@ -11,7 +16,7 @@
     @since PR-0.2.D (RFC pack: knowledge/research/2026-04-masc-ide-strategy/) *)
 
 val sample_once : unit -> unit
-(** [sample_once ()] reads [Gc.quick_stat] once and updates the six
+(** [sample_once ()] reads [Gc.quick_stat] once and updates the seven
     Prometheus GC gauges. Exposed for unit tests so the sampler can be
     exercised without spawning an Eio fiber. *)
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -899,6 +899,7 @@ let metric_gc_heap_words = "masc_gc_heap_words"
 let metric_gc_live_words = "masc_gc_live_words"
 let metric_gc_compactions = "masc_gc_compactions"
 let metric_gc_promoted_words = "masc_gc_promoted_words"
+let metric_memory_usage_bytes = "masc_memory_usage_bytes"
 
 let metric_sse_connections_active = "masc_sse_connections_active"
 let metric_sse_reconnects = "masc_sse_reconnects_total"
@@ -1328,6 +1329,9 @@ let init () =
   add metric_gc_promoted_words
     "Cumulative words promoted from minor to major heap since program \
      start (from Gc.quick_stat)" Gauge;
+  add metric_memory_usage_bytes
+    "Approximate live OCaml heap memory usage in bytes, derived from \
+     Gc.quick_stat live_words and Sys.word_size" Gauge;
   add metric_sse_connections_active "Active SSE connections" Gauge;
   add metric_sse_reconnects "Total SSE reconnects (same session reattached)" Counter;
   add metric_sse_idle_evictions "Total SSE clients evicted by idle reaper" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -954,6 +954,10 @@ val metric_gc_compactions : string
 val metric_gc_promoted_words : string
 (** Cumulative words promoted from minor to major heap since program start. *)
 
+val metric_memory_usage_bytes : string
+(** Approximate live OCaml heap memory usage in bytes, derived from
+    [Gc.quick_stat.live_words] and [Sys.word_size]. *)
+
 val metric_keeper_stale_termination_total : string
 val metric_keeper_stale_termination_by_class : string
 val metric_keeper_oas_timeout_budget_watchdog_termination : string

--- a/test/test_gc_sampler.ml
+++ b/test/test_gc_sampler.ml
@@ -1,7 +1,8 @@
 (** Gc_sampler smoke tests (PR-0.2.D).
 
-    Verifies that {!Masc_mcp.Gc_sampler.sample_once} writes the six
-    [masc_gc_*] gauges so [Prometheus.metric_value_or_zero] returns
+    Verifies that {!Masc_mcp.Gc_sampler.sample_once} writes the GC
+    gauges, including [masc_memory_usage_bytes], so
+    [Prometheus.metric_value_or_zero] returns
     non-zero values for the cumulative word counters after a single
     sample.  We do not exercise the Eio fiber loop here — that path is
     covered transitively by every server boot.  Coverage of [run]
@@ -21,6 +22,7 @@ let metrics_to_check =
     Prometheus.metric_gc_live_words;
     Prometheus.metric_gc_compactions;
     Prometheus.metric_gc_promoted_words;
+    Prometheus.metric_memory_usage_bytes;
   ]
 
 let test_sample_once_writes_all_gauges () =
@@ -50,14 +52,28 @@ let test_minor_words_advances_after_allocation () =
   in
   check bool "minor_words gauge advances after allocation" true (after >= before)
 
+let test_memory_usage_derives_from_live_words () =
+  Gc_sampler.sample_once ();
+  let live_words =
+    Prometheus.metric_value_or_zero Prometheus.metric_gc_live_words ()
+  in
+  let memory_usage =
+    Prometheus.metric_value_or_zero Prometheus.metric_memory_usage_bytes ()
+  in
+  let expected = live_words *. float_of_int (Sys.word_size / 8) in
+  check (float 0.001) "memory usage bytes derives from live words" expected
+    memory_usage
+
 let () =
   run "Gc_sampler"
     [
       ( "sample_once",
         [
-          test_case "writes all six gauges" `Quick
+          test_case "writes all runtime heap gauges" `Quick
             test_sample_once_writes_all_gauges;
           test_case "minor_words gauge advances after allocation" `Quick
             test_minor_words_advances_after_allocation;
+          test_case "memory_usage derives from live_words" `Quick
+            test_memory_usage_derives_from_live_words;
         ] );
     ]

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -321,6 +321,15 @@ let test_build_identity_probe_metric_registered () =
        ("# TYPE " ^ Prometheus.metric_build_identity_probe_failures
         ^ " counter"))
 
+let test_memory_usage_metric_registered () =
+  let text = Prometheus.to_prometheus_text () in
+  check bool "has memory usage HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_memory_usage_bytes ^ " "));
+  check bool "has memory usage TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_memory_usage_bytes ^ " gauge"))
+
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
   Prometheus.register_histogram ~name ~help:"export format test" ();
@@ -500,6 +509,8 @@ let () =
         test_workspace_route_metric_registered;
       test_case "build identity probe metric registered" `Quick
         test_build_identity_probe_metric_registered;
+      test_case "memory usage metric registered" `Quick
+        test_memory_usage_metric_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
     ];


### PR DESCRIPTION
## What

- Add `masc_memory_usage_bytes` as the Phase 0.5 `memory_usage` Prometheus gauge.
- Sample it from `Gc.quick_stat.live_words * (Sys.word_size / 8)`, so the metric is live OCaml heap bytes rather than process RSS.
- Register the gauge in `Prometheus.init` and pin coverage in `test_gc_sampler` and `test_prometheus_coverage`.

## Why

Phase 0.5 needs a direct runtime `memory_usage` signal. The GC sampler already exposed word counters, but operators had to infer byte usage manually and there was no stable metric name for dashboards or alert contracts to consume.

## Validation

- `git diff --check origin/main...HEAD`

Earlier local focused proof before the later main rebase:

- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_gc_sampler.exe test/test_prometheus_coverage.exe`
- `./_build/default/test/test_gc_sampler.exe` - 3 tests passed
- `./_build/default/test/test_prometheus_coverage.exe` - 56 tests passed

## Current Local Verification Caveat

After rebasing onto current `main`, a fresh focused Dune attempt on this host still failed while compiling shared current-main code with `Unbound constructor Inactive`, then wedged and had to be stopped. The PR remains draft; CI/current clean-switch verification is the authoritative compile surface for this rebased head.

`opam exec -- ocamlformat --check ...` is also still blocked by pre-existing `lib/prometheus.mli` Warning 50 docstring placement, so this PR avoids a broad formatter rewrite.
