### PR TITLE
feat(governance): expose judge timeout telemetry

### DIFF
--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -23,6 +23,17 @@ let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot
       ("model_used", string_option_json runtime.model_used);
       ("keeper_name", `String runtime.keeper_name);
       ("last_error", string_option_json runtime.last_error);
+      ("compute_in_flight", `Int runtime.compute_in_flight);
+      ( "last_compute_duration_sec",
+        option_to_yojson (fun value -> `Float value)
+          runtime.last_compute_duration_sec );
+      ( "last_compute_timeout_sec",
+        option_to_yojson (fun value -> `Float value)
+          runtime.last_compute_timeout_sec );
+      ( "last_compute_outcome",
+        string_option_json runtime.last_compute_outcome );
+      ( "last_compute_reason",
+        string_option_json runtime.last_compute_reason );
       ( "lenient_json_fallback",
         Judge_diagnostics.lenient_fallback_metrics_json ~judge_label:"Governance" );
     ]

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -13,6 +13,11 @@ type runtime_snapshot = {
   model_used : string option;
   keeper_name : string;
   last_error : string option;
+  compute_in_flight : int;
+  last_compute_duration_sec : float option;
+  last_compute_timeout_sec : float option;
+  last_compute_outcome : string option;
+  last_compute_reason : string option;
 }
 
 type state = {
@@ -28,6 +33,11 @@ type state = {
   mutable expires_at : string option;
   mutable model_used : string option;
   mutable last_error : string option;
+  mutable compute_in_flight : int;
+  mutable last_compute_duration_sec : float option;
+  mutable last_compute_timeout_sec : float option;
+  mutable last_compute_outcome : string option;
+  mutable last_compute_reason : string option;
   mutable last_disk_load_unix : float option;
   mutable judgments : (string, Yojson.Safe.t) Hashtbl.t;
 }
@@ -41,6 +51,15 @@ type state = {
 let governance_response_model_empty_metric =
   "masc_governance_response_model_empty_total"
 
+let governance_compute_total_metric =
+  "masc_governance_judge_compute_total"
+
+let governance_compute_duration_metric =
+  "masc_governance_judge_compute_duration_seconds"
+
+let governance_compute_in_flight_metric =
+  "masc_governance_judge_compute_in_flight"
+
 let () =
   Prometheus.register_counter
     ~name:governance_response_model_empty_metric
@@ -48,6 +67,22 @@ let () =
       "Count of governance compute_judgments cycles where \
        [response.model] was empty.  Labels: \
        [source=telemetry_resolved | unknown_sentinel]."
+    ();
+  Prometheus.register_counter
+    ~name:governance_compute_total_metric
+    ~help:
+      "Count of governance judge compute_judgments attempts. Labels: \
+       [outcome=ok|error, reason=ok|timeout|error|cancelled]."
+    ();
+  Prometheus.register_histogram
+    ~name:governance_compute_duration_metric
+    ~help:
+      "Observed governance judge compute_judgments duration in seconds. \
+       Labels: [outcome=ok|error, reason=ok|timeout|error|cancelled]."
+    ();
+  Prometheus.register_gauge
+    ~name:governance_compute_in_flight_metric
+    ~help:"Current in-flight governance judge compute_judgments attempts."
     ()
 
 type governance_model_source =
@@ -143,6 +178,27 @@ let degraded_reason_of_error message =
   else
     "error"
 
+let timeout_sec_of_error message =
+  let marker = "timed out after " in
+  let lower = String.lowercase_ascii message in
+  match String_util.find_substring lower marker with
+  | None -> None
+  | Some marker_idx ->
+      let start = marker_idx + String.length marker in
+      let len = String.length lower in
+      let rec find_stop idx =
+        if idx >= len then idx
+        else
+          match lower.[idx] with
+          | '0' .. '9' | '.' -> find_stop (idx + 1)
+          | _ -> idx
+      in
+      let stop = find_stop start in
+      if stop <= start then None
+      else
+        String.sub lower start (stop - start)
+        |> float_of_string_opt
+
 let cached_judgments_still_fresh ~now_ts (st : state) =
   match st.expires_at_unix with
   | Some expires_at -> expires_at > now_ts
@@ -194,6 +250,11 @@ let get_state base_path =
             expires_at = None;
             model_used = None;
             last_error = None;
+            compute_in_flight = 0;
+            last_compute_duration_sec = None;
+            last_compute_timeout_sec = None;
+            last_compute_outcome = None;
+            last_compute_reason = None;
             last_disk_load_unix = None;
           judgments = Hashtbl.create 32;
         }
@@ -362,6 +423,11 @@ let runtime_status_at ~now_ts base_path =
         model_used = st.model_used;
         keeper_name;
         last_error = st.last_error;
+        compute_in_flight = st.compute_in_flight;
+        last_compute_duration_sec = st.last_compute_duration_sec;
+        last_compute_timeout_sec = st.last_compute_timeout_sec;
+        last_compute_outcome = st.last_compute_outcome;
+        last_compute_reason = st.last_compute_reason;
       })
 
 let runtime_status base_path =
@@ -625,6 +691,43 @@ let should_backoff ~sw ~net =
       (Printexc.to_string exn);
     false
 
+let mark_compute_start (st : state) =
+  let in_flight =
+    with_lock st (fun () ->
+        st.compute_in_flight <- st.compute_in_flight + 1;
+        st.compute_in_flight)
+  in
+  Prometheus.set_gauge governance_compute_in_flight_metric
+    (float_of_int in_flight);
+  in_flight
+
+let mark_compute_finish (st : state) ~started_at ~outcome ~reason
+    ~timeout_sec =
+  let duration_sec = Unix.gettimeofday () -. started_at in
+  let in_flight =
+    with_lock st (fun () ->
+        st.compute_in_flight <- max 0 (st.compute_in_flight - 1);
+        st.last_compute_duration_sec <- Some duration_sec;
+        st.last_compute_timeout_sec <- timeout_sec;
+        st.last_compute_outcome <- Some outcome;
+        st.last_compute_reason <- Some reason;
+        st.compute_in_flight)
+  in
+  let labels = [ ("outcome", outcome); ("reason", reason) ] in
+  Prometheus.set_gauge governance_compute_in_flight_metric
+    (float_of_int in_flight);
+  Prometheus.inc_counter governance_compute_total_metric ~labels ();
+  Prometheus.observe_histogram governance_compute_duration_metric
+    ~labels duration_sec;
+  Log.Governance.info
+    "refresh_once: compute_judgments telemetry outcome=%s reason=%s duration=%.3fs timeout_budget=%s in_flight_after=%d"
+    outcome reason duration_sec
+    (match timeout_sec with
+     | Some value -> Printf.sprintf "%.1fs" value
+     | None -> "unknown")
+    in_flight;
+  (duration_sec, in_flight)
+
 let refresh_once ~sw ~net
     ~(masc_tools : Masc_domain.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.t)
@@ -667,8 +770,30 @@ let refresh_once ~sw ~net
         st.refreshing <- true;
         st.runtime_status <- status_refreshing;
         st.degraded_reason <- None);
-    match compute_judgments ~masc_tools ~dispatch ~build_facts with
+    let started_at = Unix.gettimeofday () in
+    let timeout_budget =
+      Some
+        (Env_config_oas_bridge.timeout_sec
+           ~caller:Env_config_oas_bridge.Governance_judge ())
+    in
+    ignore (mark_compute_start st);
+    let compute_result =
+      try compute_judgments ~masc_tools ~dispatch ~build_facts with
+      | Eio.Cancel.Cancelled _ as exn ->
+          ignore
+            (mark_compute_finish st ~started_at ~outcome:"error"
+               ~reason:"cancelled" ~timeout_sec:timeout_budget);
+          raise exn
+      | exn ->
+          Error
+            (Printf.sprintf "compute_judgments raised: %s"
+               (Printexc.to_string exn))
+    in
+    match compute_result with
     | Ok (model_used, generated_at, expires_at, judgments) ->
+        ignore
+          (mark_compute_finish st ~started_at ~outcome:"ok" ~reason:"ok"
+             ~timeout_sec:timeout_budget);
         if judgments = [] then
           Log.Governance.routine
             "refresh_once: ok model=%s judgments=%d"
@@ -694,9 +819,23 @@ let refresh_once ~sw ~net
               (fun json -> Hashtbl.replace st.judgments (judgment_key json) json)
               judgments)
     | Error message ->
+        let reason = degraded_reason_of_error message in
+        let timeout_sec =
+          match timeout_sec_of_error message with
+          | Some value -> Some value
+          | None -> timeout_budget
+        in
+        let duration_sec, in_flight =
+          mark_compute_finish st ~started_at ~outcome:"error" ~reason
+            ~timeout_sec
+        in
         Log.Governance.warn
-          "refresh_once: compute_judgments failed: %s"
-          message;
+          "refresh_once: compute_judgments failed: %s (duration=%.3fs timeout_budget=%s in_flight=%d)"
+          message duration_sec
+          (match timeout_sec with
+           | Some value -> Printf.sprintf "%.1fs" value
+           | None -> "unknown")
+          in_flight;
         with_lock st (fun () ->
             mark_refresh_failure ~now_ts:(Unix.gettimeofday ()) st ~message)
   end

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -66,6 +66,11 @@ type runtime_snapshot = {
   model_used : string option;
   keeper_name : string;
   last_error : string option;
+  compute_in_flight : int;
+  last_compute_duration_sec : float option;
+  last_compute_timeout_sec : float option;
+  last_compute_outcome : string option;
+  last_compute_reason : string option;
 }
 (** Snapshot of the daemon's externally-visible runtime
     state.  Constructed by {!runtime_status_at} under
@@ -87,6 +92,11 @@ type state = {
   mutable expires_at : string option;
   mutable model_used : string option;
   mutable last_error : string option;
+  mutable compute_in_flight : int;
+  mutable last_compute_duration_sec : float option;
+  mutable last_compute_timeout_sec : float option;
+  mutable last_compute_outcome : string option;
+  mutable last_compute_reason : string option;
   mutable last_disk_load_unix : float option;
   mutable judgments : (string, Yojson.Safe.t) Hashtbl.t;
 }
@@ -99,7 +109,10 @@ type state = {
     the mutable fields directly under {!with_lock} to
     seed cache state for individual scenarios.  The
     [judgments] table and [mutex] are exposed alongside
-    them for the same reason — every other reader goes
+    them for the same reason.  The compute telemetry fields
+    expose #11079 measurement state: current in-flight count,
+    last duration, resolved timeout budget, outcome, and
+    reason.  Every other reader goes
     through {!runtime_status} / {!fresh_judgments_json}. *)
 
 (** {1 Response-model classification} *)

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -311,6 +311,57 @@ let test_runtime_timestamps_fallback_to_unix_values () =
       check string "judge expires_at falls back to unix" expires_at
         (judge |> member "expires_at" |> to_string))
 
+let test_dashboard_surfaces_compute_telemetry () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.compute_in_flight <- 2;
+        st.last_compute_duration_sec <- Some 12.5;
+        st.last_compute_timeout_sec <- Some 45.0;
+        st.last_compute_outcome <- Some "error";
+        st.last_compute_reason <- Some "timeout");
+      let status =
+        Lib.Dashboard_governance_judge.runtime_status_at ~now_ts:now dir
+      in
+      check int "runtime exposes compute in-flight" 2
+        status.compute_in_flight;
+      check (option string) "runtime exposes compute outcome" (Some "error")
+        status.last_compute_outcome;
+      check (option string) "runtime exposes compute reason" (Some "timeout")
+        status.last_compute_reason;
+      (match status.last_compute_duration_sec with
+       | Some duration ->
+         check (float 0.001) "runtime exposes compute duration" 12.5
+           duration
+       | None -> fail "expected compute duration");
+      (match status.last_compute_timeout_sec with
+       | Some timeout_sec ->
+         check (float 0.001) "runtime exposes timeout budget" 45.0
+           timeout_sec
+       | None -> fail "expected timeout budget");
+      let json =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20
+          ~offset:0 ~status_filter:None
+      in
+      let open Yojson.Safe.Util in
+      let judge = json |> member "judge" in
+      check int "dashboard exposes compute in-flight" 2
+        (judge |> member "compute_in_flight" |> to_int);
+      check (float 0.001) "dashboard exposes compute duration" 12.5
+        (judge |> member "last_compute_duration_sec" |> to_float);
+      check (float 0.001) "dashboard exposes timeout budget" 45.0
+        (judge |> member "last_compute_timeout_sec" |> to_float);
+      check string "dashboard exposes compute outcome" "error"
+        (judge |> member "last_compute_outcome" |> to_string);
+      check string "dashboard exposes compute reason" "timeout"
+        (judge |> member "last_compute_reason" |> to_string))
+
 let test_refresh_failure_keeps_fresh_cache_online () =
   let dir = test_dir () in
   Fun.protect
@@ -720,6 +771,8 @@ let () =
             test_empty_judgment_disk_scan_uses_cooldown;
           test_case "runtime timestamps fallback to unix values" `Quick
             test_runtime_timestamps_fallback_to_unix_values;
+          test_case "dashboard surfaces compute telemetry" `Quick
+            test_dashboard_surfaces_compute_telemetry;
           test_case "refresh failure keeps fresh cache online" `Quick
             test_refresh_failure_keeps_fresh_cache_online;
           test_case "refresh failure marks expired cache offline" `Quick


### PR DESCRIPTION
## Summary
- add governance judge compute telemetry around `refresh_once`
- expose current in-flight compute count, last duration, timeout budget, outcome, and reason in dashboard governance JSON
- emit Prometheus compute counters, duration observations, and in-flight gauge for `compute_judgments`
- add a dashboard governance regression test for the new runtime telemetry fields

## Stack / dependency
- Stacked on #13726 because current `main` is missing `Coord_status_rendering.assigned_task_ids` and cannot build this target without that compile fix.
- Review diff for this PR is the governance telemetry change only when compared against `fix/coord-status-assigned-task-ids-0506`.

## Issue
- Refs #11079

## Validation
- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_governance.exe`
- `./_build/default/test/test_dashboard_governance.exe` (16 tests)

Note: `MASC_SKIP_PIN_CHECK=1` was used because the shared opam switch was pinned to a different OAS commit by concurrent worktrees; the focused build/test ran against the currently pinned switch without repinning the host mid-session.
