### PR TITLE
fix(dashboard): expose input metadata

### DIFF
--- a/dashboard/src/components/common/input.test.ts
+++ b/dashboard/src/components/common/input.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { TextInput, TextArea } from './input'
+import { TextInput, TextArea, summarizeTextInput, summarizeTextArea } from './input'
 
 const flushUi = async () => {
   for (let i = 0; i < 4; i++) await Promise.resolve()
@@ -127,6 +127,85 @@ describe('TextInput', () => {
     const input = container.querySelector('input') as HTMLInputElement
     expect(ref.current).toBe(input)
   })
+
+  it('stamps design-system metadata on the input element', () => {
+    render(
+      html`<${TextInput}
+        id="my-input"
+        value="hello"
+        placeholder="type here"
+        disabled=${true}
+        required=${true}
+        class="extra-hook"
+        type="search"
+        name="query"
+        ariaLabel="Search query"
+        autoComplete="off"
+        testId="search-filter"
+        autoFocus=${true}
+      />`,
+      container,
+    )
+    const input = container.querySelector('[data-text-input]')!
+
+    expect(input.getAttribute('data-text-input-kind')).toBe('text-input')
+    expect(input.getAttribute('data-text-input-type')).toBe('search')
+    expect(input.getAttribute('data-text-input-has-value')).toBe('true')
+    expect(input.getAttribute('data-text-input-value-length')).toBe('5')
+    expect(input.getAttribute('data-text-input-has-placeholder')).toBe('true')
+    expect(input.getAttribute('data-text-input-placeholder-length')).toBe('9')
+    expect(input.getAttribute('data-text-input-disabled')).toBe('true')
+    expect(input.getAttribute('data-text-input-required')).toBe('true')
+    expect(input.getAttribute('data-text-input-has-custom-class')).toBe('true')
+    expect(input.getAttribute('data-text-input-class-length')).toBe('10')
+    expect(input.getAttribute('data-text-input-has-id')).toBe('true')
+    expect(input.getAttribute('data-text-input-has-name')).toBe('true')
+    expect(input.getAttribute('data-text-input-has-aria-label')).toBe('true')
+    expect(input.getAttribute('data-text-input-has-autocomplete')).toBe('true')
+    expect(input.getAttribute('data-text-input-has-test-id')).toBe('true')
+    expect(input.getAttribute('data-text-input-autofocus')).toBe('true')
+  })
+
+  it('summarizes default text input state', () => {
+    expect(summarizeTextInput({})).toMatchObject({
+      kind: 'text-input',
+      type: 'text',
+      hasValue: false,
+      valueLength: 0,
+      hasPlaceholder: false,
+      disabled: false,
+      required: false,
+      hasCustomClass: false,
+      hasId: false,
+      hasName: false,
+      hasAriaLabel: false,
+      hasAutoComplete: false,
+      hasTestId: false,
+      autoFocus: false,
+      ariaExpandedState: 'unset',
+      autocompleteState: 'none',
+    })
+  })
+
+  it('summarizes populated text input state without exposing the value text', () => {
+    expect(summarizeTextInput({
+      value: 'token',
+      placeholder: 'secret',
+      class: 'extra-hook',
+      type: 'password',
+      testId: 'token-input',
+    })).toMatchObject({
+      kind: 'text-input',
+      type: 'password',
+      hasValue: true,
+      valueLength: 5,
+      hasPlaceholder: true,
+      placeholderLength: 6,
+      hasCustomClass: true,
+      classNameLength: 10,
+      hasTestId: true,
+    })
+  })
 })
 
 describe('TextArea', () => {
@@ -182,5 +261,63 @@ describe('TextArea', () => {
     render(html`<${TextArea} inputRef=${ref} />`, container)
     const ta = container.querySelector('textarea') as HTMLTextAreaElement
     expect(ref.current).toBe(ta)
+  })
+
+  it('stamps design-system metadata on the textarea element', () => {
+    const ref: { current: HTMLTextAreaElement | null } = { current: null }
+    render(
+      html`<${TextArea}
+        id="prompt"
+        value=${'multi\nline'}
+        placeholder="Write"
+        rows=${4}
+        class="grow"
+        name="prompt"
+        ariaLabel="Prompt"
+        ariaAutocomplete="list"
+        ariaControls="prompt-list"
+        ariaExpanded="true"
+        ariaActiveDescendant="prompt-option-1"
+        role="combobox"
+        required=${true}
+        inputRef=${ref}
+        onInput=${vi.fn()}
+        onKeyDown=${vi.fn()}
+      />`,
+      container,
+    )
+    const textarea = container.querySelector('[data-textarea]')!
+
+    expect(textarea.getAttribute('data-textarea-kind')).toBe('textarea')
+    expect(textarea.getAttribute('data-textarea-rows')).toBe('4')
+    expect(textarea.getAttribute('data-textarea-has-rows')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-has-value')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-value-length')).toBe('10')
+    expect(textarea.getAttribute('data-textarea-has-placeholder')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-placeholder-length')).toBe('5')
+    expect(textarea.getAttribute('data-textarea-required')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-has-custom-class')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-class-length')).toBe('4')
+    expect(textarea.getAttribute('data-textarea-has-id')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-has-name')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-has-aria-label')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-aria-expanded-state')).toBe('true')
+    expect(textarea.getAttribute('data-textarea-autocomplete-state')).toBe('complete')
+  })
+
+  it('summarizes textarea autocomplete state', () => {
+    expect(summarizeTextArea({
+      rows: 3,
+      ariaExpanded: 'mixed',
+      ariaControls: 'listbox',
+      role: 'combobox',
+      onKeyDown: vi.fn(),
+    })).toMatchObject({
+      kind: 'textarea',
+      rows: 3,
+      hasRows: true,
+      ariaExpandedState: 'other',
+      autocompleteState: 'partial',
+    })
   })
 })

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -11,6 +11,33 @@
 import { html } from 'htm/preact'
 import { ringFocusClasses } from './ring'
 
+export type InputControlKind = 'text-input' | 'textarea'
+export type InputAriaExpandedState = 'unset' | 'true' | 'false' | 'other'
+export type TextAreaAutocompleteState = 'none' | 'partial' | 'complete'
+
+export interface InputControlSummary {
+  readonly kind: InputControlKind
+  readonly type: string
+  readonly rows: number
+  readonly hasRows: boolean
+  readonly hasValue: boolean
+  readonly valueLength: number
+  readonly hasPlaceholder: boolean
+  readonly placeholderLength: number
+  readonly disabled: boolean
+  readonly required: boolean
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+  readonly hasId: boolean
+  readonly hasName: boolean
+  readonly hasAriaLabel: boolean
+  readonly hasAutoComplete: boolean
+  readonly hasTestId: boolean
+  readonly autoFocus: boolean
+  readonly ariaExpandedState: InputAriaExpandedState
+  readonly autocompleteState: TextAreaAutocompleteState
+}
+
 // Form input surface — bg/fg/border + hover/focus state slots resolve
 // from the input-* component-level token family (#11917). Future field
 // retune (e.g. brand re-skin, dark/light) ripples to all 4 form
@@ -19,7 +46,117 @@ import { ringFocusClasses } from './ring'
 // pending follow-up token slots (input-placeholder, input-border-focus).
 const INPUT_BASE = `w-full rounded-[var(--r-1)] bg-[var(--input-bg)] border border-[var(--input-border)] text-[var(--input-fg)] placeholder:text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--input-bg-hover)] focus-visible:bg-[var(--input-bg-focus)] focus-visible:border-[var(--info-border)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`
 
-interface TextInputProps {
+function nonEmptyLength(value: string | undefined): number {
+  return value?.length ?? 0
+}
+
+function hasNonEmptyValue(value: string | undefined): boolean {
+  return value !== undefined && value !== ''
+}
+
+function ariaExpandedState(value: boolean | string | undefined): InputAriaExpandedState {
+  if (value === undefined) return 'unset'
+  if (value === true || value === 'true') return 'true'
+  if (value === false || value === 'false') return 'false'
+  return 'other'
+}
+
+function textAreaAutocompleteState({
+  role,
+  ariaAutocomplete,
+  ariaControls,
+  ariaActiveDescendant,
+}: {
+  role?: string
+  ariaAutocomplete?: string
+  ariaControls?: string
+  ariaActiveDescendant?: string
+}): TextAreaAutocompleteState {
+  const hasAutocompleteShape =
+    hasNonEmptyValue(role) ||
+    hasNonEmptyValue(ariaAutocomplete) ||
+    hasNonEmptyValue(ariaControls) ||
+    hasNonEmptyValue(ariaActiveDescendant)
+  if (!hasAutocompleteShape) return 'none'
+  if (
+    role === 'combobox' &&
+    hasNonEmptyValue(ariaAutocomplete) &&
+    hasNonEmptyValue(ariaControls)
+  ) return 'complete'
+  return 'partial'
+}
+
+function summarizeInputControl({
+  kind,
+  type,
+  rows,
+  value,
+  placeholder,
+  disabled,
+  required,
+  className,
+  id,
+  name,
+  ariaLabel,
+  autoComplete,
+  testId,
+  autoFocus,
+  role,
+  ariaAutocomplete,
+  ariaControls,
+  ariaExpanded,
+  ariaActiveDescendant,
+}: {
+  kind: InputControlKind
+  type?: string
+  rows?: number
+  value?: string
+  placeholder?: string
+  disabled?: boolean
+  required?: boolean
+  className?: string
+  id?: string
+  name?: string
+  ariaLabel?: string
+  autoComplete?: string
+  testId?: string
+  autoFocus?: boolean
+  role?: string
+  ariaAutocomplete?: string
+  ariaControls?: string
+  ariaExpanded?: boolean | string
+  ariaActiveDescendant?: string
+}): InputControlSummary {
+  return {
+    kind,
+    type: type ?? '',
+    rows: rows ?? 0,
+    hasRows: rows !== undefined,
+    hasValue: hasNonEmptyValue(value),
+    valueLength: nonEmptyLength(value),
+    hasPlaceholder: hasNonEmptyValue(placeholder),
+    placeholderLength: nonEmptyLength(placeholder),
+    disabled: disabled === true,
+    required: required === true,
+    hasCustomClass: hasNonEmptyValue(className),
+    classNameLength: nonEmptyLength(className),
+    hasId: hasNonEmptyValue(id),
+    hasName: hasNonEmptyValue(name),
+    hasAriaLabel: hasNonEmptyValue(ariaLabel),
+    hasAutoComplete: hasNonEmptyValue(autoComplete),
+    hasTestId: hasNonEmptyValue(testId),
+    autoFocus: autoFocus === true,
+    ariaExpandedState: ariaExpandedState(ariaExpanded),
+    autocompleteState: textAreaAutocompleteState({
+      role,
+      ariaAutocomplete,
+      ariaControls,
+      ariaActiveDescendant,
+    }),
+  }
+}
+
+export interface TextInputProps {
   id?: string
   value?: string
   placeholder?: string
@@ -50,6 +187,37 @@ interface TextInputProps {
   onBlur?: (e: FocusEvent) => void
 }
 
+export function summarizeTextInput({
+  id,
+  value,
+  placeholder,
+  disabled,
+  required,
+  class: cx,
+  type = 'text',
+  name,
+  ariaLabel,
+  autoComplete,
+  testId,
+  autoFocus,
+}: TextInputProps): InputControlSummary {
+  return summarizeInputControl({
+    kind: 'text-input',
+    type,
+    value,
+    placeholder,
+    disabled,
+    required,
+    className: cx,
+    id,
+    name,
+    ariaLabel,
+    autoComplete,
+    testId,
+    autoFocus,
+  })
+}
+
 export function TextInput({
   id,
   value,
@@ -68,6 +236,21 @@ export function TextInput({
   onKeyDown,
   onBlur,
 }: TextInputProps) {
+  const summary = summarizeTextInput({
+    id,
+    value,
+    placeholder,
+    disabled,
+    required,
+    class: cx,
+    type,
+    name,
+    ariaLabel,
+    autoComplete,
+    testId,
+    autoFocus,
+  })
+
   return html`
     <input
       ref=${inputRef}
@@ -82,6 +265,23 @@ export function TextInput({
       aria-label=${ariaLabel}
       autocomplete=${autoComplete}
       data-testid=${testId}
+      data-text-input
+      data-text-input-kind=${summary.kind}
+      data-text-input-type=${summary.type}
+      data-text-input-has-value=${summary.hasValue}
+      data-text-input-value-length=${summary.valueLength}
+      data-text-input-has-placeholder=${summary.hasPlaceholder}
+      data-text-input-placeholder-length=${summary.placeholderLength}
+      data-text-input-disabled=${summary.disabled}
+      data-text-input-required=${summary.required}
+      data-text-input-has-custom-class=${summary.hasCustomClass}
+      data-text-input-class-length=${summary.classNameLength}
+      data-text-input-has-id=${summary.hasId}
+      data-text-input-has-name=${summary.hasName}
+      data-text-input-has-aria-label=${summary.hasAriaLabel}
+      data-text-input-has-autocomplete=${summary.hasAutoComplete}
+      data-text-input-has-test-id=${summary.hasTestId}
+      data-text-input-autofocus=${summary.autoFocus}
       autofocus=${autoFocus}
       onInput=${onInput}
       onKeyDown=${onKeyDown}
@@ -90,7 +290,7 @@ export function TextInput({
   `
 }
 
-interface TextAreaProps {
+export interface TextAreaProps {
   id?: string
   value?: string
   placeholder?: string
@@ -113,6 +313,41 @@ interface TextAreaProps {
   onKeyDown?: (e: KeyboardEvent) => void
 }
 
+export function summarizeTextArea({
+  id,
+  value,
+  placeholder,
+  rows,
+  class: cx,
+  name,
+  ariaLabel,
+  ariaAutocomplete,
+  ariaControls,
+  ariaExpanded,
+  ariaActiveDescendant,
+  role,
+  disabled,
+  required,
+}: TextAreaProps): InputControlSummary {
+  return summarizeInputControl({
+    kind: 'textarea',
+    rows,
+    value,
+    placeholder,
+    disabled,
+    required,
+    className: cx,
+    id,
+    name,
+    ariaLabel,
+    role,
+    ariaAutocomplete,
+    ariaControls,
+    ariaExpanded,
+    ariaActiveDescendant,
+  })
+}
+
 export function TextArea({
   id,
   value,
@@ -132,6 +367,23 @@ export function TextArea({
   onInput,
   onKeyDown,
 }: TextAreaProps) {
+  const summary = summarizeTextArea({
+    id,
+    value,
+    placeholder,
+    rows,
+    class: cx,
+    name,
+    ariaLabel,
+    ariaAutocomplete,
+    ariaControls,
+    ariaExpanded,
+    ariaActiveDescendant,
+    role,
+    disabled,
+    required,
+  })
+
   return html`
     <textarea
       ref=${inputRef}
@@ -149,6 +401,23 @@ export function TextArea({
       disabled=${disabled}
       required=${required}
       value=${value}
+      data-textarea
+      data-textarea-kind=${summary.kind}
+      data-textarea-rows=${summary.rows}
+      data-textarea-has-rows=${summary.hasRows}
+      data-textarea-has-value=${summary.hasValue}
+      data-textarea-value-length=${summary.valueLength}
+      data-textarea-has-placeholder=${summary.hasPlaceholder}
+      data-textarea-placeholder-length=${summary.placeholderLength}
+      data-textarea-disabled=${summary.disabled}
+      data-textarea-required=${summary.required}
+      data-textarea-has-custom-class=${summary.hasCustomClass}
+      data-textarea-class-length=${summary.classNameLength}
+      data-textarea-has-id=${summary.hasId}
+      data-textarea-has-name=${summary.hasName}
+      data-textarea-has-aria-label=${summary.hasAriaLabel}
+      data-textarea-aria-expanded-state=${summary.ariaExpandedState}
+      data-textarea-autocomplete-state=${summary.autocompleteState}
       onInput=${onInput}
       onKeyDown=${onKeyDown}
     ></textarea>


### PR DESCRIPTION
## Summary

- Export `TextInputProps` / `TextAreaProps` and add pure `summarizeTextInput` / `summarizeTextArea` helpers.
- Stamp `TextInput` and `TextArea` DOM nodes with stable design-system metadata for value/placeholder lengths, disabled/required state, custom class hooks, identity/name/a11y hooks, input type, textarea rows, aria-expanded state, and textarea autocomplete wiring.
- Extend common input tests to cover the metadata attributes and summary helpers without exposing actual field values.

## Why

The dashboard component audit needs reusable form primitives to expose inspectable state without parsing CSS classes or leaking sensitive field content. These metadata attributes let browser QA and downstream screens verify the rendered input contract directly.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/input.test.ts src/components/common/input.a11y.test.ts` passed after rebase: 2 files, 31 tests.
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` passed after rebase.
- `git diff --check` passed.
- `pnpm --dir dashboard run lint` passed with the existing warnings in `virtual-list.ts` and `fsm-hub.ts`.
- `pnpm --dir dashboard run build` passed with the known Vite dynamic/static import warning for `dashboard.ts`.

## Browser QA

- Served a temporary fixture with `env MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9 pnpm --dir dashboard exec vite --host 127.0.0.1 --port 5233 --strictPort --force`.
- Desktop 1280x900: verified 2 `TextInput` controls plus 1 `TextArea`, expected metadata attributes, and no horizontal overflow. Screenshot: `/tmp/masc-input-summary-0506.png`.
- Mobile 390x760: verified the same metadata and no horizontal overflow. Screenshot: `/tmp/masc-input-summary-0506-mobile.png`.
- Console check showed only Vite debug connection logs; page errors were empty.

## Cleanup

- Temporary QA fixture was removed before commit.
- Dashboard `node_modules` symlink was removed before commit/push.
- Local Vite server on port 5233 was stopped and the `masc-input-0506` browser session was closed.