### PR TITLE
feat(dashboard): add event stream semantic gravity and intent projection

### DIFF
--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -282,10 +282,12 @@ describe('EventStream', () => {
     expect(rows.map(row => row.event.id)).toEqual(['e1', 'e3', 'e2'])
     expect(rows[0]?.semanticGravityScore).toBe(0.85)
     expect(rows[0]?.semanticGravityRank).toBe(1)
+    expect(rows[0]?.originalVisibleIndex).toBe(2)
     expect(summarizeEventStream(baseEvents, 100, 5000, ['agent-a', 'started'])).toMatchObject({
       semanticGravityTermCount: 2,
       semanticGravityMatchCount: 1,
       maxSemanticGravityScore: 0.85,
+      maxAttractionScore: 0.9,
     })
   })
 
@@ -299,7 +301,10 @@ describe('EventStream', () => {
     expect(root.dataset.eventStreamSemanticGravityTermCount).toBe('2')
     expect(root.dataset.eventStreamSemanticGravityMatchCount).toBe('1')
     expect(root.dataset.eventStreamMaxSemanticGravityScore).toBe('0.85')
+    expect(root.dataset.eventStreamMaxAttractionScore).toBe('0.90')
     expect(items[0]?.getAttribute('data-stream-event-id')).toBe('e1')
+    expect(focused.dataset.streamEventVisibleIndex).toBe('2')
+    expect(focused.dataset.streamEventAttractionScore).toBe('0.32')
     expect(focused.dataset.streamEventSemanticGravityScore).toBe('0.85')
     expect(focused.dataset.streamEventSemanticGravityRank).toBe('1')
   })

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import {
+  buildSemanticGravityRows,
   buildTemporalSyncRows,
   DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
   EventStream,
@@ -9,6 +10,7 @@ import {
   summarizeEventStream,
   streamEventAttractionBand,
   streamEventAttractionScore,
+  streamEventSemanticGravityScore,
 } from './event-stream'
 
 const baseEvents = [
@@ -251,6 +253,45 @@ describe('EventStream', () => {
     expect(latest.dataset.streamEventAttractionBand).toBe('high')
     expect(middle.dataset.streamEventAttractionBand).toBe('medium')
     expect(older.dataset.streamEventAttractionBand).toBe('low')
+  })
+
+  it('scores semantic gravity from the current focus', () => {
+    const score = streamEventSemanticGravityScore(baseEvents[0]!, ['agent-a', 'started'])
+    const unrelated = streamEventSemanticGravityScore(baseEvents[2]!, ['agent-a', 'started'])
+
+    expect(score).toBe(0.85)
+    expect(unrelated).toBe(0)
+  })
+
+  it('orders semantically related events before unrelated visible rows', () => {
+    const rows = buildSemanticGravityRows(
+      buildTemporalSyncRows(getVisibleStreamEvents(baseEvents, 100), 5000),
+      ['agent-a', 'started'],
+    )
+
+    expect(rows.map(row => row.event.id)).toEqual(['e1', 'e3', 'e2'])
+    expect(rows[0]?.semanticGravityScore).toBe(0.85)
+    expect(rows[0]?.semanticGravityRank).toBe(1)
+    expect(summarizeEventStream(baseEvents, 100, 5000, ['agent-a', 'started'])).toMatchObject({
+      semanticGravityTermCount: 2,
+      semanticGravityMatchCount: 1,
+      maxSemanticGravityScore: 0.85,
+    })
+  })
+
+  it('renders semantic gravity metadata on event rows', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents, semanticFocus: ['agent-a', 'started'] }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const items = container.querySelectorAll('[role="listitem"]')
+    const focused = container.querySelector('[data-stream-event-id="e1"]') as HTMLElement
+
+    expect(root.dataset.eventStreamSemanticGravityTermCount).toBe('2')
+    expect(root.dataset.eventStreamSemanticGravityMatchCount).toBe('1')
+    expect(root.dataset.eventStreamMaxSemanticGravityScore).toBe('0.85')
+    expect(items[0]?.getAttribute('data-stream-event-id')).toBe('e1')
+    expect(focused.dataset.streamEventSemanticGravityScore).toBe('0.85')
+    expect(focused.dataset.streamEventSemanticGravityRank).toBe('1')
   })
 
   it('treats maxItems zero as an empty visible window', () => {

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import {
+  buildIntentProjectionRows,
   buildSemanticGravityRows,
   buildTemporalSyncRows,
   DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
@@ -17,6 +18,15 @@ const baseEvents = [
   { id: 'e1', timestamp: new Date('2024-01-01T09:30:00').getTime(), level: 'info' as const, message: 'started', source: 'agent-a' },
   { id: 'e2', timestamp: new Date('2024-01-01T09:31:00').getTime(), level: 'warn' as const, message: 'slow', source: 'agent-b' },
   { id: 'e3', timestamp: new Date('2024-01-01T09:32:00').getTime(), level: 'error' as const, message: 'failed' },
+]
+
+const projectionEvents = [
+  { id: 'p1', timestamp: new Date('2024-01-01T10:00:00').getTime(), level: 'info' as const, message: 'edit app.ts', source: 'editor' },
+  { id: 'p2', timestamp: new Date('2024-01-01T10:01:00').getTime(), level: 'error' as const, message: 'test failed', source: 'test' },
+  { id: 'p3', timestamp: new Date('2024-01-01T10:02:00').getTime(), level: 'info' as const, message: 'edit app.ts', source: 'editor' },
+  { id: 'p4', timestamp: new Date('2024-01-01T10:03:00').getTime(), level: 'info' as const, message: 'test passed', source: 'test' },
+  { id: 'p5', timestamp: new Date('2024-01-01T10:04:00').getTime(), level: 'info' as const, message: 'edit app.ts', source: 'editor' },
+  { id: 'p6', timestamp: new Date('2024-01-01T10:05:00').getTime(), level: 'info' as const, message: 'update docs', source: 'docs' },
 ]
 
 describe('EventStream', () => {
@@ -292,6 +302,51 @@ describe('EventStream', () => {
     expect(items[0]?.getAttribute('data-stream-event-id')).toBe('e1')
     expect(focused.dataset.streamEventSemanticGravityScore).toBe('0.85')
     expect(focused.dataset.streamEventSemanticGravityRank).toBe('1')
+  })
+
+  it('projects likely next intent from focused event history', () => {
+    const rows = buildIntentProjectionRows(projectionEvents, 'editor')
+
+    expect(rows.map(row => row.key)).toEqual(['source:test', 'source:docs'])
+    expect(rows[0]).toMatchObject({
+      label: 'test',
+      targetKind: 'source',
+      probability: 0.67,
+      evidenceCount: 2,
+    })
+    expect(rows[1]).toMatchObject({
+      label: 'docs',
+      probability: 0.33,
+      evidenceCount: 1,
+    })
+    expect(summarizeEventStream(projectionEvents, 100, DEFAULT_TEMPORAL_SYNC_WINDOW_MS, 'editor')).toMatchObject({
+      intentProjectionCount: 2,
+      topIntentProjectionProbability: 0.67,
+    })
+  })
+
+  it('renders intentional projection metadata and suggestion chips', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: projectionEvents, semanticFocus: 'editor' }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const projections = container.querySelectorAll('[data-intent-projection-key]')
+    const top = projections[0] as HTMLElement
+
+    expect(root.dataset.eventStreamIntentProjectionCount).toBe('2')
+    expect(root.dataset.eventStreamTopIntentProjectionProbability).toBe('0.67')
+    expect(top.dataset.intentProjectionKey).toBe('source:test')
+    expect(top.dataset.intentProjectionTargetKind).toBe('source')
+    expect(top.dataset.intentProjectionProbability).toBe('0.67')
+    expect(top.dataset.intentProjectionEvidenceCount).toBe('2')
+    expect(container.textContent).toContain('test')
+    expect(container.textContent).toContain('67%')
+  })
+
+  it('limits intentional projections', () => {
+    const rows = buildIntentProjectionRows(projectionEvents, 'editor', 1)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.key).toBe('source:test')
   })
 
   it('treats maxItems zero as an empty visible window', () => {

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -253,6 +253,21 @@ describe('EventStream', () => {
     expect(older.dataset.streamEventAttractionBand).toBe('low')
   })
 
+  it('renders gradient attraction metadata on event rows', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: baseEvents }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const latest = container.querySelector('[data-stream-event-id="e3"]') as HTMLElement
+    const middle = container.querySelector('[data-stream-event-id="e2"]') as HTMLElement
+    const older = container.querySelector('[data-stream-event-id="e1"]') as HTMLElement
+
+    expect(root.dataset.eventStreamHighAttractionCount).toBe('1')
+    expect(latest.dataset.streamEventAttractionScore).toBe('0.90')
+    expect(latest.dataset.streamEventAttractionBand).toBe('high')
+    expect(middle.dataset.streamEventAttractionBand).toBe('medium')
+    expect(older.dataset.streamEventAttractionBand).toBe('low')
+  })
+
   it('treats maxItems zero as an empty visible window', () => {
     const container = document.createElement('div')
     render(h(EventStream, { events: baseEvents, maxItems: 0 }), container)

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -253,21 +253,6 @@ describe('EventStream', () => {
     expect(older.dataset.streamEventAttractionBand).toBe('low')
   })
 
-  it('renders gradient attraction metadata on event rows', () => {
-    const container = document.createElement('div')
-    render(h(EventStream, { events: baseEvents }), container)
-    const root = container.querySelector('[data-event-stream]') as HTMLElement
-    const latest = container.querySelector('[data-stream-event-id="e3"]') as HTMLElement
-    const middle = container.querySelector('[data-stream-event-id="e2"]') as HTMLElement
-    const older = container.querySelector('[data-stream-event-id="e1"]') as HTMLElement
-
-    expect(root.dataset.eventStreamHighAttractionCount).toBe('1')
-    expect(latest.dataset.streamEventAttractionScore).toBe('0.90')
-    expect(latest.dataset.streamEventAttractionBand).toBe('high')
-    expect(middle.dataset.streamEventAttractionBand).toBe('medium')
-    expect(older.dataset.streamEventAttractionBand).toBe('low')
-  })
-
   it('treats maxItems zero as an empty visible window', () => {
     const container = document.createElement('div')
     render(h(EventStream, { events: baseEvents, maxItems: 0 }), container)

--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -267,9 +267,11 @@ describe('EventStream', () => {
 
   it('scores semantic gravity from the current focus', () => {
     const score = streamEventSemanticGravityScore(baseEvents[0]!, ['agent-a', 'started'])
+    const phraseScore = streamEventSemanticGravityScore(baseEvents[0]!, 'agent-a started')
     const unrelated = streamEventSemanticGravityScore(baseEvents[2]!, ['agent-a', 'started'])
 
     expect(score).toBe(0.85)
+    expect(phraseScore).toBe(score)
     expect(unrelated).toBe(0)
   })
 
@@ -352,6 +354,13 @@ describe('EventStream', () => {
 
     expect(rows).toHaveLength(1)
     expect(rows[0]?.key).toBe('source:test')
+  })
+
+  it('scopes intentional projection summary to the visible event window', () => {
+    expect(summarizeEventStream(projectionEvents, 4, DEFAULT_TEMPORAL_SYNC_WINDOW_MS, 'editor')).toMatchObject({
+      intentProjectionCount: 2,
+      topIntentProjectionProbability: 0.5,
+    })
   })
 
   it('treats maxItems zero as an empty visible window', () => {

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -48,6 +48,7 @@ export interface TemporalSyncStreamRow {
 }
 
 export interface SemanticGravityStreamRow extends TemporalSyncStreamRow {
+  originalVisibleIndex: number
   semanticGravityScore: number
   semanticGravityRank: number
 }
@@ -58,6 +59,14 @@ export interface IntentProjectionRow {
   targetKind: IntentProjectionTargetKind
   probability: number
   evidenceCount: number
+}
+
+interface EventStreamModel {
+  visible: StreamEvent[]
+  syncRows: TemporalSyncStreamRow[]
+  semanticRows: SemanticGravityStreamRow[]
+  intentProjections: IntentProjectionRow[]
+  summary: EventStreamSummary
 }
 
 interface EventStreamProps {
@@ -202,6 +211,7 @@ export function buildSemanticGravityRows(
 
   return ordered.map((item, index) => ({
     ...item.row,
+    originalVisibleIndex: item.originalIndex,
     semanticGravityScore: item.score,
     semanticGravityRank: index + 1,
   }))
@@ -330,17 +340,14 @@ export function buildTemporalSyncRows(
   return rows
 }
 
-export function summarizeEventStream(
-  events: StreamEvent[],
-  maxItems: number,
-  temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
+function summarizeEventRows(
+  totalCount: number,
+  visible: StreamEvent[],
+  syncRows: TemporalSyncStreamRow[],
+  semanticRows: SemanticGravityStreamRow[],
+  intentProjections: IntentProjectionRow[],
   semanticFocus?: EventStreamSemanticFocus,
-  maxIntentProjections = 3,
 ): EventStreamSummary {
-  const visible = getVisibleStreamEvents(events, maxItems)
-  const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
-  const semanticRows = buildSemanticGravityRows(syncRows, semanticFocus)
-  const intentProjections = buildIntentProjectionRows(events, semanticFocus, maxIntentProjections)
   const latestTimestamp = visible.length > 0 ? finiteTimestamp(visible[0]!.timestamp) : null
   const oldestVisibleTimestamp = visible.length > 0
     ? finiteTimestamp(visible[visible.length - 1]!.timestamp)
@@ -353,8 +360,8 @@ export function summarizeEventStream(
       .filter(row => row.syncGroupSize > 1)
       .map(row => row.syncGroupId),
   )
-  const attractionScores = semanticRows.map((row, index) =>
-    streamEventAttractionScore(row, index, semanticRows.length),
+  const attractionScores = semanticRows.map(row =>
+    streamEventAttractionScore(row, row.originalVisibleIndex, semanticRows.length),
   )
   const highAttractionCount = attractionScores.filter(score => streamEventAttractionBand(score) === 'high').length
   const semanticScores = semanticRows.map(row => row.semanticGravityScore)
@@ -369,9 +376,9 @@ export function summarizeEventStream(
           : 'ok'
 
   return {
-    totalCount: events.length,
+    totalCount,
     visibleCount: visible.length,
-    hiddenCount: Math.max(0, events.length - visible.length),
+    hiddenCount: Math.max(0, totalCount - visible.length),
     infoCount,
     warnCount,
     errorCount,
@@ -388,6 +395,49 @@ export function summarizeEventStream(
     topIntentProjectionProbability: intentProjections[0]?.probability ?? 0,
     status,
   }
+}
+
+function buildEventStreamModel(
+  events: StreamEvent[],
+  maxItems: number,
+  temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
+  semanticFocus?: EventStreamSemanticFocus,
+  maxIntentProjections = 3,
+): EventStreamModel {
+  const visible = getVisibleStreamEvents(events, maxItems)
+  const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
+  const semanticRows = buildSemanticGravityRows(syncRows, semanticFocus)
+  const intentProjections = buildIntentProjectionRows(events, semanticFocus, maxIntentProjections)
+  return {
+    visible,
+    syncRows,
+    semanticRows,
+    intentProjections,
+    summary: summarizeEventRows(
+      events.length,
+      visible,
+      syncRows,
+      semanticRows,
+      intentProjections,
+      semanticFocus,
+    ),
+  }
+}
+
+export function summarizeEventStream(
+  events: StreamEvent[],
+  maxItems: number,
+  temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
+  semanticFocus?: EventStreamSemanticFocus,
+  maxIntentProjections = 3,
+): EventStreamSummary {
+  return buildEventStreamModel(
+    events,
+    maxItems,
+    temporalSyncWindowMs,
+    semanticFocus,
+    maxIntentProjections,
+  ).summary
 }
 
 function attractionRowClass(band: EventStreamAttractionBand, isSynced: boolean): string {
@@ -414,23 +464,11 @@ export function EventStream({
   maxIntentProjections = 3,
   testId,
 }: EventStreamProps) {
-  const visible = useMemo(() => getVisibleStreamEvents(events, maxItems), [events, maxItems])
-  const syncRows = useMemo(
-    () => buildTemporalSyncRows(visible, temporalSyncWindowMs),
-    [visible, temporalSyncWindowMs],
-  )
-  const semanticRows = useMemo(
-    () => buildSemanticGravityRows(syncRows, semanticFocus),
-    [syncRows, semanticFocus],
-  )
-  const intentProjections = useMemo(
-    () => buildIntentProjectionRows(events, semanticFocus, maxIntentProjections),
-    [events, semanticFocus, maxIntentProjections],
-  )
-  const summary = useMemo(
-    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs, semanticFocus, maxIntentProjections),
+  const model = useMemo(
+    () => buildEventStreamModel(events, maxItems, temporalSyncWindowMs, semanticFocus, maxIntentProjections),
     [events, maxItems, temporalSyncWindowMs, semanticFocus, maxIntentProjections],
   )
+  const { visible, semanticRows, intentProjections, summary } = model
 
   return html`
     <div
@@ -510,11 +548,11 @@ export function EventStream({
           : html`
             <div class="space-y-1" role="list">
               ${semanticRows.map(
-                (row, index) => {
+                row => {
                   const e = row.event
                   const isSynced = row.syncGroupSize > 1
                   const eventTimestamp = finiteTimestamp(e.timestamp)
-                  const attractionScore = streamEventAttractionScore(row, index, semanticRows.length)
+                  const attractionScore = streamEventAttractionScore(row, row.originalVisibleIndex, semanticRows.length)
                   const attractionBand = streamEventAttractionBand(attractionScore)
                   return html`
                   <div
@@ -525,7 +563,7 @@ export function EventStream({
                     data-stream-event-level=${e.level}
                     data-stream-event-source=${e.source ?? ''}
                     data-stream-event-timestamp=${eventTimestamp ?? ''}
-                    data-stream-event-visible-index=${index}
+                    data-stream-event-visible-index=${row.originalVisibleIndex}
                     data-stream-event-sync-group=${row.syncGroupId}
                     data-stream-event-sync-size=${row.syncGroupSize}
                     data-stream-event-sync-anchor=${row.syncAnchorTimestamp ?? ''}

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -144,10 +144,26 @@ function normalizedSemanticTerms(focus: EventStreamSemanticFocus | undefined): s
   for (const value of values) {
     const normalized = value.trim().toLowerCase()
     if (!normalized) continue
-    terms.push(normalized)
-    for (const part of normalized.split(/[^a-z0-9_.:/-]+/)) {
-      if (part.length >= 2) terms.push(part)
+    // Tokenize on non-word chars and feed only the parts into [terms].
+    // Previously we also pushed the full [normalized] string, but
+    // streamEventSemanticGravityScore averages over [terms.length], so
+    // multi-word focus strings (e.g. "agent-a started") were paying an
+    // extra averaging slot for a literal-string term that almost never
+    // matches event fields — systematically lowering the score even when
+    // every meaningful token did match. Set dedupe still collapses
+    // single-token focuses (where token === normalized) to one entry.
+    const parts = normalized.split(/[^a-z0-9_.:/-]+/)
+    let tokenized = false
+    for (const part of parts) {
+      if (part.length >= 2) {
+        terms.push(part)
+        tokenized = true
+      }
     }
+    // Fall back to the full normalized string only when tokenization
+    // produced nothing usable (e.g. a single character like "a"); we
+    // still want a non-empty terms list for the score path.
+    if (!tokenized) terms.push(normalized)
   }
 
   return Array.from(new Set(terms)).slice(0, 16)
@@ -175,13 +191,8 @@ function eventMatchesTerms(event: StreamEvent, terms: readonly string[]): boolea
   )
 }
 
-export function streamEventSemanticGravityScore(
-  event: StreamEvent,
-  semanticFocus?: EventStreamSemanticFocus,
-): number {
-  const terms = normalizedSemanticTerms(semanticFocus)
+function scoreEventForTerms(event: StreamEvent, terms: readonly string[]): number {
   if (terms.length === 0) return 0
-
   const total = terms.reduce((sum, term) => {
     const termScore = Math.max(
       fieldIncludes(event.source, term) ? 0.9 : 0,
@@ -190,21 +201,32 @@ export function streamEventSemanticGravityScore(
     )
     return sum + termScore
   }, 0)
-
   return roundedScore(clamp01(total / terms.length))
+}
+
+export function streamEventSemanticGravityScore(
+  event: StreamEvent,
+  semanticFocus?: EventStreamSemanticFocus,
+): number {
+  return scoreEventForTerms(event, normalizedSemanticTerms(semanticFocus))
 }
 
 export function buildSemanticGravityRows(
   rows: TemporalSyncStreamRow[],
   semanticFocus?: EventStreamSemanticFocus,
 ): SemanticGravityStreamRow[] {
+  // Normalize once per build instead of once per row. Repeated
+  // [normalizedSemanticTerms(semanticFocus)] calls inside the hot loop
+  // produced the same terms for every row, turning the build into
+  // O(rows × terms) when rows × terms ≪ rows alone could cover.
+  const terms = normalizedSemanticTerms(semanticFocus)
+  const hasFocus = terms.length > 0
   const scored = rows.map((row, originalIndex) => ({
     row,
     originalIndex,
-    score: streamEventSemanticGravityScore(row.event, semanticFocus),
+    score: scoreEventForTerms(row.event, terms),
   }))
 
-  const hasFocus = normalizedSemanticTerms(semanticFocus).length > 0
   const ordered = hasFocus
     ? [...scored].sort((a, b) => (b.score - a.score) || (a.originalIndex - b.originalIndex))
     : scored
@@ -407,7 +429,10 @@ function buildEventStreamModel(
   const visible = getVisibleStreamEvents(events, maxItems)
   const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
   const semanticRows = buildSemanticGravityRows(syncRows, semanticFocus)
-  const intentProjections = buildIntentProjectionRows(events, semanticFocus, maxIntentProjections)
+  // Bound projection work to the visible window, but preserve the
+  // chronological order expected by buildIntentProjectionRows.
+  const projectionWindow = [...visible].reverse()
+  const intentProjections = buildIntentProjectionRows(projectionWindow, semanticFocus, maxIntentProjections)
   return {
     visible,
     syncRows,

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -17,6 +17,7 @@ export interface StreamEvent {
 export type EventStreamStatus = 'empty' | 'ok' | 'warning' | 'error'
 export type EventStreamAttractionBand = 'high' | 'medium' | 'low'
 export type EventStreamSemanticFocus = string | readonly string[]
+export type IntentProjectionTargetKind = 'source' | 'level'
 
 export interface EventStreamSummary {
   totalCount: number
@@ -34,6 +35,8 @@ export interface EventStreamSummary {
   semanticGravityTermCount: number
   semanticGravityMatchCount: number
   maxSemanticGravityScore: number
+  intentProjectionCount: number
+  topIntentProjectionProbability: number
   status: EventStreamStatus
 }
 
@@ -49,11 +52,20 @@ export interface SemanticGravityStreamRow extends TemporalSyncStreamRow {
   semanticGravityRank: number
 }
 
+export interface IntentProjectionRow {
+  key: string
+  label: string
+  targetKind: IntentProjectionTargetKind
+  probability: number
+  evidenceCount: number
+}
+
 interface EventStreamProps {
   events: StreamEvent[]
   maxItems?: number
   temporalSyncWindowMs?: number
   semanticFocus?: EventStreamSemanticFocus
+  maxIntentProjections?: number
   testId?: string
 }
 
@@ -132,8 +144,26 @@ function normalizedSemanticTerms(focus: EventStreamSemanticFocus | undefined): s
   return Array.from(new Set(terms)).slice(0, 16)
 }
 
+function intentTermsForEvent(event: StreamEvent): string[] {
+  return normalizedSemanticTerms([
+    event.source ?? '',
+    event.message,
+    event.id,
+    event.level,
+  ])
+}
+
 function fieldIncludes(value: string | undefined, term: string): boolean {
   return value?.toLowerCase().includes(term) ?? false
+}
+
+function eventMatchesTerms(event: StreamEvent, terms: readonly string[]): boolean {
+  return terms.some(term =>
+    fieldIncludes(event.source, term)
+    || fieldIncludes(event.message, term)
+    || fieldIncludes(event.id, term)
+    || event.level === term,
+  )
 }
 
 export function streamEventSemanticGravityScore(
@@ -175,6 +205,60 @@ export function buildSemanticGravityRows(
     semanticGravityScore: item.score,
     semanticGravityRank: index + 1,
   }))
+}
+
+function projectionTargetForEvent(event: StreamEvent): Pick<IntentProjectionRow, 'key' | 'label' | 'targetKind'> {
+  if (event.source?.trim()) {
+    const source = event.source.trim()
+    return { key: `source:${source}`, label: source, targetKind: 'source' }
+  }
+  return { key: `level:${event.level}`, label: levelLabel(event.level), targetKind: 'level' }
+}
+
+export function buildIntentProjectionRows(
+  events: StreamEvent[],
+  semanticFocus?: EventStreamSemanticFocus,
+  maxIntentProjections = 3,
+): IntentProjectionRow[] {
+  const limit = Number.isFinite(maxIntentProjections)
+    ? Math.max(0, Math.floor(maxIntentProjections))
+    : 0
+  if (limit === 0 || events.length < 2) return []
+
+  const explicitTerms = normalizedSemanticTerms(semanticFocus)
+  const latestEvent = events[events.length - 1]
+  const terms = explicitTerms.length > 0 || latestEvent == null
+    ? explicitTerms
+    : intentTermsForEvent(latestEvent)
+  if (terms.length === 0) return []
+
+  const counts = new Map<string, IntentProjectionRow>()
+  let evidenceTotal = 0
+
+  for (let index = 0; index < events.length - 1; index += 1) {
+    const event = events[index]!
+    const next = events[index + 1]!
+    if (!eventMatchesTerms(event, terms)) continue
+
+    const target = projectionTargetForEvent(next)
+    const current = counts.get(target.key)
+    counts.set(target.key, {
+      ...target,
+      probability: 0,
+      evidenceCount: (current?.evidenceCount ?? 0) + 1,
+    })
+    evidenceTotal += 1
+  }
+
+  if (evidenceTotal === 0) return []
+
+  return Array.from(counts.values())
+    .map(row => ({
+      ...row,
+      probability: roundedScore(row.evidenceCount / evidenceTotal),
+    }))
+    .sort((a, b) => (b.probability - a.probability) || (b.evidenceCount - a.evidenceCount) || a.label.localeCompare(b.label))
+    .slice(0, limit)
 }
 
 export function streamEventAttractionScore(
@@ -251,10 +335,12 @@ export function summarizeEventStream(
   maxItems: number,
   temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
   semanticFocus?: EventStreamSemanticFocus,
+  maxIntentProjections = 3,
 ): EventStreamSummary {
   const visible = getVisibleStreamEvents(events, maxItems)
   const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
   const semanticRows = buildSemanticGravityRows(syncRows, semanticFocus)
+  const intentProjections = buildIntentProjectionRows(events, semanticFocus, maxIntentProjections)
   const latestTimestamp = visible.length > 0 ? finiteTimestamp(visible[0]!.timestamp) : null
   const oldestVisibleTimestamp = visible.length > 0
     ? finiteTimestamp(visible[visible.length - 1]!.timestamp)
@@ -298,6 +384,8 @@ export function summarizeEventStream(
     semanticGravityTermCount: normalizedSemanticTerms(semanticFocus).length,
     semanticGravityMatchCount: semanticMatchCount,
     maxSemanticGravityScore: semanticScores.reduce((max, score) => Math.max(max, score), 0),
+    intentProjectionCount: intentProjections.length,
+    topIntentProjectionProbability: intentProjections[0]?.probability ?? 0,
     status,
   }
 }
@@ -323,6 +411,7 @@ export function EventStream({
   maxItems = 100,
   temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
   semanticFocus,
+  maxIntentProjections = 3,
   testId,
 }: EventStreamProps) {
   const visible = useMemo(() => getVisibleStreamEvents(events, maxItems), [events, maxItems])
@@ -334,9 +423,13 @@ export function EventStream({
     () => buildSemanticGravityRows(syncRows, semanticFocus),
     [syncRows, semanticFocus],
   )
+  const intentProjections = useMemo(
+    () => buildIntentProjectionRows(events, semanticFocus, maxIntentProjections),
+    [events, semanticFocus, maxIntentProjections],
+  )
   const summary = useMemo(
-    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs, semanticFocus),
-    [events, maxItems, temporalSyncWindowMs, semanticFocus],
+    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs, semanticFocus, maxIntentProjections),
+    [events, maxItems, temporalSyncWindowMs, semanticFocus, maxIntentProjections],
   )
 
   return html`
@@ -360,6 +453,8 @@ export function EventStream({
       data-event-stream-semantic-gravity-term-count=${summary.semanticGravityTermCount}
       data-event-stream-semantic-gravity-match-count=${summary.semanticGravityMatchCount}
       data-event-stream-max-semantic-gravity-score=${summary.maxSemanticGravityScore.toFixed(2)}
+      data-event-stream-intent-projection-count=${summary.intentProjectionCount}
+      data-event-stream-top-intent-projection-probability=${summary.topIntentProjectionProbability.toFixed(2)}
       data-testid=${testId}
     >
       <div
@@ -381,6 +476,29 @@ export function EventStream({
           <div class="font-mono text-sm text-[var(--color-status-err)]">${summary.errorCount}</div>
         </div>
       </div>
+      ${intentProjections.length > 0
+        ? html`
+          <div
+            class="flex min-w-0 flex-wrap gap-1"
+            aria-label="의도 예측"
+            data-event-stream-intent-projections
+          >
+            ${intentProjections.map(projection => html`
+              <div
+                key=${projection.key}
+                class="inline-flex min-w-0 items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-secondary)]"
+                data-intent-projection-key=${projection.key}
+                data-intent-projection-target-kind=${projection.targetKind}
+                data-intent-projection-probability=${projection.probability.toFixed(2)}
+                data-intent-projection-evidence-count=${projection.evidenceCount}
+              >
+                <span class="max-w-28 truncate" title=${projection.label}>${projection.label}</span>
+                <span class="font-mono text-[var(--color-fg-muted)]">${Math.round(projection.probability * 100)}%</span>
+              </div>
+            `)}
+          </div>
+        `
+        : null}
       <div
         role="log"
         aria-label="이벤트 스트림, 이벤트 ${summary.visibleCount}개, 에러 ${summary.errorCount}개"

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -16,6 +16,7 @@ export interface StreamEvent {
 
 export type EventStreamStatus = 'empty' | 'ok' | 'warning' | 'error'
 export type EventStreamAttractionBand = 'high' | 'medium' | 'low'
+export type EventStreamSemanticFocus = string | readonly string[]
 
 export interface EventStreamSummary {
   totalCount: number
@@ -30,6 +31,9 @@ export interface EventStreamSummary {
   maxTemporalSyncGroupSize: number
   highAttractionCount: number
   maxAttractionScore: number
+  semanticGravityTermCount: number
+  semanticGravityMatchCount: number
+  maxSemanticGravityScore: number
   status: EventStreamStatus
 }
 
@@ -40,10 +44,16 @@ export interface TemporalSyncStreamRow {
   syncAnchorTimestamp: number | null
 }
 
+export interface SemanticGravityStreamRow extends TemporalSyncStreamRow {
+  semanticGravityScore: number
+  semanticGravityRank: number
+}
+
 interface EventStreamProps {
   events: StreamEvent[]
   maxItems?: number
   temporalSyncWindowMs?: number
+  semanticFocus?: EventStreamSemanticFocus
   testId?: string
 }
 
@@ -104,6 +114,67 @@ function levelAttraction(level: StreamEvent['level']): number {
     case 'info':
       return 0.45
   }
+}
+
+function normalizedSemanticTerms(focus: EventStreamSemanticFocus | undefined): string[] {
+  const values = typeof focus === 'string' ? [focus] : focus ?? []
+  const terms: string[] = []
+
+  for (const value of values) {
+    const normalized = value.trim().toLowerCase()
+    if (!normalized) continue
+    terms.push(normalized)
+    for (const part of normalized.split(/[^a-z0-9_.:/-]+/)) {
+      if (part.length >= 2) terms.push(part)
+    }
+  }
+
+  return Array.from(new Set(terms)).slice(0, 16)
+}
+
+function fieldIncludes(value: string | undefined, term: string): boolean {
+  return value?.toLowerCase().includes(term) ?? false
+}
+
+export function streamEventSemanticGravityScore(
+  event: StreamEvent,
+  semanticFocus?: EventStreamSemanticFocus,
+): number {
+  const terms = normalizedSemanticTerms(semanticFocus)
+  if (terms.length === 0) return 0
+
+  const total = terms.reduce((sum, term) => {
+    const termScore = Math.max(
+      fieldIncludes(event.source, term) ? 0.9 : 0,
+      fieldIncludes(event.message, term) ? 0.8 : 0,
+      fieldIncludes(event.id, term) ? 0.6 : 0,
+    )
+    return sum + termScore
+  }, 0)
+
+  return roundedScore(clamp01(total / terms.length))
+}
+
+export function buildSemanticGravityRows(
+  rows: TemporalSyncStreamRow[],
+  semanticFocus?: EventStreamSemanticFocus,
+): SemanticGravityStreamRow[] {
+  const scored = rows.map((row, originalIndex) => ({
+    row,
+    originalIndex,
+    score: streamEventSemanticGravityScore(row.event, semanticFocus),
+  }))
+
+  const hasFocus = normalizedSemanticTerms(semanticFocus).length > 0
+  const ordered = hasFocus
+    ? [...scored].sort((a, b) => (b.score - a.score) || (a.originalIndex - b.originalIndex))
+    : scored
+
+  return ordered.map((item, index) => ({
+    ...item.row,
+    semanticGravityScore: item.score,
+    semanticGravityRank: index + 1,
+  }))
 }
 
 export function streamEventAttractionScore(
@@ -179,9 +250,11 @@ export function summarizeEventStream(
   events: StreamEvent[],
   maxItems: number,
   temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
+  semanticFocus?: EventStreamSemanticFocus,
 ): EventStreamSummary {
   const visible = getVisibleStreamEvents(events, maxItems)
   const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
+  const semanticRows = buildSemanticGravityRows(syncRows, semanticFocus)
   const latestTimestamp = visible.length > 0 ? finiteTimestamp(visible[0]!.timestamp) : null
   const oldestVisibleTimestamp = visible.length > 0
     ? finiteTimestamp(visible[visible.length - 1]!.timestamp)
@@ -194,10 +267,12 @@ export function summarizeEventStream(
       .filter(row => row.syncGroupSize > 1)
       .map(row => row.syncGroupId),
   )
-  const attractionScores = syncRows.map((row, index) =>
-    streamEventAttractionScore(row, index, syncRows.length),
+  const attractionScores = semanticRows.map((row, index) =>
+    streamEventAttractionScore(row, index, semanticRows.length),
   )
   const highAttractionCount = attractionScores.filter(score => streamEventAttractionBand(score) === 'high').length
+  const semanticScores = semanticRows.map(row => row.semanticGravityScore)
+  const semanticMatchCount = semanticScores.filter(score => score > 0).length
   const status: EventStreamStatus =
     visible.length === 0
       ? 'empty'
@@ -220,6 +295,9 @@ export function summarizeEventStream(
     maxTemporalSyncGroupSize: syncRows.reduce((max, row) => Math.max(max, row.syncGroupSize), 0),
     highAttractionCount,
     maxAttractionScore: attractionScores.reduce((max, score) => Math.max(max, score), 0),
+    semanticGravityTermCount: normalizedSemanticTerms(semanticFocus).length,
+    semanticGravityMatchCount: semanticMatchCount,
+    maxSemanticGravityScore: semanticScores.reduce((max, score) => Math.max(max, score), 0),
     status,
   }
 }
@@ -234,10 +312,17 @@ function attractionRowClass(band: EventStreamAttractionBand, isSynced: boolean):
   return 'border-transparent opacity-80'
 }
 
+function semanticGravityRowClass(score: number): string {
+  if (score >= 0.75) return 'ring-1 ring-[var(--color-accent)]'
+  if (score > 0) return 'ring-1 ring-[var(--color-border-strong)]'
+  return ''
+}
+
 export function EventStream({
   events,
   maxItems = 100,
   temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
+  semanticFocus,
   testId,
 }: EventStreamProps) {
   const visible = useMemo(() => getVisibleStreamEvents(events, maxItems), [events, maxItems])
@@ -245,9 +330,13 @@ export function EventStream({
     () => buildTemporalSyncRows(visible, temporalSyncWindowMs),
     [visible, temporalSyncWindowMs],
   )
+  const semanticRows = useMemo(
+    () => buildSemanticGravityRows(syncRows, semanticFocus),
+    [syncRows, semanticFocus],
+  )
   const summary = useMemo(
-    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs),
-    [events, maxItems, temporalSyncWindowMs],
+    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs, semanticFocus),
+    [events, maxItems, temporalSyncWindowMs, semanticFocus],
   )
 
   return html`
@@ -268,6 +357,9 @@ export function EventStream({
       data-event-stream-max-temporal-sync-group-size=${summary.maxTemporalSyncGroupSize}
       data-event-stream-high-attraction-count=${summary.highAttractionCount}
       data-event-stream-max-attraction-score=${summary.maxAttractionScore.toFixed(2)}
+      data-event-stream-semantic-gravity-term-count=${summary.semanticGravityTermCount}
+      data-event-stream-semantic-gravity-match-count=${summary.semanticGravityMatchCount}
+      data-event-stream-max-semantic-gravity-score=${summary.maxSemanticGravityScore.toFixed(2)}
       data-testid=${testId}
     >
       <div
@@ -299,17 +391,17 @@ export function EventStream({
           ? html`<div class="text-3xs text-[var(--color-fg-muted)]">이벤트 없음</div>`
           : html`
             <div class="space-y-1" role="list">
-              ${syncRows.map(
+              ${semanticRows.map(
                 (row, index) => {
                   const e = row.event
                   const isSynced = row.syncGroupSize > 1
                   const eventTimestamp = finiteTimestamp(e.timestamp)
-                  const attractionScore = streamEventAttractionScore(row, index, syncRows.length)
+                  const attractionScore = streamEventAttractionScore(row, index, semanticRows.length)
                   const attractionBand = streamEventAttractionBand(attractionScore)
                   return html`
                   <div
                     key=${e.id}
-                    class=${`flex min-w-0 items-start gap-2 rounded-[var(--r-1)] border-l-2 px-2 py-1 hover:bg-[var(--color-bg-hover)] ${attractionRowClass(attractionBand, isSynced)}`}
+                    class=${`flex min-w-0 items-start gap-2 rounded-[var(--r-1)] border-l-2 px-2 py-1 hover:bg-[var(--color-bg-hover)] ${attractionRowClass(attractionBand, isSynced)} ${semanticGravityRowClass(row.semanticGravityScore)}`}
                     role="listitem"
                     data-stream-event-id=${e.id}
                     data-stream-event-level=${e.level}
@@ -321,6 +413,8 @@ export function EventStream({
                     data-stream-event-sync-anchor=${row.syncAnchorTimestamp ?? ''}
                     data-stream-event-attraction-score=${attractionScore.toFixed(2)}
                     data-stream-event-attraction-band=${attractionBand}
+                    data-stream-event-semantic-gravity-score=${row.semanticGravityScore.toFixed(2)}
+                    data-stream-event-semantic-gravity-rank=${row.semanticGravityRank}
                   >
                     <span
                       class="mt-0.5 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"


### PR DESCRIPTION
## Summary
- add semantic focus scoring for event stream rows and reorder focused rows by semantic gravity
- expose semantic gravity and intentional projection metadata on the stream root and rows/chips
- add history-based intent projection chips for likely next source/level targets

## Stack
- base: main, after #13779 merged Temporal Synchronization + Gradient Attraction
- includes #13808 merged into this branch
- implements P0 Convergence Flow: Semantic Gravity + Intentional Projection

## Verification
- pnpm install --offline --frozen-lockfile
- pnpm exec vitest run --config vitest.config.ts src/components/common/event-stream.test.ts src/components/common/event-stream.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src (passes with existing unrelated warnings in virtual-list.ts and fsm-hub.ts)
- git diff --check
- gh pr checks 13800 --watch --interval 10