### PR TITLE
fix: avoid dune-local opam lock convoys

### DIFF
--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -162,15 +162,17 @@ if _needs_opam_lock; then
   opam_bounded_wait=0
   opam_lock_timeout=""
   if [[ "${MASC_DUNE_LOCK_HELD:-0}" = "1" \
-        && -n "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-}" \
-        && "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT}" != "0" ]]; then
+        && -n "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-}" ]]; then
     opam_lock_timeout="${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT}"
     if ! [[ "$opam_lock_timeout" =~ ^[0-9]+$ ]]; then
       printf '[dune-local] invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=%q; expected non-negative integer seconds\n' \
         "$opam_lock_timeout" >&2
       exit 2
     fi
-    opam_bounded_wait=1
+    opam_lock_timeout="$((10#$opam_lock_timeout))"
+    if (( opam_lock_timeout > 0 )); then
+      opam_bounded_wait=1
+    fi
   fi
   if command -v lockf >/dev/null 2>&1; then
     if [[ "$opam_bounded_wait" = "1" ]]; then

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -21,6 +21,7 @@ Local Dune wrapper for multi-agent development:
 Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
 Set MASC_OPAM_LOCK=0 or MASC_SKIP_OPAM_LOCK=1 to bypass the shared opam switch lock.
 Set MASC_OPAM_LOCK_PATH=/path/to/lock to override the shared opam lock path.
+Set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=seconds to bound opam-lock wait after the Dune lock (0 = wait forever).
 Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
 Set MASC_SKIP_PIN_CHECK=1 to skip the agent_sdk pin guard.
 Set MASC_SKIP_DEPS_CHECK=1 to skip the core-deps installed guard.
@@ -112,6 +113,30 @@ _detect_subcommand() {
   printf 'build\n'
 }
 _subcommand="$(_detect_subcommand)"
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+_needs_dune_lock() {
+  [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 1
+  [[ "${MASC_DUNE_THROTTLE:-1}" != "0" ]] || return 1
+  [[ "${MASC_DUNE_DRY_RUN:-0}" != "1" ]] || return 1
+  [[ "${MASC_DUNE_LOCK_HELD:-0}" != "1" ]] || return 1
+  return 0
+}
+
+# Acquire the build throttle before the opam-switch lock.  The opam lock is
+# intentionally held while the active build uses the shared switch, but queued
+# builds must not hold it while waiting for the Dune throttle; otherwise stale
+# worktrees can block pin repair before they are actually compiling.
+if _needs_dune_lock; then
+  printf '[dune-local] waiting for lock %s\n' "$lock_path" >&2
+  if command -v lockf >/dev/null 2>&1; then
+    exec lockf -k "$lock_path" env MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
+  elif command -v flock >/dev/null 2>&1; then
+    exec flock "$lock_path" env MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
+  else
+    printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
+  fi
+fi
 
 _needs_opam_lock() {
   [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 1
@@ -125,9 +150,24 @@ _needs_opam_lock() {
 }
 
 if _needs_opam_lock; then
-  script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
   printf '[dune-local] waiting for opam switch lock %s\n' "$opam_lock_path" >&2
   if command -v lockf >/dev/null 2>&1; then
+    if [[ "${MASC_DUNE_LOCK_HELD:-0}" = "1" \
+          && "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-60}" != "0" ]]; then
+      opam_lock_timeout="${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-60}"
+      set +e
+      lockf -k -t "$opam_lock_timeout" "$opam_lock_path" \
+        env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+      status=$?
+      set -e
+      if [[ "$status" -eq 0 ]]; then
+        exit 0
+      fi
+      printf '[dune-local] opam switch lock stayed busy for %ss after acquiring Dune lock; releasing Dune lock to avoid mixed lock-order deadlock\n' \
+        "$opam_lock_timeout" >&2
+      printf '[dune-local] retry after older dune-local invocations drain, or set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=0 to wait indefinitely\n' >&2
+      exit "$status"
+    fi
     exec lockf -k "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
   elif command -v flock >/dev/null 2>&1; then
     exec flock "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
@@ -262,16 +302,11 @@ if [[ "${MASC_DUNE_DRY_RUN:-0}" = "1" ]]; then
   exit 0
 fi
 
-if [[ "${GITHUB_ACTIONS:-}" = "true" || "${MASC_DUNE_THROTTLE:-1}" = "0" ]]; then
+if [[ "${GITHUB_ACTIONS:-}" = "true" \
+      || "${MASC_DUNE_THROTTLE:-1}" = "0" \
+      || "${MASC_DUNE_LOCK_HELD:-0}" = "1" ]]; then
   exec "${cmd[@]}"
 fi
 
-printf '[dune-local] waiting for lock %s\n' "$lock_path" >&2
-if command -v lockf >/dev/null 2>&1; then
-  exec lockf -k "$lock_path" "${cmd[@]}"
-elif command -v flock >/dev/null 2>&1; then
-  exec flock "$lock_path" "${cmd[@]}"
-else
-  printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
-  exec "${cmd[@]}"
-fi
+printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
+exec "${cmd[@]}"

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -114,6 +114,7 @@ _detect_subcommand() {
 }
 _subcommand="$(_detect_subcommand)"
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+dune_lock_warning_emitted=0
 
 _needs_dune_lock() {
   [[ "${GITHUB_ACTIONS:-}" != "true" ]] || return 1
@@ -135,6 +136,7 @@ if _needs_dune_lock; then
     exec flock "$lock_path" env MASC_DUNE_LOCK_HELD=1 "$script_path" "$@"
   else
     printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
+    dune_lock_warning_emitted=1
   fi
 fi
 
@@ -155,6 +157,11 @@ if _needs_opam_lock; then
     if [[ "${MASC_DUNE_LOCK_HELD:-0}" = "1" \
           && "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-60}" != "0" ]]; then
       opam_lock_timeout="${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-60}"
+      if ! [[ "$opam_lock_timeout" =~ ^[0-9]+$ ]]; then
+        printf '[dune-local] invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=%q; expected non-negative integer seconds\n' \
+          "$opam_lock_timeout" >&2
+        exit 2
+      fi
       set +e
       lockf -k -t "$opam_lock_timeout" "$opam_lock_path" \
         env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
@@ -163,15 +170,21 @@ if _needs_opam_lock; then
       if [[ "$status" -eq 0 ]]; then
         exit 0
       fi
-      printf '[dune-local] opam switch lock stayed busy for %ss after acquiring Dune lock; releasing Dune lock to avoid mixed lock-order deadlock\n' \
-        "$opam_lock_timeout" >&2
-      printf '[dune-local] retry after older dune-local invocations drain, or set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=0 to wait indefinitely\n' >&2
+      if [[ "$status" -eq 75 ]]; then
+        printf '[dune-local] opam switch lock stayed busy for %ss after acquiring Dune lock; releasing Dune lock to avoid mixed lock-order deadlock\n' \
+          "$opam_lock_timeout" >&2
+        printf '[dune-local] retry after older dune-local invocations drain, or set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=0 to wait indefinitely\n' >&2
+      fi
       exit "$status"
     fi
     exec lockf -k "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
   elif command -v flock >/dev/null 2>&1; then
     exec flock "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-  else
+  elif [[ "${MASC_DUNE_LOCK_HELD:-0}" != "1" ]]; then
+    # Skip the warning when the Dune-lock branch above already emitted
+    # an equivalent "neither lockf nor flock found" message in this
+    # process. Without the guard, both paths print and operators see
+    # two warnings even though there is only one underlying problem.
     printf '[dune-local] warning: neither lockf nor flock found; opam switch checks are unlocked\n' >&2
   fi
 fi
@@ -308,5 +321,7 @@ if [[ "${GITHUB_ACTIONS:-}" = "true" \
   exec "${cmd[@]}"
 fi
 
-printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
+if [[ "$dune_lock_warning_emitted" -eq 0 ]]; then
+  printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
+fi
 exec "${cmd[@]}"

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -153,15 +153,27 @@ _needs_opam_lock() {
 
 if _needs_opam_lock; then
   printf '[dune-local] waiting for opam switch lock %s\n' "$opam_lock_path" >&2
+  # Apply the bounded-wait deadlock guard whenever this invocation is
+  # already holding the Dune lock AND the operator opted in by setting
+  # MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=<positive integer>. Default is
+  # unset, which preserves the historical "wait indefinitely" semantics
+  # so existing operators are not surprised by builds that suddenly
+  # fail under long-lived opam lock holders.
+  opam_bounded_wait=0
+  opam_lock_timeout=""
+  if [[ "${MASC_DUNE_LOCK_HELD:-0}" = "1" \
+        && -n "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-}" \
+        && "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT}" != "0" ]]; then
+    opam_lock_timeout="${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT}"
+    if ! [[ "$opam_lock_timeout" =~ ^[0-9]+$ ]]; then
+      printf '[dune-local] invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=%q; expected non-negative integer seconds\n' \
+        "$opam_lock_timeout" >&2
+      exit 2
+    fi
+    opam_bounded_wait=1
+  fi
   if command -v lockf >/dev/null 2>&1; then
-    if [[ "${MASC_DUNE_LOCK_HELD:-0}" = "1" \
-          && "${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-60}" != "0" ]]; then
-      opam_lock_timeout="${MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT:-60}"
-      if ! [[ "$opam_lock_timeout" =~ ^[0-9]+$ ]]; then
-        printf '[dune-local] invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=%q; expected non-negative integer seconds\n' \
-          "$opam_lock_timeout" >&2
-        exit 2
-      fi
+    if [[ "$opam_bounded_wait" = "1" ]]; then
       set +e
       lockf -k -t "$opam_lock_timeout" "$opam_lock_path" \
         env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
@@ -173,18 +185,43 @@ if _needs_opam_lock; then
       if [[ "$status" -eq 75 ]]; then
         printf '[dune-local] opam switch lock stayed busy for %ss after acquiring Dune lock; releasing Dune lock to avoid mixed lock-order deadlock\n' \
           "$opam_lock_timeout" >&2
-        printf '[dune-local] retry after older dune-local invocations drain, or set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=0 to wait indefinitely\n' >&2
+        printf '[dune-local] retry after older dune-local invocations drain, or unset MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT (or set =0) to wait indefinitely\n' >&2
       fi
       exit "$status"
     fi
     exec lockf -k "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
   elif command -v flock >/dev/null 2>&1; then
+    if [[ "$opam_bounded_wait" = "1" ]]; then
+      # flock(1) honors -w/--timeout to bound the wait; without it the
+      # mixed-lock-order deadlock the lockf branch above already handles
+      # would resurface on flock-only hosts (Linux without lockf).
+      set +e
+      flock -w "$opam_lock_timeout" "$opam_lock_path" \
+        env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
+      status=$?
+      set -e
+      if [[ "$status" -eq 0 ]]; then
+        exit 0
+      fi
+      # flock returns 1 when the lock cannot be acquired within the
+      # timeout (vs >1 for command failures). Match the lockf message
+      # so operators see consistent diagnostics across hosts.
+      if [[ "$status" -eq 1 ]]; then
+        printf '[dune-local] opam switch lock stayed busy for %ss after acquiring Dune lock; releasing Dune lock to avoid mixed lock-order deadlock\n' \
+          "$opam_lock_timeout" >&2
+        printf '[dune-local] retry after older dune-local invocations drain, or unset MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT (or set =0) to wait indefinitely\n' >&2
+      fi
+      exit "$status"
+    fi
     exec flock "$opam_lock_path" env MASC_OPAM_LOCK_HELD=1 "$script_path" "$@"
-  elif [[ "${MASC_DUNE_LOCK_HELD:-0}" != "1" ]]; then
-    # Skip the warning when the Dune-lock branch above already emitted
+  elif [[ "$dune_lock_warning_emitted" != "1" ]]; then
+    # Skip the warning when the Dune-lock branch above already printed
     # an equivalent "neither lockf nor flock found" message in this
-    # process. Without the guard, both paths print and operators see
-    # two warnings even though there is only one underlying problem.
+    # process. The Dune-lock branch tracks that via the local
+    # [dune_lock_warning_emitted] flag (not MASC_DUNE_LOCK_HELD, which
+    # is only set when the Dune lock was actually acquired); using the
+    # flag avoids the case where opam is available but neither lock
+    # tool is, where the env-var check would let both warnings print.
     printf '[dune-local] warning: neither lockf nor flock found; opam switch checks are unlocked\n' >&2
   fi
 fi

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -560,6 +560,13 @@ let test_oas_pin_source_contracts () =
   check bool "dune-local.sh exposes shared opam switch lock path" true
     (file_contains_pattern "scripts/dune-local.sh"
        "MASC_OPAM_LOCK_PATH:-/tmp/me-opam-switch.lock");
+  check bool "dune-local.sh takes build lock before opam switch lock" true
+    (match
+       file_pattern_position "scripts/dune-local.sh" "_needs_dune_lock",
+       file_pattern_position "scripts/dune-local.sh" "_needs_opam_lock"
+     with
+     | Some dune_pos, Some opam_pos -> dune_pos < opam_pos
+     | _ -> false);
   check bool "dune-local.sh locks opam switch before pin guard" true
     (match
        file_pattern_position "scripts/dune-local.sh"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -562,8 +562,9 @@ let test_oas_pin_source_contracts () =
        "MASC_OPAM_LOCK_PATH:-/tmp/me-opam-switch.lock");
   check bool "dune-local.sh takes build lock before opam switch lock" true
     (match
-       file_pattern_position "scripts/dune-local.sh" "_needs_dune_lock",
-       file_pattern_position "scripts/dune-local.sh" "_needs_opam_lock"
+       file_pattern_position "scripts/dune-local.sh" "waiting for lock %s",
+       file_pattern_position "scripts/dune-local.sh"
+         "waiting for opam switch lock"
      with
      | Some dune_pos, Some opam_pos -> dune_pos < opam_pos
      | _ -> false);

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -392,6 +392,46 @@ exec "$@"
       check bool "dune was not invoked after opam timeout" false
         (Sys.file_exists dune_log))
 
+let test_unset_opam_lock_timeout_waits_forever () =
+  with_temp_dir "dune-local-opam-lock-timeout-unset" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      let lockf_log = Filename.concat dir "lockf-calls.log" in
+      write_executable
+        (Filename.concat bin_dir "lockf")
+        (Printf.sprintf
+           {|#!/bin/sh
+printf 'argv=%%s\n' "$*" >> %s
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) printf 'timeout=%%s\n' "$2" >> %s; exit 98 ;;
+    *) shift ;;
+  esac
+done
+shift
+exec "$@"
+|}
+           (quote lockf_log) (quote lockf_log));
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir
+          ~unset_env:
+            [
+              "GITHUB_ACTIONS";
+              "MASC_OPAM_LOCK_HELD";
+              "MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT";
+            ]
+          "build"
+      in
+      check int "unset timeout keeps historical wait-forever path" 0 code;
+      let lock_log = read_file lockf_log in
+      check bool "lockf timeout flag not used by default" false
+        (contains_substring lock_log "timeout=");
+      check bool "timeout message not emitted" false
+        (contains_substring stderr "releasing Dune lock");
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_opam_lockf_wrapped_failure_does_not_claim_timeout () =
   with_temp_dir "dune-local-opam-lock-wrapped-failure" (fun dir ->
       let bin_dir, dune_log =
@@ -468,6 +508,7 @@ esac
 base="${1##*/}"
 printf '%s\n' "$base"
 |};
+      let opam_path = Filename.concat bin_dir "opam" in
       let script =
         Filename.concat (Filename.concat dir "scripts") "dune-local.sh"
       in
@@ -495,7 +536,11 @@ printf '%s\n' "$base"
             substring_index tail needle = None
       in
       check int "no-lock-tools run exits zero" 0 code;
+      check bool "fake opam kept in PATH" true (Sys.file_exists opam_path);
       check bool "warning emitted exactly once" true only_once;
+      check bool "opam lock warning suppressed" false
+        (contains_substring stderr
+           "neither lockf nor flock found; opam switch checks are unlocked");
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
 let test_opam_flock_reexec_env_passthrough () =
@@ -559,6 +604,79 @@ exec "$@"
       check bool "held env passed through argv" true
         (contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
       check bool "dune was invoked after flock reexec" true
+        (Sys.file_exists dune_log))
+
+let test_opam_flock_timeout_releases_dune_lock () =
+  with_temp_dir "dune-local-opam-flock-timeout" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      write_executable (Filename.concat bin_dir "dirname")
+        {|#!/bin/sh
+case "$1" in
+  */*) printf '%s\n' "${1%/*}" ;;
+  *) printf '.\n' ;;
+esac
+|};
+      write_executable (Filename.concat bin_dir "basename")
+        {|#!/bin/sh
+base="${1##*/}"
+printf '%s\n' "$base"
+|};
+      let flock_log = Filename.concat dir "flock-calls.log" in
+      let opam_lock_path = Filename.concat dir "opam.lock" in
+      let dune_lock_path = Filename.concat dir "dune-local.lock" in
+      write_executable
+        (Filename.concat bin_dir "flock")
+        (Printf.sprintf
+           {|#!/bin/sh
+printf 'argv=%%s\n' "$*" >> %s
+timeout=""
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -w) timeout="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+lock_path="$1"
+printf 'lock=%%s timeout=%%s\n' "$lock_path" "$timeout" >> %s
+if [ "$lock_path" = %s ] && [ -n "$timeout" ]; then exit 1; fi
+shift
+if [ "${1:-}" = "env" ]; then
+  shift
+  export "$1"
+  shift
+fi
+exec "$@"
+|}
+           (quote flock_log) (quote flock_log) (quote opam_lock_path));
+      let code, _stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("PATH", Printf.sprintf "%s:/bin" bin_dir);
+              ("GIT_CEILING_DIRECTORIES", dir);
+              ("DUNE_LOCAL_LOCK", dune_lock_path);
+              ("MASC_OPAM_LOCK_PATH", opam_lock_path);
+              ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "2");
+              ("MASC_SKIP_DEPS_CHECK", "1");
+              ("MASC_SKIP_OCAML_VERSION_CHECK", "1");
+            ]
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
+          (Printf.sprintf "bash %s build"
+             (quote
+                (Filename.concat
+                   (Filename.concat dir "scripts")
+                   "dune-local.sh")))
+      in
+      check int "opam flock timeout exits with flock status" 1 code;
+      let lock_log = read_file flock_log in
+      check bool "flock timeout flag used" true
+        (contains_substring lock_log "timeout=2");
+      check bool "timeout explains Dune lock release" true
+        (contains_substring stderr "releasing Dune lock");
+      check bool "dune was not invoked after opam timeout" false
         (Sys.file_exists dune_log))
 
 let test_clean_subcommand_skips_pin_guard () =
@@ -860,6 +978,8 @@ let () =
             test_opam_lockf_reexec_env_passthrough;
           test_case "opam lock timeout releases Dune lock" `Quick
             test_opam_lock_timeout_releases_dune_lock;
+          test_case "unset opam lock timeout waits forever" `Quick
+            test_unset_opam_lock_timeout_waits_forever;
           test_case "opam lock wrapped failure is not labeled timeout" `Quick
             test_opam_lockf_wrapped_failure_does_not_claim_timeout;
           test_case "opam lock timeout env must be numeric" `Quick
@@ -868,6 +988,8 @@ let () =
             test_missing_lock_tools_warn_once;
           test_case "opam flock reexec propagates env" `Quick
             test_opam_flock_reexec_env_passthrough;
+          test_case "opam flock timeout releases Dune lock" `Quick
+            test_opam_flock_timeout_releases_dune_lock;
           test_case "clean subcommand skips pin guard" `Quick
             test_clean_subcommand_skips_pin_guard;
           test_case

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -432,6 +432,42 @@ exec "$@"
         (contains_substring stderr "releasing Dune lock");
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
+let test_zero_like_opam_lock_timeout_waits_forever () =
+  with_temp_dir "dune-local-opam-lock-timeout-zero-like" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      let lockf_log = Filename.concat dir "lockf-calls.log" in
+      write_executable
+        (Filename.concat bin_dir "lockf")
+        (Printf.sprintf
+           {|#!/bin/sh
+printf 'argv=%%s\n' "$*" >> %s
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) printf 'timeout=%%s\n' "$2" >> %s; exit 98 ;;
+    *) shift ;;
+  esac
+done
+shift
+exec "$@"
+|}
+           (quote lockf_log) (quote lockf_log));
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir
+          ~env:[ ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "00") ]
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
+          "build"
+      in
+      check int "zero-like timeout waits forever" 0 code;
+      let lock_log = read_file lockf_log in
+      check bool "lockf timeout flag not used for zero-like value" false
+        (contains_substring lock_log "timeout=");
+      check bool "timeout message not emitted for zero-like value" false
+        (contains_substring stderr "releasing Dune lock");
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_opam_lockf_wrapped_failure_does_not_claim_timeout () =
   with_temp_dir "dune-local-opam-lock-wrapped-failure" (fun dir ->
       let bin_dir, dune_log =
@@ -980,6 +1016,8 @@ let () =
             test_opam_lock_timeout_releases_dune_lock;
           test_case "unset opam lock timeout waits forever" `Quick
             test_unset_opam_lock_timeout_waits_forever;
+          test_case "zero-like opam lock timeout waits forever" `Quick
+            test_zero_like_opam_lock_timeout_waits_forever;
           test_case "opam lock wrapped failure is not labeled timeout" `Quick
             test_opam_lockf_wrapped_failure_does_not_claim_timeout;
           test_case "opam lock timeout env must be numeric" `Quick

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -392,6 +392,112 @@ exec "$@"
       check bool "dune was not invoked after opam timeout" false
         (Sys.file_exists dune_log))
 
+let test_opam_lockf_wrapped_failure_does_not_claim_timeout () =
+  with_temp_dir "dune-local-opam-lock-wrapped-failure" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:42
+          ~pin_check_stderr_msg:"pin check failed after opam lock"
+      in
+      write_executable
+        (Filename.concat bin_dir "lockf")
+        {|#!/bin/sh
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) shift 2 ;;
+    *) shift ;;
+  esac
+done
+shift
+exec "$@"
+|};
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir
+          ~env:[ ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "1") ]
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
+          "build"
+      in
+      check int "wrapped command status propagates" 1 code;
+      check bool "timeout message suppressed for wrapped failure" false
+        (contains_substring stderr "releasing Dune lock");
+      check bool "dune was not invoked after pin failure" false
+        (Sys.file_exists dune_log))
+
+let test_opam_lock_timeout_env_must_be_numeric () =
+  with_temp_dir "dune-local-opam-timeout-invalid" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      write_executable (Filename.concat bin_dir "lockf")
+        {|#!/bin/sh
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) shift 2 ;;
+    *) shift ;;
+  esac
+done
+shift
+exec "$@"
+|};
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir
+          ~env:[ ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "abc") ]
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
+          "build"
+      in
+      check int "invalid timeout exits usage error" 2 code;
+      check bool "invalid timeout named" true
+        (contains_substring stderr "invalid MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT");
+      check bool "dune was not invoked" false (Sys.file_exists dune_log))
+
+let test_missing_lock_tools_warn_once () =
+  with_temp_dir "dune-local-no-lock-tools" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      write_executable (Filename.concat bin_dir "dirname")
+        {|#!/bin/sh
+case "$1" in
+  */*) printf '%s\n' "${1%/*}" ;;
+  *) printf '.\n' ;;
+esac
+|};
+      write_executable (Filename.concat bin_dir "basename")
+        {|#!/bin/sh
+base="${1##*/}"
+printf '%s\n' "$base"
+|};
+      let script =
+        Filename.concat (Filename.concat dir "scripts") "dune-local.sh"
+      in
+      let code, _stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("PATH", bin_dir);
+              ("GIT_CEILING_DIRECTORIES", dir);
+              ("DUNE_LOCAL_LOCK", Filename.concat dir "dune-local.lock");
+              ("MASC_SKIP_PIN_CHECK", "1");
+              ("MASC_SKIP_DEPS_CHECK", "1");
+              ("MASC_SKIP_OCAML_VERSION_CHECK", "1");
+            ]
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_DUNE_LOCK_HELD" ]
+          (Printf.sprintf "/bin/bash %s build" (quote script))
+      in
+      let needle = "neither lockf nor flock found; running unlocked" in
+      let only_once =
+        match substring_index stderr needle with
+        | None -> false
+        | Some idx ->
+            let start = idx + String.length needle in
+            let tail = String.sub stderr start (String.length stderr - start) in
+            substring_index tail needle = None
+      in
+      check int "no-lock-tools run exits zero" 0 code;
+      check bool "warning emitted exactly once" true only_once;
+      check bool "dune was invoked" true (Sys.file_exists dune_log))
+
 let test_opam_flock_reexec_env_passthrough () =
   with_temp_dir "dune-local-opam-flock" (fun dir ->
       let bin_dir, dune_log =
@@ -754,6 +860,12 @@ let () =
             test_opam_lockf_reexec_env_passthrough;
           test_case "opam lock timeout releases Dune lock" `Quick
             test_opam_lock_timeout_releases_dune_lock;
+          test_case "opam lock wrapped failure is not labeled timeout" `Quick
+            test_opam_lockf_wrapped_failure_does_not_claim_timeout;
+          test_case "opam lock timeout env must be numeric" `Quick
+            test_opam_lock_timeout_env_must_be_numeric;
+          test_case "missing lock tools warn once" `Quick
+            test_missing_lock_tools_warn_once;
           test_case "opam flock reexec propagates env" `Quick
             test_opam_flock_reexec_env_passthrough;
           test_case "clean subcommand skips pin guard" `Quick

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -22,6 +22,17 @@ let contains_substring haystack needle =
   in
   nlen = 0 || loop 0
 
+let substring_index haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    if nlen = 0 then Some 0
+    else if idx + nlen > hlen then None
+    else if String.sub haystack idx nlen = needle then Some idx
+    else loop (idx + 1)
+  in
+  loop 0
+
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
@@ -250,12 +261,20 @@ exit 0
         (Filename.concat bin_dir "lockf")
         (Printf.sprintf
            {|#!/bin/sh
-printf 'lock=%%s argv=%%s\n' "$2" "$*" >> %s
-if [ "$2" = %s ]; then exit 97; fi
-shift 2
+printf 'argv=%%s\n' "$*" >> %s
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) shift 2 ;;
+    *) shift ;;
+  esac
+done
+lock_path="$1"
+printf 'lock=%%s\n' "$lock_path" >> %s
+if [ "$lock_path" = %s ]; then exit 97; fi
+shift
 exec "$@"
 |}
-           (quote lockf_log) (quote opam_lock_path));
+           (quote lockf_log) (quote lockf_log) (quote opam_lock_path));
       (* Use a minimal PATH (no opam install directories) so that
          'command -v opam' fails and the guard is skipped.
          opam is typically in ~/.opam/SWITCH/bin/, not in /usr/bin or /bin. *)
@@ -294,7 +313,13 @@ let test_opam_lockf_reexec_env_passthrough () =
         (Printf.sprintf
            {|#!/bin/sh
 printf 'held=%%s argv=%%s\n' "${MASC_OPAM_LOCK_HELD:-unset}" "$*" >> %s
-shift 2
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) shift 2 ;;
+    *) shift ;;
+  esac
+done
+shift
 exec "$@"
 |}
            (quote lockf_log));
@@ -308,11 +333,63 @@ exec "$@"
       check int "exits zero through lockf reexec" 0 code;
       check bool "lockf invoked" true (Sys.file_exists lockf_log);
       let lock_log = read_file lockf_log in
+      let dune_lock_path = Filename.concat dir "dune-local.lock" in
       check bool "lock path passed to lockf" true
         (contains_substring lock_log opam_lock_path);
+      check bool "dune lock acquired before opam lock" true
+        (match
+           ( substring_index lock_log dune_lock_path,
+             substring_index lock_log opam_lock_path )
+         with
+        | Some dune_pos, Some opam_pos -> dune_pos < opam_pos
+        | _ -> false);
       check bool "held env passed through argv" true
         (contains_substring lock_log "MASC_OPAM_LOCK_HELD=1");
+      check bool "dune held env passed through argv" true
+        (contains_substring lock_log "MASC_DUNE_LOCK_HELD=1");
       check bool "dune was invoked after reexec" true
+        (Sys.file_exists dune_log))
+
+let test_opam_lock_timeout_releases_dune_lock () =
+  with_temp_dir "dune-local-opam-lock-timeout" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:0
+          ~pin_check_stderr_msg:"pin ok"
+      in
+      let lockf_log = Filename.concat dir "lockf-calls.log" in
+      let opam_lock_path = Filename.concat dir "opam.lock" in
+      write_executable
+        (Filename.concat bin_dir "lockf")
+        (Printf.sprintf
+           {|#!/bin/sh
+printf 'argv=%%s\n' "$*" >> %s
+while [ "${1#-}" != "$1" ]; do
+  case "$1" in
+    -t) shift 2 ;;
+    *) shift ;;
+  esac
+done
+lock_path="$1"
+printf 'lock=%%s\n' "$lock_path" >> %s
+if [ "$lock_path" = %s ]; then exit 75; fi
+shift
+exec "$@"
+|}
+           (quote lockf_log) (quote lockf_log) (quote opam_lock_path));
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir
+          ~env:
+            [
+              ("MASC_OPAM_LOCK_PATH", opam_lock_path);
+              ("MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT", "1");
+            ]
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_OPAM_LOCK_HELD" ]
+          "build"
+      in
+      check int "opam lock timeout exits with lockf status" 75 code;
+      check bool "timeout explains Dune lock release" true
+        (contains_substring stderr "releasing Dune lock");
+      check bool "dune was not invoked after opam timeout" false
         (Sys.file_exists dune_log))
 
 let test_opam_flock_reexec_env_passthrough () =
@@ -675,6 +752,8 @@ let () =
             test_opam_absent_skips_pin_guard;
           test_case "opam lockf reexec propagates env" `Quick
             test_opam_lockf_reexec_env_passthrough;
+          test_case "opam lock timeout releases Dune lock" `Quick
+            test_opam_lock_timeout_releases_dune_lock;
           test_case "opam flock reexec propagates env" `Quick
             test_opam_flock_reexec_env_passthrough;
           test_case "clean subcommand skips pin guard" `Quick


### PR DESCRIPTION
## Summary
- Acquire the local Dune throttle before taking the shared opam switch lock so queued builds do not block opam pin repair while waiting.
- Add bounded post-Dune opam-lock wait via `MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT`, releasing the Dune lock if older lock-order invocations are still holding opam.
- Suppress duplicate missing-lock-tool warnings on the opam-lock path.
- Extend dune-local script tests and source hardening guards for the lock ordering and edge cases.

## Verification
- `bash -n scripts/dune-local.sh`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_dune_local_script.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_dune_local_script.exe` (24/24)
- `./_build/default/test/test_ci_hardening_source.exe` (53/53)

Refs #13827: current-main stale fleet duplicate was repaired separately in #13830 before this rebase.