### PR TITLE
fix(keeper): close keeper turn match stack

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -666,4 +666,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-)))))
+))))))


### PR DESCRIPTION
## Summary
- Fix main build syntax error in lib/keeper/keeper_turn.ml by closing the keeper message validation match stack.

## Product impact
- Restores main OCaml build parsing for keeper turn handling after the manual discovery refresh merge.

## Evidence
- ocamlc -stop-after parsing lib/keeper/keeper_turn.ml
- git diff --check
- scripts/dune-local.sh build lib/masc_mcp.cmxa attempted, but /tmp/me-opam-switch.lock stayed held for more than 60s; stopped only my waiting lockf process.

## Review evidence
- Diff is one closing parenthesis at the parser-reported unmatched match stack.

## Linked issue
- Follow-up to main build failure reported on 2026-05-06.