### PR TITLE
feat(dashboard): add event stream gradient attraction

### DIFF
--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -6,6 +6,8 @@ import {
   EventStream,
   getVisibleStreamEvents,
   summarizeEventStream,
+  streamEventAttractionBand,
+  streamEventAttractionScore,
 } from './event-stream'
 
 const baseEvents = [
@@ -126,6 +128,8 @@ describe('EventStream', () => {
     expect(root.dataset.eventStreamTemporalSyncWindowMs).toBe('5000')
     expect(root.dataset.eventStreamTemporalSyncGroupCount).toBe('0')
     expect(root.dataset.eventStreamMaxTemporalSyncGroupSize).toBe('1')
+    expect(root.dataset.eventStreamHighAttractionCount).toBe('1')
+    expect(root.dataset.eventStreamMaxAttractionScore).toBe('0.90')
   })
 
   it('exposes event row metadata and datetime', () => {
@@ -179,6 +183,20 @@ describe('EventStream', () => {
     })
   })
 
+  it('scores gradient attraction by severity, recency, and sync grouping', () => {
+    const rows = buildTemporalSyncRows(getVisibleStreamEvents(baseEvents, 100), 65000)
+    const latestScore = streamEventAttractionScore(rows[0]!, 0, rows.length)
+    const neighborScore = streamEventAttractionScore(rows[1]!, 1, rows.length)
+    const olderScore = streamEventAttractionScore(rows[2]!, 2, rows.length)
+
+    expect(latestScore).toBe(1)
+    expect(neighborScore).toBe(0.69)
+    expect(olderScore).toBe(0.32)
+    expect(streamEventAttractionBand(latestScore)).toBe('high')
+    expect(streamEventAttractionBand(neighborScore)).toBe('medium')
+    expect(streamEventAttractionBand(olderScore)).toBe('low')
+  })
+
   it('renders temporal synchronization metadata and cue badges', () => {
     const container = document.createElement('div')
     render(h(EventStream, { events: baseEvents, temporalSyncWindowMs: 65000 }), container)
@@ -195,6 +213,21 @@ describe('EventStream', () => {
     expect(neighbor.dataset.streamEventSyncSize).toBe('2')
     expect(older.dataset.streamEventSyncSize).toBe('1')
     expect(container.textContent).toContain('sync 2')
+  })
+
+  it('renders gradient attraction metadata on event rows', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const latest = container.querySelector('[data-stream-event-id="e3"]') as HTMLElement
+    const middle = container.querySelector('[data-stream-event-id="e2"]') as HTMLElement
+    const older = container.querySelector('[data-stream-event-id="e1"]') as HTMLElement
+
+    expect(root.dataset.eventStreamHighAttractionCount).toBe('1')
+    expect(latest.dataset.streamEventAttractionScore).toBe('0.90')
+    expect(latest.dataset.streamEventAttractionBand).toBe('high')
+    expect(middle.dataset.streamEventAttractionBand).toBe('medium')
+    expect(older.dataset.streamEventAttractionBand).toBe('low')
   })
 
   it('treats maxItems zero as an empty visible window', () => {

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -15,6 +15,7 @@ export interface StreamEvent {
 }
 
 export type EventStreamStatus = 'empty' | 'ok' | 'warning' | 'error'
+export type EventStreamAttractionBand = 'high' | 'medium' | 'low'
 
 export interface EventStreamSummary {
   totalCount: number
@@ -27,6 +28,8 @@ export interface EventStreamSummary {
   oldestVisibleTimestamp: number | null
   temporalSyncGroupCount: number
   maxTemporalSyncGroupSize: number
+  highAttractionCount: number
+  maxAttractionScore: number
   status: EventStreamStatus
 }
 
@@ -80,6 +83,41 @@ function finiteTimestamp(value: number): number | null {
 
 function normalizedSyncWindowMs(value: number): number {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+function roundedScore(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function levelAttraction(level: StreamEvent['level']): number {
+  switch (level) {
+    case 'error':
+      return 1
+    case 'warn':
+      return 0.7
+    case 'info':
+      return 0.45
+  }
+}
+
+export function streamEventAttractionScore(
+  row: TemporalSyncStreamRow,
+  visibleIndex: number,
+  visibleCount: number,
+): number {
+  const recency = visibleCount <= 1 ? 1 : 1 - (visibleIndex / Math.max(1, visibleCount - 1))
+  const syncBonus = row.syncGroupSize > 1 ? 0.1 : 0
+  return roundedScore(clamp01((levelAttraction(row.event.level) * 0.7) + (recency * 0.2) + syncBonus))
+}
+
+export function streamEventAttractionBand(score: number): EventStreamAttractionBand {
+  if (score >= 0.8) return 'high'
+  if (score >= 0.55) return 'medium'
+  return 'low'
 }
 
 export function buildTemporalSyncRows(
@@ -147,6 +185,10 @@ export function summarizeEventStream(
       .filter(row => row.syncGroupSize > 1)
       .map(row => row.syncGroupId),
   )
+  const attractionScores = syncRows.map((row, index) =>
+    streamEventAttractionScore(row, index, syncRows.length),
+  )
+  const highAttractionCount = attractionScores.filter(score => streamEventAttractionBand(score) === 'high').length
   const status: EventStreamStatus =
     visible.length === 0
       ? 'empty'
@@ -167,8 +209,20 @@ export function summarizeEventStream(
     oldestVisibleTimestamp: visible[visible.length - 1]?.timestamp ?? null,
     temporalSyncGroupCount: syncedGroups.size,
     maxTemporalSyncGroupSize: syncRows.reduce((max, row) => Math.max(max, row.syncGroupSize), 0),
+    highAttractionCount,
+    maxAttractionScore: attractionScores.reduce((max, score) => Math.max(max, score), 0),
     status,
   }
+}
+
+function attractionRowClass(band: EventStreamAttractionBand, isSynced: boolean): string {
+  if (band === 'high') return 'border-[var(--color-accent)] bg-[var(--color-bg-elevated)]'
+  if (band === 'medium') {
+    return isSynced
+      ? 'border-[var(--color-accent)] bg-[var(--color-bg-elevated)]'
+      : 'border-[var(--color-border-strong)]'
+  }
+  return 'border-transparent opacity-80'
 }
 
 export function EventStream({
@@ -203,6 +257,8 @@ export function EventStream({
       data-event-stream-temporal-sync-window-ms=${normalizedSyncWindowMs(temporalSyncWindowMs)}
       data-event-stream-temporal-sync-group-count=${summary.temporalSyncGroupCount}
       data-event-stream-max-temporal-sync-group-size=${summary.maxTemporalSyncGroupSize}
+      data-event-stream-high-attraction-count=${summary.highAttractionCount}
+      data-event-stream-max-attraction-score=${summary.maxAttractionScore.toFixed(2)}
       data-testid=${testId}
     >
       <div
@@ -238,10 +294,12 @@ export function EventStream({
                 (row, index) => {
                   const e = row.event
                   const isSynced = row.syncGroupSize > 1
+                  const attractionScore = streamEventAttractionScore(row, index, syncRows.length)
+                  const attractionBand = streamEventAttractionBand(attractionScore)
                   return html`
                   <div
                     key=${e.id}
-                    class=${`flex min-w-0 items-start gap-2 rounded-[var(--r-1)] border-l-2 px-2 py-1 hover:bg-[var(--color-bg-hover)] ${isSynced ? 'border-[var(--color-accent)] bg-[var(--color-bg-elevated)]' : 'border-transparent'}`}
+                    class=${`flex min-w-0 items-start gap-2 rounded-[var(--r-1)] border-l-2 px-2 py-1 hover:bg-[var(--color-bg-hover)] ${attractionRowClass(attractionBand, isSynced)}`}
                     role="listitem"
                     data-stream-event-id=${e.id}
                     data-stream-event-level=${e.level}
@@ -251,6 +309,8 @@ export function EventStream({
                     data-stream-event-sync-group=${row.syncGroupId}
                     data-stream-event-sync-size=${row.syncGroupSize}
                     data-stream-event-sync-anchor=${row.syncAnchorTimestamp ?? ''}
+                    data-stream-event-attraction-score=${attractionScore.toFixed(2)}
+                    data-stream-event-attraction-band=${attractionBand}
                   >
                     <span
                       class="mt-0.5 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"


### PR DESCRIPTION
## Summary
- add gradient-attraction scoring for EventStream rows using severity, recency, and temporal sync grouping
- expose attraction summary and row metadata for observer/test surfaces
- apply high/medium/low visual contrast bands without changing event ordering

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/common/event-stream.test.ts src/components/common/event-stream.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src (passes with existing unrelated warnings in virtual-list.ts and fsm-hub.ts)
- git diff --check

## Stack
- Base branch: fix/event-stream-temporal-sync-0506
- Builds on #13779 Temporal Synchronization.

## Review focus
- Attraction score stays deterministic and local to visible EventStream rows.
- High/medium/low bands are additive visual cues; newest-first order is unchanged.