### PR TITLE
Normalize blank Goal list filters

### DIFF
--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -78,6 +78,7 @@ let make_type_field_error ~field ~constraint_violated ~expected ~received =
 let parse_optional_horizon args field =
   match Yojson.Safe.Util.member field args with
   | `Null -> Ok None
+  | `String raw when String.trim raw = "" -> Ok None
   | `String raw -> (
       match Goal_store.parse_horizon (Some raw) with
       | Some horizon -> Ok (Some horizon)
@@ -94,6 +95,7 @@ let parse_optional_horizon args field =
 let parse_optional_goal_status args field =
   match Yojson.Safe.Util.member field args with
   | `Null -> Ok None
+  | `String raw when String.trim raw = "" -> Ok None
   | `String raw -> (
       match Goal_store.parse_goal_status (Some raw) with
       | Some status -> Ok (Some status)
@@ -110,6 +112,7 @@ let parse_optional_goal_status args field =
 let parse_optional_goal_phase args field =
   match Yojson.Safe.Util.member field args with
   | `Null -> Ok None
+  | `String raw when String.trim raw = "" -> Ok None
   | `String raw -> (
       match Goal_store.parse_goal_phase (Some raw) with
       | Some phase -> Ok (Some phase)
@@ -132,6 +135,7 @@ let goal_upsert_lifecycle_error field =
 let parse_optional_review_outcome args field =
   match Yojson.Safe.Util.member field args with
   | `Null -> Ok None
+  | `String raw when String.trim raw = "" -> Ok None
   | `String raw -> (
       match Goal_store.parse_review_outcome raw with
       | Some outcome -> Ok (Some outcome)

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -182,6 +182,29 @@ let test_goal_list_filters_by_phase () =
         (get_string_field goal_json "phase")
   | _ -> fail "expected one filtered goal"
 
+let test_goal_list_ignores_blank_optional_filters () =
+  with_room @@ fun config ->
+  (match Goal_store.upsert_goal config ~title:"Blank filter goal" () with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
+  let listed =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_list"
+      ~args:
+        (`Assoc
+          [
+            ("horizon", `String "");
+            ("phase", `String "");
+            ("status", `String "");
+          ])
+  in
+  let listed_json =
+    match listed with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_list not handled"
+  in
+  check int "blank filters are ignored" 1
+    (Yojson.Safe.Util.member "count" listed_json |> Yojson.Safe.Util.to_int)
+
 let test_goal_upsert_rejects_lifecycle_fields () =
   with_room @@ fun config ->
   let rejected_phase =
@@ -709,6 +732,8 @@ let () =
         [
           test_case "upsert and list" `Quick test_goal_upsert_and_list;
           test_case "list filters by phase" `Quick test_goal_list_filters_by_phase;
+          test_case "list ignores blank optional filters" `Quick
+            test_goal_list_ignores_blank_optional_filters;
           test_case "upsert rejects lifecycle fields" `Quick
             test_goal_upsert_rejects_lifecycle_fields;
           test_case "review updates status" `Quick test_goal_review_updates_status;


### PR DESCRIPTION
## Summary

Normalize blank optional Goal filters so keeper/tool clients that serialize omitted enum fields as `""` do not fail validation.

## Why

Runtime proof after the Goal lifecycle allowlist reload showed that keepers could see and call the Goal tools, but real `masc_goal_list` calls failed when optional filters were present as empty strings:

- `status must be one of: active, paused, done, dropped`, received `""`
- `horizon must be one of: short, mid, long`, received `""`

That is an interoperability bug in the tool boundary, not a policy denial. Blank optional filters should behave the same as missing filters.

## Changes

- Treat blank `horizon`, `status`, `phase`, and review `outcome` strings as omitted optional arguments.
- Add a `masc_goal_list` regression test that passes blank optional filters and expects the existing goal to be listed.

## Validation

- `git diff --check`
- Attempted `scripts/dune-local.sh build test/test_goal_tools.exe`; local wrapper aborted before build because the shared opam switch currently has `agent_sdk` pinned to `52515168760a716d73400c2bb398194452f8103c` while this repo expects `434b72c0141886bf70214799ca03309c48cbd202`. I did not global-repin the shared switch because other worktrees are actively running SDK pin work. CI should validate in a clean environment.
