### PR TITLE
fix(dashboard): expose progress bar metadata

### DIFF
--- a/dashboard/src/components/common/progress-bar.test.ts
+++ b/dashboard/src/components/common/progress-bar.test.ts
@@ -8,6 +8,7 @@ import {
   progressBarHeightClass,
   progressBarToneClass,
   progressBarTrackToneClass,
+  summarizeProgressBar,
 } from './progress-bar'
 
 describe('progressBarWidthStyle (pure)', () => {
@@ -68,6 +69,62 @@ describe('progressBarToneClass (pure)', () => {
   })
 })
 
+describe('summarizeProgressBar (pure)', () => {
+  it('summarizes default progress bar state', () => {
+    expect(summarizeProgressBar({ pct: 42.5 })).toEqual({
+      inputPct: 42.5,
+      clampedPct: 42.5,
+      roundedPct: 43,
+      widthStyle: 'width: 42.50%',
+      size: 'sm',
+      tone: 'accent',
+      trackTone: 'default',
+      isSemantic: false,
+      fillSource: 'tone',
+      hasCustomFillClass: false,
+      fillClassLength: 0,
+      hasTrackClass: false,
+      trackClassLength: 0,
+      hasTitle: false,
+      titleLength: 0,
+      hasTestId: false,
+      testIdLength: 0,
+    })
+  })
+
+  it('summarizes custom fill, semantic, and clamped state', () => {
+    expect(summarizeProgressBar({
+      pct: -9,
+      size: 'md',
+      tone: 'bad',
+      class: 'bg-[var(--bad-10)]',
+      trackTone: 'dim',
+      trackClass: 'flex-1',
+      title: '0% complete',
+      ariaLabel: 'Build progress',
+      testId: 'build-progress',
+    })).toEqual({
+      inputPct: -9,
+      clampedPct: 0,
+      roundedPct: 0,
+      widthStyle: 'width: 0.00%',
+      size: 'md',
+      tone: 'bad',
+      trackTone: 'dim',
+      isSemantic: true,
+      fillSource: 'custom-class',
+      hasCustomFillClass: true,
+      fillClassLength: 18,
+      hasTrackClass: true,
+      trackClassLength: 6,
+      hasTitle: true,
+      titleLength: 11,
+      hasTestId: true,
+      testIdLength: 14,
+    })
+  })
+})
+
 describe('ProgressBar component', () => {
   let container: HTMLElement
   beforeEach(() => {
@@ -83,6 +140,12 @@ describe('ProgressBar component', () => {
     render(html`<${ProgressBar} pct=${42.5} />`, container)
     const track = container.querySelector('[data-progress-bar]') as HTMLElement
     expect(track).toBeTruthy()
+    expect(track.getAttribute('data-progress-bar-tone')).toBe('accent')
+    expect(track.getAttribute('data-progress-bar-track-tone')).toBe('default')
+    expect(track.getAttribute('data-progress-bar-input-pct')).toBe('42.5')
+    expect(track.getAttribute('data-progress-bar-clamped-pct')).toBe('42.50')
+    expect(track.getAttribute('data-progress-bar-is-semantic')).toBe('false')
+    expect(track.getAttribute('data-progress-bar-fill-source')).toBe('tone')
     const fill = track.querySelector('div') as HTMLElement
     expect(fill.getAttribute('style')).toContain('width: 42.50%')
   })
@@ -113,6 +176,7 @@ describe('ProgressBar component', () => {
     expect(track.getAttribute('aria-valuemin')).toBe('0')
     expect(track.getAttribute('aria-valuemax')).toBe('100')
     expect(track.getAttribute('aria-hidden')).toBeNull()
+    expect(track.getAttribute('data-progress-bar-is-semantic')).toBe('true')
   })
 
   it('tone prop maps to the fill bg class', () => {
@@ -130,6 +194,10 @@ describe('ProgressBar component', () => {
     expect(fill.className).toContain('bg-[var(--sky-400)]')
     // Tone fallback must NOT also be present when class is given.
     expect(fill.className).not.toContain('bg-[var(--color-accent-fg)]')
+    const track = container.querySelector('[data-progress-bar]')!
+    expect(track.getAttribute('data-progress-bar-fill-source')).toBe('custom-class')
+    expect(track.getAttribute('data-progress-bar-has-custom-fill-class')).toBe('true')
+    expect(track.getAttribute('data-progress-bar-fill-class-length')).toBe('19')
   })
 
   it('title attribute propagates to the track', () => {
@@ -137,7 +205,10 @@ describe('ProgressBar component', () => {
       html`<${ProgressBar} pct=${50} title="67% complete" />`,
       container,
     )
-    expect(container.querySelector('[data-progress-bar]')!.getAttribute('title')).toBe('67% complete')
+    const track = container.querySelector('[data-progress-bar]')!
+    expect(track.getAttribute('title')).toBe('67% complete')
+    expect(track.getAttribute('data-progress-bar-has-title')).toBe('true')
+    expect(track.getAttribute('data-progress-bar-title-length')).toBe('12')
   })
 
   it('size variant reflected in data attribute + height class', () => {
@@ -152,6 +223,9 @@ describe('ProgressBar component', () => {
       html`<${ProgressBar} pct=${50} testId="build-progress" />`,
       container,
     )
-    expect(container.querySelector('[data-testid="build-progress"]')).toBeTruthy()
+    const track = container.querySelector('[data-testid="build-progress"]')!
+    expect(track).toBeTruthy()
+    expect(track.getAttribute('data-progress-bar-has-test-id')).toBe('true')
+    expect(track.getAttribute('data-progress-bar-test-id-length')).toBe('14')
   })
 })

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -14,17 +14,42 @@
 
 import { html } from 'htm/preact'
 
-type ProgressBarSize = 'xs' | 'sm' | 'md'
-type ProgressBarTone =
+export type ProgressBarSize = 'xs' | 'sm' | 'md'
+export type ProgressBarTone =
   | 'accent' | 'ok' | 'warn' | 'bad'
   | 'emerald' | 'amber' | 'rose' | 'sky'
+export type ProgressBarFillSource = 'tone' | 'custom-class'
+
+export interface ProgressBarSummary {
+  readonly inputPct: number
+  readonly clampedPct: number
+  readonly roundedPct: number
+  readonly widthStyle: string
+  readonly size: ProgressBarSize
+  readonly tone: ProgressBarTone
+  readonly trackTone: ProgressBarTrackTone
+  readonly isSemantic: boolean
+  readonly fillSource: ProgressBarFillSource
+  readonly hasCustomFillClass: boolean
+  readonly fillClassLength: number
+  readonly hasTrackClass: boolean
+  readonly trackClassLength: number
+  readonly hasTitle: boolean
+  readonly titleLength: number
+  readonly hasTestId: boolean
+  readonly testIdLength: number
+}
+
+function clampProgressPct(pct: number): number {
+  return Math.max(0, Math.min(100, pct))
+}
 
 /** Pure: clamp a percentage into [0, 100] and produce the inline width
     style string. Exposed so callers that need to render the bar inline
     (inside a flex row with other progress bars) can use the same
     semantics without mounting the component. */
 export function progressBarWidthStyle(pct: number): string {
-  const clamped = Math.max(0, Math.min(100, pct))
+  const clamped = clampProgressPct(pct)
   return `width: ${clamped.toFixed(2)}%`
 }
 
@@ -53,7 +78,7 @@ export function progressBarToneClass(tone: ProgressBarTone): string {
   }
 }
 
-type ProgressBarTrackTone = 'default' | 'dim' | 'muted'
+export type ProgressBarTrackTone = 'default' | 'dim' | 'muted'
 
 /** Pure: track (muted background) bg class for a given track tone.
     Default = --white-5 (most rows); dim = --white-6 (keeper detail);
@@ -67,7 +92,7 @@ export function progressBarTrackToneClass(tone: ProgressBarTrackTone = 'default'
   }
 }
 
-interface ProgressBarProps {
+export interface ProgressBarProps {
   /** Percentage 0–100; values outside are clamped (no throw). */
   pct: number
   size?: ProgressBarSize
@@ -94,6 +119,41 @@ interface ProgressBarProps {
 const TRACK_BASE = 'w-full overflow-hidden rounded-[var(--r-0)]'
 const FILL_BASE = 'h-full rounded-[var(--r-0)] transition-[width] duration-[var(--t-slow)] ease-[var(--ease-inout)]'
 
+export function summarizeProgressBar({
+  pct,
+  size = 'sm',
+  tone = 'accent',
+  class: cx,
+  trackTone = 'default',
+  trackClass,
+  title,
+  ariaLabel,
+  testId,
+}: ProgressBarProps): ProgressBarSummary {
+  const clampedPct = clampProgressPct(pct)
+  const fillSource = cx !== undefined && cx !== '' ? 'custom-class' : 'tone'
+
+  return {
+    inputPct: pct,
+    clampedPct,
+    roundedPct: Number(clampedPct.toFixed(0)),
+    widthStyle: progressBarWidthStyle(pct),
+    size,
+    tone,
+    trackTone,
+    isSemantic: ariaLabel !== undefined,
+    fillSource,
+    hasCustomFillClass: fillSource === 'custom-class',
+    fillClassLength: cx?.length ?? 0,
+    hasTrackClass: trackClass !== undefined && trackClass !== '',
+    trackClassLength: trackClass?.length ?? 0,
+    hasTitle: title !== undefined && title !== '',
+    titleLength: title?.length ?? 0,
+    hasTestId: testId !== undefined && testId !== '',
+    testIdLength: testId?.length ?? 0,
+  }
+}
+
 export function ProgressBar({
   pct,
   size = 'sm',
@@ -105,26 +165,48 @@ export function ProgressBar({
   ariaLabel,
   testId,
 }: ProgressBarProps) {
+  const summary = summarizeProgressBar({
+    pct,
+    size,
+    tone,
+    class: cx,
+    trackTone,
+    trackClass,
+    title,
+    ariaLabel,
+    testId,
+  })
   const height = progressBarHeightClass(size)
   const fillClass = cx ?? progressBarToneClass(tone)
   const trackBg = progressBarTrackToneClass(trackTone)
-  const widthStyle = progressBarWidthStyle(pct)
-  const clamped = Math.max(0, Math.min(100, pct))
-  const semantic = ariaLabel !== undefined
   return html`<div
     class=${`${TRACK_BASE} ${height} ${trackBg} ${trackClass ?? ''}`}
     title=${title}
-    role=${semantic ? 'progressbar' : undefined}
+    role=${summary.isSemantic ? 'progressbar' : undefined}
     aria-label=${ariaLabel}
-    aria-valuenow=${semantic ? clamped.toFixed(0) : undefined}
-    aria-valuemin=${semantic ? '0' : undefined}
-    aria-valuemax=${semantic ? '100' : undefined}
-    aria-hidden=${semantic ? undefined : 'true'}
+    aria-valuenow=${summary.isSemantic ? summary.roundedPct.toFixed(0) : undefined}
+    aria-valuemin=${summary.isSemantic ? '0' : undefined}
+    aria-valuemax=${summary.isSemantic ? '100' : undefined}
+    aria-hidden=${summary.isSemantic ? undefined : 'true'}
     data-progress-bar
-    data-progress-bar-size=${size}
-    data-progress-bar-pct=${clamped.toFixed(0)}
+    data-progress-bar-size=${summary.size}
+    data-progress-bar-tone=${summary.tone}
+    data-progress-bar-track-tone=${summary.trackTone}
+    data-progress-bar-pct=${summary.roundedPct.toFixed(0)}
+    data-progress-bar-input-pct=${summary.inputPct}
+    data-progress-bar-clamped-pct=${summary.clampedPct.toFixed(2)}
+    data-progress-bar-is-semantic=${summary.isSemantic}
+    data-progress-bar-fill-source=${summary.fillSource}
+    data-progress-bar-has-custom-fill-class=${summary.hasCustomFillClass}
+    data-progress-bar-fill-class-length=${summary.fillClassLength}
+    data-progress-bar-has-track-class=${summary.hasTrackClass}
+    data-progress-bar-track-class-length=${summary.trackClassLength}
+    data-progress-bar-has-title=${summary.hasTitle}
+    data-progress-bar-title-length=${summary.titleLength}
+    data-progress-bar-has-test-id=${summary.hasTestId}
+    data-progress-bar-test-id-length=${summary.testIdLength}
     data-testid=${testId}
   >
-    <div class=${`${FILL_BASE} ${fillClass}`} style=${widthStyle}></div>
+    <div class=${`${FILL_BASE} ${fillClass}`} style=${summary.widthStyle}></div>
   </div>`
 }


### PR DESCRIPTION
## Summary

- Export `ProgressBar` prop/tone/size types and add a pure `summarizeProgressBar` helper.
- Stamp progress bars with metadata for raw/clamped/rounded pct, tone, track tone, semantic vs decorative mode, fill source, custom fill/track/title/test hooks, and length-only hook details.
- Extend progress bar tests to cover summary output and DOM metadata for default, semantic, and custom fill cases.

## Why

The dashboard component audit needs progress primitives to expose stable rendered state without parsing width styles or class lists. The summary keeps the raw pct visible while also proving clamped visual state and semantic accessibility wiring.

## Validation

- `pnpm --dir dashboard exec vitest run src/components/common/progress-bar.test.ts src/components/common/progress-bar.a11y.test.ts` passed after rebase: 2 files, 26 tests.
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` passed after rebase.
- `git diff --check` passed.
- `pnpm --dir dashboard run lint` passed with the existing warnings in `virtual-list.ts` and `fsm-hub.ts`.
- `pnpm --dir dashboard run build` passed with the known Vite dynamic/static import warning for `dashboard.ts`.

## Browser QA

- Served a temporary fixture with `env MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9 pnpm --dir dashboard exec vite --host 127.0.0.1 --port 5234 --strictPort --force`.
- Desktop 1280x900: verified 3 bars, expected metadata attributes, semantic/decorative roles, custom class source, clamped 125 -> 100, and no horizontal overflow. Screenshot: `/tmp/masc-progress-bar-summary-0506.png`.
- Mobile 390x760: verified the same metadata and no horizontal overflow. Screenshot: `/tmp/masc-progress-bar-summary-0506-mobile.png`.
- Console check showed only Vite debug connection logs; page errors were empty.

## Cleanup

- Temporary QA fixture was removed before commit.
- Dashboard `node_modules` symlink was removed before commit/push.
- Local Vite server on port 5234 was stopped and the `masc-progress-bar-0506` browser session was closed.