### PR TITLE
Normalize blank optional enum tool inputs

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -70,10 +70,56 @@ let normalize_transition_args (args : Yojson.Safe.t) : Yojson.Safe.t =
       `Assoc fields
   | _ -> args
 
-let prepare_args ~name args =
+let required_names schema =
+  match Yojson.Safe.Util.member "required" schema with
+  | `List items ->
+      List.filter_map
+        (function
+          | `String name -> Some name
+          | _ -> None)
+        items
+  | _ -> []
+
+let has_enum schema =
+  match Yojson.Safe.Util.member "enum" schema with
+  | `List (_ :: _) -> true
+  | _ -> false
+
+let optional_enum_fields schema =
+  let required = required_names schema in
+  match Yojson.Safe.Util.member "properties" schema with
+  | `Assoc props ->
+      List.filter_map
+        (fun (name, prop_schema) ->
+          if (not (List.mem name required)) && has_enum prop_schema then Some name
+          else None)
+        props
+  | _ -> []
+
+let normalize_blank_optional_enum_args ?schema args =
+  match schema, args with
+  | Some schema, `Assoc fields ->
+      let optional_enums = optional_enum_fields schema in
+      if optional_enums = [] then args
+      else
+        `Assoc
+          (List.filter
+             (fun (key, value) ->
+               match value with
+               | `String raw
+                 when List.mem key optional_enums && String.trim raw = "" ->
+                   false
+               | _ -> true)
+             fields)
+  | _ -> args
+
+let prepare_args ?schema ~name args =
   let args = strip_internal_marker_args args in
-  if String.equal name "masc_transition" then normalize_transition_args args
-  else args
+  let args =
+    if String.equal name "masc_transition" then normalize_transition_args args
+    else args
+  in
+  normalize_blank_optional_enum_args ?schema args
 
 let register_pre_hook () =
   let lookup name =
@@ -83,7 +129,8 @@ let register_pre_hook () =
   in
   let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
   Tool_dispatch.register_pre_hook (fun ~name ~args ->
-    let prepared_args = prepare_args ~name args in
+    let schema = Tool_dispatch.lookup_schema name in
+    let prepared_args = prepare_args ?schema ~name args in
     match hook ~name ~args:prepared_args with
     | Agent_sdk.Tool_middleware.Pass
       when not (Yojson.Safe.equal prepared_args args) ->

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -353,6 +353,9 @@ let find_schema_exn name schemas =
 let masc_transition_schema =
   find_schema_exn "masc_transition" Tool_task_schemas.schemas
 
+let masc_goal_list_schema =
+  find_schema_exn "masc_goal_list" Tool_schemas_coord_extra.schemas
+
 let assoc_string key json =
   match Yojson.Safe.Util.member key json with
   | `String value -> value
@@ -428,6 +431,73 @@ let test_registered_hook_transition_strips_internal_agent_marker () =
   Alcotest.(check string) "agent_name preserved" "codex-local-admin"
     (assoc_string "agent_name" forwarded)
 
+let test_registered_hook_goal_list_strips_blank_optional_enums () =
+  let args =
+    `Assoc
+      [
+        ("horizon", `String "");
+        ("phase", `String " ");
+        ("status", `String "");
+      ]
+  in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:masc_goal_list_schema
+      ~tool_name:"masc_goal_list"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check bool) "horizon removed" true
+    (Yojson.Safe.Util.member "horizon" forwarded = `Null);
+  Alcotest.(check bool) "phase removed" true
+    (Yojson.Safe.Util.member "phase" forwarded = `Null);
+  Alcotest.(check bool) "status removed" true
+    (Yojson.Safe.Util.member "status" forwarded = `Null)
+
+let test_registered_hook_goal_list_preserves_invalid_enum_for_handler () =
+  let args = `Assoc [("horizon", `String "week")] in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:masc_goal_list_schema
+      ~tool_name:"masc_goal_list"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check string) "invalid value preserved for handler validation" "week"
+    (assoc_string "horizon" forwarded)
+
+let test_registered_hook_required_enum_blank_is_not_stripped () =
+  let schema =
+    `Assoc
+      [
+        ("type", `String "object");
+        ( "properties",
+          `Assoc
+            [
+              ( "mode",
+                `Assoc
+                  [
+                    ("type", `String "string");
+                    ("enum", `List [ `String "strict"; `String "lenient" ]);
+                  ] );
+            ] );
+        ("required", `List [ `String "mode" ]);
+      ]
+  in
+  let args = `Assoc [("mode", `String "")] in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema
+      ~tool_name:"__tool_input_validation_required_enum_blank"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check string) "required blank preserved for handler validation" ""
+    (assoc_string "mode" forwarded)
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -476,5 +546,11 @@ let () =
         test_registered_hook_transition_compat_status_action;
       Alcotest.test_case "masc_transition strips internal markers" `Quick
         test_registered_hook_transition_strips_internal_agent_marker;
+      Alcotest.test_case "masc_goal_list strips blank optional enum filters"
+        `Quick test_registered_hook_goal_list_strips_blank_optional_enums;
+      Alcotest.test_case "masc_goal_list preserves invalid enum filters" `Quick
+        test_registered_hook_goal_list_preserves_invalid_enum_for_handler;
+      Alcotest.test_case "required enum blanks are not stripped" `Quick
+        test_registered_hook_required_enum_blank_is_not_stripped;
     ]);
   ]


### PR DESCRIPTION
## Summary

- normalize blank string values for optional enum-valued tool inputs before OAS/MCP input validation
- preserve required enum blanks and invalid nonblank enum values for the downstream handler's existing validation instead of silently omitting them
- add registered pre-hook regression coverage for masc_goal_list blank filters

## Root cause

Live MCP calls such as masc_goal_list with horizon/phase/status set to empty strings can fail when blank strings reach the Goal handler as explicit enum values. This boundary normalization treats optional enum blanks as omitted, which matches the handler's intended optional-filter semantics while leaving nonblank values to the existing handler-level validation.

## Validation

- scripts/dune-local.sh build test/test_tool_input_validation.exe
- ./_build/default/test/test_tool_input_validation.exe
  - 28 tests run; all passed
- GitHub checks are expected to re-run after the amended push. Previous head had CI Gate, PR Live Gate, and fundamental guards passing while Build and Test/Lint were path-filter skipped.
