### PR TITLE
fix(dashboard): expose checkbox metadata

### DIFF
--- a/dashboard/src/components/common/checkbox.test.ts
+++ b/dashboard/src/components/common/checkbox.test.ts
@@ -2,11 +2,82 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { Checkbox } from './checkbox'
+import { Checkbox, summarizeCheckbox } from './checkbox'
 
 const flushUi = async () => {
   for (let i = 0; i < 4; i++) await Promise.resolve()
 }
+
+describe('summarizeCheckbox', () => {
+  it('summarizes default checkbox state', () => {
+    expect(summarizeCheckbox({})).toEqual({
+      checkedState: 'unset',
+      checked: false,
+      disabled: false,
+      hasCustomClass: false,
+      classNameLength: 0,
+      hasId: false,
+      idLength: 0,
+      hasName: false,
+      nameLength: 0,
+      a11yHook: 'none',
+      hasAriaLabel: false,
+      ariaLabelLength: 0,
+      hasAriaLabelledby: false,
+      ariaLabelledbyLength: 0,
+      hasValue: false,
+      valueLength: 0,
+      hasTestId: false,
+      testIdLength: 0,
+      hasOnChange: false,
+      hasOnClick: false,
+    })
+  })
+
+  it('summarizes populated checkbox state', () => {
+    const onChange = vi.fn()
+    const onClick = vi.fn()
+    expect(summarizeCheckbox({
+      checked: true,
+      disabled: true,
+      class: 'extra-hook',
+      id: 'opt-in',
+      name: 'newsletter',
+      ariaLabel: 'Accept terms',
+      ariaLabelledby: 'tos-heading',
+      value: 'yes',
+      testId: 'optin-newsletter',
+      onChange,
+      onClick,
+    })).toEqual({
+      checkedState: 'true',
+      checked: true,
+      disabled: true,
+      hasCustomClass: true,
+      classNameLength: 10,
+      hasId: true,
+      idLength: 6,
+      hasName: true,
+      nameLength: 10,
+      a11yHook: 'aria-label',
+      hasAriaLabel: true,
+      ariaLabelLength: 12,
+      hasAriaLabelledby: true,
+      ariaLabelledbyLength: 11,
+      hasValue: true,
+      valueLength: 3,
+      hasTestId: true,
+      testIdLength: 16,
+      hasOnChange: true,
+      hasOnClick: true,
+    })
+  })
+
+  it('falls back to aria-labelledby and id as a11y hooks', () => {
+    expect(summarizeCheckbox({ ariaLabelledby: 'label-id' }).a11yHook).toBe('aria-labelledby')
+    expect(summarizeCheckbox({ id: 'field-id' }).a11yHook).toBe('id')
+  })
+})
 
 describe('Checkbox', () => {
   let container: HTMLElement
@@ -24,16 +95,33 @@ describe('Checkbox', () => {
     const cb = container.querySelector('input') as HTMLInputElement
     expect(cb).toBeTruthy()
     expect(cb.type).toBe('checkbox')
+    expect(cb.hasAttribute('data-checkbox')).toBe(true)
+    expect(cb.getAttribute('data-checkbox-checked-state')).toBe('unset')
+    expect(cb.getAttribute('data-checkbox-checked')).toBe('false')
+    expect(cb.getAttribute('data-checkbox-a11y-hook')).toBe('none')
   })
 
   it('checked=true renders a checked input', () => {
     render(html`<${Checkbox} checked=${true} />`, container)
-    expect((container.querySelector('input') as HTMLInputElement).checked).toBe(true)
+    const cb = container.querySelector('input') as HTMLInputElement
+    expect(cb.checked).toBe(true)
+    expect(cb.getAttribute('data-checkbox-checked-state')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-checked')).toBe('true')
+  })
+
+  it('checked=false renders explicit false metadata', () => {
+    render(html`<${Checkbox} checked=${false} />`, container)
+    const cb = container.querySelector('input') as HTMLInputElement
+    expect(cb.checked).toBe(false)
+    expect(cb.getAttribute('data-checkbox-checked-state')).toBe('false')
+    expect(cb.getAttribute('data-checkbox-checked')).toBe('false')
   })
 
   it('disabled=true disables the input', () => {
     render(html`<${Checkbox} disabled=${true} />`, container)
-    expect((container.querySelector('input') as HTMLInputElement).disabled).toBe(true)
+    const cb = container.querySelector('input') as HTMLInputElement
+    expect(cb.disabled).toBe(true)
+    expect(cb.getAttribute('data-checkbox-disabled')).toBe('true')
   })
 
   it('forwards id so <label for> can resolve (accessibility contract)', () => {
@@ -43,6 +131,9 @@ describe('Checkbox', () => {
     render(html`<${Checkbox} id="opt-in" />`, container)
     const cb = container.querySelector('input') as HTMLInputElement
     expect(cb.id).toBe('opt-in')
+    expect(cb.getAttribute('data-checkbox-has-id')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-id-length')).toBe('6')
+    expect(cb.getAttribute('data-checkbox-a11y-hook')).toBe('id')
 
     // End-to-end label association works:
     const label = document.createElement('label')
@@ -54,27 +145,44 @@ describe('Checkbox', () => {
 
   it('forwards name for FormData serialization', () => {
     render(html`<${Checkbox} name="newsletter" checked=${true} />`, container)
-    expect(container.querySelector('input')!.getAttribute('name')).toBe('newsletter')
+    const cb = container.querySelector('input')!
+    expect(cb.getAttribute('name')).toBe('newsletter')
+    expect(cb.getAttribute('data-checkbox-has-name')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-name-length')).toBe('10')
   })
 
   it('forwards value — the string submitted when checked', () => {
     render(html`<${Checkbox} name="tier" value="pro" checked=${true} />`, container)
-    expect(container.querySelector('input')!.getAttribute('value')).toBe('pro')
+    const cb = container.querySelector('input')!
+    expect(cb.getAttribute('value')).toBe('pro')
+    expect(cb.getAttribute('data-checkbox-has-value')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-value-length')).toBe('3')
   })
 
   it('aria-label is forwarded (accessible name without external <label>)', () => {
     render(html`<${Checkbox} ariaLabel="Accept terms" />`, container)
-    expect(container.querySelector('input')!.getAttribute('aria-label')).toBe('Accept terms')
+    const cb = container.querySelector('input')!
+    expect(cb.getAttribute('aria-label')).toBe('Accept terms')
+    expect(cb.getAttribute('data-checkbox-a11y-hook')).toBe('aria-label')
+    expect(cb.getAttribute('data-checkbox-has-aria-label')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-aria-label-length')).toBe('12')
   })
 
   it('aria-labelledby is forwarded (external-id label reference)', () => {
     render(html`<${Checkbox} ariaLabelledby="tos-heading" />`, container)
-    expect(container.querySelector('input')!.getAttribute('aria-labelledby')).toBe('tos-heading')
+    const cb = container.querySelector('input')!
+    expect(cb.getAttribute('aria-labelledby')).toBe('tos-heading')
+    expect(cb.getAttribute('data-checkbox-a11y-hook')).toBe('aria-labelledby')
+    expect(cb.getAttribute('data-checkbox-has-aria-labelledby')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-aria-labelledby-length')).toBe('11')
   })
 
   it('testId renders as data-testid (E2E stable hook)', () => {
     render(html`<${Checkbox} testId="optin-newsletter" />`, container)
-    expect(container.querySelector('input')!.getAttribute('data-testid')).toBe('optin-newsletter')
+    const cb = container.querySelector('input')!
+    expect(cb.getAttribute('data-testid')).toBe('optin-newsletter')
+    expect(cb.getAttribute('data-checkbox-has-test-id')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-test-id-length')).toBe('16')
   })
 
   it('onChange fires with the new checked boolean when user toggles on', async () => {
@@ -86,6 +194,7 @@ describe('Checkbox', () => {
     await flushUi()
     expect(spy).toHaveBeenCalledOnce()
     expect(spy.mock.calls[0]![0]).toBe(true)
+    expect(cb.getAttribute('data-checkbox-has-change-handler')).toBe('true')
   })
 
   it('onChange fires with false when user toggles off', async () => {
@@ -113,6 +222,7 @@ describe('Checkbox', () => {
     expect(spy).toHaveBeenCalledOnce()
     const passed = spy.mock.calls[0]![0] as Event
     expect(passed.target).toBe(cb)
+    expect(cb.getAttribute('data-checkbox-has-click-handler')).toBe('true')
   })
 
   it('onClick does not block onChange — both fire independently', async () => {
@@ -130,7 +240,10 @@ describe('Checkbox', () => {
 
   it('extra `class` prop is appended to the base class string', () => {
     render(html`<${Checkbox} class="extra-hook" />`, container)
-    expect(container.querySelector('input')!.className).toContain('extra-hook')
+    const cb = container.querySelector('input')!
+    expect(cb.className).toContain('extra-hook')
+    expect(cb.getAttribute('data-checkbox-has-custom-class')).toBe('true')
+    expect(cb.getAttribute('data-checkbox-class-length')).toBe('10')
   })
 
   it('base classes are still present even when `class` extension is given', () => {

--- a/dashboard/src/components/common/checkbox.test.ts
+++ b/dashboard/src/components/common/checkbox.test.ts
@@ -59,7 +59,7 @@ describe('summarizeCheckbox', () => {
       idLength: 6,
       hasName: true,
       nameLength: 10,
-      a11yHook: 'aria-label',
+      a11yHook: 'aria-labelledby',
       hasAriaLabel: true,
       ariaLabelLength: 12,
       hasAriaLabelledby: true,
@@ -74,6 +74,9 @@ describe('summarizeCheckbox', () => {
   })
 
   it('falls back to aria-labelledby and id as a11y hooks', () => {
+    expect(
+      summarizeCheckbox({ ariaLabel: 'Label', ariaLabelledby: 'label-id' }).a11yHook,
+    ).toBe('aria-labelledby')
     expect(summarizeCheckbox({ ariaLabelledby: 'label-id' }).a11yHook).toBe('aria-labelledby')
     expect(summarizeCheckbox({ id: 'field-id' }).a11yHook).toBe('id')
   })

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -15,7 +15,33 @@ import { ringFocusClasses } from './ring'
 
 const CHECKBOX_BASE = `w-4 h-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] cursor-pointer transition-colors hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })} accent-[var(--color-accent-fg)]`
 
-interface CheckboxProps {
+export type CheckboxCheckedState = 'unset' | 'true' | 'false'
+export type CheckboxA11yHook = 'aria-label' | 'aria-labelledby' | 'id' | 'none'
+
+export interface CheckboxSummary {
+  readonly checkedState: CheckboxCheckedState
+  readonly checked: boolean
+  readonly disabled: boolean
+  readonly hasCustomClass: boolean
+  readonly classNameLength: number
+  readonly hasId: boolean
+  readonly idLength: number
+  readonly hasName: boolean
+  readonly nameLength: number
+  readonly a11yHook: CheckboxA11yHook
+  readonly hasAriaLabel: boolean
+  readonly ariaLabelLength: number
+  readonly hasAriaLabelledby: boolean
+  readonly ariaLabelledbyLength: number
+  readonly hasValue: boolean
+  readonly valueLength: number
+  readonly hasTestId: boolean
+  readonly testIdLength: number
+  readonly hasOnChange: boolean
+  readonly hasOnClick: boolean
+}
+
+export interface CheckboxProps {
   checked?: boolean
   disabled?: boolean
   class?: string
@@ -45,6 +71,67 @@ interface CheckboxProps {
   onClick?: (e: Event) => void
 }
 
+function hasNonEmptyString(value: string | undefined): boolean {
+  return value !== undefined && value !== ''
+}
+
+function checkedState(checked: boolean | undefined): CheckboxCheckedState {
+  if (checked === undefined) return 'unset'
+  return checked ? 'true' : 'false'
+}
+
+function a11yHook({
+  id,
+  ariaLabel,
+  ariaLabelledby,
+}: {
+  id?: string
+  ariaLabel?: string
+  ariaLabelledby?: string
+}): CheckboxA11yHook {
+  if (hasNonEmptyString(ariaLabel)) return 'aria-label'
+  if (hasNonEmptyString(ariaLabelledby)) return 'aria-labelledby'
+  if (hasNonEmptyString(id)) return 'id'
+  return 'none'
+}
+
+export function summarizeCheckbox({
+  checked,
+  disabled,
+  class: cx,
+  id,
+  name,
+  ariaLabel,
+  ariaLabelledby,
+  value,
+  testId,
+  onChange,
+  onClick,
+}: CheckboxProps): CheckboxSummary {
+  return {
+    checkedState: checkedState(checked),
+    checked: checked === true,
+    disabled: disabled === true,
+    hasCustomClass: hasNonEmptyString(cx),
+    classNameLength: cx?.length ?? 0,
+    hasId: hasNonEmptyString(id),
+    idLength: id?.length ?? 0,
+    hasName: hasNonEmptyString(name),
+    nameLength: name?.length ?? 0,
+    a11yHook: a11yHook({ id, ariaLabel, ariaLabelledby }),
+    hasAriaLabel: hasNonEmptyString(ariaLabel),
+    ariaLabelLength: ariaLabel?.length ?? 0,
+    hasAriaLabelledby: hasNonEmptyString(ariaLabelledby),
+    ariaLabelledbyLength: ariaLabelledby?.length ?? 0,
+    hasValue: hasNonEmptyString(value),
+    valueLength: value?.length ?? 0,
+    hasTestId: hasNonEmptyString(testId),
+    testIdLength: testId?.length ?? 0,
+    hasOnChange: onChange !== undefined,
+    hasOnClick: onClick !== undefined,
+  }
+}
+
 export function Checkbox({
   checked,
   disabled,
@@ -58,6 +145,19 @@ export function Checkbox({
   onChange,
   onClick,
 }: CheckboxProps) {
+  const summary = summarizeCheckbox({
+    checked,
+    disabled,
+    class: cx,
+    id,
+    name,
+    ariaLabel,
+    ariaLabelledby,
+    value,
+    testId,
+    onChange,
+    onClick,
+  })
   const handleChange = (e: Event) => { onChange?.((e.target as HTMLInputElement).checked) }
   return html`
     <input
@@ -70,6 +170,27 @@ export function Checkbox({
       disabled=${disabled}
       aria-label=${ariaLabel}
       aria-labelledby=${ariaLabelledby}
+      data-checkbox
+      data-checkbox-checked-state=${summary.checkedState}
+      data-checkbox-checked=${summary.checked}
+      data-checkbox-disabled=${summary.disabled}
+      data-checkbox-has-custom-class=${summary.hasCustomClass}
+      data-checkbox-class-length=${summary.classNameLength}
+      data-checkbox-has-id=${summary.hasId}
+      data-checkbox-id-length=${summary.idLength}
+      data-checkbox-has-name=${summary.hasName}
+      data-checkbox-name-length=${summary.nameLength}
+      data-checkbox-a11y-hook=${summary.a11yHook}
+      data-checkbox-has-aria-label=${summary.hasAriaLabel}
+      data-checkbox-aria-label-length=${summary.ariaLabelLength}
+      data-checkbox-has-aria-labelledby=${summary.hasAriaLabelledby}
+      data-checkbox-aria-labelledby-length=${summary.ariaLabelledbyLength}
+      data-checkbox-has-value=${summary.hasValue}
+      data-checkbox-value-length=${summary.valueLength}
+      data-checkbox-has-test-id=${summary.hasTestId}
+      data-checkbox-test-id-length=${summary.testIdLength}
+      data-checkbox-has-change-handler=${summary.hasOnChange}
+      data-checkbox-has-click-handler=${summary.hasOnClick}
       data-testid=${testId}
       onChange=${handleChange}
       onClick=${onClick}

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -89,8 +89,8 @@ function a11yHook({
   ariaLabel?: string
   ariaLabelledby?: string
 }): CheckboxA11yHook {
-  if (hasNonEmptyString(ariaLabel)) return 'aria-label'
   if (hasNonEmptyString(ariaLabelledby)) return 'aria-labelledby'
+  if (hasNonEmptyString(ariaLabel)) return 'aria-label'
   if (hasNonEmptyString(id)) return 'id'
   return 'none'
 }
@@ -158,7 +158,9 @@ export function Checkbox({
     onChange,
     onClick,
   })
-  const handleChange = (e: Event) => { onChange?.((e.target as HTMLInputElement).checked) }
+  const handleChange = onChange === undefined
+    ? undefined
+    : (e: Event) => { onChange((e.target as HTMLInputElement).checked) }
   return html`
     <input
       type="checkbox"


### PR DESCRIPTION
## Summary
- export Checkbox props/types and pure `summarizeCheckbox` metadata helper
- stamp checkbox DOM metadata for checked state, disabled state, custom class, id/name/value/test hooks, a11y hook source, and change/click handler presence
- extend focused checkbox tests to cover pure summary output and rendered metadata attributes

## Why
The MASC Cockpit/Kimi component audit needs checkbox state to be inspectable without parsing class names or reading form values. This exposes checked/uncontrolled state and accessibility hook shape while keeping sensitive prop values length-only.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/common/checkbox.test.ts src/components/common/checkbox.a11y.test.ts` passed after rebase: 2 files, 24 tests
- `pnpm --dir dashboard exec tsc --noEmit --pretty false` passed after rebase
- `git diff --check` passed after rebase
- `pnpm --dir dashboard run lint` passed with existing warnings in `dashboard/src/components/common/virtual-list.ts` and `dashboard/src/components/fsm-hub.ts`
- `pnpm --dir dashboard run build` passed with the known Vite dynamic/static import warning for `dashboard.ts`

## Browser QA
- served with `env MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:9 pnpm --dir dashboard exec vite --host 127.0.0.1 --port 5237 --strictPort --force`
- desktop 1280x900 on `/dashboard/checkbox-qa.html`: verified 3 checkbox controls, metadata attributes for checked/custom/disabled/a11y states, no horizontal overflow, and toggle interaction `false` to `true`; screenshot `/tmp/masc-checkbox-summary-0506.png`
- mobile 390x760 on `/dashboard/checkbox-qa.html`: verified the same metadata counts and no horizontal overflow; screenshot `/tmp/masc-checkbox-summary-0506-mobile.png`
- browser console only had Vite debug connection logs after reload; page errors were empty

## Cleanup
- removed temporary `dashboard/checkbox-qa.html`
- removed temporary `dashboard/node_modules` symlink
- stopped Vite on port 5237
- browser QA session had no remaining listener/process