### PR TITLE
fix(keeper): count preflight diagnostics as tool success

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -278,7 +278,11 @@ let execute_keeper_tool_call_with_outcome
       make_executed_tool_result
         (Keeper_exec_voice.handle_keeper_voice_tool ~meta ~name ~args)
     | "keeper_preflight_check" ->
-      make_executed_tool_result
+      (* A preflight can legitimately return ok=false to block a risky or
+         unready workflow.  That is a successful read-only diagnostic result,
+         not a tool transport/execution failure.  The keeper still sees the
+         raw ok=false report and must obey it. *)
+      success_tool_result
         (Keeper_exec_preflight.handle_keeper_preflight_check ~config ~meta ~args)
     | "keeper_pr_list" ->
       make_executed_tool_result

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -309,6 +309,24 @@ let test_execute_with_outcome_bad_query_is_failure () =
       check string "bad query payload shape" "structured_error"
         (payload_kind result.payload_shape))
 
+let test_preflight_structured_block_is_execution_success () =
+  with_exec_fixture "keeper_exec_tools_preflight_block"
+    (fun ~config ~meta ~ctx_work ->
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config ~meta ~ctx_work ~exec_cache:None
+          ~name:"keeper_preflight_check"
+          ~input:(`Assoc [])
+          ()
+      in
+      check string "preflight outcome" "success"
+        (match result.outcome with `Success -> "success" | `Failure -> "failure");
+      check string "raw diagnostic shape still blocks" "structured_error"
+        (payload_kind result.payload_shape);
+      let json = Yojson.Safe.from_string result.raw_output in
+      check bool "preflight raw ok=false preserved" false
+        Yojson.Safe.Util.(member "ok" json |> to_bool))
+
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
 let register_registered_dispatch_probe () =
@@ -466,6 +484,8 @@ let () =
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick
         test_execute_with_outcome_bad_query_is_failure;
+      test_case "preflight block is execution success" `Quick
+        test_preflight_structured_block_is_execution_success;
       test_case "registered dispatch does not require masc_ prefix" `Quick
         test_registered_tool_dispatch_without_masc_prefix;
     ]);


### PR DESCRIPTION
## Summary

- Count completed `keeper_preflight_check` diagnostics as successful tool executions even when the diagnostic payload reports `ok=false`.
- Preserve the raw structured `ok=false` report so keepers and operators still see and obey preflight blocks.
- Add a dispatcher regression test for the preflight structured-block path.

## Why this matters

The latest strict keeper proof showed `keeper_preflight_check` with completed diagnostic reports but 0 recorded successes. Those were not tool crashes: the tool returned valid read-only diagnostics with `ok=false` for an unready or risky workflow. Counting that as transport/execution failure makes the keeper feature proof understate real tool execution while still correctly blocking unsafe progress.

This follow-up split is separate because #13715 was already merged before this one-file accounting fix landed locally.

## Verification

- `git diff --check origin/main..HEAD`
- `DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_exec_tools.exe`
- `_build/default/test/test_keeper_exec_tools.exe test execute_keeper_tool_call_with_outcome` (`5 tests run`)

## Strict Proof Status

This should improve future `keeper_preflight_check` success accounting after deployment and fresh keeper calls. It does not by itself prove all keeper features pass; the latest strict proof remains `warn` at 8 pass / 10 warn until the live runtime produces new evidence.