### PR TITLE
fix(ci): unblock fresh opam pin and structure ratchet

### DIFF
--- a/lib/coord/coord_task_cache_invariant.mli
+++ b/lib/coord/coord_task_cache_invariant.mli
@@ -1,0 +1,15 @@
+(** Guard stale task-cache broadcasts against canonical backlog state. *)
+
+val stale_active_task_signal_present :
+  config:Coord_utils_backend_setup.config ->
+  from_agent:string ->
+  module_name:string ->
+  content:string ->
+  bool
+
+val rewrite_broadcast_content :
+  config:Coord_utils_backend_setup.config ->
+  from_agent:string ->
+  module_name:string ->
+  content:string ->
+  string

--- a/lib/dashboard/dashboard_goal_loop.mli
+++ b/lib/dashboard/dashboard_goal_loop.mli
@@ -1,0 +1,3 @@
+(** Dashboard read model for goal-loop runtime status. *)
+
+val status_json : base_path:string -> unit -> Yojson.Safe.t

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -141,8 +141,10 @@ installed_agent_sdk_version() {
     return 0
   fi
 
-  echo "[opam-pin] ERROR: could not determine installed agent_sdk version from opam list or opam show" >&2
-  return 2
+  # Clean CI switches have no installed agent_sdk yet and may not have
+  # package metadata before this script pins it.  Treat that as "not
+  # installed" so the initial pin can proceed.
+  return 1
 }
 
 guard_agent_sdk_downgrade() {

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -145,8 +145,14 @@ installed_agent_sdk_version() {
     return 0
   fi
 
+  # Anchor the missing-package patterns on the package name. Generic
+  # "not found" / "not installed" output (file errors, network errors,
+  # corrupt switch state) must NOT silently classify as fresh-switch and
+  # bypass the downgrade floor; only an explicit "...agent_sdk..." form
+  # qualifies. This mirrors PR #13787 which closed the same family of
+  # bypass on the sibling installed_agent_sdk_version() implementation.
   if [[ "${show_status}" -ne 0 ]] \
-    && grep -Eiq 'no package|not found|unknown package|not installed' <<<"${show_output}"; then
+    && grep -Eiq 'No package named (agent_sdk|"agent_sdk")|no packages matching .*agent_sdk|unknown package .*agent_sdk' <<<"${show_output}"; then
     return 1
   fi
 
@@ -156,10 +162,13 @@ installed_agent_sdk_version() {
     return 2
   fi
 
-  # Clean CI switches have no installed agent_sdk yet and may not have
-  # package metadata before this script pins it.  Treat that as "not
-  # installed" so the initial pin can proceed.
-  return 1
+  # opam show exited 0 with empty output: this is an unexpected
+  # inspection result (a successful command should produce a version
+  # field). Fail closed with rc=2 so the downgrade guard surfaces the
+  # ambiguity to the operator instead of silently treating it as a
+  # fresh switch and allowing the pin.
+  echo "[opam-pin] ERROR: opam show agent_sdk returned exit 0 but empty output; refusing to bypass downgrade guard" >&2
+  return 2
 }
 
 guard_agent_sdk_downgrade() {

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -109,7 +109,7 @@ version_gt() {
 installed_agent_sdk_version() {
   command -v opam >/dev/null 2>&1 || return 1
 
-  local installed_packages agent_sdk_row installed_version show_version
+  local installed_packages agent_sdk_row installed_version show_output show_status
   if ! installed_packages="$(OPAMCOLOR=never opam list --installed --columns=name,version 2>&1)"; then
     echo "[opam-pin] ERROR: failed to inspect installed agent_sdk via opam list" >&2
     echo "[opam-pin] opam list output: ${installed_packages:-<empty>}" >&2
@@ -127,18 +127,33 @@ installed_agent_sdk_version() {
     return 0
   fi
 
-  # Fallback: opam show reads package metadata directly from the switch.  This
+  # Fallback: opam show reads package metadata directly from the switch. This
   # covers cases where opam list output is incomplete but the switch still knows
-  # the package version.
-  show_version="$(OPAMCOLOR=never opam show agent_sdk --field=version 2>/dev/null || true)"
-  if [[ -n "${show_version}" ]]; then
-    installed_version="$(normalize_version_triplet "${show_version}")"
+  # the package version. Unexpected opam failures fail closed; only an explicit
+  # missing-package result means the package is not installed yet.
+  set +e
+  show_output="$(OPAMCOLOR=never opam show agent_sdk --field=version 2>&1)"
+  show_status=$?
+  set -e
+  if [[ "${show_status}" -eq 0 && -n "${show_output}" ]]; then
+    installed_version="$(normalize_version_triplet "${show_output}")"
     if [[ -z "${installed_version}" ]]; then
-      echo "[opam-pin] ERROR: could not parse installed agent_sdk version from opam show output: ${show_version}" >&2
+      echo "[opam-pin] ERROR: could not parse installed agent_sdk version from opam show output: ${show_output}" >&2
       return 2
     fi
     printf '%s' "${installed_version}"
     return 0
+  fi
+
+  if [[ "${show_status}" -ne 0 ]] \
+    && grep -Eiq 'no package|not found|unknown package|not installed' <<<"${show_output}"; then
+    return 1
+  fi
+
+  if [[ "${show_status}" -ne 0 ]]; then
+    echo "[opam-pin] ERROR: failed to inspect installed agent_sdk via opam show" >&2
+    echo "[opam-pin] opam show output: ${show_output:-<empty>}" >&2
+    return 2
   fi
 
   # Clean CI switches have no installed agent_sdk yet and may not have

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -44,6 +44,10 @@ case "$1" in
   show)
     shift
     if [[ "${1:-}" == "agent_sdk" && "${2:-}" == "--field=version" ]]; then
+      if [[ "${FAKE_OPAM_SHOW_MISSING:-0}" == "1" ]]; then
+        echo "No package named agent_sdk found" >&2
+        exit 1
+      fi
       [[ "${FAKE_OPAM_SHOW_FAIL:-0}" == "1" ]] && exit 43
       printf '%s\n' "${FAKE_OPAM_SHOW_VERSION:-${FAKE_AGENT_SDK_VERSION:-0.0.0}}"
       exit 0
@@ -201,16 +205,31 @@ echo "ok case 8 - opam show fallback preserves installed-version protection"
 
 : > "${CALLS_FILE}"
 rm -f "${FLOOR_FILE}"
-run_pin_script \
+if run_pin_script \
   FAKE_AGENT_SDK_LIST_OUTPUT=$'other_pkg 1.0.0\n' \
   FAKE_OPAM_SHOW_FAIL=1 \
-  bash "${PIN_SCRIPT}" >"${TMP}/case9.out" 2>"${TMP}/case9.err"
-assert_contains "${CALLS_FILE}" "pin add agent_sdk"
-if [[ "$(cat "${FLOOR_FILE}")" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
-  echo "FAIL case 9: fresh switch should record floor ${OAS_AGENT_SDK_MIN_VERSION}, got $(cat "${FLOOR_FILE}" 2>/dev/null || true)" >&2
+  bash "${PIN_SCRIPT}" >"${TMP}/case9.out" 2>"${TMP}/case9.err"; then
+  echo "FAIL case 9: unexpected opam show failure should fail closed" >&2
   exit 1
 fi
-echo "ok case 9 - fresh switch without installed agent_sdk permits initial pinning"
+assert_contains "${TMP}/case9.err" "failed to inspect installed agent_sdk via opam show"
+assert_contains "${TMP}/case9.err" "refusing to mutate agent_sdk pin because installed version could not be determined"
+assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
+echo "ok case 9 - unexpected opam show failure fails closed"
+
+: > "${CALLS_FILE}"
+rm -f "${FLOOR_FILE}"
+run_pin_script \
+  FAKE_AGENT_SDK_LIST_OUTPUT=$'other_pkg 1.0.0\n' \
+  FAKE_OPAM_SHOW_MISSING=1 \
+  bash "${PIN_SCRIPT}" >"${TMP}/case10.out" 2>"${TMP}/case10.err"
+assert_contains "${CALLS_FILE}" "pin add agent_sdk"
+recorded_floor="$(head -n 1 "${FLOOR_FILE}" 2>/dev/null || true)"
+if [[ "${recorded_floor}" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
+  echo "FAIL case 10: fresh switch should record floor ${OAS_AGENT_SDK_MIN_VERSION}, got ${recorded_floor}" >&2
+  exit 1
+fi
+echo "ok case 10 - fresh switch without installed agent_sdk permits initial pinning"
 
 echo ""
-echo "[opam-pin-downgrade-guard test] PASS - 9/9 cases"
+echo "[opam-pin-downgrade-guard test] PASS - 10/10 cases"

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -199,20 +199,18 @@ assert_contains "${TMP}/case8.err" "refusing to downgrade installed agent_sdk 99
 assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
 echo "ok case 8 - opam show fallback preserves installed-version protection"
 
-case9_err="${TMP}/case9.err"
 : > "${CALLS_FILE}"
 rm -f "${FLOOR_FILE}"
-if run_pin_script \
+run_pin_script \
   FAKE_AGENT_SDK_LIST_OUTPUT=$'other_pkg 1.0.0\n' \
   FAKE_OPAM_SHOW_FAIL=1 \
-  bash "${PIN_SCRIPT}" >"${TMP}/case9.out" 2>"${case9_err}"; then
-  echo "FAIL case 9: missing agent_sdk list row plus failed opam show should fail closed" >&2
+  bash "${PIN_SCRIPT}" >"${TMP}/case9.out" 2>"${TMP}/case9.err"
+assert_contains "${CALLS_FILE}" "pin add agent_sdk"
+if [[ "$(cat "${FLOOR_FILE}")" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
+  echo "FAIL case 9: fresh switch should record floor ${OAS_AGENT_SDK_MIN_VERSION}, got $(cat "${FLOOR_FILE}" 2>/dev/null || true)" >&2
   exit 1
 fi
-assert_contains "${case9_err}" "could not determine installed agent_sdk version"
-assert_contains "${case9_err}" "refusing to mutate agent_sdk pin because installed version could not be determined"
-assert_not_contains "${CALLS_FILE}" "pin add agent_sdk"
-echo "ok case 9 - unavailable installed version fails closed when opam is present"
+echo "ok case 9 - fresh switch without installed agent_sdk permits initial pinning"
 
 echo ""
 echo "[opam-pin-downgrade-guard test] PASS - 9/9 cases"


### PR DESCRIPTION
Summary
- Treat absent agent_sdk in fresh opam switches as not installed so the initial CI pin can proceed while preserving fail-closed behavior for opam list inspection failures and newer installed versions.
- Add curated interfaces for the coord/dashboard modules that exceeded the OCaml structure ratchet, leaving Types_core as the existing long-tail exception.

Validation
- bash -n scripts/opam-pin-external-deps.sh test/test_opam_pin_downgrade_guard.sh
- bash test/test_opam_pin_downgrade_guard.sh
- scripts/ocaml-structure-ratchet.sh
- git diff --cached --check
- Manual workflow_dispatch odoc Pages on this branch: success, including Pin external OCaml dependencies, Install system and OCaml dependencies, Build library, and Build documentation. Run: https://github.com/jeong-sik/masc-mcp/actions/runs/25433353582
- Manual workflow_dispatch CI on this branch: OCaml Structure Ratchet passed and Pin external OCaml dependencies passed in Build/Lint/Health before the run was canceled by an unrelated Dashboard test drift. Run: https://github.com/jeong-sik/masc-mcp/actions/runs/25433353569

Known unrelated follow-up
- Dashboard workflow_dispatch currently fails `src/config/navigation.test.ts` because the test still expects `fleet-health` immediately after `runtime` while current navigation includes `goal-loop` first. Tracked as #13788.

Local note
- Focused Dune build was attempted locally, but the shared opam/Dune locks were saturated by other local sessions, so compile validation came from the manual odoc workflow instead.