### PR TITLE
Qualify agent status constructors in Coord

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -337,18 +337,19 @@ let clear_agent_current_task_cache config ~task_id =
                | Ok agent when agent.current_task = Some task_id ->
                  let status =
                    match agent.status with
-                   | Inactive -> Inactive
-                   | Active | Busy | Listening -> Active
+                   | Masc_domain.Inactive -> Masc_domain.Inactive
+                   | Masc_domain.Active | Masc_domain.Busy | Masc_domain.Listening ->
+                     Masc_domain.Active
                  in
                  let updated =
                    {
                      agent with
                      status;
                      current_task = None;
-                     last_seen = now_iso ();
+                     last_seen = Masc_domain.now_iso ();
                    }
                  in
-                 write_json config path (agent_to_yojson updated);
+                 write_json config path (Masc_domain.agent_to_yojson updated);
                  log_event
                    config
                    (`Assoc
@@ -356,7 +357,7 @@ let clear_agent_current_task_cache config ~task_id =
                         ("type", `String "agent_current_task_cache_cleared");
                         ("agent", `String agent.name);
                         ("stale_task", `String task_id);
-                        ("ts", `String (now_iso ()));
+                        ("ts", `String (Masc_domain.now_iso ()));
                       ])
                | Ok _ -> ()
                | Error msg ->


### PR DESCRIPTION
## Summary

Qualify agent status constructors in `Coord.clear_agent_current_task_cache`.

## Why

Current `origin/main` fails to build `bin/main_eio.exe` with:

```text
File "lib/coord.ml", line 340, characters 33-41:
Error: Unbound constructor Inactive
```

`coord.ml` does not open `Masc_domain`, so the new helper must reference `Masc_domain.Inactive`, `Masc_domain.Active`, `Masc_domain.Busy`, and `Masc_domain.Listening` explicitly.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build bin/main_eio.exe` is currently queued behind the shared Dune lock in this workspace. The previous attempt reached this exact compiler error before this patch.
