### PR TITLE
fix: close keeper local discovery guard

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -666,4 +666,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-)))))
+))))))


### PR DESCRIPTION
## Summary
- closes the new local-discovery readiness match in keeper_turn
- unblocks current main compilation after #13504

## Verification
- git diff --check origin/main...HEAD
- scripts/check-oas-pin.sh --local-only
- env MASC_OPAM_LOCK=0 scripts/dune-local.sh build lib/masc_mcp.cmxa

## Notes
- MASC_OPAM_LOCK=0 was used only to avoid contributing to the current mixed old-wrapper opam/Dune lock inversion while waiting for the Dune throttle; the OAS pin guard passed separately before the build.