### PR TITLE
fix(keeper): cap passive tool reads per turn

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -364,6 +364,16 @@ type streak_state = { mutable entry : string * int }
 
 let make_streak_state () : streak_state = { entry = ("", 0) }
 
+(** Mutable per-turn passive-tool budget state captured by
+    [passive_tool_budget_guard]. *)
+type passive_tool_budget_state = { mutable passive_count : int }
+
+let make_passive_tool_budget_state () : passive_tool_budget_state =
+  { passive_count = 0 }
+
+let reset_passive_tool_budget_state (state : passive_tool_budget_state) =
+  state.passive_count <- 0
+
 (* -------------------------------------------------------------- *)
 (* Timing guard — records tool_start_time for post_tool_use use    *)
 (* -------------------------------------------------------------- *)
@@ -474,6 +484,61 @@ let streak_guard
              ~tool_name ~reason_code:"streak_gate" ~reason_text)
       end
       else Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(** Passive status/read budget gate: allow a small amount of observation,
+    then force the next tool call to be productive.  This targets the
+    #11083 failure mode where a keeper spends an entire actionable turn on
+    board/task/status reads and only fails at the completion contract. *)
+let passive_tool_budget_guard
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~on_gate_decision
+    ~(state : passive_tool_budget_state)
+    ~(max_passive_tools : int)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse
+        { tool_name; input; accumulated_cost_usd; turn; _ } ->
+      let t0 = Time_compat.now () in
+      if Keeper_tool_disclosure.is_passive_status_tool_name tool_name then begin
+        state.passive_count <- state.passive_count + 1;
+        if state.passive_count > max_passive_tools then begin
+          let keeper_name = (!meta_ref).Keeper_types.name in
+          let reason_text =
+            Printf.sprintf
+              "%s is passive status/read tool #%d in this turn (max=%d). Use an execution or completion tool next, such as keeper_shell, keeper_board_post, keeper_board_comment, keeper_task_claim, keeper_task_done, or keeper_stay_silent with typed no-work proof."
+              tool_name state.passive_count max_passive_tools
+          in
+          let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_guards_failures
+            ~labels:[("keeper", keeper_name); ("site", "passive_tool_budget")]
+            ();
+          Log.Keeper.warn
+            "keeper:%s passive_tool_budget: blocked %s after %d passive tools in current turn"
+            keeper_name tool_name state.passive_count;
+          broadcast_tool_skipped
+            ~keeper_name ~tool_name ~reason_code:"passive_tool_budget";
+          let source_path = keeper_guards_source_path in
+          let source_line = __LINE__ in
+          report_gate_decision on_gate_decision
+            ~source_path:(Some source_path) ~source_line:(Some source_line)
+            ~stage:"passive_tool_budget" ~decision:Gate_override
+            ~reason_code:"passive_tool_budget" ~reason_text
+            ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+            ~stage_latency_ms:latency_ms;
+          Agent_sdk.Hooks.Override
+            (render_inline_skip_reason_with_source
+               ~source_path ~source_line
+               ~tool_name ~reason_code:"passive_tool_budget" ~reason_text)
+        end
+        else Agent_sdk.Hooks.Continue
+      end
+      else begin
+        reset_passive_tool_budget_state state;
+        Agent_sdk.Hooks.Continue
+      end
     | _ -> Agent_sdk.Hooks.Continue)
 
 (** Keeper deny list. Block administrative / destructive tools that
@@ -666,6 +731,8 @@ let build_chain
     ~(tool_start_time : float ref)
     ~(streak_state : streak_state)
     ~(streak_threshold : int)
+    ~(passive_tool_budget_state : passive_tool_budget_state)
+    ~(passive_tool_budget_threshold : int)
     ~(denied : string list)
     ~(max_cost_usd : float option)
     ~(destructive_check : bool)
@@ -677,6 +744,9 @@ let build_chain
     timing_guard ~tool_start_time;
     custom_guard ~meta_ref ~on_gate_decision ~guard:pre_tool_use_guard;
     streak_guard ~meta_ref ~on_gate_decision ~state:streak_state ~threshold:streak_threshold;
+    passive_tool_budget_guard ~meta_ref ~on_gate_decision
+      ~state:passive_tool_budget_state
+      ~max_passive_tools:passive_tool_budget_threshold;
     deny_guard ~meta_ref ~on_gate_decision ~denied;
     cost_guard ~meta_ref ~on_gate_decision ~max_cost_usd;
     destructive_guard ~meta_ref ~on_gate_decision ~enabled:destructive_check;

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -129,6 +129,14 @@ type streak_state = { mutable entry : string * int }
 
 val make_streak_state : unit -> streak_state
 
+(** Mutable per-turn passive status/read budget state captured by
+    [passive_tool_budget_guard]. *)
+type passive_tool_budget_state
+
+val make_passive_tool_budget_state : unit -> passive_tool_budget_state
+
+val reset_passive_tool_budget_state : passive_tool_budget_state -> unit
+
 (** Record [tool_start_time] so the post_tool_use phase can compute
     latency. Always returns [Continue]. Compose FIRST so the
     timestamp is set even when a later guard returns [Override]. *)
@@ -151,6 +159,15 @@ val streak_guard :
   on_gate_decision:(gate_decision_event -> unit) ->
   state:streak_state ->
   threshold:int ->
+  Agent_sdk.Hooks.hooks
+
+(** Block further passive status/read tools once a turn has consumed
+    [max_passive_tools]. Non-passive tools reset the per-turn count. *)
+val passive_tool_budget_guard :
+  meta_ref:Keeper_types.keeper_meta ref ->
+  on_gate_decision:(gate_decision_event -> unit) ->
+  state:passive_tool_budget_state ->
+  max_passive_tools:int ->
   Agent_sdk.Hooks.hooks
 
 (** Reject every tool name in [denied]. *)
@@ -184,13 +201,15 @@ val governance_approval_guard :
   Agent_sdk.Hooks.hooks
 
 (** Build the full keeper pre_tool_use chain in canonical order:
-    timing -> custom -> streak -> deny -> cost -> destructive ->
-    governance_approval. *)
+    timing -> custom -> streak -> passive budget -> deny -> cost ->
+    destructive -> governance_approval. *)
 val build_chain :
   meta_ref:Keeper_types.keeper_meta ref ->
   tool_start_time:float ref ->
   streak_state:streak_state ->
   streak_threshold:int ->
+  passive_tool_budget_state:passive_tool_budget_state ->
+  passive_tool_budget_threshold:int ->
   denied:string list ->
   max_cost_usd:float option ->
   destructive_check:bool ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1484,6 +1484,14 @@ let make_hooks
      [make_hooks] closure — one state per keeper. *)
   let streak_state = Keeper_guards.make_streak_state () in
   let streak_threshold = 5 in
+  (* #11083: cap passive status/read loops inside one actionable turn.
+     Cross-turn passive loops are handled by Keeper_passive_loop_detector;
+     this per-turn budget prevents a single turn from spending all tool calls
+     on read-only observation before failing the completion contract. *)
+  let passive_tool_budget_state =
+    Keeper_guards.make_passive_tool_budget_state ()
+  in
+  let passive_tool_budget_threshold = 5 in
   let record_gate_decision event =
     record_pre_tool_gate_attempt
       ~meta_ref
@@ -1502,6 +1510,8 @@ let make_hooks
       ~tool_start_time
       ~streak_state
       ~streak_threshold
+      ~passive_tool_budget_state
+      ~passive_tool_budget_threshold
       ~denied:keeper_denied_tools
       ~max_cost_usd
       ~destructive_check
@@ -1556,6 +1566,7 @@ let make_hooks
     after_turn = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.AfterTurn { turn; response } ->
+        Keeper_guards.reset_passive_tool_budget_state passive_tool_budget_state;
         let meta = !meta_ref in
         let model = resolve_after_turn_model ~keeper_name:meta.name ~response in
         let usage_trust =

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -330,6 +330,66 @@ let test_streak_state_manual_reset () =
   let d = invoke hook (pre_tool_use_event ~tool_name:"t" ()) in
   check string "after reset -> Continue" "Continue" (decision_kind d)
 
+let test_passive_tool_budget_blocks_after_limit () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let state = KG.make_passive_tool_budget_state () in
+  let observed = ref [] in
+  let on_gate_decision event = observed := event :: !observed in
+  let hook =
+    KG.passive_tool_budget_guard ~meta_ref ~on_gate_decision
+      ~state ~max_passive_tools:2
+  in
+  let first =
+    invoke hook (pre_tool_use_event ~tool_name:"keeper_tasks_list" ())
+  in
+  let second =
+    invoke hook (pre_tool_use_event ~tool_name:"keeper_board_get" ())
+  in
+  check string "first passive -> Continue" "Continue" (decision_kind first);
+  check string "second passive -> Continue" "Continue" (decision_kind second);
+  let blocked = invoke hook (pre_tool_use_event ~tool_name:"masc_status" ()) in
+  check string "third passive -> Override" "Override" (decision_kind blocked);
+  let text = override_text blocked in
+  check bool "override mentions passive budget" true
+    (contains_substring text "code=passive_tool_budget");
+  match !observed with
+  | [ event ] ->
+    check string "stage" "passive_tool_budget" event.KG.stage;
+    check string "reason_code" "passive_tool_budget" event.KG.reason_code;
+    check string "tool_name" "masc_status" event.KG.tool_name;
+    check string "decision" "override"
+      (KG.gate_decision_to_string event.KG.decision);
+    check bool "reason mentions current turn" true
+      (contains_substring event.KG.reason_text "in this turn")
+  | events ->
+    failf "expected one observer event, got %d" (List.length events)
+
+let test_passive_tool_budget_resets_on_productive_tool () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let state = KG.make_passive_tool_budget_state () in
+  let hook =
+    KG.passive_tool_budget_guard ~meta_ref
+      ~on_gate_decision:no_gate_observer ~state ~max_passive_tools:2
+  in
+  let _ = invoke hook (pre_tool_use_event ~tool_name:"keeper_tasks_list" ()) in
+  let _ = invoke hook (pre_tool_use_event ~tool_name:"keeper_board_get" ()) in
+  let productive =
+    invoke hook (pre_tool_use_event ~tool_name:"keeper_task_done" ())
+  in
+  check string "productive tool resets and continues" "Continue"
+    (decision_kind productive);
+  let after_reset =
+    invoke hook (pre_tool_use_event ~tool_name:"masc_status" ())
+  in
+  check string "passive after productive reset -> Continue" "Continue"
+    (decision_kind after_reset);
+  KG.reset_passive_tool_budget_state state;
+  let after_manual_reset =
+    invoke hook (pre_tool_use_event ~tool_name:"keeper_tasks_list" ())
+  in
+  check string "passive after manual reset -> Continue" "Continue"
+    (decision_kind after_manual_reset)
+
 let test_custom_guard_blocks () =
   let meta_ref = make_meta_ref "test_keeper" in
   let guard ~tool_name ~input:_ =
@@ -491,6 +551,12 @@ let () = run "Keeper_guards" [
     test_case "at threshold -> override" `Quick test_streak_guard_at_threshold;
     test_case "resets on different tool" `Quick test_streak_guard_resets_on_different_tool;
     test_case "manual state reset" `Quick test_streak_state_manual_reset;
+  ];
+  "passive_tool_budget_guard", [
+    test_case "blocks after passive limit" `Quick
+      test_passive_tool_budget_blocks_after_limit;
+    test_case "resets on productive tool" `Quick
+      test_passive_tool_budget_resets_on_productive_tool;
   ];
   "custom_guard", [
     test_case "user blocks" `Quick test_custom_guard_blocks;


### PR DESCRIPTION
## Summary

- Add a keeper pre-tool guard that caps passive status/read tools inside a single turn.
- Allow five passive reads for observation, then return a structured `passive_tool_budget` override that tells the keeper to use an execution/completion tool or `keeper_stay_silent` with typed no-work proof.
- Reset the per-turn budget on productive tools and after each turn; existing cross-turn passive-loop detection remains unchanged.

## Why

#11083 identifies `keeper.operator_broadcast_required` events dominated by `passive_only` completion-contract failures. The existing contract rejects the turn only after the model has already spent the turn on passive reads. This guard interrupts the loop earlier, before another read-only call, and gives the model an inline action directive.

## Validation

- `git diff --check`
- Risk scan on touched files:
  - `rg "Stdlib\\.Lazy\\.(force|from_val)|Fun\\.protect|Mutex\\.(lock|unlock)|failwith|assert false|Eio\\.traceln|Sys\\.(readdir|command)" lib/keeper/keeper_guards.ml lib/keeper/keeper_guards.mli lib/keeper/keeper_hooks_oas.ml test/test_keeper_guards.ml`
  - Runtime files introduced no risky-pattern hits; test file reports existing `Fun.protect` / `failwith` helpers.
- `scripts/dune-local.sh build test/test_keeper_guards.exe`
  - Attempted first; blocked behind `/tmp/me-opam-switch.lock`, then stopped.
- `dune build --root . test/test_keeper_guards.exe`
- `./_build/default/test/test_keeper_guards.exe`
  - 25 tests passed.
