### PR TITLE
docs(dashboard): align ws-only env default

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -21,11 +21,11 @@ MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935
 
 # SSE → WebSocket cutover.  When true, the dashboard skips the /sse
 # EventSource entirely and consumes broadcast traffic only over /ws.
-# Default is false (parallel mode) to keep existing deployments on the
-# safety net until the operator has validated WS in their environment.
-# Dev defaults to true via .env.development.  Production builds default
-# to true via .env.production (loaded by `vite build`).  For a one-off
-# build with the flag off, copy .env.production to .env.production.local
-# and comment out the assignment.  Hot rollback in the browser:
+# Default is true (WS-only mode).  Leave unset to use the code default,
+# or set false to keep the old parallel /sse + /ws safety net for a
+# one-off environment.  Dev and production env files also set true.
+# For a one-off production build with the flag off, copy .env.production
+# to .env.production.local and set the assignment to false.  Hot rollback
+# in the browser:
 #   window.__MASC_DASHBOARD_WS_ONLY__ = false; location.reload()
 # VITE_DASHBOARD_WS_ONLY=true


### PR DESCRIPTION
## What

- Update `dashboard/.env.example` so the documented `VITE_DASHBOARD_WS_ONLY` default matches the current code and checked-in dashboard env files.
- Keep the rollback instructions explicit: set the flag to `false` for the old parallel `/sse` + `/ws` mode or use the runtime browser override.

## Why

The dashboard cutover code now defaults to WS-only mode, and both `.env.development` and `.env.production` set `VITE_DASHBOARD_WS_ONLY=true`. The example file still described the default as false, which made the QW-1 / WS-only status look less complete than the code actually is.

## Validation

- `git diff --check`
- `rg -n "Default is false|Default is true|VITE_DASHBOARD_WS_ONLY" dashboard/.env.example dashboard/.env.development dashboard/.env.production dashboard/src/dashboard-ws-cutover.ts dashboard/src/dashboard-ws-cutover.test.ts`

## Caveat

- Focused Vitest was not runnable in this fresh worktree because `pnpm --dir dashboard exec vitest ...` returned `Command "vitest" not found`; I did not install dependencies for a comment-only `.env.example` change.
