### PR TITLE
feat(goal-loop): publish live replay status for dashboard

### DIFF
--- a/docs/examples/goal-loop-live-replay.md
+++ b/docs/examples/goal-loop-live-replay.md
@@ -15,6 +15,7 @@ python3 scripts/goal_loop_live_replay.py \
   --act-map test/fixtures/goal_loop/act-map.startup.json \
   --runtime-source localhost:8935 \
   --base-path /Users/dancer/me \
+  --publish-dashboard-status \
   --loop-iteration post-act-live \
   --fail-on verify \
   --format text
@@ -31,6 +32,11 @@ Artifacts written:
   `evidence_kind=live_runtime_logs`, concrete evidence source, evidence window,
   and `checked_at`.
 - `status.json`: aggregate GOAL LOOP status and next action.
+
+When `--publish-dashboard-status` is set, the same status snapshot is also
+written to `<base-path>/.masc/goal-loop/status.json`. The dashboard endpoint
+`/api/v1/dashboard/goal-loop/status` reads that runtime path, so use this flag
+with the active server base path when the replay should update the operator UI.
 
 Interpretation:
 

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -88,6 +88,19 @@ def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
             temp_path.unlink()
 
 
+def normalize_base_path(base_path: str | None) -> str | None:
+    """Expand ``~`` so every downstream consumer (artifact metadata,
+    evidence_source, dashboard status path) sees the same canonical form.
+
+    Without this, ``--base-path ~/foo`` produced inconsistent artifacts:
+    metadata.base_path / evidence_source kept the unexpanded ``~``, but
+    dashboard_status_path_for_base_path expanded it for filesystem writes.
+    """
+    if base_path is None:
+        return None
+    return str(Path(base_path).expanduser())
+
+
 def dashboard_status_path_for_base_path(base_path: str) -> Path:
     return Path(base_path).expanduser() / ".masc" / "goal-loop" / "status.json"
 
@@ -460,7 +473,7 @@ def main(argv: list[str] | None = None) -> int:
         verify_policy=args.verify_policy,
         max_samples=args.max_samples,
         runtime_source=args.runtime_source,
-        base_path=args.base_path,
+        base_path=normalize_base_path(args.base_path),
         publish_dashboard_status=args.publish_dashboard_status,
     )
     if args.format == "json":

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -87,6 +87,7 @@ def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
         text=True,
     )
     temp_path = Path(temp_name)
+    replaced = False
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
@@ -94,14 +95,16 @@ def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         temp_path.replace(path)
+        replaced = True
     finally:
-        if temp_path.exists():
+        if not replaced and temp_path.exists():
             temp_path.unlink()
 
 
 def normalize_base_path(base_path: str | None) -> str | None:
-    """Expand ``~`` so every downstream consumer (artifact metadata,
-    evidence_source, dashboard status path) sees the same canonical form.
+    """Expand and resolve base path so every downstream consumer (artifact
+    metadata, evidence_source, dashboard status path) sees the same canonical
+    absolute form.
 
     Without this, ``--base-path ~/foo`` produced inconsistent artifacts:
     metadata.base_path / evidence_source kept the unexpanded ``~``, but
@@ -115,7 +118,7 @@ def normalize_base_path(base_path: str | None) -> str | None:
         # guard does not silently fall through and write
         # ./.masc/goal-loop/status.json relative to CWD.
         return None
-    return str(Path(stripped).expanduser())
+    return str(Path(stripped).expanduser().resolve(strict=False))
 
 
 def dashboard_status_path_for_base_path(base_path: str) -> Path:

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -98,7 +98,13 @@ def normalize_base_path(base_path: str | None) -> str | None:
     """
     if base_path is None:
         return None
-    return str(Path(base_path).expanduser())
+    stripped = base_path.strip()
+    if not stripped:
+        # Whitespace-only is treated the same as missing so the publish-mode
+        # guard does not silently fall through and write
+        # ./.masc/goal-loop/status.json relative to CWD.
+        return ""
+    return str(Path(stripped).expanduser())
 
 
 def dashboard_status_path_for_base_path(base_path: str) -> Path:
@@ -235,6 +241,14 @@ def replay_logs(
     base_path: str | None,
     publish_dashboard_status: bool = False,
 ) -> ReplaySummary:
+    # Normalize at the API boundary (not just in main()) so callers that go
+    # through replay_logs directly — unit tests, downstream Python harnesses —
+    # also see consistent base_path semantics. Strip whitespace before any
+    # check so a base_path of "  " is treated as missing instead of writing
+    # ./.masc/goal-loop/status.json relative to CWD.
+    base_path = normalize_base_path(base_path)
+    if base_path is not None and not base_path.strip():
+        base_path = None
     if publish_dashboard_status and not base_path:
         raise ValueError("--publish-dashboard-status requires --base-path")
 
@@ -473,7 +487,9 @@ def main(argv: list[str] | None = None) -> int:
         verify_policy=args.verify_policy,
         max_samples=args.max_samples,
         runtime_source=args.runtime_source,
-        base_path=normalize_base_path(args.base_path),
+        # replay_logs normalizes base_path internally, so unit tests and
+        # other Python callers get the same expansion + whitespace handling.
+        base_path=args.base_path,
         publish_dashboard_status=args.publish_dashboard_status,
     )
     if args.format == "json":

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -15,6 +15,7 @@ import json
 import os
 import shutil
 import sys
+import tempfile
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -79,9 +80,19 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
 
 def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    temp_path = Path(temp_name)
     try:
-        write_json(temp_path, payload)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
         temp_path.replace(path)
     finally:
         if temp_path.exists():
@@ -103,7 +114,7 @@ def normalize_base_path(base_path: str | None) -> str | None:
         # Whitespace-only is treated the same as missing so the publish-mode
         # guard does not silently fall through and write
         # ./.masc/goal-loop/status.json relative to CWD.
-        return ""
+        return None
     return str(Path(stripped).expanduser())
 
 
@@ -247,8 +258,6 @@ def replay_logs(
     # check so a base_path of "  " is treated as missing instead of writing
     # ./.masc/goal-loop/status.json relative to CWD.
     base_path = normalize_base_path(base_path)
-    if base_path is not None and not base_path.strip():
-        base_path = None
     if publish_dashboard_status and not base_path:
         raise ValueError("--publish-dashboard-status requires --base-path")
 

--- a/scripts/goal_loop_live_replay.py
+++ b/scripts/goal_loop_live_replay.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import sys
 import time
@@ -53,6 +54,7 @@ class ReplaySummary:
     verify_json: str
     status_json: str
     metadata_json: str
+    dashboard_status_json: str | None
 
 
 @dataclass(frozen=True)
@@ -73,6 +75,21 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        write_json(temp_path, payload)
+        temp_path.replace(path)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
+def dashboard_status_path_for_base_path(base_path: str) -> Path:
+    return Path(base_path).expanduser() / ".masc" / "goal-loop" / "status.json"
 
 
 def artifact_log_name(index: int, source: Path) -> str:
@@ -203,7 +220,11 @@ def replay_logs(
     max_samples: int,
     runtime_source: str,
     base_path: str | None,
+    publish_dashboard_status: bool = False,
 ) -> ReplaySummary:
+    if publish_dashboard_status and not base_path:
+        raise ValueError("--publish-dashboard-status requires --base-path")
+
     artifact_dir.mkdir(parents=True, exist_ok=True)
     max_samples_effective = max(max_samples, 0)
     window_start = utc_now_iso()
@@ -264,6 +285,11 @@ def replay_logs(
     )
     status_json = asdict(status_report)
     status_json = status_summary_with_verify_metadata(status_json, verify_json)
+    dashboard_status_json = (
+        dashboard_status_path_for_base_path(base_path)
+        if publish_dashboard_status and base_path
+        else None
+    )
 
     metadata = {
         "schema_version": 1,
@@ -281,6 +307,9 @@ def replay_logs(
         "max_samples": max_samples_effective,
         "max_samples_requested": max_samples,
         "max_samples_effective": max_samples_effective,
+        "dashboard_status_json": str(dashboard_status_json)
+        if dashboard_status_json is not None
+        else None,
     }
 
     paths = {
@@ -297,6 +326,8 @@ def replay_logs(
     write_json(paths["decide_json"], decide_json)
     write_json(paths["verify_json"], verify_json)
     write_json(paths["status_json"], status_json)
+    if dashboard_status_json is not None:
+        write_json_atomic(dashboard_status_json, status_json)
 
     return ReplaySummary(
         artifact_dir=str(artifact_dir),
@@ -309,6 +340,9 @@ def replay_logs(
         verify_json=str(paths["verify_json"]),
         status_json=str(paths["status_json"]),
         metadata_json=str(paths["metadata_json"]),
+        dashboard_status_json=str(dashboard_status_json)
+        if dashboard_status_json is not None
+        else None,
     )
 
 
@@ -325,6 +359,8 @@ def summary_to_text(summary: ReplaySummary) -> str:
         f"status_json: {summary.status_json}",
         f"metadata_json: {summary.metadata_json}",
     ]
+    if summary.dashboard_status_json:
+        lines.append(f"dashboard_status_json: {summary.dashboard_status_json}")
     return "\n".join(lines)
 
 
@@ -374,6 +410,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Runtime base path associated with the captured logs.",
     )
     parser.add_argument(
+        "--publish-dashboard-status",
+        action="store_true",
+        help=(
+            "Also write status.json to <base-path>/.masc/goal-loop/status.json, "
+            "which is the dashboard runtime status path."
+        ),
+    )
+    parser.add_argument(
         "--loop-iteration",
         default="post-act-live",
         help="Loop iteration label stored in status.json.",
@@ -417,6 +461,7 @@ def main(argv: list[str] | None = None) -> int:
         max_samples=args.max_samples,
         runtime_source=args.runtime_source,
         base_path=args.base_path,
+        publish_dashboard_status=args.publish_dashboard_status,
     )
     if args.format == "json":
         print(json.dumps(asdict(summary), ensure_ascii=False, indent=2, sort_keys=True))

--- a/test/test_goal_loop_live_replay.py
+++ b/test/test_goal_loop_live_replay.py
@@ -274,6 +274,56 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
             self.assertIn("runtime_source=cli-test", verify["evidence_source"])
             self.assertIn("base_path=/tmp/masc", verify["evidence_source"])
 
+    def test_cli_publish_dashboard_status_writes_under_base_path(self) -> None:
+        # Exercise --publish-dashboard-status end-to-end through the CLI so a
+        # future refactor that drops the wiring (e.g., main() forgetting to
+        # pass the flag through to replay_logs) would fail this test rather
+        # than silently dropping the dashboard publish path.
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            base_path = root / "base"
+            base_path.mkdir()
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            log_path.write_text(
+                "[WARN] [Keeper] executor: alive-but-stuck detected\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--log",
+                    str(log_path),
+                    "--artifact-dir",
+                    str(artifact_dir),
+                    "--act-map",
+                    str(FIXTURE_DIR / "act-map.startup.json"),
+                    "--loop-iteration",
+                    "cli-publish",
+                    "--runtime-source",
+                    "cli-test",
+                    "--base-path",
+                    str(base_path),
+                    "--publish-dashboard-status",
+                    "--format",
+                    "text",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            published = base_path / ".masc" / "goal-loop" / "status.json"
+            self.assertTrue(
+                published.exists(),
+                f"dashboard status not published: stdout={result.stdout} stderr={result.stderr}",
+            )
+            status = read_json(published)
+            self.assertEqual(status["loop_iteration"], "cli-publish")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_goal_loop_live_replay.py
+++ b/test/test_goal_loop_live_replay.py
@@ -224,6 +224,21 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
                     publish_dashboard_status=True,
                 )
 
+    def test_write_json_atomic_ignores_predictable_temp_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            target = root / "status.json"
+            victim = root / "victim.json"
+            predictable_temp = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+            victim.write_text("do not clobber\n", encoding="utf-8")
+            predictable_temp.symlink_to(victim)
+
+            goal_loop_live_replay.write_json_atomic(target, {"ok": True})
+
+            self.assertEqual(victim.read_text(encoding="utf-8"), "do not clobber\n")
+            self.assertEqual(read_json(target), {"ok": True})
+            self.assertTrue(predictable_temp.is_symlink())
+
     def test_capture_window_reads_from_start_after_truncation(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:
             root = Path(raw_dir)

--- a/test/test_goal_loop_live_replay.py
+++ b/test/test_goal_loop_live_replay.py
@@ -108,6 +108,65 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
             self.assertEqual(metadata["max_samples_effective"], 0)
             self.assertEqual(metadata["max_samples"], 0)
 
+    def test_replay_can_publish_dashboard_status_for_base_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            base_path = root / "base"
+            log_path.write_text(
+                "[INFO] provider_health_probe_completed provider=ollama\n",
+                encoding="utf-8",
+            )
+
+            summary = goal_loop_live_replay.replay_logs(
+                log_paths=[str(log_path)],
+                artifact_dir=artifact_dir,
+                duration_seconds=0,
+                act_map_path=None,
+                loop_iteration="test-dashboard-publish",
+                verify_policy="critical",
+                max_samples=2,
+                runtime_source="unit-test",
+                base_path=str(base_path),
+                publish_dashboard_status=True,
+            )
+
+            dashboard_status_path = base_path / ".masc" / "goal-loop" / "status.json"
+            self.assertEqual(summary.dashboard_status_json, str(dashboard_status_path))
+            self.assertTrue(dashboard_status_path.is_file())
+            self.assertEqual(
+                read_json(dashboard_status_path),
+                read_json(artifact_dir / "status.json"),
+            )
+            metadata = read_json(artifact_dir / "metadata.json")
+            self.assertEqual(
+                metadata["dashboard_status_json"], str(dashboard_status_path)
+            )
+
+    def test_dashboard_status_publish_requires_base_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            log_path = root / "server.log"
+            log_path.write_text(
+                "[INFO] provider_health_probe_completed provider=ollama\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "requires --base-path"):
+                goal_loop_live_replay.replay_logs(
+                    log_paths=[str(log_path)],
+                    artifact_dir=root / "artifacts",
+                    duration_seconds=0,
+                    act_map_path=None,
+                    loop_iteration="test-dashboard-publish-missing-base",
+                    verify_policy="critical",
+                    max_samples=2,
+                    runtime_source="unit-test",
+                    base_path=None,
+                    publish_dashboard_status=True,
+                )
+
     def test_capture_window_reads_from_start_after_truncation(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:
             root = Path(raw_dir)

--- a/test/test_goal_loop_live_replay.py
+++ b/test/test_goal_loop_live_replay.py
@@ -64,16 +64,19 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
             self.assertIs(verify_summary["post_act_verify"], True)
             self.assertEqual(verify_summary["evidence_kind"], "live_runtime_logs")
             self.assertIn("runtime_source=unit-test", verify_summary["evidence_source"])
-            self.assertIn("base_path=/tmp/masc", verify_summary["evidence_source"])
             self.assertIsInstance(verify_summary["evidence_window_start"], str)
             self.assertIsInstance(verify_summary["evidence_window_end"], str)
             self.assertIsInstance(verify_summary["checked_at"], str)
             self.assertEqual(verify_summary["violation_kinds"], [])
+            expected_base_path = goal_loop_live_replay.normalize_base_path("/tmp/masc")
             verify = read_json(artifact_dir / "verify.json")
             self.assertIs(verify["post_act_verify"], True)
             self.assertEqual(verify["evidence_kind"], "live_runtime_logs")
             self.assertIn("runtime_source=unit-test", verify["evidence_source"])
-            self.assertIn("base_path=/tmp/masc", verify["evidence_source"])
+            self.assertIn(
+                f"base_path={expected_base_path}", verify_summary["evidence_source"]
+            )
+            self.assertIn(f"base_path={expected_base_path}", verify["evidence_source"])
             self.assertIsInstance(verify["evidence_window_start"], str)
             self.assertIsInstance(verify["evidence_window_end"], str)
             self.assertIsInstance(verify["checked_at"], str)
@@ -133,7 +136,10 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
                 publish_dashboard_status=True,
             )
 
-            dashboard_status_path = base_path / ".masc" / "goal-loop" / "status.json"
+            normalized_base_path = base_path.resolve(strict=False)
+            dashboard_status_path = (
+                normalized_base_path / ".masc" / "goal-loop" / "status.json"
+            )
             self.assertEqual(summary.dashboard_status_json, str(dashboard_status_path))
             self.assertTrue(dashboard_status_path.is_file())
             self.assertEqual(
@@ -171,7 +177,7 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
                     publish_dashboard_status=True,
                 )
 
-            normalized_base_path = home / "runtime"
+            normalized_base_path = (home / "runtime").resolve(strict=False)
             dashboard_status_path = (
                 normalized_base_path / ".masc" / "goal-loop" / "status.json"
             )
@@ -224,6 +230,16 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
                     publish_dashboard_status=True,
                 )
 
+    def test_normalize_base_path_resolves_absolute_segments(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            raw_path = root / "nested" / ".." / "runtime"
+
+            self.assertEqual(
+                goal_loop_live_replay.normalize_base_path(str(raw_path)),
+                str((root / "runtime").resolve(strict=False)),
+            )
+
     def test_write_json_atomic_ignores_predictable_temp_symlink(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:
             root = Path(raw_dir)
@@ -238,6 +254,49 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
             self.assertEqual(victim.read_text(encoding="utf-8"), "do not clobber\n")
             self.assertEqual(read_json(target), {"ok": True})
             self.assertTrue(predictable_temp.is_symlink())
+
+    def test_write_json_atomic_keeps_recreated_temp_after_replace(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            target = root / "status.json"
+            temp_path = root / ".status.json.fixed.tmp"
+            original_replace = Path.replace
+
+            def fake_mkstemp(
+                *,
+                prefix: str,
+                suffix: str,
+                dir: Path,
+                text: bool,
+            ) -> tuple[int, str]:
+                self.assertTrue(prefix.startswith(".status.json."))
+                self.assertEqual(suffix, ".tmp")
+                self.assertEqual(Path(dir), root)
+                self.assertTrue(text)
+                fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                return fd, str(temp_path)
+
+            def replace_and_recreate(self: Path, target_path: Path) -> Path:
+                result = original_replace(self, target_path)
+                if self == temp_path:
+                    self.write_text("owned by another writer\n", encoding="utf-8")
+                return result
+
+            with (
+                mock.patch.object(
+                    goal_loop_live_replay.tempfile,
+                    "mkstemp",
+                    side_effect=fake_mkstemp,
+                ),
+                mock.patch.object(Path, "replace", replace_and_recreate),
+            ):
+                goal_loop_live_replay.write_json_atomic(target, {"ok": True})
+
+            self.assertEqual(read_json(target), {"ok": True})
+            self.assertEqual(
+                temp_path.read_text(encoding="utf-8"),
+                "owned by another writer\n",
+            )
 
     def test_capture_window_reads_from_start_after_truncation(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:
@@ -341,10 +400,13 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
             verify_summary = status["phases"]["verify"]["summary"]
             self.assertIs(verify_summary["post_act_verify"], True)
             self.assertIn("runtime_source=cli-test", verify_summary["evidence_source"])
-            self.assertIn("base_path=/tmp/masc", verify_summary["evidence_source"])
+            expected_base_path = goal_loop_live_replay.normalize_base_path("/tmp/masc")
+            self.assertIn(
+                f"base_path={expected_base_path}", verify_summary["evidence_source"]
+            )
             verify = read_json(artifact_dir / "verify.json")
             self.assertIn("runtime_source=cli-test", verify["evidence_source"])
-            self.assertIn("base_path=/tmp/masc", verify["evidence_source"])
+            self.assertIn(f"base_path={expected_base_path}", verify["evidence_source"])
 
     def test_cli_publish_dashboard_status_writes_under_base_path(self) -> None:
         # Exercise --publish-dashboard-status end-to-end through the CLI so a

--- a/test/test_goal_loop_live_replay.py
+++ b/test/test_goal_loop_live_replay.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -144,6 +145,48 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
                 metadata["dashboard_status_json"], str(dashboard_status_path)
             )
 
+    def test_replay_normalizes_tilde_base_path_for_dashboard_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            root = Path(raw_dir)
+            home = root / "home"
+            home.mkdir()
+            log_path = root / "server.log"
+            artifact_dir = root / "artifacts"
+            log_path.write_text(
+                "[INFO] provider_health_probe_completed provider=ollama\n",
+                encoding="utf-8",
+            )
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+                summary = goal_loop_live_replay.replay_logs(
+                    log_paths=[str(log_path)],
+                    artifact_dir=artifact_dir,
+                    duration_seconds=0,
+                    act_map_path=None,
+                    loop_iteration="test-dashboard-publish-tilde",
+                    verify_policy="critical",
+                    max_samples=2,
+                    runtime_source="unit-test",
+                    base_path="~/runtime",
+                    publish_dashboard_status=True,
+                )
+
+            normalized_base_path = home / "runtime"
+            dashboard_status_path = (
+                normalized_base_path / ".masc" / "goal-loop" / "status.json"
+            )
+            self.assertEqual(summary.dashboard_status_json, str(dashboard_status_path))
+            self.assertTrue(dashboard_status_path.is_file())
+            metadata = read_json(artifact_dir / "metadata.json")
+            self.assertEqual(metadata["base_path"], str(normalized_base_path))
+            self.assertEqual(
+                metadata["dashboard_status_json"], str(dashboard_status_path)
+            )
+            verify = read_json(artifact_dir / "verify.json")
+            self.assertIn(
+                f"base_path={normalized_base_path}", verify["evidence_source"]
+            )
+
     def test_dashboard_status_publish_requires_base_path(self) -> None:
         with tempfile.TemporaryDirectory() as raw_dir:
             root = Path(raw_dir)
@@ -164,6 +207,20 @@ class GoalLoopLiveReplayTest(unittest.TestCase):
                     max_samples=2,
                     runtime_source="unit-test",
                     base_path=None,
+                    publish_dashboard_status=True,
+                )
+
+            with self.assertRaisesRegex(ValueError, "requires --base-path"):
+                goal_loop_live_replay.replay_logs(
+                    log_paths=[str(log_path)],
+                    artifact_dir=root / "artifacts-blank",
+                    duration_seconds=0,
+                    act_map_path=None,
+                    loop_iteration="test-dashboard-publish-blank-base",
+                    verify_policy="critical",
+                    max_samples=2,
+                    runtime_source="unit-test",
+                    base_path="   ",
                     publish_dashboard_status=True,
                 )
 


### PR DESCRIPTION
## Summary
- add `--publish-dashboard-status` to `scripts/goal_loop_live_replay.py`
- atomically writes the aggregate status snapshot to `<base-path>/.masc/goal-loop/status.json`, the path consumed by the dashboard endpoint
- records `dashboard_status_json` in replay metadata/summary and rejects publish mode without `--base-path`
- document the dashboard publish flow and cover it in unit tests

## Verification
- `python3 test/test_goal_loop_live_replay.py`
- `ruff check scripts/goal_loop_live_replay.py test/test_goal_loop_live_replay.py`
- `ruff format --check scripts/goal_loop_live_replay.py test/test_goal_loop_live_replay.py`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `pyright --outputjson ...` unavailable in this environment (`command not found`); `python3 -m pyright ...` also unavailable (`No module named pyright`)

## Live dashboard proof
- ran a bounded replay against `/Users/dancer/me/.masc/logs/system_log_2026-05-06.jsonl` with `--base-path /Users/dancer/me --publish-dashboard-status`
- wrote durable artifacts under `/Users/dancer/me/.masc/goal-loop/live-replays/20260506T2028-kst-dashboard-publish/`
- after restarting local 8935 from the current `d2b7f1aa5c` runtime binary, `GET /api/v1/dashboard/goal-loop/status` returned `dashboard_source.kind=runtime_status_json`, path `/Users/dancer/me/.masc/goal-loop/status.json`, `overall_status=ok`, and `verify_status=PASS`
