### PR TITLE
fix(dashboard): route worktree gh timeout through SSOT

### DIFF
--- a/lib/dashboard/dashboard_worktree_status.ml
+++ b/lib/dashboard/dashboard_worktree_status.ml
@@ -98,7 +98,7 @@ let query_pr_for_branch branch =
           ~actor:"dashboard/worktree_status"
           ~raw_source:(exec_gate_raw_source argv)
           ~summary:"dashboard_worktree_status gh pr list"
-          ~timeout_sec:10.0
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Gh_shared ())
           argv
       in
       (* Output is a JSON array: [{"number":42,"state":"OPEN"}] or [] *)


### PR DESCRIPTION
## Summary

- Replace the dashboard worktree-status `gh pr list` hardcoded `~timeout_sec:10.0` with `Env_config_exec_timeout.timeout_sec ~caller:Gh_shared ()`.
- This preserves the current 10s default while moving the last `lib/` `~timeout_sec:N` literal onto the #10426 exec-timeout SSOT and its operator override path.

## Why

#10426 tracks scattered subprocess timeout literals. Current `main` had already reduced `rg -n "~timeout_sec:[0-9]" lib/` to one remaining production hit: this dashboard worktree GitHub probe. The adjacent git probes in the same module already use a config-backed timeout, so this closes the remaining literal without changing behavior.

## Validation

- `scripts/dune-local.sh build test/test_env_config_exec_timeout_10426.exe test/test_worktree_status_single_flight_9632.exe` attempted, but the shared wrapper waited on `/tmp/me-opam-switch.lock`; I stopped only that queued wrapper process.
- `dune build --root . test/test_env_config_exec_timeout_10426.exe`
- `./_build/default/test/test_env_config_exec_timeout_10426.exe` (9 tests)
- `rg -n "~timeout_sec:[0-9]" lib/ -S` (no matches)
- `git diff --check`

Note: `./_build/default/test/test_worktree_status_single_flight_9632.exe` currently fails before reaching this change with `Eio__core__Cancel.Get_context` from `test/test_worktree_status_single_flight_9632.ml:55` because the test calls an `Eio.Mutex` reset outside an Eio context.