### PR TITLE
fix(keeper): require recent scheduled proof evidence

### DIFF
--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -319,7 +319,14 @@ let board_reactive_feature snapshots =
     ~next_action:
       "Post board events and confirm every active keeper records board-reactive turns."
 
-let scheduled_proactive_feature ~config snapshots =
+let timestamp_within_window ?window_hours ~now ts =
+  ts > 0.0
+  &&
+  match window_hours with
+  | None -> true
+  | Some hours -> now -. ts <= hours *. 3600.0
+
+let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
   let decision_stats =
     snapshots
     |> List.map (fun snapshot ->
@@ -338,9 +345,18 @@ let scheduled_proactive_feature ~config snapshots =
       | None -> false)
   in
   let total = keeper_count enabled in
-  let has_scheduled_evidence snapshot meta =
+  let has_recent_meta_evidence meta =
     meta.Keeper_types.runtime.proactive_rt.count_total > 0
-    || (decision_stat_for snapshot.keeper_name).decision_count > 0
+    && timestamp_within_window ?window_hours ~now
+         meta.Keeper_types.runtime.proactive_rt.last_ts
+  in
+  let has_recent_decision_evidence snapshot =
+    match (decision_stat_for snapshot.keeper_name).latest_ts_unix with
+    | Some ts -> timestamp_within_window ?window_hours ~now ts
+    | None -> false
+  in
+  let has_scheduled_evidence snapshot meta =
+    has_recent_meta_evidence meta || has_recent_decision_evidence snapshot
   in
   let observed =
     enabled
@@ -373,9 +389,22 @@ let scheduled_proactive_feature ~config snapshots =
         | Some meta -> meta.Keeper_types.runtime.proactive_rt.count_total
         | None -> 0
       in
+      let meta_last_ts =
+        match snapshot.meta with
+        | Some meta -> meta.Keeper_types.runtime.proactive_rt.last_ts
+        | None -> 0.0
+      in
+      let meta_recent =
+        match snapshot.meta with
+        | Some meta -> has_recent_meta_evidence meta
+        | None -> false
+      in
       `Assoc [
         ("keeper", `String snapshot.keeper_name);
         ("meta_proactive_count_total", `Int meta_count);
+        ( "meta_last_proactive_ts",
+          if meta_last_ts > 0.0 then `Float meta_last_ts else `Null );
+        ("meta_evidence_within_window", `Bool meta_recent);
         ("decision_log", Decision.scheduled_evidence_json stat);
       ])
   in
@@ -386,8 +415,11 @@ let scheduled_proactive_feature ~config snapshots =
     ("summary",
      `String
        (Printf.sprintf
-          "%d/%d proactive-enabled keepers have scheduled proactive evidence"
-          (List.length observed) total));
+          "%d/%d proactive-enabled keepers have scheduled proactive evidence%s"
+          (List.length observed) total
+          (match window_hours with
+           | Some hours -> Printf.sprintf " in the last %.1fh" hours
+           | None -> "")));
     ("required_tools", `List []);
     ("passing_tools", `List []);
     ("weak_tools", `List []);
@@ -535,7 +567,7 @@ let json
       persistent_turn_exchange_feature ~config ~now snapshots;
       autonomous_tool_feature snapshots;
       board_reactive_feature snapshots;
-      scheduled_proactive_feature ~config snapshots;
+      scheduled_proactive_feature ~config ?window_hours ~now snapshots;
       Git_pr.json ~n ?window_hours ~keeper_names ();
     ]
     @ List.map

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -349,6 +349,9 @@ let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
     meta.Keeper_types.runtime.proactive_rt.count_total > 0
     && timestamp_within_window ?window_hours ~now
          meta.Keeper_types.runtime.proactive_rt.last_ts
+    && not
+         (meta.Keeper_types.runtime.proactive_rt.last_outcome
+          = Keeper_types.Proactive_error)
   in
   let has_recent_decision_evidence snapshot =
     match (decision_stat_for snapshot.keeper_name).latest_ts_unix with
@@ -399,11 +402,23 @@ let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
         | Some meta -> has_recent_meta_evidence meta
         | None -> false
       in
+      let meta_outcome =
+        match snapshot.meta with
+        | Some meta ->
+          Some
+            (Keeper_types.proactive_cycle_outcome_to_string
+               meta.Keeper_types.runtime.proactive_rt.last_outcome)
+        | None -> None
+      in
       `Assoc [
         ("keeper", `String snapshot.keeper_name);
         ("meta_proactive_count_total", `Int meta_count);
         ( "meta_last_proactive_ts",
           if meta_last_ts > 0.0 then `Float meta_last_ts else `Null );
+        ( "meta_last_proactive_outcome",
+          match meta_outcome with
+          | Some outcome -> `String outcome
+          | None -> `Null );
         ("meta_evidence_within_window", `Bool meta_recent);
         ("decision_log", Decision.scheduled_evidence_json stat);
       ])

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -320,10 +320,21 @@ let board_reactive_feature snapshots =
       "Post board events and confirm every active keeper records board-reactive turns."
 
 let timestamp_within_window ?window_hours ~now ts =
+  (* Reject zero/negative timestamps (sentinel/unset) and future timestamps
+     (clock skew or corrupted logs). Without the [ts <= now] guard, any
+     future timestamp would satisfy the recency check because [now -. ts]
+     would be negative and trivially [<= hours *. 3600.0]. *)
   ts > 0.0
+  && ts <= now
   &&
   match window_hours with
   | None -> true
+  | Some hours when hours <= 0.0 ->
+    (* Non-positive window is treated as "no recency check": flipping it
+       to a hard reject would silently disqualify all past evidence. The
+       top-level [json] helper clamps callers' inputs to a sane domain;
+       this keeps internal logic robust if a caller bypasses the boundary. *)
+    true
   | Some hours -> now -. ts <= hours *. 3600.0
 
 let scheduled_proactive_feature ~config ?window_hours ~now snapshots =
@@ -570,6 +581,16 @@ let json
   let now = Option.value ~default:(Unix.gettimeofday ()) now in
   let success_threshold_pct =
     clamp_float ~low:0.0 ~high:100.0 success_threshold_pct
+  in
+  (* Normalize at the public boundary so feature helpers never see a
+     non-positive window. Callers passing [Some h] with [h <= 0.0] from
+     CLI/config are treated the same as [None] (no recency check)
+     instead of producing surprising "negative window rejects all"
+     semantics. *)
+  let window_hours =
+    match window_hours with
+    | Some h when h > 0.0 -> Some h
+    | Some _ | None -> None
   in
   let snapshots = load_keeper_snapshots config in
   let keeper_names = snapshot_keeper_names snapshots in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -666,4 +666,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-)))))
+))))))

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -647,7 +647,10 @@ let test_scheduled_proactive_evidence_uses_enabled_population () =
 
 let test_scheduled_proactive_window_requires_recent_evidence () =
   with_store @@ fun config ->
-  let now = Unix.gettimeofday () in
+  (* Fixed [now] makes the regression deterministic across machines; the
+     other recency tests in this file (e.g. line 734) follow the same
+     1_777_000_000.0 epoch convention. *)
+  let now = 1_777_000_000.0 in
   ignore
     (persist_keeper_with_proactive
        ~proactive_last_ts:(now -. (49.0 *. 3600.0))
@@ -680,9 +683,50 @@ let test_scheduled_proactive_window_requires_recent_evidence () =
     ["alpha"]
     (json_string_values "missing_keepers" evidence)
 
+let test_scheduled_proactive_window_all_stale_is_fail () =
+  (* Regression for the [observed = []] -> Fail branch: when every
+     proactive-enabled keeper has only stale meta evidence and no recent
+     decision-log evidence, the feature must fail, not warn. *)
+  with_store @@ fun config ->
+  let now = 1_777_000_000.0 in
+  ignore
+    (persist_keeper_with_proactive
+       ~proactive_last_ts:(now -. (49.0 *. 3600.0))
+       config ~proactive_enabled:true
+       ~name:"alpha" ~total_turns:3 ~autonomous_action_count:2
+       ~autonomous_tool_turn_count:2 ~board_reactive_turn_count:1
+       ~proactive_count_total:1);
+  ignore
+    (persist_keeper_with_proactive
+       ~proactive_last_ts:(now -. (72.0 *. 3600.0))
+       config ~proactive_enabled:true
+       ~name:"gamma" ~total_turns:2 ~autonomous_action_count:1
+       ~autonomous_tool_turn_count:1 ~board_reactive_turn_count:0
+       ~proactive_count_total:1);
+  let json =
+    Dashboard_keeper_feature_proof.json
+      ~config
+      ~n:100
+      ~window_hours:24.0
+      ~success_threshold_pct:80.0
+      ~now
+      ()
+  in
+  let scheduled = feature "scheduled_proactive_autonomy" json in
+  let evidence = keeper_evidence "scheduled_proactive_autonomy" json in
+  check string "all-stale fleet hits Fail branch" "fail"
+    (Safe_ops.json_string ~default:"missing" "status" scheduled);
+  check (list string) "no observed keepers when all stale"
+    []
+    (json_string_values "observed_keepers" evidence);
+  check (list string) "all enabled keepers report missing"
+    ["alpha"; "gamma"]
+    (List.sort String.compare
+       (json_string_values "missing_keepers" evidence))
+
 let test_scheduled_proactive_meta_error_does_not_prove_success () =
   with_store @@ fun config ->
-  let now = Unix.gettimeofday () in
+  let now = 1_777_000_000.0 in
   ignore
     (persist_keeper_with_proactive
        ~proactive_last_ts:(now -. 60.0)
@@ -796,6 +840,8 @@ let () =
             test_scheduled_proactive_evidence_uses_enabled_population;
           test_case "scheduled proof window requires recent evidence" `Quick
             test_scheduled_proactive_window_requires_recent_evidence;
+          test_case "scheduled proof fails when fleet is fully stale" `Quick
+            test_scheduled_proactive_window_all_stale_is_fail;
           test_case "scheduled proof ignores recent meta error" `Quick
             test_scheduled_proactive_meta_error_does_not_prove_success;
           test_case "decision log counts as 24h turn exchange proof" `Quick

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -64,6 +64,7 @@ let make_meta ?(name = "alpha") () =
   | Error err -> fail ("meta_of_json failed: " ^ err)
 
 let persist_keeper_with_proactive
+      ?proactive_last_ts
       config
       ~proactive_enabled
       ~name
@@ -93,7 +94,10 @@ let persist_keeper_with_proactive
             {
               base.runtime.proactive_rt with
               count_total = proactive_count_total;
-              last_ts = (if proactive_count_total > 0 then now else 0.0);
+              last_ts =
+                (match proactive_last_ts with
+                 | Some ts -> ts
+                 | None -> if proactive_count_total > 0 then now else 0.0);
               last_outcome =
                 (if proactive_count_total > 0
                  then KT.Proactive_tool_use
@@ -186,6 +190,17 @@ let write_scheduled_decision config keeper_name =
     [
       `Assoc [
         ("ts", `String "2026-05-06T01:00:00Z");
+        ("channel", `String "scheduled_autonomous");
+        ("outcome", `String "success");
+      ];
+    ]
+
+let write_scheduled_decision_at config keeper_name ~ts =
+  write_decision_lines config keeper_name
+    [
+      `Assoc [
+        ("ts_unix", `Float ts);
+        ("ts", `String (Masc_domain.iso8601_of_unix_seconds ts));
         ("channel", `String "scheduled_autonomous");
         ("outcome", `String "success");
       ];
@@ -626,6 +641,41 @@ let test_scheduled_proactive_evidence_uses_enabled_population () =
     ["alpha"]
     (json_string_values "observed_keepers" evidence)
 
+let test_scheduled_proactive_window_requires_recent_evidence () =
+  with_store @@ fun config ->
+  let now = Unix.gettimeofday () in
+  ignore
+    (persist_keeper_with_proactive
+       ~proactive_last_ts:(now -. (49.0 *. 3600.0))
+       config ~proactive_enabled:true
+       ~name:"alpha" ~total_turns:3 ~autonomous_action_count:2
+       ~autonomous_tool_turn_count:2 ~board_reactive_turn_count:1
+       ~proactive_count_total:1);
+  ignore
+    (persist_keeper config ~name:"beta" ~total_turns:2
+       ~autonomous_action_count:1 ~autonomous_tool_turn_count:1
+       ~board_reactive_turn_count:1 ~proactive_count_total:0);
+  write_scheduled_decision_at config "beta" ~ts:(now -. 60.0);
+  let json =
+    Dashboard_keeper_feature_proof.json
+      ~config
+      ~n:100
+      ~window_hours:24.0
+      ~success_threshold_pct:80.0
+      ~now
+      ()
+  in
+  let scheduled = feature "scheduled_proactive_autonomy" json in
+  let evidence = keeper_evidence "scheduled_proactive_autonomy" json in
+  check string "stale meta evidence does not satisfy window" "warn"
+    (Safe_ops.json_string ~default:"missing" "status" scheduled);
+  check (list string) "recent decision log proves beta"
+    ["beta"]
+    (json_string_values "observed_keepers" evidence);
+  check (list string) "stale meta-only alpha stays missing"
+    ["alpha"]
+    (json_string_values "missing_keepers" evidence)
+
 let test_persistent_24h_turn_exchange_counts_decision_span () =
   with_store @@ fun config ->
   let now = 1_777_000_000.0 in
@@ -691,6 +741,8 @@ let () =
             test_decision_log_counts_as_scheduled_proof;
           test_case "scheduled proof uses enabled population" `Quick
             test_scheduled_proactive_evidence_uses_enabled_population;
+          test_case "scheduled proof window requires recent evidence" `Quick
+            test_scheduled_proactive_window_requires_recent_evidence;
           test_case "decision log counts as 24h turn exchange proof" `Quick
             test_persistent_24h_turn_exchange_counts_decision_span;
         ] );

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -65,6 +65,7 @@ let make_meta ?(name = "alpha") () =
 
 let persist_keeper_with_proactive
       ?proactive_last_ts
+      ?proactive_last_outcome
       config
       ~proactive_enabled
       ~name
@@ -99,9 +100,12 @@ let persist_keeper_with_proactive
                  | Some ts -> ts
                  | None -> if proactive_count_total > 0 then now else 0.0);
               last_outcome =
-                (if proactive_count_total > 0
-                 then KT.Proactive_tool_use
-                 else KT.Proactive_never_started);
+                (match proactive_last_outcome with
+                 | Some outcome -> outcome
+                 | None ->
+                   if proactive_count_total > 0
+                   then KT.Proactive_tool_use
+                   else KT.Proactive_never_started);
             };
           autonomous_action_count;
           autonomous_turn_count = autonomous_action_count;
@@ -676,6 +680,55 @@ let test_scheduled_proactive_window_requires_recent_evidence () =
     ["alpha"]
     (json_string_values "missing_keepers" evidence)
 
+let test_scheduled_proactive_meta_error_does_not_prove_success () =
+  with_store @@ fun config ->
+  let now = Unix.gettimeofday () in
+  ignore
+    (persist_keeper_with_proactive
+       ~proactive_last_ts:(now -. 60.0)
+       ~proactive_last_outcome:KT.Proactive_error
+       config ~proactive_enabled:true
+       ~name:"alpha" ~total_turns:3 ~autonomous_action_count:2
+       ~autonomous_tool_turn_count:2 ~board_reactive_turn_count:1
+       ~proactive_count_total:1);
+  ignore
+    (persist_keeper config ~name:"beta" ~total_turns:2
+       ~autonomous_action_count:1 ~autonomous_tool_turn_count:1
+       ~board_reactive_turn_count:1 ~proactive_count_total:0);
+  write_scheduled_decision_at config "beta" ~ts:(now -. 60.0);
+  let json =
+    Dashboard_keeper_feature_proof.json
+      ~config
+      ~n:100
+      ~window_hours:24.0
+      ~success_threshold_pct:80.0
+      ~now
+      ()
+  in
+  let scheduled = feature "scheduled_proactive_autonomy" json in
+  let evidence = keeper_evidence "scheduled_proactive_autonomy" json in
+  check string "recent failed meta evidence does not satisfy proof" "warn"
+    (Safe_ops.json_string ~default:"missing" "status" scheduled);
+  check (list string) "successful decision log proves beta only"
+    ["beta"]
+    (json_string_values "observed_keepers" evidence);
+  check (list string) "recent meta error alpha stays missing"
+    ["alpha"]
+    (json_string_values "missing_keepers" evidence);
+  let alpha_rows =
+    Yojson.Safe.Util.(
+      evidence |> member "per_keeper" |> to_list)
+    |> List.filter (fun row ->
+      Safe_ops.json_string ~default:"" "keeper" row = "alpha")
+  in
+  match alpha_rows with
+  | [ alpha ] ->
+    check string "meta outcome is reported" "error"
+      (Safe_ops.json_string ~default:"missing" "meta_last_proactive_outcome" alpha);
+    check bool "error outcome is not proof" false
+      (Safe_ops.json_bool ~default:true "meta_evidence_within_window" alpha)
+  | _ -> fail "expected one alpha per-keeper row"
+
 let test_persistent_24h_turn_exchange_counts_decision_span () =
   with_store @@ fun config ->
   let now = 1_777_000_000.0 in
@@ -743,6 +796,8 @@ let () =
             test_scheduled_proactive_evidence_uses_enabled_population;
           test_case "scheduled proof window requires recent evidence" `Quick
             test_scheduled_proactive_window_requires_recent_evidence;
+          test_case "scheduled proof ignores recent meta error" `Quick
+            test_scheduled_proactive_meta_error_does_not_prove_success;
           test_case "decision log counts as 24h turn exchange proof" `Quick
             test_persistent_24h_turn_exchange_counts_decision_span;
         ] );

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -189,17 +189,7 @@ let write_decision_lines config keeper_name rows =
   Fs_compat.save_file path
     (String.concat "\n" (List.map Yojson.Safe.to_string rows) ^ "\n")
 
-let write_scheduled_decision config keeper_name =
-  write_decision_lines config keeper_name
-    [
-      `Assoc [
-        ("ts", `String "2026-05-06T01:00:00Z");
-        ("channel", `String "scheduled_autonomous");
-        ("outcome", `String "success");
-      ];
-    ]
-
-let write_scheduled_decision_at config keeper_name ~ts =
+let write_scheduled_decision config keeper_name ~ts =
   write_decision_lines config keeper_name
     [
       `Assoc [
@@ -209,6 +199,9 @@ let write_scheduled_decision_at config keeper_name ~ts =
         ("outcome", `String "success");
       ];
     ]
+
+let write_scheduled_decision_at config keeper_name ~ts =
+  write_scheduled_decision config keeper_name ~ts
 
 let write_24h_turn_span config keeper_name ~now =
   write_decision_lines config keeper_name
@@ -587,12 +580,13 @@ let test_decision_log_counts_as_scheduled_proof () =
         ("outcome", `String "failure");
       ];
     ];
-  write_scheduled_decision config "beta";
+  write_scheduled_decision config "beta" ~ts:latest_success_ts;
   let json =
     Dashboard_keeper_feature_proof.json
       ~config
       ~n:100
       ~success_threshold_pct:80.0
+      ~now:(newer_failure_ts +. 60.0)
       ()
   in
   let scheduled = feature "scheduled_proactive_autonomy" json in


### PR DESCRIPTION
## Summary

- Make `scheduled_proactive_autonomy` respect `--window-hours` instead of crediting lifetime `proactive_count_total` forever.
- Require meta-only scheduled proof to be recent and non-error, because failed scheduled attempts update `last_proactive_ts` for cooldown but do not prove the feature works.
- Surface per-keeper `meta_last_proactive_ts`, `meta_last_proactive_outcome`, and whether meta evidence satisfies the active proof window.
- Add regressions proving stale meta-only evidence and recent error meta do not satisfy a 24h scheduled-proactive proof.
- Repair the current-main unmatched parenthesis in `lib/keeper/keeper_turn.ml` that blocked the focused Dune target after rebasing.

## Why this matters

The objective is to prove whether real keepers are autonomously using every feature. A strict 24h proof cannot rely on stale lifetime scheduled counters from days ago, and it also cannot treat failed scheduled attempts as success. With this branch, the report now reflects live scheduled-proactive recency and outcome quality instead of stale or failed counters.

Latest current-runtime branch proof artifact:

- `/private/tmp/keeper_feature_proof_20260506_current3_recency_branch.json`
- status: `warn`
- summary: 18 features, 9 pass / 9 warn / 0 fail / 9 gaps
- scheduled proactive: `2/17 proactive-enabled keepers have scheduled proactive evidence in the last 24.0h`
- observed scheduled keepers: `taskmaster`, `verifier`
- recent scheduled attempts excluded as proof: `jobsian_purist` and `tech_glutton` have `meta_last_proactive_outcome=error` / decision-log failures

Earlier same-branch snapshots were useful but less strict: the first showed `0/17`, then a rerun showed `3/17` before this patch rejected failed scheduled meta. The remaining truth is still not all-green: 15 proactive-enabled keepers are missing successful 24h scheduled-proactive proof, and the other weak/missing feature groups still need controlled live exercises or additional repair.

## Verification

- `git diff --check origin/main..HEAD`
- `DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_dashboard_keeper_feature_proof.exe bin/keeper_feature_proof_report.exe`
- `_build/default/test/test_dashboard_keeper_feature_proof.exe` (`10 tests run`)
- `_build/default/bin/keeper_feature_proof_report.exe --base-path /Users/dancer/me --window-hours 24 --strict > /private/tmp/keeper_feature_proof_20260506_current3_recency_branch.json` exits 2 because strict proof still has gaps.

## Strict Proof Status

This PR does not make all features pass. It makes the proof stricter and shows the remaining all-feature claim is not achieved: scheduled proactive evidence is partial in the 24h window, and the other weak/missing feature groups still require controlled live exercises or additional repair.