### PR TITLE
fix(keeper): honor explicit required tools

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -263,6 +263,24 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
        task_update, task_done, etc.). *)
     Agent_sdk.Types.Any
 
+let required_tool_names_for_turn ~(current_task_required_tool_names : string list)
+    ~(per_call_required_tool_names : string list) =
+  match per_call_required_tool_names with
+  | [] -> current_task_required_tool_names
+  | _ :: _ -> per_call_required_tool_names
+
+let preferred_tool_choice_for_required_tool_names
+    ~(required_tool_names : string list) ~(allowed_tool_names : string list) =
+  let visible_required =
+    required_tool_names
+    |> List.filter (fun name -> List.mem name allowed_tool_names)
+    |> Keeper_types.dedupe_keep_order
+  in
+  match visible_required with
+  | [ name ] -> Agent_sdk.Types.Tool name
+  | _ :: _ -> Agent_sdk.Types.Any
+  | [] -> Agent_sdk.Types.Auto
+
 let owned_active_task_id_for_meta =
   Keeper_current_task_reconcile.owned_active_task_id_for_meta
 

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -120,6 +120,23 @@ val preferred_tool_choice_for_required_turn :
   allowed_tool_names:string list ->
   Agent_sdk.Types.tool_choice
 
+(** Per-call [masc_keeper_msg.required_tools] is an explicit operator/harness
+    contract for this turn. When present, it takes precedence over the keeper's
+    active task contract so stale task-specific required tools cannot hijack the
+    message. *)
+val required_tool_names_for_turn :
+  current_task_required_tool_names:string list ->
+  per_call_required_tool_names:string list ->
+  string list
+
+(** Pick the model-facing [tool_choice] for an explicit required-tool list. A
+    single visible required tool should be forced specifically; multiple visible
+    required tools use [Any] and are checked after execution. *)
+val preferred_tool_choice_for_required_tool_names :
+  required_tool_names:string list ->
+  allowed_tool_names:string list ->
+  Agent_sdk.Types.tool_choice
+
 (** Find the active task ID a keeper currently owns. *)
 val owned_active_task_id_for_meta :
   config:Coord.config ->

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -716,7 +716,9 @@ let prepare_agent_setup
 
     in
     let required_tool_names =
-      current_task_required_tools () @ required_tool_names
+      required_tool_names_for_turn
+        ~current_task_required_tool_names:(current_task_required_tools ())
+        ~per_call_required_tool_names:required_tool_names
       |> Keeper_types.dedupe_keep_order
     in
     let visible_required_tool_names =
@@ -1291,7 +1293,11 @@ let prepare_agent_setup
                let tool_choice =
                  if computed_surface.required_tool_names <> []
                     && all_allowed <> []
-                 then Some Agent_sdk.Types.Any
+                 then
+                   Some
+                     (preferred_tool_choice_for_required_tool_names
+                        ~required_tool_names:computed_surface.required_tool_names
+                        ~allowed_tool_names:all_allowed)
                  else if computed_surface.is_last_turn
                  then current_params.tool_choice
                  else if computed_surface.tool_gate_requested && all_allowed <> []

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7351,6 +7351,7 @@ let test_tools_for_gated_affordance_covers_each_variant () =
        [ "board_post_or_comment" ])
 
 let test_preferred_tool_choice_for_required_turn_claims_first () =
+  let module Surface = Masc_mcp.Keeper_agent_tool_surface in
   let choose ?(has_current_task = false) ?(turn_affordances = [ "task_claim" ])
       ?(allowed_tool_names =
         [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_board_post" ])
@@ -7470,6 +7471,43 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
            "expected Auto when claim is unavailable and keeper is \
             idle (#10008), got %s"
            (Agent_sdk.Types.show_tool_choice other)));
+  check (list string)
+    "per-call required tools override active task required tools"
+    [ "keeper_board_post" ]
+    (Surface.required_tool_names_for_turn
+       ~current_task_required_tool_names:[ "keeper_board_curation_submit" ]
+       ~per_call_required_tool_names:[ "keeper_board_post" ]);
+  check (list string)
+    "active task required tools remain when no per-call requirement exists"
+    [ "keeper_board_curation_submit" ]
+    (Surface.required_tool_names_for_turn
+       ~current_task_required_tool_names:[ "keeper_board_curation_submit" ]
+       ~per_call_required_tool_names:[]);
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:[ "keeper_board_post" ]
+       ~allowed_tool_names:
+         [ "keeper_board_curation_submit"; "keeper_board_post" ]
+   with
+   | Agent_sdk.Types.Tool name ->
+       check string "single per-call required tool is forced"
+         "keeper_board_post" name
+   | other ->
+       fail
+         (Printf.sprintf "expected Tool keeper_board_post, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:
+         [ "keeper_shell"; "keeper_bash"; "keeper_board_post" ]
+       ~allowed_tool_names:
+         [ "keeper_shell"; "keeper_bash"; "keeper_board_post" ]
+   with
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+       fail
+         (Printf.sprintf "expected Any for multiple required tools, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
   (* Active task keeper retains the strict gate even without a
      specific applicable tool — the caller is expected to make
      progress via board_post, task_update, etc. *)


### PR DESCRIPTION
## Summary

- make per-call `masc_keeper_msg.required_tools` take precedence over active task contract required tools for that one turn
- force `tool_choice` to the single explicit required tool when exactly one required tool is visible, instead of falling through to unrelated affordance/task tools
- add regression coverage for explicit `keeper_board_post` not being hijacked by stale `keeper_board_curation_submit` task contracts

## Why it matters

The product/design reprobe exposed a real runtime blocker: `tech_glutton` was sent `required_tools=["keeper_board_post"]`, but the async result failed with a specific-tool contract for `keeper_board_curation_submit`. That makes a one-turn operator/harness request look like it failed the wrong task contract and blocks strict product/design fleet audit closure.

This keeps normal active-task required tools intact when no per-call requirement is supplied, while making explicit per-message requirements authoritative for the current keeper turn.

Tracks #13737 and supports #13727.

## Validation

- `python3 test/test_audit_keeper_fleet_readiness.py`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/harness/workload/keeper_product_design_board_reprobe.sh scripts/harness_keeper_product_design_board_reprobe.sh scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `git diff --check`

## Local Dune Caveat

- `scripts/dune-local.sh build test/test_keeper_unified.exe` is currently blocked on the known main build issue tracked by #13716/#13725 and fixed by draft PR #13722: `lib/coord_status_rendering.mli` exposes `assigned_task_ids`, but current `main` does not implement it yet.
- I also repaired the local `agent_sdk` pin drift with `scripts/opam-pin-external-deps.sh --install`; the installed switch now reports `agent_sdk 0.190.26`.