### PR TITLE
fix(dashboard): expose card metadata

### DIFF
--- a/dashboard/src/components/common/card.test.ts
+++ b/dashboard/src/components/common/card.test.ts
@@ -2,19 +2,127 @@
 import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
-import { SurfaceCard, SectionCard, Card } from './card'
+import {
+  SurfaceCard,
+  SectionCard,
+  Card,
+  summarizeSurfaceCard,
+  summarizeSectionCard,
+  sectionCardStatusDotTone,
+} from './card'
+
+describe('summarizeSurfaceCard', () => {
+  it('summarizes default surface card state', () => {
+    expect(summarizeSurfaceCard({ children: 'Content' })).toEqual({
+      variant: 'standard',
+      tone: '',
+      toneSource: 'none',
+      hasTone: false,
+      toneLength: 0,
+      hasCustomClass: false,
+      classNameLength: 0,
+      hasTestId: false,
+      testIdLength: 0,
+      contentState: 'text',
+    })
+  })
+
+  it('summarizes populated surface card state', () => {
+    expect(summarizeSurfaceCard({
+      variant: 'compact',
+      tone: 'ok',
+      class: 'extra-card',
+      testId: 'card-1',
+      children: h('span', null, 'Node'),
+    })).toEqual({
+      variant: 'compact',
+      tone: 'ok',
+      toneSource: 'tone-class',
+      hasTone: true,
+      toneLength: 2,
+      hasCustomClass: true,
+      classNameLength: 10,
+      hasTestId: true,
+      testIdLength: 6,
+      contentState: 'node',
+    })
+  })
+})
+
+describe('summarizeSectionCard', () => {
+  it('summarizes status-eyebrow section state', () => {
+    expect(summarizeSectionCard({
+      title: 'Transport',
+      status: 'Watch',
+      eyebrow: 'observing',
+      tone: 'warn',
+      variant: 'compact',
+      class: 'wide',
+      testId: 'section-a',
+      children: h('p', null, 'Body'),
+    })).toEqual({
+      variant: 'compact',
+      bodyPadding: 'p-3.5',
+      labelSource: 'title',
+      labelState: 'text',
+      labelTextLength: 9,
+      tailSource: 'status-eyebrow',
+      status: 'Watch',
+      normalizedStatus: 'watch',
+      statusDotTone: 'warn',
+      hasStatus: true,
+      statusLength: 5,
+      hasEyebrow: true,
+      eyebrowState: 'text',
+      eyebrowTextLength: 9,
+      hasRightSlot: false,
+      hasTone: true,
+      toneLength: 4,
+      hasCustomClass: true,
+      classNameLength: 4,
+      hasTestId: true,
+      testIdLength: 9,
+      contentState: 'node',
+    })
+  })
+
+  it('summarizes explicit right slot state', () => {
+    expect(summarizeSectionCard({
+      label: 'Queue',
+      right: h('button', null, 'Refresh'),
+      children: 'Body',
+    }).tailSource).toBe('right')
+  })
+})
+
+describe('sectionCardStatusDotTone', () => {
+  it('keeps section-specific status aliases stable', () => {
+    expect(sectionCardStatusDotTone('healthy')).toBe('ok')
+    expect(sectionCardStatusDotTone('live')).toBe('ok')
+    expect(sectionCardStatusDotTone('watch')).toBe('warn')
+    expect(sectionCardStatusDotTone('danger')).toBe('bad')
+    expect(sectionCardStatusDotTone('offline')).toBe('neutral')
+  })
+})
 
 describe('SurfaceCard', () => {
   it('renders children', () => {
     const container = document.createElement('div')
     render(h(SurfaceCard, null, 'Content'), container)
     expect(container.textContent).toContain('Content')
+    const el = container.querySelector('[data-surface-card]')
+    expect(el).not.toBeNull()
+    expect(el?.getAttribute('data-surface-card-variant')).toBe('standard')
+    expect(el?.getAttribute('data-surface-card-content-state')).toBe('text')
   })
 
   it('applies testId', () => {
     const container = document.createElement('div')
     render(h(SurfaceCard, { testId: 'card-1' }, 'A'), container)
-    expect(container.querySelector('[data-testid="card-1"]')).not.toBeNull()
+    const el = container.querySelector('[data-testid="card-1"]')
+    expect(el).not.toBeNull()
+    expect(el?.getAttribute('data-surface-card-has-test-id')).toBe('true')
+    expect(el?.getAttribute('data-surface-card-test-id-length')).toBe('6')
   })
 
   it('applies standard variant class', () => {
@@ -22,6 +130,7 @@ describe('SurfaceCard', () => {
     render(h(SurfaceCard, { variant: 'standard' }, 'A'), container)
     const el = container.querySelector('div')
     expect(el?.classList.contains('card')).toBe(true)
+    expect(el?.getAttribute('data-surface-card-variant')).toBe('standard')
   })
 
   it('applies light variant class', () => {
@@ -29,6 +138,7 @@ describe('SurfaceCard', () => {
     render(h(SurfaceCard, { variant: 'light' }, 'A'), container)
     const el = container.querySelector('div')
     expect(el?.classList.contains('!bg-transparent')).toBe(true)
+    expect(el?.getAttribute('data-surface-card-variant')).toBe('light')
   })
 
   it('applies compact variant class', () => {
@@ -36,6 +146,7 @@ describe('SurfaceCard', () => {
     render(h(SurfaceCard, { variant: 'compact' }, 'A'), container)
     const el = container.querySelector('div')
     expect(el?.classList.contains('!p-3.5')).toBe(true)
+    expect(el?.getAttribute('data-surface-card-variant')).toBe('compact')
   })
 
   it('applies tone class', () => {
@@ -43,6 +154,10 @@ describe('SurfaceCard', () => {
     render(h(SurfaceCard, { tone: 'ok' }, 'A'), container)
     const el = container.querySelector('div')
     expect(el?.classList.contains('ok')).toBe(true)
+    expect(el?.getAttribute('data-surface-card-tone')).toBe('ok')
+    expect(el?.getAttribute('data-surface-card-tone-source')).toBe('tone-class')
+    expect(el?.getAttribute('data-surface-card-has-tone')).toBe('true')
+    expect(el?.getAttribute('data-surface-card-tone-length')).toBe('2')
   })
 
   it('applies custom class', () => {
@@ -50,6 +165,8 @@ describe('SurfaceCard', () => {
     render(h(SurfaceCard, { class: 'extra' }, 'A'), container)
     const el = container.querySelector('div')
     expect(el?.classList.contains('extra')).toBe(true)
+    expect(el?.getAttribute('data-surface-card-has-custom-class')).toBe('true')
+    expect(el?.getAttribute('data-surface-card-class-length')).toBe('5')
   })
 })
 
@@ -59,12 +176,20 @@ describe('SectionCard', () => {
     render(h(SectionCard, { label: 'Section A' }, h('p', null, 'Body')), container)
     expect(container.textContent).toContain('Section A')
     expect(container.textContent).toContain('Body')
+    const el = container.querySelector('[data-section-card]')
+    expect(el).not.toBeNull()
+    expect(el?.getAttribute('data-section-card-label-source')).toBe('label')
+    expect(el?.getAttribute('data-section-card-label-state')).toBe('text')
+    expect(el?.getAttribute('data-section-card-label-text-length')).toBe('9')
+    expect(el?.getAttribute('data-section-card-tail-source')).toBe('none')
+    expect(el?.getAttribute('data-section-card-content-state')).toBe('node')
   })
 
   it('applies compact body padding', () => {
     const container = document.createElement('div')
     render(h(SectionCard, { label: 'T', variant: 'compact' }, 'Body'), container)
     expect(container.innerHTML).toContain('p-3.5')
+    expect(container.querySelector('[data-section-card]')?.getAttribute('data-section-card-body-padding')).toBe('p-3.5')
   })
 
   it('accepts legacy title, right slot, and test id props', () => {
@@ -77,7 +202,13 @@ describe('SectionCard', () => {
       ),
       container,
     )
-    expect(container.querySelector('[data-testid="section-b"]')).not.toBeNull()
+    const el = container.querySelector('[data-testid="section-b"]')
+    expect(el).not.toBeNull()
+    expect(el?.getAttribute('data-section-card-label-source')).toBe('title')
+    expect(el?.getAttribute('data-section-card-tail-source')).toBe('right')
+    expect(el?.getAttribute('data-section-card-has-right-slot')).toBe('true')
+    expect(el?.getAttribute('data-section-card-has-test-id')).toBe('true')
+    expect(el?.getAttribute('data-section-card-test-id-length')).toBe('9')
     expect(container.textContent).toContain('Section B')
     expect(container.textContent).toContain('Tail')
     expect(container.textContent).toContain('Body')
@@ -96,6 +227,13 @@ describe('SectionCard', () => {
     expect(container.textContent).toContain('Transport')
     expect(container.textContent).toContain('degraded')
     expect(container.innerHTML).toContain('bg-[var(--color-status-warn)]')
+    const el = container.querySelector('[data-section-card]')
+    expect(el?.getAttribute('data-section-card-status')).toBe('warn')
+    expect(el?.getAttribute('data-section-card-status-dot-tone')).toBe('warn')
+    expect(el?.getAttribute('data-section-card-tail-source')).toBe('status-eyebrow')
+    expect(el?.getAttribute('data-section-card-has-status')).toBe('true')
+    expect(el?.getAttribute('data-section-card-has-eyebrow')).toBe('true')
+    expect(el?.getAttribute('data-section-card-eyebrow-text-length')).toBe('8')
   })
 
   it('normalizes watch status before choosing the dot tone', () => {

--- a/dashboard/src/components/common/card.test.ts
+++ b/dashboard/src/components/common/card.test.ts
@@ -93,6 +93,50 @@ describe('summarizeSectionCard', () => {
       children: 'Body',
     }).tailSource).toBe('right')
   })
+
+  it('treats blank string metadata as absent', () => {
+    expect(summarizeSurfaceCard({
+      tone: '  ',
+      class: ' ',
+      testId: '\t',
+      children: 'Body',
+    })).toMatchObject({
+      hasTone: false,
+      toneLength: 0,
+      hasCustomClass: false,
+      classNameLength: 0,
+      hasTestId: false,
+      testIdLength: 0,
+    })
+
+    expect(summarizeSectionCard({
+      title: 'Queue',
+      status: '  ',
+      tone: ' ',
+      testId: ' ',
+      children: 'Body',
+    })).toMatchObject({
+      tailSource: 'none',
+      normalizedStatus: '',
+      hasStatus: false,
+      statusLength: 0,
+      hasTone: false,
+      hasTestId: false,
+    })
+  })
+
+  it('keeps status length aligned to normalized status metadata', () => {
+    expect(summarizeSectionCard({
+      title: 'Queue',
+      status: ' Watch ',
+      children: 'Body',
+    })).toMatchObject({
+      tailSource: 'status-eyebrow',
+      normalizedStatus: 'watch',
+      hasStatus: true,
+      statusLength: 5,
+    })
+  })
 })
 
 describe('sectionCardStatusDotTone', () => {
@@ -241,12 +285,15 @@ describe('SectionCard', () => {
     render(
       h(
         SectionCard,
-        { title: 'Transport', status: 'Watch', eyebrow: 'observing' },
+        { title: 'Transport', status: ' Watch ', eyebrow: 'observing' },
         h('p', null, 'Body'),
       ),
       container,
     )
     expect(container.innerHTML).toContain('bg-[var(--color-status-warn)]')
+    const el = container.querySelector('[data-section-card]')
+    expect(el?.getAttribute('data-section-card-status')).toBe('watch')
+    expect(el?.getAttribute('data-section-card-status-length')).toBe('5')
   })
 
   it('maps offline status through the shared neutral dot tone', () => {

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -4,7 +4,7 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { SectionHead } from '../section-head'
-import { statusDotColor } from './status-badge'
+import { statusBadgeTone, statusDotColor } from './status-badge'
 
 // ── Class constants (CARD_STANDARD exported for inline section usage) ──
 const CARD_BASE = 'card'
@@ -12,7 +12,50 @@ export const CARD_STANDARD = `${CARD_BASE}`
 const CARD_LIGHT = `${CARD_BASE} !bg-transparent !backdrop-blur-none`
 const CARD_COMPACT = `${CARD_BASE} !p-3.5 !shadow-[var(--shadow-1)]`
 
-type CardVariant = 'standard' | 'light' | 'compact'
+export type CardVariant = 'standard' | 'light' | 'compact'
+export type CardToneSource = 'none' | 'tone-class'
+export type CardContentState = 'empty' | 'text' | 'node'
+export type SectionCardLabelSource = 'label' | 'title' | 'empty'
+export type SectionCardTailSource = 'right' | 'status-eyebrow' | 'none'
+export type CardStatusDotTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral'
+
+export interface SurfaceCardSummary {
+  readonly variant: CardVariant
+  readonly tone: string
+  readonly toneSource: CardToneSource
+  readonly hasTone: boolean
+  readonly toneLength: number
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+  readonly hasTestId: boolean
+  readonly testIdLength: number
+  readonly contentState: CardContentState
+}
+
+export interface SectionCardSummary {
+  readonly variant: CardVariant
+  readonly bodyPadding: string
+  readonly labelSource: SectionCardLabelSource
+  readonly labelState: CardContentState
+  readonly labelTextLength: number
+  readonly tailSource: SectionCardTailSource
+  readonly status: string
+  readonly normalizedStatus: string
+  readonly statusDotTone: CardStatusDotTone
+  readonly hasStatus: boolean
+  readonly statusLength: number
+  readonly hasEyebrow: boolean
+  readonly eyebrowState: CardContentState
+  readonly eyebrowTextLength: number
+  readonly hasRightSlot: boolean
+  readonly hasTone: boolean
+  readonly toneLength: number
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+  readonly hasTestId: boolean
+  readonly testIdLength: number
+  readonly contentState: CardContentState
+}
 
 const VARIANT_CLASSES: Record<CardVariant, string> = {
   standard: CARD_STANDARD,
@@ -20,13 +63,86 @@ const VARIANT_CLASSES: Record<CardVariant, string> = {
   compact: CARD_COMPACT,
 }
 
-interface SurfaceCardProps {
+function hasNonEmptyString(value: string | undefined): boolean {
+  return value !== undefined && value !== ''
+}
+
+function contentState(children: ComponentChildren | undefined): CardContentState {
+  if (
+    children === undefined ||
+    children === null ||
+    children === false ||
+    children === ''
+  ) return 'empty'
+  if (typeof children === 'string' || typeof children === 'number') return 'text'
+  return 'node'
+}
+
+function textLength(children: ComponentChildren | undefined): number {
+  if (typeof children === 'string') return children.length
+  if (typeof children === 'number') return String(children).length
+  return 0
+}
+
+function normalizeStatus(status: string | undefined): string {
+  return status?.trim().toLowerCase() ?? ''
+}
+
+function surfaceCardClassName({
+  variant,
+  tone,
+  className,
+}: {
+  variant: CardVariant
+  tone?: string
+  className?: string
+}): string {
+  return [VARIANT_CLASSES[variant], tone, className].filter(Boolean).join(' ')
+}
+
+export function sectionCardStatusDotTone(status?: string): CardStatusDotTone {
+  const normalized = normalizeStatus(status)
+  switch (normalized) {
+    case 'healthy':
+    case 'live':
+      return 'ok'
+    case 'watch':
+      return 'warn'
+    case 'danger':
+      return 'bad'
+    default:
+      return statusBadgeTone(normalized) as CardStatusDotTone
+  }
+}
+
+export interface SurfaceCardProps {
   variant?: CardVariant
   class?: string
   /** Tone class: 'ok' | 'warn' | 'bad' */
   tone?: string
   testId?: string
   children: ComponentChildren
+}
+
+export function summarizeSurfaceCard({
+  variant = 'standard',
+  class: cx,
+  tone,
+  testId,
+  children,
+}: SurfaceCardProps): SurfaceCardSummary {
+  return {
+    variant,
+    tone: tone ?? '',
+    toneSource: hasNonEmptyString(tone) ? 'tone-class' : 'none',
+    hasTone: hasNonEmptyString(tone),
+    toneLength: tone?.length ?? 0,
+    hasCustomClass: hasNonEmptyString(cx),
+    classNameLength: cx?.length ?? 0,
+    hasTestId: hasNonEmptyString(testId),
+    testIdLength: testId?.length ?? 0,
+    contentState: contentState(children),
+  }
 }
 
 export function SurfaceCard({
@@ -36,12 +152,33 @@ export function SurfaceCard({
   testId,
   children,
 }: SurfaceCardProps) {
-  const cls = [VARIANT_CLASSES[variant], tone, cx].filter(Boolean).join(' ')
-  return html`<div class=${cls} data-testid=${testId}>${children}</div>`
+  const summary = summarizeSurfaceCard({
+    variant,
+    class: cx,
+    tone,
+    testId,
+    children,
+  })
+  const cls = surfaceCardClassName({ variant, tone, className: cx })
+  return html`<div
+    class=${cls}
+    data-surface-card
+    data-surface-card-variant=${summary.variant}
+    data-surface-card-tone=${summary.tone}
+    data-surface-card-tone-source=${summary.toneSource}
+    data-surface-card-has-tone=${summary.hasTone}
+    data-surface-card-tone-length=${summary.toneLength}
+    data-surface-card-has-custom-class=${summary.hasCustomClass}
+    data-surface-card-class-length=${summary.classNameLength}
+    data-surface-card-has-test-id=${summary.hasTestId}
+    data-surface-card-test-id-length=${summary.testIdLength}
+    data-surface-card-content-state=${summary.contentState}
+    data-testid=${testId}
+  >${children}</div>`
 }
 
 // ── Section card with label header ──
-interface SectionCardProps {
+export interface SectionCardProps {
   label?: ComponentChildren
   title?: ComponentChildren
   right?: ComponentChildren
@@ -56,16 +193,56 @@ interface SectionCardProps {
 }
 
 function statusDotClass(status?: string): string {
-  const normalized = (status ?? '').toLowerCase()
-  switch (normalized) {
-    case 'healthy':
-    case 'live':
-      return statusDotColor('active')
-    case 'watch':
-    case 'danger':
-      return statusDotColor(normalized === 'watch' ? 'warn' : 'bad')
-    default:
-      return statusDotColor(normalized)
+  return statusDotColor(sectionCardStatusDotTone(status))
+}
+
+export function summarizeSectionCard({
+  label,
+  title,
+  right,
+  eyebrow,
+  status,
+  tone,
+  class: cx,
+  variant = 'light',
+  testId,
+  'data-testid': dataTestId,
+  children,
+}: SectionCardProps): SectionCardSummary {
+  const sectionLabel = label ?? title
+  const labelSource =
+    label != null ? 'label' :
+      title != null ? 'title' :
+        'empty'
+  const tailSource =
+    right != null ? 'right' :
+      eyebrow != null || status != null ? 'status-eyebrow' :
+        'none'
+  const effectiveTestId = testId ?? dataTestId
+
+  return {
+    variant,
+    bodyPadding: variant === 'compact' ? 'p-3.5' : 'p-4',
+    labelSource,
+    labelState: contentState(sectionLabel),
+    labelTextLength: textLength(sectionLabel),
+    tailSource,
+    status: status ?? '',
+    normalizedStatus: normalizeStatus(status),
+    statusDotTone: sectionCardStatusDotTone(status),
+    hasStatus: hasNonEmptyString(status),
+    statusLength: status?.length ?? 0,
+    hasEyebrow: eyebrow != null,
+    eyebrowState: contentState(eyebrow),
+    eyebrowTextLength: textLength(eyebrow),
+    hasRightSlot: right != null,
+    hasTone: hasNonEmptyString(tone),
+    toneLength: tone?.length ?? 0,
+    hasCustomClass: hasNonEmptyString(cx),
+    classNameLength: cx?.length ?? 0,
+    hasTestId: hasNonEmptyString(effectiveTestId),
+    testIdLength: effectiveTestId?.length ?? 0,
+    contentState: contentState(children),
   }
 }
 
@@ -91,7 +268,20 @@ export function SectionCard({
   // SectionHead's bg-surface still reads as a strip because it sits
   // above transparent body. Variant `compact` had p-3.5 in the legacy
   // path; the new wrapper uses p-3.5 to preserve that visual.
-  const bodyPadding = variant === 'compact' ? 'p-3.5' : 'p-4'
+  const summary = summarizeSectionCard({
+    label,
+    title,
+    right,
+    eyebrow,
+    status,
+    tone,
+    class: cx,
+    variant,
+    testId,
+    'data-testid': dataTestId,
+    children,
+  })
+  const bodyPadding = summary.bodyPadding
   const sectionLabel = label ?? title ?? ''
   const tail = right ?? (
     eyebrow != null || status != null
@@ -103,22 +293,59 @@ export function SectionCard({
         `
       : null
   )
+  const effectiveTestId = testId ?? dataTestId
+  const rootClass = surfaceCardClassName({
+    variant,
+    tone,
+    className: ['flex flex-col !p-0 overflow-hidden', cx].filter(Boolean).join(' '),
+  })
   return html`
-    <${SurfaceCard}
-      variant=${variant}
-      tone=${tone}
-      testId=${testId ?? dataTestId}
-      class="flex flex-col !p-0 overflow-hidden ${cx ?? ''}"
+    <div
+      class=${rootClass}
+      data-surface-card
+      data-surface-card-variant=${summary.variant}
+      data-surface-card-tone=${tone ?? ''}
+      data-surface-card-tone-source=${summary.hasTone ? 'tone-class' : 'none'}
+      data-surface-card-has-tone=${summary.hasTone}
+      data-surface-card-tone-length=${summary.toneLength}
+      data-surface-card-has-custom-class=${summary.hasCustomClass}
+      data-surface-card-class-length=${summary.classNameLength}
+      data-surface-card-has-test-id=${summary.hasTestId}
+      data-surface-card-test-id-length=${summary.testIdLength}
+      data-surface-card-content-state=${summary.contentState}
+      data-section-card
+      data-section-card-variant=${summary.variant}
+      data-section-card-body-padding=${summary.bodyPadding}
+      data-section-card-label-source=${summary.labelSource}
+      data-section-card-label-state=${summary.labelState}
+      data-section-card-label-text-length=${summary.labelTextLength}
+      data-section-card-tail-source=${summary.tailSource}
+      data-section-card-status=${summary.normalizedStatus}
+      data-section-card-status-dot-tone=${summary.statusDotTone}
+      data-section-card-has-status=${summary.hasStatus}
+      data-section-card-status-length=${summary.statusLength}
+      data-section-card-has-eyebrow=${summary.hasEyebrow}
+      data-section-card-eyebrow-state=${summary.eyebrowState}
+      data-section-card-eyebrow-text-length=${summary.eyebrowTextLength}
+      data-section-card-has-right-slot=${summary.hasRightSlot}
+      data-section-card-has-tone=${summary.hasTone}
+      data-section-card-tone-length=${summary.toneLength}
+      data-section-card-has-custom-class=${summary.hasCustomClass}
+      data-section-card-class-length=${summary.classNameLength}
+      data-section-card-has-test-id=${summary.hasTestId}
+      data-section-card-test-id-length=${summary.testIdLength}
+      data-section-card-content-state=${summary.contentState}
+      data-testid=${effectiveTestId}
     >
       <${SectionHead} tail=${tail}>${sectionLabel}<//>
       <div class="${bodyPadding} flex flex-col gap-4">${children}</div>
-    <//>
+    </div>
   `
 }
 
 
 // ── Legacy Card (backward compat — accepts title prop) ──
-interface CardProps {
+export interface CardProps {
   title?: ComponentChildren
   class?: string
   variant?: CardVariant

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -64,7 +64,11 @@ const VARIANT_CLASSES: Record<CardVariant, string> = {
 }
 
 function hasNonEmptyString(value: string | undefined): boolean {
-  return value !== undefined && value !== ''
+  return value !== undefined && value.trim() !== ''
+}
+
+function trimmedTextLength(value: string | undefined): number {
+  return value?.trim().length ?? 0
 }
 
 function contentState(children: ComponentChildren | undefined): CardContentState {
@@ -136,11 +140,11 @@ export function summarizeSurfaceCard({
     tone: tone ?? '',
     toneSource: hasNonEmptyString(tone) ? 'tone-class' : 'none',
     hasTone: hasNonEmptyString(tone),
-    toneLength: tone?.length ?? 0,
+    toneLength: trimmedTextLength(tone),
     hasCustomClass: hasNonEmptyString(cx),
-    classNameLength: cx?.length ?? 0,
+    classNameLength: trimmedTextLength(cx),
     hasTestId: hasNonEmptyString(testId),
-    testIdLength: testId?.length ?? 0,
+    testIdLength: trimmedTextLength(testId),
     contentState: contentState(children),
   }
 }
@@ -210,13 +214,15 @@ export function summarizeSectionCard({
   children,
 }: SectionCardProps): SectionCardSummary {
   const sectionLabel = label ?? title
+  const normalizedStatus = normalizeStatus(status)
+  const hasStatus = normalizedStatus !== ''
   const labelSource =
     label != null ? 'label' :
       title != null ? 'title' :
         'empty'
   const tailSource =
     right != null ? 'right' :
-      eyebrow != null || status != null ? 'status-eyebrow' :
+      eyebrow != null || hasStatus ? 'status-eyebrow' :
         'none'
   const effectiveTestId = testId ?? dataTestId
 
@@ -228,20 +234,20 @@ export function summarizeSectionCard({
     labelTextLength: textLength(sectionLabel),
     tailSource,
     status: status ?? '',
-    normalizedStatus: normalizeStatus(status),
+    normalizedStatus,
     statusDotTone: sectionCardStatusDotTone(status),
-    hasStatus: hasNonEmptyString(status),
-    statusLength: status?.length ?? 0,
+    hasStatus,
+    statusLength: normalizedStatus.length,
     hasEyebrow: eyebrow != null,
     eyebrowState: contentState(eyebrow),
     eyebrowTextLength: textLength(eyebrow),
     hasRightSlot: right != null,
     hasTone: hasNonEmptyString(tone),
-    toneLength: tone?.length ?? 0,
+    toneLength: trimmedTextLength(tone),
     hasCustomClass: hasNonEmptyString(cx),
-    classNameLength: cx?.length ?? 0,
+    classNameLength: trimmedTextLength(cx),
     hasTestId: hasNonEmptyString(effectiveTestId),
-    testIdLength: effectiveTestId?.length ?? 0,
+    testIdLength: trimmedTextLength(effectiveTestId),
     contentState: contentState(children),
   }
 }
@@ -284,10 +290,10 @@ export function SectionCard({
   const bodyPadding = summary.bodyPadding
   const sectionLabel = label ?? title ?? ''
   const tail = right ?? (
-    eyebrow != null || status != null
+    eyebrow != null || summary.hasStatus
       ? html`
           <span class="inline-flex items-center gap-1.5 text-2xs text-[var(--color-fg-muted)]">
-            ${status != null ? html`<span class="h-1.5 w-1.5 rounded-full ${statusDotClass(status)}" />` : null}
+            ${summary.hasStatus ? html`<span class="h-1.5 w-1.5 rounded-full ${statusDotClass(status)}" />` : null}
             ${eyebrow != null ? html`<span>${eyebrow}</span>` : null}
           </span>
         `


### PR DESCRIPTION
## Summary
- export card prop/types and pure summary helpers for `SurfaceCard` and `SectionCard`
- stamp card DOM metadata for variant, tone/test hooks, custom class presence, content shape, section label source, tail source, body padding, and status-dot tone
- keep legacy `Card` routing behavior intact while covering the routed surface/section metadata in tests

## Why
The MASC Cockpit/Kimi component audit needs card anatomy to be inspectable without parsing Tailwind class strings. Surface and section cards now expose the header/tail/status routing that determines dashboard card structure.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/card.test.ts src/components/common/card.a11y.test.ts` passed after rebase: 2 files, 25 tests
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` passed after rebase
- `git diff --check` passed after rebase
- `pnpm --dir dashboard run lint` passed with existing warnings in `dashboard/src/components/common/virtual-list.ts` and `dashboard/src/components/fsm-hub.ts`
- `pnpm --dir dashboard run build` passed with the known Vite dynamic/static import warning for `dashboard.ts`

## Browser QA
- served with `env MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9 pnpm --dir dashboard exec vite --host 127.0.0.1 --port 5236 --strictPort --force`
- desktop 1280x900 on `/dashboard/card-qa.html`: verified 5 surface cards, 3 section cards, metadata attributes, no horizontal overflow, and `Refresh` -> `Synced` right-slot button interaction; screenshot `/tmp/masc-card-summary-0506.png`
- mobile 390x760 on `/dashboard/card-qa.html`: verified the same metadata counts and no horizontal overflow; screenshot `/tmp/masc-card-summary-0506-mobile.png`
- browser console after correct-route reload only had Vite debug connection logs; page errors were empty

## Cleanup
- removed temporary `dashboard/card-qa.html`
- removed temporary browser QA spec/script artifacts
- removed temporary `dashboard/node_modules` symlink
- stopped Vite on port 5236
- closed the browser QA session