### PR TITLE
fix(keeper): allow first contract retry after slot phase

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -371,11 +371,16 @@ let next_fail_open_cascade_for_turn_with_budget
   | Some retry ->
       (* The candidate is always a retry, so use per-attempt budget semantics
          regardless of whether the current attempt was itself a retry. *)
+      let first_contract_rotation =
+        EC.is_required_tool_contract_violation err
+        && List.length attempted_cascades <= 1
+      in
       if
         match time_spent_in_turn_s with
         | Some time_spent_in_turn_s ->
             (not (degraded_retry_slot_phase_available ~time_spent_in_turn_s))
             && not (degraded_retry_bypasses_slot_phase_guard err)
+            && not first_contract_rotation
         | None -> false
       then Degraded_retry_slot_phase_exhausted retry
       else if

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5964,7 +5964,7 @@ let test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery () =
       fail "expected retry budget to remain"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
 
-let test_degraded_retry_slot_phase_blocks_contract_rotation () =
+let test_degraded_retry_slot_phase_allows_first_contract_rotation () =
   match
     UT.next_fail_open_cascade_for_turn_with_budget
       ~base_cascade:KC.default_cascade_name
@@ -5977,15 +5977,15 @@ let test_degraded_retry_slot_phase_blocks_contract_rotation () =
       ~remaining_turn_budget_s:1200.0
       (required_tool_contract_violation_error ())
   with
-  | UT.Degraded_retry_slot_phase_exhausted retry ->
+  | UT.Degraded_retry_allowed retry ->
       check string "retry cascade candidate" KC.default_cascade_name
         retry.next_cascade;
       check string "fallback reason" "required_tool_contract_violation"
         retry.fallback_reason
-  | UT.Degraded_retry_allowed _ ->
-      fail "expected contract rotation blocked after productive slot phase"
+  | UT.Degraded_retry_slot_phase_exhausted _ ->
+      fail "expected first contract rotation to bypass productive slot phase"
   | UT.Degraded_retry_budget_exhausted _ ->
-      fail "expected slot phase exhaustion before retry budget exhaustion"
+      fail "expected retry budget to remain"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
 
 (* Regression: GitHub #12675 / RFC #12887 — per-attempt retry budget cap.
@@ -8329,8 +8329,9 @@ let () =
             test_degraded_retry_budget_gate_blocks_exhausted_budget;
           test_case "OAS timeout budget can still rotate to local recovery after slot phase" `Quick
             test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery;
-          test_case "contract retry is blocked after productive slot phase (#12888)" `Quick
-            test_degraded_retry_slot_phase_blocks_contract_rotation;
+          test_case "contract retry gets first rotation after slot phase (#12888)"
+            `Quick
+            test_degraded_retry_slot_phase_allows_first_contract_rotation;
           test_case "per-attempt retry budget with near-zero remaining (#12675)" `Quick
             test_per_attempt_retry_budget_with_near_zero_remaining;
           test_case "per-attempt retry budget capped by healthy remaining" `Quick


### PR DESCRIPTION
## Summary
- lets the first required-tool contract retry bypass the productive slot-phase guard
- keeps the existing rotation cap so repeated contract violations still stop after one rotation
- updates the retry-budget regression to match the intended one-rotation policy

## Why it matters
Live scheduled Keeper evidence showed required-tool contract violations were classified as recoverable, but the productive slot-phase guard rejected the first degraded retry after slow first attempts. That left scheduled autonomous cycles terminal even though the rotation cap already prevents repeated retry chains.

This change preserves the #12888 protection against runaway rotations while letting the first corrective cascade actually run.

## Verification
- `git diff --check origin/main..HEAD`
- `env DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_unified.exe`
- `_build/default/test/test_keeper_unified.exe test --show-errors transient_network_error`
- `_build/default/test/test_keeper_unified.exe test --show-errors phase_gate`

Related: #13534