### PR TITLE
fix(task): no-op self verification attempts

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -901,6 +901,38 @@ and handle_transition ?agent_tool_names ctx args =
       | None -> action
     else action
   in
+  let caller_matches_assignee assignee =
+    String.equal assignee ctx.agent_name
+    || String.equal assignee
+         (try Coord.resolve_agent_name ctx.config ctx.agent_name
+          with
+          | Sys_error _ | Yojson.Json_error _ -> ctx.agent_name
+          | exn ->
+              Log.Task.warn "resolve_agent_name failed for verifier precheck %s: %s"
+                ctx.agent_name
+                (Stdlib.Printexc.to_string exn);
+              ctx.agent_name)
+  in
+  let self_verification_noop =
+    match action, task_opt with
+    | ( Masc_domain.Approve_verification | Masc_domain.Reject_verification ),
+      Some
+        {
+          Masc_domain.task_status =
+            Masc_domain.AwaitingVerification { assignee; verification_id; _ };
+          _;
+        }
+      when caller_matches_assignee assignee ->
+        Some
+          ( true,
+            Printf.sprintf
+              "No-op: task %s is awaiting verification %s from a different agent; current agent %s submitted it and cannot %s its own work. Ask another verifier, or stay silent until a different keeper handles verification."
+              task_id verification_id ctx.agent_name action_s )
+    | _ -> None
+  in
+  match self_verification_noop with
+  | Some response -> response
+  | None ->
   let default_time = Time_compat.now () -. 60.0 in
   let (started_at_actual, collaborators_from_task) = match task_opt with
     | Some t -> (match t.task_status with

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -131,6 +131,11 @@ let assert_task_awaiting_verification_by ctx agent_name =
       assert (verification_id <> "")
   | _ -> failwith "expected task to be awaiting verification"
 
+let awaiting_verification_id ctx =
+  match (only_task ctx).Masc_domain.task_status with
+  | Masc_domain.AwaitingVerification { verification_id; _ } -> verification_id
+  | _ -> failwith "expected task to be awaiting verification"
+
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -795,6 +800,60 @@ let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun
     assert (not success);
     assert (str_contains result "awaiting verification");
     assert (str_contains result "approve or reject")))
+
+let () = test "handle_transition_self_verification_is_successful_noop" (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx () in
+    let _ =
+      Tool_task.handle_add_task ctx
+        (`Assoc
+          [
+            ("title", `String "Self verification task");
+            ( "contract",
+              `Assoc
+                [
+                  ("strict", `Bool true);
+                  ("completion_contract", `List [ `String "tests pass" ]);
+                ] );
+          ])
+    in
+    let _ = Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001" in
+    (match
+       Coord.transition_task_r ctx.config ~agent_name:"test-agent"
+         ~task_id:"task-001" ~action:Masc_domain.Submit_for_verification ()
+     with
+     | Ok _ -> ()
+     | Error e -> failwith (Masc_domain.masc_error_to_string e));
+    let verification_id = awaiting_verification_id ctx in
+    let reject_success, reject_result =
+      Tool_task.handle_transition ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "reject");
+            ("reason", `String "needs evidence");
+          ])
+    in
+    if not reject_success then failwith reject_result;
+    assert (str_contains reject_result "No-op");
+    assert (str_contains reject_result "different agent");
+    assert (not (str_contains reject_result "Self-rejection"));
+    assert (awaiting_verification_id ctx = verification_id);
+    let approve_success, approve_result =
+      Tool_task.handle_transition ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "approve");
+            ("notes", `String "looks good");
+          ])
+    in
+    if not approve_success then failwith approve_result;
+    assert (str_contains approve_result "No-op");
+    assert (str_contains approve_result "different agent");
+    assert (not (str_contains approve_result "Self-approval"));
+    assert (awaiting_verification_id ctx = verification_id)))
+
 let () = test "handle_claim_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Claim direct")]) in


### PR DESCRIPTION
## Summary

- Add a `Tool_task.handle_transition` precondition for verifier actions where the current caller is also the `AwaitingVerification` assignee.
- Return a successful no-op guidance response for same-assignee `approve` / `reject` attempts instead of calling `Coord.transition_task_r`.
- Keep the low-level FSM self-approval/self-rejection guards unchanged; this only prevents repeated invalid tool-call failures at the keeper tool boundary.

## Why

Issue #10699 Family B shows keepers repeatedly attempting self-rejection after they submitted their own work for verification. The FSM is already correct to reject that transition, but surfacing it as a failed tool call creates a retry loop. Same-assignee verifier attempts now become explicit no-ops that tell the keeper to wait for a different verifier.

## Validation

- `git diff --check`
- Risk scan on touched files:
  - `rg "Stdlib\\.Lazy\\.(force|from_val)|Fun\\.protect|Mutex\\.(lock|unlock)|failwith|assert false|Eio\\.traceln|Sys\\.(readdir|command)" lib/tool_task.ml test/test_tool_task_coverage.ml`
  - Runtime file introduced no risky-pattern hits; test file reports existing `Fun.protect` / `failwith` test helpers plus the new regression assertions.
- `scripts/dune-local.sh build test/test_tool_task_coverage.exe`
  - Attempted first; blocked behind `/tmp/me-opam-switch.lock`, then stopped.
- `dune build --root . test/test_tool_task_coverage.exe`
- `./_build/default/test/test_tool_task_coverage.exe test '^coverage$' 23,24`
  - Passed the adjacent awaiting-verification guard and the new self-verification no-op regression.
- `./_build/default/test/test_tool_task_coverage.exe`
  - New/adjacent verifier cases passed.
  - The full file still fails `transition_submit_pr_evidence_accepts_todo_pr_evidence_with_stale_do_not_reclaim_reason`; the same assertion fails on untouched base `origin/fix/keeper-pr-create-guidance-0506`, so it is unrelated base-state debt.
