### PR TITLE
fix(keeper): persist lifecycle callback gaps

### DIFF
--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -111,11 +111,8 @@ proceed_with_compaction ()
  with
  | Eio.Cancel.Cancelled _ as e -> raise e
  | exn ->
-     Prometheus.inc_counter
-       Prometheus.metric_keeper_lifecycle_callback_failures
-       ~labels:[("callback", "on_compaction_started")] ();
-     Log.Keeper.warn "callback on_compaction_started raised: %s"
-       (Printexc.to_string exn));
+     Keeper_callback_failure.record ~base_dir ~meta
+       ~callback:"on_compaction_started" exn);
 proceed_with_compaction ()
 ```
 

--- a/lib/keeper/keeper_callback_failure.ml
+++ b/lib/keeper/keeper_callback_failure.ml
@@ -1,0 +1,36 @@
+(** Durable visibility for lifecycle callback failures. *)
+
+let source = "keeper_lifecycle_callback"
+let durable_store = "keeper_lifecycle_events"
+let dashboard_surface = "keeper_lifecycle"
+let stale_reason = "callback_exception"
+
+let record ~(base_dir : string) ~(meta : Keeper_types.keeper_meta)
+    ~(callback : string) exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ ->
+    let error = Printexc.to_string exn in
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_lifecycle_callback_failures
+      ~labels:[("callback", callback)] ();
+    Log.Keeper.warn "keeper:%s lifecycle callback %s raised: %s"
+      meta.name callback error;
+    try
+      Telemetry_coverage_gap.record
+        ~masc_root:base_dir
+        ~source
+        ~producer:callback
+        ~durable_store
+        ~dashboard_surface
+        ~stale_reason
+        ~keeper_name:meta.name
+        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+        ~error
+        ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | gap_exn ->
+      Log.Keeper.warn
+        "keeper:%s lifecycle callback %s coverage-gap record failed: %s"
+        meta.name callback (Printexc.to_string gap_exn)

--- a/lib/keeper/keeper_callback_failure.mli
+++ b/lib/keeper/keeper_callback_failure.mli
@@ -1,0 +1,14 @@
+(** Keeper lifecycle callback failure recorder.
+
+    Lifecycle callbacks are non-critical side effects: failure must not
+    abort compaction or handoff, but it must be observable as a metric,
+    log, and durable telemetry coverage gap. *)
+
+val record :
+  base_dir:string ->
+  meta:Keeper_types.keeper_meta ->
+  callback:string ->
+  exn ->
+  unit
+(** Record one lifecycle callback failure. Re-raises
+    [Eio.Cancel.Cancelled] to preserve cooperative cancellation. *)

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -521,23 +521,19 @@ let apply_post_turn_lifecycle_with_resilience_handles
              entry mismatches. The naked invocation here used to abort
              the whole post-turn lifecycle on any callback exception
              without surfacing the cause; failures now increment the
-             [callback=on_compaction_started] counter and log a warn,
-             but the lifecycle continues so a downstream save error
-             still wins the failure_reason field. See
+             [callback=on_compaction_started] counter, log a warn, and
+             write a telemetry coverage-gap row, but the lifecycle
+             continues so a downstream save error still wins the
+             failure_reason field. See
              docs/architecture/actor-mailbox-pattern.md for the
              reasoning behind the keep-going-on-callback-failure
              policy. *)
           let () =
             try on_compaction_started ()
             with
-            | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
-                Prometheus.inc_counter
-                  Prometheus.metric_keeper_lifecycle_callback_failures
-                  ~labels:[("callback", "on_compaction_started")] ();
-                Log.Keeper.warn
-                  "keeper:%s post-turn on_compaction_started raised: %s"
-                  base_meta.name (Printexc.to_string exn)
+                Keeper_callback_failure.record ~base_dir ~meta:base_meta
+                  ~callback:"on_compaction_started" exn
           in
           let session =
             create_session ~session_id:(Keeper_id.Trace_id.to_string base_meta.runtime.trace_id) ~base_dir

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -225,18 +225,13 @@ let maybe_rollover_oas_handoff
            keep-going-on-callback-failure. The handoff path mirrors
            the compaction path so the operator counter aggregates a
            single fleet-wide invariant: any lifecycle callback that
-           can't reach the registry must surface as a counter+warn,
-           never silently abort the rollover. *)
+           can't reach the registry must surface as a counter+warn and
+           durable telemetry gap, never silently abort the rollover. *)
         (try on_started ()
          with
-         | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
-             Prometheus.inc_counter
-               Prometheus.metric_keeper_lifecycle_callback_failures
-               ~labels:[("callback", "on_handoff_started")] ();
-             Log.Keeper.warn
-               "keeper:%s rollover on_started raised: %s"
-               base_meta.name (Printexc.to_string exn));
+             Keeper_callback_failure.record ~base_dir ~meta:base_meta
+               ~callback:"on_handoff_started" exn);
         (try
           let new_session =
             create_session ~session_id:new_trace_id ~base_dir

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -630,8 +630,10 @@ val metric_keeper_lifecycle_transitions : string
 val metric_fsm_guard_violation : string
 
 (** Keeper callback failures that would otherwise look like missing
-    lifecycle, SSE, tool-call-log, or action-metric rows. Labels:
-    [callback] plus optional [keeper] at per-keeper OAS hook sites.
+    lifecycle, SSE, tool-call-log, or action-metric rows. Lifecycle
+    callback failures also write a durable [telemetry_coverage_gap]
+    row through [Keeper_callback_failure.record]. Labels: [callback]
+    plus optional [keeper] at per-keeper OAS hook sites.
 
     Lifecycle-only labels:
     - [on_compaction_started] — fired from

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -9,6 +9,8 @@ module KR = Masc_mcp.Keeper_registry
 module KHS = Masc_mcp.Keeper_keepalive_signal
 module KST = Masc_mcp.Keeper_state_machine
 module KCB = Masc_mcp.Keeper_turn_cascade_budget
+module P = Masc_mcp.Prometheus
+module TCG = Masc_mcp.Telemetry_coverage_gap
 
 let ctx_messages = KEC.messages_of_context
 let ctx_system_prompt = KEC.system_prompt_of_context
@@ -326,6 +328,85 @@ let test_apply_post_turn_lifecycle_compacts_and_updates_continuity () =
           check bool "compacted checkpoint persisted" true
             (List.length (ctx_messages loaded) < _original_message_count)
       | None -> fail "expected compacted checkpoint to be persisted")
+
+let test_compaction_callback_failure_records_coverage_gap () =
+  let base_dir = temp_dir "keeper_lifecycle_callback_gap" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let meta =
+        let base =
+          make_keeper_meta ~name:"callback-gap-keeper"
+            ~trace_id:"trace-callback-gap" ()
+        in
+        {
+          base with
+          auto_handoff = false;
+          compaction =
+            {
+              base.compaction with
+              ratio_gate = 0.0;
+              message_gate = 2;
+              token_gate = 1;
+              cooldown_sec = 0;
+            };
+        }
+      in
+      let checkpoint =
+        save_checkpoint ~base_dir ~meta
+          ~ctx:
+            (build_dense_context ~turns:24 ~max_tokens:320
+               ~state_reply:"ready")
+      in
+      let labels = [ ("callback", "on_compaction_started") ] in
+      let before =
+        P.metric_value_or_zero
+          P.metric_keeper_lifecycle_callback_failures
+          ~labels
+          ()
+      in
+      let lifecycle =
+        KEC.apply_post_turn_lifecycle
+          ~on_handoff_started:(fun () -> ())
+          ~base_dir ~meta
+          ~on_compaction_started:(fun () ->
+            failwith "synthetic callback failure")
+          ~model:"llama:auto"
+          ~primary_model_max_tokens:320
+          ~current_turn_overflow_blocker:None
+          ~checkpoint:(Some checkpoint)
+      in
+      check bool "compaction still applied" true
+        lifecycle.compaction.applied;
+      check (option string) "compaction no failure" None
+        lifecycle.compaction.failure_reason;
+      check (float 0.0001) "callback failure metric increments"
+        (before +. 1.0)
+        (P.metric_value_or_zero
+           P.metric_keeper_lifecycle_callback_failures
+           ~labels
+           ());
+      match TCG.read_recent ~masc_root:base_dir ~n:1 with
+      | [ row ] ->
+        let open Yojson.Safe.Util in
+        check string "gap source" "keeper_lifecycle_callback"
+          (row |> member "source" |> to_string);
+        check string "gap producer" "on_compaction_started"
+          (row |> member "producer" |> to_string);
+        check string "gap reason" "callback_exception"
+          (row |> member "stale_reason" |> to_string);
+        check string "gap keeper" "callback-gap-keeper"
+          (row |> member "keeper_name" |> to_string);
+        check string "gap trace" "trace-callback-gap"
+          (row |> member "trace_id" |> to_string);
+        check bool "gap error recorded" true
+          (contains_substring
+             (row |> member "error" |> to_string)
+             "synthetic callback failure")
+      | _ -> fail "expected one telemetry coverage gap row")
 
 let test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips () =
   let base_dir = temp_dir "keeper_lifecycle_skip_compaction" in
@@ -2408,6 +2489,8 @@ let () =
             test_load_context_prefers_live_primary_max_tokens_over_checkpoint_limit;
           test_case "compaction persists checkpoint and continuity" `Quick
             test_apply_post_turn_lifecycle_compacts_and_updates_continuity;
+          test_case "compaction callback failure records coverage gap" `Quick
+            test_compaction_callback_failure_records_coverage_gap;
           test_case "skip compaction keeps checkpoint" `Quick
             test_apply_post_turn_lifecycle_keeps_checkpoint_when_compaction_skips;
           test_case "handoff runs after compaction" `Quick


### PR DESCRIPTION
## Summary

- add `Keeper_callback_failure.record` so lifecycle callback exceptions emit the existing Prometheus counter, a warning, and a durable `telemetry_coverage_gap` row
- route compaction and handoff lifecycle callback failures through the shared recorder while preserving cancellation behavior and keep-going lifecycle policy
- add regression coverage proving compaction and handoff still continue while recording durable gap rows when lifecycle callbacks raise

## Why It Matters

Lifecycle callback failures used to be visible only as the counter/log path. Operators could still see compaction succeed, but durable telemetry had no row explaining why the lifecycle callback side effect disappeared. This makes the failure auditable in the same coverage-gap surface used for other trusted telemetry drops.

## Validation

- `git diff --check origin/main..HEAD`
- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle.exe`
- `./_build/default/test/test_keeper_lifecycle.exe` (50 tests)
