### PR TITLE
fix(metrics): reuse canonical built-in metric keys

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1281,7 +1281,7 @@ let init () =
   (* Module-level init runs before Eio context exists.
      Single-threaded at load time — bypass mutex. *)
   let add name help mt =
-    let key = name in
+    let key = metric_key name [] in
     if not (Hashtbl.mem metrics key) then
       Hashtbl.add metrics key { name; help; metric_type = mt; value = 0.0; labels = [] }
   in

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -221,9 +221,7 @@ let text_has_literal text literal =
 
 let count_lines_with_prefix text prefix =
   String.split_on_char '\n' text
-  |> List.filter (fun line ->
-         String.length line >= String.length prefix
-         && String.sub line 0 (String.length prefix) = prefix)
+  |> List.filter (fun line -> String.starts_with ~prefix line)
   |> List.length
 
 let test_keeper_metrics_registered () =
@@ -338,10 +336,20 @@ let test_memory_usage_metric_registered () =
        ("# TYPE " ^ Prometheus.metric_memory_usage_bytes ^ " gauge"))
 
 let test_builtin_gauge_update_does_not_duplicate_sample () =
-  Prometheus.set_gauge Prometheus.metric_memory_usage_bytes 123.0;
-  let text = Prometheus.to_prometheus_text () in
-  check int "single memory usage sample" 1
-    (count_lines_with_prefix text (Prometheus.metric_memory_usage_bytes ^ " "))
+  (* Save and restore the gauge so this test does not leak Prometheus
+     process state into other tests that may assume the default. *)
+  let prior =
+    Prometheus.metric_value_or_zero Prometheus.metric_memory_usage_bytes ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Prometheus.set_gauge Prometheus.metric_memory_usage_bytes prior)
+    (fun () ->
+      Prometheus.set_gauge Prometheus.metric_memory_usage_bytes 123.0;
+      let text = Prometheus.to_prometheus_text () in
+      check int "single memory usage sample" 1
+        (count_lines_with_prefix text
+           (Prometheus.metric_memory_usage_bytes ^ " ")))
 
 let test_goal_attainment_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -219,6 +219,13 @@ let text_has_literal text literal =
     true
   with Not_found -> false
 
+let count_lines_with_prefix text prefix =
+  String.split_on_char '\n' text
+  |> List.filter (fun line ->
+         String.length line >= String.length prefix
+         && String.sub line 0 (String.length prefix) = prefix)
+  |> List.length
+
 let test_keeper_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in
   let has metric =
@@ -329,6 +336,12 @@ let test_memory_usage_metric_registered () =
   check bool "has memory usage TYPE" true
     (text_has_literal text
        ("# TYPE " ^ Prometheus.metric_memory_usage_bytes ^ " gauge"))
+
+let test_builtin_gauge_update_does_not_duplicate_sample () =
+  Prometheus.set_gauge Prometheus.metric_memory_usage_bytes 123.0;
+  let text = Prometheus.to_prometheus_text () in
+  check int "single memory usage sample" 1
+    (count_lines_with_prefix text (Prometheus.metric_memory_usage_bytes ^ " "))
 
 let test_goal_attainment_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in
@@ -526,6 +539,8 @@ let () =
         test_build_identity_probe_metric_registered;
       test_case "memory usage metric registered" `Quick
         test_memory_usage_metric_registered;
+      test_case "built-in gauge update does not duplicate sample" `Quick
+        test_builtin_gauge_update_does_not_duplicate_sample;
       test_case "goal attainment metrics registered" `Quick
         test_goal_attainment_metrics_registered;
       test_case "histogram exported as summary with _sum/_count"


### PR DESCRIPTION
## What

- Register built-in Prometheus metrics with the same canonical `metric_key name []` used by update/query paths.
- Add a regression test that updates the built-in `masc_memory_usage_bytes` gauge and verifies the no-label sample is emitted exactly once.

## Why

Live `/metrics` showed `masc_memory_usage_bytes` twice: one sampled live value and one stale built-in zero value. The same issue affected other built-in no-label gauges such as `masc_gc_live_words`.

The root cause was `Prometheus.init` storing built-ins under the raw metric name while `set_gauge` and `get_metric_value` use the encoded `metric_key` form. Updating a built-in gauge created a second table entry instead of replacing the initial zero.

## Review Focus

- `lib/prometheus.ml`: `init` now uses the same key constructor as all mutation/query paths.
- `test/test_prometheus_coverage.ml`: regression coverage for duplicate no-label built-in gauge samples.

## Validation

- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `git diff -U0 -- lib/prometheus.ml test/test_prometheus_coverage.ml | rg -n "Stdlib\\.Lazy\\.(force|from_val)|Fun\\.protect|Mutex\\.(lock|unlock)|failwith|assert false|Eio\\.traceln|Sys\\.(readdir|command)"`

## Local Verification Caveat

- Focused Dune was attempted with `scripts/dune-local.sh build test/test_prometheus_coverage.exe`, but it remained queued on `/tmp/me-opam-switch.lock` behind other active worktree builds. I killed only my waiting `lockf` process and left the other builds untouched. CI is the compile/test surface for this PR.
