### PR TITLE
fix(dashboard): expose button metadata

### DIFF
--- a/dashboard/src/components/common/button.test.ts
+++ b/dashboard/src/components/common/button.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { ActionButton } from './button'
+import { ActionButton, summarizeActionButton } from './button'
 
 describe('ActionButton', () => {
   let container: HTMLElement
@@ -21,11 +21,19 @@ describe('ActionButton', () => {
     expect(btn).toBeTruthy()
     expect(btn.getAttribute('type')).toBe('button')
     expect(btn.textContent).toBe('Click me')
+    expect(btn.hasAttribute('data-action-button')).toBe(true)
+    expect(btn.getAttribute('data-action-button-variant')).toBe('primary')
+    expect(btn.getAttribute('data-action-button-size')).toBe('md')
+    expect(btn.getAttribute('data-action-button-type')).toBe('button')
+    expect(btn.getAttribute('data-action-button-pressed-state')).toBe('unset')
+    expect(btn.getAttribute('data-action-button-has-children')).toBe('true')
   })
 
   it('type="submit" is forwarded (form-wiring escape hatch)', () => {
     render(html`<${ActionButton} type="submit">Go<//>`, container)
-    expect(container.querySelector('button')!.getAttribute('type')).toBe('submit')
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('type')).toBe('submit')
+    expect(btn.getAttribute('data-action-button-type')).toBe('submit')
   })
 
   it('variant defaults to primary + classes include the accent token', () => {
@@ -54,7 +62,9 @@ describe('ActionButton', () => {
 
   it('block=true adds w-full', () => {
     render(html`<${ActionButton} block=${true}>b<//>`, container)
-    expect(container.querySelector('button')!.className).toContain('w-full')
+    const btn = container.querySelector('button')!
+    expect(btn.className).toContain('w-full')
+    expect(btn.getAttribute('data-action-button-block')).toBe('true')
   })
 
   it('disabled=true sets the attribute and adds the muted opacity class', () => {
@@ -63,28 +73,39 @@ describe('ActionButton', () => {
     expect(btn.disabled).toBe(true)
     expect(btn.className).toContain('opacity-50')
     expect(btn.className).toContain('pointer-events-none')
+    expect(btn.getAttribute('data-action-button-disabled')).toBe('true')
   })
 
   it('onClick fires when clicked', () => {
     const spy = vi.fn()
     render(html`<${ActionButton} onClick=${spy}>go<//>`, container)
-    ;(container.querySelector('button') as HTMLButtonElement).click()
+    const btn = container.querySelector('button') as HTMLButtonElement
+    expect(btn.getAttribute('data-action-button-has-click-handler')).toBe('true')
+    btn.click()
     expect(spy).toHaveBeenCalledOnce()
   })
 
   it('aria-label is forwarded', () => {
     render(html`<${ActionButton} ariaLabel="cancel task">×<//>`, container)
-    expect(container.querySelector('button')!.getAttribute('aria-label')).toBe('cancel task')
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('aria-label')).toBe('cancel task')
+    expect(btn.getAttribute('data-action-button-has-aria-label')).toBe('true')
+    expect(btn.getAttribute('data-action-button-aria-label-length')).toBe('11')
   })
 
   it('id is forwarded (label-for / programmatic focus contract)', () => {
     render(html`<${ActionButton} id="save-btn">Save<//>`, container)
-    expect(container.querySelector('button')!.id).toBe('save-btn')
+    const btn = container.querySelector('button')!
+    expect(btn.id).toBe('save-btn')
+    expect(btn.getAttribute('data-action-button-has-id')).toBe('true')
+    expect(btn.getAttribute('data-action-button-id-length')).toBe('8')
   })
 
   it('ariaBusy=true is forwarded as aria-busy="true" for AT announcements', () => {
     render(html`<${ActionButton} ariaBusy=${true} disabled=${true}>Saving...<//>`, container)
-    expect(container.querySelector('button')!.getAttribute('aria-busy')).toBe('true')
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('aria-busy')).toBe('true')
+    expect(btn.getAttribute('data-action-button-busy')).toBe('true')
   })
 
   it('ariaBusy=false / unset does NOT render the aria-busy attribute', () => {
@@ -94,27 +115,40 @@ describe('ActionButton', () => {
 
   it('title is forwarded for native hover tooltip', () => {
     render(html`<${ActionButton} title="Delete connector">✕<//>`, container)
-    expect(container.querySelector('button')!.getAttribute('title')).toBe('Delete connector')
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('title')).toBe('Delete connector')
+    expect(btn.getAttribute('data-action-button-has-title')).toBe('true')
+    expect(btn.getAttribute('data-action-button-title-length')).toBe('16')
   })
 
   it('testId is forwarded as data-testid (E2E stable hook)', () => {
     render(html`<${ActionButton} testId="connector-save">save<//>`, container)
-    expect(container.querySelector('button')!.getAttribute('data-testid')).toBe('connector-save')
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('data-testid')).toBe('connector-save')
+    expect(btn.getAttribute('data-action-button-has-test-id')).toBe('true')
+    expect(btn.getAttribute('data-action-button-test-id-length')).toBe('14')
   })
 
   it('extra `class` prop is appended to the variant/size/base classes', () => {
     render(html`<${ActionButton} class="extra-hook">x<//>`, container)
-    expect(container.querySelector('button')!.className).toContain('extra-hook')
+    const btn = container.querySelector('button')!
+    expect(btn.className).toContain('extra-hook')
+    expect(btn.getAttribute('data-action-button-has-custom-class')).toBe('true')
+    expect(btn.getAttribute('data-action-button-class-length')).toBe('10')
   })
 
   it('pressed=true renders aria-pressed="true" for AT (toggle/tab semantic)', () => {
     render(html`<${ActionButton} pressed=${true}>Filter<//>`, container)
-    expect(container.querySelector('button')!.getAttribute('aria-pressed')).toBe('true')
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('aria-pressed')).toBe('true')
+    expect(btn.getAttribute('data-action-button-pressed-state')).toBe('true')
   })
 
   it('pressed=false renders aria-pressed="false" (button is in toggle group, currently inactive)', () => {
     render(html`<${ActionButton} pressed=${false}>Filter<//>`, container)
-    expect(container.querySelector('button')!.getAttribute('aria-pressed')).toBe('false')
+    const btn = container.querySelector('button')!
+    expect(btn.getAttribute('aria-pressed')).toBe('false')
+    expect(btn.getAttribute('data-action-button-pressed-state')).toBe('false')
   })
 
   it('pressed unset does NOT render aria-pressed (plain action button)', () => {
@@ -128,5 +162,68 @@ describe('ActionButton', () => {
     // --button-ghost-bg-pressed component slot (which itself resolves
     // to var(--accent-12) via the token chain).
     expect(container.querySelector('button')!.className).toContain('button-ghost-bg-pressed')
+  })
+
+  it('summarizes default button state', () => {
+    expect(summarizeActionButton({ children: 'Save' })).toEqual({
+      variant: 'primary',
+      size: 'md',
+      type: 'button',
+      block: false,
+      disabled: false,
+      busy: false,
+      pressedState: 'unset',
+      hasCustomClass: false,
+      classNameLength: 0,
+      hasId: false,
+      idLength: 0,
+      hasAriaLabel: false,
+      ariaLabelLength: 0,
+      hasTitle: false,
+      titleLength: 0,
+      hasTestId: false,
+      testIdLength: 0,
+      hasOnClick: false,
+      hasChildren: true,
+    })
+  })
+
+  it('summarizes populated button state', () => {
+    expect(summarizeActionButton({
+      variant: 'warn',
+      size: 'lg',
+      type: 'submit',
+      class: 'extra-hook',
+      id: 'save-btn',
+      disabled: true,
+      block: true,
+      ariaLabel: 'Save changes',
+      ariaBusy: true,
+      pressed: false,
+      title: 'Save connector',
+      testId: 'connector-save',
+      onClick: vi.fn(),
+      children: 'Save',
+    })).toEqual({
+      variant: 'warn',
+      size: 'lg',
+      type: 'submit',
+      block: true,
+      disabled: true,
+      busy: true,
+      pressedState: 'false',
+      hasCustomClass: true,
+      classNameLength: 10,
+      hasId: true,
+      idLength: 8,
+      hasAriaLabel: true,
+      ariaLabelLength: 12,
+      hasTitle: true,
+      titleLength: 14,
+      hasTestId: true,
+      testIdLength: 14,
+      hasOnClick: true,
+      hasChildren: true,
+    })
   })
 })

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -13,9 +13,32 @@ import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { ringFocusClasses } from './ring'
 
-type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle' | 'ok' | 'warn'
-type ButtonSize = 'sm' | 'md' | 'lg'
-type ButtonType = 'button' | 'submit' | 'reset'
+export type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle' | 'ok' | 'warn'
+export type ButtonSize = 'sm' | 'md' | 'lg'
+export type ButtonType = 'button' | 'submit' | 'reset'
+export type ButtonPressedState = 'unset' | 'true' | 'false'
+
+export interface ActionButtonSummary {
+  readonly variant: ButtonVariant
+  readonly size: ButtonSize
+  readonly type: ButtonType
+  readonly block: boolean
+  readonly disabled: boolean
+  readonly busy: boolean
+  readonly pressedState: ButtonPressedState
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+  readonly hasId: boolean
+  readonly idLength: number
+  readonly hasAriaLabel: boolean
+  readonly ariaLabelLength: number
+  readonly hasTitle: boolean
+  readonly titleLength: number
+  readonly hasTestId: boolean
+  readonly testIdLength: number
+  readonly hasOnClick: boolean
+  readonly hasChildren: boolean
+}
 
 const SIZE_CLASSES: Record<ButtonSize, string> = {
   sm: 'py-1 px-2 text-2xs',
@@ -65,7 +88,7 @@ const PRESSED_CLASSES: Record<ButtonVariant, string> = {
 // motion for accessibility) propagates without callsite edits.
 const BASE = `rounded-[var(--r-1)] cursor-pointer transition-[background-color,border-color,box-shadow,transform,opacity] duration-[var(--t-med)] font-medium ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} active:scale-[0.97] active:opacity-90`
 
-interface ActionButtonProps {
+export interface ActionButtonProps {
   variant?: ButtonVariant
   size?: ButtonSize
   type?: ButtonType
@@ -95,6 +118,55 @@ interface ActionButtonProps {
   children: ComponentChildren
 }
 
+function hasNonEmptyString(value: string | undefined): boolean {
+  return value !== undefined && value !== ''
+}
+
+function pressedState(pressed: boolean | undefined): ButtonPressedState {
+  if (pressed === true) return 'true'
+  if (pressed === false) return 'false'
+  return 'unset'
+}
+
+export function summarizeActionButton({
+  variant = 'primary',
+  size = 'md',
+  type = 'button',
+  class: cx,
+  id,
+  disabled,
+  block,
+  ariaLabel,
+  ariaBusy,
+  pressed,
+  title,
+  testId,
+  onClick,
+  children,
+}: ActionButtonProps): ActionButtonSummary {
+  return {
+    variant,
+    size,
+    type,
+    block: block === true,
+    disabled: disabled === true,
+    busy: ariaBusy === true,
+    pressedState: pressedState(pressed),
+    hasCustomClass: hasNonEmptyString(cx),
+    classNameLength: cx?.length ?? 0,
+    hasId: hasNonEmptyString(id),
+    idLength: id?.length ?? 0,
+    hasAriaLabel: hasNonEmptyString(ariaLabel),
+    ariaLabelLength: ariaLabel?.length ?? 0,
+    hasTitle: hasNonEmptyString(title),
+    titleLength: title?.length ?? 0,
+    hasTestId: hasNonEmptyString(testId),
+    testIdLength: testId?.length ?? 0,
+    hasOnClick: typeof onClick === 'function',
+    hasChildren: children !== undefined && children !== null,
+  }
+}
+
 export function ActionButton({
   variant = 'primary',
   size = 'md',
@@ -111,6 +183,22 @@ export function ActionButton({
   onClick,
   children,
 }: ActionButtonProps) {
+  const summary = summarizeActionButton({
+    variant,
+    size,
+    type,
+    class: cx,
+    id,
+    disabled,
+    block,
+    ariaLabel,
+    ariaBusy,
+    pressed,
+    title,
+    testId,
+    onClick,
+    children,
+  })
   const cls = [
     BASE,
     SIZE_CLASSES[size],
@@ -133,6 +221,26 @@ export function ActionButton({
       aria-pressed=${pressed === true ? 'true' : pressed === false ? 'false' : undefined}
       title=${title}
       data-testid=${testId}
+      data-action-button
+      data-action-button-variant=${summary.variant}
+      data-action-button-size=${summary.size}
+      data-action-button-type=${summary.type}
+      data-action-button-block=${summary.block}
+      data-action-button-disabled=${summary.disabled}
+      data-action-button-busy=${summary.busy}
+      data-action-button-pressed-state=${summary.pressedState}
+      data-action-button-has-custom-class=${summary.hasCustomClass}
+      data-action-button-class-length=${summary.classNameLength}
+      data-action-button-has-id=${summary.hasId}
+      data-action-button-id-length=${summary.idLength}
+      data-action-button-has-aria-label=${summary.hasAriaLabel}
+      data-action-button-aria-label-length=${summary.ariaLabelLength}
+      data-action-button-has-title=${summary.hasTitle}
+      data-action-button-title-length=${summary.titleLength}
+      data-action-button-has-test-id=${summary.hasTestId}
+      data-action-button-test-id-length=${summary.testIdLength}
+      data-action-button-has-click-handler=${summary.hasOnClick}
+      data-action-button-has-children=${summary.hasChildren}
     >${children}</button>
   `
 }


### PR DESCRIPTION
## Summary
- export ActionButton props, option types, and summarizeActionButton for design-system inspection
- stamp ActionButton DOM metadata for variant, size, type, block, disabled, busy, aria-pressed state, identity hooks, labels, click handler, custom class, test id, and children presence
- extend focused Button tests to cover metadata attributes and the pure summary helper

## Why
The MASC Cockpit/Kimi dashboard audit needs button state to be inspectable without parsing class names. This makes pressed, busy, disabled, type, and hook metadata explicit for component inventory and browser automation.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/button.test.ts src/components/common/button.a11y.test.ts` passed after rebase: 2 files, 26 tests
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` passed after rebase
- `git diff --check` passed
- `pnpm --dir dashboard run lint` passed with existing warnings in `dashboard/src/components/common/virtual-list.ts` and `dashboard/src/components/fsm-hub.ts`
- `pnpm --dir dashboard run build` passed with the known Vite dynamic/static import warning for `dashboard.ts`

## Browser QA
- served with `env MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9 pnpm --dir dashboard exec vite --host 127.0.0.1 --port 5235 --strictPort --force`
- desktop 1280x900: verified 4 buttons, metadata attributes, toggle interaction `pressedState` false to true, and no horizontal overflow; screenshot `/tmp/masc-button-summary-0506.png`
- mobile 390x760: verified 4 buttons, metadata attributes, and no horizontal overflow; screenshot `/tmp/masc-button-summary-0506-mobile.png`
- browser console only had Vite debug connection logs; page errors were empty

## Cleanup
- removed temporary `dashboard/button-qa.html`
- removed temporary `dashboard/node_modules` symlink
- stopped Vite on port 5235
- closed the browser QA session