### PR TITLE
fix(metrics): export keeper cost gauge

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -90,7 +90,7 @@ let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
   let trusted_total_tokens =
     if usage_trusted then Keeper_exec_context.total_tokens result.usage else 0
   in
-  {
+  let updated_meta = {
     meta with
     updated_at = now_iso ();
     runtime =
@@ -114,7 +114,11 @@ let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
             last_latency_ms = latency_ms;
           };
       };
-  }
+  } in
+  Keeper_unified_metrics.record_keeper_total_cost_usd
+    ~keeper_name:updated_meta.name
+    ~total_cost_usd:updated_meta.runtime.usage.total_cost_usd;
+  updated_meta
 
 let direct_turn_observation (meta : keeper_meta) :
     Keeper_world_observation.world_observation =

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -252,6 +252,9 @@ let usage_trust_json_fields = Keeper_usage_trust.json_fields
 let usage_trust_outcome_metric = Prometheus.metric_keeper_usage_trust
 let usage_anomaly_reason_metric = Prometheus.metric_keeper_usage_anomaly_reason
 
+let keeper_total_cost_usd_help =
+  "Accumulated trusted USD cost per keeper (labels: keeper_name)"
+
 let record_usage_trust ~keeper_name ~(trust : usage_trust) =
   let outcome = usage_trust_to_string trust in
   Prometheus.inc_counter usage_trust_outcome_metric
@@ -269,6 +272,18 @@ let record_usage_trust ~keeper_name ~(trust : usage_trust) =
        to 0.0 for this turn by [usage_trust_is_trusted] gate."
       keeper_name (String.concat "," reasons)
   | Usage_missing | Usage_trusted -> ()
+
+let record_keeper_total_cost_usd ~keeper_name ~total_cost_usd =
+  let labels = [ ("keeper_name", keeper_name) ] in
+  Prometheus.register_gauge
+    ~name:Prometheus.metric_keeper_total_cost_usd
+    ~help:keeper_total_cost_usd_help
+    ~labels
+    ();
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_total_cost_usd
+    ~labels
+    total_cost_usd
 
 let turn_mode_to_string = function
   | Tool_use -> "tool_use"
@@ -1121,7 +1136,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       ~labels:[ ("keeper", meta.name); ("outcome", outcome) ]
       ()
   end;
-  {
+  let updated_meta = {
     meta with
     updated_at = now_iso ();
     runtime = { rt with
@@ -1266,7 +1281,11 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       last_blocker_class = None;
       last_need = Option.value ~default:"" social_state.need;
     };
-  }
+  } in
+  record_keeper_total_cost_usd
+    ~keeper_name:updated_meta.name
+    ~total_cost_usd:updated_meta.runtime.usage.total_cost_usd;
+  updated_meta
 
 let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -80,6 +80,13 @@ val record_usage_trust :
   trust:usage_trust ->
   unit
 
+val record_keeper_total_cost_usd :
+  keeper_name:string ->
+  total_cost_usd:float ->
+  unit
+(** Set [masc_keeper_total_cost_usd{keeper_name}] to the keeper runtime's
+    accumulated trusted USD cost. *)
+
 val context_max_bucket : int -> string
 (** #9953: bucket a raw [context_max] integer into a bounded
     label vocabulary [zero | 64k | 128k | 200k | 256k | 1m |

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -231,6 +231,8 @@ let metric_keeper_cache_read_tokens =
   "masc_keeper_cache_read_tokens_total"
 let metric_keeper_usage_anomalies =
   "masc_keeper_usage_anomalies_total"
+let metric_keeper_total_cost_usd =
+  "masc_keeper_total_cost_usd"
 
 (** #10530: keeper required-tool-contract violations (passive-only or
     text-only turns rejected by the keeper agent loop).
@@ -2089,6 +2091,9 @@ let init () =
   add metric_keeper_usage_anomalies
     "Keeper turns whose reported usage was marked untrusted (labels: keeper_name, model, reason)"
     Counter;
+  add metric_keeper_total_cost_usd
+    "Accumulated trusted USD cost per keeper (labels: keeper_name)"
+    Gauge;
   add metric_keeper_contract_violations
     "Keeper turns rejected for required-tool-contract violations (labels: keeper_name, kind={passive|text_only}). #10530."
     Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -74,6 +74,7 @@ val metric_keeper_output_tokens : string
 val metric_keeper_cache_creation_tokens : string
 val metric_keeper_cache_read_tokens : string
 val metric_keeper_usage_anomalies : string
+val metric_keeper_total_cost_usd : string
 
 (** #10530: keeper required-tool-contract violations.
     Labels: keeper_name, kind \in \{passive,text_only\}. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3487,6 +3487,15 @@ let test_estimate_trusted_usage_cost_uses_cache_usage () =
        ~model:"claude-sonnet-4-6"
        result.usage)
 
+let test_record_keeper_total_cost_metric () =
+  let keeper_name = "cost-metric-keeper" in
+  UM.record_keeper_total_cost_usd ~keeper_name ~total_cost_usd:0.042;
+  check (option (float 0.0001)) "keeper total cost gauge" (Some 0.042)
+    (Masc_mcp.Prometheus.get_metric_value
+       Masc_mcp.Prometheus.metric_keeper_total_cost_usd
+       ~labels:[ ("keeper_name", keeper_name) ]
+       ())
+
 let test_append_metrics_snapshot_marks_untrusted_usage () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -7948,6 +7957,8 @@ let () =
             test_append_metrics_snapshot_persists_cache_usage;
           test_case "trusted usage cost uses cache token pricing" `Quick
             test_estimate_trusted_usage_cost_uses_cache_usage;
+          test_case "total cost gauge records accumulated keeper cost" `Quick
+            test_record_keeper_total_cost_metric;
           test_case "snapshot marks untrusted usage" `Quick
             test_append_metrics_snapshot_marks_untrusted_usage;
           test_case "decision record persists tool call details" `Quick

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -237,6 +237,9 @@ let test_keeper_metrics_registered () =
     (has "masc_keeper_heartbeat_successes_total");
   check bool "has keeper heartbeat failures counter" true
     (has "masc_keeper_heartbeat_failures_total");
+  check bool "has keeper total cost gauge" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_keeper_total_cost_usd ^ " gauge"));
   check bool "has keeper tool duration histogram" true
     (has "masc_keeper_tool_call_duration_seconds");
   check bool "has operator compact counter" true


### PR DESCRIPTION
## Summary
- add the `masc_keeper_total_cost_usd{keeper_name}` gauge to Prometheus registration
- record the accumulated trusted runtime cost after unified and direct keeper turn updates
- pin registration/helper behavior in Prometheus and keeper unified tests

## Why it matters
Operators already see accumulated keeper USD cost in runtime heartbeat JSON, but Prometheus only exposed token counters and cost-ledger status. This adds the missing value metric so dashboards and alerts can track per-keeper spend directly.

## Validation
- `git diff --check origin/main..HEAD`
- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_unified.exe test/test_prometheus_coverage.exe` passed before the final clean rebase
- `./_build/default/test/test_keeper_unified.exe` passed: 338 tests
- `./_build/default/test/test_prometheus_coverage.exe` passed: 57 tests

Note: after the final clean rebase onto the latest `origin/main`, a repeat Dune pass was queued behind `/tmp/me-dune-local.lock` and stopped; CI should be treated as the exact-head validation surface.
