### PR TITLE
fix(metrics): bucket LLM provider errors by reason

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -36,6 +36,7 @@ let cache_hit_metric = Prometheus.metric_llm_provider_cache_hits
 let cache_miss_metric = Prometheus.metric_llm_provider_cache_misses
 let request_start_metric = Prometheus.metric_llm_provider_requests_started
 let error_metric = Prometheus.metric_llm_provider_errors
+let error_by_reason_metric = Prometheus.metric_llm_provider_errors_by_reason
 let retry_metric = Prometheus.metric_llm_provider_retries
 let input_tokens_metric = Prometheus.metric_llm_provider_input_tokens
 let output_tokens_metric = Prometheus.metric_llm_provider_output_tokens
@@ -77,9 +78,33 @@ let emit_request_start ~model_id =
     ~labels:[("model", model_id)]
     ()
 
-let emit_error ~model_id =
+let error_reason_label error =
+  let lower = String.lowercase_ascii (String.trim error) in
+  let has needle = String_util.contains_substring lower needle in
+  if lower = "" then "unknown"
+  else if has "timeout" || has "timed out" || has "deadline" then "timeout"
+  else if has "cancel" then "cancelled"
+  else if has "429" || has "rate limit" || has "too many requests" then
+    "rate_limit"
+  else if has "quota" then "quota"
+  else if has "capacity" || has "overloaded" then "capacity"
+  else if has "401" || has "403" || has "unauthorized" || has "forbidden"
+          || has "auth" then "auth"
+  else if has "connection" || has "network" || has "dns" || has "socket"
+          || has "econn" then "network"
+  else if has "json" || has "parse" || has "unparseable" then "parse"
+  else if has "400" || has "invalid" || has "schema" || has "validation" then
+    "invalid_request"
+  else if has "500" || has "503" || has "provider" || has "internal server"
+  then "provider_error"
+  else "unknown"
+
+let emit_error ~model_id ~error =
   Prometheus.inc_counter error_metric
     ~labels:[("model", model_id)]
+    ();
+  Prometheus.inc_counter error_by_reason_metric
+    ~labels:[("model", model_id); ("error_reason", error_reason_label error)]
     ()
 
 let emit_retry ~provider ~model_id ~attempt =
@@ -180,7 +205,7 @@ let make_sink () : Llm_provider.Metrics.t =
     on_capability_drop =
       (fun ~model_id ~field ->
         emit_capability_drop ~model_id ~field);
-    on_error = (fun ~model_id ~error:_ -> emit_error ~model_id);
+    on_error = (fun ~model_id ~error -> emit_error ~model_id ~error);
     on_retry = emit_retry;
     on_token_usage = emit_token_usage;
   }

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -42,7 +42,7 @@ val emit_cache_miss : model_id:string -> unit
 
 (** Emit request lifecycle observations from OAS metrics callbacks. *)
 val emit_request_start : model_id:string -> unit
-val emit_error : model_id:string -> unit
+val emit_error : model_id:string -> error:string -> unit
 val emit_retry : provider:string -> model_id:string -> attempt:int -> unit
 val emit_token_usage :
   provider:string ->

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -423,7 +423,7 @@ let cascade_metrics_for_candidates
       ~on_error:(fun ~model_id ~error ->
         ensure_terminal_attempt capture ~candidate_cfgs ~model_id
           ~latency_ms:None ~error:(Some error);
-        Llm_metric_bridge.emit_error ~model_id)
+        Llm_metric_bridge.emit_error ~model_id ~error)
       ~on_capability_drop:(fun ~model_id ~field ->
         (* The explicit cascade metrics object bypasses the global
            Llm_metric_bridge sink, so capability-drop telemetry must be

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -929,6 +929,8 @@ let metric_llm_provider_cache_misses = "masc_llm_provider_cache_misses_total"
 let metric_llm_provider_requests_started =
   "masc_llm_provider_requests_started_total"
 let metric_llm_provider_errors = "masc_llm_provider_errors_total"
+let metric_llm_provider_errors_by_reason =
+  "masc_llm_provider_errors_by_reason_total"
 let metric_llm_provider_retries = "masc_llm_provider_retries_total"
 let metric_llm_provider_input_tokens = "masc_llm_provider_input_tokens_total"
 let metric_llm_provider_output_tokens = "masc_llm_provider_output_tokens_total"
@@ -1532,6 +1534,9 @@ let init () =
     Counter;
   add metric_llm_provider_errors
     "Total OAS LLM request errors, labeled by model"
+    Counter;
+  add metric_llm_provider_errors_by_reason
+    "Total OAS LLM request errors, labeled by model and bounded error_reason"
     Counter;
   add metric_llm_provider_request_latency_clamped
     "Total OAS LLM request latency observations clamped before histogram \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -496,6 +496,7 @@ val metric_llm_provider_cache_hits : string
 val metric_llm_provider_cache_misses : string
 val metric_llm_provider_requests_started : string
 val metric_llm_provider_errors : string
+val metric_llm_provider_errors_by_reason : string
 val metric_llm_provider_retries : string
 val metric_llm_provider_input_tokens : string
 val metric_llm_provider_output_tokens : string

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -28,6 +28,10 @@ let test_metric_names_stable () =
     "masc_llm_provider_errors_total"
     Prom.metric_llm_provider_errors;
   Alcotest.(check string)
+    "errors by reason metric"
+    "masc_llm_provider_errors_by_reason_total"
+    Prom.metric_llm_provider_errors_by_reason;
+  Alcotest.(check string)
     "retries metric"
     "masc_llm_provider_retries_total"
     Prom.metric_llm_provider_retries;
@@ -59,6 +63,12 @@ let test_sink_records_oas_callbacks () =
     metric Prom.metric_llm_provider_requests_started ~labels:model_labels
   in
   let before_error = metric Prom.metric_llm_provider_errors ~labels:model_labels in
+  let error_reason_labels =
+    [ ("model", model_id); ("error_reason", "unknown") ]
+  in
+  let before_error_reason =
+    metric Prom.metric_llm_provider_errors_by_reason ~labels:error_reason_labels
+  in
   let before_retry = metric Prom.metric_llm_provider_retries ~labels:retry_labels in
   let before_input =
     metric Prom.metric_llm_provider_input_tokens ~labels:provider_model_labels
@@ -85,6 +95,9 @@ let test_sink_records_oas_callbacks () =
   check_metric_delta "error +1"
     Prom.metric_llm_provider_errors
     ~labels:model_labels ~before:before_error ~delta:1.0;
+  check_metric_delta "error reason +1"
+    Prom.metric_llm_provider_errors_by_reason
+    ~labels:error_reason_labels ~before:before_error_reason ~delta:1.0;
   check_metric_delta "retry +1"
     Prom.metric_llm_provider_retries
     ~labels:retry_labels ~before:before_retry ~delta:1.0;
@@ -139,6 +152,30 @@ let test_request_latency_positive_ms_does_not_clamp () =
     Prom.metric_llm_provider_request_latency_clamped
     ~labels ~before ~delta:0.0
 
+let test_error_reason_labels_are_bounded () =
+  let model_id =
+    Printf.sprintf "bridge-error-reason-%d" (Unix.getpid ())
+  in
+  let reason_labels reason =
+    [ ("model", model_id); ("error_reason", reason) ]
+  in
+  let before_timeout =
+    metric Prom.metric_llm_provider_errors_by_reason
+      ~labels:(reason_labels "timeout")
+  in
+  let before_rate_limit =
+    metric Prom.metric_llm_provider_errors_by_reason
+      ~labels:(reason_labels "rate_limit")
+  in
+  Bridge.emit_error ~model_id ~error:"deadline exceeded after 30s";
+  Bridge.emit_error ~model_id ~error:"HTTP 429 rate limit exceeded";
+  check_metric_delta "timeout reason +1"
+    Prom.metric_llm_provider_errors_by_reason
+    ~labels:(reason_labels "timeout") ~before:before_timeout ~delta:1.0;
+  check_metric_delta "rate limit reason +1"
+    Prom.metric_llm_provider_errors_by_reason
+    ~labels:(reason_labels "rate_limit") ~before:before_rate_limit ~delta:1.0
+
 let () =
   Alcotest.run "llm_metric_bridge"
     [
@@ -152,5 +189,7 @@ let () =
             test_request_latency_clamps_zero_ms;
           Alcotest.test_case "positive request latency does not clamp" `Quick
             test_request_latency_positive_ms_does_not_clamp;
+          Alcotest.test_case "error reason labels are bounded" `Quick
+            test_error_reason_labels_are_bounded;
         ] );
     ]


### PR DESCRIPTION
## Summary
- preserve the existing per-model LLM provider error counter
- add a bounded error_reason companion counter for provider error observability
- forward OAS cascade on_error details into the bridge instead of dropping the reason

## Why it matters
Keeper/cascade failures were visible only as per-model error counts, so operators could not distinguish timeout, rate limit, quota, auth, network, parse, or provider-error patterns from Prometheus alone. This keeps the aggregate metric stable while adding a low-cardinality reason surface.

## Validation
- scripts/dune-local.sh build test/test_llm_metric_bridge.exe (passed before rebase; post-rebase rerun blocked by shared opam/dune lock contention)
- ./_build/default/test/test_llm_metric_bridge.exe (passed before rebase: 5 tests)
- git diff --check origin/main...HEAD