### PR TITLE
fix(build): restore main test green — Heartbeat path + Option.bind order

### DIFF
--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -962,7 +962,7 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   ignore
     (Masc_mcp.Auth.create_token config.base_path ~agent_name ~role:Masc_domain.Admin);
   ignore
-    (Masc_mcp.Heartbeat.start ~agent_name ~interval:30 ~message:"route-test");
+    (Heartbeat.start ~agent_name ~interval:30 ~message:"route-test");
   let metrics_dir = Masc_mcp.Metrics_store_eio.agent_metrics_dir config agent_name in
   Fs_compat.mkdir_p metrics_dir;
   write_file (Filename.concat metrics_dir "2026-04.jsonl") "{}\n";
@@ -994,7 +994,7 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   check string "agent purge reports coord leave" (agent_name ^ " left the namespace")
     (cleanup_row |> member "coord_leave_result" |> to_string);
   check int "agent purge leaves no duplicate heartbeat stop work" 0
-    (Masc_mcp.Heartbeat.stop_by_agent ~agent_name);
+    (Heartbeat.stop_by_agent ~agent_name);
   check bool "agent file removed" false
     (Sys.file_exists
        (Filename.concat (Masc_mcp.Coord.agents_dir config)

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -167,10 +167,12 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
 
   let config = room_config tmp_dir in
   let current_task_for agent_name =
-    Coord.get_agents_raw config
-    |> List.find_opt (fun (agent : Masc_domain.agent) ->
-      String.equal agent.name agent_name)
-    |> Option.bind (fun agent -> agent.current_task)
+    let agent_opt =
+      Coord.get_agents_raw config
+      |> List.find_opt (fun (agent : Masc_domain.agent) ->
+        String.equal agent.name agent_name)
+    in
+    Option.bind agent_opt (fun (agent : Masc_domain.agent) -> agent.current_task)
   in
   let _ = Coord.init config ~agent_name:(Some "taskmaster") in
   let _ = Coord.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in


### PR DESCRIPTION
## Summary
PR #13766이 `keeper_turn.ml`의 paren mismatch를 이미 fix했으나, **test 빌드가 여전히 깨진 상태**에서 다음 두 에러가 남아있어 main이 회복되지 않았습니다:

### 1. test/test_dashboard_keeper_routes.ml (4 lines)
- 호출: `Masc_mcp.Heartbeat.start` / `Masc_mcp.Heartbeat.stop_by_agent` (line 965, 997)
- 에러: `Error: Unbound module Masc_mcp.Heartbeat`
- 원인: `lib/coord/heartbeat.ml`은 별도 라이브러리 `masc_coord` 안에 `(wrapped false)`로 있어 top-level `Heartbeat`로 노출. 다른 모든 호출 사이트(`test_room.ml:1590-1608`, `test_keeper_tool_matrix_cases.ml:559-561`)도 그냥 `Heartbeat.start` 사용.
- Fix: `Masc_mcp.Heartbeat` → `Heartbeat` (2곳)
- Source: PR #13538 (\"surface agent purge cleanup\")에서 추가된 코드

### 2. test/test_room.ml:173 (10 lines)
- 코드: `pipe |> Option.bind (fun agent -> agent.current_task)`
- 에러: `This expression should not be a function, the expected type is 'a option`
- 원인: Stdlib `Option.bind : 'a option -> ('a -> 'b option) -> 'b option`. \`|>\`로 풀면 함수 인자가 첫 번째 위치에 들어가 type mismatch.
- Fix: 중간 결과를 `let agent_opt = ... in Option.bind agent_opt (fun agent -> agent.current_task)`로 분리.

## Verification
- \`dune build\` ✅
- \`dune build @check\` ✅
- 변경 3개 파일 모두 fmt-clean (다른 unrelated fmt drift는 main에 누적되어 있으나 별도 fix 필요)

## Why Draft
AI agent 작성 PR. 사용자 검토 후 \`human-approved-ready\` 라벨 + ready 전환 권장.

## Notes
초기 worktree에서는 keeper_turn.ml paren fix도 포함했으나 \`git rebase origin/main\` 시 PR #13766과 자동 dedup되어 본 PR scope가 test fix only로 축소되었습니다 (split-brain 회피 성공).