### PR TITLE
fix(metrics): export goal attainment gauges

### DIFF
--- a/docs/observability/goal-loop-observe-metrics.md
+++ b/docs/observability/goal-loop-observe-metrics.md
@@ -33,6 +33,7 @@ now contract checked.
 | pricing catalog miss | `masc_pricing_catalog_miss_total` | `GoalLoopPricingCatalogMissCritical` |
 | dashboard all-zero metrics | `masc_dashboard_metric_all_zeros` | `GoalLoopDashboardMetricAllZerosWarning` |
 | dashboard snapshot latency | `masc_dashboard_snapshot_latency_seconds_bucket` | `GoalLoopDashboardSnapshotLatencyP99Warning` |
+| goal attainment | `masc_goal_attainment_pct`, `masc_goal_attainment_measured` | `GoalLoopGoalAttainmentUnmeasuredOrInvalidWarning` |
 | config unknown keys ignored | `masc_config_unknown_keys_ignored_total` | `GoalLoopConfigUnknownKeysIgnoredWarning` |
 | credential archived by starvation | `masc_config_credential_archived_starvation_total` | `GoalLoopCredentialArchivedStarvationCritical` |
 | governance judge unparseable | `masc_governance_judge_unparseable_total` | `GoalLoopGovernanceJudgeUnparseableWarning` |
@@ -57,8 +58,8 @@ Expected result:
 
 ```text
 GOAL LOOP Observe Metrics Contract: PASS
-checked_signals: 16
-passing_signals: 16
+checked_signals: 17
+passing_signals: 17
 failing_signals: 0
 ```
 
@@ -84,6 +85,7 @@ The contract uses bounded labels from the prompt:
 - `profile_name`
 - `model_id`
 - `file_path`
+- `goal_id`
 
 Counters should increment on the exact failure event. Gauges should hold
 the current runtime state. Histograms must expose Prometheus `_bucket`

--- a/infrastructure/monitoring/goal-loop-observe-alerts.yml
+++ b/infrastructure/monitoring/goal-loop-observe-alerts.yml
@@ -30,6 +30,8 @@ groups:
           or absent(masc_pricing_catalog_miss_total)
           or absent(masc_dashboard_metric_all_zeros)
           or absent(masc_dashboard_snapshot_latency_seconds_bucket)
+          or absent(masc_goal_attainment_pct)
+          or absent(masc_goal_attainment_measured)
           or absent(masc_config_unknown_keys_ignored_total)
           or absent(masc_config_credential_archived_starvation_total)
           or absent(masc_governance_judge_unparseable_total)
@@ -231,6 +233,35 @@ groups:
           description: |
             Observe dashboards are stale enough that Orient decisions may
             run against delayed state.
+
+  - name: masc_goal_loop_observe_goals
+    interval: 30s
+    rules:
+      - alert: GoalLoopGoalAttainmentUnmeasuredOrInvalidWarning
+        expr: |
+          (
+            min by (goal_id) (masc_goal_attainment_measured) == 0
+          )
+          or
+          (
+            min by (goal_id) (masc_goal_attainment_pct) < 0
+          )
+          or
+          (
+            max by (goal_id) (masc_goal_attainment_pct) > 100
+          )
+        for: 10m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Goal {{ $labels.goal_id }} attainment is unmeasured or invalid"
+          description: |
+            The goal loop dashboard exported a goal without a measured
+            attainment percentage, or with an out-of-range attainment
+            percentage. Treat 0% as unknown until
+            masc_goal_attainment_measured returns to 1 for this goal.
 
   - name: masc_goal_loop_observe_config
     interval: 30s

--- a/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
+++ b/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
@@ -143,6 +143,26 @@
       ]
     },
     {
+      "signal_id": "goal_attainment",
+      "metric_names": [
+        "masc_goal_attainment_pct",
+        "masc_goal_attainment_measured"
+      ],
+      "alert_names": [
+        "GoalLoopGoalAttainmentUnmeasuredOrInvalidWarning"
+      ],
+      "threshold_fragments": [
+        "min by (goal_id)",
+        "== 0",
+        "< 0",
+        "> 100"
+      ],
+      "dashboard_query_fragments": [
+        "masc_goal_attainment_pct",
+        "masc_goal_attainment_measured"
+      ]
+    },
+    {
       "signal_id": "config_unknown_keys_ignored",
       "metric_names": [
         "masc_config_unknown_keys_ignored_total"

--- a/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
+++ b/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
@@ -14,6 +14,8 @@
       "masc_pricing_catalog_miss_total{model_id}",
       "masc_dashboard_metric_all_zeros{keeper_name}",
       "masc_dashboard_snapshot_latency_seconds_bucket",
+      "masc_goal_attainment_pct{goal_id}",
+      "masc_goal_attainment_measured{goal_id}",
       "masc_config_unknown_keys_ignored_total{file_path}",
       "masc_config_credential_archived_starvation_total{keeper_name}",
       "masc_governance_judge_unparseable_total",
@@ -306,6 +308,53 @@
         }
       ],
       "title": "Governance And Data Integrity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".* measured"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "masc_goal_attainment_pct",
+          "legendFormat": "{{goal_id}} attainment",
+          "refId": "A"
+        },
+        {
+          "expr": "masc_goal_attainment_measured",
+          "legendFormat": "{{goal_id}} measured",
+          "refId": "B"
+        }
+      ],
+      "title": "Goal Attainment",
       "type": "timeseries"
     }
   ],

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -455,6 +455,29 @@ let build_attainment_json ~state ~basis ~task_done_count ~task_count
       ("note", `String note);
     ]
 
+let goal_attainment_pct_help =
+  "Goal attainment percentage by goal_id. Use \
+   masc_goal_attainment_measured to distinguish real 0% from unmeasured."
+
+let goal_attainment_measured_help =
+  "Whether goal attainment percentage is currently measured by goal_id \
+   (1 = measured, 0 = unmeasured)."
+
+let observe_goal_attainment_metrics (goal : Goal_store.goal) attainment =
+  let labels = [ ("goal_id", goal.id) ] in
+  let measured, pct =
+    match attainment |> member "attainment_pct" |> to_int_option with
+    | Some pct -> (1.0, float_of_int pct)
+    | None -> (0.0, 0.0)
+  in
+  Prometheus.register_gauge ~name:Prometheus.metric_goal_attainment_pct
+    ~help:goal_attainment_pct_help ~labels ();
+  Prometheus.set_gauge Prometheus.metric_goal_attainment_pct ~labels pct;
+  Prometheus.register_gauge ~name:Prometheus.metric_goal_attainment_measured
+    ~help:goal_attainment_measured_help ~labels ();
+  Prometheus.set_gauge Prometheus.metric_goal_attainment_measured ~labels
+    measured
+
 let goal_attainment_to_json (goal : Goal_store.goal) (node : tree_node) =
   let task_count = List.length node.tasks in
   let task_done_count =
@@ -1479,7 +1502,10 @@ let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
        | None -> `Null);
       ("convergence", `Float node.convergence);
       ("convergence_pct", `Int (int_of_float (node.convergence *. 100.0)));
-      ("attainment", goal_attainment_to_json goal node);
+      ( "attainment",
+        let attainment = goal_attainment_to_json goal node in
+        observe_goal_attainment_metrics goal attainment;
+        attainment );
       ("tasks", `List (List.map task_to_tree_json node.tasks));
       ("task_count", `Int (List.length node.tasks));
       ("task_done_count",

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -885,6 +885,8 @@ let metric_workspace_route_failures = "masc_workspace_route_failures_total"
 let metric_active_agents = "masc_active_agents"
 let metric_pending_tasks = "masc_pending_tasks"
 let metric_uptime_seconds = "masc_uptime_seconds"
+let metric_goal_attainment_pct = "masc_goal_attainment_pct"
+let metric_goal_attainment_measured = "masc_goal_attainment_measured"
 
 (* PR-0.2.D: OCaml GC quick_stat sampler gauges.  Populated by
    [Gc_sampler.run] from the runtime [Gc.quick_stat ()] once per
@@ -1312,6 +1314,13 @@ let init () =
   add metric_active_agents "Currently active agents" Gauge;
   add metric_pending_tasks "Tasks waiting to be claimed" Gauge;
   add metric_uptime_seconds "Server uptime in seconds" Gauge;
+  add metric_goal_attainment_pct
+    "Goal attainment percentage by goal_id. Use \
+     masc_goal_attainment_measured to distinguish real 0% from unmeasured."
+    Gauge;
+  add metric_goal_attainment_measured
+    "Whether goal attainment percentage is currently measured by goal_id \
+     (1 = measured, 0 = unmeasured)." Gauge;
   (* PR-0.2.D: OCaml runtime GC sampler gauges.  See [Gc_sampler]. *)
   add metric_gc_minor_words
     "Cumulative words allocated in the minor heap since program start \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -459,6 +459,15 @@ val metric_workspace_route_failures : string
 val metric_active_agents : string
 val metric_pending_tasks : string
 val metric_uptime_seconds : string
+val metric_goal_attainment_pct : string
+(** Goal attainment percentage by [goal_id]. Companion
+    {!metric_goal_attainment_measured} distinguishes real 0% from
+    unmeasured goals. *)
+
+val metric_goal_attainment_measured : string
+(** Gauge by [goal_id]: [1] when goal attainment percentage is measured,
+    [0] when the dashboard projection is currently unmeasured. *)
+
 val metric_sse_connections_active : string
 val metric_sse_reconnects : string
 val metric_sse_idle_evictions : string

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -423,6 +423,31 @@ let test_goal_attainment_projects_percent_target () =
   check int "done task count" 3
     (attainment |> member "task_done_count" |> to_int)
 
+let test_goal_attainment_exports_prometheus_metric () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Prometheus attainment goal"
+        ~metric:"completion_pct" ~target_value:"75%" ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Metric done task 1";
+  create_done_task config ~goal_id:goal.id ~title:"Metric done task 2";
+  create_done_task config ~goal_id:goal.id ~title:"Metric done task 3";
+  ignore
+    (Coord_task.add_task ~goal_id:goal.id config ~title:"Metric open task"
+       ~priority:3 ~description:"remaining work");
+  ignore (Dashboard_goals.dashboard_goals_tree_json ~config);
+  let labels = [ ("goal_id", goal.id) ] in
+  check (option (float 0.001)) "goal attainment pct metric" (Some 100.0)
+    (Prometheus.get_metric_value Prometheus.metric_goal_attainment_pct ~labels
+       ());
+  check (option (float 0.001)) "goal attainment measured metric" (Some 1.0)
+    (Prometheus.get_metric_value Prometheus.metric_goal_attainment_measured
+       ~labels ())
+
 let test_goal_attainment_projects_camel_case_percent_metric () =
   with_room @@ fun config ->
   let goal, _kind =
@@ -1095,6 +1120,8 @@ let () =
             test_title_marker_links_legacy_task;
           test_case "goal attainment projects percent targets" `Quick
             test_goal_attainment_projects_percent_target;
+          test_case "goal attainment exports prometheus metric" `Quick
+            test_goal_attainment_exports_prometheus_metric;
           test_case "goal attainment projects camel-case percent metrics" `Quick
             test_goal_attainment_projects_camel_case_percent_metric;
           test_case "goal attainment does not fake unparseable targets" `Quick

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -330,6 +330,21 @@ let test_memory_usage_metric_registered () =
     (text_has_literal text
        ("# TYPE " ^ Prometheus.metric_memory_usage_bytes ^ " gauge"))
 
+let test_goal_attainment_metrics_registered () =
+  let text = Prometheus.to_prometheus_text () in
+  check bool "has goal attainment pct HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_goal_attainment_pct ^ " "));
+  check bool "has goal attainment pct TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_goal_attainment_pct ^ " gauge"));
+  check bool "has goal attainment measured HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_goal_attainment_measured ^ " "));
+  check bool "has goal attainment measured TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_goal_attainment_measured ^ " gauge"))
+
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
   Prometheus.register_histogram ~name ~help:"export format test" ();
@@ -511,6 +526,8 @@ let () =
         test_build_identity_probe_metric_registered;
       test_case "memory usage metric registered" `Quick
         test_memory_usage_metric_registered;
+      test_case "goal attainment metrics registered" `Quick
+        test_goal_attainment_metrics_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
     ];

--- a/test/test_validate_goal_loop_observe_metrics.py
+++ b/test/test_validate_goal_loop_observe_metrics.py
@@ -66,8 +66,8 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         report = load_current_report()
 
         self.assertEqual("PASS", report.status)
-        self.assertEqual(16, report.checked_signals)
-        self.assertEqual(16, report.passing_signals)
+        self.assertEqual(17, report.checked_signals)
+        self.assertEqual(17, report.passing_signals)
         self.assertEqual(0, report.failing_signals)
 
     def test_contract_pins_starvation_rate_signal(self) -> None:
@@ -75,8 +75,7 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
             str(CONTRACT_PATH)
         )
         signals = {
-            signal["signal_id"]: signal
-            for signal in contract["required_signals"]
+            signal["signal_id"]: signal for signal in contract["required_signals"]
         }
 
         starvation_rate = signals["starvation_rate"]
@@ -90,6 +89,34 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         self.assertEqual(
             ["GoalLoopKeeperStarvationRateCritical"],
             starvation_rate["alert_names"],
+        )
+
+    def test_contract_pins_goal_attainment_signal(self) -> None:
+        contract = validate_goal_loop_observe_metrics.load_json_object(
+            str(CONTRACT_PATH)
+        )
+        signals = {
+            signal["signal_id"]: signal for signal in contract["required_signals"]
+        }
+
+        goal_attainment = signals["goal_attainment"]
+        self.assertEqual(
+            [
+                "masc_goal_attainment_pct",
+                "masc_goal_attainment_measured",
+            ],
+            goal_attainment["metric_names"],
+        )
+        self.assertEqual(
+            ["GoalLoopGoalAttainmentUnmeasuredOrInvalidWarning"],
+            goal_attainment["alert_names"],
+        )
+        self.assertEqual(
+            [
+                "masc_goal_attainment_pct",
+                "masc_goal_attainment_measured",
+            ],
+            goal_attainment["dashboard_query_fragments"],
         )
 
     def test_cli_require_complete_passes(self) -> None:


### PR DESCRIPTION
## What

- Export Goal Tree attainment as bounded Prometheus gauges:
  - `masc_goal_attainment_pct{goal_id}`: latest dashboard attainment percentage.
  - `masc_goal_attainment_measured{goal_id}`: `1` when the percentage is measured, `0` when the dashboard projection is unmeasured.
- Keep the metric label stable at `goal_id` only, so state/basis changes do not leave stale label combinations.
- Pin metric registration in `test_prometheus_coverage` and runtime emission from `dashboard_goals_tree_json` in `test_dashboard_goals`.
- Add the goal-attainment signal to the GOAL LOOP Observe monitoring contract:
  - Prometheus absent coverage for both metrics.
  - `GoalLoopGoalAttainmentUnmeasuredOrInvalidWarning` for unmeasured or out-of-range attainment.
  - Grafana `Goal Attainment` panel and validator coverage for the 17th Observe signal.

## Why

Phase 0.5 calls out `goal_attainment` as a first-class metric. The dashboard already computes attainment JSON, but there was no Prometheus series for operators or monitoring contracts to query.

The extra monitoring-contract commit prevents the new exporter metric from being silently dropped by alerts or Grafana after merge.

## Review Focus

- `lib/dashboard/dashboard_goals.ml`: attainment parsing and measured-vs-real-zero behavior.
- `lib/prometheus.ml` / `lib/prometheus.mli`: metric registration and public constants.
- `infrastructure/monitoring/*goal-loop-observe*`: goal-attainment signal is now contract checked across Prometheus alerts and Grafana dashboard queries.
- `test/test_dashboard_goals.ml`, `test/test_prometheus_coverage.ml`, `test/test_validate_goal_loop_observe_metrics.py`: runtime emission and contract regression coverage.

## Validation

- `python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete --format text`
- `python3 test/test_validate_goal_loop_observe_metrics.py`
- `ruff check test/test_validate_goal_loop_observe_metrics.py`
- `ruff format --check test/test_validate_goal_loop_observe_metrics.py`
- `ocamlc -stop-after parsing lib/dashboard/dashboard_goals.ml lib/prometheus.ml lib/prometheus.mli test/test_dashboard_goals.ml test/test_prometheus_coverage.ml`
- `git diff --check origin/main...HEAD`

## Local Verification Caveat

Focused Dune was not run locally because `/tmp/me-opam-switch.lock` is currently held by another worktree's focused build. This PR remains draft; CI is the authoritative compile surface until the shared switch is free.
