### PR TITLE
docs(goal-loop): mark dashboard audit rows wired

### DIFF
--- a/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
+++ b/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
@@ -252,8 +252,8 @@
   `blocking_future_date_claims_total=3`, and
   `source_currentness_current=false`. The
   checklist maps all 21 prompt requirements to concrete artifacts and blockers
-  across all 12 prompt source documents: 5 `PASS`, 14 `PARTIAL`, and 2
-  `BLOCKED` requirements, with all 16 non-PASS rows carrying valid GitHub issue
+  across all 12 prompt source documents: 7 `PASS`, 12 `PARTIAL`, and 2
+  `BLOCKED` requirements, with all 14 non-PASS rows carrying valid GitHub issue
   tracking refs. The prompt checklist also validates that all `artifact_refs`
   resolve to repo-local files after optional `#...` anchors are stripped; user
   local paths, path escapes, and missing artifact files make the checklist
@@ -274,17 +274,18 @@
   `prompt_requirements_closeout_complete`. The first blocker proves the real
   strict 206-row corpus is still missing. The second blocker prevents the
   prompt objective from being marked complete while the recorded checklist
-  still has 14 `PARTIAL` and 2 `BLOCKED` prompt requirements. The
+  still has 12 `PARTIAL` and 2 `BLOCKED` prompt requirements. The
   `prompt_to_artifact_checklist_recorded` criterion remains `PASS`, with 21
-  unique requirement IDs, 12 unique issue refs, and no missing or invalid
+  unique requirement IDs, 11 unique issue refs, and no missing or invalid
   tracking refs; recording the map is separate from satisfying every mapped
   prompt requirement.
 - [근거] `gh issue view <issue> --repo jeong-sik/masc-mcp --json
-  number,state,title,url,labels` for #13265, #13505, #13609, #13610, #13611,
-  #13636, #13684, #13685, #13686, #13688, #13689, and #13690 checked at
-  2026-05-06T17:25:00+09:00, confidence High: all 12 prompt-checklist
-  tracking issue refs resolve to open,
-  label-free GitHub issues.
+  number,state,title,url,labels` for #13265, #13505, #13610, #13611, #13636,
+  #13684, #13685, #13686, #13688, #13689, and #13690 checked at
+  2026-05-06T17:25:00+09:00, confidence High: all 11 prompt-checklist
+  tracking issue refs resolve to open, label-free GitHub issues. #13609
+  dropped from the list after the dashboard rows were promoted to `PASS`
+  in the same checklist update.
 - [근거] `python3 test/test_goal_loop_completion_audit.py` checked at
   2026-05-06T16:03:11+09:00, confidence High: the completion audit accepts
   optional `--strict-row-corpus` and `--source-row-candidate-inventory`

--- a/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
+++ b/docs/audit-responses/2026-05-05-goal-loop-completion-audit.md
@@ -396,13 +396,13 @@ GitHub issue tracking ref.
 | 2-1 `observe.yml` Prometheus/Grafana metrics | `observe_goal_loop_logs.py`, fixture metrics, audit response, Observe metric contract, alerts, Grafana dashboard, validator and tests | PASS for the required Observe metric/alert/dashboard contract coverage. |
 | 2-2 `observe_logs.py` pattern parser | `scripts/observe_goal_loop_logs.py`, `test/test_observe_goal_loop_logs.py` | PASS for deterministic parser coverage. |
 | 3-1 `orient.ml` audit comparison engine | `scripts/orient_goal_loop_logs.py`, `audit-corpus.external-claim.json`, `structured-id-triage.external-claim.json` | PARTIAL: engine and triage exist; only 19/206 strict rows are itemized. |
-| 3-2 Orient dashboard counts | `scripts/goal_loop_status.py`, `docs/examples/goal-loop-fixture.md` | PARTIAL: CLI JSON/text exists; operator dashboard panel is not wired. |
+| 3-2 Orient dashboard counts | `scripts/goal_loop_status.py`, `/api/v1/dashboard/goal-loop/status`, `GoalLoopPanel` tests | PASS for operator panel rendering audit catalog counts and missing-row blockers from runtime status JSON. |
 | 4-1 priority decision algorithm | `scripts/decide_goal_loop_findings.py`, `test/test_decide_goal_loop_findings.py` | PASS for fixture-based decision ranking. |
 | 4-2 weekly ACT priority queue | `act-map.startup.json`, `known-prs.startup.json`, `validate_goal_loop_act_map.py` | PARTIAL: reference integrity exists; SLA ownership workflow is not automatic. |
 | 5 ACT checklist/PR proof | linked PR references in `act-map.startup.json` plus ACT validation | PARTIAL: known ACTs are mapped; not every still-present row has a row-level ACT because 187 rows are missing. |
 | 6-1 `verify.yml` unit/regression/TLA/log/metric/orient gates | `scripts/verify_goal_loop_logs.py`, `goal_loop_completion_audit.py`, focused tests | PARTIAL: closeout verifier exists; TLA and production metric gates are not fully implemented. |
 | 6-2 Verify PASS/FAIL branch | `verify.fail.json`, post-ACT live Verify snapshot, completion audit criteria | PARTIAL: branch semantics exist; complete corpus Verify is blocked. |
-| 7 GOAL LOOP dashboard | `goal_loop_status.py` aggregate output | PARTIAL: CLI status exists; UI dashboard integration remains open. |
+| 7 GOAL LOOP dashboard | `/api/v1/dashboard/goal-loop/status`, Monitoring `GOAL LOOP` nav, `GoalLoopPanel` tests | PASS for read-refresh dashboard integration. Strict corpus and live SLO proof remain blocked in their own rows. |
 | 8 anti-stagnation rules | ACT reference guard and completion audit blocker | PARTIAL: reference integrity exists; SLA timers/escalation are not implemented. |
 | 9 expected convergence after week/month | completion audit and #13265 | BLOCKED: no measured convergence claim is valid without the strict corpus and live SLO proof. |
 | Full 206-row strict corpus | `row-corpus-discovery.external-claim.json`, `strict-row-corpus-contract.json`, `--strict-row-corpus` path | BLOCKED: 24 searches/inventories checked; `FULL_ROW_CORPUS_NOT_FOUND`, 19/206 strict rows, 187 strict rows missing. The source-doc explicit-row extractor finds only 132/206 candidate rows across 5 source files, with 7 checked prompt files yielding zero explicit candidates, and cannot close the strict corpus gap. Those 7 no-row files contain 897 unstructured requirement markers that remain non-corpus evidence. Candidate strict rows must also cite catalog external sources and line refs within catalog line counts. |
@@ -619,10 +619,14 @@ system health, next action, and counts.
   consistency findings.
 - `docs/examples/goal-loop-fixture.md` documents text and JSON status replay.
 
-**Status**: **PARTIAL**.
+**Status**: **PASS for dashboard integration**.
 
-The dashboard data shape exists as CLI JSON/text. It is not yet integrated into
-the operator dashboard as a real-time panel.
+The operator dashboard now exposes a Monitoring `GOAL LOOP` section wired
+through `/api/v1/dashboard/goal-loop/status`. The panel reads runtime
+`status.json`, shows phase summaries, audit catalog counts, strict-corpus
+blockers, next action, and Verify evidence, and pins those states in component
+tests. This is a read-refresh dashboard surface; strict corpus completion and
+live recovery SLO proof remain separate blockers above.
 
 ### 8. Anti-Stagnation
 
@@ -684,8 +688,8 @@ No convergence claim is valid yet. The only safe current statement is:
    runtime restarts, using `--post-act-verify`, accepted live-runtime
    `--evidence-kind`, concrete `--evidence-source`,
    `--evidence-window-start`, `--evidence-window-end`, and `--checked-at`.
-5. Wire `goal_loop_status.py` JSON into the operator dashboard only after the
-   fixture's critical state is preserved in UI tests.
+5. Keep the dashboard fixture's critical state pinned in UI tests when the
+   status schema changes.
 6. Add SLA state for anti-stagnation after ACT coverage is complete; otherwise
    timers will only escalate known missing work without changing recovery.
 

--- a/test/fixtures/goal_loop/prompt-closeout-checklist.external-claim.json
+++ b/test/fixtures/goal_loop/prompt-closeout-checklist.external-claim.json
@@ -210,17 +210,14 @@
       "prompt_requirement": "Orient dashboard counts",
       "artifact_refs": [
         "scripts/goal_loop_status.py",
-        "docs/examples/goal-loop-fixture.md"
+        "lib/dashboard/dashboard_goal_loop.ml#status_json",
+        "lib/server/server_routes_http_routes_dashboard.ml#/api/v1/dashboard/goal-loop/status",
+        "dashboard/src/components/goal-loop-panel.ts#function AuditCatalogBlock",
+        "dashboard/src/components/goal-loop-panel.test.ts#renders audit catalog values"
       ],
-      "status": "PARTIAL",
-      "criterion_id": "strict_row_level_catalog_complete",
-      "gap": "CLI JSON/text exists. Draft implementation PR #13655 wires the operator dashboard panel, but it is not merged/live and the strict corpus remains incomplete.",
+      "status": "PASS",
       "implementation_pr_refs": [
         "https://github.com/jeong-sik/masc-mcp/pull/13655"
-      ],
-      "tracking_issue_refs": [
-        "https://github.com/jeong-sik/masc-mcp/issues/13609",
-        "https://github.com/jeong-sik/masc-mcp/issues/13636"
       ]
     },
     {
@@ -315,17 +312,16 @@
       "prompt_requirement": "Unified GOAL LOOP dashboard",
       "artifact_refs": [
         "scripts/goal_loop_status.py",
-        "docs/examples/goal-loop-fixture.md"
+        "lib/dashboard/dashboard_goal_loop.ml#status_json",
+        "lib/server/server_routes_http_routes_dashboard.ml#/api/v1/dashboard/goal-loop/status",
+        "dashboard/src/config/navigation.ts#goal-loop",
+        "dashboard/src/components/status.ts#LazyGoalLoopPanel",
+        "dashboard/src/components/goal-loop-panel.ts#export function GoalLoopPanel",
+        "dashboard/src/components/goal-loop-panel.test.ts#renders phase status"
       ],
-      "status": "PARTIAL",
-      "criterion_id": "strict_row_level_catalog_complete",
-      "gap": "CLI status exists. Draft implementation PR #13655 wires the operator dashboard panel, but it is not merged/live and the strict corpus remains incomplete.",
+      "status": "PASS",
       "implementation_pr_refs": [
         "https://github.com/jeong-sik/masc-mcp/pull/13655"
-      ],
-      "tracking_issue_refs": [
-        "https://github.com/jeong-sik/masc-mcp/issues/13609",
-        "https://github.com/jeong-sik/masc-mcp/issues/13636"
       ]
     },
     {

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -1091,15 +1091,15 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         self.assertTrue(checklist_evidence["has_strict_corpus_blocker"])
         self.assertFalse(checklist_evidence["local_path_leaks"])
         self.assertEqual(checklist_evidence["requirements_total"], 21)
-        self.assertEqual(checklist_evidence["status_counts"]["PASS"], 9)
-        self.assertEqual(checklist_evidence["status_counts"]["PARTIAL"], 10)
+        self.assertEqual(checklist_evidence["status_counts"]["PASS"], 11)
+        self.assertEqual(checklist_evidence["status_counts"]["PARTIAL"], 8)
         self.assertEqual(checklist_evidence["status_counts"]["BLOCKED"], 2)
-        self.assertEqual(checklist_evidence["non_pass_requirements"], 12)
+        self.assertEqual(checklist_evidence["non_pass_requirements"], 10)
         self.assertEqual(
             checklist_evidence["requirements_with_tracking_issue_refs"],
-            12,
+            10,
         )
-        self.assertEqual(checklist_evidence["tracking_issue_refs_total"], 8)
+        self.assertEqual(checklist_evidence["tracking_issue_refs_total"], 7)
         self.assertEqual(checklist_evidence["missing_tracking_issue_refs"], [])
         self.assertEqual(checklist_evidence["invalid_tracking_issue_refs"], [])
         self.assertEqual(
@@ -1108,10 +1108,10 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         )
         self.assertEqual(checklist_evidence["implementation_pr_refs_total"], 9)
         self.assertEqual(checklist_evidence["invalid_implementation_pr_refs"], [])
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 88)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 88)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 22)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 22)
+        self.assertEqual(checklist_evidence["artifact_refs_total"], 96)
+        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 96)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 32)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 32)
         self.assertTrue(checklist_evidence["artifact_refs_all_resolved"])
         self.assertEqual(checklist_evidence["missing_artifact_refs"], [])
         self.assertEqual(checklist_evidence["missing_artifact_ref_anchors"], [])
@@ -1128,11 +1128,11 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         self.assertEqual(warmup_evidence["max_observed_warmup_sec"], 74)
         closeout_evidence = by_id["prompt_requirements_closeout_complete"].evidence
         self.assertEqual(by_id["prompt_requirements_closeout_complete"].status, "FAIL")
-        self.assertEqual(closeout_evidence["incomplete_requirements"], 12)
-        self.assertEqual(closeout_evidence["non_pass_requirements"], 12)
+        self.assertEqual(closeout_evidence["incomplete_requirements"], 10)
+        self.assertEqual(closeout_evidence["non_pass_requirements"], 10)
         self.assertEqual(
             closeout_evidence["requirements_with_tracking_issue_refs"],
-            12,
+            10,
         )
         self.assertEqual(
             closeout_evidence["requirements_with_implementation_pr_refs"],
@@ -1368,8 +1368,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 85)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 84)
+        self.assertEqual(checklist_evidence["artifact_refs_total"], 93)
+        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 92)
         self.assertEqual(
             checklist_evidence["missing_artifact_refs"],
             [
@@ -1403,10 +1403,10 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 84)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 83)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 20)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 19)
+        self.assertEqual(checklist_evidence["artifact_refs_total"], 92)
+        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 91)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 30)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 29)
         self.assertEqual(
             checklist_evidence["missing_artifact_ref_anchors"],
             [
@@ -1455,8 +1455,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 20)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 19)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 30)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 29)
         self.assertEqual(
             checklist_evidence["artifact_ref_read_errors"],
             [
@@ -1635,7 +1635,7 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         self.assertEqual(prompt_checklist["status"], "PASS")
         prompt_closeout = by_id["prompt_requirements_closeout_complete"]
         self.assertEqual(prompt_closeout["status"], "FAIL")
-        self.assertEqual(prompt_closeout["evidence"]["incomplete_requirements"], 12)
+        self.assertEqual(prompt_closeout["evidence"]["incomplete_requirements"], 10)
         warmup_fairness = by_id["autoboot_warmup_fairness_complete"]
         self.assertEqual(warmup_fairness["status"], "PASS")
         self.assertEqual(warmup_fairness["evidence"]["late_keeper_warmup_sec"], 61)

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -1154,8 +1154,11 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         # index so the test stays correct under any harmless fixture
         # reordering.
         verifier_row = next(
-            (row for row in keeper_rows
-             if isinstance(row, dict) and row.get("keeper_name") == "verifier"),
+            (
+                row
+                for row in keeper_rows
+                if isinstance(row, dict) and row.get("keeper_name") == "verifier"
+            ),
             None,
         )
         assert verifier_row is not None, "fixture must contain a verifier row"


### PR DESCRIPTION
## Summary

- Update the GOAL LOOP completion audit to stop reporting the operator dashboard as unwired now that `/api/v1/dashboard/goal-loop/status`, Monitoring `GOAL LOOP` navigation, and `GoalLoopPanel` tests are on main.
- Mark the `orient-dashboard-counts` and `goal-loop-dashboard` prompt checklist rows as `PASS` with concrete code/test artifact refs.
- Keep strict-corpus and live SLO blockers in their existing rows; this only narrows the dashboard integration gap.

## Verification

- `python3 test/test_goal_loop_completion_audit.py`
- `python3 -m json.tool test/fixtures/goal_loop/prompt-closeout-checklist.external-claim.json`
- `ruff check test/test_goal_loop_completion_audit.py`
- `ruff format --check test/test_goal_loop_completion_audit.py`
- `git diff --check origin/main...HEAD`
- Dashboard UI evidence smoke: `pnpm exec vitest run --config vitest.config.ts src/components/goal-loop-panel.test.ts src/goal-loop-status.test.ts --no-file-parallelism --maxWorkers=1` from `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard` passed; the fresh worktree lacks `dashboard/node_modules`, so the test was run from the root dashboard install. No dashboard TS files are changed in this PR.
