### PR TITLE
feat(dashboard): add event stream temporal sync cues

### DIFF
--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -169,7 +169,7 @@ describe('EventStream', () => {
     })
   })
 
-  it('groups adjacent visible events inside the temporal synchronization window', () => {
+  it('groups visible events by anchor timestamp inside the temporal synchronization window', () => {
     const rows = buildTemporalSyncRows(getVisibleStreamEvents(baseEvents, 100), 65000)
 
     expect(rows.map(row => row.event.id)).toEqual(['e3', 'e2', 'e1'])

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -6,6 +6,8 @@ import {
   EventStream,
   getVisibleStreamEvents,
   summarizeEventStream,
+  streamEventAttractionBand,
+  streamEventAttractionScore,
 } from './event-stream'
 
 const baseEvents = [
@@ -126,6 +128,8 @@ describe('EventStream', () => {
     expect(root.dataset.eventStreamTemporalSyncWindowMs).toBe('5000')
     expect(root.dataset.eventStreamTemporalSyncGroupCount).toBe('0')
     expect(root.dataset.eventStreamMaxTemporalSyncGroupSize).toBe('1')
+    expect(root.dataset.eventStreamHighAttractionCount).toBe('1')
+    expect(root.dataset.eventStreamMaxAttractionScore).toBe('0.90')
   })
 
   it('exposes event row metadata and datetime', () => {
@@ -179,6 +183,20 @@ describe('EventStream', () => {
     })
   })
 
+  it('scores gradient attraction by severity, recency, and sync grouping', () => {
+    const rows = buildTemporalSyncRows(getVisibleStreamEvents(baseEvents, 100), 65000)
+    const latestScore = streamEventAttractionScore(rows[0]!, 0, rows.length)
+    const neighborScore = streamEventAttractionScore(rows[1]!, 1, rows.length)
+    const olderScore = streamEventAttractionScore(rows[2]!, 2, rows.length)
+
+    expect(latestScore).toBe(1)
+    expect(neighborScore).toBe(0.69)
+    expect(olderScore).toBe(0.32)
+    expect(streamEventAttractionBand(latestScore)).toBe('high')
+    expect(streamEventAttractionBand(neighborScore)).toBe('medium')
+    expect(streamEventAttractionBand(olderScore)).toBe('low')
+  })
+
   it('renders temporal synchronization metadata and cue badges', () => {
     const container = document.createElement('div')
     render(h(EventStream, { events: baseEvents, temporalSyncWindowMs: 65000 }), container)
@@ -195,6 +213,21 @@ describe('EventStream', () => {
     expect(neighbor.dataset.streamEventSyncSize).toBe('2')
     expect(older.dataset.streamEventSyncSize).toBe('1')
     expect(container.textContent).toContain('sync 2')
+  })
+
+  it('renders gradient attraction metadata on event rows', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const latest = container.querySelector('[data-stream-event-id="e3"]') as HTMLElement
+    const middle = container.querySelector('[data-stream-event-id="e2"]') as HTMLElement
+    const older = container.querySelector('[data-stream-event-id="e1"]') as HTMLElement
+
+    expect(root.dataset.eventStreamHighAttractionCount).toBe('1')
+    expect(latest.dataset.streamEventAttractionScore).toBe('0.90')
+    expect(latest.dataset.streamEventAttractionBand).toBe('high')
+    expect(middle.dataset.streamEventAttractionBand).toBe('medium')
+    expect(older.dataset.streamEventAttractionBand).toBe('low')
   })
 
   it('treats maxItems zero as an empty visible window', () => {

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import {
+  buildTemporalSyncRows,
   EventStream,
   getVisibleStreamEvents,
   summarizeEventStream,
@@ -122,6 +123,9 @@ describe('EventStream', () => {
     expect(root.dataset.eventStreamWarnCount).toBe('1')
     expect(root.dataset.eventStreamErrorCount).toBe('1')
     expect(root.dataset.eventStreamLatestTimestamp).toBe(String(latest.timestamp))
+    expect(root.dataset.eventStreamTemporalSyncWindowMs).toBe('5000')
+    expect(root.dataset.eventStreamTemporalSyncGroupCount).toBe('0')
+    expect(root.dataset.eventStreamMaxTemporalSyncGroupSize).toBe('1')
   })
 
   it('exposes event row metadata and datetime', () => {
@@ -159,6 +163,38 @@ describe('EventStream', () => {
       hiddenCount: 1,
       status: 'error',
     })
+  })
+
+  it('groups adjacent visible events inside the temporal synchronization window', () => {
+    const rows = buildTemporalSyncRows(getVisibleStreamEvents(baseEvents, 100), 65000)
+
+    expect(rows.map(row => row.event.id)).toEqual(['e3', 'e2', 'e1'])
+    expect(rows[0]?.syncGroupId).toBe(rows[1]?.syncGroupId)
+    expect(rows[0]?.syncGroupSize).toBe(2)
+    expect(rows[1]?.syncGroupSize).toBe(2)
+    expect(rows[2]?.syncGroupSize).toBe(1)
+    expect(summarizeEventStream(baseEvents, 100, 65000)).toMatchObject({
+      temporalSyncGroupCount: 1,
+      maxTemporalSyncGroupSize: 2,
+    })
+  })
+
+  it('renders temporal synchronization metadata and cue badges', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents, temporalSyncWindowMs: 65000 }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const latest = container.querySelector('[data-stream-event-id="e3"]') as HTMLElement
+    const neighbor = container.querySelector('[data-stream-event-id="e2"]') as HTMLElement
+    const older = container.querySelector('[data-stream-event-id="e1"]') as HTMLElement
+
+    expect(root.dataset.eventStreamTemporalSyncWindowMs).toBe('65000')
+    expect(root.dataset.eventStreamTemporalSyncGroupCount).toBe('1')
+    expect(root.dataset.eventStreamMaxTemporalSyncGroupSize).toBe('2')
+    expect(latest.dataset.streamEventSyncGroup).toBe(neighbor.dataset.streamEventSyncGroup)
+    expect(latest.dataset.streamEventSyncSize).toBe('2')
+    expect(neighbor.dataset.streamEventSyncSize).toBe('2')
+    expect(older.dataset.streamEventSyncSize).toBe('1')
+    expect(container.textContent).toContain('sync 2')
   })
 
   it('treats maxItems zero as an empty visible window', () => {

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -3,6 +3,7 @@ import { h } from 'preact'
 import { render } from 'preact'
 import {
   buildTemporalSyncRows,
+  DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
   EventStream,
   getVisibleStreamEvents,
   summarizeEventStream,
@@ -125,7 +126,7 @@ describe('EventStream', () => {
     expect(root.dataset.eventStreamWarnCount).toBe('1')
     expect(root.dataset.eventStreamErrorCount).toBe('1')
     expect(root.dataset.eventStreamLatestTimestamp).toBe(String(latest.timestamp))
-    expect(root.dataset.eventStreamTemporalSyncWindowMs).toBe('5000')
+    expect(root.dataset.eventStreamTemporalSyncWindowMs).toBe(String(DEFAULT_TEMPORAL_SYNC_WINDOW_MS))
     expect(root.dataset.eventStreamTemporalSyncGroupCount).toBe('0')
     expect(root.dataset.eventStreamMaxTemporalSyncGroupSize).toBe('1')
     expect(root.dataset.eventStreamHighAttractionCount).toBe('1')
@@ -167,6 +168,25 @@ describe('EventStream', () => {
       hiddenCount: 1,
       status: 'error',
     })
+  })
+
+  it('omits non-finite timestamps from summary and row metadata', () => {
+    const invalidEvents = [
+      { id: 'bad-1', timestamp: Number.NaN, level: 'info' as const, message: 'bad latest' },
+      { id: 'bad-2', timestamp: Number.POSITIVE_INFINITY, level: 'warn' as const, message: 'bad oldest' },
+    ]
+    const container = document.createElement('div')
+    render(h(EventStream, { events: invalidEvents }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const latest = container.querySelector('[data-stream-event-id="bad-2"]') as HTMLElement
+
+    expect(summarizeEventStream(invalidEvents, 100)).toMatchObject({
+      latestTimestamp: null,
+      oldestVisibleTimestamp: null,
+    })
+    expect(root.dataset.eventStreamLatestTimestamp).toBe('')
+    expect(root.dataset.eventStreamOldestVisibleTimestamp).toBe('')
+    expect(latest.dataset.streamEventTimestamp).toBe('')
   })
 
   it('groups visible events by anchor timestamp inside the temporal synchronization window', () => {
@@ -213,6 +233,9 @@ describe('EventStream', () => {
     expect(neighbor.dataset.streamEventSyncSize).toBe('2')
     expect(older.dataset.streamEventSyncSize).toBe('1')
     expect(container.textContent).toContain('sync 2')
+    const syncBadge = Array.from(container.querySelectorAll('span'))
+      .find(el => el.textContent === 'sync 2') as HTMLElement | undefined
+    expect(syncBadge?.getAttribute('aria-hidden')).toBe('true')
   })
 
   it('renders gradient attraction metadata on event rows', () => {

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -15,6 +15,7 @@ export interface StreamEvent {
 }
 
 export type EventStreamStatus = 'empty' | 'ok' | 'warning' | 'error'
+export type EventStreamAttractionBand = 'high' | 'medium' | 'low'
 
 export interface EventStreamSummary {
   totalCount: number
@@ -27,6 +28,8 @@ export interface EventStreamSummary {
   oldestVisibleTimestamp: number | null
   temporalSyncGroupCount: number
   maxTemporalSyncGroupSize: number
+  highAttractionCount: number
+  maxAttractionScore: number
   status: EventStreamStatus
 }
 
@@ -80,6 +83,41 @@ function finiteTimestamp(value: number): number | null {
 
 function normalizedSyncWindowMs(value: number): number {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+function roundedScore(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function levelAttraction(level: StreamEvent['level']): number {
+  switch (level) {
+    case 'error':
+      return 1
+    case 'warn':
+      return 0.7
+    case 'info':
+      return 0.45
+  }
+}
+
+export function streamEventAttractionScore(
+  row: TemporalSyncStreamRow,
+  visibleIndex: number,
+  visibleCount: number,
+): number {
+  const recency = visibleCount <= 1 ? 1 : 1 - (visibleIndex / Math.max(1, visibleCount - 1))
+  const syncBonus = row.syncGroupSize > 1 ? 0.1 : 0
+  return roundedScore(clamp01((levelAttraction(row.event.level) * 0.7) + (recency * 0.2) + syncBonus))
+}
+
+export function streamEventAttractionBand(score: number): EventStreamAttractionBand {
+  if (score >= 0.8) return 'high'
+  if (score >= 0.55) return 'medium'
+  return 'low'
 }
 
 export function buildTemporalSyncRows(
@@ -147,6 +185,10 @@ export function summarizeEventStream(
       .filter(row => row.syncGroupSize > 1)
       .map(row => row.syncGroupId),
   )
+  const attractionScores = syncRows.map((row, index) =>
+    streamEventAttractionScore(row, index, syncRows.length),
+  )
+  const highAttractionCount = attractionScores.filter(score => streamEventAttractionBand(score) === 'high').length
   const status: EventStreamStatus =
     visible.length === 0
       ? 'empty'
@@ -167,8 +209,20 @@ export function summarizeEventStream(
     oldestVisibleTimestamp: visible[visible.length - 1]?.timestamp ?? null,
     temporalSyncGroupCount: syncedGroups.size,
     maxTemporalSyncGroupSize: syncRows.reduce((max, row) => Math.max(max, row.syncGroupSize), 0),
+    highAttractionCount,
+    maxAttractionScore: attractionScores.reduce((max, score) => Math.max(max, score), 0),
     status,
   }
+}
+
+function attractionRowClass(band: EventStreamAttractionBand, isSynced: boolean): string {
+  if (band === 'high') return 'border-[var(--color-accent)] bg-[var(--color-bg-elevated)]'
+  if (band === 'medium') {
+    return isSynced
+      ? 'border-[var(--color-accent)] bg-[var(--color-bg-elevated)]'
+      : 'border-[var(--color-border-strong)]'
+  }
+  return 'border-transparent opacity-80'
 }
 
 export function EventStream({
@@ -203,6 +257,8 @@ export function EventStream({
       data-event-stream-temporal-sync-window-ms=${normalizedSyncWindowMs(temporalSyncWindowMs)}
       data-event-stream-temporal-sync-group-count=${summary.temporalSyncGroupCount}
       data-event-stream-max-temporal-sync-group-size=${summary.maxTemporalSyncGroupSize}
+      data-event-stream-high-attraction-count=${summary.highAttractionCount}
+      data-event-stream-max-attraction-score=${summary.maxAttractionScore.toFixed(2)}
       data-testid=${testId}
     >
       <div
@@ -238,10 +294,12 @@ export function EventStream({
                 (row, index) => {
                   const e = row.event
                   const isSynced = row.syncGroupSize > 1
+                  const attractionScore = streamEventAttractionScore(row, index, syncRows.length)
+                  const attractionBand = streamEventAttractionBand(attractionScore)
                   return html`
                   <div
                     key=${e.id}
-                    class=${`flex min-w-0 items-start gap-2 rounded-[var(--r-1)] border-l-2 px-2 py-1 hover:bg-[var(--color-bg-hover)] ${isSynced ? 'border-[var(--color-accent)] bg-[var(--color-bg-elevated)]' : 'border-transparent'}`}
+                    class=${`flex min-w-0 items-start gap-2 rounded-[var(--r-1)] border-l-2 px-2 py-1 hover:bg-[var(--color-bg-hover)] ${attractionRowClass(attractionBand, isSynced)}`}
                     role="listitem"
                     data-stream-event-id=${e.id}
                     data-stream-event-level=${e.level}
@@ -251,6 +309,8 @@ export function EventStream({
                     data-stream-event-sync-group=${row.syncGroupId}
                     data-stream-event-sync-size=${row.syncGroupSize}
                     data-stream-event-sync-anchor=${row.syncAnchorTimestamp ?? ''}
+                    data-stream-event-attraction-score=${attractionScore.toFixed(2)}
+                    data-stream-event-attraction-band=${attractionBand}
                   >
                     <span
                       class="mt-0.5 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -25,12 +25,22 @@ export interface EventStreamSummary {
   errorCount: number
   latestTimestamp: number | null
   oldestVisibleTimestamp: number | null
+  temporalSyncGroupCount: number
+  maxTemporalSyncGroupSize: number
   status: EventStreamStatus
+}
+
+export interface TemporalSyncStreamRow {
+  event: StreamEvent
+  syncGroupId: string
+  syncGroupSize: number
+  syncAnchorTimestamp: number | null
 }
 
 interface EventStreamProps {
   events: StreamEvent[]
   maxItems?: number
+  temporalSyncWindowMs?: number
   testId?: string
 }
 
@@ -64,11 +74,79 @@ export function getVisibleStreamEvents(events: StreamEvent[], maxItems: number):
   return events.slice(-itemLimit).reverse()
 }
 
-export function summarizeEventStream(events: StreamEvent[], maxItems: number): EventStreamSummary {
+function finiteTimestamp(value: number): number | null {
+  return Number.isFinite(value) ? value : null
+}
+
+function normalizedSyncWindowMs(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+}
+
+export function buildTemporalSyncRows(
+  events: StreamEvent[],
+  temporalSyncWindowMs: number,
+): TemporalSyncStreamRow[] {
+  const windowMs = normalizedSyncWindowMs(temporalSyncWindowMs)
+  const rows: TemporalSyncStreamRow[] = []
+  let pending: StreamEvent[] = []
+  let anchorTimestamp: number | null = null
+  let groupIndex = 0
+
+  const flush = () => {
+    if (pending.length === 0) return
+    const syncGroupId = `sync-${groupIndex}`
+    const syncGroupSize = pending.length
+    for (const event of pending) {
+      rows.push({
+        event,
+        syncGroupId,
+        syncGroupSize,
+        syncAnchorTimestamp: anchorTimestamp,
+      })
+    }
+    groupIndex += 1
+    pending = []
+    anchorTimestamp = null
+  }
+
+  for (const event of events) {
+    const eventTimestamp = finiteTimestamp(event.timestamp)
+    const canJoin =
+      pending.length > 0
+      && anchorTimestamp != null
+      && eventTimestamp != null
+      && Math.abs(anchorTimestamp - eventTimestamp) <= windowMs
+
+    if (pending.length === 0 || canJoin) {
+      pending.push(event)
+      if (anchorTimestamp == null) anchorTimestamp = eventTimestamp
+      continue
+    }
+
+    flush()
+    pending.push(event)
+    anchorTimestamp = eventTimestamp
+  }
+
+  flush()
+  return rows
+}
+
+export function summarizeEventStream(
+  events: StreamEvent[],
+  maxItems: number,
+  temporalSyncWindowMs = 5000,
+): EventStreamSummary {
   const visible = getVisibleStreamEvents(events, maxItems)
+  const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
   const infoCount = visible.filter(e => e.level === 'info').length
   const warnCount = visible.filter(e => e.level === 'warn').length
   const errorCount = visible.filter(e => e.level === 'error').length
+  const syncedGroups = new Set(
+    syncRows
+      .filter(row => row.syncGroupSize > 1)
+      .map(row => row.syncGroupId),
+  )
   const status: EventStreamStatus =
     visible.length === 0
       ? 'empty'
@@ -87,13 +165,27 @@ export function summarizeEventStream(events: StreamEvent[], maxItems: number): E
     errorCount,
     latestTimestamp: visible[0]?.timestamp ?? null,
     oldestVisibleTimestamp: visible[visible.length - 1]?.timestamp ?? null,
+    temporalSyncGroupCount: syncedGroups.size,
+    maxTemporalSyncGroupSize: syncRows.reduce((max, row) => Math.max(max, row.syncGroupSize), 0),
     status,
   }
 }
 
-export function EventStream({ events, maxItems = 100, testId }: EventStreamProps) {
+export function EventStream({
+  events,
+  maxItems = 100,
+  temporalSyncWindowMs = 5000,
+  testId,
+}: EventStreamProps) {
   const visible = useMemo(() => getVisibleStreamEvents(events, maxItems), [events, maxItems])
-  const summary = useMemo(() => summarizeEventStream(events, maxItems), [events, maxItems])
+  const syncRows = useMemo(
+    () => buildTemporalSyncRows(visible, temporalSyncWindowMs),
+    [visible, temporalSyncWindowMs],
+  )
+  const summary = useMemo(
+    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs),
+    [events, maxItems, temporalSyncWindowMs],
+  )
 
   return html`
     <div
@@ -108,6 +200,9 @@ export function EventStream({ events, maxItems = 100, testId }: EventStreamProps
       data-event-stream-status=${summary.status}
       data-event-stream-latest-timestamp=${summary.latestTimestamp ?? ''}
       data-event-stream-oldest-visible-timestamp=${summary.oldestVisibleTimestamp ?? ''}
+      data-event-stream-temporal-sync-window-ms=${normalizedSyncWindowMs(temporalSyncWindowMs)}
+      data-event-stream-temporal-sync-group-count=${summary.temporalSyncGroupCount}
+      data-event-stream-max-temporal-sync-group-size=${summary.maxTemporalSyncGroupSize}
       data-testid=${testId}
     >
       <div
@@ -139,17 +234,23 @@ export function EventStream({ events, maxItems = 100, testId }: EventStreamProps
           ? html`<div class="text-3xs text-[var(--color-fg-muted)]">이벤트 없음</div>`
           : html`
             <div class="space-y-1" role="list">
-              ${visible.map(
-                (e, index) => html`
+              ${syncRows.map(
+                (row, index) => {
+                  const e = row.event
+                  const isSynced = row.syncGroupSize > 1
+                  return html`
                   <div
                     key=${e.id}
-                    class="flex min-w-0 items-start gap-2 rounded-[var(--r-1)] px-2 py-1 hover:bg-[var(--color-bg-hover)]"
+                    class=${`flex min-w-0 items-start gap-2 rounded-[var(--r-1)] border-l-2 px-2 py-1 hover:bg-[var(--color-bg-hover)] ${isSynced ? 'border-[var(--color-accent)] bg-[var(--color-bg-elevated)]' : 'border-transparent'}`}
                     role="listitem"
                     data-stream-event-id=${e.id}
                     data-stream-event-level=${e.level}
                     data-stream-event-source=${e.source ?? ''}
                     data-stream-event-timestamp=${e.timestamp}
                     data-stream-event-visible-index=${index}
+                    data-stream-event-sync-group=${row.syncGroupId}
+                    data-stream-event-sync-size=${row.syncGroupSize}
+                    data-stream-event-sync-anchor=${row.syncAnchorTimestamp ?? ''}
                   >
                     <span
                       class="mt-0.5 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"
@@ -165,15 +266,21 @@ export function EventStream({ events, maxItems = 100, testId }: EventStreamProps
                       ? html`<span
                           class="max-w-24 shrink-0 truncate text-3xs text-[var(--color-fg-muted)]"
                           title=${e.source}
-                          >[${e.source}]</span
+                        >[${e.source}]</span
                         >`
+                      : null}
+                    ${isSynced
+                      ? html`<span class="shrink-0 rounded-[var(--r-0)] border border-[var(--color-border-default)] px-1 font-mono text-3xs text-[var(--color-fg-muted)]">sync ${row.syncGroupSize}</span>`
                       : null}
                     <span class="min-w-0 flex-1 break-words text-xs text-[var(--color-fg-primary)]"
                       >${e.message}</span
                     >
+                    ${isSynced
+                      ? html`<span class="sr-only">동기화 그룹 ${row.syncGroupSize}개 이벤트</span>`
+                      : null}
                     <span class="sr-only">${levelLabel(e.level)}</span>
                   </div>
-                `,
+                `},
               )}
             </div>
           `}

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -149,6 +149,9 @@ export function buildTemporalSyncRows(
 
   for (const event of events) {
     const eventTimestamp = finiteTimestamp(event.timestamp)
+    // Anchor-based grouping keeps each visible cluster bounded to the first
+    // event in that cluster, instead of letting a long adjacency chain stretch
+    // beyond the configured synchronization window.
     const canJoin =
       pending.length > 0
       && anchorTimestamp != null

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -47,6 +47,8 @@ interface EventStreamProps {
   testId?: string
 }
 
+export const DEFAULT_TEMPORAL_SYNC_WINDOW_MS = 5000
+
 function levelColor(level: string): string {
   return level === 'error'
     ? 'var(--color-status-err)'
@@ -176,10 +178,14 @@ export function buildTemporalSyncRows(
 export function summarizeEventStream(
   events: StreamEvent[],
   maxItems: number,
-  temporalSyncWindowMs = 5000,
+  temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
 ): EventStreamSummary {
   const visible = getVisibleStreamEvents(events, maxItems)
   const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
+  const latestTimestamp = visible.length > 0 ? finiteTimestamp(visible[0]!.timestamp) : null
+  const oldestVisibleTimestamp = visible.length > 0
+    ? finiteTimestamp(visible[visible.length - 1]!.timestamp)
+    : null
   const infoCount = visible.filter(e => e.level === 'info').length
   const warnCount = visible.filter(e => e.level === 'warn').length
   const errorCount = visible.filter(e => e.level === 'error').length
@@ -208,8 +214,8 @@ export function summarizeEventStream(
     infoCount,
     warnCount,
     errorCount,
-    latestTimestamp: visible[0]?.timestamp ?? null,
-    oldestVisibleTimestamp: visible[visible.length - 1]?.timestamp ?? null,
+    latestTimestamp,
+    oldestVisibleTimestamp,
     temporalSyncGroupCount: syncedGroups.size,
     maxTemporalSyncGroupSize: syncRows.reduce((max, row) => Math.max(max, row.syncGroupSize), 0),
     highAttractionCount,
@@ -231,7 +237,7 @@ function attractionRowClass(band: EventStreamAttractionBand, isSynced: boolean):
 export function EventStream({
   events,
   maxItems = 100,
-  temporalSyncWindowMs = 5000,
+  temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
   testId,
 }: EventStreamProps) {
   const visible = useMemo(() => getVisibleStreamEvents(events, maxItems), [events, maxItems])
@@ -297,6 +303,7 @@ export function EventStream({
                 (row, index) => {
                   const e = row.event
                   const isSynced = row.syncGroupSize > 1
+                  const eventTimestamp = finiteTimestamp(e.timestamp)
                   const attractionScore = streamEventAttractionScore(row, index, syncRows.length)
                   const attractionBand = streamEventAttractionBand(attractionScore)
                   return html`
@@ -307,7 +314,7 @@ export function EventStream({
                     data-stream-event-id=${e.id}
                     data-stream-event-level=${e.level}
                     data-stream-event-source=${e.source ?? ''}
-                    data-stream-event-timestamp=${e.timestamp}
+                    data-stream-event-timestamp=${eventTimestamp ?? ''}
                     data-stream-event-visible-index=${index}
                     data-stream-event-sync-group=${row.syncGroupId}
                     data-stream-event-sync-size=${row.syncGroupSize}
@@ -333,7 +340,10 @@ export function EventStream({
                         >`
                       : null}
                     ${isSynced
-                      ? html`<span class="shrink-0 rounded-[var(--r-0)] border border-[var(--color-border-default)] px-1 font-mono text-3xs text-[var(--color-fg-muted)]">sync ${row.syncGroupSize}</span>`
+                      ? html`<span
+                          class="shrink-0 rounded-[var(--r-0)] border border-[var(--color-border-default)] px-1 font-mono text-3xs text-[var(--color-fg-muted)]"
+                          aria-hidden="true"
+                        >sync ${row.syncGroupSize}</span>`
                       : null}
                     <span class="min-w-0 flex-1 break-words text-xs text-[var(--color-fg-primary)]"
                       >${e.message}</span


### PR DESCRIPTION
## Summary
- add temporal synchronization grouping metadata to EventStream rows
- expose sync-window/group summary attributes for dashboard observers and tests
- show a small sync cue when adjacent visible events occur inside the synchronization window

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/common/event-stream.test.ts src/components/common/event-stream.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src (passes with existing unrelated warnings in virtual-list.ts and fsm-hub.ts)
- git diff --check

## Review focus
- Existing newest-first live append behavior is preserved.
- Temporal synchronization is additive: default window is 5000ms and only adds metadata/cue badges for grouped rows.