### PR TITLE
feat(dashboard): surface cognitive disclosure in cockpit

### DIFF
--- a/dashboard/src/components/cockpit/cockpit.test.ts
+++ b/dashboard/src/components/cockpit/cockpit.test.ts
@@ -27,9 +27,22 @@ describe('Cockpit command map', () => {
 
     expect(screen.getByTestId('cockpit-command-map')).toBeInTheDocument()
     expect(screen.getByTestId('world-visualizer')).toBeInTheDocument()
+    expect(screen.getByTestId('cockpit-disclosure')).toBeInTheDocument()
     expect(document.querySelectorAll('[data-cockpit-plane]')).toHaveLength(5)
     expect(document.querySelector('[data-cockpit-plane="work"]')).toHaveTextContent('1 blocked')
     expect(document.querySelector('[data-cockpit-plane="ide"]')).toHaveTextContent('Source')
+  })
+
+  it('renders progressive disclosure levels over the route map', () => {
+    render(h(Cockpit, null))
+
+    const disclosure = screen.getByTestId('cockpit-disclosure')
+    expect(disclosure).toHaveAttribute('data-cognitive-complete', 'true')
+    expect(disclosure.querySelectorAll('[data-cognitive-level]')).toHaveLength(3)
+    expect(disclosure.querySelector('[data-cognitive-level="perceive"]')).toHaveTextContent('Route coverage')
+    expect(disclosure.querySelector('[data-cognitive-level="comprehend"]')).toHaveTextContent('Plane grouping')
+    expect(disclosure.querySelector('[data-cognitive-level="project"]')).toHaveTextContent('Route gaps')
+    expect(disclosure).toHaveTextContent('backend-blocked')
   })
 
   it('links cockpit entries to their canonical production routes', () => {

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -6,6 +6,10 @@ import {
   type CockpitEntrypoint,
   type CockpitMode,
 } from '../../cockpit-entrypoints'
+import {
+  CognitiveDisclosure,
+  type CognitiveDisclosureItem,
+} from '../common/cognitive-disclosure'
 import { RouteLink } from '../common/route-link'
 import { WorldVisualizer } from '../world-visualizer'
 
@@ -46,6 +50,39 @@ const PLANE_META: Record<CockpitPlane, PlaneMeta> = {
     stat: 'code',
   },
 }
+
+const COCKPIT_COVERED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'covered').length
+const COCKPIT_PARTIAL_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'partial').length
+const COCKPIT_BLOCKED_ROUTES = COCKPIT_ENTRYPOINTS.filter(entry => entry.coverage === 'backend-blocked').length
+
+const COCKPIT_DISCLOSURE_ITEMS: CognitiveDisclosureItem[] = [
+  {
+    level: 'perceive',
+    title: 'Route coverage',
+    summary: `${COCKPIT_ENTRYPOINTS.length} routes across ${PLANE_ORDER.length} planes`,
+    metric: `${COCKPIT_ENTRYPOINTS.length} routes`,
+    defaultOpen: true,
+    detail: html`
+      <span class="font-mono text-3xs text-ok">${COCKPIT_COVERED_ROUTES} covered</span>
+      <span class="mx-2 text-[var(--color-fg-disabled)]">/</span>
+      <span class="font-mono text-3xs text-warn">${COCKPIT_PARTIAL_ROUTES} partial</span>
+      <span class="mx-2 text-[var(--color-fg-disabled)]">/</span>
+      <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${COCKPIT_BLOCKED_ROUTES} backend-blocked</span>
+    `,
+  },
+  {
+    level: 'comprehend',
+    title: 'Plane grouping',
+    summary: PLANE_ORDER.map(plane => PLANE_META[plane].label).join(', '),
+    metric: `${PLANE_ORDER.length} planes`,
+  },
+  {
+    level: 'project',
+    title: 'Route gaps',
+    summary: `${COCKPIT_BLOCKED_ROUTES} backend-blocked, ${COCKPIT_PARTIAL_ROUTES} partial`,
+    metric: `${COCKPIT_BLOCKED_ROUTES + COCKPIT_PARTIAL_ROUTES} gaps`,
+  },
+]
 
 function planeIcon(plane: CockpitPlane): ComponentChildren {
   switch (plane) {
@@ -191,6 +228,12 @@ export function Cockpit() {
                 </div>
               </div>
             </section>
+
+            <${CognitiveDisclosure}
+              title="Progressive Disclosure"
+              items=${COCKPIT_DISCLOSURE_ITEMS}
+              testId="cockpit-disclosure"
+            />
 
             ${PLANE_ORDER.map(plane => html`
               <${PlaneSection}

--- a/dashboard/src/components/common/cognitive-disclosure.test.ts
+++ b/dashboard/src/components/common/cognitive-disclosure.test.ts
@@ -1,0 +1,75 @@
+import { h } from 'preact'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom'
+
+import {
+  CognitiveDisclosure,
+  summarizeCognitiveDisclosure,
+  type CognitiveDisclosureItem,
+} from './cognitive-disclosure'
+
+const ITEMS: CognitiveDisclosureItem[] = [
+  {
+    level: 'perceive',
+    title: 'Route coverage',
+    summary: '12 routes',
+    metric: '12',
+    detail: h('span', null, 'Live route counts'),
+    defaultOpen: true,
+  },
+  {
+    level: 'comprehend',
+    title: 'Plane grouping',
+    summary: 'Work and Observe',
+    metric: '2',
+  },
+  {
+    level: 'project',
+    title: 'Next route',
+    summary: '1 blocked',
+    detail: h('span', null, 'Blocked route gap'),
+  },
+]
+
+describe('CognitiveDisclosure', () => {
+  afterEach(() => cleanup())
+
+  it('summarizes items by disclosure level', () => {
+    expect(summarizeCognitiveDisclosure(ITEMS)).toEqual({
+      total: 3,
+      byLevel: {
+        perceive: 1,
+        comprehend: 1,
+        project: 1,
+      },
+      openDefaultLevel: 'perceive',
+      complete: true,
+    })
+  })
+
+  it('renders stable disclosure metadata for all levels', () => {
+    render(h(CognitiveDisclosure, { items: ITEMS, testId: 'disclosure' }))
+
+    const root = screen.getByTestId('disclosure')
+    expect(root).toHaveAttribute('data-cognitive-total', '3')
+    expect(root).toHaveAttribute('data-cognitive-complete', 'true')
+    expect(root).toHaveAttribute('data-cognitive-open-default', 'perceive')
+    expect(root.querySelectorAll('[data-cognitive-level]')).toHaveLength(3)
+    expect(root.querySelector('[data-cognitive-level="project"]')).toHaveAttribute('data-cognitive-count', '1')
+    expect(screen.getByText('Perceive')).toBeInTheDocument()
+    expect(screen.getByText('Comprehend')).toBeInTheDocument()
+    expect(screen.getByText('Project')).toBeInTheDocument()
+  })
+
+  it('marks rows that have expandable detail content', () => {
+    render(h(CognitiveDisclosure, { items: ITEMS, testId: 'disclosure' }))
+
+    const root = screen.getByTestId('disclosure')
+    const routeCoverage = root.querySelector('details[data-cognitive-has-detail="true"]')
+    const planeGrouping = screen.getByText('Plane grouping').closest('details')
+
+    expect(routeCoverage).toHaveTextContent('Live route counts')
+    expect(planeGrouping).toHaveAttribute('data-cognitive-has-detail', 'false')
+  })
+})

--- a/dashboard/src/components/common/cognitive-disclosure.test.ts
+++ b/dashboard/src/components/common/cognitive-disclosure.test.ts
@@ -67,9 +67,10 @@ describe('CognitiveDisclosure', () => {
 
     const root = screen.getByTestId('disclosure')
     const routeCoverage = root.querySelector('details[data-cognitive-has-detail="true"]')
-    const planeGrouping = screen.getByText('Plane grouping').closest('details')
+    const planeGrouping = screen.getByText('Plane grouping').closest('[data-cognitive-has-detail]')
 
     expect(routeCoverage).toHaveTextContent('Live route counts')
     expect(planeGrouping).toHaveAttribute('data-cognitive-has-detail', 'false')
+    expect(planeGrouping?.tagName.toLowerCase()).toBe('div')
   })
 })

--- a/dashboard/src/components/common/cognitive-disclosure.ts
+++ b/dashboard/src/components/common/cognitive-disclosure.ts
@@ -120,25 +120,39 @@ export function CognitiveDisclosure({
               </div>
 
               <div class="divide-y divide-[var(--color-border-default)] border-t border-[var(--color-border-default)]">
-                ${entries.map((entry, entryIndex) => html`
-                  <details
-                    key=${`${level}:${entryIndex}`}
-                    open=${entry.defaultOpen}
-                    class="group"
-                    data-cognitive-has-detail=${entry.detail == null ? 'false' : 'true'}
-                  >
-                    <summary class="grid cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-2 px-3 py-2.5 text-left text-xs text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-elevated)]">
-                      <span class="min-w-0 font-medium text-[var(--color-fg-primary)]">${entry.title}</span>
-                      ${entry.metric != null
-                        ? html`<span class="font-mono text-3xs text-[var(--color-fg-muted)]">${entry.metric}</span>`
-                        : null}
-                      <span class="col-span-2 min-w-0 text-[var(--color-fg-muted)]">${entry.summary}</span>
-                    </summary>
-                    ${entry.detail != null
-                      ? html`<div class="px-3 pb-3 text-xs leading-relaxed text-[var(--color-fg-secondary)]">${entry.detail}</div>`
+                ${entries.map((entry, entryIndex) => {
+                  const rowBody = html`
+                    <span class="min-w-0 font-medium text-[var(--color-fg-primary)]">${entry.title}</span>
+                    ${entry.metric != null
+                      ? html`<span class="font-mono text-3xs text-[var(--color-fg-muted)]">${entry.metric}</span>`
                       : null}
-                  </details>
-                `)}
+                    <span class="col-span-2 min-w-0 text-[var(--color-fg-muted)]">${entry.summary}</span>
+                  `
+
+                  return entry.detail == null
+                    ? html`
+                        <div
+                          key=${`${level}:${entryIndex}`}
+                          class="grid grid-cols-[minmax(0,1fr)_auto] gap-2 px-3 py-2.5 text-left text-xs text-[var(--color-fg-secondary)]"
+                          data-cognitive-has-detail="false"
+                        >
+                          ${rowBody}
+                        </div>
+                      `
+                    : html`
+                        <details
+                          key=${`${level}:${entryIndex}`}
+                          open=${entry.defaultOpen}
+                          class="group"
+                          data-cognitive-has-detail="true"
+                        >
+                          <summary class="grid cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-2 px-3 py-2.5 text-left text-xs text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-elevated)]">
+                            ${rowBody}
+                          </summary>
+                          <div class="px-3 pb-3 text-xs leading-relaxed text-[var(--color-fg-secondary)]">${entry.detail}</div>
+                        </details>
+                      `
+                })}
               </div>
             </div>
           `

--- a/dashboard/src/components/common/cognitive-disclosure.ts
+++ b/dashboard/src/components/common/cognitive-disclosure.ts
@@ -1,0 +1,149 @@
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+export type CognitiveDisclosureLevel = 'perceive' | 'comprehend' | 'project'
+
+export interface CognitiveDisclosureItem {
+  level: CognitiveDisclosureLevel
+  title: ComponentChildren
+  summary: ComponentChildren
+  detail?: ComponentChildren
+  metric?: ComponentChildren
+  defaultOpen?: boolean
+}
+
+export interface CognitiveDisclosureSummary {
+  total: number
+  byLevel: Record<CognitiveDisclosureLevel, number>
+  openDefaultLevel: CognitiveDisclosureLevel | null
+  complete: boolean
+}
+
+interface CognitiveDisclosureProps {
+  items: readonly CognitiveDisclosureItem[]
+  title?: ComponentChildren
+  testId?: string
+  class?: string
+}
+
+const LEVEL_ORDER: CognitiveDisclosureLevel[] = ['perceive', 'comprehend', 'project']
+
+const LEVEL_META: Record<CognitiveDisclosureLevel, { label: string; caption: string }> = {
+  perceive: {
+    label: 'Perceive',
+    caption: 'Direct signal',
+  },
+  comprehend: {
+    label: 'Comprehend',
+    caption: 'Grouped meaning',
+  },
+  project: {
+    label: 'Project',
+    caption: 'Forward state',
+  },
+}
+
+export function summarizeCognitiveDisclosure(
+  items: readonly CognitiveDisclosureItem[],
+): CognitiveDisclosureSummary {
+  const byLevel: Record<CognitiveDisclosureLevel, number> = {
+    perceive: 0,
+    comprehend: 0,
+    project: 0,
+  }
+  let openDefaultLevel: CognitiveDisclosureLevel | null = null
+
+  for (const item of items) {
+    byLevel[item.level] += 1
+    if (item.defaultOpen && openDefaultLevel == null) openDefaultLevel = item.level
+  }
+
+  return {
+    total: items.length,
+    byLevel,
+    openDefaultLevel,
+    complete: LEVEL_ORDER.every(level => byLevel[level] > 0),
+  }
+}
+
+function levelItems(
+  items: readonly CognitiveDisclosureItem[],
+  level: CognitiveDisclosureLevel,
+): CognitiveDisclosureItem[] {
+  return items.filter(item => item.level === level)
+}
+
+export function CognitiveDisclosure({
+  items,
+  title = 'Cognitive Disclosure',
+  testId = 'cognitive-disclosure',
+  class: cx,
+}: CognitiveDisclosureProps) {
+  const summary = summarizeCognitiveDisclosure(items)
+
+  return html`
+    <section
+      class="border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] ${cx ?? ''}"
+      aria-label="Cognitive disclosure"
+      data-testid=${testId}
+      data-cognitive-total=${summary.total}
+      data-cognitive-complete=${summary.complete ? 'true' : 'false'}
+      data-cognitive-open-default=${summary.openDefaultLevel ?? ''}
+    >
+      <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5">
+        <h2 class="text-sm font-semibold text-[var(--color-fg-primary)]">${title}</h2>
+        <span class="font-mono text-3xs text-[var(--color-fg-muted)]">
+          ${summary.total} signals
+        </span>
+      </div>
+
+      <div class="grid grid-cols-1 divide-y divide-[var(--color-border-default)] lg:grid-cols-3 lg:divide-x lg:divide-y-0">
+        ${LEVEL_ORDER.map((level, index) => {
+          const meta = LEVEL_META[level]
+          const entries = levelItems(items, level)
+
+          return html`
+            <div
+              key=${level}
+              class="min-w-0"
+              data-cognitive-level=${level}
+              data-cognitive-count=${entries.length}
+            >
+              <div class="flex items-start gap-2 px-3 py-3">
+                <span class="inline-flex h-6 w-7 shrink-0 items-center justify-center border border-[var(--color-border-default)] bg-[var(--color-bg-page)] font-mono text-3xs text-[var(--color-fg-muted)]">
+                  L${index + 1}
+                </span>
+                <div class="min-w-0">
+                  <h3 class="text-xs font-semibold text-[var(--color-fg-primary)]">${meta.label}</h3>
+                  <p class="mt-0.5 text-3xs uppercase tracking-normal text-[var(--color-fg-muted)]">${meta.caption}</p>
+                </div>
+              </div>
+
+              <div class="divide-y divide-[var(--color-border-default)] border-t border-[var(--color-border-default)]">
+                ${entries.map((entry, entryIndex) => html`
+                  <details
+                    key=${`${level}:${entryIndex}`}
+                    open=${entry.defaultOpen}
+                    class="group"
+                    data-cognitive-has-detail=${entry.detail == null ? 'false' : 'true'}
+                  >
+                    <summary class="grid cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-2 px-3 py-2.5 text-left text-xs text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-elevated)]">
+                      <span class="min-w-0 font-medium text-[var(--color-fg-primary)]">${entry.title}</span>
+                      ${entry.metric != null
+                        ? html`<span class="font-mono text-3xs text-[var(--color-fg-muted)]">${entry.metric}</span>`
+                        : null}
+                      <span class="col-span-2 min-w-0 text-[var(--color-fg-muted)]">${entry.summary}</span>
+                    </summary>
+                    ${entry.detail != null
+                      ? html`<div class="px-3 pb-3 text-xs leading-relaxed text-[var(--color-fg-secondary)]">${entry.detail}</div>`
+                      : null}
+                  </details>
+                `)}
+              </div>
+            </div>
+          `
+        })}
+      </div>
+    </section>
+  `
+}


### PR DESCRIPTION
## Summary
- add a reusable dashboard CognitiveDisclosure component for L1/L2/L3 exposure
- surface the cockpit route map as Perceive, Comprehend, and Project layers
- cover the component and cockpit integration with focused Vitest tests

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/common/cognitive-disclosure.test.ts src/components/cockpit/cockpit.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src/components/common/cognitive-disclosure.ts src/components/common/cognitive-disclosure.test.ts src/components/cockpit/cockpit.ts src/components/cockpit/cockpit.test.ts
- git diff --check

## Review focus
- Progressive disclosure metadata is intentionally generic and reusable.
- Cockpit integration stays read-only: it only summarizes existing COCKPIT_ENTRYPOINTS coverage.