### PR TITLE
test(observe): cover memory usage contract

### DIFF
--- a/docs/observability/goal-loop-observe-metrics.md
+++ b/docs/observability/goal-loop-observe-metrics.md
@@ -34,6 +34,7 @@ now contract checked.
 | dashboard all-zero metrics | `masc_dashboard_metric_all_zeros` | `GoalLoopDashboardMetricAllZerosWarning` |
 | dashboard snapshot latency | `masc_dashboard_snapshot_latency_seconds_bucket` | `GoalLoopDashboardSnapshotLatencyP99Warning` |
 | goal attainment | `masc_goal_attainment_pct`, `masc_goal_attainment_measured` | `GoalLoopGoalAttainmentUnmeasuredOrInvalidWarning` |
+| memory usage | `masc_memory_usage_bytes` | `GoalLoopMemoryUsageInvalidWarning` |
 | config unknown keys ignored | `masc_config_unknown_keys_ignored_total` | `GoalLoopConfigUnknownKeysIgnoredWarning` |
 | credential archived by starvation | `masc_config_credential_archived_starvation_total` | `GoalLoopCredentialArchivedStarvationCritical` |
 | governance judge unparseable | `masc_governance_judge_unparseable_total` | `GoalLoopGovernanceJudgeUnparseableWarning` |
@@ -58,8 +59,8 @@ Expected result:
 
 ```text
 GOAL LOOP Observe Metrics Contract: PASS
-checked_signals: 17
-passing_signals: 17
+checked_signals: 18
+passing_signals: 18
 failing_signals: 0
 ```
 

--- a/infrastructure/monitoring/goal-loop-observe-alerts.yml
+++ b/infrastructure/monitoring/goal-loop-observe-alerts.yml
@@ -32,6 +32,7 @@ groups:
           or absent(masc_dashboard_snapshot_latency_seconds_bucket)
           or absent(masc_goal_attainment_pct)
           or absent(masc_goal_attainment_measured)
+          or absent(masc_memory_usage_bytes)
           or absent(masc_config_unknown_keys_ignored_total)
           or absent(masc_config_credential_archived_starvation_total)
           or absent(masc_governance_judge_unparseable_total)
@@ -262,6 +263,24 @@ groups:
             attainment percentage, or with an out-of-range attainment
             percentage. Treat 0% as unknown until
             masc_goal_attainment_measured returns to 1 for this goal.
+
+  - name: masc_goal_loop_observe_runtime
+    interval: 30s
+    rules:
+      - alert: GoalLoopMemoryUsageInvalidWarning
+        expr: |
+          masc_memory_usage_bytes <= 0
+        for: 10m
+        labels:
+          severity: warning
+          component: goal_loop
+          subsystem: observe
+        annotations:
+          summary: "Runtime memory usage metric is zero or invalid"
+          description: |
+            The Phase 0 memory_usage signal is present but not carrying
+            a positive sampled value. Check the GC sampler path before
+            treating memory pressure as healthy.
 
   - name: masc_goal_loop_observe_config
     interval: 30s

--- a/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
+++ b/infrastructure/monitoring/goal-loop-observe-metrics.contract.json
@@ -163,6 +163,18 @@
       ]
     },
     {
+      "signal_id": "memory_usage",
+      "metric_names": [
+        "masc_memory_usage_bytes"
+      ],
+      "alert_names": [
+        "GoalLoopMemoryUsageInvalidWarning"
+      ],
+      "threshold_fragments": [
+        "<= 0"
+      ]
+    },
+    {
       "signal_id": "config_unknown_keys_ignored",
       "metric_names": [
         "masc_config_unknown_keys_ignored_total"

--- a/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
+++ b/infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json
@@ -16,6 +16,7 @@
       "masc_dashboard_snapshot_latency_seconds_bucket",
       "masc_goal_attainment_pct{goal_id}",
       "masc_goal_attainment_measured{goal_id}",
+      "masc_memory_usage_bytes",
       "masc_config_unknown_keys_ignored_total{file_path}",
       "masc_config_credential_archived_starvation_total{keeper_name}",
       "masc_governance_judge_unparseable_total",
@@ -355,6 +356,35 @@
         }
       ],
       "title": "Goal Attainment",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "masc_memory_usage_bytes",
+          "legendFormat": "live OCaml heap",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Memory Usage",
       "type": "timeseries"
     }
   ],

--- a/test/test_validate_goal_loop_observe_metrics.py
+++ b/test/test_validate_goal_loop_observe_metrics.py
@@ -66,8 +66,8 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         report = load_current_report()
 
         self.assertEqual("PASS", report.status)
-        self.assertEqual(17, report.checked_signals)
-        self.assertEqual(17, report.passing_signals)
+        self.assertEqual(18, report.checked_signals)
+        self.assertEqual(18, report.passing_signals)
         self.assertEqual(0, report.failing_signals)
 
     def test_contract_pins_starvation_rate_signal(self) -> None:
@@ -117,6 +117,24 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
                 "masc_goal_attainment_measured",
             ],
             goal_attainment["dashboard_query_fragments"],
+        )
+
+    def test_contract_pins_memory_usage_signal(self) -> None:
+        contract = validate_goal_loop_observe_metrics.load_json_object(
+            str(CONTRACT_PATH)
+        )
+        signals = {
+            signal["signal_id"]: signal for signal in contract["required_signals"]
+        }
+
+        memory_usage = signals["memory_usage"]
+        self.assertEqual(
+            ["masc_memory_usage_bytes"],
+            memory_usage["metric_names"],
+        )
+        self.assertEqual(
+            ["GoalLoopMemoryUsageInvalidWarning"],
+            memory_usage["alert_names"],
         )
 
     def test_cli_require_complete_passes(self) -> None:


### PR DESCRIPTION
## What

- Add the Phase 0 `memory_usage` signal to the GOAL LOOP Observe monitoring contract now that `masc_memory_usage_bytes` is on `main`.
- Extend the Prometheus absent check and add `GoalLoopMemoryUsageInvalidWarning` for a present-but-zero sampled memory gauge.
- Add a Grafana `Runtime Memory Usage` panel for `masc_memory_usage_bytes`.
- Update the contract docs and validator test expectations from 17 to 18 signals, preserving the already-merged `goal_attainment` signal.

## Why

`#13731` merged the exporter for `masc_memory_usage_bytes`, but the Observe contract still did not require alerts or dashboard coverage for it. This closes that gap so the Phase 0 metric schema is visible in the same operator surface as the other goal-loop signals.

## Review Focus

- `infrastructure/monitoring/goal-loop-observe-metrics.contract.json`: `memory_usage` signal and threshold fragments.
- `infrastructure/monitoring/goal-loop-observe-alerts.yml`: absent coverage plus the zero/invalid sampled-value alert.
- `infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json`: panel placement after Goal Attainment.
- `test/test_validate_goal_loop_observe_metrics.py`: 18-signal contract regression coverage.

## Validation

- `python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete --format text`
- `python3 test/test_validate_goal_loop_observe_metrics.py`
- `ruff check test/test_validate_goal_loop_observe_metrics.py`
- `ruff format --check test/test_validate_goal_loop_observe_metrics.py`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`

## Caveat

- `pyright` is not installed in this local Python environment (`python3 -m pyright` returned `No module named pyright`), so Python type checking is left to CI/tooling with pyright available.
