### PR TITLE
fix(coord): hard-stop oscillating task release loops

### DIFF
--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -373,6 +373,16 @@ let release_should_block_reclaim handoff_context =
     (release_handoff_texts handoff_context)
 ;;
 
+let release_cycle_oscillation_hard_stop_threshold = 15
+
+let release_cycle_oscillation_hard_stop_reason ~next_cycle =
+  Printf.sprintf
+    "auto: claim-release oscillation threshold reached (cycle=%d >= %d) - \
+     operator review required before reclaim"
+    next_cycle
+    release_cycle_oscillation_hard_stop_threshold
+;;
+
 let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_context =
   match do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
   | Some _ as existing -> existing
@@ -386,5 +396,9 @@ let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_conte
     then
       Some
         (Option.value first_text ~default:"release hard-stop requested")
-    else None
+    else
+      let next_cycle = task.cycle_count + 1 in
+      if next_cycle >= release_cycle_oscillation_hard_stop_threshold
+      then Some (release_cycle_oscillation_hard_stop_reason ~next_cycle)
+      else None
 ;;

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -677,6 +677,45 @@ let test_release_cycles_do_not_create_auto_do_not_reclaim () =
       Alcotest.fail
         ("retryable task should remain claimable: " ^ Masc_domain.masc_error_to_string e))
 
+let test_release_cycle_15_creates_auto_hard_stop () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Coord.add_task config ~title:"Oscillating task" ~priority:1 ~description:""
+    in
+    let backlog = Coord.read_backlog config in
+    let tasks =
+      List.map
+        (fun (t : Masc_domain.task) ->
+           if String.equal t.id "task-001"
+           then { t with cycle_count = 14; do_not_reclaim_reason = None }
+           else t)
+        backlog.tasks
+    in
+    write_tasks config tasks;
+    (match Coord.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
+    (match Coord.release_task_r config ~agent_name:claude ~task_id:"task-001" () with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
+    let task = task_by_id config "task-001" in
+    Alcotest.(check int) "cycle count reaches hard-stop threshold" 15
+      task.cycle_count;
+    let reason =
+      match task.do_not_reclaim_reason with
+      | Some reason -> reason
+      | None -> Alcotest.fail "expected auto oscillation hard stop"
+    in
+    Alcotest.(check bool) "reason names oscillation" true
+      (str_contains reason "claim-release oscillation threshold");
+    match Coord.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+    | Ok _ -> Alcotest.fail "oscillating task should be blocked from reclaim"
+    | Error e ->
+      let msg = Masc_domain.masc_error_to_string e in
+      Alcotest.(check bool) "claim error carries hard-stop reason" true
+        (str_contains msg "operator review required"))
+
 let test_claim_next_allows_failed_verification_repair () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
@@ -1531,6 +1570,8 @@ let () =
         test_claim_next_prefers_unblocked_over_legacy_auto_cycle;
       Alcotest.test_case "release cycles do not create auto block" `Quick
         test_release_cycles_do_not_create_auto_do_not_reclaim;
+      Alcotest.test_case "cycle 15 release creates auto hard stop" `Quick
+        test_release_cycle_15_creates_auto_hard_stop;
       Alcotest.test_case "failed verification stays repair-claimable" `Quick
         test_claim_next_allows_failed_verification_repair;
     ];


### PR DESCRIPTION
## Why

#10719 already has warning telemetry at cycle 5/10/20, but the release path still allowed a task to keep cycling forever. The issue comment identified the deterministic break point: when the next release crosses a conservative hard-stop threshold, set `do_not_reclaim_reason` so future claims require operator review.

This PR is stacked on #13715 (`fix/keeper-pr-create-guidance-0506`) because current `main` + the active OAS pin needs that base's coord status qualification fix for local OCaml compilation.

## What Changed

- Adds a conservative release-cycle hard stop at cycle 15.
- Leaves existing explicit handoff hard-stop text as higher priority.
- Preserves lower retry cycles as claimable; legacy `auto: N releases` soft reasons remain fallback-claimable.
- Adds a regression that starts at cycle 14, releases to cycle 15, verifies the automatic hard-stop reason, and verifies direct reclaim is blocked.

## Validation

- `git diff --check`
- `dune build --root . test/test_room_coverage.exe`
- `./_build/default/test/test_room_coverage.exe test '^claim_next$' 16,17` — 2 targeted tests

Notes:
- The full `test_room_coverage.exe` binary currently has unrelated failures on this base in batch/update/observability/archive cases; the new claim-next hard-stop case passed in both the full run and the targeted run.
- I used a focused direct Dune build because `scripts/dune-local.sh` was blocked by the shared opam/Dune lock convoy observed in adjacent worktrees.

## Review Focus

- Whether cycle 15 is conservative enough for a hard stop.
- Whether the auto reason should remain a hard `do_not_reclaim_reason` instead of using the legacy soft-cycle pattern.
- Whether cancel-path oscillation should be a separate follow-up rather than bundled here.
