### PR TITLE
feat(dashboard): add cognitive mode registry

### DIFF
--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  COGNITIVE_MODE_ORDER,
+  COGNITIVE_MODE_STATES,
+  COGNITIVE_MODE_TARGETS,
   COCKPIT_ENTRYPOINTS,
   COCKPIT_MODE_TARGETS,
+  cognitiveModeForCockpitMode,
+  cognitiveModeForRoute,
   cockpitTargetForParams,
+  normalizeCognitiveMode,
   normalizeCockpitEntrypoint,
 } from './cockpit-entrypoints'
 import { sectionItemsForTab } from './config/navigation'
@@ -24,7 +30,50 @@ describe('cockpit entrypoint registry', () => {
       'code',
       'split',
       'terminal',
+      'explode',
     ])
+  })
+
+  it('keeps the four cognitive modes explicit and route-backed', () => {
+    expect(COGNITIVE_MODE_ORDER).toEqual(['cockpit', 'code', 'split', 'explode'])
+    expect(Object.keys(COGNITIVE_MODE_TARGETS)).toEqual(COGNITIVE_MODE_ORDER)
+    expect(COGNITIVE_MODE_STATES.cockpit).toMatchObject({
+      load: 'situational',
+      layout: 'all-panels',
+      target: { tab: 'overview' },
+    })
+    expect(COGNITIVE_MODE_STATES.code).toMatchObject({
+      load: 'focused',
+      layout: 'editor-first',
+      target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } },
+    })
+    expect(COGNITIVE_MODE_STATES.split).toMatchObject({
+      load: 'comparative',
+      layout: 'side-by-side',
+      target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } },
+    })
+    expect(COGNITIVE_MODE_STATES.explode).toMatchObject({
+      load: 'exploratory',
+      layout: 'graph-map',
+      target: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } },
+    })
+  })
+
+  it('normalizes cognitive mode aliases from cockpit routes', () => {
+    expect(normalizeCognitiveMode(' CODE ')).toBe('code')
+    expect(cognitiveModeForCockpitMode('Work')).toBe('cockpit')
+    expect(cognitiveModeForCockpitMode('terminal')).toBe('code')
+    expect(cognitiveModeForCockpitMode('split')).toBe('split')
+    expect(cognitiveModeForCockpitMode('EXPLODE')).toBe('explode')
+    expect(cognitiveModeForCockpitMode('unknown')).toBeNull()
+  })
+
+  it('infers cognitive mode from canonical route state', () => {
+    expect(cognitiveModeForRoute('overview')).toBe('cockpit')
+    expect(cognitiveModeForRoute('code', { section: 'ide-shell', view: 'source' })).toBe('code')
+    expect(cognitiveModeForRoute('code', { section: 'ide-shell', view: 'split-diff' })).toBe('split')
+    expect(cognitiveModeForRoute('workspace', { section: 'repositories', view: 'graph' })).toBe('explode')
+    expect(cognitiveModeForRoute('workspace', { mode: 'observe' })).toBe('cockpit')
   })
 
   it('normalizes human tab labels and prototype ids to stable aliases', () => {
@@ -50,6 +99,10 @@ describe('cockpit entrypoint registry', () => {
     expect(cockpitTargetForParams({ mode: 'IDE', tab: 'split-diff' })).toEqual({
       tab: 'code',
       params: { section: 'ide-shell', view: 'split-diff' },
+    })
+    expect(cockpitTargetForParams({ mode: 'EXPLODE' })).toEqual({
+      tab: 'workspace',
+      params: { section: 'repositories', view: 'graph' },
     })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-str' })).toEqual({
       tab: 'monitoring',

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -11,6 +11,9 @@ export type CockpitMode =
   | 'code'
   | 'split'
   | 'terminal'
+  | 'explode'
+
+export type CognitiveMode = 'cockpit' | 'code' | 'split' | 'explode'
 
 export interface CockpitRouteTarget {
   tab: TabId
@@ -24,17 +27,77 @@ export interface CockpitEntrypoint {
   coverage: 'covered' | 'partial' | 'backend-blocked'
 }
 
-export const COCKPIT_MODE_TARGETS: Record<CockpitMode, CockpitRouteTarget> = {
-  dashboard: { tab: 'overview' },
+export interface CognitiveModeState {
+  mode: CognitiveMode
+  label: string
+  load: 'situational' | 'focused' | 'comparative' | 'exploratory'
+  layout: 'all-panels' | 'editor-first' | 'side-by-side' | 'graph-map'
+  target: CockpitRouteTarget
+  cockpitModes: readonly CockpitMode[]
+}
+
+export const COGNITIVE_MODE_ORDER: CognitiveMode[] = ['cockpit', 'code', 'split', 'explode']
+
+export const COGNITIVE_MODE_TARGETS: Record<CognitiveMode, CockpitRouteTarget> = {
   cockpit: { tab: 'overview' },
+  code: { tab: 'code', params: { section: 'ide-shell', view: 'source' } },
+  split: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } },
+  explode: { tab: 'workspace', params: { section: 'repositories', view: 'graph' } },
+}
+
+export const COGNITIVE_MODE_STATES: Record<CognitiveMode, CognitiveModeState> = {
+  cockpit: {
+    mode: 'cockpit',
+    label: 'Cockpit',
+    load: 'situational',
+    layout: 'all-panels',
+    target: COGNITIVE_MODE_TARGETS.cockpit,
+    cockpitModes: ['dashboard', 'cockpit', 'work', 'comms', 'observe', 'cognition'],
+  },
+  code: {
+    mode: 'code',
+    label: 'Code',
+    load: 'focused',
+    layout: 'editor-first',
+    target: COGNITIVE_MODE_TARGETS.code,
+    cockpitModes: ['ide', 'code', 'terminal'],
+  },
+  split: {
+    mode: 'split',
+    label: 'Split',
+    load: 'comparative',
+    layout: 'side-by-side',
+    target: COGNITIVE_MODE_TARGETS.split,
+    cockpitModes: ['split'],
+  },
+  explode: {
+    mode: 'explode',
+    label: 'Explode',
+    load: 'exploratory',
+    layout: 'graph-map',
+    target: COGNITIVE_MODE_TARGETS.explode,
+    cockpitModes: ['explode'],
+  },
+}
+
+const COCKPIT_MODE_TO_COGNITIVE_MODE = new Map<CockpitMode, CognitiveMode>(
+  COGNITIVE_MODE_ORDER.flatMap(mode =>
+    COGNITIVE_MODE_STATES[mode].cockpitModes.map(cockpitMode => [cockpitMode, mode] as const),
+  ),
+)
+
+export const COCKPIT_MODE_TARGETS: Record<CockpitMode, CockpitRouteTarget> = {
+  dashboard: COGNITIVE_MODE_TARGETS.cockpit,
+  cockpit: COGNITIVE_MODE_TARGETS.cockpit,
   work: { tab: 'workspace', params: { section: 'planning' } },
   comms: { tab: 'workspace', params: { section: 'board' } },
   observe: { tab: 'monitoring', params: { section: 'runtime' } },
   cognition: { tab: 'monitoring', params: { section: 'cognition' } },
-  ide: { tab: 'code', params: { section: 'ide-shell', view: 'source' } },
-  code: { tab: 'code', params: { section: 'ide-shell', view: 'source' } },
-  split: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } },
+  ide: COGNITIVE_MODE_TARGETS.code,
+  code: COGNITIVE_MODE_TARGETS.code,
+  split: COGNITIVE_MODE_TARGETS.split,
   terminal: { tab: 'code', params: { section: 'ide-shell', view: 'source', terminal: 'open' } },
+  explode: COGNITIVE_MODE_TARGETS.explode,
 }
 
 export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
@@ -110,6 +173,38 @@ export function normalizeCockpitMode(input: string | null | undefined): CockpitM
   return Object.prototype.hasOwnProperty.call(COCKPIT_MODE_TARGETS, normalized)
     ? normalized as CockpitMode
     : null
+}
+
+export function normalizeCognitiveMode(input: string | null | undefined): CognitiveMode | null {
+  const normalized = input?.trim().toLowerCase()
+  if (!normalized) return null
+  return Object.prototype.hasOwnProperty.call(COGNITIVE_MODE_TARGETS, normalized)
+    ? normalized as CognitiveMode
+    : null
+}
+
+export function cognitiveModeForCockpitMode(
+  input: CockpitMode | string | null | undefined,
+): CognitiveMode | null {
+  const cockpitMode = normalizeCockpitMode(input)
+  if (cockpitMode) return COCKPIT_MODE_TO_COGNITIVE_MODE.get(cockpitMode) ?? null
+  return normalizeCognitiveMode(input)
+}
+
+export function cognitiveModeForRoute(
+  tab: TabId,
+  params: Record<string, string> = {},
+): CognitiveMode {
+  const explicitMode = cognitiveModeForCockpitMode(params.mode ?? params.plane)
+  if (explicitMode) return explicitMode
+
+  if (tab === 'code') {
+    return params.view === 'split-diff' ? 'split' : 'code'
+  }
+  if (tab === 'workspace' && params.section === 'repositories' && params.view === 'graph') {
+    return 'explode'
+  }
+  return 'cockpit'
 }
 
 export function normalizeCockpitEntrypoint(input: string): string {


### PR DESCRIPTION
## Summary
- add explicit four-mode CognitiveMode state registry: cockpit, code, split, explode
- map existing cockpit route modes onto those cognitive states
- infer cognitive mode from canonical dashboard routes and cover the explode graph route

## Verification
- pnpm exec vitest run --config vitest.config.ts src/cockpit-entrypoints.test.ts src/router.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src (passes with existing unrelated warnings in virtual-list.ts and fsm-hub.ts)
- git diff --check origin/main..HEAD

## Review focus
- This is route/state infrastructure only; it does not change panel rendering.
- The new explode mode is intentionally backed by the existing repositories graph route.