### PR TITLE
fix(dashboard): expose status chip metadata

### DIFF
--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -2,7 +2,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { StatusChip, statusChipClasses, isSemanticTone, keeperStateTone } from './status-chip'
+import {
+  StatusChip,
+  statusChipClasses,
+  isSemanticTone,
+  keeperStateTone,
+  summarizeStatusChip,
+} from './status-chip'
 
 describe('isSemanticTone (pure)', () => {
   it('accepts the 8 enum members', () => {
@@ -145,26 +151,47 @@ describe('StatusChip component', () => {
     const el = container.querySelector('[data-status-chip]')!
     expect(el.tagName).toBe('SPAN')
     expect(el.textContent).toBe('approved')
+    expect(el.getAttribute('data-status-chip-content-source')).toBe('children')
+    expect(el.getAttribute('data-status-chip-is-semantic-tone')).toBe('true')
   })
 
   it('label prop renders when children absent (legacy API)', () => {
     render(html`<${StatusChip} label="present" />`, container)
-    expect(container.querySelector('[data-status-chip]')!.textContent).toBe('present')
+    const el = container.querySelector('[data-status-chip]')!
+    expect(el.textContent).toBe('present')
+    expect(el.getAttribute('data-status-chip-content-source')).toBe('label')
+    expect(el.getAttribute('data-status-chip-label-length')).toBe('7')
   })
 
   it('children win over label when both are set', () => {
     render(html`<${StatusChip} label="legacy">actual<//>`, container)
-    expect(container.querySelector('[data-status-chip]')!.textContent).toBe('actual')
+    const el = container.querySelector('[data-status-chip]')!
+    expect(el.textContent).toBe('actual')
+    expect(el.getAttribute('data-status-chip-content-source')).toBe('children')
+    expect(el.getAttribute('data-status-chip-label-length')).toBe('6')
   })
 
   it('data-status-chip-tone reflects tone prop', () => {
     render(html`<${StatusChip} tone="warn">heads up<//>`, container)
     expect(container.querySelector('[data-status-chip]')!.getAttribute('data-status-chip-tone')).toBe('warn')
+    expect(container.querySelector('[data-status-chip]')!.getAttribute('data-status-chip-is-semantic-tone')).toBe('true')
+  })
+
+  it('raw tone strings reflect non-semantic metadata', () => {
+    render(html`<${StatusChip} tone="bg-[var(--accent-12)]">custom<//>`, container)
+    const el = container.querySelector('[data-status-chip]')!
+    expect(el.getAttribute('data-status-chip-tone')).toBe('bg-[var(--accent-12)]')
+    expect(el.getAttribute('data-status-chip-is-semantic-tone')).toBe('false')
   })
 
   it('testId renders as data-testid', () => {
-    render(html`<${StatusChip} testId="approve-chip">ok<//>`, container)
-    expect(container.querySelector('[data-testid="approve-chip"]')).toBeTruthy()
+    render(html`<${StatusChip} class="ml-2" testId="approve-chip">ok<//>`, container)
+    const el = container.querySelector('[data-testid="approve-chip"]')!
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('data-status-chip-has-custom-class')).toBe('true')
+    expect(el.getAttribute('data-status-chip-has-test-id')).toBe('true')
+    expect(el.getAttribute('data-status-chip-class-length')).toBe('4')
+    expect(el.getAttribute('data-status-chip-test-id-length')).toBe('12')
   })
 
   it('uppercase prop reflects on data-status-chip-uppercase (default true)', () => {
@@ -174,5 +201,46 @@ describe('StatusChip component', () => {
     render(null, container)
     render(html`<${StatusChip} uppercase=${false} tone="neutral">path.kind<//>`, container)
     expect(container.querySelector('[data-status-chip]')!.getAttribute('data-status-chip-uppercase')).toBe('false')
+  })
+
+  it('summarizes default status chip state', () => {
+    expect(summarizeStatusChip({})).toEqual({
+      tone: '',
+      isSemanticTone: true,
+      contentSource: 'empty',
+      uppercase: true,
+      hasCustomClass: false,
+      hasTestId: false,
+      labelLength: 0,
+      classNameLength: 0,
+      testIdLength: 0,
+    })
+  })
+
+  it('summarizes raw-tone label status chip state', () => {
+    expect(summarizeStatusChip({
+      label: 'custom',
+      tone: 'bg-[var(--accent-12)]',
+      className: 'ml-2',
+      uppercase: false,
+      testId: 'custom-chip',
+    })).toEqual({
+      tone: 'bg-[var(--accent-12)]',
+      isSemanticTone: false,
+      contentSource: 'label',
+      uppercase: false,
+      hasCustomClass: true,
+      hasTestId: true,
+      labelLength: 6,
+      classNameLength: 4,
+      testIdLength: 11,
+    })
+  })
+
+  it('summarizes children content as taking precedence over label', () => {
+    expect(summarizeStatusChip({
+      label: 'legacy',
+      children: 'actual',
+    }).contentSource).toBe('children')
   })
 })

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -49,6 +49,20 @@ export type StatusChipTone =
   | 'select'
   | ''
 
+export type StatusChipContentSource = 'children' | 'label' | 'empty'
+
+export interface StatusChipSummary {
+  readonly tone: string
+  readonly isSemanticTone: boolean
+  readonly contentSource: StatusChipContentSource
+  readonly uppercase: boolean
+  readonly hasCustomClass: boolean
+  readonly hasTestId: boolean
+  readonly labelLength: number
+  readonly classNameLength: number
+  readonly testIdLength: number
+}
+
 const BASE_SHAPE =
   'inline-flex items-center rounded-[var(--r-0)] border px-2 py-0.5 text-3xs'
 const UPPERCASE_CLASS = 'uppercase tracking-wider'
@@ -151,7 +165,45 @@ export function statusChipClasses(
   return parts.join(' ')
 }
 
-interface StatusChipProps {
+function hasChildrenContent(children: ComponentChildren | undefined): boolean {
+  return children !== undefined && children !== null
+}
+
+export function summarizeStatusChip({
+  label,
+  tone = '',
+  className,
+  uppercase = true,
+  children,
+  testId,
+}: {
+  label?: string
+  tone?: string
+  className?: string
+  uppercase?: boolean
+  children?: ComponentChildren
+  testId?: string
+}): StatusChipSummary {
+  const contentSource = hasChildrenContent(children)
+    ? 'children'
+    : label !== undefined
+      ? 'label'
+      : 'empty'
+
+  return {
+    tone,
+    isSemanticTone: isSemanticTone(tone),
+    contentSource,
+    uppercase,
+    hasCustomClass: className !== undefined && className !== '',
+    hasTestId: testId !== undefined && testId !== '',
+    labelLength: label?.length ?? 0,
+    classNameLength: className?.length ?? 0,
+    testIdLength: testId?.length ?? 0,
+  }
+}
+
+export interface StatusChipProps {
   /** Legacy API — plain text label. Prefer `children` for new
       call sites. When both are set, `children` wins. */
   label?: string
@@ -177,13 +229,28 @@ export function StatusChip({
   children,
   testId,
 }: StatusChipProps) {
+  const summary = summarizeStatusChip({
+    label,
+    tone,
+    className: cx,
+    uppercase,
+    children,
+    testId,
+  })
   const cls = statusChipClasses(tone, cx, uppercase)
-  const content = children ?? label ?? ''
+  const content = summary.contentSource === 'children' ? children : label ?? ''
   return html`<span
     class=${cls}
     data-status-chip
-    data-status-chip-tone=${tone}
-    data-status-chip-uppercase=${uppercase ? 'true' : 'false'}
+    data-status-chip-tone=${summary.tone}
+    data-status-chip-is-semantic-tone=${summary.isSemanticTone}
+    data-status-chip-content-source=${summary.contentSource}
+    data-status-chip-uppercase=${summary.uppercase ? 'true' : 'false'}
+    data-status-chip-has-custom-class=${summary.hasCustomClass}
+    data-status-chip-has-test-id=${summary.hasTestId}
+    data-status-chip-label-length=${summary.labelLength}
+    data-status-chip-class-length=${summary.classNameLength}
+    data-status-chip-test-id-length=${summary.testIdLength}
     data-testid=${testId}
   >${content}</span>`
 }


### PR DESCRIPTION
## Summary

- Export `StatusChipProps` and add a pure `summarizeStatusChip` helper for design-system/runtime inspection.
- Stamp `StatusChip` with metadata for tone semantics, content source, uppercase state, custom class/test id presence, and label/class/test id lengths.
- Extend component tests to cover children-vs-label behavior, raw tone strings, and summary output.

## Why

The dashboard design-system audit needs primitive components to expose stable state in the DOM without depending on visual class parsing. This gives browser QA and downstream screens a consistent way to verify whether a status chip is semantic or raw/custom, what content path rendered, and which optional hooks are active.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/status-chip.test.ts src/components/common/status-chip.a11y.test.ts` passed: 2 files, 29 tests.
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` passed.
- `git diff --check` passed.
- `pnpm --dir dashboard run lint` passed with the known existing warnings in `copy-id-button.test.ts`, `virtual-list.ts`, and `fsm-hub.ts`.
- `pnpm --dir dashboard run build` passed with the known Vite dynamic/static import warning for `dashboard.ts`.

## Browser QA

- Served fixture with `env MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9 pnpm --dir dashboard exec vite --host 127.0.0.1 --port 5232 --strictPort --force`.
- Desktop 1280x900: verified 5 chips, semantic ok/warn/bad tones, raw custom tone, label fallback chip, metadata attributes, no horizontal overflow. Screenshot: `/tmp/masc-status-chip-summary-0506.png`.
- Mobile 390x760: verified the same metadata and no horizontal overflow. Screenshot: `/tmp/masc-status-chip-summary-0506-mobile.png`.
- Console check showed only Vite debug connection logs; page errors were empty.

## Cleanup

- Temporary QA fixture was removed before commit.
- Dashboard `node_modules` symlink was removed before commit/push.
- Local Vite server on port 5232 was stopped and the `masc-status-chip-0506` browser session was closed.