### PR TITLE
fix(keeper): avoid forcing passive required tools

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -280,7 +280,9 @@ let preferred_tool_choice_for_required_tool_names
     ~(required_tool_names : string list) ~(allowed_tool_names : string list) =
   let visible_required =
     required_tool_names
-    |> List.filter (fun name -> List.mem name allowed_tool_names)
+    |> List.filter (fun name ->
+      List.mem name allowed_tool_names
+      && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name)
     |> Keeper_types.dedupe_keep_order
   in
   match visible_required with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7620,6 +7620,31 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        fail
          (Printf.sprintf "expected Any for multiple required tools, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:[ "keeper_tasks_audit" ]
+       ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
+   with
+   | Agent_sdk.Types.Auto -> ()
+   | other ->
+       fail
+         (Printf.sprintf
+            "expected Auto for passive-only required tool, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
+       ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
+   with
+   | Agent_sdk.Types.Tool name ->
+       check string "active required tool remains forced" "keeper_board_post"
+         name
+   | other ->
+       fail
+         (Printf.sprintf
+            "expected Tool keeper_board_post for mixed passive/active required \
+             tools, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
   (* Active task keeper retains the strict gate even without a
      specific applicable tool — the caller is expected to make
      progress via board_post, task_update, etc. *)


### PR DESCRIPTION
## Summary
- prevents current-task required tool names from exact-forcing passive/read-only tools such as keeper_tasks_audit
- keeps active required tools forceable when mixed with passive tools
- adds regressions for passive-only and mixed passive/active required-tool choices

## Why it matters
Recent scheduled Keeper attempts showed required-tool/passive-tool contract failures, including keeper_tasks_audit being selected as an exact required tool. Passive/read-only tools cannot satisfy the required execution contract, so forcing them turns a diagnostic/read path into a completion-contract failure instead of letting the model choose a valid action or respond honestly.

## Verification
- git diff --check
- env DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_unified.exe
- _build/default/test/test_keeper_unified.exe test --show-errors tool_classification 3
- _build/default/test/test_keeper_unified.exe test --show-errors tool_classification

Related: #13534