### PR TITLE
fix: detect server restarts during Docker PR lifecycle polling

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -54,6 +54,9 @@ The prompt reserves `keeper_shell` and `keeper_bash` for read-only inspection.
 Mutating git operations must go through `masc_code_git`; otherwise the shell
 guard can correctly reject `git commit`/`git push` with `write_operation_gated`
 and the run will not produce Docker push evidence.
+Likewise, proof-file writes should use `keeper_fs_edit`, and PR create/review
+mutations should use `keeper_pr_create` / `keeper_pr_review_comment` rather
+than `gh pr ...` through shell tools.
 Override the CSV with `REQUIRED_TOOLS=...` for a narrower or broader proof
 lane.
 `MSG_TIMEOUT_SEC` only bounds the harness HTTP request to the MCP server.

--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -37,6 +37,13 @@ using `build.commit` plus `build.started_at`. If the server restarts or is
 replaced while keeper turns are pending, the pending requests are recorded as
 `server_incarnation_changed` instead of accumulating misleading
 `request_id not found` poll errors from a fresh in-memory request registry.
+The incarnation check classifies failures into three statuses:
+`server_incarnation_changed` (real restart, terminates polling),
+`server_health_unavailable` (transient `/health` HTTP failure, polling
+continues), and `server_health_missing_commit` (the response was reachable
+but lacked `build.commit`, also treated as transient). Only the first
+status records pending requests as lost; the other two log a transient
+notice and the next poll iteration retries.
 When mutation is enabled, the harness sends `required_tools` with each
 `masc_keeper_msg` call. By default that one-turn contract requires
 `keeper_shell`, `keeper_bash`, `masc_code_git`, `keeper_pr_create`, and

--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -32,12 +32,21 @@ HTTP health is up but MCP startup is still completing does not fail the run.
 Transient `masc_keeper_msg_result` transport/tool errors are recorded in
 `poll_errors.jsonl` and kept pending until the poll deadline instead of being
 treated as terminal keeper results.
+For mutation runs, the harness pins the server incarnation from `/health`
+using `build.commit` plus `build.started_at`. If the server restarts or is
+replaced while keeper turns are pending, the pending requests are recorded as
+`server_incarnation_changed` instead of accumulating misleading
+`request_id not found` poll errors from a fresh in-memory request registry.
 When mutation is enabled, the harness sends `required_tools` with each
 `masc_keeper_msg` call. By default that one-turn contract requires
 `keeper_shell`, `keeper_bash`, `masc_code_git`, `keeper_pr_create`, and
 `keeper_pr_review_comment`, so the runtime records `tool_surface_mismatch` if
 those tools are not visible and `missing_required_tool_use` if the keeper
 replies without exercising them.
+The prompt reserves `keeper_shell` and `keeper_bash` for read-only inspection.
+Mutating git operations must go through `masc_code_git`; otherwise the shell
+guard can correctly reject `git commit`/`git push` with `write_operation_gated`
+and the run will not produce Docker push evidence.
 Override the CSV with `REQUIRED_TOOLS=...` for a narrower or broader proof
 lane.
 `MSG_TIMEOUT_SEC` only bounds the harness HTTP request to the MCP server.

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -797,13 +797,15 @@ Goal: produce direct, auditable Docker-backed evidence for PR create, git push, 
 Tool route rules:
 - Use keeper_shell or keeper_bash only for read-only inspection.
 - Do not run git commit, git push, or other mutating git commands through keeper_bash.
+- Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash.
+- Use keeper_fs_edit for the minimal proof-file edit inside the Docker playground; do not use approval-requiring host code-write paths for this proof file.
 - Use masc_code_git for git commit and git push so the runtime can attach Docker route evidence and avoid write_operation_gated shell denials.
 - Use keeper_pr_create and keeper_pr_review_comment for PR mutation/review actions.
 
 Required proof lane:
 1. Confirm your runtime is sandbox_profile=docker before mutating.
 2. Create a unique proof branch named: keeper/$keeper-docker-pr-proof-$RUN_ID
-3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md.
+3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_fs_edit.
 4. Commit and git push that branch with masc_code_git. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 5. Create a draft PR for that branch with keeper_pr_create or the native PR-create tool path. Do not mark ready, do not merge, do not add human-approved-ready.
 6. Use keeper_pr_review_read and keeper_pr_review_comment for review evidence. COMMENT is allowed on your own proof PR. APPROVE must target the cross-keeper PR below, not your own PR.

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -44,7 +44,12 @@ EXPECTED_SERVER_COMMIT="${EXPECTED_SERVER_COMMIT:-}"
 FORBID_GITHUB_IDENTITIES="${FORBID_GITHUB_IDENTITIES:-}"
 SERVER_HEALTH_URL="${SERVER_HEALTH_URL:-}"
 SERVER_COMMIT_ACTUAL=""
+SERVER_STARTED_AT_ACTUAL=""
+SERVER_INCARNATION_ACTUAL=""
 SERVER_HEALTH_CHECK_FILE=""
+SERVER_INCARNATION_LAST_ACTUAL=""
+SERVER_INCARNATION_LAST_REASON=""
+SERVER_INCARNATION_LAST_FILE=""
 
 usage() {
   cat <<'EOF'
@@ -220,32 +225,103 @@ server_health_url() {
 }
 
 assert_expected_server_commit() {
-  if [[ -z "$EXPECTED_SERVER_COMMIT" ]]; then
-    return 0
-  fi
-
-  local health_url health_file actual
-  health_url="$(server_health_url)"
+  local health_file fields actual started incarnation
   health_file="$RAW_DIR/server-health.json"
-  if ! curl -fsS --max-time 5 "$health_url" >"$health_file"; then
-    echo "failed to fetch server health for commit check: $health_url" >&2
+  if ! fields="$(capture_server_incarnation "$health_file")"; then
+    echo "failed to fetch server health for incarnation check: $(server_health_url)" >&2
     exit 1
+  fi
+  IFS=$'\t' read -r actual started incarnation <<<"$fields"
+  SERVER_COMMIT_ACTUAL="$actual"
+  SERVER_STARTED_AT_ACTUAL="$started"
+  SERVER_INCARNATION_ACTUAL="$incarnation"
+  SERVER_HEALTH_CHECK_FILE="$health_file"
+
+  if [[ -n "$EXPECTED_SERVER_COMMIT" \
+      && "$actual" != "$EXPECTED_SERVER_COMMIT" \
+      && "$actual" != "$EXPECTED_SERVER_COMMIT"* \
+      && "$EXPECTED_SERVER_COMMIT" != "$actual"* ]]; then
+    echo "server commit mismatch: expected=$EXPECTED_SERVER_COMMIT actual=$actual url=$(server_health_url)" >&2
+    exit 1
+  fi
+  log "server incarnation verified: commit=$actual started_at=${started:-unknown}"
+}
+
+capture_server_incarnation() {
+  # Exit codes:
+  #   0 - prints "$actual\t$started\t$incarnation"
+  #   1 - HTTP fetch failed (server_health_unavailable, transient)
+  #   2 - HTTP succeeded but build.commit was missing/empty
+  #       (server_health_missing_commit, distinct from "server down")
+  local health_file="$1"
+  local health_url actual started incarnation
+  health_url="$(server_health_url)"
+  if ! curl -fsS --max-time 5 "$health_url" >"$health_file"; then
+    return 1
   fi
 
   actual="$(jq -r '.build.commit // .build_commit // .commit // empty' "$health_file")"
-  SERVER_COMMIT_ACTUAL="$actual"
-  SERVER_HEALTH_CHECK_FILE="$health_file"
+  started="$(jq -r '.build.started_at // .started_at // .startup.started_at // empty' "$health_file")"
   if [[ -z "$actual" ]]; then
-    echo "server health did not expose build.commit: $health_url" >&2
-    exit 1
+    return 2
   fi
-  if [[ "$actual" != "$EXPECTED_SERVER_COMMIT" \
-      && "$actual" != "$EXPECTED_SERVER_COMMIT"* \
-      && "$EXPECTED_SERVER_COMMIT" != "$actual"* ]]; then
-    echo "server commit mismatch: expected=$EXPECTED_SERVER_COMMIT actual=$actual url=$health_url" >&2
-    exit 1
+  incarnation="$actual|$started"
+  printf '%s\t%s\t%s\n' "$actual" "$started" "$incarnation"
+}
+
+assert_server_incarnation_unchanged() {
+  # SERVER_INCARNATION_LAST_REASON is set to one of:
+  #   server_incarnation_changed   - real restart (caller must terminate
+  #                                  polling and record pending as lost)
+  #   server_health_unavailable    - transient HTTP failure (caller should
+  #                                  keep polling; the server may come back
+  #                                  without having restarted)
+  #   server_health_missing_commit - HTTP succeeded but build.commit empty
+  #                                  (poll-side data shape, not a restart)
+  # Capture exit status with rc=$? so callers can preserve the distinction
+  # between "transient" and "real restart" instead of collapsing both into
+  # server_health_unavailable.
+  [[ -n "$SERVER_INCARNATION_ACTUAL" ]] || return 0
+
+  local health_file fields rc actual started incarnation
+  health_file="$RAW_DIR/server-health-poll.json"
+  fields="$(capture_server_incarnation "$health_file")"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    case $rc in
+      2) SERVER_INCARNATION_LAST_REASON="server_health_missing_commit" ;;
+      *) SERVER_INCARNATION_LAST_REASON="server_health_unavailable" ;;
+    esac
+    SERVER_INCARNATION_LAST_FILE="$health_file"
+    SERVER_INCARNATION_LAST_ACTUAL=""
+    return 1
   fi
-  log "server commit verified: expected=$EXPECTED_SERVER_COMMIT actual=$actual"
+  IFS=$'\t' read -r actual started incarnation <<<"$fields"
+  SERVER_INCARNATION_LAST_FILE="$health_file"
+  SERVER_INCARNATION_LAST_ACTUAL="$incarnation"
+  if [[ "$incarnation" != "$SERVER_INCARNATION_ACTUAL" ]]; then
+    SERVER_INCARNATION_LAST_REASON="server_incarnation_changed"
+    return 1
+  fi
+  return 0
+}
+
+record_pending_server_incarnation_loss() {
+  local pending_file="$1"
+  local status="$2"
+  local raw_file="$3"
+  while IFS=$'\t' read -r request_id keeper; do
+    [[ -n "$request_id" ]] || continue
+    jq -nc \
+      --arg keeper "$keeper" \
+      --arg request_id "$request_id" \
+      --arg status "$status" \
+      --arg expected_incarnation "$SERVER_INCARNATION_ACTUAL" \
+      --arg actual_incarnation "$SERVER_INCARNATION_LAST_ACTUAL" \
+      --arg raw_file "$raw_file" \
+      '{keeper:$keeper, request_id:$request_id, status:$status, server_expected_incarnation:$expected_incarnation, server_actual_incarnation:$actual_incarnation, raw_file:$raw_file}' \
+      >>"$RESULTS_FILE"
+  done <"$pending_file"
 }
 
 load_mcp_token() {
@@ -718,11 +794,17 @@ Keeper: $keeper
 
 Goal: produce direct, auditable Docker-backed evidence for PR create, git push, PR review/comment, and PR APPROVE. Use native keeper tools where available; do not use host-local ambient GitHub credentials.
 
+Tool route rules:
+- Use keeper_shell or keeper_bash only for read-only inspection.
+- Do not run git commit, git push, or other mutating git commands through keeper_bash.
+- Use masc_code_git for git commit and git push so the runtime can attach Docker route evidence and avoid write_operation_gated shell denials.
+- Use keeper_pr_create and keeper_pr_review_comment for PR mutation/review actions.
+
 Required proof lane:
 1. Confirm your runtime is sandbox_profile=docker before mutating.
 2. Create a unique proof branch named: keeper/$keeper-docker-pr-proof-$RUN_ID
 3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md.
-4. Commit and git push that branch. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+4. Commit and git push that branch with masc_code_git. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 5. Create a draft PR for that branch with keeper_pr_create or the native PR-create tool path. Do not mark ready, do not merge, do not add human-approved-ready.
 6. Use keeper_pr_review_read and keeper_pr_review_comment for review evidence. COMMENT is allowed on your own proof PR. APPROVE must target the cross-keeper PR below, not your own PR.
 
@@ -826,6 +908,14 @@ poll_results() {
   jq -r '.request_id + "\t" + .keeper' "$REQUESTS_FILE" >"$pending_file"
 
   while [[ -s "$pending_file" && "$(date +%s)" -lt "$deadline" ]]; do
+    if ! assert_server_incarnation_unchanged; then
+      log "server incarnation changed while polling keeper results: expected=$SERVER_INCARNATION_ACTUAL actual=${SERVER_INCARNATION_LAST_ACTUAL:-unknown}"
+      record_pending_server_incarnation_loss "$pending_file" \
+        "$SERVER_INCARNATION_LAST_REASON" \
+        "$SERVER_INCARNATION_LAST_FILE"
+      : >"$pending_file"
+      break
+    fi
     local next_pending="$RUN_DIR/pending.next"
     : >"$next_pending"
     while IFS=$'\t' read -r request_id keeper; do
@@ -917,6 +1007,8 @@ write_summary() {
     --arg expected_server_commit "$EXPECTED_SERVER_COMMIT" \
     --arg forbid_github_identities "$FORBID_GITHUB_IDENTITIES" \
     --arg server_commit "$SERVER_COMMIT_ACTUAL" \
+    --arg server_started_at "$SERVER_STARTED_AT_ACTUAL" \
+    --arg server_incarnation "$SERVER_INCARNATION_ACTUAL" \
     --arg server_health_file "$SERVER_HEALTH_CHECK_FILE" \
     --arg review_targets_file "$REVIEW_TARGETS_FILE" \
     --arg github_identity_counts_file "$GITHUB_IDENTITY_COUNTS_FILE" \
@@ -936,6 +1028,8 @@ write_summary() {
       expected_server_commit:$expected_server_commit,
       forbid_github_identities:$forbid_github_identities,
       server_commit:$server_commit,
+      server_started_at:$server_started_at,
+      server_incarnation:$server_incarnation,
       server_health_file:$server_health_file,
       review_targets_file:$review_targets_file,
       github_identity_counts_file:$github_identity_counts_file,
@@ -976,7 +1070,9 @@ require_cmd jq
 require_cmd python3
 require_cmd curl
 
-assert_expected_server_commit
+if [[ "$MUTATE" == "1" || -n "$EXPECTED_SERVER_COMMIT" ]]; then
+  assert_expected_server_commit
+fi
 ensure_mcp_session_if_needed
 discover_keepers
 assert_github_identity_pool_for_mutate

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -225,10 +225,17 @@ server_health_url() {
 }
 
 assert_expected_server_commit() {
-  local health_file fields actual started incarnation
+  local health_file fields rc actual started incarnation
   health_file="$RAW_DIR/server-health.json"
-  if ! fields="$(capture_server_incarnation "$health_file")"; then
-    echo "failed to fetch server health for incarnation check: $(server_health_url)" >&2
+  if fields="$(capture_server_incarnation "$health_file")"; then
+    :
+  else
+    rc=$?
+    if [[ $rc -eq 2 ]]; then
+      echo "server health missing build.commit for incarnation check: url=$(server_health_url) file=$health_file" >&2
+    else
+      echo "failed to fetch server health for incarnation check: url=$(server_health_url) file=$health_file" >&2
+    fi
     exit 1
   fi
   IFS=$'\t' read -r actual started incarnation <<<"$fields"
@@ -285,9 +292,10 @@ assert_server_incarnation_unchanged() {
 
   local health_file fields rc actual started incarnation
   health_file="$RAW_DIR/server-health-poll.json"
-  fields="$(capture_server_incarnation "$health_file")"
-  rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if fields="$(capture_server_incarnation "$health_file")"; then
+    :
+  else
+    rc=$?
     case $rc in
       2) SERVER_INCARNATION_LAST_REASON="server_health_missing_commit" ;;
       *) SERVER_INCARNATION_LAST_REASON="server_health_unavailable" ;;

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -909,12 +909,22 @@ poll_results() {
 
   while [[ -s "$pending_file" && "$(date +%s)" -lt "$deadline" ]]; do
     if ! assert_server_incarnation_unchanged; then
-      log "server incarnation changed while polling keeper results: expected=$SERVER_INCARNATION_ACTUAL actual=${SERVER_INCARNATION_LAST_ACTUAL:-unknown}"
-      record_pending_server_incarnation_loss "$pending_file" \
-        "$SERVER_INCARNATION_LAST_REASON" \
-        "$SERVER_INCARNATION_LAST_FILE"
-      : >"$pending_file"
-      break
+      # Only terminate early on a confirmed restart. Transient failures
+      # (server_health_unavailable, server_health_missing_commit) can fix
+      # themselves on the next /health poll without the server having
+      # restarted, so prematurely clearing pending requests here would
+      # discard live in-flight keeper results.
+      if [[ "$SERVER_INCARNATION_LAST_REASON" == "server_incarnation_changed" ]]; then
+        log "server incarnation changed while polling keeper results: expected=$SERVER_INCARNATION_ACTUAL actual=${SERVER_INCARNATION_LAST_ACTUAL:-unknown}"
+        record_pending_server_incarnation_loss "$pending_file" \
+          "$SERVER_INCARNATION_LAST_REASON" \
+          "$SERVER_INCARNATION_LAST_FILE"
+        : >"$pending_file"
+        break
+      fi
+      log "server health transient ($SERVER_INCARNATION_LAST_REASON); keep polling pending=$(wc -l <"$pending_file" | tr -d ' ')"
+      sleep 1
+      continue
     fi
     local next_pending="$RUN_DIR/pending.next"
     : >"$next_pending"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1175,6 +1175,29 @@ let test_keeper_msg_timeout_contracts () =
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        {|--argjson timeout "$KEEPER_TURN_TIMEOUT_SEC"|});
+  check bool "docker PR lifecycle harness pins server incarnation" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "SERVER_INCARNATION_ACTUAL");
+  check bool "docker PR lifecycle harness checks incarnation during polling" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "assert_server_incarnation_unchanged");
+  check bool "docker PR lifecycle harness records restart-lost requests" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "server_incarnation_changed");
+  check bool "docker PR lifecycle prompt routes mutating git through masc_code_git" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "Do not run git commit, git push, or other mutating git commands through keeper_bash");
+  check bool "docker PR lifecycle prompt names masc_code_git for push" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "Commit and git push that branch with masc_code_git");
+  check bool "runbook documents server incarnation restart classification" true
+    (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+       "`server_incarnation_changed`");
   check bool "runbook documents keeper turn timeout" true
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
        "`masc_keeper_msg.timeout_sec` through `KEEPER_TURN_TIMEOUT_SEC`")

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1183,6 +1183,14 @@ let test_keeper_msg_timeout_contracts () =
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        "assert_server_incarnation_unchanged");
+  check bool "docker PR lifecycle harness captures incarnation failures under set -e" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       {|if fields="$(capture_server_incarnation "$health_file")"; then|});
+  check bool "docker PR lifecycle harness reports missing commit separately" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "server health missing build.commit for incarnation check");
   check bool "docker PR lifecycle harness records restart-lost requests" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1195,6 +1195,14 @@ let test_keeper_msg_timeout_contracts () =
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        "Commit and git push that branch with masc_code_git");
+  check bool "docker PR lifecycle prompt uses keeper_fs_edit for proof edit" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "with keeper_fs_edit");
+  check bool "docker PR lifecycle prompt forbids gh pr shell mutation" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash");
   check bool "runbook documents server incarnation restart classification" true
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
        "`server_incarnation_changed`");


### PR DESCRIPTION
## Summary
- pin Docker PR lifecycle mutation runs to the live server incarnation using /health commit + started_at
- classify confirmed server replacement as server_incarnation_changed while keeping transient health failures pending
- force the proof prompt to route proof-file edits through keeper_fs_edit, mutating git through masc_code_git, and PR mutations through keeper_pr_* tools
- document the failure modes and add source-contract coverage

## Verification
- bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
- git diff --check
- rg -n "server_incarnation_changed|build.started_at|SERVER_INCARNATION_ACTUAL|assert_server_incarnation_unchanged" scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md test/test_ci_hardening_source.ml
- rg -n "keeper_fs_edit|gh pr create|mutating GitHub|masc_code_git|write_operation_gated" scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md test/test_ci_hardening_source.ml

## Not Run
- scripts/dune-local.sh build test/test_ci_hardening_source.exe: /tmp/me-dune-local.lock is currently held by other local Dune jobs